### PR TITLE
fix: internal image dragging

### DIFF
--- a/js/app/packages/channel/Media/MediaImage.tsx
+++ b/js/app/packages/channel/Media/MediaImage.tsx
@@ -73,6 +73,9 @@ function Image(props: {
         loading={props.loading}
         onClick={() => props.onOpen?.()}
         onLoad={() => setLoaded(true)}
+        onDragStart={(e) => {
+          e.dataTransfer?.setData('application/x-macro-internal', '1');
+        }}
       />
     </>
   );

--- a/js/app/packages/channel/Media/MediaImage.tsx
+++ b/js/app/packages/channel/Media/MediaImage.tsx
@@ -2,6 +2,7 @@ import Spinner from '@phosphor-icons/core/bold/spinner-gap-bold.svg?component-so
 import { cn } from '@ui/utils/classname';
 import { internalDrag } from '@core/directive/internalDragState';
 import { type ParentProps, type JSX, Show, createSignal } from 'solid-js';
+false && internalDrag;
 const ATTACHMENT_TILE_SIZE = 92;
 
 function ImagePlaceholder(props: {

--- a/js/app/packages/channel/Media/MediaImage.tsx
+++ b/js/app/packages/channel/Media/MediaImage.tsx
@@ -1,5 +1,6 @@
 import Spinner from '@phosphor-icons/core/bold/spinner-gap-bold.svg?component-solid';
 import { cn } from '@ui/utils/classname';
+import { internalDrag } from '@core/directive/internalDragState';
 import { type ParentProps, type JSX, Show, createSignal } from 'solid-js';
 const ATTACHMENT_TILE_SIZE = 92;
 
@@ -73,9 +74,7 @@ function Image(props: {
         loading={props.loading}
         onClick={() => props.onOpen?.()}
         onLoad={() => setLoaded(true)}
-        onDragStart={(e) => {
-          e.dataTransfer?.setData('application/x-macro-internal', '1');
-        }}
+        use:internalDrag={true}
       />
     </>
   );

--- a/js/app/packages/core/component/ImageGalleryPreview.tsx
+++ b/js/app/packages/core/component/ImageGalleryPreview.tsx
@@ -1,3 +1,4 @@
+import { internalDrag } from '@core/directive/internalDragState';
 import { SERVER_HOSTS } from '@core/constant/servers';
 import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import ExpandIcon from '@icon/regular/arrows-out-simple.svg';
@@ -213,12 +214,7 @@ export const ImageGalleryPreview: Component<ImageGalleryPreviewProps> = (
                           }}
                           draggable={!isTouchDevice()}
                           onLoad={() => setLoaded(true)}
-                          onDragStart={(e) => {
-                            e.dataTransfer?.setData(
-                              'application/x-macro-internal',
-                              '1'
-                            );
-                          }}
+                          use:internalDrag={true}
                         />
                       </>
                     );

--- a/js/app/packages/core/component/ImageGalleryPreview.tsx
+++ b/js/app/packages/core/component/ImageGalleryPreview.tsx
@@ -1,4 +1,5 @@
 import { internalDrag } from '@core/directive/internalDragState';
+false && internalDrag;
 import { SERVER_HOSTS } from '@core/constant/servers';
 import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import ExpandIcon from '@icon/regular/arrows-out-simple.svg';

--- a/js/app/packages/core/component/ImagePreview.tsx
+++ b/js/app/packages/core/component/ImagePreview.tsx
@@ -1,3 +1,4 @@
+import { internalDrag } from '@core/directive/internalDragState';
 import { SERVER_HOSTS } from '@core/constant/servers';
 import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import { maybeThrow } from '@core/util/maybeResult';
@@ -212,9 +213,7 @@ export function ImagePreview(props: ImagePreviewProps) {
               }}
               draggable={!isTouchDevice()}
               onLoad={() => setLoaded(true)}
-              onDragStart={(e) => {
-                e.dataTransfer?.setData('application/x-macro-internal', '1');
-              }}
+              use:internalDrag={true}
             />
           </Show>
         </Dialog.Trigger>

--- a/js/app/packages/core/component/ImagePreview.tsx
+++ b/js/app/packages/core/component/ImagePreview.tsx
@@ -1,4 +1,5 @@
 import { internalDrag } from '@core/directive/internalDragState';
+false && internalDrag;
 import { SERVER_HOSTS } from '@core/constant/servers';
 import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import { maybeThrow } from '@core/util/maybeResult';

--- a/js/app/packages/core/component/LexicalMarkdown/component/decorator/MarkdownImage.tsx
+++ b/js/app/packages/core/component/LexicalMarkdown/component/decorator/MarkdownImage.tsx
@@ -1,3 +1,4 @@
+import { internalDrag } from '@core/directive/internalDragState';
 import { DeprecatedIconButton } from '@core/component/DeprecatedIconButton';
 import { toast } from '@core/component/Toast/Toast';
 import { debouncedDependent } from '@core/util/debounce';
@@ -318,9 +319,7 @@ export function MarkdownImage(props: ImageDecoratorProps) {
             (state() === 'loading' || state() === 'error') && 'invisible'
           )}
           draggable={true}
