### PR TITLE
fix(ai): instructionsMd eager fetch blocking render

### DIFF
--- a/js/app/packages/app/component/rightbar/Rightbar.tsx
+++ b/js/app/packages/app/component/rightbar/Rightbar.tsx
@@ -65,7 +65,6 @@ import {
   onCleanup,
   type Setter,
   Show,
-  Suspense,
   untrack,
 } from 'solid-js';
 import { SplitlikeContainer } from '../split-layout/components/SplitContainer';

--- a/js/app/packages/core/component/AI/constant/prompts.ts
+++ b/js/app/packages/core/component/AI/constant/prompts.ts
@@ -1,6 +1,5 @@
 import { useUserContext } from '@core/context/user';
 import { useInstructionsMdTextQuery } from '@queries/storage/instructions-md';
-import { createMemo } from 'solid-js';
 
 const ABOUT_MACRO = `
 Macro is an AI workspace with all the latest models and built-in editors for pdfs, docs, notes, images, diagrams, chats and more. Macro is like ChatGPT but you can do all your work inside it+


### PR DESCRIPTION
Because the additionalContext hook was being called top level and returning a memo with eagerly evaluated the instructionsMd query. We where blocking first render on the fetch of the instructions md content.
