### PR TITLE
chg(channels): improve distinction between keyboard selected + hover

### DIFF
--- a/js/app/packages/app/index.css
+++ b/js/app/packages/app/index.css
@@ -724,15 +724,15 @@ html[data-modality="keyboard"] .suppress-css-brackets .allow-css-brackets *:focu
   pointer-events: none;
 }
 
-/* Channel message highlight: hover only in mouse nav, keyboard selection only in keyboard nav */
+/* Channel message hover + non-selection highlight */
 /* Suppressed on touch devices */
-html:not([data-touch-device="true"]) [data-channel-nav="mouse"] [data-message]:hover,
-html:not([data-touch-device="true"]) [data-channel-nav="keyboard"] [data-message][data-highlighted] {
+html:not([data-touch-device="true"]) [data-message]:hover,
+html:not([data-touch-device="true"]) [data-message][data-highlighted] {
     @apply bg-accent/5 outline-1 outline-accent/20 outline-offset-[-1px];
 }
 
-html:not([data-touch-device="true"]) [data-channel-nav="mouse"] [data-message]:hover > .message-accent-bar,
-html:not([data-touch-device="true"]) [data-channel-nav="keyboard"] [data-message][data-highlighted] > .message-accent-bar {
+/* Keyboard selection accent bar can coexist with hover styles */
+[data-message][data-selected] > .message-accent-bar {
     @apply opacity-100;
 }
 

--- a/js/app/packages/channel/Channel/Channel.tsx
+++ b/js/app/packages/channel/Channel/Channel.tsx
@@ -72,7 +72,6 @@ import {
   useAddReactionMutation,
   useRemoveReactionMutation,
 } from '@queries/channel/reaction';
-import { resetKeyboardModality } from './util';
 import { DebugSuspense } from '@channel/DebugSuspense';
 import { MaybeMessageActionDrawerManager } from '@channel/Mobile/MessageActionDrawerManager';
 import { useChannelParticipants } from '@channel/use-channel-participants';
@@ -252,6 +251,14 @@ export function Channel(props: ChannelProps) {
     keys: () => messageIndex.keys,
   });
 
+  const selectMessage = (messageId: string) => {
+    selection.select(messageId);
+  };
+
+  const clearSelection = () => {
+    selection.clear();
+  };
+
   const { messageListScopeId, attachMessageListRef, attachInputRef } =
     createChannelHotkeys({
       selection,
@@ -304,8 +311,7 @@ export function Channel(props: ChannelProps) {
   };
 
   const goToMessage: ChannelHandle['goToMessage'] = (messageId, replyId) => {
-    const el = messageListElement();
-    if (el) resetKeyboardModality(el);
+    selectMessage(messageId);
     targetMessageController.goToMessage(messageId, replyId);
   };
 
@@ -331,13 +337,6 @@ export function Channel(props: ChannelProps) {
               }}
               tabIndex={-1}
               data-channel-message-list
-              data-channel-nav="keyboard"
-              onMouseMove={(e) => {
-                const el = e.currentTarget;
-                if (el.dataset.channelNav !== 'mouse') {
-                  el.dataset.channelNav = 'mouse';
-                }
-              }}
             >
               <Show when={messages().length > 0}>
                 <ThreadList
@@ -365,17 +364,12 @@ export function Channel(props: ChannelProps) {
                             isNewestThread={isNewestThread()}
                             getMessageActions={getMessageActions}
                             targetReplyId={targetMessageController.pendingTargetReplyId()}
-                            highlightedReplyId={targetMessageController.activeTargetMessageReplyId()}
                             onTargetReplyScrolled={(replyId) => {
                               targetMessageController.completePendingReplyScroll(
                                 m().id,
                                 replyId
                               );
                             }}
-                            highlighted={
-                              m().id ===
-                              targetMessageController.highlightedMessageId()
-                            }
                             isExpanded={state.isExpanded}
                             setIsExpanded={state.setIsExpanded}
                             isReplying={state.isReplying}
@@ -391,6 +385,8 @@ export function Channel(props: ChannelProps) {
                             }}
                             isNewMessage={activityTracker.isNewMessage}
                             selectedMessageId={selection.selectedId}
+                            onSelectMessage={selectMessage}
+                            onClearSelection={clearSelection}
                             messageListScopeId={messageListScopeId}
                           />
                         )}

