### PR TITLE
fix(environment): add aliases to environment for config loading

### DIFF
--- a/rust/cloud-storage/macro_env/src/lib.rs
+++ b/rust/cloud-storage/macro_env/src/lib.rs
@@ -18,11 +18,13 @@ mod var {
 #[serde(rename_all = "lowercase")]
 pub enum Environment {
     /// Production environment
+    #[serde(alias = "prod", alias = "prd")]
     Production,
     /// Dev and or staging environment
-    /// TODO: update and add new value when we have real staging
+    #[serde(alias = "dev", alias = "development")]
     Develop,
     /// The server is running on localhost
+    #[serde(alias = "lcl", alias = "localhost")]
     Local,
 }
 


### PR DESCRIPTION
The new macro_config was failing to serialize the env var due to serde. So adding these aliases makes things work for both doppler and local setup