### PR TITLE
chore(properties): clear search text when selecting entity in multiselect

### DIFF
--- a/js/app/packages/core/component/Properties/component/modal/shared/PropertyEntitySelector.tsx
+++ b/js/app/packages/core/component/Properties/component/modal/shared/PropertyEntitySelector.tsx
@@ -344,7 +344,8 @@ export function PropertyEntitySelector(props: EntityInputProps) {
     if (!props.config.isMultiSelect && props.onClose) {
       props.onClose();
     } else if (props.config.isMultiSelect && searchInputRef) {
-      // Keep input focused when multiselect is enabled
+      setInputValue('');
+      setSearchTerm('');
       setTimeout(() => searchInputRef.focus(), 0);
     }
   };
@@ -362,6 +363,8 @@ export function PropertyEntitySelector(props: EntityInputProps) {
     if (!props.config.isMultiSelect && props.onClose) {
       props.onClose();
     } else if (props.config.isMultiSelect && searchInputRef) {
+      setInputValue('');
+      setSearchTerm('');
       setTimeout(() => searchInputRef.focus(), 0);
     }
   };


### PR DESCRIPTION
realized most of teh time i just want to select a specific person, not a prefix. this optimizes around the 80 percent use case IMO