### PR TITLE
Evan/onboarding analytics fix

### DIFF
--- a/js/app/packages/app/component/Root.tsx
+++ b/js/app/packages/app/component/Root.tsx
@@ -161,6 +161,10 @@ function BasePathComponent() {
     invalidateUserInfo();
   }
 
+  if (searchParams.subscriptionCancel === 'true') {
+    analytics.track('subscription_cancel', { tier: searchParams.tier });
+  }
+
   if (searchParams.upgrade === 'true') {
     sessionStorage.setItem('showUpgradeModal', 'true');
   }

--- a/js/app/packages/app/component/interactive-onboarding/InteractiveOnboarding.tsx
+++ b/js/app/packages/app/component/interactive-onboarding/InteractiveOnboarding.tsx
@@ -336,6 +336,21 @@ export default function InteractiveOnboarding() {
 
   createEffect(
     on(
+      () => state.currentLesson(),
+      (lesson) => {
+        if (!lesson) return;
+
+        analytics.track('onboarding_step', {
+          id: lesson.definition.id,
+          index: lesson.index,
+          state: 'viewed',
+        });
+      }
+    )
+  );
+
+  createEffect(
+    on(
       () => state.dismissed(),
       (dismissed) => {
         if (dismissed) navigateAway();

--- a/js/app/packages/app/component/interactive-onboarding/lessons/about-us.tsx
+++ b/js/app/packages/app/component/interactive-onboarding/lessons/about-us.tsx
@@ -8,6 +8,8 @@ import { startSsoLogin } from '@core/auth/sso';
 import { initAndStartEmailSync } from '@core/email-link';
 import { ROUTER_BASE_CONCAT } from '@app/constants/routerBase';
 import { isTauri } from '@core/util/platform';
+// Singleton is correct here — onContinue/onCompleteParam are plain callbacks outside Solid context.
+import { analytics } from '@app/lib/analytics/analytics';
 
 function AboutUsContent(props: LessonContentProps) {
   onMount(() => {
@@ -102,6 +104,8 @@ export const aboutUsLesson: LessonDefinition = {
   demo: AboutUsDemo,
   order: 60,
   onContinue: async () => {
+    analytics.track('sign_up', { method: 'google' }, ['ga', 'meta-pixel', 'posthog']);
+
     const success = await startSsoLogin({
       returnPath: `${ROUTER_BASE_CONCAT}welcome?google=1`,
     });
@@ -125,9 +129,16 @@ export const aboutUsLesson: LessonDefinition = {
   completeOnParam: 'google',
   onCompleteParam: () =>
     initAndStartEmailSync().match(
-      () => true,
+      () => {
+        analytics.track('email_authorized');
+        return true;
+      },
       (e) => {
-        if (e.tag === 'AlreadyInitialized') return true;
+        if (e.tag === 'AlreadyInitialized') {
+          analytics.track('email_authorized');
+          return true;
+        }
+        analytics.track('email_unauthorized');
         console.error('Failed to init email link after Google auth', e);
         return false;
       }

--- a/js/app/packages/app/component/interactive-onboarding/lessons/about-us.tsx
+++ b/js/app/packages/app/component/interactive-onboarding/lessons/about-us.tsx
@@ -104,7 +104,11 @@ export const aboutUsLesson: LessonDefinition = {
   demo: AboutUsDemo,
   order: 60,
   onContinue: async () => {
-    analytics.track('sign_up', { method: 'google' }, ['ga', 'meta-pixel', 'posthog']);
+    analytics.track('sign_up', { method: 'google' }, [
+      'ga',
+      'meta-pixel',
+      'posthog',
+    ]);
 
     const success = await startSsoLogin({
       returnPath: `${ROUTER_BASE_CONCAT}welcome?google=1`,

--- a/js/app/packages/app/lib/analytics/analytics.ts
+++ b/js/app/packages/app/lib/analytics/analytics.ts
@@ -95,7 +95,10 @@ export const createAnalytics = () => {
     data?: Record<string, unknown>,
     providersToSendTo: AnalyticsProvider[] = DEFAULT_ANALYTICS_PROVIDERS
   ) => {
-    if (disabled) return;
+    if (disabled) {
+      console.log('[Analytics]', event, data);
+      return;
+    }
 
     for (const provider of providersToSendTo) {
       sendEvent(provider, event, data);

--- a/js/app/packages/app/lib/analytics/analytics.ts
+++ b/js/app/packages/app/lib/analytics/analytics.ts
@@ -95,8 +95,6 @@ export const createAnalytics = () => {
     data?: Record<string, unknown>,
     providersToSendTo: AnalyticsProvider[] = DEFAULT_ANALYTICS_PROVIDERS
   ) => {
-    console.log('[Analytics]', event, data);
-
     if (disabled) return;
 
     for (const provider of providersToSendTo) {

--- a/js/app/packages/app/lib/analytics/analytics.ts
+++ b/js/app/packages/app/lib/analytics/analytics.ts
@@ -95,10 +95,9 @@ export const createAnalytics = () => {
     data?: Record<string, unknown>,
     providersToSendTo: AnalyticsProvider[] = DEFAULT_ANALYTICS_PROVIDERS
   ) => {
-    if (disabled) {
-      console.log('[Analytics]', event, data);
-      return;
-    }
+    console.log('[Analytics]', event, data);
+
+    if (disabled) return;
 
     for (const provider of providersToSendTo) {
       sendEvent(provider, event, data);

--- a/js/app/packages/app/lib/analytics/app-events.ts
+++ b/js/app/packages/app/lib/analytics/app-events.ts
@@ -7,6 +7,7 @@ export type AppEvents = {
   onboarding_completed: Record<string, unknown>;
 
   subscription_start: Record<string, unknown>;
+  subscription_cancel: Record<string, unknown>;
   subscription_success: Record<string, unknown>;
 
   sidebar_click: Record<string, unknown>;
@@ -56,6 +57,8 @@ export type AppEvents = {
   ai_message_sent: Record<string, unknown>;
   ai_attachment_add: Record<string, unknown>;
 
+  email_authorized: Record<string, unknown>;
+  email_unauthorized: Record<string, unknown>;
   email_message_sent: Record<string, unknown>;
 
   channel_message_sent: Record<string, unknown>;

--- a/js/app/packages/service-clients/service-stripe/client.ts
+++ b/js/app/packages/service-clients/service-stripe/client.ts
@@ -48,7 +48,7 @@ export const stripeServiceClient = {
 
     const result = await authServiceClient.createCheckoutSession({
       successUrl: `${window.location.origin}/app/?subscriptionSuccess=true${type ? `&type=${type}` : ''}`,
-      cancelUrl: `${window.location.origin}/app`,
+      cancelUrl: `${window.location.origin}/app?subscriptionCancel=true${tier ? `&tier=${tier}` : ''}`,
       discount: discount ?? null,
       metadata: {
         gaClientId: gaClientId ?? null,


### PR DESCRIPTION
## Summary

Adds comprehensive analytics tracking to the interactive onboarding flow to enable a full PostHog funnel from first page load through Stripe conversion.

### Changes
- **Step viewed tracking** — fires `onboarding_step` with `state: 'viewed'` each time a lesson becomes active, enabling drop-off analysis between lessons
- **`sign_up` event in onboarding** — the Google OAuth step (`about-us`) now fires `sign_up` before redirecting to Google SSO, matching the existing `LoginOptions` behavior
- **`email_authorized` / `email_unauthorized`** — tracks whether the user granted email/calendar scopes after returning from Google OAuth
- **`subscription_cancel`** — fires when a user backs out of Stripe checkout, with the selected tier. The Stripe cancel URL now includes `subscriptionCancel=true&tier={tier}` params
- **Typed events** — added `subscription_cancel`, `email_authorized`, `email_unauthorized` to `AppEvents`

### Analytics Funnel

| Step | Trigger | Event | Properties |
|------|---------|-------|------------|
| 1 | Welcome loads | `onboarding_start` | — |
| 2 | Welcome loads | `onboarding_step` | `id: welcome, state: viewed` |
| 3 | Complete welcome | `onboarding_step` | `id: welcome, state: completed` |
| 4 | Sidebar nav loads | `onboarding_step` | `id: sidebar-nav, state: viewed` |
| 5 | Complete/skip sidebar nav | `onboarding_step` | `id: sidebar-nav, state: completed/skipped` |
| 6 | Navigate list loads | `onboarding_step` | `id: navigate-list, state: viewed` |
| 7 | Complete/skip navigate list | `onboarding_step` | `id: navigate-list, state: completed/skipped` |
| 8 | Command-k loads | `onboarding_step` | `id: command-k, state: viewed` |
| 9 | Complete/skip command-k | `onboarding_step` | `id: command-k, state: completed/skipped` |
| 10 | Create entity loads | `onboarding_step` | `id: create-entity, state: viewed` |
| 11 | Complete/skip create entity | `onboarding_step` | `id: create-entity, state: completed/skipped` |
| 12 | Markdown mentions loads | `onboarding_step` | `id: markdown-mentions, state: viewed` |
| 13 | Complete/skip markdown mentions | `onboarding_step` | `id: markdown-mentions, state: completed/skipped` |
| 14 | About us (Google OAuth) loads | `onboarding_step` | `id: about-us, state: viewed` |
| 15 | Click "Connect with Google" | `sign_up` | `method: google` |
| — | *Redirect to Google OAuth* | | |
| 16 | Return from Google | `email_authorized` or `email_unauthorized` | — |
| 17 | Email invite loads | `onboarding_step` | `id: email-invite, state: viewed` |
| 18 | Complete/skip email invite | `onboarding_step` | `id: email-invite, state: completed/skipped` |
| 19 | Choose plan loads | `onboarding_step` | `id: choose-plan, state: viewed` |
| 20 | Click a plan | `subscription_start` | `type: {tier}` |
| — | *Redirect to Stripe* | | |
| 21a | Pay and return | `subscription_success` | `type: {tier}` |
| 21b | Cancel and return | `subscription_cancel` | `tier: {tier}` |
| 22 | Onboarding finishes | `onboarding_completed` | — |

### Key drop-off points
- **Steps 2–14**: lesson-to-lesson (closed tab, lost interest)
- **15 → 17**: Google OAuth (started SSO but never came back)
- **16**: `email_unauthorized` = logged in but denied email scopes
- **17 → 19**: abandoned at invite step
- **20 → 21**: Stripe checkout (started but didn't complete or cancelled)
