### PR TITLE
chore(docker): use docker compose command so you can use podman under the hood

### DIFF
--- a/infra/stacks/fusionauth-instance/justfile
+++ b/infra/stacks/fusionauth-instance/justfile
@@ -2,9 +2,9 @@
 # single-instance by design; do not derive resource names from the directory.
 export COMPOSE_PROJECT_NAME := "macro"
 
-# Gets the .env variables for the FusionAuth docker-compose.
+# Gets the .env variables for the FusionAuth docker compose.
 get_fusionauth_env:
-  @echo "Getting fusionauth .env file for docker-compose"
+  @echo "Getting fusionauth .env file for docker compose"
   curl -o .env https://raw.githubusercontent.com/FusionAuth/fusionauth-containers/452efcac5c60f6a3a734947b1a8eefaae6f811fa/docker/fusionauth/.env
 
 # Starts up the local FusionAuth instance. This should only be used during setup/testing.
@@ -14,12 +14,12 @@ start *ARGS:
   docker network create auth 2>/dev/null || true
   docker volume create fusionauth_db_data >/dev/null
   docker volume create fusionauth_config >/dev/null
-  docker-compose up {{ ARGS }}
+  docker compose up {{ ARGS }}
 
 # Stops the local FusionAuth instance. This should only be used for setup/testing.
 stop *ARGS:
   @echo "Stopping fusionauth"
-  docker-compose stop {{ ARGS }}
+  docker compose stop {{ ARGS }}
 
 # Destroys the local pulumi stack.
 destroy_local_stack:
@@ -30,7 +30,7 @@ destroy_local_stack:
 # Destroys the local FusionAuth instance and pulumi stack.
 destroy:
   just destroy_local_stack || true
-  docker-compose down -v
+  docker compose down -v
 
 # Creates the local pulumi stack and updates FusionAuth with components.
 setup_local_stack:

--- a/infra/stacks/fusionauth-instance/justfile
+++ b/infra/stacks/fusionauth-instance/justfile
@@ -12,8 +12,8 @@ start *ARGS:
   @echo "Starting fusionauth"
   test -f .env || just get_fusionauth_env
   docker network create auth 2>/dev/null || true
-  docker volume create fusionauth_db_data >/dev/null
-  docker volume create fusionauth_config >/dev/null
+  docker volume create fusionauth_db_data 2>/dev/null || true
+  docker volume create fusionauth_config 2>/dev/null || true
   docker compose up {{ ARGS }}
 
 # Stops the local FusionAuth instance. This should only be used for setup/testing.

--- a/justfile
+++ b/justfile
@@ -51,7 +51,7 @@ edit_environment *ARGS:
 # This is used when initializing your databases
 run_dbs *ARGS:
   just create_networks
-  docker-compose -f docker-compose-databases.yml up postgres redis --wait {{ ARGS }}
+  docker compose -f docker-compose-databases.yml up postgres redis --wait {{ ARGS }}
 
 # Spins up main docker-compose
 docker_up *ARGS:
@@ -191,7 +191,7 @@ stop-local:
   docker compose down
 
 stop-databases:
-  docker-compose -f docker-compose-databases.yml down
+  docker compose -f docker-compose-databases.yml down
 
 # Import LocalStack recipes
 import 'local_stack.just'
@@ -203,7 +203,7 @@ setup_local_dbs:
   just rust/cloud-storage/macro_db_client/create_db
   just rust/cloud-storage/macro_db_client/migrate_db
   @echo "Local databases initialized"
-  docker-compose -f docker-compose-databases.yml stop
+  docker compose -f docker-compose-databases.yml stop
 
 # Setup FusionAuth: start containers, wait for healthy, run Pulumi config
 # stop container

--- a/justfile
+++ b/justfile
@@ -8,11 +8,11 @@ export COMPOSE_PROJECT_NAME := "macro"
 create_networks:
   docker network create databases 2>/dev/null || true -- db network
   docker network create auth 2>/dev/null || true -- fusionauth network
-  docker volume create macro_postgres_data >/dev/null
-  docker volume create macro_redis_data >/dev/null
-  docker volume create macro_opensearch_data >/dev/null
-  docker volume create fusionauth_db_data >/dev/null
-  docker volume create fusionauth_config >/dev/null
+  docker volume create macro_postgres_data 2>/dev/null || true
+  docker volume create macro_redis_data 2>/dev/null || true
+  docker volume create macro_opensearch_data 2>/dev/null || true
+  docker volume create fusionauth_db_data 2>/dev/null || true
+  docker volume create fusionauth_config 2>/dev/null || true
   echo "docker networks and volumes created"
 
 fix_environment *ARGS:
@@ -209,7 +209,7 @@ setup_local_dbs:
 # stop container
 setup_fusionauth:
   just create_networks
-  just infra/stacks/fusionauth-instance/setup_fusionauth
+  just infra/stacks/fusionauth-instance/setup
 
 # Stop FusionAuth containers
 stop_fusionauth:


### PR DESCRIPTION
The legacy `docker-compose` command doesn't work well with podman but `docker compose` does.