### PR TITLE
feat(channel): show total match count in find bar

### DIFF
--- a/js/app/packages/channel/Channel/Channel.tsx
+++ b/js/app/packages/channel/Channel/Channel.tsx
@@ -131,7 +131,8 @@ export function Channel(props: ChannelProps) {
     channelId: () => props.channelId,
     initialTargetMessageId: props.targetMessageId,
     initialTargetMessageReplyId: props.targetMessageReplyId,
-    messageKeys: () => messageIndex.keys,
+    // changing the array reference is required to trigger the scroll effect
+    messageKeys: () => [...messageIndex.keys],
     navigation: threadListNavigation,
     didInitialScroll: () => threadListScrollState()?.didInitialScroll ?? false,
   });

--- a/js/app/packages/channel/Channel/create-channel-find-bar.ts
+++ b/js/app/packages/channel/Channel/create-channel-find-bar.ts
@@ -53,10 +53,17 @@ export function createChannelFindBar(
         if (!searchQuery.isSuccess) return [];
         const data = searchQuery.data;
         if (!data) return [];
-        return data.filter(
+        return data.items.filter(
           (e): e is WithSearch<ChannelMessageEntity> =>
             isChannelMessageEntity(e) && e.channelId === options.channelId()
         );
+      });
+
+      const totalCount = createMemo<number | undefined>(() => {
+        if (!submittedQuery()) return undefined;
+        if (searchQuery.isPlaceholderData) return undefined;
+        if (!searchQuery.isSuccess) return undefined;
+        return searchQuery.data?.totalCount;
       });
 
       // Prefetch the next page when the cursor approaches the end of the
