### PR TITLE
Refocus desktop settings into split view and simplify sidebar actions

### DIFF
--- a/js/app/packages/app/component/app-sidebar/sidebar.tsx
+++ b/js/app/packages/app/component/app-sidebar/sidebar.tsx
@@ -1,9 +1,5 @@
 import { useAnalytics } from '@app/component/analytics-context';
 import { ChannelsUnreadWidget } from '@app/component/app-sidebar/channels-unread-widget';
-import {
-  InviteModal,
-  setInviteModalOpen,
-} from '@app/component/app-sidebar/invite-modal';
 import { CommandState } from '@app/component/command';
 import { createMenuOpen, setCreateMenuOpen } from '@app/component/Launcher';
 import { requestSearchFocus } from '@app/component/next-soup/soup-view/search-controllers';
@@ -44,7 +40,6 @@ import { AnimatedSearchIcon } from '@macro-icons/wide/animating/search';
 import { AnimatedSidebarIcon } from '@macro-icons/wide/animating/sidebar';
 import { AnimatedStarIcon } from '@macro-icons/wide/animating/star';
 import { AnimatedTaskIcon } from '@macro-icons/wide/animating/task';
-import { AnimatedUsersIcon } from '@macro-icons/wide/animating/users';
 import { useNotificationSettings } from '@notifications';
 import { debounce } from '@solid-primitives/scheduled';
 import { useLocation } from '@solidjs/router';
