### PR TITLE
fix(task): enable undo/redo in create task description editor

### DIFF
--- a/js/app/packages/block-md/component/ComposeTask.tsx
+++ b/js/app/packages/block-md/component/ComposeTask.tsx
@@ -597,6 +597,7 @@ export function ComposeTask(props: ComposeTaskProps) {
     .withCode()
     .withMedia({ fileDrop: true })
     .withSelectionData()
+    .withHistory()
     .onChange(setContent)
     .onFocusLeave({
       onStart: (e) => editorFocusChange(e, -1),


### PR DESCRIPTION
The compose task body editor was missing `.withHistory()` in its builder chain, so the Lexical history plugin never registered and cmd+z / shift+cmd+z had no effect inside the description field. Adding `.withHistory()` restores undo/redo to match the other markdown editors.

Closes [019e2752-3fca-7f35-84a3-c40672702d57](https://app.macro.com/component/document/019e2752-3fca-7f35-84a3-c40672702d57).
