### PR TITLE
fix(email-service): Only create index if it doesn't already exist

### DIFF
--- a/rust/cloud-storage/macro_db_client/migrations/20251212204146_email_delete_indices.sql
+++ b/rust/cloud-storage/macro_db_client/migrations/20251212204146_email_delete_indices.sql
@@ -1,13 +1,13 @@
 -- Indices to speed up email link deletion
-CREATE INDEX idx_email_messages_replying_to_id
+CREATE INDEX IF NOT EXISTS idx_email_messages_replying_to_id
     ON public.email_messages (replying_to_id)
     WHERE replying_to_id IS NOT NULL;
 
-CREATE INDEX idx_email_user_history_thread_id
+CREATE INDEX IF NOT EXISTS idx_email_user_history_thread_id
     ON public.email_user_history (thread_id);
 
-CREATE INDEX idx_email_threads_link_id
+CREATE INDEX IF NOT EXISTS idx_email_threads_link_id
     ON public.email_threads (link_id);
 
-CREATE INDEX idx_email_messages_link_id
+CREATE INDEX IF NOT EXISTS idx_email_messages_link_id
     ON public.email_messages (link_id);


### PR DESCRIPTION
## Summary
<!--
A good summary consists of a two sentence overview followed by bullet points (or checklist items for WIP).
-->

Had to create these indexes outside of the transaction that sqlx uses, due to deadlocks in prod. Can only use the `CONCURRENTLY` command when creating an index outside of a transaction, so I had to do it manually. Updating the migration command to use `IF NOT EXISTS` so it will ignore the migration since it has already been done, and we can reach parity with the database migration status once again.

## Screenshots, GIFs, and Videos
<!--
Include visual representations of your changes, including GIFs/videos. Screencaptures should fully illustrate sample user behavior.
-->
