### PR TITLE
fix(channel): restore main input after reply send unmounts inline input

### DIFF
--- a/js/app/packages/channel/Channel/create-inline-input-keyboard-handler.ts
+++ b/js/app/packages/channel/Channel/create-inline-input-keyboard-handler.ts
@@ -21,10 +21,33 @@ export function createInlineInputKeyboardHandler(
   setIsChannelInputHidden: Setter<boolean>
 ) {
   let activeInputContainer: HTMLElement | undefined;
+  let removalObserver: MutationObserver | undefined;
+
+  const stopWatchingForRemoval = () => {
+    removalObserver?.disconnect();
+    removalObserver = undefined;
+  };
 
   const reset = () => {
     setIsChannelInputHidden(false);
     activeInputContainer = undefined;
+    stopWatchingForRemoval();
+  };
+
+  // The active input container can be unmounted (e.g. after a reply is sent
+  // and the thread reply UI closes) without firing a focusout that bubbles to
+  // our listener, and without the virtual keyboard changing visibility. Watch
+  // the message list for DOM mutations so we can reset in that case.
+  const watchForContainerRemoval = () => {
+    stopWatchingForRemoval();
+    const root = containerEl();
+    if (!root || !activeInputContainer) return;
+    removalObserver = new MutationObserver(() => {
+      if (activeInputContainer && !activeInputContainer.isConnected) {
+        reset();
+      }
+    });
+    removalObserver.observe(root, { childList: true, subtree: true });
   };
 
   const keyboardWillShowHandler = (event: Event) => {
@@ -41,6 +64,7 @@ export function createInlineInputKeyboardHandler(
     );
     if (!inputContainer) return;
     activeInputContainer = inputContainer;
+    watchForContainerRemoval();
 
     // HACK: on mobile safari, we need to ensure that the input container is scrolled into view BEFORE we hide the input, and then perform the subsequent scroll. Some sort of weird Safari focus behavior going on.
     if (!isPlatform('ios')) {
@@ -90,6 +114,7 @@ export function createInlineInputKeyboardHandler(
       onCleanup(() => {
         el.removeEventListener('focusin', handleFocusIn);
         el.removeEventListener('focusout', handleFocusOut);
+        stopWatchingForRemoval();
       });
     })
   );


### PR DESCRIPTION
When a thread reply was sent, ThreadReplyInput unmounted (its data-inline-input-container-id wrapper removed from the DOM) without firing a focusout that bubbled to the message-list listener, and often without flipping virtualKeyboardVisible — the keyboard frequently stays visible across the unmount, or the platform's hide event never fires when an input is yanked out rather than blurred. That left activeInputContainer pointing at a detached node and isChannelInputHidden stuck at true, hiding the main channel input.

Watch the message list with a MutationObserver and reset when the active input container is no longer connected.