### PR TITLE
Add AI Explain action to channel message menus

### DIFF
--- a/js/app/packages/channel/Channel/Channel.tsx
+++ b/js/app/packages/channel/Channel/Channel.tsx
@@ -48,6 +48,8 @@ import { createChannelMessageActions } from './create-channel-message-actions';
 import { useSplitLayout } from '@app/component/split-layout/layout';
 import { useChannelName, useChannelActivity } from '@core/context/channels';
 import { buildMentionMarkdownString, markdownToPlainText } from '@lexical-core';
+import { setPendingSendData } from '@core/component/AI/signal/pendingSend';
+import { createChat } from '@core/util/create';
 import { createActivityTracker } from '@channel/activity-tracker';
 import {
   invalidateChannelsActivity,
@@ -211,7 +213,7 @@ export function Channel(props: ChannelProps) {
   });
 
   const channelName = useChannelName(props.channelId);
-  const { popoverSplit } = useSplitLayout();
+  const { popoverSplit, replaceOrInsertSplit } = useSplitLayout();
 
   const getMessageActions = createChannelMessageActions({
     channelId: () => props.channelId,
@@ -226,6 +228,32 @@ export function Channel(props: ChannelProps) {
     },
     onEdit: ({ message }) => {
       messageEditor.start(message);
+    },
+    onExplain: async (ctx) => {
+      const result = await createChat();
+      if ('error' in result) return;
+
+      const messageMention = buildMentionMarkdownString({
+        type: 'document',
+        documentId: props.channelId,
+        documentName: channelName() ?? '',
+        blockName: 'channel',
+        blockParams: {
+          channel_message_id: ctx.message.id,
+          ...(ctx.message.thread_id && {
+            channel_thread_id: ctx.message.thread_id,
+          }),
+        },
+      });
+
+      setPendingSendData({
+        content: `Explain this message:\n\n${messageMention}`,
+      });
+
+      replaceOrInsertSplit(
+        { type: 'chat', id: result.chatId },
+        'entity-actions-menu'
+      );
     },
     onCreateTask: (ctx) => {
       const plainText = markdownToPlainText(ctx.message.content).trim();

--- a/js/app/packages/channel/Channel/create-channel-message-actions.ts
+++ b/js/app/packages/channel/Channel/create-channel-message-actions.ts
@@ -55,6 +55,7 @@ export type CreateChannelMessageActionsOptions = {
   addReaction: (input: AddReactionInput) => void;
   removeReaction: (input: RemoveReactionInput) => void;
   onReply?: MessageActionHandler;
+  onExplain?: MessageActionHandler;
   onEdit?: MessageActionHandler;
   onCreateTask?: MessageActionHandler;
   effects?: Partial<ChannelMessageActionEffects>;
@@ -171,6 +172,7 @@ export function createChannelMessageActions(
               }
             }
           : undefined,
+      onExplain: !isDeleted ? options.onExplain : undefined,
       onEdit: canEditDelete ? options.onEdit : undefined,
       onDelete: canEditDelete
         ? () => {

--- a/js/app/packages/channel/Message/ActionMenu.tsx
+++ b/js/app/packages/channel/Message/ActionMenu.tsx
@@ -4,6 +4,7 @@ import EditIcon from '@macro-icons/square/edit.svg';
 import AddEmojiIcon from '@macro-icons/square/add-emoji.svg';
 import TrashIcon from '@macro-icons/square/trash.svg';
 import TaskIcon from '@macro-icons/wide/task.svg';
+import SparkleIcon from '@icon/regular/sparkle.svg';
 import { cn } from '@ui/utils/classname';
 import { createSignal, For, Show, type Component, type JSX } from 'solid-js';
 import { useMessage, useMessageActions } from './context';
@@ -14,7 +15,13 @@ import type { MessageActionEvent, MessageActionHandler } from './types';
 
 const QUICK_REACTION_EMOJIS = ['❤️', '👍', '😂'] as const;
 
-type ActionId = 'reply' | 'copy-link' | 'create-task' | 'edit' | 'delete';
+type ActionId =
+  | 'reply'
+  | 'copy-link'
+  | 'explain'
+  | 'create-task'
+  | 'edit'
+  | 'delete';
 
 type ActionItem = {
   id: ActionId;
@@ -68,6 +75,13 @@ export function ActionMenu(props: ActionMenuProps) {
   const hasReactAction = () => actions?.onReact !== undefined;
 
   const actionItems: ActionItem[] = [
+    {
+      id: 'explain',
+      label: 'Explain',
+      icon: SparkleIcon,
+      onClick: actions?.onExplain,
+      class: 'px-1.5',
+    },
     {
       id: 'create-task',
       label: 'Task',

--- a/js/app/packages/channel/Message/types.ts
+++ b/js/app/packages/channel/Message/types.ts
@@ -29,6 +29,7 @@ export type MessageActionHandler = (
 export type MessageActions = {
   onReply?: MessageActionHandler;
   onReact?: MessageActionHandler;
+  onExplain?: MessageActionHandler;
   onCopyLink?: MessageActionHandler;
   onCopyMessageText?: MessageActionHandler;
   onEdit?: MessageActionHandler;

--- a/js/app/packages/channel/Mobile/ActionDrawer.tsx
+++ b/js/app/packages/channel/Mobile/ActionDrawer.tsx
@@ -5,6 +5,7 @@ import CopyIcon from '@icon/regular/copy.svg';
 import LinkIcon from '@icon/regular/link.svg';
 import PencilIcon from '@icon/regular/pencil.svg';
 import SmileyIcon from '@icon/regular/smiley.svg';
+import SparkleIcon from '@icon/regular/sparkle.svg';
 import TrashIcon from '@icon/regular/trash.svg';
 import { focusInput } from '@core/directive/focusInput';
 import {
@@ -25,7 +26,13 @@ import type {
 
 const QUICK_REACTION_EMOJIS = ['❤️', '👍', '👎', '😂', '😡'] as const;
 
-type ActionId = 'reply' | 'copy-link' | 'copy-message-text' | 'edit' | 'delete';
+type ActionId =
+  | 'reply'
+  | 'explain'
+  | 'copy-link'
+  | 'copy-message-text'
+  | 'edit'
+  | 'delete';
 
 type ActionItem = {
   id: ActionId;
@@ -52,6 +59,12 @@ function buildActionItems(
               `[data-input-id="thread-reply-input-${messageId}"] [contenteditable]`
             )
         : undefined,
+    },
+    {
+      id: 'explain',
+      label: 'Explain',
+      icon: SparkleIcon,
+      onClick: actions?.onExplain,
     },
     {
       id: 'copy-message-text',


### PR DESCRIPTION
### Motivation
- Provide an AI "Explain" affordance on channel messages so users can trigger an AI explanation of a specific channel message from the same topbar/hovers where reactions and task creation live.

### Description
- Added a new `onExplain` message action to the message action contract to allow UIs to expose an explain handler (`js/app/packages/channel/Message/types.ts`).
- Wired `onExplain` through `createChannelMessageActions` so it is exposed for non-deleted messages like other actions (`js/app/packages/channel/Channel/create-channel-message-actions.ts`).
- Added an Explain button (sparkle icon) to the desktop hover action menu positioned immediately to the right of emoji controls and left of the Task button (`js/app/packages/channel/Message/ActionMenu.tsx`) to match the requested placement.
- Added an Explain item to the mobile message action drawer for parity (`js/app/packages/channel/Mobile/ActionDrawer.tsx`).
- Implemented channel-level behavior for Explain: create a new chat, seed the chat pending send input with an "Explain this message" prompt that references the selected channel message mention, and navigate/replace to the new chat split (`js/app/packages/channel/Channel/Channel.tsx`, uses `createChat` and `setPendingSendData`).

### Testing
- Ran type-check: `bun run check` against the app; it failed in this environment due to missing type-definition packages (e.g. `vite/client`, `@types/gtag.js`, etc.).
- Ran lint for the modified files: `bun run lint ...` which failed here because fetching `biome` from the npm registry returned HTTP 403 in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebbff765c08324862a4da8ee288535)