### PR TITLE
fix(soup): restore focus on mark-done undo

### DIFF
--- a/js/app/packages/app/component/next-soup/actions/make-mark-done-action.ts
+++ b/js/app/packages/app/component/next-soup/actions/make-mark-done-action.ts
@@ -23,6 +23,7 @@ type MarkDoneVariables = {
   entities: EntityData[];
   emailIds: string[];
   notificationIds: string[];
+  restoreFocus?: () => void;
 };
 
 /** Must be invoked inside a component tree that provides MutationUndoProvider. */
@@ -95,7 +96,6 @@ export const makeMarkDoneAction = (options: MakeMarkDoneOptions) => {
                 handle.undo({
                   onError: () => toast.failure('Failed to undo'),
                 });
-                restoreSoupFocus(firstEntityId, inPreview);
               },
             },
           ],
@@ -109,6 +109,8 @@ export const makeMarkDoneAction = (options: MakeMarkDoneOptions) => {
       return {
         onUndone: () => {
           if (toastId !== undefined) toast.dismiss(toastId);
+          variables.restoreFocus?.();
+          restoreSoupFocus(firstEntityId, inPreview);
         },
         onRedone: showToast,
       };
@@ -131,12 +133,17 @@ export const makeMarkDoneAction = (options: MakeMarkDoneOptions) => {
     return false;
   };
 
-  const execute = async (entities: EntityData[]) => {
+  const execute = async (entities: EntityData[], restoreFocus?: () => void) => {
     const { emailIds, notificationIds } = resolveMarkEntitiesDoneVariables({
       entities,
       notificationSource: notificationSource(),
     });
-    await mutation.mutateAsync({ entities, emailIds, notificationIds });
+    await mutation.mutateAsync({
+      entities,
+      emailIds,
+      notificationIds,
+      restoreFocus,
+    });
   };
 
   const executeWithSoup = async (
@@ -145,6 +152,7 @@ export const makeMarkDoneAction = (options: MakeMarkDoneOptions) => {
     onNavigate?: (entity: EntityData) => void
   ) => {
     const currentIndex = soup.focus.index();
+    const focusedIdBeforeMarkDone = soup.focus.id();
     const nextEntity =
       soup.items.at(currentIndex + 1) ?? soup.items.at(currentIndex - 1);
 
@@ -155,7 +163,11 @@ export const makeMarkDoneAction = (options: MakeMarkDoneOptions) => {
       }
     }
 
-    await execute(entities);
+    const restoreFocus = focusedIdBeforeMarkDone
+      ? () => soup.focus.set(focusedIdBeforeMarkDone)
+      : undefined;
+
+    await execute(entities, restoreFocus);
 
     soup.selection.clear();
 

--- a/js/app/packages/entity/src/extractors-notification/mobile-notification-stacks.tsx
+++ b/js/app/packages/entity/src/extractors-notification/mobile-notification-stacks.tsx
@@ -89,6 +89,7 @@ function MobileStackRow(props: {
   const notificationSource = useGlobalNotificationSource();
   const { markStackAsDone } = useNotificationStackActions({
     stack: props.stack,
+    entityId: props.entity.id,
   });
   const stackEntityId = () => getMostRecentNotification(props.stack).id;
   const unread = () => isNotificationUnread(props.stack);

--- a/js/app/packages/entity/src/extractors-notification/notification-actions.tsx
+++ b/js/app/packages/entity/src/extractors-notification/notification-actions.tsx
@@ -12,6 +12,7 @@ import { restoreSoupFocus } from '@app/component/next-soup/utils';
 
 interface NotificationActionsProps {
   stack: NotificationStack;
+  entityId?: string;
   onMarkAsDone?: () => void;
   onMarkAsRead?: () => void;
 }
@@ -51,7 +52,7 @@ export function useNotificationStackActions(props: NotificationActionsProps) {
                   handle.undo({
                     onError: () => toast.failure('Failed to undo'),
                   });
-                  restoreSoupFocus();
+                  restoreSoupFocus(props.entityId);
                 },
               },
             ],

--- a/js/app/packages/entity/src/extractors-notification/notification-actions.tsx
+++ b/js/app/packages/entity/src/extractors-notification/notification-actions.tsx
@@ -8,6 +8,7 @@ import {
 } from '@notifications';
 import { useUndoableMutation } from '@queries/undo';
 import { useGlobalNotificationSource } from '@app/component/GlobalAppState';
+import { useMaybeSoup } from '@app/component/next-soup/soup-context';
 import { restoreSoupFocus } from '@app/component/next-soup/utils';
 
 interface NotificationActionsProps {
@@ -27,6 +28,7 @@ type MarkStackDoneVariables = { notificationIds: string[] };
 
 export function useNotificationStackActions(props: NotificationActionsProps) {
   const notificationSource = useGlobalNotificationSource();
+  const soup = useMaybeSoup();
 
   const mutation = useUndoableMutation<void, Error, MarkStackDoneVariables>(
     () => ({
@@ -52,6 +54,7 @@ export function useNotificationStackActions(props: NotificationActionsProps) {
                   handle.undo({
                     onError: () => toast.failure('Failed to undo'),
                   });
+                  if (props.entityId) soup?.focus.set(props.entityId);
                   restoreSoupFocus(props.entityId);
                 },
               },

--- a/js/app/packages/entity/src/extractors-notification/notification-stacks.tsx
+++ b/js/app/packages/entity/src/extractors-notification/notification-stacks.tsx
@@ -60,6 +60,7 @@ function NotificationStackRow(props: {
 
   const { markStackAsDone, markStackAsRead } = useNotificationStackActions({
     stack: props.stack,
+    entityId: props.entity.id,
   });
 
   const handleClick = async (e: PointerEvent | MouseEvent | KeyboardEvent) => {


### PR DESCRIPTION
## Summary
- Mark-done via the soup hotkey (`e`) now captures the focused entity id before the mutation and restores it through the undo lifecycle, so both soup state focus and DOM focus snap back to the original item whether the user clicks the toast Undo or hits `cmd+z`.
- Mark-done on a notification stack inside an entity row now threads the parent entityId to the undo handler and, on undo, updates both the soup state's `focusedId` (which drives the orange highlight) and DOM focus so the entity re-highlights even if focus had moved elsewhere in the meantime.
