### PR TITLE
feat(channels): repoint frontend channel ops from @service-comms to @service-storage

### DIFF
--- a/js/app/packages/app/component/ios-share-sheet/IosShareSheet.tsx
+++ b/js/app/packages/app/component/ios-share-sheet/IosShareSheet.tsx
@@ -39,7 +39,7 @@ import type {
 } from '@macro/tauri';
 import { useShareTarget, useTauri } from '@macro/tauri';
 import { invalidateListChannels } from '@queries/channel/channels';
-import { commsServiceClient } from '@service-comms/client';
+import { storageServiceClient } from '@service-storage/client';
 import { staticFileClient } from '@service-static-files/client';
 import { isIOS } from '@solid-primitives/platform';
 import { Button } from '@ui';
@@ -280,10 +280,10 @@ function IosShareSheetComposer(props: {
 
     const result =
       destination.users.length === 1
-        ? await commsServiceClient.getOrCreateDirectMessage({
+        ? await storageServiceClient.getOrCreateDirectMessage({
             recipient_id: destination.users[0],
           })
-        : await commsServiceClient.getOrCreatePrivateChannel({
+        : await storageServiceClient.getOrCreatePrivateChannel({
             recipients: destination.users,
           });
 
@@ -305,7 +305,7 @@ function IosShareSheetComposer(props: {
     const channelId = await resolveDestinationChannelId();
     const message = buildPostMessageRequest({ snapshot });
 
-    const result = await commsServiceClient.postMessage({
+    const result = await storageServiceClient.postMessage({
       channel_id: channelId,
       message,
     });

--- a/js/app/packages/app/component/ios-share-sheet/IosShareSheet.tsx
+++ b/js/app/packages/app/component/ios-share-sheet/IosShareSheet.tsx
@@ -39,8 +39,12 @@ import type {
 } from '@macro/tauri';
 import { useShareTarget, useTauri } from '@macro/tauri';
 import { invalidateListChannels } from '@queries/channel/channels';
-import { storageServiceClient } from '@service-storage/client';
+import {
+  useGetOrCreateDirectMessageMutation,
+  useGetOrCreatePrivateChannelMutation,
+} from '@queries/channel/get-or-create-dm';
 import { staticFileClient } from '@service-static-files/client';
+import { storageServiceClient } from '@service-storage/client';
 import { isIOS } from '@solid-primitives/platform';
 import { Button } from '@ui';
 import {
@@ -220,6 +224,9 @@ function IosShareSheetComposer(props: {
   const composerId = crypto.randomUUID();
   const mentionsTracker = createMentionsTracker();
   const [scrollContainer, setScrollContainer] = createSignal<HTMLElement>();
+  const getOrCreateDmMutation = useGetOrCreateDirectMessageMutation();
+  const getOrCreatePrivateChannelMutation =
+    useGetOrCreatePrivateChannelMutation();
   let clearComposer = () => {};
 
   const [selectedOptions, setSelectedOptions] = createSignal<
@@ -278,21 +285,20 @@ function IosShareSheetComposer(props: {
       throw new Error('No valid recipients selected for iOS share sheet');
     }
 
-    const result =
-      destination.users.length === 1
-        ? await storageServiceClient.getOrCreateDirectMessage({
-            recipient_id: destination.users[0],
-          })
-        : await storageServiceClient.getOrCreatePrivateChannel({
-            recipients: destination.users,
-          });
-
-    if (result.isErr()) {
+    try {
+      const result =
+        destination.users.length === 1
+          ? await getOrCreateDmMutation.mutateAsync({
+              recipient_id: destination.users[0],
+            })
+          : await getOrCreatePrivateChannelMutation.mutateAsync({
+              recipients: destination.users,
+            });
+      return result.channel_id;
+    } catch {
       toast.failure('Failed to open channel');
       throw new Error('Failed to resolve share destination channel');
     }
-
-    return result.value.channel_id;
   };
 
   const handleSend = async (snapshot: InputSnapshot) => {

--- a/js/app/packages/app/component/next-soup/soup-view/NewCallButton.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/NewCallButton.tsx
@@ -7,7 +7,10 @@ import { getDestinationFromOptions } from '@core/util/destination';
 import PhoneCallIcon from '@icon/wide-call.svg';
 import PlusCircleIcon from '@phosphor/plus.svg';
 import XIcon from '@phosphor/x.svg';
-import { storageServiceClient } from '@service-storage/client';
+import {
+  useGetOrCreateDirectMessageMutation,
+  useGetOrCreatePrivateChannelMutation,
+} from '@queries/channel/get-or-create-dm';
 import { Button, Dialog, Surface } from '@ui';
 import { createSignal } from 'solid-js';
 
@@ -20,6 +23,9 @@ export function NewCallButton() {
   const [triedToSubmit, setTriedToSubmit] = createSignal(false);
   const [isSubmitting, setIsSubmitting] = createSignal(false);
   const { replaceSplit } = useSplitLayout();
+  const getOrCreateDmMutation = useGetOrCreateDirectMessageMutation();
+  const getOrCreatePrivateChannelMutation =
+    useGetOrCreatePrivateChannelMutation();
 
   function reset() {
     setSelectedOptions([]);
@@ -43,22 +49,21 @@ export function NewCallButton() {
       if (destination.type === 'channel') {
         channelId = destination.id;
       } else {
-        const result =
-          destination.users.length === 1
-            ? await storageServiceClient.getOrCreateDirectMessage({
-                recipient_id: destination.users[0],
-              })
-            : await storageServiceClient.getOrCreatePrivateChannel({
-                recipients: destination.users,
-              });
-
-        if (result.isErr()) {
+        try {
+          const result =
+            destination.users.length === 1
+              ? await getOrCreateDmMutation.mutateAsync({
+                  recipient_id: destination.users[0],
+                })
+              : await getOrCreatePrivateChannelMutation.mutateAsync({
+                  recipients: destination.users,
+                });
+          channelId = result.channel_id;
+        } catch {
           toast.failure('Failed to create channel for call');
           setIsSubmitting(false);
           return;
         }
-
-        channelId = result.value.channel_id;
       }
 
       setIsOpen(false);

--- a/js/app/packages/app/component/next-soup/soup-view/NewCallButton.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/NewCallButton.tsx
@@ -7,7 +7,7 @@ import { getDestinationFromOptions } from '@core/util/destination';
 import PhoneCallIcon from '@icon/wide-call.svg';
 import PlusCircleIcon from '@phosphor/plus.svg';
 import XIcon from '@phosphor/x.svg';
-import { commsServiceClient } from '@service-comms/client';
+import { storageServiceClient } from '@service-storage/client';
 import { Button, Dialog, Surface } from '@ui';
 import { createSignal } from 'solid-js';
 
@@ -45,10 +45,10 @@ export function NewCallButton() {
       } else {
         const result =
           destination.users.length === 1
-            ? await commsServiceClient.getOrCreateDirectMessage({
+            ? await storageServiceClient.getOrCreateDirectMessage({
                 recipient_id: destination.users[0],
               })
-            : await commsServiceClient.getOrCreatePrivateChannel({
+            : await storageServiceClient.getOrCreatePrivateChannel({
                 recipients: destination.users,
               });
 

--- a/js/app/packages/block-call/component/CallRecording/CallRecordingParticipants.tsx
+++ b/js/app/packages/block-call/component/CallRecording/CallRecordingParticipants.tsx
@@ -2,7 +2,7 @@ import { useSplitLayout } from '@app/component/split-layout/layout';
 import { UserIcon } from '@core/component/UserIcon';
 import { idToEmail } from '@core/user';
 
-import { storageServiceClient } from '@service-storage/client';
+import { useGetOrCreateDirectMessageMutation } from '@queries/channel/get-or-create-dm';
 import type { CallRecord } from '@service-storage/generated/schemas/callRecord';
 import type { Accessor } from 'solid-js';
 import { createMemo, For } from 'solid-js';
@@ -12,6 +12,7 @@ export function CallRecordingParticipantsSection(props: {
   record: Accessor<CallRecord>;
 }) {
   const { replaceOrInsertSplit } = useSplitLayout();
+  const getOrCreateDmMutation = useGetOrCreateDirectMessageMutation();
   const participants = createMemo(() =>
     dedupeCallRecordingParticipants(
       props.record().participants,
@@ -19,16 +20,15 @@ export function CallRecordingParticipantsSection(props: {
     )
   );
 
-  const openDirectMessage = async (participantId: string) => {
-    const result = await storageServiceClient.getOrCreateDirectMessage({
-      recipient_id: participantId,
-    });
-    const channelId = result.isOk() && result.value?.channel_id;
-    if (!channelId) return;
-    replaceOrInsertSplit({
-      type: 'channel',
-      id: channelId,
-    });
+  const openDirectMessage = (participantId: string) => {
+    getOrCreateDmMutation.mutate(
+      { recipient_id: participantId },
+      {
+        onSuccess: ({ channel_id }) => {
+          replaceOrInsertSplit({ type: 'channel', id: channel_id });
+        },
+      }
+    );
   };
 
   return (

--- a/js/app/packages/block-call/component/CallRecording/CallRecordingParticipants.tsx
+++ b/js/app/packages/block-call/component/CallRecording/CallRecordingParticipants.tsx
@@ -2,7 +2,7 @@ import { useSplitLayout } from '@app/component/split-layout/layout';
 import { UserIcon } from '@core/component/UserIcon';
 import { idToEmail } from '@core/user';
 
-import { commsServiceClient } from '@service-comms/client';
+import { storageServiceClient } from '@service-storage/client';
 import type { CallRecord } from '@service-storage/generated/schemas/callRecord';
 import type { Accessor } from 'solid-js';
 import { createMemo, For } from 'solid-js';
@@ -20,7 +20,7 @@ export function CallRecordingParticipantsSection(props: {
   );
 
   const openDirectMessage = async (participantId: string) => {
-    const result = await commsServiceClient.getOrCreateDirectMessage({
+    const result = await storageServiceClient.getOrCreateDirectMessage({
       recipient_id: participantId,
     });
     const channelId = result.isOk() && result.value?.channel_id;

--- a/js/app/packages/block-channel/component/Compose.tsx
+++ b/js/app/packages/block-channel/component/Compose.tsx
@@ -37,7 +37,7 @@ import {
   uploadFile,
 } from '@core/util/upload';
 import InfoIcon from '@phosphor/info.svg';
-import { commsServiceClient } from '@service-comms/client';
+import { storageServiceClient } from '@service-storage/client';
 import { Surface } from '@ui';
 import { createEffect, createMemo, createSignal, on, Show } from 'solid-js';
 
@@ -126,7 +126,7 @@ export function ChannelCompose() {
         channelName() &&
         destination.users.length > 1
       ) {
-        const res = await commsServiceClient.createChannel({
+        const res = await storageServiceClient.createChannel({
           channel_type: 'private',
           name: channelName() ?? null,
           participants: destination.users,

--- a/js/app/packages/block-channel/component/Compose.tsx
+++ b/js/app/packages/block-channel/component/Compose.tsx
@@ -37,7 +37,7 @@ import {
   uploadFile,
 } from '@core/util/upload';
 import InfoIcon from '@phosphor/info.svg';
-import { storageServiceClient } from '@service-storage/client';
+import { useCreateChannelMutation } from '@queries/channel/channels';
 import { Surface } from '@ui';
 import { createEffect, createMemo, createSignal, on, Show } from 'solid-js';
 
@@ -105,6 +105,7 @@ export function ChannelCompose() {
   const [error, setError] = createSignal<string>();
 
   const { sendToUsers, sendToChannel } = useSendMessageToPeople();
+  const createChannelMutation = useCreateChannelMutation();
 
   async function handleSend(snapshot: InputSnapshot) {
     setError(undefined);
@@ -126,15 +127,11 @@ export function ChannelCompose() {
         channelName() &&
         destination.users.length > 1
       ) {
-        const res = await storageServiceClient.createChannel({
+        const { id } = await createChannelMutation.mutateAsync({
           channel_type: 'private',
           name: channelName() ?? null,
           participants: destination.users,
         });
-        if (res.isErr()) {
-          throw new Error('Could not create channel');
-        }
-        const { id } = res.value;
         await sendToChannel({
           channelId: id,
           content,

--- a/js/app/packages/channel/Participants/ChannelParticipantsTab.tsx
+++ b/js/app/packages/channel/Participants/ChannelParticipantsTab.tsx
@@ -8,7 +8,7 @@ import {
   useAddParticipantsMutation,
   useRemoveParticipantsMutation,
 } from '@queries/channel/participants';
-import { commsServiceClient } from '@service-comms/client';
+import { storageServiceClient } from '@service-storage/client';
 import { ChannelType } from '@service-comms/generated/models/channelType';
 import { Panel } from '@ui';
 import { createSignal, Show } from 'solid-js';
@@ -62,7 +62,7 @@ export function ChannelParticipantsTab(props: { channelId: string }) {
   };
 
   const openDirectMessage = async (participantId: string) => {
-    const result = await commsServiceClient.getOrCreateDirectMessage({
+    const result = await storageServiceClient.getOrCreateDirectMessage({
       recipient_id: participantId,
     });
     const channelId = result.isOk() && result.value?.channel_id;

--- a/js/app/packages/channel/Participants/ChannelParticipantsTab.tsx
+++ b/js/app/packages/channel/Participants/ChannelParticipantsTab.tsx
@@ -4,11 +4,11 @@ import { useUserId } from '@core/context/user';
 import { idToEmail } from '@core/user';
 
 import { useChannelParticipantsQuery } from '@queries/channel/channel-participants';
+import { useGetOrCreateDirectMessageMutation } from '@queries/channel/get-or-create-dm';
 import {
   useAddParticipantsMutation,
   useRemoveParticipantsMutation,
 } from '@queries/channel/participants';
-import { storageServiceClient } from '@service-storage/client';
 import { ChannelType } from '@service-comms/generated/models/channelType';
 import { Panel } from '@ui';
 import { createSignal, Show } from 'solid-js';
@@ -23,6 +23,7 @@ export function ChannelParticipantsTab(props: { channelId: string }) {
   const participantsQuery = useChannelParticipantsQuery(() => props.channelId);
   const addParticipantsMutation = useAddParticipantsMutation();
   const removeParticipantsMutation = useRemoveParticipantsMutation();
+  const getOrCreateDmMutation = useGetOrCreateDirectMessageMutation();
   const [searchQuery, setSearchQuery] = createSignal('');
 
   const participants = () => participantsQuery.data ?? [];
@@ -61,18 +62,15 @@ export function ChannelParticipantsTab(props: { channelId: string }) {
     });
   };
 
-  const openDirectMessage = async (participantId: string) => {
-    const result = await storageServiceClient.getOrCreateDirectMessage({
-      recipient_id: participantId,
-    });
-    const channelId = result.isOk() && result.value?.channel_id;
-
-    if (channelId) {
-      replaceOrInsertSplit({
-        type: 'channel',
-        id: channelId,
-      });
-    }
+  const openDirectMessage = (participantId: string) => {
+    getOrCreateDmMutation.mutate(
+      { recipient_id: participantId },
+      {
+        onSuccess: ({ channel_id }) => {
+          replaceOrInsertSplit({ type: 'channel', id: channel_id });
+        },
+      }
+    );
   };
 
   return (

--- a/js/app/packages/core/component/FileList/itemOperations.ts
+++ b/js/app/packages/core/component/FileList/itemOperations.ts
@@ -9,7 +9,6 @@ import {
 } from '@queries/storage/deleted';
 import { callServiceClient } from '@service-call/client';
 import { cognitionApiServiceClient } from '@service-cognition/client';
-import { commsServiceClient } from '@service-comms/client';
 import { emailClient } from '@service-email/client';
 import { type ItemType, storageServiceClient } from '@service-storage/client';
 import type { FileType } from '@service-storage/generated/schemas/fileType';
@@ -106,7 +105,7 @@ export async function renameItem(args: {
       break;
     }
     case 'channel': {
-      result = await commsServiceClient.patchChannel({
+      result = await storageServiceClient.patchChannel({
         channel_id: id,
         channel_name: newName,
       });

--- a/js/app/packages/core/component/UserIcon.tsx
+++ b/js/app/packages/core/component/UserIcon.tsx
@@ -9,7 +9,7 @@ import {
   useDisplayNameParts,
 } from '@core/user';
 import Trash from '@phosphor-icons/core/regular/trash.svg?component-solid';
-import { commsServiceClient } from '@service-comms/client';
+import { storageServiceClient } from '@service-storage/client';
 import { Avatar, type AvatarSize } from '@ui';
 import {
   createMemo,
@@ -151,7 +151,7 @@ export function UserIcon(props: UserIconProps) {
   const getOrCreateDm = async () => {
     if (!props.id) return;
 
-    const result = await commsServiceClient.getOrCreateDirectMessage({
+    const result = await storageServiceClient.getOrCreateDirectMessage({
       recipient_id: props.id,
     });
 

--- a/js/app/packages/core/component/UserIcon.tsx
+++ b/js/app/packages/core/component/UserIcon.tsx
@@ -9,7 +9,7 @@ import {
   useDisplayNameParts,
 } from '@core/user';
 import Trash from '@phosphor-icons/core/regular/trash.svg?component-solid';
-import { storageServiceClient } from '@service-storage/client';
+import { useGetOrCreateDirectMessageMutation } from '@queries/channel/get-or-create-dm';
 import { Avatar, type AvatarSize } from '@ui';
 import {
   createMemo,
@@ -147,18 +147,18 @@ export function UserIcon(props: UserIconProps) {
   });
 
   const { replaceOrInsertSplit } = useSplitLayout();
+  const getOrCreateDmMutation = useGetOrCreateDirectMessageMutation();
 
-  const getOrCreateDm = async () => {
+  const getOrCreateDm = () => {
     if (!props.id) return;
-
-    const result = await storageServiceClient.getOrCreateDirectMessage({
-      recipient_id: props.id,
-    });
-
-    const channelId = result.isOk() && result.value?.channel_id;
-    if (!channelId) return;
-
-    replaceOrInsertSplit({ type: 'channel', id: channelId });
+    getOrCreateDmMutation.mutate(
+      { recipient_id: props.id },
+      {
+        onSuccess: ({ channel_id }) => {
+          replaceOrInsertSplit({ type: 'channel', id: channel_id });
+        },
+      }
+    );
   };
 
   const showTooltip = () => props.showTooltip !== false;

--- a/js/app/packages/core/component/UserTooltip.tsx
+++ b/js/app/packages/core/component/UserTooltip.tsx
@@ -5,7 +5,7 @@ import WideChat from '@icon/wide-chat.svg';
 import WideCopy from '@icon/wide-copy.svg';
 import WideTask from '@icon/wide-task.svg';
 import IconCheck from '@phosphor/check.svg';
-import { storageServiceClient } from '@service-storage/client';
+import { useGetOrCreateDirectMessageMutation } from '@queries/channel/get-or-create-dm';
 import { debounce } from '@solid-primitives/scheduled';
 import { Button, Surface } from '@ui';
 import { createSignal, Show } from 'solid-js';
@@ -35,29 +35,27 @@ export function UserTooltip(props: UserTooltipProps) {
   }
   const currentUserId = useUserId();
   const { openWithSplit, popoverSplit } = useSplitLayout();
+  const getOrCreateDmMutation = useGetOrCreateDirectMessageMutation({
+    onError: () => toast.failure('Failed to open direct message'),
+  });
 
-  const openDM = async (e: PointerEvent | MouseEvent) => {
+  const openDM = (e: PointerEvent | MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
     props.onClose?.();
-    if (props.id) {
-      try {
-        const result = await storageServiceClient.getOrCreateDirectMessage({
-          recipient_id: props.id,
-        });
-        const channelId = result.isOk() && result.value?.channel_id;
-        if (channelId) {
+    if (!props.id) return;
+    const preferNewSplit = e.shiftKey;
+    getOrCreateDmMutation.mutate(
+      { recipient_id: props.id },
+      {
+        onSuccess: ({ channel_id }) => {
           openWithSplit(
-            { type: 'channel', id: channelId },
-            { preferNewSplit: e.shiftKey }
+            { type: 'channel', id: channel_id },
+            { preferNewSplit }
           );
-        } else {
-          toast.failure('Failed to open direct message');
-        }
-      } catch {
-        toast.failure('Failed to open direct message');
+        },
       }
-    }
+    );
   };
 
   const openTaskComposer = (e: MouseEvent) => {

--- a/js/app/packages/core/component/UserTooltip.tsx
+++ b/js/app/packages/core/component/UserTooltip.tsx
@@ -5,7 +5,7 @@ import WideChat from '@icon/wide-chat.svg';
 import WideCopy from '@icon/wide-copy.svg';
 import WideTask from '@icon/wide-task.svg';
 import IconCheck from '@phosphor/check.svg';
-import { commsServiceClient } from '@service-comms/client';
+import { storageServiceClient } from '@service-storage/client';
 import { debounce } from '@solid-primitives/scheduled';
 import { Button, Surface } from '@ui';
 import { createSignal, Show } from 'solid-js';
@@ -42,7 +42,7 @@ export function UserTooltip(props: UserTooltipProps) {
     props.onClose?.();
     if (props.id) {
       try {
-        const result = await commsServiceClient.getOrCreateDirectMessage({
+        const result = await storageServiceClient.getOrCreateDirectMessage({
           recipient_id: props.id,
         });
         const channelId = result.isOk() && result.value?.channel_id;

--- a/js/app/packages/core/util/channels.ts
+++ b/js/app/packages/core/util/channels.ts
@@ -5,7 +5,7 @@ import { toast } from '@core/component/Toast/Toast';
 import { invalidateContacts } from '@core/user/contactService';
 
 import { invalidateListChannels } from '@queries/channel/channels';
-import { commsServiceClient, type IdResponse } from '@service-comms/client';
+import { storageServiceClient } from '@service-storage/client';
 import type {
   NewAttachment,
   SimpleMention,
@@ -44,7 +44,7 @@ export function useSendMessageToPeople() {
     attachments: NewAttachment[],
     navigate?: NavigationOptions
   ) {
-    const message = await commsServiceClient.postMessage({
+    const message = await storageServiceClient.postMessage({
       channel_id: channelId,
       message: {
         content,
@@ -59,7 +59,7 @@ export function useSendMessageToPeople() {
       return;
     }
 
-    const messageResponse = message.value as IdResponse;
+    const messageResponse = message.value;
 
     invalidateListChannels();
     invalidateContacts();
@@ -88,10 +88,10 @@ export function useSendMessageToPeople() {
   async function sendToUsers(args: SendToUsersArgs) {
     const result =
       args.users.length === 1
-        ? await commsServiceClient.getOrCreateDirectMessage({
+        ? await storageServiceClient.getOrCreateDirectMessage({
             recipient_id: args.users[0],
           })
-        : await commsServiceClient.getOrCreatePrivateChannel({
+        : await storageServiceClient.getOrCreatePrivateChannel({
             recipients: args.users,
           });
 

--- a/js/app/packages/core/util/channels.ts
+++ b/js/app/packages/core/util/channels.ts
@@ -5,11 +5,15 @@ import { toast } from '@core/component/Toast/Toast';
 import { invalidateContacts } from '@core/user/contactService';
 
 import { invalidateListChannels } from '@queries/channel/channels';
-import { storageServiceClient } from '@service-storage/client';
+import {
+  useGetOrCreateDirectMessageMutation,
+  useGetOrCreatePrivateChannelMutation,
+} from '@queries/channel/get-or-create-dm';
 import type {
   NewAttachment,
   SimpleMention,
 } from '@service-comms/generated/models';
+import { storageServiceClient } from '@service-storage/client';
 import { createCallback } from '@solid-primitives/rootless';
 
 type SendContent = {
@@ -36,6 +40,9 @@ type SendToChannelArgs = SendContent & {
 export function useSendMessageToPeople() {
   const { replaceSplit } = useSplitLayout();
   const orchestrator = useGlobalBlockOrchestrator();
+  const getOrCreateDmMutation = useGetOrCreateDirectMessageMutation();
+  const getOrCreatePrivateChannelMutation =
+    useGetOrCreatePrivateChannelMutation();
 
   async function sendAndNavigateToChannel(
     channelId: string,
@@ -86,23 +93,25 @@ export function useSendMessageToPeople() {
   }
 
   async function sendToUsers(args: SendToUsersArgs) {
-    const result =
-      args.users.length === 1
-        ? await storageServiceClient.getOrCreateDirectMessage({
-            recipient_id: args.users[0],
-          })
-        : await storageServiceClient.getOrCreatePrivateChannel({
-            recipients: args.users,
-          });
-
-    if (result.isErr()) {
+    let channelId: string;
+    try {
+      const result =
+        args.users.length === 1
+          ? await getOrCreateDmMutation.mutateAsync({
+              recipient_id: args.users[0],
+            })
+          : await getOrCreatePrivateChannelMutation.mutateAsync({
+              recipients: args.users,
+            });
+      channelId = result.channel_id;
+    } catch (err) {
       toast.failure('Failed to send message to people');
-      console.error('failed to create new channel to forward', result);
+      console.error('failed to create new channel to forward', err);
       return;
     }
 
     return sendAndNavigateToChannel(
-      result.value.channel_id,
+      channelId,
       args.content,
       args.mentions,
       args.attachments ?? [],

--- a/js/app/packages/queries/channel/channels.ts
+++ b/js/app/packages/queries/channel/channels.ts
@@ -1,7 +1,11 @@
 import { throwOnErr } from '@core/util/result';
 import { queryClient } from '@queries/client';
+import { type MutationCallbacks, withCallbacks } from '@queries/utils';
 import { commsServiceClient } from '@service-comms/client';
-import { useQuery } from '@tanstack/solid-query';
+import { storageServiceClient } from '@service-storage/client';
+import type { CreateChannelRequest } from '@service-storage/generated/schemas/createChannelRequest';
+import type { CreateChannelResponse } from '@service-storage/generated/schemas/createChannelResponse';
+import { useMutation, useQuery } from '@tanstack/solid-query';
 import { channelKeys } from './keys';
 
 export function useListChannelsQuery() {
@@ -15,4 +19,39 @@ export function invalidateListChannels() {
   return queryClient.invalidateQueries({
     queryKey: channelKeys.listChannels.queryKey,
   });
+}
+
+/**
+ * Create a channel. Invalidates the channel list on settle.
+ */
+export function useCreateChannelMutation(
+  callbacks?: MutationCallbacks<
+    CreateChannelResponse,
+    Error,
+    CreateChannelRequest,
+    undefined
+  >
+) {
+  return useMutation(() => ({
+    gcTime: 0,
+    mutationFn: async (vars: CreateChannelRequest) => {
+      return await throwOnErr(async () =>
+        storageServiceClient.createChannel(vars)
+      );
+    },
+    ...withCallbacks<
+      CreateChannelResponse,
+      Error,
+      CreateChannelRequest,
+      undefined
+    >(
+      {
+        onError(error) {
+          console.error('failed to create channel', error);
+        },
+        onSettled: () => void invalidateListChannels(),
+      },
+      callbacks
+    ),
+  }));
 }

--- a/js/app/packages/queries/channel/get-or-create-dm.ts
+++ b/js/app/packages/queries/channel/get-or-create-dm.ts
@@ -49,3 +49,44 @@ export function useGetOrCreateDirectMessageMutation(
     ),
   }));
 }
+
+type GetOrCreatePrivateChannelParams = {
+  recipients: string[];
+};
+
+/**
+ * Create or resolve a private group channel for a set of recipients. Invalidates the channel list on settle.
+ */
+export function useGetOrCreatePrivateChannelMutation(
+  callbacks?: MutationCallbacks<
+    GetOrCreateChannelResponse,
+    Error,
+    GetOrCreatePrivateChannelParams,
+    undefined
+  >
+) {
+  return useMutation(() => ({
+    gcTime: 0,
+    mutationFn: async (vars: GetOrCreatePrivateChannelParams) => {
+      return await throwOnErr(async () =>
+        storageServiceClient.getOrCreatePrivateChannel({
+          recipients: vars.recipients,
+        })
+      );
+    },
+    ...withCallbacks<
+      GetOrCreateChannelResponse,
+      Error,
+      GetOrCreatePrivateChannelParams,
+      undefined
+    >(
+      {
+        onError(error) {
+          console.error('failed to get or create private channel', error);
+        },
+        onSettled: () => void invalidateListChannels(),
+      },
+      callbacks
+    ),
+  }));
+}


### PR DESCRIPTION
First step in the `comms_service` → `channels` hex migration. Five channel methods already exist on `@service-storage/client` (backed by the `/channels` hex router on DSS), but several frontend call sites still imported `commsServiceClient` from `@service-comms` and hit the old `/comms/*` endpoints. This PR swaps those call sites to the storage client — no backend changes.
