### PR TITLE
fix(email-service): Declare sfs_id field as optional when fetching attachments in upsert_message

### DIFF
--- a/rust/cloud-storage/email_db_client/.sqlx/query-65fbbdc4a8b2ac4be0283f4297875cb62de647cebc07d42b93e58f35fb34e7bd.json
+++ b/rust/cloud-storage/email_db_client/.sqlx/query-65fbbdc4a8b2ac4be0283f4297875cb62de647cebc07d42b93e58f35fb34e7bd.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        SELECT ea.id, ea.message_id, ea.provider_attachment_id, ea.filename, ea.mime_type, ea.size_bytes, ea.content_id, eas.sfs_id, ea.created_at\n        FROM email_attachments ea LEFT JOIN email_attachments_sfs eas on ea.id = eas.attachment_id\n        WHERE message_id = $1\n        ",
+  "query": "\n        SELECT ea.id, ea.message_id, ea.provider_attachment_id, ea.filename, ea.mime_type, ea.size_bytes, ea.content_id, eas.sfs_id as \"sfs_id?\", ea.created_at\n        FROM email_attachments ea LEFT JOIN email_attachments_sfs eas on ea.id = eas.attachment_id\n        WHERE message_id = $1\n        ",
   "describe": {
     "columns": [
       {
@@ -40,7 +40,7 @@
       },
       {
         "ordinal": 7,
-        "name": "sfs_id",
+        "name": "sfs_id?",
         "type_info": "Uuid"
       },
       {
@@ -66,5 +66,5 @@
       false
     ]
   },
-  "hash": "396f7708decb9786f762606d2e52e42c16c6f9d67848ffd823e25a2ebbb01f42"
+  "hash": "65fbbdc4a8b2ac4be0283f4297875cb62de647cebc07d42b93e58f35fb34e7bd"
 }

--- a/rust/cloud-storage/email_db_client/src/attachments/provider/mod.rs
+++ b/rust/cloud-storage/email_db_client/src/attachments/provider/mod.rs
@@ -28,7 +28,7 @@ pub async fn insert_attachments(
     let existing_attachments = sqlx::query_as!(
         db::attachment::Attachment,
         r#"
-        SELECT ea.id, ea.message_id, ea.provider_attachment_id, ea.filename, ea.mime_type, ea.size_bytes, ea.content_id, eas.sfs_id, ea.created_at
+        SELECT ea.id, ea.message_id, ea.provider_attachment_id, ea.filename, ea.mime_type, ea.size_bytes, ea.content_id, eas.sfs_id as "sfs_id?", ea.created_at
         FROM email_attachments ea LEFT JOIN email_attachments_sfs eas on ea.id = eas.attachment_id
         WHERE message_id = $1
         "#,


### PR DESCRIPTION
## Summary
<!--
A good summary consists of a two sentence overview followed by bullet points (or checklist items for WIP).
-->
Declare sfs_id field as optional when fetching attachments in upsert_message

## Screenshots, GIFs, and Videos
<!--
Include visual representations of your changes, including GIFs/videos. Screencaptures should fully illustrate sample user behavior.
-->
