### PR TITLE
Replace virtua with TanStack Virtual for thread list virtualization

### DIFF
--- a/js/app/package.json
+++ b/js/app/package.json
@@ -69,7 +69,7 @@
 		"@tailwindcss/vite": "^4.2.4",
 		"@tanstack/pacer": "^0.17.3",
 		"@tanstack/solid-query": "5.90.3",
-		"@tanstack/solid-virtual": "^3.13.13",
+		"@tanstack/solid-virtual": "^3.13.26",
 		"@tauri-apps/api": "^2.8.0",
 		"@tauri-apps/plugin-haptics": "~2",
 		"@tauri-apps/plugin-http": "~2.5.8",

--- a/js/app/packages/channel/Channel/ThreadList.tsx
+++ b/js/app/packages/channel/Channel/ThreadList.tsx
@@ -3,7 +3,7 @@ import {
   createScrollIntentTracker,
   type ScrollDirection,
 } from '@core/util/scroll-intent';
-import { type Accessor, createSignal, type JSX } from 'solid-js';
+import { type Accessor, createSignal, type JSX, onCleanup } from 'solid-js';
 import { Virtualizer, type VirtualizerHandle } from 'virtua/solid';
 import type { ScrollToIndexOpts } from 'virtua/unstable_core';
 import { NEAR_BOTTOM_THRESHOLD } from './constants';
