### PR TITLE
feat(fe): Subscription tier update UI

### DIFF
--- a/js/app/packages/app/component/paywall/PaywallComponent.tsx
+++ b/js/app/packages/app/component/paywall/PaywallComponent.tsx
@@ -5,7 +5,8 @@ import { usePermissions } from '@core/context/user';
 import IconX from '@icon/regular/x.svg';
 import { invalidateUserInfo } from '@queries/auth/user-info';
 import { stripeServiceClient } from '@service-stripe/client';
-import { createEffect, createMemo, createSignal, For, Show } from 'solid-js';
+import { createMemo, createSignal, For, Show } from 'solid-js';
+import { match } from 'ts-pattern';
 import { useAnalytics } from '@app/component/analytics-context';
 import { PLANS, type PlanTier } from './plans';
 
@@ -35,19 +36,16 @@ const PaywallComponent = (props: PaywallComponent) => {
     return undefined;
   });
 
-  const [selectedTier, setSelectedTier] = createSignal<PlanTier>('sonnet');
-  // Seed `selectedTier` from `currentTier` once, the first time permissions resolve.
-  // Re-syncing on every `currentTier` change would clobber the user's active selection
-  // if permissions later refetch (post-update invalidation, multi-tab, etc.).
-  let seededFromCurrentTier = false;
-  createEffect(() => {
-    if (seededFromCurrentTier) return;
-    const tier = currentTier();
-    if (tier) {
-      setSelectedTier(tier);
-      seededFromCurrentTier = true;
-    }
-  });
+  // `userSelectedTier` is only set when the user explicitly clicks a plan card. Until
+  // then the UI derives its selection from `currentTier` (falling back to 'sonnet' for
+  // non-paying users). This avoids mirroring derived state into a signal via `createEffect`
+  // and also sidesteps the briefly-wrong-card window before permissions resolve.
+  const [userSelectedTier, setUserSelectedTier] = createSignal<PlanTier | null>(
+    null
+  );
+  const selectedTier = createMemo<PlanTier>(
+    () => userSelectedTier() ?? currentTier() ?? 'sonnet'
+  );
 
   const [updating, setUpdating] = createSignal(false);
 
