### PR TITLE
Add entity pinning feature with sidebar widget

### DIFF
--- a/js/app/packages/app/component/app-sidebar/pinned-widget.tsx
+++ b/js/app/packages/app/component/app-sidebar/pinned-widget.tsx
@@ -1,0 +1,127 @@
+import type { SidebarState } from '@app/component/app-sidebar/sidebar';
+import { openEntityInSplitFromUnifiedList } from '@app/component/next-soup/utils';
+import { pinnedEntities, unpinEntity } from '@app/signal/pins';
+import { globalSplitManager } from '@app/signal/splitLayout';
+import { ContextMenuContent, MenuItem } from '@core/component/ContextMenu';
+import { type EntityData, EntityRowIcon, EntityRowTitle } from '@entity';
+import { ContextMenu } from '@kobalte/core/context-menu';
+import { Button, cn, Tooltip } from '@ui';
+import { For, Show } from 'solid-js';
+
+function entityTitle(entity: EntityData): string {
+  return entity.name || 'Untitled';
+}
+
+function PinnedEntityItem(props: { entity: EntityData; isSlim?: boolean }) {
+  const isSlim = () => props.isSlim ?? false;
+
+  const canOpenInNewSplit = () =>
+    globalSplitManager()?.canAppendSplit() ?? false;
+
+  const open = (newSplit = false) => {
+    void openEntityInSplitFromUnifiedList(props.entity, {
+      openInNewSplit: newSplit,
+    });
+  };
+
+  const ButtonContent = () => (
+    <Button
+      class={cn(
+        'flex items-center cursor-default rounded-md text-ink-extra-muted not-disabled:hover:bg-ink/3',
+        isSlim()
+          ? 'justify-center size-8'
+          : 'justify-start gap-2 w-full h-8 py-1'
+      )}
+      draggable={false}
+      variant="ghost"
+      size="sm"
+      onMouseDown={(e) => {
+        if (e.button !== 0) return;
+        e.preventDefault();
+        open(e.shiftKey);
+      }}
+    >
+      <div class="relative flex items-center justify-center shrink-0 size-5">
+        <EntityRowIcon
+          entity={props.entity}
+          suppressClick
+          showTooltip={false}
+        />
+      </div>
+
+      <Show when={!isSlim()}>
+        <span class="text-sm font-medium truncate">
+          <EntityRowTitle entity={props.entity} />
+        </span>
+      </Show>
+    </Button>
+  );
+
+  return (
+    <ContextMenu>
+      <ContextMenu.Trigger class="w-full">
+        <Show
+          when={!isSlim()}
+          fallback={
+            <Tooltip label={entityTitle(props.entity)} placement="right">
+              <ButtonContent />
+            </Tooltip>
+          }
+        >
+          <ButtonContent />
+        </Show>
+      </ContextMenu.Trigger>
+
+      <ContextMenu.Portal>
+        <ContextMenuContent class="text-xs text-ink-muted">
+          <MenuItem text="Open in current split" onClick={() => open(false)} />
+          <MenuItem
+            text="Open in new split"
+            onClick={() => open(true)}
+            disabled={!canOpenInNewSplit()}
+          />
+          <MenuItem text="Unpin" onClick={() => unpinEntity(props.entity.id)} />
+        </ContextMenuContent>
+      </ContextMenu.Portal>
+    </ContextMenu>
+  );
+}
+
+export const PinnedWidget = (props: { sidebarState: SidebarState }) => {
+  const isSlim = () => props.sidebarState === 'slim';
+  const SLIM_MAX = 4;
+  const slimVisible = () => pinnedEntities().slice(0, SLIM_MAX);
+  const slimOverflow = () => Math.max(0, pinnedEntities().length - SLIM_MAX);
+
+  return (
+    <Show when={pinnedEntities().length > 0}>
+      <Show
+        when={!isSlim()}
+        fallback={
+          <section class="w-full p-2 flex flex-col items-center">
+            <For each={slimVisible()}>
+              {(entity) => <PinnedEntityItem entity={entity} isSlim />}
+            </For>
+            <Show when={slimOverflow() > 0}>
+              <span class="text-xxs text-ink-muted mt-1">
+                +{slimOverflow()}
+              </span>
+            </Show>
+          </section>
+        }
+      >
+        <section class="size-full flex flex-col justify-center px-2 py-1.5">
+          <header class="text-xs font-medium text-ink-muted ml-2 mb-1">
+            <h1>Pinned</h1>
+          </header>
+
+          <div class="flex-1">
+            <For each={pinnedEntities()}>
+              {(entity) => <PinnedEntityItem entity={entity} />}
+            </For>
+          </div>
+        </section>
+      </Show>
+    </Show>
+  );
+};

--- a/js/app/packages/app/component/app-sidebar/sidebar.tsx
+++ b/js/app/packages/app/component/app-sidebar/sidebar.tsx
@@ -5,6 +5,7 @@ import {
   InviteModal,
   setInviteModalOpen,
 } from '@app/component/app-sidebar/invite-modal';
