### PR TITLE
style(document): Add beveled gradient edge to document preview popup

### DIFF
--- a/js/app/packages/core/component/DocumentPreview.tsx
+++ b/js/app/packages/core/component/DocumentPreview.tsx
@@ -595,7 +595,8 @@ export function PopupPreview(props: {
                             <EntityIcon
                               size="md"
                               targetType={
-                                accessibleItem().channelType === 'direct_message'
+                                accessibleItem().channelType ===
+                                'direct_message'
                                   ? 'directMessage'
                                   : accessibleItem().channelType ===
                                       'organization'


### PR DESCRIPTION
Not sure why the diff looks so crazy. I just deleted a couple classes and wrapped a `div` in a `ClippedPanel` component.

<img width="422" height="219" alt="Screenshot 2026-01-20 at 2 00 48 PM" src="https://github.com/user-attachments/assets/a7485cd9-f2d5-400f-93ed-7d6dc5eedac8" />
