### PR TITLE
fix(hotkeys): leaking scoped commands

### DIFF
--- a/js/app/packages/core/hotkey/hotkeys.ts
+++ b/js/app/packages/core/hotkey/hotkeys.ts
@@ -38,6 +38,7 @@ import {
   getScopeId,
   normalizeEventKeyPress,
   registerScope,
+  removeCommandsFromTokenMap,
   removeScope,
   runCommand,
 } from './utils';
@@ -247,18 +248,9 @@ export function registerHotkey(
     dispose: () => {
       // Remove from hotkey token map if it exists
       if (hotkeyToken) {
-        setHotkeyTokenMap((prev) => {
-          const newMap = new Map(prev);
-          const existingCommands = newMap.get(hotkeyToken) || [];
-          // Filter out this specific command instance
-          const newCommands = existingCommands.filter((c) => c !== command);
-          if (newCommands.length > 0) {
-            newMap.set(hotkeyToken, newCommands);
-          } else {
-            newMap.delete(hotkeyToken);
-          }
-          return newMap;
-        });
+        setHotkeyTokenMap((prev) =>
+          removeCommandsFromTokenMap(prev, [command])
+        );
       }
 
       // Remove this specific command from scope's hotkey handlers

--- a/js/app/packages/core/hotkey/utils.test.ts
+++ b/js/app/packages/core/hotkey/utils.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from 'vitest';
+import { removeCommandsFromTokenMap } from './utils';
+import type { HotkeyCommand } from './types';
+import type { HotkeyToken } from './tokens';
+
+const makeCommand = (token: HotkeyToken | undefined): HotkeyCommand =>
+  ({
+    hotkeyToken: token,
+    scopeId: 'test-scope',
+  }) as HotkeyCommand;
+
+describe('removeCommandsFromTokenMap', () => {
+  test('removes command from token map', () => {
+    const cmd1 = makeCommand('hotkey:test' as HotkeyToken);
+    const cmd2 = makeCommand('hotkey:test' as HotkeyToken);
+    const map = new Map([[cmd1.hotkeyToken!, [cmd1, cmd2]]]);
+
+    const result = removeCommandsFromTokenMap(map, [cmd1]);
+
+    expect(result.get(cmd1.hotkeyToken!)).toEqual([cmd2]);
+  });
+
+  test('deletes entry when last command removed', () => {
+    const cmd = makeCommand('hotkey:test' as HotkeyToken);
+    const map = new Map([[cmd.hotkeyToken!, [cmd]]]);
+
+    const result = removeCommandsFromTokenMap(map, [cmd]);
+
+    expect(result.has(cmd.hotkeyToken!)).toBe(false);
+  });
+
+  test('returns same map reference when nothing to remove', () => {
+    const map = new Map<HotkeyToken, HotkeyCommand[]>();
+
+    const result = removeCommandsFromTokenMap(map, []);
+
+    expect(result).toBe(map);
+  });
+
+  test('returns same map reference when command not found', () => {
+    const cmd1 = makeCommand('hotkey:test' as HotkeyToken);
+    const cmd2 = makeCommand('hotkey:test' as HotkeyToken);
+    const map = new Map([[cmd1.hotkeyToken!, [cmd1]]]);
+
+    const result = removeCommandsFromTokenMap(map, [cmd2]);
+
+    expect(result).toBe(map);
+  });
+
+  test('skips commands without hotkeyToken', () => {
+    const cmdWithToken = makeCommand('hotkey:test' as HotkeyToken);
+    const cmdWithoutToken = makeCommand(undefined);
+    const map = new Map([[cmdWithToken.hotkeyToken!, [cmdWithToken]]]);
+
+    const result = removeCommandsFromTokenMap(map, [cmdWithoutToken]);
+
+    expect(result).toBe(map);
+    expect(result.get(cmdWithToken.hotkeyToken!)).toEqual([cmdWithToken]);
+  });
+
+  test('removes multiple commands with different tokens', () => {
+    const cmd1 = makeCommand('hotkey:a' as HotkeyToken);
+    const cmd2 = makeCommand('hotkey:b' as HotkeyToken);
+    const cmd3 = makeCommand('hotkey:a' as HotkeyToken);
+    const map = new Map<HotkeyToken, HotkeyCommand[]>([
+      [cmd1.hotkeyToken!, [cmd1, cmd3]],
+      [cmd2.hotkeyToken!, [cmd2]],
+    ]);
+
+    const result = removeCommandsFromTokenMap(map, [cmd1, cmd2]);
+
+    expect(result.get('hotkey:a' as HotkeyToken)).toEqual([cmd3]);
+    expect(result.has('hotkey:b' as HotkeyToken)).toBe(false);
+  });
+});

--- a/js/app/packages/core/hotkey/utils.ts
+++ b/js/app/packages/core/hotkey/utils.ts
@@ -28,6 +28,41 @@ import type {
   ValidHotkey,
 } from './types';
 
+/**
+ * Removes hotkey commands from the global token map when their scope is destroyed.
+ */
+export function removeCommandsFromTokenMap(
+  tokenMap: Map<HotkeyToken, HotkeyCommand[]>,
+  commands: HotkeyCommand[]
+): Map<HotkeyToken, HotkeyCommand[]> {
+  if (commands.length === 0) return tokenMap;
+
+  let newMap: Map<HotkeyToken, HotkeyCommand[]> | undefined;
+
+  for (const command of commands) {
+    if (!command.hotkeyToken) continue;
+
+    const currentMap = newMap ?? tokenMap;
+    const existingCommands = currentMap.get(command.hotkeyToken);
+    if (!existingCommands) continue;
+
+    const filtered = existingCommands.filter((c) => c !== command);
+    if (filtered.length === existingCommands.length) continue;
+
+    if (!newMap) {
+      newMap = new Map(tokenMap);
+    }
+
+    if (filtered.length > 0) {
+      newMap.set(command.hotkeyToken, filtered);
+    } else {
+      newMap.delete(command.hotkeyToken);
+    }
+  }
+
+  return newMap ?? tokenMap;
+}
+
 type GetHotkeyCommandOptions = {
   /**
    * The property to sort by. Defaults to 'handlerPriority'.
@@ -170,36 +205,16 @@ export function removeScope(scopeId: string) {
     return;
   }
 
-  const commandsToRemove: HotkeyCommand[] = [];
-  scope.hotkeyCommands.forEach((commands) => {
-    commandsToRemove.push(...commands);
-  });
-  commandsToRemove.push(...scope.unkeyedCommands);
+  // Collect all commands from this scope to remove from the global token map
+  const commandsToRemove = [
+    ...Array.from(scope.hotkeyCommands.values()).flat(),
+    ...scope.unkeyedCommands,
+  ];
 
   if (commandsToRemove.length > 0) {
-    setHotkeyTokenMap((prev) => {
-      const newMap = new Map(prev);
-      let modified = false;
-
-      for (const command of commandsToRemove) {
-        if (command.hotkeyToken) {
-          const existingCommands = newMap.get(command.hotkeyToken);
-          if (existingCommands) {
-            const filtered = existingCommands.filter((c) => c !== command);
-            if (filtered.length !== existingCommands.length) {
-              modified = true;
-              if (filtered.length > 0) {
-                newMap.set(command.hotkeyToken, filtered);
-              } else {
-                newMap.delete(command.hotkeyToken);
-              }
-            }
-          }
-        }
-      }
-
-      return modified ? newMap : prev;
-    });
+    setHotkeyTokenMap((prev) =>
+      removeCommandsFromTokenMap(prev, commandsToRemove)
+    );
   }
 
   scope.hotkeyCommands.clear();


### PR DESCRIPTION
commands would infintely accumulate even when their hotkey scope was cleaned up. These commands would capture refs to detached dom nodes which in turn held references to data preventing it from being gc'd
