### PR TITLE
fix(ui): keep filter search input focused when submenu is open

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/unified-filter-dropdown.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/unified-filter-dropdown.tsx
@@ -13,6 +13,7 @@ import {
   createSignal,
   For,
   type JSX,
+  onCleanup,
   Show,
 } from 'solid-js';
 import SlidersHorizontalIcon from '@macro-icons/wide/sliders-horizontal.svg';
@@ -347,18 +348,35 @@ const SearchableFilterSubmenu = (props: {
     else setInternalOpen(v);
   };
   const [inputRef, setInputRef] = createSignal<HTMLInputElement>();
+  const [subContentRef, setSubContentRef] = createSignal<HTMLDivElement>();
 
-  // Focus the search input whenever the sub is open and the input is mounted.
-  // The setTimeout defers past Kobalte's own `setTimeout(tryAutoFocus, 0)` in
-  // `createSelectableCollection`, which would otherwise focus SubContent (the
-  // menu owns no items of its own — the Combobox does). Runs for both hover
-  // and keyboard because we can't rely on Kobalte focusing SubContent: on
-  // hover, its delayed pointer handler opens with `autoFocus=false`, so no
-  // focusin fires on SubContent for us to hook.
+  // Hold focus on the search input while the sub is open. Kobalte's menu
+  // primitives can focus the SubContent in several places (mount's
+  // `tryAutoFocus`, pointer-grace `focusContent`, item-leave handlers), and
+  // which one fires depends on whether the sub was opened by keyboard or
+  // hover — so racing a setTimeout isn't reliable across environments.
+  // Instead, we listen for any focus landing inside the sub that isn't on
+  // the input or a listbox option and pull it back. Scoped to the sub's own
+  // DOM so clicks outside still dismiss the menu normally.
   createEffect(() => {
     const el = inputRef();
-    if (!isOpen() || !el) return;
-    setTimeout(() => el.focus(), 0);
+    const container = subContentRef();
+    if (!isOpen() || !el || !container) return;
+
+    const reclaim = (e: FocusEvent) => {
+      const target = e.target as HTMLElement | null;
+      if (!target || target === el) return;
+      if (!container.contains(target)) return;
+      if (target.getAttribute?.('role') === 'option') return;
+      el.focus();
+    };
+    document.addEventListener('focusin', reclaim, true);
+    onCleanup(() => document.removeEventListener('focusin', reclaim, true));
+
+    // Some open paths (e.g. hover, where Kobalte opens with autoFocus=false)
+    // don't dispatch a focusin on SubContent for us to react to, so pull
+    // focus once up front as well.
+    el.focus();
   });
 
   return (
@@ -382,7 +400,10 @@ const SearchableFilterSubmenu = (props: {
       </DropdownMenu.SubTrigger>
 
       <DropdownMenu.Portal>
-        <DropdownMenu.SubContent class="z-action-menu bg-menu border border-edge-muted rounded-sm shadow-xl w-[260px] max-w-[90vw] overflow-hidden">
+        <DropdownMenu.SubContent
+          ref={setSubContentRef}
+          class="z-action-menu bg-menu border border-edge-muted rounded-sm shadow-xl w-[260px] max-w-[90vw] overflow-hidden"
+        >
           <SearchableMultiSelectInline
             options={props.options}
             activeIds={props.activeIds}

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/unified-filter-dropdown.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/unified-filter-dropdown.tsx
@@ -348,50 +348,21 @@ const SearchableFilterSubmenu = (props: {
     else setInternalOpen(v);
   };
   const [inputRef, setInputRef] = createSignal<HTMLInputElement>();
-  const [subContentRef, setSubContentRef] = createSignal<HTMLDivElement>();
 
-  // Hold focus on the search input while the sub is open. Kobalte's menu
-  // primitives can focus the SubContent in several places with different
-  // timing for hover vs keyboard opens (`tryAutoFocus` on mount,
-  // `focusContent` on pointer-grace, item-leave handlers). We combine:
-  //   1. A scoped focusin listener that reclaims focus whenever anything
-  //      inside the sub that isn't the input or a listbox option receives
-  //      focus.
-  //   2. A short rAF-poll for ~200ms after open, to cover any focus moves
-  //      that don't emit a focusin on the container (some Kobalte paths
-  //      focus outside the sub root or blur without a replacement).
+  // Focus the search input on open. The rAF is load-bearing: Kobalte's
+  // DismissableLayer registers itself as a nested layer of the parent menu
+  // in `onMount`, and the search input lives in a portaled sub. If we focus
+  // synchronously before that registration runs, the parent (Channels)
+  // treats focus landing in the portaled sub as "focus outside" and closes
+  // the whole menu tree. Waiting one frame lets the nested-layer
+  // registration complete, so focus transitions stay within the layer stack.
   createEffect(() => {
     const el = inputRef();
-    const container = subContentRef();
-    if (!isOpen() || !el || !container) return;
-
-    const ensureFocus = () => {
-      if (!isOpen()) return;
-      if (document.activeElement === el) return;
-      el.focus();
-    };
-
-    const reclaim = (e: FocusEvent) => {
-      const target = e.target as HTMLElement | null;
-      if (!target || target === el) return;
-      if (!container.contains(target)) return;
-      if (target.getAttribute?.('role') === 'option') return;
-      el.focus();
-    };
-    document.addEventListener('focusin', reclaim, true);
-
-    const start = performance.now();
-    let rafId = requestAnimationFrame(function tick() {
-      ensureFocus();
-      if (performance.now() - start < 200) rafId = requestAnimationFrame(tick);
+    if (!isOpen() || !el) return;
+    const raf = requestAnimationFrame(() => {
+      if (isOpen()) el.focus();
     });
-
-    onCleanup(() => {
-      document.removeEventListener('focusin', reclaim, true);
-      cancelAnimationFrame(rafId);
-    });
-
-    el.focus();
+    onCleanup(() => cancelAnimationFrame(raf));
   });
 
   return (
@@ -415,10 +386,7 @@ const SearchableFilterSubmenu = (props: {
       </DropdownMenu.SubTrigger>
 
       <DropdownMenu.Portal>
-        <DropdownMenu.SubContent
-          ref={setSubContentRef}
-          class="z-action-menu bg-menu border border-edge-muted rounded-sm shadow-xl w-[260px] max-w-[90vw] overflow-hidden"
-        >
+        <DropdownMenu.SubContent class="z-action-menu bg-menu border border-edge-muted rounded-sm shadow-xl w-[260px] max-w-[90vw] overflow-hidden">
           <SearchableMultiSelectInline
             options={props.options}
             activeIds={props.activeIds}

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/unified-filter-dropdown.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/unified-filter-dropdown.tsx
@@ -347,6 +347,7 @@ const SearchableFilterSubmenu = (props: {
     else setInternalOpen(v);
   };
   let inputRef: HTMLInputElement | undefined;
+  let openedByKeyboard = false;
 
   return (
     <DropdownMenu.Sub gutter={4} open={isOpen()} onOpenChange={setIsOpen}>
@@ -360,8 +361,14 @@ const SearchableFilterSubmenu = (props: {
           // + open so Kobalte's parent selection manager updates to this
           // trigger and the shared signal closes the sibling.
           if (e.pointerType !== 'mouse') return;
+          openedByKeyboard = false;
           e.currentTarget.focus({ preventScroll: true });
           if (!isOpen()) setIsOpen(true);
+        }}
+        onKeyDown={(e) => {
+          if (e.key === 'ArrowRight' || e.key === 'Enter' || e.key === ' ') {
+            openedByKeyboard = true;
+          }
         }}
       >
         <span class="text-ink">{props.label}</span>
@@ -372,10 +379,12 @@ const SearchableFilterSubmenu = (props: {
         <DropdownMenu.SubContent
           class="z-action-menu bg-menu border border-edge-muted rounded-sm shadow-xl w-[260px] max-w-[90vw] overflow-hidden"
           onFocusIn={(e) => {
-            // Kobalte focuses SubContent itself on open; redirect to the
-            // search input so it gets focus deterministically.
-            if (e.target === e.currentTarget && inputRef) {
+            // Kobalte focuses SubContent itself on open. Only redirect to the
+            // search input when the sub was opened via keyboard — otherwise
+            // a hover would flash the caret in the input.
+            if (e.target === e.currentTarget && inputRef && openedByKeyboard) {
               inputRef.focus();
+              openedByKeyboard = false;
             }
           }}
         >

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/unified-filter-dropdown.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/unified-filter-dropdown.tsx
@@ -351,17 +351,25 @@ const SearchableFilterSubmenu = (props: {
   const [subContentRef, setSubContentRef] = createSignal<HTMLDivElement>();
 
   // Hold focus on the search input while the sub is open. Kobalte's menu
-  // primitives can focus the SubContent in several places (mount's
-  // `tryAutoFocus`, pointer-grace `focusContent`, item-leave handlers), and
-  // which one fires depends on whether the sub was opened by keyboard or
-  // hover — so racing a setTimeout isn't reliable across environments.
-  // Instead, we listen for any focus landing inside the sub that isn't on
-  // the input or a listbox option and pull it back. Scoped to the sub's own
-  // DOM so clicks outside still dismiss the menu normally.
+  // primitives can focus the SubContent in several places with different
+  // timing for hover vs keyboard opens (`tryAutoFocus` on mount,
+  // `focusContent` on pointer-grace, item-leave handlers). We combine:
+  //   1. A scoped focusin listener that reclaims focus whenever anything
+  //      inside the sub that isn't the input or a listbox option receives
+  //      focus.
+  //   2. A short rAF-poll for ~200ms after open, to cover any focus moves
+  //      that don't emit a focusin on the container (some Kobalte paths
+  //      focus outside the sub root or blur without a replacement).
   createEffect(() => {
     const el = inputRef();
     const container = subContentRef();
     if (!isOpen() || !el || !container) return;
+
+    const ensureFocus = () => {
+      if (!isOpen()) return;
+      if (document.activeElement === el) return;
+      el.focus();
+    };
 
     const reclaim = (e: FocusEvent) => {
       const target = e.target as HTMLElement | null;
@@ -371,11 +379,18 @@ const SearchableFilterSubmenu = (props: {
       el.focus();
     };
     document.addEventListener('focusin', reclaim, true);
-    onCleanup(() => document.removeEventListener('focusin', reclaim, true));
 
-    // Some open paths (e.g. hover, where Kobalte opens with autoFocus=false)
-    // don't dispatch a focusin on SubContent for us to react to, so pull
-    // focus once up front as well.
+    const start = performance.now();
+    let rafId = requestAnimationFrame(function tick() {
+      ensureFocus();
+      if (performance.now() - start < 200) rafId = requestAnimationFrame(tick);
+    });
+
+    onCleanup(() => {
+      document.removeEventListener('focusin', reclaim, true);
+      cancelAnimationFrame(rafId);
+    });
+
     el.focus();
   });
 

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/unified-filter-dropdown.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/unified-filter-dropdown.tsx
@@ -348,32 +348,29 @@ const SearchableFilterSubmenu = (props: {
     else setInternalOpen(v);
   };
   const [inputRef, setInputRef] = createSignal<HTMLInputElement>();
-  const [subContentRef, setSubContentRef] = createSignal<HTMLDivElement>();
 
   // Focus the search input while the sub is open.
   //
-  // Two separate issues conspire here:
+  // Two issues conspire:
   //   1. Initial focus has to wait for Kobalte's DismissableLayer to register
   //      itself as a nested layer of the parent menu (done in its onMount).
   //      The sub is portaled, so focusing the input before that registration
   //      looks like "focus outside" to the parent and closes the whole menu
   //      tree. One rAF is enough to get past those onMount callbacks.
-  //   2. After that, focus can still be stolen later: the Combobox re-renders
-  //      when its async options stream in, which blurs the input. Reclaim on
-  //      blur, but only when focus is moving within the sub (or going nowhere)
-  //      — let the user leave normally when they focus something outside.
+  //   2. After that, Kobalte's `onPointerMove` on the SubTrigger keeps
+  //      calling `focusWithoutScrolling(e.currentTarget)` on every mouse
+  //      move, stealing focus back to the trigger. Reclaim on blur — user
+  //      dismissal routes (Escape / click-outside) close the sub first,
+  //      which unregisters this listener before focus moves elsewhere.
   createEffect(() => {
     const el = inputRef();
-    const container = subContentRef();
-    if (!isOpen() || !el || !container) return;
+    if (!isOpen() || !el) return;
 
     const raf = requestAnimationFrame(() => {
       if (isOpen()) el.focus();
     });
 
-    const onBlur = (e: FocusEvent) => {
-      const next = e.relatedTarget as HTMLElement | null;
-      if (next && !container.contains(next)) return;
+    const onBlur = () => {
       queueMicrotask(() => {
         if (isOpen() && document.activeElement !== el) el.focus();
       });
@@ -407,10 +404,7 @@ const SearchableFilterSubmenu = (props: {
       </DropdownMenu.SubTrigger>
 
       <DropdownMenu.Portal>
-        <DropdownMenu.SubContent
-          ref={setSubContentRef}
-          class="z-action-menu bg-menu border border-edge-muted rounded-sm shadow-xl w-[260px] max-w-[90vw] overflow-hidden"
-        >
+        <DropdownMenu.SubContent class="z-action-menu bg-menu border border-edge-muted rounded-sm shadow-xl w-[260px] max-w-[90vw] overflow-hidden">
           <SearchableMultiSelectInline
             options={props.options}
             activeIds={props.activeIds}

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/unified-filter-dropdown.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/unified-filter-dropdown.tsx
@@ -348,6 +348,19 @@ const SearchableFilterSubmenu = (props: {
   };
   const [inputRef, setInputRef] = createSignal<HTMLInputElement>();
 
+  // Focus the search input whenever the sub is open and the input is mounted.
+  // The setTimeout defers past Kobalte's own `setTimeout(tryAutoFocus, 0)` in
+  // `createSelectableCollection`, which would otherwise focus SubContent (the
+  // menu owns no items of its own — the Combobox does). Runs for both hover
+  // and keyboard because we can't rely on Kobalte focusing SubContent: on
+  // hover, its delayed pointer handler opens with `autoFocus=false`, so no
+  // focusin fires on SubContent for us to hook.
+  createEffect(() => {
+    const el = inputRef();
+    if (!isOpen() || !el) return;
+    setTimeout(() => el.focus(), 0);
+  });
+
   return (
     <DropdownMenu.Sub gutter={4} open={isOpen()} onOpenChange={setIsOpen}>
       <DropdownMenu.SubTrigger
@@ -369,16 +382,7 @@ const SearchableFilterSubmenu = (props: {
       </DropdownMenu.SubTrigger>
 
       <DropdownMenu.Portal>
-        <DropdownMenu.SubContent
-          class="z-action-menu bg-menu border border-edge-muted rounded-sm shadow-xl w-[260px] max-w-[90vw] overflow-hidden"
-          onFocusIn={(e) => {
-            // Kobalte focuses SubContent on open, and again via its deferred
-            // `tryAutoFocus` (the menu has no items of its own — the Combobox
-            // owns them). Redirect to the search input both times so the
-            // caret lands in the input and stays there.
-            if (e.target === e.currentTarget) inputRef()?.focus();
-          }}
-        >
+        <DropdownMenu.SubContent class="z-action-menu bg-menu border border-edge-muted rounded-sm shadow-xl w-[260px] max-w-[90vw] overflow-hidden">
           <SearchableMultiSelectInline
             options={props.options}
             activeIds={props.activeIds}

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/unified-filter-dropdown.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/unified-filter-dropdown.tsx
@@ -346,8 +346,7 @@ const SearchableFilterSubmenu = (props: {
     if (props.onOpenChange) props.onOpenChange(v);
     else setInternalOpen(v);
   };
-  let inputRef: HTMLInputElement | undefined;
-  let openedByKeyboard = false;
+  const [inputRef, setInputRef] = createSignal<HTMLInputElement>();
 
   return (
     <DropdownMenu.Sub gutter={4} open={isOpen()} onOpenChange={setIsOpen}>
@@ -361,14 +360,8 @@ const SearchableFilterSubmenu = (props: {
           // + open so Kobalte's parent selection manager updates to this
           // trigger and the shared signal closes the sibling.
           if (e.pointerType !== 'mouse') return;
-          openedByKeyboard = false;
           e.currentTarget.focus({ preventScroll: true });
           if (!isOpen()) setIsOpen(true);
-        }}
-        onKeyDown={(e) => {
-          if (e.key === 'ArrowRight' || e.key === 'Enter' || e.key === ' ') {
-            openedByKeyboard = true;
-          }
         }}
       >
         <span class="text-ink">{props.label}</span>
@@ -379,13 +372,11 @@ const SearchableFilterSubmenu = (props: {
         <DropdownMenu.SubContent
           class="z-action-menu bg-menu border border-edge-muted rounded-sm shadow-xl w-[260px] max-w-[90vw] overflow-hidden"
           onFocusIn={(e) => {
-            // Kobalte focuses SubContent itself on open. Only redirect to the
-            // search input when the sub was opened via keyboard — otherwise
-            // a hover would flash the caret in the input.
-            if (e.target === e.currentTarget && inputRef && openedByKeyboard) {
-              inputRef.focus();
-              openedByKeyboard = false;
-            }
+            // Kobalte focuses SubContent on open, and again via its deferred
+            // `tryAutoFocus` (the menu has no items of its own — the Combobox
+            // owns them). Redirect to the search input both times so the
+            // caret lands in the input and stays there.
+            if (e.target === e.currentTarget) inputRef()?.focus();
           }}
         >
           <SearchableMultiSelectInline
@@ -393,9 +384,7 @@ const SearchableFilterSubmenu = (props: {
             activeIds={props.activeIds}
             onChange={props.onChange}
             placeholder={props.placeholder}
-            inputRef={(el) => {
-              inputRef = el;
-            }}
+            inputRef={setInputRef}
             onRequestClose={() => setIsOpen(false)}
           />
         </DropdownMenu.SubContent>

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/unified-filter-dropdown.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/unified-filter-dropdown.tsx
@@ -348,21 +348,42 @@ const SearchableFilterSubmenu = (props: {
     else setInternalOpen(v);
   };
   const [inputRef, setInputRef] = createSignal<HTMLInputElement>();
+  const [subContentRef, setSubContentRef] = createSignal<HTMLDivElement>();
 
-  // Focus the search input on open. The rAF is load-bearing: Kobalte's
-  // DismissableLayer registers itself as a nested layer of the parent menu
-  // in `onMount`, and the search input lives in a portaled sub. If we focus
-  // synchronously before that registration runs, the parent (Channels)
-  // treats focus landing in the portaled sub as "focus outside" and closes
-  // the whole menu tree. Waiting one frame lets the nested-layer
-  // registration complete, so focus transitions stay within the layer stack.
+  // Focus the search input while the sub is open.
+  //
+  // Two separate issues conspire here:
+  //   1. Initial focus has to wait for Kobalte's DismissableLayer to register
+  //      itself as a nested layer of the parent menu (done in its onMount).
+  //      The sub is portaled, so focusing the input before that registration
+  //      looks like "focus outside" to the parent and closes the whole menu
+  //      tree. One rAF is enough to get past those onMount callbacks.
+  //   2. After that, focus can still be stolen later: the Combobox re-renders
+  //      when its async options stream in, which blurs the input. Reclaim on
+  //      blur, but only when focus is moving within the sub (or going nowhere)
+  //      — let the user leave normally when they focus something outside.
   createEffect(() => {
     const el = inputRef();
-    if (!isOpen() || !el) return;
+    const container = subContentRef();
+    if (!isOpen() || !el || !container) return;
+
     const raf = requestAnimationFrame(() => {
       if (isOpen()) el.focus();
     });
-    onCleanup(() => cancelAnimationFrame(raf));
+
+    const onBlur = (e: FocusEvent) => {
+      const next = e.relatedTarget as HTMLElement | null;
+      if (next && !container.contains(next)) return;
+      queueMicrotask(() => {
+        if (isOpen() && document.activeElement !== el) el.focus();
+      });
+    };
+    el.addEventListener('blur', onBlur);
+
+    onCleanup(() => {
+      cancelAnimationFrame(raf);
+      el.removeEventListener('blur', onBlur);
+    });
   });
 
   return (
@@ -386,7 +407,10 @@ const SearchableFilterSubmenu = (props: {
       </DropdownMenu.SubTrigger>
 
       <DropdownMenu.Portal>
-        <DropdownMenu.SubContent class="z-action-menu bg-menu border border-edge-muted rounded-sm shadow-xl w-[260px] max-w-[90vw] overflow-hidden">
+        <DropdownMenu.SubContent
+          ref={setSubContentRef}
+          class="z-action-menu bg-menu border border-edge-muted rounded-sm shadow-xl w-[260px] max-w-[90vw] overflow-hidden"
+        >
           <SearchableMultiSelectInline
             options={props.options}
             activeIds={props.activeIds}


### PR DESCRIPTION
## Summary
- Fixes cursor flash/disappear in the search filter submenu (Filter → Channels → In/From/Assignee).
- Redirects `focusin` on `DropdownMenu.SubContent` to the inner `Combobox.Input` whenever focus lands on the SubContent container itself — this wins against Kobalte's deferred `tryAutoFocus` that focuses SubContent when the menu has no items of its own (true here — the Combobox owns the items).
- Behavior is consistent for hover and keyboard: opening the sub focuses the search input and keeps it focused.

## Root cause
`createSelectableCollection` inside Kobalte's menu schedules `setTimeout(tryAutoFocus, 0)` on mount. With an empty menu collection, `tryAutoFocus` falls back to `focusWithoutScrolling(refEl)` which focuses the SubContent div. The previous one-shot `onFocusIn` handler focused the input on the first `focusin`, then Kobalte's deferred timer re-focused SubContent, so the caret briefly flashed in the input and disappeared.
