### PR TITLE
feat(sync): exists should use head instead of get

### DIFF
--- a/js/app/packages/service-clients/service-sync/client.ts
+++ b/js/app/packages/service-clients/service-sync/client.ts
@@ -132,7 +132,7 @@ export const syncServiceClient = {
   },
   async exists(args: { documentId: string }) {
     const res = await syncFetch(`/document/${args.documentId}/exists`, {
-      method: 'GET',
+      method: 'HEAD',
     });
 
     if (isErr(res)) {


### PR DESCRIPTION
- `exists` should use `HEAD` instead of `GET` to avoid waiting for do output gate blocking content downloading
