### PR TITLE
chore(search): flip documents_index_uses_join on dev

### DIFF
--- a/infra/stacks/cloud-storage-service/Pulumi.dev.yaml
+++ b/infra/stacks/cloud-storage-service/Pulumi.dev.yaml
@@ -29,3 +29,4 @@ config:
   cloud-storage-service:meta_access_token: meta-access-token
   cloud-storage-service:anthropic_api_key: anthropic-api-key-dev
   cloud-storage-service:apple_bundle_id: apple-bundle-id-prod
+  cloud-storage-service:documents_index_uses_join: "true"

--- a/infra/stacks/search-processing-service/Pulumi.dev.yaml
+++ b/infra/stacks/search-processing-service/Pulumi.dev.yaml
@@ -4,3 +4,4 @@ config:
   search-processing-service:macro_db_readonly_secret_key: macro-db-readonly-dev
   search-processing-service:opensearch_password_key: macro-opensearch-password-dev
   search-processing-service:internal_auth_key: document-storage-service-auth-key-dev
+  search-processing-service:documents_index_uses_join: "true"


### PR DESCRIPTION
Activates the join-shape read path on the dev cloud-storage-service and search-processing-service stacks so we can dress-rehearse the documents alias cutover end-to-end before doing the same on prod. After CI deploys the new config, atomically swap the dev `documents` alias to documents_v2 to complete the rehearsal; swap back instantly if anything's off.

Prod stays on the flat path (env var stays `false` in `Pulumi.prod.yaml`).
