### PR TITLE
fix[mobile]: persist mobile auth

### DIFF
--- a/js/app/packages/app/component/Root.tsx
+++ b/js/app/packages/app/component/Root.tsx
@@ -16,7 +16,12 @@ import { IosPushNotificationModal } from '@core/mobile/IosPushNotificationModal'
 import { isNativeMobilePlatform } from '@core/mobile/isNativeMobilePlatform';
 import { createBlockOrchestrator } from '@core/orchestrator';
 import { formatTabTitle, tabTitleSignal } from '@core/signal/tabTitle';
-import { getLoginCookieOptions, updateCookie } from '@core/util/cookies';
+import {
+  getLoginCookieOptions,
+  hasLoginCookie,
+  syncLoginStorage,
+  updateCookie,
+} from '@core/util/cookies';
 import { licenseChannel } from '@core/util/licenseUpdateBroadcastChannel';
 import { isTauri } from '@core/util/platform';
 import { transformShortIdInUrlPathname } from '@core/util/url';
@@ -101,10 +106,10 @@ function useSyncLoginCookie() {
   createEffect(() => {
     if (!userInfoQuery.isSuccess) return;
 
-    const { value, ...options } = getLoginCookieOptions(
-      userInfoQuery.data.authenticated ?? false
-    );
+    const authenticated = userInfoQuery.data.authenticated ?? false;
+    const { value, ...options } = getLoginCookieOptions(authenticated);
     updateCookie('login', value, options);
+    syncLoginStorage(authenticated);
   });
 }
 
