### PR TITLE
feat(calls): add call again button to call records

### DIFF
--- a/js/app/packages/block-call/component/CallRecording/CallRecordingMetaStrip.tsx
+++ b/js/app/packages/block-call/component/CallRecording/CallRecordingMetaStrip.tsx
@@ -2,6 +2,7 @@ import Subtitles from '@phosphor-icons/core/assets/regular/subtitles.svg';
 import SubtitlesSlash from '@phosphor-icons/core/assets/regular/subtitles-slash.svg';
 import UserCircle from '@phosphor-icons/core/assets/regular/user-circle.svg';
 import UserCircleMinus from '@phosphor-icons/core/assets/regular/user-circle-minus.svg';
+import { CallAgainButton } from '@channel/Call/CallAgainButton';
 import type { CallRecord } from '@service-storage/generated/schemas/callRecord';
 import { cn } from '@ui';
 import { format } from 'date-fns';
@@ -42,6 +43,12 @@ export function CallRecordingMetaStrip(props: {
         </Show>
       </div>
       <div class="flex items-center gap-1.5">
+        <Show when={!props.record.isActive}>
+          <CallAgainButton
+            channelId={props.record.channelId}
+            class={cn(CALL_META_STRIP_TOGGLE_IDLE, 'shrink-0')}
+          />
+        </Show>
         <button
           type="button"
           class={cn(

--- a/js/app/packages/block-call/component/CallRecording/CallRecordingMetaStrip.tsx
+++ b/js/app/packages/block-call/component/CallRecording/CallRecordingMetaStrip.tsx
@@ -1,8 +1,8 @@
+import { CallAgainButton } from '@channel/Call/CallAgainButton';
 import Subtitles from '@phosphor-icons/core/assets/regular/subtitles.svg';
 import SubtitlesSlash from '@phosphor-icons/core/assets/regular/subtitles-slash.svg';
 import UserCircle from '@phosphor-icons/core/assets/regular/user-circle.svg';
 import UserCircleMinus from '@phosphor-icons/core/assets/regular/user-circle-minus.svg';
-import { CallAgainButton } from '@channel/Call/CallAgainButton';
 import type { CallRecord } from '@service-storage/generated/schemas/callRecord';
 import { cn } from '@ui';
 import { format } from 'date-fns';

--- a/js/app/packages/channel/Call/CallAgainButton.tsx
+++ b/js/app/packages/channel/Call/CallAgainButton.tsx
@@ -1,0 +1,21 @@
+import PhoneCallIcon from '@macro-icons/wide/call.svg';
+import { useCall } from './use-call';
+
+export function CallAgainButton(props: { channelId: string; class?: string }) {
+  const call = useCall(() => props.channelId);
+  return (
+    <button
+      type="button"
+      class={props.class}
+      disabled={call.isJoining()}
+      title="Call again"
+      onClick={(e) => {
+        e.stopPropagation();
+        void call.joinCall();
+      }}
+    >
+      <PhoneCallIcon class="size-4 shrink-0" />
+      Call again
+    </button>
+  );
+}

--- a/js/app/packages/entity/src/composed/list-entity/call.tsx
+++ b/js/app/packages/entity/src/composed/list-entity/call.tsx
@@ -1,4 +1,5 @@
 import { formatCallDuration } from '@block-call/utils';
+import { CallAgainButton } from '@channel/Call/CallAgainButton';
 import { UserGroup } from '@core/component/Properties/component/propertyValue/UserGroup';
 import { usePropertyEntityDisplay } from '@core/component/Properties/hooks';
 import type { EntityReference } from '@core/component/Properties/types';
@@ -65,6 +66,15 @@ export function CallParticipants(props: { participantIds: string[] }) {
         <UserGroup entities={entities()} maxUsers={2} />
       </Tooltip>
     </Show>
+  );
+}
+
+export function CallListAgainButton(props: { channelId: string }) {
+  return (
+    <CallAgainButton
+      channelId={props.channelId}
+      class="opacity-0 group-hover/narrow:opacity-100 transition-opacity flex shrink-0 items-center gap-1 rounded-xs border border-edge-muted px-1.5 py-1 text-xs font-medium text-ink-muted hover:bg-hover hover:text-ink focus-visible:outline-none"
+    />
   );
 }
 

--- a/js/app/packages/entity/src/composed/list-entity/call.tsx
+++ b/js/app/packages/entity/src/composed/list-entity/call.tsx
@@ -1,5 +1,4 @@
 import { formatCallDuration } from '@block-call/utils';
-import { CallAgainButton } from '@channel/Call/CallAgainButton';
 import { UserGroup } from '@core/component/Properties/component/propertyValue/UserGroup';
 import { usePropertyEntityDisplay } from '@core/component/Properties/hooks';
 import type { EntityReference } from '@core/component/Properties/types';
@@ -66,15 +65,6 @@ export function CallParticipants(props: { participantIds: string[] }) {
         <UserGroup entities={entities()} maxUsers={2} />
       </Tooltip>
     </Show>
-  );
-}
-
-export function CallListAgainButton(props: { channelId: string }) {
-  return (
-    <CallAgainButton
-      channelId={props.channelId}
-      class="opacity-0 group-hover/narrow:opacity-100 transition-opacity flex shrink-0 items-center gap-1 rounded-xs border border-edge-muted px-1.5 py-1 text-xs font-medium text-ink-muted hover:bg-hover hover:text-ink focus-visible:outline-none"
-    />
   );
 }
 

--- a/js/app/packages/entity/src/composed/list-entity/wide-layout.tsx
+++ b/js/app/packages/entity/src/composed/list-entity/wide-layout.tsx
@@ -1,4 +1,5 @@
 import { useMaybeSoupView } from '@app/component/next-soup/soup-view/soup-view-context';
+import { CallAgainButton } from '@channel/Call/CallAgainButton';
 import { cn } from '@ui';
 import { Match, Show, Switch } from 'solid-js';
 import { AttendanceBadge, SharedBadge } from '../../components/Badges';
@@ -17,7 +18,6 @@ import {
 } from '../../types/entity';
 import { isSearchEntity } from '../../types/search';
 import { AutomationWideContent } from './automation';
-import { CallAgainButton } from '@channel/Call/CallAgainButton';
 import { CallParticipants, CallWideContent } from './call';
 import { ChannelMessageWideContent, ChannelWideContent } from './channel';
 import { EmailWideContent } from './email';

--- a/js/app/packages/entity/src/composed/list-entity/wide-layout.tsx
+++ b/js/app/packages/entity/src/composed/list-entity/wide-layout.tsx
@@ -17,7 +17,8 @@ import {
 } from '../../types/entity';
 import { isSearchEntity } from '../../types/search';
 import { AutomationWideContent } from './automation';
-import { CallListAgainButton, CallParticipants, CallWideContent } from './call';
+import { CallAgainButton } from '@channel/Call/CallAgainButton';
+import { CallParticipants, CallWideContent } from './call';
 import { ChannelMessageWideContent, ChannelWideContent } from './channel';
 import { EmailWideContent } from './email';
 import type { LayoutProps } from './shared';
@@ -118,7 +119,10 @@ export function WideLayout(props: LayoutProps) {
           {(entity) => (
             <>
               <Show when={!entity().isActive}>
-                <CallListAgainButton channelId={entity().channelId} />
+                <CallAgainButton
+                  channelId={entity().channelId}
+                  class="opacity-0 group-hover/narrow:opacity-100 transition-opacity flex shrink-0 items-center gap-1 rounded-xs border border-edge-muted px-1.5 py-1 text-xs font-medium text-ink-muted hover:bg-hover hover:text-ink focus-visible:outline-none"
+                />
               </Show>
               <Show when={(soupView?.activeTab() ?? 'all') === 'all'}>
                 <AttendanceBadge attended={entity().attended} />

--- a/js/app/packages/entity/src/composed/list-entity/wide-layout.tsx
+++ b/js/app/packages/entity/src/composed/list-entity/wide-layout.tsx
@@ -17,7 +17,7 @@ import {
 } from '../../types/entity';
 import { isSearchEntity } from '../../types/search';
 import { AutomationWideContent } from './automation';
-import { CallParticipants, CallWideContent } from './call';
+import { CallListAgainButton, CallParticipants, CallWideContent } from './call';
 import { ChannelMessageWideContent, ChannelWideContent } from './channel';
 import { EmailWideContent } from './email';
 import type { LayoutProps } from './shared';
@@ -117,6 +117,9 @@ export function WideLayout(props: LayoutProps) {
         <Show when={isCallEntity(props.entity) && props.entity}>
           {(entity) => (
             <>
+              <Show when={!entity().isActive}>
+                <CallListAgainButton channelId={entity().channelId} />
+              </Show>
               <Show when={(soupView?.activeTab() ?? 'all') === 'all'}>
                 <AttendanceBadge attended={entity().attended} />
               </Show>


### PR DESCRIPTION
Add "Call again" button to call list items and call record pages so user can easily start a call with the same participants.