### PR TITLE
fix(icon): render entity icons with explicit size class for Safari

### DIFF
--- a/js/app/packages/core/component/EntityIcon.tsx
+++ b/js/app/packages/core/component/EntityIcon.tsx
@@ -404,7 +404,11 @@ export function EntityIcon(props: EntityIconProps) {
         props.class
       )}
     >
-      <Dynamic component={icon()} />
+      {/* `size-full` is required: Safari does not resolve the SVGs'
+          percentage width/height *presentation attributes* inside a flex
+          container, collapsing them to zero size. Applying the size via CSS
+          fixes the icons in Safari. */}
+      <Dynamic component={icon()} class="size-full" />
     </div>
   );
 }
@@ -429,7 +433,8 @@ export function CustomEntityIcon(
         'p-[20%]': props.useBackground,
       }}
     >
-      <Dynamic component={props.icon || config().icon} />
+      {/* See EntityIcon: `size-full` keeps the SVG sized in Safari. */}
+      <Dynamic component={props.icon || config().icon} class="size-full" />
     </div>
   );
 }

--- a/js/app/packages/core/component/EntityIcon.tsx
+++ b/js/app/packages/core/component/EntityIcon.tsx
@@ -404,10 +404,7 @@ export function EntityIcon(props: EntityIconProps) {
         props.class
       )}
     >
-      {/* `size-full` is required: Safari does not resolve the SVGs'
-          percentage width/height *presentation attributes* inside a flex
-          container, collapsing them to zero size. Applying the size via CSS
-          fixes the icons in Safari. */}
+      {/* size-full: Safari needs a CSS size, not the SVG's % attributes. */}
       <Dynamic component={icon()} class="size-full" />
     </div>
   );
@@ -433,7 +430,7 @@ export function CustomEntityIcon(
         'p-[20%]': props.useBackground,
       }}
     >
-      {/* See EntityIcon: `size-full` keeps the SVG sized in Safari. */}
+      {/* size-full: see EntityIcon (Safari). */}
       <Dynamic component={props.icon || config().icon} class="size-full" />
     </div>
   );


### PR DESCRIPTION
## Problem

Almost all entity icons were invisible in Safari — only the AI/macro icon rendered.

## Cause

`EntityIcon` rendered its SVGs via `<Dynamic component={icon()} />` with no CSS size class, relying solely on the SVGs' percentage `width`/`height` **presentation attributes**. Safari does not resolve those percentage attributes for an SVG that is a flex item, so the icons collapsed to zero size and appeared blank. Chrome resolves them, which is why the bug was Safari-only.

The AI/macro icon was unaffected because it is rendered through a different path that supplies an explicit CSS size class (`<MacroLogo class="size-[62%]" />`), and every other call site for these SVGs also passes a CSS size (e.g. `<WideChannel class="size-4" />`). `EntityIcon` was the one place that omitted it.

## Fix

Render the icons with `class="size-full"` in both `EntityIcon` and `CustomEntityIcon`, so dimensions come from CSS (which Safari resolves) rather than the percentage presentation attributes. `size-full` preserves existing behavior for all sizes, including the `useBackground` padded mode.

https://claude.ai/code/session_019XRkr7kuqWmwCzkGYzrP3Z

---
_Generated by [Claude Code](https://claude.ai/code/session_019XRkr7kuqWmwCzkGYzrP3Z)_