### PR TITLE
chore(toolbar): move preview button to right toolbar in soup filters bar

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/soup-filters-bar.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/soup-filters-bar.tsx
@@ -4,7 +4,10 @@ import { SoupViewContextGroup } from '@app/component/next-soup/soup-view/filters
 import { SoupViewContextSort } from '@app/component/next-soup/soup-view/filters-bar/soup-view-context-sort';
 import { UnifiedFilterDropdown } from '@app/component/next-soup/soup-view/filters-bar/unified-filter-dropdown';
 import { useFilterRefinements } from '@app/component/next-soup/soup-view/filters-bar/use-filter-refinements';
-import { SplitToolbarLeft } from '@app/component/split-layout/components/SplitToolbar';
+import {
+  SplitToolbarLeft,
+  SplitToolbarRight,
+} from '@app/component/split-layout/components/SplitToolbar';
 import { useSplitPanelOrThrow } from '@app/component/split-layout/layoutUtils';
 import { registerHotkey } from '@core/hotkey/hotkeys';
 import { TOKENS } from '@core/hotkey/tokens';
@@ -74,22 +77,22 @@ export function SoupFiltersBar() {
             onReplace={replaceFilter}
             onRemove={removeFilter}
           />
-          <div class="ml-auto">
-            <Tooltip hotkey={TOKENS.unifiedList.togglePreview} label="Preview">
-              <Button
-                onClick={togglePreview}
-                variant="base"
-                size="sm"
-                depth={2}
-                class="bg-surface"
-              >
-                {soup.previewEntity() ? <EyeSlashIcon /> : <EyeIcon />}
-                <span>Preview</span>
-              </Button>
-            </Tooltip>
-          </div>
         </div>
       </SplitToolbarLeft>
+      <SplitToolbarRight>
+        <Tooltip hotkey={TOKENS.unifiedList.togglePreview} label="Preview">
+          <Button
+            onClick={togglePreview}
+            variant="base"
+            size="sm"
+            depth={2}
+            class="bg-surface"
+          >
+            {soup.previewEntity() ? <EyeSlashIcon /> : <EyeIcon />}
+            <span>Preview</span>
+          </Button>
+        </Tooltip>
+      </SplitToolbarRight>
     </Show>
   );
 }

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/soup-filters-bar.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/soup-filters-bar.tsx
@@ -62,18 +62,6 @@ export function SoupFiltersBar() {
     <Show when={!isMobile()}>
       <SplitToolbarLeft>
         <div class="flex items-start gap-2 min-w-0 flex-1">
-          <Tooltip hotkey={TOKENS.unifiedList.togglePreview} label="Preview">
-            <Button
-              onClick={togglePreview}
-              variant="base"
-              size="sm"
-              depth={2}
-              class="bg-surface"
-            >
-              {soup.previewEntity() ? <EyeSlashIcon /> : <EyeIcon />}
-              <span>Preview</span>
-            </Button>
-          </Tooltip>
           <Show when={!isSearchView()}>
             <SoupViewContextSort />
             <SoupViewContextGroup />
@@ -86,6 +74,20 @@ export function SoupFiltersBar() {
             onReplace={replaceFilter}
             onRemove={removeFilter}
           />
+          <div class="ml-auto">
+            <Tooltip hotkey={TOKENS.unifiedList.togglePreview} label="Preview">
+              <Button
+                onClick={togglePreview}
+                variant="base"
+                size="sm"
+                depth={2}
+                class="bg-surface"
+              >
+                {soup.previewEntity() ? <EyeSlashIcon /> : <EyeIcon />}
+                <span>Preview</span>
+              </Button>
+            </Tooltip>
+          </div>
         </div>
       </SplitToolbarLeft>
     </Show>


### PR DESCRIPTION
## Summary
Reorganized the layout of the soup filters bar by moving the preview toggle button from the left toolbar to a newly added right toolbar section.

## Key Changes
- Added import of `SplitToolbarRight` component from the split-layout module
- Moved the preview button (with its Tooltip wrapper) from `SplitToolbarLeft` to a new `SplitToolbarRight` container
- The preview button functionality remains unchanged; only its visual positioning has been updated

## Implementation Details
- The preview button maintains all its original properties (onClick handler, styling, icons, tooltip)
- The left toolbar now focuses on filter-related controls (sort, group, and unified filter dropdown)
- The right toolbar is now used for action buttons like the preview toggle, providing better visual hierarchy and layout balance

https://claude.ai/code/session_01MLMeH4a9cuVcPr1ik45RVK