### PR TITLE
fix(email-service): Slow `/seen` endpoint

### DIFF
--- a/rust/cloud-storage/email_db_client/src/messages/get.rs
+++ b/rust/cloud-storage/email_db_client/src/messages/get.rs
@@ -258,9 +258,11 @@ pub async fn fetch_messages_with_labels(
     }
 
     let message_ids: Vec<Uuid> = db_messages.iter().map(|m| m.id).collect();
+
     let labels_map = get::fetch_message_labels_in_bulk(conn, &message_ids)
         .await
         .context("Failed to fetch message labels in bulk")?;
+
     let mut processed_messages = Vec::with_capacity(db_messages.len());
     for message in db_messages {
         let labels = labels_map.get(&message.id).cloned().unwrap_or_default();

--- a/rust/cloud-storage/email_db_client/src/messages/update.rs
+++ b/rust/cloud-storage/email_db_client/src/messages/update.rs
@@ -48,7 +48,7 @@ pub async fn update_message_read_status<'t>(
 
 /// Update the read status of multiple messages at once
 /// Returns the count of messages that were successfully updated
-#[tracing::instrument(skip(executor), level = "info")]
+#[tracing::instrument(skip(executor), err)]
 pub async fn update_message_read_status_batch<'e, E>(
     executor: E,
     message_ids: Vec<Uuid>,
@@ -80,14 +80,7 @@ where
         fusionauth_user_id
     )
     .fetch_all(executor)
-    .await
-    .with_context(|| {
-        format!(
-            "Failed to update read status for {} messages for user {}",
-            message_ids.len(),
-            fusionauth_user_id
-        )
-    })?;
+    .await?;
 
     let updated_count = result.len();
 

--- a/rust/cloud-storage/email_db_client/src/threads/update.rs
+++ b/rust/cloud-storage/email_db_client/src/threads/update.rs
@@ -82,7 +82,7 @@ pub async fn update_inbox_visible_status(
     Ok(())
 }
 
-#[tracing::instrument(skip(executor), level = "info")]
+#[tracing::instrument(skip(executor), err)]
 pub async fn update_thread_read_status<'e, E>(
     executor: E,
     thread_id: Uuid,
@@ -107,11 +107,7 @@ where
         link_id,
     )
     .execute(executor)
-    .await
-    .context(format!(
-        "Failed to update read status to {} for thread ID {} with link_id {}",
-        is_read, thread_id, link_id
-    ))?;
+    .await?;
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
<!--
A good summary consists of a two sentence overview followed by bullet points (or checklist items for WIP).
-->

`/seen` endpoint is slow because it hits gmail api to remove the `UNREAD` label on messages in the thread that we are marking as seen. We had [similar issues](https://github.com/macro-inc/macro-api/pull/2248) with the`/archived` endpoint. Making the same fix here, which is calling the gmail-api async after the endpoint returns a response. If the call to gmail API fails, we then rollback the changes we made to the message labels in the database. In my testing this reduces response times from ~400ms to ~100ms when calling from the FE.

## Screenshots, GIFs, and Videos
<!--
Include visual representations of your changes, including GIFs/videos. Screencaptures should fully illustrate sample user behavior.
-->
