### PR TITLE
fix(search): exclude foreign entities from search soup view

### DIFF
--- a/js/app/packages/app/component/app-sidebar/soup-filter-presets.ts
+++ b/js/app/packages/app/component/app-sidebar/soup-filter-presets.ts
@@ -379,7 +379,10 @@ export const VIEW_TAB_PRESETS: Record<ListView, ViewTabConfig> = {
     default: 'all',
     tabs: {
       all: () => ({
-        filters: {},
+        // Temporary: search has no full-text index over foreign entities yet,
+        // so exclude them all from the search view (matching no record id)
+        // until search supports them.
+        filters: { include: { foreignEntityRecordId: [NIL_UUID] } },
         clientFilters: {},
       }),
     },


### PR DESCRIPTION
Foreign entities (today only GitHub PRs) surface as rows in the search soup view, but search has no full-text match over them yet, so showing them is misleading and noisy. This filters the search view's soup feed on a foreign-entity record id that matches nothing, excluding all foreign entities — current and future — from search. Single line in the search preset. Temporary: remove it once search supports foreign entities (e.g. real PR search).