### PR TITLE
Add Conventional Commits guidance to task prompt

### DIFF
--- a/js/app/packages/block-md/component/DispatchAgentMenu.tsx
+++ b/js/app/packages/block-md/component/DispatchAgentMenu.tsx
@@ -90,6 +90,10 @@ async function generateTaskPrompt(
   lines.push(
     'If you have the Macro MCP server enabled, use it to gather additional context about this task.'
   );
+  lines.push('');
+  lines.push(
+    'When committing, please follow the Conventional Commits spec (e.g. `feat: ...`, `fix: ...`, `chore: ...`) so the history stays consistent.'
+  );
 
   return lines.join('\n');
 }


### PR DESCRIPTION
## Summary
Updated the task prompt generation to include guidance on following the Conventional Commits specification when committing changes.

## Key Changes
- Added instruction to follow Conventional Commits spec (e.g., `feat: ...`, `fix: ...`, `chore: ...`) in the generated task prompt
- This ensures commit history remains consistent and follows standard conventions

## Implementation Details
- The new guidance is appended to the task prompt lines in `generateTaskPrompt()` function
- Includes a blank line separator before the new instruction for better readability
- The instruction is added after the existing Macro MCP server guidance

https://claude.ai/code/session_01BXPK9K5QbkPzVPTnw32MJ1