### PR TITLE
fix(soup): only allow marking supported entities as done 

### DIFF
--- a/js/app/packages/app/component/next-soup/actions/make-mark-done-action.ts
+++ b/js/app/packages/app/component/next-soup/actions/make-mark-done-action.ts
@@ -123,9 +123,7 @@ export const makeMarkDoneAction = (options: MakeMarkDoneOptions) => {
       entity.type === 'email' ||
       entity.type === 'channel' ||
       entity.type === 'chat' ||
-      entity.type === 'document' ||
-      entity.type === 'project' ||
-      isTaskEntity(entity)
+      entity.type === 'project'
     ) {
       return true;
     }

--- a/js/app/packages/app/component/next-soup/actions/make-mark-done-action.ts
+++ b/js/app/packages/app/component/next-soup/actions/make-mark-done-action.ts
@@ -1,6 +1,6 @@
 import ArrowCounterClockwise from '@phosphor-icons/core/regular/arrow-counter-clockwise.svg?component-solid';
 import { toast } from '@core/component/Toast/Toast';
-import { type EntityData, isTaskEntity } from '@entity';
+import type { EntityData } from '@entity';
 import type { NotificationSource } from '@notifications';
 import { useUndoableMutation } from '@queries/undo';
 import {
@@ -13,6 +13,20 @@ import {
 } from '@app/component/next-soup/utils';
 import { useMaybePreviewPanel } from '@app/component/PreviewPanel';
 import type { SoupState } from '../create-soup-state';
+import type { ListView } from '@app/constants/list-views';
+
+// Valid list views where the mark done should be allowed to run
+const VALID_MARK_DONE_LIST_VIEWS: `${ListView}-${string}`[] = [
+  'inbox-signal',
+  'mail-important',
+  'mail-all',
+  'mail-noise',
+  'mail-shared',
+];
+
+export const canExecuteMarkDoneOnView = (view: ListView, tabId: string) => {
+  return VALID_MARK_DONE_LIST_VIEWS.includes(`${view}-${tabId}`);
+};
 
 type MakeMarkDoneOptions = {
   userId?: () => string | undefined;
@@ -123,6 +137,7 @@ export const makeMarkDoneAction = (options: MakeMarkDoneOptions) => {
       entity.type === 'email' ||
       entity.type === 'channel' ||
       entity.type === 'chat' ||
+      entity.type === 'document' ||
       entity.type === 'project'
     ) {
       return true;

--- a/js/app/packages/app/component/next-soup/actions/use-entity-action-hotkeys.ts
+++ b/js/app/packages/app/component/next-soup/actions/use-entity-action-hotkeys.ts
@@ -27,14 +27,13 @@ import { SYSTEM_PROPERTY_IDS } from '@core/component/Properties/constants';
 import type { SplitHandle } from '@app/component/split-layout/layoutManager';
 import { openEntityInSplitFromUnifiedList } from '@app/component/next-soup/utils';
 import { onCleanup } from 'solid-js';
-import { isListViewID, type ListView } from '@app/constants/list-views';
-
-// Valid list views where the mark done hotkey can be run in
-const VALID_MARK_DONE_LIST_VIEWS: ListView[] = ['inbox', 'mail'];
+import { isListViewID } from '@app/constants/list-views';
+import { canExecuteMarkDoneOnView } from '@app/component/next-soup/actions/make-mark-done-action';
 
 type UseEntityActionHotkeysOptions = {
   scopeId: string;
   soup: SoupState;
+  activeSoupViewTab?: () => string | undefined;
   splitHandle?: SplitHandle;
   condition?: () => boolean;
   /** Fallback entity getter used when soup has no selection/focus (e.g., block views) */
@@ -141,9 +140,12 @@ export const useEntityActionHotkeys = (
 
       const splitContentId = splitHandle?.content().id;
 
+      const soupViewTab = options.activeSoupViewTab?.();
+
       if (
+        soupViewTab &&
         isListViewID(splitContentId) &&
-        !VALID_MARK_DONE_LIST_VIEWS.includes(splitContentId)
+        !canExecuteMarkDoneOnView(splitContentId, soupViewTab)
       )
         return false;
 

--- a/js/app/packages/app/component/next-soup/actions/use-entity-action-hotkeys.ts
+++ b/js/app/packages/app/component/next-soup/actions/use-entity-action-hotkeys.ts
@@ -138,14 +138,13 @@ export const useEntityActionHotkeys = (
     condition: () => {
       if (condition && !condition()) return false;
 
-      const splitContentId = splitHandle?.content().id;
+      const contentId = splitHandle?.content().id;
 
       const soupViewTab = options.activeSoupViewTab?.();
 
       if (
-        !soupViewTab ||
-        !isListViewID(splitContentId) ||
-        !canExecuteMarkDoneOnView(splitContentId, soupViewTab)
+        !isListViewID(contentId) ||
+        (soupViewTab && !canExecuteMarkDoneOnView(contentId, soupViewTab))
       )
         return false;
 

--- a/js/app/packages/app/component/next-soup/actions/use-entity-action-hotkeys.ts
+++ b/js/app/packages/app/component/next-soup/actions/use-entity-action-hotkeys.ts
@@ -143,8 +143,8 @@ export const useEntityActionHotkeys = (
       const soupViewTab = options.activeSoupViewTab?.();
 
       if (
-        soupViewTab &&
-        isListViewID(splitContentId) &&
+        !soupViewTab ||
+        !isListViewID(splitContentId) ||
         !canExecuteMarkDoneOnView(splitContentId, soupViewTab)
       )
         return false;

--- a/js/app/packages/app/component/next-soup/actions/use-entity-action-hotkeys.ts
+++ b/js/app/packages/app/component/next-soup/actions/use-entity-action-hotkeys.ts
@@ -27,7 +27,10 @@ import { SYSTEM_PROPERTY_IDS } from '@core/component/Properties/constants';
 import type { SplitHandle } from '@app/component/split-layout/layoutManager';
 import { openEntityInSplitFromUnifiedList } from '@app/component/next-soup/utils';
 import { onCleanup } from 'solid-js';
-import { isListViewID } from '@app/constants/list-views';
+import { isListViewID, type ListView } from '@app/constants/list-views';
+
+// Valid list views where the mark done hotkey can be run in
+const VALID_MARK_DONE_LIST_VIEWS: ListView[] = ['inbox', 'mail'];
 
 type UseEntityActionHotkeysOptions = {
   scopeId: string;
@@ -135,6 +138,15 @@ export const useEntityActionHotkeys = (
     },
     condition: () => {
       if (condition && !condition()) return false;
+
+      const splitContentId = splitHandle?.content().id;
+
+      if (
+        isListViewID(splitContentId) &&
+        !VALID_MARK_DONE_LIST_VIEWS.includes(splitContentId)
+      )
+        return false;
+
       const entities = getEntitiesForAction();
       return entities.length > 0 && entities.every(markDone.canExecute);
     },

--- a/js/app/packages/app/component/next-soup/soup-view/SoupEntityActionDrawer.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/SoupEntityActionDrawer.tsx
@@ -7,8 +7,10 @@ import { For, Show } from 'solid-js';
 import { createSoupEntityActions } from './create-soup-entity-actions';
 import { useSoupEntityActionDrawer } from './soup-entity-action-drawer-context';
 import { useSoupView } from './soup-view-context';
+import { useSplitPanelOrThrow } from '@app/component/split-layout/layoutUtils';
 
 export function SoupEntityActionDrawer() {
+  const panel = useSplitPanelOrThrow();
   const drawerState = useSoupEntityActionDrawer();
   const { activeTab } = useSoupView();
   const { buildActionGroups } = createSoupEntityActions();
@@ -22,7 +24,10 @@ export function SoupEntityActionDrawer() {
     const e = drawerState.entity();
     const s = drawerState.soup();
     if (!e || !s) return [];
-    return buildActionGroups([e], s, activeTab());
+    return buildActionGroups(s, [e], {
+      activeTab: activeTab(),
+      activeListView: panel.handle.content().id,
+    });
   };
 
   return (

--- a/js/app/packages/app/component/next-soup/soup-view/create-soup-entity-actions.ts
+++ b/js/app/packages/app/component/next-soup/soup-view/create-soup-entity-actions.ts
@@ -21,6 +21,8 @@ import { useUserId } from '@core/context/user';
 import { useAnalytics } from '@app/component/analytics-context';
 import { getChannelParams } from '@block-channel/utils/link';
 import { isMobile } from '@core/mobile/isMobile';
+import { canExecuteMarkDoneOnView } from '@app/component/next-soup/actions/make-mark-done-action';
+import { isListViewID } from '@app/constants/list-views';
 
 const SIGNAL_TABS = new Set<string | undefined>([
   undefined,
@@ -40,12 +42,17 @@ export type SoupEntityActionGroup = {
   items: SoupEntityActionItem[];
 };
 
+type BuildActionGroups = (
+  soup: SoupState,
+  entities: EntityData[],
+  context: {
+    activeListView: string;
+    activeTab: string | undefined;
+  }
+) => SoupEntityActionGroup[];
+
 export function createSoupEntityActions(): {
-  buildActionGroups: (
-    entities: EntityData[],
-    soup: SoupState,
-    activeTab: string | undefined
-  ) => SoupEntityActionGroup[];
+  buildActionGroups: BuildActionGroups;
 } {
   const analytics = useAnalytics();
   const userId = useUserId();
@@ -74,11 +81,11 @@ export function createSoupEntityActions(): {
   const markSenderSignalAction = makeMarkSenderSignalAction();
   const markSenderNoiseAction = makeMarkSenderNoiseAction();
 
-  const buildActionGroups = (
-    entities: EntityData[],
-    soup: SoupState,
-    activeTab: string | undefined
-  ): SoupEntityActionGroup[] => {
+  const buildActionGroups: BuildActionGroups = (
+    soup,
+    entities,
+    { activeTab, activeListView }
+  ) => {
     const canExecuteAll = (canExecute: (e: EntityData) => boolean) =>
       entities.length > 0 && entities.every(canExecute);
 
@@ -90,7 +97,12 @@ export function createSoupEntityActions(): {
     // Top group: Mark Done, Open in new split
     const topItems: SoupEntityActionItem[] = [];
 
-    if (canExecuteAll(markDone.canExecute)) {
+    if (
+      activeTab &&
+      isListViewID(activeListView) &&
+      canExecuteMarkDoneOnView(activeListView, activeTab) &&
+      canExecuteAll(markDone.canExecute)
+    ) {
       topItems.push({
         id: 'mark-done',
         label: 'Mark Done',

--- a/js/app/packages/app/component/next-soup/soup-view/soup-entity-actions-menu.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-entity-actions-menu.tsx
@@ -4,6 +4,7 @@ import { For, Show } from 'solid-js';
 import type { SoupState } from '../create-soup-state';
 import { createSoupEntityActions } from './create-soup-entity-actions';
 import { useSoupView } from './soup-view-context';
+import { useSplitPanelOrThrow } from '@app/component/split-layout/layoutUtils';
 
 interface SoupEntityActionsMenuProps {
   entities: EntityData[];
@@ -12,11 +13,15 @@ interface SoupEntityActionsMenuProps {
 }
 
 export const SoupEntityActionsMenu = (props: SoupEntityActionsMenuProps) => {
+  const panel = useSplitPanelOrThrow();
   const { activeTab } = useSoupView();
   const { buildActionGroups } = createSoupEntityActions();
 
   const groups = () =>
-    buildActionGroups(props.entities, props.soup, activeTab());
+    buildActionGroups(props.soup, props.entities, {
+      activeTab: activeTab(),
+      activeListView: panel.handle.content().id,
+    });
 
   const handleAction = async (onClick: () => void | Promise<void>) => {
     await onClick();

--- a/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
@@ -496,6 +496,7 @@ export const SoupViewList = (props: SoupViewListProps) => {
   useEntityActionHotkeys({
     scopeId: scopeId(),
     soup,
+    activeSoupViewTab: activeTab,
     splitHandle: panel.handle,
   });
 

--- a/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
@@ -113,6 +113,7 @@ import { LabelAndHotKey, Tooltip } from '@core/component/Tooltip';
 import SearchIcon from '@macro-icons/macro-magnifying-glass.svg';
 import type { SetPredicatesInput } from '@app/component/next-soup/filters/filter-store/predicates-store';
 import { VIEW_TAB_PRESETS } from '@app/component/app-sidebar/soup-filter-presets';
+import { canExecuteMarkDoneOnView } from '@app/component/next-soup/actions/make-mark-done-action';
 
 const useSoupNotificationInvalidators = () => {
   const notificationSource = useGlobalNotificationSource();
@@ -874,6 +875,16 @@ export const SoupViewList = (props: SoupViewListProps) => {
                         canSwipeLeft={(entityId) => {
                           const entity = entityById().get(entityId);
                           if (!entity) return false;
+
+                          const tab = activeTab();
+
+                          if (
+                            !tab ||
+                            !isListViewID(contentId) ||
+                            !canExecuteMarkDoneOnView(contentId, tab)
+                          )
+                            return false;
+
                           return markDoneAction.canExecute(entity.original);
                         }}
                         onSwipeLeft={(entityId) => {

--- a/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
@@ -879,9 +879,8 @@ export const SoupViewList = (props: SoupViewListProps) => {
                           const tab = activeTab();
 
                           if (
-                            !tab ||
                             !isListViewID(contentId) ||
-                            !canExecuteMarkDoneOnView(contentId, tab)
+                            (tab && !canExecuteMarkDoneOnView(contentId, tab))
                           )
                             return false;
 


### PR DESCRIPTION
This PR updates it so you can only mark entities as done in inbox signal and some mail tab views