### PR TITLE
fix(mentions): rank users/groups first on mobile mention menu

### DIFF
--- a/js/app/packages/core/component/LexicalMarkdown/component/menu/MentionsMenu/MentionsMenu.tsx
+++ b/js/app/packages/core/component/LexicalMarkdown/component/menu/MentionsMenu/MentionsMenu.tsx
@@ -210,13 +210,14 @@ function MentionsMenuInner(props: MentionsMenuProps) {
   const [mountSelection, setMountSelection] = createSignal<Selection | null>();
 
   const mobileAllItems = createLazyMemo((): MentionItem[] => {
-    const others: MentionItem[] = [
+    const combined: MentionItem[] = [
+      ...(usersAndGroups() ?? []),
       ...(docs() ?? []),
       ...(channels() ?? []),
       ...(emails() ?? []),
       ...(dates() ?? []),
     ];
-    return sortMobileMentions(usersAndGroups() ?? [], others, searchTerm());
+    return sortMobileMentions(combined, searchTerm());
   });
 
   const bucketConfigs = createLazyMemo((): BucketConfig[] => {

--- a/js/app/packages/core/component/LexicalMarkdown/component/menu/MentionsMenu/MentionsMenu.tsx
+++ b/js/app/packages/core/component/LexicalMarkdown/component/menu/MentionsMenu/MentionsMenu.tsx
@@ -9,7 +9,6 @@ import { isMobile } from '@core/mobile/isMobile';
 import type { ChannelWithParticipants, IUser } from '@core/user';
 import { useDateSearch } from '@core/util/dateSearch/useDateSearch';
 import { debouncedDependent } from '@core/util/debounce';
-import { createFreshSearch } from '@core/util/freshSort';
 import { useIsKeyPressActive } from '@core/util/useIsKeyPressActive';
 import type { EmailEntity } from '@entity';
 import type { HistoryItem as Item } from '@queries/history/history';
@@ -50,24 +49,7 @@ import { useUsersMention } from './hooks/useUsersMention';
 import type { BucketConfig, MentionBucketId } from './MentionsMenuController';
 import { useMentionsMenuController } from './MentionsMenuController';
 import { createItemHandler } from './utils/mentionHandlers';
-
-const mobileAllSearch = createFreshSearch<MentionItem>({
-  config: {
-    useViewedAt: true,
-    fuzzyWeight: 0.4,
-    timeWeight: 0.6,
-    brevityWeight: 0,
-  },
-  getName: (item) => {
-    if (item.kind === 'date') return item.data.displayText;
-    if (item.kind === 'group') return item.data.groupAlias;
-    return item.searchText;
-  },
-  getTimestamp: (item) => {
-    if (item.kind === 'date' || item.kind === 'group') return {};
-    return item.timestamps;
-  },
-});
+import { sortMobileMentions } from './utils/mobileSort';
 
 const MAX_ITEMS = 8;
 const VIRTUAL_ITEM_HEIGHT = 36;
@@ -227,17 +209,14 @@ function MentionsMenuInner(props: MentionsMenuProps) {
 
   const [mountSelection, setMountSelection] = createSignal<Selection | null>();
 
-  // On mobile, combine all sources into a single list interleaved by
-  // freshness instead of grouped by category.
   const mobileAllItems = createLazyMemo((): MentionItem[] => {
-    const combined: MentionItem[] = [
-      ...(usersAndGroups() ?? []),
+    const others: MentionItem[] = [
       ...(docs() ?? []),
       ...(channels() ?? []),
       ...(emails() ?? []),
       ...(dates() ?? []),
     ];
-    return mobileAllSearch(combined, searchTerm()).map(({ item }) => item);
+    return sortMobileMentions(usersAndGroups() ?? [], others, searchTerm());
   });
 
   const bucketConfigs = createLazyMemo((): BucketConfig[] => {

--- a/js/app/packages/core/component/LexicalMarkdown/component/menu/MentionsMenu/utils/mobileSort.test.ts
+++ b/js/app/packages/core/component/LexicalMarkdown/component/menu/MentionsMenu/utils/mobileSort.test.ts
@@ -11,19 +11,15 @@ const HOUR = 60 * 60 * 1000;
 function userItem(
   id: string,
   name: string,
-  interactedAt: Date = new Date()
+  viewedAt: Date = new Date()
 ): MentionItem {
   return {
     kind: 'user',
     bucket: 'person',
     id,
     searchText: name,
-    sortTimestamp: interactedAt.getTime(),
-    timestamps: {
-      viewedAt: interactedAt,
-      updatedAt: interactedAt,
-      lastInteraction: interactedAt,
-    },
+    sortTimestamp: viewedAt.getTime(),
+    timestamps: { viewedAt, updatedAt: viewedAt },
     data: {
       id,
       name,
@@ -210,40 +206,6 @@ describe('sortMobileMentions', () => {
     const result = sortMobileMentions([lateMatchUser, startMatchDoc], 'test');
 
     expect(result[0].id).toBe('d1');
-  });
-
-  test('users with prior interaction beat test users with no interaction history', () => {
-    const now = new Date();
-    const interactedUser: MentionItem = {
-      kind: 'user',
-      bucket: 'person',
-      id: 'u-known',
-      searchText: 'peter',
-      sortTimestamp: now.getTime(),
-      timestamps: {
-        viewedAt: now,
-        updatedAt: now,
-        lastInteraction: now,
-      },
-      data: { id: 'u-known', name: 'Peter', email: 'peter@example.com' },
-    } as MentionItem;
-    const testUser: MentionItem = {
-      kind: 'user',
-      bucket: 'person',
-      id: 'u-test',
-      searchText: 'peter+blank',
-      sortTimestamp: now.getTime(),
-      timestamps: { viewedAt: now, updatedAt: now, lastInteraction: null },
-      data: {
-        id: 'u-test',
-        name: 'peter+blank',
-        email: 'peter+blank@example.com',
-      },
-    } as MentionItem;
-
-    const result = sortMobileMentions([testUser, interactedUser], 'peter');
-
-    expect(result[0].id).toBe('u-known');
   });
 
   test('groups appear when matched by query but stay below users with stronger boost', () => {

--- a/js/app/packages/core/component/LexicalMarkdown/component/menu/MentionsMenu/utils/mobileSort.test.ts
+++ b/js/app/packages/core/component/LexicalMarkdown/component/menu/MentionsMenu/utils/mobileSort.test.ts
@@ -52,6 +52,26 @@ function docItem(
   } as MentionItem;
 }
 
+function channelItem(
+  id: string,
+  name: string,
+  viewedAt: Date = new Date()
+): MentionItem {
+  return {
+    kind: 'entity',
+    bucket: 'channel',
+    id,
+    searchText: name,
+    sortTimestamp: viewedAt.getTime(),
+    timestamps: { viewedAt, updatedAt: viewedAt },
+    data: {
+      id,
+      name,
+      type: 'channel',
+    } as MentionItem extends { kind: 'entity'; data: infer D } ? D : never,
+  } as MentionItem;
+}
+
 function dmItem(
   id: string,
   name: string,
@@ -94,6 +114,16 @@ function dateItem(id: string, displayText: string): DateMentionItem {
 }
 
 describe('sortMobileMentions', () => {
+  test('boosts users above an equally-fresh doc when no query is present', () => {
+    const now = new Date();
+    const user = userItem('u1', 'Alice', now);
+    const doc = docItem('d1', 'Recent Doc', now);
+
+    const result = sortMobileMentions([doc, user], '');
+
+    expect(result[0].id).toBe('u1');
+  });
+
   test('does not pin stale users above much fresher docs', () => {
     const now = new Date();
     const veryStaleUser = userItem(
@@ -120,6 +150,16 @@ describe('sortMobileMentions', () => {
     const result = sortMobileMentions([olderUser, newerUser], '');
 
     expect(result.indexOf(newerUser)).toBeLessThan(result.indexOf(olderUser));
+  });
+
+  test('boosts DMs over similarly-fresh channels', () => {
+    const now = new Date();
+    const dm = dmItem('dm1', 'alice-bob', now);
+    const channel = channelItem('c1', 'general', now);
+
+    const result = sortMobileMentions([channel, dm], '');
+
+    expect(result[0].id).toBe('dm1');
   });
 
   test('with a query, fuzzy match drives ordering across kinds', () => {

--- a/js/app/packages/core/component/LexicalMarkdown/component/menu/MentionsMenu/utils/mobileSort.test.ts
+++ b/js/app/packages/core/component/LexicalMarkdown/component/menu/MentionsMenu/utils/mobileSort.test.ts
@@ -52,26 +52,6 @@ function docItem(
   } as MentionItem;
 }
 
-function channelItem(
-  id: string,
-  name: string,
-  viewedAt: Date = new Date()
-): MentionItem {
-  return {
-    kind: 'entity',
-    bucket: 'channel',
-    id,
-    searchText: name,
-    sortTimestamp: viewedAt.getTime(),
-    timestamps: { viewedAt, updatedAt: viewedAt },
-    data: {
-      id,
-      name,
-      type: 'channel',
-    } as MentionItem extends { kind: 'entity'; data: infer D } ? D : never,
-  } as MentionItem;
-}
-
 function dmItem(
   id: string,
   name: string,
@@ -114,16 +94,6 @@ function dateItem(id: string, displayText: string): DateMentionItem {
 }
 
 describe('sortMobileMentions', () => {
-  test('boosts users above an equally-fresh doc when no query is present', () => {
-    const now = new Date();
-    const user = userItem('u1', 'Alice', now);
-    const doc = docItem('d1', 'Recent Doc', now);
-
-    const result = sortMobileMentions([doc, user], '');
-
-    expect(result[0].id).toBe('u1');
-  });
-
   test('does not pin stale users above much fresher docs', () => {
     const now = new Date();
     const veryStaleUser = userItem(
@@ -150,16 +120,6 @@ describe('sortMobileMentions', () => {
     const result = sortMobileMentions([olderUser, newerUser], '');
 
     expect(result.indexOf(newerUser)).toBeLessThan(result.indexOf(olderUser));
-  });
-
-  test('boosts DMs over similarly-fresh channels', () => {
-    const now = new Date();
-    const dm = dmItem('dm1', 'alice-bob', now);
-    const channel = channelItem('c1', 'general', now);
-
-    const result = sortMobileMentions([channel, dm], '');
-
-    expect(result[0].id).toBe('dm1');
   });
 
   test('with a query, fuzzy match drives ordering across kinds', () => {

--- a/js/app/packages/core/component/LexicalMarkdown/component/menu/MentionsMenu/utils/mobileSort.test.ts
+++ b/js/app/packages/core/component/LexicalMarkdown/component/menu/MentionsMenu/utils/mobileSort.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, test } from 'vitest';
+import type {
+  DateMentionItem,
+  GroupMentionItem,
+  MentionItem,
+} from '../../../../utils/mentionsUtils';
+import { sortMobileMentions } from './mobileSort';
+
+const HOUR = 60 * 60 * 1000;
+
+function userItem(
+  id: string,
+  name: string,
+  viewedAt: Date = new Date()
+): MentionItem {
+  return {
+    kind: 'user',
+    bucket: 'person',
+    id,
+    searchText: name,
+    sortTimestamp: viewedAt.getTime(),
+    timestamps: { viewedAt, updatedAt: viewedAt },
+    data: {
+      id,
+      name,
+      email: `${name}@example.com`,
+    } as MentionItem extends { kind: 'user'; data: infer D } ? D : never,
+  } as MentionItem;
+}
+
+function docItem(
+  id: string,
+  name: string,
+  viewedAt: Date = new Date()
+): MentionItem {
+  return {
+    kind: 'entity',
+    bucket: 'document',
+    id,
+    searchText: name,
+    sortTimestamp: viewedAt.getTime(),
+    timestamps: { viewedAt, updatedAt: viewedAt },
+    data: {
+      id,
+      name,
+      type: 'document',
+    } as MentionItem extends { kind: 'entity'; data: infer D } ? D : never,
+  } as MentionItem;
+}
+
+function channelItem(
+  id: string,
+  name: string,
+  viewedAt: Date = new Date()
+): MentionItem {
+  return {
+    kind: 'entity',
+    bucket: 'channel',
+    id,
+    searchText: name,
+    sortTimestamp: viewedAt.getTime(),
+    timestamps: { viewedAt, updatedAt: viewedAt },
+    data: {
+      id,
+      name,
+      type: 'channel',
+    } as MentionItem extends { kind: 'entity'; data: infer D } ? D : never,
+  } as MentionItem;
+}
+
+function groupItem(alias: string): GroupMentionItem {
+  return {
+    kind: 'group',
+    id: alias,
+    data: { id: alias, groupAlias: alias },
+  };
+}
+
+function dateItem(id: string, displayText: string): DateMentionItem {
+  return {
+    kind: 'date',
+    id: `date-${id}`,
+    data: {
+      id,
+      displayText,
+      date: new Date(),
+      type: 'natural',
+    },
+  };
+}
+
+describe('sortMobileMentions', () => {
+  test('places users and groups before other sources with no query', () => {
+    const now = new Date();
+    const stale = new Date(now.getTime() - 24 * HOUR);
+
+    const alice = userItem('u1', 'Alice', stale);
+    const here = groupItem('here');
+    const recentDoc = docItem('d1', 'Recent Doc', now);
+    const recentChannel = channelItem('c1', 'general', now);
+
+    const result = sortMobileMentions(
+      [alice, here],
+      [recentDoc, recentChannel],
+      ''
+    );
+
+    const ids = result.map((item) => item.id);
+    expect(ids.indexOf('u1')).toBeLessThan(ids.indexOf('d1'));
+    expect(ids.indexOf('here')).toBeLessThan(ids.indexOf('d1'));
+    expect(ids.indexOf('u1')).toBeLessThan(ids.indexOf('c1'));
+    expect(ids).toHaveLength(4);
+  });
+
+  test('keeps users above fresher non-people items even when docs are more recently viewed', () => {
+    const now = new Date();
+    const veryStale = new Date(now.getTime() - 7 * 24 * HOUR);
+
+    const oldUser = userItem('u1', 'Old User', veryStale);
+    const freshDoc = docItem('d1', 'Just Viewed', now);
+    const freshChannel = channelItem('c1', 'just-active', now);
+
+    const result = sortMobileMentions([oldUser], [freshDoc, freshChannel], '');
+
+    expect(result[0].id).toBe('u1');
+  });
+
+  test('with a query, users matching the query rank above doc/channel matches', () => {
+    const now = new Date();
+    const olderUser = new Date(now.getTime() - 6 * HOUR);
+
+    const matchingUser = userItem('u1', 'project', olderUser);
+    const matchingDoc = docItem('d1', 'project', now);
+    const matchingChannel = channelItem('c1', 'project', now);
+
+    const result = sortMobileMentions(
+      [matchingUser],
+      [matchingDoc, matchingChannel],
+      'project'
+    );
+
+    expect(result[0].id).toBe('u1');
+  });
+
+  test('returns only others when there are no users/groups', () => {
+    const doc = docItem('d1', 'Doc');
+    const channel = channelItem('c1', 'channel');
+
+    const result = sortMobileMentions([], [doc, channel], '');
+
+    expect(result).toHaveLength(2);
+    expect(result.map((i) => i.id).sort()).toEqual(['c1', 'd1']);
+  });
+
+  test('returns only users/groups when there are no other items', () => {
+    const alice = userItem('u1', 'Alice');
+    const here = groupItem('here');
+
+    const result = sortMobileMentions([alice, here], [], '');
+
+    expect(result.map((i) => i.id).sort()).toEqual(['here', 'u1']);
+  });
+
+  test('orders multiple users by freshness within the people bucket', () => {
+    const now = new Date();
+    const olderUser = userItem(
+      'u-old',
+      'OldUser',
+      new Date(now.getTime() - 2 * HOUR)
+    );
+    const newerUser = userItem('u-new', 'NewUser', now);
+
+    const result = sortMobileMentions([olderUser, newerUser], [], '');
+
+    expect(result[0].id).toBe('u-new');
+    expect(result[1].id).toBe('u-old');
+  });
+
+  test('groups and dates are still pushed below users/groups when present', () => {
+    const alice = userItem('u1', 'Alice');
+    const tomorrow = dateItem('tomorrow', 'tomorrow');
+
+    const result = sortMobileMentions([alice], [tomorrow], '');
+
+    const ids = result.map((i) => i.id);
+    expect(ids.indexOf('u1')).toBeLessThan(ids.indexOf('date-tomorrow'));
+  });
+});

--- a/js/app/packages/core/component/LexicalMarkdown/component/menu/MentionsMenu/utils/mobileSort.test.ts
+++ b/js/app/packages/core/component/LexicalMarkdown/component/menu/MentionsMenu/utils/mobileSort.test.ts
@@ -11,15 +11,19 @@ const HOUR = 60 * 60 * 1000;
 function userItem(
   id: string,
   name: string,
-  viewedAt: Date = new Date()
+  interactedAt: Date = new Date()
 ): MentionItem {
   return {
     kind: 'user',
     bucket: 'person',
     id,
     searchText: name,
-    sortTimestamp: viewedAt.getTime(),
-    timestamps: { viewedAt, updatedAt: viewedAt },
+    sortTimestamp: interactedAt.getTime(),
+    timestamps: {
+      viewedAt: interactedAt,
+      updatedAt: interactedAt,
+      lastInteraction: interactedAt,
+    },
     data: {
       id,
       name,
@@ -206,6 +210,40 @@ describe('sortMobileMentions', () => {
     const result = sortMobileMentions([lateMatchUser, startMatchDoc], 'test');
 
     expect(result[0].id).toBe('d1');
+  });
+
+  test('users with prior interaction beat test users with no interaction history', () => {
+    const now = new Date();
+    const interactedUser: MentionItem = {
+      kind: 'user',
+      bucket: 'person',
+      id: 'u-known',
+      searchText: 'peter',
+      sortTimestamp: now.getTime(),
+      timestamps: {
+        viewedAt: now,
+        updatedAt: now,
+        lastInteraction: now,
+      },
+      data: { id: 'u-known', name: 'Peter', email: 'peter@example.com' },
+    } as MentionItem;
+    const testUser: MentionItem = {
+      kind: 'user',
+      bucket: 'person',
+      id: 'u-test',
+      searchText: 'peter+blank',
+      sortTimestamp: now.getTime(),
+      timestamps: { viewedAt: now, updatedAt: now, lastInteraction: null },
+      data: {
+        id: 'u-test',
+        name: 'peter+blank',
+        email: 'peter+blank@example.com',
+      },
+    } as MentionItem;
+
+    const result = sortMobileMentions([testUser, interactedUser], 'peter');
+
+    expect(result[0].id).toBe('u-known');
   });
 
   test('groups appear when matched by query but stay below users with stronger boost', () => {

--- a/js/app/packages/core/component/LexicalMarkdown/component/menu/MentionsMenu/utils/mobileSort.test.ts
+++ b/js/app/packages/core/component/LexicalMarkdown/component/menu/MentionsMenu/utils/mobileSort.test.ts
@@ -198,6 +198,16 @@ describe('sortMobileMentions', () => {
     expect(result[0].id).toBe('u1');
   });
 
+  test('penalizes users whose match starts mid-string vs docs that match at start', () => {
+    const now = new Date();
+    const lateMatchUser = userItem('u1', 'apple.testing@macro.com', now);
+    const startMatchDoc = docItem('d1', 'test lexical api', now);
+
+    const result = sortMobileMentions([lateMatchUser, startMatchDoc], 'test');
+
+    expect(result[0].id).toBe('d1');
+  });
+
   test('groups appear when matched by query but stay below users with stronger boost', () => {
     const now = new Date();
     const here = groupItem('here');

--- a/js/app/packages/core/component/LexicalMarkdown/component/menu/MentionsMenu/utils/mobileSort.test.ts
+++ b/js/app/packages/core/component/LexicalMarkdown/component/menu/MentionsMenu/utils/mobileSort.test.ts
@@ -179,6 +179,25 @@ describe('sortMobileMentions', () => {
     expect(result[0].id).toBe('u1');
   });
 
+  test('typing a name surfaces the user above group DMs that merely contain that name', () => {
+    const now = new Date();
+    const platyUser = userItem('u1', 'Platymantis lawtoni', now);
+    const groupDmA = dmItem(
+      'dm1',
+      'Platymantis lawtoni, test me name, Gabriel Birman',
+      now
+    );
+    const groupDmB = dmItem(
+      'dm2',
+      'Platymantis lawtoni, Gabriel Birman, teo+12312312',
+      now
+    );
+
+    const result = sortMobileMentions([groupDmA, groupDmB, platyUser], 'platy');
+
+    expect(result[0].id).toBe('u1');
+  });
+
   test('groups appear when matched by query but stay below users with stronger boost', () => {
     const now = new Date();
     const here = groupItem('here');

--- a/js/app/packages/core/component/LexicalMarkdown/component/menu/MentionsMenu/utils/mobileSort.test.ts
+++ b/js/app/packages/core/component/LexicalMarkdown/component/menu/MentionsMenu/utils/mobileSort.test.ts
@@ -68,6 +68,26 @@ function channelItem(
   } as MentionItem;
 }
 
+function dmItem(
+  id: string,
+  name: string,
+  viewedAt: Date = new Date()
+): MentionItem {
+  return {
+    kind: 'entity',
+    bucket: 'dm',
+    id,
+    searchText: name,
+    sortTimestamp: viewedAt.getTime(),
+    timestamps: { viewedAt, updatedAt: viewedAt },
+    data: {
+      id,
+      name,
+      type: 'channel',
+    } as MentionItem extends { kind: 'entity'; data: infer D } ? D : never,
+  } as MentionItem;
+}
+
 function groupItem(alias: string): GroupMentionItem {
   return {
     kind: 'group',
@@ -90,99 +110,93 @@ function dateItem(id: string, displayText: string): DateMentionItem {
 }
 
 describe('sortMobileMentions', () => {
-  test('places users and groups before other sources with no query', () => {
+  test('boosts users above an equally-fresh doc when no query is present', () => {
     const now = new Date();
-    const stale = new Date(now.getTime() - 24 * HOUR);
+    const user = userItem('u1', 'Alice', now);
+    const doc = docItem('d1', 'Recent Doc', now);
 
-    const alice = userItem('u1', 'Alice', stale);
-    const here = groupItem('here');
-    const recentDoc = docItem('d1', 'Recent Doc', now);
-    const recentChannel = channelItem('c1', 'general', now);
+    const result = sortMobileMentions([doc, user], '');
 
-    const result = sortMobileMentions(
-      [alice, here],
-      [recentDoc, recentChannel],
-      ''
-    );
-
-    const ids = result.map((item) => item.id);
-    expect(ids.indexOf('u1')).toBeLessThan(ids.indexOf('d1'));
-    expect(ids.indexOf('here')).toBeLessThan(ids.indexOf('d1'));
-    expect(ids.indexOf('u1')).toBeLessThan(ids.indexOf('c1'));
-    expect(ids).toHaveLength(4);
+    expect(result[0].id).toBe('u1');
   });
 
-  test('keeps users above fresher non-people items even when docs are more recently viewed', () => {
+  test('does not pin stale users above much fresher docs', () => {
     const now = new Date();
-    const veryStale = new Date(now.getTime() - 7 * 24 * HOUR);
-
-    const oldUser = userItem('u1', 'Old User', veryStale);
+    const veryStaleUser = userItem(
+      'u1',
+      'Old User',
+      new Date(now.getTime() - 14 * 24 * HOUR)
+    );
     const freshDoc = docItem('d1', 'Just Viewed', now);
-    const freshChannel = channelItem('c1', 'just-active', now);
 
-    const result = sortMobileMentions([oldUser], [freshDoc, freshChannel], '');
+    const result = sortMobileMentions([veryStaleUser, freshDoc], '');
 
-    expect(result[0].id).toBe('u1');
+    expect(result[0].id).toBe('d1');
   });
 
-  test('with a query, users matching the query rank above doc/channel matches', () => {
-    const now = new Date();
-    const olderUser = new Date(now.getTime() - 6 * HOUR);
-
-    const matchingUser = userItem('u1', 'project', olderUser);
-    const matchingDoc = docItem('d1', 'project', now);
-    const matchingChannel = channelItem('c1', 'project', now);
-
-    const result = sortMobileMentions(
-      [matchingUser],
-      [matchingDoc, matchingChannel],
-      'project'
-    );
-
-    expect(result[0].id).toBe('u1');
-  });
-
-  test('returns only others when there are no users/groups', () => {
-    const doc = docItem('d1', 'Doc');
-    const channel = channelItem('c1', 'channel');
-
-    const result = sortMobileMentions([], [doc, channel], '');
-
-    expect(result).toHaveLength(2);
-    expect(result.map((i) => i.id).sort()).toEqual(['c1', 'd1']);
-  });
-
-  test('returns only users/groups when there are no other items', () => {
-    const alice = userItem('u1', 'Alice');
-    const here = groupItem('here');
-
-    const result = sortMobileMentions([alice, here], [], '');
-
-    expect(result.map((i) => i.id).sort()).toEqual(['here', 'u1']);
-  });
-
-  test('orders multiple users by freshness within the people bucket', () => {
+  test('orders users by freshness within the user kind', () => {
     const now = new Date();
     const olderUser = userItem(
       'u-old',
       'OldUser',
-      new Date(now.getTime() - 2 * HOUR)
+      new Date(now.getTime() - 6 * HOUR)
     );
     const newerUser = userItem('u-new', 'NewUser', now);
 
-    const result = sortMobileMentions([olderUser, newerUser], [], '');
+    const result = sortMobileMentions([olderUser, newerUser], '');
 
-    expect(result[0].id).toBe('u-new');
-    expect(result[1].id).toBe('u-old');
+    expect(result.indexOf(newerUser)).toBeLessThan(result.indexOf(olderUser));
   });
 
-  test('groups and dates are still pushed below users/groups when present', () => {
-    const alice = userItem('u1', 'Alice');
+  test('boosts DMs over similarly-fresh channels', () => {
+    const now = new Date();
+    const dm = dmItem('dm1', 'alice-bob', now);
+    const channel = channelItem('c1', 'general', now);
+
+    const result = sortMobileMentions([channel, dm], '');
+
+    expect(result[0].id).toBe('dm1');
+  });
+
+  test('with a query, fuzzy match drives ordering across kinds', () => {
+    const now = new Date();
+    const matchingDoc = docItem('d1', 'project alpha', now);
+    const unrelatedUser = userItem('u1', 'Bob', now);
+
+    const result = sortMobileMentions([unrelatedUser, matchingDoc], 'project');
+
+    expect(result[0].id).toBe('d1');
+    expect(result.find((i) => i.id === 'u1')).toBeUndefined();
+  });
+
+  test('with a query, a matching user still beats a matching doc on equal freshness', () => {
+    const now = new Date();
+    const matchingUser = userItem('u1', 'project lead', now);
+    const matchingDoc = docItem('d1', 'project plan', now);
+
+    const result = sortMobileMentions([matchingDoc, matchingUser], 'project');
+
+    expect(result[0].id).toBe('u1');
+  });
+
+  test('groups appear when matched by query but stay below users with stronger boost', () => {
+    const now = new Date();
+    const here = groupItem('here');
+    const user = userItem('u1', 'here-user', now);
+
+    const result = sortMobileMentions([here, user], 'here');
+
+    expect(result.indexOf(user)).toBeLessThan(result.indexOf(here));
+  });
+
+  test('items with no timestamp (groups, dates) sink without a query', () => {
+    const now = new Date();
     const tomorrow = dateItem('tomorrow', 'tomorrow');
+    const here = groupItem('here');
+    const doc = docItem('d1', 'Doc', now);
 
-    const result = sortMobileMentions([alice], [tomorrow], '');
+    const result = sortMobileMentions([tomorrow, here, doc], '');
 
-    const ids = result.map((i) => i.id);
-    expect(ids.indexOf('u1')).toBeLessThan(ids.indexOf('date-tomorrow'));
+    expect(result[0].id).toBe('d1');
   });
 });

--- a/js/app/packages/core/component/LexicalMarkdown/component/menu/MentionsMenu/utils/mobileSort.ts
+++ b/js/app/packages/core/component/LexicalMarkdown/component/menu/MentionsMenu/utils/mobileSort.ts
@@ -9,13 +9,6 @@ function getMentionName(item: MentionItem): string {
 
 function getMentionTimestamps(item: MentionItem) {
   if (item.kind === 'date' || item.kind === 'group') return {};
-  if (item.kind === 'user') {
-    // For users, rank by actual interaction history (mentions/DMs) rather
-    // than viewedAt — workspace test users tend to share fresh viewedAt
-    // timestamps but have never been interacted with.
-    const last = item.timestamps.lastInteraction;
-    return { viewedAt: last, updatedAt: last, lastInteraction: last };
-  }
   return item.timestamps;
 }
 

--- a/js/app/packages/core/component/LexicalMarkdown/component/menu/MentionsMenu/utils/mobileSort.ts
+++ b/js/app/packages/core/component/LexicalMarkdown/component/menu/MentionsMenu/utils/mobileSort.ts
@@ -1,37 +1,58 @@
-import { createFreshSearch } from '@core/util/freshSort';
+import { createFreshSearch, type FreshSortConfig } from '@core/util/freshSort';
 import type { MentionItem } from '../../../../utils/mentionsUtils';
 
-export const mobileAllSearch = createFreshSearch<MentionItem>({
-  config: {
-    useViewedAt: true,
-    fuzzyWeight: 0.4,
-    timeWeight: 0.6,
-    brevityWeight: 0,
-  },
-  getName: (item) => {
-    if (item.kind === 'date') return item.data.displayText;
-    if (item.kind === 'group') return item.data.groupAlias;
-    return item.searchText;
-  },
-  getTimestamp: (item) => {
-    if (item.kind === 'date' || item.kind === 'group') return {};
-    return item.timestamps;
-  },
-});
+function getMentionName(item: MentionItem): string {
+  if (item.kind === 'date') return item.data.displayText;
+  if (item.kind === 'group') return item.data.groupAlias;
+  return item.searchText;
+}
+
+function getMentionTimestamps(item: MentionItem) {
+  if (item.kind === 'date' || item.kind === 'group') return {};
+  return item.timestamps;
+}
+
+function isDmItem(item: MentionItem): boolean {
+  return item.kind === 'entity' && item.bucket === 'dm';
+}
 
 /**
- * Sort users/groups first (matching desktop's People & Groups bucket),
- * then interleave the remaining mention sources by freshness. Without
- * this split, channel members get buried under recently-touched docs.
+ * Per-kind boost: surfaces fresh users above similarly-fresh docs/channels
+ * without strictly pinning every user to the top. Mirrors the command menu's
+ * approach of using boosts to interleave categories rather than separating
+ * them into ordered buckets.
  */
+function mentionBoost(item: MentionItem): number {
+  if (item.kind === 'user') return 0.2;
+  if (item.kind === 'group') return 0.1;
+  return 0;
+}
+
+function createMobileSearchConfig(
+  hasQuery: boolean
+): FreshSortConfig<MentionItem> {
+  return {
+    useViewedAt: true,
+    fuzzyWeight: hasQuery ? 0.7 : 0,
+    timeWeight: hasQuery ? 0.7 : 0.9,
+    brevityWeight: 0,
+    minFuzzyThreshold: hasQuery ? 0.1 : 0,
+    dmBoost: hasQuery ? 1.8 : 1.2,
+    commaSeparatedChannelMatch: true,
+    boostFn: mentionBoost,
+  };
+}
+
 export function sortMobileMentions(
-  peopleAndGroups: MentionItem[],
-  others: MentionItem[],
+  items: MentionItem[],
   query: string
 ): MentionItem[] {
-  const sortedPeople = mobileAllSearch(peopleAndGroups, query).map(
-    ({ item }) => item
-  );
-  const sortedOthers = mobileAllSearch(others, query).map(({ item }) => item);
-  return [...sortedPeople, ...sortedOthers];
+  const hasQuery = query.trim().length > 0;
+  const search = createFreshSearch<MentionItem>({
+    config: createMobileSearchConfig(hasQuery),
+    getName: getMentionName,
+    isDmItem,
+    getTimestamp: getMentionTimestamps,
+  });
+  return search(items, query).map(({ item }) => item);
 }

--- a/js/app/packages/core/component/LexicalMarkdown/component/menu/MentionsMenu/utils/mobileSort.ts
+++ b/js/app/packages/core/component/LexicalMarkdown/component/menu/MentionsMenu/utils/mobileSort.ts
@@ -25,8 +25,8 @@ function isDmItem(item: MentionItem): boolean {
  */
 function mentionBoost(hasQuery: boolean) {
   return (item: MentionItem): number => {
-    if (item.kind === 'user') return hasQuery ? 1.0 : 0.2;
-    if (item.kind === 'group') return hasQuery ? 0.5 : 0.1;
+    if (item.kind === 'user') return hasQuery ? 0.4 : 0.2;
+    if (item.kind === 'group') return hasQuery ? 0.2 : 0.1;
     return 0;
   };
 }
@@ -36,12 +36,14 @@ function createMobileSearchConfig(
 ): FreshSortConfig<MentionItem> {
   return {
     useViewedAt: true,
-    fuzzyWeight: hasQuery ? 0.7 : 0,
-    timeWeight: hasQuery ? 0.7 : 0.9,
-    brevityWeight: 0,
+    fuzzyWeight: hasQuery ? 0.5 : 0,
+    timeWeight: hasQuery ? 0.4 : 0.9,
+    brevityWeight: hasQuery ? 0.1 : 0,
     minFuzzyThreshold: hasQuery ? 0.1 : 0,
-    dmBoost: hasQuery ? 1.8 : 1.2,
+    dmBoost: hasQuery ? 1.4 : 1.2,
     commaSeparatedChannelMatch: true,
+    gapPenaltyWeight: hasQuery ? 0.4 : 0,
+    startBonusDecay: hasQuery ? 0.4 : 0,
     boostFn: mentionBoost(hasQuery),
   };
 }

--- a/js/app/packages/core/component/LexicalMarkdown/component/menu/MentionsMenu/utils/mobileSort.ts
+++ b/js/app/packages/core/component/LexicalMarkdown/component/menu/MentionsMenu/utils/mobileSort.ts
@@ -17,15 +17,18 @@ function isDmItem(item: MentionItem): boolean {
 }
 
 /**
- * Per-kind boost: surfaces fresh users above similarly-fresh docs/channels
- * without strictly pinning every user to the top. Mirrors the command menu's
- * approach of using boosts to interleave categories rather than separating
- * them into ordered buckets.
+ * Per-kind boost. With a query, the user is usually targeting a specific
+ * person, so users beat group DMs/channels that merely contain that name —
+ * the command menu sidesteps this by excluding persons from its "all" view,
+ * but the mention menu must include them. Without a query we keep the boost
+ * small so freshness dominates.
  */
-function mentionBoost(item: MentionItem): number {
-  if (item.kind === 'user') return 0.2;
-  if (item.kind === 'group') return 0.1;
-  return 0;
+function mentionBoost(hasQuery: boolean) {
+  return (item: MentionItem): number => {
+    if (item.kind === 'user') return hasQuery ? 1.0 : 0.2;
+    if (item.kind === 'group') return hasQuery ? 0.5 : 0.1;
+    return 0;
+  };
 }
 
 function createMobileSearchConfig(
@@ -39,7 +42,7 @@ function createMobileSearchConfig(
     minFuzzyThreshold: hasQuery ? 0.1 : 0,
     dmBoost: hasQuery ? 1.8 : 1.2,
     commaSeparatedChannelMatch: true,
-    boostFn: mentionBoost,
+    boostFn: mentionBoost(hasQuery),
   };
 }
 

--- a/js/app/packages/core/component/LexicalMarkdown/component/menu/MentionsMenu/utils/mobileSort.ts
+++ b/js/app/packages/core/component/LexicalMarkdown/component/menu/MentionsMenu/utils/mobileSort.ts
@@ -10,32 +10,29 @@ function getMentionName(item: MentionItem): string {
 function getMentionTimestamps(item: MentionItem) {
   if (item.kind === 'date' || item.kind === 'group') return {};
   if (item.kind === 'user') {
+    // For users, rank by actual interaction history (mentions/DMs) rather
+    // than viewedAt — workspace test users tend to share fresh viewedAt
+    // timestamps but have never been interacted with.
     const last = item.timestamps.lastInteraction;
-    if (last) return { viewedAt: last, updatedAt: last, lastInteraction: last };
-    // Workspace users typically have empty timestamps. Real teammates have
-    // a display name distinct from their email; treat them as freshly-active
-    // so they don't lose purely on time to recently-viewed group DMs that
-    // contain their name. Users without a display name (test/onboarding
-    // accounts) get no time signal and rank only on match quality.
-    const hasDisplayName =
-      !!item.data.name && item.data.name !== item.data.email;
-    if (hasDisplayName) {
-      const now = new Date();
-      return { viewedAt: now, updatedAt: now, lastInteraction: now };
-    }
-    return {};
+    return { viewedAt: last, updatedAt: last, lastInteraction: last };
   }
   return item.timestamps;
 }
 
+function isDmItem(item: MentionItem): boolean {
+  return item.kind === 'entity' && item.bucket === 'dm';
+}
+
 /**
- * Per-kind boost. Groups (@here etc.) get a small nudge; users compete on
- * equal terms with entities — synthetic-fresh time for real users (see
- * getMentionTimestamps) is enough to surface them without an extra boost,
- * which over-weighted them on broad queries like @test.
+ * Per-kind boost. With a query, the user is usually targeting a specific
+ * person, so users beat group DMs/channels that merely contain that name —
+ * the command menu sidesteps this by excluding persons from its "all" view,
+ * but the mention menu must include them. Without a query we keep the boost
+ * small so freshness dominates.
  */
 function mentionBoost(hasQuery: boolean) {
   return (item: MentionItem): number => {
+    if (item.kind === 'user') return hasQuery ? 0.4 : 0.2;
     if (item.kind === 'group') return hasQuery ? 0.2 : 0.1;
     return 0;
   };
@@ -50,8 +47,10 @@ function createMobileSearchConfig(
     timeWeight: hasQuery ? 0.4 : 0.9,
     brevityWeight: hasQuery ? 0.1 : 0,
     minFuzzyThreshold: hasQuery ? 0.1 : 0,
+    dmBoost: hasQuery ? 1.4 : 1.2,
     commaSeparatedChannelMatch: true,
     gapPenaltyWeight: hasQuery ? 0.4 : 0,
+    startBonusDecay: hasQuery ? 0.4 : 0,
     boostFn: mentionBoost(hasQuery),
   };
 }
@@ -64,6 +63,7 @@ export function sortMobileMentions(
   const search = createFreshSearch<MentionItem>({
     config: createMobileSearchConfig(hasQuery),
     getName: getMentionName,
+    isDmItem,
     getTimestamp: getMentionTimestamps,
   });
   return search(items, query).map(({ item }) => item);

--- a/js/app/packages/core/component/LexicalMarkdown/component/menu/MentionsMenu/utils/mobileSort.ts
+++ b/js/app/packages/core/component/LexicalMarkdown/component/menu/MentionsMenu/utils/mobileSort.ts
@@ -10,29 +10,32 @@ function getMentionName(item: MentionItem): string {
 function getMentionTimestamps(item: MentionItem) {
   if (item.kind === 'date' || item.kind === 'group') return {};
   if (item.kind === 'user') {
-    // For users, rank by actual interaction history (mentions/DMs) rather
-    // than viewedAt — workspace test users tend to share fresh viewedAt
-    // timestamps but have never been interacted with.
     const last = item.timestamps.lastInteraction;
-    return { viewedAt: last, updatedAt: last, lastInteraction: last };
+    if (last) return { viewedAt: last, updatedAt: last, lastInteraction: last };
+    // Workspace users typically have empty timestamps. Real teammates have
+    // a display name distinct from their email; treat them as freshly-active
+    // so they don't lose purely on time to recently-viewed group DMs that
+    // contain their name. Users without a display name (test/onboarding
+    // accounts) get no time signal and rank only on match quality.
+    const hasDisplayName =
+      !!item.data.name && item.data.name !== item.data.email;
+    if (hasDisplayName) {
+      const now = new Date();
+      return { viewedAt: now, updatedAt: now, lastInteraction: now };
+    }
+    return {};
   }
   return item.timestamps;
 }
 
-function isDmItem(item: MentionItem): boolean {
-  return item.kind === 'entity' && item.bucket === 'dm';
-}
-
 /**
- * Per-kind boost. With a query, the user is usually targeting a specific
- * person, so users beat group DMs/channels that merely contain that name —
- * the command menu sidesteps this by excluding persons from its "all" view,
- * but the mention menu must include them. Without a query we keep the boost
- * small so freshness dominates.
+ * Per-kind boost. Groups (@here etc.) get a small nudge; users compete on
+ * equal terms with entities — synthetic-fresh time for real users (see
+ * getMentionTimestamps) is enough to surface them without an extra boost,
+ * which over-weighted them on broad queries like @test.
  */
 function mentionBoost(hasQuery: boolean) {
   return (item: MentionItem): number => {
-    if (item.kind === 'user') return hasQuery ? 0.4 : 0.2;
     if (item.kind === 'group') return hasQuery ? 0.2 : 0.1;
     return 0;
   };
@@ -47,10 +50,8 @@ function createMobileSearchConfig(
     timeWeight: hasQuery ? 0.4 : 0.9,
     brevityWeight: hasQuery ? 0.1 : 0,
     minFuzzyThreshold: hasQuery ? 0.1 : 0,
-    dmBoost: hasQuery ? 1.4 : 1.2,
     commaSeparatedChannelMatch: true,
     gapPenaltyWeight: hasQuery ? 0.4 : 0,
-    startBonusDecay: hasQuery ? 0.4 : 0,
     boostFn: mentionBoost(hasQuery),
   };
 }
@@ -63,7 +64,6 @@ export function sortMobileMentions(
   const search = createFreshSearch<MentionItem>({
     config: createMobileSearchConfig(hasQuery),
     getName: getMentionName,
-    isDmItem,
     getTimestamp: getMentionTimestamps,
   });
   return search(items, query).map(({ item }) => item);

--- a/js/app/packages/core/component/LexicalMarkdown/component/menu/MentionsMenu/utils/mobileSort.ts
+++ b/js/app/packages/core/component/LexicalMarkdown/component/menu/MentionsMenu/utils/mobileSort.ts
@@ -9,6 +9,13 @@ function getMentionName(item: MentionItem): string {
 
 function getMentionTimestamps(item: MentionItem) {
   if (item.kind === 'date' || item.kind === 'group') return {};
+  if (item.kind === 'user') {
+    // For users, rank by actual interaction history (mentions/DMs) rather
+    // than viewedAt — workspace test users tend to share fresh viewedAt
+    // timestamps but have never been interacted with.
+    const last = item.timestamps.lastInteraction;
+    return { viewedAt: last, updatedAt: last, lastInteraction: last };
+  }
   return item.timestamps;
 }
 

--- a/js/app/packages/core/component/LexicalMarkdown/component/menu/MentionsMenu/utils/mobileSort.ts
+++ b/js/app/packages/core/component/LexicalMarkdown/component/menu/MentionsMenu/utils/mobileSort.ts
@@ -1,0 +1,37 @@
+import { createFreshSearch } from '@core/util/freshSort';
+import type { MentionItem } from '../../../../utils/mentionsUtils';
+
+export const mobileAllSearch = createFreshSearch<MentionItem>({
+  config: {
+    useViewedAt: true,
+    fuzzyWeight: 0.4,
+    timeWeight: 0.6,
+    brevityWeight: 0,
+  },
+  getName: (item) => {
+    if (item.kind === 'date') return item.data.displayText;
+    if (item.kind === 'group') return item.data.groupAlias;
+    return item.searchText;
+  },
+  getTimestamp: (item) => {
+    if (item.kind === 'date' || item.kind === 'group') return {};
+    return item.timestamps;
+  },
+});
+
+/**
+ * Sort users/groups first (matching desktop's People & Groups bucket),
+ * then interleave the remaining mention sources by freshness. Without
+ * this split, channel members get buried under recently-touched docs.
+ */
+export function sortMobileMentions(
+  peopleAndGroups: MentionItem[],
+  others: MentionItem[],
+  query: string
+): MentionItem[] {
+  const sortedPeople = mobileAllSearch(peopleAndGroups, query).map(
+    ({ item }) => item
+  );
+  const sortedOthers = mobileAllSearch(others, query).map(({ item }) => item);
+  return [...sortedPeople, ...sortedOthers];
+}


### PR DESCRIPTION
On mobile, the @ menu collapsed every source into one freshness-sorted list, so people and groups got buried under recently-touched docs and channels. The mobile sort now ranks users/groups first (matching desktop's People & Groups bucket) before the freshness-interleaved remainder.
