### PR TITLE
fix: Auto focus first item in recipient selector when typing and mount

### DIFF
--- a/js/app/packages/core/component/RecipientSelector.tsx
+++ b/js/app/packages/core/component/RecipientSelector.tsx
@@ -388,8 +388,11 @@ export function RecipientSelector<K extends CombinedRecipientKind>(
   const onInputChange = (next: string) => {
     setInputValue(next);
 
+    // Send the keydown event to the listbox so Kobalte's internal system can update the focus state
+    // This makes it so it behaves the same as if you had manually pressed the down arrow to focus the item
     queueMicrotask(() => {
       listboxRef()?.dispatchEvent(
+        // We need to send `bubbles: true` because otherwise Kobalte ignores the event
         new KeyboardEvent('keydown', { bubbles: true, key: 'ArrowDown' })
       );
     });


### PR DESCRIPTION
## Summary
Uses the undocumented `autoFocus` property for the list box to handle focusing the first item on mount. For focusing the first item after typing, we can send the `keydown` event manually to the listbox which will call Kobalte's internal systems to update their state and produce the desired output.

## Screenshots, GIFs, and Videos
<!--
Include visual representations of your changes, including GIFs/videos. Screencaptures should fully illustrate sample user behavior.
-->
