### PR TITLE
fix(dss): update UserItemAccess for user who shared item

### DIFF
--- a/rust/cloud-storage/document_storage_service/src/api/channel/update_channel_share_permission.rs
+++ b/rust/cloud-storage/document_storage_service/src/api/channel/update_channel_share_permission.rs
@@ -145,8 +145,11 @@ pub async fn handler(
                     .into_response()
             })?
             .into_iter()
-            .filter(|p| p.user_id != req.user_id.0.as_ref() && p.left_at.is_none())
-            .map(|p| p.user_id)
+            .filter_map(|p| match p.left_at {
+                // If the user left we should not update their user item access
+                Some(_) => None,
+                None => Some(p.user_id)
+            })
             .collect::<Vec<_>>();
 
 


### PR DESCRIPTION
## Summary
<!--
A good summary consists of a two sentence overview followed by bullet points (or checklist items for WIP).
-->

We shouldn't filter out the user who sent the item because they may have shared a public item via a link so it could potentially not be in their user item access.

## Screenshots, GIFs, and Videos
<!--
Include visual representations of your changes, including GIFs/videos. Screencaptures should fully illustrate sample user behavior.
-->
