### PR TITLE
feat(sps): support index_override on every entity backfill

### DIFF
--- a/rust/cloud-storage/comms_service/src/service/search.rs
+++ b/rust/cloud-storage/comms_service/src/service/search.rs
@@ -23,6 +23,7 @@ pub fn send_channel_message_to_search_extractor_queue(
                             sqs_client::search::channel::ChannelMessageUpdate {
                                 channel_id,
                                 message_id,
+                                index_override: None,
                             },
                         ),
                     )
@@ -61,6 +62,7 @@ pub fn send_remove_channel_message_to_search_extractor_queue(
                             sqs_client::search::channel::RemoveChannelMessage {
                                 channel_id,
                                 message_id,
+                                index_override: None,
                             },
                         ),
                     )

--- a/rust/cloud-storage/deleted_item_poller/src/handler.rs
+++ b/rust/cloud-storage/deleted_item_poller/src/handler.rs
@@ -65,6 +65,7 @@ async fn handle_chats(ctx: &context::Context) -> anyhow::Result<()> {
                     SearchQueueMessage::RemoveChatMessage(RemoveChatMessage {
                         chat_id: id.to_string(),
                         message_id: None,
+                        index_override: None,
                     })
                 })
                 .collect(),

--- a/rust/cloud-storage/document_cognition_service/src/api/utils/search.rs
+++ b/rust/cloud-storage/document_cognition_service/src/api/utils/search.rs
@@ -17,6 +17,7 @@ pub fn send_remove_chat_message_to_search(ctx: &ApiContext, chat_id: &str, messa
                         sqs_client::search::chat::RemoveChatMessage {
                             chat_id: chat_id.to_string(),
                             message_id: Some(message_id.to_string()),
+                            index_override: None,
                         },
                     ),
                 )
@@ -48,6 +49,7 @@ pub fn send_chat_message_to_search(
                         user_id,
                         created_at,
                         updated_at,
+                        index_override: None,
                     },
                 ))
                 .await;

--- a/rust/cloud-storage/document_storage_service/src/api/projects/delete_project.rs
+++ b/rust/cloud-storage/document_storage_service/src/api/projects/delete_project.rs
@@ -270,6 +270,7 @@ pub async fn permanently_delete_project_handler(
                                 SearchQueueMessage::RemoveChatMessage(RemoveChatMessage {
                                     chat_id: id.to_string(),
                                     message_id: None,
+                                    index_override: None,
                                 })
                             })
                             .collect(),

--- a/rust/cloud-storage/document_storage_service/src/service/call_search_indexer.rs
+++ b/rust/cloud-storage/document_storage_service/src/service/call_search_indexer.rs
@@ -26,6 +26,7 @@ impl CallSearchIndexer for SqsCallSearchIndexer {
         self.sqs
             .send_message_to_search_event_queue(SearchQueueMessage::CallRecord(CallRecordMessage {
                 call_id: call_id.to_string(),
+                index_override: None,
             }))
             .await?;
         Ok(())
@@ -37,6 +38,7 @@ impl CallSearchIndexer for SqsCallSearchIndexer {
                 RemoveCallRecord {
                     channel_id: channel_id.to_string(),
                     call_id: Some(call_id.to_string()),
+                    index_override: None,
                 },
             ))
             .await?;

