### PR TITLE
fix(soup): clear stale group-by when switching views within a split

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
@@ -966,9 +966,13 @@ export const SoupViewList = (props: SoupViewListProps) => {
       if (props.initialClientFilters) {
         soup.predicates.set(props.initialClientFilters);
       }
-      if (props.initialGroupBy) {
+      // soup state is shared at the SplitPanel level, so a prior view in the
+      // same split (e.g. tasks) may have left grouping state behind. Always
+      // reset to this view's initial grouping, even when undefined.
+      batch(() => {
         soup.grouping.setActiveGroupId(props.initialGroupBy);
-      }
+        soup.grouping.collapseAll([]);
+      });
       // Set default tab for list views when no persisted state exists
       if (isListViewID(contentId)) {
         const defaultTab = VIEW_TAB_PRESETS[contentId].default;


### PR DESCRIPTION
A split's soup state is shared across every view rendered in it, so when a split went inbox → tasks → inbox the returning inbox view kept the tasks view's `activeGroupId` because the duplicate-view check disabled persistence and the else branch only reset grouping when `initialGroupBy` was truthy. Reset grouping unconditionally in that branch.
