### PR TITLE
feat(projects): enable project sharing feature flag by default

### DIFF
--- a/js/app/packages/core/constant/featureFlags.ts
+++ b/js/app/packages/core/constant/featureFlags.ts
@@ -71,7 +71,7 @@ export const ENABLE_PDF_MULTISPLIT = resolveFeatureFlag(
 
 export const ENABLE_PROJECT_SHARING = resolveFeatureFlag(
   'ENABLE_PROJECT_SHARING',
-  DEV_MODE_ENV
+  true
 );
 
 export const ENABLE_CANVAS_IMAGES = resolveFeatureFlag(


### PR DESCRIPTION
## Summary
This change enables the project sharing feature by default, making it available to all users regardless of development mode status.

## Key Changes
- Changed `ENABLE_PROJECT_SHARING` feature flag from `DEV_MODE_ENV` to `true`, enabling the feature for all environments

## Implementation Details
The project sharing feature was previously gated behind development mode only. By setting the flag to `true`, the feature is now permanently enabled and will be available in production environments.

https://claude.ai/code/session_01SqXoYoshvTUAcxypNKhTNv