### PR TITLE
fix(email): use unique index on email_contacts upsert lookup

### DIFF
--- a/rust/cloud-storage/email_db_client/.sqlx/query-cea740c7d7764d20771d15ddd5cf047e9638cfa5d7e07d9885af0592142e5304.json
+++ b/rust/cloud-storage/email_db_client/.sqlx/query-cea740c7d7764d20771d15ddd5cf047e9638cfa5d7e07d9885af0592142e5304.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        SELECT id, LOWER(email_address) as \"email_address!\", name\n        FROM email_contacts\n        WHERE (link_id, LOWER(email_address)) IN (\n            SELECT * FROM UNNEST($1::uuid[], $2::varchar[])\n        )\n        ",
+  "query": "\n        SELECT id, email_address, name\n        FROM email_contacts\n        WHERE (link_id, email_address) IN (\n            SELECT * FROM UNNEST($1::uuid[], $2::varchar[])\n        )\n        ",
   "describe": {
     "columns": [
       {
@@ -10,8 +10,8 @@
       },
       {
         "ordinal": 1,
-        "name": "email_address!",
-        "type_info": "Text"
+        "name": "email_address",
+        "type_info": "Varchar"
       },
       {
         "ordinal": 2,
@@ -27,9 +27,9 @@
     },
     "nullable": [
       false,
-      null,
+      false,
       true
     ]
   },
-  "hash": "5202dbabd4943bf87bcaab8c34b9a5ebb7f76933011fe8607aff109ccf1705a0"
+  "hash": "cea740c7d7764d20771d15ddd5cf047e9638cfa5d7e07d9885af0592142e5304"
 }

--- a/rust/cloud-storage/email_db_client/src/contacts/upsert_sync.rs
+++ b/rust/cloud-storage/email_db_client/src/contacts/upsert_sync.rs
@@ -52,9 +52,9 @@ pub async fn upsert_contacts(
 
     let existing_contacts = sqlx::query!(
         r#"
-        SELECT id, LOWER(email_address) as "email_address!", name
+        SELECT id, email_address, name
         FROM email_contacts
-        WHERE (link_id, LOWER(email_address)) IN (
+        WHERE (link_id, email_address) IN (
             SELECT * FROM UNNEST($1::uuid[], $2::varchar[])
         )
         "#,


### PR DESCRIPTION
## Summary

The contact upsert existence lookup in `upsert_contacts` wrapped `email_address` in `LOWER()` on both sides of the predicate:

```sql
WHERE (link_id, LOWER(email_address)) IN (SELECT * FROM UNNEST($1::uuid[], $2::varchar[]))
```

This prevented Postgres from using the existing `contacts_link_id_email_address_idx` unique index and forced per-row `LOWER()` evaluation on the column side — a pure-CPU operation.

All three writers to `email_contacts` lowercase before insert:
- `email_db_client/src/contacts/upsert_sync.rs:41` — `email.to_lowercase()`
- `email_db_client/src/contacts/upsert_message.rs:33` — `addr.email_address.clone().to_lowercase()`
- `email/src/outbound/email_pg_repo/contact.rs:16,27` — `to_lowercase()` on `from` and recipients

So stored `email_address` is guaranteed lowercase and `LOWER()` on the column side is redundant. Dropping it lets the unique index do the work.

## Why

Performance Insights identified this query as the dominant contributor to a **93% CPU spike on `macro-db-prod` (2026-04-19 20:44 UTC)** — 2.56 of 2.72 AAS, 100% of waits in `CPU` category (no IO, no locks). Same query signature appeared in the recurring daily pattern.

The companion `INSERT ... ON CONFLICT (link_id, email_address)` already uses the raw column and benefits from the same index, so the SELECT and INSERT are now consistent.