### PR TITLE
feat(projects): refactor preview panel to prevent nested preview nesting

### DIFF
--- a/js/app/packages/app/component/PreviewPanel.tsx
+++ b/js/app/packages/app/component/PreviewPanel.tsx
@@ -50,7 +50,10 @@ const PreviewPanelContent: Component<NonNullableFields<PreviewPanel>> = (
   scopedLayoutRefs.headerRight = undefined;
 
   if (props.selectedEntity.type === 'project') {
-    const [previewState, setPreviewState] = createSignal(true);
+    // Isolate the previewed project's preview state from the outer panel so
+    // the nested SoupView's sync effect doesn't clobber the parent. Preview
+    // can only work one level deep, so we never enable preview inside.
+    const [previewState, setPreviewState] = createSignal(false);
     scopedSplitPanelContextType.previewState = [previewState, setPreviewState];
   }
 

--- a/js/app/packages/block-project/component/Block.tsx
+++ b/js/app/packages/block-project/component/Block.tsx
@@ -1,3 +1,4 @@
+import { useAnalytics } from '@app/component/analytics-context';
 import { useBlockEntityCommands } from '@app/component/next-soup/actions';
 import {
   createSoupState,
@@ -93,22 +94,7 @@ const Block: Component = () => {
   const previewPanel = useMaybePreviewPanel();
 
   const splitPanelContext = useSplitPanelOrThrow();
-
-  const [preview, setPreview] = splitPanelContext.previewState;
-
-  if (!previewPanel) {
-    registerHotkey({
-      hotkey: ['space'],
-      scopeId: splitPanelContext.splitHotkeyScope,
-      description: 'Toggle Preview',
-      hotkeyToken: TOKENS.unifiedList.togglePreview,
-      keyDownHandler: () => {
-        setPreview((prev) => !prev);
-        return true;
-      },
-      hide: true,
-    });
-  }
+  const analytics = useAnalytics();
 
   const projectSoup = createSoupState({
     initialPredicates: { and: ['project-content'] },
@@ -120,6 +106,29 @@ const Block: Component = () => {
       },
     ],
   });
+
+  // Preview can only work one level deep — don't register the toggle when
+  // this project is already being rendered inside a preview panel.
+  if (!previewPanel) {
+    registerHotkey({
+      hotkey: ['space'],
+      scopeId: splitPanelContext.splitHotkeyScope,
+      description: 'Toggle Preview',
+      hotkeyToken: TOKENS.unifiedList.togglePreview,
+      keyDownHandler: () => {
+        if (projectSoup.previewEntity()) {
+          projectSoup.setPreviewEntity(undefined);
+          return true;
+        }
+        const focused = projectSoup.focus.id();
+        if (!focused) return true;
+        analytics.track('preview_panel_use');
+        projectSoup.setPreviewEntity(focused);
+        return true;
+      },
+      hide: true,
+    });
+  }
 
   const [attachHotkeys, projectViewScope] = useHotkeyDOMScope('project-view');
 
@@ -157,7 +166,9 @@ const Block: Component = () => {
                 value={{
                   ...splitPanelContext,
                   halfSplitState: () =>
-                    preview() ? { side: 'left', percentage: 30 } : undefined,
+                    projectSoup.previewEntity() && projectSoup.focus.item()
+                      ? { side: 'left', percentage: 30 }
+                      : undefined,
                 }}
               >
                 <ProjectEntityList


### PR DESCRIPTION
This PR refactors the preview panel implementation to prevent nested preview panels from being opened inside already-previewed projects. It moves preview state management from the split panel context to the project soup state and adds analytics tracking for preview panel usage.


https://claude.ai/code/session_0112UHkLNxy2xzif724vBpPL