### PR TITLE
fix(agent-schedule-service): wire SYNC_SERVICE_AUTH_KEY env var

### DIFF
--- a/infra/stacks/agent-schedule-service/Pulumi.dev.yaml
+++ b/infra/stacks/agent-schedule-service/Pulumi.dev.yaml
@@ -6,6 +6,7 @@ config:
   agent-schedule-service:fusionauth_client_id: fusionauth-client-id-key-dev
   agent-schedule-service:fusionauth_issuer: fusionauth-dev.macro.com
   agent-schedule-service:internal_auth_key: document-storage-service-auth-key-dev
+  agent-schedule-service:sync_service_auth_key: sync-service-key-dev
   agent-schedule-service:openai_api_key: openai-key
   agent-schedule-service:anthropic_api_key: anthropic-api-key-dev
   agent-schedule-service:xai-api-key: xai-api-key

--- a/infra/stacks/agent-schedule-service/Pulumi.prod.yaml
+++ b/infra/stacks/agent-schedule-service/Pulumi.prod.yaml
@@ -6,6 +6,7 @@ config:
   agent-schedule-service:fusionauth_client_id: fusionauth-client-id-key-prod
   agent-schedule-service:fusionauth_issuer: auth.macro.com
   agent-schedule-service:internal_auth_key: document-storage-service-auth-key-prod
+  agent-schedule-service:sync_service_auth_key: sync-service-key-prod
   agent-schedule-service:openai_api_key: openai-key
   agent-schedule-service:anthropic_api_key: anthropic-api-key
   agent-schedule-service:xai-api-key: xai-api-key

--- a/infra/stacks/agent-schedule-service/index.ts
+++ b/infra/stacks/agent-schedule-service/index.ts
@@ -77,9 +77,6 @@ const internalAuthKeyArn = aws.secretsmanager
   .getSecretVersionOutput({ secretId: INTERNAL_AUTH_KEY_NAME })
   .apply((secret) => secret.arn);
 
-// Name of the Secrets Manager entry that holds the sync service auth key.
-// The env var passes this NAME; the container fetches the current value at
-// runtime via the secrets manager client.
 const SYNC_SERVICE_AUTH_KEY = config.require('sync_service_auth_key');
 const syncServiceAuthKeyArn = aws.secretsmanager
   .getSecretVersionOutput({ secretId: SYNC_SERVICE_AUTH_KEY })

--- a/infra/stacks/agent-schedule-service/index.ts
+++ b/infra/stacks/agent-schedule-service/index.ts
@@ -77,6 +77,14 @@ const internalAuthKeyArn = aws.secretsmanager
   .getSecretVersionOutput({ secretId: INTERNAL_AUTH_KEY_NAME })
   .apply((secret) => secret.arn);
 
+// Name of the Secrets Manager entry that holds the sync service auth key.
+// The env var passes this NAME; the container fetches the current value at
+// runtime via the secrets manager client.
+const SYNC_SERVICE_AUTH_KEY = config.require('sync_service_auth_key');
+const syncServiceAuthKeyArn = aws.secretsmanager
+  .getSecretVersionOutput({ secretId: SYNC_SERVICE_AUTH_KEY })
+  .apply((secret) => secret.arn);
+
 const MACRO_API_TOKENS = getMacroApiToken();
 const { notificationIngressQueueArn, notificationIngressQueueName } =
   getMacroNotify();
@@ -171,6 +179,7 @@ const service = new AgentScheduleService(`agent-schedule-service-${stack}`, {
     cloudfrontPrivateKeySecretArn,
     MACRO_API_TOKENS.macroApiTokenPublicKeyArn,
     internalAuthKeyArn,
+    syncServiceAuthKeyArn,
   ],
   queueArns: [notificationIngressQueueArn, emailScheduledQueueArn],
   bucketArns: [documentStorageBucketArn, docxUploadBucketArn],
@@ -244,6 +253,10 @@ const service = new AgentScheduleService(`agent-schedule-service-${stack}`, {
     {
       name: 'SYNC_SERVICE_URL',
       value: `https://sync-service-${stack === 'dev' ? 'dev3' : 'prod2'}.macroverse.workers.dev`,
+    },
+    {
+      name: 'SYNC_SERVICE_AUTH_KEY',
+      value: SYNC_SERVICE_AUTH_KEY,
     },
     {
       name: 'LEXICAL_SERVICE_URL',


### PR DESCRIPTION
## Summary
- The agent-schedule-service container was crashing on startup with `An error occurred while reading envvar: SYNC_SERVICE_AUTH_KEY. Err: environment variable not found` because `ai_tools::build_tool_service_context_from_env` requires it but the infra stack never set it.
- Wire `SYNC_SERVICE_AUTH_KEY` (secret name) into the task's env vars, add its ARN to `secretKeyArns` so the task role can fetch the value at runtime, and map `sync_service_auth_key` to `sync-service-key-{dev,prod}` in the Pulumi configs, matching how `document-cognition-service`, `cloud-storage-service`, `mcp-server`, and `search-processing-service` already handle it.
- Audited every env var read by `scheduled_action/src/bins/service.rs` and `build_tool_service_context_from_env`; this was the only missing one.
