### PR TITLE
feat(search): sort by updated_at_seconds for unified

### DIFF
--- a/rust/cloud-storage/Cargo.lock
+++ b/rust/cloud-storage/Cargo.lock
@@ -5998,9 +5998,9 @@ dependencies = [
 
 [[package]]
 name = "opensearch_query_builder"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2be0ec85f59a03d8bc068a79c4397f48695d89d6129a3bfec8712b378bc5b73c"
+checksum = "a6fcee6064e63dae6b248bcaea82fd6d6e2b9d934ea199bb8d3ec89f2c3d2d77"
 dependencies = [
  "serde",
  "serde_json",

--- a/rust/cloud-storage/opensearch_client/Cargo.toml
+++ b/rust/cloud-storage/opensearch_client/Cargo.toml
@@ -14,13 +14,13 @@ uuid = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
+models_opensearch = { path = "../models_opensearch" }
 opensearch = { version = "2.3.0" }
-opensearch_query_builder = { version = "0.2.4", default-features = false }
+opensearch_query_builder = { version = "0.2.5", default-features = false }
 serde = { workspace = true }
 serde_json = { workspace = true }
+strum = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 unicode-segmentation = "1.9.0"
-strum = { workspace = true }
-models_opensearch = { path = "../models_opensearch" }
 uuid = { workspace = true }

--- a/rust/cloud-storage/opensearch_client/src/search/unified.rs
+++ b/rust/cloud-storage/opensearch_client/src/search/unified.rs
@@ -459,8 +459,12 @@ fn build_unified_search_request(args: &UnifiedSearchArgs) -> Result<SearchReques
 
     // Build sort
     let sort = vec![
+        SortType::Field(
+            FieldSort::new("updated_at_seconds", SortOrder::Desc)
+                .missing("_last")
+                .unmapped_type("long"),
+        ),
         SortType::ScoreWithOrder(ScoreWithOrderSort::new(SortOrder::Desc)),
-        SortType::Field(FieldSort::new("entity_id", SortOrder::Desc)),
     ];
 
     for sort in sort {

--- a/rust/cloud-storage/opensearch_client/src/search/unified/test.rs
+++ b/rust/cloud-storage/opensearch_client/src/search/unified/test.rs
@@ -398,6 +398,17 @@ fn test_deserialization() -> anyhow::Result<()> {
     Ok(())
 }
 
+fn expected_sort<'a>() -> Vec<SortType<'a>> {
+    vec![
+        SortType::Field(
+            FieldSort::new("updated_at_seconds", SortOrder::Desc)
+                .missing("_last")
+                .unmapped_type("long"),
+        ),
+        SortType::ScoreWithOrder(ScoreWithOrderSort::new(SortOrder::Desc)),
+    ]
+}
+
 #[test]
 fn test_build_unified_search_request_content() -> anyhow::Result<()> {
     let unified_search_args = UnifiedSearchArgs {
@@ -847,14 +858,7 @@ fn test_build_unified_search_request_content() -> anyhow::Result<()> {
         }
       },
       "size": 20,
-      "sort": [
-        {
-          "_score": "desc"
-        },
-        {
-          "entity_id": "desc"
-        }
-      ]
+      "sort": expected_sort().iter().map(|s| s.to_json()).collect::<Vec<_>>(),
     });
 
     assert_eq!(result.to_json(), expected);
@@ -1095,14 +1099,7 @@ fn test_build_unified_search_request_name() -> anyhow::Result<()> {
         }
       },
       "size": 20,
-      "sort": [
-        {
-          "_score": "desc"
-        },
-        {
-          "entity_id": "desc"
-        }
-      ]
+      "sort": expected_sort().iter().map(|s| s.to_json()).collect::<Vec<_>>(),
     });
 
     assert_eq!(result.to_json(), expected);
@@ -1810,14 +1807,7 @@ fn test_build_unified_search_request_name_content() -> anyhow::Result<()> {
         }
       },
       "size": 20,
-      "sort": [
-        {
-          "_score": "desc"
-        },
-        {
-          "entity_id": "desc"
-        }
-      ]
+      "sort": expected_sort().iter().map(|s| s.to_json()).collect::<Vec<_>>(),
     });
 
     assert_eq!(result.to_json(), expected);
@@ -1904,14 +1894,7 @@ fn test_build_unified_search_request_single_index() -> anyhow::Result<()> {
       },
       "from": 20,
       "size": 20,
-      "sort": [
-        {
-          "_score": "desc"
-        },
-        {
-          "entity_id": "desc"
-        }
-      ],
+      "sort": expected_sort().iter().map(|s| s.to_json()).collect::<Vec<_>>(),
       "highlight": {
         "require_field_match": true,
         "fields": {


### PR DESCRIPTION
## Summary
<!--
A good summary consists of a two sentence overview followed by bullet points (or checklist items for WIP).
-->

This PR updates the way we sort our results to use `updated_at_seconds` if not present we default to moving to the end of the results list. This is something we will want to play around with for what good looks like

## Screenshots, GIFs, and Videos
<!--
Include visual representations of your changes, including GIFs/videos. Screencaptures should fully illustrate sample user behavior.
-->
