### PR TITLE
seanaye/fix/conn gateway payload

### DIFF
--- a/rust/cloud-storage/notification/src/domain/models.rs
+++ b/rust/cloud-storage/notification/src/domain/models.rs
@@ -40,11 +40,13 @@ pub struct UserNotificationRow<T> {
     /// The user who owns this notification.
     pub owner_id: MacroUserIdStr<'static>,
     /// The notification ID.
+    #[serde(rename = "id")]
     pub notification_id: uuid::Uuid,
     /// The notification event type string (e.g. "channel_mention").
     /// TODO make this a new type
     pub notification_event_type: String,
     /// The entity the notification is about.
+    #[serde(flatten)]
     pub entity: Entity<'static>,
     /// Whether the notification has been sent.
     pub sent: bool,

--- a/rust/cloud-storage/notification/src/domain/models/queue_message.rs
+++ b/rust/cloud-storage/notification/src/domain/models/queue_message.rs
@@ -1,9 +1,13 @@
 use crate::domain::models::{
-    RateLimitConfig, RateLimitKey, apple::APNSPushNotification, mobile::MessageAttributes,
+    Notification, RateLimitConfig, RateLimitKey, SendNotificationRequest,
+    apple::APNSPushNotification, mobile::MessageAttributes,
 };
-use macro_user_id::user_id::MacroUserIdStr;
+use chrono::{DateTime, Utc, serde::ts_seconds_option};
+use macro_user_id::{cowlike::CowLike, user_id::MacroUserIdStr};
+use model_entity::{Entity, as_owned::IntoOwned};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+use uuid::Uuid;
 
 /// APNS push notification targets.
 #[derive(Debug, Serialize, Deserialize)]
@@ -32,11 +36,66 @@ pub struct EmailNotification<'a> {
     pub content: EmailContent,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Notif<T> {
+    /// The notification ID.
+    #[serde(rename = "id")]
+    pub(crate) notification_id: uuid::Uuid,
+    /// The notification event type string (e.g. "channel_mention").
+    /// TODO make this a new type
+    pub(crate) notification_event_type: String,
+    /// The entity the notification is about.
+    #[serde(flatten)]
+    pub(crate) entity: Entity<'static>,
+    /// Whether the notification has been sent.
+    pub(crate) sent: bool,
+    /// Whether the notification is marked as done.
+    pub(crate) done: bool,
+    /// When the notification was created.
+    #[serde(with = "ts_seconds_option")]
+    pub(crate) created_at: Option<DateTime<Utc>>,
+    /// When the notification was viewed/seen.
+    #[serde(with = "ts_seconds_option")]
+    pub(crate) viewed_at: Option<DateTime<Utc>>,
+    /// When the notification was last updated.
+    #[serde(with = "ts_seconds_option")]
+    pub(crate) updated_at: Option<DateTime<Utc>>,
+    /// When the notification was deleted.
+    #[serde(with = "ts_seconds_option")]
+    pub(crate) deleted_at: Option<DateTime<Utc>>,
+    /// Deserialized notification metadata.
+    pub(crate) notification_metadata: T,
+    /// The user who triggered the notification.
+    pub(crate) sender_id: Option<MacroUserIdStr<'static>>,
+}
+
+impl<T> Notif<T>
+where
+    T: Notification + Clone,
+{
+    pub(crate) fn clone_from_request<U>(id: Uuid, req: &SendNotificationRequest<'_, T, U>) -> Self {
+        Notif {
+            notification_id: id,
+            notification_event_type: T::TYPE_NAME.to_string(),
+            entity: req.req.notification_entity.clone().into_owned(),
+            sent: true,
+            done: false,
+            created_at: None,
+            viewed_at: None,
+            updated_at: None,
+            deleted_at: None,
+            notification_metadata: req.req.notification.clone(),
+            sender_id: req.req.sender_id.as_ref().map(|x| x.clone().into_owned()),
+        }
+    }
+}
+
 /// Connection gateway (WebSocket) notification payload.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ConnGatewayNotification<'a, T> {
     /// The notification payload to send.
-    pub notif: T,
+    pub notif: Notif<T>,
     /// The recipients to deliver to.
     pub recipients: Vec<MacroUserIdStr<'a>>,
 }

--- a/rust/cloud-storage/notification/src/domain/ports.rs
+++ b/rust/cloud-storage/notification/src/domain/ports.rs
@@ -167,7 +167,6 @@ pub trait WebSocketSender: Send + Sync + 'static {
     /// (i.e., they were online and the message was delivered).
     fn send_notifications<'a, T: Serialize + Send + Sync>(
         &self,
