### PR TITLE
Move settings tabs into sidebar; consolidate Account/Team and Mobile/MCP panels

### DIFF
--- a/js/app/packages/app/component/app-sidebar/sidebar.tsx
+++ b/js/app/packages/app/component/app-sidebar/sidebar.tsx
@@ -441,7 +441,7 @@ const CALLS_LINK: SidebarItem = {
 export const AppSidebar = (props: AppSidebarProps) => {
   const analytics = useAnalytics();
   const layout = useSplitLayout();
-  const { toggleSettings } = useSettingsState();
+  const { openSettings } = useSettingsState();
   const notificationSettings = useNotificationSettings();
   const callCtx = useCallContextOptional();
 
@@ -492,9 +492,6 @@ export const AppSidebar = (props: AppSidebarProps) => {
     }
     setCreateMenuOpen((p) => !p);
   };
-
-  const canCreateNewSplit = () =>
-    globalSplitManager()?.canAppendSplit() ?? true;
 
   const handleNewSplitClick = () => {
     const manager = globalSplitManager();
@@ -582,15 +579,19 @@ export const AppSidebar = (props: AppSidebarProps) => {
         <hr class="border-transparent" />
       </div>
 
-      <div class="w-full px-2 my-[4.5px]">
-        <SidebarActionButton
-          label="Create"
-          hotkeyToken={TOKENS.global.createCommand}
-          isSlim={isSlim}
-          onClick={handleCreateClick}
-          icon={() => <AnimatedPlusIcon class="size-4" />}
-        />
-      </div>
+      <Show when={isExpanded()}>
+        <div class="w-full px-2 my-[4.5px] flex items-center justify-end gap-1">
+          <Button label="New Split" onClick={handleNewSplitClick} class="p-1">
+            <AnimatedNewSplitIcon class="size-4" />
+          </Button>
+          <Button label="Command" hotkey={TOKENS.global.commandMenu} onClick={handleCommandPaletteClick} class="p-1">
+            <AnimatedCommandIcon class="size-4" />
+          </Button>
+          <Button label="Create" hotkey={TOKENS.global.createCommand} onClick={handleCreateClick} class="p-1">
+            <AnimatedPlusIcon class="size-4" />
+          </Button>
+        </div>
+      </Show>
 
       <div class="px-2">
         <hr class="border-transparent mb-2" />
@@ -640,43 +641,28 @@ export const AppSidebar = (props: AppSidebarProps) => {
           />
         </Show>
         <SidebarActionButton
-          label="New Split"
-          hotkeyToken={TOKENS.global.createNewSplit}
-          isSlim={isSlim}
-          onClick={handleNewSplitClick}
-          disabled={() => !canCreateNewSplit()}
-          icon={AnimatedNewSplitIcon}
-        />
-
-        <SidebarActionButton
-          label="Command"
-          hotkeyToken={TOKENS.global.commandMenu}
-          isSlim={isSlim}
-          onClick={handleCommandPaletteClick}
-          icon={AnimatedCommandIcon}
-        />
-
-        <SidebarActionButton
-          onClick={(event) => {
-            if (event?.shiftKey) {
-              if (!(globalSplitManager()?.canAppendSplit() ?? true)) return;
-              analytics.track('split_created', { from: 'sidebar' });
-              layout.openWithSplit(
-                { type: 'component', id: 'settings' },
-                {
-                  referredFrom: 'sidebar',
-                  allowDuplicate: true,
-                  preferNewSplit: true,
-                  mergeHistory: false,
-                }
-              );
-              return;
-            }
-            toggleSettings();
-          }}
-          hotkeyToken={TOKENS.global.toggleSettings}
+          onClick={() => openSettings('Mobile & MCPs')}
           icon={AnimatedGearIcon}
-          label="Settings"
+          label="Mobile & MCPs"
+          isSlim={isSlim}
+        />
+        <SidebarActionButton
+          onClick={() => openSettings('Account & Team')}
+          icon={AnimatedGearIcon}
+          label="Account & Team"
+          isSlim={isSlim}
+        />
+        <SidebarActionButton
+          onClick={() => openSettings('Appearance')}
+          icon={AnimatedGearIcon}
+          label="Appearance"
+          isSlim={isSlim}
+        />
+        <SidebarActionButton
+          hotkeyToken={TOKENS.global.toggleSettings}
+          onClick={() => openSettings('Keyboard Shortcuts')}
+          icon={AnimatedGearIcon}
+          label="Keyboard Shortcuts"
           isSlim={isSlim}
         />
       </div>

--- a/js/app/packages/app/component/settings/Settings.tsx
+++ b/js/app/packages/app/component/settings/Settings.tsx
@@ -7,15 +7,12 @@ import { useFeatureFlag } from '@app/lib/analytics/posthog';
 import { MobileApp } from './MobileApp';
 import { Agent } from './Agent';
 import { Appearance } from './Appearance';
-import { TabsInset } from '@core/component/TabsInset';
-import { TabsInsetDropdown } from '@core/component/TabsInsetDropdown';
 import { Account } from './Account';
 import { Shortcuts } from './Shortcuts';
 import { Team } from './Team';
 import { registerHotkey, useHotkeyDOMScope } from '@core/hotkey/hotkeys';
 import type { ValidHotkey } from '@core/hotkey/types';
 import { SplitHeaderLeft, SplitHeaderRight } from '../split-layout/components/SplitHeader';
-import { CollapsibleHeaderItem } from '../split-layout/components/CollapsibleHeaderItem';
 import { SettingsButton } from './SettingsButton';
 import { isTouchDevice } from '@core/mobile/isTouchDevice';
 
@@ -57,13 +54,13 @@ export function SettingsPanel(props: SettingsPanelProps) {
 
   function settingsTabs() {
     const tabs: { value: string; label: string }[] = [
+      { value: 'Keyboard Shortcuts', label: 'Keyboard Shortcuts' },
       { value: 'Appearance', label: 'Appearance' },
-      { value: 'Account', label: 'Account' },
+      { value: 'Account & Team', label: 'Account & Team' },
     ];
-    if (teamsFlag().enabled) { tabs.push({ value: 'Team', label: 'Team' }) }
-    tabs.push({ value: 'Shortcuts', label: 'Shortcuts' });
-    if (ENABLE_APP_STORE_QR_CODE && !isNativeMobilePlatform()) { tabs.push({ value: 'Mobile App', label: 'App' }) }
-    if (!isNativeMobilePlatform()) { tabs.push({ value: 'Agent', label: 'Agent' }) }
+    if (ENABLE_APP_STORE_QR_CODE || !isNativeMobilePlatform()) {
+      tabs.push({ value: 'Mobile & MCPs', label: 'Mobile & MCPs' });
+    }
     if (isNativeMobilePlatform() && DEV_MODE_ENV) { tabs.push({ value: 'Mobile', label: 'Mobile Dev Tools' }) }
     return tabs;
   }
@@ -157,19 +154,6 @@ export function SettingsPanel(props: SettingsPanelProps) {
     }
   }
 
-  function BottomTabs() {
-    return (
-    <div class="bg-surface border-t border-edge-muted h-11 shrink-0 px-1 flex items-center">
-      <TabsInset
-        list={settingsTabs()}
-        value={activeTabId()}
-        defaultValue="Appearance"
-        onChange={handleTabChange}
-      />
-    </div>
-    );
-  }
-
   return (
     <div
       class="size-full flex flex-col outline-none"
@@ -182,62 +166,38 @@ export function SettingsPanel(props: SettingsPanelProps) {
           <h1 class="font-semibold text-ink select-none text-sm shrink-0">
             Settings
           </h1>
-          <Show when={!isMobile()}>
-            <CollapsibleHeaderItem
-              id="settings-tabs"
-              priority={1}
-              containerClass="h-full"
-              expanded={() => (
-                <TabsInset
-                  list={settingsTabs()}
-                  value={activeTabId()}
-                  defaultValue="Appearance"
-                  onChange={handleTabChange}
-                />
-              )}
-              collapsed={() => (
-                <TabsInsetDropdown
-                  list={settingsTabs()}
-                  value={activeTabId()}
-                  defaultValue="Appearance"
-                  onChange={handleTabChange}
-                />
-              )}
-            />
-          </Show>
         </div>
       </SplitHeaderLeft>
 
       <div class="relative grow min-h-1 overflow-auto">
-        <Show when={activeTabId() === 'Account'}>
+        <Show when={activeTabId() === 'Account & Team'}>
           <Suspense>
-            <Account />
+            <div class="flex flex-col gap-4">
+              <Account />
+              <Show when={teamsFlag().enabled}>
+                <Team />
+              </Show>
+            </div>
           </Suspense>
         </Show>
 
         <Show when={activeTabId() === 'Appearance'}>
           <Appearance />
         </Show>
-        <Show when={activeTabId() === 'Shortcuts' && !isTouchDevice()}>
+        <Show when={activeTabId() === 'Keyboard Shortcuts' && !isTouchDevice()}>
           <Shortcuts />
         </Show>
-        <Show when={activeTabId() === 'Team' && teamsFlag().enabled}>
-          <Suspense>
-            <Team />
-          </Suspense>
-        </Show>
-        <Show when={activeTabId() === 'Mobile App' && ENABLE_APP_STORE_QR_CODE && !isNativeMobilePlatform()}>
-          <MobileApp />
-        </Show>
-        <Show when={activeTabId() === 'Agent' && !isNativeMobilePlatform()}>
-          <Agent />
+        <Show when={activeTabId() === 'Mobile & MCPs'}>
+          <div class="flex flex-col gap-4">
+            <Show when={ENABLE_APP_STORE_QR_CODE && !isNativeMobilePlatform()}>
+              <MobileApp />
+            </Show>
+            <Show when={!isNativeMobilePlatform()}>
+              <Agent />
+            </Show>
+          </div>
         </Show>
       </div>
-
-      <Show when={isMobile()}>
-        <BottomTabs />
-      </Show>
     </div>
   );
 }
-

--- a/js/app/packages/core/constant/SettingsState.tsx
+++ b/js/app/packages/core/constant/SettingsState.tsx
@@ -3,6 +3,9 @@ import { globalSplitManager } from '@app/signal/splitLayout';
 import { createMemo, createSignal } from 'solid-js';
 
 export type SettingsTab =
+  | 'Keyboard Shortcuts'
+  | 'Account & Team'
+  | 'Mobile & MCPs'
   | 'Account'
   | 'Subscription'
   | 'Organization'
@@ -16,7 +19,7 @@ export type SettingsTab =
   | 'Team';
 
 export const [activeTabId, setActiveTabId] =
-  createSignal<SettingsTab>('Appearance');
+  createSignal<SettingsTab>('Keyboard Shortcuts');
 
 export type AgentSettingsSubTab = 'connectors' | 'mcp_server';
 export const [agentSettingsSubTab, setAgentSettingsSubTab] =


### PR DESCRIPTION
### Motivation
- Improve discoverability of settings by surfacing `Keyboard Shortcuts`, `Appearance`, `Account & Team`, and `Mobile & MCPs` directly in the desktop sidebar footer. 
- Combine related settings (Account+Team and Mobile App+MCP/Agent) into single panels to reduce confusion and duplicates. 
- Replace the top/bottom settings tab strip with explicit sidebar entries and move small utility actions into icon-only controls near the top of the expanded sidebar for compactness.

### Description
- Added new settings tab labels and default: updated `SettingsTab` in `js/app/packages/core/constant/SettingsState.tsx` and set the default active tab to `Keyboard Shortcuts`. 
- Rewrote `SettingsPanel` (`js/app/packages/app/component/settings/Settings.tsx`) to: present `Account & Team` as a merged view (renders `Account` plus `Team` when enabled), present `Mobile & MCPs` as a merged view (renders `MobileApp` and `Agent` where applicable), include `Keyboard Shortcuts` as a first item, and removed the collapsible top/bottom tab strip UI so navigation is now driven by sidebar entries. 
- Updated the desktop `AppSidebar` (`js/app/packages/app/component/app-sidebar/sidebar.tsx`) to replace the single Settings action with four explicit `SidebarActionButton` entries that open Settings directly to `Mobile & MCPs`, `Account & Team`, `Appearance`, and `Keyboard Shortcuts`, and moved the `New Split`, `Command`, and `Create` controls to compact icon-only buttons near the top that are only shown when the sidebar is expanded. 
- Preserved conditional rendering behavior for `Team` (feature-flag gated) and `MobileApp`/`Agent` based on platform and feature flags.

### Testing
- Attempted type check with `cd js/app && bun run check`, which failed due to missing type definition packages in the environment (errors for `@types/facebook-pixel`, `vite/client`, etc.), so a full compile could not be validated. 
- Attempted lint with `cd js/app && bun run lint`, which failed due to registry/network resolution error while resolving `biome` (`GET https://registry.npmjs.org/biome - 403`), so automated linting could not be completed. 
- No runtime or unit test failures were observed locally because automated checks could not finish due to the environment/dependency issues described above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0db19935788324be312718482776ec)