### PR TITLE
feat: share public docs with users mentioned in comments

### DIFF
--- a/rust/cloud-storage/.sqlx/query-ab7417eb79789bfff9a6084c7881191a9b0ee849745041e1fecc7e4ba9b4fc5d.json
+++ b/rust/cloud-storage/.sqlx/query-ab7417eb79789bfff9a6084c7881191a9b0ee849745041e1fecc7e4ba9b4fc5d.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        INSERT INTO entity_access (entity_id, entity_type, source_id, source_type, access_level)\n        SELECT dp.\"documentId\"::uuid, 'document', u.user_id, 'user', sp.\"publicAccessLevel\"::\"AccessLevel\"\n        FROM \"DocumentPermission\" dp\n        JOIN \"SharePermission\" sp ON sp.id = dp.\"sharePermissionId\"\n        CROSS JOIN UNNEST($2::text[]) AS u(user_id)\n        WHERE dp.\"documentId\" = $1\n          AND sp.\"isPublic\" = true\n          AND sp.\"publicAccessLevel\" IS NOT NULL\n        ON CONFLICT (entity_id, entity_type, source_id, source_type)\n        WHERE granted_from_project_id IS NULL\n        DO NOTHING\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "TextArray"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "ab7417eb79789bfff9a6084c7881191a9b0ee849745041e1fecc7e4ba9b4fc5d"
+}

