### PR TITLE
fix(email): Draft scroll bug

### DIFF
--- a/js/app/packages/block-email/component/BaseInput.tsx
+++ b/js/app/packages/block-email/component/BaseInput.tsx
@@ -98,7 +98,11 @@ import {
 } from '../util/prepareEmailBody';
 import { convertEmailRecipientToContactInfo } from '../util/recipientConversion';
 import { getReplyTypeFromDraft } from '../util/replyType';
-import { type EmailRecipient, useEmailContext } from './EmailContext';
+import {
+  type EmailRecipient,
+  markThreadDraftSaved,
+  useEmailContext,
+} from './EmailContext';
 import { getOrInitEmailFormContext } from './EmailFormContext';
 import {
   useRemoveDraftAttachmentMutation,
@@ -392,7 +396,10 @@ export function BaseInput(props: {
   const deleteDraftMutation = useDeleteDraftMutation();
 
   function refetchThreadMessages() {
-    ctx.query.refetch();
+    const threadId = ctx.thread()?.db_id;
+    if (threadId) {
+      markThreadDraftSaved(threadId);
+    }
   }
 
   // Attach side-effect handlers on mount; they replay against current state

--- a/js/app/packages/block-email/component/EmailContext.tsx
+++ b/js/app/packages/block-email/component/EmailContext.tsx
@@ -25,6 +25,8 @@ import {
   useArchiveThreadMutation,
   useThreadQuery,
 } from '@queries/email/thread';
+import { emailKeys } from '@queries/email/keys';
+import { queryClient } from '@queries/client';
 import type {
   APIThread,
   ContactInfo,
@@ -38,11 +40,24 @@ import {
   createMemo,
   createSignal,
   type FlowProps,
+  onCleanup,
   Suspense,
   untrack,
   useContext,
 } from 'solid-js';
 import { createStore } from 'solid-js/store';
+
+/**
+ * Tracks thread IDs that had a draft saved since the last query fetch.
+ * When the EmailProvider unmounts, threads in this set have their query
+ * cache cleared so the next visit fetches fresh data (with the draft).
+ * This avoids touching the active query during draft save, which would
+ * trigger Suspense DOM detach and reset scroll position.
+ */
+const draftSavedThreadIds = new Set<string>();
+export function markThreadDraftSaved(threadId: string) {
+  draftSavedThreadIds.add(threadId);
+}
 
 export type EmailRecipient = WithCustomUserInput<'user' | 'contact'>;
 
@@ -430,6 +445,21 @@ export function EmailProvider(props: FlowProps<{ threadID: string }>) {
       messagesListRef()?.scrollBy({ top: diff });
     });
   };
+
+  // When the provider unmounts (user navigates away), clear the thread query
+  // cache if a draft was saved during this session. This ensures the next visit
+  // fetches fresh data from the server (which includes the saved draft).
+  // We can't invalidate/refetch while mounted because any query state change
+  // triggers SolidQuery's createClientSubscriber → Resource.refetch() → Suspense
+  // DOM detach, which resets scroll position.
+  onCleanup(() => {
+    if (draftSavedThreadIds.has(props.threadID)) {
+      draftSavedThreadIds.delete(props.threadID);
+      queryClient.removeQueries({
+        queryKey: emailKeys.threadMessages(props.threadID).queryKey,
+      });
+    }
+  });
 
   return (
     <Suspense>


### PR DESCRIPTION
## Problem

When composing a reply in the email thread view, the first auto-save of a draft (1 second after typing) causes the scroll position to jump to the bottom. The same issue reproduces when deleting an existing draft after a hard refresh.

## Root Cause

`executeSaveDraft()` called `refetchThreadMessages()` after each save, which called `threadQuery.refetch()`. In SolidQuery (`@tanstack/solid-query`), **any query state change** — refetch, invalidation, even `invalidateQueries` with `refetchType: 'none'` — notifies the `QueryObserver`, which triggers `createClientSubscriber` → `Resource.refetch()`. This causes SolidJS `<Suspense>` boundaries to physically detach and reattach DOM nodes (`cleanChildren` / `insertExpression`), resetting `scrollTop` to 0.

The first save is the worst because it adds a new draft message to the thread data (structural change). Subsequent saves update the draft in place, so TanStack Query's structural sharing means no effective data change and no Suspense trigger.

The `startTransition` wrapper inside `createClientSubscriber` does not prevent this — the transition commit still swaps DOM nodes when data structurally changes.

## Fix

**Don't touch the active thread query during draft save at all.** Any interaction with the query (refetch, invalidation, `setQueryData`) triggers the observer → Suspense → scroll reset chain.

Instead:

- **`BaseInput.tsx`**: `refetchThreadMessages()` now records the thread ID in a module-level `Set` via `markThreadDraftSaved()` — zero query interaction.
- **`EmailContext.tsx`**: On `onCleanup` (user navigates away), if the thread had a draft saved, `queryClient.removeQueries()` clears the cached data. The next visit triggers a fresh server fetch that includes the saved draft.

This is safe because:

- During the active session, the draft is visible through `BaseInput`'s own local state — it doesn't need the query cache.
- Other refetch triggers (send message, new email notification, archive) are unaffected and continue to work normally.