### PR TITLE
Add light haptic feedback to mobile dock buttons

### DIFF
--- a/js/app/packages/app/component/mobile/MobileDock.tsx
+++ b/js/app/packages/app/component/mobile/MobileDock.tsx
@@ -3,6 +3,7 @@ import SignalIcon from '@macro-icons/wide/signal.svg';
 import WideFolder from '@macro-icons/wide/folder.svg';
 import WidePlus from '@macro-icons/wide/plus.svg';
 import WideTask from '@macro-icons/wide/task.svg';
+import { impactFeedback } from '@tauri-apps/plugin-haptics';
 import { batch, type Component, type JSX } from 'solid-js';
 import { setCreateMenuOpen } from '../Launcher';
 import { useSplitPanelOrThrow } from '../split-layout/layoutUtils';
@@ -24,7 +25,10 @@ type MobileDockButtonProps = {
 function MobileDockButton(props: MobileDockButtonProps) {
   return (
     <button
-      onClick={props.onClick}
+      onClick={() => {
+        impactFeedback('light');
+        props.onClick();
+      }}
       class="flex flex-col items-center justify-center w-[20%] py-4"
       classList={{
         'text-ink-muted': !props.active,


### PR DESCRIPTION
### Motivation
- Provide a light haptic cue on mobile/Tauri when tapping items in the bottom dock to improve tactile UX.

### Description
- Import `impactFeedback` from `@tauri-apps/plugin-haptics` and invoke `impactFeedback('light')` inside the `MobileDockButton` `onClick` handler in `js/app/packages/app/component/mobile/MobileDock.tsx`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c63ab35e083248889e633c3accde2)