### PR TITLE
chore: remove api version from service calls

### DIFF
--- a/js/app/packages/macro-entity/src/queries/project.ts
+++ b/js/app/packages/macro-entity/src/queries/project.ts
@@ -37,8 +37,7 @@ const fetchProjectData = async (
   if (!apiToken) throw new Error('No API token provided');
 
   const dssHost = SERVER_HOSTS['document-storage-service'];
-  const apiVersion = 'v2';
-  const url = `${dssHost}/${apiVersion}/projects/preview`;
+  const url = `${dssHost}/projects/preview`;
 
   const response = await fetch(url, {
     method: 'POST',

--- a/js/app/packages/service-clients/service-cognition/client.ts
+++ b/js/app/packages/service-clients/service-cognition/client.ts
@@ -17,7 +17,6 @@ import type { DocumentTextPart } from '@service-cognition/generated/schemas/docu
 import { uuid } from 'short-uuid';
 import { waitExtractionStatus } from './extraction';
 import type { CreateChatRequest } from './generated/schemas/createChatRequest';
-import { DocumentCognitionServiceApiVersion } from './generated/schemas/documentCognitionServiceApiVersion';
 import type { EmptyResponse } from './generated/schemas/emptyResponse';
 import type { GetBatchPreviewRequest } from './generated/schemas/getBatchPreviewRequest';
 import type { GetBatchPreviewResponse } from './generated/schemas/getBatchPreviewResponse';
@@ -42,18 +41,6 @@ import {
 
 const dcsHost: string = SERVER_HOSTS['cognition-service'];
 
-const apiVersions = Object.values(
-  DocumentCognitionServiceApiVersion
-) satisfies string[];
-const latestApiVersion = apiVersions[apiVersions.length - 1];
-
-// NOTE: change this to the version you want to use, defaults to latest
-// TODO: @whutchinson98 will update this back to undefined once we've made it so v2 is the default version
-const overrideApiVersion: string | undefined = 'v2';
-
-const apiVersion = overrideApiVersion ?? latestApiVersion;
-console.log('DCS API version:', apiVersion);
-
 type WithChatId = { chat_id: string };
 type WithDocumentId = { document_id: string };
 type WithName = { name: string };
@@ -73,7 +60,7 @@ export function dcsFetch<T extends ObjectLike = never>(
 ):
   | Promise<MaybeResult<FetchWithTokenErrorCode, T>>
   | Promise<MaybeError<FetchWithTokenErrorCode>> {
-  return fetchWithToken<T>(`${dcsHost}/${apiVersion}${url}`, init);
+  return fetchWithToken<T>(`${dcsHost}/${url}`, init);
 }
 export type Success = { success: boolean };
 

--- a/js/app/packages/service-clients/service-notification/client.ts
+++ b/js/app/packages/service-clients/service-notification/client.ts
@@ -18,7 +18,6 @@ import type {
 } from './generated/schemas';
 import type { DeviceRequest } from './generated/schemas/deviceRequest';
 import type { NotificationBulkRequest } from './generated/schemas/notificationBulkRequest';
-import { NotificationServiceApiVersion } from './generated/schemas/notificationServiceApiVersion';
 import type { UserNotification } from './generated/schemas/userNotification';
 import type { UserUnsubscribe } from './generated/schemas/userUnsubscribe';
 
@@ -42,17 +41,6 @@ export type UnifiedNotification = Omit<UserNotification, 'ownerId'> & {
   new?: boolean;
 };
 
-const apiVersions = Object.values(
-  NotificationServiceApiVersion
-) satisfies string[];
-const latestApiVersion = apiVersions[apiVersions.length - 1];
-
-// NOTE: change this to the version you want to use, defaults to latest
-const overrideApiVersion: string | undefined = undefined;
-
-const apiVersion = overrideApiVersion ?? latestApiVersion;
-console.log('Notification Service API version:', apiVersion);
-
 export function notificationFetch(
   url: string,
   init?: SafeFetchInit
@@ -67,7 +55,7 @@ export function notificationFetch<T extends ObjectLike = never>(
 ):
   | Promise<MaybeResult<FetchWithTokenErrorCode, T>>
   | Promise<MaybeError<FetchWithTokenErrorCode>> {
-  return fetchWithToken<T>(`${notificationHost}/${apiVersion}${url}`, init);
+  return fetchWithToken<T>(`${notificationHost}/${url}`, init);
 }
 export type Success = { success: boolean };
 

--- a/js/app/packages/service-clients/service-storage/client.ts
+++ b/js/app/packages/service-clients/service-storage/client.ts
@@ -50,7 +50,6 @@ import type { DeleteCommentResponse } from './generated/schemas/deleteCommentRes
 import type { DeleteUnthreadedAnchorResponse } from './generated/schemas/deleteUnthreadedAnchorResponse';
 import type { DocumentMetadata } from './generated/schemas/documentMetadata';
 import type { DocumentPreview } from './generated/schemas/documentPreview';
-import { DocumentStorageServiceApiVersion } from './generated/schemas/documentStorageServiceApiVersion';
 import type { EditAnchorResponse } from './generated/schemas/editAnchorResponse';
 import type { EditCommentResponse } from './generated/schemas/editCommentResponse';
 import type { ExportDocumentResponse } from './generated/schemas/exportDocumentResponse';
@@ -95,18 +94,6 @@ const MINUTES_BEFORE_PRESIGNED_EXPIRES = 14;
 
 const dssHost = SERVER_HOSTS['document-storage-service'];
 
-const apiVersions = Object.values(
-  DocumentStorageServiceApiVersion
-) satisfies string[];
-const latestApiVersion = apiVersions[apiVersions.length - 1];
-
-// NOTE: change this to the version you want to use, defaults to latest
-// TODO: @whutchinson98 will update this back to undefined once we've made it so v2 is the default version
-const overrideApiVersion: string | undefined = 'v2';
-
-const apiVersion = overrideApiVersion ?? latestApiVersion;
-console.log('DSS API version:', apiVersion);
-
 export function dssFetch(
   url: string,
   init?: SafeFetchInit
@@ -121,7 +108,7 @@ export function dssFetch<T extends Record<string, any> = never>(
 ):
   | Promise<MaybeResult<FetchWithTokenErrorCode, T>>
   | Promise<MaybeError<FetchWithTokenErrorCode>> {
-  return fetchWithToken<T>(`${dssHost}/${apiVersion}${url}`, init);
+  return fetchWithToken<T>(`${dssHost}/${url}`, init);
 }
 
 export type Success = {


### PR DESCRIPTION
We have no plans to use this api versioning system and having it is extra middleware we hit per request.