### PR TITLE
fix(infra): add Docker build layer caching via ECR registry

### DIFF
--- a/infra/packages/service/src/ecr.ts
+++ b/infra/packages/service/src/ecr.ts
@@ -1,10 +1,11 @@
 import * as aws from '@pulumi/aws';
 import * as awsx from '@pulumi/awsx';
+import * as docker_build from '@pulumi/docker-build';
 import * as pulumi from '@pulumi/pulumi';
 
 export class EcrImage extends pulumi.ComponentResource {
   public ecr: awsx.ecr.Repository;
-  public image: awsx.ecr.Image;
+  public image: { imageUri: pulumi.Output<string> };
   public tags: { [key: string]: string };
 
   constructor(
@@ -73,17 +74,47 @@ export class EcrImage extends pulumi.ComponentResource {
       { parent: this }
     );
 
-    this.image = new awsx.ecr.Image(
+    const authToken = aws.ecr.getAuthorizationTokenOutput({
+      registryId: this.ecr.repository.registryId,
+    });
+
+    const cacheRef = pulumi.interpolate`${this.ecr.url}:cache`;
+
+    const dockerImage = new docker_build.Image(
       imageId,
       {
-        imageTag: 'latest',
-        context: imagePath,
-        platform: `${platform.family}/${platform.architecture}`,
-        dockerfile: dockerfile ? `${imagePath}/${dockerfile}` : undefined,
-        repositoryUrl: this.ecr.url,
-        args: buildArgs,
+        tags: [pulumi.interpolate`${this.ecr.url}:latest`],
+        context: { location: imagePath },
+        dockerfile: dockerfile
+          ? { location: `${imagePath}/${dockerfile}` }
+          : undefined,
+        platforms: [
+          `${platform.family}/${platform.architecture}` as docker_build.Platform,
+        ],
+        push: true,
+        buildArgs,
+        registries: [
+          {
+            address: this.ecr.url,
+            password: authToken.apply((t) => t.password),
+            username: authToken.apply((t) => t.userName),
+          },
+        ],
+        cacheFrom: [{ registry: { ref: cacheRef } }],
+        cacheTo: [
+          {
+            registry: {
+              ref: cacheRef,
+              imageManifest: true,
+              ociMediaTypes: true,
+              mode: docker_build.CacheMode.Max,
+            },
+          },
+        ],
       },
       { parent: this }
     );
+
+    this.image = { imageUri: dockerImage.ref };
   }
 }

--- a/rust/cloud-storage/Dockerfile.convert_service
+++ b/rust/cloud-storage/Dockerfile.convert_service
@@ -1,7 +1,6 @@
-FROM rust:latest AS chef 
+# syntax=docker/dockerfile:1
+FROM rust:latest AS chef
 ENV SQLX_OFFLINE=true
-# We only pay the installation cost once, 
-# it will be cached from the second build onwards
 # Adding dependencies for bindgen
 RUN apt-get update && apt-get install -y \
   llvm \


### PR DESCRIPTION
## Summary

Switches EcrImage from awsx.ecr.Image to @pulumi/docker-build.Image with ECR registry cache (mode: max), which caches all intermediate Docker build stages across deploys.

The previous setup already cached the final stage (convert-service libreoffice install) by importing the :latest image as a cache source. This change adds cacheTo so intermediate stages (Rust compilation, LOK assets, toolchain setup) are also cached.

The biggest remaining bottleneck is that cargo-chef treats the whole workspace as one unit, so any Cargo.toml change in any crate invalidates the cook layer. Fixing that would require scoping the build context or splitting convert-service out of the workspace.

Fyi, for the last 20 prod releases of convert-service:
  - 17 out of 20 were full rebuilds averaging 14.7 min
  - 3 out of 20 hit cache averaging 3.9 min — those are the deploys where Cargo.toml didn't change between consecutive releases

So 85% of prod deploys do a full Rust rebuild. Workspace deps change on most releases, invalidating the cook layer.
This change would shave ~1-2 min off those 14.7 min builds (caching the toolchain/LOK stages). The 3.9 min cached builds would drop further to ~1-2 min.