### PR TITLE
fix(projects): j/k navigation not working

### DIFF
--- a/js/app/packages/block-project/component/Block.tsx
+++ b/js/app/packages/block-project/component/Block.tsx
@@ -31,6 +31,7 @@ import { toast } from 'core/component/Toast/Toast';
 import { type Component, createSignal, Show } from 'solid-js';
 import { ModalsProvider } from './ModalsProvider';
 import { TopBar } from './TopBar';
+import { blockHotkeyScopeSignal } from '@core/signal/blockElement';
 
 // HACK: prevent lint error on custom directive
 false && fileFolderDrop;
@@ -130,12 +131,9 @@ const Block: Component = () => {
     });
   }
 
-  const [attachHotkeys, projectViewScope] = useHotkeyDOMScope('project-view');
-
   return (
     <DocumentBlockContainer>
       <div
-        ref={attachHotkeys}
         class="size-full bg-surface flex flex-col relative"
         use:fileFolderDrop={{
           onDragStart: () => setIsDragging(true),
@@ -157,7 +155,9 @@ const Block: Component = () => {
               <ProjectEntityList
                 projectId={projectId}
                 soup={projectSoup}
-                scopeId={projectViewScope}
+                // Scope is already attached by the block container so we can use that
+                // Change this when we remove blocks
+                scopeId={blockHotkeyScopeSignal.get()}
               />
             }
           >
@@ -174,7 +174,9 @@ const Block: Component = () => {
                 <ProjectEntityList
                   projectId={projectId}
                   soup={projectSoup}
-                  scopeId={projectViewScope}
+                  // Scope is already attached by the block container so we can use that
+                  // Change this when we remove blocks
+                  scopeId={blockHotkeyScopeSignal.get()}
                 />
               </SplitPanelContext.Provider>
             </div>

--- a/js/app/packages/block-project/component/Block.tsx
+++ b/js/app/packages/block-project/component/Block.tsx
@@ -18,8 +18,9 @@ import { FileDropOverlay } from '@core/component/FileDropOverlay';
 import { ENABLE_PROJECT_VIEW_PREVIEW } from '@core/constant/featureFlags';
 import { fileFolderDrop } from '@core/directive/fileFolderDrop';
 import { fileSelector } from '@core/directive/fileSelector';
-import { registerHotkey, useHotkeyDOMScope } from '@core/hotkey/hotkeys';
+import { registerHotkey } from '@core/hotkey/hotkeys';
 import { TOKENS } from '@core/hotkey/tokens';
+import { blockHotkeyScopeSignal } from '@core/signal/blockElement';
 import {
   handleFileFolderDrop,
   type UploadInput,
@@ -31,7 +32,6 @@ import { toast } from 'core/component/Toast/Toast';
 import { type Component, createSignal, Show } from 'solid-js';
 import { ModalsProvider } from './ModalsProvider';
 import { TopBar } from './TopBar';
-import { blockHotkeyScopeSignal } from '@core/signal/blockElement';
 
 // HACK: prevent lint error on custom directive
 false && fileFolderDrop;


### PR DESCRIPTION
The custom scope creation/attachment was breaking because the block already setup a hotkey scope for that element. So, we just switch to use the scope exposed by the block system instead of creating a custom one. 

Note: this does not solve the issue of j/k navigation not working when the split element is focused. That requires a different solution that accounts for the project block being shown in preview panel.