### PR TITLE
Remove fade effect from read entities

### DIFF
--- a/js/app/packages/macro-entity/src/components/EntityWithEverything.tsx
+++ b/js/app/packages/macro-entity/src/components/EntityWithEverything.tsx
@@ -356,7 +356,6 @@ function NotificationRow(props: {
             }
           : undefined
       }
-      classList={{}}
     >
       <div class="flex size-5 shrink-0 items-center justify-center mr-1">
         <UserIcon id={props.notification.senderId!} size="xs" />
@@ -1123,10 +1122,7 @@ export function EntityWithEverything(
           <EntityTitle />
         </div>
         {/* Date and user - top right on mobile, end on desktop  */}
-        <div
-          class="row-1 ml-2 @md:ml-4 self-center min-w-0 col-3 @max-md/uList:col-auto @max-md/uList:row-auto @max-md/uList:ml-0 @max-md/uList:mt-1 @max-md/uList:self-start @max-md/uList:w-full"
-          classList={{}}
-        >
+        <div class="row-1 ml-2 @md:ml-4 self-center min-w-0 col-3 @max-md/uList:col-auto @max-md/uList:row-auto @max-md/uList:ml-0 @max-md/uList:mt-1 @max-md/uList:self-start @max-md/uList:w-full">
           <div class="flex flex-row items-center justify-end gap-2 min-w-0 @max-md/uList:justify-start @max-md/uList:flex-wrap">
             <Show when={sharedData()}>
               {(shared) => (


### PR DESCRIPTION
I didn't like how this looked. Superhuman maintains the same opacity/color other than the dot. It looks especially silly on screens that don't have a concept of read/unread ... like Tasks, or on screens where I don't really care if I've read or unread, like on [no filters applied]. In the inbox it was kind of nice but also unnecessary. It looked "dirty".