### PR TITLE
Channel message context menu

### DIFF
--- a/js/app/packages/block-channel/component/Message/MessageContainer.tsx
+++ b/js/app/packages/block-channel/component/Message/MessageContainer.tsx
@@ -517,7 +517,7 @@ export function MessageContainer(props: MessageProps) {
             setContextMenuOpen(isOpen);
           }}
         >
-          <ContextMenu.Trigger>
+          <ContextMenu.Trigger disabled={editing()}>
             <MessageComponent
               id={message.id}
               focused={props.isFocused}


### PR DESCRIPTION
Disable the message context menu when a user is editing a message.

---
<a href="https://cursor.com/background-agent?bcId=bc-d6701f3a-1fd1-4976-a198-4d2adb9572c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d6701f3a-1fd1-4976-a198-4d2adb9572c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

