### PR TITLE
fix(soup): truncate long sender names and overflowing call snippets

### DIFF
--- a/js/app/packages/core/util/searchHighlight.tsx
+++ b/js/app/packages/core/util/searchHighlight.tsx
@@ -122,8 +122,14 @@ export function windowSearchMatch(text: string, chars: number): string {
       : line
           .slice(lastCloseIndex + macroClose.length)
           .replace(/<\/?macro_em>/g, '').length;
+  const visibleMatch =
+    lastCloseIndex === -1
+      ? 0
+      : line
+          .slice(tagIndex, lastCloseIndex + macroClose.length)
+          .replace(/<\/?macro_em>/g, '').length;
 
-  const totalBudget = chars * 2;
+  const totalBudget = Math.max(0, chars * 2 - visibleMatch);
   const frontKeep = Math.max(chars, totalBudget - visibleAfter);
   const backKeep = Math.max(chars, totalBudget - visibleBefore);
 

--- a/js/app/packages/entity/src/components/DisplayName.tsx
+++ b/js/app/packages/entity/src/components/DisplayName.tsx
@@ -1,20 +1,23 @@
 import { tryMacroId, useDisplayNameParts } from '@core/user';
 
+const DEFAULT_MAX_CHARS = 30;
+
 export function DisplayName(props: {
   id: string;
   format?: 'firstName' | 'lastName' | 'fullName';
+  maxChars?: number;
 }) {
   const name = () => {
     const parts = useDisplayNameParts(tryMacroId(props.id));
     const format = props.format ?? 'fullName';
 
-    if (format === 'fullName') {
-      return parts.fullName();
-    }
+    const raw =
+      format === 'fullName'
+        ? parts.fullName()
+        : parts[format]() || parts.fullName();
 
-    // For firstName or lastName, fall back to fullName if empty
-    const requestedPart = parts[format]();
-    return requestedPart || parts.fullName();
+    const max = props.maxChars ?? DEFAULT_MAX_CHARS;
+    return raw.length > max ? `${raw.slice(0, max)}…` : raw;
   };
 
   return <>{name()}</>;

--- a/js/app/packages/entity/src/composed/list-entity/call.tsx
+++ b/js/app/packages/entity/src/composed/list-entity/call.tsx
@@ -161,7 +161,7 @@ export function CallWideContent(props: {
             </span>
             <div
               ref={props.setContainerRef}
-              class="text-ink/50 font-medium flex-1 min-w-0 overflow-hidden"
+              class="text-ink/50 font-medium flex-1 min-w-0 truncate"
             >
               <HitSnippet content={h().content} chars={props.chars} />
             </div>


### PR DESCRIPTION
## Summary
- Default 30-char ellipsis on `DisplayName` so an obnoxiously long sender first name (e.g. `"HELLO".repeat(20)`) no longer blows out call/channel/task/notification rows.
- `windowSearchMatch` reserves the match length in its `totalBudget`. Previously when the highlight sat at the end of a snippet, the trimmed result exceeded the container width by the match length, so the highlighted term and any trailing chars were clipped off-screen.
- `CallWideContent`'s snippet div now uses `truncate` instead of `overflow-hidden`, so any residual overflow (e.g. from the `CHAR_WIDTH_PX` underestimate) renders a clean `…` instead of silent clipping.
