### PR TITLE
BaseInput attachment clearing

### DIFF
--- a/js/app/packages/block-channel/component/BaseInput.tsx
+++ b/js/app/packages/block-channel/component/BaseInput.tsx
@@ -381,13 +381,17 @@ export function BaseInput(props: BaseInputProps) {
       mentions: allMentions(),
     };
 
+    // Stash attachments for potential restoration on error
+    const stashedAttachments = [...attachments()];
+
     clearMarkdownArea();
+    // Clear attachments immediately (optimistically), like we do with text content
+    props.inputAttachments.setStore(key, []);
     focusMarkdownArea();
 
     props
       .onSend(args)
       .then(() => {
-        props.inputAttachments.setStore(key, []);
         stopTyping();
         return props.afterSend?.();
       })
@@ -401,6 +405,8 @@ export function BaseInput(props: BaseInputProps) {
             error: e,
           });
         }
+        // Restore attachments on error
+        props.inputAttachments.setStore(key, stashedAttachments);
         focusMarkdownArea();
       })
       .finally(() => {


### PR DESCRIPTION
Clear attachments optimistically in `BaseInput.tsx` after sending a message.

Previously, attachments were only cleared after the `onSend` promise resolved, leading to them remaining in the input if only an attachment was sent. This change makes attachment clearing consistent with text clearing (optimistic clear, restore on error).

---
<a href="https://cursor.com/background-agent?bcId=bc-f2664996-95bc-440e-bb63-c758061c5a77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f2664996-95bc-440e-bb63-c758061c5a77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

