### PR TITLE
fix: include latest 150 channel messages in AI context instead of oldest

### DIFF
--- a/rust/cloud-storage/ai_tools/src/read.rs
+++ b/rust/cloud-storage/ai_tools/src/read.rs
@@ -9,7 +9,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
-pub const MAX_MESSAGES: i64 = 300;
+pub const MAX_MESSAGES: i64 = 150;
 
 #[derive(Debug, JsonSchema, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -100,7 +100,7 @@ impl From<ParsedMessage> for EmailMessage {
 #[serde(rename_all = "camelCase")]
 #[schemars(
     description = "Read content by ID(s). Supports reading documents, channels, chats, and emails by their respective IDs. Use this tool when you need to retrieve the full content of a specific item(s).
-    Channel transcripts only include 300 messages. Use 'messages_since' to see messages in a different time window.",
+    Channel transcripts only include the latest 150 messages. Use 'messages_since' to see messages in a different time window.",
     title = "Read"
 )]
 pub struct Read {

--- a/rust/cloud-storage/comms_db_client/.sqlx/query-0d8ce94d378705522f09670658378808a603fd92d5415206114636d493a8a5b3.json
+++ b/rust/cloud-storage/comms_db_client/.sqlx/query-0d8ce94d378705522f09670658378808a603fd92d5415206114636d493a8a5b3.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT COUNT(*) as \"count!\"\n            FROM comms_entity_mentions\n            WHERE source_entity_type = 'message'\n              AND source_entity_id = $1\n              AND entity_type = 'document'\n              AND entity_id = 'doc123'\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "0d8ce94d378705522f09670658378808a603fd92d5415206114636d493a8a5b3"
+}

--- a/rust/cloud-storage/comms_db_client/.sqlx/query-2556c2cf7833c3f764cc6f34f482370e1e16f1024fe838445befdb0d4a9183ba.json
+++ b/rust/cloud-storage/comms_db_client/.sqlx/query-2556c2cf7833c3f764cc6f34f482370e1e16f1024fe838445befdb0d4a9183ba.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO comms_entity_mentions (id, source_entity_type, source_entity_id, entity_type, entity_id, user_id) VALUES (gen_random_uuid(), 'message', $1, 'doc', 'doc1', NULL)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Varchar"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "2556c2cf7833c3f764cc6f34f482370e1e16f1024fe838445befdb0d4a9183ba"
+}

--- a/rust/cloud-storage/comms_db_client/.sqlx/query-3d0e27d34fbe55dfd6f96147d768cd70022c79223e41060fb79d61fe8e1c1971.json
+++ b/rust/cloud-storage/comms_db_client/.sqlx/query-3d0e27d34fbe55dfd6f96147d768cd70022c79223e41060fb79d61fe8e1c1971.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT COUNT(*) as \"count!\"\n            FROM comms_entity_mentions\n            WHERE source_entity_type = 'message'\n              AND source_entity_id = $1\n              AND entity_type = 'document'\n              AND entity_id = 'doc456'\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "3d0e27d34fbe55dfd6f96147d768cd70022c79223e41060fb79d61fe8e1c1971"
+}

--- a/rust/cloud-storage/comms_db_client/.sqlx/query-67809c28827bd163e23a02284f0e90f4649aa8d50d5fb4d088e01cfd25b59738.json
+++ b/rust/cloud-storage/comms_db_client/.sqlx/query-67809c28827bd163e23a02284f0e90f4649aa8d50d5fb4d088e01cfd25b59738.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT m.entity_id, m.entity_type\n            FROM comms_entity_mentions m\n            WHERE m.source_entity_type = 'message' AND m.source_entity_id = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "entity_type",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "67809c28827bd163e23a02284f0e90f4649aa8d50d5fb4d088e01cfd25b59738"
+}

--- a/rust/cloud-storage/comms_db_client/.sqlx/query-6afd9b2962faea63afc99a8d075fab233f34c6165c59a22c10804d3141b2c5cf.json
+++ b/rust/cloud-storage/comms_db_client/.sqlx/query-6afd9b2962faea63afc99a8d075fab233f34c6165c59a22c10804d3141b2c5cf.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT COUNT(*) as \"count!\"\n            FROM comms_entity_mentions\n            WHERE entity_id = 'user1' AND source_entity_id = 'different_doc'\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "6afd9b2962faea63afc99a8d075fab233f34c6165c59a22c10804d3141b2c5cf"
+}

--- a/rust/cloud-storage/comms_db_client/.sqlx/query-736b4d3f1ba6d173672bbac8e54b472b9f086d9a5a4784b71cc18c20098dd07c.json
+++ b/rust/cloud-storage/comms_db_client/.sqlx/query-736b4d3f1ba6d173672bbac8e54b472b9f086d9a5a4784b71cc18c20098dd07c.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT COUNT(*) as \"count!\"\n            FROM comms_entity_mentions\n            WHERE id = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "736b4d3f1ba6d173672bbac8e54b472b9f086d9a5a4784b71cc18c20098dd07c"
+}

--- a/rust/cloud-storage/comms_db_client/.sqlx/query-a07f0622de5a2491d3561e87eff3e856f48779041f64fee910a5dade485c25a8.json
+++ b/rust/cloud-storage/comms_db_client/.sqlx/query-a07f0622de5a2491d3561e87eff3e856f48779041f64fee910a5dade485c25a8.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO comms_entity_mentions (id, source_entity_type, source_entity_id, entity_type, entity_id, user_id) VALUES (gen_random_uuid(), 'doc', 'doc_source_mixed', 'doc', 'doc1', NULL)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": []
+  },
+  "hash": "a07f0622de5a2491d3561e87eff3e856f48779041f64fee910a5dade485c25a8"
+}

