### PR TITLE
feat(custom-cursor): use only default cursor for now

### DIFF
--- a/js/app/packages/app/component/custom-cursor/custom-cursor.ts
+++ b/js/app/packages/app/component/custom-cursor/custom-cursor.ts
@@ -321,7 +321,6 @@ function getCursor(cursorType: string): string {
 }
 
 function updateCursorStyle() {
-  console.log({ currentCursorType });
   if (!currentCursorType) return;
   const cursor = getCursor(currentCursorType);
 


### PR DESCRIPTION
too much of a performance impact to detect cursor type from element, just setting custom cursor to just default type for now