### PR TITLE
chg(kommand): disable email + search in kommand menu

### DIFF
--- a/js/app/packages/app/component/command/Konsole.tsx
+++ b/js/app/packages/app/component/command/Konsole.tsx
@@ -23,7 +23,6 @@ import {
   untrack,
 } from 'solid-js';
 import { VList } from 'virtua/solid';
-import FullTextModeToggle from './FullTextModeToggle';
 import { KonsoleFilter } from './KonsoleFilter';
 import {
   COMMAND_ITEM_HEIGHT,
@@ -362,9 +361,6 @@ export function KommandMenuInner(props: {
           placeholder="Search files..."
           class="flex-1 border-0 outline-none! focus:outline-none ring-0! focus:ring-0 font-mono placeholder:text-edge text-accent-270"
           onValueChange={setRawQuery}
-        />
-        <FullTextModeToggle
-          checked={currentKonsoleMode() === 'FULL_TEXT_SEARCH'}
         />
       </div>
       <div

--- a/js/app/packages/app/component/command/KonsoleItem.tsx
+++ b/js/app/packages/app/component/command/KonsoleItem.tsx
@@ -107,7 +107,7 @@ const DEFAULT_CATEGORIES = [
   { name: 'Documents', visible: true },
   { name: 'Chats', visible: true },
   { name: 'Folders', visible: true },
-  { name: 'Emails', visible: true },
+  { name: 'Emails', visible: false },
   { name: 'Contacts', visible: ENABLE_GMAIL_BASED_CONTACTS },
   { name: 'Companies', visible: ENABLE_GMAIL_BASED_CONTACTS },
 ] as const;

--- a/js/app/packages/app/component/command/state.ts
+++ b/js/app/packages/app/component/command/state.ts
@@ -44,7 +44,7 @@ export function cleanQuery(query?: string) {
 }
 
 export const COMMAND_MODES = [
-  { id: 'FULL_TEXT_SEARCH', sigil: '%', label: 'Full Text Search' },
+  // { id: 'FULL_TEXT_SEARCH', sigil: '%', label: 'Full Text Search' },
   // { id: "REGEX_SEARCH", sigil: "/", label: "Regex Search" },
   // { id: "RUN_COMMAND", sigil: ">", label: "Run" },
   // { id: "TEMP_CHAT", sigil: " ", label: "Temporary Chat" },


### PR DESCRIPTION
Email Section in the kommand menu is broken. Full-text search is not working due to the fact that it is being re-built in the unified list.
Full text search in the unified list is sufficiently working to disable it in the kommand menu.


Once ehayes finishes adding support for emails in the mentions menu, simmilar logic could be ported to the kommand menu.
