### PR TITLE
fix(kommand): don't auto-focus search row at top

### DIFF
--- a/js/app/packages/app/component/command/CommandMenu.tsx
+++ b/js/app/packages/app/component/command/CommandMenu.tsx
@@ -138,7 +138,9 @@ export function CommandMenuInner(props: {
 
   createEffect(
     on(query, () => {
-      CommandState.setSelectedIndex(0);
+      const items = filteredItems();
+      const firstIsSearch = items[0] && isSearchItem(items[0]);
+      CommandState.setSelectedIndex(firstIsSearch && items.length > 1 ? 1 : 0);
     })
   );
 


### PR DESCRIPTION
Search row stays at the top of Cmd+K, but selection now lands on the first real result when one exists, so the search row no longer steals focus by default. Arrow up to reach it.
