### PR TITLE
feat(search): tasks-style filter menu with F hotkey and chips

### DIFF
--- a/.github/workflows/code-check-infra.yml
+++ b/.github/workflows/code-check-infra.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Biome
         uses: biomejs/setup-biome@v2
         with:
-          version: 2.4.10
+          version: 2.4.12
       - name: Run Biome
         working-directory: infra
         run: biome ci --changed --no-errors-on-unmatched --error-on-warnings

--- a/.github/workflows/web-app-check-main.yml
+++ b/.github/workflows/web-app-check-main.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Setup Biome
         uses: biomejs/setup-biome@v2
         with:
-          version: 2.4.10
+          version: 2.4.12
       - name: Generate API Types
         if: needs.path-check.outputs.api_changed == 'true'
         working-directory: js/app
@@ -70,7 +70,7 @@ jobs:
       - name: Setup Biome
         uses: biomejs/setup-biome@v2
         with:
-          version: 2.4.10
+          version: 2.4.12
       - name: Run Biome
         working-directory: js/app
         run: biome ci --changed --no-errors-on-unmatched --error-on-warnings
@@ -121,7 +121,7 @@ jobs:
       - name: Setup Biome
         uses: biomejs/setup-biome@v2
         with:
-          version: 2.4.10
+          version: 2.4.12
       - name: Cycles Import Check
         working-directory: js/app
         run: biome lint --changed --no-errors-on-unmatched --only=suspicious/noImportCycles

