### PR TITLE
fix(email): incorrect enter key spacing for emails

### DIFF
--- a/js/app/packages/block-email/util/prepareEmailBody.ts
+++ b/js/app/packages/block-email/util/prepareEmailBody.ts
@@ -433,8 +433,8 @@ function flattenConsecutiveParagraphs(container: Element) {
         !p.textContent?.trim() &&
         !p.querySelector('img, video, iframe, canvas');
 
-      if (p.children.length) {
-        div.append(...p.children);
+      if (p.childNodes.length) {
+        div.append(...p.childNodes);
       }
 
       if (j < group.length - 1 && !isEmpty) {


### PR DESCRIPTION
This PR fixes the issue with there being different spacing compared to Gmail and Superhuman when pressing enter in the input to create a new line. 

We introduce a `flattenConsecutiveParagraphs` function and call it within `prepareEmailBody` to remove consecutive paragraphs and replace with line breaks. This mimics the behavior of Gmail where consecutive text is just separated by a line break instead of a new node