### PR TITLE
fix(search): precise email-address highlighting

### DIFF
--- a/rust/cloud-storage/opensearch_client/src/search/emails.rs
+++ b/rust/cloud-storage/opensearch_client/src/search/emails.rs
@@ -36,13 +36,19 @@ const EMAIL_SIMPLE_QUERY_FIELDS: &[&str] = &[
 /// Single-word terms become `(term | term@*)` so they match both text fields
 /// and keyword email-address fields. Multi-word terms (containing spaces) skip
 /// the `@*` pattern since email addresses never contain spaces.
+/// Email-like terms (containing `@`) are wrapped in quotes to force phrase
+/// matching on analyzed text fields — otherwise the standard analyzer tokenizes
+/// `hutch@macro.com` into `[hutch, macro, com]`, causing `macro.com` to be
+/// highlighted inside unrelated addresses like `gab@macro.com`.
 /// The email pattern is lowercased because email addresses are case-insensitive.
 /// Terms are ANDed together with `+`.
 fn build_simple_query_string(terms: &[String]) -> String {
     terms
         .iter()
         .map(|term| {
-            if term.contains(' ') {
+            if term.contains('@') {
+                format!("\"{}\"", term)
+            } else if term.contains(' ') {
                 format!("({})", term)
             } else {
                 format!("({} | {}@*)", term, term.to_lowercase())

--- a/rust/cloud-storage/opensearch_client/src/search/emails/test.rs
+++ b/rust/cloud-storage/opensearch_client/src/search/emails/test.rs
@@ -39,10 +39,7 @@ fn test_build_simple_query_string_email_term_uses_phrase() {
 
 #[test]
 fn test_build_simple_query_string_email_term_mixed_with_word() {
-    let result = build_simple_query_string(&[
-        "hutch@macro.com".to_string(),
-        "review".to_string(),
-    ]);
+    let result = build_simple_query_string(&["hutch@macro.com".to_string(), "review".to_string()]);
     assert_eq!(result, "\"hutch@macro.com\" + (review | review@*)");
 }
 

--- a/rust/cloud-storage/opensearch_client/src/search/emails/test.rs
+++ b/rust/cloud-storage/opensearch_client/src/search/emails/test.rs
@@ -32,6 +32,21 @@ fn test_build_simple_query_string_mixed_single_and_multi_word() {
 }
 
 #[test]
+fn test_build_simple_query_string_email_term_uses_phrase() {
+    let result = build_simple_query_string(&["hutch@macro.com".to_string()]);
+    assert_eq!(result, "\"hutch@macro.com\"");
+}
+
+#[test]
+fn test_build_simple_query_string_email_term_mixed_with_word() {
+    let result = build_simple_query_string(&[
+        "hutch@macro.com".to_string(),
+        "review".to_string(),
+    ]);
+    assert_eq!(result, "\"hutch@macro.com\" + (review | review@*)");
+}
+
+#[test]
 fn test_email_search_args_build_injects_simple_query_string() -> anyhow::Result<()> {
     let builder: EmailQueryBuilder = EmailSearchArgs {
         terms: vec!["hello".to_string(), "test".to_string()],

--- a/rust/cloud-storage/opensearch_client/src/search/model/mod.rs
+++ b/rust/cloud-storage/opensearch_client/src/search/model/mod.rs
@@ -44,6 +44,16 @@ const OPEN_TAG: &str = "<macro_em>";
 const CLOSE_TAG: &str = "</macro_em>";
 const CHARS_BEFORE_HIGHLIGHT: usize = 200;
 
+/// Merges adjacent highlight spans separated only by `@` into a single span.
+/// The `plain` highlighter wraps each matched token individually, so a hit on
+/// `hutch@macro.com` comes back as
+/// `<macro_em>hutch</macro_em>@<macro_em>macro.com</macro_em>`. Merging across
+/// `@` renders it as `<macro_em>hutch@macro.com</macro_em>`, which reads as
+/// one email address.
+pub(crate) fn merge_highlights_across_at(fragment: &str) -> String {
+    fragment.replace(&format!("{CLOSE_TAG}@{OPEN_TAG}"), "@")
+}
+
 fn normalize_highlight_fragment(fragment: &str) -> String {
     let stripped: String = fragment
         .chars()
@@ -73,8 +83,8 @@ fn normalize_highlight_fragment(fragment: &str) -> String {
         })
         .collect();
 
-    let trimmed = normalized.trim();
-    window_around_highlight(trimmed, MAX_VISIBLE_FRAGMENT_CHARS)
+    let merged = merge_highlights_across_at(normalized.trim());
+    window_around_highlight(&merged, MAX_VISIBLE_FRAGMENT_CHARS)
 }
 
 /// Returns a window of `max_chars` visible characters around the first

--- a/rust/cloud-storage/opensearch_client/src/search/model/test.rs
+++ b/rust/cloud-storage/opensearch_client/src/search/model/test.rs
@@ -131,6 +131,44 @@ fn find_tag_aware_byte_offset_handles_utf8() {
 }
 
 #[test]
+fn merge_highlights_across_at_joins_email_tokens() {
+    let input = "sent to <macro_em>hutch</macro_em>@<macro_em>macro.com</macro_em> today";
+    let result = merge_highlights_across_at(input);
+    assert_eq!(result, "sent to <macro_em>hutch@macro.com</macro_em> today");
+}
+
+#[test]
+fn merge_highlights_across_at_leaves_standalone_highlights() {
+    let input = "say <macro_em>hello</macro_em> world";
+    let result = merge_highlights_across_at(input);
+    assert_eq!(result, "say <macro_em>hello</macro_em> world");
+}
+
+#[test]
+fn merge_highlights_across_at_leaves_plain_at_symbol() {
+    let input = "contact us @ <macro_em>macro</macro_em>";
+    let result = merge_highlights_across_at(input);
+    assert_eq!(result, "contact us @ <macro_em>macro</macro_em>");
+}
+
+#[test]
+fn merge_highlights_across_at_multiple_pairs() {
+    let input = "<macro_em>a</macro_em>@<macro_em>b.com</macro_em> and <macro_em>c</macro_em>@<macro_em>d.org</macro_em>";
+    let result = merge_highlights_across_at(input);
+    assert_eq!(
+        result,
+        "<macro_em>a@b.com</macro_em> and <macro_em>c@d.org</macro_em>"
+    );
+}
+
+#[test]
+fn normalize_merges_email_highlight_tokens() {
+    let input = "hi <macro_em>hutch</macro_em>@<macro_em>macro.com</macro_em> thanks";
+    let result = normalize_highlight_fragment(input);
+    assert_eq!(result, "hi <macro_em>hutch@macro.com</macro_em> thanks");
+}
+
+#[test]
 fn window_real_world_email_fragment() {
     let input = "Hi Gabriel, We often need to copy email to other tools — our notes, todo list, or Slack. In Gmail and Outlook, this is error prone and tedious. In Superhuman Mail, it is accurate and instantaneous: Hit Cmd+C (Mac) or Ctrl+C (Windows) to copy the current message. Hit it again to copy the conversation. Hit Cmd+V (Mac) or Ctrl+V (Windows) to paste wherever you want. You can even paste straight into Superhuman Mail! No selecting, no dragging, no fuss. I'd love to hear what you think: please reply and say <macro_em>hello</macro_em> :) Speak soon, Rahul";
     let result = window_around_highlight(input, MAX_VISIBLE_FRAGMENT_CHARS);


### PR DESCRIPTION
## Summary

Searching for `@hutch` (which expands to `hutch@macro.com`) produced a valid recipient highlight but a bogus content highlight: `macro.com` was being highlighted inside unrelated addresses like `gab@macro.com`. Two fixes:

- **`emails.rs::build_simple_query_string`** — Wrap email-like terms (containing `@`) in quotes so `simple_query_string` treats them as a phrase. The `standard` analyzer tokenizes `hutch@macro.com` into `[hutch, macro.com]`; without phrase semantics the content highlighter matches those tokens anywhere they appear, so `macro.com` lit up inside other addresses. Keyword fields (`recipients`, `sender`, etc.) are unaffected — single-token keywords match phrase queries the same way.
- **`model::merge_highlights_across_at`** — The `plain` highlighter wraps each matched token individually, producing `<macro_em>hutch</macro_em>@<macro_em>macro.com</macro_em>`. Post-process content fragments (via `normalize_highlight_fragment`) to collapse `</macro_em>@<macro_em>` back into a single span so the address reads as one highlight. Switching highlighter types to fix this at the index level is more invasive and costs the perf we get from `plain`, so doing it in Rust is the simpler path.