### PR TITLE
fix(references): use tanstack query for attachment references

### DIFF
--- a/js/app/packages/block-call/component/sidepanel/CallSidePanelSections.tsx
+++ b/js/app/packages/block-call/component/sidepanel/CallSidePanelSections.tsx
@@ -175,7 +175,10 @@ function SharingSectionContent(props: { record: Accessor<CallRecord> }) {
 // ─────────────────────────────────────────────────────────────────────────────
 
 function ReferencesSectionConditional(props: { callId: string }) {
-  const references = useAttachmentReferencesQuery(() => props.callId, 'call');
+  const references = useAttachmentReferencesQuery(
+    () => props.callId,
+    () => 'call'
+  );
 
   const count = () => references.data?.length ?? 0;
 

--- a/js/app/packages/block-call/component/sidepanel/CallSidePanelSections.tsx
+++ b/js/app/packages/block-call/component/sidepanel/CallSidePanelSections.tsx
@@ -11,10 +11,10 @@ import {
   useSetCallRecordShareWithTeamMutation,
   useToggleShareWithTeamMutation,
 } from '@queries/call/call';
-import { storageServiceClient } from '@service-storage/client';
+import { useAttachmentReferencesQuery } from '@queries/storage/attachment-references';
 import type { CallRecord } from '@service-storage/generated/schemas/callRecord';
 import { cn } from '@ui';
-import { type Accessor, createResource, Show, Suspense } from 'solid-js';
+import { type Accessor, Show, Suspense } from 'solid-js';
 import { formatCallDuration } from '../../utils';
 
 interface CallSidePanelSectionsProps {
@@ -175,24 +175,9 @@ function SharingSectionContent(props: { record: Accessor<CallRecord> }) {
 // ─────────────────────────────────────────────────────────────────────────────
 
 function ReferencesSectionConditional(props: { callId: string }) {
-  const [references] = createResource(
-    () => props.callId,
-    async (id) => {
-      const response = await storageServiceClient.attachmentReferences({
-        entity_type: 'call',
-        entity_id: id,
-      });
+  const references = useAttachmentReferencesQuery(() => props.callId, 'call');
 
-      if (response.isErr()) {
-        console.error(response);
-        return [];
-      }
-
-      return response.value.references;
-    }
-  );
-
-  const count = () => references()?.length ?? 0;
+  const count = () => references.data?.length ?? 0;
 
   return (
     <Show when={count() > 0}>

--- a/js/app/packages/block-md/component/sidepanel/MarkdownSidePanelSections.tsx
+++ b/js/app/packages/block-md/component/sidepanel/MarkdownSidePanelSections.tsx
@@ -37,13 +37,11 @@ import { useEntityProperties, usePropertyEntityDisplay } from '@property/hooks';
 import type { Property, PropertyApiValues } from '@property/types';
 import { getEntityValues, hasValue } from '@property/utils';
 import { useBulkSaveEntityPropertiesMutation } from '@queries/properties/entity';
+import { useAttachmentReferencesQuery } from '@queries/storage/attachment-references';
 import { useDocumentMetadataQuery } from '@queries/storage/document-metadata';
 import { useDocumentGithubPullRequestsQuery } from '@queries/storage/github-pull-requests';
 import type { EntityType as PropertiesEntityType } from '@service-properties/generated/schemas/entityType';
-import {
-  blockNameToItemType,
-  storageServiceClient,
-} from '@service-storage/client';
+import { blockNameToItemType } from '@service-storage/client';
 import type { GithubPullRequest } from '@service-storage/generated/schemas';
 import { createCallback } from '@solid-primitives/rootless';
 import { Button } from '@ui';
@@ -51,7 +49,6 @@ import { cn } from '@ui/utils/classname';
 import {
   createEffect,
   createMemo,
-  createResource,
   createSignal,
   For,
   Match,
@@ -900,24 +897,12 @@ function NotificationsSectionConditional(props: { entity: Entity }) {
 // ─────────────────────────────────────────────────────────────────────────────
 
 function ReferencesSectionConditional(props: { documentId: string }) {
-  const [references] = createResource(
+  const references = useAttachmentReferencesQuery(
     () => props.documentId,
-    async (id) => {
-      const response = await storageServiceClient.attachmentReferences({
-        entity_type: 'document',
-        entity_id: id,
-      });
-
-      if (response.isErr()) {
-        console.error(response);
-        return [];
-      }
-
-      return response.value.references;
-    }
+    'document'
   );
 
-  const count = createMemo(() => references()?.length ?? 0);
+  const count = createMemo(() => references.data?.length ?? 0);
 
   return (
     <Show when={count() > 0}>

--- a/js/app/packages/block-md/component/sidepanel/MarkdownSidePanelSections.tsx
+++ b/js/app/packages/block-md/component/sidepanel/MarkdownSidePanelSections.tsx
@@ -54,6 +54,7 @@ import {
   Match,
   onCleanup,
   Show,
+  Suspense,
   Switch,
 } from 'solid-js';
 import { mdStore } from '../../signal/markdownBlockData';
@@ -911,9 +912,11 @@ function ReferencesSectionConditional(props: { documentId: string }) {
         title={<SidePanel.CountTitle label="References" count={count()} />}
         order={50}
       >
-        <div class="text-xs">
-          <References documentId={props.documentId} />
-        </div>
+        <Suspense fallback={<SidePanel.Loading />}>
+          <div class="text-xs">
+            <References documentId={props.documentId} />
+          </div>
+        </Suspense>
       </SidePanel.Section>
     </Show>
   );

--- a/js/app/packages/block-md/component/sidepanel/MarkdownSidePanelSections.tsx
+++ b/js/app/packages/block-md/component/sidepanel/MarkdownSidePanelSections.tsx
@@ -900,7 +900,7 @@ function NotificationsSectionConditional(props: { entity: Entity }) {
 function ReferencesSectionConditional(props: { documentId: string }) {
   const references = useAttachmentReferencesQuery(
     () => props.documentId,
-    'document'
+    () => 'document'
   );
 
   const count = createMemo(() => references.data?.length ?? 0);

--- a/js/app/packages/core/component/References.tsx
+++ b/js/app/packages/core/component/References.tsx
@@ -14,10 +14,11 @@ import {
   type PreviewItem,
   useItemPreview,
 } from '@queries/preview';
-import { type ItemType, storageServiceClient } from '@service-storage/client';
+import { useAttachmentReferencesQuery } from '@queries/storage/attachment-references';
+import type { ItemType } from '@service-storage/client';
 import type { ApiAttachmentEntityReference as EntityReference } from '@service-storage/generated/schemas/apiAttachmentEntityReference';
 import type { ApiAttachmentGenericReference as GenericReference } from '@service-storage/generated/schemas/apiAttachmentGenericReference';
-import { createMemo, createResource, For, type JSX, Show } from 'solid-js';
+import { createMemo, For, type JSX, Show } from 'solid-js';
 import { InlineItemPreview } from './ItemPreview';
 import { StaticMarkdown } from './LexicalMarkdown/component/core/StaticMarkdown';
 import { twoLineClampMarkdownTheme } from './LexicalMarkdown/theme';
@@ -209,20 +210,10 @@ function GenericReferenceRow(props: {
 }
 
 export function References(props: ReferenceProps) {
-  const [references] = createResource(async () => {
-    const entityType = props.entityType ?? 'document';
-    const response = await storageServiceClient.attachmentReferences({
-      entity_type: entityType,
-      entity_id: props.documentId,
-    });
-
-    if (response.isErr()) {
-      console.error(response);
-      return [];
-    }
-
-    return response.value.references;
-  });
+  const references = useAttachmentReferencesQuery(
+    () => props.documentId,
+    () => props.entityType ?? 'document'
+  );
   const { openWithSplit } = useSplitLayout();
   const blockOrchestrator = useGlobalBlockOrchestrator();
 
@@ -289,8 +280,8 @@ export function References(props: ReferenceProps) {
   };
 
   const sortedReferences = createMemo(() => {
-    const refs = references() ?? [];
-    return refs.sort((a, b) =>
+    const refs = references.data ?? [];
+    return [...refs].sort((a, b) =>
       compareDateDesc(getReferenceCreatedAt(a), getReferenceCreatedAt(b))
     );
   });

--- a/js/app/packages/core/component/ReferencesModal.tsx
+++ b/js/app/packages/core/component/ReferencesModal.tsx
@@ -2,9 +2,10 @@ import { SplitDrawer } from '@app/component/split-layout/components/SplitDrawer'
 import { useDrawerControl } from '@app/component/split-layout/components/SplitDrawerContext';
 import clickOutside from '@core/directive/clickOutside';
 import Quotes from '@phosphor/quotes.svg';
-import { type ItemType, storageServiceClient } from '@service-storage/client';
+import { useAttachmentReferencesQuery } from '@queries/storage/attachment-references';
+import type { ItemType } from '@service-storage/client';
 import { Button, Tooltip } from '@ui';
-import { createResource, Suspense } from 'solid-js';
+import { Suspense } from 'solid-js';
 import { References } from './References';
 
 false && clickOutside;
@@ -81,23 +82,11 @@ type ReferencesModalProps = {
 
 function _ReferencesModal(props: ReferencesModalProps) {
   const drawerControl = useDrawerControl(REFERENCES_DRAWER_ID);
-  const [referenceCount] = createResource(
+  const references = useAttachmentReferencesQuery(
     () => props.documentId,
-    async (id) => {
-      const entityType = props.entityType ?? 'document';
-      const response = await storageServiceClient.attachmentReferences({
-        entity_type: entityType,
-        entity_id: id,
-      });
-
-      if (response.isErr()) {
-        console.error(response);
-        return 0;
-      }
-
-      return response.value.references.length;
-    }
+    () => props.entityType ?? 'document'
   );
+  const referenceCount = () => references.data?.length ?? 0;
 
   const title = () => {
     if (!props.documentName) return 'References';
@@ -122,7 +111,7 @@ function _ReferencesModal(props: ReferencesModalProps) {
         >
           <Quotes class="size-4 text-ink" />
           <Suspense fallback={<div class="text-xs">0</div>}>
-            <span class="text-xs">{referenceCount() ?? ''}</span>
+            <span class="text-xs">{referenceCount()}</span>
           </Suspense>
         </div>
       </Tooltip>

--- a/js/app/packages/queries/storage/attachment-references.ts
+++ b/js/app/packages/queries/storage/attachment-references.ts
@@ -1,0 +1,56 @@
+import { type ItemType, storageServiceClient } from '@service-storage/client';
+import type { ApiAttachmentEntityReference } from '@service-storage/generated/schemas/apiAttachmentEntityReference';
+import { useQuery } from '@tanstack/solid-query';
+import type { Accessor } from 'solid-js';
+import { attachmentReferencesKeys } from './keys';
+
+const ATTACHMENT_REFERENCES_STALE_TIME = 60 * 1000;
+
+type MaybeAccessor<T> = T | Accessor<T>;
+
+function read<T>(value: MaybeAccessor<T>): T {
+  return typeof value === 'function' ? (value as Accessor<T>)() : value;
+}
+
+async function fetchAttachmentReferences(
+  entityType: ItemType,
+  entityId: string
+): Promise<ApiAttachmentEntityReference[]> {
+  const response = await storageServiceClient.attachmentReferences({
+    entity_type: entityType,
+    entity_id: entityId,
+  });
+
+  if (response.isErr()) {
+    console.error(response);
+    return [];
+  }
+
+  return response.value.references;
+}
+
+export function useAttachmentReferencesQuery(
+  entityId: MaybeAccessor<string | null | undefined>,
+  entityType: MaybeAccessor<ItemType> = 'document'
+) {
+  return useQuery(() => {
+    const id = read(entityId);
+    const type = read(entityType);
+
+    return {
+      queryKey: id
+        ? attachmentReferencesKeys.list(type, id).queryKey
+        : attachmentReferencesKeys.list._def,
+      queryFn: () => {
+        if (!id) {
+          throw new Error(
+            'Entity ID is required to fetch attachment references'
+          );
+        }
+        return fetchAttachmentReferences(type, id);
+      },
+      staleTime: ATTACHMENT_REFERENCES_STALE_TIME,
+      enabled: !!id,
+    };
+  });
+}

--- a/js/app/packages/queries/storage/attachment-references.ts
+++ b/js/app/packages/queries/storage/attachment-references.ts
@@ -1,3 +1,4 @@
+import { throwOnErr } from '@core/util/result';
 import { type ItemType, storageServiceClient } from '@service-storage/client';
 import type { ApiAttachmentEntityReference } from '@service-storage/generated/schemas/apiAttachmentEntityReference';
 import { useQuery } from '@tanstack/solid-query';
@@ -6,36 +7,27 @@ import { attachmentReferencesKeys } from './keys';
 
 const ATTACHMENT_REFERENCES_STALE_TIME = 60 * 1000;
 
-type MaybeAccessor<T> = T | Accessor<T>;
-
-function read<T>(value: MaybeAccessor<T>): T {
-  return typeof value === 'function' ? (value as Accessor<T>)() : value;
-}
-
 async function fetchAttachmentReferences(
   entityType: ItemType,
   entityId: string
 ): Promise<ApiAttachmentEntityReference[]> {
-  const response = await storageServiceClient.attachmentReferences({
-    entity_type: entityType,
-    entity_id: entityId,
-  });
+  const response = await throwOnErr(() =>
+    storageServiceClient.attachmentReferences({
+      entity_type: entityType,
+      entity_id: entityId,
+    })
+  );
 
-  if (response.isErr()) {
-    console.error(response);
-    return [];
-  }
-
-  return response.value.references;
+  return response.references;
 }
 
 export function useAttachmentReferencesQuery(
-  entityId: MaybeAccessor<string | null | undefined>,
-  entityType: MaybeAccessor<ItemType> = 'document'
+  entityId: Accessor<string | null | undefined>,
+  entityType: Accessor<ItemType>
 ) {
   return useQuery(() => {
-    const id = read(entityId);
-    const type = read(entityType);
+    const id = entityId();
+    const type = entityType();
 
     return {
       queryKey: id

--- a/js/app/packages/queries/storage/keys.ts
+++ b/js/app/packages/queries/storage/keys.ts
@@ -40,6 +40,15 @@ export const documentGithubPullRequestsKeys = createQueryKeys(
   }
 );
 
+export const attachmentReferencesKeys = createQueryKeys(
+  'attachmentReferences',
+  {
+    list: (entityType: string, entityId: string) => ({
+      queryKey: [entityType, entityId],
+    }),
+  }
+);
+
 // Scoped under `entity` so `invalidateQueries({ queryKey: ['entity'] })`
 // (fired from the move/rename mutations) refreshes every key below.
 export const entityKeys = createQueryKeys('entity', {


### PR DESCRIPTION
Attachment references were fetched via ad-hoc `createResource` calls hitting the storage service client directly in four places (`References`, `ReferencesModal`, and the call/markdown side-panel sections), each refetching independently with no shared cache.

This adds a shared `useAttachmentReferencesQuery` tanstack query hook (with a query key) and migrates all four consumers to it, giving caching/deduplication across them.

https://claude.ai/code/session_01FJoWLfbepV8qWJLdh21X2n

---
_Generated by [Claude Code](https://claude.ai/code/session_01FJoWLfbepV8qWJLdh21X2n)_