### PR TITLE
feat(soup): support channel_type filter

### DIFF
--- a/rust/cloud-storage/comms/src/outbound/postgres/comms_repo/dynamic.rs
+++ b/rust/cloud-storage/comms/src/outbound/postgres/comms_repo/dynamic.rs
@@ -93,7 +93,7 @@ fn build_channel_filter(ast: Option<&Expr<ChannelLiteral>>) -> String {
             format!("c.org_id = {org_id}")
         }
         filter_ast::ExprFrame::Literal(ChannelLiteral::ChannelType(ct)) => {
-            format!("c.channel_type = '{}'", ct.as_str())
+            format!("c.channel_type = '{ct}'")
         }
         // These filters don't apply at the channel level, they're for messages
         // So we return an empty string which will be filtered out

--- a/rust/cloud-storage/comms/src/outbound/postgres/comms_repo/dynamic.rs
+++ b/rust/cloud-storage/comms/src/outbound/postgres/comms_repo/dynamic.rs
@@ -92,6 +92,9 @@ fn build_channel_filter(ast: Option<&Expr<ChannelLiteral>>) -> String {
         filter_ast::ExprFrame::Literal(ChannelLiteral::OrganizationId(org_id)) => {
             format!("c.org_id = {org_id}")
         }
+        filter_ast::ExprFrame::Literal(ChannelLiteral::ChannelType(ct)) => {
+            format!("c.channel_type = '{}'", ct.as_str())
+        }
         // These filters don't apply at the channel level, they're for messages
         // So we return an empty string which will be filtered out
         filter_ast::ExprFrame::Literal(ChannelLiteral::ThreadId(_)) => String::new(),

--- a/rust/cloud-storage/item_filters/src/ast.rs
+++ b/rust/cloud-storage/item_filters/src/ast.rs
@@ -4,7 +4,7 @@
 use crate::{
     ChannelFilters, ChatFilters, DocumentFilters, EmailFilters, EntityFilters, ProjectFilters,
     ast::{
-        channel::ChannelLiteral,
+        channel::{ChannelLiteral, InvalidChannelType},
         chat::{ChatLiteral, ChatRole},
         email::EmailLiteral,
         project::ProjectLiteral,
@@ -55,6 +55,9 @@ pub enum ExpandErr {
     /// invalid macro user id
     #[error(transparent)]
     MacroIdErr(#[from] macro_user_id::error::ParseErr),
+    /// invalid channel type
+    #[error(transparent)]
+    ChannelTypeErr(#[from] InvalidChannelType),
 }
 
 /// type alias for a maybe empty, cheaply cloneable ast literal tree

--- a/rust/cloud-storage/item_filters/src/ast/channel.rs
+++ b/rust/cloud-storage/item_filters/src/ast/channel.rs
@@ -3,45 +3,22 @@ use std::str::FromStr;
 use filter_ast::{ExpandFrame, Expr, FoldTree, TryExpandNode};
 use macro_user_id::{cowlike::CowLike, user_id::MacroUserIdStr};
 use serde::{Deserialize, Serialize};
+use strum::{Display, EnumString};
 use uuid::Uuid;
 
 use crate::{ChannelFilters, ast::ExpandErr};
 
-/// Channel type filter
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+/// Channel type filter - mirrors `models_comms::channel::ChannelType`
+/// but lives here to avoid cyclic dependencies
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Display, EnumString)]
+#[strum(serialize_all = "snake_case")]
 #[serde(rename_all = "snake_case")]
 #[allow(missing_docs)]
-pub enum ChannelTypeFilter {
+pub enum ChannelType {
     Public,
     Organization,
     Private,
     DirectMessage,
-}
-
-impl ChannelTypeFilter {
-    /// String representation
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            Self::Public => "public",
-            Self::Organization => "organization",
-            Self::Private => "private",
-            Self::DirectMessage => "direct_message",
-        }
-    }
-}
-
-impl FromStr for ChannelTypeFilter {
-    type Err = InvalidChannelType;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "public" => Ok(Self::Public),
-            "organization" => Ok(Self::Organization),
-            "private" => Ok(Self::Private),
-            "direct_message" => Ok(Self::DirectMessage),
-            _ => Err(InvalidChannelType(s.to_owned())),
-        }
-    }
 }
 
 /// Invalid channel type error
@@ -55,6 +32,12 @@ impl std::fmt::Display for InvalidChannelType {
 }
 
 impl std::error::Error for InvalidChannelType {}
