### PR TITLE
chore [frontend] - remove unused feature flags

### DIFF
--- a/js/app/packages/core/constant/featureFlags.ts
+++ b/js/app/packages/core/constant/featureFlags.ts
@@ -31,41 +31,18 @@ export const ENABLE_PINS = false;
 
 export const ENABLE_THUMBNAIL_VIEWER = false;
 
-export const EDITOR_TOPBAR_BOOKMARKS = false;
-
 export const ENABLE_PDF_TABS = true;
 
 export const ENABLE_PDF_MARKUP = true;
-
-export const ENABLE_MACROTATIONS = false;
-
-// TODO: rename this, this only applies to writer block at the moment
-export const ENABLE_MACROTATIONS_PANEL = false;
-
-export const ENABLE_INBOX = true;
-
-export const ENABLE_MARKDOWN_BLOCK = true;
-
-export const ENABLE_CANVAS_BLOCK = true;
 
 // NOTE: disabling scripting: event listener needs to be properly unmounted first
 // this is the offending line in our pdfjs repo, which has been fixed in the upstream
 // https://github.com/macro-inc/pdf.js/blob/d22768d78ebaaf038707d3d926992a7aeb88e730/web/pdf_scripting_manager.js?plain=1#L59
 export const ENABLE_SCRIPTING = false;
 
-export const ENABLE_ONBOARDING = true;
-
 export const ENABLE_PDF_MULTISPLIT = true;
 
-export const ENABLE_CHAT_INITIALIZER = true;
-
-export const ENABLE_CITATIONS = true;
-
-export const ENABLE_CONNECTION_POPUP = DEV_MODE_ENV;
-
 export const ENABLE_PROJECT_SHARING = DEV_MODE_ENV;
-
-export const ENABLE_CHAT_CREATE_TYPE_DROPDOWN = DEV_MODE_ENV;
 
 export const ENABLE_CANVAS_IMAGES = true;
 
@@ -75,13 +52,9 @@ export const ENABLE_CANVAS_TEXT = true;
 
 export const ENABLE_ORG_SETTING_DEFAULT_SHARE = false;
 
-export const ENABLE_SEPARATE_NOTIFICATION_STACKS = true;
-
 export const ENABLE_NAME_IN_LOGIN = false;
 
 export const ENABLE_LIVE_INDICATORS = true;
-
-export const ENABLE_MINDMAP = true;
 
 export const ENABLE_CONTACTS = true;
 export const ENABLE_GMAIL_BASED_CONTACTS = DEV_MODE_ENV;


### PR DESCRIPTION
Removed the following unused feature flags:
- EDITOR_TOPBAR_BOOKMARKS
- ENABLE_MACROTATIONS
- ENABLE_MACROTATIONS_PANEL
- ENABLE_INBOX
- ENABLE_MARKDOWN_BLOCK
- ENABLE_CANVAS_BLOCK
- ENABLE_ONBOARDING
- ENABLE_CHAT_INITIALIZER
- ENABLE_CITATIONS
- ENABLE_CONNECTION_POPUP
- ENABLE_CHAT_CREATE_TYPE_DROPDOWN
- ENABLE_SEPARATE_NOTIFICATION_STACKS
- ENABLE_MINDMAP
