### PR TITLE
fix(search): selected-first sort + empty-selection + focus restore for In/From filters

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/searchable-multi-select.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/searchable-multi-select.tsx
@@ -139,7 +139,7 @@ export const SearchableMultiSelect = (props: SearchableMultiSelectProps) => {
     selectedIds: props.activeIds,
     searchQuery,
     getId: getOptionId,
-    resortDeps: [isOpen],
+    sortDeps: [isOpen],
   });
 
   const handleChange = (selected: SearchableOption[]) => {

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/searchable-multi-select.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/searchable-multi-select.tsx
@@ -6,12 +6,12 @@ import {
   createMemo,
   createSignal,
   type JSX,
-  on,
   Show,
 } from 'solid-js';
 import { Virtualizer, type VirtualizerHandle } from 'virtua/solid';
 import CheckIcon from '@icon/regular/check.svg';
 import SearchIcon from '@icon/regular/magnifying-glass.svg';
+import { useSelectedFirst } from '@core/util/useSelectedFirst';
 import type { SearchableOption } from './search-filter-controls';
 
 const ITEM_HEIGHT = 36;
@@ -120,35 +120,7 @@ const useActiveOptions = (
     return options().filter((opt) => set.has(opt.id));
   });
 
-/**
- * Returns options with currently-selected items sorted to the top. The sort
- * is recomputed only when the listed deps change (typically: options,
- * searchQuery, and a "menu opened" trigger). It deliberately does NOT track
- * `activeIds` so toggling selection inside an open menu doesn't shuffle the
- * list out from under the user — same pattern as the task assignee menu.
- */
-const useSortedOptions = (
-  options: Accessor<SearchableOption[]>,
-  activeIds: Accessor<string[]>,
-  searchQuery: Accessor<string>,
-  resortDeps: Accessor<unknown>[]
-) =>
-  createMemo(
-    on([options, searchQuery, ...resortDeps], () => {
-      const opts = options();
-      if (searchQuery()) return opts;
-      const ids = activeIds();
-      if (ids.length === 0) return opts;
-      const idSet = new Set(ids);
-      const selected: SearchableOption[] = [];
-      const unselected: SearchableOption[] = [];
-      for (const opt of opts) {
-        if (idSet.has(opt.id)) selected.push(opt);
-        else unselected.push(opt);
-      }
-      return [...selected, ...unselected];
-    })
-  );
+const getOptionId = (opt: SearchableOption) => opt.id;
 
 export const SearchableMultiSelect = (props: SearchableMultiSelectProps) => {
   const [internalOpen, setInternalOpen] = createSignal(false);
@@ -162,12 +134,13 @@ export const SearchableMultiSelect = (props: SearchableMultiSelectProps) => {
 
   const activeOptions = useActiveOptions(props.options, props.activeIds);
   const hasMatches = useHasMatches(props.options, searchQuery);
-  const sortedOptions = useSortedOptions(
-    props.options,
-    props.activeIds,
+  const sortedOptions = useSelectedFirst({
+    items: props.options,
+    selectedIds: props.activeIds,
     searchQuery,
-    [isOpen]
-  );
+    getId: getOptionId,
+    resortDeps: [isOpen],
+  });
 
   const handleChange = (selected: SearchableOption[]) => {
     props.onChange(selected.map((o) => o.id));
@@ -265,12 +238,12 @@ export const SearchableMultiSelectInline = (
   // Inline variant is freshly mounted each time the parent submenu opens,
   // so we don't need an explicit "menu opened" trigger — the memo's first
   // run captures the current selection ordering.
-  const sortedOptions = useSortedOptions(
-    props.options,
-    props.activeIds,
+  const sortedOptions = useSelectedFirst({
+    items: props.options,
+    selectedIds: props.activeIds,
     searchQuery,
-    []
-  );
+    getId: getOptionId,
+  });
 
   const handleChange = (selected: SearchableOption[]) => {
     props.onChange(selected.map((o) => o.id));

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/searchable-multi-select.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/searchable-multi-select.tsx
@@ -6,6 +6,7 @@ import {
   createMemo,
   createSignal,
   type JSX,
+  on,
   Show,
 } from 'solid-js';
 import { Virtualizer, type VirtualizerHandle } from 'virtua/solid';
@@ -119,6 +120,36 @@ const useActiveOptions = (
     return options().filter((opt) => set.has(opt.id));
   });
 
+/**
+ * Returns options with currently-selected items sorted to the top. The sort
+ * is recomputed only when the listed deps change (typically: options,
+ * searchQuery, and a "menu opened" trigger). It deliberately does NOT track
+ * `activeIds` so toggling selection inside an open menu doesn't shuffle the
+ * list out from under the user — same pattern as the task assignee menu.
+ */
+const useSortedOptions = (
+  options: Accessor<SearchableOption[]>,
+  activeIds: Accessor<string[]>,
+  searchQuery: Accessor<string>,
+  resortDeps: Accessor<unknown>[]
+) =>
+  createMemo(
+    on([options, searchQuery, ...resortDeps], () => {
+      const opts = options();
+      if (searchQuery()) return opts;
+      const ids = activeIds();
+      if (ids.length === 0) return opts;
+      const idSet = new Set(ids);
+      const selected: SearchableOption[] = [];
+      const unselected: SearchableOption[] = [];
+      for (const opt of opts) {
+        if (idSet.has(opt.id)) selected.push(opt);
+        else unselected.push(opt);
+      }
+      return [...selected, ...unselected];
+    })
+  );
+
 export const SearchableMultiSelect = (props: SearchableMultiSelectProps) => {
   const [internalOpen, setInternalOpen] = createSignal(false);
   const [searchQuery, setSearchQuery] = createSignal('');
@@ -131,6 +162,12 @@ export const SearchableMultiSelect = (props: SearchableMultiSelectProps) => {
 
   const activeOptions = useActiveOptions(props.options, props.activeIds);
   const hasMatches = useHasMatches(props.options, searchQuery);
+  const sortedOptions = useSortedOptions(
+    props.options,
+    props.activeIds,
+    searchQuery,
+    [isOpen]
+  );
 
   const handleChange = (selected: SearchableOption[]) => {
     props.onChange(selected.map((o) => o.id));
@@ -147,7 +184,7 @@ export const SearchableMultiSelect = (props: SearchableMultiSelectProps) => {
       selectionBehavior="toggle"
       closeOnSelection={false}
       open={isOpen()}
-      options={props.options()}
+      options={sortedOptions()}
       value={activeOptions()}
       onChange={handleChange}
       onInputChange={setSearchQuery}
@@ -191,7 +228,7 @@ export const SearchableMultiSelect = (props: SearchableMultiSelectProps) => {
               }
             >
               <VirtualizedListbox
-                options={props.options()}
+                options={sortedOptions()}
                 class={props.listboxClass}
               />
             </Show>
@@ -225,6 +262,15 @@ export const SearchableMultiSelectInline = (
 
   const activeOptions = useActiveOptions(props.options, props.activeIds);
   const hasMatches = useHasMatches(props.options, searchQuery);
+  // Inline variant is freshly mounted each time the parent submenu opens,
+  // so we don't need an explicit "menu opened" trigger — the memo's first
+  // run captures the current selection ordering.
+  const sortedOptions = useSortedOptions(
+    props.options,
+    props.activeIds,
+    searchQuery,
+    []
+  );
 
   const handleChange = (selected: SearchableOption[]) => {
     props.onChange(selected.map((o) => o.id));
@@ -268,7 +314,7 @@ export const SearchableMultiSelectInline = (
       selectionBehavior="toggle"
       closeOnSelection={false}
       open
-      options={props.options()}
+      options={sortedOptions()}
       value={activeOptions()}
       onChange={handleChange}
       onInputChange={setSearchQuery}
@@ -297,7 +343,7 @@ export const SearchableMultiSelectInline = (
           }
         >
           <VirtualizedListbox
-            options={props.options()}
+            options={sortedOptions()}
             class={props.listboxClass}
           />
         </Show>

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/use-filter-refinements.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/use-filter-refinements.tsx
@@ -265,7 +265,16 @@ export function useFilterRefinements() {
       seenKeys.add(args.key);
       filters.push(
         getOrCreateChip(args.key, () => {
-          const [isPopupOpen, setPopupOpen] = createSignal(false);
+          const [isPopupOpen, _setPopupOpen] = createSignal(false);
+          // restores focus to the split panel on close
+          const setPopupOpen = (v: boolean) => {
+            if (!v) {
+              queueMicrotask(() =>
+                panel.panelRef()?.focus({ preventScroll: true })
+              );
+            }
+            _setPopupOpen(v);
+          };
           return {
             categoryLabel: args.categoryLabel,
             optionId: () => `${args.optionIdPrefix}:${args.getIds().join(',')}`,

--- a/js/app/packages/core/component/Properties/component/modal/shared/PropertyEntitySelector.tsx
+++ b/js/app/packages/core/component/Properties/component/modal/shared/PropertyEntitySelector.tsx
@@ -2,6 +2,7 @@ import { Entity, type EntityData } from '@entity';
 import { UserIcon } from '@core/component/UserIcon';
 import { useAugmentUserWithDmActivity } from '@core/user';
 import { createFreshSearch } from '@core/util/freshSort';
+import { useSelectedFirst } from '@core/util/useSelectedFirst';
 import SearchIcon from '@icon/regular/magnifying-glass.svg';
 import { createEmailsInfiniteQuery } from '@macro-entity';
 import type { EmailEntity } from '@entity';
@@ -13,7 +14,6 @@ import {
   createEffect,
   createMemo,
   createSignal,
-  on,
   onCleanup,
   onMount,
   Show,
@@ -274,50 +274,16 @@ export function PropertyEntitySelector(props: EntityInputProps) {
     return localResults;
   });
 
-  // Sort entities with selected items first when not searching
-  const sortedEntities = createMemo(
-    on([searchTerm, filteredEntities], () => {
-      const term = searchTerm();
-      const filteredResults = filteredEntities();
-
-      // When there's a search term, return results as-is
-      if (term) {
-        return filteredResults;
-      }
-
-      // When browsing (no search), show selected entities first, then others
-      // (self is already sorted to top within filteredEntities)
-      const selectedIds = props.selectedOptions();
-      const entityIdsInResults = new Set(filteredResults.map((e) => e.id));
-
-      // Partition filtered results into selected and unselected
-      const selected: CombinedEntity[] = [];
-      const unselected: CombinedEntity[] = [];
-
-      for (const entity of filteredResults) {
-        if (selectedIds.has(entity.id)) {
-          selected.push(entity);
-        } else {
-          unselected.push(entity);
-        }
-      }
-
-      // Add missing selected entities that aren't in the visible results
-      const allAvailableEntities = entities();
-      for (const selectedId of selectedIds) {
-        if (!entityIdsInResults.has(selectedId)) {
-          const actualEntity = allAvailableEntities.find(
-            (e) => e.id === selectedId
-          );
-          if (actualEntity) {
-            selected.push(actualEntity);
-          }
-        }
-      }
-
-      return [...selected, ...unselected];
-    })
-  );
+  // Sort entities with selected items first when not searching. Self is
+  // already pinned to the top within `filteredEntities`; this layers
+  // selected-first on top of that ordering.
+  const sortedEntities = useSelectedFirst({
+    items: filteredEntities,
+    allItems: entities,
+    selectedIds: props.selectedOptions,
+    searchQuery: searchTerm,
+    getId: (e: CombinedEntity) => e.id,
+  });
 
   const toggleEntity = (entity: CombinedEntity) => {
     const newSelected = new Set(props.selectedOptions());

--- a/js/app/packages/core/util/useSelectedFirst.ts
+++ b/js/app/packages/core/util/useSelectedFirst.ts
@@ -1,0 +1,67 @@
+import { type Accessor, createMemo, on } from 'solid-js';
+
+type UseSelectedFirstOptions<T> = {
+  /** Items currently visible (after search/filter). */
+  items: Accessor<T[]>;
+  /** Currently-selected ids. Read non-reactively — see `resortDeps`. */
+  selectedIds: Accessor<Iterable<string>>;
+  /** Active search/filter query. When non-empty, items are returned as-is. */
+  searchQuery: Accessor<string>;
+  /** Extracts a stable id from an item. */
+  getId: (item: T) => string;
+  /**
+   * Optional pool of all available items. When `items` is sliced (e.g. top N
+   * by recency), selected ids missing from `items` are looked up here so the
+   * user can still see and toggle them off.
+   */
+  allItems?: Accessor<T[]>;
+  /**
+   * Reactive deps that, when changed, recompute the partition. The memo
+   * deliberately does NOT track `selectedIds`, so toggling selection inside
+   * an open menu doesn't shuffle items underneath the user. Pass an "is
+   * open" accessor to re-sort each time the menu reopens.
+   */
+  resortDeps?: Accessor<unknown>[];
+};
+
+/**
+ * Returns `items` with currently-selected entries pinned to the top. Used by
+ * the task assignee menu and the In/From search filter menus: stable order
+ * during a single open session, re-sorted on (re)open.
+ */
+export function useSelectedFirst<T>(
+  opts: UseSelectedFirstOptions<T>
+): Accessor<T[]> {
+  return createMemo(
+    on([opts.items, opts.searchQuery, ...(opts.resortDeps ?? [])], () => {
+      const items = opts.items();
+      if (opts.searchQuery()) return items;
+
+      const idSet = new Set<string>();
+      for (const id of opts.selectedIds()) idSet.add(id);
+      if (idSet.size === 0) return items;
+
+      const selected: T[] = [];
+      const unselected: T[] = [];
+      const visibleIds = new Set<string>();
+
+      for (const item of items) {
+        const id = opts.getId(item);
+        visibleIds.add(id);
+        if (idSet.has(id)) selected.push(item);
+        else unselected.push(item);
+      }
+
+      const all = opts.allItems?.();
+      if (all) {
+        for (const id of idSet) {
+          if (visibleIds.has(id)) continue;
+          const found = all.find((it) => opts.getId(it) === id);
+          if (found) selected.push(found);
+        }
+      }
+
+      return [...selected, ...unselected];
+    })
+  );
+}

--- a/js/app/packages/core/util/useSelectedFirst.ts
+++ b/js/app/packages/core/util/useSelectedFirst.ts
@@ -21,7 +21,7 @@ type UseSelectedFirstOptions<T> = {
    * an open menu doesn't shuffle items underneath the user. Pass an "is
    * open" accessor to re-sort each time the menu reopens.
    */
-  resortDeps?: Accessor<unknown>[];
+  sortDeps?: Accessor<unknown>[];
 };
 
 /**
@@ -33,7 +33,7 @@ export function useSelectedFirst<T>(
   opts: UseSelectedFirstOptions<T>
 ): Accessor<T[]> {
   return createMemo(
-    on([opts.items, opts.searchQuery, ...(opts.resortDeps ?? [])], () => {
+    on([opts.items, opts.searchQuery, ...(opts.sortDeps ?? [])], () => {
       const items = opts.items();
       if (opts.searchQuery()) return items;
 


### PR DESCRIPTION
Match the In/From search filter menus to the task assignee menu: selected items pin to the top on (re)open, empty selection is allowed without the menu closing, and closing the popup with no selection restores focus to the split so j/k keep working. Sort logic extracted to a shared `useSelectedFirst` hook used by both menus.
