### PR TITLE
fix(search): index persistent chats so agent chat content is searchable

### DIFF
--- a/rust/cloud-storage/.sqlx/query-92e2916a16d165600f457c778ac3db9ae11c6625c948798e19ca19da4a30f3c1.json
+++ b/rust/cloud-storage/.sqlx/query-92e2916a16d165600f457c778ac3db9ae11c6625c948798e19ca19da4a30f3c1.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        SELECT\n            m.content as \"content\",\n            c.name as \"name\",\n            m.role as \"role\",\n            c.\"deletedAt\"::timestamptz as \"deleted_at\"\n        FROM\n            \"ChatMessage\" m\n        JOIN\n            \"Chat\" c on c.\"id\" = m.\"chatId\"\n        WHERE\n            m.id = $1 AND m.\"chatId\" = $2 AND c.\"isPersistent\" = false\n        ",
+  "query": "\n        SELECT\n            m.content as \"content\",\n            c.name as \"name\",\n            m.role as \"role\",\n            c.\"deletedAt\"::timestamptz as \"deleted_at\"\n        FROM\n            \"ChatMessage\" m\n        JOIN\n            \"Chat\" c on c.\"id\" = m.\"chatId\"\n        WHERE\n            m.id = $1 AND m.\"chatId\" = $2\n        ",
   "describe": {
     "columns": [
       {
@@ -37,5 +37,5 @@
       null
     ]
   },
-  "hash": "7e30c2f23eec4e4131e6463f0b05722b1dd8b220025c72ec4c70772251b03656"
+  "hash": "92e2916a16d165600f457c778ac3db9ae11c6625c948798e19ca19da4a30f3c1"
 }

--- a/rust/cloud-storage/macro_db_client/fixtures/chat_message_info.sql
+++ b/rust/cloud-storage/macro_db_client/fixtures/chat_message_info.sql
@@ -1,0 +1,15 @@
+INSERT INTO public."macro_user" ("id", "username", "email", "stripe_customer_id")
+VALUES ('a1111111-1111-1111-1111-111111111111', 'user', 'user@user.com', 'stripe_id');
+
+INSERT INTO public."User" ("id","email","stripeCustomerId","macro_user_id")
+VALUES ('macro|user@user.com', 'user@user.com','stripe_id','a1111111-1111-1111-1111-111111111111');
+
+INSERT INTO public."Chat" ("id","name","userId","model","createdAt","updatedAt","isPersistent")
+VALUES
+  ('chat-persistent', 'persistent chat', 'macro|user@user.com', 'gpt-4o', '2024-01-01 00:00:00', '2024-01-01 00:00:00', true),
+  ('chat-ephemeral', 'ephemeral chat', 'macro|user@user.com', 'gpt-4o', '2024-01-01 00:00:00', '2024-01-01 00:00:00', false);
+
+INSERT INTO public."ChatMessage" ("id","content","role","chatId")
+VALUES
+  ('msg-persistent', '"codebase brighter"', 'user', 'chat-persistent'),
+  ('msg-ephemeral', '"another message"', 'user', 'chat-ephemeral');

--- a/rust/cloud-storage/macro_db_client/src/chat/get.rs
+++ b/rust/cloud-storage/macro_db_client/src/chat/get.rs
@@ -3,6 +3,9 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+#[cfg(test)]
+mod test;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChatSearchBackfill {
     pub chat_id: String,
@@ -202,8 +205,7 @@ pub struct ChatMessageInfo {
 }
 
 /// Gets the chat title, message content and role used for search.
-/// Returns `None` when the message does not exist or the owning chat is
-/// persistent (persistent chats are not indexed). Soft-deleted chats are
+/// Returns `None` when the message does not exist. Soft-deleted chats are
 /// returned with `deleted_at` populated so the caller can prune the search
 /// index entry.
 #[tracing::instrument(skip(db))]
@@ -224,7 +226,7 @@ pub async fn get_chat_message_info(
         JOIN
             "Chat" c on c."id" = m."chatId"
         WHERE
-            m.id = $1 AND m."chatId" = $2 AND c."isPersistent" = false
+            m.id = $1 AND m."chatId" = $2
         "#,
         chat_message_id,
         chat_id

--- a/rust/cloud-storage/macro_db_client/src/chat/get/test.rs
+++ b/rust/cloud-storage/macro_db_client/src/chat/get/test.rs
@@ -1,0 +1,21 @@
+use super::*;
+use sqlx::{Pool, Postgres};
+
+#[sqlx::test(fixtures(path = "../../../fixtures", scripts("chat_message_info")))]
+async fn persistent_chat_messages_are_indexed_for_search(
+    pool: Pool<Postgres>,
+) -> anyhow::Result<()> {
+    let persistent = get_chat_message_info(&pool, "chat-persistent", "msg-persistent")
+        .await?
+        .expect("persistent chat message should be returned for indexing");
+    assert_eq!(persistent.content, "codebase brighter");
+    assert!(persistent.deleted_at.is_none());
+
+    let ephemeral = get_chat_message_info(&pool, "chat-ephemeral", "msg-ephemeral")
+        .await?
+        .expect("ephemeral chat message should be returned for indexing");
+    assert_eq!(ephemeral.content, "another message");
+    assert!(ephemeral.deleted_at.is_none());
+
+    Ok(())
+}


### PR DESCRIPTION
`get_chat_message_info` had `AND c."isPersistent" = false` in its WHERE clause, so search processing skipped every persistent chat — and DCS creates every agent chat with `is_persistent: true`. Result: agent chat content never made it into OpenSearch, so searches like "codebase brighter" returned nothing. Dropping the filter indexes both persistent and ephemeral chats; soft-delete handling is unchanged. Existing persistent chats still need a one-time backfill via the SPS `/internal/backfill/chats` endpoint to become searchable.
