### PR TITLE
fix: disable overscroll on soup-view lists

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
@@ -1480,7 +1480,7 @@ const SoupList = (props: SoupListProps) => {
       <VList
         cache={props.cache}
         ref={registerVirtualizerHandler}
-        class={props.virtualizerClass}
+        class={cn('overscroll-none', props.virtualizerClass)}
         data={stableRows}
         itemSize={itemSize()}
         bufferSize={overscan() * itemSize()}


### PR DESCRIPTION
Prevents the overscroll bounce on the virtualized soup list, so clicks register immediately instead of waiting for the bounce animation to finish.