### PR TITLE
fix(notif): empty digest and comms data race

### DIFF
--- a/rust/cloud-storage/authentication_service/src/api/context.rs
+++ b/rust/cloud-storage/authentication_service/src/api/context.rs
@@ -12,7 +12,7 @@ use macro_env::Environment;
 use macro_env_var::env_var;
 use macro_middleware::auth::internal_access::InternalApiSecretKey;
 use native_app_service::{domain::service::NativeAppServiceImpl, outbound::DefaultBundleFetcher};
-use notification::outbound::queue::SqsIngressQueue;
+use notification::outbound::queue::SqsQueue;
 use notification::{
     domain::service::SqsNotificationIngress, outbound::rate_limit::RedisRateLimitAdapter,
 };
@@ -29,7 +29,7 @@ use sqlx::PgPool;
 
 use crate::config::StripePriceIds;
 
-pub(crate) type NotificationIngressType = SqsNotificationIngress<SqsIngressQueue>;
+pub(crate) type NotificationIngressType = SqsNotificationIngress<SqsQueue>;
 
 pub(crate) type TeamsServiceType = teams::domain::team_service::TeamServiceImpl<
     teams::outbound::team_repo::TeamRepositoryImpl,
@@ -44,7 +44,7 @@ type RateLimiter = RateLimitServiceImpl<RedisRateLimitAdapter<redis::Client>>;
 pub(crate) type ReferralServiceType = ReferralServiceImpl<
     PgReferralRepo,
     StripeDiscountClient,
-    Arc<SqsNotificationIngress<SqsIngressQueue>>,
+    Arc<SqsNotificationIngress<SqsQueue>>,
 >;
 
 pub(crate) type GithubLinkServiceType =

--- a/rust/cloud-storage/authentication_service/src/main.rs
+++ b/rust/cloud-storage/authentication_service/src/main.rs
@@ -19,7 +19,7 @@ use native_app_service::{
     domain::{models::PlatformData, service::NativeAppServiceImpl},
     outbound::DefaultBundleFetcher,
 };
-use notification::outbound::queue::SqsIngressQueue;
+use notification::outbound::queue::SqsQueue;
 use notification::{
     domain::service::SqsNotificationIngress, outbound::rate_limit::RedisRateLimitAdapter,
 };
@@ -176,10 +176,10 @@ async fn main() -> anyhow::Result<()> {
         .await
         .context("failed to get multiplexed redis connection")?;
 
-    let ingress_queue = SqsIngressQueue {
-        client: aws_sdk_sqs::Client::new(&macro_aws_config::get_macro_aws_config().await),
-        queue_url: config.notification_queue.clone(),
-    };
+    let ingress_queue = SqsQueue::new(
+        aws_sdk_sqs::Client::new(&macro_aws_config::get_macro_aws_config().await),
+        config.notification_queue.clone(),
+    );
     let notification_ingress_service = SqsNotificationIngress {
         queue: ingress_queue,
     };

--- a/rust/cloud-storage/comms_db_client/.sqlx/query-6be5aa69eb2f953dcefeebec85994f26d25cc170a7ae1eaca2e73ef0581605e4.json
+++ b/rust/cloud-storage/comms_db_client/.sqlx/query-6be5aa69eb2f953dcefeebec85994f26d25cc170a7ae1eaca2e73ef0581605e4.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        SELECT COUNT(id) as count FROM comms_messages\n        WHERE channel_id = $1\n        LIMIT 1\n        ",
+  "query": "\n        SELECT COUNT(id) as count FROM comms_messages\n        WHERE channel_id = $1\n        ",
   "describe": {
     "columns": [
       {
@@ -18,5 +18,5 @@
       null
     ]
   },
-  "hash": "1308ba1a19b78a512b2753a7a837b756219ded649e524027acdbc8e2a0fd3fc6"
+  "hash": "6be5aa69eb2f953dcefeebec85994f26d25cc170a7ae1eaca2e73ef0581605e4"
 }

--- a/rust/cloud-storage/comms_db_client/src/messages/get_count.rs
+++ b/rust/cloud-storage/comms_db_client/src/messages/get_count.rs
@@ -1,6 +1,9 @@
 use sqlx::{Executor, Postgres};
 use uuid::Uuid;
 
+#[cfg(test)]
+mod test;
+
 /// Returns the number of messages in the given channel.
 ///
 /// Despite the name, this is a plain `COUNT(id)` and returns the actual row

--- a/rust/cloud-storage/comms_db_client/src/messages/get_count.rs
+++ b/rust/cloud-storage/comms_db_client/src/messages/get_count.rs
@@ -4,16 +4,10 @@ use uuid::Uuid;
 #[cfg(test)]
 mod test;
 
-/// Returns the number of messages in the given channel.
-///
-/// Despite the name, this is a plain `COUNT(id)` and returns the actual row
-/// count, not a 0/1 boolean. Callers that only need to know whether any
-/// messages exist should compare against `0`.
+/// Returns the total number of messages (including soft-deleted) in the
+/// given channel.
 #[tracing::instrument(skip(executor))]
-pub async fn check_if_channel_has_messages<'e, E>(
-    executor: E,
-    channel_id: &Uuid,
-) -> anyhow::Result<i64>
+pub async fn get_channel_message_count<'e, E>(executor: E, channel_id: &Uuid) -> anyhow::Result<i64>
 where
     E: Executor<'e, Database = Postgres>,
 {
@@ -21,7 +15,6 @@ where
         r#"
         SELECT COUNT(id) as count FROM comms_messages
         WHERE channel_id = $1
-        LIMIT 1
         "#,
         channel_id
     )

