### PR TITLE
fix[channels]: scroll thread reply input into view

### DIFF
--- a/js/app/packages/channel/Channel/Channel.tsx
+++ b/js/app/packages/channel/Channel/Channel.tsx
@@ -82,7 +82,6 @@ import { DebugSuspense } from '@channel/DebugSuspense';
 import { MaybeMessageActionDrawerManager } from '@channel/Mobile/MessageActionDrawerManager';
 import { useChannelParticipants } from '@channel/use-channel-participants';
 import { usePostTypingUpdateMutation } from '@queries/channel/typing';
-import { scrollReplyInputIntoView } from '../scroll-utils';
 
 export type ChannelProps = {
   channelId: string;
@@ -239,7 +238,6 @@ export function Channel(props: ChannelProps) {
     onReply: (ctx) => {
       const state = threadManager.getOrCreateThreadState(ctx.message.id);
       state.setIsReplying(true);
-      requestAnimationFrame(() => scrollReplyInputIntoView(ctx.message.id));
     },
     onEdit: ({ message }) => {
       messageEditor.start(message);

--- a/js/app/packages/channel/Channel/thread-manager.ts
+++ b/js/app/packages/channel/Channel/thread-manager.ts
@@ -24,8 +24,9 @@ export function createThreadManager() {
           typeof val === 'function' ? val(isReplying()) : val;
         if (next) {
           setIsExpanded(true);
-          requestAnimationFrame(() => replyInputEl()?.scrollIntoView({ block: 'nearest' }))
-          
+          requestAnimationFrame(() =>
+            replyInputEl()?.scrollIntoView({ block: 'nearest' })
+          );
         }
         setIsReplyingRaw(next);
       });

--- a/js/app/packages/channel/Channel/thread-manager.ts
+++ b/js/app/packages/channel/Channel/thread-manager.ts
@@ -22,7 +22,11 @@ export function createThreadManager() {
       batch(() => {
         const next: boolean =
           typeof val === 'function' ? val(isReplying()) : val;
-        if (next) setIsExpanded(true);
+        if (next) {
+          setIsExpanded(true);
+          requestAnimationFrame(() => replyInputEl()?.scrollIntoView({ block: 'nearest' }))
+          
+        }
         setIsReplyingRaw(next);
       });
     };

--- a/js/app/packages/channel/scroll-utils.ts
+++ b/js/app/packages/channel/scroll-utils.ts
@@ -14,37 +14,18 @@ function getChannelScrollElement(element: HTMLElement) {
   return element.closest('[data-channel-scroll]');
 }
 
-function isElementInView(element: HTMLElement) {
-  const rect = element.getBoundingClientRect();
-  return rect.top >= 0 && rect.bottom <= window.innerHeight;
-}
-
-export function scrollIntoViewIfNeeded(element: HTMLElement) {
-  if (isElementInView(element)) return false;
-  element.scrollIntoView({ block: 'nearest' });
-  return true;
-}
-
-export function isMessageInView(messageId: string) {
-  const element = getMessageElement(messageId);
-  return !!element && isElementInView(element);
-}
-
 export function scrollMessageIntoView(messageId: string) {
   const element = getMessageElement(messageId);
   if (!element) return false;
-  return scrollIntoViewIfNeeded(element);
-}
-
-export function isReplyInputInView(messageId: string) {
-  const element = getReplyInputElement(messageId);
-  return !!element && isElementInView(element);
+  element.scrollIntoView({ block: 'nearest' });
+  return true;
 }
 
 export function scrollReplyInputIntoView(messageId: string) {
   const element = getReplyInputElement(messageId);
   if (!element) return false;
-  return scrollIntoViewIfNeeded(element);
+  element.scrollIntoView({ block: 'nearest' });
+  return true;
 }
 
 /**


### PR DESCRIPTION
We weren't scrolling the reply input into view if it was created via the thread reply button, only if it was created via the hover action button. This centralizes the scrolling into view so that it occurs whenever a thread reply input is created.

Also removes unneeded code paths checking if an element was in view before running `el.scrollIntoView()`. 