### PR TITLE
fix(soup): drop collapsed group children from the row list

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/soup-view-context.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-view-context.tsx
@@ -536,6 +536,11 @@ export const SoupViewContextProvider: FlowComponent<
         })
       );
 
+      // Collapsed groups render only their header row. Excluding the children
+      // here (rather than hiding them per-row) shrinks the virtualized list so
+      // the rows actually disappear instead of leaving stale content behind.
+      if (!groupMeta.isExpanded()) continue;
+
       // Entity rows
       for (const entity of groupEntities) {
         result.push(


### PR DESCRIPTION
Collapsing a group-by section only rotated the chevron — the child rows stayed visible because they were hidden per-row (`<Match when={isExpanded()}>`) instead of being removed from the virtualized list, which doesn't reflow when row content unmounts. Excluding them from `rows()` shrinks the list so collapse actually hides them. Pre-existing bug, reproduces by clicking the chevron; independent of #3707.
