### PR TITLE
feat(task): notify assignees of comments

### DIFF
--- a/rust/cloud-storage/document_storage_service/src/api/annotations/create_comment.rs
+++ b/rust/cloud-storage/document_storage_service/src/api/annotations/create_comment.rs
@@ -113,7 +113,11 @@ pub async fn create_comment_handler(
                     Ok(Some(PropertyValue::EntityRef(refs))) => {
                         refs.iter().map(|r| r.entity_id.clone()).collect()
                     }
-                    _ => vec![],
+                    Ok(_) => vec![],
+                    Err(e) => {
+                        tracing::error!(error = ?e, document_id = %document_id, "failed to fetch task assignees for comment notification");
+                        vec![]
+                    }
                 };
 
                 let recipients = compute_notification_recipients(

--- a/rust/cloud-storage/document_storage_service/src/api/annotations/create_comment.rs
+++ b/rust/cloud-storage/document_storage_service/src/api/annotations/create_comment.rs
@@ -25,8 +25,11 @@ use model::{
     response::ErrorResponse,
     user::UserContext,
 };
+use models_properties::service::property_value::PropertyValue;
 use notification::domain::service::NotificationIngress;
+use properties::PropertiesService as _;
 use sqlx::PgPool;
+use system_properties::SystemPropertyKey;
 
 use super::comment_error_response;
 
@@ -52,8 +55,10 @@ pub struct Params {
         )
     )]
 #[axum::debug_handler(state = ApiContext)]
