### PR TITLE
feat(channel): highlight matched text in find bar results

### DIFF
--- a/js/app/packages/channel/Channel/Channel.tsx
+++ b/js/app/packages/channel/Channel/Channel.tsx
@@ -8,6 +8,7 @@ import {
   makeAttachmentTrackerPersistenceKey,
   makeInputValuePersistenceKey,
 } from '@channel/Input/utils/persistence';
+import { SearchHighlightTermsProvider } from '@channel/Message';
 import { MaybeMessageActionDrawerManager } from '@channel/Mobile/MessageActionDrawerManager';
 import { useChannelParticipants } from '@channel/use-channel-participants';
 import { FindBar } from '@core/component/FindBar';
@@ -402,138 +403,140 @@ export function Channel(props: ChannelProps) {
   return (
     <DebugSuspense name="Channel.root">
       <StaticMarkdownContext>
-        <MaybeMessageActionDrawerManager>
-          <ChannelDropZone dragState={dragState}>
-            <div
-              class="ph-no-capture relative flex-1 min-h-0 outline-none flex flex-col"
-              ref={(element) => {
-                setMessageListElement(element);
-                attachMessageListRef(element);
-              }}
-              tabIndex={-1}
-              data-channel-message-list
-            >
-              <Show when={findBar.isOpen()}>
-                <FindBar
-                  class="absolute top-2 right-3 z-10 w-80 max-w-[calc(100%-1.5rem)]"
-                  controller={findBar}
-                  direction="desc"
-                />
-              </Show>
-              <Show when={messages().length > 0}>
-                <div class="relative flex-1 min-h-0">
-                  <ThreadList
-                    keys={() => messageIndex.keys}
-                    initialScrollTarget={threadListInitialScrollTarget()}
-                    shift={shift}
-                    prepend={threadPaginator.isPrepending}
-                    onScrollNearTop={threadPaginator.shiftPaginate}
-                    onScrollNearBottom={threadPaginator.prependPaginate}
-                    onNavigationReady={setThreadListNavigation}
-                    onScrollStateChange={setThreadListScrollState}
-                  >
-                    {(item) => {
-                      const message = () => messageById().get(item.id);
-                      const state = threadManager.getOrCreateThreadState(
-                        item.id
-                      );
-                      const isNewestThread = () =>
-                        item.id === messageIndex.keys.at(-1);
-
-                      return (
-                        <Show when={message()}>
-                          {(m) => (
-                            <ChannelThread
-                              data={m}
-                              channelId={() => props.channelId}
-                              isNewestThread={isNewestThread()}
-                              getMessageActions={getMessageActions}
-                              targetReplyId={targetMessageController.pendingTargetReplyId()}
-                              selectedReplyId={targetMessageController.activeTargetMessageReplyId()}
-                              onTargetReplyScrolled={(replyId) => {
-                                targetMessageController.completePendingReplyScroll(
-                                  m().id,
-                                  replyId
-                                );
-                              }}
-                              isExpanded={state.isExpanded}
-                              setIsExpanded={state.setIsExpanded}
-                              isReplying={state.isReplying}
-                              setIsReplying={state.setIsReplying}
-                              replyInputState={state.replyInputState}
-                              setReplyInputState={state.setReplyInputState}
-                              setReplyInputEl={state.setReplyInputEl}
-                              listMeta={listMetaByMessageId()[item.id]}
-                              messageEditor={messageEditor}
-                              threadActions={{
-                                onDismissNewMessages:
-                                  activityTracker.dismissNewMessages,
-                              }}
-                              isNewMessage={activityTracker.isNewMessage}
-                              selectedMessageId={selection.selectedId}
-                              onSelectMessage={selectMessage}
-                              onClearSelection={clearSelection}
-                              messageListScopeId={messageListScopeId}
-                            />
-                          )}
-                        </Show>
-                      );
-                    }}
-                  </ThreadList>
-                  <ScrollToBottomOverlay
-                    scrollState={threadListScrollState}
-                    onScrollToBottom={handleScrollToBottom}
-                  />
-                </div>
-              </Show>
-            </div>
-            <DebugSuspense name="Channel.input">
-              <ChannelInputContainer
-                ref={(el) => {
-                  attachInputRef(el);
-                  setChannelInputEl(el);
+        <SearchHighlightTermsProvider value={findBar.getSearchTermsForMessage}>
+          <MaybeMessageActionDrawerManager>
+            <ChannelDropZone dragState={dragState}>
+              <div
+                class="ph-no-capture relative flex-1 min-h-0 outline-none flex flex-col"
+                ref={(element) => {
+                  setMessageListElement(element);
+                  attachMessageListRef(element);
                 }}
-                isHidden={isChannelInputHidden()}
+                tabIndex={-1}
+                data-channel-message-list
               >
-                <ChannelInput
-                  autofocus={props.autofocus}
-                  input={{
-                    mode: 'channel',
-                    id: `channel-input-${props.channelId}`,
-                    placeholder: 'Message channel',
-                    isDraggingOverChannel: dragState.isDraggingOverChannel(),
-                    isValidChannelDrag: dragState.isValidChannelDrag(),
+                <Show when={findBar.isOpen()}>
+                  <FindBar
+                    class="absolute top-2 right-3 z-10 w-80 max-w-[calc(100%-1.5rem)]"
+                    controller={findBar}
+                    direction="desc"
+                  />
+                </Show>
+                <Show when={messages().length > 0}>
+                  <div class="relative flex-1 min-h-0">
+                    <ThreadList
+                      keys={() => messageIndex.keys}
+                      initialScrollTarget={threadListInitialScrollTarget()}
+                      shift={shift}
+                      prepend={threadPaginator.isPrepending}
+                      onScrollNearTop={threadPaginator.shiftPaginate}
+                      onScrollNearBottom={threadPaginator.prependPaginate}
+                      onNavigationReady={setThreadListNavigation}
+                      onScrollStateChange={setThreadListScrollState}
+                    >
+                      {(item) => {
+                        const message = () => messageById().get(item.id);
+                        const state = threadManager.getOrCreateThreadState(
+                          item.id
+                        );
+                        const isNewestThread = () =>
+                          item.id === messageIndex.keys.at(-1);
+
+                        return (
+                          <Show when={message()}>
+                            {(m) => (
+                              <ChannelThread
+                                data={m}
+                                channelId={() => props.channelId}
+                                isNewestThread={isNewestThread()}
+                                getMessageActions={getMessageActions}
+                                targetReplyId={targetMessageController.pendingTargetReplyId()}
+                                selectedReplyId={targetMessageController.activeTargetMessageReplyId()}
+                                onTargetReplyScrolled={(replyId) => {
+                                  targetMessageController.completePendingReplyScroll(
+                                    m().id,
+                                    replyId
+                                  );
+                                }}
+                                isExpanded={state.isExpanded}
+                                setIsExpanded={state.setIsExpanded}
+                                isReplying={state.isReplying}
+                                setIsReplying={state.setIsReplying}
+                                replyInputState={state.replyInputState}
+                                setReplyInputState={state.setReplyInputState}
+                                setReplyInputEl={state.setReplyInputEl}
+                                listMeta={listMetaByMessageId()[item.id]}
+                                messageEditor={messageEditor}
+                                threadActions={{
+                                  onDismissNewMessages:
+                                    activityTracker.dismissNewMessages,
+                                }}
+                                isNewMessage={activityTracker.isNewMessage}
+                                selectedMessageId={selection.selectedId}
+                                onSelectMessage={selectMessage}
+                                onClearSelection={clearSelection}
+                                messageListScopeId={messageListScopeId}
+                              />
+                            )}
+                          </Show>
+                        );
+                      }}
+                    </ThreadList>
+                    <ScrollToBottomOverlay
+                      scrollState={threadListScrollState}
+                      onScrollToBottom={handleScrollToBottom}
+                    />
+                  </div>
+                </Show>
+              </div>
+              <DebugSuspense name="Channel.input">
+                <ChannelInputContainer
+                  ref={(el) => {
+                    attachInputRef(el);
+                    setChannelInputEl(el);
                   }}
-                  participants={participants.users}
-                  attachmentTracker={attachmentTracker}
-                  persistenceKey={makeInputValuePersistenceKey({
-                    channelId: props.channelId,
-                  })}
-                  onReady={(handle) => {
-                    dragState.setAttachFilesToChannel(handle.attachFiles);
-                    setChannelInputHandle(handle);
-                  }}
-                  onChange={(snapshot) =>
-                    void setChannelInputSnapshot(snapshot)
-                  }
-                  onSend={onSend}
-                  onStartTyping={() =>
-                    typingMutation.mutate({
+                  isHidden={isChannelInputHidden()}
+                >
+                  <ChannelInput
+                    autofocus={props.autofocus}
+                    input={{
+                      mode: 'channel',
+                      id: `channel-input-${props.channelId}`,
+                      placeholder: 'Message channel',
+                      isDraggingOverChannel: dragState.isDraggingOverChannel(),
+                      isValidChannelDrag: dragState.isValidChannelDrag(),
+                    }}
+                    participants={participants.users}
+                    attachmentTracker={attachmentTracker}
+                    persistenceKey={makeInputValuePersistenceKey({
                       channelId: props.channelId,
-                      action: 'start',
-                    })
-                  }
-                  onStopTyping={() =>
-                    typingMutation.mutate({
-                      channelId: props.channelId,
-                      action: 'stop',
-                    })
-                  }
-                />
-              </ChannelInputContainer>
-            </DebugSuspense>
-          </ChannelDropZone>
-        </MaybeMessageActionDrawerManager>
+                    })}
+                    onReady={(handle) => {
+                      dragState.setAttachFilesToChannel(handle.attachFiles);
+                      setChannelInputHandle(handle);
+                    }}
+                    onChange={(snapshot) =>
+                      void setChannelInputSnapshot(snapshot)
+                    }
+                    onSend={onSend}
+                    onStartTyping={() =>
+                      typingMutation.mutate({
+                        channelId: props.channelId,
+                        action: 'start',
+                      })
+                    }
+                    onStopTyping={() =>
+                      typingMutation.mutate({
+                        channelId: props.channelId,
+                        action: 'stop',
+                      })
+                    }
+                  />
+                </ChannelInputContainer>
+              </DebugSuspense>
+            </ChannelDropZone>
+          </MaybeMessageActionDrawerManager>
+        </SearchHighlightTermsProvider>
       </StaticMarkdownContext>
     </DebugSuspense>
   );

--- a/js/app/packages/channel/Channel/create-channel-find-bar.ts
+++ b/js/app/packages/channel/Channel/create-channel-find-bar.ts
@@ -2,6 +2,7 @@ import {
   createFindBarController,
   type FindBarController,
 } from '@core/component/createFindBarController';
+import { extractSearchTerms } from '@core/util/searchHighlight';
 import {
   type ChannelMessageEntity,
   isChannelMessageEntity,
@@ -13,6 +14,7 @@ import {
 } from '@queries/soup/search';
 import { ChannelSortTimestamp } from '@service-search/generated/models';
 import { type Accessor, createEffect, createMemo } from 'solid-js';
+import type { SearchHighlightTermsLookup } from '../Message/context';
 
 const FIND_BAR_PAGE_SIZE = 50;
 const FIND_BAR_PREFETCH_THRESHOLD = 10;
@@ -23,12 +25,17 @@ type CreateChannelFindBarOptions = {
   clearSelection: () => void;
 };
 
-export type ChannelFindBar = FindBarController;
+export type ChannelFindBar = FindBarController & {
+  /** Per-message highlight terms derived from loaded search results. */
+  getSearchTermsForMessage: Accessor<SearchHighlightTermsLookup | undefined>;
+};
 
 export function createChannelFindBar(
   options: CreateChannelFindBarOptions
 ): ChannelFindBar {
-  return createFindBarController<WithSearch<ChannelMessageEntity>>(
+  let termsByMessageId: Accessor<Map<string, string[]>> = () => new Map();
+
+  const controller = createFindBarController<WithSearch<ChannelMessageEntity>>(
     ({ isOpen, submittedQuery, activeIndex }) => {
       // Channel-only search with thread sort so results paginate monotonically
       // through the channel's thread list (replies cluster with their parent
@@ -57,6 +64,28 @@ export function createChannelFindBar(
           (e): e is WithSearch<ChannelMessageEntity> =>
             isChannelMessageEntity(e) && e.channelId === options.channelId()
         );
+      });
+
+      termsByMessageId = createMemo<Map<string, string[]>>(() => {
+        if (!isOpen()) return new Map();
+        const map = new Map<string, string[]>();
+        for (const entity of results()) {
+          const hit = entity.search.contentHitData?.[0]?.content;
+          if (!hit) continue;
+          const terms = [
+            ...new Set(extractSearchTerms(hit).filter((t) => t.length > 0)),
+          ];
+          if (!terms.length) continue;
+          const existing = map.get(entity.messageId);
+          if (existing) {
+            for (const t of terms) {
+              if (!existing.includes(t)) existing.push(t);
+            }
+          } else {
+            map.set(entity.messageId, terms);
+          }
+        }
+        return map;
       });
 
       const totalCount = createMemo<number | undefined>(() => {
@@ -97,4 +126,14 @@ export function createChannelFindBar(
       onBeforeSubmit: () => options.clearSelection(),
     }
   );
+
+  const getSearchTermsForMessage: Accessor<
+    SearchHighlightTermsLookup | undefined
+  > = () => {
+    const map = termsByMessageId();
+    if (map.size === 0) return undefined;
+    return (messageId: string) => map.get(messageId);
+  };
+
+  return { ...controller, getSearchTermsForMessage };
 }

--- a/js/app/packages/channel/Channel/create-channel-find-bar.ts
+++ b/js/app/packages/channel/Channel/create-channel-find-bar.ts
@@ -13,7 +13,12 @@ import {
   validateSearchServiceText,
 } from '@queries/soup/search';
 import { ChannelSortTimestamp } from '@service-search/generated/models';
-import { type Accessor, createEffect, createMemo } from 'solid-js';
+import {
+  type Accessor,
+  createEffect,
+  createMemo,
+  createSelector,
+} from 'solid-js';
 import type { SearchHighlightTermsLookup } from '../Message/context';
 
 const FIND_BAR_PAGE_SIZE = 50;
@@ -27,7 +32,7 @@ type CreateChannelFindBarOptions = {
 
 export type ChannelFindBar = FindBarController & {
   /** Per-message highlight terms derived from loaded search results. */
-  getSearchTermsForMessage: Accessor<SearchHighlightTermsLookup | undefined>;
+  getSearchTermsForMessage: SearchHighlightTermsLookup;
 };
 
 type ActiveMatch = { messageId: string; terms: string[] };
@@ -125,14 +130,12 @@ export function createChannelFindBar(
     }
   );
 
-  const getSearchTermsForMessage: Accessor<
-    SearchHighlightTermsLookup | undefined
-  > = () => {
-    const match = activeMatch();
-    if (!match) return undefined;
-    return (messageId: string) =>
-      messageId === match.messageId ? match.terms : undefined;
-  };
+  const isActiveMessage = createSelector<string | undefined, string>(
+    () => activeMatch()?.messageId
+  );
+
+  const getSearchTermsForMessage: SearchHighlightTermsLookup = (messageId) =>
+    isActiveMessage(messageId) ? activeMatch()?.terms : undefined;
 
   return { ...controller, getSearchTermsForMessage };
 }

--- a/js/app/packages/channel/Channel/create-channel-find-bar.ts
+++ b/js/app/packages/channel/Channel/create-channel-find-bar.ts
@@ -33,7 +33,9 @@ export type ChannelFindBar = FindBarController & {
 export function createChannelFindBar(
   options: CreateChannelFindBarOptions
 ): ChannelFindBar {
-  let termsByMessageId: Accessor<Map<string, string[]>> = () => new Map();
+  let activeMatch: Accessor<
+    { messageId: string; terms: string[] } | undefined
+  > = () => undefined;
 
   const controller = createFindBarController<WithSearch<ChannelMessageEntity>>(
     ({ isOpen, submittedQuery, activeIndex }) => {
@@ -66,26 +68,23 @@ export function createChannelFindBar(
         );
       });
 
-      termsByMessageId = createMemo<Map<string, string[]>>(() => {
-        if (!isOpen()) return new Map();
-        const map = new Map<string, string[]>();
-        for (const entity of results()) {
-          const hit = entity.search.contentHitData?.[0]?.content;
-          if (!hit) continue;
-          const terms = [
-            ...new Set(extractSearchTerms(hit).filter((t) => t.length > 0)),
-          ];
-          if (!terms.length) continue;
-          const existing = map.get(entity.messageId);
-          if (existing) {
-            for (const t of terms) {
-              if (!existing.includes(t)) existing.push(t);
-            }
-          } else {
-            map.set(entity.messageId, terms);
-          }
-        }
-        return map;
+      // Highlight only the active match so we never paint spans we don't
+      // have hit data for (results outside the loaded page have no terms).
+      activeMatch = createMemo<
+        { messageId: string; terms: string[] } | undefined
+      >(() => {
+        if (!isOpen()) return undefined;
+        const idx = activeIndex();
+        if (idx === 0) return undefined;
+        const entity = results()[idx - 1];
+        if (!entity) return undefined;
+        const hit = entity.search.contentHitData?.[0]?.content;
+        if (!hit) return undefined;
+        const terms = [
+          ...new Set(extractSearchTerms(hit).filter((t) => t.length > 0)),
+        ];
+        if (!terms.length) return undefined;
+        return { messageId: entity.messageId, terms };
       });
 
       const totalCount = createMemo<number | undefined>(() => {
@@ -130,9 +129,10 @@ export function createChannelFindBar(
   const getSearchTermsForMessage: Accessor<
     SearchHighlightTermsLookup | undefined
   > = () => {
-    const map = termsByMessageId();
-    if (map.size === 0) return undefined;
-    return (messageId: string) => map.get(messageId);
+    const match = activeMatch();
+    if (!match) return undefined;
+    return (messageId: string) =>
+      messageId === match.messageId ? match.terms : undefined;
   };
 
   return { ...controller, getSearchTermsForMessage };

--- a/js/app/packages/channel/Channel/create-channel-find-bar.ts
+++ b/js/app/packages/channel/Channel/create-channel-find-bar.ts
@@ -78,13 +78,14 @@ export function createChannelFindBar(
         if (idx === 0) return undefined;
         const entity = results()[idx - 1];
         if (!entity) return undefined;
-        const hit = entity.search.contentHitData?.[0]?.content;
-        if (!hit) return undefined;
-        const terms = [
-          ...new Set(extractSearchTerms(hit).filter((t) => t.length > 0)),
-        ];
-        if (!terms.length) return undefined;
-        return { messageId: entity.messageId, terms };
+        const termSet = new Set<string>();
+        for (const hit of entity.search.contentHitData ?? []) {
+          for (const term of extractSearchTerms(hit.content)) {
+            if (term.length) termSet.add(term);
+          }
+        }
+        if (termSet.size === 0) return undefined;
+        return { messageId: entity.messageId, terms: [...termSet] };
       });
 
       const totalCount = createMemo<number | undefined>(() => {

--- a/js/app/packages/channel/Channel/create-channel-find-bar.ts
+++ b/js/app/packages/channel/Channel/create-channel-find-bar.ts
@@ -30,12 +30,12 @@ export type ChannelFindBar = FindBarController & {
   getSearchTermsForMessage: Accessor<SearchHighlightTermsLookup | undefined>;
 };
 
+type ActiveMatch = { messageId: string; terms: string[] };
+
 export function createChannelFindBar(
   options: CreateChannelFindBarOptions
 ): ChannelFindBar {
-  let activeMatch: Accessor<
-    { messageId: string; terms: string[] } | undefined
-  > = () => undefined;
+  let activeMatch: Accessor<ActiveMatch | undefined> = () => undefined;
 
   const controller = createFindBarController<WithSearch<ChannelMessageEntity>>(
     ({ isOpen, submittedQuery, activeIndex }) => {
@@ -70,9 +70,7 @@ export function createChannelFindBar(
 
       // Highlight only the active match so we never paint spans we don't
       // have hit data for (results outside the loaded page have no terms).
-      activeMatch = createMemo<
-        { messageId: string; terms: string[] } | undefined
-      >(() => {
+      activeMatch = createMemo<ActiveMatch | undefined>(() => {
         if (!isOpen()) return undefined;
         const idx = activeIndex();
         if (idx === 0) return undefined;

--- a/js/app/packages/channel/Message/Content.tsx
+++ b/js/app/packages/channel/Message/Content.tsx
@@ -21,7 +21,7 @@ export function Content(props: ContentProps) {
 
   const renderedMarkdown = createMemo(() => {
     const raw = message().content ?? '';
-    const terms = termsLookup?.()?.(message().id);
+    const terms = termsLookup?.(message().id);
     if (!terms?.length) return raw;
     return mergeAdjacentMacroEmTags(highlightTermsInText(raw, [...terms]));
   });

--- a/js/app/packages/channel/Message/Content.tsx
+++ b/js/app/packages/channel/Message/Content.tsx
@@ -1,10 +1,14 @@
 import { StaticMarkdown } from '@core/component/LexicalMarkdown/component/core/StaticMarkdown';
 
 import { channelTheme } from '@core/component/LexicalMarkdown/theme';
+import {
+  highlightTermsInText,
+  mergeAdjacentMacroEmTags,
+} from '@core/util/searchHighlight';
 import { isEmojiOnly } from '@core/util/string';
 import { cn } from '@ui';
 import { createMemo, Show } from 'solid-js';
-import { useMessage } from './context';
+import { useMessage, useSearchHighlightTermsLookup } from './context';
 
 type ContentProps = {
   class?: string;
@@ -13,6 +17,14 @@ type ContentProps = {
 export function Content(props: ContentProps) {
   const message = useMessage();
   const bigEmoji = createMemo(() => isEmojiOnly(message().content ?? ''));
+  const termsLookup = useSearchHighlightTermsLookup();
+
+  const renderedMarkdown = createMemo(() => {
+    const raw = message().content ?? '';
+    const terms = termsLookup?.()?.(message().id);
+    if (!terms?.length) return raw;
+    return mergeAdjacentMacroEmTags(highlightTermsInText(raw, [...terms]));
+  });
 
   return (
     <Show when={message().content}>
@@ -24,7 +36,7 @@ export function Content(props: ContentProps) {
         )}
       >
         <StaticMarkdown
-          markdown={message().content ?? ''}
+          markdown={renderedMarkdown()}
           theme={channelTheme}
           target="internal"
         />

--- a/js/app/packages/channel/Message/context.ts
+++ b/js/app/packages/channel/Message/context.ts
@@ -4,8 +4,23 @@ import type { MessageActions, MessageData } from './types';
 const MessageContext = createContext<Accessor<MessageData>>();
 const MessageActionsContext = createContext<MessageActions>();
 
+export type SearchHighlightTermsLookup = (
+  messageId: string
+) => readonly string[] | undefined;
+
+const SearchHighlightTermsContext =
+  createContext<Accessor<SearchHighlightTermsLookup | undefined>>();
+
 export const MessageProvider = MessageContext.Provider;
 export const MessageActionsProvider = MessageActionsContext.Provider;
+export const SearchHighlightTermsProvider =
+  SearchHighlightTermsContext.Provider;
+
+export function useSearchHighlightTermsLookup():
+  | Accessor<SearchHighlightTermsLookup | undefined>
+  | undefined {
+  return useContext(SearchHighlightTermsContext);
+}
 
 export function useMessage(): Accessor<MessageData> {
   const ctx = useContext(MessageContext);

--- a/js/app/packages/channel/Message/context.ts
+++ b/js/app/packages/channel/Message/context.ts
@@ -8,8 +8,7 @@ export type SearchHighlightTermsLookup = (
   messageId: string
 ) => readonly string[] | undefined;
 
-const SearchHighlightTermsContext =
-  createContext<Accessor<SearchHighlightTermsLookup | undefined>>();
+const SearchHighlightTermsContext = createContext<SearchHighlightTermsLookup>();
 
 export const MessageProvider = MessageContext.Provider;
 export const MessageActionsProvider = MessageActionsContext.Provider;
@@ -17,7 +16,7 @@ export const SearchHighlightTermsProvider =
   SearchHighlightTermsContext.Provider;
 
 export function useSearchHighlightTermsLookup():
-  | Accessor<SearchHighlightTermsLookup | undefined>
+  | SearchHighlightTermsLookup
   | undefined {
   return useContext(SearchHighlightTermsContext);
 }

--- a/js/app/packages/channel/Message/index.ts
+++ b/js/app/packages/channel/Message/index.ts
@@ -1,15 +1,20 @@
 import {
   MessageActionsProvider,
   MessageSelectionProvider,
+  SearchHighlightTermsProvider,
   useMessage,
   useMessageActions,
   useMessageSelection,
+  useSearchHighlightTermsLookup,
 } from './context';
 
 export { ActionMenu } from './ActionMenu';
 export { Attachments } from './Attachments';
 export { ChannelMessage } from './ChannelMessage';
-export type { MessageSelectionState } from './context';
+export type {
+  MessageSelectionState,
+  SearchHighlightTermsLookup,
+} from './context';
 export { DateDivider } from './DateDivider';
 export type { ChannelMessageListMeta } from './list-meta';
 export { MediaPreview } from './MediaPreview';
@@ -26,7 +31,9 @@ export type {
 export {
   MessageActionsProvider,
   MessageSelectionProvider,
+  SearchHighlightTermsProvider,
   useMessage,
   useMessageActions,
   useMessageSelection,
+  useSearchHighlightTermsLookup,
 };


### PR DESCRIPTION
Channel find bar navigates to a result with the orange selection bar but the matched text inside the message body was not visually emphasized. This pipes the per-result highlight terms (extracted from `channel_message_search_results[].highlight.content`) through a context lookup, then wraps matches in the message markdown with `<macro_em>` so the existing `SEARCH_MATCH` lexical transformer renders them with the `search-match` style.
