### PR TITLE
fix: scope expand/collapse hotkey to active split

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/use-soup-navigation-hotkeys.ts
+++ b/js/app/packages/app/component/next-soup/soup-view/use-soup-navigation-hotkeys.ts
@@ -197,7 +197,11 @@ export const useSoupNavigationHotkeys = (
   const getCollapsibleToggle = () => {
     const focusedId = soup.focus.id();
     if (!focusedId) return undefined;
-    const entityEl = document.querySelector(`[data-entity-id="${focusedId}"]`);
+    const splitEl = document.querySelector(
+      `[data-split-id="${splitHandle.id}"]`
+    );
+    if (!splitEl) return undefined;
+    const entityEl = splitEl.querySelector(`[data-entity-id="${focusedId}"]`);
     if (!entityEl) return undefined;
     return entityEl.querySelector(
       'button[data-collapsible-toggle]'


### PR DESCRIPTION
## Summary
- The h/l expand/collapse hotkey in the soup view queried the DOM globally for `[data-entity-id]`, so when multiple splits were open it always matched the first split's toggle button regardless of which split's hotkey fired.
- Scope the lookup to the split that owns the hotkey via `[data-split-id="${splitHandle.id}"]`, then find the entity inside it.