### PR TITLE
chore: flag task dedup

### DIFF
--- a/js/app/packages/block-md/component/TaskDuplicateMatches.tsx
+++ b/js/app/packages/block-md/component/TaskDuplicateMatches.tsx
@@ -1,7 +1,12 @@
 import { SidePanel } from '@app/component/side-panel';
+import { useFeatureFlag } from '@app/lib/analytics/posthog';
 import { useBlockId } from '@core/block';
 import { DocumentMention } from '@core/component/LexicalMarkdown/component/decorator/DocumentMention';
 import { toast } from '@core/component/Toast/Toast';
+import {
+  ENABLE_TASK_DUPLICATES_FLAG,
+  ENABLE_TASK_DUPLICATES_OVERRIDE,
+} from '@core/constant/featureFlags';
 import CaretDownIcon from '@phosphor/caret-down.svg';
 import WarningIcon from '@phosphor/warning.svg';
 import {
@@ -13,52 +18,66 @@ import { Button, cn, Dropdown } from '@ui';
 import { createMemo, createSignal, For, Show, Suspense } from 'solid-js';
 
 export function TaskDuplicateMatchPill() {
+  const flag = useFeatureFlag(ENABLE_TASK_DUPLICATES_FLAG, {
+    enabledOverride: ENABLE_TASK_DUPLICATES_OVERRIDE,
+  });
   const matches = useTaskDuplicateMatches();
   const [open, setOpen] = createSignal(false);
 
   return (
-    <Suspense>
-      <Show when={matches.count() > 0}>
-        <Dropdown open={open()} onOpenChange={setOpen} placement="bottom-start">
-          <Dropdown.Trigger
-            depth={2}
-            class={cn(
-              'h-auto min-w-0 gap-1.5 rounded-full border-failure/40 px-2 py-1 leading-tight',
-              'bg-failure/10 text-failure-ink shadow-none',
-              'hover:bg-failure/15 focus-visible:bg-failure/15 focus-visible:ring-failure/60',
-              open() && 'bg-failure/15'
-            )}
-            title="Possible duplicate tasks"
+    <Show when={flag().enabled}>
+      <Suspense>
+        <Show when={matches.count() > 0}>
+          <Dropdown
+            open={open()}
+            onOpenChange={setOpen}
+            placement="bottom-start"
           >
-            <WarningIcon class="size-3 shrink-0" />
-            <span class="truncate">Duplicate Detected</span>
-            <CaretDownIcon class="size-3 shrink-0 text-current/70" />
-          </Dropdown.Trigger>
-          <Dropdown.Content class="max-w-[calc(100vw-24px)]">
-            <TaskDuplicateMatchPopover matches={matches} />
-          </Dropdown.Content>
-        </Dropdown>
-      </Show>
-    </Suspense>
+            <Dropdown.Trigger
+              depth={2}
+              class={cn(
+                'h-auto min-w-0 gap-1.5 rounded-full border-failure/40 px-2 py-1 leading-tight',
+                'bg-failure/10 text-failure-ink shadow-none',
+                'hover:bg-failure/15 focus-visible:bg-failure/15 focus-visible:ring-failure/60',
+                open() && 'bg-failure/15'
+              )}
+              title="Possible duplicate tasks"
+            >
+              <WarningIcon class="size-3 shrink-0" />
+              <span class="truncate">Duplicate Detected</span>
+              <CaretDownIcon class="size-3 shrink-0 text-current/70" />
+            </Dropdown.Trigger>
+            <Dropdown.Content class="max-w-[calc(100vw-24px)]">
+              <TaskDuplicateMatchPopover matches={matches} />
+            </Dropdown.Content>
+          </Dropdown>
+        </Show>
+      </Suspense>
+    </Show>
   );
 }
 
 export function TaskDuplicateMatchesSidePanelSection() {
+  const flag = useFeatureFlag(ENABLE_TASK_DUPLICATES_FLAG, {
+    enabledOverride: ENABLE_TASK_DUPLICATES_OVERRIDE,
+  });
   const matches = useTaskDuplicateMatches();
 
   return (
-    <Suspense>
-      <Show when={matches.count() > 0}>
-        <SidePanel.Section
-          id="duplicates"
-          title="Duplicate Tasks"
-          defaultOpen
-          order={60}
-        >
-          <TaskDuplicateMatchesSidePanel matches={matches} />
-        </SidePanel.Section>
-      </Show>
-    </Suspense>
+    <Show when={flag().enabled}>
+      <Suspense>
+        <Show when={matches.count() > 0}>
+          <SidePanel.Section
+            id="duplicates"
+            title="Duplicate Tasks"
+            defaultOpen
+            order={60}
+          >
+            <TaskDuplicateMatchesSidePanel matches={matches} />
+          </SidePanel.Section>
+        </Show>
+      </Suspense>
+    </Show>
   );
 }
 

--- a/js/app/packages/block-md/component/TaskDuplicatesPill.tsx
+++ b/js/app/packages/block-md/component/TaskDuplicatesPill.tsx
@@ -1,4 +1,9 @@
 import { TaskListEntity } from '@app/component/next-soup/soup-view/views/tasks/TaskListEntity';
+import { useFeatureFlag } from '@app/lib/analytics/posthog';
+import {
+  ENABLE_TASK_DUPLICATES_FLAG,
+  ENABLE_TASK_DUPLICATES_OVERRIDE,
+} from '@core/constant/featureFlags';
 import { ListLayoutProvider } from '@entity';
 import CaretRightIcon from '@phosphor/caret-right.svg';
 import CopyIcon from '@phosphor/copy.svg';
@@ -139,6 +144,10 @@ export function SimilarTasksSection(props: {
   onResults: (results: TaskSimilarityResult[]) => void;
   onOpenTask: (taskId: string) => void;
 }) {
+  const flag = useFeatureFlag(ENABLE_TASK_DUPLICATES_FLAG, {
+    enabledOverride: ENABLE_TASK_DUPLICATES_OVERRIDE,
+  });
+
   const [debounced, setDebounced] = createSignal<DebouncedInput>({
     title: props.title(),
     markdown: props.content(),
@@ -154,13 +163,15 @@ export function SimilarTasksSection(props: {
   });
 
   return (
-    <Suspense>
-      <SimilarTasksInner
-        debounced={debounced}
-        initialResults={props.initialResults}
-        onResults={props.onResults}
-        onOpenTask={props.onOpenTask}
-      />
-    </Suspense>
+    <Show when={flag().enabled}>
+      <Suspense>
+        <SimilarTasksInner
+          debounced={debounced}
+          initialResults={props.initialResults}
+          onResults={props.onResults}
+          onOpenTask={props.onOpenTask}
+        />
+      </Suspense>
+    </Show>
   );
 }

--- a/js/app/packages/core/constant/featureFlags.ts
+++ b/js/app/packages/core/constant/featureFlags.ts
@@ -359,6 +359,9 @@ export const ENABLE_TEAM_INVITE_TIERS_OVERRIDE = DEV_MODE_ENV
 
 export const ENABLE_SOUP_GROUP_BY_OVERRIDE = DEV_MODE_ENV ? true : undefined;
 
+export const ENABLE_TASK_DUPLICATES_FLAG = 'enable-task-duplicates';
+export const ENABLE_TASK_DUPLICATES_OVERRIDE = DEV_MODE_ENV ? true : undefined;
+
 export const ENABLE_AUTO_UPDATE_UI = resolveFeatureFlag(
   'ENABLE_AUTO_UPDATE_UI',
   true


### PR DESCRIPTION
Gate the duplicate-task UI behind a new \`enable-task-duplicates\` PostHog feature flag.

The flag is accessed **within** each top-level duplicate-task component via a top-level \`<Show when={flag().enabled}>\`, so the gate travels with the component wherever it's mounted:

- \`TaskDuplicateMatchPill\` & \`TaskDuplicateMatchesSidePanelSection\` (`TaskDuplicateMatches.tsx`)
- \`SimilarTasksSection\` — the composer's "Possible duplicates" section (`TaskDuplicatesPill.tsx`)

Adds \`ENABLE_TASK_DUPLICATES_OVERRIDE\` in `featureFlags.ts` (force-on in dev, fully PostHog-controlled in prod).

## Notes
- PostHog flag key: **\`enable-task-duplicates\`** — needs to be created in the PostHog dashboard to be toggleable in prod. Until then it's off in prod, on in dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)