@@ -96,27 +94,26 @@ const PaywallComponent = (props: PaywallComponent) => {
       const result = await stripeServiceClient.updateSubscriptionTier(next);
       if (!result.ok) {
         // Messages mirror the backend's StripeOperationError `Display` impls, adapted
-        // to second-person for UI. Switch on `result.code` — TS enforces exhaustiveness
-        // against `PatchSubscriptionTierErrorCode | 'UNKNOWN'`.
-        switch (result.code) {
-          case 'USER_IN_TEAM':
-            toast.failure('Contact your team owner to update.');
-            break;
-          case 'UPDATE_IN_PROGRESS':
-            toast.failure(
+        // to second-person for UI. `.exhaustive()` fails the build if the code union
+        // grows a new variant without a toast case.
+        const message = match(result.code)
+          .with('USER_IN_TEAM', () => 'Contact your team owner to update.')
+          .with(
+            'UPDATE_IN_PROGRESS',
+            () =>
               'Another subscription update is already in progress. Please try again in a moment.'
-            );
-            break;
-          case 'NO_SUBSCRIPTION':
-            toast.failure("You don't have an active subscription to update.");
-            break;
-          case 'TIER_UNCHANGED':
-            toast.failure('Subscription is already on the requested tier.');
-            break;
-          case 'UNKNOWN':
-            toast.failure('Failed to update subscription.');
-            break;
-        }
+          )
+          .with(
+            'NO_SUBSCRIPTION',
+            () => "You don't have an active subscription to update."
+          )
+          .with(
+            'TIER_UNCHANGED',
+            () => 'Subscription is already on the requested tier.'
+          )
+          .with('UNKNOWN', () => 'Failed to update subscription.')
+          .exhaustive();
+        toast.failure(message);
         return;
       }
       analytics.track('subscription_tier_updated', { from: prev, to: next });
@@ -161,7 +158,7 @@ const PaywallComponent = (props: PaywallComponent) => {
           <For each={PLANS}>
             {(plan) => (
               <button
-                onClick={() => setSelectedTier(plan.tier)}
+                onClick={() => setUserSelectedTier(plan.tier)}
                 class="p-4 sm:p-5 border flex flex-col transition-all relative text-left"
                 classList={{
                   'border-accent ring-1 ring-accent bg-active':

--- a/js/app/packages/app/component/paywall/PaywallComponent.tsx
+++ b/js/app/packages/app/component/paywall/PaywallComponent.tsx
@@ -2,7 +2,6 @@ import { useHasPaidAccess } from '@core/auth';
 import { toast } from '@core/component/Toast/Toast';
 import { type PaywallKey, PaywallMessages } from '@core/constant/PaywallState';
 import { usePermissions } from '@core/context/user';
-import { isOk } from '@core/util/maybeResult';
 import IconX from '@icon/regular/x.svg';
 import { invalidateUserInfo } from '@queries/auth/user-info';
 import { stripeServiceClient } from '@service-stripe/client';
@@ -37,11 +36,17 @@ const PaywallComponent = (props: PaywallComponent) => {
   });
 
   const [selectedTier, setSelectedTier] = createSignal<PlanTier>('sonnet');
-  // Once the user's current tier is known (permissions load async), highlight it so
-  // the UI opens on the card they're actually on.
+  // Seed `selectedTier` from `currentTier` once, the first time permissions resolve.
+  // Re-syncing on every `currentTier` change would clobber the user's active selection
+  // if permissions later refetch (post-update invalidation, multi-tab, etc.).
+  let seededFromCurrentTier = false;
   createEffect(() => {
+    if (seededFromCurrentTier) return;
     const tier = currentTier();
-    if (tier) setSelectedTier(tier);
+    if (tier) {
+      setSelectedTier(tier);
+      seededFromCurrentTier = true;
+    }
   });
 
   const [updating, setUpdating] = createSignal(false);
@@ -89,15 +94,13 @@ const PaywallComponent = (props: PaywallComponent) => {
     setUpdating(true);
     try {
       const result = await stripeServiceClient.updateSubscriptionTier(next);
-      if (!isOk(result)) {
+      if (!result.ok) {
         // Messages mirror the backend's StripeOperationError `Display` impls, adapted
-        // to second-person for UI. Switch on the semantic code, not the body text.
-        const code = result[0]?.[0]?.code;
-        switch (code) {
+        // to second-person for UI. Switch on `result.code` — TS enforces exhaustiveness
+        // against `PatchSubscriptionTierErrorCode | 'UNKNOWN'`.
+        switch (result.code) {
           case 'USER_IN_TEAM':
-            toast.failure(
-              "Contact your team owner to update."
-            );
+            toast.failure('Contact your team owner to update.');
             break;
           case 'UPDATE_IN_PROGRESS':
             toast.failure(
@@ -110,8 +113,9 @@ const PaywallComponent = (props: PaywallComponent) => {
           case 'TIER_UNCHANGED':
             toast.failure('Subscription is already on the requested tier.');
             break;
-          default:
+          case 'UNKNOWN':
             toast.failure('Failed to update subscription.');
+            break;
         }
         return;
       }

--- a/js/app/packages/app/component/paywall/PaywallComponent.tsx
+++ b/js/app/packages/app/component/paywall/PaywallComponent.tsx
@@ -1,8 +1,12 @@
 import { useHasPaidAccess } from '@core/auth';
+import { toast } from '@core/component/Toast/Toast';
 import { type PaywallKey, PaywallMessages } from '@core/constant/PaywallState';
+import { usePermissions } from '@core/context/user';
+import { isOk } from '@core/util/maybeResult';
 import IconX from '@icon/regular/x.svg';
+import { invalidateUserInfo } from '@queries/auth/user-info';
 import { stripeServiceClient } from '@service-stripe/client';
-import { createSignal, For, Show } from 'solid-js';
+import { createEffect, createMemo, createSignal, For, Show } from 'solid-js';
 import { useAnalytics } from '@app/component/analytics-context';
 import { PLANS, type PlanTier } from './plans';
 
@@ -17,9 +21,30 @@ interface PaywallComponent {
 
 const PaywallComponent = (props: PaywallComponent) => {
   const analytics = useAnalytics();
+  const permissions = usePermissions();
+  const hasPaid = useHasPaidAccess();
+
+  // Tier a paying user is currently subscribed to, derived from RBAC permissions
+  // (sub_opus grants write:opus; sub_sonnet grants write:sonnet + write:haiku;
+  // sub_haiku grants write:haiku — so check highest-to-lowest).
+  const currentTier = createMemo((): PlanTier | undefined => {
+    if (!hasPaid()) return undefined;
+    const perms = permissions();
+    if (perms.includes('write:opus')) return 'opus';
+    if (perms.includes('write:sonnet')) return 'sonnet';
+    if (perms.includes('write:haiku')) return 'haiku';
+    return undefined;
+  });
 
   const [selectedTier, setSelectedTier] = createSignal<PlanTier>('sonnet');
-  const hasPaid = useHasPaidAccess();
+  // Once the user's current tier is known (permissions load async), highlight it so
+  // the UI opens on the card they're actually on.
+  createEffect(() => {
+    const tier = currentTier();
+    if (tier) setSelectedTier(tier);
+  });
+
+  const [updating, setUpdating] = createSignal(false);
 
   const handleCheckout = async (tier: PlanTier) => {
     try {
@@ -57,6 +82,49 @@ const PaywallComponent = (props: PaywallComponent) => {
     handleCheckout(selectedTier());
   };
 
+  const handleUpdateTier = async () => {
+    const next = selectedTier();
+    const prev = currentTier();
+    if (!prev || next === prev) return;
+    setUpdating(true);
+    try {
+      const result = await stripeServiceClient.updateSubscriptionTier(next);
+      if (!isOk(result)) {
+        // Messages mirror the backend's StripeOperationError `Display` impls, adapted
+        // to second-person for UI. Switch on the semantic code, not the body text.
+        const code = result[0]?.[0]?.code;
+        switch (code) {
+          case 'USER_IN_TEAM':
+            toast.failure(
+              "Contact your team owner to update."
+            );
+            break;
+          case 'UPDATE_IN_PROGRESS':
+            toast.failure(
+              'Another subscription update is already in progress. Please try again in a moment.'
+            );
+            break;
+          case 'NO_SUBSCRIPTION':
+            toast.failure("You don't have an active subscription to update.");
+            break;
+          case 'TIER_UNCHANGED':
+            toast.failure('Subscription is already on the requested tier.');
+            break;
+          default:
+            toast.failure('Failed to update subscription.');
+        }
+        return;
+      }
+      analytics.track('subscription_tier_updated', { from: prev, to: next });
+      // Refetches permissions so `currentTier` reflects the new tier and this button
+      // auto-hides (selectedTier === currentTier).
+      await invalidateUserInfo();
+      toast.success('Subscription updated!');
+    } finally {
+      setUpdating(false);
+    }
+  };
+
   return (
     <div class="space-y-6 sm:space-y-8 w-full">
       <div class="relative w-full text-center">
@@ -89,7 +157,6 @@ const PaywallComponent = (props: PaywallComponent) => {
           <For each={PLANS}>
             {(plan) => (
               <button
-                inert={hasPaid()}
                 onClick={() => setSelectedTier(plan.tier)}
                 class="p-4 sm:p-5 border flex flex-col transition-all relative text-left"
                 classList={{
@@ -129,18 +196,31 @@ const PaywallComponent = (props: PaywallComponent) => {
       </div>
 
       <div class="mx-auto mt-8 max-w-2xl text-center">
-        <button
-          onClick={handleContinue}
-          class={`w-full px-4 py-2 sm:px-6 sm:py-3 font-medium transition-none hover:transition text-sm sm:text-base border border-transparent ${
-            hasPaid()
-              ? 'bg-active text-ink border-edge hover:bg-hover hover:border-edge'
-              : 'bg-accent text-page hover:bg-accent-ink'
-          }`}
+        <Show
+          when={hasPaid() && currentTier() && selectedTier() !== currentTier()}
+          fallback={
+            <button
+              onClick={handleContinue}
+              class={`w-full px-4 py-2 sm:px-6 sm:py-3 font-medium transition-none hover:transition text-sm sm:text-base border border-transparent ${
+                hasPaid()
+                  ? 'bg-active text-ink border-edge hover:bg-hover hover:border-edge'
+                  : 'bg-accent text-page hover:bg-accent-ink'
+              }`}
+            >
+              <Show when={!hasPaid()} fallback={'Manage Subscription'}>
+                Get {PLANS.find((p) => p.tier === selectedTier())?.name}
+              </Show>
+            </button>
+          }
         >
-          <Show when={!hasPaid()} fallback={'Manage Subscription'}>
-            Get {PLANS.find((p) => p.tier === selectedTier())?.name}
-          </Show>
-        </button>
+          <button
+            onClick={handleUpdateTier}
+            disabled={updating()}
+            class="w-full px-4 py-2 sm:px-6 sm:py-3 font-medium transition-none hover:transition text-sm sm:text-base border border-transparent bg-accent text-page hover:bg-accent-ink disabled:opacity-60"
+          >
+            {updating() ? 'Updating…' : 'Update Subscription'}
+          </button>
+        </Show>
         <Show when={!hasPaid() && props.handleGuest}>
           <button
             onClick={() => props.handleGuest?.()}

--- a/js/app/packages/service-clients/service-auth/client.ts
+++ b/js/app/packages/service-clients/service-auth/client.ts
@@ -16,6 +16,7 @@ import { createSignal } from 'solid-js';
 import { fetchWithAuth as _fetchWithAuth } from './fetch';
 import type {
   InitGithubLinkResponse,
+  PatchSubscriptionTierRequest,
   PatchUserTutorialRequest,
   SendMobileWelcomeEmailResponse,
   UserQuota,
@@ -127,6 +128,12 @@ export async function getAccessToken(): Promise<string | null> {
 }
 
 export type { GetLegacyUserPermissionsResponse, UserOrganizationResponse };
+
+export type PatchSubscriptionTierErrorCode =
+  | 'TIER_UNCHANGED'
+  | 'USER_IN_TEAM'
+  | 'NO_SUBSCRIPTION'
+  | 'UPDATE_IN_PROGRESS';
 
 export const authServiceClient = {
   async logout() {
@@ -453,6 +460,56 @@ export const authServiceClient = {
         }),
       }),
       (result) => result.url
+    );
+  },
+
+  /**
+   * Patches the current user's subscription tier. Backend swaps both the RBAC role and
+   * Stripe subscription line item; caller should invalidate user info afterwards so the
+   * new permissions are picked up.
+   *
+   * Maps each distinct backend failure (distinguished by HTTP status) to a semantic code
+   * the UI can switch on. Uses `_fetchWithAuth` directly so the `CustomErrorCode` generic
+   * survives the module-level `fetchWithAuth` cast.
+   */
+  async patchSubscriptionTier(args: PatchSubscriptionTierRequest) {
+    return _fetchWithAuth<{}, PatchSubscriptionTierErrorCode>(
+      `${authHost}/user/stripe/subscription`,
+      {
+        method: 'PATCH',
+        body: JSON.stringify(args),
+        errorResponseHandler: async (response) => {
+          switch (response.status) {
+            case 400:
+              return {
+                code: 'TIER_UNCHANGED',
+                message: 'Subscription is already on the requested tier',
+              };
+            case 403:
+              return {
+                code: 'USER_IN_TEAM',
+                message:
+                  'User is a member of a team; tier is managed by the team owner',
+              };
+            case 404:
+              return {
+                code: 'NO_SUBSCRIPTION',
+                message: 'User does not have an active subscription',
+              };
+            case 409:
+              return {
+                code: 'UPDATE_IN_PROGRESS',
+                message:
+                  'Another subscription update is already in progress for this user',
+              };
+            default:
+              return {
+                code: 'HTTP_ERROR',
+                message: `HTTP error! status: ${response.status}`,
+              };
+          }
+        },
+      }
     );
   },
 

--- a/js/app/packages/service-clients/service-auth/client.ts
+++ b/js/app/packages/service-clients/service-auth/client.ts
@@ -479,12 +479,16 @@ export const authServiceClient = {
         method: 'PATCH',
         body: JSON.stringify(args),
         errorResponseHandler: async (response) => {
+          // Custom handler fully replaces fetchWithAuth's default mapping, so preserve
+          // the base cases we still want (401/500) alongside our endpoint-specific codes.
           switch (response.status) {
             case 400:
               return {
                 code: 'TIER_UNCHANGED',
                 message: 'Subscription is already on the requested tier',
               };
+            case 401:
+              return { code: 'UNAUTHORIZED', message: 'Unauthorized access' };
             case 403:
               return {
                 code: 'USER_IN_TEAM',
@@ -501,6 +505,11 @@ export const authServiceClient = {
                 code: 'UPDATE_IN_PROGRESS',
                 message:
                   'Another subscription update is already in progress for this user',
+              };
+            case 500:
+              return {
+                code: 'SERVER_ERROR',
+                message: 'Internal server error',
               };
             default:
               return {

--- a/js/app/packages/service-clients/service-stripe/client.ts
+++ b/js/app/packages/service-clients/service-stripe/client.ts
@@ -5,6 +5,7 @@ import {
   type PatchSubscriptionTierErrorCode,
 } from '@service-auth/client';
 import type { StripeProductTier } from '@service-auth/generated/schemas/stripeProductTier';
+import { match, P } from 'ts-pattern';
 
 /**
  * Gets Meta _fbp (browser ID) and _fbc (click ID) values from cookies set by the Meta Pixel.
@@ -100,16 +101,22 @@ export const stripeServiceClient = {
       newTier: tier,
     });
     if (isOk(result)) return { ok: true };
-    const code = result[0]?.code;
-    switch (code) {
-      case 'TIER_UNCHANGED':
-      case 'USER_IN_TEAM':
-      case 'NO_SUBSCRIPTION':
-      case 'UPDATE_IN_PROGRESS':
-        return { ok: false, code };
-      default:
-        return { ok: false, code: 'UNKNOWN' };
-    }
+    // Narrow the first error's code to our known union; anything else (NETWORK_ERROR,
+    // UNAUTHORIZED, SERVER_ERROR, etc.) collapses to 'UNKNOWN'. `match` + the explicit
+    // P.union of `PatchSubscriptionTierErrorCode` members means adding a new backend
+    // code without widening this union is a compile error.
+    const code = match(result[0]?.code)
+      .with(
+        P.union(
+          'TIER_UNCHANGED',
+          'USER_IN_TEAM',
+          'NO_SUBSCRIPTION',
+          'UPDATE_IN_PROGRESS'
+        ),
+        (c) => c
+      )
+      .otherwise(() => 'UNKNOWN' as const);
+    return { ok: false, code };
   },
 };
 

--- a/js/app/packages/service-clients/service-stripe/client.ts
+++ b/js/app/packages/service-clients/service-stripe/client.ts
@@ -1,6 +1,9 @@
 import { isOk } from '@core/util/maybeResult';
 import { registerClient } from '@core/util/mockClient';
-import { authServiceClient } from '@service-auth/client';
+import {
+  authServiceClient,
+  type PatchSubscriptionTierErrorCode,
+} from '@service-auth/client';
 import type { StripeProductTier } from '@service-auth/generated/schemas/stripeProductTier';
 
 /**
@@ -85,13 +88,33 @@ export const stripeServiceClient = {
     return result[1];
   },
   /**
-   * Changes the current user's subscription tier. Returns the raw MaybeResult so callers
-   * can switch on the error code (see `PatchSubscriptionTierErrorCode`) to pick a UX-
-   * appropriate toast. Callers should invalidate the user info query after success.
+   * Changes the current user's subscription tier. Returns a narrow discriminated union so
+   * callers get a type-checked error `code` without drilling into the MaybeResult tuple
+   * shape (`result[0]?.[0]?.code`), which would silently fall through to the default case
+   * if the shape ever changes. Callers should invalidate the user info query on success.
    */
-  updateSubscriptionTier: async (tier: StripeProductTier) => {
-    return authServiceClient.patchSubscriptionTier({ newTier: tier });
+  updateSubscriptionTier: async (
+    tier: StripeProductTier
+  ): Promise<UpdateSubscriptionTierResult> => {
+    const result = await authServiceClient.patchSubscriptionTier({
+      newTier: tier,
+    });
+    if (isOk(result)) return { ok: true };
+    const code = result[0]?.code;
+    switch (code) {
+      case 'TIER_UNCHANGED':
+      case 'USER_IN_TEAM':
+      case 'NO_SUBSCRIPTION':
+      case 'UPDATE_IN_PROGRESS':
+        return { ok: false, code };
+      default:
+        return { ok: false, code: 'UNKNOWN' };
+    }
   },
 };
+
+export type UpdateSubscriptionTierResult =
+  | { ok: true }
+  | { ok: false; code: PatchSubscriptionTierErrorCode | 'UNKNOWN' };
 
 registerClient('stripe', stripeServiceClient);

--- a/js/app/packages/service-clients/service-stripe/client.ts
+++ b/js/app/packages/service-clients/service-stripe/client.ts
@@ -1,6 +1,7 @@
 import { isOk } from '@core/util/maybeResult';
 import { registerClient } from '@core/util/mockClient';
 import { authServiceClient } from '@service-auth/client';
+import type { StripeProductTier } from '@service-auth/generated/schemas/stripeProductTier';
 
 /**
  * Gets Meta _fbp (browser ID) and _fbc (click ID) values from cookies set by the Meta Pixel.
@@ -82,6 +83,14 @@ export const stripeServiceClient = {
     }
 
     return result[1];
+  },
+  /**
+   * Changes the current user's subscription tier. Returns the raw MaybeResult so callers
+   * can switch on the error code (see `PatchSubscriptionTierErrorCode`) to pick a UX-
+   * appropriate toast. Callers should invalidate the user info query after success.
+   */
+  updateSubscriptionTier: async (tier: StripeProductTier) => {
+    return authServiceClient.patchSubscriptionTier({ newTier: tier });
   },
 };
 


### PR DESCRIPTION
## Summary

Wires the new `PATCH /user/stripe/subscription` endpoint into the Settings → Subscription tab so paying users can change tier without leaving the app.

## Changes

### UI (`PaywallComponent.tsx`)

- Paying users can now click between tier cards (the `inert` guard is removed).
- `selectedTier` is seeded from the user's current tier on first permission load, then left alone — subsequent permission refetches (post-update invalidation, multi-tab) won't clobber the user's in-progress selection.
- When the selected tier differs from the current tier, the "Manage Subscription" button is replaced by an accent-styled "Update Subscription" button. Clicking it calls the new endpoint, invalidates `userInfo` so `currentTier` refreshes, and shows a success toast.
- Fires a `subscription_tier_updated` analytics event on success with `{ from, to }`.

### Error handling (Pattern B)

`authServiceClient.patchSubscriptionTier` declares a `PatchSubscriptionTierErrorCode` union mapping HTTP status → semantic code:
- `400 → TIER_UNCHANGED`
- `403 → USER_IN_TEAM`
- `404 → NO_SUBSCRIPTION`
- `409 → UPDATE_IN_PROGRESS`

`stripeServiceClient.updateSubscriptionTier` returns a narrow discriminated union (`{ ok: true } | { ok: false; code: ... | 'UNKNOWN' }`), so the caller switches on a typed code instead of reaching into `result[0]?.[0]?.code`. TypeScript enforces exhaustiveness — a new backend code added later without a toast case fails at compile time.

Each case maps to a user-facing toast with wording derived from the backend `StripeOperationError::Display` impls (e.g. `USER_IN_TEAM` → "Contact your team owner to update.").
