### PR TITLE
fix(email): thread messages should expand down

### DIFF
--- a/js/app/packages/block-email/component/EmailMessageBody.tsx
+++ b/js/app/packages/block-email/component/EmailMessageBody.tsx
@@ -27,7 +27,7 @@ import { themeUpdate } from '../../block-theme/signals/themeSignals';
 interface EmailMessageBodyProps {
   message: MessageWithBodyReplyless;
   isBodyExpanded: Accessor<boolean>;
-  onExpandMessageBody: () => void;
+  setExpandedMessageBody: (id: string) => void;
   setFocusedMessageId: (messageID: string | undefined) => void;
   isFirstMessageInThread: boolean;
 }
@@ -211,7 +211,7 @@ export function EmailMessageBody(props: EmailMessageBodyProps) {
       class="flex flex-col pt-2"
       onPointerDown={() => {
         if (!props.isBodyExpanded() && props.message.db_id) {
-          props.onExpandMessageBody();
+          props.setExpandedMessageBody(props.message.db_id);
           props.setFocusedMessageId(props.message.db_id);
         } else if (props.message.db_id) {
           props.setFocusedMessageId(props.message.db_id);

--- a/js/app/packages/block-email/component/EmailMessageTopBar.tsx
+++ b/js/app/packages/block-email/component/EmailMessageTopBar.tsx
@@ -23,7 +23,7 @@ import { type EmailMessageAction, MessageActions } from './MessageActions';
 interface EmailMessageTopBarProps {
   message: MessageWithBodyReplyless;
   focused: boolean;
-  onExpandMessageBody: (expanded: boolean) => void;
+  setExpandedBodyId: (id: string, expanded: boolean) => void;
   isBodyExpanded: Accessor<boolean>;
   expandedHeader: Accessor<boolean>;
   setExpandedHeader: Setter<boolean>;
@@ -226,7 +226,7 @@ export function EmailMessageTopBar(props: EmailMessageTopBarProps) {
     const id = props.message.db_id;
     if (id) props.setFocusedMessageId(id);
     if (shouldIgnoreClick(e.target as Element)) return;
-    if (id) props.onExpandMessageBody(!props.isBodyExpanded());
+    if (id) props.setExpandedBodyId(id, !props.isBodyExpanded());
   };
 
   return (

--- a/js/app/packages/block-email/component/MessageContainer.tsx
+++ b/js/app/packages/block-email/component/MessageContainer.tsx
@@ -34,7 +34,6 @@ interface MessageContainerProps {
   isFocused: boolean;
   isTarget: boolean;
   isExpanded: boolean;
-  onToggleBodyExpand: (expanded: boolean) => void;
 }
 
 export function MessageContainer(props: MessageContainerProps) {
@@ -188,7 +187,7 @@ export function MessageContainer(props: MessageContainerProps) {
 
   const handleExpand = () => {
     if (props.message.db_id) {
-      props.onToggleBodyExpand(true);
+      context.messages.setExpandedBodyId(props.message.db_id, true);
       context.messages.setFocused(props.message.db_id);
     }
   };
@@ -222,7 +221,7 @@ export function MessageContainer(props: MessageContainerProps) {
               <EmailMessageTopBar
                 message={props.message}
                 focused={props.isFocused}
-                onExpandMessageBody={props.onToggleBodyExpand}
+                setExpandedBodyId={context.messages.setExpandedBodyId}
                 isBodyExpanded={isBodyExpanded}
                 expandedHeader={expandedHeader}
                 setExpandedHeader={setExpandedHeader}
@@ -240,7 +239,9 @@ export function MessageContainer(props: MessageContainerProps) {
               <EmailMessageBody
                 message={props.message}
                 isBodyExpanded={isBodyExpanded}
-                onExpandMessageBody={() => props.onToggleBodyExpand(true)}
+                setExpandedMessageBody={(id) =>
+                  context.messages.setExpandedBodyId(id, true)
+                }
                 setFocusedMessageId={context.messages.setFocused}
                 isFirstMessageInThread={props.isFirstMessage}
               />


### PR DESCRIPTION
This PR updates the expansion logic for email thread messages to maintain the scroll position of when the thread was no expanded. This makes it so the thread looks like it's expanding down instead of up and helps makes sure the top of the message is in view.