### PR TITLE
chore(soup): bump persisted state version

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
@@ -173,7 +173,7 @@ type PersistedSoupViewState = {
   assigneeFilter: string[];
 };
 
-const PERSISTED_STATE_VERSION = 2;
+const PERSISTED_STATE_VERSION = 3;
 
 const listStateCache = new Map<
   string,


### PR DESCRIPTION
this is to override recipients exclude in the cached email filters with the updated email thread id exclude field