### PR TITLE
split-panel: restore ClippedPanel for accent border on active panel

### DIFF
--- a/js/app/packages/app/component/split-layout/components/SplitContainer.tsx
+++ b/js/app/packages/app/component/split-layout/components/SplitContainer.tsx
@@ -18,6 +18,8 @@ import { SplitDrawerGroup } from './SplitDrawerContext';
 import { SplitHeader } from './SplitHeader';
 import { SplitModalProvider } from './SplitModalContext';
 import { SplitToolbar } from './SplitToolbar';
+import { ClippedPanel } from '@core/component/ClippedPanel';
+import { globalSplitManager } from '@app/signal/splitLayout';
 
 export function SplitContainer(
   props: ParentProps<{
@@ -53,6 +55,11 @@ export function SplitContainer(
     return offset;
   });
 
+  function multipleSplits() {
+    const splits = globalSplitManager()?.splits?.();
+    return Boolean(splits && splits.length > 1);
+  }
+
   return (
     <SplitModalProvider>
       <SplitDrawerGroup
@@ -86,19 +93,28 @@ export function SplitContainer(
           data-modal={panel.handle.isSpotLight()}
           tabindex={-1}
         >
-          <div class="flex flex-col min-h-0 size-full bg-panel">
-            <SplitHeader ref={setHeaderRef} />
-            <SplitToolbar ref={setToolbarRef} />
-            <div class="@container/split size-full overflow-hidden">
-              {props.children}
+          <ClippedPanel
+            active={
+              panel.handle.isActive() &&
+              multipleSplits() &&
+              !panel.handle.isSpotLight()
+            }
+            edgeMutedColor="transparent"
+          >
+            <div class="flex flex-col min-h-0 size-full bg-panel">
+              <SplitHeader ref={setHeaderRef} />
+              <SplitToolbar ref={setToolbarRef} />
+              <div class="@container/split size-full overflow-hidden">
+                {props.children}
+              </div>
+              <Show when={panel.handle.isSpotLight()}>
+                <MacroJump tabbableParent={ref} />
+              </Show>
+              <Show when={isTouchDevice() && isMobileWidth()}>
+                <MobileDock />
+              </Show>
             </div>
-            <Show when={panel.handle.isSpotLight()}>
-              <MacroJump tabbableParent={ref} />
-            </Show>
-            <Show when={isTouchDevice() && isMobileWidth()}>
-              <MobileDock />
-            </Show>
-          </div>
+          </ClippedPanel>
         </div>
       </SplitDrawerGroup>
     </SplitModalProvider>

--- a/js/app/packages/core/component/ClippedPanel.tsx
+++ b/js/app/packages/core/component/ClippedPanel.tsx
@@ -1,12 +1,13 @@
 import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import { isMobileWidth } from '@core/mobile/mobileWidth';
 import { cornerClip } from '@core/util/clipPath';
-import { type JSXElement, type Ref, Show } from 'solid-js';
+import { type JSX, type JSXElement, type Ref, Show } from 'solid-js';
 import { beveledCorners } from '../../block-theme/signals/themeSignals';
 
 interface PanelProps {
   children?: JSXElement;
   active?: boolean;
+  edgeMutedColor?: JSX.CSSProperties['color'];
   tr?: boolean;
   tl?: boolean;
   bl?: boolean;
@@ -22,7 +23,7 @@ export function ClippedPanel(props: PanelProps) {
     >
       <div
         style={{
-          'background-image': `linear-gradient(${props.active ? 'var(--color-accent), var(--color-edge-muted) 80%' : 'var(--color-edge-muted)'} )`,
+          'background-image': `linear-gradient(${props.active ? `var(--color-accent), ${props.edgeMutedColor || 'var(--color-edge-muted)'} 80%` : `${props.edgeMutedColor || 'var(--color-edge-muted)'}`} )`,
           'clip-path': !beveledCorners()
             ? cornerClip(
                 props.tl ? '0.5rem' : 0,


### PR DESCRIPTION
Restore ClippedPanel for accent border on active panel.

Added `edgeMutedColor` prop to ClippedPanel to "hide" muted border by passing "transparent" color.