### PR TITLE
fix(search): keep In/From chip popup open on multi-select

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/active-filter-chips.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/active-filter-chips.tsx
@@ -95,13 +95,41 @@ const SearchableChipItem = (itemProps: {
   </Combobox.Item>
 );
 
+// Persist open/search state across chip remounts — the active-filters array
+// recomputes with new object references on every selection toggle, which makes
+// <For> destroy and re-mount the chip, losing its internal open state.
+const chipPersistentState = new Map<
+  string,
+  {
+    isOpen: Accessor<boolean>;
+    setIsOpen: (v: boolean) => void;
+    searchQuery: Accessor<string>;
+    setSearchQuery: (v: string) => void;
+  }
+>();
+
+const getChipState = (key: string) => {
+  let entry = chipPersistentState.get(key);
+  if (!entry) {
+    const [isOpen, setIsOpen] = createSignal(false);
+    const [searchQuery, setSearchQuery] = createSignal('');
+    entry = { isOpen, setIsOpen, searchQuery, setSearchQuery };
+    chipPersistentState.set(key, entry);
+  }
+  return entry;
+};
+
 const SearchableFilterChip = (props: {
   filter: ActiveFilter;
   onRemove: () => void;
   chipClass?: string;
   hideCategoryLabel?: boolean;
 }) => {
-  const [searchQuery, setSearchQuery] = createSignal('');
+  const state = () => getChipState(props.filter.categoryLabel);
+  const searchQuery = () => state().searchQuery();
+  const setSearchQuery = (v: string) => state().setSearchQuery(v);
+  const isOpen = () => state().isOpen();
+  const setIsOpen = (v: boolean) => state().setIsOpen(v);
 
   const allOptions = () => props.filter.searchableOptions?.() ?? [];
   const activeIds = () => props.filter.activeSearchableIds?.() ?? [];
@@ -126,6 +154,7 @@ const SearchableFilterChip = (props: {
   };
 
   const onOpenChange = (open: boolean) => {
+    setIsOpen(open);
     if (!open) setSearchQuery('');
   };
 
@@ -140,6 +169,9 @@ const SearchableFilterChip = (props: {
     >
       <Combobox<SearchableOption>
         multiple
+        selectionBehavior="toggle"
+        closeOnSelection={false}
+        open={isOpen()}
         options={filteredOptions()}
         value={activeOptions()}
         onChange={handleChange}

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/search-filter-controls.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/search-filter-controls.tsx
@@ -43,7 +43,11 @@ export function useSearchFilterOptions() {
         label: ch.data.name,
         icon: () => (
           <div class="size-4">
-            <EntityIconWithAvatar entity={ch.data} />
+            <EntityIconWithAvatar
+              entity={ch.data}
+              suppressClick
+              showTooltip={false}
+            />
           </div>
         ),
       }))

--- a/js/app/packages/entity/src/extractors/entity-icon.tsx
+++ b/js/app/packages/entity/src/extractors/entity-icon.tsx
@@ -21,9 +21,16 @@ interface EntityIconProps {
   entity: EntityData;
   streamState?: StreamEvent;
   class?: string;
+  suppressClick?: boolean;
+  showTooltip?: boolean;
 }
 
-function DirectMessageIcon(props: { entity: ChannelEntity; class?: string }) {
+function DirectMessageIcon(props: {
+  entity: ChannelEntity;
+  class?: string;
+  suppressClick?: boolean;
+  showTooltip?: boolean;
+}) {
   const userId = useUserId();
   const participantId = () => {
     const participants = props.entity.participantIds ?? [];
@@ -48,6 +55,8 @@ function DirectMessageIcon(props: { entity: ChannelEntity; class?: string }) {
             isDeleted={false}
             size="fill"
             class={props.class}
+            suppressClick={props.suppressClick}
+            showTooltip={props.showTooltip}
           />
         )}
       </Show>
@@ -97,6 +106,8 @@ export function EntityIcon(props: EntityIconProps) {
         <DirectMessageIcon
           entity={props.entity as ChannelEntity}
           class={props.class}
+          suppressClick={props.suppressClick}
+          showTooltip={props.showTooltip}
         />
       </Match>
       <Match when={isChatEntity()}>


### PR DESCRIPTION
channel search in/from filters multi-select stays open. also prevents hover/click state on the user icon in the in filter. also i disable click/hover state on the channel entity icon in the in: filter so you don't accidentally click the channel when you don't want to