### PR TITLE
fix(search): pass attended/speaker/importance filters to search service

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/create-search-state.ts
+++ b/js/app/packages/app/component/next-soup/soup-view/create-search-state.ts
@@ -45,12 +45,14 @@ function filterDataToQueryFilters(data: QueryState): EntityFilters {
   if (
     include.threadId?.length ||
     include.emailSender?.length ||
-    include.emailShared
+    include.emailShared ||
+    include.emailImportance !== undefined
   ) {
     filters.email_filters = {
       email_thread_ids: include.threadId,
       senders: include.emailSender,
       shared: include.emailShared,
+      importance: include.emailImportance,
     };
   }
 
@@ -89,9 +91,15 @@ function filterDataToQueryFilters(data: QueryState): EntityFilters {
   }
 
   // Call filters
-  if (include.callChannelId?.length) {
+  if (
+    include.callChannelId?.length ||
+    include.callSpeakerId?.length ||
+    include.callAttended !== undefined
+  ) {
     filters.call_filters = {
       channel_ids: include.callChannelId,
+      speaker_ids: include.callSpeakerId,
+      attended: include.callAttended,
     };
   }
 


### PR DESCRIPTION
`filterDataToQueryFilters` dropped `emailImportance`, `callSpeakerId`, and `callAttended` when translating the query store into the search-service `EntityFilters` body, so those chips set state but never reached the backend. Verified in the browser that `/search` now sends `call_filters.attended` (and the soup AST path already honored it).
