### PR TITLE
feat(onboarding): refine sidebar glow, lesson flow, and editor interactions

### DIFF
--- a/js/app/packages/app/component/interactive-onboarding/components/MockAppChrome.tsx
+++ b/js/app/packages/app/component/interactive-onboarding/components/MockAppChrome.tsx
@@ -157,8 +157,8 @@ export function MockAppChrome(props: MockAppChromeProps) {
     <div class="size-full p-4 bg-panel">
       <style>{`
         @keyframes sidebar-glow-pulse {
-          0%, 100% { box-shadow: 0 0 0 0 rgb(from var(--color-accent) r g b / 0.5), 0 0 8px 2px rgb(from var(--color-accent) r g b / 0.35); }
-          50%      { box-shadow: 0 0 0 2px rgb(from var(--color-accent) r g b / 0.15), 0 0 14px 4px rgb(from var(--color-accent) r g b / 0.55); }
+          0%, 100% { box-shadow: 0 0 0 0 rgb(from var(--color-accent) r g b / 0.7), 0 0 6px 1px rgb(from var(--color-accent) r g b / 0.7), 0 0 12px 3px rgb(from var(--color-accent) r g b / 0.4); }
+          50%      { box-shadow: 0 0 0 1px rgb(from var(--color-accent) r g b / 0.4), 0 0 10px 3px rgb(from var(--color-accent) r g b / 0.9), 0 0 18px 6px rgb(from var(--color-accent) r g b / 0.6); }
         }
         .sidebar-glow { animation: sidebar-glow-pulse 1.8s ease-in-out infinite; border-radius: 4px; }
       `}</style>

--- a/js/app/packages/app/component/interactive-onboarding/lessons/about-us.tsx
+++ b/js/app/packages/app/component/interactive-onboarding/lessons/about-us.tsx
@@ -65,7 +65,7 @@ const PANELS: { icon: () => JSX.Element; label: string }[] = [
   },
   {
     icon: () => <UsersThree class="size-12 text-accent" />,
-    label: 'Trusted by over 170k users',
+    label: 'Trusted by over 200k users',
   },
 ];
 

--- a/js/app/packages/app/component/interactive-onboarding/lessons/choose-plan.tsx
+++ b/js/app/packages/app/component/interactive-onboarding/lessons/choose-plan.tsx
@@ -11,7 +11,7 @@ function ChoosePlanContent(props: LessonContentProps) {
 
   return (
     <div class="flex flex-col gap-3 onboarding-stagger">
-      <p>Pick the plan that works best for your team.</p>
+      <p>Pick the plan that matches how you want to use Macro.</p>
     </div>
   );
 }

