### PR TITLE
fix(channels): optimistic deletion of top-level messages without replies

### DIFF
--- a/js/app/packages/queries/channel/message.ts
+++ b/js/app/packages/queries/channel/message.ts
@@ -37,6 +37,7 @@ import {
   resolveMessageTarget,
   restoreMessageInTargetCaches,
   softInvalidateTargetCaches,
+  topLevelMessageHasReplies,
 } from './reconcile';
 
 /**
@@ -240,10 +241,11 @@ function replaceOptimisticMessage(
 /**
  * Optimistically delete a message from the channel cache.
  *
- * Top-level messages are soft-deleted in place (we set `deleted_at`) so the
- * UI renders the "this message was deleted" placeholder while preserving any
- * thread replies hanging off the message. Thread replies don't have a
- * `deleted_at` field in the schema, so we still remove them from the caches
+ * Top-level messages with thread replies are soft-deleted in place (we set
+ * `deleted_at`) so the UI renders the "this message was deleted" placeholder
+ * while preserving the replies hanging off the message. Top-level messages
+ * with no replies are removed outright. Thread replies don't have a
+ * `deleted_at` field in the schema, so we always remove them from the caches
  * and capture a snapshot for rollback.
  */
 export function optimisticDeleteChannelMessage(
@@ -263,13 +265,21 @@ export function optimisticDeleteChannelMessage(
   };
 
   if (target.kind === 'top_level') {
-    context.previousDeletedAt =
-      getTopLevelMessageDeletedAt(vars.channelId, target.messageId) ?? null;
-    markTopLevelMessageDeletedInTargetCaches(
-      vars.channelId,
-      target,
-      new Date().toISOString()
-    );
+    if (topLevelMessageHasReplies(vars.channelId, target.messageId)) {
+      context.previousDeletedAt =
+        getTopLevelMessageDeletedAt(vars.channelId, target.messageId) ?? null;
+      markTopLevelMessageDeletedInTargetCaches(
+        vars.channelId,
+        target,
+        new Date().toISOString()
+      );
+    } else {
+      context.targetSnapshot = captureDeleteSnapshotForTarget(
+        vars.channelId,
+        target
+      );
+      removeMessageFromTargetCaches(vars.channelId, target);
+    }
   } else {
     context.targetSnapshot = captureDeleteSnapshotForTarget(
       vars.channelId,
@@ -288,7 +298,7 @@ export function rollbackDeleteChannelMessage(
   channelId: string,
   context: DeleteMessageContext
 ): void {
-  if (context.target.kind === 'top_level') {
+  if (context.target.kind === 'top_level' && !context.targetSnapshot) {
     markTopLevelMessageDeletedInTargetCaches(
       channelId,
       context.target,

--- a/js/app/packages/queries/channel/reconcile.ts
+++ b/js/app/packages/queries/channel/reconcile.ts
@@ -237,6 +237,25 @@ export function getTopLevelMessageDeletedAt(
     ?.deleted_at;
 }
 
+/**
+ * Returns true if the top-level message has any thread replies, based on the
+ * latest reply_count visible in either the paginated channel cache or the
+ * by-ids cache.
+ */
+export function topLevelMessageHasReplies(
+  channelId: string,
+  messageId: string
+): boolean {
+  const paginated = findTopLevelMessageSnapshotInChannelMessages(
+    channelId,
+    messageId
+  );
+  if (paginated) return paginated.message.thread.reply_count > 0;
+
+  const byIds = findTopLevelMessageInChannelMessagesByIds(channelId, messageId);
+  return (byIds?.thread.reply_count ?? 0) > 0;
+}
+
 /** Captures rollback snapshots for a target before optimistic delete. */
 export function captureDeleteSnapshotForTarget(
   channelId: string,

--- a/js/app/packages/queries/channel/reconcile.ts
+++ b/js/app/packages/queries/channel/reconcile.ts
@@ -246,14 +246,14 @@ export function topLevelMessageHasReplies(
   channelId: string,
   messageId: string
 ): boolean {
-  const paginated = findTopLevelMessageSnapshotInChannelMessages(
-    channelId,
-    messageId
-  );
-  if (paginated) return paginated.message.thread.reply_count > 0;
+  const paginatedReplyCount =
+    findTopLevelMessageSnapshotInChannelMessages(channelId, messageId)?.message
+      .thread.reply_count ?? 0;
+  const byIdsReplyCount =
+    findTopLevelMessageInChannelMessagesByIds(channelId, messageId)?.thread
+      .reply_count ?? 0;
 
-  const byIds = findTopLevelMessageInChannelMessagesByIds(channelId, messageId);
-  return (byIds?.thread.reply_count ?? 0) > 0;
+  return paginatedReplyCount > 0 || byIdsReplyCount > 0;
 }
 
 /** Captures rollback snapshots for a target before optimistic delete. */

--- a/js/app/packages/queries/channel/tests/channel-optimistic.test.ts
+++ b/js/app/packages/queries/channel/tests/channel-optimistic.test.ts
@@ -494,6 +494,39 @@ describe('channel optimistic cache regressions', () => {
     expect(restored?.thread.preview).toHaveLength(2);
   });
 
+  it('removes top-level messages with no replies from caches on optimistic delete and restores them on rollback', () => {
+    seedChannelMessagesCache(
+      'channel-1',
+      createChannelMessagesData([
+        [
+          createPaginatedMessage('parent-1', '2024-01-03T00:00:00.000Z'),
+          createPaginatedMessage('parent-2', '2024-01-03T01:00:00.000Z'),
+        ],
+      ])
+    );
+
+    const context = optimisticDeleteChannelMessage({
+      channelId: 'channel-1',
+      message_id: 'parent-1',
+    });
+
+    const itemsAfter =
+      getChannelMessagesFromCache('channel-1')?.pages[0].items ?? [];
+    expect(itemsAfter.map((item) => item.id)).toEqual(['parent-2']);
+
+    if (context) {
+      rollbackDeleteChannelMessage('channel-1', context);
+    }
+
+    const itemsRolledBack =
+      getChannelMessagesFromCache('channel-1')?.pages[0].items ?? [];
+    expect(itemsRolledBack.map((item) => item.id)).toEqual([
+      'parent-1',
+      'parent-2',
+    ]);
+    expect(itemsRolledBack[0].deleted_at).toBeFalsy();
+  });
+
   it('removes thread replies from caches on optimistic delete and restores them on rollback', () => {
     seedChannelMessagesCache(
       'channel-1',
@@ -545,6 +578,11 @@ describe('channel optimistic cache regressions', () => {
       [
         createPaginatedMessage('parent-1', '2024-01-03T00:00:00.000Z', {
           deleted_at: previousDeletedAt,
+          thread: {
+            preview: [createThreadReply('reply-1', '2024-01-03T01:00:00.000Z')],
+            reply_count: 1,
+            latest_reply_at: '2024-01-03T01:00:00.000Z',
+          },
         }),
       ]
     );


### PR DESCRIPTION
This PR updates the optimistic message deletion logic to properly handle top-level messages based on whether they have thread replies. Messages with replies are soft-deleted (preserving the thread), while messages without replies are completely removed from the cache.