### PR TITLE
feat(infra): add idle_in_transaction_session_timeout

### DIFF
--- a/infra/stacks/macrodb/index.ts
+++ b/infra/stacks/macrodb/index.ts
@@ -42,6 +42,7 @@ const parameterGroup = new aws.rds.ParameterGroup(
       { name: 'auto_explain.log_verbose', value: 'on' },
       { name: 'auto_explain.log_nested_statements', value: 'on' },
       { name: 'auto_explain.sample_rate', value: '1' },
+      { name: 'idle_in_transaction_session_timeout', value: '300000' },
     ],
     tags,
   },


### PR DESCRIPTION
## Summary
- Set `idle_in_transaction_session_timeout` to 300000ms (5 minutes) in the RDS parameter group
- Automatically terminates sessions stuck in "idle in transaction" state, preventing blocked VACUUMs and held locks
- Addresses recurring issue where the frecency poller leaves transactions open indefinitely

🤖 Generated with [Claude Code](https://claude.com/claude-code)