### PR TITLE
unified-list: improve jk experience keeping scroll gap at most of entity minimum height

### DIFF
--- a/js/app/packages/app/component/EntityModal/MoveToProjectView.tsx
+++ b/js/app/packages/app/component/EntityModal/MoveToProjectView.tsx
@@ -1,4 +1,3 @@
-import { scrollToKeepGap } from '@app/component/SoupContext';
 import { BozzyBracket } from '@core/component/BozzyBracket';
 import {
   CustomEntityIcon,
@@ -8,6 +7,7 @@ import {
 import { ExplorerSpacer } from '@core/component/FileList/ExplorerSpacer';
 import { registerHotkey, useHotkeyDOMScope } from '@core/hotkey/hotkeys';
 import Fragment from '@core/util/Fragment';
+import { scrollToKeepGap } from '@core/util/scrollToKeepGap';
 import CaretRight from '@icon/regular/caret-right.svg';
 import ArrowRight from '@phosphor-icons/core/regular/arrow-right.svg?component-solid';
 import type { Project } from '@service-storage/generated/schemas';

--- a/js/app/packages/app/component/SoupContext.tsx
+++ b/js/app/packages/app/component/SoupContext.tsx
@@ -13,6 +13,7 @@ import { isInteractiveElement } from '@core/util/isInteractiveElement';
 import { filterMap } from '@core/util/list';
 import { isErr } from '@core/util/maybeResult';
 import { getScrollParent } from '@core/util/scrollParent';
+import { scrollToKeepGap } from '@core/util/scrollToKeepGap';
 import { waitForFrames } from '@core/util/sleep';
 import { type EntityData, isTaskEntity } from '@macro-entity';
 import { entityHasUnreadNotifications } from '@notifications';
@@ -45,6 +46,7 @@ import {
   type SetStoreFunction,
   type Store,
 } from 'solid-js/store';
+import { ENTITY_HEIGHT } from '../../macro-entity/src/components/EntityWithEverything';
 import { useUserId } from '../../macro-entity/src/queries/auth';
 import { createBulkCopyDssEntityMutation } from '../../macro-entity/src/queries/dss';
 import { playSound } from '../util/sound';
@@ -964,6 +966,7 @@ export function createNavigationEntityListShortcut({
           container: scrollParent,
           target: newSelectedEntityEl.parentElement!,
           align: axis === 'start' ? 'top' : 'bottom',
+          gap: ENTITY_HEIGHT,
         });
       }
 
@@ -1460,61 +1463,6 @@ const useAllViews = ({
 
   return [viewsData, setViewsData] as const;
 };
-
-type AlignMode = 'top' | 'bottom';
-
-/**
- * Conditionally scrolls the container to align the target element
- * near either the container's top or bottom based on the align parameter.
- *
- * @param container - The scrollable container
- * @param target - The element to bring into view
- * @param threshold - Distance from the viewport edge within which to trigger scroll
- * @param gap - Desired distance from the aligned edge after scrolling
- * @param align - "top" or "bottom" (default: "bottom")
- */
-export function scrollToKeepGap({
-  container,
-  target,
-  threshold,
-  gap,
-  align = 'bottom',
-}: {
-  container: Element;
-  target: Element;
-  threshold?: number; // px distance from edge to trigger scroll
-  gap?: number; // px distance from edge after scrolling
-  align?: AlignMode; // "top" | "bottom"
-}) {
-  const containerRect = container.getBoundingClientRect();
-  const targetRect = target.getBoundingClientRect();
-
-  // Relative positions (in container scroll coordinates)
-  const targetTop = targetRect.top - containerRect.top + container.scrollTop;
-  const targetBottom =
-    targetRect.bottom - containerRect.top + container.scrollTop;
-
-  gap = targetRect.height ?? 50;
-  threshold = targetRect.height ?? 50;
-
-  if (align === 'bottom') {
-    const containerBottom = container.scrollTop + container.clientHeight;
-    const distanceToBottom = containerBottom - targetBottom;
-
-    if (distanceToBottom <= threshold) {
-      const newScrollTop = targetBottom - container.clientHeight + gap;
-      container.scrollTo({ top: newScrollTop, behavior: 'auto' });
-    }
-  } else {
-    // align = "top"
-    const distanceToTop = targetTop - container.scrollTop;
-
-    if (distanceToTop <= threshold) {
-      const newScrollTop = targetTop - gap;
-      container.scrollTo({ top: newScrollTop, behavior: 'auto' });
-    }
-  }
-}
 
 let globalKeyboardEvent: KeyboardEvent | undefined;
 

--- a/js/app/packages/app/component/UnifiedListView.tsx
+++ b/js/app/packages/app/component/UnifiedListView.tsx
@@ -111,7 +111,10 @@ import {
   type SetStoreFunction,
   unwrap,
 } from 'solid-js/store';
-import { EntityWithEverything } from '../../macro-entity/src/components/EntityWithEverything';
+import {
+  ENTITY_HEIGHT,
+  EntityWithEverything,
+} from '../../macro-entity/src/components/EntityWithEverything';
 import {
   resetCommandCategoryIndex,
   searchCategories,
@@ -1460,6 +1463,7 @@ export function UnifiedListView(props: UnifiedListViewProps) {
             viewId={view()?.id}
             searchText={searchText()}
             hasRefinementsFromBase={isViewConfigChanged()}
+            entityMinHeight={ENTITY_HEIGHT}
           >
             {(innerProps) => {
               const displayDoneButton = () => {

--- a/js/app/packages/app/component/bulk-edit-entity/BulkMoveToProjectView.tsx
+++ b/js/app/packages/app/component/bulk-edit-entity/BulkMoveToProjectView.tsx
@@ -1,11 +1,11 @@
 import { EntityIcon } from '@core/component/EntityIcon';
+import { scrollToKeepGap } from '@core/util/scrollToKeepGap';
 import type { Project } from '@service-storage/generated/schemas';
 import { useProjects } from '@service-storage/projects';
 import { registerHotkey, useHotkeyDOMScope } from 'core/hotkey/hotkeys';
 import { createMemo, createSignal, For, onMount, Show } from 'solid-js';
 import { createBulkMoveToProjectDssEntityMutation } from '../../../macro-entity/src/queries/dss';
 import type { EntityData } from '../../../macro-entity/src/types/entity';
-import { scrollToKeepGap } from '../SoupContext';
 import {
   BulkEditEntityModalActionFooter,
   BulkEditEntityModalTitle,

--- a/js/app/packages/core/util/scrollToKeepGap.ts
+++ b/js/app/packages/core/util/scrollToKeepGap.ts
@@ -1,0 +1,54 @@
+type AlignMode = 'top' | 'bottom';
+
+/**
+ * Conditionally scrolls the container to align the target element
+ * near either the container's top or bottom based on the align parameter.
+ *
+ * @param container - The scrollable container
+ * @param target - The element to bring into view
+ * @param threshold - Distance from the viewport edge within which to trigger scroll
+ * @param gap - Desired distance from the aligned edge after scrolling
+ * @param align - "top" or "bottom" (default: "bottom")
+ */
+export function scrollToKeepGap({
+  container,
+  target,
+  threshold,
+  gap,
+  align = 'bottom',
+}: {
+  container: Element;
+  target: Element;
+  threshold?: number; // px distance from edge to trigger scroll
+  gap?: number; // px distance from edge after scrolling
+  align?: AlignMode; // "top" | "bottom"
+}) {
+  const containerRect = container.getBoundingClientRect();
+  const targetRect = target.getBoundingClientRect();
+
+  // Relative positions (in container scroll coordinates)
+  const targetTop = targetRect.top - containerRect.top + container.scrollTop;
+  const targetBottom =
+    targetRect.bottom - containerRect.top + container.scrollTop;
+
+  gap = gap ?? targetRect.height ?? 50;
+  threshold = threshold ?? targetRect.height ?? 50;
+
+  if (align === 'bottom') {
+    const containerHeight = containerRect.height;
+    const containerBottom = container.scrollTop + containerHeight;
+    const distanceToBottom = containerBottom - targetBottom;
+
+    if (distanceToBottom <= threshold) {
+      const newScrollTop = targetBottom - containerHeight + gap;
+      container.scrollTo({ top: newScrollTop, behavior: 'auto' });
+    }
+  } else {
+    const distanceToTop = targetTop - container.scrollTop;
+
+    if (distanceToTop <= threshold) {
+      const newScrollTop = targetTop - gap;
+      container.scrollTo({ top: newScrollTop, behavior: 'auto' });
+    }
+  }
+}

--- a/js/app/packages/macro-entity/src/components/EntityWithEverything.tsx
+++ b/js/app/packages/macro-entity/src/components/EntityWithEverything.tsx
@@ -49,6 +49,8 @@ import type {
 import type { EntityClickEvent, EntityClickHandler } from './Entity';
 import { PropertyPills } from './PropertyPills';
 
+export const ENTITY_HEIGHT = 40;
+
 function UnreadIndicator(props: { active?: boolean }) {
   return (
     <div class="flex size-4 items-center justify-center">
@@ -808,6 +810,9 @@ export function EntityWithEverything(
       use:droppable
       data-checked={props.checked}
       class="everything-entity relative group/entity hover:bg-hover/30"
+      style={{
+        'min-height': `${ENTITY_HEIGHT}px`,
+      }}
       classList={{
         'outline outline-accent/20 outline-offset-[-1px]':
           !isTouchDevice && props.selected && !props.checked,

--- a/js/app/packages/macro-entity/src/components/UnifiedInfiniteList.tsx
+++ b/js/app/packages/macro-entity/src/components/UnifiedInfiniteList.tsx
@@ -409,15 +409,16 @@ export function createUnifiedInfiniteList<T extends EntityData>({
     hasRefinementsFromBase?: boolean;
     viewId?: ViewId;
     searchText?: string;
+    entityMinHeight?: number;
   }) => {
     const [scrollParentRef, setScrollParentRef] =
       createSignal<HTMLDivElement>();
 
     // Estimate items per viewport and derive overscan and page size
-    // Keep a conservative default item size for estimation; virtua will auto-measure precisely.
-    const ENTITY_HEIGHT = 40;
+    // Keep a conservative default item size for estimation;
+    const entityHeight = props.entityMinHeight ?? 40;
     const viewportItemCount = createMemo(() =>
-      Math.max(1, Math.ceil(containerHeight() / ENTITY_HEIGHT))
+      Math.max(1, Math.ceil(containerHeight() / entityHeight))
     );
     const computedOverscan = createMemo(() =>
       Math.max(6, Math.ceil(viewportItemCount() * 0.5))
@@ -426,7 +427,7 @@ export function createUnifiedInfiniteList<T extends EntityData>({
       get count() {
         return sortedEntitiesStore.length;
       },
-      estimateSize: () => ENTITY_HEIGHT,
+      estimateSize: () => entityHeight,
       getScrollElement: () => scrollParentRef() as Element,
       overscan: computedOverscan(),
     });


### PR DESCRIPTION
When navigating via jk, the gap spacing between selected entity and viewport is based on entity height. The problem is when selected entity has a larger height then default, then the gap spacing is larger as well. By setting the gap spacing to default entity height, selected entity visually stays in the same position.

before:


https://github.com/user-attachments/assets/fb1a28dd-783b-43fc-86a2-2798bcd1ea66



after:


https://github.com/user-attachments/assets/10b1478d-5bc1-4ba9-8337-79c269011ab3


