### PR TITLE
feat(search): search-view inbox filter dropdown + chip

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/consolidated-filter-chip.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/consolidated-filter-chip.tsx
@@ -39,6 +39,8 @@ export type ConsolidatedFilter = {
   onRemoveValue?: (valueId: string) => void;
   /** Remove all values (clear entire filter) */
   onRemoveAll: () => void;
+  /** Whether to show the trailing remove (✕) button. Defaults to true. */
+  showRemove?: Accessor<boolean>;
   /** Toggle a value on/off */
   onToggleValue?: (valueId: string) => void;
   /** Check if a value is active */
@@ -367,21 +369,23 @@ export const ConsolidatedFilterChip = (props: ConsolidatedFilterChipProps) => {
           </Match>
         </Switch>
 
-        <ChipDivider mobile={props.mobile} />
+        <Show when={props.filter.showRemove?.() ?? true}>
+          <ChipDivider mobile={props.mobile} />
 
-        <Button
-          class={cn(
-            'rounded-none h-full not-disabled:hover:text-failure',
-            props.mobile && 'bg-active border-none'
-          )}
-          size="icon-sm"
-          onClick={(e) => {
-            e.stopPropagation();
-            props.filter.onRemoveAll();
-          }}
-        >
-          <XIcon class="size-3.5!" />
-        </Button>
+          <Button
+            class={cn(
+              'rounded-none h-full not-disabled:hover:text-failure',
+              props.mobile && 'bg-active border-none'
+            )}
+            size="icon-sm"
+            onClick={(e) => {
+              e.stopPropagation();
+              props.filter.onRemoveAll();
+            }}
+          >
+            <XIcon class="size-3.5!" />
+          </Button>
+        </Show>
       </div>
     </Layer>
   );

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/inbox-selector.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/inbox-selector.tsx
@@ -1,13 +1,9 @@
-import { useSoupView } from '@app/component/next-soup/soup-view/soup-view-context';
-import { inboxIconProps } from '@core/component/inboxIcon';
-import { UserIcon } from '@core/component/UserIcon';
 import { Combobox } from '@kobalte/core/combobox';
 import CaretDownIcon from '@phosphor/caret-down.svg';
 import TrayIcon from '@phosphor/tray.svg';
-import { useEmailLinksQuery } from '@queries/email/link';
 import { Button } from '@ui';
-import { createMemo, Show } from 'solid-js';
-import type { SearchableOption } from './search-filter-controls';
+import { Show } from 'solid-js';
+import { useInboxFilter } from './search-filter-controls';
 import { SearchableMultiSelect } from './searchable-multi-select';
 
 /**
@@ -17,51 +13,14 @@ import { SearchableMultiSelect } from './searchable-multi-select';
  * into `Owner` email literals.
  */
 export function InboxSelector() {
-  const linksQuery = useEmailLinksQuery();
-  const links = () => linksQuery.data?.links ?? [];
-  const { inboxFilter, setInboxFilter } = useSoupView();
-
-  const options = createMemo((): SearchableOption[] =>
-    links()
-      .map((link) => ({
-        id: link.id,
-        label: link.email_address,
-        icon: () => (
-          <UserIcon
-            {...inboxIconProps(link.email_address)}
-            photoUrl={link.photo_url ?? undefined}
-            size="sm"
-            suppressClick
-            showTooltip={false}
-          />
-        ),
-      }))
-      .sort((a, b) => a.label.localeCompare(b.label))
-  );
-
-  const activeIds = createMemo(() => {
-    const selected = inboxFilter();
-    return selected === undefined ? links().map((l) => l.id) : selected;
-  });
-
-  const onChange = (ids: string[]) =>
-    setInboxFilter(ids.length === links().length ? undefined : ids);
-
-  const label = () => {
-    const ids = inboxFilter();
-    if (ids === undefined) return 'All inboxes';
-    if (ids.length === 0) return 'No inboxes';
-    if (ids.length === 1)
-      return links().find((l) => l.id === ids[0])?.email_address ?? '1 inbox';
-    return `${ids.length} inboxes`;
-  };
+  const inbox = useInboxFilter();
 
   return (
-    <Show when={links().length > 1}>
+    <Show when={inbox.hasMultiple()}>
       <SearchableMultiSelect
-        options={options}
-        activeIds={activeIds}
-        onChange={onChange}
+        options={inbox.options}
+        activeIds={inbox.activeIds}
+        onChange={inbox.setIds}
         placeholder="Search inboxes..."
         preserveOrder
       >
@@ -73,7 +32,7 @@ export function InboxSelector() {
           class="bg-surface gap-1 max-w-50"
         >
           <TrayIcon />
-          <span class="truncate">{label()}</span>
+          <span class="truncate">{inbox.label()}</span>
           <CaretDownIcon class="size-3 shrink-0" />
         </Combobox.Trigger>
       </SearchableMultiSelect>

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/search-filter-controls.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/search-filter-controls.tsx
@@ -158,7 +158,7 @@ export function useSearchFilterOptions() {
 }
 
 type ChannelSubFilters = Pick<ChannelFilters, 'channel_ids' | 'sender_ids'>;
-type EmailSubFilters = Pick<EmailFilters, 'importance' | 'link_ids'>;
+type EmailSubFilters = Pick<EmailFilters, 'importance'>;
 type CallSubFilters = {
   channel_ids?: string[];
   speaker_ids?: string[];
@@ -312,21 +312,20 @@ export function useChannelSearchFilter(opts: SearchFilterHookOpts) {
 }
 
 /**
- * Inbox options + selection for the email search filter. Shared by the filter
- * dropdown and the active-filter chip. Empty selection means "all inboxes"
- * (no clause); the dropdown shows every inbox checked in that state.
+ * Inbox filter shared by the email view (InboxSelector), the search filter
+ * dropdown, and the active-filter chip. Selection lives in soup-view's
+ * `inboxFilter`: `undefined` = all inboxes (no clause), `[]` = no inboxes, a
+ * subset = those inboxes. Selecting every inbox collapses back to `undefined`.
+ * `applyInboxFilter` compiles it into the soup feed and search-service request.
  */
-export function useEmailInboxPicker() {
-  const { soup, queryFilters } = useSoupView();
-  const { changeIndex } = useSearchIndexController();
+export function useInboxFilter() {
+  const { inboxFilter, setInboxFilter } = useSoupView();
   const linksQuery = useEmailLinksQuery();
 
-  const allIds = createMemo(() =>
-    (linksQuery.data?.links ?? []).map((l) => l.id)
-  );
+  const links = createMemo(() => linksQuery.data?.links ?? []);
 
   const options = createMemo((): SearchableOption[] =>
-    (linksQuery.data?.links ?? [])
+    links()
       .map((link) => ({
         id: link.id,
         label: link.email_address,
@@ -349,38 +348,42 @@ export function useEmailInboxPicker() {
     return map;
   });
 
-  // The explicit selection; empty means "all inboxes" (no clause).
-  const selectedIds = createMemo(
-    () => queryFilters.state.include.emailLinkId ?? []
-  );
-
-  // Dropdown display: every inbox checked when unfiltered.
-  const activeIds = createMemo(() => {
-    const selected = selectedIds();
-    return selected.length ? selected : allIds();
-  });
+  // Checkbox state: every inbox checked when unfiltered (selection is undefined).
+  const activeIds = createMemo(() => inboxFilter() ?? links().map((l) => l.id));
 
   const setIds = (ids: string[]) =>
-    batch(() => {
-      if (!soup.predicates.isActive('email')) changeIndex('email');
-      queryFilters.set({
-        include: {
-          emailLinkId:
-            ids.length === 0 || ids.length === allIds().length
-              ? undefined
-              : ids,
-        },
-      });
-    });
+    setInboxFilter(ids.length === links().length ? undefined : ids);
 
-  return { options, labelMap, selectedIds, activeIds, setIds };
+  // Back to all inboxes (the chip's remove action).
+  const reset = () => setInboxFilter(undefined);
+
+  const hasMultiple = () => links().length > 1;
+
+  const label = () => {
+    const ids = inboxFilter();
+    if (ids === undefined) return 'All inboxes';
+    if (ids.length === 0) return 'No inboxes';
+    if (ids.length === 1) return labelMap().get(ids[0]) ?? '1 inbox';
+    return `${ids.length} inboxes`;
+  };
+
+  return {
+    options,
+    labelMap,
+    selectedIds: inboxFilter,
+    activeIds,
+    setIds,
+    reset,
+    hasMultiple,
+    label,
+  };
 }
 
 /** Email search filters (importance, inbox). */
 export function useEmailSearchFilter(opts: SearchFilterHookOpts) {
   const { soup, queryFilters } = useSoupView();
   const { changeIndex } = useSearchIndexController();
-  const inbox = useEmailInboxPicker();
+  const inbox = useInboxFilter();
 
   const isActive = () => soup.predicates.isActive('email');
   const importance = createMemo(
@@ -400,11 +403,18 @@ export function useEmailSearchFilter(opts: SearchFilterHookOpts) {
       });
     });
 
+  // Activate the email index when scoping inboxes from the dropdown while a
+  // different index is selected.
+  const setInboxIds = (ids: string[]) =>
+    batch(() => {
+      if (!isActive()) changeIndex('email');
+      inbox.setIds(ids);
+    });
+
   createEffect(() => {
     if (!opts.isSearchView() || !isActive()) return;
     cacheEmailSubFilters(opts.contentId, {
       importance: importance() ?? null,
-      link_ids: inbox.selectedIds().length ? inbox.selectedIds() : undefined,
     });
   });
 
@@ -414,7 +424,7 @@ export function useEmailSearchFilter(opts: SearchFilterHookOpts) {
     setImportance,
     inboxOptions: inbox.options,
     inboxActiveIds: inbox.activeIds,
-    setInboxIds: inbox.setIds,
+    setInboxIds,
   };
 }
 
@@ -533,7 +543,6 @@ export function useSearchIndexController() {
           include: {
             ...opt.queryFilters.include,
             emailImportance: importance,
-            emailLinkId: cached.link_ids,
           },
           exclude: opt.queryFilters.exclude,
         });

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/search-filter-controls.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/search-filter-controls.tsx
@@ -15,10 +15,12 @@ import {
 import { useSoupView } from '@app/component/next-soup/soup-view/soup-view-context';
 import { useSplitPanelOrThrow } from '@app/component/split-layout/layoutUtils';
 import { EntityIcon } from '@core/component/EntityIcon';
+import { inboxIconProps } from '@core/component/inboxIcon';
 import { UserIcon } from '@core/component/UserIcon';
 import { useQuickAccess } from '@core/context/quickAccess';
 import { useUserId } from '@core/context/user';
 import { EntityIcon as EntityIconWithAvatar } from '@entity/extractors/entity-icon';
+import { useEmailLinksQuery } from '@queries/email/link';
 import type {
   ChannelFilters,
   EmailFilters,
@@ -156,7 +158,7 @@ export function useSearchFilterOptions() {
 }
 
 type ChannelSubFilters = Pick<ChannelFilters, 'channel_ids' | 'sender_ids'>;
-type EmailSubFilters = Pick<EmailFilters, 'importance'>;
+type EmailSubFilters = Pick<EmailFilters, 'importance' | 'link_ids'>;
 type CallSubFilters = {
   channel_ids?: string[];
   speaker_ids?: string[];
@@ -309,10 +311,76 @@ export function useChannelSearchFilter(opts: SearchFilterHookOpts) {
   };
 }
 
-/** Email search filters (importance). */
+/**
+ * Inbox options + selection for the email search filter. Shared by the filter
+ * dropdown and the active-filter chip. Empty selection means "all inboxes"
+ * (no clause); the dropdown shows every inbox checked in that state.
+ */
+export function useEmailInboxPicker() {
+  const { soup, queryFilters } = useSoupView();
+  const { changeIndex } = useSearchIndexController();
+  const linksQuery = useEmailLinksQuery();
+
+  const allIds = createMemo(() =>
+    (linksQuery.data?.links ?? []).map((l) => l.id)
+  );
+
+  const options = createMemo((): SearchableOption[] =>
+    (linksQuery.data?.links ?? [])
+      .map((link) => ({
+        id: link.id,
+        label: link.email_address,
+        icon: () => (
+          <UserIcon
+            {...inboxIconProps(link.email_address)}
+            photoUrl={link.photo_url ?? undefined}
+            size="sm"
+            suppressClick
+            showTooltip={false}
+          />
+        ),
+      }))
+      .sort((a, b) => a.label.localeCompare(b.label))
+  );
+
+  const labelMap = createMemo(() => {
+    const map = new Map<string, string>();
+    for (const opt of options()) map.set(opt.id, opt.label);
+    return map;
+  });
+
+  // The explicit selection; empty means "all inboxes" (no clause).
+  const selectedIds = createMemo(
+    () => queryFilters.state.include.emailLinkId ?? []
+  );
+
+  // Dropdown display: every inbox checked when unfiltered.
+  const activeIds = createMemo(() => {
+    const selected = selectedIds();
+    return selected.length ? selected : allIds();
+  });
+
+  const setIds = (ids: string[]) =>
+    batch(() => {
+      if (!soup.predicates.isActive('email')) changeIndex('email');
+      queryFilters.set({
+        include: {
+          emailLinkId:
+            ids.length === 0 || ids.length === allIds().length
+              ? undefined
+              : ids,
+        },
+      });
+    });
+
+  return { options, labelMap, selectedIds, activeIds, setIds };
+}
+
+/** Email search filters (importance, inbox). */
 export function useEmailSearchFilter(opts: SearchFilterHookOpts) {
   const { soup, queryFilters } = useSoupView();
   const { changeIndex } = useSearchIndexController();
+  const inbox = useEmailInboxPicker();
 
   const isActive = () => soup.predicates.isActive('email');
   const importance = createMemo(
@@ -334,10 +402,20 @@ export function useEmailSearchFilter(opts: SearchFilterHookOpts) {
 
   createEffect(() => {
     if (!opts.isSearchView() || !isActive()) return;
-    cacheEmailSubFilters(opts.contentId, { importance: importance() ?? null });
+    cacheEmailSubFilters(opts.contentId, {
+      importance: importance() ?? null,
+      link_ids: inbox.selectedIds().length ? inbox.selectedIds() : undefined,
+    });
   });
 
-  return { isActive, importance, setImportance };
+  return {
+    isActive,
+    importance,
+    setImportance,
+    inboxOptions: inbox.options,
+    inboxActiveIds: inbox.activeIds,
+    setInboxIds: inbox.setIds,
+  };
 }
 
 type CallFieldMap = {
@@ -455,6 +533,7 @@ export function useSearchIndexController() {
           include: {
             ...opt.queryFilters.include,
             emailImportance: importance,
+            emailLinkId: cached.link_ids,
           },
           exclude: opt.queryFilters.exclude,
         });

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/unified-filter-dropdown.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/unified-filter-dropdown.tsx
@@ -533,16 +533,27 @@ const IMPORTANCE_OPTIONS: {
   { label: 'All', value: undefined },
 ];
 
-/** Importance (emails). */
+/** Importance + Inbox (emails). */
 const EmailSearchSubContent = (props: {
   email: ReturnType<typeof useEmailSearchFilter>;
 }) => (
-  <SingleValueSubmenu
-    label="Importance"
-    options={IMPORTANCE_OPTIONS}
-    current={props.email.importance}
-    onSelect={props.email.setImportance}
-  />
+  <>
+    <SingleValueSubmenu
+      label="Importance"
+      options={IMPORTANCE_OPTIONS}
+      current={props.email.importance}
+      onSelect={props.email.setImportance}
+    />
+    <Show when={props.email.inboxOptions().length > 1}>
+      <SearchableFilterSubmenu
+        label="Inbox"
+        options={props.email.inboxOptions}
+        activeIds={props.email.inboxActiveIds}
+        onChange={props.email.setInboxIds}
+        placeholder="Search inboxes..."
+      />
+    </Show>
+  </>
 );
 
 /** In + From + Status (calls). */

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/use-filter-refinements.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/use-filter-refinements.tsx
@@ -48,7 +48,7 @@ import {
   getCallStatusLabel,
   INDEX_OPTIONS,
   type SearchableOption,
-  useEmailInboxPicker,
+  useInboxFilter,
   useSearchFilterOptions,
   useSearchIndexController,
 } from './search-filter-controls';
@@ -92,7 +92,7 @@ export function useFilterRefinements() {
   const currentUserId = useUserId();
   const { channelOptions, channelLabelMap, senderOptions, senderLabelMap } =
     useSearchFilterOptions();
-  const inbox = useEmailInboxPicker();
+  const inbox = useInboxFilter();
   const { changeIndex } = useSearchIndexController();
 
   const getPresetContext = (): PresetContext => ({
@@ -556,33 +556,22 @@ export function useFilterRefinements() {
       key: string;
       categoryLabel: string;
       getIds: () => string[];
-      // Checked state for the popup, when it differs from the displayed values
-      // (e.g. inbox: empty selection means "all", shown as every box checked).
-      activeIds?: Accessor<string[]>;
       searchableOptions: Accessor<SearchableOption[]>;
       labelMap: Accessor<Map<string, string>>;
       onChange: (ids: string[]) => void;
       searchPlaceholder: string;
-      // When set, the chip is always shown; an empty selection renders this
-      // neutral label instead of disappearing, and the remove button is hidden
-      // until a non-default subset is chosen.
-      neutralLabel?: string;
     }) => {
       const popupOpen =
         consolidatedChipCache.get(args.key)?.isPopupOpen?.() ?? false;
       const ids = args.getIds();
-      if (ids.length === 0 && !popupOpen && !args.neutralLabel) return;
+      if (ids.length === 0 && !popupOpen) return;
 
       seenKeys.add(args.key);
 
       // Compute values as accessor for reactivity
       const getValues = (): FilterValue[] => {
-        const ids = args.getIds();
-        if (ids.length === 0 && args.neutralLabel) {
-          return [{ id: '__all__', label: args.neutralLabel }];
-        }
         const options = args.searchableOptions();
-        return ids.map((id) => {
+        return args.getIds().map((id) => {
           const opt = options.find((o) => o.id === id);
           return {
             id,
@@ -608,15 +597,12 @@ export function useFilterRefinements() {
             categoryLabel: args.categoryLabel,
             values: getValues,
             searchableOptions: args.searchableOptions,
-            activeSearchableIds: args.activeIds ?? args.getIds,
+            activeSearchableIds: args.getIds,
             onSearchableChange: args.onChange,
             searchPlaceholder: args.searchPlaceholder,
             isPopupOpen,
             setPopupOpen,
             onRemoveAll: () => args.onChange([]),
-            showRemove: args.neutralLabel
-              ? () => args.getIds().length > 0
-              : undefined,
           };
         })
       );
@@ -761,19 +747,42 @@ export function useFilterRefinements() {
         );
       }
 
-      // Email inbox filter (only when the account has more than one inbox)
-      if (soup.predicates.isActive('email') && inbox.options().length > 1) {
-        pushSearchableConsolidatedChip({
-          key: 'email-inbox',
-          categoryLabel: 'Inbox',
-          getIds: inbox.selectedIds,
-          activeIds: inbox.activeIds,
-          searchableOptions: inbox.options,
-          labelMap: inbox.labelMap,
-          onChange: inbox.setIds,
-          searchPlaceholder: 'Search inboxes...',
-          neutralLabel: 'All inboxes',
-        });
+      // Email inbox filter (always shown; "All inboxes" when unset). Backed by
+      // soup-view's inboxFilter — same state and semantics as the email view.
+      if (soup.predicates.isActive('email') && inbox.hasMultiple()) {
+        const key = 'email-inbox';
+        seenKeys.add(key);
+
+        const getInboxValues = (): FilterValue[] => [
+          { id: '__inbox__', label: inbox.label() },
+        ];
+
+        filters.push(
+          getOrCreateConsolidatedChip(key, () => {
+            const [isPopupOpen, _setPopupOpen] = createSignal(false);
+            const setPopupOpen = (v: boolean) => {
+              if (!v) {
+                queueMicrotask(() =>
+                  panel.panelRef()?.focus({ preventScroll: true })
+                );
+              }
+              _setPopupOpen(v);
+            };
+            return {
+              key,
+              categoryLabel: 'Inbox',
+              values: getInboxValues,
+              searchableOptions: inbox.options,
+              activeSearchableIds: inbox.activeIds,
+              onSearchableChange: inbox.setIds,
+              searchPlaceholder: 'Search inboxes...',
+              isPopupOpen,
+              setPopupOpen,
+              showRemove: () => inbox.selectedIds() !== undefined,
+              onRemoveAll: () => inbox.reset(),
+            };
+          })
+        );
       }
     }
 

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/use-filter-refinements.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/use-filter-refinements.tsx
@@ -563,18 +563,26 @@ export function useFilterRefinements() {
       labelMap: Accessor<Map<string, string>>;
       onChange: (ids: string[]) => void;
       searchPlaceholder: string;
+      // When set, the chip is always shown; an empty selection renders this
+      // neutral label instead of disappearing, and the remove button is hidden
+      // until a non-default subset is chosen.
+      neutralLabel?: string;
     }) => {
       const popupOpen =
         consolidatedChipCache.get(args.key)?.isPopupOpen?.() ?? false;
       const ids = args.getIds();
-      if (ids.length === 0 && !popupOpen) return;
+      if (ids.length === 0 && !popupOpen && !args.neutralLabel) return;
 
       seenKeys.add(args.key);
 
       // Compute values as accessor for reactivity
       const getValues = (): FilterValue[] => {
+        const ids = args.getIds();
+        if (ids.length === 0 && args.neutralLabel) {
+          return [{ id: '__all__', label: args.neutralLabel }];
+        }
         const options = args.searchableOptions();
-        return args.getIds().map((id) => {
+        return ids.map((id) => {
           const opt = options.find((o) => o.id === id);
           return {
             id,
@@ -606,6 +614,9 @@ export function useFilterRefinements() {
             isPopupOpen,
             setPopupOpen,
             onRemoveAll: () => args.onChange([]),
+            showRemove: args.neutralLabel
+              ? () => args.getIds().length > 0
+              : undefined,
           };
         })
       );
@@ -703,17 +714,14 @@ export function useFilterRefinements() {
         }
       }
 
-      // Email importance filter
-      if (
-        soup.predicates.isActive('email') &&
-        queryFilters.state.include.emailImportance !== undefined
-      ) {
+      // Email importance filter (always shown; "All" when unset)
+      if (soup.predicates.isActive('email')) {
         const key = 'email-importance';
         seenKeys.add(key);
 
         const getImportanceValues = (): FilterValue[] => {
           const importance = filterData().include.emailImportance;
-          if (importance === undefined) return [];
+          if (importance === undefined) return [{ id: 'all', label: 'All' }];
           return [
             {
               id: importance ? 'signal' : 'noise',
@@ -732,9 +740,13 @@ export function useFilterRefinements() {
               { id: 'noise', label: 'Noise' },
             ],
             multiple: false,
-            isValueActive: (id) =>
-              id ===
-              (filterData().include.emailImportance ? 'signal' : 'noise'),
+            showRemove: () =>
+              filterData().include.emailImportance !== undefined,
+            isValueActive: (id) => {
+              const importance = filterData().include.emailImportance;
+              if (importance === undefined) return false;
+              return id === (importance ? 'signal' : 'noise');
+            },
             onToggleValue: (id) =>
               queryFilters.add({
                 include: { emailImportance: id === 'signal' },
@@ -760,6 +772,7 @@ export function useFilterRefinements() {
           labelMap: inbox.labelMap,
           onChange: inbox.setIds,
           searchPlaceholder: 'Search inboxes...',
+          neutralLabel: 'All inboxes',
         });
       }
     }

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/use-filter-refinements.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/use-filter-refinements.tsx
@@ -459,7 +459,9 @@ export function useFilterRefinements() {
       }
     }
 
-    if (activeIndexOptions.length > 0) {
+    // In the search view the type chip is always shown (defaulting to "All")
+    // so the index selector isn't hidden behind the filter dropdown.
+    if (activeIndexOptions.length > 0 || currentView() === 'search') {
       const key = 'type:index';
       seenKeys.add(key);
 
@@ -479,7 +481,7 @@ export function useFilterRefinements() {
             });
           }
         }
-        return result;
+        return result.length ? result : [{ id: 'all', label: 'All' }];
       };
 
       filters.push(
@@ -494,6 +496,10 @@ export function useFilterRefinements() {
             icon: o.icon,
           })),
           multiple: false,
+          showRemove: () => {
+            const [first] = getActiveIndexValues();
+            return first !== undefined && first.id !== 'all';
+          },
           isValueActive: (id) => soup.predicates.isActive(id),
           onToggleValue: (id) => changeIndex(id),
           onRemoveAll: () => changeIndex('all'),

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/use-filter-refinements.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/use-filter-refinements.tsx
@@ -48,6 +48,7 @@ import {
   getCallStatusLabel,
   INDEX_OPTIONS,
   type SearchableOption,
+  useEmailInboxPicker,
   useSearchFilterOptions,
   useSearchIndexController,
 } from './search-filter-controls';
@@ -91,6 +92,7 @@ export function useFilterRefinements() {
   const currentUserId = useUserId();
   const { channelOptions, channelLabelMap, senderOptions, senderLabelMap } =
     useSearchFilterOptions();
+  const inbox = useEmailInboxPicker();
   const { changeIndex } = useSearchIndexController();
 
   const getPresetContext = (): PresetContext => ({
@@ -554,6 +556,9 @@ export function useFilterRefinements() {
       key: string;
       categoryLabel: string;
       getIds: () => string[];
+      // Checked state for the popup, when it differs from the displayed values
+      // (e.g. inbox: empty selection means "all", shown as every box checked).
+      activeIds?: Accessor<string[]>;
       searchableOptions: Accessor<SearchableOption[]>;
       labelMap: Accessor<Map<string, string>>;
       onChange: (ids: string[]) => void;
@@ -595,7 +600,7 @@ export function useFilterRefinements() {
             categoryLabel: args.categoryLabel,
             values: getValues,
             searchableOptions: args.searchableOptions,
-            activeSearchableIds: args.getIds,
+            activeSearchableIds: args.activeIds ?? args.getIds,
             onSearchableChange: args.onChange,
             searchPlaceholder: args.searchPlaceholder,
             isPopupOpen,
@@ -742,6 +747,20 @@ export function useFilterRefinements() {
               }),
           }))
         );
+      }
+
+      // Email inbox filter (only when the account has more than one inbox)
+      if (soup.predicates.isActive('email') && inbox.options().length > 1) {
+        pushSearchableConsolidatedChip({
+          key: 'email-inbox',
+          categoryLabel: 'Inbox',
+          getIds: inbox.selectedIds,
+          activeIds: inbox.activeIds,
+          searchableOptions: inbox.options,
+          labelMap: inbox.labelMap,
+          onChange: inbox.setIds,
+          searchPlaceholder: 'Search inboxes...',
+        });
       }
     }
 

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/use-filter-refinements.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/use-filter-refinements.tsx
@@ -566,18 +566,25 @@ export function useFilterRefinements() {
       labelMap: Accessor<Map<string, string>>;
       onChange: (ids: string[]) => void;
       searchPlaceholder: string;
+      // When set, the chip is always shown; an empty selection renders this
+      // neutral label and hides the remove button until a value is chosen.
+      neutralLabel?: string;
     }) => {
       const popupOpen =
         consolidatedChipCache.get(args.key)?.isPopupOpen?.() ?? false;
       const ids = args.getIds();
-      if (ids.length === 0 && !popupOpen) return;
+      if (ids.length === 0 && !popupOpen && !args.neutralLabel) return;
 
       seenKeys.add(args.key);
 
       // Compute values as accessor for reactivity
       const getValues = (): FilterValue[] => {
+        const ids = args.getIds();
+        if (ids.length === 0 && args.neutralLabel) {
+          return [{ id: '__all__', label: args.neutralLabel }];
+        }
         const options = args.searchableOptions();
-        return args.getIds().map((id) => {
+        return ids.map((id) => {
           const opt = options.find((o) => o.id === id);
           return {
             id,
@@ -609,12 +616,19 @@ export function useFilterRefinements() {
             isPopupOpen,
             setPopupOpen,
             onRemoveAll: () => args.onChange([]),
+            showRemove: args.neutralLabel
+              ? () => args.getIds().length > 0
+              : undefined,
           };
         })
       );
     };
 
-    // Channel In/From filters
+    // Channel In/From filters. In the search view they default to their neutral
+    // state (shown even when empty) when the channels index is active.
+    const searchChannelsActive =
+      currentView() === 'search' && soup.predicates.isActive('channels');
+
     pushSearchableConsolidatedChip({
       key: 'channel-in',
       categoryLabel: 'In',
@@ -626,6 +640,7 @@ export function useFilterRefinements() {
       labelMap: channelLabelMap,
       onChange: setFilterIds('channelId'),
       searchPlaceholder: 'Search channels...',
+      neutralLabel: searchChannelsActive ? 'All channels' : undefined,
     });
 
     pushSearchableConsolidatedChip({
@@ -636,6 +651,7 @@ export function useFilterRefinements() {
       labelMap: senderLabelMap,
       onChange: setFilterIds('channelSenderId'),
       searchPlaceholder: 'Search senders...',
+      neutralLabel: searchChannelsActive ? 'Anyone' : undefined,
     });
 
     // Search view specific filters
@@ -652,6 +668,7 @@ export function useFilterRefinements() {
           labelMap: channelLabelMap,
           onChange: setFilterIds('callChannelId'),
           searchPlaceholder: 'Search channels...',
+          neutralLabel: 'All channels',
         });
 
         pushSearchableConsolidatedChip({
@@ -662,48 +679,48 @@ export function useFilterRefinements() {
           labelMap: senderLabelMap,
           onChange: setFilterIds('callSpeakerId'),
           searchPlaceholder: 'Search speakers...',
+          neutralLabel: 'Anyone',
         });
 
-        // Call status filter
+        // Call status filter (always shown; "All" when unset)
         const getCurrentCallStatus = (): CallStatus | undefined =>
           queryFilters.state.include.callStatus ??
           callStatusFromAttended(queryFilters.state.include.callAttended);
 
-        if (getCurrentCallStatus() !== undefined) {
-          const key = 'call-status';
-          seenKeys.add(key);
+        const key = 'call-status';
+        seenKeys.add(key);
 
-          const getCallStatusValues = (): FilterValue[] => {
-            const status = getCurrentCallStatus();
-            if (status === undefined) return [];
-            return [{ id: status, label: getCallStatusLabel(status) }];
-          };
+        const getCallStatusValues = (): FilterValue[] => {
+          const status = getCurrentCallStatus();
+          if (status === undefined) return [{ id: 'all', label: 'All' }];
+          return [{ id: status, label: getCallStatusLabel(status) }];
+        };
 
-          filters.push(
-            getOrCreateConsolidatedChip(key, () => ({
-              key,
-              categoryLabel: 'Status',
-              values: getCallStatusValues,
-              availableOptions: CALL_STATUS_FILTER_OPTIONS,
-              multiple: false,
-              isValueActive: (id) => id === getCurrentCallStatus(),
-              onToggleValue: (id) =>
-                queryFilters.set({
-                  include: {
-                    callStatus: id as CallStatus,
-                    callAttended: undefined,
-                  },
-                }),
-              onRemoveAll: () =>
-                queryFilters.set({
-                  include: {
-                    callStatus: undefined,
-                    callAttended: undefined,
-                  },
-                }),
-            }))
-          );
-        }
+        filters.push(
+          getOrCreateConsolidatedChip(key, () => ({
+            key,
+            categoryLabel: 'Status',
+            values: getCallStatusValues,
+            availableOptions: CALL_STATUS_FILTER_OPTIONS,
+            multiple: false,
+            showRemove: () => getCurrentCallStatus() !== undefined,
+            isValueActive: (id) => id === getCurrentCallStatus(),
+            onToggleValue: (id) =>
+              queryFilters.set({
+                include: {
+                  callStatus: id as CallStatus,
+                  callAttended: undefined,
+                },
+              }),
+            onRemoveAll: () =>
+              queryFilters.set({
+                include: {
+                  callStatus: undefined,
+                  callAttended: undefined,
+                },
+              }),
+          }))
+        );
       }
 
       // Email importance filter (always shown; "All" when unset)


### PR DESCRIPTION
Adds an inbox filter to the global search view: an Inbox submenu in the Filter dropdown's Email section and a matching active-filters chip, both gated to accounts with more than one inbox. Selecting all inboxes (or removing the chip) is a no-op — no `email_filters.link_ids` is sent and the chip stays hidden; only a non-default subset scopes results.
