### PR TITLE
fix(command): track recency for parent-scope commands

### DIFF
--- a/js/app/packages/app/component/command/CommandMenu.tsx
+++ b/js/app/packages/app/component/command/CommandMenu.tsx
@@ -171,6 +171,7 @@ export function CommandMenuInner(props: {
 
       // Check if this is a multi-stage command
       if (command.activateCommandScopeId) {
+        trackCommandUsage(item.id);
         // Get commands from the nested scope
         const nestedCommands = getActiveCommandsFromScope(
           command.activateCommandScopeId,

--- a/js/app/packages/app/component/command/CommandMenu.tsx
+++ b/js/app/packages/app/component/command/CommandMenu.tsx
@@ -168,10 +168,10 @@ export function CommandMenuInner(props: {
 
     if (isCommandItem(item)) {
       const command = item.data;
+      trackCommandUsage(item.id);
 
       // Check if this is a multi-stage command
       if (command.activateCommandScopeId) {
-        trackCommandUsage(item.id);
         // Get commands from the nested scope
         const nestedCommands = getActiveCommandsFromScope(
           command.activateCommandScopeId,
@@ -189,7 +189,6 @@ export function CommandMenuInner(props: {
       }
 
       // Regular command - close and run
-      trackCommandUsage(item.id);
       CommandState.close();
       CommandState.setQuery('');
       runCommand(command);


### PR DESCRIPTION
Parent-scope commands (e.g. "Change theme") returned early before calling `trackCommandUsage`, so they never showed up in kommand recency. Track them when the nested scope is activated.
