### PR TITLE
fix(opensearch): add search slow-log thresholds to v2 join indexes

### DIFF
--- a/infra/stacks/opensearch/helpers/constants.ts
+++ b/infra/stacks/opensearch/helpers/constants.ts
@@ -44,4 +44,17 @@ export const SHARD_SETTINGS =
         refresh_interval: '30s', // Default is 1s
       };
 
+// Search slow-log thresholds, applied at index creation so every new physical
+// index emits slow logs without a separate configure step. Lowered from the
+// OpenSearch 2s/5s defaults: the parent/child join (has_child + inner_hits)
+// read path runs a few hundred ms, so a 2s threshold never fires. inner_hits
+// cost lands in the fetch phase, so both phases are covered.
+export const SLOWLOG_SETTINGS = {
+  'index.search.slowlog.threshold.query.warn': '1s',
+  'index.search.slowlog.threshold.query.info': '300ms',
+  'index.search.slowlog.threshold.fetch.warn': '1s',
+  'index.search.slowlog.threshold.fetch.info': '300ms',
+  'index.search.slowlog.level': 'info',
+};
+
 export const IS_DRY_RUN = process.env.DRY_RUN !== 'false';

--- a/infra/stacks/opensearch/helpers/scripts/configure_slow_logs.ts
+++ b/infra/stacks/opensearch/helpers/scripts/configure_slow_logs.ts
@@ -1,28 +1,22 @@
 import { client } from '../client';
+import { SLOWLOG_SETTINGS } from '../constants';
 
 async function configureSlowLogs() {
   const opensearchClient = client();
   console.log('Configuring slow query logging thresholds...');
 
   try {
-    // Configure slow query thresholds for all indices
+    // Configure slow query thresholds for all indices. Search thresholds come
+    // from the shared SLOWLOG_SETTINGS so existing indices match what new ones
+    // are created with.
     const response = await opensearchClient.indices.putSettings({
       index: '_all',
       body: {
-        // Search query slow logs
-        'index.search.slowlog.threshold.query.warn': '5s',
-        'index.search.slowlog.threshold.query.info': '2s',
-
-        // Search fetch slow logs
-        'index.search.slowlog.threshold.fetch.warn': '5s',
-        'index.search.slowlog.threshold.fetch.info': '2s',
+        ...SLOWLOG_SETTINGS,
 
         // Indexing slow logs
         'index.indexing.slowlog.threshold.index.warn': '5s',
         'index.indexing.slowlog.threshold.index.info': '2s',
-
-        // Slow log level - only log INFO and above (no DEBUG/TRACE)
-        'index.search.slowlog.level': 'info',
         'index.indexing.slowlog.level': 'info',
       },
     });
@@ -54,8 +48,8 @@ async function configureSlowLogs() {
     }
 
     console.log('\n📝 Slow queries will now be logged to CloudWatch:');
-    console.log('  - Queries > 5s: WARN level');
-    console.log('  - Queries > 2s: INFO level');
+    console.log('  - Search queries/fetches > 1s: WARN level');
+    console.log('  - Search queries/fetches > 300ms: INFO level');
   } catch (error) {
     console.error('❌ Error configuring slow logs:', error);
     throw error;

--- a/infra/stacks/opensearch/helpers/scripts/create_call_records_v2.ts
+++ b/infra/stacks/opensearch/helpers/scripts/create_call_records_v2.ts
@@ -18,7 +18,7 @@
 require('dotenv').config();
 
 import { client } from '../client';
-import { SHARD_SETTINGS } from '../constants';
+import { SHARD_SETTINGS, SLOWLOG_SETTINGS } from '../constants';
 
 const INDEX = 'call_records_v2';
 const RELATION_PARENT = 'call';
@@ -27,6 +27,7 @@ const RELATION_CHILD = 'segment';
 const BODY = {
   settings: {
     ...SHARD_SETTINGS,
+    ...SLOWLOG_SETTINGS,
     refresh_interval: '2s',
   },
   mappings: {

--- a/infra/stacks/opensearch/helpers/scripts/create_chats_v2.ts
+++ b/infra/stacks/opensearch/helpers/scripts/create_chats_v2.ts
@@ -17,7 +17,7 @@
 require('dotenv').config();
 
 import { client } from '../client';
-import { SHARD_SETTINGS } from '../constants';
+import { SHARD_SETTINGS, SLOWLOG_SETTINGS } from '../constants';
 
 const INDEX = 'chats_v2';
 const RELATION_PARENT = 'chat';
@@ -26,6 +26,7 @@ const RELATION_CHILD = 'message';
 const BODY = {
   settings: {
     ...SHARD_SETTINGS,
+    ...SLOWLOG_SETTINGS,
     refresh_interval: '1s',
   },
   mappings: {

--- a/infra/stacks/opensearch/helpers/scripts/create_documents_v2.ts
+++ b/infra/stacks/opensearch/helpers/scripts/create_documents_v2.ts
@@ -17,7 +17,7 @@
 require('dotenv').config();
 
 import { client } from '../client';
-import { SHARD_SETTINGS } from '../constants';
+import { SHARD_SETTINGS, SLOWLOG_SETTINGS } from '../constants';
 
 const INDEX = 'documents_v2';
 const RELATION_PARENT = 'document';
@@ -26,6 +26,7 @@ const RELATION_CHILD = 'chunk';
 const BODY = {
   settings: {
     ...SHARD_SETTINGS,
+    ...SLOWLOG_SETTINGS,
     refresh_interval: '1s',
   },
   mappings: {


### PR DESCRIPTION
The v2 join indexes (documents_v2/chats_v2/call_records_v2) were created without slow-log thresholds, and configure_slow_logs.ts only ever applied settings to indices that already existed when it ran — so no prod index currently has any slow-log threshold set, leaving the has_child + inner_hits read path's latency invisible to slow logs. This bakes a shared SLOWLOG_SETTINGS into index creation and lowers the threshold to 300ms info / 1s warn (query + fetch, since inner_hits cost lands in the fetch phase).
