### PR TITLE
fix(tasks): update property delete buttons to use subtle X style

### DIFF
--- a/js/app/packages/core/component/Properties/component/propertyValue/DateValue.tsx
+++ b/js/app/packages/core/component/Properties/component/propertyValue/DateValue.tsx
@@ -1,9 +1,9 @@
 import type { Component } from 'solid-js';
 import { createSignal, Show } from 'solid-js';
 import { formatDate } from '../../utils';
+import DeleteIcon from '@icon/bold/x-bold.svg';
 import {
   EmptyValue,
-  PropertyValueDeleteButton,
   stubSaveHandler,
   type PropertyValueProps,
 } from './ValueComponents';
@@ -69,11 +69,14 @@ export const DateValue: Component<PropertyValueProps> = (props) => {
         </Show>
       </button>
       <Show when={!isReadOnly() && isHovered() && displayValue && !isSaving()}>
-        <div class="absolute right-1 inset-y-0 flex items-center">
-          <PropertyValueDeleteButton
+        <div class="absolute right-0 inset-y-0 flex items-center pr-1 pl-2 bg-gradient-to-r from-transparent to-hover to-40%">
+          <button
             onClick={handleDelete}
             disabled={isSaving()}
-          />
+            class="size-4 p-0.5 flex items-center justify-center text-ink-muted hover:text-failure-ink"
+          >
+            <DeleteIcon class="size-3" />
+          </button>
         </div>
       </Show>
     </div>

--- a/js/app/packages/core/component/Properties/component/propertyValue/LinkValue.tsx
+++ b/js/app/packages/core/component/Properties/component/propertyValue/LinkValue.tsx
@@ -10,10 +10,10 @@ import {
   isValidUrl,
   normalizeUrl,
 } from '../../utils';
+import DeleteIcon from '@icon/bold/x-bold.svg';
 import {
   AddPropertyValueButton,
   EmptyValue,
-  PropertyValueDeleteButton,
   stubSaveHandler,
   type PropertyValueProps,
 } from './ValueComponents';
@@ -270,11 +270,14 @@ const LinkDisplay: Component<LinkDisplayProps> = (props) => {
         <span class="truncate flex-1 text-ink">{title()}</span>
       </button>
       <Show when={props.canEdit && isHovered() && !props.isRemoving}>
-        <div class="absolute right-1 inset-y-0 flex items-center">
-          <PropertyValueDeleteButton
+        <div class="absolute right-0 inset-y-0 flex items-center pr-1 pl-2 bg-gradient-to-r from-transparent to-hover to-40%">
+          <button
             onClick={handleRemoveClick}
             disabled={props.isRemoving}
-          />
+            class="size-4 p-0.5 flex items-center justify-center text-ink-muted hover:text-failure-ink"
+          >
+            <DeleteIcon class="size-3" />
+          </button>
         </div>
       </Show>
     </div>

--- a/js/app/packages/core/component/Properties/component/propertyValue/SelectValue.tsx
+++ b/js/app/packages/core/component/Properties/component/propertyValue/SelectValue.tsx
@@ -3,10 +3,10 @@ import { createSignal, For, Show } from 'solid-js';
 import { PROPERTY_STYLES } from '../../styles/styles';
 import { formatPropertyValue, getSelectValues } from '../../utils';
 import { PropertyValueIcon } from './PropertyValueIcon';
+import DeleteIcon from '@icon/bold/x-bold.svg';
 import {
   AddPropertyValueButton,
   EmptyValue,
-  PropertyValueDeleteButton,
   stubSaveHandler,
   type PropertyValueProps,
 } from './ValueComponents';
@@ -81,11 +81,14 @@ export const SelectValue: Component<PropertyValueProps> = (props) => {
                 <span class="block truncate">{formatted}</span>
               </div>
               <Show when={!isReadOnly() && isHovered() && !isSaving()}>
-                <div class="absolute right-1 inset-y-0 flex items-center">
-                  <PropertyValueDeleteButton
+                <div class="absolute right-0 inset-y-0 flex items-center pr-1 pl-2 bg-gradient-to-r from-transparent to-hover to-40%">
+                  <button
                     onClick={() => handleRemoveValue(value)}
                     disabled={isSaving()}
-                  />
+                    class="size-4 p-0.5 flex items-center justify-center text-ink-muted hover:text-failure-ink"
+                  >
+                    <DeleteIcon class="size-3" />
+                  </button>
                 </div>
               </Show>
             </div>

--- a/js/app/packages/core/component/Properties/component/propertyValue/ValueComponents.tsx
+++ b/js/app/packages/core/component/Properties/component/propertyValue/ValueComponents.tsx
@@ -1,7 +1,4 @@
-import SwapIcon from '@icon/bold/swap-bold.svg';
-import DeleteIcon from '@icon/bold/x-bold.svg';
 import type { EntityType } from '@service-properties/generated/schemas/entityType';
-import { Button } from '@ui/components/Button';
 import type { Component, JSX } from 'solid-js';
 import { twMerge } from 'tailwind-merge';
 import type { PropertySaveHandler } from '../../context/PropertiesContext';
@@ -93,51 +90,5 @@ export const PropertyValueButton: Component<{
     >
       {props.children}
     </button>
-  );
-};
-
-/**
- * Edit button for modifying property values
- * Consistent styling and behavior for all property types
- */
-export const PropertyValueEditButton: Component<{
-  onClick: () => void;
-  disabled?: boolean;
-}> = (props) => {
-  return (
-    <Button
-      onClick={props.onClick}
-      disabled={props.disabled}
-      class={twMerge(
-        'bg-panel size-4 p-0.5 border border-edge-muted text-ink-muted cursor-default',
-        'hover:bg-hover hover:text-ink',
-        'active:bg-panel active:border-edge active:text-ink'
-      )}
-    >
-      <SwapIcon class="size-3" />
-    </Button>
-  );
-};
-
-/**
- * Delete button for removing property values
- * Consistent styling and behavior for all property types
- */
-export const PropertyValueDeleteButton: Component<{
-  onClick: () => void;
-  disabled?: boolean;
-}> = (props) => {
-  return (
-    <Button
-      onClick={props.onClick}
-      disabled={props.disabled}
-      class={twMerge(
-        'bg-panel floating-failure-bg size-4 p-0.5 border border-edge-muted text-failure-ink cursor-default',
-        'hover:bg-panel hover:floating-failure-bg',
-        'active:bg-failure-ink active:border-failure-ink active:text-panel'
-      )}
-    >
-      <DeleteIcon class="size-3" />
-    </Button>
   );
 };


### PR DESCRIPTION
## Summary
- Replace the red background delete buttons on property values (status, priority, date, links) with the subtle X icon style matching the assignee property
- Remove unused `PropertyValueDeleteButton` and `PropertyValueEditButton` components

🤖 Generated with [Claude Code](https://claude.com/claude-code)