### PR TITLE
Reorganize sidebar navigation: rename Documents to Files, move Folders to tab

### DIFF
--- a/js/app/packages/app/component/app-sidebar/sidebar.tsx
+++ b/js/app/packages/app/component/app-sidebar/sidebar.tsx
@@ -147,7 +147,7 @@ const SIDEBAR_LINKS = [
     label: 'Files',
     href: LIST_VIEW_PATHS.documents,
     icon: AnimatedFileMdIcon,
-    hotkey: 'd',
+    hotkey: 'f',
     hotkeyToken: TOKENS.sidebar.goTo.documents,
   },
   {

--- a/js/app/packages/app/component/app-sidebar/sidebar.tsx
+++ b/js/app/packages/app/component/app-sidebar/sidebar.tsx
@@ -144,7 +144,7 @@ const SIDEBAR_LINKS = [
   },
   {
     id: 'documents',
-    label: 'Documents',
+    label: 'Files',
     href: LIST_VIEW_PATHS.documents,
     icon: AnimatedFileMdIcon,
     hotkey: 'd',
@@ -165,14 +165,6 @@ const SIDEBAR_LINKS = [
     icon: AnimatedChannelIcon,
     hotkey: 'c',
     hotkeyToken: TOKENS.sidebar.goTo.channels,
-  },
-  {
-    id: 'folders',
-    label: 'Folders',
-    href: LIST_VIEW_PATHS.folders,
-    icon: AnimatedFolderIcon,
-    hotkey: 'f',
-    hotkeyToken: TOKENS.sidebar.goTo.folders,
   },
 ] satisfies SidebarItem[];
 

--- a/js/app/packages/app/component/app-sidebar/sidebar.tsx
+++ b/js/app/packages/app/component/app-sidebar/sidebar.tsx
@@ -61,7 +61,6 @@ import { AnimatedCallIcon } from '@icon/wide-call';
 import { AnimatedChannelIcon } from '@icon/wide-channel';
 import { AnimatedEmailIcon } from '@icon/wide-email';
 import { AnimatedFileMdIcon } from '@icon/wide-fileMd';
-import { AnimatedFolderIcon } from '@icon/wide-folder';
 import { AnimatedInboxIcon } from '@icon/wide-inbox';
 import { AnimatedNewSplitIcon } from '@icon/wide-newSplit';
 import { AnimatedPlusIcon } from '@icon/wide-plus';

--- a/js/app/packages/app/component/app-sidebar/soup-filter-presets.ts
+++ b/js/app/packages/app/component/app-sidebar/soup-filter-presets.ts
@@ -242,6 +242,12 @@ export const VIEW_TAB_PRESETS: Record<ListView, ViewTabConfig> = {
         }),
         clientFilters: { and: ['document-or-file'] },
       }),
+      folders: () => ({
+        filters: defineQueryFilters({
+          exclude: { folderId: [NIL_UUID] },
+        }),
+        clientFilters: { and: ['folders'] },
+      }),
       all: () => ({
         filters: defineQueryFilters({
           exclude: { subType: ['task'] },

--- a/js/app/packages/app/component/next-soup/soup-view/soup-view-tabs.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-view-tabs.tsx
@@ -60,6 +60,7 @@ export const VIEW_TAB_LISTS: Record<TabbedListView, TabItem[]> = {
     { value: 'owned', label: 'Owned' },
     { value: 'shared', label: 'Shared' },
     { value: 'attachments', label: 'Attachments' },
+    { value: 'folders', label: 'Folders' },
     { value: 'all', label: 'All' },
   ],
   tasks: [

--- a/js/app/packages/app/component/split-layout/componentRegistry.tsx
+++ b/js/app/packages/app/component/split-layout/componentRegistry.tsx
@@ -176,7 +176,7 @@ registerComponent(
     });
     return (
       <SoupView
-        viewName="Documents"
+        viewName="Files"
         initialFilters={preset?.filters}
         initialClientFilters={preset?.clientFilters}
         initialGroupBy={preset?.groupBy}


### PR DESCRIPTION
## Summary
This PR reorganizes the sidebar navigation structure by renaming the "Documents" sidebar link to "Files" and moving the "Folders" navigation from a top-level sidebar item to a tab within the Files view.

## Key Changes
- **Sidebar Navigation**: Renamed "Documents" label to "Files" in the main sidebar links
- **Removed Sidebar Item**: Deleted the "Folders" sidebar link (including its icon, hotkey, and localization token)
- **Added Tab Preset**: Created a new "folders" tab configuration in `VIEW_TAB_PRESETS` with appropriate filters to display folder items
- **Updated View Tabs**: Added "Folders" as a new tab option in the Files view's tab list, positioned before the "All" tab
- **Updated Component Registry**: Changed the SoupView display name from "Documents" to "Files" for consistency

## Implementation Details
- The folders filter uses `exclude: { folderId: [NIL_UUID] }` to filter out items without a folder ID
- The folders tab uses the `'folders'` client filter to display only folder-type items
- The tab is integrated into the existing tabbed list view structure alongside "Owned", "Shared", and "Attachments" tabs

https://claude.ai/code/session_01Ada3AbeF2wXnq9EmNUfUQT