### PR TITLE
fix(channel): Reply input mentions menu displaying all users

### DIFF
--- a/js/app/packages/block-channel/component/ReplyInputsPortaler.tsx
+++ b/js/app/packages/block-channel/component/ReplyInputsPortaler.tsx
@@ -9,6 +9,7 @@ import {
 } from '@block-channel/utils/draftMessages';
 import { blockElementSignal } from '@core/signal/blockElement';
 import type { InputAttachment } from '@core/store/cacheChannelInput';
+import { channelParticipantInfo } from '@core/user/util';
 import type { Message } from '@service-comms/generated/models';
 import { createCallback } from '@solid-primitives/rootless';
 import {
@@ -23,7 +24,6 @@ import type { SetStoreFunction } from 'solid-js/store';
 import { Portal } from 'solid-js/web';
 import type { VirtualizerHandle } from 'virtua/solid';
 import { BaseInput } from './BaseInput';
-import { channelParticipantInfo } from '@core/user/util';
 
 export type ReplyInputsPortalerProps = {
   channelId: string;


### PR DESCRIPTION
## Summary
<!--
A good summary consists of a two sentence overview followed by bullet points (or checklist items for WIP).
-->

The mentions menu in the reply input was displaying all contacts instead of just the channel participants. This was caused by not passing in the users to display for the mentions menu to `BaseInput`

## Screenshots, GIFs, and Videos
<!--
Include visual representations of your changes, including GIFs/videos. Screencaptures should fully illustrate sample user behavior.
-->
