### PR TITLE
feat(env): add FromRef trait for narrowing config field access

### DIFF
--- a/rust/cloud-storage/macro_config/src/lib.rs
+++ b/rust/cloud-storage/macro_config/src/lib.rs
@@ -19,6 +19,17 @@ use std::str::FromStr;
 #[cfg(test)]
 mod test;
 
+/// Extract a narrowed value out of a larger config struct `E`.
+///
+/// `#[derive(MacroConfig)]` generates one impl per field tagged with `#[from_ref]`, so a
+/// consumer can require just the values it needs via a bound like `where AnthropicApiKey:
+/// FromRef<E>` instead of depending on a concrete config type. Tagged field types must be
+/// distinct, since the impl is keyed on the field's type.
+pub trait FromRef<E> {
+    /// Build `Self` from a reference to the config struct.
+    fn from_ref(env: &E) -> Self;
+}
+
 /// Typed result
 pub type MacroConfigResult<T> = Result<T, MacroConfigError>;
 

--- a/rust/cloud-storage/macro_config/src/lib.rs
+++ b/rust/cloud-storage/macro_config/src/lib.rs
@@ -21,10 +21,11 @@ mod test;
 
 /// Extract a narrowed value out of a larger config struct `E`.
 ///
-/// `#[derive(MacroConfig)]` generates one impl per field tagged with `#[from_ref]`, so a
-/// consumer can require just the values it needs via a bound like `where AnthropicApiKey:
-/// FromRef<E>` instead of depending on a concrete config type. Tagged field types must be
-/// distinct, since the impl is keyed on the field's type.
+/// `#[derive(MacroConfig)]` generates one impl per field tagged with `#[from_ref]` (or every
+/// field when the struct is tagged `#[from_ref_all]`), so a consumer can require just the
+/// values it needs via a bound like `where AnthropicApiKey: FromRef<E>` instead of depending
+/// on a concrete config type. Field types covered by `FromRef` must be distinct, since the
+/// impl is keyed on the field's type.
 pub trait FromRef<E> {
     /// Build `Self` from a reference to the config struct.
     fn from_ref(env: &E) -> Self;

--- a/rust/cloud-storage/macro_config/src/test.rs
+++ b/rust/cloud-storage/macro_config/src/test.rs
@@ -332,3 +332,48 @@ fn from_ref_narrows_tagged_marker_field() {
     let narrowed = requires_narrowable(&config);
     assert_eq!(&*narrowed, "secret-value");
 }
+
+macro_env_var::env_var! {
+    #[derive(Debug, Clone)]
+    struct AllConfigDatabaseUrl;
+}
+
+macro_env_var::env_var! {
+    #[derive(Debug, Clone)]
+    struct AllConfigRedisUri;
+}
+
+// `#[from_ref_all]` opts every field into a FromRef impl without per-field tags. Requires every
+// field to be a distinct marker type.
+#[derive(MacroConfig)]
+#[from_ref_all]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+struct AllNarrowConfig {
+    database_url: AllConfigDatabaseUrl,
+    redis_uri: AllConfigRedisUri,
+}
+
+fn requires_both<E>(env: &E) -> (AllConfigDatabaseUrl, AllConfigRedisUri)
+where
+    AllConfigDatabaseUrl: FromRef<E>,
+    AllConfigRedisUri: FromRef<E>,
+{
+    (
+        AllConfigDatabaseUrl::from_ref(env),
+        AllConfigRedisUri::from_ref(env),
+    )
+}
+
+#[test]
+fn from_ref_all_narrows_every_field() {
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    let env = EnvGuard::new(&["APP_SECRETS_JSON", "DATABASE_URL", "REDIS_URI"]);
+    env.set("DATABASE_URL", "postgres://db");
+    env.set("REDIS_URI", "redis://cache");
+
+    let config = ConfigLoader::load::<AllNarrowConfig>().expect("config should load");
+
+    let (db, redis) = requires_both(&config);
+    assert_eq!(&*db, "postgres://db");
+    assert_eq!(&*redis, "redis://cache");
+}

