### PR TITLE
fix(db): drop email_links.macro_id unique index to unblock multi-inbox

### DIFF
--- a/rust/cloud-storage/macro_db_client/migrations/20260527232659_drop_email_links_macro_id_unique.sql
+++ b/rust/cloud-storage/macro_db_client/migrations/20260527232659_drop_email_links_macro_id_unique.sql
@@ -1,0 +1,6 @@
+-- no-transaction
+-- Multi-inbox requires multiple email_links per macro_id (each row is a separate
+-- inbox the user has linked). The unique index from migration 20260220183100
+-- encoded the old "one inbox per user" assumption and now blocks the second
+-- INSERT in email_db_client::links::insert::upsert_link.
+DROP INDEX CONCURRENTLY IF EXISTS email_links_macro_id_uq;


### PR DESCRIPTION
Multi-inbox stores N email_links per macro_id (macro_id is the user's identity, not the inbox email), but a single-column unique index from migration 20260220183100 still encoded "one inbox per user" and blocked the second INSERT with `email_links_macro_id_uq` before the `(fusionauth_user_id, email_address, provider)` ON CONFLICT clause could run. Drops the index `CONCURRENTLY`. The remaining unique tuple `(fusionauth_user_id, email_address, provider)` (already enforced via the `upsert_link` ON CONFLICT) keeps the table from accepting actual duplicate rows. Existing `fetch_link_by_macro_id` callers continue to work (LIMIT 1) until the companion read-side union task migrates them.
