### PR TITLE
feat(undo): bind cmd+z / shift+cmd+z to the mutation undo stack

### DIFF
--- a/js/app/packages/app/component/GlobalHotkeys.tsx
+++ b/js/app/packages/app/component/GlobalHotkeys.tsx
@@ -1,8 +1,10 @@
 import { useOpenInstructionsMd } from '@core/component/AI/util/instructions';
+import { toast } from '@core/component/Toast/Toast';
 import { useSettingsState } from '@core/constant/SettingsState';
 import { TOKENS } from '@core/hotkey/tokens';
 import type { ValidHotkey } from '@core/hotkey/types';
 import { AiInstructionsIcon } from '@queries/storage/instructions-md';
+import { useMutationUndoContext } from '@queries/undo';
 import { registerHotkey } from 'core/hotkey/hotkeys';
 import { createMemo, onCleanup } from 'solid-js';
 import { useLogout } from '@core/auth/logout';
@@ -92,6 +94,7 @@ export default function GlobalShortcuts() {
   const canFit = () => globalSplitManager()?.canAppendSplit() ?? true;
 
   const analytics = useAnalytics();
+  const undoCtx = useMutationUndoContext();
 
   useHotkeyAnalytics();
 
@@ -381,6 +384,34 @@ export default function GlobalShortcuts() {
       });
       return true;
     },
+  });
+
+  registerHotkey({
+    hotkeyToken: TOKENS.global.undo,
+    hotkey: 'cmd+z',
+    scopeId: 'global',
+    description: 'Undo',
+    keyDownHandler: (e) => {
+      if (!undoCtx.canUndo()) return false;
+      e?.preventDefault();
+      undoCtx.undo({ onError: () => toast.failure('Failed to undo') });
+      return true;
+    },
+    condition: () => undoCtx.canUndo(),
+  });
+
+  registerHotkey({
+    hotkeyToken: TOKENS.global.redo,
+    hotkey: 'shift+cmd+z',
+    scopeId: 'global',
+    description: 'Redo',
+    keyDownHandler: (e) => {
+      if (!undoCtx.canRedo()) return false;
+      e?.preventDefault();
+      undoCtx.redo({ onError: () => toast.failure('Failed to redo') });
+      return true;
+    },
+    condition: () => undoCtx.canRedo(),
   });
 
   return null;

--- a/js/app/packages/app/component/next-soup/actions/make-mark-done-action.ts
+++ b/js/app/packages/app/component/next-soup/actions/make-mark-done-action.ts
@@ -25,6 +25,8 @@ type MarkDoneVariables = {
   notificationIds: string[];
 };
 
