### PR TITLE
fix(ci): do not run gen-api unless rust files have changed

### DIFF
--- a/.github/workflows/web-app-check-main.yml
+++ b/.github/workflows/web-app-check-main.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       should_run: ${{ steps.filter.outputs.should_run }}
+      api_changed: ${{ steps.filter.outputs.api_changed }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -27,6 +28,8 @@ jobs:
               - 'js/app/src/**'
               - '.github/actions/setup-reqs-web/**'
               - '.github/workflows/web-app-check-main.yml'
+            api_changed:
+              - 'rust/cloud-storage/**/*.rs'
 
   typescript:
     needs: path-check
@@ -45,6 +48,7 @@ jobs:
         with:
           version: 2.2.6
       - name: Generate API Types
+        if: needs.path-check.outputs.api_changed == 'true'
         working-directory: js/app
         run: bun run gen-api -- --check
       - name: Check Types


### PR DESCRIPTION
## Summary
<!--
A good summary consists of a two sentence overview followed by bullet points (or checklist items for WIP).
-->

We currently run gen-api for every web-app PR even though this only changes if you are updating rust/cloud-storage files. This will save ~ 10 minutes per run as that is how long generating api types takes.

## Screenshots, GIFs, and Videos
<!--
Include visual representations of your changes, including GIFs/videos. Screencaptures should fully illustrate sample user behavior.
-->
