### PR TITLE
fix [properties-be] - allow view access for publicly shared entities

### DIFF
--- a/rust/cloud-storage/properties_service/src/api/mod.rs
+++ b/rust/cloud-storage/properties_service/src/api/mod.rs
@@ -41,21 +41,18 @@ pub async fn setup_and_serve(state: ApiContext) -> anyhow::Result<()> {
 
 fn api_router(app_state: ApiContext) -> Router {
     Router::new()
-        // Public properties routes (allows anonymous access for viewing public entities)
         .nest(
             "/properties",
-            properties::public_router().layer(axum::middleware::from_fn_with_state(
-                app_state.jwt_args.clone(),
-                macro_middleware::auth::attach_user::handler,
-            )),
-        )
-        // Authenticated properties routes (requires JWT)
-        .nest(
-            "/properties",
-            properties::authenticated_router().layer(axum::middleware::from_fn_with_state(
-                app_state.jwt_args.clone(),
-                macro_middleware::auth::decode_jwt::handler,
-            )),
+            properties::router().layer(
+                tower::ServiceBuilder::new()
+                    .layer(axum::middleware::from_fn(
+                        macro_middleware::auth::initialize_user_context::handler,
+                    ))
+                    .layer(axum::middleware::from_fn_with_state(
+                        app_state.jwt_args.clone(),
+                        macro_middleware::auth::attach_user::handler,
+                    )),
+            ),
         )
         .nest(
             "/internal",

--- a/rust/cloud-storage/properties_service/src/api/properties/entities/get.rs
+++ b/rust/cloud-storage/properties_service/src/api/properties/entities/get.rs
@@ -69,22 +69,13 @@ impl IntoResponse for GetEntityPropertiesErr {
     ),
     tag = "Properties"
 )]
-#[tracing::instrument(skip(context, user_context), fields(user_id = tracing::field::Empty, entity_type = ?entity_type, include_metadata = query.include_metadata))]
+#[tracing::instrument(skip(context, user_context), fields(user_id = %user_context.user_id, entity_type = ?entity_type, include_metadata = query.include_metadata))]
 pub async fn get_entity_properties(
     Path((entity_type, entity_id)): Path<(EntityType, String)>,
     Query(query): Query<EntityQueryParams>,
     State(context): State<ApiContext>,
-    user_context: Option<Extension<UserContext>>,
+    Extension(user_context): Extension<UserContext>,
 ) -> Result<Json<EntityPropertiesResponse>, GetEntityPropertiesErr> {
-    // Extract user_id from context, defaulting to empty string for anonymous users
-    let user_id = user_context
-        .as_ref()
-        .map(|ctx| ctx.user_id.as_str())
-        .unwrap_or("");
-
-    // Record user_id in span
-    tracing::Span::current().record("user_id", user_id);
-
     tracing::info!(
         entity_id = %entity_id,
         entity_type = ?entity_type,
@@ -96,7 +87,12 @@ pub async fn get_entity_properties(
         entity_id: entity_id.clone(),
         entity_type,
     };
-    crate::api::permissions::check_entity_view_permission(&context, user_id, &entity_ref).await?;
+    crate::api::permissions::check_entity_view_permission(
+        &context,
+        &user_context.user_id,
+        &entity_ref,
+    )
+    .await?;
 
     let (user_properties, metadata_properties) = if query.include_metadata {
         // Fetch user properties and metadata in parallel when metadata is requested
@@ -178,7 +174,7 @@ pub async fn get_entity_properties(
         entity_id = %entity_id,
         properties_count = response.properties.len(),
         include_metadata = query.include_metadata,
-        user_id = %user_id,
+        user_id = %user_context.user_id,
         "successfully retrieved entity properties"
     );
 

--- a/rust/cloud-storage/properties_service/src/api/properties/mod.rs
+++ b/rust/cloud-storage/properties_service/src/api/properties/mod.rs
@@ -9,45 +9,47 @@ pub mod entities;
 pub mod metadata;
 pub mod options;
 
-/// Routes that allow anonymous access (for viewing public entities)
-pub fn public_router() -> Router<ApiContext> {
+pub fn router() -> Router<ApiContext> {
+    let ensure_user_exists =
+        axum::middleware::from_fn(macro_middleware::auth::ensure_user_exists::handler);
+
     Router::new()
-        // GET entity properties - allows anonymous access for public documents
+        // Property Definition Management - requires authentication
+        .route(
+            "/definitions",
+            get(definitions::list::list_properties)
+                .post(definitions::create::create_property_definition)
+                .layer(ensure_user_exists.clone()),
+        )
+        .route(
+            "/definitions/:definition_id",
+            delete(definitions::delete::delete_property_definition)
+                .layer(ensure_user_exists.clone()),
+        )
+        // Property Options Management - requires authentication
+        .route(
+            "/definitions/:definition_id/options",
+            get(options::get::get_property_options)
+                .post(options::create::add_property_option)
+                .layer(ensure_user_exists.clone()),
+        )
+        .route(
+            "/definitions/:definition_id/options/:option_id",
+            delete(options::delete::delete_property_option).layer(ensure_user_exists.clone()),
+        )
+        // Entity Property Operations
+        // GET allows anonymous access for public entities
         .route(
             "/entities/:entity_type/:entity_id",
             get(entities::get::get_entity_properties),
         )
-}
-
-/// Routes that require authentication
-pub fn authenticated_router() -> Router<ApiContext> {
-    Router::new()
-        // Property Definition Management - Unified endpoint with query params
-        .route(
-            "/definitions",
-            get(definitions::list::list_properties)
-                .post(definitions::create::create_property_definition),
-        )
-        .route(
-            "/definitions/:definition_id",
-            delete(definitions::delete::delete_property_definition),
-        )
-        // Property Options Management
-        .route(
-            "/definitions/:definition_id/options",
-            get(options::get::get_property_options).post(options::create::add_property_option),
-        )
-        .route(
-            "/definitions/:definition_id/options/:option_id",
-            delete(options::delete::delete_property_option),
-        )
-        // Entity Property Operations (write operations require auth)
+        // PUT/DELETE require authentication
         .route(
             "/entities/:entity_type/:entity_id/:property_id",
-            put(entities::set::set_entity_property),
+            put(entities::set::set_entity_property).layer(ensure_user_exists.clone()),
         )
         .route(
             "/entity_properties/:entity_property_id",
-            delete(entities::delete_property::delete_entity_property),
+            delete(entities::delete_property::delete_entity_property).layer(ensure_user_exists),
         )
 }


### PR DESCRIPTION
fix [properties-be] - allow view access for publicly shared entities

- Added fallback permission check in check_entity_view_permission - when get_users_access_level_v2 returns no access, we now check if the entity is publicly shared via SharePermission.isPublic
- Uses existing macro_db_client::share_permission::get::get_*_share_permission functions to determine public visibility