### PR TITLE
feat(fe): Track google conversions

### DIFF
--- a/js/app/packages/app/component/interactive-onboarding/InteractiveOnboarding.tsx
+++ b/js/app/packages/app/component/interactive-onboarding/InteractiveOnboarding.tsx
@@ -43,6 +43,9 @@ export default function InteractiveOnboarding() {
   const [mobileWebStep, setMobileWebStep] = createSignal<
     'welcome' | 'signup-sent'
   >('welcome');
+  const [submittedEmail, setSubmittedEmail] = createSignal<string | undefined>(
+    undefined
+  );
   const sendMobileWelcomeEmail = useSendMobileWelcomeEmail();
 
   // Mobile web users who aren't authenticated get a dedicated welcome screen
@@ -59,6 +62,7 @@ export default function InteractiveOnboarding() {
 
     if (isOk(result)) {
       if (result[1].sent) {
+        setSubmittedEmail(email);
         setMobileWebStep('signup-sent');
       } else {
         toast.alert('Email already sent.');
@@ -81,7 +85,7 @@ export default function InteractiveOnboarding() {
       fallback={
         <Show
           when={mobileWebStep() === 'welcome'}
-          fallback={<MobileWebSignupSent />}
+          fallback={<MobileWebSignupSent email={submittedEmail()} />}
         >
           <MobileWebWelcome onSignUp={handleMobileSignUp} />
         </Show>

--- a/js/app/packages/app/component/interactive-onboarding/MobileWebSignupSent.tsx
+++ b/js/app/packages/app/component/interactive-onboarding/MobileWebSignupSent.tsx
@@ -5,7 +5,12 @@ import { useAnalytics } from '@app/component/analytics-context';
 import { getWebOrigin } from '@core/util/webOrigin';
 import { MOBILE_WEB_SIGNUP_LEAD_VALUE } from '@app/lib/analytics/leadValues';
 
-export default function MobileWebSignupSent() {
+type Props = {
+  /** Email submitted on the prior step — used as the Google conversion `transaction_id` for dedup. */
+  email?: string;
+};
+
+export default function MobileWebSignupSent(props: Props) {
   const analytics = useAnalytics();
 
   onMount(() => {
@@ -20,6 +25,11 @@ export default function MobileWebSignupSent() {
     };
     analytics.trackMeta('Lead', leadPayload);
     analytics.trackMeta('CompleteRegistration', leadPayload);
+    analytics.trackGoogleConversion('mobile_web_lead', {
+      value: MOBILE_WEB_SIGNUP_LEAD_VALUE,
+      currency: 'USD',
+      transaction_id: props.email,
+    });
   });
 
   return (

--- a/js/app/packages/app/component/interactive-onboarding/lessons/launch.tsx
+++ b/js/app/packages/app/component/interactive-onboarding/lessons/launch.tsx
@@ -3,6 +3,7 @@ import { useSearchParams } from '@solidjs/router';
 import AppStoreQr from '@macro-icons/app-store.svg';
 import type { LessonContentProps, LessonDefinition } from '../types';
 import { useAnalytics } from '@app/component/analytics-context';
+import { useUserId } from '@core/context/user';
 import { ENABLE_APP_STORE_QR_CODE } from '@core/constant/featureFlags';
 import {
   SIGNUP_LEAD_VALUE_BY_TIER,
@@ -12,17 +13,24 @@ import {
 function LaunchContent(props: LessonContentProps) {
   const analytics = useAnalytics();
   const [searchParams] = useSearchParams();
+  const userId = useUserId();
 
   onMount(() => {
     // `type` is set on the Stripe success redirect (see choose-plan.tsx). Free
     // users skip Stripe entirely so the param is absent — default to 'free'.
     const rawTier = searchParams.type;
     const tier = (Array.isArray(rawTier) ? rawTier[0] : rawTier) ?? 'free';
+    const value = SIGNUP_LEAD_VALUE_BY_TIER[tier] ?? SIGNUP_LEAD_VALUE_DEFAULT;
     analytics.trackMeta('CompleteRegistration', {
       content_name: 'onboarding_launch',
       content_category: tier,
-      value: SIGNUP_LEAD_VALUE_BY_TIER[tier] ?? SIGNUP_LEAD_VALUE_DEFAULT,
+      value,
       currency: 'USD',
+    });
+    analytics.trackGoogleConversion('signup', {
+      value,
+      currency: 'USD',
+      transaction_id: userId(),
     });
     setTimeout(() => props.onComplete('Launch'));
   });

--- a/js/app/packages/app/lib/analytics/analytics.ts
+++ b/js/app/packages/app/lib/analytics/analytics.ts
@@ -1,5 +1,9 @@
 import type { AppEvents, AppEventNames } from '@app/lib/analytics/app-events';
 import {
+  type GoogleConversionAction,
+  googleConversionSendTo,
+} from '@app/lib/analytics/googleConversions';
+import {
   initializeGoogleAnalytics,
   initializeMetaPixel,
 } from '@app/lib/analytics/providers';
@@ -215,6 +219,35 @@ export const createAnalytics = () => {
     sendEvent('meta-pixel', event, data);
   };
 
+  /**
+   * Fires a Google Ads conversion via `gtag('event', 'conversion', ...)`.
+   * `action` is typed to `GoogleConversionAction`, resolved to its `AW-{id}/{label}`
+   * `send_to` via `googleConversionSendTo`.
+   *
+   * Pass `transaction_id` whenever possible — Google dedupes server-side on it,
+   * which matters here because both call sites fire from `onMount` and a refresh
+   * re-fires. A user id (post-signup) or the submitted email (mobile lead capture)
+   * are both fine.
+   *
+   * Per-action `value` lets a single campaign optimize across multiple primaries
+   * (Smart Bidding sums values across the goal). See `googleConversions.ts`.
+   */
+  const trackGoogleConversion = (
+    action: GoogleConversionAction,
+    data?: { value?: number; currency?: string; transaction_id?: string }
+  ) => {
+    if (disabled) return;
+
+    try {
+      gtag('event', 'conversion', {
+        send_to: googleConversionSendTo(action),
+        ...data,
+      });
+    } catch (e) {
+      console.error('[Analytics] Failed to send Google Ads conversion:', e);
+    }
+  };
+
   const identify = (userID: string, info: Partial<UserIdentifyInfo>) => {
     if (disabled) return;
 
@@ -288,6 +321,7 @@ export const createAnalytics = () => {
     initializeProviders,
     track,
     trackMeta,
+    trackGoogleConversion,
     identify,
     reset,
     pageView,
@@ -298,6 +332,10 @@ export type AnalyticsInterface = {
   posthog: PostHog;
   track: TrackFn;
   trackMeta: (event: MetaStandardEvent, data?: Record<string, unknown>) => void;
+  trackGoogleConversion: (
+    action: GoogleConversionAction,
+    data?: { value?: number; currency?: string; transaction_id?: string }
+  ) => void;
   identify: (userID: string, info: Partial<UserIdentifyInfo>) => void;
   reset: () => void;
   pageView: (pageTitle: string, opts?: PageViewOptions) => void;

--- a/js/app/packages/app/lib/analytics/googleConversions.ts
+++ b/js/app/packages/app/lib/analytics/googleConversions.ts
@@ -1,0 +1,36 @@
+/**
+ * Google Ads Conversion Action labels, keyed by semantic name.
+ *
+ * Unlike Meta — which has a fixed standard-event taxonomy — each Google Ads
+ * conversion is its own configured action in the Ads UI with its own
+ * `AW-{id}/{label}` send-target. Group these into a single Conversion Goal
+ * with all actions marked Primary so a campaign optimizes against the sum of
+ * their values.
+ *
+ * Volume balance matters: Smart Bidding sums values across primaries, so a
+ * high-frequency low-value action will dominate a low-frequency high-value
+ * one unless the per-fire `value` is tuned to compensate. Lead values are
+ * shared with `leadValues.ts` for now; rebalance there.
+ */
+
+/** Google Ads account ID (the `AW-...` prefix). */
+const GOOGLE_ADS_ID = 'AW-11035820781';
+
+/**
+ * Per-action conversion labels from the Ads UI.
+ *
+ * To add an action: create the Conversion Action in Google Ads (Category:
+ * Sign-up / Submit lead form / Purchase as appropriate, Count: One, Value:
+ * "Use different values"), then paste its label here.
+ */
+export const GOOGLE_CONVERSION_LABELS = {
+  /** Mobile web email capture — user submitted email to receive desktop link. */
+  mobile_web_lead: 'lCHSCIntvaccEO2FpY4p',
+  /** Onboarding completed (post-Stripe for paid tiers, direct for free). */
+  signup: 'Gk2rCI7svaccEO2FpY4p',
+} as const;
+
+export type GoogleConversionAction = keyof typeof GOOGLE_CONVERSION_LABELS;
+
+export const googleConversionSendTo = (action: GoogleConversionAction) =>
+  `${GOOGLE_ADS_ID}/${GOOGLE_CONVERSION_LABELS[action]}`;

--- a/js/app/packages/app/lib/analytics/googleConversions.ts
+++ b/js/app/packages/app/lib/analytics/googleConversions.ts
@@ -14,7 +14,7 @@
  */
 
 /** Google Ads account ID (the `AW-...` prefix). */
-const GOOGLE_ADS_ID = 'AW-11035820781';
+export const GOOGLE_ADS_ID = 'AW-11035820781';
 
 /**
  * Per-action conversion labels from the Ads UI.

--- a/js/app/packages/app/lib/analytics/providers.ts
+++ b/js/app/packages/app/lib/analytics/providers.ts
@@ -1,5 +1,9 @@
 export const initializeGoogleAnalytics = () => {
   const G_ID = 'G-52HPEL3FTV';
+  // Registering the AW account on page load is what lets gtag pick up
+  // ?gclid=… from the URL into the _gcl_aw cookie, so subsequent
+  // gtag('event', 'conversion', ...) fires can be attributed to the ad click.
+  const AW_ID = 'AW-11035820781';
 
   // Google Analytics
   const gaScript = document.createElement('script');
@@ -13,6 +17,7 @@ export const initializeGoogleAnalytics = () => {
     function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
     gtag('config', '${G_ID}', { send_page_view: false });
+    gtag('config', '${AW_ID}');
   `;
   document.head.appendChild(gaInit);
 

--- a/js/app/packages/app/lib/analytics/providers.ts
+++ b/js/app/packages/app/lib/analytics/providers.ts
@@ -1,9 +1,7 @@
+import { GOOGLE_ADS_ID } from '@app/lib/analytics/googleConversions';
+
 export const initializeGoogleAnalytics = () => {
   const G_ID = 'G-52HPEL3FTV';
-  // Registering the AW account on page load is what lets gtag pick up
-  // ?gclid=… from the URL into the _gcl_aw cookie, so subsequent
-  // gtag('event', 'conversion', ...) fires can be attributed to the ad click.
-  const AW_ID = 'AW-11035820781';
 
   // Google Analytics
   const gaScript = document.createElement('script');
@@ -11,13 +9,16 @@ export const initializeGoogleAnalytics = () => {
   gaScript.async = true;
   document.head.appendChild(gaScript);
 
+  // Registering the AW account on page load is what lets gtag pick up
+  // ?gclid=… from the URL into the _gcl_aw cookie, so subsequent
+  // gtag('event', 'conversion', ...) fires can be attributed to the ad click.
   const gaInit = document.createElement('script');
   gaInit.innerHTML = `
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
     gtag('config', '${G_ID}', { send_page_view: false });
-    gtag('config', '${AW_ID}');
+    gtag('config', '${GOOGLE_ADS_ID}');
   `;
   document.head.appendChild(gaInit);
 


### PR DESCRIPTION
## Summary

Adds Google Ads conversion tracking on the FE alongside the existing Meta Pixel events. Each tracked action is its own Conversion Action in Google Ads, so a single campaign can optimize against the sum of values across multiple primaries (unlike Meta, where everything had to overload a single standard event).

Two events fire today:
- **`mobile_web_lead`** — fired on `MobileWebSignupSent` next to the existing Meta `Lead` / `CompleteRegistration` fires. The submitted email is threaded down as a prop and used as `transaction_id` so refreshes don't double-count.
- **`signup`** — fired on the onboarding launch lesson next to the existing Meta `CompleteRegistration` fire, with the post-signup `userId()` as `transaction_id`. Per-tier value comes from `SIGNUP_LEAD_VALUE_BY_TIER` (shared with the Meta path).

Conversion IDs and labels live in `googleConversions.ts` keyed by semantic action name. To add a new event later, create the Conversion Action in Ads, add a label entry, and call `analytics.trackGoogleConversion(...)`.

## Notes

- `providers.ts` now registers `AW-11035820781` alongside the GA4 ID. This is what lets gtag pick up `?gclid=` from the URL into the `_gcl_aw` cookie — without it, conversion fires would land but not attribute to the ad click.
- Server-side conversion tracking (cal.com webhook → Google Ads API) is not in this PR. Will follow separately and feed into the same Conversion Goal.
