### PR TITLE
fix(properties): assignee menu rows overlapping when searching

### DIFF
--- a/js/app/packages/core/component/Properties/component/modal/shared/PropertyEntitySelector.tsx
+++ b/js/app/packages/core/component/Properties/component/modal/shared/PropertyEntitySelector.tsx
@@ -238,6 +238,7 @@ export function PropertyEntitySelector(props: EntityInputProps) {
     const allEntities = entities();
     const userId = currentUserId();
 
+    // List is unvirtualized — revisit if these caps grow significantly.
     const MAX_VISIBLE_ENTITIES_NO_SEARCH = 50;
     const MAX_SEARCH_RESULTS = 20;
 

--- a/js/app/packages/core/component/Properties/component/modal/shared/PropertyEntitySelector.tsx
+++ b/js/app/packages/core/component/Properties/component/modal/shared/PropertyEntitySelector.tsx
@@ -18,7 +18,6 @@ import {
   onMount,
   Show,
 } from 'solid-js';
-import { type VirtualizerHandle, VList } from 'virtua/solid';
 import { useSearchInputFocus } from '../../../utils';
 import {
   type CombinedEntity,
@@ -89,7 +88,7 @@ function getEntityName(entity: CombinedEntity): string {
   return data.name ?? '';
 }
 
-const ITEM_SIZE = 32;
+const MAX_LIST_HEIGHT = 192;
 
 export function PropertyEntitySelector(props: EntityInputProps) {
   const [inputValue, setInputValue] = createSignal('');
@@ -106,7 +105,7 @@ export function PropertyEntitySelector(props: EntityInputProps) {
   });
   const pinnedCount = () => visiblePinnedOptions().length;
 
-  let virtualizerHandle: VirtualizerHandle | undefined;
+  let scrollContainerRef: HTMLDivElement | undefined;
 
   // Debounce search term updates (60ms like MentionsMenu)
   const debouncedSetSearchTerm = debounce(
@@ -378,13 +377,15 @@ export function PropertyEntitySelector(props: EntityInputProps) {
     setSelectedIndex(0);
   });
 
-  // Scroll VList to selected index only during keyboard navigation
+  // Scroll the selected row into view during keyboard navigation
   createEffect(() => {
     const index = selectedIndex();
     const pCount = pinnedCount();
-    if (keyboardMode() && index >= pCount && virtualizerHandle) {
-      virtualizerHandle.scrollToIndex(index - pCount, { align: 'nearest' });
-    }
+    if (!keyboardMode() || index < pCount || !scrollContainerRef) return;
+    const row = scrollContainerRef.querySelector<HTMLDivElement>(
+      `[data-entity-index="${index - pCount}"]`
+    );
+    row?.scrollIntoView({ block: 'nearest' });
   });
 
   const handleKeyDown = (e: KeyboardEvent) => {
@@ -481,76 +482,75 @@ export function PropertyEntitySelector(props: EntityInputProps) {
             }}
           </For>
           <Show when={sortedEntities().length > 0}>
-            <VList
-              ref={(handle) => {
-                virtualizerHandle = handle;
-              }}
-              data={sortedEntities()}
-              itemSize={ITEM_SIZE}
-              bufferSize={5 * ITEM_SIZE}
+            <div
+              ref={scrollContainerRef}
               style={{
-                height: `${Math.min(sortedEntities().length * ITEM_SIZE, 192)}px`,
-                contain: 'content',
+                'max-height': `${MAX_LIST_HEIGHT}px`,
               }}
               class="overflow-y-auto overflow-x-hidden scrollbar-hidden"
             >
-              {(entity, index) => {
-                const adjustedIndex = () => index() + pinnedCount();
-                const isSelected = () => props.selectedOptions().has(entity.id);
-                const isKeyboardSelected = () =>
-                  adjustedIndex() === selectedIndex();
+              <For each={sortedEntities()}>
+                {(entity, index) => {
+                  const adjustedIndex = () => index() + pinnedCount();
+                  const isSelected = () =>
+                    props.selectedOptions().has(entity.id);
+                  const isKeyboardSelected = () =>
+                    adjustedIndex() === selectedIndex();
 
-                return (
-                  <div
-                    data-entity-index={index()}
-                    class="flex items-center justify-between gap-2 py-1.5 px-2 min-w-0 h-8"
-                    classList={{
-                      'bg-hover': isKeyboardSelected(),
-                      'bg-accent/10': isSelected(),
-                    }}
-                    onClick={() => toggleEntity(entity)}
-                    onKeyDown={(e) => e.key === 'Enter' && toggleEntity(entity)}
-                    onMouseEnter={() => {
-                      if (!keyboardMode()) {
-                        setSelectedIndex(adjustedIndex());
+                  return (
+                    <div
+                      data-entity-index={index()}
+                      class="flex items-center justify-between gap-2 py-1.5 px-2 min-w-0 h-8"
+                      classList={{
+                        'bg-hover': isKeyboardSelected(),
+                        'bg-accent/10': isSelected(),
+                      }}
+                      onClick={() => toggleEntity(entity)}
+                      onKeyDown={(e) =>
+                        e.key === 'Enter' && toggleEntity(entity)
                       }
-                    }}
-                  >
-                    <div class="flex items-center gap-2 flex-1 min-w-0">
-                      <div class="size-4 shrink-0">
-                        <Show
-                          when={entity.kind === 'entity'}
-                          fallback={
-                            <UserIcon
-                              id={entity.id}
-                              size="xs"
-                              isDeleted={false}
-                              suppressClick={true}
-                            />
-                          }
-                        >
-                          <Entity.Icon entity={entity.data as EntityData} />
-                        </Show>
+                      onMouseEnter={() => {
+                        if (!keyboardMode()) {
+                          setSelectedIndex(adjustedIndex());
+                        }
+                      }}
+                    >
+                      <div class="flex items-center gap-2 flex-1 min-w-0">
+                        <div class="size-4 shrink-0">
+                          <Show
+                            when={entity.kind === 'entity'}
+                            fallback={
+                              <UserIcon
+                                id={entity.id}
+                                size="xs"
+                                isDeleted={false}
+                                suppressClick={true}
+                              />
+                            }
+                          >
+                            <Entity.Icon entity={entity.data as EntityData} />
+                          </Show>
+                        </div>
+                        <span class="truncate min-w-0">
+                          <Show
+                            when={entity.kind === 'entity'}
+                            fallback={getEntityName(entity)}
+                          >
+                            <Entity.Title entity={entity.data as EntityData} />
+                          </Show>
+                        </span>
                       </div>
-                      <span class="truncate min-w-0">
-                        <Show
-                          when={entity.kind === 'entity'}
-                          fallback={getEntityName(entity)}
-                        >
-                          <Entity.Title entity={entity.data as EntityData} />
-                        </Show>
-                      </span>
+                      <div class="shrink-0">
+                        <OptionCheckBox
+                          checked={isSelected()}
+                          multiselect={props.config.isMultiSelect}
+                        />
+                      </div>
                     </div>
-                    <div class="shrink-0">
-                      <OptionCheckBox
-                        checked={isSelected()}
-                        multiselect={props.config.isMultiSelect}
-                      />
-                    </div>
-                  </div>
-                );
-              }}
-            </VList>
+                  );
+                }}
+              </For>
+            </div>
           </Show>
         </div>
       </Show>


### PR DESCRIPTION
Replaces the `virtua` VList in the assignee/entity picker with a plain scrollable `<For>`. The list is bounded at 50 items (20 during search), so virtualization wasn't needed and was the source of row-overlap glitches when data swapped during search. Keyboard scroll-into-view now uses `querySelector` on the scroll container via `data-entity-index`.
