### PR TITLE
fix: missing uuid feature flag schemars

### DIFF
--- a/rust/cloud-storage/Cargo.toml
+++ b/rust/cloud-storage/Cargo.toml
@@ -170,7 +170,7 @@ redis = "0.29.0"
 regex = "1.11.1"
 reqwest = { version = "0.12.12", features = ["json"] }
 reqwest-middleware = { git = "https://github.com/seanaye/reqwest-middleware" }
-schemars = { version = "1.0.4", features = ["chrono04"] }
+schemars = { version = "1.0.4", features = ["chrono04", "uuid1"] }
 serde = { version = "1.0.214", features = ["derive"] }
 serde_dynamo = { version = "4", features = ["aws-sdk-dynamodb+1"] }
 serde_json = { version = "1.0.132" }


### PR DESCRIPTION
There was some strange workspace dependency resolution going on. When blake and I ran `cargo b` or `cargo c` in `models_search` or `document_storage_service` it would fail due to `JsonSchmea not being implemented for uuid`.

I assume that whatever crates consume `models_search` package have some dependency that adds uuid schemars support. Harmless and safer
to just add feature to workspace.
