### PR TITLE
fix: give floating channel timestamp a solid bg-panel background

### DIFF
--- a/js/app/packages/channel/Message/ChannelMessage.tsx
+++ b/js/app/packages/channel/Message/ChannelMessage.tsx
@@ -125,7 +125,7 @@ function RegularMessageLayout(props: {
         <Message.SenderName />
         <Message.EditedIndicator />
         {/* On message hover, timestamp floats above actions. */}
-        <div class="grow shrink-0 min-w-0 flex justify-end group-hover/message:absolute group-hover/message:right-1 group-hover/message:-top-9 group-hover/message:p-1 group-hover/message:bg-panel group-hover/message:rounded-md">
+        <div class="grow shrink-0 min-w-0 flex justify-end group-hover/message:absolute group-hover/message:right-1 group-hover/message:-top-9 group-hover/message:p-1 group-hover/message:bg-surface group-hover/message:rounded-md">
           <Message.Timestamp class="ml-auto shrink-0" format="dateAndTime" />
         </div>
       </Message.Slot>

--- a/js/app/packages/channel/Message/ChannelMessage.tsx
+++ b/js/app/packages/channel/Message/ChannelMessage.tsx
@@ -125,7 +125,7 @@ function RegularMessageLayout(props: {
         <Message.SenderName />
         <Message.EditedIndicator />
         {/* On message hover, timestamp floats above actions. */}
-        <div class="grow shrink-0 min-w-0 flex justify-end group-hover/message:absolute group-hover/message:right-1 group-hover/message:-top-9 group-hover/message:p-1">
+        <div class="grow shrink-0 min-w-0 flex justify-end group-hover/message:absolute group-hover/message:right-1 group-hover/message:-top-9 group-hover/message:p-1 group-hover/message:bg-panel group-hover/message:rounded-md">
           <Message.Timestamp class="ml-auto shrink-0" format="dateAndTime" />
         </div>
       </Message.Slot>


### PR DESCRIPTION
The timestamp that floats above the hover action menu on channel messages had a transparent background, so message content showed through it. This adds `bg-panel` (with matching `rounded-md` corners) on hover so the floating timestamp reads as a solid element above the action menu.

Changed `js/app/packages/channel/Message/ChannelMessage.tsx` to add `group-hover/message:bg-panel group-hover/message:rounded-md` to the floating timestamp wrapper.

https://claude.ai/code/session_01A4q5VmKdxui9crVau8DrnE

---
_Generated by [Claude Code](https://claude.ai/code/session_01A4q5VmKdxui9crVau8DrnE)_