### PR TITLE
fix(channel): focus input when pressing enter with no message selected

### DIFF
--- a/js/app/packages/channel/Channel/create-channel-hotkeys.ts
+++ b/js/app/packages/channel/Channel/create-channel-hotkeys.ts
@@ -53,6 +53,10 @@ export function createChannelHotkeys(options: CreateChannelHotkeysOptions) {
     return options.messageById().get(id);
   };
 
+  const focusInput = () => {
+    inputEl?.querySelector<HTMLElement>('[contenteditable]')?.focus();
+  };
+
   registerHotkey({
     scopeId: messageListScope,
     hotkey: 'arrowup',
@@ -79,7 +83,7 @@ export function createChannelHotkeys(options: CreateChannelHotkeysOptions) {
         options.navigation()?.markUserIntent('down');
         options.navigation()?.scrollToId(id, { align: 'nearest' });
       } else {
-        inputEl?.querySelector<HTMLElement>('[contenteditable]')?.focus();
+        focusInput();
       }
       return true;
     },
@@ -108,6 +112,19 @@ export function createChannelHotkeys(options: CreateChannelHotkeysOptions) {
       if (!msg) return false;
       const actions = options.getMessageActions(msg);
       actions?.onReply?.({ message: msg });
+      return true;
+    },
+  });
+
+  registerHotkey({
+    scopeId: messageListScope,
+    hotkey: 'enter',
+    hotkeyToken: TOKENS.channel.focusInput,
+    description: 'Focus input',
+    registrationType: 'add',
+    condition: () => !hasSelection(),
+    keyDownHandler: () => {
+      focusInput();
       return true;
     },
   });


### PR DESCRIPTION
## Problem

Regression: when a channel message list was focused but the input was not, pressing **enter** no longer focused the input. The focus-input-on-enter hotkey was dropped in a refactor, leaving `TOKENS.channel.focusInput` orphaned (defined but never registered).

## Fix

Re-register an `enter` hotkey on the message list scope (via `registrationType: 'add'`) that focuses the channel input when no message is selected. The existing reply-on-enter behavior still takes precedence when a message is selected.

https://claude.ai/code/session_01W97jtR2NF17k66NXWTKE7Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01W97jtR2NF17k66NXWTKE7Y)_