### PR TITLE
feat(email-service): Delete gmail attachment script

### DIFF
--- a/rust/cloud-storage/document_storage_service/src/api/internal/mod.rs
+++ b/rust/cloud-storage/document_storage_service/src/api/internal/mod.rs
@@ -18,6 +18,7 @@ use super::{
     },
     user::populate_items,
 };
+use crate::api::documents::delete_document;
 use crate::api::items::get_item_ids;
 use crate::api::threads::get_thread_access_level;
 use crate::api::{documents::get_documents_metadata, items::validate_item_ids};
@@ -115,6 +116,11 @@ pub fn router(state: ApiContext) -> Router<ApiContext> {
         .route(
             "/documents/:document_id/update",
             put(put_document_update::handler),
+        )
+        .route(
+            "/documents/:document_id/permanent",
+            delete(delete_document::permanently_delete_document_handler)
+                .layer(ensure_document_exists_middleware.clone()),
         )
         .route("/documents/metadata", post(get_documents_metadata::handler))
         // History routes

--- a/rust/cloud-storage/email_service/Cargo.toml
+++ b/rust/cloud-storage/email_service/Cargo.toml
@@ -17,6 +17,10 @@ path = "src/bin/backfill_gmail_attachments/backfill_gmail_attachments.rs"
 name = "backfill_search"
 path = "src/bin/backfill_search/backfill_search.rs"
 
+[[bin]]
+name = "delete_gmail_attachments"
+path = "src/bin/delete_gmail_attachments/delete_gmail_attachments.rs"
+
 [features]
 disable_attachment_upload = []
 disable_connection_gateway = []

--- a/rust/cloud-storage/email_service/src/bin/delete_gmail_attachments/README.md
+++ b/rust/cloud-storage/email_service/src/bin/delete_gmail_attachments/README.md
@@ -1,0 +1,18 @@
+# Delete Gmail Attachment Utility
+
+This binary is used to delete any gmail attachments we uploaded for the user(s) from Macro.
+
+## Required Environment Variables
+
+| Variable             | Description                                                     | Required |
+|----------------------|-----------------------------------------------------------------|----------|
+| `DATABASE_URL`       | The connection string for the PostgreSQL database               | Yes      |
+| `DSS_URL`            | The URL for the Document Storage Service                        | Yes      |
+| `INTERNAL_AUTH_KEY`  | An access token for authenticating with internal Macro services | Yes      |
+| `MACRO_IDS`          | The Macro IDs of the user accounts to delete attachments for    | Yes      |
+| `DELETE_CONCURRENCY` | Number of concurrent uploads to process (defaults to 10)        | No       |
+
+## Setup
+
+1. Ensure all required environment variables are set
+2. Run the binary using cargo

--- a/rust/cloud-storage/email_service/src/bin/delete_gmail_attachments/config.rs
+++ b/rust/cloud-storage/email_service/src/bin/delete_gmail_attachments/config.rs
@@ -1,0 +1,31 @@
+use anyhow::Context;
+
+/// Holds all configuration loaded from environment variables.
+pub struct Config {
+    pub dss_url: String,
+    pub internal_auth_key: String,
+    pub macro_ids: String,
+    pub database_url: String,
+    pub delete_concurrency: usize,
+}
+
+impl Config {
+    /// Creates a new `Config` instance by reading from environment variables.
+    /// Returns an error if any required variable is not set.
+    pub fn from_env() -> anyhow::Result<Self> {
+        let delete_concurrency =
+            std::env::var("DELETE_CONCURRENCY").context("DELETE_CONCURRENCY not set")?;
+        let delete_concurrency = delete_concurrency
+            .parse::<usize>()
+            .context("DELETE_CONCURRENCY is not a number")?;
+
+        Ok(Self {
+            dss_url: std::env::var("DSS_URL").context("DSS_URL not set")?,
+            internal_auth_key: std::env::var("INTERNAL_AUTH_KEY")
+                .context("INTERNAL_AUTH_KEY not set")?,
+            macro_ids: std::env::var("MACRO_IDS").context("MACRO_IDS not set")?, // Changed
+            database_url: std::env::var("DATABASE_URL").context("DATABASE_URL not set")?,
+            delete_concurrency,
+        })
+    }
+}

--- a/rust/cloud-storage/email_service/src/bin/delete_gmail_attachments/database.rs
+++ b/rust/cloud-storage/email_service/src/bin/delete_gmail_attachments/database.rs
@@ -1,0 +1,30 @@
+use anyhow::Context;
+use sqlx::PgPool;
+use sqlx::postgres::PgPoolOptions;
+
+const FETCH_EMAIL_ATTACHMENTS_QUERY: &str = r#"
+SELECT ID FROM "Document" d 
+INNER JOIN public.document_email de ON d.id = de.document_id 
+WHERE d.owner = $1;
+"#;
+
+/// Creates and returns a new PostgreSQL connection pool.
+pub async fn create_db_pool(database_url: &str, min_connections: u32) -> anyhow::Result<PgPool> {
+    PgPoolOptions::new()
+        .min_connections(min_connections)
+        .max_connections(60)
+        .connect(database_url)
+        .await
+        .context("Could not connect to db")
+}
+
+/// Fetches the document ids of attachments we have uploaded for the user
+pub async fn fetch_document_ids(db: &PgPool, macro_id: &str) -> anyhow::Result<Vec<String>> {
+    let rows = sqlx::query_scalar::<_, String>(FETCH_EMAIL_ATTACHMENTS_QUERY)
+        .bind(macro_id)
+        .fetch_all(db)
+        .await
+        .context("Failed to fetch document IDs")?;
+
+    Ok(rows)
+}

--- a/rust/cloud-storage/email_service/src/bin/delete_gmail_attachments/delete_gmail_attachments.rs
+++ b/rust/cloud-storage/email_service/src/bin/delete_gmail_attachments/delete_gmail_attachments.rs
@@ -1,0 +1,65 @@
+//! # Delete Gmail Attachment Utility
+//!
+//! This binary is used to delete any gmail attachments we uploaded for the user(s) from macro.
+//!
+//! ## Required Environment Variables:
+//! - `DATABASE_URL`: The connection string for the PostgreSQL database.
+//! - `DSS_URL`: The URL for the Document Storage Service.
+//! - `INTERNAL_AUTH_KEY`: An access token for authenticating with internal Macro services.
+//! - `MACRO_IDS`: The Macro IDs of the user accounts to delete attachments for
+//! - `DELETE_CONCURRENCY`: Number of concurrent uploads to process (optional, defaults to 10).
+
+mod config;
+mod database;
+mod process;
+
+use anyhow::Context;
+use macro_entrypoint::MacroEntrypoint;
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    println!("Loading configuration...");
+    MacroEntrypoint::default().init();
+    let config = config::Config::from_env().context("Failed to load configuration")?;
+
+    println!("Connecting to the database...");
+    let db_pool = database::create_db_pool(&config.database_url, config.delete_concurrency as u32)
+        .await
+        .context("Failed to create database pool")?;
+
+    let dss_client = document_storage_service_client::DocumentStorageServiceClient::new(
+        config.internal_auth_key.clone(),
+        config.dss_url.clone(),
+    );
+    let macro_ids: Vec<String> = config
+        .macro_ids
+        .split(',')
+        .map(|id| id.trim().to_string())
+        .collect();
+
+    println!("Processing {} macro IDs: {:?}", macro_ids.len(), macro_ids);
+
+    for (index, macro_id) in macro_ids.iter().enumerate() {
+        println!(
+            "\n=== Processing macro ID {} ({}/{}) ===",
+            macro_id,
+            index + 1,
+            macro_ids.len()
+        );
+
+        match process::process_macro_id(&config, &db_pool, &dss_client, macro_id).await {
+            Ok((success_count, total_documents)) => {
+                println!(
+                    "Completed processing for {}. Successfully deleted {} out of {} documents.",
+                    macro_id, success_count, total_documents
+                );
+            }
+            Err(e) => {
+                println!("Failed to process macro ID {}: {:?}", macro_id, e);
+                // Continue with next macro ID instead of failing completely
+            }
+        }
+    }
+
+    println!("\n=== All macro IDs processed ===");
+    Ok(())
+}

