### PR TITLE
Swap Launcher Menu split behavior with Option key

### DIFF
--- a/js/app/packages/app/component/Launcher.tsx
+++ b/js/app/packages/app/component/Launcher.tsx
@@ -63,7 +63,9 @@ const createBlock = async (spec: {
 
     const id = await createFn();
     if (!id) {
-      split?.goBack();
+      // If we created a new split and creation failed, close it
+      // If we replaced existing split, go back to previous content
+      spec.shouldInsert ? split?.close() : split?.goBack();
       return;
     }
 


### PR DESCRIPTION
Default behavior now opens items in a new split. Holding Option opens in the same split instead of a new one.