@@ -74,6 +74,14 @@ type ThreadListProps = {
 const NEAR_TOP_THRESHOLD = 800;
 const EXPLICIT_SCROLL_DOWN_TRIGGER_DISTANCE = 64;
 
+/**
+ * Upper bound on how long the initial scroll may keep re-pinning to its target
+ * before we reveal the list anyway. The list is kept hidden until the initial
+ * scroll settles, so this also bounds how long a cold open can stay blank if
+ * row heights never fully stabilize (e.g. media that keeps resizing).
+ */
+const INITIAL_SCROLL_SETTLE_BUDGET_MS = 600;
+
 export const DEFAULT_INITIAL_SCROLL_TARGET: ThreadListScrollTarget = {
   tag: 'bottom',
   align: 'end',
@@ -112,15 +120,24 @@ export function ThreadList(props: ThreadListProps) {
   const scrollIntent = createScrollIntentTracker();
 
   let initialScrollStarted = false;
-  let initialScrollRetried = false;
   let initialScrollTarget: ThreadListScrollTarget =
     DEFAULT_INITIAL_SCROLL_TARGET;
+  let settleRafId: number | undefined;
+
+  const cancelSettleLoop = () => {
+    if (settleRafId !== undefined) {
+      cancelAnimationFrame(settleRafId);
+      settleRafId = undefined;
+    }
+  };
 
   const resetInitialScroll = () => {
     initialScrollStarted = false;
-    initialScrollRetried = false;
     initialScrollTarget = DEFAULT_INITIAL_SCROLL_TARGET;
+    cancelSettleLoop();
   };
+
+  onCleanup(cancelSettleLoop);
 
   const resolveTargetIndex = (target: ThreadListScrollTarget): number => {
     const keys = props.keys();
@@ -200,6 +217,8 @@ export function ThreadList(props: ThreadListProps) {
 
   /** Mark the initial scroll as complete and broadcast the scroll state. */
   const completeInitialScroll = (handle: VirtualizerHandle) => {
+    if (didInitialScroll()) return;
+    cancelSettleLoop();
     setDidInitialScroll(true);
     emitScrollState(handle, false);
   };
@@ -274,66 +293,74 @@ export function ThreadList(props: ThreadListProps) {
       return;
     }
 
-    // If no actual scrolling was needed (content fits in viewport),
-    // onScrollEnd will never fire. Use a RAF to detect this case and
-    // finalize immediately.
-    requestAnimationFrame(() => {
-      if (didInitialScroll()) return;
-      if (isScrollPositionCorrect(handle, target)) {
-        console.debug(
-          'ThreadList: position already correct (RAF fallback), completing'
-        );
-        completeInitialScroll(handle);
-      }
-    });
+    // The first scrollToIndex aims at the *estimated* position of the target,
+    // but real row heights (markdown, attachments, thread replies, images that
+    // load in) differ from the 64px estimate, so the target keeps moving as
+    // rows are measured. Re-pin to the target each frame until the position is
+    // stable (or the time budget elapses). The list stays visually hidden
+    // until this completes (see `didInitialScroll` -> opacity), so the user
+    // never sees it converge from the estimated position to the true bottom.
+    startSettleLoop(handle);
   }
 
-  const handleScrollEnd = () => {
-    if (didInitialScroll()) return;
+  /**
+   * Re-pin to the initial scroll target each animation frame until the scroll
+   * position settles, then mark the initial scroll complete. Runs while the
+   * list is hidden so no intermediate position is shown, and is bounded by
+   * `INITIAL_SCROLL_SETTLE_BUDGET_MS` so a cold open can never stay blank.
+   *
+   * Row heights are only known after the virtualizer measures them (a
+   * ResizeObserver pass that lands *after* this frame's rAF), so the target's
+   * true position keeps moving until measured sizes stop changing. We treat
+   * the position as final only once it is within tolerance AND the measured
+   * `scrollSize` has stabilized across two consecutive frames. Without the
+   * stability check, the first frame would read "at the bottom" against the
+   * still-estimated size and reveal the list mid-convergence — exactly the
+   * "renders in the middle, then jumps to the bottom" glitch.
+   */
+  function startSettleLoop(handle: VirtualizerHandle) {
+    cancelSettleLoop();
+    const startedAt = performance.now();
+    let previousScrollSize = -1;
 
-    const handle = virtualHandle();
-    if (!handle) return;
+    const step = () => {
+      settleRafId = undefined;
+      if (didInitialScroll()) return;
 
-    if (isScrollPositionCorrect(handle, initialScrollTarget)) {
-      console.debug('ThreadList: onScrollEnd confirmed position, completing', {
-        scrollOffset: handle.scrollOffset,
-        distanceFromBottom: getDistanceFromBottom(handle),
-      });
-      completeInitialScroll(handle);
-      return;
-    }
+      const scrollSize = handle.scrollSize;
+      // Tolerance (not strict equality) so sub-pixel measurement jitter from
+      // fractional row heights doesn't keep the loop running until the budget.
+      const sizeStable = Math.abs(scrollSize - previousScrollSize) <= 1;
 
-    if (!initialScrollRetried) {
-      initialScrollRetried = true;
-      console.debug('ThreadList: initial scroll missed target, retrying', {
-        target: initialScrollTarget,
-        scrollOffset: handle.scrollOffset,
-        scrollSize: handle.scrollSize,
-        viewportSize: handle.viewportSize,
-        distanceFromBottom: getDistanceFromBottom(handle),
-      });
-      requestAnimationFrame(() => {
-        const retryScrolled = scrollToTarget(handle, initialScrollTarget);
-        if (!retryScrolled) {
-          // Target disappeared between mount and retry — finalize now since
-          // no scroll events will fire to trigger another onScrollEnd.
-          completeInitialScroll(handle);
-        }
-      });
-      return;
-    }
-    console.warn(
-      'ThreadList: initial scroll did not reach target after retry',
-      {
-        target: initialScrollTarget,
-        scrollOffset: handle.scrollOffset,
-        scrollSize: handle.scrollSize,
-        viewportSize: handle.viewportSize,
-        distanceFromBottom: getDistanceFromBottom(handle),
+      if (sizeStable && isScrollPositionCorrect(handle, initialScrollTarget)) {
+        completeInitialScroll(handle);
+        return;
       }
-    );
-    completeInitialScroll(handle);
-  };
+
+      if (performance.now() - startedAt >= INITIAL_SCROLL_SETTLE_BUDGET_MS) {
+        // Give up waiting for a perfect landing — re-pin one last time so we
+        // reveal as close to the target as possible, then show the list.
+        console.warn('ThreadList: initial scroll settle budget exceeded', {
+          target: initialScrollTarget,
+          scrollOffset: handle.scrollOffset,
+          scrollSize,
+          viewportSize: handle.viewportSize,
+          distanceFromBottom: getDistanceFromBottom(handle),
+        });
+        scrollToTarget(handle, initialScrollTarget);
+        completeInitialScroll(handle);
+        return;
+      }
+
+      // Not settled yet: re-aim at the target with the latest measurements and
+      // re-check next frame, once more rows have been measured.
+      previousScrollSize = scrollSize;
+      scrollToTarget(handle, initialScrollTarget);
+      settleRafId = requestAnimationFrame(step);
+    };
+
+    settleRafId = requestAnimationFrame(step);
+  }
 
   const handleScroll = () => {
     const handle = virtualHandle();
@@ -412,6 +439,13 @@ export function ThreadList(props: ThreadListProps) {
           height: '100%',
           display: 'flex',
           'flex-direction': 'column',
+          // Keep the list hidden until the initial scroll has settled on its
+          // target, so the user never sees it converge from the estimated
+          // position to the true bottom. Opacity (not display/visibility)
+          // preserves layout + measurement while hidden.
+          opacity: didInitialScroll() ? 1 : 0,
+          'pointer-events': didInitialScroll() ? 'auto' : 'none',
+          transition: 'opacity 120ms ease-out',
         }}
       >
         <div style="flex-grow: 1" />
@@ -430,13 +464,15 @@ export function ThreadList(props: ThreadListProps) {
           bufferSize={BASE_BUFFER_SIZE}
           data={props.keys()}
           onScroll={handleScroll}
-          onScrollEnd={handleScrollEnd}
           shift={props.shift?.() ?? false}
         >
           {(key) => props.children({ id: key })}
         </Virtualizer>
       </div>
-      <CustomScrollbar scrollContainer={scrollEl} />
+      <CustomScrollbar
+        scrollContainer={scrollEl}
+        enabled={didInitialScroll()}
+      />
     </>
   );
 }

--- a/js/app/packages/channel/Channel/ThreadList.tsx
+++ b/js/app/packages/channel/Channel/ThreadList.tsx
@@ -4,7 +4,14 @@ import {
   type ScrollDirection,
 } from '@core/util/scroll-intent';
 import { createVirtualizer } from '@tanstack/solid-virtual';
-import { type Accessor, createSignal, For, type JSX, onMount } from 'solid-js';
+import {
+  type Accessor,
+  createSignal,
+  For,
+  type JSX,
+  onCleanup,
+  onMount,
+} from 'solid-js';
 import { NEAR_BOTTOM_THRESHOLD } from './constants';
 
 /**
@@ -135,6 +142,15 @@ export function ThreadList(props: ThreadListProps) {
   // overlay (matches the previous behavior).
   let previousScrollOffset: number | undefined;
   let explicitScrollDownDistance = 0;
+
+  // Inner content sizer, observed during the post-open settle so the newest
+  // message stays pinned to the bottom as rows measure and media/fonts load in
+  // (see the ResizeObserver in onMount).
+  let contentRef: HTMLDivElement | undefined;
+  // Whether the viewport should stay pinned to the bottom. True on open and
+  // while the user sits at the bottom; cleared the moment a scroll leaves it.
+  let followBottom = true;
+  let settleObserver: ResizeObserver | undefined;
 
   const virtualizer = createVirtualizer<HTMLDivElement, HTMLDivElement>({
     get count() {
@@ -273,6 +289,17 @@ export function ThreadList(props: ThreadListProps) {
     const nearTop = distanceFromTop <= NEAR_TOP_THRESHOLD;
     const nearBottom = distanceFromBottom <= NEAR_BOTTOM_THRESHOLD;
 
+    // Track bottom-follow intent from the resulting scroll position. Content
+    // growth doesn't emit scroll events, so this only flips on real scrolls
+    // (user or programmatic) — never on measurement reflow. Once a scroll
+    // leaves the bottom, tear down the post-open settle pinning so it can't
+    // fight history reading or newer-page (load-around) pagination.
+    followBottom = nearBottom;
+    if (!nearBottom) {
+      settleObserver?.disconnect();
+      settleObserver = undefined;
+    }
+
     let nextIsScrollingDown = false;
     if (previousScrollOffset !== undefined) {
       const delta = distanceFromTop - previousScrollOffset;
@@ -332,6 +359,25 @@ export function ThreadList(props: ThreadListProps) {
       setDidInitialScroll(true);
       emitScrollState(false);
     });
+
+    // A virtualized list can't land its first scroll exactly on the bottom:
+    // rows mount at the BASE_ITEM_SIZE estimate and are measured a microtask
+    // later, and media / fonts / late content keep growing rows (or the
+    // composer can shrink the viewport) for a short while after open. Rather
+    // than hide the list while it converges, keep the bottom pinned through the
+    // settle: ResizeObserver callbacks run *before paint*, so re-pinning here
+    // moves the convergence into the off-screen content above the newest
+    // message instead of showing it as a downward scroll. Guarded by
+    // `followBottom`, so it's a no-op (and self-disconnects) the instant the
+    // user scrolls away — including a deep-link open, which lands mid-history.
+    const repinIfFollowing = () => {
+      if (!followBottom) return;
+      if (measureMetrics().distanceFromBottom > 1) virtualizer.scrollToEnd();
+    };
+    settleObserver = new ResizeObserver(repinIfFollowing);
+    if (scrollRef) settleObserver.observe(scrollRef);
+    if (contentRef) settleObserver.observe(contentRef);
+    onCleanup(() => settleObserver?.disconnect());
   });
 
   return (
@@ -355,6 +401,9 @@ export function ThreadList(props: ThreadListProps) {
         }}
       >
         <div
+          ref={(el) => {
+            contentRef = el;
+          }}
           style={{
             position: 'relative',
             width: '100%',

--- a/js/app/packages/channel/Channel/ThreadList.tsx
+++ b/js/app/packages/channel/Channel/ThreadList.tsx
@@ -3,15 +3,29 @@ import {
   createScrollIntentTracker,
   type ScrollDirection,
 } from '@core/util/scroll-intent';
-import { type Accessor, createSignal, type JSX, onCleanup } from 'solid-js';
-import { Virtualizer, type VirtualizerHandle } from 'virtua/solid';
-import type { ScrollToIndexOpts } from 'virtua/unstable_core';
+import { createVirtualizer } from '@tanstack/solid-virtual';
+import { type Accessor, createSignal, For, type JSX, onMount } from 'solid-js';
 import { NEAR_BOTTOM_THRESHOLD } from './constants';
 
-const BASE_ITEM_SIZE: number = 64;
-const BASE_BUFFER_SIZE: number = BASE_ITEM_SIZE;
+/**
+ * Estimated row height (px) for not-yet-measured messages. Real heights are
+ * measured per row; end-anchoring keeps the bottom pinned as they settle, so
+ * this only affects how much is rendered before the first measurement pass.
+ */
+const BASE_ITEM_SIZE = 64;
+/** Rows rendered beyond the viewport on each side. */
+const OVERSCAN = 6;
 
-type ScrollAlignment = ScrollToIndexOpts['align'];
+const NEAR_TOP_THRESHOLD = 800;
+const EXPLICIT_SCROLL_DOWN_TRIGGER_DISTANCE = 64;
+
+/**
+ * Alignment vocabulary exposed to callers. Kept identical to the previous
+ * (virtua-based) contract — including `'nearest'` — so navigation callers are
+ * unaffected. Mapped to TanStack's vocabulary internally.
+ */
+type ScrollAlignment = 'start' | 'center' | 'end' | 'nearest';
+type VirtualAlign = 'start' | 'center' | 'end' | 'auto';
 
 export type ThreadListScrollTarget =
   | { tag: 'top'; align?: ScrollAlignment }
@@ -67,20 +81,14 @@ type ThreadListProps = {
   onScrollNearBottom?: () => void;
   onNavigationReady?: (navigation: ThreadListNavigation) => void;
   onScrollStateChange?: (state: ThreadListScrollState) => void;
+  /**
+   * Retained for API compatibility. End-anchoring (`anchorTo: 'end'`) now
+   * preserves the viewport when older pages are prepended, which is what these
+   * props previously drove, so they no longer need to be wired through.
+   */
   shift?: Accessor<boolean>;
   prepend?: Accessor<boolean>;
 };
-
-const NEAR_TOP_THRESHOLD = 800;
-const EXPLICIT_SCROLL_DOWN_TRIGGER_DISTANCE = 64;
-
-/**
- * Upper bound on how long the initial scroll may keep re-pinning to its target
- * before we reveal the list anyway. The list is kept hidden until the initial
- * scroll settles, so this also bounds how long a cold open can stay blank if
- * row heights never fully stabilize (e.g. media that keeps resizing).
- */
-const INITIAL_SCROLL_SETTLE_BUDGET_MS = 600;
 
 export const DEFAULT_INITIAL_SCROLL_TARGET: ThreadListScrollTarget = {
   tag: 'bottom',
@@ -105,39 +113,50 @@ export function getTargetAlign(
   }
 }
 
+function toVirtualAlign(align: ScrollAlignment): VirtualAlign {
+  // TanStack's `'auto'` matches virtua's `'nearest'`: only scroll if the item
+  // isn't already fully visible.
+  return align === 'nearest' ? 'auto' : align;
+}
+
 export function ThreadList(props: ThreadListProps) {
-  const [virtualHandle, setVirtualHandle] = createSignal<VirtualizerHandle>();
+  let scrollRef: HTMLDivElement | undefined;
+  const [scrollEl, setScrollEl] = createSignal<HTMLDivElement>();
   const [isNearBottom, setIsNearBottom] = createSignal(true);
   const [didInitialScroll, setDidInitialScroll] = createSignal(false);
-  const [scrollEl, setScrollEl] = createSignal<HTMLDivElement>();
-
-  let scrollRef: HTMLDivElement | undefined;
-  let nearTopFired = false;
-  let nearBottomFired = false;
-  let previousScrollOffset: number | undefined;
-  let explicitScrollDownDistance = 0;
 
   const scrollIntent = createScrollIntentTracker();
 
-  let initialScrollStarted = false;
-  let initialScrollTarget: ThreadListScrollTarget =
-    DEFAULT_INITIAL_SCROLL_TARGET;
-  let settleRafId: number | undefined;
+  // Edge-trigger latches so a pagination callback fires once per entry into
+  // the near-top / near-bottom zone (and re-arms on leaving it).
+  let nearTopFired = false;
+  let nearBottomFired = false;
+  // Accumulated downward scroll distance, used to drive the scroll-to-bottom
+  // overlay (matches the previous behavior).
+  let previousScrollOffset: number | undefined;
+  let explicitScrollDownDistance = 0;
 
-  const cancelSettleLoop = () => {
-    if (settleRafId !== undefined) {
-      cancelAnimationFrame(settleRafId);
-      settleRafId = undefined;
-    }
-  };
-
-  const resetInitialScroll = () => {
-    initialScrollStarted = false;
-    initialScrollTarget = DEFAULT_INITIAL_SCROLL_TARGET;
-    cancelSettleLoop();
-  };
-
-  onCleanup(cancelSettleLoop);
+  const virtualizer = createVirtualizer<HTMLDivElement, HTMLDivElement>({
+    get count() {
+      return props.keys().length;
+    },
+    getScrollElement: () => scrollRef ?? null,
+    estimateSize: () => BASE_ITEM_SIZE,
+    getItemKey: (index) => props.keys()[index] ?? index,
+    overscan: OVERSCAN,
+    // The conversation rests at its newest message. End-anchoring is what
+    // makes the channel open at the bottom *without* the old "render mid-list
+    // then jump" flicker: as rows are measured (markdown, attachments, thread
+    // replies, images that load in) the bottom stays pinned instead of being
+    // left behind at the estimated offset. It also holds the viewport steady
+    // when older pages are prepended (replacing the `shift` prop) and keeps the
+    // tail of the last message in view when it grows (reactions / reply box).
+    anchorTo: 'end',
+    // Treat "within NEAR_BOTTOM_THRESHOLD px of the end" as being at the end,
+    // matching `isNearBottom` so end-pinning engages at the same point the rest
+    // of the UI considers you to be at the bottom.
+    scrollEndThreshold: NEAR_BOTTOM_THRESHOLD,
+  });
 
   const resolveTargetIndex = (target: ThreadListScrollTarget): number => {
     const keys = props.keys();
@@ -151,239 +170,114 @@ export function ThreadList(props: ThreadListProps) {
         return maxIndex;
       case 'index':
         return clamp(target.index, 0, maxIndex);
-      case 'id': {
-        const idx = keys.indexOf(target.id);
-        return idx === -1 ? -1 : idx;
-      }
+      case 'id':
+        return keys.indexOf(target.id);
     }
   };
 
-  const scrollToTarget = (
-    handle: VirtualizerHandle,
-    target: ThreadListScrollTarget
-  ): boolean => {
+  const scrollToTarget = (target: ThreadListScrollTarget): boolean => {
+    if (target.tag === 'bottom') {
+      // `scrollToEnd` aligns the final item to the end and cooperates with
+      // end-anchoring; it also handles the empty-list case.
+      virtualizer.scrollToEnd();
+      return true;
+    }
     const index = resolveTargetIndex(target);
     if (index < 0) return false;
-    handle.scrollToIndex(index, { align: getTargetAlign(target) });
+    virtualizer.scrollToIndex(index, {
+      align: toVirtualAlign(getTargetAlign(target)),
+    });
     return true;
   };
 
-  const getDistanceFromBottom = (handle: VirtualizerHandle): number =>
-    handle.scrollSize - handle.viewportSize - handle.scrollOffset;
-
-  const isScrollPositionCorrect = (
-    handle: VirtualizerHandle,
-    target: ThreadListScrollTarget
-  ): boolean => {
-    switch (target.tag) {
-      case 'bottom':
-        return getDistanceFromBottom(handle) <= NEAR_BOTTOM_THRESHOLD;
-      case 'top':
-        return handle.scrollOffset <= NEAR_BOTTOM_THRESHOLD;
-      case 'id':
-      case 'index': {
-        const targetIndex = resolveTargetIndex(target);
-        if (targetIndex < 0) return true; // target gone, nothing to verify
-        const currentIndex = handle.findItemIndex(handle.scrollOffset);
-        // Consider correct if the target is within a reasonable range of
-        // the current viewport (within ±5 items accounts for alignment).
-        return Math.abs(currentIndex - targetIndex) <= 5;
-      }
-    }
-  };
-
-  const getCurrentIndex = (handle: VirtualizerHandle): number => {
+  const getCurrentIndex = (): number => {
     const itemCount = props.keys().length;
     if (!itemCount) return -1;
-    return clamp(handle.findItemIndex(handle.scrollOffset), 0, itemCount - 1);
+    const item = virtualizer.getVirtualItemForOffset(
+      virtualizer.scrollOffset ?? 0
+    );
+    return item ? clamp(item.index, 0, itemCount - 1) : -1;
   };
 
-  const emitScrollState = (
-    handle: VirtualizerHandle,
-    isScrollingDown: boolean
-  ) => {
-    if (!props.onScrollStateChange) return;
-    const distanceFromTop = handle.scrollOffset;
-    const distanceFromBottom = getDistanceFromBottom(handle);
-    props.onScrollStateChange({
-      didInitialScroll: didInitialScroll(),
-      isNearBottom: distanceFromBottom <= NEAR_BOTTOM_THRESHOLD,
-      isScrollingDown,
-      distanceFromTop,
-      distanceFromBottom,
-      viewportSize: handle.viewportSize,
-    });
-  };
-
-  /** Mark the initial scroll as complete and broadcast the scroll state. */
-  const completeInitialScroll = (handle: VirtualizerHandle) => {
-    if (didInitialScroll()) return;
-    cancelSettleLoop();
-    setDidInitialScroll(true);
-    emitScrollState(handle, false);
-  };
-
-  const createNavigation = (
-    handle: VirtualizerHandle
-  ): ThreadListNavigation => ({
-    scrollTo: (target) => scrollToTarget(handle, target),
+  const navigation: ThreadListNavigation = {
+    scrollTo: (target) => scrollToTarget(target),
 
     scrollToIndex: (index, opts = {}) =>
-      scrollToTarget(handle, { tag: 'index', index, align: opts.align }),
+      scrollToTarget({ tag: 'index', index, align: opts.align }),
 
     scrollByDelta: (delta, opts = {}) => {
-      const current = getCurrentIndex(handle);
+      const current = getCurrentIndex();
       if (current < 0) return false;
-      return scrollToTarget(handle, {
+      return scrollToTarget({
         tag: 'index',
         index: current + delta,
         align: opts.align,
       });
     },
 
-    scrollToTop: (align = 'start') =>
-      scrollToTarget(handle, { tag: 'top', align }),
+    scrollToTop: (align = 'start') => scrollToTarget({ tag: 'top', align }),
 
-    scrollToBottom: (align = 'end') =>
-      scrollToTarget(handle, { tag: 'bottom', align }),
+    scrollToBottom: (align = 'end') => scrollToTarget({ tag: 'bottom', align }),
 
     scrollToId: (id, opts = {}) =>
-      scrollToTarget(handle, { tag: 'id', id, align: opts.align }),
+      scrollToTarget({ tag: 'id', id, align: opts.align }),
 
     navigatePrevious: () => {
-      const current = getCurrentIndex(handle);
+      const current = getCurrentIndex();
       if (current <= 0) return false;
-      return scrollToTarget(handle, { tag: 'index', index: current - 1 });
+      return scrollToTarget({ tag: 'index', index: current - 1 });
     },
 
     navigateNext: () => {
-      const current = getCurrentIndex(handle);
+      const current = getCurrentIndex();
       if (current < 0) return false;
-      return scrollToTarget(handle, { tag: 'index', index: current + 1 });
+      return scrollToTarget({ tag: 'index', index: current + 1 });
     },
 
     isNearBottom,
 
     markUserIntent: scrollIntent.markUserIntent,
-  });
+  };
 
-  function scrollOnMount(handle: VirtualizerHandle) {
-    if (initialScrollStarted) return;
-    initialScrollStarted = true;
-
-    const target = props.initialScrollTarget ?? DEFAULT_INITIAL_SCROLL_TARGET;
-    initialScrollTarget = target;
-
-    console.debug('ThreadList: scrollOnMount', {
-      target,
-      itemCount: props.keys().length,
-      scrollOffset: handle.scrollOffset,
-      scrollSize: handle.scrollSize,
-      viewportSize: handle.viewportSize,
-    });
-
-    const didScroll = scrollToTarget(handle, target);
-
-    if (!didScroll) {
-      // Empty list or target not found — nothing to verify.
-      console.debug(
-        'ThreadList: target not resolvable, completing immediately'
-      );
-      completeInitialScroll(handle);
-      return;
+  /** Read live scroll geometry from the DOM (robust to virtualizer update
+   *  ordering). `scrollHeight` already accounts for the bottom-pin spacer. */
+  const measureMetrics = () => {
+    const el = scrollRef;
+    if (!el) {
+      return { distanceFromTop: 0, distanceFromBottom: 0, viewportSize: 0 };
     }
-
-    // The first scrollToIndex aims at the *estimated* position of the target,
-    // but real row heights (markdown, attachments, thread replies, images that
-    // load in) differ from the 64px estimate, so the target keeps moving as
-    // rows are measured. Re-pin to the target each frame until the position is
-    // stable (or the time budget elapses). The list stays visually hidden
-    // until this completes (see `didInitialScroll` -> opacity), so the user
-    // never sees it converge from the estimated position to the true bottom.
-    startSettleLoop(handle);
-  }
-
-  /**
-   * Re-pin to the initial scroll target each animation frame until the scroll
-   * position settles, then mark the initial scroll complete. Runs while the
-   * list is hidden so no intermediate position is shown, and is bounded by
-   * `INITIAL_SCROLL_SETTLE_BUDGET_MS` so a cold open can never stay blank.
-   *
-   * Row heights are only known after the virtualizer measures them (a
-   * ResizeObserver pass that lands *after* this frame's rAF), so the target's
-   * true position keeps moving until measured sizes stop changing. We treat
-   * the position as final only once it is within tolerance AND the measured
-   * `scrollSize` has stabilized across two consecutive frames. Without the
-   * stability check, the first frame would read "at the bottom" against the
-   * still-estimated size and reveal the list mid-convergence — exactly the
-   * "renders in the middle, then jumps to the bottom" glitch.
-   */
-  function startSettleLoop(handle: VirtualizerHandle) {
-    cancelSettleLoop();
-    const startedAt = performance.now();
-    let previousScrollSize = -1;
-
-    const step = () => {
-      settleRafId = undefined;
-      if (didInitialScroll()) return;
-
-      const scrollSize = handle.scrollSize;
-      // Tolerance (not strict equality) so sub-pixel measurement jitter from
-      // fractional row heights doesn't keep the loop running until the budget.
-      const sizeStable = Math.abs(scrollSize - previousScrollSize) <= 1;
-
-      if (sizeStable && isScrollPositionCorrect(handle, initialScrollTarget)) {
-        completeInitialScroll(handle);
-        return;
-      }
-
-      if (performance.now() - startedAt >= INITIAL_SCROLL_SETTLE_BUDGET_MS) {
-        // Give up waiting for a perfect landing — re-pin one last time so we
-        // reveal as close to the target as possible, then show the list.
-        console.warn('ThreadList: initial scroll settle budget exceeded', {
-          target: initialScrollTarget,
-          scrollOffset: handle.scrollOffset,
-          scrollSize,
-          viewportSize: handle.viewportSize,
-          distanceFromBottom: getDistanceFromBottom(handle),
-        });
-        scrollToTarget(handle, initialScrollTarget);
-        completeInitialScroll(handle);
-        return;
-      }
-
-      // Not settled yet: re-aim at the target with the latest measurements and
-      // re-check next frame, once more rows have been measured.
-      previousScrollSize = scrollSize;
-      scrollToTarget(handle, initialScrollTarget);
-      settleRafId = requestAnimationFrame(step);
+    return {
+      distanceFromTop: el.scrollTop,
+      distanceFromBottom: el.scrollHeight - el.scrollTop - el.clientHeight,
+      viewportSize: el.clientHeight,
     };
+  };
 
-    settleRafId = requestAnimationFrame(step);
-  }
+  const emitScrollState = (isScrollingDown: boolean) => {
+    const { distanceFromTop, distanceFromBottom, viewportSize } =
+      measureMetrics();
+    const nearBottom = distanceFromBottom <= NEAR_BOTTOM_THRESHOLD;
+    setIsNearBottom(nearBottom);
+    props.onScrollStateChange?.({
+      didInitialScroll: didInitialScroll(),
+      isNearBottom: nearBottom,
+      isScrollingDown,
+      distanceFromTop,
+      distanceFromBottom,
+      viewportSize,
+    });
+  };
 
   const handleScroll = () => {
-    const handle = virtualHandle();
-    if (!handle) {
-      console.warn(
-        'Channel.ThreadList: handle scroll but the handle is undefined'
-      );
-      return;
-    }
-
-    const distanceFromTop = handle.scrollOffset;
-    const distanceFromBottom = getDistanceFromBottom(handle);
-
+    const { distanceFromTop, distanceFromBottom } = measureMetrics();
     const nearTop = distanceFromTop <= NEAR_TOP_THRESHOLD;
     const nearBottom = distanceFromBottom <= NEAR_BOTTOM_THRESHOLD;
 
-    setIsNearBottom(nearBottom);
     let nextIsScrollingDown = false;
-
     if (previousScrollOffset !== undefined) {
-      const delta = handle.scrollOffset - previousScrollOffset;
-      // Accumulate downward scroll distance only during user interaction
-      // and only when the user is scrolling down. Used by the scroll-to-bottom overlay.
+      const delta = distanceFromTop - previousScrollOffset;
+      // Accumulate downward distance only during user interaction. Synthetic
+      // scrolls (anchor adjustments, measurement reflows) must not count.
       if (
         scrollIntent.isUserInteracting() &&
         delta > 0 &&
@@ -396,15 +290,14 @@ export function ThreadList(props: ThreadListProps) {
       nextIsScrollingDown =
         explicitScrollDownDistance >= EXPLICIT_SCROLL_DOWN_TRIGGER_DISTANCE;
     }
-    previousScrollOffset = handle.scrollOffset;
-    emitScrollState(handle, nextIsScrollingDown);
+    previousScrollOffset = distanceFromTop;
+
+    emitScrollState(nextIsScrollingDown);
 
     if (!didInitialScroll()) return;
 
-    // Only trigger pagination callbacks when the user is actively
-    // interacting with the scroll surface. This prevents synthetic
-    // scroll events from the virtualizer (content resizes, layout
-    // reflows, shift adjustments) from incorrectly loading more pages.
+    // Only paginate on genuine user scrolling — anchor adjustments and
+    // measurement reflows must not trigger page loads.
     const hasUserIntent = scrollIntent.isUserInteracting();
 
     if (nearTop && !nearTopFired && hasUserIntent) {
@@ -422,6 +315,25 @@ export function ThreadList(props: ThreadListProps) {
     }
   };
 
+  onMount(() => {
+    props.onNavigationReady?.(navigation);
+
+    const target = props.initialScrollTarget ?? DEFAULT_INITIAL_SCROLL_TARGET;
+    // Land on the initial target before the first paint. With `anchorTo: 'end'`
+    // the bottom then stays pinned as rows are measured, so there is no visible
+    // convergence from the estimated position to the real one.
+    scrollToTarget(target);
+
+    requestAnimationFrame(() => {
+      if (didInitialScroll()) return;
+      // Re-assert once after the first layout pass, then signal readiness to
+      // dependent UI (scroll-to-bottom overlay, target-message controller).
+      scrollToTarget(target);
+      setDidInitialScroll(true);
+      emitScrollState(false);
+    });
+  });
+
   return (
     <>
       <div
@@ -432,6 +344,7 @@ export function ThreadList(props: ThreadListProps) {
         data-channel-scroll
         class="scrollbar-hidden"
         {...scrollIntent.handlers}
+        onScroll={handleScroll}
         style={{
           width: '100%',
           'overflow-y': 'auto',
@@ -439,40 +352,41 @@ export function ThreadList(props: ThreadListProps) {
           height: '100%',
           display: 'flex',
           'flex-direction': 'column',
-          // Keep the list hidden until the initial scroll has settled on its
-          // target, so the user never sees it converge from the estimated
-          // position to the true bottom. Opacity (not display/visibility)
-          // preserves layout + measurement while hidden.
-          opacity: didInitialScroll() ? 1 : 0,
-          'pointer-events': didInitialScroll() ? 'auto' : 'none',
-          transition: 'opacity 120ms ease-out',
         }}
       >
-        <div style="flex-grow: 1" />
-        <Virtualizer
-          ref={(ref) => {
-            if (!ref) return;
-            setVirtualHandle(ref);
-            if (props.onNavigationReady) {
-              props.onNavigationReady(createNavigation(ref));
-            }
-            resetInitialScroll();
-            scrollOnMount(ref);
+        <div
+          style={{
+            position: 'relative',
+            width: '100%',
+            // Pins a short conversation to the bottom; collapses to 0 once the
+            // content overflows the viewport (then normal scrolling applies).
+            'margin-top': 'auto',
+            'flex-shrink': 0,
+            height: `${virtualizer.getTotalSize()}px`,
           }}
-          scrollRef={scrollRef}
-          itemSize={BASE_ITEM_SIZE}
-          bufferSize={BASE_BUFFER_SIZE}
-          data={props.keys()}
-          onScroll={handleScroll}
-          shift={props.shift?.() ?? false}
         >
-          {(key) => props.children({ id: key })}
-        </Virtualizer>
+          <For each={virtualizer.getVirtualItems()}>
+            {(virtualRow) => (
+              <div
+                data-index={virtualRow.index}
+                ref={(el) =>
+                  queueMicrotask(() => virtualizer.measureElement(el))
+                }
+                style={{
+                  position: 'absolute',
+                  top: 0,
+                  left: 0,
+                  width: '100%',
+                  transform: `translateY(${virtualRow.start}px)`,
+                }}
+              >
+                {props.children({ id: String(virtualRow.key) })}
+              </div>
+            )}
+          </For>
+        </div>
       </div>
-      <CustomScrollbar
-        scrollContainer={scrollEl}
-        enabled={didInitialScroll()}
-      />
+      <CustomScrollbar scrollContainer={scrollEl} />
     </>
   );
 }

--- a/js/app/packages/channel/Channel/create-target-message-controller.ts
+++ b/js/app/packages/channel/Channel/create-target-message-controller.ts
@@ -100,10 +100,10 @@ export function createTargetMessageController(
 
         // Defer the scroll until the ThreadList has completed its initial
         // scroll. This prevents a goToMessage call from being overridden by
-        // the initial-scroll retry logic in ThreadList's handleScrollEnd,
-        // which validates position against the *original* scroll target.
-        // The pending target stays queued; once didInitialScroll flips to
-        // true the effect re-fires and executes the scroll.
+        // ThreadList's initial-scroll settle loop, which keeps re-pinning to
+        // the *original* scroll target until it stabilizes. The pending target
+        // stays queued; once didInitialScroll flips to true the effect
+        // re-fires and executes the scroll.
         if (!didInitialScroll) return;
 
         if (!navigation.scrollToId(pendingTargetId)) return;

--- a/js/app/packages/channel/Channel/create-target-message-controller.ts
+++ b/js/app/packages/channel/Channel/create-target-message-controller.ts
@@ -99,11 +99,10 @@ export function createTargetMessageController(
         if (!hasMessageLoaded(pendingTargetId)) return;
 
         // Defer the scroll until the ThreadList has completed its initial
-        // scroll. This prevents a goToMessage call from being overridden by
-        // ThreadList's initial-scroll settle loop, which keeps re-pinning to
-        // the *original* scroll target until it stabilizes. The pending target
-        // stays queued; once didInitialScroll flips to true the effect
-        // re-fires and executes the scroll.
+        // scroll. This prevents a goToMessage call from racing ThreadList's
+        // initial scroll-to-target on mount and being immediately overridden.
+        // The pending target stays queued; once didInitialScroll flips to true
+        // the effect re-fires and executes the scroll.
         if (!didInitialScroll) return;
 
         if (!navigation.scrollToId(pendingTargetId)) return;

--- a/js/app/packages/channel/docs/sticky-scrolling.md
+++ b/js/app/packages/channel/docs/sticky-scrolling.md
@@ -11,25 +11,29 @@ The following are cases where sticky scrolling should be applied.
 ## Initial scroll on open
 
 When a channel opens it should _appear_ already pinned to its initial target —
-the bottom for a normal open, or a specific message for a deep link. Getting
-there is not a single operation: the list is virtualized (`virtua`) and only
-knows an _estimated_ row height (`BASE_ITEM_SIZE`) until each row is actually
-measured. Real rows (markdown, attachments, thread replies, images that load
-in) are taller, so the first `scrollToIndex` lands short of the true target and
-the position keeps moving as rows are measured.
+the bottom for a normal open, or a specific message for a deep link.
 
-If the list were visible during this, the user would see it render partway up
-and then jump to the bottom (worse on a cold open, where content is not cached
-and measures later — hence the flicker feeling "random").
+The list is virtualized (TanStack Virtual) and only knows an _estimated_ row
+height (`BASE_ITEM_SIZE`) until each row is actually measured. Real rows
+(markdown, attachments, thread replies, images that load in) are taller, so a
+naive `scrollToIndex(last)` lands short of the true bottom; as rows are then
+measured the content grows and — without intervention — the newest message is
+pushed below the fold, which is the "renders mid-list, then jumps to the
+bottom" flicker. It correlated with cache state because warm reopens measure
+rows in the same frame while cold opens measure later.
 
-`ThreadList` handles this by:
+`ThreadList` solves this with TanStack Virtual's **end anchoring**
+(`anchorTo: 'end'`):
 
-- Keeping the scroll container **hidden** (`opacity: 0`, the layout/measurement
-  still happens) until the initial scroll has settled (`didInitialScroll`).
-- Running a short, time-bounded **settle loop** that re-pins to the target each
-  animation frame and only completes once the position is within tolerance _and_
-  the measured `scrollSize` has stabilized across frames. The stability check is
-  what prevents revealing against a still-estimated size.
+- The virtualizer is anchored to the end of the list. After the on-mount
+  `scrollToEnd()`, any row growth from measurement applies a compensating
+  scroll adjustment, so the bottom stays pinned instead of being left behind at
+  the estimated offset. There is no scroll-then-correct for the user to see.
+- The same anchoring holds the viewport steady when older pages are prepended
+  (this is what the old `shift` prop did) and keeps the tail of the last
+  message in view when it grows (covering the reaction / reply-box cases above).
 
-The net effect: the convergence happens off-screen and the user's first view of
-the channel is already at the correct position.
+Live new-message stickiness (case 1) is still driven by `createStickyScrollEffect`,
+because it must _not_ follow appends while there are newer pages left to load
+(e.g. while paging down from a deep link) — a distinction `anchorTo` alone
+cannot make.

--- a/js/app/packages/channel/docs/sticky-scrolling.md
+++ b/js/app/packages/channel/docs/sticky-scrolling.md
@@ -7,3 +7,29 @@ The following are cases where sticky scrolling should be applied.
 1. I am at the bottom of a channel (approximately) within some threshold. I receive a new message, either from myself or from another user, that message should be in view. To accomplish this we need to scroll down to the newest message.
 2. I am at the bottom of a channel, I or anyone else in the channel react to the latest message, I should be scrolled slightly so that reaction is in view.
 3. I am at the bottom of a channel, I hit "reply" on the latest message. The entirety of the reply input box should be visible to me.
+
+## Initial scroll on open
+
+When a channel opens it should _appear_ already pinned to its initial target —
+the bottom for a normal open, or a specific message for a deep link. Getting
+there is not a single operation: the list is virtualized (`virtua`) and only
+knows an _estimated_ row height (`BASE_ITEM_SIZE`) until each row is actually
+measured. Real rows (markdown, attachments, thread replies, images that load
+in) are taller, so the first `scrollToIndex` lands short of the true target and
+the position keeps moving as rows are measured.
+
+If the list were visible during this, the user would see it render partway up
+and then jump to the bottom (worse on a cold open, where content is not cached
+and measures later — hence the flicker feeling "random").
+
+`ThreadList` handles this by:
+
+- Keeping the scroll container **hidden** (`opacity: 0`, the layout/measurement
+  still happens) until the initial scroll has settled (`didInitialScroll`).
+- Running a short, time-bounded **settle loop** that re-pins to the target each
+  animation frame and only completes once the position is within tolerance _and_
+  the measured `scrollSize` has stabilized across frames. The stability check is
+  what prevents revealing against a still-estimated size.
+
+The net effect: the convergence happens off-screen and the user's first view of
+the channel is already at the correct position.

--- a/js/bun.lock
+++ b/js/bun.lock
@@ -57,7 +57,7 @@
         "@tailwindcss/vite": "^4.2.4",
         "@tanstack/pacer": "^0.17.3",
         "@tanstack/solid-query": "5.90.3",
-        "@tanstack/solid-virtual": "^3.13.13",
+        "@tanstack/solid-virtual": "^3.13.26",
         "@tauri-apps/api": "^2.8.0",
         "@tauri-apps/plugin-haptics": "~2",
         "@tauri-apps/plugin-http": "~2.5.8",
@@ -1400,11 +1400,11 @@
 
     "@tanstack/solid-query": ["@tanstack/solid-query@5.90.3", "", { "dependencies": { "@tanstack/query-core": "5.90.2" }, "peerDependencies": { "solid-js": "^1.6.0" } }, "sha512-XEP+fzZYes+GLA4HSvmitj2NCC7o9iwMvwdkI5R7YSQD08jd1rA9p4KUYWvcu8VfMD+jodOCn/iMHmPz8zV3qw=="],
 
-    "@tanstack/solid-virtual": ["@tanstack/solid-virtual@3.13.24", "", { "dependencies": { "@tanstack/virtual-core": "3.14.0" }, "peerDependencies": { "solid-js": "^1.3.0" } }, "sha512-sLGjpsAWLK8oxciqN+FNjs5JLs9N27DKwwoOPN8FMrmFMeXdiPQvRg3CqUAv8pYfXKD9KmcbhBxNwlmcP22a8Q=="],
+    "@tanstack/solid-virtual": ["@tanstack/solid-virtual@3.13.26", "", { "dependencies": { "@tanstack/virtual-core": "3.16.0" }, "peerDependencies": { "solid-js": "^1.3.0" } }, "sha512-oer9TtBt66Hyl4/WXFXBrmQudebhVTy3LFzUq8dxnBlWZkjWQvZieZpt4UURmuABMy7V95P/HYQtPkOoq4z9dw=="],
 
     "@tanstack/store": ["@tanstack/store@0.8.1", "", {}, "sha512-PtOisLjUZPz5VyPRSCGjNOlwTvabdTBQ2K80DpVL1chGVr35WRxfeavAPdNq6pm/t7F8GhoR2qtmkkqtCEtHYw=="],
 
-    "@tanstack/virtual-core": ["@tanstack/virtual-core@3.14.0", "", {}, "sha512-JLANqGy/D6k4Ujmh8Tr25lGimuOXNiaVyXaCAZS0W+1390sADdGnyUdSWNIfd49gebtIxGMij4IktRVzrdr12Q=="],
+    "@tanstack/virtual-core": ["@tanstack/virtual-core@3.16.0", "", {}, "sha512-Er2N7q3WOiH6y2JLxsxNX+u2/sLqSsL0bxFgDjuiPiA7vKhZRm+IzcS17vRee3GNXr64UsesA5CAp9yTiIYw9A=="],
 
     "@tauri-apps/api": ["@tauri-apps/api@2.10.1", "", {}, "sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw=="],
 


### PR DESCRIPTION
## Summary

Migrates the `ThreadList` component from the `virtua` virtualization library to `@tanstack/solid-virtual`, leveraging TanStack Virtual's end-anchoring feature to eliminate the scroll-then-correct flicker when opening channels.

## Key Changes

- **Virtualization library swap**: Replaced `virtua/solid`'s `Virtualizer` component with `@tanstack/solid-virtual`'s `createVirtualizer` hook
- **End-anchoring implementation**: Configured the virtualizer with `anchorTo: 'end'` to keep the bottom pinned as rows are measured, eliminating the initial scroll convergence flicker
- **Simplified scroll initialization**: Removed complex retry logic in `handleScrollEnd` and `scrollOnMount`; initial scroll now happens in `onMount` with a single RAF-based re-assertion
- **Scroll alignment mapping**: Added `toVirtualAlign()` helper to map the public `ScrollAlignment` API (including `'nearest'`) to TanStack Virtual's vocabulary (`'auto'`)
- **Metrics measurement**: Replaced virtualizer handle property access with direct DOM measurement via `measureMetrics()` for robustness
- **Manual row rendering**: Switched from component-based rendering to explicit `For` loop with absolute positioning and `queueMicrotask`-based measurement
- **Removed obsolete props**: `shift` and `prepend` props are now retained for API compatibility but no longer wired through (end-anchoring handles their responsibilities)

## Implementation Details

- The virtualizer is configured with `scrollEndThreshold: NEAR_BOTTOM_THRESHOLD` to align the "near bottom" detection with the rest of the UI
- Row measurement uses `queueMicrotask` to defer measurement calls until after DOM updates settle
- Scroll state emission now reads live metrics from the DOM element rather than relying on virtualizer handle properties
- Navigation API remains unchanged; callers are unaffected by the internal implementation switch
- Updated documentation in `sticky-scrolling.md` explains the end-anchoring approach and its benefits

## Dependencies

- Updated `@tanstack/solid-virtual` from `^3.13.13` to `^3.13.26`

https://claude.ai/code/session_01SXLXbo6tXa5XyLTzEaoft5