### PR TITLE
Style sidebar dropdown menus to match Codex visual treatment

### DIFF
--- a/js/app/packages/app/component/SimpleDropdown.tsx
+++ b/js/app/packages/app/component/SimpleDropdown.tsx
@@ -94,7 +94,7 @@ function FloatingContent(props: {
       ref={ref}
       style={{ position: 'fixed', left: `${pos().x}px`, top: `${pos().y}px` }}
       class={cn(
-        'bg-surface w-fit p-1 border border-edge-muted rounded-xs shadow z-highlight-menu',
+        'bg-surface w-fit p-1.5 rounded-xl ring-1 ring-edge shadow-[0_12px_36px_-14px_rgba(0,0,0,0.4),0_4px_14px_-10px_rgba(0,0,0,0.3)] z-highlight-menu',
         props.class
       )}
     >
@@ -134,7 +134,7 @@ export type DropdownItemProps = {
   class?: string;
 };
 
-const ITEM_BASE_CLASS = `flex flex-row w-full gap-1.5 tracking-tight ${isMobile() ? 'py-2 px-1 text-base' : 'py-1 pl-2 pr-2 text-sm'} font-medium justify-between items-center rounded-xs outline-none focus:bg-active data-[highlighted]:bg-active`;
+const ITEM_BASE_CLASS = `flex flex-row w-full gap-1.5 tracking-tight ${isMobile() ? 'py-2 px-1.5 text-base' : 'py-1 pl-2.5 pr-2 text-sm'} font-medium justify-between items-center rounded-md outline-none focus:bg-active data-[highlighted]:bg-active`;
 
 function ItemInner(props: Pick<DropdownItemProps, 'icon' | 'text'>) {
   return (

--- a/js/app/packages/app/component/app-sidebar/channels-unread-widget.tsx
+++ b/js/app/packages/app/component/app-sidebar/channels-unread-widget.tsx
@@ -188,7 +188,7 @@ function ChannelGroupItem(props: {
   const ButtonContent = () => (
     <Button
       class={cn(
-        'flex items-center cursor-default rounded-sm not-disabled:hover:bg-ink/3',
+        'flex items-center cursor-default rounded-md not-disabled:hover:bg-ink/3',
         isSlim() ? 'justify-center size-8' : 'justify-start gap-3 size-full h-8'
       )}
       draggable={false}

--- a/js/app/packages/app/component/app-sidebar/sidebar.tsx
+++ b/js/app/packages/app/component/app-sidebar/sidebar.tsx
@@ -397,7 +397,7 @@ const SidebarActionButton = (props: SidebarActionButtonProps) => {
   return (
     <Button
       class={cn(
-        'flex items-center justify-start group-data-[slim=true]/sidebar:justify-center text-sm gap-2 cursor-default w-full rounded-sm py-1 text-ink-extra-muted not-disabled:hover:bg-ink/3'
+        'flex items-center justify-start group-data-[slim=true]/sidebar:justify-center text-sm gap-2 cursor-default w-full rounded-md py-1 text-ink-extra-muted not-disabled:hover:bg-ink/3'
       )}
       variant="ghost"
       tooltipPlacement="right"
@@ -756,7 +756,7 @@ const SidebarLink = (props: SidebarLinkProps) => {
           data-sidebar-link={props.id}
           data-active={isActive() ? '' : undefined}
           class={cn(
-            'flex items-center justify-start group-data-[slim=true]/sidebar:justify-center text-sm gap-2 cursor-default w-full rounded-sm py-1 text-ink-extra-muted not-disabled:hover:bg-ink/3',
+            'flex items-center justify-start group-data-[slim=true]/sidebar:justify-center text-sm gap-2 cursor-default w-full rounded-md py-1 text-ink-extra-muted not-disabled:hover:bg-ink/3',
             isActive() && 'bg-ink/6 not-disabled:hover:bg-ink/6 text-ink'
           )}
           tooltipPlacement="right"

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/group-dropdown.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/group-dropdown.tsx
@@ -31,7 +31,7 @@ export const GroupDropdown: Component<GroupDropdownProps> = (props) => {
       </Tooltip>
       <Dropdown.Portal>
         <Layer depth={2}>
-          <Dropdown.Content class="z-action-menu bg-surface border border-edge-muted rounded-sm shadow-sm min-w-35 p-1">
+          <Dropdown.Content class="min-w-35">
             <For each={props.options}>
               {(option) => (
                 <Dropdown.Item

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/sort-dropdown.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/sort-dropdown.tsx
@@ -39,7 +39,7 @@ export const SortDropdown: Component<SortDropdownProps> = (props) => {
       </Tooltip>
       <Dropdown.Portal>
         <Layer depth={2}>
-          <Dropdown.Content class="z-action-menu bg-surface border border-edge-muted rounded-sm shadow-sm min-w-35 p-1">
+          <Dropdown.Content class="min-w-35">
             <For each={options()}>
               {(option) => (
                 <Dropdown.Item

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/unified-filter-dropdown.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/unified-filter-dropdown.tsx
@@ -810,7 +810,7 @@ export const UnifiedFilterDropdown = () => {
 
         <Dropdown.Portal>
           <Layer depth={2}>
-            <Dropdown.Content class="z-action-menu bg-surface border border-edge-muted rounded-sm shadow-xl min-w-45 p-1">
+            <Dropdown.Content class="min-w-45">
               <Show
                 when={
                   categories().length === 1 && !isTasksView() && !isSearchView()
@@ -827,7 +827,7 @@ export const UnifiedFilterDropdown = () => {
 
                           <Dropdown.Portal>
                             <Layer depth={2}>
-                              <Dropdown.SubContent class="z-action-menu bg-surface border border-edge-muted rounded-sm shadow-xl min-w-40 p-1">
+                              <Dropdown.SubContent class="min-w-40">
                                 <For each={category.options}>
                                   {(option) => {
                                     const active = () =>

--- a/js/app/packages/app/component/next-soup/soup-view/soup-view-create-button.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-view-create-button.tsx
@@ -147,7 +147,7 @@ export const SoupViewCreateButton = () => {
             </Dropdown.Trigger>
             <Dropdown.Portal>
               <Layer depth={2}>
-                <Dropdown.Content class="z-action-menu bg-surface border border-edge-muted rounded-sm shadow-sm min-w-35 p-1">
+                <Dropdown.Content class="min-w-35">
                   <For each={options()}>
                     {(item) => (
                       <Dropdown.Item

--- a/js/app/packages/app/component/split-layout/components/SplitFileMenu.tsx
+++ b/js/app/packages/app/component/split-layout/components/SplitFileMenu.tsx
@@ -199,7 +199,7 @@ export function SplitFileMenu(props: {
       </ResponsiveDropdown.Trigger>
       <ResponsiveDropdown.Portal>
         <Layer depth={2}>
-          <ResponsiveDropdown.Content class="bg-surface w-fit p-1 border border-edge-muted rounded shadow">
+          <ResponsiveDropdown.Content class="w-fit">
             <For each={ops()}>
               {(op, i) => (
                 <>

--- a/js/app/packages/core/component/Menu.tsx
+++ b/js/app/packages/core/component/Menu.tsx
@@ -129,7 +129,7 @@ export type MenuItemProps =
   | CheckboxMenuItemProps
   | RadioMenuItemProps;
 
-export const MENU_ITEM_CLASS = `flex flex-row w-full gap-1.5 tracking-tight ${isMobile() ? 'py-2 px-1 text-base' : 'py-1 pl-2 pr-2 text-sm'} font-medium justify-between items-center rounded-xs outline-none focus:bg-active data-[highlighted]:bg-active`;
+export const MENU_ITEM_CLASS = `flex flex-row w-full gap-1.5 tracking-tight ${isMobile() ? 'py-2 px-1.5 text-base' : 'py-1 pl-2.5 pr-2 text-sm'} font-medium justify-between items-center rounded-md outline-none focus:bg-active data-[highlighted]:bg-active`;
 
 /**
  * A menu item component that can be used interchangeably within either a ContextMenu or DropdownMenu.
@@ -359,7 +359,7 @@ const menuWidths: Record<MenuWidth, string> = {
   screen: 'w-screen',
 };
 
-export const MENU_CONTENT_CLASS = `flex flex-col justify-start items-start bg-surface shadow-lg ring-1 ring-edge-muted rounded-sm p-1 cursor-default select-none max-w-full max-h-[calc(100dvh-10rem)] overflow-y-auto z-modal`;
+export const MENU_CONTENT_CLASS = `flex flex-col justify-start items-start bg-surface shadow-[0_12px_36px_-14px_rgba(0,0,0,0.4),0_4px_14px_-10px_rgba(0,0,0,0.3)] ring-1 ring-edge rounded-xl p-1.5 cursor-default select-none max-w-full max-h-[calc(100dvh-10rem)] overflow-y-auto z-modal`;
 
 type MenuContentProps = ParentProps<{
   class?: string;

--- a/js/app/packages/ui/components/Dropdown.tsx
+++ b/js/app/packages/ui/components/Dropdown.tsx
@@ -1,5 +1,6 @@
 import { DropdownMenu as KobalteDropdownMenu } from '@kobalte/core/dropdown-menu';
 import { Button, type ButtonProps } from './Button';
+import { cn } from '../utils/classname';
 import type { ComponentProps } from 'solid-js';
 
 /*
@@ -14,6 +15,24 @@ import type { ComponentProps } from 'solid-js';
 */
 
 export type DropdownTriggerProps = ComponentProps<typeof KobalteDropdownMenu.Trigger> & ButtonProps;
+type DropdownContentProps = ComponentProps<typeof KobalteDropdownMenu.Content>;
+type DropdownSubContentProps = ComponentProps<typeof KobalteDropdownMenu.SubContent>;
+type DropdownItemProps = ComponentProps<typeof KobalteDropdownMenu.Item>;
+
+const DROPDOWN_CONTENT_CLASS = 'z-action-menu bg-surface rounded-xl ring-1 ring-edge shadow-[0_12px_36px_-14px_rgba(0,0,0,0.4),0_4px_14px_-10px_rgba(0,0,0,0.3)] p-1.5';
+const DROPDOWN_ITEM_CLASS = 'rounded-md';
+
+function DropdownContent(props: DropdownContentProps) {
+  return <KobalteDropdownMenu.Content {...props} class={cn(DROPDOWN_CONTENT_CLASS, props.class)} />;
+}
+
+function DropdownSubContent(props: DropdownSubContentProps) {
+  return <KobalteDropdownMenu.SubContent {...props} class={cn(DROPDOWN_CONTENT_CLASS, props.class)} />;
+}
+
+function DropdownItem(props: DropdownItemProps) {
+  return <KobalteDropdownMenu.Item {...props} class={cn(DROPDOWN_ITEM_CLASS, props.class)} />;
+}
 
 function DropdownTrigger(props: DropdownTriggerProps) {
   return (
@@ -32,14 +51,14 @@ export const Dropdown = Object.assign((props: ComponentProps<typeof KobalteDropd
   CheckboxItem: KobalteDropdownMenu.CheckboxItem,       /* todo */
   RadioGroup: KobalteDropdownMenu.RadioGroup,           /* todo */
   GroupLabel: KobalteDropdownMenu.GroupLabel,           /* todo */
-  SubContent: KobalteDropdownMenu.SubContent,           /* todo */
+  SubContent: DropdownSubContent,
   SubTrigger: KobalteDropdownMenu.SubTrigger,           /* todo */
   ItemLabel: KobalteDropdownMenu.ItemLabel,             /* todo */
   RadioItem: KobalteDropdownMenu.RadioItem,             /* todo */
-  Content: KobalteDropdownMenu.Content,                 /* todo */
+  Content: DropdownContent,
   Portal: KobalteDropdownMenu.Portal,                   /* todo */
   Group: KobalteDropdownMenu.Group,                     /* todo */
-  Item: KobalteDropdownMenu.Item,                       /* todo */
+  Item: DropdownItem,
   Icon: KobalteDropdownMenu.Icon,                       /* todo */
   Sub: KobalteDropdownMenu.Sub,                         /* todo */
   Trigger: DropdownTrigger,


### PR DESCRIPTION
### Motivation
- Make shared dropdown/context-menu surfaces match Codex: adjust outer menu rounding, inner item rounding, shadow, and add a visible ring for a closer visual match.

### Description
- Change `MENU_ITEM_CLASS` to use slightly larger horizontal padding and `rounded-md` so inner rows read like Codex menu pills.
- Change `MENU_CONTENT_CLASS` to replace `shadow-lg` with a softer layered shadow, add `ring-1 ring-edge`, increase corner radius to `rounded-xl`, and bump padding to `p-1.5` for the outer menu container.

### Testing
- Ran `bun run check` from the repository root which failed because the `check` script is not defined in this environment.
- Ran `bun run check` in `js/app`, which executes `tsc` and failed due to missing type definition packages (e.g. `vite/client`, `@types/gtag.js`, `vite-plugin-solid-svg/types`), so type-check could not complete here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0db5942dd4832482802ce0f4179464)