### PR TITLE
Fix email reply, scheduling, and message handling bugs

### DIFF
--- a/js/app/packages/block-email/component/BaseInput.tsx
+++ b/js/app/packages/block-email/component/BaseInput.tsx
@@ -501,7 +501,10 @@ export function BaseInput(props: {
 
   // Register a callback so stale undoSend closures from a previous mount can
   // restore state into this (the live) component instance.
-  restoreUndoCallback = (snapshot, draftId) => {
+  const ownRestoreUndoCallback: typeof restoreUndoCallback = (
+    snapshot,
+    draftId
+  ) => {
     setSavedDraftId(draftId);
     const currentEditor = editor();
     if (currentEditor && snapshot.bodyHtml) {
@@ -511,8 +514,14 @@ export function BaseInput(props: {
       form().attachments.add(attachment);
     }
   };
+  restoreUndoCallback = ownRestoreUndoCallback;
   onCleanup(() => {
-    restoreUndoCallback = null;
+    // Multiple BaseInputs can be mounted at once (bottom input + inline
+    // reply); only clear the slot if this instance still owns it so
+    // unmounting one doesn't break the other's undo-send restore.
+    if (restoreUndoCallback === ownRestoreUndoCallback) {
+      restoreUndoCallback = null;
+    }
   });
 
   let pendingMentions: { documentId: string }[] = [];
@@ -626,8 +635,11 @@ export function BaseInput(props: {
     }
   }
 
-  // Attach side-effect handlers on mount; they replay against current state
-  onMount(() => {
+  // Attach side-effect handlers; they replay against current state. Runs in
+  // an effect (not onMount) because form() re-keys when the reply context
+  // changes (e.g. after a send) and the new form instance needs the
+  // callbacks too.
+  createEffect(() => {
     form().setOnDirty(() => {
       scheduleDraftSave();
     });
@@ -944,7 +956,11 @@ export function BaseInput(props: {
       return;
     }
 
-    let linkId: string | undefined = currentThread?.link_id;
+    // Same precedence as activeLinkId(): a user-selected "from" inbox wins
+    // over the thread's inbox, so sends go out from the inbox shown in the UI
+    // (and match where persistDraftOnSenderSwitch saved the draft).
+    let linkId: string | undefined =
+      form().selectedLinkId() ?? currentThread?.link_id ?? props.draft?.link_id;
     if (newMessage || !linkId) {
       if (emailLinksQuery.isPending) {
         toast.alert('Loading email accounts...');
@@ -963,7 +979,7 @@ export function BaseInput(props: {
         logger.error('No links found');
         return;
       }
-      linkId = primaryLinkId() ?? linksData.links[0].id;
+      linkId = linkId ?? primaryLinkId() ?? linksData.links[0].id;
     }
 
     const currentEditor = editor();
@@ -1324,27 +1340,41 @@ export function BaseInput(props: {
       // Ensure draft is saved before scheduling
       const draftID = currentDraft ?? (await executeSaveDraft());
       if (!draftID) {
+        // Clear the send time so a failed schedule doesn't leave the
+        // composer stuck in a phantom "scheduled" state with Send disabled
+        form().setSendTime(null);
         toast.failure('Failed to schedule message', {
           subtext: 'Draft required',
         });
         return;
       }
 
-      await emailClient.scheduleMessage(
-        {
-          draftID,
-          send_time: date.toISOString(),
-        },
-        headerLinkId()
-      );
+      try {
+        await emailClient.scheduleMessage(
+          {
+            draftID,
+            send_time: date.toISOString(),
+          },
+          headerLinkId()
+        );
+      } catch (error) {
+        form().setSendTime(null);
+        logger.error(error);
+        toast.failure('Failed to schedule message');
+        return;
+      }
 
       // Mark the thread as done
       const threadID = ctx.thread()?.db_id;
       if (threadID) {
-        await emailClient.flagArchived(
-          { id: threadID, value: true },
-          headerLinkId()
-        );
+        try {
+          await emailClient.flagArchived(
+            { id: threadID, value: true },
+            headerLinkId()
+          );
+        } catch (error) {
+          logger.error(error);
+        }
       }
     }
   };
@@ -1798,8 +1828,9 @@ export function BaseInput(props: {
                 size="icon-sm"
                 pressed={form().replyAppended()}
                 onChange={() => {
-                  const replyingToID = props.replyingTo()?.replying_to_id;
-                  if (!replyingToID) return;
+                  // Guard on db_id: a thread's root message has no
+                  // replying_to_id but its quoted text can still be toggled
+                  if (!props.replyingTo()?.db_id) return;
 
                   const currentlyAppended = form().replyAppended();
                   form().setReplyAppended(!currentlyAppended);

--- a/js/app/packages/block-email/component/Block.tsx
+++ b/js/app/packages/block-email/component/Block.tsx
@@ -23,14 +23,15 @@ export default function BlockEmail() {
   const title = () => {
     const data = threadQuery.data;
     if (!data || !data.thread || data.thread.messages.length === 0) return '';
-    if (data.thread.messages[0].subject?.length === 0) return '[No subject]';
+    const subject = data.thread.messages[0].subject;
+    if (!subject) return '[No subject]';
     // remove "re:" prefix(es)
-    return data.thread.messages[0].subject!.replace(/^(re:\s*)+/i, '');
+    return subject.replace(/^(re:\s*)+/i, '');
   };
 
   return (
     <Suspense>
-      <DocumentBlockContainer title={title() ?? 'Email'}>
+      <DocumentBlockContainer title={title() || 'Email'}>
         <div class="size-full" tabIndex={-1}>
           <Show when={blockData()}>
             <Show when={threadId()}>

--- a/js/app/packages/block-email/component/Email.tsx
+++ b/js/app/packages/block-email/component/Email.tsx
@@ -25,6 +25,7 @@ import {
   createMemo,
   createSignal,
   Match,
+  onCleanup,
   onMount,
   Show,
   Switch,
@@ -80,13 +81,18 @@ function EmailContent(props: EmailViewProps) {
     setIsScrolled(scrollFromTop > 1);
   };
 
+  let disposed = false;
+  onCleanup(() => {
+    disposed = true;
+  });
+
   /**
    * Waits for the query to finish fetching
    */
   const waitForQueryLoad = (): Promise<void> => {
     return new Promise((resolve) => {
       const checkInterval = setInterval(() => {
-        if (!context.query.isFetching()) {
+        if (disposed || !context.query.isFetching()) {
           clearInterval(checkInterval);
           resolve();
         }
@@ -100,7 +106,7 @@ function EmailContent(props: EmailViewProps) {
   const loadMessagesUntilFound = async (
     targetMessageId: string
   ): Promise<boolean> => {
-    while (true) {
+    while (!disposed) {
       const messages = context.messages.unfiltered();
 
       // Check if message exists in current batch
@@ -117,6 +123,7 @@ function EmailContent(props: EmailViewProps) {
       context.query.fetchNextPage();
       await waitForQueryLoad();
     }
+    return false;
   };
 
   /**
@@ -187,21 +194,12 @@ function EmailContent(props: EmailViewProps) {
     performScrollToMessage(lastMessage.db_id, { behavior, focus });
   };
 
+  // context.messages.list() is already sorted oldest-first (see EmailContext)
   const firstUnreadMessageId = createMemo(() => {
-    const messages = context.messages.list().toSorted((a, b) => {
-      if (a.internal_date_ts && b.internal_date_ts) {
-        return (
-          new Date(a.internal_date_ts).getTime() -
-          new Date(b.internal_date_ts).getTime()
-        );
-      } else if (a.sent_at && b.sent_at) {
-        return new Date(a.sent_at).getTime() - new Date(b.sent_at).getTime();
-      }
-      return 0;
-    });
-    return messages?.find((m) =>
-      m.labels.some((l) => l.provider_label_id === 'UNREAD')
-    )?.db_id;
+    return context.messages
+      .list()
+      .find((m) => m.labels.some((l) => l.provider_label_id === 'UNREAD'))
+      ?.db_id;
   });
 
   const canRunInitialEmailScroll = () =>
@@ -219,8 +217,6 @@ function EmailContent(props: EmailViewProps) {
 
     // Check for target message
     const targetMessageId_ = context.messages.targetMessageID();
-
-    if (targetMessageId_ && typeof targetMessageId_ !== 'string') return true;
 
     if (targetMessageId_) {
       handleTargetMessage(targetMessageId_);
@@ -279,11 +275,12 @@ function EmailContent(props: EmailViewProps) {
         performScrollToMessage(messageId, { behavior: 'instant' })
       );
     }
-
     // Case 3: Message is in current batch with sufficient context
-    setTimeout(() =>
-      performScrollToMessage(messageId, { behavior: 'instant' })
-    );
+    else {
+      setTimeout(() =>
+        performScrollToMessage(messageId, { behavior: 'instant' })
+      );
+    }
   }
 
   // If there is a focused message id, but it does not currently exist in the message list, it is because the user has just sent a message. When it does come into existence, we want to scroll to the bottom.
@@ -527,7 +524,7 @@ function EmailContent(props: EmailViewProps) {
                   title={props.title}
                   isDraft={
                     emailReplyInfo()?.replyingTo == null &&
-                    emailReplyInfo()?.draft !== null
+                    emailReplyInfo()?.draft != null
                   }
                 />
                 <div

--- a/js/app/packages/block-email/component/EmailContext.tsx
+++ b/js/app/packages/block-email/component/EmailContext.tsx
@@ -124,22 +124,16 @@ export function EmailProvider(props: FlowProps<{ threadID: string }>) {
       select(data) {
         const messages = data.pages.flatMap((t) => t.messages);
 
-        // Sort all messages by recency
-        messages.sort((a, b) => {
-          if (a.internal_date_ts && b.internal_date_ts) {
-            return (
-              new Date(a.internal_date_ts).getTime() -
-              new Date(b.internal_date_ts).getTime()
-            );
-          }
-          // Below is fallback for when internal_date_ts is not set
-          else if (a.sent_at && b.sent_at) {
-            return (
-              new Date(a.sent_at).getTime() - new Date(b.sent_at).getTime()
-            );
-          }
-          return 0;
-        });
+        // Sort all messages by recency, falling back to sent_at when
+        // internal_date_ts is not set. Comparing per-message keys (instead of
+        // requiring both messages to have the same field) keeps the
+        // comparator transitive when timestamp availability is mixed.
+        const messageTime = (m: ApiMessage) => {
+          const ts = m.internal_date_ts ?? m.sent_at;
+          // Messages with no timestamp (e.g. fresh drafts) sort newest
+          return ts ? new Date(ts).getTime() : Number.POSITIVE_INFINITY;
+        };
+        messages.sort((a, b) => messageTime(a) - messageTime(b));
 
         const filtered = [];
         const messageDraftMap: Record<string, ApiMessage> = {};
@@ -340,14 +334,6 @@ export function EmailProvider(props: FlowProps<{ threadID: string }>) {
     const thread = threadQuery.data;
 
     if (!thread?.db_id) return false;
-
-    archiveMutation.mutate({
-      threadId: thread.db_id,
-      archive: thread.inbox_visible,
-      linkId: toHeaderLinkId(thread.link_id),
-    });
-
-    if (!props) return false;
 
     const selectedRow = soup?.items.get(thread.db_id);
 

--- a/js/app/packages/block-email/component/EmailMessageBody.tsx
+++ b/js/app/packages/block-email/component/EmailMessageBody.tsx
@@ -61,13 +61,11 @@ export function EmailMessageBody(props: EmailMessageBodyProps) {
         const styleTags = Array.from(doc.head?.querySelectorAll('style') ?? [])
           .map((style) => style.outerHTML)
           .join('\n');
-        const quoted = doc.body.querySelector('.macro_quote');
-        if (quoted) {
-          quoted?.remove();
-          return styleTags
-            ? `${styleTags}\n${doc.body.innerHTML}`
-            : doc.body.innerHTML;
-        }
+        // If there is no quoted reply, the whole message is the replyless body
+        doc.body.querySelector('.macro_quote')?.remove();
+        return styleTags
+          ? `${styleTags}\n${doc.body.innerHTML}`
+          : doc.body.innerHTML;
       }
     }
     return replyless;
@@ -327,7 +325,7 @@ export function EmailMessageBody(props: EmailMessageBodyProps) {
           </Match>
           <Match when={isPlaintext()}>
             <StaticMarkdown
-              markdown={props.message.body_text!}
+              markdown={props.message.body_text ?? ''}
               theme={channelTheme}
               target="internal"
             />

--- a/js/app/packages/block-email/component/MessageActions.tsx
+++ b/js/app/packages/block-email/component/MessageActions.tsx
@@ -28,8 +28,8 @@ export function MessageActions(props: {
   const canShowActions = () => {
     if (!props.showActions) return false;
 
-    const allActionsHidden = props.hiddenActions?.every((a) =>
-      EMAIL_MESSAGE_ACTIONS.includes(a)
+    const allActionsHidden = EMAIL_MESSAGE_ACTIONS.every((a) =>
+      props.hiddenActions?.includes(a)
     );
 
     return !allActionsHidden;

--- a/js/app/packages/block-email/component/compose/Compose.tsx
+++ b/js/app/packages/block-email/component/compose/Compose.tsx
@@ -496,26 +496,40 @@ export function EmailCompose(props: EmailComposeProps) {
     if (date) {
       const draftID = currentDraft ?? (await executeSaveDraft());
       if (!draftID) {
+        // Clear the send time so a failed schedule doesn't leave the
+        // composer stuck in a phantom "scheduled" state with Send disabled
+        form.setSendTime(null);
         toast.failure('Failed to schedule message', {
           subtext: 'Draft required',
         });
         return;
       }
 
-      await emailClient.scheduleMessage(
-        {
-          draftID,
-          send_time: date.toISOString(),
-        },
-        headerLinkId()
-      );
+      try {
+        await emailClient.scheduleMessage(
+          {
+            draftID,
+            send_time: date.toISOString(),
+          },
+          headerLinkId()
+        );
+      } catch (error) {
+        form.setSendTime(null);
+        logger.error(error);
+        toast.failure('Failed to schedule message');
+        return;
+      }
 
       const threadID = saveDraftMutation.data?.draft.thread_db_id;
       if (threadID) {
-        await emailClient.flagArchived(
-          { id: threadID, value: true },
-          headerLinkId()
-        );
+        try {
+          await emailClient.flagArchived(
+            { id: threadID, value: true },
+            headerLinkId()
+          );
+        } catch (error) {
+          logger.error(error);
+        }
       }
     }
   };

--- a/js/app/packages/block-email/component/compose/ComposeBody.tsx
+++ b/js/app/packages/block-email/component/compose/ComposeBody.tsx
@@ -84,8 +84,6 @@ export function ComposeBody(props: {
     );
   };
 
-  let bodyDiv!: HTMLDivElement;
-
   const logComposeBody = (event: string, details?: Record<string, unknown>) => {
     if (!props.debugName) return;
     logger.log(`[ComposeBody] ${event}`, {
@@ -140,7 +138,6 @@ export function ComposeBody(props: {
       <div class="size-full min-h-0 sm:max-h-full mobile:flex-1 flex flex-col flex-1">
         <div
           class="grow size-full flex flex-col cursor-text placeholder:text-ink-placeholder placeholder:opacity-50 overflow-hidden relative"
-          ref={bodyDiv}
           onclick={() => {
             editor()?.focus();
           }}

--- a/js/app/packages/block-email/component/compose/ComposeToolbar.tsx
+++ b/js/app/packages/block-email/component/compose/ComposeToolbar.tsx
@@ -27,7 +27,6 @@ export function EmailComposeToolbar(props: {
 }) {
   const ctx = useCompose();
   const [showFormatRibbon, setShowFormatRibbon] = createSignal(false);
-  let attachButtonRef!: HTMLDivElement;
 
   const handleAddAttachments = (files: File[]) => {
     const currentAttachments = ctx.attachments();
@@ -81,15 +80,12 @@ export function EmailComposeToolbar(props: {
         <Show
           when={!isMobile()}
           fallback={
-            <MobileToolbar
-              attachButtonRef={attachButtonRef}
-              handleAddAttachments={handleAddAttachments}
-            />
+            <MobileToolbar handleAddAttachments={handleAddAttachments} />
           }
         >
           <div class="flex flex-row items-center gap-2">
             <Show when={!ctx.hideAttachments}>
-              <div class="relative" ref={attachButtonRef}>
+              <div class="relative">
                 <Button
                   ref={(el) =>
                     fileSelector(el, () => ({
@@ -168,7 +164,6 @@ export function EmailComposeToolbar(props: {
 }
 
 function MobileToolbar(props: {
-  attachButtonRef: HTMLDivElement;
   handleAddAttachments: (files: File[]) => void;
 }) {
   const ctx = useCompose();
@@ -176,7 +171,7 @@ function MobileToolbar(props: {
   return (
     <SplitHeaderRight>
       <div class="flex items-center pl-2">
-        <div class="relative" ref={props.attachButtonRef}>
+        <div class="relative">
           <Button
             ref={(el) =>
               fileSelector(el, () => ({

--- a/js/app/packages/block-email/component/date-selector.tsx
+++ b/js/app/packages/block-email/component/date-selector.tsx
@@ -247,17 +247,17 @@ export const DateSelector = (props: DateSelectorProps) => {
     }
 
     const split = value.split(':');
-    if (!split.length || split.length !== 2) return;
+    if (split.length !== 2) return;
 
-    if (Number.isNaN(split[0]) || Number.isNaN(split[1])) return;
+    const hours = Number(split[0]);
+    const mins = Number(split[1]);
 
-    let hours = Number(split[0]);
-    let mins = Number(split[1]);
+    if (Number.isNaN(hours) || Number.isNaN(mins)) return;
 
     let currentDate = selectedDate() ?? new Date();
 
-    currentDate = setHours(currentDate, Number(hours));
-    currentDate = setMinutes(currentDate, Number(mins));
+    currentDate = setHours(currentDate, hours);
+    currentDate = setMinutes(currentDate, mins);
 
     onChange({ type: 'custom', date: currentDate });
   };

--- a/js/app/packages/block-email/util/emailHotkeys.ts
+++ b/js/app/packages/block-email/util/emailHotkeys.ts
@@ -14,41 +14,10 @@ export function registerEmailHotkeys(
   scopeId: string,
   handlers: EmailHotkeyHandlers
 ) {
-  registerHotkey({
-    hotkey: 'opt+r',
-    scopeId: scopeId,
-    description: 'Reply to thread',
-    keyDownHandler: () => {
-      // handlers.setReplyMode('reply');
-      return true;
-    },
-    hotkeyToken: TOKENS.email.reply,
-    displayPriority: 9,
-  });
-  registerHotkey({
-    hotkey: 'r',
-    scopeId: scopeId,
-    description: 'Reply all to thread',
-    keyDownHandler: () => {
-      // handlers.setReplyMode('reply-all');
-      return true;
-    },
-    hotkeyToken: TOKENS.email.replyAll,
-    displayPriority: 8,
-  });
-  registerHotkey({
-    hotkey: 'f',
-    scopeId: scopeId,
-    description: 'Forward thread',
-    keyDownHandler: () => {
-      // TODO: Populate to field
-      // TODO: Attachments from last/current selected message
-      // handlers.setReplyMode('forward');
-      return true;
-    },
-    hotkeyToken: TOKENS.email.forward,
-    displayPriority: 7,
-  });
+  // NOTE: reply ('opt+r'), reply-all ('r') and forward ('f') hotkeys were
+  // removed here: their handlers were stubbed out but still consumed the
+  // keypress and showed dead entries in the hotkey UI. Re-add them with real
+  // handlers when reply-mode switching is wired up.
   registerHotkey({
     hotkey: 'e',
     scopeId,

--- a/js/app/packages/block-email/util/emailUser.ts
+++ b/js/app/packages/block-email/util/emailUser.ts
@@ -3,16 +3,25 @@ import type { ApiMessage } from '@service-email/generated/schemas';
 import { getFirstName } from './name';
 
 /**
+ * Case-insensitive email address comparison. Returns false when either
+ * address is missing.
+ */
+export function emailsMatch(
+  a: string | null | undefined,
+  b: string | null | undefined
+): boolean {
+  if (!a || !b) return false;
+  return a.toLowerCase() === b.toLowerCase();
+}
+
+/**
  * Check if a message is from the current user
  */
 function isMessageFromCurrentUser(
   message: ApiMessage,
   currentUserEmail?: string
 ): boolean {
-  if (!currentUserEmail) return false;
-  const fromEmail = message.from?.email?.toLowerCase();
-  const userEmail = currentUserEmail.toLowerCase();
-  return fromEmail !== undefined && fromEmail === userEmail;
+  return emailsMatch(message.from?.email, currentUserEmail);
 }
 
 /**
@@ -53,7 +62,7 @@ export function getRecipientDisplayName(
   recipient: Recipient,
   currentUserEmail?: string
 ): string {
-  if (recipient.email === currentUserEmail) return 'Me';
+  if (emailsMatch(recipient.email, currentUserEmail)) return 'Me';
   return recipient.name
     ? getFirstName(recipient.name)
     : (recipient.email?.split('@')[0] ?? '');

--- a/js/app/packages/block-email/util/mentionToCc.ts
+++ b/js/app/packages/block-email/util/mentionToCc.ts
@@ -1,5 +1,6 @@
 import type { EmailRecipient } from '@block-email/component/EmailContext';
 import { convertContactInfoToEmailRecipient } from '@block-email/util/recipientConversion';
+import { emailsMatch } from '@block-email/util/emailUser';
 import type { UserMentionRecord } from '@core/component/LexicalMarkdown/utils/mentionsUtils';
 import { toast } from '@core/component/Toast/Toast';
 
@@ -23,7 +24,7 @@ export function addUserMentionToCc(params: {
   if (!mentionEmail) return;
 
   const matches = (recipient: EmailRecipient) =>
-    recipient.data.email === mentionEmail;
+    emailsMatch(recipient.data.email, mentionEmail);
 
   if (
     toRecipients.some(matches) ||

--- a/js/app/packages/block-email/util/plainTextToHtml.test.ts
+++ b/js/app/packages/block-email/util/plainTextToHtml.test.ts
@@ -21,13 +21,13 @@ describe('plainTextToHtml', () => {
 
   it('handles consecutive newlines as double br', () => {
     expect(plainTextToHtml('above\n\nbelow')).toBe(
-      `<div>${span('above')}<br><br><br>${span('below')}</div>`
+      `<div>${span('above')}<br><br>${span('below')}</div>`
     );
   });
 
   it('handles only newlines', () => {
-    // '\n\n' splits into ['', '', ''] → <br> joined by <br> = 5 <br>s
-    expect(plainTextToHtml('\n\n')).toBe('<div><br><br><br><br><br></div>');
+    // '\n\n' splits into ['', '', ''] → joined by <br> = 2 <br>s
+    expect(plainTextToHtml('\n\n')).toBe('<div><br><br></div>');
   });
 
   describe('html escaping', () => {
@@ -71,7 +71,7 @@ describe('plainTextToHtml', () => {
   it('handles multiline content matching editor format', () => {
     const input = 'Hi,\n\nSome text here';
     expect(plainTextToHtml(input)).toBe(
-      `<div>${span('Hi,')}<br><br><br>${span('Some text here')}</div>`
+      `<div>${span('Hi,')}<br><br>${span('Some text here')}</div>`
     );
   });
 });

--- a/js/app/packages/block-email/util/plainTextToHtml.ts
+++ b/js/app/packages/block-email/util/plainTextToHtml.ts
@@ -9,9 +9,12 @@ export function plainTextToHtml(text: string): string {
   const lines = text.split('\n');
   const inner = lines
     .map((line) => {
-      if (!line) return '<br>';
+      // Empty lines map to '' — the join below already contributes the
+      // line break, so emitting <br> here would double the blank lines
+      if (!line) return '';
       return `<span style="white-space: pre-wrap;">${escapeHtml(line)}</span>`;
     })
     .join('<br>');
-  return `<div>${inner}</div>`;
+  // An empty body still needs a <br> so the div renders as one blank line
+  return `<div>${inner || '<br>'}</div>`;
 }

--- a/js/app/packages/block-email/util/prepareEmailBody.ts
+++ b/js/app/packages/block-email/util/prepareEmailBody.ts
@@ -4,10 +4,8 @@ import { $createQuoteNode } from '@lexical/rich-text';
 import { $dfsIterator } from '@lexical/utils';
 import {
   $createClassedBlockNode,
-  $createDocumentMentionNode,
   $createHtmlRenderNode,
   $isClassedBlockNode,
-  type ClassedBlockNode,
   type DocumentMentionInfo,
 } from '@lexical-core';
 import type { ApiMessage } from '@service-email/generated/schemas';
@@ -16,7 +14,6 @@ import {
   $createParagraphNode,
   $createTextNode,
   $getRoot,
-  $isLineBreakNode,
   COMMAND_PRIORITY_EDITOR,
   createCommand,
   type LexicalEditor,
@@ -96,7 +93,7 @@ function buildHeaderDescriptor(
     'On ' +
     formattedDate +
     ' ' +
-    (replyingTo.from?.name ?? replyingTo.from?.email) +
+    (replyingTo.from?.name ?? replyingTo.from?.email ?? '') +
     ' <' +
     (replyingTo.from?.email ?? '') +
     '> wrote: ';
@@ -179,7 +176,7 @@ const $appendPreviousEmail = (
 };
 
 function* $findPreviousEmailNode(replyingToID: string | undefined) {
-  if (!replyingToID) yield;
+  if (!replyingToID) return;
   for (const { node } of $dfsIterator()) {
     if (!$isClassedBlockNode(node)) continue;
 
@@ -237,60 +234,6 @@ export function registerToggleAppendedThread(editor: LexicalEditor) {
   );
 }
 
-async function _appendItemsAsMacroMentions(
-  editor: LexicalEditor | undefined,
-  items: DocumentMentionInfo[]
-) {
-  if (!editor) return;
-  if (!items || items.length === 0) return;
-  editor.update(() => {
-    const root = $getRoot();
-
-    // Find an existing mentions wrapper (search from the end for the most recent)
-    const children = root.getChildren();
-    let wrapper: ClassedBlockNode | null = null;
-    for (let i = children.length - 1; i >= 0; i--) {
-      const candidate = children[i];
-      if (
-        $isClassedBlockNode(candidate) &&
-        (candidate as any).__classes?.includes('macro_mentions')
-      ) {
-        wrapper = candidate as any;
-        break;
-      }
-    }
-
-    // If no wrapper, create one and add an empty line above it
-    if (!wrapper) {
-      const spacer = $createParagraphNode();
-      root.append(spacer);
-      wrapper = $createClassedBlockNode({
-        tag: 'div',
-        classes: ['macro_mentions'],
-      });
-      root.append(wrapper);
-    }
-
-    // Append each mention as its own paragraph at the bottom of the wrapper
-    items.forEach((item) => {
-      const last = wrapper.getLastChild();
-      if (last && !$isLineBreakNode(last)) {
-        wrapper.append($createLineBreakNode());
-      }
-
-      const mention = $createDocumentMentionNode({
-        documentId: item.documentId,
-        documentName: item.documentName,
-        blockName: item.blockName,
-      });
-
-      wrapper.append(mention);
-      // Trailing break to keep future insertions on a new line
-      wrapper.append($createLineBreakNode());
-    });
-  });
-}
-
 function getAppendedReplyElement(
   replyingTo: ApiMessage,
   replyType: ReplyType | undefined
@@ -342,17 +285,24 @@ function convertMentionsToLinks(root: ParentNode) {
   );
   let mentions: DocumentMentionInfo[] = [];
   mentionElements.forEach((el) => {
+    let blockParams: DocumentMentionInfo['blockParams'];
+    const blockParamsAttr = el.getAttribute('data-block-params');
+    if (blockParamsAttr) {
+      // A malformed attribute shouldn't abort the whole send/draft-save path
+      try {
+        blockParams = JSON.parse(blockParamsAttr);
+      } catch {
+        blockParams = undefined;
+      }
+    }
+    const collapsedAttr = el.getAttribute('data-collapsed');
     const mention: DocumentMentionInfo = {
       documentId: el.getAttribute('data-document-id') || '',
       documentName: el.getAttribute('data-document-name') || '',
       blockName: el.getAttribute('data-block-name') || '',
-      blockParams: el.getAttribute('data-block-params')
-        ? JSON.parse(el.getAttribute('data-block-params') || '{}')
-        : undefined,
+      blockParams,
       mentionUuid: el.getAttribute('data-mention-uuid') || undefined,
-      collapsed: el.getAttribute('data-collapsed')
-        ? Boolean(el.getAttribute('data-collapsed'))
-        : undefined,
+      collapsed: collapsedAttr ? collapsedAttr === 'true' : undefined,
       channelType: el.getAttribute('data-channel-type') || undefined,
     };
     if (!mention.documentId || !mention.documentName || !mention.blockName)
@@ -502,7 +452,13 @@ export function prepareEmailBody(
     .replace(/\//g, '_')
     .replace(/={1,}$/, '');
   const bodyHtml = html;
-  const bodyText = parsed.body.firstChild?.textContent ?? '';
+  // Plain text of the user-authored content. Read from the whole body (not
+  // just the first child — flattening can leave multiple top-level elements,
+  // e.g. around lists or headings), but exclude any quoted thread so empty
+  // replies aren't mistaken for content (see hasDraftContent).
+  const bodyClone = parsed.body.cloneNode(true) as HTMLElement;
+  bodyClone.querySelectorAll('.macro_quote').forEach((quote) => quote.remove());
+  const bodyText = bodyClone.textContent ?? '';
 
   return { bodyHtml, bodyText, mentions };
 }

--- a/js/app/packages/block-email/util/recipientConversion.ts
+++ b/js/app/packages/block-email/util/recipientConversion.ts
@@ -6,6 +6,7 @@ import {
 } from '@core/user';
 import type { ApiMessage } from '@service-email/generated/schemas';
 import type { EmailRecipient } from '../component/EmailContext';
+import { emailsMatch } from './emailUser';
 
 const extractedContactInfo = (contact: ContactInfo): ExtractedContactInfo => ({
   ...contact,
@@ -46,7 +47,7 @@ export const getReplyAllRecipients = (
   if (!referenceMessage) return { to, cc, bcc: [] };
 
   // If last message was from user - reply to the to recipients (cc is handled separately below)
-  if (referenceMessage?.from?.email === userEmail) {
+  if (emailsMatch(referenceMessage?.from?.email, userEmail)) {
     if (referenceMessage.to && referenceMessage.to.length > 0) {
       to = referenceMessage.to.map(recipientEntityMapper('contact'));
     }
@@ -59,18 +60,18 @@ export const getReplyAllRecipients = (
     };
     const otherRecipients = referenceMessage.to.filter(
       (recipient) =>
-        recipient.email !== userEmail && recipient.email !== sender.email
+        !emailsMatch(recipient.email, userEmail) &&
+        !emailsMatch(recipient.email, sender.email)
     );
     to = [sender, ...otherRecipients].map(convertContactInfoToEmailRecipient);
   }
-  if (
-    referenceMessage.cc &&
-    referenceMessage.cc.filter((recipient) => recipient.email !== userEmail)
-      .length > 0
-  ) {
-    cc = referenceMessage.cc
-      .filter((recipient) => recipient.email !== userEmail)
-      .map(convertContactInfoToEmailRecipient);
+  if (referenceMessage.cc) {
+    const otherCc = referenceMessage.cc.filter(
+      (recipient) => !emailsMatch(recipient.email, userEmail)
+    );
+    if (otherCc.length > 0) {
+      cc = otherCc.map(convertContactInfoToEmailRecipient);
+    }
   }
   return { to, cc, bcc: [] };
 };
@@ -84,8 +85,9 @@ export const isReplyAllEligible = (
   userEmail: string
 ): boolean => {
   const sender = message.from?.email;
-  if (sender === userEmail) return false;
-  const isOther = (email: string) => email !== userEmail && email !== sender;
+  if (emailsMatch(sender, userEmail)) return false;
+  const isOther = (email: string) =>
+    !emailsMatch(email, userEmail) && !emailsMatch(email, sender);
   const otherTo = message.to.filter((r) => isOther(r.email));
   const otherCc = message.cc.filter((r) => isOther(r.email));
   return otherTo.length + otherCc.length > 0;
@@ -101,7 +103,7 @@ export const getReplyRecipientsFromParent = (
 } => {
   if (!replyingTo) return { to: [], cc: [], bcc: [] };
   // If last message was from user, reply === replyAll
-  if (replyingTo?.from?.email === userEmail) {
+  if (emailsMatch(replyingTo?.from?.email, userEmail)) {
     return getReplyAllRecipients(replyingTo, userEmail);
   } else {
     // Last message was NOT the user - reply to the sender

--- a/js/app/packages/block-email/util/scrollToMessage.ts
+++ b/js/app/packages/block-email/util/scrollToMessage.ts
@@ -19,12 +19,14 @@ export function scrollToMessage(
 ): boolean {
   let messageIndex = messages.findIndex((m) => m.db_id === messageId);
 
-  if (reversed) {
-    messageIndex = messages.length - 1 - messageIndex;
-  }
-
+  // Check before applying the reversal: findIndex's -1 would otherwise map
+  // to messages.length and escape this guard
   if (messageIndex < 0) {
     return false;
+  }
+
+  if (reversed) {
+    messageIndex = messages.length - 1 - messageIndex;
   }
 
   const targetElement = messagesContainer.children[messageIndex];
@@ -39,34 +41,4 @@ export function scrollToMessage(
   });
 
   return true;
-}
-
-/**
- * Scrolls to the last message in the thread
- * @param messagesContainer - The DOM container holding the message elements
- * @param behavior - Scroll behavior ('smooth' | 'instant' | 'auto')
- */
-function _scrollToLastMessage(
-  messagesContainer: HTMLDivElement,
-  behavior: ScrollBehavior | 'instant' = 'instant'
-): void {
-  const nativeBehavior: ScrollBehavior =
-    behavior === 'instant' ? 'auto' : behavior;
-  const lastChild = messagesContainer.children[
-    messagesContainer.children.length - 1
-  ] as HTMLElement | undefined;
-
-  if (!lastChild) return;
-  // Align the last child to the bottom of the nearest scrolling container
-  lastChild.scrollIntoView({ behavior: nativeBehavior, block: 'start' });
-}
-
-/**
- * Gets the last message ID from a thread
- * @param messages - Array of messages in the current thread
- * @returns The db_id of the last message, or undefined if no messages
- */
-function _getLastMessageId(messages: ApiMessage[]): string | undefined {
-  const lastMessage = messages[messages.length - 1];
-  return lastMessage?.db_id?.toString();
 }

--- a/js/app/packages/block-email/util/subjectText.test.ts
+++ b/js/app/packages/block-email/util/subjectText.test.ts
@@ -1,0 +1,40 @@
+import type { ApiMessage } from '@service-email/generated/schemas';
+import { describe, expect, it } from 'vitest';
+import { getSubjectText } from './subjectText';
+
+const message = (subject: string | null) => ({ subject }) as ApiMessage;
+
+describe('getSubjectText', () => {
+  it('returns empty string without a message', () => {
+    expect(getSubjectText(undefined, 'reply')).toBe('');
+  });
+
+  it('prefixes replies with Re:', () => {
+    expect(getSubjectText(message('Budget'), 'reply')).toBe('Re: Budget');
+    expect(getSubjectText(message('Budget'), 'reply-all')).toBe('Re: Budget');
+  });
+
+  it('does not stack Re: prefixes, case-insensitively', () => {
+    expect(getSubjectText(message('Re: Budget'), 'reply')).toBe('Re: Budget');
+    expect(getSubjectText(message('RE: Budget'), 'reply')).toBe('RE: Budget');
+    expect(getSubjectText(message('re: Budget'), 'reply-all')).toBe(
+      're: Budget'
+    );
+  });
+
+  it('still prefixes subjects that merely contain "Re:"', () => {
+    expect(getSubjectText(message('Talking about Re: budgets'), 'reply')).toBe(
+      'Re: Talking about Re: budgets'
+    );
+  });
+
+  it('prefixes forwards with Fwd:', () => {
+    expect(getSubjectText(message('Budget'), 'forward')).toBe('Fwd: Budget');
+  });
+
+  it('treats a null subject as empty instead of the string "null"', () => {
+    expect(getSubjectText(message(null), 'reply')).toBe('Re: ');
+    expect(getSubjectText(message(null), 'forward')).toBe('Fwd: ');
+    expect(getSubjectText(message(null), undefined)).toBe('');
+  });
+});

--- a/js/app/packages/block-email/util/subjectText.ts
+++ b/js/app/packages/block-email/util/subjectText.ts
@@ -6,15 +6,17 @@ export const getSubjectText = (
   replyType: ReplyType | undefined
 ) => {
   if (!replyingTo) return '';
+  const subject = replyingTo.subject ?? '';
   if (replyType === 'reply-all' || replyType === 'reply') {
-    if (replyingTo.subject?.includes('Re: ')) {
-      return replyingTo.subject;
-    } else {
-      return `Re: ${replyingTo.subject}`;
+    // Match existing prefixes case-insensitively ("RE:", "re:") so we don't
+    // stack prefixes on replies from other clients
+    if (/^re:/i.test(subject)) {
+      return subject;
     }
+    return `Re: ${subject}`;
   } else if (replyType === 'forward') {
-    return `Fwd: ${replyingTo.subject}`;
+    return `Fwd: ${subject}`;
   } else {
-    return replyingTo.subject ?? '';
+    return subject;
   }
 };

--- a/js/lexical-core/nodes/DocumentMentionNode.ts
+++ b/js/lexical-core/nodes/DocumentMentionNode.ts
@@ -205,7 +205,7 @@ export class DocumentMentionNode extends DecoratorNode<
       'data-mention-uuid': this.__mentionUuid || '',
       'data-channel-type': this.__channelType || '',
       'data-created-at': this.__createdAt?.toString() || '',
-      DOMConversionMap: this.__collapsed.toString(),
+      'data-collapsed': this.__collapsed.toString(),
     };
   }
 


### PR DESCRIPTION
This PR addresses multiple bugs and edge cases in the email compose and message handling flows, with a focus on improving reliability and correctness.

## Summary
Fixes several issues in email reply composition, message scheduling, recipient handling, and message scrolling. Includes improvements to error handling, state management, and email address comparison logic.

## Key Changes

**Compose & Scheduling:**
- Fixed schedule message flow to clear send time on failure, preventing phantom "scheduled" state
- Added try-catch error handling around `scheduleMessage` and `flagArchived` calls
- Fixed `restoreUndoCallback` to only clear when the current instance owns it, preventing interference between multiple BaseInput instances
- Changed `onMount` to `createEffect` for form callbacks to handle re-keying when reply context changes

**Email Address Handling:**
- Added `emailsMatch()` utility for case-insensitive email comparison
- Updated recipient conversion logic to use case-insensitive matching throughout
- Fixed reply-all recipient filtering to properly handle email case variations

**Message Display & Scrolling:**
- Fixed `scrollToMessage()` to check bounds before applying reversed index calculation
- Removed unnecessary sorting in `firstUnreadMessageId` memo (messages already sorted in context)
- Improved message loading loop with disposal flag to prevent operations after unmount
- Fixed `loadMessagesUntilFound` to return false when disposed instead of infinite loop

**Reply Handling:**
- Fixed reply append toggle guard to check `db_id` instead of `replying_to_id` (root messages have no replying_to_id)
- Improved `buildHeaderDescriptor` to handle missing sender name/email with fallback to empty string
- Fixed `$findPreviousEmailNode` generator to use `return` instead of `yield` when no replyingToID

**Draft Content Detection:**
- Updated `prepareEmailBody` to exclude quoted thread text when extracting plain text, preventing empty replies from being mistaken as having content
- Clones body and removes `.macro_quote` elements before extracting text

**Subject Line Handling:**
- Improved `getSubjectText` to use case-insensitive regex for detecting existing "Re:" prefixes
- Added comprehensive test coverage for subject line prefix handling

**HTML/Text Conversion:**
- Fixed `plainTextToHtml` to not double blank lines (empty lines map to '' with join providing the break)
- Updated test expectations to match corrected behavior

**UI & Hotkeys:**
- Removed stubbed reply/reply-all/forward hotkey handlers that were consuming keypresses without functionality
- Cleaned up unused ref in ComposeToolbar

**Code Quality:**
- Improved error handling with try-catch blocks in scheduling flows
- Better null/undefined handling with optional chaining and fallbacks
- Removed unused imports and dead code
- Added comments explaining non-obvious logic (e.g., message time comparison, email matching)

https://claude.ai/code/session_01GJDgV1YUdUHqAB8GDXu5QQ