### PR TITLE
feat[mobile]: swipe back gesture

### DIFF
--- a/js/app/packages/app/component/mobile/MobileDock.tsx
+++ b/js/app/packages/app/component/mobile/MobileDock.tsx
@@ -182,7 +182,13 @@ export function MobileDock() {
   });
 
   const navigate = (id: ListView) => {
-    openWithSplit({ type: 'component', id }, { mergeHistory: true });
+    // If we're already on a soup/component view, replace in-place (mergeHistory)
+    // so the tab switch doesn't push a new entry into the swipe-back BG slot.
+    // From any other view (document, task, etc.) treat it as forward navigation
+    // so the user can swipe back to where they were.
+    const fgContent = globalSplitManager()?.activeSplit()?.content();
+    const isOnSoupView = fgContent?.type === 'component';
+    openWithSplit({ type: 'component', id }, { mergeHistory: isOnSoupView });
   };
 
   return (

--- a/js/app/packages/app/component/split-layout/SplitLayout.tsx
+++ b/js/app/packages/app/component/split-layout/SplitLayout.tsx
@@ -1,57 +1,41 @@
 import { useGlobalBlockOrchestrator } from '@app/component/GlobalAppState';
-import { createSoupState } from '@app/component/next-soup/create-soup-state';
-import { SoupContextProvider } from '@app/component/next-soup/soup-context';
 import { activeElement } from '@app/signal/focus';
 import { Resize } from '@core/component/Resize';
+import { isMobile } from '@core/mobile/isMobile';
+import { isSidebarVisible } from '@app/component/sidebarVisibility';
 import { tabTitleSignal } from '@core/signal/tabTitle';
-import { createElementSize } from '@solid-primitives/resize-observer';
 import { useNavigate } from '@solidjs/router';
-import { useHotkeyDOMScope } from 'core/hotkey/hotkeys';
 import {
   type Accessor,
-  batch,
   createEffect,
   createMemo,
   createSelector,
-  createSignal,
   For,
   on,
   onCleanup,
-  onMount,
   type Setter,
   Show,
   Suspense,
 } from 'solid-js';
-import { Dynamic } from 'solid-js/web';
 import { PopoverSplitRenderer } from './components/PopoverSplitRenderer';
-import { SplitContainer } from './components/SplitContainer';
-import {
-  SplitLayoutContext,
-  SplitPanelContext,
-  type SplitPanelContextType,
-} from './context';
-import { useSplitLayout } from './layout';
+import { SplitPanel } from './components/SplitPanel';
+import { SplitLayoutContext } from './context';
 import {
   createSplitLayout,
   type SplitContent,
   SplitEvent,
   type SplitEventWithType,
-  type SplitHandle,
   type SplitId,
   type SplitManager,
   type SplitState,
 } from './layoutManager';
 import { decodePairs } from './layoutUtils';
-import { createHeaderCollapser } from './utils/createHeaderCollapser';
-import { registerSplitHotkeys } from './registerSplitHotkeys';
-import { isListViewID } from '@app/constants/list-views';
-import { isMobile } from '@core/mobile/isMobile';
-import { isSidebarVisible } from '@app/component/sidebarVisibility';
 import { cn } from '@ui/utils/classname';
 import {
   createMobileSwipeLayout,
   type MobileSwipeLayout,
 } from './mobile/createMobileSwipeLayout';
+import { MobileSwipeBackContainer } from './mobile/MobileSwipeBackContainer';
 
 type SplitLayoutContainerProps = {
   pairs: string[];
@@ -375,302 +359,5 @@ export function SplitLayoutContainer(props: SplitLayoutContainerProps) {
         }}
       />
     </SplitLayoutContext.Provider>
-  );
-}
-
-type SplitPanelProps = {
-  split: SplitState;
-  handle: SplitHandle;
-  active: boolean;
-  setPanelRef: (ref: HTMLDivElement) => void;
-  index: number;
-};
-
-function SplitPanel(props: SplitPanelProps) {
-  const [panelRef, setPanelRef] = createSignal<HTMLDivElement | null>(null);
-  const [attachHotKeys, splitHotkeyScope] = useHotkeyDOMScope(
-    `split=${props.split.id}`
-  );
-
-  const panelSize = createElementSize(panelRef);
-  const [contentOffsetTop, setContentOffsetTop] = createSignal(0);
-
-  const [previewState, setPreviewState] = createSignal(false);
-
-  const layoutRefs: SplitPanelContextType['layoutRefs'] = {};
-  const headerCollapser = createHeaderCollapser(
-    () => layoutRefs.headerLeft,
-    () => panelSize.width
-  );
-
-  const splitLayoutHelpers = useSplitLayout();
-  registerSplitHotkeys({
-    splitHotkeyScope,
-    insertSplit: splitLayoutHelpers.insertSplit,
-    closeSplit: () => props.handle.close(),
-    toggleSpotlight: () => props.handle.toggleSpotlight(),
-    canGoBack: () => props.handle.canGoBack(),
-    goBack: () => props.handle.goBack(),
-    canGoForward: () => props.handle.canGoForward(),
-    goForward: () => props.handle.goForward(),
-    replaceSplit: splitLayoutHelpers.replaceSplit,
-    splitName: () => props.handle.displayName(),
-    getSplitCount: () => splitLayoutHelpers.getSplitCount(),
-    isNotUnifiedList: () => {
-      const content = props.handle.content();
-      return !isListViewID(content.id);
-    },
-  });
-
-  const nextSoup = createSoupState({
-    initialFilters: ['explicit-noise'],
-  });
-
-  return (
-    <SoupContextProvider soup={nextSoup}>
-      <SplitPanelContext.Provider
-        value={{
-          handle: props.handle,
-          splitHotkeyScope,
-          isPanelActive: () => props.active,
-          panelRef,
-          panelSize,
-          layoutRefs,
-          contentOffsetTop,
-          setContentOffsetTop,
-          previewState: [previewState, setPreviewState],
-          headerCollapser,
-        }}
-      >
-        <SplitContainer
-          id={props.split.id}
-          ref={(ref) => {
-            setPanelRef(ref);
-            props.setPanelRef(ref);
-            attachHotKeys(ref);
-          }}
-          tl={props.index === 0 && !isMobile()}
-          bl={props.index === 0 && !isMobile()}
-          tr={
-            splitLayoutHelpers.getSplitCount() > 1 &&
-            props.index === splitLayoutHelpers.getSplitCount() - 1 &&
-            !isMobile()
-          }
-          br={
-            splitLayoutHelpers.getSplitCount() > 1 &&
-            props.index === splitLayoutHelpers.getSplitCount() - 1 &&
-            !isMobile()
-          }
-        >
-          <Suspense>
-            <Dynamic component={props.split.mount.element} />
-          </Suspense>
-        </SplitContainer>
-      </SplitPanelContext.Provider>
-    </SoupContextProvider>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Mobile swipe-back stacked layout
-// ---------------------------------------------------------------------------
-
-const SWIPE_EDGE_THRESHOLD = 28; // px from left edge to initiate gesture
-const SWIPE_VELOCITY_THRESHOLD = 0.3; // px/ms — fast flick completes swipe
-const SWIPE_DISTANCE_THRESHOLD = 0.5; // fraction of screen width
-const SWIPE_ANIMATION_MS = 150;
-
-type MobileSwipeBackContainerProps = {
-  splitManager: SplitManager;
-  mobileSwipeLayout: MobileSwipeLayout;
-  splits: Accessor<ReadonlyArray<SplitState>>;
-  panelRefs: Map<SplitId, HTMLDivElement>;
-};
-
-function MobileSwipeBackContainer(props: MobileSwipeBackContainerProps) {
-  const { splitManager, mobileSwipeLayout } = props;
-
-  const [dragOffset, setDragOffset] = createSignal(0);
-  const [isDragging, setIsDragging] = createSignal(false);
-  const [isAnimatingOut, setIsAnimatingOut] = createSignal(false);
-
-  let startX = 0;
-  let startTime = 0;
-  let animationTimer: ReturnType<typeof setTimeout> | undefined;
-  onCleanup(() => clearTimeout(animationTimer));
-
-  function animateComplete(onDone: () => void) {
-    setIsAnimatingOut(true);
-    setDragOffset(window.innerWidth);
-    animationTimer = setTimeout(() => {
-      batch(() => {
-        setIsAnimatingOut(false);
-        setDragOffset(0);
-        onDone();
-      });
-    }, SWIPE_ANIMATION_MS);
-  }
-
-  function animateSnapBack() {
-    setIsAnimatingOut(true);
-    setDragOffset(0);
-    animationTimer = setTimeout(
-      () => setIsAnimatingOut(false),
-      SWIPE_ANIMATION_MS
-    );
-  }
-
-  function triggerAnimatedSwipeBack() {
-    if (!mobileSwipeLayout.canGoBack()) return;
-    animateComplete(() => mobileSwipeLayout.completeSwipeBack());
-  }
-
-  // Register the animated trigger so the back button can invoke it.
-  onMount(() => mobileSwipeLayout.setAnimatedTrigger(triggerAnimatedSwipeBack));
-  onCleanup(() => mobileSwipeLayout.setAnimatedTrigger(undefined));
-
-  function handleTouchStart(e: TouchEvent) {
-    if (!mobileSwipeLayout.canGoBack()) return;
-    const touch = e.touches[0];
-    if (!touch || touch.clientX > SWIPE_EDGE_THRESHOLD) return;
-    startX = touch.clientX;
-    startTime = Date.now();
-    setIsDragging(true);
-  }
-
-  function handleTouchMove(e: TouchEvent) {
-    if (!isDragging()) return;
-    const touch = e.touches[0];
-    if (!touch) return;
-    const dx = Math.max(0, touch.clientX - startX);
-    setDragOffset(dx);
-  }
-
-  function handleTouchEnd() {
-    if (!isDragging()) return;
-    setIsDragging(false);
-    const dx = dragOffset();
-    const elapsed = Date.now() - startTime;
-    const velocity = elapsed > 0 ? dx / elapsed : 0;
-    const threshold = window.innerWidth * SWIPE_DISTANCE_THRESHOLD;
-    if (dx > threshold || velocity > SWIPE_VELOCITY_THRESHOLD) {
-      animateComplete(() => mobileSwipeLayout.completeSwipeBack());
-    } else {
-      animateSnapBack();
-    }
-  }
-
-  const slotAData = createMemo(() => {
-    const id = mobileSwipeLayout.slotASplitId();
-    if (!id) return undefined;
-    const split = props.splits().find((s) => s.id === id);
-    const rawHandle = splitManager.getSplit(id);
-    if (!split || !rawHandle) return undefined;
-    const handle: SplitHandle = {
-      ...rawHandle,
-      goBack: () => mobileSwipeLayout.swipeBack(),
-      canGoBack: () => mobileSwipeLayout.canGoBack(),
-    };
-    return { split, handle };
-  });
-
-  const slotBData = createMemo(() => {
-    const id = mobileSwipeLayout.slotBSplitId();
-    if (!id) return undefined;
-    const split = props.splits().find((s) => s.id === id);
-    const rawHandle = splitManager.getSplit(id);
-    if (!split || !rawHandle) return undefined;
-    const handle: SplitHandle = {
-      ...rawHandle,
-      goBack: () => mobileSwipeLayout.swipeBack(),
-      canGoBack: () => mobileSwipeLayout.canGoBack(),
-    };
-    return { split, handle };
-  });
-
-  function getFgTransition(): string {
-    if (isDragging()) return 'none';
-    if (isAnimatingOut()) return `transform ${SWIPE_ANIMATION_MS}ms ease-out`;
-    return 'none';
-  }
-
-  // FG translation style — applied only to the currently-active FG slot div.
-  const fgStyle = () => ({
-    transform: `translateX(${dragOffset()}px)`,
-    transition: getFgTransition(),
-    'will-change': 'transform',
-  });
-
-  return (
-    <div
-      class="relative size-full overflow-hidden"
-      onTouchStart={handleTouchStart}
-      onTouchMove={handleTouchMove}
-      onTouchEnd={handleTouchEnd}
-      onTouchCancel={() => {
-        if (!isDragging()) return;
-        setIsDragging(false);
-        animateSnapBack();
-      }}
-    >
-      <Show when={slotAData()}>
-        {(a) => (
-          <div
-            class={cn('absolute inset-0', {
-              'z-10': mobileSwipeLayout.fgIsSlotA(),
-              '-z-100 pointer-events-none': !mobileSwipeLayout.fgIsSlotA(),
-            })}
-            style={mobileSwipeLayout.fgIsSlotA() ? fgStyle() : undefined}
-          >
-            {/*
-             * Key by content id so that SplitPanel (and its soup state) remounts when the slot's content changes, needed for dock / soup-view navigation.
-             */}
-            <Show when={a().split.content.id} keyed>
-              {(_contentId) => (
-                <Suspense>
-                  <SplitPanel
-                    split={a().split}
-                    handle={a().handle}
-                    active={mobileSwipeLayout.fgIsSlotA()}
-                    setPanelRef={(ref) =>
-                      props.panelRefs.set(a().split.id, ref)
-                    }
-                    index={0}
-                  />
-                </Suspense>
-              )}
-            </Show>
-          </div>
-        )}
-      </Show>
-
-      <Show when={slotBData()}>
-        {(b) => (
-          <div
-            class={cn('absolute inset-0', {
-              'z-10': !mobileSwipeLayout.fgIsSlotA(),
-              '-z-100 pointer-events-none': mobileSwipeLayout.fgIsSlotA(),
-            })}
-            style={!mobileSwipeLayout.fgIsSlotA() ? fgStyle() : undefined}
-          >
-            <Show when={b().split.content.id} keyed>
-              {(_contentId) => (
-                <Suspense>
-                  <SplitPanel
-                    split={b().split}
-                    handle={b().handle}
-                    active={!mobileSwipeLayout.fgIsSlotA()}
-                    setPanelRef={(ref) =>
-                      props.panelRefs.set(b().split.id, ref)
-                    }
-                    index={1}
-                  />
-                </Suspense>
-              )}
-            </Show>
-          </div>
-        )}
-      </Show>
-    </div>
   );
 }

--- a/js/app/packages/app/component/split-layout/SplitLayout.tsx
+++ b/js/app/packages/app/component/split-layout/SplitLayout.tsx
@@ -313,15 +313,6 @@ export function SplitLayoutContainer(props: SplitLayoutContainerProps) {
     setTabTitle(splitManager.tabTitle());
   });
 
-  // Wire the mobile swipe layout into the split manager so that any call to
-  // splitManager.openWithSplit() is automatically routed through it on mobile.
-  if (mobileSwipeLayout) {
-    splitManager.setMobileForwardOverride(mobileSwipeLayout.navigateForward);
-    onCleanup(() => {
-      splitManager.setMobileForwardOverride(undefined);
-    });
-  }
-
   // <For> on plain ids for stable referential equality
   const ids = createMemo(() => splits().map(({ id }) => id));
 

--- a/js/app/packages/app/component/split-layout/SplitLayout.tsx
+++ b/js/app/packages/app/component/split-layout/SplitLayout.tsx
@@ -86,7 +86,7 @@ function createLayoutUrlSync(
 
   /** Syncs changes from the layout manager to the URL*/
   createEffect(
-    on([() => splitManager.splits().length], () => {
+    on([() => splitManager.getUrlSegments().join('/')], () => {
       if (urlLayoutDrift()) {
         // Flush the state to the url
         navigate(`/${splitManager.getUrlSegments().join('/')}`);

--- a/js/app/packages/app/component/split-layout/SplitLayout.tsx
+++ b/js/app/packages/app/component/split-layout/SplitLayout.tsx
@@ -588,14 +588,16 @@ function MobileSwipeBackContainer(props: MobileSwipeBackContainerProps) {
     return { split, handle };
   });
 
+  function getFgTransition(): string {
+    if (isDragging()) return 'none';
+    if (isAnimatingOut()) return `transform ${SWIPE_ANIMATION_MS}ms ease-out`;
+    return 'none';
+  }
+
   // FG translation style — applied only to the currently-active FG slot div.
   const fgStyle = () => ({
     transform: `translateX(${dragOffset()}px)`,
-    transition: isDragging()
-      ? 'none'
-      : isAnimatingOut()
-        ? `transform ${SWIPE_ANIMATION_MS}ms ease-out`
-        : 'none',
+    transition: getFgTransition(),
     'will-change': 'transform',
   });
 

--- a/js/app/packages/app/component/split-layout/SplitLayout.tsx
+++ b/js/app/packages/app/component/split-layout/SplitLayout.tsx
@@ -505,25 +505,28 @@ function MobileSwipeBackContainer(props: MobileSwipeBackContainerProps) {
 
   let startX = 0;
   let startTime = 0;
+  let animationTimer: ReturnType<typeof setTimeout> | undefined;
+  onCleanup(() => clearTimeout(animationTimer));
 
   function animateComplete(onDone: () => void) {
     setIsAnimatingOut(true);
     setDragOffset(window.innerWidth);
-    const t = setTimeout(() => {
+    animationTimer = setTimeout(() => {
       batch(() => {
         setIsAnimatingOut(false);
         setDragOffset(0);
         onDone();
       });
     }, SWIPE_ANIMATION_MS);
-    onCleanup(() => clearTimeout(t));
   }
 
   function animateSnapBack() {
     setIsAnimatingOut(true);
     setDragOffset(0);
-    const t = setTimeout(() => setIsAnimatingOut(false), SWIPE_ANIMATION_MS);
-    onCleanup(() => clearTimeout(t));
+    animationTimer = setTimeout(
+      () => setIsAnimatingOut(false),
+      SWIPE_ANIMATION_MS
+    );
   }
 
   function triggerAnimatedSwipeBack() {
@@ -611,7 +614,11 @@ function MobileSwipeBackContainer(props: MobileSwipeBackContainerProps) {
       onTouchStart={handleTouchStart}
       onTouchMove={handleTouchMove}
       onTouchEnd={handleTouchEnd}
-      onTouchCancel={handleTouchEnd}
+      onTouchCancel={() => {
+        if (!isDragging()) return;
+        setIsDragging(false);
+        animateSnapBack();
+      }}
     >
       <Show when={slotAData()}>
         {(a) => (

--- a/js/app/packages/app/component/split-layout/SplitLayout.tsx
+++ b/js/app/packages/app/component/split-layout/SplitLayout.tsx
@@ -9,6 +9,7 @@ import { useNavigate } from '@solidjs/router';
 import { useHotkeyDOMScope } from 'core/hotkey/hotkeys';
 import {
   type Accessor,
+  batch,
   createEffect,
   createMemo,
   createSelector,
@@ -16,6 +17,7 @@ import {
   For,
   on,
   onCleanup,
+  onMount,
   type Setter,
   Show,
   Suspense,
@@ -46,6 +48,10 @@ import { isListViewID } from '@app/constants/list-views';
 import { isMobile } from '@core/mobile/isMobile';
 import { isSidebarVisible } from '@app/component/sidebarVisibility';
 import { cn } from '@ui/utils/classname';
+import {
+  createMobileSwipeLayout,
+  type MobileSwipeLayout,
+} from './mobile/createMobileSwipeLayout';
 
 type SplitLayoutContainerProps = {
   pairs: string[];
@@ -280,6 +286,11 @@ export function SplitLayoutContainer(props: SplitLayoutContainerProps) {
   const splitManager = createSplitLayout(blockOrchestrator, decodedPairs());
   const [, setTabTitle] = tabTitleSignal;
 
+  // Create the mobile swipe layout once on mobile devices.
+  const mobileSwipeLayout: MobileSwipeLayout | undefined = isMobile()
+    ? createMobileSwipeLayout(splitManager)
+    : undefined;
+
   // Store a ref to each panel by id
   const panelRefs = new Map<SplitId, HTMLDivElement>();
   createEffect(
@@ -302,6 +313,15 @@ export function SplitLayoutContainer(props: SplitLayoutContainerProps) {
     setTabTitle(splitManager.tabTitle());
   });
 
+  // Wire the mobile swipe layout into the split manager so that any call to
+  // splitManager.openWithSplit() is automatically routed through it on mobile.
+  if (mobileSwipeLayout) {
+    splitManager.setMobileForwardOverride(mobileSwipeLayout.navigateForward);
+    onCleanup(() => {
+      splitManager.setMobileForwardOverride(undefined);
+    });
+  }
+
   // <For> on plain ids for stable referential equality
   const ids = createMemo(() => splits().map(({ id }) => id));
 
@@ -313,31 +333,47 @@ export function SplitLayoutContainer(props: SplitLayoutContainerProps) {
       <div
         class={cn('size-full p-2 mobile:p-0', { 'pl-0': isSidebarVisible() })}
       >
-        <Resize.Zone
-          direction="horizontal"
-          gutter={4}
-          captureResizeCtx={splitManager.setResizeContext}
-        >
-          <For each={ids()}>
-            {(id, index) => (
-              <Show when={splitManager.getSplit(id)}>
-                {(handle) => (
-                  <Suspense>
-                    <Resize.Panel id={id} minSize={400} index={index()}>
-                      <SplitPanel
-                        split={splits()[index()]!}
-                        handle={handle()}
-                        active={activeSplitSelector(id)}
-                        setPanelRef={(panelRef) => panelRefs.set(id, panelRef)}
-                        index={index()}
-                      />
-                    </Resize.Panel>
-                  </Suspense>
+        <Show
+          when={isMobile() && mobileSwipeLayout}
+          fallback={
+            // Desktop: side-by-side resizable splits.
+            <Resize.Zone
+              direction="horizontal"
+              gutter={4}
+              captureResizeCtx={splitManager.setResizeContext}
+            >
+              <For each={ids()}>
+                {(id, index) => (
+                  <Show when={splitManager.getSplit(id)}>
+                    {(handle) => (
+                      <Suspense>
+                        <Resize.Panel id={id} minSize={400} index={index()}>
+                          <SplitPanel
+                            split={splits()[index()]!}
+                            handle={handle()}
+                            active={activeSplitSelector(id)}
+                            setPanelRef={(panelRef) =>
+                              panelRefs.set(id, panelRef)
+                            }
+                            index={index()}
+                          />
+                        </Resize.Panel>
+                      </Suspense>
+                    )}
+                  </Show>
                 )}
-              </Show>
-            )}
-          </For>
-        </Resize.Zone>
+              </For>
+            </Resize.Zone>
+          }
+        >
+          {/* Mobile: stacked FG/BG layout with swipe-back gesture. */}
+          <MobileSwipeBackContainer
+            splitManager={splitManager}
+            mobileSwipeLayout={mobileSwipeLayout!}
+            splits={splits}
+            panelRefs={panelRefs}
+          />
+        </Show>
       </div>
       <PopoverSplitRenderer
         popovers={splitManager.popovers}
@@ -441,5 +477,200 @@ function SplitPanel(props: SplitPanelProps) {
         </SplitContainer>
       </SplitPanelContext.Provider>
     </SoupContextProvider>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Mobile swipe-back stacked layout
+// ---------------------------------------------------------------------------
+
+const SWIPE_EDGE_THRESHOLD = 28; // px from left edge to initiate gesture
+const SWIPE_VELOCITY_THRESHOLD = 0.3; // px/ms — fast flick completes swipe
+const SWIPE_DISTANCE_THRESHOLD = 0.5; // fraction of screen width
+const SWIPE_ANIMATION_MS = 150;
+
+type MobileSwipeBackContainerProps = {
+  splitManager: SplitManager;
+  mobileSwipeLayout: MobileSwipeLayout;
+  splits: Accessor<ReadonlyArray<SplitState>>;
+  panelRefs: Map<SplitId, HTMLDivElement>;
+};
+
+function MobileSwipeBackContainer(props: MobileSwipeBackContainerProps) {
+  const { splitManager, mobileSwipeLayout } = props;
+
+  const [dragOffset, setDragOffset] = createSignal(0);
+  const [isDragging, setIsDragging] = createSignal(false);
+  const [isAnimatingOut, setIsAnimatingOut] = createSignal(false);
+
+  let startX = 0;
+  let startTime = 0;
+
+  function animateComplete(onDone: () => void) {
+    setIsAnimatingOut(true);
+    setDragOffset(window.innerWidth);
+    const t = setTimeout(() => {
+      batch(() => {
+        setIsAnimatingOut(false);
+        setDragOffset(0);
+        onDone();
+      });
+    }, SWIPE_ANIMATION_MS);
+    onCleanup(() => clearTimeout(t));
+  }
+
+  function animateSnapBack() {
+    setIsAnimatingOut(true);
+    setDragOffset(0);
+    const t = setTimeout(() => setIsAnimatingOut(false), SWIPE_ANIMATION_MS);
+    onCleanup(() => clearTimeout(t));
+  }
+
+  function triggerAnimatedSwipeBack() {
+    if (!mobileSwipeLayout.canGoBack()) return;
+    animateComplete(() => mobileSwipeLayout.completeSwipeBack());
+  }
+
+  // Register the animated trigger so the back button can invoke it.
+  onMount(() => mobileSwipeLayout.setAnimatedTrigger(triggerAnimatedSwipeBack));
+  onCleanup(() => mobileSwipeLayout.setAnimatedTrigger(undefined));
+
+  function handleTouchStart(e: TouchEvent) {
+    if (!mobileSwipeLayout.canGoBack()) return;
+    const touch = e.touches[0];
+    if (!touch || touch.clientX > SWIPE_EDGE_THRESHOLD) return;
+    startX = touch.clientX;
+    startTime = Date.now();
+    setIsDragging(true);
+  }
+
+  function handleTouchMove(e: TouchEvent) {
+    if (!isDragging()) return;
+    const touch = e.touches[0];
+    if (!touch) return;
+    const dx = Math.max(0, touch.clientX - startX);
+    setDragOffset(dx);
+  }
+
+  function handleTouchEnd() {
+    if (!isDragging()) return;
+    setIsDragging(false);
+    const dx = dragOffset();
+    const elapsed = Date.now() - startTime;
+    const velocity = elapsed > 0 ? dx / elapsed : 0;
+    const threshold = window.innerWidth * SWIPE_DISTANCE_THRESHOLD;
+    if (dx > threshold || velocity > SWIPE_VELOCITY_THRESHOLD) {
+      animateComplete(() => mobileSwipeLayout.completeSwipeBack());
+    } else {
+      animateSnapBack();
+    }
+  }
+
+  const slotAData = createMemo(() => {
+    const id = mobileSwipeLayout.slotASplitId();
+    if (!id) return undefined;
+    const split = props.splits().find((s) => s.id === id);
+    const rawHandle = splitManager.getSplit(id);
+    if (!split || !rawHandle) return undefined;
+    const handle: SplitHandle = {
+      ...rawHandle,
+      goBack: () => mobileSwipeLayout.swipeBack(),
+      canGoBack: () => mobileSwipeLayout.canGoBack(),
+    };
+    return { split, handle };
+  });
+
+  const slotBData = createMemo(() => {
+    const id = mobileSwipeLayout.slotBSplitId();
+    if (!id) return undefined;
+    const split = props.splits().find((s) => s.id === id);
+    const rawHandle = splitManager.getSplit(id);
+    if (!split || !rawHandle) return undefined;
+    const handle: SplitHandle = {
+      ...rawHandle,
+      goBack: () => mobileSwipeLayout.swipeBack(),
+      canGoBack: () => mobileSwipeLayout.canGoBack(),
+    };
+    return { split, handle };
+  });
+
+  // FG translation style — applied only to the currently-active FG slot div.
+  const fgStyle = () => ({
+    transform: `translateX(${dragOffset()}px)`,
+    transition: isDragging()
+      ? 'none'
+      : isAnimatingOut()
+        ? `transform ${SWIPE_ANIMATION_MS}ms ease-out`
+        : 'none',
+    'will-change': 'transform',
+  });
+
+  return (
+    <div
+      class="relative size-full overflow-hidden"
+      onTouchStart={handleTouchStart}
+      onTouchMove={handleTouchMove}
+      onTouchEnd={handleTouchEnd}
+      onTouchCancel={handleTouchEnd}
+    >
+      <Show when={slotAData()}>
+        {(a) => (
+          <div
+            class={cn('absolute inset-0', {
+              'z-10': mobileSwipeLayout.fgIsSlotA(),
+              '-z-100 pointer-events-none': !mobileSwipeLayout.fgIsSlotA(),
+            })}
+            style={mobileSwipeLayout.fgIsSlotA() ? fgStyle() : undefined}
+          >
+            {/*
+             * Key by content id so that SplitPanel (and its soup state) remounts when the slot's content changes, needed for dock / soup-view navigation.
+             */}
+            <Show when={a().split.content.id} keyed>
+              {(_contentId) => (
+                <Suspense>
+                  <SplitPanel
+                    split={a().split}
+                    handle={a().handle}
+                    active={mobileSwipeLayout.fgIsSlotA()}
+                    setPanelRef={(ref) =>
+                      props.panelRefs.set(a().split.id, ref)
+                    }
+                    index={0}
+                  />
+                </Suspense>
+              )}
+            </Show>
+          </div>
+        )}
+      </Show>
+
+      <Show when={slotBData()}>
+        {(b) => (
+          <div
+            class={cn('absolute inset-0', {
+              'z-10': !mobileSwipeLayout.fgIsSlotA(),
+              '-z-100 pointer-events-none': mobileSwipeLayout.fgIsSlotA(),
+            })}
+            style={!mobileSwipeLayout.fgIsSlotA() ? fgStyle() : undefined}
+          >
+            <Show when={b().split.content.id} keyed>
+              {(_contentId) => (
+                <Suspense>
+                  <SplitPanel
+                    split={b().split}
+                    handle={b().handle}
+                    active={!mobileSwipeLayout.fgIsSlotA()}
+                    setPanelRef={(ref) =>
+                      props.panelRefs.set(b().split.id, ref)
+                    }
+                    index={1}
+                  />
+                </Suspense>
+              )}
+            </Show>
+          </div>
+        )}
+      </Show>
+    </div>
   );
 }

--- a/js/app/packages/app/component/split-layout/components/PopoverSplitRenderer.tsx
+++ b/js/app/packages/app/component/split-layout/components/PopoverSplitRenderer.tsx
@@ -73,6 +73,8 @@ function PopoverSplitModal(props: {
     removeFromHistory: () => {},
     registerContentChangeListener: () => {},
     unregisterContentChangeListener: () => {},
+    previousContent: () => null,
+    history: () => [],
     getUrlSegments: () => [],
     getUrl: () => '',
     meta: () =>

--- a/js/app/packages/app/component/split-layout/components/SplitContainer.tsx
+++ b/js/app/packages/app/component/split-layout/components/SplitContainer.tsx
@@ -90,8 +90,6 @@ export function SplitContainer(
             'opacity-100': panel.isPanelActive() || panel.handle.isSpotLight(),
             'size-full': !panel.handle.isSpotLight(),
             'opacity-85': !panel.isPanelActive(),
-            // On mobile swipe back, we want smooth opacity shift
-            'transition-opacity': isMobile(),
           }}
           ref={(ref) => {
             setRef(ref);

--- a/js/app/packages/app/component/split-layout/components/SplitContainer.tsx
+++ b/js/app/packages/app/component/split-layout/components/SplitContainer.tsx
@@ -87,10 +87,11 @@ export function SplitContainer(
           classList={{
             'fixed inset-[4rem] z-modal-overlay isolate opacity-50':
               panel.handle.isSpotLight(),
-            'opacity-100':
-              panel.handle.isActive() || panel.handle.isSpotLight(),
+            'opacity-100': panel.isPanelActive() || panel.handle.isSpotLight(),
             'size-full': !panel.handle.isSpotLight(),
-            'opacity-85': !panel.handle.isActive(),
+            'opacity-85': !panel.isPanelActive(),
+            // On mobile swipe back, we want smooth opacity shift
+            'transition-opacity': isMobile(),
           }}
           ref={(ref) => {
             setRef(ref);
@@ -104,7 +105,7 @@ export function SplitContainer(
         >
           <MaybeClippedPanel
             active={
-              panel.handle.isActive() &&
+              panel.isPanelActive() &&
               multipleSplits() &&
               !panel.handle.isSpotLight()
             }

--- a/js/app/packages/app/component/split-layout/components/SplitContainer.tsx
+++ b/js/app/packages/app/component/split-layout/components/SplitContainer.tsx
@@ -89,7 +89,7 @@ export function SplitContainer(
               panel.handle.isSpotLight(),
             'opacity-100': panel.isPanelActive() || panel.handle.isSpotLight(),
             'size-full': !panel.handle.isSpotLight(),
-            'opacity-85': !panel.isPanelActive(),
+            'opacity-85': !panel.isPanelActive() && !isMobile(),
           }}
           ref={(ref) => {
             setRef(ref);

--- a/js/app/packages/app/component/split-layout/components/SplitPanel.tsx
+++ b/js/app/packages/app/component/split-layout/components/SplitPanel.tsx
@@ -1,0 +1,107 @@
+import { createSoupState } from '@app/component/next-soup/create-soup-state';
+import { SoupContextProvider } from '@app/component/next-soup/soup-context';
+import { createElementSize } from '@solid-primitives/resize-observer';
+import { useHotkeyDOMScope } from 'core/hotkey/hotkeys';
+import { createSignal, Suspense } from 'solid-js';
+import { Dynamic } from 'solid-js/web';
+import { SplitContainer } from './SplitContainer';
+import { SplitPanelContext, type SplitPanelContextType } from '../context';
+import { useSplitLayout } from '../layout';
+import type { SplitHandle, SplitState } from '../layoutManager';
+import { createHeaderCollapser } from '../utils/createHeaderCollapser';
+import { registerSplitHotkeys } from '../registerSplitHotkeys';
+import { isListViewID } from '@app/constants/list-views';
+import { isMobile } from '@core/mobile/isMobile';
+
+export type SplitPanelProps = {
+  split: SplitState;
+  handle: SplitHandle;
+  active: boolean;
+  setPanelRef: (ref: HTMLDivElement) => void;
+  index: number;
+};
+
+export function SplitPanel(props: SplitPanelProps) {
+  const [panelRef, setPanelRef] = createSignal<HTMLDivElement | null>(null);
+  const [attachHotKeys, splitHotkeyScope] = useHotkeyDOMScope(
+    `split=${props.split.id}`
+  );
+
+  const panelSize = createElementSize(panelRef);
+  const [contentOffsetTop, setContentOffsetTop] = createSignal(0);
+
+  const [previewState, setPreviewState] = createSignal(false);
+
+  const layoutRefs: SplitPanelContextType['layoutRefs'] = {};
+  const headerCollapser = createHeaderCollapser(
+    () => layoutRefs.headerLeft,
+    () => panelSize.width
+  );
+
+  const splitLayoutHelpers = useSplitLayout();
+  registerSplitHotkeys({
+    splitHotkeyScope,
+    insertSplit: splitLayoutHelpers.insertSplit,
+    closeSplit: () => props.handle.close(),
+    toggleSpotlight: () => props.handle.toggleSpotlight(),
+    canGoBack: () => props.handle.canGoBack(),
+    goBack: () => props.handle.goBack(),
+    canGoForward: () => props.handle.canGoForward(),
+    goForward: () => props.handle.goForward(),
+    replaceSplit: splitLayoutHelpers.replaceSplit,
+    splitName: () => props.handle.displayName(),
+    getSplitCount: () => splitLayoutHelpers.getSplitCount(),
+    isNotUnifiedList: () => {
+      const content = props.handle.content();
+      return !isListViewID(content.id);
+    },
+  });
+
+  const nextSoup = createSoupState({
+    initialFilters: ['explicit-noise'],
+  });
+
+  return (
+    <SoupContextProvider soup={nextSoup}>
+      <SplitPanelContext.Provider
+        value={{
+          handle: props.handle,
+          splitHotkeyScope,
+          isPanelActive: () => props.active,
+          panelRef,
+          panelSize,
+          layoutRefs,
+          contentOffsetTop,
+          setContentOffsetTop,
+          previewState: [previewState, setPreviewState],
+          headerCollapser,
+        }}
+      >
+        <SplitContainer
+          id={props.split.id}
+          ref={(ref) => {
+            setPanelRef(ref);
+            props.setPanelRef(ref);
+            attachHotKeys(ref);
+          }}
+          tl={props.index === 0 && !isMobile()}
+          bl={props.index === 0 && !isMobile()}
+          tr={
+            splitLayoutHelpers.getSplitCount() > 1 &&
+            props.index === splitLayoutHelpers.getSplitCount() - 1 &&
+            !isMobile()
+          }
+          br={
+            splitLayoutHelpers.getSplitCount() > 1 &&
+            props.index === splitLayoutHelpers.getSplitCount() - 1 &&
+            !isMobile()
+          }
+        >
+          <Suspense>
+            <Dynamic component={props.split.mount.element} />
+          </Suspense>
+        </SplitContainer>
+      </SplitPanelContext.Provider>
+    </SoupContextProvider>
+  );
+}

--- a/js/app/packages/app/component/split-layout/layout.ts
+++ b/js/app/packages/app/component/split-layout/layout.ts
@@ -21,7 +21,6 @@ export function useSplitLayout() {
       return;
     }
 
-    // On mobile, never open in new split
     const preferNewSplit = isMobile() ? false : options?.preferNewSplit;
 
     return splitManager.openWithSplit(content, {
@@ -96,7 +95,8 @@ export function useSplitLayout() {
     if (!splitManager) {
       return 0;
     }
-    return splitManager.splits().length;
+    // Exclude background splits (mobile swipe-back) from the visible count.
+    return splitManager.splits().filter((s) => !s.isBackground).length;
   }
 
   return {

--- a/js/app/packages/app/component/split-layout/layout.ts
+++ b/js/app/packages/app/component/split-layout/layout.ts
@@ -95,8 +95,7 @@ export function useSplitLayout() {
     if (!splitManager) {
       return 0;
     }
-    // Exclude background splits (mobile swipe-back) from the visible count.
-    return splitManager.splits().filter((s) => !s.isBackground).length;
+    return splitManager.getVisibleSplitCount();
   }
 
   return {

--- a/js/app/packages/app/component/split-layout/layoutManager.ts
+++ b/js/app/packages/app/component/split-layout/layoutManager.ts
@@ -750,7 +750,7 @@ export function createSplitLayout(
     const s = () => findSplitById(id);
     const currentSplit = s();
     if (!currentSplit) return;
-    const content = () => currentSplit.content;
+    const content = () => s()!.content;
 
     return {
       id: currentSplit.id,

--- a/js/app/packages/app/component/split-layout/layoutManager.ts
+++ b/js/app/packages/app/component/split-layout/layoutManager.ts
@@ -117,6 +117,8 @@ export type SplitState = {
   content: SplitContent; // mirror of current history entry
   mount: SplitMount; // contains pinned element
   referredFrom: ReferredFrom;
+  /** When true, this split is the mobile background (previous page). Excluded from URL encoding. */
+  isBackground?: boolean;
 };
 
 export type CreateNewSplitOptions = {
@@ -124,6 +126,15 @@ export type CreateNewSplitOptions = {
   activate?: boolean;
   allowDuplicate?: boolean;
   referredFrom: ReferredFrom;
+  /** When true, marks this split as a mobile background split (excluded from URL). */
+  isBackground?: boolean;
+  /**
+   * Optional prior navigation entries to pre-populate this split's history stack.
+   * The `content` field is appended as the final (current) entry.
+   * Used by the mobile swipe-back system to give BG splits an accurate history so
+   * `previousContent()` is correct if this split is ever promoted to foreground.
+   */
+  initialHistory?: SplitContent[];
 };
 
 export type OpenWithSplitOptions = {
@@ -136,6 +147,16 @@ export type OpenWithSplitOptions = {
   preferNewSplit?: boolean;
   handle?: SplitHandle;
 };
+
+/**
+ * Callback injected by the mobile swipe layout to intercept forward navigation.
+ * When set, `openWithSplit` delegates to this instead of its normal split logic,
+ * so the previous page stays mounted as a background split for swipe-back.
+ */
+export type MobileForwardOverride = (
+  content: SplitContent,
+  options?: { referredFrom?: ReferredFrom }
+) => void;
 
 function keyOfSplitState(s: SplitState): SplitKey {
   return `${s.content.type}:${s.content.id}`;
@@ -222,7 +243,7 @@ export type SplitManager = {
   openWithSplit: (
     content: SplitContent,
     options?: OpenWithSplitOptions
-  ) => SplitHandle;
+  ) => SplitHandle | undefined;
 
   /** Set a split as active by its split id  */
   activateSplit: (id: SplitId) => void;
@@ -284,6 +305,16 @@ export type SplitManager = {
   /** Close all popover splits */
   closeAllPopovers: () => void;
 
+  /** Set or clear the background flag on a split (used by mobile swipe-back). */
+  setBackground: (id: SplitId, value: boolean) => void;
+
+  /**
+   * Register a mobile forward-navigation override.
+   * When set, `openWithSplit` calls this instead of its normal split logic,
+   * keeping the old page alive as a background split for swipe-back.
+   */
+  setMobileForwardOverride: (fn: MobileForwardOverride | undefined) => void;
+
   /** Get reactive accessor to popovers map */
   popovers: () => Map<
     string,
@@ -327,6 +358,12 @@ export type SplitHandle<TMeta extends ComponentMeta = ComponentMeta> = {
   goBack: () => void;
   close: () => void;
   reset: () => void;
+  /** Returns the content item one step back in this split's history, without mutating. */
+  previousContent: () => SplitContent | null;
+  /**
+   * Returns all history items up to and including the current one.
+   */
+  history: () => SplitContent[];
   id: SplitId;
   /** Component metadata store (only available for component splits) */
   meta: () => Store<TMeta> | undefined;
@@ -394,9 +431,9 @@ function isDuplicateSplit(
   splits: SplitState[],
   content: SplitContent
 ): boolean {
-  return splits.some((split) =>
-    sameNonComponentIdentity(split.content, content)
-  );
+  return splits
+    .filter((s) => !s.isBackground)
+    .some((split) => sameNonComponentIdentity(split.content, content));
 }
 
 export function createSplitLayout(
@@ -432,6 +469,9 @@ export function createSplitLayout(
 
   const [resizeContext, setResizeContext] = createSignal<ResizeZoneCtx>();
 
+  // Injected by the mobile swipe layout to intercept forward navigation.
+  let mobileForwardOverride: MobileForwardOverride | undefined;
+
   const canAppendSplit = createMemo(
     () => resizeContext()?.canFit({ minSize: 400 }) ?? true
   );
@@ -460,19 +500,38 @@ export function createSplitLayout(
     ]);
   }
 
+  const findSplitById = (id: SplitId) => state.splits.find((s) => s.id === id);
+  const splitIndexById = (id: SplitId) =>
+    state.splits.findIndex((s) => s.id === id);
+
   function buildSplit(options: {
     initialContent: SplitContent;
     isDefault?: boolean;
     referredFrom?: ReferredFrom;
+    isBackground?: boolean;
+    initialHistory?: SplitContent[];
   }): SplitState {
-    const { initialContent, isDefault, referredFrom } = options;
+    const {
+      initialContent,
+      isDefault,
+      referredFrom,
+      isBackground,
+      initialHistory,
+    } = options;
     const id = newSplitId();
     const history = createHistory<SplitContent>();
     const content = attachAliasContext(initialContent);
 
-    // If enabled, we always want to be able to go back to the default split
-    if (!isDefault && ENABLE_DEFAULT_ALWAYS_IN_HISTORY) {
-      history.push(DEFAULT_SPLIT_CONTENT);
+    if (initialHistory && initialHistory.length > 0) {
+      // Pre-populate prior navigation entries so previousContent() is accurate.
+      for (const item of initialHistory) {
+        history.push(attachAliasContext(item));
+      }
+    } else {
+      // If enabled, we always want to be able to go back to the default split
+      if (!isDefault && ENABLE_DEFAULT_ALWAYS_IN_HISTORY) {
+        history.push(DEFAULT_SPLIT_CONTENT);
+      }
     }
 
     history.push(content);
@@ -484,6 +543,7 @@ export function createSplitLayout(
       content,
       mount,
       referredFrom: referredFrom ?? null,
+      isBackground: isBackground ?? false,
     };
   }
 
@@ -496,7 +556,7 @@ export function createSplitLayout(
     const content = attachAliasContext(next);
     if (isDuplicateSplit(otherSplits, next)) return;
 
-    const splitIndex = state.splits.findIndex((s) => s.id === split.id);
+    const splitIndex = splitIndexById(split.id);
     if (splitIndex >= 0 && !sameIdentity(split.content, content)) {
       setSplitNamesById(
         produce((map) => {
@@ -556,7 +616,7 @@ export function createSplitLayout(
   }
 
   function back(id: SplitId) {
-    const i = state.splits.findIndex((s) => s.id === id);
+    const i = splitIndexById(id);
     if (i < 0) return console.error(`Split with id ${id} not found`);
 
     const split = state.splits[i];
@@ -569,7 +629,7 @@ export function createSplitLayout(
   }
 
   function forward(id: SplitId) {
-    const i = state.splits.findIndex((s) => s.id === id);
+    const i = splitIndexById(id);
     if (i < 0) return console.error(`Split with id ${id} not found`);
 
     const split = state.splits[i];
@@ -585,7 +645,7 @@ export function createSplitLayout(
     id: SplitId,
     predicate: (content: SplitContent) => boolean
   ) {
-    const i = state.splits.findIndex((s) => s.id === id);
+    const i = splitIndexById(id);
     if (i < 0) return console.error(`Split with id ${id} not found`);
 
     const split = state.splits[i];
@@ -607,7 +667,7 @@ export function createSplitLayout(
     }
   ) {
     const { next, mergeHistory, referredFrom } = options;
-    const i = state.splits.findIndex((s) => s.id === id);
+    const i = splitIndexById(id);
     if (i < 0) return console.error(`Split with id ${id} not found`);
 
     const content = attachAliasContext(next);
@@ -623,7 +683,7 @@ export function createSplitLayout(
   }
 
   function reset(id: SplitId) {
-    const i = state.splits.findIndex((s) => s.id === id);
+    const i = splitIndexById(id);
     if (i < 0) return console.error(`Split with id ${id} not found`);
 
     const split = state.splits[i];
@@ -633,6 +693,7 @@ export function createSplitLayout(
 
   const getUrlSegments = () => {
     return state.splits
+      .filter((s) => !s.isBackground)
       .flatMap((s) => [getAliasOrType(s.content), s.content.id])
       .map(String);
   };
@@ -658,7 +719,7 @@ export function createSplitLayout(
     if (state.splits.length <= 1 && !isSettingsPanelOpen()) {
       return;
     }
-    const split = state.splits.find((s) => s.id === id);
+    const split = findSplitById(id);
     if (!split) {
       console.error(`Split with id ${id} not found`);
       return;
@@ -689,10 +750,10 @@ export function createSplitLayout(
   }
 
   const getSplit = (id: SplitId): SplitHandle | undefined => {
-    const s = () => state.splits.find((x) => x.id === id);
+    const s = () => findSplitById(id);
     const currentSplit = s();
     if (!currentSplit) return;
-    const content = () => s()!.content;
+    const content = () => currentSplit.content;
 
     return {
       id: currentSplit.id,
@@ -707,6 +768,17 @@ export function createSplitLayout(
         replace(currentSplit.id, { next, mergeHistory, referredFrom }),
       removeFromHistory: (predicate: (content: SplitContent) => boolean) => {
         removeFromHistory(currentSplit.id, predicate);
+      },
+      previousContent: () => {
+        const s = findSplitById(currentSplit.id);
+        if (!s) return null;
+        const idx = s.history.index;
+        return idx > 0 ? (s.history.items[idx - 1] ?? null) : null;
+      },
+      history: () => {
+        const s = findSplitById(currentSplit.id);
+        if (!s) return [];
+        return s.history.items.slice(0, s.history.index + 1) as SplitContent[];
       },
       close: () => {
         // If there's only one split and it's the default split, then no-op
@@ -769,7 +841,14 @@ export function createSplitLayout(
   };
 
   function createNewSplit(options: CreateNewSplitOptions): SplitHandle {
-    const { content, activate, referredFrom, allowDuplicate } = options;
+    const {
+      content,
+      activate,
+      referredFrom,
+      allowDuplicate,
+      isBackground,
+      initialHistory,
+    } = options;
     const initialContent = content ?? DEFAULT_SPLIT_CONTENT;
     const isDefault = sameContent(initialContent, DEFAULT_SPLIT_CONTENT);
 
@@ -783,7 +862,13 @@ export function createSplitLayout(
       return getSplit(existingSplit!.id)!;
     }
 
-    const split = buildSplit({ initialContent, isDefault, referredFrom });
+    const split = buildSplit({
+      initialContent,
+      isDefault,
+      referredFrom,
+      isBackground,
+      initialHistory,
+    });
 
     setState('splits', (previousSplits) => [...previousSplits, split]);
 
@@ -803,7 +888,7 @@ export function createSplitLayout(
   }
 
   function removeSplit(id: SplitId, createNewOnEmpty: boolean = true) {
-    const idx = state.splits.findIndex((s) => s.id === id);
+    const idx = splitIndexById(id);
     if (idx < 0) return;
 
     contentChangeListeners.delete(id);
@@ -835,7 +920,7 @@ export function createSplitLayout(
     id: string
   ): SplitHandle | undefined {
     const match = state.splits.find(
-      (s) => s.content.type === type && s.content.id === id
+      (s) => s.content.type === type && s.content.id === id && !s.isBackground
     );
     if (!match) return;
     return getSplit(match.id);
@@ -983,7 +1068,14 @@ export function createSplitLayout(
   function openWithSplit(
     content: SplitContent,
     options: OpenWithSplitOptions = {}
-  ): SplitHandle {
+  ): SplitHandle | undefined {
+    // Mobile: delegate forward navigation to the swipe layout so the previous
+    // page stays mounted as a background split for swipe-back.
+    if (mobileForwardOverride && !options.mergeHistory) {
+      mobileForwardOverride(content, { referredFrom: options.referredFrom });
+      return undefined;
+    }
+
     const existingSplit = getSplitByContent(content.type, content.id);
 
     if (!options.allowDuplicate && existingSplit) {
@@ -1081,5 +1173,13 @@ export function createSplitLayout(
     closeAllPopovers,
     popovers: () => state.popovers,
     canAppendSplit,
+    setBackground: (id: SplitId, value: boolean) => {
+      setState('splits', (splits) =>
+        splits.map((s) => (s.id === id ? { ...s, isBackground: value } : s))
+      );
+    },
+    setMobileForwardOverride: (fn: MobileForwardOverride | undefined) => {
+      mobileForwardOverride = fn;
+    },
   };
 }

--- a/js/app/packages/app/component/split-layout/layoutManager.ts
+++ b/js/app/packages/app/component/split-layout/layoutManager.ts
@@ -117,8 +117,6 @@ export type SplitState = {
   content: SplitContent; // mirror of current history entry
   mount: SplitMount; // contains pinned element
   referredFrom: ReferredFrom;
-  /** When true, this split is the mobile background (previous page). Excluded from URL encoding. */
-  isBackground: boolean;
 };
 
 export type CreateNewSplitOptions = {
@@ -126,13 +124,9 @@ export type CreateNewSplitOptions = {
   activate?: boolean;
   allowDuplicate?: boolean;
   referredFrom: ReferredFrom;
-  /** When true, marks this split as a mobile background split (excluded from URL). */
-  isBackground?: boolean;
   /**
    * Optional prior navigation entries to pre-populate this split's history stack.
    * The `content` field is appended as the final (current) entry.
-   * Used by the mobile swipe-back system to give BG splits an accurate history so
-   * `previousContent()` is correct if this split is ever promoted to foreground.
    */
   initialHistory?: SplitContent[];
 };
@@ -149,14 +143,14 @@ export type OpenWithSplitOptions = {
 };
 
 /**
- * Callback injected by the mobile swipe layout to intercept forward navigation.
- * When set, `openWithSplit` delegates to this instead of its normal split logic,
- * so the previous page stays mounted as a background split for swipe-back.
+ * A navigation interceptor registered by, e.g. mobile swipe layout.
+ * Called at the start of `openWithSplit`. Return `{ handled: true }` to consume
+ * the navigation; return `{ handled: false }` to let the normal split logic run.
  */
-export type MobileForwardOverride = (
+export type NavigationInterceptor = (
   content: SplitContent,
-  options?: { referredFrom?: ReferredFrom }
-) => void;
+  options: OpenWithSplitOptions
+) => { handled: boolean };
 
 function keyOfSplitState(s: SplitState): SplitKey {
   return `${s.content.type}:${s.content.id}`;
@@ -305,15 +299,23 @@ export type SplitManager = {
   /** Close all popover splits */
   closeAllPopovers: () => void;
 
-  /** Set or clear the background flag on a split (used by mobile swipe-back). */
-  setBackground: (id: SplitId, value: boolean) => void;
+  /** Count of splits not excluded by the current exclusion filter. */
+  getVisibleSplitCount: () => number;
 
   /**
-   * Register a mobile forward-navigation override.
-   * When set, `openWithSplit` calls this instead of its normal split logic,
-   * keeping the old page alive as a background split for swipe-back.
+   * Register a predicate that marks certain splits as excluded — excluded splits
+   * are hidden from URL encoding, duplicate detection, and content lookup.
+   * Used for mobile swipe back behavior, where we want to ignore the bg split.
    */
-  setMobileForwardOverride: (fn: MobileForwardOverride | undefined) => void;
+  setExclusionFilter: (
+    fn: ((split: SplitState) => boolean) | undefined
+  ) => void;
+
+  /**
+   * Register a navigation interceptor. Called at the start of `openWithSplit`;
+   * if it returns `{ handled: true }` the normal split logic is skipped.
+   */
+  setNavigationInterceptor: (fn: NavigationInterceptor | undefined) => void;
 
   /** Get reactive accessor to popovers map */
   popovers: () => Map<
@@ -429,10 +431,11 @@ function sameNonComponentIdentity(a: SplitContent, b: SplitContent): boolean {
 
 function isDuplicateSplit(
   splits: SplitState[],
-  content: SplitContent
+  content: SplitContent,
+  isExcluded: (split: SplitState) => boolean = () => false
 ): boolean {
   return splits
-    .filter((s) => !s.isBackground)
+    .filter((s) => !isExcluded(s))
     .some((split) => sameNonComponentIdentity(split.content, content));
 }
 
@@ -469,8 +472,9 @@ export function createSplitLayout(
 
   const [resizeContext, setResizeContext] = createSignal<ResizeZoneCtx>();
 
-  // Injected by the mobile swipe layout to intercept forward navigation.
-  let mobileForwardOverride: MobileForwardOverride | undefined;
+  let exclusionFilter: ((split: SplitState) => boolean) | undefined;
+  let navigationInterceptor: NavigationInterceptor | undefined;
+  const isExcluded = (split: SplitState) => exclusionFilter?.(split) ?? false;
 
   const canAppendSplit = createMemo(
     () => resizeContext()?.canFit({ minSize: 400 }) ?? true
@@ -508,16 +512,9 @@ export function createSplitLayout(
     initialContent: SplitContent;
     isDefault?: boolean;
     referredFrom?: ReferredFrom;
-    isBackground?: boolean;
     initialHistory?: SplitContent[];
   }): SplitState {
-    const {
-      initialContent,
-      isDefault,
-      referredFrom,
-      isBackground,
-      initialHistory,
-    } = options;
+    const { initialContent, isDefault, referredFrom, initialHistory } = options;
     const id = newSplitId();
     const history = createHistory<SplitContent>();
     const content = attachAliasContext(initialContent);
@@ -543,7 +540,6 @@ export function createSplitLayout(
       content,
       mount,
       referredFrom: referredFrom ?? null,
-      isBackground: isBackground ?? false,
     };
   }
 
@@ -693,13 +689,13 @@ export function createSplitLayout(
 
   const getUrlSegments = () => {
     return state.splits
-      .filter((s) => !s.isBackground)
+      .filter((s) => !isExcluded(s))
       .flatMap((s) => [getAliasOrType(s.content), s.content.id])
       .map(String);
   };
 
   const getUrl = () => {
-    const visibleSplits = state.splits.filter((s) => !s.isBackground);
+    const visibleSplits = state.splits.filter((s) => !isExcluded(s));
     return (
       visibleSplits.map((s) => getAliasOrType(s.content)).join('/') +
       '/' +
@@ -842,18 +838,15 @@ export function createSplitLayout(
   };
 
   function createNewSplit(options: CreateNewSplitOptions): SplitHandle {
-    const {
-      content,
-      activate,
-      referredFrom,
-      allowDuplicate,
-      isBackground,
-      initialHistory,
-    } = options;
+    const { content, activate, referredFrom, allowDuplicate, initialHistory } =
+      options;
     const initialContent = content ?? DEFAULT_SPLIT_CONTENT;
     const isDefault = sameContent(initialContent, DEFAULT_SPLIT_CONTENT);
 
-    if (!allowDuplicate && isDuplicateSplit(state.splits, initialContent)) {
+    if (
+      !allowDuplicate &&
+      isDuplicateSplit(state.splits, initialContent, isExcluded)
+    ) {
       const existingSplit = state.splits.find(
         (s) =>
           s.content.type === initialContent.type &&
@@ -867,7 +860,6 @@ export function createSplitLayout(
       initialContent,
       isDefault,
       referredFrom,
-      isBackground,
       initialHistory,
     });
 
@@ -921,7 +913,7 @@ export function createSplitLayout(
     id: string
   ): SplitHandle | undefined {
     const match = state.splits.find(
-      (s) => s.content.type === type && s.content.id === id && !s.isBackground
+      (s) => s.content.type === type && s.content.id === id && !isExcluded(s)
     );
     if (!match) return;
     return getSplit(match.id);
@@ -1070,11 +1062,9 @@ export function createSplitLayout(
     content: SplitContent,
     options: OpenWithSplitOptions = {}
   ): SplitHandle | undefined {
-    // Mobile: delegate forward navigation to the swipe layout so the previous
-    // page stays mounted as a background split for swipe-back.
-    if (mobileForwardOverride && !options.mergeHistory) {
-      mobileForwardOverride(content, { referredFrom: options.referredFrom });
-      return undefined;
+    if (navigationInterceptor) {
+      const result = navigationInterceptor(content, options);
+      if (result.handled) return undefined;
     }
 
     const existingSplit = getSplitByContent(content.type, content.id);
@@ -1174,13 +1164,13 @@ export function createSplitLayout(
     closeAllPopovers,
     popovers: () => state.popovers,
     canAppendSplit,
-    setBackground: (id: SplitId, value: boolean) => {
-      setState('splits', (splits) =>
-        splits.map((s) => (s.id === id ? { ...s, isBackground: value } : s))
-      );
+    getVisibleSplitCount: () =>
+      state.splits.filter((s) => !isExcluded(s)).length,
+    setExclusionFilter: (fn) => {
+      exclusionFilter = fn;
     },
-    setMobileForwardOverride: (fn: MobileForwardOverride | undefined) => {
-      mobileForwardOverride = fn;
+    setNavigationInterceptor: (fn) => {
+      navigationInterceptor = fn;
     },
   };
 }

--- a/js/app/packages/app/component/split-layout/layoutManager.ts
+++ b/js/app/packages/app/component/split-layout/layoutManager.ts
@@ -118,7 +118,7 @@ export type SplitState = {
   mount: SplitMount; // contains pinned element
   referredFrom: ReferredFrom;
   /** When true, this split is the mobile background (previous page). Excluded from URL encoding. */
-  isBackground?: boolean;
+  isBackground: boolean;
 };
 
 export type CreateNewSplitOptions = {
@@ -699,10 +699,11 @@ export function createSplitLayout(
   };
 
   const getUrl = () => {
+    const visibleSplits = state.splits.filter((s) => !s.isBackground);
     return (
-      state.splits.map((s) => getAliasOrType(s.content)).join('/') +
+      visibleSplits.map((s) => getAliasOrType(s.content)).join('/') +
       '/' +
-      state.splits.map((s) => s.content.id).join('/')
+      visibleSplits.map((s) => s.content.id).join('/')
     );
   };
 

--- a/js/app/packages/app/component/split-layout/mobile/MobileSwipeBackContainer.tsx
+++ b/js/app/packages/app/component/split-layout/mobile/MobileSwipeBackContainer.tsx
@@ -1,0 +1,228 @@
+import { cn } from '@ui/utils/classname';
+import {
+  type Accessor,
+  batch,
+  createMemo,
+  createSignal,
+  onCleanup,
+  onMount,
+  Show,
+  Suspense,
+} from 'solid-js';
+import type {
+  SplitHandle,
+  SplitId,
+  SplitManager,
+  SplitState,
+} from '../layoutManager';
+import type { MobileSwipeLayout } from './createMobileSwipeLayout';
+import { SplitPanel } from '../components/SplitPanel';
+
+const SWIPE_EDGE_THRESHOLD = 28; // px from left edge to initiate gesture
+const SWIPE_VELOCITY_THRESHOLD = 0.3; // px/ms — fast flick completes swipe
+const SWIPE_DISTANCE_THRESHOLD = 0.5; // fraction of screen width
+const SWIPE_ANIMATION_MS = 100;
+const BG_PEEK_OFFSET = 110; // px the BG panel is offset left at rest; closes to 0 as FG slides away
+
+export type MobileSwipeBackContainerProps = {
+  splitManager: SplitManager;
+  mobileSwipeLayout: MobileSwipeLayout;
+  splits: Accessor<ReadonlyArray<SplitState>>;
+  panelRefs: Map<SplitId, HTMLDivElement>;
+};
+
+export function MobileSwipeBackContainer(props: MobileSwipeBackContainerProps) {
+  const { splitManager, mobileSwipeLayout } = props;
+
+  const [dragOffset, setDragOffset] = createSignal(0);
+  const [isDragging, setIsDragging] = createSignal(false);
+  const [isAnimatingOut, setIsAnimatingOut] = createSignal(false);
+
+  let startX = 0;
+  let startTime = 0;
+  let animationTimer: ReturnType<typeof setTimeout> | undefined;
+  onCleanup(() => clearTimeout(animationTimer));
+
+  function animateComplete(onDone: () => void) {
+    setIsAnimatingOut(true);
+    setDragOffset(window.innerWidth);
+    animationTimer = setTimeout(() => {
+      batch(() => {
+        setIsAnimatingOut(false);
+        setDragOffset(0);
+        onDone();
+      });
+    }, SWIPE_ANIMATION_MS);
+  }
+
+  function animateSnapBack() {
+    setIsAnimatingOut(true);
+    setDragOffset(0);
+    animationTimer = setTimeout(
+      () => setIsAnimatingOut(false),
+      SWIPE_ANIMATION_MS
+    );
+  }
+
+  function triggerAnimatedSwipeBack() {
+    if (!mobileSwipeLayout.canGoBack()) return;
+    animateComplete(() => mobileSwipeLayout.completeSwipeBack());
+  }
+
+  // Register the animated trigger so the back button can invoke it.
+  onMount(() => mobileSwipeLayout.setAnimatedTrigger(triggerAnimatedSwipeBack));
+  onCleanup(() => mobileSwipeLayout.setAnimatedTrigger(undefined));
+
+  function handleTouchStart(e: TouchEvent) {
+    if (!mobileSwipeLayout.canGoBack()) return;
+    const touch = e.touches[0];
+    if (!touch || touch.clientX > SWIPE_EDGE_THRESHOLD) return;
+    startX = touch.clientX;
+    startTime = Date.now();
+    setIsDragging(true);
+  }
+
+  function handleTouchMove(e: TouchEvent) {
+    if (!isDragging()) return;
+    e.preventDefault();
+    const touch = e.touches[0];
+    if (!touch) return;
+    const dx = Math.max(0, touch.clientX - startX);
+    setDragOffset(dx);
+  }
+
+  function handleTouchEnd() {
+    if (!isDragging()) return;
+    setIsDragging(false);
+    const dx = dragOffset();
+    const elapsed = Date.now() - startTime;
+    const velocity = elapsed > 0 ? dx / elapsed : 0;
+    const threshold = window.innerWidth * SWIPE_DISTANCE_THRESHOLD;
+    if (dx > threshold || velocity > SWIPE_VELOCITY_THRESHOLD) {
+      animateComplete(() => mobileSwipeLayout.completeSwipeBack());
+    } else {
+      animateSnapBack();
+    }
+  }
+
+  const slotAData = createMemo(() => {
+    const id = mobileSwipeLayout.slotASplitId();
+    if (!id) return undefined;
+    const split = props.splits().find((s) => s.id === id);
+    const rawHandle = splitManager.getSplit(id);
+    if (!split || !rawHandle) return undefined;
+    const handle: SplitHandle = {
+      ...rawHandle,
+      goBack: () => mobileSwipeLayout.swipeBack(),
+      canGoBack: () => mobileSwipeLayout.canGoBack(),
+    };
+    return { split, handle };
+  });
+
+  const slotBData = createMemo(() => {
+    const id = mobileSwipeLayout.slotBSplitId();
+    if (!id) return undefined;
+    const split = props.splits().find((s) => s.id === id);
+    const rawHandle = splitManager.getSplit(id);
+    if (!split || !rawHandle) return undefined;
+    const handle: SplitHandle = {
+      ...rawHandle,
+      goBack: () => mobileSwipeLayout.swipeBack(),
+      canGoBack: () => mobileSwipeLayout.canGoBack(),
+    };
+    return { split, handle };
+  });
+
+  function getFgTransition(): string {
+    if (isDragging()) return 'none';
+    if (isAnimatingOut()) return `transform ${SWIPE_ANIMATION_MS}ms ease-out`;
+    return 'none';
+  }
+
+  // FG translation style — applied only to the currently-active FG slot div.
+  const fgStyle = () => ({
+    transform: `translateX(${dragOffset()}px)`,
+    transition: getFgTransition(),
+    'will-change': 'transform',
+  });
+
+  // BG parallax style — BG starts BG_PEEK_OFFSET px to the left and closes to 0 as FG slides away.
+  const bgStyle = () => ({
+    transform: `translateX(${-BG_PEEK_OFFSET + (dragOffset() / window.innerWidth) * BG_PEEK_OFFSET}px)`,
+    transition: getFgTransition(),
+    'will-change': 'transform',
+  });
+
+  return (
+    <div
+      class="relative size-full overflow-hidden"
+      on:touchstart={handleTouchStart}
+      on:touchmove={handleTouchMove}
+      on:touchend={handleTouchEnd}
+      on:touchcancel={() => {
+        if (!isDragging()) return;
+        setIsDragging(false);
+        animateSnapBack();
+      }}
+    >
+      <Show when={slotAData()}>
+        {(a) => (
+          <div
+            class={cn('absolute inset-0', {
+              'z-10 shadow-xl': mobileSwipeLayout.fgIsSlotA(),
+              'z-0 pointer-events-none': !mobileSwipeLayout.fgIsSlotA(),
+            })}
+            style={mobileSwipeLayout.fgIsSlotA() ? fgStyle() : bgStyle()}
+          >
+            {/*
+             * Key by content id so that SplitPanel (and its soup state) remounts when the slot's content changes, needed for dock / soup-view navigation.
+             */}
+            <Show when={a().split.content.id} keyed>
+              {(_contentId) => (
+                <Suspense>
+                  <SplitPanel
+                    split={a().split}
+                    handle={a().handle}
+                    active={mobileSwipeLayout.fgIsSlotA()}
+                    setPanelRef={(ref) =>
+                      props.panelRefs.set(a().split.id, ref)
+                    }
+                    index={0}
+                  />
+                </Suspense>
+              )}
+            </Show>
+          </div>
+        )}
+      </Show>
+
+      <Show when={slotBData()}>
+        {(b) => (
+          <div
+            class={cn('absolute inset-0', {
+              'z-10 shadow-xl': !mobileSwipeLayout.fgIsSlotA(),
+              'z-0 pointer-events-none': mobileSwipeLayout.fgIsSlotA(),
+            })}
+            style={!mobileSwipeLayout.fgIsSlotA() ? fgStyle() : bgStyle()}
+          >
+            <Show when={b().split.content.id} keyed>
+              {(_contentId) => (
+                <Suspense>
+                  <SplitPanel
+                    split={b().split}
+                    handle={b().handle}
+                    active={!mobileSwipeLayout.fgIsSlotA()}
+                    setPanelRef={(ref) =>
+                      props.panelRefs.set(b().split.id, ref)
+                    }
+                    index={1}
+                  />
+                </Suspense>
+              )}
+            </Show>
+          </div>
+        )}
+      </Show>
+    </div>
+  );
+}

--- a/js/app/packages/app/component/split-layout/mobile/MobileSwipeBackContainer.tsx
+++ b/js/app/packages/app/component/split-layout/mobile/MobileSwipeBackContainer.tsx
@@ -21,7 +21,7 @@ import { SplitPanel } from '../components/SplitPanel';
 const SWIPE_EDGE_THRESHOLD = 28; // px from left edge to initiate gesture
 const SWIPE_VELOCITY_THRESHOLD = 0.3; // px/ms — fast flick completes swipe
 const SWIPE_DISTANCE_THRESHOLD = 0.5; // fraction of screen width
-const SWIPE_ANIMATION_MS = 100;
+const SWIPE_ANIMATION_MS = 88;
 const BG_PEEK_OFFSET = 110; // px the BG panel is offset left at rest; closes to 0 as FG slides away
 
 export type MobileSwipeBackContainerProps = {

--- a/js/app/packages/app/component/split-layout/mobile/createMobileSwipeLayout.ts
+++ b/js/app/packages/app/component/split-layout/mobile/createMobileSwipeLayout.ts
@@ -129,6 +129,8 @@ export function createMobileSwipeLayout(
         splitManager.removeSplit(currentFgId);
       }
 
+      splitManager.activateSplit(currentBgId);
+
       const newBgHandle = newBgContent
         ? splitManager.createNewSplit({
             content: newBgContent,

--- a/js/app/packages/app/component/split-layout/mobile/createMobileSwipeLayout.ts
+++ b/js/app/packages/app/component/split-layout/mobile/createMobileSwipeLayout.ts
@@ -1,4 +1,4 @@
-import { batch, createSignal } from 'solid-js';
+import { batch, createSignal, onCleanup } from 'solid-js';
 import type {
   OpenWithSplitOptions,
   ReferredFrom,
@@ -8,23 +8,19 @@ import type {
 } from '../layoutManager';
 
 export type MobileSwipeLayout = {
+  /** Split ID currently in slot A (may be FG or BG depending on fgIsSlotA). */
   slotASplitId: () => SplitId | undefined;
+  /** Split ID currently in slot B (may be FG or BG depending on fgIsSlotA). */
   slotBSplitId: () => SplitId | undefined;
   /** True when slot A is the foreground; false when slot B is the foreground. */
   fgIsSlotA: () => boolean;
+  /** True when a background split is available to swipe back to. */
   canGoBack: () => boolean;
   /**
-   * Intercepts forward navigation on mobile.
-   * Puts the new content into the current BG slot, demotes the current FG to BG,
-   * then flips the FG/BG role — zero remount on the new FG slot.
-   */
-  navigateForward: (
-    content: SplitContent,
-    options?: Pick<OpenWithSplitOptions, 'referredFrom'>
-  ) => void;
-  /**
-   * Completes a swipe-back. Flips the FG/BG role so the current BG slot becomes FG, destroys the old FG, and mounts a
+   * Completes a swipe-back. Flips the FG/BG role so the current BG slot becomes FG
+   * (no remount for the promoted panel), destroys the old FG, and lazily mounts a
    * new BG from the promoted split's history into the old FG slot.
+   * Called by MobileSwipeBackContainer after its animation finishes.
    */
   completeSwipeBack: () => void;
   /**
@@ -33,7 +29,8 @@ export type MobileSwipeLayout = {
    */
   setAnimatedTrigger: (trigger: (() => void) | undefined) => void;
   /**
-   * Initiate a swipe-back
+   * Initiate a swipe-back — animated if container has registered a trigger,
+   * otherwise completes immediately. Called by the split header back button.
    */
   swipeBack: () => void;
 };
@@ -58,6 +55,19 @@ export function createMobileSwipeLayout(
 
   const fgSplitId = () => (fgIsSlotA() ? slotASplitId() : slotBSplitId());
   const bgSplitId = () => (fgIsSlotA() ? slotBSplitId() : slotASplitId());
+
+  // The BG split is always exactly bgSplitId() — derive exclusion directly from
+  // the slot signals rather than maintaining a separate set.
+  splitManager.setExclusionFilter((split) => split.id === bgSplitId());
+  splitManager.setNavigationInterceptor((content, options) => {
+    if (options.mergeHistory) return { handled: false };
+    navigateForward(content, options);
+    return { handled: true };
+  });
+  onCleanup(() => {
+    splitManager.setExclusionFilter(undefined);
+    splitManager.setNavigationInterceptor(undefined);
+  });
 
   function canGoBack() {
     return bgSplitId() !== undefined;
@@ -90,16 +100,9 @@ export function createMobileSwipeLayout(
         initialHistory: newFgInitialHistory,
         activate: true,
         referredFrom,
-        isBackground: false,
       });
 
-      // Demote FG → BG
-      if (currentFgId) {
-        splitManager.setBackground(currentFgId, true);
-      }
-
       setNewFgSlotId(newFgHandle.id);
-
       toggleFgSlot();
     });
   }
@@ -108,7 +111,7 @@ export function createMobileSwipeLayout(
     const isFgA = fgIsSlotA();
     const currentFgId = fgSplitId();
     const currentBgId = bgSplitId();
-    // New BG content (page behind the promoted split) goes into the old FG slot (it becomes BG after swap).
+    // New BG content goes into the old FG slot (it becomes BG after the swap).
     const setNewBgSlotId = isFgA ? setSlotASplitId : setSlotBSplitId;
 
     if (!currentBgId) return;
@@ -126,21 +129,16 @@ export function createMobileSwipeLayout(
         splitManager.removeSplit(currentFgId);
       }
 
-      // Promote BG → FG
-      splitManager.setBackground(currentBgId, false);
-
       const newBgHandle = newBgContent
         ? splitManager.createNewSplit({
             content: newBgContent,
             initialHistory: newBgInitialHistory,
             activate: false,
             referredFrom: null,
-            isBackground: true,
           })
         : undefined;
 
       setNewBgSlotId(newBgHandle?.id);
-
       toggleFgSlot();
     });
   }
@@ -163,7 +161,6 @@ export function createMobileSwipeLayout(
     slotBSplitId,
     fgIsSlotA,
     canGoBack,
-    navigateForward,
     completeSwipeBack,
     setAnimatedTrigger,
     swipeBack,

--- a/js/app/packages/app/component/split-layout/mobile/createMobileSwipeLayout.ts
+++ b/js/app/packages/app/component/split-layout/mobile/createMobileSwipeLayout.ts
@@ -1,0 +1,171 @@
+import { batch, createSignal } from 'solid-js';
+import type {
+  OpenWithSplitOptions,
+  ReferredFrom,
+  SplitContent,
+  SplitId,
+  SplitManager,
+} from '../layoutManager';
+
+export type MobileSwipeLayout = {
+  slotASplitId: () => SplitId | undefined;
+  slotBSplitId: () => SplitId | undefined;
+  /** True when slot A is the foreground; false when slot B is the foreground. */
+  fgIsSlotA: () => boolean;
+  canGoBack: () => boolean;
+  /**
+   * Intercepts forward navigation on mobile.
+   * Puts the new content into the current BG slot, demotes the current FG to BG,
+   * then flips the FG/BG role — zero remount on the new FG slot.
+   */
+  navigateForward: (
+    content: SplitContent,
+    options?: Pick<OpenWithSplitOptions, 'referredFrom'>
+  ) => void;
+  /**
+   * Completes a swipe-back. Flips the FG/BG role so the current BG slot becomes FG, destroys the old FG, and mounts a
+   * new BG from the promoted split's history into the old FG slot.
+   */
+  completeSwipeBack: () => void;
+  /**
+   * Register an animated trigger provided by MobileSwipeBackContainer.
+   * When set, swipeBack() will animate before completing.
+   */
+  setAnimatedTrigger: (trigger: (() => void) | undefined) => void;
+  /**
+   * Initiate a swipe-back
+   */
+  swipeBack: () => void;
+};
+
+export function createMobileSwipeLayout(
+  splitManager: SplitManager
+): MobileSwipeLayout {
+  // Initialise slot A to whatever the first (only) split is on mobile load.
+  const initialFgId = splitManager.splits()[0]?.id;
+
+  const [slotASplitId, setSlotASplitId] = createSignal<SplitId | undefined>(
+    initialFgId
+  );
+  const [slotBSplitId, setSlotBSplitId] = createSignal<SplitId | undefined>(
+    undefined
+  );
+  /** When true, slot A is foreground; when false, slot B is foreground. */
+  const [fgIsSlotA, setFgIsSlotA] = createSignal(true);
+  const toggleFgSlot = () => setFgIsSlotA((prev) => !prev);
+
+  let animatedTrigger: (() => void) | undefined;
+
+  const fgSplitId = () => (fgIsSlotA() ? slotASplitId() : slotBSplitId());
+  const bgSplitId = () => (fgIsSlotA() ? slotBSplitId() : slotASplitId());
+
+  function canGoBack() {
+    return bgSplitId() !== undefined;
+  }
+
+  function navigateForward(
+    content: SplitContent,
+    options?: Pick<OpenWithSplitOptions, 'referredFrom'>
+  ) {
+    const isFgA = fgIsSlotA();
+    const currentFgId = fgSplitId();
+    const currentBgId = bgSplitId();
+    // New FG content goes into the old BG slot (it becomes FG after the swap).
+    const setNewFgSlotId = isFgA ? setSlotBSplitId : setSlotASplitId;
+    const referredFrom: ReferredFrom = options?.referredFrom ?? null;
+
+    const fgHandle = currentFgId
+      ? splitManager.getSplit(currentFgId)
+      : undefined;
+    const newFgInitialHistory = fgHandle?.history() ?? [];
+
+    // Batch to ensure reactive dependencies never see intermediate state.
+    batch(() => {
+      if (currentBgId) {
+        splitManager.removeSplit(currentBgId);
+      }
+
+      const newFgHandle = splitManager.createNewSplit({
+        content,
+        initialHistory: newFgInitialHistory,
+        activate: true,
+        referredFrom,
+        isBackground: false,
+      });
+
+      // Demote FG → BG
+      if (currentFgId) {
+        splitManager.setBackground(currentFgId, true);
+      }
+
+      setNewFgSlotId(newFgHandle.id);
+
+      toggleFgSlot();
+    });
+  }
+
+  function completeSwipeBack() {
+    const isFgA = fgIsSlotA();
+    const currentFgId = fgSplitId();
+    const currentBgId = bgSplitId();
+    // New BG content (page behind the promoted split) goes into the old FG slot (it becomes BG after swap).
+    const setNewBgSlotId = isFgA ? setSlotASplitId : setSlotBSplitId;
+
+    if (!currentBgId) return;
+
+    const bgHandle = splitManager.getSplit(currentBgId);
+    if (!bgHandle) return;
+
+    const newBgContent = bgHandle.previousContent();
+    // Current content gets appended to history, so we want to slice before the new bg content
+    const newBgInitialHistory = bgHandle.history().slice(0, -2);
+
+    // Batch to ensure reactive dependencies never see intermediate state.
+    batch(() => {
+      if (currentFgId) {
+        splitManager.removeSplit(currentFgId);
+      }
+
+      // Promote BG → FG
+      splitManager.setBackground(currentBgId, false);
+
+      const newBgHandle = newBgContent
+        ? splitManager.createNewSplit({
+            content: newBgContent,
+            initialHistory: newBgInitialHistory,
+            activate: false,
+            referredFrom: null,
+            isBackground: true,
+          })
+        : undefined;
+
+      setNewBgSlotId(newBgHandle?.id);
+
+      toggleFgSlot();
+    });
+  }
+
+  function setAnimatedTrigger(trigger: (() => void) | undefined) {
+    animatedTrigger = trigger;
+  }
+
+  function swipeBack() {
+    if (!canGoBack()) return;
+    if (animatedTrigger) {
+      animatedTrigger();
+    } else {
+      completeSwipeBack();
+    }
+  }
+
+  return {
+    slotASplitId,
+    slotBSplitId,
+    fgIsSlotA,
+    canGoBack,
+    navigateForward,
+    completeSwipeBack,
+    setAnimatedTrigger,
+    swipeBack,
+  };
+}


### PR DESCRIPTION
We use our split layout system to manage mobile swipe back behavior. We always keep two splits mounted: the current "foreground" split, and the previous "background" split, which is revealed if the user swipes from the left side of the screen.