### PR TITLE
feat(search): go-to navigation for call record hits

### DIFF
--- a/js/app/packages/app/component/next-soup/utils.ts
+++ b/js/app/packages/app/component/next-soup/utils.ts
@@ -314,9 +314,6 @@ export const openEntityInSplitFromUnifiedList = async (
   const { openInNewSplit, splitHandle, mergeHistory } = options;
   let { location } = options;
 
-  // For snippet entities (email, call), fall back to the rendered snippet
-  // hit's location so the row click lands on the previewed match rather
-  // than the entity's default landing position.
   if (!location && isSnippetEntity(entity)) {
     location = getSnippetHit(entity)?.location;
   }

--- a/js/app/packages/app/component/next-soup/utils.ts
+++ b/js/app/packages/app/component/next-soup/utils.ts
@@ -230,10 +230,10 @@ export const openEntityInNewTab = ({
         }
         break;
       case 'call_record':
-        if (location.sequenceNum !== undefined) {
+        if (location.transcriptId) {
           entityUrl.searchParams.set(
-            CALL_PARAMS.segmentSeq,
-            location.sequenceNum.toString()
+            CALL_PARAMS.transcriptId,
+            location.transcriptId
           );
         }
         break;
@@ -338,7 +338,7 @@ export const openEntityInSplitFromUnifiedList = async (
   } else if (entity.type === 'channel_message') {
     params = getChannelParams(entity.messageId, entity.threadId);
   } else if (entity.type === 'call' && location?.type === 'call_record') {
-    params = { [CALL_PARAMS.segmentSeq]: location.sequenceNum.toString() };
+    params = { [CALL_PARAMS.transcriptId]: location.transcriptId };
   }
 
   splitManager.openWithSplit(
@@ -429,7 +429,7 @@ async function navigateToLocation(
     }
     case 'call_record': {
       await blockHandle.goToLocationFromParams({
-        [CALL_PARAMS.segmentSeq]: location.sequenceNum.toString(),
+        [CALL_PARAMS.transcriptId]: location.transcriptId,
       });
       break;
     }

--- a/js/app/packages/app/component/next-soup/utils.ts
+++ b/js/app/packages/app/component/next-soup/utils.ts
@@ -309,7 +309,17 @@ export const openEntityInSplitFromUnifiedList = async (
   entity: EntityData,
   options: OpenEntityOptions
 ): Promise<void> => {
-  const { openInNewSplit, location, splitHandle, mergeHistory } = options;
+  const { openInNewSplit, splitHandle, mergeHistory } = options;
+  let { location } = options;
+
+  // For call entity rows, fall back to the first content hit so the row click
+  // lands on the segment that's previewed inline rather than the call's start.
+  if (!location && entity.type === 'call' && isSearchEntity(entity)) {
+    const firstHit = entity.search.contentHitData?.[0];
+    if (firstHit?.location?.type === 'call_record') {
+      location = firstHit.location;
+    }
+  }
 
   // Get dependencies internally
   const splitManager = globalSplitManager();

--- a/js/app/packages/app/component/next-soup/utils.ts
+++ b/js/app/packages/app/component/next-soup/utils.ts
@@ -1,5 +1,6 @@
 import type { BlockOrchestrator } from '@core/orchestrator';
 import type { DateValue } from '@core/util/date';
+import { URL_PARAMS as CALL_PARAMS } from '@block-call/constants';
 import { URL_PARAMS as CHANNEL_PARAMS } from '@block-channel/constants';
 import { URL_PARAMS as EMAIL_PARAMS } from '@block-email/constants';
 import { URL_PARAMS as MD_PARAMS } from '@block-md/constants';
@@ -226,6 +227,14 @@ export const openEntityInNewTab = ({
           entityUrl.searchParams.set('search_snippet', location.searchSnippet);
         }
         break;
+      case 'call_record':
+        if (location.sequenceNum !== undefined) {
+          entityUrl.searchParams.set(
+            CALL_PARAMS.segmentSeq,
+            location.sequenceNum.toString()
+          );
+        }
+        break;
     }
   }
 
@@ -318,6 +327,8 @@ export const openEntityInSplitFromUnifiedList = async (
     params = getChannelParams(location.messageId, location.threadId);
   } else if (entity.type === 'channel_message') {
     params = getChannelParams(entity.messageId, entity.threadId);
+  } else if (entity.type === 'call' && location?.type === 'call_record') {
+    params = { [CALL_PARAMS.segmentSeq]: location.sequenceNum.toString() };
   }
 
   splitManager.openWithSplit(
@@ -403,6 +414,12 @@ async function navigateToLocation(
           location.highlightTerms
         ),
         [PDF_PARAMS.searchSnippet]: location.searchSnippet,
+      });
+      break;
+    }
+    case 'call_record': {
+      await blockHandle.goToLocationFromParams({
+        [CALL_PARAMS.segmentSeq]: location.sequenceNum.toString(),
       });
       break;
     }

--- a/js/app/packages/app/component/next-soup/utils.ts
+++ b/js/app/packages/app/component/next-soup/utils.ts
@@ -11,7 +11,9 @@ import { fileTypeToBlockName } from '@core/constant/allBlocks';
 import { waitForFrames } from '@core/util/sleep';
 import {
   type EntityData,
+  getSnippetHit,
   isSearchEntity,
+  isSnippetEntity,
   type SearchLocation,
   type WithSearch,
 } from '@entity';
@@ -312,13 +314,11 @@ export const openEntityInSplitFromUnifiedList = async (
   const { openInNewSplit, splitHandle, mergeHistory } = options;
   let { location } = options;
 
-  // For call entity rows, fall back to the first content hit so the row click
-  // lands on the segment that's previewed inline rather than the call's start.
-  if (!location && entity.type === 'call' && isSearchEntity(entity)) {
-    const firstHit = entity.search.contentHitData?.[0];
-    if (firstHit?.location?.type === 'call_record') {
-      location = firstHit.location;
-    }
+  // For snippet entities (email, call), fall back to the rendered snippet
+  // hit's location so the row click lands on the previewed match rather
+  // than the entity's default landing position.
+  if (!location && isSnippetEntity(entity)) {
+    location = getSnippetHit(entity)?.location;
   }
 
   // Get dependencies internally

--- a/js/app/packages/block-call/component/CallBlockAdapter.tsx
+++ b/js/app/packages/block-call/component/CallBlockAdapter.tsx
@@ -1,8 +1,13 @@
+import { URL_PARAMS } from '@block-call/constants';
 import { useBlockId } from '@core/block';
 import Unauthorized from '@core/component/AccessErrorViews/Unauthorized';
+import { createMethodRegistration } from '@core/orchestrator';
+import { blockHandleSignal } from '@core/signal/load';
 import { MaybeResultError } from '@core/util/maybeResult';
 import { useCallRecordQuery } from '@queries/call/call';
-import { Match, Switch } from 'solid-js';
+import { globalSplitManager } from '@app/signal/splitLayout';
+import { useSearchParams } from '@solidjs/router';
+import { createSignal, Match, Switch } from 'solid-js';
 import { CallRecordingBody } from './CallRecording/CallRecordingBody';
 import { CallRecordingSplitHeaderLoading } from './CallRecording/CallRecordingSplitHeader';
 
@@ -13,15 +18,63 @@ function isUnauthorized(error: Error | null): boolean {
   return false;
 }
 
-export function CallBlockAdapter() {
+export type CallBlockProps = {
+  [URL_PARAMS.segmentSeq]?: string;
+};
+
+export type CallTranscriptTarget = { sequenceNum: number; gen: number };
+
+function parseSequenceNum(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+export function CallBlockAdapter(props: CallBlockProps) {
   const callId = useBlockId();
   const callRecord = useCallRecordQuery(() => callId);
+  const blockHandle = blockHandleSignal.get;
+  const [searchParams] = useSearchParams();
+
+  const initialSequenceNum = (): number | undefined => {
+    const fromProps = parseSequenceNum(props[URL_PARAMS.segmentSeq]);
+    if (fromProps !== undefined) return fromProps;
+    const isSingleSplit = globalSplitManager()?.splits().length === 1;
+    if (!isSingleSplit) return undefined;
+    return parseSequenceNum(
+      searchParams[URL_PARAMS.segmentSeq] as string | undefined
+    );
+  };
+
+  const [transcriptTarget, setTranscriptTarget] = createSignal<
+    CallTranscriptTarget | undefined
+  >(
+    initialSequenceNum() !== undefined
+      ? { sequenceNum: initialSequenceNum()!, gen: 0 }
+      : undefined
+  );
+
+  createMethodRegistration(blockHandle, {
+    goToLocationFromParams: async (params: CallBlockProps) => {
+      const next = parseSequenceNum(params[URL_PARAMS.segmentSeq]);
+      if (next === undefined) return;
+      setTranscriptTarget((prev) => ({
+        sequenceNum: next,
+        gen: (prev?.gen ?? 0) + 1,
+      }));
+    },
+  });
 
   return (
     <div class="h-full flex flex-col @container">
       <Switch>
         <Match when={callRecord.data}>
-          {(data) => <CallRecordingBody data={data} />}
+          {(data) => (
+            <CallRecordingBody
+              data={data}
+              transcriptTarget={transcriptTarget}
+            />
+          )}
         </Match>
         <Match when={callRecord.isLoading}>
           <CallRecordingSplitHeaderLoading />

--- a/js/app/packages/block-call/component/CallBlockAdapter.tsx
+++ b/js/app/packages/block-call/component/CallBlockAdapter.tsx
@@ -30,19 +30,19 @@ export function CallBlockAdapter(props: CallBlockProps) {
   const blockHandle = blockHandleSignal.get;
   const [searchParams] = useSearchParams();
 
-  const initialTranscriptId = (): string | undefined => {
+  const initialTranscriptId = ((): string | undefined => {
     const fromProps = props[URL_PARAMS.transcriptId];
     if (fromProps) return fromProps;
     const isSingleSplit = globalSplitManager()?.splits().length === 1;
     if (!isSingleSplit) return undefined;
     return searchParams[URL_PARAMS.transcriptId] as string | undefined;
-  };
+  })();
 
   const [transcriptTarget, setTranscriptTarget] = createSignal<
     CallTranscriptTarget | undefined
   >(
-    initialTranscriptId()
-      ? { transcriptId: initialTranscriptId()!, gen: 0 }
+    initialTranscriptId
+      ? { transcriptId: initialTranscriptId, gen: 0 }
       : undefined
   );
 

--- a/js/app/packages/block-call/component/CallBlockAdapter.tsx
+++ b/js/app/packages/block-call/component/CallBlockAdapter.tsx
@@ -19,16 +19,10 @@ function isUnauthorized(error: Error | null): boolean {
 }
 
 export type CallBlockProps = {
-  [URL_PARAMS.segmentSeq]?: string;
+  [URL_PARAMS.transcriptId]?: string;
 };
 
-export type CallTranscriptTarget = { sequenceNum: number; gen: number };
-
-function parseSequenceNum(value: string | undefined): number | undefined {
-  if (!value) return undefined;
-  const n = Number(value);
-  return Number.isFinite(n) ? n : undefined;
-}
+export type CallTranscriptTarget = { transcriptId: string; gen: number };
 
 export function CallBlockAdapter(props: CallBlockProps) {
   const callId = useBlockId();
@@ -36,30 +30,28 @@ export function CallBlockAdapter(props: CallBlockProps) {
   const blockHandle = blockHandleSignal.get;
   const [searchParams] = useSearchParams();
 
-  const initialSequenceNum = (): number | undefined => {
-    const fromProps = parseSequenceNum(props[URL_PARAMS.segmentSeq]);
-    if (fromProps !== undefined) return fromProps;
+  const initialTranscriptId = (): string | undefined => {
+    const fromProps = props[URL_PARAMS.transcriptId];
+    if (fromProps) return fromProps;
     const isSingleSplit = globalSplitManager()?.splits().length === 1;
     if (!isSingleSplit) return undefined;
-    return parseSequenceNum(
-      searchParams[URL_PARAMS.segmentSeq] as string | undefined
-    );
+    return searchParams[URL_PARAMS.transcriptId] as string | undefined;
   };
 
   const [transcriptTarget, setTranscriptTarget] = createSignal<
     CallTranscriptTarget | undefined
   >(
-    initialSequenceNum() !== undefined
-      ? { sequenceNum: initialSequenceNum()!, gen: 0 }
+    initialTranscriptId()
+      ? { transcriptId: initialTranscriptId()!, gen: 0 }
       : undefined
   );
 
   createMethodRegistration(blockHandle, {
     goToLocationFromParams: async (params: CallBlockProps) => {
-      const next = parseSequenceNum(params[URL_PARAMS.segmentSeq]);
-      if (next === undefined) return;
+      const next = params[URL_PARAMS.transcriptId];
+      if (!next) return;
       setTranscriptTarget((prev) => ({
-        sequenceNum: next,
+        transcriptId: next,
         gen: (prev?.gen ?? 0) + 1,
       }));
     },

--- a/js/app/packages/block-call/component/CallRecording/CallRecordingBody.tsx
+++ b/js/app/packages/block-call/component/CallRecording/CallRecordingBody.tsx
@@ -43,6 +43,14 @@ export function CallRecordingBody(props: {
     sortTranscriptSegments(record().transcript)
   );
 
+  // The recording starts when the call started, not when the first
+  // transcript segment was spoken — anchor video offsets to call.startedAt
+  // so search hits and the transcript view agree.
+  const timelineStartMs = createMemo(() => {
+    const ms = new Date(record().startedAt).getTime();
+    return Number.isFinite(ms) ? ms : null;
+  });
+
   const [transcriptOpen, setTranscriptOpen] = createSignal(true);
   const [participantsOpen, setParticipantsOpen] = createSignal(false);
   const [layoutDefaultsSeeded, setLayoutDefaultsSeeded] = createSignal(false);
@@ -79,6 +87,7 @@ export function CallRecordingBody(props: {
     getActiveTranscriptSequenceNum(
       sortedTranscript(),
       playbackSeconds(),
+      timelineStartMs(),
       allowFutureLead()
     )
   );
@@ -103,15 +112,11 @@ export function CallRecordingBody(props: {
   };
 
   const goToTranscriptSegment = (sequenceNum: number) => {
-    const segments = sortedTranscript();
-    const segment = segments.find((s) => s.sequenceNum === sequenceNum);
-    if (!segment) return;
-    const firstStartMs =
-      segments.length > 0 ? new Date(segments[0].startedAt).getTime() : NaN;
-    const seconds = getSegmentVideoSeconds(
-      segment,
-      Number.isFinite(firstStartMs) ? firstStartMs : null
+    const segment = sortedTranscript().find(
+      (s) => s.sequenceNum === sequenceNum
     );
+    if (!segment) return;
+    const seconds = getSegmentVideoSeconds(segment, timelineStartMs());
     if (seconds === null) return;
 
     setPlaybackSeconds(seconds);
@@ -244,6 +249,7 @@ export function CallRecordingBody(props: {
             transcriptOpen={transcriptOpen}
             participantsOpen={participantsOpen}
             activeSequenceNum={activeSequenceNum}
+            timelineStartMs={timelineStartMs}
             videoSeekGeneration={videoSeekGeneration}
             onToggleTranscript={toggleTranscript}
             onToggleParticipants={toggleParticipants}

--- a/js/app/packages/block-call/component/CallRecording/CallRecordingBody.tsx
+++ b/js/app/packages/block-call/component/CallRecording/CallRecordingBody.tsx
@@ -4,14 +4,17 @@ import {
   createEffect,
   createMemo,
   createSignal,
+  on,
   onCleanup,
   untrack,
 } from 'solid-js';
 import { cn } from '@ui/utils/classname';
 import {
   getActiveTranscriptSequenceNum,
+  getSegmentVideoSeconds,
   sortTranscriptSegments,
 } from '../transcript-playback';
+import type { CallTranscriptTarget } from '../CallBlockAdapter';
 import {
   CallRecordingMediaColumn,
   type CallRecordingTimeUpdateSource,
@@ -25,7 +28,10 @@ import {
   shouldCoalesceSeekGenerationBump,
 } from './call-recording-utils';
 
-export function CallRecordingBody(props: { data: Accessor<CallRecord> }) {
+export function CallRecordingBody(props: {
+  data: Accessor<CallRecord>;
+  transcriptTarget?: Accessor<CallTranscriptTarget | undefined>;
+}) {
   const record = props.data;
   const hasTranscripts = createMemo(() => record().transcript.length > 0);
   const [playbackSeconds, setPlaybackSeconds] = createSignal(0);
@@ -95,6 +101,41 @@ export function CallRecordingBody(props: { data: Accessor<CallRecord> }) {
     setPlaybackSeconds(targetSeconds);
     setAllowFutureLead(false);
   };
+
+  const goToTranscriptSegment = (sequenceNum: number) => {
+    const segments = sortedTranscript();
+    const segment = segments.find((s) => s.sequenceNum === sequenceNum);
+    if (!segment) return;
+    const firstStartMs =
+      segments.length > 0 ? new Date(segments[0].startedAt).getTime() : NaN;
+    const seconds = getSegmentVideoSeconds(
+      segment,
+      Number.isFinite(firstStartMs) ? firstStartMs : null
+    );
+    if (seconds === null) return;
+
+    setPlaybackSeconds(seconds);
+    setAllowFutureLead(false);
+    bumpVideoSeekGeneration(seconds);
+
+    const video = videoRef();
+    if (video) {
+      const maxTime = Number.isFinite(video.duration)
+        ? video.duration
+        : seconds;
+      video.currentTime = Math.max(0, Math.min(seconds, maxTime));
+    }
+  };
+
+  createEffect(
+    on(
+      () => props.transcriptTarget?.(),
+      (target) => {
+        if (!target) return;
+        goToTranscriptSegment(target.sequenceNum);
+      }
+    )
+  );
 
   const toggleTranscript = () => {
     setTranscriptOpen((open) => {

--- a/js/app/packages/block-call/component/CallRecording/CallRecordingBody.tsx
+++ b/js/app/packages/block-call/component/CallRecording/CallRecordingBody.tsx
@@ -134,6 +134,11 @@ export function CallRecordingBody(props: {
       () => props.transcriptTarget?.(),
       (target) => {
         if (!target) return;
+        // If the user previously collapsed the transcript, opening the panel
+        // here is what makes the deep-linked row actually visible. The scroll
+        // container's ResizeObserver re-runs `scrollActiveIntoView` after the
+        // open animation, so no manual defer is needed.
+        if (hasTranscripts()) setTranscriptOpen(true);
         goToTranscriptSegment(target.transcriptId);
       }
     )

--- a/js/app/packages/block-call/component/CallRecording/CallRecordingBody.tsx
+++ b/js/app/packages/block-call/component/CallRecording/CallRecordingBody.tsx
@@ -102,13 +102,21 @@ export function CallRecordingBody(props: {
   };
 
   const seekToSeconds = (seconds: number) => {
+    if (!Number.isFinite(seconds)) return;
     const video = videoRef();
-    if (!video || !Number.isFinite(seconds)) return;
-    const maxTime = Number.isFinite(video.duration) ? video.duration : seconds;
+    const maxTime = Number.isFinite(video?.duration ?? Number.NaN)
+      ? (video!.duration as number)
+      : seconds;
     const targetSeconds = Math.max(0, Math.min(seconds, maxTime));
-    video.currentTime = targetSeconds;
+
     setPlaybackSeconds(targetSeconds);
     setAllowFutureLead(false);
+    // Explicit bump so transcript-only calls (no video / video not loaded)
+    // still scroll the active row into view. Deduped against the `seeked`
+    // event that fires when video is present.
+    bumpVideoSeekGeneration(targetSeconds);
+
+    if (video) video.currentTime = targetSeconds;
   };
 
   const goToTranscriptSegment = (transcriptId: string) => {
@@ -118,18 +126,7 @@ export function CallRecordingBody(props: {
     if (!segment) return;
     const seconds = getSegmentVideoSeconds(segment, timelineStartMs());
     if (seconds === null) return;
-
-    setPlaybackSeconds(seconds);
-    setAllowFutureLead(false);
-    bumpVideoSeekGeneration(seconds);
-
-    const video = videoRef();
-    if (video) {
-      const maxTime = Number.isFinite(video.duration)
-        ? video.duration
-        : seconds;
-      video.currentTime = Math.max(0, Math.min(seconds, maxTime));
-    }
+    seekToSeconds(seconds);
   };
 
   createEffect(

--- a/js/app/packages/block-call/component/CallRecording/CallRecordingBody.tsx
+++ b/js/app/packages/block-call/component/CallRecording/CallRecordingBody.tsx
@@ -111,9 +111,9 @@ export function CallRecordingBody(props: {
     setAllowFutureLead(false);
   };
 
-  const goToTranscriptSegment = (sequenceNum: number) => {
+  const goToTranscriptSegment = (transcriptId: string) => {
     const segment = sortedTranscript().find(
-      (s) => s.sequenceNum === sequenceNum
+      (s) => s.transcriptId === transcriptId
     );
     if (!segment) return;
     const seconds = getSegmentVideoSeconds(segment, timelineStartMs());
@@ -137,7 +137,7 @@ export function CallRecordingBody(props: {
       () => props.transcriptTarget?.(),
       (target) => {
         if (!target) return;
-        goToTranscriptSegment(target.sequenceNum);
+        goToTranscriptSegment(target.transcriptId);
       }
     )
   );

--- a/js/app/packages/block-call/component/CallRecording/CallRecordingBody.tsx
+++ b/js/app/packages/block-call/component/CallRecording/CallRecordingBody.tsx
@@ -43,9 +43,6 @@ export function CallRecordingBody(props: {
     sortTranscriptSegments(record().transcript)
   );
 
-  // The recording starts when the call started, not when the first
-  // transcript segment was spoken — anchor video offsets to call.startedAt
-  // so search hits and the transcript view agree.
   const timelineStartMs = createMemo(() => {
     const ms = new Date(record().startedAt).getTime();
     return Number.isFinite(ms) ? ms : null;
@@ -111,9 +108,6 @@ export function CallRecordingBody(props: {
 
     setPlaybackSeconds(targetSeconds);
     setAllowFutureLead(false);
-    // Explicit bump so transcript-only calls (no video / video not loaded)
-    // still scroll the active row into view. Deduped against the `seeked`
-    // event that fires when video is present.
     bumpVideoSeekGeneration(targetSeconds);
 
     if (video) video.currentTime = targetSeconds;
@@ -134,10 +128,6 @@ export function CallRecordingBody(props: {
       () => props.transcriptTarget?.(),
       (target) => {
         if (!target) return;
-        // If the user previously collapsed the transcript, opening the panel
-        // here is what makes the deep-linked row actually visible. The scroll
-        // container's ResizeObserver re-runs `scrollActiveIntoView` after the
-        // open animation, so no manual defer is needed.
         if (hasTranscripts()) setTranscriptOpen(true);
         goToTranscriptSegment(target.transcriptId);
       }

--- a/js/app/packages/block-call/component/CallRecording/CallRecordingTranscriptColumn.tsx
+++ b/js/app/packages/block-call/component/CallRecording/CallRecordingTranscriptColumn.tsx
@@ -16,6 +16,7 @@ export function CallRecordingTranscriptColumn(props: {
   transcriptOpen: Accessor<boolean>;
   participantsOpen: Accessor<boolean>;
   activeSequenceNum: Accessor<number | null>;
+  timelineStartMs: Accessor<number | null>;
   videoSeekGeneration: Accessor<number>;
   onToggleTranscript: () => void;
   onToggleParticipants: () => void;
@@ -58,6 +59,7 @@ export function CallRecordingTranscriptColumn(props: {
             <CallTranscript
               transcript={props.record().transcript}
               channelId={props.record().channelId}
+              timelineStartMs={props.timelineStartMs()}
               activeSequenceNum={props.activeSequenceNum()}
               videoSeekGeneration={props.videoSeekGeneration()}
               onSeekToSeconds={props.onSeekToSeconds}

--- a/js/app/packages/block-call/component/CallTranscript.tsx
+++ b/js/app/packages/block-call/component/CallTranscript.tsx
@@ -13,10 +13,8 @@ import {
   onCleanup,
   Show,
 } from 'solid-js';
-import {
-  formatVideoTimestamp,
-  getSegmentVideoSeconds,
-} from './transcript-playback';
+import { formatVideoTimestamp } from '@core/util/duration';
+import { getSegmentVideoSeconds } from './transcript-playback';
 
 // Match the channel message grouping window (5 minutes).
 const GROUPING_WINDOW_MS = 5 * 60 * 1000;

--- a/js/app/packages/block-call/component/CallTranscript.tsx
+++ b/js/app/packages/block-call/component/CallTranscript.tsx
@@ -148,7 +148,6 @@ function GroupedTranscriptSegmentRow(props: {
 export function CallTranscript(props: {
   transcript: CallRecordTranscriptSegment[];
   channelId: string;
-  /** Anchor for video offsets — the moment the recording starts (call.startedAt). */
   timelineStartMs: number | null;
   activeSequenceNum?: number | null;
   /** Bumps when the user seeks via the native video controls (deduped in CallBlockAdapter). */

--- a/js/app/packages/block-call/component/CallTranscript.tsx
+++ b/js/app/packages/block-call/component/CallTranscript.tsx
@@ -148,6 +148,8 @@ function GroupedTranscriptSegmentRow(props: {
 export function CallTranscript(props: {
   transcript: CallRecordTranscriptSegment[];
   channelId: string;
+  /** Anchor for video offsets — the moment the recording starts (call.startedAt). */
+  timelineStartMs: number | null;
   activeSequenceNum?: number | null;
   /** Bumps when the user seeks via the native video controls (deduped in CallBlockAdapter). */
   videoSeekGeneration?: number;
@@ -168,13 +170,7 @@ export function CallTranscript(props: {
       segment,
       groupedWithPrevious: shouldGroupWithPrevious(segment, sorted[index - 1]),
     }));
-    if (sorted.length === 0) return { items, timelineStartMs: null };
-
-    const firstStartMs = new Date(sorted[0].startedAt).getTime();
-    return {
-      items,
-      timelineStartMs: Number.isFinite(firstStartMs) ? firstStartMs : null,
-    };
+    return { items };
   });
 
   const scrollActiveIntoView = (
@@ -349,7 +345,7 @@ export function CallTranscript(props: {
                         isActive={
                           item.segment.sequenceNum === props.activeSequenceNum
                         }
-                        timelineStartMs={transcriptMeta().timelineStartMs}
+                        timelineStartMs={props.timelineStartMs}
                         onSeekToSeconds={props.onSeekToSeconds}
                       />
                     </div>
@@ -362,7 +358,7 @@ export function CallTranscript(props: {
                       isActive={
                         item.segment.sequenceNum === props.activeSequenceNum
                       }
-                      timelineStartMs={transcriptMeta().timelineStartMs}
+                      timelineStartMs={props.timelineStartMs}
                       onSeekToSeconds={props.onSeekToSeconds}
                     />
                   </div>

--- a/js/app/packages/block-call/component/transcript-playback.ts
+++ b/js/app/packages/block-call/component/transcript-playback.ts
@@ -1,5 +1,7 @@
 import type { CallRecordTranscriptSegment } from '@service-storage/generated/schemas/callRecordTranscriptSegment';
 
+export { formatVideoTimestamp } from '@core/util/duration';
+
 export function sortTranscriptSegments(
   transcript: CallRecordTranscriptSegment[]
 ): CallRecordTranscriptSegment[] {
@@ -41,17 +43,6 @@ export function getActiveTranscriptSequenceNum(
   }
 
   return activeSequenceNum;
-}
-
-export function formatVideoTimestamp(totalSeconds: number): string {
-  const clamped = Math.max(0, Math.floor(totalSeconds));
-  const hours = Math.floor(clamped / 3600);
-  const minutes = Math.floor((clamped % 3600) / 60);
-  const seconds = clamped % 60;
-  if (hours > 0) {
-    return `${hours}:${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
-  }
-  return `${minutes}:${String(seconds).padStart(2, '0')}`;
 }
 
 export function getSegmentVideoSeconds(

--- a/js/app/packages/block-call/component/transcript-playback.ts
+++ b/js/app/packages/block-call/component/transcript-playback.ts
@@ -11,16 +11,20 @@ export function sortTranscriptSegments(
 export function getActiveTranscriptSequenceNum(
   sortedTranscript: CallRecordTranscriptSegment[],
   playbackSeconds: number,
+  timelineStartMs: number | null,
   allowFutureLead = true
 ): number | null {
-  if (sortedTranscript.length === 0 || playbackSeconds < 0) return null;
-  const firstStartMs = new Date(sortedTranscript[0].startedAt).getTime();
-  if (!Number.isFinite(firstStartMs)) return null;
+  if (
+    sortedTranscript.length === 0 ||
+    playbackSeconds < 0 ||
+    timelineStartMs === null ||
+    !Number.isFinite(timelineStartMs)
+  )
+    return null;
 
   // Bias slightly earlier so short segments feel responsive.
   const ACTIVE_LEAD_MS = 250;
-  const rawTimelineMs = firstStartMs + playbackSeconds * 1000;
-  if (rawTimelineMs < firstStartMs) return null;
+  const rawTimelineMs = timelineStartMs + playbackSeconds * 1000;
   const currentTimelineMs = allowFutureLead
     ? rawTimelineMs + ACTIVE_LEAD_MS
     : rawTimelineMs;

--- a/js/app/packages/block-call/component/transcript-playback.ts
+++ b/js/app/packages/block-call/component/transcript-playback.ts
@@ -1,7 +1,5 @@
 import type { CallRecordTranscriptSegment } from '@service-storage/generated/schemas/callRecordTranscriptSegment';
 
-export { formatVideoTimestamp } from '@core/util/duration';
-
 export function sortTranscriptSegments(
   transcript: CallRecordTranscriptSegment[]
 ): CallRecordTranscriptSegment[] {

--- a/js/app/packages/block-call/constants.ts
+++ b/js/app/packages/block-call/constants.ts
@@ -1,3 +1,3 @@
 export const URL_PARAMS = {
-  segmentSeq: 'call_segment_seq',
+  transcriptId: 'call_transcript_id',
 };

--- a/js/app/packages/block-call/constants.ts
+++ b/js/app/packages/block-call/constants.ts
@@ -1,0 +1,3 @@
+export const URL_PARAMS = {
+  segmentSeq: 'call_segment_seq',
+};

--- a/js/app/packages/core/util/duration.ts
+++ b/js/app/packages/core/util/duration.ts
@@ -1,0 +1,14 @@
+/**
+ * Formats a duration as `m:ss` (or `h:mm:ss` past one hour). Used for
+ * video / call playback offsets.
+ */
+export function formatVideoTimestamp(totalSeconds: number): string {
+  const clamped = Math.max(0, Math.floor(totalSeconds));
+  const hours = Math.floor(clamped / 3600);
+  const minutes = Math.floor((clamped % 3600) / 60);
+  const seconds = clamped % 60;
+  if (hours > 0) {
+    return `${hours}:${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+  }
+  return `${minutes}:${String(seconds).padStart(2, '0')}`;
+}

--- a/js/app/packages/core/util/duration.ts
+++ b/js/app/packages/core/util/duration.ts
@@ -1,7 +1,3 @@
-/**
- * Formats a duration as `m:ss` (or `h:mm:ss` past one hour). Used for
- * video / call playback offsets.
- */
 export function formatVideoTimestamp(totalSeconds: number): string {
   const clamped = Math.max(0, Math.floor(totalSeconds));
   const hours = Math.floor(clamped / 3600);

--- a/js/app/packages/core/util/searchHighlight.test.ts
+++ b/js/app/packages/core/util/searchHighlight.test.ts
@@ -158,6 +158,28 @@ describe('windowSearchMatch', () => {
       'no highlight here'
     );
   });
+
+  it('donates unused front budget to back when highlight is at start', () => {
+    // chars=10, total budget 20. Front is empty so back should keep ~20.
+    const longSuffix = 'b '.repeat(40);
+    const text = `<macro_em>match</macro_em> ${longSuffix}`;
+    const result = windowSearchMatch(text, 10);
+    const visibleAfter = result
+      .slice(result.lastIndexOf('</macro_em>') + '</macro_em>'.length)
+      .trim().length;
+    expect(visibleAfter).toBeGreaterThan(10);
+    expect(visibleAfter).toBeLessThanOrEqual(20);
+  });
+
+  it('donates unused back budget to front when highlight is at end', () => {
+    const longPrefix = 'a '.repeat(40);
+    const text = `${longPrefix}<macro_em>match</macro_em>`;
+    const result = windowSearchMatch(text, 10);
+    const visibleBefore = result.slice(0, result.indexOf('<macro_em>')).trim()
+      .length;
+    expect(visibleBefore).toBeGreaterThan(10);
+    expect(visibleBefore).toBeLessThanOrEqual(20);
+  });
 });
 
 describe('parseSearchHighlightSegments', () => {

--- a/js/app/packages/core/util/searchHighlight.test.ts
+++ b/js/app/packages/core/util/searchHighlight.test.ts
@@ -160,7 +160,6 @@ describe('windowSearchMatch', () => {
   });
 
   it('donates unused front budget to back when highlight is at start', () => {
-    // chars=10, total budget 20. Front is empty so back should keep ~20.
     const longSuffix = 'b '.repeat(40);
     const text = `<macro_em>match</macro_em> ${longSuffix}`;
     const result = windowSearchMatch(text, 10);

--- a/js/app/packages/core/util/searchHighlight.test.ts
+++ b/js/app/packages/core/util/searchHighlight.test.ts
@@ -175,8 +175,9 @@ describe('windowSearchMatch', () => {
     const longPrefix = 'a '.repeat(40);
     const text = `${longPrefix}<macro_em>match</macro_em>`;
     const result = windowSearchMatch(text, 10);
-    const visibleBefore = result.slice(0, result.indexOf('<macro_em>')).trim()
-      .length;
+    const visibleBefore = result
+      .slice(0, result.indexOf('<macro_em>'))
+      .trim().length;
     expect(visibleBefore).toBeGreaterThan(10);
     expect(visibleBefore).toBeLessThanOrEqual(20);
   });

--- a/js/app/packages/core/util/searchHighlight.test.ts
+++ b/js/app/packages/core/util/searchHighlight.test.ts
@@ -164,6 +164,7 @@ describe('windowSearchMatch', () => {
     const longSuffix = 'b '.repeat(40);
     const text = `<macro_em>match</macro_em> ${longSuffix}`;
     const result = windowSearchMatch(text, 10);
+    expect(result).toContain('<macro_em>match</macro_em>');
     const visibleAfter = result
       .slice(result.lastIndexOf('</macro_em>') + '</macro_em>'.length)
       .trim().length;
@@ -175,6 +176,7 @@ describe('windowSearchMatch', () => {
     const longPrefix = 'a '.repeat(40);
     const text = `${longPrefix}<macro_em>match</macro_em>`;
     const result = windowSearchMatch(text, 10);
+    expect(result).toContain('<macro_em>match</macro_em>');
     const visibleBefore = result
       .slice(0, result.indexOf('<macro_em>'))
       .trim().length;

--- a/js/app/packages/core/util/searchHighlight.tsx
+++ b/js/app/packages/core/util/searchHighlight.tsx
@@ -96,27 +96,43 @@ export function highlightTermsInText(text: string, terms: string[]): string {
 /**
  * Creates a single-line window around the first <macro_em> highlight.
  * - Collapses newlines and invisible chars into a clean single line
- * - If the highlight is within `chars` of the start, keeps the start
- * - Otherwise, trims the front to show context before the highlight
- * - Trims the end to keep total visible length reasonable
+ * - Targets ~`2 * chars` total visible characters around the highlight
+ * - When one side is shorter than `chars`, donates the unused budget to
+ *   the other side so the rendered row uses the full available width
  *
  * @param text - Content with <macro_em> tags
- * @param chars - Max visible characters to show on each side of the highlight
+ * @param chars - Half-width visible character budget (each side of highlight)
  */
 export function windowSearchMatch(text: string, chars: number): string {
   let line = stripInvisibleChars(text);
 
   const macroOpen = '<macro_em>';
+  const macroClose = '</macro_em>';
   const tagIndex = line.indexOf(macroOpen);
   if (tagIndex === -1) return line;
+
+  const lastCloseIndex = line.lastIndexOf(macroClose);
 
   const visibleBefore = line
     .slice(0, tagIndex)
     .replace(/<\/?macro_em>/g, '').length;
+  const visibleAfter =
+    lastCloseIndex === -1
+      ? 0
+      : line
+          .slice(lastCloseIndex + macroClose.length)
+          .replace(/<\/?macro_em>/g, '')
+          .replace(INVISIBLE_CHARS_RE, '').length;
+
+  // Half-budget is `chars`; rebalance so unused space on one side goes to
+  // the other (otherwise short-prefix or short-suffix rows under-fill).
+  const totalBudget = chars * 2;
+  const frontKeep = Math.max(chars, totalBudget - visibleAfter);
+  const backKeep = Math.max(chars, totalBudget - visibleBefore);
 
   // Trim from front if highlight is far from the start
-  if (visibleBefore > chars) {
-    const targetStart = Math.max(0, tagIndex - chars);
+  if (visibleBefore > frontKeep) {
+    const targetStart = Math.max(0, tagIndex - frontKeep);
     let cutIndex = targetStart;
     for (let i = targetStart; i < tagIndex; i++) {
       if (/\s/.test(line[i])) {
@@ -128,16 +144,15 @@ export function windowSearchMatch(text: string, chars: number): string {
   }
 
   // Trim from end to keep total length reasonable
-  const macroClose = '</macro_em>';
-  const lastCloseIndex = line.lastIndexOf(macroClose);
-  if (lastCloseIndex !== -1) {
-    const afterLastTag = lastCloseIndex + macroClose.length;
+  const finalCloseIndex = line.lastIndexOf(macroClose);
+  if (finalCloseIndex !== -1) {
+    const afterLastTag = finalCloseIndex + macroClose.length;
     const remainingVisible = line
       .slice(afterLastTag)
       .replace(/<\/?macro_em>/g, '')
       .replace(INVISIBLE_CHARS_RE, '').length;
-    if (remainingVisible > chars) {
-      let endCut = afterLastTag + chars;
+    if (remainingVisible > backKeep) {
+      let endCut = afterLastTag + backKeep;
       for (let i = endCut; i < line.length; i++) {
         if (/\s/.test(line[i])) {
           endCut = i;

--- a/js/app/packages/core/util/searchHighlight.tsx
+++ b/js/app/packages/core/util/searchHighlight.tsx
@@ -96,12 +96,12 @@ export function highlightTermsInText(text: string, terms: string[]): string {
 /**
  * Creates a single-line window around the first <macro_em> highlight.
  * - Collapses newlines and invisible chars into a clean single line
- * - Targets ~`2 * chars` total visible characters around the highlight
- * - When one side is shorter than `chars`, donates the unused budget to
- *   the other side so the rendered row uses the full available width
+ * - If the highlight is within `chars` of the start, keeps the start
+ * - Otherwise, trims the front to show context before the highlight
+ * - Trims the end to keep total visible length reasonable
  *
  * @param text - Content with <macro_em> tags
- * @param chars - Half-width visible character budget (each side of highlight)
+ * @param chars - Max visible characters to show on each side of the highlight
  */
 export function windowSearchMatch(text: string, chars: number): string {
   let line = stripInvisibleChars(text);
@@ -121,11 +121,8 @@ export function windowSearchMatch(text: string, chars: number): string {
       ? 0
       : line
           .slice(lastCloseIndex + macroClose.length)
-          .replace(/<\/?macro_em>/g, '')
-          .replace(INVISIBLE_CHARS_RE, '').length;
+          .replace(/<\/?macro_em>/g, '').length;
 
-  // Half-budget is `chars`; rebalance so unused space on one side goes to
-  // the other (otherwise short-prefix or short-suffix rows under-fill).
   const totalBudget = chars * 2;
   const frontKeep = Math.max(chars, totalBudget - visibleAfter);
   const backKeep = Math.max(chars, totalBudget - visibleBefore);
@@ -149,8 +146,7 @@ export function windowSearchMatch(text: string, chars: number): string {
     const afterLastTag = finalCloseIndex + macroClose.length;
     const remainingVisible = line
       .slice(afterLastTag)
-      .replace(/<\/?macro_em>/g, '')
-      .replace(INVISIBLE_CHARS_RE, '').length;
+      .replace(/<\/?macro_em>/g, '').length;
     if (remainingVisible > backKeep) {
       let endCut = afterLastTag + backKeep;
       for (let i = endCut; i < line.length; i++) {

--- a/js/app/packages/entity/src/composed/list-entity/email.tsx
+++ b/js/app/packages/entity/src/composed/list-entity/email.tsx
@@ -2,7 +2,7 @@ import { Show } from 'solid-js';
 import { DraftBadge } from '../../components/Badges';
 import { Entity } from '../../entity';
 import { HitSnippet } from '../../extractors-search/HitSnippet';
-import { getSnippetHitContent } from '../../extractors-search/snippet-entity';
+import { getSnippetHit } from '../../extractors-search/snippet-entity';
 import type { EmailEntity } from '../../types/entity';
 
 export function EmailIdentity(props: { entity: EmailEntity }) {
@@ -25,10 +25,10 @@ function EmailSnippet(props: {
 }) {
   return (
     <Show
-      when={props.showHitSnippet && getSnippetHitContent(props.entity)}
+      when={props.showHitSnippet && getSnippetHit(props.entity)}
       fallback={props.entity.snippet}
     >
-      {(content) => <HitSnippet content={content()} chars={props.chars} />}
+      {(hit) => <HitSnippet content={hit().content} chars={props.chars} />}
     </Show>
   );
 }

--- a/js/app/packages/entity/src/extractors-search/search-content-hit-row.tsx
+++ b/js/app/packages/entity/src/extractors-search/search-content-hit-row.tsx
@@ -22,6 +22,7 @@ interface SearchContentHitRowProps {
 export function SearchContentHitRow(props: SearchContentHitRowProps) {
   const senderId = () => getSenderId(props.hit);
   const handleClick = (e: PointerEvent | MouseEvent) => {
+    e.stopPropagation();
     props.onClick?.(e, props.hit.location);
   };
 

--- a/js/app/packages/entity/src/extractors-search/search-timestamp.tsx
+++ b/js/app/packages/entity/src/extractors-search/search-timestamp.tsx
@@ -11,9 +11,7 @@ interface SearchTimestampProps {
 }
 
 /**
- * Displays the timestamp of a search hit:
- * - call_record: offset within the call (0:02, 1:24, …)
- * - channel/email: relative date
+ * Displays the timestamp of a search hit (for channel/email/call_record)
  */
 export function SearchTimestamp(props: SearchTimestampProps) {
   const formatted = () => {

--- a/js/app/packages/entity/src/extractors-search/search-timestamp.tsx
+++ b/js/app/packages/entity/src/extractors-search/search-timestamp.tsx
@@ -1,25 +1,28 @@
-import type { DateValue } from '@core/util/date';
-import { type ContentHitData, hitHasSender } from '../types/search';
+import { formatVideoTimestamp } from '@core/util/duration';
+import {
+  type ContentHitData,
+  hitHasSender,
+  isCallRecordHit,
+} from '../types/search';
 import { formatRelativeTimestamp } from '../utils/timestamp';
 
 interface SearchTimestampProps {
   hit?: ContentHitData;
 }
 
-function getTimestamp(hit: ContentHitData): DateValue | undefined {
-  return hitHasSender(hit) ? hit.sentAt : undefined;
-}
-
 /**
- * Displays the timestamp of a search hit (for channel/email)
+ * Displays the timestamp of a search hit:
+ * - call_record: offset within the call (0:02, 1:24, …)
+ * - channel/email: relative date
  */
 export function SearchTimestamp(props: SearchTimestampProps) {
-  const timestamp = () => (props.hit ? getTimestamp(props.hit) : undefined);
-
-  const formattedTimestamp = () => {
-    const ts = timestamp();
-    return ts ? formatRelativeTimestamp(ts) : '';
+  const formatted = () => {
+    const hit = props.hit;
+    if (!hit) return '';
+    if (isCallRecordHit(hit)) return formatVideoTimestamp(hit.videoSeconds);
+    if (hitHasSender(hit)) return formatRelativeTimestamp(hit.sentAt);
+    return '';
   };
 
-  return <>{formattedTimestamp()}</>;
+  return <>{formatted()}</>;
 }

--- a/js/app/packages/entity/src/extractors-search/snippet-entity.ts
+++ b/js/app/packages/entity/src/extractors-search/snippet-entity.ts
@@ -6,7 +6,7 @@ import {
   isCallEntity,
   isEmailEntity,
 } from '../types/entity';
-import { isSearchEntity } from '../types/search';
+import { type ContentHitData, isSearchEntity } from '../types/search';
 
 /**
  * Entities whose inline row snippet renders search hit content via
@@ -19,13 +19,15 @@ export const isSnippetEntity = (entity: EntityData): entity is SnippetEntity =>
   isEmailEntity(entity) || isCallEntity(entity);
 
 /**
- * Hit content rendered as the row snippet for a SnippetEntity:
+ * The hit rendered as the row snippet for a SnippetEntity. Click handlers
+ * use this hit's location so the row click lands on the previewed match.
+ *
  * - email: longest hit (best context window around the highlight)
  * - call: first hit (typically the first transcript match)
  */
-export const getSnippetHitContent = (
+export const getSnippetHit = (
   entity: EntityData
-): string | undefined => {
+): ContentHitData | undefined => {
   if (!isSnippetEntity(entity)) return undefined;
   if (!isSearchEntity(entity)) return undefined;
   const hits = entity.search.contentHitData;
@@ -40,9 +42,9 @@ export const getSnippetHitContent = (
         bestIdx = i;
       }
     }
-    return hits[bestIdx].content;
+    return hits[bestIdx];
   }
-  return hits[0].content;
+  return hits[0];
 };
 
 /**

--- a/js/app/packages/entity/src/extractors-search/snippet-entity.ts
+++ b/js/app/packages/entity/src/extractors-search/snippet-entity.ts
@@ -19,9 +19,7 @@ export const isSnippetEntity = (entity: EntityData): entity is SnippetEntity =>
   isEmailEntity(entity) || isCallEntity(entity);
 
 /**
- * The hit rendered as the row snippet for a SnippetEntity. Click handlers
- * use this hit's location so the row click lands on the previewed match.
- *
+ * Hit rendered as the row snippet for a SnippetEntity:
  * - email: longest hit (best context window around the highlight)
  * - call: first hit (typically the first transcript match)
  */

--- a/js/app/packages/entity/src/index.ts
+++ b/js/app/packages/entity/src/index.ts
@@ -41,4 +41,11 @@ export {
   isCurrentUserAssigned,
 } from './utils/task-properties';
 
+export {
+  getSnippetHit,
+  isHitSnippetComplete,
+  isSnippetEntity,
+  type SnippetEntity,
+} from './extractors-search/snippet-entity';
+
 export { default as DebugEntityView } from './debug/DebugEntityView';

--- a/js/app/packages/entity/src/types/search.ts
+++ b/js/app/packages/entity/src/types/search.ts
@@ -29,7 +29,6 @@ type EmailMessageHighlightLocation = {
 type CallRecordSegmentHighlightLocation = {
   type: 'call_record';
   callId: string;
-  /** Stable DB-row id for the segment — the safe deep-link key. */
   transcriptId: string;
 };
 
@@ -82,7 +81,6 @@ export type CallRecordContentHitData = {
   content: string;
   senderId: string;
   sentAt: DateValue;
-  /** Seconds from the start of the call to this segment. */
   videoSeconds: number;
   location: CallRecordSegmentHighlightLocation;
 };

--- a/js/app/packages/entity/src/types/search.ts
+++ b/js/app/packages/entity/src/types/search.ts
@@ -29,7 +29,7 @@ type EmailMessageHighlightLocation = {
 type CallRecordSegmentHighlightLocation = {
   type: 'call_record';
   callId: string;
-  transcriptId: string;
+  sequenceNum: number;
 };
 
 export type SearchLocation =

--- a/js/app/packages/entity/src/types/search.ts
+++ b/js/app/packages/entity/src/types/search.ts
@@ -29,7 +29,8 @@ type EmailMessageHighlightLocation = {
 type CallRecordSegmentHighlightLocation = {
   type: 'call_record';
   callId: string;
-  sequenceNum: number;
+  /** Stable DB-row id for the segment — the safe deep-link key. */
+  transcriptId: string;
 };
 
 export type SearchLocation =

--- a/js/app/packages/entity/src/types/search.ts
+++ b/js/app/packages/entity/src/types/search.ts
@@ -81,6 +81,8 @@ export type CallRecordContentHitData = {
   content: string;
   senderId: string;
   sentAt: DateValue;
+  /** Seconds from the start of the call to this segment. */
+  videoSeconds: number;
   location: CallRecordSegmentHighlightLocation;
 };
 

--- a/js/app/packages/queries/soup/transform-utils.ts
+++ b/js/app/packages/queries/soup/transform-utils.ts
@@ -37,6 +37,7 @@ import type {
   SoupPage,
 } from '@service-storage/generated/schemas';
 import type { UseQueryResult } from '@tanstack/solid-query';
+import { differenceInMilliseconds } from 'date-fns';
 
 type InnerSearchResult =
   | DocumentSearchResult
@@ -136,17 +137,15 @@ const getSearchData = (data: TypedInnerSearchResult): SearchData => {
       break;
     }
     case 'call_record': {
-      const callStartMs = new Date(data.callStartedAt).getTime();
       contentHitData = data.results.flatMap((r) => {
         // TODO: support name only hits for call records when we support rename
         const isContentHit = !!r.transcript_id;
         if (!isContentHit) return [];
 
-        const segmentStartMs = new Date(r.started_at!).getTime();
-        const videoSeconds =
-          Number.isFinite(callStartMs) && Number.isFinite(segmentStartMs)
-            ? Math.max(0, (segmentStartMs - callStartMs) / 1000)
-            : 0;
+        const videoSeconds = Math.max(
+          0,
+          differenceInMilliseconds(r.started_at!, data.callStartedAt) / 1000
+        );
 
         const contents = r.highlight.content ?? [];
         return contents.map((content) => ({

--- a/js/app/packages/queries/soup/transform-utils.ts
+++ b/js/app/packages/queries/soup/transform-utils.ts
@@ -159,7 +159,7 @@ const getSearchData = (data: TypedInnerSearchResult): SearchData => {
           location: {
             type: 'call_record' as const,
             callId: data.callId,
-            sequenceNum: r.sequence_num!,
+            transcriptId: r.transcript_id!,
           },
         }));
       });

--- a/js/app/packages/queries/soup/transform-utils.ts
+++ b/js/app/packages/queries/soup/transform-utils.ts
@@ -150,7 +150,7 @@ const getSearchData = (data: TypedInnerSearchResult): SearchData => {
           location: {
             type: 'call_record' as const,
             callId: data.callId,
-            transcriptId: r.transcript_id!,
+            sequenceNum: r.sequence_num!,
           },
         }));
       });

--- a/js/app/packages/queries/soup/transform-utils.ts
+++ b/js/app/packages/queries/soup/transform-utils.ts
@@ -56,6 +56,7 @@ type TypedInnerSearchResult =
       results: CallRecordSearchResult[];
       type: 'call_record';
       callId: string;
+      callStartedAt: string;
     };
 
 const getSearchData = (data: TypedInnerSearchResult): SearchData => {
@@ -135,10 +136,17 @@ const getSearchData = (data: TypedInnerSearchResult): SearchData => {
       break;
     }
     case 'call_record': {
+      const callStartMs = new Date(data.callStartedAt).getTime();
       contentHitData = data.results.flatMap((r) => {
         // TODO: support name only hits for call records when we support rename
         const isContentHit = !!r.transcript_id;
         if (!isContentHit) return [];
+
+        const segmentStartMs = new Date(r.started_at!).getTime();
+        const videoSeconds =
+          Number.isFinite(callStartMs) && Number.isFinite(segmentStartMs)
+            ? Math.max(0, (segmentStartMs - callStartMs) / 1000)
+            : 0;
 
         const contents = r.highlight.content ?? [];
         return contents.map((content) => ({
@@ -147,6 +155,7 @@ const getSearchData = (data: TypedInnerSearchResult): SearchData => {
           content: mergeAdjacentMacroEmTags(content),
           senderId: r.speaker_id!,
           sentAt: r.started_at!,
+          videoSeconds,
           location: {
             type: 'call_record' as const,
             callId: data.callId,
@@ -364,6 +373,7 @@ export const useSearchResponseItemMapper = () => {
           type: 'call_record',
           results: result.call_search_results,
           callId: result.call_id,
+          callStartedAt: result.metadata.started_at,
         });
 
         const channelName: string | undefined =

--- a/js/app/packages/service-clients/service-notification/generated/zod.ts
+++ b/js/app/packages/service-clients/service-notification/generated/zod.ts
@@ -125,19 +125,17 @@ export const listTypedNotificationsResponse = zod
           )
           .and(
             zod.object({
-              created_at: zod
-                .string()
+              created_at: zod.iso
                 .datetime({})
                 .describe('When the notification was created.'),
-              deleted_at: zod
-                .string()
+              deleted_at: zod.iso
                 .datetime({})
                 .nullish()
                 .describe('When the notification was deleted.'),
               done: zod
                 .boolean()
                 .describe('Whether the notification is marked as done.'),
-              id: zod.string().uuid().describe('The notification ID.'),
+              id: zod.uuid().describe('The notification ID.'),
               notification_event_type: zod
                 .string()
                 .describe(
@@ -427,11 +425,9 @@ export const listTypedNotificationsResponse = zod
                               "The sender's profile picture URL, if available."
                             ),
                           teamId: zod
-                            .string()
                             .uuid()
                             .describe('The unique identifier of the team'),
                           teamInviteId: zod
-                            .string()
                             .uuid()
                             .describe(
                               'The unique identifier of the team invite'
@@ -491,12 +487,10 @@ export const listTypedNotificationsResponse = zod
               sent: zod
                 .boolean()
                 .describe('Whether the notification has been sent.'),
-              updated_at: zod
-                .string()
+              updated_at: zod.iso
                 .datetime({})
                 .describe('When the notification was last updated.'),
-              viewed_at: zod
-                .string()
+              viewed_at: zod.iso
                 .datetime({})
                 .nullish()
                 .describe('When the notification was viewed\/seen.'),
@@ -533,7 +527,7 @@ export const bulkGetTypedNotificationsByEventItemIdsQueryParams = zod.object({
 export const bulkGetTypedNotificationsByEventItemIdsBody = zod
   .object({
     eventItemIds: zod
-      .array(zod.string().uuid())
+      .array(zod.uuid())
       .describe('The event item IDs to filter notifications by.'),
   })
   .describe('Request body for bulk-fetching notifications by event item IDs.');
@@ -564,19 +558,17 @@ export const bulkGetTypedNotificationsByEventItemIdsResponse = zod
           )
           .and(
             zod.object({
-              created_at: zod
-                .string()
+              created_at: zod.iso
                 .datetime({})
                 .describe('When the notification was created.'),
-              deleted_at: zod
-                .string()
+              deleted_at: zod.iso
                 .datetime({})
                 .nullish()
                 .describe('When the notification was deleted.'),
               done: zod
                 .boolean()
                 .describe('Whether the notification is marked as done.'),
-              id: zod.string().uuid().describe('The notification ID.'),
+              id: zod.uuid().describe('The notification ID.'),
               notification_event_type: zod
                 .string()
                 .describe(
@@ -866,11 +858,9 @@ export const bulkGetTypedNotificationsByEventItemIdsResponse = zod
                               "The sender's profile picture URL, if available."
                             ),
                           teamId: zod
-                            .string()
                             .uuid()
                             .describe('The unique identifier of the team'),
                           teamInviteId: zod
-                            .string()
                             .uuid()
                             .describe(
                               'The unique identifier of the team invite'
@@ -930,12 +920,10 @@ export const bulkGetTypedNotificationsByEventItemIdsResponse = zod
               sent: zod
                 .boolean()
                 .describe('Whether the notification has been sent.'),
-              updated_at: zod
-                .string()
+              updated_at: zod.iso
                 .datetime({})
                 .describe('When the notification was last updated.'),
-              viewed_at: zod
-                .string()
+              viewed_at: zod.iso
                 .datetime({})
                 .nullish()
                 .describe('When the notification was viewed\/seen.'),
@@ -954,7 +942,7 @@ export const bulkGetTypedNotificationsByEventItemIdsResponse = zod
  * @summary Typed wrapper for getting notifications by a single event item ID.
  */
 export const getTypedNotificationsByEventItemIdParams = zod.object({
-  event_item_id: zod.string().uuid().describe('The event item ID'),
+  event_item_id: zod.uuid().describe('The event item ID'),
 });
 
 export const getTypedNotificationsByEventItemIdQueryLimitMin = 0;
@@ -997,19 +985,17 @@ export const getTypedNotificationsByEventItemIdResponse = zod
           )
           .and(
             zod.object({
-              created_at: zod
-                .string()
+              created_at: zod.iso
                 .datetime({})
                 .describe('When the notification was created.'),
-              deleted_at: zod
-                .string()
+              deleted_at: zod.iso
                 .datetime({})
                 .nullish()
                 .describe('When the notification was deleted.'),
               done: zod
                 .boolean()
                 .describe('Whether the notification is marked as done.'),
-              id: zod.string().uuid().describe('The notification ID.'),
+              id: zod.uuid().describe('The notification ID.'),
               notification_event_type: zod
                 .string()
                 .describe(
@@ -1299,11 +1285,9 @@ export const getTypedNotificationsByEventItemIdResponse = zod
                               "The sender's profile picture URL, if available."
                             ),
                           teamId: zod
-                            .string()
                             .uuid()
                             .describe('The unique identifier of the team'),
                           teamInviteId: zod
-                            .string()
                             .uuid()
                             .describe(
                               'The unique identifier of the team invite'
@@ -1363,12 +1347,10 @@ export const getTypedNotificationsByEventItemIdResponse = zod
               sent: zod
                 .boolean()
                 .describe('Whether the notification has been sent.'),
-              updated_at: zod
-                .string()
+              updated_at: zod.iso
                 .datetime({})
                 .describe('When the notification was last updated.'),
-              viewed_at: zod
-                .string()
+              viewed_at: zod.iso
                 .datetime({})
                 .nullish()
                 .describe('When the notification was viewed\/seen.'),
@@ -1416,7 +1398,7 @@ export const enableNotificationTypeParams = zod.object({
  * @summary Typed wrapper for getting a single notification by ID.
  */
 export const getTypedNotificationByIdParams = zod.object({
-  notification_id: zod.string().uuid().describe('ID of the notification'),
+  notification_id: zod.uuid().describe('ID of the notification'),
 });
 
 export const getTypedNotificationByIdResponse = zod
@@ -1441,19 +1423,17 @@ export const getTypedNotificationByIdResponse = zod
   )
   .and(
     zod.object({
-      created_at: zod
-        .string()
+      created_at: zod.iso
         .datetime({})
         .describe('When the notification was created.'),
-      deleted_at: zod
-        .string()
+      deleted_at: zod.iso
         .datetime({})
         .nullish()
         .describe('When the notification was deleted.'),
       done: zod
         .boolean()
         .describe('Whether the notification is marked as done.'),
-      id: zod.string().uuid().describe('The notification ID.'),
+      id: zod.uuid().describe('The notification ID.'),
       notification_event_type: zod
         .string()
         .describe(
@@ -1717,11 +1697,9 @@ export const getTypedNotificationByIdResponse = zod
                       "The sender's profile picture URL, if available."
                     ),
                   teamId: zod
-                    .string()
                     .uuid()
                     .describe('The unique identifier of the team'),
                   teamInviteId: zod
-                    .string()
                     .uuid()
                     .describe('The unique identifier of the team invite'),
                   teamName: zod
@@ -1771,12 +1749,10 @@ export const getTypedNotificationByIdResponse = zod
         .nullish()
         .describe('The user who triggered the notification.'),
       sent: zod.boolean().describe('Whether the notification has been sent.'),
-      updated_at: zod
-        .string()
+      updated_at: zod.iso
         .datetime({})
         .describe('When the notification was last updated.'),
-      viewed_at: zod
-        .string()
+      viewed_at: zod.iso
         .datetime({})
         .nullish()
         .describe('When the notification was viewed\/seen.'),
@@ -1789,7 +1765,7 @@ export const getTypedNotificationByIdResponse = zod
 export const bulkDeleteUserNotificationsV2Body = zod
   .object({
     notificationIds: zod
-      .array(zod.string().uuid())
+      .array(zod.uuid())
       .describe('The ids of the notifications to handle'),
   })
   .describe('the notification ids that we are bulk updating');
@@ -1800,7 +1776,7 @@ export const bulkDeleteUserNotificationsV2Body = zod
 export const bulkMarkNotificationsDoneBody = zod
   .object({
     notificationIds: zod
-      .array(zod.string().uuid())
+      .array(zod.uuid())
       .describe('The ids of the notifications to handle'),
   })
   .describe('the notification ids that we are bulk updating');
@@ -1811,7 +1787,7 @@ export const bulkMarkNotificationsDoneBody = zod
 export const bulkMarkNotificationsSeenBody = zod
   .object({
     notificationIds: zod
-      .array(zod.string().uuid())
+      .array(zod.uuid())
       .describe('The ids of the notifications to handle'),
   })
   .describe('the notification ids that we are bulk updating');
@@ -1822,7 +1798,7 @@ export const bulkMarkNotificationsSeenBody = zod
 export const bulkMarkNotificationsUndoneBody = zod
   .object({
     notificationIds: zod
-      .array(zod.string().uuid())
+      .array(zod.uuid())
       .describe('The ids of the notifications to handle'),
   })
   .describe('the notification ids that we are bulk updating');
@@ -1831,5 +1807,5 @@ export const bulkMarkNotificationsUndoneBody = zod
  * @summary Soft-delete a single user notification.
  */
 export const deleteUserNotificationV2Params = zod.object({
-  notification_id: zod.string().uuid().describe('ID of the notification'),
+  notification_id: zod.uuid().describe('ID of the notification'),
 });

--- a/js/app/packages/service-clients/service-properties/generated/zod.ts
+++ b/js/app/packages/service-clients/service-properties/generated/zod.ts
@@ -36,7 +36,7 @@ export const listPropertiesResponseItem = zod
   .union([
     zod
       .object({
-        created_at: zod.string().datetime({}),
+        created_at: zod.iso.datetime({}),
         data_type: zod
           .enum([
             'BOOLEAN',
@@ -52,7 +52,7 @@ export const listPropertiesResponseItem = zod
             'Data type for property values, determining storage and validation.'
           ),
         display_name: zod.string(),
-        id: zod.string().uuid(),
+        id: zod.uuid(),
         is_metadata: zod
           .boolean()
           .describe(
@@ -113,14 +113,14 @@ export const listPropertiesResponseItem = zod
               ),
           ])
           .optional(),
-        updated_at: zod.string().datetime({}),
+        updated_at: zod.iso.datetime({}),
       })
       .describe('Property definition model (service representation).'),
     zod
       .object({
         definition: zod
           .object({
-            created_at: zod.string().datetime({}),
+            created_at: zod.iso.datetime({}),
             data_type: zod
               .enum([
                 'BOOLEAN',
@@ -136,7 +136,7 @@ export const listPropertiesResponseItem = zod
                 'Data type for property values, determining storage and validation.'
               ),
             display_name: zod.string(),
-            id: zod.string().uuid(),
+            id: zod.uuid(),
             is_metadata: zod
               .boolean()
               .describe(
@@ -197,17 +197,17 @@ export const listPropertiesResponseItem = zod
                   ),
               ])
               .optional(),
-            updated_at: zod.string().datetime({}),
+            updated_at: zod.iso.datetime({}),
           })
           .describe('Property definition model (service representation).'),
         property_options: zod.array(
           zod
             .object({
-              created_at: zod.string().datetime({}),
+              created_at: zod.iso.datetime({}),
               display_order: zod.number(),
-              id: zod.string().uuid(),
-              property_definition_id: zod.string().uuid(),
-              updated_at: zod.string().datetime({}),
+              id: zod.uuid(),
+              property_definition_id: zod.uuid(),
+              updated_at: zod.iso.datetime({}),
               value: zod
                 .union([
                   zod
@@ -372,23 +372,23 @@ export const createPropertyDefinitionBody = zod
  * @summary Delete a property definition
  */
 export const deletePropertyDefinitionParams = zod.object({
-  definition_id: zod.string().uuid().describe('Property definition ID'),
+  definition_id: zod.uuid().describe('Property definition ID'),
 });
 
 /**
  * @summary Get all options for a property (for dropdowns)
  */
 export const getPropertyOptionsParams = zod.object({
-  definition_id: zod.string().uuid().describe('Property definition ID'),
+  definition_id: zod.uuid().describe('Property definition ID'),
 });
 
 export const getPropertyOptionsResponseItem = zod
   .object({
-    created_at: zod.string().datetime({}),
+    created_at: zod.iso.datetime({}),
     display_order: zod.number(),
-    id: zod.string().uuid(),
-    property_definition_id: zod.string().uuid(),
-    updated_at: zod.string().datetime({}),
+    id: zod.uuid(),
+    property_definition_id: zod.uuid(),
+    updated_at: zod.iso.datetime({}),
     value: zod
       .union([
         zod
@@ -423,7 +423,7 @@ export const getPropertyOptionsResponse = zod.array(
  * @summary Add a new option to a property dropdown
  */
 export const addPropertyOptionParams = zod.object({
-  definition_id: zod.string().uuid().describe('Property definition ID'),
+  definition_id: zod.uuid().describe('Property definition ID'),
 });
 
 export const addPropertyOptionBody = zod
@@ -461,8 +461,8 @@ export const addPropertyOptionBody = zod
  * @summary Delete a property option
  */
 export const deletePropertyOptionParams = zod.object({
-  definition_id: zod.string().uuid().describe('Property definition ID'),
-  option_id: zod.string().uuid().describe('Property option ID'),
+  definition_id: zod.uuid().describe('Property definition ID'),
+  option_id: zod.uuid().describe('Property option ID'),
 });
 
 /**
@@ -492,7 +492,6 @@ export const getBulkEntityPropertiesBody = zod
                 'Type of entity that can be referenced by entity properties.'
               ),
             specific_message_id: zod
-              .string()
               .uuid()
               .nullish()
               .describe(
@@ -503,7 +502,7 @@ export const getBulkEntityPropertiesBody = zod
       )
       .describe('Array of entity references (entity_id and entity_type pairs)'),
     property_ids: zod
-      .array(zod.string().uuid())
+      .array(zod.uuid())
       .optional()
       .describe(
         'Optional: only return properties with these definition IDs. If empty, returns all.'
@@ -521,7 +520,7 @@ export const getBulkEntityPropertiesResponse = zod.record(
           .object({
             definition: zod
               .object({
-                created_at: zod.string().datetime({}),
+                created_at: zod.iso.datetime({}),
                 data_type: zod
                   .enum([
                     'BOOLEAN',
@@ -537,7 +536,7 @@ export const getBulkEntityPropertiesResponse = zod.record(
                     'Data type for property values, determining storage and validation.'
                   ),
                 display_name: zod.string(),
-                id: zod.string().uuid(),
+                id: zod.uuid(),
                 is_metadata: zod
                   .boolean()
                   .describe(
@@ -598,18 +597,18 @@ export const getBulkEntityPropertiesResponse = zod.record(
                       ),
                   ])
                   .optional(),
-                updated_at: zod.string().datetime({}),
+                updated_at: zod.iso.datetime({}),
               })
               .describe('Property definition model (service representation).'),
             options: zod
               .array(
                 zod
                   .object({
-                    created_at: zod.string().datetime({}),
+                    created_at: zod.iso.datetime({}),
                     display_order: zod.number(),
-                    id: zod.string().uuid(),
-                    property_definition_id: zod.string().uuid(),
-                    updated_at: zod.string().datetime({}),
+                    id: zod.uuid(),
+                    property_definition_id: zod.uuid(),
+                    updated_at: zod.iso.datetime({}),
                     value: zod
                       .union([
                         zod
@@ -644,7 +643,7 @@ export const getBulkEntityPropertiesResponse = zod.record(
               .nullish(),
             property: zod
               .object({
-                created_at: zod.string().datetime({}),
+                created_at: zod.iso.datetime({}),
                 entity_id: zod.string(),
                 entity_type: zod
                   .enum([
@@ -660,9 +659,9 @@ export const getBulkEntityPropertiesResponse = zod.record(
                   .describe(
                     'Type of entity that can be referenced by entity properties.'
                   ),
-                id: zod.string().uuid(),
-                property_definition_id: zod.string().uuid(),
-                updated_at: zod.string().datetime({}),
+                id: zod.uuid(),
+                property_definition_id: zod.uuid(),
+                updated_at: zod.iso.datetime({}),
               })
               .describe(
                 'Assignment of a property definition to a specific entity (service representation).'
@@ -711,8 +710,7 @@ export const getBulkEntityPropertiesResponse = zod.record(
                     zod
                       .object({
                         type: zod.enum(['Date']),
-                        value: zod
-                          .string()
+                        value: zod.iso
                           .datetime({})
                           .describe(
                             'Date\/timestamp value\nSerializes as: {\"type\": \"Date\", \"value\": \"2025-01-01T00:00:00Z\"}'
@@ -725,7 +723,7 @@ export const getBulkEntityPropertiesResponse = zod.record(
                       .object({
                         type: zod.enum(['SelectOption']),
                         value: zod
-                          .array(zod.string().uuid())
+                          .array(zod.uuid())
                           .describe(
                             'Select option(s) - always an array (check is_multi_select to determine if single or multi)\nSingle-select: {\"type\": \"SelectOption\", \"value\": [\"uuid\"]} (length 0 or 1)\nMulti-select: {\"type\": \"SelectOption\", \"value\": [\"uuid1\", \"uuid2\", ...]} (length 0+)'
                           ),
@@ -756,7 +754,6 @@ export const getBulkEntityPropertiesResponse = zod.record(
                                     'Type of entity that can be referenced by entity properties.'
                                   ),
                                 specific_message_id: zod
-                                  .string()
                                   .uuid()
                                   .nullish()
                                   .describe(
@@ -835,7 +832,7 @@ export const getEntityPropertiesResponse = zod
         .object({
           definition: zod
             .object({
-              created_at: zod.string().datetime({}),
+              created_at: zod.iso.datetime({}),
               data_type: zod
                 .enum([
                   'BOOLEAN',
@@ -851,7 +848,7 @@ export const getEntityPropertiesResponse = zod
                   'Data type for property values, determining storage and validation.'
                 ),
               display_name: zod.string(),
-              id: zod.string().uuid(),
+              id: zod.uuid(),
               is_metadata: zod
                 .boolean()
                 .describe(
@@ -912,18 +909,18 @@ export const getEntityPropertiesResponse = zod
                     ),
                 ])
                 .optional(),
-              updated_at: zod.string().datetime({}),
+              updated_at: zod.iso.datetime({}),
             })
             .describe('Property definition model (service representation).'),
           options: zod
             .array(
               zod
                 .object({
-                  created_at: zod.string().datetime({}),
+                  created_at: zod.iso.datetime({}),
                   display_order: zod.number(),
-                  id: zod.string().uuid(),
-                  property_definition_id: zod.string().uuid(),
-                  updated_at: zod.string().datetime({}),
+                  id: zod.uuid(),
+                  property_definition_id: zod.uuid(),
+                  updated_at: zod.iso.datetime({}),
                   value: zod
                     .union([
                       zod
@@ -958,7 +955,7 @@ export const getEntityPropertiesResponse = zod
             .nullish(),
           property: zod
             .object({
-              created_at: zod.string().datetime({}),
+              created_at: zod.iso.datetime({}),
               entity_id: zod.string(),
               entity_type: zod
                 .enum([
@@ -974,9 +971,9 @@ export const getEntityPropertiesResponse = zod
                 .describe(
                   'Type of entity that can be referenced by entity properties.'
                 ),
-              id: zod.string().uuid(),
-              property_definition_id: zod.string().uuid(),
-              updated_at: zod.string().datetime({}),
+              id: zod.uuid(),
+              property_definition_id: zod.uuid(),
+              updated_at: zod.iso.datetime({}),
             })
             .describe(
               'Assignment of a property definition to a specific entity (service representation).'
@@ -1025,8 +1022,7 @@ export const getEntityPropertiesResponse = zod
                   zod
                     .object({
                       type: zod.enum(['Date']),
-                      value: zod
-                        .string()
+                      value: zod.iso
                         .datetime({})
                         .describe(
                           'Date\/timestamp value\nSerializes as: {\"type\": \"Date\", \"value\": \"2025-01-01T00:00:00Z\"}'
@@ -1039,7 +1035,7 @@ export const getEntityPropertiesResponse = zod
                     .object({
                       type: zod.enum(['SelectOption']),
                       value: zod
-                        .array(zod.string().uuid())
+                        .array(zod.uuid())
                         .describe(
                           'Select option(s) - always an array (check is_multi_select to determine if single or multi)\nSingle-select: {\"type\": \"SelectOption\", \"value\": [\"uuid\"]} (length 0 or 1)\nMulti-select: {\"type\": \"SelectOption\", \"value\": [\"uuid1\", \"uuid2\", ...]} (length 0+)'
                         ),
@@ -1070,7 +1066,6 @@ export const getEntityPropertiesResponse = zod
                                   'Type of entity that can be referenced by entity properties.'
                                 ),
                               specific_message_id: zod
-                                .string()
                                 .uuid()
                                 .nullish()
                                 .describe(
@@ -1131,7 +1126,7 @@ export const setEntityPropertyParams = zod.object({
     ])
     .describe('Entity type (user, document, channel, project, thread)'),
   entity_id: zod.string().describe('Entity ID'),
-  property_id: zod.string().uuid().describe('Property ID'),
+  property_id: zod.uuid().describe('Property ID'),
 });
 
 export const setEntityPropertyBody = zod
@@ -1150,7 +1145,7 @@ export const setEntityPropertyBody = zod
             zod
               .object({
                 type: zod.enum(['date']),
-                value: zod.string().datetime({}),
+                value: zod.iso.datetime({}),
               })
               .describe('Date and time value'),
             zod
@@ -1167,13 +1162,13 @@ export const setEntityPropertyBody = zod
               .describe('String\/text value'),
             zod
               .object({
-                option_id: zod.string().uuid(),
+                option_id: zod.uuid(),
                 type: zod.enum(['select_option']),
               })
               .describe('Select option by ID (for select-type properties)'),
             zod
               .object({
-                option_ids: zod.array(zod.string().uuid()),
+                option_ids: zod.array(zod.uuid()),
                 type: zod.enum(['multi_select_option']),
               })
               .describe(
@@ -1199,7 +1194,6 @@ export const setEntityPropertyBody = zod
                         'Type of entity that can be referenced by entity properties.'
                       ),
                     specific_message_id: zod
-                      .string()
                       .uuid()
                       .nullish()
                       .describe(
@@ -1233,7 +1227,6 @@ export const setEntityPropertyBody = zod
                           'Type of entity that can be referenced by entity properties.'
                         ),
                       specific_message_id: zod
-                        .string()
                         .uuid()
                         .nullish()
                         .describe(
@@ -1276,5 +1269,5 @@ export const setEntityPropertyBody = zod
  * @summary Remove a specific entity property by its ID
  */
 export const deleteEntityPropertyParams = zod.object({
-  entity_property_id: zod.string().uuid().describe('Entity Property ID'),
+  entity_property_id: zod.uuid().describe('Entity Property ID'),
 });

--- a/js/app/packages/service-clients/service-storage/generated/schemas/callRecordTranscriptSegment.ts
+++ b/js/app/packages/service-clients/service-storage/generated/schemas/callRecordTranscriptSegment.ts
@@ -28,4 +28,8 @@ return a speaker label. */
   speakerId: string;
   /** When the speaker started this segment. */
   startedAt: string;
+  /** Stable DB-row identifier for the segment. Always present and unique
+within a call — clients use this for deep-link targeting (e.g. search
+"go to" navigation) where `sequence_num` is only an ordering hint. */
+  transcriptId: string;
 }

--- a/js/app/packages/service-clients/service-storage/generated/schemas/callRecordTranscriptSegment.ts
+++ b/js/app/packages/service-clients/service-storage/generated/schemas/callRecordTranscriptSegment.ts
@@ -28,8 +28,6 @@ return a speaker label. */
   speakerId: string;
   /** When the speaker started this segment. */
   startedAt: string;
-  /** Stable DB-row identifier for the segment. Always present and unique
-within a call — clients use this for deep-link targeting (e.g. search
-"go to" navigation) where `sequence_num` is only an ordering hint. */
+  /** Stable DB-row id for the segment. */
   transcriptId: string;
 }

--- a/js/app/packages/service-clients/service-storage/generated/zod.ts
+++ b/js/app/packages/service-clients/service-storage/generated/zod.ts
@@ -997,6 +997,12 @@ export const getCallRecordResponse = zod
               .string()
               .datetime({})
               .describe('When the speaker started this segment.'),
+            transcriptId: zod
+              .string()
+              .uuid()
+              .describe(
+                'Stable DB-row identifier for the segment. Always present and unique\nwithin a call — clients use this for deep-link targeting (e.g. search\n\"go to\" navigation) where `sequence_num` is only an ordering hint.'
+              ),
           })
           .describe('A transcript segment as returned in a [`CallRecord`].')
       )

--- a/js/app/packages/service-clients/service-storage/generated/zod.ts
+++ b/js/app/packages/service-clients/service-storage/generated/zod.ts
@@ -43,13 +43,11 @@ export const getRecentActivityHandlerResponse = zod.object({
                     .describe(
                       'The id of the version this document branched from\nThis could be either DocumentInstance or DocumentBom id depending on\nthe file type'
                     ),
-                  createdAt: zod
-                    .string()
+                  createdAt: zod.iso
                     .datetime({})
                     .nullish()
                     .describe('The time the document was created'),
-                  deletedAt: zod
-                    .string()
+                  deletedAt: zod.iso
                     .datetime({})
                     .nullish()
                     .describe('The time the document was deleted'),
@@ -103,8 +101,7 @@ export const getRecentActivityHandlerResponse = zod.object({
                         ),
                     ])
                     .optional(),
-                  updatedAt: zod
-                    .string()
+                  updatedAt: zod.iso
                     .datetime({})
                     .nullish()
                     .describe(
@@ -115,13 +112,11 @@ export const getRecentActivityHandlerResponse = zod.object({
               }),
               zod.object({
                 Chat: zod.object({
-                  createdAt: zod
-                    .string()
+                  createdAt: zod.iso
                     .datetime({})
                     .nullish()
                     .describe('The time the chat was created'),
-                  deletedAt: zod
-                    .string()
+                  deletedAt: zod.iso
                     .datetime({})
                     .nullish()
                     .describe('The time the chat was deleted'),
@@ -137,8 +132,7 @@ export const getRecentActivityHandlerResponse = zod.object({
                     .nullish()
                     .describe('The project id of the chat'),
                   tokenCount: zod.number().nullish(),
-                  updatedAt: zod
-                    .string()
+                  updatedAt: zod.iso
                     .datetime({})
                     .nullish()
                     .describe('The time the chat was last updated'),
@@ -165,7 +159,7 @@ If you need to delete a threaded anchor, see the delete comment handler
 export const deleteAnchorBody = zod
   .object({
     anchorType: zod.enum(['highlight']),
-    uuid: zod.string().uuid(),
+    uuid: zod.uuid(),
   })
   .and(
     zod.object({
@@ -177,11 +171,11 @@ export const deleteAnchorResponse = zod
   .union([
     zod.object({
       anchorType: zod.enum(['free-comment']),
-      uuid: zod.string().uuid(),
+      uuid: zod.uuid(),
     }),
     zod.object({
       anchorType: zod.enum(['highlight']),
-      uuid: zod.string().uuid(),
+      uuid: zod.uuid(),
     }),
   ])
   .and(
@@ -208,7 +202,7 @@ export const editAnchorBody = zod
     page: zod.number().nullish(),
     rotation: zod.number().nullish(),
     shouldLockOnSave: zod.boolean().nullish(),
-    uuid: zod.string().uuid(),
+    uuid: zod.uuid(),
     wasDeleted: zod.boolean().nullish(),
     wasEdited: zod.boolean().nullish(),
     widthPct: zod.number().nullish(),
@@ -240,7 +234,7 @@ export const editAnchorResponse = zod
         rotation: zod.number(),
         shouldLockOnSave: zod.boolean(),
         threadId: zod.number(),
-        uuid: zod.string().uuid(),
+        uuid: zod.uuid(),
         wasDeleted: zod.boolean(),
         wasEdited: zod.boolean(),
         widthPct: zod.number(),
@@ -256,8 +250,8 @@ export const editAnchorResponse = zod
       .object({
         alpha: zod.number(),
         blue: zod.number(),
-        createdAt: zod.string().datetime({}).nullish(),
-        deletedAt: zod.string().datetime({}).nullish(),
+        createdAt: zod.iso.datetime({}).nullish(),
+        deletedAt: zod.iso.datetime({}).nullish(),
         documentId: zod.string(),
         green: zod.number(),
         highlightRects: zod.array(
@@ -281,8 +275,8 @@ export const editAnchorResponse = zod
         red: zod.number(),
         text: zod.string(),
         threadId: zod.number().nullish(),
-        updatedAt: zod.string().datetime({}).nullish(),
-        uuid: zod.string().uuid(),
+        updatedAt: zod.iso.datetime({}).nullish(),
+        uuid: zod.uuid(),
       })
       .and(
         zod.object({
@@ -318,7 +312,7 @@ export const getDocumentAnchorsResponse = zod.object({
           rotation: zod.number(),
           shouldLockOnSave: zod.boolean(),
           threadId: zod.number(),
-          uuid: zod.string().uuid(),
+          uuid: zod.uuid(),
           wasDeleted: zod.boolean(),
           wasEdited: zod.boolean(),
           widthPct: zod.number(),
@@ -334,8 +328,8 @@ export const getDocumentAnchorsResponse = zod.object({
         .object({
           alpha: zod.number(),
           blue: zod.number(),
-          createdAt: zod.string().datetime({}).nullish(),
-          deletedAt: zod.string().datetime({}).nullish(),
+          createdAt: zod.iso.datetime({}).nullish(),
+          deletedAt: zod.iso.datetime({}).nullish(),
           documentId: zod.string(),
           green: zod.number(),
           highlightRects: zod.array(
@@ -359,8 +353,8 @@ export const getDocumentAnchorsResponse = zod.object({
           red: zod.number(),
           text: zod.string(),
           threadId: zod.number().nullish(),
-          updatedAt: zod.string().datetime({}).nullish(),
-          uuid: zod.string().uuid(),
+          updatedAt: zod.iso.datetime({}).nullish(),
+          uuid: zod.uuid(),
         })
         .and(
           zod.object({
@@ -398,7 +392,7 @@ export const createAnchorBody = zod
     pageViewportWidth: zod.number(),
     red: zod.number(),
     text: zod.string(),
-    uuid: zod.string().uuid().nullish(),
+    uuid: zod.uuid().nullish(),
   })
   .and(
     zod.object({
@@ -425,7 +419,7 @@ export const createAnchorResponse = zod
         rotation: zod.number(),
         shouldLockOnSave: zod.boolean(),
         threadId: zod.number(),
-        uuid: zod.string().uuid(),
+        uuid: zod.uuid(),
         wasDeleted: zod.boolean(),
         wasEdited: zod.boolean(),
         widthPct: zod.number(),
@@ -441,8 +435,8 @@ export const createAnchorResponse = zod
       .object({
         alpha: zod.number(),
         blue: zod.number(),
-        createdAt: zod.string().datetime({}).nullish(),
-        deletedAt: zod.string().datetime({}).nullish(),
+        createdAt: zod.iso.datetime({}).nullish(),
+        deletedAt: zod.iso.datetime({}).nullish(),
         documentId: zod.string(),
         green: zod.number(),
         highlightRects: zod.array(
@@ -466,8 +460,8 @@ export const createAnchorResponse = zod
         red: zod.number(),
         text: zod.string(),
         threadId: zod.number().nullish(),
-        updatedAt: zod.string().datetime({}).nullish(),
-        uuid: zod.string().uuid(),
+        updatedAt: zod.iso.datetime({}).nullish(),
+        uuid: zod.uuid(),
       })
       .and(
         zod.object({
@@ -502,11 +496,11 @@ export const deleteCommentResponse = zod.object({
         .union([
           zod.object({
             anchorType: zod.enum(['free-comment']),
-            uuid: zod.string().uuid(),
+            uuid: zod.uuid(),
           }),
           zod.object({
             anchorType: zod.enum(['highlight']),
-            uuid: zod.string().uuid(),
+            uuid: zod.uuid(),
           }),
         ])
         .and(
@@ -554,15 +548,15 @@ export const editCommentBody = zod.object({
 export const editCommentResponse = zod
   .object({
     commentId: zod.number(),
-    createdAt: zod.string().datetime({}).nullish(),
-    deletedAt: zod.string().datetime({}).nullish(),
+    createdAt: zod.iso.datetime({}).nullish(),
+    deletedAt: zod.iso.datetime({}).nullish(),
     metadata: zod.unknown().optional(),
     order: zod.number().nullish(),
     owner: zod.string(),
     sender: zod.string().nullish(),
     text: zod.string(),
     threadId: zod.number(),
-    updatedAt: zod.string().datetime({}).nullish(),
+    updatedAt: zod.iso.datetime({}).nullish(),
   })
   .and(
     zod.object({
@@ -586,26 +580,26 @@ export const getDocumentCommentsResponse = zod.object({
       comments: zod.array(
         zod.object({
           commentId: zod.number(),
-          createdAt: zod.string().datetime({}).nullish(),
-          deletedAt: zod.string().datetime({}).nullish(),
+          createdAt: zod.iso.datetime({}).nullish(),
+          deletedAt: zod.iso.datetime({}).nullish(),
           metadata: zod.unknown().optional(),
           order: zod.number().nullish(),
           owner: zod.string(),
           sender: zod.string().nullish(),
           text: zod.string(),
           threadId: zod.number(),
-          updatedAt: zod.string().datetime({}).nullish(),
+          updatedAt: zod.iso.datetime({}).nullish(),
         })
       ),
       thread: zod.object({
-        createdAt: zod.string().datetime({}).nullish(),
-        deletedAt: zod.string().datetime({}).nullish(),
+        createdAt: zod.iso.datetime({}).nullish(),
+        deletedAt: zod.iso.datetime({}).nullish(),
         documentId: zod.string(),
         metadata: zod.unknown().optional(),
         owner: zod.string(),
         resolved: zod.boolean(),
         threadId: zod.number(),
-        updatedAt: zod.string().datetime({}).nullish(),
+        updatedAt: zod.iso.datetime({}).nullish(),
       }),
     })
   ),
@@ -634,7 +628,7 @@ export const createCommentBody = zod.object({
               page: zod.number(),
               rotation: zod.number(),
               shouldLockOnSave: zod.boolean(),
-              uuid: zod.string().uuid().nullish(),
+              uuid: zod.uuid().nullish(),
               wasDeleted: zod.boolean(),
               wasEdited: zod.boolean(),
               widthPct: zod.number(),
@@ -669,7 +663,7 @@ export const createCommentBody = zod.object({
               pageViewportWidth: zod.number(),
               red: zod.number(),
               text: zod.string(),
-              uuid: zod.string().uuid().nullish(),
+              uuid: zod.uuid().nullish(),
             })
             .and(
               zod.object({
@@ -679,7 +673,7 @@ export const createCommentBody = zod.object({
           zod
             .object({
               attachmentType: zod.enum(['highlight']),
-              uuid: zod.string().uuid(),
+              uuid: zod.uuid(),
             })
             .and(
               zod.object({
@@ -714,26 +708,26 @@ export const createCommentResponse = zod
     comments: zod.array(
       zod.object({
         commentId: zod.number(),
-        createdAt: zod.string().datetime({}).nullish(),
-        deletedAt: zod.string().datetime({}).nullish(),
+        createdAt: zod.iso.datetime({}).nullish(),
+        deletedAt: zod.iso.datetime({}).nullish(),
         metadata: zod.unknown().optional(),
         order: zod.number().nullish(),
         owner: zod.string(),
         sender: zod.string().nullish(),
         text: zod.string(),
         threadId: zod.number(),
-        updatedAt: zod.string().datetime({}).nullish(),
+        updatedAt: zod.iso.datetime({}).nullish(),
       })
     ),
     thread: zod.object({
-      createdAt: zod.string().datetime({}).nullish(),
-      deletedAt: zod.string().datetime({}).nullish(),
+      createdAt: zod.iso.datetime({}).nullish(),
+      deletedAt: zod.iso.datetime({}).nullish(),
       documentId: zod.string(),
       metadata: zod.unknown().optional(),
       owner: zod.string(),
       resolved: zod.boolean(),
       threadId: zod.number(),
-      updatedAt: zod.string().datetime({}).nullish(),
+      updatedAt: zod.iso.datetime({}).nullish(),
     }),
   })
   .and(
@@ -754,7 +748,7 @@ export const createCommentResponse = zod
                 rotation: zod.number(),
                 shouldLockOnSave: zod.boolean(),
                 threadId: zod.number(),
-                uuid: zod.string().uuid(),
+                uuid: zod.uuid(),
                 wasDeleted: zod.boolean(),
                 wasEdited: zod.boolean(),
                 widthPct: zod.number(),
@@ -770,8 +764,8 @@ export const createCommentResponse = zod
               .object({
                 alpha: zod.number(),
                 blue: zod.number(),
-                createdAt: zod.string().datetime({}).nullish(),
-                deletedAt: zod.string().datetime({}).nullish(),
+                createdAt: zod.iso.datetime({}).nullish(),
+                deletedAt: zod.iso.datetime({}).nullish(),
                 documentId: zod.string(),
                 green: zod.number(),
                 highlightRects: zod.array(
@@ -795,8 +789,8 @@ export const createCommentResponse = zod
                 red: zod.number(),
                 text: zod.string(),
                 threadId: zod.number().nullish(),
-                updatedAt: zod.string().datetime({}).nullish(),
-                uuid: zod.string().uuid(),
+                updatedAt: zod.iso.datetime({}).nullish(),
+                uuid: zod.uuid(),
               })
               .and(
                 zod.object({
@@ -820,7 +814,7 @@ ids are deduplicated server-side, and missing ids come back as
 export const getBatchCallRecordPreviewBody = zod
   .object({
     callIds: zod
-      .array(zod.string().uuid())
+      .array(zod.uuid())
       .describe(
         'The call ids to preview. Duplicate ids are deduplicated server-side.\nCapped at [`MAX_BATCH_CALL_IDS`] entries.'
       ),
@@ -837,22 +831,19 @@ export const getBatchCallRecordPreviewResponse = zod
           .union([
             zod
               .object({
-                callId: zod.string().uuid().describe('The call identifier.'),
+                callId: zod.uuid().describe('The call identifier.'),
                 channelId: zod
-                  .string()
                   .uuid()
                   .describe('The channel this call belongs to.'),
                 channelName: zod
                   .string()
                   .nullish()
                   .describe('Resolved display name for the channel.'),
-                endedAt: zod
-                  .string()
+                endedAt: zod.iso
                   .datetime({})
                   .nullish()
                   .describe('When the call ended (None if still active).'),
-                startedAt: zod
-                  .string()
+                startedAt: zod.iso
                   .datetime({})
                   .describe(
                     'When the call started (created_at for active, started_at for archived).'
@@ -869,7 +860,7 @@ export const getBatchCallRecordPreviewResponse = zod
               ),
             zod
               .object({
-                callId: zod.string().uuid().describe('The call identifier.'),
+                callId: zod.uuid().describe('The call identifier.'),
               })
               .describe(
                 'Wrapper carrying just a call id. Used by the [`CallRecordPreview::DoesNotExist`]\nvariant.'
@@ -898,16 +889,13 @@ Access is validated via channel membership (MemberParticipantRole).
  * @summary Handler for `GET /call/record/{call_id}`.
  */
 export const getCallRecordParams = zod.object({
-  call_id: zod.string().uuid().describe('Call ID'),
+  call_id: zod.uuid().describe('Call ID'),
 });
 
 export const getCallRecordResponse = zod
   .object({
-    callId: zod.string().uuid().describe('The call identifier.'),
-    channelId: zod
-      .string()
-      .uuid()
-      .describe('The channel this call belongs to.'),
+    callId: zod.uuid().describe('The call identifier.'),
+    channelId: zod.uuid().describe('The channel this call belongs to.'),
     channelName: zod
       .string()
       .nullish()
@@ -924,8 +912,7 @@ export const getCallRecordResponse = zod
       .nullish()
       .describe('Call duration in milliseconds (None if still active).'),
     egressId: zod.string().nullish().describe('Recording egress ID, if any.'),
-    endedAt: zod
-      .string()
+    endedAt: zod.iso
       .datetime({})
       .nullish()
       .describe('When the call ended (None if still active).'),
@@ -936,12 +923,10 @@ export const getCallRecordResponse = zod
       .array(
         zod
           .object({
-            joinedAt: zod
-              .string()
+            joinedAt: zod.iso
               .datetime({})
               .describe('When the user joined the call.'),
-            leftAt: zod
-              .string()
+            leftAt: zod.iso
               .datetime({})
               .nullish()
               .describe(
@@ -959,8 +944,7 @@ export const getCallRecordResponse = zod
       .nullish()
       .describe('Presigned URL for the call recording, if available.'),
     roomName: zod.string().describe('The RTC room name.'),
-    startedAt: zod
-      .string()
+    startedAt: zod.iso
       .datetime({})
       .describe(
         'When the call started (created_at for active, started_at for archived).'
@@ -982,8 +966,7 @@ export const getCallRecordResponse = zod
               .describe(
                 "Stable per-speaker identifier produced by the STT provider's diarization\npass. Unique across tracks in the call. `None` when the provider didn't\nreturn a speaker label."
               ),
-            endedAt: zod
-              .string()
+            endedAt: zod.iso
               .datetime({})
               .nullish()
               .describe('When the speaker stopped (if known).'),
@@ -993,12 +976,10 @@ export const getCallRecordResponse = zod
               .describe('LiveKit segment ID (nullable for archived records).'),
             sequenceNum: zod.number().describe('Ordering within the call.'),
             speakerId: zod.string().describe("The speaker's user ID."),
-            startedAt: zod
-              .string()
+            startedAt: zod.iso
               .datetime({})
               .describe('When the speaker started this segment.'),
             transcriptId: zod
-              .string()
               .uuid()
               .describe('Stable DB-row id for the segment.'),
           })
@@ -1016,7 +997,7 @@ Access is validated via channel membership (MemberParticipantRole).
  * @summary Handler for `DELETE /call/record/{call_id}`.
  */
 export const deleteCallRecordParams = zod.object({
-  call_id: zod.string().uuid().describe('Call ID'),
+  call_id: zod.uuid().describe('Call ID'),
 });
 
 /**
@@ -1025,7 +1006,7 @@ permissions. Access is validated via channel membership
  * @summary Handler for `PATCH /call/record/{call_id}`.
  */
 export const editCallRecordParams = zod.object({
-  call_id: zod.string().uuid().describe('Call ID'),
+  call_id: zod.uuid().describe('Call ID'),
 });
 
 export const editCallRecordBody = zod
@@ -1091,7 +1072,7 @@ value as the JSON body.
  * @summary Handler for `POST /call/record/{call_id}/share-with-team/toggle`.
  */
 export const toggleShareWithTeamParams = zod.object({
-  call_id: zod.string().uuid().describe('Call ID'),
+  call_id: zod.uuid().describe('Call ID'),
 });
 
 export const toggleShareWithTeamResponse = zod.boolean();
@@ -1103,7 +1084,7 @@ as `edit_call_record_handler`.
  * @summary Handler for `PATCH /call/record/{call_id}/transcript`.
  */
 export const editCallTranscriptParams = zod.object({
-  call_id: zod.string().uuid().describe('Call ID'),
+  call_id: zod.uuid().describe('Call ID'),
 });
 
 export const editCallTranscriptBody = zod
@@ -1139,16 +1120,13 @@ otherwise creates a new one. Always returns a join token.
  * @summary Handler for `GET /call/{channel_id}`.
  */
 export const getOrCreateCallParams = zod.object({
-  channel_id: zod.string().uuid().describe('Channel ID'),
+  channel_id: zod.uuid().describe('Channel ID'),
 });
 
 export const getOrCreateCallResponse = zod
   .object({
-    callId: zod.string().uuid().describe('The call identifier.'),
-    channelId: zod
-      .string()
-      .uuid()
-      .describe('The channel this call is associated with.'),
+    callId: zod.uuid().describe('The call identifier.'),
+    channelId: zod.uuid().describe('The channel this call is associated with.'),
     roomName: zod.string().describe('The RTC room name.'),
     serverUrl: zod
       .string()
@@ -1161,7 +1139,7 @@ export const getOrCreateCallResponse = zod
  * @summary Handler for `DELETE /call/{channel_id}`.
  */
 export const leaveOrEndCallParams = zod.object({
-  channel_id: zod.string().uuid().describe('Channel ID'),
+  channel_id: zod.uuid().describe('Channel ID'),
 });
 
 export const leaveOrEndCallResponse = zod
@@ -1177,17 +1155,14 @@ export const leaveOrEndCallResponse = zod
  * @summary Handler for `GET /call/{channel_id}/active`.
  */
 export const checkActiveCallParams = zod.object({
-  channel_id: zod.string().uuid().describe('Channel ID'),
+  channel_id: zod.uuid().describe('Channel ID'),
 });
 
 export const checkActiveCallResponse = zod
   .object({
-    callId: zod.string().uuid().describe('The call identifier.'),
-    channelId: zod
-      .string()
-      .uuid()
-      .describe('The channel this call belongs to.'),
-    createdAt: zod.string().datetime({}).describe('When the call was created.'),
+    callId: zod.uuid().describe('The call identifier.'),
+    channelId: zod.uuid().describe('The channel this call belongs to.'),
+    createdAt: zod.iso.datetime({}).describe('When the call was created.'),
     createdBy: zod.string().describe('User who created the call.'),
   })
   .describe('Response indicating whether an active call exists for a channel.');
@@ -1199,7 +1174,7 @@ Duplicate segments (same `segment_id`) are ignored.
  * @summary Handler for `POST /call/{channel_id}/transcript`.
  */
 export const ingestTranscriptParams = zod.object({
-  channel_id: zod.string().uuid().describe('Channel ID'),
+  channel_id: zod.uuid().describe('Channel ID'),
 });
 
 export const ingestTranscriptBody = zod
@@ -1211,8 +1186,7 @@ export const ingestTranscriptBody = zod
       .describe(
         "Stable per-speaker identifier produced by the STT provider's diarization\npass. Namespaced upstream by audio track so values are unique across all\ntracks in a call. `None` when the provider didn't return a speaker label."
       ),
-    endedAt: zod
-      .string()
+    endedAt: zod.iso
       .datetime({})
       .nullish()
       .describe('When the speaker stopped talking for this segment.'),
@@ -1227,8 +1201,7 @@ export const ingestTranscriptBody = zod
     speakerId: zod
       .string()
       .describe("The speaker's user ID (from `lk.transcribed_track_id`)."),
-    startedAt: zod
-      .string()
+    startedAt: zod.iso
       .datetime({})
       .describe('When the speaker started talking for this segment.'),
   })
@@ -1238,7 +1211,7 @@ export const ingestTranscriptBody = zod
  * @summary Handler for `GET /channels/{channel_id}/attachments`.
  */
 export const getChannelAttachmentsParams = zod.object({
-  channel_id: zod.string().uuid().describe('Channel ID'),
+  channel_id: zod.uuid().describe('Channel ID'),
 });
 
 export const getChannelAttachmentsQueryLimitMin = 0;
@@ -1264,17 +1237,15 @@ export const getChannelAttachmentsResponse = zod
       .array(
         zod
           .object({
-            channel_id: zod.string().uuid().describe('Channel id.'),
-            created_at: zod
-              .string()
+            channel_id: zod.uuid().describe('Channel id.'),
+            created_at: zod.iso
               .datetime({})
               .describe('When the attachment was created.'),
             entity_id: zod.string().describe('Entity id.'),
             entity_type: zod.string().describe('Type of entity.'),
             height: zod.number().nullish().describe('Height (for images).'),
-            id: zod.string().uuid().describe('Attachment id.'),
+            id: zod.uuid().describe('Attachment id.'),
             message_id: zod
-              .string()
               .uuid()
               .describe('Message id this attachment belongs to.'),
             sender_id: zod
@@ -1298,7 +1269,7 @@ export const getChannelAttachmentsResponse = zod
  * @summary Handler for `GET /channels/{channel_id}/messages`.
  */
 export const getChannelMessagesParams = zod.object({
-  channel_id: zod.string().uuid().describe('Channel ID'),
+  channel_id: zod.uuid().describe('Channel ID'),
 });
 
 export const getChannelMessagesQueryLimitMin = 0;
@@ -1318,7 +1289,6 @@ export const getChannelMessagesQueryParams = zod.object({
     .optional()
     .describe('Base64 encoded cursor value for newer messages'),
   load_around_message_id: zod
-    .string()
     .uuid()
     .optional()
     .describe('Return a centered window around this message ID'),
@@ -1334,8 +1304,7 @@ export const getChannelMessagesResponse = zod
               .array(
                 zod
                   .object({
-                    created_at: zod
-                      .string()
+                    created_at: zod.iso
                       .datetime({})
                       .describe('When the attachment was created.'),
                     entity_id: zod.string().describe('Entity id.'),
@@ -1344,7 +1313,7 @@ export const getChannelMessagesResponse = zod
                       .number()
                       .nullish()
                       .describe('Height (for images).'),
-                    id: zod.string().uuid().describe('Attachment id.'),
+                    id: zod.uuid().describe('Attachment id.'),
                     width: zod
                       .number()
                       .nullish()
@@ -1353,23 +1322,20 @@ export const getChannelMessagesResponse = zod
                   .describe('An attachment on a message.')
               )
               .describe('Attachments on this message.'),
-            channel_id: zod.string().uuid().describe('Channel id.'),
+            channel_id: zod.uuid().describe('Channel id.'),
             content: zod.string().describe('Message content.'),
-            created_at: zod
-              .string()
+            created_at: zod.iso
               .datetime({})
               .describe('When the message was created.'),
-            deleted_at: zod
-              .string()
+            deleted_at: zod.iso
               .datetime({})
               .nullish()
               .describe('When the message was soft-deleted.'),
-            edited_at: zod
-              .string()
+            edited_at: zod.iso
               .datetime({})
               .nullish()
               .describe('When the message was edited.'),
-            id: zod.string().uuid().describe('Message id.'),
+            id: zod.uuid().describe('Message id.'),
             reactions: zod
               .array(
                 zod
@@ -1385,8 +1351,7 @@ export const getChannelMessagesResponse = zod
             sender_id: zod.string().describe('Sender user id.'),
             thread: zod
               .object({
-                latest_reply_at: zod
-                  .string()
+                latest_reply_at: zod.iso
                   .datetime({})
                   .nullish()
                   .describe('Timestamp of the latest reply.'),
@@ -1398,8 +1363,7 @@ export const getChannelMessagesResponse = zod
                           .array(
                             zod
                               .object({
-                                created_at: zod
-                                  .string()
+                                created_at: zod.iso
                                   .datetime({})
                                   .describe('When the attachment was created.'),
                                 entity_id: zod.string().describe('Entity id.'),
@@ -1410,10 +1374,7 @@ export const getChannelMessagesResponse = zod
                                   .number()
                                   .nullish()
                                   .describe('Height (for images).'),
-                                id: zod
-                                  .string()
-                                  .uuid()
-                                  .describe('Attachment id.'),
+                                id: zod.uuid().describe('Attachment id.'),
                                 width: zod
                                   .number()
                                   .nullish()
@@ -1423,16 +1384,14 @@ export const getChannelMessagesResponse = zod
                           )
                           .describe('Attachments on this reply.'),
                         content: zod.string().describe('Reply content.'),
-                        created_at: zod
-                          .string()
+                        created_at: zod.iso
                           .datetime({})
                           .describe('When the reply was created.'),
-                        edited_at: zod
-                          .string()
+                        edited_at: zod.iso
                           .datetime({})
                           .nullish()
                           .describe('When the reply was edited.'),
-                        id: zod.string().uuid().describe('Reply id.'),
+                        id: zod.uuid().describe('Reply id.'),
                         reactions: zod
                           .array(
                             zod
@@ -1450,8 +1409,7 @@ export const getChannelMessagesResponse = zod
                           )
                           .describe('Reactions on this reply.'),
                         sender_id: zod.string().describe('Sender user id.'),
-                        updated_at: zod
-                          .string()
+                        updated_at: zod.iso
                           .datetime({})
                           .describe('When the reply was last updated.'),
                       })
@@ -1461,8 +1419,7 @@ export const getChannelMessagesResponse = zod
                 reply_count: zod.number().describe('Total reply count.'),
               })
               .describe('Thread metadata and preview replies.'),
-            updated_at: zod
-              .string()
+            updated_at: zod.iso
               .datetime({})
               .describe('When the message was last updated.'),
           })
@@ -1484,7 +1441,7 @@ export const getChannelMessagesResponse = zod
  * @summary Handler for `POST /channels/{channel_id}/messages`.
  */
 export const postChannelMessagesParams = zod.object({
-  channel_id: zod.string().uuid().describe('Channel ID'),
+  channel_id: zod.uuid().describe('Channel ID'),
 });
 
 export const postChannelMessagesQueryLimitMin = 0;
@@ -1504,7 +1461,6 @@ export const postChannelMessagesQueryParams = zod.object({
     .optional()
     .describe('Base64 encoded cursor value for newer messages'),
   load_around_message_id: zod
-    .string()
     .uuid()
     .optional()
     .describe('Return a centered window around this message ID'),
@@ -1512,15 +1468,14 @@ export const postChannelMessagesQueryParams = zod.object({
 
 export const postChannelMessagesBody = zod
   .object({
-    last_activity: zod
-      .string()
+    last_activity: zod.iso
       .datetime({})
       .nullish()
       .describe(
         'When set, only return top-level messages that have activity after this\ntimestamp. Activity means either the message itself was created after\nthis time, or a thread reply was created after this time.'
       ),
     message_ids: zod
-      .array(zod.string().uuid())
+      .array(zod.uuid())
       .optional()
       .describe('When non-empty, only return messages with these IDs.'),
     notification_filters: zod
@@ -1553,8 +1508,7 @@ export const postChannelMessagesResponse = zod
               .array(
                 zod
                   .object({
-                    created_at: zod
-                      .string()
+                    created_at: zod.iso
                       .datetime({})
                       .describe('When the attachment was created.'),
                     entity_id: zod.string().describe('Entity id.'),
@@ -1563,7 +1517,7 @@ export const postChannelMessagesResponse = zod
                       .number()
                       .nullish()
                       .describe('Height (for images).'),
-                    id: zod.string().uuid().describe('Attachment id.'),
+                    id: zod.uuid().describe('Attachment id.'),
                     width: zod
                       .number()
                       .nullish()
@@ -1572,23 +1526,20 @@ export const postChannelMessagesResponse = zod
                   .describe('An attachment on a message.')
               )
               .describe('Attachments on this message.'),
-            channel_id: zod.string().uuid().describe('Channel id.'),
+            channel_id: zod.uuid().describe('Channel id.'),
             content: zod.string().describe('Message content.'),
-            created_at: zod
-              .string()
+            created_at: zod.iso
               .datetime({})
               .describe('When the message was created.'),
-            deleted_at: zod
-              .string()
+            deleted_at: zod.iso
               .datetime({})
               .nullish()
               .describe('When the message was soft-deleted.'),
-            edited_at: zod
-              .string()
+            edited_at: zod.iso
               .datetime({})
               .nullish()
               .describe('When the message was edited.'),
-            id: zod.string().uuid().describe('Message id.'),
+            id: zod.uuid().describe('Message id.'),
             reactions: zod
               .array(
                 zod
@@ -1604,8 +1555,7 @@ export const postChannelMessagesResponse = zod
             sender_id: zod.string().describe('Sender user id.'),
             thread: zod
               .object({
-                latest_reply_at: zod
-                  .string()
+                latest_reply_at: zod.iso
                   .datetime({})
                   .nullish()
                   .describe('Timestamp of the latest reply.'),
@@ -1617,8 +1567,7 @@ export const postChannelMessagesResponse = zod
                           .array(
                             zod
                               .object({
-                                created_at: zod
-                                  .string()
+                                created_at: zod.iso
                                   .datetime({})
                                   .describe('When the attachment was created.'),
                                 entity_id: zod.string().describe('Entity id.'),
@@ -1629,10 +1578,7 @@ export const postChannelMessagesResponse = zod
                                   .number()
                                   .nullish()
                                   .describe('Height (for images).'),
-                                id: zod
-                                  .string()
-                                  .uuid()
-                                  .describe('Attachment id.'),
+                                id: zod.uuid().describe('Attachment id.'),
                                 width: zod
                                   .number()
                                   .nullish()
@@ -1642,16 +1588,14 @@ export const postChannelMessagesResponse = zod
                           )
                           .describe('Attachments on this reply.'),
                         content: zod.string().describe('Reply content.'),
-                        created_at: zod
-                          .string()
+                        created_at: zod.iso
                           .datetime({})
                           .describe('When the reply was created.'),
-                        edited_at: zod
-                          .string()
+                        edited_at: zod.iso
                           .datetime({})
                           .nullish()
                           .describe('When the reply was edited.'),
-                        id: zod.string().uuid().describe('Reply id.'),
+                        id: zod.uuid().describe('Reply id.'),
                         reactions: zod
                           .array(
                             zod
@@ -1669,8 +1613,7 @@ export const postChannelMessagesResponse = zod
                           )
                           .describe('Reactions on this reply.'),
                         sender_id: zod.string().describe('Sender user id.'),
-                        updated_at: zod
-                          .string()
+                        updated_at: zod.iso
                           .datetime({})
                           .describe('When the reply was last updated.'),
                       })
@@ -1680,8 +1623,7 @@ export const postChannelMessagesResponse = zod
                 reply_count: zod.number().describe('Total reply count.'),
               })
               .describe('Thread metadata and preview replies.'),
-            updated_at: zod
-              .string()
+            updated_at: zod.iso
               .datetime({})
               .describe('When the message was last updated.'),
           })
@@ -1703,11 +1645,8 @@ export const postChannelMessagesResponse = zod
  * @summary Handler for `GET /channels/{channel_id}/messages/{message_id}/replies`.
  */
 export const getThreadRepliesParams = zod.object({
-  channel_id: zod.string().uuid().describe('Channel ID'),
-  message_id: zod
-    .string()
-    .uuid()
-    .describe('Message ID (thread parent or reply id)'),
+  channel_id: zod.uuid().describe('Channel ID'),
+  message_id: zod.uuid().describe('Message ID (thread parent or reply id)'),
 });
 
 export const getThreadRepliesResponseItem = zod
@@ -1716,30 +1655,25 @@ export const getThreadRepliesResponseItem = zod
       .array(
         zod
           .object({
-            created_at: zod
-              .string()
+            created_at: zod.iso
               .datetime({})
               .describe('When the attachment was created.'),
             entity_id: zod.string().describe('Entity id.'),
             entity_type: zod.string().describe('Type of entity.'),
             height: zod.number().nullish().describe('Height (for images).'),
-            id: zod.string().uuid().describe('Attachment id.'),
+            id: zod.uuid().describe('Attachment id.'),
             width: zod.number().nullish().describe('Width (for images).'),
           })
           .describe('An attachment on a message.')
       )
       .describe('Attachments on this reply.'),
     content: zod.string().describe('Reply content.'),
-    created_at: zod
-      .string()
-      .datetime({})
-      .describe('When the reply was created.'),
-    edited_at: zod
-      .string()
+    created_at: zod.iso.datetime({}).describe('When the reply was created.'),
+    edited_at: zod.iso
       .datetime({})
       .nullish()
       .describe('When the reply was edited.'),
-    id: zod.string().uuid().describe('Reply id.'),
+    id: zod.uuid().describe('Reply id.'),
     reactions: zod
       .array(
         zod
@@ -1753,8 +1687,7 @@ export const getThreadRepliesResponseItem = zod
       )
       .describe('Reactions on this reply.'),
     sender_id: zod.string().describe('Sender user id.'),
-    updated_at: zod
-      .string()
+    updated_at: zod.iso
       .datetime({})
       .describe('When the reply was last updated.'),
   })
@@ -1765,13 +1698,13 @@ export const getThreadRepliesResponse = zod.array(getThreadRepliesResponseItem);
  * @summary Handler for `GET /channels/{channel_id}/participants`.
  */
 export const getChannelParticipantsParams = zod.object({
-  channel_id: zod.string().uuid().describe('Channel ID'),
+  channel_id: zod.uuid().describe('Channel ID'),
 });
 
 export const getChannelParticipantsResponseItem = zod
   .object({
-    channel_id: zod.string().uuid().describe('Channel id.'),
-    joined_at: zod.string().datetime({}).describe('When the user joined.'),
+    channel_id: zod.uuid().describe('Channel id.'),
+    joined_at: zod.iso.datetime({}).describe('When the user joined.'),
     role: zod
       .enum(['owner', 'admin', 'member'])
       .describe('Participant role in a channel.'),
@@ -1812,13 +1745,11 @@ export const getUserDocumentsHandlerResponse = zod.object({
               .describe(
                 'The id of the version this document branched from\nThis could be either DocumentInstance or DocumentBom id depending on\nthe file type'
               ),
-            createdAt: zod
-              .string()
+            createdAt: zod.iso
               .datetime({})
               .nullish()
               .describe('The time the document was created'),
-            deletedAt: zod
-              .string()
+            deletedAt: zod.iso
               .datetime({})
               .nullish()
               .describe('The time the document was deleted'),
@@ -1890,8 +1821,7 @@ export const getUserDocumentsHandlerResponse = zod.object({
                   ),
               ])
               .optional(),
-            updatedAt: zod
-              .string()
+            updatedAt: zod.iso
               .datetime({})
               .nullish()
               .describe(
@@ -1927,8 +1857,7 @@ export const createDocumentBody = zod.object({
     .number()
     .nullish()
     .describe('The version id if the document is being branched.'),
-  createdAt: zod
-    .string()
+  createdAt: zod.iso
     .datetime({})
     .nullish()
     .describe(
@@ -1942,7 +1871,6 @@ export const createDocumentBody = zod.object({
     .string()
     .describe('The name of the document without extension.'),
   emailAttachmentId: zod
-    .string()
     .uuid()
     .nullish()
     .describe(
@@ -1952,11 +1880,7 @@ export const createDocumentBody = zod.object({
     .string()
     .nullish()
     .describe('Optional file type of the document.'),
-  id: zod
-    .string()
-    .uuid()
-    .nullish()
-    .describe('The id of the document in the database'),
+  id: zod.uuid().nullish().describe('The id of the document in the database'),
   isTask: zod
     .boolean()
     .optional()
@@ -1975,7 +1899,7 @@ export const createDocumentBody = zod.object({
     .describe(
       'The content type of the document (currently only used for logging matches against file type).'
     ),
-  projectId: zod.string().uuid().nullish(),
+  projectId: zod.uuid().nullish(),
   sha: zod.string().describe('The sha of the document.'),
   skipHistory: zod
     .boolean()
@@ -1999,8 +1923,7 @@ export const createDocumentResponse = zod.object({
           .describe(
             'The id of the version this document branched from\nThis could be either DocumentInstance or DocumentBom id depending on\nthe file type'
           ),
-        createdAt: zod
-          .string()
+        createdAt: zod.iso
           .datetime({})
           .nullish()
           .describe('The time the document was created'),
@@ -2060,8 +1983,7 @@ export const createDocumentResponse = zod.object({
               ),
           ])
           .optional(),
-        updatedAt: zod
-          .string()
+        updatedAt: zod.iso
           .datetime({})
           .nullish()
           .describe(
@@ -2093,7 +2015,6 @@ Task content should be set separately via the sync service.
 export const createTaskHandlerBody = zod
   .object({
     projectId: zod
-      .string()
       .uuid()
       .nullish()
       .describe('Optional project ID to associate the task with.'),
@@ -2113,7 +2034,7 @@ export const createTaskHandlerBody = zod
                 zod
                   .object({
                     type: zod.enum(['date']),
-                    value: zod.string().datetime({}),
+                    value: zod.iso.datetime({}),
                   })
                   .describe('Date and time value'),
                 zod
@@ -2130,13 +2051,13 @@ export const createTaskHandlerBody = zod
                   .describe('String\/text value'),
                 zod
                   .object({
-                    option_id: zod.string().uuid(),
+                    option_id: zod.uuid(),
                     type: zod.enum(['select_option']),
                   })
                   .describe('Select option by ID (for select-type properties)'),
                 zod
                   .object({
-                    option_ids: zod.array(zod.string().uuid()),
+                    option_ids: zod.array(zod.uuid()),
                     type: zod.enum(['multi_select_option']),
                   })
                   .describe(
@@ -2162,7 +2083,6 @@ export const createTaskHandlerBody = zod
                             'Type of entity that can be referenced by entity properties.'
                           ),
                         specific_message_id: zod
-                          .string()
                           .uuid()
                           .nullish()
                           .describe(
@@ -2196,7 +2116,6 @@ export const createTaskHandlerBody = zod
                               'Type of entity that can be referenced by entity properties.'
                             ),
                           specific_message_id: zod
-                            .string()
                             .uuid()
                             .nullish()
                             .describe(
@@ -2272,8 +2191,7 @@ export const getDocumentListHandlerResponse = zod.object({
           .describe(
             'The id of the version this document branched from\nThis could be either DocumentInstance or DocumentBom id depending on\nthe file type'
           ),
-        createdAt: zod
-          .string()
+        createdAt: zod.iso
           .datetime({})
           .nullish()
           .describe('The time the document was created'),
@@ -2290,8 +2208,7 @@ export const getDocumentListHandlerResponse = zod.object({
           .string()
           .nullish()
           .describe('The file type of the document'),
-        updatedAt: zod
-          .string()
+        updatedAt: zod.iso
           .datetime({})
           .nullish()
           .describe(
@@ -2414,8 +2331,7 @@ export const getBatchPreviewHandlerResponse = zod.object({
                 ),
             ])
             .optional(),
-          updated_at: zod
-            .string()
+          updated_at: zod.iso
             .datetime({})
             .nullish()
             .describe('The time the document was last updated'),
@@ -2468,13 +2384,11 @@ export const getDocumentResponse = zod.object({
         .describe(
           'The id of the version this document branched from\nThis could be either DocumentInstance or DocumentBom id depending on\nthe file type'
         ),
-      createdAt: zod
-        .string()
+      createdAt: zod.iso
         .datetime({})
         .nullish()
         .describe('The time the document was created'),
-      deletedAt: zod
-        .string()
+      deletedAt: zod.iso
         .datetime({})
         .nullish()
         .describe('The time the document was deleted'),
@@ -2542,8 +2456,7 @@ export const getDocumentResponse = zod.object({
             ),
         ])
         .optional(),
-      updatedAt: zod
-        .string()
+      updatedAt: zod.iso
         .datetime({})
         .nullish()
         .describe('The time the document instance \/ document BOM was updated'),
@@ -2609,8 +2522,7 @@ export const saveDocumentHandlerResponse = zod.object({
         .describe(
           'The id of the version this document branched from\nThis could be either DocumentInstance or DocumentBom id depending on\nthe file type'
         ),
-      createdAt: zod
-        .string()
+      createdAt: zod.iso
         .datetime({})
         .nullish()
         .describe('The time the document was created'),
@@ -2670,8 +2582,7 @@ export const saveDocumentHandlerResponse = zod.object({
             ),
         ])
         .optional(),
-      updatedAt: zod
-        .string()
+      updatedAt: zod.iso
         .datetime({})
         .nullish()
         .describe('The time the document instance \/ document BOM was updated'),
@@ -3262,8 +3173,7 @@ export const copyDocumentResponse = zod
           .describe(
             'The id of the version this document branched from\nThis could be either DocumentInstance or DocumentBom id depending on\nthe file type'
           ),
-        createdAt: zod
-          .string()
+        createdAt: zod.iso
           .datetime({})
           .nullish()
           .describe('The time the document was created'),
@@ -3323,8 +3233,7 @@ export const copyDocumentResponse = zod
               ),
           ])
           .optional(),
-        updatedAt: zod
-          .string()
+        updatedAt: zod.iso
           .datetime({})
           .nullish()
           .describe(
@@ -3509,8 +3418,7 @@ export const simpleSaveResponse = zod.object({
         .describe(
           'The id of the version this document branched from\nThis could be either DocumentInstance or DocumentBom id depending on\nthe file type'
         ),
-      createdAt: zod
-        .string()
+      createdAt: zod.iso
         .datetime({})
         .nullish()
         .describe('The time the document was created'),
@@ -3570,8 +3478,7 @@ export const simpleSaveResponse = zod.object({
             ),
         ])
         .optional(),
-      updatedAt: zod
-        .string()
+      updatedAt: zod.iso
         .datetime({})
         .nullish()
         .describe('The time the document instance \/ document BOM was updated'),
@@ -3621,13 +3528,11 @@ export const getDocumentVersionResponse = zod.object({
         .describe(
           'The id of the version this document branched from\nThis could be either DocumentInstance or DocumentBom id depending on\nthe file type'
         ),
-      createdAt: zod
-        .string()
+      createdAt: zod.iso
         .datetime({})
         .nullish()
         .describe('The time the document was created'),
-      deletedAt: zod
-        .string()
+      deletedAt: zod.iso
         .datetime({})
         .nullish()
         .describe('The time the document was deleted'),
@@ -3695,8 +3600,7 @@ export const getDocumentVersionResponse = zod.object({
             ),
         ])
         .optional(),
-      updatedAt: zod
-        .string()
+      updatedAt: zod.iso
         .datetime({})
         .nullish()
         .describe('The time the document instance \/ document BOM was updated'),
@@ -3777,13 +3681,11 @@ export const getHistoryHandlerResponse = zod.object({
             .describe(
               'The id of the version this document branched from\nThis could be either DocumentInstance or DocumentBom id depending on\nthe file type'
             ),
-          createdAt: zod
-            .string()
+          createdAt: zod.iso
             .datetime({})
             .nullish()
             .describe('The time the document was created'),
-          deletedAt: zod
-            .string()
+          deletedAt: zod.iso
             .datetime({})
             .nullish()
             .describe('The time the document was deleted'),
@@ -3831,8 +3733,7 @@ export const getHistoryHandlerResponse = zod.object({
                 ),
             ])
             .optional(),
-          updatedAt: zod
-            .string()
+          updatedAt: zod.iso
             .datetime({})
             .nullish()
             .describe(
@@ -3841,13 +3742,11 @@ export const getHistoryHandlerResponse = zod.object({
           type: zod.enum(['document']),
         }),
         zod.object({
-          createdAt: zod
-            .string()
+          createdAt: zod.iso
             .datetime({})
             .nullish()
             .describe('The time the chat was created'),
-          deletedAt: zod
-            .string()
+          deletedAt: zod.iso
             .datetime({})
             .nullish()
             .describe('The time the chat was deleted'),
@@ -3863,8 +3762,7 @@ export const getHistoryHandlerResponse = zod.object({
             .nullish()
             .describe('The project id of the chat'),
           tokenCount: zod.number().nullish(),
-          updatedAt: zod
-            .string()
+          updatedAt: zod.iso
             .datetime({})
             .nullish()
             .describe('The time the chat was last updated'),
@@ -3872,17 +3770,15 @@ export const getHistoryHandlerResponse = zod.object({
           type: zod.enum(['chat']),
         }),
         zod.object({
-          createdAt: zod
-            .string()
+          createdAt: zod.iso
             .datetime({})
             .nullish()
             .describe('The time the project was created'),
-          deletedAt: zod.string().datetime({}).nullish(),
+          deletedAt: zod.iso.datetime({}).nullish(),
           id: zod.string().describe('The id of the project'),
           name: zod.string().describe('The name of the project'),
           parentId: zod.string().nullish().describe('The parent project id'),
-          updatedAt: zod
-            .string()
+          updatedAt: zod.iso
             .datetime({})
             .nullish()
             .describe('The time the project was updated'),
@@ -3980,7 +3876,6 @@ export const getItemsSoupResponse = zod.object({
         zod.object({
           data: zod.object({
             branchedFromId: zod
-              .string()
               .uuid()
               .nullish()
               .describe('The id of the document this document branched from'),
@@ -3990,12 +3885,10 @@ export const getItemsSoupResponse = zod.object({
               .describe(
                 'The id of the version this document branched from\nThis could be either DocumentInstance or DocumentBom id depending on the file type'
               ),
-            createdAt: zod
-              .string()
+            createdAt: zod.iso
               .datetime({})
               .describe('The time the document was created'),
-            deletedAt: zod
-              .string()
+            deletedAt: zod.iso
               .datetime({})
               .nullish()
               .describe('The time the document was deleted'),
@@ -4014,11 +3907,10 @@ export const getItemsSoupResponse = zod.object({
               .string()
               .nullish()
               .describe('The file type of the document (e.g. pdf, docx)'),
-            id: zod.string().uuid().describe('The document id'),
+            id: zod.uuid().describe('The document id'),
             name: zod.string().describe('The name of the document'),
             ownerId: zod.string().describe('The owner of the document'),
             projectId: zod
-              .string()
               .uuid()
               .nullish()
               .describe('The id of the project that this document belongs to'),
@@ -4028,7 +3920,7 @@ export const getItemsSoupResponse = zod.object({
                   .object({
                     definition: zod
                       .object({
-                        created_at: zod.string().datetime({}),
+                        created_at: zod.iso.datetime({}),
                         data_type: zod
                           .enum([
                             'BOOLEAN',
@@ -4044,7 +3936,7 @@ export const getItemsSoupResponse = zod.object({
                             'Data type for property values, determining storage and validation.'
                           ),
                         display_name: zod.string(),
-                        id: zod.string().uuid(),
+                        id: zod.uuid(),
                         is_metadata: zod
                           .boolean()
                           .describe(
@@ -4107,7 +3999,7 @@ export const getItemsSoupResponse = zod.object({
                               ),
                           ])
                           .optional(),
-                        updated_at: zod.string().datetime({}),
+                        updated_at: zod.iso.datetime({}),
                       })
                       .describe(
                         'Property definition model (service representation).'
@@ -4156,8 +4048,7 @@ export const getItemsSoupResponse = zod.object({
                             zod
                               .object({
                                 type: zod.enum(['Date']),
-                                value: zod
-                                  .string()
+                                value: zod.iso
                                   .datetime({})
                                   .describe(
                                     'Date\/timestamp value\nSerializes as: {\"type\": \"Date\", \"value\": \"2025-01-01T00:00:00Z\"}'
@@ -4170,7 +4061,7 @@ export const getItemsSoupResponse = zod.object({
                               .object({
                                 type: zod.enum(['SelectOption']),
                                 value: zod
-                                  .array(zod.string().uuid())
+                                  .array(zod.uuid())
                                   .describe(
                                     'Select option(s) - always an array (check is_multi_select to determine if single or multi)\nSingle-select: {\"type\": \"SelectOption\", \"value\": [\"uuid\"]} (length 0 or 1)\nMulti-select: {\"type\": \"SelectOption\", \"value\": [\"uuid1\", \"uuid2\", ...]} (length 0+)'
                                   ),
@@ -4201,7 +4092,6 @@ export const getItemsSoupResponse = zod.object({
                                             'Type of entity that can be referenced by entity properties.'
                                           ),
                                         specific_message_id: zod
-                                          .string()
                                           .uuid()
                                           .nullish()
                                           .describe(
@@ -4267,14 +4157,12 @@ export const getItemsSoupResponse = zod.object({
                   ),
               ])
               .optional(),
-            updatedAt: zod
-              .string()
+            updatedAt: zod.iso
               .datetime({})
               .describe(
                 'The time the document instance \/ document BOM was updated'
               ),
-            viewedAt: zod
-              .string()
+            viewedAt: zod.iso
               .datetime({})
               .nullish()
               .describe('The time the document was last viewed'),
@@ -4283,23 +4171,20 @@ export const getItemsSoupResponse = zod.object({
         }),
         zod.object({
           data: zod.object({
-            createdAt: zod
-              .string()
+            createdAt: zod.iso
               .datetime({})
               .describe('The time the chat was created'),
-            deletedAt: zod
-              .string()
+            deletedAt: zod.iso
               .datetime({})
               .nullish()
               .describe('The time the chat was deleted'),
-            id: zod.string().uuid().describe('The chat uuid'),
+            id: zod.uuid().describe('The chat uuid'),
             isPersistent: zod
               .boolean()
               .describe('Whether the chat is persistent or not'),
             name: zod.string().describe('The name of the chat'),
             ownerId: zod.string().describe('Who the chat belongs to'),
             projectId: zod
-              .string()
               .uuid()
               .nullish()
               .describe('The project id of the chat'),
@@ -4309,7 +4194,7 @@ export const getItemsSoupResponse = zod.object({
                   .object({
                     definition: zod
                       .object({
-                        created_at: zod.string().datetime({}),
+                        created_at: zod.iso.datetime({}),
                         data_type: zod
                           .enum([
                             'BOOLEAN',
@@ -4325,7 +4210,7 @@ export const getItemsSoupResponse = zod.object({
                             'Data type for property values, determining storage and validation.'
                           ),
                         display_name: zod.string(),
-                        id: zod.string().uuid(),
+                        id: zod.uuid(),
                         is_metadata: zod
                           .boolean()
                           .describe(
@@ -4388,7 +4273,7 @@ export const getItemsSoupResponse = zod.object({
                               ),
                           ])
                           .optional(),
-                        updated_at: zod.string().datetime({}),
+                        updated_at: zod.iso.datetime({}),
                       })
                       .describe(
                         'Property definition model (service representation).'
@@ -4437,8 +4322,7 @@ export const getItemsSoupResponse = zod.object({
                             zod
                               .object({
                                 type: zod.enum(['Date']),
-                                value: zod
-                                  .string()
+                                value: zod.iso
                                   .datetime({})
                                   .describe(
                                     'Date\/timestamp value\nSerializes as: {\"type\": \"Date\", \"value\": \"2025-01-01T00:00:00Z\"}'
@@ -4451,7 +4335,7 @@ export const getItemsSoupResponse = zod.object({
                               .object({
                                 type: zod.enum(['SelectOption']),
                                 value: zod
-                                  .array(zod.string().uuid())
+                                  .array(zod.uuid())
                                   .describe(
                                     'Select option(s) - always an array (check is_multi_select to determine if single or multi)\nSingle-select: {\"type\": \"SelectOption\", \"value\": [\"uuid\"]} (length 0 or 1)\nMulti-select: {\"type\": \"SelectOption\", \"value\": [\"uuid1\", \"uuid2\", ...]} (length 0+)'
                                   ),
@@ -4482,7 +4366,6 @@ export const getItemsSoupResponse = zod.object({
                                             'Type of entity that can be referenced by entity properties.'
                                           ),
                                         specific_message_id: zod
-                                          .string()
                                           .uuid()
                                           .nullish()
                                           .describe(
@@ -4524,12 +4407,10 @@ export const getItemsSoupResponse = zod.object({
                   )
               )
               .describe('Properties'),
-            updatedAt: zod
-              .string()
+            updatedAt: zod.iso
               .datetime({})
               .describe('The time the chat was last updated'),
-            viewedAt: zod
-              .string()
+            viewedAt: zod.iso
               .datetime({})
               .nullish()
               .describe('The time the chat was last viewed'),
@@ -4538,32 +4419,26 @@ export const getItemsSoupResponse = zod.object({
         }),
         zod.object({
           data: zod.object({
-            createdAt: zod
-              .string()
+            createdAt: zod.iso
               .datetime({})
               .describe('The time the project was created'),
-            deletedAt: zod
-              .string()
+            deletedAt: zod.iso
               .datetime({})
               .nullish()
               .describe('The time the project was deleted'),
-            id: zod.string().uuid().describe('The id of the project'),
+            id: zod.uuid().describe('The id of the project'),
             name: zod.string().describe('The name of the project'),
             ownerId: zod
               .string()
               .describe('The user id of who created the project'),
-            parentId: zod
-              .string()
-              .uuid()
-              .nullish()
-              .describe('The parent project id'),
+            parentId: zod.uuid().nullish().describe('The parent project id'),
             properties: zod
               .array(
                 zod
                   .object({
                     definition: zod
                       .object({
-                        created_at: zod.string().datetime({}),
+                        created_at: zod.iso.datetime({}),
                         data_type: zod
                           .enum([
                             'BOOLEAN',
@@ -4579,7 +4454,7 @@ export const getItemsSoupResponse = zod.object({
                             'Data type for property values, determining storage and validation.'
                           ),
                         display_name: zod.string(),
-                        id: zod.string().uuid(),
+                        id: zod.uuid(),
                         is_metadata: zod
                           .boolean()
                           .describe(
@@ -4642,7 +4517,7 @@ export const getItemsSoupResponse = zod.object({
                               ),
                           ])
                           .optional(),
-                        updated_at: zod.string().datetime({}),
+                        updated_at: zod.iso.datetime({}),
                       })
                       .describe(
                         'Property definition model (service representation).'
@@ -4691,8 +4566,7 @@ export const getItemsSoupResponse = zod.object({
                             zod
                               .object({
                                 type: zod.enum(['Date']),
-                                value: zod
-                                  .string()
+                                value: zod.iso
                                   .datetime({})
                                   .describe(
                                     'Date\/timestamp value\nSerializes as: {\"type\": \"Date\", \"value\": \"2025-01-01T00:00:00Z\"}'
@@ -4705,7 +4579,7 @@ export const getItemsSoupResponse = zod.object({
                               .object({
                                 type: zod.enum(['SelectOption']),
                                 value: zod
-                                  .array(zod.string().uuid())
+                                  .array(zod.uuid())
                                   .describe(
                                     'Select option(s) - always an array (check is_multi_select to determine if single or multi)\nSingle-select: {\"type\": \"SelectOption\", \"value\": [\"uuid\"]} (length 0 or 1)\nMulti-select: {\"type\": \"SelectOption\", \"value\": [\"uuid1\", \"uuid2\", ...]} (length 0+)'
                                   ),
@@ -4736,7 +4610,6 @@ export const getItemsSoupResponse = zod.object({
                                             'Type of entity that can be referenced by entity properties.'
                                           ),
                                         specific_message_id: zod
-                                          .string()
                                           .uuid()
                                           .nullish()
                                           .describe(
@@ -4778,12 +4651,10 @@ export const getItemsSoupResponse = zod.object({
                   )
               )
               .describe('Properties'),
-            updatedAt: zod
-              .string()
+            updatedAt: zod.iso
               .datetime({})
               .describe('The time the project was updated'),
-            viewedAt: zod
-              .string()
+            viewedAt: zod.iso
               .datetime({})
               .nullish()
               .describe('The time the document was last viewed'),
@@ -4793,8 +4664,8 @@ export const getItemsSoupResponse = zod.object({
         zod.object({
           data: zod
             .object({
-              createdAt: zod.string().datetime({}),
-              id: zod.string().uuid(),
+              createdAt: zod.iso.datetime({}),
+              id: zod.uuid(),
               inboxVisible: zod.boolean(),
               isDraft: zod.boolean(),
               isImportant: zod.boolean(),
@@ -4807,19 +4678,19 @@ export const getItemsSoupResponse = zod.object({
               senderName: zod.string().nullish(),
               senderPhotoUrl: zod.string().nullish(),
               snippet: zod.string().nullish(),
-              sortTs: zod.string().datetime({}),
-              updatedAt: zod.string().datetime({}),
-              viewedAt: zod.string().datetime({}).nullish(),
+              sortTs: zod.iso.datetime({}),
+              updatedAt: zod.iso.datetime({}),
+              viewedAt: zod.iso.datetime({}).nullish(),
             })
             .and(
               zod.object({
                 attachments: zod.array(
                   zod.object({
                     contentId: zod.string().nullish(),
-                    createdAt: zod.string().datetime({}),
+                    createdAt: zod.iso.datetime({}),
                     filename: zod.string().nullish(),
-                    id: zod.string().uuid(),
-                    messageId: zod.string().uuid(),
+                    id: zod.uuid(),
+                    messageId: zod.uuid(),
                     mimeType: zod.string().nullish(),
                     providerAttachmentId: zod.string().nullish(),
                     sizeBytes: zod.number().nullish(),
@@ -4827,14 +4698,14 @@ export const getItemsSoupResponse = zod.object({
                 ),
                 labels: zod.array(
                   zod.object({
-                    createdAt: zod.string().datetime({}),
-                    id: zod.string().uuid(),
+                    createdAt: zod.iso.datetime({}),
+                    id: zod.uuid(),
                     labelListVisibility: zod.enum([
                       'labelShow',
                       'labelShowIfUnread',
                       'labelHide',
                     ]),
-                    linkId: zod.string().uuid(),
+                    linkId: zod.uuid(),
                     messageListVisibility: zod.enum(['show', 'hide']),
                     name: zod.string(),
                     providerLabelId: zod.string(),
@@ -4844,8 +4715,8 @@ export const getItemsSoupResponse = zod.object({
                 participants: zod.array(
                   zod.object({
                     emailAddress: zod.string().nullish(),
-                    id: zod.string().uuid(),
-                    linkId: zod.string().uuid(),
+                    id: zod.uuid(),
+                    linkId: zod.uuid(),
                     name: zod.string().nullish(),
                     sfsPhotoUrl: zod.string().nullish(),
                   })
@@ -4855,7 +4726,7 @@ export const getItemsSoupResponse = zod.object({
                     .object({
                       definition: zod
                         .object({
-                          created_at: zod.string().datetime({}),
+                          created_at: zod.iso.datetime({}),
                           data_type: zod
                             .enum([
                               'BOOLEAN',
@@ -4871,7 +4742,7 @@ export const getItemsSoupResponse = zod.object({
                               'Data type for property values, determining storage and validation.'
                             ),
                           display_name: zod.string(),
-                          id: zod.string().uuid(),
+                          id: zod.uuid(),
                           is_metadata: zod
                             .boolean()
                             .describe(
@@ -4934,7 +4805,7 @@ export const getItemsSoupResponse = zod.object({
                                 ),
                             ])
                             .optional(),
-                          updated_at: zod.string().datetime({}),
+                          updated_at: zod.iso.datetime({}),
                         })
                         .describe(
                           'Property definition model (service representation).'
@@ -4983,8 +4854,7 @@ export const getItemsSoupResponse = zod.object({
                               zod
                                 .object({
                                   type: zod.enum(['Date']),
-                                  value: zod
-                                    .string()
+                                  value: zod.iso
                                     .datetime({})
                                     .describe(
                                       'Date\/timestamp value\nSerializes as: {\"type\": \"Date\", \"value\": \"2025-01-01T00:00:00Z\"}'
@@ -4997,7 +4867,7 @@ export const getItemsSoupResponse = zod.object({
                                 .object({
                                   type: zod.enum(['SelectOption']),
                                   value: zod
-                                    .array(zod.string().uuid())
+                                    .array(zod.uuid())
                                     .describe(
                                       'Select option(s) - always an array (check is_multi_select to determine if single or multi)\nSingle-select: {\"type\": \"SelectOption\", \"value\": [\"uuid\"]} (length 0 or 1)\nMulti-select: {\"type\": \"SelectOption\", \"value\": [\"uuid1\", \"uuid2\", ...]} (length 0+)'
                                     ),
@@ -5028,7 +4898,6 @@ export const getItemsSoupResponse = zod.object({
                                               'Type of entity that can be referenced by entity properties.'
                                             ),
                                           specific_message_id: zod
-                                            .string()
                                             .uuid()
                                             .nullish()
                                             .describe(
@@ -5084,22 +4953,22 @@ export const getItemsSoupResponse = zod.object({
                   'direct_message',
                   'team',
                 ]),
-                created_at: zod.string().datetime({}),
-                id: zod.string().uuid(),
+                created_at: zod.iso.datetime({}),
+                id: zod.uuid(),
                 name: zod.string().nullish(),
                 org_id: zod
                   .number()
                   .min(getItemsSoupResponseItemsItemDataChannelOrgIdMin)
                   .nullish(),
                 owner_id: zod.string(),
-                team_id: zod.string().uuid().nullish(),
-                updated_at: zod.string().datetime({}),
+                team_id: zod.uuid().nullish(),
+                updated_at: zod.iso.datetime({}),
               }),
               participants: zod.array(
                 zod.object({
-                  channel_id: zod.string().uuid(),
-                  joined_at: zod.string().datetime({}),
-                  left_at: zod.string().datetime({}).nullish(),
+                  channel_id: zod.uuid(),
+                  joined_at: zod.iso.datetime({}),
+                  left_at: zod.iso.datetime({}).nullish(),
                   role: zod
                     .enum(['owner', 'admin', 'member'])
                     .describe('The role a user has within a channel.'),
@@ -5114,17 +4983,17 @@ export const getItemsSoupResponse = zod.object({
                     zod.null(),
                     zod.object({
                       content: zod.string(),
-                      created_at: zod.string().datetime({}),
-                      deleted_at: zod.string().datetime({}).nullish(),
+                      created_at: zod.iso.datetime({}),
+                      deleted_at: zod.iso.datetime({}).nullish(),
                       mentions: zod
                         .array(zod.string())
                         .describe(
                           'message mentions formatted as `{ENTITY_TYPE}:{ENTITY_ID}`'
                         ),
-                      message_id: zod.string().uuid(),
+                      message_id: zod.uuid(),
                       sender_id: zod.string(),
-                      thread_id: zod.string().uuid().nullish(),
-                      updated_at: zod.string().datetime({}),
+                      thread_id: zod.uuid().nullish(),
+                      updated_at: zod.iso.datetime({}),
                     }),
                   ])
                   .optional(),
@@ -5133,17 +5002,17 @@ export const getItemsSoupResponse = zod.object({
                     zod.null(),
                     zod.object({
                       content: zod.string(),
-                      created_at: zod.string().datetime({}),
-                      deleted_at: zod.string().datetime({}).nullish(),
+                      created_at: zod.iso.datetime({}),
+                      deleted_at: zod.iso.datetime({}).nullish(),
                       mentions: zod
                         .array(zod.string())
                         .describe(
                           'message mentions formatted as `{ENTITY_TYPE}:{ENTITY_ID}`'
                         ),
-                      message_id: zod.string().uuid(),
+                      message_id: zod.uuid(),
                       sender_id: zod.string(),
-                      thread_id: zod.string().uuid().nullish(),
-                      updated_at: zod.string().datetime({}),
+                      thread_id: zod.uuid().nullish(),
+                      updated_at: zod.iso.datetime({}),
                     }),
                   ])
                   .optional(),
@@ -5151,8 +5020,8 @@ export const getItemsSoupResponse = zod.object({
             )
             .and(
               zod.object({
-                interacted_at: zod.string().datetime({}).nullish(),
-                viewed_at: zod.string().datetime({}).nullish(),
+                interacted_at: zod.iso.datetime({}).nullish(),
+                viewed_at: zod.iso.datetime({}).nullish(),
               })
             ),
           tag: zod.enum(['channel']),
@@ -5165,9 +5034,8 @@ export const getItemsSoupResponse = zod.object({
                 .describe(
                   'Whether the requesting user attended this call (i.e. appears in the\n`call_participants` \/ `call_record_participants` table).'
                 ),
-              callId: zod.string().uuid().describe('The call identifier.'),
+              callId: zod.uuid().describe('The call identifier.'),
               channelId: zod
-                .string()
                 .uuid()
                 .describe('The channel this call belongs to.'),
               channelName: zod
@@ -5187,8 +5055,7 @@ export const getItemsSoupResponse = zod.object({
                 .describe(
                   'Call duration in milliseconds (None if still active).'
                 ),
-              endedAt: zod
-                .string()
+              endedAt: zod.iso
                 .datetime({})
                 .nullish()
                 .describe('When the call ended (None if still active).'),
@@ -5199,12 +5066,10 @@ export const getItemsSoupResponse = zod.object({
                 .array(
                   zod
                     .object({
-                      joinedAt: zod
-                        .string()
+                      joinedAt: zod.iso
                         .datetime({})
                         .describe('When the user joined the call.'),
-                      leftAt: zod
-                        .string()
+                      leftAt: zod.iso
                         .datetime({})
                         .nullish()
                         .describe(
@@ -5217,8 +5082,7 @@ export const getItemsSoupResponse = zod.object({
                     )
                 )
                 .describe('Participants in the call.'),
-              startedAt: zod
-                .string()
+              startedAt: zod.iso
                 .datetime({})
                 .describe('When the call started.'),
             })
@@ -5683,7 +5547,6 @@ export const postItemsSoupResponse = zod.object({
         zod.object({
           data: zod.object({
             branchedFromId: zod
-              .string()
               .uuid()
               .nullish()
               .describe('The id of the document this document branched from'),
@@ -5693,12 +5556,10 @@ export const postItemsSoupResponse = zod.object({
               .describe(
                 'The id of the version this document branched from\nThis could be either DocumentInstance or DocumentBom id depending on the file type'
               ),
-            createdAt: zod
-              .string()
+            createdAt: zod.iso
               .datetime({})
               .describe('The time the document was created'),
-            deletedAt: zod
-              .string()
+            deletedAt: zod.iso
               .datetime({})
               .nullish()
               .describe('The time the document was deleted'),
@@ -5717,11 +5578,10 @@ export const postItemsSoupResponse = zod.object({
               .string()
               .nullish()
               .describe('The file type of the document (e.g. pdf, docx)'),
-            id: zod.string().uuid().describe('The document id'),
+            id: zod.uuid().describe('The document id'),
             name: zod.string().describe('The name of the document'),
             ownerId: zod.string().describe('The owner of the document'),
             projectId: zod
-              .string()
               .uuid()
               .nullish()
               .describe('The id of the project that this document belongs to'),
@@ -5731,7 +5591,7 @@ export const postItemsSoupResponse = zod.object({
                   .object({
                     definition: zod
                       .object({
-                        created_at: zod.string().datetime({}),
+                        created_at: zod.iso.datetime({}),
                         data_type: zod
                           .enum([
                             'BOOLEAN',
@@ -5747,7 +5607,7 @@ export const postItemsSoupResponse = zod.object({
                             'Data type for property values, determining storage and validation.'
                           ),
                         display_name: zod.string(),
-                        id: zod.string().uuid(),
+                        id: zod.uuid(),
                         is_metadata: zod
                           .boolean()
                           .describe(
@@ -5810,7 +5670,7 @@ export const postItemsSoupResponse = zod.object({
                               ),
                           ])
                           .optional(),
-                        updated_at: zod.string().datetime({}),
+                        updated_at: zod.iso.datetime({}),
                       })
                       .describe(
                         'Property definition model (service representation).'
@@ -5859,8 +5719,7 @@ export const postItemsSoupResponse = zod.object({
                             zod
                               .object({
                                 type: zod.enum(['Date']),
-                                value: zod
-                                  .string()
+                                value: zod.iso
                                   .datetime({})
                                   .describe(
                                     'Date\/timestamp value\nSerializes as: {\"type\": \"Date\", \"value\": \"2025-01-01T00:00:00Z\"}'
@@ -5873,7 +5732,7 @@ export const postItemsSoupResponse = zod.object({
                               .object({
                                 type: zod.enum(['SelectOption']),
                                 value: zod
-                                  .array(zod.string().uuid())
+                                  .array(zod.uuid())
                                   .describe(
                                     'Select option(s) - always an array (check is_multi_select to determine if single or multi)\nSingle-select: {\"type\": \"SelectOption\", \"value\": [\"uuid\"]} (length 0 or 1)\nMulti-select: {\"type\": \"SelectOption\", \"value\": [\"uuid1\", \"uuid2\", ...]} (length 0+)'
                                   ),
@@ -5904,7 +5763,6 @@ export const postItemsSoupResponse = zod.object({
                                             'Type of entity that can be referenced by entity properties.'
                                           ),
                                         specific_message_id: zod
-                                          .string()
                                           .uuid()
                                           .nullish()
                                           .describe(
@@ -5970,14 +5828,12 @@ export const postItemsSoupResponse = zod.object({
                   ),
               ])
               .optional(),
-            updatedAt: zod
-              .string()
+            updatedAt: zod.iso
               .datetime({})
               .describe(
                 'The time the document instance \/ document BOM was updated'
               ),
-            viewedAt: zod
-              .string()
+            viewedAt: zod.iso
               .datetime({})
               .nullish()
               .describe('The time the document was last viewed'),
@@ -5986,23 +5842,20 @@ export const postItemsSoupResponse = zod.object({
         }),
         zod.object({
           data: zod.object({
-            createdAt: zod
-              .string()
+            createdAt: zod.iso
               .datetime({})
               .describe('The time the chat was created'),
-            deletedAt: zod
-              .string()
+            deletedAt: zod.iso
               .datetime({})
               .nullish()
               .describe('The time the chat was deleted'),
-            id: zod.string().uuid().describe('The chat uuid'),
+            id: zod.uuid().describe('The chat uuid'),
             isPersistent: zod
               .boolean()
               .describe('Whether the chat is persistent or not'),
             name: zod.string().describe('The name of the chat'),
             ownerId: zod.string().describe('Who the chat belongs to'),
             projectId: zod
-              .string()
               .uuid()
               .nullish()
               .describe('The project id of the chat'),
@@ -6012,7 +5865,7 @@ export const postItemsSoupResponse = zod.object({
                   .object({
                     definition: zod
                       .object({
-                        created_at: zod.string().datetime({}),
+                        created_at: zod.iso.datetime({}),
                         data_type: zod
                           .enum([
                             'BOOLEAN',
@@ -6028,7 +5881,7 @@ export const postItemsSoupResponse = zod.object({
                             'Data type for property values, determining storage and validation.'
                           ),
                         display_name: zod.string(),
-                        id: zod.string().uuid(),
+                        id: zod.uuid(),
                         is_metadata: zod
                           .boolean()
                           .describe(
@@ -6091,7 +5944,7 @@ export const postItemsSoupResponse = zod.object({
                               ),
                           ])
                           .optional(),
-                        updated_at: zod.string().datetime({}),
+                        updated_at: zod.iso.datetime({}),
                       })
                       .describe(
                         'Property definition model (service representation).'
@@ -6140,8 +5993,7 @@ export const postItemsSoupResponse = zod.object({
                             zod
                               .object({
                                 type: zod.enum(['Date']),
-                                value: zod
-                                  .string()
+                                value: zod.iso
                                   .datetime({})
                                   .describe(
                                     'Date\/timestamp value\nSerializes as: {\"type\": \"Date\", \"value\": \"2025-01-01T00:00:00Z\"}'
@@ -6154,7 +6006,7 @@ export const postItemsSoupResponse = zod.object({
                               .object({
                                 type: zod.enum(['SelectOption']),
                                 value: zod
-                                  .array(zod.string().uuid())
+                                  .array(zod.uuid())
                                   .describe(
                                     'Select option(s) - always an array (check is_multi_select to determine if single or multi)\nSingle-select: {\"type\": \"SelectOption\", \"value\": [\"uuid\"]} (length 0 or 1)\nMulti-select: {\"type\": \"SelectOption\", \"value\": [\"uuid1\", \"uuid2\", ...]} (length 0+)'
                                   ),
@@ -6185,7 +6037,6 @@ export const postItemsSoupResponse = zod.object({
                                             'Type of entity that can be referenced by entity properties.'
                                           ),
                                         specific_message_id: zod
-                                          .string()
                                           .uuid()
                                           .nullish()
                                           .describe(
@@ -6227,12 +6078,10 @@ export const postItemsSoupResponse = zod.object({
                   )
               )
               .describe('Properties'),
-            updatedAt: zod
-              .string()
+            updatedAt: zod.iso
               .datetime({})
               .describe('The time the chat was last updated'),
-            viewedAt: zod
-              .string()
+            viewedAt: zod.iso
               .datetime({})
               .nullish()
               .describe('The time the chat was last viewed'),
@@ -6241,32 +6090,26 @@ export const postItemsSoupResponse = zod.object({
         }),
         zod.object({
           data: zod.object({
-            createdAt: zod
-              .string()
+            createdAt: zod.iso
               .datetime({})
               .describe('The time the project was created'),
-            deletedAt: zod
-              .string()
+            deletedAt: zod.iso
               .datetime({})
               .nullish()
               .describe('The time the project was deleted'),
-            id: zod.string().uuid().describe('The id of the project'),
+            id: zod.uuid().describe('The id of the project'),
             name: zod.string().describe('The name of the project'),
             ownerId: zod
               .string()
               .describe('The user id of who created the project'),
-            parentId: zod
-              .string()
-              .uuid()
-              .nullish()
-              .describe('The parent project id'),
+            parentId: zod.uuid().nullish().describe('The parent project id'),
             properties: zod
               .array(
                 zod
                   .object({
                     definition: zod
                       .object({
-                        created_at: zod.string().datetime({}),
+                        created_at: zod.iso.datetime({}),
                         data_type: zod
                           .enum([
                             'BOOLEAN',
@@ -6282,7 +6125,7 @@ export const postItemsSoupResponse = zod.object({
                             'Data type for property values, determining storage and validation.'
                           ),
                         display_name: zod.string(),
-                        id: zod.string().uuid(),
+                        id: zod.uuid(),
                         is_metadata: zod
                           .boolean()
                           .describe(
@@ -6345,7 +6188,7 @@ export const postItemsSoupResponse = zod.object({
                               ),
                           ])
                           .optional(),
-                        updated_at: zod.string().datetime({}),
+                        updated_at: zod.iso.datetime({}),
                       })
                       .describe(
                         'Property definition model (service representation).'
@@ -6394,8 +6237,7 @@ export const postItemsSoupResponse = zod.object({
                             zod
                               .object({
                                 type: zod.enum(['Date']),
-                                value: zod
-                                  .string()
+                                value: zod.iso
                                   .datetime({})
                                   .describe(
                                     'Date\/timestamp value\nSerializes as: {\"type\": \"Date\", \"value\": \"2025-01-01T00:00:00Z\"}'
@@ -6408,7 +6250,7 @@ export const postItemsSoupResponse = zod.object({
                               .object({
                                 type: zod.enum(['SelectOption']),
                                 value: zod
-                                  .array(zod.string().uuid())
+                                  .array(zod.uuid())
                                   .describe(
                                     'Select option(s) - always an array (check is_multi_select to determine if single or multi)\nSingle-select: {\"type\": \"SelectOption\", \"value\": [\"uuid\"]} (length 0 or 1)\nMulti-select: {\"type\": \"SelectOption\", \"value\": [\"uuid1\", \"uuid2\", ...]} (length 0+)'
                                   ),
@@ -6439,7 +6281,6 @@ export const postItemsSoupResponse = zod.object({
                                             'Type of entity that can be referenced by entity properties.'
                                           ),
                                         specific_message_id: zod
-                                          .string()
                                           .uuid()
                                           .nullish()
                                           .describe(
@@ -6481,12 +6322,10 @@ export const postItemsSoupResponse = zod.object({
                   )
               )
               .describe('Properties'),
-            updatedAt: zod
-              .string()
+            updatedAt: zod.iso
               .datetime({})
               .describe('The time the project was updated'),
-            viewedAt: zod
-              .string()
+            viewedAt: zod.iso
               .datetime({})
               .nullish()
               .describe('The time the document was last viewed'),
@@ -6496,8 +6335,8 @@ export const postItemsSoupResponse = zod.object({
         zod.object({
           data: zod
             .object({
-              createdAt: zod.string().datetime({}),
-              id: zod.string().uuid(),
+              createdAt: zod.iso.datetime({}),
+              id: zod.uuid(),
               inboxVisible: zod.boolean(),
               isDraft: zod.boolean(),
               isImportant: zod.boolean(),
@@ -6510,19 +6349,19 @@ export const postItemsSoupResponse = zod.object({
               senderName: zod.string().nullish(),
               senderPhotoUrl: zod.string().nullish(),
               snippet: zod.string().nullish(),
-              sortTs: zod.string().datetime({}),
-              updatedAt: zod.string().datetime({}),
-              viewedAt: zod.string().datetime({}).nullish(),
+              sortTs: zod.iso.datetime({}),
+              updatedAt: zod.iso.datetime({}),
+              viewedAt: zod.iso.datetime({}).nullish(),
             })
             .and(
               zod.object({
                 attachments: zod.array(
                   zod.object({
                     contentId: zod.string().nullish(),
-                    createdAt: zod.string().datetime({}),
+                    createdAt: zod.iso.datetime({}),
                     filename: zod.string().nullish(),
-                    id: zod.string().uuid(),
-                    messageId: zod.string().uuid(),
+                    id: zod.uuid(),
+                    messageId: zod.uuid(),
                     mimeType: zod.string().nullish(),
                     providerAttachmentId: zod.string().nullish(),
                     sizeBytes: zod.number().nullish(),
@@ -6530,14 +6369,14 @@ export const postItemsSoupResponse = zod.object({
                 ),
                 labels: zod.array(
                   zod.object({
-                    createdAt: zod.string().datetime({}),
-                    id: zod.string().uuid(),
+                    createdAt: zod.iso.datetime({}),
+                    id: zod.uuid(),
                     labelListVisibility: zod.enum([
                       'labelShow',
                       'labelShowIfUnread',
                       'labelHide',
                     ]),
-                    linkId: zod.string().uuid(),
+                    linkId: zod.uuid(),
                     messageListVisibility: zod.enum(['show', 'hide']),
                     name: zod.string(),
                     providerLabelId: zod.string(),
@@ -6547,8 +6386,8 @@ export const postItemsSoupResponse = zod.object({
                 participants: zod.array(
                   zod.object({
                     emailAddress: zod.string().nullish(),
-                    id: zod.string().uuid(),
-                    linkId: zod.string().uuid(),
+                    id: zod.uuid(),
+                    linkId: zod.uuid(),
                     name: zod.string().nullish(),
                     sfsPhotoUrl: zod.string().nullish(),
                   })
@@ -6558,7 +6397,7 @@ export const postItemsSoupResponse = zod.object({
                     .object({
                       definition: zod
                         .object({
-                          created_at: zod.string().datetime({}),
+                          created_at: zod.iso.datetime({}),
                           data_type: zod
                             .enum([
                               'BOOLEAN',
@@ -6574,7 +6413,7 @@ export const postItemsSoupResponse = zod.object({
                               'Data type for property values, determining storage and validation.'
                             ),
                           display_name: zod.string(),
-                          id: zod.string().uuid(),
+                          id: zod.uuid(),
                           is_metadata: zod
                             .boolean()
                             .describe(
@@ -6637,7 +6476,7 @@ export const postItemsSoupResponse = zod.object({
                                 ),
                             ])
                             .optional(),
-                          updated_at: zod.string().datetime({}),
+                          updated_at: zod.iso.datetime({}),
                         })
                         .describe(
                           'Property definition model (service representation).'
@@ -6686,8 +6525,7 @@ export const postItemsSoupResponse = zod.object({
                               zod
                                 .object({
                                   type: zod.enum(['Date']),
-                                  value: zod
-                                    .string()
+                                  value: zod.iso
                                     .datetime({})
                                     .describe(
                                       'Date\/timestamp value\nSerializes as: {\"type\": \"Date\", \"value\": \"2025-01-01T00:00:00Z\"}'
@@ -6700,7 +6538,7 @@ export const postItemsSoupResponse = zod.object({
                                 .object({
                                   type: zod.enum(['SelectOption']),
                                   value: zod
-                                    .array(zod.string().uuid())
+                                    .array(zod.uuid())
                                     .describe(
                                       'Select option(s) - always an array (check is_multi_select to determine if single or multi)\nSingle-select: {\"type\": \"SelectOption\", \"value\": [\"uuid\"]} (length 0 or 1)\nMulti-select: {\"type\": \"SelectOption\", \"value\": [\"uuid1\", \"uuid2\", ...]} (length 0+)'
                                     ),
@@ -6731,7 +6569,6 @@ export const postItemsSoupResponse = zod.object({
                                               'Type of entity that can be referenced by entity properties.'
                                             ),
                                           specific_message_id: zod
-                                            .string()
                                             .uuid()
                                             .nullish()
                                             .describe(
@@ -6787,22 +6624,22 @@ export const postItemsSoupResponse = zod.object({
                   'direct_message',
                   'team',
                 ]),
-                created_at: zod.string().datetime({}),
-                id: zod.string().uuid(),
+                created_at: zod.iso.datetime({}),
+                id: zod.uuid(),
                 name: zod.string().nullish(),
                 org_id: zod
                   .number()
                   .min(postItemsSoupResponseItemsItemDataChannelOrgIdMin)
                   .nullish(),
                 owner_id: zod.string(),
-                team_id: zod.string().uuid().nullish(),
-                updated_at: zod.string().datetime({}),
+                team_id: zod.uuid().nullish(),
+                updated_at: zod.iso.datetime({}),
               }),
               participants: zod.array(
                 zod.object({
-                  channel_id: zod.string().uuid(),
-                  joined_at: zod.string().datetime({}),
-                  left_at: zod.string().datetime({}).nullish(),
+                  channel_id: zod.uuid(),
+                  joined_at: zod.iso.datetime({}),
+                  left_at: zod.iso.datetime({}).nullish(),
                   role: zod
                     .enum(['owner', 'admin', 'member'])
                     .describe('The role a user has within a channel.'),
@@ -6817,17 +6654,17 @@ export const postItemsSoupResponse = zod.object({
                     zod.null(),
                     zod.object({
                       content: zod.string(),
-                      created_at: zod.string().datetime({}),
-                      deleted_at: zod.string().datetime({}).nullish(),
+                      created_at: zod.iso.datetime({}),
+                      deleted_at: zod.iso.datetime({}).nullish(),
                       mentions: zod
                         .array(zod.string())
                         .describe(
                           'message mentions formatted as `{ENTITY_TYPE}:{ENTITY_ID}`'
                         ),
-                      message_id: zod.string().uuid(),
+                      message_id: zod.uuid(),
                       sender_id: zod.string(),
-                      thread_id: zod.string().uuid().nullish(),
-                      updated_at: zod.string().datetime({}),
+                      thread_id: zod.uuid().nullish(),
+                      updated_at: zod.iso.datetime({}),
                     }),
                   ])
                   .optional(),
@@ -6836,17 +6673,17 @@ export const postItemsSoupResponse = zod.object({
                     zod.null(),
                     zod.object({
                       content: zod.string(),
-                      created_at: zod.string().datetime({}),
-                      deleted_at: zod.string().datetime({}).nullish(),
+                      created_at: zod.iso.datetime({}),
+                      deleted_at: zod.iso.datetime({}).nullish(),
                       mentions: zod
                         .array(zod.string())
                         .describe(
                           'message mentions formatted as `{ENTITY_TYPE}:{ENTITY_ID}`'
                         ),
-                      message_id: zod.string().uuid(),
+                      message_id: zod.uuid(),
                       sender_id: zod.string(),
-                      thread_id: zod.string().uuid().nullish(),
-                      updated_at: zod.string().datetime({}),
+                      thread_id: zod.uuid().nullish(),
+                      updated_at: zod.iso.datetime({}),
                     }),
                   ])
                   .optional(),
@@ -6854,8 +6691,8 @@ export const postItemsSoupResponse = zod.object({
             )
             .and(
               zod.object({
-                interacted_at: zod.string().datetime({}).nullish(),
-                viewed_at: zod.string().datetime({}).nullish(),
+                interacted_at: zod.iso.datetime({}).nullish(),
+                viewed_at: zod.iso.datetime({}).nullish(),
               })
             ),
           tag: zod.enum(['channel']),
@@ -6868,9 +6705,8 @@ export const postItemsSoupResponse = zod.object({
                 .describe(
                   'Whether the requesting user attended this call (i.e. appears in the\n`call_participants` \/ `call_record_participants` table).'
                 ),
-              callId: zod.string().uuid().describe('The call identifier.'),
+              callId: zod.uuid().describe('The call identifier.'),
               channelId: zod
-                .string()
                 .uuid()
                 .describe('The channel this call belongs to.'),
               channelName: zod
@@ -6890,8 +6726,7 @@ export const postItemsSoupResponse = zod.object({
                 .describe(
                   'Call duration in milliseconds (None if still active).'
                 ),
-              endedAt: zod
-                .string()
+              endedAt: zod.iso
                 .datetime({})
                 .nullish()
                 .describe('When the call ended (None if still active).'),
@@ -6902,12 +6737,10 @@ export const postItemsSoupResponse = zod.object({
                 .array(
                   zod
                     .object({
-                      joinedAt: zod
-                        .string()
+                      joinedAt: zod.iso
                         .datetime({})
                         .describe('When the user joined the call.'),
-                      leftAt: zod
-                        .string()
+                      leftAt: zod.iso
                         .datetime({})
                         .nullish()
                         .describe(
@@ -6920,8 +6753,7 @@ export const postItemsSoupResponse = zod.object({
                     )
                 )
                 .describe('Participants in the call.'),
-              startedAt: zod
-                .string()
+              startedAt: zod.iso
                 .datetime({})
                 .describe('When the call started.'),
             })
@@ -7030,7 +6862,6 @@ export const postItemsSoupAstResponse = zod.object({
         zod.object({
           data: zod.object({
             branchedFromId: zod
-              .string()
               .uuid()
               .nullish()
               .describe('The id of the document this document branched from'),
@@ -7040,12 +6871,10 @@ export const postItemsSoupAstResponse = zod.object({
               .describe(
                 'The id of the version this document branched from\nThis could be either DocumentInstance or DocumentBom id depending on the file type'
               ),
-            createdAt: zod
-              .string()
+            createdAt: zod.iso
               .datetime({})
               .describe('The time the document was created'),
-            deletedAt: zod
-              .string()
+            deletedAt: zod.iso
               .datetime({})
               .nullish()
               .describe('The time the document was deleted'),
@@ -7064,11 +6893,10 @@ export const postItemsSoupAstResponse = zod.object({
               .string()
               .nullish()
               .describe('The file type of the document (e.g. pdf, docx)'),
-            id: zod.string().uuid().describe('The document id'),
+            id: zod.uuid().describe('The document id'),
             name: zod.string().describe('The name of the document'),
             ownerId: zod.string().describe('The owner of the document'),
             projectId: zod
-              .string()
               .uuid()
               .nullish()
               .describe('The id of the project that this document belongs to'),
@@ -7078,7 +6906,7 @@ export const postItemsSoupAstResponse = zod.object({
                   .object({
                     definition: zod
                       .object({
-                        created_at: zod.string().datetime({}),
+                        created_at: zod.iso.datetime({}),
                         data_type: zod
                           .enum([
                             'BOOLEAN',
@@ -7094,7 +6922,7 @@ export const postItemsSoupAstResponse = zod.object({
                             'Data type for property values, determining storage and validation.'
                           ),
                         display_name: zod.string(),
-                        id: zod.string().uuid(),
+                        id: zod.uuid(),
                         is_metadata: zod
                           .boolean()
                           .describe(
@@ -7157,7 +6985,7 @@ export const postItemsSoupAstResponse = zod.object({
                               ),
                           ])
                           .optional(),
-                        updated_at: zod.string().datetime({}),
+                        updated_at: zod.iso.datetime({}),
                       })
                       .describe(
                         'Property definition model (service representation).'
@@ -7206,8 +7034,7 @@ export const postItemsSoupAstResponse = zod.object({
                             zod
                               .object({
                                 type: zod.enum(['Date']),
-                                value: zod
-                                  .string()
+                                value: zod.iso
                                   .datetime({})
                                   .describe(
                                     'Date\/timestamp value\nSerializes as: {\"type\": \"Date\", \"value\": \"2025-01-01T00:00:00Z\"}'
@@ -7220,7 +7047,7 @@ export const postItemsSoupAstResponse = zod.object({
                               .object({
                                 type: zod.enum(['SelectOption']),
                                 value: zod
-                                  .array(zod.string().uuid())
+                                  .array(zod.uuid())
                                   .describe(
                                     'Select option(s) - always an array (check is_multi_select to determine if single or multi)\nSingle-select: {\"type\": \"SelectOption\", \"value\": [\"uuid\"]} (length 0 or 1)\nMulti-select: {\"type\": \"SelectOption\", \"value\": [\"uuid1\", \"uuid2\", ...]} (length 0+)'
                                   ),
@@ -7251,7 +7078,6 @@ export const postItemsSoupAstResponse = zod.object({
                                             'Type of entity that can be referenced by entity properties.'
                                           ),
                                         specific_message_id: zod
-                                          .string()
                                           .uuid()
                                           .nullish()
                                           .describe(
@@ -7317,14 +7143,12 @@ export const postItemsSoupAstResponse = zod.object({
                   ),
               ])
               .optional(),
-            updatedAt: zod
-              .string()
+            updatedAt: zod.iso
               .datetime({})
               .describe(
                 'The time the document instance \/ document BOM was updated'
               ),
-            viewedAt: zod
-              .string()
+            viewedAt: zod.iso
               .datetime({})
               .nullish()
               .describe('The time the document was last viewed'),
@@ -7333,23 +7157,20 @@ export const postItemsSoupAstResponse = zod.object({
         }),
         zod.object({
           data: zod.object({
-            createdAt: zod
-              .string()
+            createdAt: zod.iso
               .datetime({})
               .describe('The time the chat was created'),
-            deletedAt: zod
-              .string()
+            deletedAt: zod.iso
               .datetime({})
               .nullish()
               .describe('The time the chat was deleted'),
-            id: zod.string().uuid().describe('The chat uuid'),
+            id: zod.uuid().describe('The chat uuid'),
             isPersistent: zod
               .boolean()
               .describe('Whether the chat is persistent or not'),
             name: zod.string().describe('The name of the chat'),
             ownerId: zod.string().describe('Who the chat belongs to'),
             projectId: zod
-              .string()
               .uuid()
               .nullish()
               .describe('The project id of the chat'),
@@ -7359,7 +7180,7 @@ export const postItemsSoupAstResponse = zod.object({
                   .object({
                     definition: zod
                       .object({
-                        created_at: zod.string().datetime({}),
+                        created_at: zod.iso.datetime({}),
                         data_type: zod
                           .enum([
                             'BOOLEAN',
@@ -7375,7 +7196,7 @@ export const postItemsSoupAstResponse = zod.object({
                             'Data type for property values, determining storage and validation.'
                           ),
                         display_name: zod.string(),
-                        id: zod.string().uuid(),
+                        id: zod.uuid(),
                         is_metadata: zod
                           .boolean()
                           .describe(
@@ -7438,7 +7259,7 @@ export const postItemsSoupAstResponse = zod.object({
                               ),
                           ])
                           .optional(),
-                        updated_at: zod.string().datetime({}),
+                        updated_at: zod.iso.datetime({}),
                       })
                       .describe(
                         'Property definition model (service representation).'
@@ -7487,8 +7308,7 @@ export const postItemsSoupAstResponse = zod.object({
                             zod
                               .object({
                                 type: zod.enum(['Date']),
-                                value: zod
-                                  .string()
+                                value: zod.iso
                                   .datetime({})
                                   .describe(
                                     'Date\/timestamp value\nSerializes as: {\"type\": \"Date\", \"value\": \"2025-01-01T00:00:00Z\"}'
@@ -7501,7 +7321,7 @@ export const postItemsSoupAstResponse = zod.object({
                               .object({
                                 type: zod.enum(['SelectOption']),
                                 value: zod
-                                  .array(zod.string().uuid())
+                                  .array(zod.uuid())
                                   .describe(
                                     'Select option(s) - always an array (check is_multi_select to determine if single or multi)\nSingle-select: {\"type\": \"SelectOption\", \"value\": [\"uuid\"]} (length 0 or 1)\nMulti-select: {\"type\": \"SelectOption\", \"value\": [\"uuid1\", \"uuid2\", ...]} (length 0+)'
                                   ),
@@ -7532,7 +7352,6 @@ export const postItemsSoupAstResponse = zod.object({
                                             'Type of entity that can be referenced by entity properties.'
                                           ),
                                         specific_message_id: zod
-                                          .string()
                                           .uuid()
                                           .nullish()
                                           .describe(
@@ -7574,12 +7393,10 @@ export const postItemsSoupAstResponse = zod.object({
                   )
               )
               .describe('Properties'),
-            updatedAt: zod
-              .string()
+            updatedAt: zod.iso
               .datetime({})
               .describe('The time the chat was last updated'),
-            viewedAt: zod
-              .string()
+            viewedAt: zod.iso
               .datetime({})
               .nullish()
               .describe('The time the chat was last viewed'),
@@ -7588,32 +7405,26 @@ export const postItemsSoupAstResponse = zod.object({
         }),
         zod.object({
           data: zod.object({
-            createdAt: zod
-              .string()
+            createdAt: zod.iso
               .datetime({})
               .describe('The time the project was created'),
-            deletedAt: zod
-              .string()
+            deletedAt: zod.iso
               .datetime({})
               .nullish()
               .describe('The time the project was deleted'),
-            id: zod.string().uuid().describe('The id of the project'),
+            id: zod.uuid().describe('The id of the project'),
             name: zod.string().describe('The name of the project'),
             ownerId: zod
               .string()
               .describe('The user id of who created the project'),
-            parentId: zod
-              .string()
-              .uuid()
-              .nullish()
-              .describe('The parent project id'),
+            parentId: zod.uuid().nullish().describe('The parent project id'),
             properties: zod
               .array(
                 zod
                   .object({
                     definition: zod
                       .object({
-                        created_at: zod.string().datetime({}),
+                        created_at: zod.iso.datetime({}),
                         data_type: zod
                           .enum([
                             'BOOLEAN',
@@ -7629,7 +7440,7 @@ export const postItemsSoupAstResponse = zod.object({
                             'Data type for property values, determining storage and validation.'
                           ),
                         display_name: zod.string(),
-                        id: zod.string().uuid(),
+                        id: zod.uuid(),
                         is_metadata: zod
                           .boolean()
                           .describe(
@@ -7692,7 +7503,7 @@ export const postItemsSoupAstResponse = zod.object({
                               ),
                           ])
                           .optional(),
-                        updated_at: zod.string().datetime({}),
+                        updated_at: zod.iso.datetime({}),
                       })
                       .describe(
                         'Property definition model (service representation).'
@@ -7741,8 +7552,7 @@ export const postItemsSoupAstResponse = zod.object({
                             zod
                               .object({
                                 type: zod.enum(['Date']),
-                                value: zod
-                                  .string()
+                                value: zod.iso
                                   .datetime({})
                                   .describe(
                                     'Date\/timestamp value\nSerializes as: {\"type\": \"Date\", \"value\": \"2025-01-01T00:00:00Z\"}'
@@ -7755,7 +7565,7 @@ export const postItemsSoupAstResponse = zod.object({
                               .object({
                                 type: zod.enum(['SelectOption']),
                                 value: zod
-                                  .array(zod.string().uuid())
+                                  .array(zod.uuid())
                                   .describe(
                                     'Select option(s) - always an array (check is_multi_select to determine if single or multi)\nSingle-select: {\"type\": \"SelectOption\", \"value\": [\"uuid\"]} (length 0 or 1)\nMulti-select: {\"type\": \"SelectOption\", \"value\": [\"uuid1\", \"uuid2\", ...]} (length 0+)'
                                   ),
@@ -7786,7 +7596,6 @@ export const postItemsSoupAstResponse = zod.object({
                                             'Type of entity that can be referenced by entity properties.'
                                           ),
                                         specific_message_id: zod
-                                          .string()
                                           .uuid()
                                           .nullish()
                                           .describe(
@@ -7828,12 +7637,10 @@ export const postItemsSoupAstResponse = zod.object({
                   )
               )
               .describe('Properties'),
-            updatedAt: zod
-              .string()
+            updatedAt: zod.iso
               .datetime({})
               .describe('The time the project was updated'),
-            viewedAt: zod
-              .string()
+            viewedAt: zod.iso
               .datetime({})
               .nullish()
               .describe('The time the document was last viewed'),
@@ -7843,8 +7650,8 @@ export const postItemsSoupAstResponse = zod.object({
         zod.object({
           data: zod
             .object({
-              createdAt: zod.string().datetime({}),
-              id: zod.string().uuid(),
+              createdAt: zod.iso.datetime({}),
+              id: zod.uuid(),
               inboxVisible: zod.boolean(),
               isDraft: zod.boolean(),
               isImportant: zod.boolean(),
@@ -7857,19 +7664,19 @@ export const postItemsSoupAstResponse = zod.object({
               senderName: zod.string().nullish(),
               senderPhotoUrl: zod.string().nullish(),
               snippet: zod.string().nullish(),
-              sortTs: zod.string().datetime({}),
-              updatedAt: zod.string().datetime({}),
-              viewedAt: zod.string().datetime({}).nullish(),
+              sortTs: zod.iso.datetime({}),
+              updatedAt: zod.iso.datetime({}),
+              viewedAt: zod.iso.datetime({}).nullish(),
             })
             .and(
               zod.object({
                 attachments: zod.array(
                   zod.object({
                     contentId: zod.string().nullish(),
-                    createdAt: zod.string().datetime({}),
+                    createdAt: zod.iso.datetime({}),
                     filename: zod.string().nullish(),
-                    id: zod.string().uuid(),
-                    messageId: zod.string().uuid(),
+                    id: zod.uuid(),
+                    messageId: zod.uuid(),
                     mimeType: zod.string().nullish(),
                     providerAttachmentId: zod.string().nullish(),
                     sizeBytes: zod.number().nullish(),
@@ -7877,14 +7684,14 @@ export const postItemsSoupAstResponse = zod.object({
                 ),
                 labels: zod.array(
                   zod.object({
-                    createdAt: zod.string().datetime({}),
-                    id: zod.string().uuid(),
+                    createdAt: zod.iso.datetime({}),
+                    id: zod.uuid(),
                     labelListVisibility: zod.enum([
                       'labelShow',
                       'labelShowIfUnread',
                       'labelHide',
                     ]),
-                    linkId: zod.string().uuid(),
+                    linkId: zod.uuid(),
                     messageListVisibility: zod.enum(['show', 'hide']),
                     name: zod.string(),
                     providerLabelId: zod.string(),
@@ -7894,8 +7701,8 @@ export const postItemsSoupAstResponse = zod.object({
                 participants: zod.array(
                   zod.object({
                     emailAddress: zod.string().nullish(),
-                    id: zod.string().uuid(),
-                    linkId: zod.string().uuid(),
+                    id: zod.uuid(),
+                    linkId: zod.uuid(),
                     name: zod.string().nullish(),
                     sfsPhotoUrl: zod.string().nullish(),
                   })
@@ -7905,7 +7712,7 @@ export const postItemsSoupAstResponse = zod.object({
                     .object({
                       definition: zod
                         .object({
-                          created_at: zod.string().datetime({}),
+                          created_at: zod.iso.datetime({}),
                           data_type: zod
                             .enum([
                               'BOOLEAN',
@@ -7921,7 +7728,7 @@ export const postItemsSoupAstResponse = zod.object({
                               'Data type for property values, determining storage and validation.'
                             ),
                           display_name: zod.string(),
-                          id: zod.string().uuid(),
+                          id: zod.uuid(),
                           is_metadata: zod
                             .boolean()
                             .describe(
@@ -7984,7 +7791,7 @@ export const postItemsSoupAstResponse = zod.object({
                                 ),
                             ])
                             .optional(),
-                          updated_at: zod.string().datetime({}),
+                          updated_at: zod.iso.datetime({}),
                         })
                         .describe(
                           'Property definition model (service representation).'
@@ -8033,8 +7840,7 @@ export const postItemsSoupAstResponse = zod.object({
                               zod
                                 .object({
                                   type: zod.enum(['Date']),
-                                  value: zod
-                                    .string()
+                                  value: zod.iso
                                     .datetime({})
                                     .describe(
                                       'Date\/timestamp value\nSerializes as: {\"type\": \"Date\", \"value\": \"2025-01-01T00:00:00Z\"}'
@@ -8047,7 +7853,7 @@ export const postItemsSoupAstResponse = zod.object({
                                 .object({
                                   type: zod.enum(['SelectOption']),
                                   value: zod
-                                    .array(zod.string().uuid())
+                                    .array(zod.uuid())
                                     .describe(
                                       'Select option(s) - always an array (check is_multi_select to determine if single or multi)\nSingle-select: {\"type\": \"SelectOption\", \"value\": [\"uuid\"]} (length 0 or 1)\nMulti-select: {\"type\": \"SelectOption\", \"value\": [\"uuid1\", \"uuid2\", ...]} (length 0+)'
                                     ),
@@ -8078,7 +7884,6 @@ export const postItemsSoupAstResponse = zod.object({
                                               'Type of entity that can be referenced by entity properties.'
                                             ),
                                           specific_message_id: zod
-                                            .string()
                                             .uuid()
                                             .nullish()
                                             .describe(
@@ -8134,22 +7939,22 @@ export const postItemsSoupAstResponse = zod.object({
                   'direct_message',
                   'team',
                 ]),
-                created_at: zod.string().datetime({}),
-                id: zod.string().uuid(),
+                created_at: zod.iso.datetime({}),
+                id: zod.uuid(),
                 name: zod.string().nullish(),
                 org_id: zod
                   .number()
                   .min(postItemsSoupAstResponseItemsItemDataChannelOrgIdMin)
                   .nullish(),
                 owner_id: zod.string(),
-                team_id: zod.string().uuid().nullish(),
-                updated_at: zod.string().datetime({}),
+                team_id: zod.uuid().nullish(),
+                updated_at: zod.iso.datetime({}),
               }),
               participants: zod.array(
                 zod.object({
-                  channel_id: zod.string().uuid(),
-                  joined_at: zod.string().datetime({}),
-                  left_at: zod.string().datetime({}).nullish(),
+                  channel_id: zod.uuid(),
+                  joined_at: zod.iso.datetime({}),
+                  left_at: zod.iso.datetime({}).nullish(),
                   role: zod
                     .enum(['owner', 'admin', 'member'])
                     .describe('The role a user has within a channel.'),
@@ -8164,17 +7969,17 @@ export const postItemsSoupAstResponse = zod.object({
                     zod.null(),
                     zod.object({
                       content: zod.string(),
-                      created_at: zod.string().datetime({}),
-                      deleted_at: zod.string().datetime({}).nullish(),
+                      created_at: zod.iso.datetime({}),
+                      deleted_at: zod.iso.datetime({}).nullish(),
                       mentions: zod
                         .array(zod.string())
                         .describe(
                           'message mentions formatted as `{ENTITY_TYPE}:{ENTITY_ID}`'
                         ),
-                      message_id: zod.string().uuid(),
+                      message_id: zod.uuid(),
                       sender_id: zod.string(),
-                      thread_id: zod.string().uuid().nullish(),
-                      updated_at: zod.string().datetime({}),
+                      thread_id: zod.uuid().nullish(),
+                      updated_at: zod.iso.datetime({}),
                     }),
                   ])
                   .optional(),
@@ -8183,17 +7988,17 @@ export const postItemsSoupAstResponse = zod.object({
                     zod.null(),
                     zod.object({
                       content: zod.string(),
-                      created_at: zod.string().datetime({}),
-                      deleted_at: zod.string().datetime({}).nullish(),
+                      created_at: zod.iso.datetime({}),
+                      deleted_at: zod.iso.datetime({}).nullish(),
                       mentions: zod
                         .array(zod.string())
                         .describe(
                           'message mentions formatted as `{ENTITY_TYPE}:{ENTITY_ID}`'
                         ),
-                      message_id: zod.string().uuid(),
+                      message_id: zod.uuid(),
                       sender_id: zod.string(),
-                      thread_id: zod.string().uuid().nullish(),
-                      updated_at: zod.string().datetime({}),
+                      thread_id: zod.uuid().nullish(),
+                      updated_at: zod.iso.datetime({}),
                     }),
                   ])
                   .optional(),
@@ -8201,8 +8006,8 @@ export const postItemsSoupAstResponse = zod.object({
             )
             .and(
               zod.object({
-                interacted_at: zod.string().datetime({}).nullish(),
-                viewed_at: zod.string().datetime({}).nullish(),
+                interacted_at: zod.iso.datetime({}).nullish(),
+                viewed_at: zod.iso.datetime({}).nullish(),
               })
             ),
           tag: zod.enum(['channel']),
@@ -8215,9 +8020,8 @@ export const postItemsSoupAstResponse = zod.object({
                 .describe(
                   'Whether the requesting user attended this call (i.e. appears in the\n`call_participants` \/ `call_record_participants` table).'
                 ),
-              callId: zod.string().uuid().describe('The call identifier.'),
+              callId: zod.uuid().describe('The call identifier.'),
               channelId: zod
-                .string()
                 .uuid()
                 .describe('The channel this call belongs to.'),
               channelName: zod
@@ -8237,8 +8041,7 @@ export const postItemsSoupAstResponse = zod.object({
                 .describe(
                   'Call duration in milliseconds (None if still active).'
                 ),
-              endedAt: zod
-                .string()
+              endedAt: zod.iso
                 .datetime({})
                 .nullish()
                 .describe('When the call ended (None if still active).'),
@@ -8249,12 +8052,10 @@ export const postItemsSoupAstResponse = zod.object({
                 .array(
                   zod
                     .object({
-                      joinedAt: zod
-                        .string()
+                      joinedAt: zod.iso
                         .datetime({})
                         .describe('When the user joined the call.'),
-                      leftAt: zod
-                        .string()
+                      leftAt: zod.iso
                         .datetime({})
                         .nullish()
                         .describe(
@@ -8267,8 +8068,7 @@ export const postItemsSoupAstResponse = zod.object({
                     )
                 )
                 .describe('Participants in the call.'),
-              startedAt: zod
-                .string()
+              startedAt: zod.iso
                 .datetime({})
                 .describe('When the call started.'),
             })
@@ -8312,13 +8112,11 @@ export const getPinsHandlerResponse = zod.object({
                     .describe(
                       'The id of the version this document branched from\nThis could be either DocumentInstance or DocumentBom id depending on\nthe file type'
                     ),
-                  createdAt: zod
-                    .string()
+                  createdAt: zod.iso
                     .datetime({})
                     .nullish()
                     .describe('The time the document was created'),
-                  deletedAt: zod
-                    .string()
+                  deletedAt: zod.iso
                     .datetime({})
                     .nullish()
                     .describe('The time the document was deleted'),
@@ -8372,8 +8170,7 @@ export const getPinsHandlerResponse = zod.object({
                         ),
                     ])
                     .optional(),
-                  updatedAt: zod
-                    .string()
+                  updatedAt: zod.iso
                     .datetime({})
                     .nullish()
                     .describe(
@@ -8382,13 +8179,11 @@ export const getPinsHandlerResponse = zod.object({
                   type: zod.enum(['document']),
                 }),
                 zod.object({
-                  createdAt: zod
-                    .string()
+                  createdAt: zod.iso
                     .datetime({})
                     .nullish()
                     .describe('The time the chat was created'),
-                  deletedAt: zod
-                    .string()
+                  deletedAt: zod.iso
                     .datetime({})
                     .nullish()
                     .describe('The time the chat was deleted'),
@@ -8404,8 +8199,7 @@ export const getPinsHandlerResponse = zod.object({
                     .nullish()
                     .describe('The project id of the chat'),
                   tokenCount: zod.number().nullish(),
-                  updatedAt: zod
-                    .string()
+                  updatedAt: zod.iso
                     .datetime({})
                     .nullish()
                     .describe('The time the chat was last updated'),
@@ -8413,20 +8207,18 @@ export const getPinsHandlerResponse = zod.object({
                   type: zod.enum(['chat']),
                 }),
                 zod.object({
-                  createdAt: zod
-                    .string()
+                  createdAt: zod.iso
                     .datetime({})
                     .nullish()
                     .describe('The time the project was created'),
-                  deletedAt: zod.string().datetime({}).nullish(),
+                  deletedAt: zod.iso.datetime({}).nullish(),
                   id: zod.string().describe('The id of the project'),
                   name: zod.string().describe('The name of the project'),
                   parentId: zod
                     .string()
                     .nullish()
                     .describe('The parent project id'),
-                  updatedAt: zod
-                    .string()
+                  updatedAt: zod.iso
                     .datetime({})
                     .nullish()
                     .describe('The time the project was updated'),
@@ -8450,13 +8242,11 @@ export const getPinsHandlerResponse = zod.object({
                     .describe(
                       'The id of the version this document branched from\nThis could be either DocumentInstance or DocumentBom id depending on\nthe file type'
                     ),
-                  createdAt: zod
-                    .string()
+                  createdAt: zod.iso
                     .datetime({})
                     .nullish()
                     .describe('The time the document was created'),
-                  deletedAt: zod
-                    .string()
+                  deletedAt: zod.iso
                     .datetime({})
                     .nullish()
                     .describe('The time the document was deleted'),
@@ -8510,8 +8300,7 @@ export const getPinsHandlerResponse = zod.object({
                         ),
                     ])
                     .optional(),
-                  updatedAt: zod
-                    .string()
+                  updatedAt: zod.iso
                     .datetime({})
                     .nullish()
                     .describe(
@@ -8520,13 +8309,11 @@ export const getPinsHandlerResponse = zod.object({
                   type: zod.enum(['document']),
                 }),
                 zod.object({
-                  createdAt: zod
-                    .string()
+                  createdAt: zod.iso
                     .datetime({})
                     .nullish()
                     .describe('The time the chat was created'),
-                  deletedAt: zod
-                    .string()
+                  deletedAt: zod.iso
                     .datetime({})
                     .nullish()
                     .describe('The time the chat was deleted'),
@@ -8542,8 +8329,7 @@ export const getPinsHandlerResponse = zod.object({
                     .nullish()
                     .describe('The project id of the chat'),
                   tokenCount: zod.number().nullish(),
-                  updatedAt: zod
-                    .string()
+                  updatedAt: zod.iso
                     .datetime({})
                     .nullish()
                     .describe('The time the chat was last updated'),
@@ -8551,20 +8337,18 @@ export const getPinsHandlerResponse = zod.object({
                   type: zod.enum(['chat']),
                 }),
                 zod.object({
-                  createdAt: zod
-                    .string()
+                  createdAt: zod.iso
                     .datetime({})
                     .nullish()
                     .describe('The time the project was created'),
-                  deletedAt: zod.string().datetime({}).nullish(),
+                  deletedAt: zod.iso.datetime({}).nullish(),
                   id: zod.string().describe('The id of the project'),
                   name: zod.string().describe('The name of the project'),
                   parentId: zod
                     .string()
                     .nullish()
                     .describe('The parent project id'),
-                  updatedAt: zod
-                    .string()
+                  updatedAt: zod.iso
                     .datetime({})
                     .nullish()
                     .describe('The time the project was updated'),
@@ -8645,17 +8429,15 @@ export const getProjectsHandlerResponse = zod.object({
   data: zod
     .array(
       zod.object({
-        createdAt: zod
-          .string()
+        createdAt: zod.iso
           .datetime({})
           .nullish()
           .describe('The time the project was created'),
-        deletedAt: zod.string().datetime({}).nullish(),
+        deletedAt: zod.iso.datetime({}).nullish(),
         id: zod.string().describe('The id of the project'),
         name: zod.string().describe('The name of the project'),
         parentId: zod.string().nullish().describe('The parent project id'),
-        updatedAt: zod
-          .string()
+        updatedAt: zod.iso
           .datetime({})
           .nullish()
           .describe('The time the project was updated'),
@@ -8674,7 +8456,6 @@ The project can be created as a sub-project of another project or as a top-level
 export const createProjectHandlerBody = zod.object({
   name: zod.string().describe('The name of the project.'),
   projectParentId: zod
-    .string()
     .uuid()
     .nullish()
     .describe('The project that the new project will belong to.'),
@@ -8682,17 +8463,15 @@ export const createProjectHandlerBody = zod.object({
 
 export const createProjectHandlerResponse = zod.object({
   data: zod.object({
-    createdAt: zod
-      .string()
+    createdAt: zod.iso
       .datetime({})
       .nullish()
       .describe('The time the project was created'),
-    deletedAt: zod.string().datetime({}).nullish(),
+    deletedAt: zod.iso.datetime({}).nullish(),
     id: zod.string().describe('The id of the project'),
     name: zod.string().describe('The name of the project'),
     parentId: zod.string().nullish().describe('The parent project id'),
-    updatedAt: zod
-      .string()
+    updatedAt: zod.iso
       .datetime({})
       .nullish()
       .describe('The time the project was updated'),
@@ -8710,17 +8489,15 @@ export const getPendingProjectsHandlerResponse = zod.object({
     .array(
       zod
         .object({
-          createdAt: zod
-            .string()
+          createdAt: zod.iso
             .datetime({})
             .nullish()
             .describe('The time the project was created'),
-          deletedAt: zod.string().datetime({}).nullish(),
+          deletedAt: zod.iso.datetime({}).nullish(),
           id: zod.string().describe('The id of the project'),
           name: zod.string().describe('The name of the project'),
           parentId: zod.string().nullish().describe('The parent project id'),
-          updatedAt: zod
-            .string()
+          updatedAt: zod.iso
             .datetime({})
             .nullish()
             .describe('The time the project was updated'),
@@ -8759,7 +8536,7 @@ export const getBatchProjectPreviewResponse = zod.object({
           name: zod.string(),
           owner: zod.string(),
           path: zod.array(zod.string()),
-          updatedAt: zod.string().datetime({}).nullish(),
+          updatedAt: zod.iso.datetime({}).nullish(),
         })
         .and(
           zod.object({
@@ -9777,17 +9554,15 @@ export const getProjectHandlerParams = zod.object({
 export const getProjectHandlerResponse = zod.object({
   data: zod.object({
     projectMetadata: zod.object({
-      createdAt: zod
-        .string()
+      createdAt: zod.iso
         .datetime({})
         .nullish()
         .describe('The time the project was created'),
-      deletedAt: zod.string().datetime({}).nullish(),
+      deletedAt: zod.iso.datetime({}).nullish(),
       id: zod.string().describe('The id of the project'),
       name: zod.string().describe('The name of the project'),
       parentId: zod.string().nullish().describe('The parent project id'),
-      updatedAt: zod
-        .string()
+      updatedAt: zod.iso
         .datetime({})
         .nullish()
         .describe('The time the project was updated'),
@@ -9861,13 +9636,11 @@ export const getProjectContentHandlerResponse = zod.object({
               .describe(
                 'The id of the version this document branched from\nThis could be either DocumentInstance or DocumentBom id depending on\nthe file type'
               ),
-            createdAt: zod
-              .string()
+            createdAt: zod.iso
               .datetime({})
               .nullish()
               .describe('The time the document was created'),
-            deletedAt: zod
-              .string()
+            deletedAt: zod.iso
               .datetime({})
               .nullish()
               .describe('The time the document was deleted'),
@@ -9917,8 +9690,7 @@ export const getProjectContentHandlerResponse = zod.object({
                   ),
               ])
               .optional(),
-            updatedAt: zod
-              .string()
+            updatedAt: zod.iso
               .datetime({})
               .nullish()
               .describe(
@@ -9927,13 +9699,11 @@ export const getProjectContentHandlerResponse = zod.object({
             type: zod.enum(['document']),
           }),
           zod.object({
-            createdAt: zod
-              .string()
+            createdAt: zod.iso
               .datetime({})
               .nullish()
               .describe('The time the chat was created'),
-            deletedAt: zod
-              .string()
+            deletedAt: zod.iso
               .datetime({})
               .nullish()
               .describe('The time the chat was deleted'),
@@ -9949,8 +9719,7 @@ export const getProjectContentHandlerResponse = zod.object({
               .nullish()
               .describe('The project id of the chat'),
             tokenCount: zod.number().nullish(),
-            updatedAt: zod
-              .string()
+            updatedAt: zod.iso
               .datetime({})
               .nullish()
               .describe('The time the chat was last updated'),
@@ -9958,17 +9727,15 @@ export const getProjectContentHandlerResponse = zod.object({
             type: zod.enum(['chat']),
           }),
           zod.object({
-            createdAt: zod
-              .string()
+            createdAt: zod.iso
               .datetime({})
               .nullish()
               .describe('The time the project was created'),
-            deletedAt: zod.string().datetime({}).nullish(),
+            deletedAt: zod.iso.datetime({}).nullish(),
             id: zod.string().describe('The id of the project'),
             name: zod.string().describe('The name of the project'),
             parentId: zod.string().nullish().describe('The parent project id'),
-            updatedAt: zod
-              .string()
+            updatedAt: zod.iso
               .datetime({})
               .nullish()
               .describe('The time the project was updated'),
@@ -10072,13 +9839,11 @@ export const recentlyDeletedResponse = zod.object({
                 .describe(
                   'The id of the version this document branched from\nThis could be either DocumentInstance or DocumentBom id depending on\nthe file type'
                 ),
-              createdAt: zod
-                .string()
+              createdAt: zod.iso
                 .datetime({})
                 .nullish()
                 .describe('The time the document was created'),
-              deletedAt: zod
-                .string()
+              deletedAt: zod.iso
                 .datetime({})
                 .nullish()
                 .describe('The time the document was deleted'),
@@ -10130,8 +9895,7 @@ export const recentlyDeletedResponse = zod.object({
                     ),
                 ])
                 .optional(),
-              updatedAt: zod
-                .string()
+              updatedAt: zod.iso
                 .datetime({})
                 .nullish()
                 .describe(
@@ -10140,13 +9904,11 @@ export const recentlyDeletedResponse = zod.object({
               type: zod.enum(['document']),
             }),
             zod.object({
-              createdAt: zod
-                .string()
+              createdAt: zod.iso
                 .datetime({})
                 .nullish()
                 .describe('The time the chat was created'),
-              deletedAt: zod
-                .string()
+              deletedAt: zod.iso
                 .datetime({})
                 .nullish()
                 .describe('The time the chat was deleted'),
@@ -10162,8 +9924,7 @@ export const recentlyDeletedResponse = zod.object({
                 .nullish()
                 .describe('The project id of the chat'),
               tokenCount: zod.number().nullish(),
-              updatedAt: zod
-                .string()
+              updatedAt: zod.iso
                 .datetime({})
                 .nullish()
                 .describe('The time the chat was last updated'),
@@ -10171,20 +9932,18 @@ export const recentlyDeletedResponse = zod.object({
               type: zod.enum(['chat']),
             }),
             zod.object({
-              createdAt: zod
-                .string()
+              createdAt: zod.iso
                 .datetime({})
                 .nullish()
                 .describe('The time the project was created'),
-              deletedAt: zod.string().datetime({}).nullish(),
+              deletedAt: zod.iso.datetime({}).nullish(),
               id: zod.string().describe('The id of the project'),
               name: zod.string().describe('The name of the project'),
               parentId: zod
                 .string()
                 .nullish()
                 .describe('The parent project id'),
-              updatedAt: zod
-                .string()
+              updatedAt: zod.iso
                 .datetime({})
                 .nullish()
                 .describe('The time the project was updated'),
@@ -10206,7 +9965,7 @@ export const getViewsHandlerResponse = zod.object({
     zod
       .object({
         defaultViewId: zod.string(),
-        id: zod.string().uuid(),
+        id: zod.uuid(),
         userId: zod.string(),
       })
       .describe(
@@ -10220,10 +9979,10 @@ export const getViewsHandlerResponse = zod.object({
         .describe(
           'It is an explicit choice that the structure of the view configuration\nis up to the frontend. The structure and composition of view configuration\nis still very much in flux.'
         ),
-      createdAt: zod.string().datetime({}),
-      id: zod.string().uuid(),
+      createdAt: zod.iso.datetime({}),
+      id: zod.uuid(),
       name: zod.string(),
-      updatedAt: zod.string().datetime({}),
+      updatedAt: zod.iso.datetime({}),
       userId: zod.string(),
     })
   ),
@@ -10240,10 +9999,10 @@ export const createViewHandlerResponse = zod.object({
     .describe(
       'It is an explicit choice that the structure of the view configuration\nis up to the frontend. The structure and composition of view configuration\nis still very much in flux.'
     ),
-  createdAt: zod.string().datetime({}),
-  id: zod.string().uuid(),
+  createdAt: zod.iso.datetime({}),
+  id: zod.uuid(),
   name: zod.string(),
-  updatedAt: zod.string().datetime({}),
+  updatedAt: zod.iso.datetime({}),
   userId: zod.string(),
 });
 

--- a/js/app/packages/service-clients/service-storage/generated/zod.ts
+++ b/js/app/packages/service-clients/service-storage/generated/zod.ts
@@ -1000,9 +1000,7 @@ export const getCallRecordResponse = zod
             transcriptId: zod
               .string()
               .uuid()
-              .describe(
-                'Stable DB-row identifier for the segment. Always present and unique\nwithin a call — clients use this for deep-link targeting (e.g. search\n\"go to\" navigation) where `sequence_num` is only an ordering hint.'
-              ),
+              .describe('Stable DB-row id for the segment.'),
           })
           .describe('A transcript segment as returned in a [`CallRecord`].')
       )

--- a/js/app/packages/service-clients/service-storage/openapi.json
+++ b/js/app/packages/service-clients/service-storage/openapi.json
@@ -6484,7 +6484,13 @@
       "CallRecordTranscriptSegment": {
         "type": "object",
         "description": "A transcript segment as returned in a [`CallRecord`].",
-        "required": ["speakerId", "content", "startedAt", "sequenceNum"],
+        "required": [
+          "transcriptId",
+          "speakerId",
+          "content",
+          "startedAt",
+          "sequenceNum"
+        ],
         "properties": {
           "content": {
             "type": "string",
@@ -6516,6 +6522,11 @@
             "type": "string",
             "format": "date-time",
             "description": "When the speaker started this segment."
+          },
+          "transcriptId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Stable DB-row identifier for the segment. Always present and unique\nwithin a call — clients use this for deep-link targeting (e.g. search\n\"go to\" navigation) where `sequence_num` is only an ordering hint."
           }
         }
       },

--- a/js/app/packages/service-clients/service-storage/openapi.json
+++ b/js/app/packages/service-clients/service-storage/openapi.json
@@ -6526,7 +6526,7 @@
           "transcriptId": {
             "type": "string",
             "format": "uuid",
-            "description": "Stable DB-row identifier for the segment. Always present and unique\nwithin a call — clients use this for deep-link targeting (e.g. search\n\"go to\" navigation) where `sequence_num` is only an ordering hint."
+            "description": "Stable DB-row id for the segment."
           }
         }
       },

--- a/rust/cloud-storage/.sqlx/query-8a0e545eabb0a82a436eff39cf37a956514fd084748105272d9915b515d0ebd2.json
+++ b/rust/cloud-storage/.sqlx/query-8a0e545eabb0a82a436eff39cf37a956514fd084748105272d9915b515d0ebd2.json
@@ -1,40 +1,45 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n                SELECT segment_id, speaker_id, diarized_speaker_id, content, started_at, ended_at, sequence_num\n                FROM call_transcripts\n                WHERE call_id = $1\n                ORDER BY sequence_num ASC\n                ",
+  "query": "\n                SELECT id, segment_id, speaker_id, diarized_speaker_id, content, started_at, ended_at, sequence_num\n                FROM call_transcripts\n                WHERE call_id = $1\n                ORDER BY sequence_num ASC\n                ",
   "describe": {
     "columns": [
       {
         "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
         "name": "segment_id",
         "type_info": "Text"
       },
       {
-        "ordinal": 1,
+        "ordinal": 2,
         "name": "speaker_id",
         "type_info": "Text"
       },
       {
-        "ordinal": 2,
+        "ordinal": 3,
         "name": "diarized_speaker_id",
         "type_info": "Text"
       },
       {
-        "ordinal": 3,
+        "ordinal": 4,
         "name": "content",
         "type_info": "Text"
       },
       {
-        "ordinal": 4,
+        "ordinal": 5,
         "name": "started_at",
         "type_info": "Timestamptz"
       },
       {
-        "ordinal": 5,
+        "ordinal": 6,
         "name": "ended_at",
         "type_info": "Timestamptz"
       },
       {
-        "ordinal": 6,
+        "ordinal": 7,
         "name": "sequence_num",
         "type_info": "Int4"
       }
@@ -47,6 +52,7 @@
     "nullable": [
       false,
       false,
+      false,
       true,
       false,
       false,
@@ -54,5 +60,5 @@
       false
     ]
   },
-  "hash": "b683cd2f7a93ff5eb1264823b9a4ce8e500abd7c2e170ce4efc4fa06123e82f6"
+  "hash": "8a0e545eabb0a82a436eff39cf37a956514fd084748105272d9915b515d0ebd2"
 }

--- a/rust/cloud-storage/.sqlx/query-e0f6814556fe2f6367e9e337e4f33fb4c48b673d594fcaf198ee927949796957.json
+++ b/rust/cloud-storage/.sqlx/query-e0f6814556fe2f6367e9e337e4f33fb4c48b673d594fcaf198ee927949796957.json
@@ -1,45 +1,50 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            SELECT segment_id, speaker_id, diarized_speaker_id, custom_speaker, content, started_at, ended_at, sequence_num\n            FROM call_record_transcripts\n            WHERE call_record_id = $1\n            ORDER BY sequence_num ASC\n            ",
+  "query": "\n            SELECT id, segment_id, speaker_id, diarized_speaker_id, custom_speaker, content, started_at, ended_at, sequence_num\n            FROM call_record_transcripts\n            WHERE call_record_id = $1\n            ORDER BY sequence_num ASC\n            ",
   "describe": {
     "columns": [
       {
         "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
         "name": "segment_id",
         "type_info": "Text"
       },
       {
-        "ordinal": 1,
+        "ordinal": 2,
         "name": "speaker_id",
         "type_info": "Text"
       },
       {
-        "ordinal": 2,
+        "ordinal": 3,
         "name": "diarized_speaker_id",
         "type_info": "Text"
       },
       {
-        "ordinal": 3,
+        "ordinal": 4,
         "name": "custom_speaker",
         "type_info": "Text"
       },
       {
-        "ordinal": 4,
+        "ordinal": 5,
         "name": "content",
         "type_info": "Text"
       },
       {
-        "ordinal": 5,
+        "ordinal": 6,
         "name": "started_at",
         "type_info": "Timestamptz"
       },
       {
-        "ordinal": 6,
+        "ordinal": 7,
         "name": "ended_at",
         "type_info": "Timestamptz"
       },
       {
-        "ordinal": 7,
+        "ordinal": 8,
         "name": "sequence_num",
         "type_info": "Int4"
       }
@@ -50,6 +55,7 @@
       ]
     },
     "nullable": [
+      false,
       true,
       false,
       true,
@@ -60,5 +66,5 @@
       false
     ]
   },
-  "hash": "f2ca3e891cf63cbdad88b2ef040dd73e501abe540dbe1c8150fe70db531ef36a"
+  "hash": "e0f6814556fe2f6367e9e337e4f33fb4c48b673d594fcaf198ee927949796957"
 }

--- a/rust/cloud-storage/call/src/domain/models.rs
+++ b/rust/cloud-storage/call/src/domain/models.rs
@@ -200,9 +200,7 @@ pub struct EditCallTranscriptRequest {
 #[cfg_attr(feature = "inbound", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct CallRecordTranscriptSegment {
-    /// Stable DB-row identifier for the segment. Always present and unique
-    /// within a call — clients use this for deep-link targeting (e.g. search
-    /// "go to" navigation) where `sequence_num` is only an ordering hint.
+    /// Stable DB-row id for the segment.
     pub transcript_id: Uuid,
     /// LiveKit segment ID (nullable for archived records).
     pub segment_id: Option<String>,

--- a/rust/cloud-storage/call/src/domain/models.rs
+++ b/rust/cloud-storage/call/src/domain/models.rs
@@ -200,6 +200,10 @@ pub struct EditCallTranscriptRequest {
 #[cfg_attr(feature = "inbound", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct CallRecordTranscriptSegment {
+    /// Stable DB-row identifier for the segment. Always present and unique
+    /// within a call — clients use this for deep-link targeting (e.g. search
+    /// "go to" navigation) where `sequence_num` is only an ordering hint.
+    pub transcript_id: Uuid,
     /// LiveKit segment ID (nullable for archived records).
     pub segment_id: Option<String>,
     /// The speaker's user ID.

--- a/rust/cloud-storage/call/src/outbound/pg_call_repo.rs
+++ b/rust/cloud-storage/call/src/outbound/pg_call_repo.rs
@@ -805,7 +805,7 @@ impl CallRepository for PgCallRepo {
 
             let transcript = sqlx::query!(
                 r#"
-                SELECT segment_id, speaker_id, diarized_speaker_id, content, started_at, ended_at, sequence_num
+                SELECT id, segment_id, speaker_id, diarized_speaker_id, content, started_at, ended_at, sequence_num
                 FROM call_transcripts
                 WHERE call_id = $1
                 ORDER BY sequence_num ASC
@@ -816,6 +816,7 @@ impl CallRepository for PgCallRepo {
             .await?
             .into_iter()
             .map(|row| CallRecordTranscriptSegment {
+                transcript_id: row.id,
                 segment_id: Some(row.segment_id),
                 speaker_id: row.speaker_id,
                 diarized_speaker_id: row.diarized_speaker_id,
@@ -884,7 +885,7 @@ impl CallRepository for PgCallRepo {
 
         let transcript = sqlx::query!(
             r#"
-            SELECT segment_id, speaker_id, diarized_speaker_id, custom_speaker, content, started_at, ended_at, sequence_num
+            SELECT id, segment_id, speaker_id, diarized_speaker_id, custom_speaker, content, started_at, ended_at, sequence_num
             FROM call_record_transcripts
             WHERE call_record_id = $1
             ORDER BY sequence_num ASC
@@ -895,6 +896,7 @@ impl CallRepository for PgCallRepo {
         .await?
         .into_iter()
         .map(|row| CallRecordTranscriptSegment {
+            transcript_id: row.id,
             segment_id: row.segment_id,
             speaker_id: row.custom_speaker.unwrap_or(row.speaker_id),
             diarized_speaker_id: row.diarized_speaker_id,

--- a/rust/cloud-storage/search_service/src/api/search/call_record.rs
+++ b/rust/cloud-storage/search_service/src/api/search/call_record.rs
@@ -87,7 +87,9 @@ pub(in crate::api::search) async fn enrich_call_records(
     let result = hits_by_call_id
         .into_iter()
         .map(|(call_id, mut hits)| {
-            hits.sort_by_key(|h| h.sequence_num);
+            // Hits without a sequence_num sink to the bottom rather than
+            // floating to the top (where `None` would sort by default).
+            hits.sort_by_key(|h| h.sequence_num.unwrap_or(i32::MAX));
 
             let (channel_id, participant_ids) = call_context
                 .get(&call_id)

--- a/rust/cloud-storage/search_service/src/api/search/call_record.rs
+++ b/rust/cloud-storage/search_service/src/api/search/call_record.rs
@@ -87,8 +87,6 @@ pub(in crate::api::search) async fn enrich_call_records(
     let result = hits_by_call_id
         .into_iter()
         .map(|(call_id, mut hits)| {
-            // Hits without a sequence_num sink to the bottom rather than
-            // floating to the top (where `None` would sort by default).
             hits.sort_by_key(|h| h.sequence_num.unwrap_or(i32::MAX));
 
             let (channel_id, participant_ids) = call_context

--- a/rust/cloud-storage/search_service/src/api/search/call_record.rs
+++ b/rust/cloud-storage/search_service/src/api/search/call_record.rs
@@ -86,7 +86,9 @@ pub(in crate::api::search) async fn enrich_call_records(
 
     let result = hits_by_call_id
         .into_iter()
-        .map(|(call_id, hits)| {
+        .map(|(call_id, mut hits)| {
+            hits.sort_by_key(|h| h.sequence_num);
+
             let (channel_id, participant_ids) = call_context
                 .get(&call_id)
                 .cloned()


### PR DESCRIPTION
Clicking a call-record content hit in search now opens the call and highlights/scrolls to the matched transcript segment, mirroring channel message go-to. Backend already returns `sequence_num` on hits — the frontend wires it through a new `call_segment_seq` param and `goToLocationFromParams` on the call block.
