### PR TITLE
fix(email-service): Get attachment document_id endpoint upload location

### DIFF
--- a/rust/cloud-storage/email_service/src/api/email/attachments/get_document_id.rs
+++ b/rust/cloud-storage/email_service/src/api/email/attachments/get_document_id.rs
@@ -7,7 +7,7 @@ use axum::{Extension, Json};
 use model::response::ErrorResponse;
 use models_email::db::address::EmailRecipientType;
 use models_email::email::service::link::Link;
-use models_email::service::attachment::AttachmentUploadArgs;
+use models_email::service::attachment::{AttachmentUploadArgs, AttachmentUploadDestination};
 use strum_macros::AsRefStr;
 use thiserror::Error;
 use utoipa::ToSchema;
@@ -113,6 +113,9 @@ pub async fn handler(
         attachment_metadata,
         recipient_emails,
         backfill: false,
+        // Frontend will soon use SFS URLs for image/video attachments directly instead of DSS
+        // Until this transition is complete, we continue uploading all attachments to DSS
+        upload_destination: AttachmentUploadDestination::Dss,
     };
 
     let ctx_upload = UploadAttachmentContext {

--- a/rust/cloud-storage/email_service/src/pubsub/backfill/increment_counters.rs
+++ b/rust/cloud-storage/email_service/src/pubsub/backfill/increment_counters.rs
@@ -3,7 +3,9 @@ use crate::util::backfill::backfill_insights::backfill_email_insights;
 use model::contacts::ConnectionsMessage;
 use model::insight_context::email_insights::BackfillEmailInsightsFilter;
 use models_email::db::address::EmailRecipientType;
-use models_email::service::attachment::{AttachmentUploadArgs, AttachmentUploadMetadata};
+use models_email::service::attachment::{
+    AttachmentUploadArgs, AttachmentUploadDestination, AttachmentUploadMetadata,
+};
 use models_email::service::backfill::{
     BackfillAttachmentPayload, BackfillJobStatus, BackfillMessagePayload, BackfillOperation,
     BackfillPubsubMessage, UpdateMetadataPayload,
@@ -284,10 +286,20 @@ async fn send_attachment_backfill_messages(
             .filter_map(|(contact, _)| contact.email_address.clone())
             .collect();
 
+        let upload_destination = if matches!(
+            attachment.mime_type.split('/').next(),
+            Some("image" | "video")
+        ) {
+            AttachmentUploadDestination::Sfs
+        } else {
+            AttachmentUploadDestination::Dss
+        };
+
         let attachment_upload_args = AttachmentUploadArgs {
             recipient_emails,
             attachment_metadata: attachment,
             backfill: true,
+            upload_destination,
         };
 
         let new_payload = BackfillAttachmentPayload {

--- a/rust/cloud-storage/email_service/src/pubsub/webhook/operations/upsert_message.rs
+++ b/rust/cloud-storage/email_service/src/pubsub/webhook/operations/upsert_message.rs
@@ -25,7 +25,7 @@ use models_email::email::service::message::SimpleMessage;
 use models_email::email::service::thread::UserThreadIds;
 use models_email::gmail::operations::GmailApiOperation;
 use models_email::gmail::webhook::{UpsertMessagePayload, WebhookOperation};
-use models_email::service::attachment::AttachmentUploadArgs;
+use models_email::service::attachment::{AttachmentUploadArgs, AttachmentUploadDestination};
 use models_email::service::message::Message;
 use models_email::service::pubsub::{DetailedError, FailureReason, ProcessingError};
 use models_opensearch::SearchEntityType;
@@ -255,10 +255,20 @@ async fn handle_attachment_upload(
                 .filter_map(|(contact, _)| contact.email_address.clone())
                 .collect();
 
+            let upload_destination = if matches!(
+                attachment.mime_type.split('/').next(),
+                Some("image" | "video")
+            ) {
+                AttachmentUploadDestination::Sfs
+            } else {
+                AttachmentUploadDestination::Dss
+            };
+
             let attachment_upload_args = AttachmentUploadArgs {
                 recipient_emails,
                 attachment_metadata: attachment,
                 backfill: false,
+                upload_destination,
             };
 
             let ctx_upload = UploadAttachmentContext {

--- a/rust/cloud-storage/email_service/src/util/upload_attachment.rs
+++ b/rust/cloud-storage/email_service/src/util/upload_attachment.rs
@@ -61,10 +61,13 @@ pub async fn upload_attachment(
 
     let mime_type = args.attachment_metadata.mime_type.clone();
 
-    if mime_type.starts_with("image/") || mime_type.starts_with("video/") {
-        upload_media_attachment(&ctx, args, attachment_data, mime_type).await
-    } else {
-        upload_document_attachment(&ctx, args, attachment_data).await
+    match args.upload_destination {
+        models_email::service::attachment::AttachmentUploadDestination::Sfs => {
+            upload_media_attachment(&ctx, args, attachment_data, mime_type).await
+        }
+        models_email::service::attachment::AttachmentUploadDestination::Dss => {
+            upload_document_attachment(&ctx, args, attachment_data).await
+        }
     }
 }
 

--- a/rust/cloud-storage/models_email/src/email/service/attachment.rs
+++ b/rust/cloud-storage/models_email/src/email/service/attachment.rs
@@ -78,4 +78,11 @@ pub struct AttachmentUploadArgs {
     pub attachment_metadata: AttachmentUploadMetadata,
     pub recipient_emails: Vec<String>,
     pub backfill: bool,
+    pub upload_destination: AttachmentUploadDestination,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum AttachmentUploadDestination {
+    Dss,
+    Sfs,
 }


### PR DESCRIPTION
## Summary
<!--
A good summary consists of a two sentence overview followed by bullet points (or checklist items for WIP).
-->
Soon, the FE will display image/video email attachments using SFS. However, until the change is made, it grabs image/video attachments using the `GET /attachment/document_id` endpoint, which expects the attachment it is querying for to be stored in DSS.

Reverting the logic in that endpoint to always upload the requested attachment to DSS, instead of uploading requested image attachments to SFS.

Tested in dev successfully

## Screenshots, GIFs, and Videos
<!--
Include visual representations of your changes, including GIFs/videos. Screencaptures should fully illustrate sample user behavior.
-->
