### PR TITLE
chore(ios): console-logs

### DIFF
--- a/js/app/tauri/Cargo.lock
+++ b/js/app/tauri/Cargo.lock
@@ -103,6 +103,7 @@ dependencies = [
  "thiserror 2.0.17",
  "tokio",
  "tracing",
+ "tracing-oslog",
  "tracing-subscriber",
  "url",
  "urlencoding",
@@ -5229,6 +5230,18 @@ dependencies = [
  "log",
  "once_cell",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-oslog"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d76902d2a8d5f9f55a81155c08971734071968c90f2d9bfe645fe700579b2950"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "tracing-core",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/js/app/tauri/src-tauri/Cargo.toml
+++ b/js/app/tauri/src-tauri/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
-name = "app"
-version = "0.1.0"
-description = "A Tauri App"
 authors = ["you"]
-license = ""
-repository = ""
+description = "A Tauri App"
 edition = "2024"
+license = ""
+name = "app"
+repository = ""
+version = "0.1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [lib]
+crate-type = ["cdylib", "rlib", "staticlib"]
 name = "app_lib"
-crate-type = ["staticlib", "cdylib", "rlib"]
 
 [build-dependencies]
 tauri-build = { version = "2.3.1", features = [] }
@@ -20,34 +20,38 @@ tauri-build = { version = "2.3.1", features = [] }
 default = []
 
 [dependencies]
-serde_json = "1.0"
-serde = { version = "1.0", features = ["derive"] }
 log = "0.4"
 logger = { path = "../logger" }
 rootcause = { workspace = true }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+tracing-oslog = { version = "0.3" }
 
-tauri = { workspace = true , features = [] }
-tauri-plugin-log = { version = "2", features = ["tracing"] }
-tauri-plugin-http = { git = "https://github.com/seanaye/plugins-workspace", branch = "seanaye/feat/websocket-cookies" }
 nom = "8.0.0"
-thiserror = "2.0.14"
-tauri-plugin-opener = "2"
-url = { workspace = true }
-tokio = { version = "1.47.1", features = ["full"] }
-tauri-plugin-deep-link = "2"
+reqwest = { version = "0.12.23", default-features = false, features = [
+  "cookies",
+  "rustls-tls",
+] }
 serde_qs = "0.15.0"
-urlencoding = "2.1.3"
-tauri-plugin-websocket = { git = "https://github.com/seanaye/plugins-workspace", branch = "seanaye/feat/websocket-cookies" }
-reqwest = { version = "0.12.23", default-features = false, features = ["cookies", "rustls-tls"] }
+tauri = { workspace = true, features = [] }
+tauri-plugin-deep-link = "2"
+tauri-plugin-http = { git = "https://github.com/seanaye/plugins-workspace", branch = "seanaye/feat/websocket-cookies" }
+tauri-plugin-log = { version = "2", features = ["tracing"] }
+tauri-plugin-opener = "2"
 tauri-plugin-safe-area-insets = "0.1.0"
+tauri-plugin-websocket = { git = "https://github.com/seanaye/plugins-workspace", branch = "seanaye/feat/websocket-cookies" }
+thiserror = "2.0.14"
+tokio = { version = "1.47.1", features = ["full"] }
 tracing = { workspace = true }
 tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
+url = { workspace = true }
+urlencoding = "2.1.3"
 # system notifications for when the app is open
 tauri-plugin-notification = "2"
 # push notifications for mobile (when app is closed)
+navigation_plugin = { path = "../navigation_plugin" }
 tauri-plugin-notifications = { git = "https://github.com/seanaye/tauri-plugins", branch = "seanaye+mnlphlp/add/android-notifications" }
 tauri-plugin-os = "2"
-navigation_plugin = { path = "../navigation_plugin" }
 
 
 [target."cfg(any(target_os = \"macos\", windows, target_os = \"linux\"))".dependencies]

--- a/js/app/tauri/src-tauri/src/lib.rs
+++ b/js/app/tauri/src-tauri/src/lib.rs
@@ -9,6 +9,8 @@ use tauri::http::{HeaderMap, HeaderValue};
 use tauri::{AppHandle, Emitter};
 use tauri::{Manager, Runtime};
 use tauri_plugin_deep_link::{DeepLinkExt, OpenUrlEvent};
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
 use url::Url;
 
 /// This module provides debuging utilities and should not be compiled in prodiction builds
@@ -30,23 +32,31 @@ static ALLOWED_DOMAINS: &[&str] = &[
 pub fn run() {
     use tracing_subscriber::EnvFilter;
 
-    tracing_subscriber::fmt()
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+        if cfg!(debug_assertions) {
+            "debug,tungstenite=info,tokio_tungstenite=info,reqwest=info,hyper=info,h2=info".into()
+        } else {
+            "info,tungstenite=info,tokio_tungstenite=info,reqwest=info".into()
+        }
+    });
+
+    let fmt_layer = tracing_subscriber::fmt::layer()
         .with_file(true)
         .with_target(false)
         .with_writer(std::io::stderr)
         .with_line_number(true)
-        .pretty()
-        .with_env_filter(EnvFilter::try_from_default_env().unwrap_or_else(|_| {
-            // Set default log levels
-            if cfg!(debug_assertions) {
-                // Enable debug logs for websocket and HTTP crates in debug mode
-                "debug,tungstenite=info,tokio_tungstenite=info,reqwest=info,hyper=info,h2=info"
-                    .into()
-            } else {
-                "info,tungstenite=info,tokio_tungstenite=info,reqwest=info".into()
-            }
-        }))
-        .init();
+        .pretty();
+
+    let registry = tracing_subscriber::registry().with(filter).with(fmt_layer);
+
+    #[cfg(target_os = "ios")]
+    let registry = registry.with(tracing_oslog::OsLogger::new(
+        "com.macro.app.prod",
+        "default",
+    ));
+
+    registry.init();
+
     let mut builder = tauri::Builder::default();
 
     #[cfg(desktop)]


### PR DESCRIPTION
## Summary
<!--
A good summary consists of a two sentence overview followed by bullet points (or checklist items for WIP).
-->

This PR adds the os_log tracing layer to the tracing subscriber. Allowing the rust logs to appear in the Console.app on MacOS when running from testflight install

This is useful for diagnosing the cause of periodic loss of auth state

## Screenshots, GIFs, and Videos
<!--
Include visual representations of your changes, including GIFs/videos. Screencaptures should fully illustrate sample user behavior.
-->
