### PR TITLE
fix(email-service): Better attachment upload checking

### DIFF
--- a/rust/cloud-storage/email_service/src/pubsub/webhook/operations/upsert_message.rs
+++ b/rust/cloud-storage/email_service/src/pubsub/webhook/operations/upsert_message.rs
@@ -132,7 +132,9 @@ pub async fn upsert_message(
 
     // temporarily only for macro emails, for testing purposes
     if link.macro_id.ends_with("@macro.com")
-        && !cfg!(feature = "disable_attachment_upload") && message_attachment_count > 0 {
+        && !cfg!(feature = "disable_attachment_upload")
+        && message_attachment_count > 0
+    {
         // upload attachments to Macro
         let attachments = email_db_client::attachments::provider::upload::fetch_insertable_attachments_for_new_email(
             &ctx.db,

--- a/rust/cloud-storage/gmail_client/src/watch.rs
+++ b/rust/cloud-storage/gmail_client/src/watch.rs
@@ -42,7 +42,7 @@ pub(crate) async fn register_watch(
             .await
             .unwrap_or_else(|_| "Failed to read error body".to_string());
         return Err(GmailError::ApiError(format!(
-            "Gmail API error ({}): {}",
+            "({}): {}",
             status, error_body
         )));
     }

--- a/rust/cloud-storage/models_email/src/gmail/error.rs
+++ b/rust/cloud-storage/models_email/src/gmail/error.rs
@@ -11,7 +11,7 @@ pub enum GmailError {
     #[error("HTTP Request Error: {0}")]
     HttpRequest(String),
 
-    #[error("API Error")]
+    #[error("API Error: {0}")]
     ApiError(String),
 
     #[error("Multipart Parsing Error: {0}")]


### PR DESCRIPTION
## Summary
<!--
A good summary consists of a two sentence overview followed by bullet points (or checklist items for WIP).
-->
Only do the expensive check for uploadable attachments on message upsert if the message has attachments.

Improve APIError logging in gmail-client for unrelated issue.

## Screenshots, GIFs, and Videos
<!--
Include visual representations of your changes, including GIFs/videos. Screencaptures should fully illustrate sample user behavior.
-->
