### PR TITLE
fix(notifications): stop refetching all notifications on mark-as-read

### DIFF
--- a/js/app/packages/queries/notification/user-notifications.ts
+++ b/js/app/packages/queries/notification/user-notifications.ts
@@ -249,6 +249,7 @@ function notificationsMutationSuccessCallback<T>(
 ) {
   queryClient.invalidateQueries({
     queryKey: notificationKeys.user._def,
+    refetchType: 'none',
   });
 }
 


### PR DESCRIPTION
## Summary
- `notificationsMutationSuccessCallback` was calling `invalidateQueries` without `refetchType`, which defaults to `'active'` — triggering an immediate `GET /user_notifications?limit=500` every time a notification mutation succeeds
- Opening a channel from the sidebar mounts `MarkMessageNotifications`, which calls `markAsRead` → triggers the seen mutation → success callback refetches all 500 notifications
- Added `refetchType: 'none'` so the invalidation marks cached data as stale without an immediate refetch — the optimistic update in `onMutate` already applies the correct cache state

🤖 Generated with [Claude Code](https://claude.com/claude-code)