### PR TITLE
fix(email): add @mention'd users to CC in reply and compose

### DIFF
--- a/js/app/packages/block-email/component/BaseInput.tsx
+++ b/js/app/packages/block-email/component/BaseInput.tsx
@@ -1059,6 +1059,7 @@ export function BaseInput(props: {
       recipientOptions: ctx.recipientOptions(),
       toRecipients: form().recipients().to,
       ccRecipients: form().recipients().cc,
+      bccRecipients: form().recipients().bcc,
       setCc: (next) => form().setRecipients('cc', next),
     });
   };

--- a/js/app/packages/block-email/component/BaseInput.tsx
+++ b/js/app/packages/block-email/component/BaseInput.tsx
@@ -6,7 +6,7 @@ import {
   MACRO_EMAIL_SIGNATURE,
   MAX_ATTACHMENTS_BYTES_SIZE,
 } from '@block-email/constants';
-import { convertContactInfoToEmailRecipient } from '@block-email/util/recipientConversion';
+import { addUserMentionToCc } from '@block-email/util/mentionToCc';
 import { FormatButtons } from '@channel/Input/FormatButtons';
 import {
   applyInlineFormat,
@@ -1054,40 +1054,13 @@ export function BaseInput(props: {
   };
 
   const handleUserMention = (mention: UserMentionRecord) => {
-    // Extract the email from the mention argument
-    const mentionEmail = mention.mentions[0].split('|')[1];
-
-    // Check if user already in To or CC
-    const isInTo = form()
-      .recipients()
-      .to.some((recipient: EmailRecipient) => {
-        const email = recipient.data.email;
-        if (!email) return false;
-        return email === mentionEmail;
-      });
-
-    const isInCc = form()
-      .recipients()
-      .cc.some((recipient: EmailRecipient) => {
-        const email = recipient.data.email;
-        if (!email) return false;
-        return email === mentionEmail;
-      });
-
-    // If not already in To or CC, add user to CC
-    if (!isInTo && !isInCc) {
-      // Find the user in recipient options, or construct from mention data
-      const userOption =
-        ctx.recipientOptions().find((recipient) => {
-          const email = recipient.data.email;
-          if (!email) return false;
-          return email === mentionEmail;
-        }) ?? convertContactInfoToEmailRecipient({ email: mentionEmail });
-
-      // Add to CC recipients
-      form().setRecipients('cc', [...form().recipients().cc, userOption]);
-      toast.success(`${mentionEmail} added to CC`);
-    }
+    addUserMentionToCc({
+      mention,
+      recipientOptions: ctx.recipientOptions(),
+      toRecipients: form().recipients().to,
+      ccRecipients: form().recipients().cc,
+      setCc: (next) => form().setRecipients('cc', next),
+    });
   };
 
   onMount(() => {

--- a/js/app/packages/block-email/component/compose/ComposeBody.tsx
+++ b/js/app/packages/block-email/component/compose/ComposeBody.tsx
@@ -2,6 +2,7 @@ import { useSplitPanel } from '@app/component/split-layout/layoutUtils';
 import { EmailAttachmentPill } from '@block-email/component/AttachmentPill';
 import type { DraftFormAttachment } from '@block-email/component/createEmailFormState';
 import { MacroSignatureButton } from '@block-email/component/MacroSignatureButton';
+import { addUserMentionToCc } from '@block-email/util/mentionToCc';
 import { FileDropOverlay } from '@core/component/FileDropOverlay';
 import { MarkdownTextarea } from '@core/component/LexicalMarkdown/component/core/MarkdownTextarea';
 import { createFilesReadyHandler } from '@core/component/LexicalMarkdown/utils/fileUploadUtils';
@@ -170,6 +171,15 @@ export function ComposeBody(props: {
               !ctx.hasPaidAccess() ? <MacroSignatureButton /> : undefined
             }
             onChange={ctx.onContentChange}
+            onUserMention={(mention) => {
+              addUserMentionToCc({
+                mention,
+                recipientOptions: ctx.recipientOptions(),
+                toRecipients: ctx.recipients().to,
+                ccRecipients: ctx.recipients().cc,
+                setCc: (next) => ctx.setRecipients('cc', next),
+              });
+            }}
             onFocusLeaveStart={(e) => {
               e.preventDefault();
               focusSibling('prev');

--- a/js/app/packages/block-email/component/compose/ComposeBody.tsx
+++ b/js/app/packages/block-email/component/compose/ComposeBody.tsx
@@ -177,6 +177,7 @@ export function ComposeBody(props: {
                 recipientOptions: ctx.recipientOptions(),
                 toRecipients: ctx.recipients().to,
                 ccRecipients: ctx.recipients().cc,
+                bccRecipients: ctx.recipients().bcc,
                 setCc: (next) => ctx.setRecipients('cc', next),
               });
             }}

--- a/js/app/packages/block-email/util/mentionToCc.ts
+++ b/js/app/packages/block-email/util/mentionToCc.ts
@@ -1,0 +1,29 @@
+import type { EmailRecipient } from '@block-email/component/EmailContext';
+import { convertContactInfoToEmailRecipient } from '@block-email/util/recipientConversion';
+import type { UserMentionRecord } from '@core/component/LexicalMarkdown/utils/mentionsUtils';
+import { toast } from '@core/component/Toast/Toast';
+
+export function addUserMentionToCc(params: {
+  mention: UserMentionRecord;
+  recipientOptions: EmailRecipient[];
+  toRecipients: EmailRecipient[];
+  ccRecipients: EmailRecipient[];
+  setCc: (next: EmailRecipient[]) => void;
+}) {
+  const { mention, recipientOptions, toRecipients, ccRecipients, setCc } =
+    params;
+  const mentionEmail = mention.email;
+  if (!mentionEmail) return;
+
+  const matches = (recipient: EmailRecipient) =>
+    recipient.data.email === mentionEmail;
+
+  if (toRecipients.some(matches) || ccRecipients.some(matches)) return;
+
+  const userOption =
+    recipientOptions.find(matches) ??
+    convertContactInfoToEmailRecipient({ email: mentionEmail });
+
+  setCc([...ccRecipients, userOption]);
+  toast.success(`${mentionEmail} added to CC`);
+}

--- a/js/app/packages/block-email/util/mentionToCc.ts
+++ b/js/app/packages/block-email/util/mentionToCc.ts
@@ -8,17 +8,30 @@ export function addUserMentionToCc(params: {
   recipientOptions: EmailRecipient[];
   toRecipients: EmailRecipient[];
   ccRecipients: EmailRecipient[];
+  bccRecipients: EmailRecipient[];
   setCc: (next: EmailRecipient[]) => void;
 }) {
-  const { mention, recipientOptions, toRecipients, ccRecipients, setCc } =
-    params;
+  const {
+    mention,
+    recipientOptions,
+    toRecipients,
+    ccRecipients,
+    bccRecipients,
+    setCc,
+  } = params;
   const mentionEmail = mention.email;
   if (!mentionEmail) return;
 
   const matches = (recipient: EmailRecipient) =>
     recipient.data.email === mentionEmail;
 
-  if (toRecipients.some(matches) || ccRecipients.some(matches)) return;
+  if (
+    toRecipients.some(matches) ||
+    ccRecipients.some(matches) ||
+    bccRecipients.some(matches)
+  ) {
+    return;
+  }
 
   const userOption =
     recipientOptions.find(matches) ??

--- a/js/app/packages/core/component/LexicalMarkdown/utils/mentionsUtils.ts
+++ b/js/app/packages/core/component/LexicalMarkdown/utils/mentionsUtils.ts
@@ -79,6 +79,7 @@ export type DateItem = ParsedDate & {
 export type UserMentionRecord = {
   documentId: string;
   mentions: string[];
+  email: string;
   metadata: DocumentMentionMetadata;
 };
 
@@ -155,20 +156,19 @@ export async function handleUserMention(
   let mentionId: string | undefined;
 
   if (blockName !== 'channel') {
-    if (blockId) {
-      const record: UserMentionRecord = {
-        documentId: blockId,
-        mentions: [user.id],
-        metadata: {
-          mention_id: v7(),
-        },
-      };
-      if (onUserMention) {
-        onUserMention(record);
-      }
-      if (!disableMentionTracking) {
-        mentionId = await trackMention(blockId, 'user', user.id);
-      }
+    const record: UserMentionRecord = {
+      documentId: blockId ?? '',
+      mentions: [user.id],
+      email: user.email,
+      metadata: {
+        mention_id: v7(),
+      },
+    };
+    if (onUserMention) {
+      onUserMention(record);
+    }
+    if (blockId && !disableMentionTracking) {
+      mentionId = await trackMention(blockId, 'user', user.id);
     }
   }
 


### PR DESCRIPTION
## Summary

Mentioning a user in the email composer is supposed to add them to CC. It was silently broken in two ways:

**Reply (`BaseInput.tsx`)** — `handleUserMention` parsed `mention.mentions[0]` as a `name|email` string (`.split('|')[1]`), but the producer in `mentionsUtils.ts` populates `mentions: [user.id]` — a bare user-ID UUID. The split returned `undefined`, the "already in to/cc" checks didn't match anything, and the CC fallback added a malformed recipient with no email.

**Compose (`ComposeBody.tsx`)** — `<MarkdownTextarea>` was rendered without `onUserMention` at all. Even after wiring it up, `handleUserMention` short-circuited because the new-message Compose flow mounts as a registered split-layout component (`componentRegistry.tsx:279`), outside any `<BlockContext.Provider>`, so `useMaybeBlockId()` returned `undefined`. The outer `if (blockId)` gate suppressed the callback entirely.

## Changes

- `UserMentionRecord` now carries `email` directly, so consumers don't have to parse it out of the user-ID string.
- New `block-email/util/mentionToCc.ts` with a shared `addUserMentionToCc` helper covering the lookup-in-recipientOptions / fall-back-to-constructing-a-recipient logic, plus the "already in TO or CC" check.
- `BaseInput.tsx`: replaced the buggy inline handler with a call into the shared util.
- `ComposeBody.tsx`: wired `onUserMention` on `MarkdownTextarea` so the new-message flow now adds mentioned users to CC.
- `mentionsUtils.ts`: fire `onUserMention` even when `blockId` is undefined; still gate `trackMention` on `blockId` since it needs a source document. The outer gate originally guarded a `storageServiceClient.upsertUserMentions(record)` call that needed `documentId`; that was deleted in #722, but the gate around the callback was left behind.

Verified safe for the other `UserMentionRecord` consumer — `core/comments` only reads `mention.mentions` and `mention.metadata.mention_id`, never `documentId`.
