### PR TITLE
fix(soup-view): save group-by as history entry state

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
@@ -907,10 +907,6 @@ export const SoupViewList = (props: SoupViewListProps) => {
     `macro:pref:soup:${contentId}:sort`,
     { default: [] }
   );
-  const [groupByPref, setGroupByPref] = usePreference<string | undefined>(
-    `macro:pref:soup:${contentId}:groupBy`,
-    { default: undefined }
-  );
 
   // Preview-pane open state is transient per history entry: captured into
   // per-entry state on nav-away and restored on back/forward. Read
@@ -937,6 +933,20 @@ export const SoupViewList = (props: SoupViewListProps) => {
   );
   onCleanup(collapsedCaptorTeardown);
 
+  // Active grouping is per-entry state too, so back/forward restores the
+  // grouping the user left each entry with. `null` (vs. key absent) records
+  // an explicit "no grouping" choice, which would otherwise be
+  // indistinguishable from a fresh entry.
+  const persistedGroupBy = panel.handle.currentEntryState()?.['soup.groupBy'] as
+    | string
+    | null
+    | undefined;
+  const groupByCaptorTeardown = panel.handle.registerEntryStateCaptor(
+    'soup.groupBy',
+    () => soup.grouping.activeGroupId() ?? null
+  );
+  onCleanup(groupByCaptorTeardown);
+
   onMount(() => {
     batch(() => {
       const savedSort = sortPref();
@@ -948,8 +958,13 @@ export const SoupViewList = (props: SoupViewListProps) => {
       }
       // soup state is shared at the SplitPanel level, so a prior view in the
       // same split (e.g. tasks) may have left grouping state behind. Always
-      // reset to this view's saved or initial grouping, even when undefined.
-      soup.grouping.setActiveGroupId(groupByPref() ?? props.initialGroupBy);
+      // reset to this entry's captured or initial grouping, even when
+      // undefined.
+      soup.grouping.setActiveGroupId(
+        persistedGroupBy !== undefined
+          ? (persistedGroupBy ?? undefined)
+          : props.initialGroupBy
+      );
       soup.grouping.collapseAll(persistedCollapsedGroups ?? []);
 
       // Apply view-supplied client filters only when per-entry state didn't
@@ -976,13 +991,6 @@ export const SoupViewList = (props: SoupViewListProps) => {
     on(
       () => soup.sort.active().map((s) => s.id),
       (ids) => setSortPref(ids),
-      { defer: true }
-    )
-  );
-  createEffect(
-    on(
-      () => soup.grouping.activeGroupId(),
-      (id) => setGroupByPref(id),
       { defer: true }
     )
   );


### PR DESCRIPTION
Group-by now propagates through split history entry state (same mechanism as search state and collapsed groups), so back/forward restores each entry's grouping — including an explicit "none". Removes the localStorage group-by preference; fresh navigations use the view default.