+#[expect(clippy::too_many_arguments, reason = "axum handler extractors")]
 pub async fn create_comment_handler(
     State(notification_ingress_service): State<Arc<crate::api::context::NotificationIngressType>>,
+    State(properties_service): State<Arc<crate::api::context::PropertiesService>>,
     State(db): State<PgPool>,
     State(conn_gateway_client): State<Arc<ConnectionGatewayClient>>,
     Extension(UserContext { user_id, .. }): Extension<UserContext>,
@@ -97,10 +102,25 @@ pub async fn create_comment_handler(
                     .map(|c| c.owner.clone())
                     .collect();
 
+                let task_assignee_ids: Vec<String> = match properties_service
+                    .get_system_property_value(
+                        &document_id,
+                        models_properties::EntityType::Task,
+                        SystemPropertyKey::Assignees,
+                    )
+                    .await
+                {
+                    Ok(Some(PropertyValue::EntityRef(refs))) => {
+                        refs.iter().map(|r| r.entity_id.clone()).collect()
+                    }
+                    _ => vec![],
+                };
+
                 let recipients = compute_notification_recipients(
                     sender_id.as_ref(),
                     mentioned_user_ids,
                     &thread_comment_owners,
+                    &task_assignee_ids,
                     &document_context.owner,
                     is_reply,
                 );
@@ -147,7 +167,21 @@ pub async fn create_comment_handler(
                         .inspect_err(|e| tracing::error!(error =? e, "couldn't send thread reply notification"));
                 }
 
-                // 3. Document owner notification (lowest priority)
+                // 3. Task assignee notifications
+                if !recipients.assignee_recipients.is_empty() {
+                    let request = notif_ctx
+                        .build_task_assignee_comment_notif(recipients.assignee_recipients)
+                        .into_request()
+                        .with_apns()
+                        .with_conn_gateway();
+
+                    _ = notification_ingress_service
+                        .send_notification(request)
+                        .await
+                        .inspect_err(|e| tracing::error!(error =? e, "couldn't send task assignee comment notification"));
+                }
+
+                // 4. Document owner notification (lowest priority)
                 if recipients.doc_owner_recipient.is_some() {
                     let request = notif_ctx
                         .build_document_comment_notif()

--- a/rust/cloud-storage/document_storage_service/src/api/annotations/mod.rs
+++ b/rust/cloud-storage/document_storage_service/src/api/annotations/mod.rs
@@ -293,11 +293,8 @@ impl CommentNotifContext {
         }
     }
 
-    pub fn build_task_assignee_comment_notif(
-        &self,
-        assignee_ids: HashSet<MacroUserIdStr<'static>>,
-    ) -> SendNotificationRequestBuilder<'static, CommentedOnDocumentMetadata> {
-        let notification = CommentedOnDocumentMetadata {
+    fn commented_on_document_metadata(&self) -> CommentedOnDocumentMetadata {
+        CommentedOnDocumentMetadata {
             document_name: self.document_name.clone(),
             owner: self.owner.clone(),
             file_type: self.file_type.clone(),
@@ -305,11 +302,16 @@ impl CommentNotifContext {
             thread_id: self.thread_id,
             text: self.text.clone(),
             sender_profile_picture_url: self.sender_profile_picture_url.clone(),
-        };
+        }
+    }
 
+    pub fn build_task_assignee_comment_notif(
+        &self,
+        assignee_ids: HashSet<MacroUserIdStr<'static>>,
+    ) -> SendNotificationRequestBuilder<'static, CommentedOnDocumentMetadata> {
         SendNotificationRequestBuilder {
             notification_entity: EntityType::Document.with_entity_string(self.document_id.clone()),
-            notification,
+            notification: self.commented_on_document_metadata(),
             sender_id: self.sender_id.clone(),
             recipient_ids: assignee_ids,
         }
@@ -318,22 +320,12 @@ impl CommentNotifContext {
     pub fn build_document_comment_notif(
         &self,
     ) -> SendNotificationRequestBuilder<'static, CommentedOnDocumentMetadata> {
-        let notification = CommentedOnDocumentMetadata {
-            document_name: self.document_name.clone(),
-            owner: self.owner.clone(),
-            file_type: self.file_type.clone(),
-            comment_id: self.comment_id,
-            thread_id: self.thread_id,
-            text: self.text.clone(),
-            sender_profile_picture_url: self.sender_profile_picture_url.clone(),
-        };
-
         let mut recipient_ids = HashSet::new();
         recipient_ids.insert(self.owner.clone());
 
         SendNotificationRequestBuilder {
             notification_entity: EntityType::Document.with_entity_string(self.document_id.clone()),
-            notification,
+            notification: self.commented_on_document_metadata(),
             sender_id: self.sender_id.clone(),
             recipient_ids,
         }

--- a/rust/cloud-storage/document_storage_service/src/api/annotations/mod.rs
+++ b/rust/cloud-storage/document_storage_service/src/api/annotations/mod.rs
@@ -135,6 +135,7 @@ pub(crate) fn compute_notification_recipients(
     sender_id: Option<&MacroUserIdStr<'_>>,
     mentioned_user_ids: &[String],
     thread_comment_owners: &[String],
+    task_assignee_ids: &[String],
     document_owner: &MacroUserIdStr<'_>,
     is_reply: bool,
 ) -> NotificationRecipients {
@@ -162,7 +163,20 @@ pub(crate) fn compute_notification_recipients(
         }
     }
 
-    // 3. Document owner — only if not sender and not already notified
+    // 3. Task assignee recipients — only if not sender and not already notified
+    let mut assignee_recipients: HashSet<MacroUserIdStr<'static>> = HashSet::new();
+    for assignee_str in task_assignee_ids {
+        if let Ok(parsed) = MacroUserIdStr::try_from(assignee_str.clone()) {
+            let normalized = parsed.as_ref().to_string();
+            let is_sender = sender_id.is_some_and(|s| s.as_ref() == normalized);
+            if !is_sender && !notified.contains(&normalized) {
+                notified.insert(normalized);
+                assignee_recipients.insert(parsed);
+            }
+        }
+    }
+
+    // 4. Document owner — only if not sender and not already notified
     let owner_normalized = document_owner.as_ref().to_string();
     let owner_is_sender = sender_id.is_some_and(|s| s.as_ref() == owner_normalized);
     let doc_owner_recipient = if !owner_is_sender && !notified.contains(&owner_normalized) {
@@ -174,6 +188,7 @@ pub(crate) fn compute_notification_recipients(
     NotificationRecipients {
         mention_recipients,
         thread_reply_recipients,
+        assignee_recipients,
         doc_owner_recipient,
     }
 }
@@ -183,6 +198,8 @@ pub(crate) struct NotificationRecipients {
     pub mention_recipients: HashSet<MacroUserIdStr<'static>>,
     /// Users who should get a thread reply notification (already parsed and owned).
     pub thread_reply_recipients: HashSet<MacroUserIdStr<'static>>,
+    /// Task assignees who should get a "commented on your task" notification.
+    pub assignee_recipients: HashSet<MacroUserIdStr<'static>>,
     /// The document owner, if they should get a "commented on your document" notification.
     pub doc_owner_recipient: Option<String>,
 }
@@ -198,6 +215,9 @@ impl NotificationRecipients {
         for r in &self.thread_reply_recipients {
             all.insert(r.as_ref().to_string());
         }
+        for r in &self.assignee_recipients {
+            all.insert(r.as_ref().to_string());
+        }
         if let Some(r) = &self.doc_owner_recipient {
             all.insert(r.clone());
         }
@@ -209,6 +229,7 @@ impl NotificationRecipients {
     pub fn total_count(&self) -> usize {
         self.mention_recipients.len()
             + self.thread_reply_recipients.len()
+            + self.assignee_recipients.len()
             + self.doc_owner_recipient.iter().count()
     }
 }
@@ -269,6 +290,28 @@ impl CommentNotifContext {
             notification,
             sender_id: self.sender_id.clone(),
             recipient_ids: participant_ids,
+        }
+    }
+
+    pub fn build_task_assignee_comment_notif(
+        &self,
+        assignee_ids: HashSet<MacroUserIdStr<'static>>,
+    ) -> SendNotificationRequestBuilder<'static, CommentedOnDocumentMetadata> {
+        let notification = CommentedOnDocumentMetadata {
+            document_name: self.document_name.clone(),
+            owner: self.owner.clone(),
+            file_type: self.file_type.clone(),
+            comment_id: self.comment_id,
+            thread_id: self.thread_id,
+            text: self.text.clone(),
+            sender_profile_picture_url: self.sender_profile_picture_url.clone(),
+        };
+
+        SendNotificationRequestBuilder {
+            notification_entity: EntityType::Document.with_entity_string(self.document_id.clone()),
+            notification,
+            sender_id: self.sender_id.clone(),
+            recipient_ids: assignee_ids,
         }
     }
 

--- a/rust/cloud-storage/document_storage_service/src/api/annotations/test.rs
+++ b/rust/cloud-storage/document_storage_service/src/api/annotations/test.rs
@@ -36,6 +36,7 @@ fn mentioned_user_who_is_also_thread_participant_gets_only_mention() {
         Some(&sender),
         &[bob.to_string()],                              // bob is mentioned
         &[bob.to_string(), sender.as_ref().to_string()], // bob is also a thread participant
+        &[],
         &user_id("macro|owner@test.com"),
         true, // is_reply
     );
@@ -64,6 +65,7 @@ fn mentioned_user_who_is_also_doc_owner_gets_only_mention() {
         Some(&sender),
         &[owner.as_ref().to_string()], // owner is mentioned
         &[sender.as_ref().to_string()],
+        &[],
         &owner,
         false,
     );
@@ -87,6 +89,7 @@ fn thread_participant_who_is_also_doc_owner_gets_only_thread_reply() {
         Some(&sender),
         &[],                                                        // no mentions
         &[owner.as_ref().to_string(), sender.as_ref().to_string()], // owner is thread participant
+        &[],
         &owner,
         true,
     );
@@ -110,7 +113,8 @@ fn user_who_is_mentioned_and_thread_participant_and_doc_owner_gets_only_mention(
         Some(&sender),
         &[owner.as_ref().to_string()], // owner is mentioned
         &[owner.as_ref().to_string(), sender.as_ref().to_string()], // owner is thread participant
-        &owner,                        // and doc owner
+        &[],
+        &owner, // and doc owner
         true,
     );
 
@@ -137,6 +141,7 @@ fn dedup_works_across_different_casing() {
             "macro|bob@test.com".to_string(),
             sender.as_ref().to_string(),
         ], // lowercase owner
+        &[],
         &owner,
         true,
     );
@@ -161,6 +166,7 @@ fn dedup_works_for_doc_owner_with_different_casing() {
         Some(&sender),
         &["macro|Owner@Test.COM".to_string()], // mixed case
         &[sender.as_ref().to_string()],
+        &[],
         &owner,
         false,
     );
@@ -187,7 +193,8 @@ fn sender_never_receives_notification() {
         Some(&sender),
         &[],
         &[sender.as_ref().to_string()], // sender is only thread participant
-        &sender,                        // sender is also doc owner
+        &[],
+        &sender, // sender is also doc owner
         true,
     );
 
@@ -210,6 +217,7 @@ fn new_thread_comment_notifies_doc_owner() {
         Some(&sender),
         &[],
         &[sender.as_ref().to_string()], // only one comment (the new one)
+        &[],
         &owner,
         false, // not a reply
     );
@@ -229,6 +237,7 @@ fn reply_notifies_thread_participants_and_doc_owner() {
         Some(&sender),
         &[],
         &[alice.to_string(), sender.as_ref().to_string()],
+        &[],
         &owner,
         true,
     );
@@ -247,9 +256,203 @@ fn no_thread_reply_notifications_for_first_comment() {
         Some(&sender),
         &[],
         &[sender.as_ref().to_string()],
+        &[],
         &owner,
         false, // first comment, not a reply
     );
 
     assert!(result.thread_reply_recipients.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// Task assignee notifications
+// ---------------------------------------------------------------------------
+
+#[test]
+fn assignee_gets_notification_when_not_in_other_groups() {
+    let sender = user_id("macro|sender@test.com");
+    let owner = user_id("macro|owner@test.com");
+    let assignee = "macro|assignee@test.com";
+
+    let result = compute_notification_recipients(
+        Some(&sender),
+        &[],
+        &[sender.as_ref().to_string()],
+        &[assignee.to_string()],
+        &owner,
+        false,
+    );
+
+    assert!(
+        result.assignee_recipients.contains(&user_id(assignee)),
+        "assignee should be in assignee recipients"
+    );
+    assert_eq!(result.doc_owner_recipient.as_deref(), Some(owner.as_ref()));
+    assert_eq!(result.all_recipients().len(), result.total_count());
+}
+
+#[test]
+fn mentioned_user_who_is_also_assignee_gets_only_mention() {
+    let sender = user_id("macro|sender@test.com");
+    let owner = user_id("macro|owner@test.com");
+    let bob = "macro|bob@test.com";
+
+    let result = compute_notification_recipients(
+        Some(&sender),
+        &[bob.to_string()],
+        &[sender.as_ref().to_string()],
+        &[bob.to_string()],
+        &owner,
+        false,
+    );
+
+    assert!(
+        result.mention_recipients.contains(&user_id(bob)),
+        "bob should be in mention recipients"
+    );
+    assert!(
+        !result.assignee_recipients.contains(&user_id(bob)),
+        "bob should NOT be in assignee recipients"
+    );
+    assert_eq!(result.all_recipients().len(), result.total_count());
+}
+
+#[test]
+fn thread_participant_who_is_also_assignee_gets_only_thread_reply() {
+    let sender = user_id("macro|sender@test.com");
+    let owner = user_id("macro|owner@test.com");
+    let alice = "macro|alice@test.com";
+
+    let result = compute_notification_recipients(
+        Some(&sender),
+        &[],
+        &[alice.to_string(), sender.as_ref().to_string()],
+        &[alice.to_string()],
+        &owner,
+        true,
+    );
+
+    assert!(
+        result.thread_reply_recipients.contains(&user_id(alice)),
+        "alice should be in thread reply recipients"
+    );
+    assert!(
+        !result.assignee_recipients.contains(&user_id(alice)),
+        "alice should NOT be in assignee recipients"
+    );
+    assert_eq!(result.all_recipients().len(), result.total_count());
+}
+
+#[test]
+fn assignee_who_is_also_doc_owner_gets_only_assignee() {
+    let sender = user_id("macro|sender@test.com");
+    let owner = user_id("macro|owner@test.com");
+
+    let result = compute_notification_recipients(
+        Some(&sender),
+        &[],
+        &[sender.as_ref().to_string()],
+        &[owner.as_ref().to_string()],
+        &owner,
+        false,
+    );
+
+    assert!(
+        result.assignee_recipients.contains(&owner),
+        "owner should be in assignee recipients"
+    );
+    assert!(
+        result.doc_owner_recipient.is_none(),
+        "owner should NOT also get doc owner notification"
+    );
+    assert_eq!(result.all_recipients().len(), result.total_count());
+}
+
+#[test]
+fn sender_who_is_assignee_gets_no_notification() {
+    let sender = user_id("macro|sender@test.com");
+    let owner = user_id("macro|owner@test.com");
+
+    let result = compute_notification_recipients(
+        Some(&sender),
+        &[],
+        &[sender.as_ref().to_string()],
+        &[sender.as_ref().to_string()],
+        &owner,
+        false,
+    );
+
+    assert!(
+        !result.assignee_recipients.contains(&sender),
+        "sender should NOT be in assignee recipients"
+    );
+    assert_eq!(result.doc_owner_recipient.as_deref(), Some(owner.as_ref()));
+}
+
+#[test]
+fn multiple_assignees_deduped_correctly() {
+    let sender = user_id("macro|sender@test.com");
+    let owner = user_id("macro|owner@test.com");
+    let mentioned = "macro|mentioned@test.com";
+    let thread_participant = "macro|thread@test.com";
+    let pure_assignee = "macro|assignee@test.com";
+
+    let result = compute_notification_recipients(
+        Some(&sender),
+        &[mentioned.to_string()],
+        &[thread_participant.to_string(), sender.as_ref().to_string()],
+        &[
+            mentioned.to_string(),
+            thread_participant.to_string(),
+            pure_assignee.to_string(),
+        ],
+        &owner,
+        true,
+    );
+
+    assert!(result.mention_recipients.contains(&user_id(mentioned)));
+    assert!(!result.assignee_recipients.contains(&user_id(mentioned)));
+    assert!(
+        result
+            .thread_reply_recipients
+            .contains(&user_id(thread_participant))
+    );
+    assert!(
+        !result
+            .assignee_recipients
+            .contains(&user_id(thread_participant))
+    );
+    assert!(
+        result.assignee_recipients.contains(&user_id(pure_assignee)),
+        "pure assignee should be in assignee recipients"
+    );
+    assert_eq!(result.doc_owner_recipient.as_deref(), Some(owner.as_ref()));
+    assert_eq!(result.all_recipients().len(), result.total_count());
+}
+
+#[test]
+fn assignee_dedup_works_across_different_casing() {
+    let sender = user_id("macro|sender@test.com");
+    let owner = user_id("macro|owner@test.com");
+
+    let result = compute_notification_recipients(
+        Some(&sender),
+        &["macro|Bob@Test.COM".to_string()],
+        &[sender.as_ref().to_string()],
+        &["macro|bob@test.com".to_string()],
+        &owner,
+        false,
+    );
+
+    let all = result.all_recipients();
+    let bob_count = all.iter().filter(|r| r.contains("bob")).count();
+    assert_eq!(
+        bob_count, 1,
+        "bob should receive exactly one notification, got {bob_count}"
+    );
+    assert!(
+        result.assignee_recipients.is_empty(),
+        "bob already in mentions, should not be in assignees"
+    );
+    assert_eq!(result.all_recipients().len(), result.total_count());
 }

--- a/rust/cloud-storage/document_storage_service/src/api/context.rs
+++ b/rust/cloud-storage/document_storage_service/src/api/context.rs
@@ -84,7 +84,7 @@ type DssSoupState = SoupRouterState<
 
 type SystemPropertiesService = SystemPropertiesServiceImpl<PgSystemPropertiesRepository>;
 pub(crate) type NotificationIngressType = SqsNotificationIngress<SqsQueue>;
-type PropertiesService = PropertiesServiceImpl<
+pub(crate) type PropertiesService = PropertiesServiceImpl<
     PropertiesPgRepo,
     PermissionServiceImpl<EntityAccessService>,
     NotificationServiceImpl<NotificationIngressType>,


### PR DESCRIPTION
This PR adds the ability to notify the assignees of a task for root level comments
