### PR TITLE
fix(auth): return generic error when oauth callback has no code

### DIFF
--- a/rust/cloud-storage/authentication_service/src/api/oauth/oauth_redirect.rs
+++ b/rust/cloud-storage/authentication_service/src/api/oauth/oauth_redirect.rs
@@ -29,8 +29,14 @@ mod tests;
 
 #[derive(Debug, Deserialize)]
 pub(crate) struct OAuthCbParams {
-    code: String,
+    code: Option<String>,
     state: Option<JsonEncoded<SsoState>>,
+    #[serde(default)]
+    error: Option<String>,
+    #[serde(default)]
+    error_description: Option<String>,
+    #[serde(default)]
+    error_reason: Option<String>,
 }
 
 /// Handles oauth redirect
@@ -52,6 +58,25 @@ pub async fn handler(
     cookies: Cookies,
     extract::Query(params): extract::Query<OAuthCbParams>,
 ) -> Result<Response, Response> {
+    let code = match params.code {
+        Some(c) => c,
+        None => {
+            tracing::warn!(
+                error = ?params.error,
+                error_reason = ?params.error_reason,
+                error_description = ?params.error_description,
+                "oauth redirect received without code",
+            );
+            return Err((
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    message: "Sign-in failed. Please try again or contact support.".into(),
+                }),
+            )
+                .into_response());
+        }
+    };
+
     // Perform the oauth code grant
     // NOTE: rust is so blazingly fast (super crazy, I know) that we actually need to sleep here temporarily
     // to ensure we give time for the oauth authorization code to be setup in the backend.
@@ -60,7 +85,7 @@ pub async fn handler(
 
     let (access_token, refresh_token) = match ctx
         .auth_client
-        .complete_authorization_code_grant(&params.code)
+        .complete_authorization_code_grant(&code)
         .await
     {
         Ok(tokens) => tokens,

--- a/rust/cloud-storage/authentication_service/src/api/oauth/oauth_redirect/tests.rs
+++ b/rust/cloud-storage/authentication_service/src/api/oauth/oauth_redirect/tests.rs
@@ -28,13 +28,50 @@ async fn it_should_deserialize_query_params() {
         .await
         .unwrap();
 
-    assert_matches!(data, OAuthCbParams { code, state: Some(container) } => {
+    assert_matches!(data, OAuthCbParams { code: Some(code), state: Some(container), .. } => {
         assert_eq!(code, "test123");
         assert_matches!(container.decode().unwrap(), SsoState { original_url: Some(url), is_mobile: true, referral_code: Some(code) } => {
             assert_eq!(url.as_str(), "https://example.com/");
             assert_eq!(code.as_str(), "test");
         })
     });
+}
+
+#[tokio::test]
+async fn it_should_deserialize_error_redirect_without_code() {
+    let mut url: Url = "https://test.com".parse().unwrap();
+    url.query_pairs_mut()
+        .append_pair("error", "invalid_request")
+        .append_pair("error_reason", "invalid_origin")
+        .append_pair(
+            "error_description",
+            "Invalid origin uri https://accounts.google.com",
+        );
+
+    let (mut parts, ()) = Request::builder()
+        .uri(url.as_str())
+        .body(())
+        .unwrap()
+        .into_parts();
+
+    let extract::Query(data) = extract::Query::<OAuthCbParams>::from_request_parts(&mut parts, &())
+        .await
+        .unwrap();
+
+    assert_matches!(
+        data,
+        OAuthCbParams {
+            code: None,
+            state: None,
+            error: Some(err),
+            error_reason: Some(reason),
+            error_description: Some(desc),
+        } => {
+            assert_eq!(err, "invalid_request");
+            assert_eq!(reason, "invalid_origin");
+            assert_eq!(desc, "Invalid origin uri https://accounts.google.com");
+        }
+    );
 }
 
 #[derive(Debug, Default)]

--- a/rust/cloud-storage/authentication_service/src/api/oauth2/mod.rs
+++ b/rust/cloud-storage/authentication_service/src/api/oauth2/mod.rs
@@ -46,9 +46,15 @@ pub(in crate::api) struct OAuthState {
 #[derive(Debug, serde::Deserialize)]
 pub(in crate::api) struct Params {
     /// The code to complete the login
-    code: String,
+    code: Option<String>,
     /// State that is passed from the original request
     state: String,
+    #[serde(default)]
+    error: Option<String>,
+    #[serde(default)]
+    error_description: Option<String>,
+    #[serde(default)]
+    error_reason: Option<String>,
 }
 
 #[derive(Debug, serde::Deserialize)]
@@ -93,9 +99,28 @@ pub(in crate::api) async fn handler(
             .into_response()
     })?;
 
+    let code = match params.code {
+        Some(c) => c,
+        None => {
+            tracing::warn!(
+                error = ?params.error,
+                error_reason = ?params.error_reason,
+                error_description = ?params.error_description,
+                "oauth2 callback received without code",
+            );
+            return Err((
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    message: "Sign-in failed. Please try again or contact support.".into(),
+                }),
+            )
+                .into_response());
+        }
+    };
+
     match provider.as_str() {
-        "google" => google::handler(&ctx, cookies, &params.code, &state).await,
-        "github" => github::handler(&ctx, cookies, &params.code, &state)
+        "google" => google::handler(&ctx, cookies, &code, &state).await,
+        "github" => github::handler(&ctx, cookies, &code, &state)
             .await
             .map(|r| r.into_response())
             .map_err(|e| e.into_response()),


### PR DESCRIPTION
Return a generic 400 instead of an axum deserialization error when the OAuth callbacks receive an `error=...` redirect with no `code`. FA's reconcile lambda throws on secondary-inbox sign-ins, which is the case that ships this code through this path today.
