### PR TITLE
fix(search): only hint @mention in sidebar search placeholder

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/soup-filters-bar.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/soup-filters-bar.tsx
@@ -71,7 +71,7 @@ export const SoupFiltersBar = () => {
     <Switch>
       <Match when={isComponentListView('search')}>
         <div class="w-full flex flex-col gap-2 p-2 border-b border-edge-muted/50">
-          <SoupSearchbar autoFocus />
+          <SoupSearchbar autoFocus placeholder="Search, @mention contacts" />
           <div class="flex items-start gap-2">
             <UnifiedFilterDropdown />
             <ActiveFilterChips

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/soup-view-search-bar.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/soup-view-search-bar.tsx
@@ -16,6 +16,7 @@ interface SoupSearchbarProps {
   variant?: SearchbarVariant;
   autoFocus?: boolean;
   onDismiss?: () => void;
+  placeholder?: string;
 }
 
 const variantStyles: Record<SearchbarVariant, string> = {
@@ -124,7 +125,7 @@ export const SoupSearchbar = (props: SoupSearchbarProps) => {
         >
           <MarkdownShell
             config={editor}
-            placeholder="Search, @mention contacts"
+            placeholder={props.placeholder ?? 'Search'}
             autofocus={props.autoFocus}
             class="!min-h-0 !overflow-visible"
           />


### PR DESCRIPTION
## Summary
- #2730 changed the SoupSearchbar placeholder to "Search, @mention contacts", which leaked the hint into the filled/narrow-expanded search bars in every soup view.
- Gate the hint behind an optional placeholder prop and only pass it from the sidebar search list view (SoupFiltersBar's isComponentListView('search') branch). Other call sites fall back to "Search".