### PR TITLE
Add MP3 (audio/mpeg) playback support to media block

### DIFF
--- a/js/app/packages/block-video/component/Block.tsx
+++ b/js/app/packages/block-video/component/Block.tsx
@@ -1,13 +1,14 @@
 import { DocumentBlockContainer } from '@core/component/DocumentBlockContainer';
 import { useBlockEntityCommands } from '@app/component/next-soup/actions';
 import { toast } from 'core/component/Toast/Toast';
-import { createEffect, createSignal, Show } from 'solid-js';
+import { Show } from 'solid-js';
 import { blockData } from '../signal/blockData';
 import { ModalsProvider } from './ModalsProvider';
 import { TopBar } from './TopBar';
 
 export default function BlockVideo() {
   useBlockEntityCommands();
+
   return (
     <DocumentBlockContainer>
       <div class="w-full h-full bg-panel select-none overscroll-none overflow-hidden flex flex-col relative">
@@ -16,7 +17,7 @@ export default function BlockVideo() {
             <TopBar />
           </div>
           <div class="w-full grow-1 relative overflow-hidden">
-            <Video />
+            <Media />
           </div>
         </ModalsProvider>
       </div>
@@ -24,30 +25,32 @@ export default function BlockVideo() {
   );
 }
 
-const Video = () => {
-  const videoUrl = () => blockData()?.videoUrl;
-  const [playbackError, setPlaybackError] = createSignal<string>();
+const Media = () => {
+  const mediaUrl = () => blockData()?.videoUrl;
+  const fileType = () => blockData()?.documentMetadata?.fileType;
+  const isAudio = () => fileType() === 'mp3';
 
-  createEffect(() => {
-    const err = playbackError();
-    if (err) {
-      toast.failure(err);
-    }
-  });
+  const handleError = () => {
+    toast.failure('Media playback failed');
+  };
 
   return (
     <div class="w-full h-full flex flex-col items-center justify-center gap-3 text-ink">
-      <Show when={videoUrl()}>
-        <video
-          class="w-full h-full"
-          controls
-          autoplay
-          src={videoUrl()}
-          onError={(e) => {
-            console.error('video error', e);
-            setPlaybackError('Video playback failed');
-          }}
-        />
+      <Show when={mediaUrl()}>
+        <Show
+          when={isAudio()}
+          fallback={
+            <video
+              class="w-full h-full"
+              controls
+              autoplay
+              src={mediaUrl()}
+              onError={handleError}
+            />
+          }
+        >
+          <audio class="w-full max-w-[720px]" controls autoplay src={mediaUrl()} onError={handleError} />
+        </Show>
       </Show>
     </div>
   );

--- a/js/app/packages/block-video/definition.ts
+++ b/js/app/packages/block-video/definition.ts
@@ -30,6 +30,7 @@ export const VIDEO_MIMES: Record<
       flv: 'video/x-flv',
       f4v: 'video/mp4',
       threegp: 'video/3gpp',
+      mp3: 'audio/mpeg',
     }
   : {};
 
@@ -47,6 +48,7 @@ export const PLAYBACK_ENABLED_MIMES: Record<keyof typeof VIDEO_MIMES, boolean> =
     flv: true,
     f4v: true,
     threegp: true,
+    mp3: true,
   };
 
 export const definition = defineBlock({
@@ -87,7 +89,7 @@ export const definition = defineBlock({
         });
       } else {
         toast.failure(
-          'Video playback is not supported for this file type',
+          'Media playback is not supported for this file type',
           `File type: ${fileType}`
         );
       }


### PR DESCRIPTION
### Motivation
- Allow the existing media block to play audio files (MP3) in addition to video so users can preview audio stored in DSS without needing an external player. 

### Description
- Register `mp3` with MIME `audio/mpeg` in `VIDEO_MIMES` and enable it in `PLAYBACK_ENABLED_MIMES`. 
- Change the unsupported message from `"Video playback is not supported for this file type"` to the broader `"Media playback is not supported for this file type"`. 
- Replace the previous `Video` renderer with a `Media` renderer that detects `mp3` via `documentMetadata.fileType` and renders an `<audio>` element for MP3 files while preserving the `<video>` path for other formats, and consolidate playback error handling to a single toast. 

### Testing
- Ran `cd js/app && bunx --bun biome format --write packages/block-video/definition.ts packages/block-video/component/Block.tsx`, which failed due to `biome` fetch being blocked by registry access (`GET https://registry.npmjs.org/biome - 403`).
- Ran `cd js/app && bun run check` (TypeScript project check), which failed in this environment due to missing local type definition packages such as `@types/facebook-pixel`, `vite/client`, and others, so full typecheck could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d439e974148324aed3f547e09500b3)