### PR TITLE
fix(convert): dyn linking

### DIFF
--- a/rust/cloud-storage/Dockerfile.convert_service.prebuilt
+++ b/rust/cloud-storage/Dockerfile.convert_service.prebuilt
@@ -37,6 +37,23 @@ COPY ./prebuilt/nix-store/ /nix/store/
 COPY ./prebuilt/${SERVICE_NAME} /app/svc
 RUN chmod +x /app/svc
 
+# The nix-built binary uses the nix dynamic linker, which doesn't search system
+# library paths (/usr/lib, /lib). LibreOfficeKit's libmergedlo.so is loaded via
+# dlopen at runtime and depends on system libraries (libz, libfreetype, etc.).
+# We symlink system shared libs into the LOK program dir so they are found via
+# LD_LIBRARY_PATH, but skip libs that the nix binary provides (glibc, OpenSSL,
+# gcc) to avoid version conflicts between nix and system libraries.
+RUN for lib in /usr/lib/x86_64-linux-gnu/*.so* /lib/x86_64-linux-gnu/*.so*; do \
+      name="$(basename "$lib")"; \
+      case "$name" in \
+        libc.so*|libm.so*|libdl.so*|librt.so*|libpthread.so*|ld-linux*) continue ;; \
+        libssl.so*|libcrypto.so*) continue ;; \
+        libgcc_s.so*) continue ;; \
+      esac; \
+      [ ! -e "/app/lok/instdir/program/$name" ] && ln -s "$lib" "/app/lok/instdir/program/$name" 2>/dev/null || true; \
+    done
+
 ENV PORT=8080
+ENV LD_LIBRARY_PATH=/app/lok/instdir/program
 EXPOSE ${PORT}
 ENTRYPOINT ["dumb-init", "./svc"]

--- a/rust/cloud-storage/convert_service/src/main.rs
+++ b/rust/cloud-storage/convert_service/src/main.rs
@@ -16,10 +16,54 @@ mod model;
 mod process;
 mod utils;
 
+/// Smoke-tests LibreOfficeKit by forking a child process that initializes LOK.
+/// Fails fast at startup if the LOK shared libraries cannot be loaded.
+fn smoke_test_lok(lok_path: &str) -> anyhow::Result<()> {
+    use nix::unistd::{ForkResult, fork};
+
+    tracing::info!("running LOK smoke test");
+
+    match unsafe { fork() } {
+        Ok(ForkResult::Parent { child }) => {
+            let status = nix::sys::wait::waitpid(child, None)
+                .context("failed to wait for LOK smoke test child")?;
+            match status {
+                nix::sys::wait::WaitStatus::Exited(_, 0) => {
+                    tracing::info!("LOK smoke test passed");
+                    Ok(())
+                }
+                _ => {
+                    anyhow::bail!("LOK smoke test failed with status: {:?}", status);
+                }
+            }
+        }
+        Ok(ForkResult::Child) => unsafe {
+            std::env::set_var("SAL_LOG", "");
+            let result = rs_libreoffice_bindings::Office::new(lok_path);
+            match result {
+                Ok(office) => {
+                    drop(office);
+                    nix::libc::exit(0);
+                }
+                Err(e) => {
+                    eprintln!("LOK smoke test: failed to initialize LibreOfficeKit: {e}");
+                    nix::libc::exit(1);
+                }
+            }
+        },
+        Err(e) => {
+            anyhow::bail!("LOK smoke test fork failed: {e}");
+        }
+    }
+}
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let env = Environment::new_or_prod();
     MacroEntrypoint::new(env).init();
+
+    let lok_path = std::env::var("LOK_PATH").context("LOK_PATH must be provided")?;
+    smoke_test_lok(&lok_path)?;
 
     let aws_config = macro_aws_config::get_macro_aws_config().await;
 


### PR DESCRIPTION
When the build process for the convert service switched over to nix the image that is created by CI didn't have the correct linker args to properly instantiate LOK.

The aws smoke tests did not catch this because the dyanmic linking happens at request time, meaning the smoke tests would pass even though the instantiation would fail.

This PR fixes the linker args and adds a smoke test to the application startup, such that an LOK instantiation failure will be caught during the deploy process.

- **update linker args**
- **add smoke test on init**