+type MarkDoneContext = MarkEntitiesDoneContext & { toastId?: number };
+
 /** Must be invoked inside a component tree that provides MutationUndoProvider. */
 export const makeMarkDoneAction = (options: MakeMarkDoneOptions) => {
   const { notificationSource } = options;
@@ -32,11 +34,36 @@ export const makeMarkDoneAction = (options: MakeMarkDoneOptions) => {
   const inPreview = previewPanel !== undefined;
   const undoCtx = useMutationUndoContext();
 
+  const showMarkDoneToast = (
+    variables: MarkDoneVariables
+  ): number | undefined => {
+    const count = variables.entities.length;
+    const firstEntityId = variables.entities[0]?.id;
+    return toast.success(
+      count > 1 ? `Marked ${count} items as done` : 'Marked as done',
+      undefined,
+      [
+        {
+          label: 'Undo',
+          icon: ArrowCounterClockwise,
+          onClick: () => {
+            undoCtx.undo({
+              onError: () => toast.failure('Failed to undo'),
+            });
+            restoreSoupFocus(firstEntityId, inPreview);
+          },
+        },
+      ],
+      10_000,
+      true
+    );
+  };
+
   const mutation = useUndoableMutation<
     void,
     Error,
     MarkDoneVariables,
-    MarkEntitiesDoneContext
+    MarkDoneContext
   >(() => ({
     onMutate: (variables) =>
       applyEntitiesDoneOptimistic({
@@ -48,36 +75,16 @@ export const makeMarkDoneAction = (options: MakeMarkDoneOptions) => {
         emailIds: variables.emailIds,
         notificationIds: variables.notificationIds,
       }),
-    onSuccess: (_data, variables) => {
-      const count = variables.entities.length;
-      const firstEntityId = variables.entities[0]?.id;
-      const toastId = toast.success(
-        count > 1 ? `Marked ${count} items as done` : 'Marked as done',
-        undefined,
-        [
-          {
-            label: 'Undo',
-            icon: ArrowCounterClockwise,
-            onClick: () => {
-              if (toastId != null) toast.dismiss(toastId);
-              // Route through the undo stack so the entry is popped and
-              // Cmd+Z / shift+Cmd+Z stay in sync with the toast action.
-              undoCtx.undo({
-                onError: () => toast.failure('Failed to undo'),
-              });
-              restoreSoupFocus(firstEntityId, inPreview);
-            },
-          },
-        ],
-        10_000,
-        true
-      );
+    onSuccess: (_data, variables, context) => {
+      const toastId = showMarkDoneToast(variables);
+      if (context && toastId !== undefined) context.toastId = toastId;
     },
     onError: (_err, _variables, context) => {
       context?.rollback();
       toast.failure('Failed to mark as done');
     },
     undoFn: async (variables, context) => {
+      if (context?.toastId !== undefined) toast.dismiss(context.toastId);
       context?.applyUndone();
       try {
         await executeMarkEntitiesUndone({
@@ -96,6 +103,8 @@ export const makeMarkDoneAction = (options: MakeMarkDoneOptions) => {
           emailIds: variables.emailIds,
           notificationIds: variables.notificationIds,
         });
+        const toastId = showMarkDoneToast(variables);
+        if (context && toastId !== undefined) context.toastId = toastId;
       } catch (err) {
         context?.applyUndone();
         throw err;

--- a/js/app/packages/app/component/next-soup/actions/make-mark-done-action.ts
+++ b/js/app/packages/app/component/next-soup/actions/make-mark-done-action.ts
@@ -2,7 +2,8 @@ import ArrowCounterClockwise from '@phosphor-icons/core/regular/arrow-counter-cl
 import { toast } from '@core/component/Toast/Toast';
 import { type EntityData, isTaskEntity } from '@entity';
 import type { NotificationSource } from '@notifications';
-import { useMutationUndoContext, useUndoableMutation } from '@queries/undo';
+import { useMutation } from '@tanstack/solid-query';
+import { type UndoHandle, useMutationUndoContext } from '@queries/undo';
 import {
   applyEntitiesDoneOptimistic,
   executeMarkEntitiesDone,
@@ -25,106 +26,96 @@ type MarkDoneVariables = {
   notificationIds: string[];
 };
 
-type MarkDoneContext = MarkEntitiesDoneContext & { toastId?: number };
-
-// Only one mark-done toast may be visible at a time — an older toast's Undo
-// button would otherwise invoke the LIFO undo stack and pop the newer entry.
-let visibleMarkDoneToastId: number | undefined;
-
 /** Must be invoked inside a component tree that provides MutationUndoProvider. */
 export const makeMarkDoneAction = (options: MakeMarkDoneOptions) => {
   const { notificationSource } = options;
   const previewPanel = useMaybePreviewPanel();
   const inPreview = previewPanel !== undefined;
-  const undoCtx = useMutationUndoContext();
+  const { pushUndo } = useMutationUndoContext();
 
-  const showMarkDoneToast = (
-    variables: MarkDoneVariables
-  ): number | undefined => {
-    if (visibleMarkDoneToastId !== undefined) {
-      toast.dismiss(visibleMarkDoneToastId);
-    }
-    const count = variables.entities.length;
-    const firstEntityId = variables.entities[0]?.id;
-    const id = toast.success(
-      count > 1 ? `Marked ${count} items as done` : 'Marked as done',
-      undefined,
-      [
-        {
-          label: 'Undo',
-          icon: ArrowCounterClockwise,
-          onClick: () => {
-            undoCtx.undo({
-              onError: () => toast.failure('Failed to undo'),
-            });
-            restoreSoupFocus(firstEntityId, inPreview);
-          },
-        },
-      ],
-      10_000,
-      true
-    );
-    visibleMarkDoneToastId = id;
-    return id;
-  };
-
-  const mutation = useUndoableMutation<
+  const mutation = useMutation<
     void,
     Error,
     MarkDoneVariables,
-    MarkDoneContext
+    MarkEntitiesDoneContext
   >(() => ({
     onMutate: (variables) =>
       applyEntitiesDoneOptimistic({
         emailIds: variables.emailIds,
         notificationIds: variables.notificationIds,
       }),
-    mutationFn: async (variables) =>
-      await executeMarkEntitiesDone({
+    mutationFn: (variables) =>
+      executeMarkEntitiesDone({
         emailIds: variables.emailIds,
         notificationIds: variables.notificationIds,
       }),
-    onSuccess: (_data, variables, context) => {
-      const toastId = showMarkDoneToast(variables);
-      if (context && toastId !== undefined) context.toastId = toastId;
-    },
     onError: (_err, _variables, context) => {
       context?.rollback();
       toast.failure('Failed to mark as done');
     },
-    undoFn: async (variables, context) => {
-      if (context?.toastId !== undefined) {
-        toast.dismiss(context.toastId);
-        if (visibleMarkDoneToastId === context.toastId) {
-          visibleMarkDoneToastId = undefined;
-        }
-      }
-      context?.applyUndone();
-      try {
-        await executeMarkEntitiesUndone({
-          emailIds: variables.emailIds,
-          notificationIds: variables.notificationIds,
-        });
-      } catch (err) {
-        context?.reapply();
-        throw err;
-      }
+    onSuccess: (_data, variables, context) => {
+      const firstEntityId = variables.entities[0]?.id;
+      const count = variables.entities.length;
+      const message =
+        count > 1 ? `Marked ${count} items as done` : 'Marked as done';
+      const toastRef = { id: undefined as number | undefined };
+      let handle: UndoHandle;
+
+      const showToast = () => {
+        toastRef.id = toast.success(
+          message,
+          undefined,
+          [
+            {
+              label: 'Undo',
+              icon: ArrowCounterClockwise,
+              onClick: () => {
+                handle.undo({
+                  onError: () => toast.failure('Failed to undo'),
+                });
+                restoreSoupFocus(firstEntityId, inPreview);
+              },
+            },
+          ],
+          10_000,
+          true
+        );
+      };
+
+      handle = pushUndo({
+        undo: async () => {
+          context?.applyUndone();
+          try {
+            await executeMarkEntitiesUndone({
+              emailIds: variables.emailIds,
+              notificationIds: variables.notificationIds,
+            });
+          } catch (err) {
+            context?.reapply();
+            throw err;
+          }
+        },
+        redo: async () => {
+          context?.reapply();
+          try {
+            await executeMarkEntitiesDone({
+              emailIds: variables.emailIds,
+              notificationIds: variables.notificationIds,
+            });
+          } catch (err) {
+            context?.applyUndone();
+            throw err;
+          }
+        },
+        onUndone: () => {
+          if (toastRef.id !== undefined) toast.dismiss(toastRef.id);
+        },
+        onRedone: showToast,
+        label: 'Mark Done',
+      });
+
+      showToast();
     },
-    redoFn: async (variables, context) => {
-      context?.reapply();
-      try {
-        await executeMarkEntitiesDone({
-          emailIds: variables.emailIds,
-          notificationIds: variables.notificationIds,
-        });
-        const toastId = showMarkDoneToast(variables);
-        if (context && toastId !== undefined) context.toastId = toastId;
-      } catch (err) {
-        context?.applyUndone();
-        throw err;
-      }
-    },
-    undoLabel: 'Mark Done',
   }));
 
   const canExecute = (entity: EntityData): boolean => {
@@ -160,7 +151,6 @@ export const makeMarkDoneAction = (options: MakeMarkDoneOptions) => {
     const nextEntity =
       soup.items.at(currentIndex + 1) ?? soup.items.at(currentIndex - 1);
 
-    // Run collapse animation if conditions are met (touch modality + not-done filter active)
     if (soup.collapseEntity.shouldCollapse()) {
       const collapse = soup.collapseEntity.callback();
       if (collapse) {

--- a/js/app/packages/app/component/next-soup/actions/make-mark-done-action.ts
+++ b/js/app/packages/app/component/next-soup/actions/make-mark-done-action.ts
@@ -2,8 +2,7 @@ import ArrowCounterClockwise from '@phosphor-icons/core/regular/arrow-counter-cl
 import { toast } from '@core/component/Toast/Toast';
 import { type EntityData, isTaskEntity } from '@entity';
 import type { NotificationSource } from '@notifications';
-import { useMutation } from '@tanstack/solid-query';
-import { type UndoHandle, useMutationUndoContext } from '@queries/undo';
+import { useUndoableMutation } from '@queries/undo';
 import {
   applyEntitiesDoneOptimistic,
   executeMarkEntitiesDone,
@@ -31,9 +30,8 @@ export const makeMarkDoneAction = (options: MakeMarkDoneOptions) => {
   const { notificationSource } = options;
   const previewPanel = useMaybePreviewPanel();
   const inPreview = previewPanel !== undefined;
-  const { pushUndo } = useMutationUndoContext();
 
-  const mutation = useMutation<
+  const mutation = useUndoableMutation<
     void,
     Error,
     MarkDoneVariables,
@@ -53,16 +51,40 @@ export const makeMarkDoneAction = (options: MakeMarkDoneOptions) => {
       context?.rollback();
       toast.failure('Failed to mark as done');
     },
-    onSuccess: (_data, variables, context) => {
+    undoFn: async (variables, context) => {
+      context?.applyUndone();
+      try {
+        await executeMarkEntitiesUndone({
+          emailIds: variables.emailIds,
+          notificationIds: variables.notificationIds,
+        });
+      } catch (err) {
+        context?.reapply();
+        throw err;
+      }
+    },
+    redoFn: async (variables, context) => {
+      context?.reapply();
+      try {
+        await executeMarkEntitiesDone({
+          emailIds: variables.emailIds,
+          notificationIds: variables.notificationIds,
+        });
+      } catch (err) {
+        context?.applyUndone();
+        throw err;
+      }
+    },
+    undoLabel: 'Mark Done',
+    onPushed: (handle, variables) => {
       const firstEntityId = variables.entities[0]?.id;
       const count = variables.entities.length;
       const message =
         count > 1 ? `Marked ${count} items as done` : 'Marked as done';
-      const toastRef = { id: undefined as number | undefined };
-      let handle: UndoHandle;
+      let toastId: number | undefined;
 
       const showToast = () => {
-        toastRef.id = toast.success(
+        toastId = toast.success(
           message,
           undefined,
           [
@@ -82,39 +104,14 @@ export const makeMarkDoneAction = (options: MakeMarkDoneOptions) => {
         );
       };
 
-      handle = pushUndo({
-        undo: async () => {
-          context?.applyUndone();
-          try {
-            await executeMarkEntitiesUndone({
-              emailIds: variables.emailIds,
-              notificationIds: variables.notificationIds,
-            });
-          } catch (err) {
-            context?.reapply();
-            throw err;
-          }
-        },
-        redo: async () => {
-          context?.reapply();
-          try {
-            await executeMarkEntitiesDone({
-              emailIds: variables.emailIds,
-              notificationIds: variables.notificationIds,
-            });
-          } catch (err) {
-            context?.applyUndone();
-            throw err;
-          }
-        },
+      showToast();
+
+      return {
         onUndone: () => {
-          if (toastRef.id !== undefined) toast.dismiss(toastRef.id);
+          if (toastId !== undefined) toast.dismiss(toastId);
         },
         onRedone: showToast,
-        label: 'Mark Done',
-      });
-
-      showToast();
+      };
     },
   }));
 

--- a/js/app/packages/app/component/next-soup/actions/make-mark-done-action.ts
+++ b/js/app/packages/app/component/next-soup/actions/make-mark-done-action.ts
@@ -27,6 +27,10 @@ type MarkDoneVariables = {
 
 type MarkDoneContext = MarkEntitiesDoneContext & { toastId?: number };
 
+// Only one mark-done toast may be visible at a time — an older toast's Undo
+// button would otherwise invoke the LIFO undo stack and pop the newer entry.
+let visibleMarkDoneToastId: number | undefined;
+
 /** Must be invoked inside a component tree that provides MutationUndoProvider. */
 export const makeMarkDoneAction = (options: MakeMarkDoneOptions) => {
   const { notificationSource } = options;
@@ -37,9 +41,12 @@ export const makeMarkDoneAction = (options: MakeMarkDoneOptions) => {
   const showMarkDoneToast = (
     variables: MarkDoneVariables
   ): number | undefined => {
+    if (visibleMarkDoneToastId !== undefined) {
+      toast.dismiss(visibleMarkDoneToastId);
+    }
     const count = variables.entities.length;
     const firstEntityId = variables.entities[0]?.id;
-    return toast.success(
+    const id = toast.success(
       count > 1 ? `Marked ${count} items as done` : 'Marked as done',
       undefined,
       [
@@ -57,6 +64,8 @@ export const makeMarkDoneAction = (options: MakeMarkDoneOptions) => {
       10_000,
       true
     );
+    visibleMarkDoneToastId = id;
+    return id;
   };
 
   const mutation = useUndoableMutation<
@@ -84,7 +93,12 @@ export const makeMarkDoneAction = (options: MakeMarkDoneOptions) => {
       toast.failure('Failed to mark as done');
     },
     undoFn: async (variables, context) => {
-      if (context?.toastId !== undefined) toast.dismiss(context.toastId);
+      if (context?.toastId !== undefined) {
+        toast.dismiss(context.toastId);
+        if (visibleMarkDoneToastId === context.toastId) {
+          visibleMarkDoneToastId = undefined;
+        }
+      }
       context?.applyUndone();
       try {
         await executeMarkEntitiesUndone({

--- a/js/app/packages/core/hotkey/tokens.ts
+++ b/js/app/packages/core/hotkey/tokens.ts
@@ -77,6 +77,8 @@ export const TOKENS = {
     createNewSplit: 'global.createNewSplit',
     toggleVisor: 'global.toggleVisor',
     inviteTeam: 'global.inviteTeam',
+    undo: 'global.undo',
+    redo: 'global.redo',
   },
 
   // email

--- a/js/app/packages/entity/src/extractors-notification/notification-actions.tsx
+++ b/js/app/packages/entity/src/extractors-notification/notification-actions.tsx
@@ -6,7 +6,8 @@ import {
   executeMarkNotificationsUndone,
   getAllNotificationsFromGroup,
 } from '@notifications';
-import { useMutationUndoContext, useUndoableMutation } from '@queries/undo';
+import { useMutation } from '@tanstack/solid-query';
+import { type UndoHandle, useMutationUndoContext } from '@queries/undo';
 import { useGlobalNotificationSource } from '@app/component/GlobalAppState';
 import { restoreSoupFocus } from '@app/component/next-soup/utils';
 
@@ -23,75 +24,54 @@ interface SingleNotificationActionsProps {
 }
 
 type MarkStackDoneVariables = { notificationIds: string[] };
-type MarkStackDoneContext = { toastId?: number };
-
-// Only one notification mark-done toast may be visible at a time — an older
-// toast's Undo button would otherwise invoke the LIFO undo stack and pop the
-// newer entry.
-let visibleMarkDoneToastId: number | undefined;
 
 export function useNotificationStackActions(props: NotificationActionsProps) {
   const notificationSource = useGlobalNotificationSource();
-  const undoCtx = useMutationUndoContext();
+  const { pushUndo } = useMutationUndoContext();
 
-  const showMarkDoneToast = (): number | undefined => {
-    if (visibleMarkDoneToastId !== undefined) {
-      toast.dismiss(visibleMarkDoneToastId);
-    }
-    const id = toast.success(
-      'Marked as done',
-      undefined,
-      [
-        {
-          label: 'Undo',
-          icon: ArrowCounterClockwise,
-          onClick: () => {
-            undoCtx.undo({
-              onError: () => toast.failure('Failed to undo'),
-            });
-            restoreSoupFocus();
-          },
-        },
-      ],
-      10_000,
-      true
-    );
-    visibleMarkDoneToastId = id;
-    return id;
-  };
-
-  const mutation = useUndoableMutation<
-    void,
-    Error,
-    MarkStackDoneVariables,
-    MarkStackDoneContext
-  >(() => ({
-    onMutate: () => ({}),
-    mutationFn: async (vars) =>
-      await executeMarkNotificationsDone(vars.notificationIds),
-    onSuccess: (_data, _variables, context) => {
-      const toastId = showMarkDoneToast();
-      if (context && toastId !== undefined) context.toastId = toastId;
-      props.onMarkAsDone?.();
-    },
+  const mutation = useMutation<void, Error, MarkStackDoneVariables>(() => ({
+    mutationFn: (vars) => executeMarkNotificationsDone(vars.notificationIds),
     onError: () => {
       toast.failure('Failed to mark as done');
     },
-    undoFn: async (vars, context) => {
-      if (context?.toastId !== undefined) {
-        toast.dismiss(context.toastId);
-        if (visibleMarkDoneToastId === context.toastId) {
-          visibleMarkDoneToastId = undefined;
-        }
-      }
-      await executeMarkNotificationsUndone(vars.notificationIds);
+    onSuccess: (_data, variables) => {
+      const toastRef = { id: undefined as number | undefined };
+      let handle: UndoHandle;
+
+      const showToast = () => {
+        toastRef.id = toast.success(
+          'Marked as done',
+          undefined,
+          [
+            {
+              label: 'Undo',
+              icon: ArrowCounterClockwise,
+              onClick: () => {
+                handle.undo({
+                  onError: () => toast.failure('Failed to undo'),
+                });
+                restoreSoupFocus();
+              },
+            },
+          ],
+          10_000,
+          true
+        );
+      };
+
+      handle = pushUndo({
+        undo: () => executeMarkNotificationsUndone(variables.notificationIds),
+        redo: () => executeMarkNotificationsDone(variables.notificationIds),
+        onUndone: () => {
+          if (toastRef.id !== undefined) toast.dismiss(toastRef.id);
+        },
+        onRedone: showToast,
+        label: 'Mark Done',
+      });
+
+      showToast();
+      props.onMarkAsDone?.();
     },
-    redoFn: async (vars, context) => {
-      await executeMarkNotificationsDone(vars.notificationIds);
-      const toastId = showMarkDoneToast();
-      if (context && toastId !== undefined) context.toastId = toastId;
-    },
-    undoLabel: 'Mark Done',
   }));
 
   const markStackAsDone = () => {

--- a/js/app/packages/entity/src/extractors-notification/notification-actions.tsx
+++ b/js/app/packages/entity/src/extractors-notification/notification-actions.tsx
@@ -6,8 +6,7 @@ import {
   executeMarkNotificationsUndone,
   getAllNotificationsFromGroup,
 } from '@notifications';
-import { useMutation } from '@tanstack/solid-query';
-import { type UndoHandle, useMutationUndoContext } from '@queries/undo';
+import { useUndoableMutation } from '@queries/undo';
 import { useGlobalNotificationSource } from '@app/component/GlobalAppState';
 import { restoreSoupFocus } from '@app/component/next-soup/utils';
 
@@ -27,52 +26,52 @@ type MarkStackDoneVariables = { notificationIds: string[] };
 
 export function useNotificationStackActions(props: NotificationActionsProps) {
   const notificationSource = useGlobalNotificationSource();
-  const { pushUndo } = useMutationUndoContext();
 
-  const mutation = useMutation<void, Error, MarkStackDoneVariables>(() => ({
-    mutationFn: (vars) => executeMarkNotificationsDone(vars.notificationIds),
-    onError: () => {
-      toast.failure('Failed to mark as done');
-    },
-    onSuccess: (_data, variables) => {
-      const toastRef = { id: undefined as number | undefined };
-      let handle: UndoHandle;
+  const mutation = useUndoableMutation<void, Error, MarkStackDoneVariables>(
+    () => ({
+      mutationFn: (vars) => executeMarkNotificationsDone(vars.notificationIds),
+      onError: () => {
+        toast.failure('Failed to mark as done');
+      },
+      undoFn: (vars) => executeMarkNotificationsUndone(vars.notificationIds),
+      redoFn: (vars) => executeMarkNotificationsDone(vars.notificationIds),
+      undoLabel: 'Mark Done',
+      onPushed: (handle) => {
+        let toastId: number | undefined;
 
-      const showToast = () => {
-        toastRef.id = toast.success(
-          'Marked as done',
-          undefined,
-          [
-            {
-              label: 'Undo',
-              icon: ArrowCounterClockwise,
-              onClick: () => {
-                handle.undo({
-                  onError: () => toast.failure('Failed to undo'),
-                });
-                restoreSoupFocus();
+        const showToast = () => {
+          toastId = toast.success(
+            'Marked as done',
+            undefined,
+            [
+              {
+                label: 'Undo',
+                icon: ArrowCounterClockwise,
+                onClick: () => {
+                  handle.undo({
+                    onError: () => toast.failure('Failed to undo'),
+                  });
+                  restoreSoupFocus();
+                },
               },
-            },
-          ],
-          10_000,
-          true
-        );
-      };
+            ],
+            10_000,
+            true
+          );
+        };
 
-      handle = pushUndo({
-        undo: () => executeMarkNotificationsUndone(variables.notificationIds),
-        redo: () => executeMarkNotificationsDone(variables.notificationIds),
-        onUndone: () => {
-          if (toastRef.id !== undefined) toast.dismiss(toastRef.id);
-        },
-        onRedone: showToast,
-        label: 'Mark Done',
-      });
+        showToast();
+        props.onMarkAsDone?.();
 
-      showToast();
-      props.onMarkAsDone?.();
-    },
-  }));
+        return {
+          onUndone: () => {
+            if (toastId !== undefined) toast.dismiss(toastId);
+          },
+          onRedone: showToast,
+        };
+      },
+    })
+  );
 
   const markStackAsDone = () => {
     const notifications = getAllNotificationsFromGroup(props.stack);

--- a/js/app/packages/entity/src/extractors-notification/notification-actions.tsx
+++ b/js/app/packages/entity/src/extractors-notification/notification-actions.tsx
@@ -23,47 +23,60 @@ interface SingleNotificationActionsProps {
 }
 
 type MarkStackDoneVariables = { notificationIds: string[] };
+type MarkStackDoneContext = { toastId?: number };
 
 export function useNotificationStackActions(props: NotificationActionsProps) {
   const notificationSource = useGlobalNotificationSource();
   const undoCtx = useMutationUndoContext();
 
-  const mutation = useUndoableMutation<void, Error, MarkStackDoneVariables>(
-    () => ({
-      mutationFn: async (vars) =>
-        await executeMarkNotificationsDone(vars.notificationIds),
-      onSuccess: () => {
-        const toastId = toast.success(
-          'Marked as done',
-          undefined,
-          [
-            {
-              label: 'Undo',
-              icon: ArrowCounterClockwise,
-              onClick: () => {
-                if (toastId != null) toast.dismiss(toastId);
-                undoCtx.undo({
-                  onError: () => toast.failure('Failed to undo'),
-                });
-                restoreSoupFocus();
-              },
-            },
-          ],
-          10_000,
-          true
-        );
-        props.onMarkAsDone?.();
-      },
-      onError: () => {
-        toast.failure('Failed to mark as done');
-      },
-      undoFn: async (vars) =>
-        await executeMarkNotificationsUndone(vars.notificationIds),
-      redoFn: async (vars) =>
-        await executeMarkNotificationsDone(vars.notificationIds),
-      undoLabel: 'Mark Done',
-    })
-  );
+  const showMarkDoneToast = (): number | undefined =>
+    toast.success(
+      'Marked as done',
+      undefined,
+      [
+        {
+          label: 'Undo',
+          icon: ArrowCounterClockwise,
+          onClick: () => {
+            undoCtx.undo({
+              onError: () => toast.failure('Failed to undo'),
+            });
+            restoreSoupFocus();
+          },
+        },
+      ],
+      10_000,
+      true
+    );
+
+  const mutation = useUndoableMutation<
+    void,
+    Error,
+    MarkStackDoneVariables,
+    MarkStackDoneContext
+  >(() => ({
+    onMutate: () => ({}),
+    mutationFn: async (vars) =>
+      await executeMarkNotificationsDone(vars.notificationIds),
+    onSuccess: (_data, _variables, context) => {
+      const toastId = showMarkDoneToast();
+      if (context && toastId !== undefined) context.toastId = toastId;
+      props.onMarkAsDone?.();
+    },
+    onError: () => {
+      toast.failure('Failed to mark as done');
+    },
+    undoFn: async (vars, context) => {
+      if (context?.toastId !== undefined) toast.dismiss(context.toastId);
+      await executeMarkNotificationsUndone(vars.notificationIds);
+    },
+    redoFn: async (vars, context) => {
+      await executeMarkNotificationsDone(vars.notificationIds);
+      const toastId = showMarkDoneToast();
+      if (context && toastId !== undefined) context.toastId = toastId;
+    },
+    undoLabel: 'Mark Done',
+  }));
 
   const markStackAsDone = () => {
     const notifications = getAllNotificationsFromGroup(props.stack);

--- a/js/app/packages/entity/src/extractors-notification/notification-actions.tsx
+++ b/js/app/packages/entity/src/extractors-notification/notification-actions.tsx
@@ -25,12 +25,20 @@ interface SingleNotificationActionsProps {
 type MarkStackDoneVariables = { notificationIds: string[] };
 type MarkStackDoneContext = { toastId?: number };
 
+// Only one notification mark-done toast may be visible at a time — an older
+// toast's Undo button would otherwise invoke the LIFO undo stack and pop the
+// newer entry.
+let visibleMarkDoneToastId: number | undefined;
+
 export function useNotificationStackActions(props: NotificationActionsProps) {
   const notificationSource = useGlobalNotificationSource();
   const undoCtx = useMutationUndoContext();
 
-  const showMarkDoneToast = (): number | undefined =>
-    toast.success(
+  const showMarkDoneToast = (): number | undefined => {
+    if (visibleMarkDoneToastId !== undefined) {
+      toast.dismiss(visibleMarkDoneToastId);
+    }
+    const id = toast.success(
       'Marked as done',
       undefined,
       [
@@ -48,6 +56,9 @@ export function useNotificationStackActions(props: NotificationActionsProps) {
       10_000,
       true
     );
+    visibleMarkDoneToastId = id;
+    return id;
+  };
 
   const mutation = useUndoableMutation<
     void,
@@ -67,7 +78,12 @@ export function useNotificationStackActions(props: NotificationActionsProps) {
       toast.failure('Failed to mark as done');
     },
     undoFn: async (vars, context) => {
-      if (context?.toastId !== undefined) toast.dismiss(context.toastId);
+      if (context?.toastId !== undefined) {
+        toast.dismiss(context.toastId);
+        if (visibleMarkDoneToastId === context.toastId) {
+          visibleMarkDoneToastId = undefined;
+        }
+      }
       await executeMarkNotificationsUndone(vars.notificationIds);
     },
     redoFn: async (vars, context) => {

--- a/js/app/packages/queries/undo.ts
+++ b/js/app/packages/queries/undo.ts
@@ -171,6 +171,11 @@ export const [MutationUndoProvider, useMutationUndoContext] =
     }
   );
 
+export type UndoLifecycle = {
+  onUndone?: () => void;
+  onRedone?: () => void;
+};
+
 export function useUndoableMutation<
   TData = unknown,
   TError = Error,
@@ -181,21 +186,36 @@ export function useUndoableMutation<
     undoFn?: UndoHandler<TVariables, TContext>;
     redoFn?: UndoHandler<TVariables, TContext>;
     undoLabel?: string;
+    /** Fires after the entry is pushed onto the undo stack. Returned
+     *  lifecycle hooks (onUndone/onRedone) will run on this specific
+     *  entry — regardless of whether it is undone via the returned
+     *  handle, the global LIFO `ctx.undo()`, or by a later `ctx.redo()`. */
+    onPushed?: (
+      handle: UndoHandle,
+      variables: TVariables,
+      context: TContext | undefined
+    ) => UndoLifecycle | void;
   }
 ) {
   const { pushUndo } = useMutationUndoContext();
 
   return useMutation(() => {
-    const { undoFn, redoFn, undoLabel, onSuccess, ...opts } = options();
+    const { undoFn, redoFn, undoLabel, onPushed, onSuccess, ...opts } =
+      options();
     return {
       ...opts,
       onSuccess: (data, variables, context, mutation) => {
         if (undoFn) {
-          pushUndo({
+          const lifecycleRef: { current?: UndoLifecycle } = {};
+          const handle = pushUndo({
             undo: () => undoFn(variables, context),
             redo: redoFn ? () => redoFn(variables, context) : undefined,
             label: undoLabel,
+            onUndone: () => lifecycleRef.current?.onUndone?.(),
+            onRedone: () => lifecycleRef.current?.onRedone?.(),
           });
+          lifecycleRef.current =
+            onPushed?.(handle, variables, context) ?? undefined;
         }
         onSuccess?.(data, variables, context, mutation);
       },

--- a/js/app/packages/queries/undo.ts
+++ b/js/app/packages/queries/undo.ts
@@ -7,19 +7,21 @@
  *   <App />
  * </MutationUndoProvider>
  *
- * // 2. Use undoable mutations
- * const updateItem = useUndoableMutation(() => ({
- *   mutationFn: (data) => api.update(data.id, data.value),
- *   undoFn: (variables) => api.update(variables.id, variables.previousValue),
- *   redoFn: (variables) => api.update(variables.id, variables.value),
- * }));
- *
- * // 3. Trigger undo/redo with callbacks
- * const { undo, redo, canUndo, canRedo } = useMutationUndoContext();
- * await undo({
- *   onSuccess: () => toast.success('Undone'),
- *   onError: (err) => toast.error(err.message),
+ * // 2. Push an entry directly and bind side effects (toast, highlight, etc.)
+ * //    to its lifecycle hooks.
+ * const { pushUndo } = useMutationUndoContext();
+ * const handle = pushUndo({
+ *   undo: async () => api.update(id, previousValue),
+ *   redo: async () => api.update(id, nextValue),
+ *   onUndone: () => toast.dismiss(toastId),
+ *   onRedone: () => showToast(),
  * });
+ *
+ * // 3. Target this specific entry from UI (e.g. an Undo button):
+ * handle.undo({ onError: (e) => toast.failure(e.message) });
+ *
+ * // 4. Global LIFO shortcuts (cmd+z / shift+cmd+z) use the stack top:
+ * const { undo, redo, canUndo, canRedo } = useMutationUndoContext();
  */
 
 import { type MutationOptions, useMutation } from '@tanstack/solid-query';
@@ -32,9 +34,23 @@ type UndoHandler<TVariables, TContext> = (
 ) => Promise<void> | void;
 
 type UndoEntry = {
+  id: string;
   undo: () => Promise<void> | void;
   redo?: () => Promise<void> | void;
   label?: string;
+  /** Fires after `undo` resolves, regardless of whether it was triggered by
+   *  `handle.undo()` or the global `ctx.undo()` LIFO call. */
+  onUndone?: () => void;
+  /** Fires after `redo` resolves. */
+  onRedone?: () => void;
+};
+
+export type UndoEntryInput = Omit<UndoEntry, 'id'>;
+
+export type UndoHandle = {
+  id: string;
+  /** Undo this specific entry, even if it is not at the top of the stack. */
+  undo: (callbacks?: UndoCallbacks) => Promise<void>;
 };
 
 type UndoCallbacks = {
@@ -44,13 +60,18 @@ type UndoCallbacks = {
 };
 
 type MutationUndoContextValue = {
-  pushUndo: (entry: UndoEntry) => void;
+  pushUndo: (entry: UndoEntryInput) => UndoHandle;
   canUndo: () => boolean;
   canRedo: () => boolean;
   clear: () => void;
   undo: (callbacks?: UndoCallbacks) => Promise<void>;
   redo: (callbacks?: UndoCallbacks) => Promise<void>;
 };
+
+const genId = (): string =>
+  typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+    ? crypto.randomUUID()
+    : `undo-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 
 export const [MutationUndoProvider, useMutationUndoContext] =
   createAssertedContextProvider(
@@ -59,10 +80,70 @@ export const [MutationUndoProvider, useMutationUndoContext] =
       const [undoStack, setUndoStack] = createSignal<UndoEntry[]>([]);
       const [redoStack, setRedoStack] = createSignal<UndoEntry[]>([]);
 
+      const runUndo = async (
+        entry: UndoEntry,
+        callbacks?: UndoCallbacks
+      ): Promise<void> => {
+        const current = undoStack();
+        const prevPos = current.indexOf(entry);
+        // Already removed (e.g. handle.undo() called twice, or entry was
+        // cleared by a new pushUndo after redoStack reset).
+        if (prevPos < 0) return;
+
+        setUndoStack(current.filter((e) => e !== entry));
+        try {
+          await entry.undo();
+          if (entry.redo) {
+            setRedoStack((prev) => [...prev, entry]);
+          }
+          entry.onUndone?.();
+          callbacks?.onSuccess?.();
+        } catch (err) {
+          // Restore at original position so a non-top undo that fails doesn't
+          // reorder the stack.
+          setUndoStack((prev) => {
+            const next = [...prev];
+            next.splice(Math.min(prevPos, next.length), 0, entry);
+            return next;
+          });
+          callbacks?.onError?.(
+            err instanceof Error ? err : new Error(String(err))
+          );
+        } finally {
+          callbacks?.onSettled?.();
+        }
+      };
+
+      const runRedo = async (
+        entry: UndoEntry,
+        callbacks?: UndoCallbacks
+      ): Promise<void> => {
+        try {
+          if (entry.redo) {
+            await entry.redo();
+          }
+          setUndoStack((prev) => [...prev, entry]);
+          entry.onRedone?.();
+          callbacks?.onSuccess?.();
+        } catch (err) {
+          setRedoStack((prev) => [...prev, entry]);
+          callbacks?.onError?.(
+            err instanceof Error ? err : new Error(String(err))
+          );
+        } finally {
+          callbacks?.onSettled?.();
+        }
+      };
+
       return {
-        pushUndo: (entry) => {
+        pushUndo: (input) => {
+          const entry: UndoEntry = { ...input, id: genId() };
           setUndoStack((prev) => [...prev, entry]);
           setRedoStack([]);
+          return {
+            id: entry.id,
+            undo: (callbacks) => runUndo(entry, callbacks),
+          };
         },
 
         canUndo: () => undoStack().length > 0,
@@ -73,48 +154,18 @@ export const [MutationUndoProvider, useMutationUndoContext] =
           setRedoStack([]);
         },
 
-        undo: async (callbacks?: UndoCallbacks) => {
-          const stack = undoStack();
-          const entry = stack.at(-1);
+        undo: async (callbacks) => {
+          const entry = undoStack().at(-1);
           if (!entry) return;
-
-          setUndoStack(stack.slice(0, -1));
-          try {
-            await entry.undo();
-            if (entry.redo) {
-              setRedoStack((prev) => [...prev, entry]);
-            }
-            callbacks?.onSuccess?.();
-          } catch (err) {
-            setUndoStack((prev) => [...prev, entry]);
-            callbacks?.onError?.(
-              err instanceof Error ? err : new Error(String(err))
-            );
-          } finally {
-            callbacks?.onSettled?.();
-          }
+          await runUndo(entry, callbacks);
         },
 
-        redo: async (callbacks?: UndoCallbacks) => {
+        redo: async (callbacks) => {
           const stack = redoStack();
           const entry = stack.at(-1);
           if (!entry) return;
-
           setRedoStack(stack.slice(0, -1));
-          try {
-            if (entry.redo) {
-              await entry.redo();
-            }
-            setUndoStack((prev) => [...prev, entry]);
-            callbacks?.onSuccess?.();
-          } catch (err) {
-            setRedoStack((prev) => [...prev, entry]);
-            callbacks?.onError?.(
-              err instanceof Error ? err : new Error(String(err))
-            );
-          } finally {
-            callbacks?.onSettled?.();
-          }
+          await runRedo(entry, callbacks);
         },
       };
     }


### PR DESCRIPTION
Stacked on top of #2701.

## Summary
- Adds `TOKENS.global.undo` and `TOKENS.global.redo`, plus a `GlobalUndoHotkeys` component mounted inside `MutationUndoProvider` that binds `cmd+z` / `shift+cmd+z` to `ctx.undo()` / `ctx.redo()`. Hotkeys are registered at the `global` scope so editors (inputs, canvas, lexical) still win their own undo semantics.
- Adds a `redo()` method to `MarkNotificationsDoneHandle` and `MarkDoneHandle` and wires it into `useUndoableMutation`'s `redoFn` so `shift+cmd+z` actually re-applies the last mark-as-done.
