### PR TITLE
fix(macrodb): Remove backfill operation from db migration

### DIFF
--- a/rust/cloud-storage/macro_db_client/migrations/20251202193438_email_message_names.sql
+++ b/rust/cloud-storage/macro_db_client/migrations/20251202193438_email_message_names.sql
@@ -3,15 +3,3 @@ ALTER TABLE public.email_messages
 
 ALTER TABLE public.email_message_recipients
     ADD COLUMN name VARCHAR(255);
-
-UPDATE public.email_messages m
-SET from_name = c.name
-    FROM public.email_contacts c
-WHERE m.from_contact_id = c.id
-  AND m.from_name IS NULL;
-
-UPDATE public.email_message_recipients mr
-SET name = c.name
-    FROM public.email_contacts c
-WHERE mr.contact_id = c.id
-  AND mr.name IS NULL;


### PR DESCRIPTION
## Summary
<!--
A good summary consists of a two sentence overview followed by bullet points (or checklist items for WIP).
-->
Updating the db migration for the changes I just merged to not perform the backfill as a sql update operation.

While this works fine in dev and locally, the scale of prod results in a bunch of locks while the large amount of messages are updating.

We don't even _need_ to backfill this stuff, as all the logic for fetching contact names is a coalesce on the email_contacts table anyway. The backfill was just putting what was already in email_contacts into the email_message / email_recipients table.

I ran the old migration in dev already so i'll manually revert the changes it made, update the `_sqlx_migrations` table accordingly, and rerun this new migration.

The prod one I cancelled midway through so it effectively didn't run, so no changes are needed there.
## Screenshots, GIFs, and Videos
<!--
Include visual representations of your changes, including GIFs/videos. Screencaptures should fully illustrate sample user behavior.
-->
