### PR TITLE
fix(search): include channel messages in inbox signal search results

### DIFF
--- a/js/app/packages/app/component/next-soup/filters/predicates.ts
+++ b/js/app/packages/app/component/next-soup/filters/predicates.ts
@@ -1,4 +1,5 @@
 import { PROPERTY_OPTION_IDS } from '@core/component/Properties/constants';
+import type { Entity } from '@core/types';
 import {
   type EntityData,
   getTaskAssigneeIds,
@@ -9,6 +10,15 @@ import {
 } from '@entity';
 import { getTaskPriorityOptionId } from '@entity/utils/task-properties';
 import { compositeEntity, type NotificationSource } from '@notifications';
+
+// Channel messages don't have their own notifications — they share the parent
+// channel's. Resolve to the channel entity for notification lookups.
+function notificationLookupEntity(entity: EntityData): Entity {
+  if (entity.type === 'channel_message') {
+    return { type: 'channel', id: entity.channelId };
+  }
+  return entity;
+}
 
 /**
  * Unread filter - entity has unread content.
@@ -23,7 +33,9 @@ export function unreadFilter(notificationSource: NotificationSource) {
       return !entity.isRead;
     }
     const notifications =
-      notificationSource.notificationsByEntity()[compositeEntity(entity)];
+      notificationSource.notificationsByEntity()[
+        compositeEntity(notificationLookupEntity(entity))
+      ];
 
     return notifications?.some((n) => !n.viewed_at) ?? false;
   };
@@ -41,7 +53,9 @@ export function notDoneFilter(notificationSource: NotificationSource) {
     if (entity.type === 'email') return !entity.done;
 
     const notifications =
-      notificationSource.notificationsByEntity()[compositeEntity(entity)];
+      notificationSource.notificationsByEntity()[
+        compositeEntity(notificationLookupEntity(entity))
+      ];
 
     return notifications?.some(({ done }) => !done);
   };


### PR DESCRIPTION
The inbox/signal client filter combined `signalFilter` and `notDoneFilter`, but `notDoneFilter` looked up notifications by the entity's composite key. `channel_message` entities use a synthetic `channelId:messageId` id while notifications are always stored under the parent channel (`channel@<channelId>`), so the lookup returned `undefined` and the predicate dropped messages the backend had correctly included.

Resolve `channel_message` entities to their parent channel for notification lookups in both `notDoneFilter` and `unreadFilter`.
