### PR TITLE
fix: Help Drawer showing when View is not Empty

### DIFF
--- a/js/app/packages/app/component/UnifiedListEmptyState.tsx
+++ b/js/app/packages/app/component/UnifiedListEmptyState.tsx
@@ -23,7 +23,9 @@ export function EmptyState(props: { view?: View }) {
     <Switch>
       <Match when={props.view === 'emails' && !emailActive()}>
         {(_) => {
-          onMount(() => setShowHelpDrawer((prev) => new Set([...prev, 'emails'])));
+          onMount(() =>
+            setShowHelpDrawer((prev) => new Set([...prev, 'emails']))
+          );
           return <EmptyStateInner emptyMessage={'Email not connected.'} />;
         }}
       </Match>
@@ -36,7 +38,9 @@ export function EmptyState(props: { view?: View }) {
       </Match>
       <Match when={props.view === 'inbox' && !emailActive()}>
         {(_) => {
-          onMount(() => setShowHelpDrawer((prev) => new Set([...prev, 'inbox'])));
+          onMount(() =>
+            setShowHelpDrawer((prev) => new Set([...prev, 'inbox']))
+          );
           return (
             <EmptyStateInner
               emptyMessage={'Nothing to show. Email not connected.'}
@@ -46,13 +50,17 @@ export function EmptyState(props: { view?: View }) {
       </Match>
       <Match when={props.view === 'comms'}>
         {(_) => {
-          onMount(() => setShowHelpDrawer((prev) => new Set([...prev, 'comms'])));
+          onMount(() =>
+            setShowHelpDrawer((prev) => new Set([...prev, 'comms']))
+          );
           return <EmptyStateInner emptyMessage={'No messages to show.'} />;
         }}
       </Match>
       <Match when={props.view === 'docs'}>
         {(_) => {
-          onMount(() => setShowHelpDrawer((prev) => new Set([...prev, 'docs'])));
+          onMount(() =>
+            setShowHelpDrawer((prev) => new Set([...prev, 'docs']))
+          );
           return <EmptyStateInner showDropZone />;
         }}
       </Match>
@@ -64,7 +72,9 @@ export function EmptyState(props: { view?: View }) {
       </Match>
       <Match when={props.view === 'folders'}>
         {(_) => {
-          onMount(() => setShowHelpDrawer((prev) => new Set([...prev, 'folders'])));
+          onMount(() =>
+            setShowHelpDrawer((prev) => new Set([...prev, 'folders']))
+          );
           return <EmptyStateInner showDropZone />;
         }}
       </Match>


### PR DESCRIPTION
Help Drawers show on certain Soup tabs when you have nothing in that Soup tab. The setters that set this Help Drawer state needed to be wrapped in onMount() or else they fire too early.
