### PR TITLE
feat(email): hide thread reply box behind Reply/Forward buttons

### DIFF
--- a/js/app/packages/block-email/component/BaseInput.tsx
+++ b/js/app/packages/block-email/component/BaseInput.tsx
@@ -1722,15 +1722,13 @@ export function BaseInput(props: {
                 disablePortal={isMobile()}
               />
             </Show>
-            <Show when={savedDraftId()}>
-              <Button
-                onclick={deleteDraftAndReset}
-                tooltip="Delete draft"
-                class="aspect-square p-1"
-              >
-                <Trash class="h-5" />
-              </Button>
-            </Show>
+            <Button
+              onclick={deleteDraftAndReset}
+              tooltip={savedDraftId() ? 'Delete draft' : 'Discard'}
+              class="aspect-square p-1"
+            >
+              <Trash class="h-5" />
+            </Button>
           </div>
 
           <Tooltip

--- a/js/app/packages/block-email/component/BottomReplyButtons.tsx
+++ b/js/app/packages/block-email/component/BottomReplyButtons.tsx
@@ -1,0 +1,49 @@
+import ArrowBendUpLeft from '@icon/regular/arrow-bend-up-left.svg';
+import ArrowBendUpRight from '@icon/regular/arrow-bend-up-right.svg';
+import type { ApiMessage } from '@service-email/generated/schemas';
+import { createCallback } from '@solid-primitives/rootless';
+import { Button } from '@ui/components/Button';
+import type { ReplyType } from '../util/replyType';
+import { useEmailContext } from './EmailContext';
+import { getEmailFormRegistry } from './EmailFormContext';
+
+export function BottomReplyButtons(props: { lastMessage: ApiMessage }) {
+  const ctx = useEmailContext();
+  const formRegistry = getEmailFormRegistry();
+
+  const open = (type: ReplyType) =>
+    createCallback(() => {
+      const messageId = props.lastMessage.db_id;
+      if (!messageId) return;
+      const form = formRegistry.getOrInit({
+        type: 'replying_to',
+        messageID: messageId,
+      });
+      form.setReplyType(type);
+      form.setShouldFocusInput(true);
+      ctx.messages.setBottomReplyOpen(true);
+    });
+
+  return (
+    <div class="w-full border-t border-edge-muted flex flex-row items-center justify-center gap-2 pt-3 pb-2">
+      <Button
+        variant="secondary"
+        size="md"
+        class="rounded-full px-4 py-0.8"
+        onClick={open('reply')}
+      >
+        <ArrowBendUpLeft class="h-4 w-4" />
+        <span>Reply</span>
+      </Button>
+      <Button
+        variant="secondary"
+        size="md"
+        class="rounded-full px-4 py-0.8"
+        onClick={open('forward')}
+      >
+        <ArrowBendUpRight class="h-4 w-4" />
+        <span>Forward</span>
+      </Button>
+    </div>
+  );
+}

--- a/js/app/packages/block-email/component/BottomReplyButtons.tsx
+++ b/js/app/packages/block-email/component/BottomReplyButtons.tsx
@@ -27,7 +27,7 @@ export function BottomReplyButtons(props: { lastMessage: ApiMessage }) {
   return (
     <div class="w-full border-t border-edge-muted flex flex-row items-center justify-center gap-2 pt-3 pb-2">
       <Button
-        variant="secondary"
+        variant="base"
         size="md"
         class="rounded-full px-4 py-0.8"
         onClick={open('reply')}
@@ -36,7 +36,7 @@ export function BottomReplyButtons(props: { lastMessage: ApiMessage }) {
         <span>Reply</span>
       </Button>
       <Button
-        variant="secondary"
+        variant="base"
         size="md"
         class="rounded-full px-4 py-0.8"
         onClick={open('forward')}

--- a/js/app/packages/block-email/component/BottomReplyButtons.tsx
+++ b/js/app/packages/block-email/component/BottomReplyButtons.tsx
@@ -29,7 +29,7 @@ export function BottomReplyButtons(props: { lastMessage: ApiMessage }) {
       <Button
         variant="base"
         size="md"
-        class="rounded-full px-4 py-0.8"
+        class="rounded-full px-4 py-0.5"
         onClick={open('reply')}
       >
         <ArrowBendUpLeft class="h-4 w-4" />
@@ -38,7 +38,7 @@ export function BottomReplyButtons(props: { lastMessage: ApiMessage }) {
       <Button
         variant="base"
         size="md"
-        class="rounded-full px-4 py-0.8"
+        class="rounded-full px-4 py-0.5"
         onClick={open('forward')}
       >
         <ArrowBendUpRight class="h-4 w-4" />

--- a/js/app/packages/block-email/component/BottomReplyButtons.tsx
+++ b/js/app/packages/block-email/component/BottomReplyButtons.tsx
@@ -29,7 +29,7 @@ export function BottomReplyButtons(props: { lastMessage: ApiMessage }) {
       <Button
         variant="base"
         size="md"
-        class="rounded-full px-4 py-0.5"
+        class="rounded-full px-4 py-1"
         onClick={open('reply')}
       >
         <ArrowBendUpLeft class="h-4 w-4" />
@@ -38,7 +38,7 @@ export function BottomReplyButtons(props: { lastMessage: ApiMessage }) {
       <Button
         variant="base"
         size="md"
-        class="rounded-full px-4 py-0.5"
+        class="rounded-full px-4 py-1"
         onClick={open('forward')}
       >
         <ArrowBendUpRight class="h-4 w-4" />

--- a/js/app/packages/block-email/component/Email.tsx
+++ b/js/app/packages/block-email/component/Email.tsx
@@ -30,6 +30,7 @@ import {
 import { isScrollingToMessage } from '../signal/scrollState';
 import { registerEmailHotkeys } from '../util/emailHotkeys';
 import { scrollToMessage } from '../util/scrollToMessage';
+import { BottomReplyButtons } from './BottomReplyButtons';
 import { EmailFormContextProvider } from './EmailFormContext';
 import { MessageList } from './MessageList';
 import { ModalsProvider } from './ModalsProvider';
@@ -412,6 +413,23 @@ function EmailContent(props: EmailViewProps) {
     hide: true,
   });
 
+  // Auto-open the bottom reply box when the last message has an in-progress
+  // draft, so a partly-written reply isn't hidden behind the buttons.
+  createEffect(() => {
+    const filtered = context.messages.list();
+    if (filtered.length === 0) return;
+    const lastMessage = filtered.at(-1);
+    if (!lastMessage?.db_id) return;
+    const draft = context.drafts.getDraftForMessage(lastMessage.db_id);
+    if (draft) context.messages.setBottomReplyOpen(true);
+  });
+
+  // Reset the bottom reply state when the thread changes.
+  createEffect(() => {
+    props.threadId();
+    context.messages.setBottomReplyOpen(false);
+  });
+
   const emailReplyInfo = createMemo(() => {
     const filtered = context.messages.list();
 
@@ -507,25 +525,46 @@ function EmailContent(props: EmailViewProps) {
                     emailReplyInfo()
                   }
                 >
-                  {(info) => {
-                    return (
-                      <div class="shrink-0 w-full pb-2">
-                        <div class="relative w-full flex flex-row justify-center bg-panel macro-message-width macro-message-padding mx-auto">
-                          <FloatingInputLoader
-                            isLoading={context.query.isFetching}
-                            loadingText="Loading messages"
-                          />
+                  {(info) => (
+                    <div class="shrink-0 w-full pb-2">
+                      <div class="relative w-full flex flex-row justify-center bg-panel macro-message-width macro-message-padding mx-auto">
+                        <FloatingInputLoader
+                          isLoading={context.query.isFetching}
+                          loadingText="Loading messages"
+                        />
+                        <Show
+                          when={
+                            context.messages.bottomReplyOpen() ||
+                            info().replyingTo == null
+                          }
+                          fallback={
+                            <Show when={info().replyingTo}>
+                              {(lastMessage) => (
+                                <BottomReplyButtons
+                                  lastMessage={lastMessage()}
+                                />
+                              )}
+                            </Show>
+                          }
+                        >
                           <EmailInput
                             replyingTo={() => info().replyingTo}
                             draft={info().draft}
+                            setShowReply={(v) => {
+                              const next =
+                                typeof v === 'function'
+                                  ? v(context.messages.bottomReplyOpen())
+                                  : v;
+                              context.messages.setBottomReplyOpen(next);
+                            }}
                             markdownDomRef={(el) => {
                               markdownDomRef = el;
                             }}
                           />
-                        </div>
+                        </Show>
                       </div>
-                    );
-                  }}
+                    </div>
+                  )}
                 </Show>
               </div>
             </EmailFormContextProvider>

--- a/js/app/packages/block-email/component/Email.tsx
+++ b/js/app/packages/block-email/component/Email.tsx
@@ -413,21 +413,25 @@ function EmailContent(props: EmailViewProps) {
     hide: true,
   });
 
-  // Auto-open the bottom reply box when the last message has an in-progress
-  // draft, so a partly-written reply isn't hidden behind the buttons.
+  // On thread change: collapse the bottom reply, then re-evaluate auto-open
+  // for the current thread's last message. Single effect to avoid an
+  // ordering race between separate "reset on thread change" and "auto-open
+  // on draft" effects (Solid runs effects in declaration order on first
+  // mount, which can let the reset clobber the auto-open if both data
+  // sources are synchronously available).
+  let prevThreadId: string | undefined;
   createEffect(() => {
+    const tid = props.threadId();
+    if (prevThreadId !== tid) {
+      prevThreadId = tid;
+      context.messages.setBottomReplyOpen(false);
+    }
     const filtered = context.messages.list();
-    if (filtered.length === 0) return;
     const lastMessage = filtered.at(-1);
     if (!lastMessage?.db_id) return;
-    const draft = context.drafts.getDraftForMessage(lastMessage.db_id);
-    if (draft) context.messages.setBottomReplyOpen(true);
-  });
-
-  // Reset the bottom reply state when the thread changes.
-  createEffect(() => {
-    props.threadId();
-    context.messages.setBottomReplyOpen(false);
+    if (context.drafts.getDraftForMessage(lastMessage.db_id)) {
+      context.messages.setBottomReplyOpen(true);
+    }
   });
 
   const emailReplyInfo = createMemo(() => {

--- a/js/app/packages/block-email/component/EmailContext.tsx
+++ b/js/app/packages/block-email/component/EmailContext.tsx
@@ -88,6 +88,8 @@ export type EmailContextValues = {
     isBodyExpanded: (id: string) => boolean;
     replyingToMessageId: Accessor<string | undefined>;
     setReplyingToMessageId: (id: string | undefined) => void;
+    bottomReplyOpen: Accessor<boolean>;
+    setBottomReplyOpen: (open: boolean) => void;
   };
   thread: Accessor<ApiThread | undefined>;
   permissions: Accessor<{
@@ -182,6 +184,7 @@ export function EmailProvider(props: FlowProps<{ threadID: string }>) {
 
   const [focusedMessageId, setFocusedMessageId] = createSignal<string>();
   const [replyingToMessageId, setReplyingToMessageId] = createSignal<string>();
+  const [bottomReplyOpen, setBottomReplyOpen] = createSignal(false);
   const [expandedMessageBodyIds, setExpandedMessageBodyIds] = createStore<
     Record<string, boolean>
   >({});
@@ -549,6 +552,8 @@ export function EmailProvider(props: FlowProps<{ threadID: string }>) {
             isBodyExpanded: (id: string) => expandedMessageBodyIds[id] ?? false,
             replyingToMessageId,
             setReplyingToMessageId,
+            bottomReplyOpen,
+            setBottomReplyOpen,
           },
           permissions: createMemo(() => {
             const perms = getPermissions(threadQuery.data?.access_level);

--- a/js/app/packages/block-email/component/EmailInput.tsx
+++ b/js/app/packages/block-email/component/EmailInput.tsx
@@ -36,6 +36,9 @@ export function EmailInput(props: EmailInputProps) {
 
     // Set focus to new message if provided
     if (newMessageId) ctx.messages.setFocused(newMessageId);
+
+    // Collapse the input after sending (Gmail-style).
+    props.setShowReply?.(false);
   }
 
   return (

--- a/js/app/packages/block-email/component/MessageContainer.tsx
+++ b/js/app/packages/block-email/component/MessageContainer.tsx
@@ -62,6 +62,11 @@ export function MessageContainer(props: MessageContainerProps) {
     ) {
       context.messages.setReplyingToMessageId(undefined);
     }
+    // Reply/Reply-All/Forward actions on the last message open the bottom
+    // reply input (the inline reply only renders for non-last messages).
+    if (props.isLastMessage) {
+      context.messages.setBottomReplyOpen(newValue);
+    }
   };
 
   const userId = useUserId();

--- a/js/app/packages/block-email/component/MessageList.tsx
+++ b/js/app/packages/block-email/component/MessageList.tsx
@@ -25,7 +25,7 @@ export function MessageList(props: MessageListProps) {
 
   return (
     <div
-      class="pt-2 w-full flex flex-col-reverse items-center overflow-y-scroll overflow-x-hidden hide-scrollbar text-sm"
+      class="pt-2 pb-6 w-full flex flex-col-reverse items-center overflow-y-scroll overflow-x-hidden hide-scrollbar text-sm"
       ref={context.registerMessagesList}
       onscroll={(e) => {
         // Since the list is reversed, calculate scroll from visual top

--- a/js/app/packages/block-email/component/createEmailFormState.ts
+++ b/js/app/packages/block-email/component/createEmailFormState.ts
@@ -162,6 +162,10 @@ export function createEmailFormState(
   >();
 
   const [capturedEditor, setCapturedEditor] = createSignal<LexicalEditor>();
+  // If setReplyType('forward') is called before the Lexical editor mounts
+  // (e.g. user clicks Forward while the bottom reply input is collapsed),
+  // we stash the dispatch and replay it once the editor is captured.
+  let pendingForwardAppend = false;
 
   // We track the last reply type applied to replay against the current state when setOnReplyTypeApplied is attached
   const [lastReplyTypeApplied, setLastReplyTypeApplied] = createSignal<
@@ -236,11 +240,16 @@ export function createEmailFormState(
 
       if (rt === 'forward') {
         setState('withQuotedText', true);
-        capturedEditor()?.dispatchCommand(TOGGLE_APPEND_EMAIL_THREAD_COMMAND, {
-          replyingTo: replyingTo,
-          replyType: rt,
-          visible: true,
-        });
+        const editor = capturedEditor();
+        if (editor) {
+          editor.dispatchCommand(TOGGLE_APPEND_EMAIL_THREAD_COMMAND, {
+            replyingTo: replyingTo,
+            replyType: rt,
+            visible: true,
+          });
+        } else {
+          pendingForwardAppend = true;
+        }
 
         // Populate forwarded attachments from original message (skip inline images)
         const fwdAttachments: DraftFormAttachment[] = (msg.attachments ?? [])
@@ -328,6 +337,20 @@ export function createEmailFormState(
     },
     setCapturedEditor: (editor: LexicalEditor) => {
       setCapturedEditor(editor);
+      if (pendingForwardAppend && replyingTo) {
+        pendingForwardAppend = false;
+        // Defer past the current Solid batch / microtask queue so that
+        // registerToggleAppendedThread (registered via lazyRegister, which
+        // uses createEffect) has actually attached the command handler
+        // before we dispatch. queueMicrotask runs too early.
+        setTimeout(() => {
+          editor.dispatchCommand(TOGGLE_APPEND_EMAIL_THREAD_COMMAND, {
+            replyingTo,
+            replyType: 'forward',
+            visible: true,
+          });
+        }, 0);
+      }
     },
     attachments: {
       list: attachments,

--- a/js/app/packages/core/component/Message.tsx
+++ b/js/app/packages/core/component/Message.tsx
@@ -254,7 +254,7 @@ const Root: Component<MessageRootProps> = (props) => {
             <div
               class={cn(
                 'relative flex flex-col pl-[calc(var(--user-icon-width)/2+var(--message-padding-x))] ml-(--left-of-connector)',
-                !props.hideConnectors && 'border-l',
+                !props.hideConnectors && !props.isLastMessage && 'border-l',
                 props.isNewMessage ? 'border-accent' : 'border-edge-muted',
                 !(
                   props.isConsecutive ||


### PR DESCRIPTION
## Summary

Email thread view no longer always renders the reply input at the bottom — it shows Gmail-style **Reply** and **Forward** buttons instead, and the input only appears when the user clicks one (or clicks reply/forward on a specific message via the per-message action bar).

### Behavior

- Bottom of a thread now renders compact pill-shaped **Reply** / **Forward** buttons (separated from the messages by a horizontal divider).
- Clicking **Reply** opens the input, replying to the sender of the last message (matches Gmail; no Reply-all at the bottom).
- Clicking **Forward** opens the input, populates the quoted thread, and focuses the recipient field.
- Clicking Reply / Reply-all / Forward on the **last** message via its own action bar also opens the bottom input.
- Mid-thread reply (clicking actions on a non-last message) is unchanged — still uses the existing inline reply slot.
- Auto-opens when there's already a saved draft for the last message (so a partly-written reply isn't hidden).
- Auto-closes after a successful send (Gmail-style).
- Trash icon is now always present in the input — if there's no saved draft to delete, clicking it just collapses the input back to buttons.
- Thread switching resets the open/closed state.

### Layout fixes

- The expanded `Message` body was rendering narrower than the collapsed row because its inner flex wrapper had no `flex-1`. Added `flex-1 min-w-0` so it fills the row and the topbar's `justify-between` can push the date/actions to the right edge.
- Removed the left rail on the **last** message in the thread so the bottom area reads cleanly.
- Added breathing room (`pb-6`) between the last message and the bottom Reply/Forward buttons.

### Forward command timing

`form.setReplyType('forward')` dispatches a Lexical command to append the quoted thread. Previously the bottom input was always mounted, so the editor was always available. Now the editor mounts only after the user clicks Forward, so the dispatch was a no-op and `registerToggleAppendedThread` (registered via `lazyRegister` / `createEffect`) hadn't attached its handler yet. The form now stashes a pending-forward flag and replays the dispatch from `setCapturedEditor` via `setTimeout(0)` (a macrotask) so it lands after Solid's effect graph settles and the command handler is registered.
