### PR TITLE
fix: search highlight name show entire name

### DIFF
--- a/rust/cloud-storage/opensearch_client/src/search/builder.rs
+++ b/rust/cloud-storage/opensearch_client/src/search/builder.rs
@@ -336,7 +336,7 @@ impl<T: SearchQueryConfig> SearchQueryBuilder<T> {
                     .highlight_type("plain")
                     .pre_tags(vec![MacroEm::Open.to_string()])
                     .post_tags(vec![MacroEm::Close.to_string()])
-                    .number_of_fragments(1),
+                    .number_of_fragments(0),
             ),
             SearchOn::NameContent => Highlight::new()
                 .require_field_match(false)
@@ -346,7 +346,7 @@ impl<T: SearchQueryConfig> SearchQueryBuilder<T> {
                         .highlight_type("plain")
                         .pre_tags(vec![MacroEm::Open.to_string()])
                         .post_tags(vec![MacroEm::Close.to_string()])
-                        .number_of_fragments(1),
+                        .number_of_fragments(0),
                 )
                 .field(
                     T::CONTENT_KEY,
@@ -354,7 +354,7 @@ impl<T: SearchQueryConfig> SearchQueryBuilder<T> {
                         .highlight_type("plain")
                         .pre_tags(vec![MacroEm::Open.to_string()])
                         .post_tags(vec![MacroEm::Close.to_string()])
-                        .number_of_fragments(1),
+                        .number_of_fragments(0),
                 ),
         };
 

--- a/rust/cloud-storage/opensearch_client/src/search/builder/test.rs
+++ b/rust/cloud-storage/opensearch_client/src/search/builder/test.rs
@@ -79,13 +79,13 @@ fn test_build_search_request() -> anyhow::Result<()> {
             "fields": {
                 "content": {
                     "type": "plain",
-                    "number_of_fragments": 1,
+                    "number_of_fragments": 0,
                     "pre_tags": ["<macro_em>"],
                     "post_tags": ["</macro_em>"],
                 },
                 "test_title": {
                     "type": "plain",
-                    "number_of_fragments": 1,
+                    "number_of_fragments": 0,
                     "pre_tags": ["<macro_em>"],
                     "post_tags": ["</macro_em>"],
                 }
@@ -148,13 +148,13 @@ fn test_build_search_request() -> anyhow::Result<()> {
             "fields": {
                 "content": {
                     "type": "plain",
-                    "number_of_fragments": 1,
+                    "number_of_fragments": 0,
                     "pre_tags": ["<macro_em>"],
                     "post_tags": ["</macro_em>"],
                 },
                 "test_title": {
                     "type": "plain",
-                    "number_of_fragments": 1,
+                    "number_of_fragments": 0,
                     "pre_tags": ["<macro_em>"],
                     "post_tags": ["</macro_em>"],
                 }

--- a/rust/cloud-storage/opensearch_client/src/search/projects.rs
+++ b/rust/cloud-storage/opensearch_client/src/search/projects.rs
@@ -31,7 +31,7 @@ impl SearchQueryConfig for ProjectSearchConfig {
                 Self::TITLE_KEY,
                 HighlightField::new()
                     .highlight_type("plain")
-                    .number_of_fragments(1)
+                    .number_of_fragments(0)
                     .pre_tags(vec![MacroEm::Open.to_string()])
                     .post_tags(vec![MacroEm::Close.to_string()]),
             )

--- a/rust/cloud-storage/opensearch_client/src/search/unified.rs
+++ b/rust/cloud-storage/opensearch_client/src/search/unified.rs
@@ -489,7 +489,7 @@ fn build_unified_search_request(args: &UnifiedSearchArgs) -> Result<SearchReques
                         .highlight_type("plain")
                         .pre_tags(vec![MacroEm::Open.to_string()])
                         .post_tags(vec![MacroEm::Close.to_string()])
-                        .number_of_fragments(1),
+                        .number_of_fragments(0),
                 );
             }
             highlight
@@ -506,7 +506,7 @@ fn build_unified_search_request(args: &UnifiedSearchArgs) -> Result<SearchReques
                         .highlight_type("plain")
                         .pre_tags(vec![MacroEm::Open.to_string()])
                         .post_tags(vec![MacroEm::Close.to_string()])
-                        .number_of_fragments(1),
+                        .number_of_fragments(0),
                 );
             }
 
@@ -516,7 +516,7 @@ fn build_unified_search_request(args: &UnifiedSearchArgs) -> Result<SearchReques
                     .highlight_type("plain")
                     .pre_tags(vec![MacroEm::Open.to_string()])
                     .post_tags(vec![MacroEm::Close.to_string()])
-                    .number_of_fragments(1),
+                    .number_of_fragments(0),
             );
 
             highlight

--- a/rust/cloud-storage/opensearch_client/src/search/unified/test.rs
+++ b/rust/cloud-storage/opensearch_client/src/search/unified/test.rs
@@ -823,7 +823,7 @@ fn test_build_unified_search_request_name() -> anyhow::Result<()> {
       "highlight": {
         "fields": {
           "name": {
-            "number_of_fragments": 1,
+            "number_of_fragments": 0,
             "post_tags": [
               "</macro_em>"
             ],
@@ -833,7 +833,7 @@ fn test_build_unified_search_request_name() -> anyhow::Result<()> {
             "type": "plain"
           },
           "project_name": {
-            "number_of_fragments": 1,
+            "number_of_fragments": 0,
             "post_tags": [
               "</macro_em>"
             ],
@@ -1071,7 +1071,7 @@ fn test_build_unified_search_request_name_content() -> anyhow::Result<()> {
       "highlight": {
         "fields": {
           "content": {
-            "number_of_fragments": 1,
+            "number_of_fragments": 0,
             "post_tags": [
               "</macro_em>"
             ],
@@ -1081,7 +1081,7 @@ fn test_build_unified_search_request_name_content() -> anyhow::Result<()> {
             "type": "plain"
           },
           "name": {
-            "number_of_fragments": 1,
+            "number_of_fragments": 0,
             "post_tags": [
               "</macro_em>"
             ],
@@ -1091,7 +1091,7 @@ fn test_build_unified_search_request_name_content() -> anyhow::Result<()> {
             "type": "plain"
           },
           "project_name": {
-            "number_of_fragments": 1,
+            "number_of_fragments": 0,
             "post_tags": [
               "</macro_em>"
             ],


### PR DESCRIPTION
## Summary
<!--
A good summary consists of a two sentence overview followed by bullet points (or checklist items for WIP).
-->

changing from 1 -> 0 per [docs](https://docs.opensearch.org/latest/search-plugins/searching-data/highlight/): "The maximum number of returned fragments. If number_of_fragments is set to 0, OpenSearch returns the highlighted contents of the entire field. Default is 5."

## Screenshots, GIFs, and Videos
<!--
Include visual representations of your changes, including GIFs/videos. Screencaptures should fully illustrate sample user behavior.
-->
