### PR TITLE
fix(email-service): Notify for new messages after attachment upload

### DIFF
--- a/rust/cloud-storage/email_service/src/pubsub/webhook/operations/upsert_message.rs
+++ b/rust/cloud-storage/email_service/src/pubsub/webhook/operations/upsert_message.rs
@@ -149,14 +149,6 @@ pub async fn upsert_message(
         })?;
     }
 
-    // trigger FE inbox refresh
-    cg_refresh_email(
-        &ctx.connection_gateway_client,
-        link.macro_id.as_ref(),
-        "upsert_message",
-    )
-    .await;
-
     handle_attachment_upload(
         ctx,
         &gmail_access_token,
@@ -174,6 +166,14 @@ pub async fn upsert_message(
         &payload.provider_message_id,
     )
     .await?;
+
+    // trigger FE inbox refresh
+    cg_refresh_email(
+        &ctx.connection_gateway_client,
+        link.macro_id.as_ref(),
+        "upsert_message",
+    )
+    .await;
 
     // notify downstream services of new messages
     notify_for_new_messages(ctx, link, new_message_provider_ids).await?;


### PR DESCRIPTION
## Summary
<!--
A good summary consists of a two sentence overview followed by bullet points (or checklist items for WIP).
-->

Don't notify users of new messages until after attachment upload. Prevents race condition where attachment hasn't been uploaded by the time the user gets the email notification.

this doesn't cover the edge case where the user is spam refreshing soup, in that case they could open the message before the attachments are uploaded, but peter and i agreed that's an edge case not worth worrying about right now. as long as the connection gateway refresh message and notification aren't sent until after upload it's good enough for now

## Screenshots, GIFs, and Videos
<!--
Include visual representations of your changes, including GIFs/videos. Screencaptures should fully illustrate sample user behavior.
-->
