### PR TITLE
fix(finalizer): chg policy to allow get object for reading md in bucket

### DIFF
--- a/infra/stacks/link-sharing/file-storage-bucket.ts
+++ b/infra/stacks/link-sharing/file-storage-bucket.ts
@@ -40,6 +40,7 @@ export const attachPolicyToBucket = ({
   documentTextExtractorArn,
   documentProcessingServiceRoleArn,
   pdfPreprocessLambdaRoleArn,
+  documentUploadFinalizerRoleArn,
   documentStorageBucketReplicationRoleArn,
   searchProcessingServiceRoleArn,
   bulkUploadLambdaRoleArn,
@@ -54,6 +55,7 @@ export const attachPolicyToBucket = ({
   shaCleanupWorkerArn: pulumi.Output<string>;
   documentProcessingServiceRoleArn: pulumi.Output<string>;
   pdfPreprocessLambdaRoleArn: pulumi.Output<string>;
+  documentUploadFinalizerRoleArn: pulumi.Output<string>;
   documentStorageBucketReplicationRoleArn: pulumi.Output<string>;
   searchProcessingServiceRoleArn: pulumi.Output<string>;
   bulkUploadLambdaRoleArn: pulumi.Output<string>;
@@ -82,6 +84,7 @@ export const attachPolicyToBucket = ({
         shaCleanupWorkerArn,
         documentProcessingServiceRoleArn,
         pdfPreprocessLambdaRoleArn,
+        documentUploadFinalizerRoleArn,
         documentStorageBucketReplicationRoleArn,
         documentTextExtractorArn,
         searchProcessingServiceRoleArn,
@@ -240,6 +243,15 @@ export const attachPolicyToBucket = ({
           AWS: pdfPreprocessLambdaRoleArn,
         },
         Action: ['s3:GetObject', 's3:PutObject'],
+        Resource: [bucket.arn, pulumi.interpolate`${bucket.arn}/*`],
+      },
+      {
+        Sid: 'AllowAccessForDocumentUploadFinalizer',
+        Effect: 'Allow',
+        Principal: {
+          AWS: documentUploadFinalizerRoleArn,
+        },
+        Action: ['s3:GetObject'],
         Resource: [bucket.arn, pulumi.interpolate`${bucket.arn}/*`],
       },
       {

--- a/infra/stacks/link-sharing/index.ts
+++ b/infra/stacks/link-sharing/index.ts
@@ -86,6 +86,11 @@ const docxUnzipRoleArn: pulumi.Output<string> = cloudStorageServiceStack
   .getOutput('docxUnzipHandlerRoleArn')
   .apply((arn) => arn as string);
 
+const documentUploadFinalizerRoleArn: pulumi.Output<string> =
+  cloudStorageServiceStack
+    .getOutput('documentUploadFinalizerRoleArn')
+    .apply((arn) => arn as string);
+
 const shaCleanupWorkerArn: pulumi.Output<string> = shaCleanupStack
   .getOutput('shaCleanupWorkerRoleArn')
   .apply((shaCleanupWorkerArn) => shaCleanupWorkerArn as string);
@@ -130,6 +135,7 @@ export const bucketPolicy = attachPolicyToBucket({
   shaCleanupWorkerArn,
   documentProcessingServiceRoleArn,
   pdfPreprocessLambdaRoleArn,
+  documentUploadFinalizerRoleArn,
   documentStorageBucketReplicationRoleArn,
   documentTextExtractorArn,
   searchProcessingServiceRoleArn,


### PR DESCRIPTION
- When we manually upload markdown files we need to read them to initialize them
