### PR TITLE
fix(search): match channel find-bar multi-word queries as exact phrase

### DIFF
--- a/js/app/packages/channel/Channel/create-channel-find-bar.ts
+++ b/js/app/packages/channel/Channel/create-channel-find-bar.ts
@@ -54,16 +54,23 @@ export function createChannelFindBar(
       // through the channel's thread list (replies cluster with their parent
       // thread instead of jumping around when sorted strictly by message_id).
       const searchQuery = useSearchChannelQuery(
-        () => ({
-          params: { page_size: FIND_BAR_PAGE_SIZE },
-          body: {
-            match_type: 'partial',
-            query: submittedQuery(),
-            search_on: 'content',
-            channel_ids: [options.channelId()],
-            sort: ChannelSortTimestamp.thread,
-          },
-        }),
+        () => {
+          const query = submittedQuery();
+          // Exact (phrase) match once more than one word is typed so the query
+          // matches the literal phrase; partial (prefix) match for a single
+          // word so it still behaves like find-as-you-type.
+          const isMultiWord = query.trim().split(/\s+/).length > 1;
+          return {
+            params: { page_size: FIND_BAR_PAGE_SIZE },
+            body: {
+              match_type: isMultiWord ? 'exact' : 'partial',
+              query,
+              search_on: 'content',
+              channel_ids: [options.channelId()],
+              sort: ChannelSortTimestamp.thread,
+            },
+          };
+        },
         () => ({ enabled: isOpen() && submittedQuery().length > 0 })
       );
 

--- a/rust/cloud-storage/search_service/src/api/search/channel.rs
+++ b/rust/cloud-storage/search_service/src/api/search/channel.rs
@@ -15,6 +15,7 @@ use axum::{
 use macro_user_id::user_id::MacroUserId;
 use model::comms::ChannelHistoryInfo;
 use model::user::UserContext;
+use models_search::MatchType;
 use models_search::channel::{
     ChannelSearchRequest, ChannelSearchResponse, ChannelSearchResponseItem,
     ChannelSearchResponseItemWithMetadata, ChannelSearchResult, ChannelSortTimestamp,
@@ -212,10 +213,14 @@ pub async fn handler(
         (_, Some(t)) if !t.is_empty() => t,
         _ => return Err(SearchError::NoQueryOrTermsProvided),
     };
-    // Whitespace-split outside double quotes so `foo bar` matches messages
-    // containing both words (ANDed inside OpenSearch) while `"foo bar"`
-    // stays an exact-phrase term.
-    let terms = split_search_terms(&raw_terms);
+    // An exact match treats the query as a single phrase (as if double-quoted)
+    // so multi-word input matches the literal phrase. Other match types split on
+    // whitespace and AND the resulting terms.
+    let terms = if req.match_type == MatchType::Exact {
+        raw_terms
+    } else {
+        split_search_terms(&raw_terms)
+    };
     if terms.is_empty() {
         return Err(SearchError::NoQueryOrTermsProvided);
     }


### PR DESCRIPTION
The channel find bar dropped query terms shorter than 3 chars (e.g. `to` in `need to`), so multi-word queries containing a short word returned no results. `match_type: exact` now treats the query as a single phrase instead of whitespace-splitting it, and the find bar sends `exact` for multi-word input and `partial` (prefix) for a single word.
