### PR TITLE
fix: Unable to create thread for message with deleted reply

### DIFF
--- a/js/app/packages/block-channel/component/Message/MessageContainer.tsx
+++ b/js/app/packages/block-channel/component/Message/MessageContainer.tsx
@@ -253,7 +253,7 @@ export function MessageContainer(props: MessageProps) {
 
   const shouldShowFirstReply = createMemo(() => {
     return (
-      !props.threadChildren &&
+      !props.threadChildren?.length &&
       props.threadViewStore[message.id ?? '']?.hasActiveReply
     );
   });


### PR DESCRIPTION
## Summary
When trying to reply to a message with no active replies but deleted replies, it wouldn't do anything. This was just a bad check because sometimes the `threadChildren` array could be defined but empty
