### PR TITLE
feat(email): gate multi-inbox on the enable-multi-inbox posthog flag

### DIFF
--- a/js/app/packages/app/component/settings/Account.tsx
+++ b/js/app/packages/app/component/settings/Account.tsx
@@ -11,14 +11,14 @@ import {
   blockNameToFileExtensions,
   blockNameToMimeTypes,
 } from '@core/constant/allBlocks';
-import { ShowFeatureFlag } from '@app/lib/analytics/posthog';
+import { ShowFeatureFlag, useFeatureFlag } from '@app/lib/analytics/posthog';
 import {
   DEV_MODE_ENV,
   ENABLE_AUTO_UPDATE_UI,
   ENABLE_EMAIL,
   ENABLE_INBOX_RESYNC,
   ENABLE_INBOX_SYNC_STATUS,
-  ENABLE_MULTI_INBOX,
+  ENABLE_MULTI_INBOX_OVERRIDE,
   ENABLE_PROFILE_PICTURES,
   ENABLE_NEW_PRICING_OVERRIDE,
 } from '@core/constant/featureFlags';
@@ -262,6 +262,9 @@ function ProfilePictureRow(props: { userId: string }) {
 // Not accessible if user is not authenticated
 export function Account() {
   const email = useEmail();
+  const multiInboxFlag = useFeatureFlag('enable-multi-inbox', {
+    enabledOverride: ENABLE_MULTI_INBOX_OVERRIDE,
+  });
   const userId = useUserId();
   const licenseStatus = useLicenseStatus();
   const logout = useLogout();
@@ -536,7 +539,7 @@ export function Account() {
               <Show
                 when={
                   ENABLE_EMAIL &&
-                  !ENABLE_MULTI_INBOX &&
+                  !multiInboxFlag().enabled &&
                   (!emailActive() || DEV_MODE_ENV)
                 }
               >
@@ -568,7 +571,7 @@ export function Account() {
                 </Row>
               </Show>
 
-              <Show when={ENABLE_EMAIL && ENABLE_MULTI_INBOX}>
+              <Show when={ENABLE_EMAIL && multiInboxFlag().enabled}>
                 <div class="bg-surface">
                   <div class="flex items-center justify-between h-15.25 px-6">
                     <div class="text-sm">Inboxes</div>

--- a/js/app/packages/core/constant/featureFlags.ts
+++ b/js/app/packages/core/constant/featureFlags.ts
@@ -236,10 +236,8 @@ const _ENABLE_DOCK_NOTITIFCATIONS = resolveFeatureFlag(
 );
 export const ENABLE_TTFT = resolveFeatureFlag('ENABLE_TTFT', DEV_MODE_ENV);
 
-export const ENABLE_MULTI_INBOX = resolveFeatureFlag(
-  'ENABLE_MULTI_INBOX',
-  DEV_MODE_ENV
-);
+export const ENABLE_MULTI_INBOX_OVERRIDE =
+  resolveFeatureFlag('ENABLE_MULTI_INBOX', DEV_MODE_ENV) || undefined;
 
 export const ENABLE_INBOX_RESYNC = resolveFeatureFlag(
   'ENABLE_INBOX_RESYNC',


### PR DESCRIPTION
Drives the multi-inbox settings UI off the `enable-multi-inbox` PostHog flag instead of the build-time `ENABLE_MULTI_INBOX` constant, mirroring `enable-home-view`. The flag carries the `Email ∋ macro.com` filter in PostHog so it enables in prod only for @macro.com primaries; `ENABLE_MULTI_INBOX_OVERRIDE` keeps dev on for everyone and lets `VITE_ENABLE_MULTI_INBOX=true` force it on.
