### PR TITLE
feat(soup): Prefetch views

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/soup-toolbar.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-toolbar.tsx
@@ -168,24 +168,32 @@ const SoupFilters = () => {
 
     match(comb)
       .with({ id: 'signal', isActive: false }, () => {
-        setQueryFilters((prev) =>
-          applyInboxQueryFilters(removeOtherQueryFilters(prev))
-        );
-        activateFocus();
+        batch(() => {
+          setQueryFilters((prev) =>
+            applyInboxQueryFilters(removeOtherQueryFilters(prev))
+          );
+          activateFocus();
+        });
       })
       .with({ id: 'noise', isActive: false }, () => {
-        setQueryFilters((prev) =>
-          applyOtherQueryFilters(removeInboxQueryFilters(prev))
-        );
-        activateFocus();
+        batch(() => {
+          setQueryFilters((prev) =>
+            applyOtherQueryFilters(removeInboxQueryFilters(prev))
+          );
+          activateFocus();
+        });
       })
       .with({ id: 'signal', isActive: true }, () => {
-        setQueryFilters(removeInboxQueryFilters);
-        deactivateFocus();
+        batch(() => {
+          setQueryFilters(removeInboxQueryFilters);
+          deactivateFocus();
+        });
       })
       .with({ id: 'noise', isActive: true }, () => {
-        setQueryFilters(removeOtherQueryFilters);
-        deactivateFocus();
+        batch(() => {
+          setQueryFilters(removeOtherQueryFilters);
+          deactivateFocus();
+        });
       })
       .exhaustive();
   };

--- a/js/app/packages/app/component/next-soup/soup-view/soup-view-context.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-view-context.tsx
@@ -16,11 +16,22 @@ import {
 import { ENABLE_FEATURED_SEARCH_RESULTS } from '@core/constant/featureFlags';
 import { useNotificationsForEntity } from '@notifications';
 import {
+  applyInboxQueryFilters,
+  applyOtherQueryFilters,
+  removeInboxQueryFilters,
+  removeOtherQueryFilters,
+} from '@app/component/next-soup/filters/inbox-query-filters';
+import { throwOnErr } from '@core/util/maybeResult';
+import { queryClient } from '@queries/client';
+import {
   type SoupParams,
+  type SoupItemsQueryArgs,
   useSoupItemsQuery,
   type SoupItemsQueryFilters,
   type SoupBody,
 } from '@queries/soup/items';
+import { soupKeys } from '@queries/soup/keys';
+import { storageServiceClient } from '@service-storage/client';
 import {
   type Accessor,
   createContext,
@@ -160,6 +171,37 @@ export const SoupViewContextProvider: FlowComponent<
       emailView: soup.filters.isActive('signal') ? 'inbox' : 'all',
     })
   );
+
+  // Prefetch all three views (All, Inbox, Other) so they're cached when user toggles.
+  // Only re-fires when item toggles change, not Inbox/Other.
+  const baseItemFilters = createMemo(() =>
+    removeOtherQueryFilters(removeInboxQueryFilters(internalQueryFilters()))
+  );
+
+  createEffect(() => {
+    const params = soupParams();
+    const filters = baseItemFilters();
+
+    const prefetch = (body: SoupBody) => {
+      const args: SoupItemsQueryArgs = { params, body };
+      void queryClient.prefetchInfiniteQuery({
+        queryKey: soupKeys.items(args).queryKey,
+        queryFn: async (ctx) =>
+          throwOnErr(() =>
+            storageServiceClient.getSoupItems({
+              params: { cursor: ctx.pageParam },
+              body: { ...body, ...params },
+            })
+          ),
+        initialPageParam: null as string | null,
+        staleTime: 5_000,
+      });
+    };
+
+    prefetch({ ...filters, emailView: 'all' });
+    prefetch({ ...applyInboxQueryFilters(filters), emailView: 'inbox' });
+    prefetch({ ...applyOtherQueryFilters(filters), emailView: 'inbox' });
+  });
 
   const search = createSearchState({ soup, queryFilters });
 


### PR DESCRIPTION
## Prefetch soup views

Prefetch all three soup views (All, Inbox, Other) so they're already cached when the user toggles between them. Also wraps filter toggle updates in `batch()` to avoid intermediate re-renders.