### PR TITLE
fix(split-layout): skip search bar on H/L focus restoration

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/soup-view-search-bar.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/soup-view-search-bar.tsx
@@ -116,6 +116,7 @@ export const SoupSearchbar = (props: SoupSearchbarProps) => {
     <div
       class="w-full flex items-center shrink-0 grow min-w-0 mobile:-order-2"
       data-search-bar-wrapper
+      data-no-focus-restore
     >
       <div
         class={cn(

--- a/js/app/packages/app/component/split-layout/SplitLayout.tsx
+++ b/js/app/packages/app/component/split-layout/SplitLayout.tsx
@@ -245,7 +245,11 @@ function createSplitFocusTracker(props: {
       if (!element) return;
 
       const parentId = getParentSplitId(element);
-      if (parentId && element instanceof HTMLElement) {
+      if (
+        parentId &&
+        element instanceof HTMLElement &&
+        !element.closest('[data-no-focus-restore]')
+      ) {
         lastFocusedChildBySplitId.set(parentId, element);
       }
 


### PR DESCRIPTION
## Summary

- The split focus tracker records the last-focused child per split and refocuses it when the split is re-activated via Shift+H/L. The search bar auto-focuses on mount, so it got recorded as the split's last-focused child — every H/L back into the search split yanked focus into the search input.
- Add a generic `data-no-focus-restore` opt-out on the split tracker and apply it to the search bar wrapper. Explicit focus paths (click, Cmd+F, `/` hotkey, mount-time `autoFocus`) still work; H/L split navigation no longer restores focus to the search bar.
