### PR TITLE
fix [properties-fe] - filter current entity from entity selection list

### DIFF
--- a/js/app/packages/core/component/Properties/component/modal/shared/PropertyEntitySelector.tsx
+++ b/js/app/packages/core/component/Properties/component/modal/shared/PropertyEntitySelector.tsx
@@ -1,3 +1,4 @@
+import { useBlockId } from '@core/block';
 import { useChannelsContext } from '@core/component/ChannelsProvider';
 import { EntityIcon } from '@core/component/EntityIcon';
 import { UserIcon } from '@core/component/UserIcon';
@@ -31,6 +32,7 @@ import {
   on,
   Show,
 } from 'solid-js';
+import { usePropertiesContext } from '../../../context/PropertiesContext';
 import { PROPERTY_STYLES } from '../../../styles/styles';
 import type { Property } from '../../../types';
 import { useSearchInputFocus } from '../../../utils';
@@ -205,6 +207,10 @@ export function PropertyEntitySelector(props: EntityInputProps) {
 
   let searchInputRef!: HTMLInputElement;
 
+  // Get current entity context for self-filtering
+  const blockId = useBlockId();
+  const { entityType: currentEntityType } = usePropertiesContext();
+
   const history = useHistory();
   const contacts = useContacts();
   const channelsContext = useChannelsContext();
@@ -315,17 +321,26 @@ export function PropertyEntitySelector(props: EntityInputProps) {
     const MAX_VISIBLE_ENTITIES_NO_SEARCH = 50;
     const MAX_SEARCH_RESULTS = 20;
 
+    // Filter out the current entity when selecting same entity type (e.g., parent task on a task)
+    const excludeFilter = (e: CombinedEntity) =>
+      !(getEntityType(e) === currentEntityType && e.id === blockId);
+
     // Get visible entities based on search
     const localResults = term
       ? entitySearch(allEntities, term)
           .slice(0, MAX_SEARCH_RESULTS)
           .map((result) => result.item)
-      : allEntities.slice(0, MAX_VISIBLE_ENTITIES_NO_SEARCH);
+          .filter(excludeFilter)
+      : allEntities
+          .filter(excludeFilter)
+          .slice(0, MAX_VISIBLE_ENTITIES_NO_SEARCH);
 
     // For THREAD: merge local + server results (local first, server appended, deduped)
     if (props.property.specificEntityType === 'THREAD' && term) {
       const localIds = new Set(localResults.map((e) => e.id));
-      const serverResults = serverEmails().filter((e) => !localIds.has(e.id));
+      const serverResults = serverEmails()
+        .filter((e) => !localIds.has(e.id))
+        .filter(excludeFilter);
       return [...localResults, ...serverResults].slice(0, MAX_SEARCH_RESULTS);
     }
 


### PR DESCRIPTION
fix [properties-fe] - filter current entity from entity selection list

Prevents self-references when selecting entity properties (e.g., a task cannot be set as its own parent task).