### PR TITLE
Add 'Yesterday' display and preset to date utilities

### DIFF
--- a/js/app/packages/core/util/dateParser.ts
+++ b/js/app/packages/core/util/dateParser.ts
@@ -274,11 +274,13 @@ export function parseDateString(input: string): ParsedDate | null {
 }
 
 export function formatDate(date: Date): string {
-  // Check if it's today or tomorrow for special formatting
+  // Check if it's today/tomorrow/yesterday for special formatting
   const today = new Date();
   today.setHours(0, 0, 0, 0);
   const tomorrow = new Date(today);
   tomorrow.setDate(tomorrow.getDate() + 1);
+  const yesterday = new Date(today);
+  yesterday.setDate(yesterday.getDate() - 1);
 
   const dateOnly = new Date(date);
   dateOnly.setHours(0, 0, 0, 0);
@@ -287,6 +289,8 @@ export function formatDate(date: Date): string {
     return 'Today';
   } else if (dateOnly.getTime() === tomorrow.getTime()) {
     return 'Tomorrow';
+  } else if (dateOnly.getTime() === yesterday.getTime()) {
+    return 'Yesterday';
   }
 
   // Calculate if we should show the year

--- a/js/app/packages/core/util/dateSearch/presets.ts
+++ b/js/app/packages/core/util/dateSearch/presets.ts
@@ -27,6 +27,14 @@ export const DATE_PRESETS: DatePreset[] = [
     category: 'quick',
   },
   {
+    id: 'yesterday',
+    label: 'Yesterday',
+    shortLabel: 'Yest',
+    keywords: ['yesterday', 'yest'],
+    getDate: (baseDate = new Date()) => addDays(endOfDay(baseDate), -1),
+    category: 'quick',
+  },
+  {
     id: 'in-2-days',
     label: 'In 2 days',
     shortLabel: '2d',


### PR DESCRIPTION
### Motivation
- Surface "Yesterday" consistently across date parsing/formatting and quick date presets so users can select and see yesterday as a first-class option.

### Description
- Update `formatDate` to recognize yesterday and return `"Yesterday"` when appropriate by comparing `dateOnly` to a computed `yesterday` value. 
- Add a `yesterday` entry to `DATE_PRESETS` with `shortLabel`, `keywords`, and `getDate` implemented via `addDays(endOfDay(baseDate), -1)` to enable quick selection.

### Testing
- Ran the date utilities unit tests (date parsing/formatting and presets); the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca82d7e0ec8324b7c61f8e4206a436)