### PR TITLE
Apply custom scrollbar to channel compose and slim global scrollbar

### DIFF
--- a/js/app/packages/app/index.css
+++ b/js/app/packages/app/index.css
@@ -414,6 +414,11 @@
   }
 }
 
+@utility custom-scrollbar {
+  scrollbar-width: thin;
+  scrollbar-color: oklch(from var(--color-edge) l c h / 0.5) transparent;
+}
+
 :root {
   --viewport-padding: 16px;
   --keyboard-height: 0px;
@@ -762,9 +767,9 @@ html[data-modality="keyboard"] [contenteditable="true"]:focus-visible::after {
 }
 
 ::-webkit-scrollbar {
-    height: 8px;
+    height: 6px;
     /* Thickness of horizontal scrollbar */
-    width: 8px;
+    width: 6px;
     /* Thickness of vertical scrollbar */
     overflow: auto;
 }

--- a/js/app/packages/block-channel/component/Compose.tsx
+++ b/js/app/packages/block-channel/component/Compose.tsx
@@ -220,7 +220,7 @@ export function ChannelCompose() {
         <div class="h-full items-center flex" p-1></div>
       </SplitToolbarLeft>
       <div class="relative flex flex-col w-full h-full panel">
-        <div class="pt-2 h-full grow w-full overflow-y-auto @min-[40rem]:px-4">
+        <div class="pt-2 h-full grow w-full overflow-y-auto custom-scrollbar @min-[40rem]:px-4">
           <div class="macro-message-width macro-message-padding mx-auto pb-1 h-full">
             <input
               type="text"


### PR DESCRIPTION
### Motivation
- Channels were not using the shared custom scrollbar used elsewhere (email, markdown, tasks), causing inconsistent UI; also wanted a slightly thinner scrollbar for a sleeker look.

### Description
- Add a reusable `@utility custom-scrollbar` in `js/app/packages/app/index.css` which sets `scrollbar-width: thin` and a themed `scrollbar-color`.
- Reduce the global WebKit scrollbar thickness from `8px` to `6px` by updating the `::-webkit-scrollbar` rules in `js/app/packages/app/index.css`.
- Apply the `custom-scrollbar` utility to the main scrollable container in Channel Compose by updating `js/app/packages/block-channel/component/Compose.tsx` to include the `custom-scrollbar` class.

### Testing
- Ran `bun run check` in `js/app`, which failed due to missing ambient type definition packages (`@types/facebook-pixel`, `@types/gtag.js`, `vite-plugin-solid-svg/*`, `vite/client`, `wicg-file-system-access`); this failure is unrelated to the CSS/markup changes introduced here and prevents a clean type-check in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8c747d04483248435343930fd5efd)