### PR TITLE
fix ios notification body for attachment-only channel messages

### DIFF
--- a/rust/cloud-storage/comms_service/src/api/channels/post_message.rs
+++ b/rust/cloud-storage/comms_service/src/api/channels/post_message.rs
@@ -193,6 +193,7 @@ pub async fn post_message_handler(
     .ok();
     tracing::debug!("activity upsert took {:?}ms", start_time.elapsed());
 
+    let has_attachments = !req.attachments.is_empty();
     let start_time = Instant::now();
     let maybe_attachments = add_attachments::add_attachments_to_message(
         &ctx.db,
@@ -245,6 +246,7 @@ pub async fn post_message_handler(
         <Vec<model::comms::ChannelParticipant>>::mirror(channel_participants),
         message.clone(),
         req.mentions.clone(),
+        has_attachments,
     );
 
     service::search::send_channel_message_to_search_extractor_queue(
@@ -269,6 +271,7 @@ pub fn dispatch_notification_task(
     participants: Vec<ChannelParticipant>,
     message: Message,
     mentions: Vec<SimpleMention>,
+    has_attachments: bool,
 ) {
     // Safe to clone, context conains a bunch of Arcs
     let api_context = ctx.clone();
@@ -281,6 +284,7 @@ pub fn dispatch_notification_task(
             participants,
             message,
             mentions,
+            has_attachments,
         )
         .await
         {

--- a/rust/cloud-storage/comms_service/src/notification.rs
+++ b/rust/cloud-storage/comms_service/src/notification.rs
@@ -32,6 +32,7 @@ struct ChannelMessageEvent<'a> {
     participants: &'a [ChannelParticipant],
     thread_participants: &'a [MacroUserIdStr<'static>],
     thread_parent_sender_id: Option<MacroUserIdStr<'static>>,
+    has_attachments: bool,
     sender_profile_picture_url: Option<String>,
     /// Pre-computed set of existing user IDs; used by the `(0, None)` invite
     /// branch to split recipients into push vs email delivery.
@@ -64,6 +65,7 @@ impl ChannelMessageEvent<'_> {
                         notification: ChannelMentionMetadata {
                             message_content: self.message.content.clone(),
                             message_id: self.message.id.to_string(),
+                            has_attachments: self.has_attachments,
                             thread_id: self.message.thread_id.map(|t| t.to_string()),
                             common: self.channel_metadata.clone(),
                             sender_profile_picture_url: self.sender_profile_picture_url.clone(),
@@ -143,6 +145,7 @@ impl ChannelMessageEvent<'_> {
                                     message_id: self.message.id.to_string(),
                                     user_id: self.message.sender_id.clone(),
                                     message_content: self.message.content.clone(),
+                                    has_attachments: self.has_attachments,
                                     thread_parent_sender_id: self.thread_parent_sender_id.clone(),
                                     common: self.channel_metadata.clone(),
                                     sender_profile_picture_url: self
@@ -192,6 +195,7 @@ impl ChannelMessageEvent<'_> {
                                 message_id: self.message.id.to_string(),
                                 sender: self.message.sender_id.clone(),
                                 message_content: self.message.content.to_string(),
+                                has_attachments: self.has_attachments,
                                 common: self.channel_metadata.clone(),
                                 sender_profile_picture_url: self.sender_profile_picture_url.clone(),
                             },
@@ -267,6 +271,7 @@ pub async fn dispatch_notifications_for_message(
     participants: Vec<ChannelParticipant>,
     message: Message,
     mentions: Vec<SimpleMention>,
+    has_attachments: bool,
 ) -> anyhow::Result<()> {
     // The message is already persisted before this task runs, so the row
     // count includes the message we just created — the first message in a
@@ -343,6 +348,7 @@ pub async fn dispatch_notifications_for_message(
         participants: &participants,
         thread_participants: &thread_participants,
         thread_parent_sender_id,
+        has_attachments,
         sender_profile_picture_url,
         existing_user_ids,
     }

--- a/rust/cloud-storage/comms_service/src/notification/test.rs
+++ b/rust/cloud-storage/comms_service/src/notification/test.rs
@@ -144,6 +144,7 @@ async fn mentioned_users_get_mention_not_message_send() {
         participants: &participants,
         thread_participants: &[],
         thread_parent_sender_id: None,
+        has_attachments: false,
         sender_profile_picture_url: None,
         existing_user_ids: HashSet::new(),
     }
@@ -201,6 +202,7 @@ async fn thread_reply_excludes_sender_and_mentions() {
         participants: &participants,
         thread_participants: &thread_participants,
         thread_parent_sender_id: Some(uid("macro|thread_parent_sender@test.com")),
+        has_attachments: false,
         sender_profile_picture_url: None,
         existing_user_ids: HashSet::new(),
     }
@@ -251,6 +253,7 @@ async fn first_message_sends_email_invite_to_non_existing_users() {
         participants: &participants,
         thread_participants: &[],
         thread_parent_sender_id: None,
+        has_attachments: false,
         sender_profile_picture_url: None,
         existing_user_ids,
     }

--- a/rust/cloud-storage/model_notifications/src/metadata.rs
+++ b/rust/cloud-storage/model_notifications/src/metadata.rs
@@ -79,6 +79,9 @@ pub struct ChannelMessageSendMetadata {
     /// The message id
     #[serde(alias = "message_id")]
     pub message_id: String,
+    /// Whether the message includes attachments.
+    #[serde(skip)]
+    pub has_attachments: bool,
     #[serde(flatten)]
     pub common: CommonChannelMetadata,
     #[serde(default)]
@@ -118,6 +121,9 @@ pub struct ChannelMentionMetadata {
     /// The message content
     #[serde(alias = "message_content")]
     pub message_content: String,
+    /// Whether the message includes attachments.
+    #[serde(skip)]
+    pub has_attachments: bool,
     /// the id of the thread
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(alias = "thread_id")]
@@ -144,6 +150,9 @@ pub struct ChannelReplyMetadata {
     /// The message content
     #[serde(alias = "message_content")]
     pub message_content: String,
+    /// Whether the message includes attachments.
+    #[serde(skip)]
+    pub has_attachments: bool,
     /// The user who sent the root message of the thread
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(alias = "thread_parent_sender_id")]
@@ -265,7 +274,7 @@ impl NotificationTitle for ChannelMentionMetadata {
         &self,
         _sender_id: Option<MacroUserIdStr<'_>>,
     ) -> Result<String, rootcause::Report> {
-        parse_message_plain_text(&self.message_content)
+        parse_message_plain_text_or_attachment(&self.message_content, self.has_attachments)
     }
 }
 
@@ -309,7 +318,7 @@ impl NotificationTitle for ChannelMessageSendMetadata {
         &self,
         _sender_id: Option<MacroUserIdStr<'_>>,
     ) -> Result<String, rootcause::Report> {
-        parse_message_plain_text(&self.message_content)
+        parse_message_plain_text_or_attachment(&self.message_content, self.has_attachments)
     }
 }
 
@@ -352,7 +361,7 @@ impl NotificationTitle for ChannelReplyMetadata {
         &self,
         _sender_id: Option<MacroUserIdStr<'_>>,
     ) -> Result<String, rootcause::Report> {
-        parse_message_plain_text(&self.message_content)
+        parse_message_plain_text_or_attachment(&self.message_content, self.has_attachments)
     }
 }
 
@@ -378,6 +387,22 @@ pub struct TaskAssignedMetadata {
 fn parse_message_plain_text(content: &str) -> Result<String, Report> {
     let parsed = ParsedXmlText::parse(content)?;
     Ok(PlainTextFormatter::format_xml_text(parsed).0)
+}
+
+fn parse_message_plain_text_or_attachment(
+    content: &str,
+    has_attachments: bool,
+) -> Result<String, Report> {
+    let mut text = parse_message_plain_text(content)?;
+    let attached_items = "[attached items]";
+    if has_attachments && text.trim().is_empty() {
+        return Ok(attached_items.to_string());
+    }
+    if has_attachments {
+        text.push('\n');
+        text.push_str(attached_items);
+    }
+    Ok(text)
 }
 
 /// Helper to create an alert-style APNS notification with title and body.

--- a/rust/cloud-storage/notification_sandbox/src/main.rs
+++ b/rust/cloud-storage/notification_sandbox/src/main.rs
@@ -301,6 +301,7 @@ async fn run_notification_cycle<I: NotificationIngress>(
             sender: MacroUserIdStr::try_from_email("fake-user@example.com").unwrap(),
             message_content: "This is a message".to_string(),
             message_id: uuid::Uuid::now_v7().to_string(),
+            has_attachments: false,
             common: model_notifications::CommonChannelMetadata {
                 channel_type: model_notifications::ChannelType::Public,
                 channel_name: "test-channel-name".to_string(),

--- a/rust/cloud-storage/notification_service/src/api/user_notification/test.rs
+++ b/rust/cloud-storage/notification_service/src/api/user_notification/test.rs
@@ -270,6 +270,7 @@ fn api_user_notification_and_conn_gateway_inner_notif_metadata_serialize_identic
     let notif_metadata = ChannelMentionMetadata {
         message_id: "msg-1".to_string(),
         message_content: "Hello @user".to_string(),
+        has_attachments: false,
         thread_id: None,
         common: model_notifications::CommonChannelMetadata {
             channel_type: model_notifications::ChannelType::Public,
@@ -348,6 +349,7 @@ fn conn_gateway_inner_val_has_identical_serialization() {
     let notif_metadata = ChannelMentionMetadata {
         message_id: "testing".to_string(),
         message_content: "some data".to_string(),
+        has_attachments: false,
         thread_id: Some("threadid".to_string()),
         common: model_notifications::CommonChannelMetadata {
             channel_type: model_notifications::ChannelType::Public,

--- a/rust/rust-toolchain.toml
+++ b/rust/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "1.94.0"
-components = ["clippy", "rustfmt", "rust-analyzer"]
+components = ["clippy", "rustfmt", "rust-analyzer", "rust-src"]


### PR DESCRIPTION
This PR adds support for `[attached items]` display inside ios push notification bodies