### PR TITLE
fix(video): show progress toast while downloading

### DIFF
--- a/js/app/packages/block-video/component/TopBar.tsx
+++ b/js/app/packages/block-video/component/TopBar.tsx
@@ -29,9 +29,11 @@ import { downloadFile } from '@filesystem/download';
 import Download from '@icon/regular/download.svg';
 import Info from '@icon/regular/info.svg';
 import Quotes from '@icon/regular/quotes.svg';
+import Spinner from '@icon/regular/spinner.svg';
 import IconShared from '@macro-icons/wide/share.svg';
 import { createCallback } from '@solid-primitives/rootless';
 import { toast } from 'core/component/Toast/Toast';
+import { createSignal } from 'solid-js';
 import { useGetFileBlob } from '../signal/blockData';
 
 export function TopBar() {
@@ -46,10 +48,26 @@ export function TopBar() {
   const shareCtx = useShareDialogContext();
 
   const downloadDocument = createCallback(async () => {
+    const fileName = downloadName();
+    const [progress, setProgress] = createSignal({ loaded: 0, total: 0 });
+
+    const toastId = toast.custom(
+      {
+        title: `Downloading ${fileName}`,
+        icon: () => <Spinner class="text-accent size-5 animate-spin" />,
+        color: 'var(--color-accent)',
+        content: () => <DownloadProgressBar progress={progress()} />,
+      },
+      { persistent: true }
+    );
+
     try {
-      const blob = await getBlob();
-      downloadFile(blob, downloadName());
+      const blob = await getBlob({ onProgress: setProgress });
+      downloadFile(blob, fileName);
+      toast.dismiss(toastId);
+      toast.success(`Downloaded ${fileName}`);
     } catch (e) {
+      toast.dismiss(toastId);
       console.error('error downloading file', e);
       toast.failure('Error downloading file');
     }
@@ -113,5 +131,48 @@ export function TopBar() {
         name={name()}
       />
     </>
+  );
+}
+
+const SIZE_UNITS = ['B', 'KB', 'MB', 'GB', 'TB'];
+
+function formatBytes(bytes: number): string {
+  if (bytes <= 0) return '0 B';
+  const exp = Math.min(
+    Math.floor(Math.log(bytes) / Math.log(1024)),
+    SIZE_UNITS.length - 1
+  );
+  const value = bytes / 1024 ** exp;
+  const decimals = exp === 0 || value >= 100 ? 0 : value >= 10 ? 1 : 2;
+  return `${value.toFixed(decimals)} ${SIZE_UNITS[exp]}`;
+}
+
+function DownloadProgressBar(props: {
+  progress: { loaded: number; total: number };
+}) {
+  const hasTotal = () => props.progress.total > 0;
+  const percent = () =>
+    hasTotal()
+      ? Math.min(
+          100,
+          Math.round((props.progress.loaded / props.progress.total) * 100)
+        )
+      : 0;
+
+  return (
+    <div class="space-y-1">
+      <div class="h-1 w-full bg-edge rounded-full overflow-hidden">
+        <div
+          class="h-full bg-accent transition-[width] duration-150 ease-linear"
+          classList={{ 'animate-pulse w-full': !hasTotal() }}
+          style={hasTotal() ? { width: `${percent()}%` } : undefined}
+        />
+      </div>
+      <div class="text-xs text-ink-extra-muted">
+        {hasTotal() ? `${percent()}% — ` : ''}
+        {formatBytes(props.progress.loaded)}
+        {hasTotal() ? ` of ${formatBytes(props.progress.total)}` : ''}
+      </div>
+    </div>
   );
 }

--- a/js/app/packages/block-video/signal/blockData.ts
+++ b/js/app/packages/block-video/signal/blockData.ts
@@ -1,6 +1,10 @@
 import { blockDataSignalAs, useBlockId } from '@core/block';
 import { isErr } from '@core/util/maybeResult';
-import { fetchPresigned } from '@service-storage/util/fetchPresigned';
+import {
+  type FetchProgress,
+  fetchPresigned,
+  fetchPresignedBlobWithProgress,
+} from '@service-storage/util/fetchPresigned';
 import { getPresignedUrl } from '@service-storage/util/presignedUrl';
 import { createMemo } from 'solid-js';
 import type { VideoFileData } from '../definition';
@@ -22,11 +26,20 @@ export const useGetFileUrl = () => {
   };
 };
 
+type GetBlobOptions = {
+  onProgress?: (progress: FetchProgress) => void;
+};
+
 export const useGetFileBlob = () => {
   const getPresignedUrl = useGetFileUrl();
 
-  const fetchFromPresignedUrl = async (url: string) => {
-    const maybeResult = await fetchPresigned(url, 'blob');
+  const fetchFromPresignedUrl = async (
+    url: string,
+    options?: GetBlobOptions
+  ) => {
+    const maybeResult = options?.onProgress
+      ? await fetchPresignedBlobWithProgress(url, options.onProgress)
+      : await fetchPresigned(url, 'blob');
     if (isErr(maybeResult)) {
       throw new Error('unable to fetch from presigned url');
     }
@@ -39,9 +52,9 @@ export const useGetFileBlob = () => {
     return blob;
   };
 
-  const getBlob = async () => {
+  const getBlob = async (options?: GetBlobOptions) => {
     const url = await getPresignedUrl();
-    const blob = await fetchFromPresignedUrl(url);
+    const blob = await fetchFromPresignedUrl(url, options);
     return blob;
   };
 

--- a/js/app/packages/service-clients/service-storage/util/fetchPresigned.ts
+++ b/js/app/packages/service-clients/service-storage/util/fetchPresigned.ts
@@ -14,6 +14,26 @@ type ResultMap = {
   json: ObjectLike;
 };
 
+function httpStatusToError(status: number) {
+  switch (status) {
+    case 404:
+      return err('NOT_FOUND', 'Resource not found');
+    case 401:
+      return err('UNAUTHORIZED', 'Unauthorized access');
+    case 500:
+      return err('SERVER_ERROR', 'Internal server error');
+    default:
+      return err('HTTP_ERROR', `HTTP error! status: ${status}`);
+  }
+}
+
+function fetchExceptionToError(error: unknown) {
+  if (error instanceof TypeError && error.message === 'Failed to fetch') {
+    return err('NETWORK_ERROR', 'Network error occurred');
+  }
+  return err('UNKNOWN_ERROR', `An unknown error occurred: ${error}`);
+}
+
 export async function fetchPresigned<K extends keyof ResultMap>(
   url: string,
   responseType: K,
@@ -23,26 +43,66 @@ export async function fetchPresigned<K extends keyof ResultMap>(
     const response = await platformFetch(url, init);
 
     if (!response.ok) {
-      switch (response.status) {
-        case 404:
-          return err('NOT_FOUND', 'Resource not found');
-        case 401:
-          return err('UNAUTHORIZED', 'Unauthorized access');
-        case 500:
-          return err('SERVER_ERROR', 'Internal server error');
-        default:
-          return err('HTTP_ERROR', `HTTP error! status: ${response.status}`);
-      }
+      return httpStatusToError(response.status);
     }
 
     const data =
       await response[responseType as keyof Response & keyof ResultMap]();
     return ok(data);
   } catch (error) {
-    if (error instanceof TypeError && error.message === 'Failed to fetch') {
-      return err('NETWORK_ERROR', 'Network error occurred');
-    } else {
-      return err('UNKNOWN_ERROR', `An unknown error occurred: ${error}`);
+    return fetchExceptionToError(error);
+  }
+}
+
+export type FetchProgress = {
+  loaded: number;
+  /** 0 when Content-Length is missing. */
+  total: number;
+};
+
+export async function fetchPresignedBlobWithProgress(
+  url: string,
+  onProgress: (progress: FetchProgress) => void,
+  init?: RequestInit
+): Promise<MaybeResult<FetchError, Blob>> {
+  try {
+    const response = await platformFetch(url, init);
+
+    if (!response.ok) {
+      return httpStatusToError(response.status);
     }
+
+    const totalHeader = response.headers.get('Content-Length');
+    const total = totalHeader ? Number.parseInt(totalHeader, 10) : 0;
+    const contentType = response.headers.get('Content-Type') ?? undefined;
+
+    onProgress({ loaded: 0, total });
+
+    if (!response.body) {
+      const blob = await response.blob();
+      onProgress({ loaded: blob.size, total: blob.size });
+      return ok(blob);
+    }
+
+    const reader = response.body.getReader();
+    const chunks: BlobPart[] = [];
+    let loaded = 0;
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      chunks.push(
+        value.buffer.slice(
+          value.byteOffset,
+          value.byteOffset + value.byteLength
+        ) as ArrayBuffer
+      );
+      loaded += value.byteLength;
+      onProgress({ loaded, total });
+    }
+
+    return ok(new Blob(chunks, contentType ? { type: contentType } : {}));
+  } catch (error) {
+    return fetchExceptionToError(error);
   }
 }


### PR DESCRIPTION
Streams the presigned-URL response and reports progress to a persistent toast, so clicking Download on a large video gives immediate feedback and a live percentage instead of appearing frozen until the file lands.
