### PR TITLE
fix(soup): return notification-backed items to list on undo mark-done

### DIFF
--- a/js/app/packages/app/component/next-soup/actions/make-mark-done-action.ts
+++ b/js/app/packages/app/component/next-soup/actions/make-mark-done-action.ts
@@ -59,6 +59,7 @@ export const makeMarkDoneAction = (options: MakeMarkDoneOptions) => {
     hotkeyGroup,
     onMutate: (variables) =>
       applyEntitiesDoneOptimistic({
+        entityIds: variables.entities.map((entity) => entity.id),
         emailIds: variables.emailIds,
         notificationIds: variables.notificationIds,
       }),

--- a/js/app/packages/app/component/next-soup/utils.ts
+++ b/js/app/packages/app/component/next-soup/utils.ts
@@ -35,6 +35,8 @@ import { notificationKeys } from '@queries/notification/keys';
 import {
   bulkMarkNotificationsAsDone,
   bulkMarkNotificationsAsUndone,
+  restoreUserNotifications,
+  snapshotUserNotifications,
 } from '@queries/notification/user-notifications';
 import {
   getSoupEntityById,
@@ -649,11 +651,19 @@ export function resolveMarkEntitiesDoneVariables(args: {
  * override. Returns a context the mutation uses for rollback / reapply.
  */
 export function applyEntitiesDoneOptimistic(args: {
+  entityIds: string[];
   emailIds: string[];
   notificationIds: string[];
 }): MarkEntitiesDoneContext {
-  const { emailIds, notificationIds } = args;
+  const { entityIds, emailIds, notificationIds } = args;
   const emailIdSet = new Set(emailIds);
+  const entityIdSet = new Set(entityIds);
+
+  // Snapshot the affected notifications before marking done. A done
+  // notification gets dropped from the cache (status-update event or a stale
+  // refetch), so undo re-adds it here so the soup `notDoneFilter` predicate
+  // lets the restored entity through again.
+  const notificationSnapshots = snapshotUserNotifications(notificationIds);
 
   type EmailQueryKey = readonly unknown[];
   type EmailCacheData = { pages: { items: EntityData[] }[] };
@@ -716,7 +726,10 @@ export function applyEntitiesDoneOptimistic(args: {
   let soupTxn: ReturnType<typeof removeSoupEntities> | null = null;
 
   const reapply = () => {
-    soupTxn = emailIds.length > 0 ? removeSoupEntities(emailIdSet) : null;
+    // Remove every marked entity from the soup feed cache so the hide is
+    // authoritative for all types; undo restores them via this transaction's
+    // rollback.
+    soupTxn = entityIds.length > 0 ? removeSoupEntities(entityIdSet) : null;
     filterEmailCache();
     setDoneOverride(notificationIds, true);
   };
@@ -732,6 +745,7 @@ export function applyEntitiesDoneOptimistic(args: {
     soupTxn?.rollback();
     soupTxn = null;
     restoreEmailCache();
+    restoreUserNotifications(notificationSnapshots);
     // Force `done=false` — cache may have reconciled to `done=true` from the
     // server, so clearing the override would leave the UI hidden after undo.
     setDoneOverride(notificationIds, false);

--- a/js/app/packages/queries/notification/user-notifications.ts
+++ b/js/app/packages/queries/notification/user-notifications.ts
@@ -553,6 +553,66 @@ function notificationEntityTypeToSoupTag(
     .exhaustive();
 }
 
+/**
+ * Snapshot the cached notification objects for the given ids. The returned
+ * items can later be put back via `restoreUserNotifications`. Optimistic
+ * mark-done flows rely on this so undo can resurrect notifications that get
+ * dropped from the cache once the server confirms the done — whether by the
+ * `notification_status_updated` event or a stale refetch. A plain `done`
+ * override can't overlay a notification that is no longer in the cache.
+ */
+export function snapshotUserNotifications(ids: string[]): NotificationItem[] {
+  if (ids.length === 0) return [];
+  const idSet = new Set(ids);
+  const found = new Map<string, NotificationItem>();
+  for (const [, data] of queryClient.getQueriesData<
+    NotificationData<UserNotificationsPageParam>
+  >({ queryKey: notificationKeys.user._def })) {
+    if (!data) continue;
+    for (const page of data.pages) {
+      for (const notification of page.items) {
+        if (idSet.has(notification.id) && !found.has(notification.id)) {
+          found.set(notification.id, notification);
+        }
+      }
+    }
+  }
+  return [...found.values()];
+}
+
+/**
+ * Re-insert snapshotted notifications that are no longer in the cache (e.g.
+ * dropped after a mark-done was confirmed), marking each not-done so it
+ * re-enters not-done filtered views. Notifications still present are left
+ * untouched.
+ */
+export function restoreUserNotifications(notifications: NotificationItem[]) {
+  if (notifications.length === 0) return;
+  queryClient.setQueriesData<NotificationData<UserNotificationsPageParam>>(
+    { queryKey: notificationKeys.user._def },
+    (data) => {
+      if (!data) return data;
+      const present = new Set(
+        data.pages.flatMap((page) => page.items.map((n) => n.id))
+      );
+      const missing = notifications
+        .filter((n) => !present.has(n.id))
+        .map((n) => ({ ...n, done: false }));
+      if (missing.length === 0) return data;
+      return {
+        ...data,
+        pages: data.pages.map((page, index) =>
+          index === 0 ? { ...page, items: [...missing, ...page.items] } : page
+        ),
+      };
+    }
+  );
+  queryClient.invalidateQueries({
+    queryKey: notificationKeys.user._def,
+    refetchType: 'none',
+  });
+}
+
 export function optimisticInsertNotification(
   notification: UnifiedNotification
 ) {


### PR DESCRIPTION
Marking a notification-backed item (channel/chat/doc) done only flipped a notification `done` overlay and relied on `notDoneFilter` to hide it; once the server confirmed, a sync event cleared the overlay and a stale notification refetch re-inserted the item not-done, re-adding it to the soup feed before the user could even undo. Now mark-done removes every marked entity from the soup feed cache (authoritative, the way emails already worked) and undo restores it via the cache rollback plus a notification re-insert so it passes `notDoneFilter` again.
