### PR TITLE
fix(chat): don't autofocus chat input when in preview

### DIFF
--- a/js/app/packages/block-chat/component/Chat.tsx
+++ b/js/app/packages/block-chat/component/Chat.tsx
@@ -1,3 +1,4 @@
+import { useMaybePreviewPanel } from '@app/component/PreviewPanel';
 import { useNavigatedFromJK } from '@app/component/useNavigatedFromJK';
 import type { SendBuilder } from '@block-chat/blockClient';
 import { TopBar } from '@block-chat/component/TopBar';
@@ -81,6 +82,7 @@ function ChatInner(props: {
   const scopeId = blockHotkeyScopeSignal.get;
   const blockElement = blockElementSignal.get;
   const { navigatedFromJK } = useNavigatedFromJK();
+  const isPreview = !!useMaybePreviewPanel();
   const [scrollRef, setScrollRef] = createSignal<HTMLElement>();
   const [showStreamDebug, setShowStreamDebug] = createSignal(false);
   const [markdownText, setMarkdownText] = createSignal(
@@ -311,7 +313,7 @@ function ChatInner(props: {
               chatId={chat.chatId()}
               onSend={onSend}
               onStop={onStop}
-              autoFocusOnMount={true}
+              autoFocusOnMount={!isPreview}
             />
           </div>
         </div>


### PR DESCRIPTION
Chat block in preview was autofocusing its input on mount, stealing focus from the search bar mid-typing. The PreviewPanel then redirected focus back via DOM `.focus()`, which collapsed the contenteditable selection and dropped the cursor to position 0. Same fix as #2420 did for channels: gate `autoFocusOnMount` on `useMaybePreviewPanel()`.
