### PR TITLE
fix(search): highlight correct term in sender name for contact searches

### DIFF
--- a/js/app/packages/queries/soup/transform-utils.ts
+++ b/js/app/packages/queries/soup/transform-utils.ts
@@ -146,8 +146,8 @@ const getSearchData = (data: TypedInnerSearchResult): SearchData => {
     const terms = [
       ...new Set(
         data.results
-          .flatMap((r) => (r.highlight.sender ?? '').toLowerCase().split(/\s+/))
-          .filter(Boolean)
+          .flatMap((r) => extractSearchTerms(r.highlight.sender ?? ''))
+          .map((t) => t.toLowerCase())
       ),
     ];
     if (hasSenderMatch && data.searchQuery) {


### PR DESCRIPTION
fixes change introduced by https://github.com/macro-inc/macro/pull/2585

## Summary
- Fixes sender name highlighting when searching by contact (e.g. `@jacob`) 
- The old code split the raw highlighted sender string on whitespace, producing terms like `<macro_em>jacob</macro_em>` (doesn't match anything) and `beckerman` (matches the wrong word)
- Now uses `extractSearchTerms()` to properly extract only the text within `<macro_em>` tags, so "Jacob" gets highlighted instead of "Beckerman"