### PR TITLE
feat: undo mark-as-done + notification refetch cleanup

### DIFF
--- a/js/app/packages/app/component/Root.tsx
+++ b/js/app/packages/app/component/Root.tsx
@@ -37,6 +37,7 @@ import {
 import { prefetchHistory } from '@queries/history/history';
 import { invalidateUserNotifications } from '@queries/notification/user-notifications';
 import { QuerySyncProvider } from '@queries/sync/SyncProvider';
+import { MutationUndoProvider } from '@queries/undo';
 import { ws as connectionGatewayWebsocket } from '@service-connection/websocket';
 import { MetaProvider, Title } from '@solidjs/meta';
 import {
@@ -436,32 +437,34 @@ export function Root() {
                 <QuerySyncProviderWithUserId />
                 <UserInfoSideEffects />
                 <ConfiguredGlobalAppStateProvider>
-                  <ChannelsContextProvider>
-                    <QuickAccessProvider>
-                      <SearchProvider>
-                        <ChatAttachmentsInit />
-                        <ReactiveFavicon />
-                        <Title>{tabTitle()}</Title>
-                        <MacroJump />
-                        <Visor />
-                        <Suspense>
-                          <IsomorphicRouter
-                            transformUrl={transformShortIdInUrlPathname}
-                            root={Layout}
-                            rootPreload={rootPreload}
-                            base={ROUTER_BASE}
-                          >
-                            {{
-                              path: '/',
-                              component: TauriRouteListener,
-                              children: ROUTES,
-                            }}
-                          </IsomorphicRouter>
-                        </Suspense>
-                        <ToastRegion />
-                      </SearchProvider>
-                    </QuickAccessProvider>
-                  </ChannelsContextProvider>
+                  <MutationUndoProvider>
+                    <ChannelsContextProvider>
+                      <QuickAccessProvider>
+                        <SearchProvider>
+                          <ChatAttachmentsInit />
+                          <ReactiveFavicon />
+                          <Title>{tabTitle()}</Title>
+                          <MacroJump />
+                          <Visor />
+                          <Suspense>
+                            <IsomorphicRouter
+                              transformUrl={transformShortIdInUrlPathname}
+                              root={Layout}
+                              rootPreload={rootPreload}
+                              base={ROUTER_BASE}
+                            >
+                              {{
+                                path: '/',
+                                component: TauriRouteListener,
+                                children: ROUTES,
+                              }}
+                            </IsomorphicRouter>
+                          </Suspense>
+                          <ToastRegion />
+                        </SearchProvider>
+                      </QuickAccessProvider>
+                    </ChannelsContextProvider>
+                  </MutationUndoProvider>
                 </ConfiguredGlobalAppStateProvider>
               </UserContextProvider>
             </EntityProvider>

--- a/js/app/packages/app/component/next-soup/actions/make-mark-done-action.ts
+++ b/js/app/packages/app/component/next-soup/actions/make-mark-done-action.ts
@@ -6,7 +6,9 @@ import { useUndoableMutation } from '@queries/undo';
 import {
   type MarkDoneHandle,
   markEntitiesDone,
+  restoreSoupFocus,
 } from '@app/component/next-soup/utils';
+import { useMaybePreviewPanel } from '@app/component/PreviewPanel';
 import type { SoupState } from '../create-soup-state';
 
 type MakeMarkDoneOptions = {
@@ -23,6 +25,8 @@ type MarkDoneContext = {
 /** Must be invoked inside a component tree that provides MutationUndoProvider. */
 export const makeMarkDoneAction = (options: MakeMarkDoneOptions) => {
   const { notificationSource } = options;
+  const previewPanel = useMaybePreviewPanel();
+  const inPreview = previewPanel !== undefined;
 
   const mutation = useUndoableMutation<
     void,
@@ -51,6 +55,7 @@ export const makeMarkDoneAction = (options: MakeMarkDoneOptions) => {
     onSuccess: (_data, variables, context) => {
       const count = variables.entities.length;
       const handle = context?.handle;
+      const firstEntityId = variables.entities[0]?.id;
       const toastId = toast.success(
         count > 1 ? `Marked ${count} items as done` : 'Marked as done',
         undefined,
@@ -61,6 +66,7 @@ export const makeMarkDoneAction = (options: MakeMarkDoneOptions) => {
             onClick: () => {
               if (toastId != null) toast.dismiss(toastId);
               handle?.undo().catch(() => toast.failure('Failed to undo'));
+              restoreSoupFocus(firstEntityId, inPreview);
             },
           },
         ],

--- a/js/app/packages/app/component/next-soup/actions/make-mark-done-action.ts
+++ b/js/app/packages/app/component/next-soup/actions/make-mark-done-action.ts
@@ -2,6 +2,7 @@ import ArrowCounterClockwise from '@phosphor-icons/core/regular/arrow-counter-cl
 import { toast } from '@core/component/Toast/Toast';
 import { type EntityData, isTaskEntity } from '@entity';
 import type { NotificationSource } from '@notifications';
+import { useMutationUndoContext } from '@queries/undo';
 import type { SoupState } from '../create-soup-state';
 import { markEntitiesDone } from '@app/component/next-soup/utils';
 
@@ -12,6 +13,7 @@ type MakeMarkDoneOptions = {
 
 export const makeMarkDoneAction = (options: MakeMarkDoneOptions) => {
   const { notificationSource } = options;
+  const undoCtx = useMutationUndoContext();
 
   const canExecute = (entity: EntityData): boolean => {
     if (entity.type === 'channel_message') return false;
@@ -35,6 +37,8 @@ export const makeMarkDoneAction = (options: MakeMarkDoneOptions) => {
       notificationSource: notificationSource(),
     });
 
+    undoCtx.pushUndo({ undo: handle.undo, label: 'Mark Done' });
+
     const toastId = toast.success(
       entities.length > 1
         ? `Marked ${entities.length} items as done`
@@ -46,7 +50,9 @@ export const makeMarkDoneAction = (options: MakeMarkDoneOptions) => {
           icon: ArrowCounterClockwise,
           onClick: () => {
             if (toastId != null) toast.dismiss(toastId);
-            handle.undo().catch(() => toast.failure('Failed to undo'));
+            undoCtx.undo({
+              onError: () => toast.failure('Failed to undo'),
+            });
           },
         },
       ],

--- a/js/app/packages/app/component/next-soup/actions/make-mark-done-action.ts
+++ b/js/app/packages/app/component/next-soup/actions/make-mark-done-action.ts
@@ -70,7 +70,8 @@ export const makeMarkDoneAction = (options: MakeMarkDoneOptions) => {
             },
           },
         ],
-        10_000
+        10_000,
+        true
       );
       context?.setSuccessToastId(toastId);
     },

--- a/js/app/packages/app/component/next-soup/actions/make-mark-done-action.ts
+++ b/js/app/packages/app/component/next-soup/actions/make-mark-done-action.ts
@@ -17,14 +17,10 @@ type MakeMarkDoneOptions = {
 type MarkDoneVariables = { entities: EntityData[] };
 type MarkDoneContext = {
   handle: MarkDoneHandle;
-  /** Populated by onSuccess; `handle.done` failures use it to dismiss the stale success toast. */
   setSuccessToastId: (id: number | undefined) => void;
 };
 
-/**
- * Must be invoked inside a component tree that provides `MutationUndoProvider`
- * (via `useUndoableMutation`) and the notification source.
- */
+/** Must be invoked inside a component tree that provides MutationUndoProvider. */
 export const makeMarkDoneAction = (options: MakeMarkDoneOptions) => {
   const { notificationSource } = options;
 
@@ -34,11 +30,6 @@ export const makeMarkDoneAction = (options: MakeMarkDoneOptions) => {
     MarkDoneVariables,
     MarkDoneContext
   >(() => ({
-    // onMutate does the optimistic work and starts the API calls via the
-    // handle. mutationFn is a no-op so the mutation resolves immediately and
-    // onSuccess fires (pushing the undo entry) before the user can react.
-    // API failures surface via handle.done.catch below, which dismisses the
-    // stale success toast and shows a failure toast.
     mutationFn: async () => {},
     onMutate: async (variables) => {
       const handle = await markEntitiesDone({
@@ -69,8 +60,6 @@ export const makeMarkDoneAction = (options: MakeMarkDoneOptions) => {
             icon: ArrowCounterClockwise,
             onClick: () => {
               if (toastId != null) toast.dismiss(toastId);
-              // Invoke this action's own undo so older toasts don't pop
-              // newer entries off the global undo stack.
               handle?.undo().catch(() => toast.failure('Failed to undo'));
             },
           },

--- a/js/app/packages/app/component/next-soup/actions/make-mark-done-action.ts
+++ b/js/app/packages/app/component/next-soup/actions/make-mark-done-action.ts
@@ -1,11 +1,9 @@
+import ArrowCounterClockwise from '@phosphor-icons/core/regular/arrow-counter-clockwise.svg?component-solid';
 import { toast } from '@core/component/Toast/Toast';
 import { type EntityData, isTaskEntity } from '@entity';
-import {
-  markNotificationsForEntityAsDone,
-  type NotificationSource,
-} from '@notifications';
+import type { NotificationSource } from '@notifications';
 import type { SoupState } from '../create-soup-state';
-import { archiveEmail } from '@app/component/next-soup/utils';
+import { markEntitiesDone } from '@app/component/next-soup/utils';
 
 type MakeMarkDoneOptions = {
   userId?: () => string | undefined;
@@ -32,26 +30,35 @@ export const makeMarkDoneAction = (options: MakeMarkDoneOptions) => {
   };
 
   const execute = async (entities: EntityData[]) => {
-    const source = notificationSource();
+    const handle = markEntitiesDone({
+      entities,
+      notificationSource: notificationSource(),
+    });
 
-    await Promise.all(
-      entities.map(async (entity) => {
-        if (entity.type === 'email') {
-          await archiveEmail(entity.id, {
-            archive: true,
-            optimisticallyExclude: true,
-          });
-        }
-
-        markNotificationsForEntityAsDone(source, entity);
-      })
-    );
-
-    toast.success(
+    const toastId = toast.success(
       entities.length > 1
         ? `Marked ${entities.length} items as done`
-        : 'Marked as done'
+        : 'Marked as done',
+      undefined,
+      [
+        {
+          label: 'Undo',
+          icon: ArrowCounterClockwise,
+          onClick: () => {
+            if (toastId != null) toast.dismiss(toastId);
+            handle.undo().then(
+              () => toast.success('Undone'),
+              () => toast.failure('Failed to undo')
+            );
+          },
+        },
+      ],
+      10_000
     );
+
+    handle.done.catch(() => {
+      toast.failure('Failed to mark as done');
+    });
   };
 
   const executeWithSoup = async (

--- a/js/app/packages/app/component/next-soup/actions/make-mark-done-action.ts
+++ b/js/app/packages/app/component/next-soup/actions/make-mark-done-action.ts
@@ -74,6 +74,9 @@ export const makeMarkDoneAction = (options: MakeMarkDoneOptions) => {
       );
       context?.setSuccessToastId(toastId);
     },
+    onError: () => {
+      toast.failure('Failed to mark as done');
+    },
     undoFn: async (_variables, context) => {
       await context?.handle.undo();
     },

--- a/js/app/packages/app/component/next-soup/actions/make-mark-done-action.ts
+++ b/js/app/packages/app/component/next-soup/actions/make-mark-done-action.ts
@@ -2,7 +2,7 @@ import ArrowCounterClockwise from '@phosphor-icons/core/regular/arrow-counter-cl
 import { toast } from '@core/component/Toast/Toast';
 import { type EntityData, isTaskEntity } from '@entity';
 import type { NotificationSource } from '@notifications';
-import { useMutationUndoContext, useUndoableMutation } from '@queries/undo';
+import { useUndoableMutation } from '@queries/undo';
 import {
   type MarkDoneHandle,
   markEntitiesDone,
@@ -15,11 +15,18 @@ type MakeMarkDoneOptions = {
 };
 
 type MarkDoneVariables = { entities: EntityData[] };
-type MarkDoneContext = { handle: MarkDoneHandle };
+type MarkDoneContext = {
+  handle: MarkDoneHandle;
+  /** Populated by onSuccess; `handle.done` failures use it to dismiss the stale success toast. */
+  setSuccessToastId: (id: number | undefined) => void;
+};
 
+/**
+ * Must be invoked inside a component tree that provides `MutationUndoProvider`
+ * (via `useUndoableMutation`) and the notification source.
+ */
 export const makeMarkDoneAction = (options: MakeMarkDoneOptions) => {
   const { notificationSource } = options;
-  const undoCtx = useMutationUndoContext();
 
   const mutation = useUndoableMutation<
     void,
@@ -30,17 +37,29 @@ export const makeMarkDoneAction = (options: MakeMarkDoneOptions) => {
     // onMutate does the optimistic work and starts the API calls via the
     // handle. mutationFn is a no-op so the mutation resolves immediately and
     // onSuccess fires (pushing the undo entry) before the user can react.
+    // API failures surface via handle.done.catch below, which dismisses the
+    // stale success toast and shows a failure toast.
     mutationFn: async () => {},
-    onMutate: (variables) => {
-      const handle = markEntitiesDone({
+    onMutate: async (variables) => {
+      const handle = await markEntitiesDone({
         entities: variables.entities,
         notificationSource: notificationSource(),
       });
-      handle.done.catch(() => toast.failure('Failed to mark as done'));
-      return { handle };
+      let successToastId: number | undefined;
+      handle.done.catch(() => {
+        if (successToastId != null) toast.dismiss(successToastId);
+        toast.failure('Failed to mark as done');
+      });
+      return {
+        handle,
+        setSuccessToastId: (id) => {
+          successToastId = id;
+        },
+      };
     },
-    onSuccess: (_data, variables) => {
+    onSuccess: (_data, variables, context) => {
       const count = variables.entities.length;
+      const handle = context?.handle;
       const toastId = toast.success(
         count > 1 ? `Marked ${count} items as done` : 'Marked as done',
         undefined,
@@ -50,14 +69,15 @@ export const makeMarkDoneAction = (options: MakeMarkDoneOptions) => {
             icon: ArrowCounterClockwise,
             onClick: () => {
               if (toastId != null) toast.dismiss(toastId);
-              undoCtx.undo({
-                onError: () => toast.failure('Failed to undo'),
-              });
+              // Invoke this action's own undo so older toasts don't pop
+              // newer entries off the global undo stack.
+              handle?.undo().catch(() => toast.failure('Failed to undo'));
             },
           },
         ],
         10_000
       );
+      context?.setSuccessToastId(toastId);
     },
     undoFn: async (_variables, context) => {
       await context?.handle.undo();

--- a/js/app/packages/app/component/next-soup/actions/make-mark-done-action.ts
+++ b/js/app/packages/app/component/next-soup/actions/make-mark-done-action.ts
@@ -4,8 +4,11 @@ import { type EntityData, isTaskEntity } from '@entity';
 import type { NotificationSource } from '@notifications';
 import { useUndoableMutation } from '@queries/undo';
 import {
-  type MarkDoneHandle,
-  markEntitiesDone,
+  applyEntitiesDoneOptimistic,
+  executeMarkEntitiesDone,
+  executeMarkEntitiesUndone,
+  type MarkEntitiesDoneContext,
+  resolveMarkEntitiesDoneVariables,
   restoreSoupFocus,
 } from '@app/component/next-soup/utils';
 import { useMaybePreviewPanel } from '@app/component/PreviewPanel';
@@ -16,10 +19,10 @@ type MakeMarkDoneOptions = {
   notificationSource: () => NotificationSource;
 };
 
-type MarkDoneVariables = { entities: EntityData[] };
-type MarkDoneContext = {
-  handle: MarkDoneHandle;
-  setSuccessToastId: (id: number | undefined) => void;
+type MarkDoneVariables = {
+  entities: EntityData[];
+  emailIds: string[];
+  notificationIds: string[];
 };
 
 /** Must be invoked inside a component tree that provides MutationUndoProvider. */
@@ -32,29 +35,20 @@ export const makeMarkDoneAction = (options: MakeMarkDoneOptions) => {
     void,
     Error,
     MarkDoneVariables,
-    MarkDoneContext
+    MarkEntitiesDoneContext
   >(() => ({
-    mutationFn: async () => {},
-    onMutate: async (variables) => {
-      const handle = await markEntitiesDone({
-        entities: variables.entities,
-        notificationSource: notificationSource(),
-      });
-      let successToastId: number | undefined;
-      handle.done.catch(() => {
-        if (successToastId != null) toast.dismiss(successToastId);
-        toast.failure('Failed to mark as done');
-      });
-      return {
-        handle,
-        setSuccessToastId: (id) => {
-          successToastId = id;
-        },
-      };
-    },
+    onMutate: (variables) =>
+      applyEntitiesDoneOptimistic({
+        emailIds: variables.emailIds,
+        notificationIds: variables.notificationIds,
+      }),
+    mutationFn: async (variables) =>
+      await executeMarkEntitiesDone({
+        emailIds: variables.emailIds,
+        notificationIds: variables.notificationIds,
+      }),
     onSuccess: (_data, variables, context) => {
       const count = variables.entities.length;
-      const handle = context?.handle;
       const firstEntityId = variables.entities[0]?.id;
       const toastId = toast.success(
         count > 1 ? `Marked ${count} items as done` : 'Marked as done',
@@ -63,9 +57,18 @@ export const makeMarkDoneAction = (options: MakeMarkDoneOptions) => {
           {
             label: 'Undo',
             icon: ArrowCounterClockwise,
-            onClick: () => {
+            onClick: async () => {
               if (toastId != null) toast.dismiss(toastId);
-              handle?.undo().catch(() => toast.failure('Failed to undo'));
+              context?.rollback();
+              try {
+                await executeMarkEntitiesUndone({
+                  emailIds: variables.emailIds,
+                  notificationIds: variables.notificationIds,
+                });
+              } catch {
+                context?.reapply();
+                toast.failure('Failed to undo');
+              }
               restoreSoupFocus(firstEntityId, inPreview);
             },
           },
@@ -73,13 +76,34 @@ export const makeMarkDoneAction = (options: MakeMarkDoneOptions) => {
         10_000,
         true
       );
-      context?.setSuccessToastId(toastId);
     },
-    onError: () => {
+    onError: (_err, _variables, context) => {
+      context?.rollback();
       toast.failure('Failed to mark as done');
     },
-    undoFn: async (_variables, context) => {
-      await context?.handle.undo();
+    undoFn: async (variables, context) => {
+      context?.rollback();
+      try {
+        await executeMarkEntitiesUndone({
+          emailIds: variables.emailIds,
+          notificationIds: variables.notificationIds,
+        });
+      } catch (err) {
+        context?.reapply();
+        throw err;
+      }
+    },
+    redoFn: async (variables, context) => {
+      context?.reapply();
+      try {
+        await executeMarkEntitiesDone({
+          emailIds: variables.emailIds,
+          notificationIds: variables.notificationIds,
+        });
+      } catch (err) {
+        context?.rollback();
+        throw err;
+      }
     },
     undoLabel: 'Mark Done',
   }));
@@ -101,7 +125,11 @@ export const makeMarkDoneAction = (options: MakeMarkDoneOptions) => {
   };
 
   const execute = async (entities: EntityData[]) => {
-    await mutation.mutateAsync({ entities });
+    const { emailIds, notificationIds } = resolveMarkEntitiesDoneVariables({
+      entities,
+      notificationSource: notificationSource(),
+    });
+    await mutation.mutateAsync({ entities, emailIds, notificationIds });
   };
 
   const executeWithSoup = async (

--- a/js/app/packages/app/component/next-soup/actions/make-mark-done-action.ts
+++ b/js/app/packages/app/component/next-soup/actions/make-mark-done-action.ts
@@ -2,18 +2,68 @@ import ArrowCounterClockwise from '@phosphor-icons/core/regular/arrow-counter-cl
 import { toast } from '@core/component/Toast/Toast';
 import { type EntityData, isTaskEntity } from '@entity';
 import type { NotificationSource } from '@notifications';
-import { useMutationUndoContext } from '@queries/undo';
+import { useMutationUndoContext, useUndoableMutation } from '@queries/undo';
+import {
+  type MarkDoneHandle,
+  markEntitiesDone,
+} from '@app/component/next-soup/utils';
 import type { SoupState } from '../create-soup-state';
-import { markEntitiesDone } from '@app/component/next-soup/utils';
 
 type MakeMarkDoneOptions = {
   userId?: () => string | undefined;
   notificationSource: () => NotificationSource;
 };
 
+type MarkDoneVariables = { entities: EntityData[] };
+type MarkDoneContext = { handle: MarkDoneHandle };
+
 export const makeMarkDoneAction = (options: MakeMarkDoneOptions) => {
   const { notificationSource } = options;
   const undoCtx = useMutationUndoContext();
+
+  const mutation = useUndoableMutation<
+    void,
+    Error,
+    MarkDoneVariables,
+    MarkDoneContext
+  >(() => ({
+    // onMutate does the optimistic work and starts the API calls via the
+    // handle. mutationFn is a no-op so the mutation resolves immediately and
+    // onSuccess fires (pushing the undo entry) before the user can react.
+    mutationFn: async () => {},
+    onMutate: (variables) => {
+      const handle = markEntitiesDone({
+        entities: variables.entities,
+        notificationSource: notificationSource(),
+      });
+      handle.done.catch(() => toast.failure('Failed to mark as done'));
+      return { handle };
+    },
+    onSuccess: (_data, variables) => {
+      const count = variables.entities.length;
+      const toastId = toast.success(
+        count > 1 ? `Marked ${count} items as done` : 'Marked as done',
+        undefined,
+        [
+          {
+            label: 'Undo',
+            icon: ArrowCounterClockwise,
+            onClick: () => {
+              if (toastId != null) toast.dismiss(toastId);
+              undoCtx.undo({
+                onError: () => toast.failure('Failed to undo'),
+              });
+            },
+          },
+        ],
+        10_000
+      );
+    },
+    undoFn: async (_variables, context) => {
+      await context?.handle.undo();
+    },
+    undoLabel: 'Mark Done',
+  }));
 
   const canExecute = (entity: EntityData): boolean => {
     if (entity.type === 'channel_message') return false;
@@ -32,36 +82,7 @@ export const makeMarkDoneAction = (options: MakeMarkDoneOptions) => {
   };
 
   const execute = async (entities: EntityData[]) => {
-    const handle = markEntitiesDone({
-      entities,
-      notificationSource: notificationSource(),
-    });
-
-    undoCtx.pushUndo({ undo: handle.undo, label: 'Mark Done' });
-
-    const toastId = toast.success(
-      entities.length > 1
-        ? `Marked ${entities.length} items as done`
-        : 'Marked as done',
-      undefined,
-      [
-        {
-          label: 'Undo',
-          icon: ArrowCounterClockwise,
-          onClick: () => {
-            if (toastId != null) toast.dismiss(toastId);
-            undoCtx.undo({
-              onError: () => toast.failure('Failed to undo'),
-            });
-          },
-        },
-      ],
-      10_000
-    );
-
-    handle.done.catch(() => {
-      toast.failure('Failed to mark as done');
-    });
+    await mutation.mutateAsync({ entities });
   };
 
   const executeWithSoup = async (

--- a/js/app/packages/app/component/next-soup/actions/make-mark-done-action.ts
+++ b/js/app/packages/app/component/next-soup/actions/make-mark-done-action.ts
@@ -46,10 +46,7 @@ export const makeMarkDoneAction = (options: MakeMarkDoneOptions) => {
           icon: ArrowCounterClockwise,
           onClick: () => {
             if (toastId != null) toast.dismiss(toastId);
-            handle.undo().then(
-              () => toast.success('Undone'),
-              () => toast.failure('Failed to undo')
-            );
+            handle.undo().catch(() => toast.failure('Failed to undo'));
           },
         },
       ],

--- a/js/app/packages/app/component/next-soup/actions/make-mark-done-action.ts
+++ b/js/app/packages/app/component/next-soup/actions/make-mark-done-action.ts
@@ -2,7 +2,7 @@ import ArrowCounterClockwise from '@phosphor-icons/core/regular/arrow-counter-cl
 import { toast } from '@core/component/Toast/Toast';
 import { type EntityData, isTaskEntity } from '@entity';
 import type { NotificationSource } from '@notifications';
-import { useUndoableMutation } from '@queries/undo';
+import { useMutationUndoContext, useUndoableMutation } from '@queries/undo';
 import {
   applyEntitiesDoneOptimistic,
   executeMarkEntitiesDone,
@@ -30,6 +30,7 @@ export const makeMarkDoneAction = (options: MakeMarkDoneOptions) => {
   const { notificationSource } = options;
   const previewPanel = useMaybePreviewPanel();
   const inPreview = previewPanel !== undefined;
+  const undoCtx = useMutationUndoContext();
 
   const mutation = useUndoableMutation<
     void,
@@ -47,7 +48,7 @@ export const makeMarkDoneAction = (options: MakeMarkDoneOptions) => {
         emailIds: variables.emailIds,
         notificationIds: variables.notificationIds,
       }),
-    onSuccess: (_data, variables, context) => {
+    onSuccess: (_data, variables) => {
       const count = variables.entities.length;
       const firstEntityId = variables.entities[0]?.id;
       const toastId = toast.success(
@@ -57,18 +58,13 @@ export const makeMarkDoneAction = (options: MakeMarkDoneOptions) => {
           {
             label: 'Undo',
             icon: ArrowCounterClockwise,
-            onClick: async () => {
+            onClick: () => {
               if (toastId != null) toast.dismiss(toastId);
-              context?.rollback();
-              try {
-                await executeMarkEntitiesUndone({
-                  emailIds: variables.emailIds,
-                  notificationIds: variables.notificationIds,
-                });
-              } catch {
-                context?.reapply();
-                toast.failure('Failed to undo');
-              }
+              // Route through the undo stack so the entry is popped and
+              // Cmd+Z / shift+Cmd+Z stay in sync with the toast action.
+              undoCtx.undo({
+                onError: () => toast.failure('Failed to undo'),
+              });
               restoreSoupFocus(firstEntityId, inPreview);
             },
           },
@@ -82,7 +78,7 @@ export const makeMarkDoneAction = (options: MakeMarkDoneOptions) => {
       toast.failure('Failed to mark as done');
     },
     undoFn: async (variables, context) => {
-      context?.rollback();
+      context?.applyUndone();
       try {
         await executeMarkEntitiesUndone({
           emailIds: variables.emailIds,
@@ -101,7 +97,7 @@ export const makeMarkDoneAction = (options: MakeMarkDoneOptions) => {
           notificationIds: variables.notificationIds,
         });
       } catch (err) {
-        context?.rollback();
+        context?.applyUndone();
         throw err;
       }
     },

--- a/js/app/packages/app/component/next-soup/utils.ts
+++ b/js/app/packages/app/component/next-soup/utils.ts
@@ -592,10 +592,10 @@ type NotificationCacheData = {
  * then fires the API calls in the background. Returns synchronously so the caller
  * can show the undo toast immediately.
  */
-export function markEntitiesDone(args: {
+export async function markEntitiesDone(args: {
   entities: EntityData[];
   notificationSource: NotificationSource;
-}): MarkDoneHandle {
+}): Promise<MarkDoneHandle> {
   const { entities, notificationSource } = args;
 
   const emailIds = entities.filter((e) => e.type === 'email').map((e) => e.id);
@@ -608,8 +608,12 @@ export function markEntitiesDone(args: {
   );
   const notificationIdSet = new Set(notificationIds);
 
-  queryClient.cancelQueries({ queryKey: queryKeys.all.email });
-  queryClient.cancelQueries({ queryKey: notificationKeys.user._def });
+  // Cancel in-flight fetches up front so arriving responses can't clobber
+  // the optimistic update (TanStack Query v5 pattern for optimistic updates).
+  await Promise.all([
+    queryClient.cancelQueries({ queryKey: queryKeys.all.email }),
+    queryClient.cancelQueries({ queryKey: notificationKeys.user._def }),
+  ]);
 
   const previousEmail = queryClient.getQueriesData<{
     pages: { items: EntityData[] }[];
@@ -617,18 +621,24 @@ export function markEntitiesDone(args: {
     queryKey: queryKeys.all.email,
   });
 
-  const soupTxn = emailIds.length > 0 ? removeSoupEntities(emailIdSet) : null;
+  const filterEmailCache = () => {
+    for (const [key, data] of previousEmail) {
+      if (!data) continue;
+      queryClient.setQueryData(key, {
+        ...data,
+        pages: data.pages.map((page) => ({
+          ...page,
+          items: page.items.filter((item) => !emailIdSet.has(item.id)),
+        })),
+      });
+    }
+  };
 
-  for (const [key, data] of previousEmail) {
-    if (!data) continue;
-    queryClient.setQueryData(key, {
-      ...data,
-      pages: data.pages.map((page) => ({
-        ...page,
-        items: page.items.filter((item) => !emailIdSet.has(item.id)),
-      })),
-    });
-  }
+  const restoreEmailCache = () => {
+    for (const [key, data] of previousEmail) {
+      queryClient.setQueryData(key, data);
+    }
+  };
 
   // Flip `done` on target notifications in place. Touching only the specific
   // items (instead of snapshotting and restoring the whole cache) keeps any
@@ -652,20 +662,32 @@ export function markEntitiesDone(args: {
     );
   };
 
-  setNotificationDoneFlag(true);
+  // Re-runnable optimistic update. Each application needs a fresh soup
+  // transaction since rollback consumes the previous one.
+  let soupTxn: ReturnType<typeof removeSoupEntities> | null = null;
+  const applyOptimistic = () => {
+    soupTxn = emailIds.length > 0 ? removeSoupEntities(emailIdSet) : null;
+    filterEmailCache();
+    setNotificationDoneFlag(true);
+  };
 
   const rollback = () => {
     soupTxn?.rollback();
-    for (const [key, data] of previousEmail) {
-      queryClient.setQueryData(key, data);
-    }
+    soupTxn = null;
+    restoreEmailCache();
     setNotificationDoneFlag(false);
   };
+
+  applyOptimistic();
 
   const done = (async () => {
     try {
       await Promise.all([
-        ...emailIds.map((id) => emailClient.flagArchived({ value: true, id })),
+        ...emailIds.map((id) =>
+          throwOnErr(
+            async () => await emailClient.flagArchived({ value: true, id })
+          )
+        ),
         notificationIds.length > 0
           ? throwOnErr(
               async () =>
@@ -707,12 +729,19 @@ export function markEntitiesDone(args: {
         return;
       }
 
+      await Promise.all([
+        queryClient.cancelQueries({ queryKey: queryKeys.all.email }),
+        queryClient.cancelQueries({ queryKey: notificationKeys.user._def }),
+      ]);
+
       rollback();
 
       try {
         await Promise.all([
           ...emailIds.map((id) =>
-            emailClient.flagArchived({ value: false, id })
+            throwOnErr(
+              async () => await emailClient.flagArchived({ value: false, id })
+            )
           ),
           notificationIds.length > 0
             ? throwOnErr(
@@ -723,6 +752,11 @@ export function markEntitiesDone(args: {
               )
             : Promise.resolve(),
         ]);
+      } catch (err) {
+        // Server still thinks these are done — re-apply the optimistic done
+        // state so the UI matches the backend.
+        applyOptimistic();
+        throw err;
       } finally {
         await Promise.all([
           queryClient.invalidateQueries({

--- a/js/app/packages/app/component/next-soup/utils.ts
+++ b/js/app/packages/app/component/next-soup/utils.ts
@@ -584,7 +584,7 @@ export type MarkDoneHandle = {
 };
 
 type NotificationCacheData = {
-  pages: { items: { id: string }[] }[];
+  pages: { items: { id: string; done?: boolean }[] }[];
 };
 
 /**
@@ -616,10 +616,6 @@ export function markEntitiesDone(args: {
   }>({
     queryKey: queryKeys.all.email,
   });
-  const previousNotifications =
-    queryClient.getQueriesData<NotificationCacheData>({
-      queryKey: notificationKeys.user._def,
-    });
 
   const soupTxn = emailIds.length > 0 ? removeSoupEntities(emailIdSet) : null;
 
@@ -634,25 +630,36 @@ export function markEntitiesDone(args: {
     });
   }
 
-  for (const [key, data] of previousNotifications) {
-    if (!data) continue;
-    queryClient.setQueryData(key, {
-      ...data,
-      pages: data.pages.map((page) => ({
-        ...page,
-        items: page.items.filter((item) => !notificationIdSet.has(item.id)),
-      })),
-    });
-  }
+  // Flip `done` on target notifications in place. Touching only the specific
+  // items (instead of snapshotting and restoring the whole cache) keeps any
+  // concurrent websocket inserts intact across the undo window.
+  const setNotificationDoneFlag = (value: boolean) => {
+    if (notificationIdSet.size === 0) return;
+    queryClient.setQueriesData<NotificationCacheData>(
+      { queryKey: notificationKeys.user._def },
+      (data) => {
+        if (!data) return data;
+        return {
+          ...data,
+          pages: data.pages.map((page) => ({
+            ...page,
+            items: page.items.map((item) =>
+              notificationIdSet.has(item.id) ? { ...item, done: value } : item
+            ),
+          })),
+        };
+      }
+    );
+  };
+
+  setNotificationDoneFlag(true);
 
   const rollback = () => {
     soupTxn?.rollback();
     for (const [key, data] of previousEmail) {
       queryClient.setQueryData(key, data);
     }
-    for (const [key, data] of previousNotifications) {
-      queryClient.setQueryData(key, data);
-    }
+    setNotificationDoneFlag(false);
   };
 
   const done = (async () => {

--- a/js/app/packages/app/component/next-soup/utils.ts
+++ b/js/app/packages/app/component/next-soup/utils.ts
@@ -594,8 +594,8 @@ export type MarkDoneHandle = {
 /**
  * Optimistically marks entities as done (archives emails, clears notifications),
  * then fires the API calls in the background. Awaits `cancelQueries` so a stale
- * in-flight fetch can't clobber the optimistic update, then returns a handle
- * the caller can hold onto for the undo toast.
+ * in-flight fetch can't clobber the email/soup cache writes before returning
+ * the handle the caller uses for the undo toast.
  */
 export async function markEntitiesDone(args: {
   entities: EntityData[];

--- a/js/app/packages/app/component/next-soup/utils.ts
+++ b/js/app/packages/app/component/next-soup/utils.ts
@@ -28,7 +28,11 @@ import {
 import { match } from 'ts-pattern';
 import { isAfter } from 'date-fns';
 import { getChannelParams } from '@block-channel/utils/link';
-import { compositeEntity, type NotificationSource } from '@notifications';
+import {
+  compositeEntity,
+  type NotificationSource,
+  setDoneOverride,
+} from '@notifications';
 import { notificationServiceClient } from '@service-notification/client';
 import { notificationKeys } from '@queries/notification/keys';
 
@@ -587,10 +591,6 @@ export type MarkDoneHandle = {
   undo: () => Promise<void>;
 };
 
-type NotificationCacheData = {
-  pages: { items: { id: string; done?: boolean }[] }[];
-};
-
 /**
  * Optimistically marks entities as done (archives emails, clears notifications),
  * then fires the API calls in the background. Returns synchronously so the caller
@@ -610,7 +610,6 @@ export async function markEntitiesDone(args: {
       notificationSource.notificationsByEntity()[compositeEntity(entity)] ?? []
     ).map((n) => n.id)
   );
-  const notificationIdSet = new Set(notificationIds);
 
   await Promise.all([
     queryClient.cancelQueries({ queryKey: queryKeys.all.email }),
@@ -642,37 +641,18 @@ export async function markEntitiesDone(args: {
     }
   };
 
-  const setNotificationDoneFlag = (value: boolean) => {
-    if (notificationIdSet.size === 0) return;
-    queryClient.setQueriesData<NotificationCacheData>(
-      { queryKey: notificationKeys.user._def },
-      (data) => {
-        if (!data) return data;
-        return {
-          ...data,
-          pages: data.pages.map((page) => ({
-            ...page,
-            items: page.items.map((item) =>
-              notificationIdSet.has(item.id) ? { ...item, done: value } : item
-            ),
-          })),
-        };
-      }
-    );
-  };
-
   let soupTxn: ReturnType<typeof removeSoupEntities> | null = null;
   const applyOptimistic = () => {
     soupTxn = emailIds.length > 0 ? removeSoupEntities(emailIdSet) : null;
     filterEmailCache();
-    setNotificationDoneFlag(true);
+    setDoneOverride(notificationIds, true);
   };
 
   const rollback = () => {
     soupTxn?.rollback();
     soupTxn = null;
     restoreEmailCache();
-    setNotificationDoneFlag(false);
+    setDoneOverride(notificationIds, undefined);
   };
 
   applyOptimistic();

--- a/js/app/packages/app/component/next-soup/utils.ts
+++ b/js/app/packages/app/component/next-soup/utils.ts
@@ -250,25 +250,29 @@ export const restoreSoupFocus = async (
     );
   }
 
-  if (!domRef) return;
+  if (!(domRef instanceof HTMLElement)) return;
 
   // Wait for DOM to update after modal closes
   await waitForFrames(2);
 
-  // Find and focus the entity element
+  // Entity rows are plain divs without a `tabindex` attribute so `.focus()`
+  // on them is a no-op. Targeting them is still useful because the browser
+  // may scroll them into view as part of the focus attempt. Always follow
+  // up by focusing the soup container (which has `tabindex={-1}`) — that's
+  // what actually reactivates the hotkey scope.
   if (entityId) {
     const entityEl = domRef.querySelector(`[data-entity-id="${entityId}"]`);
-    if (entityEl instanceof HTMLElement) {
-      entityEl.focus();
-      return;
-    }
+    if (entityEl instanceof HTMLElement) entityEl.focus();
   }
 
-  // Fallback: focus the first entity in the list if no specific entity to focus
+  if (document.activeElement && domRef.contains(document.activeElement)) return;
+
   const firstEntityEl = domRef.querySelector('[data-entity-id]');
-  if (firstEntityEl instanceof HTMLElement) {
-    firstEntityEl.focus();
-  }
+  if (firstEntityEl instanceof HTMLElement) firstEntityEl.focus();
+
+  if (document.activeElement && domRef.contains(document.activeElement)) return;
+
+  domRef.focus();
 };
 
 export interface OpenEntityOptions {

--- a/js/app/packages/app/component/next-soup/utils.ts
+++ b/js/app/packages/app/component/next-soup/utils.ts
@@ -584,48 +584,50 @@ export function trashEmails(ids: string[]): TrashEmailsHandle {
   };
 }
 
-export type MarkDoneHandle = {
-  /** Fire-and-forget promise for the API calls. Rejects on failure (rolls back optimistic update). */
-  done: Promise<void>;
-  /** Reverses the mark-done: restores caches and calls the undone APIs. */
-  undo: () => Promise<void>;
+export type MarkEntitiesDoneContext = {
+  /** Reverses the optimistic cache writes. Safe to call multiple times. */
+  rollback: () => void;
+  /** Re-applies the optimistic cache writes with a fresh soup transaction. */
+  reapply: () => void;
 };
 
 /**
- * Optimistically marks entities as done (archives emails, clears notifications),
- * then fires the API calls in the background. Awaits `cancelQueries` so a stale
- * in-flight fetch can't clobber the email/soup cache writes before returning
- * the handle the caller uses for the undo toast.
+ * Extract the email ids and notification ids targeted by a mark-done on these
+ * entities. The ids are snapshotted here so mutationFn/undoFn/redoFn operate
+ * on the set that existed at mutation time.
  */
-export async function markEntitiesDone(args: {
+export function resolveMarkEntitiesDoneVariables(args: {
   entities: EntityData[];
   notificationSource: NotificationSource;
-}): Promise<MarkDoneHandle> {
+}): { emailIds: string[]; notificationIds: string[] } {
   const { entities, notificationSource } = args;
-
   const emailIds = entities.filter((e) => e.type === 'email').map((e) => e.id);
-  const emailIdSet = new Set(emailIds);
-
   const notificationIds = entities.flatMap((entity) =>
     (
       notificationSource.notificationsByEntity()[compositeEntity(entity)] ?? []
     ).map((n) => n.id)
   );
+  return { emailIds, notificationIds };
+}
 
-  await Promise.all([
-    queryClient.cancelQueries({ queryKey: queryKeys.all.email }),
-    queryClient.cancelQueries({ queryKey: notificationKeys.user._def }),
-  ]);
+/**
+ * Applies the optimistic UI state for marking entities as done — removes
+ * emails from the soup + email caches and flips the notification `done`
+ * override. Returns a context the mutation uses for rollback / reapply.
+ */
+export function applyEntitiesDoneOptimistic(args: {
+  emailIds: string[];
+  notificationIds: string[];
+}): MarkEntitiesDoneContext {
+  const { emailIds, notificationIds } = args;
+  const emailIdSet = new Set(emailIds);
 
-  // Track the actual email objects we filter out, keyed by cache query, so
-  // we can restore just those items without clobbering emails that arrived
-  // concurrently during the undo window.
   type EmailQueryKey = readonly unknown[];
   type EmailCacheData = { pages: { items: EntityData[] }[] };
   const removedEmails = new Map<EmailQueryKey, Map<string, EntityData>>();
 
-  const filterEmailCache = (ids: Set<string>) => {
-    if (ids.size === 0) return;
+  const filterEmailCache = () => {
+    if (emailIdSet.size === 0) return;
     for (const [key, data] of queryClient.getQueriesData<EmailCacheData>({
       queryKey: queryKeys.all.email,
     })) {
@@ -635,7 +637,7 @@ export async function markEntitiesDone(args: {
       const pages = data.pages.map((page) => {
         const items: EntityData[] = [];
         for (const item of page.items) {
-          if (ids.has(item.id)) {
+          if (emailIdSet.has(item.id)) {
             bucket.set(item.id, item);
             mutated = true;
           } else {
@@ -653,18 +655,11 @@ export async function markEntitiesDone(args: {
     }
   };
 
-  const restoreEmailCache = (ids: Set<string>) => {
-    if (ids.size === 0) return;
+  const restoreEmailCache = () => {
     for (const [key, bucket] of removedEmails) {
-      const toRestore: EntityData[] = [];
-      for (const id of ids) {
-        const item = bucket.get(id);
-        if (item) {
-          toRestore.push(item);
-          bucket.delete(id);
-        }
-      }
-      if (toRestore.length === 0) continue;
+      if (bucket.size === 0) continue;
+      const toRestore = [...bucket.values()];
+      bucket.clear();
       queryClient.setQueryData<EmailCacheData>(key, (current) => {
         if (!current) return current;
         const restoredIds = new Set(toRestore.map((e) => e.id));
@@ -686,162 +681,134 @@ export async function markEntitiesDone(args: {
   };
 
   let soupTxn: ReturnType<typeof removeSoupEntities> | null = null;
-  const applyOptimistic = () => {
+
+  const reapply = () => {
     soupTxn = emailIds.length > 0 ? removeSoupEntities(emailIdSet) : null;
-    filterEmailCache(emailIdSet);
+    filterEmailCache();
     setDoneOverride(notificationIds, true);
   };
 
-  const rollback = (opts?: {
-    emailIds?: string[];
-    notificationIds?: string[];
-  }) => {
-    const emailsToRoll = opts?.emailIds ?? emailIds;
-    const notificationsToRoll = opts?.notificationIds ?? notificationIds;
-    // `removeSoupEntities` returns one transaction for all ids; if a partial
-    // rollback is requested we still roll back the whole batch and rely on
-    // soup re-sync to reconcile from server state.
-    if (soupTxn && emailsToRoll.length > 0) {
-      soupTxn.rollback();
-      soupTxn = null;
-    }
-    restoreEmailCache(new Set(emailsToRoll));
-    setDoneOverride(notificationsToRoll, undefined);
+  const rollback = () => {
+    soupTxn?.rollback();
+    soupTxn = null;
+    restoreEmailCache();
+    setDoneOverride(notificationIds, undefined);
   };
 
-  applyOptimistic();
+  reapply();
 
-  const reconcile = () =>
-    Promise.all([
+  return { rollback, reapply };
+}
+
+/**
+ * Fires the archive + bulk-done APIs for the given ids. Throws on any
+ * failure; caller is responsible for rollback via the context returned by
+ * `applyEntitiesDoneOptimistic`.
+ */
+export async function executeMarkEntitiesDone(args: {
+  emailIds: string[];
+  notificationIds: string[];
+}): Promise<void> {
+  const { emailIds, notificationIds } = args;
+  await Promise.all([
+    queryClient.cancelQueries({ queryKey: queryKeys.all.email }),
+    queryClient.cancelQueries({ queryKey: notificationKeys.user._def }),
+  ]);
+
+  const results = await Promise.allSettled([
+    ...emailIds.map((id) =>
+      throwOnErr(
+        async () => await emailClient.flagArchived({ value: true, id })
+      )
+    ),
+    notificationIds.length > 0
+      ? throwOnErr(
+          async () =>
+            await notificationServiceClient.bulkMarkNotificationAsDone({
+              notificationIds,
+            })
+        )
+      : Promise.resolve(),
+  ]);
+
+  const rejected = results.find(
+    (r): r is PromiseRejectedResult => r.status === 'rejected'
+  );
+
+  if (rejected) {
+    // Real refetch to reconcile server state with the UI after the caller
+    // rolls back its optimistic cache writes.
+    await Promise.all([
       queryClient.invalidateQueries({ queryKey: queryKeys.all.email }),
       queryClient.invalidateQueries({ queryKey: notificationKeys.user._def }),
       ...emailIds.map((id) => invalidateSoupEntity(id)),
     ]);
+    throw rejected.reason ?? new Error('Failed to mark as done');
+  }
 
-  const done = (async () => {
-    const results = await Promise.allSettled([
-      ...emailIds.map((id) =>
-        throwOnErr(
-          async () => await emailClient.flagArchived({ value: true, id })
+  await Promise.all([
+    queryClient.invalidateQueries({
+      queryKey: queryKeys.all.email,
+      refetchType: 'none',
+    }),
+    queryClient.invalidateQueries({
+      queryKey: notificationKeys.user._def,
+      refetchType: 'none',
+    }),
+    ...emailIds.map((id) => invalidateSoupEntity(id)),
+  ]);
+}
+
+/**
+ * Fires the unarchive + bulk-undone APIs for the given ids. Throws on any
+ * failure; caller is responsible for re-applying optimistic state.
+ */
+export async function executeMarkEntitiesUndone(args: {
+  emailIds: string[];
+  notificationIds: string[];
+}): Promise<void> {
+  const { emailIds, notificationIds } = args;
+  await Promise.all([
+    queryClient.cancelQueries({ queryKey: queryKeys.all.email }),
+    queryClient.cancelQueries({ queryKey: notificationKeys.user._def }),
+  ]);
+
+  const results = await Promise.allSettled([
+    ...emailIds.map((id) =>
+      throwOnErr(
+        async () => await emailClient.flagArchived({ value: false, id })
+      )
+    ),
+    notificationIds.length > 0
+      ? throwOnErr(
+          async () =>
+            await notificationServiceClient.bulkMarkNotificationAsUndone({
+              notificationIds,
+            })
         )
-      ),
-      notificationIds.length > 0
-        ? throwOnErr(
-            async () =>
-              await notificationServiceClient.bulkMarkNotificationAsDone({
-                notificationIds,
-              })
-          )
-        : Promise.resolve(),
+      : Promise.resolve(),
+  ]);
+
+  const rejected = results.find(
+    (r): r is PromiseRejectedResult => r.status === 'rejected'
+  );
+
+  if (rejected) {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: queryKeys.all.email }),
+      queryClient.invalidateQueries({ queryKey: notificationKeys.user._def }),
     ]);
+    throw rejected.reason ?? new Error('Failed to undo');
+  }
 
-    const failedEmailIds = emailIds.filter(
-      (_, i) => results[i]?.status === 'rejected'
-    );
-    const notificationsFailed = results[emailIds.length]?.status === 'rejected';
-    const anyFailed = failedEmailIds.length > 0 || notificationsFailed;
-
-    try {
-      if (anyFailed) {
-        rollback({
-          emailIds: failedEmailIds,
-          notificationIds: notificationsFailed ? notificationIds : [],
-        });
-        // Partial failures need a real refetch to reconcile server state
-        // with our now-partially-rolled-back UI.
-        await reconcile();
-        const firstErr = results.find(
-          (r): r is PromiseRejectedResult => r.status === 'rejected'
-        )?.reason;
-        throw firstErr ?? new Error('Failed to mark as done');
-      }
-    } finally {
-      if (!anyFailed) {
-        await Promise.all([
-          queryClient.invalidateQueries({
-            queryKey: queryKeys.all.email,
-            refetchType: 'none',
-          }),
-          queryClient.invalidateQueries({
-            queryKey: notificationKeys.user._def,
-            refetchType: 'none',
-          }),
-          ...emailIds.map((id) => invalidateSoupEntity(id)),
-        ]);
-      }
-    }
-  })();
-
-  return {
-    done,
-    undo: async () => {
-      try {
-        await done;
-      } catch {
-        return;
-      }
-
-      await Promise.all([
-        queryClient.cancelQueries({ queryKey: queryKeys.all.email }),
-        queryClient.cancelQueries({ queryKey: notificationKeys.user._def }),
-      ]);
-
-      rollback();
-
-      const results = await Promise.allSettled([
-        ...emailIds.map((id) =>
-          throwOnErr(
-            async () => await emailClient.flagArchived({ value: false, id })
-          )
-        ),
-        notificationIds.length > 0
-          ? throwOnErr(
-              async () =>
-                await notificationServiceClient.bulkMarkNotificationAsUndone({
-                  notificationIds,
-                })
-            )
-          : Promise.resolve(),
-      ]);
-
-      const failedEmailIds = emailIds.filter(
-        (_, i) => results[i]?.status === 'rejected'
-      );
-      const notificationsFailed =
-        results[emailIds.length]?.status === 'rejected';
-      const anyFailed = failedEmailIds.length > 0 || notificationsFailed;
-
-      try {
-        if (anyFailed) {
-          // Re-apply the mark-done state only for the items whose undo
-          // failed. Items whose undo succeeded stay restored.
-          if (failedEmailIds.length > 0) {
-            soupTxn = removeSoupEntities(new Set(failedEmailIds));
-            filterEmailCache(new Set(failedEmailIds));
-          }
-          if (notificationsFailed) {
-            setDoneOverride(notificationIds, true);
-          }
-          await reconcile();
-          const firstErr = results.find(
-            (r): r is PromiseRejectedResult => r.status === 'rejected'
-          )?.reason;
-          throw firstErr ?? new Error('Failed to undo');
-        }
-      } finally {
-        if (!anyFailed) {
-          await Promise.all([
-            queryClient.invalidateQueries({
-              queryKey: queryKeys.all.email,
-              refetchType: 'none',
-            }),
-            queryClient.invalidateQueries({
-              queryKey: notificationKeys.user._def,
-              refetchType: 'none',
-            }),
-          ]);
-        }
-      }
-    },
-  };
+  await Promise.all([
+    queryClient.invalidateQueries({
+      queryKey: queryKeys.all.email,
+      refetchType: 'none',
+    }),
+    queryClient.invalidateQueries({
+      queryKey: notificationKeys.user._def,
+      refetchType: 'none',
+    }),
+  ]);
 }

--- a/js/app/packages/app/component/next-soup/utils.ts
+++ b/js/app/packages/app/component/next-soup/utils.ts
@@ -616,79 +616,156 @@ export async function markEntitiesDone(args: {
     queryClient.cancelQueries({ queryKey: notificationKeys.user._def }),
   ]);
 
-  const previousEmail = queryClient.getQueriesData<{
-    pages: { items: EntityData[] }[];
-  }>({
-    queryKey: queryKeys.all.email,
-  });
+  // Track the actual email objects we filter out, keyed by cache query, so
+  // we can restore just those items without clobbering emails that arrived
+  // concurrently during the undo window.
+  type EmailQueryKey = readonly unknown[];
+  type EmailCacheData = { pages: { items: EntityData[] }[] };
+  const removedEmails = new Map<EmailQueryKey, Map<string, EntityData>>();
 
-  const filterEmailCache = () => {
-    for (const [key, data] of previousEmail) {
+  const filterEmailCache = (ids: Set<string>) => {
+    if (ids.size === 0) return;
+    for (const [key, data] of queryClient.getQueriesData<EmailCacheData>({
+      queryKey: queryKeys.all.email,
+    })) {
       if (!data) continue;
-      queryClient.setQueryData(key, {
-        ...data,
-        pages: data.pages.map((page) => ({
-          ...page,
-          items: page.items.filter((item) => !emailIdSet.has(item.id)),
-        })),
+      const bucket = removedEmails.get(key) ?? new Map<string, EntityData>();
+      let mutated = false;
+      const pages = data.pages.map((page) => {
+        const items: EntityData[] = [];
+        for (const item of page.items) {
+          if (ids.has(item.id)) {
+            bucket.set(item.id, item);
+            mutated = true;
+          } else {
+            items.push(item);
+          }
+        }
+        return mutated && items.length !== page.items.length
+          ? { ...page, items }
+          : page;
       });
+      if (mutated) {
+        removedEmails.set(key, bucket);
+        queryClient.setQueryData(key, { ...data, pages });
+      }
     }
   };
 
-  const restoreEmailCache = () => {
-    for (const [key, data] of previousEmail) {
-      queryClient.setQueryData(key, data);
+  const restoreEmailCache = (ids: Set<string>) => {
+    if (ids.size === 0) return;
+    for (const [key, bucket] of removedEmails) {
+      const toRestore: EntityData[] = [];
+      for (const id of ids) {
+        const item = bucket.get(id);
+        if (item) {
+          toRestore.push(item);
+          bucket.delete(id);
+        }
+      }
+      if (toRestore.length === 0) continue;
+      queryClient.setQueryData<EmailCacheData>(key, (current) => {
+        if (!current) return current;
+        const restoredIds = new Set(toRestore.map((e) => e.id));
+        return {
+          ...current,
+          pages: current.pages.map((page, idx) => {
+            const filtered = page.items.filter((i) => !restoredIds.has(i.id));
+            return idx === 0
+              ? { ...page, items: [...toRestore, ...filtered] }
+              : filtered.length === page.items.length
+                ? page
+                : { ...page, items: filtered };
+          }),
+        };
+      });
     }
   };
 
   let soupTxn: ReturnType<typeof removeSoupEntities> | null = null;
   const applyOptimistic = () => {
     soupTxn = emailIds.length > 0 ? removeSoupEntities(emailIdSet) : null;
-    filterEmailCache();
+    filterEmailCache(emailIdSet);
     setDoneOverride(notificationIds, true);
   };
 
-  const rollback = () => {
-    soupTxn?.rollback();
-    soupTxn = null;
-    restoreEmailCache();
-    setDoneOverride(notificationIds, undefined);
+  const rollback = (opts?: {
+    emailIds?: string[];
+    notificationIds?: string[];
+  }) => {
+    const emailsToRoll = opts?.emailIds ?? emailIds;
+    const notificationsToRoll = opts?.notificationIds ?? notificationIds;
+    // `removeSoupEntities` returns one transaction for all ids; if a partial
+    // rollback is requested we still roll back the whole batch and rely on
+    // soup re-sync to reconcile from server state.
+    if (soupTxn && emailsToRoll.length > 0) {
+      soupTxn.rollback();
+      soupTxn = null;
+    }
+    restoreEmailCache(new Set(emailsToRoll));
+    setDoneOverride(notificationsToRoll, undefined);
   };
 
   applyOptimistic();
 
+  const reconcile = () =>
+    Promise.all([
+      queryClient.invalidateQueries({ queryKey: queryKeys.all.email }),
+      queryClient.invalidateQueries({ queryKey: notificationKeys.user._def }),
+      ...emailIds.map((id) => invalidateSoupEntity(id)),
+    ]);
+
   const done = (async () => {
-    try {
-      await Promise.all([
-        ...emailIds.map((id) =>
-          throwOnErr(
-            async () => await emailClient.flagArchived({ value: true, id })
+    const results = await Promise.allSettled([
+      ...emailIds.map((id) =>
+        throwOnErr(
+          async () => await emailClient.flagArchived({ value: true, id })
+        )
+      ),
+      notificationIds.length > 0
+        ? throwOnErr(
+            async () =>
+              await notificationServiceClient.bulkMarkNotificationAsDone({
+                notificationIds,
+              })
           )
-        ),
-        notificationIds.length > 0
-          ? throwOnErr(
-              async () =>
-                await notificationServiceClient.bulkMarkNotificationAsDone({
-                  notificationIds,
-                })
-            )
-          : Promise.resolve(),
-      ]);
-    } catch (err) {
-      rollback();
-      throw err;
+        : Promise.resolve(),
+    ]);
+
+    const failedEmailIds = emailIds.filter(
+      (_, i) => results[i]?.status === 'rejected'
+    );
+    const notificationsFailed = results[emailIds.length]?.status === 'rejected';
+    const anyFailed = failedEmailIds.length > 0 || notificationsFailed;
+
+    try {
+      if (anyFailed) {
+        rollback({
+          emailIds: failedEmailIds,
+          notificationIds: notificationsFailed ? notificationIds : [],
+        });
+        // Partial failures need a real refetch to reconcile server state
+        // with our now-partially-rolled-back UI.
+        await reconcile();
+        const firstErr = results.find(
+          (r): r is PromiseRejectedResult => r.status === 'rejected'
+        )?.reason;
+        throw firstErr ?? new Error('Failed to mark as done');
+      }
     } finally {
-      await Promise.all([
-        queryClient.invalidateQueries({
-          queryKey: queryKeys.all.email,
-          refetchType: 'none',
-        }),
-        queryClient.invalidateQueries({
-          queryKey: notificationKeys.user._def,
-          refetchType: 'none',
-        }),
-        ...emailIds.map((id) => invalidateSoupEntity(id)),
-      ]);
+      if (!anyFailed) {
+        await Promise.all([
+          queryClient.invalidateQueries({
+            queryKey: queryKeys.all.email,
+            refetchType: 'none',
+          }),
+          queryClient.invalidateQueries({
+            queryKey: notificationKeys.user._def,
+            refetchType: 'none',
+          }),
+          ...emailIds.map((id) => invalidateSoupEntity(id)),
+        ]);
+      }
     }
   })();
 
@@ -708,36 +785,59 @@ export async function markEntitiesDone(args: {
 
       rollback();
 
-      try {
-        await Promise.all([
-          ...emailIds.map((id) =>
-            throwOnErr(
-              async () => await emailClient.flagArchived({ value: false, id })
+      const results = await Promise.allSettled([
+        ...emailIds.map((id) =>
+          throwOnErr(
+            async () => await emailClient.flagArchived({ value: false, id })
+          )
+        ),
+        notificationIds.length > 0
+          ? throwOnErr(
+              async () =>
+                await notificationServiceClient.bulkMarkNotificationAsUndone({
+                  notificationIds,
+                })
             )
-          ),
-          notificationIds.length > 0
-            ? throwOnErr(
-                async () =>
-                  await notificationServiceClient.bulkMarkNotificationAsUndone({
-                    notificationIds,
-                  })
-              )
-            : Promise.resolve(),
-        ]);
-      } catch (err) {
-        applyOptimistic();
-        throw err;
+          : Promise.resolve(),
+      ]);
+
+      const failedEmailIds = emailIds.filter(
+        (_, i) => results[i]?.status === 'rejected'
+      );
+      const notificationsFailed =
+        results[emailIds.length]?.status === 'rejected';
+      const anyFailed = failedEmailIds.length > 0 || notificationsFailed;
+
+      try {
+        if (anyFailed) {
+          // Re-apply the mark-done state only for the items whose undo
+          // failed. Items whose undo succeeded stay restored.
+          if (failedEmailIds.length > 0) {
+            soupTxn = removeSoupEntities(new Set(failedEmailIds));
+            filterEmailCache(new Set(failedEmailIds));
+          }
+          if (notificationsFailed) {
+            setDoneOverride(notificationIds, true);
+          }
+          await reconcile();
+          const firstErr = results.find(
+            (r): r is PromiseRejectedResult => r.status === 'rejected'
+          )?.reason;
+          throw firstErr ?? new Error('Failed to undo');
+        }
       } finally {
-        await Promise.all([
-          queryClient.invalidateQueries({
-            queryKey: queryKeys.all.email,
-            refetchType: 'none',
-          }),
-          queryClient.invalidateQueries({
-            queryKey: notificationKeys.user._def,
-            refetchType: 'none',
-          }),
-        ]);
+        if (!anyFailed) {
+          await Promise.all([
+            queryClient.invalidateQueries({
+              queryKey: queryKeys.all.email,
+              refetchType: 'none',
+            }),
+            queryClient.invalidateQueries({
+              queryKey: notificationKeys.user._def,
+              refetchType: 'none',
+            }),
+          ]);
+        }
       }
     },
   };

--- a/js/app/packages/app/component/next-soup/utils.ts
+++ b/js/app/packages/app/component/next-soup/utils.ts
@@ -608,8 +608,6 @@ export async function markEntitiesDone(args: {
   );
   const notificationIdSet = new Set(notificationIds);
 
-  // Cancel in-flight fetches up front so arriving responses can't clobber
-  // the optimistic update (TanStack Query v5 pattern for optimistic updates).
   await Promise.all([
     queryClient.cancelQueries({ queryKey: queryKeys.all.email }),
     queryClient.cancelQueries({ queryKey: notificationKeys.user._def }),
@@ -640,9 +638,6 @@ export async function markEntitiesDone(args: {
     }
   };
 
-  // Flip `done` on target notifications in place. Touching only the specific
-  // items (instead of snapshotting and restoring the whole cache) keeps any
-  // concurrent websocket inserts intact across the undo window.
   const setNotificationDoneFlag = (value: boolean) => {
     if (notificationIdSet.size === 0) return;
     queryClient.setQueriesData<NotificationCacheData>(
@@ -662,8 +657,6 @@ export async function markEntitiesDone(args: {
     );
   };
 
-  // Re-runnable optimistic update. Each application needs a fresh soup
-  // transaction since rollback consumes the previous one.
   let soupTxn: ReturnType<typeof removeSoupEntities> | null = null;
   const applyOptimistic = () => {
     soupTxn = emailIds.length > 0 ? removeSoupEntities(emailIdSet) : null;
@@ -701,9 +694,6 @@ export async function markEntitiesDone(args: {
       rollback();
       throw err;
     } finally {
-      // Cache is already consistent via the optimistic update (or rollback on
-      // failure). Skip refetches — invalidating the infinite notification
-      // query would otherwise re-fetch every cached page.
       await Promise.all([
         queryClient.invalidateQueries({
           queryKey: queryKeys.all.email,
@@ -721,8 +711,6 @@ export async function markEntitiesDone(args: {
   return {
     done,
     undo: async () => {
-      // Wait for the mark-done calls to finish. If they failed, rollback
-      // already happened — nothing to undo.
       try {
         await done;
       } catch {
@@ -753,8 +741,6 @@ export async function markEntitiesDone(args: {
             : Promise.resolve(),
         ]);
       } catch (err) {
-        // Server still thinks these are done — re-apply the optimistic done
-        // state so the UI matches the backend.
         applyOptimistic();
         throw err;
       } finally {

--- a/js/app/packages/app/component/next-soup/utils.ts
+++ b/js/app/packages/app/component/next-soup/utils.ts
@@ -28,6 +28,9 @@ import {
 import { match } from 'ts-pattern';
 import { isAfter } from 'date-fns';
 import { getChannelParams } from '@block-channel/utils/link';
+import { compositeEntity, type NotificationSource } from '@notifications';
+import { notificationServiceClient } from '@service-notification/client';
+import { notificationKeys } from '@queries/notification/keys';
 
 const mergeSearchEntities = <T extends EntityData>(
   first: WithSearch<T>,
@@ -568,6 +571,155 @@ export function trashEmails(ids: string[]): TrashEmailsHandle {
           queryKey: queryKeys.all.email,
           refetchType: 'none',
         });
+      }
+    },
+  };
+}
+
+export type MarkDoneHandle = {
+  /** Fire-and-forget promise for the API calls. Rejects on failure (rolls back optimistic update). */
+  done: Promise<void>;
+  /** Reverses the mark-done: restores caches and calls the undone APIs. */
+  undo: () => Promise<void>;
+};
+
+type NotificationCacheData = {
+  pages: { items: { id: string }[] }[];
+};
+
+/**
+ * Optimistically marks entities as done (archives emails, clears notifications),
+ * then fires the API calls in the background. Returns synchronously so the caller
+ * can show the undo toast immediately.
+ */
+export function markEntitiesDone(args: {
+  entities: EntityData[];
+  notificationSource: NotificationSource;
+}): MarkDoneHandle {
+  const { entities, notificationSource } = args;
+
+  const emailIds = entities.filter((e) => e.type === 'email').map((e) => e.id);
+  const emailIdSet = new Set(emailIds);
+
+  const notificationIds = entities.flatMap((entity) =>
+    (
+      notificationSource.notificationsByEntity()[compositeEntity(entity)] ?? []
+    ).map((n) => n.id)
+  );
+  const notificationIdSet = new Set(notificationIds);
+
+  queryClient.cancelQueries({ queryKey: queryKeys.all.email });
+  queryClient.cancelQueries({ queryKey: notificationKeys.user._def });
+
+  const previousEmail = queryClient.getQueriesData<{
+    pages: { items: EntityData[] }[];
+  }>({
+    queryKey: queryKeys.all.email,
+  });
+  const previousNotifications =
+    queryClient.getQueriesData<NotificationCacheData>({
+      queryKey: notificationKeys.user._def,
+    });
+
+  const soupTxn = emailIds.length > 0 ? removeSoupEntities(emailIdSet) : null;
+
+  for (const [key, data] of previousEmail) {
+    if (!data) continue;
+    queryClient.setQueryData(key, {
+      ...data,
+      pages: data.pages.map((page) => ({
+        ...page,
+        items: page.items.filter((item) => !emailIdSet.has(item.id)),
+      })),
+    });
+  }
+
+  for (const [key, data] of previousNotifications) {
+    if (!data) continue;
+    queryClient.setQueryData(key, {
+      ...data,
+      pages: data.pages.map((page) => ({
+        ...page,
+        items: page.items.filter((item) => !notificationIdSet.has(item.id)),
+      })),
+    });
+  }
+
+  const rollback = () => {
+    soupTxn?.rollback();
+    for (const [key, data] of previousEmail) {
+      queryClient.setQueryData(key, data);
+    }
+    for (const [key, data] of previousNotifications) {
+      queryClient.setQueryData(key, data);
+    }
+  };
+
+  const done = (async () => {
+    try {
+      await Promise.all([
+        ...emailIds.map((id) => emailClient.flagArchived({ value: true, id })),
+        notificationIds.length > 0
+          ? throwOnErr(
+              async () =>
+                await notificationServiceClient.bulkMarkNotificationAsDone({
+                  notificationIds,
+                })
+            )
+          : Promise.resolve(),
+      ]);
+    } catch (err) {
+      rollback();
+      throw err;
+    } finally {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: queryKeys.all.email }),
+        queryClient.invalidateQueries({
+          queryKey: notificationKeys.user._def,
+        }),
+        ...emailIds.map((id) => invalidateSoupEntity(id)),
+      ]);
+    }
+  })();
+
+  return {
+    done,
+    undo: async () => {
+      // Wait for the mark-done calls to finish. If they failed, rollback
+      // already happened — nothing to undo.
+      try {
+        await done;
+      } catch {
+        return;
+      }
+
+      rollback();
+
+      try {
+        await Promise.all([
+          ...emailIds.map((id) =>
+            emailClient.flagArchived({ value: false, id })
+          ),
+          notificationIds.length > 0
+            ? throwOnErr(
+                async () =>
+                  await notificationServiceClient.bulkMarkNotificationAsUndone({
+                    notificationIds,
+                  })
+              )
+            : Promise.resolve(),
+        ]);
+      } finally {
+        await Promise.all([
+          queryClient.invalidateQueries({
+            queryKey: queryKeys.all.email,
+            refetchType: 'none',
+          }),
+          queryClient.invalidateQueries({
+            queryKey: notificationKeys.user._def,
+            refetchType: 'none',
+          }),
+        ]);
       }
     },
   };

--- a/js/app/packages/app/component/next-soup/utils.ts
+++ b/js/app/packages/app/component/next-soup/utils.ts
@@ -33,7 +33,10 @@ import {
   type NotificationSource,
   setDoneOverride,
 } from '@notifications';
-import { notificationServiceClient } from '@service-notification/client';
+import {
+  bulkMarkNotificationsAsDone,
+  bulkMarkNotificationsAsUndone,
+} from '@queries/notification/user-notifications';
 import { notificationKeys } from '@queries/notification/keys';
 
 const mergeSearchEntities = <T extends EntityData>(
@@ -585,10 +588,12 @@ export function trashEmails(ids: string[]): TrashEmailsHandle {
 }
 
 export type MarkEntitiesDoneContext = {
-  /** Reverses the optimistic cache writes. Safe to call multiple times. */
+  /** Clears optimistic state — use for mark-done failure (cache is pre-mutation). */
   rollback: () => void;
-  /** Re-applies the optimistic cache writes with a fresh soup transaction. */
+  /** Re-applies the optimistic done state. Use for redo / undo failure. */
   reapply: () => void;
+  /** Reverts email/soup caches and forces `done=false` override. Use for undo. */
+  applyUndone: () => void;
 };
 
 /**
@@ -695,9 +700,18 @@ export function applyEntitiesDoneOptimistic(args: {
     setDoneOverride(notificationIds, undefined);
   };
 
+  const applyUndone = () => {
+    soupTxn?.rollback();
+    soupTxn = null;
+    restoreEmailCache();
+    // Force `done=false` — cache may have reconciled to `done=true` from the
+    // server, so clearing the override would leave the UI hidden after undo.
+    setDoneOverride(notificationIds, false);
+  };
+
   reapply();
 
-  return { rollback, reapply };
+  return { rollback, reapply, applyUndone };
 }
 
 /**
@@ -722,12 +736,7 @@ export async function executeMarkEntitiesDone(args: {
       )
     ),
     notificationIds.length > 0
-      ? throwOnErr(
-          async () =>
-            await notificationServiceClient.bulkMarkNotificationAsDone({
-              notificationIds,
-            })
-        )
+      ? bulkMarkNotificationsAsDone(notificationIds)
       : Promise.resolve(),
   ]);
 
@@ -780,12 +789,7 @@ export async function executeMarkEntitiesUndone(args: {
       )
     ),
     notificationIds.length > 0
-      ? throwOnErr(
-          async () =>
-            await notificationServiceClient.bulkMarkNotificationAsUndone({
-              notificationIds,
-            })
-        )
+      ? bulkMarkNotificationsAsUndone(notificationIds)
       : Promise.resolve(),
   ]);
 

--- a/js/app/packages/app/component/next-soup/utils.ts
+++ b/js/app/packages/app/component/next-soup/utils.ts
@@ -672,10 +672,17 @@ export function markEntitiesDone(args: {
       rollback();
       throw err;
     } finally {
+      // Cache is already consistent via the optimistic update (or rollback on
+      // failure). Skip refetches — invalidating the infinite notification
+      // query would otherwise re-fetch every cached page.
       await Promise.all([
-        queryClient.invalidateQueries({ queryKey: queryKeys.all.email }),
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.all.email,
+          refetchType: 'none',
+        }),
         queryClient.invalidateQueries({
           queryKey: notificationKeys.user._def,
+          refetchType: 'none',
         }),
         ...emailIds.map((id) => invalidateSoupEntity(id)),
       ]);

--- a/js/app/packages/app/component/next-soup/utils.ts
+++ b/js/app/packages/app/component/next-soup/utils.ts
@@ -593,8 +593,9 @@ export type MarkDoneHandle = {
 
 /**
  * Optimistically marks entities as done (archives emails, clears notifications),
- * then fires the API calls in the background. Returns synchronously so the caller
- * can show the undo toast immediately.
+ * then fires the API calls in the background. Awaits `cancelQueries` so a stale
+ * in-flight fetch can't clobber the optimistic update, then returns a handle
+ * the caller can hold onto for the undo toast.
  */
 export async function markEntitiesDone(args: {
   entities: EntityData[];
@@ -671,11 +672,13 @@ export async function markEntitiesDone(args: {
           ...current,
           pages: current.pages.map((page, idx) => {
             const filtered = page.items.filter((i) => !restoredIds.has(i.id));
-            return idx === 0
-              ? { ...page, items: [...toRestore, ...filtered] }
-              : filtered.length === page.items.length
-                ? page
-                : { ...page, items: filtered };
+            if (idx === 0) {
+              return { ...page, items: [...toRestore, ...filtered] };
+            }
+            if (filtered.length === page.items.length) {
+              return page;
+            }
+            return { ...page, items: filtered };
           }),
         };
       });

--- a/js/app/packages/core/component/Toast/Toast.tsx
+++ b/js/app/packages/core/component/Toast/Toast.tsx
@@ -165,10 +165,19 @@ function success(
   message: string,
   subtext?: string,
   actions?: ToastAction[],
-  duration?: number
+  duration?: number,
+  /** When true, bypasses the 3s dedupe so repeated calls stack instead of replacing. */
+  stack?: boolean
 ): number | undefined {
-  dismissIfRecent(message, ToastType.SUCCESS);
-  return createToast(message, ToastType.SUCCESS, subtext, actions, duration);
+  if (!stack) dismissIfRecent(message, ToastType.SUCCESS);
+  return createToast(
+    message,
+    ToastType.SUCCESS,
+    subtext,
+    actions,
+    duration,
+    stack
+  );
 }
 
 function dismiss(toastId: number) {
@@ -468,18 +477,17 @@ function createToast(
   actions?: ToastAction[],
   // When undefined, the toast auto-dismisses after a default delay but shows NO progress bar.
   // When explicitly set, the toast uses that duration AND shows the progress bar.
-  duration?: number
+  duration?: number,
+  /** Skip recentToasts tracking so this toast never dedupes against a future call. */
+  stack?: boolean
 ) {
-  const key = createToastKey(message, toastType);
-
-  const existingToast = recentToasts.get(key);
-  if (existingToast?.timeoutId) {
-    clearTimeout(existingToast.timeoutId);
+  if (!stack) {
+    const key = createToastKey(message, toastType);
+    const existingToast = recentToasts.get(key);
+    if (existingToast?.timeoutId) {
+      clearTimeout(existingToast.timeoutId);
+    }
   }
-
-  const timeoutId = setTimeout(() => {
-    recentToasts.delete(key);
-  }, THROTTLE_DURATION);
 
   const toastId = toaster.show(
     (props) => (
@@ -497,15 +505,21 @@ function createToast(
     { region: 'toast-region' }
   );
 
-  recentToasts.set(key, {
-    message,
-    toastType,
-    timestamp: Date.now(),
-    timeoutId,
-    toastId,
-    subtext,
-    actions,
-  });
+  if (!stack) {
+    const key = createToastKey(message, toastType);
+    const timeoutId = setTimeout(() => {
+      recentToasts.delete(key);
+    }, THROTTLE_DURATION);
+    recentToasts.set(key, {
+      message,
+      toastType,
+      timestamp: Date.now(),
+      timeoutId,
+      toastId,
+      subtext,
+      actions,
+    });
+  }
 
   return toastId;
 }

--- a/js/app/packages/core/component/Toast/Toast.tsx
+++ b/js/app/packages/core/component/Toast/Toast.tsx
@@ -189,26 +189,22 @@ function alert(message: string, subtext?: string, duration?: number) {
 
 // ─── Shared actions row ──────────────────────────────────────────────────────
 
-function ActionsRow(props: { actions: ToastAction[] }) {
+function ActionButtons(props: { actions: ToastAction[] }) {
   return (
-    <div class="flex flex-row flex-wrap justify-end gap-2 mt-2">
-      <For each={props.actions}>
-        {(action) => (
-          <Button
-            onClick={action.onClick}
-            variant="secondary"
-            class="flex items-center gap-1.5 rounded py-1.5 px-3 text-sm font-semibold"
-          >
-            <Show when={action.icon}>
-              {(icon) => (
-                <Dynamic component={icon()} class="size-3.5 shrink-0" />
-              )}
-            </Show>
-            {action.label}
-          </Button>
-        )}
-      </For>
-    </div>
+    <For each={props.actions}>
+      {(action) => (
+        <Button
+          onClick={action.onClick}
+          variant="secondary"
+          class="flex items-center gap-1.5 rounded py-1 px-2 text-sm font-semibold shrink-0"
+        >
+          <Show when={action.icon}>
+            {(icon) => <Dynamic component={icon()} class="size-3.5 shrink-0" />}
+          </Show>
+          {action.label}
+        </Button>
+      )}
+    </For>
   );
 }
 
@@ -335,6 +331,9 @@ function ToastContent(props: {
                   <Toast.Title class="font-semibold text-ink grow shrink truncate">
                     {customConfig().title}
                   </Toast.Title>
+                  <Show when={customConfig().actions?.length}>
+                    <ActionButtons actions={customConfig().actions!} />
+                  </Show>
                   <Toast.CloseButton>
                     <Button variant="ghost" size="icon-sm" class="rounded-xs">
                       <XIcon />
@@ -343,9 +342,6 @@ function ToastContent(props: {
                 </div>
                 <Show when={customConfig().content}>
                   <div class="my-2 ml-7">{customConfig().content?.()}</div>
-                </Show>
-                <Show when={customConfig().actions?.length}>
-                  <ActionsRow actions={customConfig().actions!} />
                 </Show>
               </>
             )}
@@ -373,6 +369,9 @@ function ToastContent(props: {
                   <Toast.Title class="font-semibold text-ink grow shrink truncate">
                     {props.message}
                   </Toast.Title>
+                  <Show when={props.actions?.length}>
+                    <ActionButtons actions={props.actions!} />
+                  </Show>
                   <Toast.CloseButton>
                     <Button variant="ghost" size="icon-sm" class="rounded-xs">
                       <XIcon />
@@ -383,9 +382,6 @@ function ToastContent(props: {
                   <Toast.Description class="text-sm text-ink-extra-muted ml-7">
                     {props.subtext}
                   </Toast.Description>
-                </Show>
-                <Show when={props.actions?.length}>
-                  <ActionsRow actions={props.actions!} />
                 </Show>
               </>
             )}

--- a/js/app/packages/entity/src/extractors-notification/mobile-notification-stacks.tsx
+++ b/js/app/packages/entity/src/extractors-notification/mobile-notification-stacks.tsx
@@ -3,11 +3,8 @@ import { reconcile, createStore } from 'solid-js/store';
 import {
   type NotificationStack,
   getMostRecentNotification,
-  getAllNotificationsFromGroup,
-  markNotificationsDone,
   openNotification,
 } from '@notifications';
-import ArrowCounterClockwise from '@phosphor-icons/core/regular/arrow-counter-clockwise.svg?component-solid';
 import { globalSplitManager } from '@app/signal/splitLayout';
 import type { WithNotification } from '../types/notification';
 import { isChannelEntity, type EntityData } from '../types/entity';
@@ -17,9 +14,8 @@ import { Entity } from '../entity';
 import { UnreadIndicator } from '../components/UnreadIndicator';
 import { EntityRow, EntityRowContext } from '@app/component/mobile/EntityRow';
 import { useGlobalNotificationSource } from '@app/component/GlobalAppState';
-import { toast } from '@core/component/Toast/Toast';
-import { useMutationUndoContext } from '@queries/undo';
 import { cn } from '@ui/utils/classname';
+import { useNotificationStackActions } from './notification-actions';
 import { NotificationContent } from './notification-content';
 import { NotificationTimestamp } from './notification-timestamp';
 
@@ -91,39 +87,15 @@ function MobileStackRow(props: {
 }) {
   const ctx = useContext(EntityRowContext);
   const notificationSource = useGlobalNotificationSource();
-  const undoCtx = useMutationUndoContext();
+  const { markStackAsDone } = useNotificationStackActions({
+    stack: props.stack,
+  });
   const stackEntityId = () => getMostRecentNotification(props.stack).id;
   const unread = () => isNotificationUnread(props.stack);
 
   const handleSwipeLeft = async () => {
     await ctx?.collapseEntity(stackEntityId());
-
-    const notifications = getAllNotificationsFromGroup(props.stack);
-    const handle = markNotificationsDone(notifications.map((n) => n.id));
-
-    undoCtx.pushUndo({ undo: handle.undo, label: 'Mark Done' });
-
-    const toastId = toast.success(
-      'Marked as done',
-      undefined,
-      [
-        {
-          label: 'Undo',
-          icon: ArrowCounterClockwise,
-          onClick: () => {
-            if (toastId != null) toast.dismiss(toastId);
-            undoCtx.undo({
-              onError: () => toast.failure('Failed to undo'),
-            });
-          },
-        },
-      ],
-      10_000
-    );
-
-    handle.done.catch(() => {
-      toast.failure('Failed to mark as done');
-    });
+    markStackAsDone();
   };
 
   const handleClick = async (e: MouseEvent) => {

--- a/js/app/packages/entity/src/extractors-notification/mobile-notification-stacks.tsx
+++ b/js/app/packages/entity/src/extractors-notification/mobile-notification-stacks.tsx
@@ -108,10 +108,7 @@ function MobileStackRow(props: {
           icon: ArrowCounterClockwise,
           onClick: () => {
             if (toastId != null) toast.dismiss(toastId);
-            handle.undo().then(
-              () => toast.success('Undone'),
-              () => toast.failure('Failed to undo')
-            );
+            handle.undo().catch(() => toast.failure('Failed to undo'));
           },
         },
       ],

--- a/js/app/packages/entity/src/extractors-notification/mobile-notification-stacks.tsx
+++ b/js/app/packages/entity/src/extractors-notification/mobile-notification-stacks.tsx
@@ -18,6 +18,7 @@ import { UnreadIndicator } from '../components/UnreadIndicator';
 import { EntityRow, EntityRowContext } from '@app/component/mobile/EntityRow';
 import { useGlobalNotificationSource } from '@app/component/GlobalAppState';
 import { toast } from '@core/component/Toast/Toast';
+import { useMutationUndoContext } from '@queries/undo';
 import { cn } from '@ui/utils/classname';
 import { NotificationContent } from './notification-content';
 import { NotificationTimestamp } from './notification-timestamp';
@@ -90,6 +91,7 @@ function MobileStackRow(props: {
 }) {
   const ctx = useContext(EntityRowContext);
   const notificationSource = useGlobalNotificationSource();
+  const undoCtx = useMutationUndoContext();
   const stackEntityId = () => getMostRecentNotification(props.stack).id;
   const unread = () => isNotificationUnread(props.stack);
 
@@ -98,6 +100,8 @@ function MobileStackRow(props: {
 
     const notifications = getAllNotificationsFromGroup(props.stack);
     const handle = markNotificationsDone(notifications.map((n) => n.id));
+
+    undoCtx.pushUndo({ undo: handle.undo, label: 'Mark Done' });
 
     const toastId = toast.success(
       'Marked as done',
@@ -108,7 +112,9 @@ function MobileStackRow(props: {
           icon: ArrowCounterClockwise,
           onClick: () => {
             if (toastId != null) toast.dismiss(toastId);
-            handle.undo().catch(() => toast.failure('Failed to undo'));
+            undoCtx.undo({
+              onError: () => toast.failure('Failed to undo'),
+            });
           },
         },
       ],

--- a/js/app/packages/entity/src/extractors-notification/mobile-notification-stacks.tsx
+++ b/js/app/packages/entity/src/extractors-notification/mobile-notification-stacks.tsx
@@ -4,8 +4,10 @@ import {
   type NotificationStack,
   getMostRecentNotification,
   getAllNotificationsFromGroup,
+  markNotificationsDone,
   openNotification,
 } from '@notifications';
+import ArrowCounterClockwise from '@phosphor-icons/core/regular/arrow-counter-clockwise.svg?component-solid';
 import { globalSplitManager } from '@app/signal/splitLayout';
 import type { WithNotification } from '../types/notification';
 import { isChannelEntity, type EntityData } from '../types/entity';
@@ -93,10 +95,32 @@ function MobileStackRow(props: {
 
   const handleSwipeLeft = async () => {
     await ctx?.collapseEntity(stackEntityId());
-    void notificationSource.bulkMarkAsDone(
-      getAllNotificationsFromGroup(props.stack)
+
+    const notifications = getAllNotificationsFromGroup(props.stack);
+    const handle = markNotificationsDone(notifications.map((n) => n.id));
+
+    const toastId = toast.success(
+      'Marked as done',
+      undefined,
+      [
+        {
+          label: 'Undo',
+          icon: ArrowCounterClockwise,
+          onClick: () => {
+            if (toastId != null) toast.dismiss(toastId);
+            handle.undo().then(
+              () => toast.success('Undone'),
+              () => toast.failure('Failed to undo')
+            );
+          },
+        },
+      ],
+      10_000
     );
-    toast.success('Marked as done');
+
+    handle.done.catch(() => {
+      toast.failure('Failed to mark as done');
+    });
   };
 
   const handleClick = async (e: MouseEvent) => {

--- a/js/app/packages/entity/src/extractors-notification/notification-actions.tsx
+++ b/js/app/packages/entity/src/extractors-notification/notification-actions.tsx
@@ -67,7 +67,8 @@ export function useNotificationStackActions(props: NotificationActionsProps) {
               },
             },
           ],
-          10_000
+          10_000,
+          true
         );
         context?.setSuccessToastId(toastId);
         props.onMarkAsDone?.();

--- a/js/app/packages/entity/src/extractors-notification/notification-actions.tsx
+++ b/js/app/packages/entity/src/extractors-notification/notification-actions.tsx
@@ -63,8 +63,6 @@ export function useNotificationStackActions(props: NotificationActionsProps) {
               icon: ArrowCounterClockwise,
               onClick: () => {
                 if (toastId != null) toast.dismiss(toastId);
-                // Invoke this action's own undo so older toasts don't pop
-                // newer entries off the global undo stack.
                 handle?.undo().catch(() => toast.failure('Failed to undo'));
               },
             },

--- a/js/app/packages/entity/src/extractors-notification/notification-actions.tsx
+++ b/js/app/packages/entity/src/extractors-notification/notification-actions.tsx
@@ -11,6 +11,7 @@ import {
 } from '@notifications';
 import { useUndoableMutation } from '@queries/undo';
 import { useGlobalNotificationSource } from '@app/component/GlobalAppState';
+import { restoreSoupFocus } from '@app/component/next-soup/utils';
 
 interface NotificationActionsProps {
   stack: NotificationStack;
@@ -64,6 +65,7 @@ export function useNotificationStackActions(props: NotificationActionsProps) {
               onClick: () => {
                 if (toastId != null) toast.dismiss(toastId);
                 handle?.undo().catch(() => toast.failure('Failed to undo'));
+                restoreSoupFocus();
               },
             },
           ],

--- a/js/app/packages/entity/src/extractors-notification/notification-actions.tsx
+++ b/js/app/packages/entity/src/extractors-notification/notification-actions.tsx
@@ -1,6 +1,12 @@
-import type { NotificationStack } from '@notifications';
-import type { UnifiedNotification } from '@notifications';
-import { getAllNotificationsFromGroup } from '@notifications';
+import type {
+  MarkNotificationsDoneHandle,
+  NotificationStack,
+  UnifiedNotification,
+} from '@notifications';
+import {
+  getAllNotificationsFromGroup,
+  markNotificationsDone,
+} from '@notifications';
 import { useGlobalNotificationSource } from '@app/component/GlobalAppState';
 
 interface NotificationActionsProps {
@@ -18,10 +24,11 @@ interface SingleNotificationActionsProps {
 export function useNotificationStackActions(props: NotificationActionsProps) {
   const notificationSource = useGlobalNotificationSource();
 
-  const markStackAsDone = async () => {
+  const markStackAsDone = (): MarkNotificationsDoneHandle => {
     const notifications = getAllNotificationsFromGroup(props.stack);
-    await notificationSource.bulkMarkAsDone(notifications);
+    const handle = markNotificationsDone(notifications.map((n) => n.id));
     props.onMarkAsDone?.();
+    return handle;
   };
 
   const markStackAsRead = async () => {

--- a/js/app/packages/entity/src/extractors-notification/notification-actions.tsx
+++ b/js/app/packages/entity/src/extractors-notification/notification-actions.tsx
@@ -74,6 +74,9 @@ export function useNotificationStackActions(props: NotificationActionsProps) {
         context?.setSuccessToastId(toastId);
         props.onMarkAsDone?.();
       },
+      onError: () => {
+        toast.failure('Failed to mark as done');
+      },
       undoFn: async (_variables, context) => {
         await context?.handle.undo();
       },

--- a/js/app/packages/entity/src/extractors-notification/notification-actions.tsx
+++ b/js/app/packages/entity/src/extractors-notification/notification-actions.tsx
@@ -38,9 +38,7 @@ export function useNotificationStackActions(props: NotificationActionsProps) {
       mutationFn: async () => {},
       onMutate: async () => {
         const notifications = getAllNotificationsFromGroup(props.stack);
-        const handle = await markNotificationsDone(
-          notifications.map((n) => n.id)
-        );
+        const handle = markNotificationsDone(notifications.map((n) => n.id));
         let successToastId: number | undefined;
         handle.done.catch(() => {
           if (successToastId != null) toast.dismiss(successToastId);

--- a/js/app/packages/entity/src/extractors-notification/notification-actions.tsx
+++ b/js/app/packages/entity/src/extractors-notification/notification-actions.tsx
@@ -1,13 +1,10 @@
 import ArrowCounterClockwise from '@phosphor-icons/core/regular/arrow-counter-clockwise.svg?component-solid';
 import { toast } from '@core/component/Toast/Toast';
-import type {
-  MarkNotificationsDoneHandle,
-  NotificationStack,
-  UnifiedNotification,
-} from '@notifications';
+import type { NotificationStack, UnifiedNotification } from '@notifications';
 import {
+  executeMarkNotificationsDone,
+  executeMarkNotificationsUndone,
   getAllNotificationsFromGroup,
-  markNotificationsDone,
 } from '@notifications';
 import { useUndoableMutation } from '@queries/undo';
 import { useGlobalNotificationSource } from '@app/component/GlobalAppState';
@@ -25,34 +22,16 @@ interface SingleNotificationActionsProps {
   onMarkAsRead?: () => void;
 }
 
-type MarkStackDoneContext = {
-  handle: MarkNotificationsDoneHandle;
-  setSuccessToastId: (id: number | undefined) => void;
-};
+type MarkStackDoneVariables = { notificationIds: string[] };
 
 export function useNotificationStackActions(props: NotificationActionsProps) {
   const notificationSource = useGlobalNotificationSource();
 
-  const mutation = useUndoableMutation<void, Error, void, MarkStackDoneContext>(
+  const mutation = useUndoableMutation<void, Error, MarkStackDoneVariables>(
     () => ({
-      mutationFn: async () => {},
-      onMutate: async () => {
-        const notifications = getAllNotificationsFromGroup(props.stack);
-        const handle = markNotificationsDone(notifications.map((n) => n.id));
-        let successToastId: number | undefined;
-        handle.done.catch(() => {
-          if (successToastId != null) toast.dismiss(successToastId);
-          toast.failure('Failed to mark as done');
-        });
-        return {
-          handle,
-          setSuccessToastId: (id) => {
-            successToastId = id;
-          },
-        };
-      },
-      onSuccess: (_data, _variables, context) => {
-        const handle = context?.handle;
+      mutationFn: async (vars) =>
+        await executeMarkNotificationsDone(vars.notificationIds),
+      onSuccess: (_data, vars) => {
         const toastId = toast.success(
           'Marked as done',
           undefined,
@@ -62,7 +41,9 @@ export function useNotificationStackActions(props: NotificationActionsProps) {
               icon: ArrowCounterClockwise,
               onClick: () => {
                 if (toastId != null) toast.dismiss(toastId);
-                handle?.undo().catch(() => toast.failure('Failed to undo'));
+                executeMarkNotificationsUndone(vars.notificationIds).catch(() =>
+                  toast.failure('Failed to undo')
+                );
                 restoreSoupFocus();
               },
             },
@@ -70,21 +51,22 @@ export function useNotificationStackActions(props: NotificationActionsProps) {
           10_000,
           true
         );
-        context?.setSuccessToastId(toastId);
         props.onMarkAsDone?.();
       },
       onError: () => {
         toast.failure('Failed to mark as done');
       },
-      undoFn: async (_variables, context) => {
-        await context?.handle.undo();
-      },
+      undoFn: async (vars) =>
+        await executeMarkNotificationsUndone(vars.notificationIds),
+      redoFn: async (vars) =>
+        await executeMarkNotificationsDone(vars.notificationIds),
       undoLabel: 'Mark Done',
     })
   );
 
   const markStackAsDone = () => {
-    mutation.mutate();
+    const notifications = getAllNotificationsFromGroup(props.stack);
+    mutation.mutate({ notificationIds: notifications.map((n) => n.id) });
   };
 
   const markStackAsRead = async () => {

--- a/js/app/packages/entity/src/extractors-notification/notification-actions.tsx
+++ b/js/app/packages/entity/src/extractors-notification/notification-actions.tsx
@@ -9,7 +9,7 @@ import {
   getAllNotificationsFromGroup,
   markNotificationsDone,
 } from '@notifications';
-import { useMutationUndoContext, useUndoableMutation } from '@queries/undo';
+import { useUndoableMutation } from '@queries/undo';
 import { useGlobalNotificationSource } from '@app/component/GlobalAppState';
 
 interface NotificationActionsProps {
@@ -24,22 +24,36 @@ interface SingleNotificationActionsProps {
   onMarkAsRead?: () => void;
 }
 
-type MarkStackDoneContext = { handle: MarkNotificationsDoneHandle };
+type MarkStackDoneContext = {
+  handle: MarkNotificationsDoneHandle;
+  setSuccessToastId: (id: number | undefined) => void;
+};
 
 export function useNotificationStackActions(props: NotificationActionsProps) {
   const notificationSource = useGlobalNotificationSource();
-  const undoCtx = useMutationUndoContext();
 
   const mutation = useUndoableMutation<void, Error, void, MarkStackDoneContext>(
     () => ({
       mutationFn: async () => {},
-      onMutate: () => {
+      onMutate: async () => {
         const notifications = getAllNotificationsFromGroup(props.stack);
-        const handle = markNotificationsDone(notifications.map((n) => n.id));
-        handle.done.catch(() => toast.failure('Failed to mark as done'));
-        return { handle };
+        const handle = await markNotificationsDone(
+          notifications.map((n) => n.id)
+        );
+        let successToastId: number | undefined;
+        handle.done.catch(() => {
+          if (successToastId != null) toast.dismiss(successToastId);
+          toast.failure('Failed to mark as done');
+        });
+        return {
+          handle,
+          setSuccessToastId: (id) => {
+            successToastId = id;
+          },
+        };
       },
-      onSuccess: () => {
+      onSuccess: (_data, _variables, context) => {
+        const handle = context?.handle;
         const toastId = toast.success(
           'Marked as done',
           undefined,
@@ -49,14 +63,15 @@ export function useNotificationStackActions(props: NotificationActionsProps) {
               icon: ArrowCounterClockwise,
               onClick: () => {
                 if (toastId != null) toast.dismiss(toastId);
-                undoCtx.undo({
-                  onError: () => toast.failure('Failed to undo'),
-                });
+                // Invoke this action's own undo so older toasts don't pop
+                // newer entries off the global undo stack.
+                handle?.undo().catch(() => toast.failure('Failed to undo'));
               },
             },
           ],
           10_000
         );
+        context?.setSuccessToastId(toastId);
         props.onMarkAsDone?.();
       },
       undoFn: async (_variables, context) => {

--- a/js/app/packages/entity/src/extractors-notification/notification-actions.tsx
+++ b/js/app/packages/entity/src/extractors-notification/notification-actions.tsx
@@ -1,3 +1,5 @@
+import ArrowCounterClockwise from '@phosphor-icons/core/regular/arrow-counter-clockwise.svg?component-solid';
+import { toast } from '@core/component/Toast/Toast';
 import type {
   MarkNotificationsDoneHandle,
   NotificationStack,
@@ -7,6 +9,7 @@ import {
   getAllNotificationsFromGroup,
   markNotificationsDone,
 } from '@notifications';
+import { useMutationUndoContext, useUndoableMutation } from '@queries/undo';
 import { useGlobalNotificationSource } from '@app/component/GlobalAppState';
 
 interface NotificationActionsProps {
@@ -21,14 +24,50 @@ interface SingleNotificationActionsProps {
   onMarkAsRead?: () => void;
 }
 
+type MarkStackDoneContext = { handle: MarkNotificationsDoneHandle };
+
 export function useNotificationStackActions(props: NotificationActionsProps) {
   const notificationSource = useGlobalNotificationSource();
+  const undoCtx = useMutationUndoContext();
 
-  const markStackAsDone = (): MarkNotificationsDoneHandle => {
-    const notifications = getAllNotificationsFromGroup(props.stack);
-    const handle = markNotificationsDone(notifications.map((n) => n.id));
-    props.onMarkAsDone?.();
-    return handle;
+  const mutation = useUndoableMutation<void, Error, void, MarkStackDoneContext>(
+    () => ({
+      mutationFn: async () => {},
+      onMutate: () => {
+        const notifications = getAllNotificationsFromGroup(props.stack);
+        const handle = markNotificationsDone(notifications.map((n) => n.id));
+        handle.done.catch(() => toast.failure('Failed to mark as done'));
+        return { handle };
+      },
+      onSuccess: () => {
+        const toastId = toast.success(
+          'Marked as done',
+          undefined,
+          [
+            {
+              label: 'Undo',
+              icon: ArrowCounterClockwise,
+              onClick: () => {
+                if (toastId != null) toast.dismiss(toastId);
+                undoCtx.undo({
+                  onError: () => toast.failure('Failed to undo'),
+                });
+              },
+            },
+          ],
+          10_000
+        );
+        props.onMarkAsDone?.();
+      },
+      undoFn: async (_variables, context) => {
+        await context?.handle.undo();
+      },
+      undoLabel: 'Mark Done',
+    })
+  );
+
+  const markStackAsDone = () => {
+    mutation.mutate();
   };
 
   const markStackAsRead = async () => {

--- a/js/app/packages/entity/src/extractors-notification/notification-actions.tsx
+++ b/js/app/packages/entity/src/extractors-notification/notification-actions.tsx
@@ -6,7 +6,7 @@ import {
   executeMarkNotificationsUndone,
   getAllNotificationsFromGroup,
 } from '@notifications';
-import { useUndoableMutation } from '@queries/undo';
+import { useMutationUndoContext, useUndoableMutation } from '@queries/undo';
 import { useGlobalNotificationSource } from '@app/component/GlobalAppState';
 import { restoreSoupFocus } from '@app/component/next-soup/utils';
 
@@ -26,12 +26,13 @@ type MarkStackDoneVariables = { notificationIds: string[] };
 
 export function useNotificationStackActions(props: NotificationActionsProps) {
   const notificationSource = useGlobalNotificationSource();
+  const undoCtx = useMutationUndoContext();
 
   const mutation = useUndoableMutation<void, Error, MarkStackDoneVariables>(
     () => ({
       mutationFn: async (vars) =>
         await executeMarkNotificationsDone(vars.notificationIds),
-      onSuccess: (_data, vars) => {
+      onSuccess: () => {
         const toastId = toast.success(
           'Marked as done',
           undefined,
@@ -41,9 +42,9 @@ export function useNotificationStackActions(props: NotificationActionsProps) {
               icon: ArrowCounterClockwise,
               onClick: () => {
                 if (toastId != null) toast.dismiss(toastId);
-                executeMarkNotificationsUndone(vars.notificationIds).catch(() =>
-                  toast.failure('Failed to undo')
-                );
+                undoCtx.undo({
+                  onError: () => toast.failure('Failed to undo'),
+                });
                 restoreSoupFocus();
               },
             },

--- a/js/app/packages/entity/src/extractors-notification/notification-stacks.tsx
+++ b/js/app/packages/entity/src/extractors-notification/notification-stacks.tsx
@@ -86,10 +86,7 @@ function NotificationStackRow(props: {
           icon: ArrowCounterClockwise,
           onClick: () => {
             if (toastId != null) toast.dismiss(toastId);
-            handle.undo().then(
-              () => toast.success('Undone'),
-              () => toast.failure('Failed to undo')
-            );
+            handle.undo().catch(() => toast.failure('Failed to undo'));
           },
         },
       ],

--- a/js/app/packages/entity/src/extractors-notification/notification-stacks.tsx
+++ b/js/app/packages/entity/src/extractors-notification/notification-stacks.tsx
@@ -4,9 +4,7 @@ import { ContextMenuContent, MenuItem } from '@core/component/Menu';
 import { toast } from '@core/component/Toast/Toast';
 import { buildSimpleEntityUrl } from '@core/util/url';
 import CheckIcon from '@icon/regular/check.svg';
-import ArrowCounterClockwise from '@phosphor-icons/core/regular/arrow-counter-clockwise.svg?component-solid';
 import { ContextMenu } from '@kobalte/core/context-menu';
-import { useMutationUndoContext } from '@queries/undo';
 import {
   getChannelNotificationParams,
   getMostRecentNotification,
@@ -57,7 +55,6 @@ function NotificationStackRow(props: {
   content?: JSX.Element;
 }) {
   const notificationSource = useGlobalNotificationSource();
-  const undoCtx = useMutationUndoContext();
   const unread = () => isNotificationUnread(props.stack);
 
   const { markStackAsDone, markStackAsRead } = useNotificationStackActions({
@@ -77,31 +74,7 @@ function NotificationStackRow(props: {
 
   const handleMarkAsDone = (e?: PointerEvent | MouseEvent) => {
     e?.stopPropagation();
-    const handle = markStackAsDone();
-
-    undoCtx.pushUndo({ undo: handle.undo, label: 'Mark Done' });
-
-    const toastId = toast.success(
-      'Marked as done',
-      undefined,
-      [
-        {
-          label: 'Undo',
-          icon: ArrowCounterClockwise,
-          onClick: () => {
-            if (toastId != null) toast.dismiss(toastId);
-            undoCtx.undo({
-              onError: () => toast.failure('Failed to undo'),
-            });
-          },
-        },
-      ],
-      10_000
-    );
-
-    handle.done.catch(() => {
-      toast.failure('Failed to mark as done');
-    });
+    markStackAsDone();
   };
 
   const handleMarkAsRead = async () => {

--- a/js/app/packages/entity/src/extractors-notification/notification-stacks.tsx
+++ b/js/app/packages/entity/src/extractors-notification/notification-stacks.tsx
@@ -6,6 +6,7 @@ import { buildSimpleEntityUrl } from '@core/util/url';
 import CheckIcon from '@icon/regular/check.svg';
 import ArrowCounterClockwise from '@phosphor-icons/core/regular/arrow-counter-clockwise.svg?component-solid';
 import { ContextMenu } from '@kobalte/core/context-menu';
+import { useMutationUndoContext } from '@queries/undo';
 import {
   getChannelNotificationParams,
   getMostRecentNotification,
@@ -56,6 +57,7 @@ function NotificationStackRow(props: {
   content?: JSX.Element;
 }) {
   const notificationSource = useGlobalNotificationSource();
+  const undoCtx = useMutationUndoContext();
   const unread = () => isNotificationUnread(props.stack);
 
   const { markStackAsDone, markStackAsRead } = useNotificationStackActions({
@@ -77,6 +79,8 @@ function NotificationStackRow(props: {
     e?.stopPropagation();
     const handle = markStackAsDone();
 
+    undoCtx.pushUndo({ undo: handle.undo, label: 'Mark Done' });
+
     const toastId = toast.success(
       'Marked as done',
       undefined,
@@ -86,7 +90,9 @@ function NotificationStackRow(props: {
           icon: ArrowCounterClockwise,
           onClick: () => {
             if (toastId != null) toast.dismiss(toastId);
-            handle.undo().catch(() => toast.failure('Failed to undo'));
+            undoCtx.undo({
+              onError: () => toast.failure('Failed to undo'),
+            });
           },
         },
       ],

--- a/js/app/packages/entity/src/extractors-notification/notification-stacks.tsx
+++ b/js/app/packages/entity/src/extractors-notification/notification-stacks.tsx
@@ -4,6 +4,7 @@ import { ContextMenuContent, MenuItem } from '@core/component/Menu';
 import { toast } from '@core/component/Toast/Toast';
 import { buildSimpleEntityUrl } from '@core/util/url';
 import CheckIcon from '@icon/regular/check.svg';
+import ArrowCounterClockwise from '@phosphor-icons/core/regular/arrow-counter-clockwise.svg?component-solid';
 import { ContextMenu } from '@kobalte/core/context-menu';
 import {
   getChannelNotificationParams,
@@ -72,9 +73,32 @@ function NotificationStackRow(props: {
     props.onClick?.(e);
   };
 
-  const handleMarkAsDone = async (e?: PointerEvent | MouseEvent) => {
+  const handleMarkAsDone = (e?: PointerEvent | MouseEvent) => {
     e?.stopPropagation();
-    await markStackAsDone();
+    const handle = markStackAsDone();
+
+    const toastId = toast.success(
+      'Marked as done',
+      undefined,
+      [
+        {
+          label: 'Undo',
+          icon: ArrowCounterClockwise,
+          onClick: () => {
+            if (toastId != null) toast.dismiss(toastId);
+            handle.undo().then(
+              () => toast.success('Undone'),
+              () => toast.failure('Failed to undo')
+            );
+          },
+        },
+      ],
+      10_000
+    );
+
+    handle.done.catch(() => {
+      toast.failure('Failed to mark as done');
+    });
   };
 
   const handleMarkAsRead = async () => {

--- a/js/app/packages/notifications/index.ts
+++ b/js/app/packages/notifications/index.ts
@@ -21,6 +21,7 @@ export {
   createEffectOnEntityTypeNotification,
   entityHasUnreadNotifications,
   markNotificationForEntityIdAsRead,
+  markNotificationsDone,
   markNotificationsForEntityAsDone,
   markNotificationsForEntityAsRead,
   notificationIsOfEntity,
@@ -33,6 +34,7 @@ export {
   useUnreadEntityTypeNotifications,
   useUnreadNotifications,
 } from './notification-helpers';
+export type { MarkNotificationsDoneHandle } from './notification-helpers';
 export {
   getNotificationAction,
   getNotificationContent,

--- a/js/app/packages/notifications/index.ts
+++ b/js/app/packages/notifications/index.ts
@@ -68,7 +68,10 @@ export type {
 } from './notification-settings';
 export { useNotificationSettings } from './notification-settings';
 export type { NotificationSource } from './notification-source';
-export { createNotificationSource } from './notification-source';
+export {
+  createNotificationSource,
+  setDoneOverride,
+} from './notification-source';
 export type { NotificationStack } from './notification-stacking';
 export {
   getAllNotificationsFromGroup,

--- a/js/app/packages/notifications/index.ts
+++ b/js/app/packages/notifications/index.ts
@@ -20,8 +20,9 @@ export { createTabLeaderSignal } from './notification-election';
 export {
   createEffectOnEntityTypeNotification,
   entityHasUnreadNotifications,
+  executeMarkNotificationsDone,
+  executeMarkNotificationsUndone,
   markNotificationForEntityIdAsRead,
-  markNotificationsDone,
   markNotificationsForEntityAsDone,
   markNotificationsForEntityAsRead,
   notificationIsOfEntity,
@@ -34,7 +35,6 @@ export {
   useUnreadEntityTypeNotifications,
   useUnreadNotifications,
 } from './notification-helpers';
-export type { MarkNotificationsDoneHandle } from './notification-helpers';
 export {
   getNotificationAction,
   getNotificationContent,

--- a/js/app/packages/notifications/notification-helpers.ts
+++ b/js/app/packages/notifications/notification-helpers.ts
@@ -1,8 +1,10 @@
 import type { Entity, EntityType } from '@core/types';
-import { throwOnErr } from '@core/util/maybeResult';
 import { queryClient } from '@queries/client';
 import { notificationKeys } from '@queries/notification/keys';
-import { notificationServiceClient } from '@service-notification/client';
+import {
+  bulkMarkNotificationsAsDone,
+  bulkMarkNotificationsAsUndone,
+} from '@queries/notification/user-notifications';
 import { type Accessor, createEffect, createMemo, onCleanup } from 'solid-js';
 import { isMatching, P } from 'ts-pattern';
 import { CHANNEL_EVENT_TYPES, setDoneOverride } from './notification-source';
@@ -216,12 +218,7 @@ export async function executeMarkNotificationsDone(
   setDoneOverride(notificationIds, true);
   await queryClient.cancelQueries({ queryKey: notificationKeys.user._def });
   try {
-    await throwOnErr(
-      async () =>
-        await notificationServiceClient.bulkMarkNotificationAsDone({
-          notificationIds,
-        })
-    );
+    await bulkMarkNotificationsAsDone(notificationIds);
   } catch (err) {
     setDoneOverride(notificationIds, false);
     throw err;
@@ -244,12 +241,7 @@ export async function executeMarkNotificationsUndone(
   setDoneOverride(notificationIds, false);
   await queryClient.cancelQueries({ queryKey: notificationKeys.user._def });
   try {
-    await throwOnErr(
-      async () =>
-        await notificationServiceClient.bulkMarkNotificationAsUndone({
-          notificationIds,
-        })
-    );
+    await bulkMarkNotificationsAsUndone(notificationIds);
   } catch (err) {
     setDoneOverride(notificationIds, true);
     throw err;

--- a/js/app/packages/notifications/notification-helpers.ts
+++ b/js/app/packages/notifications/notification-helpers.ts
@@ -213,7 +213,7 @@ export type MarkNotificationsDoneHandle = {
 };
 
 type NotificationCacheData = {
-  pages: { items: { id: string }[] }[];
+  pages: { items: { id: string; done?: boolean }[] }[];
 };
 
 /**
@@ -226,28 +226,30 @@ export function markNotificationsDone(
 ): MarkNotificationsDoneHandle {
   queryClient.cancelQueries({ queryKey: notificationKeys.user._def });
 
-  const previousData = queryClient.getQueriesData<NotificationCacheData>({
-    queryKey: notificationKeys.user._def,
-  });
-
   const idSet = new Set(notificationIds);
 
-  for (const [key, data] of previousData) {
-    if (!data) continue;
-    queryClient.setQueryData(key, {
-      ...data,
-      pages: data.pages.map((page) => ({
-        ...page,
-        items: page.items.filter((item) => !idSet.has(item.id)),
-      })),
-    });
-  }
-
-  const rollback = () => {
-    for (const [key, data] of previousData) {
-      queryClient.setQueryData(key, data);
-    }
+  // Flip `done` on the targeted notifications in place. Touching only the
+  // specific items (instead of snapshotting and restoring the whole cache)
+  // keeps any concurrent websocket inserts intact.
+  const setDoneFlag = (value: boolean) => {
+    queryClient.setQueriesData<NotificationCacheData>(
+      { queryKey: notificationKeys.user._def },
+      (data) => {
+        if (!data) return data;
+        return {
+          ...data,
+          pages: data.pages.map((page) => ({
+            ...page,
+            items: page.items.map((item) =>
+              idSet.has(item.id) ? { ...item, done: value } : item
+            ),
+          })),
+        };
+      }
+    );
   };
+
+  setDoneFlag(true);
 
   const done = (async () => {
     try {
@@ -258,12 +260,11 @@ export function markNotificationsDone(
           })
       );
     } catch (err) {
-      rollback();
+      setDoneFlag(false);
       throw err;
     } finally {
-      // Cache is already consistent via the optimistic update (or rollback on
-      // failure). Avoid refetchType default — it would re-fetch every page of
-      // the infinite query.
+      // Cache is already consistent via the optimistic flip. refetchType
+      // default would re-fetch every page of the infinite query.
       await queryClient.invalidateQueries({
         queryKey: notificationKeys.user._def,
         refetchType: 'none',
@@ -280,7 +281,7 @@ export function markNotificationsDone(
         return;
       }
 
-      rollback();
+      setDoneFlag(false);
 
       try {
         await throwOnErr(

--- a/js/app/packages/notifications/notification-helpers.ts
+++ b/js/app/packages/notifications/notification-helpers.ts
@@ -221,12 +221,14 @@ type NotificationCacheData = {
  * call in the background. Returns synchronously so the caller can show an
  * undo toast immediately.
  */
-export function markNotificationsDone(
+export async function markNotificationsDone(
   notificationIds: string[]
-): MarkNotificationsDoneHandle {
-  queryClient.cancelQueries({ queryKey: notificationKeys.user._def });
-
+): Promise<MarkNotificationsDoneHandle> {
   const idSet = new Set(notificationIds);
+
+  // Cancel in-flight fetches up front so an arriving response can't clobber
+  // the optimistic flip (TanStack Query v5 pattern for optimistic updates).
+  await queryClient.cancelQueries({ queryKey: notificationKeys.user._def });
 
   // Flip `done` on the targeted notifications in place. Touching only the
   // specific items (instead of snapshotting and restoring the whole cache)
@@ -281,6 +283,9 @@ export function markNotificationsDone(
         return;
       }
 
+      await queryClient.cancelQueries({
+        queryKey: notificationKeys.user._def,
+      });
       setDoneFlag(false);
 
       try {
@@ -290,6 +295,11 @@ export function markNotificationsDone(
               notificationIds,
             })
         );
+      } catch (err) {
+        // Server still thinks these are done — re-apply the optimistic done
+        // state so the UI matches the backend.
+        setDoneFlag(true);
+        throw err;
       } finally {
         await queryClient.invalidateQueries({
           queryKey: notificationKeys.user._def,

--- a/js/app/packages/notifications/notification-helpers.ts
+++ b/js/app/packages/notifications/notification-helpers.ts
@@ -5,7 +5,7 @@ import { notificationKeys } from '@queries/notification/keys';
 import { notificationServiceClient } from '@service-notification/client';
 import { type Accessor, createEffect, createMemo, onCleanup } from 'solid-js';
 import { isMatching, P } from 'ts-pattern';
-import { CHANNEL_EVENT_TYPES } from './notification-source';
+import { CHANNEL_EVENT_TYPES, setDoneOverride } from './notification-source';
 import type { NotificationSource } from './notification-source';
 import { type UnifiedNotification, compositeEntity } from './types';
 
@@ -212,10 +212,6 @@ export type MarkNotificationsDoneHandle = {
   undo: () => Promise<void>;
 };
 
-type NotificationCacheData = {
-  pages: { items: { id: string; done?: boolean }[] }[];
-};
-
 /**
  * Optimistically marks notifications as done in the cache and fires the API
  * call in the background. Returns synchronously so the caller can show an
@@ -224,29 +220,12 @@ type NotificationCacheData = {
 export async function markNotificationsDone(
   notificationIds: string[]
 ): Promise<MarkNotificationsDoneHandle> {
-  const idSet = new Set(notificationIds);
-
   await queryClient.cancelQueries({ queryKey: notificationKeys.user._def });
 
-  const setDoneFlag = (value: boolean) => {
-    queryClient.setQueriesData<NotificationCacheData>(
-      { queryKey: notificationKeys.user._def },
-      (data) => {
-        if (!data) return data;
-        return {
-          ...data,
-          pages: data.pages.map((page) => ({
-            ...page,
-            items: page.items.map((item) =>
-              idSet.has(item.id) ? { ...item, done: value } : item
-            ),
-          })),
-        };
-      }
-    );
-  };
-
-  setDoneFlag(true);
+  // Override lives outside the cache so an in-flight page fetch that lands
+  // after this flip cannot revert it. The notifications memo applies the
+  // override when reading cache data.
+  setDoneOverride(notificationIds, true);
 
   const done = (async () => {
     try {
@@ -257,7 +236,7 @@ export async function markNotificationsDone(
           })
       );
     } catch (err) {
-      setDoneFlag(false);
+      setDoneOverride(notificationIds, undefined);
       throw err;
     } finally {
       await queryClient.invalidateQueries({
@@ -276,10 +255,7 @@ export async function markNotificationsDone(
         return;
       }
 
-      await queryClient.cancelQueries({
-        queryKey: notificationKeys.user._def,
-      });
-      setDoneFlag(false);
+      setDoneOverride(notificationIds, false);
 
       try {
         await throwOnErr(
@@ -289,7 +265,7 @@ export async function markNotificationsDone(
             })
         );
       } catch (err) {
-        setDoneFlag(true);
+        setDoneOverride(notificationIds, true);
         throw err;
       } finally {
         await queryClient.invalidateQueries({

--- a/js/app/packages/notifications/notification-helpers.ts
+++ b/js/app/packages/notifications/notification-helpers.ts
@@ -1,4 +1,8 @@
 import type { Entity, EntityType } from '@core/types';
+import { throwOnErr } from '@core/util/maybeResult';
+import { queryClient } from '@queries/client';
+import { notificationKeys } from '@queries/notification/keys';
+import { notificationServiceClient } from '@service-notification/client';
 import { type Accessor, createEffect, createMemo, onCleanup } from 'solid-js';
 import { isMatching, P } from 'ts-pattern';
 import { CHANNEL_EVENT_TYPES } from './notification-source';
@@ -199,6 +203,96 @@ export function useNotificationsMutedForEntity(
       item_id: entity.id,
     })
   );
+}
+
+export type MarkNotificationsDoneHandle = {
+  /** Fire-and-forget promise for the API call. Rejects on failure (rolls back optimistic update). */
+  done: Promise<void>;
+  /** Restores the notification cache and calls the undone API. */
+  undo: () => Promise<void>;
+};
+
+type NotificationCacheData = {
+  pages: { items: { id: string }[] }[];
+};
+
+/**
+ * Optimistically marks notifications as done in the cache and fires the API
+ * call in the background. Returns synchronously so the caller can show an
+ * undo toast immediately.
+ */
+export function markNotificationsDone(
+  notificationIds: string[]
+): MarkNotificationsDoneHandle {
+  queryClient.cancelQueries({ queryKey: notificationKeys.user._def });
+
+  const previousData = queryClient.getQueriesData<NotificationCacheData>({
+    queryKey: notificationKeys.user._def,
+  });
+
+  const idSet = new Set(notificationIds);
+
+  for (const [key, data] of previousData) {
+    if (!data) continue;
+    queryClient.setQueryData(key, {
+      ...data,
+      pages: data.pages.map((page) => ({
+        ...page,
+        items: page.items.filter((item) => !idSet.has(item.id)),
+      })),
+    });
+  }
+
+  const rollback = () => {
+    for (const [key, data] of previousData) {
+      queryClient.setQueryData(key, data);
+    }
+  };
+
+  const done = (async () => {
+    try {
+      await throwOnErr(
+        async () =>
+          await notificationServiceClient.bulkMarkNotificationAsDone({
+            notificationIds,
+          })
+      );
+    } catch (err) {
+      rollback();
+      throw err;
+    } finally {
+      await queryClient.invalidateQueries({
+        queryKey: notificationKeys.user._def,
+      });
+    }
+  })();
+
+  return {
+    done,
+    undo: async () => {
+      try {
+        await done;
+      } catch {
+        return;
+      }
+
+      rollback();
+
+      try {
+        await throwOnErr(
+          async () =>
+            await notificationServiceClient.bulkMarkNotificationAsUndone({
+              notificationIds,
+            })
+        );
+      } finally {
+        await queryClient.invalidateQueries({
+          queryKey: notificationKeys.user._def,
+          refetchType: 'none',
+        });
+      }
+    },
+  };
 }
 
 export function createEffectOnEntityTypeNotification(

--- a/js/app/packages/notifications/notification-helpers.ts
+++ b/js/app/packages/notifications/notification-helpers.ts
@@ -226,13 +226,8 @@ export async function markNotificationsDone(
 ): Promise<MarkNotificationsDoneHandle> {
   const idSet = new Set(notificationIds);
 
-  // Cancel in-flight fetches up front so an arriving response can't clobber
-  // the optimistic flip (TanStack Query v5 pattern for optimistic updates).
   await queryClient.cancelQueries({ queryKey: notificationKeys.user._def });
 
-  // Flip `done` on the targeted notifications in place. Touching only the
-  // specific items (instead of snapshotting and restoring the whole cache)
-  // keeps any concurrent websocket inserts intact.
   const setDoneFlag = (value: boolean) => {
     queryClient.setQueriesData<NotificationCacheData>(
       { queryKey: notificationKeys.user._def },
@@ -265,8 +260,6 @@ export async function markNotificationsDone(
       setDoneFlag(false);
       throw err;
     } finally {
-      // Cache is already consistent via the optimistic flip. refetchType
-      // default would re-fetch every page of the infinite query.
       await queryClient.invalidateQueries({
         queryKey: notificationKeys.user._def,
         refetchType: 'none',
@@ -296,8 +289,6 @@ export async function markNotificationsDone(
             })
         );
       } catch (err) {
-        // Server still thinks these are done — re-apply the optimistic done
-        // state so the UI matches the backend.
         setDoneFlag(true);
         throw err;
       } finally {

--- a/js/app/packages/notifications/notification-helpers.ts
+++ b/js/app/packages/notifications/notification-helpers.ts
@@ -261,8 +261,12 @@ export function markNotificationsDone(
       rollback();
       throw err;
     } finally {
+      // Cache is already consistent via the optimistic update (or rollback on
+      // failure). Avoid refetchType default — it would re-fetch every page of
+      // the infinite query.
       await queryClient.invalidateQueries({
         queryKey: notificationKeys.user._def,
+        refetchType: 'none',
       });
     }
   })();

--- a/js/app/packages/notifications/notification-helpers.ts
+++ b/js/app/packages/notifications/notification-helpers.ts
@@ -205,75 +205,60 @@ export function useNotificationsMutedForEntity(
   );
 }
 
-export type MarkNotificationsDoneHandle = {
-  /** Fire-and-forget promise for the API call. Rejects on failure (rolls back optimistic update). */
-  done: Promise<void>;
-  /** Restores the notification cache and calls the undone API. */
-  undo: () => Promise<void>;
-};
+/**
+ * Optimistically flips the `done` override to `true` for these ids, fires the
+ * bulk-done API, and rolls the override back on failure. Used as a mutation's
+ * mutationFn / redoFn.
+ */
+export async function executeMarkNotificationsDone(
+  notificationIds: string[]
+): Promise<void> {
+  setDoneOverride(notificationIds, true);
+  await queryClient.cancelQueries({ queryKey: notificationKeys.user._def });
+  try {
+    await throwOnErr(
+      async () =>
+        await notificationServiceClient.bulkMarkNotificationAsDone({
+          notificationIds,
+        })
+    );
+  } catch (err) {
+    setDoneOverride(notificationIds, false);
+    throw err;
+  } finally {
+    await queryClient.invalidateQueries({
+      queryKey: notificationKeys.user._def,
+      refetchType: 'none',
+    });
+  }
+}
 
 /**
- * Optimistically marks notifications as done in the cache and fires the API
- * call in the background. Returns synchronously so the caller can show an
- * undo toast immediately.
+ * Optimistically flips the override to `false` and fires the bulk-undone API.
+ * On failure the override is re-applied so the UI stays consistent with the
+ * server. Used as a mutation's undoFn.
  */
-export function markNotificationsDone(
+export async function executeMarkNotificationsUndone(
   notificationIds: string[]
-): MarkNotificationsDoneHandle {
-  // Override lives outside the cache so an in-flight page fetch that lands
-  // after this flip cannot revert it. The notifications memo applies the
-  // override when reading cache data.
-  setDoneOverride(notificationIds, true);
-
-  const done = (async () => {
-    await queryClient.cancelQueries({ queryKey: notificationKeys.user._def });
-    try {
-      await throwOnErr(
-        async () =>
-          await notificationServiceClient.bulkMarkNotificationAsDone({
-            notificationIds,
-          })
-      );
-    } catch (err) {
-      setDoneOverride(notificationIds, undefined);
-      throw err;
-    } finally {
-      await queryClient.invalidateQueries({
-        queryKey: notificationKeys.user._def,
-        refetchType: 'none',
-      });
-    }
-  })();
-
-  return {
-    done,
-    undo: async () => {
-      try {
-        await done;
-      } catch {
-        return;
-      }
-
-      setDoneOverride(notificationIds, false);
-
-      try {
-        await throwOnErr(
-          async () =>
-            await notificationServiceClient.bulkMarkNotificationAsUndone({
-              notificationIds,
-            })
-        );
-      } catch (err) {
-        setDoneOverride(notificationIds, true);
-        throw err;
-      } finally {
-        await queryClient.invalidateQueries({
-          queryKey: notificationKeys.user._def,
-          refetchType: 'none',
-        });
-      }
-    },
-  };
+): Promise<void> {
+  setDoneOverride(notificationIds, false);
+  await queryClient.cancelQueries({ queryKey: notificationKeys.user._def });
+  try {
+    await throwOnErr(
+      async () =>
+        await notificationServiceClient.bulkMarkNotificationAsUndone({
+          notificationIds,
+        })
+    );
+  } catch (err) {
+    setDoneOverride(notificationIds, true);
+    throw err;
+  } finally {
+    await queryClient.invalidateQueries({
+      queryKey: notificationKeys.user._def,
+      refetchType: 'none',
+    });
+  }
 }
 
 export function createEffectOnEntityTypeNotification(

--- a/js/app/packages/notifications/notification-helpers.ts
+++ b/js/app/packages/notifications/notification-helpers.ts
@@ -217,17 +217,16 @@ export type MarkNotificationsDoneHandle = {
  * call in the background. Returns synchronously so the caller can show an
  * undo toast immediately.
  */
-export async function markNotificationsDone(
+export function markNotificationsDone(
   notificationIds: string[]
-): Promise<MarkNotificationsDoneHandle> {
-  await queryClient.cancelQueries({ queryKey: notificationKeys.user._def });
-
+): MarkNotificationsDoneHandle {
   // Override lives outside the cache so an in-flight page fetch that lands
   // after this flip cannot revert it. The notifications memo applies the
   // override when reading cache data.
   setDoneOverride(notificationIds, true);
 
   const done = (async () => {
+    await queryClient.cancelQueries({ queryKey: notificationKeys.user._def });
     try {
       await throwOnErr(
         async () =>

--- a/js/app/packages/notifications/notification-source.ts
+++ b/js/app/packages/notifications/notification-source.ts
@@ -23,6 +23,7 @@ import {
   createEffect,
   createMemo,
   createSignal,
+  createRoot,
 } from 'solid-js';
 import { reconcile } from 'solid-js/store';
 import { createMutedEntitiesQuery } from './queries/muted-entities-query';
@@ -85,6 +86,29 @@ const NOTIFICATION_EVENT_TYPE = 'notification';
 
 const QUERY_LIMIT = 500;
 
+// Persistent overrides for the `done` flag that survive cache writes.
+// In-flight infinite-query page fetches can land after an optimistic cache
+// flip and overwrite it with stale server data; this map keeps the UI
+// consistent regardless of what the cache says.
+const [doneOverrides, setDoneOverrides] = createRoot(() =>
+  createSignal<ReadonlyMap<string, boolean>>(new Map())
+);
+
+export function setDoneOverride(
+  ids: readonly string[],
+  done: boolean | undefined
+) {
+  if (ids.length === 0) return;
+  setDoneOverrides((prev) => {
+    const next = new Map(prev);
+    for (const id of ids) {
+      if (done === undefined) next.delete(id);
+      else next.set(id, done);
+    }
+    return next;
+  });
+}
+
 export function createNotificationSource(
   ws: ConnectionGatewayWebsocket,
   onNotification?: (notification: UnifiedNotification) => void
@@ -99,9 +123,16 @@ export function createNotificationSource(
   const markNotificationsAsSeenMutation = useMarkNotificationsAsSeenMutation();
   const markNotificationsAsDoneMutation = useMarkNotificationsAsDoneMutation();
 
-  const notifications = createMemo(() =>
-    notificationsQuery.isSuccess ? notificationsQuery.data : []
-  );
+  const notifications = createMemo(() => {
+    if (!notificationsQuery.isSuccess) return [];
+    const raw = notificationsQuery.data;
+    const overrides = doneOverrides();
+    if (overrides.size === 0) return raw;
+    return raw.map((n) => {
+      const override = overrides.get(n.id);
+      return override !== undefined ? { ...n, done: override } : n;
+    });
+  });
 
   const notificationsByEntity = createMemo(() => {
     const data = notifications();

--- a/js/app/packages/notifications/notification-source.ts
+++ b/js/app/packages/notifications/notification-source.ts
@@ -136,18 +136,19 @@ export function createNotificationSource(
 
   // Prune overrides for notifications that are no longer in the query cache
   // (aged out of QUERY_LIMIT, deleted server-side) so the map doesn't grow
-  // unbounded. Also drop overrides whose target server state now matches the
-  // cache — the override is redundant at that point.
+  // unbounded. Overrides whose value happens to match the cache are NOT
+  // pruned — during an in-flight mutation the cache may still hold the
+  // pre-mutation value and a stale fetch could flip it back before the
+  // API lands.
   createEffect(() => {
     if (!notificationsQuery.isSuccess) return;
     const raw = notificationsQuery.data;
     const overrides = doneOverrides();
     if (overrides.size === 0) return;
-    const present = new Map(raw.map((n) => [n.id, n.done ?? false]));
+    const presentIds = new Set(raw.map((n) => n.id));
     const toPrune: string[] = [];
-    for (const [id, expected] of overrides) {
-      const actual = present.get(id);
-      if (actual === undefined || actual === expected) toPrune.push(id);
+    for (const id of overrides.keys()) {
+      if (!presentIds.has(id)) toPrune.push(id);
     }
     if (toPrune.length > 0) setDoneOverride(toPrune, undefined);
   });

--- a/js/app/packages/notifications/notification-source.ts
+++ b/js/app/packages/notifications/notification-source.ts
@@ -134,6 +134,24 @@ export function createNotificationSource(
     });
   });
 
+  // Prune overrides for notifications that are no longer in the query cache
+  // (aged out of QUERY_LIMIT, deleted server-side) so the map doesn't grow
+  // unbounded. Also drop overrides whose target server state now matches the
+  // cache — the override is redundant at that point.
+  createEffect(() => {
+    if (!notificationsQuery.isSuccess) return;
+    const raw = notificationsQuery.data;
+    const overrides = doneOverrides();
+    if (overrides.size === 0) return;
+    const present = new Map(raw.map((n) => [n.id, n.done ?? false]));
+    const toPrune: string[] = [];
+    for (const [id, expected] of overrides) {
+      const actual = present.get(id);
+      if (actual === undefined || actual === expected) toPrune.push(id);
+    }
+    if (toPrune.length > 0) setDoneOverride(toPrune, undefined);
+  });
+
   const notificationsByEntity = createMemo(() => {
     const data = notifications();
     const grouped: NotificationsByEntity = {};

--- a/js/app/packages/queries/notification/user-notifications.ts
+++ b/js/app/packages/queries/notification/user-notifications.ts
@@ -192,6 +192,30 @@ export function invalidateUserNotifications() {
   });
 }
 
+/** Plain-async wrapper around `bulkMarkNotificationAsDone`. Throws on failure. */
+export async function bulkMarkNotificationsAsDone(
+  notificationIds: string[]
+): Promise<void> {
+  await throwOnErr(
+    async () =>
+      await notificationServiceClient.bulkMarkNotificationAsDone({
+        notificationIds,
+      })
+  );
+}
+
+/** Plain-async wrapper around `bulkMarkNotificationAsUndone`. Throws on failure. */
+export async function bulkMarkNotificationsAsUndone(
+  notificationIds: string[]
+): Promise<void> {
+  await throwOnErr(
+    async () =>
+      await notificationServiceClient.bulkMarkNotificationAsUndone({
+        notificationIds,
+      })
+  );
+}
+
 export function invalidateEntityNotifications(eventItemId: string) {
   return queryClient.invalidateQueries({
     queryKey: [...notificationKeys.entity._def, eventItemId],

--- a/js/app/packages/queries/notification/user-notifications.ts
+++ b/js/app/packages/queries/notification/user-notifications.ts
@@ -439,5 +439,11 @@ export function optimisticInsertNotification(
     );
   }
 
-  invalidateUserNotifications();
+  // Cache is already updated via setQueriesData above. Mark as stale without
+  // refetching — refetchType default would re-fetch every cached page of the
+  // infinite notification query for every incoming websocket notification.
+  queryClient.invalidateQueries({
+    queryKey: notificationKeys.user._def,
+    refetchType: 'none',
+  });
 }

--- a/js/app/packages/service-clients/service-notification/client.ts
+++ b/js/app/packages/service-clients/service-notification/client.ts
@@ -173,6 +173,16 @@ export const notificationServiceClient = {
       (result) => result
     );
   },
+  async bulkMarkNotificationAsUndone(args: NotificationBulkRequest) {
+    const { notificationIds } = args;
+    return mapOk(
+      await notificationFetch<any>(`/user_notifications/bulk/undone`, {
+        method: 'PATCH',
+        body: JSON.stringify({ notificationIds }),
+      }),
+      (result) => result
+    );
+  },
   async markNotificationEntityAsSeen(args: WithEventItemId) {
     const { event_item_id } = args;
     return mapOk(


### PR DESCRIPTION
## Summary
- Adds an **Undo** toast (10s) after marking an entity or notification stack as done — clicking Undo restores it in-place.
- Surfaces the Undo button inline with the toast title (previously it wrapped to a second row).
- Skips refetching the infinite notification query after mark-done/mark-undone and after websocket-driven inserts — the cache is already consistent via the optimistic update, but the default `invalidateQueries` was re-fetching every cached page (15+ requests for a single incoming message).
- Switches the optimistic update from snapshot/restore to flipping the `done` flag on targeted items, so newer notifications delivered by the websocket during the undo window are preserved.

## Notes
- Applies to entity-level mark-done (`e` hotkey, soup action menu) and to individual notification stacks (desktop check button / context menu / `e` on focused row, mobile swipe-left).
- A new `bulkMarkNotificationAsUndone` client method hits the existing `PATCH /v2/user_notifications/bulk/undone` endpoint.