### PR TITLE
fix: show mobile send button when only attachments are present

### DIFF
--- a/js/app/packages/channel/Input/SendAction.tsx
+++ b/js/app/packages/channel/Input/SendAction.tsx
@@ -15,7 +15,6 @@ export function SendAction(props: SendActionProps) {
   const [local, rest] = splitProps(props, ['class', 'tooltip', 'hidden']);
   const isBlockedByPending = () => !!input().hasPendingAttachments;
   const isBlockedByEmptyInput = () => !hasSendableInputContent(input());
-  const hasTextInput = () => (input().value?.trim().length ?? 0) > 0;
 
   const tooltipText = () => local.tooltip ?? 'Send message';
 
@@ -27,7 +26,7 @@ export function SendAction(props: SendActionProps) {
       data-input-action="send"
       pending={isBlockedByPending()}
       disabled={isBlockedByPending() || isBlockedByEmptyInput()}
-      hidden={isMobile() && !hasTextInput()}
+      hidden={isMobile() && isBlockedByEmptyInput()}
       class={local.class}
       onPointerDown={(event) => {
         event.preventDefault();


### PR DESCRIPTION
The mobile send button was hidden whenever there was no text input, even if the user had attached an image. Use hasSendableInputContent so the button shows whenever there is text or attachments.