### PR TITLE
chore(email-service): Tracing::instrument improvements

### DIFF
--- a/rust/cloud-storage/email_db_client/src/attachments/marco/mod.rs
+++ b/rust/cloud-storage/email_db_client/src/attachments/marco/mod.rs
@@ -8,7 +8,7 @@ use sqlx::{PgPool, Pool, Postgres};
 use std::collections::HashMap;
 
 /// inserts the metadata for attachments of an email into the database in a batch
-#[tracing::instrument(skip(tx, attachments, message_id))]
+#[tracing::instrument(skip(tx, attachments, message_id), err)]
 pub async fn insert_macro_attachments(
     tx: &mut sqlx::PgConnection,
     message_id: Uuid,
@@ -135,7 +135,7 @@ pub async fn insert_macro_attachments(
     Ok(())
 }
 
-#[tracing::instrument(skip(pool))]
+#[tracing::instrument(skip(pool), err)]
 pub async fn fetch_db_macro_attachments(
     pool: &PgPool,
     message_db_id: Uuid,

--- a/rust/cloud-storage/email_db_client/src/attachments/provider/mod.rs
+++ b/rust/cloud-storage/email_db_client/src/attachments/provider/mod.rs
@@ -13,7 +13,7 @@ use sqlx::{Executor, PgPool, Pool, Postgres};
 use std::collections::HashMap;
 
 /// inserts the metadata for attachments of an email into the database in a batch
-#[tracing::instrument(skip(tx, attachments, message_id))]
+#[tracing::instrument(skip(tx, attachments, message_id), err)]
 pub async fn insert_attachments(
     tx: &mut sqlx::PgConnection,
     message_id: Uuid,
@@ -156,7 +156,7 @@ pub async fn insert_attachments(
     Ok(())
 }
 
-#[tracing::instrument(skip(pool))]
+#[tracing::instrument(skip(pool), err)]
 pub async fn fetch_db_attachments(
     pool: &PgPool,
     message_db_id: Uuid,
@@ -178,7 +178,7 @@ pub async fn fetch_db_attachments(
 }
 
 // deletes all attachments of a given message
-#[tracing::instrument(skip(executor), level = "info")]
+#[tracing::instrument(skip(executor), err)]
 pub async fn delete_message_attachments<'e, E>(executor: E, message_id: Uuid) -> anyhow::Result<()>
 where
     E: Executor<'e, Database = Postgres>,

--- a/rust/cloud-storage/email_db_client/src/backfill/job/get.rs
+++ b/rust/cloud-storage/email_db_client/src/backfill/job/get.rs
@@ -4,7 +4,7 @@ use models_email::email::service;
 use sqlx::PgPool;
 use sqlx::types::Uuid;
 
-#[tracing::instrument(skip(pool), level = "info")]
+#[tracing::instrument(skip(pool), err)]
 pub async fn get_backfill_job(
     pool: &PgPool,
     job_id: Uuid,
@@ -34,7 +34,7 @@ pub async fn get_backfill_job(
     Ok(record.map(Into::into))
 }
 
-#[tracing::instrument(skip(pool), level = "info")]
+#[tracing::instrument(skip(pool), err)]
 pub async fn get_backfill_job_with_link_id(
     pool: &PgPool,
     job_id: Uuid,
@@ -98,7 +98,7 @@ pub async fn get_active_backfill_job(
 }
 
 /// Retrieves all backfill jobs created in the last 24 hours for a given macro ID
-#[tracing::instrument(skip(pool), level = "info")]
+#[tracing::instrument(skip(pool), err)]
 pub async fn get_recent_jobs_by_fusionauth_user_id(
     pool: &PgPool,
     fusionauth_user_id: &str,

--- a/rust/cloud-storage/email_db_client/src/backfill/job/insert.rs
+++ b/rust/cloud-storage/email_db_client/src/backfill/job/insert.rs
@@ -4,7 +4,7 @@ use models_email::email::service;
 use sqlx::PgPool;
 use sqlx::types::Uuid;
 
-#[tracing::instrument(skip(pool), level = "info")]
+#[tracing::instrument(skip(pool), err)]
 pub async fn create_backfill_job(
     pool: &PgPool,
     link_id: Uuid,

--- a/rust/cloud-storage/email_db_client/src/backfill/job/update.rs
+++ b/rust/cloud-storage/email_db_client/src/backfill/job/update.rs
@@ -4,7 +4,7 @@ use models_email::email::service;
 use sqlx::PgPool;
 use sqlx::types::Uuid;
 
-#[tracing::instrument(skip(executor), level = "info")]
+#[tracing::instrument(skip(executor), err)]
 pub async fn update_backfill_job_status<'e, E>(
     executor: E,
     job_id: Uuid,
@@ -34,7 +34,7 @@ where
     Ok(())
 }
 
-#[tracing::instrument(skip(pool), level = "info")]
+#[tracing::instrument(skip(pool), err)]
 pub async fn cancel_active_jobs_by_link_id(pool: &PgPool, link_id: Uuid) -> anyhow::Result<usize> {
     let db_status = db::backfill::BackfillJobStatus::Cancelled;
 
@@ -61,7 +61,7 @@ pub async fn cancel_active_jobs_by_link_id(pool: &PgPool, link_id: Uuid) -> anyh
     Ok(rows_affected)
 }
 
-#[tracing::instrument(skip(pool), level = "info")]
+#[tracing::instrument(skip(pool), err)]
 pub async fn update_job_total_threads(
     pool: &PgPool,
     job_id: Uuid,
@@ -87,7 +87,7 @@ pub async fn update_job_total_threads(
     Ok(())
 }
 
-#[tracing::instrument(skip(pool), level = "info")]
+#[tracing::instrument(skip(pool), err)]
 pub async fn update_job_threads_retrieved_count(
     pool: &PgPool,
     job_id: Uuid,

--- a/rust/cloud-storage/email_db_client/src/contacts/delete.rs
+++ b/rust/cloud-storage/email_db_client/src/contacts/delete.rs
@@ -3,7 +3,7 @@ use sqlx::types::Uuid;
 use sqlx::{Executor, Postgres};
 
 /// deletes recipients for a given message
-#[tracing::instrument(skip(executor), level = "info")]
+#[tracing::instrument(skip(executor), err)]
 pub async fn delete_message_recipients<'e, E>(executor: E, message_id: Uuid) -> anyhow::Result<()>
 where
     E: Executor<'e, Database = Postgres>,

--- a/rust/cloud-storage/email_db_client/src/contacts/get.rs
+++ b/rust/cloud-storage/email_db_client/src/contacts/get.rs
@@ -39,7 +39,7 @@ pub async fn get_sender_by_message_id(
     Ok(result)
 }
 
-#[tracing::instrument(skip(executor))]
+#[tracing::instrument(skip(executor), err)]
 pub async fn get_senders_contacts_map<'e, E>(
     executor: E,
     message_ids: &[Uuid],
@@ -71,7 +71,7 @@ struct RecipientQueryResult {
 }
 
 /// fetch recipients (to, cc, bcc) from db
-#[tracing::instrument(skip(pool))]
+#[tracing::instrument(skip(pool), err)]
 pub async fn fetch_db_recipients(
     pool: &PgPool,
     message_db_id: Uuid,
@@ -119,7 +119,7 @@ pub async fn fetch_db_recipients(
 }
 
 /// Fetches all recipients for a given list of message IDs in a single query
-#[tracing::instrument(skip(executor), level = "info")]
+#[tracing::instrument(skip(executor), err)]
 pub async fn fetch_db_recipients_in_bulk<'e, E>(
     executor: E,
     message_ids: &[Uuid],
@@ -181,7 +181,7 @@ where
 }
 
 /// Fetch UUID for a given email address
-#[tracing::instrument(skip(pool))]
+#[tracing::instrument(skip(pool), err)]
 pub async fn fetch_id_by_email(
     pool: &mut sqlx::PgConnection,
     link_id: Uuid,
@@ -207,7 +207,7 @@ pub async fn fetch_id_by_email(
 }
 
 /// Fetch contact for a given email address
-#[tracing::instrument(skip(pool))]
+#[tracing::instrument(skip(pool), err)]
 pub async fn fetch_contact_by_email(
     pool: &PgPool,
     link_id: Uuid,
@@ -235,7 +235,7 @@ pub async fn fetch_contact_by_email(
     Ok(contact.and_then(|c| map_db_contact_to_service(Some(c))))
 }
 
-#[tracing::instrument(skip(pool))]
+#[tracing::instrument(skip(pool), err)]
 pub async fn fetch_sender_contact_info(
     pool: &PgPool,
     message_ids: &[Uuid],
@@ -252,7 +252,7 @@ pub async fn fetch_sender_contact_info(
     Ok(result)
 }
 
-#[tracing::instrument(skip(executor))]
+#[tracing::instrument(skip(executor), err)]
 pub async fn fetch_sender_contacts_by_message_ids<'e, E>(
     executor: E,
     message_ids: &[Uuid],
@@ -299,7 +299,7 @@ where
 }
 
 /// returns all email addresses and names the passed link has sent emails to.
-#[tracing::instrument(skip(pool))]
+#[tracing::instrument(skip(pool), err)]
 pub async fn fetch_contacts_by_link_id(
     pool: &PgPool,
     link_id: Uuid,
@@ -361,7 +361,7 @@ pub async fn fetch_contacts_by_link_id(
 }
 
 /// returns all non-generic email addresses the passed link has sent emails to.
-#[tracing::instrument(skip(pool))]
+#[tracing::instrument(skip(pool), err)]
 pub async fn fetch_contacts_emails_by_link_id(
     pool: &PgPool,
     link_id: Uuid,

--- a/rust/cloud-storage/email_db_client/src/contacts/upsert_message.rs
+++ b/rust/cloud-storage/email_db_client/src/contacts/upsert_message.rs
@@ -92,7 +92,7 @@ pub async fn parse_and_upsert_message_contacts(
 }
 
 /// inserts email addresses into the database in a batch
-#[tracing::instrument(skip(pool, contacts))]
+#[tracing::instrument(skip(pool, contacts), err)]
 async fn upsert_message_contacts(
     pool: &PgPool,
     contacts: Vec<ContactPhotoless>,

--- a/rust/cloud-storage/email_db_client/src/contacts/upsert_sync.rs
+++ b/rust/cloud-storage/email_db_client/src/contacts/upsert_sync.rs
@@ -7,7 +7,7 @@ use sqlx::types::Uuid;
 
 /// Upsert methods used by contact sync process, triggered by initial backfill and daily cron.
 /// Upserts multiple contacts into the contacts table
-#[tracing::instrument(skip(pool, contacts), level = "info")]
+#[tracing::instrument(skip(pool, contacts), err)]
 pub async fn upsert_contacts(pool: &PgPool, contacts: &[Contact]) -> anyhow::Result<u64> {
     if contacts.is_empty() {
         return Ok(0);

--- a/rust/cloud-storage/email_db_client/src/histories/mod.rs
+++ b/rust/cloud-storage/email_db_client/src/histories/mod.rs
@@ -6,7 +6,7 @@ use sqlx::types::Uuid;
 
 use crate::links::types::DbUserProvider;
 
-#[tracing::instrument(skip(pool), level = "info")]
+#[tracing::instrument(skip(pool), err)]
 pub async fn fetch_history_id_for_link(
     pool: &PgPool,
     email_address: &str,
@@ -43,7 +43,7 @@ pub async fn fetch_history_id_for_link(
     Ok(result.map(|r| r.history_id))
 }
 
-#[tracing::instrument(skip(pool), level = "info")]
+#[tracing::instrument(skip(pool), err)]
 pub async fn upsert_gmail_history(
     pool: &PgPool,
     link_id: Uuid,

--- a/rust/cloud-storage/email_db_client/src/labels/delete.rs
+++ b/rust/cloud-storage/email_db_client/src/labels/delete.rs
@@ -4,7 +4,7 @@ use sqlx::{Executor, PgPool, Postgres};
 
 /// Deletes a label from multiple messages at once
 /// Returns the number of message-label associations that were deleted
-#[tracing::instrument(skip(executor), level = "info")]
+#[tracing::instrument(skip(executor), err)]
 pub async fn delete_message_labels_batch<'e, E>(
     executor: E,
     message_ids: &Vec<Uuid>,
@@ -51,7 +51,7 @@ where
 }
 
 // delete all the message labels for a message.
-#[tracing::instrument(skip(executor), level = "info")]
+#[tracing::instrument(skip(executor), err)]
 pub async fn delete_all_message_labels<'e, E>(executor: E, message_id: Uuid) -> anyhow::Result<()>
 where
     E: Executor<'e, Database = Postgres>,
@@ -76,7 +76,7 @@ where
 }
 
 /// delete one or more message labels
-#[tracing::instrument(skip(tx), level = "info")]
+#[tracing::instrument(skip(tx), err)]
 pub async fn delete_db_message_labels(
     tx: &mut sqlx::PgConnection,
     message_id: Uuid,
@@ -112,7 +112,7 @@ pub async fn delete_db_message_labels(
     Ok(())
 }
 
-#[tracing::instrument(skip(pool), level = "info")]
+#[tracing::instrument(skip(pool), err)]
 pub async fn delete_labels_by_provider_ids(
     pool: &PgPool,
     link_id: Uuid,
@@ -171,7 +171,7 @@ pub async fn delete_labels_by_provider_ids(
     Ok(rows_affected)
 }
 
-#[tracing::instrument(skip(pool), level = "info")]
+#[tracing::instrument(skip(pool), err)]
 pub async fn delete_label_by_id(
     pool: &PgPool,
     label_id: Uuid,

--- a/rust/cloud-storage/email_db_client/src/labels/get.rs
+++ b/rust/cloud-storage/email_db_client/src/labels/get.rs
@@ -6,7 +6,7 @@ use sqlx::types::Uuid;
 use std::collections::{HashMap, HashSet};
 
 /// retrieves a message label if it exists
-#[tracing::instrument(skip(pool), level = "info")]
+#[tracing::instrument(skip(pool), err)]
 pub async fn fetch_message_label(
     pool: &PgPool,
     message_id: Uuid,
@@ -43,7 +43,7 @@ pub async fn fetch_message_label(
     Ok(record.map(Into::into))
 }
 
-#[tracing::instrument(skip(pool))]
+#[tracing::instrument(skip(pool), err)]
 pub async fn fetch_message_labels(
     pool: &PgPool,
     message_db_id: Uuid,
@@ -72,7 +72,7 @@ pub async fn fetch_message_labels(
     .context("Failed to fetch labels")
 }
 
-#[tracing::instrument(skip(executor), level = "info")]
+#[tracing::instrument(skip(executor), err)]
 pub async fn fetch_message_labels_in_bulk<'e, E>(
     executor: E,
     message_ids: &[Uuid],
@@ -191,7 +191,7 @@ pub async fn find_missing_provider_labels(
     Ok(missing_labels)
 }
 
-#[tracing::instrument(skip(pool), level = "info")]
+#[tracing::instrument(skip(pool), err)]
 pub async fn fetch_labels_by_link_id(
     pool: &PgPool,
     link_id: Uuid,
@@ -224,7 +224,7 @@ pub async fn fetch_labels_by_link_id(
     Ok(service_labels)
 }
 
-#[tracing::instrument(skip(pool), level = "info")]
+#[tracing::instrument(skip(pool), err)]
 pub async fn fetch_label_by_id(
     pool: &PgPool,
     label_id: Uuid,

--- a/rust/cloud-storage/email_db_client/src/labels/insert.rs
+++ b/rust/cloud-storage/email_db_client/src/labels/insert.rs
@@ -3,7 +3,7 @@ use models_email::email::{db, service};
 use sqlx::types::Uuid;
 use sqlx::{Executor, PgPool, Postgres};
 
-#[tracing::instrument(skip(pool), level = "info")]
+#[tracing::instrument(skip(pool), err)]
 pub async fn insert_message_label(
     pool: &PgPool,
     message_id: Uuid,
@@ -59,7 +59,7 @@ pub async fn insert_message_label(
 }
 
 /// Inserts a label for multiple messages at once
-#[tracing::instrument(skip(executor), level = "info")]
+#[tracing::instrument(skip(executor), err)]
 pub async fn insert_message_labels_batch<'e, E>(
     executor: E,
     message_ids: &Vec<Uuid>,
@@ -112,7 +112,7 @@ where
 /// Inserts or updates labels for a user.
 /// Labels are shared across messages, so this should be done separately from inserting message_labels
 /// to avoid deadlock issues.
-#[tracing::instrument(skip(pool, service_labels), fields(label_count = service_labels.len()))]
+#[tracing::instrument(skip(pool, service_labels), fields(label_count = service_labels.len()), err)]
 pub async fn insert_or_update_labels(
     pool: &PgPool,
     mut service_labels: Vec<service::label::Label>,
@@ -214,7 +214,7 @@ pub async fn insert_or_update_labels(
     Ok(())
 }
 
-#[tracing::instrument(skip(pool, service_label))]
+#[tracing::instrument(skip(pool, service_label), err)]
 pub async fn insert_label(
     pool: &PgPool,
     mut service_label: service::label::Label,

--- a/rust/cloud-storage/email_db_client/src/links/delete.rs
+++ b/rust/cloud-storage/email_db_client/src/links/delete.rs
@@ -5,7 +5,7 @@ use sqlx::types::Uuid;
 /// Deletes a link by its ID.
 /// Will cascade to delete threads, messages, attachments, and labels for the user.
 /// Returns the number of rows affected (should be 1 if successful, 0 if the link didn't exist).
-#[tracing::instrument(skip(pool), level = "info")]
+#[tracing::instrument(skip(pool), err)]
 pub async fn delete_link_by_id(pool: &PgPool, link_id: Uuid) -> anyhow::Result<u64> {
     let result = sqlx::query!(
         r#"

--- a/rust/cloud-storage/email_db_client/src/links/get.rs
+++ b/rust/cloud-storage/email_db_client/src/links/get.rs
@@ -44,7 +44,7 @@ pub async fn fetch_link_by_email(
 }
 
 /// fetches email_links given a macro_id.
-#[tracing::instrument(skip(pool), level = "info")]
+#[tracing::instrument(skip(pool), err)]
 pub async fn fetch_link_by_macro_id(
     pool: &PgPool,
     macro_id: &str,
@@ -74,7 +74,7 @@ pub async fn fetch_link_by_macro_id(
 }
 
 /// fetches email_links given a fusionauth_user_id. a fusionauth_user_id can have multiple email_links, each with a unique macro_id
-#[tracing::instrument(skip(pool), level = "info")]
+#[tracing::instrument(skip(pool), err)]
 pub async fn fetch_links_by_fusionauth_user_id(
     pool: &PgPool,
     fusionauth_user_id: &str,
@@ -114,7 +114,7 @@ pub async fn fetch_links_by_fusionauth_user_id(
 
 /// Fetches a link by its ID.
 /// Returns None if no link with the given ID exists.
-#[tracing::instrument(skip(pool), level = "info")]
+#[tracing::instrument(skip(pool), err)]
 pub async fn fetch_link_by_id(pool: &PgPool, link_id: Uuid) -> anyhow::Result<Option<link::Link>> {
     let db_link = sqlx::query_as!(
         DbLink,

--- a/rust/cloud-storage/email_db_client/src/links/insert.rs
+++ b/rust/cloud-storage/email_db_client/src/links/insert.rs
@@ -14,7 +14,7 @@ struct LinkId {
 /// If a record with matching fusionauth_user_id, email_address, and provider already exists,
 /// updates the existing record with values from the provided Link.
 /// Returns the ID of the inserted or updated link and a boolean indicating if a new record was created.
-#[tracing::instrument(skip(pool), level = "info", err)]
+#[tracing::instrument(skip(pool), err)]
 pub async fn upsert_link(
     pool: &PgPool,
     service_link: service::link::Link,

--- a/rust/cloud-storage/email_db_client/src/links/update.rs
+++ b/rust/cloud-storage/email_db_client/src/links/update.rs
@@ -4,7 +4,7 @@ use sqlx::types::Uuid;
 
 /// Updates the sync active status for a link by its ID.
 /// Also updates the updated_at timestamp to the current time.
-#[tracing::instrument(skip(pool), level = "info")]
+#[tracing::instrument(skip(pool), err)]
 pub async fn update_link_sync_status(
     pool: &PgPool,
     link_id: Uuid,

--- a/rust/cloud-storage/email_db_client/src/messages/delete.rs
+++ b/rust/cloud-storage/email_db_client/src/messages/delete.rs
@@ -6,7 +6,7 @@ use sqlx::{Executor, Postgres};
 
 /// Deletes message from the database with transaction handling. Returns an optional db thread id
 /// if the thread was deleted
-#[tracing::instrument(skip(tx, message), fields(link_id = %message.link_id), level = "info")]
+#[tracing::instrument(skip(tx, message), fields(link_id = %message.link_id), err)]
 pub async fn delete_message_with_tx(
     tx: &mut sqlx::PgConnection,
     message: &message::SimpleMessage,
@@ -36,7 +36,7 @@ pub async fn delete_message_with_tx(
     }
 }
 
-#[tracing::instrument(skip(executor), level = "info")]
+#[tracing::instrument(skip(executor), err)]
 pub async fn delete_db_message<'e, E>(executor: E, message_id: Uuid) -> anyhow::Result<()>
 where
     E: Executor<'e, Database = Postgres>,

--- a/rust/cloud-storage/email_db_client/src/messages/get.rs
+++ b/rust/cloud-storage/email_db_client/src/messages/get.rs
@@ -117,7 +117,7 @@ pub async fn message_exists_by_provider_id(
 }
 
 /// Fetches the thread's messages without attachments and body attributes.
-#[tracing::instrument(skip(conn), level = "info")]
+#[tracing::instrument(skip(conn), err)]
 pub async fn fetch_messages_metadata(
     conn: &mut sqlx::PgConnection,
     thread_db_id: Uuid,
@@ -203,7 +203,7 @@ pub async fn fetch_messages_metadata(
 }
 
 /// Fetches the thread's messages with labels.
-#[tracing::instrument(skip(conn), level = "info")]
+#[tracing::instrument(skip(conn), err)]
 pub async fn fetch_messages_with_labels(
     conn: &PgPool,
     thread_db_id: Uuid,
@@ -348,7 +348,7 @@ where
 }
 
 /// fetch draft message and sender contact info from database for sending
-#[tracing::instrument(skip(pool), level = "info")]
+#[tracing::instrument(skip(pool), err)]
 pub async fn get_message_to_send(
     pool: &PgPool,
     message_id: Uuid,

--- a/rust/cloud-storage/email_db_client/src/messages/get_parsed.rs
+++ b/rust/cloud-storage/email_db_client/src/messages/get_parsed.rs
@@ -10,7 +10,7 @@ use sqlx::types::Uuid;
 
 /// retreive a parsed message by its id.
 /// returns None if no message was found.
-#[tracing::instrument(skip(pool))]
+#[tracing::instrument(skip(pool), err)]
 pub async fn get_parsed_message_by_id(
     pool: &PgPool,
     message_id: &Uuid,
@@ -83,7 +83,7 @@ pub async fn get_parsed_message_by_id(
 }
 
 /// retreive a list of parsed message by their ids
-#[tracing::instrument(skip(pool))]
+#[tracing::instrument(skip(pool), err)]
 pub async fn get_parsed_messages_by_id_batch(
     pool: &PgPool,
     message_ids: &[Uuid],
@@ -158,7 +158,7 @@ pub async fn get_parsed_messages_by_id_batch(
 }
 
 /// get a paginated number of messages for a given thread.
-#[tracing::instrument(skip(pool))]
+#[tracing::instrument(skip(pool), err)]
 pub async fn get_paginated_parsed_messages_by_thread_id(
     pool: &PgPool,
     thread_id: Uuid,

--- a/rust/cloud-storage/email_db_client/src/messages/get_parsed_search.rs
+++ b/rust/cloud-storage/email_db_client/src/messages/get_parsed_search.rs
@@ -10,7 +10,7 @@ use sqlx::types::Uuid;
 
 /// retreive a parsed search message by its id.
 /// returns None if no message was found.
-#[tracing::instrument(skip(pool))]
+#[tracing::instrument(skip(pool), err)]
 pub async fn get_parsed_search_message_by_id(
     pool: &PgPool,
     message_id: &Uuid,
@@ -83,7 +83,7 @@ pub async fn get_parsed_search_message_by_id(
 }
 
 /// get a paginated number of messages for a given thread.
-#[tracing::instrument(skip(pool))]
+#[tracing::instrument(skip(pool), err)]
 pub async fn get_paginated_parsed_search_messages_by_thread_id(
     pool: &PgPool,
     thread_id: Uuid,

--- a/rust/cloud-storage/email_db_client/src/messages/get_simple_messages.rs
+++ b/rust/cloud-storage/email_db_client/src/messages/get_simple_messages.rs
@@ -110,7 +110,7 @@ pub async fn get_simple_message(
 }
 
 /// Returns a vector of SimpleMessage objects for all found messages
-#[tracing::instrument(skip(pool), level = "info")]
+#[tracing::instrument(skip(pool), err)]
 pub async fn get_simple_messages_batch(
     pool: &PgPool,
     message_ids: &Vec<Uuid>,
@@ -156,7 +156,7 @@ pub async fn get_simple_messages_batch(
 }
 
 // returns SimpleMessage objects for each message in the passed thread. ordered by date desc nulls last
-#[tracing::instrument(skip(executor), level = "info")]
+#[tracing::instrument(skip(executor), err)]
 pub async fn get_simple_messages_for_thread<'e, E>(
     executor: E,
     thread_id: Uuid,

--- a/rust/cloud-storage/email_db_client/src/messages/insert.rs
+++ b/rust/cloud-storage/email_db_client/src/messages/insert.rs
@@ -82,7 +82,7 @@ pub async fn insert_message_with_tx(
 }
 
 /// inserts message object into the database
-#[tracing::instrument(skip(tx, message))]
+#[tracing::instrument(skip(tx, message), err)]
 async fn insert_db_message(
     tx: &mut sqlx::PgConnection,
     message: &mut message::Message,
@@ -167,7 +167,7 @@ async fn insert_db_message(
 }
 
 /// Inserts a single message into the database with transaction handling
-#[tracing::instrument(skip(pool, message), fields(link_id = %message.link_id), level = "info")]
+#[tracing::instrument(skip(pool, message), fields(link_id = %message.link_id), err)]
 pub async fn insert_message(
     pool: &PgPool,
     thread_id: Uuid,

--- a/rust/cloud-storage/email_db_client/src/messages/replying_to_id.rs
+++ b/rust/cloud-storage/email_db_client/src/messages/replying_to_id.rs
@@ -6,7 +6,7 @@ use sqlx::types::Uuid;
 use std::collections::HashMap;
 
 /// Updates a single message's replying_to_id field
-#[tracing::instrument(skip(executor), level = "info")]
+#[tracing::instrument(skip(executor), err)]
 pub async fn update_db_message_replying_to_id<'e, E>(
     executor: E,
     link_id: Uuid,
@@ -56,7 +56,7 @@ where
 
 /// Updates the replying_to_id for multiple messages belonging to a single link (typically part
 /// of the same thread)
-#[tracing::instrument(skip(executor), level = "info")]
+#[tracing::instrument(skip(executor), err)]
 pub async fn update_db_messages_replying_to_ids<'e, E>(
     executor: E,
     link_id: Uuid,
@@ -115,7 +115,7 @@ where
 /// Update the replying_to_id field of a message based on its In-Reply-To header. This can only be done
 /// after all existing messages in the message's thread have been inserted, else the message the passed
 /// message is replying to may not exist in the database yet.
-#[tracing::instrument(skip(tx, message), level = "info")]
+#[tracing::instrument(skip(tx, message), err)]
 pub async fn update_message_replying_to_from_headers(
     tx: &mut sqlx::PgConnection,
     message: &message::Message,
@@ -161,7 +161,7 @@ pub async fn update_message_replying_to_from_headers(
 /// Update the replying_to_id field of a message in a thread based on its In-Reply-To header. This can only be done
 /// after all existing messages in the message's thread have been inserted, else the message a message
 /// is replying to may not exist in the database yet.
-#[tracing::instrument(skip(tx), level = "info")]
+#[tracing::instrument(skip(tx), err)]
 pub async fn update_thread_messages_replying_to(
     tx: &mut sqlx::PgConnection,
     thread_db_id: Uuid,

--- a/rust/cloud-storage/email_db_client/src/parse/db_to_service.rs
+++ b/rust/cloud-storage/email_db_client/src/parse/db_to_service.rs
@@ -104,7 +104,7 @@ pub fn map_db_macro_attachment_to_service(
     }
 }
 
-#[tracing::instrument(skip_all)]
+#[tracing::instrument(skip_all, err)]
 pub fn map_db_message_attachments_to_service(
     mut service_message: message::Message,
     attachments_res: Vec<db::attachment::Attachment>,

--- a/rust/cloud-storage/email_db_client/src/settings/mod.rs
+++ b/rust/cloud-storage/email_db_client/src/settings/mod.rs
@@ -31,7 +31,7 @@ pub async fn patch_settings(
 }
 
 /// Fetches a user's settings by link ID.
-#[tracing::instrument(skip(pool), level = "info", err)]
+#[tracing::instrument(skip(pool), err)]
 pub async fn fetch_settings(
     pool: &PgPool,
     link_id: Uuid,

--- a/rust/cloud-storage/email_db_client/src/sfs_mappings/mod.rs
+++ b/rust/cloud-storage/email_db_client/src/sfs_mappings/mod.rs
@@ -3,7 +3,7 @@ use sqlx::PgPool;
 use std::collections::{HashMap, HashSet};
 
 /// Fetches a single mapping from source URL to destination URL
-#[tracing::instrument(skip(pool), level = "info")]
+#[tracing::instrument(skip(pool), err)]
 pub async fn fetch_sfs_mapping(pool: &PgPool, source: &str) -> anyhow::Result<Option<String>> {
     let record = sqlx::query!(
         r#"
@@ -21,7 +21,7 @@ pub async fn fetch_sfs_mapping(pool: &PgPool, source: &str) -> anyhow::Result<Op
 }
 
 /// Fetches mappings from source URLs to destination URLs
-#[tracing::instrument(skip(pool), level = "info")]
+#[tracing::instrument(skip(pool), err)]
 pub async fn fetch_sfs_mappings(
     pool: &PgPool,
     sources: &HashSet<String>,
@@ -54,7 +54,7 @@ pub async fn fetch_sfs_mappings(
 }
 
 /// Inserts multiple source to destination URL mappings into the email_sfs_mappings table
-#[tracing::instrument(skip(pool, mappings), level = "info")]
+#[tracing::instrument(skip(pool, mappings), err)]
 pub async fn insert_sfs_mappings(
     pool: &PgPool,
     mappings: &HashMap<String, String>,

--- a/rust/cloud-storage/email_db_client/src/threads/delete.rs
+++ b/rust/cloud-storage/email_db_client/src/threads/delete.rs
@@ -2,7 +2,7 @@ use anyhow::Context;
 use sqlx::types::Uuid;
 
 /// Deletes a thread if it has no associated messages
-#[tracing::instrument(skip(tx), level = "info")]
+#[tracing::instrument(skip(tx), err)]
 pub async fn delete_thread_if_empty(
     tx: &mut sqlx::PgConnection,
     thread_id: Uuid,

--- a/rust/cloud-storage/email_db_client/src/threads/get.rs
+++ b/rust/cloud-storage/email_db_client/src/threads/get.rs
@@ -11,7 +11,7 @@ use sqlx::types::Uuid;
 use std::collections::{HashMap, HashSet};
 
 /// gets a list of thread ids with the macro user id for the user
-#[tracing::instrument(skip(pool))]
+#[tracing::instrument(skip(pool), err)]
 pub async fn get_paginated_thread_ids_with_macro_user_id(
     pool: &PgPool,
     thread_limit: i64,
@@ -77,7 +77,7 @@ pub async fn fetch_thread_with_messages_paginated(
 }
 
 /// get the ids of the latest-updated threads for the user.
-#[tracing::instrument(skip(pool), level = "info")]
+#[tracing::instrument(skip(pool), err)]
 pub async fn get_latest_thread_ids_paginated(
     pool: &PgPool,
     fusionauth_user_id: &str,
@@ -115,7 +115,7 @@ pub async fn get_latest_thread_ids_paginated(
     Ok(thread_ids)
 }
 
-#[tracing::instrument(skip(pool), level = "info")]
+#[tracing::instrument(skip(pool), err)]
 pub async fn get_threads_by_link_id_and_provider_ids(
     pool: &PgPool,
     link_id: Uuid,
@@ -259,7 +259,7 @@ pub async fn get_outbound_threads_by_thread_ids(
     Ok(result)
 }
 
-#[tracing::instrument(skip(pool))]
+#[tracing::instrument(skip(pool), err)]
 pub async fn get_provider_id_by_link_and_thread_id(
     pool: &PgPool,
     link_id: Uuid,
@@ -287,7 +287,7 @@ pub async fn get_provider_id_by_link_and_thread_id(
     Ok(provider_id)
 }
 
-#[tracing::instrument(skip(pool))]
+#[tracing::instrument(skip(pool), err)]
 pub async fn get_macro_id_from_thread_id(
     pool: &PgPool,
     thread_id: Uuid,
@@ -309,7 +309,7 @@ pub async fn get_macro_id_from_thread_id(
 }
 
 /// Gets a single thread by ID and link_ID
-#[tracing::instrument(skip(pool), level = "info")]
+#[tracing::instrument(skip(pool), err)]
 pub async fn get_thread_by_id_and_link_id(
     pool: &PgPool,
     thread_id: Uuid,
@@ -348,7 +348,7 @@ pub async fn get_thread_by_id_and_link_id(
 }
 
 /// Returns a paginated list of thread IDs, sorting by ascending so we don't miss new ones
-#[tracing::instrument(skip(db))]
+#[tracing::instrument(skip(db), err)]
 pub async fn get_all_thread_ids_paginated(
     db: &sqlx::Pool<sqlx::Postgres>,
     limit: i64,

--- a/rust/cloud-storage/email_db_client/src/threads/insert.rs
+++ b/rust/cloud-storage/email_db_client/src/threads/insert.rs
@@ -16,7 +16,7 @@ use std::collections::HashMap;
         thread_provider_id = %service_thread.provider_id.clone().unwrap_or_default(),
         link_id = %link_id
     ),
-    level = "info"
+    err
 )]
 pub async fn insert_thread_and_messages(
     pool: &PgPool,
@@ -93,7 +93,7 @@ pub async fn insert_thread_and_messages(
 }
 
 /// inserts a thread object into the database using the provided transaction
-#[tracing::instrument(skip(executor, service_thread))]
+#[tracing::instrument(skip(executor, service_thread), err)]
 pub async fn insert_thread<'e, E>(
     executor: E,
     service_thread: &thread::Thread,
@@ -137,7 +137,7 @@ where
 }
 
 /// inserts a thread object into the database that has no metadata or rizz
-#[tracing::instrument(skip(executor))]
+#[tracing::instrument(skip(executor), err)]
 pub async fn insert_blank_thread<'e, E>(
     executor: E,
     thread_provider_id: &str,

--- a/rust/cloud-storage/email_db_client/src/threads/update.rs
+++ b/rust/cloud-storage/email_db_client/src/threads/update.rs
@@ -8,7 +8,7 @@ use sqlx::types::Uuid;
 
 /// Updates a thread's metadata
 #[expect(clippy::too_many_arguments, reason = "too annoying to fix right now")]
-#[tracing::instrument(skip(tx), level = "debug")]
+#[tracing::instrument(skip(tx), err)]
 async fn update_db_thread_metadata(
     tx: &mut sqlx::PgConnection,
     thread_id: Uuid,
@@ -52,7 +52,7 @@ async fn update_db_thread_metadata(
 }
 
 // updates a thread's archived status to the passed boolean without performing checks
-#[tracing::instrument(skip(conn))]
+#[tracing::instrument(skip(conn), err)]
 pub async fn update_inbox_visible_status(
     conn: &mut sqlx::PgConnection,
     thread_id: Uuid,
@@ -114,7 +114,7 @@ where
 }
 
 /// Updates a thread's provider_id
-#[tracing::instrument(skip(conn))]
+#[tracing::instrument(skip(conn), err)]
 pub async fn update_thread_provider_id(
     conn: &mut sqlx::PgConnection,
     thread_id: Uuid,
@@ -146,7 +146,7 @@ pub async fn update_thread_provider_id(
 }
 
 // Updates a thread's metadata (archived status, latest_timestamps)
-#[tracing::instrument(skip(tx), level = "debug")]
+#[tracing::instrument(skip(tx), err)]
 pub async fn update_thread_metadata(
     tx: &mut sqlx::PgConnection,
     thread_db_id: Uuid,


### PR DESCRIPTION
Removing `level = "info"` and adding `err` to tracing::instrument