-        message_type: &str,
         recipients: &[MacroUserIdStr<'a>],
         notification: &T,
     ) -> impl Future<Output = Result<HashSet<MacroUserIdStr<'static>>, Report>> + Send;

--- a/rust/cloud-storage/notification/src/domain/service/egress.rs
+++ b/rust/cloud-storage/notification/src/domain/service/egress.rs
@@ -93,9 +93,7 @@ where
         mut recursion_tail: Vec<Result<DeliverySuccess, Report>>,
     ) -> Vec<Result<DeliverySuccess, Report>> {
         let result = match &node.notif {
-            NotificationChannel::ConnGateway(conn) => {
-                self.deliver_conn_gateway(message_type, conn).await
-            }
+            NotificationChannel::ConnGateway(conn) => self.deliver_conn_gateway(conn).await,
             NotificationChannel::Ios(apns) => self.deliver_ios(apns).await,
             NotificationChannel::Email(email) => self.deliver_email(email).await,
         };
@@ -116,11 +114,10 @@ where
     /// Deliver via connection gateway (WebSocket).
     async fn deliver_conn_gateway(
         &self,
-        message_type: &str,
         conn: &ConnGatewayNotification<'static, serde_json::Value>,
     ) -> Result<DeliverySuccess, Report> {
         self.websocket
-            .send_notifications(message_type, &conn.recipients, &conn.notif)
+            .send_notifications(&conn.recipients, &conn.notif)
             .await?;
         Ok(DeliverySuccess::ConnGateway)
     }

--- a/rust/cloud-storage/notification/src/domain/service/ingress.rs
+++ b/rust/cloud-storage/notification/src/domain/service/ingress.rs
@@ -6,7 +6,7 @@
 use crate::domain::models::apple::{APNSPushNotification, Aps};
 use crate::domain::models::mobile::{MessageAttributes, PushType};
 use crate::domain::models::queue_message::{
-    APNSTargets, ClearPushIdentifier, ConnGatewayNotification, EmailNotification, Node,
+    APNSTargets, ClearPushIdentifier, ConnGatewayNotification, EmailNotification, Node, Notif,
     NotificationChannel, QueueMessage,
 };
 use crate::domain::models::request::{
@@ -210,10 +210,13 @@ where
 
         // Build queue messages first so we can extract the APNS collapse key
         let mut request = request;
-        let (queue_messages, apns_collapse_key) = self.build_queue_message(&mut request).await?;
+
+        let notification_id = Uuid::now_v7();
+        let (queue_messages, apns_collapse_key) = self
+            .build_queue_message(notification_id, &mut request)
+            .await?;
 
         // Create notification in DB (with collapse key if APNS was built)
-        let notification_id = Uuid::now_v7();
         let created = self
             .repository
             .create_notification(
@@ -371,6 +374,7 @@ where
     ///   Returns `(queue_messages, apns_collapse_key)`.
     async fn build_queue_message<'a, T: Notification + Clone, U: Serialize + Send + Sync>(
         &self,
+        notification_id: Uuid,
         notification: &mut SendNotificationRequest<'a, T, U>,
     ) -> Result<(Vec<QueueMessage<'a, T, U>>, Option<String>), Report<SendNotificationError>> {
         let rate_limit = notification.req.get_rate_limit()?;
@@ -385,7 +389,7 @@ where
                 rate_limit: rate_limit.clone(),
                 content: Node {
                     notif: NotificationChannel::ConnGateway(ConnGatewayNotification {
-                        notif: notification.req.notification.clone(),
+                        notif: Notif::clone_from_request(notification_id, notification),
                         recipients: notification.req.recipient_ids.iter().cloned().collect(),
                     }),
                     on_failure: None,

--- a/rust/cloud-storage/notification/src/domain/service/test.rs
+++ b/rust/cloud-storage/notification/src/domain/service/test.rs
@@ -3,7 +3,8 @@
 use crate::domain::models::apple::APNSPushNotification;
 use crate::domain::models::mobile::NotifCollapseKey;
 use crate::domain::models::queue_message::{
-    ConnGatewayNotification, EmailContent, Node, NotificationChannel, QueueMessage, RawQueueMessage,
+    ConnGatewayNotification, EmailContent, Node, Notif, NotificationChannel, QueueMessage,
+    RawQueueMessage,
 };
 use crate::domain::models::request::{NotificationStatus, UpdateNotificationsRequest};
 use crate::domain::models::{
@@ -833,7 +834,6 @@ struct MockWebSocketSender;
 impl WebSocketSender for MockWebSocketSender {
     async fn send_notifications<'a, T: Serialize + Send + Sync>(
         &self,
-        _message_type: &str,
         _recipients: &[MacroUserIdStr<'a>],
         _notification: &T,
     ) -> Result<HashSet<MacroUserIdStr<'static>>, Report> {
@@ -934,6 +934,22 @@ fn create_egress_service<R: RateLimitPort>(
     )
 }
 
+fn create_mock_notif(meta: serde_json::Value) -> Notif<serde_json::Value> {
+    Notif {
+        notification_id: Uuid::nil(),
+        notification_event_type: "testing".to_string(),
+        entity: EntityType::Document.with_entity_str("testing"),
+        sent: false,
+        done: false,
+        created_at: None,
+        viewed_at: None,
+        updated_at: None,
+        deleted_at: None,
+        notification_metadata: meta,
+        sender_id: None,
+    }
+}
+
 #[tokio::test]
 async fn test_egress_rate_limit_exceeded() {
     let service = create_egress_service(MockRateLimiter::exceeding());
@@ -947,7 +963,7 @@ async fn test_egress_rate_limit_exceeded() {
         )),
         content: Node {
             notif: NotificationChannel::ConnGateway(ConnGatewayNotification {
-                notif: json!({"message": "Hello"}),
+                notif: create_mock_notif(json!({"message": "Hello"})),
                 recipients: vec![recipient],
             }),
             on_failure: None,
@@ -981,7 +997,8 @@ async fn test_egress_rate_limit_allowed() {
         )),
         content: Node {
             notif: NotificationChannel::ConnGateway(ConnGatewayNotification {
-                notif: json!({"message": "Hello"}),
+                notif: create_mock_notif(json!({"message": "Hello"})),
+
                 recipients: vec![recipient],
             }),
             on_failure: None,
@@ -1005,7 +1022,7 @@ async fn test_egress_no_rate_limit_configured() {
         rate_limit: None, // No rate limit configured
         content: Node {
             notif: NotificationChannel::ConnGateway(ConnGatewayNotification {
-                notif: json!({"message": "Hello"}),
+                notif: create_mock_notif(json!({"message": "Hello"})),
                 recipients: vec![recipient],
             }),
             on_failure: None,

--- a/rust/cloud-storage/notification/src/outbound/websocket.rs
+++ b/rust/cloud-storage/notification/src/outbound/websocket.rs
@@ -35,7 +35,6 @@ pub trait WebSocketGatewayOps {
     /// (i.e., users who had an active WebSocket connection).
     fn send_to_users<'a, T: Serialize + Send + Sync>(
         &self,
-        message_type: &str,
         user_ids: &[MacroUserIdStr<'a>],
         payload: &T,
     ) -> impl std::future::Future<Output = Result<HashSet<MacroUserIdStr<'static>>, Report>> + Send;
@@ -96,7 +95,6 @@ impl WebSocketGatewayOps for ConnectionGatewayClient {
     #[tracing::instrument(err, skip(self, payload))]
     async fn send_to_users<'a, T: Serialize + Send + Sync>(
         &self,
-        message_type: &str,
         user_ids: &[MacroUserIdStr<'a>],
         payload: &T,
     ) -> Result<HashSet<MacroUserIdStr<'static>>, Report> {
@@ -110,7 +108,7 @@ impl WebSocketGatewayOps for ConnectionGatewayClient {
             .collect();
 
         let body = BatchSendMessageBody {
-            message_type,
+            message_type: "notification",
             message: serde_json::to_value(payload)?,
             entities,
         };
@@ -150,12 +148,9 @@ impl<W: WebSocketGatewayOps + Send + Sync + 'static> WebSocketSender
 {
     async fn send_notifications<'a, T: Serialize + Send + Sync>(
         &self,
-        message_type: &str,
         recipients: &[MacroUserIdStr<'a>],
         notification: &T,
     ) -> Result<HashSet<MacroUserIdStr<'static>>, Report> {
-        self.gateway
-            .send_to_users(message_type, recipients, notification)
-            .await
+        self.gateway.send_to_users(recipients, notification).await
     }
 }


### PR DESCRIPTION
This PR sends an augmented data payload to conn gateway with type notification.

The payload roughly mirrors the data stored in the db for a notification, rather than just the metadata for the notif

- **send augmented data payload to conn gateway**