--- a/rust/cloud-storage/document_storage_service/src/api/annotations/create_comment.rs
+++ b/rust/cloud-storage/document_storage_service/src/api/annotations/create_comment.rs
@@ -150,6 +150,19 @@ pub async fn create_comment_handler(
                 if let Some(Mentions { mention_id, .. }) = &req.mentions
                     && !recipients.mention_recipients.is_empty()
                 {
+                    // If the document is public, grant the mentioned users access so
+                    // the comment surfaces in their soup/inbox — a notification alone
+                    // isn't enough for the document to appear there.
+                    let mention_recipients: Vec<MacroUserIdStr<'_>> =
+                        recipients.mention_recipients.iter().cloned().collect();
+                    _ = macro_db_client::annotations::share_on_mention::share_public_document_with_mentioned_users(
+                        &db,
+                        &document_id,
+                        &mention_recipients,
+                    )
+                    .await
+                    .inspect_err(|e| tracing::error!(error =? e, "couldn't share public document with mentioned users"));
+
                     let request = notif_ctx
                         .build_mention_notif(recipients.mention_recipients, mention_id)
                         .into_request()

--- a/rust/cloud-storage/document_storage_service/src/api/annotations/edit_comment.rs
+++ b/rust/cloud-storage/document_storage_service/src/api/annotations/edit_comment.rs
@@ -82,10 +82,23 @@ pub async fn edit_comment_handler(
                     sender_profile_picture_url,
                 };
 
-                let recipient_ids = users
+                let recipient_ids: std::collections::HashSet<MacroUserIdStr<'static>> = users
                     .iter()
                     .filter_map(|id| MacroUserIdStr::try_from(id.clone()).ok())
                     .collect();
+
+                // If the document is public, grant the mentioned users access so
+                // the comment surfaces in their soup/inbox — a notification alone
+                // isn't enough for the document to appear there.
+                let mention_recipients: Vec<MacroUserIdStr<'_>> =
+                    recipient_ids.iter().cloned().collect();
+                _ = macro_db_client::annotations::share_on_mention::share_public_document_with_mentioned_users(
+                    &db,
+                    &res.document_id,
+                    &mention_recipients,
+                )
+                .await
+                .inspect_err(|e| tracing::error!(error =? e, "couldn't share public document with mentioned users"));
 
                 let request = notif_ctx
                     .build_mention_notif(recipient_ids, &mention_id)

--- a/rust/cloud-storage/macro_db_client/fixtures/share_on_mention.sql
+++ b/rust/cloud-storage/macro_db_client/fixtures/share_on_mention.sql
@@ -1,0 +1,52 @@
+-- Fixture for share_on_mention tests: a public document and a private document,
+-- each with a SharePermission/DocumentPermission link. Document ids are real
+-- UUIDs because entity_access.entity_id is a UUID column.
+
+INSERT INTO public."Organization" ("id", "name")
+VALUES (1, 'organization-one');
+
+INSERT INTO public."macro_user" ("id", "username", "email", "stripe_customer_id")
+VALUES ('a1111111-1111-1111-1111-111111111111', 'owner', 'owner@user.com', 'stripe_owner');
+
+INSERT INTO public."User" ("id", "email", "stripeCustomerId", "organizationId", "macro_user_id")
+VALUES (
+    'macro|owner@user.com',
+    'owner@user.com',
+    'stripe_owner',
+    1,
+    'a1111111-1111-1111-1111-111111111111'
+);
+
+-- Public document (anyone can comment).
+INSERT INTO public."Document" ("id", "name", "fileType", "owner", "createdAt", "updatedAt")
+VALUES (
+    '11111111-1111-1111-1111-111111111111',
+    'Public Doc',
+    'pdf',
+    'macro|owner@user.com',
+    '2022-01-01 00:00:00',
+    '2022-01-01 00:00:00'
+);
+
+INSERT INTO public."SharePermission" ("id", "isPublic", "publicAccessLevel", "createdAt", "updatedAt")
+VALUES ('sp-public', true, 'comment', '2022-01-01 00:00:00', '2022-01-01 00:00:00');
+
+INSERT INTO public."DocumentPermission" ("documentId", "sharePermissionId")
+VALUES ('11111111-1111-1111-1111-111111111111', 'sp-public');
+
+-- Private document (not public).
+INSERT INTO public."Document" ("id", "name", "fileType", "owner", "createdAt", "updatedAt")
+VALUES (
+    '22222222-2222-2222-2222-222222222222',
+    'Private Doc',
+    'pdf',
+    'macro|owner@user.com',
+    '2022-01-01 00:00:00',
+    '2022-01-01 00:00:00'
+);
+
+INSERT INTO public."SharePermission" ("id", "isPublic", "publicAccessLevel", "createdAt", "updatedAt")
+VALUES ('sp-private', false, NULL, '2022-01-01 00:00:00', '2022-01-01 00:00:00');
+
+INSERT INTO public."DocumentPermission" ("documentId", "sharePermissionId")
+VALUES ('22222222-2222-2222-2222-222222222222', 'sp-private');

--- a/rust/cloud-storage/macro_db_client/src/annotations/mod.rs
+++ b/rust/cloud-storage/macro_db_client/src/annotations/mod.rs
@@ -9,6 +9,7 @@ pub mod delete_thread;
 pub mod edit_anchor;
 pub mod edit_comment;
 pub mod get;
+pub mod share_on_mention;
 
 #[derive(Error, Debug)]
 pub enum CommentError {

--- a/rust/cloud-storage/macro_db_client/src/annotations/share_on_mention.rs
+++ b/rust/cloud-storage/macro_db_client/src/annotations/share_on_mention.rs
@@ -1,0 +1,67 @@
+//! Auto-share a public document with users mentioned in its comments.
+//!
+//! When a user is `@mentioned` in a document comment we notify them, but being
+//! notified isn't enough for the document to surface in their soup/inbox — that
+//! requires an explicit `entity_access` row. For **public** documents we grant
+//! the mentioned users access at the document's public access level so the
+//! mention is actionable from their inbox. Private documents are left untouched
+//! so a mention can't silently widen access beyond what was already public.
+
+use macro_user_id::user_id::MacroUserIdStr;
+use sqlx::{Pool, Postgres};
+
+#[cfg(test)]
+mod test;
+
+/// Grants the mentioned users `entity_access` to the document when it is public,
+/// so the document appears in their soup.
+///
+/// No-op when the document isn't public or no users are supplied. Existing
+/// access rows are never downgraded (conflicts are ignored), and the owner row
+/// is left intact.
+#[tracing::instrument(
+    skip(db, mentioned_user_ids),
+    fields(document_id = %document_id, user_count = mentioned_user_ids.len()),
+    err
+)]
+pub async fn share_public_document_with_mentioned_users(
+    db: &Pool<Postgres>,
+    document_id: &str,
+    mentioned_user_ids: &[MacroUserIdStr<'_>],
+) -> anyhow::Result<()> {
+    if mentioned_user_ids.is_empty() {
+        return Ok(());
+    }
+
+    let user_ids: Vec<String> = mentioned_user_ids
+        .iter()
+        .map(|id| id.as_ref().to_string())
+        .collect();
+
+    // Insert one access row per mentioned user, but only when the document is
+    // public — the join against `SharePermission` yields no rows otherwise, so
+    // the whole statement becomes a no-op for private documents. We grant the
+    // same level the document is public at, and `DO NOTHING` ensures we never
+    // clobber a user's pre-existing (possibly higher) access.
+    sqlx::query!(
+        r#"
+        INSERT INTO entity_access (entity_id, entity_type, source_id, source_type, access_level)
+        SELECT dp."documentId"::uuid, 'document', u.user_id, 'user', sp."publicAccessLevel"::"AccessLevel"
+        FROM "DocumentPermission" dp
+        JOIN "SharePermission" sp ON sp.id = dp."sharePermissionId"
+        CROSS JOIN UNNEST($2::text[]) AS u(user_id)
+        WHERE dp."documentId" = $1
+          AND sp."isPublic" = true
+          AND sp."publicAccessLevel" IS NOT NULL
+        ON CONFLICT (entity_id, entity_type, source_id, source_type)
+        WHERE granted_from_project_id IS NULL
+        DO NOTHING
+        "#,
+        document_id,
+        user_ids.as_slice(),
+    )
+    .execute(db)
+    .await?;
+
+    Ok(())
+}

--- a/rust/cloud-storage/macro_db_client/src/annotations/share_on_mention/test.rs
+++ b/rust/cloud-storage/macro_db_client/src/annotations/share_on_mention/test.rs
@@ -1,0 +1,109 @@
+use super::*;
+
+const PUBLIC_DOC: &str = "11111111-1111-1111-1111-111111111111";
+const PRIVATE_DOC: &str = "22222222-2222-2222-2222-222222222222";
+
+async fn access_level_for(
+    pool: &Pool<Postgres>,
+    document_id: &str,
+    source_id: &str,
+) -> Option<String> {
+    let entity_id = macro_uuid::string_to_uuid(document_id).unwrap();
+    sqlx::query_scalar!(
+        r#"
+        SELECT access_level::text as "access_level!"
+        FROM entity_access
+        WHERE entity_id = $1
+          AND entity_type = 'document'
+          AND source_type = 'user'
+          AND source_id = $2
+        "#,
+        entity_id,
+        source_id,
+    )
+    .fetch_optional(pool)
+    .await
+    .unwrap()
+}
+
+#[sqlx::test(fixtures(path = "../../../fixtures", scripts("share_on_mention")))]
+async fn shares_public_document_with_mentioned_users(pool: Pool<Postgres>) -> anyhow::Result<()> {
+    let mentioned = MacroUserIdStr::try_from("macro|mentioned@user.com".to_string()).unwrap();
+
+    share_public_document_with_mentioned_users(&pool, PUBLIC_DOC, std::slice::from_ref(&mentioned))
+        .await?;
+
+    // The mentioned user gets access at the document's public access level.
+    assert_eq!(
+        access_level_for(&pool, PUBLIC_DOC, mentioned.as_ref()).await,
+        Some("comment".to_string()),
+    );
+
+    Ok(())
+}
+
+#[sqlx::test(fixtures(path = "../../../fixtures", scripts("share_on_mention")))]
+async fn does_not_share_private_document(pool: Pool<Postgres>) -> anyhow::Result<()> {
+    let mentioned = MacroUserIdStr::try_from("macro|mentioned@user.com".to_string()).unwrap();
+
+    share_public_document_with_mentioned_users(
+        &pool,
+        PRIVATE_DOC,
+        std::slice::from_ref(&mentioned),
+    )
+    .await?;
+
+    // Private documents are left untouched — no access is granted.
+    assert_eq!(
+        access_level_for(&pool, PRIVATE_DOC, mentioned.as_ref()).await,
+        None,
+    );
+
+    Ok(())
+}
+
+#[sqlx::test(fixtures(path = "../../../fixtures", scripts("share_on_mention")))]
+async fn does_not_downgrade_existing_access(pool: Pool<Postgres>) -> anyhow::Result<()> {
+    let mentioned = MacroUserIdStr::try_from("macro|mentioned@user.com".to_string()).unwrap();
+    let entity_id = macro_uuid::string_to_uuid(PUBLIC_DOC).unwrap();
+
+    // The user already has edit access to the public document.
+    sqlx::query!(
+        r#"
+        INSERT INTO entity_access (entity_id, entity_type, source_id, source_type, access_level)
+        VALUES ($1, 'document', $2, 'user', 'edit')
+        "#,
+        entity_id,
+        mentioned.as_ref(),
+    )
+    .execute(&pool)
+    .await?;
+
+    share_public_document_with_mentioned_users(&pool, PUBLIC_DOC, std::slice::from_ref(&mentioned))
+        .await?;
+
+    // The pre-existing (higher) access level is preserved, not clobbered.
+    assert_eq!(
+        access_level_for(&pool, PUBLIC_DOC, mentioned.as_ref()).await,
+        Some("edit".to_string()),
+    );
+
+    Ok(())
+}
+
+#[sqlx::test(fixtures(path = "../../../fixtures", scripts("share_on_mention")))]
+async fn empty_recipients_is_a_noop(pool: Pool<Postgres>) -> anyhow::Result<()> {
+    let entity_id = macro_uuid::string_to_uuid(PUBLIC_DOC).unwrap();
+    share_public_document_with_mentioned_users(&pool, PUBLIC_DOC, &[]).await?;
+
+    let count = sqlx::query_scalar!(
+        r#"SELECT COUNT(*) as "count!" FROM entity_access WHERE entity_id = $1"#,
+        entity_id,
+    )
+    .fetch_one(&pool)
+    .await?;
+
+    assert_eq!(count, 0);
+
+    Ok(())
+}


### PR DESCRIPTION
## Problem

@mentioning a user in a document comment notifies them, but the document never shows up in their soup/inbox unless the doc has been explicitly shared with them. The notification surfaces in the feed, but the mentioned doc isn't discoverable/actionable from soup because that requires an explicit `entity_access` row — which a public doc doesn't grant on its own.

## Fix

When a user is @mentioned in a document comment, also grant them access so the doc surfaces in their soup — scoped to **public documents**:

- New helper `macro_db_client::annotations::share_on_mention::share_public_document_with_mentioned_users` — a single `INSERT … SELECT` that:
  - Only inserts when the doc is public (`SharePermission.isPublic = true`); private docs are a no-op, so a mention can't silently widen access beyond what was already public.
  - Grants each mentioned user the document's `publicAccessLevel`.
  - `ON CONFLICT … DO NOTHING`, so a user's pre-existing (possibly higher) access is never downgraded.
- Wired into both `create_comment` and `edit_comment` handlers alongside the existing mention-notification send. Failures are logged, not fatal.

## Tests

Added `sqlx` tests covering: public doc grants access at the public level, private doc is a no-op, existing `edit` access isn't downgraded, and empty recipients is a no-op.

https://claude.ai/code/session_01UtKyaUnjC6PZgpEQHxSNsT

---
_Generated by [Claude Code](https://claude.ai/code/session_01UtKyaUnjC6PZgpEQHxSNsT)_