### PR TITLE
Apply custom scrollbar to channel surfaces and reduce scrollbar thickness

### DIFF
--- a/js/app/packages/app/index.css
+++ b/js/app/packages/app/index.css
@@ -414,6 +414,10 @@
   }
 }
 
+@utility custom-scrollbar {
+  scrollbar-width: thin;
+}
+
 :root {
   --viewport-padding: 16px;
   --keyboard-height: 0px;
@@ -762,9 +766,9 @@ html[data-modality="keyboard"] [contenteditable="true"]:focus-visible::after {
 }
 
 ::-webkit-scrollbar {
-    height: 8px;
+    height: 6px;
     /* Thickness of horizontal scrollbar */
-    width: 8px;
+    width: 6px;
     /* Thickness of vertical scrollbar */
     overflow: auto;
 }

--- a/js/app/packages/block-channel/component/Compose.tsx
+++ b/js/app/packages/block-channel/component/Compose.tsx
@@ -220,7 +220,7 @@ export function ChannelCompose() {
         <div class="h-full items-center flex" p-1></div>
       </SplitToolbarLeft>
       <div class="relative flex flex-col w-full h-full panel">
-        <div class="pt-2 h-full grow w-full overflow-y-auto @min-[40rem]:px-4">
+        <div class="pt-2 h-full grow w-full overflow-y-auto custom-scrollbar @min-[40rem]:px-4">
           <div class="macro-message-width macro-message-padding mx-auto pb-1 h-full">
             <input
               type="text"

--- a/js/app/packages/channel/Message/EmojiReactionPopover.tsx
+++ b/js/app/packages/channel/Message/EmojiReactionPopover.tsx
@@ -66,7 +66,7 @@ export function EmojiReactionPopover(props: EmojiReactionPopoverProps) {
                   />
                 </div>
               </div>
-              <div class="grow overflow-y-auto overflow-x-hidden mt-2">
+              <div class="grow overflow-y-auto overflow-x-hidden custom-scrollbar mt-2">
                 <EmojiSelector
                   nameFilter={query()}
                   onEmojiClick={(emoji) => {


### PR DESCRIPTION
### Motivation
- Channel surfaces were not using the projects visible custom scrollbar while other blocks (email, markdown, tasks) do, causing inconsistent UX.
- The scrollbar visual appeared thicker than desired, so make the custom scrollbar thinner to match the overall design.

### Description
- Added a `custom-scrollbar` utility with `scrollbar-width: thin` to `js/app/packages/app/index.css` to allow opt-in visible scrollbars.
- Reduced the global WebKit scrollbar thickness from `8px` to `6px` in `js/app/packages/app/index.css` for both horizontal and vertical tracks.
- Applied `custom-scrollbar` to the channel compose scroll container in `js/app/packages/block-channel/component/Compose.tsx` so the channel compose area uses the visible scrollbar.
- Applied `custom-scrollbar` to the emoji reaction popover list in `js/app/packages/channel/Message/EmojiReactionPopover.tsx` so channel popovers match other blocks.

### Testing
- Ran `bun run check`, which failed in this environment due to missing type definition packages listed by `tsc` (e.g. `@types/facebook-pixel`, `@types/gtag.js`, `vite/client`, `vite-plugin-solid-svg` types, `wicg-file-system-access`), and those failures are unrelated to the CSS/markup changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8c747d04483248435343930fd5efd)