### PR TITLE
chg(kommand): deprioritize commands in Kommand Menu, remove splitting

### DIFF
--- a/js/app/packages/app/component/command/Konsole.tsx
+++ b/js/app/packages/app/component/command/Konsole.tsx
@@ -176,17 +176,9 @@ export function KommandMenuInner(props: {
   });
 
   const searchItems = createMemo(() => {
-    let actionItems: CommandItemCard[] = [];
-    const otherItems = freshSearch(allItems(), debouncedLocalQuery())
-      .map((result) => result.item)
-      .filter((item) => {
-        if (item.type === 'command') {
-          actionItems.push(item);
-          return false;
-        }
-        return true;
-      });
-    return [...actionItems, ...otherItems];
+    return freshSearch(allItems(), debouncedLocalQuery()).map(
+      (result) => result.item
+    );
   });
 
   createModeListenerEffects();


### PR DESCRIPTION
- Commands & Files are no longer being split when ordered.
- Files should show up first
- Commands are still searchable
