### PR TITLE
feat(soup): add date ast filters

### DIFF
--- a/rust/cloud-storage/frecency/src/outbound/postgres/dynamic.rs
+++ b/rust/cloud-storage/frecency/src/outbound/postgres/dynamic.rs
@@ -198,11 +198,23 @@ fn build_document_filter(ast: Option<&Expr<DocumentLiteral>>) -> String {
         filter_ast::ExprFrame::Literal(DocumentLiteral::CreatedAt(DateLiteral::LessThan(dt))) => {
             format!(r#"entity_id IN (SELECT id FROM "Document" WHERE "createdAt" < '{}'::timestamptz AND "deletedAt" IS NULL)"#, dt.to_rfc3339())
         }
+        filter_ast::ExprFrame::Literal(DocumentLiteral::CreatedAt(DateLiteral::GreaterThanOrEqual(dt))) => {
+            format!(r#"entity_id IN (SELECT id FROM "Document" WHERE "createdAt" >= '{}'::timestamptz AND "deletedAt" IS NULL)"#, dt.to_rfc3339())
+        }
+        filter_ast::ExprFrame::Literal(DocumentLiteral::CreatedAt(DateLiteral::LessThanOrEqual(dt))) => {
+            format!(r#"entity_id IN (SELECT id FROM "Document" WHERE "createdAt" <= '{}'::timestamptz AND "deletedAt" IS NULL)"#, dt.to_rfc3339())
+        }
         filter_ast::ExprFrame::Literal(DocumentLiteral::UpdatedAt(DateLiteral::GreaterThan(dt))) => {
             format!(r#"entity_id IN (SELECT id FROM "Document" WHERE "updatedAt" > '{}'::timestamptz AND "deletedAt" IS NULL)"#, dt.to_rfc3339())
         }
         filter_ast::ExprFrame::Literal(DocumentLiteral::UpdatedAt(DateLiteral::LessThan(dt))) => {
             format!(r#"entity_id IN (SELECT id FROM "Document" WHERE "updatedAt" < '{}'::timestamptz AND "deletedAt" IS NULL)"#, dt.to_rfc3339())
+        }
+        filter_ast::ExprFrame::Literal(DocumentLiteral::UpdatedAt(DateLiteral::GreaterThanOrEqual(dt))) => {
+            format!(r#"entity_id IN (SELECT id FROM "Document" WHERE "updatedAt" >= '{}'::timestamptz AND "deletedAt" IS NULL)"#, dt.to_rfc3339())
+        }
+        filter_ast::ExprFrame::Literal(DocumentLiteral::UpdatedAt(DateLiteral::LessThanOrEqual(dt))) => {
+            format!(r#"entity_id IN (SELECT id FROM "Document" WHERE "updatedAt" <= '{}'::timestamptz AND "deletedAt" IS NULL)"#, dt.to_rfc3339())
         }
     });
     if formatting.is_empty() {
@@ -263,11 +275,23 @@ fn build_chat_filter(ast: Option<&Expr<ChatLiteral>>) -> String {
             filter_ast::ExprFrame::Literal(ChatLiteral::CreatedAt(DateLiteral::LessThan(dt))) => {
                 format!(r#"entity_id IN (SELECT id FROM "Chat" WHERE "createdAt" < '{}'::timestamptz AND "deletedAt" IS NULL)"#, dt.to_rfc3339())
             }
+            filter_ast::ExprFrame::Literal(ChatLiteral::CreatedAt(DateLiteral::GreaterThanOrEqual(dt))) => {
+                format!(r#"entity_id IN (SELECT id FROM "Chat" WHERE "createdAt" >= '{}'::timestamptz AND "deletedAt" IS NULL)"#, dt.to_rfc3339())
+            }
+            filter_ast::ExprFrame::Literal(ChatLiteral::CreatedAt(DateLiteral::LessThanOrEqual(dt))) => {
+                format!(r#"entity_id IN (SELECT id FROM "Chat" WHERE "createdAt" <= '{}'::timestamptz AND "deletedAt" IS NULL)"#, dt.to_rfc3339())
+            }
             filter_ast::ExprFrame::Literal(ChatLiteral::UpdatedAt(DateLiteral::GreaterThan(dt))) => {
                 format!(r#"entity_id IN (SELECT id FROM "Chat" WHERE "updatedAt" > '{}'::timestamptz AND "deletedAt" IS NULL)"#, dt.to_rfc3339())
             }
             filter_ast::ExprFrame::Literal(ChatLiteral::UpdatedAt(DateLiteral::LessThan(dt))) => {
                 format!(r#"entity_id IN (SELECT id FROM "Chat" WHERE "updatedAt" < '{}'::timestamptz AND "deletedAt" IS NULL)"#, dt.to_rfc3339())
+            }
+            filter_ast::ExprFrame::Literal(ChatLiteral::UpdatedAt(DateLiteral::GreaterThanOrEqual(dt))) => {
+                format!(r#"entity_id IN (SELECT id FROM "Chat" WHERE "updatedAt" >= '{}'::timestamptz AND "deletedAt" IS NULL)"#, dt.to_rfc3339())
+            }
+            filter_ast::ExprFrame::Literal(ChatLiteral::UpdatedAt(DateLiteral::LessThanOrEqual(dt))) => {
+                format!(r#"entity_id IN (SELECT id FROM "Chat" WHERE "updatedAt" <= '{}'::timestamptz AND "deletedAt" IS NULL)"#, dt.to_rfc3339())
             }
         });
     if formatting.is_empty() {
@@ -306,11 +330,23 @@ fn build_project_filter(ast: Option<&Expr<ProjectLiteral>>) -> String {
         filter_ast::ExprFrame::Literal(ProjectLiteral::CreatedAt(DateLiteral::LessThan(dt))) => {
             format!(r#"entity_id IN (SELECT id FROM "Project" WHERE "createdAt" < '{}'::timestamptz AND "deletedAt" IS NULL)"#, dt.to_rfc3339())
         }
+        filter_ast::ExprFrame::Literal(ProjectLiteral::CreatedAt(DateLiteral::GreaterThanOrEqual(dt))) => {
+            format!(r#"entity_id IN (SELECT id FROM "Project" WHERE "createdAt" >= '{}'::timestamptz AND "deletedAt" IS NULL)"#, dt.to_rfc3339())
+        }
+        filter_ast::ExprFrame::Literal(ProjectLiteral::CreatedAt(DateLiteral::LessThanOrEqual(dt))) => {
+            format!(r#"entity_id IN (SELECT id FROM "Project" WHERE "createdAt" <= '{}'::timestamptz AND "deletedAt" IS NULL)"#, dt.to_rfc3339())
+        }
         filter_ast::ExprFrame::Literal(ProjectLiteral::UpdatedAt(DateLiteral::GreaterThan(dt))) => {
             format!(r#"entity_id IN (SELECT id FROM "Project" WHERE "updatedAt" > '{}'::timestamptz AND "deletedAt" IS NULL)"#, dt.to_rfc3339())
         }
         filter_ast::ExprFrame::Literal(ProjectLiteral::UpdatedAt(DateLiteral::LessThan(dt))) => {
             format!(r#"entity_id IN (SELECT id FROM "Project" WHERE "updatedAt" < '{}'::timestamptz AND "deletedAt" IS NULL)"#, dt.to_rfc3339())
+        }
+        filter_ast::ExprFrame::Literal(ProjectLiteral::UpdatedAt(DateLiteral::GreaterThanOrEqual(dt))) => {
+            format!(r#"entity_id IN (SELECT id FROM "Project" WHERE "updatedAt" >= '{}'::timestamptz AND "deletedAt" IS NULL)"#, dt.to_rfc3339())
+        }
+        filter_ast::ExprFrame::Literal(ProjectLiteral::UpdatedAt(DateLiteral::LessThanOrEqual(dt))) => {
+            format!(r#"entity_id IN (SELECT id FROM "Project" WHERE "updatedAt" <= '{}'::timestamptz AND "deletedAt" IS NULL)"#, dt.to_rfc3339())
         }
     });
     if formatting.is_empty() {

--- a/rust/cloud-storage/frecency/src/outbound/postgres/dynamic.rs
+++ b/rust/cloud-storage/frecency/src/outbound/postgres/dynamic.rs
@@ -3,7 +3,8 @@
 use crate::domain::models::{AggregateFrecency, AggregateId, FrecencyData, TimestampWeight};
 use filter_ast::Expr;
 use item_filters::ast::{
-    EntityFilterAst, chat::ChatLiteral, document::DocumentLiteral, project::ProjectLiteral,
+    EntityFilterAst, chat::ChatLiteral, date::DateLiteral, document::DocumentLiteral,
+    project::ProjectLiteral,
 };
 use macro_user_id::{cowlike::CowLike, user_id::MacroUserIdStr};
 use model_entity::EntityType;
@@ -191,6 +192,18 @@ fn build_document_filter(ast: Option<&Expr<DocumentLiteral>>) -> String {
             r#"NOT EXISTS(SELECT 1 FROM document_email WHERE document_id = fa.entity_id)"#
                 .to_string()
         }
+        filter_ast::ExprFrame::Literal(DocumentLiteral::CreatedAt(DateLiteral::GreaterThan(dt))) => {
+            format!(r#"entity_id IN (SELECT id FROM "Document" WHERE "createdAt" > '{}'::timestamptz AND "deletedAt" IS NULL)"#, dt.to_rfc3339())
+        }
+        filter_ast::ExprFrame::Literal(DocumentLiteral::CreatedAt(DateLiteral::LessThan(dt))) => {
+            format!(r#"entity_id IN (SELECT id FROM "Document" WHERE "createdAt" < '{}'::timestamptz AND "deletedAt" IS NULL)"#, dt.to_rfc3339())
+        }
+        filter_ast::ExprFrame::Literal(DocumentLiteral::UpdatedAt(DateLiteral::GreaterThan(dt))) => {
+            format!(r#"entity_id IN (SELECT id FROM "Document" WHERE "updatedAt" > '{}'::timestamptz AND "deletedAt" IS NULL)"#, dt.to_rfc3339())
+        }
+        filter_ast::ExprFrame::Literal(DocumentLiteral::UpdatedAt(DateLiteral::LessThan(dt))) => {
+            format!(r#"entity_id IN (SELECT id FROM "Document" WHERE "updatedAt" < '{}'::timestamptz AND "deletedAt" IS NULL)"#, dt.to_rfc3339())
+        }
     });
     if formatting.is_empty() {
         String::new()
@@ -244,6 +257,18 @@ fn build_chat_filter(ast: Option<&Expr<ChatLiteral>>) -> String {
             filter_ast::ExprFrame::Literal(ChatLiteral::NotificationSeen(seen)) => {
                 build_notification_seen_clause("entity_id", "chat", seen)
             }
+            filter_ast::ExprFrame::Literal(ChatLiteral::CreatedAt(DateLiteral::GreaterThan(dt))) => {
+                format!(r#"entity_id IN (SELECT id FROM "Chat" WHERE "createdAt" > '{}'::timestamptz AND "deletedAt" IS NULL)"#, dt.to_rfc3339())
+            }
+            filter_ast::ExprFrame::Literal(ChatLiteral::CreatedAt(DateLiteral::LessThan(dt))) => {
+                format!(r#"entity_id IN (SELECT id FROM "Chat" WHERE "createdAt" < '{}'::timestamptz AND "deletedAt" IS NULL)"#, dt.to_rfc3339())
+            }
+            filter_ast::ExprFrame::Literal(ChatLiteral::UpdatedAt(DateLiteral::GreaterThan(dt))) => {
+                format!(r#"entity_id IN (SELECT id FROM "Chat" WHERE "updatedAt" > '{}'::timestamptz AND "deletedAt" IS NULL)"#, dt.to_rfc3339())
+            }
+            filter_ast::ExprFrame::Literal(ChatLiteral::UpdatedAt(DateLiteral::LessThan(dt))) => {
+                format!(r#"entity_id IN (SELECT id FROM "Chat" WHERE "updatedAt" < '{}'::timestamptz AND "deletedAt" IS NULL)"#, dt.to_rfc3339())
+            }
         });
     if formatting.is_empty() {
         String::new()
@@ -274,6 +299,18 @@ fn build_project_filter(ast: Option<&Expr<ProjectLiteral>>) -> String {
         }
         filter_ast::ExprFrame::Literal(ProjectLiteral::NotificationSeen(seen)) => {
             build_notification_seen_clause("entity_id", "project", seen)
+        }
+        filter_ast::ExprFrame::Literal(ProjectLiteral::CreatedAt(DateLiteral::GreaterThan(dt))) => {
+            format!(r#"entity_id IN (SELECT id FROM "Project" WHERE "createdAt" > '{}'::timestamptz AND "deletedAt" IS NULL)"#, dt.to_rfc3339())
+        }
+        filter_ast::ExprFrame::Literal(ProjectLiteral::CreatedAt(DateLiteral::LessThan(dt))) => {
+            format!(r#"entity_id IN (SELECT id FROM "Project" WHERE "createdAt" < '{}'::timestamptz AND "deletedAt" IS NULL)"#, dt.to_rfc3339())
+        }
+        filter_ast::ExprFrame::Literal(ProjectLiteral::UpdatedAt(DateLiteral::GreaterThan(dt))) => {
+            format!(r#"entity_id IN (SELECT id FROM "Project" WHERE "updatedAt" > '{}'::timestamptz AND "deletedAt" IS NULL)"#, dt.to_rfc3339())
+        }
+        filter_ast::ExprFrame::Literal(ProjectLiteral::UpdatedAt(DateLiteral::LessThan(dt))) => {
+            format!(r#"entity_id IN (SELECT id FROM "Project" WHERE "updatedAt" < '{}'::timestamptz AND "deletedAt" IS NULL)"#, dt.to_rfc3339())
         }
     });
     if formatting.is_empty() {

--- a/rust/cloud-storage/frecency/src/outbound/postgres/dynamic_tests.rs
+++ b/rust/cloud-storage/frecency/src/outbound/postgres/dynamic_tests.rs
@@ -2,14 +2,18 @@
 
 use super::*;
 use crate::domain::models::{AggregateId, FrecencyData};
-use chrono::Utc;
+use chrono::{DateTime, Utc};
+use filter_ast::Expr;
+use item_filters::ast::{date::DateLiteral, document::DocumentLiteral};
 use item_filters::{
     ChatFilters, DocumentFilters, EntityFilters, NotificationFilters, ProjectFilters, TaskFilters,
+    ast::EntityFilterAst,
 };
 use macro_db_migrator::MACRO_DB_MIGRATIONS;
 use macro_user_id::{cowlike::CowLike, user_id::MacroUserIdStr};
 use model_entity::EntityType;
 use std::collections::VecDeque;
+use std::sync::Arc;
 use uuid::Uuid;
 
 #[sqlx::test(migrator = "MACRO_DB_MIGRATIONS")]
@@ -693,4 +697,413 @@ async fn test_dynamic_filter_document_task_include_cbm_atm_nc(pool: PgPool) {
 
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].id.entity.entity_id, matching_task_id.to_string());
+}
+
+async fn setup_date_filter_user(pool: &PgPool, user_id: &MacroUserIdStr<'_>) {
+    let macro_user_uuid = Uuid::new_v4();
+    sqlx::query(
+        r#"
+        INSERT INTO "macro_user" ("id", "username", "email", "stripe_customer_id")
+        VALUES ($1, 'test', $2, 'stripe_test')
+        ON CONFLICT ("id") DO NOTHING
+        "#,
+    )
+    .bind(macro_user_uuid)
+    .bind("test@example.com")
+    .execute(pool)
+    .await
+    .unwrap();
+
+    sqlx::query(
+        r#"
+        INSERT INTO "User" ("id", "email", "macro_user_id")
+        VALUES ($1, $2, $3)
+        ON CONFLICT ("id") DO NOTHING
+        "#,
+    )
+    .bind(user_id.as_ref())
+    .bind("test@example.com")
+    .bind(macro_user_uuid)
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+async fn insert_doc_with_timestamps(
+    pool: &PgPool,
+    id: Uuid,
+    owner: &str,
+    created_at: &str,
+    updated_at: &str,
+) {
+    sqlx::query(
+        r#"
+        INSERT INTO "Document" ("id", "name", "owner", "fileType", "createdAt", "updatedAt")
+        VALUES ($1, $2, $3, 'txt', $4::timestamptz, $5::timestamptz)
+        "#,
+    )
+    .bind(id.to_string())
+    .bind(id.to_string())
+    .bind(owner)
+    .bind(created_at)
+    .bind(updated_at)
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+#[sqlx::test(migrator = "MACRO_DB_MIGRATIONS")]
+async fn test_dynamic_filter_document_date_created_at_gt(pool: PgPool) {
+    let storage = FrecencyPgStorage::new(pool.clone());
+    let user_id = MacroUserIdStr::parse_from_str("macro|test@example.com").unwrap();
+    setup_date_filter_user(&pool, &user_id).await;
+
+    let doc_early = Uuid::new_v4();
+    let doc_mid = Uuid::new_v4();
+    let doc_late = Uuid::new_v4();
+
+    insert_doc_with_timestamps(
+        &pool,
+        doc_early,
+        user_id.as_ref(),
+        "2023-01-01T10:00:00Z",
+        "2023-01-01T10:00:00Z",
+    )
+    .await;
+    insert_doc_with_timestamps(
+        &pool,
+        doc_mid,
+        user_id.as_ref(),
+        "2023-01-01T12:00:00Z",
+        "2023-01-01T12:00:00Z",
+    )
+    .await;
+    insert_doc_with_timestamps(
+        &pool,
+        doc_late,
+        user_id.as_ref(),
+        "2023-01-01T14:00:00Z",
+        "2023-01-01T14:00:00Z",
+    )
+    .await;
+
+    for (id, score) in [
+        (doc_early.to_string(), 100.0),
+        (doc_mid.to_string(), 90.0),
+        (doc_late.to_string(), 80.0),
+    ] {
+        storage
+            .set_aggregate(AggregateFrecency {
+                id: AggregateId {
+                    entity: EntityType::Document.with_entity_string(id),
+                    user_id: user_id.clone(),
+                },
+                data: FrecencyData {
+                    event_count: 1,
+                    frecency_score: score,
+                    first_event: Utc::now(),
+                    recent_events: VecDeque::new(),
+                },
+            })
+            .await
+            .unwrap();
+    }
+
+    let cutoff: DateTime<Utc> = DateTime::parse_from_rfc3339("2023-01-01T11:00:00Z")
+        .unwrap()
+        .into();
+    let filter = EntityFilterAst {
+        document_filter: Some(Arc::new(Expr::Literal(DocumentLiteral::CreatedAt(
+            DateLiteral::GreaterThan(cutoff),
+        )))),
+        project_filter: None,
+        chat_filter: None,
+        email_filter: None,
+        channel_filter: None,
+        call_filter: None,
+        properties_filter: None,
+    };
+
+    let results = storage
+        .get_top_entities(FrecencyPageRequest {
+            user_id: user_id.copied(),
+            from_score: None,
+            limit: 10,
+            filters: Some(filter),
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(results.len(), 2);
+    let ids: Vec<String> = results
+        .iter()
+        .map(|r| r.id.entity.entity_id.as_ref().to_string())
+        .collect();
+    assert!(ids.contains(&doc_mid.to_string()));
+    assert!(ids.contains(&doc_late.to_string()));
+}
+
+#[sqlx::test(migrator = "MACRO_DB_MIGRATIONS")]
+async fn test_dynamic_filter_document_date_created_at_lt(pool: PgPool) {
+    let storage = FrecencyPgStorage::new(pool.clone());
+    let user_id = MacroUserIdStr::parse_from_str("macro|test@example.com").unwrap();
+    setup_date_filter_user(&pool, &user_id).await;
+
+    let doc_early = Uuid::new_v4();
+    let doc_mid = Uuid::new_v4();
+    let doc_late = Uuid::new_v4();
+
+    insert_doc_with_timestamps(
+        &pool,
+        doc_early,
+        user_id.as_ref(),
+        "2023-01-01T10:00:00Z",
+        "2023-01-01T10:00:00Z",
+    )
+    .await;
+    insert_doc_with_timestamps(
+        &pool,
+        doc_mid,
+        user_id.as_ref(),
+        "2023-01-01T12:00:00Z",
+        "2023-01-01T12:00:00Z",
+    )
+    .await;
+    insert_doc_with_timestamps(
+        &pool,
+        doc_late,
+        user_id.as_ref(),
+        "2023-01-01T14:00:00Z",
+        "2023-01-01T14:00:00Z",
+    )
+    .await;
+
+    for (id, score) in [
+        (doc_early.to_string(), 100.0),
+        (doc_mid.to_string(), 90.0),
+        (doc_late.to_string(), 80.0),
+    ] {
+        storage
+            .set_aggregate(AggregateFrecency {
+                id: AggregateId {
+                    entity: EntityType::Document.with_entity_string(id),
+                    user_id: user_id.clone(),
+                },
+                data: FrecencyData {
+                    event_count: 1,
+                    frecency_score: score,
+                    first_event: Utc::now(),
+                    recent_events: VecDeque::new(),
+                },
+            })
+            .await
+            .unwrap();
+    }
+
+    let cutoff: DateTime<Utc> = DateTime::parse_from_rfc3339("2023-01-01T11:00:00Z")
+        .unwrap()
+        .into();
+    let filter = EntityFilterAst {
+        document_filter: Some(Arc::new(Expr::Literal(DocumentLiteral::CreatedAt(
+            DateLiteral::LessThan(cutoff),
+        )))),
+        project_filter: None,
+        chat_filter: None,
+        email_filter: None,
+        channel_filter: None,
+        call_filter: None,
+        properties_filter: None,
+    };
+
+    let results = storage
+        .get_top_entities(FrecencyPageRequest {
+            user_id: user_id.copied(),
+            from_score: None,
+            limit: 10,
+            filters: Some(filter),
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].id.entity.entity_id, doc_early.to_string());
+}
+
+#[sqlx::test(migrator = "MACRO_DB_MIGRATIONS")]
+async fn test_dynamic_filter_document_date_updated_at_gt(pool: PgPool) {
+    let storage = FrecencyPgStorage::new(pool.clone());
+    let user_id = MacroUserIdStr::parse_from_str("macro|test@example.com").unwrap();
+    setup_date_filter_user(&pool, &user_id).await;
+
+    let doc_early = Uuid::new_v4();
+    let doc_mid = Uuid::new_v4();
+    let doc_late = Uuid::new_v4();
+
+    // createdAt is old for all; updatedAt varies
+    insert_doc_with_timestamps(
+        &pool,
+        doc_early,
+        user_id.as_ref(),
+        "2023-01-01T10:00:00Z",
+        "2023-01-01T10:00:00Z",
+    )
+    .await;
+    insert_doc_with_timestamps(
+        &pool,
+        doc_mid,
+        user_id.as_ref(),
+        "2023-01-01T10:00:00Z",
+        "2023-01-01T12:00:00Z",
+    )
+    .await;
+    insert_doc_with_timestamps(
+        &pool,
+        doc_late,
+        user_id.as_ref(),
+        "2023-01-01T10:00:00Z",
+        "2023-01-01T14:00:00Z",
+    )
+    .await;
+
+    for (id, score) in [
+        (doc_early.to_string(), 100.0),
+        (doc_mid.to_string(), 90.0),
+        (doc_late.to_string(), 80.0),
+    ] {
+        storage
+            .set_aggregate(AggregateFrecency {
+                id: AggregateId {
+                    entity: EntityType::Document.with_entity_string(id),
+                    user_id: user_id.clone(),
+                },
+                data: FrecencyData {
+                    event_count: 1,
+                    frecency_score: score,
+                    first_event: Utc::now(),
+                    recent_events: VecDeque::new(),
+                },
+            })
+            .await
+            .unwrap();
+    }
+
+    let cutoff: DateTime<Utc> = DateTime::parse_from_rfc3339("2023-01-01T11:00:00Z")
+        .unwrap()
+        .into();
+    let filter = EntityFilterAst {
+        document_filter: Some(Arc::new(Expr::Literal(DocumentLiteral::UpdatedAt(
+            DateLiteral::GreaterThan(cutoff),
+        )))),
+        project_filter: None,
+        chat_filter: None,
+        email_filter: None,
+        channel_filter: None,
+        call_filter: None,
+        properties_filter: None,
+    };
+
+    let results = storage
+        .get_top_entities(FrecencyPageRequest {
+            user_id: user_id.copied(),
+            from_score: None,
+            limit: 10,
+            filters: Some(filter),
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(results.len(), 2);
+    let ids: Vec<String> = results
+        .iter()
+        .map(|r| r.id.entity.entity_id.as_ref().to_string())
+        .collect();
+    assert!(ids.contains(&doc_mid.to_string()));
+    assert!(ids.contains(&doc_late.to_string()));
+}
+
+#[sqlx::test(migrator = "MACRO_DB_MIGRATIONS")]
+async fn test_dynamic_filter_document_date_updated_at_lt(pool: PgPool) {
+    let storage = FrecencyPgStorage::new(pool.clone());
+    let user_id = MacroUserIdStr::parse_from_str("macro|test@example.com").unwrap();
+    setup_date_filter_user(&pool, &user_id).await;
+
+    let doc_early = Uuid::new_v4();
+    let doc_mid = Uuid::new_v4();
+    let doc_late = Uuid::new_v4();
+
+    // createdAt is old for all; updatedAt varies
+    insert_doc_with_timestamps(
+        &pool,
+        doc_early,
+        user_id.as_ref(),
+        "2023-01-01T10:00:00Z",
+        "2023-01-01T10:00:00Z",
+    )
+    .await;
+    insert_doc_with_timestamps(
+        &pool,
+        doc_mid,
+        user_id.as_ref(),
+        "2023-01-01T10:00:00Z",
+        "2023-01-01T12:00:00Z",
+    )
+    .await;
+    insert_doc_with_timestamps(
+        &pool,
+        doc_late,
+        user_id.as_ref(),
+        "2023-01-01T10:00:00Z",
+        "2023-01-01T14:00:00Z",
+    )
+    .await;
+
+    for (id, score) in [
+        (doc_early.to_string(), 100.0),
+        (doc_mid.to_string(), 90.0),
+        (doc_late.to_string(), 80.0),
+    ] {
+        storage
+            .set_aggregate(AggregateFrecency {
+                id: AggregateId {
+                    entity: EntityType::Document.with_entity_string(id),
+                    user_id: user_id.clone(),
+                },
+                data: FrecencyData {
+                    event_count: 1,
+                    frecency_score: score,
+                    first_event: Utc::now(),
+                    recent_events: VecDeque::new(),
+                },
+            })
+            .await
+            .unwrap();
+    }
+
+    let cutoff: DateTime<Utc> = DateTime::parse_from_rfc3339("2023-01-01T11:00:00Z")
+        .unwrap()
+        .into();
+    let filter = EntityFilterAst {
+        document_filter: Some(Arc::new(Expr::Literal(DocumentLiteral::UpdatedAt(
+            DateLiteral::LessThan(cutoff),
+        )))),
+        project_filter: None,
+        chat_filter: None,
+        email_filter: None,
+        channel_filter: None,
+        call_filter: None,
+        properties_filter: None,
+    };
+
+    let results = storage
+        .get_top_entities(FrecencyPageRequest {
+            user_id: user_id.copied(),
+            from_score: None,
+            limit: 10,
+            filters: Some(filter),
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].id.entity.entity_id, doc_early.to_string());
 }

--- a/rust/cloud-storage/item_filters/src/ast.rs
+++ b/rust/cloud-storage/item_filters/src/ast.rs
@@ -26,6 +26,8 @@ pub mod call;
 pub mod channel;
 /// contains the ast literal value for chat
 pub mod chat;
+/// contains the date comparison literal type
+pub mod date;
 /// contains the ast literal value for documents
 pub mod document;
 /// contains the ast literal value for emails

--- a/rust/cloud-storage/item_filters/src/ast/chat.rs
+++ b/rust/cloud-storage/item_filters/src/ast/chat.rs
@@ -5,7 +5,7 @@ use uuid::Uuid;
 
 use crate::{
     ChatFilters,
-    ast::{ExpandErr, ParseFromStr, UnknownValue},
+    ast::{ExpandErr, ParseFromStr, UnknownValue, date::DateLiteral},
 };
 
 /// the literal ast type for the chat entity
@@ -25,6 +25,12 @@ pub enum ChatLiteral {
     NotificationDone(bool),
     /// this node value filters by notification seen state for chats.
     NotificationSeen(bool),
+    /// this node value filters by chat createdAt timestamp
+    #[serde(rename = "ca")]
+    CreatedAt(DateLiteral),
+    /// this node value filters by chat updatedAt timestamp
+    #[serde(rename = "ua")]
+    UpdatedAt(DateLiteral),
 }
 
 /// the possible roles for a chat

--- a/rust/cloud-storage/item_filters/src/ast/chat.rs
+++ b/rust/cloud-storage/item_filters/src/ast/chat.rs
@@ -12,18 +12,25 @@ use crate::{
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum ChatLiteral {
     /// the chat is in some nested project structure where [Uuid] is a parent node
+    #[serde(rename = "pid")]
     ProjectId(Uuid),
     /// the chat has role [ChatRole]
+    #[serde(rename = "r")]
     Role(ChatRole),
     /// the chat has the id [Uuid]
+    #[serde(rename = "cid")]
     ChatId(Uuid),
     /// the chat is owned by [MacroUserIdStr]
+    #[serde(rename = "o")]
     Owner(MacroUserIdStr<'static>),
     /// this node value filters by chat importance. false short-circuits to match nothing.
+    #[serde(rename = "imp")]
     Importance(bool),
     /// this node value filters by notification done state for chats.
+    #[serde(rename = "nd")]
     NotificationDone(bool),
     /// this node value filters by notification seen state for chats.
+    #[serde(rename = "ns")]
     NotificationSeen(bool),
     /// this node value filters by chat createdAt timestamp
     #[serde(rename = "ca")]

--- a/rust/cloud-storage/item_filters/src/ast/date.rs
+++ b/rust/cloud-storage/item_filters/src/ast/date.rs
@@ -10,4 +10,10 @@ pub enum DateLiteral {
     /// Matches entities whose date column is strictly before this timestamp.
     #[serde(rename = "lt")]
     LessThan(DateTime<Utc>),
+    /// Matches entities whose date column is at or after this timestamp.
+    #[serde(rename = "gte")]
+    GreaterThanOrEqual(DateTime<Utc>),
+    /// Matches entities whose date column is at or before this timestamp.
+    #[serde(rename = "lte")]
+    LessThanOrEqual(DateTime<Utc>),
 }

--- a/rust/cloud-storage/item_filters/src/ast/date.rs
+++ b/rust/cloud-storage/item_filters/src/ast/date.rs
@@ -1,0 +1,13 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// A date comparison literal used within entity-specific filter AST nodes.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub enum DateLiteral {
+    /// Matches entities whose date column is strictly after this timestamp.
+    #[serde(rename = "gt")]
+    GreaterThan(DateTime<Utc>),
+    /// Matches entities whose date column is strictly before this timestamp.
+    #[serde(rename = "lt")]
+    LessThan(DateTime<Utc>),
+}

--- a/rust/cloud-storage/item_filters/src/ast/document.rs
+++ b/rust/cloud-storage/item_filters/src/ast/document.rs
@@ -1,4 +1,7 @@
-use crate::{DocumentFilters, ast::ExpandErr};
+use crate::{
+    DocumentFilters,
+    ast::{ExpandErr, date::DateLiteral},
+};
 use document_sub_type::DocumentSubType;
 use either::Either;
 use filter_ast::{ExpandFrame, Expr, FoldTree, TryExpandNode};
@@ -50,6 +53,12 @@ pub enum DocumentLiteral {
     /// this node value filters by email attachment status
     #[serde(rename = "iea")]
     IsEmailAttachment(bool),
+    /// this node value filters by document createdAt timestamp
+    #[serde(rename = "ca")]
+    CreatedAt(DateLiteral),
+    /// this node value filters by document updatedAt timestamp
+    #[serde(rename = "ua")]
+    UpdatedAt(DateLiteral),
 }
 
 fn prefix(s: &str) -> IResult<&str, &str> {

--- a/rust/cloud-storage/item_filters/src/ast/project.rs
+++ b/rust/cloud-storage/item_filters/src/ast/project.rs
@@ -12,14 +12,19 @@ use crate::{
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum ProjectLiteral {
     /// the id of the project
+    #[serde(rename = "pid")]
     ProjectId(Uuid),
     /// the owner of the project
+    #[serde(rename = "o")]
     Owner(MacroUserIdStr<'static>),
     /// this node value filters by project importance. false short-circuits to match nothing.
+    #[serde(rename = "imp")]
     Importance(bool),
     /// this node value filters by notification done state for projects.
+    #[serde(rename = "nd")]
     NotificationDone(bool),
     /// this node value filters by notification seen state for projects.
+    #[serde(rename = "ns")]
     NotificationSeen(bool),
     /// this node value filters by project createdAt timestamp
     #[serde(rename = "ca")]

--- a/rust/cloud-storage/item_filters/src/ast/project.rs
+++ b/rust/cloud-storage/item_filters/src/ast/project.rs
@@ -3,7 +3,10 @@ use macro_user_id::{cowlike::CowLike, user_id::MacroUserIdStr};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::{ProjectFilters, ast::ExpandErr};
+use crate::{
+    ProjectFilters,
+    ast::{ExpandErr, date::DateLiteral},
+};
 
 /// the literal ast types for a project
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -18,6 +21,12 @@ pub enum ProjectLiteral {
     NotificationDone(bool),
     /// this node value filters by notification seen state for projects.
     NotificationSeen(bool),
+    /// this node value filters by project createdAt timestamp
+    #[serde(rename = "ca")]
+    CreatedAt(DateLiteral),
+    /// this node value filters by project updatedAt timestamp
+    #[serde(rename = "ua")]
+    UpdatedAt(DateLiteral),
 }
 
 impl ExpandFrame<ProjectLiteral> for ProjectFilters {

--- a/rust/cloud-storage/soup/src/outbound/pg_soup_repo/expanded/dynamic.rs
+++ b/rust/cloud-storage/soup/src/outbound/pg_soup_repo/expanded/dynamic.rs
@@ -9,6 +9,7 @@ use filter_ast::Expr;
 use item_filters::ast::{
     EntityFilterAst,
     chat::ChatLiteral,
+    date::DateLiteral,
     document::DocumentLiteral,
     project::ProjectLiteral,
     properties::{PropertiesLiteral, PropertyMatchValue},
@@ -346,6 +347,18 @@ fn build_document_filter(ast: Option<&Expr<DocumentLiteral>>) -> String {
             r#"NOT EXISTS(SELECT 1 FROM document_email WHERE document_id = d.id)"#
                 .to_string()
         }
+        filter_ast::ExprFrame::Literal(DocumentLiteral::CreatedAt(DateLiteral::GreaterThan(dt))) => {
+            format!(r#"d."createdAt" > '{}'::timestamptz"#, dt.to_rfc3339())
+        }
+        filter_ast::ExprFrame::Literal(DocumentLiteral::CreatedAt(DateLiteral::LessThan(dt))) => {
+            format!(r#"d."createdAt" < '{}'::timestamptz"#, dt.to_rfc3339())
+        }
+        filter_ast::ExprFrame::Literal(DocumentLiteral::UpdatedAt(DateLiteral::GreaterThan(dt))) => {
+            format!(r#"d."updatedAt" > '{}'::timestamptz"#, dt.to_rfc3339())
+        }
+        filter_ast::ExprFrame::Literal(DocumentLiteral::UpdatedAt(DateLiteral::LessThan(dt))) => {
+            format!(r#"d."updatedAt" < '{}'::timestamptz"#, dt.to_rfc3339())
+        }
     });
     if formatting.is_empty() {
         String::new()
@@ -380,6 +393,18 @@ fn build_chat_filter(ast: Option<&Expr<ChatLiteral>>) -> String {
         filter_ast::ExprFrame::Literal(ChatLiteral::NotificationSeen(seen)) => {
             build_notification_seen_clause("c.id", "chat", seen)
         }
+        filter_ast::ExprFrame::Literal(ChatLiteral::CreatedAt(DateLiteral::GreaterThan(dt))) => {
+            format!(r#"c."createdAt" > '{}'::timestamptz"#, dt.to_rfc3339())
+        }
+        filter_ast::ExprFrame::Literal(ChatLiteral::CreatedAt(DateLiteral::LessThan(dt))) => {
+            format!(r#"c."createdAt" < '{}'::timestamptz"#, dt.to_rfc3339())
+        }
+        filter_ast::ExprFrame::Literal(ChatLiteral::UpdatedAt(DateLiteral::GreaterThan(dt))) => {
+            format!(r#"c."updatedAt" > '{}'::timestamptz"#, dt.to_rfc3339())
+        }
+        filter_ast::ExprFrame::Literal(ChatLiteral::UpdatedAt(DateLiteral::LessThan(dt))) => {
+            format!(r#"c."updatedAt" < '{}'::timestamptz"#, dt.to_rfc3339())
+        }
     });
     if formatting.is_empty() {
         String::new()
@@ -410,6 +435,18 @@ fn build_project_filter(ast: Option<&Expr<ProjectLiteral>>) -> String {
         }
         filter_ast::ExprFrame::Literal(ProjectLiteral::NotificationSeen(seen)) => {
             build_notification_seen_clause("p.id", "project", seen)
+        }
+        filter_ast::ExprFrame::Literal(ProjectLiteral::CreatedAt(DateLiteral::GreaterThan(dt))) => {
+            format!(r#"p."createdAt" > '{}'::timestamptz"#, dt.to_rfc3339())
+        }
+        filter_ast::ExprFrame::Literal(ProjectLiteral::CreatedAt(DateLiteral::LessThan(dt))) => {
+            format!(r#"p."createdAt" < '{}'::timestamptz"#, dt.to_rfc3339())
+        }
+        filter_ast::ExprFrame::Literal(ProjectLiteral::UpdatedAt(DateLiteral::GreaterThan(dt))) => {
+            format!(r#"p."updatedAt" > '{}'::timestamptz"#, dt.to_rfc3339())
+        }
+        filter_ast::ExprFrame::Literal(ProjectLiteral::UpdatedAt(DateLiteral::LessThan(dt))) => {
+            format!(r#"p."updatedAt" < '{}'::timestamptz"#, dt.to_rfc3339())
         }
     });
     if formatting.is_empty() {

--- a/rust/cloud-storage/soup/src/outbound/pg_soup_repo/expanded/dynamic.rs
+++ b/rust/cloud-storage/soup/src/outbound/pg_soup_repo/expanded/dynamic.rs
@@ -289,6 +289,17 @@ fn build_task_include_cbm_atm_nc_clause() -> String {
     .to_string()
 }
 
+fn date_predicate(col: &str, lit: &DateLiteral) -> String {
+    match lit {
+        DateLiteral::GreaterThan(dt) => format!("{col} > '{}'::timestamptz", dt.to_rfc3339()),
+        DateLiteral::LessThan(dt) => format!("{col} < '{}'::timestamptz", dt.to_rfc3339()),
+        DateLiteral::GreaterThanOrEqual(dt) => {
+            format!("{col} >= '{}'::timestamptz", dt.to_rfc3339())
+        }
+        DateLiteral::LessThanOrEqual(dt) => format!("{col} <= '{}'::timestamptz", dt.to_rfc3339()),
+    }
+}
+
 fn build_document_filter(ast: Option<&Expr<DocumentLiteral>>) -> String {
     let Some(expr) = ast else {
         return String::new();
@@ -347,17 +358,11 @@ fn build_document_filter(ast: Option<&Expr<DocumentLiteral>>) -> String {
             r#"NOT EXISTS(SELECT 1 FROM document_email WHERE document_id = d.id)"#
                 .to_string()
         }
-        filter_ast::ExprFrame::Literal(DocumentLiteral::CreatedAt(DateLiteral::GreaterThan(dt))) => {
-            format!(r#"d."createdAt" > '{}'::timestamptz"#, dt.to_rfc3339())
+        filter_ast::ExprFrame::Literal(DocumentLiteral::CreatedAt(lit)) => {
+            date_predicate(r#"d."createdAt""#, &lit)
         }
-        filter_ast::ExprFrame::Literal(DocumentLiteral::CreatedAt(DateLiteral::LessThan(dt))) => {
-            format!(r#"d."createdAt" < '{}'::timestamptz"#, dt.to_rfc3339())
-        }
-        filter_ast::ExprFrame::Literal(DocumentLiteral::UpdatedAt(DateLiteral::GreaterThan(dt))) => {
-            format!(r#"d."updatedAt" > '{}'::timestamptz"#, dt.to_rfc3339())
-        }
-        filter_ast::ExprFrame::Literal(DocumentLiteral::UpdatedAt(DateLiteral::LessThan(dt))) => {
-            format!(r#"d."updatedAt" < '{}'::timestamptz"#, dt.to_rfc3339())
+        filter_ast::ExprFrame::Literal(DocumentLiteral::UpdatedAt(lit)) => {
+            date_predicate(r#"d."updatedAt""#, &lit)
         }
     });
     if formatting.is_empty() {
@@ -393,17 +398,11 @@ fn build_chat_filter(ast: Option<&Expr<ChatLiteral>>) -> String {
         filter_ast::ExprFrame::Literal(ChatLiteral::NotificationSeen(seen)) => {
             build_notification_seen_clause("c.id", "chat", seen)
         }
-        filter_ast::ExprFrame::Literal(ChatLiteral::CreatedAt(DateLiteral::GreaterThan(dt))) => {
-            format!(r#"c."createdAt" > '{}'::timestamptz"#, dt.to_rfc3339())
+        filter_ast::ExprFrame::Literal(ChatLiteral::CreatedAt(lit)) => {
+            date_predicate(r#"c."createdAt""#, &lit)
         }
-        filter_ast::ExprFrame::Literal(ChatLiteral::CreatedAt(DateLiteral::LessThan(dt))) => {
-            format!(r#"c."createdAt" < '{}'::timestamptz"#, dt.to_rfc3339())
-        }
-        filter_ast::ExprFrame::Literal(ChatLiteral::UpdatedAt(DateLiteral::GreaterThan(dt))) => {
-            format!(r#"c."updatedAt" > '{}'::timestamptz"#, dt.to_rfc3339())
-        }
-        filter_ast::ExprFrame::Literal(ChatLiteral::UpdatedAt(DateLiteral::LessThan(dt))) => {
-            format!(r#"c."updatedAt" < '{}'::timestamptz"#, dt.to_rfc3339())
+        filter_ast::ExprFrame::Literal(ChatLiteral::UpdatedAt(lit)) => {
+            date_predicate(r#"c."updatedAt""#, &lit)
         }
     });
     if formatting.is_empty() {
@@ -436,17 +435,11 @@ fn build_project_filter(ast: Option<&Expr<ProjectLiteral>>) -> String {
         filter_ast::ExprFrame::Literal(ProjectLiteral::NotificationSeen(seen)) => {
             build_notification_seen_clause("p.id", "project", seen)
         }
-        filter_ast::ExprFrame::Literal(ProjectLiteral::CreatedAt(DateLiteral::GreaterThan(dt))) => {
-            format!(r#"p."createdAt" > '{}'::timestamptz"#, dt.to_rfc3339())
+        filter_ast::ExprFrame::Literal(ProjectLiteral::CreatedAt(lit)) => {
+            date_predicate(r#"p."createdAt""#, &lit)
         }
-        filter_ast::ExprFrame::Literal(ProjectLiteral::CreatedAt(DateLiteral::LessThan(dt))) => {
-            format!(r#"p."createdAt" < '{}'::timestamptz"#, dt.to_rfc3339())
-        }
-        filter_ast::ExprFrame::Literal(ProjectLiteral::UpdatedAt(DateLiteral::GreaterThan(dt))) => {
-            format!(r#"p."updatedAt" > '{}'::timestamptz"#, dt.to_rfc3339())
-        }
-        filter_ast::ExprFrame::Literal(ProjectLiteral::UpdatedAt(DateLiteral::LessThan(dt))) => {
-            format!(r#"p."updatedAt" < '{}'::timestamptz"#, dt.to_rfc3339())
+        filter_ast::ExprFrame::Literal(ProjectLiteral::UpdatedAt(lit)) => {
+            date_predicate(r#"p."updatedAt""#, &lit)
         }
     });
     if formatting.is_empty() {

--- a/rust/cloud-storage/soup/src/outbound/pg_soup_repo/expanded/tests.rs
+++ b/rust/cloud-storage/soup/src/outbound/pg_soup_repo/expanded/tests.rs
@@ -5371,3 +5371,281 @@ async fn test_dyn_filter_by_not_document_sub_type_task(db: PgPool) -> anyhow::Re
 
     Ok(())
 }
+
+// ---- Date literal filter tests ----
+// Uses `entity_filter_tests` fixture which has:
+//   Docs (accessible): aaaa(10:00), bbbb(11:00), cccc(12:00), dddd(13:00), eeee(14:00) on 2023-01-05
+//   Chats (accessible): a1a1(10:00), b2b2(11:00), c3c3(12:00), d4d4(13:00) on 2023-01-06
+//   Projects (accessible): 1111(Jan-01 10:00), 2222(11:00), 3333(12:00), 4444(Jan-02 10:00)
+
+#[sqlx::test(
+    fixtures(
+        path = "../../../../../macro_db_client/fixtures",
+        scripts("entity_filter_tests")
+    ),
+    migrator = "MACRO_DB_MIGRATIONS"
+)]
+async fn test_date_filter_document_created_at_gt(db: PgPool) -> anyhow::Result<()> {
+    use chrono::DateTime;
+    use filter_ast::Expr;
+    use item_filters::ast::{date::DateLiteral, document::DocumentLiteral};
+    use std::sync::Arc;
+
+    let user_id = MacroUserIdStr::parse_from_str("macro|user-1@test.com").unwrap();
+    // cutoff between bbbb(11:00) and cccc(12:00) → expect cccc, dddd, eeee = 3 docs
+    let cutoff = DateTime::parse_from_rfc3339("2023-01-05T11:30:00Z")?.into();
+    let ast = EntityFilterAst {
+        document_filter: Some(Arc::new(Expr::Literal(DocumentLiteral::CreatedAt(
+            DateLiteral::GreaterThan(cutoff),
+        )))),
+        project_filter: None,
+        chat_filter: None,
+        email_filter: None,
+        channel_filter: None,
+        call_filter: None,
+        properties_filter: None,
+    };
+
+    let items = expanded_dynamic_cursor_soup(
+        &db,
+        ExpandedDynamicCursorArgs {
+            user_id: user_id.copied(),
+            limit: 20,
+            cursor: Query::Sort(SimpleSortMethod::CreatedAt, ast),
+            exclude_frecency: false,
+        },
+    )
+    .await?;
+
+    let mut doc_count = 0;
+    let mut chat_count = 0;
+    let mut project_count = 0;
+    for item in &items {
+        match item {
+            SoupItem::Document(d) => {
+                assert!(
+                    d.created_at > cutoff,
+                    "doc {} created_at {:?} should be > cutoff",
+                    d.id,
+                    d.created_at
+                );
+                doc_count += 1;
+            }
+            SoupItem::Chat(_) => chat_count += 1,
+            SoupItem::Project(_) => project_count += 1,
+            _ => unimplemented!(),
+        }
+    }
+
+    assert_eq!(doc_count, 3, "expected 3 docs with createdAt after cutoff");
+    assert_eq!(chat_count, 4, "chats unaffected by document date filter");
+    assert_eq!(
+        project_count, 4,
+        "projects unaffected by document date filter"
+    );
+    Ok(())
+}
+
+#[sqlx::test(
+    fixtures(
+        path = "../../../../../macro_db_client/fixtures",
+        scripts("entity_filter_tests")
+    ),
+    migrator = "MACRO_DB_MIGRATIONS"
+)]
+async fn test_date_filter_document_created_at_lt(db: PgPool) -> anyhow::Result<()> {
+    use chrono::DateTime;
+    use filter_ast::Expr;
+    use item_filters::ast::{date::DateLiteral, document::DocumentLiteral};
+    use std::sync::Arc;
+
+    let user_id = MacroUserIdStr::parse_from_str("macro|user-1@test.com").unwrap();
+    // cutoff between bbbb(11:00) and cccc(12:00) → expect aaaa, bbbb = 2 docs
+    let cutoff = DateTime::parse_from_rfc3339("2023-01-05T11:30:00Z")?.into();
+    let ast = EntityFilterAst {
+        document_filter: Some(Arc::new(Expr::Literal(DocumentLiteral::CreatedAt(
+            DateLiteral::LessThan(cutoff),
+        )))),
+        project_filter: None,
+        chat_filter: None,
+        email_filter: None,
+        channel_filter: None,
+        call_filter: None,
+        properties_filter: None,
+    };
+
+    let items = expanded_dynamic_cursor_soup(
+        &db,
+        ExpandedDynamicCursorArgs {
+            user_id: user_id.copied(),
+            limit: 20,
+            cursor: Query::Sort(SimpleSortMethod::CreatedAt, ast),
+            exclude_frecency: false,
+        },
+    )
+    .await?;
+
+    let mut doc_count = 0;
+    let mut chat_count = 0;
+    let mut project_count = 0;
+    for item in &items {
+        match item {
+            SoupItem::Document(d) => {
+                assert!(
+                    d.created_at < cutoff,
+                    "doc {} created_at {:?} should be < cutoff",
+                    d.id,
+                    d.created_at
+                );
+                doc_count += 1;
+            }
+            SoupItem::Chat(_) => chat_count += 1,
+            SoupItem::Project(_) => project_count += 1,
+            _ => unimplemented!(),
+        }
+    }
+
+    assert_eq!(doc_count, 2, "expected 2 docs with createdAt before cutoff");
+    assert_eq!(chat_count, 4, "chats unaffected by document date filter");
+    assert_eq!(
+        project_count, 4,
+        "projects unaffected by document date filter"
+    );
+    Ok(())
+}
+
+#[sqlx::test(
+    fixtures(
+        path = "../../../../../macro_db_client/fixtures",
+        scripts("entity_filter_tests")
+    ),
+    migrator = "MACRO_DB_MIGRATIONS"
+)]
+async fn test_date_filter_chat_created_at_gt(db: PgPool) -> anyhow::Result<()> {
+    use chrono::DateTime;
+    use filter_ast::Expr;
+    use item_filters::ast::{chat::ChatLiteral, date::DateLiteral};
+    use std::sync::Arc;
+
+    let user_id = MacroUserIdStr::parse_from_str("macro|user-1@test.com").unwrap();
+    // cutoff between b2b2(11:00) and c3c3(12:00) → expect c3c3, d4d4 = 2 chats
+    let cutoff = DateTime::parse_from_rfc3339("2023-01-06T11:30:00Z")?.into();
+    let ast = EntityFilterAst {
+        document_filter: None,
+        project_filter: None,
+        chat_filter: Some(Arc::new(Expr::Literal(ChatLiteral::CreatedAt(
+            DateLiteral::GreaterThan(cutoff),
+        )))),
+        email_filter: None,
+        channel_filter: None,
+        call_filter: None,
+        properties_filter: None,
+    };
+
+    let items = expanded_dynamic_cursor_soup(
+        &db,
+        ExpandedDynamicCursorArgs {
+            user_id: user_id.copied(),
+            limit: 20,
+            cursor: Query::Sort(SimpleSortMethod::CreatedAt, ast),
+            exclude_frecency: false,
+        },
+    )
+    .await?;
+
+    let mut doc_count = 0;
+    let mut chat_count = 0;
+    let mut project_count = 0;
+    for item in &items {
+        match item {
+            SoupItem::Document(_) => doc_count += 1,
+            SoupItem::Chat(c) => {
+                assert!(
+                    c.created_at > cutoff,
+                    "chat {} created_at {:?} should be > cutoff",
+                    c.id,
+                    c.created_at
+                );
+                chat_count += 1;
+            }
+            SoupItem::Project(_) => project_count += 1,
+            _ => unimplemented!(),
+        }
+    }
+
+    assert_eq!(doc_count, 5, "docs unaffected by chat date filter");
+    assert_eq!(
+        chat_count, 2,
+        "expected 2 chats with createdAt after cutoff"
+    );
+    assert_eq!(project_count, 4, "projects unaffected by chat date filter");
+    Ok(())
+}
+
+#[sqlx::test(
+    fixtures(
+        path = "../../../../../macro_db_client/fixtures",
+        scripts("entity_filter_tests")
+    ),
+    migrator = "MACRO_DB_MIGRATIONS"
+)]
+async fn test_date_filter_project_created_at_gt(db: PgPool) -> anyhow::Result<()> {
+    use chrono::DateTime;
+    use filter_ast::Expr;
+    use item_filters::ast::{date::DateLiteral, project::ProjectLiteral};
+    use std::sync::Arc;
+
+    let user_id = MacroUserIdStr::parse_from_str("macro|user-1@test.com").unwrap();
+    // cutoff between 2222(Jan-01 11:00) and 3333(Jan-01 12:00) → expect 3333, 4444 = 2 projects
+    let cutoff = DateTime::parse_from_rfc3339("2023-01-01T11:30:00Z")?.into();
+    let ast = EntityFilterAst {
+        document_filter: None,
+        project_filter: Some(Arc::new(Expr::Literal(ProjectLiteral::CreatedAt(
+            DateLiteral::GreaterThan(cutoff),
+        )))),
+        chat_filter: None,
+        email_filter: None,
+        channel_filter: None,
+        call_filter: None,
+        properties_filter: None,
+    };
+
+    let items = expanded_dynamic_cursor_soup(
+        &db,
+        ExpandedDynamicCursorArgs {
+            user_id: user_id.copied(),
+            limit: 20,
+            cursor: Query::Sort(SimpleSortMethod::CreatedAt, ast),
+            exclude_frecency: false,
+        },
+    )
+    .await?;
+
+    let mut doc_count = 0;
+    let mut chat_count = 0;
+    let mut project_count = 0;
+    for item in &items {
+        match item {
+            SoupItem::Document(_) => doc_count += 1,
+            SoupItem::Chat(_) => chat_count += 1,
+            SoupItem::Project(p) => {
+                assert!(
+                    p.created_at > cutoff,
+                    "project {} created_at {:?} should be > cutoff",
+                    p.id,
+                    p.created_at
+                );
+                project_count += 1;
+            }
+            _ => unimplemented!(),
+        }
+    }
+
+    assert_eq!(doc_count, 5, "docs unaffected by project date filter");
+    assert_eq!(chat_count, 4, "chats unaffected by project date filter");
+    assert_eq!(
+        project_count, 2,
+        "expected 2 projects with createdAt after cutoff"
+    );
+    Ok(())
+}

--- a/rust/cloud-storage/soup/src/outbound/pg_soup_repo/expanded/tests.rs
+++ b/rust/cloud-storage/soup/src/outbound/pg_soup_repo/expanded/tests.rs
@@ -5649,3 +5649,753 @@ async fn test_date_filter_project_created_at_gt(db: PgPool) -> anyhow::Result<()
     );
     Ok(())
 }
+
+// document / createdAt / AND(gt, lt)
+#[sqlx::test(
+    fixtures(
+        path = "../../../../../macro_db_client/fixtures",
+        scripts("entity_filter_tests")
+    ),
+    migrator = "MACRO_DB_MIGRATIONS"
+)]
+async fn test_date_filter_document_created_at_range(db: PgPool) -> anyhow::Result<()> {
+    use chrono::DateTime;
+    use filter_ast::Expr;
+    use item_filters::ast::{date::DateLiteral, document::DocumentLiteral};
+    use std::sync::Arc;
+
+    let user_id = MacroUserIdStr::parse_from_str("macro|user-1@test.com").unwrap();
+    // lower after aaaa(10:00), upper before eeee(14:00) → bbbb, cccc, dddd = 3 docs
+    let lower: chrono::DateTime<chrono::Utc> =
+        DateTime::parse_from_rfc3339("2023-01-05T10:30:00Z")?.into();
+    let upper: chrono::DateTime<chrono::Utc> =
+        DateTime::parse_from_rfc3339("2023-01-05T13:30:00Z")?.into();
+    let ast = EntityFilterAst {
+        document_filter: Some(Arc::new(Expr::And(
+            Box::new(Expr::Literal(DocumentLiteral::CreatedAt(
+                DateLiteral::GreaterThan(lower),
+            ))),
+            Box::new(Expr::Literal(DocumentLiteral::CreatedAt(
+                DateLiteral::LessThan(upper),
+            ))),
+        ))),
+        project_filter: None,
+        chat_filter: None,
+        email_filter: None,
+        channel_filter: None,
+        call_filter: None,
+        properties_filter: None,
+    };
+
+    let items = expanded_dynamic_cursor_soup(
+        &db,
+        ExpandedDynamicCursorArgs {
+            user_id: user_id.copied(),
+            limit: 20,
+            cursor: Query::Sort(SimpleSortMethod::CreatedAt, ast),
+            exclude_frecency: false,
+        },
+    )
+    .await?;
+
+    let mut doc_count = 0;
+    let mut chat_count = 0;
+    let mut project_count = 0;
+    for item in &items {
+        match item {
+            SoupItem::Document(d) => {
+                assert!(
+                    d.created_at > lower && d.created_at < upper,
+                    "doc {} created_at {:?} outside [{:?}, {:?}]",
+                    d.id,
+                    d.created_at,
+                    lower,
+                    upper
+                );
+                doc_count += 1;
+            }
+            SoupItem::Chat(_) => chat_count += 1,
+            SoupItem::Project(_) => project_count += 1,
+            _ => unimplemented!(),
+        }
+    }
+
+    assert_eq!(doc_count, 3, "expected 3 docs in range");
+    assert_eq!(chat_count, 4, "chats unaffected");
+    assert_eq!(project_count, 4, "projects unaffected");
+    Ok(())
+}
+
+// document / updatedAt / gt
+#[sqlx::test(
+    fixtures(
+        path = "../../../../../macro_db_client/fixtures",
+        scripts("entity_filter_tests")
+    ),
+    migrator = "MACRO_DB_MIGRATIONS"
+)]
+async fn test_date_filter_document_updated_at_gt(db: PgPool) -> anyhow::Result<()> {
+    use chrono::DateTime;
+    use filter_ast::Expr;
+    use item_filters::ast::{date::DateLiteral, document::DocumentLiteral};
+    use std::sync::Arc;
+
+    let user_id = MacroUserIdStr::parse_from_str("macro|user-1@test.com").unwrap();
+    // fixture has updatedAt == createdAt; cutoff same as createdAt gt test → cccc, dddd, eeee = 3
+    let cutoff: chrono::DateTime<chrono::Utc> =
+        DateTime::parse_from_rfc3339("2023-01-05T11:30:00Z")?.into();
+    let ast = EntityFilterAst {
+        document_filter: Some(Arc::new(Expr::Literal(DocumentLiteral::UpdatedAt(
+            DateLiteral::GreaterThan(cutoff),
+        )))),
+        project_filter: None,
+        chat_filter: None,
+        email_filter: None,
+        channel_filter: None,
+        call_filter: None,
+        properties_filter: None,
+    };
+
+    let items = expanded_dynamic_cursor_soup(
+        &db,
+        ExpandedDynamicCursorArgs {
+            user_id: user_id.copied(),
+            limit: 20,
+            cursor: Query::Sort(SimpleSortMethod::CreatedAt, ast),
+            exclude_frecency: false,
+        },
+    )
+    .await?;
+
+    let mut doc_count = 0;
+    for item in &items {
+        if let SoupItem::Document(d) = item {
+            assert!(
+                d.updated_at > cutoff,
+                "doc {} updated_at {:?} should be > cutoff",
+                d.id,
+                d.updated_at
+            );
+            doc_count += 1;
+        }
+    }
+    assert_eq!(doc_count, 3, "expected 3 docs with updatedAt after cutoff");
+    Ok(())
+}
+
+// document / updatedAt / lt
+#[sqlx::test(
+    fixtures(
+        path = "../../../../../macro_db_client/fixtures",
+        scripts("entity_filter_tests")
+    ),
+    migrator = "MACRO_DB_MIGRATIONS"
+)]
+async fn test_date_filter_document_updated_at_lt(db: PgPool) -> anyhow::Result<()> {
+    use chrono::DateTime;
+    use filter_ast::Expr;
+    use item_filters::ast::{date::DateLiteral, document::DocumentLiteral};
+    use std::sync::Arc;
+
+    let user_id = MacroUserIdStr::parse_from_str("macro|user-1@test.com").unwrap();
+    let cutoff: chrono::DateTime<chrono::Utc> =
+        DateTime::parse_from_rfc3339("2023-01-05T11:30:00Z")?.into();
+    let ast = EntityFilterAst {
+        document_filter: Some(Arc::new(Expr::Literal(DocumentLiteral::UpdatedAt(
+            DateLiteral::LessThan(cutoff),
+        )))),
+        project_filter: None,
+        chat_filter: None,
+        email_filter: None,
+        channel_filter: None,
+        call_filter: None,
+        properties_filter: None,
+    };
+
+    let items = expanded_dynamic_cursor_soup(
+        &db,
+        ExpandedDynamicCursorArgs {
+            user_id: user_id.copied(),
+            limit: 20,
+            cursor: Query::Sort(SimpleSortMethod::CreatedAt, ast),
+            exclude_frecency: false,
+        },
+    )
+    .await?;
+
+    let mut doc_count = 0;
+    for item in &items {
+        if let SoupItem::Document(d) = item {
+            assert!(
+                d.updated_at < cutoff,
+                "doc {} updated_at {:?} should be < cutoff",
+                d.id,
+                d.updated_at
+            );
+            doc_count += 1;
+        }
+    }
+    assert_eq!(doc_count, 2, "expected 2 docs with updatedAt before cutoff");
+    Ok(())
+}
+
+// document / updatedAt / AND(gt, lt)
+#[sqlx::test(
+    fixtures(
+        path = "../../../../../macro_db_client/fixtures",
+        scripts("entity_filter_tests")
+    ),
+    migrator = "MACRO_DB_MIGRATIONS"
+)]
+async fn test_date_filter_document_updated_at_range(db: PgPool) -> anyhow::Result<()> {
+    use chrono::DateTime;
+    use filter_ast::Expr;
+    use item_filters::ast::{date::DateLiteral, document::DocumentLiteral};
+    use std::sync::Arc;
+
+    let user_id = MacroUserIdStr::parse_from_str("macro|user-1@test.com").unwrap();
+    let lower: chrono::DateTime<chrono::Utc> =
+        DateTime::parse_from_rfc3339("2023-01-05T10:30:00Z")?.into();
+    let upper: chrono::DateTime<chrono::Utc> =
+        DateTime::parse_from_rfc3339("2023-01-05T13:30:00Z")?.into();
+    let ast = EntityFilterAst {
+        document_filter: Some(Arc::new(Expr::And(
+            Box::new(Expr::Literal(DocumentLiteral::UpdatedAt(
+                DateLiteral::GreaterThan(lower),
+            ))),
+            Box::new(Expr::Literal(DocumentLiteral::UpdatedAt(
+                DateLiteral::LessThan(upper),
+            ))),
+        ))),
+        project_filter: None,
+        chat_filter: None,
+        email_filter: None,
+        channel_filter: None,
+        call_filter: None,
+        properties_filter: None,
+    };
+
+    let items = expanded_dynamic_cursor_soup(
+        &db,
+        ExpandedDynamicCursorArgs {
+            user_id: user_id.copied(),
+            limit: 20,
+            cursor: Query::Sort(SimpleSortMethod::CreatedAt, ast),
+            exclude_frecency: false,
+        },
+    )
+    .await?;
+
+    let mut doc_count = 0;
+    for item in &items {
+        if let SoupItem::Document(d) = item {
+            assert!(
+                d.updated_at > lower && d.updated_at < upper,
+                "doc {} updated_at {:?} outside range",
+                d.id,
+                d.updated_at
+            );
+            doc_count += 1;
+        }
+    }
+    assert_eq!(doc_count, 3, "expected 3 docs with updatedAt in range");
+    Ok(())
+}
+
+// chat / createdAt / lt
+#[sqlx::test(
+    fixtures(
+        path = "../../../../../macro_db_client/fixtures",
+        scripts("entity_filter_tests")
+    ),
+    migrator = "MACRO_DB_MIGRATIONS"
+)]
+async fn test_date_filter_chat_created_at_lt(db: PgPool) -> anyhow::Result<()> {
+    use chrono::DateTime;
+    use filter_ast::Expr;
+    use item_filters::ast::{chat::ChatLiteral, date::DateLiteral};
+    use std::sync::Arc;
+
+    let user_id = MacroUserIdStr::parse_from_str("macro|user-1@test.com").unwrap();
+    // cutoff between b2b2(11:00) and c3c3(12:00) → a1a1, b2b2 = 2 chats
+    let cutoff: chrono::DateTime<chrono::Utc> =
+        DateTime::parse_from_rfc3339("2023-01-06T11:30:00Z")?.into();
+    let ast = EntityFilterAst {
+        document_filter: None,
+        project_filter: None,
+        chat_filter: Some(Arc::new(Expr::Literal(ChatLiteral::CreatedAt(
+            DateLiteral::LessThan(cutoff),
+        )))),
+        email_filter: None,
+        channel_filter: None,
+        call_filter: None,
+        properties_filter: None,
+    };
+
+    let items = expanded_dynamic_cursor_soup(
+        &db,
+        ExpandedDynamicCursorArgs {
+            user_id: user_id.copied(),
+            limit: 20,
+            cursor: Query::Sort(SimpleSortMethod::CreatedAt, ast),
+            exclude_frecency: false,
+        },
+    )
+    .await?;
+
+    let mut chat_count = 0;
+    for item in &items {
+        if let SoupItem::Chat(c) = item {
+            assert!(
+                c.created_at < cutoff,
+                "chat {} created_at {:?} should be < cutoff",
+                c.id,
+                c.created_at
+            );
+            chat_count += 1;
+        }
+    }
+    assert_eq!(
+        chat_count, 2,
+        "expected 2 chats with createdAt before cutoff"
+    );
+    Ok(())
+}
+
+// chat / createdAt / AND(gt, lt)
+#[sqlx::test(
+    fixtures(
+        path = "../../../../../macro_db_client/fixtures",
+        scripts("entity_filter_tests")
+    ),
+    migrator = "MACRO_DB_MIGRATIONS"
+)]
+async fn test_date_filter_chat_created_at_range(db: PgPool) -> anyhow::Result<()> {
+    use chrono::DateTime;
+    use filter_ast::Expr;
+    use item_filters::ast::{chat::ChatLiteral, date::DateLiteral};
+    use std::sync::Arc;
+
+    let user_id = MacroUserIdStr::parse_from_str("macro|user-1@test.com").unwrap();
+    // lower after a1a1(10:00), upper before d4d4(13:00) → b2b2, c3c3 = 2 chats
+    let lower: chrono::DateTime<chrono::Utc> =
+        DateTime::parse_from_rfc3339("2023-01-06T10:30:00Z")?.into();
+    let upper: chrono::DateTime<chrono::Utc> =
+        DateTime::parse_from_rfc3339("2023-01-06T12:30:00Z")?.into();
+    let ast = EntityFilterAst {
+        document_filter: None,
+        project_filter: None,
+        chat_filter: Some(Arc::new(Expr::And(
+            Box::new(Expr::Literal(ChatLiteral::CreatedAt(
+                DateLiteral::GreaterThan(lower),
+            ))),
+            Box::new(Expr::Literal(ChatLiteral::CreatedAt(
+                DateLiteral::LessThan(upper),
+            ))),
+        ))),
+        email_filter: None,
+        channel_filter: None,
+        call_filter: None,
+        properties_filter: None,
+    };
+
+    let items = expanded_dynamic_cursor_soup(
+        &db,
+        ExpandedDynamicCursorArgs {
+            user_id: user_id.copied(),
+            limit: 20,
+            cursor: Query::Sort(SimpleSortMethod::CreatedAt, ast),
+            exclude_frecency: false,
+        },
+    )
+    .await?;
+
+    let mut chat_count = 0;
+    for item in &items {
+        if let SoupItem::Chat(c) = item {
+            assert!(
+                c.created_at > lower && c.created_at < upper,
+                "chat {} created_at {:?} outside range",
+                c.id,
+                c.created_at
+            );
+            chat_count += 1;
+        }
+    }
+    assert_eq!(chat_count, 2, "expected 2 chats in createdAt range");
+    Ok(())
+}
+
+// chat / updatedAt / gt
+#[sqlx::test(
+    fixtures(
+        path = "../../../../../macro_db_client/fixtures",
+        scripts("entity_filter_tests")
+    ),
+    migrator = "MACRO_DB_MIGRATIONS"
+)]
+async fn test_date_filter_chat_updated_at_gt(db: PgPool) -> anyhow::Result<()> {
+    use chrono::DateTime;
+    use filter_ast::Expr;
+    use item_filters::ast::{chat::ChatLiteral, date::DateLiteral};
+    use std::sync::Arc;
+
+    let user_id = MacroUserIdStr::parse_from_str("macro|user-1@test.com").unwrap();
+    let cutoff: chrono::DateTime<chrono::Utc> =
+        DateTime::parse_from_rfc3339("2023-01-06T11:30:00Z")?.into();
+    let ast = EntityFilterAst {
+        document_filter: None,
+        project_filter: None,
+        chat_filter: Some(Arc::new(Expr::Literal(ChatLiteral::UpdatedAt(
+            DateLiteral::GreaterThan(cutoff),
+        )))),
+        email_filter: None,
+        channel_filter: None,
+        call_filter: None,
+        properties_filter: None,
+    };
+
+    let items = expanded_dynamic_cursor_soup(
+        &db,
+        ExpandedDynamicCursorArgs {
+            user_id: user_id.copied(),
+            limit: 20,
+            cursor: Query::Sort(SimpleSortMethod::CreatedAt, ast),
+            exclude_frecency: false,
+        },
+    )
+    .await?;
+
+    let mut chat_count = 0;
+    for item in &items {
+        if let SoupItem::Chat(c) = item {
+            assert!(
+                c.updated_at > cutoff,
+                "chat {} updated_at {:?} should be > cutoff",
+                c.id,
+                c.updated_at
+            );
+            chat_count += 1;
+        }
+    }
+    assert_eq!(
+        chat_count, 2,
+        "expected 2 chats with updatedAt after cutoff"
+    );
+    Ok(())
+}
+
+// chat / updatedAt / AND(gt, lt)
+#[sqlx::test(
+    fixtures(
+        path = "../../../../../macro_db_client/fixtures",
+        scripts("entity_filter_tests")
+    ),
+    migrator = "MACRO_DB_MIGRATIONS"
+)]
+async fn test_date_filter_chat_updated_at_range(db: PgPool) -> anyhow::Result<()> {
+    use chrono::DateTime;
+    use filter_ast::Expr;
+    use item_filters::ast::{chat::ChatLiteral, date::DateLiteral};
+    use std::sync::Arc;
+
+    let user_id = MacroUserIdStr::parse_from_str("macro|user-1@test.com").unwrap();
+    let lower: chrono::DateTime<chrono::Utc> =
+        DateTime::parse_from_rfc3339("2023-01-06T10:30:00Z")?.into();
+    let upper: chrono::DateTime<chrono::Utc> =
+        DateTime::parse_from_rfc3339("2023-01-06T12:30:00Z")?.into();
+    let ast = EntityFilterAst {
+        document_filter: None,
+        project_filter: None,
+        chat_filter: Some(Arc::new(Expr::And(
+            Box::new(Expr::Literal(ChatLiteral::UpdatedAt(
+                DateLiteral::GreaterThan(lower),
+            ))),
+            Box::new(Expr::Literal(ChatLiteral::UpdatedAt(
+                DateLiteral::LessThan(upper),
+            ))),
+        ))),
+        email_filter: None,
+        channel_filter: None,
+        call_filter: None,
+        properties_filter: None,
+    };
+
+    let items = expanded_dynamic_cursor_soup(
+        &db,
+        ExpandedDynamicCursorArgs {
+            user_id: user_id.copied(),
+            limit: 20,
+            cursor: Query::Sort(SimpleSortMethod::CreatedAt, ast),
+            exclude_frecency: false,
+        },
+    )
+    .await?;
+
+    let mut chat_count = 0;
+    for item in &items {
+        if let SoupItem::Chat(c) = item {
+            assert!(
+                c.updated_at > lower && c.updated_at < upper,
+                "chat {} updated_at {:?} outside range",
+                c.id,
+                c.updated_at
+            );
+            chat_count += 1;
+        }
+    }
+    assert_eq!(chat_count, 2, "expected 2 chats with updatedAt in range");
+    Ok(())
+}
+
+// project / createdAt / lt
+#[sqlx::test(
+    fixtures(
+        path = "../../../../../macro_db_client/fixtures",
+        scripts("entity_filter_tests")
+    ),
+    migrator = "MACRO_DB_MIGRATIONS"
+)]
+async fn test_date_filter_project_created_at_lt(db: PgPool) -> anyhow::Result<()> {
+    use chrono::DateTime;
+    use filter_ast::Expr;
+    use item_filters::ast::{date::DateLiteral, project::ProjectLiteral};
+    use std::sync::Arc;
+
+    let user_id = MacroUserIdStr::parse_from_str("macro|user-1@test.com").unwrap();
+    // cutoff between 2222(Jan-01 11:00) and 3333(Jan-01 12:00) → 1111, 2222 = 2 projects
+    let cutoff: chrono::DateTime<chrono::Utc> =
+        DateTime::parse_from_rfc3339("2023-01-01T11:30:00Z")?.into();
+    let ast = EntityFilterAst {
+        document_filter: None,
+        project_filter: Some(Arc::new(Expr::Literal(ProjectLiteral::CreatedAt(
+            DateLiteral::LessThan(cutoff),
+        )))),
+        chat_filter: None,
+        email_filter: None,
+        channel_filter: None,
+        call_filter: None,
+        properties_filter: None,
+    };
+
+    let items = expanded_dynamic_cursor_soup(
+        &db,
+        ExpandedDynamicCursorArgs {
+            user_id: user_id.copied(),
+            limit: 20,
+            cursor: Query::Sort(SimpleSortMethod::CreatedAt, ast),
+            exclude_frecency: false,
+        },
+    )
+    .await?;
+
+    let mut project_count = 0;
+    for item in &items {
+        if let SoupItem::Project(p) = item {
+            assert!(
+                p.created_at < cutoff,
+                "project {} created_at {:?} should be < cutoff",
+                p.id,
+                p.created_at
+            );
+            project_count += 1;
+        }
+    }
+    assert_eq!(
+        project_count, 2,
+        "expected 2 projects with createdAt before cutoff"
+    );
+    Ok(())
+}
+
+// project / createdAt / AND(gt, lt)
+#[sqlx::test(
+    fixtures(
+        path = "../../../../../macro_db_client/fixtures",
+        scripts("entity_filter_tests")
+    ),
+    migrator = "MACRO_DB_MIGRATIONS"
+)]
+async fn test_date_filter_project_created_at_range(db: PgPool) -> anyhow::Result<()> {
+    use chrono::DateTime;
+    use filter_ast::Expr;
+    use item_filters::ast::{date::DateLiteral, project::ProjectLiteral};
+    use std::sync::Arc;
+
+    let user_id = MacroUserIdStr::parse_from_str("macro|user-1@test.com").unwrap();
+    // lower after 1111(Jan-01 10:00), upper before 4444(Jan-02 10:00) → 2222, 3333 = 2 projects
+    let lower: chrono::DateTime<chrono::Utc> =
+        DateTime::parse_from_rfc3339("2023-01-01T10:30:00Z")?.into();
+    let upper: chrono::DateTime<chrono::Utc> =
+        DateTime::parse_from_rfc3339("2023-01-01T12:30:00Z")?.into();
+    let ast = EntityFilterAst {
+        document_filter: None,
+        project_filter: Some(Arc::new(Expr::And(
+            Box::new(Expr::Literal(ProjectLiteral::CreatedAt(
+                DateLiteral::GreaterThan(lower),
+            ))),
+            Box::new(Expr::Literal(ProjectLiteral::CreatedAt(
+                DateLiteral::LessThan(upper),
+            ))),
+        ))),
+        chat_filter: None,
+        email_filter: None,
+        channel_filter: None,
+        call_filter: None,
+        properties_filter: None,
+    };
+
+    let items = expanded_dynamic_cursor_soup(
+        &db,
+        ExpandedDynamicCursorArgs {
+            user_id: user_id.copied(),
+            limit: 20,
+            cursor: Query::Sort(SimpleSortMethod::CreatedAt, ast),
+            exclude_frecency: false,
+        },
+    )
+    .await?;
+
+    let mut project_count = 0;
+    for item in &items {
+        if let SoupItem::Project(p) = item {
+            assert!(
+                p.created_at > lower && p.created_at < upper,
+                "project {} created_at {:?} outside range",
+                p.id,
+                p.created_at
+            );
+            project_count += 1;
+        }
+    }
+    assert_eq!(
+        project_count, 2,
+        "expected 2 projects with createdAt in range"
+    );
+    Ok(())
+}
+
+// project / updatedAt / gt
+#[sqlx::test(
+    fixtures(
+        path = "../../../../../macro_db_client/fixtures",
+        scripts("entity_filter_tests")
+    ),
+    migrator = "MACRO_DB_MIGRATIONS"
+)]
+async fn test_date_filter_project_updated_at_gt(db: PgPool) -> anyhow::Result<()> {
+    use chrono::DateTime;
+    use filter_ast::Expr;
+    use item_filters::ast::{date::DateLiteral, project::ProjectLiteral};
+    use std::sync::Arc;
+
+    let user_id = MacroUserIdStr::parse_from_str("macro|user-1@test.com").unwrap();
+    let cutoff: chrono::DateTime<chrono::Utc> =
+        DateTime::parse_from_rfc3339("2023-01-01T11:30:00Z")?.into();
+    let ast = EntityFilterAst {
+        document_filter: None,
+        project_filter: Some(Arc::new(Expr::Literal(ProjectLiteral::UpdatedAt(
+            DateLiteral::GreaterThan(cutoff),
+        )))),
+        chat_filter: None,
+        email_filter: None,
+        channel_filter: None,
+        call_filter: None,
+        properties_filter: None,
+    };
+
+    let items = expanded_dynamic_cursor_soup(
+        &db,
+        ExpandedDynamicCursorArgs {
+            user_id: user_id.copied(),
+            limit: 20,
+            cursor: Query::Sort(SimpleSortMethod::CreatedAt, ast),
+            exclude_frecency: false,
+        },
+    )
+    .await?;
+
+    let mut project_count = 0;
+    for item in &items {
+        if let SoupItem::Project(p) = item {
+            assert!(
+                p.updated_at > cutoff,
+                "project {} updated_at {:?} should be > cutoff",
+                p.id,
+                p.updated_at
+            );
+            project_count += 1;
+        }
+    }
+    assert_eq!(
+        project_count, 2,
+        "expected 2 projects with updatedAt after cutoff"
+    );
+    Ok(())
+}
+
+// project / updatedAt / AND(gt, lt)
+#[sqlx::test(
+    fixtures(
+        path = "../../../../../macro_db_client/fixtures",
+        scripts("entity_filter_tests")
+    ),
+    migrator = "MACRO_DB_MIGRATIONS"
+)]
+async fn test_date_filter_project_updated_at_range(db: PgPool) -> anyhow::Result<()> {
+    use chrono::DateTime;
+    use filter_ast::Expr;
+    use item_filters::ast::{date::DateLiteral, project::ProjectLiteral};
+    use std::sync::Arc;
+
+    let user_id = MacroUserIdStr::parse_from_str("macro|user-1@test.com").unwrap();
+    let lower: chrono::DateTime<chrono::Utc> =
+        DateTime::parse_from_rfc3339("2023-01-01T10:30:00Z")?.into();
+    let upper: chrono::DateTime<chrono::Utc> =
+        DateTime::parse_from_rfc3339("2023-01-01T12:30:00Z")?.into();
+    let ast = EntityFilterAst {
+        document_filter: None,
+        project_filter: Some(Arc::new(Expr::And(
+            Box::new(Expr::Literal(ProjectLiteral::UpdatedAt(
+                DateLiteral::GreaterThan(lower),
+            ))),
+            Box::new(Expr::Literal(ProjectLiteral::UpdatedAt(
+                DateLiteral::LessThan(upper),
+            ))),
+        ))),
+        chat_filter: None,
+        email_filter: None,
+        channel_filter: None,
+        call_filter: None,
+        properties_filter: None,
+    };
+
+    let items = expanded_dynamic_cursor_soup(
+        &db,
+        ExpandedDynamicCursorArgs {
+            user_id: user_id.copied(),
+            limit: 20,
+            cursor: Query::Sort(SimpleSortMethod::CreatedAt, ast),
+            exclude_frecency: false,
+        },
+    )
+    .await?;
+
+    let mut project_count = 0;
+    for item in &items {
+        if let SoupItem::Project(p) = item {
+            assert!(
+                p.updated_at > lower && p.updated_at < upper,
+                "project {} updated_at {:?} outside range",
+                p.id,
+                p.updated_at
+            );
+            project_count += 1;
+        }
+    }
+    assert_eq!(
+        project_count, 2,
+        "expected 2 projects with updatedAt in range"
+    );
+    Ok(())
+}

--- a/rust/cloud-storage/soup/src/outbound/pg_soup_repo/expanded/tests.rs
+++ b/rust/cloud-storage/soup/src/outbound/pg_soup_repo/expanded/tests.rs
@@ -3,7 +3,14 @@ use crate::outbound::pg_soup_repo::expanded::{
     by_ids::expanded_soup_by_ids,
     dynamic::{ExpandedDynamicCursorArgs, expanded_dynamic_cursor_soup},
 };
-use item_filters::{PropertyFilter, ast::EntityFilterAst};
+use filter_ast::Expr;
+use item_filters::{
+    PropertyFilter,
+    ast::{
+        EntityFilterAst, chat::ChatLiteral, date::DateLiteral, document::DocumentLiteral,
+        project::ProjectLiteral,
+    },
+};
 use macro_db_migrator::MACRO_DB_MIGRATIONS;
 use macro_user_id::{cowlike::CowLike, user_id::MacroUserIdStr};
 use model_entity::EntityType;
@@ -12,6 +19,7 @@ use models_pagination::{Frecency, PaginateOn, Query, SimpleSortMethod};
 use models_soup::item::SoupItem;
 use sqlx::{PgPool, Pool, Postgres};
 use std::collections::HashSet;
+use std::sync::Arc;
 use uuid::Uuid;
 
 macro_rules! unwrap_enum {
@@ -5378,6 +5386,68 @@ async fn test_dyn_filter_by_not_document_sub_type_task(db: PgPool) -> anyhow::Re
 //   Chats (accessible): a1a1(10:00), b2b2(11:00), c3c3(12:00), d4d4(13:00) on 2023-01-06
 //   Projects (accessible): 1111(Jan-01 10:00), 2222(11:00), 3333(12:00), 4444(Jan-02 10:00)
 
+fn mock_empty_ast() -> EntityFilterAst {
+    EntityFilterAst {
+        document_filter: None,
+        project_filter: None,
+        chat_filter: None,
+        email_filter: None,
+        channel_filter: None,
+        call_filter: None,
+        properties_filter: None,
+    }
+}
+
+fn doc_ast(lit: DocumentLiteral) -> EntityFilterAst {
+    EntityFilterAst {
+        document_filter: Some(Arc::new(Expr::Literal(lit))),
+        ..mock_empty_ast()
+    }
+}
+
+fn chat_ast(lit: ChatLiteral) -> EntityFilterAst {
+    EntityFilterAst {
+        chat_filter: Some(Arc::new(Expr::Literal(lit))),
+        ..mock_empty_ast()
+    }
+}
+
+fn project_ast(lit: ProjectLiteral) -> EntityFilterAst {
+    EntityFilterAst {
+        project_filter: Some(Arc::new(Expr::Literal(lit))),
+        ..mock_empty_ast()
+    }
+}
+
+async fn run_and_count(
+    db: &PgPool,
+    ast: EntityFilterAst,
+) -> anyhow::Result<(Vec<SoupItem>, usize, usize, usize)> {
+    let user_id = MacroUserIdStr::parse_from_str("macro|user-1@test.com").unwrap();
+    let items = expanded_dynamic_cursor_soup(
+        db,
+        ExpandedDynamicCursorArgs {
+            user_id: user_id.copied(),
+            limit: 20,
+            cursor: Query::Sort(SimpleSortMethod::CreatedAt, ast),
+            exclude_frecency: false,
+        },
+    )
+    .await?;
+    let mut doc_count = 0usize;
+    let mut chat_count = 0usize;
+    let mut project_count = 0usize;
+    for item in &items {
+        match item {
+            SoupItem::Document(_) => doc_count += 1,
+            SoupItem::Chat(_) => chat_count += 1,
+            SoupItem::Project(_) => project_count += 1,
+            _ => {}
+        }
+    }
+    Ok((items, doc_count, chat_count, project_count))
+}
+
 #[sqlx::test(
     fixtures(
         path = "../../../../../macro_db_client/fixtures",
@@ -5387,56 +5457,24 @@ async fn test_dyn_filter_by_not_document_sub_type_task(db: PgPool) -> anyhow::Re
 )]
 async fn test_date_filter_document_created_at_gt(db: PgPool) -> anyhow::Result<()> {
     use chrono::DateTime;
-    use filter_ast::Expr;
-    use item_filters::ast::{date::DateLiteral, document::DocumentLiteral};
-    use std::sync::Arc;
-
-    let user_id = MacroUserIdStr::parse_from_str("macro|user-1@test.com").unwrap();
     // cutoff between bbbb(11:00) and cccc(12:00) → expect cccc, dddd, eeee = 3 docs
-    let cutoff = DateTime::parse_from_rfc3339("2023-01-05T11:30:00Z")?.into();
-    let ast = EntityFilterAst {
-        document_filter: Some(Arc::new(Expr::Literal(DocumentLiteral::CreatedAt(
-            DateLiteral::GreaterThan(cutoff),
-        )))),
-        project_filter: None,
-        chat_filter: None,
-        email_filter: None,
-        channel_filter: None,
-        call_filter: None,
-        properties_filter: None,
-    };
-
-    let items = expanded_dynamic_cursor_soup(
+    let cutoff: chrono::DateTime<chrono::Utc> =
+        DateTime::parse_from_rfc3339("2023-01-05T11:30:00Z")?.into();
+    let (items, doc_count, chat_count, project_count) = run_and_count(
         &db,
-        ExpandedDynamicCursorArgs {
-            user_id: user_id.copied(),
-            limit: 20,
-            cursor: Query::Sort(SimpleSortMethod::CreatedAt, ast),
-            exclude_frecency: false,
-        },
+        doc_ast(DocumentLiteral::CreatedAt(DateLiteral::GreaterThan(cutoff))),
     )
     .await?;
-
-    let mut doc_count = 0;
-    let mut chat_count = 0;
-    let mut project_count = 0;
     for item in &items {
-        match item {
-            SoupItem::Document(d) => {
-                assert!(
-                    d.created_at > cutoff,
-                    "doc {} created_at {:?} should be > cutoff",
-                    d.id,
-                    d.created_at
-                );
-                doc_count += 1;
-            }
-            SoupItem::Chat(_) => chat_count += 1,
-            SoupItem::Project(_) => project_count += 1,
-            _ => unimplemented!(),
+        if let SoupItem::Document(d) = item {
+            assert!(
+                d.created_at > cutoff,
+                "doc {} created_at {:?} should be > cutoff",
+                d.id,
+                d.created_at
+            );
         }
     }
-
     assert_eq!(doc_count, 3, "expected 3 docs with createdAt after cutoff");
     assert_eq!(chat_count, 4, "chats unaffected by document date filter");
     assert_eq!(
@@ -5455,56 +5493,24 @@ async fn test_date_filter_document_created_at_gt(db: PgPool) -> anyhow::Result<(
 )]
 async fn test_date_filter_document_created_at_lt(db: PgPool) -> anyhow::Result<()> {
     use chrono::DateTime;
-    use filter_ast::Expr;
-    use item_filters::ast::{date::DateLiteral, document::DocumentLiteral};
-    use std::sync::Arc;
-
-    let user_id = MacroUserIdStr::parse_from_str("macro|user-1@test.com").unwrap();
     // cutoff between bbbb(11:00) and cccc(12:00) → expect aaaa, bbbb = 2 docs
-    let cutoff = DateTime::parse_from_rfc3339("2023-01-05T11:30:00Z")?.into();
-    let ast = EntityFilterAst {
-        document_filter: Some(Arc::new(Expr::Literal(DocumentLiteral::CreatedAt(
-            DateLiteral::LessThan(cutoff),
-        )))),
-        project_filter: None,
-        chat_filter: None,
-        email_filter: None,
-        channel_filter: None,
-        call_filter: None,
-        properties_filter: None,
-    };
-
-    let items = expanded_dynamic_cursor_soup(
+    let cutoff: chrono::DateTime<chrono::Utc> =
+        DateTime::parse_from_rfc3339("2023-01-05T11:30:00Z")?.into();
+    let (items, doc_count, chat_count, project_count) = run_and_count(
         &db,
-        ExpandedDynamicCursorArgs {
-            user_id: user_id.copied(),
-            limit: 20,
-            cursor: Query::Sort(SimpleSortMethod::CreatedAt, ast),
-            exclude_frecency: false,
-        },
+        doc_ast(DocumentLiteral::CreatedAt(DateLiteral::LessThan(cutoff))),
     )
     .await?;
-
-    let mut doc_count = 0;
-    let mut chat_count = 0;
-    let mut project_count = 0;
     for item in &items {
-        match item {
-            SoupItem::Document(d) => {
-                assert!(
-                    d.created_at < cutoff,
-                    "doc {} created_at {:?} should be < cutoff",
-                    d.id,
-                    d.created_at
-                );
-                doc_count += 1;
-            }
-            SoupItem::Chat(_) => chat_count += 1,
-            SoupItem::Project(_) => project_count += 1,
-            _ => unimplemented!(),
+        if let SoupItem::Document(d) = item {
+            assert!(
+                d.created_at < cutoff,
+                "doc {} created_at {:?} should be < cutoff",
+                d.id,
+                d.created_at
+            );
         }
     }
-
     assert_eq!(doc_count, 2, "expected 2 docs with createdAt before cutoff");
     assert_eq!(chat_count, 4, "chats unaffected by document date filter");
     assert_eq!(
@@ -5523,56 +5529,24 @@ async fn test_date_filter_document_created_at_lt(db: PgPool) -> anyhow::Result<(
 )]
 async fn test_date_filter_chat_created_at_gt(db: PgPool) -> anyhow::Result<()> {
     use chrono::DateTime;
-    use filter_ast::Expr;
-    use item_filters::ast::{chat::ChatLiteral, date::DateLiteral};
-    use std::sync::Arc;
-
-    let user_id = MacroUserIdStr::parse_from_str("macro|user-1@test.com").unwrap();
     // cutoff between b2b2(11:00) and c3c3(12:00) → expect c3c3, d4d4 = 2 chats
-    let cutoff = DateTime::parse_from_rfc3339("2023-01-06T11:30:00Z")?.into();
-    let ast = EntityFilterAst {
-        document_filter: None,
-        project_filter: None,
-        chat_filter: Some(Arc::new(Expr::Literal(ChatLiteral::CreatedAt(
-            DateLiteral::GreaterThan(cutoff),
-        )))),
-        email_filter: None,
-        channel_filter: None,
-        call_filter: None,
-        properties_filter: None,
-    };
-
-    let items = expanded_dynamic_cursor_soup(
+    let cutoff: chrono::DateTime<chrono::Utc> =
+        DateTime::parse_from_rfc3339("2023-01-06T11:30:00Z")?.into();
+    let (items, doc_count, chat_count, project_count) = run_and_count(
         &db,
-        ExpandedDynamicCursorArgs {
-            user_id: user_id.copied(),
-            limit: 20,
-            cursor: Query::Sort(SimpleSortMethod::CreatedAt, ast),
-            exclude_frecency: false,
-        },
+        chat_ast(ChatLiteral::CreatedAt(DateLiteral::GreaterThan(cutoff))),
     )
     .await?;
-
-    let mut doc_count = 0;
-    let mut chat_count = 0;
-    let mut project_count = 0;
     for item in &items {
-        match item {
-            SoupItem::Document(_) => doc_count += 1,
-            SoupItem::Chat(c) => {
-                assert!(
-                    c.created_at > cutoff,
-                    "chat {} created_at {:?} should be > cutoff",
-                    c.id,
-                    c.created_at
-                );
-                chat_count += 1;
-            }
-            SoupItem::Project(_) => project_count += 1,
-            _ => unimplemented!(),
+        if let SoupItem::Chat(c) = item {
+            assert!(
+                c.created_at > cutoff,
+                "chat {} created_at {:?} should be > cutoff",
+                c.id,
+                c.created_at
+            );
         }
     }
-
     assert_eq!(doc_count, 5, "docs unaffected by chat date filter");
     assert_eq!(
         chat_count, 2,
@@ -5591,56 +5565,24 @@ async fn test_date_filter_chat_created_at_gt(db: PgPool) -> anyhow::Result<()> {
 )]
 async fn test_date_filter_project_created_at_gt(db: PgPool) -> anyhow::Result<()> {
     use chrono::DateTime;
-    use filter_ast::Expr;
-    use item_filters::ast::{date::DateLiteral, project::ProjectLiteral};
-    use std::sync::Arc;
-
-    let user_id = MacroUserIdStr::parse_from_str("macro|user-1@test.com").unwrap();
     // cutoff between 2222(Jan-01 11:00) and 3333(Jan-01 12:00) → expect 3333, 4444 = 2 projects
-    let cutoff = DateTime::parse_from_rfc3339("2023-01-01T11:30:00Z")?.into();
-    let ast = EntityFilterAst {
-        document_filter: None,
-        project_filter: Some(Arc::new(Expr::Literal(ProjectLiteral::CreatedAt(
-            DateLiteral::GreaterThan(cutoff),
-        )))),
-        chat_filter: None,
-        email_filter: None,
-        channel_filter: None,
-        call_filter: None,
-        properties_filter: None,
-    };
-
-    let items = expanded_dynamic_cursor_soup(
+    let cutoff: chrono::DateTime<chrono::Utc> =
+        DateTime::parse_from_rfc3339("2023-01-01T11:30:00Z")?.into();
+    let (items, doc_count, chat_count, project_count) = run_and_count(
         &db,
-        ExpandedDynamicCursorArgs {
-            user_id: user_id.copied(),
-            limit: 20,
-            cursor: Query::Sort(SimpleSortMethod::CreatedAt, ast),
-            exclude_frecency: false,
-        },
+        project_ast(ProjectLiteral::CreatedAt(DateLiteral::GreaterThan(cutoff))),
     )
     .await?;
-
-    let mut doc_count = 0;
-    let mut chat_count = 0;
-    let mut project_count = 0;
     for item in &items {
-        match item {
-            SoupItem::Document(_) => doc_count += 1,
-            SoupItem::Chat(_) => chat_count += 1,
-            SoupItem::Project(p) => {
-                assert!(
-                    p.created_at > cutoff,
-                    "project {} created_at {:?} should be > cutoff",
-                    p.id,
-                    p.created_at
-                );
-                project_count += 1;
-            }
-            _ => unimplemented!(),
+        if let SoupItem::Project(p) = item {
+            assert!(
+                p.created_at > cutoff,
+                "project {} created_at {:?} should be > cutoff",
+                p.id,
+                p.created_at
+            );
         }
     }
-
     assert_eq!(doc_count, 5, "docs unaffected by project date filter");
     assert_eq!(chat_count, 4, "chats unaffected by project date filter");
     assert_eq!(
@@ -5660,11 +5602,6 @@ async fn test_date_filter_project_created_at_gt(db: PgPool) -> anyhow::Result<()
 )]
 async fn test_date_filter_document_created_at_range(db: PgPool) -> anyhow::Result<()> {
     use chrono::DateTime;
-    use filter_ast::Expr;
-    use item_filters::ast::{date::DateLiteral, document::DocumentLiteral};
-    use std::sync::Arc;
-
-    let user_id = MacroUserIdStr::parse_from_str("macro|user-1@test.com").unwrap();
     // lower after aaaa(10:00), upper before eeee(14:00) → bbbb, cccc, dddd = 3 docs
     let lower: chrono::DateTime<chrono::Utc> =
         DateTime::parse_from_rfc3339("2023-01-05T10:30:00Z")?.into();
@@ -5679,47 +5616,21 @@ async fn test_date_filter_document_created_at_range(db: PgPool) -> anyhow::Resul
                 DateLiteral::LessThan(upper),
             ))),
         ))),
-        project_filter: None,
-        chat_filter: None,
-        email_filter: None,
-        channel_filter: None,
-        call_filter: None,
-        properties_filter: None,
+        ..mock_empty_ast()
     };
-
-    let items = expanded_dynamic_cursor_soup(
-        &db,
-        ExpandedDynamicCursorArgs {
-            user_id: user_id.copied(),
-            limit: 20,
-            cursor: Query::Sort(SimpleSortMethod::CreatedAt, ast),
-            exclude_frecency: false,
-        },
-    )
-    .await?;
-
-    let mut doc_count = 0;
-    let mut chat_count = 0;
-    let mut project_count = 0;
+    let (items, doc_count, chat_count, project_count) = run_and_count(&db, ast).await?;
     for item in &items {
-        match item {
-            SoupItem::Document(d) => {
-                assert!(
-                    d.created_at > lower && d.created_at < upper,
-                    "doc {} created_at {:?} outside [{:?}, {:?}]",
-                    d.id,
-                    d.created_at,
-                    lower,
-                    upper
-                );
-                doc_count += 1;
-            }
-            SoupItem::Chat(_) => chat_count += 1,
-            SoupItem::Project(_) => project_count += 1,
-            _ => unimplemented!(),
+        if let SoupItem::Document(d) = item {
+            assert!(
+                d.created_at > lower && d.created_at < upper,
+                "doc {} created_at {:?} outside [{:?}, {:?}]",
+                d.id,
+                d.created_at,
+                lower,
+                upper
+            );
         }
     }
-
     assert_eq!(doc_count, 3, "expected 3 docs in range");
     assert_eq!(chat_count, 4, "chats unaffected");
     assert_eq!(project_count, 4, "projects unaffected");
@@ -5736,38 +5647,14 @@ async fn test_date_filter_document_created_at_range(db: PgPool) -> anyhow::Resul
 )]
 async fn test_date_filter_document_updated_at_gt(db: PgPool) -> anyhow::Result<()> {
     use chrono::DateTime;
-    use filter_ast::Expr;
-    use item_filters::ast::{date::DateLiteral, document::DocumentLiteral};
-    use std::sync::Arc;
-
-    let user_id = MacroUserIdStr::parse_from_str("macro|user-1@test.com").unwrap();
     // fixture has updatedAt == createdAt; cutoff same as createdAt gt test → cccc, dddd, eeee = 3
     let cutoff: chrono::DateTime<chrono::Utc> =
         DateTime::parse_from_rfc3339("2023-01-05T11:30:00Z")?.into();
-    let ast = EntityFilterAst {
-        document_filter: Some(Arc::new(Expr::Literal(DocumentLiteral::UpdatedAt(
-            DateLiteral::GreaterThan(cutoff),
-        )))),
-        project_filter: None,
-        chat_filter: None,
-        email_filter: None,
-        channel_filter: None,
-        call_filter: None,
-        properties_filter: None,
-    };
-
-    let items = expanded_dynamic_cursor_soup(
+    let (items, doc_count, _, _) = run_and_count(
         &db,
-        ExpandedDynamicCursorArgs {
-            user_id: user_id.copied(),
-            limit: 20,
-            cursor: Query::Sort(SimpleSortMethod::CreatedAt, ast),
-            exclude_frecency: false,
-        },
+        doc_ast(DocumentLiteral::UpdatedAt(DateLiteral::GreaterThan(cutoff))),
     )
     .await?;
-
-    let mut doc_count = 0;
     for item in &items {
         if let SoupItem::Document(d) = item {
             assert!(
@@ -5776,7 +5663,6 @@ async fn test_date_filter_document_updated_at_gt(db: PgPool) -> anyhow::Result<(
                 d.id,
                 d.updated_at
             );
-            doc_count += 1;
         }
     }
     assert_eq!(doc_count, 3, "expected 3 docs with updatedAt after cutoff");
@@ -5793,37 +5679,13 @@ async fn test_date_filter_document_updated_at_gt(db: PgPool) -> anyhow::Result<(
 )]
 async fn test_date_filter_document_updated_at_lt(db: PgPool) -> anyhow::Result<()> {
     use chrono::DateTime;
-    use filter_ast::Expr;
-    use item_filters::ast::{date::DateLiteral, document::DocumentLiteral};
-    use std::sync::Arc;
-
-    let user_id = MacroUserIdStr::parse_from_str("macro|user-1@test.com").unwrap();
     let cutoff: chrono::DateTime<chrono::Utc> =
         DateTime::parse_from_rfc3339("2023-01-05T11:30:00Z")?.into();
-    let ast = EntityFilterAst {
-        document_filter: Some(Arc::new(Expr::Literal(DocumentLiteral::UpdatedAt(
-            DateLiteral::LessThan(cutoff),
-        )))),
-        project_filter: None,
-        chat_filter: None,
-        email_filter: None,
-        channel_filter: None,
-        call_filter: None,
-        properties_filter: None,
-    };
-
-    let items = expanded_dynamic_cursor_soup(
+    let (items, doc_count, _, _) = run_and_count(
         &db,
-        ExpandedDynamicCursorArgs {
-            user_id: user_id.copied(),
-            limit: 20,
-            cursor: Query::Sort(SimpleSortMethod::CreatedAt, ast),
-            exclude_frecency: false,
-        },
+        doc_ast(DocumentLiteral::UpdatedAt(DateLiteral::LessThan(cutoff))),
     )
     .await?;
-
-    let mut doc_count = 0;
     for item in &items {
         if let SoupItem::Document(d) = item {
             assert!(
@@ -5832,7 +5694,6 @@ async fn test_date_filter_document_updated_at_lt(db: PgPool) -> anyhow::Result<(
                 d.id,
                 d.updated_at
             );
-            doc_count += 1;
         }
     }
     assert_eq!(doc_count, 2, "expected 2 docs with updatedAt before cutoff");
@@ -5849,11 +5710,6 @@ async fn test_date_filter_document_updated_at_lt(db: PgPool) -> anyhow::Result<(
 )]
 async fn test_date_filter_document_updated_at_range(db: PgPool) -> anyhow::Result<()> {
     use chrono::DateTime;
-    use filter_ast::Expr;
-    use item_filters::ast::{date::DateLiteral, document::DocumentLiteral};
-    use std::sync::Arc;
-
-    let user_id = MacroUserIdStr::parse_from_str("macro|user-1@test.com").unwrap();
     let lower: chrono::DateTime<chrono::Utc> =
         DateTime::parse_from_rfc3339("2023-01-05T10:30:00Z")?.into();
     let upper: chrono::DateTime<chrono::Utc> =
@@ -5867,26 +5723,9 @@ async fn test_date_filter_document_updated_at_range(db: PgPool) -> anyhow::Resul
                 DateLiteral::LessThan(upper),
             ))),
         ))),
-        project_filter: None,
-        chat_filter: None,
-        email_filter: None,
-        channel_filter: None,
-        call_filter: None,
-        properties_filter: None,
+        ..mock_empty_ast()
     };
-
-    let items = expanded_dynamic_cursor_soup(
-        &db,
-        ExpandedDynamicCursorArgs {
-            user_id: user_id.copied(),
-            limit: 20,
-            cursor: Query::Sort(SimpleSortMethod::CreatedAt, ast),
-            exclude_frecency: false,
-        },
-    )
-    .await?;
-
-    let mut doc_count = 0;
+    let (items, doc_count, _, _) = run_and_count(&db, ast).await?;
     for item in &items {
         if let SoupItem::Document(d) = item {
             assert!(
@@ -5895,7 +5734,6 @@ async fn test_date_filter_document_updated_at_range(db: PgPool) -> anyhow::Resul
                 d.id,
                 d.updated_at
             );
-            doc_count += 1;
         }
     }
     assert_eq!(doc_count, 3, "expected 3 docs with updatedAt in range");
@@ -5912,38 +5750,14 @@ async fn test_date_filter_document_updated_at_range(db: PgPool) -> anyhow::Resul
 )]
 async fn test_date_filter_chat_created_at_lt(db: PgPool) -> anyhow::Result<()> {
     use chrono::DateTime;
-    use filter_ast::Expr;
-    use item_filters::ast::{chat::ChatLiteral, date::DateLiteral};
-    use std::sync::Arc;
-
-    let user_id = MacroUserIdStr::parse_from_str("macro|user-1@test.com").unwrap();
     // cutoff between b2b2(11:00) and c3c3(12:00) → a1a1, b2b2 = 2 chats
     let cutoff: chrono::DateTime<chrono::Utc> =
         DateTime::parse_from_rfc3339("2023-01-06T11:30:00Z")?.into();
-    let ast = EntityFilterAst {
-        document_filter: None,
-        project_filter: None,
-        chat_filter: Some(Arc::new(Expr::Literal(ChatLiteral::CreatedAt(
-            DateLiteral::LessThan(cutoff),
-        )))),
-        email_filter: None,
-        channel_filter: None,
-        call_filter: None,
-        properties_filter: None,
-    };
-
-    let items = expanded_dynamic_cursor_soup(
+    let (items, _, chat_count, _) = run_and_count(
         &db,
-        ExpandedDynamicCursorArgs {
-            user_id: user_id.copied(),
-            limit: 20,
-            cursor: Query::Sort(SimpleSortMethod::CreatedAt, ast),
-            exclude_frecency: false,
-        },
+        chat_ast(ChatLiteral::CreatedAt(DateLiteral::LessThan(cutoff))),
     )
     .await?;
-
-    let mut chat_count = 0;
     for item in &items {
         if let SoupItem::Chat(c) = item {
             assert!(
@@ -5952,7 +5766,6 @@ async fn test_date_filter_chat_created_at_lt(db: PgPool) -> anyhow::Result<()> {
                 c.id,
                 c.created_at
             );
-            chat_count += 1;
         }
     }
     assert_eq!(
@@ -5972,19 +5785,12 @@ async fn test_date_filter_chat_created_at_lt(db: PgPool) -> anyhow::Result<()> {
 )]
 async fn test_date_filter_chat_created_at_range(db: PgPool) -> anyhow::Result<()> {
     use chrono::DateTime;
-    use filter_ast::Expr;
-    use item_filters::ast::{chat::ChatLiteral, date::DateLiteral};
-    use std::sync::Arc;
-
-    let user_id = MacroUserIdStr::parse_from_str("macro|user-1@test.com").unwrap();
     // lower after a1a1(10:00), upper before d4d4(13:00) → b2b2, c3c3 = 2 chats
     let lower: chrono::DateTime<chrono::Utc> =
         DateTime::parse_from_rfc3339("2023-01-06T10:30:00Z")?.into();
     let upper: chrono::DateTime<chrono::Utc> =
         DateTime::parse_from_rfc3339("2023-01-06T12:30:00Z")?.into();
     let ast = EntityFilterAst {
-        document_filter: None,
-        project_filter: None,
         chat_filter: Some(Arc::new(Expr::And(
             Box::new(Expr::Literal(ChatLiteral::CreatedAt(
                 DateLiteral::GreaterThan(lower),
@@ -5993,24 +5799,9 @@ async fn test_date_filter_chat_created_at_range(db: PgPool) -> anyhow::Result<()
                 DateLiteral::LessThan(upper),
             ))),
         ))),
-        email_filter: None,
-        channel_filter: None,
-        call_filter: None,
-        properties_filter: None,
+        ..mock_empty_ast()
     };
-
-    let items = expanded_dynamic_cursor_soup(
-        &db,
-        ExpandedDynamicCursorArgs {
-            user_id: user_id.copied(),
-            limit: 20,
-            cursor: Query::Sort(SimpleSortMethod::CreatedAt, ast),
-            exclude_frecency: false,
-        },
-    )
-    .await?;
-
-    let mut chat_count = 0;
+    let (items, _, chat_count, _) = run_and_count(&db, ast).await?;
     for item in &items {
         if let SoupItem::Chat(c) = item {
             assert!(
@@ -6019,7 +5810,6 @@ async fn test_date_filter_chat_created_at_range(db: PgPool) -> anyhow::Result<()
                 c.id,
                 c.created_at
             );
-            chat_count += 1;
         }
     }
     assert_eq!(chat_count, 2, "expected 2 chats in createdAt range");
@@ -6036,37 +5826,13 @@ async fn test_date_filter_chat_created_at_range(db: PgPool) -> anyhow::Result<()
 )]
 async fn test_date_filter_chat_updated_at_gt(db: PgPool) -> anyhow::Result<()> {
     use chrono::DateTime;
-    use filter_ast::Expr;
-    use item_filters::ast::{chat::ChatLiteral, date::DateLiteral};
-    use std::sync::Arc;
-
-    let user_id = MacroUserIdStr::parse_from_str("macro|user-1@test.com").unwrap();
     let cutoff: chrono::DateTime<chrono::Utc> =
         DateTime::parse_from_rfc3339("2023-01-06T11:30:00Z")?.into();
-    let ast = EntityFilterAst {
-        document_filter: None,
-        project_filter: None,
-        chat_filter: Some(Arc::new(Expr::Literal(ChatLiteral::UpdatedAt(
-            DateLiteral::GreaterThan(cutoff),
-        )))),
-        email_filter: None,
-        channel_filter: None,
-        call_filter: None,
-        properties_filter: None,
-    };
-
-    let items = expanded_dynamic_cursor_soup(
+    let (items, _, chat_count, _) = run_and_count(
         &db,
-        ExpandedDynamicCursorArgs {
-            user_id: user_id.copied(),
-            limit: 20,
-            cursor: Query::Sort(SimpleSortMethod::CreatedAt, ast),
-            exclude_frecency: false,
-        },
+        chat_ast(ChatLiteral::UpdatedAt(DateLiteral::GreaterThan(cutoff))),
     )
     .await?;
-
-    let mut chat_count = 0;
     for item in &items {
         if let SoupItem::Chat(c) = item {
             assert!(
@@ -6075,7 +5841,6 @@ async fn test_date_filter_chat_updated_at_gt(db: PgPool) -> anyhow::Result<()> {
                 c.id,
                 c.updated_at
             );
-            chat_count += 1;
         }
     }
     assert_eq!(
@@ -6095,18 +5860,11 @@ async fn test_date_filter_chat_updated_at_gt(db: PgPool) -> anyhow::Result<()> {
 )]
 async fn test_date_filter_chat_updated_at_range(db: PgPool) -> anyhow::Result<()> {
     use chrono::DateTime;
-    use filter_ast::Expr;
-    use item_filters::ast::{chat::ChatLiteral, date::DateLiteral};
-    use std::sync::Arc;
-
-    let user_id = MacroUserIdStr::parse_from_str("macro|user-1@test.com").unwrap();
     let lower: chrono::DateTime<chrono::Utc> =
         DateTime::parse_from_rfc3339("2023-01-06T10:30:00Z")?.into();
     let upper: chrono::DateTime<chrono::Utc> =
         DateTime::parse_from_rfc3339("2023-01-06T12:30:00Z")?.into();
     let ast = EntityFilterAst {
-        document_filter: None,
-        project_filter: None,
         chat_filter: Some(Arc::new(Expr::And(
             Box::new(Expr::Literal(ChatLiteral::UpdatedAt(
                 DateLiteral::GreaterThan(lower),
@@ -6115,24 +5873,9 @@ async fn test_date_filter_chat_updated_at_range(db: PgPool) -> anyhow::Result<()
                 DateLiteral::LessThan(upper),
             ))),
         ))),
-        email_filter: None,
-        channel_filter: None,
-        call_filter: None,
-        properties_filter: None,
+        ..mock_empty_ast()
     };
-
-    let items = expanded_dynamic_cursor_soup(
-        &db,
-        ExpandedDynamicCursorArgs {
-            user_id: user_id.copied(),
-            limit: 20,
-            cursor: Query::Sort(SimpleSortMethod::CreatedAt, ast),
-            exclude_frecency: false,
-        },
-    )
-    .await?;
-
-    let mut chat_count = 0;
+    let (items, _, chat_count, _) = run_and_count(&db, ast).await?;
     for item in &items {
         if let SoupItem::Chat(c) = item {
             assert!(
@@ -6141,7 +5884,6 @@ async fn test_date_filter_chat_updated_at_range(db: PgPool) -> anyhow::Result<()
                 c.id,
                 c.updated_at
             );
-            chat_count += 1;
         }
     }
     assert_eq!(chat_count, 2, "expected 2 chats with updatedAt in range");
@@ -6158,38 +5900,14 @@ async fn test_date_filter_chat_updated_at_range(db: PgPool) -> anyhow::Result<()
 )]
 async fn test_date_filter_project_created_at_lt(db: PgPool) -> anyhow::Result<()> {
     use chrono::DateTime;
-    use filter_ast::Expr;
-    use item_filters::ast::{date::DateLiteral, project::ProjectLiteral};
-    use std::sync::Arc;
-
-    let user_id = MacroUserIdStr::parse_from_str("macro|user-1@test.com").unwrap();
     // cutoff between 2222(Jan-01 11:00) and 3333(Jan-01 12:00) → 1111, 2222 = 2 projects
     let cutoff: chrono::DateTime<chrono::Utc> =
         DateTime::parse_from_rfc3339("2023-01-01T11:30:00Z")?.into();
-    let ast = EntityFilterAst {
-        document_filter: None,
-        project_filter: Some(Arc::new(Expr::Literal(ProjectLiteral::CreatedAt(
-            DateLiteral::LessThan(cutoff),
-        )))),
-        chat_filter: None,
-        email_filter: None,
-        channel_filter: None,
-        call_filter: None,
-        properties_filter: None,
-    };
-
-    let items = expanded_dynamic_cursor_soup(
+    let (items, _, _, project_count) = run_and_count(
         &db,
-        ExpandedDynamicCursorArgs {
-            user_id: user_id.copied(),
-            limit: 20,
-            cursor: Query::Sort(SimpleSortMethod::CreatedAt, ast),
-            exclude_frecency: false,
-        },
+        project_ast(ProjectLiteral::CreatedAt(DateLiteral::LessThan(cutoff))),
     )
     .await?;
-
-    let mut project_count = 0;
     for item in &items {
         if let SoupItem::Project(p) = item {
             assert!(
@@ -6198,7 +5916,6 @@ async fn test_date_filter_project_created_at_lt(db: PgPool) -> anyhow::Result<()
                 p.id,
                 p.created_at
             );
-            project_count += 1;
         }
     }
     assert_eq!(
@@ -6218,18 +5935,12 @@ async fn test_date_filter_project_created_at_lt(db: PgPool) -> anyhow::Result<()
 )]
 async fn test_date_filter_project_created_at_range(db: PgPool) -> anyhow::Result<()> {
     use chrono::DateTime;
-    use filter_ast::Expr;
-    use item_filters::ast::{date::DateLiteral, project::ProjectLiteral};
-    use std::sync::Arc;
-
-    let user_id = MacroUserIdStr::parse_from_str("macro|user-1@test.com").unwrap();
     // lower after 1111(Jan-01 10:00), upper before 4444(Jan-02 10:00) → 2222, 3333 = 2 projects
     let lower: chrono::DateTime<chrono::Utc> =
         DateTime::parse_from_rfc3339("2023-01-01T10:30:00Z")?.into();
     let upper: chrono::DateTime<chrono::Utc> =
         DateTime::parse_from_rfc3339("2023-01-01T12:30:00Z")?.into();
     let ast = EntityFilterAst {
-        document_filter: None,
         project_filter: Some(Arc::new(Expr::And(
             Box::new(Expr::Literal(ProjectLiteral::CreatedAt(
                 DateLiteral::GreaterThan(lower),
@@ -6238,25 +5949,9 @@ async fn test_date_filter_project_created_at_range(db: PgPool) -> anyhow::Result
                 DateLiteral::LessThan(upper),
             ))),
         ))),
-        chat_filter: None,
-        email_filter: None,
-        channel_filter: None,
-        call_filter: None,
-        properties_filter: None,
+        ..mock_empty_ast()
     };
-
-    let items = expanded_dynamic_cursor_soup(
-        &db,
-        ExpandedDynamicCursorArgs {
-            user_id: user_id.copied(),
-            limit: 20,
-            cursor: Query::Sort(SimpleSortMethod::CreatedAt, ast),
-            exclude_frecency: false,
-        },
-    )
-    .await?;
-
-    let mut project_count = 0;
+    let (items, _, _, project_count) = run_and_count(&db, ast).await?;
     for item in &items {
         if let SoupItem::Project(p) = item {
             assert!(
@@ -6265,7 +5960,6 @@ async fn test_date_filter_project_created_at_range(db: PgPool) -> anyhow::Result
                 p.id,
                 p.created_at
             );
-            project_count += 1;
         }
     }
     assert_eq!(
@@ -6285,37 +5979,13 @@ async fn test_date_filter_project_created_at_range(db: PgPool) -> anyhow::Result
 )]
 async fn test_date_filter_project_updated_at_gt(db: PgPool) -> anyhow::Result<()> {
     use chrono::DateTime;
-    use filter_ast::Expr;
-    use item_filters::ast::{date::DateLiteral, project::ProjectLiteral};
-    use std::sync::Arc;
-
-    let user_id = MacroUserIdStr::parse_from_str("macro|user-1@test.com").unwrap();
     let cutoff: chrono::DateTime<chrono::Utc> =
         DateTime::parse_from_rfc3339("2023-01-01T11:30:00Z")?.into();
-    let ast = EntityFilterAst {
-        document_filter: None,
-        project_filter: Some(Arc::new(Expr::Literal(ProjectLiteral::UpdatedAt(
-            DateLiteral::GreaterThan(cutoff),
-        )))),
-        chat_filter: None,
-        email_filter: None,
-        channel_filter: None,
-        call_filter: None,
-        properties_filter: None,
-    };
-
-    let items = expanded_dynamic_cursor_soup(
+    let (items, _, _, project_count) = run_and_count(
         &db,
-        ExpandedDynamicCursorArgs {
-            user_id: user_id.copied(),
-            limit: 20,
-            cursor: Query::Sort(SimpleSortMethod::CreatedAt, ast),
-            exclude_frecency: false,
-        },
+        project_ast(ProjectLiteral::UpdatedAt(DateLiteral::GreaterThan(cutoff))),
     )
     .await?;
-
-    let mut project_count = 0;
     for item in &items {
         if let SoupItem::Project(p) = item {
             assert!(
@@ -6324,7 +5994,6 @@ async fn test_date_filter_project_updated_at_gt(db: PgPool) -> anyhow::Result<()
                 p.id,
                 p.updated_at
             );
-            project_count += 1;
         }
     }
     assert_eq!(
@@ -6344,17 +6013,11 @@ async fn test_date_filter_project_updated_at_gt(db: PgPool) -> anyhow::Result<()
 )]
 async fn test_date_filter_project_updated_at_range(db: PgPool) -> anyhow::Result<()> {
     use chrono::DateTime;
-    use filter_ast::Expr;
-    use item_filters::ast::{date::DateLiteral, project::ProjectLiteral};
-    use std::sync::Arc;
-
-    let user_id = MacroUserIdStr::parse_from_str("macro|user-1@test.com").unwrap();
     let lower: chrono::DateTime<chrono::Utc> =
         DateTime::parse_from_rfc3339("2023-01-01T10:30:00Z")?.into();
     let upper: chrono::DateTime<chrono::Utc> =
         DateTime::parse_from_rfc3339("2023-01-01T12:30:00Z")?.into();
     let ast = EntityFilterAst {
-        document_filter: None,
         project_filter: Some(Arc::new(Expr::And(
             Box::new(Expr::Literal(ProjectLiteral::UpdatedAt(
                 DateLiteral::GreaterThan(lower),
@@ -6363,25 +6026,9 @@ async fn test_date_filter_project_updated_at_range(db: PgPool) -> anyhow::Result
                 DateLiteral::LessThan(upper),
             ))),
         ))),
-        chat_filter: None,
-        email_filter: None,
-        channel_filter: None,
-        call_filter: None,
-        properties_filter: None,
+        ..mock_empty_ast()
     };
-
-    let items = expanded_dynamic_cursor_soup(
-        &db,
-        ExpandedDynamicCursorArgs {
-            user_id: user_id.copied(),
-            limit: 20,
-            cursor: Query::Sort(SimpleSortMethod::CreatedAt, ast),
-            exclude_frecency: false,
-        },
-    )
-    .await?;
-
-    let mut project_count = 0;
+    let (items, _, _, project_count) = run_and_count(&db, ast).await?;
     for item in &items {
         if let SoupItem::Project(p) = item {
             assert!(
@@ -6390,7 +6037,6 @@ async fn test_date_filter_project_updated_at_range(db: PgPool) -> anyhow::Result
                 p.id,
                 p.updated_at
             );
-            project_count += 1;
         }
     }
     assert_eq!(


### PR DESCRIPTION
This PR adds date ast filters to soup

- **add date literal soup ast**
- **update tests**
- **fix frecency compilation**
- **add more tests**
- **sqlx prepare**
