### PR TITLE
perf(soup): more enhancements

### DIFF
--- a/rust/cloud-storage/soup/src/outbound/pg_soup_repo/expanded/dynamic.rs
+++ b/rust/cloud-storage/soup/src/outbound/pg_soup_repo/expanded/dynamic.rs
@@ -487,6 +487,134 @@ fn build_notification_seen_clause(entity_id_sql: &str, entity_type: &str, seen: 
     )
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum NotificationPredicate {
+    Done(bool),
+    Seen(bool),
+}
+
+impl NotificationPredicate {
+    fn sql(self) -> &'static str {
+        match self {
+            NotificationPredicate::Done(true) => "un.done = true",
+            NotificationPredicate::Done(false) => "un.done = false",
+            NotificationPredicate::Seen(true) => "un.seen_at IS NOT NULL",
+            NotificationPredicate::Seen(false) => "un.seen_at IS NULL",
+        }
+    }
+}
+
+fn expr_contains_notification<T>(
+    expr: &Expr<T>,
+    notification_predicate: impl Fn(&T) -> Option<NotificationPredicate> + Copy,
+) -> bool {
+    match expr {
+        Expr::And(a, b) | Expr::Or(a, b) => {
+            expr_contains_notification(a, notification_predicate)
+                || expr_contains_notification(b, notification_predicate)
+        }
+        Expr::Not(a) => expr_contains_notification(a, notification_predicate),
+        Expr::Literal(lit) => notification_predicate(lit).is_some(),
+    }
+}
+
+fn clone_expr<T: Clone>(expr: &Expr<T>) -> Expr<T> {
+    match expr {
+        Expr::And(a, b) => Expr::and(clone_expr(a), clone_expr(b)),
+        Expr::Or(a, b) => Expr::or(clone_expr(a), clone_expr(b)),
+        Expr::Not(a) => Expr::is_not(clone_expr(a)),
+        Expr::Literal(lit) => Expr::val(lit.clone()),
+    }
+}
+
+fn strip_notification_conjunction<T: Clone>(
+    expr: &Expr<T>,
+    notification_predicate: impl Fn(&T) -> Option<NotificationPredicate> + Copy,
+) -> Option<(NotificationPredicate, Option<Expr<T>>)> {
+    match expr {
+        Expr::Literal(lit) => notification_predicate(lit).map(|pred| (pred, None)),
+        Expr::And(a, b) => {
+            let left = strip_notification_conjunction(a, notification_predicate);
+            let right = strip_notification_conjunction(b, notification_predicate);
+            match (left, right) {
+                (Some((left_pred, left_expr)), Some((right_pred, right_expr)))
+                    if left_pred == right_pred =>
+                {
+                    let stripped = match (left_expr, right_expr) {
+                        (Some(left), Some(right)) => Some(Expr::and(left, right)),
+                        (Some(expr), None) | (None, Some(expr)) => Some(expr),
+                        (None, None) => None,
+                    };
+                    Some((left_pred, stripped))
+                }
+                (Some((pred, left_expr)), None)
+                    if !expr_contains_notification(b, notification_predicate) =>
+                {
+                    let right_expr = clone_expr(b);
+                    Some((
+                        pred,
+                        Some(match left_expr {
+                            Some(left_expr) => Expr::and(left_expr, right_expr),
+                            None => right_expr,
+                        }),
+                    ))
+                }
+                (None, Some((pred, right_expr)))
+                    if !expr_contains_notification(a, notification_predicate) =>
+                {
+                    let left_expr = clone_expr(a);
+                    Some((
+                        pred,
+                        Some(match right_expr {
+                            Some(right_expr) => Expr::and(left_expr, right_expr),
+                            None => left_expr,
+                        }),
+                    ))
+                }
+                _ => None,
+            }
+        }
+        Expr::Or(_, _) | Expr::Not(_) => None,
+    }
+}
+
+fn build_notification_items_cte(
+    builder: &mut QueryBuilder<'_, Postgres>,
+    predicate: NotificationPredicate,
+    item_types: &[&str],
+) {
+    if item_types.is_empty() {
+        return;
+    }
+    let item_types = item_types
+        .iter()
+        .map(|item_type| format!("'{item_type}'"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    builder.push(format!(
+        r#"NotificationItems AS MATERIALIZED (
+        SELECT DISTINCT n.event_item_type, n.event_item_id
+        FROM user_notification un
+        JOIN notification n ON n.id = un.notification_id
+        WHERE un.user_id = $1
+          AND un.deleted_at IS NULL
+          AND {}
+          AND n.event_item_type IN ({item_types})
+    ),
+"#,
+        predicate.sql()
+    ));
+}
+
+fn build_notification_join(entity_alias: &str, item_type: &str) -> String {
+    format!(
+        r#"                INNER JOIN NotificationItems ni_{item_type}
+                    ON ni_{item_type}.event_item_type = '{item_type}'
+                    AND ni_{item_type}.event_item_id = {entity_alias}.id::text
+"#
+    )
+}
+
 fn build_task_include_cbm_atm_nc_clause() -> String {
     r#"(
         dt.sub_type = 'task'
@@ -778,6 +906,109 @@ fn push_union_separator(builder: &mut QueryBuilder<'_, Postgres>, needs_separato
     *needs_separator = true;
 }
 
+fn top_sort_expr(alias: &str, sort_method: SimpleSortMethod) -> String {
+    match sort_method {
+        SimpleSortMethod::ViewedAt => {
+            r#"COALESCE(uh."updatedAt", '1970-01-01 00:00:00+00')"#.to_string()
+        }
+        SimpleSortMethod::ViewedUpdated => {
+            format!(r#"COALESCE(uh."updatedAt", {alias}."updatedAt")"#)
+        }
+        SimpleSortMethod::CreatedAt => format!(r#"{alias}."createdAt""#),
+        SimpleSortMethod::UpdatedAt => format!(r#"{alias}."updatedAt""#),
+    }
+}
+
+fn top_needs_user_history(sort_method: SimpleSortMethod) -> bool {
+    matches!(
+        sort_method,
+        SimpleSortMethod::ViewedAt | SimpleSortMethod::ViewedUpdated
+    )
+}
+
+fn document_top_clause(sort_method: SimpleSortMethod) -> String {
+    format!(
+        r#"
+                SELECT
+                    'document'::text as item_type,
+                    d.id,
+                    {}::timestamptz as sort_ts
+                FROM AccessibleItems ai
+                INNER JOIN "Document" d ON d.id = ai.item_id AND ai.item_type = 'document'
+                LEFT JOIN document_sub_type dt ON dt.document_id = d.id
+"#,
+        top_sort_expr("d", sort_method)
+    )
+}
+
+fn document_top_where_clause(sort_method: SimpleSortMethod) -> &'static str {
+    if top_needs_user_history(sort_method) {
+        r#"
+                LEFT JOIN "UserHistory" uh ON uh."itemId" = d.id AND uh."itemType" = 'document' AND uh."userId" = $1
+                WHERE d."deletedAt" IS NULL
+"#
+    } else {
+        r#"
+                WHERE d."deletedAt" IS NULL
+"#
+    }
+}
+
+fn chat_top_clause(sort_method: SimpleSortMethod) -> String {
+    let user_history_join = if top_needs_user_history(sort_method) {
+        r#"                LEFT JOIN "UserHistory" uh ON uh."itemId" = c.id AND uh."itemType" = 'chat' AND uh."userId" = $1
+"#
+    } else {
+        ""
+    };
+    format!(
+        r#"
+                SELECT
+                    'chat'::text as item_type,
+                    c.id,
+                    {}::timestamptz as sort_ts
+                FROM AccessibleItems ai
+                INNER JOIN "Chat" c ON c.id = ai.item_id AND ai.item_type = 'chat'
+{}"#,
+        top_sort_expr("c", sort_method),
+        user_history_join
+    )
+}
+
+fn chat_top_where_clause() -> &'static str {
+    r#"                WHERE c."deletedAt" IS NULL
+"#
+}
+
+fn project_top_clause(sort_method: SimpleSortMethod) -> String {
+    let user_history_join = if top_needs_user_history(sort_method) {
+        r#"                LEFT JOIN "UserHistory" uh
+                    ON uh."itemId" = p.id
+                    AND uh."itemType" = 'project'
+                    AND uh."userId" = $1
+"#
+    } else {
+        ""
+    };
+    format!(
+        r#"
+                SELECT
+                    'project'::text as item_type,
+                    p.id,
+                    {}::timestamptz as sort_ts
+                FROM AccessibleItems ai
+                INNER JOIN "Project" p ON p.id = ai.item_id AND ai.item_type = 'project'
+{}"#,
+        top_sort_expr("p", sort_method),
+        user_history_join
+    )
+}
+
+fn project_top_where_clause() -> &'static str {
+    r#"                WHERE p."deletedAt" IS NULL
+"#
+}
+
 fn push_accessible_items_cte(
     builder: &mut QueryBuilder<'_, Postgres>,
     include_documents: bool,
@@ -847,7 +1078,11 @@ fn push_accessible_items_cte(
     ));
 }
 
-fn build_query(filter_ast: &EntityFilterAst, exclude_frecency: bool) -> QueryBuilder<'_, Postgres> {
+fn build_query(
+    filter_ast: &EntityFilterAst,
+    exclude_frecency: bool,
+    sort_method: SimpleSortMethod,
+) -> QueryBuilder<'_, Postgres> {
     let mut builder = sqlx::QueryBuilder::new(PREFIX);
 
     let include_documents = !document_filter_is_impossible(filter_ast.document_filter.as_deref())
@@ -866,12 +1101,87 @@ fn build_query(filter_ast: &EntityFilterAst, exclude_frecency: bool) -> QueryBui
             &[PropertyEntityType::Project],
         );
 