+
+impl From<strum::ParseError> for InvalidChannelType {
+    fn from(e: strum::ParseError) -> Self {
+        InvalidChannelType(e.to_string())
+    }
+}
 
 /// the possible literal values in a channel filter ast
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -70,7 +53,7 @@ pub enum ChannelLiteral {
     /// the message comes from some sender x
     Sender(MacroUserIdStr<'static>),
     /// the channel is of a specific type
-    ChannelType(ChannelTypeFilter),
+    ChannelType(ChannelType),
 }
 
 impl ExpandFrame<ChannelLiteral> for ChannelFilters {
@@ -114,7 +97,7 @@ impl ExpandFrame<ChannelLiteral> for ChannelFilters {
 
         let channel_types = channel_types
             .iter()
-            .map(|s| ChannelTypeFilter::from_str(s))
+            .map(|s| ChannelType::from_str(s).map_err(|_| InvalidChannelType(s.clone())))
             .try_expand(|r| r.map(ChannelLiteral::ChannelType), Expr::or)?;
 
         Ok([

--- a/rust/cloud-storage/item_filters/src/ast/channel.rs
+++ b/rust/cloud-storage/item_filters/src/ast/channel.rs
@@ -1,9 +1,60 @@
+use std::str::FromStr;
+
 use filter_ast::{ExpandFrame, Expr, FoldTree, TryExpandNode};
 use macro_user_id::{cowlike::CowLike, user_id::MacroUserIdStr};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::{ChannelFilters, ast::ExpandErr};
+
+/// Channel type filter
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[allow(missing_docs)]
+pub enum ChannelTypeFilter {
+    Public,
+    Organization,
+    Private,
+    DirectMessage,
+}
+
+impl ChannelTypeFilter {
+    /// String representation
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Public => "public",
+            Self::Organization => "organization",
+            Self::Private => "private",
+            Self::DirectMessage => "direct_message",
+        }
+    }
+}
+
+impl FromStr for ChannelTypeFilter {
+    type Err = InvalidChannelType;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "public" => Ok(Self::Public),
+            "organization" => Ok(Self::Organization),
+            "private" => Ok(Self::Private),
+            "direct_message" => Ok(Self::DirectMessage),
+            _ => Err(InvalidChannelType(s.to_owned())),
+        }
+    }
+}
+
+/// Invalid channel type error
+#[derive(Debug, Clone)]
+pub struct InvalidChannelType(pub String);
+
+impl std::fmt::Display for InvalidChannelType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "invalid channel type '{}'", self.0)
+    }
+}
+
+impl std::error::Error for InvalidChannelType {}
 
 /// the possible literal values in a channel filter ast
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -18,6 +69,8 @@ pub enum ChannelLiteral {
     ChannelId(Uuid),
     /// the message comes from some sender x
     Sender(MacroUserIdStr<'static>),
+    /// the channel is of a specific type
+    ChannelType(ChannelTypeFilter),
 }
 
 impl ExpandFrame<ChannelLiteral> for ChannelFilters {
@@ -32,6 +85,7 @@ impl ExpandFrame<ChannelLiteral> for ChannelFilters {
             org_id,
             channel_ids,
             sender_ids,
+            channel_types,
         } = filter_request;
 
         let thread_ids = thread_ids
@@ -58,10 +112,20 @@ impl ExpandFrame<ChannelLiteral> for ChannelFilters {
             .map(|s| MacroUserIdStr::parse_from_str(s).map(CowLike::into_owned))
             .try_expand(|r| r.map(ChannelLiteral::Sender), Expr::or)?;
 
-        Ok(
-            [thread_ids, mentions, organizations, channel_ids, sender_ids]
-                .into_iter()
-                .fold_with(Expr::and),
-        )
+        let channel_types = channel_types
+            .iter()
+            .map(|s| ChannelTypeFilter::from_str(s))
+            .try_expand(|r| r.map(ChannelLiteral::ChannelType), Expr::or)?;
+
+        Ok([
+            thread_ids,
+            mentions,
+            organizations,
+            channel_ids,
+            sender_ids,
+            channel_types,
+        ]
+        .into_iter()
+        .fold_with(Expr::and))
     }
 }

--- a/rust/cloud-storage/item_filters/src/ast/tests.rs
+++ b/rust/cloud-storage/item_filters/src/ast/tests.rs
@@ -181,3 +181,52 @@ fn it_expands_other_association() {
 
     assert_eq!(json.trim(), include_str!("tests/other.json").trim());
 }
+
+#[test]
+fn it_expands_channel_filters() {
+    let channel_id = Uuid::new_v4();
+    let f = EntityFilters {
+        channel_filters: ChannelFilters {
+            channel_ids: vec![channel_id.to_string()],
+            channel_types: vec!["public".to_string(), "direct_message".to_string()],
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let ast = Arc::into_inner(
+        EntityFilterAst::new_from_filters(f)
+            .unwrap()
+            .unwrap()
+            .channel_filter
+            .unwrap(),
+    )
+    .unwrap();
+
+    let json = serde_json::to_value(ast).unwrap();
+    let exp = json!({
+        "&": [
+            {
+                "l": {
+                    "ChannelId": channel_id
+                }
+            },
+            {
+                "|": [
+                    {
+                        "l": {
+                            "ChannelType": "public"
+                        }
+                    },
+                    {
+                        "l": {
+                            "ChannelType": "direct_message"
+                        }
+                    }
+                ]
+            }
+        ]
+    });
+
+    assert_eq!(json, exp);
+}

--- a/rust/cloud-storage/item_filters/src/lib.rs
+++ b/rust/cloud-storage/item_filters/src/lib.rs
@@ -141,6 +141,9 @@ pub struct ChannelFilters {
     /// Sender IDs to search within. Examples: ['user1']. Empty to search all accessible senders.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub sender_ids: Vec<String>,
+    /// Channel types to filter by. Examples: ['public', 'direct_message']. Empty to search all channel types.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub channel_types: Vec<String>,
 }
 
 impl IsEmpty for ChannelFilters {
@@ -151,12 +154,14 @@ impl IsEmpty for ChannelFilters {
             org_id,
             channel_ids,
             sender_ids,
+            channel_types,
         } = self;
         thread_ids.is_empty()
             && mentions.is_empty()
             && org_id.is_none()
             && channel_ids.is_empty()
             && sender_ids.is_empty()
+            && channel_types.is_empty()
     }
 }
 


### PR DESCRIPTION
- the unified list now seperates out direct_messages vs private channels
