### PR TITLE
Reduce email-service pods from 5 to 3

### DIFF
--- a/infra/stacks/email-service/service.ts
+++ b/infra/stacks/email-service/service.ts
@@ -170,7 +170,7 @@ export class EmailService extends pulumi.ComponentResource {
             }`,
           },
         },
-        desiredCount: stack === 'prod' ? 5 : 1,
+        desiredCount: stack === 'prod' ? 3 : 1,
       },
       { parent: this }
     );
@@ -312,7 +312,7 @@ export class EmailService extends pulumi.ComponentResource {
       `${BASE_NAME}-service-scalable-target-${stack}`,
       {
         maxCapacity: stack === 'prod' ? 10 : 2,
-        minCapacity: stack === 'prod' ? 5 : 1,
+        minCapacity: stack === 'prod' ? 3 : 1,
         resourceId: pulumi.interpolate`service/${this.clusterName}/${this.service.service.name}`,
         scalableDimension: 'ecs:service:DesiredCount',
         serviceNamespace: 'ecs',


### PR DESCRIPTION
## Summary
<!--
A good summary consists of a two sentence overview followed by bullet points (or checklist items for WIP).
-->

Now that pubsub workers are in their own pods, we can reduce the number of pods for the API. Starting by reducing from 5 to 3, will monitor and see if we can decrease further

## Screenshots, GIFs, and Videos
<!--
Include visual representations of your changes, including GIFs/videos. Screencaptures should fully illustrate sample user behavior.
-->
