### PR TITLE
feat(sidebar): restore prior entry state on sidebar nav

### DIFF
--- a/js/app/packages/app/component/app-sidebar/sidebar.tsx
+++ b/js/app/packages/app/component/app-sidebar/sidebar.tsx
@@ -12,6 +12,11 @@ import { CommandState } from '@app/component/command';
 import { createMenuOpen, setCreateMenuOpen } from '@app/component/Launcher';
 import { requestSearchFocus } from '@app/component/next-soup/soup-view/search-controllers';
 import { useSplitLayout } from '@app/component/split-layout/layout';
+import type {
+  ReferredFrom,
+  SplitContent,
+  SplitHandle,
+} from '@app/component/split-layout/layoutManager';
 import { GO_TO_COMMAND_SCOPE, GO_TO_LEADER_KEY } from '@app/constants/hotkeys';
 import {
   LIST_VIEW_ID,
@@ -259,6 +264,45 @@ type SidebarHotkeyDeps = {
   openWithSplit: ReturnType<typeof useSplitLayout>['openWithSplit'];
 };
 
+type OpenWithSplitFn = ReturnType<typeof useSplitLayout>['openWithSplit'];
+
+const isComponentEntry =
+  (id: ListView) =>
+  (entry: SplitContent): boolean =>
+    entry.type === 'component' && entry.id === id;
+
+/**
+ * Navigate to a sidebar view, preserving prior state when possible.
+ *
+ * If the active split's history already contains an entry for this view, jump
+ * back to it so search text, filters, preview state, etc. are restored from
+ * that entry. Otherwise push a fresh entry. Holding shift bypasses the lookup
+ * and forces a new entry / new split.
+ */
+function navigateToSidebarView(args: {
+  viewId: ListView;
+  shiftKey: boolean;
+  activeSplit: SplitHandle | undefined;
+  openWithSplit: OpenWithSplitFn;
+  referredFrom?: ReferredFrom;
+}): SplitHandle | undefined {
+  const { viewId, shiftKey, activeSplit, openWithSplit, referredFrom } = args;
+
+  if (!shiftKey && activeSplit?.goToEntry(isComponentEntry(viewId))) {
+    return activeSplit;
+  }
+
+  return openWithSplit(
+    { type: 'component', id: viewId },
+    {
+      preferNewSplit: shiftKey,
+      mergeHistory: false,
+      allowDuplicate: true,
+      referredFrom,
+    }
+  );
+}
+
 const registerSidebarHotkeys = ({
   links,
   isSlim,
@@ -367,30 +411,12 @@ const registerSidebarHotkeys = ({
         }
       }
 
-      // Restore the prior entry for this view if one exists in the active
-      // split's history, so state like search text or filters survives.
-      // Shift bypasses this to force a fresh entry / new split.
-      const activeHandle = globalSplitManager()?.activeSplit();
-      const restored =
-        !e?.shiftKey &&
-        activeHandle?.goToEntry(
-          (entry) => entry.type === 'component' && entry.id === link.id
-        ) === true;
-
-      const handle =
-        restored && activeHandle
-          ? activeHandle
-          : openWithSplit(
-              {
-                type: 'component',
-                id: link.id,
-              },
-              {
-                preferNewSplit: e?.shiftKey,
-                mergeHistory: false,
-                allowDuplicate: true,
-              }
-            );
+      const handle = navigateToSidebarView({
+        viewId: link.id,
+        shiftKey: !!e?.shiftKey,
+        activeSplit: globalSplitManager()?.activeSplit(),
+        openWithSplit,
+      });
       if (link.id === 'search' && handle) {
         requestSearchFocus(handle.id);
       }
@@ -1136,24 +1162,13 @@ const SidebarLink = (props: SidebarLinkProps) => {
               currentContent?.id === props.id;
 
             if (!isSameContent || e.shiftKey) {
-              // If the active split already has an entry for this view in its
-              // history, jump to it so any prior state (search text, filters,
-              // etc.) is restored. Falls back to a fresh push otherwise.
-              // Shift-click bypasses this to force a new split/entry.
-              const restored =
-                !e.shiftKey &&
-                currentContentHandle?.goToEntry(
-                  (entry) => entry.type === 'component' && entry.id === props.id
-                ) === true;
-
-              if (!restored) {
-                currentContentHandle = layout.openWithSplit(content(), {
-                  preferNewSplit: e.shiftKey,
-                  mergeHistory: false,
-                  allowDuplicate: true,
-                  referredFrom: 'sidebar',
-                });
-              }
+              currentContentHandle = navigateToSidebarView({
+                viewId: props.id,
+                shiftKey: e.shiftKey,
+                activeSplit: currentContentHandle,
+                openWithSplit: layout.openWithSplit,
+                referredFrom: 'sidebar',
+              });
             }
 
             if (props.id === 'search' && currentContentHandle) {

--- a/js/app/packages/app/component/app-sidebar/sidebar.tsx
+++ b/js/app/packages/app/component/app-sidebar/sidebar.tsx
@@ -367,17 +367,30 @@ const registerSidebarHotkeys = ({
         }
       }
 
-      const handle = openWithSplit(
-        {
-          type: 'component',
-          id: link.id,
-        },
-        {
-          preferNewSplit: e?.shiftKey,
-          mergeHistory: false,
-          allowDuplicate: true,
-        }
-      );
+      // Restore the prior entry for this view if one exists in the active
+      // split's history, so state like search text or filters survives.
+      // Shift bypasses this to force a fresh entry / new split.
+      const activeHandle = globalSplitManager()?.activeSplit();
+      const restored =
+        !e?.shiftKey &&
+        activeHandle?.goToEntry(
+          (entry) => entry.type === 'component' && entry.id === link.id
+        ) === true;
+
+      const handle =
+        restored && activeHandle
+          ? activeHandle
+          : openWithSplit(
+              {
+                type: 'component',
+                id: link.id,
+              },
+              {
+                preferNewSplit: e?.shiftKey,
+                mergeHistory: false,
+                allowDuplicate: true,
+              }
+            );
       if (link.id === 'search' && handle) {
         requestSearchFocus(handle.id);
       }
@@ -1123,12 +1136,24 @@ const SidebarLink = (props: SidebarLinkProps) => {
               currentContent?.id === props.id;
 
             if (!isSameContent || e.shiftKey) {
-              currentContentHandle = layout.openWithSplit(content(), {
-                preferNewSplit: e.shiftKey,
-                mergeHistory: false,
-                allowDuplicate: true,
-                referredFrom: 'sidebar',
-              });
+              // If the active split already has an entry for this view in its
+              // history, jump to it so any prior state (search text, filters,
+              // etc.) is restored. Falls back to a fresh push otherwise.
+              // Shift-click bypasses this to force a new split/entry.
+              const restored =
+                !e.shiftKey &&
+                currentContentHandle?.goToEntry(
+                  (entry) => entry.type === 'component' && entry.id === props.id
+                ) === true;
+
+              if (!restored) {
+                currentContentHandle = layout.openWithSplit(content(), {
+                  preferNewSplit: e.shiftKey,
+                  mergeHistory: false,
+                  allowDuplicate: true,
+                  referredFrom: 'sidebar',
+                });
+              }
             }
 
             if (props.id === 'search' && currentContentHandle) {

--- a/js/app/packages/app/component/split-layout/components/PopoverSplitRenderer.tsx
+++ b/js/app/packages/app/component/split-layout/components/PopoverSplitRenderer.tsx
@@ -70,6 +70,7 @@ function PopoverSplitModal(props: {
     isPopover: () => true,
     replace: () => {},
     removeFromHistory: () => {},
+    goToEntry: () => false,
     registerContentChangeListener: () => {},
     unregisterContentChangeListener: () => {},
     previousContent: () => null,

--- a/js/app/packages/app/component/split-layout/history.ts
+++ b/js/app/packages/app/component/split-layout/history.ts
@@ -15,6 +15,13 @@ export type History<T extends object> = {
    * (e.g. captured per-entry state) before navigating away.
    */
   replaceCurrent: (next: T) => void;
+  /**
+   * Jump the current index to `n` (clamped to the valid range). Returns the
+   * item at that position, or null if the history is empty. Use this to
+   * navigate to a known prior entry in one step rather than walking via
+   * `back()`/`forward()`.
+   */
+  goToIndex: (n: number) => T | null;
   remove: (predicate: (item: T) => boolean) => T | null;
 };
 
@@ -76,6 +83,13 @@ export function createHistory<T extends object>(): History<T> {
     return items[index()];
   };
 
+  const goToIndex = (n: number) => {
+    if (items.length === 0) return null;
+    const clamped = Math.max(0, Math.min(items.length - 1, n));
+    setIndex(clamped);
+    return items[clamped];
+  };
+
   const remove = (predicate: (item: T) => boolean) => {
     const prevItems = items;
     const prevIndex = index();
@@ -119,6 +133,7 @@ export function createHistory<T extends object>(): History<T> {
     push,
     merge,
     replaceCurrent,
+    goToIndex,
     forward,
     canGoBack,
     canGoForward,

--- a/js/app/packages/app/component/split-layout/layoutManager.ts
+++ b/js/app/packages/app/component/split-layout/layoutManager.ts
@@ -365,6 +365,16 @@ export type SplitHandle<TMeta extends ComponentMeta = ComponentMeta> = {
     referredFrom?: ReferredFrom;
   }) => void;
   removeFromHistory: (predicate: (content: SplitContent) => boolean) => void;
+  /**
+   * Jump to the most-recent prior history entry matching `predicate` (or
+   * forward to the closest match if none earlier). Captures current entry
+   * state first, like back/forward. Returns true if a match was found and
+   * navigated to; false if no match (history left unchanged).
+   *
+   * Use for "open this view if it's already in my history, otherwise fall
+   * back to a fresh push" patterns (e.g. sidebar nav).
+   */
+  goToEntry: (predicate: (content: SplitContent) => boolean) => boolean;
   toggleSpotlight: (force?: boolean) => void;
   setDisplayName: (name: string) => void;
   canGoForward: () => boolean;
@@ -743,6 +753,48 @@ export function createSplitLayout(
     reattach(split, next, undefined, 'replace');
   }
 
+  function goToEntry(
+    id: SplitId,
+    predicate: (content: SplitContent) => boolean
+  ): boolean {
+    const i = splitIndexById(id);
+    if (i < 0) {
+      console.error(`Split with id ${id} not found`);
+      return false;
+    }
+    const split = state.splits[i];
+    const items = split.history.items;
+    const currentIdx = split.history.index;
+    if (items.length === 0) return false;
+
+    // Prefer the closest match looking backwards (more common case — the
+    // user just came from there). Fall back to looking forward.
+    let targetIdx = -1;
+    for (let j = currentIdx - 1; j >= 0; j--) {
+      if (predicate(items[j])) {
+        targetIdx = j;
+        break;
+      }
+    }
+    if (targetIdx === -1) {
+      for (let j = currentIdx + 1; j < items.length; j++) {
+        if (predicate(items[j])) {
+          targetIdx = j;
+          break;
+        }
+      }
+    }
+    if (targetIdx === -1 || targetIdx === currentIdx) return false;
+
+    captureCurrentEntryState(split);
+    const target = split.history.goToIndex(targetIdx);
+    if (!target) return false;
+    const cause: NavigationCause =
+      targetIdx < currentIdx ? 'history-back' : 'history-forward';
+    reattach(split, target, undefined, cause);
+    return true;
+  }
+
   /**
    * Replace the content of a split with the provided content. If mergeHistory is true, the current history index will be replaced with the new content.
    */
@@ -867,6 +919,8 @@ export function createSplitLayout(
       removeFromHistory: (predicate: (content: SplitContent) => boolean) => {
         removeFromHistory(currentSplit.id, predicate);
       },
+      goToEntry: (predicate: (content: SplitContent) => boolean) =>
+        goToEntry(currentSplit.id, predicate),
       previousContent: () => {
         const s = findSplitById(currentSplit.id);
         if (!s) return null;


### PR DESCRIPTION
Sidebar clicks (and hotkey nav) used to push a fresh history entry via `openWithSplit(allowDuplicate: true)`, losing any state on the prior entry for that view. They now first try `splitHandle.goToEntry(predicate)` to jump back to an existing matching entry, restoring search text / filters / preview / active tab automatically. Shift-click still forces a fresh entry. Adds `History#goToIndex` and `SplitHandle#goToEntry` for the jump. Stacked on #3535.
