### PR TITLE
fix(email): notify delegated primaries of new emails in shared inboxes

### DIFF
--- a/rust/cloud-storage/.sqlx/query-a577fec197448ea02b8378cc0ddca6fc4fcfc26228c3d3f8f055702598616a64.json
+++ b/rust/cloud-storage/.sqlx/query-a577fec197448ea02b8378cc0ddca6fc4fcfc26228c3d3f8f055702598616a64.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT primary_macro_id\n            FROM macro_user_links\n            WHERE child_macro_id = $1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "primary_macro_id",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "a577fec197448ea02b8378cc0ddca6fc4fcfc26228c3d3f8f055702598616a64"
+}

--- a/rust/cloud-storage/email_service/src/pubsub/inbox_sync/operations/upsert_message.rs
+++ b/rust/cloud-storage/email_service/src/pubsub/inbox_sync/operations/upsert_message.rs
@@ -571,20 +571,31 @@ async fn send_notifications(
         snippet: message.snippet.unwrap_or_default(),
     };
 
-    let macro_id_str = link.macro_id.to_string();
-    let recipient = MacroUserIdStr::parse_from_str(&macro_id_str).map_err(|e| {
-        ProcessingError::NonRetryable(DetailedError {
-            reason: FailureReason::InvalidData,
-            source: anyhow::anyhow!("failed to parse macro user id: {}", e),
-        })
-    })?;
+    let mut recipient_ids: HashSet<MacroUserIdStr<'static>> =
+        HashSet::from([link.macro_id.clone()]);
+
+    let primaries =
+        macro_db_client::macro_user_links::get_primaries_for_child(&ctx.db, link.macro_id.as_ref())
+            .await
+            .map_err(|e| {
+                ProcessingError::Retryable(DetailedError {
+                    reason: FailureReason::DatabaseQueryFailed,
+                    source: e.context("Failed to fetch delegated primaries".to_string()),
+                })
+            })?;
+
+    recipient_ids.extend(
+        primaries
+            .into_iter()
+            .filter_map(|p| MacroUserIdStr::try_from(p).ok()),
+    );
 
     let request = SendNotificationRequestBuilder {
         notification_entity: EntityType::EmailThread
             .with_entity_string(message.thread_db_id.to_string()),
         notification,
         sender_id,
-        recipient_ids: HashSet::from([recipient]),
+        recipient_ids,
     }
     .into_request()
     .with_conn_gateway();

--- a/rust/cloud-storage/email_service/src/pubsub/inbox_sync/operations/upsert_message.rs
+++ b/rust/cloud-storage/email_service/src/pubsub/inbox_sync/operations/upsert_message.rs
@@ -34,6 +34,9 @@ use std::result;
 use std::sync::Arc;
 use uuid::Uuid;
 
+#[cfg(test)]
+mod test;
+
 // upsert a message into the db. could be a new message or an existing one that had changes
 #[tracing::instrument(skip(ctx))]
 pub async fn upsert_message(

--- a/rust/cloud-storage/email_service/src/pubsub/inbox_sync/operations/upsert_message.rs
+++ b/rust/cloud-storage/email_service/src/pubsub/inbox_sync/operations/upsert_message.rs
@@ -571,9 +571,6 @@ async fn send_notifications(
         snippet: message.snippet.unwrap_or_default(),
     };
 
-    let mut recipient_ids: HashSet<MacroUserIdStr<'static>> =
-        HashSet::from([link.macro_id.clone()]);
-
     let primaries =
         macro_db_client::macro_user_links::get_primaries_for_child(&ctx.db, link.macro_id.as_ref())
             .await
@@ -584,11 +581,7 @@ async fn send_notifications(
                 })
             })?;
 
-    recipient_ids.extend(
-        primaries
-            .into_iter()
-            .filter_map(|p| MacroUserIdStr::try_from(p).ok()),
-    );
+    let recipient_ids = build_notification_recipients(&link.macro_id, primaries);
 
     let request = SendNotificationRequestBuilder {
         notification_entity: EntityType::EmailThread
@@ -609,6 +602,30 @@ async fn send_notifications(
     }
 
     Ok(())
+}
+
+fn build_notification_recipients(
+    owner: &MacroUserIdStr<'static>,
+    primaries: Vec<String>,
+) -> HashSet<MacroUserIdStr<'static>> {
+    let mut recipient_ids = HashSet::from([owner.clone()]);
+
+    for primary in primaries {
+        match MacroUserIdStr::try_from(primary) {
+            Ok(id) => {
+                recipient_ids.insert(id);
+            }
+            Err(e) => {
+                tracing::warn!(
+                    error=?e,
+                    inbox_owner=%owner,
+                    "skipping delegated primary that failed to parse as a macro user id"
+                );
+            }
+        }
+    }
+
+    recipient_ids
 }
 
 // filter out messages we don't want to send notifications for

