### PR TITLE
fix(channel): mark message notification viewed when it arrives after mount

### DIFF
--- a/js/app/packages/notifications/components/MarkMessageNotifications.tsx
+++ b/js/app/packages/notifications/components/MarkMessageNotifications.tsx
@@ -1,4 +1,4 @@
-import { onCleanup, onMount } from 'solid-js';
+import { createEffect } from 'solid-js';
 import type { JSXElement } from 'solid-js';
 import { useGlobalNotificationSource } from '@app/component/GlobalAppState';
 import type { UnifiedNotification } from '@notifications/types';
@@ -21,24 +21,13 @@ export function MarkMessageNotifications(props: {
     isChannelNotification(n) &&
     n.notification_metadata.content.messageId === props.messageId;
 
-  let unsubscribe: () => void = () => {};
-  onCleanup(() => {
-    unsubscribe();
-  });
+  let marked = false;
 
-  onMount(() => {
+  createEffect(() => {
+    if (marked) return;
     const existing = notifications().find(isMessageNotification);
-
-    if (!existing) {
-      unsubscribe = notificationSource.subscribe((n) => {
-        if (!isMessageNotification(n)) return;
-        notificationSource.markAsRead(n);
-        unsubscribe();
-      });
-      return;
-    }
-
-    if (!existing.viewed_at) {
+    if (existing && !existing.viewed_at) {
+      marked = true;
       notificationSource.markAsRead(existing);
     }
   });


### PR DESCRIPTION
## Summary

`MarkMessageNotifications` used `onMount`, which ran exactly once: it looked for a matching notification in the cache and, if missing, fell back to a websocket-only subscription. That fallback never fires for notifications that land in the cache via the subsequent paginated query fetch (cold start / full refresh), so `viewed_at` stayed null until the user reloaded the app.

Switch to `createEffect` with a `marked` guard so the mark-as-read happens as soon as the notification appears in the reactive `notifications()` memo — whether it came from the query or a websocket push.

## Repro before
1. Receive a channel message while the app is closed.
2. Reopen the app and view the channel.
3. Notification stays `viewed_at: null`; the unread badge on the channel in the sidebar persists until reload.