### PR TITLE
fix(email): properly set the sender on email notification

### DIFF
--- a/rust/cloud-storage/email_service/src/pubsub/webhook/operations/upsert_message.rs
+++ b/rust/cloud-storage/email_service/src/pubsub/webhook/operations/upsert_message.rs
@@ -8,6 +8,7 @@ use email_db_client::threads::get::get_outbound_threads_by_thread_ids;
 use email_utils::dedupe_emails;
 use futures::future::join_all;
 use insight_service_client::InsightContextProvider;
+use macro_user_id::user_id::MacroUserIdStr;
 use model::contacts::ConnectionsMessage;
 use model::insight_context::email_insights::{
     EMAIL_INSIGHT_PROVIDER_SOURCE_NAME, EmailInfo, GenerateEmailInsightContext, NewMessagePayload,
@@ -573,7 +574,9 @@ async fn send_notifications(
                 .unwrap_or_else(|| contact.email.clone())
         });
 
-        let sender_id = sender_contact.map(|contact| format!("macro|{}", contact.email));
+        let sender_id = sender_contact
+            .and_then(|contact| MacroUserIdStr::try_from_email(&contact.email).ok())
+            .map(|id| id.to_string());
 
         let notification_metadata = NewEmailMetadata {
             sender,

--- a/rust/cloud-storage/macro_user_id/src/user_id.rs
+++ b/rust/cloud-storage/macro_user_id/src/user_id.rs
@@ -89,6 +89,13 @@ impl<'a> MacroUserIdStr<'a> {
     }
 }
 
+impl MacroUserIdStr<'static> {
+    /// Create a MacroUserIdStr from an email address by prepending "macro|"
+    pub fn try_from_email(email: &str) -> Result<Self, ParseErr> {
+        Self::try_from(format!("{}|{}", MACRO_PREFIX, email))
+    }
+}
+
 impl TryFrom<String> for MacroUserIdStr<'static> {
     type Error = ParseErr;
 


### PR DESCRIPTION
The notification `sender_id` on `new_email` notifications was being set to the id of the email link not to the person who sent the email.

Further along in the notification pipeline we filter out `sender_id` from the list of notification recipients. Since normally we wouldn't want the "sender" of a notification to receive their own notification.
