### PR TITLE
Move settings model to split view

### DIFF
--- a/js/app/packages/app/component/Layout.tsx
+++ b/js/app/packages/app/component/Layout.tsx
@@ -21,7 +21,6 @@ import { ItemDndProvider } from './ItemDragAndDrop';
 import { Paywall } from './paywall/Paywall';
 import { QuickCreateMenu } from './QuickCreateMenu';
 import { RightbarWrapper } from './rightbar/Rightbar';
-import { Settings, setViewportOffset } from './settings/Settings';
 
 export function Layout(props: RouteSectionProps) {
   const isAuthenticated = useIsAuthenticated();
@@ -44,7 +43,7 @@ export function Layout(props: RouteSectionProps) {
     });
   });
 
-  // We are tracking viewport height, and using that to set a CSS variable and the viewport offset, so that we can properly constrain the viewport-height for mobile in response to changes such as the virtual keyboard appearing
+  // We are tracking viewport height, and using that to set a CSS variable, so that we can properly constrain the viewport-height for mobile in response to changes such as the virtual keyboard appearing
   const handleResize = () => {
     if (window.visualViewport) {
       // Set the CSS variable with the calculated height
@@ -52,8 +51,6 @@ export function Layout(props: RouteSectionProps) {
         '--viewport-height',
         `${window.visualViewport.height}px`
       );
-
-      setViewportOffset(window.visualViewport.offsetTop);
     }
   };
 
@@ -62,7 +59,6 @@ export function Layout(props: RouteSectionProps) {
       window.visualViewport.addEventListener('resize', handleResize);
       window.visualViewport.addEventListener('scroll', handleResize);
       handleResize();
-      setViewportOffset(window.visualViewport.offsetTop);
     }
 
     if (sessionStorage.getItem('showUpgradeModal') === 'true') {
@@ -107,7 +103,6 @@ export function Layout(props: RouteSectionProps) {
     <div class="relative pb-[max(env(safe-area-inset-bottom),var(--tauri-inset-bottom))] pt-[max(env(safe-area-inset-top),var(--tauri-inset-top))] flex flex-col justify-between w-dvw h-dvh">
       <Show when={isAuthenticated()}>
         <GlobalShortcuts />
-        <Settings />
         <Suspense>
           <KommandMenu />
         </Suspense>

--- a/js/app/packages/app/component/dock/Dock.tsx
+++ b/js/app/packages/app/component/dock/Dock.tsx
@@ -13,10 +13,7 @@ import {
   ENABLE_DOCK_NOTITIFCATIONS,
   ENABLE_RIGHTHAND_SIDEBAR,
 } from '@core/constant/featureFlags';
-import {
-  setSettingsOpen,
-  useSettingsState,
-} from '@core/constant/SettingsState';
+import { useSettingsState } from '@core/constant/SettingsState';
 import { runCommand } from '@core/hotkey/hotkeys';
 import { activeScope, hotkeyScopeTree } from '@core/hotkey/state';
 import { TOKENS } from '@core/hotkey/tokens';
@@ -38,7 +35,7 @@ import { QuickAccess } from './QuickAccess';
 
 export function Dock() {
   const hasPaid = useHasPaidAccess();
-  const { settingsOpen } = useSettingsState();
+  const { settingsOpen, openSettings } = useSettingsState();
   const toggleRightPanel = useToggleRightPanel();
   const isRightPanelCollapsed = () => !isRightPanelOpen();
   const activeSplitId = createMemo(() => globalSplitManager()?.activeSplitId());
@@ -322,7 +319,7 @@ export function Dock() {
               class="h-full aspect-square"
               data-settings-button
               onDeepClick={() => {
-                setSettingsOpen(true);
+                openSettings();
               }}
             />
           </div>

--- a/js/app/packages/app/component/settings/Mobile.tsx
+++ b/js/app/packages/app/component/settings/Mobile.tsx
@@ -12,7 +12,7 @@ import { updateUserAuth, useIsAuthenticated } from '@core/auth';
 import { useLogout } from '@core/auth/logout';
 import { TabContent, TabContentRow } from '@core/component/TabContent';
 import { TextButton } from '@core/component/TextButton';
-import { setSettingsOpen } from '@core/constant/SettingsState';
+import { useSettingsState } from '@core/constant/SettingsState';
 import { isNativeMobilePlatform } from '@core/mobile/isNativeMobilePlatform';
 import { setKeyboardVisible } from '@core/mobile/virtualKeyboardDetection';
 import { unsetTokenPromise } from '@core/util/fetchWithToken';
@@ -156,6 +156,7 @@ export function useMobileNavigate() {
 
   const navigate = useNavigate();
   const isAuthenticated = useIsAuthenticated();
+  const { closeSettings } = useSettingsState();
 
   App.addListener('appUrlOpen', async (event) => {
     if (event.url.startsWith('file://') && isAuthenticated()) {
@@ -187,7 +188,7 @@ export function useMobileNavigate() {
             },
           });
         }
-        setSettingsOpen(false);
+        closeSettings();
       }
 
       return;
@@ -219,7 +220,7 @@ export function useMobileNavigate() {
     'pushNotificationActionPerformed',
     ({ notification }) => {
       const notificationData = notification.data as PushNotificationData;
-      setSettingsOpen(false);
+      closeSettings();
       navigate(notificationData.openRoute);
     }
   );

--- a/js/app/packages/app/component/split-layout/componentRegistry.tsx
+++ b/js/app/packages/app/component/split-layout/componentRegistry.tsx
@@ -4,6 +4,7 @@ import { DEV_MODE_ENV, LOCAL_ONLY } from '@core/constant/featureFlags';
 import { type JSXElement, lazy } from 'solid-js';
 import { EmailCompose } from '../../../block-email/component/Compose';
 import { Soup } from '../Soup';
+import { Settings } from '../settings/Settings';
 
 export type ComponentFactory = (params?: Record<string, any>) => JSXElement;
 
@@ -26,6 +27,7 @@ registerComponent('unified-list', () => <Soup />);
 registerComponent('loading', () => <LoadingBlock />);
 registerComponent('channel-compose', () => <ChannelCompose />);
 registerComponent('email-compose', () => <EmailCompose />);
+registerComponent('settings', () => <Settings />);
 
 if (LOCAL_ONLY) {
   registerComponent(


### PR DESCRIPTION
## Summary
This PR migrates the Settings UI from a standalone modal to a dedicated split panel, aligning it with the application's existing split system. This provides a more integrated and consistent user experience for accessing settings.

*   The `Settings` component is now registered and managed as a split panel.
*   `SettingsState` was refactored to use split management functions (`replaceOrInsertSplit`, `close`).
*   The `Settings` component's UI was updated to remove modal-specific wrappers and styling.
*   All call sites for opening/closing settings were updated to interact with the new split system.

## Screenshots, GIFs, and Videos
<!--
Please include a screenshot or GIF demonstrating the settings opening in a split panel.
-->

---
<a href="https://cursor.com/background-agent?bcId=bc-5adf9bc9-a55f-45ba-896e-43fb946482af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5adf9bc9-a55f-45ba-896e-43fb946482af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

