### PR TITLE
feat(search): remove legacy update entity name events

### DIFF
--- a/rust/cloud-storage/document_cognition_service/src/api/chats/patch_chat.rs
+++ b/rust/cloud-storage/document_cognition_service/src/api/chats/patch_chat.rs
@@ -139,21 +139,6 @@ async fn patch_chat_v2(
                 tracing::error!(error=?err, "failed to convert chat_id to uuid");
             }
         }
-
-        // TODO: remove once we have fully moved to names index
-        let _ = ctx
-            .sqs_client
-            .send_message_to_search_event_queue(
-                sqs_client::search::SearchQueueMessage::UpdateChatMessageMetadata(
-                    sqs_client::search::chat::UpdateChatMessageMetadata {
-                        chat_id: chat_id.to_string(),
-                    },
-                ),
-            )
-            .await
-            .inspect_err(|e| {
-                tracing::error!(error=?e, "SEARCH_QUEUE unable to enqueue message");
-            });
     }
 
     Ok(())

--- a/rust/cloud-storage/document_cognition_service/src/api/ws/chat_message/mod.rs
+++ b/rust/cloud-storage/document_cognition_service/src/api/ws/chat_message/mod.rs
@@ -408,19 +408,6 @@ pub async fn handle_send_chat_message(
                 tracing::error!(error=?err, "failed to convert chat_id to uuid");
             }
         }
-
-        // TODO: remove this once we have fully moved to names index
-        let _ = ctx
-            .sqs_client
-            .send_message_to_search_event_queue(SearchQueueMessage::UpdateChatMessageMetadata(
-                sqs_client::search::chat::UpdateChatMessageMetadata {
-                    chat_id: incoming_message.chat_id.clone(),
-                },
-            ))
-            .await
-            .inspect_err(
-                |err| tracing::error!(error=?err, "failed to send message to search event queue"),
-            );
     }
     ctx.context_provider_client
         .provide_context(user_id, &user_message_id)

