### PR TITLE
feat(crm): skip populate_contact when contact and user share a domain

### DIFF
--- a/rust/cloud-storage/crm/src/domain/service.rs
+++ b/rust/cloud-storage/crm/src/domain/service.rs
@@ -233,8 +233,10 @@ where
         // populate path; the link's email is treated as the source of
         // truth elsewhere, so we don't want a bad value here to error
         // out an otherwise valid contact populate.
-        if let Some((_, user_domain)) = user_email.trim().split_once('@')
+        if let Some((user_local_part, user_domain)) = user_email.trim().split_once('@')
+            && !user_local_part.is_empty()
             && !user_domain.is_empty()
+            && !user_domain.contains('@')
             && user_domain.eq_ignore_ascii_case(domain)
         {
             tracing::debug!(

--- a/rust/cloud-storage/crm/src/domain/service.rs
+++ b/rust/cloud-storage/crm/src/domain/service.rs
@@ -33,6 +33,11 @@ pub trait CrmService: Clone + Send + Sync + 'static {
     /// `crm_contacts` row; later populates from other team members can't
     /// overwrite it. Pass `None` when no display name is available.
     ///
+    /// `user_email` is the email address registered against `link_id`
+    /// (i.e. the user's own mailbox). When the contact's domain matches
+    /// the user's, the call is a no-op: intra-company correspondence
+    /// would just fill the team's CRM with the team itself.
+    ///
     /// Before the populate transaction, this method ensures
     /// `crm_domain_directory` has an entry for the email's domain — if
     /// not, it invokes the
@@ -45,6 +50,7 @@ pub trait CrmService: Clone + Send + Sync + 'static {
         &self,
         team_id: &uuid::Uuid,
         link_id: &uuid::Uuid,
+        user_email: &str,
         email: &str,
         name: Option<&str>,
     ) -> impl Future<Output = Result<(), CrmError>> + Send;
@@ -200,6 +206,7 @@ where
         &self,
         team_id: &uuid::Uuid,
         link_id: &uuid::Uuid,
+        user_email: &str,
         email: &str,
         name: Option<&str>,
     ) -> Result<(), CrmError> {
@@ -218,6 +225,23 @@ where
             return Err(CrmError::StorageLayerError(anyhow::anyhow!(
                 "email {email} has an empty domain"
             )));
+        }
+
+        // Skip when the contact lives on the user's own domain —
+        // colleagues at the user's company shouldn't show up in their
+        // team's CRM. Malformed user emails fall through to the regular
+        // populate path; the link's email is treated as the source of
+        // truth elsewhere, so we don't want a bad value here to error
+        // out an otherwise valid contact populate.
+        if let Some((_, user_domain)) = user_email.trim().split_once('@')
+            && !user_domain.is_empty()
+            && user_domain.eq_ignore_ascii_case(domain)
+        {
+            tracing::debug!(
+                domain,
+                "Skipping CRM populate for contact on the user's own domain"
+            );
+            return Ok(());
         }
 
         // Skip personal / free-mail-provider domains (gmail, yahoo,

--- a/rust/cloud-storage/crm/src/outbound/companies_repo/test.rs
+++ b/rust/cloud-storage/crm/src/outbound/companies_repo/test.rs
@@ -557,3 +557,120 @@ async fn set_contact_hidden_isolates_contacts_across_teams(pool: PgPool) -> anyh
     assert_eq!(fetch_contact_hidden(&pool, contact_a).await?, Some(false));
     Ok(())
 }
