### PR TITLE
fix(search): Don't populate spam/trash email messages

### DIFF
--- a/rust/cloud-storage/Cargo.lock
+++ b/rust/cloud-storage/Cargo.lock
@@ -7601,6 +7601,7 @@ dependencies = [
  "mention_utils",
  "model",
  "model_file_type",
+ "models_email",
  "models_opensearch",
  "models_search",
  "nom 8.0.0",

--- a/rust/cloud-storage/email_service/src/pubsub/inbox_sync/operations/shared.rs
+++ b/rust/cloud-storage/email_service/src/pubsub/inbox_sync/operations/shared.rs
@@ -6,18 +6,29 @@ use sqs_client::search::email::EmailMessage;
 use std::result;
 use uuid::Uuid;
 
-/// Notify search that a message was upserted
+/// Notify search about a message change. If the message is spam or trash, it will be removed from
+/// search. Otherwise, it will be upserted.
 #[tracing::instrument(skip(ctx, link, message_db_id))]
 pub async fn notify_search(
     ctx: &PubSubContext,
     link: &link::Link,
     message_db_id: Uuid,
+    is_spam_or_trash: bool,
 ) -> result::Result<(), ProcessingError> {
-    ctx.sqs_client
-        .send_message_to_search_event_queue(SearchQueueMessage::ExtractEmailMessage(EmailMessage {
+    let message = if is_spam_or_trash {
+        SearchQueueMessage::RemoveEmailMessage(EmailMessage {
             message_id: message_db_id.to_string(),
             macro_user_id: link.macro_id.to_string(),
-        }))
+        })
+    } else {
+        SearchQueueMessage::ExtractEmailMessage(EmailMessage {
+            message_id: message_db_id.to_string(),
+            macro_user_id: link.macro_id.to_string(),
+        })
+    };
+
+    ctx.sqs_client
+        .send_message_to_search_event_queue(message)
         .await
         .inspect_err(
             |e| tracing::error!(error = ?e, "failed to send message to search extractor queue"),

--- a/rust/cloud-storage/email_service/src/pubsub/inbox_sync/operations/update_labels.rs
+++ b/rust/cloud-storage/email_service/src/pubsub/inbox_sync/operations/update_labels.rs
@@ -152,7 +152,13 @@ pub async fn update_labels(
     }
 
     if has_label_changes {
-        notify_search(ctx, link, db_message.db_id).await?;
+        let is_spam_or_trash = gmail_message_labels.iter().any(|label| {
+            label == service::label::system_labels::SPAM
+                || label == service::label::system_labels::TRASH
+        });
+
+        notify_search(ctx, link, db_message.db_id, is_spam_or_trash).await?;
+
         // tell FE to refresh user's inbox
         cg_refresh_email(
             &ctx.connection_gateway_client,

--- a/rust/cloud-storage/email_service/src/pubsub/inbox_sync/operations/upsert_message.rs
+++ b/rust/cloud-storage/email_service/src/pubsub/inbox_sync/operations/upsert_message.rs
@@ -19,7 +19,7 @@ use models_email::email::service::message::SimpleMessage;
 use models_email::gmail::inbox_sync::{InboxSyncOperation, UpsertMessagePayload};
 use models_email::gmail::operations::GmailApiOperation;
 use models_email::service::attachment::{AttachmentUploadArgs, AttachmentUploadDestination};
-use models_email::service::message::Message;
+use models_email::service::message::{Message, is_spam_or_trash};
 use models_email::service::pubsub::{DetailedError, FailureReason, ProcessingError};
 use std::collections::HashSet;
 use std::result;
@@ -76,6 +76,7 @@ pub async fn upsert_message(
     let provider_thread_id = message.provider_thread_id.clone().unwrap();
 
     let is_sent = message.is_sent;
+    let is_spam_or_trash = is_spam_or_trash(&message);
 
     let sender_email = message
         .from
@@ -185,7 +186,7 @@ pub async fn upsert_message(
     )
     .await?;
 
-    notify_search(ctx, link, message_db_id).await?;
+    notify_search(ctx, link, message_db_id, is_spam_or_trash).await?;
 
     // trigger FE inbox refresh
     cg_refresh_email(

--- a/rust/cloud-storage/search_processing_service/Cargo.toml
+++ b/rust/cloud-storage/search_processing_service/Cargo.toml
@@ -45,6 +45,7 @@ macro_user_id = { path = "../macro_user_id" }
 macro_uuid = { path = "../macro_uuid" }
 mention_utils = { path = "../mention_utils" }
 model = { path = "../model" }
+models_email = { path = "../models_email" }
 model_file_type = { path = "../model_file_type" }
 models_opensearch = { path = "../models_opensearch" }
 models_search = { path = "../models_search" }

--- a/rust/cloud-storage/search_processing_service/src/process/email/upsert.rs
+++ b/rust/cloud-storage/search_processing_service/src/process/email/upsert.rs
@@ -1,6 +1,7 @@
 use anyhow::Context;
 use chrono::Utc;
 use email_service_client::EmailServiceClient;
+use models_email::service::label::system_labels;
 use opensearch_client::{
     OpensearchClient, date_format::EpochSeconds, upsert::email::UpsertEmailArgs,
 };
@@ -15,6 +16,13 @@ pub async fn process_upsert_message(
         .get_search_message_by_id_internal(&upsert_email_message.message_id)
         .await
         .context("failed to get message info")?;
+
+    // don't insert spam or trash messages
+    if message_info.labels.iter().any(|label| {
+        label.provider_id == system_labels::SPAM || label.provider_id == system_labels::TRASH
+    }) {
+        return Ok(());
+    }
 
     let content = if let Some(content) = message_info.body_parsed_linkless {
         content
@@ -106,6 +114,14 @@ pub async fn process_upsert_thread_message(
         let mut upsert_email_message_args = Vec::new();
 
         for message in messages {
+            // don't insert spam or trash messages
+            if message.labels.iter().any(|label| {
+                label.provider_id == system_labels::SPAM
+                    || label.provider_id == system_labels::TRASH
+            }) {
+                continue;
+            }
+
             if let Some(content) = message.body_parsed_linkless {
                 let sent_at = message
                     .internal_date_ts


### PR DESCRIPTION
Adding checks to both email-service and sps to ensure spam/trash messages don't get populated in OS.

Adding `models_email` dependency to SPS, which it already had as a transitive dependency.