--- a/rust/cloud-storage/macro_config/src/test.rs
+++ b/rust/cloud-storage/macro_config/src/test.rs
@@ -293,3 +293,42 @@ fn load_errors_when_required_value_is_missing() {
         MacroConfigError::MissingRequiredValue("missing")
     ));
 }
+
+macro_env_var::env_var! {
+    #[derive(Debug, Clone)]
+    struct NarrowableSecret;
+}
+
+#[derive(MacroConfig)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+struct NarrowConfig {
+    #[from_ref]
+    narrowable_secret: NarrowableSecret,
+    // a plain, untagged field: it gets no FromRef impl, so it never collides with other
+    // String fields and can't be narrowed.
+    plain_value: String,
+}
+
+/// Consumes any config that can produce a `NarrowableSecret`, regardless of its concrete type.
+/// This compiling at all is the proof that `#[from_ref]` generated `FromRef<NarrowConfig>`.
+fn requires_narrowable<E>(env: &E) -> NarrowableSecret
+where
+    NarrowableSecret: FromRef<E>,
+{
+    NarrowableSecret::from_ref(env)
+}
+
+#[test]
+fn from_ref_narrows_tagged_marker_field() {
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    let env = EnvGuard::new(&["APP_SECRETS_JSON", "NARROWABLE_SECRET", "PLAIN_VALUE"]);
+    env.set("NARROWABLE_SECRET", "secret-value");
+    env.set("PLAIN_VALUE", "plain");
+
+    let config = ConfigLoader::load::<NarrowConfig>().expect("config should load");
+
+    assert_eq!(&*config.plain_value, "plain");
+
+    let narrowed = requires_narrowable(&config);
+    assert_eq!(&*narrowed, "secret-value");
+}

--- a/rust/cloud-storage/macro_config_derive/src/lib.rs
+++ b/rust/cloud-storage/macro_config_derive/src/lib.rs
@@ -1,12 +1,12 @@
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
-use quote::{format_ident, quote};
+use quote::{ToTokens, format_ident, quote};
 use syn::{
     Data, DeriveInput, Fields, GenericArgument, LitStr, PathArguments, Type, parse_macro_input,
     parse_quote,
 };
 
-#[proc_macro_derive(MacroConfig, attributes(macro_config_default, serde))]
+#[proc_macro_derive(MacroConfig, attributes(macro_config_default, serde, from_ref))]
 pub fn derive_macro_config(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
 
@@ -51,6 +51,7 @@ fn expand_macro_config(input: DeriveInput) -> syn::Result<TokenStream2> {
         });
         let default = macro_config_default(&field.attrs)?;
         let is_option = default.is_none() && is_option_type(&ty);
+        let from_ref = has_from_ref(&field.attrs);
         let variant = format_ident!("Field{index}");
 
         field_data.push(FieldData {
@@ -59,6 +60,7 @@ fn expand_macro_config(input: DeriveInput) -> syn::Result<TokenStream2> {
             key,
             default,
             is_option,
+            from_ref,
             variant,
         });
     }
