### PR TITLE
fix: show *attached items* for empty string

### DIFF
--- a/js/app/packages/macro-entity/src/components/EntityWithEverything.tsx
+++ b/js/app/packages/macro-entity/src/components/EntityWithEverything.tsx
@@ -245,7 +245,7 @@ function NotificationRow(props: {
     if (
       !metadata ||
       !('messageContent' in metadata) ||
-      !metadata.messageContent
+      metadata.messageContent === undefined
     )
       return '';
 


### PR DESCRIPTION
## Summary
<!--
A good summary consists of a two sentence overview followed by bullet points (or checklist items for WIP).
-->

we only want the undefined case to return empty string, empty string should show "attached items"

## Screenshots, GIFs, and Videos
<!--
Include visual representations of your changes, including GIFs/videos. Screencaptures should fully illustrate sample user behavior.
-->
