### PR TITLE
feat(sps): always populate channel message thread_id

### DIFF
--- a/rust/cloud-storage/opensearch_client/src/upsert/channel_message.rs
+++ b/rust/cloud-storage/opensearch_client/src/upsert/channel_message.rs
@@ -2,7 +2,9 @@ use models_opensearch::SearchIndex;
 
 use crate::{Result, date_format::EpochSeconds, error::OpensearchClientError};
 
-/// The arguments for upserting a channel message into the opensearch index
+/// The arguments for upserting a channel message into the opensearch index.
+/// Threadless messages are indexed with `thread_id == message_id` so the
+/// index is uniformly sortable on `[thread_id, message_id]`.
 #[derive(Debug, serde::Serialize)]
 pub struct UpsertChannelMessageArgs {
     #[serde(rename = "entity_id")]
@@ -10,7 +12,7 @@ pub struct UpsertChannelMessageArgs {
     pub channel_type: String,
     pub org_id: Option<i64>,
     pub message_id: String,
-    pub thread_id: Option<String>,
+    pub thread_id: String,
     pub sender_id: String,
     pub mentions: Vec<String>,
     pub content: String,

--- a/rust/cloud-storage/search_processing_service/src/process/channel.rs
+++ b/rust/cloud-storage/search_processing_service/src/process/channel.rs
@@ -45,7 +45,8 @@ pub async fn process_channel_message_update(
         thread_id: channel_message_info
             .channel_message
             .thread_id
-            .map(|id| id.to_string()),
+            .unwrap_or(channel_message_info.channel_message.message_id)
+            .to_string(),
         sender_id: channel_message_info.channel_message.sender_id,
         mentions: channel_message_info.channel_message.mentions,
         content: transformed_content.0.trim().to_string(),


### PR DESCRIPTION
Index threadless channel messages with `thread_id = message_id` so channels_v1 can be sorted on `[thread_id, message_id]` without null handling. Read-side tightening lands in a follow-up after a one-shot backfill sets `thread_id = message_id` on existing null docs.
