### PR TITLE
fix local logging

### DIFF
--- a/rust/cloud-storage/macro_entrypoint/src/lib.rs
+++ b/rust/cloud-storage/macro_entrypoint/src/lib.rs
@@ -65,9 +65,7 @@ impl MacroEntrypoint {
             (Environment::Local, LocalOptions { tree_tracing: None }) => {
                 tracing_subscriber::fmt()
                     .with_ansi(true)
-                    // Leaving this commented out to show we explicitly don't want with_env_filter when
-                    // running locally. RUST_LOG=trace doesn't work if you use this.
-                    // .with_env_filter(EnvFilter::from_default_env())
+                    .with_env_filter(EnvFilter::from_default_env())
                     .with_file(true)
                     .with_line_number(true)
                     .pretty()


### PR DESCRIPTION
Removing the env filter was causing weirdness when running locally not in docker. I'll investigate and fix the docker version later