### PR TITLE
feat: suppress user affordances on inbox-only linked-child contacts

### DIFF
--- a/js/app/packages/core/component/UserIcon.tsx
+++ b/js/app/packages/core/component/UserIcon.tsx
@@ -8,6 +8,7 @@ import {
   tryMacroId,
   useDisplayName,
   useDisplayNameParts,
+  useIsInboxOnlyLinkedChild,
 } from '@core/user';
 import MacroLogo from '@icon/macro-logo.svg';
 import Trash from '@phosphor-icons/core/regular/trash.svg?component-solid';
@@ -160,9 +161,10 @@ export function UserIcon(props: UserIconProps) {
 
   const { replaceOrInsertSplit } = useSplitLayout();
   const getOrCreateDmMutation = useGetOrCreateDirectMessageMutation();
+  const isInboxOnlyLinkedChild = useIsInboxOnlyLinkedChild();
 
   const getOrCreateDm = () => {
-    if (!props.id) return;
+    if (!props.id || isInboxOnlyLinkedChild(props.id)) return;
     getOrCreateDmMutation.mutate(
       { recipient_id: props.id },
       {

--- a/js/app/packages/core/component/UserTooltip.tsx
+++ b/js/app/packages/core/component/UserTooltip.tsx
@@ -1,6 +1,7 @@
 import { useSplitLayout } from '@app/component/split-layout/layout';
 import { toast } from '@core/component/Toast/Toast';
 import { useUserId } from '@core/context/user';
+import { useIsInboxOnlyLinkedChild } from '@core/user';
 import WideChat from '@icon/wide-chat.svg';
 import WideCopy from '@icon/wide-copy.svg';
 import WideTask from '@icon/wide-task.svg';
@@ -35,6 +36,9 @@ export function UserTooltip(props: UserTooltipProps) {
     props.onClose?.();
   }
   const currentUserId = useUserId();
+  const isInboxOnlyLinkedChild = useIsInboxOnlyLinkedChild();
+  const canTreatAsUser = () =>
+    !!props.id && !props.isDeleted && !isInboxOnlyLinkedChild(props.id);
   const { openWithSplit, popoverSplit } = useSplitLayout();
   const getOrCreateDmMutation = useGetOrCreateDirectMessageMutation({
     onError: () => toast.failure('Failed to open direct message'),
@@ -116,17 +120,13 @@ export function UserTooltip(props: UserTooltipProps) {
                 Copy email
               </ActionItem>
             </Show>
-            <Show
-              when={
-                props.id && !props.isDeleted && props.id !== currentUserId()
-              }
-            >
+            <Show when={canTreatAsUser() && props.id !== currentUserId()}>
               <ActionItem onClick={openDM}>
                 <WideChat class="size-3.5" />
                 DM
               </ActionItem>
             </Show>
-            <Show when={props.id && !props.isDeleted}>
+            <Show when={canTreatAsUser()}>
               <ActionItem onClick={openTaskComposer}>
                 <WideTask class="size-3.5" />
                 Assign task

--- a/js/app/packages/core/context/quickAccess/QuickAccessProvider.tsx
+++ b/js/app/packages/core/context/quickAccess/QuickAccessProvider.tsx
@@ -4,6 +4,7 @@ import {
   type IUser,
   useAugmentUserWithDmActivity,
   useContacts,
+  useIsInboxOnlyLinkedChild,
 } from '@core/user';
 import type { DateValue } from '@core/util/date';
 import type { ChannelEntity } from '@entity';
@@ -211,6 +212,7 @@ export const [QuickAccessProvider, useQuickAccess] =
       const { channels, isLoading: channelsLoading } = useChannelsContext();
       const contacts = useContacts();
       const augmentUserWithDmActivity = useAugmentUserWithDmActivity();
+      const isInboxOnlyLinkedChild = useIsInboxOnlyLinkedChild();
       const instructionsIdQuery = useInstructionsMdIdQuery();
 
       // globally hidden ids
@@ -376,6 +378,7 @@ export const [QuickAccessProvider, useQuickAccess] =
         // Process contacts (users)
         const contactData = contacts();
         for (const contact of contactData) {
+          if (isInboxOnlyLinkedChild(contact.id)) continue;
           const augmentedUser = augmentUserWithDmActivity(contact);
           seenIds.add(augmentedUser.id);
 

--- a/js/app/packages/core/signal/useCombinedRecipient.ts
+++ b/js/app/packages/core/signal/useCombinedRecipient.ts
@@ -3,6 +3,7 @@ import {
   type CombinedRecipientItem,
   recipientEntityMapper,
   useContacts,
+  useIsInboxOnlyLinkedChild,
 } from '@core/user';
 import { type Accessor, createMemo } from 'solid-js';
 
@@ -35,9 +36,12 @@ type UseCombinedRecipients<K extends 'user' | 'channel'> = {
 const useCombinedRecipientsRoot = () => {
   const contacts = useContacts();
   const channelsContext = useChannelsContext();
+  const isInboxOnlyLinkedChild = useIsInboxOnlyLinkedChild();
 
   const userContactEntities = createMemo<CombinedRecipientItem<'user'>[]>(() =>
-    contacts().map(recipientEntityMapper('user'))
+    contacts()
+      .filter((contact) => !isInboxOnlyLinkedChild(contact.id))
+      .map(recipientEntityMapper('user'))
   );
 
   const channelsWithParticipants = createMemo<

--- a/js/app/packages/core/user/inboxOnly.ts
+++ b/js/app/packages/core/user/inboxOnly.ts
@@ -1,0 +1,23 @@
+import { useEmailLinksQuery } from '@queries/email/link';
+import { createMemo } from 'solid-js';
+import { macroIdToEmail, tryMacroId } from './macroId';
+
+/** Predicate: is this macro id one of the current user's inbox-only delegated inboxes. */
+export function useIsInboxOnlyLinkedChild() {
+  const linksQuery = useEmailLinksQuery();
+
+  const inboxOnlyEmails = createMemo(() => {
+    const set = new Set<string>();
+    for (const link of linksQuery.data?.links ?? []) {
+      if (link.is_inbox_only) set.add(link.email_address.toLowerCase());
+    }
+    return set;
+  });
+
+  return (id: string | undefined | null): boolean => {
+    if (!id) return false;
+    const macroId = tryMacroId(id);
+    if (!macroId) return false;
+    return inboxOnlyEmails().has(macroIdToEmail(macroId).toLowerCase());
+  };
+}

--- a/js/app/packages/core/user/index.ts
+++ b/js/app/packages/core/user/index.ts
@@ -13,6 +13,7 @@ export {
   useDisplayNameParts,
 } from './displayName';
 export { useAugmentUserWithDmActivity } from './dmActivity';
+export { useIsInboxOnlyLinkedChild } from './inboxOnly';
 export {
   emailToMacroId,
   type MacroId,

--- a/js/app/packages/service-clients/service-email/generated/schemas/link.ts
+++ b/js/app/packages/service-clients/service-email/generated/schemas/link.ts
@@ -15,6 +15,7 @@ export interface Link {
   email_address: string;
   fusionauth_user_id: string;
   id: string;
+  is_inbox_only: boolean;
   is_sync_active: boolean;
   macro_id: string;
   /** The inbox's own profile photo (its self-contact's SFS photo), if synced. */

--- a/js/app/packages/service-clients/service-email/openapi.json
+++ b/js/app/packages/service-clients/service-email/openapi.json
@@ -4134,6 +4134,7 @@
           "is_sync_active",
           "sync_status",
           "settings",
+          "is_inbox_only",
           "created_at",
           "updated_at"
         ],
@@ -4151,6 +4152,9 @@
           "id": {
             "type": "string",
             "format": "uuid"
+          },
+          "is_inbox_only": {
+            "type": "boolean"
           },
           "is_sync_active": {
             "type": "boolean"

--- a/rust/cloud-storage/email_service/src/api/email/links/list.rs
+++ b/rust/cloud-storage/email_service/src/api/email/links/list.rs
@@ -75,8 +75,13 @@ pub async fn list_links_handler(
             .await
             .map_err(ListLinksError::DatabaseError)?;
 
+    let my_macro_id = user_context.user_id.clone();
+    let my_fusion = user_context.fusion_user_id.clone();
+
     let tasks = links.into_iter().map(|link| {
         let ctx = ctx.clone();
+        let is_inbox_only =
+            link.macro_id.to_string() != my_macro_id && link.fusionauth_user_id == my_fusion;
         async move {
             let settings = email_db_client::settings::fetch_settings(&ctx.db, link.id)
                 .await
@@ -126,6 +131,7 @@ pub async fn list_links_handler(
                 api::settings::Settings::from(settings),
                 sync_status,
                 photo_url,
+                is_inbox_only,
             ))
         }
     });

--- a/rust/cloud-storage/models_email/src/email/api/link.rs
+++ b/rust/cloud-storage/models_email/src/email/api/link.rs
@@ -82,6 +82,7 @@ pub struct Link {
     pub sync_status: SyncStatus,
     pub signature: Option<String>,
     pub settings: Settings,
+    pub is_inbox_only: bool,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -93,6 +94,7 @@ impl Link {
         settings: Settings,
         sync_status: SyncStatus,
         photo_url: Option<String>,
+        is_inbox_only: bool,
     ) -> Self {
         Link {
             id: source.id,
@@ -105,6 +107,7 @@ impl Link {
             sync_status,
             signature,
             settings,
+            is_inbox_only,
             created_at: source.created_at,
             updated_at: source.updated_at,
         }


### PR DESCRIPTION
Linked inbox-only children (a delegated inbox the user provisioned under their own grant, not a separately-loggable user) were being treated like real users. The email Link response now carries a per-requester `is_inbox_only` flag and a `useIsInboxOnlyLinkedChild` helper gates user-only affordances on it; real linked users (own grant) and undelegated contacts are unaffected.

Audited surfaces:
- Contact card (`UserTooltip`): hides DM + Assign task, keeps Copy email — fixed.
- Avatar click (`UserIcon`): no longer opens a DM — fixed.
- DM / recipient / channel pickers (`useCombinedRecipients`): excluded as candidates — fixed.
- @-mention + task-assignee pickers (QuickAccess `person` list): excluded as candidates — fixed.
- Presence indicators, sharing/invite, workspace-members lists: not at risk — they key off channel participants, which inbox-only children can no longer be added to; left as-is.
