### PR TITLE
Prevent mention pills from opening new splits on mobile

### DIFF
--- a/js/app/packages/core/util/openInNewSplit.test.ts
+++ b/js/app/packages/core/util/openInNewSplit.test.ts
@@ -1,7 +1,21 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { isMobilePlatform, isMobileWidth } = vi.hoisted(() => ({
+  isMobilePlatform: vi.fn(() => false),
+  isMobileWidth: vi.fn(() => false),
+}));
+
+vi.mock('./platform', () => ({ isMobilePlatform }));
+vi.mock('../mobile/mobileWidth', () => ({ isMobileWidth }));
+
 import { openInNewSplitForMention } from './openInNewSplit';
 
 describe('openInNewSplitForMention', () => {
+  beforeEach(() => {
+    isMobilePlatform.mockReturnValue(false);
+    isMobileWidth.mockReturnValue(false);
+  });
+
   it('opens in a new split by default for mouse/keyboard interactions', () => {
     expect(openInNewSplitForMention(false, true)).toBe(true);
   });
@@ -12,5 +26,15 @@ describe('openInNewSplitForMention', () => {
 
   it('defaults to current split when there is no event (e.g. touch)', () => {
     expect(openInNewSplitForMention(undefined, false)).toBe(false);
+  });
+
+  it('opens in the current split on mobile platforms', () => {
+    isMobilePlatform.mockReturnValue(true);
+    expect(openInNewSplitForMention(false, true)).toBe(false);
+  });
+
+  it('opens in the current split on mobile widths', () => {
+    isMobileWidth.mockReturnValue(true);
+    expect(openInNewSplitForMention(false, true)).toBe(false);
   });
 });

--- a/js/app/packages/core/util/openInNewSplit.ts
+++ b/js/app/packages/core/util/openInNewSplit.ts
@@ -1,3 +1,6 @@
+import { isMobileWidth } from '../mobile/mobileWidth';
+import { isMobilePlatform } from './platform';
+
 /**
  * Macro uses "splits" as its tab-like navigation concept.
  *
@@ -12,5 +15,6 @@ export function openInNewSplitForMention(
   altKey: boolean | undefined,
   defaultOpenInNewSplit: boolean
 ): boolean {
+  if (isMobilePlatform() || isMobileWidth()) return false;
   return altKey ? false : defaultOpenInNewSplit;
 }


### PR DESCRIPTION
### Motivation
- Clicking a mention pill could create a new split on mobile where there isn't enough room, which is surprising and undesirable.
- Add a mobile-aware guard so mention navigation opens in the current split on mobile widths or native mobile platforms.

### Description
- Updated `openInNewSplitForMention` to check `isMobilePlatform()` and `isMobileWidth()` and force current-split behavior when either is true. 
- Added imports for `isMobilePlatform` and `isMobileWidth` in `js/app/packages/core/util/openInNewSplit.ts` and short-circuited to `false` for mobile.
- Extended `js/app/packages/core/util/openInNewSplit.test.ts` to mock mobile platform/width using `vi.hoisted` and added tests that verify mention navigation stays in the current split on mobile.
- Kept existing behavior for desktop/keyboard interactions and Option(alt)-held behavior.

### Testing
- Added unit tests in `openInNewSplit.test.ts` that assert desktop, Option-key, touch/no-event, mobile platform, and mobile width behaviors; these are automated `vitest` tests but were not executed in this change.
- No automated test suites were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c637d81808324be97f2d6a53f2362)