### PR TITLE
Fix(dss): thread commenter gets subscribed to thread

### DIFF
--- a/rust/cloud-storage/document_storage_service/src/api/annotations/create_comment.rs
+++ b/rust/cloud-storage/document_storage_service/src/api/annotations/create_comment.rs
@@ -92,11 +92,15 @@ pub async fn create_comment_handler(
                     .as_ref()
                     .map(|m| m.users.as_slice())
                     .unwrap_or_default();
-                let thread_comment_owners: Vec<String> = res
+                let thread_participant_ids: Vec<String> = res
                     .comment_thread
                     .comments
                     .iter()
-                    .map(|c| c.owner.clone())
+                    // `sender` is the actual commenter when present; `owner` is the legacy
+                    // fallback. Use the commenter identity so anyone who comments on a thread
+                    // is auto-subscribed to subsequent replies, even if they are not the
+                    // document owner or a task assignee.
+                    .map(|c| c.sender.as_ref().unwrap_or(&c.owner).clone())
                     .collect();
 
                 let task_assignee_ids: Vec<String> = match properties_service
@@ -120,7 +124,7 @@ pub async fn create_comment_handler(
                 let recipients = compute_notification_recipients(
                     sender_id.as_ref(),
                     mentioned_user_ids,
-                    &thread_comment_owners,
+                    &thread_participant_ids,
                     &task_assignee_ids,
                     &document_context.owner,
                     is_reply,

--- a/rust/cloud-storage/document_storage_service/src/api/annotations/mod.rs
+++ b/rust/cloud-storage/document_storage_service/src/api/annotations/mod.rs
@@ -130,11 +130,11 @@ pub fn comment_error_response(e: anyhow::Error, default_msg: &str) -> Result<Res
 /// Computes the recipient sets for each notification type, ensuring no user
 /// receives more than one notification per comment.
 ///
-/// Priority: mention > thread reply > document owner.
+/// Priority: mention > thread reply > task assignee > document owner.
 pub(crate) fn compute_notification_recipients(
     sender_id: Option<&MacroUserIdStr<'_>>,
     mentioned_user_ids: &[String],
-    thread_comment_owners: &[String],
+    thread_participant_ids: &[String],
     task_assignee_ids: &[String],
     document_owner: &MacroUserIdStr<'_>,
     is_reply: bool,
@@ -148,11 +148,14 @@ pub(crate) fn compute_notification_recipients(
         .collect();
     notified.extend(mention_recipients.iter().map(|id| id.as_ref().to_string()));
 
-    // 2. Thread reply recipients — only if this is a reply (>1 comments in thread)
+    // 2. Thread reply recipients — only if this is a reply (>1 comments in thread).
+    // Any user who has commented on the thread is a participant and should receive
+    // subsequent reply notifications, even when they are not the document owner or
+    // a task assignee.
     let mut thread_reply_recipients: HashSet<MacroUserIdStr<'static>> = HashSet::new();
     if is_reply {
-        for owner_str in thread_comment_owners {
-            if let Ok(parsed) = MacroUserIdStr::try_from(owner_str.clone()) {
+        for participant_str in thread_participant_ids {
+            if let Ok(parsed) = MacroUserIdStr::try_from(participant_str.clone()) {
                 let normalized = parsed.as_ref().to_string();
                 let is_sender = sender_id.is_some_and(|s| s.as_ref() == normalized);
                 if !is_sender && !notified.contains(&normalized) {

--- a/rust/cloud-storage/document_storage_service/src/api/annotations/test.rs
+++ b/rust/cloud-storage/document_storage_service/src/api/annotations/test.rs
@@ -228,6 +228,30 @@ fn new_thread_comment_notifies_doc_owner() {
 }
 
 #[test]
+fn non_owner_non_assignee_commenter_gets_subsequent_thread_reply() {
+    let sender = user_id("macro|sender@test.com");
+    let owner = user_id("macro|owner@test.com");
+    let commenter = "macro|commenter@test.com";
+
+    let result = compute_notification_recipients(
+        Some(&sender),
+        &[],
+        &[commenter.to_string(), sender.as_ref().to_string()],
+        &[],
+        &owner,
+        true,
+    );
+
+    assert!(
+        result.thread_reply_recipients.contains(&user_id(commenter)),
+        "a prior commenter should be subscribed to subsequent replies even when they are not the owner or an assignee"
+    );
+    assert!(result.assignee_recipients.is_empty());
+    assert_eq!(result.doc_owner_recipient.as_deref(), Some(owner.as_ref()));
+    assert_eq!(result.all_recipients().len(), result.total_count());
+}
+
+#[test]
 fn reply_notifies_thread_participants_and_doc_owner() {
     let sender = user_id("macro|sender@test.com");
     let owner = user_id("macro|owner@test.com");


### PR DESCRIPTION
this pr fixes a bug where a non-owner and non-assignee commenter on a thread was not getting subscribed to the notificaitons for the thread
