### PR TITLE
fix(ai): stream logging

### DIFF
--- a/rust/cloud-storage/stream/src/outbound/redis_pg/manager.rs
+++ b/rust/cloud-storage/stream/src/outbound/redis_pg/manager.rs
@@ -75,7 +75,10 @@ impl StreamManager for RedisPostgresStreamManager {
                                 }
                             },
                             Ok(_) => continue,
-                            Err(_) => break
+                            Err(e) => {
+                                tracing::warn!(error=%e, %entity_id, "stream notify channel error, ending subscription");
+                                break
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- Add TTL expiration detection in `stream_from_beginning` — checks if the Redis key still exists after an empty XREAD and logs + breaks instead of spinning forever
- Add logging for broadcast channel errors in the stream subscription manager, which previously broke silently
- Existing `failed to read from stream` error logging is unchanged
