### PR TITLE
fix(multi-inbox): don't flash contact photoUrl while macro pic loads

### DIFF
--- a/js/app/packages/core/component/UserIcon.tsx
+++ b/js/app/packages/core/component/UserIcon.tsx
@@ -86,8 +86,13 @@ function ProfileImage(props: {
 
   const [profilePicUrl] = useProfilePictureUrl(props.id);
 
-  // Macro profile picture wins; fall back to a contact photo before initials.
-  const imageUrl = () => profilePicUrl() || props.photoUrl;
+  const imageUrl = () => {
+    const macro = profilePicUrl();
+    // Still loading: show initials; don't flash the contact photo.
+    if (macro === undefined) return undefined;
+    // Resolved: macro pic wins, then contact photo, then initials.
+    return macro || props.photoUrl;
+  };
 
   return (
     <Show

--- a/js/app/packages/core/signal/profilePicture.ts
+++ b/js/app/packages/core/signal/profilePicture.ts
@@ -39,10 +39,13 @@ function queueItemsForFetch(items: string[]) {
   setProfilePictureFetchQueue((prev) => [...prev, ...items]);
 }
 
-function defaultUrlTransform(item: ProfilePictureItem): string | undefined {
-  if (item.loading) return;
+/** `undefined` while loading, `null` once resolved with no picture, otherwise the URL. */
+type ProfilePictureUrl = string | null | undefined;
 
-  return item.url;
+function defaultUrlTransform(item: ProfilePictureItem): ProfilePictureUrl {
+  if (item.loading) return undefined;
+
+  return item.url ?? null;
 }
 
 async function fetchProfilePictures(
@@ -66,7 +69,7 @@ async function fetchProfilePictures(
 }
 
 type ProfilePictureUrlFetcher = [
-  Accessor<string | undefined>,
+  Accessor<ProfilePictureUrl>,
   {
     refetch: () => void;
     mutate: (value: ProfilePictureItem) => void;
@@ -98,7 +101,7 @@ async function batchFetchProfilePictures(ids: string[]) {
 export function useProfilePictureUrl(id?: string): ProfilePictureUrlFetcher {
   if (!id) {
     const dummy_accessor = () => {
-      return '';
+      return null;
     };
 
     const dummy_controls = {


### PR DESCRIPTION
`useProfilePictureUrl` conflated loading with absent (both returned `undefined`), so `UserIcon` fell back to the contact `photoUrl` on first paint before the macro fetch resolved, flashing the Gmail contact photo. The accessor is now tri-state — `undefined` while loading, `null` when confirmed absent, otherwise the url — and `UserIcon` renders initials during the load, only falling back to `photoUrl` once the macro fetch resolves with no picture.

Closes task `019e944c-5dff-7519-9d2f-357d2be5e7be`.
