### PR TITLE
feat(email-service): Enable attachment syncing for all users

### DIFF
--- a/rust/cloud-storage/email_service/src/pubsub/backfill/increment_counters.rs
+++ b/rust/cloud-storage/email_service/src/pubsub/backfill/increment_counters.rs
@@ -125,7 +125,6 @@ async fn handle_attachment_upload(
     link: &Link,
     job_id: Uuid,
 ) -> Result<(), ProcessingError> {
-    // temporarily only enabling for macro emails for testing
     if cfg!(not(feature = "attachment_upload")) {
         return Ok(());
     }
@@ -333,7 +332,6 @@ async fn handle_thread_attachment_upload(
     job_id: Uuid,
     thread_db_id: Uuid,
 ) -> Result<(), ProcessingError> {
-    // temporarily only for macro emails, for testing
     if cfg!(not(feature = "attachment_upload")) {
         return Ok(());
     }

--- a/rust/cloud-storage/email_service/src/pubsub/webhook/operations/upsert_message.rs
+++ b/rust/cloud-storage/email_service/src/pubsub/webhook/operations/upsert_message.rs
@@ -212,7 +212,6 @@ async fn handle_attachment_upload(
     payload: &UpsertMessagePayload,
     message_attachment_count: usize,
 ) -> result::Result<(), ProcessingError> {
-    // temporarily only for macro emails, for testing purposes
     if cfg!(not(feature = "attachment_upload")) || message_attachment_count == 0 {
         return Ok(());
     }


### PR DESCRIPTION
## Summary
<!--
A good summary consists of a two sentence overview followed by bullet points (or checklist items for WIP).
-->
Up until now we only had attachment syncing active for `@macro.com` users, for internal testing. It is now in a place where we can enable it for all users.

User's image/video attachments will automatically be uploaded to SFS so we can display them in messages.

User's pdf, docx, doc, html, and plaintext attachments will be automatically uploaded to DSS as documents.

These operations happen both on backfill and during inbox syncing as new messages come in for the user.

## Screenshots, GIFs, and Videos
<!--
Include visual representations of your changes, including GIFs/videos. Screencaptures should fully illustrate sample user behavior.
-->