--- a/js/app/biome.jsonc
+++ b/js/app/biome.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.10/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.12/schema.json",
   "vcs": {
     "clientKind": "git",
     "enabled": true,

--- a/js/app/bun.lock
+++ b/js/app/bun.lock
@@ -104,7 +104,7 @@
         "zod": "^3.23.8",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.4.7",
+        "@biomejs/biome": "2.4.12",
         "@playwright/test": "^1.55.1",
         "@solidjs/meta": "^0.29.4",
         "@solidjs/testing-library": "^0.8.10",
@@ -443,23 +443,23 @@
 
     "@babel/types": ["@babel/types@7.27.6", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.27.1" } }, "sha512-ETyHEk2VHHvl9b9jZP5IHPavHYk57EhanlRRuae9XCpb/j5bDCbPPMOBfCWhnl/7EDJz0jEMCi/RhccCE8r1+Q=="],
 
-    "@biomejs/biome": ["@biomejs/biome@2.4.7", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.7", "@biomejs/cli-darwin-x64": "2.4.7", "@biomejs/cli-linux-arm64": "2.4.7", "@biomejs/cli-linux-arm64-musl": "2.4.7", "@biomejs/cli-linux-x64": "2.4.7", "@biomejs/cli-linux-x64-musl": "2.4.7", "@biomejs/cli-win32-arm64": "2.4.7", "@biomejs/cli-win32-x64": "2.4.7" }, "bin": { "biome": "bin/biome" } }, "sha512-vXrgcmNGZ4lpdwZSpMf1hWw1aWS6B+SyeSYKTLrNsiUsAdSRN0J4d/7mF3ogJFbIwFFSOL3wT92Zzxia/d5/ng=="],
+    "@biomejs/biome": ["@biomejs/biome@2.4.12", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.12", "@biomejs/cli-darwin-x64": "2.4.12", "@biomejs/cli-linux-arm64": "2.4.12", "@biomejs/cli-linux-arm64-musl": "2.4.12", "@biomejs/cli-linux-x64": "2.4.12", "@biomejs/cli-linux-x64-musl": "2.4.12", "@biomejs/cli-win32-arm64": "2.4.12", "@biomejs/cli-win32-x64": "2.4.12" }, "bin": { "biome": "bin/biome" } }, "sha512-Rro7adQl3NLq/zJCIL98eElXKI8eEiBtoeu5TbXF/U3qbjuSc7Jb5rjUbeHHcquDWeSf3HnGP7XI5qGrlRk/pA=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Oo0cF5mHzmvDmTXw8XSjhCia8K6YrZnk7aCS54+/HxyMdZMruMO3nfpDsrlar/EQWe41r1qrwKiCa2QDYHDzWA=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-BnMU4Pc3ciEVteVpZ0BK33MLr7X57F5w1dwDLDn+/iy/yTrA4Q/N2yftidFtsA4vrDh0FMXDpacNV/Tl3fbmng=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-I+cOG3sd/7HdFtvDSnF9QQPrWguUH7zrkIMMykM3PtfWU9soTcS2yRb9Myq6MHmzbeCT08D1UmY+BaiMl5CcoQ=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-x9uJ0bI1rJsWICp3VH8w/5PnAVD3A7SqzDpbrfoUQX1QyWrK5jSU4fRLo/wSgGeplCivbxBRKmt5Xq4/nWvq8A=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-om6FugwmibzfP/6ALj5WRDVSND4H2G9X0nkI1HZpp2ySf9lW2j0X68oQSaHEnls6666oy4KDsc5RFjT4m0kV0w=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-tOwuCuZZtKi1jVzbk/5nXmIsziOB6yqN8c9r9QM0EJYPU6DpQWf11uBOSCfFKKM4H3d9ZoarvlgMfbcuD051Pw=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-I2NvM9KPb09jWml93O2/5WMfNR7Lee5Latag1JThDRMURVhPX74p9UDnyTw3Ae6cE1DgXfw7sqQgX7rkvpc0vw=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-FhfpkAAlKL6kwvcVap0Hgp4AhZmtd3YImg0kK1jd7C/aSoh4SfsB2f++yG1rU0lr8Y5MCFJrcSkmssiL9Xnnig=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.7", "", { "os": "linux", "cpu": "x64" }, "sha512-bV8/uo2Tj+gumnk4sUdkerWyCPRabaZdv88IpbmDWARQQoA/Q0YaqPz1a+LSEDIL7OfrnPi9Hq1Llz4ZIGyIQQ=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.12", "", { "os": "linux", "cpu": "x64" }, "sha512-8pFeAnLU9QdW9jCIslB/v82bI0lhBmz2ZAKc8pVMFPO0t0wAHsoEkrUQUbMkIorTRIjbqyNZHA3lEXavsPWYSw=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.7", "", { "os": "linux", "cpu": "x64" }, "sha512-00kx4YrBMU8374zd2wHuRV5wseh0rom5HqRND+vDldJPrWwQw+mzd/d8byI9hPx926CG+vWzq6AeiT7Yi5y59g=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.12", "", { "os": "linux", "cpu": "x64" }, "sha512-dwTIgZrGutzhkQCuvHynCkyW6hJxUuyZqKKO0YNfaS2GUoRO+tOvxXZqZB6SkWAOdfZTzwaw8IEdUnIkHKHoew=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.7", "", { "os": "win32", "cpu": "arm64" }, "sha512-hOUHBMlFCvDhu3WCq6vaBoG0dp0LkWxSEnEEsxxXvOa9TfT6ZBnbh72A/xBM7CBYB7WgwqboetzFEVDnMxelyw=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-B0DLnx0vA9ya/3v7XyCaP+/lCpnbWbMOfUFFve+xb5OxyYvdHaS55YsSddr228Y+JAFk58agCuZTsqNiw2a6ig=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.7", "", { "os": "win32", "cpu": "x64" }, "sha512-qEpGjSkPC3qX4ycbMUthXvi9CkRq7kZpkqMY1OyhmYlYLnANnooDQ7hDerM8+0NJ+DZKVnsIc07h30XOpt7LtQ=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.12", "", { "os": "win32", "cpu": "x64" }, "sha512-yMckRzTyZ83hkk8iDFWswqSdU8tvZxspJKnYNh7JZr/zhZNOlzH13k4ecboU6MurKExCe2HUkH75pGI/O2JwGA=="],
 
     "@bufbuild/protobuf": ["@bufbuild/protobuf@1.10.1", "", {}, "sha512-wJ8ReQbHxsAfXhrf9ixl0aYbZorRuOWpBNzm8pL8ftmSxQx/wnJD5Eg861NwJU/czy2VXFIebCeZnZrI9rktIQ=="],
 

--- a/js/app/package.json
+++ b/js/app/package.json
@@ -121,7 +121,7 @@
 		"zod": "^3.23.8"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.4.7",
+		"@biomejs/biome": "2.4.12",
 		"@playwright/test": "^1.55.1",
 		"@solidjs/meta": "^0.29.4",
 		"@solidjs/testing-library": "^0.8.10",

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/active-filter-chips.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/active-filter-chips.tsx
@@ -44,6 +44,12 @@ export type ActiveFilter = {
    */
   onReplace?: (newOptionId: string) => void;
   /**
+   * Per-chip active-state predicate. When set, takes precedence over the shared
+   * `isOptionActive` for this chip's dropdown. Use when the filter state lives
+   * outside `soup.filters` (e.g. email importance in queryFilters).
+   */
+  isOptionActive?: (optionId: string) => boolean;
+  /**
    * When set, the chip opens a searchable multi-select combobox instead of the
    * simple replace dropdown. Use for list-valued filters like In/From.
    */
@@ -292,7 +298,10 @@ const FilterChip = (props: {
             <DropdownMenu.Content class="z-action-menu bg-surface-0 border border-edge-muted rounded-sm shadow-xl min-w-[160px] p-1">
               <For each={props.filter.categoryOptions}>
                 {(option) => {
-                  const active = () => props.isOptionActive(option.id);
+                  const active = () =>
+                    props.filter.isOptionActive
+                      ? props.filter.isOptionActive(option.id)
+                      : props.isOptionActive(option.id);
                   const isSingleSelect = () =>
                     props.filter.multiple === false;
                   return (

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/active-filter-chips.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/active-filter-chips.tsx
@@ -119,9 +119,7 @@ const SearchableFilterChip = (props: {
   const filteredOptions = createMemo(() => {
     const q = searchQuery().toLowerCase().trim();
     if (!q) return allOptions();
-    return allOptions().filter((opt) =>
-      opt.label.toLowerCase().includes(q)
-    );
+    return allOptions().filter((opt) => opt.label.toLowerCase().includes(q));
   });
 
   const handleChange = (selected: SearchableChipOption[]) => {
@@ -302,8 +300,7 @@ const FilterChip = (props: {
                     props.filter.isOptionActive
                       ? props.filter.isOptionActive(option.id)
                       : props.isOptionActive(option.id);
-                  const isSingleSelect = () =>
-                    props.filter.multiple === false;
+                  const isSingleSelect = () => props.filter.multiple === false;
                   return (
                     <DropdownMenu.Item
                       class="w-full flex items-center gap-2.5 px-2 py-1.5 rounded-md text-left text-xs transition-colors hover:bg-ink/5 outline-none data-[highlighted]:bg-ink/5 cursor-default"

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/active-filter-chips.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/active-filter-chips.tsx
@@ -14,13 +14,8 @@ import XIcon from '@icon/regular/x.svg';
 import CheckIcon from '@icon/regular/check.svg';
 import SearchIcon from '@icon/regular/magnifying-glass.svg';
 import type { FilterOption } from './unified-filter-dropdown';
+import type { SearchableOption } from './search-filter-controls';
 import { Button } from '@ui/components/Button';
-
-export type SearchableChipOption = {
-  id: string;
-  label: string;
-  icon?: () => JSX.Element;
-};
 
 export type ActiveFilter = {
   categoryLabel: string;
@@ -53,7 +48,7 @@ export type ActiveFilter = {
    * When set, the chip opens a searchable multi-select combobox instead of the
    * simple replace dropdown. Use for list-valued filters like In/From.
    */
-  searchableOptions?: Accessor<SearchableChipOption[]>;
+  searchableOptions?: Accessor<SearchableOption[]>;
   /** Currently-active ids for the searchable chip, used to render selection state. */
   activeSearchableIds?: Accessor<string[]>;
   /** Called with the new full id list when the searchable selection changes. */
@@ -76,7 +71,7 @@ interface ActiveFilterChipsProps {
 }
 
 const SearchableChipItem = (itemProps: {
-  item: CollectionNode<SearchableChipOption>;
+  item: CollectionNode<SearchableOption>;
 }) => (
   <Combobox.Item
     item={itemProps.item}
@@ -122,7 +117,7 @@ const SearchableFilterChip = (props: {
     return allOptions().filter((opt) => opt.label.toLowerCase().includes(q));
   });
 
-  const handleChange = (selected: SearchableChipOption[]) => {
+  const handleChange = (selected: SearchableOption[]) => {
     props.filter.onSearchableChange?.(selected.map((o) => o.id));
   };
 
@@ -143,7 +138,7 @@ const SearchableFilterChip = (props: {
         props.chipClass
       )}
     >
-      <Combobox<SearchableChipOption>
+      <Combobox<SearchableOption>
         multiple
         options={filteredOptions()}
         value={activeOptions()}

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/active-filter-chips.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/active-filter-chips.tsx
@@ -1,10 +1,26 @@
 import { DropdownMenu } from '@kobalte/core/dropdown-menu';
+import { Combobox } from '@kobalte/core/combobox';
+import type { CollectionNode } from '@kobalte/core';
 import { cn } from '@ui/utils/classname';
-import { createSignal, For, type JSX, Show } from 'solid-js';
+import {
+  type Accessor,
+  createMemo,
+  createSignal,
+  For,
+  type JSX,
+  Show,
+} from 'solid-js';
 import XIcon from '@icon/regular/x.svg';
 import CheckIcon from '@icon/regular/check.svg';
+import SearchIcon from '@icon/regular/magnifying-glass.svg';
 import type { FilterOption } from './unified-filter-dropdown';
 import { Button } from '@ui/components/Button';
+
+export type SearchableChipOption = {
+  id: string;
+  label: string;
+  icon?: () => JSX.Element;
+};
 
 export type ActiveFilter = {
   categoryLabel: string;
@@ -27,6 +43,17 @@ export type ActiveFilter = {
    * side effects beyond toggling `soup.filters` (e.g. updating queryFilters).
    */
   onReplace?: (newOptionId: string) => void;
+  /**
+   * When set, the chip opens a searchable multi-select combobox instead of the
+   * simple replace dropdown. Use for list-valued filters like In/From.
+   */
+  searchableOptions?: Accessor<SearchableChipOption[]>;
+  /** Currently-active ids for the searchable chip, used to render selection state. */
+  activeSearchableIds?: Accessor<string[]>;
+  /** Called with the new full id list when the searchable selection changes. */
+  onSearchableChange?: (ids: string[]) => void;
+  /** Placeholder for the searchable chip's search input. */
+  searchPlaceholder?: string;
 };
 
 interface ActiveFilterChipsProps {
@@ -41,6 +68,160 @@ interface ActiveFilterChipsProps {
   /** Hide the "Category: " prefix in each chip label */
   hideCategoryLabel?: boolean;
 }
+
+const SearchableChipItem = (itemProps: {
+  item: CollectionNode<SearchableChipOption>;
+}) => (
+  <Combobox.Item
+    item={itemProps.item}
+    class="w-full flex items-center gap-2.5 px-3 py-2 rounded-xs text-left text-xs data-[highlighted]:bg-ink/5 group"
+  >
+    <span class="size-4 flex items-center justify-center shrink-0 rounded-xs border border-edge group-data-[selected]:bg-accent group-data-[selected]:border-accent">
+      <Combobox.ItemIndicator>
+        <CheckIcon class="size-2.5 text-page" />
+      </Combobox.ItemIndicator>
+    </span>
+    <Show when={itemProps.item.rawValue.icon}>
+      {(icon) => (
+        <span class="size-4 flex items-center justify-center shrink-0">
+          {icon()()}
+        </span>
+      )}
+    </Show>
+    <Combobox.ItemLabel class="flex-1 truncate text-ink-muted group-data-[selected]:text-ink">
+      {itemProps.item.rawValue.label}
+    </Combobox.ItemLabel>
+  </Combobox.Item>
+);
+
+const SearchableFilterChip = (props: {
+  filter: ActiveFilter;
+  onRemove: () => void;
+  chipClass?: string;
+  hideCategoryLabel?: boolean;
+}) => {
+  const [searchQuery, setSearchQuery] = createSignal('');
+
+  const allOptions = () => props.filter.searchableOptions?.() ?? [];
+  const activeIds = () => props.filter.activeSearchableIds?.() ?? [];
+
+  const activeOptions = createMemo(() => {
+    const set = new Set(activeIds());
+    return allOptions().filter((opt) => set.has(opt.id));
+  });
+
+  const filteredOptions = createMemo(() => {
+    const q = searchQuery().toLowerCase().trim();
+    if (!q) return allOptions();
+    return allOptions().filter((opt) =>
+      opt.label.toLowerCase().includes(q)
+    );
+  });
+
+  const handleChange = (selected: SearchableChipOption[]) => {
+    props.filter.onSearchableChange?.(selected.map((o) => o.id));
+  };
+
+  const onInputChange = (value: string) => {
+    setSearchQuery(value);
+  };
+
+  const onOpenChange = (open: boolean) => {
+    if (!open) setSearchQuery('');
+  };
+
+  return (
+    <div
+      class={cn(
+        'flex text-xs rounded-xs',
+        'bg-ink/10 text-ink-muted border border-edge-muted',
+        'group transition-colors',
+        props.chipClass
+      )}
+    >
+      <Combobox<SearchableChipOption>
+        multiple
+        options={filteredOptions()}
+        value={activeOptions()}
+        onChange={handleChange}
+        onInputChange={onInputChange}
+        onOpenChange={onOpenChange}
+        optionValue="id"
+        optionTextValue="label"
+        optionLabel="label"
+        allowsEmptyCollection
+        placement="bottom-start"
+        gutter={4}
+        itemComponent={SearchableChipItem}
+      >
+        <Combobox.Control class="flex">
+          <Combobox.Trigger
+            class={cn(
+              'inline-flex items-center gap-1.5 pl-2 pr-1 py-1',
+              'hover:text-ink hover:bg-edge-muted'
+            )}
+          >
+            <Show when={props.filter.icon}>
+              {(icon) => (
+                <span class="size-3 flex items-center justify-center shrink-0">
+                  {icon()()}
+                </span>
+              )}
+            </Show>
+            <span class="font-medium">
+              <Show when={!props.hideCategoryLabel}>
+                {props.filter.categoryLabel}:{' '}
+              </Show>
+              {props.filter.optionLabel}
+            </span>
+          </Combobox.Trigger>
+          <Combobox.Input class="sr-only" />
+        </Combobox.Control>
+
+        <Combobox.Portal>
+          <Combobox.Content class="z-action-menu bg-surface-0 border border-edge-muted rounded-sm shadow-md w-[260px] max-w-[90vw] overflow-hidden">
+            <div class="flex items-center gap-2 px-3 py-2 border-b border-edge-muted">
+              <SearchIcon class="size-3.5 text-ink-muted shrink-0" />
+              <Combobox.Input
+                class="flex-1 min-w-0 text-xs bg-transparent outline-none caret-accent placeholder:text-ink-faint"
+                placeholder={
+                  props.filter.searchPlaceholder ??
+                  `Search ${props.filter.categoryLabel.toLowerCase()}...`
+                }
+              />
+            </div>
+            <div class="p-1">
+              <Show
+                when={filteredOptions().length > 0}
+                fallback={
+                  <div class="py-3 px-2 text-center text-xs text-ink-muted">
+                    No options match "{searchQuery()}"
+                  </div>
+                }
+              >
+                <Combobox.Listbox class="max-h-[240px] overflow-y-auto" />
+              </Show>
+            </div>
+          </Combobox.Content>
+        </Combobox.Portal>
+      </Combobox>
+
+      <button
+        type="button"
+        class={cn(
+          'px-1 min-h-full',
+          'hover:bg-edge-muted hover:text-ink transition-colors'
+        )}
+        onClick={(e) => {
+          e.stopPropagation();
+          props.onRemove();
+        }}
+      >
+        <XIcon class="size-3" />
+      </button>
+    </div>
+  );
+};
 
 const FilterChip = (props: {
   filter: ActiveFilter;
@@ -214,29 +395,65 @@ export const ActiveFilterChips = (props: ActiveFilterChipsProps) => {
             <Show
               when={props.filters.length > 1 && index() === lastIndex()}
               fallback={
-                <FilterChip
-                  filter={filter}
-                  onRemove={() => props.onRemove(filter.optionId)}
-                  onReplace={(newOptionId) =>
-                    props.onReplace(filter.optionId, newOptionId)
+                <Show
+                  when={filter.searchableOptions}
+                  fallback={
+                    <FilterChip
+                      filter={filter}
+                      onRemove={() => props.onRemove(filter.optionId)}
+                      onReplace={(newOptionId) =>
+                        props.onReplace(filter.optionId, newOptionId)
+                      }
+                      isOptionActive={props.isOptionActive}
+                      chipClass={props.chipClass}
+                      hideCategoryLabel={props.hideCategoryLabel}
+                    />
                   }
-                  isOptionActive={props.isOptionActive}
-                  chipClass={props.chipClass}
-                  hideCategoryLabel={props.hideCategoryLabel}
-                />
+                >
+                  <SearchableFilterChip
+                    filter={filter}
+                    onRemove={() => {
+                      if (filter.onRemove) {
+                        filter.onRemove();
+                      } else {
+                        props.onRemove(filter.optionId);
+                      }
+                    }}
+                    chipClass={props.chipClass}
+                    hideCategoryLabel={props.hideCategoryLabel}
+                  />
+                </Show>
               }
             >
               <span class="inline-flex items-center gap-1.5">
-                <FilterChip
-                  filter={filter}
-                  onRemove={() => props.onRemove(filter.optionId)}
-                  onReplace={(newOptionId) =>
-                    props.onReplace(filter.optionId, newOptionId)
+                <Show
+                  when={filter.searchableOptions}
+                  fallback={
+                    <FilterChip
+                      filter={filter}
+                      onRemove={() => props.onRemove(filter.optionId)}
+                      onReplace={(newOptionId) =>
+                        props.onReplace(filter.optionId, newOptionId)
+                      }
+                      isOptionActive={props.isOptionActive}
+                      chipClass={props.chipClass}
+                      hideCategoryLabel={props.hideCategoryLabel}
+                    />
                   }
-                  isOptionActive={props.isOptionActive}
-                  chipClass={props.chipClass}
-                  hideCategoryLabel={props.hideCategoryLabel}
-                />
+                >
+                  <SearchableFilterChip
+                    filter={filter}
+                    onRemove={() => {
+                      if (filter.onRemove) {
+                        filter.onRemove();
+                      } else {
+                        props.onRemove(filter.optionId);
+                      }
+                    }}
+                    chipClass={props.chipClass}
+                    hideCategoryLabel={props.hideCategoryLabel}
+                  />
+                </Show>
                 <Button
                   class={cn(
                     'rounded-xs whitespace-nowrap'

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/active-filter-chips.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/active-filter-chips.tsx
@@ -13,12 +13,20 @@ export type ActiveFilter = {
   icon?: () => JSX.Element;
   /** Available options in this category for replacement */
   categoryOptions?: FilterOption[];
+  /** When false, the chip dropdown renders radio-style indicators instead of checkboxes. */
+  multiple?: boolean;
   /**
    * Per-chip remove handler. When present, takes precedence over the shared
    * `onRemove` prop on `ActiveFilterChips`. Use this for filters that live
    * outside `soup.filters` (e.g. assigneeFilter).
    */
   onRemove?: () => void;
+  /**
+   * Per-chip replace handler. When present, takes precedence over the shared
+   * `onReplace` prop on `ActiveFilterChips`. Use this for filters that need
+   * side effects beyond toggling `soup.filters` (e.g. updating queryFilters).
+   */
+  onReplace?: (newOptionId: string) => void;
 };
 
 interface ActiveFilterChipsProps {
@@ -104,25 +112,48 @@ const FilterChip = (props: {
               <For each={props.filter.categoryOptions}>
                 {(option) => {
                   const active = () => props.isOptionActive(option.id);
+                  const isSingleSelect = () =>
+                    props.filter.multiple === false;
                   return (
                     <DropdownMenu.Item
                       class="w-full flex items-center gap-2.5 px-2 py-1.5 rounded-md text-left text-xs transition-colors hover:bg-ink/5 outline-none data-[highlighted]:bg-ink/5 cursor-default"
                       onSelect={() => {
-                        if (!active()) {
+                        if (active()) return;
+                        if (props.filter.onReplace) {
+                          props.filter.onReplace(option.id);
+                        } else {
                           props.onReplace(option.id);
                         }
                       }}
                     >
-                      <span
-                        class={cn(
-                          'size-4 flex items-center justify-center shrink-0 rounded border transition-colors',
-                          active() ? 'bg-accent border-accent' : 'border-edge'
-                        )}
+                      <Show
+                        when={isSingleSelect()}
+                        fallback={
+                          <span
+                            class={cn(
+                              'size-4 flex items-center justify-center shrink-0 rounded border transition-colors',
+                              active()
+                                ? 'bg-accent border-accent'
+                                : 'border-edge'
+                            )}
+                          >
+                            <Show when={active()}>
+                              <CheckIcon class="size-2.5 text-page" />
+                            </Show>
+                          </span>
+                        }
                       >
-                        <Show when={active()}>
-                          <CheckIcon class="size-2.5 text-page" />
-                        </Show>
-                      </span>
+                        <span
+                          class={cn(
+                            'size-4 flex items-center justify-center shrink-0 rounded-full border transition-colors',
+                            active() ? 'border-accent' : 'border-edge'
+                          )}
+                        >
+                          <Show when={active()}>
+                            <span class="size-2 rounded-full bg-accent" />
+                          </Show>
+                        </span>
+                      </Show>
 
                       <Show when={option.icon}>
                         {(icon) => (

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/active-filter-chips.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/active-filter-chips.tsx
@@ -327,11 +327,11 @@ const FilterChip = (props: {
                         <span
                           class={cn(
                             'size-4 flex items-center justify-center shrink-0 rounded-full border transition-colors',
-                            active() ? 'border-accent' : 'border-edge'
+                            active() ? 'bg-accent border-accent' : 'border-edge'
                           )}
                         >
                           <Show when={active()}>
-                            <span class="size-2 rounded-full bg-accent" />
+                            <CheckIcon class="size-2.5 text-page" />
                           </Show>
                         </span>
                       </Show>

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/filter-primitives.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/filter-primitives.tsx
@@ -5,6 +5,7 @@ import { Combobox } from '@kobalte/core/combobox';
 import { Select as KSelect } from '@kobalte/core/select';
 import { cn } from '@ui/utils/classname';
 import { Button } from '@app/component/next-soup/soup-view/filters-bar/button';
+import { Tooltip } from '@core/component/Tooltip';
 import { createMemo, createSignal, For, type JSX, Show } from 'solid-js';
 import type { CollectionNode } from '@kobalte/core';
 import { Virtualizer, type VirtualizerHandle } from 'virtua/solid';
@@ -21,6 +22,9 @@ interface FilterSelectProps {
   active: Option[];
   onChange: (options: Option[]) => void;
   multiple?: boolean;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  tooltip?: JSX.Element;
 }
 
 export const FilterSelect = (props: FilterSelectProps) => {
@@ -72,11 +76,32 @@ export const FilterSelect = (props: FilterSelectProps) => {
     }
   };
 
+  const triggerContent = () => (
+    <>
+      <span class="font-medium">{props.label}</span>
+      <Show when={multiple() && hasActiveFilters()}>
+        <span class="absolute -top-2 -right-2 flex items-center justify-center size-4 z-1 rounded-full text-xs font-semibold bg-accent text-page">
+          {activeCount()}
+        </span>
+      </Show>
+      <ChevronDownIcon class="size-3" />
+    </>
+  );
+
+  const triggerClass = () =>
+    cn(
+      'relative transition-none rounded-xs h-full',
+      hasActiveFilters() &&
+        'bg-accent/15 text-accent border border-accent/30 hover:bg-accent/25'
+    );
+
   return (
     <KSelect<Option>
       options={props.options}
       value={value() as Option & Option[]}
       onChange={handleChange as (value: Option & Option[]) => void}
+      open={props.open}
+      onOpenChange={props.onOpenChange}
       optionTextValue="label"
       optionValue="value"
       gutter={4}
@@ -84,24 +109,32 @@ export const FilterSelect = (props: FilterSelectProps) => {
       placement="bottom-start"
       itemComponent={renderItem}
     >
-      <KSelect.Trigger
-        as={Button}
-        variant="secondary"
-        size="sm"
-        class={cn(
-          'relative transition-none rounded-xs h-full',
-          hasActiveFilters() &&
-            'bg-accent/15 text-accent border border-accent/30 hover:bg-accent/25'
-        )}
+      <Show
+        when={props.tooltip}
+        fallback={
+          <KSelect.Trigger
+            as={Button}
+            variant="secondary"
+            size="sm"
+            class={triggerClass()}
+          >
+            {triggerContent()}
+          </KSelect.Trigger>
+        }
       >
-        <span class="font-medium">{props.label}</span>
-        <Show when={multiple() && hasActiveFilters()}>
-          <span class="absolute -top-2 -right-2 flex items-center justify-center size-4 z-1 rounded-full text-xs font-semibold bg-accent text-page">
-            {activeCount()}
-          </span>
-        </Show>
-        <ChevronDownIcon class="size-3" />
-      </KSelect.Trigger>
+        {(tooltip) => (
+          <Tooltip tooltip={tooltip()}>
+            <KSelect.Trigger
+              as={Button}
+              variant="secondary"
+              size="sm"
+              class={triggerClass()}
+            >
+              {triggerContent()}
+            </KSelect.Trigger>
+          </Tooltip>
+        )}
+      </Show>
       <KSelect.Portal>
         <KSelect.Content class="z-action-menu bg-surface-0 border border-edge-muted rounded-sm shadow min-w-[var(--kb-popper-anchor-width)] p-1">
           <KSelect.Listbox />

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/filter-primitives.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/filter-primitives.tsx
@@ -25,6 +25,8 @@ interface FilterSelectProps {
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
   tooltip?: JSX.Element;
+  hideClear?: boolean;
+  accentActive?: boolean;
 }
 
 export const FilterSelect = (props: FilterSelectProps) => {
@@ -32,7 +34,9 @@ export const FilterSelect = (props: FilterSelectProps) => {
 
   const activeFilters = createMemo(() => props.active);
   const activeCount = createMemo(() => activeFilters().length);
-  const hasActiveFilters = createMemo(() => activeCount() > 0);
+  const hasActiveFilters = createMemo(() =>
+    props.accentActive !== undefined ? props.accentActive : activeCount() > 0
+  );
 
   const renderItem = (itemProps: { item: CollectionNode<Option> }) => (
     <KSelect.Item
@@ -138,16 +142,18 @@ export const FilterSelect = (props: FilterSelectProps) => {
       <KSelect.Portal>
         <KSelect.Content class="z-action-menu bg-surface-0 border border-edge-muted rounded-sm shadow min-w-[var(--kb-popper-anchor-width)] p-1">
           <KSelect.Listbox />
-          <div class="w-full pt-1 mt-1 flex items-center border-t border-t-edge-muted">
-            <Button
-              variant="ghost"
-              size="sm"
-              class="ml-auto rounded-xs w-full"
-              onClick={() => props.onChange([])}
-            >
-              Clear
-            </Button>
-          </div>
+          <Show when={!props.hideClear}>
+            <div class="w-full pt-1 mt-1 flex items-center border-t border-t-edge-muted">
+              <Button
+                variant="ghost"
+                size="sm"
+                class="ml-auto rounded-xs w-full"
+                onClick={() => props.onChange([])}
+              >
+                Clear
+              </Button>
+            </div>
+          </Show>
         </KSelect.Content>
       </KSelect.Portal>
     </KSelect>

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/search-filter-controls.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/search-filter-controls.tsx
@@ -268,12 +268,13 @@ export const SearchIndexFilter = () => {
 const EMAIL_IMPORTANCE_OPTIONS: Option[] = [
   { value: 'signal', label: 'Signal' },
   { value: 'noise', label: 'Noise' },
+  ALL_OPTION,
 ];
 
 function importanceToOption(importance: boolean | null | undefined): Option[] {
   if (importance === true) return [EMAIL_IMPORTANCE_OPTIONS[0]];
   if (importance === false) return [EMAIL_IMPORTANCE_OPTIONS[1]];
-  return [];
+  return [ALL_OPTION];
 }
 
 const EmailImportanceFilter = () => {
@@ -283,15 +284,17 @@ const EmailImportanceFilter = () => {
     importanceToOption(queryFilters().email_filters?.importance)
   );
 
-  const label = createMemo(() => {
-    const a = active();
-    const value = a.length > 0 ? a[0].label : 'All';
-    return `Importance: ${value}`;
-  });
+  const hasSpecificImportance = () =>
+    active().some((o) => o.value !== ALL_OPTION.value);
+
+  const label = createMemo(() => `Importance: ${active()[0].label}`);
 
   const handleChange = (selected: Option[]) => {
+    const first = selected[0];
     const importance =
-      selected.length > 0 ? selected[0].value === 'signal' : undefined;
+      first && first.value !== ALL_OPTION.value
+        ? first.value === 'signal'
+        : undefined;
     setQueryFilters((prev) => ({
       ...prev,
       email_filters: {
@@ -308,6 +311,8 @@ const EmailImportanceFilter = () => {
       active={active()}
       onChange={handleChange}
       multiple={false}
+      hideClear
+      accentActive={hasSpecificImportance()}
     />
   );
 };

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/search-filter-controls.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/search-filter-controls.tsx
@@ -1,4 +1,8 @@
 import { EntityIcon } from '@core/component/EntityIcon';
+import { EntityIcon as EntityIconWithAvatar } from '@entity/extractors/entity-icon';
+import { UserIcon } from '@core/component/UserIcon';
+import { useQuickAccess } from '@core/context/quickAccess';
+import { useUserId } from '@core/context/user';
 import { QUERY_FILTERS } from '@app/component/next-soup/filters/query-filters';
 import type { FilterID } from '@app/component/next-soup/filters/configs';
 import { useSoupView } from '@app/component/next-soup/soup-view/soup-view-context';
@@ -8,12 +12,64 @@ import {
 } from '@app/component/next-soup/soup-view/soup-view-cache-key';
 import { useSplitPanelOrThrow } from '@app/component/split-layout/layoutUtils';
 import type { SoupBody } from '@queries/soup/items';
-import { batch } from 'solid-js';
+import { batch, createMemo, type JSX } from 'solid-js';
 import type { Option } from './filter-primitives';
 import type {
   ChannelFilters,
   EmailFilters,
 } from '@service-storage/generated/schemas';
+
+export type SearchableOption = {
+  id: string;
+  label: string;
+  icon?: () => JSX.Element;
+};
+
+/**
+ * Shared option accessors for search view's In/From pickers. Used both by the
+ * Filter menu submenus and by the active-filter chips.
+ */
+export function useSearchFilterOptions() {
+  const { useList } = useQuickAccess();
+  const currentUserId = useUserId();
+  const channels = useList('channel', 'dm');
+  const senders = useList('person');
+
+  const channelOptions = createMemo((): SearchableOption[] =>
+    channels()
+      .filter((ch) => ch.data.name)
+      .map((ch) => ({
+        id: ch.id,
+        label: ch.data.name,
+        icon: () => (
+          <div class="size-4">
+            <EntityIconWithAvatar entity={ch.data} />
+          </div>
+        ),
+      }))
+  );
+
+  const senderOptions = createMemo((): SearchableOption[] => {
+    const uid = currentUserId();
+    let me: SearchableOption | undefined;
+    const others: SearchableOption[] = [];
+    for (const s of senders()) {
+      const opt: SearchableOption = {
+        id: s.id,
+        label:
+          s.id === uid ? `${s.data.name || 'Me'} (me)` : s.data.name || s.id,
+        icon: () => (
+          <UserIcon id={s.id} size="xs" suppressClick showTooltip={false} />
+        ),
+      };
+      if (s.id === uid) me = opt;
+      else others.push(opt);
+    }
+    return [...(me ? [me] : []), ...others];
+  });
+
+  return { channelOptions, senderOptions };
+}
 
 export type ChannelSubFilters = Pick<
   ChannelFilters,

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/search-filter-controls.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/search-filter-controls.tsx
@@ -12,9 +12,11 @@ import {
 } from '@app/component/next-soup/soup-view/soup-view-cache-key';
 import { useSplitPanelOrThrow } from '@app/component/split-layout/layoutUtils';
 import type { SoupBody } from '@queries/soup/items';
-import { batch, createEffect, createMemo, Show } from 'solid-js';
+import { batch, createEffect, createMemo, createSignal, Show } from 'solid-js';
 import { FilterCombobox, FilterSelect, type Option } from './filter-primitives';
 import type { FilterID } from '@app/component/next-soup/filters/configs';
+import { registerHotkey } from '@core/hotkey/hotkeys';
+import { LabelAndHotKey } from '@core/component/Tooltip';
 import type {
   ChannelFilters,
   EmailFilters,
@@ -124,6 +126,17 @@ export const SearchIndexFilter = () => {
   const { soup, queryFilters, setQueryFilters } = useSoupView();
   const panel = useSplitPanelOrThrow();
   const contentId = panel.handle.content().id;
+  const [open, setOpen] = createSignal(false);
+
+  registerHotkey({
+    hotkey: 'f',
+    scopeId: panel.splitHotkeyScope,
+    description: 'Open filter menu',
+    keyDownHandler: () => {
+      setOpen(true);
+      return true;
+    },
+  });
 
   const activeIndex = createMemo((): Option[] => {
     const found = INDEX_OPTIONS.find((opt) => soup.filters.isActive(opt.value));
@@ -223,6 +236,9 @@ export const SearchIndexFilter = () => {
         active={activeIndex()}
         onChange={handleChange}
         multiple={false}
+        open={open()}
+        onOpenChange={setOpen}
+        tooltip={<LabelAndHotKey label="Filter" shortcut="F" />}
       />
       <Show when={isChannelsActive()}>
         <InChannelFilter />

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/search-filter-controls.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/search-filter-controls.tsx
@@ -116,11 +116,16 @@ export const INDEX_OPTIONS: (Option & { queryFilters: SoupBody })[] = [
   },
 ];
 
-const INDEX_SELECT_OPTIONS: Option[] = INDEX_OPTIONS.map((o) => ({
-  value: o.value,
-  label: o.label,
-  icon: o.icon,
-}));
+const ALL_OPTION: Option = { value: 'all', label: 'All' };
+
+const INDEX_SELECT_OPTIONS: Option[] = [
+  ...INDEX_OPTIONS.map((o) => ({
+    value: o.value,
+    label: o.label,
+    icon: o.icon,
+  })),
+  ALL_OPTION,
+];
 
 export const SearchIndexFilter = () => {
   const { soup, queryFilters, setQueryFilters } = useSoupView();
@@ -142,8 +147,11 @@ export const SearchIndexFilter = () => {
     const found = INDEX_OPTIONS.find((opt) => soup.filters.isActive(opt.value));
     return found
       ? [{ value: found.value, label: found.label, icon: found.icon }]
-      : [];
+      : [ALL_OPTION];
   });
+
+  const hasSpecificIndex = () =>
+    activeIndex().some((o) => o.value !== ALL_OPTION.value);
 
   const isChannelsActive = () =>
     activeIndex().some((o) => o.value === 'channels');
@@ -173,8 +181,9 @@ export const SearchIndexFilter = () => {
         }
       }
 
-      if (selected.length > 0) {
-        const opt = INDEX_OPTIONS.find((o) => o.value === selected[0].value);
+      const first = selected[0];
+      if (first && first.value !== ALL_OPTION.value) {
+        const opt = INDEX_OPTIONS.find((o) => o.value === first.value);
         if (opt) {
           soup.filters.toggle({ or: [opt.value as FilterID] });
           if (opt.value === 'channels') {
@@ -215,13 +224,7 @@ export const SearchIndexFilter = () => {
     });
   };
 
-  const indexLabel = createMemo(() => {
-    const active = activeIndex();
-    const value = active.length > 0 ? active[0].label : 'All';
-    return `Type: ${value}`;
-  });
-
-  const hasActiveIndex = () => activeIndex().length > 0;
+  const indexLabel = createMemo(() => `Type: ${activeIndex()[0].label}`);
 
   const clearFilters = () => {
     cacheChannelSubFilters(contentId, {});
@@ -239,6 +242,8 @@ export const SearchIndexFilter = () => {
         open={open()}
         onOpenChange={setOpen}
         tooltip={<LabelAndHotKey label="Filter" shortcut="F" />}
+        hideClear
+        accentActive={hasSpecificIndex()}
       />
       <Show when={isChannelsActive()}>
         <InChannelFilter />
@@ -247,7 +252,7 @@ export const SearchIndexFilter = () => {
       <Show when={isEmailActive()}>
         <EmailImportanceFilter />
       </Show>
-      <Show when={hasActiveIndex()}>
+      <Show when={hasSpecificIndex()}>
         <button
           type="button"
           class="flex items-center px-1 py-1 text-ink-muted rounded-xs hover:bg-ink/5 hover:text-ink"

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/search-filter-controls.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/search-filter-controls.tsx
@@ -1,31 +1,25 @@
-import XIcon from '@icon/regular/x.svg';
 import { EntityIcon } from '@core/component/EntityIcon';
-import { EntityIcon as EntityIconWithAvatar } from '@entity/extractors/entity-icon';
-import { UserIcon } from '@core/component/UserIcon';
-import { useQuickAccess } from '@core/context/quickAccess';
-import { useUserId } from '@core/context/user';
 import { QUERY_FILTERS } from '@app/component/next-soup/filters/query-filters';
-import { useSoupView } from '@app/component/next-soup/soup-view/soup-view-context';
 import {
   soupViewCacheKey,
   activeSoupViewCounts,
 } from '@app/component/next-soup/soup-view/soup-view-cache-key';
-import { useSplitPanelOrThrow } from '@app/component/split-layout/layoutUtils';
 import type { SoupBody } from '@queries/soup/items';
-import { batch, createEffect, createMemo, createSignal, Show } from 'solid-js';
-import { FilterCombobox, FilterSelect, type Option } from './filter-primitives';
-import type { FilterID } from '@app/component/next-soup/filters/configs';
-import { registerHotkey } from '@core/hotkey/hotkeys';
-import { LabelAndHotKey } from '@core/component/Tooltip';
+import type { Option } from './filter-primitives';
 import type {
   ChannelFilters,
   EmailFilters,
 } from '@service-storage/generated/schemas';
 
-type ChannelSubFilters = Pick<ChannelFilters, 'channel_ids' | 'sender_ids'>;
-type EmailSubFilters = Pick<EmailFilters, 'importance'>;
+export type ChannelSubFilters = Pick<
+  ChannelFilters,
+  'channel_ids' | 'sender_ids'
+>;
+export type EmailSubFilters = Pick<EmailFilters, 'importance'>;
 
-function getCachedChannelSubFilters(contentId: string): ChannelSubFilters {
+export function getCachedChannelSubFilters(
+  contentId: string
+): ChannelSubFilters {
   if ((activeSoupViewCounts.get(contentId) ?? 0) > 1) return {};
   try {
     const raw = localStorage.getItem(
@@ -37,7 +31,10 @@ function getCachedChannelSubFilters(contentId: string): ChannelSubFilters {
   }
 }
 
-function cacheChannelSubFilters(contentId: string, filters: ChannelSubFilters) {
+export function cacheChannelSubFilters(
+  contentId: string,
+  filters: ChannelSubFilters
+) {
   if ((activeSoupViewCounts.get(contentId) ?? 0) > 1) return;
   try {
     localStorage.setItem(
@@ -49,7 +46,7 @@ function cacheChannelSubFilters(contentId: string, filters: ChannelSubFilters) {
   }
 }
 
-function getCachedEmailSubFilters(contentId: string): EmailSubFilters {
+export function getCachedEmailSubFilters(contentId: string): EmailSubFilters {
   if ((activeSoupViewCounts.get(contentId) ?? 0) > 1) return {};
   try {
     const raw = localStorage.getItem(
@@ -61,7 +58,10 @@ function getCachedEmailSubFilters(contentId: string): EmailSubFilters {
   }
 }
 
-function cacheEmailSubFilters(contentId: string, filters: EmailSubFilters) {
+export function cacheEmailSubFilters(
+  contentId: string,
+  filters: EmailSubFilters
+) {
   if ((activeSoupViewCounts.get(contentId) ?? 0) > 1) return;
   try {
     localStorage.setItem(
@@ -115,347 +115,3 @@ export const INDEX_OPTIONS: (Option & { queryFilters: SoupBody })[] = [
     queryFilters: QUERY_FILTERS.agent,
   },
 ];
-
-const ALL_OPTION: Option = { value: 'all', label: 'All' };
-
-const INDEX_SELECT_OPTIONS: Option[] = [
-  ...INDEX_OPTIONS.map((o) => ({
-    value: o.value,
-    label: o.label,
-    icon: o.icon,
-  })),
-  ALL_OPTION,
-];
-
-export const SearchIndexFilter = () => {
-  const { soup, queryFilters, setQueryFilters } = useSoupView();
-  const panel = useSplitPanelOrThrow();
-  const contentId = panel.handle.content().id;
-  const [open, setOpen] = createSignal(false);
-
-  registerHotkey({
-    hotkey: 'f',
-    scopeId: panel.splitHotkeyScope,
-    description: 'Open filter menu',
-    keyDownHandler: () => {
-      setOpen(true);
-      return true;
-    },
-  });
-
-  const activeIndex = createMemo((): Option[] => {
-    const found = INDEX_OPTIONS.find((opt) => soup.filters.isActive(opt.value));
-    return found
-      ? [{ value: found.value, label: found.label, icon: found.icon }]
-      : [ALL_OPTION];
-  });
-
-  const hasSpecificIndex = () =>
-    activeIndex().some((o) => o.value !== ALL_OPTION.value);
-
-  const isChannelsActive = () =>
-    activeIndex().some((o) => o.value === 'channels');
-  const isEmailActive = () => activeIndex().some((o) => o.value === 'email');
-
-  createEffect(() => {
-    if (!isChannelsActive()) return;
-    const cf = queryFilters().channel_filters;
-    const sub: ChannelSubFilters = {};
-    if (cf?.channel_ids?.length) sub.channel_ids = cf.channel_ids;
-    if (cf?.sender_ids?.length) sub.sender_ids = cf.sender_ids;
-    cacheChannelSubFilters(contentId, sub);
-  });
-
-  createEffect(() => {
-    if (!isEmailActive()) return;
-    const ef = queryFilters().email_filters;
-    // Use null as sentinel for "explicitly cleared" since undefined is dropped by JSON.stringify
-    cacheEmailSubFilters(contentId, { importance: ef?.importance ?? null });
-  });
-
-  const handleChange = (selected: Option[]) => {
-    batch(() => {
-      for (const opt of INDEX_OPTIONS) {
-        if (soup.filters.isActive(opt.value)) {
-          soup.filters.toggle({ or: [opt.value as FilterID] });
-        }
-      }
-
-      const first = selected[0];
-      if (first && first.value !== ALL_OPTION.value) {
-        const opt = INDEX_OPTIONS.find((o) => o.value === first.value);
-        if (opt) {
-          soup.filters.toggle({ or: [opt.value as FilterID] });
-          if (opt.value === 'channels') {
-            const cached = getCachedChannelSubFilters(contentId);
-            setQueryFilters({
-              ...opt.queryFilters,
-              channel_filters: {
-                ...opt.queryFilters.channel_filters,
-                ...cached,
-              },
-            });
-          } else if (opt.value === 'email') {
-            const cached = getCachedEmailSubFilters(contentId);
-            // null in cache means "explicitly cleared" — convert to undefined to override the default
-            const importance =
-              'importance' in cached
-                ? (cached.importance ?? undefined)
-                : opt.queryFilters.email_filters?.importance;
-            setQueryFilters({
-              ...opt.queryFilters,
-              email_filters: {
-                ...opt.queryFilters.email_filters,
-                importance,
-              },
-            });
-          } else {
-            setQueryFilters({
-              ...opt.queryFilters,
-            });
-          }
-        }
-      } else {
-        setQueryFilters({
-          ...QUERY_FILTERS.default,
-          email_filters: { importance: true },
-        });
-      }
-    });
-  };
-
-  const indexLabel = createMemo(() => `Type: ${activeIndex()[0].label}`);
-
-  const clearFilters = () => {
-    cacheChannelSubFilters(contentId, {});
-    handleChange([]);
-  };
-
-  return (
-    <div class="flex items-center gap-1.5">
-      <FilterSelect
-        label={indexLabel()}
-        options={INDEX_SELECT_OPTIONS}
-        active={activeIndex()}
-        onChange={handleChange}
-        multiple={false}
-        open={open()}
-        onOpenChange={setOpen}
-        tooltip={<LabelAndHotKey label="Filter" shortcut="F" />}
-        hideClear
-        accentActive={hasSpecificIndex()}
-      />
-      <Show when={isChannelsActive()}>
-        <InChannelFilter />
-        <FromSenderFilter />
-      </Show>
-      <Show when={isEmailActive()}>
-        <EmailImportanceFilter />
-      </Show>
-      <Show when={hasSpecificIndex()}>
-        <button
-          type="button"
-          class="flex items-center px-1 py-1 text-ink-muted rounded-xs hover:bg-ink/5 hover:text-ink"
-          onClick={clearFilters}
-        >
-          <XIcon class="size-3.5" />
-        </button>
-      </Show>
-    </div>
-  );
-};
-
-const EMAIL_IMPORTANCE_OPTIONS: Option[] = [
-  { value: 'signal', label: 'Signal' },
-  { value: 'noise', label: 'Noise' },
-  ALL_OPTION,
-];
-
-function importanceToOption(importance: boolean | null | undefined): Option[] {
-  if (importance === true) return [EMAIL_IMPORTANCE_OPTIONS[0]];
-  if (importance === false) return [EMAIL_IMPORTANCE_OPTIONS[1]];
-  return [ALL_OPTION];
-}
-
-const EmailImportanceFilter = () => {
-  const { setQueryFilters, queryFilters } = useSoupView();
-
-  const active = createMemo(() =>
-    importanceToOption(queryFilters().email_filters?.importance)
-  );
-
-  const hasSpecificImportance = () =>
-    active().some((o) => o.value !== ALL_OPTION.value);
-
-  const label = createMemo(() => `Importance: ${active()[0].label}`);
-
-  const handleChange = (selected: Option[]) => {
-    const first = selected[0];
-    const importance =
-      first && first.value !== ALL_OPTION.value
-        ? first.value === 'signal'
-        : undefined;
-    setQueryFilters((prev) => ({
-      ...prev,
-      email_filters: {
-        ...prev.email_filters,
-        importance,
-      },
-    }));
-  };
-
-  return (
-    <FilterSelect
-      label={label()}
-      options={EMAIL_IMPORTANCE_OPTIONS}
-      active={active()}
-      onChange={handleChange}
-      multiple={false}
-      hideClear
-      accentActive={hasSpecificImportance()}
-    />
-  );
-};
-
-const InChannelFilter = () => {
-  const { setQueryFilters, queryFilters } = useSoupView();
-  const { useList } = useQuickAccess();
-  const channels = useList('channel', 'dm');
-
-  const channelOptions = createMemo((): Option[] =>
-    channels()
-      .filter((ch) => ch.data.name)
-      .map((ch) => ({
-        value: ch.id,
-        label: ch.data.name,
-        icon: () => (
-          <div class="size-4">
-            <EntityIconWithAvatar entity={ch.data} />
-          </div>
-        ),
-      }))
-  );
-
-  const activeChannelFilter = createMemo((): Option[] => {
-    const ids = queryFilters().channel_filters?.channel_ids;
-    if (!ids?.length) return [];
-    return channelOptions().filter((opt) => ids.includes(opt.value));
-  });
-
-  const inLabel = createMemo(() => {
-    const active = activeChannelFilter();
-    if (active.length === 0) return 'In';
-    if (active.length === 1) return `In: ${active[0].label}`;
-    return `In: ${active.length} channels`;
-  });
-
-  const handleChange = (selected: Option[]) => {
-    const ids = selected.map((opt) => opt.value);
-    setQueryFilters((prev) => ({
-      ...prev,
-      channel_filters: {
-        ...prev.channel_filters,
-        channel_ids: ids.length > 0 ? ids : undefined,
-      },
-    }));
-  };
-
-  return (
-    <div class="flex items-stretch">
-      <FilterCombobox
-        label={inLabel()}
-        options={channelOptions()}
-        active={activeChannelFilter()}
-        onChange={handleChange}
-        placeholder="Search channels..."
-        virtualized
-      />
-      <Show when={activeChannelFilter().length > 0}>
-        <button
-          type="button"
-          class="flex items-center ml-[-1px] px-1 border border-accent/30 bg-accent/15 text-accent rounded-r-xs hover:bg-accent/25"
-          onClick={() => handleChange([])}
-        >
-          <XIcon class="size-3" />
-        </button>
-      </Show>
-    </div>
-  );
-};
-
-const FromSenderFilter = () => {
-  const { setQueryFilters, queryFilters } = useSoupView();
-  const { useList } = useQuickAccess();
-  const contacts = useList('person');
-  const userId = useUserId();
-
-  const senderOptions = createMemo((): Option[] => {
-    const currentUserId = userId();
-    let me: Option | undefined;
-    const others: Option[] = [];
-    for (const c of contacts()) {
-      const opt: Option = {
-        value: c.id,
-        label:
-          c.id === currentUserId
-            ? `${c.data.name || 'Me'} (me)`
-            : c.data.name || c.id,
-        icon: () => (
-          <UserIcon id={c.id} size="xs" suppressClick showTooltip={false} />
-        ),
-      };
-      if (c.id === currentUserId) {
-        me = opt;
-      } else {
-        others.push(opt);
-      }
-    }
-    return [...(me ? [me] : []), ...others];
-  });
-
-  const activeSenderFilter = createMemo((): Option[] => {
-    const ids = queryFilters().channel_filters?.sender_ids;
-    if (!ids?.length) return [];
-    return senderOptions().filter((opt) => ids.includes(opt.value));
-  });
-
-  const fromLabel = createMemo(() => {
-    const active = activeSenderFilter();
-    if (active.length === 0) return 'From';
-    if (active.length === 1) return `From: ${active[0].label}`;
-    return `From: ${active.length} people`;
-  });
-
-  const handleChange = (selected: Option[]) => {
-    const ids = selected.map((opt) => opt.value);
-    setQueryFilters((prev) => ({
-      ...prev,
-      channel_filters: {
-        ...prev.channel_filters,
-        sender_ids: ids.length > 0 ? ids : undefined,
-      },
-    }));
-  };
-
-  return (
-    <div class="flex items-stretch">
-      <FilterCombobox
-        label={fromLabel()}
-        options={senderOptions()}
-        active={activeSenderFilter()}
-        onChange={handleChange}
-        placeholder="Search senders..."
-        virtualized
-      />
-      <Show when={activeSenderFilter().length > 0}>
-        <button
-          type="button"
-          class="flex items-center ml-[-1px] px-1 border border-accent/30 bg-accent/15 text-accent rounded-r-xs hover:bg-accent/25"
-          onClick={() => handleChange([])}
-        >
-          <XIcon class="size-3" />
-        </button>
-      </Show>
-    </div>
-  );
-};

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/search-filter-controls.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/search-filter-controls.tsx
@@ -1,10 +1,14 @@
 import { EntityIcon } from '@core/component/EntityIcon';
 import { QUERY_FILTERS } from '@app/component/next-soup/filters/query-filters';
+import type { FilterID } from '@app/component/next-soup/filters/configs';
+import { useSoupView } from '@app/component/next-soup/soup-view/soup-view-context';
 import {
   soupViewCacheKey,
   activeSoupViewCounts,
 } from '@app/component/next-soup/soup-view/soup-view-cache-key';
+import { useSplitPanelOrThrow } from '@app/component/split-layout/layoutUtils';
 import type { SoupBody } from '@queries/soup/items';
+import { batch } from 'solid-js';
 import type { Option } from './filter-primitives';
 import type {
   ChannelFilters,
@@ -71,6 +75,63 @@ export function cacheEmailSubFilters(
   } catch {
     // best-effort
   }
+}
+
+export function useSearchIndexController() {
+  const { soup, setQueryFilters } = useSoupView();
+  const panel = useSplitPanelOrThrow();
+  const contentId = panel.handle.content().id;
+
+  const changeIndex = (newValue: string) => {
+    batch(() => {
+      for (const opt of INDEX_OPTIONS) {
+        if (soup.filters.isActive(opt.value)) {
+          soup.filters.toggle({ or: [opt.value as FilterID] });
+        }
+      }
+
+      if (newValue === 'all') {
+        cacheChannelSubFilters(contentId, {});
+        setQueryFilters({
+          ...QUERY_FILTERS.default,
+          email_filters: { importance: true },
+        });
+        return;
+      }
+
+      const opt = INDEX_OPTIONS.find((o) => o.value === newValue);
+      if (!opt) return;
+      soup.filters.toggle({ or: [opt.value as FilterID] });
+
+      if (opt.value === 'channels') {
+        const cached = getCachedChannelSubFilters(contentId);
+        setQueryFilters({
+          ...opt.queryFilters,
+          channel_filters: {
+            ...opt.queryFilters.channel_filters,
+            ...cached,
+          },
+        });
+      } else if (opt.value === 'email') {
+        const cached = getCachedEmailSubFilters(contentId);
+        const importance =
+          'importance' in cached
+            ? (cached.importance ?? undefined)
+            : opt.queryFilters.email_filters?.importance;
+        setQueryFilters({
+          ...opt.queryFilters,
+          email_filters: {
+            ...opt.queryFilters.email_filters,
+            importance,
+          },
+        });
+      } else {
+        setQueryFilters({ ...opt.queryFilters });
+      }
+    });
+  };
+
+  return { changeIndex };
 }
 
 export const INDEX_OPTIONS: (Option & { queryFilters: SoupBody })[] = [

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/soup-filters-bar.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/soup-filters-bar.tsx
@@ -6,7 +6,6 @@ import type { ListView } from '@app/constants/list-views';
 import { createMemo, createSignal, Match, Show, Switch } from 'solid-js';
 import { UnifiedFilterDropdown } from '@app/component/next-soup/soup-view/filters-bar/unified-filter-dropdown';
 import { ActiveFilterChips } from '@app/component/next-soup/soup-view/filters-bar/active-filter-chips';
-import { SearchIndexFilter } from '@app/component/next-soup/soup-view/filters-bar/search-filter-controls';
 import { isMobile } from '@core/mobile/isMobile';
 import { LabelAndHotKey, Tooltip } from '@core/component/Tooltip';
 import { Button } from './button';
@@ -73,8 +72,15 @@ export const SoupFiltersBar = () => {
       <Match when={isComponentListView('search')}>
         <div class="w-full flex flex-col gap-2 p-2 border-b border-edge-muted/50">
           <SoupSearchbar autoFocus />
-          <div class="flex items-center gap-2">
-            <SearchIndexFilter />
+          <div class="flex items-start gap-2">
+            <UnifiedFilterDropdown />
+            <ActiveFilterChips
+              filters={activeFiltersList()}
+              onRemove={removeFilter}
+              onReplace={replaceFilter}
+              onClearAll={resetToTabDefaults}
+              isOptionActive={isOptionActive}
+            />
             <div class="flex-1" />
             <Tooltip
               tooltip={<LabelAndHotKey label="Preview" shortcut="space" />}

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/unified-filter-dropdown.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/unified-filter-dropdown.tsx
@@ -25,7 +25,6 @@ import { PropertyValueIcon } from '@core/component/Properties/component/property
 import { PROPERTY_OPTION_IDS } from '@core/component/Properties/constants';
 
 import { useContacts } from '@queries/contacts/contacts';
-import { useQuickAccess } from '@core/context/quickAccess';
 import { useUserId } from '@core/context/user';
 import { UserIcon } from '@core/component/UserIcon';
 import type { FilterID } from '@app/component/next-soup/filters';
@@ -36,8 +35,10 @@ import {
   INDEX_OPTIONS,
   cacheChannelSubFilters,
   cacheEmailSubFilters,
+  useSearchFilterOptions,
   useSearchIndexController,
   type ChannelSubFilters,
+  type SearchableOption,
 } from './search-filter-controls';
 
 const TypeIndicator = (props: { active: boolean }) => (
@@ -55,13 +56,6 @@ const TypeIndicator = (props: { active: boolean }) => (
 
 export type FilterOption = {
   id: FilterID;
-  label: string;
-  icon?: () => JSX.Element;
-};
-
-/** Options whose ids are arbitrary strings (e.g. contact IDs), not FilterIDs. */
-type SearchableOption = {
-  id: string;
   label: string;
   icon?: () => JSX.Element;
 };
@@ -518,7 +512,6 @@ export const UnifiedFilterDropdown = () => {
   } = useSoupView();
   const contacts = useContacts();
   const userId = useUserId();
-  const { useList } = useQuickAccess();
   const contentId = panel.handle.content().id;
 
   const currentView = createMemo((): ListView | undefined => {
@@ -611,20 +604,8 @@ export const UnifiedFilterDropdown = () => {
     cacheEmailSubFilters(contentId, { importance: ef?.importance ?? null });
   });
 
-  const channelListItems = useList('channel', 'dm');
-  const senderListItems = useList('person');
-
-  const inChannelOptions = createMemo((): SearchableOption[] =>
-    channelListItems()
-      .filter((ch) => ch.data.name)
-      .map((ch) => ({
-        id: ch.id,
-        label: ch.data.name,
-        icon: () => (
-          <EntityIcon targetType={ch.data.channelType || 'channel'} size="xs" />
-        ),
-      }))
-  );
+  const { channelOptions: inChannelOptions, senderOptions: fromSenderOptions } =
+    useSearchFilterOptions();
 
   const activeChannelIds: Accessor<string[]> = createMemo(
     () => queryFilters().channel_filters?.channel_ids ?? []
@@ -646,25 +627,6 @@ export const UnifiedFilterDropdown = () => {
       }));
     });
   };
-
-  const fromSenderOptions = createMemo((): SearchableOption[] => {
-    const uid = userId();
-    let meOption: SearchableOption | undefined;
-    const others: SearchableOption[] = [];
-    for (const c of senderListItems()) {
-      const opt: SearchableOption = {
-        id: c.id,
-        label:
-          c.id === uid ? `${c.data.name || 'Me'} (me)` : c.data.name || c.id,
-        icon: () => (
-          <UserIcon id={c.id} size="xs" suppressClick showTooltip={false} />
-        ),
-      };
-      if (c.id === uid) meOption = opt;
-      else others.push(opt);
-    }
-    return [...(meOption ? [meOption] : []), ...others];
-  });
 
   const activeSenderIds: Accessor<string[]> = createMemo(
     () => queryFilters().channel_filters?.sender_ids ?? []

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/unified-filter-dropdown.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/unified-filter-dropdown.tsx
@@ -44,11 +44,11 @@ const TypeIndicator = (props: { active: boolean }) => (
   <span
     class={cn(
       'size-4 flex items-center justify-center shrink-0 rounded-full border transition-colors',
-      props.active ? 'border-accent' : 'border-edge'
+      props.active ? 'bg-accent border-accent' : 'border-edge'
     )}
   >
     <Show when={props.active}>
-      <span class="size-2 rounded-full bg-accent" />
+      <CheckIcon class="size-2.5 text-page" />
     </Show>
   </span>
 );

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/unified-filter-dropdown.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/unified-filter-dropdown.tsx
@@ -36,21 +36,19 @@ import {
   INDEX_OPTIONS,
   cacheChannelSubFilters,
   cacheEmailSubFilters,
-  getCachedChannelSubFilters,
-  getCachedEmailSubFilters,
+  useSearchIndexController,
   type ChannelSubFilters,
 } from './search-filter-controls';
-import { QUERY_FILTERS } from '@app/component/next-soup/filters/query-filters';
 
 const TypeIndicator = (props: { active: boolean }) => (
   <span
     class={cn(
       'size-4 flex items-center justify-center shrink-0 rounded-full border transition-colors',
-      props.active ? 'bg-accent border-accent' : 'border-edge'
+      props.active ? 'border-accent' : 'border-edge'
     )}
   >
     <Show when={props.active}>
-      <CheckIcon class="size-2.5 text-page" />
+      <span class="size-2 rounded-full bg-accent" />
     </Show>
   </span>
 );
@@ -596,54 +594,7 @@ export const UnifiedFilterDropdown = () => {
   const hasActiveIndex = () =>
     INDEX_OPTIONS.some((opt) => soup.filters.isActive(opt.value));
 
-  const handleIndexChange = (newValue: string) => {
-    batch(() => {
-      for (const opt of INDEX_OPTIONS) {
-        if (soup.filters.isActive(opt.value)) {
-          soup.filters.toggle({ or: [opt.value as FilterID] });
-        }
-      }
-
-      if (newValue === 'all') {
-        cacheChannelSubFilters(contentId, {});
-        setQueryFilters({
-          ...QUERY_FILTERS.default,
-          email_filters: { importance: true },
-        });
-        return;
-      }
-
-      const opt = INDEX_OPTIONS.find((o) => o.value === newValue);
-      if (!opt) return;
-      soup.filters.toggle({ or: [opt.value as FilterID] });
-
-      if (opt.value === 'channels') {
-        const cached = getCachedChannelSubFilters(contentId);
-        setQueryFilters({
-          ...opt.queryFilters,
-          channel_filters: {
-            ...opt.queryFilters.channel_filters,
-            ...cached,
-          },
-        });
-      } else if (opt.value === 'email') {
-        const cached = getCachedEmailSubFilters(contentId);
-        const importance =
-          'importance' in cached
-            ? (cached.importance ?? undefined)
-            : opt.queryFilters.email_filters?.importance;
-        setQueryFilters({
-          ...opt.queryFilters,
-          email_filters: {
-            ...opt.queryFilters.email_filters,
-            importance,
-          },
-        });
-      } else {
-        setQueryFilters({ ...opt.queryFilters });
-      }
-    });
-  };
+  const { changeIndex: handleIndexChange } = useSearchIndexController();
 
   createEffect(() => {
     if (!isSearchView() || !isChannelsIndexActive()) return;

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/unified-filter-dropdown.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/unified-filter-dropdown.tsx
@@ -7,6 +7,8 @@ import { isListViewID } from '@app/constants/list-views';
 import { useSoupView } from '@app/component/next-soup/soup-view/soup-view-context';
 import {
   type Accessor,
+  batch,
+  createEffect,
   createMemo,
   createSignal,
   For,
@@ -23,12 +25,35 @@ import { PropertyValueIcon } from '@core/component/Properties/component/property
 import { PROPERTY_OPTION_IDS } from '@core/component/Properties/constants';
 
 import { useContacts } from '@queries/contacts/contacts';
+import { useQuickAccess } from '@core/context/quickAccess';
 import { useUserId } from '@core/context/user';
 import { UserIcon } from '@core/component/UserIcon';
 import type { FilterID } from '@app/component/next-soup/filters';
 import { NO_ASSIGNEE } from '@app/component/next-soup/soup-view/task-sub-filter-matcher';
 import { registerHotkey } from '@core/hotkey/hotkeys';
 import { LabelAndHotKey, Tooltip } from '@core/component/Tooltip';
+import {
+  INDEX_OPTIONS,
+  cacheChannelSubFilters,
+  cacheEmailSubFilters,
+  getCachedChannelSubFilters,
+  getCachedEmailSubFilters,
+  type ChannelSubFilters,
+} from './search-filter-controls';
+import { QUERY_FILTERS } from '@app/component/next-soup/filters/query-filters';
+
+const TypeIndicator = (props: { active: boolean }) => (
+  <span
+    class={cn(
+      'size-4 flex items-center justify-center shrink-0 rounded-full border transition-colors',
+      props.active ? 'bg-accent border-accent' : 'border-edge'
+    )}
+  >
+    <Show when={props.active}>
+      <CheckIcon class="size-2.5 text-page" />
+    </Show>
+  </span>
+);
 
 export type FilterOption = {
   id: FilterID;
@@ -486,9 +511,17 @@ const SearchableFilterSubmenu = (props: {
 export const UnifiedFilterDropdown = () => {
   const [open, setOpen] = createSignal(false);
   const panel = useSplitPanelOrThrow();
-  const { soup, assigneeFilter, setAssigneeFilter } = useSoupView();
+  const {
+    soup,
+    queryFilters,
+    setQueryFilters,
+    assigneeFilter,
+    setAssigneeFilter,
+  } = useSoupView();
   const contacts = useContacts();
   const userId = useUserId();
+  const { useList } = useQuickAccess();
+  const contentId = panel.handle.content().id;
 
   const currentView = createMemo((): ListView | undefined => {
     const content = panel.handle.content();
@@ -557,6 +590,168 @@ export const UnifiedFilterDropdown = () => {
   };
 
   const isTasksView = () => currentView() === 'tasks';
+  const isSearchView = () => currentView() === 'search';
+  const isChannelsIndexActive = () => soup.filters.isActive('channels');
+  const isEmailIndexActive = () => soup.filters.isActive('email');
+  const hasActiveIndex = () =>
+    INDEX_OPTIONS.some((opt) => soup.filters.isActive(opt.value));
+
+  const handleIndexChange = (newValue: string) => {
+    batch(() => {
+      for (const opt of INDEX_OPTIONS) {
+        if (soup.filters.isActive(opt.value)) {
+          soup.filters.toggle({ or: [opt.value as FilterID] });
+        }
+      }
+
+      if (newValue === 'all') {
+        cacheChannelSubFilters(contentId, {});
+        setQueryFilters({
+          ...QUERY_FILTERS.default,
+          email_filters: { importance: true },
+        });
+        return;
+      }
+
+      const opt = INDEX_OPTIONS.find((o) => o.value === newValue);
+      if (!opt) return;
+      soup.filters.toggle({ or: [opt.value as FilterID] });
+
+      if (opt.value === 'channels') {
+        const cached = getCachedChannelSubFilters(contentId);
+        setQueryFilters({
+          ...opt.queryFilters,
+          channel_filters: {
+            ...opt.queryFilters.channel_filters,
+            ...cached,
+          },
+        });
+      } else if (opt.value === 'email') {
+        const cached = getCachedEmailSubFilters(contentId);
+        const importance =
+          'importance' in cached
+            ? (cached.importance ?? undefined)
+            : opt.queryFilters.email_filters?.importance;
+        setQueryFilters({
+          ...opt.queryFilters,
+          email_filters: {
+            ...opt.queryFilters.email_filters,
+            importance,
+          },
+        });
+      } else {
+        setQueryFilters({ ...opt.queryFilters });
+      }
+    });
+  };
+
+  createEffect(() => {
+    if (!isSearchView() || !isChannelsIndexActive()) return;
+    const cf = queryFilters().channel_filters;
+    const sub: ChannelSubFilters = {};
+    if (cf?.channel_ids?.length) sub.channel_ids = cf.channel_ids;
+    if (cf?.sender_ids?.length) sub.sender_ids = cf.sender_ids;
+    cacheChannelSubFilters(contentId, sub);
+  });
+
+  createEffect(() => {
+    if (!isSearchView() || !isEmailIndexActive()) return;
+    const ef = queryFilters().email_filters;
+    cacheEmailSubFilters(contentId, { importance: ef?.importance ?? null });
+  });
+
+  const channelListItems = useList('channel', 'dm');
+  const senderListItems = useList('person');
+
+  const inChannelOptions = createMemo((): SearchableOption[] =>
+    channelListItems()
+      .filter((ch) => ch.data.name)
+      .map((ch) => ({
+        id: ch.id,
+        label: ch.data.name,
+        icon: () => (
+          <EntityIcon
+            targetType={ch.data.channelType || 'channel'}
+            size="xs"
+          />
+        ),
+      }))
+  );
+
+  const activeChannelIds: Accessor<string[]> = createMemo(
+    () => queryFilters().channel_filters?.channel_ids ?? []
+  );
+
+  const toggleChannelId = (id: string) => {
+    batch(() => {
+      if (!isChannelsIndexActive()) handleIndexChange('channels');
+      const current = queryFilters().channel_filters?.channel_ids ?? [];
+      const nextIds = current.includes(id)
+        ? current.filter((cid) => cid !== id)
+        : [...current, id];
+      setQueryFilters((prev) => ({
+        ...prev,
+        channel_filters: {
+          ...prev.channel_filters,
+          channel_ids: nextIds.length > 0 ? nextIds : undefined,
+        },
+      }));
+    });
+  };
+
+  const fromSenderOptions = createMemo((): SearchableOption[] => {
+    const uid = userId();
+    let meOption: SearchableOption | undefined;
+    const others: SearchableOption[] = [];
+    for (const c of senderListItems()) {
+      const opt: SearchableOption = {
+        id: c.id,
+        label:
+          c.id === uid
+            ? `${c.data.name || 'Me'} (me)`
+            : c.data.name || c.id,
+        icon: () => (
+          <UserIcon id={c.id} size="xs" suppressClick showTooltip={false} />
+        ),
+      };
+      if (c.id === uid) meOption = opt;
+      else others.push(opt);
+    }
+    return [...(meOption ? [meOption] : []), ...others];
+  });
+
+  const activeSenderIds: Accessor<string[]> = createMemo(
+    () => queryFilters().channel_filters?.sender_ids ?? []
+  );
+
+  const toggleSenderId = (id: string) => {
+    batch(() => {
+      if (!isChannelsIndexActive()) handleIndexChange('channels');
+      const current = queryFilters().channel_filters?.sender_ids ?? [];
+      const nextIds = current.includes(id)
+        ? current.filter((sid) => sid !== id)
+        : [...current, id];
+      setQueryFilters((prev) => ({
+        ...prev,
+        channel_filters: {
+          ...prev.channel_filters,
+          sender_ids: nextIds.length > 0 ? nextIds : undefined,
+        },
+      }));
+    });
+  };
+
+  const setImportance = (val: boolean | undefined) => {
+    batch(() => {
+      if (!isEmailIndexActive()) handleIndexChange('email');
+      setQueryFilters((prev) => ({
+        ...prev,
+        email_filters: { ...prev.email_filters, importance: val },
+      }));
+    });
+  };
+
+  const importance = createMemo(() => queryFilters().email_filters?.importance);
 
   registerHotkey({
     hotkey: 'f',
@@ -569,7 +764,7 @@ export const UnifiedFilterDropdown = () => {
   });
 
   return (
-    <Show when={categories().length > 0 || isTasksView()}>
+    <Show when={categories().length > 0 || isTasksView() || isSearchView()}>
       <DropdownMenu open={open()} onOpenChange={setOpen}>
         <Tooltip tooltip={<LabelAndHotKey label="Filter" shortcut="F" />}>
           <DropdownMenu.Trigger
@@ -586,7 +781,9 @@ export const UnifiedFilterDropdown = () => {
         <DropdownMenu.Portal>
           <DropdownMenu.Content class="z-action-menu bg-menu border border-edge-muted rounded-sm shadow-xl min-w-[180px] p-1">
             <Show
-              when={categories().length === 1 && !isTasksView()}
+              when={
+                categories().length === 1 && !isTasksView() && !isSearchView()
+              }
               fallback={
                 <>
                   <For each={categories()}>
@@ -657,6 +854,183 @@ export const UnifiedFilterDropdown = () => {
                       placeholder="Search assignees..."
                       multiple
                     />
+                  </Show>
+
+                  {/* Search view: 7 type rows (Channels/Email have nested submenus) */}
+                  <Show when={isSearchView()}>
+                    <For each={INDEX_OPTIONS}>
+                      {(option) => {
+                        const active = () =>
+                          soup.filters.isActive(option.value);
+                        const hasSub =
+                          option.value === 'channels' ||
+                          option.value === 'email';
+                        return (
+                          <Show
+                            when={hasSub}
+                            fallback={
+                              <DropdownMenu.Item
+                                class="w-full flex items-center gap-2.5 px-3 py-1.5 rounded-xs text-left text-xs transition-colors hover:bg-hover outline-none data-[highlighted]:bg-hover"
+                                onSelect={() =>
+                                  handleIndexChange(option.value)
+                                }
+                                closeOnSelect
+                              >
+                                <TypeIndicator active={active()} />
+                                <Show when={option.icon}>
+                                  {(icon) => (
+                                    <span class="size-4 flex items-center justify-center shrink-0">
+                                      {icon()()}
+                                    </span>
+                                  )}
+                                </Show>
+                                <span
+                                  class={cn(
+                                    'flex-1 truncate',
+                                    active() ? 'text-ink' : 'text-ink-muted'
+                                  )}
+                                >
+                                  {option.label}
+                                </span>
+                              </DropdownMenu.Item>
+                            }
+                          >
+                            <DropdownMenu.Sub gutter={4}>
+                              <DropdownMenu.SubTrigger
+                                class="w-full flex items-center gap-2.5 px-3 py-1.5 rounded-xs text-left text-xs transition-colors hover:bg-hover outline-none data-[highlighted]:bg-hover"
+                                onPointerDown={() =>
+                                  handleIndexChange(option.value)
+                                }
+                              >
+                                <TypeIndicator active={active()} />
+                                <Show when={option.icon}>
+                                  {(icon) => (
+                                    <span class="size-4 flex items-center justify-center shrink-0">
+                                      {icon()()}
+                                    </span>
+                                  )}
+                                </Show>
+                                <span
+                                  class={cn(
+                                    'flex-1 truncate',
+                                    active() ? 'text-ink' : 'text-ink-muted'
+                                  )}
+                                >
+                                  {option.label}
+                                </span>
+                                <CaretRightIcon class="size-3 text-ink-muted" />
+                              </DropdownMenu.SubTrigger>
+                              <DropdownMenu.Portal>
+                                <DropdownMenu.SubContent class="z-action-menu bg-menu border border-edge-muted rounded-sm shadow-xl min-w-[180px] p-1">
+                                  <Show when={option.value === 'channels'}>
+                                    <SearchableFilterSubmenu
+                                      label="In"
+                                      options={inChannelOptions}
+                                      activeIds={activeChannelIds}
+                                      onToggle={toggleChannelId}
+                                      placeholder="Search channels..."
+                                      multiple
+                                    />
+                                    <SearchableFilterSubmenu
+                                      label="From"
+                                      options={fromSenderOptions}
+                                      activeIds={activeSenderIds}
+                                      onToggle={toggleSenderId}
+                                      placeholder="Search senders..."
+                                      multiple
+                                    />
+                                  </Show>
+                                  <Show when={option.value === 'email'}>
+                                    <DropdownMenu.Sub gutter={4}>
+                                      <DropdownMenu.SubTrigger class="w-full flex items-center justify-between gap-2 px-3 py-1.5 rounded-xs text-left text-xs transition-colors hover:bg-hover outline-none data-[highlighted]:bg-hover">
+                                        <span class="text-ink">
+                                          Importance
+                                        </span>
+                                        <CaretRightIcon class="size-3 text-ink-muted" />
+                                      </DropdownMenu.SubTrigger>
+                                      <DropdownMenu.Portal>
+                                        <DropdownMenu.SubContent class="z-action-menu bg-menu border border-edge-muted rounded-sm shadow-xl min-w-[160px] p-1">
+                                          <For
+                                            each={[
+                                              {
+                                                label: 'Signal',
+                                                value: true as
+                                                  | boolean
+                                                  | undefined,
+                                              },
+                                              {
+                                                label: 'Noise',
+                                                value: false as
+                                                  | boolean
+                                                  | undefined,
+                                              },
+                                              {
+                                                label: 'All',
+                                                value: undefined as
+                                                  | boolean
+                                                  | undefined,
+                                              },
+                                            ]}
+                                          >
+                                            {(importanceOption) => {
+                                              const importanceActive = () =>
+                                                importance() ===
+                                                importanceOption.value;
+                                              return (
+                                                <DropdownMenu.Item
+                                                  class="w-full flex items-center gap-2.5 px-3 py-1.5 rounded-xs text-left text-xs transition-colors hover:bg-hover outline-none data-[highlighted]:bg-hover"
+                                                  onSelect={() =>
+                                                    setImportance(
+                                                      importanceOption.value
+                                                    )
+                                                  }
+                                                  closeOnSelect
+                                                >
+                                                  <TypeIndicator
+                                                    active={importanceActive()}
+                                                  />
+                                                  <span
+                                                    class={cn(
+                                                      'flex-1 truncate',
+                                                      importanceActive()
+                                                        ? 'text-ink'
+                                                        : 'text-ink-muted'
+                                                    )}
+                                                  >
+                                                    {importanceOption.label}
+                                                  </span>
+                                                </DropdownMenu.Item>
+                                              );
+                                            }}
+                                          </For>
+                                        </DropdownMenu.SubContent>
+                                      </DropdownMenu.Portal>
+                                    </DropdownMenu.Sub>
+                                  </Show>
+                                </DropdownMenu.SubContent>
+                              </DropdownMenu.Portal>
+                            </DropdownMenu.Sub>
+                          </Show>
+                        );
+                      }}
+                    </For>
+
+                    {/* All row */}
+                    <DropdownMenu.Item
+                      class="w-full flex items-center gap-2.5 px-3 py-1.5 rounded-xs text-left text-xs transition-colors hover:bg-hover outline-none data-[highlighted]:bg-hover"
+                      onSelect={() => handleIndexChange('all')}
+                      closeOnSelect
+                    >
+                      <TypeIndicator active={!hasActiveIndex()} />
+                      <span
+                        class={cn(
+                          'flex-1 truncate',
+                          !hasActiveIndex() ? 'text-ink' : 'text-ink-muted'
+                        )}
+                      >
+                        All
+                      </span>
+                    </DropdownMenu.Item>
                   </Show>
                 </>
               }

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/unified-filter-dropdown.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/unified-filter-dropdown.tsx
@@ -621,10 +621,7 @@ export const UnifiedFilterDropdown = () => {
         id: ch.id,
         label: ch.data.name,
         icon: () => (
-          <EntityIcon
-            targetType={ch.data.channelType || 'channel'}
-            size="xs"
-          />
+          <EntityIcon targetType={ch.data.channelType || 'channel'} size="xs" />
         ),
       }))
   );
@@ -658,9 +655,7 @@ export const UnifiedFilterDropdown = () => {
       const opt: SearchableOption = {
         id: c.id,
         label:
-          c.id === uid
-            ? `${c.data.name || 'Me'} (me)`
-            : c.data.name || c.id,
+          c.id === uid ? `${c.data.name || 'Me'} (me)` : c.data.name || c.id,
         icon: () => (
           <UserIcon id={c.id} size="xs" suppressClick showTooltip={false} />
         ),
@@ -822,9 +817,7 @@ export const UnifiedFilterDropdown = () => {
                             fallback={
                               <DropdownMenu.Item
                                 class="w-full flex items-center gap-2.5 px-3 py-1.5 rounded-xs text-left text-xs transition-colors hover:bg-hover outline-none data-[highlighted]:bg-hover"
-                                onSelect={() =>
-                                  handleIndexChange(option.value)
-                                }
+                                onSelect={() => handleIndexChange(option.value)}
                                 closeOnSelect
                               >
                                 <TypeIndicator active={active()} />
@@ -894,9 +887,7 @@ export const UnifiedFilterDropdown = () => {
                                   <Show when={option.value === 'email'}>
                                     <DropdownMenu.Sub gutter={4}>
                                       <DropdownMenu.SubTrigger class="w-full flex items-center justify-between gap-2 px-3 py-1.5 rounded-xs text-left text-xs transition-colors hover:bg-hover outline-none data-[highlighted]:bg-hover">
-                                        <span class="text-ink">
-                                          Importance
-                                        </span>
+                                        <span class="text-ink">Importance</span>
                                         <CaretRightIcon class="size-3 text-ink-muted" />
                                       </DropdownMenu.SubTrigger>
                                       <DropdownMenu.Portal>

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/use-filter-refinements.ts
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/use-filter-refinements.ts
@@ -3,10 +3,7 @@ import {
   type PresetContext,
 } from '@app/component/app-sidebar/soup-filter-presets';
 import type { FilterID } from '@app/component/next-soup/filters/configs';
-import {
-  NIL_UUID,
-  QUERY_FILTERS,
-} from '@app/component/next-soup/filters/query-filters';
+import { NIL_UUID } from '@app/component/next-soup/filters/query-filters';
 import { NO_ASSIGNEE } from '@app/component/next-soup/soup-view/task-sub-filter-matcher';
 import { useSoupView } from '@app/component/next-soup/soup-view/soup-view-context';
 import { useSplitPanelOrThrow } from '@app/component/split-layout/layoutUtils';
@@ -19,6 +16,7 @@ import { useContacts } from '@queries/contacts/contacts';
 import { batch, createMemo } from 'solid-js';
 import type { ActiveFilter } from './active-filter-chips';
 import { INDEX_OPTIONS } from './search-operator-autocomplete';
+import { useSearchIndexController } from './search-filter-controls';
 import {
   buildContactLabel,
   VIEW_FILTER_CATEGORIES,
@@ -57,6 +55,9 @@ export function useFilterRefinements() {
   const contacts = useContacts();
   const currentUserId = useUserId();
   const quickAccess = useQuickAccess();
+  const channelList = quickAccess.useList('channel', 'dm');
+  const senderList = quickAccess.useList('person');
+  const { changeIndex } = useSearchIndexController();
 
   const getPresetContext = (): PresetContext => ({
     userId: user.userId(),
@@ -175,15 +176,14 @@ export function useFilterRefinements() {
         continue;
       }
       filters.push({
-        categoryLabel: 'Index',
+        categoryLabel: 'Type',
         optionId: option.id,
         optionLabel: option.label,
         icon: option.icon,
         categoryOptions: INDEX_OPTIONS as ActiveFilter['categoryOptions'],
-        onRemove: () => {
-          soup.filters.toggle({ or: [optionId] });
-          setQueryFilters(QUERY_FILTERS.default);
-        },
+        multiple: false,
+        onRemove: () => changeIndex('all'),
+        onReplace: (newOptionId) => changeIndex(newOptionId),
       });
     }
 
@@ -204,14 +204,24 @@ export function useFilterRefinements() {
     const channelIds = (
       queryFilters().channel_filters?.channel_ids ?? []
     ).filter((id) => id !== NIL_UUID);
+    const channelReplaceOptions = channelIds.length > 0
+      ? (channelList()
+          .filter((ch) => ch.data.name)
+          .map((ch) => ({
+            id: ch.id,
+            label: ch.data.name,
+          })) as unknown as ActiveFilter['categoryOptions'])
+      : undefined;
     for (const channelId of channelIds) {
       const item = quickAccess.getById(channelId);
       const label =
         item && 'data' in item && item.data?.name ? item.data.name : channelId;
       filters.push({
         categoryLabel: 'In',
-        optionId: `in:${channelId}`,
+        optionId: channelId,
         optionLabel: label,
+        categoryOptions: channelReplaceOptions,
+        multiple: true,
         onRemove: () =>
           setQueryFilters((prev) => {
             const ids = (prev.channel_filters?.channel_ids ?? []).filter(
@@ -225,19 +235,41 @@ export function useFilterRefinements() {
               },
             };
           }),
+        onReplace: (newOptionId) =>
+          setQueryFilters((prev) => {
+            const existing = prev.channel_filters?.channel_ids ?? [];
+            const ids = existing
+              .filter((id) => id !== channelId && id !== newOptionId)
+              .concat(newOptionId);
+            return {
+              ...prev,
+              channel_filters: {
+                ...prev.channel_filters,
+                channel_ids: ids,
+              },
+            };
+          }),
       });
     }
 
     // Search operator filters: from: (sender_ids)
     const senderIds = queryFilters().channel_filters?.sender_ids ?? [];
+    const senderReplaceOptions = senderIds.length > 0
+      ? (senderList().map((s) => ({
+          id: s.id,
+          label: s.data.name || s.id,
+        })) as unknown as ActiveFilter['categoryOptions'])
+      : undefined;
     for (const senderId of senderIds) {
       const item = quickAccess.getById(senderId);
       const label =
         item && 'data' in item && item.data?.name ? item.data.name : senderId;
       filters.push({
         categoryLabel: 'From',
-        optionId: `from:${senderId}`,
+        optionId: senderId,
         optionLabel: label,
+        categoryOptions: senderReplaceOptions,
+        multiple: true,
         onRemove: () =>
           setQueryFilters((prev) => {
             const ids = (prev.channel_filters?.sender_ids ?? []).filter(
@@ -251,6 +283,20 @@ export function useFilterRefinements() {
               },
             };
           }),
+        onReplace: (newOptionId) =>
+          setQueryFilters((prev) => {
+            const existing = prev.channel_filters?.sender_ids ?? [];
+            const ids = existing
+              .filter((id) => id !== senderId && id !== newOptionId)
+              .concat(newOptionId);
+            return {
+              ...prev,
+              channel_filters: {
+                ...prev.channel_filters,
+                sender_ids: ids,
+              },
+            };
+          }),
       });
     }
 
@@ -258,14 +304,29 @@ export function useFilterRefinements() {
     if (soup.filters.isActive('email')) {
       const importance = queryFilters().email_filters?.importance;
       if (importance !== undefined) {
+        const IMPORTANCE_SIGNAL = 'importance:signal';
+        const IMPORTANCE_NOISE = 'importance:noise';
         filters.push({
           categoryLabel: 'Importance',
-          optionId: importance ? 'importance:signal' : 'importance:noise',
+          optionId: importance ? IMPORTANCE_SIGNAL : IMPORTANCE_NOISE,
           optionLabel: importance ? 'Signal' : 'Noise',
+          categoryOptions: [
+            { id: IMPORTANCE_SIGNAL, label: 'Signal' },
+            { id: IMPORTANCE_NOISE, label: 'Noise' },
+          ] as unknown as ActiveFilter['categoryOptions'],
+          multiple: false,
           onRemove: () =>
             setQueryFilters((prev) => ({
               ...prev,
               email_filters: { ...prev.email_filters, importance: undefined },
+            })),
+          onReplace: (newOptionId) =>
+            setQueryFilters((prev) => ({
+              ...prev,
+              email_filters: {
+                ...prev.email_filters,
+                importance: newOptionId === IMPORTANCE_SIGNAL,
+              },
             })),
         });
       }

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/use-filter-refinements.ts
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/use-filter-refinements.ts
@@ -254,6 +254,23 @@ export function useFilterRefinements() {
       });
     }
 
+    // Email importance (only when the email index is active)
+    if (soup.filters.isActive('email')) {
+      const importance = queryFilters().email_filters?.importance;
+      if (importance !== undefined) {
+        filters.push({
+          categoryLabel: 'Importance',
+          optionId: importance ? 'importance:signal' : 'importance:noise',
+          optionLabel: importance ? 'Signal' : 'Noise',
+          onRemove: () =>
+            setQueryFilters((prev) => ({
+              ...prev,
+              email_filters: { ...prev.email_filters, importance: undefined },
+            })),
+        });
+      }
+    }
+
     return filters;
   });
 

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/use-filter-refinements.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/use-filter-refinements.tsx
@@ -297,8 +297,8 @@ export function useFilterRefinements() {
       });
     }
 
-    // Email importance (only when the email index is active)
-    if (soup.filters.isActive('email')) {
+    // Email importance (only when the email index is active in the search view)
+    if (currentView() === 'search' && soup.filters.isActive('email')) {
       const importance = queryFilters().email_filters?.importance;
       if (importance !== undefined) {
         const IMPORTANCE_SIGNAL = 'importance:signal';

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/use-filter-refinements.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/use-filter-refinements.tsx
@@ -4,6 +4,8 @@ import {
 } from '@app/component/app-sidebar/soup-filter-presets';
 import type { FilterID } from '@app/component/next-soup/filters/configs';
 import { NIL_UUID } from '@app/component/next-soup/filters/query-filters';
+import { EntityIcon as EntityIconWithAvatar } from '@entity/extractors/entity-icon';
+import { UserIcon } from '@core/component/UserIcon';
 import { NO_ASSIGNEE } from '@app/component/next-soup/soup-view/task-sub-filter-matcher';
 import { useSoupView } from '@app/component/next-soup/soup-view/soup-view-context';
 import { useSplitPanelOrThrow } from '@app/component/split-layout/layoutUtils';
@@ -13,7 +15,7 @@ import { useQuickAccess } from '@core/context/quickAccess';
 import { useUserContext, useUserId } from '@core/context/user';
 import { deepEqual } from '@core/util/compareUtils';
 import { useContacts } from '@queries/contacts/contacts';
-import { batch, createMemo } from 'solid-js';
+import { batch, createMemo, type JSX } from 'solid-js';
 import type { ActiveFilter } from './active-filter-chips';
 import { INDEX_OPTIONS } from './search-operator-autocomplete';
 import { useSearchIndexController } from './search-filter-controls';
@@ -204,14 +206,26 @@ export function useFilterRefinements() {
     const channelIds = (
       queryFilters().channel_filters?.channel_ids ?? []
     ).filter((id) => id !== NIL_UUID);
-    const channelReplaceOptions = channelIds.length > 0
-      ? (channelList()
-          .filter((ch) => ch.data.name)
-          .map((ch) => ({
-            id: ch.id,
-            label: ch.data.name,
-          })) as unknown as ActiveFilter['categoryOptions'])
-      : undefined;
+    const channelOptionsAccessor = () =>
+      channelList()
+        .filter((ch) => ch.data.name)
+        .map((ch) => ({
+          id: ch.id,
+          label: ch.data.name,
+          icon: () => (
+            <div class="size-4">
+              <EntityIconWithAvatar entity={ch.data} />
+            </div>
+          ),
+        }));
+    const setChannelIds = (ids: string[]) =>
+      setQueryFilters((prev) => ({
+        ...prev,
+        channel_filters: {
+          ...prev.channel_filters,
+          channel_ids: ids.length > 0 ? ids : undefined,
+        },
+      }));
     for (const channelId of channelIds) {
       const item = quickAccess.getById(channelId);
       const label =
@@ -220,46 +234,51 @@ export function useFilterRefinements() {
         categoryLabel: 'In',
         optionId: channelId,
         optionLabel: label,
-        categoryOptions: channelReplaceOptions,
-        multiple: true,
+        searchableOptions: channelOptionsAccessor,
+        activeSearchableIds: () =>
+          (queryFilters().channel_filters?.channel_ids ?? []).filter(
+            (id) => id !== NIL_UUID
+          ),
+        onSearchableChange: setChannelIds,
+        searchPlaceholder: 'Search channels...',
         onRemove: () =>
-          setQueryFilters((prev) => {
-            const ids = (prev.channel_filters?.channel_ids ?? []).filter(
-              (id) => id !== channelId
-            );
-            return {
-              ...prev,
-              channel_filters: {
-                ...prev.channel_filters,
-                channel_ids: ids.length > 0 ? ids : undefined,
-              },
-            };
-          }),
-        onReplace: (newOptionId) =>
-          setQueryFilters((prev) => {
-            const existing = prev.channel_filters?.channel_ids ?? [];
-            const ids = existing
-              .filter((id) => id !== channelId && id !== newOptionId)
-              .concat(newOptionId);
-            return {
-              ...prev,
-              channel_filters: {
-                ...prev.channel_filters,
-                channel_ids: ids,
-              },
-            };
-          }),
+          setChannelIds(channelIds.filter((id) => id !== channelId)),
       });
     }
 
     // Search operator filters: from: (sender_ids)
     const senderIds = queryFilters().channel_filters?.sender_ids ?? [];
-    const senderReplaceOptions = senderIds.length > 0
-      ? (senderList().map((s) => ({
+    const senderOptionsAccessor = () => {
+      const uid = currentUserId();
+      let me:
+        | { id: string; label: string; icon?: () => JSX.Element }
+        | undefined;
+      const others: { id: string; label: string; icon?: () => JSX.Element }[] =
+        [];
+      for (const s of senderList()) {
+        const opt = {
           id: s.id,
-          label: s.data.name || s.id,
-        })) as unknown as ActiveFilter['categoryOptions'])
-      : undefined;
+          label:
+            s.id === uid
+              ? `${s.data.name || 'Me'} (me)`
+              : s.data.name || s.id,
+          icon: () => (
+            <UserIcon id={s.id} size="xs" suppressClick showTooltip={false} />
+          ),
+        };
+        if (s.id === uid) me = opt;
+        else others.push(opt);
+      }
+      return [...(me ? [me] : []), ...others];
+    };
+    const setSenderIds = (ids: string[]) =>
+      setQueryFilters((prev) => ({
+        ...prev,
+        channel_filters: {
+          ...prev.channel_filters,
+          sender_ids: ids.length > 0 ? ids : undefined,
+        },
+      }));
     for (const senderId of senderIds) {
       const item = quickAccess.getById(senderId);
       const label =
@@ -268,35 +287,13 @@ export function useFilterRefinements() {
         categoryLabel: 'From',
         optionId: senderId,
         optionLabel: label,
-        categoryOptions: senderReplaceOptions,
-        multiple: true,
+        searchableOptions: senderOptionsAccessor,
+        activeSearchableIds: () =>
+          queryFilters().channel_filters?.sender_ids ?? [],
+        onSearchableChange: setSenderIds,
+        searchPlaceholder: 'Search senders...',
         onRemove: () =>
-          setQueryFilters((prev) => {
-            const ids = (prev.channel_filters?.sender_ids ?? []).filter(
-              (id) => id !== senderId
-            );
-            return {
-              ...prev,
-              channel_filters: {
-                ...prev.channel_filters,
-                sender_ids: ids.length > 0 ? ids : undefined,
-              },
-            };
-          }),
-        onReplace: (newOptionId) =>
-          setQueryFilters((prev) => {
-            const existing = prev.channel_filters?.sender_ids ?? [];
-            const ids = existing
-              .filter((id) => id !== senderId && id !== newOptionId)
-              .concat(newOptionId);
-            return {
-              ...prev,
-              channel_filters: {
-                ...prev.channel_filters,
-                sender_ids: ids,
-              },
-            };
-          }),
+          setSenderIds(senderIds.filter((id) => id !== senderId)),
       });
     }
 

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/use-filter-refinements.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/use-filter-refinements.tsx
@@ -259,9 +259,7 @@ export function useFilterRefinements() {
         const opt = {
           id: s.id,
           label:
-            s.id === uid
-              ? `${s.data.name || 'Me'} (me)`
-              : s.data.name || s.id,
+            s.id === uid ? `${s.data.name || 'Me'} (me)` : s.data.name || s.id,
           icon: () => (
             <UserIcon id={s.id} size="xs" suppressClick showTooltip={false} />
           ),
@@ -292,59 +290,43 @@ export function useFilterRefinements() {
           queryFilters().channel_filters?.sender_ids ?? [],
         onSearchableChange: setSenderIds,
         searchPlaceholder: 'Search senders...',
-        onRemove: () =>
-          setSenderIds(senderIds.filter((id) => id !== senderId)),
+        onRemove: () => setSenderIds(senderIds.filter((id) => id !== senderId)),
       });
     }
 
-    // Email importance (only when the email index is active in the search view)
+    // Email importance (only when the email index is active in the search view
+    // and the user has explicitly set a value — undefined means "All", no chip)
     if (currentView() === 'search' && soup.filters.isActive('email')) {
       const importance = queryFilters().email_filters?.importance;
-      const IMPORTANCE_SIGNAL = 'importance:signal';
-      const IMPORTANCE_NOISE = 'importance:noise';
-      const IMPORTANCE_ALL = 'importance:all';
-      const currentOptionId =
-        importance === true
-          ? IMPORTANCE_SIGNAL
-          : importance === false
-            ? IMPORTANCE_NOISE
-            : IMPORTANCE_ALL;
-      const currentLabel =
-        importance === true
-          ? 'Signal'
-          : importance === false
-            ? 'Noise'
-            : 'All';
-      filters.push({
-        categoryLabel: 'Importance',
-        optionId: currentOptionId,
-        optionLabel: currentLabel,
-        categoryOptions: [
-          { id: IMPORTANCE_SIGNAL, label: 'Signal' },
-          { id: IMPORTANCE_NOISE, label: 'Noise' },
-          { id: IMPORTANCE_ALL, label: 'All' },
-        ] as unknown as ActiveFilter['categoryOptions'],
-        multiple: false,
-        isOptionActive: (optionId) => optionId === currentOptionId,
-        onRemove: () =>
-          setQueryFilters((prev) => ({
-            ...prev,
-            email_filters: { ...prev.email_filters, importance: undefined },
-          })),
-        onReplace: (newOptionId) =>
-          setQueryFilters((prev) => ({
-            ...prev,
-            email_filters: {
-              ...prev.email_filters,
-              importance:
-                newOptionId === IMPORTANCE_SIGNAL
-                  ? true
-                  : newOptionId === IMPORTANCE_NOISE
-                    ? false
-                    : undefined,
-            },
-          })),
-      });
+      if (importance !== undefined) {
+        const IMPORTANCE_SIGNAL = 'importance:signal';
+        const IMPORTANCE_NOISE = 'importance:noise';
+        const currentOptionId = importance ? IMPORTANCE_SIGNAL : IMPORTANCE_NOISE;
+        filters.push({
+          categoryLabel: 'Importance',
+          optionId: currentOptionId,
+          optionLabel: importance ? 'Signal' : 'Noise',
+          categoryOptions: [
+            { id: IMPORTANCE_SIGNAL, label: 'Signal' },
+            { id: IMPORTANCE_NOISE, label: 'Noise' },
+          ] as unknown as ActiveFilter['categoryOptions'],
+          multiple: false,
+          isOptionActive: (optionId) => optionId === currentOptionId,
+          onRemove: () =>
+            setQueryFilters((prev) => ({
+              ...prev,
+              email_filters: { ...prev.email_filters, importance: undefined },
+            })),
+          onReplace: (newOptionId) =>
+            setQueryFilters((prev) => ({
+              ...prev,
+              email_filters: {
+                ...prev.email_filters,
+                importance: newOptionId === IMPORTANCE_SIGNAL,
+              },
+            })),
+        });
+      }
     }
 
     return filters;

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/use-filter-refinements.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/use-filter-refinements.tsx
@@ -202,6 +202,17 @@ export function useFilterRefinements() {
       });
     }
 
+    const labelForIds = (ids: string[]): string => {
+      const [first, ...rest] = ids;
+      const firstItem = quickAccess.getById(first);
+      const firstLabel =
+        firstItem && 'data' in firstItem && firstItem.data?.name
+          ? firstItem.data.name
+          : first;
+      if (rest.length === 0) return firstLabel;
+      return `${firstLabel} and ${rest.length} ${rest.length === 1 ? 'other' : 'others'}`;
+    };
+
     // Search operator filters: in: (channel_ids)
     const channelIds = (
       queryFilters().channel_filters?.channel_ids ?? []
@@ -214,14 +225,11 @@ export function useFilterRefinements() {
           channel_ids: ids.length > 0 ? ids : undefined,
         },
       }));
-    for (const channelId of channelIds) {
-      const item = quickAccess.getById(channelId);
-      const label =
-        item && 'data' in item && item.data?.name ? item.data.name : channelId;
+    if (channelIds.length > 0) {
       filters.push({
         categoryLabel: 'In',
-        optionId: channelId,
-        optionLabel: label,
+        optionId: `in:${channelIds.join(',')}`,
+        optionLabel: labelForIds(channelIds),
         searchableOptions: channelOptions,
         activeSearchableIds: () =>
           (queryFilters().channel_filters?.channel_ids ?? []).filter(
@@ -229,8 +237,7 @@ export function useFilterRefinements() {
           ),
         onSearchableChange: setChannelIds,
         searchPlaceholder: 'Search channels...',
-        onRemove: () =>
-          setChannelIds(channelIds.filter((id) => id !== channelId)),
+        onRemove: () => setChannelIds([]),
       });
     }
 
@@ -244,20 +251,17 @@ export function useFilterRefinements() {
           sender_ids: ids.length > 0 ? ids : undefined,
         },
       }));
-    for (const senderId of senderIds) {
-      const item = quickAccess.getById(senderId);
-      const label =
-        item && 'data' in item && item.data?.name ? item.data.name : senderId;
+    if (senderIds.length > 0) {
       filters.push({
         categoryLabel: 'From',
-        optionId: senderId,
-        optionLabel: label,
+        optionId: `from:${senderIds.join(',')}`,
+        optionLabel: labelForIds(senderIds),
         searchableOptions: senderOptions,
         activeSearchableIds: () =>
           queryFilters().channel_filters?.sender_ids ?? [],
         onSearchableChange: setSenderIds,
         searchPlaceholder: 'Search senders...',
-        onRemove: () => setSenderIds(senderIds.filter((id) => id !== senderId)),
+        onRemove: () => setSenderIds([]),
       });
     }
 

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/use-filter-refinements.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/use-filter-refinements.tsx
@@ -300,33 +300,51 @@ export function useFilterRefinements() {
     // Email importance (only when the email index is active in the search view)
     if (currentView() === 'search' && soup.filters.isActive('email')) {
       const importance = queryFilters().email_filters?.importance;
-      if (importance !== undefined) {
-        const IMPORTANCE_SIGNAL = 'importance:signal';
-        const IMPORTANCE_NOISE = 'importance:noise';
-        filters.push({
-          categoryLabel: 'Importance',
-          optionId: importance ? IMPORTANCE_SIGNAL : IMPORTANCE_NOISE,
-          optionLabel: importance ? 'Signal' : 'Noise',
-          categoryOptions: [
-            { id: IMPORTANCE_SIGNAL, label: 'Signal' },
-            { id: IMPORTANCE_NOISE, label: 'Noise' },
-          ] as unknown as ActiveFilter['categoryOptions'],
-          multiple: false,
-          onRemove: () =>
-            setQueryFilters((prev) => ({
-              ...prev,
-              email_filters: { ...prev.email_filters, importance: undefined },
-            })),
-          onReplace: (newOptionId) =>
-            setQueryFilters((prev) => ({
-              ...prev,
-              email_filters: {
-                ...prev.email_filters,
-                importance: newOptionId === IMPORTANCE_SIGNAL,
-              },
-            })),
-        });
-      }
+      const IMPORTANCE_SIGNAL = 'importance:signal';
+      const IMPORTANCE_NOISE = 'importance:noise';
+      const IMPORTANCE_ALL = 'importance:all';
+      const currentOptionId =
+        importance === true
+          ? IMPORTANCE_SIGNAL
+          : importance === false
+            ? IMPORTANCE_NOISE
+            : IMPORTANCE_ALL;
+      const currentLabel =
+        importance === true
+          ? 'Signal'
+          : importance === false
+            ? 'Noise'
+            : 'All';
+      filters.push({
+        categoryLabel: 'Importance',
+        optionId: currentOptionId,
+        optionLabel: currentLabel,
+        categoryOptions: [
+          { id: IMPORTANCE_SIGNAL, label: 'Signal' },
+          { id: IMPORTANCE_NOISE, label: 'Noise' },
+          { id: IMPORTANCE_ALL, label: 'All' },
+        ] as unknown as ActiveFilter['categoryOptions'],
+        multiple: false,
+        isOptionActive: (optionId) => optionId === currentOptionId,
+        onRemove: () =>
+          setQueryFilters((prev) => ({
+            ...prev,
+            email_filters: { ...prev.email_filters, importance: undefined },
+          })),
+        onReplace: (newOptionId) =>
+          setQueryFilters((prev) => ({
+            ...prev,
+            email_filters: {
+              ...prev.email_filters,
+              importance:
+                newOptionId === IMPORTANCE_SIGNAL
+                  ? true
+                  : newOptionId === IMPORTANCE_NOISE
+                    ? false
+                    : undefined,
+            },
+          })),
+      });
     }
 
     return filters;

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/use-filter-refinements.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/use-filter-refinements.tsx
@@ -4,8 +4,6 @@ import {
 } from '@app/component/app-sidebar/soup-filter-presets';
 import type { FilterID } from '@app/component/next-soup/filters/configs';
 import { NIL_UUID } from '@app/component/next-soup/filters/query-filters';
-import { EntityIcon as EntityIconWithAvatar } from '@entity/extractors/entity-icon';
-import { UserIcon } from '@core/component/UserIcon';
 import { NO_ASSIGNEE } from '@app/component/next-soup/soup-view/task-sub-filter-matcher';
 import { useSoupView } from '@app/component/next-soup/soup-view/soup-view-context';
 import { useSplitPanelOrThrow } from '@app/component/split-layout/layoutUtils';
@@ -15,10 +13,13 @@ import { useQuickAccess } from '@core/context/quickAccess';
 import { useUserContext, useUserId } from '@core/context/user';
 import { deepEqual } from '@core/util/compareUtils';
 import { useContacts } from '@queries/contacts/contacts';
-import { batch, createMemo, type JSX } from 'solid-js';
+import { batch, createMemo } from 'solid-js';
 import type { ActiveFilter } from './active-filter-chips';
 import { INDEX_OPTIONS } from './search-operator-autocomplete';
-import { useSearchIndexController } from './search-filter-controls';
+import {
+  useSearchFilterOptions,
+  useSearchIndexController,
+} from './search-filter-controls';
 import {
   buildContactLabel,
   VIEW_FILTER_CATEGORIES,
@@ -57,8 +58,7 @@ export function useFilterRefinements() {
   const contacts = useContacts();
   const currentUserId = useUserId();
   const quickAccess = useQuickAccess();
-  const channelList = quickAccess.useList('channel', 'dm');
-  const senderList = quickAccess.useList('person');
+  const { channelOptions, senderOptions } = useSearchFilterOptions();
   const { changeIndex } = useSearchIndexController();
 
   const getPresetContext = (): PresetContext => ({
@@ -206,18 +206,6 @@ export function useFilterRefinements() {
     const channelIds = (
       queryFilters().channel_filters?.channel_ids ?? []
     ).filter((id) => id !== NIL_UUID);
-    const channelOptionsAccessor = () =>
-      channelList()
-        .filter((ch) => ch.data.name)
-        .map((ch) => ({
-          id: ch.id,
-          label: ch.data.name,
-          icon: () => (
-            <div class="size-4">
-              <EntityIconWithAvatar entity={ch.data} />
-            </div>
-          ),
-        }));
     const setChannelIds = (ids: string[]) =>
       setQueryFilters((prev) => ({
         ...prev,
@@ -234,7 +222,7 @@ export function useFilterRefinements() {
         categoryLabel: 'In',
         optionId: channelId,
         optionLabel: label,
-        searchableOptions: channelOptionsAccessor,
+        searchableOptions: channelOptions,
         activeSearchableIds: () =>
           (queryFilters().channel_filters?.channel_ids ?? []).filter(
             (id) => id !== NIL_UUID
@@ -248,27 +236,6 @@ export function useFilterRefinements() {
 
     // Search operator filters: from: (sender_ids)
     const senderIds = queryFilters().channel_filters?.sender_ids ?? [];
-    const senderOptionsAccessor = () => {
-      const uid = currentUserId();
-      let me:
-        | { id: string; label: string; icon?: () => JSX.Element }
-        | undefined;
-      const others: { id: string; label: string; icon?: () => JSX.Element }[] =
-        [];
-      for (const s of senderList()) {
-        const opt = {
-          id: s.id,
-          label:
-            s.id === uid ? `${s.data.name || 'Me'} (me)` : s.data.name || s.id,
-          icon: () => (
-            <UserIcon id={s.id} size="xs" suppressClick showTooltip={false} />
-          ),
-        };
-        if (s.id === uid) me = opt;
-        else others.push(opt);
-      }
-      return [...(me ? [me] : []), ...others];
-    };
     const setSenderIds = (ids: string[]) =>
       setQueryFilters((prev) => ({
         ...prev,
@@ -285,7 +252,7 @@ export function useFilterRefinements() {
         categoryLabel: 'From',
         optionId: senderId,
         optionLabel: label,
-        searchableOptions: senderOptionsAccessor,
+        searchableOptions: senderOptions,
         activeSearchableIds: () =>
           queryFilters().channel_filters?.sender_ids ?? [],
         onSearchableChange: setSenderIds,

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/use-filter-refinements.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/use-filter-refinements.tsx
@@ -301,7 +301,9 @@ export function useFilterRefinements() {
       if (importance !== undefined) {
         const IMPORTANCE_SIGNAL = 'importance:signal';
         const IMPORTANCE_NOISE = 'importance:noise';
-        const currentOptionId = importance ? IMPORTANCE_SIGNAL : IMPORTANCE_NOISE;
+        const currentOptionId = importance
+          ? IMPORTANCE_SIGNAL
+          : IMPORTANCE_NOISE;
         filters.push({
           categoryLabel: 'Importance',
           optionId: currentOptionId,


### PR DESCRIPTION
Brings the search view's filter bar in line with the tasks view: one Filter button, nested submenus, and removable active-filter chips alongside it

<img width="1058" height="662" alt="CleanShot 2026-04-16 at 15 42 27" src="https://github.com/user-attachments/assets/29426be5-9256-483d-a31d-3d2c4d22d002" />

