### PR TITLE
Narrow desktop sidebar width by 20px

### DIFF
--- a/js/app/packages/app/component/app-sidebar/sidebar.tsx
+++ b/js/app/packages/app/component/app-sidebar/sidebar.tsx
@@ -383,7 +383,7 @@ export const AppSidebar = (props: AppSidebarProps) => {
       class={cn(
         'group/sidebar h-full py-2 flex flex-col gap-0 mobile:absolute mobile:z-modal-content overflow-hidden',
         isExpanded() &&
-          'max-w-56 w-full mobile:max-w-2/3 translate-x-0 opacity-100',
+          'max-w-[204px] w-full mobile:max-w-2/3 translate-x-0 opacity-100',
         props.sidebarState === 'hidden' &&
           '-translate-x-full overflow-hidden opacity-0',
 


### PR DESCRIPTION
### Motivation
- Reduce the expanded desktop sidebar width by 20px to better match updated layout spacing.

### Description
- Replace Tailwind `max-w-56` (224px) with an explicit `max-w-[204px]` in `js/app/packages/app/component/app-sidebar/sidebar.tsx` so the expanded sidebar is narrower while preserving `mobile:max-w-2/3` for mobile behavior.

### Testing
- Ran the type check with `cd js/app && bun run check`, which failed in this environment due to missing type definition packages (e.g. `@types/facebook-pixel`, `@types/gtag.js`, `vite-plugin-solid-svg` types, `vite/client`, `wicg-file-system-access`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d415e748308324a8138b1cbd340943)