### PR TITLE
feat(calls): auto share call record with team

### DIFF
--- a/js/app/packages/service-clients/service-storage/generated/zod.ts
+++ b/js/app/packages/service-clients/service-storage/generated/zod.ts
@@ -973,6 +973,17 @@ export const editCallRecordBody = zod
   .describe('Edit call request');
 
 /**
+ * Toggles the `share_with_team` flag on the active call. Returns the new
+value as the JSON body.
+ * @summary Handler for `POST /call/record/{call_id}/share-with-team/toggle`.
+ */
+export const toggleShareWithTeamParams = zod.object({
+  call_id: zod.string().uuid().describe('Call ID'),
+});
+
+export const toggleShareWithTeamResponse = zod.boolean();
+
+/**
  * Gets or creates a call for the channel. If a call already exists, joins it;
 otherwise creates a new one. Always returns a join token.
  * @summary Handler for `GET /call/{channel_id}`.

--- a/js/app/packages/service-clients/service-storage/openapi.json
+++ b/js/app/packages/service-clients/service-storage/openapi.json
@@ -772,6 +772,68 @@
         }
       }
     },
+    "/call/record/{call_id}/share-with-team/toggle": {
+      "post": {
+        "tags": ["call::inbound::axum_router"],
+        "summary": "Handler for `POST /call/record/{call_id}/share-with-team/toggle`.",
+        "description": "Toggles the `share_with_team` flag on the active call. Returns the new\nvalue as the JSON body.",
+        "operationId": "toggle_share_with_team",
+        "parameters": [
+          {
+            "name": "call_id",
+            "in": "path",
+            "description": "Call ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "New value of share_with_team after toggle",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/call/webhook": {
       "post": {
         "tags": ["call::inbound::axum_router"],

--- a/rust/cloud-storage/call/.sqlx/query-b514f8481c5d7b865fd3265fd927a9bb5855eb01eb33f90137e7685573b3be8e.json
+++ b/rust/cloud-storage/call/.sqlx/query-b514f8481c5d7b865fd3265fd927a9bb5855eb01eb33f90137e7685573b3be8e.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            SELECT id, channel_id, room_name, created_by, created_at, egress_id, recording_key, share_permission_id\n            FROM calls\n            WHERE id = $1\n            FOR UPDATE\n            ",
+  "query": "\n            SELECT id, channel_id, room_name, created_by, created_at, egress_id, recording_key, share_permission_id, share_with_team\n            FROM calls\n            WHERE id = $1\n            FOR UPDATE\n            ",
   "describe": {
     "columns": [
       {
@@ -42,6 +42,11 @@
         "ordinal": 7,
         "name": "share_permission_id",
         "type_info": "Text"
+      },
+      {
+        "ordinal": 8,
+        "name": "share_with_team",
+        "type_info": "Bool"
       }
     ],
     "parameters": {
@@ -57,8 +62,9 @@
       false,
       true,
       true,
+      false,
       false
     ]
   },
-  "hash": "eb38775373a5ee3fdb942593936a3231b9303a5cc2fd2198b3ac132cae45024a"
+  "hash": "b514f8481c5d7b865fd3265fd927a9bb5855eb01eb33f90137e7685573b3be8e"
 }

--- a/rust/cloud-storage/call/.sqlx/query-d913bcfef1a7d318743aca5d1db542ffe191451bf3b578cb3aaedaf754a46a19.json
+++ b/rust/cloud-storage/call/.sqlx/query-d913bcfef1a7d318743aca5d1db542ffe191451bf3b578cb3aaedaf754a46a19.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE calls\n               SET share_with_team = NOT share_with_team\n             WHERE id = $1\n            RETURNING share_with_team\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "share_with_team",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "d913bcfef1a7d318743aca5d1db542ffe191451bf3b578cb3aaedaf754a46a19"
+}

--- a/rust/cloud-storage/call/.sqlx/query-fc0744ebeb842c69501102f111cb569a6f2b0c2fc0e62e5243a5857e054e61c7.json
+++ b/rust/cloud-storage/call/.sqlx/query-fc0744ebeb842c69501102f111cb569a6f2b0c2fc0e62e5243a5857e054e61c7.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                SELECT team_id\n                FROM team_user\n                WHERE user_id = $1\n                LIMIT 1\n                ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "team_id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "fc0744ebeb842c69501102f111cb569a6f2b0c2fc0e62e5243a5857e054e61c7"
+}

--- a/rust/cloud-storage/call/src/domain/ports.rs
+++ b/rust/cloud-storage/call/src/domain/ports.rs
@@ -96,6 +96,12 @@ pub trait CallRepository: Send + Sync + 'static {
         egress_id: &str,
     ) -> impl Future<Output = Result<(), Self::Err>> + Send;
 
+    /// Flip the `share_with_team` flag on an active call. Returns the new value.
+    fn toggle_share_with_team(
+        &self,
+        call_id: &Uuid,
+    ) -> impl Future<Output = Result<bool, Self::Err>> + Send;
+
     /// Archive an active call to the permanent `call_records` and
     /// `call_record_participants` tables, then delete the ephemeral rows.
     /// Returns the new `call_records` id.
@@ -336,6 +342,16 @@ pub trait CallService: Send + Sync + 'static {
         receipt: EntityAccessReceipt<MemberParticipantRole>,
         request: EditCallRecordRequest,
     ) -> impl Future<Output = Result<(), CallError>> + Send;
+
+    /// Toggle the `share_with_team` flag on the active call identified by the
+    /// receipt. Authorization is carried in the receipt produced by
+    /// `CallAccessLevelExtractor`; the entity on the receipt must be
+    /// `EntityType::Call` and its `entity_id` must be the call's UUID.
+    /// Returns the new value.
+    fn toggle_share_with_team(
+        &self,
+        receipt: EntityAccessReceipt<MemberParticipantRole>,
+    ) -> impl Future<Output = Result<bool, CallError>> + Send;
 }
 
 /// Lightweight read-only port for querying call records in Soup.

--- a/rust/cloud-storage/call/src/domain/service.rs
+++ b/rust/cloud-storage/call/src/domain/service.rs
@@ -729,6 +729,28 @@ impl<
             .await
             .map_err(|e| CallError::Internal(e.into()))
     }
+
+    #[tracing::instrument(err, skip(self))]
+    async fn toggle_share_with_team(
+        &self,
+        receipt: EntityAccessReceipt<MemberParticipantRole>,
+    ) -> Result<bool, CallError> {
+        let entity = receipt.entity();
+        if entity.entity_type != EntityType::Call {
+            return Err(CallError::Internal(anyhow::anyhow!(
+                "expected Call entity in receipt, got {:?}",
+                entity.entity_type
+            )));
+        }
+
+        let call_id = macro_uuid::string_to_uuid(&entity.entity_id)
+            .map_err(|_| CallError::Internal(anyhow::anyhow!("invalid call entity receipt")))?;
+
+        self.repo
+            .toggle_share_with_team(&call_id)
+            .await
+            .map_err(|e| CallError::Internal(e.into()))
+    }
 }
 
 /// Extract the recording key from a full S3 URL.

--- a/rust/cloud-storage/call/src/inbound/axum_router.rs
+++ b/rust/cloud-storage/call/src/inbound/axum_router.rs
@@ -79,6 +79,7 @@ impl<S, Svc> FromRef<CallRouterState<S, Svc>> for Arc<Svc> {
 /// - `GET /record/{call_id}` — get a full call record (transcript + participants)
 /// - `PATCH /record/{call_id}` — edit a call record (e.g. share permissions)
 /// - `DELETE /record/{call_id}` — delete a call record
+/// - `POST /record/{call_id}/share-with-team/toggle` — flip the call's share_with_team flag
 pub fn call_router<S, Svc, T>(state: CallRouterState<S, Svc>) -> Router<T>
 where
     S: CallService,
@@ -99,6 +100,10 @@ where
             get(get_call_record_handler::<S, Svc>)
                 .patch(edit_call_record_handler::<S, Svc>)
                 .delete(delete_call_record_handler::<S, Svc>),
+        )
+        .route(
+            "/record/{call_id}/share-with-team/toggle",
+            post(toggle_share_with_team_handler::<S, Svc>),
         )
         .with_state(state)
 }
@@ -384,6 +389,36 @@ pub async fn edit_call_record_handler<S: CallService, Svc: EntityAccessService>(
         .edit_call_record(access.entity_access_receipt, request)
         .await?;
     Ok(StatusCode::NO_CONTENT)
+}
+
+/// Handler for `POST /call/record/{call_id}/share-with-team/toggle`.
+///
+/// Toggles the `share_with_team` flag on the active call. Returns the new
+/// value as the JSON body.
+#[utoipa::path(
+    post,
+    operation_id = "toggle_share_with_team",
+    path = "/call/record/{call_id}/share-with-team/toggle",
+    params(
+        ("call_id" = Uuid, Path, description = "Call ID"),
+    ),
+    responses(
+        (status = 200, body = bool, content_type = "application/json", description = "New value of share_with_team after toggle"),
+        (status = 401, body = ErrorResponse),
+        (status = 404, body = ErrorResponse),
+        (status = 500, body = ErrorResponse),
+    )
+)]
+#[tracing::instrument(err, skip_all)]
+pub async fn toggle_share_with_team_handler<S: CallService, Svc: EntityAccessService>(
+    State(state): State<CallRouterState<S, Svc>>,
+    access: CallAccessLevelExtractor<MemberParticipantRole, Svc>,
+) -> Result<Json<bool>, CallError> {
+    let new_value = state
+        .service
+        .toggle_share_with_team(access.entity_access_receipt)
+        .await?;
+    Ok(Json(new_value))
 }
 
 /// Handler for `DELETE /call/{channel_id}`.

--- a/rust/cloud-storage/call/src/outbound/pg_call_repo.rs
+++ b/rust/cloud-storage/call/src/outbound/pg_call_repo.rs
@@ -369,13 +369,29 @@ impl CallRepository for PgCallRepo {
     }
 
     #[tracing::instrument(err, skip(self))]
+    async fn toggle_share_with_team(&self, call_id: &Uuid) -> Result<bool, Self::Err> {
+        let row = sqlx::query!(
+            r#"
+            UPDATE calls
+               SET share_with_team = NOT share_with_team
+             WHERE id = $1
+            RETURNING share_with_team
+            "#,
+            call_id,
+        )
+        .fetch_one(&self.pool)
+        .await?;
+        Ok(row.share_with_team)
+    }
+
+    #[tracing::instrument(err, skip(self))]
     async fn archive_call(&self, call_id: &Uuid) -> Result<Uuid, Self::Err> {
         let mut tx = self.pool.begin().await?;
 
         // Fetch and lock the active call so concurrent archive_call callers serialize.
         let call = sqlx::query!(
             r#"
-            SELECT id, channel_id, room_name, created_by, created_at, egress_id, recording_key, share_permission_id
+            SELECT id, channel_id, room_name, created_by, created_at, egress_id, recording_key, share_permission_id, share_with_team
             FROM calls
             WHERE id = $1
             FOR UPDATE
@@ -385,6 +401,34 @@ impl CallRepository for PgCallRepo {
         .fetch_optional(tx.as_mut())
         .await?
         .ok_or(sqlx::Error::RowNotFound)?;
+
+        // If the call opted in to team sharing, grant the creator's team View
+        // access on the archived call. Silently skip if the creator has no team.
+        if call.share_with_team {
+            let team_id: Option<Uuid> = sqlx::query_scalar!(
+                r#"
+                SELECT team_id
+                FROM team_user
+                WHERE user_id = $1
+                LIMIT 1
+                "#,
+                &call.created_by,
+            )
+            .fetch_optional(tx.as_mut())
+            .await?;
+
+            if let Some(team_id) = team_id {
+                entity_access_db_utils::insert_entity_access_row(
+                    &mut tx,
+                    call_id,
+                    entity_access_db_utils::EntityType::Call,
+                    &team_id.to_string(),
+                    entity_access_db_utils::EntityAccessSourceType::Team,
+                    entity_access_db_utils::AccessLevel::View,
+                )
+                .await?;
+            }
+        }
 
         let now = Utc::now();
         let duration_ms = now

--- a/rust/cloud-storage/call/src/outbound/pg_call_repo/test.rs
+++ b/rust/cloud-storage/call/src/outbound/pg_call_repo/test.rs
@@ -308,6 +308,123 @@ async fn archive_call_preserves_soft_deleted_participants(
     Ok(())
 }
 
+/// Test helper: give `user_id` a brand new team owned by that user. Inserts
+/// the parent `macro_user` and `User` rows that the `team_user` FK requires.
+async fn give_user_a_team(
+    pool: &Pool<Postgres>,
+    user_id: &str,
+    team_id: &Uuid,
+) -> anyhow::Result<()> {
+    let macro_user_id = Uuid::now_v7();
+
+    sqlx::query(
+        r#"INSERT INTO macro_user (id, username, email, stripe_customer_id) VALUES ($1, $2, $3, '')"#,
+    )
+    .bind(macro_user_id)
+    .bind(user_id)
+    .bind(format!("{user_id}@test.com"))
+    .execute(pool)
+    .await?;
+
+    sqlx::query(r#"INSERT INTO "User" (id, email, macro_user_id) VALUES ($1, $2, $3)"#)
+        .bind(user_id)
+        .bind(format!("{user_id}@test.com"))
+        .bind(macro_user_id)
+        .execute(pool)
+        .await?;
+
+    sqlx::query(r#"INSERT INTO team (id, name, owner_id) VALUES ($1, $2, $3)"#)
+        .bind(team_id)
+        .bind("test team")
+        .bind(user_id)
+        .execute(pool)
+        .await?;
+
+    sqlx::query(r#"INSERT INTO team_user (user_id, team_id, team_role) VALUES ($1, $2, 'owner')"#)
+        .bind(user_id)
+        .bind(team_id)
+        .execute(pool)
+        .await?;
+
+    Ok(())
+}
+
+// -- archive_call grants team view access when share_with_team is true -------
+
+#[sqlx::test(
+    fixtures(path = "../../../fixtures", scripts("call_repo")),
+    migrator = "MACRO_DB_MIGRATIONS"
+)]
+async fn archive_call_grants_team_view_access_when_share_with_team_true(
+    pool: Pool<Postgres>,
+) -> anyhow::Result<()> {
+    use sqlx::Row as _;
+
+    let repo = repo(pool.clone());
+    let team_id: Uuid = Uuid::from_u128(0xaaaaaaaa_aaaa_aaaa_aaaa_aaaaaaaaaaaa);
+
+    give_user_a_team(&pool, USER_A.as_ref(), &team_id).await?;
+
+    // share_with_team defaults to TRUE on the fixture call.
+    repo.archive_call(&CALL1).await?;
+
+    let row = sqlx::query(
+        r#"
+        SELECT entity_id, entity_type, source_id, access_level
+        FROM entity_access
+        WHERE entity_id = $1 AND source_type = 'team'
+        "#,
+    )
+    .bind(CALL1)
+    .fetch_one(&pool)
+    .await?;
+
+    assert_eq!(row.get::<Uuid, _>("entity_id"), CALL1);
+    assert_eq!(row.get::<String, _>("entity_type"), "call");
+    assert_eq!(row.get::<String, _>("source_id"), team_id.to_string());
+    assert_eq!(row.get::<AccessLevel, _>("access_level"), AccessLevel::View);
+
+    Ok(())
+}
+
+// -- archive_call skips team grant when share_with_team is false -------------
+
+#[sqlx::test(
+    fixtures(path = "../../../fixtures", scripts("call_repo")),
+    migrator = "MACRO_DB_MIGRATIONS"
+)]
+async fn archive_call_skips_team_grant_when_share_with_team_false(
+    pool: Pool<Postgres>,
+) -> anyhow::Result<()> {
+    use sqlx::Row as _;
+
+    let repo = repo(pool.clone());
+    let team_id: Uuid = Uuid::from_u128(0xbbbbbbbb_bbbb_bbbb_bbbb_bbbbbbbbbbbb);
+
+    // USER_A is on a team, but the call opted out of team sharing — so no
+    // team-scoped entity_access row should be created at archive time.
+    give_user_a_team(&pool, USER_A.as_ref(), &team_id).await?;
+
+    sqlx::query(r#"UPDATE calls SET share_with_team = false WHERE id = $1"#)
+        .bind(CALL1)
+        .execute(&pool)
+        .await?;
+
+    repo.archive_call(&CALL1).await?;
+
+    let count: i64 = sqlx::query(
+        r#"SELECT COUNT(*) AS count FROM entity_access WHERE entity_id = $1 AND source_type = 'team'"#,
+    )
+    .bind(CALL1)
+    .map(|r: sqlx::postgres::PgRow| r.get::<i64, _>("count"))
+    .fetch_one(&pool)
+    .await?;
+
+    assert_eq!(count, 0);
+
+    Ok(())
+}
+
 // -- archive_call preserves id and share_permission_id ------------------------
 
 #[sqlx::test(

--- a/rust/cloud-storage/document_storage_service/src/api/swagger.rs
+++ b/rust/cloud-storage/document_storage_service/src/api/swagger.rs
@@ -198,6 +198,7 @@ use utoipa::OpenApi;
         call::inbound::axum_router::get_call_record_handler,
         call::inbound::axum_router::edit_call_record_handler,
         call::inbound::axum_router::delete_call_record_handler,
+        call::inbound::axum_router::toggle_share_with_team_handler,
         call::inbound::axum_router::webhook_handler,
         call::inbound::axum_router::transcript_handler,
 

--- a/rust/cloud-storage/macro_db_client/migrations/20260421120000_call_share_with_team.sql
+++ b/rust/cloud-storage/macro_db_client/migrations/20260421120000_call_share_with_team.sql
@@ -1,0 +1,2 @@
+ALTER TABLE calls
+    ADD COLUMN share_with_team BOOLEAN NOT NULL DEFAULT TRUE;


### PR DESCRIPTION
This PR adds in auto share call record for teams

Currently we go with auto sharing with the creator's team only (this may change in future)

It is toggleable via an api call so you can swap that at any point during the calls progress