### PR TITLE
chore(infra): enable join-shape documents index reads on prod

### DIFF
--- a/infra/stacks/cloud-storage-service/Pulumi.prod.yaml
+++ b/infra/stacks/cloud-storage-service/Pulumi.prod.yaml
@@ -29,3 +29,4 @@ config:
   cloud-storage-service:meta_access_token: meta-access-token
   cloud-storage-service:anthropic_api_key: anthropic-api-key
   cloud-storage-service:apple_bundle_id: apple-bundle-id-prod
+  cloud-storage-service:documents_index_uses_join: "true"

--- a/infra/stacks/search-processing-service/Pulumi.prod.yaml
+++ b/infra/stacks/search-processing-service/Pulumi.prod.yaml
@@ -4,3 +4,4 @@ config:
   search-processing-service:macro_db_readonly_secret_key: macro-db-readonly-prod
   search-processing-service:opensearch_password_key: macro-opensearch-password-prod
   search-processing-service:internal_auth_key: document-storage-service-auth-key-prod
+  search-processing-service:documents_index_uses_join: "true"


### PR DESCRIPTION
Mirrors the dev change — sets `DOCUMENTS_INDEX_USES_JOIN=true` on cloud-storage-service and search-processing-service in prod so they read documents as parent/child join. Pre-req for swapping the `documents` alias to `documents_v2`; without this the alias swap would break search because the service would issue v1-shape queries against a join-shape index.