--- a/rust/cloud-storage/email_service/src/bin/delete_gmail_attachments/process.rs
+++ b/rust/cloud-storage/email_service/src/bin/delete_gmail_attachments/process.rs
@@ -1,0 +1,63 @@
+use crate::{config, database};
+use anyhow::Context;
+use futures::{StreamExt, stream};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// Process documents for a single macro ID
+pub async fn process_macro_id(
+    config: &config::Config,
+    db_pool: &sqlx::PgPool,
+    dss_client: &document_storage_service_client::DocumentStorageServiceClient,
+    macro_id: &str,
+) -> anyhow::Result<(usize, usize)> {
+    let document_ids = database::fetch_document_ids(db_pool, macro_id)
+        .await
+        .context("Failed to fetch document ids")?;
+    println!(
+        "Found {} document ids to process for {}.",
+        document_ids.len(),
+        macro_id
+    );
+
+    if document_ids.is_empty() {
+        return Ok((0, 0));
+    }
+
+    let success_count = Arc::new(AtomicUsize::new(0));
+    let total_documents = document_ids.len();
+
+    println!("Starting concurrent upload process for {}...", macro_id);
+
+    stream::iter(document_ids.into_iter().enumerate())
+        .for_each_concurrent(config.delete_concurrency, |(index, document_id)| {
+            let dss_client_clone = dss_client.clone();
+            let success_count = Arc::clone(&success_count);
+            let macro_id = macro_id.to_string();
+
+            async move {
+                match dss_client_clone
+                    .delete_document_permanent_internal(&document_id, &macro_id)
+                    .await
+                {
+                    Ok(_) => {
+                        success_count.fetch_add(1, Ordering::Relaxed);
+                        println!(
+                            "Successfully deleted '{}' (index: {}) for {}",
+                            document_id, index, macro_id
+                        );
+                    }
+                    Err(e) => {
+                        panic!(
+                            "Failed to delete document - id: {}, error: {:?}",
+                            document_id, e
+                        );
+                    }
+                }
+            }
+        })
+        .await;
+
+    let final_success_count = success_count.load(Ordering::SeqCst);
+    Ok((final_success_count, total_documents))
+}

