### PR TITLE
feat(onboarding): track team creation and skip events

### DIFF
--- a/js/app/packages/app/component/interactive-onboarding/lessons/invite-team.tsx
+++ b/js/app/packages/app/component/interactive-onboarding/lessons/invite-team.tsx
@@ -17,6 +17,7 @@ import {
   useCreateTeamWithInvitesMutation,
 } from '@queries/team';
 import { useEmail } from '@core/context/user';
+import { useAnalytics } from '@app/component/analytics-context';
 import type { LessonContentProps, LessonDefinition } from '../types';
 
 const inviteFormSchema = z.object({
@@ -47,6 +48,7 @@ type FormErrors = {
 };
 
 function InviteTeamDemo(props: LessonContentProps) {
+  const analytics = useAnalytics();
   const [teamName, setTeamName] = createSignal('');
   const [emails, setEmails] = createSignal<string[]>(['']);
   const [errors, setErrors] = createSignal<FormErrors>({});
@@ -197,6 +199,9 @@ function InviteTeamDemo(props: LessonContentProps) {
       await createTeamMutation.mutateAsync({
         name: result.data.teamName,
         emails: result.data.emails.length > 0 ? result.data.emails : undefined,
+      });
+      analytics.track('onboarding_team_created', {
+        inviteCount: result.data.emails.length,
       });
       props.advance();
     } catch {
@@ -364,10 +369,14 @@ function InviteTeamDemo(props: LessonContentProps) {
 }
 
 function SkipAction(props: LessonContentProps) {
+  const analytics = useAnalytics();
   return (
     <button
       type="button"
-      onClick={() => props.advance()}
+      onClick={() => {
+        analytics.track('onboarding_team_skipped');
+        props.advance();
+      }}
       class="w-full px-3 py-2.5 text-lg rounded-xs flex items-center justify-between text-ink/40 hover:text-ink hover:bg-ink/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/50 focus-visible:ring-offset-1 focus-visible:ring-offset-panel"
     >
       Skip for now

--- a/js/app/packages/app/lib/analytics/app-events.ts
+++ b/js/app/packages/app/lib/analytics/app-events.ts
@@ -8,6 +8,8 @@ export type AppEvents = {
   login_from_onboarding: Record<string, unknown>;
   mobile_web_welcome_viewed: Record<string, unknown>;
   mobile_web_signup_sent_viewed: Record<string, unknown>;
+  onboarding_team_created: { inviteCount: number };
+  onboarding_team_skipped: Record<string, unknown>;
 
   subscription_start: Record<string, unknown>;
   subscription_cancel: Record<string, unknown>;


### PR DESCRIPTION
## Summary
- Adds two PostHog events to the invite-team onboarding step: `onboarding_team_created` (with `inviteCount`) and `onboarding_team_skipped`.
- `onboarding_team_created` fires after `createTeamMutation.mutateAsync` resolves successfully in `InviteTeamDemo` — only on actual creation, not on validation failures.
- `onboarding_team_skipped` fires from the "Skip for now" button in `SkipAction`.
- Declares both event names in `app-events.ts` so `track()` is type-checked.

## Why
We want PostHog insights for the invite-team step:
1. Daily count of users who create a team vs skip — exposes the impact of this step on team adoption.
2. Average / total invites sent per team creation — measures how much network effect each new team brings in.

The shell already emits `onboarding_step_invite_team` with `state: 'viewed'` / `'completed'`, so abandonment (closed tab without acting) can be derived as `viewed − (created + skipped)`.