### PR TITLE
fix(email): verify child email_links row before graph edge in /email/init

### DIFF
--- a/rust/cloud-storage/email_service/src/api/email/init.rs
+++ b/rust/cloud-storage/email_service/src/api/email/init.rs
@@ -154,34 +154,46 @@ pub async fn handler(
         if let Some(child_macro_id) = existing_owner.as_deref()
             && child_macro_id != user_context.user_id
         {
-            // Graph path: link primary (caller) → child so primary can read child's inbox.
-            macro_db_client::macro_user_links::insert_edge(
-                &ctx.db,
-                &user_context.user_id,
-                child_macro_id,
-            )
-            .await
-            .context("Failed to insert macro_user_links edge")?;
-
-            macro_db_client::in_progress_user_link::delete_in_progress_user_link(&ctx.db, &link_id)
-                .await
-                .inspect_err(|e| {
-                    tracing::error!(error=?e, ?link_id, "Failed to delete in_progress_user_link after graph delegation");
-                })
-                .ok();
-
+            // Verify the child has actually connected an inbox before mutating any state.
+            // Looking this up first means a missing email_links row fails cleanly, without
+            // leaving a dangling edge or consuming the in_progress row with no recovery path.
             let child_link = email_db_client::links::get::fetch_link_by_email(
                 &ctx.db,
                 &linked_email,
                 link::UserProvider::Gmail,
             )
             .await
-            .context("Failed to look up child link after delegation")?
+            .context("Failed to look up child link before delegation")?
             .ok_or_else(|| {
-                InitError::BadRequest(
-                    "child macro user exists but has no email_links row".to_string(),
-                )
+                InitError::BadRequest("child has not connected their inbox yet".to_string())
             })?;
+
+            // Graph path: link primary (caller) → child so primary can read child's inbox.
+            // The edge insert and in_progress consumption are a coupled pair, so commit them
+            // atomically: any failure rolls back, leaving the in_progress row for a retry.
+            let mut tx = ctx
+                .db
+                .begin()
+                .await
+                .context("Failed to begin graph delegation transaction")?;
+
+            macro_db_client::macro_user_links::insert_edge(
+                &mut *tx,
+                &user_context.user_id,
+                child_macro_id,
+            )
+            .await
+            .context("Failed to insert macro_user_links edge")?;
+
+            macro_db_client::in_progress_user_link::delete_in_progress_user_link(
+                &mut *tx, &link_id,
+            )
+            .await
+            .context("Failed to delete in_progress_user_link after graph delegation")?;
+
+            tx.commit()
+                .await
+                .context("Failed to commit graph delegation transaction")?;
 
             return Ok((
                 StatusCode::OK,

--- a/rust/cloud-storage/macro_db_client/src/in_progress_user_link.rs
+++ b/rust/cloud-storage/macro_db_client/src/in_progress_user_link.rs
@@ -47,10 +47,10 @@ pub async fn create_in_progress_user_link(
     Ok(link_id)
 }
 
-pub async fn delete_in_progress_user_link(
-    db: &sqlx::Pool<sqlx::Postgres>,
-    link_id: &uuid::Uuid,
-) -> anyhow::Result<()> {
+pub async fn delete_in_progress_user_link<'e, E>(db: E, link_id: &uuid::Uuid) -> anyhow::Result<()>
+where
+    E: sqlx::Executor<'e, Database = sqlx::Postgres>,
+{
     sqlx::query!(
         r#"
             DELETE FROM

--- a/rust/cloud-storage/macro_db_client/src/macro_user_links.rs
+++ b/rust/cloud-storage/macro_db_client/src/macro_user_links.rs
@@ -2,7 +2,7 @@
 //! read another macro user's inbox without merging identities. The "what" of the
 //! delegation is implicit — primary may read child's email_links rows.
 
-use sqlx::{Pool, Postgres};
+use sqlx::{Executor, Pool, Postgres};
 
 #[cfg(test)]
 mod test;
@@ -10,11 +10,14 @@ mod test;
 /// Insert an edge `(primary, child)`. Idempotent: if the edge already exists
 /// the conflict is swallowed.
 #[tracing::instrument(skip(db), err)]
-pub async fn insert_edge(
-    db: &Pool<Postgres>,
+pub async fn insert_edge<'e, E>(
+    db: E,
     primary_macro_id: &str,
     child_macro_id: &str,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<()>
+where
+    E: Executor<'e, Database = Postgres>,
+{
     sqlx::query!(
         r#"
             INSERT INTO macro_user_links (primary_macro_id, child_macro_id)

--- a/rust/cloud-storage/macro_db_client/src/macro_user_links/test.rs
+++ b/rust/cloud-storage/macro_db_client/src/macro_user_links/test.rs
@@ -118,6 +118,22 @@ async fn delete_edges_for_child_removes_all_grants(pool: Pool<Postgres>) -> anyh
 }
 
 #[sqlx::test]
+async fn insert_edge_within_transaction_commits(pool: Pool<Postgres>) -> anyhow::Result<()> {
+    insert_user(&pool, "macro|primary@x.com").await?;
+    insert_user(&pool, "macro|child@x.com").await?;
+
+    let mut tx = pool.begin().await?;
+    insert_edge(&mut *tx, "macro|primary@x.com", "macro|child@x.com").await?;
+    // Not visible outside the transaction until commit.
+    assert!(!edge_exists(&pool, "macro|primary@x.com", "macro|child@x.com").await?);
+    tx.commit().await?;
+
+    assert!(edge_exists(&pool, "macro|primary@x.com", "macro|child@x.com").await?);
+
+    Ok(())
+}
+
+#[sqlx::test]
 async fn self_referential_edge_rejected(pool: Pool<Postgres>) -> anyhow::Result<()> {
     insert_user(&pool, "macro|primary@x.com").await?;
 


### PR DESCRIPTION
The `/email/init` graph path inserted the delegation edge and deleted the in_progress row before checking whether the child had an `email_links` row, so a child who never connected their inbox got a 400 only after that state was already written, with no recovery path. Reorder so the child link is verified first (returning `400 "child has not connected their inbox yet"`), then write the edge + delete the in_progress row inside a single transaction.

Task: 019e938d-e7da-709e-b20e-3dc447c3b073
