### PR TITLE
Add index page to documentation navigation

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -25,6 +25,7 @@
       {
         "tab": "Documentation",
         "pages": [
+          "index",
           {
             "group": "Features",
             "pages": [


### PR DESCRIPTION
## Summary
Added the index page to the documentation navigation structure in the docs configuration.

## Changes
- Added `"index"` entry to the pages array in the Documentation tab of `docs/docs.json`
- This ensures the index page appears in the documentation navigation menu

## Details
The index page is now explicitly included as the first item in the Documentation pages list, making it accessible through the documentation navigation structure.

https://claude.ai/code/session_01GPaZ8q7guuqnWwdzeZ444u