### PR TITLE
fix(email): Don't create user_history row for auto-inserted attachments

### DIFF
--- a/js/app/packages/service-clients/service-storage/generated/schemas/createDocumentRequest.ts
+++ b/js/app/packages/service-clients/service-storage/generated/schemas/createDocumentRequest.ts
@@ -45,4 +45,6 @@ Will need to have a corresponding job initiated for the file beforehand. */
   projectId?: CreateDocumentRequestProjectId;
   /** The sha of the document. */
   sha: string;
+  /** Whether to add a viewed_at record for this document upon creation. */
+  skipHistory?: boolean;
 }

--- a/js/app/packages/service-clients/service-storage/generated/zod.ts
+++ b/js/app/packages/service-clients/service-storage/generated/zod.ts
@@ -984,6 +984,12 @@ export const createDocumentHandlerBody = zod.object({
     ),
   projectId: zod.string().nullish(),
   sha: zod.string().describe('The sha of the document.'),
+  skipHistory: zod
+    .boolean()
+    .optional()
+    .describe(
+      'Whether to add a viewed_at record for this document upon creation.'
+    ),
 });
 
 export const createDocumentHandlerResponse = zod.object({

--- a/js/app/packages/service-clients/service-storage/openapi.json
+++ b/js/app/packages/service-clients/service-storage/openapi.json
@@ -5136,6 +5136,10 @@
           "sha": {
             "type": "string",
             "description": "The sha of the document."
+          },
+          "skipHistory": {
+            "type": "boolean",
+            "description": "Whether to add a viewed_at record for this document upon creation."
           }
         }
       },

--- a/rust/cloud-storage/document_storage_service/src/api/documents/create_document/create_document_handler.rs
+++ b/rust/cloud-storage/document_storage_service/src/api/documents/create_document/create_document_handler.rs
@@ -94,6 +94,7 @@ pub(in crate::api) async fn create_document_handler(
             email_attachment_id: req.email_attachment_id,
             created_at: req.created_at.as_ref(),
             is_task: req.is_task,
+            skip_history: req.skip_history,
         },
     )
     .await;

--- a/rust/cloud-storage/document_storage_service/src/api/documents/create_document/create_document_v2.rs
+++ b/rust/cloud-storage/document_storage_service/src/api/documents/create_document/create_document_v2.rs
@@ -23,6 +23,7 @@ pub struct CreateDocumentParams<'a> {
     pub email_attachment_id: Option<Uuid>,
     pub created_at: Option<&'a DateTime<Utc>>,
     pub is_task: bool,
+    pub skip_history: bool,
 }
 
 /// Creates a document in the database
@@ -45,6 +46,7 @@ pub async fn create_document(
         email_attachment_id,
         created_at,
         is_task,
+        skip_history,
     } = params;
 
     let owner = owner.into_owned();
@@ -65,7 +67,7 @@ pub async fn create_document(
             project_id,
             project_name: None,
             share_permission: &share_permission,
-            skip_history: false,
+            skip_history,
             email_attachment_id,
             created_at,
             is_task,

--- a/rust/cloud-storage/document_storage_service/src/api/documents/create_task.rs
+++ b/rust/cloud-storage/document_storage_service/src/api/documents/create_task.rs
@@ -95,6 +95,7 @@ pub(in crate::api) async fn create_task_handler(
             email_attachment_id: None,
             created_at: None,
             is_task: true,
+            skip_history: false,
         },
     )
     .await;

--- a/rust/cloud-storage/email_service/src/bin/backfill_gmail_attachments/upload.rs
+++ b/rust/cloud-storage/email_service/src/bin/backfill_gmail_attachments/upload.rs
@@ -135,6 +135,7 @@ impl AttachmentProcessor {
                     created_at: Some(attachment.internal_date_ts),
                     email_attachment_id: Some(attachment.attachment_db_id),
                     is_task: false,
+                    skip_history: true,
                 },
                 &self.macro_id_destination,
             )

--- a/rust/cloud-storage/email_service/src/util/upload_attachment.rs
+++ b/rust/cloud-storage/email_service/src/util/upload_attachment.rs
@@ -289,6 +289,7 @@ async fn create_dss_document_record(
         created_at,
         email_attachment_id: Some(p.attachment_db_id),
         is_task: false,
+        skip_history: true,
     };
 
     dss_client

--- a/rust/cloud-storage/model/src/document/response/mod.rs
+++ b/rust/cloud-storage/model/src/document/response/mod.rs
@@ -230,4 +230,7 @@ pub struct CreateDocumentRequest {
     /// md.
     #[serde(default)]
     pub is_task: bool,
+    /// Whether to add a viewed_at record for this document upon creation.
+    #[serde(default)]
+    pub skip_history: bool,
 }


### PR DESCRIPTION
## Fix: Don't create user_history row for auto-inserted attachments

### Summary

Adds a `skipHistory` option to the create document endpoint to prevent automatic `viewed_at` records from being created when documents are inserted programmatically.

### Problem

When email attachments are automatically uploaded to the document storage service (either via the backfill job or during normal email sync), they were creating `user_history` records as if the user had viewed them. This polluted the user's view history with documents they never actually opened.

### Solution

- Added `skip_history: bool` field to `CreateDocumentRequest` with `#[serde(default)]` so it defaults to `false`
- Existing FE calls that don't pass `skipHistory` continue to work unchanged (history is recorded)
- Email attachment upload paths now pass `skip_history: true` to suppress history creation