### PR TITLE
fix(props): unify priority critical label

### DIFF
--- a/js/app/packages/entity/src/extractors-property/property-helpers.ts
+++ b/js/app/packages/entity/src/extractors-property/property-helpers.ts
@@ -64,7 +64,7 @@ const SYSTEM_PROPERTY_OPTIONS: Record<string, PropertyOption[]> = {
     {
       id: PROPERTY_OPTION_IDS.PRIORITY.URGENT,
       property_definition_id: SYSTEM_PROPERTY_IDS.PRIORITY,
-      value: { type: 'string', value: 'Urgent' },
+      value: { type: 'string', value: 'Critical' },
       display_order: 3,
       created_at: EPOCH_ZERO.toISOString(),
       updated_at: EPOCH_ZERO.toISOString(),

--- a/js/app/packages/entity/src/utils/task-properties.ts
+++ b/js/app/packages/entity/src/utils/task-properties.ts
@@ -10,7 +10,7 @@ export const TASK_STATUS_OPTIONS = [
 ] as const;
 
 const TASK_PRIORITY_OPTIONS = [
-  { value: PROPERTY_OPTION_IDS.PRIORITY.URGENT, label: 'Urgent' },
+  { value: PROPERTY_OPTION_IDS.PRIORITY.URGENT, label: 'Critical' },
   { value: PROPERTY_OPTION_IDS.PRIORITY.HIGH, label: 'High' },
   { value: PROPERTY_OPTION_IDS.PRIORITY.MEDIUM, label: 'Medium' },
   { value: PROPERTY_OPTION_IDS.PRIORITY.LOW, label: 'Low' },

--- a/js/app/packages/property/mocks/mockProperties.ts
+++ b/js/app/packages/property/mocks/mockProperties.ts
@@ -73,7 +73,7 @@ const priorityOptions: PropertyOption[] = [
   {
     id: PROPERTY_OPTION_IDS.PRIORITY.URGENT,
     property_definition_id: SYSTEM_PROPERTY_IDS.PRIORITY,
-    value: { type: 'string', value: 'Urgent' },
+    value: { type: 'string', value: 'Critical' },
     display_order: 3,
     created_at: EPOCH,
     updated_at: EPOCH,


### PR DESCRIPTION
note: we actaully want this to say urgent. but that will require a backend migration which is pretty low prio. better to be internally consistent on the front end for now