--- a/rust/cloud-storage/document_storage_service/src/api/documents/edit_document/edit_document_v2.rs
+++ b/rust/cloud-storage/document_storage_service/src/api/documents/edit_document/edit_document_v2.rs
@@ -13,7 +13,7 @@ use model::{
 use models_opensearch::SearchEntityType;
 use models_permissions::share_permission::UpdateSharePermissionRequestV2;
 use models_permissions::share_permission::access_level::AccessLevel;
-use sqs_client::search::{SearchQueueMessage, document::DocumentId, name::EntityName};
+use sqs_client::search::{SearchQueueMessage, name::EntityName};
 use tracing::Instrument;
 
 pub async fn edit_document(
@@ -102,18 +102,6 @@ pub async fn edit_document(
                         EntityName {
                             entity_id: document_id,
                             entity_type: SearchEntityType::Documents,
-                        },
-                    ))
-                    .await
-                    .inspect_err(|e| {
-                        tracing::error!(error=?e, "SEARCH_QUEUE unable to enqueue message");
-                    });
-
-                // TODO: remove once we have fully moved to names index
-                let _ = sqs_client
-                    .send_message_to_search_event_queue(SearchQueueMessage::UpdateDocumentMetadata(
-                        DocumentId {
-                            document_id: document_id.to_string(),
                         },
                     ))
                     .await

--- a/rust/cloud-storage/search_processing_service/src/process/document/mod.rs
+++ b/rust/cloud-storage/search_processing_service/src/process/document/mod.rs
@@ -77,31 +77,3 @@ pub async fn process_extract_sync_message(
 
     Ok(())
 }
-
-pub async fn process_update_metadata_message(
-    opensearch_client: &OpensearchClient,
-    db: &sqlx::Pool<sqlx::Postgres>,
-    document_id: &str,
-) -> anyhow::Result<()> {
-    let document_info = match macro_db_client::document::get_basic_document(db, document_id).await {
-        Ok(document_info) => document_info,
-        Err(e) => match e {
-            sqlx::Error::RowNotFound => {
-                return Ok(());
-            }
-            _ => {
-                anyhow::bail!("unable to get document info")
-            }
-        },
-    };
-
-    if document_info.deleted_at.is_some() {
-        return Ok(());
-    }
-
-    opensearch_client
-        .update_document_metadata(document_id, document_info.document_name.as_str())
-        .await?;
-
-    Ok(())
-}

--- a/rust/cloud-storage/search_processing_service/src/process/mod.rs
+++ b/rust/cloud-storage/search_processing_service/src/process/mod.rs
@@ -43,14 +43,6 @@ pub async fn process_message(
             tracing::trace!(user_profile_id = user_profile_id, "removing user profile");
             user::remove_user_profile(&ctx.opensearch_client, &user_profile_id).await?;
         }
-        SearchQueueMessage::UpdateDocumentMetadata(message) => {
-            document::process_update_metadata_message(
-                &ctx.opensearch_client,
-                &ctx.db,
-                &message.document_id,
-            )
-            .await?;
-        }
         SearchQueueMessage::ChannelMessageUpdate(message) => {
             channel::process_channel_message_update(
                 &ctx.opensearch_client,
@@ -114,9 +106,6 @@ pub async fn process_message(
         }
         SearchQueueMessage::RemoveChatMessage(message) => {
             chat::remove_chat_message(&ctx.opensearch_client, &message).await?;
-        }
-        SearchQueueMessage::UpdateChatMessageMetadata(message) => {
-            chat::update_chat_message_metadata(&ctx.opensearch_client, &ctx.db, &message).await?;
         }
         SearchQueueMessage::ProjectMessage(message) => {
             project::insert_project(&ctx.opensearch_client, &ctx.db, &message).await?;

--- a/rust/cloud-storage/sqs_client/src/search/chat.rs
+++ b/rust/cloud-storage/sqs_client/src/search/chat.rs
@@ -13,12 +13,6 @@ pub struct ChatMessage {
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq, Eq)]
-pub struct UpdateChatMessageMetadata {
-    /// The chat id
-    pub chat_id: String,
-}
-
-#[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq, Eq)]
 pub struct RemoveChatMessage {
     /// The chat id to remove
     pub chat_id: String,

--- a/rust/cloud-storage/sqs_client/src/search/mod.rs
+++ b/rust/cloud-storage/sqs_client/src/search/mod.rs
@@ -2,7 +2,7 @@ use crate::{
     SQS,
     search::{
         channel::{ChannelMessageUpdate, RemoveChannelMessage},
-        chat::{ChatMessage, RemoveChatMessage, UpdateChatMessageMetadata},
+        chat::{ChatMessage, RemoveChatMessage},
         document::{DocumentId, SearchExtractorMessage},
         email::{EmailLinkMessage, EmailMessage, EmailThreadMessage},
         name::EntityName,
@@ -71,11 +71,9 @@ pub enum SearchQueueMessage {
     ExtractDocumentText(SearchExtractorMessage),
     RemoveDocument(DocumentId),
     ExtractSync(SearchExtractorMessage),
-    UpdateDocumentMetadata(DocumentId),
     // Chat
     ChatMessage(ChatMessage),
     RemoveChatMessage(RemoveChatMessage),
-    UpdateChatMessageMetadata(UpdateChatMessageMetadata),
     // Email
     ExtractEmailMessage(EmailMessage),
     RemoveEmailMessage(EmailMessage),
@@ -104,10 +102,6 @@ impl PrimaryId for SearchQueueMessage {
             SearchQueueMessage::RemoveDocument(message) => message.document_id.clone(),
             SearchQueueMessage::ExtractSync(message) => message.document_id.clone(),
             SearchQueueMessage::ChatMessage(message) => message.message_id.clone(), // needs
-            SearchQueueMessage::UpdateChatMessageMetadata(message) => {
-                format!("{}update", message.chat_id.clone())
-            }
-            SearchQueueMessage::UpdateDocumentMetadata(message) => message.document_id.clone(),
             // to be the message id to ensure it's unique for batch
             SearchQueueMessage::RemoveChatMessage(message) => message.chat_id.clone(),
             SearchQueueMessage::ExtractEmailMessage(message)
@@ -142,11 +136,9 @@ impl SearchQueueMessage {
             SearchQueueMessage::ExtractDocumentText(_) => Operation::ExtractText,
             SearchQueueMessage::RemoveDocument(_) => Operation::Remove,
             SearchQueueMessage::ExtractSync(_) => Operation::ExtractSync,
-            SearchQueueMessage::UpdateDocumentMetadata(_) => Operation::UpdateMetadata,
             // Chat
             SearchQueueMessage::ChatMessage(_) => Operation::ExtractText,
             SearchQueueMessage::RemoveChatMessage(_) => Operation::Remove,
-            SearchQueueMessage::UpdateChatMessageMetadata(_) => Operation::UpdateMetadata,
             // Email
             SearchQueueMessage::ExtractEmailMessage(_) => Operation::ExtractText,
             SearchQueueMessage::RemoveEmailMessage(_) => Operation::Remove,


### PR DESCRIPTION
## Summary
<!--
A good summary consists of a two sentence overview followed by bullet points (or checklist items for WIP).
-->

Once we have #345 merged in, we can merge this in to remove the processing of name update events on entity indices.

## Screenshots, GIFs, and Videos
<!--
Include visual representations of your changes, including GIFs/videos. Screencaptures should fully illustrate sample user behavior.
-->
