### PR TITLE
fix(tauri): decouple debug assertions from environment

### DIFF
--- a/js/app/justfile
+++ b/js/app/justfile
@@ -3,7 +3,7 @@ ios-dev:
     cd tauri/src-tauri && cargo tauri ios dev --open -- --no-default-features
 
 # iOS: prod-facing build, with auto-update turned off, for testing locally on actual iPhone
-ios-build-dev:
+ios-build-no-update:
     cd tauri/src-tauri && cargo tauri ios build --open -- --no-default-features
 
 # iOS: build for release

--- a/js/app/justfile
+++ b/js/app/justfile
@@ -1,4 +1,19 @@
+# iOS: dev-facing, for testing in Simulator
+ios-dev:
+    cd tauri/src-tauri && cargo tauri ios dev --open -- --no-default-features
+
+# iOS: prod-facing build, with auto-update turned off, for testing locally on actual iPhone
+ios-build-dev:
+    cd tauri/src-tauri && cargo tauri ios build --open -- --no-default-features
+
+# iOS: build for release
+ios-build:
+    cd tauri/src-tauri && cargo tauri ios build --open
+
+# Tauri build hook (run automatically via beforeDevCommand) — not meant to be run directly
+[private]
 dev-tauri:
+    printf development > tauri/src-tauri/.macro-tauri-env
     cd packages/app && bun run --bun dev
 
 # List available local service names
@@ -34,7 +49,10 @@ build-staging:
 build-prod:
     cd packages/app && MODE=production NODE_ENV=production bun run --bun build
 
+# Tauri build hook (run automatically via beforeBuildCommand) — not meant to be run directly
+[private]
 build-tauri:
+    printf production > tauri/src-tauri/.macro-tauri-env
     cd packages/app && MODE=production NODE_ENV=production bun run --bun build
 
 # Build the bundle, zip it, and install it at

--- a/js/app/justfile
+++ b/js/app/justfile
@@ -2,7 +2,7 @@
 ios-dev:
     cd tauri/src-tauri && cargo tauri ios dev --open -- --no-default-features
 
-# iOS: prod-facing build, with auto-update turned off, for testing locally on actual iPhone
+# iOS: prod-facing build, with bundle auto-update turned off, for testing locally on actual iPhone
 ios-build-no-update:
     cd tauri/src-tauri && cargo tauri ios build --open -- --no-default-features
 

--- a/js/app/tauri/src-tauri/.gitignore
+++ b/js/app/tauri/src-tauri/.gitignore
@@ -3,3 +3,4 @@
 /target/
 /gen/schemas
 google-services.json
+.macro-tauri-env

--- a/js/app/tauri/src-tauri/build.rs
+++ b/js/app/tauri/src-tauri/build.rs
@@ -1,3 +1,23 @@
 fn main() {
+    println!("cargo:rerun-if-changed=.macro-tauri-env");
+
+    let contents = std::fs::read_to_string(".macro-tauri-env").unwrap_or_default();
+
+    // A missing or blank file falls back to the safe `production` default;
+    // any other content must be a valid environment name.
+    let app_env = match contents.trim() {
+        "" => "production",
+        other => other,
+    };
+
+    match app_env {
+        "development" | "production" => {
+            println!("cargo:rustc-env=MACRO_TAURI_APP_ENV={app_env}");
+        }
+        other => {
+            panic!(".macro-tauri-env must contain `development` or `production`, found `{other}`");
+        }
+    }
+
     tauri_build::build()
 }

--- a/js/app/tauri/src-tauri/src/lib.rs
+++ b/js/app/tauri/src-tauri/src/lib.rs
@@ -27,6 +27,36 @@ use url::Url;
 mod share_target;
 mod staged_upload;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AppEnvironment {
+    Development,
+    Production,
+}
+
+impl AppEnvironment {
+    fn current() -> Self {
+        match env!("MACRO_TAURI_APP_ENV") {
+            "development" => Self::Development,
+            "production" => Self::Production,
+            other => unreachable!("invalid MACRO_TAURI_APP_ENV: {other}"),
+        }
+    }
+
+    fn auth_service_url(self) -> &'static str {
+        match self {
+            Self::Development => "https://auth-service-dev.macro.com/",
+            Self::Production => "https://auth-service.macro.com/",
+        }
+    }
+
+    fn web_origin(self) -> &'static str {
+        match self {
+            Self::Development => "https://dev.macro.com",
+            Self::Production => "https://macro.com",
+        }
+    }
+}
+
 /// This module provides debuging utilities and should not be compiled in prodiction builds
 #[cfg(debug_assertions)] // do not remove this
 mod debug;
@@ -39,6 +69,7 @@ static ALLOWED_DOMAINS: &[&str] = &[
     "http://tauri.localhost",
     "tauri://localhost",
     "https://macro.com",
+    "https://dev.macro.com",
     "http://localhost:3000",
     "http://localhost:3001",
     "http://localhost:3002",
@@ -129,13 +160,10 @@ pub fn run() {
         .plugin(MacroNavigationPlugin::new(ALLOWED_DOMAINS).expect("Domains must be valid urls"))
         .plugin(
             macro_bundle_updater_plugin::inbound::plugin::MacroBundleUpdaterPlugin::new(
-                if cfg!(debug_assertions) {
-                    "https://auth-service-dev.macro.com/"
-                } else {
-                    "https://auth-service.macro.com/"
-                }
-                .parse()
-                .expect("valid url"),
+                AppEnvironment::current()
+                    .auth_service_url()
+                    .parse()
+                    .expect("valid url"),
             ),
         );
 
@@ -282,20 +310,17 @@ fn merge_header_callback<R: Runtime>(url: String, headers: &mut HeaderMap, handl
         return;
     };
 
-    // Origin headers are required for service auth and must be set unconditionally,
-    // independent of whether cookie state is available.
+    // These services (including the macroverse.workers.dev sync service) validate
+    // Origin for auth, so set it to our web origin unconditionally — independent of
+    // whether cookie state is available.
     match parsed_url.host_str() {
-        Some("services.macro.com") | Some("services-dev.macro.com") => {
-            headers.insert(ORIGIN, HeaderValue::from_static("https://macro.com"));
-        }
-        // The sync service (macroverse.workers.dev) also validates Origin.
-        Some("macroverse.workers.dev") => {
-            let origin = if cfg!(debug_assertions) {
-                "https://dev.macro.com"
-            } else {
-                "https://macro.com"
-            };
-            headers.insert(ORIGIN, HeaderValue::from_static(origin));
+        Some("services.macro.com")
+        | Some("services-dev.macro.com")
+        | Some("macroverse.workers.dev") => {
+            headers.insert(
+                ORIGIN,
+                HeaderValue::from_static(AppEnvironment::current().web_origin()),
+            );
         }
         _ => {}
     }


### PR DESCRIPTION
Running `cargo tauri ios build` should point at prod servers, but, because we were gating on debug assertions instead of environment variable, it was pointing at dev when testing locally. Introduced actual prod vs dev environment variable for tauri ios builds.

Also introduced new `just` recipes for building/running ios tauri.

local dev:
`just ios-dev`

prod-facing, no auto-update:
`just ios-build-no-update`

release:
`just ios-build`