### PR TITLE
feat(kommand): rank command items by recency

### DIFF
--- a/js/app/packages/app/component/command/CommandMenu.tsx
+++ b/js/app/packages/app/component/command/CommandMenu.tsx
@@ -24,6 +24,7 @@ import { useSplitLayout } from '../split-layout/layout';
 import { CommandItem } from './CommandItem';
 import { CommandState } from './state';
 import { useCommandItems } from './useCommandItems';
+import { trackCommandUsage } from './recency';
 import type { CategoryFilter } from './types';
 import { itemToBlockName } from '@core/constant/allBlocks';
 import { cn } from '@ui/utils/classname';
@@ -149,6 +150,7 @@ export function CommandMenuInner(props: {
       }
 
       // Regular command - close and run
+      trackCommandUsage(item.id);
       CommandState.close();
       CommandState.setQuery('');
       runCommand(command);

--- a/js/app/packages/app/component/command/recency.ts
+++ b/js/app/packages/app/component/command/recency.ts
@@ -15,6 +15,7 @@ export function trackCommandUsage(commandId: string): void {
   setRecencyStore(commandId, Date.now());
 }
 
-export function getCommandLastUsedAt(commandId: string): number | undefined {
-  return recencyStore[commandId];
+export function getCommandLastUsedAt(commandId: string): Date | null {
+  const timestamp = recencyStore[commandId];
+  return timestamp ? new Date(timestamp) : null;
 }

--- a/js/app/packages/app/component/command/recency.ts
+++ b/js/app/packages/app/component/command/recency.ts
@@ -1,0 +1,19 @@
+import { makePersisted } from '@solid-primitives/storage';
+import { createStore } from 'solid-js/store';
+
+const STORE_NAME = 'command-recency-v1';
+
+type RecencyStore = Record<string, number>;
+
+const [recencyStore, setRecencyStore] = makePersisted(
+  createStore<RecencyStore>({}),
+  { name: STORE_NAME }
+);
+
+export function trackCommandUsage(commandId: string): void {
+  setRecencyStore(commandId, Date.now());
+}
+
+export function getCommandLastUsedAt(commandId: string): number | undefined {
+  return recencyStore[commandId];
+}

--- a/js/app/packages/app/component/command/recency.ts
+++ b/js/app/packages/app/component/command/recency.ts
@@ -3,6 +3,7 @@ import { createStore } from 'solid-js/store';
 
 const STORE_NAME = 'command-recency-v1';
 
+// stores command id -> last used timestamp in ms
 type RecencyStore = Record<string, number>;
 
 const [recencyStore, setRecencyStore] = makePersisted(

--- a/js/app/packages/app/component/command/useCommandItems.ts
+++ b/js/app/packages/app/component/command/useCommandItems.ts
@@ -100,15 +100,14 @@ function commandsToItems(
         : command.description;
     const tags = command.tags?.join(' ') ?? '';
     const id = `command-${description.replaceAll(' ', '-')}`;
-    const lastUsedAtMs = getCommandLastUsedAt(id);
-    const lastUsedAt = lastUsedAtMs ? new Date(lastUsedAtMs) : null;
+    const lastUsedAt = getCommandLastUsedAt(id);
 
     return {
       id,
       kind: 'command',
       bucket: 'command',
       searchText: [tags, description].filter(Boolean).join(' '),
-      sortTimestamp: lastUsedAtMs ?? 0,
+      sortTimestamp: lastUsedAt?.getTime() ?? 0,
       timestamps: { viewedAt: lastUsedAt, updatedAt: lastUsedAt },
       data: command,
       displayHotkey: options?.displayHotkey?.(command),

--- a/js/app/packages/app/component/command/useCommandItems.ts
+++ b/js/app/packages/app/component/command/useCommandItems.ts
@@ -7,7 +7,11 @@ import {
   exclude,
 } from '@core/context/quickAccess';
 import type { HotkeyCommand } from '@core/hotkey/types';
-import { createFreshSearch, type FreshSortConfig } from '@core/util/freshSort';
+import {
+  createFreshSearch,
+  type FreshSortConfig,
+  type TimestampedItem,
+} from '@core/util/freshSort';
 import { createMemo } from 'solid-js';
 import type { CategoryFilter } from './types';
 import {
@@ -19,6 +23,8 @@ import { CommandState } from './state';
 import { HotkeyTags } from '@core/hotkey/constants';
 import { GO_TO_COMMAND_SCOPE, GO_TO_LEADER_KEY } from '@app/constants/hotkeys';
 import type { HotkeySequenceStep } from '@core/component/Tooltip';
+import { getCommandLastUsedAt } from './recency';
+import { mergeSortedArrays } from '@core/util/list';
 
 /** Command item type - local to command menu, not part of quickAccess */
 type CommandItem = {
@@ -27,7 +33,7 @@ type CommandItem = {
   bucket: 'command';
   searchText: string;
   sortTimestamp: number;
-  timestamps: Record<string, never>;
+  timestamps: TimestampedItem;
   data: HotkeyCommand;
   displayHotkey?: string;
   displayHotkeySequence?: HotkeySequenceStep[];
@@ -87,25 +93,30 @@ function commandsToItems(
     return true;
   });
 
-  return dedupedCommands.map((command): CommandItem => {
+  const items = dedupedCommands.map((command): CommandItem => {
     const description =
       typeof command.description === 'function'
         ? command.description()
         : command.description;
     const tags = command.tags?.join(' ') ?? '';
+    const id = `command-${description.replaceAll(' ', '-')}`;
+    const lastUsedAtMs = getCommandLastUsedAt(id);
+    const lastUsedAt = lastUsedAtMs ? new Date(lastUsedAtMs) : null;
 
     return {
-      id: `command-${description.replaceAll(' ', '-')}`,
+      id,
       kind: 'command',
       bucket: 'command',
       searchText: [tags, description].filter(Boolean).join(' '),
-      sortTimestamp: 0,
-      timestamps: {},
+      sortTimestamp: lastUsedAtMs ?? 0,
+      timestamps: { viewedAt: lastUsedAt, updatedAt: lastUsedAt },
       data: command,
       displayHotkey: options?.displayHotkey?.(command),
       displayHotkeySequence: options?.displayHotkeySequence?.(command),
     };
   });
+
+  return items.sort((a, b) => b.sortTimestamp - a.sortTimestamp);
 }
 
 /**
@@ -176,11 +187,13 @@ function useQuickAccessBuckets(): Record<
   const commandsList = useCommandsList();
   const entitiesList = quickAccess.useList(...exclude('person'));
 
-  const allWithCommands = createMemo((): CommandMenuItem[] => {
-    const entities = entitiesList();
-    const commands = commandsList();
-    return [...entities, ...commands];
-  });
+  const allWithCommands = createMemo((): CommandMenuItem[] =>
+    mergeSortedArrays(
+      entitiesList(),
+      commandsList(),
+      (a, b) => b.sortTimestamp - a.sortTimestamp
+    )
+  );
 
   return {
     all: allWithCommands,

--- a/js/app/packages/core/util/list.ts
+++ b/js/app/packages/core/util/list.ts
@@ -36,3 +36,29 @@ export function intersection<T>(
 ): T[] {
   return a.filter((item) => b.some((other) => equal(item, other)));
 }
+
+/**
+ * Merge two pre-sorted arrays into a single sorted array.
+ * `compare` follows the Array.sort convention (negative if a goes first).
+ */
+export function mergeSortedArrays<T>(
+  arr1: T[],
+  arr2: T[],
+  compare: (a: T, b: T) => number
+): T[] {
+  const merged: T[] = [];
+  let i = 0;
+  let j = 0;
+
+  while (i < arr1.length && j < arr2.length) {
+    if (compare(arr1[i], arr2[j]) <= 0) {
+      merged.push(arr1[i]);
+      i++;
+    } else {
+      merged.push(arr2[j]);
+      j++;
+    }
+  }
+
+  return [...merged, ...arr1.slice(i), ...arr2.slice(j)];
+}


### PR DESCRIPTION
Track command-menu invocations in localStorage and use the lastUsedAt timestamp as the command item's sortTimestamp + viewedAt, matching how QuickAccess sorts entities by recency. The All tab now interleaves recently-used commands with recently-viewed entities by a shared timestamp.
