### PR TITLE
fix(analytics): Send CompleteRegistration meta analytics event

### DIFF
--- a/js/app/packages/app/component/interactive-onboarding/MobileWebSignupSent.tsx
+++ b/js/app/packages/app/component/interactive-onboarding/MobileWebSignupSent.tsx
@@ -10,11 +10,16 @@ export default function MobileWebSignupSent() {
 
   onMount(() => {
     analytics.track('mobile_web_signup_sent_viewed');
-    analytics.trackMeta('Lead', {
+    // Fire as both Lead and CompleteRegistration: Meta's Maximize Value
+    // campaigns don't support Lead, so we duplicate to CompleteRegistration.
+    // The existing Lead event is used in a custom conversion we use in an ad campaign, so can't remove it
+    const leadPayload = {
       content_name: 'mobile_web_signup',
       value: MOBILE_WEB_SIGNUP_LEAD_VALUE,
       currency: 'USD',
-    });
+    };
+    analytics.trackMeta('Lead', leadPayload);
+    analytics.trackMeta('CompleteRegistration', leadPayload);
   });
 
   return (

--- a/js/app/packages/app/component/interactive-onboarding/lessons/launch.tsx
+++ b/js/app/packages/app/component/interactive-onboarding/lessons/launch.tsx
@@ -21,10 +21,6 @@ function LaunchContent(props: LessonContentProps) {
     analytics.trackMeta('CompleteRegistration', {
       content_name: 'onboarding_launch',
       content_category: tier,
-    });
-    analytics.trackMeta('Lead', {
-      content_name: 'signup',
-      content_category: tier,
       value: SIGNUP_LEAD_VALUE_BY_TIER[tier] ?? SIGNUP_LEAD_VALUE_DEFAULT,
       currency: 'USD',
     });

--- a/rust/cloud-storage/cal/src/outbound/analytics_client.rs
+++ b/rust/cloud-storage/cal/src/outbound/analytics_client.rs
@@ -83,7 +83,7 @@ impl AnalyticsSink for AnalyticsClientSink {
         // carrying the browser attribution signals. Only presence flags and
         // metadata key names are emitted — the raw email, fbp/fbc values,
         // and user_agent are deliberately not logged to avoid PII leakage.
-        // Enable with `RUST_LOG=cal=debug` when investigating match quality.
+        // Enable with `RUST_LOG=cal=debug` when investigating match quality
         tracing::debug!(
             uid = %booking.uid,
             content_name = %content_name,

--- a/rust/cloud-storage/cal/src/outbound/analytics_client.rs
+++ b/rust/cloud-storage/cal/src/outbound/analytics_client.rs
@@ -97,7 +97,7 @@ impl AnalyticsSink for AnalyticsClientSink {
 
         self.client
             .track_meta(
-                "Lead",
+                "CompleteRegistration",
                 &user_data,
                 MetaActionSource::Website,
                 Some(&booking.uid),


### PR DESCRIPTION
Need to send CompleteRegistration Meta event because we can't run a Maximize Value campaign with the existing Lead event type.