### PR TITLE
Swap keyboard shortcut behavior in Launcher menu

### DIFF
--- a/js/app/packages/app/component/Launcher.tsx
+++ b/js/app/packages/app/component/Launcher.tsx
@@ -105,13 +105,13 @@ type CreatableBlock = Omit<HotkeyRegistrationOptions, 'scopeId'> & {
 
 export const CREATABLE_BLOCKS: CreatableBlock[] = [
   {
-    label: 'Note',
+    label: 'Docs',
     icon: () => <WideFileMd />,
-    description: 'Create note',
+    description: 'Create doc',
     blockName: 'md',
     hotkeyToken: TOKENS.create.note,
     altHotkeyToken: TOKENS.create.noteNewSplit,
-    hotkey: 'n',
+    hotkey: 'd',
     keyDownHandler: () => {
       createBlock({
         blockName: 'md',
@@ -209,7 +209,7 @@ export const CREATABLE_BLOCKS: CreatableBlock[] = [
     blockName: 'canvas',
     hotkeyToken: TOKENS.create.canvas,
     altHotkeyToken: TOKENS.create.canvasNewSplit,
-    hotkey: 'd',
+    hotkey: 'n',
     keyDownHandler: () => {
       createBlock({
         blockName: 'canvas',


### PR DESCRIPTION
Change default launcher shortcut behavior to open items in a new split. Holding option now opens in the current split instead.