### PR TITLE
fix: sfs logging bucket ACL depends on ownership controls

### DIFF
--- a/infra/stacks/static-file-service/distribution.ts
+++ b/infra/stacks/static-file-service/distribution.ts
@@ -116,7 +116,7 @@ export class StaticFileCloudFront extends pulumi.ComponentResource {
       { parent: this }
     );
 
-    new aws.s3.BucketOwnershipControls(
+    const logBucketOwnership = new aws.s3.BucketOwnershipControls(
       `${name}-cf-logs-ownership`,
       {
         bucket: logBucket.id,
@@ -139,7 +139,6 @@ export class StaticFileCloudFront extends pulumi.ComponentResource {
           },
           grants: [
             {
-              // Grant the awslogsdelivery account FULL_CONTROL for CloudFront standard logging
               grantee: {
                 id: 'c4c1ede66af53448b93c283ce9448c4ba468c9432aa01d700d3878632f77d2d0',
                 type: 'CanonicalUser',
@@ -149,7 +148,7 @@ export class StaticFileCloudFront extends pulumi.ComponentResource {
           ],
         },
       },
-      { parent: this }
+      { parent: this, dependsOn: [logBucketOwnership] }
     );
 
     new aws.s3.BucketLifecycleConfigurationV2(


### PR DESCRIPTION
## Summary
- Add `dependsOn: [logBucketOwnership]` to the `BucketAclV2` resource so it waits for `BucketOwnershipControls` to propagate before setting the ACL
- Fixes prod deploy failure: `AccessControlListNotSupported: The bucket does not allow ACLs`

## Context
The SFS monitoring PR (#3007) added a CloudFront access log bucket with ACLs for log delivery. Pulumi created the `BucketOwnershipControls` and `BucketAclV2` in parallel, but the ACL requires ownership controls to be applied first. Dev worked by luck; prod hit the race condition.

## Test plan
- [ ] Pulumi preview shows no diff on dev (already deployed)
- [ ] Prod deploy succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)