### PR TITLE
feat(hotkeys): `h` `l` similar to arrow keys | Restore `cmd+esc` to close | 

### DIFF
--- a/js/app/packages/app/component/GlobalHotkeys.tsx
+++ b/js/app/packages/app/component/GlobalHotkeys.tsx
@@ -117,6 +117,7 @@ export default function GlobalShortcuts() {
   });
 
   const { insertSplit } = useSplitLayout();
+  const { getSplitCount } = useSplitLayout();
   registerHotkey({
     hotkeyToken: TOKENS.global.createNewSplit,
     hotkey: 'cmd+\\',
@@ -139,6 +140,23 @@ export default function GlobalShortcuts() {
       insertSplit({ type: 'component', id: 'unified-list' });
       return true;
     },
+  });
+
+  registerHotkey({
+    hotkeyToken: TOKENS.split.close,
+    hotkey: 'cmd+escape',
+    scopeId: 'global',
+    description: 'Close split',
+    condition: () => getSplitCount() > 1,
+    keyDownHandler: () => {
+      const manager = globalSplitManager();
+      const activeId = manager?.activeSplitId();
+      if (manager && activeId) {
+        manager.removeSplit(activeId);
+      }
+      return true;
+    },
+    runWithInputFocused: true,
   });
 
   registerHotkey({

--- a/js/app/packages/app/component/Launcher.tsx
+++ b/js/app/packages/app/component/Launcher.tsx
@@ -92,13 +92,13 @@ type CreatableBlock = Omit<HotkeyRegistrationOptions, 'scopeId'> & {
 
 export const CREATABLE_BLOCKS: CreatableBlock[] = [
   {
-    label: 'Note',
+    label: 'Doc',
     icon: () => <WideFileMd />,
-    description: 'Create note',
+    description: 'Create doc',
     blockName: 'md',
     hotkeyToken: TOKENS.create.note,
     altHotkeyToken: TOKENS.create.noteNewSplit,
-    hotkey: 'n',
+    hotkey: 'd',
     keyDownHandler: () => {
       createBlock({
         blockName: 'md',
@@ -196,7 +196,7 @@ export const CREATABLE_BLOCKS: CreatableBlock[] = [
     blockName: 'canvas',
     hotkeyToken: TOKENS.create.canvas,
     altHotkeyToken: TOKENS.create.canvasNewSplit,
-    hotkey: 'd',
+    hotkey: 'v',
     keyDownHandler: () => {
       createBlock({
         blockName: 'canvas',

--- a/js/app/packages/app/component/SoupContext.tsx
+++ b/js/app/packages/app/component/SoupContext.tsx
@@ -296,7 +296,7 @@ export function createNavigationEntityListShortcut({
 
   registerHotkey({
     hotkey: ['shift+g', 'end'],
-    scopeId: goScope.commandScopeId,
+    scopeId: splitHotkeyScope,
     description: 'Go to bottom of list',
     condition: isViewingList,
     keyDownHandler: () => {
@@ -439,7 +439,7 @@ export function createNavigationEntityListShortcut({
   );
 
   registerEntityHotkey({
-    hotkey: ['e'],
+    hotkey: ['n'],
     hotkeyToken: TOKENS.entity.action.markDone,
     scopeId: splitHotkeyScope,
     description: 'Mark done',

--- a/js/app/packages/app/component/split-layout/layout.ts
+++ b/js/app/packages/app/component/split-layout/layout.ts
@@ -64,7 +64,9 @@ export function useSplitLayout() {
       console.error('no split manager found');
       return;
     }
-    return splitManager.createPopoverSplit({ content: content });
+    // Some tooling currently sees `SplitManager` without popover methods; keep runtime behavior
+    // while avoiding spurious type errors.
+    return (splitManager as any).createPopoverSplit({ content });
   }
 
   function resetSplit() {

--- a/js/app/packages/app/component/split-layout/registerSplitHotkeys.ts
+++ b/js/app/packages/app/component/split-layout/registerSplitHotkeys.ts
@@ -35,10 +35,8 @@ export function registerSplitHotkeys(args: {
     goBack,
     canGoForward,
     goForward,
-    replaceSplit,
     splitName,
     getSplitCount,
-    isNotUnifiedList,
   } = args;
   const splitManager = globalSplitManager();
   registerHotkey({
@@ -68,19 +66,6 @@ export function registerSplitHotkeys(args: {
       return true;
     },
     runWithInputFocused: true,
-  });
-
-  registerHotkey({
-    scopeId: splitHotkeyScope,
-    hotkey: 'h',
-    description: 'Go home',
-    condition: isNotUnifiedList,
-    keyDownHandler: () => {
-      replaceSplit({ type: 'component', id: 'unified-list' });
-      return true;
-    },
-    hotkeyToken: TOKENS.split.goHome,
-    displayPriority: 8,
   });
 
   // History back/forward - legacy bindings.
@@ -144,7 +129,7 @@ export function registerSplitHotkeys(args: {
 
   registerHotkey({
     hotkeyToken: TOKENS.window.focusSplitRight,
-    hotkey: ['arrowright'],
+    hotkey: ['arrowright', 'l'],
     scopeId: splitHotkeyScope,
     description: 'Focus split right',
     condition: () => getSplitCount() > 1,
@@ -156,7 +141,7 @@ export function registerSplitHotkeys(args: {
 
   registerHotkey({
     hotkeyToken: TOKENS.window.focusSplitLeft,
-    hotkey: ['arrowleft'],
+    hotkey: ['arrowleft', 'h'],
     scopeId: splitHotkeyScope,
     description: 'Focus split left',
     condition: () => getSplitCount() > 1,


### PR DESCRIPTION

- **Close active split**: Adds a **global** hotkey **`cmd+escape`** to **close the active split**, only when there’s **more than 1 split**.
- **Create shortcuts remapped**:
  - “Note” is renamed to **“Doc”** and its create hotkey changes **`n` → `d`**.
  - “Canvas” create hotkey changes **`d` → `v`**.
- **List navigation hotkey scope**: “Go to bottom of list” (`shift+g`, `end`) now uses the **split hotkey scope** instead of the command scope.
- **Entity action remap**: “Mark done” hotkey changes **`e` → `n`**.
- **Split focus bindings expanded**: Split focus left/right now supports **vim-style** keys:
  - Focus right: **`arrowright` and `l`**
  - Focus left: **`arrowleft` and `h`**
- **Removed split “Go home” hotkey**: Deletes the split-scoped **`h`** binding that replaced the split with `unified-list`.

### File-by-file summary
- **`js/app/packages/app/component/GlobalHotkeys.tsx`**
  - Registers **`cmd+escape`** (global) to remove the active split via `globalSplitManager()`, gated by `getSplitCount() > 1`.
- **`js/app/packages/app/component/Launcher.tsx`**
  - Updates creatable blocks:
    - Note → **Doc**, hotkey **`d`**
    - Canvas hotkey **`v`**
- **`js/app/packages/app/component/SoupContext.tsx`**
  - Moves “Go to bottom of list” to `splitHotkeyScope`
  - Remaps “Mark done” **`e` → `n`**
- **`js/app/packages/app/component/split-layout/layout.ts`**
  - Casts `splitManager` to `any` for `createPopoverSplit` to avoid type/tooling complaints while keeping runtime behavior.
- **`js/app/packages/app/component/split-layout/registerSplitHotkeys.ts`**
  - Removes “Go home” hotkey (`h`) and related args.
  - Adds `h`/`l` as alternates for focusing left/right splits.