### PR TITLE
fix(channel): stop findbar previous from wrapping past most recent

### DIFF
--- a/js/app/packages/block-pdf/component/SimpleSearch.tsx
+++ b/js/app/packages/block-pdf/component/SimpleSearch.tsx
@@ -87,6 +87,8 @@ export function SimpleSearch() {
     hasUnsubmittedChanges: () => searchText() !== submittedQuery(),
     isPending,
     resultsCount: total,
+    canNext: () => total() > 0,
+    canPrevious: () => total() > 0,
     open: () => setIsOpen(true),
     close,
     submit,

--- a/js/app/packages/channel/Channel/create-channel-find-bar.ts
+++ b/js/app/packages/channel/Channel/create-channel-find-bar.ts
@@ -177,6 +177,10 @@ export function createChannelFindBar(
         totalCount,
         isFetching: () => searchQuery.isFetching,
         validateText: validateSearchServiceText,
+        // Only wrap past the most recent result once every page is loaded —
+        // otherwise wrapping would jump to a "last" result that isn't truly
+        // the global oldest hit.
+        wrapPrevious: () => !searchQuery.hasNextPage,
         navigate: (result) => {
           if (result.threadId) {
             options.goToMessage(result.threadId, result.messageId);
@@ -188,7 +192,6 @@ export function createChannelFindBar(
     },
     {
       onBeforeSubmit: () => options.clearSelection(),
-      wrapPrevious: false,
     }
   );
 

--- a/js/app/packages/channel/Channel/create-channel-find-bar.ts
+++ b/js/app/packages/channel/Channel/create-channel-find-bar.ts
@@ -188,6 +188,7 @@ export function createChannelFindBar(
     },
     {
       onBeforeSubmit: () => options.clearSelection(),
+      wrapPrevious: false,
     }
   );
 

--- a/js/app/packages/core/component/FindBar.tsx
+++ b/js/app/packages/core/component/FindBar.tsx
@@ -201,7 +201,9 @@ function FindBarPreviousButton() {
       variant="ghost"
       aria-label={direction() === 'desc' ? 'Next match' : 'Previous match'}
       disabled={
-        direction() === 'desc' ? !controller.canNext() : !controller.canPrevious()
+        direction() === 'desc'
+          ? !controller.canNext()
+          : !controller.canPrevious()
       }
       onClick={() =>
         direction() === 'desc' ? controller.next() : controller.previous()
@@ -220,7 +222,9 @@ function FindBarNextButton() {
       variant="ghost"
       aria-label={direction() === 'desc' ? 'Previous match' : 'Next match'}
       disabled={
-        direction() === 'desc' ? !controller.canPrevious() : !controller.canNext()
+        direction() === 'desc'
+          ? !controller.canPrevious()
+          : !controller.canNext()
       }
       onClick={() =>
         direction() === 'desc' ? controller.previous() : controller.next()

--- a/js/app/packages/core/component/FindBar.tsx
+++ b/js/app/packages/core/component/FindBar.tsx
@@ -200,6 +200,9 @@ function FindBarPreviousButton() {
       size="icon-sm"
       variant="ghost"
       aria-label={direction() === 'desc' ? 'Next match' : 'Previous match'}
+      disabled={
+        direction() === 'desc' ? !controller.canNext() : !controller.canPrevious()
+      }
       onClick={() =>
         direction() === 'desc' ? controller.next() : controller.previous()
       }
@@ -216,6 +219,9 @@ function FindBarNextButton() {
       size="icon-sm"
       variant="ghost"
       aria-label={direction() === 'desc' ? 'Previous match' : 'Next match'}
+      disabled={
+        direction() === 'desc' ? !controller.canPrevious() : !controller.canNext()
+      }
       onClick={() =>
         direction() === 'desc' ? controller.previous() : controller.next()
       }

--- a/js/app/packages/core/component/createFindBarController.ts
+++ b/js/app/packages/core/component/createFindBarController.ts
@@ -12,6 +12,10 @@ export type FindBarSource<T> = {
   navigate: (result: T) => void;
   validateText?: (text: string) => boolean;
   totalCount?: Accessor<number | undefined>;
+  /** When false, `previous()` stops at index 1. Defaults to true. */
+  wrapPrevious?: Accessor<boolean>;
+  /** When false, `next()` stops at the last result. Defaults to true. */
+  wrapNext?: Accessor<boolean>;
 };
 
 export type FindBarController = {
@@ -40,16 +44,6 @@ export type FindBarControllerOptions = {
    * that must complete before downstream results-driven effects run.
    */
   onBeforeSubmit?: () => void;
-  /**
-   * When false, `previous()` stops at first result instead of wrapping to the last
-   * result. Defaults to true.
-   */
-  wrapPrevious?: boolean;
-  /**
-   * When false, `next()` stops at the last result instead of wrapping back to
-   * first result. Defaults to true.
-   */
-  wrapNext?: boolean;
 };
 
 export function createFindBarController<T>(
@@ -80,13 +74,13 @@ export function createFindBarController<T>(
     })
   );
 
-  const wrapNext = options.wrapNext ?? true;
-  const wrapPrevious = options.wrapPrevious ?? true;
+  const wrapNext = () => source.wrapNext?.() ?? true;
+  const wrapPrevious = () => source.wrapPrevious?.() ?? true;
 
   const next = () => {
     const rs = source.results();
     if (rs.length === 0) return;
-    if (activeIndex() >= rs.length && !wrapNext) return;
+    if (activeIndex() >= rs.length && !wrapNext()) return;
     const i = activeIndex() >= rs.length ? 1 : activeIndex() + 1;
     setActiveIndex(i);
     source.navigate(rs[i - 1]);
@@ -95,7 +89,7 @@ export function createFindBarController<T>(
   const previous = () => {
     const rs = source.results();
     if (rs.length === 0) return;
-    if (activeIndex() <= 1 && !wrapPrevious) return;
+    if (activeIndex() <= 1 && !wrapPrevious()) return;
     const i = activeIndex() <= 1 ? rs.length : activeIndex() - 1;
     setActiveIndex(i);
     source.navigate(rs[i - 1]);
@@ -139,12 +133,12 @@ export function createFindBarController<T>(
     canNext: () => {
       const len = source.results().length;
       if (len === 0) return false;
-      return wrapNext || activeIndex() < len;
+      return wrapNext() || activeIndex() < len;
     },
     canPrevious: () => {
       const len = source.results().length;
       if (len === 0) return false;
-      return wrapPrevious || activeIndex() > 1;
+      return wrapPrevious() || activeIndex() > 1;
     },
     open,
     close,

--- a/js/app/packages/core/component/createFindBarController.ts
+++ b/js/app/packages/core/component/createFindBarController.ts
@@ -23,6 +23,8 @@ export type FindBarController = {
   hasUnsubmittedChanges: Accessor<boolean>;
   isPending: Accessor<boolean>;
   resultsCount: Accessor<number>;
+  canNext: Accessor<boolean>;
+  canPrevious: Accessor<boolean>;
   open: () => void;
   close: () => void;
   submit: () => void;
@@ -134,6 +136,16 @@ export function createFindBarController<T>(
     hasUnsubmittedChanges: () => query().trim() !== submittedQuery(),
     isPending: () => !!submittedQuery() && source.isFetching(),
     resultsCount: () => source.totalCount?.() ?? source.results().length,
+    canNext: () => {
+      const len = source.results().length;
+      if (len === 0) return false;
+      return wrapNext || activeIndex() < len;
+    },
+    canPrevious: () => {
+      const len = source.results().length;
+      if (len === 0) return false;
+      return wrapPrevious || activeIndex() > 1;
+    },
     open,
     close,
     submit,

--- a/js/app/packages/core/component/createFindBarController.ts
+++ b/js/app/packages/core/component/createFindBarController.ts
@@ -38,6 +38,16 @@ export type FindBarControllerOptions = {
    * that must complete before downstream results-driven effects run.
    */
   onBeforeSubmit?: () => void;
+  /**
+   * When false, `previous()` stops at first result instead of wrapping to the last
+   * result. Defaults to true.
+   */
+  wrapPrevious?: boolean;
+  /**
+   * When false, `next()` stops at the last result instead of wrapping back to
+   * first result. Defaults to true.
+   */
+  wrapNext?: boolean;
 };
 
 export function createFindBarController<T>(
@@ -68,9 +78,13 @@ export function createFindBarController<T>(
     })
   );
 
+  const wrapNext = options.wrapNext ?? true;
+  const wrapPrevious = options.wrapPrevious ?? true;
+
   const next = () => {
     const rs = source.results();
     if (rs.length === 0) return;
+    if (activeIndex() >= rs.length && !wrapNext) return;
     const i = activeIndex() >= rs.length ? 1 : activeIndex() + 1;
     setActiveIndex(i);
     source.navigate(rs[i - 1]);
@@ -79,6 +93,7 @@ export function createFindBarController<T>(
   const previous = () => {
     const rs = source.results();
     if (rs.length === 0) return;
+    if (activeIndex() <= 1 && !wrapPrevious) return;
     const i = activeIndex() <= 1 ? rs.length : activeIndex() - 1;
     setActiveIndex(i);
     source.navigate(rs[i - 1]);


### PR DESCRIPTION
Channel findbar previous-match action no longer wraps from the most recent result to the oldest. Next still wraps from the last result back to the first. Adds `wrapPrevious`/`wrapNext` options to `createFindBarController` (both default to true) and opts the channel into `wrapPrevious: false`.

this is a temporary workaround until we have global wrap around
