### PR TITLE
fix: scroll channel to bottom if notification has been deleted + notify user

### DIFF
--- a/js/app/packages/block-channel/component/MessageList/MessageList.tsx
+++ b/js/app/packages/block-channel/component/MessageList/MessageList.tsx
@@ -199,8 +199,8 @@ export function MessageList(props: MessageListProps) {
    * @returns
    */
   const scrollToBottomOrTarget = debounce(
-    (params?: { forceBottom?: boolean }) => {
-      const { forceBottom } = params || { forceBottom: false };
+    (params: { forceBottom?: boolean } = {}) => {
+      const { forceBottom } = params;
       const timeStamp = Date.now();
       const delta = timeStamp - lastTargetMessageTimestamp();
       const target = props.targetMessage();


### PR DESCRIPTION
## Summary
<!--
A good summary consists of a two sentence overview followed by bullet points (or checklist items for WIP).
-->

- scrolls channel to bottom if target message not found (in this case notification message was deleted)
- removes onlyBottom param and cleans up forceBottom
- adds toast indicating message not found

## Screenshots, GIFs, and Videos
<!--
Include visual representations of your changes, including GIFs/videos. Screencaptures should fully illustrate sample user behavior.
-->

https://github.com/user-attachments/assets/2f222628-40f2-4be8-ba68-c9b7432aabf1

