### PR TITLE
fix(email): Reply all logic

### DIFF
--- a/js/app/packages/block-email/component/BottomReplyButtons.tsx
+++ b/js/app/packages/block-email/component/BottomReplyButtons.tsx
@@ -1,8 +1,11 @@
+import { useEmail } from '@core/context/user';
+import ArrowBendDoubleUpLeft from '@icon/regular/arrow-bend-double-up-left.svg';
 import ArrowBendUpLeft from '@icon/regular/arrow-bend-up-left.svg';
 import ArrowBendUpRight from '@icon/regular/arrow-bend-up-right.svg';
 import type { ApiMessage } from '@service-email/generated/schemas';
 import { createCallback } from '@solid-primitives/rootless';
 import { Button } from '@ui';
+import { Show } from 'solid-js';
 import type { ReplyType } from '../util/replyType';
 import { useEmailContext } from './EmailContext';
 import { getEmailFormRegistry } from './EmailFormContext';
@@ -10,6 +13,19 @@ import { getEmailFormRegistry } from './EmailFormContext';
 export function BottomReplyButtons(props: { lastMessage: ApiMessage }) {
   const ctx = useEmailContext();
   const formRegistry = getEmailFormRegistry();
+  const userEmail = useEmail();
+
+  const shouldShowReplyAll = () => {
+    const me = userEmail();
+    const sender = props.lastMessage.from?.email;
+    // If we sent the last message, Reply and Reply-all resolve to the
+    // same recipients (see getReplyRecipientsFromParent), so hide it.
+    if (sender === me) return false;
+    const isOther = (email: string) => email !== me && email !== sender;
+    const otherTo = props.lastMessage.to.filter((r) => isOther(r.email));
+    const otherCc = props.lastMessage.cc.filter((r) => isOther(r.email));
+    return otherTo.length + otherCc.length > 0;
+  };
 
   const open = (type: ReplyType) =>
     createCallback(() => {
@@ -25,25 +41,38 @@ export function BottomReplyButtons(props: { lastMessage: ApiMessage }) {
     });
 
   return (
-    <div class="w-full border-t border-edge-muted flex flex-row items-center justify-center gap-2 pt-3 pb-2">
-      <Button
-        variant="base"
-        size="md"
-        class="rounded-full px-4 py-1"
-        onClick={open('reply')}
-      >
-        <ArrowBendUpLeft class="size-4" />
-        <span>Reply</span>
-      </Button>
-      <Button
-        variant="base"
-        size="md"
-        class="rounded-full px-4 py-1"
-        onClick={open('forward')}
-      >
-        <ArrowBendUpRight class="size-4" />
-        <span>Forward</span>
-      </Button>
+    <div class="w-full border-t border-edge-muted pt-3 pb-2">
+      <div class="flex flex-row items-center gap-2 pl-[calc(var(--user-icon-width)+2*var(--message-padding-x))]">
+        <Button
+          variant="base"
+          size="md"
+          class="rounded-full px-4 py-1"
+          onClick={open('reply')}
+        >
+          <ArrowBendUpLeft class="size-4" />
+          <span>Reply</span>
+        </Button>
+        <Show when={shouldShowReplyAll()}>
+          <Button
+            variant="base"
+            size="md"
+            class="rounded-full px-4 py-1"
+            onClick={open('reply-all')}
+          >
+            <ArrowBendDoubleUpLeft class="size-4" />
+            <span>Reply all</span>
+          </Button>
+        </Show>
+        <Button
+          variant="base"
+          size="md"
+          class="rounded-full px-4 py-1"
+          onClick={open('forward')}
+        >
+          <ArrowBendUpRight class="size-4" />
+          <span>Forward</span>
+        </Button>
+      </div>
     </div>
   );
 }

--- a/js/app/packages/block-email/component/BottomReplyButtons.tsx
+++ b/js/app/packages/block-email/component/BottomReplyButtons.tsx
@@ -6,6 +6,7 @@ import type { ApiMessage } from '@service-email/generated/schemas';
 import { createCallback } from '@solid-primitives/rootless';
 import { Button } from '@ui';
 import { Show } from 'solid-js';
+import { isReplyAllEligible } from '../util/recipientConversion';
 import type { ReplyType } from '../util/replyType';
 import { useEmailContext } from './EmailContext';
 import { getEmailFormRegistry } from './EmailFormContext';
@@ -15,17 +16,8 @@ export function BottomReplyButtons(props: { lastMessage: ApiMessage }) {
   const formRegistry = getEmailFormRegistry();
   const userEmail = useEmail();
 
-  const shouldShowReplyAll = () => {
-    const me = userEmail();
-    const sender = props.lastMessage.from?.email;
-    // If we sent the last message, Reply and Reply-all resolve to the
-    // same recipients (see getReplyRecipientsFromParent), so hide it.
-    if (sender === me) return false;
-    const isOther = (email: string) => email !== me && email !== sender;
-    const otherTo = props.lastMessage.to.filter((r) => isOther(r.email));
-    const otherCc = props.lastMessage.cc.filter((r) => isOther(r.email));
-    return otherTo.length + otherCc.length > 0;
-  };
+  const shouldShowReplyAll = () =>
+    isReplyAllEligible(props.lastMessage, userEmail() ?? '');
 
   const open = (type: ReplyType) =>
     createCallback(() => {

--- a/js/app/packages/block-email/component/MessageActions.tsx
+++ b/js/app/packages/block-email/component/MessageActions.tsx
@@ -21,14 +21,16 @@ export function MessageActions(props: {
 }) {
   const formRegistry = getEmailFormRegistry();
   const userEmail = useEmail();
-  const filteredTo = () => {
-    return props.message.to.filter((to) => to.email !== userEmail());
-  };
-  const filteredCc = () => {
-    return props.message.cc.filter((cc) => cc.email !== userEmail());
-  };
   const shouldShowReplyAll = () => {
-    return filteredTo().length + filteredCc().length > 1;
+    const me = userEmail();
+    const sender = props.message.from?.email;
+    // If we sent the message, Reply and Reply-all resolve to the same
+    // recipients (see getReplyRecipientsFromParent), so hide it.
+    if (sender === me) return false;
+    const isOther = (email: string) => email !== me && email !== sender;
+    const otherTo = props.message.to.filter((r) => isOther(r.email));
+    const otherCc = props.message.cc.filter((r) => isOther(r.email));
+    return otherTo.length + otherCc.length > 0;
   };
 
   const canShowActions = () => {
@@ -55,26 +57,24 @@ export function MessageActions(props: {
 
   return (
     <div
-      class="flex flex-row items-center gap-4 transition-opacity"
+      class="flex flex-row items-center gap-1 transition-opacity"
       classList={{
         'opacity-0 pointer-events-none': !canShowActions(),
         'opacity-100': canShowActions(),
       }}
     >
+      <Show when={!props.hiddenActions?.includes('reply')}>
+        <Button
+          class="size-8 p-0 border-0 bg-transparent hover:bg-hover hover-transition-bg text-ink gap-0.5 active:bg-hover active:text-ink active:border-transparent"
+          onClick={onChangeReplyType('reply')}
+          tooltip="Reply"
+        >
+          <ArrowBendUpLeft class="size-5" />
+        </Button>
+      </Show>
       <Show
         when={
           shouldShowReplyAll() && !props.hiddenActions?.includes('reply-all')
-        }
-        fallback={
-          <Show when={!props.hiddenActions?.includes('reply')}>
-            <Button
-              class="size-8 p-0 border-0 bg-transparent hover:bg-hover hover-transition-bg text-ink gap-0.5 active:bg-hover active:text-ink active:border-transparent"
-              onClick={onChangeReplyType('reply')}
-              tooltip="Reply"
-            >
-              <ArrowBendUpLeft class="size-5" />
-            </Button>
-          </Show>
         }
       >
         <Button

--- a/js/app/packages/block-email/component/MessageActions.tsx
+++ b/js/app/packages/block-email/component/MessageActions.tsx
@@ -1,3 +1,4 @@
+import { isReplyAllEligible } from '@block-email/util/recipientConversion';
 import type { ReplyType } from '@block-email/util/replyType';
 import { useEmail } from '@core/context/user';
 import ArrowBendDoubleUpLeft from '@icon/regular/arrow-bend-double-up-left.svg';
@@ -21,17 +22,8 @@ export function MessageActions(props: {
 }) {
   const formRegistry = getEmailFormRegistry();
   const userEmail = useEmail();
-  const shouldShowReplyAll = () => {
-    const me = userEmail();
-    const sender = props.message.from?.email;
-    // If we sent the message, Reply and Reply-all resolve to the same
-    // recipients (see getReplyRecipientsFromParent), so hide it.
-    if (sender === me) return false;
-    const isOther = (email: string) => email !== me && email !== sender;
-    const otherTo = props.message.to.filter((r) => isOther(r.email));
-    const otherCc = props.message.cc.filter((r) => isOther(r.email));
-    return otherTo.length + otherCc.length > 0;
-  };
+  const shouldShowReplyAll = () =>
+    isReplyAllEligible(props.message, userEmail() ?? '');
 
   const canShowActions = () => {
     if (!props.showActions) return false;

--- a/js/app/packages/block-email/util/recipientConversion.ts
+++ b/js/app/packages/block-email/util/recipientConversion.ts
@@ -75,6 +75,22 @@ export const getReplyAllRecipients = (
   return { to, cc, bcc: [] };
 };
 
+// Whether Reply-all is meaningfully different from Reply for this message.
+// Hidden when the user sent the message (Reply == Reply-all per
+// getReplyRecipientsFromParent), or when no recipient remains in to/cc
+// after filtering out both the user and the sender.
+export const isReplyAllEligible = (
+  message: ApiMessage,
+  userEmail: string
+): boolean => {
+  const sender = message.from?.email;
+  if (sender === userEmail) return false;
+  const isOther = (email: string) => email !== userEmail && email !== sender;
+  const otherTo = message.to.filter((r) => isOther(r.email));
+  const otherCc = message.cc.filter((r) => isOther(r.email));
+  return otherTo.length + otherCc.length > 0;
+};
+
 export const getReplyRecipientsFromParent = (
   replyingTo: ApiMessage | undefined,
   userEmail: string


### PR DESCRIPTION
## Summary

Fixes the Reply-all logic across the per-message top bar and the new bottom Reply/Forward buttons:

- **Predicate now accounts for the sender.** Previously Reply-all could appear when the only other party in `to`/`cc` was the sender (or yourself), making it functionally identical to Reply. New rule: hide Reply-all when you sent the message; otherwise show it only when ≥1 recipient remains in `to`+`cc` after filtering out *both* you and the sender. This matches `getReplyRecipientsFromParent` in `recipientConversion.ts`.
- **Bottom buttons** now render Reply (always) + Reply all (conditional) + Forward, left-aligned and indented to line up flush with the email body (Gmail-style).
- **Per-message top bar** now shows Reply alongside Reply all (rather than one-or-the-other), with tighter spacing.

### Behavior matrix (you = `you@x.com`)

| Last message | Buttons shown |
|---|---|
| From: alice → To: you | Reply, Forward |
| From: alice → To: you, bob | Reply, Reply all, Forward |
| From: you → To: alice | Reply, Forward |
| From: alice → To: bob, carol; Cc: you | Reply, Reply all, Forward |