### PR TITLE
chore(ai): start .pi folder for ai helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,5 @@ run-local.fish
 **/node_modules
 **/result
 **/result-*
-.pi/
+.pi/plan/
+.pi/plans/

--- a/.pi/prompts/rust_clean.md
+++ b/.pi/prompts/rust_clean.md
@@ -1,0 +1,15 @@
+---
+description: Cleanup rust code
+---
+
+You will clean up the rust code in `rust/cloud-storage`.
+
+Inside of `rust/cloud-storage` run the following commands in order:
+1. `just prepare_db`
+1. `just clippy`
+1. `just check`  
+1. `just format`
+
+Note: If any of the above tests fail make sure to always run `just format` after any code is updated
+
+If any command fails surface that failure to the user and do not continue running commands.


### PR DESCRIPTION
creates the .pi folder for with a simple /rust_clean prompt that will clean up the rust codebase before you commit code