### PR TITLE
[ignore] docs: fix invalid bash syntax in SOPS_KMS_ARN export

### DIFF
--- a/RUNNING_LOCALLY.md
+++ b/RUNNING_LOCALLY.md
@@ -18,7 +18,7 @@
 Export the **SOPS_KMS_ARN** (you can skip if you use nix-shell)
 
 ```bash
-export SOPS_KMS_ARN = "arn:aws:kms:us-east-1:569036502058:key/mrk-cab29bf948044eb79005a81f48d40e93,arn:aws:kms:us-west-1:569036502058:key/mrk-cab29bf948044eb79005a81f48d40e93"
+export SOPS_KMS_ARN="arn:aws:kms:us-east-1:569036502058:key/mrk-cab29bf948044eb79005a81f48d40e93,arn:aws:kms:us-west-1:569036502058:key/mrk-cab29bf948044eb79005a81f48d40e93"
 ```
 
 Run `just setup` to initialize your entire environment.


### PR DESCRIPTION
## Summary

Small demo change fixing a real copy-paste bug in `RUNNING_LOCALLY.md`.

The setup instructions told users to run:

```bash
export SOPS_KMS_ARN = "arn:aws:kms:..."
```

But `export VAR = "value"` (with spaces around `=`) is **invalid bash** — it fails with:

```
bash: export: `=': not a valid identifier
```

This PR removes the spaces so the command works as written when copy-pasted:

```bash
export SOPS_KMS_ARN="arn:aws:kms:..."
```

## Changes

- `RUNNING_LOCALLY.md`: remove spaces around `=` in the `SOPS_KMS_ARN` export example.

## Verification

- Confirmed `export VAR = "x"` errors in bash while `export VAR="x"` succeeds.
- Documentation-only change; no code paths affected.