### PR TITLE
fix(notif): make full collapsible row clickable to expand

### DIFF
--- a/js/app/packages/entity/src/components/CollapsibleList.tsx
+++ b/js/app/packages/entity/src/components/CollapsibleList.tsx
@@ -14,24 +14,22 @@ interface ToggleButtonProps {
 function ToggleButton(props: ToggleButtonProps) {
   return (
     <Show when={props.hasMore}>
-      <div class="px-3 py-1.5">
-        <button
-          type="button"
-          class="flex items-center gap-1 text-[0.6875rem] text-ink-muted/70 hover:text-ink-muted"
-          data-collapsible-toggle
-          data-collapsible-state={props.showAll ? 'expanded' : 'collapsed'}
-          onClick={props.toggle}
-        >
-          <ChevronDownIcon
-            class={cn('size-2.5', {
-              'rotate-180': props.showAll,
-            })}
-          />
-          <Show when={!props.showAll} fallback="Show less">
-            {props.getExpandTextFn(props.itemsLength - props.visibleCount)}
-          </Show>
-        </button>
-      </div>
+      <button
+        type="button"
+        class="w-full flex items-center gap-1 px-3 py-1.5 text-[0.6875rem] text-ink-muted/70 hover:text-ink-muted hover:bg-ink-muted/[0.06]"
+        data-collapsible-toggle
+        data-collapsible-state={props.showAll ? 'expanded' : 'collapsed'}
+        onClick={props.toggle}
+      >
+        <ChevronDownIcon
+          class={cn('size-2.5', {
+            'rotate-180': props.showAll,
+          })}
+        />
+        <Show when={!props.showAll} fallback="Show less">
+          {props.getExpandTextFn(props.itemsLength - props.visibleCount)}
+        </Show>
+      </button>
     </Show>
   );
 }

--- a/js/app/packages/entity/src/components/CollapsibleList.tsx
+++ b/js/app/packages/entity/src/components/CollapsibleList.tsx
@@ -20,6 +20,10 @@ function ToggleButton(props: ToggleButtonProps) {
         data-collapsible-toggle
         data-collapsible-state={props.showAll ? 'expanded' : 'collapsed'}
         onClick={props.toggle}
+        onContextMenu={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+        }}
       >
         <ChevronDownIcon
           class={cn('size-2.5', {


### PR DESCRIPTION
show more should be clickable anywhere in the row
also disables right click context menu 