### PR TITLE
fix(mobile): process dragged images through native pasteboard pipeline

### DIFF
--- a/js/app/packages/core/directive/fileFolderDrop.ts
+++ b/js/app/packages/core/directive/fileFolderDrop.ts
@@ -1,4 +1,5 @@
 import { internalDragExceedsThreshold } from '@core/directive/internalDragState';
+import { processMobileDroppedImageEntries } from '@core/mobile/mobileDroppedImageRecovery';
 import { extractFileSystemEntries } from '@core/util/dataTransfer';
 import { type Accessor, onCleanup } from 'solid-js';
 
@@ -124,6 +125,13 @@ export function fileFolderDrop(
       return;
     }
 
+    // On mobile, run dragged image bytes through the same native processing
+    // (downscale + re-encode) that pasted images receive before attaching.
+    const emitFileEntries = async (entries: FileSystemFileEntry[]) => {
+      const processed = await processMobileDroppedImageEntries(entries);
+      options?.onDrop?.(processed, [], e);
+    };
+
     const { fileEntries, directoryEntries } =
       extractFileSystemEntries(dataTransfer);
 
@@ -134,7 +142,7 @@ export function fileFolderDrop(
     }
 
     if (fileEntries.length > 0) {
-      options?.onDrop?.(fileEntries, [], e);
+      await emitFileEntries(fileEntries);
       return;
     }
 
@@ -144,7 +152,7 @@ export function fileFolderDrop(
       const fileEntries: FileSystemFileEntry[] = Array.from(files).map(
         fileToFileSystemFileEntry
       );
-      options?.onDrop?.(fileEntries, [], e);
+      await emitFileEntries(fileEntries);
       return;
     }
 
@@ -187,7 +195,7 @@ export function fileFolderDrop(
 
           const file = new File([blob], filename, { type: blob.type });
           const fileEntry = fileToFileSystemFileEntry(file);
-          options?.onDrop?.([fileEntry], [], e);
+          await emitFileEntries([fileEntry]);
           return;
         } catch (error) {
           console.error('Failed to fetch dragged image:', error);

--- a/js/app/packages/core/mobile/mobileDroppedImageRecovery.ts
+++ b/js/app/packages/core/mobile/mobileDroppedImageRecovery.ts
@@ -1,0 +1,90 @@
+import { isNativeMobilePlatform } from '@core/mobile/isNativeMobilePlatform';
+import { createSyntheticFileEntry } from '@core/util/dataTransfer';
+import { isAndroid, isIOS } from '@solid-primitives/platform';
+import { invoke, isTauri } from '@tauri-apps/api/core';
+import {
+  createNativeStagedUploadFile,
+  type NativeStagedUploadData,
+} from './nativeStagedUpload';
+
+const IMAGE_FILE_EXTENSION =
+  /\.(png|jpe?g|gif|webp|bmp|tiff?|heic|heif|avif)$/i;
+
+function isMobileDropContext(): boolean {
+  return isTauri() && (isIOS || isAndroid || isNativeMobilePlatform());
+}
+
+function isImageFile(file: File): boolean {
+  if (file.type.startsWith('image/')) return true;
+  // iOS can surface HEIC/HEIF drops with an empty MIME type.
+  if (file.type === '') return IMAGE_FILE_EXTENSION.test(file.name);
+  return false;
+}
+
+function fileToBase64(file: File): Promise<string> {
+  return file.arrayBuffer().then((buffer) => {
+    const bytes = new Uint8Array(buffer);
+    let binary = '';
+    const chunkSize = 0x8000;
+    for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+      binary += String.fromCharCode(
+        ...bytes.subarray(offset, offset + chunkSize)
+      );
+    }
+    return btoa(binary);
+  });
+}
+
+function entryToFile(entry: FileSystemFileEntry): Promise<File | null> {
+  return new Promise((resolve) => {
+    try {
+      entry.file(
+        (file) => resolve(file),
+        () => resolve(null)
+      );
+    } catch {
+      resolve(null);
+    }
+  });
+}
+
+async function stageDroppedImage(file: File): Promise<File | null> {
+  try {
+    const imageData = await fileToBase64(file);
+    const staged = await invoke<NativeStagedUploadData>(
+      'plugin:pasteboard|stage_dropped_image',
+      { imageData, fileName: file.name }
+    );
+    return createNativeStagedUploadFile('pasteboard', staged);
+  } catch {
+    return null;
+  }
+}
+
+async function processEntry(
+  entry: FileSystemFileEntry
+): Promise<FileSystemFileEntry> {
+  const file = await entryToFile(entry);
+  if (!file || !isImageFile(file)) return entry;
+
+  const staged = await stageDroppedImage(file);
+  return staged ? createSyntheticFileEntry(staged) : entry;
+}
+
+/**
+ * Runs dragged image entries through the native pasteboard plugin so they get
+ * the same downscaling and re-encoding as pasted images.
+ *
+ * Needed on mobile WKWebView where the browser hands us the raw drop bytes
+ * (often large or HEIC), which the upload pipeline can't process on its own.
+ * Non-image entries and any entries that fail native staging pass through
+ * unchanged.
+ */
+export async function processMobileDroppedImageEntries(
+  fileEntries: FileSystemFileEntry[]
+): Promise<FileSystemFileEntry[]> {
+  if (!isMobileDropContext() || fileEntries.length === 0) {
+    return fileEntries;
+  }
+  return Promise.all(fileEntries.map(processEntry));
+}

