### PR TITLE
fix(mentions): clean duped people listings

### DIFF
--- a/js/app/packages/core/component/LexicalMarkdown/component/menu/MentionsMenu.tsx
+++ b/js/app/packages/core/component/LexicalMarkdown/component/menu/MentionsMenu.tsx
@@ -733,7 +733,7 @@ export function MentionsMenu(props: {
     const orgUsers = useOrganizationUsers();
     const contacts = useContacts();
     users = createMemo(() =>
-      mergeByKey('id', contacts(), orgUsers())
+      mergeByKey('email', orgUsers(), contacts())
         .map(entityMapper('user'))
         .filter(allItemFilter)
     );


### PR DESCRIPTION
the contacts service returns multiples for some entries: for example i get both 
`email=daniel@macro.com id=daniel@macro.com` and `email=daniel@macro.com id=macro|daniel@macro.com`

this pr cleans up the UI for US ONLY - by treating org users as the dedupe base case. 
