### PR TITLE
fix: prefetch query so cache gets updated when the channel name is needed

### DIFF
--- a/js/app/packages/app/component/EntityModal/RenameView.tsx
+++ b/js/app/packages/app/component/EntityModal/RenameView.tsx
@@ -40,11 +40,11 @@ export const RenameView = (props: {
         () => onMutateResult.previousData
       );
     },
-    onSettled(_, __, _variables) {
+    onSettled(_, __, variables) {
       // TODO: fix the backend so that the /channels/{id} endpoint returns the updated name
-      // queryClient.invalidateQueries({
-      //   queryKey: channelKeys.withID(variables.entity.id).queryKey,
-      // });
+      queryClient.prefetchQuery({
+        queryKey: channelKeys.withID(variables.entity.id).queryKey,
+      });
     },
   });
   let inputRef: HTMLInputElement | undefined;


### PR DESCRIPTION
even though https://github.com/macro-inc/macro/pull/1164 ensured that the channel name got updated in the top bar by removing the query invalidation, if you went back into soup and then clicked the channel again the subsequent GET channel/id call would return stale data. now we prefetch the query so the cache is fresh. this is still a workaround until backeng gets fixed tbf