### PR TITLE
fix(filters): clean up soup/search filters

### DIFF
--- a/js/app/packages/app/component/SoupChatInput.tsx
+++ b/js/app/packages/app/component/SoupChatInput.tsx
@@ -22,12 +22,11 @@ import { invalidateAllSoup } from '@queries/soup/cache';
 import { cognitionApiServiceClient } from '@service-cognition/client';
 import { ChatInput } from 'core/component/AI/component/input/ChatInput';
 import { registerHotkey, useHotkeyDOMScope } from 'core/hotkey/hotkeys';
-import { createSignal, onCleanup, onMount, Show } from 'solid-js';
+import { createSignal, onCleanup, Show } from 'solid-js';
 import { useSplitPanelOrThrow } from './split-layout/layoutUtils';
 
 function SoupChatInputInner() {
   const analytics = useAnalytics();
-  let containerRef!: HTMLDivElement;
   const splitPanelContext = useSplitPanelOrThrow();
   const soup = useSoup();
   const input = useChatInputContext();
@@ -50,17 +49,17 @@ function SoupChatInputInner() {
   const [chatHasFocus, setChatHasFocus] = createSignal(false);
   const metaHeld = () => chatHasFocus() && pressedKeys().has('cmd');
 
-  onMount(() => {
-    attachHotkeys(containerRef);
+  const attachContainer = (el: HTMLDivElement) => {
+    attachHotkeys(el);
     const focusIn = () => setChatHasFocus(true);
     const focusOut = () => setChatHasFocus(false);
-    containerRef.addEventListener('focusin', focusIn);
-    containerRef.addEventListener('focusout', focusOut);
+    el.addEventListener('focusin', focusIn);
+    el.addEventListener('focusout', focusOut);
     onCleanup(() => {
-      containerRef.removeEventListener('focusin', focusIn);
-      containerRef.removeEventListener('focusout', focusOut);
+      el.removeEventListener('focusin', focusIn);
+      el.removeEventListener('focusout', focusOut);
     });
-  });
+  };
 
   // cmd+j - Focus AI chat
   registerHotkey({
@@ -128,7 +127,7 @@ function SoupChatInputInner() {
   return (
     <Show when={!soup.previewEntity()}>
       <div
-        ref={containerRef}
+        ref={attachContainer}
         class="absolute bottom-0 right-px left-px pb-2 px-2 flex justify-center pointer-events-none"
         style={{
           'background-image': `linear-gradient(transparent, var(--color-panel) 85%)`,

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/active-filter-chips.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/active-filter-chips.tsx
@@ -395,7 +395,7 @@ export const ActiveFilterChips = (props: ActiveFilterChipsProps) => {
                   variant="ghost"
                   onClick={() => props.onClearAll()}
                 >
-                  Clear all
+                  Clear
                 </Button>
               </span>
             </Show>

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/active-filter-chips.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/active-filter-chips.tsx
@@ -320,7 +320,7 @@ export const ActiveFilterChips = (props: ActiveFilterChipsProps) => {
 
   return (
     <Show when={props.filters.length > 0}>
-      <div class="flex items-center gap-1.5 flex-wrap min-w-0">
+      <div class="flex items-center gap-1.5 flex-wrap px-2">
         <For each={props.filters}>
           {(filter, index) => (
             // To make sure that the Clear all button never wraps to a new line on its own, we wrap it with the last FilterChip
@@ -395,7 +395,7 @@ export const ActiveFilterChips = (props: ActiveFilterChipsProps) => {
                   variant="ghost"
                   onClick={() => props.onClearAll()}
                 >
-                  Clear
+                  Clear all
                 </Button>
               </span>
             </Show>

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/active-filter-chips.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/active-filter-chips.tsx
@@ -320,7 +320,7 @@ export const ActiveFilterChips = (props: ActiveFilterChipsProps) => {
 
   return (
     <Show when={props.filters.length > 0}>
-      <div class="flex items-center gap-1.5 flex-wrap px-2">
+      <div class="flex items-center gap-1.5 flex-wrap min-w-0">
         <For each={props.filters}>
           {(filter, index) => (
             // To make sure that the Clear all button never wraps to a new line on its own, we wrap it with the last FilterChip
@@ -395,7 +395,7 @@ export const ActiveFilterChips = (props: ActiveFilterChipsProps) => {
                   variant="ghost"
                   onClick={() => props.onClearAll()}
                 >
-                  Clear all
+                  Clear
                 </Button>
               </span>
             </Show>

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/soup-filters-bar.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/soup-filters-bar.tsx
@@ -30,6 +30,8 @@ export const SoupFiltersBar = () => {
   const soup = useSoup();
   const panel = useSplitPanelOrThrow();
 
+  const isNarrow = () => (panel.panelSize.width ?? Infinity) < 720;
+
   const togglePreview = () => {
     const currentPreview = soup.previewEntity();
     if (currentPreview) {
@@ -72,7 +74,7 @@ export const SoupFiltersBar = () => {
       <Match when={isComponentListView('search')}>
         <div class="w-full flex flex-col gap-2 p-2 border-b border-edge-muted/50">
           <SoupSearchbar autoFocus />
-          <div class="flex items-start gap-2">
+          <div class="flex items-center gap-2">
             <UnifiedFilterDropdown />
             <ActiveFilterChips
               filters={activeFiltersList()}
@@ -80,6 +82,7 @@ export const SoupFiltersBar = () => {
               onReplace={replaceFilter}
               onClearAll={resetToTabDefaults}
               isOptionActive={isOptionActive}
+              hideCategoryLabel={isNarrow()}
             />
             <div class="flex-1" />
             <Tooltip
@@ -101,7 +104,7 @@ export const SoupFiltersBar = () => {
       </Match>
       <Match when={true}>
         <Show when={!isMobile()}>
-          <div class="flex items-start gap-2 px-2 py-1.5 border-b border-edge-muted/50 w-full">
+          <div class="flex items-center gap-2 px-2 py-1.5 border-b border-edge-muted/50 w-full">
             <UnifiedFilterDropdown />
             <ActiveFilterChips
               filters={activeFiltersList()}
@@ -109,6 +112,7 @@ export const SoupFiltersBar = () => {
               onReplace={replaceFilter}
               onClearAll={resetToTabDefaults}
               isOptionActive={isOptionActive}
+              hideCategoryLabel={isNarrow()}
             />
             <div class="flex-1" />
             <Tooltip

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/soup-filters-bar.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/soup-filters-bar.tsx
@@ -30,8 +30,6 @@ export const SoupFiltersBar = () => {
   const soup = useSoup();
   const panel = useSplitPanelOrThrow();
 
-  const isNarrow = () => (panel.panelSize.width ?? Infinity) < 720;
-
   const togglePreview = () => {
     const currentPreview = soup.previewEntity();
     if (currentPreview) {
@@ -74,7 +72,7 @@ export const SoupFiltersBar = () => {
       <Match when={isComponentListView('search')}>
         <div class="w-full flex flex-col gap-2 p-2 border-b border-edge-muted/50">
           <SoupSearchbar autoFocus />
-          <div class="flex items-center gap-2">
+          <div class="flex items-start gap-2">
             <UnifiedFilterDropdown />
             <ActiveFilterChips
               filters={activeFiltersList()}
@@ -82,7 +80,6 @@ export const SoupFiltersBar = () => {
               onReplace={replaceFilter}
               onClearAll={resetToTabDefaults}
               isOptionActive={isOptionActive}
-              hideCategoryLabel={isNarrow()}
             />
             <div class="flex-1" />
             <Tooltip
@@ -104,7 +101,7 @@ export const SoupFiltersBar = () => {
       </Match>
       <Match when={true}>
         <Show when={!isMobile()}>
-          <div class="flex items-center gap-2 px-2 py-1.5 border-b border-edge-muted/50 w-full">
+          <div class="flex items-start gap-2 px-2 py-1.5 border-b border-edge-muted/50 w-full">
             <UnifiedFilterDropdown />
             <ActiveFilterChips
               filters={activeFiltersList()}
@@ -112,7 +109,6 @@ export const SoupFiltersBar = () => {
               onReplace={replaceFilter}
               onClearAll={resetToTabDefaults}
               isOptionActive={isOptionActive}
-              hideCategoryLabel={isNarrow()}
             />
             <div class="flex-1" />
             <Tooltip

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/unified-filter-dropdown.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/unified-filter-dropdown.tsx
@@ -561,7 +561,7 @@ export const UnifiedFilterDropdown = () => {
             as={Button}
             variant="secondary"
             size="sm"
-            class="rounded-xs [&_svg]:size-4"
+            class="rounded-xs [&_svg]:size-4 suppress-css-bracket"
           >
             <SlidersHorizontalIcon />
             <span class="font-medium">Filter</span>

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/unified-filter-dropdown.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/unified-filter-dropdown.tsx
@@ -688,6 +688,14 @@ export const UnifiedFilterDropdown = () => {
                                 onPointerDown={() =>
                                   handleIndexChange(option.value)
                                 }
+                                onKeyDown={(e) => {
+                                  if (e.key === 'Enter' || e.key === ' ') {
+                                    e.preventDefault();
+                                    e.stopPropagation();
+                                    handleIndexChange(option.value);
+                                    setOpen(false);
+                                  }
+                                }}
                               >
                                 <TypeIndicator active={active()} />
                                 <Show when={option.icon}>


### PR DESCRIPTION
some nit cleanups and also fixes an app crash bug for attaching a focus listener to an unavailable container ref (the container div lives inside Show when={!soup.previewEntity()}, so when a preview is active on first mount the div doesn't exist yet and onMount crashed trying to call addEventListener on an undefined ref )