### PR TITLE
feat(search): add preview button to search view header

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/soup-filters-bar.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/soup-filters-bar.tsx
@@ -73,7 +73,24 @@ export const SoupFiltersBar = () => {
       <Match when={isComponentListView('search')}>
         <div class="w-full flex flex-col gap-2 p-2 border-b border-edge-muted/50">
           <SoupSearchbar autoFocus />
-          <SearchIndexFilter />
+          <div class="flex items-center gap-2">
+            <SearchIndexFilter />
+            <div class="flex-1" />
+            <Tooltip
+              tooltip={<LabelAndHotKey label="Preview" shortcut="space" />}
+            >
+              <Button
+                variant={soup.previewEntity() ? 'primary' : 'ghost'}
+                size="sm"
+                class="rounded-xs [&_svg]:size-4 px-1 border border-transparent"
+                onClick={togglePreview}
+                onMouseEnter={() => setPreviewBtnHovering(true)}
+                onMouseLeave={() => setPreviewBtnHovering(false)}
+              >
+                <AnimatedPreviewIcon triggerAnimation={previewBtnHovering()} />
+              </Button>
+            </Tooltip>
+          </div>
         </div>
       </Match>
       <Match when={true}>

--- a/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
@@ -111,8 +111,6 @@ import {
 import { Button } from '@app/component/next-soup/soup-view/filters-bar/button';
 import { LabelAndHotKey, Tooltip } from '@core/component/Tooltip';
 import SearchIcon from '@macro-icons/macro-magnifying-glass.svg';
-import { AnimatedPreviewIcon } from '@macro-icons/wide/animating/preview';
-import { useAnalytics } from '@app/component/analytics-context';
 import { QUERY_FILTERS } from '../filters/query-filters';
 
 const useSoupNotificationInvalidators = () => {
@@ -213,22 +211,6 @@ export const SoupView = (props: SoupViewProps) => {
   };
 
   const [narrowSearchExpanded, setNarrowSearchExpanded] = createSignal(false);
-  const [previewBtnHovering, setPreviewBtnHovering] = createSignal(false);
-  const analytics = useAnalytics();
-
-  const togglePreview = () => {
-    const currentPreview = soup.previewEntity();
-    if (currentPreview) {
-      soup.setPreviewEntity(undefined);
-      return;
-    }
-
-    const focused = soup.focus.id();
-    if (!focused) return;
-
-    analytics.track('preview_panel_use');
-    soup.setPreviewEntity(focused);
-  };
 
   const isMailView = createMemo(() => {
     const content = panel.handle.content();
@@ -334,24 +316,6 @@ export const SoupView = (props: SoupViewProps) => {
                     </Show>
                   }
                 />
-              </Show>
-              <Show when={isComponentListView('search')}>
-                <Tooltip
-                  tooltip={<LabelAndHotKey label="Preview" shortcut="space" />}
-                >
-                  <Button
-                    variant={soup.previewEntity() ? 'primary' : 'ghost'}
-                    size="sm"
-                    class="rounded-xs [&_svg]:size-4 px-1 border border-transparent"
-                    onClick={togglePreview}
-                    onMouseEnter={() => setPreviewBtnHovering(true)}
-                    onMouseLeave={() => setPreviewBtnHovering(false)}
-                  >
-                    <AnimatedPreviewIcon
-                      triggerAnimation={previewBtnHovering()}
-                    />
-                  </Button>
-                </Tooltip>
               </Show>
             </SplitHeaderRight>
             <SoupFiltersBar />

--- a/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
@@ -111,6 +111,8 @@ import {
 import { Button } from '@app/component/next-soup/soup-view/filters-bar/button';
 import { LabelAndHotKey, Tooltip } from '@core/component/Tooltip';
 import SearchIcon from '@macro-icons/macro-magnifying-glass.svg';
+import { AnimatedPreviewIcon } from '@macro-icons/wide/animating/preview';
+import { useAnalytics } from '@app/component/analytics-context';
 import { QUERY_FILTERS } from '../filters/query-filters';
 
 const useSoupNotificationInvalidators = () => {
@@ -211,6 +213,22 @@ export const SoupView = (props: SoupViewProps) => {
   };
 
   const [narrowSearchExpanded, setNarrowSearchExpanded] = createSignal(false);
+  const [previewBtnHovering, setPreviewBtnHovering] = createSignal(false);
+  const analytics = useAnalytics();
+
+  const togglePreview = () => {
+    const currentPreview = soup.previewEntity();
+    if (currentPreview) {
+      soup.setPreviewEntity(undefined);
+      return;
+    }
+
+    const focused = soup.focus.id();
+    if (!focused) return;
+
+    analytics.track('preview_panel_use');
+    soup.setPreviewEntity(focused);
+  };
 
   const isMailView = createMemo(() => {
     const content = panel.handle.content();
@@ -316,6 +334,24 @@ export const SoupView = (props: SoupViewProps) => {
                     </Show>
                   }
                 />
+              </Show>
+              <Show when={isComponentListView('search')}>
+                <Tooltip
+                  tooltip={<LabelAndHotKey label="Preview" shortcut="space" />}
+                >
+                  <Button
+                    variant={soup.previewEntity() ? 'primary' : 'ghost'}
+                    size="sm"
+                    class="rounded-xs [&_svg]:size-4 px-1 border border-transparent"
+                    onClick={togglePreview}
+                    onMouseEnter={() => setPreviewBtnHovering(true)}
+                    onMouseLeave={() => setPreviewBtnHovering(false)}
+                  >
+                    <AnimatedPreviewIcon
+                      triggerAnimation={previewBtnHovering()}
+                    />
+                  </Button>
+                </Tooltip>
               </Show>
             </SplitHeaderRight>
             <SoupFiltersBar />


### PR DESCRIPTION
## Summary
- Adds the preview toggle button to the search view header, positioned just left of the spotlight split button
- Reuses the same pattern as the inbox preview button: animated icon, tooltip with spacebar shortcut, primary/ghost variant toggle
- Spacebar hotkey (already registered globally in SoupFiltersBar) works for search as well

🤖 Generated with [Claude Code](https://claude.com/claude-code)