### PR TITLE
fix(onboarding): keep focus on tutorial shell so hotkeys work immediately

### DIFF
--- a/js/app/packages/app/component/interactive-onboarding/InteractiveOnboarding.tsx
+++ b/js/app/packages/app/component/interactive-onboarding/InteractiveOnboarding.tsx
@@ -239,9 +239,26 @@ function InteractiveOnboardingInner(props: InteractiveOnboardingProps) {
       };
       shellRef.addEventListener('keydown', stopKeyboardPropagation);
       shellRef.addEventListener('keyup', stopKeyboardPropagation);
+
+      // Keep focus inside the shell so the detached `onboarding-shell` scope
+      // stays the active hotkey scope. Whenever a lesson advances the Continue
+      // button is disabled (and lesson elements unmount), which drops focus to
+      // <body> — deactivating the scope and silently breaking lesson hotkeys
+      // like the `g` then `e` sidebar-nav leader until the user clicks back in.
+      // A null relatedTarget means focus was lost rather than moved to a real
+      // element, so reclaim it. Focus intentionally handed to the sandbox
+      // command-k dialog (a portal outside the shell) has a non-null
+      // relatedTarget and is left alone — that flow restores focus on close.
+      const reclaimLostFocus = (event: FocusEvent) => {
+        if (event.relatedTarget || commandKOpen()) return;
+        shellRef?.focus();
+      };
+      shellRef.addEventListener('focusout', reclaimLostFocus);
+
       onCleanup(() => {
         shellRef?.removeEventListener('keydown', stopKeyboardPropagation);
         shellRef?.removeEventListener('keyup', stopKeyboardPropagation);
+        shellRef?.removeEventListener('focusout', reclaimLostFocus);
       });
     }
   });
@@ -309,30 +326,6 @@ function InteractiveOnboardingInner(props: InteractiveOnboardingProps) {
         shellRef?.focus();
       }
     })
