### PR TITLE
fix(soup): notifications unrolled for email

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
@@ -1281,6 +1281,7 @@ export const SoupViewList = (props: SoupViewListProps) => {
                                           soup.focus.setIndex(row.index);
                                         }}
                                         showUnrollNotifications={
+                                          row.original.type !== 'email' &&
                                           soup.predicates.isActive('inbox') &&
                                           !soup.predicates.isActive('noise')
                                         }


### PR DESCRIPTION
This is was caused by the mapping fix in #3792 for `toNotificationEntity` that correctly mapped the emails to their corresponding notification type. This was originally not mapped before this PR either by mistake or intentionally.