### PR TITLE
fix(email): refetch new email thread on WS notification

### DIFF
--- a/js/app/packages/queries/notification/tests/user-notifications.test.tsx
+++ b/js/app/packages/queries/notification/tests/user-notifications.test.tsx
@@ -31,9 +31,15 @@ vi.mock('@service-notification/client', () => ({
 
 vi.mock('@queries/soup/normalized-cache', () => ({
   optimisticUpdateSoupItemUpdatedAt: vi.fn(),
+  hasSoupEntity: vi.fn(() => false),
+  refetchSoupEntity: vi.fn(),
 }));
 
-import { optimisticUpdateSoupItemUpdatedAt } from '@queries/soup/normalized-cache';
+import {
+  hasSoupEntity,
+  optimisticUpdateSoupItemUpdatedAt,
+  refetchSoupEntity,
+} from '@queries/soup/normalized-cache';
 import { notificationServiceClient } from '@service-notification/client';
 
 const mockBulkMarkNotificationAsSeen = vi.mocked(
@@ -45,6 +51,8 @@ const mockBulkMarkNotificationAsDone = vi.mocked(
 const mockOptimisticUpdateSoupItemUpdatedAt = vi.mocked(
   optimisticUpdateSoupItemUpdatedAt
 );
+const mockHasSoupEntity = vi.mocked(hasSoupEntity);
+const mockRefetchSoupEntity = vi.mocked(refetchSoupEntity);
 
 let testQueryClient: QueryClient;
 
@@ -417,6 +425,7 @@ describe('optimisticInsertNotification', () => {
   });
 
   it('should insert notification at the beginning of the first page', () => {
+    mockHasSoupEntity.mockReturnValue(true);
     const n1 = createMockNotification({ id: 'n1' });
     const n2 = createMockNotification({ id: 'n2' });
     seedQueryCache([createMockNotificationPage([n1, n2])]);
@@ -434,6 +443,7 @@ describe('optimisticInsertNotification', () => {
       'document',
       newNotification.created_at
     );
+    expect(mockRefetchSoupEntity).not.toHaveBeenCalled();
   });
 
   it('should not insert duplicate notifications', () => {
@@ -450,7 +460,8 @@ describe('optimisticInsertNotification', () => {
     expect(notifications[1].id).toBe('n2');
   });
 
-  it('should map email notifications to emailThread soup tag', () => {
+  it('should bump the updatedAt of an already-cached email thread', () => {
+    mockHasSoupEntity.mockReturnValue(true);
     seedQueryCache([createMockNotificationPage([])]);
 
     const emailNotification = createMockNotification({
@@ -466,9 +477,30 @@ describe('optimisticInsertNotification', () => {
       'emailThread',
       '2024-01-01T00:00:00.000Z'
     );
+    expect(mockRefetchSoupEntity).not.toHaveBeenCalled();
   });
 
-  it('should skip soup update when notification has no created_at', () => {
+  it('should refetch a brand-new soup entity that is not cached', () => {
+    mockHasSoupEntity.mockReturnValue(false);
+    seedQueryCache([createMockNotificationPage([])]);
+
+    const emailNotification = createMockNotification({
+      entity_type: 'email_thread',
+      entity_id: 'thread-1',
+      created_at: '2024-01-01T00:00:00.000Z',
+    });
+
+    optimisticInsertNotification(emailNotification);
+
+    expect(mockRefetchSoupEntity).toHaveBeenCalledWith(
+      'thread-1',
+      'emailThread'
+    );
+    expect(mockOptimisticUpdateSoupItemUpdatedAt).not.toHaveBeenCalled();
+  });
+
+  it('should skip the timestamp bump when a cached entity has no created_at', () => {
+    mockHasSoupEntity.mockReturnValue(true);
     seedQueryCache([createMockNotificationPage([])]);
 
     const notificationWithoutCreatedAt = createMockNotification({
@@ -478,6 +510,7 @@ describe('optimisticInsertNotification', () => {
     optimisticInsertNotification(notificationWithoutCreatedAt);
 
     expect(mockOptimisticUpdateSoupItemUpdatedAt).not.toHaveBeenCalled();
+    expect(mockRefetchSoupEntity).not.toHaveBeenCalled();
   });
 
   it('should skip soup update for unsupported entity types', () => {
@@ -491,5 +524,6 @@ describe('optimisticInsertNotification', () => {
     optimisticInsertNotification(userNotification);
 
     expect(mockOptimisticUpdateSoupItemUpdatedAt).not.toHaveBeenCalled();
+    expect(mockRefetchSoupEntity).not.toHaveBeenCalled();
   });
 });

--- a/js/app/packages/queries/notification/user-notifications.ts
+++ b/js/app/packages/queries/notification/user-notifications.ts
@@ -2,7 +2,9 @@ import type { Maybe } from '@core/types';
 import { type ResultError, throwOnErr } from '@core/util/result';
 import type { UnifiedNotification } from '@notifications/types';
 import {
+  hasSoupEntity,
   optimisticUpdateSoupItemUpdatedAt,
+  refetchSoupEntity,
   type SoupEntityTag,
 } from '@queries/soup/normalized-cache';
 import { type MutationCallbacks, withCallbacks } from '@queries/utils';
@@ -578,12 +580,18 @@ export function optimisticInsertNotification(
     }
   );
 
-  if (soupTag && notification.created_at) {
-    optimisticUpdateSoupItemUpdatedAt(
-      notification.entity_id,
-      soupTag,
-      notification.created_at
-    );
+  if (soupTag) {
+    if (hasSoupEntity(notification.entity_id)) {
+      if (notification.created_at) {
+        optimisticUpdateSoupItemUpdatedAt(
+          notification.entity_id,
+          soupTag,
+          notification.created_at
+        );
+      }
+    } else {
+      refetchSoupEntity(notification.entity_id, soupTag);
+    }
   }
 
   // Cache is already updated via setQueriesData above. Mark as stale without

--- a/js/app/packages/queries/soup/transform-utils.ts
+++ b/js/app/packages/queries/soup/transform-utils.ts
@@ -448,6 +448,19 @@ const resolveDocumentEntityName = (
   });
 };
 
+/**
+ * The email soup query encodes "no sort timestamp" — e.g. a never-viewed thread
+ * under the `viewed_at` sort — as the Unix epoch. Map it to `undefined` so each
+ * soup view's sort and the row date fall back to their own column
+ * (`updatedAt`/`createdAt`/`viewedAt`) instead of pinning the thread to 1970.
+ */
+function normalizeSentinelTs(
+  ts: string | null | undefined
+): string | undefined {
+  if (!ts) return undefined;
+  return Date.parse(ts) > 0 ? ts : undefined;
+}
+
 export const mapSoupPageToEntityList: (
   data: SoupPage,
   options: {
@@ -536,7 +549,7 @@ export const mapSoupPageToEntityList: (
             ...item.data,
             createdAt: item.data.createdAt,
             updatedAt: item.data.updatedAt,
-            sortTs: item.data.sortTs,
+            sortTs: normalizeSentinelTs(item.data.sortTs),
             senderEmail: item.data.senderEmail ?? undefined,
             senderName: item.data.senderName ?? undefined,
             snippet: item.data.snippet ?? undefined,


### PR DESCRIPTION
When a `new_email` WS notification arrives for a thread not already in the soup cache, refetch it so brand-new threads show up in the inbox/email list without a manual refresh (previously the optimistic timestamp bump no-opped on uncached entities). Also normalizes the email `sortTs` epoch sentinel to `undefined` so a never-viewed thread sorts/displays by the active view's own column (updated/created/viewed) instead of being pinned to 1970.

Task: https://macro.com/app/task/019e947b-4f71-74e6-85a8-59802c7ab161

🤖 Generated with [Claude Code](https://claude.com/claude-code)
