### PR TITLE
style(email): Don't anchor subject on mobile

### DIFF
--- a/js/app/packages/block-email/component/Email.tsx
+++ b/js/app/packages/block-email/component/Email.tsx
@@ -24,6 +24,7 @@ import {
   Switch,
   untrack,
 } from 'solid-js';
+import { isMobile } from '@core/mobile/isMobile';
 import { isScrollingToMessage } from '../signal/scrollState';
 import { registerEmailHotkeys } from '../util/emailHotkeys';
 import { scrollToMessage } from '../util/scrollToMessage';
@@ -468,22 +469,25 @@ function EmailContent(props: EmailViewProps) {
                 class="w-full flex-1 flex flex-col items-center overflow-hidden"
                 ref={context.registerMessagesContainer}
               >
-                <div class="shrink-0 w-full flex justify-center">
-                  <div
-                    class="macro-message-width w-full border-b"
-                    classList={{
-                      'border-edge-muted/50': isScrolled(),
-                      'border-transparent': !isScrolled(),
-                    }}
-                  >
-                    <h1 class="text-3xl font-semibold text-ink pt-3 pb-4">
-                      {props.title}
-                    </h1>
+                <Show when={!isMobile()}>
+                  <div class="shrink-0 w-full flex justify-center">
+                    <div
+                      class="macro-message-width w-full border-b"
+                      classList={{
+                        'border-edge-muted/50': isScrolled(),
+                        'border-transparent': !isScrolled(),
+                      }}
+                    >
+                      <h1 class="text-3xl font-semibold text-ink pt-3 pb-4">
+                        {props.title}
+                      </h1>
+                    </div>
                   </div>
-                </div>
+                </Show>
                 <MessageList
                   initialLoadComplete={context.initialLoadComplete()}
                   onScrollPositionChange={handleScrollPositionChange}
+                  title={props.title}
                 />
                 <CustomScrollbar
                   reverse

--- a/js/app/packages/block-email/component/MessageList.tsx
+++ b/js/app/packages/block-email/component/MessageList.tsx
@@ -1,12 +1,14 @@
 import { useEmailContext } from '@block-email/component/EmailContext';
 import { isScrollingToMessage } from '@block-email/signal/scrollState';
 import { StaticMarkdownContext } from '@core/component/LexicalMarkdown/component/core/StaticMarkdown';
-import { createMemo, createSelector, Index } from 'solid-js';
+import { isMobile } from '@core/mobile/isMobile';
+import { createMemo, createSelector, Index, Show } from 'solid-js';
 import { MessageContainer } from './MessageContainer';
 
 interface MessageListProps {
   initialLoadComplete: boolean;
   onScrollPositionChange?: (scrollFromTop: number) => void;
+  title?: string;
 }
 
 export function MessageList(props: MessageListProps) {
@@ -112,6 +114,15 @@ export function MessageList(props: MessageListProps) {
           }}
         </Index>
       </StaticMarkdownContext>
+      <Show when={isMobile() && props.title}>
+        <div class="shrink-0 w-full flex justify-center pb-4">
+          <div class="macro-message-width w-full">
+            <h1 class="text-3xl font-semibold text-ink pt-1 pb-4">
+              {props.title}
+            </h1>
+          </div>
+        </div>
+      </Show>
     </div>
   );
 }


### PR DESCRIPTION
Don't anchor email subject to the top of the screen on mobile. Takes up too much room.