### PR TITLE
chore(name_search): split highlight module into its own file

### DIFF
--- a/rust/cloud-storage/call/src/domain/service.rs
+++ b/rust/cloud-storage/call/src/domain/service.rs
@@ -4,9 +4,7 @@
 mod test;
 
 use connection::domain::ports::ConnectionService;
-use entity_access::domain::models::{
-    EntityAccessReceipt, EntityType, ViewAccessLevel,
-};
+use entity_access::domain::models::{EntityAccessReceipt, EntityType, ViewAccessLevel};
 use entity_access::domain::ports::EntityAccessService;
 use macro_user_id::cowlike::CowLike;
 use macro_user_id::user_id::MacroUserIdStr;

--- a/rust/cloud-storage/name_search/src/highlight.rs
+++ b/rust/cloud-storage/name_search/src/highlight.rs
@@ -1,0 +1,23 @@
+//! In-memory name highlighting that mirrors the Postgres
+//! `regexp_replace(..., 'gi')` applied by the SQL name-search queries.
+
+use crate::escape_regex;
+
+/// Applies the same `<macro_em>` name-highlight replacement that the Postgres
+/// name-search queries apply via `regexp_replace(..., 'gi')`, but against an
+/// in-memory name string. Returns `None` when the term is empty or the name
+/// does not contain the term (case-insensitive).
+pub fn highlight_name(name: &str, term: &str) -> Option<String> {
+    let term = term.trim();
+    if term.is_empty() {
+        return None;
+    }
+    let re = regex::Regex::new(&format!("(?i)({})", escape_regex(term))).ok()?;
+    if !re.is_match(name) {
+        return None;
+    }
+    Some(re.replace_all(name, "<macro_em>$1</macro_em>").into_owned())
+}
+
+#[cfg(test)]
+mod test;

--- a/rust/cloud-storage/name_search/src/highlight/test.rs
+++ b/rust/cloud-storage/name_search/src/highlight/test.rs
@@ -1,0 +1,40 @@
+use super::highlight_name;
+
+#[test]
+fn returns_none_for_empty_term() {
+    assert!(highlight_name("testingfoop", "").is_none());
+    assert!(highlight_name("testingfoop", "   ").is_none());
+}
+
+#[test]
+fn returns_none_when_name_does_not_match() {
+    assert!(highlight_name("unrelated", "test").is_none());
+}
+
+#[test]
+fn wraps_substring_matches_case_insensitively() {
+    assert_eq!(
+        highlight_name("testingfoop", "test").as_deref(),
+        Some("<macro_em>test</macro_em>ingfoop")
+    );
+    assert_eq!(
+        highlight_name("MD CHECKBOX LIST TEST", "test").as_deref(),
+        Some("MD CHECKBOX LIST <macro_em>TEST</macro_em>")
+    );
+}
+
+#[test]
+fn wraps_all_occurrences() {
+    assert_eq!(
+        highlight_name("test of a test", "test").as_deref(),
+        Some("<macro_em>test</macro_em> of a <macro_em>test</macro_em>")
+    );
+}
+
+#[test]
+fn escapes_regex_specials_in_term() {
+    assert_eq!(
+        highlight_name("plan (v2) draft", "(v2)").as_deref(),
+        Some("plan <macro_em>(v2)</macro_em> draft")
+    );
+}

--- a/rust/cloud-storage/name_search/src/lib.rs
+++ b/rust/cloud-storage/name_search/src/lib.rs
@@ -3,10 +3,12 @@
 
 mod chat;
 mod document;
+mod highlight;
 mod project;
 
 pub use chat::*;
 pub use document::*;
+pub use highlight::*;
 pub use models_opensearch::SearchEntityType;
 use models_search_cursor::{PaginatedResult, SearchCursorAttributes};
 pub use project::*;
@@ -24,66 +26,6 @@ pub fn escape_regex(term: &str) -> String {
         escaped.push(c);
     }
     escaped
-}
-
-/// Applies the same `<macro_em>` name-highlight replacement that the Postgres
-/// name-search queries apply via `regexp_replace(..., 'gi')`, but against an
-/// in-memory name string. Returns `None` when the term is empty or the name
-/// does not contain the term (case-insensitive).
-pub fn highlight_name(name: &str, term: &str) -> Option<String> {
-    let term = term.trim();
-    if term.is_empty() {
-        return None;
-    }
-    let re = regex::Regex::new(&format!("(?i)({})", escape_regex(term))).ok()?;
-    if !re.is_match(name) {
-        return None;
-    }
-    Some(re.replace_all(name, "<macro_em>$1</macro_em>").into_owned())
-}
-
-#[cfg(test)]
-mod highlight_test {
-    use super::highlight_name;
-
-    #[test]
-    fn returns_none_for_empty_term() {
-        assert!(highlight_name("testingfoop", "").is_none());
-        assert!(highlight_name("testingfoop", "   ").is_none());
-    }
-
-    #[test]
-    fn returns_none_when_name_does_not_match() {
-        assert!(highlight_name("unrelated", "test").is_none());
-    }
-
-    #[test]
-    fn wraps_substring_matches_case_insensitively() {
-        assert_eq!(
-            highlight_name("testingfoop", "test").as_deref(),
-            Some("<macro_em>test</macro_em>ingfoop")
-        );
-        assert_eq!(
-            highlight_name("MD CHECKBOX LIST TEST", "test").as_deref(),
-            Some("MD CHECKBOX LIST <macro_em>TEST</macro_em>")
-        );
-    }
-
-    #[test]
-    fn wraps_all_occurrences() {
-        assert_eq!(
-            highlight_name("test of a test", "test").as_deref(),
-            Some("<macro_em>test</macro_em> of a <macro_em>test</macro_em>")
-        );
-    }
-
-    #[test]
-    fn escapes_regex_specials_in_term() {
-        assert_eq!(
-            highlight_name("plan (v2) draft", "(v2)").as_deref(),
-            Some("plan <macro_em>(v2)</macro_em> draft")
-        );
-    }
 }
 
 /// Errors for name search crate


### PR DESCRIPTION
## Summary

- Extracts the `highlight_name` helper and its unit tests out of `name_search/src/lib.rs` into `highlight.rs` + `highlight/test.rs`, matching the `chat`/`document`/`project` layout the rest of the crate already uses.
- `escape_regex` stays at the crate root since it's shared by the SQL name-search modules and the new `highlight` module.