### PR TITLE
feat(email-service): Enable contacts syncing

### DIFF
--- a/rust/cloud-storage/email_service/src/pubsub/webhook/operations/upsert_message.rs
+++ b/rust/cloud-storage/email_service/src/pubsub/webhook/operations/upsert_message.rs
@@ -247,7 +247,7 @@ async fn handle_contacts_sync(
     provider_message_id: &str,
 ) -> result::Result<(), ProcessingError> {
     // if the user sent the message, upsert contacts for its recipients in contacts-service.
-    if cfg!(feature = "contacts_sync") || !is_sent || recipient_emails.is_empty() {
+    if cfg!(not(feature = "contacts_sync")) || !is_sent || recipient_emails.is_empty() {
         return Ok(());
     }
 


### PR DESCRIPTION
## Summary
<!--
A good summary consists of a two sentence overview followed by bullet points (or checklist items for WIP).
-->

Now that the auth-service endpoint has been released to prod and I was able to validate the contact name functionality, we can enable contact syncing for users in production.

Once enabled I will run the backfill script I created to populate contacts for all email users in prod.

## Screenshots, GIFs, and Videos
<!--
Include visual representations of your changes, including GIFs/videos. Screencaptures should fully illustrate sample user behavior.
-->
