### PR TITLE
fix(teams): tier changes not giving proper feedback

### DIFF
--- a/js/app/packages/app/component/settings/Team.tsx
+++ b/js/app/packages/app/component/settings/Team.tsx
@@ -511,7 +511,7 @@ function TeamManagement(props: { teamId: string; teamName: string; ownerId: stri
                   onRemove={() => setShowRemoveModal(member)}
                   onTierChange={(newTier) => {
                     if (!props.teamId) return;
-                    toast.promise(
+                    void toast.promise(
                       patchTierMutation.mutateAsync({
                         teamId: props.teamId,
                         request: {

--- a/js/app/packages/app/component/settings/Team.tsx
+++ b/js/app/packages/app/component/settings/Team.tsx
@@ -7,6 +7,7 @@ import XIcon from '@icon/regular/x.svg';
 import CaretDownIcon from '@icon/regular/caret-down.svg';
 import CheckIcon from '@icon/regular/check.svg';
 import { DialogWrapper } from '@core/component/DialogWrapper';
+import { toast } from '@core/component/Toast/Toast';
 import { Tooltip } from '@core/component/Tooltip';
 import { Button } from '@ui/components/Button';
 import { Dialog } from '@kobalte/core/dialog';
@@ -510,13 +511,20 @@ function TeamManagement(props: { teamId: string; teamName: string; ownerId: stri
                   onRemove={() => setShowRemoveModal(member)}
                   onTierChange={(newTier) => {
                     if (!props.teamId) return;
-                    patchTierMutation.mutate({
-                      teamId: props.teamId,
-                      request: {
-                        team_user_id: member.user_id,
-                        new_tier: newTier,
-                      },
-                    });
+                    toast.promise(
+                      patchTierMutation.mutateAsync({
+                        teamId: props.teamId,
+                        request: {
+                          team_user_id: member.user_id,
+                          new_tier: newTier,
+                        },
+                      }),
+                      {
+                        loading: 'Updating member tier...',
+                        success: 'Member tier updated',
+                        error: 'Failed to update member tier',
+                      }
+                    );
                   }}
                 />
               )}

--- a/js/app/packages/queries/team/members.ts
+++ b/js/app/packages/queries/team/members.ts
@@ -15,10 +15,12 @@ type PatchTeamUserTierArgs = {
   teamId: string;
   request: PatchTeamUserTierRequest;
 };
+type PatchTeamUserTierContext = { previousTeam: TeamWithMembers | undefined };
 type PatchTeamUserTierCallbacks = MutationCallbacks<
   void,
   Error,
-  PatchTeamUserTierArgs
+  PatchTeamUserTierArgs,
+  PatchTeamUserTierContext
 >;
 
 export function usePatchTeamUserTierMutation(
@@ -31,16 +33,53 @@ export function usePatchTeamUserTierMutation(
       );
     },
 
-    ...withCallbacks<void, Error, PatchTeamUserTierArgs>(
+    ...withCallbacks<
+      void,
+      Error,
+      PatchTeamUserTierArgs,
+      PatchTeamUserTierContext
+    >(
       {
+        onMutate: async ({ teamId, request }) => {
+          const queryKey = teamKeys.detail(teamId).queryKey;
+          await queryClient.cancelQueries({ queryKey });
+
+          const previousTeam =
+            queryClient.getQueryData<TeamWithMembers>(queryKey);
+
+          queryClient.setQueryData<TeamWithMembers>(queryKey, (old) =>
+            old
+              ? {
+                  ...old,
+                  members: old.members.map((member) =>
+                    member.user_id === request.team_user_id
+                      ? { ...member, tier: request.new_tier }
+                      : member
+                  ),
+                }
+              : undefined
+          );
+
+          console.log('Tier change');
+
+          return { previousTeam: structuredClone(previousTeam) };
+        },
+
         onSuccess: (_data, { teamId }) => {
           invalidateTeam(teamId);
           toast.success('Member tier updated');
         },
 
-        onError: (error) => {
+        onError: (error, { teamId }, context) => {
           console.error('Failed to update team member tier', error);
           toast.failure('Failed to update team member tier');
+
+          if (context?.previousTeam) {
+            queryClient.setQueryData(
+              teamKeys.detail(teamId).queryKey,
+              context.previousTeam
+            );
+          }
         },
       },
       callbacks

--- a/js/app/packages/queries/team/members.ts
+++ b/js/app/packages/queries/team/members.ts
@@ -70,7 +70,10 @@ export function usePatchTeamUserTierMutation(
           const userInfo = queryClient.getQueryData<{ userId: string }>(
             authKeys.userInfo.queryKey
           );
-          if (userInfo?.userId === request.team_user_id) {
+          if (
+            userInfo?.id === request.team_user_id ||
+            userInfo?.userId === request.team_user_id
+          ) {
             queryClient.invalidateQueries({
               queryKey: authKeys.userInfo.queryKey,
             });

--- a/js/app/packages/queries/team/members.ts
+++ b/js/app/packages/queries/team/members.ts
@@ -78,13 +78,10 @@ export function usePatchTeamUserTierMutation(
               queryKey: authKeys.userQuota.queryKey,
             });
           }
-
-          toast.success('Member tier updated');
         },
 
         onError: (error, { teamId }, context) => {
           console.error('Failed to update team member tier', error);
-          toast.failure('Failed to update team member tier');
 
           if (context?.previousTeam) {
             queryClient.setQueryData(

--- a/js/app/packages/queries/team/members.ts
+++ b/js/app/packages/queries/team/members.ts
@@ -67,9 +67,10 @@ export function usePatchTeamUserTierMutation(
         onSuccess: (_data, { teamId, request }) => {
           invalidateTeam(teamId);
 
-          const userInfo = queryClient.getQueryData<{ userId: string }>(
-            authKeys.userInfo.queryKey
-          );
+          const userInfo = queryClient.getQueryData<{
+            userId: string;
+            id: string;
+          }>(authKeys.userInfo.queryKey);
           if (
             userInfo?.id === request.team_user_id ||
             userInfo?.userId === request.team_user_id

--- a/js/app/packages/queries/team/members.ts
+++ b/js/app/packages/queries/team/members.ts
@@ -5,6 +5,7 @@ import type { PatchTeamUserTierRequest } from '@service-auth/generated/schemas/p
 import type { TeamWithMembers } from '@service-auth/generated/schemas/teamWithMembers';
 import { useMutation } from '@tanstack/solid-query';
 
+import { authKeys } from '../auth';
 import { queryClient } from '../client';
 import { type MutationCallbacks, withCallbacks } from '../utils';
 
@@ -60,13 +61,24 @@ export function usePatchTeamUserTierMutation(
               : undefined
           );
 
-          console.log('Tier change');
-
-          return { previousTeam: structuredClone(previousTeam) };
+          return { previousTeam };
         },
 
-        onSuccess: (_data, { teamId }) => {
+        onSuccess: (_data, { teamId, request }) => {
           invalidateTeam(teamId);
+
+          const userInfo = queryClient.getQueryData<{ userId: string }>(
+            authKeys.userInfo.queryKey
+          );
+          if (userInfo?.userId === request.team_user_id) {
+            queryClient.invalidateQueries({
+              queryKey: authKeys.userInfo.queryKey,
+            });
+            queryClient.invalidateQueries({
+              queryKey: authKeys.userQuota.queryKey,
+            });
+          }
+
           toast.success('Member tier updated');
         },
 


### PR DESCRIPTION
This PR updates the tier change to display toasts using `toast.promise` and apply an optimistic update because the backend request takes a while to complete. Also, this fixes an issue where changing your own tier wasn't reflecting in the subscription tab of settings