### PR TITLE
feat(notifications): show modal to request browser notification permission

### DIFF
--- a/js/app/packages/notifications/components/BrowserNotificationModal.tsx
+++ b/js/app/packages/notifications/components/BrowserNotificationModal.tsx
@@ -1,0 +1,104 @@
+import { useIsAuthenticated } from '@core/auth';
+import { Dialog } from '@kobalte/core/dialog';
+import { createMemo, createSignal, Show } from 'solid-js';
+import { usePlatformNotificationState } from './PlatformNotificationProvider';
+
+const DISMISSED_KEY = 'browser-notification-modal-dismissed';
+
+function useBrowserNotificationModal() {
+  const isAuthenticated = useIsAuthenticated();
+  const notificationState = usePlatformNotificationState();
+  const [isDismissed, setIsDismissed] = createSignal(
+    !!localStorage.getItem(DISMISSED_KEY)
+  );
+
+  const shouldShow = createMemo(() => {
+    if (notificationState === 'not-supported') {
+      return false;
+    }
+
+    if (!isAuthenticated()) {
+      return false;
+    }
+
+    if (isDismissed()) {
+      return false;
+    }
+
+    const permission = notificationState.permission();
+    return (
+      permission !== undefined &&
+      permission !== 'granted' &&
+      permission !== 'disabled-in-ui'
+    );
+  });
+
+  const handleEnableNotifications = async () => {
+    if (notificationState === 'not-supported') {
+      return;
+    }
+
+    try {
+      await notificationState.requestPermission();
+    } catch (error) {
+      console.error('Failed to enable notifications:', error);
+    }
+  };
+
+  const handleDismiss = () => {
+    localStorage.setItem(DISMISSED_KEY, 'true');
+    setIsDismissed(true);
+  };
+
+  return {
+    shouldShow,
+    handleEnableNotifications,
+    handleDismiss,
+    isSupported: notificationState !== 'not-supported',
+  };
+}
+
+export const BrowserNotificationModal = () => {
+  const { shouldShow, handleEnableNotifications, handleDismiss, isSupported } =
+    useBrowserNotificationModal();
+
+  return (
+    <Show when={isSupported}>
+      <Dialog open={shouldShow()} modal={true}>
+        <Dialog.Portal>
+          <Dialog.Overlay class="fixed inset-0 z-modal bg-modal-overlay" />
+          <div class="fixed inset-0 z-modal w-screen h-screen flex items-center justify-center">
+            <Dialog.Content class="flex items-center justify-center">
+              <div class="pointer-events-auto max-w-xl bg-menu border border-edge w-lg h-fit p-2">
+                <div class="w-full my-1">
+                  <h2 class="text-xl mb-3">Enable Browser Notifications</h2>
+
+                  <div class="mb-4">
+                    <p class="text-ink-muted text-sm">
+                      Get notified about new messages, mentions, comments, and
+                      emails.
+                    </p>
+                  </div>
+                  <div class="flex justify-end mt-2 tex-sm pt-2 gap-2">
+                    <button
+                      class="py-1 px-3 font-mono text-sm"
+                      onClick={handleDismiss}
+                    >
+                      Not Now
+                    </button>
+                    <button
+                      class="uppercase py-1 px-3 font-mono text-sm bg-accent text-menu"
+                      onClick={handleEnableNotifications}
+                    >
+                      Enable
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </Dialog.Content>
+          </div>
+        </Dialog.Portal>
+      </Dialog>
+    </Show>
+  );
+};

--- a/js/app/packages/notifications/index.ts
+++ b/js/app/packages/notifications/index.ts
@@ -1,3 +1,4 @@
+export { BrowserNotificationModal } from './components/BrowserNotificationModal';
 export {
   ChannelDebouncedNotificationReadMarker,
   DebouncedNotificationReadMarker,

--- a/js/app/packages/tauri/src/TauriProvider.tsx
+++ b/js/app/packages/tauri/src/TauriProvider.tsx
@@ -1,4 +1,7 @@
-import { PlatformNotificationProvider } from '@notifications';
+import {
+  BrowserNotificationModal,
+  PlatformNotificationProvider,
+} from '@notifications';
 import type { RouteSectionProps } from '@solidjs/router';
 import { type OsType, type as osType } from '@tauri-apps/plugin-os';
 import { isTauri } from 'core/util/platformFetch';
@@ -83,6 +86,7 @@ export function MaybeTauriProvider(props: { children: JSX.Element }) {
 
   return (
     <PlatformNotificationProvider>
+      <BrowserNotificationModal />
       {props.children}
     </PlatformNotificationProvider>
   );


### PR DESCRIPTION
Simple modal that shows when the user doesn't have browser notification permissions enabled. Won't show again after dismiss.


https://github.com/user-attachments/assets/7dd88378-4522-4db7-a8f0-bf03ee0015fc

