### PR TITLE
fix(search): quoted phrases use phrase query in email SQS

### DIFF
--- a/rust/cloud-storage/opensearch_client/src/search/emails.rs
+++ b/rust/cloud-storage/opensearch_client/src/search/emails.rs
@@ -37,19 +37,21 @@ const EMAIL_TEXT_FIELDS: &[&str] = &[
 /// local-part match on the address. This deliberately does NOT use a trailing
 /// `*` on the bare term, so partial local-parts don't leak across addresses
 /// (e.g. `ali` won't match `alice@example.com` via this group).
-/// Email-like terms (containing `@`) are wrapped in quotes to force phrase
-/// matching — otherwise the standard analyzer would tokenize
-/// `alice@example.com` into `[alice, example, com]`.
+/// Email-like terms (containing `@`) and multi-word terms (quoted phrases
+/// from `split_search_terms`) are wrapped in quotes to force phrase matching.
+/// Without the quotes, `default_operator: "AND"` would turn `(reply test)`
+/// into `reply AND test` and match each token independently anywhere in the
+/// field instead of as an adjacent phrase. The standard analyzer also
+/// tokenizes `alice@example.com` into `[alice, example, com]`, so phrase
+/// matching is what keeps the address from matching across unrelated tokens.
 /// The email pattern is lowercased because email addresses are case-insensitive.
 /// Terms are ANDed together with `+`.
 fn build_keyword_query_string(terms: &[String]) -> String {
     terms
         .iter()
         .map(|term| {
-            if term.contains('@') {
+            if term.contains('@') || term.contains(' ') {
                 format!("\"{}\"", term)
-            } else if term.contains(' ') {
-                format!("({})", term)
             } else {
                 format!("({} | {}@*)", term, term.to_lowercase())
             }
@@ -66,15 +68,19 @@ const MIN_PREFIX_LEN: usize = 3;
 /// Builds the simple_query_string over the text-analyzed fields.
 /// Single-word terms become `term*` so a prefix like `scri` matches the
 /// token `script` in subject/content/display-name fields. Terms shorter than
-/// `MIN_PREFIX_LEN` fall back to exact match to keep term expansion bounded.
-/// Multi-word and `@`-containing terms use grouped / phrase matching.
+/// `MIN_PREFIX_LEN` fall back to a grouped exact-token match to keep term
+/// expansion bounded. Multi-word terms (quoted phrases from
+/// `split_search_terms`) and `@`-containing terms are wrapped in quotes to
+/// force phrase matching — otherwise `default_operator: "AND"` would turn
+/// `(reply test)` into `reply AND test` and match each token independently
+/// anywhere in the field instead of as an adjacent phrase.
 fn build_text_query_string(terms: &[String]) -> String {
     terms
         .iter()
         .map(|term| {
-            if term.contains('@') {
+            if term.contains('@') || term.contains(' ') {
                 format!("\"{}\"", term)
-            } else if term.contains(' ') || term.chars().count() < MIN_PREFIX_LEN {
+            } else if term.chars().count() < MIN_PREFIX_LEN {
                 format!("({})", term)
             } else {
                 format!("{}*", term)

--- a/rust/cloud-storage/opensearch_client/src/search/emails/test.rs
+++ b/rust/cloud-storage/opensearch_client/src/search/emails/test.rs
@@ -14,9 +14,12 @@ fn test_build_keyword_query_string_multiple_terms() {
 }
 
 #[test]
-fn test_build_keyword_query_string_multi_word_term_skips_email_pattern() {
+fn test_build_keyword_query_string_multi_word_term_uses_phrase() {
+    // Multi-word terms come from quoted phrases via `split_search_terms`
+    // and must render as a phrase so simple_query_string's AND default
+    // operator doesn't decompose them into independent tokens.
     let result = build_keyword_query_string(&["hi there".to_string()]);
-    assert_eq!(result, "(hi there)");
+    assert_eq!(result, "\"hi there\"");
 }
 
 #[test]
@@ -28,7 +31,7 @@ fn test_build_keyword_query_string_uppercase_lowercased_for_email() {
 #[test]
 fn test_build_keyword_query_string_mixed_single_and_multi_word() {
     let result = build_keyword_query_string(&["Teo".to_string(), "hello world".to_string()]);
-    assert_eq!(result, "(Teo | teo@*) + (hello world)");
+    assert_eq!(result, "(Teo | teo@*) + \"hello world\"");
 }
 
 #[test]
@@ -57,9 +60,12 @@ fn test_build_text_query_string_multiple_terms_are_prefixed_and_anded() {
 }
 
 #[test]
-fn test_build_text_query_string_multi_word_term_uses_group() {
+fn test_build_text_query_string_multi_word_term_uses_phrase() {
+    // Multi-word terms come from quoted phrases via `split_search_terms`
+    // and must render as a phrase so simple_query_string's AND default
+    // operator doesn't decompose them into independent tokens.
     let result = build_text_query_string(&["hi there".to_string()]);
-    assert_eq!(result, "(hi there)");
+    assert_eq!(result, "\"hi there\"");
 }
 
 #[test]
@@ -78,6 +84,48 @@ fn test_build_text_query_string_short_term_skips_prefix() {
 fn test_build_text_query_string_three_char_term_gets_prefix() {
     let result = build_text_query_string(&["abc".to_string()]);
     assert_eq!(result, "abc*");
+}
+
+#[test]
+fn test_email_search_args_quoted_phrase_uses_phrase_query_in_sqs() -> anyhow::Result<()> {
+    // Regression: a quoted phrase like `"reply test"` arrives here as a
+    // single term with internal whitespace (already stripped of quotes
+    // by `split_search_terms`). Both simple_query_string clauses must
+    // emit it as a phrase — otherwise `default_operator: "AND"` would
+    // turn `(reply test)` into `reply AND test` and match each token
+    // independently anywhere in the field.
+    let builder: EmailQueryBuilder = EmailSearchArgs {
+        terms: vec!["reply test".to_string()],
+        user_id: "macro|alice@example.com".to_string(),
+        thread_ids: vec![],
+        link_ids: vec![],
+        sender: vec![],
+        cc: vec![],
+        bcc: vec![],
+        recipients: vec![],
+        include_labels: vec![],
+        exclude_labels: vec![],
+        importance: None,
+        page: 0,
+        page_size: 20,
+        match_type: "partial".to_string(),
+        collapse: true,
+        ids_only: false,
+        subject_only: false,
+    }
+    .into();
+
+    let json = builder.build_bool_query()?.build().to_json();
+    let should = json["bool"]["must"][0]["bool"]["should"]
+        .as_array()
+        .unwrap();
+    for sqs in should.iter().map(|s| &s["simple_query_string"]) {
+        assert_eq!(
+            sqs["query"], "\"reply test\"",
+            "expected phrase query, got {sqs:?}"
+        );
+    }
+    Ok(())
 }
 
 #[test]


### PR DESCRIPTION
The email simple_query_string builders rendered a whitespace-bearing term (i.e. one that came from a user-quoted phrase via `split_search_terms`) as `(reply test)`, which under `default_operator: "AND"` parses as `reply AND test` anywhere in the field instead of as an adjacent phrase — so `"reply test"` was returning every email containing both words somewhere. Wrap those terms in quotes so they emit as phrase queries.

Regression dates to #2585 (where the multi-term-only guard around the SQS path was dropped), not #3402 — the documents path already handles whitespace terms as `match_phrase` in both flat and join shapes.
