### PR TITLE
feat(lexical-service): endpoint for md -> snapshot conversion

### DIFF
--- a/js/app/packages/block-md/definition.ts
+++ b/js/app/packages/block-md/definition.ts
@@ -5,11 +5,11 @@ import {
   loadResult,
 } from '@core/block';
 import { createLoroManager } from '@core/collab/manager';
-import { rawMarkdownStateToLoroSnapshot } from '@lexical-core/markdown-loro-snapshot';
 import { serializedStateFromBlob } from '@core/component/LexicalMarkdown/collaboration/utils';
 import { ENABLE_MARKDOWN_LIVE_COLLABORATION } from '@core/constant/featureFlags';
 import { isErr, ok } from '@core/util/maybeResult';
 import { MARKDOWN_LORO_SCHEMA } from '@lexical-core/markdown-loro-schema';
+import { rawMarkdownStateToLoroSnapshot } from '@lexical-core/markdown-loro-snapshot';
 import { storageServiceClient } from '@service-storage/client';
 import { fetchBinary } from '@service-storage/util/fetchBinary';
 import { makeFileFromBlob } from '@service-storage/util/makeFileFromBlob';

--- a/js/app/packages/block-md/definition.ts
+++ b/js/app/packages/block-md/definition.ts
@@ -5,7 +5,7 @@ import {
   loadResult,
 } from '@core/block';
 import { createLoroManager } from '@core/collab/manager';
-import { rawStateToLoroSnapshot } from '@core/collab/utils';
+import { rawMarkdownStateToLoroSnapshot } from '@lexical-core/markdown-loro-snapshot';
 import { serializedStateFromBlob } from '@core/component/LexicalMarkdown/collaboration/utils';
 import { ENABLE_MARKDOWN_LIVE_COLLABORATION } from '@core/constant/featureFlags';
 import { isErr, ok } from '@core/util/maybeResult';
@@ -87,10 +87,7 @@ const migrateToSyncService = async (documentId: string) => {
     return LoadErrors.INVALID;
   }
 