--- a/rust/cloud-storage/opensearch_client/src/call_record.rs
+++ b/rust/cloud-storage/opensearch_client/src/call_record.rs
@@ -11,25 +11,40 @@ impl OpensearchClient {
     pub async fn upsert_call_record_segment(
         &self,
         args: &UpsertCallRecordSegmentArgs,
+        index_override: Option<&str>,
     ) -> Result<()> {
-        upsert::call_record::upsert_call_record_segment(&self.inner, args).await
+        upsert::call_record::upsert_call_record_segment(&self.inner, args, index_override).await
     }
 
     #[tracing::instrument(skip(self, segments))]
     pub async fn bulk_upsert_call_record_segments(
         &self,
         segments: &[UpsertCallRecordSegmentArgs],
+        index_override: Option<&str>,
     ) -> Result<BulkUpsertResult> {
-        bulk_upsert_call_record_segments(&self.inner, segments).await
+        bulk_upsert_call_record_segments(&self.inner, segments, index_override).await
     }
 
     #[tracing::instrument(skip(self))]
-    pub async fn delete_call_record(&self, call_id: &str) -> Result<()> {
-        delete::call_record::delete_call_record_by_id(&self.inner, call_id).await
+    pub async fn delete_call_record(
+        &self,
+        call_id: &str,
+        index_override: Option<&str>,
+    ) -> Result<()> {
+        delete::call_record::delete_call_record_by_id(&self.inner, call_id, index_override).await
     }
 
     #[tracing::instrument(skip(self))]
-    pub async fn delete_call_records_by_channel(&self, channel_id: &str) -> Result<()> {
-        delete::call_record::delete_call_records_by_channel_id(&self.inner, channel_id).await
+    pub async fn delete_call_records_by_channel(
+        &self,
+        channel_id: &str,
+        index_override: Option<&str>,
+    ) -> Result<()> {
+        delete::call_record::delete_call_records_by_channel_id(
+            &self.inner,
+            channel_id,
+            index_override,
+        )
+        .await
     }
 }

--- a/rust/cloud-storage/opensearch_client/src/channel_message.rs
+++ b/rust/cloud-storage/opensearch_client/src/channel_message.rs
@@ -9,16 +9,25 @@ impl OpensearchClient {
     pub async fn upsert_channel_message(
         &self,
         upsert_channel_message_args: &UpsertChannelMessageArgs,
+        index_override: Option<&str>,
     ) -> Result<()> {
-        upsert::channel_message::upsert_channel_message(&self.inner, upsert_channel_message_args)
-            .await
+        upsert::channel_message::upsert_channel_message(
+            &self.inner,
+            upsert_channel_message_args,
+            index_override,
+        )
+        .await
     }
 
     /// Deletes a channel from the opensearch chat index
     /// This will remove all messages for a given channel
     #[tracing::instrument(skip(self))]
-    pub async fn delete_channel(&self, channel_id: &str) -> Result<()> {
-        delete::channel::delete_channel_by_id(&self.inner, channel_id).await
+    pub async fn delete_channel(
+        &self,
+        channel_id: &str,
+        index_override: Option<&str>,
+    ) -> Result<()> {
+        delete::channel::delete_channel_by_id(&self.inner, channel_id, index_override).await
     }
 
     /// Deletes a channel message from the opensearch channel index
@@ -28,8 +37,14 @@ impl OpensearchClient {
         &self,
         channel_id: &str,
         channel_message_id: &str,
+        index_override: Option<&str>,
     ) -> Result<()> {
-        delete::channel::delete_channel_message_by_id(&self.inner, channel_id, channel_message_id)
-            .await
+        delete::channel::delete_channel_message_by_id(
+            &self.inner,
+            channel_id,
+            channel_message_id,
+            index_override,
+        )
+        .await
     }
 }

--- a/rust/cloud-storage/opensearch_client/src/chat.rs
+++ b/rust/cloud-storage/opensearch_client/src/chat.rs
@@ -8,22 +8,39 @@ impl OpensearchClient {
     pub async fn upsert_chat_message(
         &self,
         upsert_chat_message_args: &UpsertChatMessageArgs,
+        index_override: Option<&str>,
     ) -> Result<()> {
-        upsert::chat_message::upsert_chat_message(&self.inner, upsert_chat_message_args).await
+        upsert::chat_message::upsert_chat_message(
+            &self.inner,
+            upsert_chat_message_args,
+            index_override,
+        )
+        .await
     }
 
     /// Deletes a chat from the opensearch chat index
     /// This will remove all messages for a given chat
     #[tracing::instrument(skip(self))]
-    pub async fn delete_chat(&self, chat_id: &str) -> Result<()> {
-        delete::chat::delete_chat_by_id(&self.inner, chat_id).await
+    pub async fn delete_chat(&self, chat_id: &str, index_override: Option<&str>) -> Result<()> {
+        delete::chat::delete_chat_by_id(&self.inner, chat_id, index_override).await
     }
 
     /// Deletes a chat message from the opensearch chat index
     /// This removes a specific message from a chat
     #[tracing::instrument(skip(self))]
-    pub async fn delete_chat_message(&self, chat_id: &str, chat_message_id: &str) -> Result<()> {
-        delete::chat::delete_chat_message_by_id(&self.inner, chat_id, chat_message_id).await
+    pub async fn delete_chat_message(
+        &self,
+        chat_id: &str,
+        chat_message_id: &str,
+        index_override: Option<&str>,
+    ) -> Result<()> {
+        delete::chat::delete_chat_message_by_id(
+            &self.inner,
+            chat_id,
+            chat_message_id,
+            index_override,
+        )
+        .await
     }
 
     pub async fn update_chat_metadata(&self, chat_id: &str, title: &str) -> Result<()> {

--- a/rust/cloud-storage/opensearch_client/src/delete/call_record.rs
+++ b/rust/cloud-storage/opensearch_client/src/delete/call_record.rs
@@ -6,20 +6,30 @@ use crate::{Result, error::OpensearchClientError};
 pub async fn delete_call_record_by_id(
     client: &opensearch::OpenSearch,
     call_id: &str,
+    index_override: Option<&str>,
 ) -> Result<()> {
-    delete_by_term(client, "entity_id", call_id, "delete_call_record_by_id").await
+    delete_by_term(
+        client,
+        "entity_id",
+        call_id,
+        "delete_call_record_by_id",
+        index_override,
+    )
+    .await
 }
 
 #[tracing::instrument(skip(client))]
 pub async fn delete_call_records_by_channel_id(
     client: &opensearch::OpenSearch,
     channel_id: &str,
+    index_override: Option<&str>,
 ) -> Result<()> {
     delete_by_term(
         client,
         "channel_id",
         channel_id,
         "delete_call_records_by_channel_id",
+        index_override,
     )
     .await
 }
@@ -29,13 +39,13 @@ async fn delete_by_term(
     field: &str,
     value: &str,
     method: &str,
+    index_override: Option<&str>,
 ) -> Result<()> {
     let query = serde_json::json!({ "query": { "term": { field: value } } });
 
+    let index = index_override.unwrap_or(SearchIndex::CallRecords.as_ref());
     let response = client
-        .delete_by_query(opensearch::DeleteByQueryParts::Index(&[
-            SearchIndex::CallRecords.as_ref(),
-        ]))
+        .delete_by_query(opensearch::DeleteByQueryParts::Index(&[index]))
         .body(query)
         .refresh(true)
         .send()

--- a/rust/cloud-storage/opensearch_client/src/delete/channel.rs
+++ b/rust/cloud-storage/opensearch_client/src/delete/channel.rs
@@ -2,6 +2,7 @@ use models_opensearch::SearchIndex;
 
 use crate::{Result, error::OpensearchClientError};
 
+/// Deletes all channel messages with the specified channel_id
 #[tracing::instrument(skip(client))]
 pub async fn delete_channel_by_id(
     client: &opensearch::OpenSearch,
@@ -55,6 +56,7 @@ pub async fn delete_channel_by_id(
     Ok(())
 }
 
+/// Deletes a particular channel message with the specified channel_id and channel_message_id
 #[tracing::instrument(skip(client))]
 pub async fn delete_channel_message_by_id(
     client: &opensearch::OpenSearch,

--- a/rust/cloud-storage/opensearch_client/src/delete/channel.rs
+++ b/rust/cloud-storage/opensearch_client/src/delete/channel.rs
@@ -2,9 +2,12 @@ use models_opensearch::SearchIndex;
 
 use crate::{Result, error::OpensearchClientError};
 
-/// Deletes all channel messages with the specified channel_id
 #[tracing::instrument(skip(client))]
-pub async fn delete_channel_by_id(client: &opensearch::OpenSearch, channel_id: &str) -> Result<()> {
+pub async fn delete_channel_by_id(
+    client: &opensearch::OpenSearch,
+    channel_id: &str,
+    index_override: Option<&str>,
+) -> Result<()> {
     let query = serde_json::json!({
         "query": {
             "term": {
@@ -13,10 +16,9 @@ pub async fn delete_channel_by_id(client: &opensearch::OpenSearch, channel_id: &
         },
     });
 
+    let index = index_override.unwrap_or(SearchIndex::Channels.as_ref());
     let response = client
-        .delete_by_query(opensearch::DeleteByQueryParts::Index(&[
-            SearchIndex::Channels.as_ref(),
-        ]))
+        .delete_by_query(opensearch::DeleteByQueryParts::Index(&[index]))
         .body(query)
         .refresh(true) // Ensure the index reflects changes immediately
         .send()
@@ -53,12 +55,12 @@ pub async fn delete_channel_by_id(client: &opensearch::OpenSearch, channel_id: &
     Ok(())
 }
 
-/// Deletes a particular channel message with the specified channel_id and channel_message_id
 #[tracing::instrument(skip(client))]
 pub async fn delete_channel_message_by_id(
     client: &opensearch::OpenSearch,
     channel_id: &str,
     channel_message_id: &str,
+    index_override: Option<&str>,
 ) -> Result<()> {
     let query = serde_json::json!({
         "query": {
@@ -79,10 +81,9 @@ pub async fn delete_channel_message_by_id(
         }
     });
 
+    let index = index_override.unwrap_or(SearchIndex::Channels.as_ref());
     let response = client
-        .delete_by_query(opensearch::DeleteByQueryParts::Index(&[
-            SearchIndex::Channels.as_ref(),
-        ]))
+        .delete_by_query(opensearch::DeleteByQueryParts::Index(&[index]))
         .body(query)
         .refresh(true) // Ensure the index reflects changes immediately
         .send()

--- a/rust/cloud-storage/opensearch_client/src/delete/chat.rs
+++ b/rust/cloud-storage/opensearch_client/src/delete/chat.rs
@@ -2,9 +2,12 @@ use models_opensearch::SearchIndex;
 
 use crate::{Result, error::OpensearchClientError};
 
-/// Deletes all chat messages with the specified chat_id
 #[tracing::instrument(skip(client))]
-pub async fn delete_chat_by_id(client: &opensearch::OpenSearch, chat_id: &str) -> Result<()> {
+pub async fn delete_chat_by_id(
+    client: &opensearch::OpenSearch,
+    chat_id: &str,
+    index_override: Option<&str>,
+) -> Result<()> {
     let query = serde_json::json!({
         "query": {
             "term": {
@@ -13,10 +16,9 @@ pub async fn delete_chat_by_id(client: &opensearch::OpenSearch, chat_id: &str) -
         },
     });
 
+    let index = index_override.unwrap_or(SearchIndex::Chats.as_ref());
     let response = client
-        .delete_by_query(opensearch::DeleteByQueryParts::Index(&[
-            SearchIndex::Chats.as_ref()
-        ]))
+        .delete_by_query(opensearch::DeleteByQueryParts::Index(&[index]))
         .body(query)
         .refresh(true) // Ensure the index reflects changes immediately
         .send()
@@ -53,12 +55,12 @@ pub async fn delete_chat_by_id(client: &opensearch::OpenSearch, chat_id: &str) -
     Ok(())
 }
 
-/// Deletes a particular chat message with the specified chat_id and chat_message_id
 #[tracing::instrument(skip(client))]
 pub async fn delete_chat_message_by_id(
     client: &opensearch::OpenSearch,
     chat_id: &str,
     chat_message_id: &str,
+    index_override: Option<&str>,
 ) -> Result<()> {
     let query = serde_json::json!({
         "query": {
@@ -79,10 +81,9 @@ pub async fn delete_chat_message_by_id(
         }
     });
 
+    let index = index_override.unwrap_or(SearchIndex::Chats.as_ref());
     let response = client
-        .delete_by_query(opensearch::DeleteByQueryParts::Index(&[
-            SearchIndex::Chats.as_ref()
-        ]))
+        .delete_by_query(opensearch::DeleteByQueryParts::Index(&[index]))
         .body(query)
         .refresh(true) // Ensure the index reflects changes immediately
         .send()

--- a/rust/cloud-storage/opensearch_client/src/delete/chat.rs
+++ b/rust/cloud-storage/opensearch_client/src/delete/chat.rs
@@ -2,6 +2,7 @@ use models_opensearch::SearchIndex;
 
 use crate::{Result, error::OpensearchClientError};
 
+/// Deletes all chat messages with the specified chat_id
 #[tracing::instrument(skip(client))]
 pub async fn delete_chat_by_id(
     client: &opensearch::OpenSearch,
@@ -55,6 +56,7 @@ pub async fn delete_chat_by_id(
     Ok(())
 }
 
+/// Deletes a particular chat message with the specified chat_id and chat_message_id
 #[tracing::instrument(skip(client))]
 pub async fn delete_chat_message_by_id(
     client: &opensearch::OpenSearch,

--- a/rust/cloud-storage/opensearch_client/src/delete/document.rs
+++ b/rust/cloud-storage/opensearch_client/src/delete/document.rs
@@ -2,12 +2,14 @@ use models_opensearch::SearchIndex;
 
 use crate::{Result, error::OpensearchClientError};
 
+/// Deletes all document nodes with the specified document_id
 #[tracing::instrument(skip(client))]
 pub async fn delete_document_by_id(
     client: &opensearch::OpenSearch,
     document_id: &str,
     index_override: Option<&str>,
 ) -> Result<()> {
+    // First, search for all documents with the given document_id
     let query = serde_json::json!({
         "query": {
             "term": {

--- a/rust/cloud-storage/opensearch_client/src/delete/document.rs
+++ b/rust/cloud-storage/opensearch_client/src/delete/document.rs
@@ -2,13 +2,12 @@ use models_opensearch::SearchIndex;
 
 use crate::{Result, error::OpensearchClientError};
 
-/// Deletes all document nodes with the specified document_id
 #[tracing::instrument(skip(client))]
 pub async fn delete_document_by_id(
     client: &opensearch::OpenSearch,
     document_id: &str,
+    index_override: Option<&str>,
 ) -> Result<()> {
-    // First, search for all documents with the given document_id
     let query = serde_json::json!({
         "query": {
             "term": {
@@ -17,10 +16,9 @@ pub async fn delete_document_by_id(
         },
     });
 
+    let index = index_override.unwrap_or(SearchIndex::Documents.as_ref());
     let response = client
-        .delete_by_query(opensearch::DeleteByQueryParts::Index(&[
-            SearchIndex::Documents.as_ref(),
-        ]))
+        .delete_by_query(opensearch::DeleteByQueryParts::Index(&[index]))
         .body(query)
         .refresh(true) // Ensure the index reflects changes immediately
         .send()

--- a/rust/cloud-storage/opensearch_client/src/document.rs
+++ b/rust/cloud-storage/opensearch_client/src/document.rs
@@ -7,7 +7,7 @@ impl OpensearchClient {
     /// Inserts a document into the opensearch index
     #[tracing::instrument(skip(self))]
     pub async fn upsert_document(&self, upsert_document_args: &UpsertDocumentArgs) -> Result<()> {
-        upsert::document::upsert_document(&self.inner, upsert_document_args).await
+        upsert::document::upsert_document(&self.inner, upsert_document_args, None).await
     }
 
     /// Bulk upserts documents into the opensearch index
@@ -15,14 +15,19 @@ impl OpensearchClient {
     pub async fn bulk_upsert_documents(
         &self,
         documents: &[UpsertDocumentArgs],
+        index_override: Option<&str>,
     ) -> Result<upsert::BulkUpsertResult> {
-        upsert::document::bulk_upsert_documents(&self.inner, documents).await
+        upsert::document::bulk_upsert_documents(&self.inner, documents, index_override).await
     }
 
     /// Deletes a document from the opensearch document index
     #[tracing::instrument(skip(self))]
-    pub async fn delete_document(&self, document_id: &str) -> Result<()> {
-        delete::document::delete_document_by_id(&self.inner, document_id).await
+    pub async fn delete_document(
+        &self,
+        document_id: &str,
+        index_override: Option<&str>,
+    ) -> Result<()> {
+        delete::document::delete_document_by_id(&self.inner, document_id, index_override).await
     }
 
     #[tracing::instrument(skip(self))]

--- a/rust/cloud-storage/opensearch_client/src/upsert/call_record.rs
+++ b/rust/cloud-storage/opensearch_client/src/upsert/call_record.rs
@@ -24,13 +24,12 @@ pub struct UpsertCallRecordSegmentArgs {
 pub(crate) async fn upsert_call_record_segment(
     client: &opensearch::OpenSearch,
     args: &UpsertCallRecordSegmentArgs,
+    index_override: Option<&str>,
 ) -> Result<()> {
     let id = &args.transcript_id;
+    let index = index_override.unwrap_or(SearchIndex::CallRecords.as_ref());
     let response = client
-        .index(opensearch::IndexParts::IndexId(
-            SearchIndex::CallRecords.as_ref(),
-            id,
-        ))
+        .index(opensearch::IndexParts::IndexId(index, id))
         .body(args)
         .send()
         .await
@@ -66,6 +65,7 @@ pub(crate) async fn upsert_call_record_segment(
 pub(crate) async fn bulk_upsert_call_record_segments(
     client: &opensearch::OpenSearch,
     segments: &[UpsertCallRecordSegmentArgs],
+    index_override: Option<&str>,
 ) -> Result<BulkUpsertResult> {
     if segments.is_empty() {
         return Ok(BulkUpsertResult::default());
@@ -84,11 +84,6 @@ pub(crate) async fn bulk_upsert_call_record_segments(
         })?);
     }
 
-    super::bulk_upsert_to_index(
-        client,
-        SearchIndex::CallRecords.as_ref(),
-        bulk_body,
-        "bulk_upsert_call_record_segments",
-    )
-    .await
+    let index = index_override.unwrap_or(SearchIndex::CallRecords.as_ref());
+    super::bulk_upsert_to_index(client, index, bulk_body, "bulk_upsert_call_record_segments").await
 }

--- a/rust/cloud-storage/opensearch_client/src/upsert/channel_message.rs
+++ b/rust/cloud-storage/opensearch_client/src/upsert/channel_message.rs
@@ -22,14 +22,13 @@ pub struct UpsertChannelMessageArgs {
 pub(crate) async fn upsert_channel_message(
     client: &opensearch::OpenSearch,
     args: &UpsertChannelMessageArgs,
+    index_override: Option<&str>,
 ) -> Result<()> {
     let id = format!("{}:{}", args.channel_id, args.message_id);
+    let index = index_override.unwrap_or(SearchIndex::Channels.as_ref());
 
     let response = client
-        .index(opensearch::IndexParts::IndexId(
-            SearchIndex::Channels.as_ref(),
-            &id,
-        ))
+        .index(opensearch::IndexParts::IndexId(index, &id))
         .body(args)
         .send()
         .await

--- a/rust/cloud-storage/opensearch_client/src/upsert/chat_message.rs
+++ b/rust/cloud-storage/opensearch_client/src/upsert/chat_message.rs
@@ -28,13 +28,12 @@ pub struct UpsertChatMessageArgs {
 pub(crate) async fn upsert_chat_message(
     client: &opensearch::OpenSearch,
     args: &UpsertChatMessageArgs,
+    index_override: Option<&str>,
 ) -> Result<()> {
     let id = format!("{}:{}", args.chat_id, args.chat_message_id);
+    let index = index_override.unwrap_or(SearchIndex::Chats.as_ref());
     let response = client
-        .index(opensearch::IndexParts::IndexId(
-            SearchIndex::Chats.as_ref(),
-            &id,
-        ))
+        .index(opensearch::IndexParts::IndexId(index, &id))
         .body(args)
         .send()
         .await

--- a/rust/cloud-storage/opensearch_client/src/upsert/document.rs
+++ b/rust/cloud-storage/opensearch_client/src/upsert/document.rs
@@ -35,10 +35,10 @@ pub struct UpsertDocumentArgs {
     pub sub_type: Option<String>,
 }
 
-/// Process a single chunk of documents
 async fn bulk_upsert_single_chunk(
     client: &opensearch::OpenSearch,
     documents: &[UpsertDocumentArgs],
+    index_override: Option<&str>,
 ) -> Result<BulkUpsertResult> {
     let mut bulk_body = Vec::new();
 
@@ -60,13 +60,9 @@ async fn bulk_upsert_single_chunk(
         })?);
     }
 
-    let result = super::bulk_upsert_to_index(
-        client,
-        SearchIndex::Documents.as_ref(),
-        bulk_body,
-        "bulk_upsert_single_chunk",
-    )
-    .await?;
+    let index = index_override.unwrap_or(SearchIndex::Documents.as_ref());
+    let result =
+        super::bulk_upsert_to_index(client, index, bulk_body, "bulk_upsert_single_chunk").await?;
 
     tracing::trace!(
         chunk_total = documents.len(),
@@ -79,11 +75,11 @@ async fn bulk_upsert_single_chunk(
     Ok(result)
 }
 
-/// Bulk upsert documents to reduce version conflicts with automatic chunking
 #[tracing::instrument(skip(client, documents))]
 pub(crate) async fn bulk_upsert_documents(
     client: &opensearch::OpenSearch,
     documents: &[UpsertDocumentArgs],
+    index_override: Option<&str>,
 ) -> Result<BulkUpsertResult> {
     if documents.is_empty() {
         return Ok(BulkUpsertResult::default());
@@ -109,7 +105,7 @@ pub(crate) async fn bulk_upsert_documents(
             "processing chunk"
         );
 
-        match bulk_upsert_single_chunk(client, chunk).await {
+        match bulk_upsert_single_chunk(client, chunk, index_override).await {
             Ok(chunk_result) => {
                 overall_result.successful += chunk_result.successful;
                 overall_result.failed += chunk_result.failed;
@@ -146,13 +142,12 @@ pub(crate) async fn bulk_upsert_documents(
 pub(crate) async fn upsert_document(
     client: &opensearch::OpenSearch,
     args: &UpsertDocumentArgs,
+    index_override: Option<&str>,
 ) -> Result<()> {
     let id = format!("{}:{}", args.document_id, args.node_id);
+    let index = index_override.unwrap_or(SearchIndex::Documents.as_ref());
     let response = client
-        .index(opensearch::IndexParts::IndexId(
-            SearchIndex::Documents.as_ref(),
-            &id,
-        ))
+        .index(opensearch::IndexParts::IndexId(index, &id))
         .body(args)
         .send()
         .await

--- a/rust/cloud-storage/opensearch_client/src/upsert/document.rs
+++ b/rust/cloud-storage/opensearch_client/src/upsert/document.rs
@@ -35,6 +35,7 @@ pub struct UpsertDocumentArgs {
     pub sub_type: Option<String>,
 }
 
+/// Process a single chunk of documents
 async fn bulk_upsert_single_chunk(
     client: &opensearch::OpenSearch,
     documents: &[UpsertDocumentArgs],
@@ -75,6 +76,7 @@ async fn bulk_upsert_single_chunk(
     Ok(result)
 }
 
+/// Bulk upsert documents to reduce version conflicts with automatic chunking
 #[tracing::instrument(skip(client, documents))]
 pub(crate) async fn bulk_upsert_documents(
     client: &opensearch::OpenSearch,

--- a/rust/cloud-storage/search_processing_service/src/api/internal/delete_document.rs
+++ b/rust/cloud-storage/search_processing_service/src/api/internal/delete_document.rs
@@ -19,7 +19,7 @@ pub async fn handler(
     tracing::info!("delete document request initiated");
 
     ctx.opensearch_client
-        .delete_document(&document_id)
+        .delete_document(&document_id, None)
         .await
         .map_err(|e| {
             tracing::error!(error=?e, "failed to delete document");

--- a/rust/cloud-storage/search_processing_service/src/api/internal/extract_sync.rs
+++ b/rust/cloud-storage/search_processing_service/src/api/internal/extract_sync.rs
@@ -41,6 +41,7 @@ fn documents_to_messages(documents: Vec<SyncDocument>) -> Vec<SearchQueueMessage
                 // change
                 file_type: doc.file_type,
                 document_version_id,
+                index_override: None,
             })
         })
         .collect()

--- a/rust/cloud-storage/search_processing_service/src/domain/models.rs
+++ b/rust/cloud-storage/search_processing_service/src/domain/models.rs
@@ -109,7 +109,6 @@ pub struct DocumentBackfillRequest {
 pub struct EmailBackfillRequest {
     /// Only backfill threads updated at or after this instant.
     pub since: Option<DateTime<Utc>>,
-    /// Override the OpenSearch target index for upserts (e.g. blue/green swap).
     pub index_override: Option<String>,
     /// Number of thread ids grouped into each SQS batch message. `None` uses
     /// the adapter's default.

--- a/rust/cloud-storage/search_processing_service/src/domain/models.rs
+++ b/rust/cloud-storage/search_processing_service/src/domain/models.rs
@@ -63,6 +63,8 @@ impl DeletionFilter {
 #[serde(default)]
 pub struct CallBackfillRequest {
     pub call_ids: Vec<String>,
+    /// Override the OpenSearch target index for upserts (e.g. blue/green swap).
+    pub index_override: Option<String>,
 }
 
 /// Chat-message backfill filter. Empty vectors mean "all messages for every

--- a/rust/cloud-storage/search_processing_service/src/domain/models.rs
+++ b/rust/cloud-storage/search_processing_service/src/domain/models.rs
@@ -93,6 +93,8 @@ pub struct DocumentBackfillRequest {
     pub created_after: Option<DateTime<Utc>>,
     pub created_before: Option<DateTime<Utc>>,
     pub deletion_filter: DeletionFilter,
+    /// Override the OpenSearch target index for upserts (e.g. blue/green swap).
+    pub index_override: Option<String>,
 }
 
 /// Email-thread backfill filter.

--- a/rust/cloud-storage/search_processing_service/src/domain/models.rs
+++ b/rust/cloud-storage/search_processing_service/src/domain/models.rs
@@ -73,6 +73,8 @@ pub struct ChatBackfillRequest {
     pub chat_ids: Vec<String>,
     pub user_ids: Vec<String>,
     pub deletion_filter: DeletionFilter,
+    /// Override the OpenSearch target index for upserts (e.g. blue/green swap).
+    pub index_override: Option<String>,
 }
 
 /// Channel-message backfill filter. No scoping knobs yet — reserved so adding

--- a/rust/cloud-storage/search_processing_service/src/domain/models.rs
+++ b/rust/cloud-storage/search_processing_service/src/domain/models.rs
@@ -81,6 +81,8 @@ pub struct ChatBackfillRequest {
 #[serde(default)]
 pub struct ChannelBackfillRequest {
     pub deletion_filter: DeletionFilter,
+    /// Override the OpenSearch target index for upserts (e.g. blue/green swap).
+    pub index_override: Option<String>,
 }
 
 /// Document backfill filter. Every field is additive — all `None` means "every

--- a/rust/cloud-storage/search_processing_service/src/domain/service/test.rs
+++ b/rust/cloud-storage/search_processing_service/src/domain/service/test.rs
@@ -98,6 +98,7 @@ impl SearchEventPublisher for ExplodingPublisher {
 fn msg(id: &str) -> SearchQueueMessage {
     SearchQueueMessage::CallRecord(CallRecordMessage {
         call_id: id.to_string(),
+        index_override: None,
     })
 }
 

--- a/rust/cloud-storage/search_processing_service/src/outbound/source.rs
+++ b/rust/cloud-storage/search_processing_service/src/outbound/source.rs
@@ -115,6 +115,7 @@ impl BackfillSource for PgBackfillSource {
                     user_id: chat.user_id,
                     created_at: chat.created_at,
                     updated_at: chat.updated_at,
+                    index_override: req.index_override.clone(),
                 })
             })
             .collect();

--- a/rust/cloud-storage/search_processing_service/src/outbound/source.rs
+++ b/rust/cloud-storage/search_processing_service/src/outbound/source.rs
@@ -178,10 +178,12 @@ impl BackfillSource for PgBackfillSource {
         let messages: Vec<SearchQueueMessage> = batch
             .iter()
             .map(|d| {
+                let mut msg: sqs_client::search::document::SearchExtractorMessage = d.into();
+                msg.index_override.clone_from(&req.index_override);
                 if d.file_type == FileType::Md {
-                    SearchQueueMessage::ExtractSync(d.into())
+                    SearchQueueMessage::ExtractSync(msg)
                 } else {
-                    SearchQueueMessage::ExtractDocumentText(d.into())
+                    SearchQueueMessage::ExtractDocumentText(msg)
                 }
             })
             .collect();

--- a/rust/cloud-storage/search_processing_service/src/outbound/source.rs
+++ b/rust/cloud-storage/search_processing_service/src/outbound/source.rs
@@ -52,6 +52,7 @@ impl BackfillSource for PgBackfillSource {
                 .map(|id| {
                     SearchQueueMessage::CallRecord(CallRecordMessage {
                         call_id: id.clone(),
+                        index_override: req.index_override.clone(),
                     })
                 })
                 .collect();
@@ -76,6 +77,7 @@ impl BackfillSource for PgBackfillSource {
             .map(|r| {
                 SearchQueueMessage::CallRecord(CallRecordMessage {
                     call_id: r.call_id.to_string(),
+                    index_override: req.index_override.clone(),
                 })
             })
             .collect();

--- a/rust/cloud-storage/search_processing_service/src/outbound/source.rs
+++ b/rust/cloud-storage/search_processing_service/src/outbound/source.rs
@@ -146,6 +146,7 @@ impl BackfillSource for PgBackfillSource {
                 SearchQueueMessage::ChannelMessageUpdate(ChannelMessageUpdate {
                     channel_id: channel_id.to_string(),
                     message_id: message_id.to_string(),
+                    index_override: req.index_override.clone(),
                 })
             })
             .collect();

--- a/rust/cloud-storage/search_processing_service/src/process/call.rs
+++ b/rust/cloud-storage/search_processing_service/src/process/call.rs
@@ -56,7 +56,7 @@ pub async fn process_call_record(
         .collect::<Result<Vec<_>, _>>()?;
 
     let result = opensearch_client
-        .bulk_upsert_call_record_segments(&segments)
+        .bulk_upsert_call_record_segments(&segments, message.index_override.as_deref())
         .await
         .context("failed to bulk upsert call record segments")?;
 
@@ -77,11 +77,14 @@ pub async fn process_remove_call_record(
     opensearch_client: &OpensearchClient,
     message: &RemoveCallRecord,
 ) -> anyhow::Result<()> {
+    let index_override = message.index_override.as_deref();
     if let Some(call_id) = &message.call_id {
-        opensearch_client.delete_call_record(call_id).await?;
+        opensearch_client
+            .delete_call_record(call_id, index_override)
+            .await?;
     } else {
         opensearch_client
-            .delete_call_records_by_channel(&message.channel_id)
+            .delete_call_records_by_channel(&message.channel_id, index_override)
             .await?;
     }
     Ok(())

--- a/rust/cloud-storage/search_processing_service/src/process/channel.rs
+++ b/rust/cloud-storage/search_processing_service/src/process/channel.rs
@@ -24,10 +24,11 @@ pub async fn process_channel_message_update(
         .await
         .context("unable to get channel message")?;
 
+    let index_override = message.index_override.as_deref();
     if channel_message_info.channel_message.deleted_at.is_some() {
         tracing::trace!("channel message is deleted, removing from search index");
         opensearch_client
-            .delete_channel_message(&message.channel_id, &message.message_id)
+            .delete_channel_message(&message.channel_id, &message.message_id, index_override)
             .await?;
         return Ok(());
     }
@@ -57,7 +58,7 @@ pub async fn process_channel_message_update(
     };
 
     opensearch_client
-        .upsert_channel_message(&upsert_channel_message_args)
+        .upsert_channel_message(&upsert_channel_message_args, index_override)
         .await?;
 
     Ok(())
@@ -67,14 +68,15 @@ pub async fn process_remove_channel_message(
     opensearch_client: &OpensearchClient,
     message: &RemoveChannelMessage,
 ) -> anyhow::Result<()> {
+    let index_override = message.index_override.as_deref();
     if let Some(message_id) = &message.message_id {
         opensearch_client
-            .delete_channel_message(&message.channel_id, message_id)
+            .delete_channel_message(&message.channel_id, message_id, index_override)
             .await?;
     } else {
         tracing::trace!("message id is empty, deleting channel");
         opensearch_client
-            .delete_channel(&message.channel_id)
+            .delete_channel(&message.channel_id, index_override)
             .await?;
     }
 

--- a/rust/cloud-storage/search_processing_service/src/process/chat.rs
+++ b/rust/cloud-storage/search_processing_service/src/process/chat.rs
@@ -23,12 +23,14 @@ pub async fn insert_chat_message(
         return Ok(());
     };
 
+    let index_override = chat_message.index_override.as_deref();
     if info.deleted_at.is_some() {
         tracing::trace!("chat is deleted, removing message from search index");
         opensearch_client
             .delete_chat_message(
                 chat_message.chat_id.as_str(),
                 chat_message.message_id.as_str(),
+                index_override,
             )
             .await
             .context("failed to delete chat message from search")?;
@@ -36,16 +38,19 @@ pub async fn insert_chat_message(
     }
 
     opensearch_client
-        .upsert_chat_message(&UpsertChatMessageArgs {
-            chat_id: chat_message.chat_id.clone(),
-            chat_message_id: chat_message.message_id.clone(),
-            user_id: chat_message.user_id.clone(),
-            created_at_seconds: EpochSeconds::new(chat_message.created_at.timestamp())?,
-            updated_at_seconds: EpochSeconds::new(chat_message.updated_at.timestamp())?,
-            title: info.name,
-            content: info.content,
-            role: info.role,
-        })
+        .upsert_chat_message(
+            &UpsertChatMessageArgs {
+                chat_id: chat_message.chat_id.clone(),
+                chat_message_id: chat_message.message_id.clone(),
+                user_id: chat_message.user_id.clone(),
+                created_at_seconds: EpochSeconds::new(chat_message.created_at.timestamp())?,
+                updated_at_seconds: EpochSeconds::new(chat_message.updated_at.timestamp())?,
+                title: info.name,
+                content: info.content,
+                role: info.role,
+            },
+            index_override,
+        )
         .await
         .context("failed to upsert chat message")?;
 
@@ -58,15 +63,16 @@ pub async fn remove_chat_message(
     opensearch_client: &OpensearchClient,
     remove_message: &RemoveChatMessage,
 ) -> anyhow::Result<()> {
+    let index_override = remove_message.index_override.as_deref();
     if let Some(message_id) = remove_message.message_id.as_ref() {
         tracing::trace!("deleting chat message");
         opensearch_client
-            .delete_chat_message(remove_message.chat_id.as_str(), message_id)
+            .delete_chat_message(remove_message.chat_id.as_str(), message_id, index_override)
             .await?;
     } else {
         tracing::trace!("deleting chat");
         opensearch_client
-            .delete_chat(remove_message.chat_id.as_str())
+            .delete_chat(remove_message.chat_id.as_str(), index_override)
             .await?;
     }
 

--- a/rust/cloud-storage/search_processing_service/src/process/document/mod.rs
+++ b/rust/cloud-storage/search_processing_service/src/process/document/mod.rs
@@ -11,7 +11,7 @@ pub async fn process_remove_message(
     remove_message: &DocumentId,
 ) -> anyhow::Result<()> {
     opensearch_client
-        .delete_document(remove_message.document_id.as_str())
+        .delete_document(remove_message.document_id.as_str(), None)
         .await?;
 
     Ok(())

--- a/rust/cloud-storage/search_processing_service/src/process/document/raw_document.rs
+++ b/rust/cloud-storage/search_processing_service/src/process/document/raw_document.rs
@@ -26,6 +26,8 @@ async fn upsert_document(
     upserts: Vec<UpsertDocumentArgs>,
 ) -> anyhow::Result<()> {
     let index_override = search_extractor_message.index_override.as_deref();
+    // Delete existing documents for the document id
+    // This ensures we replace any old nodes with new ones for editable files
     match search_extractor_message.file_type {
         FileType::Md | FileType::Canvas => {
             tracing::debug!("deleting existing search results");
@@ -45,6 +47,7 @@ async fn upsert_document(
     if !results.errors.is_empty() {
         tracing::error!(errors=?results.errors, "bulk upsert failed");
 
+        // delete document that failed to upsert
         opensearch_client
             .delete_document(&search_extractor_message.document_id, index_override)
             .await

--- a/rust/cloud-storage/search_processing_service/src/process/document/raw_document.rs
+++ b/rust/cloud-storage/search_processing_service/src/process/document/raw_document.rs
@@ -25,13 +25,12 @@ async fn upsert_document(
     search_extractor_message: &SearchExtractorMessage,
     upserts: Vec<UpsertDocumentArgs>,
 ) -> anyhow::Result<()> {
-    // Delete existing documents for the document id
-    // This ensures we replace any old nodes with new ones for editable files
+    let index_override = search_extractor_message.index_override.as_deref();
     match search_extractor_message.file_type {
         FileType::Md | FileType::Canvas => {
             tracing::debug!("deleting existing search results");
             opensearch_client
-                .delete_document(&search_extractor_message.document_id)
+                .delete_document(&search_extractor_message.document_id, index_override)
                 .await
                 .context("unable to delete existing search results")?;
         }
@@ -39,16 +38,15 @@ async fn upsert_document(
     }
 
     let results = opensearch_client
-        .bulk_upsert_documents(&upserts)
+        .bulk_upsert_documents(&upserts, index_override)
         .await
         .context("unable to bulk upsert documents in opensearch")?;
 
     if !results.errors.is_empty() {
         tracing::error!(errors=?results.errors, "bulk upsert failed");
 
-        // delete document that failed to upsert
         opensearch_client
-            .delete_document(&search_extractor_message.document_id)
+            .delete_document(&search_extractor_message.document_id, index_override)
             .await
             .context("failed to delete document for failed bulk upsert")?;
 
@@ -84,7 +82,10 @@ pub async fn update_search_with_raw_document(
         DocumentInfo::Removable => {
             tracing::trace!("document is deleted or missing, removing from search index");
             opensearch_client
-                .delete_document(&search_extractor_message.document_id)
+                .delete_document(
+                    &search_extractor_message.document_id,
+                    search_extractor_message.index_override.as_deref(),
+                )
                 .await
                 .context("failed to delete document from search index")?;
             return Ok(());
@@ -302,7 +303,10 @@ pub async fn update_search_with_sync_document(
         DocumentInfo::Removable => {
             tracing::trace!("document is deleted or missing, removing from search index");
             opensearch_client
-                .delete_document(&search_extractor_message.document_id)
+                .delete_document(
+                    &search_extractor_message.document_id,
+                    search_extractor_message.index_override.as_deref(),
+                )
                 .await
                 .context("failed to delete document from search index")?;
             return Ok(());

--- a/rust/cloud-storage/search_processing_service/src/process/mod.rs
+++ b/rust/cloud-storage/search_processing_service/src/process/mod.rs
@@ -132,6 +132,7 @@ mod tests {
                 document_id: "document_id".to_string(),
                 file_type: FileType::Pdf,
                 document_version_id: None,
+                index_override: None,
             }
         );
 
@@ -150,6 +151,7 @@ mod tests {
                 document_id: "document_id".to_string(),
                 file_type: FileType::Docx,
                 document_version_id: Some("1".to_string()),
+                index_override: None,
             }
         );
 
@@ -177,6 +179,7 @@ mod tests {
                 document_id: "253880fb-77d4-4e6c-856d-9f52c2d9a8b0".to_string(),
                 file_type: FileType::Md,
                 document_version_id: Some("565533".to_string()),
+                index_override: None,
             })
         );
 

--- a/rust/cloud-storage/search_upload_handler/src/handler.rs
+++ b/rust/cloud-storage/search_upload_handler/src/handler.rs
@@ -62,6 +62,7 @@ pub async fn handler(
         document_id: document_id.to_string(),
         document_version_id: document_key.version_id_string(),
         file_type,
+        index_override: None,
     };
 
     // All other file types are to be sent to the search text extractor queue

--- a/rust/cloud-storage/sqs_client/src/search/call.rs
+++ b/rust/cloud-storage/sqs_client/src/search/call.rs
@@ -1,6 +1,9 @@
 #[derive(serde::Serialize, serde::Deserialize, PartialEq, Eq, Debug)]
 pub struct CallRecordMessage {
     pub call_id: String,
+    /// Optional override for the target OpenSearch index
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub index_override: Option<String>,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, PartialEq, Eq, Debug)]
@@ -8,4 +11,7 @@ pub struct RemoveCallRecord {
     pub channel_id: String,
     /// `None` removes every call record for `channel_id`.
     pub call_id: Option<String>,
+    /// Optional override for the target OpenSearch index
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub index_override: Option<String>,
 }

--- a/rust/cloud-storage/sqs_client/src/search/channel.rs
+++ b/rust/cloud-storage/sqs_client/src/search/channel.rs
@@ -4,6 +4,9 @@ pub struct ChannelMessageUpdate {
     pub channel_id: String,
     /// The message id
     pub message_id: String,
+    /// Optional override for the target OpenSearch index
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub index_override: Option<String>,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, PartialEq, Eq, Debug)]
@@ -12,4 +15,7 @@ pub struct RemoveChannelMessage {
     pub channel_id: String,
     /// The message id
     pub message_id: Option<String>,
+    /// Optional override for the target OpenSearch index
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub index_override: Option<String>,
 }

--- a/rust/cloud-storage/sqs_client/src/search/chat.rs
+++ b/rust/cloud-storage/sqs_client/src/search/chat.rs
@@ -10,6 +10,9 @@ pub struct ChatMessage {
     pub user_id: String,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+    /// Optional override for the target OpenSearch index
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub index_override: Option<String>,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq, Eq)]
@@ -18,4 +21,7 @@ pub struct RemoveChatMessage {
     pub chat_id: String,
     /// The message id to remove, if None then all messages for the chat will be removed
     pub message_id: Option<String>,
+    /// Optional override for the target OpenSearch index
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub index_override: Option<String>,
 }

--- a/rust/cloud-storage/sqs_client/src/search/document.rs
+++ b/rust/cloud-storage/sqs_client/src/search/document.rs
@@ -23,6 +23,9 @@ pub struct SearchExtractorMessage {
     /// NOTE: this will become deprecated once we remove document versioning
     #[serde(skip_serializing_if = "Option::is_none")]
     pub document_version_id: Option<String>,
+    /// Optional override for the target OpenSearch index (e.g. "documents_v1" for migration backfills)
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub index_override: Option<String>,
 }
 
 impl<'a> From<&'a BackfillSearchDocumentInformation> for SearchExtractorMessage {
@@ -34,6 +37,7 @@ impl<'a> From<&'a BackfillSearchDocumentInformation> for SearchExtractorMessage 
                     document_id: value.document_id.clone(),
                     file_type: FileType::Pdf, // Explicitly override the file type to pdf since we are looking for the converted file
                     document_version_id: Some(CONVERTED_DOCUMENT_FILE_NAME.to_string()),
+                    index_override: None,
                 }
             }
             _ => SearchExtractorMessage {
@@ -41,6 +45,7 @@ impl<'a> From<&'a BackfillSearchDocumentInformation> for SearchExtractorMessage 
                 document_id: value.document_id.clone(),
                 file_type: value.file_type,
                 document_version_id: Some(value.document_version_id.to_string()),
+                index_override: None,
             },
         }
     }


### PR DESCRIPTION
Adds an optional `index_override` field to every backfill request type (`Document`, `Channel`, `Chat`, `Call` — `Email` already had it) and threads it through the corresponding `SearchExtractorMessage`-style SQS messages, the SPS process handlers, and the opensearch_client upsert/delete paths. This lets a re-extraction be directed at a non-canonical index (e.g. `documents_v1`) for blue/green migrations without disturbing the live alias.

One commit per entity type for reviewability.
