### PR TITLE
fix(soup): drop mention AND filter from soup search bar

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/create-search-state.ts
+++ b/js/app/packages/app/component/next-soup/soup-view/create-search-state.ts
@@ -124,7 +124,6 @@ interface CreateSearchStateArgs {
   assignees: Accessor<string[]>;
   disableLocalSearch?: boolean;
   searchPaused?: Accessor<boolean>;
-  searchMentions?: Accessor<string[]>;
   /** Pre-populate searchText so the service request fires on mount (skips the debounce wait for the initial value). */
   initialText?: string;
 }
@@ -135,7 +134,6 @@ export const createSearchState = ({
   assignees,
   disableLocalSearch,
   searchPaused,
-  searchMentions,
   initialText,
 }: CreateSearchStateArgs) => {
   const [searchText, setSearchText] = createSignal(initialText ?? '');
@@ -174,21 +172,7 @@ export const createSearchState = ({
   const searchUnifiedNameContentRequest = createMemo(
     (): UnifiedSearchRequest => {
       const query = debouncedSearchForService();
-      const mentionIds =
-        isSearchServiceDebounceSettled() && !isSearchServiceDisabled()
-          ? searchMentions?.()
-          : undefined;
-
-      // Translate FilterData to legacy EntityFilters format for search service
       const baseFilters = filterDataToQueryFilters(filters());
-
-      // Merge mention filters into channel_filters if present
-      if (mentionIds && mentionIds.length > 0) {
-        baseFilters.channel_filters = {
-          ...baseFilters.channel_filters,
-          mentions: mentionIds,
-        };
-      }
 
       return {
         search_on: 'name_content',

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/soup-view-search-bar.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/soup-view-search-bar.tsx
@@ -43,14 +43,12 @@ const variantStyles: Record<SearchbarVariant, string> = {
 };
 
 export const SoupSearchbar = (props: SoupSearchbarProps) => {
-  const { setSearchText, setSearchPaused, setSearchMentions, queryFilters } =
-    useSoupView();
+  const { setSearchText, setSearchPaused, queryFilters } = useSoupView();
   const soup = useSoup();
   const panel = useSplitPanelOrThrow();
 
   const [hasContent, setHasContent] = createSignal(false);
   const [latestMarkdown, setLatestMarkdown] = createSignal('');
-  const [mentions, setMentions] = createSignal<string[]>([]);
 
   const editor = buildConfig('chat')
     .namespace('soup-search-bar')
@@ -58,16 +56,6 @@ export const SoupSearchbar = (props: SoupSearchbarProps) => {
     .withMentions({
       sources: ['users'],
       disableMentionTracking: true,
-      onCreate: (mention) => {
-        if (mention.itemType !== 'user') return;
-        setMentions((prev) =>
-          prev.includes(mention.itemId) ? prev : [...prev, mention.itemId]
-        );
-      },
-      onRemove: (mention) => {
-        if (mention.itemType !== 'user') return;
-        setMentions((prev) => prev.filter((m) => m !== mention.itemId));
-      },
     })
     .withHistory({ timeGap: 400 })
     .onChange((markdown) => {
@@ -100,9 +88,9 @@ export const SoupSearchbar = (props: SoupSearchbarProps) => {
       )
     );
 
-  // Sync search text + mention filters only when the mention menu is closed.
-  // This avoids cascading reactive updates during mention insertion and
-  // prevents search from firing while typing @partial.
+  // Sync search text only when the mention menu is closed. This avoids
+  // cascading reactive updates during mention insertion and prevents search
+  // from firing while typing @partial.
   const menuIsOpen = () => editor.controls.isInlineMenuOpen();
 
   createEffect(() => setSearchPaused(menuIsOpen()));
@@ -113,8 +101,6 @@ export const SoupSearchbar = (props: SoupSearchbarProps) => {
       setSearchText(markdownToPlainText(markdown).trim());
     })
   );
-
-  createEffect(() => setSearchMentions(mentions()));
 
   const searchHotkey = registerHotkey({
     hotkey: ['cmd+f'],
@@ -195,8 +181,6 @@ export const SoupSearchbar = (props: SoupSearchbarProps) => {
               editor.controls.clear();
               setSearchText('');
               setHasContent(false);
-              setMentions([]);
-              setSearchMentions([]);
               props.onDismiss?.();
             }}
           >

--- a/js/app/packages/app/component/next-soup/soup-view/soup-view-context.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-view-context.tsx
@@ -52,8 +52,6 @@ interface SoupViewContextValues {
   setSearchText: (value: string) => void;
   searchPaused: Accessor<boolean>;
   setSearchPaused: Setter<boolean>;
-  searchMentions: Accessor<string[]>;
-  setSearchMentions: Setter<string[]>;
   featuredIds: Accessor<string[]>;
   rows: Accessor<SoupRow[]>;
   isSearchServiceLoading: Accessor<boolean>;
@@ -162,7 +160,6 @@ export const SoupViewContextProvider: FlowComponent<
   };
 
   const [searchPaused, setSearchPaused] = createSignal(false);
-  const [searchMentions, setSearchMentions] = createSignal<string[]>([]);
   const [assigneeFilter, setAssigneeFilter] = createSignal<string[]>([]);
   const [activeTab, setActiveTab] = createSignal<string | undefined>(undefined);
 
@@ -182,7 +179,6 @@ export const SoupViewContextProvider: FlowComponent<
     assignees: assigneeFilter,
     disableLocalSearch: props.disableLocalSearch,
     searchPaused,
-    searchMentions,
     initialText: props.initialSearchText,
   });
 
@@ -338,8 +334,6 @@ export const SoupViewContextProvider: FlowComponent<
     setSearchText: search.setSearchText,
     searchPaused,
     setSearchPaused,
-    searchMentions,
-    setSearchMentions,
     featuredIds: search.featuredIds,
     isSearchServiceLoading: search.isSearchServiceLoading,
     isLocalSearchSettling: search.isLocalSearchSettling,


### PR DESCRIPTION
## Summary

In the soup search bar, an `@sean` pill produced both `searchText="sean@macro.com"` (via `markdownToPlainText` on the editor) and `searchMentions=["macro|sean@macro.com"]` (via the editor's onCreate). The mention array got merged into `channel_filters.mentions` and AND'd with the text query, which excluded any message where the same text was present via plain text or an `<m-link>` — surprising for a search-bar `@` shortcut. The text path alone is strictly broader (the indexed `content` already renders user mentions as their email), so the AND only subtracted. Drop the merge and remove the now-dead `searchMentions` plumbing through the soup view context. Surfaces that pass `channel_filters.mentions` outside the search bar are unaffected.
