### PR TITLE
fix(email): stop backspace from deselecting an inbox in the selector

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/inbox-selector.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/inbox-selector.tsx
@@ -64,6 +64,7 @@ export function InboxSelector() {
         onChange={onChange}
         placeholder="Search inboxes..."
         preserveOrder
+        removeOnBackspace={false}
       >
         <Combobox.Trigger
           as={Button}

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/inbox-selector.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/inbox-selector.tsx
@@ -64,7 +64,6 @@ export function InboxSelector() {
         onChange={onChange}
         placeholder="Search inboxes..."
         preserveOrder
-        removeOnBackspace={false}
       >
         <Combobox.Trigger
           as={Button}

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/searchable-multi-select.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/searchable-multi-select.tsx
@@ -34,8 +34,6 @@ type SearchableMultiSelectProps = {
   listboxClass?: string;
   /** Keep `options` in their given order instead of pinning selected first. */
   preserveOrder?: boolean;
-  /** Forwarded to Combobox; defaults to kobalte's `true` when omitted. */
-  removeOnBackspace?: boolean;
   open?: Accessor<boolean>;
   onOpenChange?: (open: boolean) => void;
   children: JSX.Element;
@@ -179,7 +177,7 @@ export const SearchableMultiSelect = (props: SearchableMultiSelectProps) => {
       optionLabel="label"
       allowsEmptyCollection
       virtualized
-      removeOnBackspace={props.removeOnBackspace}
+      removeOnBackspace={false}
       placement={props.placement ?? 'bottom-start'}
       gutter={props.gutter ?? 4}
     >
@@ -311,6 +309,7 @@ export const SearchableMultiSelectInline = (
       optionLabel="label"
       allowsEmptyCollection
       virtualized
+      removeOnBackspace={false}
     >
       <div class="flex items-center gap-2 px-3 py-2 border-b border-edge-muted">
         <SearchIcon class="size-3.5 text-ink-muted shrink-0" />

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/searchable-multi-select.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/searchable-multi-select.tsx
@@ -34,6 +34,8 @@ type SearchableMultiSelectProps = {
   listboxClass?: string;
   /** Keep `options` in their given order instead of pinning selected first. */
   preserveOrder?: boolean;
+  /** Forwarded to Combobox; defaults to kobalte's `true` when omitted. */
+  removeOnBackspace?: boolean;
   open?: Accessor<boolean>;
   onOpenChange?: (open: boolean) => void;
   children: JSX.Element;
@@ -177,6 +179,7 @@ export const SearchableMultiSelect = (props: SearchableMultiSelectProps) => {
       optionLabel="label"
       allowsEmptyCollection
       virtualized
+      removeOnBackspace={props.removeOnBackspace}
       placement={props.placement ?? 'bottom-start'}
       gutter={props.gutter ?? 4}
     >


### PR DESCRIPTION
In the mail inbox selector, pressing Backspace with the search box empty no longer unchecks the last inbox — kobalte combobox's `removeOnBackspace` is now disabled for that menu (other filter menus are unchanged).