--- a/rust/cloud-storage/comms_db_client/src/messages/get_count.rs
+++ b/rust/cloud-storage/comms_db_client/src/messages/get_count.rs
@@ -1,8 +1,11 @@
 use sqlx::{Executor, Postgres};
 use uuid::Uuid;
 
-/// This will return 0 if there are no messages in the channel
-/// This will return 1 if there is at least 1 message in the channel
+/// Returns the number of messages in the given channel.
+///
+/// Despite the name, this is a plain `COUNT(id)` and returns the actual row
+/// count, not a 0/1 boolean. Callers that only need to know whether any
+/// messages exist should compare against `0`.
 #[tracing::instrument(skip(executor))]
 pub async fn check_if_channel_has_messages<'e, E>(
     executor: E,

--- a/rust/cloud-storage/comms_db_client/src/messages/get_count/test.rs
+++ b/rust/cloud-storage/comms_db_client/src/messages/get_count/test.rs
@@ -41,7 +41,7 @@ async fn returns_zero_for_empty_channel(pool: PgPool) -> anyhow::Result<()> {
     let channel_id = Uuid::new_v4();
     insert_channel(&pool, channel_id).await;
 
-    let count = check_if_channel_has_messages(&pool, &channel_id).await?;
+    let count = get_channel_message_count(&pool, &channel_id).await?;
     assert_eq!(count, 0);
     Ok(())
 }
@@ -52,7 +52,7 @@ async fn returns_one_for_single_message(pool: PgPool) -> anyhow::Result<()> {
     insert_channel(&pool, channel_id).await;
     insert_message(&pool, channel_id, false, None).await;
 
-    let count = check_if_channel_has_messages(&pool, &channel_id).await?;
+    let count = get_channel_message_count(&pool, &channel_id).await?;
     assert_eq!(count, 1);
     Ok(())
 }
@@ -65,7 +65,7 @@ async fn returns_full_count_not_capped_at_one(pool: PgPool) -> anyhow::Result<()
         insert_message(&pool, channel_id, false, None).await;
     }
 
