### PR TITLE
style(soup): Make topbar icons smaller

### DIFF
--- a/js/app/packages/app/component/Soup/components/FilterButton.tsx
+++ b/js/app/packages/app/component/Soup/components/FilterButton.tsx
@@ -58,7 +58,7 @@ export const FilterButton: Component<FilterButtonProps> = (props) => (
         }}
         onClick={props.onClick}
       >
-        <Dynamic component={props.icon} class="size-4.5" />
+        <Dynamic component={props.icon} class="size-3.5" />
         <span class="leading-none">
           <ShortcutLabel label={props.label} shortcut={props.shortcut} />
         </span>


### PR DESCRIPTION
Before:
<img width="552" height="36" alt="Screenshot 2026-01-20 at 11 41 25 AM" src="https://github.com/user-attachments/assets/ee184fd8-46bc-4064-b5b4-c2c893fbedd9" />
After:
<img width="534" height="37" alt="Screenshot 2026-01-20 at 11 41 09 AM" src="https://github.com/user-attachments/assets/0161adae-d705-4927-9113-d0b695f9f3cf" />
