### PR TITLE
fix(channels): scroll-to-bottom hotkey to use dedicated handler

### DIFF
--- a/js/app/packages/channel/Channel/Channel.tsx
+++ b/js/app/packages/channel/Channel/Channel.tsx
@@ -319,6 +319,16 @@ export function Channel(props: ChannelProps) {
     isMessageLoaded: (id) => messageIndex.keys.includes(id),
   });
 
+  const handleScrollToBottom = () => {
+    if (messagesQuery.hasPreviousPage) {
+      targetMessageController.reset();
+      const defaultKey = getChannelMessagesQueryKey(props.channelId, null);
+      queryClient.resetQueries({ queryKey: defaultKey });
+    } else {
+      threadListNavigation()?.scrollToBottom('end');
+    }
+  };
+
   const { messageListScopeId, attachMessageListRef, attachInputRef } =
     createChannelHotkeys({
       selection,
@@ -330,17 +340,8 @@ export function Channel(props: ChannelProps) {
       isInputEmpty: () =>
         (channelInputSnapshot()?.value.trim().length ?? 0) === 0,
       onOpenFindBar: findBar.open,
+      onGoToBottom: handleScrollToBottom,
     });
-
-  const handleScrollToBottom = () => {
-    if (messagesQuery.hasPreviousPage) {
-      targetMessageController.reset();
-      const defaultKey = getChannelMessagesQueryKey(props.channelId, null);
-      queryClient.resetQueries({ queryKey: defaultKey });
-    } else {
-      threadListNavigation()?.scrollToBottom('end');
-    }
-  };
 
   createStickyScrollEffect({
     isNearBottom: () => threadListScrollState()?.isNearBottom ?? false,

--- a/js/app/packages/channel/Channel/create-channel-hotkeys.ts
+++ b/js/app/packages/channel/Channel/create-channel-hotkeys.ts
@@ -15,6 +15,7 @@ type CreateChannelHotkeysOptions = {
   isInputEmpty: Accessor<boolean>;
   isEditing: Accessor<boolean>;
   onOpenFindBar: () => void;
+  onGoToBottom: () => void;
 };
 
 export function canReplyToSelectedMessageFromHotkey(input: {
@@ -90,10 +91,8 @@ export function createChannelHotkeys(options: CreateChannelHotkeysOptions) {
     description: 'Go to latest message',
     keyDownHandler: () => {
       options.selection.clear();
-      const id = options.selection.selectPrevious();
-      if (!id) return false;
       options.navigation()?.markUserIntent('down');
-      options.navigation()?.scrollToId(id, { align: 'end' });
+      options.onGoToBottom();
       return true;
     },
   });


### PR DESCRIPTION
## Summary
Refactored the "go to latest message" hotkey implementation to use a dedicated `handleScrollToBottom` callback instead of inline logic, improving code organization and reusability.

## Key Changes
- Moved `handleScrollToBottom` function definition before its usage in `createChannelHotkeys` call
- Added `onGoToBottom` callback parameter to `CreateChannelHotkeysOptions` type
- Simplified the hotkey handler to call `options.onGoToBottom()` instead of directly selecting the previous message and scrolling to it
- Removed the inline message selection logic (`selectPrevious()`) from the hotkey handler, delegating this responsibility to the centralized handler

## Implementation Details
- The `handleScrollToBottom` function maintains the same logic: if there are previous pages to load, it resets the target message controller and queries; otherwise, it scrolls to the bottom
- The hotkey handler now focuses solely on clearing selection and marking user intent, with the actual scroll behavior delegated to the callback
- This change improves separation of concerns and makes the scroll-to-bottom logic reusable across different parts of the codebase

https://claude.ai/code/session_019dP4pUTTw21RX9Wtrkh276