### PR TITLE
fix(channel): trim edge @mentions from task title when creating from message

### DIFF
--- a/js/app/packages/channel/Channel/Channel.tsx
+++ b/js/app/packages/channel/Channel/Channel.tsx
@@ -49,7 +49,10 @@ import { useSplitLayout } from '@app/component/split-layout/layout';
 import { openChatWithInput } from '@app/component/ChatWithAgentButton';
 import { useChannelName, useChannelActivity } from '@core/context/channels';
 import { buildMentionMarkdownString, markdownToPlainText } from '@lexical-core';
-import { extractUserMentions } from '@core/util/taskExtraction';
+import {
+  extractUserMentions,
+  trimEdgeUserMentions,
+} from '@core/util/taskExtraction';
 import { createActivityTracker } from '@channel/activity-tracker';
 import {
   invalidateChannelsActivity,
@@ -245,7 +248,8 @@ export function Channel(props: ChannelProps) {
       messageEditor.start(message);
     },
     onCreateTask: (ctx) => {
-      const plainText = markdownToPlainText(ctx.message.content).trim();
+      const trimmedMarkdown = trimEdgeUserMentions(ctx.message.content);
+      const plainText = markdownToPlainText(trimmedMarkdown).trim();
       const title =
         plainText.length > 70 ? `${plainText.slice(0, 70)}...` : plainText;
       const mentionedUserIds = extractUserMentions(ctx.message.content);

--- a/js/app/packages/core/util/taskExtraction.test.ts
+++ b/js/app/packages/core/util/taskExtraction.test.ts
@@ -21,7 +21,10 @@ vi.mock('@core/component/LexicalMarkdown/utils', () => ({
   $elementNodeToMarkdown: vi.fn(),
 }));
 
-import { extractCheckboxesFromMarkdown } from './taskExtraction';
+import {
+  extractCheckboxesFromMarkdown,
+  trimEdgeUserMentions,
+} from './taskExtraction';
 
 describe('extractCheckboxesFromMarkdown', () => {
   it('should extract single unchecked checkbox', () => {
@@ -200,5 +203,61 @@ Some notes below.
 
     expect(result).toHaveLength(1);
     expect(result[0].rawLine).toBe('  - [ ] Indented with spaces');
+  });
+});
+
+describe('trimEdgeUserMentions', () => {
+  const aliceMention =
+    '<m-user-mention>{"userId":"u1","email":"alice@test.com"}</m-user-mention>';
+  const bobMention =
+    '<m-user-mention>{"userId":"u2","email":"bob@test.com"}</m-user-mention>';
+
+  it('trims a leading user mention', () => {
+    expect(trimEdgeUserMentions(`${aliceMention} fix the search bug`)).toBe(
+      'fix the search bug'
+    );
+  });
+
+  it('trims a trailing user mention', () => {
+    expect(trimEdgeUserMentions(`fix the search bug ${aliceMention}`)).toBe(
+      'fix the search bug'
+    );
+  });
+
+  it('trims mentions on both ends', () => {
+    expect(
+      trimEdgeUserMentions(`${aliceMention} fix the search bug ${bobMention}`)
+    ).toBe('fix the search bug');
+  });
+
+  it('trims multiple consecutive mentions at edges', () => {
+    expect(
+      trimEdgeUserMentions(
+        `${aliceMention} ${bobMention} fix the search bug ${aliceMention} ${bobMention}`
+      )
+    ).toBe('fix the search bug');
+  });
+
+  it('preserves mentions in the middle', () => {
+    const input = `${aliceMention} ping ${bobMention} about the bug`;
+    expect(trimEdgeUserMentions(input)).toBe(
+      `ping ${bobMention} about the bug`
+    );
+  });
+
+  it('returns empty string when content is only mentions', () => {
+    expect(trimEdgeUserMentions(`${aliceMention} ${bobMention}`)).toBe('');
+  });
+
+  it('handles surrounding whitespace', () => {
+    expect(
+      trimEdgeUserMentions(`  ${aliceMention}   fix the bug   ${bobMention}  `)
+    ).toBe('fix the bug');
+  });
+
+  it('leaves text without edge mentions unchanged', () => {
+    expect(trimEdgeUserMentions('fix the search bug')).toBe(
+      'fix the search bug'
+    );
   });
 });

--- a/js/app/packages/core/util/taskExtraction.ts
+++ b/js/app/packages/core/util/taskExtraction.ts
@@ -35,6 +35,28 @@ export type PotentialTask = {
 // Captures: (1) leading whitespace, (2) check state, (3) content after checkbox
 const CHECKBOX_LINE_PATTERN = /^(\s*)-\s*\[([ xX])\]\s*(.*)$/;
 
+const LEADING_USER_MENTION_PATTERN =
+  /^<m-user-mention>[^<]*<\/m-user-mention>\s*/;
+const TRAILING_USER_MENTION_PATTERN =
+  /\s*<m-user-mention>[^<]*<\/m-user-mention>$/;
+
+/**
+ * Trim user @mention tags from the start and end of a markdown string.
+ * Mentions in the middle are preserved.
+ */
+export function trimEdgeUserMentions(markdown: string): string {
+  let result = markdown.trim();
+  let prev: string;
+  do {
+    prev = result;
+    result = result
+      .replace(LEADING_USER_MENTION_PATTERN, '')
+      .replace(TRAILING_USER_MENTION_PATTERN, '')
+      .trim();
+  } while (result !== prev);
+  return result;
+}
+
 /**
  * Extract all checkbox items from a markdown string as potential tasks.
  *


### PR DESCRIPTION
When creating a task from a channel message, strip leading/trailing `@mention` tags from the generated title so it reads cleanly. Mentions in the middle remain as text and all mentioned users are still added as assignees.
