### PR TITLE
fix(search): skip entity types with ids_only and empty IDs in unified search

### DIFF
--- a/rust/cloud-storage/search_service/src/api/search/simple/simple_unified.rs
+++ b/rust/cloud-storage/search_service/src/api/search/simple/simple_unified.rs
@@ -275,16 +275,21 @@ pub(in crate::api::search) async fn perform_unified_search(
         collapse,
         search_indices: {
             let mut indices = std::collections::HashSet::new();
-            if should_include_documents {
+            if should_include_documents
+                && !(filter_document_response.ids_only
+                    && filter_document_response.document_ids.is_empty())
+            {
                 indices.insert(models_opensearch::SearchEntityType::Documents);
             }
-            if should_include_chats {
+            if should_include_chats
+                && !(filter_chat_response.ids_only && filter_chat_response.chat_ids.is_empty())
+            {
                 indices.insert(models_opensearch::SearchEntityType::Chats);
             }
             if should_include_emails {
                 indices.insert(models_opensearch::SearchEntityType::Emails);
             }
-            if should_include_channels {
+            if should_include_channels && !filter_channel_response.channel_ids.is_empty() {
                 indices.insert(models_opensearch::SearchEntityType::Channels);
             }
             if should_include_projects {


### PR DESCRIPTION
## Summary
- Fixes "unable to search" error in unified search when entity types using ids_only mode resolve to zero matching IDs
- **Channels** (always ids_only: true): excluded from OpenSearch query when user has no channels
- **Documents/Chats** (ids_only when filtered by project, owner, file type): excluded when filters match nothing
- Emails and Projects are unaffected (emails never use ids_only, projects are not in OpenSearch)