-          onDragStart={(e) => {
-            e.dataTransfer?.setData('application/x-macro-internal', '1');
-          }}
+          use:internalDrag={true}
           ref={imageRef}
           src={imageUrl()}
           style={{

--- a/js/app/packages/core/component/LexicalMarkdown/component/decorator/MarkdownImage.tsx
+++ b/js/app/packages/core/component/LexicalMarkdown/component/decorator/MarkdownImage.tsx
@@ -1,4 +1,5 @@
 import { internalDrag } from '@core/directive/internalDragState';
+false && internalDrag;
 import { DeprecatedIconButton } from '@core/component/DeprecatedIconButton';
 import { toast } from '@core/component/Toast/Toast';
 import { debouncedDependent } from '@core/util/debounce';

--- a/js/app/packages/core/component/ProfilePicture.tsx
+++ b/js/app/packages/core/component/ProfilePicture.tsx
@@ -1,6 +1,7 @@
 import { toast } from '@core/component/Toast/Toast';
 import { ENABLE_PROFILE_PICTURES } from '@core/constant/featureFlags';
 import { staticFileIdEndpoint } from '@core/constant/servers';
+import { internalDrag } from '@core/directive/internalDragState';
 import { useProfilePictureUrl } from '@core/signal/profilePicture';
 import { idToEmail } from '@core/user';
 import { createStaticFile } from '@core/util/create';
@@ -80,6 +81,7 @@ export function ProfilePicture(props: ProfilePictureProps) {
           <img
             src={url}
             class="object-cover rounded-full w-full h-full origin-[50%_20%]"
+            use:internalDrag={true}
           />
         </div>
       )}

--- a/js/app/packages/core/component/ProfilePicture.tsx
+++ b/js/app/packages/core/component/ProfilePicture.tsx
@@ -2,6 +2,7 @@ import { toast } from '@core/component/Toast/Toast';
 import { ENABLE_PROFILE_PICTURES } from '@core/constant/featureFlags';
 import { staticFileIdEndpoint } from '@core/constant/servers';
 import { internalDrag } from '@core/directive/internalDragState';
+false && internalDrag;
 import { useProfilePictureUrl } from '@core/signal/profilePicture';
 import { idToEmail } from '@core/user';
 import { createStaticFile } from '@core/util/create';

--- a/js/app/packages/core/directive/fileFolderDrop.ts
+++ b/js/app/packages/core/directive/fileFolderDrop.ts
@@ -1,4 +1,5 @@
 import { extractFileSystemEntries } from '@core/util/dataTransfer';
+import { internalDragExceedsThreshold } from '@core/directive/internalDragState';
 import { type Accessor, onCleanup } from 'solid-js';
 
 interface FileFolderDropDirectiveOptions {
@@ -38,11 +39,22 @@ export function fileFolderDrop(
   accessor: Accessor<FileFolderDropDirectiveOptions | undefined>
 ) {
   let dragCounter = 0;
+  let internalDragActivated = false;
 
   const handleDragOver = (e: DragEvent) => {
     if (accessor()?.disabled) return;
     e.preventDefault();
     e.stopPropagation();
+
+    // Upgrade an internal drag to active once the 20px threshold is exceeded.
+    if (
+      !internalDragActivated &&
+      e.dataTransfer?.types.includes('application/x-macro-internal') &&
+      internalDragExceedsThreshold()
+    ) {
+      internalDragActivated = true;
+      accessor()?.onDragStart?.(true);
+    }
   };
 
   const handleDragEnter = (e: DragEvent) => {
@@ -61,8 +73,10 @@ export function fileFolderDrop(
 
       if (!hasFiles) {
         const types = e.dataTransfer?.types || [];
-        // Skip internal drags (images dragged from within the app)
+        // For internal image drags, wait for the 20px threshold before activating.
+        // handleDragOver will upgrade to valid once the threshold is exceeded.
         if (types.includes('application/x-macro-internal')) {
+          internalDragActivated = false;
           options?.onDragStart?.(false);
           return;
         }
@@ -88,6 +102,7 @@ export function fileFolderDrop(
     dragCounter--;
 
     if (dragCounter === 0) {
+      internalDragActivated = false;
       const options = accessor();
       options?.onDragEnd?.();
     }
@@ -100,6 +115,7 @@ export function fileFolderDrop(
 
     const options = accessor();
     dragCounter = 0;
+    internalDragActivated = false;
     options?.onDragEnd?.();
     options?.onMouseUp?.(e.pageX, e.pageY);
 
@@ -132,10 +148,12 @@ export function fileFolderDrop(
       return;
     }
 
-    // If no files but we have HTML data, try to extract image URLs
-    // Skip if the drag originated from within the app to prevent replication
+    // If no files but we have HTML data, try to extract image URLs.
+    // For internal drags, only proceed if the drag exceeded the 20px threshold.
     if (dataTransfer.types.includes('application/x-macro-internal')) {
-      return;
+      if (!internalDragExceedsThreshold()) {
+        return;
+      }
     }
 
     const html = dataTransfer.getData('text/html');

--- a/js/app/packages/core/directive/internalDragState.ts
+++ b/js/app/packages/core/directive/internalDragState.ts
@@ -1,0 +1,49 @@
+import { onCleanup } from 'solid-js';
+
+const THRESHOLD = 50;
+
+let startX = 0;
+let startY = 0;
+let maxDistance = 0;
+
+export function internalDragExceedsThreshold() {
+  return maxDistance >= THRESHOLD;
+}
+
+declare module 'solid-js' {
+  namespace JSX {
+    interface Directives {
+      internalDrag: true;
+    }
+  }
+}
+
+export function internalDrag(element: HTMLElement) {
+  const onDragStart = (e: DragEvent) => {
+    e.dataTransfer?.setData('application/x-macro-internal', '1');
+    startX = e.clientX;
+    startY = e.clientY;
+    maxDistance = 0;
+  };
+
+  const onDrag = (e: DragEvent) => {
+    // drag event fires (0, 0) when cursor leaves the viewport
+    if (e.clientX === 0 && e.clientY === 0) return;
+    const dist = Math.hypot(e.clientX - startX, e.clientY - startY);
+    if (dist > maxDistance) maxDistance = dist;
+  };
+
+  const onDragEnd = () => {
+    maxDistance = 0;
+  };
+
+  element.addEventListener('dragstart', onDragStart);
+  element.addEventListener('drag', onDrag);
+  element.addEventListener('dragend', onDragEnd);
+
+  onCleanup(() => {
+    element.removeEventListener('dragstart', onDragStart);
+    element.removeEventListener('drag', onDrag);
+    element.removeEventListener('dragend', onDragEnd);
+  });
+}


### PR DESCRIPTION
There is now a 50px threshold for dragging internal images before `fileFolderDrop` will recognize them as droppable. Add `use:internalDrag` to add this to any other element. 