### PR TITLE
Add section-aware 'Create' item to sidebar link context menus

### DIFF
--- a/js/app/packages/app/component/app-sidebar/sidebar.tsx
+++ b/js/app/packages/app/component/app-sidebar/sidebar.tsx
@@ -29,7 +29,11 @@ import {
   type ListView,
 } from '@app/constants/list-views';
 import { LabelAndHotKey } from '@core/component/Tooltip';
-import { createMenuOpen, setCreateMenuOpen } from '@app/component/Launcher';
+import {
+  createMenuOpen,
+  runCreateAction,
+  setCreateMenuOpen,
+} from '@app/component/Launcher';
 import { CommandState } from '@app/component/command';
 import { cn } from '@ui/utils/classname';
 import { Button } from '@ui/components/Button';
@@ -639,6 +643,43 @@ const SidebarLink = (props: SidebarLinkProps) => {
     split?.toggleSpotlight(true);
   };
 
+  const createAction = () => {
+    switch (props.id) {
+      case 'documents':
+        return {
+          text: 'New document',
+          onClick: () => runCreateAction('md'),
+        };
+      case 'tasks':
+        return {
+          text: 'New task',
+          onClick: () => runCreateAction('task'),
+        };
+      case 'mail':
+        return {
+          text: 'New email',
+          onClick: () => runCreateAction('email'),
+        };
+      case 'folders':
+        return {
+          text: 'New folder',
+          onClick: () => runCreateAction('project'),
+        };
+      case 'agents':
+        return {
+          text: 'New agent',
+          onClick: () => runCreateAction('chat'),
+        };
+      case 'channels':
+        return {
+          text: 'New message',
+          onClick: () => runCreateAction('channel'),
+        };
+      default:
+        return null;
+    }
+  };
+
   return (
     <ContextMenu>
       <ContextMenu.Trigger class="w-full">
@@ -738,6 +779,11 @@ const SidebarLink = (props: SidebarLinkProps) => {
           />
           <MenuItem text="Open fullscreen" onClick={openFullscreen} />
           <MenuItem text="Open in current split" onClick={openInCurrentSplit} />
+          <Show when={createAction()}>
+            {(action) => (
+              <MenuItem text={action().text} onClick={action().onClick} />
+            )}
+          </Show>
         </ContextMenuContent>
       </ContextMenu.Portal>
     </ContextMenu>


### PR DESCRIPTION
### Motivation
- Provide quick "New ..." actions in the sidebar link context menu so users can create a new document, task, email, folder, agent, or message scoped to the selected sidebar section. 
- Reuse existing launcher create flows rather than implementing new creation logic.

### Description
- Import `runCreateAction` from `@app/component/Launcher` and keep the existing `createMenuOpen` usage in `js/app/packages/app/component/app-sidebar/sidebar.tsx`.
- Add a `createAction` helper that maps `props.id` (sidebar section ids like `documents`, `tasks`, `mail`, `folders`, `agents`, `channels`) to an action object with `text` and `onClick` which calls `runCreateAction` with the appropriate block type.
- Render a conditional create `MenuItem` (via `<Show when={createAction()}>`) appended to the existing context menu entries `Open in new split`, `Open fullscreen`, and `Open in current split`.
- The change adds a contextual menu label (e.g., `New document`, `New task`, `New email`, `New folder`, `New agent`, `New message`) and wires it to existing launcher handlers.

### Testing
- Ran type check with `bun run check` in `js/app`, which failed in this environment due to missing type definition packages (examples: `@types/facebook-pixel`, `vite/client`, `wicg-file-system-access`).
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9195fe4088324a5312a410b53b7da)