@@ -136,6 +138,37 @@ fn expand_macro_config(input: DeriveInput) -> syn::Result<TokenStream2> {
     let (impl_generics, _, where_clause) = impl_generics_with_de.split_for_impl();
     let (_, ty_generics, _) = input.generics.split_for_impl();
 
+    // `#[from_ref]` fields each get a `macro_config::FromRef<Struct>` impl keyed on the field's
+    // type. Since the impl is type-keyed, two tagged fields of the same type would collide
+    // (E0119), so reject that here with a clear message rather than a raw coherence error.
+    let mut seen_from_ref: std::collections::HashMap<String, ()> = std::collections::HashMap::new();
+    for field in field_data.iter().filter(|field| field.from_ref) {
+        let key = field.ty.to_token_stream().to_string();
+        if seen_from_ref.insert(key.clone(), ()).is_some() {
+            return Err(syn::Error::new_spanned(
+                &field.ty,
+                format!(
+                    "duplicate `#[from_ref]` field type `{key}`: each tagged field must be a \
+                     distinct type so `FromRef<{struct_name}>` is unambiguous"
+                ),
+            ));
+        }
+    }
+    let (from_ref_impl_generics, _, from_ref_where_clause) = input.generics.split_for_impl();
+    let from_ref_impls = field_data.iter().filter(|field| field.from_ref).map(|field| {
+        let ident = &field.ident;
+        let ty = &field.ty;
+        quote! {
+            impl #from_ref_impl_generics ::macro_config::FromRef<#struct_name #ty_generics> for #ty
+                #from_ref_where_clause
+            {
+                fn from_ref(env: &#struct_name #ty_generics) -> Self {
+                    ::core::clone::Clone::clone(&env.#ident)
+                }
+            }
+        }
+    });
+
     Ok(quote! {
         impl #impl_generics ::macro_config::__serde::Deserialize<'de> for #struct_name #ty_generics #where_clause {
             fn deserialize<__D>(deserializer: __D) -> Result<Self, __D::Error>
@@ -209,6 +242,8 @@ fn expand_macro_config(input: DeriveInput) -> syn::Result<TokenStream2> {
                 deserializer.deserialize_struct(#struct_name_string, FIELDS, __MacroConfigVisitor)
             }
         }
+
+        #(#from_ref_impls)*
     })
 }
 
@@ -218,7 +253,14 @@ struct FieldData {
     key: String,
     default: Option<TokenStream2>,
     is_option: bool,
+    from_ref: bool,
     variant: syn::Ident,
+}
+
+/// Whether a field is tagged with `#[from_ref]`, opting it into a generated
+/// `macro_config::FromRef<Struct>` impl for its type.
+fn has_from_ref(attrs: &[syn::Attribute]) -> bool {
+    attrs.iter().any(|attr| attr.path().is_ident("from_ref"))
 }
 
 fn macro_config_default(attrs: &[syn::Attribute]) -> syn::Result<Option<TokenStream2>> {

--- a/rust/cloud-storage/macro_config_derive/src/lib.rs
+++ b/rust/cloud-storage/macro_config_derive/src/lib.rs
@@ -6,7 +6,10 @@ use syn::{
     parse_quote,
 };
 
-#[proc_macro_derive(MacroConfig, attributes(macro_config_default, serde, from_ref))]
+#[proc_macro_derive(
+    MacroConfig,
+    attributes(macro_config_default, serde, from_ref, from_ref_all)
+)]
 pub fn derive_macro_config(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
 
@@ -20,6 +23,10 @@ fn expand_macro_config(input: DeriveInput) -> syn::Result<TokenStream2> {
     let struct_name = input.ident;
     let struct_name_string = struct_name.to_string();
     let rename_all = serde_rename_all(&input.attrs)?;
+    // `#[from_ref_all]` on the struct opts every field into a generated `FromRef` impl, for
+    // fully-typed configs where each field is a distinct marker type. Individual fields can
+    // still opt in with `#[from_ref]` when the struct isn't fully typed yet.
+    let from_ref_all = has_from_ref_all(&input.attrs);
 
     let fields = match input.data {
         Data::Struct(data) => match data.fields {
@@ -51,7 +58,7 @@ fn expand_macro_config(input: DeriveInput) -> syn::Result<TokenStream2> {
         });
         let default = macro_config_default(&field.attrs)?;
         let is_option = default.is_none() && is_option_type(&ty);
-        let from_ref = has_from_ref(&field.attrs);
+        let from_ref = from_ref_all || has_from_ref(&field.attrs);
         let variant = format_ident!("Field{index}");
 
         field_data.push(FieldData {
@@ -138,9 +145,9 @@ fn expand_macro_config(input: DeriveInput) -> syn::Result<TokenStream2> {
     let (impl_generics, _, where_clause) = impl_generics_with_de.split_for_impl();
     let (_, ty_generics, _) = input.generics.split_for_impl();
 
-    // `#[from_ref]` fields each get a `macro_config::FromRef<Struct>` impl keyed on the field's
-    // type. Since the impl is type-keyed, two tagged fields of the same type would collide
-    // (E0119), so reject that here with a clear message rather than a raw coherence error.
+    // Fields covered by FromRef each get a `macro_config::FromRef<Struct>` impl keyed on the
+    // field's type. Since the impl is type-keyed, two covered fields of the same type would
+    // collide (E0119), so reject that here with a clear message rather than a raw coherence error.
     let mut seen_from_ref: std::collections::HashMap<String, ()> = std::collections::HashMap::new();
     for field in field_data.iter().filter(|field| field.from_ref) {
         let key = field.ty.to_token_stream().to_string();
@@ -148,8 +155,9 @@ fn expand_macro_config(input: DeriveInput) -> syn::Result<TokenStream2> {
             return Err(syn::Error::new_spanned(
                 &field.ty,
                 format!(
-                    "duplicate `#[from_ref]` field type `{key}`: each tagged field must be a \
-                     distinct type so `FromRef<{struct_name}>` is unambiguous"
+                    "duplicate FromRef field type `{key}`: every field covered by \
+                     `#[from_ref]`/`#[from_ref_all]` must be a distinct type so \
+                     `FromRef<{struct_name}>` is unambiguous"
                 ),
             ));
         }
@@ -261,6 +269,14 @@ struct FieldData {
 /// `macro_config::FromRef<Struct>` impl for its type.
 fn has_from_ref(attrs: &[syn::Attribute]) -> bool {
     attrs.iter().any(|attr| attr.path().is_ident("from_ref"))
+}
+
+/// Whether the struct is tagged with `#[from_ref_all]`, opting every field into a generated
+/// `macro_config::FromRef<Struct>` impl. Requires all field types to be distinct.
+fn has_from_ref_all(attrs: &[syn::Attribute]) -> bool {
+    attrs
+        .iter()
+        .any(|attr| attr.path().is_ident("from_ref_all"))
 }
 
 fn macro_config_default(attrs: &[syn::Attribute]) -> syn::Result<Option<TokenStream2>> {


### PR DESCRIPTION
This PR introduces a `FromRef` trait that enables extracting individual fields from a `MacroConfig` struct without depending on the concrete config type. This allows consumers to express dependencies on just the values they need through generic bounds. For example:

- **New `FromRef<E>` trait**: A generic trait that allows extracting a value of type `Self` from a config struct `E`. Implementations are automatically generated by the derive macro.
- **`#[from_ref]` field attribute**: Opts individual fields into `FromRef` impl generation. Each field type must be distinct to avoid coherence conflicts.
- **`#[from_ref_all]` struct attribute**: Opts every field into `FromRef` impl generation at once, useful for fully-typed configs where each field is a distinct marker type.
- **Duplicate type detection**: The macro validates that no two fields covered by `FromRef` have the same type, providing a clear error message instead of a raw E0119 coherence error.


```rust 
env_var! { pub struct AnthropicApiKey }
env_var! { pub struct OpenAIApiKey }
env_var! { pub struct InernalApiKey }

#[derive(macro_config::MacroConfig)]
#[macro_config::from_ref_all]
pub struct DCSEnvironment {
    anthropic_api_key: AnthropicApiKey,
    openai_api_key: OpenAIApiKey,
}

#[derive(macro_config::MacroConfig)]
#[macro_config::from_ref_all]
pub struct DSSEnvironment {
    anthropic_api_key: AnthropicApiKey,
    openai_api_key: OpenAIApiKey,
    internal_api_key: InernalApiKey,
}

fn requires_api_keys<E>(env: &E)
where
    E: FromRef<AnthropicApiKey> + FromRef<OpenAIApiKey>,
{
    let anthropic_api_key = AnthropicApiKey::from_ref(env);
    let openai_api_key = OpenAIApiKey::from_ref(env);
}

fn dss_caller(config: &DSSEnvironment) {
    requires_api_keys(config);
}

fn dcs_caller(config: &DCSEnvironment) {
    requires_api_keys(config);
}

```