### PR TITLE
feat(email): render email contact photos in avatars

### DIFF
--- a/js/app/packages/block-email/component/CollapsedMessage.tsx
+++ b/js/app/packages/block-email/component/CollapsedMessage.tsx
@@ -22,8 +22,9 @@ export function CollapsedMessage(props: CollapsedMessageProps) {
   const senderMacroId = createMemo(() => getSenderMacroId(props.message));
   const senderIconProps = createMemo<UserIconProps>(() => {
     const senderId = senderMacroId();
-    if (senderId) return { id: senderId };
-    return { email: props.message.from?.email ?? '' };
+    const photoUrl = props.message.from?.photo_url ?? undefined;
+    if (senderId) return { id: senderId, photoUrl };
+    return { email: props.message.from?.email ?? '', photoUrl };
   });
 
   const snippet = createMemo(() => {

--- a/js/app/packages/block-email/component/EmailParticipants.tsx
+++ b/js/app/packages/block-email/component/EmailParticipants.tsx
@@ -8,6 +8,7 @@ import { EmailUserTooltip } from './EmailUserTooltip';
 interface Participant {
   email: string;
   name?: string;
+  photoUrl?: string;
 }
 
 const DEFAULT_VISIBLE_COUNT = 5;
@@ -28,6 +29,7 @@ export function EmailParticipants() {
           seen.set(m.from.email, {
             email: m.from.email,
             name: m.from.name ?? undefined,
+            photoUrl: m.from.photo_url ?? existing?.photoUrl ?? undefined,
           });
         }
       }
@@ -38,6 +40,7 @@ export function EmailParticipants() {
           seen.set(r.email, {
             email: r.email,
             name: r.name ?? undefined,
+            photoUrl: r.photo_url ?? existing?.photoUrl ?? undefined,
           });
         }
       }
@@ -64,8 +67,8 @@ export function EmailParticipants() {
 
   const getIconProps = (p: Participant): UserIconProps => {
     const macroId = emailToMacroId(p.email);
-    if (macroId) return { id: macroId };
-    return { email: p.email };
+    if (macroId) return { id: macroId, photoUrl: p.photoUrl };
+    return { email: p.email, photoUrl: p.photoUrl };
   };
 
   return (

--- a/js/app/packages/block-email/component/MessageContainer.tsx
+++ b/js/app/packages/block-email/component/MessageContainer.tsx
@@ -212,6 +212,7 @@ export function MessageContainer(props: MessageContainerProps) {
               isFirstMessage={true}
               isLastMessage={props.isLastMessage}
               senderId={senderMacroId()}
+              senderPhotoUrl={props.message.from?.photo_url ?? undefined}
               isNewMessage={isNewMessage()}
               isTarget={props.isTarget}
               hasReplyInputBelow={true}

--- a/js/app/packages/core/component/Message.tsx
+++ b/js/app/packages/core/component/Message.tsx
@@ -29,6 +29,7 @@ type MessageRootProps = {
   focused: boolean;
   unfocusable?: boolean;
   senderId?: string;
+  senderPhotoUrl?: string;
   customIcon?: Component<JSX.SvgSVGAttributes<SVGSVGElement>>;
   customIconTargetType?: EntityWithValidIcon;
   isFirstMessage: boolean;
@@ -309,6 +310,7 @@ const Root: Component<MessageRootProps> = (props) => {
                         >
                           <UserIcon
                             id={props.senderId ?? ''}
+                            photoUrl={props.senderPhotoUrl}
                             isDeleted={false}
                             size="fill"
                             suppressClick={true}

--- a/js/app/packages/core/component/UserIcon.tsx
+++ b/js/app/packages/core/component/UserIcon.tsx
@@ -33,6 +33,8 @@ export type UserIconProps = {
   suppressClick?: boolean;
   showTooltip?: boolean;
   class?: string;
+  /** Fallback image (e.g. an email contact photo) shown when the user has no Macro profile picture. */
+  photoUrl?: string;
 } & ({ id: string; email?: never } | { email: string; id?: never });
 
 function getInitials(
@@ -55,7 +57,11 @@ function getInitials(
 /**
  * Internal render. Image or fallback.
  */
-function ProfileImage(props: { id?: string; email?: string }) {
+function ProfileImage(props: {
+  id?: string;
+  email?: string;
+  photoUrl?: string;
+}) {
   const macroId = createMemo(() =>
     props.id ? tryMacroId(props.id) : undefined
   );
@@ -80,9 +86,12 @@ function ProfileImage(props: { id?: string; email?: string }) {
 
   const [profilePicUrl] = useProfilePictureUrl(props.id);
 
+  // Macro profile picture wins; fall back to a contact photo before initials.
+  const imageUrl = () => profilePicUrl() || props.photoUrl;
+
   return (
     <Show
-      when={profilePicUrl()}
+      when={imageUrl()}
       fallback={
         <Avatar.Fallback class="font-semibold">{initials()}</Avatar.Fallback>
       }
@@ -110,6 +119,7 @@ function UserIconContent(props: {
   id?: string;
   email?: string;
   isDeleted?: boolean;
+  photoUrl?: string;
 }) {
   return (
     <Switch>
@@ -117,10 +127,10 @@ function UserIconContent(props: {
         <Trash />
       </Match>
       <Match when={props.id} keyed>
-        {(id) => <ProfileImage id={id} />}
+        {(id) => <ProfileImage id={id} photoUrl={props.photoUrl} />}
       </Match>
       <Match when={!props.id && props.email} keyed>
-        {(email) => <ProfileImage email={email} />}
+        {(email) => <ProfileImage email={email} photoUrl={props.photoUrl} />}
       </Match>
       <Match when={!props.id && !props.email}>
         <Avatar.Fallback class="font-semibold">?</Avatar.Fallback>
@@ -195,6 +205,7 @@ export function UserIcon(props: UserIconProps) {
             id={props.id}
             email={props.email}
             isDeleted={props.isDeleted}
+            photoUrl={props.photoUrl}
           />
         </Avatar>
       </Match>
@@ -213,6 +224,7 @@ export function UserIcon(props: UserIconProps) {
                   id={id}
                   email={props.email}
                   isDeleted={props.isDeleted}
+                  photoUrl={props.photoUrl}
                 />
               </Avatar>
             }
@@ -242,6 +254,7 @@ export function UserIcon(props: UserIconProps) {
                 id={props.id}
                 email={props.email}
                 isDeleted={props.isDeleted}
+                photoUrl={props.photoUrl}
               />
             </Avatar>
           }

--- a/js/app/packages/core/component/UserIcon.tsx
+++ b/js/app/packages/core/component/UserIcon.tsx
@@ -234,6 +234,7 @@ export function UserIcon(props: UserIconProps) {
                 email={email()}
                 id={id}
                 isDeleted={props.isDeleted}
+                photoUrl={props.photoUrl}
                 onClose={close}
               />
             )}
@@ -263,6 +264,7 @@ export function UserIcon(props: UserIconProps) {
               displayName={email() || ''}
               email={email()}
               isDeleted={props.isDeleted}
+              photoUrl={props.photoUrl}
               onClose={close}
             />
           )}

--- a/js/app/packages/core/component/UserTooltip.tsx
+++ b/js/app/packages/core/component/UserTooltip.tsx
@@ -17,6 +17,7 @@ type UserTooltipProps = {
   id?: string;
   isDeleted?: boolean;
   onClose?: () => void;
+  photoUrl?: string;
 };
 
 export function UserTooltip(props: UserTooltipProps) {
@@ -72,13 +73,13 @@ export function UserTooltip(props: UserTooltipProps) {
   // Determine avatar props based on what we have
   const avatarProps = () => {
     if (props.id) {
-      return { id: props.id } as const;
+      return { id: props.id, photoUrl: props.photoUrl } as const;
     }
     if (props.email) {
-      return { email: props.email } as const;
+      return { email: props.email, photoUrl: props.photoUrl } as const;
     }
     // Fallback - use email even if empty to satisfy the union type
-    return { email: '?' } as const;
+    return { email: '?', photoUrl: props.photoUrl } as const;
   };
 
   return (


### PR DESCRIPTION
`UserIcon` now takes an optional `photoUrl` and falls back to it when the user has no Macro profile picture (Macro profile picture > contact photo > initials). The email participant chips, collapsed message rows, and the `Message` sender avatar pass each contact's `photo_url` through, so email senders who aren't Macro users (e.g. connected inboxes) show their synced photo instead of initials.
