### PR TITLE
fix(search): keep tab in search, hint @mention in placeholder

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/soup-view-search-bar.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/soup-view-search-bar.tsx
@@ -64,6 +64,10 @@ export const SoupSearchbar = (props: SoupSearchbarProps) => {
       editor.controls.blur();
       props.onDismiss?.();
       return true;
+    })
+    .onTab((e) => {
+      e.preventDefault();
+      return true;
     });
 
   // Sync search text + mention filters only when the mention menu is closed.
@@ -120,7 +124,7 @@ export const SoupSearchbar = (props: SoupSearchbarProps) => {
         >
           <MarkdownShell
             config={editor}
-            placeholder="Search"
+            placeholder="Search, @mention contacts"
             autofocus={props.autoFocus}
             class="!min-h-0 !overflow-visible"
           />


### PR DESCRIPTION
## Summary
- Tab in the soup search bar was moving focus from the left pane's search to the right pane's search. Hooking `onTab` via the Lexical builder so `preventDefault` actually lands — the wrapping `onKeyDown` never received the event because `MarkdownShell.tsx:182` calls `stopPropagation` on keydown.
- Extend the placeholder from `"Search"` to `"Search, @mention contacts"` to surface the existing `@` mention filter.