### PR TITLE
Show recent channels in sidebar with pagination

### DIFF
--- a/js/app/packages/app/component/app-sidebar/channels-unread-widget.tsx
+++ b/js/app/packages/app/component/app-sidebar/channels-unread-widget.tsx
@@ -1,4 +1,6 @@
 import { useGlobalNotificationSource } from '@app/component/GlobalAppState';
+import { useChannelsContext } from '@core/context/channels';
+import { useUserId } from '@core/context/user';
 import type { UnifiedNotification } from '@notifications/types';
 import { openNotification } from '@notifications';
 import {
@@ -6,8 +8,6 @@ import {
   Show,
   createSignal,
   createMemo,
-  createEffect,
-  on,
   onMount,
 } from 'solid-js';
 import { UserIcon } from '@core/component/UserIcon';
@@ -22,6 +22,7 @@ import { isChannelNotification } from '@notifications/notification-helpers';
 import type { SidebarState } from '@app/component/app-sidebar/sidebar';
 import { cn } from '@ui/utils/classname';
 import { Button } from '@ui/components/Button';
+import { ChannelTypeEnum } from '@service-comms/client';
 
 function getChannelInfo(notification: UnifiedNotification): {
   channelName: string | null;
@@ -45,8 +46,10 @@ interface ChannelGroup {
   channelName: string | null;
   channelType: string | null;
   isDM: boolean;
-  notifications: UnifiedNotification[];
+  unreadCount: number;
   latestSenderId: string | null;
+  latestNotification: UnifiedNotification | null;
+  activityAt: string | null;
 }
 
 function computeChannelLetters(groups: ChannelGroup[]): Map<string, string> {
@@ -96,13 +99,25 @@ function groupByChannel(
         channelName: info.channelName,
         channelType: info.channelType,
         isDM: info.isDM,
-        notifications: [],
+        unreadCount: 0,
         latestSenderId: null,
+        latestNotification: null,
+        activityAt: null,
       });
     }
 
     const group = groups.get(entityId)!;
-    group.notifications.push(notification);
+    group.unreadCount += 1;
+    if (
+      !group.latestNotification ||
+      compareDateDesc(
+        notification.created_at,
+        group.latestNotification.created_at
+      ) < 0
+    ) {
+      group.latestNotification = notification;
+      group.activityAt = notification.created_at;
+    }
 
     // Track latest sender for DMs
     if (info.isDM && notification.sender_id) {
@@ -130,7 +145,7 @@ function ChannelGroupItem(props: {
   });
 
   const senderName = useSenderName(props.group.latestSenderId);
-  const count = () => props.group.notifications.length;
+  const count = () => props.group.unreadCount;
 
   const isDM = () => props.group.isDM;
   const senderId = () => props.group.latestSenderId;
@@ -144,7 +159,7 @@ function ChannelGroupItem(props: {
       : 'Unknown Channel';
   };
 
-  const latestNotification = () => props.group.notifications[0];
+  const latestNotification = () => props.group.latestNotification;
 
   const canOpenInNewSplit = () =>
     globalSplitManager()?.canAppendSplit() ?? false;
@@ -153,7 +168,19 @@ function ChannelGroupItem(props: {
     const manager = globalSplitManager();
     if (!manager) return;
     const notification = latestNotification();
-    openNotification(notification, manager, newSplit);
+    if (notification) {
+      openNotification(notification, manager, newSplit);
+      return;
+    }
+
+    manager.openWithSplit(
+      { type: 'channel', id: props.group.entityId },
+      {
+        activate: true,
+        referredFrom: null,
+        preferNewSplit: newSplit,
+      }
+    );
   };
 
   const openInCurrentSplit = () => {
@@ -271,46 +298,58 @@ function filterUnreadNotDone(notifications: UnifiedNotification[]) {
 
 export const ChannelsUnreadWidget = (props: { sidebarState: SidebarState }) => {
   const notificationSource = useGlobalNotificationSource();
+  const channelsContext = useChannelsContext();
+  const userId = useUserId();
   const allNotifications = () => [...notificationSource.notifications()];
 
   const filteredNotifications = () => filterUnreadNotDone(allNotifications());
 
-  const channelGroupsMap = createMemo(() =>
+  const unreadGroupsMap = createMemo(() =>
     groupByChannel(filteredNotifications())
   );
 
-  const [orderedIds, setOrderedIds] = createSignal<string[]>([]);
-
-  createEffect(
-    on(channelGroupsMap, (groups) => {
-      const currentIds = new Set(groups.keys());
-      const prev = orderedIds();
-      const kept = prev.filter((id) => currentIds.has(id));
-      const keptSet = new Set(kept);
-      const added = [...currentIds].filter((id) => !keptSet.has(id));
-
-      if (added.length === 0 && kept.length === prev.length) return;
-
-      added.sort((a, b) => {
-        const aTime = groups.get(a)?.notifications[0]?.created_at;
-        const bTime = groups.get(b)?.notifications[0]?.created_at;
-        return compareDateDesc(aTime, bTime);
-      });
-
-      setOrderedIds([...added, ...kept]);
-    })
-  );
-
   const channelGroups = createMemo(() => {
-    const groups = channelGroupsMap();
-    return orderedIds()
-      .map((id) => groups.get(id))
-      .filter((g): g is ChannelGroup => g != null);
+    const unreadGroups = unreadGroupsMap();
+    const currentUserId = userId();
+
+    return channelsContext
+      .channels()
+      .map<ChannelGroup>((channel) => {
+        const unreadGroup = unreadGroups.get(channel.id);
+        const isDM = channel.channel_type === ChannelTypeEnum.DirectMessage;
+        const dmOtherParticipantId = isDM
+          ? (channel.participants.find((p) => p.user_id !== currentUserId)
+              ?.user_id ?? null)
+          : null;
+
+        return {
+          entityId: channel.id,
+          channelName: channel.name ?? null,
+          channelType: channel.channel_type,
+          isDM,
+          unreadCount: unreadGroup?.unreadCount ?? 0,
+          latestSenderId: unreadGroup?.latestSenderId ?? dmOtherParticipantId,
+          latestNotification: unreadGroup?.latestNotification ?? null,
+          activityAt:
+            unreadGroup?.activityAt ??
+            channel.interacted_at ??
+            channel.updated_at ??
+            null,
+        };
+      })
+      .sort((a, b) => compareDateDesc(a.activityAt, b.activityAt));
   });
 
   const channelLettersMap = createMemo(() =>
     computeChannelLetters(channelGroups())
   );
+
+  const PAGE_SIZE = 20;
+  const [visibleCount, setVisibleCount] = createSignal(PAGE_SIZE);
+  const visibleGroups = createMemo(() =>
+    channelGroups().slice(0, visibleCount())
+  );
+  const hasMore = () => channelGroups().length > visibleCount();
 
   const isSlim = () => props.sidebarState === 'slim';
   const SLIM_MAX = 4;
@@ -343,11 +382,11 @@ export const ChannelsUnreadWidget = (props: { sidebarState: SidebarState }) => {
       >
         <section class="w-full h-full flex flex-col justify-center px-2 py-1.5">
           <header class="text-xs font-medium text-ink-muted ml-2 mb-1">
-            <h1>Unread</h1>
+            <h1>Recent channels</h1>
           </header>
 
           <div class="flex-1">
-            <For each={channelGroups()}>
+            <For each={visibleGroups()}>
               {(group) => (
                 <ChannelGroupItem
                   group={group}
@@ -356,6 +395,16 @@ export const ChannelsUnreadWidget = (props: { sidebarState: SidebarState }) => {
                 />
               )}
             </For>
+            <Show when={hasMore()}>
+              <Button
+                variant="ghost"
+                size="sm"
+                class="mt-1 ml-1 text-xs text-ink-muted"
+                onClick={() => setVisibleCount((current) => current + PAGE_SIZE)}
+              >
+                Show more
+              </Button>
+            </Show>
           </div>
         </section>
       </Show>

--- a/js/app/packages/app/component/app-sidebar/channels-unread-widget.tsx
+++ b/js/app/packages/app/component/app-sidebar/channels-unread-widget.tsx
@@ -193,7 +193,9 @@ function ChannelGroupItem(props: {
   };
 
   const _openFullscreen = () => {
-    const { params } = getChannelNotificationParams(latestNotification());
+    const notification = latestNotification();
+    if (!notification) return;
+    const { params } = getChannelNotificationParams(notification);
     globalSplitManager()?.createPopoverSplit({
       content: {
         type: 'channel',
@@ -220,12 +222,12 @@ function ChannelGroupItem(props: {
         'opacity-0 -translate-y-2': !isVisible(),
         'opacity-100 translate-y-0': isVisible(),
       }}
-      onClick={(e) => {
-        if (e.button === 1) return;
-
+      onMouseDown={(e) => {
+        if (e.button !== 0) return;
         e.preventDefault();
         navigateToLatestNotification(e.shiftKey);
       }}
+      onClick={(e) => e.preventDefault()}
     >
       <div class="relative flex items-center justify-center flex-shrink-0 size-5">
         <Show
@@ -380,12 +382,12 @@ export const ChannelsUnreadWidget = (props: { sidebarState: SidebarState }) => {
           </section>
         }
       >
-        <section class="w-full h-full flex flex-col justify-center px-2 py-1.5">
+        <section class="w-full flex flex-col px-2 py-1.5">
           <header class="text-xs font-medium text-ink-muted ml-2 mb-1">
             <h1>Recent channels</h1>
           </header>
 
-          <div class="flex-1">
+          <div class="min-h-0 overflow-y-auto">
             <For each={visibleGroups()}>
               {(group) => (
                 <ChannelGroupItem

--- a/js/app/packages/app/component/app-sidebar/sidebar.tsx
+++ b/js/app/packages/app/component/app-sidebar/sidebar.tsx
@@ -502,28 +502,32 @@ export const AppSidebar = (props: AppSidebarProps) => {
         <hr class="border-ink/5 mb-[8px]" />
       </div>
 
-      <nav>
-        <ul class="w-full h-full px-2 flex flex-col gap-1">
-          <For each={visibleLinks()}>
-            {(link) => (
-              <li class="flex items-center justify-center">
-                <SidebarLink
-                  {...link}
-                  sidebarState={props.sidebarState ?? 'expanded'}
-                  hotkeyVisible={hotkeyVisible()}
-                />
-              </li>
-            )}
-          </For>
-        </ul>
-      </nav>
+      <div class="flex-1 min-h-0 overflow-y-auto">
+        <nav>
+          <ul class="w-full px-2 flex flex-col gap-1">
+            <For each={visibleLinks()}>
+              {(link) => (
+                <li class="flex items-center justify-center">
+                  <SidebarLink
+                    {...link}
+                    sidebarState={props.sidebarState ?? 'expanded'}
+                    hotkeyVisible={hotkeyVisible()}
+                  />
+                </li>
+              )}
+            </For>
+          </ul>
+        </nav>
 
-      <div class="px-2">
-        <hr class="border-ink/5 my-[8px]" />
-      </div>
+        <div class="px-2">
+          <hr class="border-ink/5 my-[8px]" />
+        </div>
 
-      <div class="block max-h-[clamp(10%,60%,20rem)]">
-        <ChannelsUnreadWidget sidebarState={props.sidebarState ?? 'expanded'} />
+        <div class="block">
+          <ChannelsUnreadWidget
+            sidebarState={props.sidebarState ?? 'expanded'}
+          />
+        </div>
       </div>
 
       <div class="px-2 mt-auto w-full">


### PR DESCRIPTION
### Motivation
- Replace the existing unread-only sidebar widget so the sidebar surfaces recent channels (so users can jump to channels they interacted with even if they have no unread notifications). 
- Preserve important unread UX (badges and deep-linking into notification targets) while expanding visibility to all channels. 
- Limit visual noise by paginating the expanded list and preserving compact slim-sidebar behaviour.

### Description
- Rework `ChannelsUnreadWidget` to source channels from `useChannelsContext()` and merge unread metadata from notifications via `groupByChannel`, exposing `unreadCount`, `latestNotification`, and `activityAt` for each channel.
- Sort channel entries by recency using `activityAt` with fallbacks to `interacted_at` / `updated_at`, and show the top 20 entries by default with a `Show more` button that increments visibility by 20.
- Update click handling to open the notification deep-link when an unread `latestNotification` exists and otherwise open the channel split directly via the split manager.
- Preserve slim-sidebar behaviour (top 4 entries + overflow indicator) and change the header from `Unread` to `Recent channels` to reflect the new content.

### Testing
- Ran `bun run check` (TypeScript check) which fails in this environment due to missing type-definition packages referenced in `tsconfig` such as `@types/facebook-pixel`, `@types/gtag.js`, `vite-plugin-solid-svg/types`, `vite/client`, and `wicg-file-system-access` so a full type-check could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e913d2bbe08324a54be987108e2de0)