### PR TITLE
fix(email): Scrolling issue

### DIFF
--- a/js/app/packages/block-email/component/Email.tsx
+++ b/js/app/packages/block-email/component/Email.tsx
@@ -264,7 +264,7 @@ function EmailContent(props: EmailViewProps) {
     );
   }
 
-  // If there is a focused message id, but it does not currently exist in the message list, it is because the user has just sent a message. When it does come into existence, we want to scroll to the bottom
+  // If there is a focused message id, but it does not currently exist in the message list, it is because the user has just sent a message. When it does come into existence, we want to scroll to the bottom.
   createEffect((prev: boolean | undefined) => {
     const currentFocusedId = context.messages.focusedID();
     const messages = context.messages.list();


### PR DESCRIPTION
## Fix email view scroll position reset when marking thread as seen

### Problem
When marking an email thread as seen, the email view would unexpectedly reset its scroll position back to the top. This made for a frustrating user experience when reading through longer email threads.

### Cause
The `threadSeenOnMutate` function was updating the thread messages cache and invalidating it on success. This triggered React Suspense boundaries, causing the email view component to unmount and remount, which reset the scroll position.

### Solution
Removed the thread messages cache updates and invalidation since the `is_read` property isn't actually used in the email view—it's only needed for the soup/list view. Now we only update the soup queries optimistically, avoiding the Suspense trigger entirely.