### PR TITLE
chore: remove unused deps

### DIFF
--- a/rust/cloud-storage/ai/Cargo.toml
+++ b/rust/cloud-storage/ai/Cargo.toml
@@ -14,12 +14,8 @@ path = "src/bin/cli.rs"
 anyhow = { workspace = true }
 async-openai = { workspace = true }
 async-stream = { workspace = true }
-async-trait = { workspace = true }
-chrono = { workspace = true }
-const_format = "0.2.34"
 futures = { workspace = true }
 lazy_static = { workspace = true }
-rand.workspace = true
 reqwest = { workspace = true }
 schemars = { workspace = true }
 secrecy = "0.10.3"

--- a/rust/cloud-storage/ai_tools/Cargo.toml
+++ b/rust/cloud-storage/ai_tools/Cargo.toml
@@ -35,19 +35,13 @@ item_filters = { path = "../item_filters" }
 lazy_static.workspace = true
 lexical_client = { path = "../lexical_client" }
 macro_aws_config = { path = "../macro_aws_config" }
-macro_db_client = { path = "../macro_db_client" }
 macro_env_var = { path = "../macro_env_var" }
 macro_user_id = { path = "../macro_user_id" }
 model = { path = "../model" }
 model_notifications = { path = "../model_notifications" }
-models_dcs = { path = "../models_dcs" }
-models_email = { path = "../models_email" }
-models_pagination = { path = "../models_pagination" }
-models_permissions = { path = "../models_permissions" }
 notification = { path = "../notification" }
 models_properties = { path = "../models_properties" }
 models_search = { path = "../models_search" }
-rand.workspace = true
 readonly_pool = { path = "../readonly_pool" }
 rootcause = { workspace = true }
 schemars.workspace = true
@@ -68,14 +62,11 @@ sqlx.workspace = true
 static_file_service_client = { path = "../static_file_service_client" }
 strum.workspace = true
 sync_service_client = { path = "../sync_service_client" }
-tokio.workspace = true
 tracing.workspace = true
 utoipa.workspace = true
 uuid.workspace = true
-remote_env_var = { path = "../remote_env_var" }
 macro_env = { path = "../macro_env" }
 secretsmanager_client = { path = "../secretsmanager_client" }
 aws-sdk-secretsmanager = { workspace = true }
 
 [dev-dependencies]
-cool_asserts = "2"

--- a/rust/cloud-storage/ai_toolset/Cargo.toml
+++ b/rust/cloud-storage/ai_toolset/Cargo.toml
@@ -6,7 +6,6 @@ publish = false
 
 [dependencies]
 serde_json = { workspace = true }
-futures = { workspace = true }
 serde = { workspace = true }
 utoipa = { workspace = true }
 schemars = { workspace = true }
@@ -15,5 +14,4 @@ thiserror = { workspace = true }
 anyhow = { workspace = true }
 macro_user_id = { path = "../macro_user_id" }
 axum = { workspace = true }
-axum-macros = { workspace = true }
 tracing = { workspace = true }

--- a/rust/cloud-storage/authentication_service/Cargo.toml
+++ b/rust/cloud-storage/authentication_service/Cargo.toml
@@ -36,11 +36,9 @@ aws-sdk-sesv2 = { workspace = true }
 aws-sdk-sqs = { workspace = true }
 axum = { workspace = true, features = ["macros"] }
 base64 = { workspace = true }
-chrono = { workspace = true }
 comms_db_client = { path = "../comms_db_client" }
 cookie = { workspace = true }
 document_storage_service_client = { path = "../document_storage_service_client" }
-doppleganger = { workspace = true }
 email_validator = { path = "../email_validator" }
 fusionauth = { path = "../fusionauth" }
 futures = { workspace = true }
@@ -51,8 +49,6 @@ github = { path = "../github", default-features = false, features = [
   "outbound",
 ] }
 http-body-util = { workspace = true }
