### PR TITLE
feat(crm): expand generic email domain filter

### DIFF
--- a/rust/cloud-storage/crm/src/domain/generic_email_domains.rs
+++ b/rust/cloud-storage/crm/src/domain/generic_email_domains.rs
@@ -16,19 +16,31 @@
 //! domain filter. Together they keep CRM populate focused on real
 //! company-to-company correspondence.
 //!
-//! Entries are kept in three categories so downstream consumers
+//! The same logic applies to vendors a team merely *uses* and to big
+//! consumer brands: a flood of automated mail from `github.com`,
+//! `stripe.com`, `amazon.com`, or `marriott.com` is
+//! product/billing/marketing traffic, not a business relationship, and
+//! would seed the CRM with rows nobody is selling to or buying from. We
+//! do NOT block law firms, banks, funds, or corporates that show up as
+//! real correspondents — only tools, consumer brands, and bulk senders.
+//!
+//! Entries are kept in six categories so downstream consumers
 //! (scoring, retention, alerting) can later distinguish a contact at a
-//! big consumer provider from one at a disposable inbox or an alias
-//! forwarder. The check ([`is_generic_email_domain`]) unions all
-//! three plus a small set of suffix rules for RFC-reserved TLDs.
+//! big consumer provider from one at a disposable inbox, an alias
+//! forwarder, a SaaS/dev-tool vendor, a big consumer-brand domain, or a
+//! bulk-mail sending domain. The check ([`is_generic_email_domain`])
+//! unions all six plus a small set of suffix rules for RFC-reserved
+//! TLDs.
 
 #[cfg(test)]
 mod test;
 
 /// Returns `true` when `domain` is a known personal / free email
 /// provider, a disposable-mail service, a privacy-relay / alias
