### PR TITLE
Email image size constraints

### DIFF
--- a/js/app/packages/block-email/component/EmailMessageBody.tsx
+++ b/js/app/packages/block-email/component/EmailMessageBody.tsx
@@ -32,6 +32,9 @@ interface EmailMessageBodyProps {
   isFirstMessageInThread: boolean;
 }
 
+const EMAIL_INLINE_IMAGE_MAX_WIDTH_PX = 600;
+const EMAIL_INLINE_IMAGE_MAX_HEIGHT_PX = 400;
+
 export function EmailMessageBody(props: EmailMessageBodyProps) {
   const [showFullHTML, setShowFullHTML] = createSignal<boolean>(false);
   const userEmail = useEmail();
@@ -117,7 +120,15 @@ export function EmailMessageBody(props: EmailMessageBodyProps) {
     const shadow = hostContainer.attachShadow({ mode: 'open' });
     // Style that uses a CSS variable to control image visibility
     const styleEl = document.createElement('style');
-    styleEl.textContent = `img{display: var(--macro-email-img-display, initial);}`;
+    styleEl.textContent = `
+      img {
+        display: var(--macro-email-img-display, initial);
+        max-width: min(100%, ${EMAIL_INLINE_IMAGE_MAX_WIDTH_PX}px);
+        max-height: ${EMAIL_INLINE_IMAGE_MAX_HEIGHT_PX}px;
+        width: auto;
+        height: auto;
+      }
+    `;
     shadow.appendChild(styleEl);
     const messageDiv = document.createElement('div');
     messageDiv.innerHTML = source()?.mainContent ?? '';


### PR DESCRIPTION
Constrain inline email image attachments to a reasonable size to prevent oversized images.

---
<a href="https://cursor.com/background-agent?bcId=bc-f699a863-fafe-4fca-9131-4592f42fa278"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f699a863-fafe-4fca-9131-4592f42fa278"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

