### PR TITLE
fix(tauri): only append is_mobile if it doesn't already exist

### DIFF
--- a/js/app/tauri/navigation_plugin/src/lib.rs
+++ b/js/app/tauri/navigation_plugin/src/lib.rs
@@ -6,6 +6,9 @@ use tauri::{Manager, Runtime, plugin::Plugin};
 use tauri_plugin_opener::OpenerExt;
 use url::Url;
 
+#[cfg(test)]
+mod tests;
+
 pub mod scheme;
 
 #[derive(Debug, Clone)]
@@ -108,36 +111,36 @@ impl MacroNavigationPlugin {
             .then_some(InternalUrl(Cow::Borrowed(url)))
             .ok_or(ExternalUrl(Cow::Borrowed(url)))
     }
+}
 
-    #[tracing::instrument(ret, level = tracing::Level::DEBUG, skip(self))]
-    fn transform_external(&self, mut url: Url) -> Url {
-        let Some(query) = url.query() else {
+#[tracing::instrument(ret, level = tracing::Level::DEBUG)]
+fn transform_external_url(mut url: Url) -> Url {
+    let Some(query) = url.query() else {
+        return url;
+    };
+
+    if let Ok(AuthCallbackQuery {
+        original_url: Some(cb),
+        remaining,
+    }) = serde_qs::from_str(query).log_err()
+    {
+        let Ok(macro_scheme) = MacroScheme::from_url(&cb) else {
             return url;
         };
 
-        if let Ok(AuthCallbackQuery {
-            original_url: Some(cb),
-            remaining,
-        }) = serde_qs::from_str(query).log_err()
-        {
-            let Ok(macro_scheme) = MacroScheme::from_url(&cb) else {
-                return url;
-            };
-
-            url.set_query(Some(
-                serde_qs::to_string(&MacroCallbackQuery {
-                    original_url: macro_scheme,
-                    remaining,
-                })
-                .expect("serialization should not fail")
-                .as_str(),
-            ));
-        }
-        if let None = url.query_pairs().find(|(k, _v)| k.as_ref() == "is_mobile") {
-            url.query_pairs_mut().append_pair("is_mobile", "true");
-        }
-        url
+        url.set_query(Some(
+            serde_qs::to_string(&MacroCallbackQuery {
+                original_url: macro_scheme,
+                remaining,
+            })
+            .expect("serialization should not fail")
+            .as_str(),
+        ));
     }
+    if let None = url.query_pairs().find(|(k, _v)| k.as_ref() == "is_mobile") {
+        url.query_pairs_mut().append_pair("is_mobile", "true");
+    }
+    url
 }
 
 impl<R: Runtime> Plugin<R> for MacroNavigationPlugin {
@@ -156,11 +159,10 @@ impl<R: Runtime> Plugin<R> for MacroNavigationPlugin {
                 // on android this panics if called on the main thread
                 let app_handle = webview.app_handle().clone();
                 let url = external_url.0.into_owned();
-                let cloned = self.clone();
                 std::thread::spawn(move || {
                     app_handle
                         .opener()
-                        .open_url(cloned.transform_external(url).as_str(), None::<&str>)
+                        .open_url(transform_external_url(url).as_str(), None::<&str>)
                         .log_and_consume();
                 });
                 false

--- a/js/app/tauri/navigation_plugin/src/tests.rs
+++ b/js/app/tauri/navigation_plugin/src/tests.rs
@@ -1,0 +1,67 @@
+use super::*;
+
+#[test]
+fn transform_external_url_adds_is_mobile_when_query_exists() {
+    let url = Url::parse("https://example.com/path?foo=bar").unwrap();
+    let result = transform_external_url(url);
+    assert_eq!(
+        result.query_pairs().find(|(k, _)| k == "is_mobile"),
+        Some((Cow::Borrowed("is_mobile"), Cow::Borrowed("true")))
+    );
+}
+
+#[test]
+fn transform_external_url_no_query_does_not_add_is_mobile() {
+    let url = Url::parse("https://example.com/path").unwrap();
+    let result = transform_external_url(url);
+    assert_eq!(result.query_pairs().find(|(k, _)| k == "is_mobile"), None);
+}
+
+#[test]
+fn transform_external_url_preserves_existing_is_mobile_true() {
+    let url = Url::parse("https://example.com/path?is_mobile=true").unwrap();
+    let result = transform_external_url(url);
+    let is_mobile_count = result
+        .query_pairs()
+        .filter(|(k, _)| k == "is_mobile")
+        .count();
+    assert_eq!(is_mobile_count, 1);
+    assert_eq!(
+        result.query_pairs().find(|(k, _)| k == "is_mobile"),
+        Some((Cow::Borrowed("is_mobile"), Cow::Borrowed("true")))
+    );
+}
+
+#[test]
+fn transform_external_url_preserves_existing_is_mobile_false() {
+    let url = Url::parse("https://example.com/path?is_mobile=false").unwrap();
+    let result = transform_external_url(url);
+    let is_mobile_count = result
+        .query_pairs()
+        .filter(|(k, _)| k == "is_mobile")
+        .count();
+    assert_eq!(is_mobile_count, 1);
+    assert_eq!(
+        result.query_pairs().find(|(k, _)| k == "is_mobile"),
+        Some((Cow::Borrowed("is_mobile"), Cow::Borrowed("false")))
+    );
+}
+
+#[test]
+fn transform_external_url_preserves_other_query_params() {
+    let url = Url::parse("https://example.com/path?foo=bar&baz=qux").unwrap();
+    let result = transform_external_url(url);
+    assert_eq!(
+        result.query_pairs().find(|(k, _)| k == "foo"),
+        Some((Cow::Borrowed("foo"), Cow::Borrowed("bar")))
+    );
+    assert_eq!(
+        result.query_pairs().find(|(k, _)| k == "baz"),
+        Some((Cow::Borrowed("baz"), Cow::Borrowed("qux")))
+    );
+    assert_eq!(
+        result.query_pairs().find(|(k, _)| k == "is_mobile"),
+        Some((Cow::Borrowed("is_mobile"), Cow::Borrowed("true")))
+    );
+}
+


### PR DESCRIPTION
## Summary
<!--
A good summary consists of a two sentence overview followed by bullet points (or checklist items for WIP).
-->
The frontend of the mobile app has changed to include the is_mobile query param, the tauri backend was previously adding this parameter.
This was causing the server to fail deserialization because there is_mobile parameter exists 2 times.

This PR changes the tauri backend behaviour to only append the query param if it does not already exist.

There are unit tests for this behaviour


- **prevent adding duplicate query string**
- **add tests**

## Screenshots, GIFs, and Videos
<!--
Include visual representations of your changes, including GIFs/videos. Screencaptures should fully illustrate sample user behavior.
-->
