### PR TITLE
fix: hide search results with no metadata

### DIFF
--- a/js/app/packages/app/component/command/useChatItems.ts
+++ b/js/app/packages/app/component/command/useChatItems.ts
@@ -11,7 +11,11 @@ export function useChatItems(fullTextSearchTerm: () => string) {
 
     const items: CommandItemCard[] = [];
     for (const chat of chatResults.results) {
-      if (chat.chat_search_results.length === 0 || chat.metadata?.deleted_at)
+      if (
+        chat.chat_search_results.length === 0 ||
+        !chat.metadata ||
+        chat.metadata.deleted_at
+      )
         continue;
       for (const result of chat.chat_search_results) {
         const contents = result.highlight.content ?? [];

--- a/js/app/packages/app/component/command/useDocumentItems.ts
+++ b/js/app/packages/app/component/command/useDocumentItems.ts
@@ -12,7 +12,11 @@ export function useDocumentItems(fullTextSearchTerm: () => string) {
 
     const items: CommandItemCard[] = [];
     for (const doc of docResults.results) {
-      if (doc.document_search_results.length === 0 || doc.metadata?.deleted_at)
+      if (
+        doc.document_search_results.length === 0 ||
+        !doc.metadata ||
+        doc.metadata.deleted_at
+      )
         continue;
 
       for (const result of doc.document_search_results) {

--- a/js/app/packages/app/component/command/useSearchItems.ts
+++ b/js/app/packages/app/component/command/useSearchItems.ts
@@ -14,7 +14,11 @@ function createDocumentItems(
   const items: CommandItemCard[] = [];
   if (doc.type !== 'document') return [];
 
-  if (doc.document_search_results.length === 0 || doc.metadata?.deleted_at)
+  if (
+    doc.document_search_results.length === 0 ||
+    !doc.metadata ||
+    doc.metadata.deleted_at
+  )
     return [];
 
   // TODO: de-duplicate: see logic in useDocumentItems
@@ -86,7 +90,11 @@ function createChatItems(chat: UnifiedSearchResponseItem): CommandItemCard[] {
   const items: CommandItemCard[] = [];
   if (chat.type !== 'chat') return [];
 
-  if (chat.chat_search_results.length === 0 || chat.metadata?.deleted_at)
+  if (
+    chat.chat_search_results.length === 0 ||
+    !chat.metadata ||
+    chat.metadata.deleted_at
+  )
     return [];
 
   // TODO: de-duplicate: see logic in useChatItems
@@ -155,7 +163,8 @@ function createProjectItems(
 
   if (
     project.project_search_results.length === 0 ||
-    project.metadata?.deleted_at
+    !project.metadata ||
+    project.metadata.deleted_at
   )
     return [];
 

--- a/js/app/packages/macro-entity/src/queries/search.ts
+++ b/js/app/packages/macro-entity/src/queries/search.ts
@@ -45,7 +45,7 @@ const useMapSearchResponseItem = () => {
   return (result: UnifiedSearchResponseItem): Entity | undefined => {
     switch (result.type) {
       case 'document': {
-        if (result.metadata?.deleted_at) return;
+        if (!result.metadata || result.metadata.deleted_at) return;
         const search = getHighlights(result.document_search_results);
         return {
           type: 'document',
@@ -83,7 +83,7 @@ const useMapSearchResponseItem = () => {
         };
       }
       case 'chat': {
-        if (result.metadata?.deleted_at) return;
+        if (!result.metadata || result.metadata.deleted_at) return;
         const search = getHighlights(result.chat_search_results);
         let name = result.name;
         if (!name || name === 'New Chat') {
@@ -138,7 +138,7 @@ const useMapSearchResponseItem = () => {
       }
 
       case 'project': {
-        if (result.metadata?.deleted_at) return;
+        if (!result.metadata || result.metadata.deleted_at) return;
         const search = getHighlights(result.project_search_results);
         return {
           type: 'project',


### PR DESCRIPTION
## Summary
<!--
A good summary consists of a two sentence overview followed by bullet points (or checklist items for WIP).
-->

this is an issue with older docs that haven't been removed from the search index and are hard deleted so they don't have deleted at or any metadata at all for that matter. e.g. 

```
     {
            "type": "document",
            "metadata": null,
            "id": "64d19af1-02f3-4c5a-add8-8475f6538288",
            "name": "2 DP Compare ",
            "owner_id": "macro|gab@macro.com",
            "document_id": "64d19af1-02f3-4c5a-add8-8475f6538288",
            "document_name": "2 DP Compare ",
            "file_type": "docx",
            "document_search_results": [
                {
                    "node_id": "3",
                    "highlight": {
                        "content": [
                            " <macro_em>CREDIT</macro_em> <macro_em>AGREEMENT</macro_em>\r\nTHIS <macro_em>AGREEMENT</macro_em> is made as of August 22nd, 2022\r\nBETWEEN :\r\nALVAREZ & MARSAL"
                        ]
                    },
                    "raw_content": null,
                    "updated_at": 1763492297,
                    "score": 852650.06
                }
            ]
        },
```

## Screenshots, GIFs, and Videos
<!--
Include visual representations of your changes, including GIFs/videos. Screencaptures should fully illustrate sample user behavior.
-->
