### PR TITLE
chore(infra): enable join-shape call records index reads on dev

### DIFF
--- a/infra/stacks/cloud-storage-service/Pulumi.dev.yaml
+++ b/infra/stacks/cloud-storage-service/Pulumi.dev.yaml
@@ -31,3 +31,4 @@ config:
   cloud-storage-service:apple_bundle_id: apple-bundle-id-prod
   cloud-storage-service:documents_index_uses_join: "true"
   cloud-storage-service:chats_index_uses_join: "true"
+  cloud-storage-service:call_records_index_uses_join: "true"

--- a/infra/stacks/search-processing-service/Pulumi.dev.yaml
+++ b/infra/stacks/search-processing-service/Pulumi.dev.yaml
@@ -6,3 +6,4 @@ config:
   search-processing-service:internal_auth_key: document-storage-service-auth-key-dev
   search-processing-service:documents_index_uses_join: "true"
   search-processing-service:chats_index_uses_join: "true"
+  search-processing-service:call_records_index_uses_join: "true"


### PR DESCRIPTION
Stacked on #3499. **Do not merge until dev `call_records_v2` exists and is backfilled** — otherwise flipping the env var points services at an empty index and search breaks for dev users.

Sequence:
1. #3499 merges → deploy dev
2. Create `call_records_v2` on dev OS (idle, no alias)
3. Full backfill into `call_records_v2` via the deployed sps (`index_override: "call_records_v2"`)
4. Merge this PR → dev services read join-shape
5. Swap dev alias `call_records` → `call_records_v2`
