### PR TITLE
fix(properties): prevent metadata properties from disappearing in task view

### DIFF
--- a/js/app/packages/queries/properties/entity.ts
+++ b/js/app/packages/queries/properties/entity.ts
@@ -46,6 +46,7 @@ export function useEntityPropertiesQuery(
         queryKey: propertiesKeys.entity({
           entityType: type,
           entityId: id,
+          includeMetadata,
         }).queryKey,
         queryFn: async () => {
           const data = await throwOnErr(
@@ -162,7 +163,7 @@ export function useSaveEntityPropertyMutation(
         return optimisticUpdateSoupEntity({
           tag: current.tag,
           data: {
-            id: current.data.id,
+            ...current.data,
             properties: current.data.properties.map((prop) =>
               prop.definition.id === vars.property.propertyDefinitionId
                 ? { ...prop, value: soupValue }
@@ -406,7 +407,7 @@ export function useSetPropertyStatusCompleteMutation(
         soupTxn = optimisticUpdateSoupEntity({
           tag: current.tag,
           data: {
-            id: current.data.id,
+            ...current.data,
             properties: updateStatusPropertyToCompleted(
               current.data.properties
             ),

--- a/js/app/packages/queries/properties/keys.ts
+++ b/js/app/packages/queries/properties/keys.ts
@@ -4,8 +4,15 @@ import type { PropertyScope } from '../../service-clients/service-properties/gen
 
 export const propertiesKeys = createQueryKeys('properties', {
   all: null,
-  entity: (params: { entityType: EntityType; entityId: string }) => ({
-    queryKey: ['entity', params.entityType, params.entityId],
+  entity: (params: {
+    entityType: EntityType;
+    entityId: string;
+    includeMetadata?: boolean;
+  }) => ({
+    queryKey:
+      params.includeMetadata !== undefined
+        ? ['entity', params.entityType, params.entityId, params.includeMetadata]
+        : ['entity', params.entityType, params.entityId],
   }),
   options: (params: { propertyDefinitionId: string }) => ({
     queryKey: ['options', params.propertyDefinitionId],


### PR DESCRIPTION
## Summary
- The entity properties query key did not include `includeMetadata`, so `PropertiesView` (`includeMetadata=true`) and `InlineTaskProperties` (`includeMetadata=false`) shared the same cache entry. When a task mention was inserted in a channel input, `InlineTaskProperties` triggered a refetch with `includeMetadata=false`, overwriting the cache and dropping metadata properties (Owner, Created At, Last Updated) from the task sidebar.
- Include `includeMetadata` in the query key so both variants are cached independently. When omitted (for invalidation), the key acts as a prefix matching both variants.
- Spread full entity data in optimistic updates to prevent field loss during soup cache merges.

## Test plan
- [ ] Open a task with properties panel visible (Owner, Created At, etc.)
- [ ] Open the Channels split for that task
- [ ] Insert the task as a mention in a channel input box
- [ ] Verify Owner and other metadata properties remain visible in the task sidebar
- [ ] Verify editing task properties (Status, Priority, Assignees) still works correctly with optimistic updates