### PR TITLE
fix(sync): use remote DSS for sync permission tokens in local dev

### DIFF
--- a/js/app/packages/core/constant/servers.ts
+++ b/js/app/packages/core/constant/servers.ts
@@ -60,9 +60,8 @@ function selectLocalServers(): Servers {
       throw new Error(`unknown server name ${name}`);
     return true;
   }
-  const servers = selectedLocalServers
-    .split(',')
-    .reduce((acc: Servers, entry: string) => {
+  const servers = selectedLocalServers.split(',').reduce(
+    (acc: Servers, entry: string) => {
       // Support "service-name:port" to override the default local port
       const [name, portOverride] = entry.split(':') as [
         string,
@@ -78,7 +77,9 @@ function selectLocalServers(): Servers {
       }
       console.log(`Using local server ${name}: ${acc[name]}`);
       return acc;
-    }, serverHostRemote);
+    },
+    { ...serverHostRemote }
+  );
   return servers;
 }
 
@@ -112,6 +113,16 @@ function selectSyncServiceHost():
 }
 
 export const SYNC_SERVICE_HOSTS = selectSyncServiceHost();
+
+/**
+ * The DSS host to use for sync-service permission tokens.
+ * When the sync service is remote, permission tokens must come from the remote DSS
+ * because they need to be signed with the matching JWT secret.
+ */
+export const SYNC_PERMISSION_TOKEN_DSS_HOST =
+  SYNC_SERVICE_HOSTS === syncServiceHostRemote
+    ? serverHostRemote['document-storage-service']
+    : SERVER_HOSTS['document-storage-service'];
 
 /** Creates endpoint URL for accessing a static file by its ID */
 export function staticFileIdEndpoint(id: string): string {

--- a/js/app/packages/service-clients/service-storage/client.ts
+++ b/js/app/packages/service-clients/service-storage/client.ts
@@ -9,7 +9,10 @@ import { modificationDataReplacer } from '@block-pdf/util/buildModificationData'
 import type { BlockAlias, BlockName } from '@core/block';
 import { ENABLE_DOCX_TO_PDF } from '@core/constant/featureFlags';
 import { PaywallKey, usePaywallState } from '@core/constant/PaywallState';
-import { SERVER_HOSTS } from '@core/constant/servers';
+import {
+  SERVER_HOSTS,
+  SYNC_PERMISSION_TOKEN_DSS_HOST,
+} from '@core/constant/servers';
 import type { FetchError } from '@core/service';
 import { cache } from '@core/util/cache';
 import {
@@ -223,9 +226,11 @@ export const storageServiceClient = {
   },
 
   permissionsTokens: {
+    // Uses SYNC_PERMISSION_TOKEN_DSS_HOST instead of dssFetch so that tokens are
+    // always signed by the DSS whose JWT secret matches the sync service's secret.
     async createPermissionToken(args) {
-      return await dssFetch<GetDocumentPermissionsTokenResponse>(
-        `/documents/permissions_token/${args.document_id}`,
+      return await fetchWithToken<GetDocumentPermissionsTokenResponse>(
+        `${SYNC_PERMISSION_TOKEN_DSS_HOST}/documents/permissions_token/${args.document_id}`,
         {
           method: 'POST',
         }


### PR DESCRIPTION
## Summary
- When running DSS locally against the remote sync service, markdown documents failed to load because permission tokens were signed with the local JWT secret which doesn't match the remote sync service's secret
- Sync-related permission token requests now always route through the remote DSS when the sync service is remote, ensuring JWT signatures match
- Added `SYNC_PERMISSION_TOKEN_DSS_HOST` constant that correctly resolves the remote DSS URL (working around `selectLocalServers()` mutating `serverHostRemote` in-place)


🤖 Generated with [Claude Code](https://claude.com/claude-code)