### PR TITLE
fix(opensearch_client): remove un-needed fields from response indices

### DIFF
--- a/rust/cloud-storage/opensearch_client/src/search/chats.rs
+++ b/rust/cloud-storage/opensearch_client/src/search/chats.rs
@@ -26,7 +26,6 @@ pub(crate) struct ChatIndex {
     pub chat_message_id: uuid::Uuid,
     pub user_id: String,
     pub role: String,
-    pub updated_at_seconds: i64,
     pub title: String,
     pub content: String,
 }

--- a/rust/cloud-storage/opensearch_client/src/search/documents.rs
+++ b/rust/cloud-storage/opensearch_client/src/search/documents.rs
@@ -92,7 +92,6 @@ pub(crate) struct DocumentIndex {
     pub content: String,
     pub owner_id: String,
     pub file_type: String,
-    pub updated_at_seconds: i64,
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]

--- a/rust/cloud-storage/opensearch_client/src/search/emails.rs
+++ b/rust/cloud-storage/opensearch_client/src/search/emails.rs
@@ -188,8 +188,6 @@ pub(crate) struct EmailIndex {
     pub link_id: String,
     /// The user id of the email message
     pub user_id: String,
-    /// The updated at time of the email message
-    pub updated_at_seconds: i64,
     /// The subject of the email message
     pub subject: Option<String>,
     /// The sent at time of the email message

--- a/rust/cloud-storage/opensearch_client/src/search/projects.rs
+++ b/rust/cloud-storage/opensearch_client/src/search/projects.rs
@@ -86,8 +86,6 @@ pub struct ProjectIndex {
     pub user_id: String,
     pub parent_project_id: Option<uuid::Uuid>,
     pub project_name: String,
-    pub created_at_seconds: i64,
-    pub updated_at_seconds: i64,
 }
 
 #[derive(Debug, Default)]


### PR DESCRIPTION
## Summary
<!--
A good summary consists of a two sentence overview followed by bullet points (or checklist items for WIP).
-->

This PR removes un-needed fields from the responses of opensearch indices that can cause deserialization errors if not present.

Some items do not have updated_at_seconds for example due to never having updated_at inside of opensearch so they were skipped during the migration scripts.

## Screenshots, GIFs, and Videos
<!--
Include visual representations of your changes, including GIFs/videos. Screencaptures should fully illustrate sample user behavior.
-->