--- a/js/app/packages/channel/Channel/create-channel-hotkeys.ts
+++ b/js/app/packages/channel/Channel/create-channel-hotkeys.ts
@@ -1,7 +1,6 @@
 import { registerHotkey, useHotkeyDOMScope } from '@core/hotkey/hotkeys';
 import { TOKENS } from '@core/hotkey/tokens';
 import type { Accessor } from 'solid-js';
-import { useSubscribeToKeypress } from '@app/signal/hotkeyRoot';
 import type { ThreadListNavigation } from './ThreadList';
 import type { MessageSelection } from './create-message-selection';
 import type { ApiChannelMessage } from '@service-comms/client';
@@ -38,12 +37,6 @@ export function createChannelHotkeys(options: CreateChannelHotkeysOptions) {
 
   let messageListEl: HTMLElement | undefined;
   let inputEl: HTMLElement | undefined;
-
-  useSubscribeToKeypress(() => {
-    if (messageListEl && messageListEl.dataset.channelNav !== 'keyboard') {
-      messageListEl.dataset.channelNav = 'keyboard';
-    }
-  });
 
   const hasSelection = () => !!options.selection.selectedId();
   const canRunSelectionActionHotkeys = () =>

--- a/js/app/packages/channel/Channel/create-target-message-controller.ts
+++ b/js/app/packages/channel/Channel/create-target-message-controller.ts
@@ -31,7 +31,6 @@ export type TargetMessageController = ReturnType<
 type TargetMessageData = {
   activeTargetMessageId: string | undefined;
   activeTargetMessageReplyId: string | undefined;
-  highlightedMessageId: string | undefined;
   loadAroundMessageId: string | undefined;
   pendingScrollTargetId: string | undefined;
   pendingTargetReplyId: string | undefined;
@@ -43,8 +42,6 @@ export function createTargetMessageController(
   const initialTargetMessageData: TargetMessageData = {
     activeTargetMessageId: options.initialTargetMessageId,
     activeTargetMessageReplyId: options.initialTargetMessageReplyId,
-    highlightedMessageId:
-      options.initialTargetMessageReplyId ?? options.initialTargetMessageId,
     loadAroundMessageId: options.initialTargetMessageId,
     pendingScrollTargetId: options.initialTargetMessageId,
     pendingTargetReplyId: options.initialTargetMessageReplyId,
@@ -68,7 +65,6 @@ export function createTargetMessageController(
     setTargetMessageData({
       activeTargetMessageId: messageId,
       activeTargetMessageReplyId: replyId,
-      highlightedMessageId: replyId ?? messageId,
       loadAroundMessageId: hasMessageLoaded(messageId) ? undefined : messageId,
       pendingScrollTargetId: messageId,
       pendingTargetReplyId: replyId,
@@ -125,7 +121,6 @@ export function createTargetMessageController(
     activeTargetMessageId: () => targetMessageData['activeTargetMessageId'],
     activeTargetMessageReplyId: () =>
       targetMessageData['activeTargetMessageReplyId'],
-    highlightedMessageId: () => targetMessageData['highlightedMessageId'],
     loadAroundMessageId: () => targetMessageData['loadAroundMessageId'],
     pendingScrollTargetId: () => targetMessageData['pendingScrollTargetId'],
     pendingTargetReplyId: () => targetMessageData['pendingTargetReplyId'],

--- a/js/app/packages/channel/Channel/tests/create-target-message-controller.test.ts
+++ b/js/app/packages/channel/Channel/tests/create-target-message-controller.test.ts
@@ -75,7 +75,6 @@ describe('createTargetMessageController', () => {
       controller.goToMessage('message-2');
 
       expect(controller.activeTargetMessageId()).toBe('message-2');
-      expect(controller.highlightedMessageId()).toBe('message-2');
       expect(controller.pendingScrollTargetId()).toBe('message-2');
       expect(controller.loadAroundMessageId()).toBeUndefined();
       dispose();
@@ -91,7 +90,6 @@ describe('createTargetMessageController', () => {
       controller.goToMessage('message-9');
 
       expect(controller.activeTargetMessageId()).toBe('message-9');
-      expect(controller.highlightedMessageId()).toBe('message-9');
       expect(controller.pendingScrollTargetId()).toBe('message-9');
       expect(controller.loadAroundMessageId()).toBe('message-9');
       dispose();

--- a/js/app/packages/channel/Channel/util.ts
+++ b/js/app/packages/channel/Channel/util.ts
@@ -41,4 +41,3 @@ export function isNewMessage(
     ctx.userId !== message.sender_id
   );
 }
-

--- a/js/app/packages/channel/Channel/util.ts
+++ b/js/app/packages/channel/Channel/util.ts
@@ -42,8 +42,3 @@ export function isNewMessage(
   );
 }
 
-export function resetKeyboardModality(listElement: HTMLElement) {
-  if (listElement && listElement.dataset.channelNav !== 'keyboard') {
-    listElement.dataset.channelNav = 'keyboard';
-  }
-}

--- a/js/app/packages/channel/Message/ChannelMessage.tsx
+++ b/js/app/packages/channel/Message/ChannelMessage.tsx
@@ -1,4 +1,4 @@
-import { Match, Show, Switch } from 'solid-js';
+import { Match, Show, Switch, type JSX } from 'solid-js';
 import { cn } from '@ui/utils/classname';
 import type { MessageActions, MessageData } from './types';
 import { Message } from './Message';
@@ -19,6 +19,7 @@ type ChannelMessageProps = {
   messageEditor?: MessageEditor;
   highlighted?: boolean;
   selectionState?: MessageSelectionState;
+  onClick?: JSX.EventHandlerUnion<HTMLDivElement, MouseEvent>;
 };
 
 function isEditingMessage(
@@ -167,6 +168,8 @@ export function ChannelMessage(props: ChannelMessageProps) {
       message={props.message}
       actions={props.actions}
       highlighted={props.highlighted}
+      selected={props.selectionState?.isSelected}
+      onClick={props.onClick}
       ref={(el) =>
         longPressHighlight(el, () => ({
           onLongPress: () => drawerManager?.open(props.message, props.actions),

--- a/js/app/packages/channel/Message/Root.tsx
+++ b/js/app/packages/channel/Message/Root.tsx
@@ -7,6 +7,7 @@ type RootProps = JSX.HTMLAttributes<HTMLDivElement> & {
   message: MessageData;
   actions?: MessageActions;
   highlighted?: boolean;
+  selected?: boolean;
 };
 
 export function Root(props: RootProps) {
@@ -16,6 +17,7 @@ export function Root(props: RootProps) {
     'message',
     'actions',
     'highlighted',
+    'selected',
   ]);
 
   return (
@@ -24,9 +26,10 @@ export function Root(props: RootProps) {
       data-message
       data-message-id={local.message.id}
       data-highlighted={local.highlighted ? '' : undefined}
+      data-selected={local.selected ? '' : undefined}
       {...rest}
     >
-      <div class="absolute h-full w-[3px] left-0 top-0 bg-accent opacity-0 message-accent-bar" />
+      <div class="absolute h-full w-1 left-0 top-0 bg-accent opacity-0 message-accent-bar" />
       <MessageProvider value={() => local.message}>
         <MessageActionsProvider value={local.actions}>
           {props.children}

--- a/js/app/packages/channel/Thread/ChannelThread.tsx
+++ b/js/app/packages/channel/Thread/ChannelThread.tsx
@@ -74,6 +74,26 @@ export function ChannelThread(props: ThreadProps) {
   });
 
   const isThreadFocused = () => isSelected() && !!replySelection.selectedId();
+  const selectThreadMessage = () => {
+    if (isSelected() && !isThreadFocused()) {
+      props.onClearSelection?.();
+      return;
+    }
+
+    props.onSelectMessage?.(props.data().id);
+    replySelection.clear();
+  };
+
+  const selectReply = (replyId: string) => {
+    if (isSelected() && replySelection.selectedId() === replyId) {
+      replySelection.clear();
+      props.onClearSelection?.();
+      return;
+    }
+
+    props.onSelectMessage?.(props.data().id);
+    replySelection.select(replyId);
+  };
 
   let replyInputContainerRef: HTMLDivElement | undefined;
 
@@ -148,6 +168,8 @@ export function ChannelThread(props: ThreadProps) {
         );
         if (targetReplyIndex === -1) return;
 
+        replySelection.select(targetReplyId);
+
         if (!isExpanded) {
           const renderedTargetReplyIndex = renderedReplies.findIndex(
             (reply) => reply.id === targetReplyId
@@ -187,9 +209,8 @@ export function ChannelThread(props: ThreadProps) {
                 actions={props.getMessageActions?.(props.data())}
                 listMeta={props.listMeta}
                 messageEditor={props.messageEditor}
-                highlighted={
-                  props.highlighted || (isSelected() && !isThreadFocused())
-                }
+                onClick={selectThreadMessage}
+                highlighted={isSelected() && !isThreadFocused()}
                 selectionState={
                   isSelected() && !isThreadFocused()
                     ? { isSelected: true }
@@ -216,10 +237,10 @@ export function ChannelThread(props: ThreadProps) {
                       getMessageActions={props.getMessageActions}
                       messageEditor={props.messageEditor}
                       isNewMessage={props.isNewMessage}
-                      highlightedReplyId={props.highlightedReplyId}
                       onReady={setReplyListHandle}
                       selectedReplyId={replySelection.selectedId}
                       isThreadFocused={isThreadFocused}
+                      onSelectReply={selectReply}
                     />
                   </DebugSuspense>
 

--- a/js/app/packages/channel/Thread/ChannelThread.tsx
+++ b/js/app/packages/channel/Thread/ChannelThread.tsx
@@ -168,6 +168,7 @@ export function ChannelThread(props: ThreadProps) {
         );
         if (targetReplyIndex === -1) return;
 
+        props.onSelectMessage?.(props.data().id);
         replySelection.select(targetReplyId);
 
         if (!isExpanded) {

--- a/js/app/packages/channel/Thread/ThreadReplyList.tsx
+++ b/js/app/packages/channel/Thread/ThreadReplyList.tsx
@@ -30,10 +30,10 @@ export function ThreadReplyList(props: {
   getMessageActions?: (message: MessageData) => MessageActions | undefined;
   messageEditor?: MessageEditor;
   isNewMessage?: (message: NewMessageCheckable) => boolean;
-  highlightedReplyId?: string;
   onReady?: (handle: ThreadReplyListHandle) => void;
   selectedReplyId?: Accessor<string | undefined>;
   isThreadFocused?: Accessor<boolean>;
+  onSelectReply?: (replyId: string) => void;
 }) {
   const listMetaByReplyId = createMemo(() =>
     buildThreadReplyListMeta(props.replies, props.isNewMessage)
@@ -84,9 +84,8 @@ export function ThreadReplyList(props: {
                 actions={props.getMessageActions?.(replyMessage())}
                 listMeta={listMetaByReplyId()[reply.id]}
                 messageEditor={props.messageEditor}
-                highlighted={
-                  props.highlightedReplyId === reply.id || isReplySelected()
-                }
+                onClick={() => props.onSelectReply?.(reply.id)}
+                highlighted={isReplySelected()}
                 selectionState={
                   isReplySelected() ? { isSelected: true } : undefined
                 }

--- a/js/app/packages/channel/Thread/types.ts
+++ b/js/app/packages/channel/Thread/types.ts
@@ -37,11 +37,11 @@ export type ThreadProps = {
   threadActions?: ThreadActions;
   messageEditor?: MessageEditor;
   targetReplyId?: string;
-  highlightedReplyId?: string;
   onTargetReplyScrolled?: (replyId: string) => void;
   isNewMessage?: (reply: NewMessageCheckable) => boolean;
-  highlighted?: boolean;
   selectedMessageId?: Accessor<string | undefined>;
+  onSelectMessage?: (messageId: string) => void;
+  onClearSelection?: () => void;
   messageListScopeId?: string;
   isNewestThread?: boolean;
 } & ThreadState;


### PR DESCRIPTION
- stop using keyboard modality to show and hide keyboard selection vs hover state
- show both selected message and hover state simulatniously but distinguish visually
- use selected message for go to message instead of using seperate highlighted state
