### PR TITLE
fix(subscription): Invalidate user info after trial signup

### DIFF
--- a/js/app/packages/app/component/Root.tsx
+++ b/js/app/packages/app/component/Root.tsx
@@ -148,6 +148,8 @@ function BasePathComponent() {
     track(TrackingEvents.SUBSCRIPTION.SUCCESS, {
       type: type ?? undefined,
     });
+    // Invalidate user info to refresh trial status and subscription data
+    invalidateUserInfo();
   }
 
   if (searchParams.upgrade === 'true') {


### PR DESCRIPTION
After completing trial signup via Stripe, the subscription panel UI wasn't updating to reflect the new trial status. Added invalidateUserInfo() call when subscriptionSuccess=true to trigger a query refetch and update the UI with current subscription state.