### PR TITLE
fix(search): emails not excluded using nil thread id

### DIFF
--- a/js/app/packages/app/component/next-soup/filters/query-filters.ts
+++ b/js/app/packages/app/component/next-soup/filters/query-filters.ts
@@ -13,7 +13,7 @@ export const QUERY_FILTERS_BASE: SoupItemsQueryFilters = {
   channel_filters: { channel_ids: EXCLUDE },
   chat_filters: { chat_ids: EXCLUDE },
   document_filters: { document_ids: EXCLUDE },
-  email_filters: { recipients: EXCLUDE },
+  email_filters: { email_thread_ids: EXCLUDE },
   project_filters: { project_ids: EXCLUDE },
 };
 
@@ -82,7 +82,7 @@ export const QUERY_FILTERS = {
   document: {
     channel_filters: { channel_ids: EXCLUDE },
     chat_filters: { chat_ids: EXCLUDE },
-    email_filters: { recipients: EXCLUDE },
+    email_filters: { email_thread_ids: EXCLUDE },
     project_filters: { project_ids: EXCLUDE },
     document_filters: { file_types: ['md', 'canvas'] },
   },
@@ -90,7 +90,7 @@ export const QUERY_FILTERS = {
   task: {
     channel_filters: { channel_ids: EXCLUDE },
     chat_filters: { chat_ids: EXCLUDE },
-    email_filters: { recipients: EXCLUDE },
+    email_filters: { email_thread_ids: EXCLUDE },
     project_filters: { project_ids: EXCLUDE },
     document_filters: { sub_types: ['task'] },
   },
@@ -106,7 +106,7 @@ export const QUERY_FILTERS = {
   people: {
     chat_filters: { chat_ids: EXCLUDE },
     document_filters: { document_ids: EXCLUDE },
-    email_filters: { recipients: EXCLUDE },
+    email_filters: { email_thread_ids: EXCLUDE },
     project_filters: { project_ids: EXCLUDE },
     channel_filters: { channel_types: [ChannelTypeEnum.DirectMessage] },
   },
@@ -114,7 +114,7 @@ export const QUERY_FILTERS = {
   teams: {
     chat_filters: { chat_ids: EXCLUDE },
     document_filters: { document_ids: EXCLUDE },
-    email_filters: { recipients: EXCLUDE },
+    email_filters: { email_thread_ids: EXCLUDE },
     project_filters: { project_ids: EXCLUDE },
     channel_filters: {
       channel_types: [
@@ -128,7 +128,7 @@ export const QUERY_FILTERS = {
   agent: {
     channel_filters: { channel_ids: EXCLUDE },
     document_filters: { document_ids: EXCLUDE },
-    email_filters: { recipients: EXCLUDE },
+    email_filters: { email_thread_ids: EXCLUDE },
     project_filters: { project_ids: EXCLUDE },
     chat_filters: {},
   },
@@ -136,7 +136,7 @@ export const QUERY_FILTERS = {
   file: {
     channel_filters: { channel_ids: EXCLUDE },
     chat_filters: { chat_ids: EXCLUDE },
-    email_filters: { recipients: EXCLUDE },
+    email_filters: { email_thread_ids: EXCLUDE },
     project_filters: { project_ids: EXCLUDE },
     document_filters: { file_types: getFileAssociations() },
   },
@@ -144,7 +144,7 @@ export const QUERY_FILTERS = {
   documentAndFile: {
     channel_filters: { channel_ids: EXCLUDE },
     chat_filters: { chat_ids: EXCLUDE },
-    email_filters: { recipients: EXCLUDE },
+    email_filters: { email_thread_ids: EXCLUDE },
     project_filters: { project_ids: EXCLUDE },
     document_filters: {
       file_types: ['md', 'canvas', 'docx', ...getFileAssociations()],
@@ -154,7 +154,7 @@ export const QUERY_FILTERS = {
   channels: {
     chat_filters: { chat_ids: EXCLUDE },
     document_filters: { document_ids: EXCLUDE },
-    email_filters: { recipients: EXCLUDE },
+    email_filters: { email_thread_ids: EXCLUDE },
     project_filters: { project_ids: EXCLUDE },
     channel_filters: {},
   },
@@ -162,7 +162,7 @@ export const QUERY_FILTERS = {
   calls: {
     chat_filters: { chat_ids: EXCLUDE },
     document_filters: { document_ids: EXCLUDE },
-    email_filters: { recipients: EXCLUDE },
+    email_filters: { email_thread_ids: EXCLUDE },
     project_filters: { project_ids: EXCLUDE },
     channel_filters: { channel_ids: EXCLUDE },
     call_filters: {},
@@ -171,7 +171,7 @@ export const QUERY_FILTERS = {
   folders: {
     channel_filters: { channel_ids: EXCLUDE },
     chat_filters: { chat_ids: EXCLUDE },
-    email_filters: { recipients: EXCLUDE },
+    email_filters: { email_thread_ids: EXCLUDE },
     document_filters: { document_ids: EXCLUDE },
     project_filters: {},
   },

--- a/rust/cloud-storage/models_search/src/unified.rs
+++ b/rust/cloud-storage/models_search/src/unified.rs
@@ -51,7 +51,7 @@ pub fn entity_filters_from_include(
         filters.chat_filters.chat_ids = exclude.clone();
     }
     if !include.contains(&UnifiedSearchIndex::Emails) {
-        filters.email_filters.recipients = exclude.clone();
+        filters.email_filters.email_thread_ids = exclude.clone();
     }
     if !include.contains(&UnifiedSearchIndex::Channels) {
         filters.channel_filters.channel_ids = exclude.clone();
@@ -152,12 +152,13 @@ impl From<EntityFilters> for SearchEntityFilters {
 
         let should_include_documents = !contains_nil_uuid(&document_filters.document_ids);
         let should_include_chats = !contains_nil_uuid(&chat_filters.chat_ids);
-        let should_include_emails = !contains_nil_uuid(&email_filters.recipients);
+        let should_include_emails = !contains_nil_uuid(&email_filters.email_thread_ids);
         let should_include_channels = !contains_nil_uuid(&channel_filters.channel_ids);
         let should_include_projects = !contains_nil_uuid(&project_filters.project_ids);
 
         strip_nil_uuids(&mut document_filters.document_ids);
         strip_nil_uuids(&mut chat_filters.chat_ids);
+        strip_nil_uuids(&mut email_filters.email_thread_ids);
         strip_nil_uuids(&mut email_filters.recipients);
         strip_nil_uuids(&mut channel_filters.channel_ids);
         strip_nil_uuids(&mut project_filters.project_ids);


### PR DESCRIPTION
This updates the search filter parsing to check `email_thread_ids` rather than `recipients` for nil uuid instead to make it consistent with the checks for the other entity types