### PR TITLE
fix(search): calls filter no longer filters out calls

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/create-search-state.ts
+++ b/js/app/packages/app/component/next-soup/soup-view/create-search-state.ts
@@ -45,14 +45,12 @@ function filterDataToQueryFilters(data: QueryState): EntityFilters {
   if (
     include.threadId?.length ||
     include.emailSender?.length ||
-    include.emailShared ||
-    include.emailImportance !== undefined
+    include.emailShared
   ) {
     filters.email_filters = {
       email_thread_ids: include.threadId,
       senders: include.emailSender,
       shared: include.emailShared,
-      importance: include.emailImportance,
     };
   }
 

--- a/js/app/packages/app/component/next-soup/soup-view/create-search-state.ts
+++ b/js/app/packages/app/component/next-soup/soup-view/create-search-state.ts
@@ -45,12 +45,14 @@ function filterDataToQueryFilters(data: QueryState): EntityFilters {
   if (
     include.threadId?.length ||
     include.emailSender?.length ||
-    include.emailShared
+    include.emailShared ||
+    include.emailImportance !== undefined
   ) {
     filters.email_filters = {
       email_thread_ids: include.threadId,
       senders: include.emailSender,
       shared: include.emailShared,
+      importance: include.emailImportance,
     };
   }
 

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/search-filter-controls.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/search-filter-controls.tsx
@@ -461,7 +461,6 @@ export const INDEX_OPTIONS: {
     label: 'Email',
     icon: () => <EntityIcon targetType="email" size="xs" theme="monochrome" />,
     queryFilters: defineQueryFilters({
-      exclude: { threadId: [NIL_UUID] },
       include: { emailImportance: true },
     }),
   },

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/search-filter-controls.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/search-filter-controls.tsx
@@ -469,9 +469,7 @@ export const INDEX_OPTIONS: {
     value: 'calls',
     label: 'Calls',
     icon: () => <EntityIcon targetType="call" size="xs" theme="monochrome" />,
-    queryFilters: defineQueryFilters({
-      exclude: { callChannelId: [NIL_UUID] },
-    }),
+    queryFilters: defineQueryFilters({}, { skipTargets: ['callf'] }),
   },
   {
     value: 'folders',

--- a/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
@@ -175,7 +175,7 @@ type PersistedSoupViewState = {
   assigneeFilter: string[];
 };
 
-const PERSISTED_STATE_VERSION = 4;
+const PERSISTED_STATE_VERSION = 5;
 
 const listStateCache = new Map<
   string,


### PR DESCRIPTION
The "Calls" filter in search was using `exclude: { callChannelId: [NIL_UUID] }`, which compiled to a `callf: !{ChannelId: NIL}` AST that filtered out calls. Replaced with `skipTargets: ['callf']` to match the "all of calls" preset.

also fixes email importance filter not working