### PR TITLE
feat(undo): scope mark-done undo hotkeys to soup

### DIFF
--- a/js/app/packages/app/component/next-soup/actions/make-mark-done-action.ts
+++ b/js/app/packages/app/component/next-soup/actions/make-mark-done-action.ts
@@ -14,6 +14,7 @@ import {
 import { useMaybePreviewPanel } from '@app/component/PreviewPanel';
 import type { SoupState } from '../create-soup-state';
 import type { ListView } from '@app/constants/list-views';
+import type { HotkeyGroup } from '@core/hotkey/types';
 
 // Valid list views where the mark done should be allowed to run
 const VALID_MARK_DONE_LIST_VIEWS: `${ListView}-${string}`[] = [
@@ -31,6 +32,9 @@ export const canExecuteMarkDoneOnView = (view: ListView, tabId: string) => {
 type MakeMarkDoneOptions = {
   userId?: () => string | undefined;
   notificationSource: () => NotificationSource;
+  /** When provided, undo entries pushed by this action are dropped from
+   *  the undo stack when the group is disposed. */
+  hotkeyGroup?: HotkeyGroup;
 };
 
 type MarkDoneVariables = {
@@ -42,7 +46,7 @@ type MarkDoneVariables = {
 
 /** Must be invoked inside a component tree that provides MutationUndoProvider. */
 export const makeMarkDoneAction = (options: MakeMarkDoneOptions) => {
-  const { notificationSource } = options;
+  const { notificationSource, hotkeyGroup } = options;
   const previewPanel = useMaybePreviewPanel();
   const inPreview = previewPanel !== undefined;
 
@@ -52,6 +56,7 @@ export const makeMarkDoneAction = (options: MakeMarkDoneOptions) => {
     MarkDoneVariables,
     MarkEntitiesDoneContext
   >(() => ({
+    hotkeyGroup,
     onMutate: (variables) =>
       applyEntitiesDoneOptimistic({
         emailIds: variables.emailIds,

--- a/js/app/packages/app/component/next-soup/actions/use-entity-action-hotkeys.ts
+++ b/js/app/packages/app/component/next-soup/actions/use-entity-action-hotkeys.ts
@@ -48,9 +48,12 @@ export const useEntityActionHotkeys = (
   const userId = useUserId();
   const notificationSource = useGlobalNotificationSource();
 
+  const group = createHotkeyGroup();
+
   const markDone = makeMarkDoneAction({
     userId: () => userId(),
     notificationSource: () => notificationSource,
+    hotkeyGroup: group,
   });
 
   const deleteAction = makeDeleteAction({
@@ -118,8 +121,6 @@ export const useEntityActionHotkeys = (
       openPropertyEditor(entities, mode, property);
     }
   };
-
-  const group = createHotkeyGroup();
 
   // Mark Done - 'e', not included in Hotkey Group so that we can use it from inside of blocks
   registerHotkey({

--- a/js/app/packages/core/hotkey/hotkeys.test.ts
+++ b/js/app/packages/core/hotkey/hotkeys.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test, vi } from 'vitest';
+import { createHotkeyGroup } from './hotkeys';
+import type { RegisterHotkeyReturn } from './types';
+
+const makeRegistration = (): RegisterHotkeyReturn => {
+  const reg: RegisterHotkeyReturn = {
+    dispose: vi.fn(),
+    withGroup: (group) => {
+      group.add(reg);
+      return reg;
+    },
+  };
+  return reg;
+};
+
+describe('createHotkeyGroup', () => {
+  test('add returns the registration unchanged', () => {
+    const group = createHotkeyGroup();
+    const reg = makeRegistration();
+    expect(group.add(reg)).toBe(reg);
+  });
+
+  test('dispose disposes every added registration', () => {
+    const group = createHotkeyGroup();
+    const a = makeRegistration();
+    const b = makeRegistration();
+    group.add(a);
+    group.add(b);
+
+    group.dispose();
+
+    expect(a.dispose).toHaveBeenCalledTimes(1);
+    expect(b.dispose).toHaveBeenCalledTimes(1);
+  });
+
+  test('addDisposer runs arbitrary cleanup on dispose', () => {
+    const group = createHotkeyGroup();
+    const cleanup = vi.fn();
+    group.addDisposer(cleanup);
+
+    group.dispose();
+
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  test('runs disposers in insertion order across add and addDisposer', () => {
+    const group = createHotkeyGroup();
+    const calls: string[] = [];
+
+    const a = makeRegistration();
+    (a.dispose as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      calls.push('a');
+    });
+
+    group.add(a);
+    group.addDisposer(() => calls.push('mid'));
+
+    const b = makeRegistration();
+    (b.dispose as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      calls.push('b');
+    });
+    group.add(b);
+
+    group.dispose();
+
+    expect(calls).toEqual(['a', 'mid', 'b']);
+  });
+
+  test('dispose is idempotent — second call is a no-op', () => {
+    const group = createHotkeyGroup();
+    const reg = makeRegistration();
+    const cleanup = vi.fn();
+
+    group.add(reg);
+    group.addDisposer(cleanup);
+
+    group.dispose();
+    group.dispose();
+
+    expect(reg.dispose).toHaveBeenCalledTimes(1);
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  test('withGroup routes through add', () => {
+    const group = createHotkeyGroup();
+    const reg = makeRegistration();
+
+    reg.withGroup(group);
+    group.dispose();
+
+    expect(reg.dispose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/js/app/packages/core/hotkey/hotkeys.ts
+++ b/js/app/packages/core/hotkey/hotkeys.ts
@@ -360,17 +360,21 @@ export function registerHotkey(
  * ```
  */
 export function createHotkeyGroup(): HotkeyGroup {
-  const registrations: RegisterHotkeyReturn[] = [];
+  const disposers: (() => void)[] = [];
 
   return {
     add: <T extends RegisterHotkeyReturn>(registration: T): T => {
-      registrations.push(registration);
+      disposers.push(() => registration.dispose());
       return registration;
     },
+    addDisposer: (dispose) => {
+      disposers.push(dispose);
+    },
     dispose: () => {
-      for (const registration of registrations) {
-        registration.dispose();
+      for (const fn of disposers) {
+        fn();
       }
+      disposers.length = 0;
     },
   };
 }

--- a/js/app/packages/core/hotkey/types.ts
+++ b/js/app/packages/core/hotkey/types.ts
@@ -182,7 +182,10 @@ export interface HotkeyRegistrationOptions {
 export type HotkeyGroup = {
   /** Add a hotkey registration to this group */
   add: <T extends RegisterHotkeyReturn>(registration: T) => T;
-  /** Dispose all hotkeys in this group */
+  /** Register an arbitrary function to run when the group is disposed.
+   *  Use this to tie non-hotkey resources to the group's lifetime. */
+  addDisposer: (dispose: () => void) => void;
+  /** Dispose all hotkeys and registered disposers in this group */
   dispose: () => void;
 };
 

--- a/js/app/packages/queries/undo.ts
+++ b/js/app/packages/queries/undo.ts
@@ -27,6 +27,7 @@
 import { type MutationOptions, useMutation } from '@tanstack/solid-query';
 import { createSignal } from 'solid-js';
 import { createAssertedContextProvider } from '@core/context/createContext';
+import type { HotkeyGroup } from '@core/hotkey/types';
 
 type UndoHandler<TVariables, TContext> = (
   variables: TVariables,
@@ -51,6 +52,9 @@ export type UndoHandle = {
   id: string;
   /** Undo this specific entry, even if it is not at the top of the stack. */
   undo: (callbacks?: UndoCallbacks) => Promise<void>;
+  /** Remove this entry from both undo and redo stacks. Lifecycle hooks
+   *  do not fire. Calling `undo()` after `dispose()` is a no-op. */
+  dispose: () => void;
 };
 
 type UndoCallbacks = {
@@ -143,6 +147,10 @@ export const [MutationUndoProvider, useMutationUndoContext] =
           return {
             id: entry.id,
             undo: (callbacks) => runUndo(entry, callbacks),
+            dispose: () => {
+              setUndoStack((prev) => prev.filter((e) => e !== entry));
+              setRedoStack((prev) => prev.filter((e) => e !== entry));
+            },
           };
         },
 
@@ -195,13 +203,23 @@ export function useUndoableMutation<
       variables: TVariables,
       context: TContext | undefined
     ) => UndoLifecycle | void;
+    /** When provided, each pushed undo entry is disposed (silently
+     *  removed from both stacks) when the group is disposed. */
+    hotkeyGroup?: HotkeyGroup;
   }
 ) {
   const { pushUndo } = useMutationUndoContext();
 
   return useMutation(() => {
-    const { undoFn, redoFn, undoLabel, onPushed, onSuccess, ...opts } =
-      options();
+    const {
+      undoFn,
+      redoFn,
+      undoLabel,
+      onPushed,
+      hotkeyGroup,
+      onSuccess,
+      ...opts
+    } = options();
     return {
       ...opts,
       onSuccess: (data, variables, context, mutation) => {
@@ -214,6 +232,7 @@ export function useUndoableMutation<
             onUndone: () => lifecycleRef.current?.onUndone?.(),
             onRedone: () => lifecycleRef.current?.onRedone?.(),
           });
+          hotkeyGroup?.addDisposer(handle.dispose);
           lifecycleRef.current =
             onPushed?.(handle, variables, context) ?? undefined;
         }


### PR DESCRIPTION
`useUndoableMutation` now accepts a hotkey group; pushed undo entries are silently dropped from the stack when the group is disposed. Wired through `makeMarkDoneAction` so navigating away from the inbox view clears its pending mark-done undos instead of leaking them into `cmd+z` on the next view.