--- a/js/app/packages/app/component/interactive-onboarding/lessons/command-k.tsx
+++ b/js/app/packages/app/component/interactive-onboarding/lessons/command-k.tsx
@@ -63,7 +63,7 @@ function CommandKContent(_props: LessonContentProps) {
       </div>
       <ClickCallout
         icon={AnimatedCommandIcon}
-        label="in the sidebar"
+        label="in the sidebar (bottom)"
         completed={completed()}
       />
     </div>
@@ -189,5 +189,5 @@ export const commandKLesson: LessonDefinition = {
   title: 'Command Menu',
   content: CommandKContent,
   demo: CommandKDemo,
-  order: 40,
+  order: 45,
 };

--- a/js/app/packages/app/component/interactive-onboarding/lessons/create-entity.tsx
+++ b/js/app/packages/app/component/interactive-onboarding/lessons/create-entity.tsx
@@ -43,12 +43,24 @@ const BLOCK_TO_SANDBOX: Record<string, SandboxEntityType> = {
 
 // Module-level signals shared between content (left) and demo (right)
 const [sharedSoup, setSharedSoup] = createSignal<SoupState | undefined>();
-const [onCreated, setOnCreated] = createSignal<(() => void) | undefined>();
-const [launcherOpen, setLauncherOpen] = createSignal(false);
+const [launcherOpen, setLauncherOpenRaw] = createSignal(false);
 const [completed, setCompleted] = createSignal(false);
+const [onLauncherOpened, setOnLauncherOpened] = createSignal<
+  (() => void) | undefined
+>();
+
+// Wrap the setter so opening the launcher also fires the lesson-completion
+// callback. This replaces a createEffect on launcherOpen — per AGENTS.md,
+// prefer wrapping the setter over using an effect to trigger updates.
+const setLauncherOpen = (value: boolean | ((prev: boolean) => boolean)) => {
+  const next = typeof value === 'function' ? value(launcherOpen()) : value;
+  const wasOpen = launcherOpen();
+  setLauncherOpenRaw(next);
+  if (next && !wasOpen) onLauncherOpened()?.();
+};
 
 function CreateEntityContent(props: LessonContentProps) {
-  setOnCreated(() => () => {
+  setOnLauncherOpened(() => () => {
     if (!completed()) {
       setCompleted(true);
       props.onComplete();
@@ -70,10 +82,12 @@ function CreateEntityContent(props: LessonContentProps) {
     }).withGroup(group);
   });
 
-  // Return focus to content panel when launcher closes
+  // Return focus to content panel when launcher closes, but only while the
+  // lesson is still in progress. Once completed, the parent auto-focuses the
+  // Continue button — refocusing here would steal it back.
   createEffect(
     on(launcherOpen, (open, prevOpen) => {
-      if (!open && prevOpen) {
+      if (!open && prevOpen && !completed()) {
         containerRef?.focus();
       }
     })
@@ -82,7 +96,7 @@ function CreateEntityContent(props: LessonContentProps) {
   onCleanup(() => {
     group.dispose();
     setLauncherOpen(false);
-    setOnCreated(undefined);
+    setOnLauncherOpened(undefined);
     setCompleted(false);
   });
 
@@ -140,7 +154,6 @@ function CreateEntityDemo(props: LessonContentProps) {
       if (sandboxType) {
         const entity = createSandboxEntity(sandboxType);
         addSandboxEntity(entity);
-        onCreated()?.();
       }
       setLauncherOpen(false);
       return true;
@@ -166,7 +179,18 @@ function CreateEntityDemo(props: LessonContentProps) {
       <Dialog open={launcherOpen()} onOpenChange={setLauncherOpen} modal={true}>
         <Dialog.Portal>
           <Dialog.Overlay class="fixed inset-0 z-modal bg-modal-overlay pattern-diagonal-4 pattern-edge-muted" />
-          <Dialog.Content>
+          <Dialog.Content
+            onCloseAutoFocus={(e) => {
+              // Once the lesson is complete, don't let the Dialog restore
+              // focus to the element that opened it (containerRef or the `+`
+              // button). Re-fire onComplete so the parent schedules focus on
+              // the Continue button — otherwise Enter won't advance the step.
+              if (completed()) {
+                e.preventDefault();
+                props.onComplete();
+              }
+            }}
+          >
             <div
               class="fixed inset-0 z-modal w-screen h-screen flex items-center justify-center"
               onClick={(e) => {
@@ -191,5 +215,5 @@ export const createEntityLesson: LessonDefinition = {
   subtitle: 'Use the launcher to create docs, emails, and more.',
   content: CreateEntityContent,
   demo: CreateEntityDemo,
-  order: 45,
+  order: 40,
 };

--- a/js/app/packages/app/component/interactive-onboarding/lessons/markdown-mentions.tsx
+++ b/js/app/packages/app/component/interactive-onboarding/lessons/markdown-mentions.tsx
@@ -15,12 +15,13 @@ function MarkdownMentionsContent(_props: LessonContentProps) {
     <div class="flex flex-col gap-3 onboarding-stagger">
       <HotkeyCallout
         keys={['@']}
-        label="to mention someone"
+        label="to mention someone or something"
         completed={completed()}
       />
       <p>
         Macro's editor supports rich markdown, mentions, and emoji. Try
-        mentioning something by typing <strong>@</strong> in the editor.
+        mentioning someone or something by typing <strong>@</strong> in the
+        editor.
       </p>
     </div>
   );

--- a/js/app/packages/app/component/interactive-onboarding/lessons/markdown-mentions.tsx
+++ b/js/app/packages/app/component/interactive-onboarding/lessons/markdown-mentions.tsx
@@ -19,8 +19,8 @@ function MarkdownMentionsContent(_props: LessonContentProps) {
         completed={completed()}
       />
       <p>
-        Macro's editor supports rich markdown, mentions, and emoji. Try typing
-        something or mentioning a teammate with <strong>@</strong>.
+        Macro's editor supports rich markdown, mentions, and emoji. Try
+        mentioning something by typing <strong>@</strong> in the editor.
       </p>
     </div>
   );
@@ -63,9 +63,10 @@ function MarkdownMentionsDemo(props: LessonContentProps) {
 
   return (
     <MockAppChrome>
-      <div class="px-8 py-6">
+      <div class="h-full flex flex-col px-8 py-6">
         <h1 class="text-3xl font-semibold text-ink mb-4">Daily Note</h1>
         <MarkdownShell
+          class="flex-1 min-h-0 cursor-text"
           config={config}
           placeholder="Start typing... use @ to mention"
           autofocus
@@ -78,7 +79,6 @@ function MarkdownMentionsDemo(props: LessonContentProps) {
 export const markdownMentionsLesson: LessonDefinition = {
   id: 'markdown-mentions',
   title: 'Editor',
-  subtitle: 'Rich text with mentions and emoji.',
   content: MarkdownMentionsContent,
   demo: MarkdownMentionsDemo,
   order: 50,


### PR DESCRIPTION
## Summary

Polish pass on the interactive onboarding flow.

### Glow
- Tightened the sidebar highlight pulse: brighter alpha, smaller blur radius. Keeps the icon halo noticeable without blooming across the sidebar.

### Lesson flow
- Swapped the order so **Create** comes before **Command Menu**.
- **Create** now completes as soon as the launcher opens (hotkey `C` or the `+` button) — no longer requires picking a block type. Refactored the completion trigger from a `createEffect` to a wrapped setter per `AGENTS.md`.
- Fixed a focus bug on the Create step: when the user picked a block, the Dialog's close-auto-focus stole focus back to whatever opened it, so Enter couldn't advance the lesson. Now `Dialog.Content` preventDefaults close-auto-focus once the lesson is complete and re-triggers `onComplete` so the parent refocuses the Continue button.

### Editor step
- Made the whole "Daily Note" pane a clickable text-input target (full-height wrapper + `flex-1 min-h-0 cursor-text` on the `MarkdownShell`). Click anywhere below the title to focus the editor.
- Added a mention hotkey callout.

### Copy
- "Pick the plan that works best for your team." → "Pick the plan that matches how you want to use Macro."
- About-us: "170k users" → "200k users".