### PR TITLE
chg(calls): remove call again button from soup, make channel call button nicer

### DIFF
--- a/js/app/packages/channel/Call/ChannelCallButton.tsx
+++ b/js/app/packages/channel/Call/ChannelCallButton.tsx
@@ -4,7 +4,7 @@ import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import PhoneIcon from '@icon/wide-call.svg';
 import PhoneDisconnectIcon from '@icon/wide-call-disconnect.svg';
 import { useActiveCallQuery } from '@queries/call/call';
-import { Button } from '@ui';
+import { Button, cn } from '@ui';
 import { Show } from 'solid-js';
 import { useCall } from './use-call';
 
@@ -46,12 +46,14 @@ export function ChannelCallButton(props: { channelId: string }) {
       onClick={handleClick}
       disabled={isPending()}
       tooltip={tooltip()}
-      class={
-        isHighlighted()
-          ? 'px-1 bg-accent/20 hover:bg-accent/30 text-accent'
-          : 'px-1'
-      }
+      variant="base"
       size={isTouchDevice() ? 'icon-md' : 'icon-sm'}
+      depth={2}
+      class={cn(
+        'bg-surface',
+        isHighlighted() &&
+          'bg-accent/20 hover:bg-accent/30 text-accent border-accent/30'
+      )}
     >
       <Show when={call.isInThisChannel()} fallback={<PhoneIcon />}>
         <PhoneDisconnectIcon />

--- a/js/app/packages/channel/Call/ChannelCallButton.tsx
+++ b/js/app/packages/channel/Call/ChannelCallButton.tsx
@@ -1,6 +1,5 @@
 import { useChannelTab } from '@channel/Channel/ChannelTabContext';
 import { DEFAULT_CHANNEL_TAB } from '@channel/Channel/channel-tabs';
-import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import PhoneIcon from '@icon/wide-call.svg';
 import PhoneDisconnectIcon from '@icon/wide-call-disconnect.svg';
 import { useActiveCallQuery } from '@queries/call/call';
@@ -24,6 +23,12 @@ export function ChannelCallButton(props: { channelId: string }) {
   const tooltip = () => {
     if (call.isInThisChannel()) return 'Leave Call';
     if (isCallInProgress()) return 'Join Call';
+    return 'Start Call';
+  };
+
+  const label = () => {
+    if (call.isInThisChannel()) return 'Leave';
+    if (isCallInProgress()) return 'Join';
     return 'Call';
   };
 
@@ -47,7 +52,7 @@ export function ChannelCallButton(props: { channelId: string }) {
       disabled={isPending()}
       tooltip={tooltip()}
       variant="base"
-      size={isTouchDevice() ? 'icon-md' : 'icon-sm'}
+      size="sm"
       depth={2}
       class={cn(
         'bg-surface',
@@ -58,6 +63,7 @@ export function ChannelCallButton(props: { channelId: string }) {
       <Show when={call.isInThisChannel()} fallback={<PhoneIcon />}>
         <PhoneDisconnectIcon />
       </Show>
+      <span>{label()}</span>
     </Button>
   );
 }

--- a/js/app/packages/entity/src/composed/list-entity/wide-layout.tsx
+++ b/js/app/packages/entity/src/composed/list-entity/wide-layout.tsx
@@ -1,5 +1,4 @@
 import { useMaybeSoupView } from '@app/component/next-soup/soup-view/soup-view-context';
-import { CallAgainButton } from '@channel/Call/CallAgainButton';
 import { cn } from '@ui';
 import { Match, Show, Switch } from 'solid-js';
 import { AttendanceBadge, SharedBadge } from '../../components/Badges';
@@ -118,14 +117,6 @@ export function WideLayout(props: LayoutProps) {
         <Show when={isCallEntity(props.entity) && props.entity}>
           {(entity) => (
             <>
-              <span class="flex w-24 shrink-0 justify-end">
-                <Show when={!entity().isActive}>
-                  <CallAgainButton
-                    channelId={entity().channelId}
-                    class="opacity-0 group-hover/narrow:opacity-100 transition-opacity flex shrink-0 items-center gap-1 rounded-xs border border-edge-muted px-1.5 py-1 text-xs font-medium text-ink-muted hover:bg-hover hover:text-ink focus-visible:outline-none"
-                  />
-                </Show>
-              </span>
               <Show when={(soupView?.activeTab() ?? 'all') === 'all'}>
                 <AttendanceBadge attended={entity().attended} />
               </Show>


### PR DESCRIPTION
## Summary
This PR refactors the ChannelCallButton component's styling approach and removes the CallAgainButton from the wide layout entity list view.

## Key Changes
- **ChannelCallButton styling refactor**: 
  - Updated to use `variant="base"` and `depth={2}` props for consistent button styling
  - Migrated conditional class logic to use the `cn()` utility function
  - Changed base class from `px-1` to `bg-surface` for better visual consistency
  - Simplified the highlighted state styling with improved class organization

- **Removed CallAgainButton from WideLayout**:
  - Deleted the CallAgainButton component and its associated wrapper span from the entity list wide layout
  - Removed the conditional rendering logic that showed the button only when the call entity is inactive
  - Removed the unused import of CallAgainButton

## Implementation Details
The ChannelCallButton now uses a more declarative styling approach with the `cn()` utility, making the conditional styling more readable and maintainable. The button's base styling is now handled through component props (`variant` and `depth`) rather than inline classes, following better component composition patterns.

https://claude.ai/code/session_012QVotGtvV3WYKdbj4h3PuM