### PR TITLE
fix(ai): mcp reauth

### DIFF
--- a/.github/workflows/code-check-cloud-storage.yml
+++ b/.github/workflows/code-check-cloud-storage.yml
@@ -278,7 +278,7 @@ jobs:
           if [ -n "$NEXTEST_FILTER" ]; then
             args+=(-E "$NEXTEST_FILTER")
           fi
-          cargo nextest run "${args[@]}"
+          cargo nextest run --no-tests=pass "${args[@]}"
       - name: show sccache stats
         if: always()
         env:

--- a/rust/cloud-storage/.dockerignore
+++ b/rust/cloud-storage/.dockerignore
@@ -27,7 +27,6 @@ search_processing_service/helpers/*
 convert_service/helpers/*
 
 # Testing 
-**/load-test/*
 **/test.rs
 
 # Documentation 

--- a/rust/cloud-storage/mcp_service/src/context.rs
+++ b/rust/cloud-storage/mcp_service/src/context.rs
@@ -69,6 +69,7 @@ pub struct McpContext {
     pub jwt_args: JwtValidationArgs,
     pub tool_context: ToolServiceContext,
     pub auth_proxy: McpAuthProxyServiceImpl<RedisInflightAuth>,
+    pub mcp_public_host: String,
 }
 
 pub async fn build_context() -> anyhow::Result<McpContext> {
@@ -120,10 +121,17 @@ pub async fn build_context() -> anyhow::Result<McpContext> {
 
     let auth_proxy = build_auth_proxy(&env_vars, &secretsmanager_client).await?;
 
+    let mcp_public_host = http::Uri::try_from(env_vars.mcp_public_url.as_ref())
+        .context("MCP_PUBLIC_URL is not a valid URI")?
+        .host()
+        .context("MCP_PUBLIC_URL has no host")?
+        .to_owned();
+
     Ok(McpContext {
         jwt_args,
         tool_context,
         auth_proxy,
+        mcp_public_host,
     })
 }
 

--- a/rust/cloud-storage/mcp_service/src/main.rs
+++ b/rust/cloud-storage/mcp_service/src/main.rs
@@ -38,7 +38,11 @@ async fn main() -> anyhow::Result<()> {
         },
         Arc::new(LocalSessionManager::default()),
         {
-            let mut config = StreamableHttpServerConfig::default();
+            let mut config = StreamableHttpServerConfig::default().with_allowed_hosts([
+                context.mcp_public_host.clone(),
+                "localhost".into(),
+                "127.0.0.1".into(),
+            ]);
             config.stateful_mode = false;
             config.json_response = true;
             config


### PR DESCRIPTION

rmcp 1.4.0 added DNS rebinding protection that defaults allowed_hosts to loopback-only (localhost, 127.0.0.1, ::1). The bump from rmcp 1.2.0 to 1.6.0 picked this up, so when the ALB forwards requests with Host: mcp-server.macro.com, rmcp silently rejects them after the JWT middleware has already passed. The fix adds the public hostname from MCP_PUBLIC_URL to the allowed hosts list.

[breaking PR](https://github.com/modelcontextprotocol/rust-sdk/pull/764/changes)