### PR TITLE
split: fix regression that broke split focus navigation

### DIFF
--- a/js/app/packages/app/component/SoupContext.tsx
+++ b/js/app/packages/app/component/SoupContext.tsx
@@ -1317,7 +1317,7 @@ export function createNavigationEntityListShortcut({
   });
 
   registerEntityHotkey({
-    hotkey: ['h', 'arrowleft'],
+    hotkey: ['h'],
     scopeId: splitHotkeyScope,
     description: 'Navigate to parent context',
     hotkeyToken: TOKENS.unifiedList.navigation.parent,
@@ -1352,7 +1352,7 @@ export function createNavigationEntityListShortcut({
   });
 
   registerEntityHotkey({
-    hotkey: ['l', 'arrowright'],
+    hotkey: ['l'],
     scopeId: splitHotkeyScope,
     description: 'Navigate to child context',
     hotkeyToken: TOKENS.unifiedList.navigation.child,


### PR DESCRIPTION
restore 'arrowleft' and 'arrowright' split focus navigation, broken by https://github.com/macro-inc/macro/pull/536