### PR TITLE
fix(email): gate per-inbox sync status label behind feature flag

### DIFF
--- a/js/app/packages/app/component/settings/Account.tsx
+++ b/js/app/packages/app/component/settings/Account.tsx
@@ -17,6 +17,7 @@ import {
   ENABLE_AUTO_UPDATE_UI,
   ENABLE_EMAIL,
   ENABLE_INBOX_RESYNC,
+  ENABLE_INBOX_SYNC_STATUS,
   ENABLE_MULTI_INBOX,
   ENABLE_PROFILE_PICTURES,
   ENABLE_NEW_PRICING_OVERRIDE,
@@ -837,15 +838,17 @@ function InboxRow(props: {
             <Chip label="Shared" />
           </Show>
         </div>
-        <span
-          class="text-xs"
-          classList={{
-            'text-failure': props.link.sync_status === 'ERROR',
-            'text-ink-muted': props.link.sync_status !== 'ERROR',
-          }}
-        >
-          {syncStatusLabel(props.link.sync_status)}
-        </span>
+        <Show when={ENABLE_INBOX_SYNC_STATUS}>
+          <span
+            class="text-xs"
+            classList={{
+              'text-failure': props.link.sync_status === 'ERROR',
+              'text-ink-muted': props.link.sync_status !== 'ERROR',
+            }}
+          >
+            {syncStatusLabel(props.link.sync_status)}
+          </span>
+        </Show>
       </div>
       <div class="flex items-center gap-2 shrink-0">
         <Show when={ENABLE_INBOX_RESYNC}>
@@ -854,7 +857,11 @@ function InboxRow(props: {
               variant="base"
               size="sm"
               depth={3}
-              disabled={props.resyncing || props.link.sync_status === 'SYNCING'}
+              disabled={
+                props.resyncing ||
+                (ENABLE_INBOX_SYNC_STATUS &&
+                  props.link.sync_status === 'SYNCING')
+              }
               onClick={props.onResync}
               aria-label={`Force sync ${props.link.email_address}`}
             >

--- a/js/app/packages/core/constant/featureFlags.ts
+++ b/js/app/packages/core/constant/featureFlags.ts
@@ -246,6 +246,11 @@ export const ENABLE_INBOX_RESYNC = resolveFeatureFlag(
   false
 );
 
+export const ENABLE_INBOX_SYNC_STATUS = resolveFeatureFlag(
+  'ENABLE_INBOX_SYNC_STATUS',
+  false
+);
+
 const _ENABLE_TASKS_TABS = resolveFeatureFlag('ENABLE_TASKS_TABS', true);
 
 export const ENABLE_EMAIL_SHARING = resolveFeatureFlag(


### PR DESCRIPTION
Hides the per-inbox sync status label in multi-inbox settings behind a new `ENABLE_INBOX_SYNC_STATUS` flag (default off) because a SIGTERMed Init-phase backfill leaves inboxes stuck showing 'Syncing…' indefinitely. The Force sync button's 'SYNCING' disabled state is gated on the same flag so it doesn't appear permanently disabled; the `syncStatusLabel` helper and the `SyncStatus` API field are untouched so we can flip it back on once Init crash-recovery lands.
