### PR TITLE
fix(search): move search bar into header and drop view title

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/soup-filters-bar.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/soup-filters-bar.tsx
@@ -79,7 +79,9 @@ export const SoupFiltersBar = () => {
             isOptionActive={isOptionActive}
           />
           <div class="flex-1" />
-          <Tooltip tooltip={<LabelAndHotKey label="Preview" shortcut="space" />}>
+          <Tooltip
+            tooltip={<LabelAndHotKey label="Preview" shortcut="space" />}
+          >
             <Button
               variant={soup.previewEntity() ? 'primary' : 'ghost'}
               size="sm"

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/soup-filters-bar.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/soup-filters-bar.tsx
@@ -1,5 +1,4 @@
 import { SoupViewContextSort } from '@app/component/next-soup/soup-view/filters-bar/soup-view-context-sort';
-import { SoupSearchbar } from '@app/component/next-soup/soup-view/filters-bar/soup-view-search-bar';
 import { useFilterRefinements } from '@app/component/next-soup/soup-view/filters-bar/use-filter-refinements';
 import { useSplitPanelOrThrow } from '@app/component/split-layout/layoutUtils';
 import type { ListView } from '@app/constants/list-views';
@@ -14,11 +13,7 @@ import { useSoup } from '../../soup-context';
 import { registerHotkey } from '@core/hotkey/hotkeys';
 import { useAnalytics } from '@app/component/analytics-context';
 
-interface SoupFiltersBarProps {
-  initialSearchText?: string;
-}
-
-export const SoupFiltersBar = (props: SoupFiltersBarProps = {}) => {
+export const SoupFiltersBar = () => {
   const {
     resetToTabDefaults,
     activeFiltersList,
@@ -74,36 +69,28 @@ export const SoupFiltersBar = (props: SoupFiltersBarProps = {}) => {
   return (
     <Switch>
       <Match when={isComponentListView('search')}>
-        <div class="w-full flex flex-col gap-2 p-2 border-b border-edge-muted">
-          <SoupSearchbar
-            placeholder="Search, @mention contacts"
-            initialValue={props.initialSearchText}
+        <div class="flex items-start gap-2 p-2 border-b border-edge-muted w-full">
+          <UnifiedFilterDropdown />
+          <ActiveFilterChips
+            filters={activeFiltersList()}
+            onRemove={removeFilter}
+            onReplace={replaceFilter}
+            onClearAll={resetToTabDefaults}
+            isOptionActive={isOptionActive}
           />
-          <div class="flex items-start gap-2">
-            <UnifiedFilterDropdown />
-            <ActiveFilterChips
-              filters={activeFiltersList()}
-              onRemove={removeFilter}
-              onReplace={replaceFilter}
-              onClearAll={resetToTabDefaults}
-              isOptionActive={isOptionActive}
-            />
-            <div class="flex-1" />
-            <Tooltip
-              tooltip={<LabelAndHotKey label="Preview" shortcut="space" />}
+          <div class="flex-1" />
+          <Tooltip tooltip={<LabelAndHotKey label="Preview" shortcut="space" />}>
+            <Button
+              variant={soup.previewEntity() ? 'primary' : 'ghost'}
+              size="sm"
+              class="rounded-xs [&_svg]:size-4 px-1 border border-transparent"
+              onClick={togglePreview}
+              onMouseEnter={() => setPreviewBtnHovering(true)}
+              onMouseLeave={() => setPreviewBtnHovering(false)}
             >
-              <Button
-                variant={soup.previewEntity() ? 'primary' : 'ghost'}
-                size="sm"
-                class="rounded-xs [&_svg]:size-4 px-1 border border-transparent"
-                onClick={togglePreview}
-                onMouseEnter={() => setPreviewBtnHovering(true)}
-                onMouseLeave={() => setPreviewBtnHovering(false)}
-              >
-                <AnimatedPreviewIcon triggerAnimation={previewBtnHovering()} />
-              </Button>
-            </Tooltip>
-          </div>
+              <AnimatedPreviewIcon triggerAnimation={previewBtnHovering()} />
+            </Button>
+          </Tooltip>
         </div>
       </Match>
       <Match when={true}>

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/soup-filters-bar.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/soup-filters-bar.tsx
@@ -1,8 +1,7 @@
 import { SoupViewContextSort } from '@app/component/next-soup/soup-view/filters-bar/soup-view-context-sort';
 import { useFilterRefinements } from '@app/component/next-soup/soup-view/filters-bar/use-filter-refinements';
 import { useSplitPanelOrThrow } from '@app/component/split-layout/layoutUtils';
-import type { ListView } from '@app/constants/list-views';
-import { createMemo, createSignal, Match, Show, Switch } from 'solid-js';
+import { createMemo, createSignal, Show } from 'solid-js';
 import { UnifiedFilterDropdown } from '@app/component/next-soup/soup-view/filters-bar/unified-filter-dropdown';
 import { ActiveFilterChips } from '@app/component/next-soup/soup-view/filters-bar/active-filter-chips';
 import { isMobile } from '@core/mobile/isMobile';
@@ -54,77 +53,45 @@ export const SoupFiltersBar = () => {
     },
   });
 
-  const component = createMemo(() => {
+  const isSearchView = createMemo(() => {
     const content = panel.handle.content();
-
-    if (content.type !== 'component') return;
-
-    return content.id;
+    return content.type === 'component' && content.id === 'search';
   });
 
-  const isComponentListView = (listView: ListView) => {
-    return component() === listView;
-  };
-
   return (
-    <Switch>
-      <Match when={isComponentListView('search')}>
-        <div class="flex items-start gap-2 p-2 border-b border-edge-muted w-full">
-          <UnifiedFilterDropdown />
-          <ActiveFilterChips
-            filters={activeFiltersList()}
-            onRemove={removeFilter}
-            onReplace={replaceFilter}
-            onClearAll={resetToTabDefaults}
-            isOptionActive={isOptionActive}
-          />
-          <div class="flex-1" />
-          <Tooltip
-            tooltip={<LabelAndHotKey label="Preview" shortcut="space" />}
+    <Show when={!isMobile()}>
+      <div
+        class="flex items-start gap-2 border-b border-edge-muted w-full"
+        classList={{
+          'p-2': isSearchView(),
+          'px-2 py-1.5': !isSearchView(),
+        }}
+      >
+        <UnifiedFilterDropdown />
+        <ActiveFilterChips
+          filters={activeFiltersList()}
+          onRemove={removeFilter}
+          onReplace={replaceFilter}
+          onClearAll={resetToTabDefaults}
+          isOptionActive={isOptionActive}
+        />
+        <div class="flex-1" />
+        <Tooltip tooltip={<LabelAndHotKey label="Preview" shortcut="space" />}>
+          <Button
+            variant={soup.previewEntity() ? 'primary' : 'ghost'}
+            size="sm"
+            class="rounded-xs [&_svg]:size-4 px-1 border border-transparent"
+            onClick={togglePreview}
+            onMouseEnter={() => setPreviewBtnHovering(true)}
+            onMouseLeave={() => setPreviewBtnHovering(false)}
           >
-            <Button
-              variant={soup.previewEntity() ? 'primary' : 'ghost'}
-              size="sm"
-              class="rounded-xs [&_svg]:size-4 px-1 border border-transparent"
-              onClick={togglePreview}
-              onMouseEnter={() => setPreviewBtnHovering(true)}
-              onMouseLeave={() => setPreviewBtnHovering(false)}
-            >
-              <AnimatedPreviewIcon triggerAnimation={previewBtnHovering()} />
-            </Button>
-          </Tooltip>
-        </div>
-      </Match>
-      <Match when={true}>
-        <Show when={!isMobile()}>
-          <div class="flex items-start gap-2 px-2 py-1.5 border-b border-edge-muted w-full">
-            <UnifiedFilterDropdown />
-            <ActiveFilterChips
-              filters={activeFiltersList()}
-              onRemove={removeFilter}
-              onReplace={replaceFilter}
-              onClearAll={resetToTabDefaults}
-              isOptionActive={isOptionActive}
-            />
-            <div class="flex-1" />
-            <Tooltip
-              tooltip={<LabelAndHotKey label="Preview" shortcut="space" />}
-            >
-              <Button
-                variant={soup.previewEntity() ? 'primary' : 'ghost'}
-                size="sm"
-                class="rounded-xs [&_svg]:size-4 px-1 border border-transparent"
-                onClick={togglePreview}
-                onMouseEnter={() => setPreviewBtnHovering(true)}
-                onMouseLeave={() => setPreviewBtnHovering(false)}
-              >
-                <AnimatedPreviewIcon triggerAnimation={previewBtnHovering()} />
-              </Button>
-            </Tooltip>
-            <SoupViewContextSort />
-          </div>
+            <AnimatedPreviewIcon triggerAnimation={previewBtnHovering()} />
+          </Button>
+        </Tooltip>
+        <Show when={!isSearchView()}>
+          <SoupViewContextSort />
         </Show>
-      </Match>
-    </Switch>
+      </div>
+    </Show>
   );
 };

--- a/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
@@ -283,39 +283,56 @@ export const SoupView = (props: SoupViewProps) => {
             <SplitHeaderLeft>
               <div
                 class={cn('h-full flex gap-3 items-center', {
-                  'shrink-0': !narrowSearchExpanded(),
-                  'flex-1 min-w-0': narrowSearchExpanded(),
+                  'shrink-0':
+                    !narrowSearchExpanded() && !isComponentListView('search'),
+                  'flex-1 min-w-0':
+                    narrowSearchExpanded() || isComponentListView('search'),
                 })}
               >
-                <Show when={!isMobile()}>
-                  <h1 class="font-semibold text-ink select-none text-sm shrink-0">
-                    {props.viewName}
-                  </h1>
-                </Show>
-                <Show when={!narrowSearchExpanded()}>
-                  <Show when={!isMobile()}>
-                    <CollapsibleHeaderItem
-                      id="tabs"
-                      priority={1}
-                      expanded={() => <SoupViewTabs />}
-                      collapsed={() => <CollapsedSoupViewTabs />}
-                      containerClass="h-full"
-                    />
-                  </Show>
-                  <Show when={!isMobile()}>
-                    <SoupViewCreateButton />
-                  </Show>
-                  <Show when={isMobile()}>
-                    <MobileFilterDrawer />
-                  </Show>
-                </Show>
-                <Show when={narrowSearchExpanded()}>
+                <Show
+                  when={isComponentListView('search')}
+                  fallback={
+                    <>
+                      <Show when={!isMobile()}>
+                        <h1 class="font-semibold text-ink select-none text-sm shrink-0">
+                          {props.viewName}
+                        </h1>
+                      </Show>
+                      <Show when={!narrowSearchExpanded()}>
+                        <Show when={!isMobile()}>
+                          <CollapsibleHeaderItem
+                            id="tabs"
+                            priority={1}
+                            expanded={() => <SoupViewTabs />}
+                            collapsed={() => <CollapsedSoupViewTabs />}
+                            containerClass="h-full"
+                          />
+                        </Show>
+                        <Show when={!isMobile()}>
+                          <SoupViewCreateButton />
+                        </Show>
+                        <Show when={isMobile()}>
+                          <MobileFilterDrawer />
+                        </Show>
+                      </Show>
+                      <Show when={narrowSearchExpanded()}>
+                        <div class="flex-1 min-w-0">
+                          <SoupSearchbar
+                            variant="secondary"
+                            autoFocus
+                            initialValue={props.initialSearchText}
+                            onDismiss={() => setNarrowSearchExpanded(false)}
+                          />
+                        </div>
+                      </Show>
+                    </>
+                  }
+                >
                   <div class="flex-1 min-w-0">
                     <SoupSearchbar
                       variant="secondary"
-                      autoFocus
+                      placeholder="Search, @mention contacts"
                       initialValue={props.initialSearchText}
-                      onDismiss={() => setNarrowSearchExpanded(false)}
                     />
                   </div>
                 </Show>
@@ -361,7 +378,7 @@ export const SoupView = (props: SoupViewProps) => {
                 />
               </Show>
             </SplitHeaderRight>
-            <SoupFiltersBar initialSearchText={props.initialSearchText} />
+            <SoupFiltersBar />
           </div>
           <Show when={hasLinkError()}>
             <EmailPermissionsBanner />


### PR DESCRIPTION
Moves the search input into the split header and drops the redundant "Search" title and tabs/create button on the search view, freeing up a row of vertical space.
