### PR TITLE
fix [properties] - datadog logging dev and prod

### DIFF
--- a/infra/stacks/properties-service/properties-service.ts
+++ b/infra/stacks/properties-service/properties-service.ts
@@ -184,7 +184,7 @@ export class PropertiesService extends pulumi.ComponentResource {
                   Name: 'datadog',
                   Host: 'http-intake.logs.us5.datadoghq.com',
                   apikey: DATADOG_API_KEY,
-                  dd_service: `properties-service`,
+                  dd_service: `properties-service-${stack}`,
                   dd_source: 'fargate',
                   dd_tags: `project:properties-service, env:${stack}`,
                   provider: 'ecs',


### PR DESCRIPTION
- Update dd_service name to include stack suffix (properties-service-dev/properties-service-prod)
- Makes it easier to filter logs by environment in Datadog