### PR TITLE
revert: remove FA IdP link data tagging

### DIFF
--- a/rust/cloud-storage/authentication_service/src/api/merge/verify_merge_request.rs
+++ b/rust/cloud-storage/authentication_service/src/api/merge/verify_merge_request.rs
@@ -145,7 +145,6 @@ pub async fn handler(
                     identity_provider_user_id: Cow::Borrowed(&link.identity_provider_user_id),
                     user_id: Cow::Borrowed(&user_context.fusion_user_id),
                     token: Cow::Borrowed(&link.token),
-                    data: None,
                 },
             })
             .collect::<Vec<_>>();

--- a/rust/cloud-storage/authentication_service/src/api/oauth2/google.rs
+++ b/rust/cloud-storage/authentication_service/src/api/oauth2/google.rs
@@ -19,9 +19,7 @@ use crate::api::{
     },
 };
 use fusionauth::error::FusionAuthClientError;
-use fusionauth::identity_provider::{
-    IdentityProviderLink, IdentityProviderLinkData, IdentityProviderLinkRole, LinkUserRequest,
-};
+use fusionauth::identity_provider::{IdentityProviderLink, LinkUserRequest};
 
 async fn link_user(
     ctx: &ApiContext,
@@ -70,9 +68,6 @@ async fn link_user(
     //   Err(alreadyLinked, owned by other) → cross-account add; init promotes to graph edge.
     // The FA error doesn't distinguish self vs other in the typed variant, but it doesn't need
     // to — init re-derives ownership via macrodb's User table to pick its dispatch path.
-    // Any link we create here is a secondary inbox-add (the primary FA link was already
-    // created at signup). Tag accordingly so login routing can reject sign-in attempts
-    // against this link — enforcement lands in a follow-up; this PR only writes the tag.
     match ctx
         .auth_client
         .link_user(LinkUserRequest {
@@ -82,9 +77,6 @@ async fn link_user(
                 identity_provider_user_id: Cow::Borrowed(&user_info.sub),
                 user_id: Cow::Borrowed(&macro_user_id.to_string()),
                 token: Cow::Borrowed(&token_response.refresh_token),
-                data: Some(IdentityProviderLinkData {
-                    role: Some(IdentityProviderLinkRole::Secondary),
-                }),
             },
         })
         .await

--- a/rust/cloud-storage/fusionauth/src/identity_provider/link.rs
+++ b/rust/cloud-storage/fusionauth/src/identity_provider/link.rs
@@ -115,24 +115,6 @@ pub(crate) async fn get_links(
     }
 }
 
-/// Role this link plays in our application
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
-#[serde(rename_all = "lowercase")]
-pub enum IdentityProviderLinkRole {
-    /// Created at signup
-    Primary,
-    /// Created via /link/gmail
-    Secondary,
-}
-
-/// Application metadata stored on the FA link
-#[derive(serde::Serialize, serde::Deserialize, Debug, Default)]
-pub struct IdentityProviderLinkData {
-    /// Role
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub role: Option<IdentityProviderLinkRole>,
-}
-
 #[derive(serde::Serialize, serde::Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 /// An identity provider link for creating a link.
@@ -147,9 +129,6 @@ pub struct IdentityProviderLink<'a> {
     pub user_id: Cow<'a, str>,
     /// The token
     pub token: Cow<'a, str>,
-    /// Application metadata
-    #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub data: Option<IdentityProviderLinkData>,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Debug)]

--- a/rust/cloud-storage/fusionauth/src/identity_provider/mod.rs
+++ b/rust/cloud-storage/fusionauth/src/identity_provider/mod.rs
@@ -8,10 +8,7 @@ mod lookup;
 mod search;
 mod unlink;
 
-pub use link::{
-    IdentityProviderLink, IdentityProviderLinkData, IdentityProviderLinkRole, Link,
-    LinkUserRequest, RetrieveLinkResponse,
-};
+pub use link::{IdentityProviderLink, Link, LinkUserRequest, RetrieveLinkResponse};
 impl FusionAuthClient {
     /// Searches for an identity provider by name and returns its ID.
     #[tracing::instrument(skip(self), fields(application_id=%self.client_id, fusion_auth_base_url=%self.fusion_auth_base_url))]

--- a/rust/cloud-storage/github/src/outbound/github_auth_client.rs
+++ b/rust/cloud-storage/github/src/outbound/github_auth_client.rs
@@ -63,7 +63,6 @@ impl Auth for GithubAuthImpl {
                     identity_provider_user_id: github_user_id.into(),
                     user_id: fusionauth_user_id.to_string().into(),
                     token: access_token.into(),
-                    data: None,
                 },
             })
             .await?;


### PR DESCRIPTION
Removes the `data: { role: "secondary" }` tagging on FA IdP links that was added in #3614. Verified against dev FA: the `IdentityProviderLink` object has no `data` field — FA silently drops it on POST and the read-back is empty. The follow-up login-gate task needs a different signal (matching `displayName` against the FA user's email, or a sidecar table in macrodb) — tracked separately on the existing follow-up task.
