### PR TITLE
feat(search): preserve query and filters on back/forward (Phase 2)

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/create-search-state.ts
+++ b/js/app/packages/app/component/next-soup/soup-view/create-search-state.ts
@@ -20,7 +20,7 @@ import type {
   EntityFilters,
   UnifiedSearchRequest,
 } from '@service-search/generated/models';
-import { type Accessor, createMemo, createSignal, on } from 'solid-js';
+import { type Accessor, createMemo, on, type Setter } from 'solid-js';
 
 function filterDataToQueryFilters(data: QueryState): EntityFilters {
   const filters: EntityFilters = {};
@@ -124,8 +124,12 @@ interface CreateSearchStateArgs {
   assignees: Accessor<string[]>;
   disableLocalSearch?: boolean;
   searchPaused?: Accessor<boolean>;
-  /** Pre-populate searchText so the service request fires on mount (skips the debounce wait for the initial value). */
-  initialText?: string;
+  /**
+   * Reactive search text. Owned by the caller so it can be wired to
+   * per-entry navigation state and survive back/forward.
+   */
+  searchText: Accessor<string>;
+  setSearchText: Setter<string>;
 }
 
 export const createSearchState = ({
@@ -134,10 +138,9 @@ export const createSearchState = ({
   assignees,
   disableLocalSearch,
   searchPaused,
-  initialText,
+  searchText,
+  setSearchText,
 }: CreateSearchStateArgs) => {
-  const [searchText, setSearchText] = createSignal(initialText ?? '');
-
   const notificationSource = useGlobalNotificationSource();
   const userId = useUserId();
 

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/soup-view-search-bar.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/soup-view-search-bar.tsx
@@ -22,6 +22,7 @@ import {
   onCleanup,
   onMount,
   Show,
+  untrack,
 } from 'solid-js';
 
 type SearchbarVariant = 'filled' | 'secondary';
@@ -42,9 +43,15 @@ const variantStyles: Record<SearchbarVariant, string> = {
 };
 
 export const SoupSearchbar = (props: SoupSearchbarProps) => {
-  const { setSearchText, setSearchPaused, queryFilters } = useSoupView();
+  const { searchText, setSearchText, setSearchPaused, queryFilters } =
+    useSoupView();
   const soup = useSoup();
   const panel = useSplitPanelOrThrow();
+
+  // Read the current search-text signal once at mount so the editor opens
+  // with whatever was captured into per-entry state by the last visit.
+  // Falls back to the explicit `initialValue` prop when entry state is empty.
+  const initialEditorValue = untrack(() => searchText() || props.initialValue);
 
   const [hasContent, setHasContent] = createSignal(false);
   const [latestMarkdown, setLatestMarkdown] = createSignal('');
@@ -167,7 +174,7 @@ export const SoupSearchbar = (props: SoupSearchbarProps) => {
             config={editor}
             placeholder={props.placeholder ?? 'Search'}
             autofocus={props.autoFocus}
-            initialValue={props.initialValue}
+            initialValue={initialEditorValue}
             class="min-h-0! overflow-visible!"
           />
         </div>

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/soup-view-search-bar.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/soup-view-search-bar.tsx
@@ -22,7 +22,6 @@ import {
   onCleanup,
   onMount,
   Show,
-  untrack,
 } from 'solid-js';
 
 type SearchbarVariant = 'filled' | 'secondary';
@@ -51,7 +50,7 @@ export const SoupSearchbar = (props: SoupSearchbarProps) => {
   // Read the current search-text signal once at mount so the editor opens
   // with whatever was captured into per-entry state by the last visit.
   // Falls back to the explicit `initialValue` prop when entry state is empty.
-  const initialEditorValue = untrack(() => searchText() || props.initialValue);
+  const initialEditorValue = searchText() || props.initialValue;
 
   const [hasContent, setHasContent] = createSignal(false);
   const [latestMarkdown, setLatestMarkdown] = createSignal('');

--- a/js/app/packages/app/component/next-soup/soup-view/soup-view-context.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-view-context.tsx
@@ -7,6 +7,7 @@ import {
   type SoupState,
 } from '@app/component/next-soup/create-soup-state';
 import type { FilterContext } from '@app/component/next-soup/filters/configs/';
+import type { SetPredicatesInput } from '@app/component/next-soup/filters/filter-store/predicates-store';
 import {
   createQueryStore,
   type Query,
@@ -160,6 +161,24 @@ export const SoupViewContextProvider: FlowComponent<
     () => structuredClone(unwrap(store.state)) as Query
   );
   onCleanup(filterCaptorTeardown);
+
+  // Client-side predicate state (drives the "Type: X" chips and other
+  // toggleable filters) also needs to round-trip per entry, since the chip UI
+  // reads predicates directly and would otherwise show empty after back-nav.
+  const persistedPredicates = panel.handle.currentEntryState()?.[
+    'search.predicates'
+  ] as SetPredicatesInput<string> | undefined;
+  if (persistedPredicates) {
+    soup.predicates.set(persistedPredicates);
+  }
+  const predicatesCaptorTeardown = panel.handle.registerEntryStateCaptor(
+    'search.predicates',
+    (): SetPredicatesInput<string> => ({
+      and: [...soup.predicates.andIds()],
+      or: [...soup.predicates.orIds()],
+    })
+  );
+  onCleanup(predicatesCaptorTeardown);
 
   const invalidateCache = () => {
     queryClient.setQueryData(

--- a/js/app/packages/app/component/next-soup/soup-view/soup-view-context.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-view-context.tsx
@@ -15,6 +15,8 @@ import {
 import { createInfiniteQueries } from '@app/component/next-soup/soup-view/create-infinite-queries';
 import { createSearchState } from '@app/component/next-soup/soup-view/create-search-state';
 import { deduplicateEntities } from '@app/component/next-soup/utils';
+import { useEntryState } from '@app/component/split-layout/entry-state';
+import { useSplitPanelOrThrow } from '@app/component/split-layout/layoutUtils';
 import { ENABLE_FEATURED_SEARCH_RESULTS } from '@core/constant/featureFlags';
 import { useUserId } from '@core/context/user';
 import { throwOnErr } from '@core/util/result';
@@ -50,10 +52,12 @@ import {
   createSignal,
   type FlowComponent,
   on,
+  onCleanup,
   type Setter,
   Suspense,
   useContext,
 } from 'solid-js';
+import { unwrap } from 'solid-js/store';
 
 type DataSource<T> = {
   data: Accessor<T[]>;
@@ -140,7 +144,22 @@ export const SoupViewContextProvider: FlowComponent<
     };
   });
 
-  const store = createQueryStore({ initial: props.initialQuery });
+  const panel = useSplitPanelOrThrow();
+
+  // Restore filter state from this history entry if it was captured during a
+  // previous nav-away; otherwise fall back to the caller-provided initial.
+  const persistedFilters = panel.handle.currentEntryState()?.[
+    'search.filters'
+  ] as Query | undefined;
+  const store = createQueryStore({
+    initial: persistedFilters ?? props.initialQuery,
+  });
+
+  const filterCaptorTeardown = panel.handle.registerEntryStateCaptor(
+    'search.filters',
+    () => structuredClone(unwrap(store.state)) as Query
+  );
+  onCleanup(filterCaptorTeardown);
 
   const invalidateCache = () => {
     queryClient.setQueryData(
@@ -208,13 +227,18 @@ export const SoupViewContextProvider: FlowComponent<
   // soupBody is derived from the query filter store's compiled AST
   const soupBody = createMemo(() => queryFilters.compile());
 
+  const [searchText, setSearchText] = useEntryState<string>('search.text', {
+    default: props.initialSearchText ?? '',
+  });
+
   const search = createSearchState({
     soup,
     filters: () => queryFilters.state,
     assignees: assigneeFilter,
     disableLocalSearch: props.disableLocalSearch,
     searchPaused,
-    initialText: props.initialSearchText,
+    searchText,
+    setSearchText,
   });
 
   const notificationSource = useGlobalNotificationSource();

--- a/js/app/packages/app/component/next-soup/soup-view/soup-view-context.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-view-context.tsx
@@ -219,7 +219,10 @@ export const SoupViewContextProvider: FlowComponent<
 
   const [searchPaused, setSearchPaused] = createSignal(false);
   const [assigneeFilter, setAssigneeFilter] = createSignal<string[]>([]);
-  const [activeTab, setActiveTab] = createSignal<string | undefined>(undefined);
+  const [activeTab, setActiveTab] = useEntryState<string | undefined>(
+    'soup.tab',
+    { default: undefined }
+  );
 
   const groupByField = createMemo((): GroupByField | undefined => {
     const id = soup.grouping.activeGroupId();

--- a/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
@@ -973,7 +973,7 @@ export const SoupViewList = (props: SoupViewListProps) => {
         soup.grouping.collapseAll(initialPersistedState.collapsedGroups ?? []);
       });
     } else {
-      if (props.initialClientFilters) {
+      if (!skipFiltersOnMount && props.initialClientFilters) {
         soup.predicates.set(props.initialClientFilters);
       }
       if (props.initialGroupBy) {

--- a/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
@@ -956,7 +956,7 @@ export const SoupViewList = (props: SoupViewListProps) => {
               emailView: persistedFilterData.emailView,
             });
           }
-          if (isListViewID(contentId)) {
+          if (!skipFiltersOnMount && isListViewID(contentId)) {
             const tab =
               initialPersistedState.activeTab ??
               VIEW_TAB_PRESETS[contentId].default;
@@ -980,7 +980,7 @@ export const SoupViewList = (props: SoupViewListProps) => {
         soup.grouping.setActiveGroupId(props.initialGroupBy);
       }
       // Set default tab for list views when no persisted state exists
-      if (isListViewID(contentId)) {
+      if (!skipFiltersOnMount && isListViewID(contentId)) {
         const defaultTab = VIEW_TAB_PRESETS[contentId].default;
         if (defaultTab) {
           setActiveTab(defaultTab);

--- a/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
@@ -62,6 +62,7 @@ import {
   SplitHeaderRight,
 } from '@app/component/split-layout/components/SplitHeader';
 import { SplitPanelContext } from '@app/component/split-layout/context';
+import { useNavigationCause } from '@app/component/split-layout/entry-state';
 import { useSplitPanelOrThrow } from '@app/component/split-layout/layoutUtils';
 import { isListViewID, type ListView } from '@app/constants/list-views';
 import { CustomScrollbar } from '@core/component/CustomScrollbar';
@@ -906,6 +907,13 @@ export const SoupViewList = (props: SoupViewListProps) => {
 
   const persistenceDisabled = isProjectList || isDuplicate;
 
+  // On back/forward navigation, filters were already restored from per-entry
+  // state during SoupViewContextProvider's body — don't let the cross-session
+  // localStorage hack overwrite them on this mount.
+  const navCause = useNavigationCause();
+  const skipFiltersOnMount =
+    navCause() === 'history-back' || navCause() === 'history-forward';
+
   const [persistedState, setPersistedState] = makePersisted(
     createSignal<PersistedSoupViewState>(),
     { name: soupViewCacheKey(contentId) }
@@ -933,19 +941,21 @@ export const SoupViewList = (props: SoupViewListProps) => {
         applyTabPreset(contentId, initialPersistedState.activeTab);
       if (!applied) {
         batch(() => {
-          soup.predicates.set(
-            isStale
-              ? (props.initialClientFilters ?? {})
-              : initialPersistedState.filters
-          );
-          const persistedFilterData = isStale
-            ? {}
-            : (initialPersistedState.queryFilters ?? {});
-          queryFilters.replace({
-            include: persistedFilterData.include,
-            exclude: persistedFilterData.exclude,
-            emailView: persistedFilterData.emailView,
-          });
+          if (!skipFiltersOnMount) {
+            soup.predicates.set(
+              isStale
+                ? (props.initialClientFilters ?? {})
+                : initialPersistedState.filters
+            );
+            const persistedFilterData = isStale
+              ? {}
+              : (initialPersistedState.queryFilters ?? {});
+            queryFilters.replace({
+              include: persistedFilterData.include,
+              exclude: persistedFilterData.exclude,
+              emailView: persistedFilterData.emailView,
+            });
+          }
           if (isListViewID(contentId)) {
             const tab =
               initialPersistedState.activeTab ??


### PR DESCRIPTION
Phase 2 of the per-entry navigation state work. Wires search text and filters in `SoupView` to `useEntryState` so they round-trip on back/forward, and gates the existing `SoupView` localStorage filter restore on `useNavigationCause()` so history navigation isn't clobbered. Implements `[search] support back navigation for search`. Stacked on #3493.
