### PR TITLE
fix(email-service): Make email signature optional in /links endpoint

### DIFF
--- a/rust/cloud-storage/email_service/src/api/email/links/list.rs
+++ b/rust/cloud-storage/email_service/src/api/email/links/list.rs
@@ -43,8 +43,9 @@ pub struct ListLinksResponse {
 
 #[derive(serde::Deserialize, Debug, ToSchema)]
 pub struct QueryParams {
-    /// the threshold in seconds to consider a user active
-    pub include_signature: Option<bool>,
+    /// if we should include the user's gmail signature in the response. hits gmail api
+    #[serde(default)]
+    pub include_signature: bool,
 }
 
 /// List all links belonging to the user.
@@ -80,7 +81,7 @@ pub async fn list_links_handler(
                 .await
                 .map_err(ListLinksError::DatabaseError)?;
 
-            let signature = if query_params.include_signature == Some(true) {
+            let signature = if query_params.include_signature {
                 let access_token = fetch_gmail_access_token_from_link(
                     &link,
                     &ctx.redis_client,


### PR DESCRIPTION
## Summary
<!--
A good summary consists of a two sentence overview followed by bullet points (or checklist items for WIP).
-->

Only include gmail signature if query param is set. Most of the time we don't need it, and the call to gmail api to get it is slow. We can't store it in the database as gmail doesn't have a mechanism to notify us of when it changes. So we have to fetch it every time.

## Screenshots, GIFs, and Videos
<!--
Include visual representations of your changes, including GIFs/videos. Screencaptures should fully illustrate sample user behavior.
-->
