### PR TITLE
fix(email): auto-refresh newly-linked inbox avatar during post-link sync

### DIFF
--- a/js/app/packages/queries/email/link.ts
+++ b/js/app/packages/queries/email/link.ts
@@ -11,12 +11,23 @@ import { emailKeys } from './keys';
 
 const LINK_STALE_TIME = 5 * 60 * 1000;
 
+// A newly-linked inbox's avatar (`photo_url`) is written async, so poll the links
+// list while any inbox is still syncing; polling stops on its own once none are,
+// leaving steady-state/single-inbox users with no extra fetches.
+const LINK_SYNC_POLL_INTERVAL = 2_000;
+
+function isAnyInboxSyncing(data: ListLinksResponse | undefined): boolean {
+  return data?.links.some((link) => link.sync_status === 'SYNCING') ?? false;
+}
+
 export function useEmailLinksQuery() {
   return useQuery(() => ({
     queryKey: emailKeys.links.queryKey,
     queryFn: async () => throwOnErr(async () => await emailClient.getLinks()),
     staleTime: LINK_STALE_TIME,
     refetchOnWindowFocus: 'always',
+    refetchInterval: (query) =>
+      isAnyInboxSyncing(query.state.data) ? LINK_SYNC_POLL_INTERVAL : false,
   }));
 }
 


### PR DESCRIPTION
Polls the links query while any inbox reports `sync_status: SYNCING` so a freshly-linked inbox's avatar (`photo_url`, written async by the sfs_uploader) fills in on its own without a manual refresh; polling self-terminates once no inbox is syncing, so steady-state/single-inbox users incur no extra fetches. Refreshing the newly-backfilled threads is deferred — the proper path is WS-driven invalidation off the already-merged `refresh_email` notification (tracked separately).