### PR TITLE
chore(infra): enable join-shape chats index reads on prod

### DIFF
--- a/infra/stacks/cloud-storage-service/Pulumi.prod.yaml
+++ b/infra/stacks/cloud-storage-service/Pulumi.prod.yaml
@@ -31,3 +31,4 @@ config:
   cloud-storage-service:apple_bundle_id: apple-bundle-id-prod
   cloud-storage-service:documents_index_uses_join: "true"
   cloud-storage-service:call_records_index_uses_join: "true"
+  cloud-storage-service:chats_index_uses_join: "true"

--- a/infra/stacks/search-processing-service/Pulumi.prod.yaml
+++ b/infra/stacks/search-processing-service/Pulumi.prod.yaml
@@ -6,3 +6,4 @@ config:
   search-processing-service:internal_auth_key: document-storage-service-auth-key-prod
   search-processing-service:documents_index_uses_join: "true"
   search-processing-service:call_records_index_uses_join: "true"
+  search-processing-service:chats_index_uses_join: "true"


### PR DESCRIPTION
Stacked on #3492. **Do not merge until prod `chats_v2` exists and is fully backfilled** — flipping the env var early points services at an empty index and breaks search for everyone.

Sequence:
1. #3492 merges → deploy prod (defaults to flat; no user-visible change)
2. Create `chats_v2` on prod OS (idle, no alias)
3. Full backfill into `chats_v2` via deployed sps (`index_override: "chats_v2"`)
4. Validate dev (via #3497) first
5. Merge this PR → prod services read join-shape
6. Swap prod alias `chats` → `chats_v2`

Diff: sets `CHATS_INDEX_USES_JOIN=true` on cloud-storage-service and search-processing-service in prod so they read chats as parent/child join.