### PR TITLE
chore(ci): faster localdev iteration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -357,6 +357,8 @@ services:
       dockerfile: Dockerfile
     ports:
       - "8787:8787"
+    volumes:
+      - ./rust/sync-service/src:/app/src
     environment:
       - INTERNAL_API_SECRET_KEY=${INTERNAL_API_SECRET_KEY}
       - DOCUMENT_PERMISSIONS_SECRET=${DOCUMENT_PERMISSION_JWT_SECRET_KEY}
@@ -402,6 +404,24 @@ services:
       retries: 3
       start_period: 10s
 
+  # ============================================================================
+  # rust-builder
+  # Persistent Rust toolchain container for hot-swap dev rebuilds.
+  # Source is mounted in; compiled artifacts live in the rust_dev_target volume.
+  # Usage: just dev-rebuild <service>
+  # ============================================================================
+  rust-builder:
+    image: rust:latest
+    working_dir: /app
+    volumes:
+      - ./rust/cloud-storage:/app
+      - rust_dev_target:/app/target
+      - ~/.cargo/registry:/usr/local/cargo/registry
+      - ~/.cargo/git:/usr/local/cargo/git
+    environment:
+      SQLX_OFFLINE: "true"
+    command: tail -f /dev/null
+
 networks:
   services:
     driver: bridge
@@ -409,3 +429,6 @@ networks:
     external: true
   auth:
     external: true
+
+volumes:
+  rust_dev_target:

--- a/js/app/packages/app/vite.base.ts
+++ b/js/app/packages/app/vite.base.ts
@@ -186,6 +186,10 @@ export const createAppViteConfig = (): UserConfigFn => {
           host: process.env.TAURI_DEV_HOST || 'localhost',
         },
         cors: true,
+        proxy: {
+          // always redirect root to /app
+          '^/$': { target: 'http://localhost:3000', rewrite: () => '/app' },
+        },
         watch: {
           usePolling: true,
           interval: 100,

--- a/justfile
+++ b/justfile
@@ -196,3 +196,31 @@ setup:
 destroy:
   just infra/stacks/fusionauth-instance/destroy
   docker compose down -v
+
+dev-rebuild service:
+  #!/usr/bin/env bash
+  set -euo pipefail
+
+  container="macro-{{ service }}-1"
+
+  if [ "{{ service }}" = "sync_service" ]; then
+    echo "==> Building sync_service wasm inside container..."
+    docker exec "$container" worker-build --release
+    docker restart "$container"
+  else
+    bin=$(docker inspect "$container" | jq -r '.[0].Config.Cmd[0]' | xargs basename)
+
+    echo "==> Building $bin (incremental)..."
+    docker exec macro-rust-builder-1 cargo build --bin "$bin"
+
+    echo "==> Copying binary into $container..."
+    tmp=$(mktemp)
+    docker cp "macro-rust-builder-1:/app/target/debug/$bin" "$tmp"
+    docker cp "$tmp" "$container:/app/out/$bin"
+    rm "$tmp"
+
+    echo "==> Restarting $container..."
+    docker restart "$container"
+  fi
+
+  echo "==> Done. $container is live with the new binary."

--- a/justfile
+++ b/justfile
@@ -211,6 +211,7 @@ dev-rebuild service:
     bin=$(docker inspect "$container" | jq -r '.[0].Config.Cmd[0]' | xargs basename)
 
     echo "==> Building $bin (incremental)..."
+    docker compose up rust-builder -d --wait 2>/dev/null || true
     docker exec macro-rust-builder-1 cargo build --bin "$bin"
 
     echo "==> Copying binary into $container..."


### PR DESCRIPTION
Add a just command to rebuild + swap the binary so you don't have to totally rebuild the container. Also make vite / redirect to /app

Note that we are doing all the builds in a "builder" container so that we know that they can run in our containers (e.g. I use nix, my nix binaries will not run in our not nix containers)