### PR TITLE
fix(search): make filter chip dropdowns opaque again

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/active-filter-chips.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/active-filter-chips.tsx
@@ -233,7 +233,7 @@ const FilterChip = (props: {
           </DropdownMenu.Trigger>
 
           <DropdownMenu.Portal>
-            <DropdownMenu.Content class="z-action-menu bg-surface-0 border border-edge-muted rounded-sm shadow-xl min-w-[160px] p-1">
+            <DropdownMenu.Content class="z-action-menu bg-menu border border-edge-muted rounded-sm shadow-xl min-w-[160px] p-1">
               <For each={props.filter.categoryOptions}>
                 {(option) => {
                   const active = () =>

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/searchable-multi-select.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/searchable-multi-select.tsx
@@ -168,7 +168,7 @@ export const SearchableMultiSelect = (props: SearchableMultiSelectProps) => {
       <Combobox.Portal>
         <Combobox.Content
           class={cn(
-            'z-action-menu bg-surface-0 border border-edge-muted rounded-sm shadow-md w-[260px] max-w-[90vw] overflow-hidden',
+            'z-action-menu bg-menu border border-edge-muted rounded-sm shadow-md w-[260px] max-w-[90vw] overflow-hidden',
             props.contentClass
           )}
         >


### PR DESCRIPTION
`bg-surface-0` stopped resolving to a color after the layers utility refactor (#2923), so chip + searchable-multi-select dropdowns went transparent — the highlighted row's accent outline bled through and made the menu look mis-z-indexed. Switching to `bg-menu` matches the other dropdowns and restores opacity.
