### PR TITLE
add [properties-fe] - panel to email

### DIFF
--- a/js/app/packages/block-email/component/EmailPropertiesModal.tsx
+++ b/js/app/packages/block-email/component/EmailPropertiesModal.tsx
@@ -1,0 +1,57 @@
+import { SplitDrawer } from '@app/component/split-layout/components/SplitDrawer';
+import { useDrawerControl } from '@app/component/split-layout/components/SplitDrawerContext';
+import { IconButton } from '@core/component/IconButton';
+import { PropertiesView } from '@core/component/Properties/PropertiesView';
+import { useCanEdit } from '@core/signal/permissions';
+import { useBlockDocumentName } from '@core/util/currentBlockDocumentName';
+import TagIcon from '@icon/regular/tag.svg';
+import type { EntityType } from '@service-properties/generated/schemas/entityType';
+import { Suspense } from 'solid-js';
+
+const DRAWER_ID = 'properties';
+
+export function EmailPropertiesModal(props: {
+  documentId: string;
+  buttonSize?: 'sm' | 'base';
+}) {
+  const drawerControl = useDrawerControl(DRAWER_ID);
+  const canEdit = useCanEdit();
+
+  return (
+    <>
+      <IconButton
+        icon={TagIcon}
+        theme={drawerControl.isOpen() ? 'accent' : 'clear'}
+        size={props.buttonSize ?? 'base'}
+        tooltip={{ label: 'Properties' }}
+        onClick={drawerControl.toggle}
+      />
+      <SplitDrawer id={DRAWER_ID} side="right" size={550} title="Properties">
+        <Suspense fallback={<LoadingFallback />}>
+          <EmailPropertiesContent canEdit={canEdit()} />
+        </Suspense>
+      </SplitDrawer>
+    </>
+  );
+}
+
+function EmailPropertiesContent(props: { canEdit: boolean }) {
+  const documentName = useBlockDocumentName();
+
+  return (
+    <PropertiesView
+      blockType={'email'}
+      canEdit={props.canEdit}
+      entityType={'THREAD' as EntityType}
+      documentName={documentName()}
+    />
+  );
+}
+
+function LoadingFallback() {
+  return (
+    <div class="flex justify-center items-center py-8">
+      <div class="animate-spin rounded-full h-6 w-6 border-b-2 border-ink-muted"></div>
+    </div>
+  );
+}

--- a/js/app/packages/block-email/component/TopBar.tsx
+++ b/js/app/packages/block-email/component/TopBar.tsx
@@ -3,9 +3,18 @@ import {
   SplitHeaderBadge,
   StaticSplitLabel,
 } from '@app/component/split-layout/components/SplitLabel';
-import { SplitToolbarLeft } from '@app/component/split-layout/components/SplitToolbar';
+import {
+  SplitToolbarLeft,
+  SplitToolbarRight,
+} from '@app/component/split-layout/components/SplitToolbar';
+import { useBlockId } from '@core/block';
+import { ENABLE_PROPERTIES_METADATA } from '@core/constant/featureFlags';
+import { Show } from 'solid-js';
+import { EmailPropertiesModal } from './EmailPropertiesModal';
 
 export function TopBar(props: { title: string }) {
+  const blockId = useBlockId();
+
   return (
     <>
       <SplitHeaderLeft>
@@ -16,6 +25,11 @@ export function TopBar(props: { title: string }) {
           <SplitHeaderBadge text="beta" tooltip="Email is in Beta" />
         </div>
       </SplitToolbarLeft>
+      <SplitToolbarRight>
+        <Show when={ENABLE_PROPERTIES_METADATA}>
+          <EmailPropertiesModal documentId={blockId} buttonSize="sm" />
+        </Show>
+      </SplitToolbarRight>
     </>
   );
 }


### PR DESCRIPTION
add [properties-fe] - panel to email

adding the properties panel to the email block
blocked by / additional things that are needed:
- ability to enter threads as property values
- individual thread message entering as part property value
- validation and permissions checks on the backend
- figure out what metadata we want
- ...