### PR TITLE
fix(iac): bulk upload lambda permissions

### DIFF
--- a/infra/stacks/bulk-upload/upload-extractor-lambda-handler.ts
+++ b/infra/stacks/bulk-upload/upload-extractor-lambda-handler.ts
@@ -104,10 +104,11 @@ export class UploadExtractorLambdaHandler extends pulumi.ComponentResource {
           aws.iam.ManagedPolicy.AWSLambdaBasicExecutionRole,
           aws.iam.ManagedPolicy.AmazonDynamoDBFullAccess,
           sqsPolicy.arn,
+          uploadBucketPolicy.arn,
         ],
         tags: this.tags,
       },
-      { parent: this }
+      { parent: this, dependsOn: [sqsPolicy, uploadBucketPolicy] }
     );
 
     const uploadExtractorLambdaHandlerLambda =
@@ -128,26 +129,6 @@ export class UploadExtractorLambdaHandler extends pulumi.ComponentResource {
 
     this.lambda = uploadExtractorLambdaHandlerLambda.lambda;
     this.role = role;
-
-    new aws.iam.RolePolicyAttachment(
-      `${LAMBDA_BASE_NAME}-role-upload-bucket-att`,
-      {
-        role,
-        policyArn: uploadBucketPolicy.arn,
-      },
-      { parent: this, dependsOn: [uploadBucketPolicy, role] }
-    );
-
-    new aws.lambda.Permission(
-      `${LAMBDA_BASE_NAME}-sqs-permission-${stack}`,
-      {
-        action: 'lambda:InvokeFunction',
-        function: this.lambda.name,
-        principal: 'sqs.amazonaws.com',
-        sourceArn: uploadExtractorQueueArn,
-      },
-      { parent: this }
-    );
 
     new aws.lambda.EventSourceMapping(
       `${LAMBDA_BASE_NAME}-sqs-source-mapping`,


### PR DESCRIPTION
## Summary
<!--
A good summary consists of a two sentence overview followed by bullet points (or checklist items for WIP).
-->

The permissions on the upload_extractor role were becoming out of sync in pulumi due to using both `managedPolicyArns` and manually attaching roles to the permission. `managedPolicyArns` behave much better in pulumi for being in sync.

## Screenshots, GIFs, and Videos
<!--
Include visual representations of your changes, including GIFs/videos. Screencaptures should fully illustrate sample user behavior.
-->
