### PR TITLE
feat(search): macrodb filter out documents by file type

### DIFF
--- a/rust/cloud-storage/macro_db_client/.sqlx/query-0392a509a0896bd3acc01964a39a4477aeafb381e532657ccb7b11ad05b9038e.json
+++ b/rust/cloud-storage/macro_db_client/.sqlx/query-0392a509a0896bd3acc01964a39a4477aeafb381e532657ccb7b11ad05b9038e.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT\n            d.id\n        FROM\n            \"Document\" d\n        WHERE\n            d.id = ANY($1)\n            AND d.\"fileType\" = ANY($2)\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "TextArray",
+        "TextArray"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "0392a509a0896bd3acc01964a39a4477aeafb381e532657ccb7b11ad05b9038e"
+}

--- a/rust/cloud-storage/macro_db_client/src/items/filter.rs
+++ b/rust/cloud-storage/macro_db_client/src/items/filter.rs
@@ -5,6 +5,34 @@ use model::item::ShareableItemType;
 
 use crate::projects::get_project::get_sub_items::bulk_get_all_sub_project_ids;
 
+/// Given a list of document ids and a list of file types, this will
+/// return a subset list of items that are of the provided file types.
+#[tracing::instrument(skip(db), err)]
+pub async fn filter_documents_by_file_types(
+    db: &sqlx::PgPool,
+    documents: &[String],
+    file_types: &[String],
+) -> anyhow::Result<Vec<String>> {
+    let documents = sqlx::query!(
+        r#"
+        SELECT
+            d.id
+        FROM
+            "Document" d
+        WHERE
+            d.id = ANY($1)
+            AND d."fileType" = ANY($2)
+        "#,
+        documents,
+        file_types,
+    )
+    .map(|row| row.id)
+    .fetch_all(db)
+    .await?;
+
+    Ok(documents)
+}
+
 /// Given a list of item ids, the item type and a list of project_ids, this will
 /// return a subset list of items that are within the provided project ids and their sub-projects.
 #[tracing::instrument(skip(db), err)]

--- a/rust/cloud-storage/opensearch_client/examples/query_document.rs
+++ b/rust/cloud-storage/opensearch_client/examples/query_document.rs
@@ -15,7 +15,6 @@ async fn main() -> anyhow::Result<()> {
             terms: vec!["equation".to_string()],
             user_id: "user".to_string(),
             document_ids: Vec::new(),
-            file_types: Vec::new(),
             page: 0,
             page_size: 10,
             match_type: "partial".to_string(),

--- a/rust/cloud-storage/opensearch_client/src/search/documents/test.rs
+++ b/rust/cloud-storage/opensearch_client/src/search/documents/test.rs
@@ -10,8 +10,7 @@ fn test_build_search_request() -> anyhow::Result<()> {
         .user_id("user123")
         .search_on(SearchOn::Content)
         .collapse(true)
-        .ids(vec!["doc1".to_string(), "doc2".to_string()])
-        .file_types(vec!["pdf".to_string(), "docx".to_string()]);
+        .ids(vec!["doc1".to_string(), "doc2".to_string()]);
 
     let result = builder.build_search_request()?;
 
@@ -31,11 +30,6 @@ fn test_build_search_request() -> anyhow::Result<()> {
                             "content": "test"
                         }
                     },
-                    {
-                        "terms": {
-                            "file_type": ["pdf", "docx"]
-                        }
-                    }
                 ],
                 "should": [
                     {


### PR DESCRIPTION
## Summary
<!--
A good summary consists of a two sentence overview followed by bullet points (or checklist items for WIP).
-->

This PR updates search service to perform filtering of document ids by file_type through macrodb instead of search directly. This is a precursor to soup+search.

## Screenshots, GIFs, and Videos
<!--
Include visual representations of your changes, including GIFs/videos. Screencaptures should fully illustrate sample user behavior.
-->
