### PR TITLE
fix(channels): handle soft-delete of top-level messages with replies

### DIFF
--- a/js/app/packages/queries/channel/sync.ts
+++ b/js/app/packages/queries/channel/sync.ts
@@ -9,12 +9,14 @@ import { ChannelNonceKeys } from './keys';
 import {
   getTargetMessageState,
   insertMessageIntoTargetCaches,
+  markTopLevelMessageDeletedInTargetCaches,
   removeMessageFromTargetCaches,
   replaceTargetAttachments,
   replaceTargetMessageState,
   replaceTargetReactions,
   resolveMessageTarget,
   softInvalidateTargetCaches,
+  topLevelMessageHasReplies,
 } from './reconcile';
 
 /**
@@ -57,14 +59,23 @@ export function handleCommsMessage(payload: CommsMessagePayload): void {
   if (isExternalUpdate) {
     try {
       if (payload.deleted_at) {
-        removeMessageFromTargetCaches(
-          payload.channel_id,
-          resolveMessageTarget({
-            channelId: payload.channel_id,
-            messageId: payload.id,
-            threadId: payload.thread_id ?? undefined,
-          })
-        );
+        const target = resolveMessageTarget({
+          channelId: payload.channel_id,
+          messageId: payload.id,
+          threadId: payload.thread_id ?? undefined,
+        });
+        if (
+          target.kind === 'top_level' &&
+          topLevelMessageHasReplies(payload.channel_id, target.messageId)
+        ) {
+          markTopLevelMessageDeletedInTargetCaches(
+            payload.channel_id,
+            target,
+            payload.deleted_at
+          );
+        } else {
+          removeMessageFromTargetCaches(payload.channel_id, target);
+        }
       } else {
         const target = resolveMessageTarget({
           channelId: payload.channel_id,

--- a/js/app/packages/queries/channel/tests/sync.test.ts
+++ b/js/app/packages/queries/channel/tests/sync.test.ts
@@ -24,7 +24,11 @@ vi.mock('@service-storage/client', () => ({
 
 import type { ChannelMessagesData } from '../channel-messages';
 import { getChannelMessagesQueryKey } from '../channel-messages';
-import { handleCommsAttachment, handleCommsReaction } from '../sync';
+import {
+  handleCommsAttachment,
+  handleCommsMessage,
+  handleCommsReaction,
+} from '../sync';
 import { getThreadRepliesQueryKey } from '../thread-replies';
 
 function createPaginatedMessage(
@@ -135,6 +139,103 @@ describe('channel sync', () => {
     expect(cached?.pages[0].items[0].attachments).toEqual([
       expect.objectContaining({ id: 'att-1', message_id: 'msg-1' }),
     ]);
+  });
+
+  it('soft-deletes a top-level message with replies on external delete', () => {
+    testQueryClient.setQueryData(
+      getChannelMessagesQueryKey('channel-1'),
+      createChannelMessagesData([
+        [
+          createPaginatedMessage('parent-1', '2024-01-03T00:00:00.000Z', {
+            thread: {
+              preview: [
+                createThreadReply('reply-1', '2024-01-03T01:00:00.000Z'),
+              ],
+              reply_count: 1,
+              latest_reply_at: '2024-01-03T01:00:00.000Z',
+            },
+          }),
+        ],
+      ])
+    );
+
+    handleCommsMessage({
+      channel_id: 'channel-1',
+      id: 'parent-1',
+      thread_id: null,
+      deleted_at: '2024-01-03T03:00:00.000Z',
+      nonce: 'external-delete',
+    } as Parameters<typeof handleCommsMessage>[0]);
+
+    const cached = testQueryClient.getQueryData<ChannelMessagesData>(
+      getChannelMessagesQueryKey('channel-1')
+    );
+    const message = cached?.pages[0].items[0];
+    expect(message?.id).toBe('parent-1');
+    expect(message?.deleted_at).toBe('2024-01-03T03:00:00.000Z');
+    expect(message?.thread.preview).toHaveLength(1);
+  });
+
+  it('removes a top-level message without replies on external delete', () => {
+    testQueryClient.setQueryData(
+      getChannelMessagesQueryKey('channel-1'),
+      createChannelMessagesData([
+        [
+          createPaginatedMessage('parent-1', '2024-01-03T00:00:00.000Z'),
+          createPaginatedMessage('parent-2', '2024-01-03T01:00:00.000Z'),
+        ],
+      ])
+    );
+
+    handleCommsMessage({
+      channel_id: 'channel-1',
+      id: 'parent-1',
+      thread_id: null,
+      deleted_at: '2024-01-03T03:00:00.000Z',
+      nonce: 'external-delete',
+    } as Parameters<typeof handleCommsMessage>[0]);
+
+    const cached = testQueryClient.getQueryData<ChannelMessagesData>(
+      getChannelMessagesQueryKey('channel-1')
+    );
+    expect(cached?.pages[0].items.map((item) => item.id)).toEqual(['parent-2']);
+  });
+
+  it('removes a thread reply on external delete', () => {
+    testQueryClient.setQueryData(
+      getChannelMessagesQueryKey('channel-1'),
+      createChannelMessagesData([
+        [
+          createPaginatedMessage('parent-1', '2024-01-03T00:00:00.000Z', {
+            thread: {
+              preview: [
+                createThreadReply('reply-1', '2024-01-03T01:00:00.000Z'),
+              ],
+              reply_count: 1,
+              latest_reply_at: '2024-01-03T01:00:00.000Z',
+            },
+          }),
+        ],
+      ])
+    );
+    testQueryClient.setQueryData(
+      getThreadRepliesQueryKey('channel-1', 'parent-1'),
+      [createThreadReply('reply-1', '2024-01-03T01:00:00.000Z')]
+    );
+
+    handleCommsMessage({
+      channel_id: 'channel-1',
+      id: 'reply-1',
+      thread_id: 'parent-1',
+      deleted_at: '2024-01-03T03:00:00.000Z',
+      nonce: 'external-delete',
+    } as Parameters<typeof handleCommsMessage>[0]);
+
+    expect(
+      testQueryClient.getQueryData<Array<ApiThreadReply>>(
+        getThreadRepliesQueryKey('channel-1', 'parent-1')
+      )
+    ).toEqual([]);
   });
 
   it('updates thread reply reactions without the legacy channel cache', () => {

--- a/js/app/packages/queries/channel/tests/sync.test.ts
+++ b/js/app/packages/queries/channel/tests/sync.test.ts
@@ -201,43 +201,6 @@ describe('channel sync', () => {
     expect(cached?.pages[0].items.map((item) => item.id)).toEqual(['parent-2']);
   });
 
-  it('removes a thread reply on external delete', () => {
-    testQueryClient.setQueryData(
-      getChannelMessagesQueryKey('channel-1'),
-      createChannelMessagesData([
-        [
-          createPaginatedMessage('parent-1', '2024-01-03T00:00:00.000Z', {
-            thread: {
-              preview: [
-                createThreadReply('reply-1', '2024-01-03T01:00:00.000Z'),
-              ],
-              reply_count: 1,
-              latest_reply_at: '2024-01-03T01:00:00.000Z',
-            },
-          }),
-        ],
-      ])
-    );
-    testQueryClient.setQueryData(
-      getThreadRepliesQueryKey('channel-1', 'parent-1'),
-      [createThreadReply('reply-1', '2024-01-03T01:00:00.000Z')]
-    );
-
-    handleCommsMessage({
-      channel_id: 'channel-1',
-      id: 'reply-1',
-      thread_id: 'parent-1',
-      deleted_at: '2024-01-03T03:00:00.000Z',
-      nonce: 'external-delete',
-    } as Parameters<typeof handleCommsMessage>[0]);
-
-    expect(
-      testQueryClient.getQueryData<Array<ApiThreadReply>>(
-        getThreadRepliesQueryKey('channel-1', 'parent-1')
-      )
-    ).toEqual([]);
-  });
-
   it('updates thread reply reactions without the legacy channel cache', () => {
     testQueryClient.setQueryData(
       getChannelMessagesQueryKey('channel-1'),


### PR DESCRIPTION
## Summary
This PR updates the message deletion logic to distinguish between top-level messages with and without replies. Messages with replies are now soft-deleted (marked with `deleted_at`), while messages without replies are completely removed from the cache.