### PR TITLE
fix(core): dismiss mention hover cards on scroll

### DIFF
--- a/js/app/packages/core/component/HoverCard.tsx
+++ b/js/app/packages/core/component/HoverCard.tsx
@@ -67,6 +67,7 @@ export function HoverCard(props: HoverCardComponentProps) {
 
   const [nestedOpenCount, setNestedOpenCount] = createSignal(0);
   const [isHoverCardOpen, setIsHoverCardOpen] = createSignal(false);
+  let contentEl: HTMLElement | undefined;
 
   // Keep the internal open signal in sync with controlled `open` so the
   // nested-card tracking effect below still fires when consumers control state.
@@ -96,6 +97,28 @@ export function HoverCard(props: HoverCardComponentProps) {
 
   const shouldForceMount = () => nestedOpenCount() > 0;
 
+  // Dismiss on scroll outside the card content. Kobalte only listens for
+  // pointermove to detect leaving the trigger, so a static cursor during
+  // rapid scrolling never fires the close — leaving cards stranded as new
+  // triggers slide under the cursor.
+  createEffect(() => {
+    if (!isHoverCardOpen()) return;
+
+    const onScroll = (e: Event) => {
+      const target = e.target as Node | null;
+      if (contentEl && target && contentEl.contains(target)) return;
+      handleOpenChange(false);
+    };
+
+    window.addEventListener('scroll', onScroll, {
+      capture: true,
+      passive: true,
+    });
+    onCleanup(() => {
+      window.removeEventListener('scroll', onScroll, true);
+    });
+  });
+
   return (
     <KobalteHoverCard
       getAnchorRect={
@@ -121,7 +144,12 @@ export function HoverCard(props: HoverCardComponentProps) {
       </KobalteHoverCard.Trigger>
 
       <KobalteHoverCard.Portal>
-        <KobalteHoverCard.Content class={props.contentClass}>
+        <KobalteHoverCard.Content
+          ref={(el) => {
+            contentEl = el;
+          }}
+          class={props.contentClass}
+        >
           <HoverCardPortalNestedPreviewOpenContext.Provider
             value={{ count: nestedOpenCount, setCount: setNestedOpenCount }}
           >

--- a/js/app/packages/core/component/HoverCard.tsx
+++ b/js/app/packages/core/component/HoverCard.tsx
@@ -20,6 +20,11 @@ const HoverCardPortalNestedPreviewOpenContext = createContext<
   NestedHoverCardContext | undefined
 >(undefined);
 
+// Top-level open cards. When a new card opens, close any already-open siblings
+// so only one card is visible at a time — Kobalte instances are independent
+// and a missed pointerleave (common during scroll) can leave multiple stranded.
+const openTopLevelHoverCards = new Set<() => void>();
+
 export type HoverCardComponentProps = {
   /** The trigger content to hover over */
   trigger: JSX.Element;
@@ -86,14 +91,34 @@ export function HoverCard(props: HoverCardComponentProps) {
     }
   });
 
+  const closeSelf = () => {
+    setIsHoverCardOpen(false);
+    props.onOpenChange?.(false);
+  };
+
+  const isTopLevel = parentNestedContext === undefined;
+
   const handleOpenChange = (open: boolean) => {
     if (!open && nestedOpenCount() > 0) {
       return;
     }
 
+    if (open && isTopLevel) {
+      for (const close of openTopLevelHoverCards) {
+        if (close !== closeSelf) close();
+      }
+      openTopLevelHoverCards.add(closeSelf);
+    } else if (!open && isTopLevel) {
+      openTopLevelHoverCards.delete(closeSelf);
+    }
+
     setIsHoverCardOpen(open);
     props.onOpenChange?.(open);
   };
+
+  onCleanup(() => {
+    if (isTopLevel) openTopLevelHoverCards.delete(closeSelf);
+  });
 
   const shouldForceMount = () => nestedOpenCount() > 0;
 


### PR DESCRIPTION
Mention hover cards lingered on screen during scroll.

**Root cause:** Kobalte's `HoverCard` has exactly one mechanism that closes an already-open card — a global `pointermove` listener (`hover-card-root.tsx`'s `onHoverOutside`). Trigger-level `onPointerLeave` only calls `cancelOpening`, not close. So the close path is: user moves cursor → `pointermove` fires → listener checks the cursor is outside trigger/content/safe-polygon → schedule close.

Scrolling under a **static cursor** never fires `pointermove` (cursor coordinates don't change, even though elements under it do). `pointerenter`/`pointerleave` on triggers fire normally, but neither closes an open card. The card has no signal to dismiss until the user actually moves the mouse — and if the scroll happens to settle with the cursor over a different mention for >100ms (the open delay), a second card opens while the first lingers, since each HoverCard instance is independent.

**Fix:**
- Window-level `scroll` capture listener that closes the card — substitutes for the missing `pointermove` signal.
- Module-level registry of open top-level cards so opening a new one closes any others — defense-in-depth for the cross-instance case.