### PR TITLE
fix(mentions): restore results after no-results state in mobile mentions menu

### DIFF
--- a/js/app/packages/core/component/LexicalMarkdown/component/menu/MentionsMenu/MentionsMenu.tsx
+++ b/js/app/packages/core/component/LexicalMarkdown/component/menu/MentionsMenu/MentionsMenu.tsx
@@ -509,12 +509,14 @@ function MentionsMenuInner(props: MentionsMenuProps) {
         >
           <Surface depth={2} active class="py-2">
             <Show
-              when={controller.combinedItems().length > 0}
-              fallback={<div class="px-2 text-ink-extra-muted">No results</div>}
-            >
-              <Show
-                when={controller.viewAllMode()}
-                fallback={
+              when={controller.viewAllMode()}
+              fallback={
+                <Show
+                  when={controller.combinedItems().length > 0}
+                  fallback={
+                    <div class="px-2 text-ink-extra-muted">No results</div>
+                  }
+                >
                   <div>
                     <For each={visibleBuckets()}>
                       {(bucket, idx) => (
@@ -552,44 +554,47 @@ function MentionsMenuInner(props: MentionsMenuProps) {
                       )}
                     </For>
                   </div>
-                }
-              >
-                <Show when={!isMobile()}>
-                  <div class="px-2 pb-2">
-                    <div class="flex items-center justify-between">
-                      <span class="text-xs font-medium text-ink-muted">
-                        {viewAllCategoryLabel()}
-                      </span>
-                      <button
-                        type="button"
-                        class="text-xs font-medium text-ink-muted hover:text-ink hover:underline flex items-center gap-1"
-                        onMouseDown={(e) => {
-                          e.preventDefault();
-                          e.stopPropagation();
-                        }}
-                        onClick={(e) => {
-                          e.preventDefault();
-                          e.stopPropagation();
-                          handleBackToAll();
-                        }}
-                      >
-                        <div class="p-0.5 px-1 -my-2 bg-surface text-ink border border-edge-muted rounded-xs text-xs">
-                          ←
-                        </div>
-                        Back to everything
-                      </button>
-                    </div>
-                  </div>
                 </Show>
-                <VirtualizedItemList
-                  items={controller.combinedItems()}
-                  selectedIndex={controller.selectedIndex()}
-                  itemAction={itemAction}
-                  setIndex={setSelectedIndexFromMouse}
-                  setOpen={setMenuOpen}
-                  maxHeight={contentMaxHeight()}
-                />
+              }
+            >
+              <Show when={!isMobile()}>
+                <div class="px-2 pb-2">
+                  <div class="flex items-center justify-between">
+                    <span class="text-xs font-medium text-ink-muted">
+                      {viewAllCategoryLabel()}
+                    </span>
+                    <button
+                      type="button"
+                      class="text-xs font-medium text-ink-muted hover:text-ink hover:underline flex items-center gap-1"
+                      onMouseDown={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                      }}
+                      onClick={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        handleBackToAll();
+                      }}
+                    >
+                      <div class="p-0.5 px-1 -my-2 bg-surface text-ink border border-edge-muted rounded-xs text-xs">
+                        ←
+                      </div>
+                      Back to everything
+                    </button>
+                  </div>
+                </div>
               </Show>
+              <Show when={controller.combinedItems().length === 0}>
+                <div class="px-2 text-ink-extra-muted">No results</div>
+              </Show>
+              <VirtualizedItemList
+                items={controller.combinedItems()}
+                selectedIndex={controller.selectedIndex()}
+                itemAction={itemAction}
+                setIndex={setSelectedIndexFromMouse}
+                setOpen={setMenuOpen}
+                maxHeight={contentMaxHeight()}
+              />
             </Show>
           </Surface>
         </div>


### PR DESCRIPTION
Restructures the mentions menu JSX so `VirtualizedItemList` stays mounted in view-all mode and "No results" is rendered alongside it when items are empty. Previously the list unmounted on empty results; on remount, an async re-computation of items could fire before layout settled, leaving the virtualizer's observers tracking an `offsetHeight=0` element and never recovering. This manifested on mobile (which is always in view-all mode) where backspacing from `@petx` to `@pet` left the menu blank.

  Before — outer Show on items.length, inner on viewAllMode:
```
  <Show when={items.length > 0} fallback={<NoResults/>}>
    <Show when={viewAllMode()} fallback={<BucketsView/>}>
      <Header/>
      <VirtualizedItemList items={...}/>
    </Show>
  </Show>
```
  When items.length hit 0, the outer Show swapped to "No results" → the entire inner subtree (including VirtualizedItemList) unmounted.

  After — outer Show on viewAllMode, inner on items.length only in the buckets branch:
```
  <Show when={viewAllMode()} fallback={
    <Show when={items.length > 0} fallback={<NoResults/>}>
      <BucketsView/>
    </Show>
  }>
    <Header/>
    <Show when={items.length === 0}><NoResults/></Show>
    <VirtualizedItemList items={...}/>
  </Show>
```
  In view-all mode (which mobile is always in), VirtualizedItemList is always mounted. "No results" is rendered alongside it as a sibling when the list is
  empty. The virtualizer never gets torn down, so it never gets into the bad state on remount.

  The non-view-all path (desktop buckets view) is unchanged — it still unmounts and shows "No results" when items are empty, which is fine there because no
  virtualizer is involved.