+
+async fn enable_crm_for_team(pool: &PgPool, team_id: Uuid) -> sqlx::Result<()> {
+    sqlx::query(
+        r#"INSERT INTO team_crm_settings (team_id, crm_enabled) VALUES ($1, TRUE)
+           ON CONFLICT (team_id) DO UPDATE SET crm_enabled = TRUE"#,
+    )
+    .bind(team_id)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+async fn count_companies_for_domain(
+    pool: &PgPool,
+    team_id: Uuid,
+    domain: &str,
+) -> sqlx::Result<i64> {
+    let (count,): (i64,) = sqlx::query_as(
+        r#"SELECT COUNT(*) FROM crm_companies c
+           JOIN crm_domains d ON d.company_id = c.id
+           WHERE c.team_id = $1 AND LOWER(d.domain) = LOWER($2)"#,
+    )
+    .bind(team_id)
+    .bind(domain)
+    .fetch_one(pool)
+    .await?;
+    Ok(count)
+}
+
+#[sqlx::test(migrator = "MACRO_DB_MIGRATIONS")]
+async fn service_populate_contact_skips_when_domain_matches_user_domain(
+    pool: PgPool,
+) -> anyhow::Result<()> {
+    let team_id = Uuid::now_v7();
+    let owner_id = "macro|owner@test.com";
+    seed_team(&pool, team_id, owner_id).await?;
+    enable_crm_for_team(&pool, team_id).await?;
+    let link_id = insert_email_link(&pool, owner_id, "user@macro.com").await?;
+
+    let service = CrmServiceImpl::new(
+        CompaniesRepositoryImpl::new(pool.clone()),
+        NoOpCompanyMetadataResolver,
+    );
+
+    service
+        .populate_contact(
+            &team_id,
+            &link_id,
+            "user@macro.com",
+            "colleague@macro.com",
+            None,
+        )
+        .await?;
+
+    assert_eq!(
+        count_companies_for_domain(&pool, team_id, "macro.com").await?,
+        0,
+        "contact on the user's own domain must not create a CRM row"
+    );
+    Ok(())
+}
+
+#[sqlx::test(migrator = "MACRO_DB_MIGRATIONS")]
+async fn service_populate_contact_same_domain_check_is_case_insensitive(
+    pool: PgPool,
+) -> anyhow::Result<()> {
+    let team_id = Uuid::now_v7();
+    let owner_id = "macro|owner@test.com";
+    seed_team(&pool, team_id, owner_id).await?;
+    enable_crm_for_team(&pool, team_id).await?;
+    let link_id = insert_email_link(&pool, owner_id, "User@MACRO.com").await?;
+
+    let service = CrmServiceImpl::new(
+        CompaniesRepositoryImpl::new(pool.clone()),
+        NoOpCompanyMetadataResolver,
+    );
+
+    service
+        .populate_contact(
+            &team_id,
+            &link_id,
+            "User@MACRO.com",
+            "colleague@macro.com",
+            None,
+        )
+        .await?;
+
+    assert_eq!(
+        count_companies_for_domain(&pool, team_id, "macro.com").await?,
+        0
+    );
+    Ok(())
+}
+
+#[sqlx::test(migrator = "MACRO_DB_MIGRATIONS")]
+async fn service_populate_contact_writes_when_domain_differs(pool: PgPool) -> anyhow::Result<()> {
+    let team_id = Uuid::now_v7();
+    let owner_id = "macro|owner@test.com";
+    seed_team(&pool, team_id, owner_id).await?;
+    enable_crm_for_team(&pool, team_id).await?;
+    let link_id = insert_email_link(&pool, owner_id, "user@macro.com").await?;
+
+    let service = CrmServiceImpl::new(
+        CompaniesRepositoryImpl::new(pool.clone()),
+        NoOpCompanyMetadataResolver,
+    );
+
+    service
+        .populate_contact(&team_id, &link_id, "user@macro.com", "alice@acme.com", None)
+        .await?;
+
+    assert_eq!(
+        count_companies_for_domain(&pool, team_id, "acme.com").await?,
+        1
+    );
+    Ok(())
+}

--- a/rust/cloud-storage/email_service/src/pubsub/backfill/populate_crm_contact.rs
+++ b/rust/cloud-storage/email_service/src/pubsub/backfill/populate_crm_contact.rs
@@ -47,6 +47,7 @@ pub async fn populate_crm_contact(
         .populate_contact(
             &team_id,
             &link.id,
+            link.email_address.0.as_ref(),
             &p.contact_email,
             p.contact_name.as_deref(),
         )


### PR DESCRIPTION
## Summary

- Plumbs the user's email (from `link.email_address`) through `CrmService::populate_contact` and skips with a debug log when the contact's domain matches the user's domain (case-insensitive).
- This complements the existing generic-provider filter — colleagues at the user's own company are no longer added as CRM contacts.
- Adds three integration tests covering the skip, case-insensitivity, and the cross-domain happy path.

## Notes

- The check is intentionally lenient on malformed `user_email`: if the link's email lacks an `@`, we fall through to the regular populate path rather than erroring an otherwise-valid populate.
- The only caller (`populate_crm_contact` in `email_service`) passes `link.email_address.0.as_ref()`.