-    let count = check_if_channel_has_messages(&pool, &channel_id).await?;
+    let count = get_channel_message_count(&pool, &channel_id).await?;
     assert_eq!(
         count, 5,
         "function should return the real row count, not a 0/1 flag"
@@ -81,7 +81,7 @@ async fn includes_deleted_messages(pool: PgPool) -> anyhow::Result<()> {
     insert_message(&pool, channel_id, true, None).await;
     insert_message(&pool, channel_id, true, None).await;
 
-    let count = check_if_channel_has_messages(&pool, &channel_id).await?;
+    let count = get_channel_message_count(&pool, &channel_id).await?;
     assert_eq!(
         count, 3,
         "soft-deleted messages are still counted by the underlying query"
@@ -100,7 +100,7 @@ async fn only_counts_matching_channel(pool: PgPool) -> anyhow::Result<()> {
     insert_message(&pool, channel_a, false, None).await;
     insert_message(&pool, channel_b, false, None).await;
 
-    assert_eq!(check_if_channel_has_messages(&pool, &channel_a).await?, 2);
-    assert_eq!(check_if_channel_has_messages(&pool, &channel_b).await?, 1);
+    assert_eq!(get_channel_message_count(&pool, &channel_a).await?, 2);
+    assert_eq!(get_channel_message_count(&pool, &channel_b).await?, 1);
     Ok(())
 }

--- a/rust/cloud-storage/comms_db_client/src/messages/get_count/test.rs
+++ b/rust/cloud-storage/comms_db_client/src/messages/get_count/test.rs
@@ -1,0 +1,106 @@
+use super::*;
+use macro_db_migrator::MACRO_DB_MIGRATIONS;
+use sqlx::PgPool;
+
+const _: &sqlx::migrate::Migrator = &MACRO_DB_MIGRATIONS; // Dummy reference for IDE
+
+async fn insert_channel(pool: &PgPool, channel_id: Uuid) {
+    sqlx::query!(
+        r#"
+        INSERT INTO comms_channels (id, name, channel_type, org_id, owner_id)
+        VALUES ($1, 'test', 'public', NULL, 'owner')
+        "#,
+        channel_id
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+async fn insert_message(pool: &PgPool, channel_id: Uuid, deleted: bool, thread_id: Option<Uuid>) {
+    sqlx::query!(
+        r#"
+        INSERT INTO comms_messages
+            (id, channel_id, sender_id, content, thread_id, deleted_at)
+        VALUES
+            ($1, $2, 'sender', 'content', $3,
+             CASE WHEN $4 THEN NOW() ELSE NULL END)
+        "#,
+        macro_uuid::generate_uuid_v7(),
+        channel_id,
+        thread_id,
+        deleted
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+#[sqlx::test(migrator = "MACRO_DB_MIGRATIONS")]
+async fn returns_zero_for_empty_channel(pool: PgPool) -> anyhow::Result<()> {
+    let channel_id = Uuid::new_v4();
+    insert_channel(&pool, channel_id).await;
+
+    let count = check_if_channel_has_messages(&pool, &channel_id).await?;
+    assert_eq!(count, 0);
+    Ok(())
+}
+
+#[sqlx::test(migrator = "MACRO_DB_MIGRATIONS")]
+async fn returns_one_for_single_message(pool: PgPool) -> anyhow::Result<()> {
+    let channel_id = Uuid::new_v4();
+    insert_channel(&pool, channel_id).await;
+    insert_message(&pool, channel_id, false, None).await;
+
+    let count = check_if_channel_has_messages(&pool, &channel_id).await?;
+    assert_eq!(count, 1);
+    Ok(())
+}
+
+#[sqlx::test(migrator = "MACRO_DB_MIGRATIONS")]
+async fn returns_full_count_not_capped_at_one(pool: PgPool) -> anyhow::Result<()> {
+    let channel_id = Uuid::new_v4();
+    insert_channel(&pool, channel_id).await;
+    for _ in 0..5 {
+        insert_message(&pool, channel_id, false, None).await;
+    }
+
+    let count = check_if_channel_has_messages(&pool, &channel_id).await?;
+    assert_eq!(
+        count, 5,
+        "function should return the real row count, not a 0/1 flag"
+    );
+    Ok(())
+}
+
+#[sqlx::test(migrator = "MACRO_DB_MIGRATIONS")]
+async fn includes_deleted_messages(pool: PgPool) -> anyhow::Result<()> {
+    let channel_id = Uuid::new_v4();
+    insert_channel(&pool, channel_id).await;
+    insert_message(&pool, channel_id, false, None).await;
+    insert_message(&pool, channel_id, true, None).await;
+    insert_message(&pool, channel_id, true, None).await;
+
+    let count = check_if_channel_has_messages(&pool, &channel_id).await?;
+    assert_eq!(
+        count, 3,
+        "soft-deleted messages are still counted by the underlying query"
+    );
+    Ok(())
+}
+
+#[sqlx::test(migrator = "MACRO_DB_MIGRATIONS")]
+async fn only_counts_matching_channel(pool: PgPool) -> anyhow::Result<()> {
+    let channel_a = Uuid::new_v4();
+    let channel_b = Uuid::new_v4();
+    insert_channel(&pool, channel_a).await;
+    insert_channel(&pool, channel_b).await;
+
+    insert_message(&pool, channel_a, false, None).await;
+    insert_message(&pool, channel_a, false, None).await;
+    insert_message(&pool, channel_b, false, None).await;
+
+    assert_eq!(check_if_channel_has_messages(&pool, &channel_a).await?, 2);
+    assert_eq!(check_if_channel_has_messages(&pool, &channel_b).await?, 1);
+    Ok(())
+}

--- a/rust/cloud-storage/comms_service/src/api/context.rs
+++ b/rust/cloud-storage/comms_service/src/api/context.rs
@@ -11,12 +11,12 @@ use frecency::outbound::postgres::FrecencyPgStorage;
 use macro_auth::middleware::decode_jwt::JwtValidationArgs;
 use macro_env_var::env_var;
 use notification_hex::domain::service::SqsNotificationIngress;
-use notification_hex::outbound::queue::SqsIngressQueue;
+use notification_hex::outbound::queue::SqsQueue;
 use secretsmanager_client::LocalOrRemoteSecret;
 use sqlx::PgPool;
 use std::sync::Arc;
 
-pub type NotificationIngressType = SqsNotificationIngress<SqsIngressQueue>;
+pub type NotificationIngressType = SqsNotificationIngress<SqsQueue>;
 pub type EntityAccessServiceType = EntityAccessServiceImpl<PgAccessRepository>;
 
 env_var! {

--- a/rust/cloud-storage/comms_service/src/notification.rs
+++ b/rust/cloud-storage/comms_service/src/notification.rs
@@ -161,8 +161,9 @@ impl ChannelMessageEvent<'_> {
                     tracing::warn!("thread participants is empty, but message has thread id");
                 }
             }
-            // Channel has no messages, send invite notification
-            (0, None) => {
+            // First message in channel — the count is 1 because our message
+            // was already persisted before this notification task runs.
+            (0 | 1, None) => {
                 dispatch_notifications_for_invite(
                     ingress,
                     self.channel_id,

--- a/rust/cloud-storage/comms_service/src/notification.rs
+++ b/rust/cloud-storage/comms_service/src/notification.rs
@@ -1,6 +1,6 @@
 use crate::api::context::AppState;
 use comms_db_client::{
-    messages::get_count::check_if_channel_has_messages,
+    messages::get_count::get_channel_message_count,
     messages::get_message_owner::get_message_owner,
     model::{Message, SimpleMention},
     participants::get_participants::get_channel_participants_for_thread_id,
@@ -267,7 +267,7 @@ pub async fn dispatch_notifications_for_message(
     // count includes the message we just created — the first message in a
     // channel yields a count of 1 (not 0).
     let channel_message_count =
-        check_if_channel_has_messages(&api_context.db, channel_id).await? as usize;
+        get_channel_message_count(&api_context.db, channel_id).await? as usize;
 
     // When this is the first message in the channel, look up which
     // participants already have accounts so the invite branch can split

--- a/rust/cloud-storage/comms_service/src/notification.rs
+++ b/rust/cloud-storage/comms_service/src/notification.rs
@@ -161,9 +161,11 @@ impl ChannelMessageEvent<'_> {
                     tracing::warn!("thread participants is empty, but message has thread id");
                 }
             }
-            // First message in channel — the count is 1 because our message
-            // was already persisted before this notification task runs.
-            (0 | 1, None) => {
+            // First message in the channel — send an invite notification.
+            // The count is 1 (not 0) because our message was already persisted
+            // before this notification task runs; 0 shouldn't happen in
+            // practice but is handled defensively.
+            (..=1, None) => {
                 dispatch_notifications_for_invite(
                     ingress,
                     self.channel_id,
@@ -261,13 +263,16 @@ pub async fn dispatch_notifications_for_message(
     message: Message,
     mentions: Vec<SimpleMention>,
 ) -> anyhow::Result<()> {
+    // The message is already persisted before this task runs, so the row
+    // count includes the message we just created — the first message in a
+    // channel yields a count of 1 (not 0).
     let channel_message_count =
         check_if_channel_has_messages(&api_context.db, channel_id).await? as usize;
 
     // When this is the first message in the channel, look up which
     // participants already have accounts so the invite branch can split
     // push (existing) vs email (non-existing) delivery.
-    let existing_user_ids: HashSet<String> = if channel_message_count == 0
+    let existing_user_ids: HashSet<String> = if channel_message_count <= 1
         && message.thread_id.is_none()
     {
         let participant_ids: Vec<_> = participants.iter().map(|p| p.user_id.0.clone()).collect();

--- a/rust/cloud-storage/comms_service/src/notification/test.rs
+++ b/rust/cloud-storage/comms_service/src/notification/test.rs
@@ -136,7 +136,9 @@ async fn mentioned_users_get_mention_not_message_send() {
         channel_id: &channel_id,
         message: &msg,
         channel_metadata: &metadata,
-        channel_message_count: 1,
+        // 2 = message we just persisted + at least one prior message, so this
+        // exercises the regular send branch (not the first-message invite).
+        channel_message_count: 2,
         user_mentions: &user_mentions,
         document_mentions: &[],
         participants: &participants,

--- a/rust/cloud-storage/document_cognition_service/src/api/context/mod.rs
+++ b/rust/cloud-storage/document_cognition_service/src/api/context/mod.rs
@@ -10,7 +10,7 @@ use entity_access::{domain::service::EntityAccessServiceImpl, outbound::PgAccess
 use macro_auth::middleware::decode_jwt::JwtValidationArgs;
 use macro_middleware::auth::internal_access::InternalApiSecretKey;
 use notification::domain::service::SqsNotificationIngress;
-use notification::outbound::queue::SqsIngressQueue;
+use notification::outbound::queue::SqsQueue;
 use scribe::{
     ScribeClient, channel::ChannelClient, dcs::DcsClient, document::DocumentClient,
     email::EmailClient, static_file::StaticFileClient,
@@ -32,7 +32,7 @@ pub use test::*;
 pub type DcsScribe =
     ScribeClient<DocumentClient, ChannelClient, DcsClient, EmailClient, StaticFileClient>;
 
-pub(crate) type NotificationIngressType = SqsNotificationIngress<SqsIngressQueue>;
+pub(crate) type NotificationIngressType = SqsNotificationIngress<SqsQueue>;
 
 pub type DcsMemoryService =
     memory::domain::service::MemoryServiceImpl<memory::outbound::pg_memory_repo::PgMemoryRepo>;

--- a/rust/cloud-storage/document_cognition_service/src/api/context/test.rs
+++ b/rust/cloud-storage/document_cognition_service/src/api/context/test.rs
@@ -122,7 +122,7 @@ pub async fn test_api_context(pool: sqlx::Pool<sqlx::Postgres>) -> std::sync::Ar
     use frecency::outbound::postgres::FrecencyPgStorage;
     use lexical_client::LexicalClient;
     use notification::domain::service::SqsNotificationIngress;
-    use notification::outbound::queue::SqsIngressQueue;
+    use notification::outbound::queue::SqsQueue;
     use scribe::ScribeClient;
     use search_service_client::SearchServiceClient;
     use soup::domain::service::SoupImpl;
@@ -206,10 +206,10 @@ pub async fn test_api_context(pool: sqlx::Pool<sqlx::Postgres>) -> std::sync::Ar
         channels_service,
     ));
 
-    let ingress_queue = SqsIngressQueue {
-        client: aws_sdk_sqs::Client::from_conf(sqs_config),
-        queue_url: "test-notification-ingress-queue".to_string(),
-    };
+    let ingress_queue = SqsQueue::new(
+        aws_sdk_sqs::Client::from_conf(sqs_config),
+        "test-notification-ingress-queue".to_string(),
+    );
     let notification_ingress_service = Arc::new(SqsNotificationIngress {
         queue: ingress_queue,
     });

--- a/rust/cloud-storage/document_cognition_service/src/main.rs
+++ b/rust/cloud-storage/document_cognition_service/src/main.rs
@@ -24,7 +24,7 @@ use macro_auth::middleware::decode_jwt::JwtValidationArgs;
 use macro_entrypoint::MacroEntrypoint;
 use macro_middleware::auth::internal_access::InternalApiSecretKey;
 use notification::domain::service::SqsNotificationIngress;
-use notification::outbound::queue::SqsIngressQueue;
+use notification::outbound::queue::SqsQueue;
 use scribe::{ScribeClient, document::DocumentClient};
 use search_service_client::SearchServiceClient;
 use secretsmanager_client::SecretManager;
@@ -193,10 +193,10 @@ async fn main() -> anyhow::Result<()> {
 
     tracing::info!("initialized connection repo");
 
-    let ingress_queue = SqsIngressQueue {
-        client: aws_sdk_sqs::Client::new(&aws_config),
-        queue_url: config.notification_queue.clone(),
-    };
+    let ingress_queue = SqsQueue::new(
+        aws_sdk_sqs::Client::new(&aws_config),
+        config.notification_queue.clone(),
+    );
     let notification_ingress_service = Arc::new(SqsNotificationIngress {
         queue: ingress_queue,
     });

--- a/rust/cloud-storage/document_storage_service/src/api/context.rs
+++ b/rust/cloud-storage/document_storage_service/src/api/context.rs
@@ -39,7 +39,7 @@ use macro_auth::middleware::decode_jwt::JwtValidationArgs;
 use macro_env_var::env_var;
 use macro_sha_count_client::Redis;
 use notification::domain::service::SqsNotificationIngress;
-use notification::outbound::queue::SqsIngressQueue;
+use notification::outbound::queue::SqsQueue;
 use opensearch_client::OpensearchClient;
 use properties::{
     NotificationServiceImpl, PermissionServiceImpl, PropertiesPgRepo, PropertiesServiceImpl,
@@ -81,7 +81,7 @@ type DssSoupState = SoupRouterState<
 >;
 
 type SystemPropertiesService = SystemPropertiesServiceImpl<PgSystemPropertiesRepository>;
-pub(crate) type NotificationIngressType = SqsNotificationIngress<SqsIngressQueue>;
+pub(crate) type NotificationIngressType = SqsNotificationIngress<SqsQueue>;
 type PropertiesService = PropertiesServiceImpl<
     PropertiesPgRepo,
     PermissionServiceImpl<EntityAccessService>,

--- a/rust/cloud-storage/document_storage_service/src/main.rs
+++ b/rust/cloud-storage/document_storage_service/src/main.rs
@@ -47,7 +47,7 @@ use macro_entrypoint::MacroEntrypoint;
 use macro_middleware::auth::internal_access::InternalApiSecretKey;
 use macro_sha_count_client::Redis;
 use notification::domain::service::SqsNotificationIngress;
-use notification::outbound::queue::SqsIngressQueue;
+use notification::outbound::queue::SqsQueue;
 use opensearch_client::OpensearchClient;
 use properties::{
     NotificationServiceImpl, PermissionServiceImpl, PropertiesPgRepo, PropertiesServiceImpl,
@@ -239,10 +239,10 @@ async fn main() -> anyhow::Result<()> {
     ));
     let system_properties_service =
         SystemPropertiesServiceImpl::new(PgSystemPropertiesRepository::new(db.clone()));
-    let ingress_queue = SqsIngressQueue {
-        client: aws_sdk_sqs::Client::new(&aws_config),
-        queue_url: config.vars.notification_queue.as_ref().to_string(),
-    };
+    let ingress_queue = SqsQueue::new(
+        aws_sdk_sqs::Client::new(&aws_config),
+        config.vars.notification_queue.as_ref().to_string(),
+    );
     let notification_ingress_service = Arc::new(SqsNotificationIngress {
         queue: ingress_queue.clone(),
     });

--- a/rust/cloud-storage/email_formatting/src/lib.rs
+++ b/rust/cloud-storage/email_formatting/src/lib.rs
@@ -10,7 +10,7 @@ use notification::domain::models::{
     UserNotificationRow, email_notification_digest::ports::DigestBatch,
     queue_message::EmailContent, signing::SignedUrl,
 };
-use rootcause::Report;
+use rootcause::{Report, report};
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
 use std::time::Duration;
@@ -71,7 +71,7 @@ impl EmailDigestNotification {
         let input_len = notifications.len();
 
         fn log_err<E: std::fmt::Debug>(e: &E) {
-            tracing::warn!("{e:?}");
+            tracing::error!("{e:?}");
         }
 
         let notifs: Vec<_> = notifications
@@ -84,6 +84,9 @@ impl EmailDigestNotification {
             .collect();
 
         let preview_len = notifs.len();
+        if preview_len == 0 {
+            return Err(report!("Batch with 0 notifications"));
+        }
         let num_truncated = input_len - preview_len;
 
         let mut unsubscribe_url = env.notification_service();

--- a/rust/cloud-storage/email_service/src/bin/pubsub_workers/pubsub_workers.rs
+++ b/rust/cloud-storage/email_service/src/bin/pubsub_workers/pubsub_workers.rs
@@ -6,7 +6,7 @@ use macro_entrypoint::MacroEntrypoint;
 use macro_env::Environment;
 use macro_middleware::auth::internal_access::InternalApiSecretKey;
 use notification::domain::service::SqsNotificationIngress;
-use notification::outbound::queue::SqsIngressQueue;
+use notification::outbound::queue::SqsQueue;
 use secretsmanager_client::SecretManager;
 use sqlx::postgres::PgPoolOptions;
 use static_file_service_client::StaticFileServiceClient;
@@ -193,10 +193,10 @@ async fn main() -> anyhow::Result<()> {
         })
         .context("failed to connect to redis")?;
 
-    let ingress_queue = SqsIngressQueue {
-        client: aws_sdk_sqs::Client::new(&aws_config),
-        queue_url: config.notification_queue.clone(),
-    };
+    let ingress_queue = SqsQueue::new(
+        aws_sdk_sqs::Client::new(&aws_config),
+        config.notification_queue.clone(),
+    );
     let notification_ingress_service = Arc::new(SqsNotificationIngress {
         queue: ingress_queue,
     });

--- a/rust/cloud-storage/email_service/src/pubsub/context.rs
+++ b/rust/cloud-storage/email_service/src/pubsub/context.rs
@@ -4,14 +4,14 @@ use connection_gateway_client::client::ConnectionGatewayClient;
 use document_storage_service_client::DocumentStorageServiceClient;
 use gmail_client::GmailClient;
 use notification::domain::service::SqsNotificationIngress;
-use notification::outbound::queue::SqsIngressQueue;
+use notification::outbound::queue::SqsQueue;
 use sqlx::PgPool;
 use static_file_service_client::StaticFileServiceClient;
 use std::sync::Arc;
 use system_properties::{PgSystemPropertiesRepository, SystemPropertiesServiceImpl};
 
 /// The concrete notification ingress service type.
-pub type NotificationIngressType = SqsNotificationIngress<SqsIngressQueue>;
+pub type NotificationIngressType = SqsNotificationIngress<SqsQueue>;
 
 #[derive(Clone)]
 pub struct PubSubContext {

--- a/rust/cloud-storage/notification/src/outbound/digest_batcher.rs
+++ b/rust/cloud-storage/notification/src/outbound/digest_batcher.rs
@@ -172,14 +172,19 @@ impl DigestBatcher for RedisDigestBatcher {
 
         let user_id = MacroUserIdStr::try_from(user_id_str)?;
 
-        let notifications = items
+        let notifications: Vec<_> = items
             .into_iter()
             .filter_map(|s| {
                 serde_json::from_str::<UserNotificationRow<serde_json::Value>>(&s)
+                    .inspect_err(|e| tracing::error!(error=?e, json=%s, "failed to deserialize digest notification"))
                     .ok()
                     .map(|n| n.into_tagged())
             })
             .collect();
+
+        if notifications.is_empty() {
+            return Ok(ClaimResult::Empty);
+        }
 
         Ok(ClaimResult::Ready(DigestBatch {
             user_id,

--- a/rust/cloud-storage/notification/src/outbound/queue.rs
+++ b/rust/cloud-storage/notification/src/outbound/queue.rs
@@ -9,33 +9,52 @@ use crate::domain::models::queue_message::{
 };
 use crate::domain::ports::{NotificationIngressQueue, NotificationQueue};
 
-/// SQS-backed implementation of the notification queue port.
+/// SQS-backed implementation of the notification queue ports.
+///
+/// A single type implements both [`NotificationQueue`] (delivery/egress queue)
+/// and [`NotificationIngressQueue`] (ingress queue). Callers construct one
+/// instance per queue URL.
 #[derive(Clone)]
-pub struct SqsNotificationQueue {
+pub struct SqsQueue {
     client: SqsClient,
     queue_url: String,
 }
 
-impl SqsNotificationQueue {
-    /// Create a new SQS notification queue adapter.
+impl SqsQueue {
+    /// Create a new SQS queue adapter pointing at `queue_url`.
     pub fn new(client: SqsClient, queue_url: String) -> Self {
         Self { client, queue_url }
     }
+
+    async fn send_json<T: Serialize>(&self, message: &T) -> Result<(), Report> {
+        let body = serde_json::to_string(message)?;
+        self.client
+            .send_message()
+            .queue_url(&self.queue_url)
+            .message_body(body)
+            .send()
+            .await?;
+        Ok(())
+    }
+
+    async fn delete(&self, receipt_handle: &str) -> Result<(), Report> {
+        self.client
+            .delete_message()
+            .queue_url(&self.queue_url)
+            .receipt_handle(receipt_handle)
+            .send()
+            .await?;
+        Ok(())
+    }
 }
 
-impl NotificationQueue for SqsNotificationQueue {
+impl NotificationQueue for SqsQueue {
     async fn publish<'a, T: Serialize + Send + Sync, U: Serialize + Send + Sync>(
         &self,
         messages: Vec<QueueMessage<'a, T, U>>,
     ) -> Result<(), Report> {
         for message in messages {
-            let body = serde_json::to_string(&message)?;
-            self.client
-                .send_message()
-                .queue_url(&self.queue_url)
-                .message_body(body)
-                .send()
-                .await?;
+            self.send_json(&message).await?;
         }
         Ok(())
     }
@@ -56,7 +75,9 @@ impl NotificationQueue for SqsNotificationQueue {
             .into_iter()
             .filter_map(|msg| {
                 let body_str = msg.body?;
-                let body = serde_json::from_str(&body_str).ok()?;
+                let body = serde_json::from_str(&body_str)
+                    .inspect_err(|e| tracing::error!(error=?e, body=%body_str, "failed to deserialize queue message"))
+                    .ok()?;
                 let receipt_handle = msg.receipt_handle?;
                 Some(RawQueueMessage {
                     body,
@@ -69,13 +90,7 @@ impl NotificationQueue for SqsNotificationQueue {
     }
 
     async fn delete_message(&self, receipt_handle: &str) -> Result<(), Report> {
-        self.client
-            .delete_message()
-            .queue_url(&self.queue_url)
-            .receipt_handle(receipt_handle)
-            .send()
-            .await?;
-        Ok(())
+        self.delete(receipt_handle).await
     }
 
     async fn delay_message(
@@ -91,6 +106,46 @@ impl NotificationQueue for SqsNotificationQueue {
             .send()
             .await?;
         Ok(())
+    }
+}
+
+impl NotificationIngressQueue for SqsQueue {
+    async fn publish(&self, message: IngressQueueMessage) -> Result<(), Report> {
+        self.send_json(&message).await
+    }
+
+    async fn receive_messages(&self) -> Result<Vec<RawIngressQueueMessage>, Report> {
+        let result = self
+            .client
+            .receive_message()
+            .queue_url(&self.queue_url)
+            .max_number_of_messages(10)
+            .wait_time_seconds(20)
+            .send()
+            .await?;
+
+        let messages = result
+            .messages
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|msg| {
+                let body_str = msg.body?;
+                let body = serde_json::from_str(&body_str)
+                    .inspect_err(|e| tracing::error!(error=?e, body=%body_str, "failed to deserialize ingress queue message"))
+                    .ok()?;
+                let receipt_handle = msg.receipt_handle?;
+                Some(RawIngressQueueMessage {
+                    body,
+                    receipt_handle,
+                })
+            })
+            .collect();
+
+        Ok(messages)
+    }
+
+    async fn delete_message(&self, receipt_handle: &str) -> Result<(), Report> {
+        self.delete(receipt_handle).await
     }
 }
 
@@ -184,69 +239,6 @@ impl NotificationQueue for FileQueue {
         _delay: std::time::Duration,
     ) -> Result<(), Report> {
         // No-op for file-based queue.
-        Ok(())
-    }
-}
-
-/// SQS-backed implementation of the notification ingress queue port.
-///
-/// Used by [`crate::domain::service::SqsNotificationIngress`] to publish
-/// type-erased notification requests, and by the ingress worker to consume them.
-#[derive(Clone)]
-pub struct SqsIngressQueue {
-    /// the sqs client
-    pub client: SqsClient,
-    /// the url of the queue
-    pub queue_url: String,
-}
-
-impl NotificationIngressQueue for SqsIngressQueue {
-    async fn publish(&self, message: IngressQueueMessage) -> Result<(), Report> {
-        let body = serde_json::to_string(&message)?;
-        self.client
-            .send_message()
-            .queue_url(&self.queue_url)
-            .message_body(body)
-            .send()
-            .await?;
-        Ok(())
-    }
-
-    async fn receive_messages(&self) -> Result<Vec<RawIngressQueueMessage>, Report> {
-        let result = self
-            .client
-            .receive_message()
-            .queue_url(&self.queue_url)
-            .max_number_of_messages(10)
-            .wait_time_seconds(20)
-            .send()
-            .await?;
-
-        let messages = result
-            .messages
-            .unwrap_or_default()
-            .into_iter()
-            .filter_map(|msg| {
-                let body_str = msg.body?;
-                let body = serde_json::from_str(&body_str).ok()?;
-                let receipt_handle = msg.receipt_handle?;
-                Some(RawIngressQueueMessage {
-                    body,
-                    receipt_handle,
-                })
-            })
-            .collect();
-
-        Ok(messages)
-    }
-
-    async fn delete_message(&self, receipt_handle: &str) -> Result<(), Report> {
-        self.client
-            .delete_message()
-            .queue_url(&self.queue_url)
-            .receipt_handle(receipt_handle)
-            .send()
-            .await?;
         Ok(())
     }
 }

--- a/rust/cloud-storage/notification_service/src/main.rs
+++ b/rust/cloud-storage/notification_service/src/main.rs
@@ -135,7 +135,7 @@ pub async fn main() -> anyhow::Result<()> {
     let notification_repository =
         ::notification::outbound::repository::DbNotificationRepository::new(db.clone());
 
-    let notification_queue = ::notification::outbound::queue::SqsNotificationQueue::new(
+    let notification_queue = ::notification::outbound::queue::SqsQueue::new(
         aws_sdk_sqs::Client::new(&aws_config),
         vars.notification_queue.as_ref().to_string(),
     );
@@ -260,7 +260,7 @@ pub async fn main() -> anyhow::Result<()> {
 
     let ingress_repository =
         ::notification::outbound::repository::DbNotificationRepository::new(db.clone());
-    let ingress_delivery_queue = ::notification::outbound::queue::SqsNotificationQueue::new(
+    let ingress_delivery_queue = ::notification::outbound::queue::SqsQueue::new(
         aws_sdk_sqs::Client::new(&aws_config),
         vars.notification_queue.as_ref().to_string(),
     );
@@ -270,10 +270,10 @@ pub async fn main() -> anyhow::Result<()> {
         ingress_state_machine,
     );
 
-    let ingress_queue = ::notification::outbound::queue::SqsIngressQueue {
-        client: aws_sdk_sqs::Client::new(&aws_config),
-        queue_url: vars.notification_ingress_queue.as_ref().to_string(),
-    };
+    let ingress_queue = ::notification::outbound::queue::SqsQueue::new(
+        aws_sdk_sqs::Client::new(&aws_config),
+        vars.notification_ingress_queue.as_ref().to_string(),
+    );
     let ingress_worker =
         ::notification::inbound::ingress_worker::IngressWorker::new(ingress_service, ingress_queue);
 

--- a/rust/cloud-storage/properties_service/src/api/context.rs
+++ b/rust/cloud-storage/properties_service/src/api/context.rs
@@ -1,14 +1,14 @@
 use axum::extract::FromRef;
 use entity_access::{domain::service::EntityAccessServiceImpl, outbound::PgAccessRepository};
 use notification::domain::service::SqsNotificationIngress;
-use notification::outbound::queue::SqsIngressQueue;
+use notification::outbound::queue::SqsQueue;
 use sqlx::PgPool;
 use std::sync::Arc;
 
 use properties::PropertiesServiceImpl;
 
 /// The concrete notification ingress service type.
-type NotificationIngressType = SqsNotificationIngress<SqsIngressQueue>;
+type NotificationIngressType = SqsNotificationIngress<SqsQueue>;
 
 /// Type alias for the entity access service.
 pub type EntityAccessServiceType = EntityAccessServiceImpl<PgAccessRepository>;


### PR DESCRIPTION
This PR fixes a bug where if all deserializations fail for a digest it could send an empty digest.

Then we also fix a data race bug in the comms service which was incorrectly checking for the wrong number of messages when sending an invite notif

- **dont send empty digest**
- **fix race with invite**
- **add tests**
- **rename function**
