### PR TITLE
fix(app): Always set login cookie on successful auth

### DIFF
--- a/js/app/packages/app/component/auth/Login.tsx
+++ b/js/app/packages/app/component/auth/Login.tsx
@@ -70,11 +70,9 @@ export function Login() {
     unsetTokenPromise();
     invalidateUserInfo();
     const userInfo = await fetchUserInfo();
-    if (
-      userInfo?.authenticated &&
-      location.state?.originalLocation &&
-      location.state.originalLocation.pathname !== location.pathname
-    ) {
+    if (userInfo?.authenticated) {
+      // Always set the login cookie when authenticated, regardless of redirect state.
+      // This ensures CloudFront can redirect logged-in users to /app on subsequent visits.
       updateCookie('login', 'true', {
         expires: oneYearFromNow,
         maxAge: 31536000, // one year in seconds


### PR DESCRIPTION
- Login.tsx: Remove conditional that only set login cookie when originalLocation existed. Now always sets the cookie when user successfully authenticates, ensuring CloudFront can redirect logged-in users to /app on subsequent visits.