### PR TITLE
fix(email): prevent post-send and post-delete draft resurrection

### DIFF
--- a/js/app/packages/block-email/component/BaseInput.tsx
+++ b/js/app/packages/block-email/component/BaseInput.tsx
@@ -629,6 +629,8 @@ export function BaseInput(props: {
   const [userName] = useDisplayName(tryMacroId(userId() ?? ''));
 
   let draftSaveTimer: number | undefined;
+  let pendingDeletion = false;
+  let pendingSend = false;
   const DRAFT_DEBOUNCE_MS = 500;
 
   function collectDraft() {
@@ -665,7 +667,7 @@ export function BaseInput(props: {
   }
 
   async function executeSaveDraft() {
-    if (sendMutation.isPending) {
+    if (sendMutation.isPending || pendingDeletion || pendingSend) {
       return;
     }
     const draftToSave = collectDraft();
@@ -760,6 +762,25 @@ export function BaseInput(props: {
       void executeSaveDraft();
     }, DRAFT_DEBOUNCE_MS);
   }
+
+  onCleanup(() => {
+    if (draftSaveTimer) window.clearTimeout(draftSaveTimer);
+  });
+
+  // After a send, the bottom input stays mounted and its replyingTo flips to
+  // the just-sent message once the thread refetches. Cancel the inhibited
+  // post-send save and re-enable saves so a fresh edit under the new form
+  // context can be persisted.
+  createEffect(
+    on(
+      () => props.replyingTo()?.db_id,
+      () => {
+        if (draftSaveTimer) window.clearTimeout(draftSaveTimer);
+        pendingSend = false;
+      },
+      { defer: true }
+    )
+  );
 
   const handleChipDragStart = (
     field: 'to' | 'cc' | 'bcc',
@@ -970,6 +991,12 @@ export function BaseInput(props: {
       },
     });
 
+    // Block any save scheduled by reset side effects (form().reset() callDirty,
+    // clearEmailBody editor onChange firing on a microtask). Without this, the
+    // 500ms timer fires after the thread refetches, the form memo switches to
+    // the just-sent message's reply context, and we POST an empty draft
+    // replying to the message we just sent — flipping it back to is_draft=TRUE.
+    pendingSend = true;
     resetState();
     clearDraftState();
 
@@ -992,6 +1019,14 @@ export function BaseInput(props: {
   };
 
   const deleteDraftAndReset = async () => {
+    // Block any further saves for the lifetime of this BaseInput. resetState()
+    // triggers two save schedulers (clearEmailBody → editor onChange, and
+    // form().reset() → callDirty), and the editor listener may run on a
+    // microtask, so synchronous clearTimeout calls aren't enough. The
+    // component unmounts via clearDraftState() right after this, so leaving
+    // the flag set is fine.
+    pendingDeletion = true;
+    if (draftSaveTimer) window.clearTimeout(draftSaveTimer);
     const draftId = savedDraftId();
     if (draftId) {
       await deleteDraftMutation.mutateAsync({ draftId });

--- a/js/app/packages/block-email/component/BaseInput.tsx
+++ b/js/app/packages/block-email/component/BaseInput.tsx
@@ -544,6 +544,11 @@ export function BaseInput(props: {
 
   const sendMutation = useSendMessageMutation({
     onSuccess: async ({ message }) => {
+      // Cancel the post-reset save scheduled by sendEmail's resetState() and
+      // re-enable autosave for any future edits in this BaseInput instance
+      // (covers new-message flows where replyingTo never changes).
+      if (draftSaveTimer) window.clearTimeout(draftSaveTimer);
+      pendingSend = false;
       const draftId = message.db_id;
       const toastId = toast.success(
         'Email sent',
@@ -574,6 +579,9 @@ export function BaseInput(props: {
       }
     },
     onError: () => {
+      // Restore autosave so the user can keep editing after a failed send.
+      if (draftSaveTimer) window.clearTimeout(draftSaveTimer);
+      pendingSend = false;
       toast.failure('Failed to send email');
     },
   });
@@ -1019,22 +1027,32 @@ export function BaseInput(props: {
   };
 
   const deleteDraftAndReset = async () => {
-    // Block any further saves for the lifetime of this BaseInput. resetState()
-    // triggers two save schedulers (clearEmailBody → editor onChange, and
-    // form().reset() → callDirty), and the editor listener may run on a
-    // microtask, so synchronous clearTimeout calls aren't enough. The
-    // component unmounts via clearDraftState() right after this, so leaving
-    // the flag set is fine.
+    // Block any save scheduled by resetState's side effects (sync form.reset
+    // callDirty + async editor onChange listener). When clearDraftState() has
+    // a setShowReply, the BaseInput unmounts and the flag goes away with it;
+    // when it doesn't (e.g. the bottom-of-thread input), the component stays
+    // mounted and we must restore the flag so subsequent edits can autosave.
     pendingDeletion = true;
     if (draftSaveTimer) window.clearTimeout(draftSaveTimer);
     const draftId = savedDraftId();
-    if (draftId) {
-      await deleteDraftMutation.mutateAsync({ draftId });
-      refetchThreadMessages();
+    try {
+      if (draftId) {
+        await deleteDraftMutation.mutateAsync({ draftId });
+        refetchThreadMessages();
+      }
+      resetState();
+      form().setReplyAppended(false);
+      clearDraftState();
+    } finally {
+      // Yield past any sync/microtask save scheduling triggered by resetState,
+      // then cancel the resulting timer and re-enable autosave. Runs on both
+      // success and error paths so a failed delete doesn't leave the user
+      // unable to save further edits.
+      setTimeout(() => {
+        if (draftSaveTimer) window.clearTimeout(draftSaveTimer);
+        pendingDeletion = false;
+      }, 0);
     }
-    resetState();
-    form().setReplyAppended(false);
-    clearDraftState();
   };
 
   const handleUserMention = (mention: UserMentionRecord) => {

--- a/rust/cloud-storage/email/src/domain/service/send.rs
+++ b/rust/cloud-storage/email/src/domain/service/send.rs
@@ -29,7 +29,7 @@ where
             .prepare_and_insert_db_message(link, input, false)
             .await?;
 
-        // FE displays "Undo" button for delay_secs. Give extra time for round trip of cancel request
+        // FE displays "Undo" button for delay_secs. Give extra time for round trip of cancel requesta
         let sqs_delay = delay_secs as i32 + 2;
         self.enqueuer
             .enqueue_scheduled_message(link.id, created.db_id, Some(sqs_delay))

--- a/rust/cloud-storage/email/src/domain/service/send.rs
+++ b/rust/cloud-storage/email/src/domain/service/send.rs
@@ -29,7 +29,7 @@ where
             .prepare_and_insert_db_message(link, input, false)
             .await?;
 
-        // FE displays "Undo" button for delay_secs. Give extra time for round trip of cancel requesta
+        // FE displays "Undo" button for delay_secs. Give extra time for round trip of cancel request
         let sqs_delay = delay_secs as i32 + 2;
         self.enqueuer
             .enqueue_scheduled_message(link.id, created.db_id, Some(sqs_delay))


### PR DESCRIPTION
## Summary

Fixes two bugs in the thread-reply compose (`BaseInput.tsx`) where a stale draft-save timer fires after the user takes a terminal action, creating a zombie draft that conflicts with — or resurrects — the action just performed.

### Post-send bug

After clicking Send, the bottom-of-thread `BaseInput` stays mounted. The flow is:

1. `sendMutation.mutate(...)` kicks off the send (async).
2. `resetState()` calls `form().reset()`, whose `callDirty()` triggers `scheduleDraftSave()` (500 ms debounce timer). The same `resetState()` also runs `clearEmailBody(editor())`, which fires `MarkdownTextarea.onChange` → `handleChange` → `scheduleDraftSave()` on a microtask.
3. Send succeeds. `afterSend()` → `ctx.query.refetch()` updates the thread cache. `Email.tsx` reactively recomputes `info().replyingTo` to point at the just-sent message Y.
4. The `form` memo (registry-cached on `replyingTo` db_id) re-evaluates and returns `form_Y`, freshly initialized with reply-to-Y recipients/subject derived from the just-sent message.
5. The 500 ms timer fires. `executeSaveDraft()` reads the current `props.replyingTo()` (now Y) and `form()` (now `form_Y`) and POSTs a draft whose `replying_to_id` is Y's `db_id`. On the backend, this writes to the same row as the just-sent message and flips `is_draft` back to `TRUE`.

### Post-delete bug

When the user clicks "Delete draft" on a thread reply with content, `deleteDraftAndReset` deletes the draft on the server, then `resetState()` runs the same two save schedulers as above. Synchronously cancelling the timer isn't enough because the editor `onChange` listener fires on a microtask and reschedules a save after the synchronous cleanup. The 500 ms timer then fires, `executeSaveDraft` reads the form's reset-but-repopulated state (the form's `reset()` re-derives recipients from the captured `replyingTo`, so it's never empty), and creates a new empty draft replying to the original message.

## Changes

`packages/block-email/component/BaseInput.tsx`:

- Added `pendingDeletion` and `pendingSend` flags. `executeSaveDraft` early-returns when either is set, alongside the existing `sendMutation.isPending` guard. The flags catch saves scheduled by reset side effects regardless of which path (sync `callDirty` or async editor `onChange`) reached `scheduleDraftSave`.
- `deleteDraftAndReset` sets `pendingDeletion = true` before any reset work and clears any pending timer. The component unmounts immediately after, so the flag never needs to be cleared.
- `sendEmail` sets `pendingSend = true` before `resetState()`. Unlike delete, the bottom input stays mounted, so a `createEffect(on(replyingTo, ..., { defer: true }))` cancels any pending timer and clears `pendingSend` once `props.replyingTo()?.db_id` changes — i.e. once the thread refetch settles and the form context has moved on. This re-enables saves for genuine user edits under the new form.
- Added an `onCleanup` for the timer as defense-in-depth so the debounced save can never survive an unmount.

`rust/cloud-storage/email/src/domain/service/send.rs`:

- Reverted a stray comment typo (`requesta` → `request`).
