### PR TITLE
fix(ci): fix cargo-deny check

### DIFF
--- a/rust/cloud-storage/Cargo.lock
+++ b/rust/cloud-storage/Cargo.lock
@@ -9181,7 +9181,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.10",
+ "rustls-webpki 0.103.12",
  "subtle",
  "zeroize",
 ]
@@ -9220,9 +9220,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/rust/cloud-storage/deny.toml
+++ b/rust/cloud-storage/deny.toml
@@ -75,6 +75,8 @@ ignore = [
   { id = "RUSTSEC-2024-0436", reason = "Paste is a 'finished' crate which is heavily depended on" },
   { id = "RUSTSEC-2025-0012", reason = "Cannot remove dep due to 3rd party openai dependency" },
   { id = "RUSTSEC-2025-0057", reason = "We should switch to rustc-hash, but haven't got to that yet" },
+  { id = "RUSTSEC-2026-0098", reason = "rustls-webpki 0.101.7 is pinned by AWS SDK's rustls 0.21.x, no patch in 0.101.x line" },
+  { id = "RUSTSEC-2026-0099", reason = "rustls-webpki 0.101.7 is pinned by AWS SDK's rustls 0.21.x, no patch in 0.101.x line" },
   #{ id = "RUSTSEC-0000-0000", reason = "you can specify a reason the advisory is ignored" },
   #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish
   #{ crate = "a-crate-that-is-yanked@0.1.1", reason = "you can specify why you are ignoring the yanked crate" },


### PR DESCRIPTION
  1. Cargo.lock: rustls-webpki 0.103.10 → 0.103.12 (patches the vulnerability directly)
  2. deny.toml: Advisory ignores for RUSTSEC-2026-0098 and RUSTSEC-2026-0099 on rustls-webpki 0.101.7 (pinned by AWS SDK's rustls 0.21.x, no patch available in
  that line)