### PR TITLE
fix(ci): add in bunfig.toml creation to setup-reqs-web action

### DIFF
--- a/.github/actions/setup-reqs-web/action.yml
+++ b/.github/actions/setup-reqs-web/action.yml
@@ -5,12 +5,28 @@ inputs:
     description: Install Playwright and cache
     required: false
     default: ''
+  npm-rc-token:
+    description: NPM RC Token
+    required: false
+    default: ''
 
 runs:
   using: composite
   steps:
     - name: Setup Bun
       uses: oven-sh/setup-bun@v2
+
+    - name: Setup bunfig.toml
+      working-directory: js/app
+      shell: bash
+      run: |
+        touch bunfig.toml
+        echo "[run]" >> bunfig.toml
+        echo "bun = true" >> bunfig.toml
+        echo "[install]" >> bunfig.toml
+        echo "linker = \"hoisted\"" >> bunfig.toml
+        echo "[install.scopes]" >> bunfig.toml
+        echo "macro-inc = { token = \"${{ inputs.npm-rc-token }}\", url = \"https://npm.pkg.github.com\" }" >> bunfig.toml
 
     - name: Install Dependencies
       shell: bash

--- a/.github/workflows/deploy-web-app.yml
+++ b/.github/workflows/deploy-web-app.yml
@@ -57,6 +57,8 @@ jobs:
           ref: ${{ github.ref_name }}
       - name: Setup
         uses: ./.github/actions/setup-reqs-web
+        with:
+          npm-rc-token: ${{ secrets.NPMRC_GH_TOKEN }}
       - name: Build
         working-directory: js/app
         run: bun run build:${{ inputs.environment }}

--- a/.github/workflows/deploy-web-services.yml
+++ b/.github/workflows/deploy-web-services.yml
@@ -51,6 +51,8 @@ jobs:
           aws-region: us-east-1
       - name: Setup
         uses: ./.github/actions/setup-reqs-web
+        with:
+          npm-rc-token: ${{ secrets.NPMRC_GH_TOKEN }}
       - name: Install infra dependencies
         run: |
           cd infra

--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -35,6 +35,8 @@ jobs:
         uses: actions/checkout@v5
       - name: Setup Prereqs
         uses: ./.github/actions/setup-reqs-web
+        with:
+          npm-rc-token: ${{ secrets.NPMRC_GH_TOKEN }}
       - name: Build for Production
         working-directory: js/app
         run: bun run build:prod
@@ -60,6 +62,8 @@ jobs:
         uses: actions/checkout@v5
       - name: Setup Prereqs
         uses: ./.github/actions/setup-reqs-web
+        with:
+          npm-rc-token: ${{ secrets.NPMRC_GH_TOKEN }}
       - name: Download Build Artifact
         uses: actions/download-artifact@v5
         with:

--- a/.github/workflows/web-app-check-main.yml
+++ b/.github/workflows/web-app-check-main.yml
@@ -22,7 +22,6 @@ jobs:
             should_run:
               - 'js/app/package.json'
               - 'js/app/bun.lock'
-              - 'js/app/bunfig.toml'
               - 'js/app/packages/**'
               - 'js/app/src/**'
               - '.github/actions/setup-reqs-web/**'
@@ -38,6 +37,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Prereqs
         uses: ./.github/actions/setup-reqs-web
+        with:
+          npm-rc-token: ${{ secrets.NPMRC_GH_TOKEN }}
       - name: Generate API Types
         working-directory: js/app
         run: bun run gen-api
@@ -76,6 +77,8 @@ jobs:
           fetch-depth: 0
       - name: Setup Prereqs
         uses: ./.github/actions/setup-reqs-web
+        with:
+          npm-rc-token: ${{ secrets.NPMRC_GH_TOKEN }}
       - name: Check Tailwind Classes
         working-directory: js/app
         run: bun run check-tailwind
@@ -90,6 +93,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup
         uses: ./.github/actions/setup-reqs-web
+        with:
+          npm-rc-token: ${{ secrets.NPMRC_GH_TOKEN }}
       - name: Test
         working-directory: js/app
         run: bunx vitest
@@ -120,6 +125,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup
         uses: ./.github/actions/setup-reqs-web
+        with:
+          npm-rc-token: ${{ secrets.NPMRC_GH_TOKEN }}
       - name: Build
         working-directory: js/app
         run: bun run build

--- a/js/app/.gitignore
+++ b/js/app/.gitignore
@@ -81,3 +81,4 @@ CLAUDE.md
 .envrc
 
 storybook-static
+bunfig.toml


### PR DESCRIPTION
## Summary
<!--
A good summary consists of a two sentence overview followed by bullet points (or checklist items for WIP).
-->

This PR adds in the generation of the `bunfig.toml` to the `setup-reqs-web` job so that when bun install is run the token is present to download private npm packages.

## Screenshots, GIFs, and Videos
<!--
Include visual representations of your changes, including GIFs/videos. Screencaptures should fully illustrate sample user behavior.
-->
