### PR TITLE
fix(soup): restore collapse animation on inbox swipe mark done

### DIFF
--- a/js/app/packages/app/component/next-soup/create-soup-state.ts
+++ b/js/app/packages/app/component/next-soup/create-soup-state.ts
@@ -14,6 +14,17 @@ import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import type { EntityData, WithNotification, WithSearch } from '@entity';
 import { createMemo, createSignal, type JSX } from 'solid-js';
 
+/**
+ * Active "focus" predicates that exclude done entities. When one of these is
+ * active, marking an entity done removes it from the list, so its row should
+ * collapse before being removed rather than disappearing instantly.
+ *
+ * The inbox tabs activate `inbox` / `noise` rather than the standalone
+ * `not-done` predicate (see `soup-filter-presets.ts`), so all three are
+ * included here.
+ */
+const COLLAPSE_ON_DONE_PREDICATES: FilterID[] = ['not-done', 'inbox', 'noise'];
+
 export type SoupEntity = WithNotification<EntityData | WithSearch<EntityData>>;
 
 export type GroupHeaderProps = {
@@ -346,7 +357,7 @@ export const createSoupState = <TId extends string = FilterID>(
       set: setCollapseEntityCallback,
       shouldCollapse: () => {
         return (
-          predicates.isActive('not-done') &&
+          COLLAPSE_ON_DONE_PREDICATES.some((id) => predicates.isActive(id)) &&
           collapseEntityCallback() !== undefined &&
           isModality('touch')
         );


### PR DESCRIPTION
Swiping to mark an inbox entity done made the row vanish instantly instead of collapsing.

The `grid-rows-[0fr]` collapse CSS in `EntityRow` is fine — the row only collapses when `shouldCollapse()` returns true, in which case `executeWithSoup` awaits the collapse animation before the optimistic removal runs. `shouldCollapse()` required the `not-done` predicate to be active, but inbox tabs activate the `inbox` / `noise` focus predicates instead (see `soup-filter-presets.ts`). So the gate was always false in the inbox: the collapse was skipped and the optimistic removal dropped the row immediately.

This broadens the check to any not-done-excluding focus predicate (`not-done`, `inbox`, `noise`) so the collapse runs before the row is removed.

https://claude.ai/code/session_01BKLhAuAfCDTyikprVfAGz4

---
_Generated by [Claude Code](https://claude.ai/code/session_01BKLhAuAfCDTyikprVfAGz4)_