### PR TITLE
feat: delete account button

### DIFF
--- a/js/app/packages/app/component/settings/Account.tsx
+++ b/js/app/packages/app/component/settings/Account.tsx
@@ -6,6 +6,9 @@ import { DeprecatedTextButton } from '@core/component/DeprecatedTextButton';
 import { useHasPaidAccess } from '@core/auth/license';
 import { UserIcon } from '@core/component/UserIcon';
 import { useLogout } from '@core/auth/logout';
+import { isNativeMobilePlatform } from '@core/mobile/isNativeMobilePlatform';
+import { Modal, Overlay, Content, Header, Message, ButtonBar } from '@core/component/Modal';
+import { Button } from '@ui/components/Button';
 import {
   blockNameToFileExtensions,
   blockNameToMimeTypes,
@@ -69,6 +72,8 @@ export function Account() {
   const { showPaywall } = usePaywallState();
   const hasPaidAccess = useHasPaidAccess();
   const [showEmailModal, setShowEmailModal] = createSignal<boolean>(false);
+  const [showDeleteModal, setShowDeleteModal] = createSignal<boolean>(false);
+  const [showDeleteConfirmModal, setShowDeleteConfirmModal] = createSignal<boolean>(false);
 
   const { connect: connectEmail, disconnect: disconnectEmail } = useEmailLinks();
 
@@ -104,6 +109,12 @@ export function Account() {
   };
 
   const logoutHandler = () => {
+    let redirectUrl = window.location.origin;
+    logout(redirectUrl);
+  };
+
+  const deleteAccountHandler = async () => {
+    await authServiceClient.deleteUser();
     let redirectUrl = window.location.origin;
     logout(redirectUrl);
   };
@@ -264,15 +275,61 @@ export function Account() {
           </div>
         </Show>
         <NotificationToggle />
-        <div class="flex flex-row justify-between items-center border-t border-edge pt-2">
+        <div class="flex flex-row justify-between items-center border-t border-edge pt-4">
           <div
-            class="mb-4.5 flex flex-row justify-start items-center gap-1"
+            class="mb-4 flex flex-row justify-start items-center gap-1"
             onClick={logoutHandler}
           >
             <Logout class="w-4 h-4" />
             <div class="text-sm select-none">Logout</div>
           </div>
           </div>
+        <Show when={isNativeMobilePlatform()}>
+          <div class="border-t border-edge pt-4">
+            <Button variant="destructive" onClick={() => setShowDeleteModal(true)}>
+              Delete Account
+            </Button>
+            <Modal open={showDeleteModal()} onOpenChange={setShowDeleteModal}>
+              <Overlay />
+              <Content>
+                <Header>Delete Account</Header>
+                <Message>
+                  Are you sure you want to delete your account? This action is
+                  permanent and cannot be undone.
+                </Message>
+                <ButtonBar>
+                  <Button variant="secondary" onClick={() => setShowDeleteModal(false)}>
+                    Cancel
+                  </Button>
+                  <Button variant="destructive" onClick={() => {
+                    setShowDeleteModal(false);
+                    setShowDeleteConfirmModal(true);
+                  }}>
+                    Delete
+                  </Button>
+                </ButtonBar>
+              </Content>
+            </Modal>
+            <Modal open={showDeleteConfirmModal()} onOpenChange={setShowDeleteConfirmModal}>
+              <Overlay />
+              <Content>
+                <Header>Are you absolutely sure?</Header>
+                <Message>
+                  This will permanently delete your account and all associated
+                  data. This cannot be undone.
+                </Message>
+                <ButtonBar>
+                  <Button variant="secondary" onClick={() => setShowDeleteConfirmModal(false)}>
+                    Cancel
+                  </Button>
+                  <Button variant="destructive" onClick={deleteAccountHandler}>
+                    Delete My Account
+                  </Button>
+                </ButtonBar>
+              </Content>
+            </Modal>
+          </div>
+        </Show>
         </div>
       </div>
     </div>

--- a/js/app/packages/core/component/Modal.tsx
+++ b/js/app/packages/core/component/Modal.tsx
@@ -86,11 +86,11 @@ export function Content(props: ComponentProps<typeof Dialog.Content<'div'>>) {
   return (
     <Dialog.Content
       {...props}
-      class={`absolute z-modal
-              min-w-96 p-3
+      class={`absolute z-modal min-w-[calc(100vw-2rem)]
+              @sm:min-w-96 p-3
               bg-dialog shadow
               rounded-lg border border-edge
-              flex-col justify-start items-end inline-flex gap-3
+              flex-col justify-start inline-flex gap-3
               duration-slow
               data-open:animate-in
               data-open:fade-in-0 data-open:zoom-in-95
@@ -130,7 +130,7 @@ export function ButtonBar(props: ComponentProps<'div'>) {
   return (
     <div
       {...props}
-      class={`pt-3 justify-start items-start gap-3 inline-flex ${props.class}`}
+      class={`pt-3 justify-start items-start self-end gap-3 inline-flex ${props.class}`}
     >
       {props.children}
     </div>


### PR DESCRIPTION
Apple requires that "apps submitted to the App Store that support account creation must also let users initiate deletion of their account within the app".

On native mobile platforms, added a big red button to the settings panel to allow users to delete their account. There are two levels of confirmation dialogs to ensure that users do not do this accidentally.