--- a/rust/cloud-storage/email_service/src/pubsub/inbox_sync/operations/upsert_message/test.rs
+++ b/rust/cloud-storage/email_service/src/pubsub/inbox_sync/operations/upsert_message/test.rs
@@ -1,0 +1,51 @@
+use super::*;
+
+fn id(s: &str) -> MacroUserIdStr<'static> {
+    MacroUserIdStr::try_from(s.to_string()).unwrap()
+}
+
+#[test]
+fn includes_owner_and_all_delegated_primaries() {
+    let owner = id("macro|owner@x.com");
+    let recipients = build_notification_recipients(
+        &owner,
+        vec![
+            "macro|primary-a@x.com".to_string(),
+            "macro|primary-b@x.com".to_string(),
+        ],
+    );
+
+    assert_eq!(
+        recipients,
+        HashSet::from([
+            owner,
+            id("macro|primary-a@x.com"),
+            id("macro|primary-b@x.com"),
+        ])
+    );
+}
+
+#[test]
+fn returns_only_owner_when_no_primaries() {
+    let owner = id("macro|owner@x.com");
+    let recipients = build_notification_recipients(&owner, vec![]);
+
+    assert_eq!(recipients, HashSet::from([owner]));
+}
+
+#[test]
+fn skips_unparseable_primaries_keeping_valid_ones() {
+    let owner = id("macro|owner@x.com");
+    let recipients = build_notification_recipients(
+        &owner,
+        vec![
+            "macro|primary-a@x.com".to_string(),
+            "not-a-valid-id".to_string(),
+        ],
+    );
+
+    assert_eq!(
+        recipients,
+        HashSet::from([owner, id("macro|primary-a@x.com")])
+    );
+}

--- a/rust/cloud-storage/macro_db_client/src/macro_user_links.rs
+++ b/rust/cloud-storage/macro_db_client/src/macro_user_links.rs
@@ -122,3 +122,25 @@ pub async fn children_for_primary(
 
     Ok(rows)
 }
+
+/// Returns the `primary_macro_id`s delegated to read the given child's inboxes.
+/// Inverse of [`children_for_primary`]; used to fan a child inbox's notifications
+/// out to every primary that can view it.
+#[tracing::instrument(skip(db), err)]
+pub async fn get_primaries_for_child(
+    db: &Pool<Postgres>,
+    child_macro_id: &str,
+) -> anyhow::Result<Vec<String>> {
+    let rows = sqlx::query_scalar!(
+        r#"
+            SELECT primary_macro_id
+            FROM macro_user_links
+            WHERE child_macro_id = $1
+        "#,
+        child_macro_id
+    )
+    .fetch_all(db)
+    .await?;
+
+    Ok(rows)
+}

--- a/rust/cloud-storage/macro_db_client/src/macro_user_links/test.rs
+++ b/rust/cloud-storage/macro_db_client/src/macro_user_links/test.rs
@@ -118,6 +118,40 @@ async fn delete_edges_for_child_removes_all_grants(pool: Pool<Postgres>) -> anyh
 }
 
 #[sqlx::test]
+async fn get_primaries_for_child_returns_all_grantees(pool: Pool<Postgres>) -> anyhow::Result<()> {
+    insert_user(&pool, "macro|primary-a@x.com").await?;
+    insert_user(&pool, "macro|primary-b@x.com").await?;
+    insert_user(&pool, "macro|owner@x.com").await?;
+    insert_user(&pool, "macro|lonely@x.com").await?;
+
+    insert_edge(&pool, "macro|primary-a@x.com", "macro|owner@x.com").await?;
+    insert_edge(&pool, "macro|primary-b@x.com", "macro|owner@x.com").await?;
+
+    let mut primaries = get_primaries_for_child(&pool, "macro|owner@x.com").await?;
+    primaries.sort();
+    assert_eq!(
+        primaries,
+        vec!["macro|primary-a@x.com", "macro|primary-b@x.com"]
+    );
+
+    // A child nobody delegates from yields no primaries.
+    assert!(
+        get_primaries_for_child(&pool, "macro|lonely@x.com")
+            .await?
+            .is_empty()
+    );
+
+    // Direction matters: querying a primary as if it were a child returns nothing.
+    assert!(
+        get_primaries_for_child(&pool, "macro|primary-a@x.com")
+            .await?
+            .is_empty()
+    );
+
+    Ok(())
+}
+
+#[sqlx::test]
 async fn insert_edge_within_transaction_commits(pool: Pool<Postgres>) -> anyhow::Result<()> {
     insert_user(&pool, "macro|primary@x.com").await?;
     insert_user(&pool, "macro|child@x.com").await?;


### PR DESCRIPTION
New emails arriving at a delegated (shared) inbox only notified the inbox owner's macro_id, so primaries delegated via `macro_user_links` never received the `new_email` WS event. `send_notifications` now unions the owner with every primary returned by the new `macro_user_links::get_primaries_for_child`. The companion frontend fix (`019e947b-4f71-74e6-85a8-59802c7ab161`) is still needed for the primary's inbox to update without a refresh.
