### PR TITLE
fix(dcs): attachments breaking due to serialization issue

### DIFF
--- a/rust/cloud-storage/document_cognition_service/src/api/ws/chat_message/ai_request.rs
+++ b/rust/cloud-storage/document_cognition_service/src/api/ws/chat_message/ai_request.rs
@@ -10,7 +10,7 @@ use anyhow::{Context, Result};
 use std::sync::Arc;
 
 // fetch documents then build request
-#[tracing::instrument(skip(ctx, chat, incoming_message), err)]
+#[tracing::instrument(skip(ctx, chat, incoming_message, static_system_prompt, jwt), err)]
 pub async fn build_chat_completion_request(
     ctx: Arc<ApiContext>,
     chat: &ChatResponse,

--- a/rust/cloud-storage/model/src/document/basic.rs
+++ b/rust/cloud-storage/model/src/document/basic.rs
@@ -1,8 +1,7 @@
 use std::str::FromStr;
 
-use crate::document::FileTypeExt;
-
 use super::file_type::FileType;
+use crate::document::FileTypeExt;
 use chrono::serde::ts_seconds_option;
 use macro_user_id::user_id::MacroUserIdStr;
 use utoipa::ToSchema;
@@ -119,7 +118,7 @@ pub struct DocumentBasic {
     pub document_family_id: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub project_id: Option<String>,
-    #[serde(with = "ts_seconds_option", skip_serializing_if = "Option::is_none")]
+    #[serde(with = "ts_seconds_option")]
     #[schema(value_type = i64, nullable=true)]
     pub deleted_at: Option<chrono::DateTime<chrono::Utc>>,
 }

--- a/rust/cloud-storage/model/src/document/mod.rs
+++ b/rust/cloud-storage/model/src/document/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(test)]
+mod test;
 use chrono::serde::ts_seconds_option;
 pub mod list;
 pub mod response;

--- a/rust/cloud-storage/model/src/document/test.rs
+++ b/rust/cloud-storage/model/src/document/test.rs
@@ -1,0 +1,74 @@
+use super::basic::DocumentBasic;
+use macro_user_id::user_id::MacroUserIdStr;
+
+#[test]
+fn test_document_basic_serde_roundtrip() {
+    let original = DocumentBasic {
+        document_id: "doc-123".to_string(),
+        document_name: "Test Document".to_string(),
+        owner: MacroUserIdStr::parse_from_str("macro|test@example.com").unwrap(),
+        file_type: Some("pdf".to_string()),
+        branched_from_id: Some("parent-doc-456".to_string()),
+        branched_from_version_id: Some(42),
+        document_family_id: Some(100),
+        project_id: Some("project-789".to_string()),
+        deleted_at: None,
+    };
+
+    let serialized = serde_json::to_string(&original).expect("Failed to serialize DocumentBasic");
+    let deserialized: DocumentBasic =
+        serde_json::from_str(&serialized).expect("Failed to deserialize DocumentBasic");
+
+    assert_eq!(original, deserialized);
+}
+
+#[test]
+fn test_document_basic_serde_minimal() {
+    let original = DocumentBasic {
+        document_id: "doc-minimal".to_string(),
+        document_name: "Minimal Doc".to_string(),
+        owner: MacroUserIdStr::parse_from_str("macro|user@test.com").unwrap(),
+        file_type: None,
+        branched_from_id: None,
+        branched_from_version_id: None,
+        document_family_id: None,
+        project_id: None,
+        deleted_at: None,
+    };
+
+    let serialized = serde_json::to_string(&original).expect("Failed to serialize DocumentBasic");
+    let deserialized: DocumentBasic =
+        serde_json::from_str(&serialized).expect("Failed to deserialize DocumentBasic");
+
+    assert_eq!(original, deserialized);
+}
+
+#[test]
+fn test_document_basic_serde_with_deleted_at() {
+    let deleted_time = chrono::Utc::now();
+    let original = DocumentBasic {
+        document_id: "doc-deleted".to_string(),
+        document_name: "Deleted Doc".to_string(),
+        owner: MacroUserIdStr::parse_from_str("macro|deleted@test.com").unwrap(),
+        file_type: Some("docx".to_string()),
+        branched_from_id: None,
+        branched_from_version_id: None,
+        document_family_id: None,
+        project_id: None,
+        deleted_at: Some(deleted_time),
+    };
+
+    let serialized = serde_json::to_string(&original).expect("Failed to serialize DocumentBasic");
+    let deserialized: DocumentBasic =
+        serde_json::from_str(&serialized).expect("Failed to deserialize DocumentBasic");
+
+    assert_eq!(original.document_id, deserialized.document_id);
+    assert_eq!(original.document_name, deserialized.document_name);
+    assert_eq!(original.owner, deserialized.owner);
+    assert_eq!(original.file_type, deserialized.file_type);
+    // deleted_at uses ts_seconds so subsecond precision is lost
+    assert_eq!(
+        original.deleted_at.map(|dt| dt.timestamp()),
+        deserialized.deleted_at.map(|dt| dt.timestamp())
+    );
+}


### PR DESCRIPTION
- Add tests for round trip serializing on `BasicDocument`
- Remove `skip_serializing_if=Option::is_none` from `BasicDocument`
- Improve logging