@@ -555,6 +550,27 @@ export const AppSidebar = (props: AppSidebarProps) => {
             <LogoIcon class="size-6" />
           </div>
           <div class="grow shrink-10 min-w-0" />
+          <Show when={isExpanded()}>
+            <div class="flex items-center gap-1 mr-1">
+              <Button
+                class="flex items-center justify-center rounded-xs p-0.5 px-2 bg-surface [&_svg]:size-4"
+                onClick={handleCommandPaletteClick}
+                label="Command"
+                hotkey={TOKENS.global.commandMenu}
+              >
+                <AnimatedCommandIcon />
+              </Button>
+              <Button
+                class="flex items-center justify-center rounded-xs p-0.5 px-2 bg-surface [&_svg]:size-4"
+                onClick={handleNewSplitClick}
+                label="New Split"
+                hotkey={TOKENS.global.createNewSplit}
+                disabled={() => !canCreateNewSplit()}
+              >
+                <AnimatedNewSplitIcon />
+              </Button>
+            </div>
+          </Show>
           <Button
             class="flex items-center justify-center rounded-xs p-0.5 px-2 bg-surface [&_svg]:size-4"
             onClick={() => handleSidebarOpenChange(!isExpanded())}
@@ -630,30 +646,6 @@ export const AppSidebar = (props: AppSidebarProps) => {
           />
         </Show>
         <SidebarActionButton
-          label="Invite"
-          isSlim={isSlim}
-          onClick={() => setInviteModalOpen(true)}
-          icon={AnimatedUsersIcon}
-        />
-
-        <SidebarActionButton
-          label="New Split"
-          hotkeyToken={TOKENS.global.createNewSplit}
-          isSlim={isSlim}
-          onClick={handleNewSplitClick}
-          disabled={() => !canCreateNewSplit()}
-          icon={AnimatedNewSplitIcon}
-        />
-
-        <SidebarActionButton
-          label="Command"
-          hotkeyToken={TOKENS.global.commandMenu}
-          isSlim={isSlim}
-          onClick={handleCommandPaletteClick}
-          icon={AnimatedCommandIcon}
-        />
-
-        <SidebarActionButton
           label="Settings"
           hotkeyToken={TOKENS.global.toggleSettings}
           isSlim={isSlim}
@@ -661,7 +653,6 @@ export const AppSidebar = (props: AppSidebarProps) => {
           icon={AnimatedGearIcon}
         />
       </div>
-      <InviteModal />
     </div>
   );
 };

--- a/js/app/packages/app/component/settings/Settings.tsx
+++ b/js/app/packages/app/component/settings/Settings.tsx
@@ -56,6 +56,14 @@ export function SettingsPanel(props: SettingsPanelProps) {
   createEffect(focusSettingsOnOpen);
 
   function settingsTabs() {
+    if (!isMobile()) {
+      return [
+        { value: 'MCP & Mobile App', label: 'MCP & Mobile App' },
+        { value: 'Invite Team Members', label: 'Invite team members' },
+        { value: 'Appearance', label: 'Appearence' },
+      ];
+    }
+
     const tabs: { value: string; label: string }[] = [
       { value: 'Appearance', label: 'Appearance' },
       { value: 'Account', label: 'Account' },
@@ -219,6 +227,12 @@ export function SettingsPanel(props: SettingsPanelProps) {
         <Show when={activeTabId() === 'Appearance'}>
           <Appearance />
         </Show>
+        <Show when={activeTabId() === 'MCP & Mobile App' && !isMobile()}>
+          <McpAndMobileApp />
+        </Show>
+        <Show when={activeTabId() === 'Invite Team Members' && !isMobile()}>
+          <InviteTeamMembers />
+        </Show>
         <Show when={activeTabId() === 'Shortcuts' && !isTouchDevice()}>
           <Shortcuts />
         </Show>
@@ -239,6 +253,58 @@ export function SettingsPanel(props: SettingsPanelProps) {
         <BottomTabs />
       </Show>
     </div>
+  );
+}
+
+function McpAndMobileApp() {
+  const { activeTabId, setActiveTabId } = useSettingsState();
+  const tabs = createMemo(() => {
+    const list = [{ value: 'MCP', label: 'MCP' }];
+    if (ENABLE_APP_STORE_QR_CODE && !isNativeMobilePlatform()) {
+      list.push({ value: 'Mobile App', label: 'Mobile App' });
+    }
+    return list;
+  });
+
+  return (
+    <>
+      <div class="px-2 pt-2">
+        <Tabs list={tabs()} value={activeTabId()} onChange={(tab) => setActiveTabId(tab as SettingsTab)} />
+      </div>
+      <Show when={activeTabId() === 'MCP' && !isNativeMobilePlatform()}>
+        <Mcp />
+      </Show>
+      <Show when={activeTabId() === 'Mobile App' && ENABLE_APP_STORE_QR_CODE && !isNativeMobilePlatform()}>
+        <MobileApp />
+      </Show>
+    </>
+  );
+}
+
+function InviteTeamMembers() {
+  const { activeTabId, setActiveTabId } = useSettingsState();
+  const teamsFlag = useFeatureFlag('enable-teams-settings', { enabledOverride: ENABLE_TEAMS_OVERRIDE });
+  const tabs = createMemo(() => {
+    const list = [{ value: 'Account', label: 'Account' }];
+    if (teamsFlag().enabled) list.push({ value: 'Team', label: 'Team' });
+    return list;
+  });
+  return (
+    <>
+      <div class="px-2 pt-2">
+        <Tabs list={tabs()} value={activeTabId()} onChange={(tab) => setActiveTabId(tab as SettingsTab)} />
+      </div>
+      <Show when={activeTabId() === 'Account'}>
+        <Suspense>
+          <Account />
+        </Suspense>
+      </Show>
+      <Show when={activeTabId() === 'Team' && teamsFlag().enabled}>
+        <Suspense>
+          <Team />
+        </Suspense>
+      </Show>
+    </>
   );
 }
 

--- a/js/app/packages/core/constant/SettingsState.tsx
+++ b/js/app/packages/core/constant/SettingsState.tsx
@@ -13,7 +13,9 @@ export type SettingsTab =
   | 'Shortcuts'
   | 'Mobile App'
   | 'MCP'
-  | 'Team';
+  | 'Team'
+  | 'MCP & Mobile App'
+  | 'Invite Team Members';
 
 export const [activeTabId, setActiveTabId] =
   createSignal<SettingsTab>('Appearance');


### PR DESCRIPTION
### Motivation
- Surface team and mobile setup on desktop by moving Settings out of the sidebar and into the active split with a small set of top-level entries. 
- Deprioritize the invite/referral CTA in the sidebar and make Command/New Split more accessible in the sidebar header. 

### Description
- Desktop Settings now shows three top-level desktop-only tabs: `MCP & Mobile App`, `Invite Team Members`, and `Appearance`, while mobile retains the original tab layout; implemented in `Settings.tsx` by switching `settingsTabs()` when `!isMobile()` and adding `McpAndMobileApp` and `InviteTeamMembers` helper views. 
- Kept existing components and reused `Mcp`, `MobileApp`, `Account`, and `Team` inside the new grouped sections instead of deleting code. 
- Extended `SettingsTab` union in `SettingsState.tsx` to include the new tab IDs so hotkeys and tab state remain typed and consistent. 
- Sidebar changes in `sidebar.tsx`: removed the footer `Invite` entry and its mounted `InviteModal`, and moved `Command` and `New Split` into compact icon buttons in the top header immediately left of the expand/collapse button; those buttons are only shown when the sidebar is expanded. 

### Testing
- Ran the TypeScript check with `bun run check` in `js/app`, which executed `tsc --noEmit` and failed due to missing ambient type definition packages (pre-existing environment dependency issues: `@types/facebook-pixel`, `@types/gtag.js`, `vite-plugin-solid-svg/*`, `vite/client`, `wicg-file-system-access`).
- No other automated test suites were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0726438628832494d94502030129f3)