-jsonwebtoken = { workspace = true }
-last_online_tracker = { path = "../last_online_tracker" }
 macro_auth = { path = "../macro_auth" }
 macro_aws_config = { path = "../macro_aws_config" }
 macro_cache_client = { path = "../macro_cache_client", default-features = false, features = [
@@ -82,10 +78,7 @@ macro_user_id = { path = "../macro_user_id" }
 macro_uuid = { path = "../macro_uuid" }
 maud = { version = "0.27.0" }
 miniserde = "0.1.45"
-mockall = { workspace = true }
 model = { path = "../model" }
-model-entity = { path = "../model-entity" }
-model_notifications = { path = "../model_notifications" }
 model_user = { path = "../model_user", features = ["axum"] }
 models_team = { path = "../models_team" }
 native_app_service = { path = "../native_app_service" }
@@ -118,7 +111,6 @@ time = { workspace = true }
 tokio = { workspace = true }
 tower = { workspace = true }
 tower-cookies = { version = "0.11.0" }
-tower-http = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
 urlencoding = { workspace = true }

--- a/rust/cloud-storage/backfill_entity_access/Cargo.toml
+++ b/rust/cloud-storage/backfill_entity_access/Cargo.toml
@@ -11,4 +11,3 @@ macro_env_var = { path = "../macro_env_var" }
 macro_uuid = { path = "../macro_uuid" }
 sqlx = { workspace = true }
 tokio = { workspace = true }
-tracing = { workspace = true }

--- a/rust/cloud-storage/cal/Cargo.toml
+++ b/rust/cloud-storage/cal/Cargo.toml
@@ -22,4 +22,3 @@ serde_json = { workspace = true }
 sha2 = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
-utoipa = { workspace = true, optional = true }

--- a/rust/cloud-storage/chat/Cargo.toml
+++ b/rust/cloud-storage/chat/Cargo.toml
@@ -36,7 +36,6 @@ macro_user_id = { path = "../macro_user_id" }
 model = { path = "../model" }
 non_empty = { path = "../non_empty" }
 model-entity = { path = "../model-entity" }
-models_entity_access_management = { path = "../models_entity_access_management", default-features = false }
 models_permissions = { path = "../models_permissions" }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/rust/cloud-storage/comms_db_client/Cargo.toml
+++ b/rust/cloud-storage/comms_db_client/Cargo.toml
@@ -17,7 +17,6 @@ models_comms = { path = "../models_comms" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sqlx = { workspace = true }
-strum = { workspace = true }
 tracing = { workspace = true }
 utoipa = { workspace = true, features = ["axum_extras", "chrono", "uuid"] }
 uuid = { workspace = true }

--- a/rust/cloud-storage/comms_service/Cargo.toml
+++ b/rust/cloud-storage/comms_service/Cargo.toml
@@ -26,8 +26,6 @@ service = ["comms_db_client"]
 [dependencies]
 ai_format = { path = "../ai_format" }
 anyhow = { workspace = true }
-async-trait = { workspace = true }
-aws-sdk-secretsmanager = { workspace = true }
 aws-sdk-sqs = { workspace = true }
 axum = { workspace = true, features = ["tower-log", "ws"] }
 axum-extra = { workspace = true }
@@ -41,13 +39,9 @@ entity_access = { path = "../entity_access" }
 entity_access_db_utils = { path = "../entity_access_db_utils" }
 frecency = { path = "../frecency", features = ["postgres"] }
 futures = { workspace = true }
-http-body-util = { workspace = true }
 jsonwebtoken.workspace = true
-last_online_tracker = { path = "../last_online_tracker" }
 macro_auth = { path = "../macro_auth" }
 macro_aws_config = { path = "../macro_aws_config" }
-macro_axum_utils = { path = "../macro_axum_utils" }
-macro_cors = { path = "../macro_cors" }
 macro_db_client = { path = "../macro_db_client" }
 macro_entrypoint = { path = "../macro_entrypoint" }
 macro_env = { path = "../macro_env" }
@@ -62,7 +56,6 @@ model = { path = "../model" }
 model-entity = { path = "../model-entity" }
 model_notifications = { path = "../model_notifications" }
 models_comms = { path = "../models_comms" }
-models_opensearch = { path = "../models_opensearch" }
 models_permissions = { path = "../models_permissions" }
 notification_hex = { path = "../notification", package = "notification" }
 reqwest.workspace = true
@@ -74,10 +67,7 @@ sqs_client = { path = "../sqs_client", default-features = false, features = [
   "contacts",
   "search",
 ] }
-thiserror = { workspace = true }
 tokio = { workspace = true }
-tower = { workspace = true }
-tower-http = { workspace = true }
 tracing = { workspace = true }
 utoipa = { workspace = true, features = ["axum_extras", "chrono", "uuid"] }
 utoipa-swagger-ui = { workspace = true, features = ["axum"] }

--- a/rust/cloud-storage/comms_service_client/Cargo.toml
+++ b/rust/cloud-storage/comms_service_client/Cargo.toml
@@ -12,7 +12,6 @@ model = { path = "../model" }
 models_comms = { path = "../models_comms" }
 reqwest.workspace = true
 serde = { workspace = true }
-serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 urlencoding = { workspace = true }

--- a/rust/cloud-storage/connection/Cargo.toml
+++ b/rust/cloud-storage/connection/Cargo.toml
@@ -12,14 +12,12 @@ ports = ["entity_access/ports"]
 [dependencies]
 # Core
 anyhow = { workspace = true }
-chrono = { workspace = true }
 entity_access = { path = "../entity_access", default-features = false }
 macro_user_id = { path = "../macro_user_id" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
-uuid = { workspace = true }
 
 # Outbound
 connection_gateway_client = { path = "../connection_gateway_client", optional = true }

--- a/rust/cloud-storage/connection_gateway/Cargo.toml
+++ b/rust/cloud-storage/connection_gateway/Cargo.toml
@@ -48,7 +48,6 @@ macro_entrypoint = { path = "../macro_entrypoint" }
 macro_env = { path = "../macro_env" }
 macro_env_var = { path = "../macro_env_var" }
 macro_middleware = { path = "../macro_middleware", features = ["auth"] }
-mockall.workspace = true
 model = { path = "../model" }
 model-entity = { path = "../model-entity" }
 models_bulk_upload = { path = "../models_bulk_upload" }
@@ -63,14 +62,12 @@ serde_dynamo = { workspace = true }
 serde_json = { workspace = true }
 sqlx = { workspace = true }
 strum = { workspace = true, features = ["derive"] }
-strum_macros = { workspace = true }
 stream = { path = "../stream" }
 tokio = { workspace = true }
 tower = { workspace = true }
 tower-http = { workspace = true }
 tracing = { workspace = true, features = ["attributes"] }
 tungstenite = "0.28"
-url = { workspace = true }
 utoipa = { workspace = true, features = ["axum_extras"] }
 utoipa-swagger-ui = { workspace = true, features = ["axum"] }
 uuid = { workspace = true }

--- a/rust/cloud-storage/contacts_db_client/Cargo.toml
+++ b/rust/cloud-storage/contacts_db_client/Cargo.toml
@@ -8,7 +8,6 @@ version = "0.1.0"
 anyhow = { workspace = true }
 serde = { workspace = true }
 sqlx = { workspace = true }
-tracing = { workspace = true }
 
 [dev-dependencies]
 macro_db_migrator = { path = "../macro_db_migrator" }

--- a/rust/cloud-storage/contacts_service/Cargo.toml
+++ b/rust/cloud-storage/contacts_service/Cargo.toml
@@ -15,7 +15,6 @@ path = "src/openapi.rs"
 
 [dependencies]
 anyhow = { workspace = true }
-async-trait = { workspace = true }
 aws-sdk-secretsmanager = { workspace = true }
 aws-sdk-sqs = { workspace = true }
 axum = { workspace = true }

--- a/rust/cloud-storage/convert_service/Cargo.toml
+++ b/rust/cloud-storage/convert_service/Cargo.toml
@@ -12,7 +12,6 @@ local_queue = []
 [dependencies]
 anyhow = { workspace = true }
 aws-sdk-lambda = { workspace = true }
-aws-sdk-s3 = { workspace = true }
 aws-sdk-secretsmanager = { workspace = true }
 aws-sdk-sqs = { workspace = true }
 axum = { workspace = true }

--- a/rust/cloud-storage/dataloss_prevention_handler/Cargo.toml
+++ b/rust/cloud-storage/dataloss_prevention_handler/Cargo.toml
@@ -7,7 +7,6 @@ version = "0.1.0"
 
 [dependencies]
 anyhow = { workspace = true }
-aws-sdk-s3 = { workspace = true }
 macro_aws_config = { path = "../macro_aws_config", features = ["s3"] }
 aws-sdk-sns = { workspace = true }
 aws_lambda_events = { workspace = true, features = ["s3"] }

--- a/rust/cloud-storage/deleted_item_poller/Cargo.toml
+++ b/rust/cloud-storage/deleted_item_poller/Cargo.toml
@@ -8,19 +8,13 @@ version = "0.1.0"
 anyhow = { workspace = true }
 aws-sdk-sqs = { workspace = true }
 macro_aws_config = { path = "../macro_aws_config" }
-aws-smithy-types = { workspace = true }
 aws_lambda_events = { workspace = true, features = ["eventbridge"] }
 chrono = { workspace = true }
-futures = { workspace = true }
 lambda_runtime = { workspace = true }
 macro_db_client = { path = "../macro_db_client" }
 macro_entrypoint = { path = "../macro_entrypoint" }
 macro_env = { path = "../macro_env" }
-macro_uuid = { path = "../macro_uuid" }
-model = { path = "../model" }
 openssl = { workspace = true }
-serde = { workspace = true }
-serde_json = { workspace = true }
 sqlx = { workspace = true }
 sqs_client = { path = "../sqs_client", default-features = false, features = [
   "chat",
@@ -29,7 +23,6 @@ sqs_client = { path = "../sqs_client", default-features = false, features = [
 ] }
 tokio = { workspace = true }
 tracing = { workspace = true }
-urlencoding = { workspace = true }
 
 [package.metadata.cargo-machete]
 ignored = ["openssl"]

--- a/rust/cloud-storage/document_cognition_service/Cargo.toml
+++ b/rust/cloud-storage/document_cognition_service/Cargo.toml
@@ -28,13 +28,10 @@ local_queue = []
 
 
 [dependencies]
-aho-corasick = "1.1.3"
 ai = { path = "../ai" }
 ai_format = { path = "../ai_format" }
 ai_tools = { path = "../ai_tools" }
-ai_toolset = { path = "../ai_toolset" }
 anyhow = { workspace = true }
-async-openai = { workspace = true }
 async-stream = { workspace = true }
 async-trait = { workspace = true }
 aws-sdk-dynamodb = { workspace = true }
@@ -48,7 +45,6 @@ chrono = { workspace = true }
 comms = { path = "../comms", features = ["outbound"] }
 comms_service_client = { path = "../comms_service_client" }
 connection_gateway = { path = "../connection_gateway" }
-cookie = { workspace = true }
 document_cognition_service_client = { path = "../document_cognition_service_client" }
 document_storage_service_client = { path = "../document_storage_service_client" }
 documents = { path = "../documents", features = ["ai_tools"] }
@@ -61,8 +57,6 @@ frecency = { path = "../frecency", features = ["outbound", "postgres"] }
 futures = { workspace = true }
 http = { workspace = true }
 http-body-util = { workspace = true }
-last_online_tracker = { path = "../last_online_tracker" }
-lazy_static = { workspace = true }
 lexical_client = { path = "../lexical_client" }
 log = { workspace = true }
 macro_auth = { path = "../macro_auth" }
@@ -77,15 +71,12 @@ macro_middleware = { path = "../macro_middleware", default-features = false, fea
   "cloud_storage",
   "user_permissions",
 ] }
-macro_project_utils = { path = "../macro_project_utils" }
 macro_user_id = { path = "../macro_user_id" }
-macro_uuid = { path = "../macro_uuid" }
 memory = { path = "../memory" }
 model = { path = "../model" }
 model-entity = { path = "../model-entity" }
 model_notifications = { path = "../model_notifications" }
 models_dcs = { path = "../models_dcs" }
-models_opensearch = { path = "../models_opensearch" }
 models_permissions = { path = "../models_permissions" }
 notification = { path = "../notification" }
 properties = { path = "../properties", features = ["ai_tools"] }
@@ -96,10 +87,7 @@ redis = { workspace = true, features = [
   "tokio-comp",
   "tokio-native-tls-comp",
 ] }
-regex = { workspace = true }
 reqwest.workspace = true
-roles_and_permissions = { path = "../roles_and_permissions", default-features = false }
-schemars = { workspace = true }
 scribe = { path = "../scribe", features = [
   "channel",
   "dcs",
@@ -125,14 +113,12 @@ stream = { path = "../stream" }
 strum = { workspace = true }
 sync_service_client = { path = "../sync_service_client" }
 thiserror = { workspace = true }
-time = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
 tower = { workspace = true, features = ["util"] }
 tower-http = { workspace = true, features = ["limit", "timeout"] }
 tracing = { workspace = true }
 unfurl_service = { path = "../unfurl_service" }
-url = { workspace = true }
 utoipa = { workspace = true, features = ["axum_extras", "chrono"] }
 utoipa-swagger-ui = { workspace = true, features = ["axum"] }
 uuid = { workspace = true }

--- a/rust/cloud-storage/document_cognition_service_client/Cargo.toml
+++ b/rust/cloud-storage/document_cognition_service_client/Cargo.toml
@@ -6,7 +6,6 @@ version = "0.1.0"
 
 [dependencies]
 anyhow = { workspace = true }
-chrono = { workspace = true }
 model = { path = "../model" }
 models_dcs = { path = "../models_dcs" }
 reqwest = { workspace = true }

--- a/rust/cloud-storage/document_storage_service/Cargo.toml
+++ b/rust/cloud-storage/document_storage_service/Cargo.toml
@@ -31,12 +31,7 @@ aws-sdk-s3 = { workspace = true }
 aws-sdk-secretsmanager = { workspace = true }
 aws-sdk-sqs = { workspace = true }
 axum = { workspace = true, features = ["macros", "multipart", "tower-log"] }
-axum-extra = { workspace = true }
 base64 = { workspace = true }
-bytes = { workspace = true }
-bzip2 = { workspace = true, default-features = false, features = [
-  "libbz2-rs-sys",
-] }
 analytics_client = { path = "../analytics_client" }
 cal = { path = "../cal", features = ["axum", "outbound"] }
 call = { path = "../call" }
@@ -51,7 +46,6 @@ connection = { path = "../connection", default-features = false, features = [
   "outbound",
 ] }
 connection_gateway_client = { path = "../connection_gateway_client" }
-cowlike = { path = "../cowlike" }
 document_sub_type = { path = "../document_sub_type" }
 documents_hex = { path = "../documents", package = "documents" }
 dynamodb_client = { path = "../dynamodb_client" }
@@ -69,8 +63,6 @@ github = { path = "../github", default-features = false, features = [
 hex = { workspace = true }
 http-body-util = { workspace = true }
 jsonwebtoken = { workspace = true }
-last_online_tracker = { path = "../last_online_tracker" }
-lazy_static = { workspace = true }
 macro_auth = { path = "../macro_auth" }
 macro_aws_config = { path = "../macro_aws_config", features = ["s3"] }
 macro_axum_utils = { path = "../macro_axum_utils" }
@@ -94,8 +86,6 @@ model-entity = { path = "../model-entity" }
 model_notifications = { path = "../model_notifications" }
 model_user = { path = "../model_user", features = ["axum"] }
 models_bulk_upload = { path = "../models_bulk_upload" }
-models_opensearch = { path = "../models_opensearch" }
-models_pagination = { path = "../models_pagination", features = ["axum"] }
 models_permissions = { path = "../models_permissions" }
 models_properties = { path = "../models_properties" }
 models_soup = { path = "../models_soup", features = ["schema"] }
@@ -111,7 +101,6 @@ redis = { workspace = true, features = [
   "cluster-async",
   "tokio-native-tls-comp",
 ] }
-regex = { workspace = true }
 reqwest = { workspace = true }
 s3_key = { path = "../s3_key" }
 saved_views = { path = "../saved_views" }
@@ -143,9 +132,7 @@ uuid = { workspace = true }
 zip = { workspace = true }
 
 [dev-dependencies]
-cool_asserts = "2"
 frecency = { path = "../frecency", features = ["mock"] }
-ordered-float = { workspace = true }
 
 [package.metadata.cargo-machete]
 ignored = ["connection_gateway_client"]

--- a/rust/cloud-storage/document_sub_type/Cargo.toml
+++ b/rust/cloud-storage/document_sub_type/Cargo.toml
@@ -8,6 +8,5 @@ version = "0.1.0"
 serde = { workspace = true }
 sqlx = { workspace = true }
 strum = { workspace = true }
-thiserror = { workspace = true }
 utoipa = { workspace = true }
 schemars = {workspace = true}

--- a/rust/cloud-storage/document_text_extractor/Cargo.toml
+++ b/rust/cloud-storage/document_text_extractor/Cargo.toml
@@ -19,7 +19,6 @@ aws_lambda_events = { workspace = true, features = [
   "s3",
   "sqs",
 ] }
-chrono = { workspace = true }
 lambda_runtime = { workspace = true }
 macro_entrypoint = { path = "../macro_entrypoint" }
 macro_env_var = { path = "../macro_env_var" }
@@ -33,7 +32,6 @@ serde_json = { workspace = true }
 sqlx = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
-urlencoding = { workspace = true }
 uuid = { workspace = true }
 
 [package.metadata.cargo-machete]

--- a/rust/cloud-storage/documents/Cargo.toml
+++ b/rust/cloud-storage/documents/Cargo.toml
@@ -79,7 +79,6 @@ tokio = { workspace = true, optional = true }
 
 # Axum dependencies (for inbound)
 axum = { workspace = true, optional = true }
-axum-extra = { workspace = true, optional = true }
 model-error-response = { path = "../model-error-response", optional = true }
 model_user = { path = "../model_user", optional = true, features = ["axum"] }
 utoipa = { workspace = true, optional = true }
@@ -110,9 +109,7 @@ non_empty = { path = "../non_empty" }
 
 [dev-dependencies]
 dotenvy = { workspace = true }
-http-body-util = { workspace = true }
 macro_db_migrator = { path = "../macro_db_migrator" }
 mockall = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
-tower = { workspace = true }

--- a/rust/cloud-storage/docx_unzip_handler/Cargo.toml
+++ b/rust/cloud-storage/docx_unzip_handler/Cargo.toml
@@ -9,19 +9,13 @@ version = "0.1.0"
 anyhow = { workspace = true }
 aws-sdk-lambda = { workspace = true }
 macro_aws_config = { path = "../macro_aws_config", features = ["s3"] }
-aws-sdk-s3 = { workspace = true }
 aws-sdk-sqs = { workspace = true }
-aws-smithy-types = { workspace = true }
 aws_lambda_events = { workspace = true, features = ["s3"] }
-bzip2 = { workspace = true, default-features = false, features = [
-  "libbz2-rs-sys",
-] }
 futures = { workspace = true }
 lambda_client = { path = "../lambda_client" }
 lambda_runtime = { workspace = true }
 macro_db_client = { path = "../macro_db_client" }
 macro_entrypoint = { path = "../macro_entrypoint" }
-macro_env = { path = "../macro_env" }
 macro_sha_count_client = { path = "../macro_sha_count_client" }
 macro_uuid = { path = "../macro_uuid" }
 model = { path = "../model" }
@@ -33,7 +27,6 @@ redis = { workspace = true, features = [
 ] }
 s3_client = { path = "../s3_client" }
 serde = { workspace = true }
-serde_json = { workspace = true }
 sha2 = { workspace = true }
 sqlx = { workspace = true }
 sqs_client = { path = "../sqs_client" }

--- a/rust/cloud-storage/dynamodb_client/Cargo.toml
+++ b/rust/cloud-storage/dynamodb_client/Cargo.toml
@@ -12,10 +12,7 @@ anyhow = { workspace = true }
 aws-sdk-dynamodb = { workspace = true }
 macro_aws_config = { path = "../macro_aws_config" }
 chrono = { workspace = true }
-model = { path = "../model" }
 models_bulk_upload = { path = "../models_bulk_upload" }
 s3_key = { path = "../s3_key" }
-strum = { workspace = true }
-thiserror = { workspace = true }
 tokio = { workspace = true, features = ["time"] }
 tracing = { workspace = true }

--- a/rust/cloud-storage/email/Cargo.toml
+++ b/rust/cloud-storage/email/Cargo.toml
@@ -54,7 +54,6 @@ either = { workspace = true }
 email_utils = { path = "../email_utils" }
 filter_ast = { path = "../filter_ast" }
 frecency = { path = "../frecency" }
-gmail_client = { path = "../gmail_client", optional = true }
 item_filters = { path = "../item_filters" }
 macro_user_id = { path = "../macro_user_id" }
 macro_uuid = { path = "../macro_uuid" }

--- a/rust/cloud-storage/email_db_client/Cargo.toml
+++ b/rust/cloud-storage/email_db_client/Cargo.toml
@@ -13,9 +13,6 @@ futures = { workspace = true }
 macro_user_id = { path = "../macro_user_id" }
 macro_uuid = { path = "../macro_uuid" }
 models_email = { path = "../models_email" }
-models_pagination = { path = "../models_pagination" }
-once_cell = { workspace = true }
-regex = { workspace = true }
 serde_json = { workspace = true }
 sqlx = { workspace = true }
 tokio = { workspace = true }

--- a/rust/cloud-storage/email_refresh_handler/Cargo.toml
+++ b/rust/cloud-storage/email_refresh_handler/Cargo.toml
@@ -13,7 +13,6 @@ chrono = { workspace = true }
 lambda_runtime = { workspace = true }
 macro_entrypoint = { path = "../macro_entrypoint" }
 macro_env = { path = "../macro_env" }
-model = { path = "../model" }
 models_email = { path = "../models_email" }
 sqlx = { workspace = true }
 sqs_client = { path = "../sqs_client" }

--- a/rust/cloud-storage/email_scheduled_handler/Cargo.toml
+++ b/rust/cloud-storage/email_scheduled_handler/Cargo.toml
@@ -9,7 +9,6 @@ anyhow = { workspace = true }
 aws-sdk-sqs = { workspace = true }
 macro_aws_config = { path = "../macro_aws_config" }
 aws_lambda_events = { workspace = true, features = ["eventbridge"] }
-chrono = { workspace = true }
 lambda_runtime = { workspace = true }
 macro_entrypoint = { path = "../macro_entrypoint" }
 macro_env = { path = "../macro_env" }

--- a/rust/cloud-storage/email_service/Cargo.toml
+++ b/rust/cloud-storage/email_service/Cargo.toml
@@ -69,11 +69,9 @@ sfs_delete = []
 
 [dependencies]
 ammonia = "4.1.0"
-openssl = { workspace = true }
 anyhow = { workspace = true }
 authentication_service_client = { path = "../authentication_service_client" }
 macro_aws_config = { path = "../macro_aws_config", features = ["s3", "sqs"] }
-aws-sdk-s3 = { workspace = true }
 aws-sdk-secretsmanager = { workspace = true }
 aws-sdk-sqs = { workspace = true }
 axum = { workspace = true }
@@ -84,7 +82,6 @@ chrono = { workspace = true }
 cloudfront_sign = { workspace = true }
 connection_gateway_client = { path = "../connection_gateway_client" }
 document_storage_service_client = { path = "../document_storage_service_client" }
-doppleganger = { workspace = true }
 ego-tree = { workspace = true }
 email = { path = "../email", features = ["axum", "gmail_token", "inbound", "outbound"] }
 entity_access = { path = "../entity_access", default-features = false, features = ["outbound"] }
@@ -106,7 +103,6 @@ macro_env_var = { path = "../macro_env_var" }
 macro_middleware = { path = "../macro_middleware", default-features = false, features = [
   "auth", "cloud_storage"
 ] }
-last_online_tracker = { path = "../last_online_tracker" }
 notification = { path = "../notification" }
 macro_user_id = { path = "../macro_user_id" }
 macro_uuid = { path = "../macro_uuid" }
@@ -116,9 +112,6 @@ model-entity = { path = "../model-entity" }
 model_file_type = { path = "../model_file_type" }
 model_notifications = { path = "../model_notifications" }
 models_email = { path = "../models_email" }
-models_opensearch = { path = "../models_opensearch" }
-models_pagination = { path = "../models_pagination", features = ["axum"] }
-models_permissions = { path = "../models_permissions" }
 once_cell = { workspace = true }
 models_properties = { path = "../models_properties" }
 redis = { workspace = true, features = [
@@ -128,7 +121,6 @@ redis = { workspace = true, features = [
 regex = { workspace = true }
 reqwest = { workspace = true, features = ["stream"] }
 s3_client = { path = "../s3_client" }
-schemars = { workspace = true }
 scraper = { workspace = true }
 secretsmanager_client = { path = "../secretsmanager_client" }
 serde = { workspace = true }

--- a/rust/cloud-storage/email_service_client/Cargo.toml
+++ b/rust/cloud-storage/email_service_client/Cargo.toml
@@ -7,10 +7,6 @@ version = "0.1.0"
 [dependencies]
 anyhow = { workspace = true }
 email = { path = "../email", features = ["axum", "inbound"] }
-model = { path = "../model" }
 models_email = { path = "../models_email" }
 reqwest = { workspace = true }
-serde = { workspace = true }
-serde_json = { workspace = true }
-tokio = { workspace = true }
 tracing = { workspace = true }

--- a/rust/cloud-storage/email_suppression_handler/Cargo.toml
+++ b/rust/cloud-storage/email_suppression_handler/Cargo.toml
@@ -7,7 +7,6 @@ version = "0.1.0"
 [dependencies]
 anyhow = { workspace = true }
 aws_lambda_events = { workspace = true, features = ["sns"] }
-chrono = { workspace = true }
 lambda_runtime = { workspace = true }
 macro_db_client = { path = "../macro_db_client" }
 macro_entrypoint = { path = "../macro_entrypoint" }

--- a/rust/cloud-storage/entity_access/Cargo.toml
+++ b/rust/cloud-storage/entity_access/Cargo.toml
@@ -37,7 +37,6 @@ tokio = { workspace = true, optional = true }
 
 # Axum dependencies (for inbound)
 axum = { workspace = true, optional = true }
-axum-extra = { workspace = true, optional = true }
 model = { path = "../model", optional = true }
 model-error-response = { path = "../model-error-response", optional = true }
 model_user = { path = "../model_user", optional = true, features = ["axum"] }
@@ -50,8 +49,6 @@ cached = { workspace = true, optional = true }
 sqlx = { workspace = true }
 
 [dev-dependencies]
-cool_asserts = "2"
 macro_db_migrator = { path = "../macro_db_migrator" }
-mockall = { workspace = true }
 sqlx = { workspace = true, features = ["postgres", "runtime-tokio-rustls"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/rust/cloud-storage/entity_access_db_utils/Cargo.toml
+++ b/rust/cloud-storage/entity_access_db_utils/Cargo.toml
@@ -8,7 +8,6 @@ version = "0.1.0"
 # Core
 anyhow = { workspace = true }
 macro_uuid = { path = "../macro_uuid" }
-serde = { workspace = true }
 sqlx = { workspace = true }
 tracing = { workspace = true }
 
@@ -21,4 +20,3 @@ models_permissions = { path = "../models_permissions" }
 
 [dev-dependencies]
 macro_db_migrator = { path = "../macro_db_migrator" }
-tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/rust/cloud-storage/entity_access_management/Cargo.toml
+++ b/rust/cloud-storage/entity_access_management/Cargo.toml
@@ -17,14 +17,9 @@ ports = []
 [dependencies]
 # Core
 anyhow = { workspace = true }
-serde = { workspace = true }
-serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
-
-# Domain models (always included)
-macro_user_id = { path = "../macro_user_id" }
 model-entity = { path = "../model-entity" }
 models_entity_access_management = { path = "../models_entity_access_management", default-features = false }
 models_permissions = { path = "../models_permissions" }
@@ -34,8 +29,5 @@ entity_access_db_utils = { path = "../entity_access_db_utils", optional = true }
 sqlx = { workspace = true, optional = true }
 
 [dev-dependencies]
-cool_asserts = "2"
 macro_db_migrator = { path = "../macro_db_migrator" }
-mockall = { workspace = true }
 sqlx = { workspace = true, features = ["postgres", "runtime-tokio-rustls"] }
-tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/rust/cloud-storage/frecency/Cargo.toml
+++ b/rust/cloud-storage/frecency/Cargo.toml
@@ -18,7 +18,6 @@ chrono = { workspace = true, features = ["serde"] }
 cowlike = { path = "../cowlike" }
 filter_ast = { path = "../filter_ast" }
 item_filters = { path = "../item_filters" }
-macro_env_var = { path = "../macro_env_var", optional = true }
 macro_user_id = { path = "../macro_user_id" }
 mockall = { workspace = true, optional = true }
 model-entity = { path = "../model-entity" }
@@ -31,13 +30,11 @@ sqlx = { workspace = true, optional = true }
 strum = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
 tokio = { workspace = true, optional = true, features = ["sync", "time"] }
-tower = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true }
 
 [dev-dependencies]
 cool_asserts = "2"
 item_filters = { path = "../item_filters", features = ["mock"] }
 macro_db_migrator = { path = "../macro_db_migrator" }
-rand = { workspace = true }
 serde_json = { workspace = true }
 uuid = { workspace = true }

--- a/rust/cloud-storage/fusionauth/Cargo.toml
+++ b/rust/cloud-storage/fusionauth/Cargo.toml
@@ -17,4 +17,3 @@ tracing = { workspace = true }
 urlencoding = { workspace = true }
 
 [dev-dependencies]
-tokio = { workspace = true }

--- a/rust/cloud-storage/github/Cargo.toml
+++ b/rust/cloud-storage/github/Cargo.toml
@@ -54,7 +54,6 @@ redis = { workspace = true, features = ["aio", "tokio-comp"], optional = true }
 tokio = { workspace = true, features = ["sync"], optional = true }
 
 axum = { workspace = true, optional = true }
-axum-extra = { workspace = true, optional = true }
 model-error-response = { path = "../model-error-response", optional = true }
 utoipa = { workspace = true, optional = true }
 

--- a/rust/cloud-storage/gmail_client/Cargo.toml
+++ b/rust/cloud-storage/gmail_client/Cargo.toml
@@ -11,7 +11,6 @@ gmail_test = []
 anyhow = { workspace = true }
 base64 = { workspace = true }
 chrono = { workspace = true }
-futures = { workspace = true }
 jsonwebtoken = { workspace = true }
 mail-builder = "0.4.3"
 mockall = { workspace = true }

--- a/rust/cloud-storage/integration_tests/test_build_full_pdf_modification_data/Cargo.toml
+++ b/rust/cloud-storage/integration_tests/test_build_full_pdf_modification_data/Cargo.toml
@@ -8,12 +8,8 @@ version = "0.1.0"
 name = "main"
 
 [dependencies]
-anyhow = { workspace = true }
-chrono = { workspace = true }
 macro_db_client = { path = "../../macro_db_client" }
 macro_entrypoint = { path = "../../macro_entrypoint" }
-model = { path = "../../model" }
-serde = { workspace = true }
 serde_json = { workspace = true }
 sqlx = { workspace = true }
 tokio = { workspace = true }

--- a/rust/cloud-storage/integration_tests/test_pdf_modification_data_deserialize/Cargo.toml
+++ b/rust/cloud-storage/integration_tests/test_pdf_modification_data_deserialize/Cargo.toml
@@ -12,9 +12,7 @@ name = "test_highlight_deserialization"
 
 [dependencies]
 anyhow = { workspace = true }
-chrono = { workspace = true }
 model = { path = "../../model" }
-serde = { workspace = true }
 serde_json = { workspace = true }
 sqlx = { workspace = true }
 tokio = { workspace = true }

--- a/rust/cloud-storage/item_filters/Cargo.toml
+++ b/rust/cloud-storage/item_filters/Cargo.toml
@@ -9,7 +9,6 @@ mock = []
 schema = ["dep:schemars", "dep:utoipa"]
 
 [dependencies]
-chrono = { workspace = true }
 document_sub_type = { path = "../document_sub_type" }
 either = { workspace = true }
 filter_ast = { path = "../filter_ast" }

--- a/rust/cloud-storage/lexical_client/Cargo.toml
+++ b/rust/cloud-storage/lexical_client/Cargo.toml
@@ -13,4 +13,3 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }
-tokio = { workspace = true }

--- a/rust/cloud-storage/macro_auth/Cargo.toml
+++ b/rust/cloud-storage/macro_auth/Cargo.toml
@@ -17,11 +17,8 @@ jsonwebtoken = { workspace = true }
 macro_env = { path = "../macro_env" }
 macro_env_var = { path = "../macro_env_var" }
 macro_user_id = { path = "../macro_user_id" }
-rand = { workspace = true }
 remote_env_var = { path = "../remote_env_var" }
 serde = { workspace = true }
-serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["macros"] }
 tracing = { workspace = true }
-urlencoding = { workspace = true }

--- a/rust/cloud-storage/macro_aws_config/Cargo.toml
+++ b/rust/cloud-storage/macro_aws_config/Cargo.toml
@@ -10,10 +10,7 @@ sqs = ["dep:aws-sdk-sqs"]
 
 [dependencies]
 aws-config = { workspace = true }
-macro_env = { path = "../macro_env" }
 macro_env_var = { path = "../macro_env_var" }
-thiserror = { workspace = true }
-tracing = { workspace = true }
 url = { workspace = true }
 aws-sdk-s3 = { workspace = true, optional = true }
 aws-sdk-sqs = { workspace = true, optional = true }

--- a/rust/cloud-storage/macro_db_client/Cargo.toml
+++ b/rust/cloud-storage/macro_db_client/Cargo.toml
@@ -13,7 +13,6 @@ team = ["dep:models_team"]
 ai = { path = "../ai" }
 anyhow = { workspace = true }
 async-recursion = "1.1.1"
-async-trait = { workspace = true }
 cached = { workspace = true }
 chrono = { workspace = true }
 document_sub_type = { path = "../document_sub_type" }
@@ -21,18 +20,11 @@ entity_access_db_utils = { path = "../entity_access_db_utils" }
 futures = { workspace = true }
 macro_user_id = { path = "../macro_user_id" }
 macro_uuid = { path = "../macro_uuid" }
-mockall = { workspace = true }
 model = { path = "../model" }
 model-entity = { path = "../model-entity" }
-model_file_type = { path = "../model_file_type" }
 models_dcs = { path = "../models_dcs" }
-models_entity_access_management = { path = "../models_entity_access_management", features = [
-  "db",
-] }
 models_opensearch = { path = "../models_opensearch" }
-models_pagination = { path = "../models_pagination" }
 models_permissions = { path = "../models_permissions" }
-models_search = { path = "../models_search" }
 models_team = { path = "../models_team", optional = true }
 non_empty = { path = "../non_empty" }
 rand = { workspace = true, optional = true }
@@ -41,7 +33,6 @@ serde_json = { workspace = true }
 sqlx = { workspace = true }
 system_properties = { path = "../system_properties" }
 thiserror = { workspace = true }
-tokio = { workspace = true }
 tracing = { workspace = true }
 user_quota = { path = "../user_quota" }
 uuid = { workspace = true }

--- a/rust/cloud-storage/macro_middleware/Cargo.toml
+++ b/rust/cloud-storage/macro_middleware/Cargo.toml
@@ -23,34 +23,24 @@ user_permissions = ["dep:macro_user_id", "dep:user_quota", "macro_db_client"]
 [dependencies]
 anyhow = { workspace = true }
 axum = { workspace = true, features = ["macros"] }
-axum-extra = { workspace = true }
 decode_jwt = { path = "../decode_jwt", optional = true }
 entity_access_db_utils = { path = "../entity_access_db_utils", optional = true }
-http-body-util = { workspace = true }
 ip_extractor = { path = "../ip_extractor", optional = true }
 macro_auth = { path = "../macro_auth", optional = true }
 macro_db_client = { path = "../macro_db_client", optional = true }
-macro_env = { path = "../macro_env" }
 macro_env_var = { path = "../macro_env_var" }
 macro_user_id = { path = "../macro_user_id", optional = true }
 macro_uuid = { path = "../macro_uuid" }
 model = { path = "../model" }
 model-entity = { path = "../model-entity" }
-model_user = { path = "../model_user", features = ["axum"], optional = true }
 models_permissions = { path = "../models_permissions" }
-permission = { path = "../permission", optional = true }
 remote_env_var = { path = "../remote_env_var" }
 serde = { workspace = true }
-serde_json = { workspace = true }
 sqlx = { workspace = true, optional = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
-tower = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true, optional = true }
 user_quota = { path = "../user_quota", optional = true }
-uuid = { workspace = true }
 
 [dev-dependencies]
-serde_urlencoded = { workspace = true }
-urlencoding = { workspace = true }

--- a/rust/cloud-storage/macro_redis/Cargo.toml
+++ b/rust/cloud-storage/macro_redis/Cargo.toml
@@ -7,5 +7,3 @@ version = "0.1.0"
 [dependencies]
 anyhow = { workspace = true }
 redis = { workspace = true, features = ["tokio-native-tls-comp"] }
-tokio = { workspace = true }
-tracing = { workspace = true }

--- a/rust/cloud-storage/macro_user_id/Cargo.toml
+++ b/rust/cloud-storage/macro_user_id/Cargo.toml
@@ -13,5 +13,4 @@ doppleganger = { workspace = true }
 nom = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
-tracing = { workspace = true }
 utoipa = { workspace = true, optional = true }

--- a/rust/cloud-storage/mention_utils/Cargo.toml
+++ b/rust/cloud-storage/mention_utils/Cargo.toml
@@ -5,10 +5,8 @@ publish = false
 version = "0.1.0"
 
 [dependencies]
-anyhow = { workspace = true }
 macro_user_id = { path = "../macro_user_id" }
 nom = { workspace = true }
-regex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/rust/cloud-storage/model-entity/Cargo.toml
+++ b/rust/cloud-storage/model-entity/Cargo.toml
@@ -11,5 +11,3 @@ strum = { workspace = true, features = ["derive"] }
 utoipa = { workspace = true }
 
 [dev-dependencies]
-cool_asserts = "2"
-serde_json = { workspace = true }

--- a/rust/cloud-storage/model/Cargo.toml
+++ b/rust/cloud-storage/model/Cargo.toml
@@ -6,10 +6,8 @@ version = "0.1.0"
 
 [dependencies]
 ai = { path = "../ai" }
-ai_format = { path = "../ai_format" }
 anyhow = { workspace = true }
 axum = { workspace = true }
-base64 = { workspace = true }
 chrono = { workspace = true }
 document_sub_type = { path = "../document_sub_type" }
 doppleganger = { workspace = true, features = ["chrono", "uuid"] }
@@ -25,7 +23,6 @@ schemars = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true, features = ["raw_value"] }
 serde_repr = { workspace = true }
-serde_with = { workspace = true }
 sqlx = { workspace = true }
 strum = { workspace = true }
 thiserror.workspace = true

--- a/rust/cloud-storage/model_notifications/Cargo.toml
+++ b/rust/cloud-storage/model_notifications/Cargo.toml
@@ -5,14 +5,12 @@ publish = false
 version = "0.1.0"
 
 [dependencies]
-anyhow = { workspace = true }
 chrono = { workspace = true }
 doppleganger = { workspace = true }
 macro_user_id = { path = "../macro_user_id" }
 mention_utils = { path = "../mention_utils" }
 model-entity = { path = "../model-entity" }
 models_comms = { path = "../models_comms" }
-models_pagination = { path = "../models_pagination" }
 notification = { path = "../notification" }
 paste = { workspace = true }
 invite_email = { path = "../invite_email" }
@@ -21,6 +19,5 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 sqlx = { workspace = true }
 strum = { workspace = true, features = ["derive"] }
-tracing = { workspace = true }
 utoipa = { workspace = true, features = ["chrono"] }
 uuid = { workspace = true }

--- a/rust/cloud-storage/models_comms/Cargo.toml
+++ b/rust/cloud-storage/models_comms/Cargo.toml
@@ -5,12 +5,10 @@ publish = false
 version = "0.1.0"
 
 [dependencies]
-anyhow = { workspace = true }
 chrono = { workspace = true }
 doppleganger = { workspace = true }
 frecency = { path = "../frecency" }
 macro_user_id = { path = "../macro_user_id" }
 serde = { workspace = true }
 strum = { workspace = true }
-thiserror = { workspace = true }
 uuid = { workspace = true }

--- a/rust/cloud-storage/models_dcs/Cargo.toml
+++ b/rust/cloud-storage/models_dcs/Cargo.toml
@@ -5,12 +5,5 @@ publish = false
 version = "0.1.0"
 
 [dependencies]
-ai = { path = "../ai" }
-chrono = { workspace = true }
-model = { path = "../model" }
-models_permissions = { path = "../models_permissions" }
 serde = { workspace = true }
-serde_json = { workspace = true }
-sqlx = { workspace = true }
-unfurl_service = { path = "../unfurl_service" }
 utoipa = { workspace = true }

--- a/rust/cloud-storage/models_entity_access_management/Cargo.toml
+++ b/rust/cloud-storage/models_entity_access_management/Cargo.toml
@@ -9,5 +9,4 @@ db = ["dep:sqlx"]
 default = ["db"]
 
 [dependencies]
-serde = { workspace = true }
 sqlx = { workspace = true, optional = true }

--- a/rust/cloud-storage/models_opensearch/Cargo.toml
+++ b/rust/cloud-storage/models_opensearch/Cargo.toml
@@ -6,5 +6,4 @@ version = "0.1.0"
 
 [dependencies]
 serde = { workspace = true }
-serde_json = { workspace = true }
 strum = { workspace = true }

--- a/rust/cloud-storage/models_permissions/Cargo.toml
+++ b/rust/cloud-storage/models_permissions/Cargo.toml
@@ -8,7 +8,6 @@ version = "0.1.0"
 model_file_type = { path = "../model_file_type" }
 schemars = { workspace = true }
 serde = { workspace = true }
-serde_json = { workspace = true }
 sqlx = { workspace = true }
 strum = { workspace = true }
 utoipa = { workspace = true }

--- a/rust/cloud-storage/models_properties/Cargo.toml
+++ b/rust/cloud-storage/models_properties/Cargo.toml
@@ -5,13 +5,10 @@ publish = false
 version = "0.1.0"
 
 [dependencies]
-anyhow = { workspace = true }
 chrono = { workspace = true }
 serde = { workspace = true }
-serde_json = { workspace = true }
 serde_with = { workspace = true }
 sqlx = { workspace = true }
-strum = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 utoipa = { workspace = true }

--- a/rust/cloud-storage/models_search/Cargo.toml
+++ b/rust/cloud-storage/models_search/Cargo.toml
@@ -8,7 +8,6 @@ version = "0.1.0"
 chrono = { workspace = true }
 item_filters = { path = "../item_filters", features = ["schema"] }
 model_file_type = { path = "../model_file_type" }
-models_opensearch = { path = "../models_opensearch" }
 opensearch_client = { path = "../opensearch_client" }
 schemars = { workspace = true }
 serde = { workspace = true }

--- a/rust/cloud-storage/models_soup/Cargo.toml
+++ b/rust/cloud-storage/models_soup/Cargo.toml
@@ -9,7 +9,6 @@ mock = []
 schema = ["dep:utoipa"]
 
 [dependencies]
-anyhow = { workspace = true }
 call = { path = "../call", default-features = false }
 chrono = { workspace = true }
 comms = { path = "../comms" }
@@ -21,6 +20,5 @@ model-entity = { path = "../model-entity" }
 models_pagination = { path = "../models_pagination" }
 models_properties = { path = "../models_properties/" }
 serde = { workspace = true }
-strum = { workspace = true }
 utoipa = { workspace = true, optional = true }
 uuid = { workspace = true }

--- a/rust/cloud-storage/models_team/Cargo.toml
+++ b/rust/cloud-storage/models_team/Cargo.toml
@@ -7,8 +7,6 @@ version = "0.1.0"
 [dependencies]
 chrono = { workspace = true }
 serde = { workspace = true }
-serde_json = { workspace = true }
 sqlx = { workspace = true }
 strum = { workspace = true }
 utoipa = { workspace = true }
-uuid = { workspace = true }

--- a/rust/cloud-storage/name_search/Cargo.toml
+++ b/rust/cloud-storage/name_search/Cargo.toml
@@ -11,7 +11,6 @@ chrono = { workspace = true }
 macro_user_id = { path = "../macro_user_id" }
 models_opensearch = { path = "../models_opensearch" }
 models_search_cursor = { path = "../models_search_cursor" }
-non_empty = { path = "../non_empty" }
 regex = { workspace = true }
 serde = { workspace = true }
 sqlx = { workspace = true }
@@ -21,4 +20,3 @@ uuid = { workspace = true }
 
 [dev-dependencies]
 macro_db_migrator = { path = "../macro_db_migrator" }
-tokio = { workspace = true }

--- a/rust/cloud-storage/notification/Cargo.toml
+++ b/rust/cloud-storage/notification/Cargo.toml
@@ -43,7 +43,6 @@ macro_user_id = { path = "../macro_user_id" }
 macro_uuid = { path = "../macro_uuid" }
 model-entity = { path = "../model-entity" }
 model-error-response = { path = "../model-error-response", optional = true }
-model_user = { path = "../model_user", optional = true, features = ["axum"] }
 models_pagination = { path = "../models_pagination" }
 rate_limit = { path = "../rate_limit" }
 redis = { workspace = true, features = [

--- a/rust/cloud-storage/notification_db_client/Cargo.toml
+++ b/rust/cloud-storage/notification_db_client/Cargo.toml
@@ -9,10 +9,7 @@ anyhow = { workspace = true }
 chrono = { workspace = true }
 macro_user_id = { path = "../macro_user_id" }
 macro_uuid = { path = "../macro_uuid" }
-model = { path = "../model" }
-model-entity = { path = "../model-entity" }
 model_notifications = { path = "../model_notifications" }
-models_pagination = { path = "../models_pagination" }
 serde = { workspace = true }
 sqlx = { workspace = true }
 tracing = { workspace = true }
@@ -20,4 +17,3 @@ uuid = { workspace = true }
 
 [dev-dependencies]
 macro_db_migrator = { path = "../macro_db_migrator" }
-serde_json = { workspace = true }

--- a/rust/cloud-storage/notification_sandbox/Cargo.toml
+++ b/rust/cloud-storage/notification_sandbox/Cargo.toml
@@ -7,8 +7,6 @@ version = "0.1.0"
 [dependencies]
 aws-sdk-sesv2 = { workspace = true }
 aws-sdk-sns = { workspace = true }
-chrono = { workspace = true }
-either = { workspace = true }
 email_formatting = { path = "../email_formatting" }
 hmac = { workspace = true }
 inquire = { workspace = true }
@@ -36,6 +34,5 @@ tokio = { workspace = true, features = [
   "signal",
   "sync",
 ] }
-tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["fmt"] }
 uuid = { workspace = true }

--- a/rust/cloud-storage/notification_service/Cargo.toml
+++ b/rust/cloud-storage/notification_service/Cargo.toml
@@ -28,7 +28,6 @@ axum = { workspace = true }
 chrono = { workspace = true }
 decode_jwt = { path = "../decode_jwt" }
 email_formatting = { path = "../email_formatting" }
-email_validator = { path = "../email_validator" }
 hmac = { workspace = true }
 http-body-util = { workspace = true }
 itertools = { workspace = true }
@@ -44,35 +43,25 @@ macro_middleware = { path = "../macro_middleware", default-features = false, fea
 ] }
 macro_tower_layers = { path = "../macro_tower_layers" }
 macro_user_id = { path = "../macro_user_id" }
-macro_uuid = { path = "../macro_uuid" }
-mention_utils = { path = "../mention_utils" }
 model = { path = "../model" }
 model-entity = { path = "../model-entity" }
 model-error-response = { path = "../model-error-response" }
-model_file_type = { path = "../model_file_type" }
 model_notifications = { path = "../model_notifications" }
-model_user = { path = "../model_user", features = ["axum"] }
-models_comms = { path = "../models_comms" }
 models_pagination = { path = "../models_pagination", features = ["axum"] }
 notification = { path = "../notification", features = ["axum"] }
 notification_db_client = { path = "../notification_db_client" }
-paste = { workspace = true }
 rate_limit = { path = "../rate_limit" }
 redis = { workspace = true }
-regex = { workspace = true }
 secretsmanager_client = { path = "../secretsmanager_client" }
 serde = { workspace = true }
 serde_json = { workspace = true }
-ses_client = { path = "../ses_client" }
 sha2 = { workspace = true }
 sns_client = { path = "../sns_client" }
 sqlx = { workspace = true }
-thiserror = { workspace = true }
 tokio = { workspace = true }
 tower = { workspace = true }
 tower-http = { workspace = true, features = ["compression-gzip"] }
 tracing = { workspace = true }
-url = { workspace = true }
 utoipa = { workspace = true, features = ["chrono"] }
 utoipa-swagger-ui = { workspace = true }
 uuid = { workspace = true }

--- a/rust/cloud-storage/opensearch_client/Cargo.toml
+++ b/rust/cloud-storage/opensearch_client/Cargo.toml
@@ -6,8 +6,6 @@ publish = false
 version = "0.1.0"
 
 [dev-dependencies]
-macro_entrypoint = { path = "../macro_entrypoint" }
-tokio = { workspace = true }
 uuid = { workspace = true }
 
 
@@ -20,8 +18,6 @@ opensearch = { version = "2.3.0" }
 opensearch_query_builder = { path = "../opensearch_query_builder", default-features = false }
 serde = { workspace = true }
 serde_json = { workspace = true }
-strum = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
-unicode-segmentation = { workspace = true }
 uuid = { workspace = true }

--- a/rust/cloud-storage/permission/Cargo.toml
+++ b/rust/cloud-storage/permission/Cargo.toml
@@ -5,6 +5,5 @@ publish = false
 version = "0.1.0"
 
 [dependencies]
-model = { path = "../model" }
 models_permissions = { path = "../models_permissions" }
 tracing = { workspace = true }

--- a/rust/cloud-storage/properties/Cargo.toml
+++ b/rust/cloud-storage/properties/Cargo.toml
@@ -22,7 +22,6 @@ entity_access_db_utils = { path = "../entity_access_db_utils" }
 futures = { workspace = true }
 email_db_client = { path = "../email_db_client" }
 macro_db_client = { path = "../macro_db_client" }
-macro_middleware = { path = "../macro_middleware", default-features = false, features = ["cloud_storage", "user_permissions"] }
 notification = { path = "../notification" }
 macro_user_id = { path = "../macro_user_id" }
 macro_uuid = { path = "../macro_uuid" }

--- a/rust/cloud-storage/properties_db_client/Cargo.toml
+++ b/rust/cloud-storage/properties_db_client/Cargo.toml
@@ -6,15 +6,11 @@ version = "0.1.0"
 
 [dependencies]
 anyhow = { workspace = true }
-cached = { workspace = true }
 chrono = { workspace = true }
-futures = { workspace = true }
 macro_uuid = { path = "../macro_uuid" }
 models_properties = { path = "../models_properties" }
-serde = { workspace = true }
 serde_json = { workspace = true }
 sqlx = { workspace = true }
-strum = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }

--- a/rust/cloud-storage/properties_service/Cargo.toml
+++ b/rust/cloud-storage/properties_service/Cargo.toml
@@ -14,27 +14,17 @@ path = "src/openapi.rs"
 
 [dependencies]
 anyhow = { workspace = true }
-async-trait = { workspace = true }
-aws-sdk-secretsmanager = { workspace = true }
-macro_aws_config = { path = "../macro_aws_config" }
 axum = { workspace = true, features = ["tower-log", "ws"] }
 chrono = { workspace = true }
 email_db_client = { path = "../email_db_client" }
 entity_access = { path = "../entity_access" }
-http-body-util = { workspace = true }
 macro_user_id = { path = "../macro_user_id" }
 model-entity = { path = "../model-entity" }
-macro_auth = { path = "../macro_auth" }
-macro_cors = { path = "../macro_cors" }
-macro_entrypoint = { path = "../macro_entrypoint" }
-macro_env = { path = "../macro_env" }
 macro_middleware = { path = "../macro_middleware", default-features = false, features = [
   "auth",
   "cloud_storage",
 ] }
-last_online_tracker = { path = "../last_online_tracker" }
 notification = { path = "../notification" }
-aws-sdk-sqs = { workspace = true }
 macro_uuid = { path = "../macro_uuid" }
 model = { path = "../model" }
 models_permissions = { path = "../models_permissions" }
@@ -42,17 +32,11 @@ models_properties = { path = "../models_properties" }
 properties_db_client = { path = "../properties_db_client" }
 properties = { path = "../properties" }
 system_properties = { path = "../system_properties" }
-secretsmanager_client = { path = "../secretsmanager_client" }
 serde = { workspace = true }
 serde_json = { workspace = true }
-serde_with = { workspace = true }
 sqlx = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
-tower = { workspace = true }
-tower-http = { workspace = true }
 tracing = { workspace = true }
-tracing-tree = { workspace = true }
 utoipa = { workspace = true }
-utoipa-swagger-ui = { workspace = true, features = ["axum"] }
 uuid = { workspace = true }

--- a/rust/cloud-storage/referral/Cargo.toml
+++ b/rust/cloud-storage/referral/Cargo.toml
@@ -22,7 +22,6 @@ ports = []
 [dependencies]
 # Core
 anyhow = { workspace = true }
-chrono = { workspace = true }
 rootcause = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -55,7 +54,6 @@ async-stripe = { workspace = true, default-features = false, features = [
 ], optional = true } # Outbound dependencies
 sqlx = { workspace = true, optional = true }
 url = { workspace = true }
-urlencoding = { workspace = true }
 
 [dev-dependencies]
 http-body-util = { workspace = true }

--- a/rust/cloud-storage/roles_and_permissions/Cargo.toml
+++ b/rust/cloud-storage/roles_and_permissions/Cargo.toml
@@ -11,7 +11,6 @@ ports = []
 
 [dependencies]
 anyhow = { workspace = true }
-async-trait = { workspace = true }
 macro_user_id = { path = "../macro_user_id" }
 non_empty = { path = "../non_empty" }
 sqlx = { workspace = true, optional = true }

--- a/rust/cloud-storage/rpc/axum_rpc_emit/Cargo.toml
+++ b/rust/cloud-storage/rpc/axum_rpc_emit/Cargo.toml
@@ -14,4 +14,3 @@ quote = { workspace = true }
 unsynn = { workspace = true }
 
 [dev-dependencies]
-cool_asserts = "2"

--- a/rust/cloud-storage/rpc/axum_rpc_parse/Cargo.toml
+++ b/rust/cloud-storage/rpc/axum_rpc_parse/Cargo.toml
@@ -5,7 +5,6 @@ publish = false
 version = "0.1.0"
 
 [dependencies]
-quote = { workspace = true }
 unsynn = { workspace = true }
 
 [dev-dependencies]

--- a/rust/cloud-storage/scribe/Cargo.toml
+++ b/rust/cloud-storage/scribe/Cargo.toml
@@ -29,28 +29,18 @@ static_file = ["models_sfs", "static_file_service_client"]
 [dependencies]
 # Core dependencies
 anyhow = { workspace = true }
-base64 = { workspace = true }
 bytes = { workspace = true }
 chrono = { workspace = true }
-derive_builder = { workspace = true }
-doppleganger = { workspace = true }
-futures = { workspace = true }
 reqwest = { workspace = true }
-serde = { workspace = true }
 serde_json = { workspace = true }
 sqlx = { workspace = true, optional = true }
-thiserror = { workspace = true }
-tokio = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
 
 # Internal dependencies
 ai = { path = "../ai" }
 ai_format = { path = "../ai_format" }
-macro_client_errors = { path = "../macro_client_errors" }
 model = { path = "../model" }
-models_dcs = { path = "../models_dcs" }
-s3_client = { path = "../s3_client" }
 
 # Service client dependencies
 document_storage_service_client = { path = "../document_storage_service_client", optional = true }

--- a/rust/cloud-storage/search_processing_service/Cargo.toml
+++ b/rust/cloud-storage/search_processing_service/Cargo.toml
@@ -27,7 +27,6 @@ required-features = ["processing", "service"]
 
 [dependencies]
 anyhow = { workspace = true }
-aws-sdk-s3 = { workspace = true }
 aws-sdk-secretsmanager = { workspace = true }
 aws-sdk-sqs = { workspace = true }
 axum = { workspace = true }
@@ -53,7 +52,6 @@ model = { path = "../model" }
 s3_key = { path = "../s3_key" }
 models_email = { path = "../models_email" }
 model_file_type = { path = "../model_file_type" }
-models_opensearch = { path = "../models_opensearch" }
 models_search = { path = "../models_search" }
 nom = { workspace = true }
 opensearch_client = { path = "../opensearch_client" }
@@ -68,7 +66,6 @@ sqs_client = { path = "../sqs_client", default-features = false, features = [
   "search",
 ] }
 sqs_worker = { path = "../sqs_worker" }
-strum = { workspace = true }
 tokio = { workspace = true }
 tower = { workspace = true }
 tower-http = { workspace = true }

--- a/rust/cloud-storage/search_service/Cargo.toml
+++ b/rust/cloud-storage/search_service/Cargo.toml
@@ -14,25 +14,18 @@ path = "src/openapi.rs"
 
 [dependencies]
 anyhow = { workspace = true }
-aws-sdk-secretsmanager = { workspace = true }
-macro_aws_config = { path = "../macro_aws_config" }
 axum = { workspace = true }
 chrono = { workspace = true }
 comms_db_client = { path = "../comms_db_client" }
 document_sub_type = { path = "../document_sub_type" }
 email_db_client = { path = "../email_db_client" }
-futures = { workspace = true }
-http-body-util = { workspace = true }
 indexmap = "2"
 item_filters = { path = "../item_filters" }
-macro_auth = { path = "../macro_auth" }
-macro_cors = { path = "../macro_cors" }
 macro_db_client = { path = "../macro_db_client" }
 models_properties = { path = "../models_properties" }
 models_soup = { path = "../models_soup" }
 properties_db_client = { path = "../properties_db_client" }
 readonly_pool = { path = "../readonly_pool" }
-macro_entrypoint = { path = "../macro_entrypoint" }
 macro_env = { path = "../macro_env" }
 macro_middleware = { path = "../macro_middleware", default-features = false, features = [
   "auth",
@@ -47,16 +40,10 @@ name_search = { path = "../name_search" }
 opensearch_client = { path = "../opensearch_client" }
 secretsmanager_client = { path = "../secretsmanager_client" }
 serde = { workspace = true }
-serde_json = { workspace = true }
 sqlx = { workspace = true }
-strum = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
-tower = { workspace = true }
-tower-http = { workspace = true }
 tracing = { workspace = true }
 utoipa = { workspace = true }
-utoipa-swagger-ui = { workspace = true }
 
 [dev-dependencies]
-macro_auth = { path = "../macro_auth", features = ["testing"] }

--- a/rust/cloud-storage/search_service_client/Cargo.toml
+++ b/rust/cloud-storage/search_service_client/Cargo.toml
@@ -8,4 +8,3 @@ version = "0.1.0"
 anyhow = { workspace = true }
 models_search = { path = "../models_search" }
 reqwest = { workspace = true }
-tracing = { workspace = true }

--- a/rust/cloud-storage/secretsmanager_client/Cargo.toml
+++ b/rust/cloud-storage/secretsmanager_client/Cargo.toml
@@ -8,9 +8,7 @@ version = "0.1.0"
 local = []
 
 [dependencies]
-anyhow = { workspace = true }
 aws-sdk-secretsmanager = { workspace = true }
-macro_env = { path = "../macro_env" }
 mockall = { workspace = true }
 remote_env_var = { path = "../remote_env_var" }
 thiserror = { workspace = true }

--- a/rust/cloud-storage/seed_cli/Cargo.toml
+++ b/rust/cloud-storage/seed_cli/Cargo.toml
@@ -27,7 +27,6 @@ model-entity = { path = "../model-entity" }
 models_email = { path = "../models_email" }
 models_permissions = { path = "../models_permissions" }
 rand = { workspace = true }
-reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sqlx = { workspace = true }

--- a/rust/cloud-storage/sns_client/Cargo.toml
+++ b/rust/cloud-storage/sns_client/Cargo.toml
@@ -7,7 +7,6 @@ version = "0.1.0"
 [dependencies]
 anyhow = { workspace = true }
 aws-sdk-sns = { workspace = true }
-model-entity = { path = "../model-entity" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }

--- a/rust/cloud-storage/soup/Cargo.toml
+++ b/rust/cloud-storage/soup/Cargo.toml
@@ -56,7 +56,6 @@ model-entity = { path = "../model-entity" }
 model-error-response = { path = "../model-error-response", optional = true }
 model_user = { path = "../model_user", optional = true, features = ["axum"] }
 models_pagination = { path = "../models_pagination" }
-models_properties = { path = "../models_properties" }
 models_soup = { path = "../models_soup" }
 non_empty = { path = "../non_empty" }
 properties_db_client = { path = "../properties_db_client/" }
@@ -79,7 +78,6 @@ cool_asserts = "2"
 entity_access = { path = "../entity_access" }
 filter_ast = { path = "../filter_ast" }
 frecency = { path = "../frecency", features = ["mock", "outbound"] }
-futures = { workspace = true }
 http-body-util = { workspace = true }
 item_filters = { path = "../item_filters", features = ["mock"] }
 macro_db_migrator = { path = "../macro_db_migrator" }

--- a/rust/cloud-storage/sqs_client/Cargo.toml
+++ b/rust/cloud-storage/sqs_client/Cargo.toml
@@ -45,6 +45,4 @@ serde_json = { workspace = true }
 strum = { workspace = true, features = ["derive"] }
 tracing = { workspace = true }
 uuid = { workspace = true, optional = true }
-macro_user_id = { path = "../macro_user_id", optional = true }
-models_opensearch = { path = "../models_opensearch", optional = true }
 futures = { workspace = true, optional = true }

--- a/rust/cloud-storage/static_file_service/Cargo.toml
+++ b/rust/cloud-storage/static_file_service/Cargo.toml
@@ -46,7 +46,6 @@ tokio = { workspace = true }
 tower = { workspace = true }
 tower-http = { workspace = true, features = ["limit", "timeout"] }
 tracing.workspace = true
-tracing-tree = { workspace = true }
 utoipa = { workspace = true }
 utoipa-swagger-ui = { workspace = true, features = ["axum"] }
 uuid.workspace = true

--- a/rust/cloud-storage/stream/Cargo.toml
+++ b/rust/cloud-storage/stream/Cargo.toml
@@ -30,5 +30,4 @@ sqlx = { workspace = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
-tokio-test = "0.4"
 serial_test = "3.3.1"

--- a/rust/cloud-storage/sync_service_client/Cargo.toml
+++ b/rust/cloud-storage/sync_service_client/Cargo.toml
@@ -12,4 +12,3 @@ serde = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
-tokio = { workspace = true }

--- a/rust/cloud-storage/unfurl_service/Cargo.toml
+++ b/rust/cloud-storage/unfurl_service/Cargo.toml
@@ -31,7 +31,6 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 tower = { workspace = true }
-tower-http = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
 utoipa = { workspace = true, features = ["axum_extras", "chrono", "uuid"] }

--- a/rust/cloud-storage/upload_extractor_lambda_handler/Cargo.toml
+++ b/rust/cloud-storage/upload_extractor_lambda_handler/Cargo.toml
@@ -10,9 +10,7 @@ local = []
 [dependencies]
 anyhow = { workspace = true }
 aws-sdk-s3 = { workspace = true }
-aws-sdk-sqs = { workspace = true }
 aws_lambda_events = { workspace = true, features = ["sqs"] }
-chrono = { workspace = true }
 connection_gateway_client = { path = "../connection_gateway_client" }
 document_storage_service_client = { path = "../document_storage_service_client" }
 dynamodb_client = { path = "../dynamodb_client" }
@@ -24,7 +22,6 @@ model = { path = "../model" }
 model-entity = { path = "../model-entity" }
 models_bulk_upload = { path = "../models_bulk_upload" }
 openssl = { workspace = true }
-serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
 sqs_client = { path = "../sqs_client" }

--- a/rust/cloud-storage/upload_extractor_lambda_trigger/Cargo.toml
+++ b/rust/cloud-storage/upload_extractor_lambda_trigger/Cargo.toml
@@ -16,7 +16,6 @@ models_bulk_upload = { path = "../models_bulk_upload" }
 s3_key = { path = "../s3_key" }
 openssl = { workspace = true }
 serde = { workspace = true }
-serde_json = { workspace = true }
 sqs_client = { path = "../sqs_client" }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/rust/cloud-storage/user_link_cleanup_handler/Cargo.toml
+++ b/rust/cloud-storage/user_link_cleanup_handler/Cargo.toml
@@ -7,14 +7,10 @@ version = "0.1.0"
 [dependencies]
 anyhow = { workspace = true }
 aws_lambda_events = { workspace = true, features = ["eventbridge"] }
-chrono = { workspace = true }
-futures = { workspace = true }
 lambda_runtime = { workspace = true }
 macro_db_client = { path = "../macro_db_client" }
 macro_entrypoint = { path = "../macro_entrypoint" }
 openssl = { workspace = true }
-serde = { workspace = true }
-serde_json = { workspace = true }
 sqlx = { workspace = true }
 tokio = { workspace = true }
 

--- a/rust/cloud-storage/user_quota/Cargo.toml
+++ b/rust/cloud-storage/user_quota/Cargo.toml
@@ -5,9 +5,7 @@ publish = false
 version = "0.1.0"
 
 [dependencies]
-anyhow = { workspace = true }
 serde = { workspace = true }
-serde_json = { workspace = true }
 utoipa = { workspace = true }
 
 [package.metadata.cargo-machete]


### PR DESCRIPTION
We have unused dependencies. This tries to remove them with `cargo machete --with-metadata --fix`. There are probably some false positives here.

