### PR TITLE
feat(search): return total_count from channel search

### DIFF
--- a/js/app/packages/service-clients/service-search/generated/models/channelSearchResponse.ts
+++ b/js/app/packages/service-clients/service-search/generated/models/channelSearchResponse.ts
@@ -16,4 +16,6 @@ export interface ChannelSearchResponse {
   next_cursor?: ChannelSearchResponseNextCursor;
   /** List containing results from email threads */
   results: ChannelSearchResponseItemWithMetadata[];
+  /** Total number of matching channel messages across all pages. */
+  total_count: number;
 }

--- a/js/app/packages/service-clients/service-search/openapi.json
+++ b/js/app/packages/service-clients/service-search/openapi.json
@@ -472,7 +472,7 @@
       "ChannelSearchResponse": {
         "type": "object",
         "description": "The document search response object",
-        "required": ["results"],
+        "required": ["results", "total_count"],
         "properties": {
           "next_cursor": {
             "type": ["string", "null"],
@@ -484,6 +484,11 @@
               "$ref": "#/components/schemas/ChannelSearchResponseItemWithMetadata"
             },
             "description": "List containing results from email threads"
+          },
+          "total_count": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Total number of matching channel messages across all pages."
           }
         }
       },

--- a/rust/cloud-storage/models_search/src/channel.rs
+++ b/rust/cloud-storage/models_search/src/channel.rs
@@ -115,6 +115,11 @@ pub struct ChannelSearchResponse {
     /// Base64-encoded cursor for the next page; `None` when exhausted.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub next_cursor: Option<String>,
+    /// Total number of matching channel messages across all pages, after
+    /// excluding deleted messages observed on the current page. Sourced from
+    /// OpenSearch's `hits.total.value` and adjusted down for any soft- or
+    /// hard-deleted hits filtered out before they reached the response.
+    pub total_count: i64,
 }
 
 #[derive(Serialize, Deserialize, Debug, ToSchema, JsonSchema)]

--- a/rust/cloud-storage/models_search/src/channel.rs
+++ b/rust/cloud-storage/models_search/src/channel.rs
@@ -115,10 +115,7 @@ pub struct ChannelSearchResponse {
     /// Base64-encoded cursor for the next page; `None` when exhausted.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub next_cursor: Option<String>,
-    /// Total number of matching channel messages across all pages, after
-    /// excluding deleted messages observed on the current page. Sourced from
-    /// OpenSearch's `hits.total.value` and adjusted down for any soft- or
-    /// hard-deleted hits filtered out before they reached the response.
+    /// Total number of matching channel messages across all pages.
     pub total_count: i64,
 }
 