+import { PinnedWidget } from '@app/component/app-sidebar/pinned-widget';
 import {
   SidebarPromoCard,
   SidebarPromoHint,
@@ -1028,6 +1029,10 @@ export const AppSidebar = (props: AppSidebarProps) => {
 
       <div class="block max-h-[clamp(10%,60%,20rem)]">
         <ChannelsUnreadWidget sidebarState={props.sidebarState ?? 'expanded'} />
+      </div>
+
+      <div class="block max-h-[clamp(10%,60%,20rem)] overflow-y-auto">
+        <PinnedWidget sidebarState={props.sidebarState ?? 'expanded'} />
       </div>
 
       <div class="mt-auto">

--- a/js/app/packages/app/component/next-soup/actions/index.ts
+++ b/js/app/packages/app/component/next-soup/actions/index.ts
@@ -8,6 +8,7 @@ export { makeMarkDoneAction } from './make-mark-done-action';
 export { makeMarkSenderSignalAction } from './make-mark-sender-important-action';
 export { makeMarkSenderNoiseAction } from './make-mark-sender-noise-action';
 export { makeMoveToProjectAction } from './make-move-to-project-action';
+export { makePinAction } from './make-pin-action';
 export { makeRenameAction } from './make-rename-action';
 export { makeShareAction } from './make-share-action';
 export { useBlockEntityCommands } from './use-block-entity-commands';

--- a/js/app/packages/app/component/next-soup/actions/make-pin-action.ts
+++ b/js/app/packages/app/component/next-soup/actions/make-pin-action.ts
@@ -1,0 +1,40 @@
+import {
+  canPinEntity,
+  isPinned,
+  pinEntity,
+  unpinEntity,
+} from '@app/signal/pins';
+import { toast } from '@core/component/Toast/Toast';
+import type { EntityData } from '@entity';
+import type { SoupState } from '../create-soup-state';
+
+export const makePinAction = () => {
+  const canExecute = (entity: EntityData): boolean => canPinEntity(entity);
+
+  /** Whether every (pinnable) entity in the selection is already pinned. */
+  const allPinned = (entities: EntityData[]): boolean => {
+    const pinnable = entities.filter(canPinEntity);
+    return (
+      pinnable.length > 0 && pinnable.every((entity) => isPinned(entity.id))
+    );
+  };
+
+  const execute = async (entities: EntityData[]) => {
+    const pinnable = entities.filter(canPinEntity);
+    if (pinnable.length === 0) return;
+
+    if (allPinned(pinnable)) {
+      for (const entity of pinnable) unpinEntity(entity.id);
+      toast.success(pinnable.length > 1 ? 'Unpinned items' : 'Unpinned');
+    } else {
+      for (const entity of pinnable) pinEntity(entity);
+      toast.success(pinnable.length > 1 ? 'Pinned items' : 'Pinned');
+    }
+  };
+
+  const executeWithSoup = async (entities: EntityData[], _soup: SoupState) => {
+    await execute(entities);
+  };
+
+  return { canExecute, allPinned, execute, executeWithSoup };
+};

--- a/js/app/packages/app/component/next-soup/soup-view/create-soup-entity-actions.ts
+++ b/js/app/packages/app/component/next-soup/soup-view/create-soup-entity-actions.ts
@@ -19,6 +19,7 @@ import {
   makeMarkSenderNoiseAction,
   makeMarkSenderSignalAction,
   makeMoveToProjectAction,
+  makePinAction,
   makeRenameAction,
   makeShareAction,
 } from '../actions';
@@ -72,6 +73,7 @@ export function createSoupEntityActions(): {
   });
 
   const copyAction = makeCopyAction();
+  const pinAction = makePinAction();
   const moveToProjectAction = makeMoveToProjectAction();
   const copyLinkAction = makeCopyLinkAction();
   const copyBranchNameAction = makeCopyBranchNameAction();
@@ -182,8 +184,16 @@ export function createSoupEntityActions(): {
       });
     }
 
-    // Middle group: Rename, Move to folder, Duplicate, Copy Link, Copy Branch Name, Share
+    // Middle group: Pin, Rename, Move to folder, Duplicate, Copy Link, Copy Branch Name, Share
     const middleItems: SoupEntityActionItem[] = [];