-/// forwarder, or a reserved-namespace TLD. Matching is case-insensitive
-/// and tolerates surrounding whitespace and a leading `www.` prefix.
+/// forwarder, a SaaS / dev-tool vendor, a big consumer brand, a
+/// bulk-mail sending domain, or a reserved-namespace TLD. Matching is
+/// case-insensitive and tolerates surrounding whitespace and a leading
+/// `www.` prefix.
 pub(crate) fn is_generic_email_domain(domain: &str) -> bool {
     let normalized = normalize_domain(domain);
     if normalized.is_empty() {
@@ -40,6 +52,9 @@ pub(crate) fn is_generic_email_domain(domain: &str) -> bool {
     contains_ci(CONSUMER_EMAIL_DOMAINS, &normalized)
         || contains_ci(DISPOSABLE_EMAIL_DOMAINS, &normalized)
         || contains_ci(ALIAS_FORWARDER_DOMAINS, &normalized)
+        || contains_ci(SAAS_VENDOR_DOMAINS, &normalized)
+        || contains_ci(CONSUMER_BRAND_DOMAINS, &normalized)
+        || contains_ci(BULK_SENDER_DOMAINS, &normalized)
 }
 
 /// Trim surrounding whitespace, lowercase, and strip a leading `www.`
@@ -254,6 +269,11 @@ const CONSUMER_EMAIL_DOMAINS: &[&str] = &[
     "spectrum.net",
     "earthlink.net",
     "optonline.net",
+    "tmomail.net", // T-Mobile
+    // ---- ISPs / telcos (Canada) ----
+    "rogers.com",
+    "bell.net",
+    "sympatico.ca",
     // ---- ISPs / telcos (UK) ----
     "btinternet.com",
     "virginmedia.com",
@@ -292,6 +312,7 @@ const CONSUMER_EMAIL_DOMAINS: &[&str] = &[
     "myself.com",
     "linuxmail.org",
     "iname.com",
+    "vivaldi.net", // Vivaldi's free webmail (the browser maker's mail service)
 ];
 
 /// Disposable / temporary inbox services. Used by signups that want to
@@ -371,4 +392,291 @@ const ALIAS_FORWARDER_DOMAINS: &[&str] = &[
     "addy.io",
     // Other independents
     "firemail.de",
+];
+
+/// SaaS, developer-tool, and infrastructure vendors a team *uses*. Mail
+/// from these apex domains is overwhelmingly automated
+/// product/billing/notification traffic, not company-to-company
+/// correspondence, so a vendor row here is CRM noise the same way
+/// `gmail.com` is. Apex domains only — the dedicated marketing /
+/// notification subdomains these vendors send from live in
+/// [`BULK_SENDER_DOMAINS`].
+///
+/// Deliberately conservative: anything that could be a real
+/// correspondent (law firms, banks, funds, PE/VC, corporates, schools)
+/// is left off. Note the `apollo.io` (sales SaaS) vs `apollo.com`
+/// (Apollo Global Management) split — only the tool is listed.
+const SAAS_VENDOR_DOMAINS: &[&str] = &[
+    // ---- Developer tooling & infrastructure ----
+    "github.com",
+    "jetbrains.com",
+    "1password.com",
+    "agilebits.com", // 1Password's corporate domain
+    "namecheap.com",
+    "digitalocean.com",
+    "pulumi.com",
+    "retool.com",
+    "zapier.com",
+    "cockroachlabs.com",
+    "hex.tech",
+    "algolia.com",
+    "gitbook.com",
+    "atlassian.com",
+    "digicert.com",
+    "ssl.com",
+    "resend.dev",
+    "mailsoar.com",
+    // ---- Auth / identity ----
+    "auth0.com",
+    "okta.com",
+    "stytch.com",
+    "descope.com",
+    "fusionauth.io",
+    // ---- Comms / messaging / data APIs ----
+    "twilio.com",
+    "livekit.io",
+    "svix.com",
+    "knock.app",
+    "segment.com",
+    "merge.dev",
+    "plaid.com",
+    "flinks.io",
+    "flinks.com",
+    "stedi.com",
+    // ---- Document / PDF / UI SDKs ----
+    "pdftron.com",
+    "apryse.com",
+    "foxitsoftware.com",
+    "pspdfkit.com",
+    "collabora.com",
+    "collaboraoffice.com",
+    "gemboxsoftware.com",
+    "syncfusion.com",
+    "ag-grid.com",
+    "liveblocks.io",
+    "liquidtext.net",
+    "photopea.com",
+    // ---- Product analytics & feedback ----
+    "datadoghq.com",
+    "posthog.com",
+    "mixpanel.com",
+    "heap.io",
+    "tryheap.io",
+    "sprig.com",
+    "contentsquare.com",
+    "vitally.io",
+    // ---- AI vendors ----
+    "anthropic.com",
+    "openai.com",
+    // ---- Productivity / collaboration ----
+    "slack.com",
+    "zoom.us",
+    "figma.com",
+    "loom.com",
+    "notion.so",
+    "calendly.com",
+    "cal.com",
+    "superhuman.com",
+    "spikenow.com",
+    "eraser.io",
+    // ---- CRM / sales / marketing / data platforms ----
+    "salesforce.com",
+    "hubspot.com",
+    "customer.io",
+    "zoominfo.com",
+    "clearbit.com",
+    "clearbit.ca",
+    "apollo.io", // sales SaaS — NOT apollo.com (Apollo Global Mgmt)
+    "outreach.io",
+    "reply.io",
+    "copper.com",
+    "impact.com",
+    "g2.com",
+    "pitchbook.com",
+    "substack.com",
+    "producthunt.com",
+    // ---- Hiring / cap table / HR / payroll ----
+    "wellfound.com",
+    "angel.co",
+    "angellist.com",
+    "angellisthub.com",
+    "lattice.com",
+    "gusto.com",
+    "rippling.com",
+    "justworks.com",
+    "adp.com",
+    "carta.com",
+    // ---- Finance / payments / expense / fintech ----
+    "stripe.com",
+    "brex.com",
+    "mercury.com",
+    "ramp.com",
+    "tryramp.com",
+    "pave.com",
+    "guideline.com",
+    "sequencehq.com",
+    "floatcard.com",
+    "capchase.com",
+    "freshbooks.com",
+    "clickpay.com",
+    "escrow.com",
+    "coinbase.com",
+    "kraken.com",
+    "zerohash.com",
+    // ---- E-sign / accounting / contract SaaS ----
+    "docusign.com",
+    "pandadoc.com",
+    "xero.com",
+    // ---- Procurement / vendor security / compliance / support ----
+    "vendr.com",
+    "vanta.com",
+    "whistic.com",
+    "secureframe.com",
+    "zendesk.com",
+];
+
+/// Big consumer-facing brands — retail, travel/hospitality, telecom,
+/// consumer tech, food, entertainment. Their mail is overwhelmingly
+/// transactional (orders, bookings, statements) or marketing aimed at
+/// individuals, never company-to-company correspondence. Includes the
+/// marketing/notification subdomains these brands blast from. As with
+/// the vendor list, big *enterprise* tech that's plausibly a real
+/// correspondent (Intel, IBM, NetApp, Corning…) is intentionally left
+/// off.
+const CONSUMER_BRAND_DOMAINS: &[&str] = &[
+    // ---- Consumer tech ----
+    "google.com",
+    "accounts.google.com",
+    "docs.google.com",
+    "calendar.google.com",
+    "allusers.d.calendar.google.com",
+    "xwf.google.com",
+    "microsoft.com",
+    "mail.support.microsoft.com",
+    "customersfeedback.microsoft.com",
+    "engage.microsoft.com",
+    "leave.microsoftstoreemail.com",
+    "apple.com",
+    "adobe.com",
+    "meta.com",
+    "fb.com",
+    "dell.com",
+    "lenovo.com",
+    "leave.americas.links.hp.com",
+    // ---- Telecom (corporate brand mail) ----
+    "verizon.com",
+    "att.com",
+    // ---- Retail / apparel / consumer goods ----
+    "amazon.com",
+    "amazon.ca",
+    "saks.com",
+    "chanel.com",
+    "missoni.com",
+    "terez.com",
+    "adidas-group.com",
+    "shutterstock.com",
+    "wish.com",
+    "email.vistaprint.com",
+    "leave.email.aloyoga.com",
+    // ---- Travel / hospitality / airlines / dining ----
+    "uber.com",
+    "replies.uber.com",
+    "doordash.com",
+    "marriott.com",
+    "marriott-sp.com",
+    "starwood.com",
+    "wyndhamriomar.com",
+    "backroads.com",
+    "mail.aircanada.com",
+    "notifications.flyporter.com",
+    "leave.e-mail.amtrak.com",
+    "leave.e.sonesta.com",
+    "mgs.opentable.com",
+    "e.starbucks.com",
+    "mistercarwash.com",
+    // ---- Real estate (consumer) ----
+    "zillow.com",
+    "zillowgroup.com",
+    "mail.zillow.com",
+    "convo.zillow.com",
+    // ---- Entertainment / gaming / lifestyle ----
+    "leave.engage.xbox.com",
+    "helpmail.elderscrollsonline.com",
+    "turntable.fm",
+    "fanduel.com",
+    "jets.nfl.com",
+    "volosports.com",
+    "chelseapiers.com",
+    "ridefox.com",
+    "whoop.com",
+];
+
+/// Email-service-provider / marketing-automation infrastructure and the
+/// dedicated notification / unsubscribe subdomains that SaaS vendors
+/// send from. No human ever replies from these, so they're never a
+/// contact regardless of the brand behind them. Kept separate from
+/// [`SAAS_VENDOR_DOMAINS`] because many are brand-agnostic ESP plumbing.
+const BULK_SENDER_DOMAINS: &[&str] = &[
+    // ---- HubSpot ----
+    "bf08x.hubspotemail.net",
+    "bf03.hubspotemail.net",
+    "bf02x.hubspotemail.net",
+    "bf05x.hubspotemail.net",
+    "bf06x.hubspotemail.net",
+    "bf10x.hubspotemail.net",
+    "bf02.eu1.hubspotemail.net",
+    "bf01.hubspotstarter.net",
+    "forward.hubspot.com",
+    "bcc.hubspot.com",
+    "notifybf1.hubspot.com",
+    "sslcom.hs-inbox.com",
+    // ---- Marketo ----
+    "unsub-ab.mktomail.com",
+    "unsub-sj.mktomail.com",
+    // ---- Mailchimp / Mandrill ----
+    "mailin.mcsv.net",
+    "unsubscribe.mailchimpapp.net",
+    // ---- Oracle (Eloqua / Responsys) ----
+    "ca.fbl.en25.com",
+    "fbl.en25.com",
+    "imh.rsys2.com",
+    // ---- Salesforce Marketing Cloud ----
+    "32pawhyk2ts8ayix0y02jragc4d91pyr7vmcjqvs7naucdvpgf.hs-1swttma0.na236.le.salesforce.com",
+    // ---- Customer.io ----
+    "unsubscribe2.customer.io",
+    "unsubscribe-eu.customer.io",
+    // ---- Other ESPs / bulk platforms ----
+    "mx.sailthru.com",
+    "listunsub.bluehornet.com",
+    "unsubscribe.qemailserver.com",
+    "bnc3.mailjet.com",
+    "1083664.email.netsuite.com",
+    "s6.csa1.acemsc3.com",
+    "unsub.spmta.com",
+    "cmail19.com",
+    "cmail20.com",
+    "unsub.beehiiv.com",
+    "unsubscribe.iterable.com",
+    "unsub-guc-com.glueup.com",
+    "product-hunt.intercom-mail.com",
+    // ---- Vendor notification / unsubscribe subdomains ----
+    "noreply.github.com",
+    "reply.github.com",
+    "e.atlassian.com",
+    "outgoing.mixpanel.com",
+    "email.zoominfo.com",
+    "mail.notion.so",
+    "email.figma.com",
+    "email.gusto.com",
+    "email.openai.com",
+    "mail.anthropic.com",
+    "camail.docusign.net",
+    "post.xero.com",
+    "mail.pandadoc.com",
+    "mail.producthunt.com",
+    "remail.angel.co",
+    "mg.ironcladapp.com",
+    "em6416.eraser.io",
+    "secureframe.zendesk.com",
+    "digitalcertvalidation.com",
 ];

--- a/rust/cloud-storage/crm/src/domain/generic_email_domains/test.rs
+++ b/rust/cloud-storage/crm/src/domain/generic_email_domains/test.rs
@@ -137,13 +137,94 @@ fn zohomail_is_flagged_but_zoho_is_not() {
 }
 
 #[test]
+fn matches_saas_and_dev_tool_vendors() {
+    for domain in [
+        "github.com",
+        "slack.com",
+        "zoom.us",
+        "figma.com",
+        "stripe.com",
+        "anthropic.com",
+        "datadoghq.com",
+        "auth0.com",
+        "carta.com",
+        "gusto.com",
+        "apollo.io",
+    ] {
+        assert!(
+            is_generic_email_domain(domain),
+            "expected {domain} to be flagged as a SaaS/dev-tool vendor"
+        );
+    }
+}
+
+#[test]
+fn matches_big_consumer_brands() {
+    for domain in [
+        "google.com",
+        "accounts.google.com",
+        "microsoft.com",
+        "apple.com",
+        "amazon.com",
+        "uber.com",
+        "doordash.com",
+        "marriott.com",
+        "e.starbucks.com",
+        "zillow.com",
+    ] {
+        assert!(
+            is_generic_email_domain(domain),
+            "expected {domain} to be flagged as a big consumer brand"
+        );
+    }
+}
+
+#[test]
+fn matches_carrier_mailboxes() {
+    for domain in ["tmomail.net", "rogers.com", "bell.net", "sympatico.ca"] {
+        assert!(
+            is_generic_email_domain(domain),
+            "expected {domain} to be flagged as a carrier mailbox"
+        );
+    }
+}
+
+#[test]
+fn matches_bulk_mail_senders() {
+    for domain in [
+        "bf08x.hubspotemail.net",
+        "unsub-ab.mktomail.com",
+        "mailin.mcsv.net",
+        "noreply.github.com",
+        "mail.anthropic.com",
+        "outgoing.mixpanel.com",
+        "unsubscribe.iterable.com",
+        "imh.rsys2.com",
+    ] {
+        assert!(
+            is_generic_email_domain(domain),
+            "expected {domain} to be flagged as a bulk-mail sender"
+        );
+    }
+}
+
+#[test]
 fn legitimate_company_domains_pass_through() {
     for domain in [
-        "anthropic.com",
         "macro.com",
         "acme.io",
-        "stripe.com",
         "zoho.com",
+        // Real correspondents we must never filter: law firms, banks,
+        // funds, and universities are genuine CRM relationships even
+        // though they send some automated mail.
+        "kirkland.com",
+        "jpmorgan.com",
+        "blackrock.com",
+        "a16z.com",
+        "harvard.edu",
+        // Apollo Global Management (a PE firm) shares a brand with the
+        // `apollo.io` sales tool — only the tool is generic.
+        "apollo.com",
         // Subdomains of generic providers aren't on the list — they
         // belong to whoever runs the subdomain, not the parent
         // provider. The lookup is exact-match by design.


### PR DESCRIPTION
## Summary

Expands the CRM "generic email domain" filter (`crm/src/domain/generic_email_domains.rs`) so vendor and consumer-brand noise stops being promoted into the CRM as company rows. Previously the filter only blocked personal/free providers, disposable inboxes, and alias forwarders — so an inbox full of automated mail from GitHub, Slack, Stripe, Amazon, Marriott, etc. would seed the CRM with rows nobody is actually selling to or buying from.

Three new categories are added (and wired into `is_generic_email_domain`):

- **`SAAS_VENDOR_DOMAINS`** — dev tools, infrastructure, and SaaS/payments/HR products a team merely *uses*: github, jetbrains, datadog, posthog, auth0/okta, twilio, segment, plaid, the PDF/UI SDKs, slack/zoom/figma/notion/calendly, salesforce/hubspot/zoominfo/clearbit/apollo.io, gusto/rippling/adp/carta, stripe/brex/mercury/ramp, docusign/pandadoc/xero, vanta/secureframe/zendesk, anthropic/openai.
- **`CONSUMER_BRAND_DOMAINS`** — big consumer tech and retail/travel/telecom/entertainment brands whose mail is transactional or marketing aimed at individuals: all `google.com` service domains, microsoft/apple/adobe/meta, amazon, uber/doordash, marriott/Starwood, airlines (Air Canada, Porter, Amtrak), starbucks, zillow, fanduel, whoop, etc.
- **`BULK_SENDER_DOMAINS`** — ESP / marketing-automation infrastructure and the notification subdomains vendors send from: hubspotemail.net variants, mktomail.com, mailchimp/mandrill, Eloqua/Responsys, Salesforce Marketing Cloud, customer.io/iterable/beehiiv unsubscribe domains, and per-vendor no-reply subdomains (noreply.github.com, mail.anthropic.com, email.figma.com, ...).

Also folds carrier/ISP personal mailboxes (`tmomail.net`, `rogers.com`, `bell.net`, `sympatico.ca`) into the existing consumer-provider list.

## Deliberately left untouched

Law firms, banks, funds, PE/VC, corporates, and `.edu` domains — these are real correspondents that should still populate the CRM. Enterprise tech that is plausibly a genuine contact (Intel, IBM, NetApp, Corning, VMware) and industry/media domains are also left off. The `apollo.io` (sales SaaS) vs `apollo.com` (Apollo Global Management) split is covered by a regression test.

The filter now spans six curated categories plus the existing RFC-reserved-TLD suffix rules. Module docs updated to explain the new scope.

## Tests

Added `matches_saas_and_dev_tool_vendors`, `matches_big_consumer_brands`, `matches_carrier_mailboxes`, and `matches_bulk_mail_senders`; rewrote `legitimate_company_domains_pass_through` to lock in that genuine contacts (law firm, bank, fund, university, `apollo.com`) still pass. 15/15 unit tests pass; `cargo fmt` and `cargo clippy -p crm --all-features` clean.