-  );
-
-  // Keep the detached `onboarding-shell` scope active as the user moves
-  // between lessons. Advancing resets readyToContinue, which disables the
-  // Continue button that held focus — so focus falls back to <body> and the
-  // active hotkey scope drifts off the shell. That leaves lesson hotkeys like
-  // the `g` then `e` sidebar-nav leader inert until the user clicks into the
-  // demo. Re-assert focus on the shell, but only when it has actually escaped
-  // so we don't steal focus from lessons that focus their own input (e.g. the
-  // markdown-mentions editor).
-  createEffect(
-    on(
-      () => state.currentIndex(),
-      () => {
-        if (isTouch) return;
-        requestAnimationFrame(() => {
-          if (!shellRef) return;
-          const active = document.activeElement;
-          if (!active || !shellRef.contains(active)) {
-            shellRef.focus();
-          }
-        });
-      }
-    )
   );
 
   createEffect(

--- a/js/app/packages/app/component/interactive-onboarding/InteractiveOnboarding.tsx
+++ b/js/app/packages/app/component/interactive-onboarding/InteractiveOnboarding.tsx
@@ -249,9 +249,13 @@ function InteractiveOnboardingInner(props: InteractiveOnboardingProps) {
       // element, so reclaim it. Focus intentionally handed to the sandbox
       // command-k dialog (a portal outside the shell) has a non-null
       // relatedTarget and is left alone — that flow restores focus on close.
+      // Skip once the shell is detaching (modal closing): there's nothing to
+      // hold focus in, and grabbing it would fight the modal's focus restore.
       const reclaimLostFocus = (event: FocusEvent) => {
-        if (event.relatedTarget || commandKOpen()) return;
-        shellRef?.focus();
+        if (event.relatedTarget || commandKOpen() || !shellRef?.isConnected) {
+          return;
+        }
+        shellRef.focus();
       };
       shellRef.addEventListener('focusout', reclaimLostFocus);
 

--- a/js/app/packages/app/component/interactive-onboarding/InteractiveOnboarding.tsx
+++ b/js/app/packages/app/component/interactive-onboarding/InteractiveOnboarding.tsx
@@ -240,11 +240,8 @@ function InteractiveOnboardingInner(props: InteractiveOnboardingProps) {
       shellRef.addEventListener('keydown', stopKeyboardPropagation);
       shellRef.addEventListener('keyup', stopKeyboardPropagation);
 
-      // Keep focus in the shell so the detached scope stays active. A null
-      // relatedTarget means focus was dropped to <body> (e.g. the Continue
-      // button being disabled on advance) rather than moved to a real element
-      // like the command-k portal, so reclaim it — unless the shell is
-      // detaching, where grabbing focus would fight the modal's close restore.
+      // Reclaim focus when it's dropped to <body> (null relatedTarget) so the
+      // scope stays active, but not while detaching — that's the close restore.
       const reclaimLostFocus = (event: FocusEvent) => {
         if (event.relatedTarget || commandKOpen() || !shellRef?.isConnected) {
           return;

--- a/js/app/packages/app/component/interactive-onboarding/InteractiveOnboarding.tsx
+++ b/js/app/packages/app/component/interactive-onboarding/InteractiveOnboarding.tsx
@@ -240,17 +240,11 @@ function InteractiveOnboardingInner(props: InteractiveOnboardingProps) {
       shellRef.addEventListener('keydown', stopKeyboardPropagation);
       shellRef.addEventListener('keyup', stopKeyboardPropagation);
 
-      // Keep focus inside the shell so the detached `onboarding-shell` scope
-      // stays the active hotkey scope. Whenever a lesson advances the Continue
-      // button is disabled (and lesson elements unmount), which drops focus to
-      // <body> — deactivating the scope and silently breaking lesson hotkeys
-      // like the `g` then `e` sidebar-nav leader until the user clicks back in.
-      // A null relatedTarget means focus was lost rather than moved to a real
-      // element, so reclaim it. Focus intentionally handed to the sandbox
-      // command-k dialog (a portal outside the shell) has a non-null
-      // relatedTarget and is left alone — that flow restores focus on close.
-      // Skip once the shell is detaching (modal closing): there's nothing to
-      // hold focus in, and grabbing it would fight the modal's focus restore.
+      // Keep focus in the shell so the detached scope stays active. A null
+      // relatedTarget means focus was dropped to <body> (e.g. the Continue
+      // button being disabled on advance) rather than moved to a real element
+      // like the command-k portal, so reclaim it — unless the shell is
+      // detaching, where grabbing focus would fight the modal's close restore.
       const reclaimLostFocus = (event: FocusEvent) => {
         if (event.relatedTarget || commandKOpen() || !shellRef?.isConnected) {
           return;

--- a/js/app/packages/app/component/interactive-onboarding/InteractiveOnboarding.tsx
+++ b/js/app/packages/app/component/interactive-onboarding/InteractiveOnboarding.tsx
@@ -311,6 +311,30 @@ function InteractiveOnboardingInner(props: InteractiveOnboardingProps) {
     })
   );
 
+  // Keep the detached `onboarding-shell` scope active as the user moves
+  // between lessons. Advancing resets readyToContinue, which disables the
+  // Continue button that held focus — so focus falls back to <body> and the
+  // active hotkey scope drifts off the shell. That leaves lesson hotkeys like
+  // the `g` then `e` sidebar-nav leader inert until the user clicks into the
+  // demo. Re-assert focus on the shell, but only when it has actually escaped
+  // so we don't steal focus from lessons that focus their own input (e.g. the
+  // markdown-mentions editor).
+  createEffect(
+    on(
+      () => state.currentIndex(),
+      () => {
+        if (isTouch) return;
+        requestAnimationFrame(() => {
+          if (!shellRef) return;
+          const active = document.activeElement;
+          if (!active || !shellRef.contains(active)) {
+            shellRef.focus();
+          }
+        });
+      }
+    )
+  );
+
   createEffect(
     on(
       () => state.isFinished(),

--- a/js/app/packages/app/component/interactive-onboarding/InteractiveOnboardingModal.tsx
+++ b/js/app/packages/app/component/interactive-onboarding/InteractiveOnboardingModal.tsx
@@ -307,8 +307,8 @@ export function InteractiveOnboardingModal(
       position="center"
       // Let the shell keep the focus it grabs in onMount (keeps its scope active).
       onOpenAutoFocus={(e) => e.preventDefault()}
-      // Auto-opened on login, so Kobalte has nothing to restore to: hand focus
-      // to the app body (owns the global hotkey scope) so the app stays usable.
+      // Auto-opened on login: hand focus to the app body (global hotkey scope)
+      // on close since Kobalte has nothing to restore to.
       onCloseAutoFocus={(e) => {
         e.preventDefault();
         document.body.focus();

--- a/js/app/packages/app/component/interactive-onboarding/InteractiveOnboardingModal.tsx
+++ b/js/app/packages/app/component/interactive-onboarding/InteractiveOnboardingModal.tsx
@@ -305,6 +305,13 @@ export function InteractiveOnboardingModal(
       open={open()}
       onOpenChange={setOpen}
       position="center"
+      // Don't let Kobalte's focus scope steal focus to the dialog content on
+      // open. InteractiveOnboarding focuses its own shell in onMount, which is
+      // what activates the detached `onboarding-shell` hotkey scope. Without
+      // this, Kobalte's deferred auto-focus runs after the shell's onMount and
+      // moves focus off the shell, so the tutorial hotkeys (cmd+enter, cmd+k)
+      // silently don't fire until the user clicks back into the modal.
+      onOpenAutoFocus={(e) => e.preventDefault()}
       class="w-[min(1600px,calc(100vw-32px))] h-[min(900px,calc(100vh-32px))] max-w-none rounded-xl bg-surface shadow-2xl"
     >
       <div class="relative size-full overflow-hidden rounded-xl flex flex-col">

--- a/js/app/packages/app/component/interactive-onboarding/InteractiveOnboardingModal.tsx
+++ b/js/app/packages/app/component/interactive-onboarding/InteractiveOnboardingModal.tsx
@@ -308,6 +308,13 @@ export function InteractiveOnboardingModal(
       // Let the onboarding shell keep the focus it grabs in onMount so its
       // hotkey scope stays active.
       onOpenAutoFocus={(e) => e.preventDefault()}
+      // The tutorial auto-opens on login, so Kobalte has no meaningful element
+      // to restore focus to on close. Hand focus back to the app body (which
+      // owns the global hotkey scope) so app hotkeys work without a click.
+      onCloseAutoFocus={(e) => {
+        e.preventDefault();
+        document.body.focus();
+      }}
       class="w-[min(1600px,calc(100vw-32px))] h-[min(900px,calc(100vh-32px))] max-w-none rounded-xl bg-surface shadow-2xl"
     >
       <div class="relative size-full overflow-hidden rounded-xl flex flex-col">

--- a/js/app/packages/app/component/interactive-onboarding/InteractiveOnboardingModal.tsx
+++ b/js/app/packages/app/component/interactive-onboarding/InteractiveOnboardingModal.tsx
@@ -1,10 +1,10 @@
+import { globalSplitManager } from '@app/signal/splitLayout';
 import MacroLogo from '@core/component/MacroLogo';
 import { isMobile } from '@core/mobile/isMobile';
 import LogoIcon from '@icon/macro-logo.svg';
 import ArrowRightIcon from '@phosphor/arrow-right.svg';
 import CloseIcon from '@phosphor/x.svg';
 import { useCompleteTutorialMutation } from '@queries/auth/tutorial';
-import { globalSplitManager } from '@app/signal/splitLayout';
 import { Button, Dialog, Hotkey } from '@ui';
 import { type Component, createSignal, Match, Show, Switch } from 'solid-js';
 import { Dynamic } from 'solid-js/web';

--- a/js/app/packages/app/component/interactive-onboarding/InteractiveOnboardingModal.tsx
+++ b/js/app/packages/app/component/interactive-onboarding/InteractiveOnboardingModal.tsx
@@ -305,12 +305,8 @@ export function InteractiveOnboardingModal(
       open={open()}
       onOpenChange={setOpen}
       position="center"
-      // Don't let Kobalte's focus scope steal focus to the dialog content on
-      // open. InteractiveOnboarding focuses its own shell in onMount, which is
-      // what activates the detached `onboarding-shell` hotkey scope. Without
-      // this, Kobalte's deferred auto-focus runs after the shell's onMount and
-      // moves focus off the shell, so the tutorial hotkeys (cmd+enter, cmd+k)
-      // silently don't fire until the user clicks back into the modal.
+      // Let the onboarding shell keep the focus it grabs in onMount so its
+      // hotkey scope stays active.
       onOpenAutoFocus={(e) => e.preventDefault()}
       class="w-[min(1600px,calc(100vw-32px))] h-[min(900px,calc(100vh-32px))] max-w-none rounded-xl bg-surface shadow-2xl"
     >

--- a/js/app/packages/app/component/interactive-onboarding/InteractiveOnboardingModal.tsx
+++ b/js/app/packages/app/component/interactive-onboarding/InteractiveOnboardingModal.tsx
@@ -4,6 +4,7 @@ import LogoIcon from '@icon/macro-logo.svg';
 import ArrowRightIcon from '@phosphor/arrow-right.svg';
 import CloseIcon from '@phosphor/x.svg';
 import { useCompleteTutorialMutation } from '@queries/auth/tutorial';
+import { globalSplitManager } from '@app/signal/splitLayout';
 import { Button, Dialog, Hotkey } from '@ui';
 import { type Component, createSignal, Match, Show, Switch } from 'solid-js';
 import { Dynamic } from 'solid-js/web';
@@ -307,11 +308,11 @@ export function InteractiveOnboardingModal(
       position="center"
       // Let the shell keep the focus it grabs in onMount (keeps its scope active).
       onOpenAutoFocus={(e) => e.preventDefault()}
-      // Auto-opened on login: hand focus to the app body (global hotkey scope)
-      // on close since Kobalte has nothing to restore to.
+      // Auto-opened on login, so Kobalte has nothing to restore to: return
+      // focus to the active split so the app stays keyboard-usable on close.
       onCloseAutoFocus={(e) => {
         e.preventDefault();
-        document.body.focus();
+        globalSplitManager()?.returnFocus();
       }}
       class="w-[min(1600px,calc(100vw-32px))] h-[min(900px,calc(100vh-32px))] max-w-none rounded-xl bg-surface shadow-2xl"
     >

--- a/js/app/packages/app/component/interactive-onboarding/InteractiveOnboardingModal.tsx
+++ b/js/app/packages/app/component/interactive-onboarding/InteractiveOnboardingModal.tsx
@@ -305,12 +305,10 @@ export function InteractiveOnboardingModal(
       open={open()}
       onOpenChange={setOpen}
       position="center"
-      // Let the onboarding shell keep the focus it grabs in onMount so its
-      // hotkey scope stays active.
+      // Let the shell keep the focus it grabs in onMount (keeps its scope active).
       onOpenAutoFocus={(e) => e.preventDefault()}
-      // The tutorial auto-opens on login, so Kobalte has no meaningful element
-      // to restore focus to on close. Hand focus back to the app body (which
-      // owns the global hotkey scope) so app hotkeys work without a click.
+      // Auto-opened on login, so Kobalte has nothing to restore to: hand focus
+      // to the app body (owns the global hotkey scope) so the app stays usable.
       onCloseAutoFocus={(e) => {
         e.preventDefault();
         document.body.focus();


### PR DESCRIPTION
The interactive tutorial's hotkeys (cmd+enter, cmd+k) did nothing until the user clicked into the modal. Kobalte's `Dialog` auto-focuses its content on open, stealing focus from the onboarding shell after the shell grabbed it in `onMount` — which deactivated the detached hotkey scope.

Prevent the dialog's auto-focus on open (`onOpenAutoFocus`) so the shell keeps focus and its hotkey scope stays active immediately. Matches the existing pattern in `settings/Team.tsx`.

https://claude.ai/code/session_019YaSVdkEE5b5juxjxJLCLq

---
_Generated by [Claude Code](https://claude.ai/code/session_019YaSVdkEE5b5juxjxJLCLq)_