### PR TITLE
fix(channel): notifications not being marked as read

### DIFF
--- a/js/app/packages/block-channel/component/Channel.tsx
+++ b/js/app/packages/block-channel/component/Channel.tsx
@@ -35,6 +35,7 @@ import type { InputAttachment } from '@core/store/cacheChannelInput';
 import { handleFileFolderDrop } from '@core/util/upload';
 import {
   ChannelDebouncedNotificationReadMarker,
+  makeDebouncedChannelNotificationReadMarker,
   createEffectOnEntityTypeNotification,
   useEntityHasUnreadNotifications,
 } from '@notifications';
@@ -62,7 +63,6 @@ import { ChannelInput } from './ChannelInput';
 import { MessageList, type TargetMessageInfo } from './MessageList/MessageList';
 import { Top } from './Top';
 import { useSplitPanelOrThrow } from '@app/component/split-layout/layoutUtils';
-import { makeDebouncedChannelNoficiationReadMarker } from '@notifications/components/DebouncedNotificationReadMarker';
 
 false && fileFolderDrop;
 
@@ -323,7 +323,7 @@ export function Channel(props: {
     })
   );
 
-  const debouncedMarkAsRead = makeDebouncedChannelNoficiationReadMarker({
+  const debouncedMarkAsRead = makeDebouncedChannelNotificationReadMarker({
     notificationSource: notificationSource,
     channelId,
     debounceTime: 500,

--- a/js/app/packages/notifications/components/DebouncedNotificationReadMarker.tsx
+++ b/js/app/packages/notifications/components/DebouncedNotificationReadMarker.tsx
@@ -100,7 +100,7 @@ type ChannelDebouncedNotificationReadMarkerProps = {
   channelId: string;
 };
 
-export const makeDebouncedChannelNoficiationReadMarker = (
+export const makeDebouncedChannelNotificationReadMarker = (
   props: ChannelDebouncedNotificationReadMarkerProps
 ) => {
   return makeDebouncedMarker({

--- a/js/app/packages/notifications/index.ts
+++ b/js/app/packages/notifications/index.ts
@@ -4,7 +4,7 @@ export {
   DebouncedNotificationReadMarker,
   DocumentDebouncedNotificationReadMarker,
   EmailDebouncedReadMarker,
-  makeDebouncedChannelNoficiationReadMarker,
+  makeDebouncedChannelNotificationReadMarker,
 } from './components/DebouncedNotificationReadMarker';
 export type {
   CreateAppNotificationInterface,


### PR DESCRIPTION
- Adds `makeDebouncedMarker` and `makeDebouncedChannelNotificationReadMarker` primitives
- Adds effect to listen for panel active state change to mark notifications as read
- Adds effect to listen to incoming notifications for channel and marks them as read