### PR TITLE
fix(tasks): remove hard dependency on blockId in PropertyLabel

### DIFF
--- a/js/app/packages/core/component/Properties/component/panel/PropertyLabel.tsx
+++ b/js/app/packages/core/component/Properties/component/panel/PropertyLabel.tsx
@@ -1,8 +1,4 @@
-import {
-  useBlockId,
-  useMaybeBlockAliasedName,
-  useMaybeBlockId,
-} from '@core/block';
+import { useMaybeBlockAliasedName, useMaybeBlockId } from '@core/block';
 import { DeprecatedIconButton } from '@core/component/DeprecatedIconButton';
 import DeleteIcon from '@icon/bold/x-bold.svg';
 import PinIcon from '@icon/regular/push-pin.svg';


### PR DESCRIPTION
I accidentally added a `useBlockId` in my previous pr not knowing this was used outside of md-block labels.

Switched it to use `useMaybeBlockId` and just return on the one blockId requiring feature, which you can't access from create task menu anyway.


Would be nice if this was fully decoupled from the block however.
