### PR TITLE
chore: remove glob exports

### DIFF
--- a/js/app/packages/service-clients/service-auth/openapi.json
+++ b/js/app/packages/service-clients/service-auth/openapi.json
@@ -2840,7 +2840,7 @@
     },
     "/user/stripe/checkout": {
       "post": {
-        "tags": ["user::stripe"],
+        "tags": ["user::stripe::create_checkout_session"],
         "summary": "Creates a Stripe checkout session for the user to subscribe.",
         "operationId": "create_checkout_session",
         "requestBody": {
@@ -2909,7 +2909,7 @@
     },
     "/user/stripe/portal": {
       "post": {
-        "tags": ["user::stripe"],
+        "tags": ["user::stripe::create_portal_session"],
         "summary": "Creates a Stripe billing portal session.",
         "operationId": "create_portal_session",
         "requestBody": {
@@ -2958,7 +2958,7 @@
     },
     "/user/stripe/subscription": {
       "patch": {
-        "tags": ["user::stripe"],
+        "tags": ["user::stripe::patch_subscription_tier"],
         "summary": "Updates the user's subscription tier, swapping both their RBAC role and Stripe subscription line item.",
         "operationId": "patch_subscription_tier",
         "requestBody": {

--- a/rust/cloud-storage/ai/src/tool/mod.rs
+++ b/rust/cloud-storage/ai/src/tool/mod.rs
@@ -7,4 +7,9 @@ pub use ai_toolset::generate_tool_output_schema;
 pub use tool_loop::ai_client::ToolLoop;
 pub use tool_loop::cli::Cli;
 pub use types::tool_object::minimized_output_schema_generator;
-pub use types::*;
+pub use types::{
+    AiStream, AsyncTool, AsyncToolCollection, ChatCompletionStream, NoContext, RequestContext,
+    RequestSchema, ServiceContext, StreamPart, ToolCall, ToolCallError, ToolCollection, ToolInfo,
+    ToolResponse, ToolResult, ToolSchema, ToolSet, ToolSetCreationError, ToolSetError, schema,
+    tool_object,
+};

--- a/rust/cloud-storage/ai/src/tool/tool_loop/chat/mod.rs
+++ b/rust/cloud-storage/ai/src/tool/tool_loop/chat/mod.rs
@@ -3,8 +3,7 @@ mod agent;
 #[cfg(test)]
 mod test;
 
-pub use agent::*;
-
 use crate::types::Model;
+pub use agent::Chat;
 pub const MAX_RECURSIONS: u32 = 100;
 pub const TOOL_GENERATOR: Model = Model::Gemini20Flash;

--- a/rust/cloud-storage/ai/src/tool/types/mod.rs
+++ b/rust/cloud-storage/ai/src/tool/types/mod.rs
@@ -2,5 +2,10 @@ mod stream;
 
 pub use ai_toolset::schema;
 pub use ai_toolset::tool_object;
-pub use ai_toolset::*;
-pub use stream::*;
+pub use ai_toolset::{
+    AsyncTool, AsyncToolCollection, NoContext, RequestContext, RequestSchema, ServiceContext,
+    ToolCallError, ToolCollection, ToolInfo, ToolResult, ToolSchema, ToolSet, ToolSetCreationError,
+    ToolSetError,
+};
+pub use stream::{AiStream, ChatCompletionStream, StreamPart, ToolCall, ToolResponse};
+pub(crate) use stream::{ExtendedPartStream, PartOrExt, PartialToolCall};

--- a/rust/cloud-storage/ai/src/types/message/mod.rs
+++ b/rust/cloud-storage/ai/src/types/message/mod.rs
@@ -2,8 +2,11 @@ mod chat_message;
 mod message_builder;
 mod system_prompt;
 
-pub use chat_message::*;
-pub use message_builder::*;
+pub use chat_message::{
+    AssistantMessagePart, ChatMessage, ChatMessageContent, ChatMessages, ToolResponseMessage,
+    UserMessagePart,
+};
+pub use message_builder::{MessageBuilder, NoContent, NoRole};
 pub use system_prompt::SystemPrompt;
 
 use serde::{Deserialize, Serialize};

--- a/rust/cloud-storage/ai/src/types/mod.rs
+++ b/rust/cloud-storage/ai/src/types/mod.rs
@@ -7,11 +7,20 @@ mod request;
 mod request_builder;
 mod response;
 
-pub use client::*;
-pub use error::*;
-pub use message::*;
-pub use model::*;
+pub use client::{
+    AnthropicClient, ExtendedClient, ExtendedOpenAIStream, ExtendedOpenAIStreamItem,
+    OpenRouterClient, anthropic, noop, openrouter, traits,
+};
+pub use error::{AiError, Result};
+pub use message::{
+    AssistantMessagePart, ChatMessage, ChatMessageContent, ChatMessages, MessageBuilder, NoContent,
+    NoRole, Role, SystemPrompt, ToolResponseMessage, UserMessagePart,
+};
+pub use model::{Model, ModelMetadata, ModelWithMetadataAndProvider, Provider, constants};
 pub(crate) use providers::*;
-pub use request::*;
-pub use request_builder::*;
-pub use response::*;
+pub use request::ChatCompletionRequest;
+pub use request_builder::{NotSet, RequestBuilder};
+pub use response::{
+    ChatCompletionError, ChatStreamCompletionContent, ChatStreamCompletionResponse,
+    ConversionError, Usage,
+};

--- a/rust/cloud-storage/ai/src/types/model/mod.rs
+++ b/rust/cloud-storage/ai/src/types/model/mod.rs
@@ -3,8 +3,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use strum::{Display, EnumIter, EnumString};
 use utoipa::ToSchema;
 mod metadata;
-pub use metadata::*;
-
+pub use metadata::{ModelMetadata, ModelWithMetadataAndProvider, Provider};
 #[derive(
     Serialize,
     Deserialize,

--- a/rust/cloud-storage/ai/src/types/model/mod.rs
+++ b/rust/cloud-storage/ai/src/types/model/mod.rs
@@ -1,5 +1,4 @@
-use anyhow::Result;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde::{Deserialize, Serialize};
 use strum::{Display, EnumIter, EnumString};
 use utoipa::ToSchema;
 mod metadata;
@@ -179,23 +178,4 @@ impl Model {
             _unknown => return None,
         })
     }
-}
-
-/// Serialize [`Model`] as strings from [`constants::models`].
-pub fn serialize_model_without_version<S>(model: &Model, serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-{
-    let (_, model_string) = model.to_provider_model_string();
-    serializer.serialize_str(model_string)
-}
-
-/// Deserialize [`Model`] from strings from [`models`]
-pub fn deserialize_model_without_version<'de, D>(deserializer: D) -> Result<Model, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let model_str = String::deserialize(deserializer)?;
-    Model::from_model_str(&model_str)
-        .ok_or_else(|| serde::de::Error::custom(format!("Unknown model: {}", model_str)))
 }

--- a/rust/cloud-storage/ai_tools/src/lib.rs
+++ b/rust/cloud-storage/ai_tools/src/lib.rs
@@ -24,8 +24,19 @@ use subagent::Subagent;
 
 pub use build_context::build_tool_service_context_from_env;
 pub use search::search_toolset;
-pub use tool_context::*;
-
+#[cfg(any(test, feature = "test-support"))]
+pub use tool_context::no_op_schedule_context;
+pub use tool_context::{
+    NoOpCallRtcClient, NoOpConnectionService, NoOpNotificationIngress, NoOpNotificationService,
+    NoOpScheduleContext, NoOpSnsEndpointManager, NoOpTaskProperties, RequestContext,
+    ToolCallRecordQueryService, ToolCallService, ToolCallToolContext, ToolChannelMessagesService,
+    ToolChannelToolContext, ToolChatService, ToolChatToolContext, ToolCommsService,
+    ToolDocumentService, ToolDocumentToolContext, ToolEmailService, ToolEmailToolContext,
+    ToolEntityAccessManagementService, ToolEntityAccessService, ToolFrecencyService,
+    ToolNotificationQueue, ToolNotificationService, ToolNotificationToolContext,
+    ToolPropertiesService, ToolPropertiesToolContext, ToolServiceContext, ToolSoupService,
+    ToolUserEmailService, build_channel_tool_context,
+};
 pub type AiToolSet = AsyncToolCollection<ToolServiceContext>;
 
 pub struct ToolSetWithPrompt {

--- a/rust/cloud-storage/ai_toolset/src/lib.rs
+++ b/rust/cloud-storage/ai_toolset/src/lib.rs
@@ -134,6 +134,9 @@ pub mod schema;
 mod tool;
 mod toolset;
 
-pub use context::*;
-pub use tool::*;
-pub use toolset::*;
+pub use context::{RequestContext, ServiceContext};
+pub use tool::{AsyncTool, NoContext, ToolCallError, ToolResult};
+pub use toolset::{
+    AsyncToolCollection, RequestSchema, ToolCollection, ToolInfo, ToolSchema, ToolSet,
+    ToolSetCreationError, ToolSetError, tool_object,
+};

--- a/rust/cloud-storage/ai_toolset/src/schema/mod.rs
+++ b/rust/cloud-storage/ai_toolset/src/schema/mod.rs
@@ -6,5 +6,8 @@
 mod generate;
 mod phantom_tool;
 
-pub use generate::*;
-pub use phantom_tool::*;
+pub use generate::{
+    CombinedToolEntry, CombinedToolSchemas, CombinedToolSchemasBuilder, NormaliseRefSiblings,
+    ToolSchema, ToolSchemaGenerator, ToolSchemas,
+};
+pub use phantom_tool::PhantomTool;

--- a/rust/cloud-storage/ai_toolset/src/toolset/mod.rs
+++ b/rust/cloud-storage/ai_toolset/src/toolset/mod.rs
@@ -4,5 +4,8 @@ pub mod tool_object;
 mod traits;
 mod types;
 
-pub use traits::*;
-pub use types::*;
+pub use traits::ToolSet;
+pub use types::{
+    AsyncToolCollection, RequestSchema, ToolCollection, ToolInfo, ToolSchema, ToolSetCreationError,
+    ToolSetError,
+};

--- a/rust/cloud-storage/ai_toolset/src/toolset/tool_object/mod.rs
+++ b/rust/cloud-storage/ai_toolset/src/toolset/tool_object/mod.rs
@@ -11,8 +11,11 @@ mod object;
 mod tool_async;
 mod user_tool;
 
-pub use json_tool::*;
-pub use object::*;
-pub use tool_async::*;
-pub use user_tool::*;
-pub use util::*;
+pub use json_tool::JsonAsyncTool;
+pub use object::{SchemaRegistrar, ToolObject, ValidationError};
+pub use tool_async::{AsyncToolObject, ToolSetCallable};
+pub use user_tool::{UserTool, UserToolResponse};
+pub use util::{
+    MinimizedOutput, input_schema_generator, minimized_output_schema_generator,
+    output_schema_generator, validate_tool_schema,
+};

--- a/rust/cloud-storage/anthropic/src/openai/request/mod.rs
+++ b/rust/cloud-storage/anthropic/src/openai/request/mod.rs
@@ -1,8 +1,7 @@
 mod conversions;
 mod request_extension;
 
-pub use conversions::*;
-pub use request_extension::*;
-
+pub use conversions::{MessageConversionError, aggregate_messages};
+pub use request_extension::{AnthropicRequestExtension, AnthropicRequestExtensions};
 #[cfg(test)]
 mod test;

--- a/rust/cloud-storage/anthropic/src/prelude.rs
+++ b/rust/cloud-storage/anthropic/src/prelude.rs
@@ -1,7 +1,16 @@
-pub use crate::client::*;
-pub use crate::config::*;
-pub use crate::types::request::*;
-pub use crate::types::response::*;
-
+pub use crate::client::{Client, chat};
+pub use crate::config::Config;
 #[cfg(feature = "openai")]
-pub use crate::openai::*;
+pub use crate::openai::{request, stream_extension, stream_response};
+pub(crate) use crate::types::request::transform_request_web_fetch;
+pub use crate::types::request::{
+    CODE_EXECUTION_TOOL, CODE_EXECUTION_TOOL_HEADER, CacheControl, ClientTool,
+    CreateMessageRequestBody, ImageSource, McpServer, Metadata, RequestContent, RequestContentKind,
+    RequestMessage, Role, ServerTool, ServiceTier, SystemContent, SystemPrompt, Thinking, Tool,
+    ToolChoice, WEB_FETCH_TOOL, WEB_FETCH_TOOL_HEADER, WEB_SEARCH_TOOL,
+};
+pub use crate::types::response::{
+    ApiError, Citation, Container, Content, ContentDeltaEvent, Error, MessageResponse,
+    RedactedThinking, ResponseContentKind, ServerToolUse, StopReason, StreamError, StreamEvent,
+    TextResponse, ThinkingResponse, ToolUse, Usage, code_execution, web_fetch, web_search,
+};

--- a/rust/cloud-storage/anthropic/src/types/request/mod.rs
+++ b/rust/cloud-storage/anthropic/src/types/request/mod.rs
@@ -2,5 +2,13 @@ mod server_tools;
 mod types;
 mod util;
 
-pub use server_tools::*;
-pub use types::*;
+pub(crate) use server_tools::transform_request_web_fetch;
+pub use server_tools::{
+    CODE_EXECUTION_TOOL, CODE_EXECUTION_TOOL_HEADER, WEB_FETCH_TOOL, WEB_FETCH_TOOL_HEADER,
+    WEB_SEARCH_TOOL,
+};
+pub use types::{
+    CacheControl, ClientTool, CreateMessageRequestBody, ImageSource, McpServer, Metadata,
+    RequestContent, RequestContentKind, RequestMessage, Role, ServerTool, ServiceTier,
+    SystemContent, SystemPrompt, Thinking, Tool, ToolChoice,
+};

--- a/rust/cloud-storage/anthropic/src/types/response/mod.rs
+++ b/rust/cloud-storage/anthropic/src/types/response/mod.rs
@@ -6,5 +6,8 @@ mod types;
 pub mod web_fetch;
 pub mod web_search;
 
-pub use stream_types::*;
-pub use types::*;
+pub use stream_types::{Citation, ContentDeltaEvent, StreamError, StreamEvent};
+pub use types::{
+    ApiError, Container, Content, Error, MessageResponse, RedactedThinking, ResponseContentKind,
+    ServerToolUse, StopReason, TextResponse, ThinkingResponse, ToolUse, Usage,
+};

--- a/rust/cloud-storage/attachment/src/image/mod.rs
+++ b/rust/cloud-storage/attachment/src/image/mod.rs
@@ -2,8 +2,7 @@
 
 mod base_64_image;
 
-pub use base_64_image::*;
-
+pub use base_64_image::{Base64Image, ImageFormat};
 /// An image that can be included in an attachment.
 #[derive(PartialEq, Eq, Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub enum ImageData {

--- a/rust/cloud-storage/attachment/src/lib.rs
+++ b/rust/cloud-storage/attachment/src/lib.rs
@@ -3,7 +3,10 @@
 
 use macro_user_id::user_id::MacroUserIdStr;
 use model_entity::Entity;
-pub use models::*;
+pub use models::{
+    AttachmentContent, AttachmentError, AttachmentPart, Attachments, FormattedParts,
+    ResolutionError, TextOrImage,
+};
 use non_empty::NonEmpty;
 
 mod attachable;

--- a/rust/cloud-storage/authentication_service/src/api/swagger.rs
+++ b/rust/cloud-storage/authentication_service/src/api/swagger.rs
@@ -26,10 +26,10 @@ use crate::api::user::patch_user_group::PatchUserGroupRequest;
 use crate::api::user::patch_user_onboarding::PatchUserOnboardingRequest;
 use crate::api::user::post_get_names::PostGetNamesRequestBody;
 use crate::api::user::post_get_names_with_email::GetNamesWithEmailRequestBody;
-use crate::api::user::stripe::{
-    CreateCheckoutSessionRequest, CreatePortalSessionRequest, PatchSubscriptionTierRequest,
-    StripeProductTier, StripeSessionResponse,
-};
+use crate::api::user::stripe::create_checkout_session::CreateCheckoutSessionRequest;
+use crate::api::user::stripe::create_portal_session::CreatePortalSessionRequest;
+use crate::api::user::stripe::patch_subscription_tier::PatchSubscriptionTierRequest;
+use crate::api::user::stripe::{StripeProductTier, StripeSessionResponse};
 use crate::api::{
     email, health, jwt, link, login, logout, merge, mobile_welcome_email, oauth, oauth2,
     permissions, session, user,
@@ -98,9 +98,9 @@ use model::user::{
                 user::get_user_quota::handler,
                 user::get_legacy_user_permissions::handler,
                 user::patch_tutorial::handler,
-                user::stripe::create_checkout_session,
-                user::stripe::create_portal_session,
-                user::stripe::patch_subscription_tier,
+                user::stripe::create_checkout_session::create_checkout_session,
+                user::stripe::create_portal_session::create_portal_session,
+                user::stripe::patch_subscription_tier::patch_subscription_tier,
 
                 /// /session
                 session::session_login::handler,

--- a/rust/cloud-storage/authentication_service/src/api/user/mod.rs
+++ b/rust/cloud-storage/authentication_service/src/api/user/mod.rs
@@ -57,11 +57,17 @@ fn router_with_auth(state: ApiContext, jwt_args: JwtValidationArgs) -> Router<Ap
                 macro_middleware::user_permissions::attach_user_permissions::handler,
             )),
         )
-        .route("/stripe/checkout", post(stripe::create_checkout_session))
-        .route("/stripe/portal", post(stripe::create_portal_session))
+        .route(
+            "/stripe/checkout",
+            post(stripe::create_checkout_session::create_checkout_session),
+        )
+        .route(
+            "/stripe/portal",
+            post(stripe::create_portal_session::create_portal_session),
+        )
         .route(
             "/stripe/subscription",
-            patch(stripe::patch_subscription_tier),
+            patch(stripe::patch_subscription_tier::patch_subscription_tier),
         )
         .route(
             "/legacy_user_permissions",

--- a/rust/cloud-storage/authentication_service/src/api/user/stripe/mod.rs
+++ b/rust/cloud-storage/authentication_service/src/api/user/stripe/mod.rs
@@ -3,7 +3,14 @@ mod create_portal_session;
 mod patch_subscription_tier;
 mod shared;
 
-pub use create_checkout_session::*;
-pub use create_portal_session::*;
-pub use patch_subscription_tier::*;
+pub use create_checkout_session::{
+    __path_create_checkout_session, CheckoutSessionMetadata, CreateCheckoutSessionRequest,
+    create_checkout_session,
+};
+pub use create_portal_session::{
+    __path_create_portal_session, CreatePortalSessionRequest, create_portal_session,
+};
+pub use patch_subscription_tier::{
+    __path_patch_subscription_tier, PatchSubscriptionTierRequest, patch_subscription_tier,
+};
 pub use shared::{StripeOperationError, StripeProductTier, StripeSessionResponse};

--- a/rust/cloud-storage/authentication_service/src/api/user/stripe/mod.rs
+++ b/rust/cloud-storage/authentication_service/src/api/user/stripe/mod.rs
@@ -1,16 +1,6 @@
-mod create_checkout_session;
-mod create_portal_session;
-mod patch_subscription_tier;
+pub mod create_checkout_session;
+pub mod create_portal_session;
+pub mod patch_subscription_tier;
 mod shared;
 
-pub use create_checkout_session::{
-    __path_create_checkout_session, CheckoutSessionMetadata, CreateCheckoutSessionRequest,
-    create_checkout_session,
-};
-pub use create_portal_session::{
-    __path_create_portal_session, CreatePortalSessionRequest, create_portal_session,
-};
-pub use patch_subscription_tier::{
-    __path_patch_subscription_tier, PatchSubscriptionTierRequest, patch_subscription_tier,
-};
 pub use shared::{StripeOperationError, StripeProductTier, StripeSessionResponse};

--- a/rust/cloud-storage/chat/src/domain/models/mod.rs
+++ b/rust/cloud-storage/chat/src/domain/models/mod.rs
@@ -4,6 +4,6 @@ mod chat;
 mod error;
 mod message;
 
-pub use chat::*;
-pub use error::*;
-pub use message::*;
+pub use chat::{ChatResponse, CopyChatArgs, CreateChatArgs, GetChatResponse, PatchChatArgs};
+pub use error::{ChatErr, Result};
+pub use message::{PatchChatMessageArgs, ResolvedMessageContent, WebCitation};

--- a/rust/cloud-storage/chat/src/domain/ports/mod.rs
+++ b/rust/cloud-storage/chat/src/domain/ports/mod.rs
@@ -1,5 +1,5 @@
 mod chat;
 mod message;
 
-pub use chat::*;
-pub use message::*;
+pub use chat::{ChatRepo, ChatService};
+pub use message::{MessageRepo, MessageService};

--- a/rust/cloud-storage/chat/src/domain/service/mod.rs
+++ b/rust/cloud-storage/chat/src/domain/service/mod.rs
@@ -3,5 +3,5 @@
 mod chat;
 mod message;
 
-pub use chat::*;
-pub use message::*;
+pub use chat::ChatServiceImpl;
+pub use message::MessageServiceImpl;

--- a/rust/cloud-storage/chat/src/inbound/mod.rs
+++ b/rust/cloud-storage/chat/src/inbound/mod.rs
@@ -6,24 +6,8 @@ pub mod attachment;
 #[cfg(test)]
 mod test;
 
-mod http;
+pub mod http;
 
 /// AI toolset exposing chat history to agents.
 #[cfg(feature = "ai_tools")]
 pub mod toolset;
-
-// Re-exports for backwards compatibility.
-pub use self::http::extractors::ChatModelAccess;
-pub use self::http::router::{
-    __path_call_tool_handler, __path_copy_chat_handler, __path_create_chat_handler,
-    __path_delete_chat_handler, __path_get_chat_handler, __path_get_chat_permissions_handler,
-    __path_patch_chat_handler, __path_permanently_delete_chat_handler,
-    __path_reject_tool_call_handler, __path_revert_delete_handler, __path_update_tool_call_handler,
-    __path_update_tool_response_handler, CallToolRequest, CallToolResponse, ChatRouterState,
-    CreateChatRequest, GetChatPermissionsResponse, PatchChatRequest, RejectToolCallRequest,
-    UpdateToolCallRequest, UpdateToolResponseRequest, call_tool_handler, chat_create_router,
-    chat_id_router, copy_chat_handler, create_chat_handler, delete_chat_handler, get_chat_handler,
-    get_chat_permissions_handler, patch_chat_handler, permanently_delete_chat_handler,
-    reject_tool_call_handler, revert_delete_handler, update_tool_call_handler,
-    update_tool_response_handler,
-};

--- a/rust/cloud-storage/chat/src/inbound/mod.rs
+++ b/rust/cloud-storage/chat/src/inbound/mod.rs
@@ -14,4 +14,16 @@ pub mod toolset;
 
 // Re-exports for backwards compatibility.
 pub use self::http::extractors::ChatModelAccess;
-pub use self::http::router::*;
+pub use self::http::router::{
+    __path_call_tool_handler, __path_copy_chat_handler, __path_create_chat_handler,
+    __path_delete_chat_handler, __path_get_chat_handler, __path_get_chat_permissions_handler,
+    __path_patch_chat_handler, __path_permanently_delete_chat_handler,
+    __path_reject_tool_call_handler, __path_revert_delete_handler, __path_update_tool_call_handler,
+    __path_update_tool_response_handler, CallToolRequest, CallToolResponse, ChatRouterState,
+    CreateChatRequest, GetChatPermissionsResponse, PatchChatRequest, RejectToolCallRequest,
+    UpdateToolCallRequest, UpdateToolResponseRequest, call_tool_handler, chat_create_router,
+    chat_id_router, copy_chat_handler, create_chat_handler, delete_chat_handler, get_chat_handler,
+    get_chat_permissions_handler, patch_chat_handler, permanently_delete_chat_handler,
+    reject_tool_call_handler, revert_delete_handler, update_tool_call_handler,
+    update_tool_response_handler,
+};

--- a/rust/cloud-storage/chat/src/inbound/test.rs
+++ b/rust/cloud-storage/chat/src/inbound/test.rs
@@ -9,11 +9,11 @@ use model::response::StringIDResponse;
 use model_user::UserContext;
 use tower::util::ServiceExt;
 
-use super::*;
 use crate::domain::models::{
     ChatErr, ChatResponse, CreateChatArgs, GetChatResponse, PatchChatArgs, Result,
 };
 use crate::domain::ports::ChatService;
+use crate::inbound::http::router::{ChatRouterState, chat_id_router};
 use ai_toolset::tool_object::UserToolResponse;
 use entity_access::domain::models::{
     AccessError, AccessLevel, EditAccessLevel, EntityAccessReceipt, EntityPermission, EntityType,

--- a/rust/cloud-storage/comms/src/domain/models.rs
+++ b/rust/cloud-storage/comms/src/domain/models.rs
@@ -1,6 +1,6 @@
 use item_filters::ast::{LiteralTree, channel::ChannelLiteral};
 use macro_user_id::user_id::MacroUserIdStr;
-pub use models_comms::*;
+pub use models_comms::{channel, mentions};
 use models_pagination::{Query, SimpleSortMethod};
 use serde::Deserialize;
 use uuid::Uuid;

--- a/rust/cloud-storage/comms/src/inbound.rs
+++ b/rust/cloud-storage/comms/src/inbound.rs
@@ -1,7 +1,10 @@
 #[cfg(feature = "inbound")]
 mod router;
 #[cfg(feature = "inbound")]
-pub use router::*;
-
+pub use router::{
+    __path_get_activity_handler, __path_get_channels_handler, ApiActivity, ApiChannelWithLatest,
+    Channel, ChannelMessage, ChannelParticipant, ChannelType, ChannelWithParticipants, CommsErr,
+    CommsRouterState, LatestMessage, ParticipantRole, comms_router, get_activity_handler,
+};
 #[cfg(feature = "attachment")]
 pub mod attachment;

--- a/rust/cloud-storage/comms/src/inbound.rs
+++ b/rust/cloud-storage/comms/src/inbound.rs
@@ -1,10 +1,4 @@
-#[cfg(feature = "inbound")]
-mod router;
-#[cfg(feature = "inbound")]
-pub use router::{
-    __path_get_activity_handler, __path_get_channels_handler, ApiActivity, ApiChannelWithLatest,
-    Channel, ChannelMessage, ChannelParticipant, ChannelType, ChannelWithParticipants, CommsErr,
-    CommsRouterState, LatestMessage, ParticipantRole, comms_router, get_activity_handler,
-};
 #[cfg(feature = "attachment")]
 pub mod attachment;
+#[cfg(feature = "inbound")]
+pub mod router;

--- a/rust/cloud-storage/comms_db_client/src/entity_mentions/mod.rs
+++ b/rust/cloud-storage/comms_db_client/src/entity_mentions/mod.rs
@@ -4,8 +4,10 @@ pub mod delete_entity_mentions_by_source;
 pub mod get_entity_mention_by_id;
 mod get_entity_mentions_for_thread;
 
-pub use create_entity_mention::*;
-pub use delete_entity_mention_by_id::*;
-pub use delete_entity_mentions_by_source::*;
-pub use get_entity_mention_by_id::*;
-pub use get_entity_mentions_for_thread::*;
+pub use create_entity_mention::{CreateEntityMentionOptions, create_entity_mention};
+pub use delete_entity_mention_by_id::{
+    delete_entity_mention_by_id, delete_entity_mentions_by_entity,
+};
+pub use delete_entity_mentions_by_source::delete_entity_mentions_by_source;
+pub use get_entity_mention_by_id::get_entity_mention_by_id;
+pub use get_entity_mentions_for_thread::get_entity_mentions_for_thread;

--- a/rust/cloud-storage/comms_service/src/api/context.rs
+++ b/rust/cloud-storage/comms_service/src/api/context.rs
@@ -1,7 +1,7 @@
 use axum_macros::FromRef;
 use comms::{
     domain::service::ChannelServiceImpl,
-    inbound::CommsRouterState,
+    inbound::router::CommsRouterState,
     outbound::postgres::{comms_repo::PgCommsRepo, user_repo::PgUserRepo},
 };
 use connection_gateway_client::client::ConnectionGatewayClient;

--- a/rust/cloud-storage/comms_service/src/api/extractors.rs
+++ b/rust/cloud-storage/comms_service/src/api/extractors.rs
@@ -7,7 +7,7 @@ use axum::{
 use axum_extra::extract::Cached;
 use comms::{
     domain::{models::channel_name::resolve_channel_name, ports::ChannelsService},
-    inbound::CommsRouterState,
+    inbound::router::CommsRouterState,
 };
 use comms_db_client::{
     channels::get_channel_info::{ChannelInfo, get_channel_info},

--- a/rust/cloud-storage/comms_service/src/api/mentions/mod.rs
+++ b/rust/cloud-storage/comms_service/src/api/mentions/mod.rs
@@ -3,9 +3,12 @@ use axum::{
     Router,
     routing::{delete, post},
 };
-pub use create_mention::*;
-pub use delete_mention::*;
-
+pub use create_mention::{
+    CreateEntityMentionRequest, CreateEntityMentionResponse, create_mention_handler,
+};
+pub use delete_mention::{
+    DeleteEntityMentionRequest, DeleteEntityMentionResponse, delete_mention_handler,
+};
 pub mod create_mention;
 pub mod delete_mention;
 mod mentions_middleware;

--- a/rust/cloud-storage/comms_service/src/api/middleware/mod.rs
+++ b/rust/cloud-storage/comms_service/src/api/middleware/mod.rs
@@ -2,5 +2,5 @@ mod permissions_token;
 mod renamed_middleware {
     pub use macro_middleware::auth::decode_jwt::handler as decode_jwt;
 }
-pub use permissions_token::*;
-pub use renamed_middleware::*;
+pub use permissions_token::{AuthToken, decode_validate_jwt, validate_edit_document_permission};
+pub use renamed_middleware::decode_jwt;

--- a/rust/cloud-storage/comms_service/src/api/mod.rs
+++ b/rust/cloud-storage/comms_service/src/api/mod.rs
@@ -18,7 +18,9 @@ pub mod swagger;
 /// It does NOT include JWT decoding middleware - that should be applied by the host service.
 pub fn router(app_state: &AppState) -> Router<AppState> {
     Router::new()
-        .merge(comms::inbound::comms_router(app_state.comms_state.clone()))
+        .merge(comms::inbound::router::comms_router(
+            app_state.comms_state.clone(),
+        ))
         .route("/activity", post(post_activity::post_activity_handler))
         .nest("/channels", channels::router())
         .nest("/preview", preview::router())

--- a/rust/cloud-storage/comms_service/src/api/swagger.rs
+++ b/rust/cloud-storage/comms_service/src/api/swagger.rs
@@ -20,7 +20,7 @@ use crate::api::{
     },
     preview::get_batch_preview::{GetBatchChannelPreviewRequest, GetBatchChannelPreviewResponse},
 };
-use comms::inbound::{ApiActivity, ApiChannelWithLatest};
+use comms::inbound::router::{ApiActivity, ApiChannelWithLatest};
 use comms_db_client::channels::patch_channel::PatchChannelOptions;
 use comms_db_client::model::{
     Activity, ActivityType, CountedReaction, EntityMention, Message, NewAttachment, Reaction,
@@ -63,13 +63,13 @@ use super::preview::get_batch_preview;
         paths(
             create_channel::create_channel_handler,
             get_channel::get_channel_handler,
-            comms::inbound::get_channels_handler,
+            comms::inbound::router::get_channels_handler,
             post_message::post_message_handler,
             post_typing::post_typing_handler,
             post_reaction::post_reaction_handler,
             patch_message::patch_message_handler,
             delete_message::delete_message_handler,
-            comms::inbound::get_activity_handler,
+            comms::inbound::router::get_activity_handler,
             post_activity::post_activity_handler,
             join_channel::join_channel_handler,
             leave_channel::leave_channel_handler,

--- a/rust/cloud-storage/comms_service/src/lib.rs
+++ b/rust/cloud-storage/comms_service/src/lib.rs
@@ -18,7 +18,7 @@ pub use api::swagger::ApiDoc as CommsApiDoc;
 
 // Re-export comms types needed to construct the state
 pub use comms::domain::service::ChannelServiceImpl;
-pub use comms::inbound::CommsRouterState;
+pub use comms::inbound::router::CommsRouterState;
 pub use comms::outbound::postgres::comms_repo::PgCommsRepo;
 pub use comms::outbound::postgres::user_repo::PgUserRepo;
 pub use frecency::outbound::postgres::FrecencyPgStorage;

--- a/rust/cloud-storage/document_cognition_service/src/api/chats/mod.rs
+++ b/rust/cloud-storage/document_cognition_service/src/api/chats/mod.rs
@@ -7,7 +7,7 @@ use axum::{
     routing::{get, post},
 };
 use chat::domain::service::ChatServiceImpl;
-use chat::inbound::{ChatRouterState, chat_create_router, chat_id_router};
+use chat::inbound::http::router::{ChatRouterState, chat_create_router, chat_id_router};
 use chat::outbound::postgres::PgChatRepo;
 use entity_access::domain::service::EntityAccessServiceImpl;
 use entity_access::outbound::PgAccessRepository;

--- a/rust/cloud-storage/document_cognition_service/src/api/context/mod.rs
+++ b/rust/cloud-storage/document_cognition_service/src/api/context/mod.rs
@@ -47,8 +47,7 @@ pub type DcsMessageService = MessageServiceImpl<PgChatRepo, DcsAttachmentProvide
 #[cfg(test)]
 mod test;
 #[cfg(test)]
-pub use test::*;
-
+pub use test::{MockConnectionRepo, MockStreamRepo, test_api_context};
 pub(crate) type NotificationIngressType = SqsNotificationIngress<SqsQueue>;
 
 pub type DcsMemoryService =

--- a/rust/cloud-storage/document_cognition_service/src/api/context/mod.rs
+++ b/rust/cloud-storage/document_cognition_service/src/api/context/mod.rs
@@ -47,7 +47,7 @@ pub type DcsMessageService = MessageServiceImpl<PgChatRepo, DcsAttachmentProvide
 #[cfg(test)]
 mod test;
 #[cfg(test)]
-pub use test::{MockConnectionRepo, MockStreamRepo, test_api_context};
+pub use test::test_api_context;
 pub(crate) type NotificationIngressType = SqsNotificationIngress<SqsQueue>;
 
 pub type DcsMemoryService =

--- a/rust/cloud-storage/document_cognition_service/src/api/stream/chat_message.rs
+++ b/rust/cloud-storage/document_cognition_service/src/api/stream/chat_message.rs
@@ -22,7 +22,7 @@ use axum::http::StatusCode;
 use axum::middleware::Next;
 use axum::response::IntoResponse;
 use chat::domain::ports::MessageService;
-use chat::inbound::ChatModelAccess;
+use chat::inbound::http::extractors::ChatModelAccess;
 use futures::StreamExt;
 use macro_auth::headers::AccessTokenExtractor;
 use macro_db_client::dcs::create_chat;

--- a/rust/cloud-storage/document_cognition_service/src/api/swagger.rs
+++ b/rust/cloud-storage/document_cognition_service/src/api/swagger.rs
@@ -28,8 +28,8 @@ use crate::api::preview::get_batch_preview::{GetBatchPreviewRequest, GetBatchPre
 use ai::types::{ModelMetadata, Provider};
 
 use chat::domain::models::{ChatResponse, GetChatResponse, WebCitation};
-use chat::inbound::{
-    self as chat_inbound, CallToolRequest, CallToolResponse, CreateChatRequest,
+use chat::inbound::http::router::{
+    self as chat_router, CallToolRequest, CallToolResponse, CreateChatRequest,
     GetChatPermissionsResponse, PatchChatRequest, RejectToolCallRequest, UpdateToolCallRequest,
     UpdateToolResponseRequest,
 };
@@ -60,18 +60,18 @@ use utoipa::OpenApi;
         ),
         paths(
             health::health_handler,
-            chat_inbound::get_chat_handler,
-            chat_inbound::create_chat_handler,
-            chat_inbound::copy_chat_handler,
-            chat_inbound::get_chat_permissions_handler,
-            chat_inbound::delete_chat_handler,
-            chat_inbound::permanently_delete_chat_handler,
-            chat_inbound::patch_chat_handler,
-            chat_inbound::revert_delete_handler,
-            chat_inbound::update_tool_call_handler,
-            chat_inbound::update_tool_response_handler,
-            chat_inbound::call_tool_handler,
-            chat_inbound::reject_tool_call_handler,
+            chat_router::get_chat_handler,
+            chat_router::create_chat_handler,
+            chat_router::copy_chat_handler,
+            chat_router::get_chat_permissions_handler,
+            chat_router::delete_chat_handler,
+            chat_router::permanently_delete_chat_handler,
+            chat_router::patch_chat_handler,
+            chat_router::revert_delete_handler,
+            chat_router::update_tool_call_handler,
+            chat_router::update_tool_response_handler,
+            chat_router::call_tool_handler,
+            chat_router::reject_tool_call_handler,
             get_models::get_models_handler,
             get_chats_for_attachment::get_chats_for_attachment_handler,
             citations::get_citation_handler,

--- a/rust/cloud-storage/document_storage_service/src/api/context.rs
+++ b/rust/cloud-storage/document_storage_service/src/api/context.rs
@@ -18,7 +18,7 @@ use channels::{
 };
 use comms::{
     domain::service::ChannelServiceImpl,
-    inbound::CommsRouterState,
+    inbound::router::CommsRouterState,
     outbound::postgres::{comms_repo::PgCommsRepo, user_repo::PgUserRepo},
 };
 use comms_service::CommsHandlerState;

--- a/rust/cloud-storage/document_storage_service/src/api/internal/mod.rs
+++ b/rust/cloud-storage/document_storage_service/src/api/internal/mod.rs
@@ -44,10 +44,12 @@ pub fn router(state: ApiContext) -> Router<ApiContext> {
         // Document routes
         .route(
             "/documents/{document_id}",
-            get(documents_hex::inbound::axum_router::get_document_handler::<
-                DocumentService,
-                EntityAccessService,
-            >)
+            get(
+                documents_hex::inbound::axum_router::get_document::get_document_handler::<
+                    DocumentService,
+                    EntityAccessService,
+                >,
+            )
             .layer(ensure_document_exists_middleware.clone()),
         )
         .route(
@@ -75,7 +77,7 @@ pub fn router(state: ApiContext) -> Router<ApiContext> {
         .route(
             "/documents/{document_id}/location_v3",
             get(
-                documents_hex::inbound::axum_router::get_location_v3_handler::<
+                documents_hex::inbound::axum_router::get_location::get_location_v3_handler::<
                     DocumentService,
                     EntityAccessService,
                 >,
@@ -93,7 +95,7 @@ pub fn router(state: ApiContext) -> Router<ApiContext> {
         .route(
             "/documents",
             post(
-                documents_hex::inbound::axum_router::create_document_handler::<
+                documents_hex::inbound::axum_router::create_document::create_document_handler::<
                     DocumentService,
                     EntityAccessService,
                 >,

--- a/rust/cloud-storage/document_storage_service/src/api/swagger.rs
+++ b/rust/cloud-storage/document_storage_service/src/api/swagger.rs
@@ -69,7 +69,10 @@ use channels::inbound::axum_router::{
     ChannelMessageFilters,
 };
 use document_sub_type::DocumentSubType;
-use documents_hex::inbound::axum_router::{BranchNameResponse, ShortIdResponse};
+use documents_hex::inbound::axum_router::{
+    edit_document::EditDocumentResponse, get_branch_name::BranchNameResponse,
+    get_short_id::ShortIdResponse,
+};
 use model::document::response::{
     CreateDocumentRequest, CreateDocumentResponse, CreateDocumentResponseData,
     DocumentResponseMetadata,
@@ -139,23 +142,23 @@ use utoipa::OpenApi;
 
         // documents
         documents::get_user_documents::get_user_documents_handler,
-        documents_hex::inbound::axum_router::get_document_handler,
+        documents_hex::inbound::axum_router::get_document::get_document_handler,
         documents::get_document_version::handler,
-        documents_hex::inbound::axum_router::create_document_handler,
-        documents_hex::inbound::axum_router::create_markdown_handler,
-        documents_hex::inbound::axum_router::copy_document_handler,
+        documents_hex::inbound::axum_router::create_document::create_document_handler,
+        documents_hex::inbound::axum_router::create_markdown::create_markdown_handler,
+        documents_hex::inbound::axum_router::copy_document::copy_document_handler,
         documents::save_document::save_document_handler,
         documents::pre_save::presave_document_handler,
-        documents_hex::inbound::axum_router::edit_document_handler,
-        documents_hex::inbound::axum_router::delete_document_handler,
+        documents_hex::inbound::axum_router::edit_document::edit_document_handler,
+        documents_hex::inbound::axum_router::delete_document::delete_document_handler,
         documents::delete_document::permanently_delete_document_handler,
         documents::get_document_list::get_document_list_handler,
         documents::get_document_permissions::get_document_permissions_handler_v2,
         documents::get_document_views::get_document_views_handler,
         documents::location::get_location_handler,
-        documents_hex::inbound::axum_router::get_location_v3_handler,
-        documents_hex::inbound::axum_router::get_branch_name_handler,
-        documents_hex::inbound::axum_router::get_short_id_handler,
+        documents_hex::inbound::axum_router::get_location::get_location_v3_handler,
+        documents_hex::inbound::axum_router::get_branch_name::get_branch_name_handler,
+        documents_hex::inbound::axum_router::get_short_id::get_short_id_handler,
         documents::simple_save::handler,
         documents::initialize_user_documents::handler,
         documents::get_batch_preview::get_batch_preview_handler,
@@ -163,7 +166,7 @@ use utoipa::OpenApi;
         documents::permissions_token::validate_permissions_token::handler,
         documents::revert_delete_document::handler,
         documents::export_document::handler,
-        documents_hex::inbound::axum_router::create_task_handler,
+        documents_hex::inbound::axum_router::create_task::create_task_handler,
 
         // instructions
         instructions::create_instructions::create_instructions_handler,
@@ -287,7 +290,7 @@ use utoipa::OpenApi;
             documents_hex::domain::models::CopyDocumentQueryParams,
             documents_hex::domain::models::CopyDocumentResponse, // Copy document
             documents_hex::domain::models::EditDocumentServiceArgs,
-            documents_hex::inbound::axum_router::EditDocumentResponse, // Edit document
+            EditDocumentResponse, // Edit document
             UserDocumentsResponse,
             GetDocumentsResponse, // Get user documents
             GetDocumentProcessingResult,

--- a/rust/cloud-storage/document_storage_service/src/main.rs
+++ b/rust/cloud-storage/document_storage_service/src/main.rs
@@ -29,7 +29,7 @@ use channels::{
 };
 use comms::{
     domain::service::ChannelServiceImpl,
-    inbound::CommsRouterState,
+    inbound::router::CommsRouterState,
     outbound::postgres::{comms_repo::PgCommsRepo, user_repo::PgUserRepo},
 };
 use config::{Config, Environment};

--- a/rust/cloud-storage/documents/src/inbound/axum_router.rs
+++ b/rust/cloud-storage/documents/src/inbound/axum_router.rs
@@ -45,18 +45,21 @@ use crate::domain::ports::DocumentService;
 use crate::domain::ports::create::DocumentCreationService;
 
 // Re-export handlers and utoipa path types for external use (swagger, internal routes)
-pub use copy_document::*;
-pub use create_document::*;
+pub use copy_document::{__path_copy_document_handler, copy_document_handler};
+pub use create_document::{__path_create_document_handler, create_document_handler};
 #[cfg(feature = "document_create")]
-pub use create_markdown::*;
-pub use create_task::*;
-pub use delete_document::*;
-pub use edit_document::*;
-pub use get_branch_name::*;
-pub use get_document::*;
-pub use get_location::*;
-pub use get_short_id::*;
-
+pub use create_markdown::{__path_create_markdown_handler, create_markdown_handler};
+pub use create_task::{__path_create_task_handler, create_task_handler};
+pub use delete_document::{__path_delete_document_handler, delete_document_handler};
+pub use edit_document::{
+    __path_edit_document_handler, EditDocumentResponse, edit_document_handler,
+};
+pub use get_branch_name::{
+    __path_get_branch_name_handler, BranchNameResponse, get_branch_name_handler,
+};
+pub use get_document::{__path_get_document_handler, get_document_handler};
+pub use get_location::{__path_get_location_v3_handler, get_location_v3_handler};
+pub use get_short_id::{__path_get_short_id_handler, ShortIdResponse, get_short_id_handler};
 impl IntoResponse for DocumentError {
     fn into_response(self) -> axum::response::Response {
         let status_code = match &self {

--- a/rust/cloud-storage/documents/src/inbound/axum_router.rs
+++ b/rust/cloud-storage/documents/src/inbound/axum_router.rs
@@ -39,6 +39,16 @@ use model_error_response::ErrorResponse;
 use serde::Deserialize;
 use sqlx::PgPool;
 
+#[cfg(feature = "document_create")]
+use self::create_markdown::create_markdown_handler;
+use self::{
+    copy_document::copy_document_handler, create_document::create_document_handler,
+    create_task::create_task_handler, delete_document::delete_document_handler,
+    edit_document::edit_document_handler, get_branch_name::get_branch_name_handler,
+    get_document::get_document_handler, get_location::get_location_v3_handler,
+    get_short_id::get_short_id_handler,
+};
+
 use crate::domain::models::DocumentError;
 use crate::domain::ports::DocumentService;
 #[cfg(feature = "document_create")]

--- a/rust/cloud-storage/documents/src/inbound/axum_router.rs
+++ b/rust/cloud-storage/documents/src/inbound/axum_router.rs
@@ -12,17 +12,17 @@
 #[cfg(test)]
 mod tests;
 
-mod copy_document;
-mod create_document;
+pub mod copy_document;
+pub mod create_document;
 #[cfg(feature = "document_create")]
-mod create_markdown;
-mod create_task;
-mod delete_document;
-mod edit_document;
-mod get_branch_name;
-mod get_document;
-mod get_location;
-mod get_short_id;
+pub mod create_markdown;
+pub mod create_task;
+pub mod delete_document;
+pub mod edit_document;
+pub mod get_branch_name;
+pub mod get_document;
+pub mod get_location;
+pub mod get_short_id;
 
 use std::sync::Arc;
 
@@ -44,22 +44,6 @@ use crate::domain::ports::DocumentService;
 #[cfg(feature = "document_create")]
 use crate::domain::ports::create::DocumentCreationService;
 
-// Re-export handlers and utoipa path types for external use (swagger, internal routes)
-pub use copy_document::{__path_copy_document_handler, copy_document_handler};
-pub use create_document::{__path_create_document_handler, create_document_handler};
-#[cfg(feature = "document_create")]
-pub use create_markdown::{__path_create_markdown_handler, create_markdown_handler};
-pub use create_task::{__path_create_task_handler, create_task_handler};
-pub use delete_document::{__path_delete_document_handler, delete_document_handler};
-pub use edit_document::{
-    __path_edit_document_handler, EditDocumentResponse, edit_document_handler,
-};
-pub use get_branch_name::{
-    __path_get_branch_name_handler, BranchNameResponse, get_branch_name_handler,
-};
-pub use get_document::{__path_get_document_handler, get_document_handler};
-pub use get_location::{__path_get_location_v3_handler, get_location_v3_handler};
-pub use get_short_id::{__path_get_short_id_handler, ShortIdResponse, get_short_id_handler};
 impl IntoResponse for DocumentError {
     fn into_response(self) -> axum::response::Response {
         let status_code = match &self {

--- a/rust/cloud-storage/docx_unzip_handler/src/service/document/mod.rs
+++ b/rust/cloud-storage/docx_unzip_handler/src/service/document/mod.rs
@@ -3,11 +3,10 @@ mod notify_docx_upload_job;
 mod process_document;
 mod unzip;
 
-pub use bom_parts::*;
-pub use notify_docx_upload_job::*;
-pub use process_document::*;
-pub use unzip::*;
-
+pub use bom_parts::upload_bom_parts;
+pub use notify_docx_upload_job::handle_docx_unzip_failure;
+pub use process_document::process;
+pub use unzip::unzip;
 #[cfg(test)]
 /// Used in testing to load a file into bytes
 pub(in crate::service::document) fn load_file_into_vec(filename: &str) -> std::io::Result<Vec<u8>> {

--- a/rust/cloud-storage/email/examples/ai_tools_cli.rs
+++ b/rust/cloud-storage/email/examples/ai_tools_cli.rs
@@ -92,7 +92,6 @@ async fn main() {
     );
     let toolset = email_toolset();
 
-    #[expect(deprecated)]
     let context = RequestContext { user_id };
 
     let cli = Cli::new(

--- a/rust/cloud-storage/email/src/inbound.rs
+++ b/rust/cloud-storage/email/src/inbound.rs
@@ -5,7 +5,28 @@ pub mod attachment;
 mod axum;
 
 #[cfg(feature = "axum")]
-pub use axum::*;
-
+pub use axum::{
+    __path_create_draft_handler, __path_cursor_handler, __path_delete_email_filter_handler,
+    __path_get_thread_handler, __path_list_email_filters_handler, __path_list_labels_handler,
+    __path_send_message_handler, __path_update_thread_labels_handler,
+    __path_update_thread_project_handler, __path_upsert_email_filter_handler, ApiAttachment,
+    ApiAttachmentDraft, ApiAttachmentForwarded, ApiContact, ApiContactInfo, ApiDraftContactInfo,
+    ApiDraftInput, ApiDraftOutput, ApiEmailFilter, ApiLabel, ApiLabelListVisibility, ApiLabelType,
+    ApiMessage, ApiMessageAttachment, ApiMessageLabel, ApiMessageListVisibility,
+    ApiPaginatedThreadCursor, ApiRecipientType, ApiSortMethod, ApiThread,
+    ApiThreadPreviewCursorInner, CreateDraftError, CreateDraftRequest, CreateDraftResponse,
+    EmailFilterError, EmailLinkErr, EmailLinkExtractor, EmailRouterState, EmailThreadRouterState,
+    GetPreviewsCursorError, GetPreviewsCursorParams, GetThreadError, GetThreadParams,
+    GetThreadResponse, GmailAccessTokenErr, GmailAccessTokenExtractor, GmailTokenState,
+    ListEmailFiltersResponse, ListLabelsError, ListLabelsResponse, OptionalEmailLinkExtractor,
+    SendMessageError, SendMessageRequest, SendMessageResponse, UpdateThreadLabelError,
+    UpdateThreadLabelRequest, UpdateThreadLabelsResponse, UpdateThreadProjectError,
+    UpdateThreadProjectRequest, UpdateThreadProjectResponse, UpsertEmailFilterRequest,
+    UpsertEmailFilterResponse, create_draft_handler, delete_email_filter_handler, draft_router,
+    email_filter_router, get_thread_handler, list_email_filters_handler, list_labels_handler,
+    list_labels_router, router, send_message_handler, send_router, thread_labels_router,
+    thread_project_router, thread_router, update_thread_labels_handler,
+    update_thread_project_handler, upsert_email_filter_handler,
+};
 #[cfg(feature = "ai_tools")]
 pub mod toolset;

--- a/rust/cloud-storage/email/src/inbound.rs
+++ b/rust/cloud-storage/email/src/inbound.rs
@@ -2,31 +2,7 @@
 pub mod attachment;
 
 #[cfg(feature = "axum")]
-mod axum;
+pub mod axum;
 
-#[cfg(feature = "axum")]
-pub use axum::{
-    __path_create_draft_handler, __path_cursor_handler, __path_delete_email_filter_handler,
-    __path_get_thread_handler, __path_list_email_filters_handler, __path_list_labels_handler,
-    __path_send_message_handler, __path_update_thread_labels_handler,
-    __path_update_thread_project_handler, __path_upsert_email_filter_handler, ApiAttachment,
-    ApiAttachmentDraft, ApiAttachmentForwarded, ApiContact, ApiContactInfo, ApiDraftContactInfo,
-    ApiDraftInput, ApiDraftOutput, ApiEmailFilter, ApiLabel, ApiLabelListVisibility, ApiLabelType,
-    ApiMessage, ApiMessageAttachment, ApiMessageLabel, ApiMessageListVisibility,
-    ApiPaginatedThreadCursor, ApiRecipientType, ApiSortMethod, ApiThread,
-    ApiThreadPreviewCursorInner, CreateDraftError, CreateDraftRequest, CreateDraftResponse,
-    EmailFilterError, EmailLinkErr, EmailLinkExtractor, EmailRouterState, EmailThreadRouterState,
-    GetPreviewsCursorError, GetPreviewsCursorParams, GetThreadError, GetThreadParams,
-    GetThreadResponse, GmailAccessTokenErr, GmailAccessTokenExtractor, GmailTokenState,
-    ListEmailFiltersResponse, ListLabelsError, ListLabelsResponse, OptionalEmailLinkExtractor,
-    SendMessageError, SendMessageRequest, SendMessageResponse, UpdateThreadLabelError,
-    UpdateThreadLabelRequest, UpdateThreadLabelsResponse, UpdateThreadProjectError,
-    UpdateThreadProjectRequest, UpdateThreadProjectResponse, UpsertEmailFilterRequest,
-    UpsertEmailFilterResponse, create_draft_handler, delete_email_filter_handler, draft_router,
-    email_filter_router, get_thread_handler, list_email_filters_handler, list_labels_handler,
-    list_labels_router, router, send_message_handler, send_router, thread_labels_router,
-    thread_project_router, thread_router, update_thread_labels_handler,
-    update_thread_project_handler, upsert_email_filter_handler,
-};
 #[cfg(feature = "ai_tools")]
 pub mod toolset;

--- a/rust/cloud-storage/email/src/inbound/axum.rs
+++ b/rust/cloud-storage/email/src/inbound/axum.rs
@@ -9,13 +9,44 @@ mod send_router;
 mod thread_labels_router;
 mod thread_project_router;
 
-pub use api_types::*;
-pub use axum_impls::*;
-pub use draft_router::*;
-pub use email_filter_router::*;
-pub use get_thread_router::*;
-pub use list_labels_router::*;
-pub use previews_router::*;
-pub use send_router::*;
-pub use thread_labels_router::*;
-pub use thread_project_router::*;
+pub use api_types::{
+    ApiAttachment, ApiAttachmentDraft, ApiAttachmentForwarded, ApiContact, ApiContactInfo,
+    ApiDraftContactInfo, ApiDraftInput, ApiDraftOutput, ApiLabel, ApiLabelListVisibility,
+    ApiLabelType, ApiMessage, ApiMessageAttachment, ApiMessageLabel, ApiMessageListVisibility,
+    ApiPaginatedThreadCursor, ApiRecipientType, ApiSortMethod, ApiThread,
+    ApiThreadPreviewCursorInner, CreateDraftRequest, CreateDraftResponse, GetThreadParams,
+    GetThreadResponse, SendMessageRequest, SendMessageResponse,
+};
+pub use axum_impls::{
+    EmailLinkErr, EmailLinkExtractor, GetPreviewsCursorError, GetPreviewsCursorParams,
+    GmailAccessTokenErr, GmailAccessTokenExtractor, GmailTokenState, OptionalEmailLinkExtractor,
+};
+pub use draft_router::{
+    __path_create_draft_handler, CreateDraftError, create_draft_handler, draft_router,
+};
+pub use email_filter_router::{
+    __path_delete_email_filter_handler, __path_list_email_filters_handler,
+    __path_upsert_email_filter_handler, ApiEmailFilter, EmailFilterError, ListEmailFiltersResponse,
+    UpsertEmailFilterRequest, UpsertEmailFilterResponse, delete_email_filter_handler,
+    email_filter_router, list_email_filters_handler, upsert_email_filter_handler,
+};
+pub use get_thread_router::{
+    __path_get_thread_handler, EmailThreadRouterState, GetThreadError, get_thread_handler,
+    thread_router,
+};
+pub use list_labels_router::{
+    __path_list_labels_handler, ListLabelsError, ListLabelsResponse, list_labels_handler,
+    list_labels_router,
+};
+pub use previews_router::{__path_cursor_handler, EmailRouterState, router};
+pub use send_router::{
+    __path_send_message_handler, SendMessageError, send_message_handler, send_router,
+};
+pub use thread_labels_router::{
+    __path_update_thread_labels_handler, UpdateThreadLabelError, UpdateThreadLabelRequest,
+    UpdateThreadLabelsResponse, thread_labels_router, update_thread_labels_handler,
+};
+pub use thread_project_router::{
+    __path_update_thread_project_handler, UpdateThreadProjectError, UpdateThreadProjectRequest,
+    UpdateThreadProjectResponse, thread_project_router, update_thread_project_handler,
+};

--- a/rust/cloud-storage/email/src/inbound/axum.rs
+++ b/rust/cloud-storage/email/src/inbound/axum.rs
@@ -1,13 +1,13 @@
-mod api_types;
-mod axum_impls;
-mod draft_router;
-mod email_filter_router;
-mod get_thread_router;
-mod list_labels_router;
-mod previews_router;
-mod send_router;
-mod thread_labels_router;
-mod thread_project_router;
+pub mod api_types;
+pub mod axum_impls;
+pub mod draft_router;
+pub mod email_filter_router;
+pub mod get_thread_router;
+pub mod list_labels_router;
+pub mod previews_router;
+pub mod send_router;
+pub mod thread_labels_router;
+pub mod thread_project_router;
 
 pub use api_types::{
     ApiAttachment, ApiAttachmentDraft, ApiAttachmentForwarded, ApiContact, ApiContactInfo,
@@ -20,33 +20,4 @@ pub use api_types::{
 pub use axum_impls::{
     EmailLinkErr, EmailLinkExtractor, GetPreviewsCursorError, GetPreviewsCursorParams,
     GmailAccessTokenErr, GmailAccessTokenExtractor, GmailTokenState, OptionalEmailLinkExtractor,
-};
-pub use draft_router::{
-    __path_create_draft_handler, CreateDraftError, create_draft_handler, draft_router,
-};
-pub use email_filter_router::{
-    __path_delete_email_filter_handler, __path_list_email_filters_handler,
-    __path_upsert_email_filter_handler, ApiEmailFilter, EmailFilterError, ListEmailFiltersResponse,
-    UpsertEmailFilterRequest, UpsertEmailFilterResponse, delete_email_filter_handler,
-    email_filter_router, list_email_filters_handler, upsert_email_filter_handler,
-};
-pub use get_thread_router::{
-    __path_get_thread_handler, EmailThreadRouterState, GetThreadError, get_thread_handler,
-    thread_router,
-};
-pub use list_labels_router::{
-    __path_list_labels_handler, ListLabelsError, ListLabelsResponse, list_labels_handler,
-    list_labels_router,
-};
-pub use previews_router::{__path_cursor_handler, EmailRouterState, router};
-pub use send_router::{
-    __path_send_message_handler, SendMessageError, send_message_handler, send_router,
-};
-pub use thread_labels_router::{
-    __path_update_thread_labels_handler, UpdateThreadLabelError, UpdateThreadLabelRequest,
-    UpdateThreadLabelsResponse, thread_labels_router, update_thread_labels_handler,
-};
-pub use thread_project_router::{
-    __path_update_thread_project_handler, UpdateThreadProjectError, UpdateThreadProjectRequest,
-    UpdateThreadProjectResponse, thread_project_router, update_thread_project_handler,
 };

--- a/rust/cloud-storage/email/src/inbound/axum/axum_impls.rs
+++ b/rust/cloud-storage/email/src/inbound/axum/axum_impls.rs
@@ -3,7 +3,7 @@ use crate::{
         models::{EmailErr, Link, PreviewView},
         ports::{EmailService, GmailTokenProvider},
     },
-    inbound::{ApiSortMethod, EmailRouterState},
+    inbound::axum::{api_types::ApiSortMethod, previews_router::EmailRouterState},
 };
 use axum::{
     RequestPartsExt,

--- a/rust/cloud-storage/email/src/inbound/axum/draft_router.rs
+++ b/rust/cloud-storage/email/src/inbound/axum/draft_router.rs
@@ -6,8 +6,9 @@ use thiserror::Error;
 use crate::domain::{models::EmailErr, ports::EmailService};
 
 use super::{
-    EmailLinkExtractor, EmailRouterState,
     api_types::{CreateDraftRequest, CreateDraftResponse},
+    axum_impls::EmailLinkExtractor,
+    previews_router::EmailRouterState,
 };
 
 /// Create the draft router with a `POST /` handler.

--- a/rust/cloud-storage/email/src/inbound/axum/email_filter_router.rs
+++ b/rust/cloud-storage/email/src/inbound/axum/email_filter_router.rs
@@ -16,7 +16,7 @@ use crate::domain::{
     ports::EmailService,
 };
 
-use super::{EmailLinkExtractor, EmailRouterState};
+use super::{axum_impls::EmailLinkExtractor, previews_router::EmailRouterState};
 
 // ── API types ────────────────────────────────────────────────────────
 

--- a/rust/cloud-storage/email/src/inbound/axum/list_labels_router.rs
+++ b/rust/cloud-storage/email/src/inbound/axum/list_labels_router.rs
@@ -5,7 +5,9 @@ use thiserror::Error;
 
 use crate::domain::{models::EmailErr, ports::EmailService};
 
-use super::{ApiLabel, EmailLinkExtractor, EmailRouterState};
+use super::{
+    api_types::ApiLabel, axum_impls::EmailLinkExtractor, previews_router::EmailRouterState,
+};
 
 /// Response body for listing labels.
 #[derive(serde::Serialize, serde::Deserialize, Debug, utoipa::ToSchema)]

--- a/rust/cloud-storage/email/src/inbound/axum/previews_router.rs
+++ b/rust/cloud-storage/email/src/inbound/axum/previews_router.rs
@@ -14,10 +14,11 @@ use uuid::Uuid;
 
 use crate::{
     domain::{models::GetEmailsRequest, ports::EmailService},
-    inbound::{
-        ApiPaginatedThreadCursor, EmailLinkExtractor,
-        axum::axum_impls::{
-            GetPreviewsCursorError, GetPreviewsCursorParams, PreviewViewPathExtractor,
+    inbound::axum::{
+        api_types::ApiPaginatedThreadCursor,
+        axum_impls::{
+            EmailLinkExtractor, GetPreviewsCursorError, GetPreviewsCursorParams,
+            PreviewViewPathExtractor,
         },
     },
 };

--- a/rust/cloud-storage/email/src/inbound/axum/send_router.rs
+++ b/rust/cloud-storage/email/src/inbound/axum/send_router.rs
@@ -6,8 +6,9 @@ use thiserror::Error;
 use crate::domain::{models::EmailErr, ports::EmailService};
 
 use super::{
-    EmailLinkExtractor, EmailRouterState,
     api_types::{SendMessageRequest, SendMessageResponse},
+    axum_impls::EmailLinkExtractor,
+    previews_router::EmailRouterState,
 };
 
 /// Create the send router with a `POST /` handler.

--- a/rust/cloud-storage/email/src/inbound/axum/thread_labels_router.rs
+++ b/rust/cloud-storage/email/src/inbound/axum/thread_labels_router.rs
@@ -14,7 +14,10 @@ use crate::domain::{
     ports::{EmailService, GmailTokenProvider},
 };
 
-use super::{EmailRouterState, GmailAccessTokenExtractor, GmailTokenState};
+use super::{
+    axum_impls::{GmailAccessTokenExtractor, GmailTokenState},
+    previews_router::EmailRouterState,
+};
 
 /// Request body for updating a thread's labels.
 #[derive(serde::Serialize, serde::Deserialize, Debug, utoipa::ToSchema)]

--- a/rust/cloud-storage/email/src/inbound/axum/thread_project_router.rs
+++ b/rust/cloud-storage/email/src/inbound/axum/thread_project_router.rs
@@ -11,7 +11,7 @@ use thiserror::Error;
 
 use crate::domain::{models::EmailErr, ports::EmailService};
 
-use super::EmailThreadRouterState;
+use super::get_thread_router::EmailThreadRouterState;
 
 /// Request body for updating a thread's project.
 #[derive(serde::Serialize, serde::Deserialize, Debug, utoipa::ToSchema)]

--- a/rust/cloud-storage/email/src/outbound.rs
+++ b/rust/cloud-storage/email/src/outbound.rs
@@ -2,6 +2,8 @@ mod email_pg_repo;
 #[cfg(feature = "gmail_token")]
 mod gmail_token_provider;
 
-pub use email_pg_repo::*;
+pub use email_pg_repo::EmailPgRepo;
 #[cfg(feature = "gmail_token")]
-pub use gmail_token_provider::*;
+pub use gmail_token_provider::{
+    GmailTokenProviderImpl, fetch_gmail_access_token, fetch_gmail_access_token_no_cache,
+};

--- a/rust/cloud-storage/email_service/src/api/context.rs
+++ b/rust/cloud-storage/email_service/src/api/context.rs
@@ -2,7 +2,10 @@ use axum::extract::FromRef;
 use document_storage_service_client::DocumentStorageServiceClient;
 use email::{
     domain::service::EmailServiceImpl,
-    inbound::{EmailRouterState, EmailThreadRouterState, GmailTokenState},
+    inbound::axum::{
+        axum_impls::GmailTokenState, get_thread_router::EmailThreadRouterState,
+        previews_router::EmailRouterState,
+    },
     outbound::{EmailPgRepo, GmailTokenProviderImpl},
 };
 

--- a/rust/cloud-storage/email_service/src/api/email/drafts/mod.rs
+++ b/rust/cloud-storage/email_service/src/api/email/drafts/mod.rs
@@ -8,7 +8,7 @@ pub(crate) mod scheduled;
 use crate::api::ApiContext;
 use axum::Router;
 use axum::routing::{delete, post};
-use email::inbound::draft_router;
+use email::inbound::axum::draft_router::draft_router;
 
 pub fn router(state: ApiContext) -> Router<ApiContext> {
     Router::new()

--- a/rust/cloud-storage/email_service/src/api/email/filters/mod.rs
+++ b/rust/cloud-storage/email_service/src/api/email/filters/mod.rs
@@ -3,5 +3,8 @@ use axum::Router;
 use crate::api::ApiContext;
 
 pub fn router() -> Router<ApiContext> {
-    email::inbound::email_filter_router::<ApiContext, crate::api::context::EmailSvc>()
+    email::inbound::axum::email_filter_router::email_filter_router::<
+        ApiContext,
+        crate::api::context::EmailSvc,
+    >()
 }

--- a/rust/cloud-storage/email_service/src/api/email/labels/mod.rs
+++ b/rust/cloud-storage/email_service/src/api/email/labels/mod.rs
@@ -7,8 +7,10 @@ use axum::routing::{delete, post};
 use crate::api::ApiContext;
 
 pub fn router(state: ApiContext) -> Router<ApiContext> {
-    let hex_list_labels_routes =
-        email::inbound::list_labels_router::<ApiContext, crate::api::context::EmailSvc>();
+    let hex_list_labels_routes = email::inbound::axum::list_labels_router::list_labels_router::<
+        ApiContext,
+        crate::api::context::EmailSvc,
+    >();
 
     Router::new()
         .route(

--- a/rust/cloud-storage/email_service/src/api/email/messages/mod.rs
+++ b/rust/cloud-storage/email_service/src/api/email/messages/mod.rs
@@ -3,7 +3,7 @@ pub(crate) mod labels;
 
 use axum::Router;
 use axum::routing::{get, patch, post};
-use email::inbound::send_router;
+use email::inbound::axum::send_router::send_router;
 
 use crate::api::ApiContext;
 

--- a/rust/cloud-storage/email_service/src/api/email/threads/mod.rs
+++ b/rust/cloud-storage/email_service/src/api/email/threads/mod.rs
@@ -11,7 +11,7 @@ pub fn router(state: ApiContext) -> Router<ApiContext> {
     let required_link_routes = Router::new()
         .nest(
             "/previews",
-            email::inbound::router(state.email_service.clone()),
+            email::inbound::axum::previews_router::router(state.email_service.clone()),
         )
         .route("/{id}/seen", post(seen::seen_handler))
         .route("/{id}/messages", get(get::get_thread_messages_handler))
@@ -21,16 +21,19 @@ pub fn router(state: ApiContext) -> Router<ApiContext> {
             crate::api::middleware::link::attach_link_context,
         ));
 
-    let hex_thread_routes = email::inbound::thread_router(state.email_thread_state.clone());
+    let hex_thread_routes =
+        email::inbound::axum::get_thread_router::thread_router(state.email_thread_state.clone());
 
-    let hex_thread_labels_routes = email::inbound::thread_labels_router::<
+    let hex_thread_labels_routes = email::inbound::axum::thread_labels_router::thread_labels_router::<
         ApiContext,
         crate::api::context::EmailSvc,
         email::outbound::GmailTokenProviderImpl,
     >();
 
     let hex_thread_project_routes =
-        email::inbound::thread_project_router(state.email_thread_state.clone());
+        email::inbound::axum::thread_project_router::thread_project_router(
+            state.email_thread_state.clone(),
+        );
 
     Router::new()
         .merge(required_link_routes)

--- a/rust/cloud-storage/email_service/src/api/middleware/link.rs
+++ b/rust/cloud-storage/email_service/src/api/middleware/link.rs
@@ -4,7 +4,7 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use axum_extra::extract::Cached;
-use email::{domain::ports::EmailService, inbound::EmailLinkExtractor};
+use email::{domain::ports::EmailService, inbound::axum::axum_impls::EmailLinkExtractor};
 
 pub(in crate::api) async fn attach_link_context<U: EmailService>(
     Cached(EmailLinkExtractor(link, _)): Cached<EmailLinkExtractor<U>>,

--- a/rust/cloud-storage/email_service/src/api/swagger.rs
+++ b/rust/cloud-storage/email_service/src/api/swagger.rs
@@ -21,17 +21,22 @@ use crate::api::email::settings::patch::{PatchSettingsRequest, PatchSettingsResp
 use crate::api::email::threads::archived::ArchiveThreadRequest;
 use crate::api::{email, health};
 use ::email::inbound;
-use ::email::inbound::ListLabelsResponse as HexListLabelsResponse;
-use ::email::inbound::{
+use ::email::inbound::axum::api_types::{
     ApiDraftContactInfo, ApiDraftInput, ApiDraftOutput, ApiPaginatedThreadCursor, ApiSortMethod,
     ApiThread, CreateDraftRequest as HexCreateDraftRequest,
-    CreateDraftResponse as HexCreateDraftResponse, GetPreviewsCursorParams, GetThreadResponse,
+    CreateDraftResponse as HexCreateDraftResponse, GetThreadResponse,
     SendMessageRequest as HexSendMessageRequest, SendMessageResponse as HexSendMessageResponse,
 };
-use ::email::inbound::{
-    ApiEmailFilter, ListEmailFiltersResponse, UpdateThreadLabelRequest, UpdateThreadLabelsResponse,
-    UpdateThreadProjectRequest, UpdateThreadProjectResponse, UpsertEmailFilterRequest,
-    UpsertEmailFilterResponse,
+use ::email::inbound::axum::axum_impls::GetPreviewsCursorParams;
+use ::email::inbound::axum::email_filter_router::{
+    ApiEmailFilter, ListEmailFiltersResponse, UpsertEmailFilterRequest, UpsertEmailFilterResponse,
+};
+use ::email::inbound::axum::list_labels_router::ListLabelsResponse as HexListLabelsResponse;
+use ::email::inbound::axum::thread_labels_router::{
+    UpdateThreadLabelRequest, UpdateThreadLabelsResponse,
+};
+use ::email::inbound::axum::thread_project_router::{
+    UpdateThreadProjectRequest, UpdateThreadProjectResponse,
 };
 use model::response::EmptyResponse;
 use models_email::api::settings::Settings;
@@ -58,7 +63,7 @@ use utoipa::OpenApi;
         email::backfill::get::handler,
         email::backfill::get::active_handler,
         email::init::handler,
-        inbound::create_draft_handler,
+        inbound::axum::draft_router::create_draft_handler,
         email::drafts::delete::handler,
         email::drafts::scheduled::list::handler,
         email::drafts::scheduled::remove::handler,
@@ -70,21 +75,21 @@ use utoipa::OpenApi;
         email::messages::get::handler,
         email::messages::get::batch_handler,
         email::messages::labels::handler,
-        inbound::send_message_handler,
+        inbound::axum::send_router::send_message_handler,
         email::threads::seen::seen_handler,
         email::threads::get::get_thread_messages_handler,
         email::threads::archived::archived_handler,
-        inbound::update_thread_labels_handler,
-        inbound::cursor_handler,
-        inbound::get_thread_handler,
-        inbound::update_thread_project_handler,
+        inbound::axum::thread_labels_router::update_thread_labels_handler,
+        inbound::axum::previews_router::cursor_handler,
+        inbound::axum::get_thread_router::get_thread_handler,
+        inbound::axum::thread_project_router::update_thread_project_handler,
         email::links::list::list_links_handler,
         email::labels::create::handler,
         email::labels::delete::handler,
-        inbound::list_labels_handler,
-        inbound::upsert_email_filter_handler,
-        inbound::delete_email_filter_handler,
-        inbound::list_email_filters_handler,
+        inbound::axum::list_labels_router::list_labels_handler,
+        inbound::axum::email_filter_router::upsert_email_filter_handler,
+        inbound::axum::email_filter_router::delete_email_filter_handler,
+        inbound::axum::email_filter_router::list_email_filters_handler,
         email::contacts::list::list_contacts_handler,
         email::contacts::block_sender::handler,
         email::contacts::unblock_sender::handler,

--- a/rust/cloud-storage/email_service/src/main.rs
+++ b/rust/cloud-storage/email_service/src/main.rs
@@ -4,7 +4,10 @@ use anyhow::Context;
 use document_storage_service_client::DocumentStorageServiceClient;
 use email::{
     domain::service::EmailServiceImpl,
-    inbound::{EmailRouterState, EmailThreadRouterState, GmailTokenState},
+    inbound::axum::{
+        axum_impls::GmailTokenState, get_thread_router::EmailThreadRouterState,
+        previews_router::EmailRouterState,
+    },
     outbound::{EmailPgRepo, GmailTokenProviderImpl},
 };
 use email_service::config::EmailServiceCloudfrontSignerPrivateKey;

--- a/rust/cloud-storage/email_service_client/src/external/get_previews.rs
+++ b/rust/cloud-storage/email_service_client/src/external/get_previews.rs
@@ -1,6 +1,6 @@
 use super::EmailServiceClientExternal;
 use anyhow::Result;
-use email::inbound::ApiPaginatedThreadCursor;
+use email::inbound::axum::api_types::ApiPaginatedThreadCursor;
 use models_email::email::service::thread::PreviewView;
 use reqwest::Method;
 use reqwest::Url;

--- a/rust/cloud-storage/email_service_client/src/lib.rs
+++ b/rust/cloud-storage/email_service_client/src/lib.rs
@@ -8,8 +8,7 @@ pub mod get_message_senders;
 pub mod get_messages_by_thread_id;
 pub mod get_thread_owner;
 
-pub use external::*;
-
+pub use external::EmailServiceClientExternal;
 #[derive(Clone)]
 pub struct EmailServiceClient {
     url: String,

--- a/rust/cloud-storage/fusionauth/src/identity_provider/mod.rs
+++ b/rust/cloud-storage/fusionauth/src/identity_provider/mod.rs
@@ -8,8 +8,7 @@ mod lookup;
 mod search;
 mod unlink;
 
-pub use link::*;
-
+pub use link::{IdentityProviderLink, Link, LinkUserRequest, RetrieveLinkResponse};
 impl FusionAuthClient {
     /// Searches for an identity provider by name and returns its ID.
     #[tracing::instrument(skip(self), fields(application_id=%self.client_id, fusion_auth_base_url=%self.fusion_auth_base_url))]

--- a/rust/cloud-storage/github/src/domain/models/mod.rs
+++ b/rust/cloud-storage/github/src/domain/models/mod.rs
@@ -6,9 +6,11 @@ mod test;
 mod link;
 mod sync;
 
-pub use link::*;
-pub use sync::*;
-
+pub use link::{GithubAccessToken, GithubExchangeTokenResponse, GithubLink, GithubUserInfo};
+pub use sync::{
+    GithubInstallationAccessToken, GithubKey, GithubWebhookEventType, MacroTaskId,
+    ValidatedGithubWebhookEvent,
+};
 /// Errors that can occur during github operations.
 #[derive(Debug, thiserror::Error)]
 pub enum GithubError {

--- a/rust/cloud-storage/github/src/domain/ports/mod.rs
+++ b/rust/cloud-storage/github/src/domain/ports/mod.rs
@@ -8,6 +8,6 @@ mod link;
 mod sync;
 
 #[cfg(feature = "link")]
-pub use link::*;
+pub use link::{Auth, GithubLinkService, GithubOauth, GithubRepo};
 #[cfg(feature = "sync")]
-pub use sync::*;
+pub use sync::{GithubSyncClient, GithubSyncRepo, GithubSyncService};

--- a/rust/cloud-storage/github/src/domain/service/mod.rs
+++ b/rust/cloud-storage/github/src/domain/service/mod.rs
@@ -4,10 +4,9 @@
 mod sync;
 
 #[cfg(feature = "sync")]
-pub use sync::*;
-
+pub use sync::{GithubSyncConfig, GithubSyncServiceImpl};
 #[cfg(feature = "link")]
 mod link;
 
 #[cfg(feature = "link")]
-pub use link::*;
+pub use link::{GithubLinkConfig, GithubLinkServiceImpl};

--- a/rust/cloud-storage/macro_db_client/src/account_merge_request/mod.rs
+++ b/rust/cloud-storage/macro_db_client/src/account_merge_request/mod.rs
@@ -3,7 +3,7 @@ mod delete;
 mod get;
 mod merge;
 
-pub use create::*;
-pub use delete::*;
-pub use get::*;
-pub use merge::*;
+pub use create::create_account_merge_request;
+pub use delete::delete_account_merge_request;
+pub use get::{check_merge_request_for_to_merge_macro_user_id, get_merge_request_info};
+pub use merge::merge_accounts;

--- a/rust/cloud-storage/macro_db_client/src/activity/mod.rs
+++ b/rust/cloud-storage/macro_db_client/src/activity/mod.rs
@@ -1,3 +1,3 @@
 mod get_recent_activities;
 
-pub use get_recent_activities::*;
+pub use get_recent_activities::get_recent_activities;

--- a/rust/cloud-storage/macro_db_client/src/document/mod.rs
+++ b/rust/cloud-storage/macro_db_client/src/document/mod.rs
@@ -8,14 +8,23 @@ mod list_documents_with_access;
 mod save_document;
 pub mod v2;
 
-pub use delete_document::*;
-pub use get_document::*;
-pub use get_document_list::*;
-pub use get_document_process_result::*;
-pub use get_document_views::*;
-pub use get_user_documents::*;
-pub use list_documents_with_access::*;
-pub use save_document::*;
+pub use delete_document::{
+    delete_document, delete_document_bulk_tsx, delete_document_version, get_shas_for_deletion,
+};
+pub use get_document::{
+    get_basic_document, get_basic_documents, get_bom_parts, get_bom_parts_bulk_tsx,
+    get_deleted_document_info, get_document, get_document_bom, get_document_name, get_document_sha,
+    get_document_version, get_document_version_id, get_latest_document_bom_version_id,
+    get_latest_document_version_id,
+};
+pub use get_document_list::get_document_list;
+pub use get_document_process_result::{
+    get_document_process_content, get_document_process_content_from_job_id,
+};
+pub use get_document_views::{get_document_view_count, get_document_views};
+pub use get_user_documents::{get_user_document_ids, get_user_documents};
+pub use list_documents_with_access::list_documents_with_access;
+pub use save_document::{insert_bom_parts, save_document, try_insert_comment_data};
 pub mod build_pdf_modification_data;
 pub mod create_blank_docx;
 pub mod document_email;

--- a/rust/cloud-storage/macro_db_client/src/history/mod.rs
+++ b/rust/cloud-storage/macro_db_client/src/history/mod.rs
@@ -1,15 +1,17 @@
 use sqlx::{Pool, Postgres};
 mod delete_history;
 mod upsert_history;
-pub use delete_history::*;
-pub use upsert_history::*;
-
+pub use delete_history::delete_user_history;
 use document_sub_type::DocumentSubType;
 use model::item::{
     Item,
     map_item::{map_chat_item, map_document_item, map_project_item},
 };
 use system_properties::{StatusOption, SystemPropertyKey};
+pub use upsert_history::{
+    add_user_history_for_project_tree, upsert_item_last_accessed,
+    upsert_item_last_accessed_timestamp, upsert_user_history, upsert_user_history_timestamp,
+};
 
 /// Gets a users recently opened history.
 #[tracing::instrument(skip(db))]

--- a/rust/cloud-storage/macro_db_client/src/item_access/mod.rs
+++ b/rust/cloud-storage/macro_db_client/src/item_access/mod.rs
@@ -3,4 +3,4 @@ pub mod get;
 pub mod get_accessible_items;
 mod validate_accessible_items;
 
-pub use validate_accessible_items::*;
+pub use validate_accessible_items::validate_user_accessible_items;

--- a/rust/cloud-storage/macro_db_client/src/items/filter.rs
+++ b/rust/cloud-storage/macro_db_client/src/items/filter.rs
@@ -8,9 +8,8 @@ use crate::projects::get_project::get_sub_items::bulk_get_all_sub_project_ids;
 mod channel;
 mod document;
 
-pub use channel::*;
-pub use document::*;
-
+pub use channel::filter_channels_by_org_id;
+pub use document::filter_documents_by_file_types;
 /// Given a list of item ids, the item type and a list of project_ids, this will
 /// return a subset list of items that are within the provided project ids and their sub-projects.
 #[tracing::instrument(skip(db), err)]

--- a/rust/cloud-storage/macro_db_client/src/projects/get_project/mod.rs
+++ b/rust/cloud-storage/macro_db_client/src/projects/get_project/mod.rs
@@ -7,5 +7,5 @@ pub mod get_basic_project;
 pub mod get_project_chats;
 pub mod get_project_documents;
 
-pub use get_project_by_id::*;
-pub use get_project_content::*;
+pub use get_project_by_id::get_project_by_id;
+pub use get_project_content::get_project_content_v2;

--- a/rust/cloud-storage/macro_db_client/src/projects/mod.rs
+++ b/rust/cloud-storage/macro_db_client/src/projects/mod.rs
@@ -6,10 +6,13 @@ pub mod nested_projects;
 pub mod preview;
 pub mod upload_folder;
 
-pub use create_project::*;
-pub use edit_project::*;
-pub use get_projects::*;
-pub use preview::*;
+pub use create_project::create_project_v2;
+pub use edit_project::{edit_project_v2, update_project_modified_date};
+pub use get_projects::{
+    get_all_project_ids_with_users_paginated, get_pending_root_projects, get_projects,
+    get_projects_to_delete, get_sub_project_ids,
+};
+pub use preview::batch_get_project_preview_v2;
 pub mod delete;
 pub mod get_project_history;
 pub mod move_item;

--- a/rust/cloud-storage/macro_db_client/src/user/get/mod.rs
+++ b/rust/cloud-storage/macro_db_client/src/user/get/mod.rs
@@ -6,8 +6,7 @@ pub mod get_user_organization;
 pub mod get_user_permissions;
 
 mod get_legacy_user_info;
-pub use get_legacy_user_info::*;
-
+pub use get_legacy_user_info::{LegacyUserInfo, get_legacy_user_info};
 use macro_user_id::{lowercased::Lowercase, user_id::MacroUserId};
 use model::user::{UserInfo, UserInfoWithMacroUserId};
 

--- a/rust/cloud-storage/macro_middleware/src/auth/decode_jwt.rs
+++ b/rust/cloud-storage/macro_middleware/src/auth/decode_jwt.rs
@@ -4,7 +4,7 @@ use axum::{
     middleware::Next,
     response::Response,
 };
-pub use decode_jwt::*;
+pub use decode_jwt::{DecodeJwtError, DecodedJwt, JwtContext, Params};
 use macro_auth::{headers::AccessTokenExtractor, middleware::decode_jwt::JwtValidationArgs};
 
 /// Axum middleware that decodes the JWT and attaches the user context to the request.

--- a/rust/cloud-storage/macro_middleware/src/tracking/mod.rs
+++ b/rust/cloud-storage/macro_middleware/src/tracking/mod.rs
@@ -1,1 +1,1 @@
-pub use ip_extractor::*;
+pub use ip_extractor::{ClientIp, ClientIpError};

--- a/rust/cloud-storage/memory/src/domain/mod.rs
+++ b/rust/cloud-storage/memory/src/domain/mod.rs
@@ -1,4 +1,4 @@
 pub mod ports;
 pub mod service;
 
-pub use ports::*;
+pub use ports::{Memory, MemoryError, MemoryRecord, MemoryRepo, MemoryService, Result};

--- a/rust/cloud-storage/model/src/chat/mod.rs
+++ b/rust/cloud-storage/model/src/chat/mod.rs
@@ -3,7 +3,7 @@ pub mod preview;
 pub mod utils;
 
 use macro_user_id::user_id::MacroUserIdStr;
-pub use message::*;
+pub use message::{ChatMessage, ChatMessageWithAttachments, NewChatMessage};
 use serde::{Deserialize, Serialize};
 use strum::Display;
 use utoipa::ToSchema;

--- a/rust/cloud-storage/model/src/document/mod.rs
+++ b/rust/cloud-storage/model/src/document/mod.rs
@@ -8,16 +8,18 @@ use schemars::JsonSchema;
 use utoipa::ToSchema;
 
 mod file_type;
-pub use file_type::*;
+pub use file_type::{ContentType, ContentTypeExt, FileAssociation, FileType, FileTypeExt};
 mod docx;
-pub use docx::*;
+pub use docx::{BomPart, BomPartWithContent, SaveBomPart};
 mod pdf;
-pub use pdf::*;
+pub use pdf::modification_data;
 mod basic;
-pub use basic::*;
+pub use basic::{
+    Document, DocumentBasic, DocumentInfo, ID, IDWithTimeStamps, VersionID,
+    VersionIDWithTimeStamps, VersionIDWithTimeStampsNoSha, VersionIDWithTimeStampsOptionalSha,
+};
 mod document_family;
-pub use document_family::*;
-
+pub use document_family::DocumentFamily;
 use models_permissions::share_permission::access_level::AccessLevel;
 
 #[derive(Debug, serde::Serialize, serde::Deserialize, ToSchema)]

--- a/rust/cloud-storage/model/src/document/response/mod.rs
+++ b/rust/cloud-storage/model/src/document/response/mod.rs
@@ -1,7 +1,7 @@
 mod location;
 
 use document_sub_type::DocumentSubType;
-pub use location::*;
+pub use location::LocationResponseV3;
 use macro_user_id::user_id::MacroUserIdStr;
 use std::str::FromStr;
 

--- a/rust/cloud-storage/model/src/user/mod.rs
+++ b/rust/cloud-storage/model/src/user/mod.rs
@@ -1,1 +1,5 @@
-pub use model_user::*;
+pub use model_user::{
+    ProfilePictureQueryParams, ProfilePictures, PutUserNameQueryParams, UserContext, UserInfo,
+    UserInfoWithMacroUserId, UserName, UserNames, UserPermission, UserProfilePicture,
+    axum_extractor,
+};

--- a/rust/cloud-storage/model_notifications/src/lib.rs
+++ b/rust/cloud-storage/model_notifications/src/lib.rs
@@ -8,10 +8,15 @@ mod device;
 pub mod digest_state;
 mod metadata;
 mod unsubscribe;
-pub use device::*;
-pub use metadata::*;
-pub use unsubscribe::*;
-
+pub use device::DeviceType;
+pub use metadata::{
+    AiResponseMetadata, ChannelInviteMetadata, ChannelMentionMetadata, ChannelMessageSendMetadata,
+    ChannelReplyMetadata, ChannelType, CommentedOnDocumentMetadata, CommonChannelMetadata,
+    DocumentMentionMetadata, InviteToTeamMetadata, ItemSharedMetadata,
+    MentionedInDocumentCommentMetadata, NewEmailMetadata, NotificationDocumentSubType,
+    NotificationTitle, RepliedToDocumentCommentThreadMetadata, TaskAssignedMetadata,
+};
+pub use unsubscribe::UserUnsubscribe;
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[serde(transparent)]
 pub struct ChannelMessageDocumentMetadata(pub DocumentMentionMetadata);

--- a/rust/cloud-storage/models_bulk_upload/src/lib.rs
+++ b/rust/cloud-storage/models_bulk_upload/src/lib.rs
@@ -4,8 +4,10 @@ use serde::{Deserialize, Serialize};
 use strum::{Display, EnumString};
 use utoipa::ToSchema;
 
-pub use folder::*;
-
+pub use folder::{
+    MarkProjectUploadedRequest, MarkProjectUploadedResponse, S3ObjectInfo,
+    UploadExtractFolderRequest, UploadExtractFolderResponseData,
+};
 /// The upload status of the folder
 #[derive(
     Debug, Serialize, Deserialize, Clone, EnumString, Display, Default, Eq, PartialEq, ToSchema,

--- a/rust/cloud-storage/models_email/src/lib.rs
+++ b/rust/cloud-storage/models_email/src/lib.rs
@@ -1,5 +1,4 @@
 pub mod email;
 
-pub use email::*;
-
+pub use email::{api, db, service};
 pub mod gmail;

--- a/rust/cloud-storage/models_pagination/src/lib.rs
+++ b/rust/cloud-storage/models_pagination/src/lib.rs
@@ -12,7 +12,11 @@ mod cursor;
 mod sort;
 
 #[cfg(feature = "axum")]
-pub use axum::*;
-pub use collections::*;
-pub use cursor::*;
-pub use sort::*;
+pub use axum::{BidirectionalCursor, CursorExtractErr, CursorOptionExt};
+pub use collections::{CollectBy, CollectByIds};
+pub use cursor::{
+    Base64SerdeErr, Base64Str, Cursor, CursorVal, CursorWithVal, CursorWithValAndFilter, Identify,
+    Paginate, PaginateOn, Paginated, PaginatedCursor, PaginatedOpaqueCursor, Paginator, Query,
+    SortOn, Sortable, TypeEraseCursor,
+};
+pub use sort::{CreatedAt, Frecency, FrecencyValue, SimpleSortMethod, SortMethod};

--- a/rust/cloud-storage/models_properties/src/api/mod.rs
+++ b/rust/cloud-storage/models_properties/src/api/mod.rs
@@ -8,7 +8,19 @@ pub mod query_params;
 pub mod requests;
 pub mod responses;
 
-pub use error::*;
-pub use query_params::*;
-pub use requests::*;
-pub use responses::*;
+pub use error::{
+    PropertyDefinitionValidationError, PropertyOptionValidationError, PropertyValueValidationError,
+    QueryParamValidationError,
+};
+pub use query_params::{BulkEntityQueryParams, EntityQueryParams};
+pub use requests::{
+    AddNumberOptionRequest, AddPropertyOptionRequest, AddStringOptionRequest,
+    CreatePropertyDefinitionRequest, PropertyDataType, SelectNumberOption, SelectStringOption,
+    SetPropertyValue,
+};
+pub use responses::{
+    BulkEntityPropertiesResponse, EntityPropertiesResponse, EntityPropertyResponse,
+    EntityPropertyWithDefinitionResponse, PropertyDefinitionResponse,
+    PropertyDefinitionWithOptionsResponse, PropertyOptionResponse, PropertyOptionValue,
+    PropertyValue,
+};

--- a/rust/cloud-storage/models_search/src/lib.rs
+++ b/rust/cloud-storage/models_search/src/lib.rs
@@ -14,10 +14,11 @@ mod simple;
 pub mod timestamp;
 pub mod unified;
 
-pub use simple::*;
-
-pub use timestamp::*;
-
+pub use simple::{
+    Highlight, SearchGotoCallRecord, SearchGotoChannel, SearchGotoChat, SearchGotoContent,
+    SearchGotoDocument, SearchGotoEmail, SimpleSearchResponse, SimpleSearchResponseItem,
+};
+pub use timestamp::{HumanReadableTimestamp, TimestampField, TimestampSeconds};
 #[derive(
     Serialize, Deserialize, Debug, ToSchema, Copy, Clone, EnumString, Display, JsonSchema, Default,
 )]

--- a/rust/cloud-storage/name_search/src/lib.rs
+++ b/rust/cloud-storage/name_search/src/lib.rs
@@ -6,13 +6,12 @@ mod document;
 mod highlight;
 mod project;
 
-pub use chat::*;
-pub use document::*;
-pub use highlight::*;
+pub use chat::search_chat_names;
+pub use document::search_document_names;
+pub use highlight::highlight_name;
 pub use models_opensearch::SearchEntityType;
 use models_search_cursor::{PaginatedResult, SearchCursorAttributes};
-pub use project::*;
-
+pub use project::search_project_names;
 /// Escapes special regex characters in a search term
 pub fn escape_regex(term: &str) -> String {
     let special_chars = [

--- a/rust/cloud-storage/notification/src/domain/models/rate_limit.rs
+++ b/rust/cloud-storage/notification/src/domain/models/rate_limit.rs
@@ -1,3 +1,6 @@
 //! Rate limiting models — re-exported from the [`rate_limit`] crate.
 
-pub use rate_limit::domain::models::*;
+pub use rate_limit::domain::models::{
+    RateLimitConfig, RateLimitExceeded, RateLimitKey, RateLimitKeyBuilder, RateLimitOk,
+    RateLimitResult,
+};

--- a/rust/cloud-storage/opensearch_query_builder/src/lib.rs
+++ b/rust/cloud-storage/opensearch_query_builder/src/lib.rs
@@ -11,5 +11,15 @@ mod query;
 mod request;
 mod util;
 
-pub use query::*;
-pub use request::*;
+pub use query::{
+    BoolQuery, BoolQueryBuilder, BoostMode, DecayFunction, FieldValueFactor, FunctionScoreQuery,
+    FunctionScoreQueryBuilder, MatchPhrasePrefixQuery, MatchPhraseQuery, MatchQuery, QueryType,
+    RandomScore, RangeQuery, RangeQueryBuilder, RegexpQuery, RegexpQueryFlags, ScoreFunction,
+    ScoreFunctionType, ScoreMode, ScriptScore, SimpleQueryStringQuery, TermQuery, TermsQuery,
+    WildcardQuery,
+};
+pub use request::{
+    AggregationType, CardinalityAggregation, Collapse, FieldSort, Highlight, HighlightField, Lang,
+    ScoreWithOrderSort, Script, ScriptSort, ScriptSortType, SearchRequest, SearchRequestBuilder,
+    SortMode, SortOrder, SortType, TermsAggregation,
+};

--- a/rust/cloud-storage/opensearch_query_builder/src/query.rs
+++ b/rust/cloud-storage/opensearch_query_builder/src/query.rs
@@ -14,20 +14,22 @@ mod term;
 mod terms;
 mod wildcard;
 
-pub use bool::*;
-pub use function_score::*;
-pub use match_phrase::*;
-pub use match_phrase_prefix::*;
-pub use match_query::*;
-pub use range::*;
-pub use regexp::*;
-use serde_json::Value;
-pub use simple_query_string::*;
-pub use term::*;
-pub use terms::*;
-pub use wildcard::*;
-
 use crate::ToOpenSearchJson;
+pub use bool::{BoolQuery, BoolQueryBuilder};
+pub use function_score::{
+    BoostMode, DecayFunction, FieldValueFactor, FunctionScoreQuery, FunctionScoreQueryBuilder,
+    RandomScore, ScoreFunction, ScoreFunctionType, ScoreMode, ScriptScore,
+};
+pub use match_phrase::MatchPhraseQuery;
+pub use match_phrase_prefix::MatchPhrasePrefixQuery;
+pub use match_query::MatchQuery;
+pub use range::{RangeQuery, RangeQueryBuilder};
+pub use regexp::{RegexpQuery, RegexpQueryFlags};
+use serde_json::Value;
+pub use simple_query_string::SimpleQueryStringQuery;
+pub use term::TermQuery;
+pub use terms::TermsQuery;
+pub use wildcard::WildcardQuery;
 
 /// Enum representing the different types of queries that can be used in a search request.
 #[derive(Debug, Clone, Serialize)]

--- a/rust/cloud-storage/opensearch_query_builder/src/query/function_score.rs
+++ b/rust/cloud-storage/opensearch_query_builder/src/query/function_score.rs
@@ -10,13 +10,13 @@ mod score_function;
 mod score_mode;
 mod script_score;
 
-pub use boost_mode::*;
-pub use decay_function::*;
-pub use field_value_factor::*;
-pub use random_score::*;
-pub use score_function::*;
-pub use score_mode::*;
-pub use script_score::*;
+pub use boost_mode::BoostMode;
+pub use decay_function::DecayFunction;
+pub use field_value_factor::FieldValueFactor;
+pub use random_score::RandomScore;
+pub use score_function::{ScoreFunction, ScoreFunctionType};
+pub use score_mode::ScoreMode;
+pub use script_score::ScriptScore;
 use serde_json::{Map, Value};
 
 use crate::util::is_empty_slice;

--- a/rust/cloud-storage/opensearch_query_builder/src/request.rs
+++ b/rust/cloud-storage/opensearch_query_builder/src/request.rs
@@ -12,11 +12,13 @@ mod collapse;
 mod highlight;
 mod sort_type;
 
-pub use aggregation_type::*;
-pub use collapse::*;
-pub use highlight::*;
-pub use sort_type::*;
-
+pub use aggregation_type::{AggregationType, CardinalityAggregation, TermsAggregation};
+pub use collapse::Collapse;
+pub use highlight::{Highlight, HighlightField};
+pub use sort_type::{
+    FieldSort, Lang, ScoreWithOrderSort, Script, ScriptSort, ScriptSortType, SortMode, SortOrder,
+    SortType,
+};
 /// Struct representing a search request.
 #[derive(Default, Debug, Clone, Serialize)]
 pub struct SearchRequest<'a> {

--- a/rust/cloud-storage/opensearch_query_builder/src/request/sort_type.rs
+++ b/rust/cloud-storage/opensearch_query_builder/src/request/sort_type.rs
@@ -7,8 +7,7 @@ use crate::ToOpenSearchJson;
 
 mod script;
 
-pub use script::*;
-
+pub use script::{Lang, Script, ScriptSort, ScriptSortType};
 /// Sort Order
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "lowercase")]

--- a/rust/cloud-storage/referral/src/inbound/axum_router.rs
+++ b/rust/cloud-storage/referral/src/inbound/axum_router.rs
@@ -6,11 +6,14 @@
 use crate::domain::models::ReferralError;
 use crate::domain::ports::ReferralService;
 use axum::{Json, Router, http::StatusCode, response::IntoResponse};
-pub use get_referral_code::*;
+pub use get_referral_code::{__path_get_referral_code_handler, get_referral_code_handler};
 use model_error_response::ErrorResponse;
 use rate_limit::RateLimitService;
 use rate_limit::inbound::rate_limit_middleware;
-pub use send_invite::*;
+pub use send_invite::{
+    __path_post_referral_invite_handler, PerIpReferralRateLimit, PerUserReferralRateLimit,
+    SendInviteBody, post_referral_invite_handler,
+};
 use std::sync::Arc;
 use tower::ServiceBuilder;
 

--- a/rust/cloud-storage/s3_key/src/lib.rs
+++ b/rust/cloud-storage/s3_key/src/lib.rs
@@ -3,10 +3,12 @@
 //! S3 key building and parsing for cloud storage buckets.
 
 mod document_key;
-pub use document_key::*;
-
+pub use document_key::{
+    CONVERTED_DOCUMENT_FILE_NAME, DOCX_EXTENSION, DocumentKey, PDF_EXTENSION, TEMP_FILE_PREFIX,
+    build_cloud_storage_bucket_document_key, build_docx_staging_bucket_document_key,
+    build_docx_to_pdf_converted_document_key, build_temp_docx_key,
+};
 mod bulk_upload_key;
-pub use bulk_upload_key::*;
-
+pub use bulk_upload_key::BulkUploadStagingKey;
 mod static_file_key;
-pub use static_file_key::*;
+pub use static_file_key::StaticFileKey;

--- a/rust/cloud-storage/saved_views/src/lib.rs
+++ b/rust/cloud-storage/saved_views/src/lib.rs
@@ -6,9 +6,8 @@ use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 use uuid::Uuid;
 
-pub use pgsql::*;
-pub use storage::*;
-
+pub use pgsql::PgViewStorage;
+pub use storage::{ExcludedDefaultViewStorage, ViewPatch, ViewStorage};
 #[derive(Serialize, Deserialize, Debug, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct View {

--- a/rust/cloud-storage/soup/src/inbound/axum_router.rs
+++ b/rust/cloud-storage/soup/src/inbound/axum_router.rs
@@ -18,7 +18,10 @@ use email::{
         models::{Link, PreviewView},
         ports::EmailService,
     },
-    inbound::{EmailLinkErr, EmailLinkExtractor, EmailRouterState},
+    inbound::axum::{
+        axum_impls::{EmailLinkErr, EmailLinkExtractor},
+        previews_router::EmailRouterState,
+    },
 };
 use filter_ast::{Expr, ExprFrame};
 use item_filters::{

--- a/rust/cloud-storage/sqs_client/src/email.rs
+++ b/rust/cloud-storage/sqs_client/src/email.rs
@@ -2,8 +2,9 @@ use crate::SQS;
 use email::domain::ports::EmailMessageEnqueuer;
 use models_email::email::service::backfill::BackfillPubsubMessage;
 pub use models_email::email::service::pubsub::LinkManagerMessage;
-use models_email::service::pubsub::{SFSUploaderMessage, ScheduledPubsubMessage};
-use serde::{Deserialize, Serialize};
+#[cfg(feature = "sfs_uploader")]
+use models_email::service::pubsub::SFSUploaderMessage;
+use models_email::service::pubsub::ScheduledPubsubMessage;
 use uuid::Uuid;
 
 impl SQS {
@@ -258,7 +259,7 @@ pub async fn enqueue_sfs_delete_message(
 
 /// The message we send to the sfs_delete
 #[cfg(feature = "sfs_delete")]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct SFSDeleteMessage {
     /// The ID of the row in email_attachments_sfs
     pub db_id: Uuid,

--- a/rust/cloud-storage/sqs_client/src/message_attribute.rs
+++ b/rust/cloud-storage/sqs_client/src/message_attribute.rs
@@ -3,8 +3,6 @@
     feature = "convert",
     feature = "document",
     feature = "document_text_extractor",
-    feature = "email",
-    feature = "gmail",
     feature = "upload_extractor"
 ))]
 pub(crate) fn build_string_message_attribute(
@@ -17,7 +15,7 @@ pub(crate) fn build_string_message_attribute(
     Ok(result)
 }
 
-#[cfg(any(feature = "gmail", feature = "organization_retention"))]
+#[cfg(feature = "organization_retention")]
 /// generified so we can pass different integer sizes
 pub(crate) fn build_number_message_attribute<T>(
     attr: T,

--- a/rust/cloud-storage/stream/src/domain/mod.rs
+++ b/rust/cloud-storage/stream/src/domain/mod.rs
@@ -4,6 +4,8 @@ mod ext;
 mod traits;
 mod types;
 
-pub use ext::*;
-pub use traits::*;
-pub use types::*;
+pub use ext::StreamRepoExt;
+pub use traits::{
+    DEFAULT_STREAM_TIMEOUT, ItemId, ItemStream, PayloadStream, StreamManager, StreamRepo,
+};
+pub use types::{Result, StreamEvent, StreamId, StreamItem, StreamServiceError};

--- a/rust/cloud-storage/stream/src/outbound/redis_pg/mod.rs
+++ b/rust/cloud-storage/stream/src/outbound/redis_pg/mod.rs
@@ -7,5 +7,5 @@ mod repo;
 #[cfg(feature = "redis-test")]
 mod test;
 
-pub use manager::*;
-pub use repo::*;
+pub use manager::RedisPostgresStreamManager;
+pub use repo::RedisPostgresStreamRepo;

--- a/rust/cloud-storage/unfurl_service/src/lib.rs
+++ b/rust/cloud-storage/unfurl_service/src/lib.rs
@@ -1,3 +1,7 @@
 pub mod http_safety;
 mod unfurl;
-pub use unfurl::*;
+pub use unfurl::{
+    BULK_CONCURRENCY, GetUnfurlResponse, GetUnfurlResponseList, MAX_HTML_SIZE, UnfurlFetchError,
+    append_optimistic_favico, extract_meta_tags, extract_meta_tags_mock, extract_meta_tags_prod,
+    favico_url, fetch_links_async, url_parsers,
+};


### PR DESCRIPTION
Glob exports can often result in the inability to analyze dead code because it can leak unused types into the crate api.

This pr just replaces glob imports and removes some resulting unused code

- **Replace pub use wildcard reexports with named reexports**
- **make some pub mods**
- **Update imports for public submodules**
- **remove unused code**
- **Fix chat inbound test imports**
