### PR TITLE
Evan/ema 41 update html sanitizer

### DIFF
--- a/rust/cloud-storage/gmail_client/src/sanitizer.rs
+++ b/rust/cloud-storage/gmail_client/src/sanitizer.rs
@@ -191,9 +191,6 @@ fn get_safe_css_properties() -> HashSet<&'static str> {
         "white-space",
         "direction",
         "unicode-bidi",
-        // Color & Background
-        "background-color",
-        "opacity",
         // Box Model & Spacing
         "padding",
         "padding-top",
@@ -272,12 +269,10 @@ fn get_safe_css_properties() -> HashSet<&'static str> {
         "mso-padding-alt",
         "mso-margin-top-alt",
         "mso-margin-bottom-alt",
-        // --- SHORTHANDS ---
-        // You have individual sides (padding-top), but standard "padding"
-        // and "background" are often used.
+        // Color & Background
+        "background-color",
+        "opacity",
         "background",
-        // Note: background-image is often blocked by clients by default,
-        // but allowing it in the sanitizer is usually fine as the *client* decides to show it.
         "background-image",
         "background-position",
         "background-repeat",


### PR DESCRIPTION
## Summary
<!--
A good summary consists of a two sentence overview followed by bullet points (or checklist items for WIP).
-->

Updating the html sanitizer we use on emails to include some additional fields. This was spurred by the previous exclusion of the `background` field, which was causing issues in some Linear emails.

I originally made this like 3 AI generations ago, so I passed it by the latest ChatGPT Gemini and Claude Opus models to see what they thought I should add, and this is the result! wee

I considered adding tests for this, but really that would be directly testing the functionality of the `ammonia` / `scraper` crates, which doesn't add much value imo. (we added this property - does it get removed from an email? etc) If anyone feels strongly I can create some simple unit tests to validate this.
## Screenshots, GIFs, and Videos
<!--
Include visual representations of your changes, including GIFs/videos. Screencaptures should fully illustrate sample user behavior.
-->
