### PR TITLE
fix(search): render name highlight when not on first result

### DIFF
--- a/js/app/packages/queries/soup/transform-utils.ts
+++ b/js/app/packages/queries/soup/transform-utils.ts
@@ -138,7 +138,8 @@ const getSearchData = (data: TypedInnerSearchResult): SearchData => {
     }
   }
 
-  const nameHighlight = data.results.at(0)?.highlight.name ?? null;
+  const nameHighlight =
+    data.results.find((r) => r.highlight.name)?.highlight.name ?? null;
 
   let senderHighlightTerms: string[] | null = null;
   if (data.type === 'email') {


### PR DESCRIPTION
## Summary

- `getSearchData` in `transform-utils.ts` read `highlight.name` only from `data.results[0]`
- When a document had both a content match (node_id present, no name highlight) and a name match (node_id null, name highlight set), the name match was always second, so its `highlight.name` was dropped and the sidebar showed no highlighted snippet
- Switched to `find(r => r.highlight.name)` so the name highlight is picked up from whichever result actually carries it