### PR TITLE
fix: force mount hover card open

### DIFF
--- a/js/app/packages/core/component/HoverCard.tsx
+++ b/js/app/packages/core/component/HoverCard.tsx
@@ -65,9 +65,15 @@ export function HoverCard(props: HoverCardComponentProps) {
   });
 
   const handleOpenChange = (open: boolean) => {
+    if (!open && nestedOpenCount() > 0) {
+      return;
+    }
+
     setIsHoverCardOpen(open);
     props.onOpenChange?.(open);
   };
+
+  const shouldForceMount = () => nestedOpenCount() > 0;
 
   return (
     <KobalteHoverCard
@@ -83,7 +89,7 @@ export function HoverCard(props: HoverCardComponentProps) {
       gutter={props.gutter ?? 8}
       open={isHoverCardOpen()}
       onOpenChange={handleOpenChange}
-      forceMount={nestedOpenCount() > 0}
+      forceMount={shouldForceMount()}
     >
       <KobalteHoverCard.Trigger as="span" disabled={props.disabled}>
         {props.trigger}


### PR DESCRIPTION
parent cards now stay truly open (not just visually mounted) as long as any child is open eliminating the race condition with close delay                                                                   
                                                                                                
