### PR TITLE
fix(pagination): limit after sort

### DIFF
--- a/rust/cloud-storage/models_pagination/src/cursor.rs
+++ b/rust/cloud-storage/models_pagination/src/cursor.rs
@@ -233,17 +233,21 @@ where
             ..
         } = self;
 
-        let mut res: Vec<_> = iter.take(limit).collect();
-
-        if let Some(sort) = ensure_sort {
-            res.sort_by_key(|r| {
-                let cursor = cb(r);
-                match sort {
-                    Direction::Asc => Either::Left(cursor.last_val),
-                    Direction::Desc => Either::Right(std::cmp::Reverse(cursor.last_val)),
-                }
-            });
-        }
+        let res = match ensure_sort {
+            Some(sort) => {
+                let mut res: Vec<_> = iter.collect();
+                res.sort_by_key(|r| {
+                    let cursor = cb(r);
+                    match sort {
+                        Direction::Asc => Either::Left(cursor.last_val),
+                        Direction::Desc => Either::Right(std::cmp::Reverse(cursor.last_val)),
+                    }
+                });
+                res.truncate(limit);
+                res
+            }
+            None => iter.take(limit).collect(),
+        };
 
         match res.len().cmp(&limit) {
             Ordering::Less => Paginated {


### PR DESCRIPTION
## Summary
<!--
A good summary consists of a two sentence overview followed by bullet points (or checklist items for WIP).
-->
fixes a bug where sorting was happening after limiting

## Screenshots, GIFs, and Videos
<!--
Include visual representations of your changes, including GIFs/videos. Screencaptures should fully illustrate sample user behavior.
-->
