### PR TITLE
chore(email): add gmail auth feature

### DIFF
--- a/rust/cloud-storage/email_service/Cargo.toml
+++ b/rust/cloud-storage/email_service/Cargo.toml
@@ -29,8 +29,10 @@ default = [
   "attachment_upload",
   "connection_gateway",
   "contacts_sync",
+  "gmail_webhook_auth",
   "sfs_map",
 ]
+gmail_webhook_auth = []
 local_queue = []
 sfs_map = []
 

--- a/rust/cloud-storage/email_service/src/api/gmail/webhook.rs
+++ b/rust/cloud-storage/email_service/src/api/gmail/webhook.rs
@@ -22,7 +22,10 @@ pub async fn webhook_handler(
     extract::Json(req): extract::Json<GmailWebhookPayload>,
 ) -> Result<Response, Response> {
     // Validate the token in the headers sent from Google
-    validate_google_token(&ctx, &headers).await?;
+    if cfg!(feature = "gmail_webhook_auth") {
+        validate_google_token(&ctx, &headers).await?;
+    }
+
     let email_address = &req.message.data.email_address;
 
     let link = email_db_client::links::get::fetch_link_by_email(


### PR DESCRIPTION
Re-adds an inverted version of the recently remove disable-gmail-webhook-auth cargo feature
