### PR TITLE
Seanaye/ci/skip cachix on network failure

### DIFF
--- a/.github/actions/setup-cachix/action.yml
+++ b/.github/actions/setup-cachix/action.yml
@@ -43,15 +43,40 @@ runs:
         echo "/nix/var/nix/profiles/default/bin" >> "$GITHUB_PATH"
         echo "CACHIX_CACHE_NAME=$CACHIX_CACHE_NAME" >> "$GITHUB_ENV"
 
+        retry() {
+          local attempts=$1
+          shift
+          local delay=5
+          local attempt=1
+
+          until "$@"; do
+            if [ "$attempt" -ge "$attempts" ]; then
+              return 1
+            fi
+            echo "Command failed, retrying in ${delay}s (${attempt}/${attempts}): $*" >&2
+            sleep "$delay"
+            attempt=$((attempt + 1))
+            delay=$((delay * 2))
+          done
+        }
+
         if ! command -v cachix >/dev/null 2>&1; then
-          nix profile add nixpkgs#cachix
+          if ! retry 3 nix profile add nixpkgs#cachix; then
+            echo "::warning::Failed to install Cachix; continuing without the Cachix binary cache."
+          fi
         fi
 
         export PATH="$HOME/.nix-profile/bin:/nix/var/nix/profiles/default/bin:$PATH"
-        if [ -n "$CACHIX_AUTH_TOKEN" ]; then
-          cachix authtoken "$CACHIX_AUTH_TOKEN"
+        if command -v cachix >/dev/null 2>&1; then
+          if [ -n "$CACHIX_AUTH_TOKEN" ] && ! retry 3 cachix authtoken "$CACHIX_AUTH_TOKEN"; then
+            echo "::warning::Failed to authenticate Cachix; continuing without authenticated cache access."
+          fi
+          if ! retry 3 cachix use "$CACHIX_CACHE_NAME"; then
+            echo "::warning::Failed to configure Cachix cache '$CACHIX_CACHE_NAME'; continuing without the Cachix binary cache."
+          fi
+        else
+          echo "::warning::Cachix is unavailable; continuing without the Cachix binary cache."
         fi
-        cachix use "$CACHIX_CACHE_NAME"
 
     - name: Configure sccache
       shell: bash

--- a/.github/workflows/build-rust-ci-image.yml
+++ b/.github/workflows/build-rust-ci-image.yml
@@ -54,9 +54,13 @@ jobs:
           export PATH="/nix/var/nix/profiles/default/bin:$PATH"
           sudo mkdir -p /var/cache/nix
           sudo chown runner:runner /var/cache/nix
-          cachix watch-store "$CACHIX_CACHE_NAME" &
-          cachix_pid=$!
-          trap 'kill "$cachix_pid" || true' EXIT
+          if command -v cachix >/dev/null 2>&1; then
+            cachix watch-store "$CACHIX_CACHE_NAME" &
+            cachix_pid=$!
+            trap 'kill "$cachix_pid" || true' EXIT
+          else
+            echo "::warning::Cachix is unavailable; skipping Cachix store uploads."
+          fi
           nix develop --profile /var/cache/nix/dev-shell --command true
 
       - name: Write image markers
@@ -81,9 +85,13 @@ jobs:
           set -euo pipefail
           export NIX_REMOTE=daemon
           export PATH="/nix/var/nix/profiles/default/bin:$PATH"
-          cachix watch-store "$CACHIX_CACHE_NAME" &
-          cachix_pid=$!
-          trap 'kill "$cachix_pid" || true' EXIT
+          if command -v cachix >/dev/null 2>&1; then
+            cachix watch-store "$CACHIX_CACHE_NAME" &
+            cachix_pid=$!
+            trap 'kill "$cachix_pid" || true' EXIT
+          else
+            echo "::warning::Cachix is unavailable; skipping Cachix store uploads."
+          fi
           nix --version
           test -L /var/cache/nix/dev-shell
           nix develop --profile /var/cache/nix/dev-shell --command bash -lc '

--- a/.github/workflows/deploy-all-services.yml
+++ b/.github/workflows/deploy-all-services.yml
@@ -86,9 +86,13 @@ jobs:
 
           binaries=$(jq -r --arg service "$SERVICE" '.services[$service].deploy_binaries // [] | @tsv' .github/services-config.json)
           if [[ -n "$binaries" ]]; then
-            cachix watch-store "$CACHIX_CACHE_NAME" &
-            cachix_pid=$!
-            trap 'kill "$cachix_pid" || true' EXIT
+            if command -v cachix >/dev/null 2>&1; then
+              cachix watch-store "$CACHIX_CACHE_NAME" &
+              cachix_pid=$!
+              trap 'kill "$cachix_pid" || true' EXIT
+            else
+              echo "::warning::Cachix is unavailable; skipping Cachix store uploads."
+            fi
 
             nix build ".#deploy-service-binaries-${SERVICE}"
             cp -r result/bin/* prebuilt/

--- a/.github/workflows/deploy-cloud-storage-on-push.yml
+++ b/.github/workflows/deploy-cloud-storage-on-push.yml
@@ -140,9 +140,13 @@ jobs:
 
           binaries=$(jq -r --arg service "$SERVICE" '.services[$service].deploy_binaries // [] | @tsv' .github/services-config.json)
           if [[ -n "$binaries" ]]; then
-            cachix watch-store "$CACHIX_CACHE_NAME" &
-            cachix_pid=$!
-            trap 'kill "$cachix_pid" || true' EXIT
+            if command -v cachix >/dev/null 2>&1; then
+              cachix watch-store "$CACHIX_CACHE_NAME" &
+              cachix_pid=$!
+              trap 'kill "$cachix_pid" || true' EXIT
+            else
+              echo "::warning::Cachix is unavailable; skipping Cachix store uploads."
+            fi
 
             nix build ".#deploy-service-binaries-${SERVICE}"
             cp -r result/bin/* prebuilt/

--- a/.github/workflows/reusable-deploy-service.yml
+++ b/.github/workflows/reusable-deploy-service.yml
@@ -77,9 +77,13 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p prebuilt
-          cachix watch-store "$CACHIX_CACHE_NAME" &
-          cachix_pid=$!
-          trap 'kill "$cachix_pid" || true' EXIT
+          if command -v cachix >/dev/null 2>&1; then
+            cachix watch-store "$CACHIX_CACHE_NAME" &
+            cachix_pid=$!
+            trap 'kill "$cachix_pid" || true' EXIT
+          else
+            echo "::warning::Cachix is unavailable; skipping Cachix store uploads."
+          fi
 
           nix build ".#deploy-service-binaries-${SERVICE}"
           cp -r result/bin/* prebuilt/


### PR DESCRIPTION
This PR allows CI jobs to continue without cachix in the event of a spurious network error