+
+    if (canExecuteAll(pinAction.canExecute)) {
+      middleItems.push({
+        id: 'pin',
+        label: pinAction.allPinned(entities) ? 'Unpin' : 'Pin',
+        onClick: handle(pinAction.executeWithSoup),
+      });
+    }
 
     if (canExecuteAll(renameAction.canExecute)) {
       middleItems.push({

--- a/js/app/packages/app/signal/pins.ts
+++ b/js/app/packages/app/signal/pins.ts
@@ -1,0 +1,133 @@
+import type { EntityData } from '@entity';
+import { storageServiceClient } from '@service-storage/client';
+import { createSignal } from 'solid-js';
+
+/**
+ * Client-side store for pinned entities.
+ *
+ * The macro backend already persists pins (see the `Pin` table and the
+ * `/pins` endpoints), but its hydrating `GET /pins` query only returns
+ * documents, chats and projects. To support pinning *any* entity type
+ * (emails, channels, calls, ...) we keep a local, persisted snapshot of the
+ * pinned entities for display and write the pin set through to the backend so
+ * it stays the source of truth.
+ */
+
+const STORAGE_KEY = 'macro:pinned-entities:v1';
+
+type PinnedEntry = {
+  /** The entity id. */
+  id: string;
+  /** Backend pin type (matches `EntityType`, snake_case). */
+  pinType: string;
+  /** Snapshot of the entity used to render the pinned row. */
+  entity: EntityData;
+};
+
+/**
+ * Maps a frontend entity to the backend pin type (`EntityType`, snake_case).
+ * Returns `null` for entities that cannot be pinned (no entity_access backing).
+ */
+function toPinType(entity: EntityData): string | null {
+  switch (entity.type) {
+    case 'document':
+      return 'document';
+    case 'chat':
+      return 'chat';
+    case 'project':
+      return 'project';
+    case 'email':
+      return 'email_thread';
+    case 'call':
+      return 'call';
+    case 'channel':
+      return 'channel';
+    // channel_message, automation and foreign entities are not pinnable.
+    default:
+      return null;
+  }
+}
+
+/** Whether the given entity can be pinned. */
+export function canPinEntity(entity: EntityData): boolean {
+  return toPinType(entity) !== null;
+}
+
+function load(): PinnedEntry[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (entry): entry is PinnedEntry =>
+        entry != null &&
+        typeof entry.id === 'string' &&
+        typeof entry.pinType === 'string' &&
+        entry.entity != null
+    );
+  } catch {
+    return [];
+  }
+}
+
+const [entries, setEntries] = createSignal<PinnedEntry[]>(load());
+
+function persist(next: PinnedEntry[]): void {
+  setEntries(next);
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+  } catch {
+    // localStorage may be unavailable or full; the in-memory signal still works.
+  }
+}
+
+/** Reactive, ordered list of pinned entities. */
+export function pinnedEntities(): EntityData[] {
+  return entries().map((entry) => entry.entity);
+}
+
+/** Whether an entity (by id) is currently pinned. */
+export function isPinned(id: string): boolean {
+  return entries().some((entry) => entry.id === id);
+}
+
+/** Pins an entity. No-op if it is not pinnable or already pinned. */
+export function pinEntity(entity: EntityData): void {
+  const pinType = toPinType(entity);
+  if (!pinType) return;
+  if (isPinned(entity.id)) return;
+
+  const next = [...entries(), { id: entity.id, pinType, entity }];
+  persist(next);
+
+  // Write through to the backend (best effort — display is driven locally).
+  void storageServiceClient
+    .pinItem({ id: entity.id, pinType, pinIndex: next.length - 1 })
+    .catch(() => {});
+}
+
+/** Removes a pin. No-op if the entity is not pinned. */
+export function unpinEntity(id: string): void {
+  const existing = entries().find((entry) => entry.id === id);
+  if (!existing) return;
+
+  persist(entries().filter((entry) => entry.id !== id));
+
+  void storageServiceClient
+    .removePin({ id, pinType: existing.pinType })
+    .catch(() => {});
+}
+
+/**
+ * Toggles the pinned state of an entity.
+ * Returns the new pinned state (`true` if now pinned).
+ */
+export function togglePin(entity: EntityData): boolean {
+  if (isPinned(entity.id)) {
+    unpinEntity(entity.id);
+    return false;
+  }
+  pinEntity(entity);
+  return true;
+}


### PR DESCRIPTION
## Summary
Implements a client-side pinning system for entities with persistent storage and UI integration. Users can now pin documents, chats, projects, emails, calls, and channels for quick access from the sidebar.

## Key Changes
- **New pinning signal store** (`pins.ts`): Manages pinned entities with local persistence via localStorage while syncing with the backend. Supports pinning any entity type that has backend pin support.
- **Pinned widget component** (`pinned-widget.tsx`): Displays pinned entities in the sidebar with two layouts:
  - Expanded: Full list with entity icons and titles
  - Slim: Compact grid showing up to 4 items with overflow indicator
- **Pin action** (`make-pin-action.ts`): Implements toggle pin/unpin functionality for entity selections with toast notifications
- **Sidebar integration**: Added PinnedWidget to the main sidebar with scrollable container (10-20rem height)
- **Context menu support**: Right-click options to open pinned items in current or new split, or unpin them
- **Action menu integration**: Pin/unpin action added to entity action menus in the soup view

## Implementation Details
- The system maintains a local snapshot of pinned entities for rendering while the backend remains the source of truth
- Pin operations are write-through: local state updates immediately for responsive UI, then syncs to backend (best effort)
- Supports mapping frontend entity types to backend pin types (e.g., `email` → `email_thread`)
- Gracefully handles localStorage unavailability—in-memory signal continues to work
- Pinned items can be opened in current split (click) or new split (shift+click)

https://claude.ai/code/session_01SgxdRrh8YABj1ANhdDNJUe