--- a/js/app/tauri/pasteboard_plugin/build.rs
+++ b/js/app/tauri/pasteboard_plugin/build.rs
@@ -1,5 +1,5 @@
 fn main() {
-    tauri_plugin::Builder::new(&["stage_pasteboard_image"])
+    tauri_plugin::Builder::new(&["stage_pasteboard_image", "stage_dropped_image"])
         .ios_path("ios")
         .try_build()
         .unwrap();

--- a/js/app/tauri/pasteboard_plugin/ios/Sources/PasteboardPlugin.swift
+++ b/js/app/tauri/pasteboard_plugin/ios/Sources/PasteboardPlugin.swift
@@ -6,6 +6,13 @@ private struct StagePasteboardImagePayload: Decodable {
     let tokenPrefix: String
 }
 
+private struct StageDroppedImagePayload: Decodable {
+    let stagingDirectoryPath: String
+    let tokenPrefix: String
+    let imageData: String
+    let fileName: String?
+}
+
 class PasteboardPlugin: Plugin {
     @objc public func stagePasteboardImage(_ invoke: Invoke) throws {
         let payload = try invoke.parseArgs(StagePasteboardImagePayload.self)
@@ -26,40 +33,80 @@ class PasteboardPlugin: Plugin {
                 return
             }
 
-            DispatchQueue.global(qos: .userInitiated).async {
-                self.cleanupStalePasteboardImages(in: stagingDirectory)
+            self.stageImage(
+                image,
+                baseName: "pasted-image",
+                stagingDirectory: stagingDirectory,
+                tokenPrefix: payload.tokenPrefix,
+                invoke: invoke
+            )
+        }
+    }
 
-                let encoded = encodedData(from: image)
-                guard let data = encoded.data else {
-                    invoke.reject("Failed to encode pasteboard image")
-                    return
-                }
+    @objc public func stageDroppedImage(_ invoke: Invoke) throws {
+        let payload = try invoke.parseArgs(StageDroppedImagePayload.self)
+        let stagingDirectory = URL(
+            fileURLWithPath: payload.stagingDirectoryPath,
+            isDirectory: true
+        )
 
-                let token = payload.tokenPrefix
-                    + UUID().uuidString.replacingOccurrences(of: "-", with: "").lowercased()
-                let name = "pasted-image.\(encoded.fileExtension)"
-                let fileURL = stagingDirectory.appendingPathComponent("\(token)-\(name)")
+        guard
+            let data = Data(base64Encoded: payload.imageData),
+            let image = UIImage(data: data)
+        else {
+            invoke.reject("Failed to decode dropped image")
+            return
+        }
 
-                do {
-                    try FileManager.default.createDirectory(
-                        at: stagingDirectory,
-                        withIntermediateDirectories: true
-                    )
-                    try data.write(to: fileURL, options: [.atomic])
-                    let size = try FileManager.default.attributesOfItem(
-                        atPath: fileURL.path
-                    )[.size] as? NSNumber
+        self.stageImage(
+            image,
+            baseName: droppedImageBaseName(from: payload.fileName),
+            stagingDirectory: stagingDirectory,
+            tokenPrefix: payload.tokenPrefix,
+            invoke: invoke
+        )
+    }
 
-                    invoke.resolve([
-                        "token": token,
-                        "name": name,
-                        "mimeType": encoded.mimeType,
-                        "size": size?.uint64Value ?? UInt64(data.count),
-                        "previewPath": fileURL.path,
-                    ])
-                } catch {
-                    invoke.reject("Failed to stage pasteboard image: \(error.localizedDescription)")
-                }
+    private func stageImage(
+        _ image: UIImage,
+        baseName: String,
+        stagingDirectory: URL,
+        tokenPrefix: String,
+        invoke: Invoke
+    ) {
+        DispatchQueue.global(qos: .userInitiated).async {
+            self.cleanupStalePasteboardImages(in: stagingDirectory)
+
+            let encoded = encodedData(from: image)
+            guard let data = encoded.data else {
+                invoke.reject("Failed to encode image")
+                return
+            }
+
+            let token = tokenPrefix
+                + UUID().uuidString.replacingOccurrences(of: "-", with: "").lowercased()
+            let name = "\(baseName).\(encoded.fileExtension)"
+            let fileURL = stagingDirectory.appendingPathComponent("\(token)-\(name)")
+
+            do {
+                try FileManager.default.createDirectory(
+                    at: stagingDirectory,
+                    withIntermediateDirectories: true
+                )
+                try data.write(to: fileURL, options: [.atomic])
+                let size = try FileManager.default.attributesOfItem(
+                    atPath: fileURL.path
+                )[.size] as? NSNumber
+
+                invoke.resolve([
+                    "token": token,
+                    "name": name,
+                    "mimeType": encoded.mimeType,
+                    "size": size?.uint64Value ?? UInt64(data.count),
+                    "previewPath": fileURL.path,
+                ])
+            } catch {
+                invoke.reject("Failed to stage image: \(error.localizedDescription)")
             }
         }
     }
@@ -88,6 +135,20 @@ private struct EncodedImageData {
     let data: Data?
     let mimeType: String
     let fileExtension: String
+}
+
+private func droppedImageBaseName(from fileName: String?) -> String {
+    let fallback = "dropped-image"
+    guard let fileName else { return fallback }
+
+    let stem = (fileName as NSString).deletingPathExtension
+    let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_"))
+    let sanitized = String(
+        stem.unicodeScalars.map { allowed.contains($0) ? Character($0) : "-" }
+    )
+    .trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+
+    return sanitized.isEmpty ? fallback : sanitized
 }
 
 private let maxImagePixelDimension: CGFloat = 4096

--- a/js/app/tauri/pasteboard_plugin/permissions/autogenerated/commands/stage_dropped_image.toml
+++ b/js/app/tauri/pasteboard_plugin/permissions/autogenerated/commands/stage_dropped_image.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-stage-dropped-image"
+description = "Enables the stage_dropped_image command without any pre-configured scope."
+commands.allow = ["stage_dropped_image"]
+
+[[permission]]
+identifier = "deny-stage-dropped-image"
+description = "Denies the stage_dropped_image command without any pre-configured scope."
+commands.deny = ["stage_dropped_image"]

--- a/js/app/tauri/pasteboard_plugin/permissions/autogenerated/reference.md
+++ b/js/app/tauri/pasteboard_plugin/permissions/autogenerated/reference.md
@@ -10,6 +10,32 @@
 <tr>
 <td>
 
+`pasteboard:allow-stage-dropped-image`
+
+</td>
+<td>
+
+Enables the stage_dropped_image command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`pasteboard:deny-stage-dropped-image`
+
+</td>
+<td>
+
+Denies the stage_dropped_image command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
 `pasteboard:allow-stage-pasteboard-image`
 
 </td>

--- a/js/app/tauri/pasteboard_plugin/permissions/schemas/schema.json
+++ b/js/app/tauri/pasteboard_plugin/permissions/schemas/schema.json
@@ -295,6 +295,18 @@
       "type": "string",
       "oneOf": [
         {
+          "description": "Enables the stage_dropped_image command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-stage-dropped-image",
+          "markdownDescription": "Enables the stage_dropped_image command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the stage_dropped_image command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-stage-dropped-image",
+          "markdownDescription": "Denies the stage_dropped_image command without any pre-configured scope."
+        },
+        {
           "description": "Enables the stage_pasteboard_image command without any pre-configured scope.",
           "type": "string",
           "const": "allow-stage-pasteboard-image",

--- a/js/app/tauri/pasteboard_plugin/src/lib.rs
+++ b/js/app/tauri/pasteboard_plugin/src/lib.rs
@@ -15,6 +15,16 @@ struct StagePasteboardImagePayload {
     token_prefix: &'static str,
 }
 
+#[cfg(target_os = "ios")]
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct StageDroppedImagePayload {
+    staging_directory_path: String,
+    token_prefix: &'static str,
+    image_data: String,
+    file_name: Option<String>,
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct StagedPasteboardImage {
@@ -39,6 +49,26 @@ impl<R: Runtime> Pasteboard<R> {
                 StagePasteboardImagePayload {
                     staging_directory_path,
                     token_prefix: staged_upload_constants::PASTEBOARD_TOKEN_PREFIX,
+                },
+            )
+            .map_err(|error| error.to_string())
+    }
+
+    #[cfg(target_os = "ios")]
+    fn stage_dropped_image(
+        &self,
+        staging_directory_path: String,
+        image_data: String,
+        file_name: Option<String>,
+    ) -> Result<StagedPasteboardImage, String> {
+        self.0
+            .run_mobile_plugin(
+                "stageDroppedImage",
+                StageDroppedImagePayload {
+                    staging_directory_path,
+                    token_prefix: staged_upload_constants::PASTEBOARD_TOKEN_PREFIX,
+                    image_data,
+                    file_name,
                 },
             )
             .map_err(|error| error.to_string())
@@ -80,9 +110,39 @@ async fn stage_pasteboard_image<R: Runtime>(
     }
 }
 
+#[command]
+async fn stage_dropped_image<R: Runtime>(
+    app: AppHandle<R>,
+    image_data: String,
+    file_name: Option<String>,
+) -> Result<StagedPasteboardImage, String> {
+    #[cfg(not(target_os = "ios"))]
+    {
+        let _ = (app, image_data, file_name);
+        Err("pasteboard plugin is only available on iOS".to_string())
+    }
+
+    #[cfg(target_os = "ios")]
+    {
+        let staging_directory_path = app
+            .path()
+            .app_cache_dir()
+            .map_err(|error| format!("failed to resolve app cache directory: {error}"))?
+            .join(staged_upload_constants::PASTEBOARD_STAGING_DIRECTORY_NAME)
+            .to_string_lossy()
+            .into_owned();
+
+        app.pasteboard()
+            .stage_dropped_image(staging_directory_path, image_data, file_name)
+    }
+}
+
 pub fn init<R: Runtime>() -> TauriPlugin<R> {
     Builder::new("pasteboard")
-        .invoke_handler(tauri::generate_handler![stage_pasteboard_image])
+        .invoke_handler(tauri::generate_handler![
+            stage_pasteboard_image,
+            stage_dropped_image
+        ])
         .setup(|_app, _api| {
             #[cfg(target_os = "ios")]
             {

--- a/js/app/tauri/src-tauri/capabilities/mobile.json
+++ b/js/app/tauri/src-tauri/capabilities/mobile.json
@@ -16,6 +16,7 @@
     "auth:allow-authenticate",
     "device-info:default",
     "pasteboard:allow-stage-pasteboard-image",
+    "pasteboard:allow-stage-dropped-image",
     "photo-library:allow-pick-photo-library-images",
     "call-kit:allow-get-voip-token",
     "call-kit:allow-end-active-call"


### PR DESCRIPTION
Dragging an image attachment didn't work on mobile because dropped image bytes (often large or HEIC) were attached raw, without the native downscaling/re-encoding that pasted images already receive.

This mirrors the paste pipeline for drops:

- **Native:** Refactored `PasteboardPlugin.swift` to share a `stageImage(...)` helper and added a `stageDroppedImage` command that decodes the dropped image (`UIImage(data:)`, also handles HEIC) and runs it through the same normalize (downscale to 4096px / orientation fix) + encode (PNG if alpha, else JPEG 0.92) + staging logic as `stagePasteboardImage`. Added the `stage_dropped_image` Tauri command (reusing the pasteboard staging dir/token prefix so the existing upload path is unchanged), wired into `build.rs`, permissions, and `capabilities/mobile.json`.
- **Frontend:** New `mobileDroppedImageRecovery.ts` reads each dropped image entry's bytes, invokes `stage_dropped_image`, and returns a `native-staged` upload entry (same kind paste produces). `fileFolderDrop.ts` routes dropped image entries through it on mobile+Tauri; non-images and failures pass through unchanged, so desktop/web behavior is unchanged.

https://claude.ai/code/session_01EdiMnRwo1u79kfXddsQNzi

---
_Generated by [Claude Code](https://claude.ai/code/session_01EdiMnRwo1u79kfXddsQNzi)_