### PR TITLE
feat(channel): assign @mentioned users when creating task from message

### DIFF
--- a/js/app/packages/app/component/split-layout/componentRegistry.tsx
+++ b/js/app/packages/app/component/split-layout/componentRegistry.tsx
@@ -271,6 +271,7 @@ registerComponent('task-compose', (params) => {
       initialContent={params?.initialContent}
       initialTitle={params?.initialTitle}
       initialAssigneeId={params?.initialAssigneeId}
+      initialAssigneeIds={params?.initialAssigneeIds}
       onSuccess={params?.onSuccess}
     />
   );

--- a/js/app/packages/app/component/split-layout/componentRegistry.tsx
+++ b/js/app/packages/app/component/split-layout/componentRegistry.tsx
@@ -270,7 +270,6 @@ registerComponent('task-compose', (params) => {
     <ComposeTask
       initialContent={params?.initialContent}
       initialTitle={params?.initialTitle}
-      initialAssigneeId={params?.initialAssigneeId}
       initialAssigneeIds={params?.initialAssigneeIds}
       onSuccess={params?.onSuccess}
     />

--- a/js/app/packages/block-md/component/ComposeTask.tsx
+++ b/js/app/packages/block-md/component/ComposeTask.tsx
@@ -166,6 +166,7 @@ export interface ComposeTaskProps {
   initialContent?: string;
   placeholder?: string;
   initialAssigneeId?: string;
+  initialAssigneeIds?: string[];
   /**
    * When provided, replaces the default success behavior (auto-copy link +
    * toast) so the caller can handle the created task however it needs.
@@ -179,11 +180,20 @@ export function ComposeTask(props: ComposeTaskProps) {
   const currentUserId = useUserId();
 
   const getDefaultPropertyValues = (): Record<string, PropertyApiValues> => {
-    const id = props.initialAssigneeId ?? currentUserId();
+    const ids = (() => {
+      if (props.initialAssigneeIds && props.initialAssigneeIds.length > 0) {
+        return [...new Set(props.initialAssigneeIds)];
+      }
+      const id = props.initialAssigneeId ?? currentUserId();
+      return id ? [id] : [];
+    })();
     return {
       [SYSTEM_PROPERTY_IDS.ASSIGNEES]: {
         valueType: 'ENTITY' as const,
-        refs: id ? [{ entity_id: id, entity_type: 'USER' as const }] : [],
+        refs: ids.map((entity_id) => ({
+          entity_id,
+          entity_type: 'USER' as const,
+        })),
       },
       [SYSTEM_PROPERTY_IDS.STATUS]: {
         valueType: 'SELECT_STRING' as const,
@@ -197,7 +207,8 @@ export function ComposeTask(props: ComposeTaskProps) {
     if (
       !props.initialTitle &&
       !props.initialContent &&
-      !props.initialAssigneeId
+      !props.initialAssigneeId &&
+      !props.initialAssigneeIds?.length
     ) {
       const draft = loadTaskComposerDraft();
       if (draft) {

--- a/js/app/packages/block-md/component/ComposeTask.tsx
+++ b/js/app/packages/block-md/component/ComposeTask.tsx
@@ -165,7 +165,6 @@ export interface ComposeTaskProps {
   initialTitle?: string;
   initialContent?: string;
   placeholder?: string;
-  initialAssigneeId?: string;
   initialAssigneeIds?: string[];
   /**
    * When provided, replaces the default success behavior (auto-copy link +
@@ -184,7 +183,7 @@ export function ComposeTask(props: ComposeTaskProps) {
       if (props.initialAssigneeIds && props.initialAssigneeIds.length > 0) {
         return [...new Set(props.initialAssigneeIds)];
       }
-      const id = props.initialAssigneeId ?? currentUserId();
+      const id = currentUserId();
       return id ? [id] : [];
     })();
     return {
@@ -207,7 +206,6 @@ export function ComposeTask(props: ComposeTaskProps) {
     if (
       !props.initialTitle &&
       !props.initialContent &&
-      !props.initialAssigneeId &&
       !props.initialAssigneeIds?.length
     ) {
       const draft = loadTaskComposerDraft();

--- a/js/app/packages/channel/Channel/Channel.tsx
+++ b/js/app/packages/channel/Channel/Channel.tsx
@@ -49,6 +49,7 @@ import { useSplitLayout } from '@app/component/split-layout/layout';
 import { openChatWithInput } from '@app/component/ChatWithAgentButton';
 import { useChannelName, useChannelActivity } from '@core/context/channels';
 import { buildMentionMarkdownString, markdownToPlainText } from '@lexical-core';
+import { extractUserMentions } from '@core/util/taskExtraction';
 import { createActivityTracker } from '@channel/activity-tracker';
 import {
   invalidateChannelsActivity,
@@ -247,12 +248,15 @@ export function Channel(props: ChannelProps) {
       const plainText = markdownToPlainText(ctx.message.content).trim();
       const title =
         plainText.length > 70 ? `${plainText.slice(0, 70)}...` : plainText;
+      const mentionedUserIds = extractUserMentions(ctx.message.content);
       popoverSplit({
         type: 'component',
         id: 'task-compose',
         params: {
           initialTitle: title,
           initialContent: buildChannelMessageMention(ctx.message),
+          initialAssigneeIds:
+            mentionedUserIds.length > 0 ? mentionedUserIds : undefined,
         },
       });
     },

--- a/js/app/packages/core/component/UserTooltip.tsx
+++ b/js/app/packages/core/component/UserTooltip.tsx
@@ -71,7 +71,7 @@ export function UserTooltip(props: UserTooltipProps) {
       popoverSplit({
         type: 'component',
         id: 'task-compose',
-        params: { initialAssigneeId: props.id },
+        params: { initialAssigneeIds: [props.id] },
       });
     }
   };


### PR DESCRIPTION
When creating a task from a channel message, any users @mentioned in the message are now auto-assigned to the new task. Falls back to the current user if no one is mentioned.
