### PR TITLE
E hotkey mark-done in split view

### DIFF
--- a/js/app/packages/app/component/SoupContext.tsx
+++ b/js/app/packages/app/component/SoupContext.tsx
@@ -555,7 +555,7 @@ export function createNavigationEntityListShortcut({
       return true;
     },
     canExecuteKeyDownHandler: () =>
-      isViewingList() &&
+      canAccessEntityList() &&
       actionRegistry.isActionEnabled('mark_as_done', plainSelectedEntities()),
     displayPriority: 10,
     tags: [HotkeyTags.SelectionModification],


### PR DESCRIPTION
Update the 'e' hotkey to use `canAccessEntityList()` to enable mark-done from inside a block in split view.

---
<a href="https://cursor.com/background-agent?bcId=bc-4c2fd6ab-ac06-4b6f-af19-4b040dd0869e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4c2fd6ab-ac06-4b6f-af19-4b040dd0869e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

