### PR TITLE
fix(email): compose/reply resolves the inbox from the thread, not links[0]

### DIFF
--- a/js/app/packages/block-email/component/BaseInput.tsx
+++ b/js/app/packages/block-email/component/BaseInput.tsx
@@ -441,6 +441,7 @@ export function BaseInput(props: {
   // non-primary inbox so the draft/send targets the right account.
   const activeLinkId = () =>
     ctx.thread()?.link_id ??
+    props.draft?.link_id ??
     primaryLinkId() ??
     emailLinksQuery.data?.links[0]?.id;
   const headerLinkId = () => toHeaderLinkId(activeLinkId());

--- a/js/app/packages/block-email/component/BaseInput.tsx
+++ b/js/app/packages/block-email/component/BaseInput.tsx
@@ -71,6 +71,7 @@ import { emailKeys } from '@queries/email/keys';
 import {
   useEmailLinksQuery,
   useNonPrimaryEmailLinkIdHeader,
+  usePrimaryEmailLinkId,
 } from '@queries/email/link';
 import {
   useSendMessageMutation,
@@ -431,14 +432,22 @@ export function BaseInput(props: {
   });
   const blockId = useBlockId();
   const emailLinksQuery = useEmailLinksQuery();
+  const userEmail = useEmail();
 
   const toHeaderLinkId = useNonPrimaryEmailLinkIdHeader();
-  // The inbox this input acts in: the open thread's inbox, else the default
+  const primaryLinkId = usePrimaryEmailLinkId();
+  // The inbox this input acts in: the open thread's inbox, else the primary
   // inbox for a new message. Mutations send it as X-Email-Link-Id when it's a
   // non-primary inbox so the draft/send targets the right account.
   const activeLinkId = () =>
-    ctx.thread()?.link_id ?? emailLinksQuery.data?.links[0]?.id;
+    ctx.thread()?.link_id ??
+    primaryLinkId() ??
+    emailLinksQuery.data?.links[0]?.id;
   const headerLinkId = () => toHeaderLinkId(activeLinkId());
+  // The address of the inbox this input sends from, for the "from" display.
+  const activeInboxEmail = () =>
+    emailLinksQuery.data?.links.find((l) => l.id === activeLinkId())
+      ?.email_address ?? userEmail();
 
   const [bodyMacro, setBodyMacro] = createSignal<string>('');
   const [expandedRecipientsRef, setExpandedRecipientsRef] =
@@ -652,7 +661,6 @@ export function BaseInput(props: {
     return registerToggleAppendedThread(editor);
   });
 
-  const userEmail = useEmail();
   const userId = useUserId();
   const [userName] = useDisplayName(tryMacroId(userId() ?? ''));
 
@@ -946,7 +954,7 @@ export function BaseInput(props: {
         logger.error('No links found');
         return;
       }
-      linkId = linksData.links[0].id;
+      linkId = primaryLinkId() ?? linksData.links[0].id;
     }
 
     const currentEditor = editor();
@@ -1434,7 +1442,7 @@ export function BaseInput(props: {
             <div class="flex flex-row items-baseline py-0.5">
               <div class="min-w-8">from</div>
               <span class="ml-2">
-                {userName()} &lt;{userEmail()}&gt;
+                {userName()} &lt;{activeInboxEmail()}&gt;
               </span>
             </div>
             {/* Expanded TO */}

--- a/js/app/packages/block-email/component/compose/Compose.tsx
+++ b/js/app/packages/block-email/component/compose/Compose.tsx
@@ -52,6 +52,7 @@ import { emailKeys } from '@queries/email/keys';
 import {
   useEmailLinksQuery,
   useNonPrimaryEmailLinkIdHeader,
+  usePrimaryEmailLinkId,
 } from '@queries/email/link';
 import {
   useSendMessageMutation,
@@ -97,12 +98,19 @@ export function EmailCompose(props: EmailComposeProps) {
   const deleteDraftMutation = useDeleteDraftMutation();
   const emailContext = useMaybeEmailContext();
 
+  const primaryLinkId = usePrimaryEmailLinkId();
   const link = createMemo(() => {
     const data = emailLinksQuery.data;
-    if (data && data.links.length > 0) {
-      return data.links[0];
-    }
-    return undefined;
+    if (!data || data.links.length === 0) return undefined;
+    // Send from the inbox that owns the draft being edited; fall back to the
+    // primary inbox for a fresh compose rather than whichever inbox sorts first.
+    const draftLinkId = props.draftID
+      ? emailContext?.messages
+          .unfiltered()
+          .find((m) => m.db_id === props.draftID)?.link_id
+      : undefined;
+    const targetId = draftLinkId ?? primaryLinkId();
+    return data.links.find((l) => l.id === targetId) ?? data.links[0];
   });
 
   const toHeaderLinkId = useNonPrimaryEmailLinkIdHeader();

--- a/js/app/packages/block-email/component/createEmailFormState.ts
+++ b/js/app/packages/block-email/component/createEmailFormState.ts
@@ -1,4 +1,5 @@
 import { useEmail } from '@core/context/user';
+import { useEmailLinksQuery } from '@queries/email/link';
 import type { ApiMessage } from '@service-email/generated/schemas';
 import type { LexicalEditor } from 'lexical';
 import { createSignal, type Setter } from 'solid-js';
@@ -102,6 +103,19 @@ export function createEmailFormState(
     draft = options?.getDraftForMessageReply(purpose?.messageID);
   }
 
+  const linksQuery = useEmailLinksQuery();
+  // Reply logic ("did I send this?") must be judged against the inbox that owns
+  // the thread, not the account's primary email — otherwise replying within a
+  // secondary or delegated inbox misclassifies the sender and picks the wrong
+  // recipients.
+  const inboxEmail = () => {
+    const linkId = (draft ?? replyingTo)?.link_id;
+    const ownerEmail = linkId
+      ? linksQuery.data?.links.find((l) => l.id === linkId)?.email_address
+      : undefined;
+    return ownerEmail ?? userEmail() ?? '';
+  };
+
   const draftContainsAppendedReply = () => {
     const encoded = draft?.body_html_sanitized;
     if (!encoded) return false;
@@ -135,8 +149,8 @@ export function createEmailFormState(
     } else if (replyingTo) {
       initialRecipients =
         replyType === 'reply-all'
-          ? getReplyAllRecipients(replyingTo, userEmail() ?? '')
-          : getReplyRecipientsFromParent(replyingTo, userEmail() ?? '');
+          ? getReplyAllRecipients(replyingTo, inboxEmail())
+          : getReplyRecipientsFromParent(replyingTo, inboxEmail());
     }
 
     return {
@@ -224,11 +238,11 @@ export function createEmailFormState(
 
       switch (rt) {
         case 'reply-all': {
-          calculated = getReplyAllRecipients(msg, userEmail() ?? '');
+          calculated = getReplyAllRecipients(msg, inboxEmail());
           break;
         }
         case 'reply': {
-          calculated = getReplyRecipientsFromParent(msg, userEmail() ?? '');
+          calculated = getReplyRecipientsFromParent(msg, inboxEmail());
         }
       }
 

--- a/js/app/packages/block-email/component/createEmailFormState.ts
+++ b/js/app/packages/block-email/component/createEmailFormState.ts
@@ -2,7 +2,7 @@ import { useEmail } from '@core/context/user';
 import { useEmailLinksQuery } from '@queries/email/link';
 import type { ApiMessage } from '@service-email/generated/schemas';
 import type { LexicalEditor } from 'lexical';
-import { createEffect, createSignal, type Setter } from 'solid-js';
+import { createSignal, type Setter } from 'solid-js';
 import { createStore, reconcile, unwrap } from 'solid-js/store';
 import { decodeBase64Utf8 } from '../util/decodeBase64';
 import { TOGGLE_APPEND_EMAIL_THREAD_COMMAND } from '../util/prepareEmailBody';
@@ -169,24 +169,6 @@ export function createEmailFormState(
     ...getInitialState(),
   });
 
-  // getInitialState() resolves the owning inbox's email from the links query,
-  // which may still be loading — in which case the reply recipients above were
-  // computed against the account-email fallback. Recompute them once the inbox
-  // resolves, unless the recipients have already been set deliberately.
-  let recipientsSettled = false;
-  createEffect(() => {
-    const linkId = replyingTo?.link_id;
-    if (!replyingTo || draft || recipientsSettled || linkId == null) return;
-    const ownerResolved = linksQuery.data?.links.some((l) => l.id === linkId);
-    if (!ownerResolved) return;
-    const recomputed =
-      state.replyType === 'reply-all'
-        ? getReplyAllRecipients(replyingTo, inboxEmail())
-        : getReplyRecipientsFromParent(replyingTo, inboxEmail());
-    setState('recipients', recomputed);
-    recipientsSettled = true;
-  });
-
   const [onDirtyCb, setOnDirtyCb] = createSignal<(() => void) | undefined>();
 
   const [onReplyTypeAppliedCb, setOnReplyTypeAppliedCb] = createSignal<
@@ -231,7 +213,6 @@ export function createEmailFormState(
     value: EmailRecipient[]
   ) => {
     setState('recipients', field, value);
-    recipientsSettled = true;
     callDirty();
     const recipients = state.recipients;
     const all = [...recipients.to, ...recipients.cc, ...recipients.bcc];

--- a/js/app/packages/block-email/component/createEmailFormState.ts
+++ b/js/app/packages/block-email/component/createEmailFormState.ts
@@ -2,7 +2,7 @@ import { useEmail } from '@core/context/user';
 import { useEmailLinksQuery } from '@queries/email/link';
 import type { ApiMessage } from '@service-email/generated/schemas';
 import type { LexicalEditor } from 'lexical';
-import { createSignal, type Setter } from 'solid-js';
+import { createEffect, createSignal, type Setter } from 'solid-js';
 import { createStore, reconcile, unwrap } from 'solid-js/store';
 import { decodeBase64Utf8 } from '../util/decodeBase64';
 import { TOGGLE_APPEND_EMAIL_THREAD_COMMAND } from '../util/prepareEmailBody';
@@ -169,6 +169,24 @@ export function createEmailFormState(
     ...getInitialState(),
   });
 
+  // getInitialState() resolves the owning inbox's email from the links query,
+  // which may still be loading — in which case the reply recipients above were
+  // computed against the account-email fallback. Recompute them once the inbox
+  // resolves, unless the recipients have already been set deliberately.
+  let recipientsSettled = false;
+  createEffect(() => {
+    const linkId = replyingTo?.link_id;
+    if (!replyingTo || draft || recipientsSettled || linkId == null) return;
+    const ownerResolved = linksQuery.data?.links.some((l) => l.id === linkId);
+    if (!ownerResolved) return;
+    const recomputed =
+      state.replyType === 'reply-all'
+        ? getReplyAllRecipients(replyingTo, inboxEmail())
+        : getReplyRecipientsFromParent(replyingTo, inboxEmail());
+    setState('recipients', recomputed);
+    recipientsSettled = true;
+  });
+
   const [onDirtyCb, setOnDirtyCb] = createSignal<(() => void) | undefined>();
 
   const [onReplyTypeAppliedCb, setOnReplyTypeAppliedCb] = createSignal<
@@ -213,6 +231,7 @@ export function createEmailFormState(
     value: EmailRecipient[]
   ) => {
     setState('recipients', field, value);
+    recipientsSettled = true;
     callDirty();
     const recipients = state.recipients;
     const all = [...recipients.to, ...recipients.cc, ...recipients.bcc];


### PR DESCRIPTION
Reply/compose was inbox-unaware: it computed reply recipients against the account email (so replying within a secondary inbox the account itself sent from was misread as "I sent this" and addressed the original recipient instead of the sender), and resolved the "from" inbox as `links[0]` instead of the thread's inbox. Resolve both from the thread/draft `link_id`, falling back to the primary inbox. Frontend-only; implements task 019e89fe.