--- a/rust/cloud-storage/comms_db_client/.sqlx/query-b128fe71ad8427cc37e6d0073c78ada6b4eb8c4866551479910c84e0003276e8.json
+++ b/rust/cloud-storage/comms_db_client/.sqlx/query-b128fe71ad8427cc37e6d0073c78ada6b4eb8c4866551479910c84e0003276e8.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT COUNT(*) as \"count!\"\n            FROM comms_entity_mentions\n            WHERE entity_id IN ('user1', 'user2') AND source_entity_id = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "b128fe71ad8427cc37e6d0073c78ada6b4eb8c4866551479910c84e0003276e8"
+}

--- a/rust/cloud-storage/comms_db_client/.sqlx/query-ed2f2e964af409b89eceb93c1b4ee3364dbb75bdc22047789492b8f73b3e2491.json
+++ b/rust/cloud-storage/comms_db_client/.sqlx/query-ed2f2e964af409b89eceb93c1b4ee3364dbb75bdc22047789492b8f73b3e2491.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        SELECT\n            id,\n            channel_id,\n            sender_id,\n            content,\n            created_at,\n            updated_at,\n            thread_id,\n            edited_at as \"edited_at: chrono::DateTime<chrono::Utc>\",\n            deleted_at as \"deleted_at: chrono::DateTime<chrono::Utc>\"\n        FROM comms_messages\n        WHERE channel_id = $1\n        AND ($2::timestamptz IS NULL OR created_at >= $2)\n        ORDER BY created_at ASC\n        LIMIT $3\n        ",
+  "query": "\n        SELECT\n            id,\n            channel_id,\n            sender_id,\n            content,\n            created_at,\n            updated_at,\n            thread_id,\n            edited_at as \"edited_at: chrono::DateTime<chrono::Utc>\",\n            deleted_at as \"deleted_at: chrono::DateTime<chrono::Utc>\"\n        FROM (\n            SELECT *\n            FROM comms_messages\n            WHERE channel_id = $1\n            AND ($2::timestamptz IS NULL OR created_at >= $2)\n            ORDER BY created_at DESC\n            LIMIT $3\n        ) AS latest_messages\n        ORDER BY created_at ASC\n        ",
   "describe": {
     "columns": [
       {
@@ -68,5 +68,5 @@
       true
     ]
   },
-  "hash": "47ac2a3c3dafb2f194b28ab41e53a2de8df9f48204ba63ee497c2593e7ee7a89"
+  "hash": "ed2f2e964af409b89eceb93c1b4ee3364dbb75bdc22047789492b8f73b3e2491"
 }

--- a/rust/cloud-storage/comms_db_client/.sqlx/query-fbb7a67d2d807967ca1427760f257d85558674e7006c9421729aba9d6507cbfe.json
+++ b/rust/cloud-storage/comms_db_client/.sqlx/query-fbb7a67d2d807967ca1427760f257d85558674e7006c9421729aba9d6507cbfe.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT COUNT(*) as \"count!\"\n            FROM comms_entity_mentions\n            WHERE entity_id = 'user3' AND source_entity_id = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "fbb7a67d2d807967ca1427760f257d85558674e7006c9421729aba9d6507cbfe"
+}

--- a/rust/cloud-storage/comms_db_client/src/messages/get_messages.rs
+++ b/rust/cloud-storage/comms_db_client/src/messages/get_messages.rs
@@ -24,11 +24,15 @@ pub async fn get_messages(
             thread_id,
             edited_at as "edited_at: chrono::DateTime<chrono::Utc>",
             deleted_at as "deleted_at: chrono::DateTime<chrono::Utc>"
-        FROM comms_messages
-        WHERE channel_id = $1
-        AND ($2::timestamptz IS NULL OR created_at >= $2)
+        FROM (
+            SELECT *
+            FROM comms_messages
+            WHERE channel_id = $1
+            AND ($2::timestamptz IS NULL OR created_at >= $2)
+            ORDER BY created_at DESC
+            LIMIT $3
+        ) AS latest_messages
         ORDER BY created_at ASC
-        LIMIT $3
         "#,
         channel_id,
         since,

--- a/rust/cloud-storage/document_cognition_service/src/core/constants.rs
+++ b/rust/cloud-storage/document_cognition_service/src/core/constants.rs
@@ -18,4 +18,4 @@ pub const DEFAULT_PROJECT_TOKENS: i64 = 1000;
 /// The transcript will include messages up to the smaller of
 /// CHANNEL_TRANSCRIPT_MAX_MESSAGES or CHANNEL_TRANSCRIPT_MAX_DAYS
 /// Maximum number of messages to include in a channel transcript (hard cap)
-pub const CHANNEL_TRANSCRIPT_MAX_MESSAGES: i64 = 1000;
+pub const CHANNEL_TRANSCRIPT_MAX_MESSAGES: i64 = 150;


### PR DESCRIPTION
## Summary
- Fix channel context to include the **latest 150 messages** instead of the **oldest N messages**
- Previously AI would miss recent conversation context because the query fetched messages in ascending order with a limit
- Now uses a subquery to select newest messages first, then orders them chronologically
