### PR TITLE
fix: invalidate cached auth token before it expires

### DIFF
--- a/js/app/packages/macro-entity/src/components/Provider.tsx
+++ b/js/app/packages/macro-entity/src/components/Provider.tsx
@@ -34,12 +34,12 @@ function _reconcileEntities(
 
 export function Provider(props: ParentProps) {
   queryClient.setQueryDefaults(queryKeys.all.auth, {
-    staleTime: 1000 * 60 * 60, // 1 hour
+    staleTime: 1000 * 60 * 55, // 55 minutes (token expires in 60 minutes)
     gcTime: 1000 * 60 * 60 * 24, // 1 day
   });
+  // inherits staleTime from auth query
   queryClient.setQueryDefaults(queryKeys.auth.apiToken, {
     queryFn: fetchApiToken,
-    staleTime: 1000 * 60 * 55, // 55 minutes (token expires in 60 minutes)
   });
 
   queryClient.setQueryDefaults(queryKeys.all.entity, {


### PR DESCRIPTION
## Summary
<!--
A good summary consists of a two sentence overview followed by bullet points (or checklist items for WIP).
-->

we also need to add retry logic to the soup/channels calls which is why they were never loading data after a 401 for jwt expiry but this should fix things by preventing the expiry from happening in the first place

## Screenshots, GIFs, and Videos
<!--
Include visual representations of your changes, including GIFs/videos. Screencaptures should fully illustrate sample user behavior.
-->
