### PR TITLE
fix(soup): clear search text on back/forward navigation

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/soup-view-search-bar.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/soup-view-search-bar.tsx
@@ -42,15 +42,9 @@ const variantStyles: Record<SearchbarVariant, string> = {
 };
 
 export const SoupSearchbar = (props: SoupSearchbarProps) => {
-  const { searchText, setSearchText, setSearchPaused, queryFilters } =
-    useSoupView();
+  const { setSearchText, setSearchPaused, queryFilters } = useSoupView();
   const soup = useSoup();
   const panel = useSplitPanelOrThrow();
-
-  // Read the current search-text signal once at mount so the editor opens
-  // with whatever was captured into per-entry state by the last visit.
-  // Falls back to the explicit `initialValue` prop when entry state is empty.
-  const initialEditorValue = searchText() || props.initialValue;
 
   const [hasContent, setHasContent] = createSignal(false);
   const [latestMarkdown, setLatestMarkdown] = createSignal('');
@@ -173,7 +167,7 @@ export const SoupSearchbar = (props: SoupSearchbarProps) => {
             config={editor}
             placeholder={props.placeholder ?? 'Search'}
             autofocus={props.autoFocus}
-            initialValue={initialEditorValue}
+            initialValue={props.initialValue}
             class="min-h-0! overflow-visible!"
           />
         </div>

--- a/js/app/packages/app/component/next-soup/soup-view/soup-view-context.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-view-context.tsx
@@ -252,9 +252,9 @@ export const SoupViewContextProvider: FlowComponent<
   // soupBody is derived from the query filter store's compiled AST
   const soupBody = createMemo(() => queryFilters.compile());
 
-  const [searchText, setSearchText] = useEntryState<string>('search.text', {
-    default: props.initialSearchText ?? '',
-  });
+  const [searchText, setSearchText] = createSignal<string>(
+    props.initialSearchText ?? ''
+  );
 
   const search = createSearchState({
     soup,


### PR DESCRIPTION
Both back-arrow click and bracket-hotkey paths funnel through the same `back(splitId)`, so the perceived divergence was the `search.text` per-entry state captor (added in Phase 2) leaving the typed query in the search bar after navigation. This drops `search.text` persistence so both paths now clear the search input on back/forward; filter and predicate state remain persisted.
