### PR TITLE
Open unified list cmd/ctrl-click in split (not new tab)

### DIFF
--- a/js/app/packages/app/component/UnifiedListView.tsx
+++ b/js/app/packages/app/component/UnifiedListView.tsx
@@ -1301,7 +1301,11 @@ export function UnifiedListView(props: UnifiedListViewProps) {
     ) as EntityData;
 
     if (event.metaKey || event.ctrlKey) {
-      openEntityInNewTab({ entity, location });
+      await openEntityInSplitFromUnifiedList(entity, {
+        openInNewSplit: true,
+        location,
+        splitHandle: splitContext.handle,
+      });
       return;
     }
 


### PR DESCRIPTION
### Motivation
- Cmd/Ctrl+clicking an entity in the unified list should open it in a new split (to the right) instead of launching a new browser tab to keep navigation inside the app.

### Description
- Replace the `openEntityInNewTab` behavior with a call to `openEntityInSplitFromUnifiedList` (with `openInNewSplit: true`) in `js/app/packages/app/component/UnifiedListView.tsx` for `event.metaKey || event.ctrlKey` clicks.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d1cee47c083249e57dd8075c9ea88)