### PR TITLE
Seanaye/feat/contacts migrations

### DIFF
--- a/rust/cloud-storage/contacts/src/domain/models/messages.rs
+++ b/rust/cloud-storage/contacts/src/domain/models/messages.rs
@@ -4,7 +4,7 @@ use std::collections::HashSet;
 
 /// A contacts SQS message carrying the list of user IDs to connect.
 #[derive(Serialize, Deserialize, Debug)]
-pub struct ContactsMessage {
+pub struct ContactsNodes {
     /// User IDs whose pairwise connections should be upserted.
     pub users: HashSet<MacroUserIdStr<'static>>,
 }

--- a/rust/cloud-storage/contacts/src/domain/ports.rs
+++ b/rust/cloud-storage/contacts/src/domain/ports.rs
@@ -1,6 +1,7 @@
-use crate::domain::models::messages::ContactsMessage;
+use crate::domain::models::messages::ContactsNodes;
 use macro_user_id::user_id::MacroUserIdStr;
 use rootcause::Report;
+use sqlx::types::Uuid;
 use std::collections::HashSet;
 
 /// Port trait for accessing the contacts data store.
@@ -30,7 +31,7 @@ pub trait ContactsNotifier: Send + Sync + 'static {
 /// Port trait for publishing a contacts message to the ingress queue.
 pub trait ContactsIngressQueue: Send + Sync + 'static {
     /// Publish a contacts message to the queue.
-    fn publish(&self, message: ContactsMessage) -> impl Future<Output = Result<(), Report>> + Send;
+    fn publish(&self, message: ContactsNodes) -> impl Future<Output = Result<(), Report>> + Send;
 }
 
 /// Port trait for enqueuing contacts messages for async processing.
@@ -50,10 +51,32 @@ pub trait ContactsService: Send + Sync + 'static {
         user_id: MacroUserIdStr<'_>,
     ) -> impl Future<Output = Result<Vec<MacroUserIdStr<'static>>, rootcause::Report>> + Send;
 
-    /// Adds a contact connection between two users.
-    fn add_contact(
+    /// Adds a contact connection between n users as a complete graph.
+    fn add_contact_nodes(
         &self,
-        caller: MacroUserIdStr<'_>,
-        recipient: MacroUserIdStr<'_>,
+        nodes: ContactsNodes,
+    ) -> impl Future<Output = Result<(), rootcause::Report>> + Send;
+}
+
+/// Trait for outbox message processing
+pub trait ContactsOutboxService: Send + Sync + 'static {
+    /// polls the outbox for non-applied messages and attempts to apply them, marking them as done
+    fn poll_outbox(&self) -> impl Future<Output = Result<(), rootcause::Report>> + Send;
+}
+
+pub(crate) struct ContactsBackfillOutboxMessage {
+    pub(crate) id: u64,
+    pub(crate) channel_id: Uuid,
+    pub(crate) channel_participants: HashSet<MacroUserIdStr<'static>>,
+}
+
+pub(crate) trait ContactsBackfillOutboxRepo: Send + Sync + 'static {
+    fn get_unapplied_messages(
+        &self,
+    ) -> impl Future<Output = Result<Vec<ContactsBackfillOutboxMessage>, rootcause::Report>> + Send;
+
+    fn mark_message_applied(
+        &self,
+        id: u64,
     ) -> impl Future<Output = Result<(), rootcause::Report>> + Send;
 }

--- a/rust/cloud-storage/contacts/src/domain/service.rs
+++ b/rust/cloud-storage/contacts/src/domain/service.rs
@@ -1,13 +1,18 @@
 use crate::domain::models::graph::{UndirectedGraph, Vertex};
