### PR TITLE
fix[mobile]: task bug

### DIFF
--- a/js/app/packages/app/component/split-layout/layoutManager.ts
+++ b/js/app/packages/app/component/split-layout/layoutManager.ts
@@ -920,19 +920,28 @@ export function createSplitLayout(
   }
 
   function reconcileSplits(newSplits: SplitContent[]) {
-    const currentKeys = state.splits.map(keyOfSplitState);
+    // URL segments are produced by getUrlSegments(), which excludes excluded splits.
+    const visibleSplits = state.splits.filter((s) => !isExcluded(s));
+    const currentKeys = visibleSplits.map(keyOfSplitState);
     const newKeys = newSplits.map(keyOfSplitContent);
     const changed = newKeys.join(',') !== currentKeys.join(',');
 
     if (!changed) return;
 
-    // Build the result array by position
+    // Build the result array by position, preserving excluded splits unchanged.
     const resultSplits: SplitState[] = [];
     const usedIds = new Set<SplitId>();
 
+    for (const split of state.splits) {
+      if (isExcluded(split)) {
+        resultSplits.push(split);
+        usedIds.add(split.id);
+      }
+    }
+
     for (let i = 0; i < newSplits.length; i++) {
       const newContent = newSplits[i];
-      const splitAtSameIndex = state.splits[i];
+      const splitAtSameIndex = visibleSplits[i];
 
       // Reuse split at same index if content matches
       if (

--- a/js/app/packages/app/component/split-layout/mobile/createMobileSwipeLayout.ts
+++ b/js/app/packages/app/component/split-layout/mobile/createMobileSwipeLayout.ts
@@ -70,7 +70,8 @@ export function createMobileSwipeLayout(
   });
 
   function canGoBack() {
-    return bgSplitId() !== undefined;
+    const bgId = bgSplitId();
+    return bgId !== undefined && splitManager.getSplit(bgId) !== undefined;
   }
 
   function navigateForward(


### PR DESCRIPTION
we were not filtering the background mobile splits out when we attempted to reconcile the splits against url state