### PR TITLE
fix: support message tag for empty message

### DIFF
--- a/js/app/packages/macro-entity/src/components/EntityWithEverything.tsx
+++ b/js/app/packages/macro-entity/src/components/EntityWithEverything.tsx
@@ -649,12 +649,7 @@ export function EntityWithEverything(
 
                   const metadata =
                     tryToTypedNotification(notification)?.notificationMetadata;
-                  if (
-                    !metadata ||
-                    !('messageContent' in metadata) ||
-                    !metadata.messageContent
-                  )
-                    return '';
+                  if (!metadata || !('messageContent' in metadata)) return '';
 
                   return 'message';
                 };


### PR DESCRIPTION
## Summary
<!--
A good summary consists of a two sentence overview followed by bullet points (or checklist items for WIP).
-->

if the message content was "\n" it would be truthy but if it was "" it would be falsy. however both of these are still messages. @sedson will work on adding some sort of *sent attachment* text to make it clearer what's going on

## Screenshots, GIFs, and Videos
<!--
Include visual representations of your changes, including GIFs/videos. Screencaptures should fully illustrate sample user behavior.
-->
in dev
<img width="659" height="203" alt="CleanShot 2025-12-10 at 16 26 06" src="https://github.com/user-attachments/assets/6c5654f9-d8d1-4562-8a79-fa9f1ed09200" />

