### PR TITLE
fix[mobile]: invalidate notifications query

### DIFF
--- a/js/app/packages/app/component/Root.tsx
+++ b/js/app/packages/app/component/Root.tsx
@@ -35,6 +35,7 @@ import {
   prefetchUserInfo,
   useUserInfoQuery,
 } from '@queries/auth/user-info';
+import { invalidateUserNotifications } from '@queries/notification/user-notifications';
 import { MetaProvider, Title } from '@solidjs/meta';
 import {
   HashRouter,
@@ -287,6 +288,18 @@ export function ConfiguredGlobalAppStateProvider(props: ParentProps) {
     connectionGatewayWebsocket,
     onNotification
   );
+
+  if (isNativeMobilePlatform()) {
+    const onVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        invalidateUserNotifications();
+      }
+    };
+    document.addEventListener('visibilitychange', onVisibilityChange);
+    onCleanup(() =>
+      document.removeEventListener('visibilitychange', onVisibilityChange)
+    );
+  }
 
   const blockOrchestrator = createBlockOrchestrator();
 

--- a/js/app/packages/tauri/src/PushNotification.tsx
+++ b/js/app/packages/tauri/src/PushNotification.tsx
@@ -11,6 +11,7 @@ import {
   type PlatformNotificationInterface,
   PlatformNotificationProvider,
 } from '@notifications';
+import { invalidateUserNotifications } from '@queries/notification/user-notifications';
 import { notificationServiceClient } from '@service-notification/client';
 import { makePersisted } from '@solid-primitives/storage';
 import {
@@ -137,6 +138,7 @@ export function MaybePushNotificationRegistration(props: {
     if (!tapped) return;
     if (!notificationId) return;
 
+    invalidateUserNotifications();
     triggerNavigation(
       `/component/notification?notificationId=${notificationId}`
     );


### PR DESCRIPTION
We now invalidate notifications query when re-opening the app, or clicking on a push notification. 