### PR TITLE
fix(notifications): use correct name for dm name

### DIFF
--- a/rust/cloud-storage/notification_service/src/notification/send/push/generate.rs
+++ b/rust/cloud-storage/notification_service/src/notification/send/push/generate.rs
@@ -210,7 +210,7 @@ impl BuildNotification for ChannelMessageSendMetadata {
                 alert: Some(sns_client::Alert::Dictionary(sns_client::AlertDictionary {
                     title: Some(match self.common.channel_type {
                         model_notifications::ChannelType::DirectMessage => {
-                            self.common.channel_name.to_string()
+                            self.sender.email_part().local_part().to_string()
                         }
                         _ => format!(
                             "{} <{}>",
@@ -234,14 +234,20 @@ impl BuildNotification for ChannelMentionMetadata {
         &self,
         ctx: Self::Ctx<'_>,
     ) -> Result<APNSPushNotification<()>, NotificationErr> {
+        let title = match self.common.channel_type {
+            model_notifications::ChannelType::DirectMessage => {
+                format!("{} mentioned you", ctx.email_part().local_part())
+            }
+            _ => format!(
+                "{} mentioned you in #{}",
+                ctx.email_part().local_part(),
+                &self.common.channel_name
+            ),
+        };
         Ok(APNSPushNotification {
             aps: Aps {
                 alert: Some(sns_client::Alert::Dictionary(sns_client::AlertDictionary {
-                    title: Some(format!(
-                        "{} mentioned you in #{}",
-                        ctx.email_part().as_ref(),
-                        &self.common.channel_name
-                    )),
+                    title: Some(title),
                     body: Some(T::format_xml_text(ParsedXmlText::parse(&self.message_content)?).0),
                     ..Default::default()
                 })),


### PR DESCRIPTION
`resolve_channel_name` returns a dynamic channel name for the SENDER not the RECIPIENT of the notification.

Because of this Direct Message notifications show up as from the person who receives it not he who sent it.
The name of my DM with Hutch for hutch is Teo. Because for him he is chatting with me. So it sends `channel_name` Teo.

Technically this is also broken for private channels without names (dyanmic name from participants). And is filtering out the name of the `sender` but we can clean that one up later.
