### PR TITLE
fix(local): running locally audience and env vars

### DIFF
--- a/.env-local.enc
+++ b/.env-local.enc
@@ -133,6 +133,7 @@ LIVEKIT_API_SECRET=ENC[AES256_GCM,data:GLdp8wpK4kpbGPmR5aaWzZ4ns8jzTkRuFfroG8PUe
 LIVEKIT_TRANSCRIPTION_AGENT_NAME=ENC[AES256_GCM,data:RgXJ+WNruFiyg1Pjjzo++SDOLg==,iv:r7XZRhIJg+4qiEBBG6Pbvj+maiUh/jrO5lnwNkUXgxM=,tag:yVVoGBzz1Bl0lY1KqH4G3Q==,type:str]
 INTERNAL_CALL_SECRET=ENC[AES256_GCM,data:66UR3BO7Ddg5bQ0xmLNeY5EGb65L4tiXcsDNpTE=,iv:ovuMlw/k257Oh1CkosXjOXDWycQ4AoA9s+hhfHpeOvs=,tag:qXXYEFhSaM0Q4ffRdGtMRg==,type:str]
 URL_SIGNING_HMAC=ENC[AES256_GCM,data:2PtDBCM6BARI7Fl5MSCVbOzGsXvgR8eFghJPfTvUFP31YRnFHpF5CBIsSlOhGUJihSoq6Ydfr9L4+LKv1EXT9g8S,iv:7ZmNUdsYr3ujUZiPVStz5ymrtYBfhsmDeyISzGX+1h0=,tag:snvxFxHfT7NyXpKF4Onu6A==,type:str]
+NOTIFICATION_INGRESS_QUEUE=ENC[AES256_GCM,data:ZNMcAeqCNUOP9P763YB5kJgPRTKjIYLoamXheZKgeTtvHIfrtwYXIGjrd9PY/uWOR+RkrfevyRKTAlOEGeu95g==,iv:4Ag6GDV9B/g0feL1ayLau6fyA2j9udJt1AAIejy5Otw=,tag:3MgDj0sUU6kOv7H4NU1dmw==,type:str]
 sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IHBpdi1wMjU2IEUzMVUyZyBBM1lmcDc3\nUENpRVorSGVGa3R2NFlrdkx1Mm43aEcyR1ZtbEswL2RnWHlqMwpVMnY4ck5makNC\nZzVZc3JrZ3NKV2x3RTY0TFovRXJtVzEyeFZOZWRheHBNCi0tLSBobjhCbHpJa25s\nZDhyQjhCaEYrOWNiWHZkRWpnRlkwTnNEbjMwYzdxcTUwCqxxxmXy3mFUAbAy29y8\n2DFYDATdVvmplHpDTvgrNyY+lAL/3Jp9vtIs5DGXW/r73Nv3AhISmuCid18qhpAY\nUqE=\n-----END AGE ENCRYPTED FILE-----\n
 sops_age__list_0__map_recipient=age1yubikey1qw64ag5lzvn9ekrflu5ruj4a6ucycscl6ctk39fjzf76jptsay39z442pxv
 sops_kms__list_0__map_arn=arn:aws:kms:us-east-1:569036502058:key/mrk-cab29bf948044eb79005a81f48d40e93
@@ -143,7 +144,7 @@ sops_kms__list_1__map_arn=arn:aws:kms:us-west-1:569036502058:key/mrk-cab29bf9480
 sops_kms__list_1__map_aws_profile=
 sops_kms__list_1__map_created_at=2026-03-03T19:32:07Z
 sops_kms__list_1__map_enc=AQICAHjuYcSMsjB0lKJtZ3DIAvxF8N3RNRn5KZaAN74Et6122wFUqf7u/HEfCUGv7j69Mb6YAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMpcJQR1XeIAFFE7ebAgEQgDvYRYIWelwN8TuwA+6fZVaB34yKo9EQ5xPLr/3BU+ro1Mn2eBPCg3q8ie2LuE/3voim1X35P/cdtDqTZg==
-sops_lastmodified=2026-04-22T15:12:33Z
-sops_mac=ENC[AES256_GCM,data:JpVvlGmEDfjrHsyENl8eWyXs1gCJjW7p/enu+AdAIK6Si2x5/UpVcm9EJQl2t4pqLh+ml3ZndycoJakzQqrPh8lyST/BvXxYdu1ry8RMCkvixRxmhedUvc5ffhKWCx6h1KZG0Bnb74Pzi6MhDnYmOpWagPUo2prAbb4WSxRMAvk=,iv:mmqEICcoy7X5FP4e5uOvZdcoZHeAJFyod128KKvDK9s=,tag:jAokatZv5r3VM622/ceHJw==,type:str]
+sops_lastmodified=2026-04-23T16:07:14Z
+sops_mac=ENC[AES256_GCM,data:GaGPjmolc5jpnTlWamosio+/LEbMBdT8uhMAJec/o4paqAunc1qN0HZpY+uNtcjLX1MvA9lVI93IVRxXHYd075NA7JJ6GJGT/kyJNaoR3P58T0POd5dYx2pBEsRWcdhg/oNVk/Kv75ekW+SDNqoAe0FMKNIyqtC7S+pBLdWEzvs=,iv:nSuMbbBUnzCdrqDOr+g0LfHhKynnKATD+yoJcMlDog8=,tag:+cKydl0OIxT2uORMZzQObw==,type:str]
 sops_unencrypted_suffix=_unencrypted
 sops_version=3.12.2

--- a/infra/stacks/fusionauth-instance/justfile
+++ b/infra/stacks/fusionauth-instance/justfile
@@ -63,26 +63,66 @@ setup:
   just stop
   @echo "FusionAuth setup complete"
 
-# Inserts local FusionAuth variables into root `.env` file
+# Patches the root `.env` file with local FusionAuth values.
+# Idempotent: replaces existing values in-place, appends if missing.
+# Covers both dynamic values (from Pulumi/FusionAuth API) and static
+# values that differ between local and dev FusionAuth.
 insert_local_fusionauth_variables:
   #!/usr/bin/env bash
+  set -eo pipefail
+
+  ENV_FILE="{{justfile_directory()}}/../../../.env"
+  if [ ! -f "$ENV_FILE" ]; then
+    echo "Error: $ENV_FILE does not exist. Run 'just get_environment' first."
+    exit 1
+  fi
+
+  if ! pulumi stack output macroApplicationClientId -s local &>/dev/null; then
+    echo "Error: Pulumi local stack not found. Run 'just setup' first."
+    exit 1
+  fi
+
   API_KEY="bf69486b-4733-4954-a44e-2e1b5f2c8a91"
   APPLICATION_ID=$(pulumi stack output macroApplicationClientId -s local)
   TENANT_ID=$(pulumi stack output defaultTenantId -s local)
+
   CURL_RESPONSE=$(curl -s "http://localhost:9011/api/application/${APPLICATION_ID}" \
     -H "Authorization: ${API_KEY}")
   if [ -z "$CURL_RESPONSE" ]; then
-    echo "Local FusionAuth instance is not running"
+    echo "Error: Local FusionAuth instance is not running."
     exit 1
   fi
   CLIENT_SECRET=$(echo "$CURL_RESPONSE" | jq -r '.application.oauthConfiguration.clientSecret')
+  if [ -z "$CLIENT_SECRET" ] || [ "$CLIENT_SECRET" = "null" ]; then
+    echo "Error: Could not read client secret from FusionAuth."
+    exit 1
+  fi
 
-  ENV_FILE="{{justfile_directory()}}/../../../.env"
+  # Sets a key=value in the env file. Replaces in-place if present, appends if missing.
+  patch_var() {
+    local key="$1" value="$2"
+    if grep -q "^${key}=" "$ENV_FILE"; then
+      if [[ "$OSTYPE" == "darwin"* ]]; then
+        sed -i '' "s|^${key}=.*|${key}=\"${value}\"|" "$ENV_FILE"
+      else
+        sed -i "s|^${key}=.*|${key}=\"${value}\"|" "$ENV_FILE"
+      fi
+    else
+      echo "${key}=\"${value}\"" >> "$ENV_FILE"
+    fi
+  }
 
-  echo "#AUTO-ADDED DO NOT MODIFY" >> "$ENV_FILE"
-  echo "FUSIONAUTH_TENANT_ID=\"${TENANT_ID}\"" >> "$ENV_FILE"
-  echo "AUDIENCE=\"${APPLICATION_ID}\"" >> "$ENV_FILE"
-  echo "FUSIONAUTH_CLIENT_ID=\"${APPLICATION_ID}\"" >> "$ENV_FILE"
-  echo "FUSIONAUTH_CLIENT_SECRET_KEY=\"${CLIENT_SECRET}\"" >> "$ENV_FILE"
+  # Dynamic (from Pulumi / FusionAuth API)
+  patch_var AUDIENCE "$APPLICATION_ID"
+  patch_var FUSIONAUTH_TENANT_ID "$TENANT_ID"
+  patch_var FUSIONAUTH_CLIENT_ID "$APPLICATION_ID"
+  patch_var FUSIONAUTH_CLIENT_SECRET_KEY "$CLIENT_SECRET"
 
-  echo "Appended FusionAuth local values to .env"
+  # Static (known values for local FusionAuth)
+  patch_var JWT_SECRET_KEY "super-secret-jwt-signing-key-for-local-development-only"
+  patch_var ISSUER "local.macro.com"
+  patch_var FUSIONAUTH_BASE_URL "http://fusionauth:9011"
+  patch_var FUSIONAUTH_API_KEY_SECRET_KEY "$API_KEY"
+  patch_var FUSIONAUTH_OAUTH_REDIRECT_URI "http://localhost:8080/oauth/redirect"
+
+  echo "Patched .env with local FusionAuth values"

--- a/justfile
+++ b/justfile
@@ -48,10 +48,39 @@ docker_up *ARGS:
   docker compose up {{ ARGS }}
 
 # Run all services locally using docker-compose
-# Requires .env file with dev environment variables
+# Requires .env file (from `just get_environment`) and FusionAuth setup (from `just setup`).
+# Automatically patches .env with local FusionAuth values before starting services.
 run_local *ARGS:
   just create_networks
+  just patch_local_fusionauth_env
   just docker_up {{ ARGS }}
+
+# Patches .env with local FusionAuth values if the Pulumi stack exists.
+# Requires FusionAuth to be running — starts it temporarily if needed.
+patch_local_fusionauth_env:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  if [ ! -f .env ]; then
+    echo "Error: .env not found. Run 'just get_environment' first."
+    exit 1
+  fi
+  if ! pulumi stack output macroApplicationClientId -s local -C infra/stacks/fusionauth-instance &>/dev/null; then
+    echo "Warning: Pulumi local stack not found — skipping FusionAuth env patching."
+    echo "         Run 'just setup' if this is a fresh checkout."
+    exit 0
+  fi
+  # FusionAuth must be running to read the client secret
+  NEEDS_STOP=false
+  if ! curl -s http://localhost:9011/api/status 2>/dev/null | grep -q '"Ok"'; then
+    echo "Starting FusionAuth temporarily to read config..."
+    docker compose up fusionauth -d --wait
+    NEEDS_STOP=true
+  fi
+  just infra/stacks/fusionauth-instance/insert_local_fusionauth_variables
+  if [ "$NEEDS_STOP" = true ]; then
+    echo "Stopping temporary FusionAuth..."
+    docker compose stop fusionauth
+  fi
 
 # Stop all local services
 stop-local:


### PR DESCRIPTION
- just run_local now auto-patches .env with correct local FusionAuth values before starting services
  - insert_local_fusionauth_variables rewritten: covers all 9 auth-related vars (was 4), replaces in-place instead of appending duplicates
  - NOTIFICATION_INGRESS_QUEUE needs to be added to both sops files (missing since email digest feature)