### PR TITLE
feat(analytics): add macro_device enrichment to all analytics events

### DIFF
--- a/js/app/packages/app/lib/analytics/analytics.ts
+++ b/js/app/packages/app/lib/analytics/analytics.ts
@@ -98,9 +98,9 @@ export const createAnalytics = () => {
     event: EventName,
     data?: Record<string, unknown>
   ) => {
-    const enriched = { [DEVICE_PROPERTY]: getDeviceType(), ...data };
-
     if (disabled) return;
+
+    const enriched = { ...data, [DEVICE_PROPERTY]: getDeviceType() };
 
     try {
       match(provider)

--- a/js/app/packages/app/lib/analytics/analytics.ts
+++ b/js/app/packages/app/lib/analytics/analytics.ts
@@ -92,9 +92,10 @@ export const createAnalytics = () => {
     event: EventName,
     data?: Record<string, unknown>
   ) => {
-    if (disabled) return;
-
     const enriched = { device: getDeviceType(), ...data };
+    console.log('[Analytics]', event, enriched, disabled ? '(disabled)' : '');
+
+    if (disabled) return;
 
     try {
       match(provider)
@@ -118,8 +119,6 @@ export const createAnalytics = () => {
     data?: Record<string, unknown>,
     providersToSendTo: AnalyticsProvider[] = DEFAULT_ANALYTICS_PROVIDERS
   ) => {
-    if (disabled) return;
-
     for (const provider of providersToSendTo) {
       sendEvent(provider, event, data);
     }

--- a/js/app/packages/app/lib/analytics/analytics.ts
+++ b/js/app/packages/app/lib/analytics/analytics.ts
@@ -22,7 +22,11 @@ import { isTouchDevice } from '@core/mobile/isTouchDevice';
  */
 const DEVICE_PROPERTY = 'macro_device' as const;
 
-function getDeviceType(): 'desktop-app' | 'desktop-web' | 'mobile-web' | 'mobile-app' {
+function getDeviceType():
+  | 'desktop-app'
+  | 'desktop-web'
+  | 'mobile-web'
+  | 'mobile-app' {
   const platform = getPlatform();
   if (platform === 'ios' || platform === 'android') return 'mobile-app';
   if (platform === 'desktop') return 'desktop-app';
@@ -95,7 +99,6 @@ export const createAnalytics = () => {
     data?: Record<string, unknown>
   ) => {
     const enriched = { [DEVICE_PROPERTY]: getDeviceType(), ...data };
-    console.log('[Analytics]', event, enriched, disabled ? '(disabled)' : '');
 
     if (disabled) return;
 

--- a/js/app/packages/app/lib/analytics/analytics.ts
+++ b/js/app/packages/app/lib/analytics/analytics.ts
@@ -5,6 +5,27 @@ import {
 } from '@app/lib/analytics/providers';
 import { PostHog } from 'posthog-js';
 import { match } from 'ts-pattern';
+import { getPlatform } from '@core/util/platform';
+import { isTouchDevice } from '@core/mobile/isTouchDevice';
+
+/**
+ * Resolves the user's device context for analytics enrichment.
+ *
+ * `getPlatform()` reads the build-time `VITE_PLATFORM` env var:
+ *   - Tauri iOS/Android builds → 'ios' | 'android' → 'mobile-app'
+ *   - Tauri desktop build → 'desktop' → 'desktop-app'
+ *   - Web build → 'web' (used by both desktop and mobile browsers)
+ *
+ * Desktop and mobile browsers share the same web build, so we use
+ * `isTouchDevice()` (checks `pointer: coarse` media query) to distinguish
+ * a phone/tablet browser ('mobile-web') from a desktop browser ('desktop-web').
+ */
+function getDeviceType(): 'desktop-app' | 'desktop-web' | 'mobile-web' | 'mobile-app' {
+  const platform = getPlatform();
+  if (platform === 'ios' || platform === 'android') return 'mobile-app';
+  if (platform === 'desktop') return 'desktop-app';
+  return isTouchDevice() ? 'mobile-web' : 'desktop-web';
+}
 
 export type AnalyticsProvider = 'ga' | 'meta-pixel' | 'posthog';
 
@@ -73,16 +94,18 @@ export const createAnalytics = () => {
   ) => {
     if (disabled) return;
 
+    const enriched = { device: getDeviceType(), ...data };
+
     try {
       match(provider)
         .with('ga', () => {
-          gtag('event', event, data);
+          gtag('event', event, enriched);
         })
         .with('meta-pixel', () => {
-          fbq('track', event, data ?? {});
+          fbq('track', event, enriched);
         })
         .with('posthog', () => {
-          posthog.capture(event, data);
+          posthog.capture(event, enriched);
         })
         .exhaustive();
     } catch (e) {
@@ -140,19 +163,23 @@ export const createAnalytics = () => {
 
     const pagePath = opts?.path ?? window.location.pathname;
     const pageLocation = opts?.location ?? window.location.href;
+    const device = getDeviceType();
 
     try {
       gtag('event', 'page_view', {
+        device,
         page_title: pageTitle,
         page_location: pageLocation,
         page_path: pagePath,
       });
 
       fbq('track', 'PageView', {
+        device,
         content_name: pageTitle,
       });
 
       posthog.capture('$pageview', {
+        device,
         $current_url: pageLocation,
         $pathname: pagePath,
         $title: pageTitle,

--- a/js/app/packages/app/lib/analytics/analytics.ts
+++ b/js/app/packages/app/lib/analytics/analytics.ts
@@ -20,6 +20,8 @@ import { isTouchDevice } from '@core/mobile/isTouchDevice';
  * `isTouchDevice()` (checks `pointer: coarse` media query) to distinguish
  * a phone/tablet browser ('mobile-web') from a desktop browser ('desktop-web').
  */
+const DEVICE_PROPERTY = 'macro_device' as const;
+
 function getDeviceType(): 'desktop-app' | 'desktop-web' | 'mobile-web' | 'mobile-app' {
   const platform = getPlatform();
   if (platform === 'ios' || platform === 'android') return 'mobile-app';
@@ -92,7 +94,7 @@ export const createAnalytics = () => {
     event: EventName,
     data?: Record<string, unknown>
   ) => {
-    const enriched = { device: getDeviceType(), ...data };
+    const enriched = { [DEVICE_PROPERTY]: getDeviceType(), ...data };
     console.log('[Analytics]', event, enriched, disabled ? '(disabled)' : '');
 
     if (disabled) return;
@@ -162,23 +164,23 @@ export const createAnalytics = () => {
 
     const pagePath = opts?.path ?? window.location.pathname;
     const pageLocation = opts?.location ?? window.location.href;
-    const device = getDeviceType();
+    const deviceType = getDeviceType();
 
     try {
       gtag('event', 'page_view', {
-        device,
+        [DEVICE_PROPERTY]: deviceType,
         page_title: pageTitle,
         page_location: pageLocation,
         page_path: pagePath,
       });
 
       fbq('track', 'PageView', {
-        device,
+        [DEVICE_PROPERTY]: deviceType,
         content_name: pageTitle,
       });
 
       posthog.capture('$pageview', {
-        device,
+        [DEVICE_PROPERTY]: deviceType,
         $current_url: pageLocation,
         $pathname: pagePath,
         $title: pageTitle,


### PR DESCRIPTION
## Summary

Adds automatic `macro_device` property enrichment to every analytics event (PostHog, GA, Meta Pixel). Every `track()` and `pageView()` call now includes a `macro_device` field with one of four values:

- `desktop-app` — Tauri desktop build
- `desktop-web` — web build on a desktop browser
- `mobile-web` — web build on a mobile/tablet browser
- `mobile-app` — Tauri iOS/Android builds

### Changes

- Added `getDeviceType()` in `analytics.ts` that combines the build-time `VITE_PLATFORM` with `isTouchDevice()` to determine device context
- Enrichment happens in `sendEvent()` (the single chokepoint for all provider dispatches) and `pageView()`, so no callers need to pass it manually
- Property key is stored as `DEVICE_PROPERTY` const for single-point-of-change
- Enables filtering PostHog funnels/trends by device type (e.g. desktop-web only onboarding funnel)