### PR TITLE
fix(email): scope recipient self-exclusion to the active sending inbox

### DIFF
--- a/js/app/packages/block-email/component/BaseInput.tsx
+++ b/js/app/packages/block-email/component/BaseInput.tsx
@@ -1472,6 +1472,7 @@ export function BaseInput(props: {
               <RecipientSelector<EmailRecipient['kind']>
                 inputRef={setToRef}
                 options={ctx.recipientOptions}
+                selfEmail={activeInboxEmail()}
                 selectedOptions={form().recipients().to}
                 setSelectedOptions={withDraftSave((v) =>
                   form().setRecipients('to', v)
@@ -1496,6 +1497,7 @@ export function BaseInput(props: {
                 <RecipientSelector<EmailRecipient['kind']>
                   inputRef={setCcRef}
                   options={ctx.recipientOptions}
+                  selfEmail={activeInboxEmail()}
                   selectedOptions={form().recipients().cc}
                   setSelectedOptions={withDraftSave((v) =>
                     form().setRecipients('cc', v)
@@ -1521,6 +1523,7 @@ export function BaseInput(props: {
                 <RecipientSelector<EmailRecipient['kind']>
                   inputRef={setBccRef}
                   options={ctx.recipientOptions}
+                  selfEmail={activeInboxEmail()}
                   selectedOptions={form().recipients().bcc}
                   setSelectedOptions={withDraftSave((v) =>
                     form().setRecipients('bcc', v)

--- a/js/app/packages/block-email/component/compose/ComposeRecipients.tsx
+++ b/js/app/packages/block-email/component/compose/ComposeRecipients.tsx
@@ -117,6 +117,7 @@ export function ComposeRecipients(props: {
         <RecipientSelector
           inputRef={props.toRef}
           options={ctx.recipientOptions}
+          selfEmail={ctx.fromAddress?.()}
           selectedOptions={ctx.recipients().to}
           setSelectedOptions={(next) => ctx.setRecipients('to', next)}
           placeholder="Macro users or email addresses"
@@ -146,6 +147,7 @@ export function ComposeRecipients(props: {
           <RecipientSelector
             inputRef={props.ccRef}
             options={ctx.recipientOptions}
+            selfEmail={ctx.fromAddress?.()}
             selectedOptions={ctx.recipients().cc}
             setSelectedOptions={(next) => ctx.setRecipients('cc', next)}
             placeholder="Macro users or email addresses"
@@ -171,6 +173,7 @@ export function ComposeRecipients(props: {
           <RecipientSelector
             inputRef={props.bccRef}
             options={ctx.recipientOptions}
+            selfEmail={ctx.fromAddress?.()}
             selectedOptions={ctx.recipients().bcc}
             setSelectedOptions={(next) => ctx.setRecipients('bcc', next)}
             placeholder="Macro users or email addresses"

--- a/js/app/packages/core/component/RecipientSelector.tsx
+++ b/js/app/packages/core/component/RecipientSelector.tsx
@@ -258,6 +258,7 @@ type RecipientSelectorProps<K extends CombinedRecipientKind> = {
   hideBorder?: boolean;
   noPadding?: boolean;
   includeSelf?: boolean;
+  selfEmail?: string;
   disabled?: boolean;
   onChipDragStart?: (option: WithCustomUserInput<K>, e: DragEvent) => void;
   onChipDragEnd?: (e: DragEvent) => void;
@@ -317,6 +318,9 @@ export function RecipientSelector<K extends CombinedRecipientKind>(
 
   const userId = useUserId();
   const userEmail = useEmail();
+  const selfEmail = () => (props.selfEmail ?? userEmail())?.toLowerCase();
+  const selfId = () =>
+    props.selfEmail ? emailToId(props.selfEmail) : userId();
 
   function handleChange(value: CombinedRecipientItem[]) {
     let newestSelection = value.at(-1);
@@ -329,7 +333,7 @@ export function RecipientSelector<K extends CombinedRecipientKind>(
     if (
       !props.includeSelf &&
       newestSelection.kind === 'user' &&
-      newestSelection.id === userId()
+      newestSelection.id === selfId()
     ) {
       const inputEl = inputRef();
       if (inputEl) inputEl.value = '';
@@ -386,6 +390,15 @@ export function RecipientSelector<K extends CombinedRecipientKind>(
     }),
   });
 
+  const selectedEmails = createMemo(() => {
+    const set = new Set<string>();
+    for (const option of props.selectedOptions) {
+      const email = getRecipientOptionEmail(option as CombinedRecipientItem);
+      if (email) set.add(email.toLowerCase());
+    }
+    return set;
+  });
+
   const augmentUserWithDmActivity = useAugmentUserWithDmActivity();
   const recipients = createMemo(() => {
     const options: CombinedRecipientItem[] = [];
@@ -397,9 +410,10 @@ export function RecipientSelector<K extends CombinedRecipientKind>(
 
       if (!props.includeSelf) {
         const matchesSelf =
-          (item.kind === 'user' && item.id === userId()) ||
-          (item.kind === 'contact' && email === userEmail()?.toLowerCase());
-        if (matchesSelf) {
+          (item.kind === 'user' && item.id === selfId()) ||
+          (item.kind === 'contact' && email === selfEmail());
+        const isSelected = !!email && selectedEmails().has(email.toLowerCase());
+        if (matchesSelf && !isSelected) {
           continue;
         }
       }

--- a/js/app/packages/core/component/RecipientSelector.tsx
+++ b/js/app/packages/core/component/RecipientSelector.tsx
@@ -72,7 +72,6 @@ function RecipientChip(props: {
   return (
     <div
       class="flex flex-row shrink-0 py-1 pl-2 gap-1 pr-1 overflow-hidden items-center bg-active rounded-full"
-      classList={{ 'cursor-grab active:cursor-grabbing': props.draggable }}
       draggable={props.draggable}
       onDragStart={props.onDragStart}
       onDragEnd={props.onDragEnd}

--- a/js/app/packages/core/component/RecipientSelector.tsx
+++ b/js/app/packages/core/component/RecipientSelector.tsx
@@ -408,10 +408,13 @@ export function RecipientSelector<K extends CombinedRecipientKind>(
       const email = getRecipientOptionEmail(item);
 
       if (!props.includeSelf) {
+        const emailLower = email?.toLowerCase();
         const matchesSelf =
           (item.kind === 'user' && item.id === selfId()) ||
-          (item.kind === 'contact' && email === selfEmail());
-        const isSelected = !!email && selectedEmails().has(email.toLowerCase());
+          (item.kind === 'contact' &&
+            !!emailLower &&
+            emailLower === selfEmail());
+        const isSelected = !!emailLower && selectedEmails().has(emailLower);
         if (matchesSelf && !isSelected) {
           continue;
         }


### PR DESCRIPTION
Treats the active sending inbox (not the signed-in account) as "self" in the recipient selector, so the user's own account is a selectable, resolvable recipient when sending from another inbox. Keeps an already-selected self-address in the options collection so its chip still renders (the combobox only renders chips for addresses present in options), and drops the grab cursor from recipient chips.
