### PR TITLE
fix(kommand): skip scroll-to-index when items fit container

### DIFF
--- a/js/app/packages/app/component/command/CommandMenu.tsx
+++ b/js/app/packages/app/component/command/CommandMenu.tsx
@@ -573,9 +573,17 @@ function VirtualizedCommandList(props: {
 
   createEffect(() => {
     const index = props.selectedIndex;
-    if (index >= 0 && index < props.items.length && virtualizerHandle) {
-      virtualizerHandle.scrollToIndex(index, { align: 'nearest' });
+    if (index < 0 || index >= props.items.length || !virtualizerHandle) {
+      return;
     }
+    // Skip when all items fit: scrolling would be a no-op at the final
+    // container size, but during the height transition the container is
+    // briefly clipped and scrollToIndex shifts scrollTop, hiding the search
+    // row across category switches.
+    if (props.items.length * VIRTUAL_ITEM_HEIGHT <= MAX_LIST_HEIGHT) {
+      return;
+    }
+    virtualizerHandle.scrollToIndex(index, { align: 'nearest' });
   });
 
   const selector = createSelector(


### PR DESCRIPTION
When tabbing between command menu categories, the search row briefly disappeared because `scrollToIndex` ran during the 60ms results-container height transition, shifting `scrollTop` to bring the new selection into view in the not-yet-expanded container. Skipping the scroll when all items fit avoids the transient shift; long-list arrow-key scrolling still works.
