### PR TITLE
fix: wrap long unbroken words in email digest

### DIFF
--- a/rust/cloud-storage/email_formatting/templates/digest.html
+++ b/rust/cloud-storage/email_formatting/templates/digest.html
@@ -125,6 +125,9 @@
                       vertical-align: middle;
                       color: #636363;
                       font-size: 16px;
+                      word-wrap: break-word;
+                      overflow-wrap: break-word;
+                      word-break: break-word;
                     "
                   >
                     {{ notif.title }}
@@ -145,7 +148,7 @@
               </tbody>
             </table>
             <table
-              style="border: none; width: 100%"
+              style="border: none; width: 100%; table-layout: fixed"
               cellpadding="0"
               cellspacing="0"
             >
@@ -159,6 +162,9 @@
                       font-size: 16px;
                       font-family: &quot;Inter&quot;, sans-serif;
                       line-height: 1.4;
+                      word-wrap: break-word;
+                      overflow-wrap: break-word;
+                      word-break: break-word;
                     "
                   >
                     {{ notif.body }}


### PR DESCRIPTION
Long tokens with no spaces (URLs, IDs, random strings) overflowed the notification digest cells instead of wrapping, because the default `table-layout: auto` expands a table to fit its longest unbreakable token regardless of any wrapping CSS.

## Changes
- Added `word-wrap: break-word; overflow-wrap: break-word; word-break: break-word;` to the title and body cells in `digest.html` (covers older Outlook via the IE-origin `word-wrap` plus modern clients).
- Set `table-layout: fixed` on the body table so the body cell honors the container width (`width: 100%`, capped at the 570px wrapper) instead of expanding to the longest token — which is what actually makes the wrapping properties take effect.

The 3-column title table is left on auto layout to preserve the indicator/title/date column sizing; the wrapping properties alone handle long title tokens there.

https://claude.ai/code/session_019sS5kW7yMyrBkC3gpeDzh1

---
_Generated by [Claude Code](https://claude.ai/code/session_019sS5kW7yMyrBkC3gpeDzh1)_