### PR TITLE
Fix sound effects not working in dev environment

### DIFF
--- a/js/app/packages/app/util/sound.ts
+++ b/js/app/packages/app/util/sound.ts
@@ -25,7 +25,9 @@ if (typeof window !== 'undefined') {
 function _getSoundPath(name: string): string {
   // Try .wav first, then fallback to .mp3
   // This allows both formats to work seamlessly
-  return `/sounds/${name}.wav`;
+  // Use BASE_URL to respect Vite's base path configuration
+  const base = import.meta.env.BASE_URL;
+  return `${base}sounds/${name}.wav`;
 }
 
 /**
@@ -46,8 +48,10 @@ export function playSound(name: string, volume?: number): void {
 
   if (!audio) {
     // Try .wav first, fallback to .mp3 if needed
-    const wavPath = `/sounds/${name}.wav`;
-    const mp3Path = `/sounds/${name}.mp3`;
+    // Use BASE_URL to respect Vite's base path configuration
+    const base = import.meta.env.BASE_URL;
+    const wavPath = `${base}sounds/${name}.wav`;
+    const mp3Path = `${base}sounds/${name}.mp3`;
 
     // Create audio element - try .wav first
     audio = new Audio(wavPath);
@@ -97,11 +101,13 @@ export function preloadSound(name: string): void {
     return;
   }
 
-  const audio = new Audio(`/sounds/${name}.wav`);
+  // Use BASE_URL to respect Vite's base path configuration
+  const base = import.meta.env.BASE_URL;
+  const audio = new Audio(`${base}sounds/${name}.wav`);
   audio.preload = 'auto';
   audio.addEventListener('error', () => {
     // Fallback to mp3
-    const fallbackAudio = new Audio(`/sounds/${name}.mp3`);
+    const fallbackAudio = new Audio(`${base}sounds/${name}.mp3`);
     fallbackAudio.preload = 'auto';
     soundCache.set(name, fallbackAudio);
   });


### PR DESCRIPTION
Use import.meta.env.BASE_URL to respect Vite's base path configuration. This ensures sound paths resolve correctly in both localhost (/) and dev (/app) environments.

