### PR TITLE
remove doppler token

### DIFF
--- a/infra/stacks/authentication-service/Pulumi.dev.yaml
+++ b/infra/stacks/authentication-service/Pulumi.dev.yaml
@@ -26,5 +26,4 @@ config:
   authentication-service:meta_access_token: meta-access-token
   authentication-service:posthog_host: https://us.i.posthog.com
   authentication-service:posthog_api_key: posthog-api-key
-  authentication-service:doppler_token_key: doppler-token-authentication-service-dev
   authentication-service:doppler_secret_sync_key: /doppler/authentication-service/dev

--- a/infra/stacks/authentication-service/Pulumi.prod.yaml
+++ b/infra/stacks/authentication-service/Pulumi.prod.yaml
@@ -26,5 +26,4 @@ config:
   authentication-service:meta_access_token: meta-access-token
   authentication-service:posthog_host: https://us.i.posthog.com
   authentication-service:posthog_api_key: posthog-api-key
-  authentication-service:doppler_token_key: doppler-token-authentication-service-prod
   authentication-service:doppler_secret_sync_key: /doppler/authentication-service/prod

--- a/infra/stacks/authentication-service/index.ts
+++ b/infra/stacks/authentication-service/index.ts
@@ -19,10 +19,6 @@ const tags = {
   project: 'authentication-service',
 };
 
-const dopplerTokenArn: pulumi.Output<string> = aws.secretsmanager
-  .getSecretVersionOutput({ secretId: config.require('doppler_token_key') })
-  .apply((secret) => secret.arn);
-
 const dopplerSecretSyncArn: pulumi.Output<string> = aws.secretsmanager
   .getSecretVersionOutput({
     secretId: config.require('doppler_secret_sync_key'),
@@ -160,10 +156,6 @@ const service = new AuthenticationService('authentication-service', {
     },
   ],
   containerSecrets: [
-    {
-      name: 'DOPPLER_TOKEN',
-      valueFrom: pulumi.interpolate`${dopplerTokenArn}`,
-    },
     {
       name: 'APP_SECRETS_JSON',
       valueFrom: pulumi.interpolate`${dopplerSecretSyncArn}`,


### PR DESCRIPTION
The doppler token is no longer needed as we inject our config in secrets into the container