### PR TITLE
Disable inbox filter by default on load

### DIFF
--- a/js/app/packages/app/component/ViewConfig.tsx
+++ b/js/app/packages/app/component/ViewConfig.tsx
@@ -152,7 +152,7 @@ export const VIEWCONFIG_BASE: ViewConfigBase = {
     documentTypeFilter: [],
     projectFilter: undefined,
     fromFilter: [],
-    focusFilters: ['signal'],
+    focusFilters: [],
     unreadOnly: false,
     channelCategoryFilter: [],
     propertyFilters: [],


### PR DESCRIPTION
Change focusFilters default from ['signal'] to [] so the inbox filter is not automatically enabled when loading Macro.
