### PR TITLE
fix(sharing): hide access level select for email sharing

### DIFF
--- a/js/app/packages/core/component/ForwardToChannel.tsx
+++ b/js/app/packages/core/component/ForwardToChannel.tsx
@@ -46,6 +46,8 @@ interface ForwardToChannelProps {
     getSubmitAccessLevel: () => AccessLevel | null;
     handleSubmit: () => void;
   }) => void;
+  hideAccessLevelSelector?: boolean;
+  initialAccessLevel?: AccessLevel | null;
 }
 
 export function ForwardToChannel(props: ForwardToChannelProps) {
@@ -87,7 +89,7 @@ export function ForwardToChannel(props: ForwardToChannelProps) {
 
   const { sendToUsers, sendToChannel } = useSendMessageToPeople();
   const [submitAccessLevel, setSubmitAccessLevel] =
-    createSignal<AccessLevel | null>(null);
+    createSignal<AccessLevel | null>(props.initialAccessLevel ?? null);
 
   createEffect(() => {
     const channelPermissions_ = channelPermissions();
@@ -352,7 +354,7 @@ export function ForwardToChannel(props: ForwardToChannelProps) {
               <Show
                 when={
                   props.submitPermissionInfo?.userPermissions ===
-                  Permissions.OWNER
+                    Permissions.OWNER && !props.hideAccessLevelSelector
                 }
               >
                 <ShareOptions

--- a/js/app/packages/core/component/TopBar/ShareButton.tsx
+++ b/js/app/packages/core/component/TopBar/ShareButton.tsx
@@ -499,6 +499,8 @@ export function ShareModal(props: ShareModalProps) {
                 onSubmit={() => props.setIsSharePermOpen(false)}
                 refetch={refetch}
                 name={props.name}
+                hideAccessLevelSelector={props.itemType === 'email'}
+                initialAccessLevel={props.itemType === 'email' ? 'view' : null}
               />
 
               <Show when={(recipients()?.length ?? 0) > 0}>


### PR DESCRIPTION
The other access levels aren't relevant for email sharing and can be confusing to have a selector that "does nothing"