### PR TITLE
fix(mobile): only condense single channel-message stacks

### DIFF
--- a/js/app/packages/entity/src/composed/ListEntity.tsx
+++ b/js/app/packages/entity/src/composed/ListEntity.tsx
@@ -162,13 +162,26 @@ export function ListEntity(props: ListEntityProps) {
     return stackNotifications(validNotifs);
   });
 
-  // Latch to true once multi-stack is ever seen (including async arrivals).
-  // Prevents a jarring layout switch when swiping down to 1 stack.
-  const [hasBeenMultiStack, setHasBeenMultiStack] = createSignal(
-    mobileStacks().length > 1
+  // A single stack collapses into the condensed entity row only when it's a
+  // new-messages-in-a-channel stack — the entity (channel) preview already
+  // conveys "new messages here". Replies, mentions, and other types carry
+  // per-stack context worth showing, so they render as a stack even when
+  // alone.
+  const shouldUnrollStacks = () => {
+    const stacks = mobileStacks();
+    if (stacks.length === 0) return false;
+    if (stacks.length > 1) return true;
+    return stacks[0].type !== 'channel_message_send';
+  };
+
+  // Latch to true once the stack view has ever been used (including async
+  // arrivals). Prevents a jarring layout switch when notifications drop back
+  // to a single condensable stack.
+  const [hasBeenUnrolled, setHasBeenUnrolled] = createSignal(
+    shouldUnrollStacks()
   );
   createEffect(() => {
-    if (mobileStacks().length > 1) setHasBeenMultiStack(true);
+    if (shouldUnrollStacks()) setHasBeenUnrolled(true);
   });
 
   return (
@@ -204,11 +217,7 @@ export function ListEntity(props: ListEntityProps) {
             <WideLayout {...layoutProps()} />
           </MaybeEntityRow>
         </Match>
-        <Match
-          when={
-            isMobile() && (hasBeenMultiStack() || mobileStacks().length > 1)
-          }
-        >
+        <Match when={isMobile() && (hasBeenUnrolled() || shouldUnrollStacks())}>
           <Entity.Notification.MobileStacks
             stacks={mobileStacks()}
             entity={props.entity}


### PR DESCRIPTION
Previously, any single mobile notification stack collapsed into the condensed entity row layout. That's the right behavior for "new messages" in a channel — the channel entity preview already conveys the gist — but it hides per-stack context for replies, mentions, and other notification types when they happen to be the only stack.

Now we only condense single-stack groups when the stack type is `channel_message_send`; everything else renders as a stack.