### PR TITLE
Remove spacing between primary sidebar nav items

### DIFF
--- a/js/app/packages/app/component/app-sidebar/sidebar.tsx
+++ b/js/app/packages/app/component/app-sidebar/sidebar.tsx
@@ -414,7 +414,7 @@ export const AppSidebar = (props: AppSidebarProps) => {
       </div>
 
       <nav>
-        <ul class="w-full h-full px-2 flex flex-col gap-1">
+        <ul class="w-full h-full px-2 flex flex-col gap-0">
           <For each={SIDEBAR_LINKS}>
             {(link) => (
               <li class="flex items-center justify-center">


### PR DESCRIPTION
### Motivation
- Remove the vertical gap between primary sidebar navigation items so the icons/labels sit directly adjacent with no spacing.

### Description
- Replace `gap-1` with `gap-0` on the primary nav list in `js/app/packages/app/component/app-sidebar/sidebar.tsx` to remove the spacing between items.

### Testing
- Ran the type check with `bun run check`, which failed in this environment due to missing type definition packages (`@types/facebook-pixel`, `@types/gtag.js`, `vite-plugin-solid-svg/types`, `vite-plugin-solid-svg/types-component-solid`, `vite/client`, `wicg-file-system-access`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cad3e82c308324a395773d17131f09)