### PR TITLE
fix(channel): List is reversed for a small number of messages

### DIFF
--- a/js/app/patches/virtua@0.48.1.patch
+++ b/js/app/patches/virtua@0.48.1.patch
@@ -7,6 +7,9 @@ index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2
 diff --git a/node_modules/virtua/.bun-tag-69ffcae45e968edb b/.bun-tag-69ffcae45e968edb
 new file mode 100644
 index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
+diff --git a/node_modules/virtua/.bun-tag-a52dba5b35f86f0d b/.bun-tag-a52dba5b35f86f0d
+new file mode 100644
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
 diff --git a/node_modules/virtua/.bun-tag-b5e5cc1416c6ecd6 b/.bun-tag-b5e5cc1416c6ecd6
 new file mode 100644
 index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
@@ -17,10 +20,19 @@ diff --git a/node_modules/virtua/.bun-tag-eeedd702ea82f0a5 b/.bun-tag-eeedd702ea
 new file mode 100644
 index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
 diff --git a/lib/solid/index.jsx b/lib/solid/index.jsx
-index 84788e713100b0e5a746bae3411a789002b42b8d..032896f69f7806c829bbbcf2e0c762b9868a5449 100644
+index 84788e713100b0e5a746bae3411a789002b42b8d..7d8782fbc046fa4218482f4b052700558cee78da 100644
 --- a/lib/solid/index.jsx
 +++ b/lib/solid/index.jsx
-@@ -819,9 +819,9 @@ const createScroller = (store, isHorizontal) => {
+@@ -809,7 +809,7 @@ const createScroller = (store, isHorizontal) => {
+     return {
+         $observe(viewport) {
+             viewportElement = viewport;
+-            const clean = store.$subscribe(UPDATE_SIZE_EVENT, () => {
++             store.$subscribe(UPDATE_SIZE_EVENT, () => {
+                 const viewportSize = store.$getViewportSize();
+                 if (viewportSize) {
+                     const prev = viewport[scrollOffsetKey];
+@@ -819,12 +819,11 @@ const createScroller = (store, isHorizontal) => {
                      // Set larger value than the viewportSize to force overflow. And the value must take subpixels into account.
                      viewportSize + 9}px`;
                      viewport.appendChild(dummy);
@@ -31,8 +43,11 @@ index 84788e713100b0e5a746bae3411a789002b42b8d..032896f69f7806c829bbbcf2e0c762b9
 +                    isNegative = viewport[scrollOffsetKey] < 0;
                      viewport.removeChild(dummy);
                      viewport[scrollOffsetKey] = prev;
-                     clean();
-@@ -1069,7 +1069,7 @@ const createResizeObserver = (cb) => {
+-                    clean();
+                 }
+             });
+             scrollObserver = createScrollObserver(store, viewport, isHorizontal, () => normalizeScrollOffset(viewport[scrollOffsetKey], isNegative), (jump, shift, isMomentumScrolling) => {
+@@ -1069,7 +1068,7 @@ const createResizeObserver = (cb) => {
              // https://www.w3.org/TR/resize-observer/#intro
              (ro ||
                  // https://bugs.chromium.org/p/chromium/issues/detail?id=1491739


### PR DESCRIPTION
## Summary
<!--
A good summary consists of a two sentence overview followed by bullet points (or checklist items for WIP).
-->
Adds another patch to `virtua` to fix an issue with the calculation for the internal `isNegative` property which determines whether the list is reversed or not. The fix was to remove the eager clean up call for the subscription to the `UPDATE_SIZE_EVENT` event because the viewport size was being reported incorrectly due to the fact that the viewport could potentially resize after the `isNegative` calculation was done and thus result in the wrong value being calculated.

## Screenshots, GIFs, and Videos
<!--
Include visual representations of your changes, including GIFs/videos. Screencaptures should fully illustrate sample user behavior.
-->
