### PR TITLE
fix: missing database envs

### DIFF
--- a/rust/cloud-storage/justfile
+++ b/rust/cloud-storage/justfile
@@ -97,6 +97,8 @@ setup_test_envs:
     echo "DATABASE_URL={{ DATABASE_URL }}" >> ./entity_access_management/.env
     echo "DATABASE_URL={{ DATABASE_URL }}" >> ./mobile_welcome_email_db_client/.env
     echo "DATABASE_URL={{ DATABASE_URL }}" >> ./entity_access_db_utils/.env
+    echo "DATABASE_URL={{ DATABASE_URL }}" >> ./mcp_client/.env
+    echo "DATABASE_URL={{ DATABASE_URL }}" >> ./document_storage_service/.env
 
 setup_macrodb:
     just macro_db_client/create_db


### PR DESCRIPTION
This PR fixes failing `cargo clippy --all-features` due to missing database env vars recently introduced
