### PR TITLE
fix(mobile): loading block

### DIFF
--- a/js/app/packages/app/component/Launcher.tsx
+++ b/js/app/packages/app/component/Launcher.tsx
@@ -14,6 +14,7 @@ import type {
   HotkeyRegistrationOptions,
   ValidHotkey,
 } from '@core/hotkey/types';
+import { isMobile } from '@core/mobile/isMobile';
 import {
   createCanvasFileFromJsonString,
   createChat,
@@ -66,49 +67,47 @@ const createBlock = async (spec: {
 
   setCreateMenuOpen(false, false);
 
-  if (!loading) {
-    const id = await createFn();
-    if (!id) return;
+  // WORKAROUND: On mobile, the navigation interceptor in createMobileSwipeLayout
+  // consumes openWithSplit calls and returns undefined instead of a SplitHandle.
+  // This means we can't show a loading spinner then replace it via split.replace(),
+  // because we never get a handle back. Instead, on mobile we skip the loading state
+  // and navigate directly to the created block after the async creation completes.
+  // If the mobile navigation interceptor is refactored to return handles, this
+  // workaround can be removed and both paths can use the loading-then-replace flow.
+  const showLoadingFirst = loading && !isMobile();
 
-    analytics.track('create_entity', {
-      entityType: blockName,
-      source: 'launcher',
-    });
+  const split = showLoadingFirst
+    ? openWithSplit(
+        { type: 'component', id: 'loading' },
+        { referredFrom: 'launcher', preferNewSplit: spec.shouldInsert }
+      )
+    : undefined;
 
-    const block = { type: blockName, id };
-
-    openWithSplit(block, {
-      referredFrom: 'launcher',
-      preferNewSplit: spec.shouldInsert,
-    });
-
+  const id = await createFn();
+  if (!id) {
+    split?.goBack();
     return;
+  }
+
+  analytics.track('create_entity', {
+    entityType: blockName,
+    source: 'launcher',
+  });
+
+  if (split) {
+    split.replace({
+      next: { type: blockName, id },
+      mergeHistory: true,
+      referredFrom: 'launcher',
+    });
   } else {
-    const split = openWithSplit(
-      { type: 'component', id: 'loading' },
+    openWithSplit(
+      { type: blockName, id },
       {
         referredFrom: 'launcher',
         preferNewSplit: spec.shouldInsert,
       }
     );
-
-    const id = await createFn();
-    if (!id) {
-      split?.goBack();
-      return;
-    }
-
-    analytics.track('create_entity', {
-      entityType: blockName,
-      source: 'launcher',
-    });
-
-    if (split)
-      split.replace({
-        next: { type: blockName, id },
-        mergeHistory: true,
-        referredFrom: 'launcher',
-      });
   }
 };
 


### PR DESCRIPTION
This PR fixes an issue on mobile where navigating to a block with `loading: true` would fail to replace the block once the content is ready, resulting in an infinite loading spinner. This PR skips over that code path by awaiting the content upfront, which doesn't look as cool but it works 