+    let document_notification = filter_ast.document_filter.as_deref().and_then(|expr| {
+        strip_notification_conjunction(expr, |lit| match lit {
+            DocumentLiteral::NotificationDone(done) => Some(NotificationPredicate::Done(*done)),
+            DocumentLiteral::NotificationSeen(seen) => Some(NotificationPredicate::Seen(*seen)),
+            _ => None,
+        })
+    });
+    let chat_notification = filter_ast.chat_filter.as_deref().and_then(|expr| {
+        strip_notification_conjunction(expr, |lit| match lit {
+            ChatLiteral::NotificationDone(done) => Some(NotificationPredicate::Done(*done)),
+            ChatLiteral::NotificationSeen(seen) => Some(NotificationPredicate::Seen(*seen)),
+            _ => None,
+        })
+    });
+    let project_notification = filter_ast.project_filter.as_deref().and_then(|expr| {
+        strip_notification_conjunction(expr, |lit| match lit {
+            ProjectLiteral::NotificationDone(done) => Some(NotificationPredicate::Done(*done)),
+            ProjectLiteral::NotificationSeen(seen) => Some(NotificationPredicate::Seen(*seen)),
+            _ => None,
+        })
+    });
+
+    let notification_predicates = [
+        document_notification.as_ref().map(|(pred, _)| *pred),
+        chat_notification.as_ref().map(|(pred, _)| *pred),
+        project_notification.as_ref().map(|(pred, _)| *pred),
+    ];
+    let optimized_notification_predicate = notification_predicates
+        .into_iter()
+        .flatten()
+        .try_fold(None, |acc, pred| match acc {
+            Some(acc) if acc != pred => None,
+            Some(acc) => Some(Some(acc)),
+            None => Some(Some(pred)),
+        })
+        .flatten();
+
+    let document_filter =
+        if optimized_notification_predicate.is_some() && document_notification.is_some() {
+            document_notification
+                .as_ref()
+                .and_then(|(_, expr)| expr.as_ref())
+        } else {
+            filter_ast.document_filter.as_deref()
+        };
+    let chat_filter = if optimized_notification_predicate.is_some() && chat_notification.is_some() {
+        chat_notification
+            .as_ref()
+            .and_then(|(_, expr)| expr.as_ref())
+    } else {
+        filter_ast.chat_filter.as_deref()
+    };
+    let project_filter =
+        if optimized_notification_predicate.is_some() && project_notification.is_some() {
+            project_notification
+                .as_ref()
+                .and_then(|(_, expr)| expr.as_ref())
+        } else {
+            filter_ast.project_filter.as_deref()
+        };
+
     push_accessible_items_cte(
         &mut builder,
         include_documents,
         include_chats,
         include_projects,
     );
