### PR TITLE
feat(analytics): per-lesson onboarding events, login tracking, environment enrichment

### DIFF
--- a/js/app/packages/app/component/interactive-onboarding/InteractiveOnboarding.tsx
+++ b/js/app/packages/app/component/interactive-onboarding/InteractiveOnboarding.tsx
@@ -138,11 +138,14 @@ export default function InteractiveOnboarding() {
     const current = state.currentLesson();
     if (!current || !readyToContinue()) return;
 
-    analytics.track(`onboarding_step_${current.definition.id.replaceAll('-', '_')}`, {
-      id: current.definition.id,
-      index: current.index,
-      state: 'completed',
-    });
+    analytics.track(
+      `onboarding_step_${current.definition.id.replaceAll('-', '_')}`,
+      {
+        id: current.definition.id,
+        index: current.index,
+        state: 'completed',
+      }
+    );
 
     if (current.definition.onContinue) {
       // On web this redirects (returns void). On native mobile it resolves
@@ -172,11 +175,14 @@ export default function InteractiveOnboarding() {
 
     if (!current) return;
 
-    analytics.track(`onboarding_step_${current.definition.id.replaceAll('-', '_')}`, {
-      id: current.definition.id,
-      index: current.index,
-      state: 'skipped',
-    });
+    analytics.track(
+      `onboarding_step_${current.definition.id.replaceAll('-', '_')}`,
+      {
+        id: current.definition.id,
+        index: current.index,
+        state: 'skipped',
+      }
+    );
 
     state.skipLesson(current.definition.id);
     setReadyToContinue(false);
@@ -340,11 +346,14 @@ export default function InteractiveOnboarding() {
       (lesson) => {
         if (!lesson) return;
 
-        analytics.track(`onboarding_step_${lesson.definition.id.replaceAll('-', '_')}`, {
-          id: lesson.definition.id,
-          index: lesson.index,
-          state: 'viewed',
-        });
+        analytics.track(
+          `onboarding_step_${lesson.definition.id.replaceAll('-', '_')}`,
+          {
+            id: lesson.definition.id,
+            index: lesson.index,
+            state: 'viewed',
+          }
+        );
       }
     )
   );

--- a/js/app/packages/app/component/interactive-onboarding/InteractiveOnboarding.tsx
+++ b/js/app/packages/app/component/interactive-onboarding/InteractiveOnboarding.tsx
@@ -138,7 +138,7 @@ export default function InteractiveOnboarding() {
     const current = state.currentLesson();
     if (!current || !readyToContinue()) return;
 
-    analytics.track('onboarding_step', {
+    analytics.track(`onboarding_step_${current.definition.id.replaceAll('-', '_')}`, {
       id: current.definition.id,
       index: current.index,
       state: 'completed',
@@ -172,7 +172,7 @@ export default function InteractiveOnboarding() {
 
     if (!current) return;
 
-    analytics.track('onboarding_step', {
+    analytics.track(`onboarding_step_${current.definition.id.replaceAll('-', '_')}`, {
       id: current.definition.id,
       index: current.index,
       state: 'skipped',
@@ -340,7 +340,7 @@ export default function InteractiveOnboarding() {
       (lesson) => {
         if (!lesson) return;
 
-        analytics.track('onboarding_step', {
+        analytics.track(`onboarding_step_${lesson.definition.id.replaceAll('-', '_')}`, {
           id: lesson.definition.id,
           index: lesson.index,
           state: 'viewed',

--- a/js/app/packages/app/component/interactive-onboarding/lessons/welcome.tsx
+++ b/js/app/packages/app/component/interactive-onboarding/lessons/welcome.tsx
@@ -2,6 +2,7 @@ import { onMount } from 'solid-js';
 import { A } from '@solidjs/router';
 import type { LessonContentProps, LessonDefinition } from '../types';
 import { isTouchDevice } from '@core/mobile/isTouchDevice';
+import { useAnalytics } from '@app/component/analytics-context';
 
 function WelcomeContent(props: LessonContentProps) {
   onMount(() => props.onComplete('Get Started'));
@@ -19,11 +20,14 @@ function WelcomeContent(props: LessonContentProps) {
 }
 
 function WelcomeSecondaryAction() {
+  const analytics = useAnalytics();
+
   return (
     <>
       <p class="text-sm text-ink/50 mt-10">Already have an account?</p>
       <A
         href="/login"
+        onClick={() => analytics.track('login_from_onboarding')}
         class="w-full px-3 py-2.5 text-lg rounded-xs flex items-center justify-between gap-2 bracket-never border-none bg-transparent text-ink/50 hover:bg-hover/60 ring-1 ring-edge-muted/50"
       >
         Login

--- a/js/app/packages/app/lib/analytics/analytics.ts
+++ b/js/app/packages/app/lib/analytics/analytics.ts
@@ -7,6 +7,7 @@ import { PostHog } from 'posthog-js';
 import { match } from 'ts-pattern';
 import { getPlatform } from '@core/util/platform';
 import { isTouchDevice } from '@core/mobile/isTouchDevice';
+import { DEV_MODE_ENV, PROD_MODE_ENV } from '@core/constant/featureFlags';
 
 /**
  * Resolves the user's device context for analytics enrichment.
@@ -21,6 +22,13 @@ import { isTouchDevice } from '@core/mobile/isTouchDevice';
  * a phone/tablet browser ('mobile-web') from a desktop browser ('desktop-web').
  */
 const DEVICE_PROPERTY = 'macro_device' as const;
+const ENVIRONMENT_PROPERTY = 'macro_environment' as const;
+
+function getEnvironment(): 'dev' | 'prod' | 'unknown' {
+  if (PROD_MODE_ENV) return 'prod';
+  if (DEV_MODE_ENV) return 'dev';
+  return 'unknown';
+}
 
 function getDeviceType():
   | 'desktop-app'
@@ -100,7 +108,11 @@ export const createAnalytics = () => {
   ) => {
     if (disabled) return;
 
-    const enriched = { ...data, [DEVICE_PROPERTY]: getDeviceType() };
+    const enriched = {
+      ...data,
+      [DEVICE_PROPERTY]: getDeviceType(),
+      [ENVIRONMENT_PROPERTY]: getEnvironment(),
+    };
 
     try {
       match(provider)
@@ -168,10 +180,12 @@ export const createAnalytics = () => {
     const pagePath = opts?.path ?? window.location.pathname;
     const pageLocation = opts?.location ?? window.location.href;
     const deviceType = getDeviceType();
+    const environment = getEnvironment();
 
     try {
       gtag('event', 'page_view', {
         [DEVICE_PROPERTY]: deviceType,
+        [ENVIRONMENT_PROPERTY]: environment,
         page_title: pageTitle,
         page_location: pageLocation,
         page_path: pagePath,
@@ -179,11 +193,13 @@ export const createAnalytics = () => {
 
       fbq('track', 'PageView', {
         [DEVICE_PROPERTY]: deviceType,
+        [ENVIRONMENT_PROPERTY]: environment,
         content_name: pageTitle,
       });
 
       posthog.capture('$pageview', {
         [DEVICE_PROPERTY]: deviceType,
+        [ENVIRONMENT_PROPERTY]: environment,
         $current_url: pageLocation,
         $pathname: pagePath,
         $title: pageTitle,

--- a/js/app/packages/app/lib/analytics/app-events.ts
+++ b/js/app/packages/app/lib/analytics/app-events.ts
@@ -5,6 +5,7 @@ export type AppEvents = {
   onboarding_start: Record<string, unknown>;
   onboarding_step: Record<string, unknown>; // payload -
   onboarding_completed: Record<string, unknown>;
+  login_from_onboarding: Record<string, unknown>;
 
   subscription_start: Record<string, unknown>;
   subscription_cancel: Record<string, unknown>;


### PR DESCRIPTION
## Summary

Extends onboarding analytics with per-lesson event names, login tracking from the welcome step, and automatic environment enrichment on all analytics events.

### Changes

- **Per-lesson event names** — `onboarding_step` is now `onboarding_step_welcome`, `onboarding_step_sidebar_nav`, `onboarding_step_command_k`, etc. This enables PostHog Paths to show each lesson as a distinct node with branching visualizations. The `id`, `index`, and `state` properties are still included for backward-compatible filtering.

- **`login_from_onboarding` event** — fires when a user clicks the "Login" link on the welcome step instead of continuing onboarding. Enables tracking the branch between new signups and returning users in PostHog Paths.

- **`macro_environment` enrichment** — every analytics event (PostHog, GA, Meta Pixel) now includes `macro_environment: 'dev' | 'prod' | 'unknown'` based on `import.meta.env.MODE`. Enables filtering dashboards to exclude dev environment traffic.

### Event name mapping

| Old | New |
|-----|-----|
| `onboarding_step` (id=welcome) | `onboarding_step_welcome` |
| `onboarding_step` (id=sidebar-nav) | `onboarding_step_sidebar_nav` |
| `onboarding_step` (id=navigate-list) | `onboarding_step_navigate_list` |
| `onboarding_step` (id=command-k) | `onboarding_step_command_k` |
| `onboarding_step` (id=create-entity) | `onboarding_step_create_entity` |
| `onboarding_step` (id=markdown-mentions) | `onboarding_step_markdown_mentions` |
| `onboarding_step` (id=about-us) | `onboarding_step_about_us` |
| `onboarding_step` (id=email-invite) | `onboarding_step_email_invite` |
| `onboarding_step` (id=choose-plan) | `onboarding_step_choose_plan` |
| — | `login_from_onboarding` (new) |