### PR TITLE
fix(kommand): surface block-entity commands from non-block focus scopes

### DIFF
--- a/js/app/packages/app/component/command/useCommandItems.ts
+++ b/js/app/packages/app/component/command/useCommandItems.ts
@@ -124,6 +124,11 @@ function useCommandsList(): () => CommandItem[] {
     hideShadowedCommands: false,
     hideCommandsWithoutHotkeys: false,
     ignoreInputFocused: true,
+    // Block-entity commands (Copy ID, Mark done, Rename, etc.) register on the
+    // block's own scope, which is a *child* of the panel's split scope. When
+    // the user clicks the task top bar, active scope = split scope and the
+    // block scope is below it, so the up-walk alone misses those commands.
+    includeDescendantDomScopes: true,
   });
   const goToCommands = getActiveCommandsFromScope(GO_TO_COMMAND_SCOPE, {
     sortByScopeLevel: false,

--- a/js/app/packages/core/hotkey/getCommands.ts
+++ b/js/app/packages/core/hotkey/getCommands.ts
@@ -15,6 +15,8 @@ type sortAndFilterOptions = {
   limitToCurrentScope?: boolean;
   // skips the runWithInputFocused filter — use for the command menu where all commands should be shown regardless of input focus
   ignoreInputFocused?: boolean;
+  // also walks DOWN through DOM child scopes of the starting scope. Block-entity commands register on a block's own scope, which is a *child* of the surrounding split panel scope; without this, focusing the panel's top bar (active scope = split panel) misses them.
+  includeDescendantDomScopes?: boolean;
 };
 
 // This is reactive on active scope (if scope not specified), activeElement, and commmand conditions.
@@ -69,6 +71,44 @@ export function getActiveCommandsFromScope(
     );
     scopeLevel++;
   }
+
+  if (displayOptions.includeDescendantDomScopes && scopeId !== 'global') {
+    const startNode = hotkeyScopeTree.get(scopeId);
+    if (startNode) {
+      const visited = new Set<string>([scopeId]);
+      const queue: { id: string; level: number }[] = [];
+      for (const childId of startNode.childScopeIds) {
+        queue.push({ id: childId, level: -1 });
+      }
+      while (queue.length) {
+        const { id, level } = queue.shift()!;
+        if (visited.has(id)) continue;
+        visited.add(id);
+        const node = hotkeyScopeTree.get(id);
+        if (!node || node.type !== 'dom') continue;
+        const allHotkeyCommands = Array.from(
+          node.hotkeyCommands.values()
+        ).flat();
+        const scopeCommands = [...allHotkeyCommands, ...node.unkeyedCommands]
+          .filter(filterCommands(displayOptions))
+          .map((command) => {
+            const hotkeys = command.hotkeys ?? [];
+            const isShadowed = hotkeys.some((hk) => hotkeySet.has(hk));
+            hotkeys.forEach((hk) => hotkeySet.add(hk));
+            return {
+              ...command,
+              scopeLevel: level,
+              hotkeyIsShadowed: isShadowed,
+            };
+          });
+        commands.push(...scopeCommands);
+        for (const childId of node.childScopeIds) {
+          queue.push({ id: childId, level: level - 1 });
+        }
+      }
+    }
+  }
+
   commands.sort((a, b) => {
     if (displayOptions.sortByScopeLevel) {
       if (a.scopeLevel !== b.scopeLevel) {


### PR DESCRIPTION
Fixes [block-entity commands not discoverable from non-block scopes](https://app.macro.com/app/task/019dd61a-6a1e-7adb-9d15-9e454cdaf590). Block-entity commands like Copy ID, Mark done, Copy link register on a block's own scope, which is a child of the split panel scope — so focusing the panel's top bar (active scope = split) skipped them on the up-walk. The kommand menu now also walks DOM child scopes of the active scope so those commands surface from any focus point on a block page.
