### PR TITLE
feat(ai): add soup chat input to open chat split on enter

### DIFF
--- a/js/app/packages/app/component/SoupChatInput.tsx
+++ b/js/app/packages/app/component/SoupChatInput.tsx
@@ -1,57 +1,54 @@
 import { useChatInput } from '@core/component/AI/component/input/useChatInput';
 import { setPendingSendData } from '@core/component/AI/signal/pendingSend';
-import type {
-  Attachment,
-  CreateAndSend,
-  Model,
-  Send,
-} from '@core/component/AI/types';
-import { useBigChat } from '@core/signal/layout';
+import type { CreateAndSend, Send } from '@core/component/AI/types';
+import { isErr } from '@core/util/maybeResult';
+import { cognitionApiServiceClient } from '@service-cognition/client';
+import { Show } from 'solid-js';
+import { useSplitPanelOrThrow } from './split-layout/layoutUtils';
 
 export function SoupChatInput() {
-  const [, setBigChatOpen] = useBigChat();
+  const splitPanelContext = useSplitPanelOrThrow();
+  const [preview] = splitPanelContext.previewState;
 
-  const { ChatInput, chatMarkdownArea, attachments, model } = useChatInput();
+  const { ChatInput } = useChatInput();
 
-  // Store content before send since ChatInput clears it before calling onSend
-  let pendingContent = '';
-  let pendingAttachments: Attachment[] = [];
-  let pendingModel: Model;
+  const handleSend = async (request: Send | CreateAndSend) => {
+    if (request.type !== 'createAndSend') return;
 
-  // Track changes to capture content before it's cleared
-  const captureState = () => {
-    pendingContent = chatMarkdownArea.markdownText();
-    pendingAttachments = attachments.attached();
-    pendingModel = model();
-  };
-
-  const handleSend = (_request: Send | CreateAndSend) => {
-    // Store the captured data for the rightbar to pick up
-    if (pendingContent) {
-      setPendingSendData({
-        content: pendingContent,
-        attachments: pendingAttachments,
-        model: pendingModel,
-      });
+    // Create a new persistent chat
+    const response = await cognitionApiServiceClient.createChat({
+      isPersistent: true,
+    });
+    if (isErr(response)) {
+      console.error('Failed to create chat', response);
+      return;
     }
+    const [, { id: chatId }] = response;
 
-    // Open bigchat - it will pick up the pending send
-    setBigChatOpen(true);
+    // Store the pending send data for the chat to pick up
+    setPendingSendData({
+      content: request.content,
+      attachments: request.attachments,
+      model: request.model,
+    });
+
+    // Replace the soup split with the chat split
+    splitPanelContext.handle.replace({
+      next: { type: 'chat', id: chatId },
+    });
   };
 
   return (
-    <div
-      class="absolute bottom-2 left-1/2 -translate-x-1/2 w-full max-w-3xl z-10 pointer-events-none"
-      onKeyDown={captureState}
-      onClick={captureState}
-    >
-      <div class="pointer-events-auto">
-        <ChatInput
-          onSend={handleSend}
-          isPersistent={true}
-          autoFocusOnMount={false}
-        />
+    <Show when={!preview()}>
+      <div class="absolute bottom-2 left-1/2 -translate-x-1/2 w-full max-w-3xl z-10 pointer-events-none">
+        <div class="pointer-events-auto">
+          <ChatInput
+            onSend={handleSend}
+            isPersistent={true}
+            autoFocusOnMount={false}
+          />
+        </div>
       </div>
-    </div>
+    </Show>
   );
 }

--- a/js/app/packages/block-chat/component/Chat.tsx
+++ b/js/app/packages/block-chat/component/Chat.tsx
@@ -6,6 +6,7 @@ import { DragDropWrapper } from '@core/component/AI/component/DragDrop';
 import { useBuildChatSendRequest } from '@core/component/AI/component/input/buildRequest';
 import { useChatInput } from '@core/component/AI/component/input/useChatInput';
 import { useChatMessages } from '@core/component/AI/component/message';
+import { getPendingSend } from '@core/component/AI/signal/pendingSend';
 import { registerToolHandler } from '@core/component/AI/signal/tool';
 import type {
   CreateAndSend,
@@ -149,6 +150,18 @@ export function Chat(props: { data: ChatData }) {
       setPendingLocation(params);
     },
   });
+
+  // Check for pending send data (e.g., from SoupChatInput) and send it
+  const pendingSend = getPendingSend();
+  if (pendingSend) {
+    buildChatSendRequest({
+      chatId: props.data.chat.id,
+      userRequest: pendingSend.content,
+      attachments: pendingSend.attachments,
+      model: pendingSend.model,
+      isPersistent: true,
+    }).then((request) => onSend(request));
+  }
 
   registerScopeSignalHotkey(scopeId, {
     hotkey: 'enter',

--- a/js/app/packages/core/component/AI/component/debug/Attachment.tsx
+++ b/js/app/packages/core/component/AI/component/debug/Attachment.tsx
@@ -144,6 +144,9 @@ async function request(simple: SimpleRequest): Promise<CreateAndSend> {
   return {
     type: 'createAndSend',
     request: {},
+    content: simple.userRequest,
+    attachments: simple.attachments,
+    model: simple.model,
     call: async () => {
       const createResponse = await cognitionApiServiceClient.createChat({});
       if (isErr(createResponse)) {

--- a/js/app/packages/core/component/AI/component/input/buildRequest.ts
+++ b/js/app/packages/core/component/AI/component/input/buildRequest.ts
@@ -65,6 +65,9 @@ export function useBuildChatSendRequest() {
       const createAndSend: CreateAndSend = {
         type: 'createAndSend',
         request: {},
+        content: userRequest,
+        attachments: attachments ?? [],
+        model: model ?? DEFAULT_MODEL,
         call: async () => {
           const response = await cognitionApiServiceClient.createChat({
             isPersistent: isPersistent ?? false,

--- a/js/app/packages/core/component/AI/types/service.ts
+++ b/js/app/packages/core/component/AI/types/service.ts
@@ -2,7 +2,9 @@ import type {
   cognitionApiServiceClient,
   cognitionWebsocketServiceClient,
 } from '@service-cognition/client';
+import type { Model } from '@service-cognition/generated/schemas';
 import type { MessageStream } from '@service-cognition/websocket';
+import type { Attachment } from './attachment';
 
 export type SendChatMessageArgs = Parameters<
   (typeof cognitionWebsocketServiceClient)['sendStreamChatMessage']
@@ -16,6 +18,9 @@ export type CreateAndSend = {
   type: 'createAndSend';
   call: () => Promise<{ type: 'error'; paymentError?: true } | Send>;
   request: CreateMessageArgs;
+  content: string;
+  attachments: Attachment[];
+  model: Model;
 };
 
 export type Send = {


### PR DESCRIPTION
## Summary
- Hide the input box when soup is in "preview" mode
- When pressing enter on a chat, replace the soup split with a chat split instead of opening bigchat
- The new chat split sends the message from the bottom input box
- Add `content`, `attachments`, `model` fields to `CreateAndSend` type for proper data passing

## Test plan
- [ ] Verify input box is hidden when soup is in preview mode
- [ ] Type a message in the soup input box and press Enter
- [ ] Verify the soup split is replaced with a chat split
- [ ] Verify the message is sent in the new chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)