### PR TITLE
unified-list: fix multiple entity rows showing same hover state

### DIFF
--- a/js/app/packages/macro-entity/src/components/EntityWithEverything.tsx
+++ b/js/app/packages/macro-entity/src/components/EntityWithEverything.tsx
@@ -480,11 +480,14 @@ interface EntityProps<T extends WithNotification<EntityData>>
   searchActive?: boolean;
 }
 
-const [hoveredEntityId, setHoveredEntityId] = createSignal<string | null>(null);
+const [hoveredComponentId, setHoveredComponentId] = createSignal<Symbol>(
+  Symbol()
+);
 
 export function EntityWithEverything(
   props: EntityProps<WithNotification<EntityData | WithSearch<EntityData>>>
 ) {
+  const id = Symbol();
   const [actionButtonRef, setActionButtonRef] =
     createSignal<HTMLButtonElement | null>(null);
   const [entityDivRef, setEntityDivRef] = createSignal<HTMLDivElement | null>(
@@ -915,7 +918,7 @@ export function EntityWithEverything(
       onMouseMove={() => {
         if (isTouchDevice()) return;
 
-        setHoveredEntityId(props.entity.id);
+        setHoveredComponentId(id);
         props.onMouseOver?.();
       }}
       onContextMenu={() => {
@@ -1106,8 +1109,7 @@ export function EntityWithEverything(
             </Show>
             <Show
               when={
-                (props.selected.active ||
-                  hoveredEntityId() === props.entity.id) &&
+                (props.selected.active || hoveredComponentId() === id) &&
                 props.onClickRowAction
               }
             >


### PR DESCRIPTION
Multiple entity rows are showing same hover state, showing mark as down checkbox, due to hover condition is compared by entity.id. 

Fix is changing hover comparison to entity component id.