### PR TITLE
fix(email): focus editor when opening reply

### DIFF
--- a/js/app/packages/block-email/component/BaseInput.tsx
+++ b/js/app/packages/block-email/component/BaseInput.tsx
@@ -610,6 +610,10 @@ export function BaseInput(props: {
             toRef()?.focus();
           }
         }, 100);
+      } else if (rt === 'reply' || rt === 'reply-all') {
+        setTimeout(() => {
+          editor()?.focus();
+        }, 100);
       }
     });
   });
@@ -1152,18 +1156,22 @@ export function BaseInput(props: {
     }
   });
 
-  // Focus when external shouldFocus signal is set to true
+  // Focus when external shouldFocus signal is set to true. Gated on
+  // editor() so the effect re-runs once the Lexical editor is captured —
+  // when the input is freshly mounted (e.g. opening from BottomReplyButtons),
+  // shouldFocusInput is true before captureEditor fires.
   createEffect(() => {
-    if (form().shouldFocusInput()) {
-      if (!isMobile()) {
-        requestAnimationFrame(() => {
-          editor()?.focus();
-          form().setShouldFocusInput(false);
-        });
-      } else {
-        form().setShouldFocusInput(false);
-      }
+    if (!form().shouldFocusInput()) return;
+    if (isMobile()) {
+      form().setShouldFocusInput(false);
+      return;
     }
+    const ed = editor();
+    if (!ed) return;
+    requestAnimationFrame(() => {
+      ed.focus();
+      form().setShouldFocusInput(false);
+    });
   });
 
   const handleAddAttachments = (files: File[]) => {


### PR DESCRIPTION
## Summary

Clicking **Reply** or **Reply all** (from the bottom buttons or a per-message action bar) now puts the cursor straight into the email body, matching the behavior of **Forward** (which already lands focus in the To: field). Before this fix you had to click Reply, then click again inside the textarea to start typing.

## Root cause

Reply and Reply-all set `form.setShouldFocusInput(true)` and rely on a `createEffect` in `BaseInput` to call `editor()?.focus()`. When the input was freshly mounting (the common case from `BottomReplyButtons` and inline message replies), that effect ran before `MarkdownTextarea` called `captureEditor`, so `editor()` was `undefined`, the focus call was a no-op, and the flag got consumed anyway.

Forward worked because it had a dedicated handler in `setOnReplyTypeApplied`, which benefits from the replay mechanism in `createEmailFormState` (re-fires the callback on attach via `queueMicrotask`).

## Fix

- Extend `setOnReplyTypeApplied` in `BaseInput` to also handle `reply` and `reply-all`: `setTimeout(() => editor()?.focus(), 100)`, mirroring the Forward pattern.
- As defense in depth, gate the existing `shouldFocusInput` effect on `editor()` being defined so it re-runs once the editor is captured rather than consuming the flag prematurely.
