### PR TITLE
chg(sync/dss): initialize markdown document util for dss

### DIFF
--- a/rust/cloud-storage/documents/Cargo.toml
+++ b/rust/cloud-storage/documents/Cargo.toml
@@ -34,6 +34,7 @@ axum = [
 ]
 default = ["ai_tools", "axum", "inbound", "outbound", "ports"]
 inbound = ["axum", "ports"]
+markdown_init = ["dep:lexical_client"]
 outbound = [
   "dep:aws-sdk-s3",
   "dep:base64",

--- a/rust/cloud-storage/documents/src/domain.rs
+++ b/rust/cloud-storage/documents/src/domain.rs
@@ -1,6 +1,10 @@
 //! Domain layer: models, ports (trait interfaces), and service implementation.
 
 pub mod branch_name;
+
+#[cfg(feature = "markdown_init")]
+pub mod markdown_init;
+
 pub mod models;
 
 #[cfg(feature = "ports")]

--- a/rust/cloud-storage/documents/src/domain/markdown_init.rs
+++ b/rust/cloud-storage/documents/src/domain/markdown_init.rs
@@ -1,0 +1,20 @@
+//! Helpers for initializing markdown documents in sync-service.
+
+use lexical_client::LexicalClient;
+use sync_service_client::SyncServiceClient;
+
+/// Converts markdown to a Loro snapshot using lexical-service and initializes
+/// the corresponding document in sync-service.
+#[tracing::instrument(skip(markdown, lexical_client, sync_service_client), err)]
+pub async fn initialize_markdown_document(
+    lexical_client: &LexicalClient,
+    sync_service_client: &SyncServiceClient,
+    document_id: &str,
+    markdown: &str,
+) -> anyhow::Result<()> {
+    let snapshot = lexical_client.markdown_to_loro_snapshot(markdown).await?;
+    sync_service_client
+        .initialize_from_snapshot(document_id, &snapshot)
+        .await?;
+    Ok(())
+}

--- a/rust/cloud-storage/sync_service_client/src/initialize.rs
+++ b/rust/cloud-storage/sync_service_client/src/initialize.rs
@@ -1,0 +1,54 @@
+use super::SyncServiceClient;
+use anyhow::{Context, Result};
+
+fn encode_initialize_from_snapshot_request(snapshot: &[u8]) -> Result<Vec<u8>> {
+    let len = u32::try_from(snapshot.len()).with_context(|| {
+        format!(
+            "snapshot is too large to encode as sync-service initialize request: {} bytes",
+            snapshot.len()
+        )
+    })?;
+
+    let mut body = Vec::with_capacity(4 + snapshot.len());
+    body.extend_from_slice(&len.to_le_bytes());
+    body.extend_from_slice(snapshot);
+    Ok(body)
+}
+
+impl SyncServiceClient {
+    pub async fn initialize_from_snapshot(&self, document_id: &str, snapshot: &[u8]) -> Result<()> {
+        let full_url = format!("{}/document/{}/initialize", self.url, document_id);
+        let body = encode_initialize_from_snapshot_request(snapshot)?;
+        let res = self
+            .client
+            .post(&full_url)
+            .header(reqwest::header::CONTENT_TYPE, "application/octet-stream")
+            .body(body)
+            .send()
+            .await?;
+
+        let status_code = res.status();
+        if status_code != reqwest::StatusCode::OK {
+            let body: String = res.text().await?;
+            tracing::error!(
+                body=%body,
+                status=%status_code,
+                "unexpected response from sync service while initializing snapshot"
+            );
+            anyhow::bail!(body);
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::encode_initialize_from_snapshot_request;
+
+    #[test]
+    fn test_encode_initialize_from_snapshot_request() {
+        let encoded = encode_initialize_from_snapshot_request(&[1, 2, 3]).unwrap();
+        assert_eq!(encoded, vec![3, 0, 0, 0, 1, 2, 3]);
+    }
+}

--- a/rust/cloud-storage/sync_service_client/src/lib.rs
+++ b/rust/cloud-storage/sync_service_client/src/lib.rs
@@ -2,6 +2,7 @@ pub mod copy_document;
 pub mod delete;
 pub mod exists;
 pub mod get_raw;
+pub mod initialize;
 pub mod metadata;
 pub mod wakeup;
 


### PR DESCRIPTION
- expose a util that allows markdown documents to be initialized in sync service on the backend.
