### PR TITLE
chore: lower search match wait time for pdf

### DIFF
--- a/js/app/packages/block-pdf/signal/location.ts
+++ b/js/app/packages/block-pdf/signal/location.ts
@@ -636,9 +636,7 @@ function useGoToPdfLocation() {
         const findControllerStateEvent = await waitForSignal(
           findControllerStateEventSignal,
           (val) =>
-            val?.state === FindState.FOUND ||
-            val?.state === FindState.NOT_FOUND,
-          10000
+            val?.state === FindState.FOUND || val?.state === FindState.NOT_FOUND
         ).catch((_e) => {
           console.error('search timed out');
           return undefined;


### PR DESCRIPTION
## Summary
<!--
A good summary consists of a two sentence overview followed by bullet points (or checklist items for WIP).
-->

now that pdf search is fast we shouldn't block for as long

## Screenshots, GIFs, and Videos
<!--
Include visual representations of your changes, including GIFs/videos. Screencaptures should fully illustrate sample user behavior.
-->
