### PR TITLE
chore(infra): bump prod OpenSearch EBS volume to 256 GB/node

### DIFF
--- a/infra/stacks/opensearch/index.ts
+++ b/infra/stacks/opensearch/index.ts
@@ -128,7 +128,7 @@ const opensearchDomain = new aws.opensearch.Domain(
     // per instance storage
     ebsOptions: {
       ebsEnabled: true,
-      volumeSize: stack === 'prod' ? 200 : 50,
+      volumeSize: stack === 'prod' ? 256 : 50,
       volumeType: 'gp3',
     },
     nodeToNodeEncryption: {


### PR DESCRIPTION
Bumps prod OpenSearch EBS volume from 200 GB to 256 GB per data node (3 nodes, gp3) to add headroom for the upcoming backfill — post-backfill projection is ~173 GB / 256 GB ≈ 68% per node. AWS applies this via blue/green so the cluster stays available, but only one config change per 24h is allowed.
