### PR TITLE
fix(soup): exclude foreign entities from recently-viewed Cmd-K menu

### DIFF
--- a/js/app/packages/queries/soup/recently-viewed.ts
+++ b/js/app/packages/queries/soup/recently-viewed.ts
@@ -20,7 +20,6 @@ const RECENTLY_VIEWED_GC_TIME = 10 * 60 * 1000; // 10 minutes
 const recentlyViewedArgs: SoupItemsQueryArgs = {
   params: { sort_method: 'viewed_at', limit: RECENTLY_VIEWED_LIMIT },
   body: {
-    // No viewed_at signal on calls or crm_companies — exclude both.
     call_filters: {
       call_ids: [NIL_UUID],
     },

--- a/js/app/packages/queries/soup/recently-viewed.ts
+++ b/js/app/packages/queries/soup/recently-viewed.ts
@@ -1,3 +1,4 @@
+import { NIL_UUID } from '@app/component/next-soup/filters/filter-store';
 import { throwOnErr } from '@core/util/result';
 import { storageServiceClient } from '@service-storage/client';
 import { useQuery } from '@tanstack/solid-query';
@@ -21,10 +22,13 @@ const recentlyViewedArgs: SoupItemsQueryArgs = {
   body: {
     // No viewed_at signal on calls or crm_companies — exclude both.
     call_filters: {
-      call_ids: ['00000000-0000-0000-0000-000000000000'],
+      call_ids: [NIL_UUID],
     },
     crm_company_filters: {
-      company_ids: ['00000000-0000-0000-0000-000000000000'],
+      company_ids: [NIL_UUID],
+    },
+    foreign_entity_filters: {
+      ids: [NIL_UUID],
     },
   },
 };


### PR DESCRIPTION
Foreign entities (today only GitHub PRs) leak into the Cmd-K recently-viewed menu, which can't navigate to them yet, so they're just noise. This adds a foreign-entity filter matching the nil UUID to the global recently-viewed-at soup call, excluding them all. Temporary, mirroring #3876 — remove once Cmd-K supports foreign entities.
