### PR TITLE
fix(ai): email tool body rendering and clickable tool previews

### DIFF
--- a/js/app/packages/core/component/AI/component/tool/CreateDocument.tsx
+++ b/js/app/packages/core/component/AI/component/tool/CreateDocument.tsx
@@ -1,4 +1,4 @@
-import { InlineItemPreview } from '@core/component/ItemPreview';
+import { ItemPreview } from '@core/component/ItemPreview';
 import FilePlus from '@phosphor-icons/core/regular/file-plus.svg';
 import { Show, Suspense } from 'solid-js';
 import { BaseTool } from './BaseTool';
@@ -19,7 +19,8 @@ const handler = createToolRenderer({
               {' '}
               <span class="text-ink-placeholder">·</span>{' '}
               <Suspense>
-                <InlineItemPreview
+                <ItemPreview
+                  class="inline-flex align-middle ring-0"
                   id={response().data.documentId}
                   type="document"
                 />

--- a/js/app/packages/core/component/AI/component/tool/ReadChat.tsx
+++ b/js/app/packages/core/component/AI/component/tool/ReadChat.tsx
@@ -1,4 +1,4 @@
-import { InlineItemPreview } from '@core/component/ItemPreview';
+import { ItemPreview } from '@core/component/ItemPreview';
 import Newspaper from '@phosphor-icons/core/regular/newspaper.svg';
 import { Suspense } from 'solid-js';
 import { BaseTool } from './BaseTool';
@@ -12,7 +12,11 @@ const handler = createToolRenderer({
         Read <span class="text-ink">chat</span>{' '}
         <span class="text-ink-placeholder">·</span>{' '}
         <Suspense>
-          <InlineItemPreview id={ctx.tool.data.chatId} type="chat" />
+          <ItemPreview
+            class="inline-flex align-middle ring-0"
+            id={ctx.tool.data.chatId}
+            type="chat"
+          />
         </Suspense>
       </div>
     </BaseTool>

--- a/js/app/packages/core/component/AI/component/tool/ReadContent.tsx
+++ b/js/app/packages/core/component/AI/component/tool/ReadContent.tsx
@@ -1,4 +1,4 @@
-import { InlineItemPreview } from '@core/component/ItemPreview';
+import { ItemPreview } from '@core/component/ItemPreview';
 import Newspaper from '@phosphor-icons/core/regular/newspaper.svg';
 import { Suspense } from 'solid-js';
 import { BaseTool } from './BaseTool';
@@ -12,7 +12,11 @@ const handler = createToolRenderer({
         Read <span class="text-ink">document</span>{' '}
         <span class="text-ink-placeholder">·</span>{' '}
         <Suspense>
-          <InlineItemPreview id={ctx.tool.data.documentId} type="document" />
+          <ItemPreview
+            class="inline-flex align-middle ring-0"
+            id={ctx.tool.data.documentId}
+            type="document"
+          />
         </Suspense>
       </div>
     </BaseTool>

--- a/js/app/packages/core/component/AI/component/tool/ReadMetadata.tsx
+++ b/js/app/packages/core/component/AI/component/tool/ReadMetadata.tsx
@@ -1,4 +1,4 @@
-import { InlineItemPreview } from '@core/component/ItemPreview';
+import { ItemPreview } from '@core/component/ItemPreview';
 import Newspaper from '@phosphor-icons/core/regular/newspaper.svg';
 import { Suspense } from 'solid-js';
 import { BaseTool } from './BaseTool';
@@ -12,7 +12,11 @@ const handler = createToolRenderer({
         Read <span class="text-ink">metadata</span>{' '}
         <span class="text-ink-placeholder">·</span>{' '}
         <Suspense>
-          <InlineItemPreview id={ctx.tool.data.documentId} type="document" />
+          <ItemPreview
+            class="inline-flex align-middle ring-0"
+            id={ctx.tool.data.documentId}
+            type="document"
+          />
         </Suspense>
       </div>
     </BaseTool>

--- a/js/app/packages/core/component/AI/component/tool/SendEmail.tsx
+++ b/js/app/packages/core/component/AI/component/tool/SendEmail.tsx
@@ -1,6 +1,6 @@
 import { useSplitLayout } from '@app/component/split-layout/layout';
 import { EntityIcon } from '@core/component/EntityIcon';
-import { InlineItemPreview } from '@core/component/ItemPreview';
+import { ItemPreview } from '@core/component/ItemPreview';
 import CaretRight from '@phosphor/caret-right.svg';
 import type { NamedTool } from '@service-cognition/generated/tools/tool';
 import type { SendEmail } from '@service-cognition/generated/tools/types';
@@ -136,7 +136,7 @@ function SentEmailResponse(props: {
                 <span class="text-ink">{getRecipientsLabel(props.args)}</span>
               </span>
               <Suspense>
-                <InlineItemPreview id={props.threadId} type="email" />
+                <ItemPreview class="ring-0" id={props.threadId} type="email" />
               </Suspense>
             </div>
             <span class="shrink-0 text-ink-muted">

--- a/js/app/packages/core/component/AI/component/tool/Tool.tsx
+++ b/js/app/packages/core/component/AI/component/tool/Tool.tsx
@@ -46,7 +46,7 @@ function Root(props: ToolRootProps) {
       class="relative overflow-hidden text-xs leading-5 text-ink-extra-muted"
       classList={{
         'opacity-50': props.muted,
-        'rounded-lg border border-edge-muted bg-surface': !props.grouped,
+        'rounded-lg bg-surface': !props.grouped,
       }}
     >
       {props.children}

--- a/js/app/packages/core/component/AI/component/tool/email/ChatCompose.tsx
+++ b/js/app/packages/core/component/AI/component/tool/email/ChatCompose.tsx
@@ -9,6 +9,7 @@ import {
 } from '@block-email/component/compose/ComposeContext';
 import type { DraftFormAttachment } from '@block-email/component/createEmailFormState';
 import type { EmailRecipient } from '@block-email/component/EmailContext';
+import { decodeBase64Utf8 } from '@block-email/util/decodeBase64';
 import { prepareEmailBody } from '@block-email/util/prepareEmailBody';
 import { convertContactInfoToEmailRecipient } from '@block-email/util/recipientConversion';
 import { useChatContext } from '@core/component/AI/context';
@@ -174,7 +175,10 @@ export function ComposeTool(props: ComposeToolProps) {
       (props.initialData.cc ?? []).map((r) => ({ ...r, name: r.name ?? null }))
     ),
     bcc: toEmailRecipients(
-      (props.initialData.bcc ?? []).map((r) => ({ ...r, name: r.name ?? null }))
+      (props.initialData.bcc ?? []).map((r) => ({
+        ...r,
+        name: r.name ?? null,
+      }))
     ),
   });
   const [subject, setSubject] = createSignal(props.initialData.subject ?? '');
@@ -311,12 +315,24 @@ export function ComposeTool(props: ComposeToolProps) {
     toast.success('Email sent');
   }
 
+  // `body` is markdown while the AI is drafting, but every persist path
+  // (flushUpdate, handleSend) replaces it with the base64url-encoded HTML
+  // that the SendEmail tool contract requires at send time. Decode and route
+  // to the editor slot that matches what the field actually holds.
+  const initialBody = (): { html?: string; markdown?: string } => {
+    const body = props.initialData.body;
+    if (!body) return {};
+    const decoded = decodeBase64Utf8(body);
+    if (decoded.startsWith('<body')) return { html: decoded };
+    return { markdown: body };
+  };
+
   const ctx: ComposeContextValue = {
     subject,
     attachments: () => [],
     sendTime: () => undefined,
-    initialHtml: () => undefined,
-    initialMarkdown: () => props.initialData.body ?? undefined,
+    initialHtml: () => initialBody().html,
+    initialMarkdown: () => initialBody().markdown,
     setRecipients: (field, value) => {
       setRecipients((prev) => ({ ...prev, [field]: value }));
       scheduleUpdate();
@@ -361,7 +377,7 @@ export function ComposeTool(props: ComposeToolProps) {
         <ComposeLayout
           bodyDebugName={`chat-compose:${props.chatId}:${props.messageId}:${props.toolCallId}`}
           class={cn(
-            'flex flex-col w-full text-xs border border-edge-muted rounded-lg p-4 bg-surface',
+            'flex flex-col w-full text-xs rounded-lg p-4 bg-surface',
             uiDisabled() &&
               '[&_button:disabled]:opacity-50 [&_button:disabled]:text-ink-disabled [&_input:disabled]:text-ink-muted'
           )}


### PR DESCRIPTION
- Decode base64url-encoded HTML email bodies before rendering in the chat compose tool, fixing garbled characters in edited drafts and the sent email view
- Stop rendering the read-only click-shield overlay for sent emails so the rendered body is selectable and interactive
- Replace InlineItemPreview with ItemPreview in the CreateDocument, ReadMetadata, ReadChat, ReadContent, and SendEmail tool cards so entity previews are clickable and show hover previews
- Remove the ring border from those tool card previews