### PR TITLE
fix(email): Email draft not displaying when moving between soup and email

### DIFF
--- a/js/app/packages/block-email/component/BaseInput.tsx
+++ b/js/app/packages/block-email/component/BaseInput.tsx
@@ -33,8 +33,6 @@ import {
   type DocumentMentionInfo,
 } from '@lexical-core';
 import { logger } from '@observability';
-import { queryClient } from '@queries/client';
-import { emailKeys } from '@queries/email/keys';
 import { useEmailLinksQuery } from '@queries/email/link';
 import { useSendMessageMutation } from '@queries/email/thread';
 import type {


### PR DESCRIPTION
## Summary
<!--
A good summary consists of a two sentence overview followed by bullet points (or checklist items for WIP).
-->

When drafts were saved or deleted, the email thread messages were not updated so when you came back, it would display stale data. This PR updates it to refetch the thread messages after saving or deleting a draft occurs

## Screenshots, GIFs, and Videos
<!--
Include visual representations of your changes, including GIFs/videos. Screencaptures should fully illustrate sample user behavior.
-->
