### PR TITLE
Add GitHub Pull Request block for viewing PRs in-app

### DIFF
--- a/js/app/packages/app/component/next-soup/utils.ts
+++ b/js/app/packages/app/component/next-soup/utils.ts
@@ -15,7 +15,6 @@ import type { BlockOrchestrator } from '@core/orchestrator';
 import type { DateValue } from '@core/util/date';
 import { throwOnErr } from '@core/util/result';
 import { waitForFrames } from '@core/util/sleep';
-import { openExternalUrl } from '@core/util/url';
 import {
   type EntityData,
   getSnippetHit,
@@ -334,12 +333,9 @@ export const openEntityInSplitFromUnifiedList = async (
     return;
   }
 
-  // TODO(dev-rb/github): Route GitHub PRs to /pr.
-  if (isGithubPrEntity(entity)) {
-    openExternalUrl(entity.metadata.url);
-    return;
-  }
-  if (entity.type === 'foreign') return;
+  // GitHub PRs open in the in-app `pr` block (see getEntitySplitContent).
+  // Other foreign entities have no in-app block to open.
+  if (entity.type === 'foreign' && !isGithubPrEntity(entity)) return;
 
   const blockOrchestrator = splitManager.getOrchestrator();
 
@@ -382,7 +378,6 @@ export const openEntityInSplitFromUnifiedList = async (
   }
 };
 
