### PR TITLE
fix(downloads): fix image download typing

### DIFF
--- a/infra/stacks/static-file-service/distribution.ts
+++ b/infra/stacks/static-file-service/distribution.ts
@@ -86,14 +86,6 @@ export class StaticFileCloudFront extends pulumi.ComponentResource {
     const responseHeadersPolicy = new aws.cloudfront.ResponseHeadersPolicy(
       'corp-policy',
       {
-        corsConfig: {
-          accessControlAllowOrigins: { items: ['*'] },
-          accessControlAllowHeaders: { items: ['*'] },
-          accessControlAllowMethods: { items: ['GET', 'HEAD', 'OPTIONS'] },
-          accessControlAllowCredentials: false,
-          accessControlMaxAgeSec: 300,
-          originOverride: true,
-        },
         securityHeadersConfig: {
           contentSecurityPolicy: {
             contentSecurityPolicy:

--- a/infra/stacks/static-file-service/distribution.ts
+++ b/infra/stacks/static-file-service/distribution.ts
@@ -86,6 +86,14 @@ export class StaticFileCloudFront extends pulumi.ComponentResource {
     const responseHeadersPolicy = new aws.cloudfront.ResponseHeadersPolicy(
       'corp-policy',
       {
+        corsConfig: {
+          accessControlAllowOrigins: { items: ['*'] },
+          accessControlAllowHeaders: { items: ['*'] },
+          accessControlAllowMethods: { items: ['GET', 'HEAD', 'OPTIONS'] },
+          accessControlAllowCredentials: false,
+          accessControlMaxAgeSec: 300,
+          originOverride: true,
+        },
         securityHeadersConfig: {
           contentSecurityPolicy: {
             contentSecurityPolicy:

--- a/js/app/packages/core/util/imageActions.ts
+++ b/js/app/packages/core/util/imageActions.ts
@@ -1,6 +1,35 @@
 import { toast } from '@core/component/Toast/Toast';
 import { isTouchDevice } from '@core/mobile/isTouchDevice';
 
+function extensionForImageBlob(blob: Blob): string {
+  const t = (blob.type || '').toLowerCase().split(';')[0].trim();
+  switch (t) {
+    case 'image/svg+xml':
+      return 'svg';
+    case 'image/jpeg':
+      return 'jpg';
+    case 'image/gif':
+      return 'gif';
+    case 'image/webp':
+      return 'webp';
+    case 'image/avif':
+      return 'avif';
+    case 'image/bmp':
+      return 'bmp';
+    case 'image/x-icon':
+    case 'image/vnd.microsoft.icon':
+      return 'ico';
+    case 'image/tiff':
+      return 'tiff';
+    case 'image/heic':
+      return 'heic';
+    case 'image/heif':
+      return 'heif';
+    default:
+      return 'png';
+  }
+}
+
 async function toPng(blob: Blob): Promise<Blob> {
   const bitmap = await createImageBitmap(blob);
   const canvas = document.createElement('canvas');
@@ -80,12 +109,14 @@ export async function downloadImage(
     const blob = await getBlob();
     if (!blob) throw new Error('No blob');
 
+    const filename = `image-${imageId}.${extensionForImageBlob(blob)}`;
+
     // iOS: Use the native share sheet instead — the user can save to Photos, AirDrop, etc.
     if (isTouchDevice() && navigator.share) {
       try {
         await navigator.share({
           files: [
-            new File([blob], `image-${imageId}.png`, {
+            new File([blob], filename, {
               type: blob.type || 'image/png',
             }),
           ],
@@ -100,7 +131,7 @@ export async function downloadImage(
     const blobUrl = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = blobUrl;
-    a.download = `image-${imageId}.png`;
+    a.download = filename;
     document.body.appendChild(a);
     a.click();
     document.body.removeChild(a);


### PR DESCRIPTION
Currently, we download all image files from chat as .pngs. This is incorrect for non-PNGs. So now we look at the filetype header and download with the appropriate extension.