### PR TITLE
feat(email): surface the owning inbox per thread in the entity emails view

### DIFF
--- a/js/app/packages/block-email/component/FromInboxSelector.tsx
+++ b/js/app/packages/block-email/component/FromInboxSelector.tsx
@@ -1,4 +1,5 @@
-import { UserIcon, type UserIconProps } from '@core/component/UserIcon';
+import { inboxIconProps } from '@core/component/inboxIcon';
+import { UserIcon } from '@core/component/UserIcon';
 import { emailToMacroId, useDisplayName } from '@core/user';
 import ChevronDown from '@phosphor/caret-down.svg';
 import Check from '@phosphor/check.svg';
@@ -7,21 +8,13 @@ import { For, Show } from 'solid-js';
 
 type FromInbox = { id: string; email_address: string };
 
-// Resolve each inbox's identity from its own address, not the link's macro_id:
-// an own secondary inbox shares the parent account's macro_id, so keying on the
-// address gives each inbox its own name and icon.
-function inboxIconProps(inbox: FromInbox): UserIconProps {
-  const macroId = emailToMacroId(inbox.email_address);
-  return macroId ? { id: macroId } : { email: inbox.email_address };
-}
-
 /** A single inbox: the account's user icon, name, and address. */
 function FromInboxOption(props: { inbox: FromInbox }) {
   const [name] = useDisplayName(emailToMacroId(props.inbox.email_address));
   return (
     <>
       <UserIcon
-        {...inboxIconProps(props.inbox)}
+        {...inboxIconProps(props.inbox.email_address)}
         size="sm"
         suppressClick
         class="shrink-0"

--- a/js/app/packages/core/component/inboxIcon.ts
+++ b/js/app/packages/core/component/inboxIcon.ts
@@ -1,0 +1,10 @@
+import type { UserIconProps } from '@core/component/UserIcon';
+import { emailToMacroId } from '@core/user';
+
+// Resolve an inbox's identity from its own address, not the link's macro_id:
+// an own secondary inbox shares the parent account's macro_id, so keying on the
+// address gives each inbox its own name and icon.
+export function inboxIconProps(emailAddress: string): UserIconProps {
+  const macroId = emailToMacroId(emailAddress);
+  return macroId ? { id: macroId } : { email: emailAddress };
+}

--- a/js/app/packages/entity/src/composed/list-entity/email.tsx
+++ b/js/app/packages/entity/src/composed/list-entity/email.tsx
@@ -111,10 +111,11 @@ export function EmailWideContent(props: {
 }) {
   return (
     <>
-      <span class="w-(--title-width) shrink-0">
+      <span class="w-(--title-width) shrink-0 flex items-center gap-2">
         <span class="truncate max-w-32 flex gap-2 items-center">
           <EmailIdentity entity={props.entity} />
         </span>
+        <EmailInboxChip entity={props.entity} class="ml-auto" />
       </span>
       <span class="truncate">
         <Entity.Title entity={props.entity} />
@@ -129,7 +130,6 @@ export function EmailWideContent(props: {
           chars={props.chars}
         />
       </span>
-      <EmailInboxChip entity={props.entity} />
     </>
   );
 }

--- a/js/app/packages/entity/src/composed/list-entity/email.tsx
+++ b/js/app/packages/entity/src/composed/list-entity/email.tsx
@@ -2,7 +2,7 @@ import { inboxIconProps } from '@core/component/inboxIcon';
 import { UserIcon } from '@core/component/UserIcon';
 import { useEmailLinksQuery } from '@queries/email/link';
 import { cn } from '@ui';
-import { createMemo, Show } from 'solid-js';
+import { type Accessor, createMemo, Show } from 'solid-js';
 import { DraftBadge } from '../../components/Badges';
 import { Entity } from '../../entity';
 import { HitSnippet } from '../../extractors-search/HitSnippet';
@@ -10,21 +10,29 @@ import { getSnippetHit } from '../../extractors-search/snippet-entity';
 import type { EmailEntity } from '../../types/entity';
 
 /**
+ * Resolves the linked inbox a thread belongs to, but only when the user has
+ * more than one accessible inbox (a single inbox needs no attribution) and the
+ * thread's link is one the user can see. Returns undefined otherwise — e.g. a
+ * thread shared with the user that isn't one of their own/delegated inboxes.
+ */
+export function useOwningInbox(entity: Accessor<EmailEntity | undefined>) {
+  const linksQuery = useEmailLinksQuery();
+  return createMemo(() => {
+    const linkId = entity()?.linkId;
+    if (!linkId) return undefined;
+    const links = linksQuery.data?.links ?? [];
+    if (links.length <= 1) return undefined;
+    return links.find((l) => l.id === linkId);
+  });
+}
+
+/**
  * Shows which linked inbox a thread belongs to, mirroring the composer's
  * "from" chip: the inbox's icon and address, resolved by email so an own
  * secondary inbox shows its own identity rather than the parent account's.
- * Only renders when the user has more than one accessible inbox — a single
- * inbox needs no attribution.
  */
 export function EmailInboxChip(props: { entity: EmailEntity; class?: string }) {
-  const linksQuery = useEmailLinksQuery();
-  const inbox = createMemo(() => {
-    const links = linksQuery.data?.links ?? [];
-    if (links.length <= 1) return undefined;
-    const linkId = props.entity.linkId;
-    if (!linkId) return undefined;
-    return links.find((l) => l.id === linkId);
-  });
+  const inbox = useOwningInbox(() => props.entity);
   return (
     <Show when={inbox()}>
       {(link) => (

--- a/js/app/packages/entity/src/composed/list-entity/email.tsx
+++ b/js/app/packages/entity/src/composed/list-entity/email.tsx
@@ -27,9 +27,9 @@ export function useOwningInbox(entity: Accessor<EmailEntity | undefined>) {
 }
 
 /**
- * Shows which linked inbox a thread belongs to, mirroring the composer's
- * "from" chip: the inbox's icon and address, resolved by email so an own
- * secondary inbox shows its own identity rather than the parent account's.
+ * Shows which linked inbox a thread belongs to as the inbox's icon (full
+ * address on hover), resolved by email so an own secondary inbox shows its own
+ * identity rather than the parent account's.
  */
 export function EmailInboxChip(props: { entity: EmailEntity; class?: string }) {
   const inbox = useOwningInbox(() => props.entity);
@@ -37,10 +37,7 @@ export function EmailInboxChip(props: { entity: EmailEntity; class?: string }) {
     <Show when={inbox()}>
       {(link) => (
         <span
-          class={cn(
-            'flex shrink-0 items-center gap-1 text-ink-extra-muted text-xs font-normal max-w-32',
-            props.class
-          )}
+          class={cn('flex shrink-0 items-center', props.class)}
           title={link().email_address}
         >
           <UserIcon
@@ -49,7 +46,6 @@ export function EmailInboxChip(props: { entity: EmailEntity; class?: string }) {
             suppressClick
             class="shrink-0"
           />
-          <span class="truncate">{link().email_address.split('@')[0]}</span>
         </span>
       )}
     </Show>

--- a/js/app/packages/entity/src/composed/list-entity/email.tsx
+++ b/js/app/packages/entity/src/composed/list-entity/email.tsx
@@ -1,9 +1,52 @@
-import { Show } from 'solid-js';
+import { inboxIconProps } from '@core/component/inboxIcon';
+import { UserIcon } from '@core/component/UserIcon';
+import { useEmailLinksQuery } from '@queries/email/link';
+import { cn } from '@ui';
+import { createMemo, Show } from 'solid-js';
 import { DraftBadge } from '../../components/Badges';
 import { Entity } from '../../entity';
 import { HitSnippet } from '../../extractors-search/HitSnippet';
 import { getSnippetHit } from '../../extractors-search/snippet-entity';
 import type { EmailEntity } from '../../types/entity';
+
+/**
+ * Shows which linked inbox a thread belongs to, mirroring the composer's
+ * "from" chip: the inbox's icon and address, resolved by email so an own
+ * secondary inbox shows its own identity rather than the parent account's.
+ * Only renders when the user has more than one accessible inbox — a single
+ * inbox needs no attribution.
+ */
+export function EmailInboxChip(props: { entity: EmailEntity; class?: string }) {
+  const linksQuery = useEmailLinksQuery();
+  const inbox = createMemo(() => {
+    const links = linksQuery.data?.links ?? [];
+    if (links.length <= 1) return undefined;
+    const linkId = props.entity.linkId;
+    if (!linkId) return undefined;
+    return links.find((l) => l.id === linkId);
+  });
+  return (
+    <Show when={inbox()}>
+      {(link) => (
+        <span
+          class={cn(
+            'flex shrink-0 items-center gap-1 text-ink-extra-muted text-xs font-normal max-w-32',
+            props.class
+          )}
+          title={link().email_address}
+        >
+          <UserIcon
+            {...inboxIconProps(link().email_address)}
+            size="sm"
+            suppressClick
+            class="shrink-0"
+          />
+          <span class="truncate">{link().email_address.split('@')[0]}</span>
+        </span>
+      )}
+    </Show>
+  );
+}
 
 export function EmailIdentity(props: { entity: EmailEntity }) {
   return (
@@ -11,7 +54,7 @@ export function EmailIdentity(props: { entity: EmailEntity }) {
       <Show when={props.entity.isDraft}>
         <DraftBadge />
       </Show>
-      <span class="truncate">
+      <span class="truncate min-w-0">
         <Entity.EmailParticipants entity={props.entity} />
       </span>
     </>
@@ -82,6 +125,7 @@ export function EmailWideContent(props: {
           chars={props.chars}
         />
       </span>
+      <EmailInboxChip entity={props.entity} />
     </>
   );
 }

--- a/js/app/packages/entity/src/composed/list-entity/narrow-inbox-layout.tsx
+++ b/js/app/packages/entity/src/composed/list-entity/narrow-inbox-layout.tsx
@@ -23,7 +23,7 @@ import {
   ChannelLatestMessageNarrowBody,
   ChannelMessageNarrowBody,
 } from './channel';
-import { EmailIdentity, EmailNarrowBody } from './email';
+import { EmailIdentity, EmailInboxChip, EmailNarrowBody } from './email';
 import { InboxDivider, type LayoutProps } from './shared';
 import { TaskNarrowBody } from './task';
 
@@ -112,7 +112,12 @@ export function NarrowInboxLayout(props: LayoutProps) {
           when={isEmailEntity(props.entity) && props.entity}
           fallback={<Entity.Title entity={props.entity} />}
         >
-          {(entity) => <EmailIdentity entity={entity()} />}
+          {(entity) => (
+            <>
+              <EmailIdentity entity={entity()} />
+              <EmailInboxChip entity={entity()} class="ml-auto" />
+            </>
+          )}
         </Show>
       </Entity.Slot>
 

--- a/js/app/packages/entity/src/composed/list-entity/wide-layout.tsx
+++ b/js/app/packages/entity/src/composed/list-entity/wide-layout.tsx
@@ -19,11 +19,16 @@ import { isSearchEntity } from '../../types/search';
 import { AutomationWideContent } from './automation';
 import { CallParticipants, CallWideContent } from './call';
 import { ChannelMessageWideContent, ChannelWideContent } from './channel';
-import { EmailWideContent } from './email';
+import { EmailWideContent, useOwningInbox } from './email';
 import type { LayoutProps } from './shared';
 
 export function WideLayout(props: LayoutProps) {
   const soupView = useMaybeSoupView();
+  // When a thread resolves to one of the user's inboxes the inbox chip already
+  // conveys ownership, so the generic "shared" badge would be redundant.
+  const owningInbox = useOwningInbox(() =>
+    isEmailEntity(props.entity) ? props.entity : undefined
+  );
 
   return (
     <Entity.Layout
@@ -111,7 +116,7 @@ export function WideLayout(props: LayoutProps) {
             </span>
           )}
         </Show>
-        <Show when={props.isShared}>
+        <Show when={props.isShared && !owningInbox()}>
           <SharedBadge ownerId={props.entity.ownerId} />
         </Show>
         <Show when={isCallEntity(props.entity) && props.entity}>

--- a/js/app/packages/entity/src/types/entity.ts
+++ b/js/app/packages/entity/src/types/entity.ts
@@ -104,6 +104,8 @@ export type EmailEntity = EntityBase & {
   participants?: EmailThreadParticipants;
   senderEmail?: string;
   senderName?: string;
+  /** The linked inbox (email_links row) this thread belongs to. */
+  linkId?: string;
   labels?: SoupLabel[] | ApiLabel[];
   hasIcsAttachment?: boolean;
   attachments?: EmailAttachment[];

--- a/js/app/packages/queries/soup/transform-utils.ts
+++ b/js/app/packages/queries/soup/transform-utils.ts
@@ -526,6 +526,12 @@ export const mapSoupPageToEntityList: (
             sizeBytes: a.sizeBytes,
           }));
 
+          // The thread preview has no link id of its own; its participants and
+          // labels are scoped to the owning inbox, so they share its link id.
+          const linkId =
+            item.data.participants?.[0]?.linkId ??
+            item.data.labels?.[0]?.linkId;
+
           return {
             ...item.data,
             createdAt: item.data.createdAt,
@@ -540,6 +546,7 @@ export const mapSoupPageToEntityList: (
             frecencyScore: item.frecency_score,
             viewedAt: item.data.viewedAt,
             projectId: item.data.projectId ?? undefined,
+            linkId,
             participants,
             hasIcsAttachment,
             attachments,


### PR DESCRIPTION
Surfaces which linked inbox each thread belongs to in the email view via a small inbox icon per row, shown only when the user has more than one accessible inbox. Identity resolves by email so an own-secondary inbox (which shares the parent's macro_id) shows its own icon, and the now-redundant shared badge is hidden when the icon resolves a link.
