### PR TITLE
fix(search): sort channel results by channel message updated_at

### DIFF
--- a/rust/cloud-storage/models_search/src/unified.rs
+++ b/rust/cloud-storage/models_search/src/unified.rs
@@ -155,11 +155,23 @@ impl UnifiedSearchResponseItem {
                 .map(|m| m.updated_at)
                 .unwrap_or_default(),
             Self::Email(item) => item.updated_at,
-            Self::Channel(item) => item
-                .metadata
-                .as_ref()
-                .map(|m| m.updated_at)
-                .unwrap_or_default(),
+            Self::Channel(item) => {
+                // Get the max updated_at from channel_message_search_results
+                let max_result_updated_at = item
+                    .extra
+                    .channel_message_search_results
+                    .iter()
+                    .filter_map(|r| r.updated_at)
+                    .max();
+
+                // Use max from results, or fall back to metadata.updated_at
+                max_result_updated_at.unwrap_or_else(|| {
+                    item.metadata
+                        .as_ref()
+                        .map(|m| m.updated_at)
+                        .unwrap_or_default()
+                })
+            }
             Self::Project(item) => item
                 .metadata
                 .as_ref()

--- a/rust/cloud-storage/search_service/src/api/search/unified/test.rs
+++ b/rust/cloud-storage/search_service/src/api/search/unified/test.rs
@@ -1,5 +1,10 @@
 use super::*;
 use models_search::{
+    SearchHighlight,
+    channel::{
+        ChannelMetadata, ChannelSearchResponseItem, ChannelSearchResponseItemWithMetadata,
+        ChannelSearchResult,
+    },
     chat::{ChatMetadata, ChatSearchResponseItem, ChatSearchResponseItemWithMetadata},
     document::{
         DocumentMetadata, DocumentSearchResponseItem, DocumentSearchResponseItemWithMetadata,
@@ -123,6 +128,192 @@ fn test_sort_unified_search_results() {
         email_id,   // 1500
         doc_id,     // 1000 - oldest
     ];
+
+    let results = sort_unified_search_results(results);
+
+    assert_eq!(
+        results.iter().map(|r| r.entity_id()).collect::<Vec<Uuid>>(),
+        expected_ids
+    );
+}
+
+#[test]
+fn test_channel_updated_at_uses_max_from_message_results() {
+    let channel_id = Uuid::new_v4();
+
+    // Channel with metadata.updated_at = 1000, but message results have higher values
+    let channel = UnifiedSearchResponseItem::Channel(ChannelSearchResponseItemWithMetadata {
+        metadata: Some(ChannelMetadata {
+            created_at: 900,
+            updated_at: 1000,
+            viewed_at: None,
+            interacted_at: None,
+        }),
+        extra: ChannelSearchResponseItem {
+            id: channel_id,
+            owner_id: Some("owner1".to_string()),
+            channel_type: "slack".to_string(),
+            channel_id,
+            channel_message_search_results: vec![
+                ChannelSearchResult {
+                    message_id: Some(Uuid::new_v4()),
+                    thread_id: None,
+                    sender_id: Some("sender1".to_string()),
+                    created_at: Some(1800),
+                    updated_at: Some(2000), // Second highest
+                    highlight: SearchHighlight::default(),
+                    score: None,
+                },
+                ChannelSearchResult {
+                    message_id: Some(Uuid::new_v4()),
+                    thread_id: None,
+                    sender_id: Some("sender2".to_string()),
+                    created_at: Some(2900),
+                    updated_at: Some(3000), // Highest - should be used
+                    highlight: SearchHighlight::default(),
+                    score: None,
+                },
+                ChannelSearchResult {
+                    message_id: Some(Uuid::new_v4()),
+                    thread_id: None,
+                    sender_id: Some("sender3".to_string()),
+                    created_at: Some(1400),
+                    updated_at: Some(1500), // Lowest of results
+                    highlight: SearchHighlight::default(),
+                    score: None,
+                },
+            ],
+        },
+    });
+
+    // Should return 3000 (max from message results), not 1000 (metadata)
+    assert_eq!(channel.updated_at(), 3000);
+}
+
+#[test]
+fn test_channel_updated_at_falls_back_to_metadata_when_no_results() {
+    let channel_id = Uuid::new_v4();
+
+    // Channel with metadata.updated_at = 1000, but no message results
+    let channel = UnifiedSearchResponseItem::Channel(ChannelSearchResponseItemWithMetadata {
+        metadata: Some(ChannelMetadata {
+            created_at: 900,
+            updated_at: 1000,
+            viewed_at: None,
+            interacted_at: None,
+        }),
+        extra: ChannelSearchResponseItem {
+            id: channel_id,
+            owner_id: Some("owner1".to_string()),
+            channel_type: "slack".to_string(),
+            channel_id,
+            channel_message_search_results: vec![],
+        },
+    });
+
+    // Should return 1000 (metadata) since no message results
+    assert_eq!(channel.updated_at(), 1000);
+}
+
+#[test]
+fn test_channel_updated_at_falls_back_to_metadata_when_results_have_no_updated_at() {
+    let channel_id = Uuid::new_v4();
+
+    // Channel with metadata.updated_at = 1000, message results have None for updated_at
+    let channel = UnifiedSearchResponseItem::Channel(ChannelSearchResponseItemWithMetadata {
+        metadata: Some(ChannelMetadata {
+            created_at: 900,
+            updated_at: 1000,
+            viewed_at: None,
+            interacted_at: None,
+        }),
+        extra: ChannelSearchResponseItem {
+            id: channel_id,
+            owner_id: Some("owner1".to_string()),
+            channel_type: "slack".to_string(),
+            channel_id,
+            channel_message_search_results: vec![
+                ChannelSearchResult {
+                    message_id: Some(Uuid::new_v4()),
+                    thread_id: None,
+                    sender_id: Some("sender1".to_string()),
+                    created_at: Some(1800),
+                    updated_at: None, // No updated_at
+                    highlight: SearchHighlight::default(),
+                    score: None,
+                },
+                ChannelSearchResult {
+                    message_id: Some(Uuid::new_v4()),
+                    thread_id: None,
+                    sender_id: Some("sender2".to_string()),
+                    created_at: Some(2900),
+                    updated_at: None, // No updated_at
+                    highlight: SearchHighlight::default(),
+                    score: None,
+                },
+            ],
+        },
+    });
+
+    // Should return 1000 (metadata) since all message results have None for updated_at
+    assert_eq!(channel.updated_at(), 1000);
+}
+
+#[test]
+fn test_sort_unified_search_results_with_channel() {
+    // Test that channels are sorted correctly based on max message result updated_at
+    let doc_id = Uuid::new_v4();
+    let channel_id = Uuid::new_v4();
+
+    let results: Vec<UnifiedSearchResponseItem> = vec![
+        // Document with updated_at = 2000
+        UnifiedSearchResponseItem::Document(DocumentSearchResponseItemWithMetadata {
+            metadata: Some(DocumentMetadata {
+                created_at: 1900,
+                updated_at: 2000,
+                viewed_at: None,
+                project_id: None,
+                deleted_at: None,
+            }),
+            extra: DocumentSearchResponseItem {
+                id: doc_id,
+                name: "Document".to_string(),
+                owner_id: "owner1".to_string(),
+                document_id: doc_id,
+                document_name: "Document".to_string(),
+                file_type: Some("pdf".to_string()),
+                sub_type: None,
+                document_search_results: vec![],
+            },
+        }),
+        // Channel with metadata.updated_at = 1000, but message result has updated_at = 3000
+        UnifiedSearchResponseItem::Channel(ChannelSearchResponseItemWithMetadata {
+            metadata: Some(ChannelMetadata {
+                created_at: 900,
+                updated_at: 1000, // Would be sorted after document if this was used
+                viewed_at: None,
+                interacted_at: None,
+            }),
+            extra: ChannelSearchResponseItem {
+                id: channel_id,
+                owner_id: Some("owner1".to_string()),
+                channel_type: "slack".to_string(),
+                channel_id,
+                channel_message_search_results: vec![ChannelSearchResult {
+                    message_id: Some(Uuid::new_v4()),
+                    thread_id: None,
+                    sender_id: Some("sender1".to_string()),
+                    created_at: Some(2900),
+                    updated_at: Some(3000), // Should make channel sort first
+                    highlight: SearchHighlight::default(),
+                    score: None,
+                }],
+            },
+        }),
+    ];
+
+    // Channel should be first because its message result has updated_at = 3000
+    let expected_ids: Vec<Uuid> = vec![channel_id, doc_id];
 
     let results = sort_unified_search_results(results);
 


### PR DESCRIPTION
## Summary
<!--
A good summary consists of a two sentence overview followed by bullet points (or checklist items for WIP).
-->

We want to make sure more recent messages channels appear first in the search results.

## Screenshots, GIFs, and Videos
<!--
Include visual representations of your changes, including GIFs/videos. Screencaptures should fully illustrate sample user behavior.
-->
