### PR TITLE
fix(auth): key gmail token cache by linked email, not macro_id

### DIFF
--- a/rust/cloud-storage/authentication_service/src/api/internal/google_access_token.rs
+++ b/rust/cloud-storage/authentication_service/src/api/internal/google_access_token.rs
@@ -14,7 +14,10 @@ use std::sync::Arc;
 #[derive(serde::Deserialize, Debug)]
 pub struct GoogleAccessTokenParams {
     fusionauth_user_id: String,
-    macro_id: String,
+    /// The linked Google account's email — what FusionAuth stores as
+    /// `display_name` on the IdP link. Discriminates one Google account from
+    /// another when the FA user has multiple Google IdP links.
+    email: String,
 }
 
 /// Gets link between user and identity provider
@@ -35,7 +38,7 @@ async fn get_access_token(
     identity_provider_name: &str,
 ) -> Result<Response, Response> {
     let fusionauth_user_id = params.fusionauth_user_id.as_str();
-    let email = params.macro_id.replace("macro|", "");
+    let email = params.email.as_str();
 
     // get identity provider id
     let idp_id = auth_client
@@ -71,7 +74,7 @@ async fn get_access_token(
     // addresses, but can only have one link with a given email
     let link = links
         .into_iter()
-        .find(|l| l.display_name == email)
+        .find(|l| l.display_name.as_str() == email)
         .ok_or_else(|| {
             tracing::error!(
                 "link not found for user id {} and idp id {}",

--- a/rust/cloud-storage/authentication_service_client/src/google_access_token.rs
+++ b/rust/cloud-storage/authentication_service_client/src/google_access_token.rs
@@ -3,18 +3,21 @@ use crate::error::{AuthServiceClientError, GenericErrorResponse};
 use model::authentication::google_token::GoogleAccessToken;
 
 impl AuthServiceClient {
-    /// Gets the Google access token for the given fusionauth user id
+    /// Gets the Google access token for the given fusionauth user and linked email.
+    /// `email` corresponds to the `display_name` on the FusionAuth IdP link — i.e.
+    /// the linked Google account's email — which is the discriminator when one FA
+    /// user has multiple IdP links (multi-inbox).
     #[tracing::instrument(skip(self))]
     pub async fn get_google_access_token(
         &self,
         fusionauth_user_id: &str,
-        macro_id: &str,
+        email: &str,
     ) -> Result<GoogleAccessToken, AuthServiceClientError> {
         let res = self
             .client
             .get(format!("{}/internal/google_access_token", self.url))
             .query(&[("fusionauth_user_id", fusionauth_user_id)])
-            .query(&[("macro_id", macro_id)])
+            .query(&[("email", email)])
             .send()
             .await
             .map_err(|e| AuthServiceClientError::RequestBuildError {

--- a/rust/cloud-storage/email/src/outbound/gmail_token_provider.rs
+++ b/rust/cloud-storage/email/src/outbound/gmail_token_provider.rs
@@ -36,7 +36,7 @@ impl GmailTokenProvider for GmailTokenProviderImpl {
     async fn fetch_gmail_access_token(&self, link: &Link) -> Result<String, EmailErr> {
         let key = TokenCacheKey::new(
             &link.fusionauth_user_id,
-            link.macro_id.0.as_ref(),
+            link.email_address.0.as_ref(),
             link.provider.as_str(),
         );
         fetch_gmail_access_token(&key, &self.redis_conn, &self.auth_service_client)
@@ -48,7 +48,7 @@ impl GmailTokenProvider for GmailTokenProviderImpl {
     async fn fetch_gmail_access_token_no_cache(&self, link: &Link) -> Result<String, EmailErr> {
         let key = TokenCacheKey::new(
             &link.fusionauth_user_id,
-            link.macro_id.0.as_ref(),
+            link.email_address.0.as_ref(),
             link.provider.as_str(),
         );
         fetch_gmail_access_token_no_cache(&key, &self.redis_conn, &self.auth_service_client)
@@ -125,7 +125,7 @@ async fn fetch_token_from_auth_service(
     auth_service_client: &AuthServiceClient,
 ) -> anyhow::Result<String> {
     let fetched_token = auth_service_client
-        .get_google_access_token(&key.fusion_user_id, &key.macro_id)
+        .get_google_access_token(&key.fusion_user_id, &key.email_address)
         .await
         .with_context(|| {
             format!(

--- a/rust/cloud-storage/email_service/src/api/email/init.rs
+++ b/rust/cloud-storage/email_service/src/api/email/init.rs
@@ -351,16 +351,15 @@ pub async fn handler(
         .into_response())
 }
 
-/// Fetches a Gmail access token scoped to a specific linked email by constructing the
-/// `macro|<email>` cache key directly. Use this instead of going through the
-/// `UserContext`-keyed path when the target inbox is not the user's primary email.
+/// Fetches a Gmail access token scoped to a specific linked email. Use this instead
+/// of going through the `UserContext`-keyed path when the target inbox is not the
+/// JWT subject's primary email.
 async fn fetch_gmail_token_for_email(
     ctx: &ApiContext,
     fusion_user_id: &str,
     linked_email: &str,
 ) -> Result<String, InitError> {
-    let macro_id = format!("macro|{}", linked_email);
-    let key = TokenCacheKey::new(fusion_user_id, macro_id, UserProvider::Gmail.as_str());
+    let key = TokenCacheKey::new(fusion_user_id, linked_email, UserProvider::Gmail.as_str());
 
     let conn = ctx
         .redis_client

--- a/rust/cloud-storage/email_service/src/pubsub/link_manager/process.rs
+++ b/rust/cloud-storage/email_service/src/pubsub/link_manager/process.rs
@@ -178,7 +178,7 @@ async fn handle_delete(
     ctx.redis_client
         .delete_gmail_access_token(&TokenCacheKey::new(
             link.fusionauth_user_id.clone(),
-            link.macro_id.to_string(),
+            link.email_address.0.as_ref(),
             UserProvider::Gmail.as_str(),
         ))
         .await

--- a/rust/cloud-storage/email_service/src/util/gmail/auth.rs
+++ b/rust/cloud-storage/email_service/src/util/gmail/auth.rs
@@ -51,6 +51,15 @@ pub async fn fetch_token_or_delete_on_revocation(
     }
 }
 
+/// Parses the email out of a `macro|<email>` JWT subject. Returns `None` on
+/// malformed input; callers map that to whatever error shape they need.
+fn primary_inbox_email(user_id: &str) -> Option<&str> {
+    user_id
+        .split_once('|')
+        .map(|(_, email)| email)
+        .filter(|email| !email.is_empty())
+}
+
 /// Checks if an error chain contains a Forbidden error from the auth service
 fn is_forbidden_error(e: &anyhow::Error) -> bool {
     e.chain().any(|cause| {
@@ -68,26 +77,40 @@ pub async fn fetch_gmail_access_token_from_link(
     redis_client: &RedisClient,
     auth_service_client: &AuthServiceClient,
 ) -> anyhow::Result<String> {
-    // Create the cache key using the extracted email
     let key = TokenCacheKey::new(
         &link.fusionauth_user_id,
-        link.macro_id.0.as_ref(),
+        link.email_address.0.as_ref(),
         link.provider.as_str(),
     );
 
     fetch_gmail_access_token(&key, redis_client, auth_service_client).await
 }
 
-/// fetches a user's gmail token using the user_context from the API request
+/// fetches a user's gmail token using the user_context from the API request.
+/// This always resolves to the JWT subject's *primary* inbox — the email part of
+/// `user_context.user_id`. For multi-inbox callers that need a specific linked
+/// inbox's token, build a `TokenCacheKey` from that link's `email_address`
+/// directly or use `fetch_gmail_access_token_from_link`.
 pub async fn fetch_gmail_token_usercontext_response(
     user_context: &UserContext,
     redis_client: &RedisClient,
     auth_service_client: &AuthServiceClient,
 ) -> Result<String, Response> {
-    // Create the cache key using the extracted email
     let key = TokenCacheKey::new(
         &user_context.fusion_user_id,
-        &user_context.user_id,
+        primary_inbox_email(&user_context.user_id).ok_or_else(|| {
+            tracing::error!(
+                user_id = %user_context.user_id,
+                "unable to derive email from user id"
+            );
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    message: "unable to get gmail access token".into(),
+                }),
+            )
+                .into_response()
+        })?,
         UserProvider::Gmail.as_str(),
     );
 
@@ -106,7 +129,8 @@ pub async fn fetch_gmail_token_usercontext_response(
 }
 
 /// Fetches a user's gmail token directly from the auth service, bypassing the Redis cache.
-/// Used by the init endpoint where we always want a fresh token.
+/// Used by the init endpoint where we always want a fresh token. Resolves to the JWT
+/// subject's primary inbox.
 #[tracing::instrument(skip(user_context, redis_client, auth_service_client))]
 pub async fn fetch_gmail_token_no_cache(
     user_context: &UserContext,
@@ -115,7 +139,19 @@ pub async fn fetch_gmail_token_no_cache(
 ) -> Result<String, Response> {
     let key = TokenCacheKey::new(
         &user_context.fusion_user_id,
-        &user_context.user_id,
+        primary_inbox_email(&user_context.user_id).ok_or_else(|| {
+            tracing::error!(
+                user_id = %user_context.user_id,
+                "unable to derive email from user id"
+            );
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    message: "unable to get gmail access token".into(),
+                }),
+            )
+                .into_response()
+        })?,
         UserProvider::Gmail.as_str(),
     );
 

--- a/rust/cloud-storage/email_service/src/util/gmail/auth.rs
+++ b/rust/cloud-storage/email_service/src/util/gmail/auth.rs
@@ -5,6 +5,7 @@ use axum::Json;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use gmail_client::GmailClient;
+use macro_user_id::user_id::MacroUserIdStr;
 use model::response::ErrorResponse;
 use model::user::UserContext;
 use models_email::email::service::cache::TokenCacheKey;
@@ -51,15 +52,6 @@ pub async fn fetch_token_or_delete_on_revocation(
     }
 }
 
-/// Parses the email out of a `macro|<email>` JWT subject. Returns `None` on
-/// malformed input; callers map that to whatever error shape they need.
-fn primary_inbox_email(user_id: &str) -> Option<&str> {
-    user_id
-        .split_once('|')
-        .map(|(_, email)| email)
-        .filter(|email| !email.is_empty())
-}
-
 /// Checks if an error chain contains a Forbidden error from the auth service
 fn is_forbidden_error(e: &anyhow::Error) -> bool {
     e.chain().any(|cause| {
@@ -98,19 +90,18 @@ pub async fn fetch_gmail_token_usercontext_response(
 ) -> Result<String, Response> {
     let key = TokenCacheKey::new(
         &user_context.fusion_user_id,
-        primary_inbox_email(&user_context.user_id).ok_or_else(|| {
-            tracing::error!(
-                user_id = %user_context.user_id,
-                "unable to derive email from user id"
-            );
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse {
-                    message: "unable to get gmail access token".into(),
-                }),
-            )
-                .into_response()
-        })?,
+        MacroUserIdStr::parse_from_str(&user_context.user_id)
+            .map(|id| id.email_str().to_string())
+            .map_err(|e| {
+                tracing::error!(error=?e, user_id=%user_context.user_id, "unable to derive email from user id");
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse {
+                        message: "unable to get gmail access token".into(),
+                    }),
+                )
+                    .into_response()
+            })?,
         UserProvider::Gmail.as_str(),
     );
 
@@ -139,19 +130,18 @@ pub async fn fetch_gmail_token_no_cache(
 ) -> Result<String, Response> {
     let key = TokenCacheKey::new(
         &user_context.fusion_user_id,
-        primary_inbox_email(&user_context.user_id).ok_or_else(|| {
-            tracing::error!(
-                user_id = %user_context.user_id,
-                "unable to derive email from user id"
-            );
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse {
-                    message: "unable to get gmail access token".into(),
-                }),
-            )
-                .into_response()
-        })?,
+        MacroUserIdStr::parse_from_str(&user_context.user_id)
+            .map(|id| id.email_str().to_string())
+            .map_err(|e| {
+                tracing::error!(error=?e, user_id=%user_context.user_id, "unable to derive email from user id");
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse {
+                        message: "unable to get gmail access token".into(),
+                    }),
+                )
+                    .into_response()
+            })?,
         UserProvider::Gmail.as_str(),
     );
 

--- a/rust/cloud-storage/email_utils/src/token_cache_key.rs
+++ b/rust/cloud-storage/email_utils/src/token_cache_key.rs
@@ -3,8 +3,11 @@
 pub struct TokenCacheKey {
     /// The FusionAuth user ID.
     pub fusion_user_id: String,
-    /// The Macro user ID.
-    pub macro_id: String,
+    /// The linked email address — what FusionAuth stores as `display_name` on
+    /// the IdP link. This is what discriminates one Gmail account from
+    /// another when a single FA user has multiple Google IdP links (e.g. a
+    /// macro user who linked a secondary inbox via `/link/gmail`).
+    pub email_address: String,
     /// The provider name (e.g. "GMAIL").
     pub provider: String,
 }
@@ -13,12 +16,12 @@ impl TokenCacheKey {
     /// Create a new TokenCacheKey.
     pub fn new(
         fusion_user_id: impl Into<String>,
-        macro_id: impl Into<String>,
+        email_address: impl Into<String>,
         provider: impl Into<String>,
     ) -> Self {
         Self {
             fusion_user_id: fusion_user_id.into(),
-            macro_id: macro_id.into(),
+            email_address: email_address.into(),
             provider: provider.into(),
         }
     }
@@ -27,7 +30,7 @@ impl TokenCacheKey {
     pub fn to_redis_key(&self) -> String {
         format!(
             "gmail_token:{}:{}:{}",
-            self.provider, self.fusion_user_id, self.macro_id
+            self.provider, self.fusion_user_id, self.email_address
         )
     }
 }


### PR DESCRIPTION
When a macro user links a second Gmail, both `email_links` rows share the same `fusionauth_user_id` and `macro_id` — they only differ in `email_address`. The `TokenCacheKey` was discriminating on `macro_id`, so the auth service always resolved to the primary inbox's IdP link and backfill for the secondary link pulled the primary mailbox. Switch the discriminator to `link.email_address` end-to-end (token-cache key, redis key, auth-service `/internal/google_access_token` query param).
