### PR TITLE
Enhance Cmd+Escape hotkey to navigate home when not in split

### DIFF
--- a/js/app/packages/app/component/split-layout/registerSplitHotkeys.ts
+++ b/js/app/packages/app/component/split-layout/registerSplitHotkeys.ts
@@ -47,13 +47,21 @@ export function registerSplitHotkeys(args: {
   registerHotkey({
     scopeId: splitHotkeyScope,
     hotkey: 'cmd+escape',
-    condition: () => getSplitCount() > 1,
-    description: `Close split`,
+    condition: () => getSplitCount() > 1 || isNotUnifiedList(),
+    description: () => (getSplitCount() > 1 ? 'Close split' : 'Go home'),
     keyDownHandler: () => {
-      closeSplit();
+      if (getSplitCount() > 1) {
+        closeSplit();
+      } else {
+        replaceSplit({
+          content: { type: 'component', id: 'unified-list' },
+          referredFrom: 'hotkey',
+        });
+      }
       return true;
     },
     hotkeyToken: TOKENS.split.close,
+    runWithInputFocused: true,
   });
 
   // Spotlight (maximize split) - legacy binding.


### PR DESCRIPTION
## Summary
Enhanced the Cmd+Escape hotkey behavior to serve dual purposes: closing splits when multiple splits are open, and navigating to the unified list (home) when in a single split view.

## Key Changes
- Updated the hotkey condition to trigger in both split and non-split scenarios (`getSplitCount() > 1 || isNotUnifiedList()`)
- Made the hotkey description dynamic, showing "Close split" or "Go home" based on context
- Added conditional logic in the key handler to either close the split or navigate to the unified list
- Enabled `runWithInputFocused` flag to allow the hotkey to work even when input fields are focused

## Implementation Details
- The hotkey now checks the split count at runtime and executes the appropriate action
- When not in a split view, it replaces the current split with the unified-list component
- The `referredFrom: 'hotkey'` metadata tracks that this navigation originated from a keyboard shortcut
- This provides a consistent escape/home navigation pattern across different view states

https://claude.ai/code/session_013YMiTNAE3kaWk9utEcp2eK