### PR TITLE
fix(search): go to target message on result click, reusing mention navigation

### DIFF
--- a/js/app/packages/channel/Channel/Channel.tsx
+++ b/js/app/packages/channel/Channel/Channel.tsx
@@ -349,6 +349,25 @@ export function Channel(props: ChannelProps) {
     targetMessageController.goToMessage(messageId, replyId);
   };
 
+  // Navigating to a message highlights it by selecting it. When the target
+  // isn't in the initially loaded page (e.g. opening an old message from
+  // search), that selection is auto-cleared by create-message-selection before
+  // the load-around resolves. Re-assert it once the target message has loaded.
+  // Tracked per-target so it applies only to the active navigation, not after
+  // the user selects something else.
+  let highlightedNavigationTarget: string | undefined;
+  createEffect(() => {
+    const targetId = targetMessageController.activeTargetMessageId();
+    if (!targetId || targetMessageController.activeTargetMessageReplyId()) {
+      highlightedNavigationTarget = undefined;
+      return;
+    }
+    if (highlightedNavigationTarget === targetId) return;
+    if (!messageIndex.keys.includes(targetId)) return;
+    highlightedNavigationTarget = targetId;
+    selectMessage(targetId);
+  });
+
   const findBar = createChannelFindBar({
     channelId: () => props.channelId,
     goToMessage,

--- a/js/app/packages/core/component/AI/component/tool/Search.tsx
+++ b/js/app/packages/core/component/AI/component/tool/Search.tsx
@@ -12,6 +12,7 @@ import MagnifyingGlass from '@phosphor-icons/core/regular/magnifying-glass.svg';
 import { useSearchResponseItemMapper } from '@queries/soup/transform-utils';
 import type { NamedTool } from '@service-cognition/generated/tools/tool';
 import { useSplitLayout } from 'app/component/split-layout/layout';
+import { globalSplitManager } from 'app/signal/splitLayout';
 import { createMemo, createSignal, For, Show } from 'solid-js';
 import { BaseTool } from './BaseTool';
 import { Tool } from './Tool';
@@ -72,13 +73,25 @@ const UnifiedSearchToolResponse = (props: {
   query: string;
 }) => {
   const mapResponseItem = useSearchResponseItemMapper();
-  const { replaceOrInsertSplit } = useSplitLayout();
+  const { insertSplit } = useSplitLayout();
 
   const entities = createMemo(() =>
     props.results.flatMap(
       (result) => mapResponseItem(result, props.query) ?? []
     )
   );
+
+  const openEntity = async (entity: SearchEntity) => {
+    const content = getEntityClickContent(entity);
+    insertSplit(content);
+
+    if (content.params) {
+      const blockHandle = await globalSplitManager()
+        ?.getOrchestrator()
+        .getBlockHandle(content.id);
+      await blockHandle?.goToLocationFromParams(content.params);
+    }
+  };
 
   return (
     <div class="max-h-120 overflow-y-auto">
@@ -89,9 +102,7 @@ const UnifiedSearchToolResponse = (props: {
             return (
               <SearchResultRow
                 entity={entity}
-                onClick={() =>
-                  replaceOrInsertSplit(getEntityClickContent(entity))
-                }
+                onClick={() => openEntity(entity)}
               />
             );
           }}


### PR DESCRIPTION
Clicking a channel-message search-tool result now opens/focuses the split and scrolls to + highlights the target message, reusing the same `goToLocationFromParams` navigation API as channel mentions and notifications. Also fixes the highlight being dropped when navigating to a message that isn't on the channel's initially loaded page — the selection that drives the highlight was auto-cleared before the load-around resolved, so the channel re-asserts it once the target message loads.

Closes MACRO-1759.
