### PR TITLE
fix(history): remove direct useQuery from updatedDssItemName util

### DIFF
--- a/js/app/packages/queries/history/history.ts
+++ b/js/app/packages/queries/history/history.ts
@@ -41,6 +41,9 @@ const [historyDirty, markHistoryDirty] = createSignal(undefined, {
   equals: () => false,
 });
 
+// Exported for testing reactivity of useUpdatedDssItemName
+export { markHistoryDirty };
+
 function historyQueryOptions() {
   return {
     queryKey: historyKeys.list.queryKey,

--- a/js/app/packages/queries/history/history.ts
+++ b/js/app/packages/queries/history/history.ts
@@ -8,12 +8,13 @@ import {
   useMutation,
   useQuery,
 } from '@tanstack/solid-query';
-import { type Accessor, createMemo } from 'solid-js';
+import { type Accessor, createMemo, createSignal } from 'solid-js';
 import { queryClient } from '../client';
 import { historyKeys } from './keys';
 import {
   type HistoryItem,
   type HistoryQueryResponse,
+  transformHistoryItem,
   transformHistoryResponse,
   updateItemViewedAt,
 } from './transforms';
@@ -29,6 +30,16 @@ export {
 
 const HISTORY_STALE_TIME = 5 * 60 * 1000;
 const HISTORY_GC_TIME = 10 * 60 * 1000;
+
+/**
+ * A lightweight dirty signal to track history refetch. The useUpdatedDssItemName
+ * is used broadly across the app and was causing app crashing during cleanup
+ * in race conditions. This signal sets up a lighter weight reactivity
+ * subscription.
+ */
+const [historyDirty, markHistoryDirty] = createSignal(undefined, {
+  equals: () => false,
+});
 
 function historyQueryOptions() {
   return {
@@ -69,10 +80,12 @@ export async function prefetchHistory() {
   ));
 }
 
-export function refetchHistory() {
-  return queryClient.invalidateQueries({
+export async function refetchHistory() {
+  const result = await queryClient.invalidateQueries({
     queryKey: historyKeys.list.queryKey,
   });
+  markHistoryDirty();
+  return result;
 }
 
 export function optimisticUpdateViewedAt(itemId: string) {
@@ -175,6 +188,7 @@ export function useTrackViewedMutation(
           queryClient.invalidateQueries({
             queryKey: historyKeys.list.queryKey,
           });
+          markHistoryDirty();
         },
       },
       callbacks
@@ -263,6 +277,7 @@ export function useUpsertToHistoryMutation(
           queryClient.invalidateQueries({
             queryKey: historyKeys.list.queryKey,
           });
+          markHistoryDirty();
         },
       },
       callbacks
@@ -318,18 +333,16 @@ export async function removeHistoryItem(
 
 /**
  * Hook to get the updated name of a DSS item from history.
+ * The memo will re-evaluate when:
+ * - The itemId changes (if it's an accessor)
+ * - History is refetched via refetchHistory()
  */
 export function useUpdatedDssItemName(itemId: string | Accessor<string>) {
-  const historyQuery = useHistoryQuery();
-
   return createMemo(() => {
-    const history = historyQuery.data;
-    if (!history) return undefined;
-
+    historyDirty();
     const itemIdValue = typeof itemId === 'function' ? itemId() : itemId;
     if (!itemIdValue) return undefined;
-
-    const item = history.find((item) => item.id === itemIdValue);
+    const item = getHistoryItem(itemIdValue);
     return item?.name;
   });
 }
@@ -344,6 +357,20 @@ export function getHistoryItems(): HistoryItem[] {
   );
   if (!data) return [];
   return transformHistoryResponse(data, null);
+}
+
+/**
+ * Get single history items from cache.
+ * Same as above, minus a filter and map.
+ */
+export function getHistoryItem(id: string): HistoryItem | undefined {
+  const data = queryClient.getQueryData<HistoryQueryResponse>(
+    historyKeys.list.queryKey
+  );
+  if (!data) return;
+  const item = data.data.find(({ id: itemId }) => itemId === id);
+  if (!item) return;
+  return transformHistoryItem(item);
 }
 
 /**

--- a/js/app/packages/queries/history/tests/history.test.tsx
+++ b/js/app/packages/queries/history/tests/history.test.tsx
@@ -1,11 +1,64 @@
-import { describe, expect, it, vi } from 'vitest';
+/**
+ * @vitest-environment jsdom
+ */
+
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { createRoot, createSignal } from 'solid-js';
 
 vi.mock('@core/constant/allBlocks', () => ({
   itemToSafeName: (item: { name?: string }) => item.name ?? 'Untitled',
 }));
 
+// Mock service clients to prevent side effects (websocket connections, etc.)
+vi.mock('@service-storage/client', () => ({
+  storageServiceClient: {
+    getUsersHistory: vi.fn(),
+    upsertItemToUserHistory: vi.fn(),
+    removeItemFromUserHistory: vi.fn(),
+    trackOpenedDocument: vi.fn(),
+    trackOpenedChat: vi.fn(),
+    projects: {
+      getContent: vi.fn(),
+    },
+  },
+  blockNameToItemType: vi.fn(),
+}));
+
+vi.mock('@service-cognition/client', () => ({
+  cognitionApiServiceClient: {},
+}));
+
+vi.mock('@service-cognition/websocket', () => ({
+  createCognitionWebsocketEffect: vi.fn(),
+}));
+
+vi.mock('@queries/storage/instructions-md', () => ({
+  useInstructionsMdIdQuery: () => ({
+    isSuccess: false,
+    data: null,
+  }),
+}));
+
+// Mock the queryClient to avoid importing the real one which has side effects
+const mockGetQueryData = vi.fn();
+vi.mock('../../client', () => ({
+  queryClient: {
+    getQueryData: (...args: unknown[]) => mockGetQueryData(...args),
+    invalidateQueries: vi.fn(),
+    cancelQueries: vi.fn(),
+    setQueryData: vi.fn(),
+  },
+}));
+
 import type { Item } from '@service-storage/generated/schemas/item';
 import { transformHistoryResponse, updateItemViewedAt } from '../transforms';
+import {
+  getHistoryItem,
+  getHistoryItems,
+  useUpdatedDssItemName,
+  markHistoryDirty,
+} from '../history';
+import { historyKeys } from '../keys';
 
 function createItem(overrides: Partial<Item> = {}): Item {
   return {
@@ -42,5 +95,214 @@ describe('history transforms', () => {
 
     expect(result[0]).toHaveProperty('viewedAt', 1704067200000);
     expect(items[0]).not.toHaveProperty('viewedAt'); // doesn't mutate
+  });
+});
+
+describe('useUpdatedDssItemName', () => {
+  beforeEach(() => {
+    mockGetQueryData.mockReset();
+  });
+
+  it('returns item name from cache when available', () => {
+    const mockHistoryData = {
+      data: [
+        createItem({ id: 'doc-123', name: 'My Document' }),
+        createItem({ id: 'doc-456', name: 'Other Document' }),
+      ],
+    };
+
+    mockGetQueryData.mockReturnValue(mockHistoryData);
+
+    let result: string | undefined;
+    createRoot((dispose) => {
+      const name = useUpdatedDssItemName('doc-123');
+      result = name();
+      dispose();
+    });
+
+    expect(result).toBe('My Document');
+    expect(mockGetQueryData).toHaveBeenCalledWith(historyKeys.list.queryKey);
+  });
+
+  it('returns undefined when item is not in cache', () => {
+    mockGetQueryData.mockReturnValue({ data: [] });
+
+    let result: string | undefined;
+    createRoot((dispose) => {
+      const name = useUpdatedDssItemName('nonexistent');
+      result = name();
+      dispose();
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined when itemId is empty', () => {
+    mockGetQueryData.mockReturnValue({
+      data: [createItem({ id: 'doc-123', name: 'My Document' })],
+    });
+
+    let result: string | undefined;
+    createRoot((dispose) => {
+      const name = useUpdatedDssItemName('');
+      result = name();
+      dispose();
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  it('works with accessor itemId', () => {
+    const mockHistoryData = {
+      data: [createItem({ id: 'doc-123', name: 'My Document' })],
+    };
+
+    mockGetQueryData.mockReturnValue(mockHistoryData);
+
+    let result: string | undefined;
+    createRoot((dispose) => {
+      const name = useUpdatedDssItemName(() => 'doc-123');
+      result = name();
+      dispose();
+    });
+
+    expect(result).toBe('My Document');
+  });
+
+  it('updates when document name changes in cache and markHistoryDirty is called', () => {
+    // Start with initial name
+    const initialData = {
+      data: [createItem({ id: 'doc-123', name: 'Original Name' })],
+    };
+    mockGetQueryData.mockReturnValue(initialData);
+
+    const results: (string | undefined)[] = [];
+
+    createRoot((dispose) => {
+      const name = useUpdatedDssItemName('doc-123');
+
+      // Capture initial value
+      results.push(name());
+
+      // Simulate cache update with new name
+      const updatedData = {
+        data: [createItem({ id: 'doc-123', name: 'Updated Name' })],
+      };
+      mockGetQueryData.mockReturnValue(updatedData);
+
+      // Trigger the dirty signal to cause memo re-evaluation
+      markHistoryDirty();
+
+      // Now the memo should pick up the updated cache value
+      results.push(name());
+
+      dispose();
+    });
+
+    expect(results[0]).toBe('Original Name');
+    // The second read should pick up the updated cache value after markHistoryDirty
+    expect(results[1]).toBe('Updated Name');
+  });
+
+  it('updates when switching to a different document via accessor', () => {
+    const mockHistoryData = {
+      data: [
+        createItem({ id: 'doc-1', name: 'First Document' }),
+        createItem({ id: 'doc-2', name: 'Second Document' }),
+      ],
+    };
+    mockGetQueryData.mockReturnValue(mockHistoryData);
+
+    const results: (string | undefined)[] = [];
+
+    createRoot((dispose) => {
+      const [docId, setDocId] = createSignal('doc-1');
+      const name = useUpdatedDssItemName(docId);
+
+      // Initial value for doc-1
+      results.push(name());
+
+      // Switch to doc-2
+      setDocId('doc-2');
+      results.push(name());
+
+      dispose();
+    });
+
+    expect(results[0]).toBe('First Document');
+    expect(results[1]).toBe('Second Document');
+  });
+});
+
+describe('getHistoryItems', () => {
+  beforeEach(() => {
+    mockGetQueryData.mockReset();
+  });
+
+  it('returns transformed history items from cache', () => {
+    const mockHistoryData = {
+      data: [
+        createItem({ id: 'doc-1', name: 'Doc 1' }),
+        createItem({ id: 'doc-2', name: 'Doc 2' }),
+      ],
+    };
+
+    mockGetQueryData.mockReturnValue(mockHistoryData);
+
+    const items = getHistoryItems();
+
+    expect(items).toHaveLength(2);
+    expect(items[0].name).toBe('Doc 1');
+    expect(items[1].name).toBe('Doc 2');
+  });
+
+  it('returns empty array when cache is empty', () => {
+    mockGetQueryData.mockReturnValue(undefined);
+
+    const items = getHistoryItems();
+
+    expect(items).toEqual([]);
+  });
+});
+
+describe('getHistoryItem', () => {
+  beforeEach(() => {
+    mockGetQueryData.mockReset();
+  });
+
+  it('returns single transformed item from cache', () => {
+    const mockHistoryData = {
+      data: [
+        createItem({ id: 'doc-1', name: 'Doc 1' }),
+        createItem({ id: 'doc-2', name: 'Doc 2' }),
+      ],
+    };
+
+    mockGetQueryData.mockReturnValue(mockHistoryData);
+
+    const item = getHistoryItem('doc-2');
+
+    expect(item?.name).toBe('Doc 2');
+    expect(item?.id).toBe('doc-2');
+  });
+
+  it('returns undefined when item not found', () => {
+    const mockHistoryData = {
+      data: [createItem({ id: 'doc-1', name: 'Doc 1' })],
+    };
+
+    mockGetQueryData.mockReturnValue(mockHistoryData);
+
+    const item = getHistoryItem('nonexistent');
+
+    expect(item).toBeUndefined();
+  });
+
+  it('returns undefined when cache is empty', () => {
+    mockGetQueryData.mockReturnValue(undefined);
+
+    const item = getHistoryItem('doc-1');
+
+    expect(item).toBeUndefined();
   });
 });


### PR DESCRIPTION
calling useHistoryQuery directly inside of a useUpdatedDssItemName was causing focus loss/suspense trigger bugs when called inside a blockSignal. My change yesterday (74a95d3df09212e450732c7f77cbdb9222bd8409) removed the blockSignal and fixes these problems but made a race condition where this hook did not clean up correctly and would crash the app on close spilt (both jacob and jackson found versions of this bug). This pr makes the the elimination of the block signal actually work.