### PR TITLE
chore(calls): flag off  sidebar active calls widget

### DIFF
--- a/js/app/packages/app/component/app-sidebar/sidebar.tsx
+++ b/js/app/packages/app/component/app-sidebar/sidebar.tsx
@@ -38,6 +38,7 @@ import {
   ENABLE_APP_STORE_QR_CODE,
   ENABLE_CALLS,
   ENABLE_NEW_PRICING_OVERRIDE,
+  ENABLE_SIDEBAR_ACTIVE_CALLS,
   ENABLE_TEAMS_OVERRIDE,
 } from '@core/constant/featureFlags';
 import {
@@ -1000,7 +1001,7 @@ export const AppSidebar = (props: AppSidebarProps) => {
       </div>
 
       <div class="mt-auto">
-        <Show when={ENABLE_CALLS()}>
+        <Show when={ENABLE_CALLS() && ENABLE_SIDEBAR_ACTIVE_CALLS()}>
           <div class="block max-h-[clamp(10%,60%,20rem)]">
             <SidebarActiveCallWidget
               sidebarState={props.sidebarState ?? 'expanded'}

--- a/js/app/packages/core/constant/featureFlags.ts
+++ b/js/app/packages/core/constant/featureFlags.ts
@@ -345,11 +345,8 @@ export function ENABLE_CALLS(): boolean {
   return analytics.posthog.isFeatureEnabled('enable-calls') ?? false;
 }
 
-// The sidebar active-calls widget polls GET /call/{channelId}/active for every
-// channel the user is in, every 15s (one request per channel). For users with
-// many channels this fans out to hundreds of requests. Flagged off by default
-// until it's batched / driven off websocket call events. Re-enable via the
-// 'enable-sidebar-active-calls' PostHog flag.
+// The sidebar active-calls widget fans out to one GET /call/{channelId}/active
+// request per channel every 15s. Flagged off until it's batched / socket-driven.
 export function ENABLE_SIDEBAR_ACTIVE_CALLS(): boolean {
   return (
     analytics.posthog.isFeatureEnabled('enable-sidebar-active-calls') ?? false

--- a/js/app/packages/core/constant/featureFlags.ts
+++ b/js/app/packages/core/constant/featureFlags.ts
@@ -345,6 +345,17 @@ export function ENABLE_CALLS(): boolean {
   return analytics.posthog.isFeatureEnabled('enable-calls') ?? false;
 }
 
+// The sidebar active-calls widget polls GET /call/{channelId}/active for every
+// channel the user is in, every 15s (one request per channel). For users with
+// many channels this fans out to hundreds of requests. Flagged off by default
+// until it's batched / driven off websocket call events. Re-enable via the
+// 'enable-sidebar-active-calls' PostHog flag.
+export function ENABLE_SIDEBAR_ACTIVE_CALLS(): boolean {
+  return (
+    analytics.posthog.isFeatureEnabled('enable-sidebar-active-calls') ?? false
+  );
+}
+
 export const ENABLE_NEW_ONBOARDING_OVERRIDE = DEV_MODE_ENV ? true : undefined;
 
 export const ENABLE_NEW_LOGIN_OVERRIDE = DEV_MODE_ENV ? true : undefined;


### PR DESCRIPTION
## Summary
This PR adds a new feature flag to control the visibility of the sidebar active-calls widget, allowing it to be disabled by default while performance improvements are being implemented.

## Key Changes
- Added `ENABLE_SIDEBAR_ACTIVE_CALLS()` feature flag function that checks the 'enable-sidebar-active-calls' PostHog flag
- Updated the sidebar to require both `ENABLE_CALLS()` and `ENABLE_SIDEBAR_ACTIVE_CALLS()` to display the active-calls widget
- Added comprehensive documentation explaining the performance concern: the widget polls GET /call/{channelId}/active every 15 seconds for each channel, which can result in hundreds of requests for users with many channels

## Implementation Details
The new flag is disabled by default and can be re-enabled via the 'enable-sidebar-active-calls' PostHog feature flag. This provides a way to control the widget's visibility while the team works on optimizing it through batching or websocket-driven call events.

https://claude.ai/code/session_011WRT7HHTS7y3yce2841EZJ