### PR TITLE
fix: sort channel first iff name match

### DIFF
--- a/js/app/packages/macro-entity/src/components/UnifiedInfiniteList.tsx
+++ b/js/app/packages/macro-entity/src/components/UnifiedInfiniteList.tsx
@@ -159,9 +159,11 @@ const deduplicateEntities = <T extends EntityData>(entities: T[]): T[] => {
  * Sorts entities for search mode
  */
 const sortEntitiesForSearch = <T extends EntityData>(a: T, b: T): number => {
-  const channelsFirst = (a: WithSearch<T>, b: WithSearch<T>) => {
-    if (a.type === 'channel' && b.type !== 'channel') return -1;
-    if (a.type !== 'channel' && b.type === 'channel') return 1;
+  const channelsWithNameMatchesFirst = (a: WithSearch<T>, b: WithSearch<T>) => {
+    if (a.type === 'channel' && b.type !== 'channel' && a.search.nameHighlight)
+      return -1;
+    if (a.type !== 'channel' && b.type === 'channel' && b.search.nameHighlight)
+      return 1;
     return 0;
   };
 
@@ -172,7 +174,7 @@ const sortEntitiesForSearch = <T extends EntityData>(a: T, b: T): number => {
   };
 
   if (isSearchEntity(a) && isSearchEntity(b)) {
-    return channelsFirst(a, b) || localFirst(a, b);
+    return channelsWithNameMatchesFirst(a, b) || localFirst(a, b);
   }
 
   return 0;


### PR DESCRIPTION
## Summary
<!--
A good summary consists of a two sentence overview followed by bullet points (or checklist items for WIP).
-->

note that battlefield/hang channels are on the bottom whereas channels with teo in name are at the top

## Screenshots, GIFs, and Videos
<!--
Include visual representations of your changes, including GIFs/videos. Screencaptures should fully illustrate sample user behavior.
-->

<img width="1235" height="1242" alt="CleanShot 2026-01-05 at 13 36 51" src="https://github.com/user-attachments/assets/b55a7c15-9751-4204-a02e-a885eaf86cb2" />

