### PR TITLE
feat(email): pick the from-inbox in the composer/reply input

### DIFF
--- a/js/app/packages/block-email/component/BaseInput.tsx
+++ b/js/app/packages/block-email/component/BaseInput.tsx
@@ -26,7 +26,7 @@ import type { UserMentionRecord } from '@core/component/LexicalMarkdown/utils/me
 import { RecipientSelector } from '@core/component/RecipientSelector';
 import { toast } from '@core/component/Toast/Toast';
 import { ENABLE_EMAIL_SCHEDULED_SEND } from '@core/constant/featureFlags';
-import { useEmail, useUserId } from '@core/context/user';
+import { useEmail } from '@core/context/user';
 import { fileFolderDrop } from '@core/directive/fileFolderDrop';
 import { fileSelector } from '@core/directive/fileSelector';
 import { observedSize } from '@core/directive/observedSize';
@@ -34,7 +34,6 @@ import { TOKENS } from '@core/hotkey/tokens';
 import { isMobile } from '@core/mobile/isMobile';
 import { useTouchOutsideToDismissKeyboard } from '@core/mobile/useTouchOutsideToDismissKeyboard';
 import { trackMention } from '@core/signal/mention';
-import { tryMacroId, useDisplayName } from '@core/user';
 import { plural } from '@core/util/string';
 import { handleFileFolderDrop } from '@core/util/upload';
 
