### PR TITLE
fix: put solid surface color behind user profile pictures

### DIFF
--- a/js/app/packages/core/component/UserIcon.tsx
+++ b/js/app/packages/core/component/UserIcon.tsx
@@ -100,6 +100,9 @@ function ProfileImage(props: {
     >
       {(url) => (
         <Avatar.Image
+          // Solid surface circle behind the picture so a transparent profile
+          // picture shows surface color rather than what's rendered behind the avatar.
+          class="bg-surface"
           src={staticFileSizedUrl(url, 'small')}
           onError={(e) => {
             if (e.currentTarget.src !== url) {


### PR DESCRIPTION
The `Avatar` root uses `has-[img]:bg-transparent`, so when a profile picture is present the avatar background becomes transparent. A profile picture with transparent regions therefore revealed whatever was rendered behind the avatar (stacked avatars, rings, indicators, etc.).

This gives the profile image element a solid `bg-surface` fill in `ProfileImage`. Since the avatar container is `rounded-full overflow-hidden`, the result is a surface-colored circle exactly the size of the picture, sitting behind any transparent regions.

https://claude.ai/code/session_019EQfhDp1XnQ4o5g9yh8tTD

---
_Generated by [Claude Code](https://claude.ai/code/session_019EQfhDp1XnQ4o5g9yh8tTD)_