### PR TITLE
fix: mobile focus issue on channel replies

### DIFF
--- a/js/app/packages/block-channel/component/BaseInput.tsx
+++ b/js/app/packages/block-channel/component/BaseInput.tsx
@@ -184,19 +184,6 @@ export function BaseInput(props: BaseInputProps) {
         }
       }, 0);
     }
-
-    viewportObserver = new IntersectionObserver(
-      (entries) => {
-        const entry = entries[0];
-        if (!entry.isIntersecting) {
-          if (containerRef.contains(document.activeElement)) {
-            blurMarkdownArea();
-          }
-        }
-      },
-      { threshold: 0 }
-    );
-    viewportObserver.observe(containerRef);
   });
 
   const onFocusLeaveEnd = (e: KeyboardEvent) => {


### PR DESCRIPTION
Removed some logic that would blur a channel reply input when it was no longer on screen. This is no longer necessary, and may be a potential fix for the issue on mobile where reply input boxes could not be focused.
