### PR TITLE
chore(tasks): remove diff-style highlights from assignee menu

### DIFF
--- a/js/app/packages/core/component/Properties/component/modal/EditPropertyValueModal.tsx
+++ b/js/app/packages/core/component/Properties/component/modal/EditPropertyValueModal.tsx
@@ -58,15 +58,13 @@ export function EditPropertyValueModal(props: PropertyEditorProps) {
     false
   );
 
-  const initialEntityRefs =
+  const [selectedEntityRefs, setSelectedEntityRefs] = createSignal<
+    EntityReference[]
+  >(
     props.property.valueType === 'ENTITY' && props.property.value != null
       ? props.property.value
-      : [];
-
-  const originalEntityOptions = entityReferencesToIdSet(initialEntityRefs);
-
-  const [selectedEntityRefs, setSelectedEntityRefs] =
-    createSignal<EntityReference[]>(initialEntityRefs);
+      : []
+  );
 
   const [selectedDate, setSelectedDate] = createSignal<Date | null>(
     props.property.valueType === 'DATE' && props.property.value != null
@@ -260,7 +258,6 @@ export function EditPropertyValueModal(props: PropertyEditorProps) {
                           const refs = selectedEntityRefs();
                           return entityReferencesToIdSet(refs);
                         }}
-                        originalOptions={() => originalEntityOptions}
                         setSelectedOptions={(newOptions, entityInfo) => {
                           const currentRefs = selectedEntityRefs();
                           const updatedRefs = updateEntityReferences(

--- a/js/app/packages/core/component/Properties/component/modal/shared/PropertyEntitySelector.tsx
+++ b/js/app/packages/core/component/Properties/component/modal/shared/PropertyEntitySelector.tsx
@@ -41,7 +41,6 @@ import type { EntityType } from '@service-properties/generated/schemas/entityTyp
 type EntityInputProps = {
   config: EntitySelectorConfig;
   selectedOptions: () => Set<string>;
-  originalOptions?: () => Set<string>;
   setSelectedOptions: (
     options: Set<string>,
     entityInfo?: { id: string; entity_type: string }[]
@@ -495,10 +494,6 @@ export function PropertyEntitySelector(props: EntityInputProps) {
               {(entity, index) => {
                 const adjustedIndex = () => index() + pinnedCount();
                 const isSelected = () => props.selectedOptions().has(entity.id);
-                const wasOriginal = () =>
-                  props.originalOptions?.().has(entity.id) ?? false;
-                const isAdded = () => isSelected() && !wasOriginal();
-                const isRemoved = () => !isSelected() && wasOriginal();
                 const isKeyboardSelected = () =>
                   adjustedIndex() === selectedIndex();
 
@@ -508,10 +503,7 @@ export function PropertyEntitySelector(props: EntityInputProps) {
                     class="flex items-center justify-between gap-2 py-1.5 px-2 min-w-0 h-8"
                     classList={{
                       'bg-hover': isKeyboardSelected(),
-                      'bg-success-bg': isAdded(),
-                      'bg-failure-bg': isRemoved(),
-                      'bg-accent/10':
-                        isSelected() && !isAdded() && !isRemoved(),
+                      'bg-accent/10': isSelected(),
                     }}
                     onClick={() => toggleEntity(entity)}
                     onKeyDown={(e) => e.key === 'Enter' && toggleEntity(entity)}


### PR DESCRIPTION
## Summary
- Remove red/green (added/removed) background color highlights from the entity selector in the assignee property editor
- Restore the standard `bg-accent/10` highlight for selected items
- Remove the `originalOptions` prop and related tracking logic from `PropertyEntitySelector` and `EditPropertyValueModal`