@@ -664,9 +663,6 @@ export function BaseInput(props: {
   lazyRegister(editor, (editor) => {
     return registerToggleAppendedThread(editor);
   });
-
-  const userId = useUserId();
-  const [userName] = useDisplayName(tryMacroId(userId() ?? ''));
 
   let draftSaveTimer: number | undefined;
   let pendingDeletion = false;
@@ -1458,11 +1454,6 @@ export function BaseInput(props: {
               <FromInboxSelector
                 links={emailLinksQuery.data?.links ?? []}
                 activeLinkId={activeLinkId()}
-                label={
-                  <>
-                    {userName()} &lt;{activeInboxEmail()}&gt;
-                  </>
-                }
                 onSelect={(id) => form().setSelectedFromLink(id)}
               />
             </div>

--- a/js/app/packages/block-email/component/BaseInput.tsx
+++ b/js/app/packages/block-email/component/BaseInput.tsx
@@ -51,6 +51,7 @@ import Forward from '@phosphor/arrow-bend-up-right.svg';
 
 import ChevronDown from '@phosphor/caret-down.svg';
 import Paperclip from '@phosphor/paperclip.svg';
+import PencilSimple from '@phosphor/pencil-simple.svg';
 import Quotes from '@phosphor/quotes.svg';
 
 import TextAa from '@phosphor/text-aa.svg';
@@ -323,7 +324,7 @@ function TruncatedRecipientList(props: {
   return (
     <div
       use:observedSize={{ setSize: setContainerRect }}
-      class="flex items-center text-sm overflow-hidden whitespace-nowrap mt-1 min-w-0 flex-1"
+      class="flex items-center text-sm overflow-hidden whitespace-nowrap min-w-0"
       onclick={props.onClick}
     >
       {/* Hidden measurement element - must have same font styles */}
@@ -1429,12 +1430,22 @@ export function BaseInput(props: {
         <Show
           when={showExpandedRecipients()}
           fallback={
-            <TruncatedRecipientList
-              toRecipients={form().recipients().to}
-              ccRecipients={form().recipients().cc}
-              bccRecipients={form().recipients().bcc}
+            <div
+              class="flex flex-1 items-center gap-1.5 min-w-0 mt-1 text-sm text-ink-muted"
               onClick={() => setShowExpandedRecipients(true)}
-            />
+            >
+              <TruncatedRecipientList
+                toRecipients={form().recipients().to}
+                ccRecipients={form().recipients().cc}
+                bccRecipients={form().recipients().bcc}
+                onClick={() => setShowExpandedRecipients(true)}
+              />
+              <Show when={(emailLinksQuery.data?.links.length ?? 0) > 1}>
+                <span class="shrink-0 text-ink-extra-muted">·</span>
+                <span class="shrink-0 truncate">from {activeInboxEmail()}</span>
+              </Show>
+              <PencilSimple class="size-3.5 shrink-0 text-ink-extra-muted" />
+            </div>
           }
         >
           <div

--- a/js/app/packages/block-email/component/BaseInput.tsx
+++ b/js/app/packages/block-email/component/BaseInput.tsx
@@ -1455,6 +1455,7 @@ export function BaseInput(props: {
                 links={emailLinksQuery.data?.links ?? []}
                 activeLinkId={activeLinkId()}
                 onSelect={(id) => form().setSelectedFromLink(id)}
+                readonly={!!props.replyingTo()}
               />
             </div>
             {/* Expanded TO */}

--- a/js/app/packages/block-email/component/BaseInput.tsx
+++ b/js/app/packages/block-email/component/BaseInput.tsx
@@ -1449,14 +1449,16 @@ export function BaseInput(props: {
             class="w-full text-sm text-ink-muted"
           >
             {/* Expanded FROM */}
-            <div class="flex flex-row items-baseline py-0.5">
+            <div class="flex flex-row items-center py-0.5">
               <div class="min-w-8">from</div>
-              <FromInboxSelector
-                links={emailLinksQuery.data?.links ?? []}
-                activeLinkId={activeLinkId()}
-                onSelect={(id) => form().setSelectedFromLink(id)}
-                readonly={!!props.replyingTo()}
-              />
+              <div class="pl-4 min-w-0 flex-1">
+                <FromInboxSelector
+                  links={emailLinksQuery.data?.links ?? []}
+                  activeLinkId={activeLinkId()}
+                  onSelect={(id) => form().setSelectedFromLink(id)}
+                  readonly={!!props.replyingTo()}
+                />
+              </div>
             </div>
             {/* Expanded TO */}
 

--- a/js/app/packages/block-email/component/BaseInput.tsx
+++ b/js/app/packages/block-email/component/BaseInput.tsx
@@ -136,6 +136,7 @@ import {
   useEmailContext,
 } from './EmailContext';
 import { getOrInitEmailFormContext } from './EmailFormContext';
+import { FromInboxSelector } from './FromInboxSelector';
 
 false && fileFolderDrop;
 false && fileSelector;
@@ -440,6 +441,7 @@ export function BaseInput(props: {
   // inbox for a new message. Mutations send it as X-Email-Link-Id when it's a
   // non-primary inbox so the draft/send targets the right account.
   const activeLinkId = () =>
+    form().selectedLinkId() ??
     ctx.thread()?.link_id ??
     props.draft?.link_id ??
     primaryLinkId() ??
@@ -1442,9 +1444,16 @@ export function BaseInput(props: {
             {/* Expanded FROM */}
             <div class="flex flex-row items-baseline py-0.5">
               <div class="min-w-8">from</div>
-              <span class="ml-2">
-                {userName()} &lt;{activeInboxEmail()}&gt;
-              </span>
+              <FromInboxSelector
+                links={emailLinksQuery.data?.links ?? []}
+                activeLinkId={activeLinkId()}
+                label={
+                  <>
+                    {userName()} &lt;{activeInboxEmail()}&gt;
+                  </>
+                }
+                onSelect={(id) => form().setSelectedFromLink(id)}
+              />
             </div>
             {/* Expanded TO */}
 

--- a/js/app/packages/block-email/component/FromInboxSelector.tsx
+++ b/js/app/packages/block-email/component/FromInboxSelector.tsx
@@ -1,9 +1,37 @@
+import { UserIcon, type UserIconProps } from '@core/component/UserIcon';
+import { tryMacroId, useDisplayName } from '@core/user';
 import ChevronDown from '@phosphor/caret-down.svg';
 import Check from '@phosphor/check.svg';
 import { Dropdown } from '@ui';
 import { For, type JSX, Show } from 'solid-js';
 
-type FromInbox = { id: string; email_address: string };
+type FromInbox = { id: string; email_address: string; macro_id?: string };
+
+/** The account's user icon, resolved by macro id when known, else by email. */
+function inboxIconProps(inbox: FromInbox): UserIconProps {
+  const macroId = tryMacroId(inbox.macro_id ?? '');
+  return macroId ? { id: macroId } : { email: inbox.email_address };
+}
+
+/** A single inbox row: the account's user icon, name, and address. */
+function FromInboxOption(props: { inbox: FromInbox }) {
+  const [name] = useDisplayName(tryMacroId(props.inbox.macro_id ?? ''));
+  return (
+    <>
+      <UserIcon
+        {...inboxIconProps(props.inbox)}
+        size="sm"
+        suppressClick
+        class="shrink-0"
+      />
+      <span class="flex-1 truncate">
+        <Show when={name()} fallback={props.inbox.email_address}>
+          {name()} &lt;{props.inbox.email_address}&gt;
+        </Show>
+      </span>
+    </>
+  );
+}
 
 /**
  * Lets the user pick which linked inbox a compose/reply sends from. Renders a
@@ -17,6 +45,8 @@ export function FromInboxSelector(props: {
   onSelect: (linkId: string) => void;
   triggerClass?: string;
 }) {
+  const activeInbox = () =>
+    props.links.find((l) => l.id === props.activeLinkId);
   return (
     <Show
       when={props.links.length > 1}
@@ -26,6 +56,16 @@ export function FromInboxSelector(props: {
         <Dropdown.Trigger
           class={props.triggerClass ?? 'ml-1 h-6 gap-1 text-ink-muted'}
         >
+          <Show when={activeInbox()}>
+            {(inbox) => (
+              <UserIcon
+                {...inboxIconProps(inbox())}
+                size="sm"
+                suppressClick
+                class="shrink-0"
+              />
+            )}
+          </Show>
           <span class="truncate">{props.label}</span>
           <ChevronDown class="size-3 shrink-0" />
         </Dropdown.Trigger>
@@ -34,7 +74,7 @@ export function FromInboxSelector(props: {
             <For each={props.links}>
               {(inbox) => (
                 <Dropdown.Item onSelect={() => props.onSelect(inbox.id)}>
-                  <span class="flex-1 truncate">{inbox.email_address}</span>
+                  <FromInboxOption inbox={inbox} />
                   <Show when={inbox.id === props.activeLinkId}>
                     <Check class="size-3.5 shrink-0" />
                   </Show>

--- a/js/app/packages/block-email/component/FromInboxSelector.tsx
+++ b/js/app/packages/block-email/component/FromInboxSelector.tsx
@@ -1,21 +1,23 @@
 import { UserIcon, type UserIconProps } from '@core/component/UserIcon';
-import { tryMacroId, useDisplayName } from '@core/user';
+import { emailToMacroId, useDisplayName } from '@core/user';
 import ChevronDown from '@phosphor/caret-down.svg';
 import Check from '@phosphor/check.svg';
 import { Dropdown } from '@ui';
 import { For, Show } from 'solid-js';
 
-type FromInbox = { id: string; email_address: string; macro_id?: string };
+type FromInbox = { id: string; email_address: string };
 
-/** The account's user icon, resolved by macro id when known, else by email. */
+// Resolve each inbox's identity from its own address, not the link's macro_id:
+// an own secondary inbox shares the parent account's macro_id, so keying on the
+// address gives each inbox its own name and icon.
 function inboxIconProps(inbox: FromInbox): UserIconProps {
-  const macroId = tryMacroId(inbox.macro_id ?? '');
+  const macroId = emailToMacroId(inbox.email_address);
   return macroId ? { id: macroId } : { email: inbox.email_address };
 }
 
 /** A single inbox: the account's user icon, name, and address. */
 function FromInboxOption(props: { inbox: FromInbox }) {
-  const [name] = useDisplayName(tryMacroId(props.inbox.macro_id ?? ''));
+  const [name] = useDisplayName(emailToMacroId(props.inbox.email_address));
   return (
     <>
       <UserIcon

--- a/js/app/packages/block-email/component/FromInboxSelector.tsx
+++ b/js/app/packages/block-email/component/FromInboxSelector.tsx
@@ -44,6 +44,7 @@ export function FromInboxSelector(props: {
   links: FromInbox[];
   activeLinkId: string | undefined;
   onSelect: (linkId: string) => void;
+  readonly?: boolean;
 }) {
   const activeInbox = () =>
     props.links.find((l) => l.id === props.activeLinkId) ?? props.links[0];
@@ -51,7 +52,7 @@ export function FromInboxSelector(props: {
     <Show when={activeInbox()}>
       {(active) => (
         <Show
-          when={props.links.length > 1}
+          when={!props.readonly && props.links.length > 1}
           fallback={
             <div class="flex items-center gap-2 min-w-0 text-sm text-ink-muted">
               <Show when={active()} keyed>

--- a/js/app/packages/block-email/component/FromInboxSelector.tsx
+++ b/js/app/packages/block-email/component/FromInboxSelector.tsx
@@ -1,0 +1,49 @@
+import ChevronDown from '@phosphor/caret-down.svg';
+import Check from '@phosphor/check.svg';
+import { Dropdown } from '@ui';
+import { For, type JSX, Show } from 'solid-js';
+
+type FromInbox = { id: string; email_address: string };
+
+/**
+ * Lets the user pick which linked inbox a compose/reply sends from. Renders a
+ * dropdown over `links` when there's more than one inbox; otherwise falls back
+ * to the static `label`.
+ */
+export function FromInboxSelector(props: {
+  links: FromInbox[];
+  activeLinkId: string | undefined;
+  label: JSX.Element;
+  onSelect: (linkId: string) => void;
+  triggerClass?: string;
+}) {
+  return (
+    <Show
+      when={props.links.length > 1}
+      fallback={<span class="ml-2 truncate">{props.label}</span>}
+    >
+      <Dropdown>
+        <Dropdown.Trigger
+          class={props.triggerClass ?? 'ml-1 h-6 gap-1 text-ink-muted'}
+        >
+          <span class="truncate">{props.label}</span>
+          <ChevronDown class="size-3 shrink-0" />
+        </Dropdown.Trigger>
+        <Dropdown.Content>
+          <Dropdown.Group>
+            <For each={props.links}>
+              {(inbox) => (
+                <Dropdown.Item onSelect={() => props.onSelect(inbox.id)}>
+                  <span class="flex-1 truncate">{inbox.email_address}</span>
+                  <Show when={inbox.id === props.activeLinkId}>
+                    <Check class="size-3.5 shrink-0" />
+                  </Show>
+                </Dropdown.Item>
+              )}
+            </For>
+          </Dropdown.Group>
+        </Dropdown.Content>
+      </Dropdown>
+    </Show>
+  );
+}

--- a/js/app/packages/block-email/component/FromInboxSelector.tsx
+++ b/js/app/packages/block-email/component/FromInboxSelector.tsx
@@ -54,13 +54,17 @@ export function FromInboxSelector(props: {
           when={props.links.length > 1}
           fallback={
             <div class="flex items-center gap-2 min-w-0 text-sm text-ink-muted">
-              <FromInboxOption inbox={active()} />
+              <Show when={active()} keyed>
+                {(inbox) => <FromInboxOption inbox={inbox} />}
+              </Show>
             </div>
           }
         >
           <Dropdown>
             <Dropdown.Trigger class="gap-2 text-sm text-ink-muted">
-              <FromInboxOption inbox={active()} />
+              <Show when={active()} keyed>
+                {(inbox) => <FromInboxOption inbox={inbox} />}
+              </Show>
               <ChevronDown class="size-3 shrink-0" />
             </Dropdown.Trigger>
             <Dropdown.Content>

--- a/js/app/packages/block-email/component/FromInboxSelector.tsx
+++ b/js/app/packages/block-email/component/FromInboxSelector.tsx
@@ -3,7 +3,7 @@ import { tryMacroId, useDisplayName } from '@core/user';
 import ChevronDown from '@phosphor/caret-down.svg';
 import Check from '@phosphor/check.svg';
 import { Dropdown } from '@ui';
-import { For, type JSX, Show } from 'solid-js';
+import { For, Show } from 'solid-js';
 
 type FromInbox = { id: string; email_address: string; macro_id?: string };
 
@@ -13,7 +13,7 @@ function inboxIconProps(inbox: FromInbox): UserIconProps {
   return macroId ? { id: macroId } : { email: inbox.email_address };
 }
 
-/** A single inbox row: the account's user icon, name, and address. */
+/** A single inbox: the account's user icon, name, and address. */
 function FromInboxOption(props: { inbox: FromInbox }) {
   const [name] = useDisplayName(tryMacroId(props.inbox.macro_id ?? ''));
   return (
@@ -34,56 +34,50 @@ function FromInboxOption(props: { inbox: FromInbox }) {
 }
 
 /**
- * Lets the user pick which linked inbox a compose/reply sends from. Renders a
- * dropdown over `links` when there's more than one inbox; otherwise falls back
- * to the static `label`.
+ * Lets the user pick which linked inbox a compose/reply sends from. Renders an
+ * identical "from" chip in every composer: the active inbox's icon, name, and
+ * address, with a dropdown over the other inboxes when there's more than one.
  */
 export function FromInboxSelector(props: {
   links: FromInbox[];
   activeLinkId: string | undefined;
-  label: JSX.Element;
   onSelect: (linkId: string) => void;
-  triggerClass?: string;
 }) {
   const activeInbox = () =>
-    props.links.find((l) => l.id === props.activeLinkId);
+    props.links.find((l) => l.id === props.activeLinkId) ?? props.links[0];
   return (
-    <Show
-      when={props.links.length > 1}
-      fallback={<span class="ml-2 truncate">{props.label}</span>}
-    >
-      <Dropdown>
-        <Dropdown.Trigger
-          class={props.triggerClass ?? 'ml-1 h-6 gap-1 text-ink-muted'}
+    <Show when={activeInbox()}>
+      {(active) => (
+        <Show
+          when={props.links.length > 1}
+          fallback={
+            <div class="flex items-center gap-2 min-w-0 text-sm text-ink-muted">
+              <FromInboxOption inbox={active()} />
+            </div>
+          }
         >
-          <Show when={activeInbox()}>
-            {(inbox) => (
-              <UserIcon
-                {...inboxIconProps(inbox())}
-                size="sm"
-                suppressClick
-                class="shrink-0"
-              />
-            )}
-          </Show>
-          <span class="truncate">{props.label}</span>
-          <ChevronDown class="size-3 shrink-0" />
-        </Dropdown.Trigger>
-        <Dropdown.Content>
-          <Dropdown.Group>
-            <For each={props.links}>
-              {(inbox) => (
-                <Dropdown.Item onSelect={() => props.onSelect(inbox.id)}>
-                  <FromInboxOption inbox={inbox} />
-                  <Show when={inbox.id === props.activeLinkId}>
-                    <Check class="size-3.5 shrink-0" />
-                  </Show>
-                </Dropdown.Item>
-              )}
-            </For>
-          </Dropdown.Group>
-        </Dropdown.Content>
-      </Dropdown>
+          <Dropdown>
+            <Dropdown.Trigger class="gap-2 text-sm text-ink-muted">
+              <FromInboxOption inbox={active()} />
+              <ChevronDown class="size-3 shrink-0" />
+            </Dropdown.Trigger>
+            <Dropdown.Content>
+              <Dropdown.Group>
+                <For each={props.links}>
+                  {(inbox) => (
+                    <Dropdown.Item onSelect={() => props.onSelect(inbox.id)}>
+                      <FromInboxOption inbox={inbox} />
+                      <Show when={inbox.id === props.activeLinkId}>
+                        <Check class="size-3.5 shrink-0" />
+                      </Show>
+                    </Dropdown.Item>
+                  )}
+                </For>
+              </Dropdown.Group>
+            </Dropdown.Content>
+          </Dropdown>
+        </Show>
+      )}
     </Show>
   );
 }

--- a/js/app/packages/block-email/component/compose/Compose.tsx
+++ b/js/app/packages/block-email/component/compose/Compose.tsx
@@ -98,18 +98,35 @@ export function EmailCompose(props: EmailComposeProps) {
   const deleteDraftMutation = useDeleteDraftMutation();
   const emailContext = useMaybeEmailContext();
 
+  const form = createEmailFormState(
+    props.draftID
+      ? {
+          type: 'draft',
+          messageID: props.draftID,
+        }
+      : undefined,
+    emailContext
+      ? {
+          getMessageByID: (id) =>
+            emailContext.messages.unfiltered().find((m) => m.db_id === id),
+          getDraftForMessageReply: emailContext.drafts.getDraftForMessage,
+          onRecipientsChange: emailContext.onRecipientsChange,
+        }
+      : undefined
+  );
+
   const primaryLinkId = usePrimaryEmailLinkId();
   const link = createMemo(() => {
     const data = emailLinksQuery.data;
     if (!data || data.links.length === 0) return undefined;
-    // Send from the inbox that owns the draft being edited; fall back to the
-    // primary inbox for a fresh compose rather than whichever inbox sorts first.
+    // Send from the inbox the user picked, else the inbox that owns the draft
+    // being edited, else the primary inbox — not whichever inbox sorts first.
     const draftLinkId = props.draftID
       ? emailContext?.messages
           .unfiltered()
           .find((m) => m.db_id === props.draftID)?.link_id
       : undefined;
-    const targetId = draftLinkId ?? primaryLinkId();
+    const targetId = form.selectedLinkId() ?? draftLinkId ?? primaryLinkId();
     return data.links.find((l) => l.id === targetId) ?? data.links[0];
   });
 
@@ -127,23 +144,6 @@ export function EmailCompose(props: EmailComposeProps) {
   });
 
   const { users: destinationOptions } = useCombinedRecipients();
-
-  const form = createEmailFormState(
-    props.draftID
-      ? {
-          type: 'draft',
-          messageID: props.draftID,
-        }
-      : undefined,
-    emailContext
-      ? {
-          getMessageByID: (id) =>
-            emailContext.messages.unfiltered().find((m) => m.db_id === id),
-          getDraftForMessageReply: emailContext.drafts.getDraftForMessage,
-          onRecipientsChange: emailContext.onRecipientsChange,
-        }
-      : undefined
-  );
 
   const [editor, setEditor] = createSignal<LexicalEditor | undefined>();
   const [content, setContent] = createSignal('');
@@ -666,6 +666,9 @@ export function EmailCompose(props: EmailComposeProps) {
 
     // Display
     fromAddress: () => link()?.email_address,
+    fromInboxes: () => emailLinksQuery.data?.links ?? [],
+    selectedFromLinkId: () => link()?.id,
+    onSelectFromLink: form.setSelectedFromLink,
     hasPaidAccess,
   };
 

--- a/js/app/packages/block-email/component/compose/ComposeContext.ts
+++ b/js/app/packages/block-email/component/compose/ComposeContext.ts
@@ -66,6 +66,11 @@ export interface ComposeContextValue {
 
   // Display
   fromAddress?: Accessor<string | undefined>;
+  // From-inbox selection: the inboxes the user can send from, the active one,
+  // and a setter to change it.
+  fromInboxes?: Accessor<{ id: string; email_address: string }[]>;
+  selectedFromLinkId?: Accessor<string | undefined>;
+  onSelectFromLink?: (linkId: string) => void;
   hasPaidAccess: Accessor<boolean>;
 
   // Toolbar slot — allows orchestrators to provide a custom toolbar

--- a/js/app/packages/block-email/component/compose/ComposeContext.ts
+++ b/js/app/packages/block-email/component/compose/ComposeContext.ts
@@ -68,7 +68,9 @@ export interface ComposeContextValue {
   fromAddress?: Accessor<string | undefined>;
   // From-inbox selection: the inboxes the user can send from, the active one,
   // and a setter to change it.
-  fromInboxes?: Accessor<{ id: string; email_address: string }[]>;
+  fromInboxes?: Accessor<
+    { id: string; email_address: string; macro_id?: string }[]
+  >;
   selectedFromLinkId?: Accessor<string | undefined>;
   onSelectFromLink?: (linkId: string) => void;
   hasPaidAccess: Accessor<boolean>;

--- a/js/app/packages/block-email/component/compose/ComposeContext.ts
+++ b/js/app/packages/block-email/component/compose/ComposeContext.ts
@@ -68,9 +68,7 @@ export interface ComposeContextValue {
   fromAddress?: Accessor<string | undefined>;
   // From-inbox selection: the inboxes the user can send from, the active one,
   // and a setter to change it.
-  fromInboxes?: Accessor<
-    { id: string; email_address: string; macro_id?: string }[]
-  >;
+  fromInboxes?: Accessor<{ id: string; email_address: string }[]>;
   selectedFromLinkId?: Accessor<string | undefined>;
   onSelectFromLink?: (linkId: string) => void;
   hasPaidAccess: Accessor<boolean>;

--- a/js/app/packages/block-email/component/compose/ComposeLayout.tsx
+++ b/js/app/packages/block-email/component/compose/ComposeLayout.tsx
@@ -2,6 +2,7 @@ import { CircleSpinner } from '@core/component/CircleSpinner';
 import { registerHotkey, useHotkeyDOMScope } from '@core/hotkey/hotkeys';
 import { TOKENS } from '@core/hotkey/tokens';
 import { createSignal, type JSX, onMount, Show, Suspense } from 'solid-js';
+import { FromInboxSelector } from '../FromInboxSelector';
 import { ComposeBody } from './ComposeBody';
 import { useCompose } from './ComposeContext';
 import { ComposeRecipients } from './ComposeRecipients';
@@ -176,8 +177,15 @@ export function ComposeLayout(props: {
               >
                 <Show when={ctx.fromAddress?.()}>
                   {(addr) => (
-                    <div class="text-xs text-ink-extra-muted/50">
-                      from {addr()}
+                    <div class="text-xs text-ink-extra-muted/50 flex items-center">
+                      <span>from</span>
+                      <FromInboxSelector
+                        links={ctx.fromInboxes?.() ?? []}
+                        activeLinkId={ctx.selectedFromLinkId?.()}
+                        label={addr()}
+                        onSelect={(id) => ctx.onSelectFromLink?.(id)}
+                        triggerClass="ml-1 h-5 gap-1 text-ink-extra-muted/50"
+                      />
                     </div>
                   )}
                 </Show>

--- a/js/app/packages/block-email/component/compose/ComposeLayout.tsx
+++ b/js/app/packages/block-email/component/compose/ComposeLayout.tsx
@@ -176,18 +176,14 @@ export function ComposeLayout(props: {
                 }
               >
                 <Show when={ctx.fromAddress?.()}>
-                  {(addr) => (
-                    <div class="text-xs text-ink-extra-muted/50 flex items-center">
-                      <span>from</span>
-                      <FromInboxSelector
-                        links={ctx.fromInboxes?.() ?? []}
-                        activeLinkId={ctx.selectedFromLinkId?.()}
-                        label={addr()}
-                        onSelect={(id) => ctx.onSelectFromLink?.(id)}
-                        triggerClass="ml-1 h-5 gap-1 text-ink-extra-muted/50"
-                      />
-                    </div>
-                  )}
+                  <div class="text-xs text-ink-extra-muted/50 flex items-center gap-1">
+                    <span>from</span>
+                    <FromInboxSelector
+                      links={ctx.fromInboxes?.() ?? []}
+                      activeLinkId={ctx.selectedFromLinkId?.()}
+                      onSelect={(id) => ctx.onSelectFromLink?.(id)}
+                    />
+                  </div>
                 </Show>
               </Suspense>
             }

--- a/js/app/packages/block-email/component/createEmailFormState.ts
+++ b/js/app/packages/block-email/component/createEmailFormState.ts
@@ -104,12 +104,17 @@ export function createEmailFormState(
   }
 
   const linksQuery = useEmailLinksQuery();
-  // Reply logic ("did I send this?") must be judged against the inbox that owns
-  // the thread, not the account's primary email — otherwise replying within a
-  // secondary or delegated inbox misclassifies the sender and picks the wrong
-  // recipients.
+  // The inbox this compose sends from. Defaults to the inbox that owns the
+  // thread/draft; the user can change it via the "from" selector.
+  const [selectedLinkId, setSelectedLinkId] = createSignal<string | undefined>(
+    (draft ?? replyingTo)?.link_id ?? undefined
+  );
+  // Reply logic ("did I send this?") must be judged against the inbox the
+  // message is sent from, not the account's primary email — otherwise replying
+  // from a secondary or delegated inbox misclassifies the sender and picks the
+  // wrong recipients.
   const inboxEmail = () => {
-    const linkId = (draft ?? replyingTo)?.link_id;
+    const linkId = selectedLinkId() ?? (draft ?? replyingTo)?.link_id;
     const ownerEmail = linkId
       ? linksQuery.data?.links.find((l) => l.id === linkId)?.email_address
       : undefined;
@@ -285,6 +290,20 @@ export function createEmailFormState(
     return rt;
   };
 
+  // Change the inbox this compose sends from. For an active reply, re-derive the
+  // recipients against the newly selected inbox (the sender comparison changes).
+  const setSelectedFromLink = (linkId: string | undefined) => {
+    setSelectedLinkId(linkId);
+    if (!replyingTo || draft || state.replyType === 'forward') return;
+    const recalculated =
+      state.replyType === 'reply-all'
+        ? getReplyAllRecipients(replyingTo, inboxEmail())
+        : getReplyRecipientsFromParent(replyingTo, inboxEmail());
+    setRecipients('to', recalculated.to ?? []);
+    setRecipients('cc', recalculated.cc ?? []);
+    setRecipients('bcc', recalculated.bcc ?? []);
+  };
+
   const setSendTime = (date: Date | null) => {
     setState('sendTime', date ?? undefined);
   };
@@ -335,6 +354,8 @@ export function createEmailFormState(
     setSubject,
     replyType: () => state.replyType,
     setReplyType,
+    selectedLinkId: () => selectedLinkId(),
+    setSelectedFromLink,
     shouldFocusInput,
     setShouldFocusInput,
     sendTime: () => state.sendTime,


### PR DESCRIPTION
Adds a "from" inbox selector to the email composer/reply input so the user can send from any inbox they've linked (own or delegated), instead of being fixed to the thread/primary inbox. A shared FromInboxSelector dropdown (shown when there's more than one inbox) is wired into the inline reply/compose (BaseInput) and the standalone draft pane (EmailCompose); the choice drives the X-Email-Link-Id header, the from display, and the reply recipients. Frontend-only; implements task 019e8a14.
