### PR TITLE
fix(document_storage_service): add deleted_at from query instead of forcing to None

### DIFF
--- a/rust/cloud-storage/macro_db_client/src/history/mod.rs
+++ b/rust/cloud-storage/macro_db_client/src/history/mod.rs
@@ -118,7 +118,7 @@ pub async fn get_user_history(db: &Pool<Postgres>, user_id: &str) -> anyhow::Res
                 r.name,
                 r.created_at,
                 r.updated_at,
-                None, // Will never be deleted
+                r.deleted_at,
                 r.sha,
                 r.file_type,
                 r.document_family_id,
@@ -137,7 +137,7 @@ pub async fn get_user_history(db: &Pool<Postgres>, user_id: &str) -> anyhow::Res
             r.name,
             r.created_at,
             r.updated_at,
-            None, // Will never be deleted
+            r.deleted_at,
             r.project_id,
             r.is_persistent,
         ))),
@@ -147,7 +147,7 @@ pub async fn get_user_history(db: &Pool<Postgres>, user_id: &str) -> anyhow::Res
             r.name,
             r.created_at,
             r.updated_at,
-            None, // Will never be deleted
+            r.deleted_at,
             r.project_id,
         ))),
         _ => Err(sqlx::Error::TypeNotFound {


### PR DESCRIPTION
## Summary
<!--
A good summary consists of a two sentence overview followed by bullet points (or checklist items for WIP).
-->

We used to filter out items with `"deletedAt" IS NOT NULL`. So we forced deletedAt to be None in the response objects. At some point that was removed so we need to expose the deletedAt value properly.

## Screenshots, GIFs, and Videos
<!--
Include visual representations of your changes, including GIFs/videos. Screencaptures should fully illustrate sample user behavior.
-->
