### PR TITLE
feat(onboarding): fire subscription_success for free-tier selection

### DIFF
--- a/js/app/packages/app/component/interactive-onboarding/lessons/choose-plan.tsx
+++ b/js/app/packages/app/component/interactive-onboarding/lessons/choose-plan.tsx
@@ -23,7 +23,10 @@ function ChoosePlanDemo(props: LessonContentProps) {
   const handleCheckout = async (tier: string) => {
     if (loading()) return;
     if (tier === 'free') {
-      analytics.track('subscription_start', { type: tier });
+      // Free bypasses Stripe, so fire subscription_success directly here to
+      // stay symmetric with the paid path (which fires it on Stripe return
+      // via Root.tsx's ?subscriptionSuccess handler).
+      analytics.track('subscription_success', { type: tier });
       // Advance to the launch step rather than leaving onboarding.
       props.advance();
       return;


### PR DESCRIPTION
## Summary

In the onboarding `choose-plan` step, the free-tier branch previously fired `subscription_start` — the same event the paid branches fire *before* redirecting to Stripe. That left free and paid on asymmetric footing: paid tiers fire `subscription_success` on Stripe return via `Root.tsx`'s `?subscriptionSuccess` handler, but free had no success event at all.

Since free bypasses Stripe entirely, its click *is* the success signal. This change swaps the free branch to fire `subscription_success` with `{ type: 'free' }`, making `subscription_success` a unified "plan activated" metric across all four tiers (free/haiku/sonnet/opus).

## Details

- `choose-plan.tsx`: free branch now tracks `subscription_success` instead of `subscription_start`.
- Paid branch is unchanged — `subscription_start` still fires pre-redirect as the intent signal, and `subscription_success` fires on Stripe return in `Root.tsx`.

## Funnel semantics

- `subscription_start` (paid tiers only) — user clicked a paid plan, about to hit Stripe.
- `subscription_success` (all tiers) — user activated a plan. Paid count < start count by the number who bail on Stripe checkout; free fires success directly.
