### PR TITLE
feat(iac): decrease deprovisioning time to improve deployment speed

### DIFF
--- a/infra/packages/resources/src/resources/datadog.ts
+++ b/infra/packages/resources/src/resources/datadog.ts
@@ -72,6 +72,7 @@ export class DatadogServiceEntity extends ComponentResource {
 export const fargateLogRouterSidecarContainer = {
   essential: true,
   image: 'amazon/aws-for-fluent-bit:latest',
+  stopTimeout: 10, // 10 seconds to force kill the task
   name: 'log_router',
   firelensConfiguration: {
     type: 'fluentbit',
@@ -101,6 +102,7 @@ export const fargateLogRouterSidecarContainer = {
 export const datadogAgentContainer = {
   name: 'datadog-agent',
   image: 'public.ecr.aws/datadog/agent:latest',
+  stopTimeout: 10, // 10 seconds to force kill the task
   environment: [
     {
       name: 'ECS_FARGATE',

--- a/infra/packages/resources/src/resources/load_balancer.ts
+++ b/infra/packages/resources/src/resources/load_balancer.ts
@@ -33,8 +33,7 @@ export function serviceLoadBalancer(
     `${serviceName}-tg-${stack}`,
     {
       name: `${serviceName}-tg-${stack}`,
-      // TODO: might want to make this smaller?
-      deregistrationDelay: 120,
+      deregistrationDelay: 30, // let any active calls finish within 30 seconds
       port: serviceContainerPort,
       protocol: 'HTTP',
       targetType: 'ip',

--- a/infra/stacks/authentication-service/service.ts
+++ b/infra/stacks/authentication-service/service.ts
@@ -218,6 +218,7 @@ export class AuthenticationService extends pulumi.ComponentResource {
             service: {
               name: BASE_NAME,
               image: image.image.imageUri,
+              stopTimeout: 10, // 10 seconds to force kill the task
               cpu: 256,
               memory: 512,
               environment: [

--- a/infra/stacks/cloud-storage-service/cloud-storage-service.ts
+++ b/infra/stacks/cloud-storage-service/cloud-storage-service.ts
@@ -278,6 +278,7 @@ export class CloudStorageService extends pulumi.ComponentResource {
             service: {
               name: BASE_NAME,
               image: image.image.imageUri,
+              stopTimeout: 10, // 10 seconds to force kill the task
               cpu: stack === 'prod' ? 1024 : 512,
               memory: stack === 'prod' ? 4096 : 2048,
               environment: containerEnvVars,

--- a/infra/stacks/comms-service/comms-service.ts
+++ b/infra/stacks/comms-service/comms-service.ts
@@ -207,6 +207,7 @@ export class CommsService extends pulumi.ComponentResource {
             service: {
               name: BASE_NAME,
               image: image.image.imageUri,
+              stopTimeout: 10, // 10 seconds to force kill the task
               cpu: 4096,
               memory: 8192,
               environment: containerEnvVars,

--- a/infra/stacks/connection-gateway/connection_gateway.ts
+++ b/infra/stacks/connection-gateway/connection_gateway.ts
@@ -188,6 +188,7 @@ export class ConnectionGateway extends pulumi.ComponentResource {
             service: {
               name: BASE_NAME,
               image: image.image.imageUri,
+              stopTimeout: 10, // 10 seconds to force kill the task
               cpu: 4096,
               memory: 8192,
               environment: containerEnvVars,

--- a/infra/stacks/contacts-service/service.ts
+++ b/infra/stacks/contacts-service/service.ts
@@ -195,6 +195,7 @@ export class ContactsService extends pulumi.ComponentResource {
             service: {
               name: BASE_NAME,
               image: image.image.imageUri,
+              stopTimeout: 10, // 10 seconds to force kill the task
               cpu: stack === 'prod' ? 512 : 256,
               memory: stack === 'prod' ? 1024 : 512,
               environment: [

--- a/infra/stacks/convert-service/service.ts
+++ b/infra/stacks/convert-service/service.ts
@@ -216,6 +216,7 @@ export class ConvertService extends pulumi.ComponentResource {
             service: {
               name: BASE_NAME,
               image: image.image.imageUri,
+              stopTimeout: 10, // 10 seconds to force kill the task
               cpu: 4096,
               memory: 8192,
               environment: [

--- a/infra/stacks/delete-document-worker/worker.ts
+++ b/infra/stacks/delete-document-worker/worker.ts
@@ -225,6 +225,7 @@ export class Worker extends pulumi.ComponentResource {
             service: {
               name: BASE_NAME,
               image: image.image.imageUri,
+              stopTimeout: 10, // 10 seconds to force kill the task
               cpu: 256,
               memory: 512,
               environment: containerEnvVars,

--- a/infra/stacks/document-cognition-service/document-cognition-service.ts
+++ b/infra/stacks/document-cognition-service/document-cognition-service.ts
@@ -200,6 +200,7 @@ export class DocumentCognitionService extends pulumi.ComponentResource {
             service: {
               name: BASE_NAME,
               image: image.image.imageUri,
+              stopTimeout: 10, // 10 seconds to force kill the task
               cpu: 4096,
               memory: 8192,
               environment: containerEnvVars,

--- a/infra/stacks/email-service/service.ts
+++ b/infra/stacks/email-service/service.ts
@@ -247,6 +247,7 @@ export class EmailService extends pulumi.ComponentResource {
             service: {
               name: BASE_NAME,
               image: image.image.imageUri,
+              stopTimeout: 10, // 10 seconds to force kill the task
               cpu: stack === 'prod' ? 2048 : 1024,
               memory: stack === 'prod' ? 3742 : 1742, // 2048 minimum - 256 for datadog - 50 for log_router
               environment: [...containerEnvVars],

--- a/infra/stacks/experiment-service/service.ts
+++ b/infra/stacks/experiment-service/service.ts
@@ -173,6 +173,7 @@ export class ExperimentService extends pulumi.ComponentResource {
             service: {
               name: BASE_NAME,
               image: image.image.imageUri,
+              stopTimeout: 10, // 10 seconds to force kill the task
               cpu: 256,
               memory: 512,
               environment: [

--- a/infra/stacks/insight-service/service.ts
+++ b/infra/stacks/insight-service/service.ts
@@ -251,6 +251,7 @@ export class InsightService extends pulumi.ComponentResource {
             service: {
               name: BASE_NAME,
               image: image.image.imageUri,
+              stopTimeout: 10, // 10 seconds to force kill the task
               cpu: 256,
               memory: 512,
               environment: envVars,

--- a/infra/stacks/metering-service/service.ts
+++ b/infra/stacks/metering-service/service.ts
@@ -158,6 +158,7 @@ export class Service extends pulumi.ComponentResource {
             service: {
               name: SERVICE_DIR_NAME,
               image: image.image.imageUri,
+              stopTimeout: 10, // 10 seconds to force kill the task
               cpu: stack === 'prod' ? 512 : 256,
               memory: stack === 'prod' ? 1024 : 512,
               environment: [

--- a/infra/stacks/notification-email-poller/notification-email-poller.ts
+++ b/infra/stacks/notification-email-poller/notification-email-poller.ts
@@ -111,6 +111,7 @@ export class Worker extends pulumi.ComponentResource {
         container: {
           name: WORKER_NAME,
           image: image.image.imageUri,
+          stopTimeout: 10, // 10 seconds to force kill the task
           cpu: 256, // Specify CPU units
           memory: 512, // Specify memory in MB
           environment: [...containerEnvVars],

--- a/infra/stacks/notification-service/service.ts
+++ b/infra/stacks/notification-service/service.ts
@@ -254,6 +254,7 @@ export class NotificationService extends pulumi.ComponentResource {
             service: {
               name: BASE_NAME,
               image: image.image.imageUri,
+              stopTimeout: 10, // 10 seconds to force kill the task
               cpu: stack === 'prod' ? 1024 : 256,
               memory: stack === 'prod' ? 2048 : 512,
               environment: [

--- a/infra/stacks/organization-service/organization-service.ts
+++ b/infra/stacks/organization-service/organization-service.ts
@@ -204,6 +204,7 @@ export class OrganizationService extends pulumi.ComponentResource {
             service: {
               name: BASE_NAME,
               image: image.image.imageUri,
+              stopTimeout: 10, // 10 seconds to force kill the task
               cpu: stack === 'prod' ? 1024 : 256,
               memory: stack === 'prod' ? 2048 : 512,
               environment: containerEnvVars,

--- a/infra/stacks/properties-service/properties-service.ts
+++ b/infra/stacks/properties-service/properties-service.ts
@@ -175,6 +175,7 @@ export class PropertiesService extends pulumi.ComponentResource {
             service: {
               name: BASE_NAME,
               image: image.image.imageUri,
+              stopTimeout: 10, // 10 seconds to force kill the task
               cpu: 1024,
               memory: 2048,
               environment: containerEnvVars,

--- a/infra/stacks/search-processing-service/service.ts
+++ b/infra/stacks/search-processing-service/service.ts
@@ -215,6 +215,7 @@ export class SearchProcessingService extends pulumi.ComponentResource {
             service: {
               name: BASE_NAME,
               image: image.image.imageUri,
+              stopTimeout: 10, // 10 seconds to force kill the task
               cpu: stack === 'prod' ? 1024 : 512,
               memory: stack === 'prod' ? 4096 : 1024,
               environment: containerEnvVars ?? [],

--- a/infra/stacks/search-service/service.ts
+++ b/infra/stacks/search-service/service.ts
@@ -171,6 +171,7 @@ export class SearchService extends pulumi.ComponentResource {
             service: {
               name: BASE_NAME,
               image: image.image.imageUri,
+              stopTimeout: 10, // 10 seconds to force kill the task
               cpu: stack === 'prod' ? 512 : 256,
               memory: stack === 'prod' ? 1024 : 512,
               environment: containerEnvVars ?? [],

--- a/infra/stacks/static-file-service/static-file-service.ts
+++ b/infra/stacks/static-file-service/static-file-service.ts
@@ -429,6 +429,7 @@ export class StaticFileService extends pulumi.ComponentResource {
             service: {
               name: SERVICE_NAME,
               image: image.image.imageUri,
+              stopTimeout: 10, // 10 seconds to force kill the task
               cpu: 256,
               memory: 512,
               environment: [

--- a/infra/stacks/unfurl-service/unfurl-service.ts
+++ b/infra/stacks/unfurl-service/unfurl-service.ts
@@ -151,6 +151,7 @@ export class UnfurlService extends pulumi.ComponentResource {
             service: {
               name: BASE_NAME,
               image: image.image.imageUri,
+              stopTimeout: 10, // 10 seconds to force kill the task
               cpu: 256,
               memory: 512,
               environment: containerEnvVars,


### PR DESCRIPTION
## Summary
<!--
A good summary consists of a two sentence overview followed by bullet points (or checklist items for WIP).
-->

This PR lowers our deregistration delay for application load balancers from 5min to 30s. This should greatly speed up our deployments as the services will deregister/deprovision faster.

It also adds a stopTimeout to all task images which will have ECS force kill the task after 10 seconds if the task hasn't exited gracefully by then

## Screenshots, GIFs, and Videos
<!--
Include visual representations of your changes, including GIFs/videos. Screencaptures should fully illustrate sample user behavior.
-->
