### PR TITLE
fix(unified-list): don't refetch on inbox filter

### DIFF
--- a/js/app/packages/app/component/UnifiedListView.tsx
+++ b/js/app/packages/app/component/UnifiedListView.tsx
@@ -1031,12 +1031,9 @@ export function UnifiedListView(props: UnifiedListViewProps) {
       limit: props.defaultDisplayOptions?.limit ?? 100,
       emailView: importantFilter()
         ? 'important'
-        : focusFilters()?.includes('signal') ||
-            entityTypeFilter().includes('email')
-          ? 'all'
-          : view().id === VIEWCONFIG_DEFAULTS_IDS_ENUM.email
-            ? emailView()
-            : undefined,
+        : view().id === VIEWCONFIG_DEFAULTS_IDS_ENUM.email
+          ? emailView()
+          : 'all',
 
       sort_method: sortType(),
     })


### PR DESCRIPTION
- Defaulting email view correctly makes it such that inbox doesn't trigger a needless soup refetch. Which makes filtering feel much better.