@@ -192,11 +197,14 @@ function BasePathComponent() {
   return (
     <Switch>
       <Match when={userInfoQuery.isLoading}>{null}</Match>
+      <Match when={userInfoQuery.isError && hasLoginCookie()}>
+        <Navigate href={redirectPath} />
+      </Match>
       <Match
         when={!userInfoQuery.isLoading && !userInfoQuery.data?.authenticated}
       >
         <Navigate
-          href={`${isNativeMobilePlatform() ? '/welcome' : '/welcome'}${window.location.search}`}
+          href={`/welcome${window.location.search}`}
         />
       </Match>
       <Match when={userInfoQuery.data?.authenticated}>

--- a/js/app/packages/app/component/Root.tsx
+++ b/js/app/packages/app/component/Root.tsx
@@ -157,12 +157,12 @@ const rootPreload: RoutePreloadFunc = async (args) => {
   }
 };
 
-function OfflineFallback(props: { onRetry: () => void }) {
+function OfflineFallback(props: { onRetry: () => Promise<unknown> }) {
   const [retrying, setRetrying] = createSignal(false);
 
   const handleRetry = async () => {
     setRetrying(true);
-    props.onRetry();
+    await props.onRetry();
     setRetrying(false);
   };
 
@@ -223,8 +223,11 @@ function BasePathComponent() {
   return (
     <Switch>
       <Match when={userInfoQuery.isLoading}>{null}</Match>
-      {/* If no service AND no persisted query (fresh install or user hasn't opened app since cutoff) AND user has been previously logged in => show offline fallback instead of log in screen */}
-      <Match when={userInfoQuery.isError && hasLoginCookie()}>
+      <Match
+        when={
+          userInfoQuery.isError && hasLoginCookie() && isNativeMobilePlatform()
+        }
+      >
         <OfflineFallback onRetry={() => userInfoQuery.refetch()} />
       </Match>
       <Match

--- a/js/app/packages/app/component/Root.tsx
+++ b/js/app/packages/app/component/Root.tsx
@@ -59,6 +59,7 @@ import { useHotKeyRoot } from 'core/hotkey/hotkeys';
 import { detect } from 'detect-browser';
 import {
   createEffect,
+  createSignal,
   type JSX,
   Match,
   on,
@@ -98,6 +99,7 @@ import {
 import { PosthogProvider, usePosthog } from '@app/lib/analytics/posthog';
 import { CallProvider } from '@channel/Call/CallContext';
 import { CallStartedNotifier } from '@channel/Call/CallStartedNotifier';
+import { Button } from '@ui';
 
 /** Syncs login cookie with auth state. Only updates on successful query (not errors/loading). */
 function useSyncLoginCookie() {
@@ -155,6 +157,30 @@ const rootPreload: RoutePreloadFunc = async (args) => {
   }
 };
 
+function OfflineFallback(props: { onRetry: () => void }) {
+  const [retrying, setRetrying] = createSignal(false);
+
+  const handleRetry = async () => {
+    setRetrying(true);
+    props.onRetry();
+    setRetrying(false);
+  };
+
+  return (
+    <div class="flex flex-col items-center justify-center gap-4 h-full w-full text-ink-muted">
+      <p class="text-sm">Unable to connect. Please check your network.</p>
+      <Button
+        class="mt-2"
+        disabled={retrying()}
+        onClick={handleRetry}
+        variant='primary'
+      >
+        {retrying() ? 'Retrying…' : 'Retry'}
+      </Button>
+    </div>
+  );
+}
+
 function BasePathComponent() {
   const analytics = useAnalytics();
 
@@ -197,8 +223,9 @@ function BasePathComponent() {
   return (
     <Switch>
       <Match when={userInfoQuery.isLoading}>{null}</Match>
+      {/* If no service AND no persisted query (fresh install or user hasn't opened app since cutoff) AND user has been previously logged in => show offline fallback instead of log in screen */}
       <Match when={userInfoQuery.isError && hasLoginCookie()}>
-        <Navigate href={redirectPath} />
+        <OfflineFallback onRetry={() => userInfoQuery.refetch()} />
       </Match>
       <Match
         when={!userInfoQuery.isLoading && !userInfoQuery.data?.authenticated}

--- a/js/app/packages/app/component/Root.tsx
+++ b/js/app/packages/app/component/Root.tsx
@@ -173,7 +173,7 @@ function OfflineFallback(props: { onRetry: () => void }) {
         class="mt-2"
         disabled={retrying()}
         onClick={handleRetry}
-        variant='primary'
+        variant="primary"
       >
         {retrying() ? 'Retrying…' : 'Retry'}
       </Button>
@@ -230,9 +230,7 @@ function BasePathComponent() {
       <Match
         when={!userInfoQuery.isLoading && !userInfoQuery.data?.authenticated}
       >
-        <Navigate
-          href={`/welcome${window.location.search}`}
-        />
+        <Navigate href={`/welcome${window.location.search}`} />
       </Match>
       <Match when={userInfoQuery.data?.authenticated}>
         <Navigate href={redirectPath} />

--- a/js/app/packages/core/auth/logout.ts
+++ b/js/app/packages/core/auth/logout.ts
@@ -2,6 +2,7 @@ import { authServiceClient } from '@service-auth/client';
 import { authKeys } from '@queries/auth/user-info';
 import { queryClient } from '@queries/client';
 import { SERVER_HOSTS } from '@core/constant/servers';
+import { syncLoginStorage } from '@core/util/cookies';
 import { createCallback } from '@solid-primitives/rootless';
 import { useAnalytics } from '@app/component/analytics-context';
 import { isNativeMobilePlatform } from '@core/mobile/isNativeMobilePlatform';
@@ -14,6 +15,7 @@ export function useLogout() {
   return createCallback(async () => {
     document.cookie =
       'login=false; expires=Thu, 01 Jan 1970 00:00:00 UTC; max-age=0; path=/; SameSite=Lax';
+    syncLoginStorage(false);
 
     queryClient.setQueryData(authKeys.userInfo.queryKey, {
       id: '',

--- a/js/app/packages/core/util/cookies.ts
+++ b/js/app/packages/core/util/cookies.ts
@@ -15,8 +15,6 @@ export type LoginCookieOptions = {
   sameSite: 'Lax';
 };
 
-import { isTauri } from '@core/util/platform';
-
 const LOGIN_STORAGE_KEY = 'macro:login';
 
 /** Check if the user appears to be authenticated based on the login cookie or localStorage fallback. */

--- a/js/app/packages/core/util/cookies.ts
+++ b/js/app/packages/core/util/cookies.ts
@@ -15,8 +15,13 @@ export type LoginCookieOptions = {
   sameSite: 'Lax';
 };
 
-/** Check if the user appears to be authenticated based on the login cookie. */
+const LOGIN_STORAGE_KEY = 'macro:login';
+
+/** Check if the user appears to be authenticated based on the login cookie or localStorage fallback. */
 export function hasLoginCookie(): boolean {
+  if (typeof localStorage !== 'undefined' && localStorage.getItem(LOGIN_STORAGE_KEY) === 'true') {
+    return true;
+  }
   if (typeof document === 'undefined') return false;
   const cookies = document.cookie.split(';');
   for (const cookie of cookies) {
@@ -26,6 +31,16 @@ export function hasLoginCookie(): boolean {
     }
   }
   return false;
+}
+
+/** Sync the login state to localStorage (for environments where cookies don't persist, e.g. Tauri iOS). */
+export function syncLoginStorage(isAuthenticated: boolean) {
+  if (typeof localStorage === 'undefined') return;
+  if (isAuthenticated) {
+    localStorage.setItem(LOGIN_STORAGE_KEY, 'true');
+  } else {
+    localStorage.removeItem(LOGIN_STORAGE_KEY);
+  }
 }
 
 /** Compute login cookie options from auth state. */

--- a/js/app/packages/core/util/cookies.ts
+++ b/js/app/packages/core/util/cookies.ts
@@ -19,7 +19,10 @@ const LOGIN_STORAGE_KEY = 'macro:login';
 
 /** Check if the user appears to be authenticated based on the login cookie or localStorage fallback. */
 export function hasLoginCookie(): boolean {
-  if (typeof localStorage !== 'undefined' && localStorage.getItem(LOGIN_STORAGE_KEY) === 'true') {
+  if (
+    typeof localStorage !== 'undefined' &&
+    localStorage.getItem(LOGIN_STORAGE_KEY) === 'true'
+  ) {
     return true;
   }
   if (typeof document === 'undefined') return false;

--- a/js/app/packages/core/util/cookies.ts
+++ b/js/app/packages/core/util/cookies.ts
@@ -15,6 +15,8 @@ export type LoginCookieOptions = {
   sameSite: 'Lax';
 };
 
+import { isTauri } from '@core/util/platform';
+
 const LOGIN_STORAGE_KEY = 'macro:login';
 
 /** Check if the user appears to be authenticated based on the login cookie or localStorage fallback. */
@@ -36,7 +38,7 @@ export function hasLoginCookie(): boolean {
   return false;
 }
 
-/** Sync the login state to localStorage (for environments where cookies don't persist, e.g. Tauri iOS). */
+/** Sync the login state to localStorage for environments where cookies don't persist, e.g. Tauri. */
 export function syncLoginStorage(isAuthenticated: boolean) {
   if (typeof localStorage === 'undefined') return;
   if (isAuthenticated) {

--- a/js/app/packages/queries/persistence-scopes.ts
+++ b/js/app/packages/queries/persistence-scopes.ts
@@ -1,5 +1,6 @@
 import { partialMatchKey, type QueryKey } from '@tanstack/query-core';
 import { hasLoginCookie } from '@core/util/cookies';
+import { isNativeMobilePlatform } from '@core/mobile/isNativeMobilePlatform';
 import { authKeys } from './auth/keys';
 import { channelKeys } from './channel/keys';
 import { createPersistenceKey, type PersistScope } from './persistence';
@@ -38,15 +39,19 @@ export function createQueryPersistenceScopes(
       shouldPersist: (queryKey) =>
         partialMatchKey(queryKey, ['email', 'threadMessages']),
     },
-    {
-      store: createPerQueryIDBStore({
-        dbName: createPersistenceKey('user-info', 1),
-      }),
-      maxAge: { value: 7, unit: 'd' },
-      buster,
-      shouldPersist: (queryKey) =>
-        partialMatchKey(queryKey, authKeys.userInfo.queryKey),
-      shouldRestore: () => hasLoginCookie(),
-    },
+    ...(isNativeMobilePlatform()
+      ? [
+          {
+            store: createPerQueryIDBStore({
+              dbName: createPersistenceKey('user-info', 1),
+            }),
+            maxAge: { value: 7, unit: 'd' },
+            buster,
+            shouldPersist: (queryKey: QueryKey) =>
+              partialMatchKey(queryKey, authKeys.userInfo.queryKey),
+            shouldRestore: hasLoginCookie,
+          } satisfies PersistScope,
+        ]
+      : []),
   ];
 }

--- a/js/app/packages/queries/persistence-scopes.ts
+++ b/js/app/packages/queries/persistence-scopes.ts
@@ -1,4 +1,6 @@
 import { partialMatchKey, type QueryKey } from '@tanstack/query-core';
+import { hasLoginCookie } from '@core/util/cookies';
+import { authKeys } from './auth/keys';
 import { channelKeys } from './channel/keys';
 import { createPersistenceKey, type PersistScope } from './persistence';
 import { createPerQueryIDBStore } from './persistence/per-query-idb';
@@ -35,6 +37,16 @@ export function createQueryPersistenceScopes(
       buster,
       shouldPersist: (queryKey) =>
         partialMatchKey(queryKey, ['email', 'threadMessages']),
+    },
+    {
+      store: createPerQueryIDBStore({
+        dbName: createPersistenceKey('user-info', 1),
+      }),
+      maxAge: { value: 7, unit: 'd' },
+      buster,
+      shouldPersist: (queryKey) =>
+        partialMatchKey(queryKey, authKeys.userInfo.queryKey),
+      shouldRestore: () => hasLoginCookie(),
     },
   ];
 }

--- a/js/app/packages/queries/persistence.ts
+++ b/js/app/packages/queries/persistence.ts
@@ -27,6 +27,7 @@ export type PersistScope = Readonly<{
   maxAge: ParsedDuration;
   buster: string;
   shouldPersist: (queryKey: QueryKey) => boolean;
+  shouldRestore?: (queryKey: QueryKey) => boolean;
 }>;
 
 type QueryClientLike = {
@@ -68,6 +69,8 @@ async function handleRestore(
   scope: PersistScope,
   query: Query
 ): Promise<void> {
+  if (scope.shouldRestore && !scope.shouldRestore(query.queryKey)) return;
+
   const state = queryClient.getQueryState(query.queryKey);
   if (state && state.status === 'success') return;
 


### PR DESCRIPTION
Multi-pronged fix for auth persistence on mobile.

1. Add `userInfo` query to IDB persistence in native tauri app.
2. Mirror log-in state for `hasLoginCookie()` (which currently gets stored in a cookie which gets wiped on mobile) to localStorage.
3. When `userInfo` query fails (e.g. no service AND no persisted query), but user previously logged in, do not redirect to login, but to Offline Fallback with button to retry.