### PR TITLE
fix: handle ip context automatically for local environment

### DIFF
--- a/rust/cloud-storage/Cargo.lock
+++ b/rust/cloud-storage/Cargo.lock
@@ -5068,6 +5068,7 @@ dependencies = [
  "http-body-util",
  "macro_auth",
  "macro_db_client",
+ "macro_env",
  "macro_env_var",
  "macro_share_permissions",
  "macro_user_id",

--- a/rust/cloud-storage/macro_middleware/Cargo.toml
+++ b/rust/cloud-storage/macro_middleware/Cargo.toml
@@ -25,6 +25,7 @@ http-body-util = { workspace = true }
 macro_auth = { path = "../macro_auth", optional = true }
 macro_db_client = { path = "../macro_db_client", optional = true }
 macro_env_var = { path = "../macro_env_var" }
+macro_env = { path = "../macro_env" }
 macro_share_permissions = { path = "../macro_share_permissions", optional = true }
 macro_user_id = { path = "../macro_user_id", optional = true }
 macro_uuid = { path = "../macro_uuid" }

--- a/rust/cloud-storage/macro_middleware/src/tracking/mod.rs
+++ b/rust/cloud-storage/macro_middleware/src/tracking/mod.rs
@@ -7,12 +7,14 @@ use axum::{
     response::{IntoResponse, Response},
 };
 
+use macro_env::Environment;
 use model::{response::ErrorResponse, tracking::IPContext};
 
 /// Attempts to decode the JWT and attach user to the request context
 /// If there is no JWT to decode, the user context remains empty
 pub async fn attach_ip_context_handler(mut req: Request, next: Next) -> Result<Response, Response> {
-    if cfg!(feature = "local_auth") {
+    // If running locally we automatically attach the ip context for you
+    if let Environment::Local = Environment::new_or_prod() {
         req.extensions_mut().insert(IPContext {
             client_ip: std::env::var("LOCAL_IP").unwrap_or("127.0.0.1".to_string()),
         });


### PR DESCRIPTION
Since we don't use the `local_auth` feature when running in docker by default we need a way to automatically handle making the IP context when running locally