### PR TITLE
feat(search): disable email subject serach in mentions when not required

### DIFF
--- a/js/app/packages/core/component/LexicalMarkdown/component/menu/MentionsMenu/MentionsMenu.tsx
+++ b/js/app/packages/core/component/LexicalMarkdown/component/menu/MentionsMenu/MentionsMenu.tsx
@@ -150,6 +150,7 @@ function MentionsMenuInner(props: MentionsMenuProps) {
         }
       : useEmailSearchMention({
           searchTerm,
+          enabled: () => !props.sources || props.sources.includes('emails'),
         });
 
   const dateOptions = useDateSearch({ query: searchTerm });

--- a/js/app/packages/core/component/LexicalMarkdown/component/menu/MentionsMenu/hooks/useEmailSearchMention.ts
+++ b/js/app/packages/core/component/LexicalMarkdown/component/menu/MentionsMenu/hooks/useEmailSearchMention.ts
@@ -10,6 +10,7 @@ import {
 
 export type UseEmailSearchMentionOptions = {
   searchTerm: Accessor<string>;
+  enabled?: Accessor<boolean | undefined>;
 };
 
 export type UseEmailSearchMentionResult = {
@@ -23,7 +24,7 @@ export type UseEmailSearchMentionResult = {
 export function useEmailSearchMention(
   options: UseEmailSearchMentionOptions
 ): UseEmailSearchMentionResult {
-  const { searchTerm } = options;
+  const { searchTerm, enabled } = options;
 
   // Build search query args for remote email search
   const args = createLazyMemo((): SearchSoupQueryArgs => {
@@ -44,7 +45,9 @@ export function useEmailSearchMention(
     };
   });
 
-  const emailSearchQuery = useSearchSoupQuery(args);
+  const emailSearchQuery = useSearchSoupQuery(args, () => ({
+    enabled: enabled?.(),
+  }));
 
   const emailList = createLazyMemo((): EntityItem[] => {
     if (emailSearchQuery.status !== 'success') return [];

--- a/js/app/packages/queries/soup/search.ts
+++ b/js/app/packages/queries/soup/search.ts
@@ -17,7 +17,7 @@ export type SearchSoupQueryArgs = {
 };
 
 interface SearchQueryOptions {
-  enabled: boolean;
+  enabled?: boolean;
 }
 
 /** Search service won't accept text less than 3 characters */


### PR DESCRIPTION
now the search bar at mentions won't fire off redundant search queries