### PR TITLE
Unify unread channel row styling with sidebar nav items

### DIFF
--- a/js/app/packages/app/component/app-sidebar/channels-unread-widget.tsx
+++ b/js/app/packages/app/component/app-sidebar/channels-unread-widget.tsx
@@ -188,7 +188,7 @@ function ChannelGroupItem(props: {
   const ButtonContent = () => (
     <Button
       class={cn(
-        'flex items-center cursor-default rounded-xs',
+        'flex items-center cursor-default rounded-sm not-disabled:hover:bg-ink/3',
         isSlim() ? 'justify-center size-8' : 'justify-start gap-3 size-full h-8'
       )}
       draggable={false}


### PR DESCRIPTION
### Motivation
- Make the unread channel rows in the sidebar visually match the top-nav/folder items by unifying the corner radius and hover background treatment.

### Description
- Updated `js/app/packages/app/component/app-sidebar/channels-unread-widget.tsx` by changing the unread row button class from `"flex items-center cursor-default rounded-xs"` to `"flex items-center cursor-default rounded-sm not-disabled:hover:bg-ink/3"` so the rows use `rounded-sm` and the same hover background as the top nav items.

### Testing
- Ran the TypeScript check with `bun run check` in the `js/app` package which failed in this environment due to missing type definition packages (`@types/facebook-pixel`, `@types/gtag.js`, `vite/client`, etc.), and the failures are unrelated to this styling-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ca84f34e0832495d48e633bcb3c1b)