### PR TITLE
fix: clean up multi-inbox settings toast and optimistic add/remove

### DIFF
--- a/js/app/packages/app/component/EmailAuth.tsx
+++ b/js/app/packages/app/component/EmailAuth.tsx
@@ -115,7 +115,11 @@ function EmailLinkCallback(props: Pick<EmailAuthParams, 'successPath'>) {
       }
 
       await initEmailLink({ linkId }).match(
-        () => {
+        async () => {
+          // Pull the newly-provisioned link into the cache before leaving the
+          // callback so the inbox panel shows it immediately on return rather
+          // than flashing a stale list until its own refetch lands.
+          await query.refetch();
           toast.success('Inbox connected');
           navigateToSuccess();
         },

--- a/js/app/packages/app/component/settings/Account.tsx
+++ b/js/app/packages/app/component/settings/Account.tsx
@@ -59,6 +59,7 @@ import PaywallTeamOwnerView from '../paywall/PaywallTeamOwnerView';
 import { ROUTER_BASE_CONCAT } from '@app/constants/routerBase';
 import { useEmailLinks, useEmailLinksStatus } from '@core/email-link';
 import { useInitGmailLink } from '@queries/auth';
+import { useRemoveInboxMutation } from '@queries/email/link';
 import {
   type SupportedNotificationSettings,
   useNotificationSettings,
@@ -142,9 +143,12 @@ export function Account() {
   const {
     query: emailLinksQuery,
     disconnect: disconnectEmail,
-    removeInbox,
     resyncInbox,
   } = useEmailLinks();
+  const removeInboxMutation = useRemoveInboxMutation({
+    onSuccess: () => toast.success('Inbox removed'),
+    onError: () => toast.failure('Failed to remove inbox. Please try again.'),
+  });
   const [removeTarget, setRemoveTarget] = createSignal<{
     id: string;
     email: string;
@@ -218,14 +222,11 @@ export function Account() {
     });
   };
 
-  const handleRemoveInbox = async () => {
+  const handleRemoveInbox = () => {
     const target = removeTarget();
     if (!target) return;
     setRemoveTarget(null);
-    await removeInbox(target.id).match(
-      () => toast.success('Inbox removed'),
-      () => toast.failure('Failed to remove inbox. Please try again.')
-    );
+    removeInboxMutation.mutate(target.id);
   };
 
   const [githubLinkStatus, { refetch: refetchGithubLinkStatus }] =

--- a/js/app/packages/app/component/settings/Account.tsx
+++ b/js/app/packages/app/component/settings/Account.tsx
@@ -223,13 +223,7 @@ export function Account() {
     if (!target) return;
     setRemoveTarget(null);
     await removeInbox(target.id).match(
-      () => {
-        toast.success(
-          target.isOwn
-            ? 'Inbox removed — clearing its data, this may take a moment.'
-            : 'Inbox removed.'
-        );
-      },
+      () => toast.success('Inbox removed'),
       () => toast.failure('Failed to remove inbox. Please try again.')
     );
   };

--- a/js/app/packages/core/email-link/index.ts
+++ b/js/app/packages/core/email-link/index.ts
@@ -7,12 +7,7 @@ import {
 import { openEmailAuthPopup } from '@core/auth/email';
 
 import { invalidateUserInfo } from '@queries/auth/user-info';
-import {
-  invalidateEmailLinks,
-  removeEmailLinkFromCache,
-  restoreEmailLinksCache,
-  useEmailLinksQuery,
-} from '@queries/email/link';
+import { invalidateEmailLinks, useEmailLinksQuery } from '@queries/email/link';
 import { emailClient } from '@service-email/client';
 import type {
   ListLinksResponse,
@@ -122,20 +117,6 @@ function disconnectEmail(): ResultAsync<void, 'failed-to-disconnect'> {
 }
 
 /**
- * Removes a linked inbox. For an owned inbox the backend cascades the full
- * teardown; for a delegated inbox it only drops the delegation edge.
- *
- * @returns ok if the inbox was removed, err if it failed
- */
-function removeInbox(linkId: string): ResultAsync<void, 'failed-to-remove'> {
-  return ResultAsync.fromSafePromise(
-    emailClient.deleteLink({ linkId })
-  ).andThen((response) =>
-    response.isErr() ? err('failed-to-remove') : okAsync(void 0)
-  );
-}
-
-/**
  * Enqueues a fresh backfill for a linked inbox. Idempotent on the backend: a
  * no-op when a backfill is already in progress.
  *
@@ -202,12 +183,6 @@ export function useEmailLinks() {
         .map(startEmailPolling)
         .andTee(invalidations),
     disconnect: () => disconnectEmail().andTee(invalidations),
-    removeInbox: (linkId: string) => {
-      const snapshot = removeEmailLinkFromCache(linkId);
-      return removeInbox(linkId)
-        .andTee(invalidations)
-        .orTee(() => restoreEmailLinksCache(snapshot));
-    },
     resyncInbox: (linkId: string) =>
       resyncInbox(linkId).andTee(() => invalidateEmailLinks()),
     invalidate: () => invalidateEmailLinks(),

--- a/js/app/packages/core/email-link/index.ts
+++ b/js/app/packages/core/email-link/index.ts
@@ -7,7 +7,12 @@ import {
 import { openEmailAuthPopup } from '@core/auth/email';
 
 import { invalidateUserInfo } from '@queries/auth/user-info';
-import { invalidateEmailLinks, useEmailLinksQuery } from '@queries/email/link';
+import {
+  invalidateEmailLinks,
+  removeEmailLinkFromCache,
+  restoreEmailLinksCache,
+  useEmailLinksQuery,
+} from '@queries/email/link';
 import { emailClient } from '@service-email/client';
 import type {
   ListLinksResponse,
@@ -197,7 +202,12 @@ export function useEmailLinks() {
         .map(startEmailPolling)
         .andTee(invalidations),
     disconnect: () => disconnectEmail().andTee(invalidations),
-    removeInbox: (linkId: string) => removeInbox(linkId).andTee(invalidations),
+    removeInbox: (linkId: string) => {
+      const snapshot = removeEmailLinkFromCache(linkId);
+      return removeInbox(linkId)
+        .andTee(invalidations)
+        .orTee(() => restoreEmailLinksCache(snapshot));
+    },
     resyncInbox: (linkId: string) =>
       resyncInbox(linkId).andTee(() => invalidateEmailLinks()),
     invalidate: () => invalidateEmailLinks(),

--- a/js/app/packages/queries/email/link.ts
+++ b/js/app/packages/queries/email/link.ts
@@ -2,6 +2,7 @@ import { useEmail } from '@core/context/user';
 import { throwOnErr } from '@core/util/result';
 import { queryClient } from '@queries/client';
 import { emailClient } from '@service-email/client';
+import type { ListLinksResponse } from '@service-email/generated/schemas';
 import { useQuery } from '@tanstack/solid-query';
 import { createMemo } from 'solid-js';
 import { emailKeys } from './keys';
@@ -51,4 +52,38 @@ export function invalidateEmailLinks() {
   queryClient.invalidateQueries({
     queryKey: emailKeys.links.queryKey,
   });
+}
+
+/**
+ * Optimistically drops a link from the cached links list and returns the prior
+ * cache value so the caller can roll back if the server delete fails.
+ */
+export function removeEmailLinkFromCache(
+  linkId: string
+): ListLinksResponse | undefined {
+  queryClient.cancelQueries({ queryKey: emailKeys.links.queryKey });
+  const previous = queryClient.getQueryData<ListLinksResponse>(
+    emailKeys.links.queryKey
+  );
+  queryClient.setQueryData<ListLinksResponse>(
+    emailKeys.links.queryKey,
+    (current) =>
+      current && {
+        ...current,
+        links: current.links.filter((link) => link.id !== linkId),
+      }
+  );
+  return previous;
+}
+
+/**
+ * Restores a previously snapshotted links cache, e.g. to roll back an
+ * optimistic removal after the server delete fails.
+ */
+export function restoreEmailLinksCache(
+  snapshot: ListLinksResponse | undefined
+) {
+  if (snapshot) {
+    queryClient.setQueryData(emailKeys.links.queryKey, snapshot);
+  }
 }

--- a/js/app/packages/queries/email/link.ts
+++ b/js/app/packages/queries/email/link.ts
@@ -1,4 +1,3 @@
-import { updateUserAuth } from '@core/auth';
 import { useEmail } from '@core/context/user';
 import { throwOnErr } from '@core/util/result';
 import { invalidateUserInfo } from '@queries/auth/user-info';
@@ -102,8 +101,11 @@ export function useRemoveInboxMutation(callbacks?: RemoveInboxCallbacks) {
         },
 
         onSuccess: async () => {
-          invalidateEmailLinks();
-          await updateUserAuth();
+          // Owned inboxes are torn down asynchronously, so the row still appears
+          // in GET /email/links for a short window after the 204. Refetching links
+          // here would resurrect the optimistically-removed row; instead leave the
+          // optimistic cache in place and let the next focus refetch reconcile once
+          // teardown completes.
           await invalidateUserInfo();
         },
 

--- a/js/app/packages/queries/email/link.ts
+++ b/js/app/packages/queries/email/link.ts
@@ -1,10 +1,13 @@
+import { updateUserAuth } from '@core/auth';
 import { useEmail } from '@core/context/user';
 import { throwOnErr } from '@core/util/result';
+import { invalidateUserInfo } from '@queries/auth/user-info';
 import { queryClient } from '@queries/client';
 import { emailClient } from '@service-email/client';
 import type { ListLinksResponse } from '@service-email/generated/schemas';
-import { useQuery } from '@tanstack/solid-query';
+import { useMutation, useQuery } from '@tanstack/solid-query';
 import { createMemo } from 'solid-js';
+import { type MutationCallbacks, withCallbacks } from '../utils';
 import { emailKeys } from './keys';
 
 const LINK_STALE_TIME = 5 * 60 * 1000;
@@ -54,36 +57,66 @@ export function invalidateEmailLinks() {
   });
 }
 
-/**
- * Optimistically drops a link from the cached links list and returns the prior
- * cache value so the caller can roll back if the server delete fails.
- */
-export function removeEmailLinkFromCache(
-  linkId: string
-): ListLinksResponse | undefined {
-  queryClient.cancelQueries({ queryKey: emailKeys.links.queryKey });
-  const previous = queryClient.getQueryData<ListLinksResponse>(
-    emailKeys.links.queryKey
-  );
-  queryClient.setQueryData<ListLinksResponse>(
-    emailKeys.links.queryKey,
-    (current) =>
-      current && {
-        ...current,
-        links: current.links.filter((link) => link.id !== linkId),
-      }
-  );
-  return previous;
-}
+type RemoveInboxContext = { previousLinks: ListLinksResponse | undefined };
+type RemoveInboxCallbacks = MutationCallbacks<
+  void,
+  Error,
+  string,
+  RemoveInboxContext
+>;
 
 /**
- * Restores a previously snapshotted links cache, e.g. to roll back an
- * optimistic removal after the server delete fails.
+ * Removes a linked inbox, optimistically dropping its row from the cached links
+ * list so the change is reflected immediately. Rolls the cache back on failure
+ * and reconciles with the server on success.
  */
-export function restoreEmailLinksCache(
-  snapshot: ListLinksResponse | undefined
-) {
-  if (snapshot) {
-    queryClient.setQueryData(emailKeys.links.queryKey, snapshot);
-  }
+export function useRemoveInboxMutation(callbacks?: RemoveInboxCallbacks) {
+  return useMutation(() => ({
+    mutationFn: async (linkId: string) => {
+      await throwOnErr(() => emailClient.deleteLink({ linkId }));
+    },
+
+    ...withCallbacks<void, Error, string, RemoveInboxContext>(
+      {
+        onMutate: async (linkId) => {
+          await queryClient.cancelQueries({
+            queryKey: emailKeys.links.queryKey,
+          });
+
+          const previousLinks = queryClient.getQueryData<ListLinksResponse>(
+            emailKeys.links.queryKey
+          );
+
+          queryClient.setQueryData<ListLinksResponse>(
+            emailKeys.links.queryKey,
+            (old) =>
+              old
+                ? {
+                    ...old,
+                    links: old.links.filter((link) => link.id !== linkId),
+                  }
+                : undefined
+          );
+
+          return { previousLinks };
+        },
+
+        onSuccess: async () => {
+          invalidateEmailLinks();
+          await updateUserAuth();
+          await invalidateUserInfo();
+        },
+
+        onError: (_error, _linkId, context) => {
+          if (context?.previousLinks) {
+            queryClient.setQueryData(
+              emailKeys.links.queryKey,
+              context.previousLinks
+            );
+          }
+        },
+      },
+      callbacks
+    ),
+  }));
 }


### PR DESCRIPTION
Shortens the inbox-removal toast to "Inbox removed" and makes the inbox settings panel optimistic: removals drop the row immediately and roll back (with the existing error toast) on failure, and the add flow primes the links cache on OAuth return so the new inbox shows without waiting for a refetch.

Leaves the FA IdP unlink path untouched (handled in the sibling remove_link task).
