### PR TITLE
fix web app archive deploy

### DIFF
--- a/infra/stacks/web-app/index.ts
+++ b/infra/stacks/web-app/index.ts
@@ -88,7 +88,7 @@ execSync(`cp ${buildOutputPath}/index.html ./appRouteLambda/index.html`, {
 const syncAssetsCommand = new command.local.Command(
   'sync-assets-command',
   {
-    create: pulumi.interpolate`aws s3 sync ./output s3://${webAppAssets.bucket} --acl public-read --delete${stack === 'prod' ? ' --exclude "*.js.map"' : ''}`,
+    create: pulumi.interpolate`aws s3 sync ./output s3://${webAppAssets.bucket} --acl public-read --delete --exclude "app/app-archive.zip"${stack === 'prod' ? ' --exclude "*.js.map"' : ''}`,
     triggers: [Date.now()],
   },
   {


### PR DESCRIPTION
Currently the dev app deploy and the prod app deploy differ in the way the artifacts are uploaded. The prod deployment destroys the archive.zip file used for auto update, but the dev deploy does not.

This PR fixes the prod deploy so it doesn't destroy this file
