### PR TITLE
fix(search): skip rows with unknown file types in documents backfill

### DIFF
--- a/rust/cloud-storage/macro_db_client/src/document/get_documents_search.rs
+++ b/rust/cloud-storage/macro_db_client/src/document/get_documents_search.rs
@@ -103,22 +103,34 @@ pub async fn get_documents_for_search(
         only_deleted,
         cursor_id as Option<String>,
     )
-    .try_map(|row| {
-        Ok(BackfillSearchDocumentInformation {
-            document_id: row.document_id,
-            document_version_id: row.document_version_id,
-            owner: row.owner,
-            file_type: FileType::from_str(row.file_type.as_str()).map_err(|e| {
-                sqlx::Error::ColumnDecode {
-                    index: "file_type".to_string(),
-                    source: e.into(),
-                }
-            })?,
-            updated_at: row.updated_at,
-        })
-    })
     .fetch_all(db)
     .await?;
 
-    Ok(result)
+    // Rows whose `fileType` doesn't map to a known `FileType` variant are
+    // skipped with a warning rather than aborting the whole batch: prod has
+    // historical rows with extensions the enum doesn't recognize yet, and
+    // failing the page would stall every backfill behind a single bad row.
+    let mapped = result
+        .into_iter()
+        .filter_map(|row| match FileType::from_str(row.file_type.as_str()) {
+            Ok(file_type) => Some(BackfillSearchDocumentInformation {
+                document_id: row.document_id,
+                document_version_id: row.document_version_id,
+                owner: row.owner,
+                file_type,
+                updated_at: row.updated_at,
+            }),
+            Err(e) => {
+                tracing::warn!(
+                    document_id = %row.document_id,
+                    file_type = %row.file_type,
+                    error = ?e,
+                    "skipping document with unknown file type during search backfill"
+                );
+                None
+            }
+        })
+        .collect();
+
+    Ok(mapped)
 }

--- a/rust/cloud-storage/model_file_type/src/lib.rs
+++ b/rust/cloud-storage/model_file_type/src/lib.rs
@@ -334,6 +334,8 @@ generate_file_types!(
     (Repo, "repo", "text/plain", Code),
     (Java, "java", "text/plain", Code),
     (Jav, "jav", "text/plain", Code),
+    (Kt, "kt", "text/plain", Code),
+    (Kts, "kts", "text/plain", Code),
     (Jsx, "jsx", "text/plain", Code),
     (Js, "js", "text/plain", Code),
     (Es6, "es6", "text/plain", Code),

--- a/rust/cloud-storage/model_file_type/src/lib.rs
+++ b/rust/cloud-storage/model_file_type/src/lib.rs
@@ -334,8 +334,6 @@ generate_file_types!(
     (Repo, "repo", "text/plain", Code),
     (Java, "java", "text/plain", Code),
     (Jav, "jav", "text/plain", Code),
-    (Kt, "kt", "text/plain", Code),
-    (Kts, "kts", "text/plain", Code),
     (Jsx, "jsx", "text/plain", Code),
     (Js, "js", "text/plain", Code),
     (Es6, "es6", "text/plain", Code),


### PR DESCRIPTION
The previous prod documents backfill ran for ~10 min, got through ~509k rows via the new keyset path, then aborted on a single row whose `fileType` value wasn't in the `FileType` enum because `try_map` propagated the per-row parse failure. Switches the source to `filter_map` + log a warning so one bad row can't stall the whole drain. Adding the missing variant itself will land in a separate PR.