--- a/rust/cloud-storage/opensearch_client/src/channel_message.rs
+++ b/rust/cloud-storage/opensearch_client/src/channel_message.rs
@@ -1,18 +1,16 @@
-use models_search_cursor::SearchCursorOption;
-
 use crate::{
     OpensearchClient, Result, delete,
-    search::{self, channels::ChannelSearchArgs, model::SearchHit},
+    search::{
+        self,
+        channels::{ChannelSearchArgs, ChannelSearchResults},
+    },
     upsert::{self, channel_message::UpsertChannelMessageArgs},
 };
 
 impl OpensearchClient {
     /// Performs a channel content search.
     #[tracing::instrument(skip(self, args))]
-    pub async fn search_channel(
-        &self,
-        args: ChannelSearchArgs,
-    ) -> Result<(Vec<SearchHit>, SearchCursorOption)> {
+    pub async fn search_channel(&self, args: ChannelSearchArgs) -> Result<ChannelSearchResults> {
         search::channels::search_channel(&self.inner, args).await
     }
 }

--- a/rust/cloud-storage/opensearch_client/src/search/channels.rs
+++ b/rust/cloud-storage/opensearch_client/src/search/channels.rs
@@ -207,11 +207,20 @@ fn build_channel_search_request(
     Ok(request_builder.build())
 }
 
+/// Result of a channel search: hits for the current page, the cursor for the
+/// next page, and the total number of matching messages reported by
+/// OpenSearch (`hits.total.value`).
+pub struct ChannelSearchResults {
+    pub hits: Vec<SearchHit>,
+    pub next_cursor: SearchCursorOption,
+    pub total: i64,
+}
+
 #[tracing::instrument(skip(client, args), err)]
 pub(crate) async fn search_channel(
     client: &opensearch::OpenSearch,
     args: ChannelSearchArgs,
-) -> Result<(Vec<SearchHit>, SearchCursorOption)> {
+) -> Result<ChannelSearchResults> {
     let mut search_request = build_channel_search_request(&args)?.to_json();
     inject_fragment_size(&mut search_request, 1000);
     exclude_source_content(&mut search_request);
@@ -246,20 +255,22 @@ pub(crate) async fn search_channel(
             raw_body: String::from_utf8_lossy(&bytes).to_string(),
         })?;
 
-    let mut results: Vec<SearchHit> = result
+    let total = result.hits.total.value;
+
+    let mut hits: Vec<SearchHit> = result
         .hits
         .hits
         .into_iter()
         .map(channel_hit_to_search_hit)
         .collect();
 
-    let has_more = results.len() > args.page_size as usize;
+    let has_more = hits.len() > args.page_size as usize;
     if has_more {
-        results.pop();
+        hits.pop();
     }
 
-    let cursor = if has_more {
-        let last_cursor = results
+    let next_cursor = if has_more {
+        let last_cursor = hits
             .last()
             .and_then(|last| build_channel_cursor(last, args.sort_mode));
         SearchCursorOption::NotDone(last_cursor)
@@ -267,7 +278,11 @@ pub(crate) async fn search_channel(
         SearchCursorOption::Done
     };
 
-    Ok((results, cursor))
+    Ok(ChannelSearchResults {
+        hits,
+        next_cursor,
+        total,
+    })
 }
 
 fn channel_hit_to_search_hit(hit: Hit<ChannelMessageIndex>) -> SearchHit {

--- a/rust/cloud-storage/opensearch_client/src/search/channels.rs
+++ b/rust/cloud-storage/opensearch_client/src/search/channels.rs
@@ -207,9 +207,6 @@ fn build_channel_search_request(
     Ok(request_builder.build())
 }
 
-/// Result of a channel search: hits for the current page, the cursor for the
-/// next page, and the total number of matching messages reported by
-/// OpenSearch (`hits.total.value`).
 pub struct ChannelSearchResults {
     pub hits: Vec<SearchHit>,
     pub next_cursor: SearchCursorOption,

--- a/rust/cloud-storage/search_service/src/api/search/channel.rs
+++ b/rust/cloud-storage/search_service/src/api/search/channel.rs
@@ -92,12 +92,9 @@ pub fn construct_search_result(
         .filter_map(|hit| {
             let result = if let Some(SearchGotoContent::Channels(goto)) = hit.goto {
                 // Drop content-match hits whose underlying message no longer exists in
-                // the DB (hard-deleted / stale OpenSearch entries) or has been
-                // soft-deleted — neither should surface to users.
+                // the DB — those are stale OpenSearch entries (e.g. hard-deleted) that
+                // shouldn't surface to users.
                 let deleted_at = *message_states.get(&goto.channel_message_id)?;
-                if deleted_at.is_some() {
-                    return None;
-                }
                 ChannelSearchResult {
                     highlight: hit.highlight.into(),
                     score: hit.score,

--- a/rust/cloud-storage/search_service/src/api/search/channel.rs
+++ b/rust/cloud-storage/search_service/src/api/search/channel.rs
@@ -31,13 +31,38 @@ pub(in crate::api::search) async fn enrich_channels(
     results: Vec<opensearch_client::search::model::SearchHit>,
     sort_timestamp: ChannelSortTimestamp,
 ) -> Result<Vec<ChannelSearchResponseItemWithMetadata>, SearchError> {
+    let EnrichChannelsResult { items, .. } =
+        enrich_channels_inner(ctx, user_id, results, sort_timestamp).await?;
+    Ok(items)
+}
+
+/// Output of [`enrich_channels_inner`]: the enriched items, plus the number of
+/// content-match hits that were dropped because the underlying message was
+/// hard- or soft-deleted. Callers that report a `total_count` should subtract
+/// `dropped_deleted` from the OpenSearch total to keep the count in sync with
+/// what the user sees.
+pub(in crate::api::search) struct EnrichChannelsResult {
+    pub items: Vec<ChannelSearchResponseItemWithMetadata>,
+    pub dropped_deleted: i64,
+}
+
+#[tracing::instrument(skip(ctx, results), err)]
+pub(in crate::api::search) async fn enrich_channels_inner(
+    ctx: &SearchHandlerState,
+    user_id: &str,
+    results: Vec<opensearch_client::search::model::SearchHit>,
+    sort_timestamp: ChannelSortTimestamp,
+) -> Result<EnrichChannelsResult, SearchError> {
     let results: Vec<opensearch_client::search::model::SearchHit> = results
         .into_iter()
         .filter(|r| r.entity_type == models_opensearch::SearchEntityType::Channels)
         .collect();
 
     if results.is_empty() {
-        return Ok(vec![]);
+        return Ok(EnrichChannelsResult {
+            items: vec![],
+            dropped_deleted: 0,
+        });
     }
 
     // Extract channel IDs from results
@@ -72,12 +97,31 @@ pub(in crate::api::search) async fn enrich_channels(
     )
     .map_err(SearchError::InternalError)?;
 
-    // Construct enriched results
-    let enriched_results =
-        construct_search_result(results, channel_histories, message_states, sort_timestamp)
-            .map_err(SearchError::InternalError)?;
+    // Count content-match hits whose underlying message is hard- or soft-deleted.
+    // These will be dropped by `construct_search_result` below, so the caller
+    // can adjust totals to match.
+    let dropped_deleted: i64 = results
+        .iter()
+        .filter(|r| {
+            let Some(SearchGotoContent::Channels(goto)) = &r.goto else {
+                return false;
+            };
+            match message_states.get(&goto.channel_message_id) {
+                None => true,          // hard-deleted (no row in DB)
+                Some(Some(_)) => true, // soft-deleted (has deleted_at)
+                Some(None) => false,   // live
+            }
+        })
+        .count() as i64;
 
-    Ok(enriched_results)
+    // Construct enriched results
+    let items = construct_search_result(results, channel_histories, message_states, sort_timestamp)
+        .map_err(SearchError::InternalError)?;
+
+    Ok(EnrichChannelsResult {
+        items,
+        dropped_deleted,
+    })
 }
 
 pub fn construct_search_result(
@@ -92,9 +136,12 @@ pub fn construct_search_result(
         .filter_map(|hit| {
             let result = if let Some(SearchGotoContent::Channels(goto)) = hit.goto {
                 // Drop content-match hits whose underlying message no longer exists in
-                // the DB — those are stale OpenSearch entries (e.g. hard-deleted) that
-                // shouldn't surface to users.
+                // the DB (hard-deleted / stale OpenSearch entries) or has been
+                // soft-deleted — neither should surface to users.
                 let deleted_at = *message_states.get(&goto.channel_message_id)?;
+                if deleted_at.is_some() {
+                    return None;
+                }
                 ChannelSearchResult {
                     highlight: hit.highlight.into(),
                     score: hit.score,
@@ -245,13 +292,25 @@ pub async fn handler(
         sort_mode,
     };
 
-    let (hits, next_cursor) = ctx
+    let opensearch_client::search::channels::ChannelSearchResults {
+        hits,
+        next_cursor,
+        total,
+    } = ctx
         .opensearch_client
         .search_channel(args)
         .await
         .map_err(SearchError::Search)?;
 
-    let results = enrich_channels(&ctx, user_id.as_ref(), hits, req.sort).await?;
+    let EnrichChannelsResult {
+        items: results,
+        dropped_deleted,
+    } = enrich_channels_inner(&ctx, user_id.as_ref(), hits, req.sort).await?;
+
+    // Best-effort total: OpenSearch reports total matches across all pages,
+    // but the index can lag deletes. Subtract the deletions we detected on
+    // this page so the surfaced number is at least as accurate as the results.
+    let total_count = (total - dropped_deleted).max(0);
 
     let next_cursor = match next_cursor {
         SearchCursorOption::NotDone(Some(c)) => c.encode(),
@@ -261,6 +320,7 @@ pub async fn handler(
     Ok(Json(ChannelSearchResponse {
         results,
         next_cursor,
+        total_count,
     }))
 }
 

--- a/rust/cloud-storage/search_service/src/api/search/channel.rs
+++ b/rust/cloud-storage/search_service/src/api/search/channel.rs
@@ -31,38 +31,13 @@ pub(in crate::api::search) async fn enrich_channels(
     results: Vec<opensearch_client::search::model::SearchHit>,
     sort_timestamp: ChannelSortTimestamp,
 ) -> Result<Vec<ChannelSearchResponseItemWithMetadata>, SearchError> {
-    let EnrichChannelsResult { items, .. } =
-        enrich_channels_inner(ctx, user_id, results, sort_timestamp).await?;
-    Ok(items)
-}
-
-/// Output of [`enrich_channels_inner`]: the enriched items, plus the number of
-/// content-match hits that were dropped because the underlying message was
-/// hard- or soft-deleted. Callers that report a `total_count` should subtract
-/// `dropped_deleted` from the OpenSearch total to keep the count in sync with
-/// what the user sees.
-pub(in crate::api::search) struct EnrichChannelsResult {
-    pub items: Vec<ChannelSearchResponseItemWithMetadata>,
-    pub dropped_deleted: i64,
-}
-
-#[tracing::instrument(skip(ctx, results), err)]
-pub(in crate::api::search) async fn enrich_channels_inner(
-    ctx: &SearchHandlerState,
-    user_id: &str,
-    results: Vec<opensearch_client::search::model::SearchHit>,
-    sort_timestamp: ChannelSortTimestamp,
-) -> Result<EnrichChannelsResult, SearchError> {
     let results: Vec<opensearch_client::search::model::SearchHit> = results
         .into_iter()
         .filter(|r| r.entity_type == models_opensearch::SearchEntityType::Channels)
         .collect();
 
     if results.is_empty() {
-        return Ok(EnrichChannelsResult {
-            items: vec![],
-            dropped_deleted: 0,
-        });
+        return Ok(vec![]);
     }
 
     // Extract channel IDs from results
@@ -97,31 +72,12 @@ pub(in crate::api::search) async fn enrich_channels_inner(
     )
     .map_err(SearchError::InternalError)?;
 
-    // Count content-match hits whose underlying message is hard- or soft-deleted.
-    // These will be dropped by `construct_search_result` below, so the caller
-    // can adjust totals to match.
-    let dropped_deleted: i64 = results
-        .iter()
-        .filter(|r| {
-            let Some(SearchGotoContent::Channels(goto)) = &r.goto else {
-                return false;
-            };
-            match message_states.get(&goto.channel_message_id) {
-                None => true,          // hard-deleted (no row in DB)
-                Some(Some(_)) => true, // soft-deleted (has deleted_at)
-                Some(None) => false,   // live
-            }
-        })
-        .count() as i64;
-
     // Construct enriched results
-    let items = construct_search_result(results, channel_histories, message_states, sort_timestamp)
-        .map_err(SearchError::InternalError)?;
+    let enriched_results =
+        construct_search_result(results, channel_histories, message_states, sort_timestamp)
+            .map_err(SearchError::InternalError)?;
 
-    Ok(EnrichChannelsResult {
-        items,
-        dropped_deleted,
-    })
+    Ok(enriched_results)
 }
 
 pub fn construct_search_result(
@@ -295,22 +251,14 @@ pub async fn handler(
     let opensearch_client::search::channels::ChannelSearchResults {
         hits,
         next_cursor,
-        total,
+        total: total_count,
     } = ctx
         .opensearch_client
         .search_channel(args)
         .await
         .map_err(SearchError::Search)?;
 
-    let EnrichChannelsResult {
-        items: results,
-        dropped_deleted,
-    } = enrich_channels_inner(&ctx, user_id.as_ref(), hits, req.sort).await?;
-
-    // Best-effort total: OpenSearch reports total matches across all pages,
-    // but the index can lag deletes. Subtract the deletions we detected on
-    // this page so the surfaced number is at least as accurate as the results.
-    let total_count = (total - dropped_deleted).max(0);
+    let results = enrich_channels(&ctx, user_id.as_ref(), hits, req.sort).await?;
 
     let next_cursor = match next_cursor {
         SearchCursorOption::NotDone(Some(c)) => c.encode(),

--- a/rust/cloud-storage/search_service/src/api/search/channel/test.rs
+++ b/rust/cloud-storage/search_service/src/api/search/channel/test.rs
@@ -265,7 +265,7 @@ fn test_construct_search_result_filters_messages_without_content() {
 }
 
 #[test]
-fn test_construct_search_result_filters_orphans_and_propagates_deleted_at() {
+fn test_construct_search_result_filters_deleted_and_orphan_hits() {
     let channel_uuid: Uuid = "550e8400-e29b-41d4-a716-446655440099".parse().unwrap();
     let active_message_id: Uuid = "11111111-1111-1111-1111-111111111111".parse().unwrap();
     let deleted_message_id: Uuid = "22222222-2222-2222-2222-222222222222".parse().unwrap();
@@ -314,14 +314,13 @@ fn test_construct_search_result_filters_orphans_and_propagates_deleted_at() {
 
     assert_eq!(result.len(), 1);
     let hits = &result[0].extra.channel_message_search_results;
-    assert_eq!(hits.len(), 2, "orphan hit should be filtered out");
-
-    let by_id: HashMap<Uuid, &ChannelSearchResult> =
-        hits.iter().map(|h| (h.message_id.unwrap(), h)).collect();
-
-    assert_eq!(by_id[&active_message_id].deleted_at, None);
-    assert_eq!(by_id[&deleted_message_id].deleted_at, Some(deleted_at));
-    assert!(!by_id.contains_key(&orphan_message_id));
+    assert_eq!(
+        hits.len(),
+        1,
+        "soft-deleted and orphan hits should both be filtered out"
+    );
+    assert_eq!(hits[0].message_id, Some(active_message_id));
+    assert_eq!(hits[0].deleted_at, None);
 }
 
 fn create_test_channel_response(

--- a/rust/cloud-storage/search_service/src/api/search/channel/test.rs
+++ b/rust/cloud-storage/search_service/src/api/search/channel/test.rs
@@ -265,7 +265,7 @@ fn test_construct_search_result_filters_messages_without_content() {
 }
 
 #[test]
-fn test_construct_search_result_filters_deleted_and_orphan_hits() {
+fn test_construct_search_result_filters_orphans_and_propagates_deleted_at() {
     let channel_uuid: Uuid = "550e8400-e29b-41d4-a716-446655440099".parse().unwrap();
     let active_message_id: Uuid = "11111111-1111-1111-1111-111111111111".parse().unwrap();
     let deleted_message_id: Uuid = "22222222-2222-2222-2222-222222222222".parse().unwrap();
@@ -314,13 +314,14 @@ fn test_construct_search_result_filters_deleted_and_orphan_hits() {
 
     assert_eq!(result.len(), 1);
     let hits = &result[0].extra.channel_message_search_results;
-    assert_eq!(
-        hits.len(),
-        1,
-        "soft-deleted and orphan hits should both be filtered out"
-    );
-    assert_eq!(hits[0].message_id, Some(active_message_id));
-    assert_eq!(hits[0].deleted_at, None);
+    assert_eq!(hits.len(), 2, "orphan hit should be filtered out");
+
+    let by_id: HashMap<Uuid, &ChannelSearchResult> =
+        hits.iter().map(|h| (h.message_id.unwrap(), h)).collect();
+
+    assert_eq!(by_id[&active_message_id].deleted_at, None);
+    assert_eq!(by_id[&deleted_message_id].deleted_at, Some(deleted_at));
+    assert!(!by_id.contains_key(&orphan_message_id));
 }
 
 fn create_test_channel_response(


### PR DESCRIPTION
Surfaces `total_count` on the channel search endpoint by passing OpenSearch's `hits.total.value` through unchanged. currently we filter out hard-deleted results (but soft-deleted with a deleted_at field go through fine) so it will be up to the FE to handle if we do experience that for some reason
