### PR TITLE
fix(email-service): Always call /seen endpoint when opening thread

### DIFF
--- a/js/app/packages/notifications/components/DebouncedNotificationReadMarker.tsx
+++ b/js/app/packages/notifications/components/DebouncedNotificationReadMarker.tsx
@@ -1,6 +1,4 @@
 import type { Entity } from '@core/types';
-import { queryClient } from '@queries/client';
-import { emailKeys } from '@queries/email/keys';
 import { useMarkThreadAsSeenMutation } from '@queries/email/thread';
 import { onMount } from 'solid-js';
 import {


### PR DESCRIPTION
Always call the endpoint, even if the thread has already been seen, as the endpoint tracks opens for `last_viewed`.