### PR TITLE
perf(macrodb): Add email indices to improve link deletion time

### DIFF
--- a/rust/cloud-storage/macro_db_client/migrations/20251212204146_email_delete_indices.sql
+++ b/rust/cloud-storage/macro_db_client/migrations/20251212204146_email_delete_indices.sql
@@ -1,0 +1,13 @@
+-- Indices to speed up email link deletion
+CREATE INDEX idx_email_messages_replying_to_id
+    ON public.email_messages (replying_to_id)
+    WHERE replying_to_id IS NOT NULL;
+
+CREATE INDEX idx_email_user_history_thread_id
+    ON public.email_user_history (thread_id);
+
+CREATE INDEX idx_email_threads_link_id
+    ON public.email_threads (link_id);
+
+CREATE INDEX idx_email_messages_link_id
+    ON public.email_messages (link_id);


### PR DESCRIPTION
## Summary
<!--
A good summary consists of a two sentence overview followed by bullet points (or checklist items for WIP).
-->
Email account link deletion times are currently very slow due to lack of indices needed when performing cascading deletions across all the tables. Adding indices that drastically reduce deletion times. Without indices in dev it took 14.8s to delete my link, with the indices it takes 350ms.

## Screenshots, GIFs, and Videos
<!--
Include visual representations of your changes, including GIFs/videos. Screencaptures should fully illustrate sample user behavior.
-->
