### PR TITLE
chore(infra): enable join-shape chats index reads on dev

### DIFF
--- a/infra/stacks/cloud-storage-service/Pulumi.dev.yaml
+++ b/infra/stacks/cloud-storage-service/Pulumi.dev.yaml
@@ -30,3 +30,4 @@ config:
   cloud-storage-service:anthropic_api_key: anthropic-api-key-dev
   cloud-storage-service:apple_bundle_id: apple-bundle-id-prod
   cloud-storage-service:documents_index_uses_join: "true"
+  cloud-storage-service:chats_index_uses_join: "true"

--- a/infra/stacks/search-processing-service/Pulumi.dev.yaml
+++ b/infra/stacks/search-processing-service/Pulumi.dev.yaml
@@ -5,3 +5,4 @@ config:
   search-processing-service:opensearch_password_key: macro-opensearch-password-dev
   search-processing-service:internal_auth_key: document-storage-service-auth-key-dev
   search-processing-service:documents_index_uses_join: "true"
+  search-processing-service:chats_index_uses_join: "true"


### PR DESCRIPTION
Stacked on #3492. **Do not merge until dev `chats_v2` exists and is backfilled** — otherwise flipping the env var points services at an empty (or partial) index and search breaks for dev users.

Sequence:
1. #3492 merges → deploy dev
2. Create `chats_v2` on dev OS (idle, no alias)
3. Full backfill into `chats_v2` via the deployed sps (`index_override: "chats_v2"`)
4. Merge this PR → dev services read join-shape
5. Swap dev alias `chats` → `chats_v2`

Diff: sets `CHATS_INDEX_USES_JOIN=true` on cloud-storage-service and search-processing-service in dev so they read chats as parent/child join.