### PR TITLE
Fix: Display names not showing in mentions menu for channel users

### DIFF
--- a/js/app/packages/block-channel/component/Message/MessageReactions.tsx
+++ b/js/app/packages/block-channel/component/Message/MessageReactions.tsx
@@ -44,7 +44,7 @@ export function MessageReactions(props: MessageReactionsProps) {
               : reaction.users.includes(userId()!);
 
             const tooltipContent = createMemo(() => {
-              let users = reaction.users.map((userId_) => {
+              const users = reaction.users.map((userId_) => {
                 if (userId_ === userId()!) {
                   return 'You';
                 }
@@ -52,8 +52,9 @@ export function MessageReactions(props: MessageReactionsProps) {
               });
 
               if (users.length === 1) {
-                return idToDisplayName(users[0]);
+                return users[0];
               }
+
               const first = users.slice(0, -1);
               const lastUser = users.slice(-1)[0];
               // Team oxford comma


### PR DESCRIPTION
## Summary
The second call to `idToDisplayName` would queue up a possible invalid id, like just the email fallback that `useDisplayName` returns while the resource is loading, which would lead to the entire fetch call for names to fail with a 422

## Screenshots, GIFs, and Videos
<!--
Include visual representations of your changes, including GIFs/videos. Screencaptures should fully illustrate sample user behavior.
-->
