### PR TITLE
fix(auth): no-op on already-linked Google identity in /link/gmail callback

### DIFF
--- a/rust/cloud-storage/authentication_service/src/api/oauth2/google.rs
+++ b/rust/cloud-storage/authentication_service/src/api/oauth2/google.rs
@@ -18,6 +18,7 @@ use crate::api::{
         login::{self},
     },
 };
+use fusionauth::error::FusionAuthClientError;
 use fusionauth::identity_provider::{IdentityProviderLink, LinkUserRequest};
 
 async fn link_user(
@@ -76,7 +77,8 @@ async fn link_user(
         ));
     }
 
-    ctx.auth_client
+    match ctx
+        .auth_client
         .link_user(LinkUserRequest {
             identity_provider_link: IdentityProviderLink {
                 display_name: user_info_email.clone(),
@@ -87,12 +89,24 @@ async fn link_user(
             },
         })
         .await
-        .map_err(|e| {
-            (
+    {
+        Ok(()) => {}
+        // Same Google identity already linked to this FA user → init's idempotency
+        // check on email_links will short-circuit downstream. No-op.
+        Err(FusionAuthClientError::IdentityProviderLinkAlreadyExists) => {
+            tracing::info!(
+                fusion_user_id = %macro_user_id,
+                linked_email = %user_info_email,
+                "idp link already exists, skipping creation"
+            );
+        }
+        Err(e) => {
+            return Err((
                 StatusCode::INTERNAL_SERVER_ERROR,
                 format!("unable to link user {e}"),
-            )
-        })?;
+            ));
+        }
+    }
 
     // Stash the linked email on the in_progress_user_link row so /email/init can pick it up.
     // The row is consumed and deleted by /email/init once the email_links record is created.

--- a/rust/cloud-storage/fusionauth/src/error.rs
+++ b/rust/cloud-storage/fusionauth/src/error.rs
@@ -17,6 +17,9 @@ pub enum FusionAuthClientError {
     /// A user with this email already exists.
     #[error("user already exists")]
     UserAlreadyExists,
+    /// The Google identity is already linked to this FusionAuth user.
+    #[error("identity provider link already exists")]
+    IdentityProviderLinkAlreadyExists,
     /// No identity provider was found.
     #[error("no identity provider found")]
     NoIdentityProviderFound,

--- a/rust/cloud-storage/fusionauth/src/identity_provider/link.rs
+++ b/rust/cloud-storage/fusionauth/src/identity_provider/link.rs
@@ -143,6 +143,13 @@ pub(crate) async fn link_user(
                 })
             })?;
 
+            // FA returns this when the (user_id, identity_provider_user_id) pair is
+            // already linked. Treat as a typed variant so callers can no-op on it.
+            if body.contains("[alreadyLinked]identityProviderUserId") {
+                tracing::info!(body=%body, "fusionauth idp link already exists");
+                return Err(FusionAuthClientError::IdentityProviderLinkAlreadyExists);
+            }
+
             tracing::error!(body=%body, "unexpected response from fusionauth");
 
             Err(FusionAuthClientError::Generic(GenericErrorResponse {

--- a/rust/cloud-storage/fusionauth/src/identity_provider/link.rs
+++ b/rust/cloud-storage/fusionauth/src/identity_provider/link.rs
@@ -1,9 +1,34 @@
 use std::borrow::Cow;
+use std::collections::HashMap;
 
 use crate::{
     AuthedClient, Result,
     error::{FusionAuthClientError, GenericErrorResponse},
 };
+
+/// Structured shape of FusionAuth validation error responses.
+/// See https://fusionauth.io/docs/v1/tech/apis/errors
+#[derive(serde::Deserialize, Debug, Default)]
+struct FusionAuthErrorBody {
+    #[serde(default, rename = "fieldErrors")]
+    field_errors: HashMap<String, Vec<FusionAuthFieldError>>,
+}
+
+#[derive(serde::Deserialize, Debug)]
+struct FusionAuthFieldError {
+    code: String,
+}
+
+impl FusionAuthErrorBody {
+    /// Returns true if any field error carries the FusionAuth `[alreadyLinked]` code,
+    /// regardless of which field triggered it.
+    fn is_already_linked(&self) -> bool {
+        self.field_errors
+            .values()
+            .flatten()
+            .any(|e| e.code.starts_with("[alreadyLinked]"))
+    }
+}
 
 #[derive(serde::Serialize, serde::Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
@@ -143,9 +168,11 @@ pub(crate) async fn link_user(
                 })
             })?;
 
-            // FA returns this when the (user_id, identity_provider_user_id) pair is
-            // already linked. Treat as a typed variant so callers can no-op on it.
-            if body.contains("[alreadyLinked]identityProviderUserId") {
+            if serde_json::from_str::<FusionAuthErrorBody>(&body)
+                .ok()
+                .as_ref()
+                .is_some_and(FusionAuthErrorBody::is_already_linked)
+            {
                 tracing::info!(body=%body, "fusionauth idp link already exists");
                 return Err(FusionAuthClientError::IdentityProviderLinkAlreadyExists);
             }


### PR DESCRIPTION
Hitting `POST /link/gmail` for a Google account that's already linked to the requesting FusionAuth user returned a generic 500 ("unable to link user an unknown error occurred") because FA responded with `[alreadyLinked]identityProviderUserId` and we mapped any non-200 to `FusionAuthClientError::Generic`. The link is already in the desired state, so it's a no-op for our purposes. This PR surfaces it as a typed `IdentityProviderLinkAlreadyExists` variant and falls through to `set_linked_email` + the original-URL redirect; `/email/init`'s idempotency check on `email_links(fusion_user_id, email, Gmail)` handles the downstream half.
