### PR TITLE
fix(calls): add breakpoints to call control layout

### DIFF
--- a/js/app/packages/channel/Call/CallOverlay.tsx
+++ b/js/app/packages/channel/Call/CallOverlay.tsx
@@ -1,3 +1,4 @@
+import { useSplitPanel } from '@app/component/split-layout/layoutUtils';
 import { UserIcon } from '@core/component/UserIcon';
 import { useAuthor, useUserId } from '@core/context/user';
 import { tryMacroId, useDisplayName } from '@core/user';
@@ -9,6 +10,10 @@ import { For, type JSXElement, Show } from 'solid-js';
 import { useCallContext } from './CallContext';
 import { CallControls } from './CallControls/CallControls';
 import { TrackView } from './TrackView';
+import {
+  CALL_PANEL_MEDIUM_NARROW_PX,
+  CALL_PANEL_VERY_NARROW_PX,
+} from './call-panel-breakpoints';
 
 function VideoTag(props: {
   children: JSXElement;
@@ -201,6 +206,11 @@ export function CallOverlay(props: { onLeave: () => void }) {
     callCtx.setSharedWithTeam(newValue);
   };
 
+  const splitPanel = useSplitPanel();
+  const panelWidth = () => splitPanel?.panelSize.width ?? Infinity;
+  const isMediumNarrow = () => panelWidth() < CALL_PANEL_MEDIUM_NARROW_PX;
+  const isVeryNarrow = () => panelWidth() < CALL_PANEL_VERY_NARROW_PX;
+
   const participants = () =>
     Array.from(callCtx.remoteParticipants().values()).filter((p) => !p.isAgent);
 
@@ -313,39 +323,55 @@ export function CallOverlay(props: { onLeave: () => void }) {
       </div>
 
       {/* Controls bar */}
-      <div class="relative flex items-center justify-center p-3 pt-1 bg-surface-1">
-        <CallControls onLeave={props.onLeave} />
-        <div class="absolute left-3 flex items-center gap-2">
-          <span class="text-xs text-ink-muted whitespace-nowrap inline-grid">
-            <span class="col-start-1 row-start-1 invisible" aria-hidden>
-              Shared with team
-            </span>
-            <span class="col-start-1 row-start-1">
-              {callCtx.isSharedWithTeam()
-                ? 'Shared with team'
-                : 'Share with team'}
-            </span>
-          </span>
-          <Tooltip
-            placement="top"
-            label="When on, all team members can view and search this call's transcript and AI summary."
+      <div
+        class={cn(
+          'flex items-center p-3 pt-1 bg-surface-1',
+          !isMediumNarrow() && 'relative justify-center',
+          isMediumNarrow() && !isVeryNarrow() && 'justify-between',
+          isVeryNarrow() && 'justify-center'
+        )}
+      >
+        <Show when={!isVeryNarrow()}>
+          <div
+            class={cn(
+              'flex items-center gap-2',
+              !isMediumNarrow() && 'absolute left-3'
+            )}
           >
-            <div class="flex items-center gap-1">
-              <ShareNetwork
-                class={cn(
-                  'size-3 shrink-0',
-                  callCtx.isSharedWithTeam() ? 'text-ink' : 'text-ink-muted'
-                )}
-                aria-hidden
-              />
-              <ToggleSwitch
-                onChange={() => void handleToggleShareWithTeam()}
-                checked={callCtx.isSharedWithTeam()}
-                disabled={isConnecting()}
-              />
-            </div>
-          </Tooltip>
-        </div>
+            <Show when={!isMediumNarrow()}>
+              <span class="text-xs text-ink-muted whitespace-nowrap inline-grid">
+                <span class="col-start-1 row-start-1 invisible" aria-hidden>
+                  Shared with team
+                </span>
+                <span class="col-start-1 row-start-1">
+                  {callCtx.isSharedWithTeam()
+                    ? 'Shared with team'
+                    : 'Share with team'}
+                </span>
+              </span>
+            </Show>
+            <Tooltip
+              placement="top"
+              label="When on, all team members can view and search this call's transcript and AI summary."
+            >
+              <div class="flex items-center gap-1">
+                <ShareNetwork
+                  class={cn(
+                    'size-3 shrink-0',
+                    callCtx.isSharedWithTeam() ? 'text-ink' : 'text-ink-muted'
+                  )}
+                  aria-hidden
+                />
+                <ToggleSwitch
+                  onChange={() => void handleToggleShareWithTeam()}
+                  checked={callCtx.isSharedWithTeam()}
+                  disabled={isConnecting()}
+                />
+              </div>
+            </Tooltip>
+          </div>
+        </Show>
+        <CallControls onLeave={props.onLeave} />
       </div>
     </div>
   );

--- a/js/app/packages/channel/Call/CallOverlay.tsx
+++ b/js/app/packages/channel/Call/CallOverlay.tsx
@@ -9,11 +9,11 @@ import { type RemoteParticipant, Track } from 'livekit-client';
 import { For, type JSXElement, Show } from 'solid-js';
 import { useCallContext } from './CallContext';
 import { CallControls } from './CallControls/CallControls';
-import { TrackView } from './TrackView';
 import {
   CALL_PANEL_MEDIUM_NARROW_PX,
   CALL_PANEL_VERY_NARROW_PX,
 } from './call-panel-breakpoints';
+import { TrackView } from './TrackView';
 
 function VideoTag(props: {
   children: JSXElement;

--- a/js/app/packages/channel/Call/ChannelCallButton.tsx
+++ b/js/app/packages/channel/Call/ChannelCallButton.tsx
@@ -1,3 +1,4 @@
+import { useSplitPanel } from '@app/component/split-layout/layoutUtils';
 import { useChannelTab } from '@channel/Channel/ChannelTabContext';
 import { DEFAULT_CHANNEL_TAB } from '@channel/Channel/channel-tabs';
 import PhoneIcon from '@icon/wide-call.svg';
@@ -6,6 +7,7 @@ import { useActiveCallQuery } from '@queries/call/call';
 import { Button, cn } from '@ui';
 import { Show } from 'solid-js';
 import { useCall } from './use-call';
+import { CALL_PANEL_VERY_NARROW_PX } from './call-panel-breakpoints';
 
 export function ChannelCallButton(props: { channelId: string }) {
   const { setActiveTab } = useChannelTab();
@@ -13,6 +15,9 @@ export function ChannelCallButton(props: { channelId: string }) {
     onJoin: () => setActiveTab('call'),
     onLeave: () => setActiveTab(DEFAULT_CHANNEL_TAB),
   });
+  const splitPanel = useSplitPanel();
+  const isVeryNarrow = () =>
+    (splitPanel?.panelSize.width ?? Infinity) < CALL_PANEL_VERY_NARROW_PX;
 
   const activeCallQuery = useActiveCallQuery(() => props.channelId);
   const isCallInProgress = () => !!activeCallQuery.data;
@@ -63,7 +68,9 @@ export function ChannelCallButton(props: { channelId: string }) {
       <Show when={call.isInThisChannel()} fallback={<PhoneIcon />}>
         <PhoneDisconnectIcon />
       </Show>
-      <span>{label()}</span>
+      <Show when={!(isVeryNarrow() && call.isInThisChannel())}>
+        <span>{label()}</span>
+      </Show>
     </Button>
   );
 }

--- a/js/app/packages/channel/Call/ChannelCallButton.tsx
+++ b/js/app/packages/channel/Call/ChannelCallButton.tsx
@@ -6,8 +6,8 @@ import PhoneDisconnectIcon from '@icon/wide-call-disconnect.svg';
 import { useActiveCallQuery } from '@queries/call/call';
 import { Button, cn } from '@ui';
 import { Show } from 'solid-js';
-import { useCall } from './use-call';
 import { CALL_PANEL_VERY_NARROW_PX } from './call-panel-breakpoints';
+import { useCall } from './use-call';
 
 export function ChannelCallButton(props: { channelId: string }) {
   const { setActiveTab } = useChannelTab();

--- a/js/app/packages/channel/Call/call-panel-breakpoints.ts
+++ b/js/app/packages/channel/Call/call-panel-breakpoints.ts
@@ -1,0 +1,2 @@
+export const CALL_PANEL_MEDIUM_NARROW_PX = 720;
+export const CALL_PANEL_VERY_NARROW_PX = 420;


### PR DESCRIPTION
Call control button layout clutters on narrow splits. Create 2 call overlay specific breakpoints to simplify UI based on split width. Remove descriptive labels and share toggle depending on space.