### PR TITLE
refactor(email): rename useIsInboxOnlyLinkedChild → useIsConnectedSecondaryInbox

### DIFF
--- a/js/app/packages/core/component/UserIcon.tsx
+++ b/js/app/packages/core/component/UserIcon.tsx
@@ -8,7 +8,7 @@ import {
   tryMacroId,
   useDisplayName,
   useDisplayNameParts,
-  useIsInboxOnlyLinkedChild,
+  useIsConnectedSecondaryInbox,
 } from '@core/user';
 import MacroLogo from '@icon/macro-logo.svg';
 import Trash from '@phosphor-icons/core/regular/trash.svg?component-solid';
@@ -161,10 +161,10 @@ export function UserIcon(props: UserIconProps) {
 
   const { replaceOrInsertSplit } = useSplitLayout();
   const getOrCreateDmMutation = useGetOrCreateDirectMessageMutation();
-  const isInboxOnlyLinkedChild = useIsInboxOnlyLinkedChild();
+  const isConnectedSecondaryInbox = useIsConnectedSecondaryInbox();
 
   const getOrCreateDm = () => {
-    if (!props.id || isInboxOnlyLinkedChild(props.id)) return;
+    if (!props.id || isConnectedSecondaryInbox(props.id)) return;
     getOrCreateDmMutation.mutate(
       { recipient_id: props.id },
       {

--- a/js/app/packages/core/component/UserTooltip.tsx
+++ b/js/app/packages/core/component/UserTooltip.tsx
@@ -1,7 +1,7 @@
 import { useSplitLayout } from '@app/component/split-layout/layout';
 import { toast } from '@core/component/Toast/Toast';
 import { useUserId } from '@core/context/user';
-import { useIsInboxOnlyLinkedChild } from '@core/user';
+import { useIsConnectedSecondaryInbox } from '@core/user';
 import WideChat from '@icon/wide-chat.svg';
 import WideCopy from '@icon/wide-copy.svg';
 import WideTask from '@icon/wide-task.svg';
@@ -36,9 +36,9 @@ export function UserTooltip(props: UserTooltipProps) {
     props.onClose?.();
   }
   const currentUserId = useUserId();
-  const isInboxOnlyLinkedChild = useIsInboxOnlyLinkedChild();
+  const isConnectedSecondaryInbox = useIsConnectedSecondaryInbox();
   const canTreatAsUser = () =>
-    !!props.id && !props.isDeleted && !isInboxOnlyLinkedChild(props.id);
+    !!props.id && !props.isDeleted && !isConnectedSecondaryInbox(props.id);
   const { openWithSplit, popoverSplit } = useSplitLayout();
   const getOrCreateDmMutation = useGetOrCreateDirectMessageMutation({
     onError: () => toast.failure('Failed to open direct message'),

--- a/js/app/packages/core/context/quickAccess/QuickAccessProvider.tsx
+++ b/js/app/packages/core/context/quickAccess/QuickAccessProvider.tsx
@@ -4,7 +4,7 @@ import {
   type IUser,
   useAugmentUserWithDmActivity,
   useContacts,
-  useIsInboxOnlyLinkedChild,
+  useIsConnectedSecondaryInbox,
 } from '@core/user';
 import type { DateValue } from '@core/util/date';
 import type { ChannelEntity } from '@entity';
@@ -212,7 +212,7 @@ export const [QuickAccessProvider, useQuickAccess] =
       const { channels, isLoading: channelsLoading } = useChannelsContext();
       const contacts = useContacts();
       const augmentUserWithDmActivity = useAugmentUserWithDmActivity();
-      const isInboxOnlyLinkedChild = useIsInboxOnlyLinkedChild();
+      const isConnectedSecondaryInbox = useIsConnectedSecondaryInbox();
       const instructionsIdQuery = useInstructionsMdIdQuery();
 
       // globally hidden ids
@@ -378,7 +378,7 @@ export const [QuickAccessProvider, useQuickAccess] =
         // Process contacts (users)
         const contactData = contacts();
         for (const contact of contactData) {
-          if (isInboxOnlyLinkedChild(contact.id)) continue;
+          if (isConnectedSecondaryInbox(contact.id)) continue;
           const augmentedUser = augmentUserWithDmActivity(contact);
           seenIds.add(augmentedUser.id);
 

--- a/js/app/packages/core/signal/useCombinedRecipient.ts
+++ b/js/app/packages/core/signal/useCombinedRecipient.ts
@@ -3,7 +3,7 @@ import {
   type CombinedRecipientItem,
   recipientEntityMapper,
   useContacts,
-  useIsInboxOnlyLinkedChild,
+  useIsConnectedSecondaryInbox,
 } from '@core/user';
 import { type Accessor, createMemo } from 'solid-js';
 
@@ -36,11 +36,11 @@ type UseCombinedRecipients<K extends 'user' | 'channel'> = {
 const useCombinedRecipientsRoot = () => {
   const contacts = useContacts();
   const channelsContext = useChannelsContext();
-  const isInboxOnlyLinkedChild = useIsInboxOnlyLinkedChild();
+  const isConnectedSecondaryInbox = useIsConnectedSecondaryInbox();
 
   const userContactEntities = createMemo<CombinedRecipientItem<'user'>[]>(() =>
     contacts()
-      .filter((contact) => !isInboxOnlyLinkedChild(contact.id))
+      .filter((contact) => !isConnectedSecondaryInbox(contact.id))
       .map(recipientEntityMapper('user'))
   );
 

--- a/js/app/packages/core/user/inboxOnly.ts
+++ b/js/app/packages/core/user/inboxOnly.ts
@@ -2,8 +2,13 @@ import { useEmailLinksQuery } from '@queries/email/link';
 import { createMemo } from 'solid-js';
 import { macroIdToEmail, tryMacroId } from './macroId';
 
-/** Predicate: is this macro id one of the current user's inbox-only delegated inboxes. */
-export function useIsInboxOnlyLinkedChild() {
+/**
+ * Predicate: is this macro id a connected secondary inbox (an extra mailbox the
+ * current user attached to their own account, flagged `is_inbox_only`) rather than
+ * a real user. Not to be confused with a delegated/shared inbox, which is a separate
+ * loggable user (its own macro id) and reports `is_inbox_only = false`.
+ */
+export function useIsConnectedSecondaryInbox() {
   const linksQuery = useEmailLinksQuery();
 
   const inboxOnlyEmails = createMemo(() => {

--- a/js/app/packages/core/user/index.ts
+++ b/js/app/packages/core/user/index.ts
@@ -13,7 +13,7 @@ export {
   useDisplayNameParts,
 } from './displayName';
 export { useAugmentUserWithDmActivity } from './dmActivity';
-export { useIsInboxOnlyLinkedChild } from './inboxOnly';
+export { useIsConnectedSecondaryInbox } from './inboxOnly';
 export {
   emailToMacroId,
   type MacroId,


### PR DESCRIPTION
Renames the FE helper `useIsInboxOnlyLinkedChild` → `useIsConnectedSecondaryInbox`: "Child" wrongly implied a `macro_user_links` child (a delegated/shared inbox, which is a real user), but the helper actually gates on `is_inbox_only` — the opposite, connected-secondary-inbox case. Pure rename plus a clarifying doc comment; behavior unchanged.
