### PR TITLE
feat(channels): serve channel list via storage client

### DIFF
--- a/js/app/packages/queries/channel/channels.ts
+++ b/js/app/packages/queries/channel/channels.ts
@@ -1,7 +1,6 @@
 import { throwOnErr } from '@core/util/result';
 import { queryClient } from '@queries/client';
 import { type MutationCallbacks, withCallbacks } from '@queries/utils';
-import { commsServiceClient } from '@service-comms/client';
 import { storageServiceClient } from '@service-storage/client';
 import type { CreateChannelRequest } from '@service-storage/generated/schemas/createChannelRequest';
 import type { CreateChannelResponse } from '@service-storage/generated/schemas/createChannelResponse';
@@ -11,7 +10,7 @@ import { channelKeys } from './keys';
 export function useListChannelsQuery() {
   return useQuery(() => ({
     queryKey: channelKeys.listChannels.queryKey,
-    queryFn: async () => await throwOnErr(commsServiceClient.getChannels),
+    queryFn: async () => await throwOnErr(storageServiceClient.getChannels),
   }));
 }
 

--- a/js/app/packages/service-clients/service-storage/client.ts
+++ b/js/app/packages/service-clients/service-storage/client.ts
@@ -24,6 +24,7 @@ import type { ResultError } from '@core/util/result';
 
 import type { SafeFetchInit } from '@core/util/safeFetch';
 import type { IDocumentStorageServiceFile } from '@filesystem/file';
+import type { ApiChannelWithLatest } from '@service-comms/generated/models/apiChannelWithLatest';
 import { platformFetch } from 'core/util/platformFetch';
 import { err, ok, type Result } from 'neverthrow';
 import type {
@@ -39,7 +40,6 @@ import type {
 import type { AddParticipantsRequest } from './generated/schemas/addParticipantsRequest';
 import type { AddPinRequest } from './generated/schemas/addPinRequest';
 import type { AnchorResponse } from './generated/schemas/anchorResponse';
-import type { ApiChannelWithLatest } from '@service-comms/generated/models/apiChannelWithLatest';
 import type { ApiChannelAttachmentsPage } from './generated/schemas/apiChannelAttachmentsPage';
 import type { ApiChannelMessagesPage } from './generated/schemas/apiChannelMessagesPage';
 import type { ApiChannelParticipant } from './generated/schemas/apiChannelParticipant';

--- a/js/app/packages/service-clients/service-storage/client.ts
+++ b/js/app/packages/service-clients/service-storage/client.ts
@@ -39,6 +39,7 @@ import type {
 import type { AddParticipantsRequest } from './generated/schemas/addParticipantsRequest';
 import type { AddPinRequest } from './generated/schemas/addPinRequest';
 import type { AnchorResponse } from './generated/schemas/anchorResponse';
+import type { ApiChannelWithLatest } from '@service-comms/generated/models/apiChannelWithLatest';
 import type { ApiChannelAttachmentsPage } from './generated/schemas/apiChannelAttachmentsPage';
 import type { ApiChannelMessagesPage } from './generated/schemas/apiChannelMessagesPage';
 import type { ApiChannelParticipant } from './generated/schemas/apiChannelParticipant';
@@ -346,6 +347,17 @@ export const storageServiceClient = {
       await dssFetch<CreateChannelResponse>(`/channels`, {
         method: 'POST',
         body: JSON.stringify(args),
+      })
+    ).map((result) => result);
+  },
+
+  // The channel list is still served by the comms hex, mounted at
+  // `/comms/channels` on the same DSS host. Repoint to `/channels` once the
+  // list moves into the channels hex (alongside the comms teardown).
+  async getChannels() {
+    return (
+      await dssFetch<ApiChannelWithLatest[]>(`/comms/channels`, {
+        method: 'GET',
       })
     ).map((result) => result);
   },


### PR DESCRIPTION
Move the frontend `getChannels` call from the serviceComms client to the serviceStorage client. Both clients target the same DSS host, so the storage client just fetches the existing `/comms/channels` route — no backend change.

The channel-list logic already lives in the `comms` hex (DSS only mounts its router; it's not in `comms_service`), and `comms` stays alive regardless because soup still depends on `comms::ChannelsService::get_channels`. A full re-port into the channels hex would only add a duplicate list impl + a `models_comms` type bridge with no functional change, so it's deferred to the soup migration where `comms` is retired and the list lands in the channels hex with its filter intact.

https://claude.ai/code/session_019U9qnnwyfp4wVVDmmfu2PE

---
_Generated by [Claude Code](https://claude.ai/code/session_019U9qnnwyfp4wVVDmmfu2PE)_