### PR TITLE
fix(onboarding): don't navigate the real app from the sandbox command menu

### DIFF
--- a/js/app/packages/app/component/command/CommandMenu.tsx
+++ b/js/app/packages/app/component/command/CommandMenu.tsx
@@ -102,6 +102,12 @@ export function CommandMenuInner(props: {
   items?: () => CommandMenuItem[];
   /** Called when the user selects an item from the menu */
   onSelect?: (item: CommandMenuItem) => void;
+  /**
+   * When true, selecting an item only fires `onSelect` — no navigation,
+   * command, or search is run. Used by the onboarding sandbox so selecting a
+   * sandbox entity doesn't navigate the real app to a non-existent doc.
+   */
+  disableDefaultAction?: boolean;
   /** Optional class merged onto the Panel wrapper. */
   class?: string;
   /** Optional depth for the Panel wrapper. */
@@ -164,6 +170,7 @@ export function CommandMenuInner(props: {
     if (!item) return;
 
     props.onSelect?.(item);
+    if (props.disableDefaultAction) return;
     analytics.track('command_menu_use', { itemType: item.bucket });
 
     if (isCommandItem(item)) {

--- a/js/app/packages/app/component/command/CommandMenu.tsx
+++ b/js/app/packages/app/component/command/CommandMenu.tsx
@@ -170,7 +170,12 @@ export function CommandMenuInner(props: {
     if (!item) return;
 
     props.onSelect?.(item);
-    if (props.disableDefaultAction) return;
+    if (props.disableDefaultAction) {
+      // Close like a normal selection, just without navigating/running.
+      CommandState.close();
+      CommandState.setQuery('');
+      return;
+    }
     analytics.track('command_menu_use', { itemType: item.bucket });
 
     if (isCommandItem(item)) {

--- a/js/app/packages/app/component/interactive-onboarding/lessons/command-k.tsx
+++ b/js/app/packages/app/component/interactive-onboarding/lessons/command-k.tsx
@@ -165,6 +165,7 @@ function CommandKDemo(props: LessonContentProps) {
             >
               <CommandMenuInner
                 items={filteredItems}
+                disableDefaultAction
                 onSelect={() => {
                   setCompleted(true);
                   props.onComplete();


### PR DESCRIPTION
The command-k lesson reuses `CommandMenuInner`, which always ran its default action on select — navigating the real app to the sandbox entity id (e.g. `/app/md/sandbox_md_1`), landing on a 401.

Add a `disableDefaultAction` flag so the sandbox menu only fires `onSelect` (lesson completion) and skips navigation/commands.

https://claude.ai/code/session_019YaSVdkEE5b5juxjxJLCLq

---
_Generated by [Claude Code](https://claude.ai/code/session_019YaSVdkEE5b5juxjxJLCLq)_