### PR TITLE
feat(macrodb): add document_task table

### DIFF
--- a/rust/cloud-storage/macro_db_client/migrations/20251204165917_create_document_task_table.sql
+++ b/rust/cloud-storage/macro_db_client/migrations/20251204165917_create_document_task_table.sql
@@ -1,0 +1,10 @@
+-- Add migration script here
+
+CREATE TABLE "document_task"
+(
+    "document_id" TEXT NOT NULL,
+
+    CONSTRAINT "document_task_pkey" PRIMARY KEY ("document_id"),
+    CONSTRAINT "document_task_document_id_fkey" FOREIGN KEY ("document_id") 
+        REFERENCES "Document" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);


### PR DESCRIPTION
## Summary
<!--
A good summary consists of a two sentence overview followed by bullet points (or checklist items for WIP).
-->

adds `document_task` table which is used to track if a given markdown document is a task.

i did not add constraints to check the file type of the document as I think that is unnecessary db overhead and we can check service side. this also means if other documents become tasks we don't shoehorn ourselves.

## Screenshots, GIFs, and Videos
<!--
Include visual representations of your changes, including GIFs/videos. Screencaptures should fully illustrate sample user behavior.
-->
