### PR TITLE
fix(channel): List is reversed for a small number of messages

### DIFF
--- a/js/app/packages/block-channel/component/MessageList/MessageList.tsx
+++ b/js/app/packages/block-channel/component/MessageList/MessageList.tsx
@@ -749,7 +749,7 @@ function MessageListImpl(props: MessageListProps) {
               }}
               style={{
                 'max-height': `${listHeight()}px`,
-                height: 'fit-content',
+                height: '100%',
                 contain: 'none',
                 'overflow-x': 'hidden',
                 'overflow-y': 'scroll',


### PR DESCRIPTION
## Summary
<!--
A good summary consists of a two sentence overview followed by bullet points (or checklist items for WIP).
-->
Changes the `height` of the `VList` to be 100% so that viewport size and `scrollTop` is correctly calculated by `virtua`. Adds `margin-bottom: auto` to the internal div child of `VList` so that the content still starts from the top, otherwise because of `flex-direction: column-reverse` the content would start from the bottom of the viewport.

The bug was caused by `virtua` calculating whether the list is reversed or not incorrectly. The closed PR #787 contains another solution to the bug by patching `virtua` to solve the incorrect measurement
## Screenshots, GIFs, and Videos
<!--
Include visual representations of your changes, including GIFs/videos. Screencaptures should fully illustrate sample user behavior.
-->
