### PR TITLE
fix(channel): restore call case in stringToItemType

### DIFF
--- a/js/app/packages/service-clients/service-storage/client.ts
+++ b/js/app/packages/service-clients/service-storage/client.ts
@@ -184,6 +184,7 @@ export function stringToItemType(str: string): ItemType | undefined {
     case 'thread': {
       return 'email';
     }
+    case 'call':
     case 'chat':
     case 'document':
     case 'project':


### PR DESCRIPTION
PR #3164 incidentally removed `case 'call':` from `stringToItemType`, which silently regressed the call-share fix from #3276 — call attachments fell through to `undefined`, got filtered out of the soup query, and rendered as deleted.
