### PR TITLE
fix(soup-view): defer auto-focus to break focus/setActiveScope loop

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
@@ -660,11 +660,17 @@ export const SoupViewList = (props: SoupViewListProps) => {
 
   const previewPanel = useMaybePreviewPanel();
 
-  // Auto focus the soup on mount except when it's in a preview panel
+  // Auto focus the soup on mount except when it's in a preview panel.
+  // .focus() is deferred so the synchronous focusin handler in @core/hotkey
+  // doesn't run inside this effect's tracking scope and re-invalidate it via
+  // its own setActiveScope write — which would re-fire .focus() and overflow
+  // the stack while an upstream context menu is still mounted.
   createEffect(() => {
     if (previewPanel) return;
 
-    soupViewRef()?.focus();
+    const ref = soupViewRef();
+    if (!ref) return;
+    queueMicrotask(() => ref.focus());
   });
 
   const [attachHotkeys, soupViewScope] = useHotkeyDOMScope('soup-view');

--- a/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
@@ -660,11 +660,7 @@ export const SoupViewList = (props: SoupViewListProps) => {
 
   const previewPanel = useMaybePreviewPanel();
 
-  // Auto focus the soup on mount except when it's in a preview panel.
-  // .focus() is deferred so the synchronous focusin handler in @core/hotkey
-  // doesn't run inside this effect's tracking scope and re-invalidate it via
-  // its own setActiveScope write — which would re-fire .focus() and overflow
-  // the stack while an upstream context menu is still mounted.
+  // Defer .focus() so the hotkey focusin handler's setActiveScope write doesn't re-invalidate this effect from inside its own tracking scope.
   createEffect(() => {
     if (previewPanel) return;
 

--- a/js/app/packages/core/component/ContextMenu.tsx
+++ b/js/app/packages/core/component/ContextMenu.tsx
@@ -7,7 +7,6 @@ import { cn, Layer } from '@ui';
 import {
   type Component,
   createEffect,
-  createMemo,
   type JSX,
   Match,
   onCleanup,
@@ -24,6 +23,71 @@ import { Hotkey } from '../../ui/components/Hotkey';
  * `@ui` `Dropdown`. Right-click menus still use this file because they need
  * separate behavior + positioning from the click-triggered Dropdown.
  */
+
+type BaseMenuItemWrapperProps = {
+  children: JSX.Element;
+  disabled?: boolean;
+  onClick?: () => void;
+  closeOnSelect?: boolean;
+  selectorType?: 'checkbox' | 'radio';
+  class?: string;
+};
+
+type CheckboxMenuItemWrapperProps = BaseMenuItemWrapperProps & {
+  selectorType: 'checkbox';
+  checked?: boolean;
+  onChange?: (value: boolean) => void;
+};
+
+type RadioMenuItemWrapperProps = BaseMenuItemWrapperProps & {
+  selectorType: 'radio';
+  value: string;
+};
+
+type MenuItemWrapperProps =
+  | BaseMenuItemWrapperProps
+  | CheckboxMenuItemWrapperProps
+  | RadioMenuItemWrapperProps;
+
+function MenuItemWrapper(props: MenuItemWrapperProps) {
+  return (
+    <Switch>
+      <Match when={props.selectorType === 'checkbox'}>
+        <ContextMenu.CheckboxItem
+          class={props.class}
+          checked={(props as CheckboxMenuItemWrapperProps).checked}
+          onChange={(props as CheckboxMenuItemWrapperProps).onChange}
+          disabled={props.disabled}
+          onSelect={props.onClick}
+          closeOnSelect={props.closeOnSelect}
+        >
+          {props.children}
+        </ContextMenu.CheckboxItem>
+      </Match>
+      <Match when={props.selectorType === 'radio'}>
+        <ContextMenu.RadioItem
+          class={props.class}
+          value={(props as RadioMenuItemWrapperProps).value}
+          disabled={props.disabled}
+          onSelect={props.onClick}
+          closeOnSelect={props.closeOnSelect}
+        >
+          {props.children}
+        </ContextMenu.RadioItem>
+      </Match>
+      <Match when={!props.selectorType}>
+        <ContextMenu.Item
+          class={props.class}
+          disabled={props.disabled}
+          onSelect={props.onClick}
+          closeOnSelect={props.closeOnSelect}
+        >
+          {props.children}
+        </ContextMenu.Item>
+      </Match>
+    </Switch>
+  );
+}
 
 type BaseMenuItemProps = {
   text?: string | JSX.Element;
@@ -74,23 +138,23 @@ export const MENU_ITEM_CLASS = `flex flex-row w-full gap-1.5 tracking-tight ${is
  * - Radio menu item (with radio button selection)
  */
 export function MenuItem(props: MenuItemProps) {
-  // Memoize `disabled` so it isn't forwarded as a chained getter — the prior
-  // MenuItem → wrapper → ContextMenu.Item chain stack-overflowed when something
-  // re-entered the same accessor during a layout-driven re-evaluation.
-  const isDisabled = createMemo(() => props.disabled ?? false);
-
-  const rowClass = createMemo(() =>
-    cn(
-      MENU_ITEM_CLASS,
-      isDisabled()
-        ? 'opacity-50 cursor-not-allowed'
-        : 'hover:bg-ink/3 hover-transition-bg',
-      props.class
-    )
-  );
-
-  const renderChildren = () => (
-    <>
+  return (
+    <MenuItemWrapper
+      class={cn(
+        MENU_ITEM_CLASS,
+        props.disabled
+          ? 'opacity-50 cursor-not-allowed'
+          : 'hover:bg-ink/3 hover-transition-bg',
+        props.class
+      )}
+      onClick={props.onClick}
+      disabled={props.disabled}
+      closeOnSelect={props.closeOnSelect}
+      selectorType={props.selectorType}
+      value={props.value}
+      checked={props.checked}
+      onChange={props.onChange}
+    >
       <Show when={props.selectorType === 'checkbox'}>
         <div
           class={cn(
@@ -153,45 +217,7 @@ export function MenuItem(props: MenuItemProps) {
           </div>
         )}
       </Show>
-    </>
-  );
-
-  return (
-    <Switch>
-      <Match when={props.selectorType === 'checkbox'}>
-        <ContextMenu.CheckboxItem
-          class={rowClass()}
-          checked={(props as CheckboxMenuItemProps).checked}
-          onChange={(props as CheckboxMenuItemProps).onChange}
-          disabled={isDisabled()}
-          onSelect={props.onClick}
-          closeOnSelect={props.closeOnSelect}
-        >
-          {renderChildren()}
-        </ContextMenu.CheckboxItem>
-      </Match>
-      <Match when={props.selectorType === 'radio'}>
-        <ContextMenu.RadioItem
-          class={rowClass()}
-          value={(props as RadioMenuItemProps).value}
-          disabled={isDisabled()}
-          onSelect={props.onClick}
-          closeOnSelect={props.closeOnSelect}
-        >
-          {renderChildren()}
-        </ContextMenu.RadioItem>
-      </Match>
-      <Match when={!props.selectorType}>
-        <ContextMenu.Item
-          class={rowClass()}
-          disabled={isDisabled()}
-          onSelect={props.onClick}
-          closeOnSelect={props.closeOnSelect}
-        >
-          {renderChildren()}
-        </ContextMenu.Item>
-      </Match>
-    </Switch>
+    </MenuItemWrapper>
   );
 }
 

--- a/js/app/packages/core/component/ContextMenu.tsx
+++ b/js/app/packages/core/component/ContextMenu.tsx
@@ -7,6 +7,7 @@ import { cn, Layer } from '@ui';
 import {
   type Component,
   createEffect,
+  createMemo,
   type JSX,
   Match,
   onCleanup,
@@ -23,71 +24,6 @@ import { Hotkey } from '../../ui/components/Hotkey';
  * `@ui` `Dropdown`. Right-click menus still use this file because they need
  * separate behavior + positioning from the click-triggered Dropdown.
  */
-
-type BaseMenuItemWrapperProps = {
-  children: JSX.Element;
-  disabled?: boolean;
-  onClick?: () => void;
-  closeOnSelect?: boolean;
-  selectorType?: 'checkbox' | 'radio';
-  class?: string;
-};
-
-type CheckboxMenuItemWrapperProps = BaseMenuItemWrapperProps & {
-  selectorType: 'checkbox';
-  checked?: boolean;
-  onChange?: (value: boolean) => void;
-};
-
-type RadioMenuItemWrapperProps = BaseMenuItemWrapperProps & {
-  selectorType: 'radio';
-  value: string;
-};
-
-type MenuItemWrapperProps =
-  | BaseMenuItemWrapperProps
-  | CheckboxMenuItemWrapperProps
-  | RadioMenuItemWrapperProps;
-
-function MenuItemWrapper(props: MenuItemWrapperProps) {
-  return (
-    <Switch>
-      <Match when={props.selectorType === 'checkbox'}>
-        <ContextMenu.CheckboxItem
-          class={props.class}
-          checked={(props as CheckboxMenuItemWrapperProps).checked}
-          onChange={(props as CheckboxMenuItemWrapperProps).onChange}
-          disabled={props.disabled}
-          onSelect={props.onClick}
-          closeOnSelect={props.closeOnSelect}
-        >
-          {props.children}
-        </ContextMenu.CheckboxItem>
-      </Match>
-      <Match when={props.selectorType === 'radio'}>
-        <ContextMenu.RadioItem
-          class={props.class}
-          value={(props as RadioMenuItemWrapperProps).value}
-          disabled={props.disabled}
-          onSelect={props.onClick}
-          closeOnSelect={props.closeOnSelect}
-        >
-          {props.children}
-        </ContextMenu.RadioItem>
-      </Match>
-      <Match when={!props.selectorType}>
-        <ContextMenu.Item
-          class={props.class}
-          disabled={props.disabled}
-          onSelect={props.onClick}
-          closeOnSelect={props.closeOnSelect}
-        >
-          {props.children}
-        </ContextMenu.Item>
-      </Match>
-    </Switch>
-  );
-}
 
 type BaseMenuItemProps = {
   text?: string | JSX.Element;
@@ -138,23 +74,23 @@ export const MENU_ITEM_CLASS = `flex flex-row w-full gap-1.5 tracking-tight ${is
  * - Radio menu item (with radio button selection)
  */
 export function MenuItem(props: MenuItemProps) {
-  return (
-    <MenuItemWrapper
-      class={cn(
-        MENU_ITEM_CLASS,
-        props.disabled
-          ? 'opacity-50 cursor-not-allowed'
-          : 'hover:bg-ink/3 hover-transition-bg',
-        props.class
-      )}
-      onClick={props.onClick}
-      disabled={props.disabled}
-      closeOnSelect={props.closeOnSelect}
-      selectorType={props.selectorType}
-      value={props.value}
-      checked={props.checked}
-      onChange={props.onChange}
-    >
+  // Memoize `disabled` so it isn't forwarded as a chained getter — the prior
+  // MenuItem → wrapper → ContextMenu.Item chain stack-overflowed when something
+  // re-entered the same accessor during a layout-driven re-evaluation.
+  const isDisabled = createMemo(() => props.disabled ?? false);
+
+  const rowClass = createMemo(() =>
+    cn(
+      MENU_ITEM_CLASS,
+      isDisabled()
+        ? 'opacity-50 cursor-not-allowed'
+        : 'hover:bg-ink/3 hover-transition-bg',
+      props.class
+    )
+  );
+
+  const renderChildren = () => (
+    <>
       <Show when={props.selectorType === 'checkbox'}>
         <div
           class={cn(
@@ -217,7 +153,45 @@ export function MenuItem(props: MenuItemProps) {
           </div>
         )}
       </Show>
-    </MenuItemWrapper>
+    </>
+  );
+
+  return (
+    <Switch>
+      <Match when={props.selectorType === 'checkbox'}>
+        <ContextMenu.CheckboxItem
+          class={rowClass()}
+          checked={(props as CheckboxMenuItemProps).checked}
+          onChange={(props as CheckboxMenuItemProps).onChange}
+          disabled={isDisabled()}
+          onSelect={props.onClick}
+          closeOnSelect={props.closeOnSelect}
+        >
+          {renderChildren()}
+        </ContextMenu.CheckboxItem>
+      </Match>
+      <Match when={props.selectorType === 'radio'}>
+        <ContextMenu.RadioItem
+          class={rowClass()}
+          value={(props as RadioMenuItemProps).value}
+          disabled={isDisabled()}
+          onSelect={props.onClick}
+          closeOnSelect={props.closeOnSelect}
+        >
+          {renderChildren()}
+        </ContextMenu.RadioItem>
+      </Match>
+      <Match when={!props.selectorType}>
+        <ContextMenu.Item
+          class={rowClass()}
+          disabled={isDisabled()}
+          onSelect={props.onClick}
+          closeOnSelect={props.closeOnSelect}
+        >
+          {renderChildren()}
+        </ContextMenu.Item>
+      </Match>
+    </Switch>
   );
 }
 


### PR DESCRIPTION
Fixes [macro-1532](https://app.macro.com/app/component/document/019e6a57-430c-7bef-9986-6b0c80e227a1).

SoupView's auto-focus `createEffect` called `soupViewRef()?.focus()` synchronously inside its tracking scope. The hotkey package's `focusin` handler reads `activeScope` and writes `setActiveScope` — so the effect subscribed to `activeScope` via its own `.focus()` call and was then re-invalidated by the same handler's write, looping until the stack overflowed (which surfaced through Kobalte's deep `disabled` getter chain on the still-mounted sidebar context menu). Deferring `.focus()` to a microtask runs it outside the effect's tracking scope and breaks the feedback.
