### PR TITLE
feat(email): allow changing the from-inbox when replying

### DIFF
--- a/js/app/packages/block-email/component/BaseInput.tsx
+++ b/js/app/packages/block-email/component/BaseInput.tsx
@@ -1456,7 +1456,6 @@ export function BaseInput(props: {
                   links={emailLinksQuery.data?.links ?? []}
                   activeLinkId={activeLinkId()}
                   onSelect={(id) => form().setSelectedFromLink(id)}
-                  readonly={!!props.replyingTo()}
                 />
               </div>
             </div>

--- a/js/app/packages/block-email/component/FromInboxSelector.tsx
+++ b/js/app/packages/block-email/component/FromInboxSelector.tsx
@@ -44,7 +44,6 @@ export function FromInboxSelector(props: {
   links: FromInbox[];
   activeLinkId: string | undefined;
   onSelect: (linkId: string) => void;
-  readonly?: boolean;
 }) {
   const activeInbox = () =>
     props.links.find((l) => l.id === props.activeLinkId) ?? props.links[0];
@@ -52,7 +51,7 @@ export function FromInboxSelector(props: {
     <Show when={activeInbox()}>
       {(active) => (
         <Show
-          when={!props.readonly && props.links.length > 1}
+          when={props.links.length > 1}
           fallback={
             <div class="flex items-center gap-2 min-w-0 text-sm text-ink-muted">
               <Show when={active()} keyed>


### PR DESCRIPTION
Stacked on #3733. Re-enables changing the from-inbox on replies by dropping the readonly gate added in #3726 (it was a temporary freeze while the backend couldn't create a reply draft from a different inbox than the thread's). With #3733 that works, so replies can now pick any owned/delegated inbox like compose.
