### PR TITLE
chg(local): freeze project names for running locally to support worktrees

### DIFF
--- a/RUNNING_LOCALLY.md
+++ b/RUNNING_LOCALLY.md
@@ -23,6 +23,8 @@ export SOPS_KMS_ARN = "arn:aws:kms:us-east-1:569036502058:key/mrk-cab29bf948044e
 
 Run `just setup` to initialize your entire environment.
 
+Local Docker resources are intentionally frozen to the `macro` Compose project. Multiple checkouts/worktrees share the same containers, volumes, networks, LocalStack, and FusionAuth instance. Do not run two local stacks at the same time.
+
 ## Running
 
 ### Backend

--- a/docker-compose-databases.yml
+++ b/docker-compose-databases.yml
@@ -1,3 +1,8 @@
+# Freeze the Docker Compose project name so every checkout/worktree uses the
+# same local database containers and Compose-managed resources.
+# Local setup is single-instance by design.
+name: macro
+
 services: 
   postgres:
     image: postgres:16

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,9 @@
 # Services
+# Freeze the Docker Compose project name so every checkout/worktree uses the
+# same local containers, networks, and anonymous Compose-managed resources.
+# Local setup is single-instance by design.
+name: macro
+
 include:
   - docker-compose-databases.yml
   - infra/stacks/fusionauth-instance/docker-compose.yml

--- a/infra/stacks/fusionauth-instance/docker-compose.yml
+++ b/infra/stacks/fusionauth-instance/docker-compose.yml
@@ -1,3 +1,8 @@
+# Freeze the Docker Compose project name so every checkout/worktree uses the
+# same local FusionAuth containers, networks, and Compose-managed resources.
+# Local setup is single-instance by design.
+name: macro
+
 services:
   db:
     image: postgres:16.0-bookworm

--- a/infra/stacks/fusionauth-instance/justfile
+++ b/infra/stacks/fusionauth-instance/justfile
@@ -1,3 +1,7 @@
+# Freeze Docker Compose resources across checkouts/worktrees. Local setup is
+# single-instance by design; do not derive resource names from the directory.
+export COMPOSE_PROJECT_NAME := "macro"
+
 # Gets the .env variables for the FusionAuth docker-compose.
 get_fusionauth_env:
   @echo "Getting fusionauth .env file for docker-compose"

--- a/justfile
+++ b/justfile
@@ -1,5 +1,9 @@
 set positional-arguments
 
+# Freeze Docker Compose resources across checkouts/worktrees. Local setup is
+# single-instance by design; do not derive resource names from the directory.
+export COMPOSE_PROJECT_NAME := "macro"
+
 # Creates global networks that are shared across docker-compose files
 create_networks:
   docker network create databases 2>/dev/null || true -- db network


### PR DESCRIPTION
Currently if you try to run `run_local` in a second worktree it will break for two reasons:
1. We can only run a single instance of a fusionauth at once
2. We dynamically name the resources based on the project

Not only does this not work, but it will actually break your existing local run in a different worktree.

This freezes the project names, so multiple work trees will share the same resources for running locally.
You can't fully run two instances at a time *yet*, but atleast it won't break anything, and you can run them seperately.
