### PR TITLE
fix(ai): Email tool improvements

### DIFF
--- a/js/app/packages/core/component/AI/component/tool/ListLabels.tsx
+++ b/js/app/packages/core/component/AI/component/tool/ListLabels.tsx
@@ -1,0 +1,14 @@
+import TagSimple from '@phosphor-icons/core/regular/tag-simple.svg';
+import { BaseTool } from './BaseTool';
+import { createToolRenderer } from './ToolRenderer';
+
+const handler = createToolRenderer({
+  name: 'ListLabels',
+  render: (ctx) => (
+    <BaseTool icon={TagSimple} renderContext={ctx.renderContext} type="call">
+      List email labels
+    </BaseTool>
+  ),
+});
+
+export const listLabelsHandler = handler;

--- a/js/app/packages/core/component/AI/component/tool/handler.tsx
+++ b/js/app/packages/core/component/AI/component/tool/handler.tsx
@@ -9,6 +9,7 @@ import { createDocumentHandler } from './CreateDocument';
 import { getThreadHandler } from './GetThread';
 import { listCallRecordsHandler } from './ListCallRecords';
 import { listEntitiesHandler } from './ListEntities';
+import { listLabelsHandler } from './ListLabels';
 import { listTeamMembersHandler } from './ListTeamMembers';
 import {
   listNotificationsHandler,
@@ -48,6 +49,7 @@ const toolHandlers: ToolHandlerMap<RenderContext> = {
   GetEntityProperties: getEntityPropertiesHandler,
   ListCallRecords: listCallRecordsHandler,
   ListEntities: listEntitiesHandler,
+  ListLabels: listLabelsHandler,
   ListNotifications: listNotificationsHandler,
   ListTeamMembers: listTeamMembersHandler,
   MarkNotificationsDone: markNotificationsDoneHandler,

--- a/js/app/packages/service-clients/service-cognition/generated/tools/schemas.ts
+++ b/js/app/packages/service-clients/service-cognition/generated/tools/schemas.ts
@@ -509,6 +509,15 @@ export const ListEntitiesResponse = z.object({
   summary: z.string(),
 });
 
+export const ListLabels = z.record(z.any());
+
+export const ListLabelsResponse = z.object({
+  labels: z.array(
+    z.object({ id: z.string().uuid(), name: z.string(), type: z.string() })
+  ),
+  summary: z.string(),
+});
+
 export const ListNotifications = z.object({
   done: z.union([z.boolean(), z.null()]).default(null),
   entities: z

--- a/js/app/packages/service-clients/service-cognition/generated/tools/tool.ts
+++ b/js/app/packages/service-clients/service-cognition/generated/tools/tool.ts
@@ -33,6 +33,7 @@ type ToolParserMap = {
     call: types.ListEntities;
     response: types.ListEntitiesResponse;
   };
+  ListLabels: { call: types.ListLabels; response: types.ListLabelsResponse };
   ListNotifications: {
     call: types.ListNotifications;
     response: types.ListNotificationsResponse;
@@ -119,6 +120,10 @@ const toolParserMap = {
   ListEntities: {
     call: schemas.ListEntities,
     response: schemas.ListEntitiesResponse,
+  },
+  ListLabels: {
+    call: schemas.ListLabels,
+    response: schemas.ListLabelsResponse,
   },
   ListNotifications: {
     call: schemas.ListNotifications,
@@ -224,6 +229,7 @@ type ToolDataMap = {
     call: types.ListEntities;
     response: types.ListEntitiesResponse;
   };
+  ListLabels: { call: types.ListLabels; response: types.ListLabelsResponse };
   ListNotifications: {
     call: types.ListNotifications;
     response: types.ListNotificationsResponse;

--- a/js/app/packages/service-clients/service-cognition/generated/tools/types.ts
+++ b/js/app/packages/service-clients/service-cognition/generated/tools/types.ts
@@ -1195,7 +1195,9 @@ export interface ListEntities {
    */
   emailPreset?: EmailPreset | null;
   /**
-   * Email view to use for email results: inbox (default), sent, drafts, starred, all, important, other, or user:<label>.
+   * Which mailbox view to hydrate previews from for email results. Valid values: inbox (default), sent, drafts, starred, all, important, other, or user:<label>.
+   *
+   * When the user asks about signal/noise emails, use emailView="inbox" together with emailPreset="signal"/"noise" — do not set emailView="important" in that case. Only override the default when the user explicitly asks for a specific mailbox or label view (e.g. "sent", "drafts", "my Foo label").
    */
   emailView?: string | null;
   /**
@@ -1223,6 +1225,53 @@ export interface ListEntities {
 export interface ListEntitiesResponse {
   items: EntityItem[];
   summary: string;
+}
+/**
+ * List the user's Gmail labels. Returns both system labels (INBOX, SENT, DRAFTS, UNREAD, STARRED, TRASH, SPAM, IMPORTANT, CATEGORY_PERSONAL, CATEGORY_SOCIAL, CATEGORY_PROMOTIONS, CATEGORY_UPDATES, CATEGORY_FORUMS, etc.) and any custom user-created labels. Each label has a UUID `id` and a `name`.
+ *
+ * Gmail represents nearly every inbox operation as a label add/remove, so this tool is the first step for almost any thread-management action: call ListLabels once to find the label `id` by `name`, then pass that `id` to UpdateThreadLabels. Common pairings (look up the named system label here, then call UpdateThreadLabels with that id):
+ * - Archive a thread → remove `INBOX` (add=false)
+ * - Move back to inbox → add `INBOX` (add=true)
+ * - Mark as read → remove `UNREAD` (add=false)
+ * - Mark as unread → add `UNREAD` (add=true)
+ * - Star → add `STARRED`; Unstar → remove `STARRED`
+ * - Move to trash → add `TRASH`; Restore from trash → remove `TRASH`
+ * - Mark important → add `IMPORTANT`; Mark unimportant → remove `IMPORTANT`
+ * - Report spam → add `SPAM`; Not spam → remove `SPAM`
+ * - Apply or remove a custom user label → look up the label by its display name and add/remove it
+ *
+ * Match label names case-insensitively when searching the response. You can also use this to understand how the user's mail is organized before filtering or searching by label.
+ */
+export type ListLabels = {};
+/**
+ * Response from the ListLabels tool.
+ */
+export interface ListLabelsResponse {
+  /**
+   * The user's email labels.
+   */
+  labels: ToolLabel[];
+  /**
+   * A human-readable summary of the labels.
+   */
+  summary: string;
+}
+/**
+ * A simplified label for tool output.
+ */
+export interface ToolLabel {
+  /**
+   * The label's unique identifier.
+   */
+  id: string;
+  /**
+   * The display name of the label.
+   */
+  name: string;
+  /**
+   * Whether this is a "system" or "user" label.
+   */
+  type: string;
 }
 /**
  * List the current user's notifications. By default returns active notifications (not deleted, not done), ordered by most recent first. Use `done` and `seen` to request done/not-done or seen/unseen notifications.
@@ -2377,19 +2426,34 @@ export interface TextEditorCodeExecutionToolCall {
   path: string;
 }
 /**
- * Add or remove a label from all messages in an email thread. Use ListLabels first to get valid label IDs. Set `add` to true to apply the label, or false to remove it.
+ * Add or remove a single label from every message in a Gmail thread. In Gmail, nearly all inbox operations are just label add/remove operations, so this tool is the primitive for archiving, marking read/unread, starring, trashing, marking important/spam, and applying or removing custom labels.
+ *
+ * Workflow: call ListLabels first to discover the UUID `id` for the label name you need, then call this tool with that `label_id` plus the thread's `thread_id` and `add=true` (apply) or `add=false` (remove). Each call modifies one label — to do multiple changes on the same thread (e.g. archive AND mark read), call this tool once per label.
+ *
+ * Common operations (look up each system label's id via ListLabels first):
+ * - Archive: remove `INBOX` (add=false)
+ * - Move back to inbox: add `INBOX` (add=true)
+ * - Mark as read: remove `UNREAD` (add=false)
+ * - Mark as unread: add `UNREAD` (add=true)
+ * - Star: add `STARRED` (add=true) / Unstar: remove (add=false)
+ * - Move to trash: add `TRASH` (add=true) / Restore: remove (add=false)
+ * - Mark important: add `IMPORTANT` (add=true) / Mark unimportant: remove (add=false)
+ * - Report spam: add `SPAM` (add=true) / Not spam: remove (add=false)
+ * - Apply custom user label: add the label with that display name (add=true) / Remove: (add=false)
+ *
+ * `thread_id` is the email thread UUID (the same id returned by ListEntities, search results, or GetThread). `label_id` is the UUID returned by ListLabels — NOT the label name.
  */
 export interface UpdateThreadLabels {
   /**
-   * Whether to add (true) or remove (false) the label.
+   * Whether to add (true) or remove (false) the label from every message in the thread.
    */
   add: boolean;
   /**
-   * The ID of the label to add or remove. Use ListLabels to get valid label IDs.
+   * The UUID of the label to add or remove. Obtain this by calling ListLabels and looking up the label by name — do not pass the label name here.
    */
   label_id: string;
   /**
-   * The ID of the email thread to modify.
+   * The ID of the email thread to modify. Same UUID returned by ListEntities, search, or GetThread.
    */
   thread_id: string;
 }

--- a/js/app/packages/service-clients/service-cognition/generated/tools/types.ts
+++ b/js/app/packages/service-clients/service-cognition/generated/tools/types.ts
@@ -1242,7 +1242,7 @@ export interface ListEntitiesResponse {
  *
  * Match label names case-insensitively when searching the response. You can also use this to understand how the user's mail is organized before filtering or searching by label.
  */
-export interface ListLabels {}
+export type ListLabels = {};
 /**
  * Response from the ListLabels tool.
  */
@@ -1367,7 +1367,7 @@ export interface NotificationItem {
 /**
  * List the current members and pending invites for the authenticated user's team. Requires the caller to be a team member.
  */
-export interface ListTeamMembers {}
+export type ListTeamMembers = {};
 /**
  * Response from [`ListTeamMembers`].
  */

--- a/js/app/packages/service-clients/service-cognition/generated/tools/types.ts
+++ b/js/app/packages/service-clients/service-cognition/generated/tools/types.ts
@@ -1197,7 +1197,7 @@ export interface ListEntities {
   /**
    * Which mailbox view to hydrate previews from for email results. Valid values: inbox (default), sent, drafts, starred, all, important, other, or user:<label>.
    *
-   * When the user asks about signal/noise emails, use emailView="inbox" together with emailPreset="signal"/"noise" — do not set emailView="important" in that case. Only override the default when the user explicitly asks for a specific mailbox or label view (e.g. "sent", "drafts", "my Foo label").
+   * When the user asks about signal or important emails, use emailView="inbox" together with emailPreset="signal" — do not set emailView="important" in that case. Only override the default when the user explicitly asks for a specific mailbox or label view (e.g. "sent", "drafts", "my Foo label").
    */
   emailView?: string | null;
   /**
@@ -1242,7 +1242,7 @@ export interface ListEntitiesResponse {
  *
  * Match label names case-insensitively when searching the response. You can also use this to understand how the user's mail is organized before filtering or searching by label.
  */
-export type ListLabels = {};
+export interface ListLabels {}
 /**
  * Response from the ListLabels tool.
  */
@@ -1367,7 +1367,7 @@ export interface NotificationItem {
 /**
  * List the current members and pending invites for the authenticated user's team. Requires the caller to be a team member.
  */
-export type ListTeamMembers = {};
+export interface ListTeamMembers {}
 /**
  * Response from [`ListTeamMembers`].
  */

--- a/js/app/scripts/generate-dcs-tools.ts
+++ b/js/app/scripts/generate-dcs-tools.ts
@@ -139,10 +139,11 @@ async function generateToolTypesFile(schema: CombinedSchema) {
   );
 
   // Strip the root wrapper interface — we only want the definition types
-  const cleaned = code.replace(
-    /export interface AllToolTypes\s*\{[\s\S]*?\n\}\n*/,
-    ''
-  );
+  const cleaned = code
+    .replace(/export interface AllToolTypes\s*\{[\s\S]*?\n\}\n*/, '')
+    // Empty Rust structs compile to `export interface X {}`, which biome's
+    // `noEmptyInterface` rule rejects. Rewrite to a type alias.
+    .replace(/export interface (\w+) \{\}/g, 'export type $1 = {};');
 
   await Bun.write(typesFile, `${warning}\n${cleaned}`);
 }

--- a/rust/cloud-storage/email/Cargo.toml
+++ b/rust/cloud-storage/email/Cargo.toml
@@ -79,6 +79,7 @@ utoipa = { workspace = true, optional = true }
 uuid = { workspace = true }
 
 [dev-dependencies]
+crm = { path = "../crm", features = ["outbound"] }
 frecency = { path = "../frecency", features = ["outbound", "postgres"] }
 macro_db_migrator = { path = "../macro_db_migrator" }
 serde_json = { workspace = true }

--- a/rust/cloud-storage/email/src/inbound/toolset/list_labels.rs
+++ b/rust/cloud-storage/email/src/inbound/toolset/list_labels.rs
@@ -55,7 +55,28 @@ pub struct ListLabelsResponse {
 #[derive(Debug, Deserialize, JsonSchema, Clone, Default)]
 #[schemars(
     title = "ListLabels",
-    description = "List the user's email labels including system labels (INBOX, SENT, DRAFTS, etc.) and any custom user-created labels. Use this to understand how the user's email is organized before filtering or searching by label."
+    description = "\
+List the user's Gmail labels. Returns both system labels (INBOX, SENT, DRAFTS, UNREAD, \
+STARRED, TRASH, SPAM, IMPORTANT, CATEGORY_PERSONAL, CATEGORY_SOCIAL, CATEGORY_PROMOTIONS, \
+CATEGORY_UPDATES, CATEGORY_FORUMS, etc.) and any custom user-created labels. Each label \
+has a UUID `id` and a `name`.\n\
+\n\
+Gmail represents nearly every inbox operation as a label add/remove, so this tool is the \
+first step for almost any thread-management action: call ListLabels once to find the label \
+`id` by `name`, then pass that `id` to UpdateThreadLabels. Common pairings (look up the \
+named system label here, then call UpdateThreadLabels with that id):\n\
+- Archive a thread → remove `INBOX` (add=false)\n\
+- Move back to inbox → add `INBOX` (add=true)\n\
+- Mark as read → remove `UNREAD` (add=false)\n\
+- Mark as unread → add `UNREAD` (add=true)\n\
+- Star → add `STARRED`; Unstar → remove `STARRED`\n\
+- Move to trash → add `TRASH`; Restore from trash → remove `TRASH`\n\
+- Mark important → add `IMPORTANT`; Mark unimportant → remove `IMPORTANT`\n\
+- Report spam → add `SPAM`; Not spam → remove `SPAM`\n\
+- Apply or remove a custom user label → look up the label by its display name and add/remove it\n\
+\n\
+Match label names case-insensitively when searching the response. You can also use this to \
+understand how the user's mail is organized before filtering or searching by label."
 )]
 #[allow(unused)]
 // empty structs can't be deserialized;

--- a/rust/cloud-storage/email/src/inbound/toolset/mod.rs
+++ b/rust/cloud-storage/email/src/inbound/toolset/mod.rs
@@ -109,4 +109,5 @@ where
     AsyncToolCollection::new()
         .add_tool::<UpdateThreadLabels, EmailToolContext<T, G, E>>()
         .add_tool::<GetThread, EmailToolContext<T, G, E>>()
+        .add_tool::<ListLabels, EmailToolContext<T, G, E>>()
 }

--- a/rust/cloud-storage/email/src/inbound/toolset/update_thread_labels.rs
+++ b/rust/cloud-storage/email/src/inbound/toolset/update_thread_labels.rs
@@ -15,14 +15,37 @@ use super::EmailToolContext;
 #[derive(Debug, Deserialize, JsonSchema, Clone)]
 #[schemars(
     title = "UpdateThreadLabels",
-    description = "Add or remove a label from all messages in an email thread. Use ListLabels first to get valid label IDs. Set `add` to true to apply the label, or false to remove it."
+    description = "\
+Add or remove a single label from every message in a Gmail thread. In Gmail, nearly all \
+inbox operations are just label add/remove operations, so this tool is the primitive for \
+archiving, marking read/unread, starring, trashing, marking important/spam, and applying \
+or removing custom labels.\n\
+\n\
+Workflow: call ListLabels first to discover the UUID `id` for the label name you need, \
+then call this tool with that `label_id` plus the thread's `thread_id` and `add=true` \
+(apply) or `add=false` (remove). Each call modifies one label — to do multiple changes \
+on the same thread (e.g. archive AND mark read), call this tool once per label.\n\
+\n\
+Common operations (look up each system label's id via ListLabels first):\n\
+- Archive: remove `INBOX` (add=false)\n\
+- Move back to inbox: add `INBOX` (add=true)\n\
+- Mark as read: remove `UNREAD` (add=false)\n\
+- Mark as unread: add `UNREAD` (add=true)\n\
+- Star: add `STARRED` (add=true) / Unstar: remove (add=false)\n\
+- Move to trash: add `TRASH` (add=true) / Restore: remove (add=false)\n\
+- Mark important: add `IMPORTANT` (add=true) / Mark unimportant: remove (add=false)\n\
+- Report spam: add `SPAM` (add=true) / Not spam: remove (add=false)\n\
+- Apply custom user label: add the label with that display name (add=true) / Remove: (add=false)\n\
+\n\
+`thread_id` is the email thread UUID (the same id returned by ListEntities, search results, \
+or GetThread). `label_id` is the UUID returned by ListLabels — NOT the label name."
 )]
 pub struct UpdateThreadLabels {
-    /// The ID of the email thread to modify.
+    /// The ID of the email thread to modify. Same UUID returned by ListEntities, search, or GetThread.
     pub thread_id: Uuid,
-    /// The ID of the label to add or remove. Use ListLabels to get valid label IDs.
+    /// The UUID of the label to add or remove. Obtain this by calling ListLabels and looking up the label by name — do not pass the label name here.
     pub label_id: Uuid,
-    /// Whether to add (true) or remove (false) the label.
+    /// Whether to add (true) or remove (false) the label from every message in the thread.
     pub add: bool,
 }
 

--- a/rust/cloud-storage/soup/src/inbound/toolset/list_entities.rs
+++ b/rust/cloud-storage/soup/src/inbound/toolset/list_entities.rs
@@ -147,7 +147,7 @@ pub struct ListEntities {
     pub include_types: Option<Vec<ItemType>>,
 
     #[schemars(
-        description = "How to sort results: recently_viewed (default), recently_updated, or recently_created. Use recently_updated for updated_at-style soup results."
+        description = "How to sort results: recently_viewed, recently_updated (default to this), or recently_created. Use recently_updated for updated_at-style soup results. If it's an email-only request, default to recently_updated."
     )]
     #[serde(default)]
     pub sort_by: SortBy,
@@ -207,9 +207,14 @@ pub struct ListEntities {
     #[serde(default, rename = "propf")]
     pub properties_filter: LiteralTree<PropertiesLiteral>,
 
-    #[schemars(
-        description = "Email view to use for email results: inbox (default), sent, drafts, starred, all, important, other, or user:<label>."
-    )]
+    #[schemars(description = "\
+Which mailbox view to hydrate previews from for email results. Valid values: inbox \
+(default), sent, drafts, starred, all, important, other, or user:<label>.\n\
+\n\
+When the user asks about signal/noise emails, use emailView=\"inbox\" together with \
+emailPreset=\"signal\"/\"noise\" — do not set emailView=\"important\" in that case. Only \
+override the default when the user explicitly asks for a specific mailbox or label view \
+(e.g. \"sent\", \"drafts\", \"my Foo label\").")]
     #[serde(default, rename = "emailView")]
     pub email_view: Option<String>,
 

--- a/rust/cloud-storage/soup/src/inbound/toolset/list_entities.rs
+++ b/rust/cloud-storage/soup/src/inbound/toolset/list_entities.rs
@@ -34,8 +34,8 @@ const MAX_RESULT_LIMIT: u16 = 500;
 #[derive(Debug, Clone, Copy, Default, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum SortBy {
-    #[default]
     RecentlyViewed,
+    #[default]
     RecentlyUpdated,
     RecentlyCreated,
 }
@@ -211,8 +211,8 @@ pub struct ListEntities {
 Which mailbox view to hydrate previews from for email results. Valid values: inbox \
 (default), sent, drafts, starred, all, important, other, or user:<label>.\n\
 \n\
-When the user asks about signal/noise emails, use emailView=\"inbox\" together with \
-emailPreset=\"signal\"/\"noise\" — do not set emailView=\"important\" in that case. Only \
+When the user asks about signal or important emails, use emailView=\"inbox\" together \
+with emailPreset=\"signal\" — do not set emailView=\"important\" in that case. Only \
 override the default when the user explicitly asks for a specific mailbox or label view \
 (e.g. \"sent\", \"drafts\", \"my Foo label\").")]
     #[serde(default, rename = "emailView")]

--- a/rust/cloud-storage/soup/src/inbound/toolset/list_entities.rs
+++ b/rust/cloud-storage/soup/src/inbound/toolset/list_entities.rs
@@ -147,7 +147,7 @@ pub struct ListEntities {
     pub include_types: Option<Vec<ItemType>>,
 
     #[schemars(
-        description = "How to sort results: recently_viewed, recently_updated (default to this), or recently_created. Use recently_updated for updated_at-style soup results. If it's an email-only request, default to recently_updated."
+        description = "How to sort results: recently_viewed, recently_updated (default to this), or recently_created. Use recently_updated for updated_at-style soup results."
     )]
     #[serde(default)]
     pub sort_by: SortBy,

--- a/rust/cloud-storage/soup/src/inbound/toolset/test.rs
+++ b/rust/cloud-storage/soup/src/inbound/toolset/test.rs
@@ -28,7 +28,7 @@ fn test_list_entities_schema_validation() {
 fn test_default_values() {
     let list = ListEntities::default();
     assert!(list.include_types.is_none());
-    assert!(matches!(list.sort_by, SortBy::RecentlyViewed));
+    assert!(matches!(list.sort_by, SortBy::RecentlyUpdated));
 }
 
 #[test]


### PR DESCRIPTION
Updating soup ai tool to sort by updated_at by default, to match FE (ehayes approved)

Wiring up ListLabels tool because for some reason it wasn't made available to the AI.

Adding good instructions to ListLabels and UpdateThreadLabels tools so AI realizes it can perform all types of operations with them, instead of us needing to make separate tools for each (tested and it works perfectly)

Added fix for asking for signal emails had buddy using the "important" inbox when it should be using "inbox"