### PR TITLE
chore(email): don't delete email draft on message send

### DIFF
--- a/js/app/packages/block-email/component/BaseInput.tsx
+++ b/js/app/packages/block-email/component/BaseInput.tsx
@@ -553,6 +553,7 @@ export function BaseInput(props: {
     });
 
     resetState();
+    clearDraftState();
 
     cleanupWatermark();
   };
@@ -564,18 +565,22 @@ export function BaseInput(props: {
     form().reset();
   };
 
+  const clearDraftState = () => {
+    const replyingToId = props.replyingTo()?.db_id;
+    if (replyingToId) {
+      ctx.drafts.deleteDraftForMessage(replyingToId);
+    }
+    props.setShowReply?.(false);
+  };
+
   const deleteDraftAndReset = async () => {
     const draftId = savedDraftId();
     if (draftId) {
       await deleteEmailDraft(draftId);
       refetchThreadMessages();
     }
-    const replyingToId = props.replyingTo()?.db_id;
-    if (replyingToId) {
-      ctx.drafts.deleteDraftForMessage(replyingToId);
-    }
     resetState();
-    props.setShowReply?.(false);
+    clearDraftState();
   };
 
   const handleUserMention = (mention: UserMentionRecord) => {


### PR DESCRIPTION
- Removes the call to delete email draft on message send success because the backend already handles this and this can cause issues
- Prevents draft save from happening after send message is called. This is to avoid the backend validation from being triggered where you can't save a draft of a message that was already sent
- Adds clearing draft and input state after send message is called