### PR TITLE
fix(core): service client urls

### DIFF
--- a/js/app/packages/service-clients/service-cognition/client.ts
+++ b/js/app/packages/service-clients/service-cognition/client.ts
@@ -60,7 +60,7 @@ export function dcsFetch<T extends ObjectLike = never>(
 ):
   | Promise<MaybeResult<FetchWithTokenErrorCode, T>>
   | Promise<MaybeError<FetchWithTokenErrorCode>> {
-  return fetchWithToken<T>(`${dcsHost}/${url}`, init);
+  return fetchWithToken<T>(`${dcsHost}${url}`, init);
 }
 export type Success = { success: boolean };
 

--- a/js/app/packages/service-clients/service-notification/client.ts
+++ b/js/app/packages/service-clients/service-notification/client.ts
@@ -55,7 +55,7 @@ export function notificationFetch<T extends ObjectLike = never>(
 ):
   | Promise<MaybeResult<FetchWithTokenErrorCode, T>>
   | Promise<MaybeError<FetchWithTokenErrorCode>> {
-  return fetchWithToken<T>(`${notificationHost}/${url}`, init);
+  return fetchWithToken<T>(`${notificationHost}${url}`, init);
 }
 export type Success = { success: boolean };
 

--- a/js/app/packages/service-clients/service-storage/client.ts
+++ b/js/app/packages/service-clients/service-storage/client.ts
@@ -108,7 +108,7 @@ export function dssFetch<T extends Record<string, any> = never>(
 ):
   | Promise<MaybeResult<FetchWithTokenErrorCode, T>>
   | Promise<MaybeError<FetchWithTokenErrorCode>> {
-  return fetchWithToken<T>(`${dssHost}/${url}`, init);
+  return fetchWithToken<T>(`${dssHost}${url}`, init);
 }
 
 export type Success = {


### PR DESCRIPTION
This pr https://github.com/macro-inc/macro/commit/747e2521fe103e3f252aa54effdf5f9b38926988 accidentally added a extra `/` to three service clients
