### PR TITLE
feat(search): use PlainTextFormatter for channel search indexing

### DIFF
--- a/rust/cloud-storage/mention_utils/src/parse.rs
+++ b/rust/cloud-storage/mention_utils/src/parse.rs
@@ -1,3 +1,4 @@
+use macro_user_id::email::ReadEmailParts;
 use macro_user_id::user_id::BorrowedUserIdStr;
 use nom::{
     Finish, IResult, Parser,
@@ -256,6 +257,42 @@ pub trait XmlFormatter: Sized {
             acc
         });
         ReformattedXmlText(s, PhantomData)
+    }
+}
+
+/// xml formatter which converts xml tags to their plain text representation
+pub struct PlainTextFormatter;
+
+impl XmlFormatter for PlainTextFormatter {
+    fn format_plain_text(s: &str, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{s}")
+    }
+
+    fn format_link(link: &ParsedLink<'_>, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", link.text)
+    }
+
+    fn format_doc(doc: &ParsedDocumentMention<'_>, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", doc.document_name)
+    }
+
+    fn format_user(user: &ParsedUserMention<'_>, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", user.user_id.0.email_part().email_str())
+    }
+
+    fn format_contact(
+        contact: &ParsedContactMention<'_>,
+        f: &mut Formatter<'_>,
+    ) -> std::fmt::Result {
+        write!(f, "{}", contact.name)
+    }
+
+    fn format_date(date: &ParsedDateMention<'_>, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", date.display_format)
+    }
+
+    fn format_group(group: &ParsedGroupMention<'_>, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "@{}", group.group_alias)
     }
 }
 

--- a/rust/cloud-storage/model_notifications/src/metadata.rs
+++ b/rust/cloud-storage/model_notifications/src/metadata.rs
@@ -2,7 +2,7 @@ use doppleganger::Doppleganger;
 pub use invite_email::{ChannelInviteMetadata, InviteToTeamMetadata};
 use macro_user_id::cowlike::CowLike;
 use macro_user_id::{email::ReadEmailParts, user_id::MacroUserIdStr};
-use mention_utils::parse::{ParsedXmlText, XmlFormatter};
+use mention_utils::parse::{ParsedXmlText, PlainTextFormatter, XmlFormatter};
 use model_entity::Entity;
 use model_entity::EntityType;
 pub use notification::domain::models::NotificationTitle;
@@ -360,57 +360,6 @@ pub struct TaskAssignedMetadata {
     pub assigned_by: MacroUserIdStr<'static>,
     #[serde(default)]
     pub sender_profile_picture_url: Option<String>,
-}
-
-// Plain text formatter for converting XML message content to plain text for APNS payloads.
-struct PlainTextFormatter;
-
-impl XmlFormatter for PlainTextFormatter {
-    fn format_plain_text(s: &str, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", s)
-    }
-
-    fn format_link(
-        link: &mention_utils::parse::ParsedLink<'_>,
-        f: &mut std::fmt::Formatter<'_>,
-    ) -> std::fmt::Result {
-        write!(f, "{}", link.url)
-    }
-
-    fn format_doc(
-        doc: &mention_utils::parse::ParsedDocumentMention<'_>,
-        f: &mut std::fmt::Formatter<'_>,
-    ) -> std::fmt::Result {
-        write!(f, "{}", doc.document_name)
-    }
-
-    fn format_user(
-        user: &mention_utils::parse::ParsedUserMention<'_>,
-        f: &mut std::fmt::Formatter<'_>,
-    ) -> std::fmt::Result {
-        write!(f, "{}", user.user_id.0.email_part().email_str())
-    }
-
-    fn format_contact(
-        contact: &mention_utils::parse::ParsedContactMention<'_>,
-        f: &mut std::fmt::Formatter<'_>,
-    ) -> std::fmt::Result {
-        write!(f, "{}", contact.name)
-    }
-
-    fn format_date(
-        date: &mention_utils::parse::ParsedDateMention<'_>,
-        f: &mut std::fmt::Formatter<'_>,
-    ) -> std::fmt::Result {
-        write!(f, "{}", date.display_format)
-    }
-
-    fn format_group(
-        group: &mention_utils::parse::ParsedGroupMention<'_>,
-        f: &mut std::fmt::Formatter<'_>,
-    ) -> std::fmt::Result {
-        write!(f, "@{}", group.group_alias)
-    }
 }
 
 /// Helper to parse XML message content to plain text, returning None on failure.

--- a/rust/cloud-storage/search_processing_service/src/process/channel.rs
+++ b/rust/cloud-storage/search_processing_service/src/process/channel.rs
@@ -1,5 +1,5 @@
 use anyhow::Context;
-use mention_utils::parse::{NullXmlFormatter, ParsedXmlText, XmlFormatter};
+use mention_utils::parse::{ParsedXmlText, PlainTextFormatter, XmlFormatter};
 use opensearch_client::{
     OpensearchClient, date_format::EpochSeconds, upsert::channel_message::UpsertChannelMessageArgs,
 };
@@ -31,7 +31,7 @@ pub async fn process_channel_message_update(
 
     let parsed = ParsedXmlText::parse(&channel_message_info.channel_message.content)?;
 
-    let transformed_content = NullXmlFormatter::format_xml_text(parsed);
+    let transformed_content = PlainTextFormatter::format_xml_text(parsed);
 
     let upsert_channel_message_args = UpsertChannelMessageArgs {
         channel_id: channel_message_info.channel_id.to_string(),


### PR DESCRIPTION
Extracts link text, document names, and user emails into searchable content instead of stripping them with NullXmlFormatter. Also consolidates the duplicate PlainTextFormatter from model_notifications into mention_utils as a shared public type.

i changed format link to use text property instead of url to mirror what user sees