### PR TITLE
fix(soup): expand find bar in narrow split via SplitHeaderRight

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/soup-view-search-bar.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/soup-view-search-bar.tsx
@@ -145,6 +145,12 @@ export const SoupSearchbar = (props: SoupSearchbarProps) => {
       class="w-full flex items-center shrink-0 grow min-w-0 mobile:-order-2"
       data-search-bar-wrapper
       data-no-focus-restore
+      onFocusOut={(e) => {
+        if (hasContent() || !props.onDismiss) return;
+        const next = e.relatedTarget as Node | null;
+        if (next && e.currentTarget.contains(next)) return;
+        props.onDismiss();
+      }}
     >
       <div
         class={cn(

--- a/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
@@ -291,11 +291,7 @@ export const SoupView = (props: SoupViewProps) => {
                     {props.viewName}
                   </h1>
                 </Show>
-                <Show
-                  when={
-                    !narrowSearchExpanded() && !isComponentListView('search')
-                  }
-                >
+                <Show when={!isComponentListView('search')}>
                   <Show when={!isMobile()}>
                     <CollapsibleHeaderItem
                       id="tabs"

--- a/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
@@ -285,12 +285,7 @@ export const SoupView = (props: SoupViewProps) => {
         <div class="size-full flex flex-col">
           <div class="flex flex-col w-full">
             <SplitHeaderLeft>
-              <div
-                class={cn('h-full flex gap-3 items-center', {
-                  'shrink-0': !narrowSearchExpanded(),
-                  'flex-1 min-w-0': narrowSearchExpanded(),
-                })}
-              >
+              <div class="h-full flex gap-3 items-center shrink-0">
                 <Show when={!isMobile()}>
                   <h1 class="font-semibold text-ink select-none text-sm shrink-0">
                     {props.viewName}
@@ -317,21 +312,21 @@ export const SoupView = (props: SoupViewProps) => {
                     <MobileFilterDrawer />
                   </Show>
                 </Show>
-                <Show when={narrowSearchExpanded()}>
-                  <div class="flex-1 min-w-0">
-                    <SoupSearchbar
-                      variant="secondary"
-                      autoFocus
-                      initialValue={props.initialSearchText}
-                      onDismiss={() => setNarrowSearchExpanded(false)}
-                    />
-                  </div>
-                </Show>
               </div>
             </SplitHeaderLeft>
             <SplitHeaderRight>
               <Show when={isMobile() && !narrowSearchExpanded()}>
                 <SettingsButton />
+              </Show>
+              <Show when={narrowSearchExpanded()}>
+                <div class="flex-1 min-w-0">
+                  <SoupSearchbar
+                    variant="secondary"
+                    autoFocus
+                    initialValue={props.initialSearchText}
+                    onDismiss={() => setNarrowSearchExpanded(false)}
+                  />
+                </div>
               </Show>
               <Show
                 when={!isComponentListView('search')}


### PR DESCRIPTION
The narrow-split search bar lived inside `SplitHeaderLeft`, which has `shrink` but no `grow`, so `flex-1` on its child couldn't actually consume free space. Move the expanded narrow bar into `SplitHeaderRight` (which has `grow shrink`), leaving the title alone on the left.
