### PR TITLE
fix(ui): preview button active state visible

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/soup-filters-bar.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/soup-filters-bar.tsx
@@ -72,7 +72,7 @@ export const SoupFiltersBar = () => {
         <div class="flex-1" />
         <Tooltip tooltip={<LabelAndHotKey label="Preview" shortcut="space" />}>
           <Button
-            variant={soup.previewEntity() ? 'base' : 'ghost'}
+            variant={soup.previewEntity() ? 'active' : 'ghost'}
             size="sm"
             class="rounded-xs [&_svg]:size-4 px-1 border border-transparent"
             onClick={togglePreview}


### PR DESCRIPTION
The preview button's active state was indistinguishable from inactive after the Button variant consolidation in 605a221bb — `variant='base'` resolved to a transparent background. Switched the active branch to `variant='active'`, which provides the accent background/border.
