### PR TITLE
add keypress global signal to fix keyboard vs cursor select priority in lists

### DIFF
--- a/js/app/packages/app/component/UnifiedListView.tsx
+++ b/js/app/packages/app/component/UnifiedListView.tsx
@@ -156,6 +156,7 @@ import {
   type ViewConfigBase,
   type ViewData,
 } from './ViewConfig';
+import { useIsKeyPressActive } from '@core/util/useIsKeyPressActive';
 
 const SEARCH_SERVICE_DEBOUNCE_MS = 200;
 const LOCAL_FUZZY_SEARCH_DEBOUNCE_MS = 20;
@@ -264,7 +265,20 @@ export function UnifiedListView(props: UnifiedListViewProps) {
     return map;
   });
 
+  const { isKeypressActive } = useIsKeyPressActive();
+
   const setSelectedEntity = (entity: EntityData | undefined) => {
+    setViewDataStore(
+      selectedView(),
+      produce((state) => {
+        if (!state) return;
+        state.selectedEntity = entity;
+      })
+    );
+  };
+  const setSelectedEntityFromMouse = (entity: EntityData | undefined) => {
+    if (isKeypressActive()) return;
+
     setViewDataStore(
       selectedView(),
       produce((state) => {
@@ -1779,7 +1793,7 @@ export function UnifiedListView(props: UnifiedListViewProps) {
                           'hasUserInteractedEntity',
                           true
                         );
-                        setSelectedEntity(innerProps.entity);
+                        setSelectedEntityFromMouse(innerProps.entity);
                       }}
                       onMouseLeave={() => {}}
                       onFocusIn={() => {

--- a/js/app/packages/core/component/LexicalMarkdown/component/menu/ActionsMenu.tsx
+++ b/js/app/packages/core/component/LexicalMarkdown/component/menu/ActionsMenu.tsx
@@ -24,6 +24,7 @@ import {
 } from '../../plugins';
 import { ACTIONS, type Action } from '../../plugins/actions/actions';
 import type { MenuOperations } from '../../shared/inlineMenu';
+import { useIsKeyPressActive } from '@core/util/useIsKeyPressActive';
 
 false && clickOutside;
 false && floatWithSelection;
@@ -89,6 +90,12 @@ export function ActionMenu(props: {
   const [selectedIndex, setSelectedIndex] = createSignal(0);
   let menuRef!: HTMLDivElement;
   const [mountSelection, setMountSelection] = createSignal<Selection | null>();
+
+  const { isKeypressActive } = useIsKeyPressActive();
+  const setSelectedIndexFromMouse = (index: number) => {
+    if (isKeypressActive()) return;
+    setSelectedIndex(index);
+  };
 
   const [searchTerm, setSearchTerm] = createSignal(props.menu.searchTerm());
   const debouncedSetSearchTerm = debounce(
@@ -250,7 +257,7 @@ export function ActionMenu(props: {
                 index={index()}
                 selected={index() === selectedIndex()}
                 editor={props.editor}
-                setIndex={setSelectedIndex}
+                setIndex={setSelectedIndexFromMouse}
                 setOpen={setIsOpen}
               />
             );

--- a/js/app/packages/core/component/LexicalMarkdown/component/menu/EmojiMenu.tsx
+++ b/js/app/packages/core/component/LexicalMarkdown/component/menu/EmojiMenu.tsx
@@ -21,6 +21,7 @@ import {
   REMOVE_EMOJI_SEARCH_COMMAND,
 } from '../../plugins';
 import type { MenuOperations } from '../../shared/inlineMenu';
+import { useIsKeyPressActive } from '@core/util/useIsKeyPressActive';
 
 false && clickOutside;
 false && floatWithSelection;
@@ -67,6 +68,12 @@ export function EmojiMenu(props: EmojiMenuProps) {
   const [mountSelection, setMountSelection] = createSignal<Selection | null>();
   const [selectedIndex, setSelectedIndex] = createSignal(0);
   const [virtualHandle, setVirtualHandle] = createSignal<VirtualizerHandle>();
+
+  const { isKeypressActive } = useIsKeyPressActive();
+  const setSelectedIndexFromMouse = (index: number) => {
+    if (isKeypressActive()) return;
+    setSelectedIndex(index);
+  };
 
   const [searchTerm, setSearchTerm] = createSignal(props.menu.searchTerm());
   const debouncedSetSearchTerm = debounce(
@@ -148,14 +155,10 @@ export function EmojiMenu(props: EmojiMenuProps) {
         setSelectedIndex((prev) => (prev + 1) % items.length);
         const handle = virtualHandle();
         if (!handle) break;
-        const endIndex = handle.findItemIndex(
-          handle.scrollOffset + handle.viewportSize
-        );
-        if (endIndex && endIndex === selectedIndex()) {
-          virtualHandle()?.scrollToIndex(selectedIndex() + 1, {
-            align: 'center',
-          });
-        }
+
+        virtualHandle()?.scrollToIndex(selectedIndex() + 1, {
+          align: 'nearest',
+        });
         break;
       }
 
@@ -165,12 +168,10 @@ export function EmojiMenu(props: EmojiMenuProps) {
         setSelectedIndex((prev) => (prev - 1 + items.length) % items.length);
         const handle = virtualHandle();
         if (!handle) break;
-        const startIndex = handle.findItemIndex(handle.scrollOffset);
-        if (startIndex && startIndex === selectedIndex()) {
-          virtualHandle()?.scrollToIndex(selectedIndex() - 1, {
-            align: 'center',
-          });
-        }
+
+        virtualHandle()?.scrollToIndex(selectedIndex() - 1, {
+          align: 'nearest',
+        });
         break;
       }
 
@@ -289,7 +290,7 @@ export function EmojiMenu(props: EmojiMenuProps) {
                         insertEmoji(emojiItem.emoji);
                         props.menu.setIsOpen(false);
                       }}
-                      setIndex={setSelectedIndex}
+                      setIndex={setSelectedIndexFromMouse}
                       setOpen={props.menu.setIsOpen}
                       index={index()}
                     />

--- a/js/app/packages/core/component/LexicalMarkdown/component/menu/MentionsMenu.tsx
+++ b/js/app/packages/core/component/LexicalMarkdown/component/menu/MentionsMenu.tsx
@@ -70,6 +70,7 @@ import {
   handleUserMention,
   type UserMentionRecord,
 } from '../../utils/mentionsUtils';
+import { useIsKeyPressActive } from '@core/util/useIsKeyPressActive';
 
 false && clickOutside;
 false && floatWithSelection;
@@ -372,7 +373,7 @@ export function MentionsMenuItem(props: {
         props.setOpen(false);
         e.stopPropagation();
       }}
-      on:mouseover={() => props.setIndex(props.index)}
+      on:mousemove={() => props.setIndex(props.index)}
       class="group flex items-center p-1.5 mx-1.5"
       classList={{ 'bg-active bracket': props.selected }}
     >
@@ -593,6 +594,11 @@ function MentionsMenuInner(props: {
 
   const [selectedIndex, setSelectedIndex] = createSignal(0);
   const [viewAllMode, setViewAllMode] = createSignal<ViewAllMode>(null);
+  const { isKeypressActive } = useIsKeyPressActive();
+  const setSelectedIndexFromMouse = (index: number) => {
+    if (isKeypressActive()) return;
+    setSelectedIndex(index);
+  };
 
   let menuRef!: HTMLDivElement;
 
@@ -1011,7 +1017,7 @@ function MentionsMenuInner(props: {
                     index={i()}
                     selected={i() === selectedIndex()}
                     itemAction={itemAction}
-                    setIndex={setSelectedIndex}
+                    setIndex={setSelectedIndexFromMouse}
                     setOpen={setMenuOpen}
                   />
                 )}
@@ -1062,7 +1068,7 @@ function MentionsMenuInner(props: {
                   index={i()}
                   selected={i() === selectedIndex()}
                   itemAction={itemAction}
-                  setIndex={setSelectedIndex}
+                  setIndex={setSelectedIndexFromMouse}
                   setOpen={setMenuOpen}
                 />
               )}
@@ -1088,7 +1094,7 @@ function MentionsMenuInner(props: {
                   index={users.length + i()}
                   selected={users.length + i() === selectedIndex()}
                   itemAction={itemAction}
-                  setIndex={setSelectedIndex}
+                  setIndex={setSelectedIndexFromMouse}
                   setOpen={setMenuOpen}
                 />
               )}
@@ -1116,7 +1122,7 @@ function MentionsMenuInner(props: {
                     users.length + docs.length + i() === selectedIndex()
                   }
                   itemAction={itemAction}
-                  setIndex={setSelectedIndex}
+                  setIndex={setSelectedIndexFromMouse}
                   setOpen={setMenuOpen}
                 />
               )}
@@ -1146,7 +1152,7 @@ function MentionsMenuInner(props: {
                     selectedIndex()
                   }
                   itemAction={itemAction}
-                  setIndex={setSelectedIndex}
+                  setIndex={setSelectedIndexFromMouse}
                   setOpen={setMenuOpen}
                 />
               )}

--- a/js/app/packages/core/util/useIsKeyPressActive.ts
+++ b/js/app/packages/core/util/useIsKeyPressActive.ts
@@ -1,0 +1,35 @@
+import { debounce } from '@solid-primitives/scheduled';
+import { createSignal, onCleanup, onMount } from 'solid-js';
+
+const [isKeypressActive, setKeypressActive] = createSignal(false);
+const debouncedSetKeypressActive = debounce(
+  setKeypressActive,
+  // based on initial OS keydown delay
+  500
+);
+const onKeydown = () => {
+  setKeypressActive(true);
+  debouncedSetKeypressActive(false);
+};
+const onKeyup = () => {
+  debouncedSetKeypressActive.clear();
+  setKeypressActive(false);
+};
+let init = false;
+export const useIsKeyPressActive = () => {
+  if (!init) {
+    init = true;
+
+    onMount(() => {
+      document.addEventListener('keydown', onKeydown, { capture: true });
+      document.addEventListener('keyup', onKeyup, { capture: true });
+    });
+    onCleanup(() => {
+      document.removeEventListener('keydown', onKeydown, { capture: true });
+      document.removeEventListener('keyup', onKeyup, { capture: true });
+      init = false;
+    });
+  }
+
+  return { isKeypressActive };
+};

--- a/js/app/packages/macro-entity/src/components/EntityWithEverything.tsx
+++ b/js/app/packages/macro-entity/src/components/EntityWithEverything.tsx
@@ -825,8 +825,6 @@ export function EntityWithEverything(
   const droppable = createDroppable(props.entity.id, props.entity);
   false && droppable;
 
-  const { didCursorMove } = useCursorMove();
-
   // The main click handler for the entity row should navigate to an entity
   // without forcing focus back to the source split until after navigation.
   // Certain buttons in the entity need to NOT Navigate AND return focus to
@@ -883,11 +881,9 @@ export function EntityWithEverything(
         'active:bracket active:outline active:outline-accent/20 active:outline-offset-[-1px]':
           isTouchDevice() && !props.checked,
       }}
-      onMouseOver={(e) => {
+      onMouseMove={() => {
         if (isTouchDevice()) return;
-        if (!didCursorMove(e)) {
-          return;
-        }
+
         setHoveredEntityId(props.entity.id);
         props.onMouseOver?.();
       }}
@@ -1353,44 +1349,4 @@ const createFormattedDate = (timestamp: number) => {
     day: 'numeric',
     year: '2-digit',
   });
-};
-
-let lastMouseX: number | null = null;
-let lastMouseY: number | null = null;
-let initialMouseMove: boolean = false;
-let cursorInit = true;
-
-const useCursorMove = () => {
-  const didCursorMove = (event: MouseEvent) => {
-    if (!initialMouseMove) return;
-    const { clientX, clientY } = event;
-    // If the mouse hasn't moved, ignore the event
-    if (clientX === lastMouseX && clientY === lastMouseY) {
-      return false;
-    }
-
-    // Update the last known position
-    lastMouseX = clientX;
-    lastMouseY = clientY;
-
-    return true;
-  };
-
-  const moveEvent = (event: MouseEvent) => {
-    const { clientX, clientY } = event;
-    initialMouseMove = true;
-
-    setTimeout(() => {
-      lastMouseX = clientX;
-      lastMouseY = clientY;
-    });
-  };
-  onMount(() => {
-    if (!cursorInit) {
-      return;
-    }
-    cursorInit = false;
-    document.addEventListener('mousemove', moveEvent, { capture: true });
-  });
-  return { didCursorMove };
 };


### PR DESCRIPTION
Bug where mouse move over triggered via dom element programmatically scrolling under cursor or user moves cursor selects active item from list.
https://github.com/user-attachments/assets/89a3a58c-de89-4999-bc56-cd935ee14df1

Adding a global signal, `isKeypressActive`, when keypress is held is used to guard against setting active item via mouse handlers.