+
+    if let Some(predicate) = optimized_notification_predicate {
+        let mut item_types = Vec::with_capacity(3);
+        if include_documents && document_notification.is_some() {
+            item_types.push("document");
+        }
+        if include_chats && chat_notification.is_some() {
+            item_types.push("chat");
+        }
+        if include_projects && project_notification.is_some() {
+            item_types.push("project");
+        }
+        build_notification_items_cte(&mut builder, predicate, &item_types);
+    }
 
     // TopItems CTE: lightweight id + sort_ts with filters, cursor, and limit
     builder.push("TopItems AS (");
@@ -882,12 +1192,15 @@ fn build_query(filter_ast: &EntityFilterAst, exclude_frecency: bool) -> QueryBui
     if include_documents {
         push_union_separator(&mut builder, &mut needs_separator);
         // Document top clause (lightweight)
-        builder.push(DOCUMENT_TOP_CLAUSE);
-        if document_filter_needs_task_property_joins(filter_ast.document_filter.as_deref()) {
+        builder.push(document_top_clause(sort_method));
+        if optimized_notification_predicate.is_some() && document_notification.is_some() {
+            builder.push(build_notification_join("d", "document"));
+        }
+        if document_filter_needs_task_property_joins(document_filter) {
             builder.push(DOCUMENT_TASK_PROPERTY_JOINS);
         }
-        builder.push(DOCUMENT_TOP_WHERE_CLAUSE);
-        builder.push(build_document_filter(filter_ast.document_filter.as_deref()));
+        builder.push(document_top_where_clause(sort_method));
+        builder.push(build_document_filter(document_filter));
         builder.push(build_properties_filter(
             filter_ast.properties_filter.as_deref(),
             "d.id",
@@ -897,8 +1210,12 @@ fn build_query(filter_ast: &EntityFilterAst, exclude_frecency: bool) -> QueryBui
     if include_chats {
         push_union_separator(&mut builder, &mut needs_separator);
         // Chat top clause (lightweight)
-        builder.push(CHAT_TOP_CLAUSE);
-        builder.push(build_chat_filter(filter_ast.chat_filter.as_deref()));
+        builder.push(chat_top_clause(sort_method));
+        if optimized_notification_predicate.is_some() && chat_notification.is_some() {
+            builder.push(build_notification_join("c", "chat"));
+        }
+        builder.push(chat_top_where_clause());
+        builder.push(build_chat_filter(chat_filter));
         builder.push(build_properties_filter(
             filter_ast.properties_filter.as_deref(),
             "c.id",
@@ -908,8 +1225,12 @@ fn build_query(filter_ast: &EntityFilterAst, exclude_frecency: bool) -> QueryBui
     if include_projects {
         push_union_separator(&mut builder, &mut needs_separator);
         // Project top clause (lightweight)
-        builder.push(PROJECT_TOP_CLAUSE);
-        builder.push(build_project_filter(filter_ast.project_filter.as_deref()));
+        builder.push(project_top_clause(sort_method));
+        if optimized_notification_predicate.is_some() && project_notification.is_some() {
+            builder.push(build_notification_join("p", "project"));
+        }
+        builder.push(project_top_where_clause());
+        builder.push(build_project_filter(project_filter));
         builder.push(build_properties_filter(
             filter_ast.properties_filter.as_deref(),
             "p.id",
@@ -1207,7 +1528,7 @@ pub(crate) async fn expanded_dynamic_cursor_soup(
     let assignees_property_id = SystemPropertyKey::ASSIGNEES_UUID;
     let completed_option_id = StatusOption::COMPLETED_UUID.to_string();
 
-    let mut items = build_query(cursor.filter(), exclude_frecency)
+    let mut items = build_query(cursor.filter(), exclude_frecency, *cursor.sort_method())
         .build()
         .bind(user_id.as_ref())
         .bind(sort_method_str)

--- a/rust/cloud-storage/soup/src/outbound/pg_soup_repo/expanded/dynamic.rs
+++ b/rust/cloud-storage/soup/src/outbound/pg_soup_repo/expanded/dynamic.rs
@@ -48,21 +48,6 @@ static PREFIX: &str = r#"
 
 // -- Lightweight top clauses: only id + sort_ts (plus filter-required joins) --
 
-static DOCUMENT_TOP_CLAUSE: &str = r#"
-                SELECT
-                    'document'::text as item_type,
-                    d.id,
-                    CASE $2
-                        WHEN 'viewed_updated' THEN COALESCE(uh."updatedAt", d."updatedAt")
-                        WHEN 'viewed_at' THEN COALESCE(uh."updatedAt", '1970-01-01 00:00:00+00')
-                        WHEN 'created_at' THEN d."createdAt"
-                        ELSE d."updatedAt"
-                    END::timestamptz as sort_ts
-                FROM AccessibleItems ai
-                INNER JOIN "Document" d ON d.id = ai.item_id AND ai.item_type = 'document'
-                LEFT JOIN document_sub_type dt ON dt.document_id = d.id
-"#;
-
 static DOCUMENT_TASK_PROPERTY_JOINS: &str = r#"
                 LEFT JOIN entity_properties ep_assignees
                     ON dt.sub_type = 'task'
@@ -79,41 +64,6 @@ static DOCUMENT_TASK_PROPERTY_JOINS: &str = r#"
 static DOCUMENT_TOP_WHERE_CLAUSE: &str = r#"
                 LEFT JOIN "UserHistory" uh ON uh."itemId" = d.id AND uh."itemType" = 'document' AND uh."userId" = $1
                 WHERE d."deletedAt" IS NULL
-"#;
-
-static CHAT_TOP_CLAUSE: &str = r#"
-                SELECT
-                    'chat'::text as item_type,
-                    c.id,
-                    CASE $2
-                        WHEN 'viewed_updated' THEN COALESCE(uh."updatedAt", c."updatedAt")
-                        WHEN 'viewed_at' THEN COALESCE(uh."updatedAt", '1970-01-01 00:00:00+00')
-                        WHEN 'created_at' THEN c."createdAt"
-                        ELSE c."updatedAt"
-                    END::timestamptz as sort_ts
-                FROM AccessibleItems ai
-                INNER JOIN "Chat" c ON c.id = ai.item_id AND ai.item_type = 'chat'
-                LEFT JOIN "UserHistory" uh ON uh."itemId" = c.id AND uh."itemType" = 'chat' AND uh."userId" = $1
-                WHERE c."deletedAt" IS NULL
-"#;
-
-static PROJECT_TOP_CLAUSE: &str = r#"
-                SELECT
-                    'project'::text as item_type,
-                    p.id,
-                    CASE $2
-                        WHEN 'viewed_updated' THEN COALESCE(uh."updatedAt", p."updatedAt")
-                        WHEN 'viewed_at' THEN COALESCE(uh."updatedAt", '1970-01-01 00:00:00+00')
-                        WHEN 'created_at' THEN p."createdAt"
-                        ELSE p."updatedAt"
-                    END::timestamptz as sort_ts
-                FROM AccessibleItems ai
-                INNER JOIN "Project" p ON p.id = ai.item_id AND ai.item_type = 'project'
-                LEFT JOIN "UserHistory" uh
-                    ON uh."itemId" = p.id
-                    AND uh."itemType" = 'project'
-                    AND uh."userId" = $1
-                WHERE p."deletedAt" IS NULL
 "#;
 
 // -- Grouped top clauses: include project_id for grouping support --

--- a/rust/cloud-storage/soup/src/outbound/pg_soup_repo/expanded/tests.rs
+++ b/rust/cloud-storage/soup/src/outbound/pg_soup_repo/expanded/tests.rs
@@ -6108,3 +6108,272 @@ async fn test_date_filter_project_updated_at_range(db: PgPool) -> anyhow::Result
     );
     Ok(())
 }
+
+async fn insert_notification(
+    db: &PgPool,
+    notification_id: &str,
+    user_id: &str,
+    item_type: &str,
+    item_id: &str,
+    done: bool,
+    seen: bool,
+) -> anyhow::Result<()> {
+    sqlx::query(
+        r#"
+        INSERT INTO notification (
+            id,
+            notification_event_type,
+            event_item_id,
+            event_item_type,
+            service_sender,
+            created_at,
+            metadata
+        )
+        VALUES ($1::uuid, 'test', $2, $3, 'test', NOW(), '{}')
+        "#,
+    )
+    .bind(notification_id)
+    .bind(item_id)
+    .bind(item_type)
+    .execute(db)
+    .await?;
+
+    sqlx::query(
+        r#"
+        INSERT INTO user_notification (
+            user_id,
+            notification_id,
+            done,
+            seen_at,
+            deleted_at
+        )
+        VALUES ($1, $2::uuid, $3, CASE WHEN $4 THEN NOW() ELSE NULL END, NULL)
+        "#,
+    )
+    .bind(user_id)
+    .bind(notification_id)
+    .bind(done)
+    .bind(seen)
+    .execute(db)
+    .await?;
+
+    Ok(())
+}
+
+async fn run_notification_filter(
+    db: &PgPool,
+    ast: EntityFilterAst,
+) -> anyhow::Result<HashSet<Uuid>> {
+    let user_id = MacroUserIdStr::parse_from_str("macro|user-1@test.com").unwrap();
+    let items = expanded_dynamic_cursor_soup(
+        db,
+        ExpandedDynamicCursorArgs {
+            user_id: user_id.copied(),
+            limit: 100,
+            cursor: Query::Sort(SimpleSortMethod::UpdatedAt, ast),
+            exclude_frecency: false,
+        },
+    )
+    .await?;
+
+    Ok(items.into_iter().map(|item| item.id()).collect())
+}
+
+#[sqlx::test(
+    fixtures(
+        path = "../../../../../macro_db_client/fixtures",
+        scripts("entity_filter_tests")
+    ),
+    migrator = "MACRO_DB_MIGRATIONS"
+)]
+async fn test_notification_optimization_preserves_access_control(db: PgPool) -> anyhow::Result<()> {
+    let user_id = "macro|user-1@test.com";
+
+    // Accessible items from entity_filter_tests.
+    let accessible_doc = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+    let accessible_chat = "a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1";
+    let accessible_project = "11111111-1111-1111-1111-111111111111";
+
+    // Existing fixture rows intentionally not present in entity_access for user-1.
+    let inaccessible_doc = "ffffffff-ffff-ffff-ffff-ffffffffffff";
+    let inaccessible_chat = "e5e5e5e5-e5e5-e5e5-e5e5-e5e5e5e5e5e5";
+    let inaccessible_project = "55555555-5555-5555-5555-555555555555";
+
+    for (notification_id, item_type, item_id) in [
+        (
+            "10000000-0000-0000-0000-000000000001",
+            "document",
+            accessible_doc,
+        ),
+        (
+            "10000000-0000-0000-0000-000000000002",
+            "chat",
+            accessible_chat,
+        ),
+        (
+            "10000000-0000-0000-0000-000000000003",
+            "project",
+            accessible_project,
+        ),
+        (
+            "10000000-0000-0000-0000-000000000004",
+            "document",
+            inaccessible_doc,
+        ),
+        (
+            "10000000-0000-0000-0000-000000000005",
+            "chat",
+            inaccessible_chat,
+        ),
+        (
+            "10000000-0000-0000-0000-000000000006",
+            "project",
+            inaccessible_project,
+        ),
+    ] {
+        insert_notification(
+            &db,
+            notification_id,
+            user_id,
+            item_type,
+            item_id,
+            false,
+            false,
+        )
+        .await?;
+    }
+
+    let ast = EntityFilterAst {
+        document_filter: Some(Arc::new(Expr::Literal(DocumentLiteral::NotificationDone(
+            false,
+        )))),
+        chat_filter: Some(Arc::new(Expr::Literal(ChatLiteral::NotificationDone(
+            false,
+        )))),
+        project_filter: Some(Arc::new(Expr::Literal(ProjectLiteral::NotificationDone(
+            false,
+        )))),
+        ..mock_empty_ast()
+    };
+
+    let ids = run_notification_filter(&db, ast).await?;
+
+    assert!(ids.contains(&Uuid::parse_str(accessible_doc)?));
+    assert!(ids.contains(&Uuid::parse_str(accessible_chat)?));
+    assert!(ids.contains(&Uuid::parse_str(accessible_project)?));
+
+    assert!(!ids.contains(&Uuid::parse_str(inaccessible_doc)?));
+    assert!(!ids.contains(&Uuid::parse_str(inaccessible_chat)?));
+    assert!(!ids.contains(&Uuid::parse_str(inaccessible_project)?));
+
+    Ok(())
+}
+
+#[sqlx::test(
+    fixtures(
+        path = "../../../../../macro_db_client/fixtures",
+        scripts("entity_filter_tests")
+    ),
+    migrator = "MACRO_DB_MIGRATIONS"
+)]
+async fn test_optimized_notification_filter_matches_unoptimized_equivalent(
+    db: PgPool,
+) -> anyhow::Result<()> {
+    let user_id = "macro|user-1@test.com";
+    for (notification_id, item_type, item_id) in [
+        (
+            "20000000-0000-0000-0000-000000000001",
+            "document",
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        ),
+        (
+            "20000000-0000-0000-0000-000000000002",
+            "document",
+            "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+        ),
+        (
+            "20000000-0000-0000-0000-000000000003",
+            "chat",
+            "a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1",
+        ),
+        (
+            "20000000-0000-0000-0000-000000000004",
+            "project",
+            "11111111-1111-1111-1111-111111111111",
+        ),
+    ] {
+        insert_notification(
+            &db,
+            notification_id,
+            user_id,
+            item_type,
+            item_id,
+            false,
+            false,
+        )
+        .await?;
+    }
+
+    let optimized = EntityFilterAst {
+        document_filter: Some(Arc::new(Expr::Literal(DocumentLiteral::NotificationDone(
+            false,
+        )))),
+        chat_filter: Some(Arc::new(Expr::Literal(ChatLiteral::NotificationDone(
+            false,
+        )))),
+        project_filter: Some(Arc::new(Expr::Literal(ProjectLiteral::NotificationDone(
+            false,
+        )))),
+        ..mock_empty_ast()
+    };
+
+    // This is logically equivalent to NotificationDone(false), but because the
+    // notification predicate appears under OR it intentionally stays on the old
+    // correlated-EXISTS path.
+    let unoptimized_doc = Expr::Or(
+        Box::new(Expr::Literal(DocumentLiteral::NotificationDone(false))),
+        Box::new(Expr::And(
+            Box::new(Expr::Literal(DocumentLiteral::NotificationDone(false))),
+            Box::new(Expr::Literal(DocumentLiteral::UpdatedAt(
+                DateLiteral::GreaterThan(
+                    chrono::DateTime::parse_from_rfc3339("2000-01-01T00:00:00Z")?.into(),
+                ),
+            ))),
+        )),
+    );
+    let unoptimized_chat = Expr::Or(
+        Box::new(Expr::Literal(ChatLiteral::NotificationDone(false))),
+        Box::new(Expr::And(
+            Box::new(Expr::Literal(ChatLiteral::NotificationDone(false))),
+            Box::new(Expr::Literal(ChatLiteral::UpdatedAt(
+                DateLiteral::GreaterThan(
+                    chrono::DateTime::parse_from_rfc3339("2000-01-01T00:00:00Z")?.into(),
+                ),
+            ))),
+        )),
+    );
+    let unoptimized_project = Expr::Or(
+        Box::new(Expr::Literal(ProjectLiteral::NotificationDone(false))),
+        Box::new(Expr::And(
+            Box::new(Expr::Literal(ProjectLiteral::NotificationDone(false))),
+            Box::new(Expr::Literal(ProjectLiteral::UpdatedAt(
+                DateLiteral::GreaterThan(
+                    chrono::DateTime::parse_from_rfc3339("2000-01-01T00:00:00Z")?.into(),
+                ),
+            ))),
+        )),
+    );
+    let unoptimized = EntityFilterAst {
+        document_filter: Some(Arc::new(unoptimized_doc)),
+        chat_filter: Some(Arc::new(unoptimized_chat)),
+        project_filter: Some(Arc::new(unoptimized_project)),
+        ..mock_empty_ast()
+    };
+
+    let optimized_ids = run_notification_filter(&db, optimized).await?;
+    let unoptimized_ids = run_notification_filter(&db, unoptimized).await?;
+
+    assert_eq!(optimized_ids, unoptimized_ids);
+
+    Ok(())
+}


### PR DESCRIPTION
This pr adds some more branch pruning optimizations which can skip expensive joins if they are not required for the query

There are tests for the changed behaviour and to prevent regressions

- **perf(soup): optimize dynamic query notification and sort paths**
- **test(soup): cover notification query optimization semantics**
