### PR TITLE
fix(channel): render call and empty-subject email shares correctly

### DIFF
--- a/js/app/packages/block-email/definition.ts
+++ b/js/app/packages/block-email/definition.ts
@@ -9,6 +9,7 @@ export const definition = defineBlock({
   component: EmailBlock,
   liveTrackingEnabled: true,
   syncServiceEnabled: false,
+  defaultFilename: '[No subject]',
 
   async load(source) {
     if (source.type === 'dss') {

--- a/js/app/packages/channel/Attachments/attachment-utils.ts
+++ b/js/app/packages/channel/Attachments/attachment-utils.ts
@@ -53,6 +53,9 @@ export function buildAttachmentEntityFilters(
       case 'project':
         projectIds.push(a.entity_id);
         break;
+      case 'call':
+        callIds.push(a.entity_id);
+        break;
     }
   }
 

--- a/js/app/packages/core/component/ForwardToChannel.tsx
+++ b/js/app/packages/core/component/ForwardToChannel.tsx
@@ -280,11 +280,7 @@ export function ForwardToChannel(props: ForwardToChannelProps) {
   const blockId = useMaybeBlockId() ?? props.blockId;
   const asAttachment = () => {
     const itemType =
-      blockName === 'email'
-        ? 'thread'
-        : blockName != null
-          ? blockNameToItemType(blockName)
-          : undefined;
+      blockName != null ? blockNameToItemType(blockName) : undefined;
     return {
       entity_type: itemType ?? 'unknown',
       entity_id: blockId ?? '',

--- a/js/app/packages/service-clients/service-storage/client.ts
+++ b/js/app/packages/service-clients/service-storage/client.ts
@@ -184,6 +184,7 @@ export function stringToItemType(str: string): ItemType | undefined {
     case 'thread': {
       return 'email';
     }
+    case 'call':
     case 'chat':
     case 'document':
     case 'project':


### PR DESCRIPTION
Call shares rendered as "Deleted" because `stringToItemType` returned `undefined` for `'call'`; added the case in both the inline message renderer and the channel Attachments-tab filter builder. Empty-subject email shares rendered as "Unknown Filename" because the email block had no `defaultFilename`; added `'[No subject]'` to match the email viewer.

Follow-up for the underlying type-safety drift (16 distinct `entity_type` values on dev, 102 rows still rendering as Deleted): macro task `019e27ab-6fb9-733f-9105-78b0b68120b1`.
