### PR TITLE
Remove default placeholder text from GitHub PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,0 @@
-## Summary
-
-## Screenshots, GIFs, and Videos


### PR DESCRIPTION
Remove instructional HTML comments from the pull request template, keeping only the section headers for Summary and Screenshots.

Remove this crap:

## Summary
<!--
A good summary consists of a two sentence overview followed by bullet points (or checklist items for WIP).
-->

## Screenshots, GIFs, and Videos
<!--
Include visual representations of your changes, including GIFs/videos. Screencaptures should fully illustrate sample user behavior.
-->


<img width="806" height="297" alt="image" src="https://github.com/user-attachments/assets/314747b7-e945-41ba-9697-3314cc97e278" />
