### PR TITLE
fix(channel): channel freezing when too many messages

### DIFF
--- a/js/app/packages/block-channel/component/MessageList/MessageList.tsx
+++ b/js/app/packages/block-channel/component/MessageList/MessageList.tsx
@@ -767,6 +767,7 @@ function MessageListImpl(props: MessageListProps) {
               data-channel-message-list
               data={rows() ?? []}
               shift={isPrepend()}
+              itemSize={BASE_ITEM_SIZE}
               bufferSize={10 * BASE_ITEM_SIZE}
               keepMounted={keepMountedIndices()}
               onScroll={handleScroll}


### PR DESCRIPTION
## Summary
<!--
A good summary consists of a two sentence overview followed by bullet points (or checklist items for WIP).
-->
This was caused by `virtua` miscalculating the range because of a large amount of elements having an initial size of 0. Adding a default `itemSize` should resolve the issue so that `virtua` does not have to wait to auto measure the sizes of the elements

## Screenshots, GIFs, and Videos
<!--
Include visual representations of your changes, including GIFs/videos. Screencaptures should fully illustrate sample user behavior.
-->
