### PR TITLE
feat [properties-fe] - add data type icons to property labels in panel

### DIFF
--- a/js/app/packages/core/component/Properties/component/panel/PropertyLabel.tsx
+++ b/js/app/packages/core/component/Properties/component/panel/PropertyLabel.tsx
@@ -8,6 +8,7 @@ import { type Component, createMemo, createSignal, Show } from 'solid-js';
 import { deleteEntityProperty } from '../../api';
 import { usePropertiesContext } from '../../context/PropertiesContext';
 import type { Property } from '../../types';
+import { PropertyDataTypeIcon } from '../../utils';
 
 type PropertyLabelProps = {
   property: Property;
@@ -61,11 +62,18 @@ export const PropertyLabel: Component<PropertyLabelProps> = (props) => {
   return (
     <>
       <div
-        class="flex items-center min-w-0"
+        class="flex items-center gap-1.5 min-w-0"
         onMouseEnter={() => setIsHovered(true)}
         onMouseLeave={() => setIsHovered(false)}
       >
-        <span class="text-sm pr-2 text-ink-muted truncate flex-shrink min-w-0">
+        <PropertyDataTypeIcon
+          property={{
+            data_type: props.property.valueType,
+            specific_entity_type: props.property.specificEntityType,
+          }}
+          class="size-4 text-ink-muted shrink-0"
+        />
+        <span class="text-sm text-ink-muted truncate flex-shrink min-w-0">
           {props.property.displayName}
         </span>
         {/* Always reserve space for delete button to prevent layout shift */}


### PR DESCRIPTION
feat [properties-fe] - add data type icons to property labels in panel

<img width="473" height="288" alt="Screenshot 2025-12-08 at 2 41 58 PM" src="https://github.com/user-attachments/assets/29d232cb-cb21-4422-9c1f-245727cbbdc5" />
