### PR TITLE
feat(infra): enable enhanced monitoring for RDS

### DIFF
--- a/infra/stacks/macrodb/Pulumi.dev.yaml
+++ b/infra/stacks/macrodb/Pulumi.dev.yaml
@@ -13,6 +13,8 @@ config:
   macrodb:performance_insights_kms_key_id: arn:aws:kms:us-east-1:569036502058:key/6a0ba9c2-b8ab-4a65-b0f2-6f8f39ccda72
   macrodb:subnet_group_name: macro-db-dev-stack-macrodbinstancesubnetgroup483984b1-io15kk1yffvr
   macrodb:security_group_ids: sg-0c947d88145e1141b
+  macrodb:monitoring_interval: 60
+  macrodb:rds_monitoring_role_arn: arn:aws:iam::569036502058:role/rds-monitoring-role
   macrodb:backup_retention_days: 1
   macrodb:read_replica_enabled: true
   macrodb:read_replica_instance_size: db.t4g.medium

--- a/infra/stacks/macrodb/Pulumi.prod.yaml
+++ b/infra/stacks/macrodb/Pulumi.prod.yaml
@@ -15,6 +15,8 @@ config:
   macrodb:performance_insights_kms_key_id: arn:aws:kms:us-east-1:569036502058:key/6a0ba9c2-b8ab-4a65-b0f2-6f8f39ccda72
   macrodb:subnet_group_name: macro-db-prod-stack-macrodbinstancesubnetgroup483984b1-ny9ca5kliq6z
   macrodb:security_group_ids: sg-0997207417c39f5b3
+  macrodb:monitoring_interval: 60
+  macrodb:rds_monitoring_role_arn: arn:aws:iam::569036502058:role/rds-monitoring-role
   macrodb:backup_retention_days: 6
   macrodb:read_replica_enabled: true
   macrodb:read_replica_instance_size: db.t4g.xlarge

--- a/infra/stacks/macrodb/index.ts
+++ b/infra/stacks/macrodb/index.ts
@@ -53,6 +53,11 @@ const database = new aws.rds.Instance(
     username: 'macrouser',
     password,
     kmsKeyId: config.require('kms_key_id'),
+    monitoringInterval: stack === 'prod' ? 60 : 0,
+    monitoringRoleArn:
+      stack === 'prod'
+        ? 'arn:aws:iam::569036502058:role/rds-monitoring-role'
+        : undefined,
     performanceInsightsEnabled: true,
     performanceInsightsRetentionPeriod: config.requireNumber(
       'performance_insights_retention_days'

--- a/infra/stacks/macrodb/index.ts
+++ b/infra/stacks/macrodb/index.ts
@@ -53,11 +53,8 @@ const database = new aws.rds.Instance(
     username: 'macrouser',
     password,
     kmsKeyId: config.require('kms_key_id'),
-    monitoringInterval: stack === 'prod' ? 60 : 0,
-    monitoringRoleArn:
-      stack === 'prod'
-        ? 'arn:aws:iam::569036502058:role/rds-monitoring-role'
-        : undefined,
+    monitoringInterval: config.requireNumber('monitoring_interval'),
+    monitoringRoleArn: config.require('rds_monitoring_role_arn'),
     performanceInsightsEnabled: true,
     performanceInsightsRetentionPeriod: config.requireNumber(
       'performance_insights_retention_days'


### PR DESCRIPTION
## Summary
- Enable RDS Enhanced Monitoring (60s interval) for the database instance
- Adds the `rds-monitoring-role` IAM role for CloudWatch metrics collection