### PR TITLE
fix(auth): clockskew on jwt validation:

### DIFF
--- a/rust/cloud-storage/macro_auth/src/middleware/decode_jwt.rs
+++ b/rust/cloud-storage/macro_auth/src/middleware/decode_jwt.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use anyhow::Context;
 use jsonwebtoken::{Algorithm, DecodingKey, Validation, decode};
 use macro_env::Environment;
@@ -128,6 +130,8 @@ pub fn validate_macro_access_token(
     )
 }
 
+const TOKEN_EXPIRATION_BUFFER_SECONDS: Duration = Duration::from_secs(60);
+
 fn validate_macro_access_token_inner(
     macro_access_token: &str,
     jwt_secret: &LocalOrRemoteSecret<JwtSecretKey>,
@@ -138,7 +142,7 @@ fn validate_macro_access_token_inner(
     let mut validation = Validation::new(Algorithm::HS256);
 
     validation.leeway = 0;
-    validation.reject_tokens_expiring_in_less_than = 60;
+    validation.reject_tokens_expiring_in_less_than = TOKEN_EXPIRATION_BUFFER_SECONDS.as_secs();
 
     validation.set_audience(&[audience.as_ref()]);
     validation.set_issuer(&[issuer.as_ref()]);


### PR DESCRIPTION
The rust `jsonwebtoken` crate sets a default leeway(clockskew) of 60 seconds.
Menawhile the nodejs `jsonwebtoken` crate sets a default leeway(clockskew) of 0 seconds.

This means that there is 60 seconds where rust thinks the token is valid, thus doesn't refresh it, but graphql rejects it.

This also explains why gab's websocket server is failing to connect because it's in node and has 0 clockskew.
