### PR TITLE
fix(search): normalize mention filter format between soup and OpenSearch

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/create-search-state.ts
+++ b/js/app/packages/app/component/next-soup/soup-view/create-search-state.ts
@@ -82,7 +82,7 @@ export const createSearchState = ({
                 ...filters,
                 channel_filters: {
                   ...filters.channel_filters,
-                  mentions: mentionIds.map((id) => `user:${id}`),
+                  mentions: mentionIds,
                 },
               }
             : filters,

--- a/rust/cloud-storage/comms_db_client/src/messages/get_channel_message.rs
+++ b/rust/cloud-storage/comms_db_client/src/messages/get_channel_message.rs
@@ -1,3 +1,4 @@
+use crate::model::SimpleMention;
 use model::comms::{ChannelMessage, ChannelType, GetChannelMessageResponse};
 use uuid::Uuid;
 
@@ -36,7 +37,13 @@ pub async fn get_channel_message_by_id(
         "#,
         &message_id.to_string(),
     )
-    .map(|row| format!("{}:{}", row.entity_type, row.entity_id))
+    .map(|row| {
+        SimpleMention {
+            entity_type: row.entity_type,
+            entity_id: row.entity_id,
+        }
+        .to_string()
+    })
     .fetch_all(db)
     .await?;
 

--- a/rust/cloud-storage/comms_db_client/src/model/mod.rs
+++ b/rust/cloud-storage/comms_db_client/src/model/mod.rs
@@ -1,6 +1,7 @@
 use macro_user_id::user_id::MacroUserIdStr;
 use model::comms::ChannelType;
 use serde::{Deserialize, Serialize};
+use std::fmt;
 use utoipa::ToSchema;
 use uuid::Uuid;
 
@@ -57,6 +58,12 @@ pub struct NewAttachment {
 pub struct SimpleMention {
     pub entity_type: String,
     pub entity_id: String,
+}
+
+impl fmt::Display for SimpleMention {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:{}", self.entity_type, self.entity_id)
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]

--- a/rust/cloud-storage/search_service/src/api/search/simple/filter.rs
+++ b/rust/cloud-storage/search_service/src/api/search/simple/filter.rs
@@ -1,6 +1,7 @@
 //! This module is responsible for defining a trait to convert item_filters into a UnifiedSearchArgsVariant
 //! This is used in simple_unified.rs
 
+use comms_db_client::model::SimpleMention;
 use opensearch_client::search::unified::{
     UnifiedChannelMessageSearchArgs, UnifiedChatSearchArgs, UnifiedDocumentSearchArgs,
     UnifiedEmailSearchArgs,
@@ -81,7 +82,17 @@ impl FilterVariantToSearchArgs for item_filters::ChannelFilters {
                     .map(|c| c.to_string())
                     .collect(),
                 thread_ids: self.thread_ids.clone(),
-                mentions: self.mentions.clone(),
+                mentions: self
+                    .mentions
+                    .iter()
+                    .map(|m| {
+                        SimpleMention {
+                            entity_type: "user".to_string(),
+                            entity_id: m.clone(),
+                        }
+                        .to_string()
+                    })
+                    .collect(),
                 sender_ids: self.sender_ids.clone(),
                 ..Default::default()
             })


### PR DESCRIPTION
## Summary
- Moved the `user:` prefix for mention IDs from the frontend (`create-search-state.ts`) to the Rust search service (`filter.rs`)
- The frontend now sends plain `MacroUserIdStr` values (e.g. `macro|email@domain.com`), keeping the soup AST layer consistent
- The search service prepends `user:` right before building the OpenSearch query, where the prefixed format is actually needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)