### PR TITLE
fix?(soup): remove reconcile from entity queries

### DIFF
--- a/js/app/packages/macro-entity/src/components/Provider.tsx
+++ b/js/app/packages/macro-entity/src/components/Provider.tsx
@@ -13,8 +13,8 @@ import type { EntityData } from '../types/entity';
 // NOTE: leaving this in as reference for now.
 // Turning this off due to [M-5344]. This is likely unnecessary.
 // @ts-ignore
-// biome-ignore
-function reconcileEntities(
+// biome-ignore: not-needed
+function _reconcileEntities(
   oldData?: EntityData[],
   newData?: EntityData[]
 ): EntityData[] | undefined {


### PR DESCRIPTION
Every entity query would need to perform an O(n^2) reconcile step for every fetch, which I believe was causing performance issues when switching tabs.



- This query client will be consolidated anyway soon.
- Seems like this reconcile was here to try and ensure referencial stability, but don't think it is needed.
