### PR TITLE
Modernize split chrome, sidebar sizing, and theme defaults

### DIFF
--- a/js/app/packages/app/component/app-sidebar/sidebar.tsx
+++ b/js/app/packages/app/component/app-sidebar/sidebar.tsx
@@ -539,7 +539,7 @@ export const AppSidebar = (props: AppSidebarProps) => {
       class={cn(
         'group/sidebar h-full py-2 flex flex-col gap-0 mobile:absolute mobile:z-modal-content overflow-hidden',
         isExpanded() &&
-          'max-w-56 w-full mobile:max-w-2/3 translate-x-0 opacity-100',
+          'max-w-51 w-full mobile:max-w-2/3 translate-x-0 opacity-100',
         props.sidebarState === 'hidden' &&
           '-translate-x-full overflow-hidden opacity-0',
 

--- a/js/app/packages/app/component/split-layout/components/SplitToolbar.tsx
+++ b/js/app/packages/app/component/split-layout/components/SplitToolbar.tsx
@@ -46,7 +46,7 @@ export function SplitToolbar(props: { ref: Setter<HTMLDivElement | null> }) {
     <div
       class={cn(
         'relative w-full flex items-center justify-between shrink-0',
-        hasContent() && 'min-h-10 border-b border-edge-muted',
+        hasContent() && 'min-h-10',
         preview() && 'hidden'
       )}
       data-split-toolbar

--- a/js/app/packages/theme/constants.ts
+++ b/js/app/packages/theme/constants.ts
@@ -1,7 +1,7 @@
 import type { ThemeV2 } from './types/themeTypes';
 
-export const DEFAULT_LIGHT_THEME: DefaultTheme = 'Macro Light';
-export const DEFAULT_DARK_THEME: DefaultTheme = 'Macro Dark';
+export const DEFAULT_LIGHT_THEME: DefaultTheme = 'Sleepless';
+export const DEFAULT_DARK_THEME: DefaultTheme = 'Sleepless';
 
 export const DEFAULT_THEMES = [
   {
@@ -19,7 +19,7 @@ export const DEFAULT_THEMES = [
       b1: { l: 0.16, c: 0.00, h:  21 },
       b2: { l: 0.18, c: 0.00, h:  21 },
       b3: { l: 0.20, c: 0.00, h:  21 },
-      b4: { l: 0.26, c: 0.00, h:  21 },
+      b4: { l: 0.80, c: 0.16, h:  86 },
       c0: { l: 0.95, c: 0.00, h:  21 },
       c1: { l: 0.83, c: 0.00, h:  21 },
       c2: { l: 0.75, c: 0.00, h:  21 },

--- a/js/app/packages/ui/components/Surface.tsx
+++ b/js/app/packages/ui/components/Surface.tsx
@@ -30,7 +30,7 @@ export function Surface(props: SurfaceProps) {
           ...local.style,
         }}
         class={cn(
-          'relative rounded-md overflow-clip min-h-0 size-full',
+          'relative rounded-[12px] overflow-clip min-h-0 size-full',
           "after:content-[''] after:absolute after:inset-0 after:pointer-events-none after:rounded-[inherit] after:z-10",
           'after:shadow-[inset_0_0_4px_var(--color-shadow)]',
           local.class,


### PR DESCRIPTION
### Motivation
- Refresh the split chrome to feel more modern by softening corners and removing visual separators. 
- Make `Sleepless` the default theme (light and dark fallbacks) and nudge its edge token toward a warm orange for a Neo-Sleepless accent. 
- Reduce the expanded sidebar footprint slightly for a tighter layout. 

### Description
- Updated split surface corner radius to `12px` by changing `Surface` to use `rounded-[12px]` (`js/app/packages/ui/components/Surface.tsx`).
- Removed the bottom divider under split toolbars by dropping the `border-b border-edge-muted` class from the split toolbar container (`js/app/packages/app/component/split-layout/components/SplitToolbar.tsx`).
- Switched `DEFAULT_LIGHT_THEME` and `DEFAULT_DARK_THEME` to `Sleepless` and tuned the Sleepless `b4` token to an orange profile (`b4: { l: 0.80, c: 0.16, h: 86 }`) to give the requested orange accent (`js/app/packages/theme/constants.ts`).
- Reduced expanded sidebar max width from `max-w-56` to `max-w-51` to decrease the expanded sidebar by ~20px (`js/app/packages/app/component/app-sidebar/sidebar.tsx`).

### Testing
- Ran `bun run check` in `js/app` to validate TypeScript; the run failed in this environment due to missing global type definition packages (unrelated to the UI edits).
- No other automated test failures related to these UI changes were observed in this workspace.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04cfcec08c8324943a3f9b56447d45)