### PR TITLE
feat(ci): Improve release workflow

### DIFF
--- a/.github/workflows/deploy-all-services.yml
+++ b/.github/workflows/deploy-all-services.yml
@@ -174,7 +174,7 @@ jobs:
 
   deploy-services:
     name: Deploy ${{ matrix.service }}
-    needs: [build-service-binaries, build-lambda-artifacts, migrate-db]
+    needs: [setup, build-service-binaries, build-lambda-artifacts, migrate-db]
     if: ${{ needs.setup.outputs.matrix != '[]' }}
     runs-on:
       [

--- a/.github/workflows/deploy-all-services.yml
+++ b/.github/workflows/deploy-all-services.yml
@@ -159,9 +159,22 @@ jobs:
           path: lambda-artifacts.tar.gz
           retention-days: 7
 
+  migrate-db:
+    name: Run Database Migrations
+    runs-on: db-migrator
+    needs: [build-service-binaries, build-lambda-artifacts]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          sparse-checkout: .github/
+      - name: Run migrations
+        uses: ./.github/actions/migrate-cloud-storage-db
+        with:
+          environment: ${{ inputs.environment }}
+
   deploy-services:
     name: Deploy ${{ matrix.service }}
-    needs: [setup, build-service-binaries, build-lambda-artifacts]
+    needs: [build-service-binaries, build-lambda-artifacts, migrate-db]
     if: ${{ needs.setup.outputs.matrix != '[]' }}
     runs-on:
       [

--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -11,21 +11,8 @@ env:
   MODE: "production"
 
 jobs:
-  migrate-db:
-    name: Run Database Migrations
-    runs-on: db-migrator
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          sparse-checkout: .github/
-      - name: Run migrations
-        uses: ./.github/actions/migrate-cloud-storage-db
-        with:
-          environment: prod
-
   deploy-cloud-storage:
     name: Deploy Cloud Storage Services
-    needs: [migrate-db]
     uses: ./.github/workflows/deploy-all-services.yml
     with:
       environment: prod
@@ -40,8 +27,7 @@ jobs:
       SCCACHE_BUCKET: ${{ secrets.SCCACHE_BUCKET }}
 
   build:
-    name: Build
-    needs: [deploy-cloud-storage]
+    name: Build Web App
     runs-on: linux-extra-beefy
     env:
       CI: "true"
@@ -72,7 +58,7 @@ jobs:
   deploy:
     name: Deploy Web App
     runs-on: linux-extra-beefy
-    needs: [build]
+    needs: [build, deploy-cloud-storage]
     env:
       CI: "true"
     steps:


### PR DESCRIPTION
- move migrate db job into the `deploy-all-services.yml` **AFTER** we have built the artifacts but **BEFORE** we deploy. This allows us to not have db changes pushed then have the service build fail.
- Update dependency tree in `release-production.yml` to build the web app in parallel to service deployment to save some time