### PR TITLE
feat: loading indicator when switching soup tabs on mobile

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/soup-view-context.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-view-context.tsx
@@ -68,6 +68,12 @@ type DataSource<T> = {
   data: Accessor<T[]>;
   isLoading: Accessor<boolean>;
   isFetching: Accessor<boolean>;
+  /**
+   * True while the query is showing placeholder data from a previous query
+   * key (e.g. the prior tab's rows) and fetching the real results. Used to
+   * surface a loading indicator when switching between soup tabs.
+   */
+  isPlaceholderData: Accessor<boolean>;
   isFetchingNextPage: Accessor<boolean>;
   hasNextPage: Accessor<boolean>;
   fetchNextPage: VoidFunction;
@@ -596,6 +602,8 @@ export const SoupViewContextProvider: FlowComponent<
       data: entities,
       isLoading: () => itemsQuery.isLoading,
       isFetching: () => itemsQuery.isFetching || searchQuery.isFetching,
+      isPlaceholderData: () =>
+        itemsQuery.isPlaceholderData && !search.isSearching(),
       isFetchingNextPage: () =>
         itemsQuery.isFetchingNextPage || searchQuery.isFetchingNextPage,
       hasNextPage: () => {

--- a/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
@@ -237,6 +237,18 @@ const DefaultGroupHeader = (
   );
 };
 
+/**
+ * Thin indeterminate progress bar shown at the top of the mobile soup list
+ * while a new tab's query loads. Switching tabs keeps the previous tab's rows
+ * on screen (placeholder data), so without this the user gets no feedback that
+ * the new soup query is still in flight.
+ */
+const MobileTabLoadingBar = () => (
+  <div class="pointer-events-none absolute inset-x-0 top-0 z-10 h-0.5 overflow-hidden bg-accent/10">
+    <div class="h-full w-2/5 rounded-full bg-accent animate-indeterminate-bar" />
+  </div>
+);
+
 const useSoupNotificationInvalidators = () => {
   const notificationSource = useGlobalNotificationSource();
   const entityQueryClient = useQueryClient();
@@ -1040,11 +1052,14 @@ export const SoupViewList = (props: SoupViewListProps) => {
           >
             <div
               class={cn(
-                '@container/u-list size-full unified-list-root flex flex-col',
+                '@container/u-list size-full unified-list-root flex flex-col relative',
                 soup.previewEntity() !== undefined &&
                   'border-r border-edge-muted'
               )}
             >
+              <Show when={isMobile() && source.isPlaceholderData()}>
+                <MobileTabLoadingBar />
+              </Show>
               <StaticMarkdownContext>
                 <Switch>
                   <Match when={source.isLoading() && !rows().length}>

--- a/js/app/packages/app/index.css
+++ b/js/app/packages/app/index.css
@@ -183,7 +183,7 @@
   --animate-slide-in: slideIn 150ms cubic-bezier(0.16, 1, 0.3, 1);
   --animate-typing-dot: typing-dot 1s infinite;
   --animate-swipe-out: swipeOut 100ms ease-out;
-  --animate-indeterminate-bar: indeterminateBar 1.1s ease-in-out infinite;
+  --animate-indeterminate-bar: indeterminate-bar 1.1s ease-in-out infinite;
 
   --z-index-modal-overlay: 100;
   --z-index-modal:         110;
@@ -306,7 +306,7 @@
   100% { transform: scale(1)   translateY(0   ); }
 }
 
-@keyframes indeterminateBar {
+@keyframes indeterminate-bar {
   0%   { transform: translateX(-100%); }
   100% { transform: translateX(350%); }
 }

--- a/js/app/packages/app/index.css
+++ b/js/app/packages/app/index.css
@@ -183,6 +183,7 @@
   --animate-slide-in: slideIn 150ms cubic-bezier(0.16, 1, 0.3, 1);
   --animate-typing-dot: typing-dot 1s infinite;
   --animate-swipe-out: swipeOut 100ms ease-out;
+  --animate-indeterminate-bar: indeterminateBar 1.1s ease-in-out infinite;
 
   --z-index-modal-overlay: 100;
   --z-index-modal:         110;
@@ -303,6 +304,11 @@
   0%   { transform: scale(1)   translateY(0   ); }
   50%  { transform: scale(1.5) translateY(-2px); }
   100% { transform: scale(1)   translateY(0   ); }
+}
+
+@keyframes indeterminateBar {
+  0%   { transform: translateX(-100%); }
+  100% { transform: translateX(350%); }
 }
 
 @keyframes long-press-accent-bar {


### PR DESCRIPTION
## Problem

Switching soup tabs on mobile (e.g. Inbox → Sent) can take several seconds to load, with no feedback. The soup items query uses `placeholderData: (p) => p`, so the previous tab's rows stay on screen while the new query fetches. That keeps `rows().length > 0`, so the existing `LoadingBlock` — which only renders when there are no rows — never appeared.

## Fix

- Expose `isPlaceholderData` on the soup view data source — true precisely when the query is showing a prior tab's placeholder rows while fetching the new tab's results (and not during search).
- Render a thin indeterminate progress bar pinned to the top of the list on mobile while `isPlaceholderData` is true.
- Add the `indeterminate-bar` keyframe/animation token driving the bar.

Scoped to mobile and to the tab-switch case: first-ever load still shows the full `LoadingBlock` skeleton (no double indicator), and re-visiting an already-cached fresh tab shows nothing (instant).

https://claude.ai/code/session_01Ktt5Fa79MHZHrX8oRSobN6

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ktt5Fa79MHZHrX8oRSobN6)_