### PR TITLE
feat[mobile]: swipe down to dismiss keyboard

### DIFF
--- a/js/app/packages/app/component/Layout.tsx
+++ b/js/app/packages/app/component/Layout.tsx
@@ -40,6 +40,7 @@ import {
 import { isMobile } from '@core/mobile/isMobile';
 import { MobileDock } from './mobile/MobileDock';
 import { MobileSearchOuter } from './mobile/MobileSearch';
+import { SwipeDownDismissKeyboard } from './mobile/SwipeDownDismissKeyboard';
 import { makePersisted } from '@solid-primitives/storage';
 import {
   SidebarVisibilityContext,
@@ -209,6 +210,7 @@ function LayoutInner(props: RouteSectionProps) {
       <Show when={isMobile()}>
         <MobileSearchOuter />
       </Show>
+      <SwipeDownDismissKeyboard />
       <Suspense>
         <Show
           when={isAuthenticated() && !AUTH_URLS.includes(location.pathname)}

--- a/js/app/packages/app/component/mobile/MobileDock.tsx
+++ b/js/app/packages/app/component/mobile/MobileDock.tsx
@@ -6,6 +6,7 @@ import { AnimatedEmailIcon } from '@macro-icons/wide/animating/email';
 import { AnimatedFileMdIcon } from '@macro-icons/wide/animating/fileMd';
 import { AnimatedTaskIcon } from '@macro-icons/wide/animating/task';
 import { hapticImpact } from '@core/mobile/haptics';
+import { focusInput } from '@core/directive/focusInput';
 import { type Component, createSignal, type JSX, Show } from 'solid-js';
 import { Dynamic } from 'solid-js/web';
 import { cn } from '@ui/utils/classname';
@@ -14,6 +15,8 @@ import type { ListView } from '@app/constants/list-views';
 import { globalSplitManager } from '@app/signal/splitLayout';
 import { SearchState } from './mobileSearchState';
 import { useLocation } from '@solidjs/router';
+
+false && focusInput;
 
 const ICON_ANIMATION_DURATION_MS = 500;
 
@@ -56,6 +59,37 @@ function MobileDockButton(props: MobileDockButtonProps) {
       <Show when={props.label}>
         <span class="text-xs">{props.label}</span>
       </Show>
+    </button>
+  );
+}
+
+function SearchDockButton(props: { active: boolean; onClick: () => void }) {
+  const [animating, setAnimating] = createSignal(false);
+
+  return (
+    <button
+      type="button"
+      use:focusInput={{
+        getTarget: () => document.getElementById('mobile-search-input'),
+      }}
+      // This needs to be onClick, rather than pointerDown like the other buttons, so that we can use onClick behavior of focusInput before the dialog overlay appears.
+      onClick={() => {
+        hapticImpact('light');
+        setAnimating(true);
+        setTimeout(() => setAnimating(false), ICON_ANIMATION_DURATION_MS);
+        props.onClick();
+      }}
+      class={cn(
+        'flex flex-col items-center justify-center flex-1 pt-3 pb-2 bg-panel border-t border-edge-muted',
+        props.active && 'text-accent'
+      )}
+    >
+      <div class="w-6 h-6 [&_svg]:size-6">
+        <Dynamic
+          component={AnimatedSearchIcon}
+          triggerAnimation={animating()}
+        />
+      </div>
     </button>
   );
 }
@@ -120,8 +154,7 @@ export function MobileDock() {
         active={isActive('agents')}
         onClick={() => navigate('agents')}
       />
-      <MobileDockButton
-        icon={AnimatedSearchIcon}
+      <SearchDockButton
         active={isActive('search')}
         onClick={() => {
           SearchState.maybeResetState();

--- a/js/app/packages/app/component/mobile/MobileSearch.tsx
+++ b/js/app/packages/app/component/mobile/MobileSearch.tsx
@@ -173,7 +173,7 @@ export function MobileSearchInner() {
           <ArrowLeft class="size-6" />
         </button>
         <input
-          ref={(el) => setTimeout(() => el.focus(), 50)} // setTimeout needed: iOS only allows focus() within the user gesture window
+          id="mobile-search-input"
           type="text"
           class="pt-3 pb-2 flex-1 bg-transparent border-0 outline-none focus:outline-none ring-0 focus:ring-0 text-ink-muted placeholder:text-ink-placeholder/50"
           placeholder={'Search...'}

--- a/js/app/packages/app/component/mobile/SwipeDownDismissKeyboard.tsx
+++ b/js/app/packages/app/component/mobile/SwipeDownDismissKeyboard.tsx
@@ -1,0 +1,61 @@
+import {
+  virtualKeyboardHeight,
+  virtualKeyboardVisible,
+} from '@core/mobile/virtualKeyboard';
+import { isPlatform } from '@core/util/platform';
+import { onCleanup, onMount, Show } from 'solid-js';
+
+const SWIPE_DOWN_THRESHOLD = 5; // px of downward movement to register as a swipe down
+const ZONE_HEIGHT = 20; // px above keyboard that activates blur
+
+export function SwipeDownDismissKeyboard() {
+  if (!isPlatform('ios')) return;
+
+  let startY = 0;
+
+  function handleTouchStart(e: TouchEvent) {
+    if (!virtualKeyboardVisible()) return;
+    const touch = e.touches[0];
+    if (!touch) return;
+    startY = touch.clientY;
+  }
+
+  function handleTouchMove(e: TouchEvent) {
+    if (!virtualKeyboardVisible()) return;
+    const touch = e.touches[0];
+    if (!touch) return;
+    const keyboardTop = window.innerHeight - virtualKeyboardHeight();
+    const inZone =
+      touch.clientY >= keyboardTop - ZONE_HEIGHT &&
+      touch.clientY <= keyboardTop;
+    const swipingDown = touch.clientY - startY > SWIPE_DOWN_THRESHOLD;
+    if (inZone && swipingDown) {
+      const active = document.activeElement as HTMLElement | null;
+      if (!active) return;
+      // If the active element is inside a dialog, focus the dialog root instead of
+      // blurring — Kobalte's focus trap would immediately re-focus the input after blur().
+      // Focusing a non-input element that's still inside the trap satisfies the trap
+      // while dismissing the iOS keyboard.
+      const dialog = active.closest('[role="dialog"]') as HTMLElement | null;
+      if (dialog) {
+        if (!dialog.hasAttribute('tabindex'))
+          dialog.setAttribute('tabindex', '-1');
+        dialog.focus();
+      } else {
+        active.blur();
+      }
+    }
+  }
+
+  onMount(() => {
+    window.addEventListener('touchmove', handleTouchMove);
+    window.addEventListener('touchstart', handleTouchStart);
+
+    onCleanup(() => {
+      window.removeEventListener('touchstart', handleTouchStart);
+      window.removeEventListener('touchmove', handleTouchMove);
+    });
+  });
+
+  return;
+}

--- a/js/app/packages/app/component/mobile/SwipeDownDismissKeyboard.tsx
+++ b/js/app/packages/app/component/mobile/SwipeDownDismissKeyboard.tsx
@@ -57,5 +57,5 @@ export function SwipeDownDismissKeyboard() {
     });
   });
 
-  return;
+  return null;
 }

--- a/js/app/packages/app/component/mobile/SwipeDownDismissKeyboard.tsx
+++ b/js/app/packages/app/component/mobile/SwipeDownDismissKeyboard.tsx
@@ -3,7 +3,7 @@ import {
   virtualKeyboardVisible,
 } from '@core/mobile/virtualKeyboard';
 import { isPlatform } from '@core/util/platform';
-import { onCleanup, onMount, Show } from 'solid-js';
+import { onCleanup, onMount } from 'solid-js';
 
 const SWIPE_DOWN_THRESHOLD = 5; // px of downward movement to register as a swipe down
 const ZONE_HEIGHT = 20; // px above keyboard that activates blur

--- a/js/app/packages/core/directive/focusInput.ts
+++ b/js/app/packages/core/directive/focusInput.ts
@@ -56,9 +56,11 @@ export function focusInput(
       window.removeEventListener('beforeunload', cleanup);
     }
 
-    function focusTargetAndCleanup() {
-      getTarget()?.focus();
-      cleanup();
+    function handleAppearance(target: HTMLElement) {
+      setTimeout(() => {
+        target.focus();
+        cleanup();
+      }, 0);
     }
 
     if ((isTouchDevice() && isIOS) || isPlatform('ios')) {
@@ -78,7 +80,7 @@ export function focusInput(
 
     observer = new MutationObserver(() => {
       const current = getTarget();
-      if (current && isVisible(current)) focusTargetAndCleanup();
+      if (current && isVisible(current)) handleAppearance(current);
     });
     observer.observe(document.body, { childList: true, subtree: true });
 
@@ -90,7 +92,10 @@ export function focusInput(
   onCleanup(() => el.removeEventListener('click', handleClick));
 }
 
-// Naively checks if element is visible. E.g. will not catch elements with `position: fixed`. We can make this more complex when needed.
 function isVisible(el: HTMLElement): boolean {
-  return el.offsetParent !== null;
+  // offsetParent is null for hidden elements, but also for position:fixed elements
+  // and their descendants — fall back to bounding rect in that case.
+  if (el.offsetParent !== null) return true;
+  const rect = el.getBoundingClientRect();
+  return rect.width > 0 || rect.height > 0;
 }


### PR DESCRIPTION
On mobile, when the user swipes down into the region immediately above the virtual keyboard, we dismiss the virtual keyboard.
