### PR TITLE
fix(soup): performance regression when selecting in preview mode

### DIFF
--- a/js/app/packages/app/component/next-soup/create-soup-state.ts
+++ b/js/app/packages/app/component/next-soup/create-soup-state.ts
@@ -99,8 +99,7 @@ export const createSoupState = <
 
   const getItemAt = (index: number): SoupEntity | undefined => data()[index];
 
-  // Navigation implementation
-  const setFocus = (index: number): NavigationResult<SoupEntity> => {
+  const calculateFocusItem = (index: number) => {
     const visibleRows = data();
     if (visibleRows.length === 0) return undefined;
 
@@ -114,8 +113,26 @@ export const createSoupState = <
     const row = visibleRows[targetIndex];
     if (!row) return undefined;
 
-    setFocusedId(row.id);
     return { item: row, index: targetIndex };
+  };
+
+  // Navigation implementation
+  const setFocus = (index: number): NavigationResult<SoupEntity> => {
+    const result = calculateFocusItem(index);
+
+    if (result) {
+      setFocusedId(result.item.id);
+    }
+
+    return result;
+  };
+
+  const peek = (offset: number) => {
+    const current = focusedIndex();
+    if (current === -1) {
+      return calculateFocusItem(offset > 0 ? 0 : data().length - 1);
+    }
+    return calculateFocusItem(current + offset);
   };
 
   const navigateBy = (offset: number): NavigationResult<SoupEntity> => {
@@ -159,12 +176,7 @@ export const createSoupState = <
       },
       toFirst: () => setFocus(0),
       toLast: () => setFocus(data().length - 1),
-      peekOffset: (offset: number) => {
-        const current = focusedIndex();
-        const next = navigateBy(offset);
-        setFocus(current);
-        return next;
-      },
+      peekOffset: peek,
     },
 
     items: {


### PR DESCRIPTION
This changes the way `peekOffset` was calculating the next position to not use `navigateBy` because it sets the focus signal which triggers any readers over and over again. Now, it just uses a helper to do the calculation