### PR TITLE
fix(soup): emailViews and importance

### DIFF
--- a/js/app/packages/app/component/next-soup/filters/filters.ts
+++ b/js/app/packages/app/component/next-soup/filters/filters.ts
@@ -304,6 +304,13 @@ export const buildDssFiltersRequest = (
     .filter((f) => ENTITY_TYPE_FILTERS.includes(f.id as EntityTypeFilters))
     .map((f) => f.id);
 
+  const isSignal = filters.some((f) => f.id === 'signal');
+  const isNoise = filters.some((f) => f.id === 'noise');
+  // if it's signal, use "inbox" emailView and importance = true
+  // if it's noise, use "inbox" emailView and importance = false
+  // if it's neither, use "all" emailView and importance = undefined
+  const email_importance = isSignal ? true : isNoise ? false : undefined;
+
   const {
     channel_filters,
     document_filters,
@@ -342,6 +349,7 @@ export const buildDssFiltersRequest = (
         (entityTypes.includes('email') || entityTypes.length === 0)
           ? []
           : [NIL_UUID]),
+      importance: email_importance,
     },
     project_filters: {
       ...project_filters,
@@ -349,6 +357,8 @@ export const buildDssFiltersRequest = (
         project_filters?.project_ids ??
         buildDefaultValue(entityTypes, ['file']),
     },
-    emailView: 'all',
+    emailView: filters.some((f) => f.id === 'signal' || f.id === 'noise')
+      ? 'inbox'
+      : 'all',
   };
 };


### PR DESCRIPTION
## Summary

Updates `Inbox` and `Other` macro views to use the `inbox` emailView and the new `importance` parameter introduced in #1316.

## Problem

A regression was causing excessive pagination when fetching emails in some inboxes. The frontend was fetching emails for both `Inbox` and `Other` views simultaneously and filtering client-side, resulting in poor performance.

## Solution

Now the frontend only fetches the emails relevant to the current view by using the `importance` parameter:

| View | emailView | importance |
|------|-----------|------------|
| Signal (Inbox) | `inbox` | `true` |
| Noise (Other) | `inbox` | `false` |
| All | `all` | `undefined` |

This significantly reduces unnecessary pagination and improves load times.