### PR TITLE
fix(channel): hide scroll-to-bottom while find bar is open

### DIFF
--- a/js/app/packages/channel/Channel/Channel.tsx
+++ b/js/app/packages/channel/Channel/Channel.tsx
@@ -484,10 +484,12 @@ export function Channel(props: ChannelProps) {
                         );
                       }}
                     </ThreadList>
-                    <ScrollToBottomOverlay
-                      scrollState={threadListScrollState}
-                      onScrollToBottom={handleScrollToBottom}
-                    />
+                    <Show when={!findBar.isOpen()}>
+                      <ScrollToBottomOverlay
+                        scrollState={threadListScrollState}
+                        onScrollToBottom={handleScrollToBottom}
+                      />
+                    </Show>
                   </div>
                 </Show>
               </div>


### PR DESCRIPTION
The find bar (top-right) and the scroll-to-bottom button (top-center) both render at the top of the message list and can visually collide. Hide the scroll-to-bottom button while the find bar is open.
