### PR TITLE
fix(inbox): Enter on single-item channel notification opens that message

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/use-soup-view-hotkeys.ts
+++ b/js/app/packages/app/component/next-soup/soup-view/use-soup-view-hotkeys.ts
@@ -10,7 +10,18 @@ import {
   isScopeInActiveBranch,
   runCommand,
 } from '@core/hotkey/utils';
-import { isSearchEntity } from '@entity';
+import {
+  isSearchEntity,
+  isWithNotification,
+  filterNotDoneNotifications,
+  filterValidNotifications,
+} from '@entity';
+import {
+  stackNotifications,
+  getMostRecentNotification,
+  openNotification,
+} from '@notifications';
+import { globalSplitManager } from '@app/signal/splitLayout';
 import { onCleanup, type Accessor } from 'solid-js';
 import type { VirtualizerHandle } from 'virtua/solid';
 import type { SoupState } from '../create-soup-state';
@@ -134,6 +145,24 @@ export const useSoupViewHotkeys = (options: UseSoupViewHotkeysOptions) => {
     keyDownHandler: () => {
       const entity = soup.focus.item();
       if (!entity) return false;
+
+      // For channel entities with a single notification stack,
+      // open that notification directly (matching click behavior)
+      if (entity.type === 'channel' && isWithNotification(entity)) {
+        const notifications = entity.notifications?.() ?? [];
+        const validNotifs = filterNotDoneNotifications(
+          filterValidNotifications(notifications)
+        );
+        const stacks = stackNotifications(validNotifs);
+        if (stacks.length === 1) {
+          const splitManager = globalSplitManager();
+          if (splitManager) {
+            const mostRecent = getMostRecentNotification(stacks[0]!);
+            openNotification(mostRecent, splitManager);
+            return true;
+          }
+        }
+      }
 
       const contentHitData = isSearchEntity(entity)
         ? entity.search.contentHitData
@@ -295,6 +324,23 @@ export const useSoupViewHotkeys = (options: UseSoupViewHotkeysOptions) => {
     keyDownHandler: () => {
       const entity = soup.focus.item();
       if (!entity) return false;
+
+      if (entity.type === 'channel' && isWithNotification(entity)) {
+        const notifications = entity.notifications?.() ?? [];
+        const validNotifs = filterNotDoneNotifications(
+          filterValidNotifications(notifications)
+        );
+        const stacks = stackNotifications(validNotifs);
+        if (stacks.length === 1) {
+          const splitManager = globalSplitManager();
+          if (splitManager) {
+            const mostRecent = getMostRecentNotification(stacks[0]!);
+            openNotification(mostRecent, splitManager, true);
+            return true;
+          }
+        }
+      }
+
       openEntityInSplitFromUnifiedList(entity, {
         splitHandle,
         openInNewSplit: true,

--- a/js/app/packages/app/component/next-soup/soup-view/use-soup-view-hotkeys.ts
+++ b/js/app/packages/app/component/next-soup/soup-view/use-soup-view-hotkeys.ts
@@ -16,11 +16,7 @@ import {
   filterNotDoneNotifications,
   filterValidNotifications,
 } from '@entity';
-import {
-  stackNotifications,
-  getMostRecentNotification,
-  openNotification,
-} from '@notifications';
+import { openSingleStackNotification } from '@notifications';
 import { globalSplitManager } from '@app/signal/splitLayout';
 import { onCleanup, type Accessor } from 'solid-js';
 import type { VirtualizerHandle } from 'virtua/solid';
@@ -146,21 +142,13 @@ export const useSoupViewHotkeys = (options: UseSoupViewHotkeysOptions) => {
       const entity = soup.focus.item();
       if (!entity) return false;
 
-      // For channel entities with a single notification stack,
-      // open that notification directly (matching click behavior)
       if (entity.type === 'channel' && isWithNotification(entity)) {
-        const notifications = entity.notifications?.() ?? [];
         const validNotifs = filterNotDoneNotifications(
-          filterValidNotifications(notifications)
+          filterValidNotifications(entity.notifications?.() ?? [])
         );
-        const stacks = stackNotifications(validNotifs);
-        if (stacks.length === 1) {
-          const splitManager = globalSplitManager();
-          if (splitManager) {
-            const mostRecent = getMostRecentNotification(stacks[0]!);
-            openNotification(mostRecent, splitManager);
-            return true;
-          }
+        const splitManager = globalSplitManager();
+        if (splitManager && openSingleStackNotification(validNotifs, splitManager)) {
+          return true;
         }
       }
 
@@ -326,18 +314,12 @@ export const useSoupViewHotkeys = (options: UseSoupViewHotkeysOptions) => {
       if (!entity) return false;
 
       if (entity.type === 'channel' && isWithNotification(entity)) {
-        const notifications = entity.notifications?.() ?? [];
         const validNotifs = filterNotDoneNotifications(
-          filterValidNotifications(notifications)
+          filterValidNotifications(entity.notifications?.() ?? [])
         );
-        const stacks = stackNotifications(validNotifs);
-        if (stacks.length === 1) {
-          const splitManager = globalSplitManager();
-          if (splitManager) {
-            const mostRecent = getMostRecentNotification(stacks[0]!);
-            openNotification(mostRecent, splitManager, true);
-            return true;
-          }
+        const splitManager = globalSplitManager();
+        if (splitManager && openSingleStackNotification(validNotifs, splitManager, true)) {
+          return true;
         }
       }
 

--- a/js/app/packages/app/component/next-soup/soup-view/use-soup-view-hotkeys.ts
+++ b/js/app/packages/app/component/next-soup/soup-view/use-soup-view-hotkeys.ts
@@ -131,6 +131,20 @@ export const useSoupViewHotkeys = (options: UseSoupViewHotkeysOptions) => {
     hide: true,
   }).withGroup(group);
 
+  const tryOpenChannelNotification = (newSplit: boolean): boolean => {
+    const entity = soup.focus.item();
+    if (!entity) return false;
+    if (entity.type !== 'channel' || !isWithNotification(entity)) return false;
+    const validNotifs = filterNotDoneNotifications(
+      filterValidNotifications(entity.notifications?.() ?? [])
+    );
+    const splitManager = globalSplitManager();
+    return (
+      !!splitManager &&
+      openSingleStackNotification(validNotifs, splitManager, newSplit)
+    );
+  };
+
   // enter - Open entity in split
   registerHotkey({
     hotkey: ['enter'],
@@ -139,21 +153,10 @@ export const useSoupViewHotkeys = (options: UseSoupViewHotkeysOptions) => {
     description: 'Open',
     hide: true,
     keyDownHandler: () => {
+      if (tryOpenChannelNotification(false)) return true;
+
       const entity = soup.focus.item();
       if (!entity) return false;
-
-      if (entity.type === 'channel' && isWithNotification(entity)) {
-        const validNotifs = filterNotDoneNotifications(
-          filterValidNotifications(entity.notifications?.() ?? [])
-        );
-        const splitManager = globalSplitManager();
-        if (
-          splitManager &&
-          openSingleStackNotification(validNotifs, splitManager)
-        ) {
-          return true;
-        }
-      }
 
       const contentHitData = isSearchEntity(entity)
         ? entity.search.contentHitData
@@ -313,22 +316,10 @@ export const useSoupViewHotkeys = (options: UseSoupViewHotkeysOptions) => {
     description: 'Open in new split',
     condition: () => soup.focus.id() !== undefined,
     keyDownHandler: () => {
+      if (tryOpenChannelNotification(true)) return true;
+
       const entity = soup.focus.item();
       if (!entity) return false;
-
-      if (entity.type === 'channel' && isWithNotification(entity)) {
-        const validNotifs = filterNotDoneNotifications(
-          filterValidNotifications(entity.notifications?.() ?? [])
-        );
-        const splitManager = globalSplitManager();
-        if (
-          splitManager &&
-          openSingleStackNotification(validNotifs, splitManager, true)
-        ) {
-          return true;
-        }
-      }
-
       openEntityInSplitFromUnifiedList(entity, {
         splitHandle,
         openInNewSplit: true,

--- a/js/app/packages/app/component/next-soup/soup-view/use-soup-view-hotkeys.ts
+++ b/js/app/packages/app/component/next-soup/soup-view/use-soup-view-hotkeys.ts
@@ -147,7 +147,10 @@ export const useSoupViewHotkeys = (options: UseSoupViewHotkeysOptions) => {
           filterValidNotifications(entity.notifications?.() ?? [])
         );
         const splitManager = globalSplitManager();
-        if (splitManager && openSingleStackNotification(validNotifs, splitManager)) {
+        if (
+          splitManager &&
+          openSingleStackNotification(validNotifs, splitManager)
+        ) {
           return true;
         }
       }
@@ -318,7 +321,10 @@ export const useSoupViewHotkeys = (options: UseSoupViewHotkeysOptions) => {
           filterValidNotifications(entity.notifications?.() ?? [])
         );
         const splitManager = globalSplitManager();
-        if (splitManager && openSingleStackNotification(validNotifs, splitManager, true)) {
+        if (
+          splitManager &&
+          openSingleStackNotification(validNotifs, splitManager, true)
+        ) {
           return true;
         }
       }

--- a/js/app/packages/notifications/index.ts
+++ b/js/app/packages/notifications/index.ts
@@ -41,6 +41,7 @@ export {
 } from './notification-metadata';
 export { openNotificationFromId } from './notification-navigation';
 export { openNotification } from './notification-navigation';
+export { openSingleStackNotification } from './notification-navigation';
 export { CHANNEL_EVENT_TYPES } from './notification-source';
 export type {
   PlatformNotificationData,

--- a/js/app/packages/notifications/notification-navigation.ts
+++ b/js/app/packages/notifications/notification-navigation.ts
@@ -10,6 +10,10 @@ import type { NotificationSource } from './notification-source';
 import { getChannelParams } from '@block-channel/utils/link';
 import { isChannelNotification } from './notification-helpers';
 import { CHANNEL_EVENT_TYPES } from './notification-source';
+import {
+  stackNotifications,
+  getMostRecentNotification,
+} from './notification-stacking';
 
 /**
  * Opens a split if it is not already open.
@@ -208,6 +212,18 @@ export function openNotification(
     });
   }
   return ResultAsync.fromSafePromise(handler(layoutManager, newSplit));
+}
+
+export function openSingleStackNotification(
+  notifications: UnifiedNotification[],
+  layoutManager: SplitManager,
+  newSplit: boolean = false
+): boolean {
+  const stacks = stackNotifications(notifications);
+  if (stacks.length !== 1) return false;
+  const mostRecent = getMostRecentNotification(stacks[0]!);
+  openNotification(mostRecent, layoutManager, newSplit);
+  return true;
 }
 
 export function openNotificationFromId(


### PR DESCRIPTION
## Summary
- When a channel entity in the inbox has exactly one notification stack, Enter now opens that specific notification (navigating to the message) instead of just opening the channel
- Shift+Enter also handles this case, opening the notification in a new split
- Extracted `openSingleStackNotification` helper in `notification-navigation.ts` to encapsulate the stack check + open logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)