### PR TITLE
fix(email-service): Thread scrolling behaviour

### DIFF
--- a/js/app/packages/block-email/component/Email.tsx
+++ b/js/app/packages/block-email/component/Email.tsx
@@ -136,24 +136,37 @@ function EmailContent(props: EmailViewProps) {
 
     setIsScrollingToMessage(true);
 
-    const success = scrollToMessage(messageId, messages, container, {
-      behavior: opts.behavior,
-      reversed: true,
-    });
+    // Wait for layout to complete before scrolling
+    // Double rAF ensures the browser has painted and layout is stable
+    const doScroll = () => {
+      // Check if container has been laid out
+      if (container.scrollHeight === 0) {
+        requestAnimationFrame(doScroll);
+        return;
+      }
 
-    if (!success) {
-      setIsScrollingToMessage(false);
-      return false;
-    }
+      const success = scrollToMessage(messageId, messages, container, {
+        behavior: opts.behavior,
+        reversed: true,
+      });
 
-    if (context.messages.targetMessageID() === messageId) {
-      setTimeout(() => {
-        context.messages.setTargetMessageID(undefined);
-      }, TARGET_MESSAGE_HIGHLIGHT_MS);
-    }
+      if (!success) {
+        setIsScrollingToMessage(false);
+        return;
+      }
 
-    // Clear scrolling flag after animation
-    setTimeout(() => setIsScrollingToMessage(false), SCROLL_ANIMATION_MS);
+      if (context.messages.targetMessageID() === messageId) {
+        setTimeout(() => {
+          context.messages.setTargetMessageID(undefined);
+        }, TARGET_MESSAGE_HIGHLIGHT_MS);
+      }
+
+      // Clear scrolling flag after animation
+      setTimeout(() => setIsScrollingToMessage(false), SCROLL_ANIMATION_MS);
+    };
+
+    // Use double requestAnimationFrame to ensure layout is complete
+    requestAnimationFrame(() => requestAnimationFrame(doScroll));
 
     return true;
   };


### PR DESCRIPTION
## Summary
This PR addresses two issues:

1. **Email thread scrolling fix** - Fixed an issue where scrolling to a specific message in an email thread sometimes wouldn't work

## Changes

### Email Thread Scrolling
Fixed a race condition where `scrollIntoView` was being called before the container element had completed its layout (dimensions were all zeros). The scroll operation would fail because there was effectively nothing to scroll to.

**Solution:** Implemented a double `requestAnimationFrame` pattern to ensure the browser has completed both layout and paint phases before attempting to scroll. Added a fallback check that continues to wait if the container's `scrollHeight` is still 0.
