### PR TITLE
fix: channel active message callout timeout directly after scroll

### DIFF
--- a/js/app/packages/block-channel/component/MessageList/MessageList.tsx
+++ b/js/app/packages/block-channel/component/MessageList/MessageList.tsx
@@ -244,6 +244,9 @@ export function MessageList(props: MessageListProps) {
       virtualHandle()?.scrollToIndex(index, {
         align: 'center',
       });
+      setTimeout(() => {
+        setTargetMessageActive(false);
+      }, TARGET_MESSAGE_ACTIVE_TIME);
     },
     5
   );
@@ -652,10 +655,6 @@ export function MessageList(props: MessageListProps) {
               keepMounted={keepMountedIndices()}
               onScroll={handleScroll}
               onScrollEnd={() => {
-                setTimeout(() => {
-                  setTargetMessageActive(false);
-                }, TARGET_MESSAGE_ACTIVE_TIME);
-
                 if (!initialScrollComplete()) {
                   setInitialScrollComplete(true);
                 }


### PR DESCRIPTION
## Summary
<!--
A good summary consists of a two sentence overview followed by bullet points (or checklist items for WIP).
-->

since onScrollEnd only gets fired if there's an actual scroll that happens and it's tough to know whether the `virtualHandle()?.scrollToIndex` call is a no-op, im just gonna do the easy fix of setting the timeout immediately after the scroll to index call. this might be a little off timing wise but since we're doing instant scroll it shouldnt be that noticeable anyways

## Screenshots, GIFs, and Videos
<!--
Include visual representations of your changes, including GIFs/videos. Screencaptures should fully illustrate sample user behavior.
-->