-  const snapshot = await rawStateToLoroSnapshot(
-    MARKDOWN_LORO_SCHEMA,
-    state as any
-  );
+  const snapshot = await rawMarkdownStateToLoroSnapshot(state as any);
 
   if (!snapshot) {
     console.error('Failed to create snapshot from blob');

--- a/js/app/packages/core/collab/utils.ts
+++ b/js/app/packages/core/collab/utils.ts
@@ -1,44 +1,6 @@
-import type { InferType } from '@loro-mirror/packages/core/src';
 import type { LoroDoc } from 'loro-crdt';
-import { createLoroDoc, createMirror } from './manager';
-import type { GenericRootSchema, RawUpdate } from './shared';
-
-// HACK: hack to get around async nature of mirror sync,
-// which we have no control over
-async function awaitMirrorSync() {
-  await Promise.resolve();
-  await Promise.resolve();
-  await Promise.resolve();
-}
-
-/**
- * Converts a raw state to a loro snapshot
- * @param schema - The schema to use for the snapshot
- * @param state - The state to convert to a snapshot
- * @returns A promise that resolves to the snapshot or undefined if it fails
- */
-export async function rawStateToLoroSnapshot<
-  S extends GenericRootSchema = GenericRootSchema,
->(schema: S, state: InferType<S>): Promise<Uint8Array | undefined> {
-  const loroDoc = createLoroDoc();
-  const mirror = createMirror(loroDoc, schema);
-
-  mirror.setState(state);
-
-  mirror.sync();
-  await awaitMirrorSync();
-
-  let snapshot: Uint8Array | undefined;
-
-  try {
-    snapshot = loroDoc.export({ mode: 'snapshot' });
-  } catch (e) {
-    console.error('Failed to export snapshot', e);
-    return undefined;
-  }
-
-  return snapshot;
-}
+import { createLoroDoc } from './manager';
+import type { RawUpdate } from './shared';
 
 export function loroDocFromSnapshot(snapshot: RawUpdate): LoroDoc {
   const loroDoc = createLoroDoc();

--- a/js/app/packages/core/util/create.ts
+++ b/js/app/packages/core/util/create.ts
@@ -1,14 +1,13 @@
 import { DEFAULT_CHAT_NAME } from '@block-chat/definition';
 import type { CodeFileExtension } from '@block-code/util/languageSupport';
-import { rawStateToLoroSnapshot } from '@core/collab/utils';
 import { createMarkdownStateFromContent } from '@core/component/LexicalMarkdown/collaboration/utils';
+import { rawMarkdownStateToLoroSnapshot } from '@lexical-core/markdown-loro-snapshot';
 import {
   PROPERTY_OPTION_IDS,
   SYSTEM_PROPERTY_IDS,
 } from '@core/component/Properties/constants';
 import { PaywallKey, usePaywallState } from '@core/constant/PaywallState';
 import { isNativeMobilePlatform } from '@core/mobile/isNativeMobilePlatform';
-import { MARKDOWN_LORO_SCHEMA } from '@lexical-core/markdown-loro-schema';
 import {
   authKeys,
   invalidateUserQuota,
@@ -62,8 +61,7 @@ export async function createMarkdownFile(
   const emptyMarkdownState = await createMarkdownStateFromContent(
     args?.content
   );
-  const snapshot = await rawStateToLoroSnapshot(
-    MARKDOWN_LORO_SCHEMA,
+  const snapshot = await rawMarkdownStateToLoroSnapshot(
     emptyMarkdownState as any
   );
   const fakeSha = fakeSha256();
@@ -118,10 +116,7 @@ export async function createTask(
 ): Promise<string | undefined> {
   // Convert content to loro snapshot for sync service
   const markdownState = await createMarkdownStateFromContent(args?.content);
-  const snapshot = await rawStateToLoroSnapshot(
-    MARKDOWN_LORO_SCHEMA,
-    markdownState as any
-  );
+  const snapshot = await rawMarkdownStateToLoroSnapshot(markdownState as any);
 
   if (!snapshot) return;
 

--- a/js/app/packages/core/util/create.ts
+++ b/js/app/packages/core/util/create.ts
@@ -1,13 +1,13 @@
 import { DEFAULT_CHAT_NAME } from '@block-chat/definition';
 import type { CodeFileExtension } from '@block-code/util/languageSupport';
 import { createMarkdownStateFromContent } from '@core/component/LexicalMarkdown/collaboration/utils';
-import { rawMarkdownStateToLoroSnapshot } from '@lexical-core/markdown-loro-snapshot';
 import {
   PROPERTY_OPTION_IDS,
   SYSTEM_PROPERTY_IDS,
 } from '@core/component/Properties/constants';
 import { PaywallKey, usePaywallState } from '@core/constant/PaywallState';
 import { isNativeMobilePlatform } from '@core/mobile/isNativeMobilePlatform';
+import { rawMarkdownStateToLoroSnapshot } from '@lexical-core/markdown-loro-snapshot';
 import {
   authKeys,
   invalidateUserQuota,

--- a/js/app/packages/queries/storage/instructions-md.ts
+++ b/js/app/packages/queries/storage/instructions-md.ts
@@ -1,11 +1,11 @@
 import { createMarkdownStateFromContent } from '@core/component/LexicalMarkdown/collaboration/utils';
-import { rawMarkdownStateToLoroSnapshot } from '@lexical-core/markdown-loro-snapshot';
 import { createLexicalWrapper } from '@core/component/LexicalMarkdown/context/LexicalWrapperContext';
 import {
   getTextContent,
   initializeEditorWithState,
 } from '@core/component/LexicalMarkdown/utils';
 import { isOk } from '@core/util/maybeResult';
+import { rawMarkdownStateToLoroSnapshot } from '@lexical-core/markdown-loro-snapshot';
 import { storageServiceClient } from '@service-storage/client';
 import { syncServiceClient } from '@service-sync/client';
 import { useQuery } from '@tanstack/solid-query';

--- a/js/app/packages/queries/storage/instructions-md.ts
+++ b/js/app/packages/queries/storage/instructions-md.ts
@@ -1,12 +1,11 @@
-import { rawStateToLoroSnapshot } from '@core/collab/utils';
 import { createMarkdownStateFromContent } from '@core/component/LexicalMarkdown/collaboration/utils';
+import { rawMarkdownStateToLoroSnapshot } from '@lexical-core/markdown-loro-snapshot';
 import { createLexicalWrapper } from '@core/component/LexicalMarkdown/context/LexicalWrapperContext';
 import {
   getTextContent,
   initializeEditorWithState,
 } from '@core/component/LexicalMarkdown/utils';
 import { isOk } from '@core/util/maybeResult';
-import { MARKDOWN_LORO_SCHEMA } from '@lexical-core/markdown-loro-schema';
 import { storageServiceClient } from '@service-storage/client';
 import { syncServiceClient } from '@service-sync/client';
 import { useQuery } from '@tanstack/solid-query';
@@ -104,8 +103,7 @@ export function useCreateInstructionsMd() {
   return async () => {
     const emptyMarkdownState = await createMarkdownStateFromContent(undefined);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const snapshot = await rawStateToLoroSnapshot(
-      MARKDOWN_LORO_SCHEMA,
+    const snapshot = await rawMarkdownStateToLoroSnapshot(
       emptyMarkdownState as any
     );
     if (!snapshot) return;

--- a/js/bun.lock
+++ b/js/bun.lock
@@ -288,6 +288,7 @@
       "version": "0.2.2",
       "dependencies": {
         "@lexical/code": "0.32.1",
+        "@lexical/headless": "0.32.1",
         "@lexical/link": "0.32.1",
         "@lexical/list": "0.32.1",
         "@lexical/mark": "0.32.1",
@@ -296,6 +297,7 @@
         "@lexical/table": "0.32.1",
         "@lexical/utils": "0.32.1",
         "lexical": "0.32.1",
+        "loro-crdt": "1.5.9",
         "nanoid": "^5.1.5",
       },
     },
@@ -319,6 +321,7 @@
         "chanfana": "^3.3.0",
         "hono": "^4.6.20",
         "lexical": "0.32.1",
+        "loro-crdt": "1.5.9",
         "nanoid": "^5.1.5",
         "zod": "^4.3.6",
       },

--- a/js/lexical-core/index.ts
+++ b/js/lexical-core/index.ts
@@ -34,4 +34,5 @@ export * from './plugins/nodeIdPlugin';
 export * from './plugins/peerIdPlugin';
 
 export * from './transformers';
+export * from './utils/markdown-state';
 export * from './utils/mentions';

--- a/js/lexical-core/markdown-loro-snapshot.ts
+++ b/js/lexical-core/markdown-loro-snapshot.ts
@@ -1,0 +1,51 @@
+import { Mirror, type InferType } from '../loro-mirror/packages/core/src';
+import { LoroDoc } from 'loro-crdt';
+import type { SerializedEditorState } from 'lexical';
+import { MARKDOWN_LORO_SCHEMA } from './markdown-loro-schema';
+import { markdownToSerializedEditorStateWithIds } from './utils/markdown-state';
+
+// HACK: hack to get around async nature of mirror sync,
+// which we have no control over. Keep this in sync with app/packages/core/collab/utils.ts.
+async function awaitMirrorSync() {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+export async function rawMarkdownStateToLoroSnapshot(
+  state: InferType<typeof MARKDOWN_LORO_SCHEMA>
+): Promise<Uint8Array | undefined> {
+  const loroDoc = new LoroDoc();
+  loroDoc.setRecordTimestamp(true);
+
+  const mirror = new Mirror({
+    doc: loroDoc,
+    schema: MARKDOWN_LORO_SCHEMA,
+  });
+
+  mirror.setState(state);
+  mirror.sync();
+  await awaitMirrorSync();
+
+  try {
+    return loroDoc.export({ mode: 'snapshot' });
+  } catch (e) {
+    console.error('Failed to export snapshot', e);
+    return undefined;
+  }
+}
+
+export function markdownToSerializedEditorState(
+  markdown: string
+): SerializedEditorState {
+  return markdownToSerializedEditorStateWithIds(
+    markdown
+  ) as SerializedEditorState;
+}
+
+export async function markdownToLoroSnapshot(
+  markdown: string
+): Promise<Uint8Array | undefined> {
+  const state = markdownToSerializedEditorState(markdown);
+  return rawMarkdownStateToLoroSnapshot(state as any);
+}

--- a/js/lexical-core/package.json
+++ b/js/lexical-core/package.json
@@ -9,7 +9,9 @@
   "dependencies": {
     "nanoid": "^5.1.5",
     "lexical": "0.32.1",
+    "loro-crdt": "1.5.9",
     "@lexical/code": "0.32.1",
+    "@lexical/headless": "0.32.1",
     "@lexical/link": "0.32.1",
     "@lexical/list": "0.32.1",
     "@lexical/mark": "0.32.1",

--- a/js/lexical-core/utils/markdown-state.ts
+++ b/js/lexical-core/utils/markdown-state.ts
@@ -1,0 +1,46 @@
+import { createHeadlessEditor } from '@lexical/headless';
+import { $convertFromMarkdownString } from '@lexical/markdown';
+import type { SerializedEditorState } from 'lexical';
+import { NodeReplacements, SupportedNodeTypes } from '../node-list';
+import {
+  $updateAllNodeIds,
+  type NodeIdMappings,
+} from '../plugins/nodeIdPlugin';
+import { ALL_TRANSFORMERS } from '../transformers';
+
+function createNodeIdMappings(): NodeIdMappings {
+  return {
+    idToNodeKeyMap: new Map(),
+    nodeKeyToIdMap: new Map(),
+  };
+}
+
+/**
+ * Converts markdown to a serialized Lexical editor state and assigns durable
+ * node ids to every node. This is the headless equivalent of the markdown block
+ * migration path used by the app.
+ */
+export function markdownToSerializedEditorStateWithIds(
+  markdown: string
+): SerializedEditorState {
+  const editor = createHeadlessEditor({
+    nodes: [...SupportedNodeTypes, ...NodeReplacements],
+  });
+  const mappings = createNodeIdMappings();
+
+  editor.update(
+    () => {
+      $convertFromMarkdownString(markdown, ALL_TRANSFORMERS);
+    },
+    { discrete: true }
+  );
+
+  editor.update(
+    () => {
+      $updateAllNodeIds(mappings);
+    },
+    { discrete: true }
+  );
+
+  return editor.getEditorState().toJSON();
+}

--- a/js/lexical-service/README.md
+++ b/js/lexical-service/README.md
@@ -23,6 +23,9 @@ Returns the pre-processed document to be uses in the search processing service.
 ## /cognition/<document-id>
 Returns the pre-processed document to be uses in the cognition service.
 
+## POST /snapshot/markdown
+Accepts `{ "markdown": "..." }` and returns an `application/octet-stream` Loro snapshot equivalent to the markdown block migration path.
+
 # Local Development
 `bun run dev` will start the development server with the wrangler env set to 'local' and the port set to 8931. The local
 environment uses 'local' as the INTERNAL_API_SECRET_KEY. There are scripts to run document ids against the local endpoints.

--- a/js/lexical-service/package.json
+++ b/js/lexical-service/package.json
@@ -14,7 +14,7 @@
 		"search": "bash scripts/test-search.sh",
 		"deploy-dev": "wrangler deploy --env dev",
 		"deploy-prod": "wrangler deploy --env prod",
-		"check": "tsc --noEmit"
+		"check": "tsc --noEmit --project tsconfig.check.json"
 	},
 	"dependencies": {
 		"@lexical/code": "0.32.1",
@@ -33,6 +33,7 @@
 		"chanfana": "^3.3.0",
 		"hono": "^4.6.20",
 		"lexical": "0.32.1",
+		"loro-crdt": "1.5.9",
 		"nanoid": "^5.1.5",
 		"zod": "^4.3.6"
 	},

--- a/js/lexical-service/src/endpoints/markdown-snapshot.ts
+++ b/js/lexical-service/src/endpoints/markdown-snapshot.ts
@@ -1,0 +1,57 @@
+import { OpenAPIRoute } from 'chanfana';
+import type { Context } from 'hono';
+import { z } from 'zod';
+import { ConversionError, handleEndpointError } from '../lib/error-handler';
+import { standardErrorResponses } from '../lib/schemas';
+import { markdownToLoroSnapshot } from '@macro-inc/lexical-core/markdown-loro-snapshot';
+
+const markdownSnapshotRequest = z.object({
+  markdown: z.string(),
+});
+
+export class MarkdownSnapshotEndpoint extends OpenAPIRoute {
+  schema = {
+    summary: 'Convert markdown to a Loro snapshot',
+    description:
+      'Converts a markdown string to Lexical editor state, assigns durable node ids, mirrors it into Loro, and returns a Loro snapshot.',
+    request: {
+      body: {
+        content: {
+          'application/json': {
+            schema: markdownSnapshotRequest,
+          },
+        },
+      },
+    },
+    responses: {
+      200: {
+        description: 'Successfully converted markdown to a Loro snapshot',
+        content: {
+          'application/octet-stream': {
+            schema: z.any(),
+          },
+        },
+      },
+      ...standardErrorResponses,
+    },
+  };
+
+  async handle(c: Context) {
+    try {
+      const { body } = await this.getValidatedData<typeof this.schema>();
+      const snapshot = await markdownToLoroSnapshot(body.markdown);
+
+      if (!snapshot) {
+        throw new ConversionError(
+          'Failed to create Loro snapshot from markdown'
+        );
+      }
+
+      return c.body(snapshot, 200, {
+        'Content-Type': 'application/octet-stream',
+      });
+    } catch (error) {
+      return handleEndpointError(error, c);
+    }
+  }
+}

--- a/js/lexical-service/src/index.ts
+++ b/js/lexical-service/src/index.ts
@@ -6,6 +6,7 @@ import { CognitionPresignedEndpoint } from './endpoints/cognition-presigned';
 import { CognitionTextEndpoint } from './endpoints/cognition-text';
 import { CognitionV2Endpoint } from './endpoints/cognition-v2';
 import { MarkdownEndpoint } from './endpoints/markdown';
+import { MarkdownSnapshotEndpoint } from './endpoints/markdown-snapshot';
 import { PlaintextEndpoint } from './endpoints/plaintext';
 import { SearchTextEndpoint } from './endpoints/search-text';
 
@@ -59,6 +60,14 @@ app.use('/markdown/*', async (c, next) => {
   await next();
 });
 
+app.use('/snapshot/*', async (c, next) => {
+  const authKey = c.req.header('x-internal-auth-key');
+  if (!authKey || authKey !== c.env.INTERNAL_AUTH_KEY) {
+    return c.json({ error: 'Unauthorized' }, 401);
+  }
+  await next();
+});
+
 app.use('/internal/health', async (c, next) => {
   const authKey = c.req.header('x-internal-auth-key');
   if (!authKey || authKey !== c.env.INTERNAL_AUTH_KEY) {
@@ -85,6 +94,7 @@ openapi.get('/cognition/:docId', CognitionTextEndpoint);
 openapi.get('/cognitionv2/:docId', CognitionV2Endpoint);
 openapi.get('/search/:docId', SearchTextEndpoint);
 openapi.get('/markdown/:docId', MarkdownEndpoint);
+openapi.post('/snapshot/markdown', MarkdownSnapshotEndpoint);
 openapi.get('/internal/health', (c) => c.json({ status: 'healthy' }));
 
 export default app;

--- a/js/lexical-service/src/types/markdown-loro-snapshot.d.ts
+++ b/js/lexical-service/src/types/markdown-loro-snapshot.d.ts
@@ -1,0 +1,3 @@
+export function markdownToLoroSnapshot(
+  markdown: string
+): Promise<Uint8Array | undefined>;

--- a/js/lexical-service/tsconfig.check.json
+++ b/js/lexical-service/tsconfig.check.json
@@ -1,0 +1,13 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"baseUrl": ".",
+		"paths": {
+			"@macro-inc/lexical-core/markdown-loro-snapshot": [
+				"src/types/markdown-loro-snapshot.d.ts"
+			],
+			"@macro-inc/lexical-core": ["../lexical-core/"],
+			"@macro-inc/lexical-core/*": ["../lexical-core/*"]
+		}
+	}
+}


### PR DESCRIPTION
- moves core conversion utils relating to md -> snapshot into lexical-core
- adds endpoint in lexical-service to convert md -> snapshot