-// TODO(dev-rb/github): Map GitHub PRs to { type: 'pr', id }.
 function getEntitySplitContent(entity: EntityData) {
   return match(entity)
     .with({ type: 'document' }, (entity) => {
@@ -394,6 +389,12 @@ function getEntitySplitContent(entity: EntityData) {
     .with({ type: 'channel_message' }, (entity) => {
       return { type: 'channel' as const, id: entity.channelId };
     })
+    .with(
+      { type: 'foreign', foreignSource: 'github_pull_request' },
+      (entity) => {
+        return { type: 'pr' as const, id: entity.id };
+      }
+    )
     .with({ type: 'foreign' }, (entity) => {
       return { type: 'unknown' as const, id: entity.id };
     })

--- a/js/app/packages/app/constants/list-views.ts
+++ b/js/app/packages/app/constants/list-views.ts
@@ -66,6 +66,7 @@ const BLOCK_LIST_VIEW_MAP = {
   video: 'documents',
   write: 'documents',
   automation: 'agents',
+  pr: 'inbox',
 } as const satisfies Record<BlockName | BlockAlias, ListView>;
 
 const _getBlockListView = (block: BlockName | BlockAlias): ListView => {

--- a/js/app/packages/block-pr/component/Block.tsx
+++ b/js/app/packages/block-pr/component/Block.tsx
@@ -1,0 +1,48 @@
+import { SidePanel } from '@app/component/side-panel';
+import { useBlockId } from '@core/block';
+import { usePullRequestEntityQuery } from '@queries/pull-request/pull-request';
+import { createMemo, Match, Switch } from 'solid-js';
+import { normalizePullRequestMetadata } from '../utils';
+import { PullRequestBody } from './PullRequestBody';
+import { PullRequestSplitHeaderLoading } from './PullRequestSplitHeader';
+import { PullRequestSidePanelSections } from './sidepanel/PullRequestSidePanelSections';
+
+export default function Block() {
+  const id = useBlockId();
+  const query = usePullRequestEntityQuery(() => id);
+
+  const metadata = createMemo(() => {
+    const data = query.data;
+    if (!data) return null;
+    return normalizePullRequestMetadata(data.metadata);
+  });
+
+  return (
+    <div class="flex h-full flex-col @container">
+      <Switch>
+        <Match when={metadata()}>
+          {(pr) => (
+            <SidePanel.Layout>
+              <PullRequestSidePanelSections metadata={pr} />
+              <div class="flex size-full min-h-0 min-w-0 flex-col overflow-hidden @container">
+                <PullRequestBody metadata={pr} />
+              </div>
+            </SidePanel.Layout>
+          )}
+        </Match>
+        <Match when={query.isLoading}>
+          <PullRequestSplitHeaderLoading />
+          <div class="flex min-h-0 flex-1 items-center justify-center text-sm text-ink-faint">
+            Loading pull request…
+          </div>
+        </Match>
+        <Match when={!query.isLoading}>
+          <PullRequestSplitHeaderLoading />
+          <div class="flex min-h-0 flex-1 items-center justify-center text-sm text-failure">
+            Failed to load pull request.
+          </div>
+        </Match>
+      </Switch>
+    </div>
+  );
+}

--- a/js/app/packages/block-pr/component/PrChecks.tsx
+++ b/js/app/packages/block-pr/component/PrChecks.tsx
@@ -1,0 +1,79 @@
+import ArrowSquareOut from '@phosphor/arrow-square-out.svg';
+import Check from '@phosphor/check.svg';
+import CircleDashed from '@phosphor/circle-dashed.svg';
+import X from '@phosphor/x.svg';
+import type { GithubPullRequestCheckRun } from '@service-storage/generated/schemas';
+import { cn } from '@ui';
+import { type Component, type JSX, Show } from 'solid-js';
+import { Dynamic } from 'solid-js/web';
+
+type CheckState = 'success' | 'failure' | 'pending' | 'neutral';
+
+const FAILURE_CONCLUSIONS = new Set([
+  'failure',
+  'timed_out',
+  'cancelled',
+  'action_required',
+  'startup_failure',
+  'stale',
+]);
+const NEUTRAL_CONCLUSIONS = new Set(['neutral', 'skipped']);
+
+function checkState(check: GithubPullRequestCheckRun): CheckState {
+  const status = (check.status ?? '').toLowerCase();
+  if (status && status !== 'completed') return 'pending';
+
+  const conclusion = (check.conclusion ?? '').toLowerCase();
+  if (conclusion === 'success') return 'success';
+  if (FAILURE_CONCLUSIONS.has(conclusion)) return 'failure';
+  if (NEUTRAL_CONCLUSIONS.has(conclusion)) return 'neutral';
+  return conclusion ? 'neutral' : 'pending';
+}
+
+const STATE_META: Record<
+  CheckState,
+  { icon: Component<JSX.SvgSVGAttributes<SVGSVGElement>>; class: string }
+> = {
+  success: { icon: Check, class: 'text-success' },
+  failure: { icon: X, class: 'text-failure' },
+  pending: { icon: CircleDashed, class: 'text-ink-muted' },
+  neutral: { icon: CircleDashed, class: 'text-ink-muted' },
+};
+
+function checkLabel(check: GithubPullRequestCheckRun): string {
+  const status = (check.status ?? '').toLowerCase();
+  if (status && status !== 'completed') return status.replace(/_/g, ' ');
+  return (check.conclusion ?? 'completed').replace(/_/g, ' ');
+}
+
+export function PrCheckRow(props: { check: GithubPullRequestCheckRun }) {
+  const state = () => checkState(props.check);
+  const meta = () => STATE_META[state()];
+
+  return (
+    <div class="flex items-center gap-2.5 px-3 py-2 text-sm">
+      <span class={cn('shrink-0', meta().class)}>
+        <Dynamic component={meta().icon} class="size-4" />
+      </span>
+      <span class="min-w-0 flex-1 truncate text-ink" title={props.check.name}>
+        {props.check.name}
+      </span>
+      <span class="shrink-0 text-xs capitalize text-ink-muted">
+        {checkLabel(props.check)}
+      </span>
+      <Show when={props.check.url}>
+        {(url) => (
+          <a
+            href={url()}
+            target="_blank"
+            rel="noopener noreferrer"
+            class="shrink-0 text-ink-extra-muted hover:text-ink"
+            aria-label={`Open ${props.check.name} on GitHub`}
+          >
+            <ArrowSquareOut class="size-3.5" />
+          </a>
+        )}
+      </Show>
+    </div>
+  );
+}

--- a/js/app/packages/block-pr/component/PrComment.tsx
+++ b/js/app/packages/block-pr/component/PrComment.tsx
@@ -1,8 +1,10 @@
+import { StaticMarkdown } from '@core/component/LexicalMarkdown/component/core/StaticMarkdown';
 import ArrowSquareOut from '@phosphor/arrow-square-out.svg';
 import type { GithubPullRequestComment } from '@service-storage/generated/schemas';
 import { Layer } from '@ui';
 import { format } from 'date-fns';
 import { Show } from 'solid-js';
+import { sanitizeCommentMarkdown } from '../utils';
 
 function sourceLabel(source: string): string {
   switch (source) {
@@ -26,7 +28,7 @@ function formatWhen(value?: string | null): string | null {
 
 export function PrComment(props: { comment: GithubPullRequestComment }) {
   const when = () => formatWhen(props.comment.createdAt);
-  const body = () => props.comment.body?.trim();
+  const body = () => sanitizeCommentMarkdown(props.comment.body ?? '');
 
   return (
     <Layer depth={1}>
@@ -63,9 +65,11 @@ export function PrComment(props: { comment: GithubPullRequestComment }) {
             </div>
           }
         >
-          <div class="whitespace-pre-wrap break-words px-3 py-2 text-sm text-ink">
-            {body()}
-          </div>
+          {(text) => (
+            <div class="px-3 py-2 text-sm/6 text-ink text-pretty">
+              <StaticMarkdown markdown={text()} target="external" />
+            </div>
+          )}
         </Show>
       </div>
     </Layer>

--- a/js/app/packages/block-pr/component/PrComment.tsx
+++ b/js/app/packages/block-pr/component/PrComment.tsx
@@ -1,0 +1,73 @@
+import ArrowSquareOut from '@phosphor/arrow-square-out.svg';
+import type { GithubPullRequestComment } from '@service-storage/generated/schemas';
+import { Layer } from '@ui';
+import { format } from 'date-fns';
+import { Show } from 'solid-js';
+
+function sourceLabel(source: string): string {
+  switch (source) {
+    case 'review':
+      return 'reviewed';
+    case 'review_comment':
+      return 'commented on code';
+    case 'issue_comment':
+      return 'commented';
+    default:
+      return 'commented';
+  }
+}
+
+function formatWhen(value?: string | null): string | null {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return format(date, 'MMM d, yyyy · h:mm a');
+}
+
+export function PrComment(props: { comment: GithubPullRequestComment }) {
+  const when = () => formatWhen(props.comment.createdAt);
+  const body = () => props.comment.body?.trim();
+
+  return (
+    <Layer depth={1}>
+      <div class="overflow-hidden rounded-lg border border-edge-muted/60 bg-surface">
+        <div class="flex items-center gap-2 border-b border-edge-muted/60 px-3 py-2 text-xs">
+          <span class="font-medium text-ink">
+            {props.comment.authorLogin ?? 'Someone'}
+          </span>
+          <span class="text-ink-muted">
+            {sourceLabel(props.comment.source)}
+          </span>
+          <Show when={when()}>
+            {(w) => <span class="text-ink-extra-muted">· {w()}</span>}
+          </Show>
+          <Show when={props.comment.url}>
+            {(url) => (
+              <a
+                href={url()}
+                target="_blank"
+                rel="noopener noreferrer"
+                class="ml-auto shrink-0 text-ink-extra-muted hover:text-ink"
+                aria-label="Open comment on GitHub"
+              >
+                <ArrowSquareOut class="size-3.5" />
+              </a>
+            )}
+          </Show>
+        </div>
+        <Show
+          when={body()}
+          fallback={
+            <div class="px-3 py-2 text-sm italic text-ink-faint">
+              No comment body.
+            </div>
+          }
+        >
+          <div class="whitespace-pre-wrap break-words px-3 py-2 text-sm text-ink">
+            {body()}
+          </div>
+        </Show>
+      </div>
+    </Layer>
+  );
+}

--- a/js/app/packages/block-pr/component/PrStatusBadge.tsx
+++ b/js/app/packages/block-pr/component/PrStatusBadge.tsx
@@ -1,0 +1,34 @@
+import GitMerge from '@phosphor/git-merge.svg';
+import GitPullRequest from '@phosphor/git-pull-request.svg';
+import { cn } from '@ui';
+import type { Component, JSX } from 'solid-js';
+import { Dynamic } from 'solid-js/web';
+import { PR_STATUS_META, type PullRequestStatus } from '../utils';
+
+const STATUS_ICON: Record<
+  PullRequestStatus,
+  Component<JSX.SvgSVGAttributes<SVGSVGElement>>
+> = {
+  open: GitPullRequest,
+  merged: GitMerge,
+  closed: GitPullRequest,
+};
+
+export function PrStatusBadge(props: {
+  status: PullRequestStatus;
+  class?: string;
+}) {
+  const meta = () => PR_STATUS_META[props.status];
+  return (
+    <span
+      class={cn(
+        'inline-flex shrink-0 items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium leading-none',
+        meta().badgeClass,
+        props.class
+      )}
+    >
+      <Dynamic component={STATUS_ICON[props.status]} class="size-3.5" />
+      <span>{meta().label}</span>
+    </span>
+  );
+}

--- a/js/app/packages/block-pr/component/PullRequestBody.tsx
+++ b/js/app/packages/block-pr/component/PullRequestBody.tsx
@@ -1,0 +1,112 @@
+import { CustomScrollbar } from '@core/component/CustomScrollbar';
+import { openExternalUrl } from '@core/util/url';
+import GithubIcon from '@icon/mcp-github.svg';
+import ArrowSquareOut from '@phosphor/arrow-square-out.svg';
+import { Button } from '@ui';
+import { type Accessor, createMemo, createSignal, For, Show } from 'solid-js';
+import { hasLineChanges, type PullRequestMetadata } from '../utils';
+import { PrComment } from './PrComment';
+import { PrStatusBadge } from './PrStatusBadge';
+import { PullRequestSplitHeader } from './PullRequestSplitHeader';
+
+function commentTimestamp(value?: string | null): number {
+  if (!value) return 0;
+  const time = new Date(value).getTime();
+  return Number.isNaN(time) ? 0 : time;
+}
+
+export function PullRequestBody(props: {
+  metadata: Accessor<PullRequestMetadata>;
+}) {
+  const [scrollRef, setScrollRef] = createSignal<HTMLDivElement>();
+  const metadata = props.metadata;
+
+  const comments = createMemo(() =>
+    [...metadata().comments].sort(
+      (a, b) => commentTimestamp(a.createdAt) - commentTimestamp(b.createdAt)
+    )
+  );
+
+  return (
+    <>
+      <PullRequestSplitHeader metadata={metadata} />
+      <div class="relative min-h-0 flex-1 overflow-hidden">
+        <div
+          class="h-full min-h-0 overflow-y-auto scrollbar-hidden"
+          ref={setScrollRef}
+        >
+          <div class="mx-auto min-w-0 max-w-3xl px-6 pt-10 pb-16">
+            <div class="flex flex-col gap-10">
+              <header class="flex flex-col gap-4">
+                <div class="flex items-start gap-3">
+                  <h1 class="min-w-0 flex-1 text-balance text-2xl font-semibold text-ink">
+                    {metadata().name}
+                  </h1>
+                  <PrStatusBadge status={metadata().status} class="mt-1" />
+                </div>
+
+                <div class="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-ink-muted">
+                  <span class="font-mono">
+                    {metadata().owner}/{metadata().repo}
+                  </span>
+                  <span class="text-ink-extra-muted">#{metadata().number}</span>
+                  <Show when={hasLineChanges(metadata())}>
+                    <span class="text-ink-extra-muted">·</span>
+                    <span class="font-mono tabular-nums">
+                      <span class="text-success">+{metadata().additions}</span>
+                      <span class="mx-0.5 text-ink-extra-muted">/</span>
+                      <span class="text-failure">-{metadata().deletions}</span>
+                    </span>
+                  </Show>
+                </div>
+
+                <div class="flex flex-col gap-1.5">
+                  <Button
+                    variant="base"
+                    size="md"
+                    class="w-fit gap-2"
+                    onClick={() => openExternalUrl(metadata().url)}
+                  >
+                    <GithubIcon class="size-4" />
+                    <span>Open in GitHub</span>
+                    <ArrowSquareOut class="size-3.5 text-ink-muted" />
+                  </Button>
+                  <p class="text-xs text-ink-faint">
+                    View the full diff and conversation on GitHub.
+                  </p>
+                </div>
+              </header>
+
+              <section class="flex flex-col gap-3">
+                <h3 class="text-sm font-semibold text-ink">
+                  Conversation
+                  <Show when={comments().length > 0}>
+                    <span class="font-normal text-ink-extra-muted">
+                      {' '}
+                      ({comments().length})
+                    </span>
+                  </Show>
+                </h3>
+                <Show
+                  when={comments().length > 0}
+                  fallback={
+                    <div class="rounded-lg border border-dashed border-edge-muted/70 px-4 py-6 text-center text-sm text-ink-faint">
+                      No comments yet.
+                    </div>
+                  }
+                >
+                  <div class="flex flex-col gap-3">
+                    <For each={comments()}>
+                      {(comment) => <PrComment comment={comment} />}
+                    </For>
+                  </div>
+                </Show>
+              </section>
+            </div>
+          </div>
+        </div>
+        <CustomScrollbar scrollContainer={scrollRef} />
+      </div>
+    </>
+  );
+}

--- a/js/app/packages/block-pr/component/PullRequestBody.tsx
+++ b/js/app/packages/block-pr/component/PullRequestBody.tsx
@@ -1,4 +1,6 @@
 import { CustomScrollbar } from '@core/component/CustomScrollbar';
+import { StaticMarkdownContext } from '@core/component/LexicalMarkdown/component/core/StaticMarkdown';
+import { aiChatTheme } from '@core/component/LexicalMarkdown/theme';
 import { openExternalUrl } from '@core/util/url';
 import GithubIcon from '@icon/mcp-github.svg';
 import ArrowSquareOut from '@phosphor/arrow-square-out.svg';
@@ -95,11 +97,13 @@ export function PullRequestBody(props: {
                     </div>
                   }
                 >
-                  <div class="flex flex-col gap-3">
-                    <For each={comments()}>
-                      {(comment) => <PrComment comment={comment} />}
-                    </For>
-                  </div>
+                  <StaticMarkdownContext theme={aiChatTheme}>
+                    <div class="flex flex-col gap-3">
+                      <For each={comments()}>
+                        {(comment) => <PrComment comment={comment} />}
+                      </For>
+                    </div>
+                  </StaticMarkdownContext>
                 </Show>
               </section>
             </div>

--- a/js/app/packages/block-pr/component/PullRequestSplitHeader.tsx
+++ b/js/app/packages/block-pr/component/PullRequestSplitHeader.tsx
@@ -1,0 +1,50 @@
+import { SidePanel } from '@app/component/side-panel';
+import { SplitHeaderLeft } from '@app/component/split-layout/components/SplitHeader';
+import { StaticSplitLabel } from '@app/component/split-layout/components/SplitLabel';
+import { SplitToolbarLeft } from '@app/component/split-layout/components/SplitToolbar';
+import GithubIcon from '@icon/mcp-github.svg';
+import type { Accessor } from 'solid-js';
+import type { PullRequestMetadata } from '../utils';
+import { PrStatusBadge } from './PrStatusBadge';
+
+function HeaderIcon() {
+  return <GithubIcon class="size-4 shrink-0 text-ink-muted touch:size-6" />;
+}
+
+export function PullRequestSplitHeaderLoading() {
+  return (
+    <SplitHeaderLeft>
+      <div class="my-auto flex h-full min-w-0 items-center justify-start gap-3">
+        <div class="relative flex h-full min-w-0 max-w-full shrink items-center gap-2">
+          <StaticSplitLabel label="Pull Request" icon={<HeaderIcon />} />
+        </div>
+      </div>
+    </SplitHeaderLeft>
+  );
+}
+
+export function PullRequestSplitHeader(props: {
+  metadata: Accessor<PullRequestMetadata>;
+}) {
+  const label = () => props.metadata().name;
+
+  return (
+    <>
+      <SplitHeaderLeft>
+        <div class="my-auto flex h-full min-w-0 items-center justify-start gap-3">
+          <div class="relative flex h-full min-w-0 max-w-full shrink items-center gap-2">
+            <StaticSplitLabel
+              label={label()}
+              icon={<HeaderIcon />}
+              badges={<PrStatusBadge status={props.metadata().status} />}
+            />
+          </div>
+        </div>
+      </SplitHeaderLeft>
+
+      <SplitToolbarLeft>
+        <SidePanel.NarrowTabs />
+      </SplitToolbarLeft>
+    </>
+  );
+}

--- a/js/app/packages/block-pr/component/sidepanel/PullRequestSidePanelSections.tsx
+++ b/js/app/packages/block-pr/component/sidepanel/PullRequestSidePanelSections.tsx
@@ -1,0 +1,81 @@
+import { SidePanel } from '@app/component/side-panel';
+import { openExternalUrl } from '@core/util/url';
+import GithubIcon from '@icon/mcp-github.svg';
+import ArrowSquareOut from '@phosphor/arrow-square-out.svg';
+import { cn } from '@ui';
+import { type Accessor, For, Show } from 'solid-js';
+import { hasLineChanges, type PullRequestMetadata } from '../../utils';
+import { PrCheckRow } from '../PrChecks';
+import { PrStatusBadge } from '../PrStatusBadge';
+
+export function PullRequestSidePanelSections(props: {
+  metadata: Accessor<PullRequestMetadata>;
+}) {
+  const metadata = props.metadata;
+  const checks = () => metadata().checks;
+
+  return (
+    <>
+      <SidePanel.Section id="details" title="Details" defaultOpen order={10}>
+        <div class="flex flex-col gap-3">
+          <SidePanel.Grid>
+            <SidePanel.Row label="Status">
+              <PrStatusBadge status={metadata().status} />
+            </SidePanel.Row>
+            <SidePanel.Row label="Repository">
+              <SidePanel.Pill>
+                <span class="truncate font-mono">
+                  {metadata().owner}/{metadata().repo}
+                </span>
+              </SidePanel.Pill>
+            </SidePanel.Row>
+            <SidePanel.Row label="Number">
+              <SidePanel.Pill>
+                <span class="truncate">#{metadata().number}</span>
+              </SidePanel.Pill>
+            </SidePanel.Row>
+            <Show when={hasLineChanges(metadata())}>
+              <SidePanel.Row label="Changes">
+                <SidePanel.Pill>
+                  <span class="font-mono tabular-nums">
+                    <span class="text-success">+{metadata().additions}</span>
+                    <span class="mx-0.5 text-ink-extra-muted">/</span>
+                    <span class="text-failure">-{metadata().deletions}</span>
+                  </span>
+                </SidePanel.Pill>
+              </SidePanel.Row>
+            </Show>
+          </SidePanel.Grid>
+
+          <button
+            type="button"
+            onClick={() => openExternalUrl(metadata().url)}
+            class={cn(
+              'inline-flex h-7 w-fit select-none items-center gap-1.5 rounded-md px-2.5 text-xs',
+              'border border-edge-muted bg-surface text-ink-muted',
+              'hover:bg-hover hover:text-ink'
+            )}
+          >
+            <GithubIcon class="size-3.5 shrink-0" />
+            <span class="whitespace-nowrap">Open in GitHub</span>
+            <ArrowSquareOut class="size-3 shrink-0" />
+          </button>
+        </div>
+      </SidePanel.Section>
+
+      <Show when={checks().length > 0}>
+        <SidePanel.Section
+          id="checks"
+          title={
+            <SidePanel.CountTitle label="Checks" count={checks().length} />
+          }
+          order={20}
+        >
+          <div class="-mx-2 flex flex-col divide-y divide-edge-muted/60">
+            <For each={checks()}>{(check) => <PrCheckRow check={check} />}</For>
+          </div>
+        </SidePanel.Section>
+      </Show>
+    </>
+  );
+}

--- a/js/app/packages/block-pr/definition.ts
+++ b/js/app/packages/block-pr/definition.ts
@@ -1,0 +1,19 @@
+import { defineBlock, type ExtractLoadType, LoadErrors } from '@core/block';
+import { ok } from 'neverthrow';
+import { lazy } from 'solid-js';
+
+export const definition = defineBlock({
+  name: 'pr',
+  description: 'View GitHub pull requests',
+  defaultFilename: 'Pull Request',
+  component: lazy(() => import('./component/Block')),
+  async load(source, _intent) {
+    if (source.type === 'dss') {
+      return ok({ id: source.id });
+    }
+    return LoadErrors.MISSING;
+  },
+  accepted: {},
+});
+
+export type PullRequestData = ExtractLoadType<(typeof definition)['load']>;

--- a/js/app/packages/block-pr/package.json
+++ b/js/app/packages/block-pr/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "block-pr",
+  "private": true,
+  "scripts": {},
+  "dependencies": {}
+}

--- a/js/app/packages/block-pr/tsconfig.json
+++ b/js/app/packages/block-pr/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "preserve",
+    "jsxImportSource": "solid-js",
+    "verbatimModuleSyntax": true,
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "composite": true
+  }
+}

--- a/js/app/packages/block-pr/utils.ts
+++ b/js/app/packages/block-pr/utils.ts
@@ -1,0 +1,62 @@
+import type { GithubPullRequestEntity } from '@entity';
+import type { GithubPullRequest } from '@service-storage/generated/schemas';
+
+/**
+ * The normalized pull request metadata used throughout the PR block. Mirrors
+ * the shape produced by the Soup transform so the block and the list view stay
+ * in sync.
+ */
+export type PullRequestMetadata = GithubPullRequestEntity['metadata'];
+export type PullRequestStatus = PullRequestMetadata['status'];
+
+/**
+ * Normalize the raw `foreign_entity.metadata` JSON (stored in the
+ * `GithubPullRequest` shape) into the strongly typed metadata the block
+ * renders. Returns `null` when the payload is not a recognizable pull request.
+ */
+export function normalizePullRequestMetadata(
+  raw: unknown
+): PullRequestMetadata | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const m = raw as Partial<GithubPullRequest>;
+  if (typeof m.number !== 'number' || !m.owner || !m.repo || !m.url) {
+    return null;
+  }
+
+  let status: PullRequestStatus = 'open';
+  if (m.status === 'merged') {
+    status = 'merged';
+  } else if (m.status === 'closed') {
+    status = 'closed';
+  }
+
+  const displayName = m.displayName ?? `${m.owner}/${m.repo}#${m.number}`;
+
+  return {
+    number: m.number,
+    name: m.name ?? displayName,
+    owner: m.owner,
+    repo: m.repo,
+    url: m.url,
+    status,
+    additions: m.additions ?? 0,
+    deletions: m.deletions ?? 0,
+    comments: m.comments ?? [],
+    checks: (m.checks ?? []).filter(Boolean),
+  };
+}
+
+/** Display label and badge styling for each pull request status. */
+export const PR_STATUS_META: Record<
+  PullRequestStatus,
+  { label: string; badgeClass: string }
+> = {
+  open: { label: 'Open', badgeClass: 'bg-success-bg text-success' },
+  merged: { label: 'Merged', badgeClass: 'bg-accent-bg text-accent' },
+  closed: { label: 'Closed', badgeClass: 'bg-failure/12 text-failure' },
+};
+
+/** Whether the pull request reports any line changes. */
+export function hasLineChanges(metadata: PullRequestMetadata): boolean {
+  return metadata.additions > 0 || metadata.deletions > 0;
+}

--- a/js/app/packages/block-pr/utils.ts
+++ b/js/app/packages/block-pr/utils.ts
@@ -60,3 +60,28 @@ export const PR_STATUS_META: Record<
 export function hasLineChanges(metadata: PullRequestMetadata): boolean {
   return metadata.additions > 0 || metadata.deletions > 0;
 }
+
+/**
+ * Lightly sanitize GitHub comment markdown for our renderer: drop HTML comments
+ * and unwrap a few structural HTML tags (e.g. `<details>`/`<summary>`) that
+ * GitHub renders but our markdown renderer doesn't, so they don't show up as
+ * literal tags. Fenced code blocks are left untouched so code examples stay
+ * intact.
+ */
+export function sanitizeCommentMarkdown(body: string): string {
+  const stripHtml = (segment: string): string =>
+    segment
+      .replace(/<!--[\s\S]*?-->/g, '')
+      .replace(/<br\s*\/?>/gi, '\n')
+      .replace(
+        /<\/?(?:details|summary|div|span|picture|source|sub|sup|kbd|img)\b[^>]*>/gi,
+        ''
+      );
+
+  return body
+    .split(/(```[\s\S]*?```)/g)
+    .map((part, index) => (index % 2 === 1 ? part : stripHtml(part)))
+    .join('')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}

--- a/js/app/packages/core/block.ts
+++ b/js/app/packages/core/block.ts
@@ -63,6 +63,7 @@ export const BlockRegistry = [
   'email',
   'contact',
   'automation',
+  'pr',
 ] as const;
 
 type BlockNameKeys = keyof typeof BlockRegistry & number;
@@ -97,6 +98,7 @@ export const NonDocumentBlockTypes = [
   'email',
   'contact',
   'automation',
+  'pr',
 ] as const as (BlockName | BlockAlias)[];
 
 /**
@@ -149,6 +151,7 @@ const _ValidBlockCombinations: BlockCombinationRules = {
   task: allBlockNames,
   automation: allBlockNames,
   csv: allBlockNames,
+  pr: allBlockNames,
 } as const;
 
 // maps block name to valid parents
@@ -170,6 +173,7 @@ export const ValidNestingCombinations: BlockCombinationRules = {
   task: new Set([]),
   automation: new Set([]),
   csv: new Set([]),
+  pr: new Set([]),
 };
 
 export const LoadErrors = {

--- a/js/app/packages/core/blockMethodRegistry.ts
+++ b/js/app/packages/core/blockMethodRegistry.ts
@@ -35,6 +35,7 @@ export interface BlockMethodRegistry {
   component: EmptySpec;
   task: EmptySpec;
   automation: EmptySpec;
+  pr: EmptySpec;
 }
 
 // Type helper to get the method spec for a block name

--- a/js/app/packages/core/component/EntityIcon.tsx
+++ b/js/app/packages/core/component/EntityIcon.tsx
@@ -260,6 +260,12 @@ export const ENTITY_ICON_CONFIGS: Record<EntityWithValidIcon, IconConfig> = {
     background: 'bg-default/20',
     prettyName: 'GitHub Pull Request',
   },
+  pr: {
+    icon: GithubIcon,
+    foreground: 'text-default',
+    background: 'bg-default/20',
+    prettyName: 'Pull Request',
+  },
   task: {
     icon: Check,
     foreground: 'text-task',
@@ -328,6 +334,7 @@ const WIDE_ICONS: Record<EntityWithValidIcon, Component> = {
   emailRead: WideEmail,
   emailInvite: WideCalendar,
   githubPullRequest: GithubIcon,
+  pr: GithubIcon,
   task: WideTask,
   automation: Robot,
 };

--- a/js/app/packages/core/component/FileList/constants.tsx
+++ b/js/app/packages/core/component/FileList/constants.tsx
@@ -75,4 +75,5 @@ const _fileTypeColors: Record<BlockName | BlockAlias | 'default', string> = {
   unknown: defaultFileColor,
   task: defaultFileColor,
   automation: defaultFileColor,
+  pr: defaultFileColor,
 };

--- a/js/app/packages/entity/src/utils/buildEntityData.ts
+++ b/js/app/packages/entity/src/utils/buildEntityData.ts
@@ -52,9 +52,15 @@ export function buildEntityData(
   const { id, name, blockName, ownerId = '' } = args;
   if (!id || !name || !blockName) return undefined;
 
+  // Pull requests are foreign entities that require GitHub metadata (owner,
+  // repo, number, etc.) not available from this simple shape.
+  if (blockName === 'pr') return undefined;
+
   const base = { id, name, ownerId };
 
-  return match<BlockName | BlockAlias, EntityData | undefined>(blockName)
+  return match<Exclude<BlockName | BlockAlias, 'pr'>, EntityData | undefined>(
+    blockName
+  )
     .with(
       'task',
       (): TaskEntity => ({

--- a/js/app/packages/queries/pull-request/keys.ts
+++ b/js/app/packages/queries/pull-request/keys.ts
@@ -1,0 +1,12 @@
+const root = ['pull-request'] as const;
+const entity = [...root, 'entity'] as const;
+
+export const pullRequestKeys = {
+  _def: root,
+  entity: Object.assign(
+    (id: string) => ({
+      queryKey: [...entity, id] as const,
+    }),
+    { _def: entity }
+  ),
+} as const;

--- a/js/app/packages/queries/pull-request/pull-request.ts
+++ b/js/app/packages/queries/pull-request/pull-request.ts
@@ -1,0 +1,21 @@
+import { throwOnErr } from '@core/util/result';
+import { storageServiceClient } from '@service-storage/client';
+import { useQuery } from '@tanstack/solid-query';
+import type { Accessor } from 'solid-js';
+import { pullRequestKeys } from './keys';
+
+/**
+ * Fetch a GitHub pull request foreign entity by its internal id. The PR block
+ * is opened with the foreign entity's id (the same id Soup uses), so this reads
+ * the stored, server-synced metadata back out for display.
+ */
+export function usePullRequestEntityQuery(id: Accessor<string>) {
+  return useQuery(() => ({
+    queryKey: pullRequestKeys.entity(id()).queryKey,
+    queryFn: async () =>
+      await throwOnErr(() =>
+        storageServiceClient.getForeignEntity({ id: id() })
+      ),
+    enabled: !!id(),
+  }));
+}

--- a/js/app/packages/service-clients/service-storage/client.ts
+++ b/js/app/packages/service-clients/service-storage/client.ts
@@ -30,6 +30,7 @@ import type { ApiChannelWithLatest } from './channel-list-types';
 import type {
   AccessLevel,
   CallRecordPreview,
+  ForeignEntity,
   GithubPullRequestsResponse,
   PostSoupAstRequest,
   PostSoupRequest,
@@ -1148,6 +1149,16 @@ export const storageServiceClient = {
       `/documents/${documentId}/github_prs`,
       { method: 'GET' }
     );
+  },
+
+  async getForeignEntity({
+    id,
+  }: {
+    id: string;
+  }): Promise<Result<ForeignEntity, ResultError<FetchWithTokenErrorCode>[]>> {
+    return await dssFetch<ForeignEntity>(`/foreign_entity/${id}`, {
+      method: 'GET',
+    });
   },
 
   async exportDocument({ documentId }) {

--- a/js/app/tsconfig.json
+++ b/js/app/tsconfig.json
@@ -78,6 +78,9 @@
       "@block-project/*": [
         "./packages/block-project/*"
       ],
+      "@block-pr/*": [
+        "./packages/block-pr/*"
+      ],
       "@service-auth/*": [
         "./packages/service-clients/service-auth/*"
       ],

--- a/js/bun.lock
+++ b/js/bun.lock
@@ -195,6 +195,9 @@
         "zod-validation-error": "^5.0.0",
       },
     },
+    "app/packages/block-pr": {
+      "name": "block-pr",
+    },
     "app/packages/block-project": {
       "name": "block-project",
     },
@@ -1655,6 +1658,8 @@
     "block-markdown": ["block-markdown@workspace:app/packages/block-md"],
 
     "block-pdf": ["block-pdf@workspace:app/packages/block-pdf"],
+
+    "block-pr": ["block-pr@workspace:app/packages/block-pr"],
 
     "block-project": ["block-project@workspace:app/packages/block-project"],
 


### PR DESCRIPTION
## Summary
Introduces a new `pr` block that allows users to view GitHub pull requests directly within the application, replacing the previous behavior of opening PRs in an external browser.

## Key Changes

- **New PR Block Package** (`block-pr`): Created a complete block implementation with:
  - `Block.tsx`: Main component that loads and displays PR metadata
  - `PullRequestBody.tsx`: Main content area showing PR title, details, and comments
  - `PullRequestSidePanelSections.tsx`: Side panel displaying PR status, repository info, and check runs
  - `PrComment.tsx`: Individual comment rendering with author, timestamp, and source type
  - `PrChecks.tsx`: GitHub check run status display with icons and links
  - `PrStatusBadge.tsx`: Visual badge for PR status (open/merged/closed)
  - `PullRequestSplitHeader.tsx`: Header components for split layout view
  - `utils.ts`: Metadata normalization and status constants

- **Query Infrastructure**: Added `usePullRequestEntityQuery` hook to fetch foreign entity data from storage service

- **Storage Service Client**: Extended `storageServiceClient` with `getForeignEntity()` method to retrieve PR metadata by ID

- **Block Registry**: Registered `pr` as a new block type in the core block system

- **Entity Handling**: Updated entity building and routing logic to:
  - Map GitHub PR entities to the new `pr` block instead of opening externally
  - Add PR icon configuration to entity icon system
  - Route PR blocks to the inbox list view

- **Type System**: Added `pr` to block name registry, method registry, and file type colors

## Implementation Details

- PR metadata is normalized from the raw foreign entity storage format into a strongly-typed `PullRequestMetadata` shape
- Comments are sorted chronologically by creation timestamp
- Check runs are filtered and displayed with status indicators (success/failure/pending/neutral)
- All external links (GitHub, comments, checks) open in new tabs with proper accessibility labels
- The UI uses existing design system components (Layer, SidePanel, Button, etc.) for consistency
- Supports displaying PR additions/deletions when available

https://claude.ai/code/session_013CcbMaiGmVBDRDv5qWigQo