### PR TITLE
fix(upload): make file extension matching case-insensitive

### DIFF
--- a/rust/cloud-storage/model/src/document/file_type/suffix_trie.rs
+++ b/rust/cloud-storage/model/src/document/file_type/suffix_trie.rs
@@ -31,7 +31,7 @@ impl ReversedSuffixTrie {
         let mut node = &self.root;
 
         for ch in filename.chars().rev() {
-            match node.children.get(&ch) {
+            match node.children.get(&ch.to_ascii_lowercase()) {
                 Some(next_node) => {
                     node = next_node;
                     if node.is_terminal {
@@ -51,7 +51,7 @@ impl ReversedSuffixTrie {
         let mut last_match_index = None;
 
         for (i, ch) in filename.chars().rev().enumerate() {
-            if let Some(next_node) = node.children.get(&ch) {
+            if let Some(next_node) = node.children.get(&ch.to_ascii_lowercase()) {
                 node = next_node;
                 if node.is_terminal {
                     last_match_index = Some(i);

--- a/rust/cloud-storage/model/src/document/file_type/tests.rs
+++ b/rust/cloud-storage/model/src/document/file_type/tests.rs
@@ -32,6 +32,14 @@ fn test_clean_document_name() {
     );
 
     assert_eq!(
+        FileType::clean_document_name("proposal.PDF").as_deref(),
+        Some("proposal")
+    );
+    assert_eq!(
+        FileType::clean_document_name("report.Docx").as_deref(),
+        Some("report")
+    );
+    assert_eq!(
         FileType::clean_document_name("testing.random").as_deref(),
         None
     );
@@ -75,6 +83,11 @@ fn test_is_suffix_match() {
     assert!(FileType::is_suffix_match("testing.docx.zip"));
     assert!(FileType::is_suffix_match("testing.tar.gz"));
     assert!(FileType::is_suffix_match(".pdf"));
+    assert!(FileType::is_suffix_match("testing.PDF"));
+    assert!(FileType::is_suffix_match("testing.Pdf"));
+    assert!(FileType::is_suffix_match("testing.DOCX"));
+    assert!(FileType::is_suffix_match("testing.MD"));
+    assert!(FileType::is_suffix_match("testing.TAR.GZ"));
 }
 
 #[test]
@@ -129,5 +142,17 @@ fn test_split_suffix_match() {
     assert_eq!(
         FileType::split_suffix_match("testing.1.5.0.tar.gz"),
         Some(("testing.1.5.0", "tar.gz"))
+    );
+    assert_eq!(
+        FileType::split_suffix_match("testing.PDF"),
+        Some(("testing", "PDF"))
+    );
+    assert_eq!(
+        FileType::split_suffix_match("testing.Docx"),
+        Some(("testing", "Docx"))
+    );
+    assert_eq!(
+        FileType::split_suffix_match("REPORT.MD"),
+        Some(("REPORT", "MD"))
     );
 }


### PR DESCRIPTION
## Summary
- The `ReversedSuffixTrie` used for file type detection performed case-sensitive character lookups, so filenames with capitalized extensions (e.g., `.PDF`, `.DOCX`) failed to match and were not recognized as valid file types
- Added `.to_ascii_lowercase()` to the trie traversal in `string_has_suffix()` and `longest_suffix()` so extensions match regardless of case
- Added test cases for capitalized and mixed-case extensions

🤖 Generated with [Claude Code](https://claude.com/claude-code)