### PR TITLE
fix(sfs): add CORS headers to CloudFront /file/* responses

### DIFF
--- a/infra/stacks/static-file-service/distribution.ts
+++ b/infra/stacks/static-file-service/distribution.ts
@@ -86,6 +86,14 @@ export class StaticFileCloudFront extends pulumi.ComponentResource {
     const responseHeadersPolicy = new aws.cloudfront.ResponseHeadersPolicy(
       'corp-policy',
       {
+        corsConfig: {
+          accessControlAllowCredentials: false,
+          accessControlAllowHeaders: { items: ['*'] },
+          accessControlAllowMethods: { items: ['GET', 'HEAD', 'OPTIONS'] },
+          accessControlAllowOrigins: { items: ['*'] },
+          accessControlMaxAgeSec: 3000,
+          originOverride: true,
+        },
         securityHeadersConfig: {
           contentSecurityPolicy: {
             contentSecurityPolicy:


### PR DESCRIPTION
## Summary
- The CloudFront response headers policy for `/file/*` only set `Cross-Origin-Resource-Policy: cross-origin` (CORP) but never set `Access-Control-Allow-Origin` (CORS)
- Normal `<img>` loading worked fine because browsers don't enforce CORS for image elements, but `fetch()` requests (used during image drag) require `Access-Control-Allow-Origin`
- Added `corsConfig` to the CloudFront response headers policy with `Access-Control-Allow-Origin: *` — safe because `/file/*` doesn't forward cookies

## Test plan
- [ ] Deploy to staging and verify dragging images no longer produces CORS errors in the console
- [ ] Verify normal image loading still works
- [ ] Verify `curl -H "Origin: https://macro.com" <staging-sfs-url>/file/<id>` returns `Access-Control-Allow-Origin: *`

🤖 Generated with [Claude Code](https://claude.com/claude-code)