### PR TITLE
demo: remove viewName prop from SoupView

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
@@ -159,7 +159,6 @@ const stateCache = new Map<
 >();
 
 interface SoupViewProps {
-  viewName: string;
   initialClientFilters?: { and?: FilterID[]; or?: FilterID[] };
   queryFilters?: SoupItemsQueryFilters;
 }
@@ -223,11 +222,6 @@ export const SoupView = (props: SoupViewProps) => {
                   'flex-1 min-w-0': narrowSearchExpanded(),
                 })}
               >
-                <Show when={!isMobile()}>
-                  <h1 class="font-medium text-ink-muted select-none text-sm shrink-0">
-                    {props.viewName}
-                  </h1>
-                </Show>
                 <Show when={!narrowSearchExpanded()}>
                   <SoupViewTabs />
                   <SoupViewCreateButton />

--- a/js/app/packages/app/component/split-layout/componentRegistry.tsx
+++ b/js/app/packages/app/component/split-layout/componentRegistry.tsx
@@ -97,7 +97,6 @@ registerComponent(
     const preset = getDefaultListViewPreset('inbox');
     return (
       <SoupView
-        viewName="Inbox"
         queryFilters={preset.queryFilters}
         initialClientFilters={preset.clientFilters}
       />
@@ -115,7 +114,6 @@ registerComponent(
     });
     return (
       <SoupView
-        viewName="Agents"
         queryFilters={preset.queryFilters}
         initialClientFilters={preset.clientFilters}
       />
@@ -129,7 +127,6 @@ registerComponent(
     const preset = getDefaultListViewPreset('mail');
     return (
       <SoupView
-        viewName="Mail"
         queryFilters={preset.queryFilters}
         initialClientFilters={preset.clientFilters}
       />
@@ -147,7 +144,6 @@ registerComponent(
     });
     return (
       <SoupView
-        viewName="Documents"
         queryFilters={preset.queryFilters}
         initialClientFilters={preset.clientFilters}
       />
@@ -165,7 +161,6 @@ registerComponent(
     });
     return (
       <SoupView
-        viewName="Tasks"
         queryFilters={preset.queryFilters}
         initialClientFilters={preset.clientFilters}
       />
@@ -179,7 +174,6 @@ registerComponent(
     const preset = getDefaultListViewPreset('channels');
     return (
       <SoupView
-        viewName="Channels"
         queryFilters={preset.queryFilters}
         initialClientFilters={preset.clientFilters}
       />
@@ -197,7 +191,6 @@ registerComponent(
     });
     return (
       <SoupView
-        viewName="Files"
         queryFilters={preset.queryFilters}
         initialClientFilters={preset.clientFilters}
       />
@@ -215,7 +208,6 @@ registerComponent(
     });
     return (
       <SoupView
-        viewName="Search"
         queryFilters={preset.queryFilters}
         initialClientFilters={preset.clientFilters}
       />


### PR DESCRIPTION
## Summary
- Remove the `viewName` prop from `SoupViewProps` interface and the `<h1>` header that displayed it
- Remove all 8 `viewName="..."` prop usages from soup view registrations in `componentRegistry.tsx`

## Test plan
- [ ] Verify all soup views (Inbox, Agents, Mail, Documents, Tasks, Channels, Files, Search) render without the view name header
- [ ] Verify no TypeScript compilation errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)