### PR TITLE
fix(search): clear sub-filter caches when resetting to tab defaults

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/use-filter-refinements.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/use-filter-refinements.tsx
@@ -16,6 +16,9 @@ import { type Accessor, batch, createMemo, createSignal } from 'solid-js';
 import type { ActiveFilter } from './active-filter-chips';
 import { INDEX_OPTIONS } from './search-operator-autocomplete';
 import {
+  cacheCallSubFilters,
+  cacheChannelSubFilters,
+  cacheEmailSubFilters,
   type SearchableOption,
   useSearchFilterOptions,
   useSearchIndexController,
@@ -468,10 +471,15 @@ export function useFilterRefinements() {
     const preset = currentPreset();
     if (!preset) return;
 
+    const contentId = panel.handle.content().id;
+
     batch(() => {
       soup.filters.set(preset.clientFilters);
       setQueryFilters(preset.queryFilters);
       setAssigneeFilter([]);
+      cacheChannelSubFilters(contentId, {});
+      cacheCallSubFilters(contentId, {});
+      cacheEmailSubFilters(contentId, {});
     });
   };
 


### PR DESCRIPTION
The Clear button reset `queryFilters` but left the channel/call/email sub-filter caches in localStorage. Adding a new `from:` filter calls `changeIndex('channels')` (since the index was deactivated by Clear), which restores the cached `channel_ids` from localStorage — so the previously-cleared `in:` filter reappears.

Fix: clear all three sub-filter caches in `resetToTabDefaults`.
