### PR TITLE
fix: add in missing env var

### DIFF
--- a/infra/stacks/authentication-service/index.ts
+++ b/infra/stacks/authentication-service/index.ts
@@ -96,6 +96,9 @@ const googleClientSecretKeyArn: pulumi.Output<string> = aws.secretsmanager
   .apply((secret) => secret.arn);
 
 const STRIPE_PRICE_ID_KEY = config.require(`stripe_price_id`);
+const STRIPE_PREMIUM_PRICE_ID = aws.secretsmanager
+  .getSecretVersionOutput({ secretId: STRIPE_PRICE_ID_KEY })
+  .apply((secret) => secret.arn);
 
 const stripePriceIdArn: pulumi.Output<string> = aws.secretsmanager
   .getSecretVersionOutput({ secretId: STRIPE_PRICE_ID_KEY })
@@ -283,6 +286,12 @@ const service = new AuthenticationService('authentication-service', {
     {
       name: 'STRIPE_PRICE_ID',
       value: pulumi.interpolate`${STRIPE_PRICE_ID_KEY}`,
+    },
+    {
+      // NOTE: this is the fetched secret value of the STRIPE_PRICE_ID
+      // from above. Will unify these in a separate PR.
+      name: 'STRIPE_PREMIUM_PRICE_ID',
+      value: pulumi.interpolate`${STRIPE_PREMIUM_PRICE_ID}`,
     },
   ],
 });


### PR DESCRIPTION
The stripe checkout stuff wasn't using the existing STRIPE_PRICE_ID and defaults to our test id if not provided.