-use crate::domain::models::messages::ContactsMessage;
+use crate::domain::models::messages::ContactsNodes;
 use crate::domain::ports::{
-    ContactsIngress, ContactsIngressQueue, ContactsNotifier, ContactsRepository, ContactsService,
+    ContactsBackfillOutboxRepo, ContactsIngress, ContactsIngressQueue, ContactsNotifier,
+    ContactsOutboxService, ContactsRepository, ContactsService,
 };
 use macro_user_id::cowlike::CowLike;
 use macro_user_id::user_id::MacroUserIdStr;
 use rootcause::Report;
 use std::collections::HashSet;
+use std::sync::Arc;
 use tracing::instrument;
+
+#[cfg(test)]
+mod test;
 
 /// Domain service combining a repository and notifier to manage contacts.
 pub struct ContactsDomainService<R, N> {
@@ -36,7 +41,7 @@ impl<R: ContactsRepository, N: ContactsNotifier> ContactsDomainService<R, N> {
     #[instrument(err, skip(self))]
     pub(crate) async fn process_message(
         &self,
-        msg: ContactsMessage,
+        msg: ContactsNodes,
     ) -> Result<(), rootcause::Report> {
         let connections: Vec<(MacroUserIdStr<'static>, MacroUserIdStr<'static>)> = {
             let graph = UndirectedGraph::new(msg.users.iter().map(Vertex::new)).complete();
@@ -64,15 +69,8 @@ impl<R: ContactsRepository, N: ContactsNotifier> ContactsService for ContactsDom
         self.query_contacts(user_id).await
     }
 
-    async fn add_contact(
-        &self,
-        caller: MacroUserIdStr<'_>,
-        recipient: MacroUserIdStr<'_>,
-    ) -> Result<(), rootcause::Report> {
-        self.process_message(ContactsMessage {
-            users: HashSet::from([caller.into_owned(), recipient.into_owned()]),
-        })
-        .await
+    async fn add_contact_nodes(&self, nodes: ContactsNodes) -> Result<(), rootcause::Report> {
+        self.process_message(nodes).await
     }
 }
 
@@ -92,9 +90,37 @@ impl<Q: ContactsIngressQueue> ContactsIngress for SqsContactsIngress<Q> {
         &self,
         users: HashSet<MacroUserIdStr<'static>>,
     ) -> Result<(), Report> {
-        self.queue.publish(ContactsMessage { users }).await
+        self.queue.publish(ContactsNodes { users }).await
     }
 }
 
-#[cfg(test)]
-mod test;
+/// Domain service that polls the backfill outbox and applies pending entries.
+pub struct ContactsOutboxServiceImpl<O, S> {
+    /// The outbox repository for fetching and marking applied messages.
+    pub outbox_repo: O,
+    /// The inner contacts service used to apply each outbox entry.
+    pub inner_service: Arc<S>,
+}
+
+impl<O, S> ContactsOutboxService for ContactsOutboxServiceImpl<O, S>
+where
+    O: ContactsBackfillOutboxRepo,
+    S: ContactsService,
+{
+    async fn poll_outbox(&self) -> Result<(), rootcause::Report> {
+        let messages = self.outbox_repo.get_unapplied_messages().await?;
+        for message in messages {
+            let Ok(()) = self
+                .inner_service
+                .add_contact_nodes(ContactsNodes {
+                    users: message.channel_participants,
+                })
+                .await
+            else {
+                continue;
+            };
+            let _ = self.outbox_repo.mark_message_applied(message.id).await;
+        }
+        Ok(())
+    }
+}

--- a/rust/cloud-storage/contacts/src/domain/service/test.rs
+++ b/rust/cloud-storage/contacts/src/domain/service/test.rs
@@ -3,7 +3,7 @@ use super::*;
 #[test]
 fn test_deserialize_connections_message() {
     let input_json = include_str!("../../../tests/fixtures/add_connection.json");
-    let msg: Option<ContactsMessage> = serde_json::from_str(input_json).ok();
+    let msg: Option<ContactsNodes> = serde_json::from_str(input_json).ok();
     assert!(msg.is_some());
     assert_eq!(msg.unwrap().users.len(), 3);
 }

--- a/rust/cloud-storage/contacts/src/inbound/http.rs
+++ b/rust/cloud-storage/contacts/src/inbound/http.rs
@@ -74,7 +74,9 @@ pub async fn add_contact_handler<S: ContactsService>(
     Json(body): Json<AddContactRequest>,
 ) -> Result<StatusCode, StatusCode> {
     service
-        .add_contact(macro_user_id, body.user_id)
+        .add_contact_nodes(ContactsNodes {
+            users: HashSet::from([macro_user_id, body.user_id]),
+        })
         .await
         .map_err(|e| {
             tracing::error!(error=?e, "failed to create contact connection");

--- a/rust/cloud-storage/contacts/src/inbound/http/test.rs
+++ b/rust/cloud-storage/contacts/src/inbound/http/test.rs
@@ -47,11 +47,7 @@ impl ContactsService for MockService {
         Ok(vec![])
     }
 
-    async fn add_contact(
-        &self,
-        _caller: MacroUserIdStr<'_>,
-        _recipient: MacroUserIdStr<'_>,
-    ) -> Result<(), rootcause::Report> {
+    async fn add_contact_nodes(&self, _nodes: ContactsNodes) -> Result<(), rootcause::Report> {
         Ok(())
     }
 }

--- a/rust/cloud-storage/contacts/src/inbound/worker.rs
+++ b/rust/cloud-storage/contacts/src/inbound/worker.rs
@@ -1,5 +1,7 @@
-use crate::domain::models::messages::ContactsMessage;
-use crate::domain::ports::{ContactsNotifier, ContactsRepository};
+use std::time::Duration;
+
+use crate::domain::models::messages::ContactsNodes;
+use crate::domain::ports::{ContactsNotifier, ContactsOutboxService, ContactsRepository};
 use crate::domain::service::ContactsDomainService;
 use rootcause::report;
 use sqs_worker::SQSWorker;
@@ -87,11 +89,39 @@ impl<R: ContactsRepository, N: ContactsNotifier> ContactsWorker<R, N> {
 }
 
 /// Parses a JSON string into a [`ContactsMessage`].
-pub fn message_from_json(body: &str) -> Option<ContactsMessage> {
+fn message_from_json(body: &str) -> Option<ContactsNodes> {
     serde_json::from_str(body).ok()
 }
 
 /// Extracts and parses the body from an SQS message.
-pub fn message_from_sqs(msg: &aws_sdk_sqs::types::Message) -> Option<ContactsMessage> {
+pub(crate) fn message_from_sqs(msg: &aws_sdk_sqs::types::Message) -> Option<ContactsNodes> {
     msg.body.as_ref().and_then(|body| message_from_json(body))
+}
+
+/// Worker that periodically polls the contacts backfill outbox.
+pub struct OutboxWorker<S> {
+    /// The outbox service to poll.
+    pub service: S,
+}
+
+impl<S> OutboxWorker<S>
+where
+    S: ContactsOutboxService,
+{
+    /// Runs the outbox poll loop indefinitely.
+    pub async fn run(&self) -> ! {
+        loop {
+            let fut = self.service.poll_outbox();
+            match tokio::time::timeout(Duration::from_secs(15), fut).await {
+                Ok(Ok(())) => {}
+                Ok(Err(err)) => {
+                    tracing::error!(error=?err, "Failed to poll contacts outbox")
+                }
+                Err(_) => {
+                    tracing::error!("Contacts worker outbox poll failed due to timeout")
+                }
+            }
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        }
+    }
 }

--- a/rust/cloud-storage/contacts/src/outbound/ingress.rs
+++ b/rust/cloud-storage/contacts/src/outbound/ingress.rs
@@ -1,4 +1,4 @@
-use crate::domain::models::messages::ContactsMessage;
+use crate::domain::models::messages::ContactsNodes;
 use crate::domain::ports::ContactsIngressQueue;
 use rootcause::Report;
 
@@ -18,7 +18,7 @@ impl SqsContactsQueue {
 
 impl ContactsIngressQueue for SqsContactsQueue {
     #[tracing::instrument(skip(self, message), err)]
-    async fn publish(&self, message: ContactsMessage) -> Result<(), Report> {
+    async fn publish(&self, message: ContactsNodes) -> Result<(), Report> {
         let body = serde_json::to_string(&message)?;
         self.client
             .send_message()

--- a/rust/cloud-storage/contacts/src/outbound/repository.rs
+++ b/rust/cloud-storage/contacts/src/outbound/repository.rs
@@ -1,10 +1,13 @@
 #[cfg(test)]
 mod test;
 
-use crate::domain::ports::ContactsRepository;
+use crate::domain::ports::{
+    ContactsBackfillOutboxMessage, ContactsBackfillOutboxRepo, ContactsRepository,
+};
 use macro_user_id::user_id::MacroUserIdStr;
 use rootcause::Report;
 use sqlx::PgPool;
+use sqlx::types::Uuid;
 
 /// Database-backed implementation of [`ContactsRepository`].
 pub struct DbContactsRepository {
@@ -76,6 +79,55 @@ impl ContactsRepository for DbContactsRepository {
             tracing::error!(error=?e, "couldn't create connections");
         })?;
 
+        Ok(())
+    }
+}
+
+struct BackfillOutboxRow {
+    id: i32,
+    comms_channel_id: Uuid,
+    user_ids: serde_json::Value,
+}
+
+impl ContactsBackfillOutboxRepo for DbContactsRepository {
+    async fn get_unapplied_messages(&self) -> Result<Vec<ContactsBackfillOutboxMessage>, Report> {
+        let rows = sqlx::query_as!(
+            BackfillOutboxRow,
+            "SELECT id, comms_channel_id, user_ids
+             FROM contacts_backfill_outbox
+             WHERE applied_at IS NULL
+             ORDER BY id"
+        )
+        .fetch_all(&self.db)
+        .await?;
+
+        rows.into_iter()
+            .map(|r| -> Result<ContactsBackfillOutboxMessage, Report> {
+                let user_ids: Vec<String> = serde_json::from_value(r.user_ids)?;
+                let channel_participants = user_ids
+                    .into_iter()
+                    .map(MacroUserIdStr::try_from)
+                    .collect::<Result<_, _>>()?;
+                Ok(ContactsBackfillOutboxMessage {
+                    id: r.id as u64,
+                    channel_id: r.comms_channel_id,
+                    channel_participants,
+                })
+            })
+            .collect()
+    }
+
+    #[tracing::instrument(err, skip(self))]
+    async fn mark_message_applied(&self, id: u64) -> Result<(), Report> {
+        sqlx::query!(
+            "UPDATE contacts_backfill_outbox SET applied_at = now() WHERE id = $1",
+            id as i64
+        )
+        .execute(&self.db)
+        .await
+        .inspect_err(
+            |e| tracing::error!(error=?e, "couldn't mark backfill outbox message applied"),
+        )?;
         Ok(())
     }
 }

--- a/rust/cloud-storage/contacts/src/outbound/repository/test.rs
+++ b/rust/cloud-storage/contacts/src/outbound/repository/test.rs
@@ -1,7 +1,8 @@
-use crate::domain::ports::ContactsRepository;
+use crate::domain::ports::{ContactsBackfillOutboxRepo, ContactsRepository};
 use macro_db_migrator::MACRO_DB_MIGRATIONS;
 use macro_user_id::user_id::MacroUserIdStr;
 use sqlx::PgPool;
+use sqlx::types::Uuid;
 
 use super::DbContactsRepository;
 
@@ -80,5 +81,75 @@ async fn test_create_connections_batch(pool: PgPool) -> sqlx::Result<()> {
         .await
         .unwrap();
     assert_eq!(contacts.len(), expected_count as usize);
+    Ok(())
+}
+
+async fn insert_channel(pool: &PgPool, id: Uuid) {
+    sqlx::query!(
+        "INSERT INTO comms_channels (id, channel_type, owner_id) \
+         VALUES ($1, 'direct_message', 'macro|owner@test.com')",
+        id
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+#[sqlx::test(migrator = "MACRO_DB_MIGRATIONS")]
+async fn test_get_unapplied_messages_returns_inserted_rows(pool: PgPool) -> sqlx::Result<()> {
+    let channel_id = Uuid::new_v4();
+    insert_channel(&pool, channel_id).await;
+
+    // Simulate what the migration backfill inserts
+    sqlx::query!(
+        "INSERT INTO contacts_backfill_outbox (comms_channel_id, user_ids) \
+         VALUES ($1, '[\"macro|a@test.com\", \"macro|b@test.com\"]'::jsonb)",
+        channel_id,
+    )
+    .execute(&pool)
+    .await?;
+
+    let repo = DbContactsRepository::new(pool);
+    let messages = repo.get_unapplied_messages().await.unwrap();
+
+    assert_eq!(messages.len(), 1);
+    assert_eq!(messages[0].channel_id, channel_id);
+    assert_eq!(
+        messages[0].channel_participants,
+        [mid("macro|a@test.com"), mid("macro|b@test.com")]
+            .into_iter()
+            .collect()
+    );
+    Ok(())
+}
+
+#[sqlx::test(migrator = "MACRO_DB_MIGRATIONS")]
+async fn test_get_unapplied_messages_excludes_applied(pool: PgPool) -> sqlx::Result<()> {
+    let unapplied_id = Uuid::new_v4();
+    let applied_id = Uuid::new_v4();
+    insert_channel(&pool, unapplied_id).await;
+    insert_channel(&pool, applied_id).await;
+
+    sqlx::query!(
+        "INSERT INTO contacts_backfill_outbox (comms_channel_id, user_ids) \
+         VALUES ($1, '[\"macro|a@test.com\"]'::jsonb)",
+        unapplied_id,
+    )
+    .execute(&pool)
+    .await?;
+
+    sqlx::query!(
+        "INSERT INTO contacts_backfill_outbox (comms_channel_id, user_ids, applied_at) \
+         VALUES ($1, '[\"macro|b@test.com\"]'::jsonb, now())",
+        applied_id,
+    )
+    .execute(&pool)
+    .await?;
+
+    let repo = DbContactsRepository::new(pool);
+    let messages = repo.get_unapplied_messages().await.unwrap();
+
+    assert_eq!(messages.len(), 1);
+    assert_eq!(messages[0].channel_id, unapplied_id);
     Ok(())
 }

--- a/rust/cloud-storage/contacts_service/examples/generate_message.rs
+++ b/rust/cloud-storage/contacts_service/examples/generate_message.rs
@@ -1,12 +1,12 @@
 // Small utility to generate a sample connections message to send to the SQS service
-use contacts::domain::models::messages::ContactsMessage;
+use contacts::domain::models::messages::ContactsNodes;
 use macro_user_id::user_id::MacroUserIdStr;
 use std::{collections::HashSet, env};
 
 fn print_contacts_message(users: HashSet<MacroUserIdStr<'static>>) {
     println!(
         "{}",
-        serde_json::to_string(&ContactsMessage { users }).unwrap()
+        serde_json::to_string(&ContactsNodes { users }).unwrap()
     );
 }
 

--- a/rust/cloud-storage/contacts_service/src/main.rs
+++ b/rust/cloud-storage/contacts_service/src/main.rs
@@ -5,9 +5,9 @@ use std::sync::Arc;
 
 use anyhow::Context;
 use config::{Config, Environment};
-use contacts::domain::service::ContactsDomainService;
+use contacts::domain::service::{ContactsDomainService, ContactsOutboxServiceImpl};
 use contacts::inbound::http::{ApiDoc, AppState};
-use contacts::inbound::worker::ContactsWorker;
+use contacts::inbound::worker::{ContactsWorker, OutboxWorker};
 use contacts::outbound::gateway::ConnectionGatewayNotifier;
 use contacts::outbound::repository::DbContactsRepository;
 use macro_entrypoint::MacroEntrypoint;
@@ -76,6 +76,7 @@ async fn main() -> anyhow::Result<()> {
     };
 
     let repository = DbContactsRepository::new(db.clone());
+    let outbox_repo = DbContactsRepository::new(db.clone());
     let service = Arc::new(ContactsDomainService {
         repository,
         notifier,
@@ -84,6 +85,16 @@ async fn main() -> anyhow::Result<()> {
     let worker = ContactsWorker::new(sqs_worker, service.clone());
     tokio::spawn(async move {
         worker.poll().await;
+    });
+
+    let outbox_worker = OutboxWorker {
+        service: ContactsOutboxServiceImpl {
+            outbox_repo,
+            inner_service: service.clone(),
+        },
+    };
+    tokio::spawn(async move {
+        outbox_worker.run().await;
     });
 
     let jwt_args = macro_auth::middleware::decode_jwt::JwtValidationArgs::new_with_secret_manager(

--- a/rust/cloud-storage/macro_db_client/migrations/20260429120000_contacts_no_self_connection.sql
+++ b/rust/cloud-storage/macro_db_client/migrations/20260429120000_contacts_no_self_connection.sql
@@ -1,0 +1,5 @@
+DELETE FROM contacts_connections WHERE user1 = user2;
+
+ALTER TABLE contacts_connections
+    DROP CONSTRAINT contacts_connections_check,
+    ADD CONSTRAINT contacts_connections_user1_user2_check CHECK (user1 < user2 COLLATE "C");

--- a/rust/cloud-storage/macro_db_client/migrations/20260429140000_contacts_backfill_outbox.sql
+++ b/rust/cloud-storage/macro_db_client/migrations/20260429140000_contacts_backfill_outbox.sql
@@ -1,0 +1,42 @@
+CREATE TABLE contacts_backfill_outbox (
+    id                SERIAL PRIMARY KEY,
+    comms_channel_id  uuid        NOT NULL REFERENCES comms_channels(id),
+    user_ids          jsonb       NOT NULL,
+    applied_at        timestamptz,
+    created_at        timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_contacts_backfill_outbox_applied_at ON contacts_backfill_outbox(applied_at);
+
+DO $$
+DECLARE
+    batch_size  INT := 100;
+    last_id     TEXT := '00000000-0000-0000-0000-000000000000';
+    batch_count INT;
+BEGIN
+    LOOP
+        WITH batch AS (
+            SELECT c.id
+            FROM comms_channels c
+            WHERE c.id::text > last_id
+            ORDER BY c.id::text
+            LIMIT batch_size
+        ),
+        inserted AS (
+            INSERT INTO contacts_backfill_outbox (comms_channel_id, user_ids)
+            SELECT
+                b.id,
+                jsonb_agg(p.user_id)
+            FROM batch b
+            JOIN comms_channel_participants p ON p.channel_id = b.id
+            GROUP BY b.id
+            RETURNING comms_channel_id
+        )
+        SELECT COUNT(*), MAX(b.id::text)
+        INTO batch_count, last_id
+        FROM batch b;
+
+        EXIT WHEN batch_count < batch_size;
+        PERFORM pg_sleep(0.5);
+    END LOOP;
+END $$;


### PR DESCRIPTION
Stacked PR which splits out just the database migrations for 

1. better graph edge constraint which prevents cyclical edges
2. Creates outbox table for backfill contacts processing. This will be used to ensure data consistency for already created channels