### PR TITLE
chore: change codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,2 @@
-/rust/ @macro-inc/rust
-/js/ @macro-inc/web
+/rust/cloud-storage/macro_db_client/migrations/ @macro-inc/infra
 /infra/ @macro-inc/infra


### PR DESCRIPTION
we dont require code reviews for code owners anymore so my notifications get flooded for no reason

this moves to only have infra as codeowners as that is something I believe should always have a second set of eyes