### PR TITLE
fix(email): Send email w/o marking as done & button UI

### DIFF
--- a/js/app/packages/block-email/component/BaseInput.tsx
+++ b/js/app/packages/block-email/component/BaseInput.tsx
@@ -902,7 +902,7 @@ export function BaseInput(props: {
           <div class="flex flex-row items-center">
             <button
               disabled={isPendingUpload() || sendMutation.isPending}
-              onClick={sendEmail}
+              onClick={() => sendEmail()}
               class="text-ink-muted hover:scale-115 transition ease-in-out flex flex-col justify-center items-center size-6 rounded-full"
             >
               <Show


### PR DESCRIPTION
## Summary
<!--
A good summary consists of a two sentence overview followed by bullet points (or checklist items for WIP).
-->
- Updates the UI of the send button for email threads to match that of channels
- Removes marking email thread as done after sending reply as default
- Swaps keybinds for sending email and marking as done and just sending the email
- Removes dropdown

## Screenshots, GIFs, and Videos
<!--
Include visual representations of your changes, including GIFs/videos. Screencaptures should fully illustrate sample user behavior.
-->
<img width="1198" height="1094" alt="Screenshot 2025-12-23 at 2 42 12 PM" src="https://github.com/user-attachments/assets/3b2f5a4f-9c24-46e9-9ca0-7727b43e581d" />

