### PR TITLE
fix(search): use icu_folding for channel content analyzer

### DIFF
--- a/infra/stacks/opensearch/helpers/constants.ts
+++ b/infra/stacks/opensearch/helpers/constants.ts
@@ -9,7 +9,7 @@ export const CALL_RECORDS_ALIAS = 'call_records';
 
 // Underlying physical indices (versioned). Bump the suffix to roll a new
 // version, then swap the alias atomically.
-export const CHANNELS_INDEX = 'channels_v1';
+export const CHANNELS_INDEX = 'channels_v2';
 export const CHATS_INDEX = 'chats_v1';
 export const DOCUMENTS_INDEX = 'documents_v2';
 export const EMAILS_INDEX = 'emails_v1';

--- a/infra/stacks/opensearch/helpers/scripts/create_indices.ts
+++ b/infra/stacks/opensearch/helpers/scripts/create_indices.ts
@@ -174,11 +174,6 @@ const CHANNEL_BODY = {
     refresh_interval: '1s',
     analysis: {
       analyzer: {
-        // Same shape as the built-in `standard` analyzer, but swaps the
-        // `lowercase` token filter for `icu_folding`. ICU folding does case
-        // folding plus UTR#30 character folding, which collapses smart
-        // punctuation (e.g. U+2019 ’) to ASCII so a typed query "can't" matches
-        // a message containing "can’t".
         content_text: {
           type: 'custom',
           tokenizer: 'standard',

--- a/infra/stacks/opensearch/helpers/scripts/create_indices.ts
+++ b/infra/stacks/opensearch/helpers/scripts/create_indices.ts
@@ -172,6 +172,20 @@ const CHANNEL_BODY = {
   settings: {
     ...SHARD_SETTINGS,
     refresh_interval: '1s',
+    analysis: {
+      analyzer: {
+        // Same shape as the built-in `standard` analyzer, but swaps the
+        // `lowercase` token filter for `icu_folding`. ICU folding does case
+        // folding plus UTR#30 character folding, which collapses smart
+        // punctuation (e.g. U+2019 ’) to ASCII so a typed query "can't" matches
+        // a message containing "can’t".
+        content_text: {
+          type: 'custom',
+          tokenizer: 'standard',
+          filter: ['icu_folding'],
+        },
+      },
+    },
   },
   mappings: {
     dynamic: 'false',
@@ -206,7 +220,7 @@ const CHANNEL_BODY = {
       },
       content: {
         type: 'text',
-        analyzer: 'standard',
+        analyzer: 'content_text',
       },
       created_at_seconds: {
         type: 'date',


### PR DESCRIPTION
Channel content search treats `'` (U+0027) and `’` (U+2019) as distinct tokens because the `standard` analyzer keeps the original codepoint inside the contraction token. A message indexed with smart quotes ("can’t") can't be found by a keyboard query ("can't"). Swap the content analyzer to a custom one that runs `icu_folding`, which folds U+2019 → U+0027 (and applies case folding) at both index and query time.

Rollout (per `infra/stacks/opensearch/helpers/README.md`):

```sh
cd infra/stacks/opensearch/helpers
DRY_RUN=false bun scripts/create_indices.ts                          # create channels_v2 with new mapping
bun scripts/reindex_with_alias_swap.ts channels channels_v2          # dry-run, review
DRY_RUN=false bun scripts/reindex_with_alias_swap.ts channels channels_v2
# backfill the reindex write window via search_processing_service
DRY_RUN=false bun scripts/delete_indices.ts channels_v1              # after a few hours of healthy traffic
```

Doesn't change the case of "ai cant" matching "ai can't" — that needs an apostrophe-stripping char_filter, which can be a follow-up if it comes up.
