### PR TITLE
fix(tasks): improve assignee property editing UX

### DIFF
--- a/js/app/packages/core/component/Properties/component/modal/EditPropertyValueModal.tsx
+++ b/js/app/packages/core/component/Properties/component/modal/EditPropertyValueModal.tsx
@@ -58,13 +58,16 @@ export function EditPropertyValueModal(props: PropertyEditorProps) {
     false
   );
 
-  const [selectedEntityRefs, setSelectedEntityRefs] = createSignal<
-    EntityReference[]
-  >(
+  const initialEntityRefs =
     props.property.valueType === 'ENTITY' && props.property.value != null
       ? props.property.value
-      : []
-  );
+      : [];
+
+  const originalEntityOptions = entityReferencesToIdSet(initialEntityRefs);
+
+  const [selectedEntityRefs, setSelectedEntityRefs] = createSignal<
+    EntityReference[]
+  >(initialEntityRefs);
 
   const [selectedDate, setSelectedDate] = createSignal<Date | null>(
     props.property.valueType === 'DATE' && props.property.value != null
@@ -258,6 +261,7 @@ export function EditPropertyValueModal(props: PropertyEditorProps) {
                           const refs = selectedEntityRefs();
                           return entityReferencesToIdSet(refs);
                         }}
+                        originalOptions={() => originalEntityOptions}
                         setSelectedOptions={(newOptions, entityInfo) => {
                           const currentRefs = selectedEntityRefs();
                           const updatedRefs = updateEntityReferences(

--- a/js/app/packages/core/component/Properties/component/modal/EditPropertyValueModal.tsx
+++ b/js/app/packages/core/component/Properties/component/modal/EditPropertyValueModal.tsx
@@ -308,7 +308,13 @@ export function EditPropertyValueModal(props: PropertyEditorProps) {
                 </Show>
               </div>
               <Show when={props.property.isMultiSelect}>
-                <div class="border-t border-edge-muted px-2 py-1.5 flex justify-end">
+                <div class="border-t border-edge-muted px-2 py-1.5 flex justify-end gap-1">
+                  <button
+                    class="text-xs text-ink-muted hover:text-ink px-2 py-1"
+                    onClick={() => props.onClose()}
+                  >
+                    Cancel
+                  </button>
                   <button
                     class="text-xs text-ink-muted hover:text-ink px-2 py-1"
                     onClick={handleClose}

--- a/js/app/packages/core/component/Properties/component/modal/EditPropertyValueModal.tsx
+++ b/js/app/packages/core/component/Properties/component/modal/EditPropertyValueModal.tsx
@@ -65,9 +65,8 @@ export function EditPropertyValueModal(props: PropertyEditorProps) {
 
   const originalEntityOptions = entityReferencesToIdSet(initialEntityRefs);
 
-  const [selectedEntityRefs, setSelectedEntityRefs] = createSignal<
-    EntityReference[]
-  >(initialEntityRefs);
+  const [selectedEntityRefs, setSelectedEntityRefs] =
+    createSignal<EntityReference[]>(initialEntityRefs);
 
   const [selectedDate, setSelectedDate] = createSignal<Date | null>(
     props.property.valueType === 'DATE' && props.property.value != null

--- a/js/app/packages/core/component/Properties/component/modal/EditPropertyValueModal.tsx
+++ b/js/app/packages/core/component/Properties/component/modal/EditPropertyValueModal.tsx
@@ -307,6 +307,16 @@ export function EditPropertyValueModal(props: PropertyEditorProps) {
                   />
                 </Show>
               </div>
+              <Show when={props.property.isMultiSelect}>
+                <div class="border-t border-edge-muted px-2 py-1.5 flex justify-end">
+                  <button
+                    class="text-xs text-ink-muted hover:text-ink px-2 py-1"
+                    onClick={handleClose}
+                  >
+                    Done
+                  </button>
+                </div>
+              </Show>
             </div>
           </Show>
         </div>

--- a/js/app/packages/core/component/Properties/component/modal/shared/PropertyEntitySelector.tsx
+++ b/js/app/packages/core/component/Properties/component/modal/shared/PropertyEntitySelector.tsx
@@ -490,7 +490,7 @@ export function PropertyEntitySelector(props: EntityInputProps) {
                 height: `${Math.min(sortedEntities().length * ITEM_SIZE, 192)}px`,
                 contain: 'content',
               }}
-              class="overflow-y-auto overflow-x-hidden scrollbar-hidden"
+              class="overflow-y-auto overflow-x-hidden"
             >
               {(entity, index) => {
                 const adjustedIndex = () => index() + pinnedCount();

--- a/js/app/packages/core/component/Properties/component/modal/shared/PropertyEntitySelector.tsx
+++ b/js/app/packages/core/component/Properties/component/modal/shared/PropertyEntitySelector.tsx
@@ -41,6 +41,7 @@ import type { EntityType } from '@service-properties/generated/schemas/entityTyp
 type EntityInputProps = {
   config: EntitySelectorConfig;
   selectedOptions: () => Set<string>;
+  originalOptions?: () => Set<string>;
   setSelectedOptions: (
     options: Set<string>,
     entityInfo?: { id: string; entity_type: string }[]
@@ -494,6 +495,10 @@ export function PropertyEntitySelector(props: EntityInputProps) {
               {(entity, index) => {
                 const adjustedIndex = () => index() + pinnedCount();
                 const isSelected = () => props.selectedOptions().has(entity.id);
+                const wasOriginal = () =>
+                  props.originalOptions?.().has(entity.id) ?? false;
+                const isAdded = () => isSelected() && !wasOriginal();
+                const isRemoved = () => !isSelected() && wasOriginal();
                 const isKeyboardSelected = () =>
                   adjustedIndex() === selectedIndex();
 
@@ -503,7 +508,10 @@ export function PropertyEntitySelector(props: EntityInputProps) {
                     class="flex items-center justify-between gap-2 py-1.5 px-2 min-w-0 h-8"
                     classList={{
                       'bg-hover': isKeyboardSelected(),
-                      'bg-accent/10': isSelected(),
+                      'bg-success-bg': isAdded(),
+                      'bg-failure-bg': isRemoved(),
+                      'bg-accent/10':
+                        isSelected() && !isAdded() && !isRemoved(),
                     }}
                     onClick={() => toggleEntity(entity)}
                     onKeyDown={(e) => e.key === 'Enter' && toggleEntity(entity)}

--- a/js/app/packages/core/component/Properties/component/modal/shared/PropertyEntitySelector.tsx
+++ b/js/app/packages/core/component/Properties/component/modal/shared/PropertyEntitySelector.tsx
@@ -490,7 +490,7 @@ export function PropertyEntitySelector(props: EntityInputProps) {
                 height: `${Math.min(sortedEntities().length * ITEM_SIZE, 192)}px`,
                 contain: 'content',
               }}
-              class="overflow-y-auto overflow-x-hidden"
+              class="overflow-y-auto overflow-x-hidden scrollbar-hidden"
             >
               {(entity, index) => {
                 const adjustedIndex = () => index() + pinnedCount();

--- a/js/app/packages/core/component/Properties/component/modal/shared/PropertyEntitySelector.tsx
+++ b/js/app/packages/core/component/Properties/component/modal/shared/PropertyEntitySelector.tsx
@@ -376,11 +376,11 @@ export function PropertyEntitySelector(props: EntityInputProps) {
     setSelectedIndex(0);
   });
 
-  // Scroll VList to selected index (offset by pinned count)
+  // Scroll VList to selected index only during keyboard navigation
   createEffect(() => {
     const index = selectedIndex();
     const pCount = pinnedCount();
-    if (index >= pCount && virtualizerHandle) {
+    if (keyboardMode() && index >= pCount && virtualizerHandle) {
       virtualizerHandle.scrollToIndex(index - pCount, { align: 'nearest' });
     }
   });

--- a/js/app/packages/core/component/Properties/component/propertyValue/EntityIcon.tsx
+++ b/js/app/packages/core/component/Properties/component/propertyValue/EntityIcon.tsx
@@ -3,7 +3,7 @@ import type { EntityType } from '@service-properties/generated/schemas/entityTyp
 import { type Component, createSignal, type ParentProps, Show } from 'solid-js';
 import { usePropertyEntityDisplay } from '../../hooks';
 import type { Property } from '../../types';
-import { PropertyValueDeleteButton } from './ValueComponents';
+import DeleteIcon from '@icon/bold/x-bold.svg';
 
 type EntityValueDisplayProps = ParentProps<{
   property: Property;
@@ -75,14 +75,17 @@ export const EntityIcon: Component<EntityValueDisplayProps> = (props) => {
           }
         >
           <div
-            class="absolute right-1 inset-y-0 flex items-center gap-1"
+            class="absolute right-0 inset-y-0 flex items-center pr-1 pl-2 bg-gradient-to-r from-transparent to-hover to-40%"
             onClick={(e: MouseEvent) => e.stopPropagation()}
           >
             <Show when={props.onRemove}>
-              <PropertyValueDeleteButton
-                onClick={props.onRemove!}
+              <button
+                onClick={() => props.onRemove!()}
                 disabled={props.isSaving}
-              />
+                class="size-4 p-0.5 flex items-center justify-center text-ink-muted hover:text-failure-ink"
+              >
+                <DeleteIcon class="size-3" />
+              </button>
             </Show>
           </div>
         </Show>

--- a/js/app/packages/core/component/Properties/component/propertyValue/EntityIcon.tsx
+++ b/js/app/packages/core/component/Properties/component/propertyValue/EntityIcon.tsx
@@ -3,10 +3,7 @@ import type { EntityType } from '@service-properties/generated/schemas/entityTyp
 import { type Component, createSignal, type ParentProps, Show } from 'solid-js';
 import { usePropertyEntityDisplay } from '../../hooks';
 import type { Property } from '../../types';
-import {
-  PropertyValueDeleteButton,
-  PropertyValueEditButton,
-} from './ValueComponents';
+import { PropertyValueDeleteButton } from './ValueComponents';
 
 type EntityValueDisplayProps = ParentProps<{
   property: Property;
@@ -52,6 +49,12 @@ export const EntityIcon: Component<EntityValueDisplayProps> = (props) => {
     </Show>
   );
 
+  const handleClick = (e: MouseEvent) => {
+    if (!props.canEdit || !props.onEdit) return;
+    e.stopPropagation();
+    props.onEdit(containerRef);
+  };
+
   return (
     <div
       ref={containerRef}
@@ -59,23 +62,22 @@ export const EntityIcon: Component<EntityValueDisplayProps> = (props) => {
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
     >
-      <div class="px-2 py-0.5 border border-edge-muted hover:bg-hover bg-transparent text-ink inline-flex items-center w-full">
+      <div
+        class="px-2 py-0.5 border border-edge-muted hover:bg-hover bg-transparent text-ink inline-flex items-center w-full"
+        onClick={handleClick}
+        role={props.canEdit && props.onEdit ? 'button' : undefined}
+        tabIndex={props.canEdit && props.onEdit ? 0 : undefined}
+      >
         <span class="truncate flex-1">{innerContent}</span>
         <Show
           when={
-            props.canEdit &&
-            isHovered() &&
-            !props.isSaving &&
-            (props.onRemove || props.onEdit)
+            props.canEdit && isHovered() && !props.isSaving && props.onRemove
           }
         >
-          <div class="absolute right-1 inset-y-0 flex items-center gap-1">
-            <Show when={props.onEdit}>
-              <PropertyValueEditButton
-                onClick={() => props.onEdit!(containerRef)}
-                disabled={props.isSaving}
-              />
-            </Show>
+          <div
+            class="absolute right-1 inset-y-0 flex items-center gap-1"
+            onClick={(e: MouseEvent) => e.stopPropagation()}
+          >
             <Show when={props.onRemove}>
               <PropertyValueDeleteButton
                 onClick={props.onRemove!}

--- a/js/app/packages/core/component/Properties/component/propertyValue/EntityValue.tsx
+++ b/js/app/packages/core/component/Properties/component/propertyValue/EntityValue.tsx
@@ -68,9 +68,7 @@ export const EntityValue: Component<PropertyValueProps> = (props) => {
             specificMessageId={entityRef.specific_message_id}
             canEdit={!isReadOnly()}
             onRemove={() => handleRemoveEntity(entityRef)}
-            onEdit={
-              !props.property.isMultiSelect ? handleEditEntity : undefined
-            }
+            onEdit={handleEditEntity}
             isSaving={isSaving()}
           />
         )}


### PR DESCRIPTION
## Summary
- Made the entire entity badge clickable to open the assignee edit modal, instead of only the small hover edit button
- Always pass `onEdit` to `EntityIcon` for all entity properties (not just single-select), fixing multi-select assignee editing
- Added `stopPropagation` on the delete button container to prevent edit modal from opening when removing an assignee

🤖 Generated with [Claude Code](https://claude.com/claude-code)