### PR TITLE
fix[email]: condense long recipient list

### DIFF
--- a/js/app/packages/block-email/component/BaseInput.tsx
+++ b/js/app/packages/block-email/component/BaseInput.tsx
@@ -153,8 +153,7 @@ function TruncatedRecipientList(props: {
 
     // Add "cc" recipients (show "cc" prefix only if no "to" recipients)
     props.ccRecipients.forEach((r, i) => {
-      const prefix =
-        i === 0 && props.toRecipients.length === 0 ? 'cc ' : '';
+      const prefix = i === 0 && props.toRecipients.length === 0 ? 'cc ' : '';
       result.push({ recipient: r, prefix });
     });
 


### PR DESCRIPTION
The recipient list now gets truncated to one line 

<img width="1694" height="298" alt="CleanShot 2026-01-20 at 15 35 31@2x" src="https://github.com/user-attachments/assets/a2db8040-1d0f-4fa7-bc6d-75d144500071" />
