### PR TITLE
fix(email): polish the mobile reply input

### DIFF
--- a/js/app/packages/block-email/component/BaseInput.tsx
+++ b/js/app/packages/block-email/component/BaseInput.tsx
@@ -1430,19 +1430,26 @@ export function BaseInput(props: {
               class="flex flex-1 items-center gap-1.5 min-w-0 mt-1 text-sm text-ink-muted"
               onClick={() => setShowExpandedRecipients(true)}
             >
-              <TruncatedRecipientList
-                toRecipients={form().recipients().to}
-                ccRecipients={form().recipients().cc}
-                bccRecipients={form().recipients().bcc}
-                onClick={() => setShowExpandedRecipients(true)}
-              />
-              <Show when={(emailLinksQuery.data?.links.length ?? 0) > 1}>
-                <span class="shrink-0 text-ink-extra-muted">·</span>
-                <span class="min-w-0 shrink-[2] truncate">
-                  from {activeInboxEmail()}
-                </span>
+              <Show
+                when={!isMobile()}
+                fallback={
+                  <PencilSimple class="size-4 shrink-0 text-ink-muted ml-auto" />
+                }
+              >
+                <TruncatedRecipientList
+                  toRecipients={form().recipients().to}
+                  ccRecipients={form().recipients().cc}
+                  bccRecipients={form().recipients().bcc}
+                  onClick={() => setShowExpandedRecipients(true)}
+                />
+                <Show when={(emailLinksQuery.data?.links.length ?? 0) > 1}>
+                  <span class="shrink-0 text-ink-extra-muted">·</span>
+                  <span class="min-w-0 shrink-[2] truncate">
+                    from {activeInboxEmail()}
+                  </span>
+                </Show>
+                <PencilSimple class="size-3.5 shrink-0 text-ink-extra-muted" />
               </Show>
-              <PencilSimple class="size-3.5 shrink-0 text-ink-extra-muted" />
             </div>
           }
         >

--- a/js/app/packages/block-email/component/BaseInput.tsx
+++ b/js/app/packages/block-email/component/BaseInput.tsx
@@ -206,7 +206,7 @@ function RecipientDropRow(props: {
 
   return (
     <div
-      class={cn('flex flex-row items-center', props.class)}
+      class={cn('flex flex-row items-start min-w-0', props.class)}
       classList={{ 'bg-accent/10': isDragOver() }}
       onDragOver={handleDragOver}
       onDragLeave={handleDragLeave}
@@ -1376,7 +1376,7 @@ export function BaseInput(props: {
       solid
     >
       {/* Top Bar */}
-      <div class="relative flex items-start gap-2 px-3 pt-1.5 pb-0.5">
+      <div class="relative flex items-start gap-2 px-3 pt-1.5 pb-0.5 min-w-0">
         <Dropdown>
           <Dropdown.Trigger>
             <Switch>
@@ -1438,7 +1438,9 @@ export function BaseInput(props: {
               />
               <Show when={(emailLinksQuery.data?.links.length ?? 0) > 1}>
                 <span class="shrink-0 text-ink-extra-muted">·</span>
-                <span class="shrink-0 truncate">from {activeInboxEmail()}</span>
+                <span class="min-w-0 shrink-[2] truncate">
+                  from {activeInboxEmail()}
+                </span>
               </Show>
               <PencilSimple class="size-3.5 shrink-0 text-ink-extra-muted" />
             </div>
@@ -1446,12 +1448,12 @@ export function BaseInput(props: {
         >
           <div
             ref={setExpandedRecipientsRef}
-            class="w-full text-sm text-ink-muted"
+            class="flex-1 min-w-0 text-sm text-ink-muted"
           >
             {/* Expanded FROM */}
-            <div class="flex flex-row items-center py-0.5">
-              <div class="min-w-8">from</div>
-              <div class="pl-4 min-w-0 flex-1">
+            <div class="flex flex-row items-center py-0.5 min-w-0">
+              <div class="w-10 shrink-0">from</div>
+              <div class="pl-2 min-w-0 flex-1">
                 <FromInboxSelector
                   links={emailLinksQuery.data?.links ?? []}
                   activeLinkId={activeLinkId()}
@@ -1467,8 +1469,9 @@ export function BaseInput(props: {
               dragState={recipientDragState}
               onDrop={handleRecipientDrop}
             >
-              <div class="min-w-8">to</div>
+              <div class="w-10 shrink-0 pt-2">to</div>
               <RecipientSelector<EmailRecipient['kind']>
+                class="min-w-0"
                 inputRef={setToRef}
                 options={ctx.recipientOptions}
                 selfEmail={activeInboxEmail()}
@@ -1492,8 +1495,9 @@ export function BaseInput(props: {
                 dragState={recipientDragState}
                 onDrop={handleRecipientDrop}
               >
-                <div class="min-w-8">cc</div>
+                <div class="w-10 shrink-0 pt-2">cc</div>
                 <RecipientSelector<EmailRecipient['kind']>
+                  class="min-w-0"
                   inputRef={setCcRef}
                   options={ctx.recipientOptions}
                   selfEmail={activeInboxEmail()}
@@ -1518,8 +1522,9 @@ export function BaseInput(props: {
                 dragState={recipientDragState}
                 onDrop={handleRecipientDrop}
               >
-                <div class="min-w-8">bcc</div>
+                <div class="w-10 shrink-0 pt-2">bcc</div>
                 <RecipientSelector<EmailRecipient['kind']>
+                  class="min-w-0"
                   inputRef={setBccRef}
                   options={ctx.recipientOptions}
                   selfEmail={activeInboxEmail()}

--- a/js/app/packages/block-email/component/FromInboxSelector.tsx
+++ b/js/app/packages/block-email/component/FromInboxSelector.tsx
@@ -61,7 +61,7 @@ export function FromInboxSelector(props: {
           }
         >
           <Dropdown>
-            <Dropdown.Trigger class="gap-2 text-sm text-ink-muted">
+            <Dropdown.Trigger class="flex items-center min-w-0 max-w-full gap-2 text-sm text-ink-muted">
               <Show when={active()} keyed>
                 {(inbox) => <FromInboxOption inbox={inbox} />}
               </Show>

--- a/js/app/packages/core/component/RecipientSelector.tsx
+++ b/js/app/packages/core/component/RecipientSelector.tsx
@@ -5,6 +5,7 @@ import { toast } from '@core/component/Toast/Toast';
 import { UserIcon } from '@core/component/UserIcon';
 import { UserTooltip } from '@core/component/UserTooltip';
 import { useEmail, useUserId } from '@core/context/user';
+import { isMobile } from '@core/mobile/isMobile';
 import {
   type CombinedRecipientItem,
   type CombinedRecipientKind,
@@ -511,7 +512,7 @@ export function RecipientSelector<K extends CombinedRecipientKind>(
         onInputChange={onInputChange}
         shouldFocusWrap
         placeholder={
-          props.selectedOptions?.length === 0
+          props.selectedOptions?.length === 0 || isMobile()
             ? (props.placeholder ?? placeholderText())
             : undefined
         }


### PR DESCRIPTION
Polishes the mobile email reply input: the expanded recipients block was fixed at full width and couldn't shrink, so the from/to fields and cc/bcc buttons overflowed off-screen and collided with the reply button. Let the rows shrink and truncate, align the from/to/cc labels to one column, surface the "select more recipients" affordance on mobile (the input was otherwise an invisible target), and reduce the cramped collapsed summary to a single edit button on mobile.
