### PR TITLE
chore(infra): enable join-shape call records index reads on prod

### DIFF
--- a/infra/stacks/cloud-storage-service/Pulumi.prod.yaml
+++ b/infra/stacks/cloud-storage-service/Pulumi.prod.yaml
@@ -30,3 +30,4 @@ config:
   cloud-storage-service:anthropic_api_key: anthropic-api-key
   cloud-storage-service:apple_bundle_id: apple-bundle-id-prod
   cloud-storage-service:documents_index_uses_join: "true"
+  cloud-storage-service:call_records_index_uses_join: "true"

--- a/infra/stacks/search-processing-service/Pulumi.prod.yaml
+++ b/infra/stacks/search-processing-service/Pulumi.prod.yaml
@@ -5,3 +5,4 @@ config:
   search-processing-service:opensearch_password_key: macro-opensearch-password-prod
   search-processing-service:internal_auth_key: document-storage-service-auth-key-prod
   search-processing-service:documents_index_uses_join: "true"
+  search-processing-service:call_records_index_uses_join: "true"


### PR DESCRIPTION
Stacked on #3499. **Do not merge until prod `call_records_v2` exists and is fully backfilled** — flipping the env var early points services at an empty index and breaks search for everyone.

Sequence:
1. #3499 merges → deploy prod (defaults to flat; no user-visible change)
2. Create `call_records_v2` on prod OS (idle, no alias)
3. Full backfill into `call_records_v2` via deployed sps (`index_override: "call_records_v2"`)
4. Validate dev (via #3500) first
5. Merge this PR → prod services read join-shape
6. Swap prod alias `call_records` → `call_records_v2`