--- a/rust/cloud-storage/macro_db_client/migrations/20251119150742_document_email_cascade.sql
+++ b/rust/cloud-storage/macro_db_client/migrations/20251119150742_document_email_cascade.sql
@@ -1,0 +1,9 @@
+-- removing ON DELETE CASCADE for the email_attachments id row
+ALTER TABLE "document_email"
+DROP CONSTRAINT document_email_email_attachment_id_fkey;
+
+-- Add it back without ON DELETE CASCADE
+ALTER TABLE "document_email"
+    ADD CONSTRAINT document_email_email_attachment_id_fkey
+        FOREIGN KEY (email_attachment_id)
+            REFERENCES email_attachments (id);

--- a/rust/cloud-storage/macro_db_client/migrations/20251119150742_document_email_cascade.sql
+++ b/rust/cloud-storage/macro_db_client/migrations/20251119150742_document_email_cascade.sql
@@ -1,9 +1,0 @@
--- removing ON DELETE CASCADE for the email_attachments id row
-ALTER TABLE "document_email"
-DROP CONSTRAINT document_email_email_attachment_id_fkey;
-
--- Add it back without ON DELETE CASCADE
-ALTER TABLE "document_email"
-    ADD CONSTRAINT document_email_email_attachment_id_fkey
-        FOREIGN KEY (email_attachment_id)
-            REFERENCES email_attachments (id);


### PR DESCRIPTION
## Summary
<!--
A good summary consists of a two sentence overview followed by bullet points (or checklist items for WIP).
-->

**This is blocked by properties service. Without properties we have no way of knowing what attachments are linked to what emails after the document_email rows are deleted when a user removes their email. The property we will have for linking the document to the email message will fix this. We will have to update this script to instead query using properties rather than using document_email to figure out what documents to delete, implying we have updated attachment backfill to create properties values. Also move query to macro_db_client**

Script that deletes any email attachments that we uploaded as Macro documents for the specified users.

Added internal endpoint for permanently deleting documents for use in the script.

## Screenshots, GIFs, and Videos
<!--
Include visual representations of your changes, including GIFs/videos. Screencaptures should fully illustrate sample user behavior.
-->