@@ -74,6 +81,7 @@ export function createChannelFindBar(
 
       return {
         results,
+        totalCount,
         isFetching: () => searchQuery.isFetching,
         validateText: validateSearchServiceText,
         navigate: (result) => {

--- a/js/app/packages/channel/Thread/ChannelThread.tsx
+++ b/js/app/packages/channel/Thread/ChannelThread.tsx
@@ -156,10 +156,6 @@ export function ChannelThread(props: ThreadProps) {
 
   createEffect(
     on(
-      // Including `targetReplyId` makes this re-fire on every navigation cycle
-      // not just when the active target reply id changes so re-navigating to
-      // the same reply (eg resubmitting a find-bar query) restores the
-      // highlight after a channel-level clearSelection blip wiped it
       [() => props.selectedReplyId, () => props.targetReplyId, loadedReplies],
       ([selectedReplyId, _targetReplyId, replies]) => {
         if (!selectedReplyId) {

--- a/js/app/packages/channel/Thread/ChannelThread.tsx
+++ b/js/app/packages/channel/Thread/ChannelThread.tsx
@@ -156,8 +156,12 @@ export function ChannelThread(props: ThreadProps) {
 
   createEffect(
     on(
-      [() => props.selectedReplyId, loadedReplies],
-      ([selectedReplyId, replies]) => {
+      // Including `targetReplyId` makes this re-fire on every navigation cycle
+      // not just when the active target reply id changes so re-navigating to
+      // the same reply (eg resubmitting a find-bar query) restores the
+      // highlight after a channel-level clearSelection blip wiped it
+      [() => props.selectedReplyId, () => props.targetReplyId, loadedReplies],
+      ([selectedReplyId, _targetReplyId, replies]) => {
         if (!selectedReplyId) {
           if (replySelection.selectedId()) replySelection.clear();
           return;

--- a/js/app/packages/core/component/createFindBarController.ts
+++ b/js/app/packages/core/component/createFindBarController.ts
@@ -11,7 +11,6 @@ export type FindBarSource<T> = {
   isFetching: Accessor<boolean>;
   navigate: (result: T) => void;
   validateText?: (text: string) => boolean;
-  // server total when known otherwise denominator is results length
   totalCount?: Accessor<number | undefined>;
 };
 

--- a/js/app/packages/core/component/createFindBarController.ts
+++ b/js/app/packages/core/component/createFindBarController.ts
@@ -11,7 +11,7 @@ export type FindBarSource<T> = {
   isFetching: Accessor<boolean>;
   navigate: (result: T) => void;
   validateText?: (text: string) => boolean;
-  // server total when known otherwise denominator is results().length
+  // server total when known otherwise denominator is results length
   totalCount?: Accessor<number | undefined>;
 };
 

--- a/js/app/packages/core/component/createFindBarController.ts
+++ b/js/app/packages/core/component/createFindBarController.ts
@@ -11,10 +11,7 @@ export type FindBarSource<T> = {
   isFetching: Accessor<boolean>;
   navigate: (result: T) => void;
   validateText?: (text: string) => boolean;
-  /**
-   * Server-side total match count when known. When omitted, the controller
-   * falls back to `results().length` (loaded matches) as the denominator.
-   */
+  // server total when known otherwise denominator is results().length
   totalCount?: Accessor<number | undefined>;
 };
 

--- a/js/app/packages/core/component/createFindBarController.ts
+++ b/js/app/packages/core/component/createFindBarController.ts
@@ -11,6 +11,11 @@ export type FindBarSource<T> = {
   isFetching: Accessor<boolean>;
   navigate: (result: T) => void;
   validateText?: (text: string) => boolean;
+  /**
+   * Server-side total match count when known. When omitted, the controller
+   * falls back to `results().length` (loaded matches) as the denominator.
+   */
+  totalCount?: Accessor<number | undefined>;
 };
 
 export type FindBarController = {
@@ -51,8 +56,6 @@ export function createFindBarController<T>(
 
   const source = makeSource({ isOpen, submittedQuery, activeIndex });
   const validateText = source.validateText ?? ((text) => text.length > 0);
-
-  createEffect(on(submittedQuery, () => setActiveIndex(0), { defer: true }));
 
   createEffect(
     on(source.results, (rs) => {
@@ -119,7 +122,7 @@ export function createFindBarController<T>(
     activeIndex,
     hasUnsubmittedChanges: () => query().trim() !== submittedQuery(),
     isPending: () => !!submittedQuery() && source.isFetching(),
-    resultsCount: () => source.results().length,
+    resultsCount: () => source.totalCount?.() ?? source.results().length,
     open,
     close,
     submit,

--- a/js/app/packages/queries/soup/search.ts
+++ b/js/app/packages/queries/soup/search.ts
@@ -159,11 +159,16 @@ export const useSearchChannelQuery = (
       };
     },
     select: (data) => {
-      return data.pages.flatMap((page) =>
+      const items = data.pages.flatMap((page) =>
         page.results.flatMap((item) =>
           mapChannelSearchResultItem(item, channels())
         )
       ) as WithSearch<ChannelMessageEntity>[];
+      // `total_count` is stable per query (passed through from OpenSearch
+      // `hits.total.value`); reading from the first page is sufficient and
+      // remains defined while later pages are still in flight.
+      const totalCount = data.pages[0]?.total_count;
+      return { items, totalCount };
     },
     enabled: enabled(),
     placeholderData: (p) => p,

--- a/js/app/packages/queries/soup/search.ts
+++ b/js/app/packages/queries/soup/search.ts
@@ -164,9 +164,7 @@ export const useSearchChannelQuery = (
           mapChannelSearchResultItem(item, channels())
         )
       ) as WithSearch<ChannelMessageEntity>[];
-      // `total_count` is stable per query (passed through from OpenSearch
-      // `hits.total.value`); reading from the first page is sufficient and
-      // remains defined while later pages are still in flight.
+      // stable per query so first page is enough
       const totalCount = data.pages[0]?.total_count;
       return { items, totalCount };
     },


### PR DESCRIPTION
Threads the new `total_count` field from `/search/channel` (PR #3194) through the find-bar controller so the indicator renders `current / server-total` instead of `current / loaded-this-far`. Also drops a racing `submittedQuery` reset effect that fired after the results effect on cached resubmits and clobbered the cursor advance.
