### PR TITLE
fix(md): make unfurl link data in floating menu reactive

### DIFF
--- a/js/app/packages/core/component/LexicalMarkdown/component/menu/FloatingLinkMenu.tsx
+++ b/js/app/packages/core/component/LexicalMarkdown/component/menu/FloatingLinkMenu.tsx
@@ -123,13 +123,6 @@ export function FloatingLinkMenu(props: { closePopup?: () => void }) {
     setTimeout(() => setPreviewHover(true));
   };
 
-  const unfurlData = createMemo(() => {
-    const url = linkInfo()?.url;
-    if (!url) return undefined;
-    const [data] = useUnfurl(url);
-    return data();
-  });
-
   // Passed to link plugin in to be called when the a link is clicked.
   const onClickLink = (link?: ILinkInfo) => {
     if (link === undefined) {
@@ -327,7 +320,7 @@ export function FloatingLinkMenu(props: { closePopup?: () => void }) {
   const unfurledDetails = createMemo(() => {
     const url = linkInfo()?.url;
     if (!url) return null;
-    const data = unfurlData();
+    const data = useUnfurl(url)[0]();
     if (!data || data.type !== 'success') {
       return {
         url,


### PR DESCRIPTION
`unfurlData` wasn't responsive to `linkInfo` so we weren't getting link previews in editor window.

Before:
<img width="414" height="196" alt="Screenshot 2026-01-23 at 3 10 54 PM" src="https://github.com/user-attachments/assets/5b1ed8db-f3f8-4250-bc9a-3714830d5256" />

After:
<img width="436" height="183" alt="Screenshot 2026-01-23 at 3 10 27 PM" src="https://github.com/user-attachments/assets/ba558e1c-772f-4e09-97df-640b61087f8c" />
