### PR TITLE
docs: getting started, migration, apps, account, support, recipes; split changelog; release CRM page

### DIFF
--- a/docs/AI/recipes.mdx
+++ b/docs/AI/recipes.mdx
@@ -1,0 +1,98 @@
+---
+title: "Agent recipes"
+description: "Copy-paste prompts for the most useful things agents can do in your Macro workspace."
+---
+
+Agents in Macro aren't a side feature — they sit on top of [unified memory](/product/unified-memory), so one prompt can reach your email, messages, tasks, docs, calls, and connectors. These recipes are starting points: paste them into an agent chat (<kbd>c</kbd> + <kbd>a</kbd>), an [automation](/product/agents#automations), a channel via **@Macro**, or any [MCP client](/AI/mcp/overview) connected to your workspace.
+
+## Daily inbox brief
+
+Create an [automation](/product/agents#automations) (agents module → **Automations** tab → **Create an automation**) scheduled for each morning:
+
+```text
+Every weekday at 8am: summarize what's in my Signal inbox.
+Group it into: needs a reply today, FYI, and waiting on others.
+Keep it under ten bullets.
+```
+
+The result lands in your inbox at the scheduled time, every day.
+
+## Project status on demand
+
+Ask in any agent chat — no need to point it at anything, since memory is refreshed from your team's activity:
+
+```text
+What's the latest status of [project]? Check recent tasks, channel
+discussion, and call transcripts, and tell me what changed this week
+and what's blocking.
+```
+
+You can @mention a specific channel, doc, or task in the prompt to skip the search and guarantee the right context — see [Mentions in Agents](/concepts/mentions#mentions-in-agents).
+
+## Weekly team recap
+
+An automation for Friday afternoons:
+
+```text
+Every Friday at 4pm: write a recap of the week for @#general —
+tasks completed, tasks started, key decisions from calls, and
+anything that slipped. Link to the relevant items.
+```
+
+## Turn a call into tasks
+
+After a call ends, its transcript is already in your workspace. From the call (or any chat):
+
+```text
+Go through @[yesterday's planning call] and create a task for each
+action item we committed to. Assign them to whoever took the item,
+and link the call in each task.
+```
+
+## Draft replies in your voice
+
+```text
+Draft a reply to @[email thread]. Tone: warm but brief. We can do
+the June 20 date, but ask them to send the revised scope first.
+```
+
+Review the draft, then tell the agent to send it — or send it yourself from the composer.
+
+## Answer questions inside a channel
+
+Mention **@Macro** in any [channel](/product/channels) to pull an agent into the conversation, with the channel as context:
+
+```text
+@Macro summarize this thread for someone joining late, and list
+the open questions nobody has answered yet.
+```
+
+## Import from another tool
+
+Connect the tool under **Settings → Connectors**, then:
+
+```text
+Import my Notion docs from the "Engineering" workspace as Macro
+docs. Keep the folder structure and skip anything archived.
+```
+
+See [Switch to Macro](/switch-to-macro) for tool-by-tool migration guides.
+
+## Use your workspace from Claude Code
+
+Once you've [connected the Macro MCP server](/AI/mcp/overview), your coding agent has the same reach — it can search your workspace, read threads and docs, create documents, send email, and update task properties with the [MCP tools](/AI/mcp/tools/index):
+
+```text
+Find the Macro task for the bug I'm fixing, read the linked channel
+discussion, and when I'm done, set the task status to In Review and
+post a summary of the fix as a comment.
+```
+
+```text
+Read the customer thread about the export bug, then draft (don't
+send) a reply explaining the fix that shipped in today's release.
+```
+
+<Tip>
+  Agents inherit your permissions: they can only see what you can see, and anything they create or send is attributed to you. Start prompts with "draft, don't send" while you calibrate trust.
+</Tip>

--- a/docs/account/billing.mdx
+++ b/docs/account/billing.mdx
@@ -1,0 +1,23 @@
+---
+title: "Billing & plans"
+description: "Macro's free and premium plans, and how to manage your subscription."
+---
+
+Macro has one paid plan, priced per person — the same whether you're solo or on a team.
+
+| | Free | Premium |
+| --- | --- | --- |
+| Price | $0 | $40 / month |
+| AI agent | Fast model only | All models |
+| AI tool calls | Limited | Unlimited |
+| Storage | 5 GB | 1 TB |
+
+Teams require a paid seat for every member — there's no free plan for teams. Your current plan is shown in **Settings → Account**, with an **Upgrade** button if you're on the free plan.
+
+## Managing your subscription
+
+Subscriptions are handled through Stripe. From **Settings → Account**, choose **Manage Subscription** to open the billing portal, where you can update your payment method, download invoices, or cancel. If you cancel, your plan stays active until the end of the billing period.
+
+## Self-hosting
+
+Macro is open source under the AGPLv3, and self-hosting is free — though some bundled services require your own licenses, and it isn't our primary focus yet. See the [FAQ](/faq) for the current state of self-hosting, and contact [licensing@macro.com](mailto:licensing@macro.com) if you want to build on Macro under a different license.

--- a/docs/account/teams.mdx
+++ b/docs/account/teams.mdx
@@ -1,0 +1,40 @@
+---
+title: "Teams & admin"
+description: "Creating a team, inviting members, roles, and what admins can do."
+---
+
+Macro works solo, but teams unlock the collaborative layer: auto-shared tasks and calls, the [CRM](/product/crm), and [team memory](/product/unified-memory) for your agents.
+
+## Create a team and invite people
+
+Click **Team** in the bottom left to create a team — you can add the first members right there, or invite more later by email from **Settings → Team**. Invitees see the pending invitation when they sign in.
+
+<Note>
+  There's no free plan for teams — every member needs a paid seat. See [Billing & plans](/account/billing).
+</Note>
+
+## Roles
+
+Teams have three roles, in increasing order of access:
+
+| Role | What it adds |
+| --- | --- |
+| **Member** | Everything shared with the team: team tasks, shared calls, visible CRM records |
+| **Admin** | Manage CRM visibility — toggle [Email Sync](/product/crm) per company, hide or unhide records |
+| **Owner** | Everything above, plus inviting and removing members |
+
+Owners can remove any member except themselves. When someone is removed, access flows out the same way it flowed in: they lose team-shared content automatically, and removing them from [channels](/permissions) revokes everything that was shared there.
+
+## What's shared with a team
+
+Joining a team changes the default sharing for a few block types — everything else stays private until you share it:
+
+- **Tasks** are visible to the whole team by default.
+- **Calls** are recorded, transcribed, and shared to team memory by default; anyone can opt a call out, which keeps it in their personal memory only.
+- **Emails** with tracked customers are shared through the [CRM](/product/crm) when Email Sync is on for that company.
+
+See [Permissions](/permissions) for the full sharing model.
+
+## Sign-in and enterprise
+
+Macro signs in with your Google account — the same one your Gmail or Google Workspace email syncs from. For enterprise requirements like HIPAA, FedRAMP, or running Macro on your own infrastructure, contact [self-host@macro.com](mailto:self-host@macro.com).

--- a/docs/apps.mdx
+++ b/docs/apps.mdx
@@ -1,0 +1,26 @@
+---
+title: "Apps & platforms"
+description: "Where you can use Macro: web, iOS, and what's different on each."
+---
+
+## Web
+
+Macro runs in any modern browser at [macro.com](https://macro.com) — no install required. Desktop is the full Macro experience: the keyboard-driven workflow, and a built-in window manager that lets you multi-task in [splits](/concepts/blocks#splits) inside a single tab, so Macro replaces a pile of browser tabs rather than adding one.
+
+## iOS
+
+The Macro iOS app is on the [App Store](https://apps.apple.com/us/app/macro-app/id6743133649). It connects to the same workspace — inbox, email, channels, tasks, docs, and agents on your phone. You can also grab it from **Settings → Mobile App** in the web app, which shows a QR code.
+
+A few things stay desktop-only by design:
+
+- **Splits** — the side-by-side window manager needs screen width; on mobile you work one block at a time.
+- **Keyboard shortcuts** — the <kbd>c</kbd> launcher, <kbd>j</kbd>/<kbd>k</kbd> navigation, and friends are desktop features.
+- **Some settings** — managing email inboxes and connectors is done from desktop.
+
+## Android
+
+An Android app isn't available yet.
+
+<Note>
+  Self-hosters: the hosted version of Macro is the one with Apple, Google Mail, and GitHub approvals — see the [FAQ](/faq) for what that means for your own deployment.
+</Note>

--- a/docs/changelog/2025-12.mdx
+++ b/docs/changelog/2025-12.mdx
@@ -1,0 +1,300 @@
+---
+title: "December 2025"
+description: "Macro releases from December 2025."
+---
+
+    <Update label="v2025.12.15.1">
+## What's Changed
+* fix(scrollbar): simplify scrollbar style by @Fake-User in https://github.com/macro-inc/macro/pull/637
+* fix(md): ammend [2813da97] and keep text formatting of children by @sedson in https://github.com/macro-inc/macro/pull/654
+* fix(ws): don't cleanup on close by @synoet in https://github.com/macro-inc/macro/pull/657
+* fix(soup): fix layout thrash on help drawer toggle by @sedson in https://github.com/macro-inc/macro/pull/656
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2025.12.15.0...v2025.12.15.1
+    </Update>
+
+    <Update label="v2025.12.15.0">
+## What's Changed
+* chore(email): add gmail auth feature by @seanaye in https://github.com/macro-inc/macro/pull/405
+* feat(email): Thread metadata in previews by @evanhutnik in https://github.com/macro-inc/macro/pull/366
+* feat(notification_service): only send notification emails to non existing users by @whutchinson98 in https://github.com/macro-inc/macro/pull/408
+* fix(sps): delete email link for SPS entity names by @whutchinson98 in https://github.com/macro-inc/macro/pull/431
+* feat(sps): speed up name index backfill script by @whutchinson98 in https://github.com/macro-inc/macro/pull/430
+* fix(opensearch): Delete from name index in delete_user_entities helper by @evanhutnik in https://github.com/macro-inc/macro/pull/432
+* fix(iac): bulk upload lambda permissions by @whutchinson98 in https://github.com/macro-inc/macro/pull/435
+* fix[channels]: new thread reply updates gated by typing by @peterchinman in https://github.com/macro-inc/macro/pull/429
+* fix[channels]: jump to reply input on tab focus by @peterchinman in https://github.com/macro-inc/macro/pull/434
+* fix: remove hard coded test stripe price id by @whutchinson98 in https://github.com/macro-inc/macro/pull/437
+* feat(email-service): Per-message contact name storage by @evanhutnik in https://github.com/macro-inc/macro/pull/438
+* fix(macrodb): Remove backfill operation from db migration by @evanhutnik in https://github.com/macro-inc/macro/pull/445
+* chore(ai): kill memory by @ehayes2000 in https://github.com/macro-inc/macro/pull/441
+* feat(macrodb): add document_task table by @whutchinson98 in https://github.com/macro-inc/macro/pull/447
+* chore(ws): add max retries for cognition, connection, storage by @synoet in https://github.com/macro-inc/macro/pull/444
+* feat(search): handle name and unified search using names index by @whutchinson98 in https://github.com/macro-inc/macro/pull/345
+* feat: update front end to handle new search types for handling name search by @gbirman in https://github.com/macro-inc/macro/pull/424
+* feat(dcs): batch id support for read tool by @ehayes2000 in https://github.com/macro-inc/macro/pull/399
+* feat(ios): applink verification by @seanaye in https://github.com/macro-inc/macro/pull/449
+* Seanaye/add/axum rpc macro by @seanaye in https://github.com/macro-inc/macro/pull/440
+* feat(dss|search|soup): update all document models to return is_task by @whutchinson98 in https://github.com/macro-inc/macro/pull/448
+* feat(dss): create/copy document handles tasks by @whutchinson98 in https://github.com/macro-inc/macro/pull/451
+* add [properties-be] - system properties for tasks and email by @danielkweon in https://github.com/macro-inc/macro/pull/436
+* fix [properties-be] - allow view access for publicly shared entities by @danielkweon in https://github.com/macro-inc/macro/pull/446
+* fix(soup) Add labels to email soup objects by @evanhutnik in https://github.com/macro-inc/macro/pull/452
+* Seanaye/add/legacy rpc interface by @seanaye in https://github.com/macro-inc/macro/pull/442
+* chore(ios+android): add app verification files by @seanaye in https://github.com/macro-inc/macro/pull/453
+* chore: remove redundant bytesEqual by @gbirman in https://github.com/macro-inc/macro/pull/398
+* fix [properties-frontend] - type check fixes by @danielkweon in https://github.com/macro-inc/macro/pull/459
+* feat: upload folders on drag and drop by @peterchinman in https://github.com/macro-inc/macro/pull/34
+* feat(notification_service): add in helper to send push notifications locally by @whutchinson98 in https://github.com/macro-inc/macro/pull/460
+* feat(auth-service): get_names_with_email endpoint by @evanhutnik in https://github.com/macro-inc/macro/pull/455
+* fix(search_service): correctly include name indice in search queries by @whutchinson98 in https://github.com/macro-inc/macro/pull/462
+* chore: remove some unused utils by @synoet in https://github.com/macro-inc/macro/pull/458
+* soup: replace dss get with post endpoint by @aquaductape in https://github.com/macro-inc/macro/pull/454
+* fix(email-service): Message contact name saving by @evanhutnik in https://github.com/macro-inc/macro/pull/463
+* feat: signal noise split for inbox by @peterchinman in https://github.com/macro-inc/macro/pull/465
+* chore(app): consolidate service clients by @synoet in https://github.com/macro-inc/macro/pull/457
+* feat(email-service): Enable contacts syncing by @evanhutnik in https://github.com/macro-inc/macro/pull/467
+* feat(notification_service): ability to mark notifications as undone by @whutchinson98 in https://github.com/macro-inc/macro/pull/466
+* Feat(email-compose): New email compose design by @dev-rb in https://github.com/macro-inc/macro/pull/469
+* fix(email-service): Better log for attachment upload create document failure by @evanhutnik in https://github.com/macro-inc/macro/pull/475
+* add [properties-be] - properties service handling system by @danielkweon in https://github.com/macro-inc/macro/pull/456
+* add [properties-be] - system properties for tasks by @danielkweon in https://github.com/macro-inc/macro/pull/461
+* chore(app): remove dead code by @synoet in https://github.com/macro-inc/macro/pull/479
+* fix(lexical): add parser for m-links in plaintext by @synoet in https://github.com/macro-inc/macro/pull/477
+* feat(notification_service): send push notification before connection gateway by @whutchinson98 in https://github.com/macro-inc/macro/pull/484
+* fix(email-service): email upload attachment endpoint issues by @evanhutnik in https://github.com/macro-inc/macro/pull/483
+* soup: replace email query with dss query by @aquaductape in https://github.com/macro-inc/macro/pull/486
+* feat(sync_service): change sync service url by @cowlicks in https://github.com/macro-inc/macro/pull/472
+* feat(documents): move from is_task to sub_type by @whutchinson98 in https://github.com/macro-inc/macro/pull/487
+* fix: Auto focus first item in recipient selector when typing and mount by @dev-rb in https://github.com/macro-inc/macro/pull/488
+* chg(kommand): deprioritize commands in Kommand Menu, remove splitting by @synoet in https://github.com/macro-inc/macro/pull/481
+* chg(kommand): disable email + search in kommand menu by @synoet in https://github.com/macro-inc/macro/pull/482
+* chore(macrodb): drop document_task by @whutchinson98 in https://github.com/macro-inc/macro/pull/491
+* fix: remove isTask by @whutchinson98 in https://github.com/macro-inc/macro/pull/495
+* change sync service url again by @cowlicks in https://github.com/macro-inc/macro/pull/494
+* feat(iac): decrease deprovisioning time to improve deployment speed by @whutchinson98 in https://github.com/macro-inc/macro/pull/492
+* fix(iac): trigger cloud-storage deploy on infra changes by @whutchinson98 in https://github.com/macro-inc/macro/pull/496
+* feat [tasks] - add tasks in create menu by @danielkweon in https://github.com/macro-inc/macro/pull/490
+* fix(email-service): Move access level into thread object by @evanhutnik in https://github.com/macro-inc/macro/pull/498
+* feat [properties-fe] - add data type icons to property labels in panel by @danielkweon in https://github.com/macro-inc/macro/pull/497
+* chore(nix): macos flake support by @seanaye in https://github.com/macro-inc/macro/pull/485
+* soup: fix mark as done in email block and update block entity navigation indicator by @aquaductape in https://github.com/macro-inc/macro/pull/474
+* Russell/feat(settings): move settings dialog to SplitLikeContainer by @Fake-User in https://github.com/macro-inc/macro/pull/476
+* Fix(comms): Use contacts as single source of truth by @dev-rb in https://github.com/macro-inc/macro/pull/450
+* soup: update dss disable logic to fix no emails on email only filter by @aquaductape in https://github.com/macro-inc/macro/pull/505
+* Russell/dialog style by @Fake-User in https://github.com/macro-inc/macro/pull/501
+* add [properties-fe] - system properties in properties panel by @danielkweon in https://github.com/macro-inc/macro/pull/500
+* fix(layout): registration time of splits during reconcile by @synoet in https://github.com/macro-inc/macro/pull/478
+* Fix: Contact names not reactive to display name fetch  by @dev-rb in https://github.com/macro-inc/macro/pull/508
+* unified-list: enable rename channel by @aquaductape in https://github.com/macro-inc/macro/pull/509
+* fix [properties-be] - bunch of fixes by @danielkweon in https://github.com/macro-inc/macro/pull/506
+* fix?(soup): remove reconcile from entity queries by @synoet in https://github.com/macro-inc/macro/pull/511
+* soup: rename unified entity action parameter by @aquaductape in https://github.com/macro-inc/macro/pull/512
+* Fix: Display names not showing in mentions menu for channel users by @dev-rb in https://github.com/macro-inc/macro/pull/513
+* feat (MentionMenu): email search by @ehayes2000 in https://github.com/macro-inc/macro/pull/507
+* unified-list: remove unified jk navigation inside project block by @aquaductape in https://github.com/macro-inc/macro/pull/514
+* fix(mention menu): arrow keys by @ehayes2000 in https://github.com/macro-inc/macro/pull/516
+* add [properties] - set property status to done for 'e' in unified list by @danielkweon in https://github.com/macro-inc/macro/pull/510
+* feat(app/email): consolidate queries package + block-email using tanstack query by @synoet in https://github.com/macro-inc/macro/pull/480
+* unified-list: project-block filter chat by project_ids by @aquaductape in https://github.com/macro-inc/macro/pull/515
+* feat: block aliases, task pseudo block, task entity types, handling several note/task forks by @sedson in https://github.com/macro-inc/macro/pull/502
+* fix [tasks] - bunch of bug fixes by @danielkweon in https://github.com/macro-inc/macro/pull/517
+* feat(email-service): Add entity properties for uploaded email attachments by @evanhutnik in https://github.com/macro-inc/macro/pull/504
+* soup: fix client noise filter logic filtering out non-email entities by @aquaductape in https://github.com/macro-inc/macro/pull/519
+* add [tasks] - automatically set pinned properties by @danielkweon in https://github.com/macro-inc/macro/pull/518
+* fix: email attachment pills only create a single macro entity by @peterchinman in https://github.com/macro-inc/macro/pull/499
+* [channels] fix: subpixel color rendering issue by @peterchinman in https://github.com/macro-inc/macro/pull/503
+* fix(tasks): fix task navigation from soup and task split preview, chg(entity): tweak as yet unuses task enity types by @sedson in https://github.com/macro-inc/macro/pull/521
+* fix(emails/soup): fix live updating in email block and in soup by @synoet in https://github.com/macro-inc/macro/pull/522
+* feat(soup): add default tasks view by @sedson in https://github.com/macro-inc/macro/pull/523
+* add [properties-fe] - entity icons for threads, emails, tasks by @danielkweon in https://github.com/macro-inc/macro/pull/524
+* add [properties-fe] - handle entity type company by @danielkweon in https://github.com/macro-inc/macro/pull/526
+* add [properties-fe] - handle entity type threads by @danielkweon in https://github.com/macro-inc/macro/pull/528
+* fix: channel message go to click from soup not working by @gbirman in https://github.com/macro-inc/macro/pull/527
+* add [properties-fe] - handle entity type tasks + task search by @danielkweon in https://github.com/macro-inc/macro/pull/529
+* fix(tasks): goto task block from ItemPreview.tsx by @sedson in https://github.com/macro-inc/macro/pull/525
+* chore: use terms not query for command k search by @gbirman in https://github.com/macro-inc/macro/pull/530
+* fix: search items stability by @gbirman in https://github.com/macro-inc/macro/pull/534
+* fix: support message tag for empty message by @gbirman in https://github.com/macro-inc/macro/pull/535
+* Fix: Channel and email scroll jumping by @dev-rb in https://github.com/macro-inc/macro/pull/533
+* chg(tasks): task tab in command, tasks are green, more task icon bug fixes, fix broken link paste by @sedson in https://github.com/macro-inc/macro/pull/537
+* chg(entity): add indication that empty message previews have attachments by @sedson in https://github.com/macro-inc/macro/pull/539
+* feat: support multi hit content matches in front end search by @gbirman in https://github.com/macro-inc/macro/pull/543
+* fix [tasks] - route task entity pills to task instead of md by @danielkweon in https://github.com/macro-inc/macro/pull/541
+* feat(search): remove legacy update entity name events by @whutchinson98 in https://github.com/macro-inc/macro/pull/351
+* feat(email-service): Upload image/video attachments to sfs by @evanhutnik in https://github.com/macro-inc/macro/pull/532
+* feat: improve email message scroll by @gbirman in https://github.com/macro-inc/macro/pull/544
+* fix: show *attached items* for empty string by @gbirman in https://github.com/macro-inc/macro/pull/551
+* feat: add format button to channel message edit input by @gbirman in https://github.com/macro-inc/macro/pull/548
+* style(launcher): make 8 cols, reduce launcher item size slightly by @sedson in https://github.com/macro-inc/macro/pull/553
+* chore: remove duplicate binary names by @whutchinson98 in https://github.com/macro-inc/macro/pull/554
+* fix: scroll channel to bottom if notification has been deleted + notify user by @gbirman in https://github.com/macro-inc/macro/pull/550
+* chore: do not show delete reply input button for non-replies by @gbirman in https://github.com/macro-inc/macro/pull/546
+* feat: channel messages multi hit content matches + fix channel goToLocationFromParams by @gbirman in https://github.com/macro-inc/macro/pull/549
+* fix: scroll to bottom for channel new message by @gbirman in https://github.com/macro-inc/macro/pull/547
+* add [properties-be] - pass in specific message id for threads by @danielkweon in https://github.com/macro-inc/macro/pull/538
+* Revert "feat(notification_service): send push notification before connection gateway" by @whutchinson98 in https://github.com/macro-inc/macro/pull/556
+* feat(soup): expose email view type to api by @seanaye in https://github.com/macro-inc/macro/pull/560
+* add [properties-fe] - search for thread in properties by @danielkweon in https://github.com/macro-inc/macro/pull/558
+* fix [properties-fe] - thread entity pills show email subject instead of id by @danielkweon in https://github.com/macro-inc/macro/pull/559
+* fix: scroll to bottom of channel on new top level message by @gbirman in https://github.com/macro-inc/macro/pull/561
+* feat(search): return pretty sender email contact info from search backend by @whutchinson98 in https://github.com/macro-inc/macro/pull/563
+* fix(chat): Attach email found from search by @ehayes2000 in https://github.com/macro-inc/macro/pull/555
+* Feat(channels): Rename channel in block view by @dev-rb in https://github.com/macro-inc/macro/pull/557
+* chore: use vendored utoipa-swagger-ui by @whutchinson98 in https://github.com/macro-inc/macro/pull/564
+* fix (model): Item type can't be deserialized by @ehayes2000 in https://github.com/macro-inc/macro/pull/545
+* feat(comms-service): Add width and height columns for message attachments by @evanhutnik in https://github.com/macro-inc/macro/pull/562
+* fix (types): deleted at must be included in project schema :( by @ehayes2000 in https://github.com/macro-inc/macro/pull/573
+* fix(iac) : infra to support bun check by @whutchinson98 in https://github.com/macro-inc/macro/pull/574
+* style(entity): style search matches, alignment fixes by @sedson in https://github.com/macro-inc/macro/pull/565
+* feat: integrate front end pretty sender into search result by @gbirman in https://github.com/macro-inc/macro/pull/571
+* fix(md): fix programmatic restore focus with checkbox bug by @sedson in https://github.com/macro-inc/macro/pull/570
+* fix: email draft issues by @peterchinman in https://github.com/macro-inc/macro/pull/566
+* style(soup): collapse email subject space when searching by @sedson in https://github.com/macro-inc/macro/pull/577
+* soup: add emailView request body param by @aquaductape in https://github.com/macro-inc/macro/pull/569
+* fix(email-service): explicitly declare optional field by @evanhutnik in https://github.com/macro-inc/macro/pull/568
+* feat(tasks): flag off task tabs in prod by @sedson in https://github.com/macro-inc/macro/pull/575
+* add [properties-fe] - navigate to thread + specific message by @danielkweon in https://github.com/macro-inc/macro/pull/580
+* fix(email-service): Get attachment document_id endpoint upload location by @evanhutnik in https://github.com/macro-inc/macro/pull/584
+* fix(iac): APNS_SANDBOX for dev by @whutchinson98 in https://github.com/macro-inc/macro/pull/588
+* feat(search): update search to use the correct uuid type by @whutchinson98 in https://github.com/macro-inc/macro/pull/579
+* feat(dcs): chat with folder backend by @ehayes2000 in https://github.com/macro-inc/macro/pull/585
+* fix [properties-fe] - hide company entity type from property creation and selection by @danielkweon in https://github.com/macro-inc/macro/pull/582
+* fix(md): plugins.useReactive util to correctly re-register plugins on reactive props by @sedson in https://github.com/macro-inc/macro/pull/587
+* feat(search): search should include searching over participants and owner of items by @whutchinson98 in https://github.com/macro-inc/macro/pull/531
+* feat (chat): chat with folder frontend by @ehayes2000 in https://github.com/macro-inc/macro/pull/586
+* chore(chat): remove ask/agent seletor by @ehayes2000 in https://github.com/macro-inc/macro/pull/572
+* fix(email-service): Upload both inline and attached email images to sfs by @evanhutnik in https://github.com/macro-inc/macro/pull/591
+* fix(email-service): Use message send times for search by @evanhutnik in https://github.com/macro-inc/macro/pull/593
+* fix(tasks): add task color to monochrome icon util by @sedson in https://github.com/macro-inc/macro/pull/596
+* feat: click search icon to focus search by @gbirman in https://github.com/macro-inc/macro/pull/578
+* feat(search): add highlight support for owner fields by @whutchinson98 in https://github.com/macro-inc/macro/pull/597
+* fix [properties-fe] - save / filter of entity type tasks by @danielkweon in https://github.com/macro-inc/macro/pull/600
+* soup: scope unified-list entity hotkeys to global by @aquaductape in https://github.com/macro-inc/macro/pull/590
+* perf(macrodb): Add email indices to improve link deletion time by @evanhutnik in https://github.com/macro-inc/macro/pull/602
+* chore(email-service): Add tests for sql queries by @evanhutnik in https://github.com/macro-inc/macro/pull/598
+* fix(email-service): Notify for new messages after attachment upload by @evanhutnik in https://github.com/macro-inc/macro/pull/608
+* fix(email-service) Handle null attachment filename during upload by @evanhutnik in https://github.com/macro-inc/macro/pull/609
+* feat(sps): use internal_date_ts for updated_at_seconds on email by @whutchinson98 in https://github.com/macro-inc/macro/pull/622
+* add [properties-be] - link parent and subtasks by @danielkweon in https://github.com/macro-inc/macro/pull/610
+* fix [properties-fe] - filter current entity from entity selection list by @danielkweon in https://github.com/macro-inc/macro/pull/615
+* add [properties-fe] - properties panel in emails by @danielkweon in https://github.com/macro-inc/macro/pull/612
+* feat(search): sort on sent_at_seconds and updated_at_seconds before score by @whutchinson98 in https://github.com/macro-inc/macro/pull/623
+* fix: no infinite soup search for query misses by @gbirman in https://github.com/macro-inc/macro/pull/605
+* fix: search has different empty state by @gbirman in https://github.com/macro-inc/macro/pull/621
+* Revert "feat(search): sort on sent_at_seconds and updated_at_seconds before score" by @whutchinson98 in https://github.com/macro-inc/macro/pull/626
+* fix: show parent project breadcrumb for folders too by @gbirman in https://github.com/macro-inc/macro/pull/607
+* chore: target descendant children svg selector for search cancel animate spin by @gbirman in https://github.com/macro-inc/macro/pull/606
+* chore: remove legacy notification email poller by @whutchinson98 in https://github.com/macro-inc/macro/pull/630
+* fix(email-service): Attachment filetype guessing logic improvement by @evanhutnik in https://github.com/macro-inc/macro/pull/628
+* feat(iac): update script for email updated_at_seconds by @whutchinson98 in https://github.com/macro-inc/macro/pull/631
+* Make viewbox aspect ratio 3:2 for all icons by @aidanhb in https://github.com/macro-inc/macro/pull/627
+* fix(email): Email compose and reply styling issues by @dev-rb in https://github.com/macro-inc/macro/pull/629
+* Feat(email): "Sent with Macro" signature for free users by @dev-rb in https://github.com/macro-inc/macro/pull/581
+* add [properties-be] - email metadata by @danielkweon in https://github.com/macro-inc/macro/pull/611
+* add [properties-fe] - properties panel in projects by @danielkweon in https://github.com/macro-inc/macro/pull/613
+* fix(styles): dialog styles, bracket fixes, share contrast, scroll container by @Fake-User in https://github.com/macro-inc/macro/pull/589
+* add [properties-be] - util for document and task isCompleted by @danielkweon in https://github.com/macro-inc/macro/pull/617
+* fix: compactify email input by @peterchinman in https://github.com/macro-inc/macro/pull/625
+* fix [email]: recipient list width bug by @peterchinman in https://github.com/macro-inc/macro/pull/620
+* fix[email]: stop email draft autofocus by @peterchinman in https://github.com/macro-inc/macro/pull/632
+* fix[email]: sending emails with appended replies by @peterchinman in https://github.com/macro-inc/macro/pull/601
+* add [properties-be] - project metadata by @danielkweon in https://github.com/macro-inc/macro/pull/614
+* fix(CimmandK): fixed corner clipping by @Fake-User in https://github.com/macro-inc/macro/pull/634
+* fix[email]: send button improvements by @peterchinman in https://github.com/macro-inc/macro/pull/638
+* fix: channels in noise tab by @peterchinman in https://github.com/macro-inc/macro/pull/639
+* chore: improve tower layers by @seanaye in https://github.com/macro-inc/macro/pull/636
+* fix(email-service): Notify search on label updates by @evanhutnik in https://github.com/macro-inc/macro/pull/635
+* fix(md): remove regex single line md in favor of lexical mutation, turn off launcher pc noise grid for now by @sedson in https://github.com/macro-inc/macro/pull/640
+* fix: channel soup scroll by @gbirman in https://github.com/macro-inc/macro/pull/644
+* fix: channel active message callout timeout directly after scroll by @gbirman in https://github.com/macro-inc/macro/pull/646
+* fix(channel): bad block name param in channel attachments by @sedson in https://github.com/macro-inc/macro/pull/645
+* fix: search invalid date by @gbirman in https://github.com/macro-inc/macro/pull/647
+* fix(email): Recipient selector losing focus on mount by @dev-rb in https://github.com/macro-inc/macro/pull/642
+* fix(ShareButton): muted styled, and use old switch statement. fix(CommandConsole): remove fts switch. by @Fake-User in https://github.com/macro-inc/macro/pull/648
+* point to new sync-service URL in prod by @cowlicks in https://github.com/macro-inc/macro/pull/595
+
+## New Contributors
+* @cowlicks made their first contribution in https://github.com/macro-inc/macro/pull/472
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2025.12.2.1...v2025.12.15.0
+    </Update>
+
+    <Update label="v2025.12.2.1">
+## What's Changed
+* add [properties-fe] - frontend sort component by @danielkweon in https://github.com/macro-inc/macro/pull/373
+* fix(iac): correctly grab secret string for fusionauth_client_id in notification service by @whutchinson98 in https://github.com/macro-inc/macro/pull/406
+* fix: command k tab cycle hard crash by @gbirman in https://github.com/macro-inc/macro/pull/407
+* chore(iac): bump base instance count for search service in prod by @whutchinson98 in https://github.com/macro-inc/macro/pull/409
+* unified-list: truncate unrolled channel notification message content by @aquaductape in https://github.com/macro-inc/macro/pull/412
+* fix(iac): queue alarm description by @whutchinson98 in https://github.com/macro-inc/macro/pull/413
+* feat: separate local/backend search debounce by @gbirman in https://github.com/macro-inc/macro/pull/411
+* fix: can't mark shared document as done by @dev-rb in https://github.com/macro-inc/macro/pull/415
+* fix(soup): syncservice wakeup on enity with evth mount by @sedson in https://github.com/macro-inc/macro/pull/410
+* fix(mentions): clean duped people listings by @sedson in https://github.com/macro-inc/macro/pull/417
+* feat(project-block): use dss post query to filter by project by @aquaductape in https://github.com/macro-inc/macro/pull/414
+* fix [properties-fe] - fixes for sort and display properties components by @danielkweon in https://github.com/macro-inc/macro/pull/416
+* fix: optimistically mark email thread as read by @dev-rb in https://github.com/macro-inc/macro/pull/418
+* channel scrolling fixes and styling updates by @peterchinman in https://github.com/macro-inc/macro/pull/420
+* fix: channel going blank when viewing settings modal by @dev-rb in https://github.com/macro-inc/macro/pull/423
+* feat(md): add arbitrary file upload on drop to markdown block [FRO-312] by @sedson in https://github.com/macro-inc/macro/pull/426
+* fix(soup): soup without email link by @seanaye in https://github.com/macro-inc/macro/pull/427
+* fix(soup): hide tables in soup message snippets by @sedson in https://github.com/macro-inc/macro/pull/428
+* unified-list: fix enter hotkey on tab switch and return from block by @aquaductape in https://github.com/macro-inc/macro/pull/422
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2025.12.2.0...v2025.12.2.1
+    </Update>
+
+    <Update label="v2025.12.2.0">
+## What's Changed
+* fix(ci): add in bunfig.toml creation to setup-reqs-web action by @whutchinson98 in https://github.com/macro-inc/macro/pull/361
+* feat(soup): email filters by @seanaye in https://github.com/macro-inc/macro/pull/354
+* fix(ci): add in SEGMENT_WRITE_KEY to env vars through github workflow by @whutchinson98 in https://github.com/macro-inc/macro/pull/362
+* chore: bump brace-expansion to address CVE by @whutchinson98 in https://github.com/macro-inc/macro/pull/363
+* chore: bump vite to address CVE by @whutchinson98 in https://github.com/macro-inc/macro/pull/364
+* chore: bump js-yaml to address CVE by @whutchinson98 in https://github.com/macro-inc/macro/pull/365
+* fix(ci): correctly provide NPMRC_GH_TOKEN secret by @whutchinson98 in https://github.com/macro-inc/macro/pull/367
+* fix(pagination): limit after sort by @seanaye in https://github.com/macro-inc/macro/pull/368
+* fix(notifications): missing check for notification permission explicitly denied by @synoet in https://github.com/macro-inc/macro/pull/374
+* feat(notifications): handle on click for browser notifications by @synoet in https://github.com/macro-inc/macro/pull/357
+* feat(iac): add queue approxiate age of oldest message alarm by @whutchinson98 in https://github.com/macro-inc/macro/pull/375
+* feat: send token to services ws by @gbirman in https://github.com/macro-inc/macro/pull/335
+* fix(ci): use correct AWS secrets by @whutchinson98 in https://github.com/macro-inc/macro/pull/377
+* refactor(ci): refactor aws key names in ci workflows by @whutchinson98 in https://github.com/macro-inc/macro/pull/381
+* add [properties-fe] - improve display property pills styling to match sort property pill by @danielkweon in https://github.com/macro-inc/macro/pull/372
+* fix(email): properly set the sender on email notification by @synoet in https://github.com/macro-inc/macro/pull/378
+* chore(md): move instructions editor to own file by @sedson in https://github.com/macro-inc/macro/pull/380
+* fix(email-service): Filter out drafts for shared threads by @evanhutnik in https://github.com/macro-inc/macro/pull/370
+* chore(ci): improve testing by @seanaye in https://github.com/macro-inc/macro/pull/355
+* fix(iac): queue alarms by @whutchinson98 in https://github.com/macro-inc/macro/pull/383
+* feat: mark email done on send by @peterchinman in https://github.com/macro-inc/macro/pull/339
+* fix(ci): cargo test improvements by @whutchinson98 in https://github.com/macro-inc/macro/pull/382
+* feat (ai): auto attach emails by @ehayes2000 in https://github.com/macro-inc/macro/pull/379
+* chore(notifications): unify notification setting and persisted signal logic by @synoet in https://github.com/macro-inc/macro/pull/384
+* fix: sender field for soup emails falls back to email address by @peterchinman in https://github.com/macro-inc/macro/pull/385
+* add [properties-fe] - display properties as chips on row by @danielkweon in https://github.com/macro-inc/macro/pull/376
+* add [properties-fe] - display properties as chips on row compact view by @danielkweon in https://github.com/macro-inc/macro/pull/371
+* Revert "feat: send token to services ws (#335)" by @gbirman in https://github.com/macro-inc/macro/pull/386
+* chg(dock): swap new split icon, fix swapped preview mode tooltip by @sedson in https://github.com/macro-inc/macro/pull/387
+* feat(layout): support component typed meta for discriminating by @synoet in https://github.com/macro-inc/macro/pull/388
+* fix: dedupe email senders names by @peterchinman in https://github.com/macro-inc/macro/pull/389
+* inbox view: fix mark_as_done optimistic update by @aquaductape in https://github.com/macro-inc/macro/pull/393
+* fix(email): need to call init always to set link by @synoet in https://github.com/macro-inc/macro/pull/392
+* fix(notifications): notifications should focus on click and close by @synoet in https://github.com/macro-inc/macro/pull/395
+* chore: add third party licenses by @synoet in https://github.com/macro-inc/macro/pull/397
+* fix: correctly handle display name when user is only participant in email by @peterchinman in https://github.com/macro-inc/macro/pull/396
+* feat: email search linking by @gbirman in https://github.com/macro-inc/macro/pull/394
+* fix: Unable to create thread for message with deleted reply by @dev-rb in https://github.com/macro-inc/macro/pull/401
+* chore: better readme by @synoet in https://github.com/macro-inc/macro/pull/400
+* Gab/m 5245 close empty channel reply input on blur by @gbirman in https://github.com/macro-inc/macro/pull/402
+* fix(md): strange click handling in checklists [M-5311] by @sedson in https://github.com/macro-inc/macro/pull/403
+* fix(history): filter deleted items from command and mentions menus by @sedson in https://github.com/macro-inc/macro/pull/404
+* feat(email-service): Retry queue for webhook pubsub processing by @evanhutnik in https://github.com/macro-inc/macro/pull/390
+
+## New Contributors
+* @dev-rb made their first contribution in https://github.com/macro-inc/macro/pull/401
+
+**Full Changelog**: https://github.com/macro-inc/macro/commits/v2025.12.2.0
+    </Update>

--- a/docs/changelog/2026-01.mdx
+++ b/docs/changelog/2026-01.mdx
@@ -1,0 +1,667 @@
+---
+title: "January 2026"
+description: "Macro releases from January 2026."
+---
+
+    <Update label="v2026.1.29.0">
+## What's Changed
+* fix(md): wrap document card in suspense for queries by @sedson in https://github.com/macro-inc/macro/pull/1235
+* feat: standardize aws_config usage by @whutchinson98 in https://github.com/macro-inc/macro/pull/1234
+* remove org service infra by @whutchinson98 in https://github.com/macro-inc/macro/pull/1237
+* revert: email thread whitelist by @evanhutnik in https://github.com/macro-inc/macro/pull/1239
+* refactor: move properties endpoints into dss by @whutchinson98 in https://github.com/macro-inc/macro/pull/1238
+* remove lingering properties service references by @whutchinson98 in https://github.com/macro-inc/macro/pull/1240
+* update flake and cargo lock by @seanaye in https://github.com/macro-inc/macro/pull/1236
+* fix(ai): soup input the semi-final-fixening by @ehayes2000 in https://github.com/macro-inc/macro/pull/1241
+* seanaye/remove/unused notification code by @seanaye in https://github.com/macro-inc/macro/pull/1242
+* fix(email-service): Always call /seen endpoint when opening thread by @evanhutnik in https://github.com/macro-inc/macro/pull/1249
+* fix[mobile]: blank screen of death on app re-open by @peterchinman in https://github.com/macro-inc/macro/pull/1245
+* fix(sfs): Dynamo permissions by @evanhutnik in https://github.com/macro-inc/macro/pull/1251
+* fix(block-names): add fallback to block-metadata for reactive names by @sedson in https://github.com/macro-inc/macro/pull/1250
+* style(email): Thread view updates by @evanhutnik in https://github.com/macro-inc/macro/pull/1246
+* fix: improve md breakpoint by @peterchinman in https://github.com/macro-inc/macro/pull/1252
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.1.28.0...v2026.1.29.0
+    </Update>
+
+    <Update label="v2026.1.28.0">
+## What's Changed
+* refactor(email-service): ID creation and gmail-to-service struct conv… by @evanhutnik in https://github.com/macro-inc/macro/pull/1197
+* chore: remove unused dbs by @whutchinson98 in https://github.com/macro-inc/macro/pull/1220
+* fix(email-service): FE types by @evanhutnik in https://github.com/macro-inc/macro/pull/1222
+* fix(ai): multi line input by @ehayes2000 in https://github.com/macro-inc/macro/pull/1218
+* chore remove experiment service by @whutchinson98 in https://github.com/macro-inc/macro/pull/1221
+* style(email): Constrain inline image, shrink attached images by @evanhutnik in https://github.com/macro-inc/macro/pull/1214
+* fix bun gen-api on nixos by @seanaye in https://github.com/macro-inc/macro/pull/1223
+* refactor notifications by @seanaye in https://github.com/macro-inc/macro/pull/1215
+* chore: remove organization service by @whutchinson98 in https://github.com/macro-inc/macro/pull/1224
+* feat: dockerize sync service by @whutchinson98 in https://github.com/macro-inc/macro/pull/1210
+* fix(contacts): contact syncing for both recipients and sender + frontend invalidations through cgw by @synoet in https://github.com/macro-inc/macro/pull/1216
+* fix(ai): hotkeys by @ehayes2000 in https://github.com/macro-inc/macro/pull/1225
+* fix persist local volumes by @whutchinson98 in https://github.com/macro-inc/macro/pull/1226
+* fix(email): Refreshing thread rendering by @evanhutnik in https://github.com/macro-inc/macro/pull/1227
+* style(document card): tighten up styling on document card by @aidanhb in https://github.com/macro-inc/macro/pull/1206
+* feat(ai): soup replace list tool with soup tool by @ehayes2000 in https://github.com/macro-inc/macro/pull/1213
+* fix(favicon): sync favicon across tabs by @aidanhb in https://github.com/macro-inc/macro/pull/1205
+* Improve notif repo queries by @seanaye in https://github.com/macro-inc/macro/pull/1228
+* feat(unified-list): Whitelisted email domains for Inbox view by @evanhutnik in https://github.com/macro-inc/macro/pull/1231
+* chore(core): move comments out of collab folder by @synoet in https://github.com/macro-inc/macro/pull/1232
+* chg: flag off ai chat inbox in soup for the 55th time by @synoet in https://github.com/macro-inc/macro/pull/1233
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.1.27.0...v2026.1.28.0
+    </Update>
+
+    <Update label="v2026.1.27.0">
+## What's Changed
+* feat(ai): fold node by @ehayes2000 in https://github.com/macro-inc/macro/pull/1172
+* local running by @whutchinson98 in https://github.com/macro-inc/macro/pull/1174
+* style(links): update link preview styling by @aidanhb in https://github.com/macro-inc/macro/pull/1158
+* update cloudfront pem by @whutchinson98 in https://github.com/macro-inc/macro/pull/1195
+* fix(ai): table rendering by @ehayes2000 in https://github.com/macro-inc/macro/pull/1196
+* fix(md): make unfurl link data in floating menu reactive by @aidanhb in https://github.com/macro-inc/macro/pull/1159
+* chore(ai): flag on snapshot by @ehayes2000 in https://github.com/macro-inc/macro/pull/1198
+* fix(block): remove memos from reactive document name hooks by @sedson in https://github.com/macro-inc/macro/pull/1201
+* fix(dss|properties): inconsistent deleted at by @whutchinson98 in https://github.com/macro-inc/macro/pull/1202
+* chore: dockerize lexical service by @whutchinson98 in https://github.com/macro-inc/macro/pull/1204
+* style(item preview): change styling on chat attachment items by @aidanhb in https://github.com/macro-inc/macro/pull/1203
+* chore: gen by @whutchinson98 in https://github.com/macro-inc/macro/pull/1207
+* fix(recip-selector): fix incorrect logic for merging freshsort and kobalte fuzzy by @sedson in https://github.com/macro-inc/macro/pull/1208
+* feat(ai): redesign input + flag on soup ai by @ehayes2000 in https://github.com/macro-inc/macro/pull/1211
+* fix(permissions): fix public link sharing of docs by @synoet in https://github.com/macro-inc/macro/pull/1200
+* fix(ai): instructionsMd eager fetch blocking render by @synoet in https://github.com/macro-inc/macro/pull/1212
+* style(email): Thread subject line by @evanhutnik in https://github.com/macro-inc/macro/pull/1209
+* feat: make unrolled notifications good by @peterchinman in https://github.com/macro-inc/macro/pull/1177
+* fix: image upload on mobile by @peterchinman in https://github.com/macro-inc/macro/pull/1217
+* chg: flag off chat input box in soup by @synoet in https://github.com/macro-inc/macro/pull/1219
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.1.26.0...v2026.1.27.0
+    </Update>
+
+    <Update label="v2026.1.26.0">
+## What's Changed
+* Message hover date display by @peterchinman in https://github.com/macro-inc/macro/pull/1106
+* chore(email-service): Tracing::instrument improvements by @evanhutnik in https://github.com/macro-inc/macro/pull/1126
+* chore(email-service): Delete the enable sync endpoint by @evanhutnik in https://github.com/macro-inc/macro/pull/1122
+* feat(email-service): Fetch thread message data in single queries by @evanhutnik in https://github.com/macro-inc/macro/pull/1124
+* chore(deps-dev): bump wrangler and @cloudflare/vitest-pool-workers in /rust/sync-service by @dependabot[bot] in https://github.com/macro-inc/macro/pull/1127
+* chore(email-service): Remove email_attachments_macro table by @evanhutnik in https://github.com/macro-inc/macro/pull/1128
+* fix(ai): dnd to chat by @ehayes2000 in https://github.com/macro-inc/macro/pull/1125
+* chore(ai): Require code execution for math calculations by @ehayes2000 in https://github.com/macro-inc/macro/pull/1116
+* feat: initial local environment support by @whutchinson98 in https://github.com/macro-inc/macro/pull/1131
+* fix: add in missing env var by @whutchinson98 in https://github.com/macro-inc/macro/pull/1132
+* fix: stripe premium price id secret string by @whutchinson98 in https://github.com/macro-inc/macro/pull/1133
+* chore: remove authentication_service_client from comms_service by @whutchinson98 in https://github.com/macro-inc/macro/pull/1135
+* fix(logging): log lexical responses by @ehayes2000 in https://github.com/macro-inc/macro/pull/1136
+* feat(user): add same domain and dm recency boost to user search fields by @sedson in https://github.com/macro-inc/macro/pull/1134
+* fix(md): fix corner nit on document preview by @sedson in https://github.com/macro-inc/macro/pull/1141
+* feat(comms): add in pg outbound port for user repo by @whutchinson98 in https://github.com/macro-inc/macro/pull/1139
+* fix: handle ip context automatically for local environment by @whutchinson98 in https://github.com/macro-inc/macro/pull/1143
+* chg(list): enable optimistic updating on all view by @synoet in https://github.com/macro-inc/macro/pull/1144
+* feat: local cookies by @whutchinson98 in https://github.com/macro-inc/macro/pull/1145
+* chore: update local service ports to match docker compose by @whutchinson98 in https://github.com/macro-inc/macro/pull/1148
+* approval by @whutchinson98 in https://github.com/macro-inc/macro/pull/1151
+* feat(tasks): update front end signal filter with task logic by @sedson in https://github.com/macro-inc/macro/pull/1138
+* basic sops file for local running against dev assets by @whutchinson98 in https://github.com/macro-inc/macro/pull/1154
+* fix: include latest 150 channel messages in AI context instead of oldest by @ehayes2000 in https://github.com/macro-inc/macro/pull/1157
+* feat(email-service): Binaries for cleaning up unused sfs images by @evanhutnik in https://github.com/macro-inc/macro/pull/1146
+* fix: focus loss due to settings panel by @peterchinman in https://github.com/macro-inc/macro/pull/1150
+* fix: include inter italic by @peterchinman in https://github.com/macro-inc/macro/pull/1161
+* feat: use item preview tanstack by @gbirman in https://github.com/macro-inc/macro/pull/1162
+* feat: update previews on rename by @gbirman in https://github.com/macro-inc/macro/pull/1164
+* fix: prefetch query so cache gets updated when the channel name is needed by @gbirman in https://github.com/macro-inc/macro/pull/1165
+* chore: remove auto approve by @whutchinson98 in https://github.com/macro-inc/macro/pull/1173
+* chore(email-service): Better logging for link manager by @evanhutnik in https://github.com/macro-inc/macro/pull/1169
+* lock all cli by @whutchinson98 in https://github.com/macro-inc/macro/pull/1175
+* feat(channels): upgrade stand-alone-mentions to document cards in channels by @sedson in https://github.com/macro-inc/macro/pull/1163
+* feat(ai): persist code execution file creation with mention pill by @ehayes2000 in https://github.com/macro-inc/macro/pull/1137
+* fix(unified-list): don't refetch on inbox filter by @synoet in https://github.com/macro-inc/macro/pull/1170
+* chore: remove dead code by @synoet in https://github.com/macro-inc/macro/pull/1167
+* fix(ai): share permissions by @ehayes2000 in https://github.com/macro-inc/macro/pull/1171
+* opt(web): low hanging optimizations for page load time by @synoet in https://github.com/macro-inc/macro/pull/1168
+* fix(email): Don't stall if init fails on signup by @evanhutnik in https://github.com/macro-inc/macro/pull/1181
+* chore: consolidate notificationdb to macrodb by @whutchinson98 in https://github.com/macro-inc/macro/pull/1178
+* chore(sync-service): update the runtime by @synoet in https://github.com/macro-inc/macro/pull/1183
+* chore(sync-service): remove qa-env by @synoet in https://github.com/macro-inc/macro/pull/1184
+* chore: freeze document-processing-types by @synoet in https://github.com/macro-inc/macro/pull/1182
+* feat: migrate contacts to macrodb by @whutchinson98 in https://github.com/macro-inc/macro/pull/1185
+* feat(properties): soup property editor modal (v0 - tasks only) by @sedson in https://github.com/macro-inc/macro/pull/1140
+* feat: make emoji-only messages big by @peterchinman in https://github.com/macro-inc/macro/pull/1180
+* fix(dpt): include in vite deps document-processing-types by @synoet in https://github.com/macro-inc/macro/pull/1186
+* chore(dpt): fix document processing types by @synoet in https://github.com/macro-inc/macro/pull/1187
+* Channel message selection by @peterchinman in https://github.com/macro-inc/macro/pull/1130
+* fix(md): fix focus loss after title editor rename by @sedson in https://github.com/macro-inc/macro/pull/1189
+* fix[mobile]: send button issue by @peterchinman in https://github.com/macro-inc/macro/pull/1191
+* fix(sync): change heartbeat config to be more lenient by @synoet in https://github.com/macro-inc/macro/pull/1190
+* fix: use model_user directly in macro_middleware crate by @whutchinson98 in https://github.com/macro-inc/macro/pull/1192
+* flag(channel/md): flag off document cards in channels until fixed by @sedson in https://github.com/macro-inc/macro/pull/1193
+* flag(md): flag off ai generate plugin until fixed by @sedson in https://github.com/macro-inc/macro/pull/1194
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.1.21.0...v2026.1.26.0
+    </Update>
+
+    <Update label="v2026.1.21.0">
+## What's Changed
+* fix(subscription): Invalidate user info after trial signup by @synoet in https://github.com/macro-inc/macro/pull/1107
+* feat(properties): add properties to soup queries. by @cowlicks in https://github.com/macro-inc/macro/pull/952
+* refactor(search): remove use of service_clients from search in step to make hexifying easier by @whutchinson98 in https://github.com/macro-inc/macro/pull/1109
+* fix: dss url by @synoet in https://github.com/macro-inc/macro/pull/1110
+* feat: Add code execution tool support by @ehayes2000 in https://github.com/macro-inc/macro/pull/1077
+* refactor(email): Inbox and All Mail thread previews by @evanhutnik in https://github.com/macro-inc/macro/pull/1083
+* chg(ai): Improve AI prompt to use tools and personalize responses by @ehayes2000 in https://github.com/macro-inc/macro/pull/1108
+* feat(ai): nested tool subcontext + docs + gen by @ehayes2000 in https://github.com/macro-inc/macro/pull/1112
+* feat(ai): remove rewrite tool  by @ehayes2000 in https://github.com/macro-inc/macro/pull/1067
+* chore(service-clients): remove statefullness from service-clients by @synoet in https://github.com/macro-inc/macro/pull/1081
+* style(document): Add beveled gradient edge to document preview popup by @aidanhb in https://github.com/macro-inc/macro/pull/1084
+* Remove fade effect from read entities by @jbecke in https://github.com/macro-inc/macro/pull/1118
+* fix: no inserting splits on mobile by @peterchinman in https://github.com/macro-inc/macro/pull/1113
+* fix: handle exact match scoring for command k fuzzy library by @gbirman in https://github.com/macro-inc/macro/pull/1120
+* Add light haptic feedback to mobile dock buttons by @jbecke in https://github.com/macro-inc/macro/pull/1060
+* chore: rationalize mobile and touch checks by @peterchinman in https://github.com/macro-inc/macro/pull/1121
+* fix(mobile): fix url link sharing + deep linking by @synoet in https://github.com/macro-inc/macro/pull/1123
+* feat(notifications): add notification badge to favicon by @aidanhb in https://github.com/macro-inc/macro/pull/1115
+* flag(md): flag off markdown history until can repro and fix by @sedson in https://github.com/macro-inc/macro/pull/1111
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.1.20.0...v2026.1.21.0
+    </Update>
+
+    <Update label="v2026.1.20.0">
+## What's Changed
+* feat(devx): playwright auto auth by @whutchinson98 in https://github.com/macro-inc/macro/pull/1056
+* fix(sfs): do not allow xss for files by @whutchinson98 in https://github.com/macro-inc/macro/pull/1058
+* feat(ai): add custom scrollbar to block-chat by @jbecke in https://github.com/macro-inc/macro/pull/1059
+* do not request to enable browser notifications on localhost by @whutchinson98 in https://github.com/macro-inc/macro/pull/1057
+* chore(deps-dev): bump devalue from 5.3.2 to 5.6.2 in /rust/sync-service by @dependabot[bot] in https://github.com/macro-inc/macro/pull/1022
+* feat(ai): AI CLI by @ehayes2000 in https://github.com/macro-inc/macro/pull/1041
+* feat(sfs): enable bucket versioning on SFS bucket by @whutchinson98 in https://github.com/macro-inc/macro/pull/1064
+* chore(auth): remove rate limit on refresh by @whutchinson98 in https://github.com/macro-inc/macro/pull/1063
+* feat(ai): center AI input box by @ehayes2000 in https://github.com/macro-inc/macro/pull/1066
+* feat: remove legacy gql rpc by @synoet in https://github.com/macro-inc/macro/pull/1065
+* feat(channels): ability to create tasks directly inside of channels. by @synoet in https://github.com/macro-inc/macro/pull/1025
+* fix(userId): fix improper userId import by @synoet in https://github.com/macro-inc/macro/pull/1070
+* chore(email): Enable email sharing by @dev-rb in https://github.com/macro-inc/macro/pull/1069
+* chore(email): don't delete email draft on message send by @dev-rb in https://github.com/macro-inc/macro/pull/1068
+* fix(email): thread messages should expand down by @dev-rb in https://github.com/macro-inc/macro/pull/1074
+* fix(auth): fix queries and effects in root by @synoet in https://github.com/macro-inc/macro/pull/1072
+* refactor(middleware): remove need for email service in middleware by @whutchinson98 in https://github.com/macro-inc/macro/pull/1079
+* feat(email-service): Delay sending emails for undo functionality by @evanhutnik in https://github.com/macro-inc/macro/pull/1071
+* chg(ci): faster api type check in ci by @synoet in https://github.com/macro-inc/macro/pull/1085
+* remove comms service client from macro_middleware crate by @whutchinson98 in https://github.com/macro-inc/macro/pull/1082
+* feat: display entity name with format document name by @gbirman in https://github.com/macro-inc/macro/pull/1047
+* chore(claude): qc check by @synoet in https://github.com/macro-inc/macro/pull/1080
+* fix(auth): only clear login cookie when auth state is actually known by @synoet in https://github.com/macro-inc/macro/pull/1086
+* fix(email): incorrect enter key spacing for emails by @dev-rb in https://github.com/macro-inc/macro/pull/1078
+* fix: channel name in search should appear regardless of order by @gbirman in https://github.com/macro-inc/macro/pull/1087
+* chg(ci): biome should only check import order on generated files by @synoet in https://github.com/macro-inc/macro/pull/1090
+* chore(dcs): remove macros by @whutchinson98 in https://github.com/macro-inc/macro/pull/1091
+* fix[email]: condense long recipient list by @peterchinman in https://github.com/macro-inc/macro/pull/1088
+* fix(channel): Opening message from popup preview not flashing message by @dev-rb in https://github.com/macro-inc/macro/pull/1096
+* fix(ci): update frontend types by @synoet in https://github.com/macro-inc/macro/pull/1099
+* fix: keep entity with everything layout static on hover by @gbirman in https://github.com/macro-inc/macro/pull/1095
+* feat(tools): Soup tool by @ehayes2000 in https://github.com/macro-inc/macro/pull/1035
+* feat(ai): add soup chat input to open chat split on enter by @ehayes2000 in https://github.com/macro-inc/macro/pull/1089
+* feat(properties): add keyboard first picker for date type properties by @sedson in https://github.com/macro-inc/macro/pull/1093
+* Settings panel navigation by @peterchinman in https://github.com/macro-inc/macro/pull/1092
+* style(soup): Add random arcanum to empty states by @aidanhb in https://github.com/macro-inc/macro/pull/1019
+* fix: property status updates in soup after block-md change by @gbirman in https://github.com/macro-inc/macro/pull/1103
+* fix: lower channel mark as read debounce time by @peterchinman in https://github.com/macro-inc/macro/pull/1102
+* Channel message context menu by @peterchinman in https://github.com/macro-inc/macro/pull/1100
+* feat: make emojis optimistically update by @gbirman in https://github.com/macro-inc/macro/pull/1104
+* fix(channel): notifications not being marked as read by @dev-rb in https://github.com/macro-inc/macro/pull/1101
+* chg(ul): temporarily flag off input in unfiied list by @synoet in https://github.com/macro-inc/macro/pull/1105
+* E hotkey mark-done in split view by @peterchinman in https://github.com/macro-inc/macro/pull/1098
+* style(soup): Make topbar icons smaller by @aidanhb in https://github.com/macro-inc/macro/pull/1076
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.1.16.0...v2026.1.20.0
+    </Update>
+
+    <Update label="v2026.1.16.0">
+## What's Changed
+* fix: lower file association cardinality [TEMPORARY] by @gbirman in https://github.com/macro-inc/macro/pull/1049
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.1.15.0...v2026.1.16.0
+    </Update>
+
+    <Update label="v2026.1.15.0">
+## What's Changed
+* chore: hexify entity_access by @ehayes2000 in https://github.com/macro-inc/macro/pull/1001
+* Hotkeys/add option to add handlers same scope id+hotkey and fix soup hotkey bugs by @aquaductape in https://github.com/macro-inc/macro/pull/1006
+* chore(log): debug log sns client errors by @seanaye in https://github.com/macro-inc/macro/pull/982
+* feat(email-service): List, remove, upsert scheduled drafts by @evanhutnik in https://github.com/macro-inc/macro/pull/974
+* fix(ci): do not run gen-api unless rust files have changed by @whutchinson98 in https://github.com/macro-inc/macro/pull/1011
+* unified-list: fix multiple entity rows showing same hover state by @aquaductape in https://github.com/macro-inc/macro/pull/1012
+* fix(sfs): Don't validate owner_id for internal requests by @evanhutnik in https://github.com/macro-inc/macro/pull/1013
+* project/block: fix filters and create menu to include tasks by @aquaductape in https://github.com/macro-inc/macro/pull/1015
+* feat(email): creating drafts & sending actual attachments in email compose  by @dev-rb in https://github.com/macro-inc/macro/pull/995
+* fix(ai): list tool text by @ehayes2000 in https://github.com/macro-inc/macro/pull/987
+* feat(soup): new topbar filter first paradigm by @jbecke in https://github.com/macro-inc/macro/pull/900
+* chore(ai): move tools to new crate by @ehayes2000 in https://github.com/macro-inc/macro/pull/1009
+* Disable inbox filter by default on load by @jbecke in https://github.com/macro-inc/macro/pull/1023
+* fix(search): sort channel results by channel message updated_at by @whutchinson98 in https://github.com/macro-inc/macro/pull/1020
+* split-panel: restore ClippedPanel for accent border on active panel by @aquaductape in https://github.com/macro-inc/macro/pull/1026
+* fix(fusionauth): correct delete event for delete webhook by @whutchinson98 in https://github.com/macro-inc/macro/pull/1027
+* Swap keyboard shortcut behavior in Launcher menu by @jbecke in https://github.com/macro-inc/macro/pull/1024
+* Remove default placeholder text from GitHub PR template by @jbecke in https://github.com/macro-inc/macro/pull/1028
+* feat(search): correctly search channel names to be agnostic of order by @whutchinson98 in https://github.com/macro-inc/macro/pull/1021
+* feat: expiry seconds env var for macro api token by @gbirman in https://github.com/macro-inc/macro/pull/1030
+* enforce bun by @whutchinson98 in https://github.com/macro-inc/macro/pull/1032
+* feat: various mobile ui improvements by @peterchinman in https://github.com/macro-inc/macro/pull/1010
+* chore(tools): prompts for blud by @ehayes2000 in https://github.com/macro-inc/macro/pull/1033
+* feat(email, scrollbar): remove velocity-scaling glow effect for perf; add customscrollbar to email by @jbecke in https://github.com/macro-inc/macro/pull/929
+* feat(tools): context extraction by @ehayes2000 in https://github.com/macro-inc/macro/pull/1016
+* fix(referencium): fix channel message params, temp hide broken soup doc shared notifications by @sedson in https://github.com/macro-inc/macro/pull/1034
+* fix(email): thread scroll jumping and loading indicator by @dev-rb in https://github.com/macro-inc/macro/pull/1014
+* feat: add retry to macro api token fetch calls by @gbirman in https://github.com/macro-inc/macro/pull/1036
+* feat(unified-list): display email drafts in inbox/signal view by @dev-rb in https://github.com/macro-inc/macro/pull/1031
+* soup: use channels in post soup query by @aquaductape in https://github.com/macro-inc/macro/pull/981
+* feat(email): allow editing and sending email drafts when there is no thread by @dev-rb in https://github.com/macro-inc/macro/pull/1005
+* feat: drag/drop entities + move/copy + fix canvas mention nodes by @gbirman in https://github.com/macro-inc/macro/pull/1002
+* new paradigm: fix some regressions by @aquaductape in https://github.com/macro-inc/macro/pull/1037
+* style(core): update user-tooltip styles by @aidanhb in https://github.com/macro-inc/macro/pull/980
+* feat(email-service): Sfs delete lambda and handler by @evanhutnik in https://github.com/macro-inc/macro/pull/1018
+* fix: mobile app squish by @peterchinman in https://github.com/macro-inc/macro/pull/1029
+* chore(email-service): Lower dev invocations of sfs delete lambda by @evanhutnik in https://github.com/macro-inc/macro/pull/1043
+* fix(channel): file drop overlay issues by @dev-rb in https://github.com/macro-inc/macro/pull/1042
+* fix(soup): nav to search result message on enter by @ehayes2000 in https://github.com/macro-inc/macro/pull/1044
+* feat: mobile filter bar and dock fixes by @peterchinman in https://github.com/macro-inc/macro/pull/1045
+* fix: quick dialog fix by @peterchinman in https://github.com/macro-inc/macro/pull/1046
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.1.14.0...v2026.1.15.0
+    </Update>
+
+    <Update label="v2026.1.14.0">
+## What's Changed
+* Blake1/bac 45 comment thread reply notification service support by @cowlicks in https://github.com/macro-inc/macro/pull/722
+* chore(email): enable email sharing in dev by @dev-rb in https://github.com/macro-inc/macro/pull/988
+* feat(email): allow sending actual attachments in emails by @dev-rb in https://github.com/macro-inc/macro/pull/935
+* feat(properties): edit task properties from list, task code cleanup by @sedson in https://github.com/macro-inc/macro/pull/992
+* fix: try cache first for mobile notifications by @peterchinman in https://github.com/macro-inc/macro/pull/994
+* fix(soup): use query mutation for task mark-as-done by @sedson in https://github.com/macro-inc/macro/pull/997
+* fix(ui): fix class reactivity and add new `cn` utility for classes by @dev-rb in https://github.com/macro-inc/macro/pull/996
+* refactor(email): refactor email form states by @dev-rb in https://github.com/macro-inc/macro/pull/993
+* fix(unified-list): filter menu causing layout thrash by @dev-rb in https://github.com/macro-inc/macro/pull/1000
+* feat(chat): hotkey to create by @ehayes2000 in https://github.com/macro-inc/macro/pull/989
+* feat(channels/core):refactor channels context by @synoet in https://github.com/macro-inc/macro/pull/998
+* feat(infra) local fusionauth pulumi by @whutchinson98 in https://github.com/macro-inc/macro/pull/1003
+* chore(email-service): Clean up logs by @evanhutnik in https://github.com/macro-inc/macro/pull/984
+* refactor(email-service): Contact upserting logic by @evanhutnik in https://github.com/macro-inc/macro/pull/999
+* style(soup): move task property display to right side of soup by @sedson in https://github.com/macro-inc/macro/pull/1004
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.1.13.1...v2026.1.14.0
+    </Update>
+
+    <Update label="v2026.1.13.1">
+## What's Changed
+* add preview project block from soup and project block by @aquaductape in https://github.com/macro-inc/macro/pull/536
+* split: fix regression that broke split focus navigation by @aquaductape in https://github.com/macro-inc/macro/pull/986
+* fix(property): date display by @ehayes2000 in https://github.com/macro-inc/macro/pull/985
+* fix(comms): remove limit on get_channels endpoint by @synoet in https://github.com/macro-inc/macro/pull/990
+* fix(email-service): Only send delete messages once daily, during the night by @evanhutnik in https://github.com/macro-inc/macro/pull/991
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.1.13.0...v2026.1.13.1
+    </Update>
+
+    <Update label="v2026.1.13.0">
+## What's Changed
+* chg(properties): simpler query, use properties in frontmatter, invalidatations by @synoet in https://github.com/macro-inc/macro/pull/953
+* feat(queries/email): persistence primitives + email cache persistence to indexdb by @synoet in https://github.com/macro-inc/macro/pull/945
+* feat(email): pull out core rendering logic, setup snapshot test suite for email rendering by @synoet in https://github.com/macro-inc/macro/pull/946
+* fix browser and tauri notifications by @peterchinman in https://github.com/macro-inc/macro/pull/911
+* chore(dcs): improve prompt by @ehayes2000 in https://github.com/macro-inc/macro/pull/938
+* feat(search) support cursor for unified search by @whutchinson98 in https://github.com/macro-inc/macro/pull/892
+* chore(log): channel name err by @seanaye in https://github.com/macro-inc/macro/pull/947
+* Generate and check OpenApi types in CI. by @cowlicks in https://github.com/macro-inc/macro/pull/811
+* style(nits): make settings and chat topbars line up, make shortcuts uppercase on cheat sheet by @sedson in https://github.com/macro-inc/macro/pull/954
+* Linear ticket CSV import by @peterchinman in https://github.com/macro-inc/macro/pull/949
+* feat(soup): add channels ast literal by @seanaye in https://github.com/macro-inc/macro/pull/944
+* upgrade log by @seanaye in https://github.com/macro-inc/macro/pull/959
+* feat: fix search highlight by @gbirman in https://github.com/macro-inc/macro/pull/956
+* fix(authentication_service): refresh token speed by @whutchinson98 in https://github.com/macro-inc/macro/pull/961
+* add keypress global signal to fix keyboard vs cursor select priority in lists by @aquaductape in https://github.com/macro-inc/macro/pull/962
+* fix: filter out invalid fetch items by @gbirman in https://github.com/macro-inc/macro/pull/960
+* fix(email-service): Upsert thread history when upserting draft by @evanhutnik in https://github.com/macro-inc/macro/pull/958
+* chore(metering): remove metering service iac by @whutchinson98 in https://github.com/macro-inc/macro/pull/965
+* feat(soup): comms filter 2 by @seanaye in https://github.com/macro-inc/macro/pull/948
+* chore(claude): add in more items to rust claude.md by @whutchinson98 in https://github.com/macro-inc/macro/pull/967
+* feat(soup): comms filter 3 by @seanaye in https://github.com/macro-inc/macro/pull/957
+* chore: update types by @synoet in https://github.com/macro-inc/macro/pull/968
+* feat(properties): fully port properties to use tanstack query, + some cleanup by @synoet in https://github.com/macro-inc/macro/pull/966
+* feat(email-service): Delete expired links by @evanhutnik in https://github.com/macro-inc/macro/pull/955
+* fix(tauri): only append is_mobile if it doesn't already exist by @seanaye in https://github.com/macro-inc/macro/pull/971
+* fix(tasks): remove hard dependency on blockId in PropertyLabel by @synoet in https://github.com/macro-inc/macro/pull/973
+* fix(ai): server-tool message ordering by @ehayes2000 in https://github.com/macro-inc/macro/pull/969
+* feat(ai): web_fetch tool by @ehayes2000 in https://github.com/macro-inc/macro/pull/964
+* chore(soup): replace custom either with axum_extra either by @seanaye in https://github.com/macro-inc/macro/pull/975
+* feat(ai): list channels tool by @ehayes2000 in https://github.com/macro-inc/macro/pull/976
+* Reduce email-service pods from 5 to 3 by @evanhutnik in https://github.com/macro-inc/macro/pull/978
+* feat(md/tasks): checkbox -> task conversion plugin by @synoet in https://github.com/macro-inc/macro/pull/972
+* fix: invalidate cached auth token before it expires by @gbirman in https://github.com/macro-inc/macro/pull/977
+* Add needed icons by @aidanhb in https://github.com/macro-inc/macro/pull/979
+* fix: focus search input by @gbirman in https://github.com/macro-inc/macro/pull/983
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.1.12.0...v2026.1.13.0
+    </Update>
+
+    <Update label="v2026.1.12.0">
+## What's Changed
+* add [properties] - add isCompleted flag for documents by @danielkweon in https://github.com/macro-inc/macro/pull/748
+* feat(dcs): add oppie by @ehayes2000 in https://github.com/macro-inc/macro/pull/888
+* fix [properties-fe] - document subtype type fixes by @danielkweon in https://github.com/macro-inc/macro/pull/899
+* chore: Add Claude Code GitHub Workflow by @synoet in https://github.com/macro-inc/macro/pull/901
+* fix(ci): trigger ci checks on draft being marked ready for review by @whutchinson98 in https://github.com/macro-inc/macro/pull/902
+* chore: remove insight service by @ehayes2000 in https://github.com/macro-inc/macro/pull/897
+* chore: try signing claude commits in ci by @synoet in https://github.com/macro-inc/macro/pull/905
+* chg: disable biome import sorting by @synoet in https://github.com/macro-inc/macro/pull/907
+* feat (ai): opus + hotkeys by @ehayes2000 in https://github.com/macro-inc/macro/pull/887
+* fix notification service query param keys by @peterchinman in https://github.com/macro-inc/macro/pull/908
+* Integrate properties for tasks by @ehayes2000 in https://github.com/macro-inc/macro/pull/859
+* chore(search): remove projects from opensearch by @whutchinson98 in https://github.com/macro-inc/macro/pull/909
+* chore(deps): bump aws-sdk-sesv2 from 1.68.0 to 1.103.0 in /rust/cloud-storage by @dependabot[bot] in https://github.com/macro-inc/macro/pull/866
+* chore(deps): bump aws-sdk-ssooidc from 1.61.0 to 1.93.0 in /rust/cloud-storage by @dependabot[bot] in https://github.com/macro-inc/macro/pull/868
+* chore(deps): bump aws-sdk-sso from 1.60.0 to 1.91.0 in /rust/cloud-storage by @dependabot[bot] in https://github.com/macro-inc/macro/pull/871
+* chg(soup): arrowup & arrowdown shouldn't navigate you outside of soup by @synoet in https://github.com/macro-inc/macro/pull/912
+* sunset metering service by @whutchinson98 in https://github.com/macro-inc/macro/pull/910
+* fix(tasks): task compose close button fix by @sedson in https://github.com/macro-inc/macro/pull/906
+* refactor(email-service): Improved Get Threads endpoint logic by @evanhutnik in https://github.com/macro-inc/macro/pull/895
+* chg(channels): remove admin / owner restriction on channel participant management by @synoet in https://github.com/macro-inc/macro/pull/913
+* update claude to prefer anyhow::bail by @whutchinson98 in https://github.com/macro-inc/macro/pull/915
+* feat(email-service): Make draft attachments visible by @evanhutnik in https://github.com/macro-inc/macro/pull/891
+* fix: docx save pdf modification data by @gbirman in https://github.com/macro-inc/macro/pull/903
+* feat(md/channels): support group mentions + @here in channels by @synoet in https://github.com/macro-inc/macro/pull/914
+* fix(dss): internal auth get document by @seanaye in https://github.com/macro-inc/macro/pull/918
+* add [properties-fe] - filter and sort to unified list filter by @danielkweon in https://github.com/macro-inc/macro/pull/633
+* feat!: move sync service to this repo by @synoet in https://github.com/macro-inc/macro/pull/924
+* chore: Remove web-services infra by @whutchinson98 in https://github.com/macro-inc/macro/pull/925
+* feat(ai): split unified search tool into content + name search by @ehayes2000 in https://github.com/macro-inc/macro/pull/773
+* feat(email-service): Async link deletion handler by @evanhutnik in https://github.com/macro-inc/macro/pull/916
+* fix [properties-be] - disable organization-shared properties in property definitions list by @danielkweon in https://github.com/macro-inc/macro/pull/927
+* Shortcuts helper by @jbecke in https://github.com/macro-inc/macro/pull/917
+* feat(mention_utils): add support for group-mention m tags in rust by @synoet in https://github.com/macro-inc/macro/pull/928
+* fix(command): fix ghost hotkeys by @sedson in https://github.com/macro-inc/macro/pull/919
+* chore(search) remove names index by @whutchinson98 in https://github.com/macro-inc/macro/pull/930
+* feat(email): ui revamp by @synoet in https://github.com/macro-inc/macro/pull/898
+* fix(md): update floatWith handlers in link menu to match mentions menu by @sedson in https://github.com/macro-inc/macro/pull/920
+* fix(dcs): fix non-sync-service `md` attachments by @ehayes2000 in https://github.com/macro-inc/macro/pull/926
+* feat(notification): better collapse + testing by @seanaye in https://github.com/macro-inc/macro/pull/904
+* fix(notifications): correctly resolve sender name for emails by @synoet in https://github.com/macro-inc/macro/pull/932
+* chore(claude): add formatter hook by @synoet in https://github.com/macro-inc/macro/pull/936
+* seanaye/chore/bump tracing by @seanaye in https://github.com/macro-inc/macro/pull/922
+* feat: endpoint to get notification by id by @peterchinman in https://github.com/macro-inc/macro/pull/923
+* chore(ai): mobile buttons + include model in prompt by @ehayes2000 in https://github.com/macro-inc/macro/pull/933
+* fix(lambda): rename infra by @seanaye in https://github.com/macro-inc/macro/pull/943
+* feat(email-service): Delete link when user revokes Macro access to inbox by @evanhutnik in https://github.com/macro-inc/macro/pull/941
+* feat: disable search service with signal/noise views by @gbirman in https://github.com/macro-inc/macro/pull/942
+* fix(lambdas) by @evanhutnik in https://github.com/macro-inc/macro/pull/951
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.1.9.0...v2026.1.12.0
+    </Update>
+
+    <Update label="v2026.1.9.0">
+## What's Changed
+* unified-list: fix scroll to top keep gap bug by @aquaductape in https://github.com/macro-inc/macro/pull/850
+* feat(kommand): kommand menu ordering improvements, history live updates by @synoet in https://github.com/macro-inc/macro/pull/816
+* Get rid of bento by @jbecke in https://github.com/macro-inc/macro/pull/848
+* chore(core): mark block signals as deprecated by @synoet in https://github.com/macro-inc/macro/pull/834
+* chore: simplify js commands + scripts by @synoet in https://github.com/macro-inc/macro/pull/799
+* fix(infra): append /app to posted feature url by @synoet in https://github.com/macro-inc/macro/pull/851
+* feat(tasks): tasks in signal tab, refresh queries on task notifs by @sedson in https://github.com/macro-inc/macro/pull/779
+* fix cargo deny by @seanaye in https://github.com/macro-inc/macro/pull/846
+* remove collapse animation on desktop by @peterchinman in https://github.com/macro-inc/macro/pull/828
+* chg(ws): use platform factory by @synoet in https://github.com/macro-inc/macro/pull/853
+* feat(tauri): log js to term by @seanaye in https://github.com/macro-inc/macro/pull/845
+* add [frecency-fe] - feature flag off frecency by @danielkweon in https://github.com/macro-inc/macro/pull/854
+* add [properties-fe] - feature flag property sort & filter & display by @danielkweon in https://github.com/macro-inc/macro/pull/855
+* feat(ui): Docs && Test harness by @nickisnoble in https://github.com/macro-inc/macro/pull/781
+* fix: make unified list robust to fetch failure by @gbirman in https://github.com/macro-inc/macro/pull/842
+* feat(properties): property style overhaul first pass  by @sedson in https://github.com/macro-inc/macro/pull/861
+* fix[mobile]: mobile dock by @peterchinman in https://github.com/macro-inc/macro/pull/862
+* fix: ios screen height by @peterchinman in https://github.com/macro-inc/macro/pull/872
+* chore(frontend): complete the migration to tailwindv4 by @nickisnoble in https://github.com/macro-inc/macro/pull/863
+* chore(ai): small attachment refactor by @ehayes2000 in https://github.com/macro-inc/macro/pull/841
+* fix(soup/md): add override for quote nodes in list by @sedson in https://github.com/macro-inc/macro/pull/852
+* fix(notifications): use correct name for dm name by @synoet in https://github.com/macro-inc/macro/pull/875
+* feat(properties): use task properties by @synoet in https://github.com/macro-inc/macro/pull/762
+* chg(email): make thread seen optimistic by @synoet in https://github.com/macro-inc/macro/pull/803
+* fix(notification): fix some deserialization by @seanaye in https://github.com/macro-inc/macro/pull/857
+* chore(deps): bump aws-sdk-sqs from 1.60.0 to 1.89.0 in /rust/cloud-storage by @dependabot[bot] in https://github.com/macro-inc/macro/pull/870
+* chore(deps): bump aws-sdk-ecs from 1.67.1 to 1.104.0 in /rust/cloud-storage by @dependabot[bot] in https://github.com/macro-inc/macro/pull/869
+* soup-context: add guard to entity list navigation, rename unifiedListContext to soupContext, add open entity helper function by @aquaductape in https://github.com/macro-inc/macro/pull/843
+* soup-context: fix entity navigation button firing incorrect command by @aquaductape in https://github.com/macro-inc/macro/pull/877
+* unified-list: add meta/ctrl click to entity row to open entity in new tab by @aquaductape in https://github.com/macro-inc/macro/pull/776
+* fix(tauri): proxy fetch calls by @seanaye in https://github.com/macro-inc/macro/pull/856
+* chore: Add agents.md and claude.md to js/app by @synoet in https://github.com/macro-inc/macro/pull/878
+* chore(deps): bump aws-sdk-dynamodb from 1.66.0 to 1.98.0 in /rust/cloud-storage by @dependabot[bot] in https://github.com/macro-inc/macro/pull/867
+* chore: move md files into js/app by @synoet in https://github.com/macro-inc/macro/pull/879
+* chore: add claude default settings whitelisting common commands by @synoet in https://github.com/macro-inc/macro/pull/881
+* chg(core): only proxy fetch if tauri by @synoet in https://github.com/macro-inc/macro/pull/880
+* feat(email-service): Send attachments with emails by @evanhutnik in https://github.com/macro-inc/macro/pull/858
+* Add CSV icon and display it for .csv files in soup and block header by @aidanhb in https://github.com/macro-inc/macro/pull/876
+* chore: remove claude md from the .gitignore by @synoet in https://github.com/macro-inc/macro/pull/884
+* fix(email-service): Swagger typegen fix by @evanhutnik in https://github.com/macro-inc/macro/pull/885
+* fix(core): fix collaped UserIcon by @sedson in https://github.com/macro-inc/macro/pull/874
+* feat(tasks): task composer improve - create more, link to clipboard, title validation by @sedson in https://github.com/macro-inc/macro/pull/883
+* fix(email-service): Allow users without email enabled to see shared threads by @evanhutnik in https://github.com/macro-inc/macro/pull/882
+* feat(task/history): add upsert mutation to history query, use tan-query history in mentions menu by @sedson in https://github.com/macro-inc/macro/pull/889
+* feat(email): add generic spinner to email block by @synoet in https://github.com/macro-inc/macro/pull/886
+* fix(core): attach custom origin to sync service requests when in tauri by @synoet in https://github.com/macro-inc/macro/pull/873
+* chore(deps): bump aws-sdk-lambda from 1.69.0 to 1.104.0 in /rust/cloud-storage by @dependabot[bot] in https://github.com/macro-inc/macro/pull/865
+* chore(deps): bump aws-sdk-secretsmanager from 1.64.0 to 1.93.0 in /rust/cloud-storage by @dependabot[bot] in https://github.com/macro-inc/macro/pull/864
+* fix(channel): channel freezing when too many messages by @dev-rb in https://github.com/macro-inc/macro/pull/894
+* fix: loading doc takes forever race condition by @gbirman in https://github.com/macro-inc/macro/pull/890
+* fix(md): wrap mention menu history query in suspense by @sedson in https://github.com/macro-inc/macro/pull/896
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.1.7.3...v2026.1.9.0
+    </Update>
+
+    <Update label="v2026.1.7.3">
+## What's Changed
+* fix(infra): regex on matching previews on previous id's by @synoet in https://github.com/macro-inc/macro/pull/847
+* fix(soup): skip returning channels for now by @seanaye in https://github.com/macro-inc/macro/pull/849
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.1.7.2...v2026.1.7.3
+    </Update>
+
+    <Update label="v2026.1.7.2">
+## What's Changed
+* feat(core): improve user tooltip style by @sedson in https://github.com/macro-inc/macro/pull/812
+* feat: global sort order locally by @gbirman in https://github.com/macro-inc/macro/pull/827
+* Seanaye/revert/revert comms soup by @seanaye in https://github.com/macro-inc/macro/pull/830
+* feat(cors): add in support for preview domains by @whutchinson98 in https://github.com/macro-inc/macro/pull/832
+* chore(soup): tracing by @seanaye in https://github.com/macro-inc/macro/pull/833
+* fix(notif): deserialize by @seanaye in https://github.com/macro-inc/macro/pull/836
+* feat(infra): support feature previews by @synoet in https://github.com/macro-inc/macro/pull/835
+* fix: don't close empty thread replies on blur by @peterchinman in https://github.com/macro-inc/macro/pull/820
+* fix: non-null assertions + channel type serialization by @gbirman in https://github.com/macro-inc/macro/pull/839
+* fix: add document subtype to search mapper by @gbirman in https://github.com/macro-inc/macro/pull/837
+* fix: optimstically remove item from search results on delete by @gbirman in https://github.com/macro-inc/macro/pull/838
+* fix(core): fix some missing/broken tooltip hot keys by @sedson in https://github.com/macro-inc/macro/pull/829
+* fix(channel): Last thread in channel not displaying replies by @dev-rb in https://github.com/macro-inc/macro/pull/844
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.1.7.1...v2026.1.7.2
+    </Update>
+
+    <Update label="v2026.1.7.1">
+## What's Changed
+* Seanaye/feat/comms in soup by @seanaye in https://github.com/macro-inc/macro/pull/757
+* Revert "Seanaye/feat/comms in soup (#757)" by @seanaye in https://github.com/macro-inc/macro/pull/822
+* chore: use regular props boolean instead of accessor for thread append input by @gbirman in https://github.com/macro-inc/macro/pull/823
+* chore: prod sqlx command to check what migrations are needed by @whutchinson98 in https://github.com/macro-inc/macro/pull/824
+* fix: search name highlight for local source by @gbirman in https://github.com/macro-inc/macro/pull/826
+* fix(channel): channel not auto updating messages by @dev-rb in https://github.com/macro-inc/macro/pull/825
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.1.7.0...v2026.1.7.1
+    </Update>
+
+    <Update label="v2026.1.7.0">
+## What's Changed
+* fix(channel): Fix reactive updates to channel query data when renaming by @dev-rb in https://github.com/macro-inc/macro/pull/618
+* fix(ai): auto attachments by @ehayes2000 in https://github.com/macro-inc/macro/pull/624
+* fix[email]: rendering of certain emails with initial style tags by @peterchinman in https://github.com/macro-inc/macro/pull/655
+* add [properties-be] - extra protection against deleting system properties by @danielkweon in https://github.com/macro-inc/macro/pull/649
+* fix [properties] - only allow entity type tasks to have parent and subtask properties by @danielkweon in https://github.com/macro-inc/macro/pull/616
+* fix(email-service): Use oldest message for subject in search thread histories endpoint by @evanhutnik in https://github.com/macro-inc/macro/pull/650
+* fix(email-service): Only create index if it doesn't already exist by @evanhutnik in https://github.com/macro-inc/macro/pull/652
+* fix: bring back inbox settings by @peterchinman in https://github.com/macro-inc/macro/pull/660
+* unified-list: fix entitywitheverything component timestamp by @aquaductape in https://github.com/macro-inc/macro/pull/658
+* feat(tauri,vite): iOS mobile v1 by @nickisnoble in https://github.com/macro-inc/macro/pull/293
+* fix [properties-fe] - inject current user into contacts list for entity property selection by @danielkweon in https://github.com/macro-inc/macro/pull/662
+* fix(opensearch_client): error on invalid query creation by @whutchinson98 in https://github.com/macro-inc/macro/pull/663
+* fix(opensearch_client): remove un-needed fields from response indices by @whutchinson98 in https://github.com/macro-inc/macro/pull/664
+* refactor(dss): Created items now private by default, except MD documents by @evanhutnik in https://github.com/macro-inc/macro/pull/665
+* Seanaye/feat/remove graphql service by @seanaye in https://github.com/macro-inc/macro/pull/443
+* seanaye/fix/ios notifications by @seanaye in https://github.com/macro-inc/macro/pull/603
+* fix (chat): auto attachments fix channels, images, projects by @ehayes2000 in https://github.com/macro-inc/macro/pull/666
+* fix(md): fix single line util for single item lists by @sedson in https://github.com/macro-inc/macro/pull/661
+* fix(email-service): Declare sfs_id field as optional when fetching attachments in upsert_message by @evanhutnik in https://github.com/macro-inc/macro/pull/670
+* chg(emails): centralize email links query by @synoet in https://github.com/macro-inc/macro/pull/667
+* feat: support create block with params by @gbirman in https://github.com/macro-inc/macro/pull/668
+* fix: channel open jitters due to unstable location by @gbirman in https://github.com/macro-inc/macro/pull/669
+* fix(channel): duplicate thread messages and sending messages not updating list by @dev-rb in https://github.com/macro-inc/macro/pull/672
+* fix(auth-service): Only fallback to contact name for empty Macro name by @evanhutnik in https://github.com/macro-inc/macro/pull/674
+* feat(email-service): Queue upsert for missing message on label update by @evanhutnik in https://github.com/macro-inc/macro/pull/676
+* Revert "fix(ai): auto attachments (#624)" by @gbirman in https://github.com/macro-inc/macro/pull/683
+* feat(search): enter key selects first item, down arrow key goes to next item by @gbirman in https://github.com/macro-inc/macro/pull/680
+* fix(channels): channel scroll should highlight from soup click + not highlight unwanted target message on message send by @gbirman in https://github.com/macro-inc/macro/pull/685
+* rm(contact): remove block contact + remove from command menu by @synoet in https://github.com/macro-inc/macro/pull/686
+* feat(email-service): Backfill sfs attachments script by @evanhutnik in https://github.com/macro-inc/macro/pull/619
+* fix (soup): screen flash on j/k by @ehayes2000 in https://github.com/macro-inc/macro/pull/677
+* feat(search): separate cmd-f and / hotkeys by @gbirman in https://github.com/macro-inc/macro/pull/681
+* feat(email-service): Enable attachment syncing for all users by @evanhutnik in https://github.com/macro-inc/macro/pull/671
+* fix(ai): suspsense trigger by @ehayes2000 in https://github.com/macro-inc/macro/pull/688
+* feat(search): ignore trash when performing email search by @whutchinson98 in https://github.com/macro-inc/macro/pull/689
+* feat(search): return 400 bad request if no valid terms are provided by @whutchinson98 in https://github.com/macro-inc/macro/pull/690
+* fix(email-service): Make email signature optional in /links endpoint by @evanhutnik in https://github.com/macro-inc/macro/pull/687
+* chore(email-service): Add param to swagger by @evanhutnik in https://github.com/macro-inc/macro/pull/694
+* feat(splits): Narrow width for narrow splits and mobile UI by @jbecke in https://github.com/macro-inc/macro/pull/583
+* fix(channel): don't clear input until after collect mentions by @sedson in https://github.com/macro-inc/macro/pull/695
+* fix(email-service): Use entire message content for replyless w/o split by @evanhutnik in https://github.com/macro-inc/macro/pull/696
+* fix virtua list bugs and restore scroll by @aquaductape in https://github.com/macro-inc/macro/pull/697
+* unified-infinite-list remove logs by @aquaductape in https://github.com/macro-inc/macro/pull/699
+* display full email names for threads with single participants by @peterchinman in https://github.com/macro-inc/macro/pull/678
+* fix: tab behavior in combobox by @peterchinman in https://github.com/macro-inc/macro/pull/673
+* feat: sfs image/video support for email message attachment by @peterchinman in https://github.com/macro-inc/macro/pull/599
+* fix(channels/ai): fix pasting images by @synoet in https://github.com/macro-inc/macro/pull/682
+* feat: error on warnings biome by @gbirman in https://github.com/macro-inc/macro/pull/702
+* Seanaye/chore/user id invariants by @seanaye in https://github.com/macro-inc/macro/pull/693
+* fix(email-service): Slow `/seen` endpoint by @evanhutnik in https://github.com/macro-inc/macro/pull/705
+* fix(ai): auto attach on create new chat by @ehayes2000 in https://github.com/macro-inc/macro/pull/679
+* fix(channel): Reply input mentions menu displaying all users by @dev-rb in https://github.com/macro-inc/macro/pull/706
+* fix(email): Add horizontal padding for compose for small containers by @dev-rb in https://github.com/macro-inc/macro/pull/707
+* chore: no underscored variable for naming collision by @gbirman in https://github.com/macro-inc/macro/pull/708
+* fix: unified empty state clean up by @gbirman in https://github.com/macro-inc/macro/pull/698
+* feat(search) update search service opensearch queries to use filter by @whutchinson98 in https://github.com/macro-inc/macro/pull/709
+* chore: add sass to model file type by @gbirman in https://github.com/macro-inc/macro/pull/701
+* feat(search) sort by updated at seconds by @whutchinson98 in https://github.com/macro-inc/macro/pull/710
+* feat: do not scroll channel reply open by @gbirman in https://github.com/macro-inc/macro/pull/711
+* soup-context: update entity properties by @aquaductape in https://github.com/macro-inc/macro/pull/712
+* soup: update filters/sort scroll to top and select first entity by @aquaductape in https://github.com/macro-inc/macro/pull/703
+* refactor(email-service): Rename webhook worker to inbox_sync worker by @evanhutnik in https://github.com/macro-inc/macro/pull/714
+* Refactor(email-service): Rename refresh pubsub worker to link_manager pubsub worker by @evanhutnik in https://github.com/macro-inc/macro/pull/715
+* fix(search): sort by updated at by @whutchinson98 in https://github.com/macro-inc/macro/pull/716
+* fix(dss): update UserItemAccess for user who shared item by @whutchinson98 in https://github.com/macro-inc/macro/pull/717
+* feat(share): new ShareButton, DialogWarper, ClippedPanel Signals, and disable transitions by @Fake-User in https://github.com/macro-inc/macro/pull/704
+* feat(soup): filter file associations by @seanaye in https://github.com/macro-inc/macro/pull/718
+* fix(channel): Sending, editing, and deleting a message not updating view  by @dev-rb in https://github.com/macro-inc/macro/pull/721
+* fix(channel): scroll position jumping and flickering by @dev-rb in https://github.com/macro-inc/macro/pull/691
+* soup: fix preview regression and add entity styling state for active context menu by @aquaductape in https://github.com/macro-inc/macro/pull/719
+* fix: empty state drawer by @gbirman in https://github.com/macro-inc/macro/pull/723
+* fix(channels): better styles for multiple invites - participant selector by @sedson in https://github.com/macro-inc/macro/pull/724
+* feat: Visor and WhichKey by @peterchinman in https://github.com/macro-inc/macro/pull/273
+* feat(tasks): task compose v1 by @sedson in https://github.com/macro-inc/macro/pull/692
+* fix: Add suspense boundaries by @dev-rb in https://github.com/macro-inc/macro/pull/727
+* feat(channel): Send static attachment dimensions and use dimensions for displaying attachments by @dev-rb in https://github.com/macro-inc/macro/pull/653
+* fix(channel): Unable to send message by @dev-rb in https://github.com/macro-inc/macro/pull/730
+* fix(task): re add portal scoping for in-modal popovers by @sedson in https://github.com/macro-inc/macro/pull/728
+* fix(email-service): Proper attachment upload retry logic, backfill rate limit tiering by @evanhutnik in https://github.com/macro-inc/macro/pull/720
+* feat(email): Email compose shortcuts by @dev-rb in https://github.com/macro-inc/macro/pull/732
+* feat(hotkeys): faster hotkeys with less nesting / remove visor system by @jbecke in https://github.com/macro-inc/macro/pull/731
+* Nick/mobile nits by @nickisnoble in https://github.com/macro-inc/macro/pull/700
+* style(share): tweak padding and add fallback icon/tooltip by @sedson in https://github.com/macro-inc/macro/pull/738
+* chore(ios): console-logs by @seanaye in https://github.com/macro-inc/macro/pull/739
+* unified-list: replace virtua with tanstack virtual by @aquaductape in https://github.com/macro-inc/macro/pull/740
+* fix(auth): remove onboarding redirect completely by @synoet in https://github.com/macro-inc/macro/pull/741
+* fix: Add more suspense boundaries by @dev-rb in https://github.com/macro-inc/macro/pull/743
+* fix(md): make markdown areas safer under suspense by @sedson in https://github.com/macro-inc/macro/pull/742
+* fix: Virtual lists are reversed by @dev-rb in https://github.com/macro-inc/macro/pull/747
+* feat: Add email to `UserIcon` tooltip by @dev-rb in https://github.com/macro-inc/macro/pull/750
+* chore(ui): create @ui package by @nickisnoble in https://github.com/macro-inc/macro/pull/755
+* add [properties & tasks] - show assignee status priority in unified list by @danielkweon in https://github.com/macro-inc/macro/pull/659
+* unified-list: multi-select mark_as_done select neighboring entity by @aquaductape in https://github.com/macro-inc/macro/pull/758
+* fix(channels): fix image preview escape handling by @sedson in https://github.com/macro-inc/macro/pull/745
+* fix: lexical crash under suspense pt2 by @sedson in https://github.com/macro-inc/macro/pull/753
+* fix(email): Send email w/o marking as done & button UI by @dev-rb in https://github.com/macro-inc/macro/pull/756
+* unified-list: improve jk experience keeping scroll gap at most of entity minimum height by @aquaductape in https://github.com/macro-inc/macro/pull/754
+* feat(notifications): port notifications to query package by @synoet in https://github.com/macro-inc/macro/pull/641
+* add [properties-be] - properties crate set entity property by @danielkweon in https://github.com/macro-inc/macro/pull/749
+* refactor [properties-be] - set_entity_property to hexagonal by @danielkweon in https://github.com/macro-inc/macro/pull/752
+* [1/3] feat(anthropic): Add support for anthropic server tools by @ehayes2000 in https://github.com/macro-inc/macro/pull/725
+* feat: mobile dock by @peterchinman in https://github.com/macro-inc/macro/pull/761
+* [2/3] feat(ai): Add extension support in ai crate by @ehayes2000 in https://github.com/macro-inc/macro/pull/726
+* fix: restore dock by @peterchinman in https://github.com/macro-inc/macro/pull/766
+* feat(unified-list): Add support for signal and noise filters on all views by @dev-rb in https://github.com/macro-inc/macro/pull/764
+* feat(email): toggle quoted text in reply by @dev-rb in https://github.com/macro-inc/macro/pull/763
+* feat: include individual content hit senders in email search by @gbirman in https://github.com/macro-inc/macro/pull/765
+* add [tasks] - grant permissions to task assignee by @danielkweon in https://github.com/macro-inc/macro/pull/760
+* add [tasks] - push notifications when assigned a task by @danielkweon in https://github.com/macro-inc/macro/pull/769
+* fix(unified-list): Make channels always show with signal filter by @dev-rb in https://github.com/macro-inc/macro/pull/771
+* add [tasks] - quick create task endpoint by @danielkweon in https://github.com/macro-inc/macro/pull/675
+* refactor [tasks-fe] - use create task endpoint in compose task by @danielkweon in https://github.com/macro-inc/macro/pull/759
+* fix (ai): update search service client to match api return type by @ehayes2000 in https://github.com/macro-inc/macro/pull/772
+* chore: change leeway and reject tokens expiring and in less than by @gbirman in https://github.com/macro-inc/macro/pull/775
+* add [properties & tasks] - enable properties and tasks feature flags by @danielkweon in https://github.com/macro-inc/macro/pull/592
+* feat(md): do not allow soft enter on new line after empty linebreak by @sedson in https://github.com/macro-inc/macro/pull/774
+* feat(md): add md util for truncating around \<macro_em> search tags for soup by @sedson in https://github.com/macro-inc/macro/pull/768
+* fix: add unauthed retry to legacy api rpc client  by @gbirman in https://github.com/macro-inc/macro/pull/777
+* fix(email): Email scroll jumping, suspense issues, and refactor by @dev-rb in https://github.com/macro-inc/macro/pull/770
+* chore(ui): drastically simplify button components by @nickisnoble in https://github.com/macro-inc/macro/pull/733
+* fix(soup): file assoc cursor by @seanaye in https://github.com/macro-inc/macro/pull/780
+* fix: sort channel first iff name match by @gbirman in https://github.com/macro-inc/macro/pull/778
+* fix: missing uuid feature flag schemars by @synoet in https://github.com/macro-inc/macro/pull/786
+* fix: downloading works now for block unknown/code by @gbirman in https://github.com/macro-inc/macro/pull/785
+* (fix): internal access by @ehayes2000 in https://github.com/macro-inc/macro/pull/782
+* feat(email): Add share button to emails by @dev-rb in https://github.com/macro-inc/macro/pull/783
+* fix(channel): List is reversed for a small number of messages by @dev-rb in https://github.com/macro-inc/macro/pull/788
+* chore(soup): increase cursor size limit by @seanaye in https://github.com/macro-inc/macro/pull/791
+* chore(deps): bump rsa from 0.9.8 to 0.9.10 in /rust/cloud-storage by @dependabot[bot] in https://github.com/macro-inc/macro/pull/792
+* style(md): minified comment thread styles by @sedson in https://github.com/macro-inc/macro/pull/795
+* move from names index to querying macrodb directly by @whutchinson98 in https://github.com/macro-inc/macro/pull/793
+* fix(dcs): attachments breaking due to serialization issue by @ehayes2000 in https://github.com/macro-inc/macro/pull/796
+* refactor(email-service): Separate email api and pubsub workers into separate services by @evanhutnik in https://github.com/macro-inc/macro/pull/594
+* feat: use file type soup request filters by @gbirman in https://github.com/macro-inc/macro/pull/790
+* fix(notifications): fix reconcile in notification source by @synoet in https://github.com/macro-inc/macro/pull/801
+* feat: swipe gestures in Soup by @peterchinman in https://github.com/macro-inc/macro/pull/784
+* fix: remove collapse on name/name_content search by @whutchinson98 in https://github.com/macro-inc/macro/pull/806
+* feat: change collapsible list visible count for search content data by @gbirman in https://github.com/macro-inc/macro/pull/805
+* fix: remove type safety for get user email names by @whutchinson98 in https://github.com/macro-inc/macro/pull/807
+* fix(email): Email draft not displaying when moving between soup and email by @dev-rb in https://github.com/macro-inc/macro/pull/808
+* feat: images in emails by @peterchinman in https://github.com/macro-inc/macro/pull/789
+* fix(UI): style share modal, fix(Dock): fix brock signup wordwrap, feat(themes): added black bezel mode by @Fake-User in https://github.com/macro-inc/macro/pull/802
+* fix: share menu by @peterchinman in https://github.com/macro-inc/macro/pull/813
+* fix(user): use branded type for Macroid string with validation by @synoet in https://github.com/macro-inc/macro/pull/809
+* fix: remove all tailwind colors by @peterchinman in https://github.com/macro-inc/macro/pull/810
+* fix(soup): unread indicator wasn't showing by @synoet in https://github.com/macro-inc/macro/pull/814
+* chg/fix(notifications): use tanstack as source of truth for optimistic updating, simplifies source by @synoet in https://github.com/macro-inc/macro/pull/815
+* fix(login): login button options cleanup, better hitbox by @synoet in https://github.com/macro-inc/macro/pull/819
+* fix(email): Marking email as seen not updating in soup by @dev-rb in https://github.com/macro-inc/macro/pull/804
+* chore(email): Feature flag email sharing by @dev-rb in https://github.com/macro-inc/macro/pull/821
+
+## New Contributors
+* @dependabot[bot] made their first contribution in https://github.com/macro-inc/macro/pull/792
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2025.12.15.1...v2026.1.7.0
+    </Update>

--- a/docs/changelog/2026-02.mdx
+++ b/docs/changelog/2026-02.mdx
@@ -1,0 +1,524 @@
+---
+title: "February 2026"
+description: "Macro releases from February 2026."
+---
+
+    <Update label="v2026.2.26.0">
+## What's Changed
+* feat(notif): integrate state machine c by @seanaye in https://github.com/macro-inc/macro/pull/1674
+* feat: bring back file type associations by @gbirman in https://github.com/macro-inc/macro/pull/1688
+* fix(mentions): restore chats in mentions search by @sedson in https://github.com/macro-inc/macro/pull/1690
+* fix[dialogs]: portal-scope and clickoutside behavior on dialogs by @peterchinman in https://github.com/macro-inc/macro/pull/1692
+* perf(search): move search provider to use quick access entities since soup is slow by @gbirman in https://github.com/macro-inc/macro/pull/1694
+* feat(github): account link by @whutchinson98 in https://github.com/macro-inc/macro/pull/1689
+* fix(soup): chat owners filter by @seanaye in https://github.com/macro-inc/macro/pull/1695
+* feat(notif): clean up notification trait by @seanaye in https://github.com/macro-inc/macro/pull/1673
+* feat: fresh sort dm boost by @gbirman in https://github.com/macro-inc/macro/pull/1696
+* fix[task-composer]: better handling for task creation failure by @peterchinman in https://github.com/macro-inc/macro/pull/1697
+* feat: include source map in dev by @gbirman in https://github.com/macro-inc/macro/pull/1700
+* feat: add in specific access level for entity_access_receipt by @whutchinson98 in https://github.com/macro-inc/macro/pull/1698
+* chg(queries): require explicit for normy by @synoet in https://github.com/macro-inc/macro/pull/1699
+* fix(soup): email dynamic query safety by @evanhutnik in https://github.com/macro-inc/macro/pull/1703
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.2.25.1...v2026.2.26.0
+    </Update>
+
+    <Update label="v2026.2.25.1">
+## What's Changed
+* fix: DCS update connection gateway table env var + add perms by @gbirman in https://github.com/macro-inc/macro/pull/1685
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.2.25.0...v2026.2.25.1
+    </Update>
+
+    <Update label="v2026.2.25.0">
+## What's Changed
+* feat(soup): use importance for other query filtering by @synoet in https://github.com/macro-inc/macro/pull/1661
+* feat: support email label search by @gbirman in https://github.com/macro-inc/macro/pull/1659
+* chore(deps): bump time from 0.3.46 to 0.3.47 in /rust/sync-service by @dependabot[bot] in https://github.com/macro-inc/macro/pull/1427
+* fix: macro user id logging by @whutchinson98 in https://github.com/macro-inc/macro/pull/1663
+* chore bump auth service size by @whutchinson98 in https://github.com/macro-inc/macro/pull/1664
+* add better logging for failed sns deliveries by @seanaye in https://github.com/macro-inc/macro/pull/1650
+* chg(properties): sort self to top for assignee properties by @sedson in https://github.com/macro-inc/macro/pull/1665
+* chore(channels): add thread replies handler to swagger by @synoet in https://github.com/macro-inc/macro/pull/1666
+* feat(seed): channel message mentions by @whutchinson98 in https://github.com/macro-inc/macro/pull/1662
+* chg(properties): show name | email in user selectors by @sedson in https://github.com/macro-inc/macro/pull/1667
+* chore(email-service): tracing sfs image upload by @evanhutnik in https://github.com/macro-inc/macro/pull/1668
+* rationalize dialogs by @peterchinman in https://github.com/macro-inc/macro/pull/1672
+* fix(soup): all pages refetching on filter change by @dev-rb in https://github.com/macro-inc/macro/pull/1669
+* feat(ai): Notifications by @ehayes2000 in https://github.com/macro-inc/macro/pull/1670
+* chg(channels): change preview ordering for thread replies in a channel by @synoet in https://github.com/macro-inc/macro/pull/1678
+* chore(notifications): notifications filter indexes by @synoet in https://github.com/macro-inc/macro/pull/1675
+* fix: slow email contact search query by @gbirman in https://github.com/macro-inc/macro/pull/1679
+* chore(log): ses logging by @seanaye in https://github.com/macro-inc/macro/pull/1671
+* fix(email): Thread reply compose bug by @evanhutnik in https://github.com/macro-inc/macro/pull/1682
+* feat: search importance filter + make ai search important only by @gbirman in https://github.com/macro-inc/macro/pull/1680
+* fix(soup): hotkeys registered to split aren't disposed when closing soup by @dev-rb in https://github.com/macro-inc/macro/pull/1681
+* fix(soup toolbar): convert vertical scroll to horizontal scroll by @aidanhb in https://github.com/macro-inc/macro/pull/1683
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.2.24.0...v2026.2.25.0
+    </Update>
+
+    <Update label="v2026.2.24.0">
+## What's Changed
+* bump fusionauth by @whutchinson98 in https://github.com/macro-inc/macro/pull/1641
+* infra: sync fusionauth prod instance with pulumi by @whutchinson98 in https://github.com/macro-inc/macro/pull/1643
+* chore: bump jsonwebtoken by @whutchinson98 in https://github.com/macro-inc/macro/pull/1642
+* feat(notif): refactor sns event queue into hex by @seanaye in https://github.com/macro-inc/macro/pull/1611
+* chore(deps): bump time from 0.3.44 to 0.3.47 in /js/app/tauri by @dependabot[bot] in https://github.com/macro-inc/macro/pull/1393
+* fix(command): don't show selection mode if not actively viewing list by @sedson in https://github.com/macro-inc/macro/pull/1644
+* style(md): update actions and emoji menu wrapper styles by @sedson in https://github.com/macro-inc/macro/pull/1645
+* feat(soup): allow dss filtering by notification (done/seen) & task cbm_atm_nc + move inbox filtering to query filters by @synoet in https://github.com/macro-inc/macro/pull/1615
+* fix(entity): fix non-reactive display name usage by @sedson in https://github.com/macro-inc/macro/pull/1648
+* feat: ai tool for creating documents by @whutchinson98 in https://github.com/macro-inc/macro/pull/1649
+* feat(search): make email search response look better by @gbirman in https://github.com/macro-inc/macro/pull/1647
+* feat(ai): chat stream indicator by @ehayes2000 in https://github.com/macro-inc/macro/pull/1640
+* feat: exclude spam from email search by @gbirman in https://github.com/macro-inc/macro/pull/1653
+* fix(focus): fix focus lock interaction with launcher and popover splits by @sedson in https://github.com/macro-inc/macro/pull/1646
+* chg(properties): use chunk buckets for properties, various type cleanups by @sedson in https://github.com/macro-inc/macro/pull/1652
+* fix(properties): stop propagation for edit property click-outside by @sedson in https://github.com/macro-inc/macro/pull/1656
+* chore(search): spam trash email cleanup by @gbirman in https://github.com/macro-inc/macro/pull/1658
+* fix(soup): Proper email querying by @evanhutnik in https://github.com/macro-inc/macro/pull/1654
+* fix(soup): batching of filter setting by @synoet in https://github.com/macro-inc/macro/pull/1660
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.2.23.0...v2026.2.24.0
+    </Update>
+
+    <Update label="v2026.2.23.0">
+## What's Changed
+* seanaye/feat/add digest state machines by @seanaye in https://github.com/macro-inc/macro/pull/1531
+* feat(ai): add ai tools for notifications by @seanaye in https://github.com/macro-inc/macro/pull/1521
+* bump fusionauth to fix ui issue by @whutchinson98 in https://github.com/macro-inc/macro/pull/1600
+* fix(settings): Email enable button when no link by @evanhutnik in https://github.com/macro-inc/macro/pull/1602
+* feat: drawer/modal triggers separated from their mounters by @peterchinman in https://github.com/macro-inc/macro/pull/1596
+* Hutch/improve local setup by @whutchinson98 in https://github.com/macro-inc/macro/pull/1601
+* chore: kill dcs websocket (frontend) by @ehayes2000 in https://github.com/macro-inc/macro/pull/1591
+* refactor(command): refactor command menu to be look nicer, work faster, be simpler, and use quick access by @sedson in https://github.com/macro-inc/macro/pull/1605
+* fix(pdf): move modal wrapper to hotfix pdfs by @sedson in https://github.com/macro-inc/macro/pull/1608
+* feat(channels): birectional cursor for message pagination by @synoet in https://github.com/macro-inc/macro/pull/1603
+* feat: macrodb optimizations by @gbirman in https://github.com/macro-inc/macro/pull/1607
+* chore(dcs): Kill dcs websocket server by @ehayes2000 in https://github.com/macro-inc/macro/pull/1599
+* chore: pulumify macrodb by @whutchinson98 in https://github.com/macro-inc/macro/pull/1613
+* chore(dcs): kill unused endpoints by @ehayes2000 in https://github.com/macro-inc/macro/pull/1604
+* fix(toasts): Overwrite if recent, instead of dismissing by @evanhutnik in https://github.com/macro-inc/macro/pull/1612
+* style(list): move entity action menu to no overlap ai chat bar by @sedson in https://github.com/macro-inc/macro/pull/1614
+* feat(notif): integrate state machine a by @seanaye in https://github.com/macro-inc/macro/pull/1564
+* chore: auto add aws creds to get_environment dev by @whutchinson98 in https://github.com/macro-inc/macro/pull/1619
+* fix(entity): add attached items fallback for empty latest message by @sedson in https://github.com/macro-inc/macro/pull/1617
+* fix(notifs): ignore document_mention type notifs by @sedson in https://github.com/macro-inc/macro/pull/1620
+* feat(soup): Move email to trash by @evanhutnik in https://github.com/macro-inc/macro/pull/1616
+* fix: auth service env var by @whutchinson98 in https://github.com/macro-inc/macro/pull/1621
+* feat: make search context queries static by @gbirman in https://github.com/macro-inc/macro/pull/1622
+* kill-rightbar by @ehayes2000 in https://github.com/macro-inc/macro/pull/1618
+* feat: kill rightbar + cmd-j focus by @ehayes2000 in https://github.com/macro-inc/macro/pull/1623
+* remove ctrl+c stop by @ehayes2000 in https://github.com/macro-inc/macro/pull/1624
+* fix: insert soup optimistic filters (type + id only) by @gbirman in https://github.com/macro-inc/macro/pull/1626
+* fix(channels): make sure load around has previous cursor by @synoet in https://github.com/macro-inc/macro/pull/1627
+* feat(channels): get thread replies api by @synoet in https://github.com/macro-inc/macro/pull/1628
+* fix(email): Always open attachments in split by @evanhutnik in https://github.com/macro-inc/macro/pull/1630
+* fix(mentions-menu): handle lazy memo returns undefined in mentions conroller by @sedson in https://github.com/macro-inc/macro/pull/1631
+* fix(canvas): no save on init by @sedson in https://github.com/macro-inc/macro/pull/1632
+* fix: mentions menu usable on mobile by @peterchinman in https://github.com/macro-inc/macro/pull/1625
+* feat(list): share and copy-link from list by @sedson in https://github.com/macro-inc/macro/pull/1633
+* ci: fail on bootstrap.zip removal by @whutchinson98 in https://github.com/macro-inc/macro/pull/1629
+* fix(blocks): move modal-provider inside of main block div for all blocks by @sedson in https://github.com/macro-inc/macro/pull/1634
+* move create document to documents hex by @whutchinson98 in https://github.com/macro-inc/macro/pull/1609
+* feat(soup): Email invite badge by @evanhutnik in https://github.com/macro-inc/macro/pull/1636
+* fix(menus): state and timeout based fix for menu sequences by @sedson in https://github.com/macro-inc/macro/pull/1635
+* chore: enable macrodb param group by @gbirman in https://github.com/macro-inc/macro/pull/1637
+* feat: a better lightbox by @peterchinman in https://github.com/macro-inc/macro/pull/1638
+* add back lambdas by @whutchinson98 in https://github.com/macro-inc/macro/pull/1639
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.2.19.1...v2026.2.23.0
+    </Update>
+
+    <Update label="v2026.2.19.1">
+## What's Changed
+* Revert "bump jsonwebtoken" by @whutchinson98 in https://github.com/macro-inc/macro/pull/1598
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.2.19.0...v2026.2.19.1
+    </Update>
+
+    <Update label="v2026.2.19.0">
+## What's Changed
+* feat(core): create quick-access context for improving performance of repeated history transformation by @sedson in https://github.com/macro-inc/macro/pull/1560
+* fix: mobile search bar by @gbirman in https://github.com/macro-inc/macro/pull/1570
+* [chore]: bump mobile version by @peterchinman in https://github.com/macro-inc/macro/pull/1571
+* feat(seed): seed cli documents by @whutchinson98 in https://github.com/macro-inc/macro/pull/1561
+* fix: localstack dynamodb tables by @whutchinson98 in https://github.com/macro-inc/macro/pull/1572
+* fix[channel]: highlighting date flags by @peterchinman in https://github.com/macro-inc/macro/pull/1574
+* bump down thread pagination by @whutchinson98 in https://github.com/macro-inc/macro/pull/1575
+* fix(email-service): Bump ram by @evanhutnik in https://github.com/macro-inc/macro/pull/1576
+* fix: no focused entity on touch device by @peterchinman in https://github.com/macro-inc/macro/pull/1577
+* seanaye/feat/email digest ports by @seanaye in https://github.com/macro-inc/macro/pull/1530
+* refactor(search_processing_service): replace email_service_client with direct email_db_client calls by @whutchinson98 in https://github.com/macro-inc/macro/pull/1578
+* feat(email): Undo send functionality by @evanhutnik in https://github.com/macro-inc/macro/pull/1580
+* fix: make channels immediately available for search with delayed queue util by @gbirman in https://github.com/macro-inc/macro/pull/1582
+* fix(local) local s3 by @whutchinson98 in https://github.com/macro-inc/macro/pull/1581
+* improve local docker build times by @whutchinson98 in https://github.com/macro-inc/macro/pull/1583
+* feat: make collapse down smooth by @gbirman in https://github.com/macro-inc/macro/pull/1584
+* chore(sps): Bump resources by @evanhutnik in https://github.com/macro-inc/macro/pull/1586
+* fix: title extract by @gbirman in https://github.com/macro-inc/macro/pull/1585
+* bump jsonwebtoken by @whutchinson98 in https://github.com/macro-inc/macro/pull/1340
+* feat: search loading state by @gbirman in https://github.com/macro-inc/macro/pull/1587
+* fix(infra): resolve OpenSearch CloudWatch log resource policy by @gbirman in https://github.com/macro-inc/macro/pull/1588
+* fix: tab title reactivity by @gbirman in https://github.com/macro-inc/macro/pull/1590
+* feat(channels): load around specific message by @synoet in https://github.com/macro-inc/macro/pull/1589
+* fix: remove mobile dock gradient by @peterchinman in https://github.com/macro-inc/macro/pull/1579
+* fix[tasks]: don't clear task composer if task creation fails by @peterchinman in https://github.com/macro-inc/macro/pull/1594
+* local sync service support by @whutchinson98 in https://github.com/macro-inc/macro/pull/1592
+* style(toasts): re-style toast components and add fading border to indicate toast freshness by @aidanhb in https://github.com/macro-inc/macro/pull/1533
+* feat(seed): Email dev seed support by @evanhutnik in https://github.com/macro-inc/macro/pull/1595
+* fix(soup): part of list goes blank when editing task properties by @dev-rb in https://github.com/macro-inc/macro/pull/1597
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.2.18.0...v2026.2.19.0
+    </Update>
+
+    <Update label="v2026.2.18.0">
+## What's Changed
+* feat: search bar ux/ui improvments by @gbirman in https://github.com/macro-inc/macro/pull/1497
+* fix[channels]: message shift at small widths by @peterchinman in https://github.com/macro-inc/macro/pull/1499
+* feat: add back video file types by @gbirman in https://github.com/macro-inc/macro/pull/1498
+* fix(notif): no pattern matches value undefined by @seanaye in https://github.com/macro-inc/macro/pull/1502
+* feat(channels): hex channels crate with pagination by @synoet in https://github.com/macro-inc/macro/pull/1484
+* feat: backfill video file types script by @gbirman in https://github.com/macro-inc/macro/pull/1503
+* feat(email): Forwarding message attachments by @evanhutnik in https://github.com/macro-inc/macro/pull/1505
+* ci(email): Migration fix by @evanhutnik in https://github.com/macro-inc/macro/pull/1509
+* fix: download name by @gbirman in https://github.com/macro-inc/macro/pull/1504
+* chore: ignore-missing on sqlx migrate for dev by @whutchinson98 in https://github.com/macro-inc/macro/pull/1510
+* feat(documents): hex crate by @whutchinson98 in https://github.com/macro-inc/macro/pull/1488
+* fix(soup): emailView param by @evanhutnik in https://github.com/macro-inc/macro/pull/1513
+* feat: stream crate by @ehayes2000 in https://github.com/macro-inc/macro/pull/1507
+* feat(ai): stream with connection_gateway by @ehayes2000 in https://github.com/macro-inc/macro/pull/1512
+* chg(soup/properties): clean up property handling in soup by @synoet in https://github.com/macro-inc/macro/pull/1511
+* feat: search improvements by @gbirman in https://github.com/macro-inc/macro/pull/1514
+* feat: persist search text by @gbirman in https://github.com/macro-inc/macro/pull/1515
+* fix: search not returning filtered responses by @gbirman in https://github.com/macro-inc/macro/pull/1516
+* fix(channels): reset task mode properties on send by @synoet in https://github.com/macro-inc/macro/pull/1517
+* chg(list): sort notif stacks by time only by @sedson in https://github.com/macro-inc/macro/pull/1518
+* chore: update anthropic key (sops) by @ehayes2000 in https://github.com/macro-inc/macro/pull/1520
+* fix: search merge empty local results by @gbirman in https://github.com/macro-inc/macro/pull/1523
+* chore: create search state separate from soup view context by @gbirman in https://github.com/macro-inc/macro/pull/1525
+* update running locally readme by @whutchinson98 in https://github.com/macro-inc/macro/pull/1528
+* chore: file association helper rename by @gbirman in https://github.com/macro-inc/macro/pull/1526
+* feat(queries): simple undo primitive for queries by @synoet in https://github.com/macro-inc/macro/pull/1301
+* feat(ai): document ai tool by @whutchinson98 in https://github.com/macro-inc/macro/pull/1527
+* queue connection_gateway messages by @ehayes2000 in https://github.com/macro-inc/macro/pull/1534
+* fix(soup): fetching more data stuck in loop by @dev-rb in https://github.com/macro-inc/macro/pull/1536
+* feat(seed) cli seed commands by @whutchinson98 in https://github.com/macro-inc/macro/pull/1538
+* fix(email): Don't add contacts exceeding length of column by @evanhutnik in https://github.com/macro-inc/macro/pull/1539
+* feat: featured results from search by @gbirman in https://github.com/macro-inc/macro/pull/1543
+* feat: collapsible list dyanmic collapse button by @gbirman in https://github.com/macro-inc/macro/pull/1544
+* chore: more results search heading by @gbirman in https://github.com/macro-inc/macro/pull/1545
+* fix: race condition for search node id by @gbirman in https://github.com/macro-inc/macro/pull/1546
+* feat: change clear filter button by @gbirman in https://github.com/macro-inc/macro/pull/1547
+* feat: search bar clear button by @gbirman in https://github.com/macro-inc/macro/pull/1548
+* fix: clear button not visible on hover unfocused state by @gbirman in https://github.com/macro-inc/macro/pull/1549
+* feat: expand and collapse search state by @gbirman in https://github.com/macro-inc/macro/pull/1551
+* chore: enable featured search result in prod by @gbirman in https://github.com/macro-inc/macro/pull/1552
+* bump redis by @seanaye in https://github.com/macro-inc/macro/pull/1537
+* chore: kill flash by @ehayes2000 in https://github.com/macro-inc/macro/pull/1550
+* fix(stream): correct close behavior + remove scan by @ehayes2000 in https://github.com/macro-inc/macro/pull/1542
+* fix(soup): project filter missing from exhaustive match by @dev-rb in https://github.com/macro-inc/macro/pull/1553
+* fix(channels): channel name positioning in top bar by @synoet in https://github.com/macro-inc/macro/pull/1554
+* chore(email): Improve logging in db client by @evanhutnik in https://github.com/macro-inc/macro/pull/1555
+* feat: move to next entity when marked as done by @peterchinman in https://github.com/macro-inc/macro/pull/1557
+* fix[channels]: emoji react menu by @peterchinman in https://github.com/macro-inc/macro/pull/1558
+* feat(soup): dynamic task filters in the top bar for asignee and status by @synoet in https://github.com/macro-inc/macro/pull/1522
+* fix streams with new redis, stream debugger, better queries by @ehayes2000 in https://github.com/macro-inc/macro/pull/1556
+* fix(soup): slow initial load by @dev-rb in https://github.com/macro-inc/macro/pull/1559
+* chore(seed_cli): Email data by @evanhutnik in https://github.com/macro-inc/macro/pull/1540
+* fix: chat suspense by @ehayes2000 in https://github.com/macro-inc/macro/pull/1563
+* seanaye/chore/split and move code by @seanaye in https://github.com/macro-inc/macro/pull/1529
+* fix-message-order by @ehayes2000 in https://github.com/macro-inc/macro/pull/1565
+* feat: compose email on mobile by @peterchinman in https://github.com/macro-inc/macro/pull/1524
+* fix: soup query needs emails + soup optimize by @gbirman in https://github.com/macro-inc/macro/pull/1568
+* fix[channels]: message spacing by @peterchinman in https://github.com/macro-inc/macro/pull/1566
+* fix: make focus first entity reactive by @gbirman in https://github.com/macro-inc/macro/pull/1569
+* fix(entity): add PartialEntity type, fix formatting for title extractor by @sedson in https://github.com/macro-inc/macro/pull/1519
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.2.12.0...v2026.2.18.0
+    </Update>
+
+    <Update label="v2026.2.12.0">
+## What's Changed
+* feat(soup/queries) normalization and generic updates, inserts and removes by @synoet in https://github.com/macro-inc/macro/pull/1450
+* Migrate db automatically on release by @whutchinson98 in https://github.com/macro-inc/macro/pull/1476
+* feat seed cli by @whutchinson98 in https://github.com/macro-inc/macro/pull/1477
+* chg(core): update clipped panel to take div props for inner div by @sedson in https://github.com/macro-inc/macro/pull/1479
+* feat(seed_cli): create channel by @whutchinson98 in https://github.com/macro-inc/macro/pull/1478
+* feat(seed_cli): channel message seed cli by @whutchinson98 in https://github.com/macro-inc/macro/pull/1480
+* feat(soup): add ability to filter soup by email thread ids by @synoet in https://github.com/macro-inc/macro/pull/1482
+* chore: mostly deprecate macro entity package by @gbirman in https://github.com/macro-inc/macro/pull/1485
+* update dd service log config by @whutchinson98 in https://github.com/macro-inc/macro/pull/1486
+* schema dump skill by @whutchinson98 in https://github.com/macro-inc/macro/pull/1487
+* fix(email): Attachment sharing by @evanhutnik in https://github.com/macro-inc/macro/pull/1489
+* feat: standardize date serialization and internal usage by @gbirman in https://github.com/macro-inc/macro/pull/1449
+* style(email): Bold top bar, remove trailing commas from names by @evanhutnik in https://github.com/macro-inc/macro/pull/1490
+* fix: channel thread/message mention hover text by @gbirman in https://github.com/macro-inc/macro/pull/1491
+* fix: remove empty terms enable search query by @gbirman in https://github.com/macro-inc/macro/pull/1493
+* feat(soup): add channel_type filters for channels in soup by @synoet in https://github.com/macro-inc/macro/pull/1492
+* fix(soup): query filters not saved and restored, notifications opening in new split by @dev-rb in https://github.com/macro-inc/macro/pull/1494
+* fix(soup): suspense and clear search text by @dev-rb in https://github.com/macro-inc/macro/pull/1495
+* feat(soup): use backend soup filtering for people / teams by @synoet in https://github.com/macro-inc/macro/pull/1496
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.2.11.0...v2026.2.12.0
+    </Update>
+
+    <Update label="v2026.2.11.0">
+## What's Changed
+* feat: ai consent flow by @peterchinman in https://github.com/macro-inc/macro/pull/1459
+* fix(channel): retsore (accidentally) deleted channel image attachments [bbb896f] by @sedson in https://github.com/macro-inc/macro/pull/1461
+* fix: unrolled list notifications opening in new split on mobile by @dev-rb in https://github.com/macro-inc/macro/pull/1462
+* style(email): Normalize font and spacing, remove text background by @evanhutnik in https://github.com/macro-inc/macro/pull/1465
+* fix(preview): fix no icon wrapper width by @sedson in https://github.com/macro-inc/macro/pull/1463
+* fix(ai): context  by @ehayes2000 in https://github.com/macro-inc/macro/pull/1466
+* refactor(soup): refactor query filter setting by @dev-rb in https://github.com/macro-inc/macro/pull/1464
+* fix(sharing): hide access level select for email sharing by @dev-rb in https://github.com/macro-inc/macro/pull/1142
+* style(list): small fixes for text truncation by @sedson in https://github.com/macro-inc/macro/pull/1469
+* fix(channels): lazy action menu blessing by @synoet in https://github.com/macro-inc/macro/pull/1470
+* [channels]: improve rail styling by @peterchinman in https://github.com/macro-inc/macro/pull/1473
+* fix(channel): list not scrolling to target by @dev-rb in https://github.com/macro-inc/macro/pull/1472
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.2.10.0...v2026.2.11.0
+    </Update>
+
+    <Update label="v2026.2.10.0">
+## What's Changed
+* fix(email): Escape escapes email block by @evanhutnik in https://github.com/macro-inc/macro/pull/1398
+* refactor(entity): create composable ui components for entities by @sedson in https://github.com/macro-inc/macro/pull/1368
+* seanaye/fix/ios payload uuid by @seanaye in https://github.com/macro-inc/macro/pull/1400
+* disable auto attach in soup by @ehayes2000 in https://github.com/macro-inc/macro/pull/1401
+* refactor(soup): refactor soup and unified list implementation [stack/01] by @dev-rb in https://github.com/macro-inc/macro/pull/1248
+* fix: replace dss query keys  by @dev-rb in https://github.com/macro-inc/macro/pull/1403
+* chore: conditionally register generate plugin behind feature flag by @gbirman in https://github.com/macro-inc/macro/pull/1405
+* Improve upload claim query performance by @evanhutnik in https://github.com/macro-inc/macro/pull/1406
+* Revert "local fusionauth" by @whutchinson98 in https://github.com/macro-inc/macro/pull/1411
+* fix[channels]: Jump to Latest behavior by @peterchinman in https://github.com/macro-inc/macro/pull/1414
+* fix(md): fix space on empty line – add conversionOnly flag to appropriate markdown transformers by @sedson in https://github.com/macro-inc/macro/pull/1408
+* fix: settings state for mobile by @peterchinman in https://github.com/macro-inc/macro/pull/1410
+* fix(soup): add scroll and state restoration by @dev-rb in https://github.com/macro-inc/macro/pull/1415
+* fix(soup): emailViews and importance by @evanhutnik in https://github.com/macro-inc/macro/pull/1419
+* feat: optimize names search by @gbirman in https://github.com/macro-inc/macro/pull/1412
+* chore(channels): remove dependency on block signals in channel by @synoet in https://github.com/macro-inc/macro/pull/1418
+* Evan/anchor fr by @evanhutnik in https://github.com/macro-inc/macro/pull/1413
+* Revert "fix(soup): emailViews and importance (#1419)" by @evanhutnik in https://github.com/macro-inc/macro/pull/1424
+* fix(lexical-core): make unknown-mention regex specific to \<m-tags> not just \<tags> by @sedson in https://github.com/macro-inc/macro/pull/1426
+* fix(soup): performance regression when selecting in preview mode by @dev-rb in https://github.com/macro-inc/macro/pull/1420
+* feat(soup): add offset to navigation scroll to show more entities by @dev-rb in https://github.com/macro-inc/macro/pull/1421
+* feat(ai): auto attach previews by @ehayes2000 in https://github.com/macro-inc/macro/pull/1402
+* fix: open in same or new split behavior by @dev-rb in https://github.com/macro-inc/macro/pull/1416
+* chore(ai): opus-4.5 -> opus-4.6 by @ehayes2000 in https://github.com/macro-inc/macro/pull/1404
+* fix(md): fix node accessory position for deeply nested node accessories by @sedson in https://github.com/macro-inc/macro/pull/1428
+* feat: enable opensearch slow logging by @gbirman in https://github.com/macro-inc/macro/pull/1423
+* fix(hotkey): new split hotkey not working by @dev-rb in https://github.com/macro-inc/macro/pull/1429
+* fix(core): remove ugly corder on document preview by @sedson in https://github.com/macro-inc/macro/pull/1430
+* feat(queries): per query persister by @synoet in https://github.com/macro-inc/macro/pull/1407
+* feat(list): use new entity components in new list view by @sedson in https://github.com/macro-inc/macro/pull/1422
+* feat(dss): generic entity permissions endpoint + utils by @synoet in https://github.com/macro-inc/macro/pull/1417
+* remove dead code by @seanaye in https://github.com/macro-inc/macro/pull/1388
+* fix(email): Selectable recipients, expand direction by @evanhutnik in https://github.com/macro-inc/macro/pull/1431
+* fix(md): fix enter transform condition with codebox + linebreak by @sedson in https://github.com/macro-inc/macro/pull/1432
+* style(list): remove checkbox transition by @sedson in https://github.com/macro-inc/macro/pull/1433
+* chg(list): swap mouse-enter for mouse-move on list entity by @sedson in https://github.com/macro-inc/macro/pull/1434
+* fix(soup): various bugs by @dev-rb in https://github.com/macro-inc/macro/pull/1435
+* local fusionauth by @whutchinson98 in https://github.com/macro-inc/macro/pull/1436
+* feat(md): add inline media upload to lexical actions by @sedson in https://github.com/macro-inc/macro/pull/1438
+* chore(ai): replace hooks with context by @ehayes2000 in https://github.com/macro-inc/macro/pull/1437
+* fix: chat attachment mentions losing focus by @gbirman in https://github.com/macro-inc/macro/pull/1440
+* feat(icons) - add animating versions of icons in Launcher and Soup filters by @aidanhb in https://github.com/macro-inc/macro/pull/1229
+* fix: task type chat attachment + use item preview directly in chat attachment by @gbirman in https://github.com/macro-inc/macro/pull/1443
+* move fusionauth into it's own create by @whutchinson98 in https://github.com/macro-inc/macro/pull/1444
+* fix local logging by @whutchinson98 in https://github.com/macro-inc/macro/pull/1442
+* fix(md): fix image copy caused by unchecked nulls by @sedson in https://github.com/macro-inc/macro/pull/1446
+* fix(email): Populate null contact names by @evanhutnik in https://github.com/macro-inc/macro/pull/1447
+* fix(soup): navigation, signal filters, and performance improvements by @dev-rb in https://github.com/macro-inc/macro/pull/1439
+* Revert "Evan/anchor fr (#1413)" by @evanhutnik in https://github.com/macro-inc/macro/pull/1448
+* feat(icons): Add animated icons for signal and noise filters by @aidanhb in https://github.com/macro-inc/macro/pull/1445
+* feat(notif): email notification decision tree by @seanaye in https://github.com/macro-inc/macro/pull/1451
+* style(chat/channel): unifiy/cleanup attachment styling by @sedson in https://github.com/macro-inc/macro/pull/1454
+* feat[mobile]: use tauri auth plugin by @peterchinman in https://github.com/macro-inc/macro/pull/1452
+* fix[mobile]: allow camera access by @peterchinman in https://github.com/macro-inc/macro/pull/1456
+* style(email): Better background and theme handling by @evanhutnik in https://github.com/macro-inc/macro/pull/1455
+* fix(soup): fix rename not updating soup and filters not restoring on navigate by @dev-rb in https://github.com/macro-inc/macro/pull/1458
+* fix(ws): prevent duplicate connection listeners by @synoet in https://github.com/macro-inc/macro/pull/1453
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.2.6.0...v2026.2.10.0
+    </Update>
+
+    <Update label="v2026.2.6.0">
+## What's Changed
+* fix(md): fix reactive rename on empty md title by @sedson in https://github.com/macro-inc/macro/pull/1344
+* add tauri localhost to cors by @peterchinman in https://github.com/macro-inc/macro/pull/1343
+* feat: otel datadog setup by @whutchinson98 in https://github.com/macro-inc/macro/pull/1323
+* remove un-needed instrument by @whutchinson98 in https://github.com/macro-inc/macro/pull/1347
+* chore(soup/email): Remove metadata field from email threads by @evanhutnik in https://github.com/macro-inc/macro/pull/1345
+* fix(email): Don't create user_history row for auto-inserted attachments by @evanhutnik in https://github.com/macro-inc/macro/pull/1346
+* chore: tracing level on macro_env_var by @whutchinson98 in https://github.com/macro-inc/macro/pull/1348
+* chore: update fe history type by @gbirman in https://github.com/macro-inc/macro/pull/1349
+* fix(email-service): Attachment upload race condition by @evanhutnik in https://github.com/macro-inc/macro/pull/1350
+* chore(email): Instrument calls by @evanhutnik in https://github.com/macro-inc/macro/pull/1352
+* automatic db migration for dev by @whutchinson98 in https://github.com/macro-inc/macro/pull/1357
+* do not log db url from just command by @whutchinson98 in https://github.com/macro-inc/macro/pull/1359
+* migrate db fixes by @whutchinson98 in https://github.com/macro-inc/macro/pull/1360
+* feat: clean up history work being done on front end by @gbirman in https://github.com/macro-inc/macro/pull/1355
+* fix: migrator ci add rustls by @whutchinson98 in https://github.com/macro-inc/macro/pull/1361
+* remove frecency poller log by @seanaye in https://github.com/macro-inc/macro/pull/1277
+* Stack/01 service migrations by @seanaye in https://github.com/macro-inc/macro/pull/1331
+* chore(dss): Reduce max pods, increase sql connection count by @evanhutnik in https://github.com/macro-inc/macro/pull/1363
+* fix(soup): Improve query performance by @evanhutnik in https://github.com/macro-inc/macro/pull/1362
+* feat(channels): infinite stale time, on mount hydration by @synoet in https://github.com/macro-inc/macro/pull/1364
+* chore: remove un-needed updateCookie from Login.tsx by @whutchinson98 in https://github.com/macro-inc/macro/pull/1354
+* seanaye/chore/ios sound and logging by @seanaye in https://github.com/macro-inc/macro/pull/1365
+* fix(soup): Improve dynamic query performance by @evanhutnik in https://github.com/macro-inc/macro/pull/1366
+* fix(channel): channel scrolling down after jumping to a message by @dev-rb in https://github.com/macro-inc/macro/pull/1367
+* seanaye/fix/conn gateway payload by @seanaye in https://github.com/macro-inc/macro/pull/1369
+* fix notif crash by @seanaye in https://github.com/macro-inc/macro/pull/1371
+* fix[mobile]: mobile typing issues in the Markdown editor by @peterchinman in https://github.com/macro-inc/macro/pull/1370
+* fix: new soup item on create by @gbirman in https://github.com/macro-inc/macro/pull/1372
+* fix[mobile]: invalidate notifications query by @peterchinman in https://github.com/macro-inc/macro/pull/1373
+* fix(ios) deliver all endpoints by @seanaye in https://github.com/macro-inc/macro/pull/1374
+* fix(channels): reactive message context by @synoet in https://github.com/macro-inc/macro/pull/1376
+* fix(notifications): fix preview access by @synoet in https://github.com/macro-inc/macro/pull/1377
+* fix(email): Draft scroll bug by @evanhutnik in https://github.com/macro-inc/macro/pull/1378
+* local fusionauth by @whutchinson98 in https://github.com/macro-inc/macro/pull/1379
+* fix: preview rename non existent query by @gbirman in https://github.com/macro-inc/macro/pull/1375
+* update dss logging to hook up with traces by @whutchinson98 in https://github.com/macro-inc/macro/pull/1381
+* fix(email): Date display and collapsing last message by @evanhutnik in https://github.com/macro-inc/macro/pull/1380
+* fix: dd logging by @whutchinson98 in https://github.com/macro-inc/macro/pull/1383
+* fix: do not attempt to register user in passwordless flow by @whutchinson98 in https://github.com/macro-inc/macro/pull/1382
+* chore: clean up icon code by @gbirman in https://github.com/macro-inc/macro/pull/1384
+* style(email): Compose box anchored to bottom when empty by @evanhutnik in https://github.com/macro-inc/macro/pull/1389
+* feat: don't update viewed at optimistically for preview blocks by @gbirman in https://github.com/macro-inc/macro/pull/1390
+* fix: focus split on preview entity click by @peterchinman in https://github.com/macro-inc/macro/pull/1391
+* tracing otel link by @whutchinson98 in https://github.com/macro-inc/macro/pull/1387
+* feat: search tracing by @gbirman in https://github.com/macro-inc/macro/pull/1386
+* fix(channel): no more suspending! by @synoet in https://github.com/macro-inc/macro/pull/1394
+* fix: item rename preview + add featuer flag auto tab attachments by @gbirman in https://github.com/macro-inc/macro/pull/1395
+* Revert "style(email): Compose box anchored to bottom when empty (#1389)" by @evanhutnik in https://github.com/macro-inc/macro/pull/1396
+* chore: remove space hint in md  by @gbirman in https://github.com/macro-inc/macro/pull/1397
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.2.4.2...v2026.2.6.0
+    </Update>
+
+    <Update label="v2026.2.4.2">
+## What's Changed
+* feat: renaming refactor, make optimistic, fixes and improvements by @gbirman in https://github.com/macro-inc/macro/pull/1311
+* fix: selected entity signal performance enhancements by @peterchinman in https://github.com/macro-inc/macro/pull/1329
+* feat(md): add unknown md-parser for hiding nasty json when new nodes by @sedson in https://github.com/macro-inc/macro/pull/1327
+* fix(email): Show attachments of sent message during undo window by @evanhutnik in https://github.com/macro-inc/macro/pull/1328
+* chore: deprecate channels entity query by @gbirman in https://github.com/macro-inc/macro/pull/1333
+* feat: delete account button by @peterchinman in https://github.com/macro-inc/macro/pull/1330
+* optimistic update item viewed at on open by @gbirman in https://github.com/macro-inc/macro/pull/1338
+* local sfs by @whutchinson98 in https://github.com/macro-inc/macro/pull/1339
+* fix[mobile]: md touch handling improvements by @peterchinman in https://github.com/macro-inc/macro/pull/1342
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.2.4.1...v2026.2.4.2
+    </Update>
+
+    <Update label="v2026.2.4.1">
+## What's Changed
+* debump jsonwebtoken by @whutchinson98 in https://github.com/macro-inc/macro/pull/1325
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.2.4.0...v2026.2.4.1
+    </Update>
+
+    <Update label="v2026.2.4.0">
+## What's Changed
+* fix: ensure fresh search gets timestamps by @gbirman in https://github.com/macro-inc/macro/pull/1310
+* bump dss cpu and db pool configuration by @whutchinson98 in https://github.com/macro-inc/macro/pull/1312
+* remove search and comms service infra by @whutchinson98 in https://github.com/macro-inc/macro/pull/1313
+* chore(deps): bump bytes from 1.11.0 to 1.11.1 in /rust/sync-service by @dependabot[bot] in https://github.com/macro-inc/macro/pull/1296
+* chore: remove api version from service calls by @whutchinson98 in https://github.com/macro-inc/macro/pull/1315
+* chore: remove br compression. gzip only by @whutchinson98 in https://github.com/macro-inc/macro/pull/1314
+* fix(md): bump lexical version, add agents.md note by @sedson in https://github.com/macro-inc/macro/pull/1317
+* feat(email): schedule sending emails by @dev-rb in https://github.com/macro-inc/macro/pull/1119
+* feat(soup): Importance filter by @evanhutnik in https://github.com/macro-inc/macro/pull/1316
+* fix(persistence): improve indexdb persistence perf by @synoet in https://github.com/macro-inc/macro/pull/1318
+* fix(core): service client urls by @synoet in https://github.com/macro-inc/macro/pull/1322
+* fix(hotkeys): leaking scoped commands by @synoet in https://github.com/macro-inc/macro/pull/1320
+* remove brotli by @whutchinson98 in https://github.com/macro-inc/macro/pull/1321
+* chore(deps): bump bytes from 1.11.0 to 1.11.1 in /js/app/tauri by @dependabot[bot] in https://github.com/macro-inc/macro/pull/1295
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.2.3.1...v2026.2.4.0
+    </Update>
+
+    <Update label="v2026.2.3.1">
+## What's Changed
+* fix: theme mentions by @peterchinman in https://github.com/macro-inc/macro/pull/1307
+* fix(channels): missing nonce for attachments by @synoet in https://github.com/macro-inc/macro/pull/1308
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.2.3.0...v2026.2.3.1
+    </Update>
+
+    <Update label="v2026.2.3.0">
+## What's Changed
+* remove dss from comms by @whutchinson98 in https://github.com/macro-inc/macro/pull/1247
+* chore: remove properties infra by @whutchinson98 in https://github.com/macro-inc/macro/pull/1253
+* chore remove comms service client by @whutchinson98 in https://github.com/macro-inc/macro/pull/1254
+* claude tracing nit by @whutchinson98 in https://github.com/macro-inc/macro/pull/1256
+* fail to send logging by @ehayes2000 in https://github.com/macro-inc/macro/pull/1255
+* fix(ai): include properties in snapshot by @ehayes2000 in https://github.com/macro-inc/macro/pull/1257
+* refactor: move search to dss by @whutchinson98 in https://github.com/macro-inc/macro/pull/1258
+* style(email): Message dark/light mode handling by @evanhutnik in https://github.com/macro-inc/macro/pull/1259
+* feat(channels): optimistic channels + part one deblockification by @synoet in https://github.com/macro-inc/macro/pull/1243
+* fix[iOS]: app crash on open by @peterchinman in https://github.com/macro-inc/macro/pull/1260
+* refactor remove redis cluster by @whutchinson98 in https://github.com/macro-inc/macro/pull/1263
+* remove redis cluster by @whutchinson98 in https://github.com/macro-inc/macro/pull/1264
+* rotate jwt secret key by @whutchinson98 in https://github.com/macro-inc/macro/pull/1265
+* fix(ai): auth disconnect by @ehayes2000 in https://github.com/macro-inc/macro/pull/1266
+* chore(s3): Add bucket deletion policies by @evanhutnik in https://github.com/macro-inc/macro/pull/1267
+* style(email): Don't anchor subject on mobile by @evanhutnik in https://github.com/macro-inc/macro/pull/1269
+* fix(email-service): Inbox thread filtering by @evanhutnik in https://github.com/macro-inc/macro/pull/1270
+* fix: prevent duplicate stripe subscriptions by @whutchinson98 in https://github.com/macro-inc/macro/pull/1268
+* upgrade redis 0.29 -> 1.03 by @ehayes2000 in https://github.com/macro-inc/macro/pull/1271
+* chore: bump esbuild for security by @whutchinson98 in https://github.com/macro-inc/macro/pull/1272
+* Enhance Cmd+Escape hotkey to navigate home when not in split by @jbecke in https://github.com/macro-inc/macro/pull/1261
+* chore: bump cargo dependencies by @whutchinson98 in https://github.com/macro-inc/macro/pull/1273
+* chore(fe): Remove organizations code by @evanhutnik in https://github.com/macro-inc/macro/pull/1262
+* fix: add missing perms to doc-storage bucket by @whutchinson98 in https://github.com/macro-inc/macro/pull/1276
+* feat: channel message/thread mention preview by @gbirman in https://github.com/macro-inc/macro/pull/1156
+* fix: Rightbar focus issues by @peterchinman in https://github.com/macro-inc/macro/pull/1281
+* fix: update item preview component to use hover card core by @gbirman in https://github.com/macro-inc/macro/pull/1282
+* fix(email): Scrolling issue by @evanhutnik in https://github.com/macro-inc/macro/pull/1280
+* local dynamodb tables by @whutchinson98 in https://github.com/macro-inc/macro/pull/1278
+* update tests to use macro_db_migrator by @whutchinson98 in https://github.com/macro-inc/macro/pull/1274
+* move comms into dss by @whutchinson98 in https://github.com/macro-inc/macro/pull/1279
+* fix(search): Don't populate spam/trash email messages by @evanhutnik in https://github.com/macro-inc/macro/pull/1285
+* bump log level by @whutchinson98 in https://github.com/macro-inc/macro/pull/1286
+* fix: force mount hover card open by @gbirman in https://github.com/macro-inc/macro/pull/1287
+* feat(channels): simplify channels, fix mid-list insert virtualization problems by @synoet in https://github.com/macro-inc/macro/pull/1284
+* Revert "upgrade redis 0.29 -> 1.03" by @whutchinson98 in https://github.com/macro-inc/macro/pull/1288
+* local buckets by @whutchinson98 in https://github.com/macro-inc/macro/pull/1289
+* fix(md): fix media node rescale save effect by @sedson in https://github.com/macro-inc/macro/pull/1290
+* fix: thread scrolling behavior by @synoet in https://github.com/macro-inc/macro/pull/1293
+* fix(auth): remove invalidation in logout causing race condition by @synoet in https://github.com/macro-inc/macro/pull/1297
+* fix: mobile login flow by @peterchinman in https://github.com/macro-inc/macro/pull/1294
+* fix: theme sharing by @peterchinman in https://github.com/macro-inc/macro/pull/1300
+* feat(ai): top bar share menu by @ehayes2000 in https://github.com/macro-inc/macro/pull/1275
+* fix(core): fix non-reactive tab title on list and channel, fix channel rename by @sedson in https://github.com/macro-inc/macro/pull/1299
+* fix(channels): fix optimistically insert attachments by @synoet in https://github.com/macro-inc/macro/pull/1302
+* chg(channels): remove pending send now that optimistic by @synoet in https://github.com/macro-inc/macro/pull/1304
+* swagger command by @whutchinson98 in https://github.com/macro-inc/macro/pull/1305
+* feat: theme mentions by @peterchinman in https://github.com/macro-inc/macro/pull/1303
+* fix: shared documents get added to history on open by @gbirman in https://github.com/macro-inc/macro/pull/1306
+* Replace AST cursor in soup by @seanaye in https://github.com/macro-inc/macro/pull/1292
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.1.29.0...v2026.2.3.0
+    </Update>

--- a/docs/changelog/2026-03.mdx
+++ b/docs/changelog/2026-03.mdx
@@ -1,0 +1,727 @@
+---
+title: "March 2026"
+description: "Macro releases from March 2026."
+---
+
+    <Update label="v2026.3.31.1">
+## What's Changed
+* fix(search): drop document name covering index and create the index without name by @gbirman in https://github.com/macro-inc/macro/pull/2323
+* fix(channels): exclude attachments from deleted messages by @synoet in https://github.com/macro-inc/macro/pull/2322
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.3.31.0...v2026.3.31.1
+    </Update>
+
+    <Update label="v2026.3.31.0">
+## What's Changed
+* feat(search): filter out local search from inbox by @gbirman in https://github.com/macro-inc/macro/pull/2286
+* feat: ability to remove github link by @whutchinson98 in https://github.com/macro-inc/macro/pull/2288
+* feat(core): invite btn in side bar, dev only for now by @sedson in https://github.com/macro-inc/macro/pull/2285
+* chore(ai): pay by @ehayes2000 in https://github.com/macro-inc/macro/pull/2282
+* Bump db's again by @evanhutnik in https://github.com/macro-inc/macro/pull/2290
+* feat(github): support redirect flow for github link by @whutchinson98 in https://github.com/macro-inc/macro/pull/2291
+* style(mentions): fix ghost divider on document preview popover, add task properties by @sedson in https://github.com/macro-inc/macro/pull/2292
+* fix(analytics): incorrect proxy url by @dev-rb in https://github.com/macro-inc/macro/pull/2293
+* fix: toast positioning by @peterchinman in https://github.com/macro-inc/macro/pull/2275
+* feat(github): enable button by @whutchinson98 in https://github.com/macro-inc/macro/pull/2289
+* feat(soup): expose soup ast endpoint by @seanaye in https://github.com/macro-inc/macro/pull/2287
+* feat(md): add inline properties to document mention decorator by @sedson in https://github.com/macro-inc/macro/pull/2295
+* feat(db): add entity_access table by @whutchinson98 in https://github.com/macro-inc/macro/pull/2296
+* fix(email): preserve button styling in sanitized HTML emails by @evanhutnik in https://github.com/macro-inc/macro/pull/2294
+* Reduce db instance size by @evanhutnik in https://github.com/macro-inc/macro/pull/2302
+* fix(properties): vuln by @seanaye in https://github.com/macro-inc/macro/pull/2301
+* fix: turn off frecency sort by @peterchinman in https://github.com/macro-inc/macro/pull/2304
+* fix(settings): use base theme for GitHub enable button by @evanhutnik in https://github.com/macro-inc/macro/pull/2303
+* feat(new-channels): attachment tab in channels by @synoet in https://github.com/macro-inc/macro/pull/2279
+* perf(search): document name search covering index by @gbirman in https://github.com/macro-inc/macro/pull/2300
+* feat(notif): truncate digest len by @seanaye in https://github.com/macro-inc/macro/pull/2306
+* perf(search): split email contact search into two queries by @gbirman in https://github.com/macro-inc/macro/pull/2297
+* feat(new-channels): participants tab by @synoet in https://github.com/macro-inc/macro/pull/2307
+* Up instance size agane by @evanhutnik in https://github.com/macro-inc/macro/pull/2309
+* feat(settings): add Enable button for email with logout confirmation by @evanhutnik in https://github.com/macro-inc/macro/pull/2311
+* feat: command k viewed at by @gbirman in https://github.com/macro-inc/macro/pull/2313
+* feat(new-channels): add back live indicators by @synoet in https://github.com/macro-inc/macro/pull/2315
+* chg: agents md improvements by @synoet in https://github.com/macro-inc/macro/pull/2317
+* chore(new-channels): restyle attachments tab by @synoet in https://github.com/macro-inc/macro/pull/2312
+* fix: command k viewed at outside recently viewed limit by @gbirman in https://github.com/macro-inc/macro/pull/2318
+* chg(new-channels): thread reply mounts by @synoet in https://github.com/macro-inc/macro/pull/2319
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.3.30.0...v2026.3.31.0
+    </Update>
+
+    <Update label="v2026.3.30.0">
+## What's Changed
+* fix(search): local fuzzy document search returns non-document results by @gbirman in https://github.com/macro-inc/macro/pull/2242
+* update macrodb prod to gp3 by @whutchinson98 in https://github.com/macro-inc/macro/pull/2244
+* feat(new-channels): typing indicators by @synoet in https://github.com/macro-inc/macro/pull/2245
+* fix[mobile]: correct toast sizing by @peterchinman in https://github.com/macro-inc/macro/pull/2247
+* fix(new-channels): static spacing by @synoet in https://github.com/macro-inc/macro/pull/2249
+* chore(email-link-delete): Disable email if no opens after 7 days inst… by @evanhutnik in https://github.com/macro-inc/macro/pull/2250
+* macrodb replica by @whutchinson98 in https://github.com/macro-inc/macro/pull/2251
+* chore(search): bump to latest opensearch version by @gbirman in https://github.com/macro-inc/macro/pull/2253
+* fix(tasks): add autocopy link bask to task creation by @sedson in https://github.com/macro-inc/macro/pull/2252
+* fix(email): improve scheduled send validation and recipient handling by @evanhutnik in https://github.com/macro-inc/macro/pull/2255
+* fix(analytics): subscription success not tracked and signup events not sent to all providers by @dev-rb in https://github.com/macro-inc/macro/pull/2256
+* feat[mobile]: soup view tabs as slidable bottom bar by @peterchinman in https://github.com/macro-inc/macro/pull/2257
+* fix(analytics): stripe subscription events not tracked in posthog by @dev-rb in https://github.com/macro-inc/macro/pull/2254
+* fix: missing virtua patch to fix window access by @dev-rb in https://github.com/macro-inc/macro/pull/2262
+* fix: suppress bom part failures for text extraction by @gbirman in https://github.com/macro-inc/macro/pull/2259
+* chore(notif): clear stale notifs with missing threadID by @seanaye in https://github.com/macro-inc/macro/pull/2258
+* feat[mobile]: improve compose header button layout and validation by @evanhutnik in https://github.com/macro-inc/macro/pull/2266
+* fix[soup]: show filter chip for email by @peterchinman in https://github.com/macro-inc/macro/pull/2261
+* feat(cmd-k): add sidebar go to commands by @synoet in https://github.com/macro-inc/macro/pull/2268
+* fix(search): update sort script by @gbirman in https://github.com/macro-inc/macro/pull/2267
+* chore: fix biome lint command by @synoet in https://github.com/macro-inc/macro/pull/2272
+* feat(md): add yesterday to date pickers and use relative date formatting  by @sedson in https://github.com/macro-inc/macro/pull/2271
+* chore(email): Refactor email compose by @ehayes2000 in https://github.com/macro-inc/macro/pull/2263
+* create single GitHub app for both oauth authentication and repo syncing by @whutchinson98 in https://github.com/macro-inc/macro/pull/2265
+* feat(ai): paywall models by @ehayes2000 in https://github.com/macro-inc/macro/pull/2234
+* perf(search): remove wildcard matching and use match phrase prefix only by @gbirman in https://github.com/macro-inc/macro/pull/2273
+* feat(team): add email notification by @seanaye in https://github.com/macro-inc/macro/pull/2246
+* fix: link_exists api call by @whutchinson98 in https://github.com/macro-inc/macro/pull/2280
+* chg(channels): return sender with attachments, bump clamp on limit by @synoet in https://github.com/macro-inc/macro/pull/2278
+* fix(db): Bump readonly replica size by @evanhutnik in https://github.com/macro-inc/macro/pull/2283
+* feat(core): simple placeholder send refferal ui by @sedson in https://github.com/macro-inc/macro/pull/2277
+* style(layout): fix broken left padding when un-authed by @sedson in https://github.com/macro-inc/macro/pull/2281
+* chore(analytics): remove old analytics usage and package by @dev-rb in https://github.com/macro-inc/macro/pull/2274
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.3.27.1...v2026.3.30.0
+    </Update>
+
+    <Update label="v2026.3.27.1">
+## What's Changed
+* fix(search): local client side filter by @gbirman in https://github.com/macro-inc/macro/pull/2235
+* fix(channels): various bugs by @dev-rb in https://github.com/macro-inc/macro/pull/2236
+* fix teams by @whutchinson98 in https://github.com/macro-inc/macro/pull/2237
+* fix(soup): use sortTs for email thread ordering and display by @evanhutnik in https://github.com/macro-inc/macro/pull/2238
+* chore(ai): make ai toolset composition panic on fail by @ehayes2000 in https://github.com/macro-inc/macro/pull/2212
+* fix(soup): search text not cached by @dev-rb in https://github.com/macro-inc/macro/pull/2239
+* fix(tauri): prevent ios blank screen by @peterchinman in https://github.com/macro-inc/macro/pull/2240
+* update macrodb dev to gp3 by @whutchinson98 in https://github.com/macro-inc/macro/pull/2241
+* feat[mobile]: what if mobile dock had so many buttons by @peterchinman in https://github.com/macro-inc/macro/pull/2243
+* feat[mobile]: soup filters as drawer by @peterchinman in https://github.com/macro-inc/macro/pull/2229
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.3.27.0...v2026.3.27.1
+    </Update>
+
+    <Update label="v2026.3.27.0">
+## What's Changed
+* feat(search): unify search filters with soup by @gbirman in https://github.com/macro-inc/macro/pull/2230
+* feat(teams): patch team user tier request by @whutchinson98 in https://github.com/macro-inc/macro/pull/2231
+* Seanaye/feat/ignore notification typenames by @seanaye in https://github.com/macro-inc/macro/pull/2214
+* chore(search): exit early if all search indices are empty by @gbirman in https://github.com/macro-inc/macro/pull/2233
+* fix: persistent tab state bug by @peterchinman in https://github.com/macro-inc/macro/pull/2232
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.3.26.2...v2026.3.27.0
+    </Update>
+
+    <Update label="v2026.3.26.2">
+## What's Changed
+* fix: anthropic no response by @ehayes2000 in https://github.com/macro-inc/macro/pull/2189
+* fix(email): include status code and error body in Gmail API error messages by @evanhutnik in https://github.com/macro-inc/macro/pull/2216
+* feat(teams) support tiers team members by @whutchinson98 in https://github.com/macro-inc/macro/pull/2175
+* refactor(gmail-client): simplify get_threads to get_thread for single thread fetch by @evanhutnik in https://github.com/macro-inc/macro/pull/2219
+* chore: remove misleadinc iac comment by @ehayes2000 in https://github.com/macro-inc/macro/pull/2221
+* chore(ai): chat state management by @ehayes2000 in https://github.com/macro-inc/macro/pull/2184
+* fix(notif): mark connection live during ping by @seanaye in https://github.com/macro-inc/macro/pull/2217
+* feat: more updates to s3 key migration script by @gbirman in https://github.com/macro-inc/macro/pull/2222
+* chore: deprecate legacy s3 key by @gbirman in https://github.com/macro-inc/macro/pull/2209
+* fix(analytics): sign up and login tracking by @dev-rb in https://github.com/macro-inc/macro/pull/2224
+* chore: consolidate bucket actions into a single const by @gbirman in https://github.com/macro-inc/macro/pull/2225
+* style(core): restyle toasts by @sedson in https://github.com/macro-inc/macro/pull/2220
+* fix(platform): move out notification provider, to disable modal when not authed by @synoet in https://github.com/macro-inc/macro/pull/2228
+* feat[soup]: persist state per tab by @peterchinman in https://github.com/macro-inc/macro/pull/2218
+* fix: channels blanking and weird virtua scroll bug by @dev-rb in https://github.com/macro-inc/macro/pull/2227
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.3.26.1...v2026.3.26.2
+    </Update>
+
+    <Update label="v2026.3.26.1">
+## What's Changed
+* fix(sidebar): sidebar hotkey capture preventing "go to top" hotkey for soup from firing by @dev-rb in https://github.com/macro-inc/macro/pull/2210
+* fix(auth): add corrent idp param to app gmail login bttns by @sedson in https://github.com/macro-inc/macro/pull/2207
+* update comments by @seanaye in https://github.com/macro-inc/macro/pull/2205
+* fix[email]: mobile rendering of images by @peterchinman in https://github.com/macro-inc/macro/pull/2211
+* chore: cowify error response by @seanaye in https://github.com/macro-inc/macro/pull/2208
+* feat(email): delete user email links on user deletion by @evanhutnik in https://github.com/macro-inc/macro/pull/2213
+* fix(email): CC on mention not working for non-existent contacts by @evanhutnik in https://github.com/macro-inc/macro/pull/2215
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.3.26.0...v2026.3.26.1
+    </Update>
+
+    <Update label="v2026.3.26.0">
+## What's Changed
+* feat(email): Set email sender as Signal/Noise with email_filters by @evanhutnik in https://github.com/macro-inc/macro/pull/2190
+* fix: remove console log by @ehayes2000 in https://github.com/macro-inc/macro/pull/2202
+* chore: remove `keyed` from `ShowFeatureFlag` by @dev-rb in https://github.com/macro-inc/macro/pull/2198
+* increase digest window to 24h by @seanaye in https://github.com/macro-inc/macro/pull/2201
+* fix(soup): derive tab keyboard nav order from visual tab list by @evanhutnik in https://github.com/macro-inc/macro/pull/2204
+* feat(search): filter by sub_type and enrich with properties by @gbirman in https://github.com/macro-inc/macro/pull/2196
+* chore: bump ios version by @peterchinman in https://github.com/macro-inc/macro/pull/2203
+* chore: remove macrotation table by @whutchinson98 in https://github.com/macro-inc/macro/pull/2206
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.3.25.0...v2026.3.26.0
+    </Update>
+
+    <Update label="v2026.3.25.0">
+## What's Changed
+* chore: improve extensionless key migration by @gbirman in https://github.com/macro-inc/macro/pull/2163
+* feat(onboarding): rework lesson flow, better styles, better focus by @sedson in https://github.com/macro-inc/macro/pull/2158
+* fix(teams) only premium users create teams by @whutchinson98 in https://github.com/macro-inc/macro/pull/2164
+* feat(ai): properties tools by @ehayes2000 in https://github.com/macro-inc/macro/pull/2143
+* fix(style): only fade in image preview on load by @aidanhb in https://github.com/macro-inc/macro/pull/2165
+* feat[soup]: add docx to document filters by @peterchinman in https://github.com/macro-inc/macro/pull/2167
+* style(core): matching menu styles for split file menu by @sedson in https://github.com/macro-inc/macro/pull/2169
+* fix memory by @ehayes2000 in https://github.com/macro-inc/macro/pull/2166
+* feat(sidebar): shortcut labels  by @dev-rb in https://github.com/macro-inc/macro/pull/1880
+* fix[tasks]: also hide cancelled tasks from default tabs by @peterchinman in https://github.com/macro-inc/macro/pull/2168
+* fix: improve email templates by @peterchinman in https://github.com/macro-inc/macro/pull/2161
+* fix(ai): handle stream errors by @ehayes2000 in https://github.com/macro-inc/macro/pull/2171
+* feat(channels): debounce thread-replies on mount, change base page size to 50, unless cursor provided by @synoet in https://github.com/macro-inc/macro/pull/2172
+* fix(email): cap reply recipient list to 3 people max by @evanhutnik in https://github.com/macro-inc/macro/pull/2176
+* chore(deps): remove unused dependencies by @synoet in https://github.com/macro-inc/macro/pull/2174
+* fix(ci): Max concurrent typegen by @evanhutnik in https://github.com/macro-inc/macro/pull/2177
+* chore(ci): update coderabbit config by @synoet in https://github.com/macro-inc/macro/pull/2179
+* feat(email): Block sender frontend + backend improvements by @evanhutnik in https://github.com/macro-inc/macro/pull/2156
+* chore(ci): remove claude workflow by @synoet in https://github.com/macro-inc/macro/pull/2181
+* fix[soup]: allow multiple inbox fiters to be applied by @peterchinman in https://github.com/macro-inc/macro/pull/2180
+* feat(search): add task subtype to opensearch by @gbirman in https://github.com/macro-inc/macro/pull/2183
+* feat(dss): add more comment notification types by @seanaye in https://github.com/macro-inc/macro/pull/2170
+* fix(soup): hide disabled context menu items by @evanhutnik in https://github.com/macro-inc/macro/pull/2185
+* fix(analytics): same hotkey events firing too often by @dev-rb in https://github.com/macro-inc/macro/pull/2186
+* chore: remove jwt from RequestContext by @ehayes2000 in https://github.com/macro-inc/macro/pull/2118
+* fix(new-channels): properly handle deleted message updates by @synoet in https://github.com/macro-inc/macro/pull/2188
+* feat[mobile]: good soup entity layouts on mobile by @peterchinman in https://github.com/macro-inc/macro/pull/2173
+* feat(growth): signup flow changes by @sedson in https://github.com/macro-inc/macro/pull/2187
+* fix(analytics): prevent posthog capture of certain elements by @dev-rb in https://github.com/macro-inc/macro/pull/2191
+* todo(onboarding): actually send refer email addresses by @sedson in https://github.com/macro-inc/macro/pull/2193
+* style(preview): restyle popup preview by @sedson in https://github.com/macro-inc/macro/pull/2195
+* feat(new-channels): reaction ordering + tooltip by @synoet in https://github.com/macro-inc/macro/pull/2192
+* feat(new-channels): nit styling improvements by @synoet in https://github.com/macro-inc/macro/pull/2194
+* fix(new-channels): remove persistence for thread-replies by @synoet in https://github.com/macro-inc/macro/pull/2197
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.3.24.2...v2026.3.25.0
+    </Update>
+
+    <Update label="v2026.3.24.2">
+## What's Changed
+* fix: extensionsless key upload problems by @gbirman in https://github.com/macro-inc/macro/pull/2159
+* feat(new-chanenls): remove raf, lower buffer by @synoet in https://github.com/macro-inc/macro/pull/2162
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.3.24.1...v2026.3.24.2
+    </Update>
+
+    <Update label="v2026.3.24.1">
+## What's Changed
+* perf(soup): Shared thread query performance by @evanhutnik in https://github.com/macro-inc/macro/pull/2139
+* Add IP-based rate limiting for referral invites by @seanaye in https://github.com/macro-inc/macro/pull/2106
+* cleanup old notifs by @seanaye in https://github.com/macro-inc/macro/pull/2132
+* Revert "chg(new-chanenls): temp disable overide" by @synoet in https://github.com/macro-inc/macro/pull/2138
+* fix(fusionauth): template by @whutchinson98 in https://github.com/macro-inc/macro/pull/2140
+* fix: use graphemes for counting item name lengths by @whutchinson98 in https://github.com/macro-inc/macro/pull/2141
+* fix(analytics): page view events capturing unnecessary data by @dev-rb in https://github.com/macro-inc/macro/pull/2134
+* chore(search): allow explicit index true by @gbirman in https://github.com/macro-inc/macro/pull/2144
+* fix[tauri]: ability to actually log out of mobile app by @peterchinman in https://github.com/macro-inc/macro/pull/2145
+* update package json by @seanaye in https://github.com/macro-inc/macro/pull/2149
+* feat(referral): template the real email by @seanaye in https://github.com/macro-inc/macro/pull/2147
+* feat(ai): memory by @ehayes2000 in https://github.com/macro-inc/macro/pull/2127
+* feat(icon): Update share icon by @aidanhb in https://github.com/macro-inc/macro/pull/2152
+* fix(email): improve mobile email rendering — scale wide HTML, tighten spacing by @evanhutnik in https://github.com/macro-inc/macro/pull/2146
+* feat(notif): dont send on no account by @seanaye in https://github.com/macro-inc/macro/pull/2151
+* fix(core-md): fix mentions plugin callback inconsitencies and add tests by @sedson in https://github.com/macro-inc/macro/pull/2153
+* feat: team channels by @whutchinson98 in https://github.com/macro-inc/macro/pull/2150
+* fix(cursor): define cursor styles so it can change by @aidanhb in https://github.com/macro-inc/macro/pull/2154
+* feat: upsert/read extensionless s3 keys with legacy support by @gbirman in https://github.com/macro-inc/macro/pull/2039
+* update notification queue name by @seanaye in https://github.com/macro-inc/macro/pull/2155
+* fix(search): add doc storage url env var to upload lambda by @gbirman in https://github.com/macro-inc/macro/pull/2157
+* fix(auth): invalidations on login by @synoet in https://github.com/macro-inc/macro/pull/2107
+* chore(new-channels): item size by @synoet in https://github.com/macro-inc/macro/pull/2160
+* feat(image): Show image preview on hover over image link by @aidanhb in https://github.com/macro-inc/macro/pull/2142
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.3.23.1...v2026.3.24.1
+    </Update>
+
+    <Update label="v2026.3.23.1">
+## What's Changed
+* chg(new-chanenls): temp disable overide by @synoet in https://github.com/macro-inc/macro/pull/2136
+* chore: setup knip for dead code detection by @synoet in https://github.com/macro-inc/macro/pull/2135
+* chg: re-initialize analytics by @synoet in https://github.com/macro-inc/macro/pull/2137
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.3.23.0...v2026.3.23.1
+    </Update>
+
+    <Update label="v2026.3.23.0">
+## What's Changed
+* feat: analytics proxy worker by @dev-rb in https://github.com/macro-inc/macro/pull/1993
+* fix(analytics): user not identified if already authenticated by @dev-rb in https://github.com/macro-inc/macro/pull/2090
+* fix: adjust plural in email digest by @peterchinman in https://github.com/macro-inc/macro/pull/2092
+* chg(new-channels): gaurd isChannelReady on didInitialScroll by @synoet in https://github.com/macro-inc/macro/pull/2096
+* feat[soup-views]: hide completed tasks from assigned and created tabs by @peterchinman in https://github.com/macro-inc/macro/pull/2093
+* chore(claude): update claude md by @synoet in https://github.com/macro-inc/macro/pull/2098
+* fix(new-channels): better thread scrolling + fix data-channel-nav highlight-nav highlight issue by @synoet in https://github.com/macro-inc/macro/pull/2100
+* feat(new-channels): add G hotkey for go to bottom by @synoet in https://github.com/macro-inc/macro/pull/2099
+* fix(new-channels): prevent enter reply hotkey from triggering while editing by @synoet in https://github.com/macro-inc/macro/pull/2101
+* feat(new-channels): add backspace hotkey for delete + fix full width edit message input by @synoet in https://github.com/macro-inc/macro/pull/2102
+* fix(new-channels): prevent empty message send by @synoet in https://github.com/macro-inc/macro/pull/2103
+* fix(spltis): resizer breaking split ordering integrity on history navigation by @synoet in https://github.com/macro-inc/macro/pull/2104
+* chore(deps): bump lz4_flex from 0.11.5 to 0.11.6 in /rust/sync-service by @dependabot[bot] in https://github.com/macro-inc/macro/pull/1980
+* chore(deps): bump rustls-webpki from 0.103.9 to 0.103.10 in /rust/sync-service by @dependabot[bot] in https://github.com/macro-inc/macro/pull/2095
+* chore(deps): bump rustls-webpki from 0.103.8 to 0.103.10 in /js/app/tauri by @dependabot[bot] in https://github.com/macro-inc/macro/pull/2094
+* fix: file size name limit by @whutchinson98 in https://github.com/macro-inc/macro/pull/2109
+* style(fonts): actually use Inter, swap mono for Roboto by @sedson in https://github.com/macro-inc/macro/pull/2112
+* chore(email-service): Better logging for init and gmail client by @evanhutnik in https://github.com/macro-inc/macro/pull/2111
+* feat(core): add logout and account commands to cmd+k by @sedson in https://github.com/macro-inc/macro/pull/2115
+* feat(github): associate GitHub installation id with a team by @whutchinson98 in https://github.com/macro-inc/macro/pull/2113
+* chore: bump rustls-webpki by @seanaye in https://github.com/macro-inc/macro/pull/2108
+* refactor(gmail_client): remove explicit level attrs from tracing instruments by @evanhutnik in https://github.com/macro-inc/macro/pull/2114
+* style(sidebar): minor style tweaks by @sedson in https://github.com/macro-inc/macro/pull/2117
+* fix(properties): only update task status property when updating task status by @whutchinson98 in https://github.com/macro-inc/macro/pull/2121
+* fix(email): bypass Redis cache for Gmail token on init endpoint by @evanhutnik in https://github.com/macro-inc/macro/pull/2120
+* feat(new-channels): limit @ user mentions to participants, add back @here support by @synoet in https://github.com/macro-inc/macro/pull/2116
+* Seanaye/chore/update cargo denylist by @seanaye in https://github.com/macro-inc/macro/pull/2122
+* fix(analytics): use proxy for posthog by @dev-rb in https://github.com/macro-inc/macro/pull/2125
+* feat(channels): return attachment width/height by @synoet in https://github.com/macro-inc/macro/pull/2123
+* fix(fe): Prompts for disabled email by @evanhutnik in https://github.com/macro-inc/macro/pull/2124
+* feat(soup): add shared email thread filtering by @evanhutnik in https://github.com/macro-inc/macro/pull/2091
+* fix(sidebar): add context menu to channels widget, remove draggable by @sedson in https://github.com/macro-inc/macro/pull/2128
+* feat(ai-tools): Email tools by @evanhutnik in https://github.com/macro-inc/macro/pull/1796
+* remove unused crate by @seanaye in https://github.com/macro-inc/macro/pull/2126
+* feat(soup): collapsible view tabs with dropdown fallback by @evanhutnik in https://github.com/macro-inc/macro/pull/2133
+* feat(analytics): use new analytics events by @dev-rb in https://github.com/macro-inc/macro/pull/2105
+* feat(soup): unify email tab filters and rename Important to Signal by @evanhutnik in https://github.com/macro-inc/macro/pull/2130
+* fix(new-channels): scroll jankyness, thread stability improvements by @synoet in https://github.com/macro-inc/macro/pull/2110
+* feat(new-channels): consistent loading media sizing by @synoet in https://github.com/macro-inc/macro/pull/2129
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.3.20.0...v2026.3.23.0
+    </Update>
+
+    <Update label="v2026.3.20.0">
+## What's Changed
+* feat(auth): limit user creation based on ip by @whutchinson98 in https://github.com/macro-inc/macro/pull/2076
+* chg(login): change login styling to match onboarding by @synoet in https://github.com/macro-inc/macro/pull/2075
+* fix(posthog): feature flag not working and add enable override by @dev-rb in https://github.com/macro-inc/macro/pull/2077
+* fix[mobile]: fix channel soup truncation by @peterchinman in https://github.com/macro-inc/macro/pull/2080
+* feat(access): update useritemaccess to track the team id association for sharing by @whutchinson98 in https://github.com/macro-inc/macro/pull/2078
+* more action bumps by @whutchinson98 in https://github.com/macro-inc/macro/pull/2081
+* fix(ai): save partial response on stream error. by @ehayes2000 in https://github.com/macro-inc/macro/pull/2069
+* fix(core): fix split header crash by @sedson in https://github.com/macro-inc/macro/pull/2082
+* fix: force hitting fusionauth oauth logout endpoint on client by @whutchinson98 in https://github.com/macro-inc/macro/pull/2083
+* feat(ai): mcp server by @ehayes2000 in https://github.com/macro-inc/macro/pull/2060
+* fix: split header right styling by @peterchinman in https://github.com/macro-inc/macro/pull/2084
+* infra(mcp-server): add Pulumi.prod.yaml for prod deployment by @ehayes2000 in https://github.com/macro-inc/macro/pull/2086
+* chore: hexify dcs (chat crud) by @ehayes2000 in https://github.com/macro-inc/macro/pull/1541
+* feat(tasks): update createtask to take sharewithteam parameter by @whutchinson98 in https://github.com/macro-inc/macro/pull/2087
+* fix(channel): opening channel causes infinite loop freeze by @dev-rb in https://github.com/macro-inc/macro/pull/2079
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.3.19.1...v2026.3.20.0
+    </Update>
+
+    <Update label="v2026.3.19.1">
+## What's Changed
+* chg: channel block switch ff by @synoet in https://github.com/macro-inc/macro/pull/2074
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.3.19.0...v2026.3.19.1
+    </Update>
+
+    <Update label="v2026.3.19.0">
+## What's Changed
+* fix(soup): optimistic email archiving by @synoet in https://github.com/macro-inc/macro/pull/2038
+* feat[soup]: filter menu  by @peterchinman in https://github.com/macro-inc/macro/pull/1969
+* fix(permissions): don't use auth check to block view permissions by @synoet in https://github.com/macro-inc/macro/pull/2042
+* chg(top-bar): hide references and notifications pane when unauthed by @synoet in https://github.com/macro-inc/macro/pull/2040
+* style(sidebar): no tool tips on sidbar nav by @sedson in https://github.com/macro-inc/macro/pull/2043
+* feat(icon): add new split icon by @aidanhb in https://github.com/macro-inc/macro/pull/2049
+* feat(referral): address referral edge cases by @whutchinson98 in https://github.com/macro-inc/macro/pull/2048
+* chore(sidebar): remove unused widget file by @dev-rb in https://github.com/macro-inc/macro/pull/2050
+* feat(analytics): track stripe subscription events by @dev-rb in https://github.com/macro-inc/macro/pull/2012
+* chore(new-channels): block compatibility by @synoet in https://github.com/macro-inc/macro/pull/2052
+* feat(pricing): implement new pricing tiers by @whutchinson98 in https://github.com/macro-inc/macro/pull/2051
+* feat[sidebar]: Merge Files and Documents, add Folders by @peterchinman in https://github.com/macro-inc/macro/pull/2041
+* feat(icon): Add static calendar icon by @aidanhb in https://github.com/macro-inc/macro/pull/2053
+* feat(icon): display calendar icon on invite emails by @aidanhb in https://github.com/macro-inc/macro/pull/2056
+* fix: email digest template by @peterchinman in https://github.com/macro-inc/macro/pull/2059
+* chg(new-channels): wait for channel ready before exposing handle by @synoet in https://github.com/macro-inc/macro/pull/2061
+* fix: posthog env var access by @dev-rb in https://github.com/macro-inc/macro/pull/2057
+* Update CreateDocument tool: string content, add is_task flag by @ehayes2000 in https://github.com/macro-inc/macro/pull/2054
+* fix: image dragging bug by @peterchinman in https://github.com/macro-inc/macro/pull/2062
+* fix(ai): logging by @ehayes2000 in https://github.com/macro-inc/macro/pull/2063
+* chore(new-channels): copy paste media by @synoet in https://github.com/macro-inc/macro/pull/2055
+* chore(readme): update with new branding by @synoet in https://github.com/macro-inc/macro/pull/2067
+* feat(ai): engooden search results by @ehayes2000 in https://github.com/macro-inc/macro/pull/2066
+* feat(growth): slideshow onboarding rough outline needs polish by @sedson in https://github.com/macro-inc/macro/pull/2068
+* feat(email): add project support for email threads by @evanhutnik in https://github.com/macro-inc/macro/pull/2065
+* chg(unified-list): use backend for task filtering in list by @synoet in https://github.com/macro-inc/macro/pull/2064
+* chg: add posthog feature flag by @synoet in https://github.com/macro-inc/macro/pull/2070
+* chore: new app icons by @peterchinman in https://github.com/macro-inc/macro/pull/2071
+* feat(notif): send referral emails by @seanaye in https://github.com/macro-inc/macro/pull/2034
+* chore(analytics): add more tracing to backend by @dev-rb in https://github.com/macro-inc/macro/pull/2073
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v.2026.3.18.0...v2026.3.19.0
+    </Update>
+
+    <Update label="v2026.3.18.0">
+## What's Changed
+* fix(notif): correct the sender address by @seanaye in https://github.com/macro-inc/macro/pull/2001
+* feat(channels): add some placeholder text for new users to understand how channel creation works by @jbecke in https://github.com/macro-inc/macro/pull/1996
+* feat(tutorial): sidebar stuff, new buttons, new split button, per user feedback via linkedin by @jbecke in https://github.com/macro-inc/macro/pull/1998
+* feat(search): reduce DB pressure during email search backfills by @gbirman in https://github.com/macro-inc/macro/pull/2007
+* chore(ai): improve tracing and prompt by @ehayes2000 in https://github.com/macro-inc/macro/pull/2004
+* fix(notifs): malformed payload by @seanaye in https://github.com/macro-inc/macro/pull/2009
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.3.17.0...v2026.3.18.0
+    </Update>
+
+    <Update label="v2026.3.17.0">
+## What's Changed
+* feat[mobile]: make mobile channel soup good by @peterchinman in https://github.com/macro-inc/macro/pull/1984
+* Add shortcut badges to top sidebar navigation links by @jbecke in https://github.com/macro-inc/macro/pull/1986
+* feat(new-channels): better media sizing by @synoet in https://github.com/macro-inc/macro/pull/1987
+* update claude.md by @whutchinson98 in https://github.com/macro-inc/macro/pull/1989
+* fix: duplicate blocks opened by new split hotkey by @dev-rb in https://github.com/macro-inc/macro/pull/1990
+* feat(soup): support document sub_type filter in dynamic query by @whutchinson98 in https://github.com/macro-inc/macro/pull/1991
+* remove nullable macro_user_id by @whutchinson98 in https://github.com/macro-inc/macro/pull/1988
+* fix(icon): Update create icon, email icon, and search icon by @aidanhb in https://github.com/macro-inc/macro/pull/1896
+* Add HTML render/code toggle for code blocks by @jbecke in https://github.com/macro-inc/macro/pull/1781
+* feat(notif): enable email digest by @seanaye in https://github.com/macro-inc/macro/pull/1921
+* Update prereqs by @evanhutnik in https://github.com/macro-inc/macro/pull/1994
+* fix(notif): only incr rate limit on success by @seanaye in https://github.com/macro-inc/macro/pull/1995
+* feat(style): Adjust styling on segmented control components in soup t… by @aidanhb in https://github.com/macro-inc/macro/pull/1897
+* feat(icon): Add animated command and settings icons for sidebar by @aidanhb in https://github.com/macro-inc/macro/pull/1999
+* feat(core): add commands to menu from blocks by @sedson in https://github.com/macro-inc/macro/pull/1997
+* feat(style): Make shift key in Launcher light up on shift hold by @aidanhb in https://github.com/macro-inc/macro/pull/2000
+* fix(icon): update tauri icons by @aidanhb in https://github.com/macro-inc/macro/pull/2005
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.3.16.0...v2026.3.17.0
+    </Update>
+
+    <Update label="v2026.3.16.0">
+## What's Changed
+* chore(new-channels): remove render icon helper by @synoet in https://github.com/macro-inc/macro/pull/1933
+* feat: create new emails index by @gbirman in https://github.com/macro-inc/macro/pull/1935
+* chore: readd release db migrator by @whutchinson98 in https://github.com/macro-inc/macro/pull/1937
+* style(core): remove op sizing on body by @sedson in https://github.com/macro-inc/macro/pull/1938
+* chore(new-channels): clean up input composition by @synoet in https://github.com/macro-inc/macro/pull/1934
+* feat: improve SPS backfill performance by @gbirman in https://github.com/macro-inc/macro/pull/1936
+* fix(soup): fix display name reactivity in notificaiton stacks by @sedson in https://github.com/macro-inc/macro/pull/1939
+* feat: add new app analytics provider by @dev-rb in https://github.com/macro-inc/macro/pull/1864
+* chore(search): remove dead code + add opensearch client example by @gbirman in https://github.com/macro-inc/macro/pull/1942
+* Russell/stable sidebar by @Fake-User in https://github.com/macro-inc/macro/pull/1943
+* Fix sidebar toggle hotkey when editor input is focused by @jbecke in https://github.com/macro-inc/macro/pull/1944
+* style(ui): add new (better) button variants from sidebar buttons to core ui button by @sedson in https://github.com/macro-inc/macro/pull/1940
+* fix: email notifications not marked as read after opening email by @dev-rb in https://github.com/macro-inc/macro/pull/1946
+* fix[email]: remove paywall to send email by @peterchinman in https://github.com/macro-inc/macro/pull/1947
+* fix[mobile]: hide sidebar by @peterchinman in https://github.com/macro-inc/macro/pull/1948
+* style(sidebar): move sidbar toggle btn back to top by @sedson in https://github.com/macro-inc/macro/pull/1949
+* style(sidebar): improve transition by @sedson in https://github.com/macro-inc/macro/pull/1952
+* refactor(soup): clean up soup filters and configs by @dev-rb in https://github.com/macro-inc/macro/pull/1892
+* fix[new-channels]: message spacing by @peterchinman in https://github.com/macro-inc/macro/pull/1950
+* feat(search): very basic email multi term by @gbirman in https://github.com/macro-inc/macro/pull/1951
+* feat(search): make search input full width + use slash to focus search in search view by @gbirman in https://github.com/macro-inc/macro/pull/1953
+* Revert "feat(search): make search input full width + use slash to focus search in search view" by @gbirman in https://github.com/macro-inc/macro/pull/1954
+* chore(deps): bump quinn-proto from 0.11.13 to 0.11.14 in /js/app/tauri by @dependabot[bot] in https://github.com/macro-inc/macro/pull/1884
+* chore(deps): bump rollup from 4.34.9 to 4.59.0 in /rust/sync-service by @dependabot[bot] in https://github.com/macro-inc/macro/pull/1724
+* chore(deps): bump quinn-proto from 0.11.9 to 0.11.14 in /rust/cloud-storage by @dependabot[bot] in https://github.com/macro-inc/macro/pull/1885
+* chore: bump package versions for dependabot by @whutchinson98 in https://github.com/macro-inc/macro/pull/1957
+* chg(new-channels): disable persistence for new-channels by @synoet in https://github.com/macro-inc/macro/pull/1956
+* dependabot skill by @whutchinson98 in https://github.com/macro-inc/macro/pull/1959
+* basic smoke test runner by @whutchinson98 in https://github.com/macro-inc/macro/pull/1958
+* record attachment info on message by @ehayes2000 in https://github.com/macro-inc/macro/pull/1960
+* style(md): better button and spacing in the md popup formatter by @sedson in https://github.com/macro-inc/macro/pull/1961
+* style(command): category tabs match split top tabs by @sedson in https://github.com/macro-inc/macro/pull/1965
+* fix(soup): weird toggle with shift+j/k at list boundaries by @sedson in https://github.com/macro-inc/macro/pull/1967
+* feat(search): add since and target index overrides for SPS backfill by @gbirman in https://github.com/macro-inc/macro/pull/1963
+* properties literal by @whutchinson98 in https://github.com/macro-inc/macro/pull/1966
+* fix(search): highlight sender names derived from email local part by @gbirman in https://github.com/macro-inc/macro/pull/1970
+* fix(email): Mobile scheduled send by @evanhutnik in https://github.com/macro-inc/macro/pull/1972
+* fix: add ref counting to tracking by @ehayes2000 in https://github.com/macro-inc/macro/pull/1971
+* fix[new-channel]: alignment by @peterchinman in https://github.com/macro-inc/macro/pull/1955
+* fix(email): Saving blank drafts by @evanhutnik in https://github.com/macro-inc/macro/pull/1973
+* rename on send from chat by @ehayes2000 in https://github.com/macro-inc/macro/pull/1962
+* fix(ai): permissive date parsing by @ehayes2000 in https://github.com/macro-inc/macro/pull/1968
+* fix(stream): stream subscription logic by @ehayes2000 in https://github.com/macro-inc/macro/pull/1976
+* feat(search): improve keyword windowing by @gbirman in https://github.com/macro-inc/macro/pull/1977
+* fix(email): exclude trashed messages from importance filter and use inbox emailView for signal/noise by @evanhutnik in https://github.com/macro-inc/macro/pull/1975
+* feat(sidebar): hotkey tooltips for links, replace \<a> with \<btn> by @sedson in https://github.com/macro-inc/macro/pull/1974
+* fix(ai): fix task link to md by @sedson in https://github.com/macro-inc/macro/pull/1979
+* Fix notification-triggered search reloads and sidebar flicker by @gbirman in https://github.com/macro-inc/macro/pull/1981
+* fix(email): Apply labels to drafts by @evanhutnik in https://github.com/macro-inc/macro/pull/1983
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.3.12.0...v2026.3.16.0
+    </Update>
+
+    <Update label="v2026.3.12.0">
+## What's Changed
+* fix[mobile]: refresh apns token if needed by @peterchinman in https://github.com/macro-inc/macro/pull/1898
+* feat(new-channels): collapsing consecutive messages by @synoet in https://github.com/macro-inc/macro/pull/1905
+* fix: limit bash tool rendered output by @ehayes2000 in https://github.com/macro-inc/macro/pull/1827
+* tool(email): Reverse sfs mappings by @evanhutnik in https://github.com/macro-inc/macro/pull/1909
+* fix[mobile]: hide dock when not authed by @peterchinman in https://github.com/macro-inc/macro/pull/1908
+* refactor(connection_gateway): use single redis connection by @whutchinson98 in https://github.com/macro-inc/macro/pull/1912
+* perf(search): make a separate table to speed up email contact search by @gbirman in https://github.com/macro-inc/macro/pull/1913
+* feat(teams): hexify teams crate by @whutchinson98 in https://github.com/macro-inc/macro/pull/1911
+* feat(list): tab and number key shortcuts for soup view tab groups by @sedson in https://github.com/macro-inc/macro/pull/1914
+* feat(search): index reply-to and email contact names in opensearch by @gbirman in https://github.com/macro-inc/macro/pull/1916
+* style(email): Improved draft saving experience by @evanhutnik in https://github.com/macro-inc/macro/pull/1917
+* refactor(documents): move create_task to documents crate by @whutchinson98 in https://github.com/macro-inc/macro/pull/1918
+* chore(claude): update claude.md to remove schema.prisma references by @whutchinson98 in https://github.com/macro-inc/macro/pull/1920
+* fix(email-reverse-sfs): Improve performance of tool by @evanhutnik in https://github.com/macro-inc/macro/pull/1919
+* feat[channels]: mark messages seen on mount by @peterchinman in https://github.com/macro-inc/macro/pull/1904
+* feat(email): Drag and drop recipients in compose by @evanhutnik in https://github.com/macro-inc/macro/pull/1910
+* feat(tasks): share tasks with team by @whutchinson98 in https://github.com/macro-inc/macro/pull/1923
+* feat(splits): hide close on single split, chg history behavior for common operations by @sedson in https://github.com/macro-inc/macro/pull/1922
+* fix(sidebar): no draggable on links by @sedson in https://github.com/macro-inc/macro/pull/1915
+* fix(email): Keep file type suffix on draft attachments by @evanhutnik in https://github.com/macro-inc/macro/pull/1924
+* chore: import openserach query builder + update deps by @gbirman in https://github.com/macro-inc/macro/pull/1925
+* feat(app): Local/dev tab title prefix by @evanhutnik in https://github.com/macro-inc/macro/pull/1926
+* chore: update openserach query builder as a workspace crate by @gbirman in https://github.com/macro-inc/macro/pull/1927
+* feat(new-channels): ability to edit messages + better composition by @synoet in https://github.com/macro-inc/macro/pull/1907
+* chore(email-db-client): Better logging by @evanhutnik in https://github.com/macro-inc/macro/pull/1929
+* feat(new-channels): sticky scrolling on new message by @synoet in https://github.com/macro-inc/macro/pull/1928
+* feat[new channels]: highlight new message rails by @peterchinman in https://github.com/macro-inc/macro/pull/1930
+* fix(channels): optimistic static attachments duplication by @synoet in https://github.com/macro-inc/macro/pull/1931
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.3.11.0...v2026.3.12.0
+    </Update>
+
+    <Update label="v2026.3.11.0">
+## What's Changed
+* remove delete document worker by @whutchinson98 in https://github.com/macro-inc/macro/pull/1883
+* bump mobile version numbers by @peterchinman in https://github.com/macro-inc/macro/pull/1881
+* fix: not able to create duplicate block splits with hotkey by @dev-rb in https://github.com/macro-inc/macro/pull/1886
+* style(settings): temp style settings fixes by @sedson in https://github.com/macro-inc/macro/pull/1874
+* chore: bump axum by @seanaye in https://github.com/macro-inc/macro/pull/1839
+* feat(email): User card on email sender/recipient hover by @evanhutnik in https://github.com/macro-inc/macro/pull/1888
+* fix(email): Too many sfs logs by @evanhutnik in https://github.com/macro-inc/macro/pull/1889
+* chore(email-service): Disable sfs mapping in prod for email backfill by @evanhutnik in https://github.com/macro-inc/macro/pull/1890
+* style(core): remove optical sizing by @sedson in https://github.com/macro-inc/macro/pull/1891
+* feat(email-service): Block users by @evanhutnik in https://github.com/macro-inc/macro/pull/1114
+* perf(search): materialized table for speed improvement by @gbirman in https://github.com/macro-inc/macro/pull/1899
+* chore(email): Enable proxy in FE by @evanhutnik in https://github.com/macro-inc/macro/pull/1900
+* fix(chat): reset scroll on emoji selector on search input change by @aidanhb in https://github.com/macro-inc/macro/pull/1887
+* chg(launcher): update launcher hot keys, make tooltip legible by @sedson in https://github.com/macro-inc/macro/pull/1901
+* fix(icons): hide animated icon tittle attr for no broswer tooltip by @sedson in https://github.com/macro-inc/macro/pull/1902
+* feat(new-channels): live updates & optimistic by @synoet in https://github.com/macro-inc/macro/pull/1877
+* chg(new-channels): remove sticky logic from the thread list by @synoet in https://github.com/macro-inc/macro/pull/1903
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.3.10.1...v2026.3.11.0
+    </Update>
+
+    <Update label="v2026.3.10.1">
+## What's Changed
+* fix: remove db job by @whutchinson98 in https://github.com/macro-inc/macro/pull/1882
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.3.10.0...v2026.3.10.1
+    </Update>
+
+    <Update label="v2026.3.10.0">
+## What's Changed
+* fix(canvas): add shallow diff to canvas node update by @sedson in https://github.com/macro-inc/macro/pull/1786
+* chore(email-service): Hexify list labels endpoint by @evanhutnik in https://github.com/macro-inc/macro/pull/1783
+* feat(github): Better tracing and event handling by @whutchinson98 in https://github.com/macro-inc/macro/pull/1787
+* chore(notif): move more stuff into notification by @seanaye in https://github.com/macro-inc/macro/pull/1778
+* chore: bump dss db connections in dev by @whutchinson98 in https://github.com/macro-inc/macro/pull/1790
+* chore(email-service): Get thread ai tool method by @evanhutnik in https://github.com/macro-inc/macro/pull/1788
+* fix(email): Show plaintext drafts by @evanhutnik in https://github.com/macro-inc/macro/pull/1792
+* get document short id call by @whutchinson98 in https://github.com/macro-inc/macro/pull/1789
+* fix(email): Invalidate thread cache on new message by @evanhutnik in https://github.com/macro-inc/macro/pull/1795
+* fix(email): Debounce times for /seen endpoint call by @evanhutnik in https://github.com/macro-inc/macro/pull/1797
+* Feat(ai): send to bg by @ehayes2000 in https://github.com/macro-inc/macro/pull/1798
+* feat(command): add global commands to upload file/folders to soup by @sedson in https://github.com/macro-inc/macro/pull/1791
+* feat(github): associate pr with task by @whutchinson98 in https://github.com/macro-inc/macro/pull/1799
+* fix(email): Draft re-appears after send by @evanhutnik in https://github.com/macro-inc/macro/pull/1800
+* fix(email): Always archive when marking as done by @evanhutnik in https://github.com/macro-inc/macro/pull/1802
+* delete eric hayes console.log by @sedson in https://github.com/macro-inc/macro/pull/1804
+* feat(tasks): copy branch name to clipboard for tasks by @sedson in https://github.com/macro-inc/macro/pull/1803
+* feat: sidebar and new soup layout by @dev-rb in https://github.com/macro-inc/macro/pull/1676
+* fix: long response times by @seanaye in https://github.com/macro-inc/macro/pull/1805
+* fix: do not upsert tasks that are not valid by @whutchinson98 in https://github.com/macro-inc/macro/pull/1808
+* fix(soup): filter and sort bugs by @dev-rb in https://github.com/macro-inc/macro/pull/1809
+* fix: add some stavation buffer time by @seanaye in https://github.com/macro-inc/macro/pull/1810
+* deploy dss for github by @whutchinson98 in https://github.com/macro-inc/macro/pull/1812
+* fix(email): Styling stuff by @evanhutnik in https://github.com/macro-inc/macro/pull/1813
+* fix(sidebar): unread channels not clickable by @dev-rb in https://github.com/macro-inc/macro/pull/1811
+* fix(notif): queue payload deserialization by @seanaye in https://github.com/macro-inc/macro/pull/1815
+* fix: mobile layout by @peterchinman in https://github.com/macro-inc/macro/pull/1818
+* fix(chat): include user name and email in AI chat instructions by @ehayes2000 in https://github.com/macro-inc/macro/pull/1817
+* fix the dss build by @seanaye in https://github.com/macro-inc/macro/pull/1819
+* fix(soup): email view not sending correct param for drafts and sent by @dev-rb in https://github.com/macro-inc/macro/pull/1821
+* feat(md): add blockquote to formatting toolbars by @sedson in https://github.com/macro-inc/macro/pull/1814
+* chore(email-service): Disable sfs map for dev/local by @evanhutnik in https://github.com/macro-inc/macro/pull/1820
+* fix(email): Recursion limit by @evanhutnik in https://github.com/macro-inc/macro/pull/1823
+* feat(ai): dss tools by @ehayes2000 in https://github.com/macro-inc/macro/pull/1801
+* fix(soup): Missing preview button and hotkey by @dev-rb in https://github.com/macro-inc/macro/pull/1824
+* fix(email): Invalidate thread cache on scheduled send by @evanhutnik in https://github.com/macro-inc/macro/pull/1825
+* fix(email): Move send button in compose view by @evanhutnik in https://github.com/macro-inc/macro/pull/1826
+* chore: isolate ConnectionGatewayClient by @whutchinson98 in https://github.com/macro-inc/macro/pull/1822
+* feat(notifications): optimistically update updated_at when notifications come in by @synoet in https://github.com/macro-inc/macro/pull/1535
+* feat(channels): new channel input by @synoet in https://github.com/macro-inc/macro/pull/1761
+* fix(ai): timeouts, prompt, throbber by @ehayes2000 in https://github.com/macro-inc/macro/pull/1828
+* chore: fix github sync pem for sops by @whutchinson98 in https://github.com/macro-inc/macro/pull/1831
+* fix: add recursion limit for all services by @whutchinson98 in https://github.com/macro-inc/macro/pull/1830
+* fix: file-folder support + basic filtering for owner in file-folder by @gbirman in https://github.com/macro-inc/macro/pull/1832
+* fix: feature flagging by @whutchinson98 in https://github.com/macro-inc/macro/pull/1833
+* fix: entity navigation indicator disappearing after navigation by @dev-rb in https://github.com/macro-inc/macro/pull/1829
+* style: update styles for soup-view and command menu segmented controls by @sedson in https://github.com/macro-inc/macro/pull/1835
+* fix(sidebar): allow opening duplicate views by @dev-rb in https://github.com/macro-inc/macro/pull/1834
+* feat(channels): make channels crate use entity access pattern by @synoet in https://github.com/macro-inc/macro/pull/1807
+* feat(icon): Add a bunch more icons, animated icons, and an icon gallery block for viewing all existing macro icons by @aidanhb in https://github.com/macro-inc/macro/pull/1806
+* style(core): make tooltips styles not inverted colors by @sedson in https://github.com/macro-inc/macro/pull/1837
+* fix: unauthenticated views not showing up by @dev-rb in https://github.com/macro-inc/macro/pull/1840
+* add get_users_by_entity to entity access service by @whutchinson98 in https://github.com/macro-inc/macro/pull/1836
+* fix: old unified list component route should redirect to inbox by @dev-rb in https://github.com/macro-inc/macro/pull/1841
+* feat: connection hex crate by @whutchinson98 in https://github.com/macro-inc/macro/pull/1842
+* feat(new-channels): add simple persistence for drafts by @synoet in https://github.com/macro-inc/macro/pull/1843
+* fix: small tauri websocket improvements by @peterchinman in https://github.com/macro-inc/macro/pull/1764
+* fix(splits): layout manager not fetching split content by @dev-rb in https://github.com/macro-inc/macro/pull/1848
+* fix(soup): virtualize combobox filter list by @dev-rb in https://github.com/macro-inc/macro/pull/1849
+* perf(search): optimize query by @gbirman in https://github.com/macro-inc/macro/pull/1851
+* feat(connection): delete document invalidation by @whutchinson98 in https://github.com/macro-inc/macro/pull/1852
+* feat(connection): add invalidation for task status update by @whutchinson98 in https://github.com/macro-inc/macro/pull/1853
+* style(core): rounded corners on splits, fix style nits, top-bar spacing by @sedson in https://github.com/macro-inc/macro/pull/1847
+* fix(sidebar): Move create and search buttons by @dev-rb in https://github.com/macro-inc/macro/pull/1816
+* fix(filters): use quick access, fix weird virtual scroll by @sedson in https://github.com/macro-inc/macro/pull/1854
+* chore(iac): update dcs min instance count by @whutchinson98 in https://github.com/macro-inc/macro/pull/1855
+* fix(sidebar): move settings and shortcuts button to bottom of sidebar by @dev-rb in https://github.com/macro-inc/macro/pull/1850
+* chore(sidebar): remove extra create button & change icon by @dev-rb in https://github.com/macro-inc/macro/pull/1860
+* fix(image_proxy_service): Hardening image fetch logic by @evanhutnik in https://github.com/macro-inc/macro/pull/1858
+* move delete_document_worker into DSS by @whutchinson98 in https://github.com/macro-inc/macro/pull/1859
+* fix(fe-proxy): Remove spaces from url by @evanhutnik in https://github.com/macro-inc/macro/pull/1862
+* feat(documents): move edit document to documents hex by @whutchinson98 in https://github.com/macro-inc/macro/pull/1857
+* feat(date-picker): Time support by @evanhutnik in https://github.com/macro-inc/macro/pull/1856
+* fix: sqs perms by @whutchinson98 in https://github.com/macro-inc/macro/pull/1865
+* fix(connection_gateway): share single Redis connection per batch by @whutchinson98 in https://github.com/macro-inc/macro/pull/1866
+* fix(notif): worker hanging by @seanaye in https://github.com/macro-inc/macro/pull/1861
+* chore(claude): allow claude to edit/write to files without permission by @whutchinson98 in https://github.com/macro-inc/macro/pull/1868
+* feat[mobile]: improve mobile dock by @peterchinman in https://github.com/macro-inc/macro/pull/1863
+* Fix lints by @evanhutnik in https://github.com/macro-inc/macro/pull/1867
+* refactor: use anyhow::bail! by @whutchinson98 in https://github.com/macro-inc/macro/pull/1869
+* feat(email): Enable scheduled send by @evanhutnik in https://github.com/macro-inc/macro/pull/1871
+* chore: bump rust toolchain by @whutchinson98 in https://github.com/macro-inc/macro/pull/1872
+* feat[mobile]: go to location from full text search results by @peterchinman in https://github.com/macro-inc/macro/pull/1870
+* style(new-layout): lots of style nits for new layout by @sedson in https://github.com/macro-inc/macro/pull/1873
+* fix(layout): hide sidebar when not authenticated by @dev-rb in https://github.com/macro-inc/macro/pull/1876
+* fix(icon): update some animated icons by @aidanhb in https://github.com/macro-inc/macro/pull/1875
+* fix[sidebar]: minor tweaks by @peterchinman in https://github.com/macro-inc/macro/pull/1878
+* feat(layout): persist sidebar state in local storage by @dev-rb in https://github.com/macro-inc/macro/pull/1879
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.3.4.0...v2026.3.10.0
+    </Update>
+
+    <Update label="v2026.3.4.0">
+## What's Changed
+* feat(ai): improve tool rendering by @ehayes2000 in https://github.com/macro-inc/macro/pull/1767
+* fix[mobile]: clean settings by @peterchinman in https://github.com/macro-inc/macro/pull/1768
+* feat(entity_access): add in `dangerously_assert_internal_user` by @whutchinson98 in https://github.com/macro-inc/macro/pull/1765
+* chore(email-service): Hexify send message endpoint by @evanhutnik in https://github.com/macro-inc/macro/pull/1766
+* chore(ai): Improve logging in stream + ai crate by @ehayes2000 in https://github.com/macro-inc/macro/pull/1771
+* chore auth service sizing by @whutchinson98 in https://github.com/macro-inc/macro/pull/1772
+* organize github crate by @whutchinson98 in https://github.com/macro-inc/macro/pull/1773
+* fix(list): move list selection on mark done if selection containes emails - regadless of view by @sedson in https://github.com/macro-inc/macro/pull/1774
+* feat(github): add document service to GithubSyncService by @whutchinson98 in https://github.com/macro-inc/macro/pull/1776
+* feat(http): add macro tower layers by @seanaye in https://github.com/macro-inc/macro/pull/1775
+* support commenting on github prs by @whutchinson98 in https://github.com/macro-inc/macro/pull/1777
+* fix(notif): filter invalid notifications instead of failing the whole query by @seanaye in https://github.com/macro-inc/macro/pull/1780
+* fix[mobile]: infinite canvas loading by @peterchinman in https://github.com/macro-inc/macro/pull/1770
+* chore(email-service): Hexify apply thread labels endpoint by @evanhutnik in https://github.com/macro-inc/macro/pull/1779
+* feat(github): sync task status from GitHub by @whutchinson98 in https://github.com/macro-inc/macro/pull/1782
+* Fix: chat names contain raw mention data by @ehayes2000 in https://github.com/macro-inc/macro/pull/1784
+* Fix: Snapshot by @ehayes2000 in https://github.com/macro-inc/macro/pull/1785
+* fix[mobile]: channel message links by @peterchinman in https://github.com/macro-inc/macro/pull/1769
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.3.3.0...v2026.3.4.0
+    </Update>
+
+    <Update label="v2026.3.3.0">
+## What's Changed
+* fix: openai key in infra by @ehayes2000 in https://github.com/macro-inc/macro/pull/1747
+* Add Business Source License 1.1 and update README contributions by @jbecke in https://github.com/macro-inc/macro/pull/1750
+* feat(github): github sync router by @whutchinson98 in https://github.com/macro-inc/macro/pull/1752
+* feat(github): webhook event parsing by @whutchinson98 in https://github.com/macro-inc/macro/pull/1753
+* fix: fusionauth version by @whutchinson98 in https://github.com/macro-inc/macro/pull/1754
+* fix(search): remove tranform using history query by @synoet in https://github.com/macro-inc/macro/pull/1755
+* chore: update jsonwebtoken to custom version to fix gty by @whutchinson98 in https://github.com/macro-inc/macro/pull/1756
+* chore(email-service): Hexify create draft endpoint by @evanhutnik in https://github.com/macro-inc/macro/pull/1757
+* feat(github): add sync_app_pem and sync_app_client_id to GithubConfig by @whutchinson98 in https://github.com/macro-inc/macro/pull/1758
+* feat(notif): render pp in ios notif by @seanaye in https://github.com/macro-inc/macro/pull/1722
+* chore(notif): delete notification service client by @seanaye in https://github.com/macro-inc/macro/pull/1759
+* rename by @ehayes2000 in https://github.com/macro-inc/macro/pull/1751
+* feat(filter): add no_assignee option to task filters by @sedson in https://github.com/macro-inc/macro/pull/1762
+* chore(github): split GitHub services by @whutchinson98 in https://github.com/macro-inc/macro/pull/1763
+* chore(entity): remove email entity type by @seanaye in https://github.com/macro-inc/macro/pull/1760
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.3.2.0...v2026.3.3.0
+    </Update>
+
+    <Update label="v2026.3.2.0">
+## What's Changed
+* tooling(notif): add digest sandbox cli by @seanaye in https://github.com/macro-inc/macro/pull/1686
+* fix: mobile notification navigation by @peterchinman in https://github.com/macro-inc/macro/pull/1708
+* chore: add granular tracing to opensearch response by @gbirman in https://github.com/macro-inc/macro/pull/1707
+* feat(github): get GitHub access token by @whutchinson98 in https://github.com/macro-inc/macro/pull/1701
+* feat(notif): email templating by @seanaye in https://github.com/macro-inc/macro/pull/1687
+* chore(dd): fix line numbers by @seanaye in https://github.com/macro-inc/macro/pull/1711
+* feat: only call refresh once at a time by @whutchinson98 in https://github.com/macro-inc/macro/pull/1710
+* feat: hardcode legacy_user_permissions has_trialed to be true by @whutchinson98 in https://github.com/macro-inc/macro/pull/1709
+* feat(notif): delete invalid notifs when listing by @seanaye in https://github.com/macro-inc/macro/pull/1702
+* feat: has trialed db support by @whutchinson98 in https://github.com/macro-inc/macro/pull/1712
+* fix: button hover styling by @peterchinman in https://github.com/macro-inc/macro/pull/1714
+* feat: ai user mentions by @ehayes2000 in https://github.com/macro-inc/macro/pull/1716
+* chore(log): increase channel logging by @seanaye in https://github.com/macro-inc/macro/pull/1715
+* fix(ai): clear notifications by @ehayes2000 in https://github.com/macro-inc/macro/pull/1718
+* image proxy service by @whutchinson98 in https://github.com/macro-inc/macro/pull/1717
+* fix: front end optimize search response handling by @gbirman in https://github.com/macro-inc/macro/pull/1723
+* fix(notif): update email template by @seanaye in https://github.com/macro-inc/macro/pull/1713
+* move resize observer into list layout provider by @gbirman in https://github.com/macro-inc/macro/pull/1725
+* feat: use image proxy service by @whutchinson98 in https://github.com/macro-inc/macro/pull/1719
+* add /v1/completions proxy by @ehayes2000 in https://github.com/macro-inc/macro/pull/1705
+* feat(image_proxy_service): only proxy image content types by @whutchinson98 in https://github.com/macro-inc/macro/pull/1726
+* fea: add user icon tool tip to email participant in soup by @gbirman in https://github.com/macro-inc/macro/pull/1728
+* feat(image_proxy_service): max content length by @whutchinson98 in https://github.com/macro-inc/macro/pull/1727
+* feat: even more search logging by @gbirman in https://github.com/macro-inc/macro/pull/1732
+* perf(search): reduce backend response payload by @gbirman in https://github.com/macro-inc/macro/pull/1734
+* fix(comms): remove internal adapter by @seanaye in https://github.com/macro-inc/macro/pull/1733
+* feat(notif): send pp url in ios notif payload by @seanaye in https://github.com/macro-inc/macro/pull/1721
+* feat(md): add MarkdownShell and fluent config builder for simple md feature sharing by @sedson in https://github.com/macro-inc/macro/pull/1704
+* chore: log token on jwt decode failure by @whutchinson98 in https://github.com/macro-inc/macro/pull/1735
+* feat: mobile topbar redesign by @peterchinman in https://github.com/macro-inc/macro/pull/1731
+* chg(canvas): use new markdown utils by @sedson in https://github.com/macro-inc/macro/pull/1738
+* fix(ai): Rename variant to expected by @ehayes2000 in https://github.com/macro-inc/macro/pull/1736
+* feat: add Satsuma theme to defaults by @peterchinman in https://github.com/macro-inc/macro/pull/1739
+* chore(email-service): Hexify get-threads endpoint by @evanhutnik in https://github.com/macro-inc/macro/pull/1737
+* Fix remote server by @evanhutnik in https://github.com/macro-inc/macro/pull/1742
+* feat(channels): channel refactor, thread/message rendering (1/n) by @synoet in https://github.com/macro-inc/macro/pull/1677
+* fix: channel drag bug by @peterchinman in https://github.com/macro-inc/macro/pull/1743
+* feat(github): basic webhook event support by @whutchinson98 in https://github.com/macro-inc/macro/pull/1741
+* chore: remove nm artifcat by @synoet in https://github.com/macro-inc/macro/pull/1746
+* fix(emails): email threads reactively showing up in soup by @synoet in https://github.com/macro-inc/macro/pull/1744
+* fix: mark done from inside blocks by @peterchinman in https://github.com/macro-inc/macro/pull/1745
+* feat(tasks): default tasks to "not started" by @sedson in https://github.com/macro-inc/macro/pull/1748
+* fix(soup): wrong notification entity type check by @synoet in https://github.com/macro-inc/macro/pull/1749
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.2.26.0...v2026.3.2.0
+    </Update>

--- a/docs/changelog/2026-04.mdx
+++ b/docs/changelog/2026-04.mdx
@@ -1,0 +1,843 @@
+---
+title: "April 2026"
+description: "Macro releases from April 2026."
+---
+
+    <Update label="v2026.4.30.0">
+## What's Changed
+* fix(search): clear In/From chip filter on X click by @gbirman in https://github.com/macro-inc/macro/pull/2933
+* fix(soup): email calendar view not loading items by @dev-rb in https://github.com/macro-inc/macro/pull/2936
+* feat(call): improve call title prompt and remove Untitled Call by @whutchinson98 in https://github.com/macro-inc/macro/pull/2937
+* fix: tool type generation by @ehayes2000 in https://github.com/macro-inc/macro/pull/2931
+* feat(ai): chat tool by @ehayes2000 in https://github.com/macro-inc/macro/pull/2925
+* fix archive s3 path by @seanaye in https://github.com/macro-inc/macro/pull/2940
+* feat(calls): custom speaker overrides by @whutchinson98 in https://github.com/macro-inc/macro/pull/2939
+* fix(mobile): mobile drawer not opening on android by @dev-rb in https://github.com/macro-inc/macro/pull/2942
+* chg(soup): remove per entity j/k navigation by @synoet in https://github.com/macro-inc/macro/pull/2941
+* refactor(sps): hexify with unified backfill surface by @gbirman in https://github.com/macro-inc/macro/pull/2875
+* fix(soup): show all task notifications in inbox signal by @gbirman in https://github.com/macro-inc/macro/pull/2944
+* chg(ai): hide topbar when in a nested block by @synoet in https://github.com/macro-inc/macro/pull/2945
+* feat(soup): add cmd+a hotkey to toggle select all by @gbirman in https://github.com/macro-inc/macro/pull/2938
+* fix(soup): selection not updated optimistically after mark as done by @dev-rb in https://github.com/macro-inc/macro/pull/2943
+* refactor(justfile): standardize DATABASE_URL to single database.justfile by @whutchinson98 in https://github.com/macro-inc/macro/pull/2948
+* chg(channels): don't return load_around for deleted message by @synoet in https://github.com/macro-inc/macro/pull/2949
+* chg(channels): adjust styling of deleted messages by @synoet in https://github.com/macro-inc/macro/pull/2950
+* fix(search): make sort dropdown opaque by @gbirman in https://github.com/macro-inc/macro/pull/2951
+* feat(md): go to location for comments by @sedson in https://github.com/macro-inc/macro/pull/2934
+* fix(infra): manage createBucket CORS via BucketCorsConfigurationV2 by @gbirman in https://github.com/macro-inc/macro/pull/2953
+* chore: bump zod to v4 by @synoet in https://github.com/macro-inc/macro/pull/2954
+* feat(calls): add participants to call tile in soup by @whutchinson98 in https://github.com/macro-inc/macro/pull/2955
+* fix(properties): assignee menu rows overlapping when searching by @gbirman in https://github.com/macro-inc/macro/pull/2952
+* fix(soup): only allow marking supported entities as done  by @dev-rb in https://github.com/macro-inc/macro/pull/2946
+* fix: ai tool gen by @synoet in https://github.com/macro-inc/macro/pull/2957
+* fix(soup): search list going blank on scroll by @dev-rb in https://github.com/macro-inc/macro/pull/2956
+* feat(search): go-to navigation for call record hits by @gbirman in https://github.com/macro-inc/macro/pull/2947
+* feat(soup): mirror channel notif stacking for doc comments by @sedson in https://github.com/macro-inc/macro/pull/2959
+* fix(search): calls filter no longer filters out calls by @gbirman in https://github.com/macro-inc/macro/pull/2961
+* feat(channel): assign @mentioned users when creating task from message by @gbirman in https://github.com/macro-inc/macro/pull/2962
+* fix(search): pass attended/speaker/importance filters to search service by @gbirman in https://github.com/macro-inc/macro/pull/2963
+* fix(search): use call record name instead of channel name by @gbirman in https://github.com/macro-inc/macro/pull/2964
+* feat(ai): new channel read tools by @synoet in https://github.com/macro-inc/macro/pull/2885
+* feat(ai): Attachment dcs, chat, ai integration by @ehayes2000 in https://github.com/macro-inc/macro/pull/2870
+* fix: custom deserialize NonEmpty by @ehayes2000 in https://github.com/macro-inc/macro/pull/2967
+* cargo feature gate applying update by @seanaye in https://github.com/macro-inc/macro/pull/2969
+* chore(calls): re add ai call summary by @whutchinson98 in https://github.com/macro-inc/macro/pull/2970
+* fix(soup): truncate long sender names and overflowing call snippets by @gbirman in https://github.com/macro-inc/macro/pull/2965
+* fix: fix typegen api by @ehayes2000 in https://github.com/macro-inc/macro/pull/2968
+* transcript delay by @whutchinson98 in https://github.com/macro-inc/macro/pull/2972
+* fix(call): better ai summary by @whutchinson98 in https://github.com/macro-inc/macro/pull/2973
+* feat(teams): change user roles by @dev-rb in https://github.com/macro-inc/macro/pull/2974
+* call notification in browser by @whutchinson98 in https://github.com/macro-inc/macro/pull/2976
+* fix[tauri]: remove auto-update toast by @peterchinman in https://github.com/macro-inc/macro/pull/2975
+* feat(ui): add layer and depth by @Fake-User in https://github.com/macro-inc/macro/pull/2977
+* fix(channels): input stretching to full width by @dev-rb in https://github.com/macro-inc/macro/pull/2979
+* feat(undo): scope mark-done undo hotkeys to soup by @gbirman in https://github.com/macro-inc/macro/pull/2983
+* fic(ui): make account panel less ugly by @Fake-User in https://github.com/macro-inc/macro/pull/2985
+* fix(notifications): toggle causes suspense trigger by @dev-rb in https://github.com/macro-inc/macro/pull/2986
+* chore(ai): entity=attachment by @ehayes2000 in https://github.com/macro-inc/macro/pull/2978
+* feat(ai): Dynamic prompt for currently open stuff by @ehayes2000 in https://github.com/macro-inc/macro/pull/2988
+* feat: kill scribe by @ehayes2000 in https://github.com/macro-inc/macro/pull/2981
+* fix(ui): more color and account fixes by @Fake-User in https://github.com/macro-inc/macro/pull/2992
+* fix(search): selected-first sort + empty-selection + focus restore for In/From filters by @gbirman in https://github.com/macro-inc/macro/pull/2991
+* fix(filters): cap active filter chip label width by @gbirman in https://github.com/macro-inc/macro/pull/2993
+* fix(style): add layer depth to floating menus and ui by @sedson in https://github.com/macro-inc/macro/pull/2990
+* rename by @Fake-User in https://github.com/macro-inc/macro/pull/2994
+* chore: kill ai_format + replace prompt attachments with attachment crate by @ehayes2000 in https://github.com/macro-inc/macro/pull/2995
+* style(layer): layer fixes by @sedson in https://github.com/macro-inc/macro/pull/2998
+* feat(md): await node for async operations by @sedson in https://github.com/macro-inc/macro/pull/2996
+* fix: migration attachment -> entity by @ehayes2000 in https://github.com/macro-inc/macro/pull/2997
+* style(layers): add layer/panel to inputs by @sedson in https://github.com/macro-inc/macro/pull/2999
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.4.28.1...v2026.4.30.0
+    </Update>
+
+    <Update label="v2026.4.28.1">
+## What's Changed
+* chore: bump version + update changelog by @synoet in https://github.com/macro-inc/macro/pull/2929
+* fix(search): make filter chip dropdowns opaque again by @gbirman in https://github.com/macro-inc/macro/pull/2932
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.4.28.0...v2026.4.28.1
+    </Update>
+
+    <Update label="v2026.4.28.0">
+## What's Changed
+* chore(vite): unify dist output by @seanaye in https://github.com/macro-inc/macro/pull/2862
+* feat(call): add tooltip to share with team button by @whutchinson98 in https://github.com/macro-inc/macro/pull/2877
+* fix(soup): navigation scroll weird on small heights by @dev-rb in https://github.com/macro-inc/macro/pull/2879
+* feat(teams): rollback on customer_repository failures by @whutchinson98 in https://github.com/macro-inc/macro/pull/2878
+* fix(mentions): fix fetch error showing email mentions as deleted by @sedson in https://github.com/macro-inc/macro/pull/2886
+* fix(teams): team invite email links to sign up not link acceptance page by @dev-rb in https://github.com/macro-inc/macro/pull/2852
+* feat(calls): blur intensity & background image support by @dev-rb in https://github.com/macro-inc/macro/pull/2880
+* feat(fe): Chat with agent button by @evanhutnik in https://github.com/macro-inc/macro/pull/2794
+* chore(ai): call records in search tools by @gbirman in https://github.com/macro-inc/macro/pull/2883
+* chore(sqlx): workspace level cache by @seanaye in https://github.com/macro-inc/macro/pull/2882
+* feat(documents): add in default task properties to ai created tasks by @whutchinson98 in https://github.com/macro-inc/macro/pull/2884
+* fix(analytics): resize observer error reporting too frequently to posthog by @dev-rb in https://github.com/macro-inc/macro/pull/2894
+* style(chat): tweak font size and user massage, fix(mentions): weird padding on doc preview by @sedson in https://github.com/macro-inc/macro/pull/2901
+* fix(channel): link wrapping for long links by @sedson in https://github.com/macro-inc/macro/pull/2902
+* style(tasks): improve style of task toast by @sedson in https://github.com/macro-inc/macro/pull/2905
+* fix(settings): panel stealing focus on splits change by @dev-rb in https://github.com/macro-inc/macro/pull/2904
+* fix(teams): hide leave button by @dev-rb in https://github.com/macro-inc/macro/pull/2906
+* chg(tasks): change order of task name, fix(chat): attachment alignment by @sedson in https://github.com/macro-inc/macro/pull/2908
+* fix(analytics): Send CompleteRegistration meta analytics event by @evanhutnik in https://github.com/macro-inc/macro/pull/2888
+* fix[mobile]: push notification dialog wasn't showing by @peterchinman in https://github.com/macro-inc/macro/pull/2903
+* fix(dev): local branch name tool by @sedson in https://github.com/macro-inc/macro/pull/2909
+* feat[mobile]: make share menu nice by @peterchinman in https://github.com/macro-inc/macro/pull/2781
+* fix[mobile]: blur channel, chat, email inputs on touch outside input by @peterchinman in https://github.com/macro-inc/macro/pull/2910
+* feat[toasts]: instead of queueing, remove oldest toasts by @peterchinman in https://github.com/macro-inc/macro/pull/2899
+* fix(ui): make appearance editor more cohesive by @Fake-User in https://github.com/macro-inc/macro/pull/2897
+* fix[mobile]: first page splash nits by @peterchinman in https://github.com/macro-inc/macro/pull/2889
+* fix[channels]: top bar squish by @peterchinman in https://github.com/macro-inc/macro/pull/2907
+* feat(soup): resize preview by @sedson in https://github.com/macro-inc/macro/pull/2912
+* fix: simple dropdown menu breaking app by @peterchinman in https://github.com/macro-inc/macro/pull/2914
+* fix(teams): tier changes not giving proper feedback by @dev-rb in https://github.com/macro-inc/macro/pull/2913
+* fix[channel]: on mobile no select messages by @peterchinman in https://github.com/macro-inc/macro/pull/2911
+* fix[tauri]: paste macro links by @peterchinman in https://github.com/macro-inc/macro/pull/2915
+* feat(call): call custom name by @whutchinson98 in https://github.com/macro-inc/macro/pull/2891
+* fix(local): make urls dns valid, add notification ingress env var by @synoet in https://github.com/macro-inc/macro/pull/2916
+* fix(call): use entity access for soup query by @whutchinson98 in https://github.com/macro-inc/macro/pull/2917
+* feat(soup): migrate to AST filters & use filters for all supported filter options by @dev-rb in https://github.com/macro-inc/macro/pull/2639
+* fix(search): clear sub-filter caches when resetting to tab defaults by @gbirman in https://github.com/macro-inc/macro/pull/2900
+* refactor(calls): consolidate call entity taxonomy on 'call' by @gbirman in https://github.com/macro-inc/macro/pull/2895
+* feat: add static entity by @ehayes2000 in https://github.com/macro-inc/macro/pull/2887
+* fix(search): hide redundant show-more for singleton hits by @gbirman in https://github.com/macro-inc/macro/pull/2892
+* fix(call): improve mic noise suppression by @whutchinson98 in https://github.com/macro-inc/macro/pull/2918
+* feat(soup): add date ast filters by @seanaye in https://github.com/macro-inc/macro/pull/2893
+* feat(sidebar): mark channels as done or read from sidebar ctx menu by @sedson in https://github.com/macro-inc/macro/pull/2919
+* update ast field name mapping by @seanaye in https://github.com/macro-inc/macro/pull/2922
+* feat(ui): add layers utility by @Fake-User in https://github.com/macro-inc/macro/pull/2923
+* fix[tauri]: tasks and docs not loading by @peterchinman in https://github.com/macro-inc/macro/pull/2921
+* chore: global video calling - WIP by @gacers in https://github.com/macro-inc/macro/pull/2703
+* feat(kommand): rank command items by recency by @gbirman in https://github.com/macro-inc/macro/pull/2926
+* fix: missing document color by @dev-rb in https://github.com/macro-inc/macro/pull/2928
+* fix(soup): items not updating optimistically by @dev-rb in https://github.com/macro-inc/macro/pull/2927
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.4.24.1...v2026.4.28.0
+    </Update>
+
+    <Update label="v2026.4.24.1">
+## What's Changed
+* fix(ui): upgrade tailwind syntax by @Fake-User in https://github.com/macro-inc/macro/pull/2851
+* feat(channels): seperate pagination for static vs dss attachment by @synoet in https://github.com/macro-inc/macro/pull/2830
+* fix(team): require write stripe subscription on team create by @whutchinson98 in https://github.com/macro-inc/macro/pull/2854
+* bump tauri by @seanaye in https://github.com/macro-inc/macro/pull/2823
+* fix(soup): keep chat input mounted when preview opens by @gbirman in https://github.com/macro-inc/macro/pull/2856
+* chg(infra): cors allow preview by @synoet in https://github.com/macro-inc/macro/pull/2857
+* feat(teams): allow patching team user role by @whutchinson98 in https://github.com/macro-inc/macro/pull/2855
+* feat(mcp): cors headers, de-auth preflight by @ehayes2000 in https://github.com/macro-inc/macro/pull/2644
+* feat(teams): accept and reject team invitations in settings by @dev-rb in https://github.com/macro-inc/macro/pull/2840
+* feat(teams): invite link page by @dev-rb in https://github.com/macro-inc/macro/pull/2849
+* feat(tauri): autoupdate on app resume by @seanaye in https://github.com/macro-inc/macro/pull/2822
+* feat(channels): add support for notification filtering on channel message by @synoet in https://github.com/macro-inc/macro/pull/2858
+* chore(deps): bump rustls-webpki from 0.103.10 to 0.103.13 in /rust/sync-service by @dependabot[bot] in https://github.com/macro-inc/macro/pull/2844
+* chore(deps): bump postcss from 8.5.3 to 8.5.10 in /rust/sync-service by @dependabot[bot] in https://github.com/macro-inc/macro/pull/2850
+* fix(ui): panel by @Fake-User in https://github.com/macro-inc/macro/pull/2863
+* fix(ai): Scheduled prompt by @ehayes2000 in https://github.com/macro-inc/macro/pull/2860
+* fix(ui): kill roundpanel by @Fake-User in https://github.com/macro-inc/macro/pull/2866
+* fix(mcp): handle upstream oauth errors in callback by @ehayes2000 in https://github.com/macro-inc/macro/pull/2865
+* fix[channel]: message outline styling by @peterchinman in https://github.com/macro-inc/macro/pull/2864
+* fix(ui): cleanup by @Fake-User in https://github.com/macro-inc/macro/pull/2868
+* feat(ai): Attachment infra by @ehayes2000 in https://github.com/macro-inc/macro/pull/2809
+* feat(search): support call records in search by @gbirman in https://github.com/macro-inc/macro/pull/2816
+* feat(mentions): calls in mentions, mention loading improvements, optimisitic preview on create by @sedson in https://github.com/macro-inc/macro/pull/2867
+* fix(soup): restore focus on mark-done undo by @gbirman in https://github.com/macro-inc/macro/pull/2871
+* fix(tasks): no delete prop btn in composer by @sedson in https://github.com/macro-inc/macro/pull/2873
+* fix(search): anchor In/From filter submenus to their row by @gbirman in https://github.com/macro-inc/macro/pull/2874
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.4.24.0...v2026.4.24.1
+    </Update>
+
+    <Update label="v2026.4.24.0">
+## What's Changed
+* chore: bump version + update changelog by @synoet in https://github.com/macro-inc/macro/pull/2824
+* fix(channel): media viewer showing navigation for single item by @dev-rb in https://github.com/macro-inc/macro/pull/2825
+* feat(icon): Add custom video call icons by @aidanhb in https://github.com/macro-inc/macro/pull/2826
+* fix(icon): make task status icons a little bigger by @aidanhb in https://github.com/macro-inc/macro/pull/2827
+* chore(cf): bump worker version by @synoet in https://github.com/macro-inc/macro/pull/2831
+* feat(email): add calendar_only filter and Calendar tab by @evanhutnik in https://github.com/macro-inc/macro/pull/2820
+* feat(call): enforce single join by @whutchinson98 in https://github.com/macro-inc/macro/pull/2832
+* feat(sfs): image optimizer lambda + infra by @ehayes2000 in https://github.com/macro-inc/macro/pull/2833
+* Drop unused email search database artifacts by @gbirman in https://github.com/macro-inc/macro/pull/2598
+* fix(ui): kill style={``} by @Fake-User in https://github.com/macro-inc/macro/pull/2834
+* feat(call): batch preview endpoint by @whutchinson98 in https://github.com/macro-inc/macro/pull/2835
+* feat(call): fix noise suppression by @whutchinson98 in https://github.com/macro-inc/macro/pull/2837
+* fix(ui): silence tailwind warnings by @Fake-User in https://github.com/macro-inc/macro/pull/2836
+* feat(ai): create-tool skill by @ehayes2000 in https://github.com/macro-inc/macro/pull/2839
+* feat: pfp + channel preview downscaling by @ehayes2000 in https://github.com/macro-inc/macro/pull/2651
+* fix(ui): frontend pruning by @Fake-User in https://github.com/macro-inc/macro/pull/2842
+* feat(run_local): running local performance optimizations by @synoet in https://github.com/macro-inc/macro/pull/2829
+* fix(ui): sidebr hr colors by @Fake-User in https://github.com/macro-inc/macro/pull/2843
+* fix(soup): missing call exclusion query filters by @dev-rb in https://github.com/macro-inc/macro/pull/2847
+* feat(call): speaker diarization by @whutchinson98 in https://github.com/macro-inc/macro/pull/2846
+* feat(call): ai summary by @whutchinson98 in https://github.com/macro-inc/macro/pull/2848
+* feat(ai): subagents by @ehayes2000 in https://github.com/macro-inc/macro/pull/2838
+* fix(ui): keep filter search input focused when submenu is open by @gbirman in https://github.com/macro-inc/macro/pull/2841
+* fix(channels): load_around_message_id returning previous_cursor when it shouldn't by @synoet in https://github.com/macro-inc/macro/pull/2853
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.4.23.0...v2026.4.24.0
+    </Update>
+
+    <Update label="v2026.4.23.0">
+## What's Changed
+* fix(tasks): various task routing bugs by @sedson in https://github.com/macro-inc/macro/pull/2782
+* fix(properties/tools): add user to accepted types by @sedson in https://github.com/macro-inc/macro/pull/2770
+* fix(core): kill split modal, use entity edit modal for operations by @sedson in https://github.com/macro-inc/macro/pull/2784
+* fix(update): wrong url by @seanaye in https://github.com/macro-inc/macro/pull/2786
+* feat(call): update required access level for calls by @whutchinson98 in https://github.com/macro-inc/macro/pull/2785
+* feat(call): share with team toggle by @whutchinson98 in https://github.com/macro-inc/macro/pull/2787
+* fix(settings): propper settings view on mobile by @Fake-User in https://github.com/macro-inc/macro/pull/2790
+* fix(sidebar): remove icon color transition by @Fake-User in https://github.com/macro-inc/macro/pull/2792
+* fix(split-layout): skip search bar on H/L focus restoration by @gbirman in https://github.com/macro-inc/macro/pull/2791
+* fix(vite): make read git branch call async by @aidanhb in https://github.com/macro-inc/macro/pull/2793
+* fix(theme): kill unused signals by @Fake-User in https://github.com/macro-inc/macro/pull/2795
+* feat(comms): trigger notif deletes on soft delete by @seanaye in https://github.com/macro-inc/macro/pull/2789
+* fix(channels): patch message take new attachments by @synoet in https://github.com/macro-inc/macro/pull/2783
+* feat(call): call video blur by @whutchinson98 in https://github.com/macro-inc/macro/pull/2788
+* fix(local): running locally audience and env vars by @synoet in https://github.com/macro-inc/macro/pull/2797
+* feat(teams): client methods, queries, and mutations by @dev-rb in https://github.com/macro-inc/macro/pull/2798
+* fix(documents): ai cant see comments on tasks by @whutchinson98 in https://github.com/macro-inc/macro/pull/2796
+* chore(notifications): use uuids for notification sandbox by @gbirman in https://github.com/macro-inc/macro/pull/2800
+* chore(soup): reduce mark done toast duration to 3s by @gbirman in https://github.com/macro-inc/macro/pull/2801
+* feat(notif): index chan notifs on msg id by @seanaye in https://github.com/macro-inc/macro/pull/2799
+* fix: internal image dragging by @peterchinman in https://github.com/macro-inc/macro/pull/2803
+* Russell/no more gamer core by @Fake-User in https://github.com/macro-inc/macro/pull/2805
+* feat(call): ai toolset by @whutchinson98 in https://github.com/macro-inc/macro/pull/2802
+* Aidan/icon call by @aidanhb in https://github.com/macro-inc/macro/pull/2806
+* fix(ui): fix settings tabs being in wrong location on desktop. by @Fake-User in https://github.com/macro-inc/macro/pull/2807
+* fix(ci): correct code path for mcp service by @whutchinson98 in https://github.com/macro-inc/macro/pull/2808
+* fix(zed/conf): add zed conf to unchud biome by @sedson in https://github.com/macro-inc/macro/pull/2810
+* feat[tauri]: only auto-download update on wifi by @peterchinman in https://github.com/macro-inc/macro/pull/2812
+* feat(analytics): fire valued Lead on every conversion path by @evanhutnik in https://github.com/macro-inc/macro/pull/2813
+* fix(channels): prevent optimistic inserts mid page by @synoet in https://github.com/macro-inc/macro/pull/2814
+* feat(lexical-service): Extract images by @ehayes2000 in https://github.com/macro-inc/macro/pull/2726
+* feat(teams): onboarding step for creating team and inviting members by @dev-rb in https://github.com/macro-inc/macro/pull/2811
+* feat(teams): team tab in settings by @dev-rb in https://github.com/macro-inc/macro/pull/2804
+* fix(ui): replace all class={``} with cn() or class="" by @Fake-User in https://github.com/macro-inc/macro/pull/2818
+* Add panel colored shapes behind shuttle icons in all arcana by @aidanhb in https://github.com/macro-inc/macro/pull/2817
+* fix(ui): dechud theme list by @Fake-User in https://github.com/macro-inc/macro/pull/2821
+* feat!(agent/slop): ability to copy prompt and open in agent from task by @synoet in https://github.com/macro-inc/macro/pull/2815
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.4.22.1...v2026.4.23.0
+    </Update>
+
+    <Update label="v2026.4.22.1">
+## What's Changed
+* fix(search): prefix-match text fields for email search by @gbirman in https://github.com/macro-inc/macro/pull/2778
+* feat(undo): bind cmd+z / shift+cmd+z to the mutation undo stack by @gbirman in https://github.com/macro-inc/macro/pull/2714
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.4.22.0...v2026.4.22.1
+    </Update>
+
+    <Update label="v2026.4.22.0">
+## What's Changed
+* feat(db): prepare db for version bump by @whutchinson98 in https://github.com/macro-inc/macro/pull/2748
+* fix(sfs): pass file_id instead of s3 key to mark_uploaded by @ehayes2000 in https://github.com/macro-inc/macro/pull/2738
+* feat(call): improve call transcription by @whutchinson98 in https://github.com/macro-inc/macro/pull/2751
+* chore(channels): remove old unused deprecated components by @synoet in https://github.com/macro-inc/macro/pull/2752
+* feat: qr code for app store in onboarding and settings by @peterchinman in https://github.com/macro-inc/macro/pull/2753
+* feat(db): add new parameter group for db version update by @whutchinson98 in https://github.com/macro-inc/macro/pull/2750
+* Russell/split by @Fake-User in https://github.com/macro-inc/macro/pull/2754
+* feat: undo mark-as-done + notification refetch cleanup by @gbirman in https://github.com/macro-inc/macro/pull/2701
+* feat(task): notify assignees of comments by @seanaye in https://github.com/macro-inc/macro/pull/2749
+* fix(notif): filter out browser notif for new email by @seanaye in https://github.com/macro-inc/macro/pull/2756
+* fix(channels): stop escape from bubbling from close mentions menu by @sedson in https://github.com/macro-inc/macro/pull/2757
+* chore(channels): migrate all consumers to new markdown builder by @synoet in https://github.com/macro-inc/macro/pull/2755
+* chore(lexical-service): decrust by @ehayes2000 in https://github.com/macro-inc/macro/pull/2723
+* feat(channels/documents): Stanalone channel thread + Full reactive thread in document cards by @synoet in https://github.com/macro-inc/macro/pull/2734
+* fix(channels): don't serialize or deserialize pending attachments by @synoet in https://github.com/macro-inc/macro/pull/2761
+* feat[ios]: dialog prompting push notification permission by @peterchinman in https://github.com/macro-inc/macro/pull/2760
+* chore: move onboarding qr code to launch screen by @peterchinman in https://github.com/macro-inc/macro/pull/2762
+* feat(tasks): new icons and colors by @dev-rb in https://github.com/macro-inc/macro/pull/2759
+* fix(share): tab + enter on share button crashing the app by @synoet in https://github.com/macro-inc/macro/pull/2767
+* chore: gate onboarding qr code behind feature flag by @peterchinman in https://github.com/macro-inc/macro/pull/2769
+* fix(soup): first entity not always focused on load by @dev-rb in https://github.com/macro-inc/macro/pull/2771
+* feat(dev): add hotkey debugger by @sedson in https://github.com/macro-inc/macro/pull/2768
+* fix(ci): pin zod, remove patch by @ehayes2000 in https://github.com/macro-inc/macro/pull/2772
+* chore: dry up preview registration in DocumentCard by @gbirman in https://github.com/macro-inc/macro/pull/2774
+* feat: cal.com webhook → Meta Lead events by @evanhutnik in https://github.com/macro-inc/macro/pull/2764
+* chore(channels): fully remove deprecated components by @synoet in https://github.com/macro-inc/macro/pull/2776
+* fix: vite resolve by @ehayes2000 in https://github.com/macro-inc/macro/pull/2779
+* feat(dev): add a local-only bottom bar that shows current branch by @sedson in https://github.com/macro-inc/macro/pull/2763
+* fix(ai): paywall free users by @ehayes2000 in https://github.com/macro-inc/macro/pull/2765
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.4.21.3...v2026.4.22.0
+    </Update>
+
+    <Update label="v2026.4.21.3">
+## What's Changed
+* chore: bump version + update changelog by @synoet in https://github.com/macro-inc/macro/pull/2746
+* fix entity access by @whutchinson98 in https://github.com/macro-inc/macro/pull/2747
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.4.21.2...v2026.4.21.3
+    </Update>
+
+    <Update label="v2026.4.21.2">
+## What's Changed
+* feat(calls): unattended call filter by @whutchinson98 in https://github.com/macro-inc/macro/pull/2715
+* feat entity access by @whutchinson98 in https://github.com/macro-inc/macro/pull/2418
+* feat(icon): update icons in message action menu by @aidanhb in https://github.com/macro-inc/macro/pull/2601
+* fix(favicon): make favicon badge a0 instead of a1 by @aidanhb in https://github.com/macro-inc/macro/pull/2717
+* feat(sync): exists should use head instead of get by @synoet in https://github.com/macro-inc/macro/pull/2716
+* fix(call): unattended/attended banner in all view by @whutchinson98 in https://github.com/macro-inc/macro/pull/2719
+* fix(mentions): use interleaved fresh search for mobile mentions by @sedson in https://github.com/macro-inc/macro/pull/2718
+* fix(entity_access): channel share by @whutchinson98 in https://github.com/macro-inc/macro/pull/2721
+* feat(call): share/unshare with team in edit call by @whutchinson98 in https://github.com/macro-inc/macro/pull/2722
+* fix[channels]: duplicate hover action menu by @peterchinman in https://github.com/macro-inc/macro/pull/2724
+* feat(onboarding): refine sidebar glow, lesson flow, and editor interactions by @evanhutnik in https://github.com/macro-inc/macro/pull/2725
+* feat(onboarding): fire subscription_success for free-tier selection by @evanhutnik in https://github.com/macro-inc/macro/pull/2727
+* feat(channels): support message_ids filter in get_channel_messages by @synoet in https://github.com/macro-inc/macro/pull/2708
+* feat(icon): add custom phone icon by @aidanhb in https://github.com/macro-inc/macro/pull/2729
+* fix(search): keep tab in search, hint @mention in placeholder by @gbirman in https://github.com/macro-inc/macro/pull/2730
+* feat(sidebar): add enable notifications button by @evanhutnik in https://github.com/macro-inc/macro/pull/2728
+* fix(search): blur soup search on ArrowDown to navigate results by @gbirman in https://github.com/macro-inc/macro/pull/2732
+* feat(icon): add custom disconnect icon by @aidanhb in https://github.com/macro-inc/macro/pull/2735
+* feat(channels): support latest_activity messages filter by @synoet in https://github.com/macro-inc/macro/pull/2736
+* feat(tasks): rail chat bottom-matter comments in tasks by @sedson in https://github.com/macro-inc/macro/pull/2731
+* fix(search): only hint @mention in sidebar search placeholder by @gbirman in https://github.com/macro-inc/macro/pull/2739
+* fix(search): render name highlight when not on first result by @gbirman in https://github.com/macro-inc/macro/pull/2740
+* fix(md): fix busted portal scoping in email base input by @sedson in https://github.com/macro-inc/macro/pull/2741
+* feat(command-k): copy entity id by @gbirman in https://github.com/macro-inc/macro/pull/2737
+* fix(call): entity access for call record routes by @whutchinson98 in https://github.com/macro-inc/macro/pull/2743
+* fix(search): highlight doc names on content-only hits by @gbirman in https://github.com/macro-inc/macro/pull/2742
+* Seanaye/feat/improve autoupdate ux by @seanaye in https://github.com/macro-inc/macro/pull/2733
+* chore(name_search): split highlight module into its own file by @gbirman in https://github.com/macro-inc/macro/pull/2744
+* chg(safeFetch): prevent draining body, and passing content-type on head request by @synoet in https://github.com/macro-inc/macro/pull/2745
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.4.21.1...v2026.4.21.2
+    </Update>
+
+    <Update label="v2026.4.21.1">
+## What's Changed
+* feat(calls): add channel name to the call started notif by @seanaye in https://github.com/macro-inc/macro/pull/2711
+* fix(layout): add tab titles to split view, fix tab title reconcile bug by @sedson in https://github.com/macro-inc/macro/pull/2713
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.4.21.0...v2026.4.21.1
+    </Update>
+
+    <Update label="v2026.4.21.0">
+## What's Changed
+* feat(onboarding): pricing table, free tier, and desktop launch step by @evanhutnik in https://github.com/macro-inc/macro/pull/2692
+* fix(channel): mark message notification viewed when it arrives after mount by @gbirman in https://github.com/macro-inc/macro/pull/2707
+* fix[tauri]: sync service by @peterchinman in https://github.com/macro-inc/macro/pull/2712
+* feat(analytics): track mobile-web signup as Meta Pixel Lead by @evanhutnik in https://github.com/macro-inc/macro/pull/2710
+* change enable bawrfoe by @evanhutnik in https://github.com/macro-inc/macro/pull/2700
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.4.20.1...v2026.4.21.0
+    </Update>
+
+    <Update label="v2026.4.20.1">
+## What's Changed
+* chore: bump version + update changelog by @synoet in https://github.com/macro-inc/macro/pull/2698
+* fix[mobile]: channel padding by @peterchinman in https://github.com/macro-inc/macro/pull/2699
+* feat[mobile]: swipe down to dismiss keyboard by @peterchinman in https://github.com/macro-inc/macro/pull/2697
+* feat(md): improve actions menu pattern, add task action by @sedson in https://github.com/macro-inc/macro/pull/2691
+* chore(search): remove projects search index by @gbirman in https://github.com/macro-inc/macro/pull/2694
+* chore(search): remove unused names index client code by @gbirman in https://github.com/macro-inc/macro/pull/2702
+* fix(channel): prevent default click reactions by @synoet in https://github.com/macro-inc/macro/pull/2706
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.4.20.0...v2026.4.20.1
+    </Update>
+
+    <Update label="v2026.4.20.0">
+## What's Changed
+* feat(auth-service): Change stripe tier endpoint by @evanhutnik in https://github.com/macro-inc/macro/pull/2655
+* fix(ai-email): Send HTML body instead of raw markdown when sending emails by @evanhutnik in https://github.com/macro-inc/macro/pull/2432
+* fix: add back cmd+esc to close split by @peterchinman in https://github.com/macro-inc/macro/pull/2664
+* chore: add star history by @seanaye in https://github.com/macro-inc/macro/pull/2665
+* fix: scope expand/collapse hotkey to active split by @gbirman in https://github.com/macro-inc/macro/pull/2667
+* fix[mobile]: notification timestamps by @peterchinman in https://github.com/macro-inc/macro/pull/2670
+* feat(fe): Subscription tier update UI by @evanhutnik in https://github.com/macro-inc/macro/pull/2666
+* fix(task): add create by as property display to task front-matter by @sedson in https://github.com/macro-inc/macro/pull/2669
+* fix(soup): optimistic batch updating of properties by @synoet in https://github.com/macro-inc/macro/pull/2668
+* feat(soup): ast file assoc expansion by @seanaye in https://github.com/macro-inc/macro/pull/2674
+* feat(tauri): autoupdate ui and persistence by @seanaye in https://github.com/macro-inc/macro/pull/2657
+* fix: ios dictation buffer by @peterchinman in https://github.com/macro-inc/macro/pull/2677
+* fix(list): preserve scroll position on expand/collapse by @gbirman in https://github.com/macro-inc/macro/pull/2678
+* fix: notification stacking behavior by @peterchinman in https://github.com/macro-inc/macro/pull/2673
+* fix(unfurl): Improvements to unfurl service to have it match what we do for similar functionality in other services by @whutchinson98 in https://github.com/macro-inc/macro/pull/2679
+* fix(soup): bulk marking emails as done happens in parallel by @synoet in https://github.com/macro-inc/macro/pull/2675
+* chore(soup): bump persisted state version by @dev-rb in https://github.com/macro-inc/macro/pull/2680
+* feat(comms): add thread mentionees to notification for channel message by @whutchinson98 in https://github.com/macro-inc/macro/pull/2682
+* fix(email): use unique index on email_contacts upsert lookup by @gbirman in https://github.com/macro-inc/macro/pull/2683
+* fix[soup]: import folder button by @peterchinman in https://github.com/macro-inc/macro/pull/2681
+* chore(ai infra): consolidate env vars for tools by @ehayes2000 in https://github.com/macro-inc/macro/pull/2672
+* fix(md): potentially fix md comment clone bug by @sedson in https://github.com/macro-inc/macro/pull/2685
+* chg(channels): improve distinction between keyboard selected + hover by @synoet in https://github.com/macro-inc/macro/pull/2684
+* chore: bump version + update changelog by @synoet in https://github.com/macro-inc/macro/pull/2689
+* fix(ai): tool error handling by @ehayes2000 in https://github.com/macro-inc/macro/pull/2671
+* chg(opensearch): drop unknown fields instead of auto-creating by @gbirman in https://github.com/macro-inc/macro/pull/2690
+* feat(channels): add failed to send message failover by @synoet in https://github.com/macro-inc/macro/pull/2693
+* fix(channels/lexical): fix input focus causing scroll instability by @synoet in https://github.com/macro-inc/macro/pull/2687
+* fix(fe-notifs): add metion info to create thread calls by @sedson in https://github.com/macro-inc/macro/pull/2695
+* Seanaye/fix/tauri services ws by @seanaye in https://github.com/macro-inc/macro/pull/2688
+* fix(channel): fix scroll to bottom when mid pagination by @synoet in https://github.com/macro-inc/macro/pull/2696
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.4.17.1...v2026.4.20.0
+    </Update>
+
+    <Update label="v2026.4.17.1">
+## What's Changed
+* fix(agent-schedule-service): wire SYNC_SERVICE_AUTH_KEY env var by @gbirman in https://github.com/macro-inc/macro/pull/2663
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.4.17.0...v2026.4.17.1
+    </Update>
+
+    <Update label="v2026.4.17.0">
+## What's Changed
+* fix[split]: accessing undefined split content by @peterchinman in https://github.com/macro-inc/macro/pull/2640
+* fix[mobile]: don't focus new splitcontainers on mobile by @peterchinman in https://github.com/macro-inc/macro/pull/2641
+* feat(blocks): add info drawer for blocks, remove metadata from frontmatter and prop-drawer by @sedson in https://github.com/macro-inc/macro/pull/2642
+* fix(sfs): image downscaling by @ehayes2000 in https://github.com/macro-inc/macro/pull/2636
+* fix(sidebar): styling for collapsed unread widget by @dev-rb in https://github.com/macro-inc/macro/pull/2645
+* feat(ai): scheduled agents (backend) by @ehayes2000 in https://github.com/macro-inc/macro/pull/2629
+* Revert "fix(sfs): image downscaling" by @ehayes2000 in https://github.com/macro-inc/macro/pull/2646
+* fix(search): snappier, keyboard-navigable In/From filter submenu by @gbirman in https://github.com/macro-inc/macro/pull/2643
+* feat(ai): Scheduled agents frontend by @ehayes2000 in https://github.com/macro-inc/macro/pull/2633
+* fix[mobile]: soup create button by @peterchinman in https://github.com/macro-inc/macro/pull/2649
+* fix[channels]: grouped message timestamps by @peterchinman in https://github.com/macro-inc/macro/pull/2648
+* fix[mobile]: no back swipe gesture on web mobile by @peterchinman in https://github.com/macro-inc/macro/pull/2650
+* fix(search): emails not excluded using nil thread id by @dev-rb in https://github.com/macro-inc/macro/pull/2647
+* chore(properties): clear search text when selecting entity in multiselect by @gbirman in https://github.com/macro-inc/macro/pull/2652
+* feat(call): use correct thread components by @whutchinson98 in https://github.com/macro-inc/macro/pull/2654
+* fix(hotkeys): shift-modified split navigation to avoid collapse/expand conflict by @gbirman in https://github.com/macro-inc/macro/pull/2653
+* style(settings): tweak font and cols for setting shortcut hints by @sedson in https://github.com/macro-inc/macro/pull/2658
+* fix(channels): sometimes channels don't load any messages by @dev-rb in https://github.com/macro-inc/macro/pull/2660
+* fix(channnels): fix broken padding for narrow channel input by @sedson in https://github.com/macro-inc/macro/pull/2659
+* style(properties): restyle ceate property and select property modal by @sedson in https://github.com/macro-inc/macro/pull/2656
+* fix(filters): clean up soup/search filters by @gbirman in https://github.com/macro-inc/macro/pull/2661
+* fix(md): front matter closed by default by @sedson in https://github.com/macro-inc/macro/pull/2662
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.4.16.0...v2026.4.17.0
+    </Update>
+
+    <Update label="v2026.4.16.0">
+## What's Changed
+* fix(frecency): clean up stale transaction in poller to prevent deadlock by @gbirman in https://github.com/macro-inc/macro/pull/2609
+* fix(call): correctly filter calls in attachments and support click on attachment to go to call record by @whutchinson98 in https://github.com/macro-inc/macro/pull/2610
+* feat(infra): add idle_in_transaction_session_timeout by @gbirman in https://github.com/macro-inc/macro/pull/2613
+* feat(call): new call button by @whutchinson98 in https://github.com/macro-inc/macro/pull/2611
+* style(tasks): un-bork padding in task composer by @sedson in https://github.com/macro-inc/macro/pull/2612
+* style(ui): add rounding back to mini toggle component by @sedson in https://github.com/macro-inc/macro/pull/2614
+* feat(auth): mobile welcome email endpoint by @evanhutnik in https://github.com/macro-inc/macro/pull/2608
+* fix: remove close split by escape key by @dev-rb in https://github.com/macro-inc/macro/pull/2616
+* fix(port-maxxing): remove hmr port option to default to same as http port by @sedson in https://github.com/macro-inc/macro/pull/2617
+* fix(tasks): allow go to location for task snippets by @sedson in https://github.com/macro-inc/macro/pull/2622
+* fix(call): return all calls you have access to in soup by @whutchinson98 in https://github.com/macro-inc/macro/pull/2621
+* feat(onboarding): mobile web welcome flow with email signup by @evanhutnik in https://github.com/macro-inc/macro/pull/2624
+* feat(call): delete call by @whutchinson98 in https://github.com/macro-inc/macro/pull/2625
+* feat(notifications): add right-click context menu to notification stacks by @gbirman in https://github.com/macro-inc/macro/pull/2549
+* fix deadlock in ios dev mode by @seanaye in https://github.com/macro-inc/macro/pull/2626
+* fix(call): delete recording from s3 by @whutchinson98 in https://github.com/macro-inc/macro/pull/2627
+* fix(search): precise email-address highlighting by @gbirman in https://github.com/macro-inc/macro/pull/2628
+* feat(search): tasks-style filter menu with F hotkey and chips by @gbirman in https://github.com/macro-inc/macro/pull/2623
+* chore: remove unnecessary code from notification right-click by @gbirman in https://github.com/macro-inc/macro/pull/2630
+* fix[mobile]: task bug by @peterchinman in https://github.com/macro-inc/macro/pull/2631
+* fix[mobile]: stop background splits from focusing by @peterchinman in https://github.com/macro-inc/macro/pull/2632
+* feat(channel): URL search params for single channel navigation by @gbirman in https://github.com/macro-inc/macro/pull/2634
+* chore: pin tauri-plugin-deep-link to avoid bug by @peterchinman in https://github.com/macro-inc/macro/pull/2635
+* fix(search): keep In/From chip popup open on multi-select by @gbirman in https://github.com/macro-inc/macro/pull/2637
+* feat(sidebar): show user icons for group dms by @dev-rb in https://github.com/macro-inc/macro/pull/2638
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.4.15.0...v2026.4.16.0
+    </Update>
+
+    <Update label="v2026.4.15.0">
+## What's Changed
+* chore(soup): remove unused filter files by @dev-rb in https://github.com/macro-inc/macro/pull/2573
+* style(share): align share modal with other modals by @sedson in https://github.com/macro-inc/macro/pull/2574
+* feat(call): use channel style rails for call transcript by @whutchinson98 in https://github.com/macro-inc/macro/pull/2576
+* style(fe): Keep fonts for macro emails by @evanhutnik in https://github.com/macro-inc/macro/pull/2578
+* feat(calls): add in safety methods to stop calls properly to avoid billing mistakes by @whutchinson98 in https://github.com/macro-inc/macro/pull/2577
+* style(fa): Change email templates by @evanhutnik in https://github.com/macro-inc/macro/pull/2579
+* fix: soup crashing safari at certain widths by @peterchinman in https://github.com/macro-inc/macro/pull/2580
+* fix:  cmd+f hotkey for collapsed search state by @peterchinman in https://github.com/macro-inc/macro/pull/2582
+* fix(call): noise filtering by @whutchinson98 in https://github.com/macro-inc/macro/pull/2586
+* feat(tasks): add assign task btn to user card, cleanup styles on user card by @sedson in https://github.com/macro-inc/macro/pull/2581
+* fix(preview): do not open preview window on empty state by @aidanhb in https://github.com/macro-inc/macro/pull/2587
+* feat(infra): add pganalyze collector with auto_explain by @gbirman in https://github.com/macro-inc/macro/pull/2589
+* feat(search): disable email subject serach in mentions when not required by @gbirman in https://github.com/macro-inc/macro/pull/2588
+* style(md): restyle media resize handles by @sedson in https://github.com/macro-inc/macro/pull/2590
+* feat[mobile]: swipe back gesture by @peterchinman in https://github.com/macro-inc/macro/pull/2572
+* feat(infra): enable enhanced monitoring for RDS by @gbirman in https://github.com/macro-inc/macro/pull/2583
+* fix(ci): fix cargo-deny check by @gbirman in https://github.com/macro-inc/macro/pull/2591
+* join_call param in channel by @whutchinson98 in https://github.com/macro-inc/macro/pull/2593
+* feat(analytics): per-lesson onboarding events, login tracking, environment enrichment by @evanhutnik in https://github.com/macro-inc/macro/pull/2594
+* feat(search): use read replica database for search queries by @gbirman in https://github.com/macro-inc/macro/pull/2592
+* feat(sidebar): unread channel widget for slim mode by @dev-rb in https://github.com/macro-inc/macro/pull/2595
+* style(chat): kill inset bottom px for soup chat gradient by @sedson in https://github.com/macro-inc/macro/pull/2575
+* Remove PG email search, use OpenSearch for all email queries by @gbirman in https://github.com/macro-inc/macro/pull/2585
+* feat(md): drag to rearrange nodes by @sedson in https://github.com/macro-inc/macro/pull/2597
+* fix(channels): update media viewer controls ui by @dev-rb in https://github.com/macro-inc/macro/pull/2596
+* feat(search): re-index OpenSearch when contact names change by @gbirman in https://github.com/macro-inc/macro/pull/2600
+* Remove email_contact_search crate from workspace by @gbirman in https://github.com/macro-inc/macro/pull/2599
+* Seanaye/feat/tauri autoupdate by @seanaye in https://github.com/macro-inc/macro/pull/2584
+* style(command): command menu tab spacing by @sedson in https://github.com/macro-inc/macro/pull/2602
+* fix(search): highlight correct term in sender name for contact searches by @gbirman in https://github.com/macro-inc/macro/pull/2604
+* fix(notifications): stop refetching all notifications on mark-as-read by @gbirman in https://github.com/macro-inc/macro/pull/2605
+* chore: bump tauri plugins by @peterchinman in https://github.com/macro-inc/macro/pull/2607
+* feat(md): md commands in command+k, cleanup format menu styles, clean up drag insert grabber by @sedson in https://github.com/macro-inc/macro/pull/2606
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.4.14.0...v2026.4.15.0
+    </Update>
+
+    <Update label="v2026.4.14.0">
+## What's Changed
+* fix[mobile-soup]: notification stack click handler by @peterchinman in https://github.com/macro-inc/macro/pull/2544
+* chore(tasks): remove diff-style highlights from assignee menu by @gbirman in https://github.com/macro-inc/macro/pull/2545
+* fix(tasks): update property delete buttons to use subtle X style by @gbirman in https://github.com/macro-inc/macro/pull/2546
+* chore(notifications): update notification checkbox tooltip by @gbirman in https://github.com/macro-inc/macro/pull/2547
+* fix(inbox): Enter on single-item channel notification opens that message by @gbirman in https://github.com/macro-inc/macro/pull/2548
+* fix[channels]: grouped message timestamp alignment by @peterchinman in https://github.com/macro-inc/macro/pull/2539
+* feat(ai): cancel stream button by @ehayes2000 in https://github.com/macro-inc/macro/pull/2543
+* chore(tauri): bump http plugin by @seanaye in https://github.com/macro-inc/macro/pull/2551
+* fix(md): add space escaping to inline md emoji picker by @sedson in https://github.com/macro-inc/macro/pull/2552
+* fix(call): handle noise suppression between mic changes by @whutchinson98 in https://github.com/macro-inc/macro/pull/2553
+* fix(md): make task creation not fail when listitem text length exceeds backend limit by @sedson in https://github.com/macro-inc/macro/pull/2556
+* fix(md): autofocus empty title editor after connect root by @sedson in https://github.com/macro-inc/macro/pull/2557
+* Evan/onboarding analytics fix by @evanhutnik in https://github.com/macro-inc/macro/pull/2555
+* feat(call): recording by @whutchinson98 in https://github.com/macro-inc/macro/pull/2558
+* Hutch/feat call block by @whutchinson98 in https://github.com/macro-inc/macro/pull/2554
+* fix(call): video player CORPS by @whutchinson98 in https://github.com/macro-inc/macro/pull/2561
+* fix(image preview): ensure image upload and fetch include Content Typ… by @aidanhb in https://github.com/macro-inc/macro/pull/2560
+* feat[channels]: big emoji by @peterchinman in https://github.com/macro-inc/macro/pull/2562
+* fix(channels): messages sometimes duplicating  by @dev-rb in https://github.com/macro-inc/macro/pull/2563
+* fix[channels]: grouped message timestamp alignment by @peterchinman in https://github.com/macro-inc/macro/pull/2565
+* chg: show localhost port # in tab title by @peterchinman in https://github.com/macro-inc/macro/pull/2566
+* fix(soup): Soup ast does not support getting non task documents by @dev-rb in https://github.com/macro-inc/macro/pull/2564
+* feat[soup]: hotkey for sort menu by @peterchinman in https://github.com/macro-inc/macro/pull/2567
+* style(entity): update entity edit modal wrapper styles by @sedson in https://github.com/macro-inc/macro/pull/2316
+* feat(call): add call to soup by @whutchinson98 in https://github.com/macro-inc/macro/pull/2559
+* fix(md): add video markdow transformers by @sedson in https://github.com/macro-inc/macro/pull/2568
+* fix(md): align our latex regex with gfm whitespace rules by @sedson in https://github.com/macro-inc/macro/pull/2571
+* feat(fe): create task button with pre-populated title for emails and channels by @evanhutnik in https://github.com/macro-inc/macro/pull/2569
+* feat(analytics): add macro_device enrichment to all analytics events by @evanhutnik in https://github.com/macro-inc/macro/pull/2570
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.4.13.0...v2026.4.14.0
+    </Update>
+
+    <Update label="v2026.4.13.0">
+## What's Changed
+* change add emoji icon by @peterchinman in https://github.com/macro-inc/macro/pull/2514
+* chg(compose): rework compose to use the new input primitives by @synoet in https://github.com/macro-inc/macro/pull/2480
+* fix(properties): prevent metadata properties from disappearing in task view by @gbirman in https://github.com/macro-inc/macro/pull/2515
+* feat(documents): move copy_document to documents hex crate by @whutchinson98 in https://github.com/macro-inc/macro/pull/2512
+* chore: change codeowners by @whutchinson98 in https://github.com/macro-inc/macro/pull/2519
+* chore(deps): bump picomatch from 4.0.3 to 4.0.4 in /rust/sync-service by @dependabot[bot] in https://github.com/macro-inc/macro/pull/2200
+* chore(deps): bump vite from 6.4.1 to 6.4.2 in /rust/sync-service by @dependabot[bot] in https://github.com/macro-inc/macro/pull/2383
+* Hutch/chore docs by @whutchinson98 in https://github.com/macro-inc/macro/pull/2521
+* feat(search): add @mention support to search bar by @gbirman in https://github.com/macro-inc/macro/pull/2517
+* chore: dependabot by @whutchinson98 in https://github.com/macro-inc/macro/pull/2520
+* fix(search): normalize mention filter format between soup and OpenSearch by @gbirman in https://github.com/macro-inc/macro/pull/2518
+* feat(mcp): expose branch name to mcp tool by @whutchinson98 in https://github.com/macro-inc/macro/pull/2522
+* fix(stripe): support unknown stripe subscriptions mapping to haiku by default by @whutchinson98 in https://github.com/macro-inc/macro/pull/2524
+* fix(upload): make file extension matching case-insensitive by @gbirman in https://github.com/macro-inc/macro/pull/2525
+* fix(call): do not drop audio when moving to messages/attachments by @whutchinson98 in https://github.com/macro-inc/macro/pull/2527
+* fix(search): skip entity types with ids_only and empty IDs in unified search by @gbirman in https://github.com/macro-inc/macro/pull/2529
+* feat: document mention notification type by @peterchinman in https://github.com/macro-inc/macro/pull/2516
+* fix: escape bug by @peterchinman in https://github.com/macro-inc/macro/pull/2532
+* feat[mobile channels]: add copy message text action by @peterchinman in https://github.com/macro-inc/macro/pull/2533
+* feat(call): support get call record endpoint by @whutchinson98 in https://github.com/macro-inc/macro/pull/2528
+* chore(search): remove lingering tooltip from search bar by @gbirman in https://github.com/macro-inc/macro/pull/2537
+* fix(search): filter noise emails from search results by @gbirman in https://github.com/macro-inc/macro/pull/2534
+* fix(tasks): improve assignee property editing UX by @gbirman in https://github.com/macro-inc/macro/pull/2536
+* fix[ios]: push notification enable flow by @peterchinman in https://github.com/macro-inc/macro/pull/2504
+* fix(sync): use remote DSS for sync permission tokens in local dev by @gbirman in https://github.com/macro-inc/macro/pull/2538
+* feat(search): add preview button to search view header by @gbirman in https://github.com/macro-inc/macro/pull/2541
+* fix(ci): gen-api timeout and better logging by @whutchinson98 in https://github.com/macro-inc/macro/pull/2540
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.4.10.1...v2026.4.13.0
+    </Update>
+
+    <Update label="v2026.4.10.1">
+## What's Changed
+* Scroll bug in onboarding by @evanhutnik in https://github.com/macro-inc/macro/pull/2513
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.4.10.0...v2026.4.10.1
+    </Update>
+
+    <Update label="v2026.4.10.0">
+## What's Changed
+* actually enable the email lol by @seanaye in https://github.com/macro-inc/macro/pull/2485
+* fix(search): not all documents showing for search soup index by @gbirman in https://github.com/macro-inc/macro/pull/2489
+* feat(search): use PlainTextFormatter for channel search indexing by @gbirman in https://github.com/macro-inc/macro/pull/2491
+* fix: channel read status by @gbirman in https://github.com/macro-inc/macro/pull/2492
+* chg(channels): add max height for images by @synoet in https://github.com/macro-inc/macro/pull/2494
+* chore: bump version by @synoet in https://github.com/macro-inc/macro/pull/2495
+* fix[mobile]: better input focus handling by @peterchinman in https://github.com/macro-inc/macro/pull/2488
+* fix(notif): empty digest and comms data race by @seanaye in https://github.com/macro-inc/macro/pull/2493
+* fix(channel): never hide flex-1 channel list by @synoet in https://github.com/macro-inc/macro/pull/2497
+* feat(search): cache channel filters by @gbirman in https://github.com/macro-inc/macro/pull/2498
+* fix[channel]: squish tabs to icons when narrow by @peterchinman in https://github.com/macro-inc/macro/pull/2496
+* Onboarding flow update by @evanhutnik in https://github.com/macro-inc/macro/pull/2446
+* fix(ui): tabs indicator jumping from start on mount by @dev-rb in https://github.com/macro-inc/macro/pull/2499
+* feat(search): clear search filters button  by @gbirman in https://github.com/macro-inc/macro/pull/2500
+* fix(search): scope channel filter cache by @gbirman in https://github.com/macro-inc/macro/pull/2505
+* feat(calls): highlight call icon if call is active by @whutchinson98 in https://github.com/macro-inc/macro/pull/2503
+* feat(channel): expand image preview on click in text input by @gbirman in https://github.com/macro-inc/macro/pull/2508
+* feat(call): add push notifications by @seanaye in https://github.com/macro-inc/macro/pull/2502
+* feat(email): user link history by @evanhutnik in https://github.com/macro-inc/macro/pull/2509
+* fix(upload): route videos to SFS when MIME type is missing by @gbirman in https://github.com/macro-inc/macro/pull/2510
+* add fallthough for unknown notifications by @seanaye in https://github.com/macro-inc/macro/pull/2511
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.4.9.1...v2026.4.10.0
+    </Update>
+
+    <Update label="v2026.4.9.1">
+## What's Changed
+* chg(pdf): disable eval by @synoet in https://github.com/macro-inc/macro/pull/2486
+* fix: generated notification types by @gbirman in https://github.com/macro-inc/macro/pull/2487
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.4.9.0...v2026.4.9.1
+    </Update>
+
+    <Update label="v2026.4.9.0">
+## What's Changed
+* feat: add profile pic to search in filter by @gbirman in https://github.com/macro-inc/macro/pull/2459
+* feat: make search index icons monochrome by @gbirman in https://github.com/macro-inc/macro/pull/2460
+* fix(search): clear filters properly by @gbirman in https://github.com/macro-inc/macro/pull/2461
+* fix(ai): mcp by @ehayes2000 in https://github.com/macro-inc/macro/pull/2443
+* style(fe): Update Macro Dark/Light default themes by @evanhutnik in https://github.com/macro-inc/macro/pull/2462
+* fix(ai): mcp infra by @ehayes2000 in https://github.com/macro-inc/macro/pull/2464
+* feat call noise filtering by @whutchinson98 in https://github.com/macro-inc/macro/pull/2463
+* chore(docs): setup docs by @synoet in https://github.com/macro-inc/macro/pull/2466
+* refactor(fe): Extract shared plan grid and update pricing tiers by @evanhutnik in https://github.com/macro-inc/macro/pull/2469
+* feat: entity access management crate by @whutchinson98 in https://github.com/macro-inc/macro/pull/2465
+* fix(ai): references by @ehayes2000 in https://github.com/macro-inc/macro/pull/2470
+* feat(ai): UI for failed tool calls by @ehayes2000 in https://github.com/macro-inc/macro/pull/2472
+* fix(analytics): meta ids not forwarded through checkout by @dev-rb in https://github.com/macro-inc/macro/pull/2471
+* fix(notif): conn gateway timestamps by @seanaye in https://github.com/macro-inc/macro/pull/2467
+* Fix mobile formatting of tier grid by @evanhutnik in https://github.com/macro-inc/macro/pull/2473
+* Update Macro Dark theme color tokens by @evanhutnik in https://github.com/macro-inc/macro/pull/2475
+* feat(notifications): return created_at/updated_at for created notification by @gbirman in https://github.com/macro-inc/macro/pull/2478
+* feat(comms): channel invite sends email for non-existing user by @seanaye in https://github.com/macro-inc/macro/pull/2468
+* feat(docs): mcp docs by @ehayes2000 in https://github.com/macro-inc/macro/pull/2481
+* add logging by @seanaye in https://github.com/macro-inc/macro/pull/2483
+* fix[channels]: video preview on safari by @peterchinman in https://github.com/macro-inc/macro/pull/2474
+* fix[ios]: drawers fit content by @peterchinman in https://github.com/macro-inc/macro/pull/2476
+* fix[ios-soup]: limit max unrolled notifications by @peterchinman in https://github.com/macro-inc/macro/pull/2477
+* chore(channels): add tracing to axum router by @synoet in https://github.com/macro-inc/macro/pull/2484
+* fix: channel message notification read status fixes by @gbirman in https://github.com/macro-inc/macro/pull/2482
+* feat(notifications): make created_at/updated_at outbound timestamp required by @gbirman in https://github.com/macro-inc/macro/pull/2479
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.4.8.1...v2026.4.9.0
+    </Update>
+
+    <Update label="v2026.4.8.1">
+## What's Changed
+* feat: search tab filter selection by @gbirman in https://github.com/macro-inc/macro/pull/2453
+* fix[ios]: remove virtual keyboard accessory bar by @peterchinman in https://github.com/macro-inc/macro/pull/2454
+* fix(channels): resolve channel name with whitespace only by @gbirman in https://github.com/macro-inc/macro/pull/2455
+* fix(channels): fix suspense boundry for thread replies by @synoet in https://github.com/macro-inc/macro/pull/2456
+* fix: radio button single select should no-op on reclick by @gbirman in https://github.com/macro-inc/macro/pull/2457
+* fix(channels): only show icons for thread replies collapsed by @synoet in https://github.com/macro-inc/macro/pull/2458
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.4.8.0...v2026.4.8.1
+    </Update>
+
+    <Update label="v2026.4.8.0">
+## What's Changed
+* chore(ai): idiomatic memory config by @ehayes2000 in https://github.com/macro-inc/macro/pull/2400
+* chore(entity_access): move access checks to entity access by @whutchinson98 in https://github.com/macro-inc/macro/pull/2437
+* feat create entity access backfill script by @whutchinson98 in https://github.com/macro-inc/macro/pull/2325
+* feat: remove tasks from Inbox by @peterchinman in https://github.com/macro-inc/macro/pull/2438
+* feat(call): use name in call by @whutchinson98 in https://github.com/macro-inc/macro/pull/2440
+* feat(calls): choose audio/video by @whutchinson98 in https://github.com/macro-inc/macro/pull/2439
+* chore: add debug logs to stripe webhook by @dev-rb in https://github.com/macro-inc/macro/pull/2441
+* chore: cors updates for more localhost sessions by @gbirman in https://github.com/macro-inc/macro/pull/2442
+* chore: add more logs to stripe webhook by @dev-rb in https://github.com/macro-inc/macro/pull/2444
+* fix(analytics): missing GA measurement id  by @dev-rb in https://github.com/macro-inc/macro/pull/2445
+* fix(channels): initial scroll race condition by @synoet in https://github.com/macro-inc/macro/pull/2447
+* chore: add api version log to stripe webhook by @dev-rb in https://github.com/macro-inc/macro/pull/2450
+* fix[ios]: only allow portrait orientation by @peterchinman in https://github.com/macro-inc/macro/pull/2449
+* fix[mobile soup]: missing sender names by @peterchinman in https://github.com/macro-inc/macro/pull/2448
+* fix[ios channels]: scroll message list when input focused" by @peterchinman in https://github.com/macro-inc/macro/pull/2452
+* chore(old-channels): remove old channel logic by @synoet in https://github.com/macro-inc/macro/pull/2451
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.4.7.0...v2026.4.8.0
+    </Update>
+
+    <Update label="v2026.4.7.0">
+## What's Changed
+* fix(ci): runner race condition by @whutchinson98 in https://github.com/macro-inc/macro/pull/2402
+* feat(calls): Frontend implementation by @whutchinson98 in https://github.com/macro-inc/macro/pull/2335
+* fix(onboarding): fix mobile layout, skip on touch, add referral hint by @sedson in https://github.com/macro-inc/macro/pull/2404
+* feat(calls): setup call recording by @whutchinson98 in https://github.com/macro-inc/macro/pull/2405
+* feat(notif): add signed unsubscribe url to digest by @seanaye in https://github.com/macro-inc/macro/pull/2371
+* feat(call): prod transcriber by @whutchinson98 in https://github.com/macro-inc/macro/pull/2407
+* feat: single documents tab in command k by @gbirman in https://github.com/macro-inc/macro/pull/2408
+* fix(ci): duplicate run-id by @whutchinson98 in https://github.com/macro-inc/macro/pull/2409
+* feat(notif): check typename ignore before publishing digest by @seanaye in https://github.com/macro-inc/macro/pull/2411
+* fix: command k safe name by @gbirman in https://github.com/macro-inc/macro/pull/2414
+* feat: command k search improve by @gbirman in https://github.com/macro-inc/macro/pull/2412
+* feat(channels): clean up call logic + call tab by @synoet in https://github.com/macro-inc/macro/pull/2410
+* feat(call): send connection gateway message on channel creation/end by @whutchinson98 in https://github.com/macro-inc/macro/pull/2415
+* fix: soup channel message alignment by @gbirman in https://github.com/macro-inc/macro/pull/2419
+* fix(ai): rendering by @ehayes2000 in https://github.com/macro-inc/macro/pull/2421
+* chore: update command k search config by @gbirman in https://github.com/macro-inc/macro/pull/2423
+* fix[lightbox]: exit with esc by @peterchinman in https://github.com/macro-inc/macro/pull/2417
+* fix: soup long press issue by @peterchinman in https://github.com/macro-inc/macro/pull/2425
+* fix[soup]: task assignee filter always shows user first by @peterchinman in https://github.com/macro-inc/macro/pull/2416
+* fix[soup:tasks]: include tasks shared with me in Assigned view by @peterchinman in https://github.com/macro-inc/macro/pull/2424
+* fix: always include status property when creating a task by @peterchinman in https://github.com/macro-inc/macro/pull/2427
+* fix(email): show full sender name when it starts with "The" by @evanhutnik in https://github.com/macro-inc/macro/pull/2413
+* feat(fe): create task button for email threads and channel messages by @evanhutnik in https://github.com/macro-inc/macro/pull/2426
+* fix: channel navigation broken for search preview mode by @gbirman in https://github.com/macro-inc/macro/pull/2428
+* fix: stripe webhook not processing incomplete status transitions by @dev-rb in https://github.com/macro-inc/macro/pull/2430
+* fix: focus search input if search is already open by @gbirman in https://github.com/macro-inc/macro/pull/2431
+* chg(new-channels): prevent focus on preview by @synoet in https://github.com/macro-inc/macro/pull/2420
+* feat(new-channels): improved scrolling stability by @synoet in https://github.com/macro-inc/macro/pull/2433
+* feat: hide new reply input after reply by @gbirman in https://github.com/macro-inc/macro/pull/2435
+* feat: notifications stack toggle list on bottom by @gbirman in https://github.com/macro-inc/macro/pull/2434
+* fix(channels): refactor task creation button by @synoet in https://github.com/macro-inc/macro/pull/2436
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.4.6.0...v2026.4.7.0
+    </Update>
+
+    <Update label="v2026.4.6.0">
+## What's Changed
+* feat: update code file type in backend by @gbirman in https://github.com/macro-inc/macro/pull/2368
+* feat: code file type chip by @gbirman in https://github.com/macro-inc/macro/pull/2370
+* fix(analytics): missing meta access token by @dev-rb in https://github.com/macro-inc/macro/pull/2373
+* fix[new-channels]: make attachements scroll horizontally by @peterchinman in https://github.com/macro-inc/macro/pull/2369
+* fix ai rendering by @ehayes2000 in https://github.com/macro-inc/macro/pull/2376
+* feat[soup]: return to traditional tabs by @peterchinman in https://github.com/macro-inc/macro/pull/2375
+* feat(ai): email tools by @ehayes2000 in https://github.com/macro-inc/macro/pull/2362
+* fix[mobile]: soup tabs don't slide by @peterchinman in https://github.com/macro-inc/macro/pull/2379
+* feat(calls): move transcript to agent by @whutchinson98 in https://github.com/macro-inc/macro/pull/2377
+* add email link id by @seanaye in https://github.com/macro-inc/macro/pull/2378
+* fix: tanstack query initial value undefined despite cached data by @dev-rb in https://github.com/macro-inc/macro/pull/2380
+* fix(splits): split ids not stable during url sync by @dev-rb in https://github.com/macro-inc/macro/pull/2381
+* Remove InviteBadge component by @evanhutnik in https://github.com/macro-inc/macro/pull/2382
+* Color calendar invite icon in email topbar by @evanhutnik in https://github.com/macro-inc/macro/pull/2386
+* feat(ai): tool restyling + improve tool rendering pipeline by @ehayes2000 in https://github.com/macro-inc/macro/pull/2385
+* feat: change code file type by @gbirman in https://github.com/macro-inc/macro/pull/2387
+* fix(memory): use updated_at for staleness by @ehayes2000 in https://github.com/macro-inc/macro/pull/2389
+* feat: add immutable file type chip for block image by @gbirman in https://github.com/macro-inc/macro/pull/2392
+* feat: add immutable file type chip to block unknown by @gbirman in https://github.com/macro-inc/macro/pull/2391
+* fix: file type change update quick access provider name by @gbirman in https://github.com/macro-inc/macro/pull/2393
+* chore: dry up file type chip component in top bar by @gbirman in https://github.com/macro-inc/macro/pull/2394
+* fix(email): wrong profile picture on messages due to Index reuse by @evanhutnik in https://github.com/macro-inc/macro/pull/2390
+* feat[soup]: mobile action drawer by @peterchinman in https://github.com/macro-inc/macro/pull/2388
+* fix[mobile]: update full text search label by @peterchinman in https://github.com/macro-inc/macro/pull/2395
+* fix[mobile]: more robust touch check by @peterchinman in https://github.com/macro-inc/macro/pull/2396
+* fix[sidebar]: focus bug by @peterchinman in https://github.com/macro-inc/macro/pull/2398
+* fix[soup]: space at end of list by @peterchinman in https://github.com/macro-inc/macro/pull/2399
+* fix(ai): fix ai email by @ehayes2000 in https://github.com/macro-inc/macro/pull/2397
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.4.3.1...v2026.4.6.0
+    </Update>
+
+    <Update label="v2026.4.3.1">
+## What's Changed
+* fix(search): bypass featured count for channels by @gbirman in https://github.com/macro-inc/macro/pull/2365
+* fix(new-channels): input size by @synoet in https://github.com/macro-inc/macro/pull/2367
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.4.3.0...v2026.4.3.1
+    </Update>
+
+    <Update label="v2026.4.3.0">
+## What's Changed
+* fix(soup): Email pagination by @evanhutnik in https://github.com/macro-inc/macro/pull/2360
+* fix(ai): Fix unowned `createEffect` + fix remounting messages by @ehayes2000 in https://github.com/macro-inc/macro/pull/2352
+* feat(search): channel message entity by @gbirman in https://github.com/macro-inc/macro/pull/2359
+* feat[new-channels]: various mobile improvements by @peterchinman in https://github.com/macro-inc/macro/pull/2363
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.4.2.0...v2026.4.3.0
+    </Update>
+
+    <Update label="v2026.4.2.0">
+## What's Changed
+* Evan/scale up prod replica by @evanhutnik in https://github.com/macro-inc/macro/pull/2343
+* chore(log): improve ingress worker logging by @seanaye in https://github.com/macro-inc/macro/pull/2342
+* chore: suppress error in search upload handler for file type not found by @gbirman in https://github.com/macro-inc/macro/pull/2345
+* feat(ai): mcp empty state by @ehayes2000 in https://github.com/macro-inc/macro/pull/2344
+* fix(ai): Chat notifications by @ehayes2000 in https://github.com/macro-inc/macro/pull/2341
+* Hutch/feat calls transcription by @whutchinson98 in https://github.com/macro-inc/macro/pull/2346
+* feat(email): add gmail_ops worker for async Gmail API operations with rate limit retry by @evanhutnik in https://github.com/macro-inc/macro/pull/2226
+* fix: wrap haptics by @peterchinman in https://github.com/macro-inc/macro/pull/2348
+* feat(calls): use share permissions by @whutchinson98 in https://github.com/macro-inc/macro/pull/2349
+* fix(email): Add gmail ops queue to sops/justfile by @evanhutnik in https://github.com/macro-inc/macro/pull/2350
+* Add custom brush icon by @aidanhb in https://github.com/macro-inc/macro/pull/2351
+* fix(new-channels): blanking on new message by @dev-rb in https://github.com/macro-inc/macro/pull/2353
+* chore: remove unnecessary suspense context by @dev-rb in https://github.com/macro-inc/macro/pull/2354
+* fix(new-channels): updates not applying to messages by @dev-rb in https://github.com/macro-inc/macro/pull/2355
+* fix(new-channels): notifications not marked as read from new channels by @dev-rb in https://github.com/macro-inc/macro/pull/2356
+* ai: remove auto attachments by @ehayes2000 in https://github.com/macro-inc/macro/pull/2347
+* feat(ai): konsole mcp by @ehayes2000 in https://github.com/macro-inc/macro/pull/2357
+* fix(new-channel): input jumping from top to bottom by @dev-rb in https://github.com/macro-inc/macro/pull/2358
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.4.1.0...v2026.4.2.0
+    </Update>
+
+    <Update label="v2026.4.1.0">
+## What's Changed
+* fix num notifications in digest by @seanaye in https://github.com/macro-inc/macro/pull/2324
+* fix: call initEmailLink on login flow by @evanhutnik in https://github.com/macro-inc/macro/pull/2326
+* fix(email): remove draft saving spinner from compose by @evanhutnik in https://github.com/macro-inc/macro/pull/2327
+* feat(style): Google Drivemaxx share menu by @aidanhb in https://github.com/macro-inc/macro/pull/2182
+* fix: command k viewed at update old items outside normy cache by @gbirman in https://github.com/macro-inc/macro/pull/2329
+* fix: only refetch specific entity for email draft by @gbirman in https://github.com/macro-inc/macro/pull/2330
+* feat(new-channels): scroll thread reply into view by @synoet in https://github.com/macro-inc/macro/pull/2331
+* feat(soup): readonly replica support by @evanhutnik in https://github.com/macro-inc/macro/pull/2305
+* fix(email): use soup mark-done for 'e' key instead of email archive by @evanhutnik in https://github.com/macro-inc/macro/pull/2334
+* feat(calls): calls backend by @whutchinson98 in https://github.com/macro-inc/macro/pull/2332
+* feat(contacts): add client facing endpoint by @seanaye in https://github.com/macro-inc/macro/pull/2328
+* fix(email): prevent duplicate Sent with Macro watermarks on failed validation by @evanhutnik in https://github.com/macro-inc/macro/pull/2336
+* fix(email): use fixed width for sender column in email list by @evanhutnik in https://github.com/macro-inc/macro/pull/2339
+* fix(email): adjust sender column spacing in email list by @evanhutnik in https://github.com/macro-inc/macro/pull/2340
+* feat[new-channels]: mobile action drawers and other mobile improvements by @peterchinman in https://github.com/macro-inc/macro/pull/2337
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.3.31.1...v2026.4.1.0
+    </Update>

--- a/docs/changelog/2026-05.mdx
+++ b/docs/changelog/2026-05.mdx
@@ -1,0 +1,720 @@
+---
+title: "May 2026"
+description: "Macro releases from May 2026."
+---
+
+    <Update label="v2026.5.28.0">
+## What's Changed
+* fix(soup): new filter clearing bug by @sedson in https://github.com/macro-inc/macro/pull/3596
+* feat(email): wire /link/gmail → callback → /email/init for multi-inbox by @gbirman in https://github.com/macro-inc/macro/pull/3593
+* fix(auth): no-op on already-linked Google identity in /link/gmail callback by @gbirman in https://github.com/macro-inc/macro/pull/3597
+* fix(db): drop email_links.macro_id unique index to unblock multi-inbox by @gbirman in https://github.com/macro-inc/macro/pull/3599
+* fix(auth): free in_progress_user_link slot on failed Gmail OAuth callback by @gbirman in https://github.com/macro-inc/macro/pull/3598
+* chore(pi): sqlx query validator skill by @whutchinson98 in https://github.com/macro-inc/macro/pull/3602
+* chore(pi): add rust validation skill by @whutchinson98 in https://github.com/macro-inc/macro/pull/3601
+* feat(github): add foreign entity for prs by @whutchinson98 in https://github.com/macro-inc/macro/pull/3590
+* db checker agent by @whutchinson98 in https://github.com/macro-inc/macro/pull/3603
+* feat: ai pricing by @ehayes2000 in https://github.com/macro-inc/macro/pull/3545
+* fix(sfs): add CORS headers to CloudFront /file/* responses by @ehayes2000 in https://github.com/macro-inc/macro/pull/3591
+* feat(ui): radio / checkbox by @Fake-User in https://github.com/macro-inc/macro/pull/3606
+* feat(md): delete btn and cmd-a override for markdown code boxes by @sedson in https://github.com/macro-inc/macro/pull/3607
+* fix(search): upgrade bundled pdfium to chromium/7857 by @gbirman in https://github.com/macro-inc/macro/pull/3609
+* feat(channels): repoint frontend channel ops from @service-comms to @service-storage by @synoet in https://github.com/macro-inc/macro/pull/3605
+* fix(mobile): clean up forward transition state machine by @peterchinman in https://github.com/macro-inc/macro/pull/3608
+* chore(deps): pin pdfium-render API to pdfium_7543 by @gbirman in https://github.com/macro-inc/macro/pull/3612
+* fix(login): auto focus email and otp inputs across stages by @synoet in https://github.com/macro-inc/macro/pull/3610
+* fix(ai): task properties by @whutchinson98 in https://github.com/macro-inc/macro/pull/3617
+* fix(md): escape hatches for lagging tanstack in rename mutation from title editor by @sedson in https://github.com/macro-inc/macro/pull/3616
+* chore(ci): simplify deploy pipeline by @whutchinson98 in https://github.com/macro-inc/macro/pull/3619
+* feat(multi-inbox): narrow-graph dispatch for cross-account inbox add by @gbirman in https://github.com/macro-inc/macro/pull/3614
+* fix(ui): single check by @Fake-User in https://github.com/macro-inc/macro/pull/3620
+* revert: remove FA IdP link data tagging by @gbirman in https://github.com/macro-inc/macro/pull/3621
+* fix(ui): stupid scroll hammer by @Fake-User in https://github.com/macro-inc/macro/pull/3622
+* feat(channels): port attachment references endpoint to channels hex by @synoet in https://github.com/macro-inc/macro/pull/3611
+* feat(core-components): simplify SplitFileMenu to use MobileDrawer and standard Dropdown by @sedson in https://github.com/macro-inc/macro/pull/3624
+* feat(fusionauth): reconcile lambda rejecting secondary-link sign-in by @gbirman in https://github.com/macro-inc/macro/pull/3623
+* feat(channels): serve channel list via storage client by @synoet in https://github.com/macro-inc/macro/pull/3625
+* fix(image_proxy): allow octet stream by @whutchinson98 in https://github.com/macro-inc/macro/pull/3628
+* fix(auth): return generic error when oauth callback has no code by @gbirman in https://github.com/macro-inc/macro/pull/3629
+* chore(channels): use MacroUserExtractor across channels handlers by @synoet in https://github.com/macro-inc/macro/pull/3631
+* feat(channels): port entity-mentions endpoints to channels hex by @synoet in https://github.com/macro-inc/macro/pull/3618
+* fix(mobile/share): dropdown scope and dismiss fix by @sedson in https://github.com/macro-inc/macro/pull/3634
+* fix[mobile]: restructure push notification navigation by @peterchinman in https://github.com/macro-inc/macro/pull/3633
+* feat(channels): port channel previews (POST /preview) to channels hex by @synoet in https://github.com/macro-inc/macro/pull/3615
+* feat(style): make empty states more descriptive and useful by @aidanhb in https://github.com/macro-inc/macro/pull/3627
+* style(properties): use panel components in call panel, restyle multiselect props, dropdown checkbox by @sedson in https://github.com/macro-inc/macro/pull/3639
+* feat(channels): port /activity endpoints to channels hex [3/7] by @synoet in https://github.com/macro-inc/macro/pull/3638
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.5.27.0...v2026.5.28.0
+    </Update>
+
+    <Update label="v2026.5.27.0">
+## What's Changed
+* feat(icon): Add animated top sidebar icons by @aidanhb in https://github.com/macro-inc/macro/pull/3560
+* feat: replace ai crate with agent crate powered by RIG by @ehayes2000 in https://github.com/macro-inc/macro/pull/3472
+* feat(foreign_entity): create foreign entity service by @whutchinson98 in https://github.com/macro-inc/macro/pull/3554
+* feat(ai): thinking by @ehayes2000 in https://github.com/macro-inc/macro/pull/3550
+* fix: push lockfile by @ehayes2000 in https://github.com/macro-inc/macro/pull/3561
+* chore: sqlx clippy rule by @whutchinson98 in https://github.com/macro-inc/macro/pull/3562
+* chore(sqlx): update migrate skill by @whutchinson98 in https://github.com/macro-inc/macro/pull/3563
+* feat(iOS): native iOS media attachments with staged uploads by @peterchinman in https://github.com/macro-inc/macro/pull/3441
+* chore(infra): enable join-shape call records index reads on prod by @gbirman in https://github.com/macro-inc/macro/pull/3501
+* fix(ai): merge consecutive deltas by @ehayes2000 in https://github.com/macro-inc/macro/pull/3564
+* chore(infra): enable join-shape chats index reads on prod by @gbirman in https://github.com/macro-inc/macro/pull/3498
+* feat(channels)!: hex channels crate, notif,realtime,contacts dispatch improvements by @synoet in https://github.com/macro-inc/macro/pull/3453
+* feat(github): allow non-teams to use sync by @whutchinson98 in https://github.com/macro-inc/macro/pull/3566
+* chore(readme): improve wording" by @synoet in https://github.com/macro-inc/macro/pull/3570
+* fix(ci): cancel stuck deploys by @whutchinson98 in https://github.com/macro-inc/macro/pull/3571
+* feat(ios): native call backend support by @peterchinman in https://github.com/macro-inc/macro/pull/3568
+* feat(entity-access): grant teammates CRM-scoped access to email threads by @evanhutnik in https://github.com/macro-inc/macro/pull/3572
+* chore(ai): add env var section to claude.md by @whutchinson98 in https://github.com/macro-inc/macro/pull/3575
+* fix(dss): fix notif env var by @synoet in https://github.com/macro-inc/macro/pull/3576
+* feat(ci): deploy all services on push by @whutchinson98 in https://github.com/macro-inc/macro/pull/3578
+* fix(mcp): add anthropic key by @ehayes2000 in https://github.com/macro-inc/macro/pull/3579
+* chg(channels): use new cloud-storage service client by @synoet in https://github.com/macro-inc/macro/pull/3573
+* feat(props): update system property priority critical -> urgent by @synoet in https://github.com/macro-inc/macro/pull/3574
+* fix(soup): fix sender reactivity on mobile inbox layout by @sedson in https://github.com/macro-inc/macro/pull/3583
+* feat(iac): add circuit breaker and timeout to service deployments by @whutchinson98 in https://github.com/macro-inc/macro/pull/3582
+* remove crap by @whutchinson98 in https://github.com/macro-inc/macro/pull/3586
+* feat(crm): expand generic email domain filter by @evanhutnik in https://github.com/macro-inc/macro/pull/3587
+* feat(channels): port context api to channels hex crate by @synoet in https://github.com/macro-inc/macro/pull/3581
+* fix(soup): inbox type filters not working correctly by @dev-rb in https://github.com/macro-inc/macro/pull/3588
+* fix(soup-view): defer auto-focus to break focus/setActiveScope loop by @gbirman in https://github.com/macro-inc/macro/pull/3585
+* feat(soup): restyle filter chips and add pop down filter chip bar by @sedson in https://github.com/macro-inc/macro/pull/3580
+* feat(channels): quote reply to thread message by @sedson in https://github.com/macro-inc/macro/pull/3589
+* fix(share): dropdown scoping and share modal styles by @sedson in https://github.com/macro-inc/macro/pull/3595
+* fix(channels): handle soft-delete of top-level messages with replies by @synoet in https://github.com/macro-inc/macro/pull/3594
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.5.26.1...v2026.5.27.0
+    </Update>
+
+    <Update label="v2026.5.26.1">
+## What's Changed
+* fix(calls): scrolling on calls by @synoet in https://github.com/macro-inc/macro/pull/3559
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.5.26.0...v2026.5.26.1
+    </Update>
+
+    <Update label="v2026.5.26.0">
+## What's Changed
+* fix(search): index persistent chats so agent chat content is searchable by @gbirman in https://github.com/macro-inc/macro/pull/3488
+* feat(search): multi-term AND with quoted-phrase support for channel messages by @gbirman in https://github.com/macro-inc/macro/pull/3489
+* feat(calls): show share with team in call record by @whutchinson98 in https://github.com/macro-inc/macro/pull/3485
+* feat(auth): add in ability to generate gmail account link by @whutchinson98 in https://github.com/macro-inc/macro/pull/3490
+* fix(calls): team share toggle) by @whutchinson98 in https://github.com/macro-inc/macro/pull/3494
+* feat(search): chats v2 parent/child join + keyset backfill by @gbirman in https://github.com/macro-inc/macro/pull/3492
+* feat(tasks): pretty branch names by @whutchinson98 in https://github.com/macro-inc/macro/pull/3495
+* feat(team): add CRM enable/disable endpoint with team-level killswitch by @evanhutnik in https://github.com/macro-inc/macro/pull/3486
+* chore(infra): enable join-shape chats index reads on dev by @gbirman in https://github.com/macro-inc/macro/pull/3497
+* fix migration collision by @evanhutnik in https://github.com/macro-inc/macro/pull/3502
+* chore(ai): update agents.md with sqlx migrate instructions by @whutchinson98 in https://github.com/macro-inc/macro/pull/3503
+* fix(md): weird spread bug with md awareness labels by @sedson in https://github.com/macro-inc/macro/pull/3504
+* feat(github): support team-slug pr task integration by @whutchinson98 in https://github.com/macro-inc/macro/pull/3506
+* fix(search): apply role filter inside each per-term has_child clause for chats by @gbirman in https://github.com/macro-inc/macro/pull/3507
+* feat(search): call records v2 parent/child join + keyset backfill by @gbirman in https://github.com/macro-inc/macro/pull/3499
+* chore(infra): enable join-shape call records index reads on dev by @gbirman in https://github.com/macro-inc/macro/pull/3500
+* fix(task-compose): fix tab nav and max height by @sedson in https://github.com/macro-inc/macro/pull/3509
+* style(md): improve sidepanel style and prop rendering by @sedson in https://github.com/macro-inc/macro/pull/3511
+* fix: show mobile send button when only attachments are present by @peterchinman in https://github.com/macro-inc/macro/pull/3445
+* fix(soup): task narrow view by @peterchinman in https://github.com/macro-inc/macro/pull/3439
+* fix(mobile): preserve text selection when dismissing keyboard via ges… by @peterchinman in https://github.com/macro-inc/macro/pull/3446
+* fix(mobile): only condense single channel-message stacks by @peterchinman in https://github.com/macro-inc/macro/pull/3440
+* fix(soup): properties not applied to duplicate entities by @dev-rb in https://github.com/macro-inc/macro/pull/3512
+* feat(teams): do not allow non-paying teams to invite or have members join by @whutchinson98 in https://github.com/macro-inc/macro/pull/3515
+* feat(crm): skip populate_contact when contact and user share a domain by @evanhutnik in https://github.com/macro-inc/macro/pull/3510
+* feat(tasks): show github pr in tasks by @whutchinson98 in https://github.com/macro-inc/macro/pull/3517
+* chore(ai): start .pi folder for ai helpers by @whutchinson98 in https://github.com/macro-inc/macro/pull/3518
+* feat(teams): show and allow team slug to be edited by @whutchinson98 in https://github.com/macro-inc/macro/pull/3519
+* feat(soup): bundle email_filter+crm_scope, extend /ast endpoint, optimize precheck by @evanhutnik in https://github.com/macro-inc/macro/pull/3516
+* feat(crm): track updated_at on crm_companies and crm_contacts by @evanhutnik in https://github.com/macro-inc/macro/pull/3520
+* chore(env): add EMAIL_BACKFILL_QUEUE to local env files by @evanhutnik in https://github.com/macro-inc/macro/pull/3521
+* fix(property): clicking on item in popover causes click to propagate by @dev-rb in https://github.com/macro-inc/macro/pull/3514
+* chore(ai): sqlx migration skill by @whutchinson98 in https://github.com/macro-inc/macro/pull/3524
+* feat(ui): input active by @Fake-User in https://github.com/macro-inc/macro/pull/3525
+* fix(ui): shove the mess under the bed by @Fake-User in https://github.com/macro-inc/macro/pull/3526
+* feat(github): pr enricher by @whutchinson98 in https://github.com/macro-inc/macro/pull/3522
+* feat(sidebar): promo card for plan upgrade by @dev-rb in https://github.com/macro-inc/macro/pull/3467
+* feat(paywall): new paywall content and plans (behind ff) by @dev-rb in https://github.com/macro-inc/macro/pull/3508
+* feat(ui): animate package by @Fake-User in https://github.com/macro-inc/macro/pull/3530
+* feat(split-layout): per-entry state + navigation cause (Phase 1) by @gbirman in https://github.com/macro-inc/macro/pull/3493
+* chore(property): finish migration to new property package by @sedson in https://github.com/macro-inc/macro/pull/3529
+* feat(search): preserve query and filters on back/forward (Phase 2) by @gbirman in https://github.com/macro-inc/macro/pull/3496
+* fix(dropdown): allow override for trigger size by @sedson in https://github.com/macro-inc/macro/pull/3531
+* fix(ui): avatar background anti-aliasing by @Fake-User in https://github.com/macro-inc/macro/pull/3532
+* fix(soup): clear stale group-by when switching views within a split by @gbirman in https://github.com/macro-inc/macro/pull/3534
+* fix(sidebar): feature flag promo card by @dev-rb in https://github.com/macro-inc/macro/pull/3528
+* fix(teams): gate invite and join behind plan check by @dev-rb in https://github.com/macro-inc/macro/pull/3527
+* chore(docker): use docker compose command so you can use podman under the hood by @whutchinson98 in https://github.com/macro-inc/macro/pull/3536
+* feat(ai): structured completion endpoint with agent by @ehayes2000 in https://github.com/macro-inc/macro/pull/3429
+* synoet/call restyle by @synoet in https://github.com/macro-inc/macro/pull/3505
+* feat(github): better github pr view in tasks by @whutchinson98 in https://github.com/macro-inc/macro/pull/3538
+* fix(sidebar): promo showing for paid users by @dev-rb in https://github.com/macro-inc/macro/pull/3542
+* refactor(soup-view): split preferences from entry state (Phase 3) by @gbirman in https://github.com/macro-inc/macro/pull/3535
+* fix(ui): remove old cancerous dropdown classes by @Fake-User in https://github.com/macro-inc/macro/pull/3544
+* refactor(login): remove custom button component by @dev-rb in https://github.com/macro-inc/macro/pull/3543
+* feat(sidebar): restore prior entry state on sidebar nav by @gbirman in https://github.com/macro-inc/macro/pull/3539
+* fix(props): unify priority critical label by @sedson in https://github.com/macro-inc/macro/pull/3549
+* feat[mobile]: swipe in animation, and other improvements by @peterchinman in https://github.com/macro-inc/macro/pull/3533
+* feat(crm): track first_interaction/last_interaction + is_sent populate gate by @evanhutnik in https://github.com/macro-inc/macro/pull/3548
+* feat(email): improve reply type dropdown UI with labels and better styling by @synoet in https://github.com/macro-inc/macro/pull/3547
+* fix(channels): optimistic deletion of top-level messages without replies by @synoet in https://github.com/macro-inc/macro/pull/3540
+* fix(settings): restore subscription tier svg animation by @dev-rb in https://github.com/macro-inc/macro/pull/3551
+* style(task): update style for github pr pill and add section to sidepanel by @sedson in https://github.com/macro-inc/macro/pull/3552
+* feat(calls): move call sharing controls to side panel by @synoet in https://github.com/macro-inc/macro/pull/3541
+* feat(db): add foreign entity table by @whutchinson98 in https://github.com/macro-inc/macro/pull/3546
+* fix(notif): channel reply notif title by @seanaye in https://github.com/macro-inc/macro/pull/3436
+* fix(settings): name change not working by @dev-rb in https://github.com/macro-inc/macro/pull/3553
+* fix(ai): Email tool improvements by @evanhutnik in https://github.com/macro-inc/macro/pull/3513
+* fix(ui): focus styling for `cta` button variant by @dev-rb in https://github.com/macro-inc/macro/pull/3556
+* feat(sidepanel): build out sidepanel ns components more by @sedson in https://github.com/macro-inc/macro/pull/3557
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.5.22.0...v2026.5.26.0
+    </Update>
+
+    <Update label="v2026.5.22.0">
+## What's Changed
+* feat(login): UI revamp behind FF by @dev-rb in https://github.com/macro-inc/macro/pull/3457
+* fix(soup): Entity being highlighted twice when in multiple groups by @dev-rb in https://github.com/macro-inc/macro/pull/3481
+* fix(md): add better vertical bounds checking for draggable block plugin by @sedson in https://github.com/macro-inc/macro/pull/3482
+* feat(teams): team task id by @whutchinson98 in https://github.com/macro-inc/macro/pull/3421
+* feat(crm): hide companies and contacts by @evanhutnik in https://github.com/macro-inc/macro/pull/3474
+* fix(task): create task for non-team members by @whutchinson98 in https://github.com/macro-inc/macro/pull/3483
+* fix(tasks): share with team by @whutchinson98 in https://github.com/macro-inc/macro/pull/3484
+* fix(channels): live updating by @synoet in https://github.com/macro-inc/macro/pull/3487
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.5.21.0...v2026.5.22.0
+    </Update>
+
+    <Update label="v2026.5.21.0">
+## What's Changed
+* Seanaye/feat/realtime notifs by @seanaye in https://github.com/macro-inc/macro/pull/3406
+* Seanaye/feat/handle fe notification updates by @seanaye in https://github.com/macro-inc/macro/pull/3432
+* fix: move screencast to right by @ehayes2000 in https://github.com/macro-inc/macro/pull/3433
+* fix(soup): search not working while group by is active by @dev-rb in https://github.com/macro-inc/macro/pull/3435
+* feat(crm): team-scoped email queries with CRM domain authorization by @evanhutnik in https://github.com/macro-inc/macro/pull/3213
+* Revert "feat(notys): make new content more visible to tab re-focus" by @synoet in https://github.com/macro-inc/macro/pull/3434
+* fix: disable overscroll on soup-view lists by @peterchinman in https://github.com/macro-inc/macro/pull/3438
+* feat(crm): populate CRM tables from sent-mail history by @evanhutnik in https://github.com/macro-inc/macro/pull/3377
+* fix(channels): soft-delete top-level messages with replies instead of removing by @synoet in https://github.com/macro-inc/macro/pull/3431
+* chore: update auto-update feature flag by @peterchinman in https://github.com/macro-inc/macro/pull/3437
+* feat(crm): wire populate/depopulate into inbox-sync, team-removal, and link-delete paths by @evanhutnik in https://github.com/macro-inc/macro/pull/3408
+* feat(ui): dropdown by @Fake-User in https://github.com/macro-inc/macro/pull/3447
+* feat(ai): grant llm access to soup ast by @seanaye in https://github.com/macro-inc/macro/pull/3443
+* feat(pricing): update to new subscription model by @whutchinson98 in https://github.com/macro-inc/macro/pull/3448
+* chore(infra): enable join-shape documents index reads on prod by @gbirman in https://github.com/macro-inc/macro/pull/3450
+* style/fix(properties): lots of property/dropdown fixes by @sedson in https://github.com/macro-inc/macro/pull/3442
+* chore(toolbar): move preview button to right toolbar in soup filters bar by @synoet in https://github.com/macro-inc/macro/pull/3451
+* fix(stripe): webhook for new price id by @whutchinson98 in https://github.com/macro-inc/macro/pull/3452
+* style(sidebar): sidebar and top bar style tweaks by @sedson in https://github.com/macro-inc/macro/pull/3454
+* style(projects): update project create dropdown by @sedson in https://github.com/macro-inc/macro/pull/3449
+* chore(task): update agent prompt guidance for PR titles and descriptions by @synoet in https://github.com/macro-inc/macro/pull/3461
+* fix: disable hover cards on mobile for mentions and user info by @peterchinman in https://github.com/macro-inc/macro/pull/3456
+* fix(md): update mobile mentions menu to always show 2 users if available by @sedson in https://github.com/macro-inc/macro/pull/3462
+* fix(ui): stamp dropdown by @Fake-User in https://github.com/macro-inc/macro/pull/3463
+* feat(projects): enable project sharing feature flag by default by @synoet in https://github.com/macro-inc/macro/pull/3458
+* feat(projects): refactor preview panel to prevent nested preview nesting by @synoet in https://github.com/macro-inc/macro/pull/3460
+* chore: improve zod usage in realtime notif update by @seanaye in https://github.com/macro-inc/macro/pull/3455
+* fix(ai): automations empty state by @ehayes2000 in https://github.com/macro-inc/macro/pull/3464
+* style(button): add scuffed color logic for cta theme by @sedson in https://github.com/macro-inc/macro/pull/3470
+* fix(search): include channel messages in inbox signal search results by @gbirman in https://github.com/macro-inc/macro/pull/3469
+* fix(ui): dechud some dropdowns by @Fake-User in https://github.com/macro-inc/macro/pull/3471
+* feat(crm): add email_sync toggle endpoint by @evanhutnik in https://github.com/macro-inc/macro/pull/3465
+* fix(md): resolve node id by walking state when cache misses by @gbirman in https://github.com/macro-inc/macro/pull/3468
+* fix(search): quoted phrases use phrase query in email SQS by @gbirman in https://github.com/macro-inc/macro/pull/3473
+* fix(mobile): squeeze unread indicator by @peterchinman in https://github.com/macro-inc/macro/pull/3475
+* fix(ui): default dark by @Fake-User in https://github.com/macro-inc/macro/pull/3476
+* feat(tasks): restyle and improve task compose modal by @sedson in https://github.com/macro-inc/macro/pull/3466
+* fix: move screencast top right by @ehayes2000 in https://github.com/macro-inc/macro/pull/3477
+* style: update rounding on md menu and toast by @sedson in https://github.com/macro-inc/macro/pull/3478
+* fix(ui): remove tab transition by @Fake-User in https://github.com/macro-inc/macro/pull/3479
+* style: tweak dropdown overlap by @sedson in https://github.com/macro-inc/macro/pull/3480
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.5.20.1...v2026.5.21.0
+    </Update>
+
+    <Update label="v2026.5.20.1">
+## What's Changed
+* Hexify GET /unfurl endpoint into new unfurl crate by @evanhutnik in https://github.com/macro-inc/macro/pull/3410
+* feat(notys): make new content more visible to tab re-focus by @aidanhb in https://github.com/macro-inc/macro/pull/3401
+* fix(ai): mcp reauth by @ehayes2000 in https://github.com/macro-inc/macro/pull/3411
+* fix(downloads): fix image download typing by @aidanhb in https://github.com/macro-inc/macro/pull/3414
+* feat(iac): include sts assume role policy for cloud storage service role by @whutchinson98 in https://github.com/macro-inc/macro/pull/3415
+* fix(styling): toolbar dropdown and unread messages by @jbecke in https://github.com/macro-inc/macro/pull/3413
+* fix(search): convert documents backfill to keyset pagination by @gbirman in https://github.com/macro-inc/macro/pull/3412
+* chore: kill dead code by @synoet in https://github.com/macro-inc/macro/pull/3360
+* Seanaye/chore/add tests by @seanaye in https://github.com/macro-inc/macro/pull/3416
+* fix(style): update top level sidebar command icons by @aidanhb in https://github.com/macro-inc/macro/pull/3420
+* feat(settings): display email for team members by @dev-rb in https://github.com/macro-inc/macro/pull/3422
+* fix(soup): group by query bugs by @dev-rb in https://github.com/macro-inc/macro/pull/3419
+* fix(ui): make shared send button and use in chat inputs by @sedson in https://github.com/macro-inc/macro/pull/3417
+* fix(search): use icu_folding for channel content analyzer by @gbirman in https://github.com/macro-inc/macro/pull/3423
+* fix(soup): incorrect navigation with collapsed group headers by @dev-rb in https://github.com/macro-inc/macro/pull/3425
+* fix(ui): typo by @Fake-User in https://github.com/macro-inc/macro/pull/3428
+* fix(search): skip rows with unknown file types in documents backfill by @gbirman in https://github.com/macro-inc/macro/pull/3426
+* style: soup create button by @sedson in https://github.com/macro-inc/macro/pull/3427
+* fix(md): floating scroll, update floating menu styles by @sedson in https://github.com/macro-inc/macro/pull/3430
+* fix(settings): return settings to previous tab state, try a more standard settings position by @sedson in https://github.com/macro-inc/macro/pull/3424
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.5.20...v2026.5.20.1
+    </Update>
+
+    <Update label="v2026.5.19.0">
+## What's Changed
+* chore: remove maybeResult by @synoet in https://github.com/macro-inc/macro/pull/3293
+* fix(soup): fix key properties for non task view by @sedson in https://github.com/macro-inc/macro/pull/3358
+* feat(comms): invite email contains better message content by @seanaye in https://github.com/macro-inc/macro/pull/3359
+* fix(github): do not auto-close task if PR is closed by @whutchinson98 in https://github.com/macro-inc/macro/pull/3362
+* perf(soup): more enhancements by @seanaye in https://github.com/macro-inc/macro/pull/3361
+* style(channel): tweak style nits by @sedson in https://github.com/macro-inc/macro/pull/3364
+* fic(ui): implement panel on SplitPanel by @Fake-User in https://github.com/macro-inc/macro/pull/3365
+* style(top bar): make collapsed tabs look like inset tab component by @sedson in https://github.com/macro-inc/macro/pull/3367
+* feat(onboarding): New onboarding flow and layout by @dev-rb in https://github.com/macro-inc/macro/pull/3316
+* fix(soup): can't preview entity in collapsed group by @dev-rb in https://github.com/macro-inc/macro/pull/3368
+* chore: unify tls provider by @seanaye in https://github.com/macro-inc/macro/pull/3363
+* feat: teams checkout support by @whutchinson98 in https://github.com/macro-inc/macro/pull/3366
+* feat(call): stability fixes to prevent call drops by @whutchinson98 in https://github.com/macro-inc/macro/pull/3370
+* remove obsolete cloud storage cache workflow by @seanaye in https://github.com/macro-inc/macro/pull/3371
+* Seanaye/chore/standalone dockerfile by @seanaye in https://github.com/macro-inc/macro/pull/3373
+* feat(mobile): make soup pretty by @peterchinman in https://github.com/macro-inc/macro/pull/3372
+* fix(ui): shit click setting by @Fake-User in https://github.com/macro-inc/macro/pull/3374
+* fix by @synoet in https://github.com/macro-inc/macro/pull/3375
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.5.18.1...v2026.5.19.0
+    </Update>
+
+    <Update label="v2026.5.18.1">
+## What's Changed
+* fix(ui): unify icons by @Fake-User in https://github.com/macro-inc/macro/pull/3328
+* fix(channels): scroll-to-bottom hotkey to use dedicated handler by @synoet in https://github.com/macro-inc/macro/pull/3330
+* fix(ui): settings and intvite by @Fake-User in https://github.com/macro-inc/macro/pull/3329
+* Add Conventional Commits guidance to task prompt by @synoet in https://github.com/macro-inc/macro/pull/3331
+* fix(channel): hide scroll-to-bottom while find bar is open by @gbirman in https://github.com/macro-inc/macro/pull/3333
+* feat(ui): start unifying inputs by @Fake-User in https://github.com/macro-inc/macro/pull/3334
+* style(md): reduce font sizes, un brick selection style, chg sidepanel breakpoints by @sedson in https://github.com/macro-inc/macro/pull/3335
+* fix(soup): assignee filter not working when group by active by @dev-rb in https://github.com/macro-inc/macro/pull/3336
+* fix(soup): "Not set" group loading wrong data when loading more by @dev-rb in https://github.com/macro-inc/macro/pull/3337
+* refactor(properties): begin refactor properties to use composable extractor pattern by @sedson in https://github.com/macro-inc/macro/pull/3332
+* fix(ui): icon / phosphor package by @Fake-User in https://github.com/macro-inc/macro/pull/3338
+* chg(ui): restyle references by @synoet in https://github.com/macro-inc/macro/pull/3340
+* fix(mobile): markdown stuck in readonly by @peterchinman in https://github.com/macro-inc/macro/pull/3341
+* feat(soup): group by assignee by @dev-rb in https://github.com/macro-inc/macro/pull/3339
+* feat(soup): better group by ordering by @dev-rb in https://github.com/macro-inc/macro/pull/3342
+* chg(calls): remove call again button from soup, make channel call button nicer by @synoet in https://github.com/macro-inc/macro/pull/3344
+* feat(search): add documents_v2 parent/child index and join-shape upsert by @gbirman in https://github.com/macro-inc/macro/pull/3345
+* fix(calls): include customName in call preview by @synoet in https://github.com/macro-inc/macro/pull/3346
+* refactor(toast): move to options rather than position args, tweak styles for mobile toasts by @sedson in https://github.com/macro-inc/macro/pull/3347
+* fix(mobile): spurious virtual keyboard signal by @peterchinman in https://github.com/macro-inc/macro/pull/3349
+* fix(mobile channels): lightbox zoompinch waits for image load by @peterchinman in https://github.com/macro-inc/macro/pull/3351
+* style(task): kill horror task toast by @sedson in https://github.com/macro-inc/macro/pull/3352
+* refactor(properties): move code from core to properties package, continue component improve by @sedson in https://github.com/macro-inc/macro/pull/3350
+* style(list): hover vs select style by @sedson in https://github.com/macro-inc/macro/pull/3353
+* fix(soup): group by header label not reactive by @dev-rb in https://github.com/macro-inc/macro/pull/3355
+* feat(soup): default task view group by by @dev-rb in https://github.com/macro-inc/macro/pull/3356
+* fix(soup): keep search bar focusable when editor collapses to 0 height by @gbirman in https://github.com/macro-inc/macro/pull/3354
+* chore(soup): bump persisted state version by @dev-rb in https://github.com/macro-inc/macro/pull/3357
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.5.18.0...v2026.5.18.1
+    </Update>
+
+    <Update label="v2026.5.18.0">
+## What's Changed
+* fix(convert): dyn linking by @seanaye in https://github.com/macro-inc/macro/pull/3320
+* enable dev tools in prod ios app by @seanaye in https://github.com/macro-inc/macro/pull/3321
+* feat(ui): individual notification enbeutification by @synoet in https://github.com/macro-inc/macro/pull/3312
+* chore: update readme by @synoet in https://github.com/macro-inc/macro/pull/3322
+* fix(ui): text-selection by @Fake-User in https://github.com/macro-inc/macro/pull/3323
+* fix(channel): restore call case in stringToItemType by @gbirman in https://github.com/macro-inc/macro/pull/3324
+* fix(ui) scuffed chat inputs by @Fake-User in https://github.com/macro-inc/macro/pull/3325
+* feat(search): match group-by header style for search sections by @gbirman in https://github.com/macro-inc/macro/pull/3315
+* fix(command): track recency for parent-scope commands by @gbirman in https://github.com/macro-inc/macro/pull/3326
+* fix(core): dismiss mention hover cards on scroll by @gbirman in https://github.com/macro-inc/macro/pull/3313
+* fix(ui): channel button sizes by @Fake-User in https://github.com/macro-inc/macro/pull/3327
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.5.16.0...v2026.5.18.0
+    </Update>
+
+    <Update label="v2026.5.16.0">
+## What's Changed
+* feat(soup): two week window for inbox signal view by @dev-rb in https://github.com/macro-inc/macro/pull/3196
+* feat!(documents): document creation centralization, richer location metadata / state, backend markdown initialization by @synoet in https://github.com/macro-inc/macro/pull/3156
+* rm: stupid artifcact by @synoet in https://github.com/macro-inc/macro/pull/3238
+* chg: add document finalizer to ci by @synoet in https://github.com/macro-inc/macro/pull/3239
+* Seanaye/ci/skip cachix on network failure by @seanaye in https://github.com/macro-inc/macro/pull/3240
+* feat(ai): Basic support for external MCP servers by @ehayes2000 in https://github.com/macro-inc/macro/pull/3217
+* fix(style): subtly style unread channel images by @aidanhb in https://github.com/macro-inc/macro/pull/3241
+* fix(call): noise filtering issues in noisy environments by @whutchinson98 in https://github.com/macro-inc/macro/pull/3233
+* chg(dss/sync): remove sync metadata from location_v3 response by @synoet in https://github.com/macro-inc/macro/pull/3242
+* chg(dss): optimistically initialize document location state to ready for historical docs by @synoet in https://github.com/macro-inc/macro/pull/3244
+* fix(finalizer): do not rely on uploaded for converted docx files by @synoet in https://github.com/macro-inc/macro/pull/3245
+* feat(call): display speaker id in call transcript by @whutchinson98 in https://github.com/macro-inc/macro/pull/3246
+* feat(call): only assign voice if user is within team scope by @whutchinson98 in https://github.com/macro-inc/macro/pull/3247
+* fix(finalizer): chg policy to allow get object for reading md in bucket by @synoet in https://github.com/macro-inc/macro/pull/3249
+* fix(ui): annihilate index.css by @Fake-User in https://github.com/macro-inc/macro/pull/3251
+* fix(email): add @mention'd users to CC in reply and compose by @evanhutnik in https://github.com/macro-inc/macro/pull/3248
+* fix(mobile): loading block by @seanaye in https://github.com/macro-inc/macro/pull/3243
+* feat(ui): scroll bar height by @Fake-User in https://github.com/macro-inc/macro/pull/3255
+* feat(call): attempt to stabilize diarization by @whutchinson98 in https://github.com/macro-inc/macro/pull/3252
+* fix(notif): document mention push notificaiton opens message by @seanaye in https://github.com/macro-inc/macro/pull/3257
+* fix(mentions): restore results after no-results state in mobile mentions menu by @gbirman in https://github.com/macro-inc/macro/pull/3258
+* feat(channel): highlight matched text in find bar results by @gbirman in https://github.com/macro-inc/macro/pull/3254
+* fix(upload): add bulk-uploaded folder to history for mentions by @gbirman in https://github.com/macro-inc/macro/pull/3261
+* feat(core): side panel component first pass, flagged off by @sedson in https://github.com/macro-inc/macro/pull/3262
+* fix(soup): optimistically populate new folder + children after bulk upload by @gbirman in https://github.com/macro-inc/macro/pull/3264
+* fix: missing database envs by @seanaye in https://github.com/macro-inc/macro/pull/3265
+* fix(task): enable undo/redo in create task description editor by @gbirman in https://github.com/macro-inc/macro/pull/3271
+* fix(mentions): fall back to props.blockName when resolved entity is unknown by @gbirman in https://github.com/macro-inc/macro/pull/3269
+* fix(notif): make full collapsible row clickable to expand by @gbirman in https://github.com/macro-inc/macro/pull/3268
+* fix convert service deployment configuration by @seanaye in https://github.com/macro-inc/macro/pull/3272
+* perf(soup): more query improvements by @seanaye in https://github.com/macro-inc/macro/pull/3270
+* chore: remove glob exports by @seanaye in https://github.com/macro-inc/macro/pull/3267
+* fix(soup): expand find bar in narrow split via SplitHeaderRight by @gbirman in https://github.com/macro-inc/macro/pull/3275
+* fix(ai): mobile overflow by @ehayes2000 in https://github.com/macro-inc/macro/pull/3273
+* fix(soup-task-view): add single click header logic by @sedson in https://github.com/macro-inc/macro/pull/3266
+* fix(channel): render call and empty-subject email shares correctly by @gbirman in https://github.com/macro-inc/macro/pull/3276
+* feat(call): expose summary to read call tool by @whutchinson98 in https://github.com/macro-inc/macro/pull/3279
+* feat(dss/sync): backfill script by @synoet in https://github.com/macro-inc/macro/pull/3263
+* feat(notif): add subtype to more payloads by @seanaye in https://github.com/macro-inc/macro/pull/3277
+* feat(ui): update toggle switch by @Fake-User in https://github.com/macro-inc/macro/pull/3282
+* style(md/task): properties sidepanel by @sedson in https://github.com/macro-inc/macro/pull/3281
+* fix(ui): toasts, settings by @Fake-User in https://github.com/macro-inc/macro/pull/3283
+* Adjust sidebar max width and Surface corner radius for UI consistency by @jbecke in https://github.com/macro-inc/macro/pull/3274
+* fix(channel): misaligned rails by @sedson in https://github.com/macro-inc/macro/pull/3284
+* style(list/command): selection vs hover style improvements after jacob retheme by @sedson in https://github.com/macro-inc/macro/pull/3285
+* fix(ui): update hover card by @Fake-User in https://github.com/macro-inc/macro/pull/3286
+* fix(call): soup record row alignment by @whutchinson98 in https://github.com/macro-inc/macro/pull/3287
+* feat(soup): backend group by support [stack/01] by @dev-rb in https://github.com/macro-inc/macro/pull/3105
+* feat(ai): Mcp by @ehayes2000 in https://github.com/macro-inc/macro/pull/3260
+* style(nits): launcher, sidebar, topbar button lightness, modal overlay by @sedson in https://github.com/macro-inc/macro/pull/3291
+* feat(soup): frontend group by [stack/02] by @dev-rb in https://github.com/macro-inc/macro/pull/3164
+* fix(ui): chanel hover by @Fake-User in https://github.com/macro-inc/macro/pull/3292
+* feat(teams): remove team user tier and default team users to Opus tier by @whutchinson98 in https://github.com/macro-inc/macro/pull/3278
+* feat(ci): add in scheduled job canceller and timeout on deploy by @whutchinson98 in https://github.com/macro-inc/macro/pull/3296
+* Persist mobile soup list queries by @seanaye in https://github.com/macro-inc/macro/pull/3294
+* feat(team): setup team plan and updating team plan by @whutchinson98 in https://github.com/macro-inc/macro/pull/3295
+* feat(teams): remove premium user gate on team creation by @whutchinson98 in https://github.com/macro-inc/macro/pull/3280
+* fix(soup): poor ui styling for group by load more and group headers by @dev-rb in https://github.com/macro-inc/macro/pull/3297
+* fix(ui): toolip portal issues with items that mount / onmount on hover by @Fake-User in https://github.com/macro-inc/macro/pull/3299
+* feat(ai): slack mcp by @ehayes2000 in https://github.com/macro-inc/macro/pull/3298
+* fix(soup): task columns not rendering anymore by @dev-rb in https://github.com/macro-inc/macro/pull/3300
+* chore: symlink agents.md by @whutchinson98 in https://github.com/macro-inc/macro/pull/3302
+* check invite count against seat count by @whutchinson98 in https://github.com/macro-inc/macro/pull/3303
+* feat(ai): notion + fix infra by @ehayes2000 in https://github.com/macro-inc/macro/pull/3304
+* feat(email): restyle by @synoet in https://github.com/macro-inc/macro/pull/3301
+* perf(channel): make search in channel gooder by @gbirman in https://github.com/macro-inc/macro/pull/3305
+* feat(core): new tabs component and use in top bar and command by @sedson in https://github.com/macro-inc/macro/pull/3306
+* fix(soup): group by option persisting across all tabs by @dev-rb in https://github.com/macro-inc/macro/pull/3307
+* fix: flag slack mcp by @ehayes2000 in https://github.com/macro-inc/macro/pull/3308
+* fix(channel): stop findbar previous from wrapping past most recent by @gbirman in https://github.com/macro-inc/macro/pull/3310
+* fix(ui): scroll bars, border radius, panels by @Fake-User in https://github.com/macro-inc/macro/pull/3311
+* fix(style): various style nits and upgrades by @sedson in https://github.com/macro-inc/macro/pull/3314
+* style(task): improve prop sidbar, add prop inline by @sedson in https://github.com/macro-inc/macro/pull/3318
+* fix(ui): dechud attachments by @Fake-User in https://github.com/macro-inc/macro/pull/3317
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.5.13.0...v2026.5.16.0
+    </Update>
+
+    <Update label="v2026.5.13.0">
+## What's Changed
+* fix(comms): persist mention edits on patch_message by @gbirman in https://github.com/macro-inc/macro/pull/3204
+* feat(documents): add separate Videos filter to documents view by @gbirman in https://github.com/macro-inc/macro/pull/3222
+* fix(soup): properties query performance by @seanaye in https://github.com/macro-inc/macro/pull/3212
+* chg: use static markdown in calls by @synoet in https://github.com/macro-inc/macro/pull/3221
+* feat(ui): flatten tokens by @Fake-User in https://github.com/macro-inc/macro/pull/3224
+* remove convert service from services-config.json to disable its deplo… by @whutchinson98 in https://github.com/macro-inc/macro/pull/3225
+* fix(call): you pane by @whutchinson98 in https://github.com/macro-inc/macro/pull/3226
+* fix(call): call success boundary by @whutchinson98 in https://github.com/macro-inc/macro/pull/3227
+* theme tweak lapis by @sedson in https://github.com/macro-inc/macro/pull/3218
+* style(launcher): use item colors not active for selected el by @sedson in https://github.com/macro-inc/macro/pull/3228
+* feat(soup): better notification styling by @synoet in https://github.com/macro-inc/macro/pull/3223
+* fix(ui): small tweaks before deploy by @Fake-User in https://github.com/macro-inc/macro/pull/3229
+* chg(calls): participants above summary by @synoet in https://github.com/macro-inc/macro/pull/3231
+* fix(email): Reply all logic by @evanhutnik in https://github.com/macro-inc/macro/pull/3230
+* feat(resize): impl target size on panel registration, use for soup preview by @sedson in https://github.com/macro-inc/macro/pull/3234
+* synoet/fix calls use correct name by @synoet in https://github.com/macro-inc/macro/pull/3232
+* style(soup): btn styles for filter and sort by @sedson in https://github.com/macro-inc/macro/pull/3235
+* fix(email): focus editor when opening reply by @evanhutnik in https://github.com/macro-inc/macro/pull/3236
+* fix(pdf): markup btns can click by @sedson in https://github.com/macro-inc/macro/pull/3237
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.5.12.0...v2026.5.13.0
+    </Update>
+
+    <Update label="v2026.5.12.0">
+## What's Changed
+* feat(call): auto-assign voice to macro user by @whutchinson98 in https://github.com/macro-inc/macro/pull/3183
+* style(soup): update task grid view by @sedson in https://github.com/macro-inc/macro/pull/3188
+* feat(call): de-fluff ai call summary by @whutchinson98 in https://github.com/macro-inc/macro/pull/3189
+* Seanaye/ci/lambdas build by @seanaye in https://github.com/macro-inc/macro/pull/3162
+* feat(call): auto-assign voice to macro user by @whutchinson98 in https://github.com/macro-inc/macro/pull/3191
+* feat(soup): date range filters by @dev-rb in https://github.com/macro-inc/macro/pull/2982
+* chore: rename uList container to u-list by @sedson in https://github.com/macro-inc/macro/pull/3190
+* feat(search): return total_count from channel search by @gbirman in https://github.com/macro-inc/macro/pull/3194
+* fix(style): Make non-video user cards more visually distinct with bg … by @aidanhb in https://github.com/macro-inc/macro/pull/3197
+* feat(ui): add ButtonGroup, update common topbar buttons by @sedson in https://github.com/macro-inc/macro/pull/3195
+* feat(entity-access): Teams support by @evanhutnik in https://github.com/macro-inc/macro/pull/3184
+* feat(calls): add call again button to call records by @aidanhb in https://github.com/macro-inc/macro/pull/3199
+* Seanaye/ci/crane deploy all by @seanaye in https://github.com/macro-inc/macro/pull/3193
+* refactor(teams): team endpoints no longer require team id by @whutchinson98 in https://github.com/macro-inc/macro/pull/3201
+* feat(ui): new tooltip and popover by @Fake-User in https://github.com/macro-inc/macro/pull/3202
+* feat(channel): cmd+F find-bar for in-channel message search by @gbirman in https://github.com/macro-inc/macro/pull/3100
+* fix(ui): cleanup hover card by @Fake-User in https://github.com/macro-inc/macro/pull/3205
+* fix(soup): drop mention AND filter from soup search bar by @gbirman in https://github.com/macro-inc/macro/pull/3206
+* style(core): update default themes, other assorted style fixes, add theme swatched to cmd+l" by @sedson in https://github.com/macro-inc/macro/pull/3207
+* chore(theme): remove faded placeholders after fixing placeholder token by @sedson in https://github.com/macro-inc/macro/pull/3209
+* fix(onboarding): stripe return url not handled properly by @dev-rb in https://github.com/macro-inc/macro/pull/3203
+* fix(ui): hotkey tokens and hovercard by @Fake-User in https://github.com/macro-inc/macro/pull/3210
+* feat(style): restyle call team share toggle by @aidanhb in https://github.com/macro-inc/macro/pull/3200
+* fix(ui): a couple scuffed hotkeys by @Fake-User in https://github.com/macro-inc/macro/pull/3211
+* chore(local): disable voip sns locally by @synoet in https://github.com/macro-inc/macro/pull/3216
+* feat(email): backend date range support for emails by @dev-rb in https://github.com/macro-inc/macro/pull/3198
+* feat(soup/tasks): add quick sort click to column headers by @sedson in https://github.com/macro-inc/macro/pull/3214
+* fix(style): tweak macro light and fix some btn styles by @sedson in https://github.com/macro-inc/macro/pull/3215
+* fic(ui): sidebar buttons by @Fake-User in https://github.com/macro-inc/macro/pull/3219
+* feat(channel): show total match count in find bar by @gbirman in https://github.com/macro-inc/macro/pull/3208
+* feat(calls): improve call ui by @synoet in https://github.com/macro-inc/macro/pull/3220
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.5.11.0...v2026.5.12.0
+    </Update>
+
+    <Update label="v2026.5.11.0">
+## What's Changed
+* feat(search): channel content thread-mode sort by @gbirman in https://github.com/macro-inc/macro/pull/3150
+* feat(call): better call ring in browser by @whutchinson98 in https://github.com/macro-inc/macro/pull/3008
+* Fix sqlx prepare invocation by @seanaye in https://github.com/macro-inc/macro/pull/3165
+* fix(call): remove join_call from history to prevent going back into the call by @whutchinson98 in https://github.com/macro-inc/macro/pull/3168
+* remove test prepare by @seanaye in https://github.com/macro-inc/macro/pull/3169
+* chore(search): drop one-time alias migration docs and helpers by @gbirman in https://github.com/macro-inc/macro/pull/3170
+* fix(search): aggregate sliced reindex progress from sub-tasks by @gbirman in https://github.com/macro-inc/macro/pull/3113
+* style(channels): add block quote btn to format ribbon, update fmt ribbon button use by @sedson in https://github.com/macro-inc/macro/pull/3171
+* Fix(dss): thread commenter gets subscribed to thread by @seanaye in https://github.com/macro-inc/macro/pull/3173
+* Speed up database-backed CI tests by @seanaye in https://github.com/macro-inc/macro/pull/3166
+* fix(ui):  small bugs, theme stuff, icon stuff, dropdown stuff by @Fake-User in https://github.com/macro-inc/macro/pull/3174
+* fix(create): chg mobile soup create btn to onClick, removce duplicate hk registraction for create by @sedson in https://github.com/macro-inc/macro/pull/3172
+* feat(calls): voice id live kit agent by @whutchinson98 in https://github.com/macro-inc/macro/pull/3167
+* feat(call): tiny video for user by @whutchinson98 in https://github.com/macro-inc/macro/pull/3175
+* feat(call): rollup transcripts by @whutchinson98 in https://github.com/macro-inc/macro/pull/3176
+* fix web app archive deploy by @seanaye in https://github.com/macro-inc/macro/pull/3180
+* fix(avatar): fix avi alignment in soup, use avi for sidebar channels by @sedson in https://github.com/macro-inc/macro/pull/3177
+* fix(ui): kill hotkey by @Fake-User in https://github.com/macro-inc/macro/pull/3178
+* fix(call): call transcription voice by @whutchinson98 in https://github.com/macro-inc/macro/pull/3179
+* fix(iac): deny deployment if localPath does not contain files by @whutchinson98 in https://github.com/macro-inc/macro/pull/3181
+* fix model access by @ehayes2000 in https://github.com/macro-inc/macro/pull/3163
+* fix(ui): tabs chevron && resize handle by @Fake-User in https://github.com/macro-inc/macro/pull/3185
+* feat(mobile): unflag mobile qr by @Fake-User in https://github.com/macro-inc/macro/pull/3187
+* feat(tasks): simple grid-based task view by @sedson in https://github.com/macro-inc/macro/pull/3056
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.5.8.0...v2026.5.11.0
+    </Update>
+
+    <Update label="v2026.5.8.0">
+## What's Changed
+* feat(ui): scrollbar by @Fake-User in https://github.com/macro-inc/macro/pull/3136
+* fix(style): fix email thread styling, add rail color token, tweak channel flag styles to be more legible by @sedson in https://github.com/macro-inc/macro/pull/3129
+* style(channels): use core button in actions menu, update reaction chips by @sedson in https://github.com/macro-inc/macro/pull/3133
+* fix(local): lexical-service & sync-service running locally by @synoet in https://github.com/macro-inc/macro/pull/3139
+* chore(dx): update local bun check scripts to match ci, style(comments): change comment thread styles, fix busted user icons by @sedson in https://github.com/macro-inc/macro/pull/3137
+* fix(channels): infinite typing indicators by @synoet in https://github.com/macro-inc/macro/pull/3138
+* chore(loro): remove react package from loro-mirror by @synoet in https://github.com/macro-inc/macro/pull/3141
+* chore(local/sync): properly run migrations when running locally by @synoet in https://github.com/macro-inc/macro/pull/3143
+* fix(ui): split header / search by @Fake-User in https://github.com/macro-inc/macro/pull/3142
+* fix ios notification body for attachment-only channel messages by @seanaye in https://github.com/macro-inc/macro/pull/3140
+* shrink image builder by @seanaye in https://github.com/macro-inc/macro/pull/3144
+* feat(sync/ws): de-duplicate permission token requests by @synoet in https://github.com/macro-inc/macro/pull/3146
+* feat(sps): always populate channel message thread_id by @gbirman in https://github.com/macro-inc/macro/pull/3148
+* chore: cleanup todos by @ehayes2000 in https://github.com/macro-inc/macro/pull/3149
+* Seanaye/ci/move jobs to smaller runners by @seanaye in https://github.com/macro-inc/macro/pull/3147
+* Build deploy service binaries with Nix by @seanaye in https://github.com/macro-inc/macro/pull/3128
+* Seanaye/fix/unexpanded soup ast by @seanaye in https://github.com/macro-inc/macro/pull/3151
+* Seanaye/ci/dry up and use cachix by @seanaye in https://github.com/macro-inc/macro/pull/3153
+* feat(sync): warmup document on wakeup by @synoet in https://github.com/macro-inc/macro/pull/3154
+* Ignore prebuilt artifacts when hashing lambdas by @seanaye in https://github.com/macro-inc/macro/pull/3155
+* perf(email): materialize address-pushdown CTE for soup pagination by @evanhutnik in https://github.com/macro-inc/macro/pull/3152
+* fix(rabbit): CI by @ehayes2000 in https://github.com/macro-inc/macro/pull/3118
+* fix(ui): preview button active state visible by @gbirman in https://github.com/macro-inc/macro/pull/3157
+* fix(video): show progress toast while downloading by @gbirman in https://github.com/macro-inc/macro/pull/3159
+* style(channel): restyle channel date flags by @sedson in https://github.com/macro-inc/macro/pull/3160
+* fix(ui): toolbar by @Fake-User in https://github.com/macro-inc/macro/pull/3161
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.5.7.1...v2026.5.8.0
+    </Update>
+
+    <Update label="v2026.5.7.1">
+## What's Changed
+* fix[callkit]: guard with feature flag by @peterchinman in https://github.com/macro-inc/macro/pull/3135
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.5.7.0...v2026.5.7.1
+    </Update>
+
+    <Update label="v2026.5.7.0">
+## What's Changed
+* feat(ui): implement window component by @Fake-User in https://github.com/macro-inc/macro/pull/3117
+* feat(ui): add ring by @Fake-User in https://github.com/macro-inc/macro/pull/3119
+* fix(channels): don't blank on load_around non existing message by @synoet in https://github.com/macro-inc/macro/pull/3093
+* fix(ui) rename panel -> surface && window -> panel by @Fake-User in https://github.com/macro-inc/macro/pull/3120
+* feat[ios]: call kit plugin by @peterchinman in https://github.com/macro-inc/macro/pull/3095
+* fix[callkit]: remove duplicate notification service stack by @peterchinman in https://github.com/macro-inc/macro/pull/3122
+* fix(ui): tailwind and imports by @Fake-User in https://github.com/macro-inc/macro/pull/3123
+* use nix cachix in ci by @seanaye in https://github.com/macro-inc/macro/pull/2971
+* feat(sps): support index_override on every entity backfill by @gbirman in https://github.com/macro-inc/macro/pull/3116
+* fix[callkit]: fix pulumi config by @peterchinman in https://github.com/macro-inc/macro/pull/3125
+* chg(loro): move loro-mirror into js workspace by @synoet in https://github.com/macro-inc/macro/pull/3126
+* use nix sccahe in typegen by @seanaye in https://github.com/macro-inc/macro/pull/3124
+* chg(lexical): move loro lexical schema into lexical-core by @synoet in https://github.com/macro-inc/macro/pull/3127
+* feat(lexical-service): endpoint for md -> snapshot conversion by @synoet in https://github.com/macro-inc/macro/pull/3130
+* fix[call-kit]: add tauri capabilities and required sns key by @peterchinman in https://github.com/macro-inc/macro/pull/3131
+* chg(lexical_client): add handler for snapshot creation by @synoet in https://github.com/macro-inc/macro/pull/3132
+* chg(sync/dss): initialize markdown document util for dss by @synoet in https://github.com/macro-inc/macro/pull/3134
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.5.6.1...v2026.5.7.0
+    </Update>
+
+    <Update label="v2026.5.6.1">
+## What's Changed
+* fic(ui): button and window by @Fake-User in https://github.com/macro-inc/macro/pull/3111
+* fix(soup): show unrolled notifications in soup by @synoet in https://github.com/macro-inc/macro/pull/3112
+* fix(soup): mentions have bad wrapping by @synoet in https://github.com/macro-inc/macro/pull/3114
+* fix(ai): button no border by @synoet in https://github.com/macro-inc/macro/pull/3115
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.5.6.0...v2026.5.6.1
+    </Update>
+
+    <Update label="v2026.5.6.0">
+## What's Changed
+* fix(kommand): skip scroll-to-index when items fit container by @gbirman in https://github.com/macro-inc/macro/pull/3083
+* fix: sanitize title branch name construction to match GitHub support on backend by @gbirman in https://github.com/macro-inc/macro/pull/3079
+* patch rustup into path by @seanaye in https://github.com/macro-inc/macro/pull/3087
+* feat(ai): add query construction guidance to search tool descriptions by @gbirman in https://github.com/macro-inc/macro/pull/3088
+* fix(sps): use internal_auth_key when calling lexical-service by @gbirman in https://github.com/macro-inc/macro/pull/3084
+* fix(ai): suppress noisy log by @ehayes2000 in https://github.com/macro-inc/macro/pull/3092
+* fix(ai): bump stream ttl by @ehayes2000 in https://github.com/macro-inc/macro/pull/3086
+* fix(sps): background backfill so it doesn't time out at the ALB by @gbirman in https://github.com/macro-inc/macro/pull/3096
+* fix(ai): remove send email from mcp server by @ehayes2000 in https://github.com/macro-inc/macro/pull/3089
+* fix(search): break created_at ties using message_id (uuidv7) by @gbirman in https://github.com/macro-inc/macro/pull/3097
+* fix(ai): token loss on error + error type by @ehayes2000 in https://github.com/macro-inc/macro/pull/3091
+* feat(ai): concurrent tool call processing by @ehayes2000 in https://github.com/macro-inc/macro/pull/3085
+* fix[channels]: scroll thread reply input into view by @peterchinman in https://github.com/macro-inc/macro/pull/3067
+* fix[mobile]: ui for auto-update by @peterchinman in https://github.com/macro-inc/macro/pull/3094
+* fix[mobile channels]: create task in action drawer by @peterchinman in https://github.com/macro-inc/macro/pull/3090
+* Fix expanded email width bug by @evanhutnik in https://github.com/macro-inc/macro/pull/3103
+* feat(search): alias all OpenSearch indices for zero-downtime reindex by @gbirman in https://github.com/macro-inc/macro/pull/3101
+* fix(ui): one f*&*^ button by @Fake-User in https://github.com/macro-inc/macro/pull/3106
+* fix(sps): back the backfill job registry with dynamodb by @gbirman in https://github.com/macro-inc/macro/pull/3102
+* fix[email digest]: truncate long messages by @peterchinman in https://github.com/macro-inc/macro/pull/3104
+* feat(search): async reindex with slicing + task polling by @gbirman in https://github.com/macro-inc/macro/pull/3107
+* refactor(soup): add group by support and update soup state data type by @dev-rb in https://github.com/macro-inc/macro/pull/2819
+* fix(email): prevent post-send and post-delete draft resurrection by @evanhutnik in https://github.com/macro-inc/macro/pull/3099
+* Seanaye/fix/signal filter push by @seanaye in https://github.com/macro-inc/macro/pull/3108
+* feat(email): hide thread reply box behind Reply/Forward buttons by @evanhutnik in https://github.com/macro-inc/macro/pull/3109
+* chore(core): make better Avatar Ui component, kill unused sizes, use correctly by @sedson in https://github.com/macro-inc/macro/pull/3110
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.5.5.0...v2026.5.6.0
+    </Update>
+
+    <Update label="v2026.5.5.0">
+## What's Changed
+* add more enqueueing contacts messages by @seanaye in https://github.com/macro-inc/macro/pull/3032
+* fix[tauri]: make xcode project build by @peterchinman in https://github.com/macro-inc/macro/pull/3059
+* fix(ui): update all settings tabs by @Fake-User in https://github.com/macro-inc/macro/pull/3060
+* fix(ui): delete bracket by @Fake-User in https://github.com/macro-inc/macro/pull/3061
+* fix(ui): settings dropdown by @Fake-User in https://github.com/macro-inc/macro/pull/3062
+* fix(ui): kill bracket even more. replace with add bg-active by @Fake-User in https://github.com/macro-inc/macro/pull/3064
+* fix(ui): slider thumb by @Fake-User in https://github.com/macro-inc/macro/pull/3065
+* style(md): update padding and layer style of document embed cards by @sedson in https://github.com/macro-inc/macro/pull/3063
+* chore(style): kill cursor pointer by @sedson in https://github.com/macro-inc/macro/pull/3066
+* feat(onboarding): track team creation and skip events by @evanhutnik in https://github.com/macro-inc/macro/pull/3068
+* fix(ui): better theme tools by @Fake-User in https://github.com/macro-inc/macro/pull/3070
+* style(md): update code colors in md themes by @sedson in https://github.com/macro-inc/macro/pull/3069
+* feat(onboarding): better teams steps, cost summary, teams analytics by @dev-rb in https://github.com/macro-inc/macro/pull/3047
+* style(core): add border to tooltips by @sedson in https://github.com/macro-inc/macro/pull/3072
+* chore(style): remove opacity modfied from hover/N bgs by @sedson in https://github.com/macro-inc/macro/pull/3073
+* feat(teams): invite members with a specific tier by @dev-rb in https://github.com/macro-inc/macro/pull/3038
+* fix(search): repair broken OpenSearch delete path + surface deleted_at by @gbirman in https://github.com/macro-inc/macro/pull/3074
+* fix(ui): one modal by @Fake-User in https://github.com/macro-inc/macro/pull/3077
+* fix(kommand): preserve non-search row selection across tab by @gbirman in https://github.com/macro-inc/macro/pull/3075
+* chore(ai): document actual search multi-term semantics in tool descriptions by @gbirman in https://github.com/macro-inc/macro/pull/3076
+* Seanaye/feat/push notif for signal email by @seanaye in https://github.com/macro-inc/macro/pull/3040
+* feat(sps): add deletion_filter to search backfill requests by @gbirman in https://github.com/macro-inc/macro/pull/3080
+* fix(ai): stream logging by @ehayes2000 in https://github.com/macro-inc/macro/pull/3078
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.5.4.0...v2026.5.5.0
+    </Update>
+
+    <Update label="v2026.5.4.0">
+## What's Changed
+* feat(kommand): full-text search row in command menu by @gbirman in https://github.com/macro-inc/macro/pull/3000
+* fix(command-menu): hide open-in-new-split hint when split can't be appended by @gbirman in https://github.com/macro-inc/macro/pull/3001
+* fix(call): call transcription version pin by @whutchinson98 in https://github.com/macro-inc/macro/pull/3002
+* fix(call): adjust transcript/recording times to reduce delay in playback sync by @whutchinson98 in https://github.com/macro-inc/macro/pull/3003
+* fix(ui): appearance on mobile by @Fake-User in https://github.com/macro-inc/macro/pull/3005
+* style(md): tweak md inline menu styles by @sedson in https://github.com/macro-inc/macro/pull/3006
+* feat(ci): build custom rust runner image for ci by @synoet in https://github.com/macro-inc/macro/pull/3010
+* feat: enable sfs monitoring by @ehayes2000 in https://github.com/macro-inc/macro/pull/3007
+* style(layer): layer styles for most property modals by @sedson in https://github.com/macro-inc/macro/pull/3012
+* fix(ui): team tab by @Fake-User in https://github.com/macro-inc/macro/pull/3014
+* chore(deps): bump deps by @seanaye in https://github.com/macro-inc/macro/pull/3011
+* fix[tauri]: reduce logs by @peterchinman in https://github.com/macro-inc/macro/pull/3013
+* fix[mobile]: lightbox safe area margin by @peterchinman in https://github.com/macro-inc/macro/pull/3009
+* fix: sfs logging bucket ACL depends on ownership controls by @ehayes2000 in https://github.com/macro-inc/macro/pull/3015
+* fix: dcs config by @ehayes2000 in https://github.com/macro-inc/macro/pull/3004
+* refactor(iac): service urls by @whutchinson98 in https://github.com/macro-inc/macro/pull/3017
+* chore: build lambda by @whutchinson98 in https://github.com/macro-inc/macro/pull/3016
+* fix(ui): mobile settings tab && qr code by @Fake-User in https://github.com/macro-inc/macro/pull/3018
+* Russell/dechud account by @Fake-User in https://github.com/macro-inc/macro/pull/3020
+* opt(ci): rust check/test ci performance improvements by @synoet in https://github.com/macro-inc/macro/pull/2989
+* fix by @synoet in https://github.com/macro-inc/macro/pull/3021
+* contacts service refactor by @seanaye in https://github.com/macro-inc/macro/pull/2920
+* style(layers): update mobile drawers and other menus for mobile styles by @sedson in https://github.com/macro-inc/macro/pull/3019
+* fix[mobile]: autofocus search input by @peterchinman in https://github.com/macro-inc/macro/pull/3022
+* feat[ios]: share target by @peterchinman in https://github.com/macro-inc/macro/pull/2984
+* fix(soup): user icon weird padding by @sedson in https://github.com/macro-inc/macro/pull/3026
+* fix(channel): trim edge @mentions from task title when creating from message by @gbirman in https://github.com/macro-inc/macro/pull/3025
+* fix(search): navigating should not refocus search bar by @gbirman in https://github.com/macro-inc/macro/pull/3029
+* feat(fe): Track google conversions by @evanhutnik in https://github.com/macro-inc/macro/pull/3027
+* fix(ai): automations config by @ehayes2000 in https://github.com/macro-inc/macro/pull/3024
+* feat(ai): create generated object utility by @synoet in https://github.com/macro-inc/macro/pull/3023
+* fix(chat): don't autofocus chat input when in preview by @gbirman in https://github.com/macro-inc/macro/pull/3036
+* fix(search): move search bar into header and drop view title by @gbirman in https://github.com/macro-inc/macro/pull/3035
+* fix(sidebar): clicking on sidebar link appends to split history even if it's the same content by @dev-rb in https://github.com/macro-inc/macro/pull/3030
+* fix[mobile]: persist mobile auth by @peterchinman in https://github.com/macro-inc/macro/pull/3037
+* fix(kommand): don't auto-focus search row at top by @gbirman in https://github.com/macro-inc/macro/pull/3041
+* flag(tasks): turn on task discussion by @sedson in https://github.com/macro-inc/macro/pull/3028
+* update RUST_LOG by @seanaye in https://github.com/macro-inc/macro/pull/3043
+* feat(sync): add bulk fire and forget wake up call to sync service by @synoet in https://github.com/macro-inc/macro/pull/3042
+* feat: add call_ids as a soup filter for call records by @gbirman in https://github.com/macro-inc/macro/pull/3031
+* feat(teams): create team and invite users from settings by @dev-rb in https://github.com/macro-inc/macro/pull/3039
+* Seanaye/chore/contacts backtrace by @seanaye in https://github.com/macro-inc/macro/pull/3045
+* chg(local): freeze project names for running locally to support worktrees by @synoet in https://github.com/macro-inc/macro/pull/3046
+* fix(local): fix fusion auth env on worktrees by @synoet in https://github.com/macro-inc/macro/pull/3048
+* fix(teams): broken invites and invitations styling in settings by @dev-rb in https://github.com/macro-inc/macro/pull/3050
+* fix(sync): lower requirement for document initialization to edit by @synoet in https://github.com/macro-inc/macro/pull/3051
+* fix(teams): Wrong plan names by @dev-rb in https://github.com/macro-inc/macro/pull/3049
+* Seanaye/fix/test incomplete user ids by @seanaye in https://github.com/macro-inc/macro/pull/3052
+* fix[mobile]: fix mentions, emojis, actions menus by @peterchinman in https://github.com/macro-inc/macro/pull/3055
+* feat: add MCP setup instructions across onboarding, settings, and agents empty state by @evanhutnik in https://github.com/macro-inc/macro/pull/3053
+* feat(md/tasks): use batch fire and forget wakeup by @synoet in https://github.com/macro-inc/macro/pull/3054
+* feat(ai/notifications): notification tools for ai by @synoet in https://github.com/macro-inc/macro/pull/2924
+* fix-md remove test asnyc action by @sedson in https://github.com/macro-inc/macro/pull/3057
+* style-soup fix search hit row colors by @sedson in https://github.com/macro-inc/macro/pull/3058
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.4.30.0...v2026.5.4.0
+    </Update>

--- a/docs/changelog/introduction.mdx
+++ b/docs/changelog/introduction.mdx
@@ -1,2971 +1,337 @@
 ---
 title: Changelog
 icon: clock-rotate-left
+description: All notable changes to Macro, pulled from GitHub Releases.
 ---
 
 All notable changes to Macro, pulled from [GitHub Releases](https://github.com/macro-inc/macro/releases).
 
-Releases follow the format `vYYYY.M.D.patch`.
-
-    <Update label="v2026.4.28.0 (Current)">
-## What's Changed
-* chore(vite): unify dist output by @seanaye in https://github.com/macro-inc/macro/pull/2862
-* feat(call): add tooltip to share with team button by @whutchinson98 in https://github.com/macro-inc/macro/pull/2877
-* fix(soup): navigation scroll weird on small heights by @dev-rb in https://github.com/macro-inc/macro/pull/2879
-* feat(teams): rollback on customer_repository failures by @whutchinson98 in https://github.com/macro-inc/macro/pull/2878
-* fix(mentions): fix fetch error showing email mentions as deleted by @sedson in https://github.com/macro-inc/macro/pull/2886
-* fix(teams): team invite email links to sign up not link acceptance page by @dev-rb in https://github.com/macro-inc/macro/pull/2852
-* feat(calls): blur intensity & background image support by @dev-rb in https://github.com/macro-inc/macro/pull/2880
-* feat(fe): Chat with agent button by @evanhutnik in https://github.com/macro-inc/macro/pull/2794
-* chore(ai): call records in search tools by @gbirman in https://github.com/macro-inc/macro/pull/2883
-* chore(sqlx): workspace level cache by @seanaye in https://github.com/macro-inc/macro/pull/2882
-* feat(documents): add in default task properties to ai created tasks by @whutchinson98 in https://github.com/macro-inc/macro/pull/2884
-* fix(analytics): resize observer error reporting too frequently to posthog by @dev-rb in https://github.com/macro-inc/macro/pull/2894
-* style(chat): tweak font size and user massage, fix(mentions): weird padding on doc preview by @sedson in https://github.com/macro-inc/macro/pull/2901
-* fix(channel): link wrapping for long links by @sedson in https://github.com/macro-inc/macro/pull/2902
-* style(tasks): improve style of task toast by @sedson in https://github.com/macro-inc/macro/pull/2905
-* fix(settings): panel stealing focus on splits change by @dev-rb in https://github.com/macro-inc/macro/pull/2904
-* fix(teams): hide leave button by @dev-rb in https://github.com/macro-inc/macro/pull/2906
-* chg(tasks): change order of task name, fix(chat): attachment alignment by @sedson in https://github.com/macro-inc/macro/pull/2908
-* fix(analytics): Send CompleteRegistration meta analytics event by @evanhutnik in https://github.com/macro-inc/macro/pull/2888
-* fix[mobile]: push notification dialog wasn't showing by @peterchinman in https://github.com/macro-inc/macro/pull/2903
-* fix(dev): local branch name tool by @sedson in https://github.com/macro-inc/macro/pull/2909
-* feat[mobile]: make share menu nice by @peterchinman in https://github.com/macro-inc/macro/pull/2781
-* fix[mobile]: blur channel, chat, email inputs on touch outside input by @peterchinman in https://github.com/macro-inc/macro/pull/2910
-* feat[toasts]: instead of queueing, remove oldest toasts by @peterchinman in https://github.com/macro-inc/macro/pull/2899
-* fix(ui): make appearance editor more cohesive by @Fake-User in https://github.com/macro-inc/macro/pull/2897
-* fix[mobile]: first page splash nits by @peterchinman in https://github.com/macro-inc/macro/pull/2889
-* fix[channels]: top bar squish by @peterchinman in https://github.com/macro-inc/macro/pull/2907
-* feat(soup): resize preview by @sedson in https://github.com/macro-inc/macro/pull/2912
-* fix: simple dropdown menu breaking app by @peterchinman in https://github.com/macro-inc/macro/pull/2914
-* fix(teams): tier changes not giving proper feedback by @dev-rb in https://github.com/macro-inc/macro/pull/2913
-* fix[channel]: on mobile no select messages by @peterchinman in https://github.com/macro-inc/macro/pull/2911
-* fix[tauri]: paste macro links by @peterchinman in https://github.com/macro-inc/macro/pull/2915
-* feat(call): call custom name by @whutchinson98 in https://github.com/macro-inc/macro/pull/2891
-* fix(local): make urls dns valid, add notification ingress env var by @synoet in https://github.com/macro-inc/macro/pull/2916
-* fix(call): use entity access for soup query by @whutchinson98 in https://github.com/macro-inc/macro/pull/2917
-* feat(soup): migrate to AST filters & use filters for all supported filter options by @dev-rb in https://github.com/macro-inc/macro/pull/2639
-* fix(search): clear sub-filter caches when resetting to tab defaults by @gbirman in https://github.com/macro-inc/macro/pull/2900
-* refactor(calls): consolidate call entity taxonomy on 'call' by @gbirman in https://github.com/macro-inc/macro/pull/2895
-* feat: add static entity by @ehayes2000 in https://github.com/macro-inc/macro/pull/2887
-* fix(search): hide redundant show-more for singleton hits by @gbirman in https://github.com/macro-inc/macro/pull/2892
-* fix(call): improve mic noise suppression by @whutchinson98 in https://github.com/macro-inc/macro/pull/2918
-* feat(soup): add date ast filters by @seanaye in https://github.com/macro-inc/macro/pull/2893
-* feat(sidebar): mark channels as done or read from sidebar ctx menu by @sedson in https://github.com/macro-inc/macro/pull/2919
-* update ast field name mapping by @seanaye in https://github.com/macro-inc/macro/pull/2922
-* feat(ui): add layers utility by @Fake-User in https://github.com/macro-inc/macro/pull/2923
-* fix[tauri]: tasks and docs not loading by @peterchinman in https://github.com/macro-inc/macro/pull/2921
-* chore: global video calling - WIP by @gacers in https://github.com/macro-inc/macro/pull/2703
-* feat(kommand): rank command items by recency by @gbirman in https://github.com/macro-inc/macro/pull/2926
-* fix: missing document color by @dev-rb in https://github.com/macro-inc/macro/pull/2928
-* fix(soup): items not updating optimistically by @dev-rb in https://github.com/macro-inc/macro/pull/2927
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.4.24.1...v2026.4.28.0
-    </Update>
-
-    <Update label="v2026.4.24.1">
-## What's Changed
-* fix(ui): upgrade tailwind syntax by @Fake-User in https://github.com/macro-inc/macro/pull/2851
-* feat(channels): seperate pagination for static vs dss attachment by @synoet in https://github.com/macro-inc/macro/pull/2830
-* fix(team): require write stripe subscription on team create by @whutchinson98 in https://github.com/macro-inc/macro/pull/2854
-* bump tauri by @seanaye in https://github.com/macro-inc/macro/pull/2823
-* fix(soup): keep chat input mounted when preview opens by @gbirman in https://github.com/macro-inc/macro/pull/2856
-* chg(infra): cors allow preview by @synoet in https://github.com/macro-inc/macro/pull/2857
-* feat(teams): allow patching team user role by @whutchinson98 in https://github.com/macro-inc/macro/pull/2855
-* feat(mcp): cors headers, de-auth preflight by @ehayes2000 in https://github.com/macro-inc/macro/pull/2644
-* feat(teams): accept and reject team invitations in settings by @dev-rb in https://github.com/macro-inc/macro/pull/2840
-* feat(teams): invite link page by @dev-rb in https://github.com/macro-inc/macro/pull/2849
-* feat(tauri): autoupdate on app resume by @seanaye in https://github.com/macro-inc/macro/pull/2822
-* feat(channels): add support for notification filtering on channel message by @synoet in https://github.com/macro-inc/macro/pull/2858
-* chore(deps): bump rustls-webpki from 0.103.10 to 0.103.13 in /rust/sync-service by @dependabot[bot] in https://github.com/macro-inc/macro/pull/2844
-* chore(deps): bump postcss from 8.5.3 to 8.5.10 in /rust/sync-service by @dependabot[bot] in https://github.com/macro-inc/macro/pull/2850
-* fix(ui): panel by @Fake-User in https://github.com/macro-inc/macro/pull/2863
-* fix(ai): Scheduled prompt by @ehayes2000 in https://github.com/macro-inc/macro/pull/2860
-* fix(ui): kill roundpanel by @Fake-User in https://github.com/macro-inc/macro/pull/2866
-* fix(mcp): handle upstream oauth errors in callback by @ehayes2000 in https://github.com/macro-inc/macro/pull/2865
-* fix[channel]: message outline styling by @peterchinman in https://github.com/macro-inc/macro/pull/2864
-* fix(ui): cleanup by @Fake-User in https://github.com/macro-inc/macro/pull/2868
-* feat(ai): Attachment infra by @ehayes2000 in https://github.com/macro-inc/macro/pull/2809
-* feat(search): support call records in search by @gbirman in https://github.com/macro-inc/macro/pull/2816
-* feat(mentions): calls in mentions, mention loading improvements, optimisitic preview on create by @sedson in https://github.com/macro-inc/macro/pull/2867
-* fix(soup): restore focus on mark-done undo by @gbirman in https://github.com/macro-inc/macro/pull/2871
-* fix(tasks): no delete prop btn in composer by @sedson in https://github.com/macro-inc/macro/pull/2873
-* fix(search): anchor In/From filter submenus to their row by @gbirman in https://github.com/macro-inc/macro/pull/2874
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.4.24.0...v2026.4.24.1
-    </Update>
-
-    <Update label="v2026.4.24.0">
-## What's Changed
-* chore: bump version + update changelog by @synoet in https://github.com/macro-inc/macro/pull/2824
-* fix(channel): media viewer showing navigation for single item by @dev-rb in https://github.com/macro-inc/macro/pull/2825
-* feat(icon): Add custom video call icons by @aidanhb in https://github.com/macro-inc/macro/pull/2826
-* fix(icon): make task status icons a little bigger by @aidanhb in https://github.com/macro-inc/macro/pull/2827
-* chore(cf): bump worker version by @synoet in https://github.com/macro-inc/macro/pull/2831
-* feat(email): add calendar_only filter and Calendar tab by @evanhutnik in https://github.com/macro-inc/macro/pull/2820
-* feat(call): enforce single join by @whutchinson98 in https://github.com/macro-inc/macro/pull/2832
-* feat(sfs): image optimizer lambda + infra by @ehayes2000 in https://github.com/macro-inc/macro/pull/2833
-* Drop unused email search database artifacts by @gbirman in https://github.com/macro-inc/macro/pull/2598
-* fix(ui): kill style={``} by @Fake-User in https://github.com/macro-inc/macro/pull/2834
-* feat(call): batch preview endpoint by @whutchinson98 in https://github.com/macro-inc/macro/pull/2835
-* feat(call): fix noise suppression by @whutchinson98 in https://github.com/macro-inc/macro/pull/2837
-* fix(ui): silence tailwind warnings by @Fake-User in https://github.com/macro-inc/macro/pull/2836
-* feat(ai): create-tool skill by @ehayes2000 in https://github.com/macro-inc/macro/pull/2839
-* feat: pfp + channel preview downscaling by @ehayes2000 in https://github.com/macro-inc/macro/pull/2651
-* fix(ui): frontend pruning by @Fake-User in https://github.com/macro-inc/macro/pull/2842
-* feat(run_local): running local performance optimizations by @synoet in https://github.com/macro-inc/macro/pull/2829
-* fix(ui): sidebr hr colors by @Fake-User in https://github.com/macro-inc/macro/pull/2843
-* fix(soup): missing call exclusion query filters by @dev-rb in https://github.com/macro-inc/macro/pull/2847
-* feat(call): speaker diarization by @whutchinson98 in https://github.com/macro-inc/macro/pull/2846
-* feat(call): ai summary by @whutchinson98 in https://github.com/macro-inc/macro/pull/2848
-* feat(ai): subagents by @ehayes2000 in https://github.com/macro-inc/macro/pull/2838
-* fix(ui): keep filter search input focused when submenu is open by @gbirman in https://github.com/macro-inc/macro/pull/2841
-* fix(channels): load_around_message_id returning previous_cursor when it shouldn't by @synoet in https://github.com/macro-inc/macro/pull/2853
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.4.23.0...v2026.4.24.0
-    </Update>
-
-    <Update label="v2026.4.23.0">
-## What's Changed
-* fix(tasks): various task routing bugs by @sedson in https://github.com/macro-inc/macro/pull/2782
-* fix(properties/tools): add user to accepted types by @sedson in https://github.com/macro-inc/macro/pull/2770
-* fix(core): kill split modal, use entity edit modal for operations by @sedson in https://github.com/macro-inc/macro/pull/2784
-* fix(update): wrong url by @seanaye in https://github.com/macro-inc/macro/pull/2786
-* feat(call): update required access level for calls by @whutchinson98 in https://github.com/macro-inc/macro/pull/2785
-* feat(call): share with team toggle by @whutchinson98 in https://github.com/macro-inc/macro/pull/2787
-* fix(settings): propper settings view on mobile by @Fake-User in https://github.com/macro-inc/macro/pull/2790
-* fix(sidebar): remove icon color transition by @Fake-User in https://github.com/macro-inc/macro/pull/2792
-* fix(split-layout): skip search bar on H/L focus restoration by @gbirman in https://github.com/macro-inc/macro/pull/2791
-* fix(vite): make read git branch call async by @aidanhb in https://github.com/macro-inc/macro/pull/2793
-* fix(theme): kill unused signals by @Fake-User in https://github.com/macro-inc/macro/pull/2795
-* feat(comms): trigger notif deletes on soft delete by @seanaye in https://github.com/macro-inc/macro/pull/2789
-* fix(channels): patch message take new attachments by @synoet in https://github.com/macro-inc/macro/pull/2783
-* feat(call): call video blur by @whutchinson98 in https://github.com/macro-inc/macro/pull/2788
-* fix(local): running locally audience and env vars by @synoet in https://github.com/macro-inc/macro/pull/2797
-* feat(teams): client methods, queries, and mutations by @dev-rb in https://github.com/macro-inc/macro/pull/2798
-* fix(documents): ai cant see comments on tasks by @whutchinson98 in https://github.com/macro-inc/macro/pull/2796
-* chore(notifications): use uuids for notification sandbox by @gbirman in https://github.com/macro-inc/macro/pull/2800
-* chore(soup): reduce mark done toast duration to 3s by @gbirman in https://github.com/macro-inc/macro/pull/2801
-* feat(notif): index chan notifs on msg id by @seanaye in https://github.com/macro-inc/macro/pull/2799
-* fix: internal image dragging by @peterchinman in https://github.com/macro-inc/macro/pull/2803
-* Russell/no more gamer core by @Fake-User in https://github.com/macro-inc/macro/pull/2805
-* feat(call): ai toolset by @whutchinson98 in https://github.com/macro-inc/macro/pull/2802
-* Aidan/icon call by @aidanhb in https://github.com/macro-inc/macro/pull/2806
-* fix(ui): fix settings tabs being in wrong location on desktop. by @Fake-User in https://github.com/macro-inc/macro/pull/2807
-* fix(ci): correct code path for mcp service by @whutchinson98 in https://github.com/macro-inc/macro/pull/2808
-* fix(zed/conf): add zed conf to unchud biome by @sedson in https://github.com/macro-inc/macro/pull/2810
-* feat[tauri]: only auto-download update on wifi by @peterchinman in https://github.com/macro-inc/macro/pull/2812
-* feat(analytics): fire valued Lead on every conversion path by @evanhutnik in https://github.com/macro-inc/macro/pull/2813
-* fix(channels): prevent optimistic inserts mid page by @synoet in https://github.com/macro-inc/macro/pull/2814
-* feat(lexical-service): Extract images by @ehayes2000 in https://github.com/macro-inc/macro/pull/2726
-* feat(teams): onboarding step for creating team and inviting members by @dev-rb in https://github.com/macro-inc/macro/pull/2811
-* feat(teams): team tab in settings by @dev-rb in https://github.com/macro-inc/macro/pull/2804
-* fix(ui): replace all class={``} with cn() or class="" by @Fake-User in https://github.com/macro-inc/macro/pull/2818
-* Add panel colored shapes behind shuttle icons in all arcana by @aidanhb in https://github.com/macro-inc/macro/pull/2817
-* fix(ui): dechud theme list by @Fake-User in https://github.com/macro-inc/macro/pull/2821
-* feat!(agent/slop): ability to copy prompt and open in agent from task by @synoet in https://github.com/macro-inc/macro/pull/2815
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.4.22.1...v2026.4.23.0
-    </Update>
-
-    <Update label="v2026.4.22.1">
-## What's Changed
-* fix(search): prefix-match text fields for email search by @gbirman in https://github.com/macro-inc/macro/pull/2778
-* feat(undo): bind cmd+z / shift+cmd+z to the mutation undo stack by @gbirman in https://github.com/macro-inc/macro/pull/2714
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.4.22.0...v2026.4.22.1
-    </Update>
-
-    <Update label="v2026.4.22.0">
-## What's Changed
-* feat(db): prepare db for version bump by @whutchinson98 in https://github.com/macro-inc/macro/pull/2748
-* fix(sfs): pass file_id instead of s3 key to mark_uploaded by @ehayes2000 in https://github.com/macro-inc/macro/pull/2738
-* feat(call): improve call transcription by @whutchinson98 in https://github.com/macro-inc/macro/pull/2751
-* chore(channels): remove old unused deprecated components by @synoet in https://github.com/macro-inc/macro/pull/2752
-* feat: qr code for app store in onboarding and settings by @peterchinman in https://github.com/macro-inc/macro/pull/2753
-* feat(db): add new parameter group for db version update by @whutchinson98 in https://github.com/macro-inc/macro/pull/2750
-* Russell/split by @Fake-User in https://github.com/macro-inc/macro/pull/2754
-* feat: undo mark-as-done + notification refetch cleanup by @gbirman in https://github.com/macro-inc/macro/pull/2701
-* feat(task): notify assignees of comments by @seanaye in https://github.com/macro-inc/macro/pull/2749
-* fix(notif): filter out browser notif for new email by @seanaye in https://github.com/macro-inc/macro/pull/2756
-* fix(channels): stop escape from bubbling from close mentions menu by @sedson in https://github.com/macro-inc/macro/pull/2757
-* chore(channels): migrate all consumers to new markdown builder by @synoet in https://github.com/macro-inc/macro/pull/2755
-* chore(lexical-service): decrust by @ehayes2000 in https://github.com/macro-inc/macro/pull/2723
-* feat(channels/documents): Stanalone channel thread + Full reactive thread in document cards by @synoet in https://github.com/macro-inc/macro/pull/2734
-* fix(channels): don't serialize or deserialize pending attachments by @synoet in https://github.com/macro-inc/macro/pull/2761
-* feat[ios]: dialog prompting push notification permission by @peterchinman in https://github.com/macro-inc/macro/pull/2760
-* chore: move onboarding qr code to launch screen by @peterchinman in https://github.com/macro-inc/macro/pull/2762
-* feat(tasks): new icons and colors by @dev-rb in https://github.com/macro-inc/macro/pull/2759
-* fix(share): tab + enter on share button crashing the app by @synoet in https://github.com/macro-inc/macro/pull/2767
-* chore: gate onboarding qr code behind feature flag by @peterchinman in https://github.com/macro-inc/macro/pull/2769
-* fix(soup): first entity not always focused on load by @dev-rb in https://github.com/macro-inc/macro/pull/2771
-* feat(dev): add hotkey debugger by @sedson in https://github.com/macro-inc/macro/pull/2768
-* fix(ci): pin zod, remove patch by @ehayes2000 in https://github.com/macro-inc/macro/pull/2772
-* chore: dry up preview registration in DocumentCard by @gbirman in https://github.com/macro-inc/macro/pull/2774
-* feat: cal.com webhook → Meta Lead events by @evanhutnik in https://github.com/macro-inc/macro/pull/2764
-* chore(channels): fully remove deprecated components by @synoet in https://github.com/macro-inc/macro/pull/2776
-* fix: vite resolve by @ehayes2000 in https://github.com/macro-inc/macro/pull/2779
-* feat(dev): add a local-only bottom bar that shows current branch by @sedson in https://github.com/macro-inc/macro/pull/2763
-* fix(ai): paywall free users by @ehayes2000 in https://github.com/macro-inc/macro/pull/2765
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.4.21.3...v2026.4.22.0
-    </Update>
-
-    <Update label="v2026.4.21.3">
-## What's Changed
-* chore: bump version + update changelog by @synoet in https://github.com/macro-inc/macro/pull/2746
-* fix entity access by @whutchinson98 in https://github.com/macro-inc/macro/pull/2747
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.4.21.2...v2026.4.21.3
-    </Update>
-
-    <Update label="v2026.4.21.2">
-## What's Changed
-* feat(calls): unattended call filter by @whutchinson98 in https://github.com/macro-inc/macro/pull/2715
-* feat entity access by @whutchinson98 in https://github.com/macro-inc/macro/pull/2418
-* feat(icon): update icons in message action menu by @aidanhb in https://github.com/macro-inc/macro/pull/2601
-* fix(favicon): make favicon badge a0 instead of a1 by @aidanhb in https://github.com/macro-inc/macro/pull/2717
-* feat(sync): exists should use head instead of get by @synoet in https://github.com/macro-inc/macro/pull/2716
-* fix(call): unattended/attended banner in all view by @whutchinson98 in https://github.com/macro-inc/macro/pull/2719
-* fix(mentions): use interleaved fresh search for mobile mentions by @sedson in https://github.com/macro-inc/macro/pull/2718
-* fix(entity_access): channel share by @whutchinson98 in https://github.com/macro-inc/macro/pull/2721
-* feat(call): share/unshare with team in edit call by @whutchinson98 in https://github.com/macro-inc/macro/pull/2722
-* fix[channels]: duplicate hover action menu by @peterchinman in https://github.com/macro-inc/macro/pull/2724
-* feat(onboarding): refine sidebar glow, lesson flow, and editor interactions by @evanhutnik in https://github.com/macro-inc/macro/pull/2725
-* feat(onboarding): fire subscription_success for free-tier selection by @evanhutnik in https://github.com/macro-inc/macro/pull/2727
-* feat(channels): support message_ids filter in get_channel_messages by @synoet in https://github.com/macro-inc/macro/pull/2708
-* feat(icon): add custom phone icon by @aidanhb in https://github.com/macro-inc/macro/pull/2729
-* fix(search): keep tab in search, hint @mention in placeholder by @gbirman in https://github.com/macro-inc/macro/pull/2730
-* feat(sidebar): add enable notifications button by @evanhutnik in https://github.com/macro-inc/macro/pull/2728
-* fix(search): blur soup search on ArrowDown to navigate results by @gbirman in https://github.com/macro-inc/macro/pull/2732
-* feat(icon): add custom disconnect icon by @aidanhb in https://github.com/macro-inc/macro/pull/2735
-* feat(channels): support latest_activity messages filter by @synoet in https://github.com/macro-inc/macro/pull/2736
-* feat(tasks): rail chat bottom-matter comments in tasks by @sedson in https://github.com/macro-inc/macro/pull/2731
-* fix(search): only hint @mention in sidebar search placeholder by @gbirman in https://github.com/macro-inc/macro/pull/2739
-* fix(search): render name highlight when not on first result by @gbirman in https://github.com/macro-inc/macro/pull/2740
-* fix(md): fix busted portal scoping in email base input by @sedson in https://github.com/macro-inc/macro/pull/2741
-* feat(command-k): copy entity id by @gbirman in https://github.com/macro-inc/macro/pull/2737
-* fix(call): entity access for call record routes by @whutchinson98 in https://github.com/macro-inc/macro/pull/2743
-* fix(search): highlight doc names on content-only hits by @gbirman in https://github.com/macro-inc/macro/pull/2742
-* Seanaye/feat/improve autoupdate ux by @seanaye in https://github.com/macro-inc/macro/pull/2733
-* chore(name_search): split highlight module into its own file by @gbirman in https://github.com/macro-inc/macro/pull/2744
-* chg(safeFetch): prevent draining body, and passing content-type on head request by @synoet in https://github.com/macro-inc/macro/pull/2745
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.4.21.1...v2026.4.21.2
-    </Update>
-
-    <Update label="v2026.4.21.1">
-## What's Changed
-* feat(calls): add channel name to the call started notif by @seanaye in https://github.com/macro-inc/macro/pull/2711
-* fix(layout): add tab titles to split view, fix tab title reconcile bug by @sedson in https://github.com/macro-inc/macro/pull/2713
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.4.21.0...v2026.4.21.1
-    </Update>
-
-    <Update label="v2026.4.21.0">
-## What's Changed
-* feat(onboarding): pricing table, free tier, and desktop launch step by @evanhutnik in https://github.com/macro-inc/macro/pull/2692
-* fix(channel): mark message notification viewed when it arrives after mount by @gbirman in https://github.com/macro-inc/macro/pull/2707
-* fix[tauri]: sync service by @peterchinman in https://github.com/macro-inc/macro/pull/2712
-* feat(analytics): track mobile-web signup as Meta Pixel Lead by @evanhutnik in https://github.com/macro-inc/macro/pull/2710
-* change enable bawrfoe by @evanhutnik in https://github.com/macro-inc/macro/pull/2700
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.4.20.1...v2026.4.21.0
-    </Update>
-
-    <Update label="v2026.4.20.1">
-## What's Changed
-* chore: bump version + update changelog by @synoet in https://github.com/macro-inc/macro/pull/2698
-* fix[mobile]: channel padding by @peterchinman in https://github.com/macro-inc/macro/pull/2699
-* feat[mobile]: swipe down to dismiss keyboard by @peterchinman in https://github.com/macro-inc/macro/pull/2697
-* feat(md): improve actions menu pattern, add task action by @sedson in https://github.com/macro-inc/macro/pull/2691
-* chore(search): remove projects search index by @gbirman in https://github.com/macro-inc/macro/pull/2694
-* chore(search): remove unused names index client code by @gbirman in https://github.com/macro-inc/macro/pull/2702
-* fix(channel): prevent default click reactions by @synoet in https://github.com/macro-inc/macro/pull/2706
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.4.20.0...v2026.4.20.1
-    </Update>
-
-    <Update label="v2026.4.20.0">
-## What's Changed
-* feat(auth-service): Change stripe tier endpoint by @evanhutnik in https://github.com/macro-inc/macro/pull/2655
-* fix(ai-email): Send HTML body instead of raw markdown when sending emails by @evanhutnik in https://github.com/macro-inc/macro/pull/2432
-* fix: add back cmd+esc to close split by @peterchinman in https://github.com/macro-inc/macro/pull/2664
-* chore: add star history by @seanaye in https://github.com/macro-inc/macro/pull/2665
-* fix: scope expand/collapse hotkey to active split by @gbirman in https://github.com/macro-inc/macro/pull/2667
-* fix[mobile]: notification timestamps by @peterchinman in https://github.com/macro-inc/macro/pull/2670
-* feat(fe): Subscription tier update UI by @evanhutnik in https://github.com/macro-inc/macro/pull/2666
-* fix(task): add create by as property display to task front-matter by @sedson in https://github.com/macro-inc/macro/pull/2669
-* fix(soup): optimistic batch updating of properties by @synoet in https://github.com/macro-inc/macro/pull/2668
-* feat(soup): ast file assoc expansion by @seanaye in https://github.com/macro-inc/macro/pull/2674
-* feat(tauri): autoupdate ui and persistence by @seanaye in https://github.com/macro-inc/macro/pull/2657
-* fix: ios dictation buffer by @peterchinman in https://github.com/macro-inc/macro/pull/2677
-* fix(list): preserve scroll position on expand/collapse by @gbirman in https://github.com/macro-inc/macro/pull/2678
-* fix: notification stacking behavior by @peterchinman in https://github.com/macro-inc/macro/pull/2673
-* fix(unfurl): Improvements to unfurl service to have it match what we do for similar functionality in other services by @whutchinson98 in https://github.com/macro-inc/macro/pull/2679
-* fix(soup): bulk marking emails as done happens in parallel by @synoet in https://github.com/macro-inc/macro/pull/2675
-* chore(soup): bump persisted state version by @dev-rb in https://github.com/macro-inc/macro/pull/2680
-* feat(comms): add thread mentionees to notification for channel message by @whutchinson98 in https://github.com/macro-inc/macro/pull/2682
-* fix(email): use unique index on email_contacts upsert lookup by @gbirman in https://github.com/macro-inc/macro/pull/2683
-* fix[soup]: import folder button by @peterchinman in https://github.com/macro-inc/macro/pull/2681
-* chore(ai infra): consolidate env vars for tools by @ehayes2000 in https://github.com/macro-inc/macro/pull/2672
-* fix(md): potentially fix md comment clone bug by @sedson in https://github.com/macro-inc/macro/pull/2685
-* chg(channels): improve distinction between keyboard selected + hover by @synoet in https://github.com/macro-inc/macro/pull/2684
-* chore: bump version + update changelog by @synoet in https://github.com/macro-inc/macro/pull/2689
-* fix(ai): tool error handling by @ehayes2000 in https://github.com/macro-inc/macro/pull/2671
-* chg(opensearch): drop unknown fields instead of auto-creating by @gbirman in https://github.com/macro-inc/macro/pull/2690
-* feat(channels): add failed to send message failover by @synoet in https://github.com/macro-inc/macro/pull/2693
-* fix(channels/lexical): fix input focus causing scroll instability by @synoet in https://github.com/macro-inc/macro/pull/2687
-* fix(fe-notifs): add metion info to create thread calls by @sedson in https://github.com/macro-inc/macro/pull/2695
-* Seanaye/fix/tauri services ws by @seanaye in https://github.com/macro-inc/macro/pull/2688
-* fix(channel): fix scroll to bottom when mid pagination by @synoet in https://github.com/macro-inc/macro/pull/2696
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.4.17.1...v2026.4.20.0
-    </Update>
-
-    <Update label="v2026.4.17.1">
-## What's Changed
-* fix(agent-schedule-service): wire SYNC_SERVICE_AUTH_KEY env var by @gbirman in https://github.com/macro-inc/macro/pull/2663
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.4.17.0...v2026.4.17.1
-    </Update>
-
-    <Update label="v2026.4.17.0">
-## What's Changed
-* fix[split]: accessing undefined split content by @peterchinman in https://github.com/macro-inc/macro/pull/2640
-* fix[mobile]: don't focus new splitcontainers on mobile by @peterchinman in https://github.com/macro-inc/macro/pull/2641
-* feat(blocks): add info drawer for blocks, remove metadata from frontmatter and prop-drawer by @sedson in https://github.com/macro-inc/macro/pull/2642
-* fix(sfs): image downscaling by @ehayes2000 in https://github.com/macro-inc/macro/pull/2636
-* fix(sidebar): styling for collapsed unread widget by @dev-rb in https://github.com/macro-inc/macro/pull/2645
-* feat(ai): scheduled agents (backend) by @ehayes2000 in https://github.com/macro-inc/macro/pull/2629
-* Revert "fix(sfs): image downscaling" by @ehayes2000 in https://github.com/macro-inc/macro/pull/2646
-* fix(search): snappier, keyboard-navigable In/From filter submenu by @gbirman in https://github.com/macro-inc/macro/pull/2643
-* feat(ai): Scheduled agents frontend by @ehayes2000 in https://github.com/macro-inc/macro/pull/2633
-* fix[mobile]: soup create button by @peterchinman in https://github.com/macro-inc/macro/pull/2649
-* fix[channels]: grouped message timestamps by @peterchinman in https://github.com/macro-inc/macro/pull/2648
-* fix[mobile]: no back swipe gesture on web mobile by @peterchinman in https://github.com/macro-inc/macro/pull/2650
-* fix(search): emails not excluded using nil thread id by @dev-rb in https://github.com/macro-inc/macro/pull/2647
-* chore(properties): clear search text when selecting entity in multiselect by @gbirman in https://github.com/macro-inc/macro/pull/2652
-* feat(call): use correct thread components by @whutchinson98 in https://github.com/macro-inc/macro/pull/2654
-* fix(hotkeys): shift-modified split navigation to avoid collapse/expand conflict by @gbirman in https://github.com/macro-inc/macro/pull/2653
-* style(settings): tweak font and cols for setting shortcut hints by @sedson in https://github.com/macro-inc/macro/pull/2658
-* fix(channels): sometimes channels don't load any messages by @dev-rb in https://github.com/macro-inc/macro/pull/2660
-* fix(channnels): fix broken padding for narrow channel input by @sedson in https://github.com/macro-inc/macro/pull/2659
-* style(properties): restyle ceate property and select property modal by @sedson in https://github.com/macro-inc/macro/pull/2656
-* fix(filters): clean up soup/search filters by @gbirman in https://github.com/macro-inc/macro/pull/2661
-* fix(md): front matter closed by default by @sedson in https://github.com/macro-inc/macro/pull/2662
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.4.16.0...v2026.4.17.0
-    </Update>
-
-    <Update label="v2026.4.16.0">
-## What's Changed
-* fix(frecency): clean up stale transaction in poller to prevent deadlock by @gbirman in https://github.com/macro-inc/macro/pull/2609
-* fix(call): correctly filter calls in attachments and support click on attachment to go to call record by @whutchinson98 in https://github.com/macro-inc/macro/pull/2610
-* feat(infra): add idle_in_transaction_session_timeout by @gbirman in https://github.com/macro-inc/macro/pull/2613
-* feat(call): new call button by @whutchinson98 in https://github.com/macro-inc/macro/pull/2611
-* style(tasks): un-bork padding in task composer by @sedson in https://github.com/macro-inc/macro/pull/2612
-* style(ui): add rounding back to mini toggle component by @sedson in https://github.com/macro-inc/macro/pull/2614
-* feat(auth): mobile welcome email endpoint by @evanhutnik in https://github.com/macro-inc/macro/pull/2608
-* fix: remove close split by escape key by @dev-rb in https://github.com/macro-inc/macro/pull/2616
-* fix(port-maxxing): remove hmr port option to default to same as http port by @sedson in https://github.com/macro-inc/macro/pull/2617
-* fix(tasks): allow go to location for task snippets by @sedson in https://github.com/macro-inc/macro/pull/2622
-* fix(call): return all calls you have access to in soup by @whutchinson98 in https://github.com/macro-inc/macro/pull/2621
-* feat(onboarding): mobile web welcome flow with email signup by @evanhutnik in https://github.com/macro-inc/macro/pull/2624
-* feat(call): delete call by @whutchinson98 in https://github.com/macro-inc/macro/pull/2625
-* feat(notifications): add right-click context menu to notification stacks by @gbirman in https://github.com/macro-inc/macro/pull/2549
-* fix deadlock in ios dev mode by @seanaye in https://github.com/macro-inc/macro/pull/2626
-* fix(call): delete recording from s3 by @whutchinson98 in https://github.com/macro-inc/macro/pull/2627
-* fix(search): precise email-address highlighting by @gbirman in https://github.com/macro-inc/macro/pull/2628
-* feat(search): tasks-style filter menu with F hotkey and chips by @gbirman in https://github.com/macro-inc/macro/pull/2623
-* chore: remove unnecessary code from notification right-click by @gbirman in https://github.com/macro-inc/macro/pull/2630
-* fix[mobile]: task bug by @peterchinman in https://github.com/macro-inc/macro/pull/2631
-* fix[mobile]: stop background splits from focusing by @peterchinman in https://github.com/macro-inc/macro/pull/2632
-* feat(channel): URL search params for single channel navigation by @gbirman in https://github.com/macro-inc/macro/pull/2634
-* chore: pin tauri-plugin-deep-link to avoid bug by @peterchinman in https://github.com/macro-inc/macro/pull/2635
-* fix(search): keep In/From chip popup open on multi-select by @gbirman in https://github.com/macro-inc/macro/pull/2637
-* feat(sidebar): show user icons for group dms by @dev-rb in https://github.com/macro-inc/macro/pull/2638
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.4.15.0...v2026.4.16.0
-    </Update>
-
-    <Update label="v2026.4.15.0">
-## What's Changed
-* chore(soup): remove unused filter files by @dev-rb in https://github.com/macro-inc/macro/pull/2573
-* style(share): align share modal with other modals by @sedson in https://github.com/macro-inc/macro/pull/2574
-* feat(call): use channel style rails for call transcript by @whutchinson98 in https://github.com/macro-inc/macro/pull/2576
-* style(fe): Keep fonts for macro emails by @evanhutnik in https://github.com/macro-inc/macro/pull/2578
-* feat(calls): add in safety methods to stop calls properly to avoid billing mistakes by @whutchinson98 in https://github.com/macro-inc/macro/pull/2577
-* style(fa): Change email templates by @evanhutnik in https://github.com/macro-inc/macro/pull/2579
-* fix: soup crashing safari at certain widths by @peterchinman in https://github.com/macro-inc/macro/pull/2580
-* fix:  cmd+f hotkey for collapsed search state by @peterchinman in https://github.com/macro-inc/macro/pull/2582
-* fix(call): noise filtering by @whutchinson98 in https://github.com/macro-inc/macro/pull/2586
-* feat(tasks): add assign task btn to user card, cleanup styles on user card by @sedson in https://github.com/macro-inc/macro/pull/2581
-* fix(preview): do not open preview window on empty state by @aidanhb in https://github.com/macro-inc/macro/pull/2587
-* feat(infra): add pganalyze collector with auto_explain by @gbirman in https://github.com/macro-inc/macro/pull/2589
-* feat(search): disable email subject serach in mentions when not required by @gbirman in https://github.com/macro-inc/macro/pull/2588
-* style(md): restyle media resize handles by @sedson in https://github.com/macro-inc/macro/pull/2590
-* feat[mobile]: swipe back gesture by @peterchinman in https://github.com/macro-inc/macro/pull/2572
-* feat(infra): enable enhanced monitoring for RDS by @gbirman in https://github.com/macro-inc/macro/pull/2583
-* fix(ci): fix cargo-deny check by @gbirman in https://github.com/macro-inc/macro/pull/2591
-* join_call param in channel by @whutchinson98 in https://github.com/macro-inc/macro/pull/2593
-* feat(analytics): per-lesson onboarding events, login tracking, environment enrichment by @evanhutnik in https://github.com/macro-inc/macro/pull/2594
-* feat(search): use read replica database for search queries by @gbirman in https://github.com/macro-inc/macro/pull/2592
-* feat(sidebar): unread channel widget for slim mode by @dev-rb in https://github.com/macro-inc/macro/pull/2595
-* style(chat): kill inset bottom px for soup chat gradient by @sedson in https://github.com/macro-inc/macro/pull/2575
-* Remove PG email search, use OpenSearch for all email queries by @gbirman in https://github.com/macro-inc/macro/pull/2585
-* feat(md): drag to rearrange nodes by @sedson in https://github.com/macro-inc/macro/pull/2597
-* fix(channels): update media viewer controls ui by @dev-rb in https://github.com/macro-inc/macro/pull/2596
-* feat(search): re-index OpenSearch when contact names change by @gbirman in https://github.com/macro-inc/macro/pull/2600
-* Remove email_contact_search crate from workspace by @gbirman in https://github.com/macro-inc/macro/pull/2599
-* Seanaye/feat/tauri autoupdate by @seanaye in https://github.com/macro-inc/macro/pull/2584
-* style(command): command menu tab spacing by @sedson in https://github.com/macro-inc/macro/pull/2602
-* fix(search): highlight correct term in sender name for contact searches by @gbirman in https://github.com/macro-inc/macro/pull/2604
-* fix(notifications): stop refetching all notifications on mark-as-read by @gbirman in https://github.com/macro-inc/macro/pull/2605
-* chore: bump tauri plugins by @peterchinman in https://github.com/macro-inc/macro/pull/2607
-* feat(md): md commands in command+k, cleanup format menu styles, clean up drag insert grabber by @sedson in https://github.com/macro-inc/macro/pull/2606
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.4.14.0...v2026.4.15.0
-    </Update>
-
-    <Update label="v2026.4.14.0">
-## What's Changed
-* fix[mobile-soup]: notification stack click handler by @peterchinman in https://github.com/macro-inc/macro/pull/2544
-* chore(tasks): remove diff-style highlights from assignee menu by @gbirman in https://github.com/macro-inc/macro/pull/2545
-* fix(tasks): update property delete buttons to use subtle X style by @gbirman in https://github.com/macro-inc/macro/pull/2546
-* chore(notifications): update notification checkbox tooltip by @gbirman in https://github.com/macro-inc/macro/pull/2547
-* fix(inbox): Enter on single-item channel notification opens that message by @gbirman in https://github.com/macro-inc/macro/pull/2548
-* fix[channels]: grouped message timestamp alignment by @peterchinman in https://github.com/macro-inc/macro/pull/2539
-* feat(ai): cancel stream button by @ehayes2000 in https://github.com/macro-inc/macro/pull/2543
-* chore(tauri): bump http plugin by @seanaye in https://github.com/macro-inc/macro/pull/2551
-* fix(md): add space escaping to inline md emoji picker by @sedson in https://github.com/macro-inc/macro/pull/2552
-* fix(call): handle noise suppression between mic changes by @whutchinson98 in https://github.com/macro-inc/macro/pull/2553
-* fix(md): make task creation not fail when listitem text length exceeds backend limit by @sedson in https://github.com/macro-inc/macro/pull/2556
-* fix(md): autofocus empty title editor after connect root by @sedson in https://github.com/macro-inc/macro/pull/2557
-* Evan/onboarding analytics fix by @evanhutnik in https://github.com/macro-inc/macro/pull/2555
-* feat(call): recording by @whutchinson98 in https://github.com/macro-inc/macro/pull/2558
-* Hutch/feat call block by @whutchinson98 in https://github.com/macro-inc/macro/pull/2554
-* fix(call): video player CORPS by @whutchinson98 in https://github.com/macro-inc/macro/pull/2561
-* fix(image preview): ensure image upload and fetch include Content Typ… by @aidanhb in https://github.com/macro-inc/macro/pull/2560
-* feat[channels]: big emoji by @peterchinman in https://github.com/macro-inc/macro/pull/2562
-* fix(channels): messages sometimes duplicating  by @dev-rb in https://github.com/macro-inc/macro/pull/2563
-* fix[channels]: grouped message timestamp alignment by @peterchinman in https://github.com/macro-inc/macro/pull/2565
-* chg: show localhost port # in tab title by @peterchinman in https://github.com/macro-inc/macro/pull/2566
-* fix(soup): Soup ast does not support getting non task documents by @dev-rb in https://github.com/macro-inc/macro/pull/2564
-* feat[soup]: hotkey for sort menu by @peterchinman in https://github.com/macro-inc/macro/pull/2567
-* style(entity): update entity edit modal wrapper styles by @sedson in https://github.com/macro-inc/macro/pull/2316
-* feat(call): add call to soup by @whutchinson98 in https://github.com/macro-inc/macro/pull/2559
-* fix(md): add video markdow transformers by @sedson in https://github.com/macro-inc/macro/pull/2568
-* fix(md): align our latex regex with gfm whitespace rules by @sedson in https://github.com/macro-inc/macro/pull/2571
-* feat(fe): create task button with pre-populated title for emails and channels by @evanhutnik in https://github.com/macro-inc/macro/pull/2569
-* feat(analytics): add macro_device enrichment to all analytics events by @evanhutnik in https://github.com/macro-inc/macro/pull/2570
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.4.13.0...v2026.4.14.0
-    </Update>
-
-    <Update label="v2026.4.13.0">
-## What's Changed
-* change add emoji icon by @peterchinman in https://github.com/macro-inc/macro/pull/2514
-* chg(compose): rework compose to use the new input primitives by @synoet in https://github.com/macro-inc/macro/pull/2480
-* fix(properties): prevent metadata properties from disappearing in task view by @gbirman in https://github.com/macro-inc/macro/pull/2515
-* feat(documents): move copy_document to documents hex crate by @whutchinson98 in https://github.com/macro-inc/macro/pull/2512
-* chore: change codeowners by @whutchinson98 in https://github.com/macro-inc/macro/pull/2519
-* chore(deps): bump picomatch from 4.0.3 to 4.0.4 in /rust/sync-service by @dependabot[bot] in https://github.com/macro-inc/macro/pull/2200
-* chore(deps): bump vite from 6.4.1 to 6.4.2 in /rust/sync-service by @dependabot[bot] in https://github.com/macro-inc/macro/pull/2383
-* Hutch/chore docs by @whutchinson98 in https://github.com/macro-inc/macro/pull/2521
-* feat(search): add @mention support to search bar by @gbirman in https://github.com/macro-inc/macro/pull/2517
-* chore: dependabot by @whutchinson98 in https://github.com/macro-inc/macro/pull/2520
-* fix(search): normalize mention filter format between soup and OpenSearch by @gbirman in https://github.com/macro-inc/macro/pull/2518
-* feat(mcp): expose branch name to mcp tool by @whutchinson98 in https://github.com/macro-inc/macro/pull/2522
-* fix(stripe): support unknown stripe subscriptions mapping to haiku by default by @whutchinson98 in https://github.com/macro-inc/macro/pull/2524
-* fix(upload): make file extension matching case-insensitive by @gbirman in https://github.com/macro-inc/macro/pull/2525
-* fix(call): do not drop audio when moving to messages/attachments by @whutchinson98 in https://github.com/macro-inc/macro/pull/2527
-* fix(search): skip entity types with ids_only and empty IDs in unified search by @gbirman in https://github.com/macro-inc/macro/pull/2529
-* feat: document mention notification type by @peterchinman in https://github.com/macro-inc/macro/pull/2516
-* fix: escape bug by @peterchinman in https://github.com/macro-inc/macro/pull/2532
-* feat[mobile channels]: add copy message text action by @peterchinman in https://github.com/macro-inc/macro/pull/2533
-* feat(call): support get call record endpoint by @whutchinson98 in https://github.com/macro-inc/macro/pull/2528
-* chore(search): remove lingering tooltip from search bar by @gbirman in https://github.com/macro-inc/macro/pull/2537
-* fix(search): filter noise emails from search results by @gbirman in https://github.com/macro-inc/macro/pull/2534
-* fix(tasks): improve assignee property editing UX by @gbirman in https://github.com/macro-inc/macro/pull/2536
-* fix[ios]: push notification enable flow by @peterchinman in https://github.com/macro-inc/macro/pull/2504
-* fix(sync): use remote DSS for sync permission tokens in local dev by @gbirman in https://github.com/macro-inc/macro/pull/2538
-* feat(search): add preview button to search view header by @gbirman in https://github.com/macro-inc/macro/pull/2541
-* fix(ci): gen-api timeout and better logging by @whutchinson98 in https://github.com/macro-inc/macro/pull/2540
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.4.10.1...v2026.4.13.0
-    </Update>
-
-    <Update label="v2026.4.10.1">
-## What's Changed
-* Scroll bug in onboarding by @evanhutnik in https://github.com/macro-inc/macro/pull/2513
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.4.10.0...v2026.4.10.1
-    </Update>
-
-    <Update label="v2026.4.10.0">
-## What's Changed
-* actually enable the email lol by @seanaye in https://github.com/macro-inc/macro/pull/2485
-* fix(search): not all documents showing for search soup index by @gbirman in https://github.com/macro-inc/macro/pull/2489
-* feat(search): use PlainTextFormatter for channel search indexing by @gbirman in https://github.com/macro-inc/macro/pull/2491
-* fix: channel read status by @gbirman in https://github.com/macro-inc/macro/pull/2492
-* chg(channels): add max height for images by @synoet in https://github.com/macro-inc/macro/pull/2494
-* chore: bump version by @synoet in https://github.com/macro-inc/macro/pull/2495
-* fix[mobile]: better input focus handling by @peterchinman in https://github.com/macro-inc/macro/pull/2488
-* fix(notif): empty digest and comms data race by @seanaye in https://github.com/macro-inc/macro/pull/2493
-* fix(channel): never hide flex-1 channel list by @synoet in https://github.com/macro-inc/macro/pull/2497
-* feat(search): cache channel filters by @gbirman in https://github.com/macro-inc/macro/pull/2498
-* fix[channel]: squish tabs to icons when narrow by @peterchinman in https://github.com/macro-inc/macro/pull/2496
-* Onboarding flow update by @evanhutnik in https://github.com/macro-inc/macro/pull/2446
-* fix(ui): tabs indicator jumping from start on mount by @dev-rb in https://github.com/macro-inc/macro/pull/2499
-* feat(search): clear search filters button  by @gbirman in https://github.com/macro-inc/macro/pull/2500
-* fix(search): scope channel filter cache by @gbirman in https://github.com/macro-inc/macro/pull/2505
-* feat(calls): highlight call icon if call is active by @whutchinson98 in https://github.com/macro-inc/macro/pull/2503
-* feat(channel): expand image preview on click in text input by @gbirman in https://github.com/macro-inc/macro/pull/2508
-* feat(call): add push notifications by @seanaye in https://github.com/macro-inc/macro/pull/2502
-* feat(email): user link history by @evanhutnik in https://github.com/macro-inc/macro/pull/2509
-* fix(upload): route videos to SFS when MIME type is missing by @gbirman in https://github.com/macro-inc/macro/pull/2510
-* add fallthough for unknown notifications by @seanaye in https://github.com/macro-inc/macro/pull/2511
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.4.9.1...v2026.4.10.0
-    </Update>
-
-    <Update label="v2026.4.9.1">
-## What's Changed
-* chg(pdf): disable eval by @synoet in https://github.com/macro-inc/macro/pull/2486
-* fix: generated notification types by @gbirman in https://github.com/macro-inc/macro/pull/2487
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.4.9.0...v2026.4.9.1
-    </Update>
-
-    <Update label="v2026.4.9.0">
-## What's Changed
-* feat: add profile pic to search in filter by @gbirman in https://github.com/macro-inc/macro/pull/2459
-* feat: make search index icons monochrome by @gbirman in https://github.com/macro-inc/macro/pull/2460
-* fix(search): clear filters properly by @gbirman in https://github.com/macro-inc/macro/pull/2461
-* fix(ai): mcp by @ehayes2000 in https://github.com/macro-inc/macro/pull/2443
-* style(fe): Update Macro Dark/Light default themes by @evanhutnik in https://github.com/macro-inc/macro/pull/2462
-* fix(ai): mcp infra by @ehayes2000 in https://github.com/macro-inc/macro/pull/2464
-* feat call noise filtering by @whutchinson98 in https://github.com/macro-inc/macro/pull/2463
-* chore(docs): setup docs by @synoet in https://github.com/macro-inc/macro/pull/2466
-* refactor(fe): Extract shared plan grid and update pricing tiers by @evanhutnik in https://github.com/macro-inc/macro/pull/2469
-* feat: entity access management crate by @whutchinson98 in https://github.com/macro-inc/macro/pull/2465
-* fix(ai): references by @ehayes2000 in https://github.com/macro-inc/macro/pull/2470
-* feat(ai): UI for failed tool calls by @ehayes2000 in https://github.com/macro-inc/macro/pull/2472
-* fix(analytics): meta ids not forwarded through checkout by @dev-rb in https://github.com/macro-inc/macro/pull/2471
-* fix(notif): conn gateway timestamps by @seanaye in https://github.com/macro-inc/macro/pull/2467
-* Fix mobile formatting of tier grid by @evanhutnik in https://github.com/macro-inc/macro/pull/2473
-* Update Macro Dark theme color tokens by @evanhutnik in https://github.com/macro-inc/macro/pull/2475
-* feat(notifications): return created_at/updated_at for created notification by @gbirman in https://github.com/macro-inc/macro/pull/2478
-* feat(comms): channel invite sends email for non-existing user by @seanaye in https://github.com/macro-inc/macro/pull/2468
-* feat(docs): mcp docs by @ehayes2000 in https://github.com/macro-inc/macro/pull/2481
-* add logging by @seanaye in https://github.com/macro-inc/macro/pull/2483
-* fix[channels]: video preview on safari by @peterchinman in https://github.com/macro-inc/macro/pull/2474
-* fix[ios]: drawers fit content by @peterchinman in https://github.com/macro-inc/macro/pull/2476
-* fix[ios-soup]: limit max unrolled notifications by @peterchinman in https://github.com/macro-inc/macro/pull/2477
-* chore(channels): add tracing to axum router by @synoet in https://github.com/macro-inc/macro/pull/2484
-* fix: channel message notification read status fixes by @gbirman in https://github.com/macro-inc/macro/pull/2482
-* feat(notifications): make created_at/updated_at outbound timestamp required by @gbirman in https://github.com/macro-inc/macro/pull/2479
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.4.8.1...v2026.4.9.0
-    </Update>
-
-    <Update label="v2026.4.8.1">
-## What's Changed
-* feat: search tab filter selection by @gbirman in https://github.com/macro-inc/macro/pull/2453
-* fix[ios]: remove virtual keyboard accessory bar by @peterchinman in https://github.com/macro-inc/macro/pull/2454
-* fix(channels): resolve channel name with whitespace only by @gbirman in https://github.com/macro-inc/macro/pull/2455
-* fix(channels): fix suspense boundry for thread replies by @synoet in https://github.com/macro-inc/macro/pull/2456
-* fix: radio button single select should no-op on reclick by @gbirman in https://github.com/macro-inc/macro/pull/2457
-* fix(channels): only show icons for thread replies collapsed by @synoet in https://github.com/macro-inc/macro/pull/2458
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.4.8.0...v2026.4.8.1
-    </Update>
-
-    <Update label="v2026.4.8.0">
-## What's Changed
-* chore(ai): idiomatic memory config by @ehayes2000 in https://github.com/macro-inc/macro/pull/2400
-* chore(entity_access): move access checks to entity access by @whutchinson98 in https://github.com/macro-inc/macro/pull/2437
-* feat create entity access backfill script by @whutchinson98 in https://github.com/macro-inc/macro/pull/2325
-* feat: remove tasks from Inbox by @peterchinman in https://github.com/macro-inc/macro/pull/2438
-* feat(call): use name in call by @whutchinson98 in https://github.com/macro-inc/macro/pull/2440
-* feat(calls): choose audio/video by @whutchinson98 in https://github.com/macro-inc/macro/pull/2439
-* chore: add debug logs to stripe webhook by @dev-rb in https://github.com/macro-inc/macro/pull/2441
-* chore: cors updates for more localhost sessions by @gbirman in https://github.com/macro-inc/macro/pull/2442
-* chore: add more logs to stripe webhook by @dev-rb in https://github.com/macro-inc/macro/pull/2444
-* fix(analytics): missing GA measurement id  by @dev-rb in https://github.com/macro-inc/macro/pull/2445
-* fix(channels): initial scroll race condition by @synoet in https://github.com/macro-inc/macro/pull/2447
-* chore: add api version log to stripe webhook by @dev-rb in https://github.com/macro-inc/macro/pull/2450
-* fix[ios]: only allow portrait orientation by @peterchinman in https://github.com/macro-inc/macro/pull/2449
-* fix[mobile soup]: missing sender names by @peterchinman in https://github.com/macro-inc/macro/pull/2448
-* fix[ios channels]: scroll message list when input focused" by @peterchinman in https://github.com/macro-inc/macro/pull/2452
-* chore(old-channels): remove old channel logic by @synoet in https://github.com/macro-inc/macro/pull/2451
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.4.7.0...v2026.4.8.0
-    </Update>
-
-    <Update label="v2026.4.7.0">
-## What's Changed
-* fix(ci): runner race condition by @whutchinson98 in https://github.com/macro-inc/macro/pull/2402
-* feat(calls): Frontend implementation by @whutchinson98 in https://github.com/macro-inc/macro/pull/2335
-* fix(onboarding): fix mobile layout, skip on touch, add referral hint by @sedson in https://github.com/macro-inc/macro/pull/2404
-* feat(calls): setup call recording by @whutchinson98 in https://github.com/macro-inc/macro/pull/2405
-* feat(notif): add signed unsubscribe url to digest by @seanaye in https://github.com/macro-inc/macro/pull/2371
-* feat(call): prod transcriber by @whutchinson98 in https://github.com/macro-inc/macro/pull/2407
-* feat: single documents tab in command k by @gbirman in https://github.com/macro-inc/macro/pull/2408
-* fix(ci): duplicate run-id by @whutchinson98 in https://github.com/macro-inc/macro/pull/2409
-* feat(notif): check typename ignore before publishing digest by @seanaye in https://github.com/macro-inc/macro/pull/2411
-* fix: command k safe name by @gbirman in https://github.com/macro-inc/macro/pull/2414
-* feat: command k search improve by @gbirman in https://github.com/macro-inc/macro/pull/2412
-* feat(channels): clean up call logic + call tab by @synoet in https://github.com/macro-inc/macro/pull/2410
-* feat(call): send connection gateway message on channel creation/end by @whutchinson98 in https://github.com/macro-inc/macro/pull/2415
-* fix: soup channel message alignment by @gbirman in https://github.com/macro-inc/macro/pull/2419
-* fix(ai): rendering by @ehayes2000 in https://github.com/macro-inc/macro/pull/2421
-* chore: update command k search config by @gbirman in https://github.com/macro-inc/macro/pull/2423
-* fix[lightbox]: exit with esc by @peterchinman in https://github.com/macro-inc/macro/pull/2417
-* fix: soup long press issue by @peterchinman in https://github.com/macro-inc/macro/pull/2425
-* fix[soup]: task assignee filter always shows user first by @peterchinman in https://github.com/macro-inc/macro/pull/2416
-* fix[soup:tasks]: include tasks shared with me in Assigned view by @peterchinman in https://github.com/macro-inc/macro/pull/2424
-* fix: always include status property when creating a task by @peterchinman in https://github.com/macro-inc/macro/pull/2427
-* fix(email): show full sender name when it starts with "The" by @evanhutnik in https://github.com/macro-inc/macro/pull/2413
-* feat(fe): create task button for email threads and channel messages by @evanhutnik in https://github.com/macro-inc/macro/pull/2426
-* fix: channel navigation broken for search preview mode by @gbirman in https://github.com/macro-inc/macro/pull/2428
-* fix: stripe webhook not processing incomplete status transitions by @dev-rb in https://github.com/macro-inc/macro/pull/2430
-* fix: focus search input if search is already open by @gbirman in https://github.com/macro-inc/macro/pull/2431
-* chg(new-channels): prevent focus on preview by @synoet in https://github.com/macro-inc/macro/pull/2420
-* feat(new-channels): improved scrolling stability by @synoet in https://github.com/macro-inc/macro/pull/2433
-* feat: hide new reply input after reply by @gbirman in https://github.com/macro-inc/macro/pull/2435
-* feat: notifications stack toggle list on bottom by @gbirman in https://github.com/macro-inc/macro/pull/2434
-* fix(channels): refactor task creation button by @synoet in https://github.com/macro-inc/macro/pull/2436
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.4.6.0...v2026.4.7.0
-    </Update>
-
-    <Update label="v2026.4.6.0">
-## What's Changed
-* feat: update code file type in backend by @gbirman in https://github.com/macro-inc/macro/pull/2368
-* feat: code file type chip by @gbirman in https://github.com/macro-inc/macro/pull/2370
-* fix(analytics): missing meta access token by @dev-rb in https://github.com/macro-inc/macro/pull/2373
-* fix[new-channels]: make attachements scroll horizontally by @peterchinman in https://github.com/macro-inc/macro/pull/2369
-* fix ai rendering by @ehayes2000 in https://github.com/macro-inc/macro/pull/2376
-* feat[soup]: return to traditional tabs by @peterchinman in https://github.com/macro-inc/macro/pull/2375
-* feat(ai): email tools by @ehayes2000 in https://github.com/macro-inc/macro/pull/2362
-* fix[mobile]: soup tabs don't slide by @peterchinman in https://github.com/macro-inc/macro/pull/2379
-* feat(calls): move transcript to agent by @whutchinson98 in https://github.com/macro-inc/macro/pull/2377
-* add email link id by @seanaye in https://github.com/macro-inc/macro/pull/2378
-* fix: tanstack query initial value undefined despite cached data by @dev-rb in https://github.com/macro-inc/macro/pull/2380
-* fix(splits): split ids not stable during url sync by @dev-rb in https://github.com/macro-inc/macro/pull/2381
-* Remove InviteBadge component by @evanhutnik in https://github.com/macro-inc/macro/pull/2382
-* Color calendar invite icon in email topbar by @evanhutnik in https://github.com/macro-inc/macro/pull/2386
-* feat(ai): tool restyling + improve tool rendering pipeline by @ehayes2000 in https://github.com/macro-inc/macro/pull/2385
-* feat: change code file type by @gbirman in https://github.com/macro-inc/macro/pull/2387
-* fix(memory): use updated_at for staleness by @ehayes2000 in https://github.com/macro-inc/macro/pull/2389
-* feat: add immutable file type chip for block image by @gbirman in https://github.com/macro-inc/macro/pull/2392
-* feat: add immutable file type chip to block unknown by @gbirman in https://github.com/macro-inc/macro/pull/2391
-* fix: file type change update quick access provider name by @gbirman in https://github.com/macro-inc/macro/pull/2393
-* chore: dry up file type chip component in top bar by @gbirman in https://github.com/macro-inc/macro/pull/2394
-* fix(email): wrong profile picture on messages due to Index reuse by @evanhutnik in https://github.com/macro-inc/macro/pull/2390
-* feat[soup]: mobile action drawer by @peterchinman in https://github.com/macro-inc/macro/pull/2388
-* fix[mobile]: update full text search label by @peterchinman in https://github.com/macro-inc/macro/pull/2395
-* fix[mobile]: more robust touch check by @peterchinman in https://github.com/macro-inc/macro/pull/2396
-* fix[sidebar]: focus bug by @peterchinman in https://github.com/macro-inc/macro/pull/2398
-* fix[soup]: space at end of list by @peterchinman in https://github.com/macro-inc/macro/pull/2399
-* fix(ai): fix ai email by @ehayes2000 in https://github.com/macro-inc/macro/pull/2397
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.4.3.1...v2026.4.6.0
-    </Update>
-
-    <Update label="v2026.4.3.1">
-## What's Changed
-* fix(search): bypass featured count for channels by @gbirman in https://github.com/macro-inc/macro/pull/2365
-* fix(new-channels): input size by @synoet in https://github.com/macro-inc/macro/pull/2367
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.4.3.0...v2026.4.3.1
-    </Update>
-
-    <Update label="v2026.4.3.0">
-## What's Changed
-* fix(soup): Email pagination by @evanhutnik in https://github.com/macro-inc/macro/pull/2360
-* fix(ai): Fix unowned `createEffect` + fix remounting messages by @ehayes2000 in https://github.com/macro-inc/macro/pull/2352
-* feat(search): channel message entity by @gbirman in https://github.com/macro-inc/macro/pull/2359
-* feat[new-channels]: various mobile improvements by @peterchinman in https://github.com/macro-inc/macro/pull/2363
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.4.2.0...v2026.4.3.0
-    </Update>
-
-    <Update label="v2026.4.2.0">
-## What's Changed
-* Evan/scale up prod replica by @evanhutnik in https://github.com/macro-inc/macro/pull/2343
-* chore(log): improve ingress worker logging by @seanaye in https://github.com/macro-inc/macro/pull/2342
-* chore: suppress error in search upload handler for file type not found by @gbirman in https://github.com/macro-inc/macro/pull/2345
-* feat(ai): mcp empty state by @ehayes2000 in https://github.com/macro-inc/macro/pull/2344
-* fix(ai): Chat notifications by @ehayes2000 in https://github.com/macro-inc/macro/pull/2341
-* Hutch/feat calls transcription by @whutchinson98 in https://github.com/macro-inc/macro/pull/2346
-* feat(email): add gmail_ops worker for async Gmail API operations with rate limit retry by @evanhutnik in https://github.com/macro-inc/macro/pull/2226
-* fix: wrap haptics by @peterchinman in https://github.com/macro-inc/macro/pull/2348
-* feat(calls): use share permissions by @whutchinson98 in https://github.com/macro-inc/macro/pull/2349
-* fix(email): Add gmail ops queue to sops/justfile by @evanhutnik in https://github.com/macro-inc/macro/pull/2350
-* Add custom brush icon by @aidanhb in https://github.com/macro-inc/macro/pull/2351
-* fix(new-channels): blanking on new message by @dev-rb in https://github.com/macro-inc/macro/pull/2353
-* chore: remove unnecessary suspense context by @dev-rb in https://github.com/macro-inc/macro/pull/2354
-* fix(new-channels): updates not applying to messages by @dev-rb in https://github.com/macro-inc/macro/pull/2355
-* fix(new-channels): notifications not marked as read from new channels by @dev-rb in https://github.com/macro-inc/macro/pull/2356
-* ai: remove auto attachments by @ehayes2000 in https://github.com/macro-inc/macro/pull/2347
-* feat(ai): konsole mcp by @ehayes2000 in https://github.com/macro-inc/macro/pull/2357
-* fix(new-channel): input jumping from top to bottom by @dev-rb in https://github.com/macro-inc/macro/pull/2358
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.4.1.0...v2026.4.2.0
-    </Update>
-
-    <Update label="v2026.4.1.0">
-## What's Changed
-* fix num notifications in digest by @seanaye in https://github.com/macro-inc/macro/pull/2324
-* fix: call initEmailLink on login flow by @evanhutnik in https://github.com/macro-inc/macro/pull/2326
-* fix(email): remove draft saving spinner from compose by @evanhutnik in https://github.com/macro-inc/macro/pull/2327
-* feat(style): Google Drivemaxx share menu by @aidanhb in https://github.com/macro-inc/macro/pull/2182
-* fix: command k viewed at update old items outside normy cache by @gbirman in https://github.com/macro-inc/macro/pull/2329
-* fix: only refetch specific entity for email draft by @gbirman in https://github.com/macro-inc/macro/pull/2330
-* feat(new-channels): scroll thread reply into view by @synoet in https://github.com/macro-inc/macro/pull/2331
-* feat(soup): readonly replica support by @evanhutnik in https://github.com/macro-inc/macro/pull/2305
-* fix(email): use soup mark-done for 'e' key instead of email archive by @evanhutnik in https://github.com/macro-inc/macro/pull/2334
-* feat(calls): calls backend by @whutchinson98 in https://github.com/macro-inc/macro/pull/2332
-* feat(contacts): add client facing endpoint by @seanaye in https://github.com/macro-inc/macro/pull/2328
-* fix(email): prevent duplicate Sent with Macro watermarks on failed validation by @evanhutnik in https://github.com/macro-inc/macro/pull/2336
-* fix(email): use fixed width for sender column in email list by @evanhutnik in https://github.com/macro-inc/macro/pull/2339
-* fix(email): adjust sender column spacing in email list by @evanhutnik in https://github.com/macro-inc/macro/pull/2340
-* feat[new-channels]: mobile action drawers and other mobile improvements by @peterchinman in https://github.com/macro-inc/macro/pull/2337
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.3.31.1...v2026.4.1.0
-    </Update>
-
-    <Update label="v2026.3.31.1">
-## What's Changed
-* fix(search): drop document name covering index and create the index without name by @gbirman in https://github.com/macro-inc/macro/pull/2323
-* fix(channels): exclude attachments from deleted messages by @synoet in https://github.com/macro-inc/macro/pull/2322
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.3.31.0...v2026.3.31.1
-    </Update>
-
-    <Update label="v2026.3.31.0">
-## What's Changed
-* feat(search): filter out local search from inbox by @gbirman in https://github.com/macro-inc/macro/pull/2286
-* feat: ability to remove github link by @whutchinson98 in https://github.com/macro-inc/macro/pull/2288
-* feat(core): invite btn in side bar, dev only for now by @sedson in https://github.com/macro-inc/macro/pull/2285
-* chore(ai): pay by @ehayes2000 in https://github.com/macro-inc/macro/pull/2282
-* Bump db's again by @evanhutnik in https://github.com/macro-inc/macro/pull/2290
-* feat(github): support redirect flow for github link by @whutchinson98 in https://github.com/macro-inc/macro/pull/2291
-* style(mentions): fix ghost divider on document preview popover, add task properties by @sedson in https://github.com/macro-inc/macro/pull/2292
-* fix(analytics): incorrect proxy url by @dev-rb in https://github.com/macro-inc/macro/pull/2293
-* fix: toast positioning by @peterchinman in https://github.com/macro-inc/macro/pull/2275
-* feat(github): enable button by @whutchinson98 in https://github.com/macro-inc/macro/pull/2289
-* feat(soup): expose soup ast endpoint by @seanaye in https://github.com/macro-inc/macro/pull/2287
-* feat(md): add inline properties to document mention decorator by @sedson in https://github.com/macro-inc/macro/pull/2295
-* feat(db): add entity_access table by @whutchinson98 in https://github.com/macro-inc/macro/pull/2296
-* fix(email): preserve button styling in sanitized HTML emails by @evanhutnik in https://github.com/macro-inc/macro/pull/2294
-* Reduce db instance size by @evanhutnik in https://github.com/macro-inc/macro/pull/2302
-* fix(properties): vuln by @seanaye in https://github.com/macro-inc/macro/pull/2301
-* fix: turn off frecency sort by @peterchinman in https://github.com/macro-inc/macro/pull/2304
-* fix(settings): use base theme for GitHub enable button by @evanhutnik in https://github.com/macro-inc/macro/pull/2303
-* feat(new-channels): attachment tab in channels by @synoet in https://github.com/macro-inc/macro/pull/2279
-* perf(search): document name search covering index by @gbirman in https://github.com/macro-inc/macro/pull/2300
-* feat(notif): truncate digest len by @seanaye in https://github.com/macro-inc/macro/pull/2306
-* perf(search): split email contact search into two queries by @gbirman in https://github.com/macro-inc/macro/pull/2297
-* feat(new-channels): participants tab by @synoet in https://github.com/macro-inc/macro/pull/2307
-* Up instance size agane by @evanhutnik in https://github.com/macro-inc/macro/pull/2309
-* feat(settings): add Enable button for email with logout confirmation by @evanhutnik in https://github.com/macro-inc/macro/pull/2311
-* feat: command k viewed at by @gbirman in https://github.com/macro-inc/macro/pull/2313
-* feat(new-channels): add back live indicators by @synoet in https://github.com/macro-inc/macro/pull/2315
-* chg: agents md improvements by @synoet in https://github.com/macro-inc/macro/pull/2317
-* chore(new-channels): restyle attachments tab by @synoet in https://github.com/macro-inc/macro/pull/2312
-* fix: command k viewed at outside recently viewed limit by @gbirman in https://github.com/macro-inc/macro/pull/2318
-* chg(new-channels): thread reply mounts by @synoet in https://github.com/macro-inc/macro/pull/2319
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.3.30.0...v2026.3.31.0
-    </Update>
-
-    <Update label="v2026.3.30.0">
-## What's Changed
-* fix(search): local fuzzy document search returns non-document results by @gbirman in https://github.com/macro-inc/macro/pull/2242
-* update macrodb prod to gp3 by @whutchinson98 in https://github.com/macro-inc/macro/pull/2244
-* feat(new-channels): typing indicators by @synoet in https://github.com/macro-inc/macro/pull/2245
-* fix[mobile]: correct toast sizing by @peterchinman in https://github.com/macro-inc/macro/pull/2247
-* fix(new-channels): static spacing by @synoet in https://github.com/macro-inc/macro/pull/2249
-* chore(email-link-delete): Disable email if no opens after 7 days inst… by @evanhutnik in https://github.com/macro-inc/macro/pull/2250
-* macrodb replica by @whutchinson98 in https://github.com/macro-inc/macro/pull/2251
-* chore(search): bump to latest opensearch version by @gbirman in https://github.com/macro-inc/macro/pull/2253
-* fix(tasks): add autocopy link bask to task creation by @sedson in https://github.com/macro-inc/macro/pull/2252
-* fix(email): improve scheduled send validation and recipient handling by @evanhutnik in https://github.com/macro-inc/macro/pull/2255
-* fix(analytics): subscription success not tracked and signup events not sent to all providers by @dev-rb in https://github.com/macro-inc/macro/pull/2256
-* feat[mobile]: soup view tabs as slidable bottom bar by @peterchinman in https://github.com/macro-inc/macro/pull/2257
-* fix(analytics): stripe subscription events not tracked in posthog by @dev-rb in https://github.com/macro-inc/macro/pull/2254
-* fix: missing virtua patch to fix window access by @dev-rb in https://github.com/macro-inc/macro/pull/2262
-* fix: suppress bom part failures for text extraction by @gbirman in https://github.com/macro-inc/macro/pull/2259
-* chore(notif): clear stale notifs with missing threadID by @seanaye in https://github.com/macro-inc/macro/pull/2258
-* feat[mobile]: improve compose header button layout and validation by @evanhutnik in https://github.com/macro-inc/macro/pull/2266
-* fix[soup]: show filter chip for email by @peterchinman in https://github.com/macro-inc/macro/pull/2261
-* feat(cmd-k): add sidebar go to commands by @synoet in https://github.com/macro-inc/macro/pull/2268
-* fix(search): update sort script by @gbirman in https://github.com/macro-inc/macro/pull/2267
-* chore: fix biome lint command by @synoet in https://github.com/macro-inc/macro/pull/2272
-* feat(md): add yesterday to date pickers and use relative date formatting  by @sedson in https://github.com/macro-inc/macro/pull/2271
-* chore(email): Refactor email compose by @ehayes2000 in https://github.com/macro-inc/macro/pull/2263
-* create single GitHub app for both oauth authentication and repo syncing by @whutchinson98 in https://github.com/macro-inc/macro/pull/2265
-* feat(ai): paywall models by @ehayes2000 in https://github.com/macro-inc/macro/pull/2234
-* perf(search): remove wildcard matching and use match phrase prefix only by @gbirman in https://github.com/macro-inc/macro/pull/2273
-* feat(team): add email notification by @seanaye in https://github.com/macro-inc/macro/pull/2246
-* fix: link_exists api call by @whutchinson98 in https://github.com/macro-inc/macro/pull/2280
-* chg(channels): return sender with attachments, bump clamp on limit by @synoet in https://github.com/macro-inc/macro/pull/2278
-* fix(db): Bump readonly replica size by @evanhutnik in https://github.com/macro-inc/macro/pull/2283
-* feat(core): simple placeholder send refferal ui by @sedson in https://github.com/macro-inc/macro/pull/2277
-* style(layout): fix broken left padding when un-authed by @sedson in https://github.com/macro-inc/macro/pull/2281
-* chore(analytics): remove old analytics usage and package by @dev-rb in https://github.com/macro-inc/macro/pull/2274
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.3.27.1...v2026.3.30.0
-    </Update>
-
-    <Update label="v2026.3.27.1">
-## What's Changed
-* fix(search): local client side filter by @gbirman in https://github.com/macro-inc/macro/pull/2235
-* fix(channels): various bugs by @dev-rb in https://github.com/macro-inc/macro/pull/2236
-* fix teams by @whutchinson98 in https://github.com/macro-inc/macro/pull/2237
-* fix(soup): use sortTs for email thread ordering and display by @evanhutnik in https://github.com/macro-inc/macro/pull/2238
-* chore(ai): make ai toolset composition panic on fail by @ehayes2000 in https://github.com/macro-inc/macro/pull/2212
-* fix(soup): search text not cached by @dev-rb in https://github.com/macro-inc/macro/pull/2239
-* fix(tauri): prevent ios blank screen by @peterchinman in https://github.com/macro-inc/macro/pull/2240
-* update macrodb dev to gp3 by @whutchinson98 in https://github.com/macro-inc/macro/pull/2241
-* feat[mobile]: what if mobile dock had so many buttons by @peterchinman in https://github.com/macro-inc/macro/pull/2243
-* feat[mobile]: soup filters as drawer by @peterchinman in https://github.com/macro-inc/macro/pull/2229
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.3.27.0...v2026.3.27.1
-    </Update>
-
-    <Update label="v2026.3.27.0">
-## What's Changed
-* feat(search): unify search filters with soup by @gbirman in https://github.com/macro-inc/macro/pull/2230
-* feat(teams): patch team user tier request by @whutchinson98 in https://github.com/macro-inc/macro/pull/2231
-* Seanaye/feat/ignore notification typenames by @seanaye in https://github.com/macro-inc/macro/pull/2214
-* chore(search): exit early if all search indices are empty by @gbirman in https://github.com/macro-inc/macro/pull/2233
-* fix: persistent tab state bug by @peterchinman in https://github.com/macro-inc/macro/pull/2232
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.3.26.2...v2026.3.27.0
-    </Update>
-
-    <Update label="v2026.3.26.2">
-## What's Changed
-* fix: anthropic no response by @ehayes2000 in https://github.com/macro-inc/macro/pull/2189
-* fix(email): include status code and error body in Gmail API error messages by @evanhutnik in https://github.com/macro-inc/macro/pull/2216
-* feat(teams) support tiers team members by @whutchinson98 in https://github.com/macro-inc/macro/pull/2175
-* refactor(gmail-client): simplify get_threads to get_thread for single thread fetch by @evanhutnik in https://github.com/macro-inc/macro/pull/2219
-* chore: remove misleadinc iac comment by @ehayes2000 in https://github.com/macro-inc/macro/pull/2221
-* chore(ai): chat state management by @ehayes2000 in https://github.com/macro-inc/macro/pull/2184
-* fix(notif): mark connection live during ping by @seanaye in https://github.com/macro-inc/macro/pull/2217
-* feat: more updates to s3 key migration script by @gbirman in https://github.com/macro-inc/macro/pull/2222
-* chore: deprecate legacy s3 key by @gbirman in https://github.com/macro-inc/macro/pull/2209
-* fix(analytics): sign up and login tracking by @dev-rb in https://github.com/macro-inc/macro/pull/2224
-* chore: consolidate bucket actions into a single const by @gbirman in https://github.com/macro-inc/macro/pull/2225
-* style(core): restyle toasts by @sedson in https://github.com/macro-inc/macro/pull/2220
-* fix(platform): move out notification provider, to disable modal when not authed by @synoet in https://github.com/macro-inc/macro/pull/2228
-* feat[soup]: persist state per tab by @peterchinman in https://github.com/macro-inc/macro/pull/2218
-* fix: channels blanking and weird virtua scroll bug by @dev-rb in https://github.com/macro-inc/macro/pull/2227
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.3.26.1...v2026.3.26.2
-    </Update>
-
-    <Update label="v2026.3.26.1">
-## What's Changed
-* fix(sidebar): sidebar hotkey capture preventing "go to top" hotkey for soup from firing by @dev-rb in https://github.com/macro-inc/macro/pull/2210
-* fix(auth): add corrent idp param to app gmail login bttns by @sedson in https://github.com/macro-inc/macro/pull/2207
-* update comments by @seanaye in https://github.com/macro-inc/macro/pull/2205
-* fix[email]: mobile rendering of images by @peterchinman in https://github.com/macro-inc/macro/pull/2211
-* chore: cowify error response by @seanaye in https://github.com/macro-inc/macro/pull/2208
-* feat(email): delete user email links on user deletion by @evanhutnik in https://github.com/macro-inc/macro/pull/2213
-* fix(email): CC on mention not working for non-existent contacts by @evanhutnik in https://github.com/macro-inc/macro/pull/2215
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.3.26.0...v2026.3.26.1
-    </Update>
-
-    <Update label="v2026.3.26.0">
-## What's Changed
-* feat(email): Set email sender as Signal/Noise with email_filters by @evanhutnik in https://github.com/macro-inc/macro/pull/2190
-* fix: remove console log by @ehayes2000 in https://github.com/macro-inc/macro/pull/2202
-* chore: remove `keyed` from `ShowFeatureFlag` by @dev-rb in https://github.com/macro-inc/macro/pull/2198
-* increase digest window to 24h by @seanaye in https://github.com/macro-inc/macro/pull/2201
-* fix(soup): derive tab keyboard nav order from visual tab list by @evanhutnik in https://github.com/macro-inc/macro/pull/2204
-* feat(search): filter by sub_type and enrich with properties by @gbirman in https://github.com/macro-inc/macro/pull/2196
-* chore: bump ios version by @peterchinman in https://github.com/macro-inc/macro/pull/2203
-* chore: remove macrotation table by @whutchinson98 in https://github.com/macro-inc/macro/pull/2206
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.3.25.0...v2026.3.26.0
-    </Update>
-
-    <Update label="v2026.3.25.0">
-## What's Changed
-* chore: improve extensionless key migration by @gbirman in https://github.com/macro-inc/macro/pull/2163
-* feat(onboarding): rework lesson flow, better styles, better focus by @sedson in https://github.com/macro-inc/macro/pull/2158
-* fix(teams) only premium users create teams by @whutchinson98 in https://github.com/macro-inc/macro/pull/2164
-* feat(ai): properties tools by @ehayes2000 in https://github.com/macro-inc/macro/pull/2143
-* fix(style): only fade in image preview on load by @aidanhb in https://github.com/macro-inc/macro/pull/2165
-* feat[soup]: add docx to document filters by @peterchinman in https://github.com/macro-inc/macro/pull/2167
-* style(core): matching menu styles for split file menu by @sedson in https://github.com/macro-inc/macro/pull/2169
-* fix memory by @ehayes2000 in https://github.com/macro-inc/macro/pull/2166
-* feat(sidebar): shortcut labels  by @dev-rb in https://github.com/macro-inc/macro/pull/1880
-* fix[tasks]: also hide cancelled tasks from default tabs by @peterchinman in https://github.com/macro-inc/macro/pull/2168
-* fix: improve email templates by @peterchinman in https://github.com/macro-inc/macro/pull/2161
-* fix(ai): handle stream errors by @ehayes2000 in https://github.com/macro-inc/macro/pull/2171
-* feat(channels): debounce thread-replies on mount, change base page size to 50, unless cursor provided by @synoet in https://github.com/macro-inc/macro/pull/2172
-* fix(email): cap reply recipient list to 3 people max by @evanhutnik in https://github.com/macro-inc/macro/pull/2176
-* chore(deps): remove unused dependencies by @synoet in https://github.com/macro-inc/macro/pull/2174
-* fix(ci): Max concurrent typegen by @evanhutnik in https://github.com/macro-inc/macro/pull/2177
-* chore(ci): update coderabbit config by @synoet in https://github.com/macro-inc/macro/pull/2179
-* feat(email): Block sender frontend + backend improvements by @evanhutnik in https://github.com/macro-inc/macro/pull/2156
-* chore(ci): remove claude workflow by @synoet in https://github.com/macro-inc/macro/pull/2181
-* fix[soup]: allow multiple inbox fiters to be applied by @peterchinman in https://github.com/macro-inc/macro/pull/2180
-* feat(search): add task subtype to opensearch by @gbirman in https://github.com/macro-inc/macro/pull/2183
-* feat(dss): add more comment notification types by @seanaye in https://github.com/macro-inc/macro/pull/2170
-* fix(soup): hide disabled context menu items by @evanhutnik in https://github.com/macro-inc/macro/pull/2185
-* fix(analytics): same hotkey events firing too often by @dev-rb in https://github.com/macro-inc/macro/pull/2186
-* chore: remove jwt from RequestContext by @ehayes2000 in https://github.com/macro-inc/macro/pull/2118
-* fix(new-channels): properly handle deleted message updates by @synoet in https://github.com/macro-inc/macro/pull/2188
-* feat[mobile]: good soup entity layouts on mobile by @peterchinman in https://github.com/macro-inc/macro/pull/2173
-* feat(growth): signup flow changes by @sedson in https://github.com/macro-inc/macro/pull/2187
-* fix(analytics): prevent posthog capture of certain elements by @dev-rb in https://github.com/macro-inc/macro/pull/2191
-* todo(onboarding): actually send refer email addresses by @sedson in https://github.com/macro-inc/macro/pull/2193
-* style(preview): restyle popup preview by @sedson in https://github.com/macro-inc/macro/pull/2195
-* feat(new-channels): reaction ordering + tooltip by @synoet in https://github.com/macro-inc/macro/pull/2192
-* feat(new-channels): nit styling improvements by @synoet in https://github.com/macro-inc/macro/pull/2194
-* fix(new-channels): remove persistence for thread-replies by @synoet in https://github.com/macro-inc/macro/pull/2197
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.3.24.2...v2026.3.25.0
-    </Update>
-
-    <Update label="v2026.3.24.2">
-## What's Changed
-* fix: extensionsless key upload problems by @gbirman in https://github.com/macro-inc/macro/pull/2159
-* feat(new-chanenls): remove raf, lower buffer by @synoet in https://github.com/macro-inc/macro/pull/2162
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.3.24.1...v2026.3.24.2
-    </Update>
-
-    <Update label="v2026.3.24.1">
-## What's Changed
-* perf(soup): Shared thread query performance by @evanhutnik in https://github.com/macro-inc/macro/pull/2139
-* Add IP-based rate limiting for referral invites by @seanaye in https://github.com/macro-inc/macro/pull/2106
-* cleanup old notifs by @seanaye in https://github.com/macro-inc/macro/pull/2132
-* Revert "chg(new-chanenls): temp disable overide" by @synoet in https://github.com/macro-inc/macro/pull/2138
-* fix(fusionauth): template by @whutchinson98 in https://github.com/macro-inc/macro/pull/2140
-* fix: use graphemes for counting item name lengths by @whutchinson98 in https://github.com/macro-inc/macro/pull/2141
-* fix(analytics): page view events capturing unnecessary data by @dev-rb in https://github.com/macro-inc/macro/pull/2134
-* chore(search): allow explicit index true by @gbirman in https://github.com/macro-inc/macro/pull/2144
-* fix[tauri]: ability to actually log out of mobile app by @peterchinman in https://github.com/macro-inc/macro/pull/2145
-* update package json by @seanaye in https://github.com/macro-inc/macro/pull/2149
-* feat(referral): template the real email by @seanaye in https://github.com/macro-inc/macro/pull/2147
-* feat(ai): memory by @ehayes2000 in https://github.com/macro-inc/macro/pull/2127
-* feat(icon): Update share icon by @aidanhb in https://github.com/macro-inc/macro/pull/2152
-* fix(email): improve mobile email rendering — scale wide HTML, tighten spacing by @evanhutnik in https://github.com/macro-inc/macro/pull/2146
-* feat(notif): dont send on no account by @seanaye in https://github.com/macro-inc/macro/pull/2151
-* fix(core-md): fix mentions plugin callback inconsitencies and add tests by @sedson in https://github.com/macro-inc/macro/pull/2153
-* feat: team channels by @whutchinson98 in https://github.com/macro-inc/macro/pull/2150
-* fix(cursor): define cursor styles so it can change by @aidanhb in https://github.com/macro-inc/macro/pull/2154
-* feat: upsert/read extensionless s3 keys with legacy support by @gbirman in https://github.com/macro-inc/macro/pull/2039
-* update notification queue name by @seanaye in https://github.com/macro-inc/macro/pull/2155
-* fix(search): add doc storage url env var to upload lambda by @gbirman in https://github.com/macro-inc/macro/pull/2157
-* fix(auth): invalidations on login by @synoet in https://github.com/macro-inc/macro/pull/2107
-* chore(new-channels): item size by @synoet in https://github.com/macro-inc/macro/pull/2160
-* feat(image): Show image preview on hover over image link by @aidanhb in https://github.com/macro-inc/macro/pull/2142
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.3.23.1...v2026.3.24.1
-    </Update>
-
-    <Update label="v2026.3.23.1">
-## What's Changed
-* chg(new-chanenls): temp disable overide by @synoet in https://github.com/macro-inc/macro/pull/2136
-* chore: setup knip for dead code detection by @synoet in https://github.com/macro-inc/macro/pull/2135
-* chg: re-initialize analytics by @synoet in https://github.com/macro-inc/macro/pull/2137
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.3.23.0...v2026.3.23.1
-    </Update>
-
-    <Update label="v2026.3.23.0">
-## What's Changed
-* feat: analytics proxy worker by @dev-rb in https://github.com/macro-inc/macro/pull/1993
-* fix(analytics): user not identified if already authenticated by @dev-rb in https://github.com/macro-inc/macro/pull/2090
-* fix: adjust plural in email digest by @peterchinman in https://github.com/macro-inc/macro/pull/2092
-* chg(new-channels): gaurd isChannelReady on didInitialScroll by @synoet in https://github.com/macro-inc/macro/pull/2096
-* feat[soup-views]: hide completed tasks from assigned and created tabs by @peterchinman in https://github.com/macro-inc/macro/pull/2093
-* chore(claude): update claude md by @synoet in https://github.com/macro-inc/macro/pull/2098
-* fix(new-channels): better thread scrolling + fix data-channel-nav highlight-nav highlight issue by @synoet in https://github.com/macro-inc/macro/pull/2100
-* feat(new-channels): add G hotkey for go to bottom by @synoet in https://github.com/macro-inc/macro/pull/2099
-* fix(new-channels): prevent enter reply hotkey from triggering while editing by @synoet in https://github.com/macro-inc/macro/pull/2101
-* feat(new-channels): add backspace hotkey for delete + fix full width edit message input by @synoet in https://github.com/macro-inc/macro/pull/2102
-* fix(new-channels): prevent empty message send by @synoet in https://github.com/macro-inc/macro/pull/2103
-* fix(spltis): resizer breaking split ordering integrity on history navigation by @synoet in https://github.com/macro-inc/macro/pull/2104
-* chore(deps): bump lz4_flex from 0.11.5 to 0.11.6 in /rust/sync-service by @dependabot[bot] in https://github.com/macro-inc/macro/pull/1980
-* chore(deps): bump rustls-webpki from 0.103.9 to 0.103.10 in /rust/sync-service by @dependabot[bot] in https://github.com/macro-inc/macro/pull/2095
-* chore(deps): bump rustls-webpki from 0.103.8 to 0.103.10 in /js/app/tauri by @dependabot[bot] in https://github.com/macro-inc/macro/pull/2094
-* fix: file size name limit by @whutchinson98 in https://github.com/macro-inc/macro/pull/2109
-* style(fonts): actually use Inter, swap mono for Roboto by @sedson in https://github.com/macro-inc/macro/pull/2112
-* chore(email-service): Better logging for init and gmail client by @evanhutnik in https://github.com/macro-inc/macro/pull/2111
-* feat(core): add logout and account commands to cmd+k by @sedson in https://github.com/macro-inc/macro/pull/2115
-* feat(github): associate GitHub installation id with a team by @whutchinson98 in https://github.com/macro-inc/macro/pull/2113
-* chore: bump rustls-webpki by @seanaye in https://github.com/macro-inc/macro/pull/2108
-* refactor(gmail_client): remove explicit level attrs from tracing instruments by @evanhutnik in https://github.com/macro-inc/macro/pull/2114
-* style(sidebar): minor style tweaks by @sedson in https://github.com/macro-inc/macro/pull/2117
-* fix(properties): only update task status property when updating task status by @whutchinson98 in https://github.com/macro-inc/macro/pull/2121
-* fix(email): bypass Redis cache for Gmail token on init endpoint by @evanhutnik in https://github.com/macro-inc/macro/pull/2120
-* feat(new-channels): limit @ user mentions to participants, add back @here support by @synoet in https://github.com/macro-inc/macro/pull/2116
-* Seanaye/chore/update cargo denylist by @seanaye in https://github.com/macro-inc/macro/pull/2122
-* fix(analytics): use proxy for posthog by @dev-rb in https://github.com/macro-inc/macro/pull/2125
-* feat(channels): return attachment width/height by @synoet in https://github.com/macro-inc/macro/pull/2123
-* fix(fe): Prompts for disabled email by @evanhutnik in https://github.com/macro-inc/macro/pull/2124
-* feat(soup): add shared email thread filtering by @evanhutnik in https://github.com/macro-inc/macro/pull/2091
-* fix(sidebar): add context menu to channels widget, remove draggable by @sedson in https://github.com/macro-inc/macro/pull/2128
-* feat(ai-tools): Email tools by @evanhutnik in https://github.com/macro-inc/macro/pull/1796
-* remove unused crate by @seanaye in https://github.com/macro-inc/macro/pull/2126
-* feat(soup): collapsible view tabs with dropdown fallback by @evanhutnik in https://github.com/macro-inc/macro/pull/2133
-* feat(analytics): use new analytics events by @dev-rb in https://github.com/macro-inc/macro/pull/2105
-* feat(soup): unify email tab filters and rename Important to Signal by @evanhutnik in https://github.com/macro-inc/macro/pull/2130
-* fix(new-channels): scroll jankyness, thread stability improvements by @synoet in https://github.com/macro-inc/macro/pull/2110
-* feat(new-channels): consistent loading media sizing by @synoet in https://github.com/macro-inc/macro/pull/2129
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.3.20.0...v2026.3.23.0
-    </Update>
-
-    <Update label="v2026.3.20.0">
-## What's Changed
-* feat(auth): limit user creation based on ip by @whutchinson98 in https://github.com/macro-inc/macro/pull/2076
-* chg(login): change login styling to match onboarding by @synoet in https://github.com/macro-inc/macro/pull/2075
-* fix(posthog): feature flag not working and add enable override by @dev-rb in https://github.com/macro-inc/macro/pull/2077
-* fix[mobile]: fix channel soup truncation by @peterchinman in https://github.com/macro-inc/macro/pull/2080
-* feat(access): update useritemaccess to track the team id association for sharing by @whutchinson98 in https://github.com/macro-inc/macro/pull/2078
-* more action bumps by @whutchinson98 in https://github.com/macro-inc/macro/pull/2081
-* fix(ai): save partial response on stream error. by @ehayes2000 in https://github.com/macro-inc/macro/pull/2069
-* fix(core): fix split header crash by @sedson in https://github.com/macro-inc/macro/pull/2082
-* fix: force hitting fusionauth oauth logout endpoint on client by @whutchinson98 in https://github.com/macro-inc/macro/pull/2083
-* feat(ai): mcp server by @ehayes2000 in https://github.com/macro-inc/macro/pull/2060
-* fix: split header right styling by @peterchinman in https://github.com/macro-inc/macro/pull/2084
-* infra(mcp-server): add Pulumi.prod.yaml for prod deployment by @ehayes2000 in https://github.com/macro-inc/macro/pull/2086
-* chore: hexify dcs (chat crud) by @ehayes2000 in https://github.com/macro-inc/macro/pull/1541
-* feat(tasks): update createtask to take sharewithteam parameter by @whutchinson98 in https://github.com/macro-inc/macro/pull/2087
-* fix(channel): opening channel causes infinite loop freeze by @dev-rb in https://github.com/macro-inc/macro/pull/2079
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.3.19.1...v2026.3.20.0
-    </Update>
-
-    <Update label="v2026.3.19.1">
-## What's Changed
-* chg: channel block switch ff by @synoet in https://github.com/macro-inc/macro/pull/2074
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.3.19.0...v2026.3.19.1
-    </Update>
-
-    <Update label="v2026.3.19.0">
-## What's Changed
-* fix(soup): optimistic email archiving by @synoet in https://github.com/macro-inc/macro/pull/2038
-* feat[soup]: filter menu  by @peterchinman in https://github.com/macro-inc/macro/pull/1969
-* fix(permissions): don't use auth check to block view permissions by @synoet in https://github.com/macro-inc/macro/pull/2042
-* chg(top-bar): hide references and notifications pane when unauthed by @synoet in https://github.com/macro-inc/macro/pull/2040
-* style(sidebar): no tool tips on sidbar nav by @sedson in https://github.com/macro-inc/macro/pull/2043
-* feat(icon): add new split icon by @aidanhb in https://github.com/macro-inc/macro/pull/2049
-* feat(referral): address referral edge cases by @whutchinson98 in https://github.com/macro-inc/macro/pull/2048
-* chore(sidebar): remove unused widget file by @dev-rb in https://github.com/macro-inc/macro/pull/2050
-* feat(analytics): track stripe subscription events by @dev-rb in https://github.com/macro-inc/macro/pull/2012
-* chore(new-channels): block compatibility by @synoet in https://github.com/macro-inc/macro/pull/2052
-* feat(pricing): implement new pricing tiers by @whutchinson98 in https://github.com/macro-inc/macro/pull/2051
-* feat[sidebar]: Merge Files and Documents, add Folders by @peterchinman in https://github.com/macro-inc/macro/pull/2041
-* feat(icon): Add static calendar icon by @aidanhb in https://github.com/macro-inc/macro/pull/2053
-* feat(icon): display calendar icon on invite emails by @aidanhb in https://github.com/macro-inc/macro/pull/2056
-* fix: email digest template by @peterchinman in https://github.com/macro-inc/macro/pull/2059
-* chg(new-channels): wait for channel ready before exposing handle by @synoet in https://github.com/macro-inc/macro/pull/2061
-* fix: posthog env var access by @dev-rb in https://github.com/macro-inc/macro/pull/2057
-* Update CreateDocument tool: string content, add is_task flag by @ehayes2000 in https://github.com/macro-inc/macro/pull/2054
-* fix: image dragging bug by @peterchinman in https://github.com/macro-inc/macro/pull/2062
-* fix(ai): logging by @ehayes2000 in https://github.com/macro-inc/macro/pull/2063
-* chore(new-channels): copy paste media by @synoet in https://github.com/macro-inc/macro/pull/2055
-* chore(readme): update with new branding by @synoet in https://github.com/macro-inc/macro/pull/2067
-* feat(ai): engooden search results by @ehayes2000 in https://github.com/macro-inc/macro/pull/2066
-* feat(growth): slideshow onboarding rough outline needs polish by @sedson in https://github.com/macro-inc/macro/pull/2068
-* feat(email): add project support for email threads by @evanhutnik in https://github.com/macro-inc/macro/pull/2065
-* chg(unified-list): use backend for task filtering in list by @synoet in https://github.com/macro-inc/macro/pull/2064
-* chg: add posthog feature flag by @synoet in https://github.com/macro-inc/macro/pull/2070
-* chore: new app icons by @peterchinman in https://github.com/macro-inc/macro/pull/2071
-* feat(notif): send referral emails by @seanaye in https://github.com/macro-inc/macro/pull/2034
-* chore(analytics): add more tracing to backend by @dev-rb in https://github.com/macro-inc/macro/pull/2073
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v.2026.3.18.0...v2026.3.19.0
-    </Update>
-
-    <Update label="v2026.3.18.0">
-## What's Changed
-* fix(notif): correct the sender address by @seanaye in https://github.com/macro-inc/macro/pull/2001
-* feat(channels): add some placeholder text for new users to understand how channel creation works by @jbecke in https://github.com/macro-inc/macro/pull/1996
-* feat(tutorial): sidebar stuff, new buttons, new split button, per user feedback via linkedin by @jbecke in https://github.com/macro-inc/macro/pull/1998
-* feat(search): reduce DB pressure during email search backfills by @gbirman in https://github.com/macro-inc/macro/pull/2007
-* chore(ai): improve tracing and prompt by @ehayes2000 in https://github.com/macro-inc/macro/pull/2004
-* fix(notifs): malformed payload by @seanaye in https://github.com/macro-inc/macro/pull/2009
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.3.17.0...v2026.3.18.0
-    </Update>
-
-    <Update label="v2026.3.17.0">
-## What's Changed
-* feat[mobile]: make mobile channel soup good by @peterchinman in https://github.com/macro-inc/macro/pull/1984
-* Add shortcut badges to top sidebar navigation links by @jbecke in https://github.com/macro-inc/macro/pull/1986
-* feat(new-channels): better media sizing by @synoet in https://github.com/macro-inc/macro/pull/1987
-* update claude.md by @whutchinson98 in https://github.com/macro-inc/macro/pull/1989
-* fix: duplicate blocks opened by new split hotkey by @dev-rb in https://github.com/macro-inc/macro/pull/1990
-* feat(soup): support document sub_type filter in dynamic query by @whutchinson98 in https://github.com/macro-inc/macro/pull/1991
-* remove nullable macro_user_id by @whutchinson98 in https://github.com/macro-inc/macro/pull/1988
-* fix(icon): Update create icon, email icon, and search icon by @aidanhb in https://github.com/macro-inc/macro/pull/1896
-* Add HTML render/code toggle for code blocks by @jbecke in https://github.com/macro-inc/macro/pull/1781
-* feat(notif): enable email digest by @seanaye in https://github.com/macro-inc/macro/pull/1921
-* Update prereqs by @evanhutnik in https://github.com/macro-inc/macro/pull/1994
-* fix(notif): only incr rate limit on success by @seanaye in https://github.com/macro-inc/macro/pull/1995
-* feat(style): Adjust styling on segmented control components in soup t… by @aidanhb in https://github.com/macro-inc/macro/pull/1897
-* feat(icon): Add animated command and settings icons for sidebar by @aidanhb in https://github.com/macro-inc/macro/pull/1999
-* feat(core): add commands to menu from blocks by @sedson in https://github.com/macro-inc/macro/pull/1997
-* feat(style): Make shift key in Launcher light up on shift hold by @aidanhb in https://github.com/macro-inc/macro/pull/2000
-* fix(icon): update tauri icons by @aidanhb in https://github.com/macro-inc/macro/pull/2005
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.3.16.0...v2026.3.17.0
-    </Update>
-
-    <Update label="v2026.3.16.0">
-## What's Changed
-* chore(new-channels): remove render icon helper by @synoet in https://github.com/macro-inc/macro/pull/1933
-* feat: create new emails index by @gbirman in https://github.com/macro-inc/macro/pull/1935
-* chore: readd release db migrator by @whutchinson98 in https://github.com/macro-inc/macro/pull/1937
-* style(core): remove op sizing on body by @sedson in https://github.com/macro-inc/macro/pull/1938
-* chore(new-channels): clean up input composition by @synoet in https://github.com/macro-inc/macro/pull/1934
-* feat: improve SPS backfill performance by @gbirman in https://github.com/macro-inc/macro/pull/1936
-* fix(soup): fix display name reactivity in notificaiton stacks by @sedson in https://github.com/macro-inc/macro/pull/1939
-* feat: add new app analytics provider by @dev-rb in https://github.com/macro-inc/macro/pull/1864
-* chore(search): remove dead code + add opensearch client example by @gbirman in https://github.com/macro-inc/macro/pull/1942
-* Russell/stable sidebar by @Fake-User in https://github.com/macro-inc/macro/pull/1943
-* Fix sidebar toggle hotkey when editor input is focused by @jbecke in https://github.com/macro-inc/macro/pull/1944
-* style(ui): add new (better) button variants from sidebar buttons to core ui button by @sedson in https://github.com/macro-inc/macro/pull/1940
-* fix: email notifications not marked as read after opening email by @dev-rb in https://github.com/macro-inc/macro/pull/1946
-* fix[email]: remove paywall to send email by @peterchinman in https://github.com/macro-inc/macro/pull/1947
-* fix[mobile]: hide sidebar by @peterchinman in https://github.com/macro-inc/macro/pull/1948
-* style(sidebar): move sidbar toggle btn back to top by @sedson in https://github.com/macro-inc/macro/pull/1949
-* style(sidebar): improve transition by @sedson in https://github.com/macro-inc/macro/pull/1952
-* refactor(soup): clean up soup filters and configs by @dev-rb in https://github.com/macro-inc/macro/pull/1892
-* fix[new-channels]: message spacing by @peterchinman in https://github.com/macro-inc/macro/pull/1950
-* feat(search): very basic email multi term by @gbirman in https://github.com/macro-inc/macro/pull/1951
-* feat(search): make search input full width + use slash to focus search in search view by @gbirman in https://github.com/macro-inc/macro/pull/1953
-* Revert "feat(search): make search input full width + use slash to focus search in search view" by @gbirman in https://github.com/macro-inc/macro/pull/1954
-* chore(deps): bump quinn-proto from 0.11.13 to 0.11.14 in /js/app/tauri by @dependabot[bot] in https://github.com/macro-inc/macro/pull/1884
-* chore(deps): bump rollup from 4.34.9 to 4.59.0 in /rust/sync-service by @dependabot[bot] in https://github.com/macro-inc/macro/pull/1724
-* chore(deps): bump quinn-proto from 0.11.9 to 0.11.14 in /rust/cloud-storage by @dependabot[bot] in https://github.com/macro-inc/macro/pull/1885
-* chore: bump package versions for dependabot by @whutchinson98 in https://github.com/macro-inc/macro/pull/1957
-* chg(new-channels): disable persistence for new-channels by @synoet in https://github.com/macro-inc/macro/pull/1956
-* dependabot skill by @whutchinson98 in https://github.com/macro-inc/macro/pull/1959
-* basic smoke test runner by @whutchinson98 in https://github.com/macro-inc/macro/pull/1958
-* record attachment info on message by @ehayes2000 in https://github.com/macro-inc/macro/pull/1960
-* style(md): better button and spacing in the md popup formatter by @sedson in https://github.com/macro-inc/macro/pull/1961
-* style(command): category tabs match split top tabs by @sedson in https://github.com/macro-inc/macro/pull/1965
-* fix(soup): weird toggle with shift+j/k at list boundaries by @sedson in https://github.com/macro-inc/macro/pull/1967
-* feat(search): add since and target index overrides for SPS backfill by @gbirman in https://github.com/macro-inc/macro/pull/1963
-* properties literal by @whutchinson98 in https://github.com/macro-inc/macro/pull/1966
-* fix(search): highlight sender names derived from email local part by @gbirman in https://github.com/macro-inc/macro/pull/1970
-* fix(email): Mobile scheduled send by @evanhutnik in https://github.com/macro-inc/macro/pull/1972
-* fix: add ref counting to tracking by @ehayes2000 in https://github.com/macro-inc/macro/pull/1971
-* fix[new-channel]: alignment by @peterchinman in https://github.com/macro-inc/macro/pull/1955
-* fix(email): Saving blank drafts by @evanhutnik in https://github.com/macro-inc/macro/pull/1973
-* rename on send from chat by @ehayes2000 in https://github.com/macro-inc/macro/pull/1962
-* fix(ai): permissive date parsing by @ehayes2000 in https://github.com/macro-inc/macro/pull/1968
-* fix(stream): stream subscription logic by @ehayes2000 in https://github.com/macro-inc/macro/pull/1976
-* feat(search): improve keyword windowing by @gbirman in https://github.com/macro-inc/macro/pull/1977
-* fix(email): exclude trashed messages from importance filter and use inbox emailView for signal/noise by @evanhutnik in https://github.com/macro-inc/macro/pull/1975
-* feat(sidebar): hotkey tooltips for links, replace \<a> with \<btn> by @sedson in https://github.com/macro-inc/macro/pull/1974
-* fix(ai): fix task link to md by @sedson in https://github.com/macro-inc/macro/pull/1979
-* Fix notification-triggered search reloads and sidebar flicker by @gbirman in https://github.com/macro-inc/macro/pull/1981
-* fix(email): Apply labels to drafts by @evanhutnik in https://github.com/macro-inc/macro/pull/1983
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.3.12.0...v2026.3.16.0
-    </Update>
-
-    <Update label="v2026.3.12.0">
-## What's Changed
-* fix[mobile]: refresh apns token if needed by @peterchinman in https://github.com/macro-inc/macro/pull/1898
-* feat(new-channels): collapsing consecutive messages by @synoet in https://github.com/macro-inc/macro/pull/1905
-* fix: limit bash tool rendered output by @ehayes2000 in https://github.com/macro-inc/macro/pull/1827
-* tool(email): Reverse sfs mappings by @evanhutnik in https://github.com/macro-inc/macro/pull/1909
-* fix[mobile]: hide dock when not authed by @peterchinman in https://github.com/macro-inc/macro/pull/1908
-* refactor(connection_gateway): use single redis connection by @whutchinson98 in https://github.com/macro-inc/macro/pull/1912
-* perf(search): make a separate table to speed up email contact search by @gbirman in https://github.com/macro-inc/macro/pull/1913
-* feat(teams): hexify teams crate by @whutchinson98 in https://github.com/macro-inc/macro/pull/1911
-* feat(list): tab and number key shortcuts for soup view tab groups by @sedson in https://github.com/macro-inc/macro/pull/1914
-* feat(search): index reply-to and email contact names in opensearch by @gbirman in https://github.com/macro-inc/macro/pull/1916
-* style(email): Improved draft saving experience by @evanhutnik in https://github.com/macro-inc/macro/pull/1917
-* refactor(documents): move create_task to documents crate by @whutchinson98 in https://github.com/macro-inc/macro/pull/1918
-* chore(claude): update claude.md to remove schema.prisma references by @whutchinson98 in https://github.com/macro-inc/macro/pull/1920
-* fix(email-reverse-sfs): Improve performance of tool by @evanhutnik in https://github.com/macro-inc/macro/pull/1919
-* feat[channels]: mark messages seen on mount by @peterchinman in https://github.com/macro-inc/macro/pull/1904
-* feat(email): Drag and drop recipients in compose by @evanhutnik in https://github.com/macro-inc/macro/pull/1910
-* feat(tasks): share tasks with team by @whutchinson98 in https://github.com/macro-inc/macro/pull/1923
-* feat(splits): hide close on single split, chg history behavior for common operations by @sedson in https://github.com/macro-inc/macro/pull/1922
-* fix(sidebar): no draggable on links by @sedson in https://github.com/macro-inc/macro/pull/1915
-* fix(email): Keep file type suffix on draft attachments by @evanhutnik in https://github.com/macro-inc/macro/pull/1924
-* chore: import openserach query builder + update deps by @gbirman in https://github.com/macro-inc/macro/pull/1925
-* feat(app): Local/dev tab title prefix by @evanhutnik in https://github.com/macro-inc/macro/pull/1926
-* chore: update openserach query builder as a workspace crate by @gbirman in https://github.com/macro-inc/macro/pull/1927
-* feat(new-channels): ability to edit messages + better composition by @synoet in https://github.com/macro-inc/macro/pull/1907
-* chore(email-db-client): Better logging by @evanhutnik in https://github.com/macro-inc/macro/pull/1929
-* feat(new-channels): sticky scrolling on new message by @synoet in https://github.com/macro-inc/macro/pull/1928
-* feat[new channels]: highlight new message rails by @peterchinman in https://github.com/macro-inc/macro/pull/1930
-* fix(channels): optimistic static attachments duplication by @synoet in https://github.com/macro-inc/macro/pull/1931
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.3.11.0...v2026.3.12.0
-    </Update>
-
-    <Update label="v2026.3.11.0">
-## What's Changed
-* remove delete document worker by @whutchinson98 in https://github.com/macro-inc/macro/pull/1883
-* bump mobile version numbers by @peterchinman in https://github.com/macro-inc/macro/pull/1881
-* fix: not able to create duplicate block splits with hotkey by @dev-rb in https://github.com/macro-inc/macro/pull/1886
-* style(settings): temp style settings fixes by @sedson in https://github.com/macro-inc/macro/pull/1874
-* chore: bump axum by @seanaye in https://github.com/macro-inc/macro/pull/1839
-* feat(email): User card on email sender/recipient hover by @evanhutnik in https://github.com/macro-inc/macro/pull/1888
-* fix(email): Too many sfs logs by @evanhutnik in https://github.com/macro-inc/macro/pull/1889
-* chore(email-service): Disable sfs mapping in prod for email backfill by @evanhutnik in https://github.com/macro-inc/macro/pull/1890
-* style(core): remove optical sizing by @sedson in https://github.com/macro-inc/macro/pull/1891
-* feat(email-service): Block users by @evanhutnik in https://github.com/macro-inc/macro/pull/1114
-* perf(search): materialized table for speed improvement by @gbirman in https://github.com/macro-inc/macro/pull/1899
-* chore(email): Enable proxy in FE by @evanhutnik in https://github.com/macro-inc/macro/pull/1900
-* fix(chat): reset scroll on emoji selector on search input change by @aidanhb in https://github.com/macro-inc/macro/pull/1887
-* chg(launcher): update launcher hot keys, make tooltip legible by @sedson in https://github.com/macro-inc/macro/pull/1901
-* fix(icons): hide animated icon tittle attr for no broswer tooltip by @sedson in https://github.com/macro-inc/macro/pull/1902
-* feat(new-channels): live updates & optimistic by @synoet in https://github.com/macro-inc/macro/pull/1877
-* chg(new-channels): remove sticky logic from the thread list by @synoet in https://github.com/macro-inc/macro/pull/1903
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.3.10.1...v2026.3.11.0
-    </Update>
-
-    <Update label="v2026.3.10.1">
-## What's Changed
-* fix: remove db job by @whutchinson98 in https://github.com/macro-inc/macro/pull/1882
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.3.10.0...v2026.3.10.1
-    </Update>
-
-    <Update label="v2026.3.10.0">
-## What's Changed
-* fix(canvas): add shallow diff to canvas node update by @sedson in https://github.com/macro-inc/macro/pull/1786
-* chore(email-service): Hexify list labels endpoint by @evanhutnik in https://github.com/macro-inc/macro/pull/1783
-* feat(github): Better tracing and event handling by @whutchinson98 in https://github.com/macro-inc/macro/pull/1787
-* chore(notif): move more stuff into notification by @seanaye in https://github.com/macro-inc/macro/pull/1778
-* chore: bump dss db connections in dev by @whutchinson98 in https://github.com/macro-inc/macro/pull/1790
-* chore(email-service): Get thread ai tool method by @evanhutnik in https://github.com/macro-inc/macro/pull/1788
-* fix(email): Show plaintext drafts by @evanhutnik in https://github.com/macro-inc/macro/pull/1792
-* get document short id call by @whutchinson98 in https://github.com/macro-inc/macro/pull/1789
-* fix(email): Invalidate thread cache on new message by @evanhutnik in https://github.com/macro-inc/macro/pull/1795
-* fix(email): Debounce times for /seen endpoint call by @evanhutnik in https://github.com/macro-inc/macro/pull/1797
-* Feat(ai): send to bg by @ehayes2000 in https://github.com/macro-inc/macro/pull/1798
-* feat(command): add global commands to upload file/folders to soup by @sedson in https://github.com/macro-inc/macro/pull/1791
-* feat(github): associate pr with task by @whutchinson98 in https://github.com/macro-inc/macro/pull/1799
-* fix(email): Draft re-appears after send by @evanhutnik in https://github.com/macro-inc/macro/pull/1800
-* fix(email): Always archive when marking as done by @evanhutnik in https://github.com/macro-inc/macro/pull/1802
-* delete eric hayes console.log by @sedson in https://github.com/macro-inc/macro/pull/1804
-* feat(tasks): copy branch name to clipboard for tasks by @sedson in https://github.com/macro-inc/macro/pull/1803
-* feat: sidebar and new soup layout by @dev-rb in https://github.com/macro-inc/macro/pull/1676
-* fix: long response times by @seanaye in https://github.com/macro-inc/macro/pull/1805
-* fix: do not upsert tasks that are not valid by @whutchinson98 in https://github.com/macro-inc/macro/pull/1808
-* fix(soup): filter and sort bugs by @dev-rb in https://github.com/macro-inc/macro/pull/1809
-* fix: add some stavation buffer time by @seanaye in https://github.com/macro-inc/macro/pull/1810
-* deploy dss for github by @whutchinson98 in https://github.com/macro-inc/macro/pull/1812
-* fix(email): Styling stuff by @evanhutnik in https://github.com/macro-inc/macro/pull/1813
-* fix(sidebar): unread channels not clickable by @dev-rb in https://github.com/macro-inc/macro/pull/1811
-* fix(notif): queue payload deserialization by @seanaye in https://github.com/macro-inc/macro/pull/1815
-* fix: mobile layout by @peterchinman in https://github.com/macro-inc/macro/pull/1818
-* fix(chat): include user name and email in AI chat instructions by @ehayes2000 in https://github.com/macro-inc/macro/pull/1817
-* fix the dss build by @seanaye in https://github.com/macro-inc/macro/pull/1819
-* fix(soup): email view not sending correct param for drafts and sent by @dev-rb in https://github.com/macro-inc/macro/pull/1821
-* feat(md): add blockquote to formatting toolbars by @sedson in https://github.com/macro-inc/macro/pull/1814
-* chore(email-service): Disable sfs map for dev/local by @evanhutnik in https://github.com/macro-inc/macro/pull/1820
-* fix(email): Recursion limit by @evanhutnik in https://github.com/macro-inc/macro/pull/1823
-* feat(ai): dss tools by @ehayes2000 in https://github.com/macro-inc/macro/pull/1801
-* fix(soup): Missing preview button and hotkey by @dev-rb in https://github.com/macro-inc/macro/pull/1824
-* fix(email): Invalidate thread cache on scheduled send by @evanhutnik in https://github.com/macro-inc/macro/pull/1825
-* fix(email): Move send button in compose view by @evanhutnik in https://github.com/macro-inc/macro/pull/1826
-* chore: isolate ConnectionGatewayClient by @whutchinson98 in https://github.com/macro-inc/macro/pull/1822
-* feat(notifications): optimistically update updated_at when notifications come in by @synoet in https://github.com/macro-inc/macro/pull/1535
-* feat(channels): new channel input by @synoet in https://github.com/macro-inc/macro/pull/1761
-* fix(ai): timeouts, prompt, throbber by @ehayes2000 in https://github.com/macro-inc/macro/pull/1828
-* chore: fix github sync pem for sops by @whutchinson98 in https://github.com/macro-inc/macro/pull/1831
-* fix: add recursion limit for all services by @whutchinson98 in https://github.com/macro-inc/macro/pull/1830
-* fix: file-folder support + basic filtering for owner in file-folder by @gbirman in https://github.com/macro-inc/macro/pull/1832
-* fix: feature flagging by @whutchinson98 in https://github.com/macro-inc/macro/pull/1833
-* fix: entity navigation indicator disappearing after navigation by @dev-rb in https://github.com/macro-inc/macro/pull/1829
-* style: update styles for soup-view and command menu segmented controls by @sedson in https://github.com/macro-inc/macro/pull/1835
-* fix(sidebar): allow opening duplicate views by @dev-rb in https://github.com/macro-inc/macro/pull/1834
-* feat(channels): make channels crate use entity access pattern by @synoet in https://github.com/macro-inc/macro/pull/1807
-* feat(icon): Add a bunch more icons, animated icons, and an icon gallery block for viewing all existing macro icons by @aidanhb in https://github.com/macro-inc/macro/pull/1806
-* style(core): make tooltips styles not inverted colors by @sedson in https://github.com/macro-inc/macro/pull/1837
-* fix: unauthenticated views not showing up by @dev-rb in https://github.com/macro-inc/macro/pull/1840
-* add get_users_by_entity to entity access service by @whutchinson98 in https://github.com/macro-inc/macro/pull/1836
-* fix: old unified list component route should redirect to inbox by @dev-rb in https://github.com/macro-inc/macro/pull/1841
-* feat: connection hex crate by @whutchinson98 in https://github.com/macro-inc/macro/pull/1842
-* feat(new-channels): add simple persistence for drafts by @synoet in https://github.com/macro-inc/macro/pull/1843
-* fix: small tauri websocket improvements by @peterchinman in https://github.com/macro-inc/macro/pull/1764
-* fix(splits): layout manager not fetching split content by @dev-rb in https://github.com/macro-inc/macro/pull/1848
-* fix(soup): virtualize combobox filter list by @dev-rb in https://github.com/macro-inc/macro/pull/1849
-* perf(search): optimize query by @gbirman in https://github.com/macro-inc/macro/pull/1851
-* feat(connection): delete document invalidation by @whutchinson98 in https://github.com/macro-inc/macro/pull/1852
-* feat(connection): add invalidation for task status update by @whutchinson98 in https://github.com/macro-inc/macro/pull/1853
-* style(core): rounded corners on splits, fix style nits, top-bar spacing by @sedson in https://github.com/macro-inc/macro/pull/1847
-* fix(sidebar): Move create and search buttons by @dev-rb in https://github.com/macro-inc/macro/pull/1816
-* fix(filters): use quick access, fix weird virtual scroll by @sedson in https://github.com/macro-inc/macro/pull/1854
-* chore(iac): update dcs min instance count by @whutchinson98 in https://github.com/macro-inc/macro/pull/1855
-* fix(sidebar): move settings and shortcuts button to bottom of sidebar by @dev-rb in https://github.com/macro-inc/macro/pull/1850
-* chore(sidebar): remove extra create button & change icon by @dev-rb in https://github.com/macro-inc/macro/pull/1860
-* fix(image_proxy_service): Hardening image fetch logic by @evanhutnik in https://github.com/macro-inc/macro/pull/1858
-* move delete_document_worker into DSS by @whutchinson98 in https://github.com/macro-inc/macro/pull/1859
-* fix(fe-proxy): Remove spaces from url by @evanhutnik in https://github.com/macro-inc/macro/pull/1862
-* feat(documents): move edit document to documents hex by @whutchinson98 in https://github.com/macro-inc/macro/pull/1857
-* feat(date-picker): Time support by @evanhutnik in https://github.com/macro-inc/macro/pull/1856
-* fix: sqs perms by @whutchinson98 in https://github.com/macro-inc/macro/pull/1865
-* fix(connection_gateway): share single Redis connection per batch by @whutchinson98 in https://github.com/macro-inc/macro/pull/1866
-* fix(notif): worker hanging by @seanaye in https://github.com/macro-inc/macro/pull/1861
-* chore(claude): allow claude to edit/write to files without permission by @whutchinson98 in https://github.com/macro-inc/macro/pull/1868
-* feat[mobile]: improve mobile dock by @peterchinman in https://github.com/macro-inc/macro/pull/1863
-* Fix lints by @evanhutnik in https://github.com/macro-inc/macro/pull/1867
-* refactor: use anyhow::bail! by @whutchinson98 in https://github.com/macro-inc/macro/pull/1869
-* feat(email): Enable scheduled send by @evanhutnik in https://github.com/macro-inc/macro/pull/1871
-* chore: bump rust toolchain by @whutchinson98 in https://github.com/macro-inc/macro/pull/1872
-* feat[mobile]: go to location from full text search results by @peterchinman in https://github.com/macro-inc/macro/pull/1870
-* style(new-layout): lots of style nits for new layout by @sedson in https://github.com/macro-inc/macro/pull/1873
-* fix(layout): hide sidebar when not authenticated by @dev-rb in https://github.com/macro-inc/macro/pull/1876
-* fix(icon): update some animated icons by @aidanhb in https://github.com/macro-inc/macro/pull/1875
-* fix[sidebar]: minor tweaks by @peterchinman in https://github.com/macro-inc/macro/pull/1878
-* feat(layout): persist sidebar state in local storage by @dev-rb in https://github.com/macro-inc/macro/pull/1879
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.3.4.0...v2026.3.10.0
-    </Update>
-
-    <Update label="v2026.3.4.0">
-## What's Changed
-* feat(ai): improve tool rendering by @ehayes2000 in https://github.com/macro-inc/macro/pull/1767
-* fix[mobile]: clean settings by @peterchinman in https://github.com/macro-inc/macro/pull/1768
-* feat(entity_access): add in `dangerously_assert_internal_user` by @whutchinson98 in https://github.com/macro-inc/macro/pull/1765
-* chore(email-service): Hexify send message endpoint by @evanhutnik in https://github.com/macro-inc/macro/pull/1766
-* chore(ai): Improve logging in stream + ai crate by @ehayes2000 in https://github.com/macro-inc/macro/pull/1771
-* chore auth service sizing by @whutchinson98 in https://github.com/macro-inc/macro/pull/1772
-* organize github crate by @whutchinson98 in https://github.com/macro-inc/macro/pull/1773
-* fix(list): move list selection on mark done if selection containes emails - regadless of view by @sedson in https://github.com/macro-inc/macro/pull/1774
-* feat(github): add document service to GithubSyncService by @whutchinson98 in https://github.com/macro-inc/macro/pull/1776
-* feat(http): add macro tower layers by @seanaye in https://github.com/macro-inc/macro/pull/1775
-* support commenting on github prs by @whutchinson98 in https://github.com/macro-inc/macro/pull/1777
-* fix(notif): filter invalid notifications instead of failing the whole query by @seanaye in https://github.com/macro-inc/macro/pull/1780
-* fix[mobile]: infinite canvas loading by @peterchinman in https://github.com/macro-inc/macro/pull/1770
-* chore(email-service): Hexify apply thread labels endpoint by @evanhutnik in https://github.com/macro-inc/macro/pull/1779
-* feat(github): sync task status from GitHub by @whutchinson98 in https://github.com/macro-inc/macro/pull/1782
-* Fix: chat names contain raw mention data by @ehayes2000 in https://github.com/macro-inc/macro/pull/1784
-* Fix: Snapshot by @ehayes2000 in https://github.com/macro-inc/macro/pull/1785
-* fix[mobile]: channel message links by @peterchinman in https://github.com/macro-inc/macro/pull/1769
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.3.3.0...v2026.3.4.0
-    </Update>
-
-    <Update label="v2026.3.3.0">
-## What's Changed
-* fix: openai key in infra by @ehayes2000 in https://github.com/macro-inc/macro/pull/1747
-* Add Business Source License 1.1 and update README contributions by @jbecke in https://github.com/macro-inc/macro/pull/1750
-* feat(github): github sync router by @whutchinson98 in https://github.com/macro-inc/macro/pull/1752
-* feat(github): webhook event parsing by @whutchinson98 in https://github.com/macro-inc/macro/pull/1753
-* fix: fusionauth version by @whutchinson98 in https://github.com/macro-inc/macro/pull/1754
-* fix(search): remove tranform using history query by @synoet in https://github.com/macro-inc/macro/pull/1755
-* chore: update jsonwebtoken to custom version to fix gty by @whutchinson98 in https://github.com/macro-inc/macro/pull/1756
-* chore(email-service): Hexify create draft endpoint by @evanhutnik in https://github.com/macro-inc/macro/pull/1757
-* feat(github): add sync_app_pem and sync_app_client_id to GithubConfig by @whutchinson98 in https://github.com/macro-inc/macro/pull/1758
-* feat(notif): render pp in ios notif by @seanaye in https://github.com/macro-inc/macro/pull/1722
-* chore(notif): delete notification service client by @seanaye in https://github.com/macro-inc/macro/pull/1759
-* rename by @ehayes2000 in https://github.com/macro-inc/macro/pull/1751
-* feat(filter): add no_assignee option to task filters by @sedson in https://github.com/macro-inc/macro/pull/1762
-* chore(github): split GitHub services by @whutchinson98 in https://github.com/macro-inc/macro/pull/1763
-* chore(entity): remove email entity type by @seanaye in https://github.com/macro-inc/macro/pull/1760
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.3.2.0...v2026.3.3.0
-    </Update>
-
-    <Update label="v2026.3.2.0">
-## What's Changed
-* tooling(notif): add digest sandbox cli by @seanaye in https://github.com/macro-inc/macro/pull/1686
-* fix: mobile notification navigation by @peterchinman in https://github.com/macro-inc/macro/pull/1708
-* chore: add granular tracing to opensearch response by @gbirman in https://github.com/macro-inc/macro/pull/1707
-* feat(github): get GitHub access token by @whutchinson98 in https://github.com/macro-inc/macro/pull/1701
-* feat(notif): email templating by @seanaye in https://github.com/macro-inc/macro/pull/1687
-* chore(dd): fix line numbers by @seanaye in https://github.com/macro-inc/macro/pull/1711
-* feat: only call refresh once at a time by @whutchinson98 in https://github.com/macro-inc/macro/pull/1710
-* feat: hardcode legacy_user_permissions has_trialed to be true by @whutchinson98 in https://github.com/macro-inc/macro/pull/1709
-* feat(notif): delete invalid notifs when listing by @seanaye in https://github.com/macro-inc/macro/pull/1702
-* feat: has trialed db support by @whutchinson98 in https://github.com/macro-inc/macro/pull/1712
-* fix: button hover styling by @peterchinman in https://github.com/macro-inc/macro/pull/1714
-* feat: ai user mentions by @ehayes2000 in https://github.com/macro-inc/macro/pull/1716
-* chore(log): increase channel logging by @seanaye in https://github.com/macro-inc/macro/pull/1715
-* fix(ai): clear notifications by @ehayes2000 in https://github.com/macro-inc/macro/pull/1718
-* image proxy service by @whutchinson98 in https://github.com/macro-inc/macro/pull/1717
-* fix: front end optimize search response handling by @gbirman in https://github.com/macro-inc/macro/pull/1723
-* fix(notif): update email template by @seanaye in https://github.com/macro-inc/macro/pull/1713
-* move resize observer into list layout provider by @gbirman in https://github.com/macro-inc/macro/pull/1725
-* feat: use image proxy service by @whutchinson98 in https://github.com/macro-inc/macro/pull/1719
-* add /v1/completions proxy by @ehayes2000 in https://github.com/macro-inc/macro/pull/1705
-* feat(image_proxy_service): only proxy image content types by @whutchinson98 in https://github.com/macro-inc/macro/pull/1726
-* fea: add user icon tool tip to email participant in soup by @gbirman in https://github.com/macro-inc/macro/pull/1728
-* feat(image_proxy_service): max content length by @whutchinson98 in https://github.com/macro-inc/macro/pull/1727
-* feat: even more search logging by @gbirman in https://github.com/macro-inc/macro/pull/1732
-* perf(search): reduce backend response payload by @gbirman in https://github.com/macro-inc/macro/pull/1734
-* fix(comms): remove internal adapter by @seanaye in https://github.com/macro-inc/macro/pull/1733
-* feat(notif): send pp url in ios notif payload by @seanaye in https://github.com/macro-inc/macro/pull/1721
-* feat(md): add MarkdownShell and fluent config builder for simple md feature sharing by @sedson in https://github.com/macro-inc/macro/pull/1704
-* chore: log token on jwt decode failure by @whutchinson98 in https://github.com/macro-inc/macro/pull/1735
-* feat: mobile topbar redesign by @peterchinman in https://github.com/macro-inc/macro/pull/1731
-* chg(canvas): use new markdown utils by @sedson in https://github.com/macro-inc/macro/pull/1738
-* fix(ai): Rename variant to expected by @ehayes2000 in https://github.com/macro-inc/macro/pull/1736
-* feat: add Satsuma theme to defaults by @peterchinman in https://github.com/macro-inc/macro/pull/1739
-* chore(email-service): Hexify get-threads endpoint by @evanhutnik in https://github.com/macro-inc/macro/pull/1737
-* Fix remote server by @evanhutnik in https://github.com/macro-inc/macro/pull/1742
-* feat(channels): channel refactor, thread/message rendering (1/n) by @synoet in https://github.com/macro-inc/macro/pull/1677
-* fix: channel drag bug by @peterchinman in https://github.com/macro-inc/macro/pull/1743
-* feat(github): basic webhook event support by @whutchinson98 in https://github.com/macro-inc/macro/pull/1741
-* chore: remove nm artifcat by @synoet in https://github.com/macro-inc/macro/pull/1746
-* fix(emails): email threads reactively showing up in soup by @synoet in https://github.com/macro-inc/macro/pull/1744
-* fix: mark done from inside blocks by @peterchinman in https://github.com/macro-inc/macro/pull/1745
-* feat(tasks): default tasks to "not started" by @sedson in https://github.com/macro-inc/macro/pull/1748
-* fix(soup): wrong notification entity type check by @synoet in https://github.com/macro-inc/macro/pull/1749
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.2.26.0...v2026.3.2.0
-    </Update>
-
-    <Update label="v2026.2.26.0">
-## What's Changed
-* feat(notif): integrate state machine c by @seanaye in https://github.com/macro-inc/macro/pull/1674
-* feat: bring back file type associations by @gbirman in https://github.com/macro-inc/macro/pull/1688
-* fix(mentions): restore chats in mentions search by @sedson in https://github.com/macro-inc/macro/pull/1690
-* fix[dialogs]: portal-scope and clickoutside behavior on dialogs by @peterchinman in https://github.com/macro-inc/macro/pull/1692
-* perf(search): move search provider to use quick access entities since soup is slow by @gbirman in https://github.com/macro-inc/macro/pull/1694
-* feat(github): account link by @whutchinson98 in https://github.com/macro-inc/macro/pull/1689
-* fix(soup): chat owners filter by @seanaye in https://github.com/macro-inc/macro/pull/1695
-* feat(notif): clean up notification trait by @seanaye in https://github.com/macro-inc/macro/pull/1673
-* feat: fresh sort dm boost by @gbirman in https://github.com/macro-inc/macro/pull/1696
-* fix[task-composer]: better handling for task creation failure by @peterchinman in https://github.com/macro-inc/macro/pull/1697
-* feat: include source map in dev by @gbirman in https://github.com/macro-inc/macro/pull/1700
-* feat: add in specific access level for entity_access_receipt by @whutchinson98 in https://github.com/macro-inc/macro/pull/1698
-* chg(queries): require explicit for normy by @synoet in https://github.com/macro-inc/macro/pull/1699
-* fix(soup): email dynamic query safety by @evanhutnik in https://github.com/macro-inc/macro/pull/1703
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.2.25.1...v2026.2.26.0
-    </Update>
-
-    <Update label="v2026.2.25.1">
-## What's Changed
-* fix: DCS update connection gateway table env var + add perms by @gbirman in https://github.com/macro-inc/macro/pull/1685
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.2.25.0...v2026.2.25.1
-    </Update>
-
-    <Update label="v2026.2.25.0">
-## What's Changed
-* feat(soup): use importance for other query filtering by @synoet in https://github.com/macro-inc/macro/pull/1661
-* feat: support email label search by @gbirman in https://github.com/macro-inc/macro/pull/1659
-* chore(deps): bump time from 0.3.46 to 0.3.47 in /rust/sync-service by @dependabot[bot] in https://github.com/macro-inc/macro/pull/1427
-* fix: macro user id logging by @whutchinson98 in https://github.com/macro-inc/macro/pull/1663
-* chore bump auth service size by @whutchinson98 in https://github.com/macro-inc/macro/pull/1664
-* add better logging for failed sns deliveries by @seanaye in https://github.com/macro-inc/macro/pull/1650
-* chg(properties): sort self to top for assignee properties by @sedson in https://github.com/macro-inc/macro/pull/1665
-* chore(channels): add thread replies handler to swagger by @synoet in https://github.com/macro-inc/macro/pull/1666
-* feat(seed): channel message mentions by @whutchinson98 in https://github.com/macro-inc/macro/pull/1662
-* chg(properties): show name | email in user selectors by @sedson in https://github.com/macro-inc/macro/pull/1667
-* chore(email-service): tracing sfs image upload by @evanhutnik in https://github.com/macro-inc/macro/pull/1668
-* rationalize dialogs by @peterchinman in https://github.com/macro-inc/macro/pull/1672
-* fix(soup): all pages refetching on filter change by @dev-rb in https://github.com/macro-inc/macro/pull/1669
-* feat(ai): Notifications by @ehayes2000 in https://github.com/macro-inc/macro/pull/1670
-* chg(channels): change preview ordering for thread replies in a channel by @synoet in https://github.com/macro-inc/macro/pull/1678
-* chore(notifications): notifications filter indexes by @synoet in https://github.com/macro-inc/macro/pull/1675
-* fix: slow email contact search query by @gbirman in https://github.com/macro-inc/macro/pull/1679
-* chore(log): ses logging by @seanaye in https://github.com/macro-inc/macro/pull/1671
-* fix(email): Thread reply compose bug by @evanhutnik in https://github.com/macro-inc/macro/pull/1682
-* feat: search importance filter + make ai search important only by @gbirman in https://github.com/macro-inc/macro/pull/1680
-* fix(soup): hotkeys registered to split aren't disposed when closing soup by @dev-rb in https://github.com/macro-inc/macro/pull/1681
-* fix(soup toolbar): convert vertical scroll to horizontal scroll by @aidanhb in https://github.com/macro-inc/macro/pull/1683
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.2.24.0...v2026.2.25.0
-    </Update>
-
-    <Update label="v2026.2.24.0">
-## What's Changed
-* bump fusionauth by @whutchinson98 in https://github.com/macro-inc/macro/pull/1641
-* infra: sync fusionauth prod instance with pulumi by @whutchinson98 in https://github.com/macro-inc/macro/pull/1643
-* chore: bump jsonwebtoken by @whutchinson98 in https://github.com/macro-inc/macro/pull/1642
-* feat(notif): refactor sns event queue into hex by @seanaye in https://github.com/macro-inc/macro/pull/1611
-* chore(deps): bump time from 0.3.44 to 0.3.47 in /js/app/tauri by @dependabot[bot] in https://github.com/macro-inc/macro/pull/1393
-* fix(command): don't show selection mode if not actively viewing list by @sedson in https://github.com/macro-inc/macro/pull/1644
-* style(md): update actions and emoji menu wrapper styles by @sedson in https://github.com/macro-inc/macro/pull/1645
-* feat(soup): allow dss filtering by notification (done/seen) & task cbm_atm_nc + move inbox filtering to query filters by @synoet in https://github.com/macro-inc/macro/pull/1615
-* fix(entity): fix non-reactive display name usage by @sedson in https://github.com/macro-inc/macro/pull/1648
-* feat: ai tool for creating documents by @whutchinson98 in https://github.com/macro-inc/macro/pull/1649
-* feat(search): make email search response look better by @gbirman in https://github.com/macro-inc/macro/pull/1647
-* feat(ai): chat stream indicator by @ehayes2000 in https://github.com/macro-inc/macro/pull/1640
-* feat: exclude spam from email search by @gbirman in https://github.com/macro-inc/macro/pull/1653
-* fix(focus): fix focus lock interaction with launcher and popover splits by @sedson in https://github.com/macro-inc/macro/pull/1646
-* chg(properties): use chunk buckets for properties, various type cleanups by @sedson in https://github.com/macro-inc/macro/pull/1652
-* fix(properties): stop propagation for edit property click-outside by @sedson in https://github.com/macro-inc/macro/pull/1656
-* chore(search): spam trash email cleanup by @gbirman in https://github.com/macro-inc/macro/pull/1658
-* fix(soup): Proper email querying by @evanhutnik in https://github.com/macro-inc/macro/pull/1654
-* fix(soup): batching of filter setting by @synoet in https://github.com/macro-inc/macro/pull/1660
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.2.23.0...v2026.2.24.0
-    </Update>
-
-    <Update label="v2026.2.23.0">
-## What's Changed
-* seanaye/feat/add digest state machines by @seanaye in https://github.com/macro-inc/macro/pull/1531
-* feat(ai): add ai tools for notifications by @seanaye in https://github.com/macro-inc/macro/pull/1521
-* bump fusionauth to fix ui issue by @whutchinson98 in https://github.com/macro-inc/macro/pull/1600
-* fix(settings): Email enable button when no link by @evanhutnik in https://github.com/macro-inc/macro/pull/1602
-* feat: drawer/modal triggers separated from their mounters by @peterchinman in https://github.com/macro-inc/macro/pull/1596
-* Hutch/improve local setup by @whutchinson98 in https://github.com/macro-inc/macro/pull/1601
-* chore: kill dcs websocket (frontend) by @ehayes2000 in https://github.com/macro-inc/macro/pull/1591
-* refactor(command): refactor command menu to be look nicer, work faster, be simpler, and use quick access by @sedson in https://github.com/macro-inc/macro/pull/1605
-* fix(pdf): move modal wrapper to hotfix pdfs by @sedson in https://github.com/macro-inc/macro/pull/1608
-* feat(channels): birectional cursor for message pagination by @synoet in https://github.com/macro-inc/macro/pull/1603
-* feat: macrodb optimizations by @gbirman in https://github.com/macro-inc/macro/pull/1607
-* chore(dcs): Kill dcs websocket server by @ehayes2000 in https://github.com/macro-inc/macro/pull/1599
-* chore: pulumify macrodb by @whutchinson98 in https://github.com/macro-inc/macro/pull/1613
-* chore(dcs): kill unused endpoints by @ehayes2000 in https://github.com/macro-inc/macro/pull/1604
-* fix(toasts): Overwrite if recent, instead of dismissing by @evanhutnik in https://github.com/macro-inc/macro/pull/1612
-* style(list): move entity action menu to no overlap ai chat bar by @sedson in https://github.com/macro-inc/macro/pull/1614
-* feat(notif): integrate state machine a by @seanaye in https://github.com/macro-inc/macro/pull/1564
-* chore: auto add aws creds to get_environment dev by @whutchinson98 in https://github.com/macro-inc/macro/pull/1619
-* fix(entity): add attached items fallback for empty latest message by @sedson in https://github.com/macro-inc/macro/pull/1617
-* fix(notifs): ignore document_mention type notifs by @sedson in https://github.com/macro-inc/macro/pull/1620
-* feat(soup): Move email to trash by @evanhutnik in https://github.com/macro-inc/macro/pull/1616
-* fix: auth service env var by @whutchinson98 in https://github.com/macro-inc/macro/pull/1621
-* feat: make search context queries static by @gbirman in https://github.com/macro-inc/macro/pull/1622
-* kill-rightbar by @ehayes2000 in https://github.com/macro-inc/macro/pull/1618
-* feat: kill rightbar + cmd-j focus by @ehayes2000 in https://github.com/macro-inc/macro/pull/1623
-* remove ctrl+c stop by @ehayes2000 in https://github.com/macro-inc/macro/pull/1624
-* fix: insert soup optimistic filters (type + id only) by @gbirman in https://github.com/macro-inc/macro/pull/1626
-* fix(channels): make sure load around has previous cursor by @synoet in https://github.com/macro-inc/macro/pull/1627
-* feat(channels): get thread replies api by @synoet in https://github.com/macro-inc/macro/pull/1628
-* fix(email): Always open attachments in split by @evanhutnik in https://github.com/macro-inc/macro/pull/1630
-* fix(mentions-menu): handle lazy memo returns undefined in mentions conroller by @sedson in https://github.com/macro-inc/macro/pull/1631
-* fix(canvas): no save on init by @sedson in https://github.com/macro-inc/macro/pull/1632
-* fix: mentions menu usable on mobile by @peterchinman in https://github.com/macro-inc/macro/pull/1625
-* feat(list): share and copy-link from list by @sedson in https://github.com/macro-inc/macro/pull/1633
-* ci: fail on bootstrap.zip removal by @whutchinson98 in https://github.com/macro-inc/macro/pull/1629
-* fix(blocks): move modal-provider inside of main block div for all blocks by @sedson in https://github.com/macro-inc/macro/pull/1634
-* move create document to documents hex by @whutchinson98 in https://github.com/macro-inc/macro/pull/1609
-* feat(soup): Email invite badge by @evanhutnik in https://github.com/macro-inc/macro/pull/1636
-* fix(menus): state and timeout based fix for menu sequences by @sedson in https://github.com/macro-inc/macro/pull/1635
-* chore: enable macrodb param group by @gbirman in https://github.com/macro-inc/macro/pull/1637
-* feat: a better lightbox by @peterchinman in https://github.com/macro-inc/macro/pull/1638
-* add back lambdas by @whutchinson98 in https://github.com/macro-inc/macro/pull/1639
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.2.19.1...v2026.2.23.0
-    </Update>
-
-    <Update label="v2026.2.19.1">
-## What's Changed
-* Revert "bump jsonwebtoken" by @whutchinson98 in https://github.com/macro-inc/macro/pull/1598
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.2.19.0...v2026.2.19.1
-    </Update>
-
-    <Update label="v2026.2.19.0">
-## What's Changed
-* feat(core): create quick-access context for improving performance of repeated history transformation by @sedson in https://github.com/macro-inc/macro/pull/1560
-* fix: mobile search bar by @gbirman in https://github.com/macro-inc/macro/pull/1570
-* [chore]: bump mobile version by @peterchinman in https://github.com/macro-inc/macro/pull/1571
-* feat(seed): seed cli documents by @whutchinson98 in https://github.com/macro-inc/macro/pull/1561
-* fix: localstack dynamodb tables by @whutchinson98 in https://github.com/macro-inc/macro/pull/1572
-* fix[channel]: highlighting date flags by @peterchinman in https://github.com/macro-inc/macro/pull/1574
-* bump down thread pagination by @whutchinson98 in https://github.com/macro-inc/macro/pull/1575
-* fix(email-service): Bump ram by @evanhutnik in https://github.com/macro-inc/macro/pull/1576
-* fix: no focused entity on touch device by @peterchinman in https://github.com/macro-inc/macro/pull/1577
-* seanaye/feat/email digest ports by @seanaye in https://github.com/macro-inc/macro/pull/1530
-* refactor(search_processing_service): replace email_service_client with direct email_db_client calls by @whutchinson98 in https://github.com/macro-inc/macro/pull/1578
-* feat(email): Undo send functionality by @evanhutnik in https://github.com/macro-inc/macro/pull/1580
-* fix: make channels immediately available for search with delayed queue util by @gbirman in https://github.com/macro-inc/macro/pull/1582
-* fix(local) local s3 by @whutchinson98 in https://github.com/macro-inc/macro/pull/1581
-* improve local docker build times by @whutchinson98 in https://github.com/macro-inc/macro/pull/1583
-* feat: make collapse down smooth by @gbirman in https://github.com/macro-inc/macro/pull/1584
-* chore(sps): Bump resources by @evanhutnik in https://github.com/macro-inc/macro/pull/1586
-* fix: title extract by @gbirman in https://github.com/macro-inc/macro/pull/1585
-* bump jsonwebtoken by @whutchinson98 in https://github.com/macro-inc/macro/pull/1340
-* feat: search loading state by @gbirman in https://github.com/macro-inc/macro/pull/1587
-* fix(infra): resolve OpenSearch CloudWatch log resource policy by @gbirman in https://github.com/macro-inc/macro/pull/1588
-* fix: tab title reactivity by @gbirman in https://github.com/macro-inc/macro/pull/1590
-* feat(channels): load around specific message by @synoet in https://github.com/macro-inc/macro/pull/1589
-* fix: remove mobile dock gradient by @peterchinman in https://github.com/macro-inc/macro/pull/1579
-* fix[tasks]: don't clear task composer if task creation fails by @peterchinman in https://github.com/macro-inc/macro/pull/1594
-* local sync service support by @whutchinson98 in https://github.com/macro-inc/macro/pull/1592
-* style(toasts): re-style toast components and add fading border to indicate toast freshness by @aidanhb in https://github.com/macro-inc/macro/pull/1533
-* feat(seed): Email dev seed support by @evanhutnik in https://github.com/macro-inc/macro/pull/1595
-* fix(soup): part of list goes blank when editing task properties by @dev-rb in https://github.com/macro-inc/macro/pull/1597
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.2.18.0...v2026.2.19.0
-    </Update>
-
-    <Update label="v2026.2.18.0">
-## What's Changed
-* feat: search bar ux/ui improvments by @gbirman in https://github.com/macro-inc/macro/pull/1497
-* fix[channels]: message shift at small widths by @peterchinman in https://github.com/macro-inc/macro/pull/1499
-* feat: add back video file types by @gbirman in https://github.com/macro-inc/macro/pull/1498
-* fix(notif): no pattern matches value undefined by @seanaye in https://github.com/macro-inc/macro/pull/1502
-* feat(channels): hex channels crate with pagination by @synoet in https://github.com/macro-inc/macro/pull/1484
-* feat: backfill video file types script by @gbirman in https://github.com/macro-inc/macro/pull/1503
-* feat(email): Forwarding message attachments by @evanhutnik in https://github.com/macro-inc/macro/pull/1505
-* ci(email): Migration fix by @evanhutnik in https://github.com/macro-inc/macro/pull/1509
-* fix: download name by @gbirman in https://github.com/macro-inc/macro/pull/1504
-* chore: ignore-missing on sqlx migrate for dev by @whutchinson98 in https://github.com/macro-inc/macro/pull/1510
-* feat(documents): hex crate by @whutchinson98 in https://github.com/macro-inc/macro/pull/1488
-* fix(soup): emailView param by @evanhutnik in https://github.com/macro-inc/macro/pull/1513
-* feat: stream crate by @ehayes2000 in https://github.com/macro-inc/macro/pull/1507
-* feat(ai): stream with connection_gateway by @ehayes2000 in https://github.com/macro-inc/macro/pull/1512
-* chg(soup/properties): clean up property handling in soup by @synoet in https://github.com/macro-inc/macro/pull/1511
-* feat: search improvements by @gbirman in https://github.com/macro-inc/macro/pull/1514
-* feat: persist search text by @gbirman in https://github.com/macro-inc/macro/pull/1515
-* fix: search not returning filtered responses by @gbirman in https://github.com/macro-inc/macro/pull/1516
-* fix(channels): reset task mode properties on send by @synoet in https://github.com/macro-inc/macro/pull/1517
-* chg(list): sort notif stacks by time only by @sedson in https://github.com/macro-inc/macro/pull/1518
-* chore: update anthropic key (sops) by @ehayes2000 in https://github.com/macro-inc/macro/pull/1520
-* fix: search merge empty local results by @gbirman in https://github.com/macro-inc/macro/pull/1523
-* chore: create search state separate from soup view context by @gbirman in https://github.com/macro-inc/macro/pull/1525
-* update running locally readme by @whutchinson98 in https://github.com/macro-inc/macro/pull/1528
-* chore: file association helper rename by @gbirman in https://github.com/macro-inc/macro/pull/1526
-* feat(queries): simple undo primitive for queries by @synoet in https://github.com/macro-inc/macro/pull/1301
-* feat(ai): document ai tool by @whutchinson98 in https://github.com/macro-inc/macro/pull/1527
-* queue connection_gateway messages by @ehayes2000 in https://github.com/macro-inc/macro/pull/1534
-* fix(soup): fetching more data stuck in loop by @dev-rb in https://github.com/macro-inc/macro/pull/1536
-* feat(seed) cli seed commands by @whutchinson98 in https://github.com/macro-inc/macro/pull/1538
-* fix(email): Don't add contacts exceeding length of column by @evanhutnik in https://github.com/macro-inc/macro/pull/1539
-* feat: featured results from search by @gbirman in https://github.com/macro-inc/macro/pull/1543
-* feat: collapsible list dyanmic collapse button by @gbirman in https://github.com/macro-inc/macro/pull/1544
-* chore: more results search heading by @gbirman in https://github.com/macro-inc/macro/pull/1545
-* fix: race condition for search node id by @gbirman in https://github.com/macro-inc/macro/pull/1546
-* feat: change clear filter button by @gbirman in https://github.com/macro-inc/macro/pull/1547
-* feat: search bar clear button by @gbirman in https://github.com/macro-inc/macro/pull/1548
-* fix: clear button not visible on hover unfocused state by @gbirman in https://github.com/macro-inc/macro/pull/1549
-* feat: expand and collapse search state by @gbirman in https://github.com/macro-inc/macro/pull/1551
-* chore: enable featured search result in prod by @gbirman in https://github.com/macro-inc/macro/pull/1552
-* bump redis by @seanaye in https://github.com/macro-inc/macro/pull/1537
-* chore: kill flash by @ehayes2000 in https://github.com/macro-inc/macro/pull/1550
-* fix(stream): correct close behavior + remove scan by @ehayes2000 in https://github.com/macro-inc/macro/pull/1542
-* fix(soup): project filter missing from exhaustive match by @dev-rb in https://github.com/macro-inc/macro/pull/1553
-* fix(channels): channel name positioning in top bar by @synoet in https://github.com/macro-inc/macro/pull/1554
-* chore(email): Improve logging in db client by @evanhutnik in https://github.com/macro-inc/macro/pull/1555
-* feat: move to next entity when marked as done by @peterchinman in https://github.com/macro-inc/macro/pull/1557
-* fix[channels]: emoji react menu by @peterchinman in https://github.com/macro-inc/macro/pull/1558
-* feat(soup): dynamic task filters in the top bar for asignee and status by @synoet in https://github.com/macro-inc/macro/pull/1522
-* fix streams with new redis, stream debugger, better queries by @ehayes2000 in https://github.com/macro-inc/macro/pull/1556
-* fix(soup): slow initial load by @dev-rb in https://github.com/macro-inc/macro/pull/1559
-* chore(seed_cli): Email data by @evanhutnik in https://github.com/macro-inc/macro/pull/1540
-* fix: chat suspense by @ehayes2000 in https://github.com/macro-inc/macro/pull/1563
-* seanaye/chore/split and move code by @seanaye in https://github.com/macro-inc/macro/pull/1529
-* fix-message-order by @ehayes2000 in https://github.com/macro-inc/macro/pull/1565
-* feat: compose email on mobile by @peterchinman in https://github.com/macro-inc/macro/pull/1524
-* fix: soup query needs emails + soup optimize by @gbirman in https://github.com/macro-inc/macro/pull/1568
-* fix[channels]: message spacing by @peterchinman in https://github.com/macro-inc/macro/pull/1566
-* fix: make focus first entity reactive by @gbirman in https://github.com/macro-inc/macro/pull/1569
-* fix(entity): add PartialEntity type, fix formatting for title extractor by @sedson in https://github.com/macro-inc/macro/pull/1519
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.2.12.0...v2026.2.18.0
-    </Update>
-
-    <Update label="v2026.2.12.0">
-## What's Changed
-* feat(soup/queries) normalization and generic updates, inserts and removes by @synoet in https://github.com/macro-inc/macro/pull/1450
-* Migrate db automatically on release by @whutchinson98 in https://github.com/macro-inc/macro/pull/1476
-* feat seed cli by @whutchinson98 in https://github.com/macro-inc/macro/pull/1477
-* chg(core): update clipped panel to take div props for inner div by @sedson in https://github.com/macro-inc/macro/pull/1479
-* feat(seed_cli): create channel by @whutchinson98 in https://github.com/macro-inc/macro/pull/1478
-* feat(seed_cli): channel message seed cli by @whutchinson98 in https://github.com/macro-inc/macro/pull/1480
-* feat(soup): add ability to filter soup by email thread ids by @synoet in https://github.com/macro-inc/macro/pull/1482
-* chore: mostly deprecate macro entity package by @gbirman in https://github.com/macro-inc/macro/pull/1485
-* update dd service log config by @whutchinson98 in https://github.com/macro-inc/macro/pull/1486
-* schema dump skill by @whutchinson98 in https://github.com/macro-inc/macro/pull/1487
-* fix(email): Attachment sharing by @evanhutnik in https://github.com/macro-inc/macro/pull/1489
-* feat: standardize date serialization and internal usage by @gbirman in https://github.com/macro-inc/macro/pull/1449
-* style(email): Bold top bar, remove trailing commas from names by @evanhutnik in https://github.com/macro-inc/macro/pull/1490
-* fix: channel thread/message mention hover text by @gbirman in https://github.com/macro-inc/macro/pull/1491
-* fix: remove empty terms enable search query by @gbirman in https://github.com/macro-inc/macro/pull/1493
-* feat(soup): add channel_type filters for channels in soup by @synoet in https://github.com/macro-inc/macro/pull/1492
-* fix(soup): query filters not saved and restored, notifications opening in new split by @dev-rb in https://github.com/macro-inc/macro/pull/1494
-* fix(soup): suspense and clear search text by @dev-rb in https://github.com/macro-inc/macro/pull/1495
-* feat(soup): use backend soup filtering for people / teams by @synoet in https://github.com/macro-inc/macro/pull/1496
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.2.11.0...v2026.2.12.0
-    </Update>
-
-    <Update label="v2026.2.11.0">
-## What's Changed
-* feat: ai consent flow by @peterchinman in https://github.com/macro-inc/macro/pull/1459
-* fix(channel): retsore (accidentally) deleted channel image attachments [bbb896f] by @sedson in https://github.com/macro-inc/macro/pull/1461
-* fix: unrolled list notifications opening in new split on mobile by @dev-rb in https://github.com/macro-inc/macro/pull/1462
-* style(email): Normalize font and spacing, remove text background by @evanhutnik in https://github.com/macro-inc/macro/pull/1465
-* fix(preview): fix no icon wrapper width by @sedson in https://github.com/macro-inc/macro/pull/1463
-* fix(ai): context  by @ehayes2000 in https://github.com/macro-inc/macro/pull/1466
-* refactor(soup): refactor query filter setting by @dev-rb in https://github.com/macro-inc/macro/pull/1464
-* fix(sharing): hide access level select for email sharing by @dev-rb in https://github.com/macro-inc/macro/pull/1142
-* style(list): small fixes for text truncation by @sedson in https://github.com/macro-inc/macro/pull/1469
-* fix(channels): lazy action menu blessing by @synoet in https://github.com/macro-inc/macro/pull/1470
-* [channels]: improve rail styling by @peterchinman in https://github.com/macro-inc/macro/pull/1473
-* fix(channel): list not scrolling to target by @dev-rb in https://github.com/macro-inc/macro/pull/1472
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.2.10.0...v2026.2.11.0
-    </Update>
-
-    <Update label="v2026.2.10.0">
-## What's Changed
-* fix(email): Escape escapes email block by @evanhutnik in https://github.com/macro-inc/macro/pull/1398
-* refactor(entity): create composable ui components for entities by @sedson in https://github.com/macro-inc/macro/pull/1368
-* seanaye/fix/ios payload uuid by @seanaye in https://github.com/macro-inc/macro/pull/1400
-* disable auto attach in soup by @ehayes2000 in https://github.com/macro-inc/macro/pull/1401
-* refactor(soup): refactor soup and unified list implementation [stack/01] by @dev-rb in https://github.com/macro-inc/macro/pull/1248
-* fix: replace dss query keys  by @dev-rb in https://github.com/macro-inc/macro/pull/1403
-* chore: conditionally register generate plugin behind feature flag by @gbirman in https://github.com/macro-inc/macro/pull/1405
-* Improve upload claim query performance by @evanhutnik in https://github.com/macro-inc/macro/pull/1406
-* Revert "local fusionauth" by @whutchinson98 in https://github.com/macro-inc/macro/pull/1411
-* fix[channels]: Jump to Latest behavior by @peterchinman in https://github.com/macro-inc/macro/pull/1414
-* fix(md): fix space on empty line – add conversionOnly flag to appropriate markdown transformers by @sedson in https://github.com/macro-inc/macro/pull/1408
-* fix: settings state for mobile by @peterchinman in https://github.com/macro-inc/macro/pull/1410
-* fix(soup): add scroll and state restoration by @dev-rb in https://github.com/macro-inc/macro/pull/1415
-* fix(soup): emailViews and importance by @evanhutnik in https://github.com/macro-inc/macro/pull/1419
-* feat: optimize names search by @gbirman in https://github.com/macro-inc/macro/pull/1412
-* chore(channels): remove dependency on block signals in channel by @synoet in https://github.com/macro-inc/macro/pull/1418
-* Evan/anchor fr by @evanhutnik in https://github.com/macro-inc/macro/pull/1413
-* Revert "fix(soup): emailViews and importance (#1419)" by @evanhutnik in https://github.com/macro-inc/macro/pull/1424
-* fix(lexical-core): make unknown-mention regex specific to \<m-tags> not just \<tags> by @sedson in https://github.com/macro-inc/macro/pull/1426
-* fix(soup): performance regression when selecting in preview mode by @dev-rb in https://github.com/macro-inc/macro/pull/1420
-* feat(soup): add offset to navigation scroll to show more entities by @dev-rb in https://github.com/macro-inc/macro/pull/1421
-* feat(ai): auto attach previews by @ehayes2000 in https://github.com/macro-inc/macro/pull/1402
-* fix: open in same or new split behavior by @dev-rb in https://github.com/macro-inc/macro/pull/1416
-* chore(ai): opus-4.5 -> opus-4.6 by @ehayes2000 in https://github.com/macro-inc/macro/pull/1404
-* fix(md): fix node accessory position for deeply nested node accessories by @sedson in https://github.com/macro-inc/macro/pull/1428
-* feat: enable opensearch slow logging by @gbirman in https://github.com/macro-inc/macro/pull/1423
-* fix(hotkey): new split hotkey not working by @dev-rb in https://github.com/macro-inc/macro/pull/1429
-* fix(core): remove ugly corder on document preview by @sedson in https://github.com/macro-inc/macro/pull/1430
-* feat(queries): per query persister by @synoet in https://github.com/macro-inc/macro/pull/1407
-* feat(list): use new entity components in new list view by @sedson in https://github.com/macro-inc/macro/pull/1422
-* feat(dss): generic entity permissions endpoint + utils by @synoet in https://github.com/macro-inc/macro/pull/1417
-* remove dead code by @seanaye in https://github.com/macro-inc/macro/pull/1388
-* fix(email): Selectable recipients, expand direction by @evanhutnik in https://github.com/macro-inc/macro/pull/1431
-* fix(md): fix enter transform condition with codebox + linebreak by @sedson in https://github.com/macro-inc/macro/pull/1432
-* style(list): remove checkbox transition by @sedson in https://github.com/macro-inc/macro/pull/1433
-* chg(list): swap mouse-enter for mouse-move on list entity by @sedson in https://github.com/macro-inc/macro/pull/1434
-* fix(soup): various bugs by @dev-rb in https://github.com/macro-inc/macro/pull/1435
-* local fusionauth by @whutchinson98 in https://github.com/macro-inc/macro/pull/1436
-* feat(md): add inline media upload to lexical actions by @sedson in https://github.com/macro-inc/macro/pull/1438
-* chore(ai): replace hooks with context by @ehayes2000 in https://github.com/macro-inc/macro/pull/1437
-* fix: chat attachment mentions losing focus by @gbirman in https://github.com/macro-inc/macro/pull/1440
-* feat(icons) - add animating versions of icons in Launcher and Soup filters by @aidanhb in https://github.com/macro-inc/macro/pull/1229
-* fix: task type chat attachment + use item preview directly in chat attachment by @gbirman in https://github.com/macro-inc/macro/pull/1443
-* move fusionauth into it's own create by @whutchinson98 in https://github.com/macro-inc/macro/pull/1444
-* fix local logging by @whutchinson98 in https://github.com/macro-inc/macro/pull/1442
-* fix(md): fix image copy caused by unchecked nulls by @sedson in https://github.com/macro-inc/macro/pull/1446
-* fix(email): Populate null contact names by @evanhutnik in https://github.com/macro-inc/macro/pull/1447
-* fix(soup): navigation, signal filters, and performance improvements by @dev-rb in https://github.com/macro-inc/macro/pull/1439
-* Revert "Evan/anchor fr (#1413)" by @evanhutnik in https://github.com/macro-inc/macro/pull/1448
-* feat(icons): Add animated icons for signal and noise filters by @aidanhb in https://github.com/macro-inc/macro/pull/1445
-* feat(notif): email notification decision tree by @seanaye in https://github.com/macro-inc/macro/pull/1451
-* style(chat/channel): unifiy/cleanup attachment styling by @sedson in https://github.com/macro-inc/macro/pull/1454
-* feat[mobile]: use tauri auth plugin by @peterchinman in https://github.com/macro-inc/macro/pull/1452
-* fix[mobile]: allow camera access by @peterchinman in https://github.com/macro-inc/macro/pull/1456
-* style(email): Better background and theme handling by @evanhutnik in https://github.com/macro-inc/macro/pull/1455
-* fix(soup): fix rename not updating soup and filters not restoring on navigate by @dev-rb in https://github.com/macro-inc/macro/pull/1458
-* fix(ws): prevent duplicate connection listeners by @synoet in https://github.com/macro-inc/macro/pull/1453
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.2.6.0...v2026.2.10.0
-    </Update>
-
-    <Update label="v2026.2.6.0">
-## What's Changed
-* fix(md): fix reactive rename on empty md title by @sedson in https://github.com/macro-inc/macro/pull/1344
-* add tauri localhost to cors by @peterchinman in https://github.com/macro-inc/macro/pull/1343
-* feat: otel datadog setup by @whutchinson98 in https://github.com/macro-inc/macro/pull/1323
-* remove un-needed instrument by @whutchinson98 in https://github.com/macro-inc/macro/pull/1347
-* chore(soup/email): Remove metadata field from email threads by @evanhutnik in https://github.com/macro-inc/macro/pull/1345
-* fix(email): Don't create user_history row for auto-inserted attachments by @evanhutnik in https://github.com/macro-inc/macro/pull/1346
-* chore: tracing level on macro_env_var by @whutchinson98 in https://github.com/macro-inc/macro/pull/1348
-* chore: update fe history type by @gbirman in https://github.com/macro-inc/macro/pull/1349
-* fix(email-service): Attachment upload race condition by @evanhutnik in https://github.com/macro-inc/macro/pull/1350
-* chore(email): Instrument calls by @evanhutnik in https://github.com/macro-inc/macro/pull/1352
-* automatic db migration for dev by @whutchinson98 in https://github.com/macro-inc/macro/pull/1357
-* do not log db url from just command by @whutchinson98 in https://github.com/macro-inc/macro/pull/1359
-* migrate db fixes by @whutchinson98 in https://github.com/macro-inc/macro/pull/1360
-* feat: clean up history work being done on front end by @gbirman in https://github.com/macro-inc/macro/pull/1355
-* fix: migrator ci add rustls by @whutchinson98 in https://github.com/macro-inc/macro/pull/1361
-* remove frecency poller log by @seanaye in https://github.com/macro-inc/macro/pull/1277
-* Stack/01 service migrations by @seanaye in https://github.com/macro-inc/macro/pull/1331
-* chore(dss): Reduce max pods, increase sql connection count by @evanhutnik in https://github.com/macro-inc/macro/pull/1363
-* fix(soup): Improve query performance by @evanhutnik in https://github.com/macro-inc/macro/pull/1362
-* feat(channels): infinite stale time, on mount hydration by @synoet in https://github.com/macro-inc/macro/pull/1364
-* chore: remove un-needed updateCookie from Login.tsx by @whutchinson98 in https://github.com/macro-inc/macro/pull/1354
-* seanaye/chore/ios sound and logging by @seanaye in https://github.com/macro-inc/macro/pull/1365
-* fix(soup): Improve dynamic query performance by @evanhutnik in https://github.com/macro-inc/macro/pull/1366
-* fix(channel): channel scrolling down after jumping to a message by @dev-rb in https://github.com/macro-inc/macro/pull/1367
-* seanaye/fix/conn gateway payload by @seanaye in https://github.com/macro-inc/macro/pull/1369
-* fix notif crash by @seanaye in https://github.com/macro-inc/macro/pull/1371
-* fix[mobile]: mobile typing issues in the Markdown editor by @peterchinman in https://github.com/macro-inc/macro/pull/1370
-* fix: new soup item on create by @gbirman in https://github.com/macro-inc/macro/pull/1372
-* fix[mobile]: invalidate notifications query by @peterchinman in https://github.com/macro-inc/macro/pull/1373
-* fix(ios) deliver all endpoints by @seanaye in https://github.com/macro-inc/macro/pull/1374
-* fix(channels): reactive message context by @synoet in https://github.com/macro-inc/macro/pull/1376
-* fix(notifications): fix preview access by @synoet in https://github.com/macro-inc/macro/pull/1377
-* fix(email): Draft scroll bug by @evanhutnik in https://github.com/macro-inc/macro/pull/1378
-* local fusionauth by @whutchinson98 in https://github.com/macro-inc/macro/pull/1379
-* fix: preview rename non existent query by @gbirman in https://github.com/macro-inc/macro/pull/1375
-* update dss logging to hook up with traces by @whutchinson98 in https://github.com/macro-inc/macro/pull/1381
-* fix(email): Date display and collapsing last message by @evanhutnik in https://github.com/macro-inc/macro/pull/1380
-* fix: dd logging by @whutchinson98 in https://github.com/macro-inc/macro/pull/1383
-* fix: do not attempt to register user in passwordless flow by @whutchinson98 in https://github.com/macro-inc/macro/pull/1382
-* chore: clean up icon code by @gbirman in https://github.com/macro-inc/macro/pull/1384
-* style(email): Compose box anchored to bottom when empty by @evanhutnik in https://github.com/macro-inc/macro/pull/1389
-* feat: don't update viewed at optimistically for preview blocks by @gbirman in https://github.com/macro-inc/macro/pull/1390
-* fix: focus split on preview entity click by @peterchinman in https://github.com/macro-inc/macro/pull/1391
-* tracing otel link by @whutchinson98 in https://github.com/macro-inc/macro/pull/1387
-* feat: search tracing by @gbirman in https://github.com/macro-inc/macro/pull/1386
-* fix(channel): no more suspending! by @synoet in https://github.com/macro-inc/macro/pull/1394
-* fix: item rename preview + add featuer flag auto tab attachments by @gbirman in https://github.com/macro-inc/macro/pull/1395
-* Revert "style(email): Compose box anchored to bottom when empty (#1389)" by @evanhutnik in https://github.com/macro-inc/macro/pull/1396
-* chore: remove space hint in md  by @gbirman in https://github.com/macro-inc/macro/pull/1397
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.2.4.2...v2026.2.6.0
-    </Update>
-
-    <Update label="v2026.2.4.2">
-## What's Changed
-* feat: renaming refactor, make optimistic, fixes and improvements by @gbirman in https://github.com/macro-inc/macro/pull/1311
-* fix: selected entity signal performance enhancements by @peterchinman in https://github.com/macro-inc/macro/pull/1329
-* feat(md): add unknown md-parser for hiding nasty json when new nodes by @sedson in https://github.com/macro-inc/macro/pull/1327
-* fix(email): Show attachments of sent message during undo window by @evanhutnik in https://github.com/macro-inc/macro/pull/1328
-* chore: deprecate channels entity query by @gbirman in https://github.com/macro-inc/macro/pull/1333
-* feat: delete account button by @peterchinman in https://github.com/macro-inc/macro/pull/1330
-* optimistic update item viewed at on open by @gbirman in https://github.com/macro-inc/macro/pull/1338
-* local sfs by @whutchinson98 in https://github.com/macro-inc/macro/pull/1339
-* fix[mobile]: md touch handling improvements by @peterchinman in https://github.com/macro-inc/macro/pull/1342
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.2.4.1...v2026.2.4.2
-    </Update>
-
-    <Update label="v2026.2.4.1">
-## What's Changed
-* debump jsonwebtoken by @whutchinson98 in https://github.com/macro-inc/macro/pull/1325
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.2.4.0...v2026.2.4.1
-    </Update>
-
-    <Update label="v2026.2.4.0">
-## What's Changed
-* fix: ensure fresh search gets timestamps by @gbirman in https://github.com/macro-inc/macro/pull/1310
-* bump dss cpu and db pool configuration by @whutchinson98 in https://github.com/macro-inc/macro/pull/1312
-* remove search and comms service infra by @whutchinson98 in https://github.com/macro-inc/macro/pull/1313
-* chore(deps): bump bytes from 1.11.0 to 1.11.1 in /rust/sync-service by @dependabot[bot] in https://github.com/macro-inc/macro/pull/1296
-* chore: remove api version from service calls by @whutchinson98 in https://github.com/macro-inc/macro/pull/1315
-* chore: remove br compression. gzip only by @whutchinson98 in https://github.com/macro-inc/macro/pull/1314
-* fix(md): bump lexical version, add agents.md note by @sedson in https://github.com/macro-inc/macro/pull/1317
-* feat(email): schedule sending emails by @dev-rb in https://github.com/macro-inc/macro/pull/1119
-* feat(soup): Importance filter by @evanhutnik in https://github.com/macro-inc/macro/pull/1316
-* fix(persistence): improve indexdb persistence perf by @synoet in https://github.com/macro-inc/macro/pull/1318
-* fix(core): service client urls by @synoet in https://github.com/macro-inc/macro/pull/1322
-* fix(hotkeys): leaking scoped commands by @synoet in https://github.com/macro-inc/macro/pull/1320
-* remove brotli by @whutchinson98 in https://github.com/macro-inc/macro/pull/1321
-* chore(deps): bump bytes from 1.11.0 to 1.11.1 in /js/app/tauri by @dependabot[bot] in https://github.com/macro-inc/macro/pull/1295
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.2.3.1...v2026.2.4.0
-    </Update>
-
-    <Update label="v2026.2.3.1">
-## What's Changed
-* fix: theme mentions by @peterchinman in https://github.com/macro-inc/macro/pull/1307
-* fix(channels): missing nonce for attachments by @synoet in https://github.com/macro-inc/macro/pull/1308
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.2.3.0...v2026.2.3.1
-    </Update>
-
-    <Update label="v2026.2.3.0">
-## What's Changed
-* remove dss from comms by @whutchinson98 in https://github.com/macro-inc/macro/pull/1247
-* chore: remove properties infra by @whutchinson98 in https://github.com/macro-inc/macro/pull/1253
-* chore remove comms service client by @whutchinson98 in https://github.com/macro-inc/macro/pull/1254
-* claude tracing nit by @whutchinson98 in https://github.com/macro-inc/macro/pull/1256
-* fail to send logging by @ehayes2000 in https://github.com/macro-inc/macro/pull/1255
-* fix(ai): include properties in snapshot by @ehayes2000 in https://github.com/macro-inc/macro/pull/1257
-* refactor: move search to dss by @whutchinson98 in https://github.com/macro-inc/macro/pull/1258
-* style(email): Message dark/light mode handling by @evanhutnik in https://github.com/macro-inc/macro/pull/1259
-* feat(channels): optimistic channels + part one deblockification by @synoet in https://github.com/macro-inc/macro/pull/1243
-* fix[iOS]: app crash on open by @peterchinman in https://github.com/macro-inc/macro/pull/1260
-* refactor remove redis cluster by @whutchinson98 in https://github.com/macro-inc/macro/pull/1263
-* remove redis cluster by @whutchinson98 in https://github.com/macro-inc/macro/pull/1264
-* rotate jwt secret key by @whutchinson98 in https://github.com/macro-inc/macro/pull/1265
-* fix(ai): auth disconnect by @ehayes2000 in https://github.com/macro-inc/macro/pull/1266
-* chore(s3): Add bucket deletion policies by @evanhutnik in https://github.com/macro-inc/macro/pull/1267
-* style(email): Don't anchor subject on mobile by @evanhutnik in https://github.com/macro-inc/macro/pull/1269
-* fix(email-service): Inbox thread filtering by @evanhutnik in https://github.com/macro-inc/macro/pull/1270
-* fix: prevent duplicate stripe subscriptions by @whutchinson98 in https://github.com/macro-inc/macro/pull/1268
-* upgrade redis 0.29 -> 1.03 by @ehayes2000 in https://github.com/macro-inc/macro/pull/1271
-* chore: bump esbuild for security by @whutchinson98 in https://github.com/macro-inc/macro/pull/1272
-* Enhance Cmd+Escape hotkey to navigate home when not in split by @jbecke in https://github.com/macro-inc/macro/pull/1261
-* chore: bump cargo dependencies by @whutchinson98 in https://github.com/macro-inc/macro/pull/1273
-* chore(fe): Remove organizations code by @evanhutnik in https://github.com/macro-inc/macro/pull/1262
-* fix: add missing perms to doc-storage bucket by @whutchinson98 in https://github.com/macro-inc/macro/pull/1276
-* feat: channel message/thread mention preview by @gbirman in https://github.com/macro-inc/macro/pull/1156
-* fix: Rightbar focus issues by @peterchinman in https://github.com/macro-inc/macro/pull/1281
-* fix: update item preview component to use hover card core by @gbirman in https://github.com/macro-inc/macro/pull/1282
-* fix(email): Scrolling issue by @evanhutnik in https://github.com/macro-inc/macro/pull/1280
-* local dynamodb tables by @whutchinson98 in https://github.com/macro-inc/macro/pull/1278
-* update tests to use macro_db_migrator by @whutchinson98 in https://github.com/macro-inc/macro/pull/1274
-* move comms into dss by @whutchinson98 in https://github.com/macro-inc/macro/pull/1279
-* fix(search): Don't populate spam/trash email messages by @evanhutnik in https://github.com/macro-inc/macro/pull/1285
-* bump log level by @whutchinson98 in https://github.com/macro-inc/macro/pull/1286
-* fix: force mount hover card open by @gbirman in https://github.com/macro-inc/macro/pull/1287
-* feat(channels): simplify channels, fix mid-list insert virtualization problems by @synoet in https://github.com/macro-inc/macro/pull/1284
-* Revert "upgrade redis 0.29 -> 1.03" by @whutchinson98 in https://github.com/macro-inc/macro/pull/1288
-* local buckets by @whutchinson98 in https://github.com/macro-inc/macro/pull/1289
-* fix(md): fix media node rescale save effect by @sedson in https://github.com/macro-inc/macro/pull/1290
-* fix: thread scrolling behavior by @synoet in https://github.com/macro-inc/macro/pull/1293
-* fix(auth): remove invalidation in logout causing race condition by @synoet in https://github.com/macro-inc/macro/pull/1297
-* fix: mobile login flow by @peterchinman in https://github.com/macro-inc/macro/pull/1294
-* fix: theme sharing by @peterchinman in https://github.com/macro-inc/macro/pull/1300
-* feat(ai): top bar share menu by @ehayes2000 in https://github.com/macro-inc/macro/pull/1275
-* fix(core): fix non-reactive tab title on list and channel, fix channel rename by @sedson in https://github.com/macro-inc/macro/pull/1299
-* fix(channels): fix optimistically insert attachments by @synoet in https://github.com/macro-inc/macro/pull/1302
-* chg(channels): remove pending send now that optimistic by @synoet in https://github.com/macro-inc/macro/pull/1304
-* swagger command by @whutchinson98 in https://github.com/macro-inc/macro/pull/1305
-* feat: theme mentions by @peterchinman in https://github.com/macro-inc/macro/pull/1303
-* fix: shared documents get added to history on open by @gbirman in https://github.com/macro-inc/macro/pull/1306
-* Replace AST cursor in soup by @seanaye in https://github.com/macro-inc/macro/pull/1292
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.1.29.0...v2026.2.3.0
-    </Update>
-
-    <Update label="v2026.1.29.0">
-## What's Changed
-* fix(md): wrap document card in suspense for queries by @sedson in https://github.com/macro-inc/macro/pull/1235
-* feat: standardize aws_config usage by @whutchinson98 in https://github.com/macro-inc/macro/pull/1234
-* remove org service infra by @whutchinson98 in https://github.com/macro-inc/macro/pull/1237
-* revert: email thread whitelist by @evanhutnik in https://github.com/macro-inc/macro/pull/1239
-* refactor: move properties endpoints into dss by @whutchinson98 in https://github.com/macro-inc/macro/pull/1238
-* remove lingering properties service references by @whutchinson98 in https://github.com/macro-inc/macro/pull/1240
-* update flake and cargo lock by @seanaye in https://github.com/macro-inc/macro/pull/1236
-* fix(ai): soup input the semi-final-fixening by @ehayes2000 in https://github.com/macro-inc/macro/pull/1241
-* seanaye/remove/unused notification code by @seanaye in https://github.com/macro-inc/macro/pull/1242
-* fix(email-service): Always call /seen endpoint when opening thread by @evanhutnik in https://github.com/macro-inc/macro/pull/1249
-* fix[mobile]: blank screen of death on app re-open by @peterchinman in https://github.com/macro-inc/macro/pull/1245
-* fix(sfs): Dynamo permissions by @evanhutnik in https://github.com/macro-inc/macro/pull/1251
-* fix(block-names): add fallback to block-metadata for reactive names by @sedson in https://github.com/macro-inc/macro/pull/1250
-* style(email): Thread view updates by @evanhutnik in https://github.com/macro-inc/macro/pull/1246
-* fix: improve md breakpoint by @peterchinman in https://github.com/macro-inc/macro/pull/1252
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.1.28.0...v2026.1.29.0
-    </Update>
-
-    <Update label="v2026.1.28.0">
-## What's Changed
-* refactor(email-service): ID creation and gmail-to-service struct conv… by @evanhutnik in https://github.com/macro-inc/macro/pull/1197
-* chore: remove unused dbs by @whutchinson98 in https://github.com/macro-inc/macro/pull/1220
-* fix(email-service): FE types by @evanhutnik in https://github.com/macro-inc/macro/pull/1222
-* fix(ai): multi line input by @ehayes2000 in https://github.com/macro-inc/macro/pull/1218
-* chore remove experiment service by @whutchinson98 in https://github.com/macro-inc/macro/pull/1221
-* style(email): Constrain inline image, shrink attached images by @evanhutnik in https://github.com/macro-inc/macro/pull/1214
-* fix bun gen-api on nixos by @seanaye in https://github.com/macro-inc/macro/pull/1223
-* refactor notifications by @seanaye in https://github.com/macro-inc/macro/pull/1215
-* chore: remove organization service by @whutchinson98 in https://github.com/macro-inc/macro/pull/1224
-* feat: dockerize sync service by @whutchinson98 in https://github.com/macro-inc/macro/pull/1210
-* fix(contacts): contact syncing for both recipients and sender + frontend invalidations through cgw by @synoet in https://github.com/macro-inc/macro/pull/1216
-* fix(ai): hotkeys by @ehayes2000 in https://github.com/macro-inc/macro/pull/1225
-* fix persist local volumes by @whutchinson98 in https://github.com/macro-inc/macro/pull/1226
-* fix(email): Refreshing thread rendering by @evanhutnik in https://github.com/macro-inc/macro/pull/1227
-* style(document card): tighten up styling on document card by @aidanhb in https://github.com/macro-inc/macro/pull/1206
-* feat(ai): soup replace list tool with soup tool by @ehayes2000 in https://github.com/macro-inc/macro/pull/1213
-* fix(favicon): sync favicon across tabs by @aidanhb in https://github.com/macro-inc/macro/pull/1205
-* Improve notif repo queries by @seanaye in https://github.com/macro-inc/macro/pull/1228
-* feat(unified-list): Whitelisted email domains for Inbox view by @evanhutnik in https://github.com/macro-inc/macro/pull/1231
-* chore(core): move comments out of collab folder by @synoet in https://github.com/macro-inc/macro/pull/1232
-* chg: flag off ai chat inbox in soup for the 55th time by @synoet in https://github.com/macro-inc/macro/pull/1233
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.1.27.0...v2026.1.28.0
-    </Update>
-
-    <Update label="v2026.1.27.0">
-## What's Changed
-* feat(ai): fold node by @ehayes2000 in https://github.com/macro-inc/macro/pull/1172
-* local running by @whutchinson98 in https://github.com/macro-inc/macro/pull/1174
-* style(links): update link preview styling by @aidanhb in https://github.com/macro-inc/macro/pull/1158
-* update cloudfront pem by @whutchinson98 in https://github.com/macro-inc/macro/pull/1195
-* fix(ai): table rendering by @ehayes2000 in https://github.com/macro-inc/macro/pull/1196
-* fix(md): make unfurl link data in floating menu reactive by @aidanhb in https://github.com/macro-inc/macro/pull/1159
-* chore(ai): flag on snapshot by @ehayes2000 in https://github.com/macro-inc/macro/pull/1198
-* fix(block): remove memos from reactive document name hooks by @sedson in https://github.com/macro-inc/macro/pull/1201
-* fix(dss|properties): inconsistent deleted at by @whutchinson98 in https://github.com/macro-inc/macro/pull/1202
-* chore: dockerize lexical service by @whutchinson98 in https://github.com/macro-inc/macro/pull/1204
-* style(item preview): change styling on chat attachment items by @aidanhb in https://github.com/macro-inc/macro/pull/1203
-* chore: gen by @whutchinson98 in https://github.com/macro-inc/macro/pull/1207
-* fix(recip-selector): fix incorrect logic for merging freshsort and kobalte fuzzy by @sedson in https://github.com/macro-inc/macro/pull/1208
-* feat(ai): redesign input + flag on soup ai by @ehayes2000 in https://github.com/macro-inc/macro/pull/1211
-* fix(permissions): fix public link sharing of docs by @synoet in https://github.com/macro-inc/macro/pull/1200
-* fix(ai): instructionsMd eager fetch blocking render by @synoet in https://github.com/macro-inc/macro/pull/1212
-* style(email): Thread subject line by @evanhutnik in https://github.com/macro-inc/macro/pull/1209
-* feat: make unrolled notifications good by @peterchinman in https://github.com/macro-inc/macro/pull/1177
-* fix: image upload on mobile by @peterchinman in https://github.com/macro-inc/macro/pull/1217
-* chg: flag off chat input box in soup by @synoet in https://github.com/macro-inc/macro/pull/1219
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.1.26.0...v2026.1.27.0
-    </Update>
-
-    <Update label="v2026.1.26.0">
-## What's Changed
-* Message hover date display by @peterchinman in https://github.com/macro-inc/macro/pull/1106
-* chore(email-service): Tracing::instrument improvements by @evanhutnik in https://github.com/macro-inc/macro/pull/1126
-* chore(email-service): Delete the enable sync endpoint by @evanhutnik in https://github.com/macro-inc/macro/pull/1122
-* feat(email-service): Fetch thread message data in single queries by @evanhutnik in https://github.com/macro-inc/macro/pull/1124
-* chore(deps-dev): bump wrangler and @cloudflare/vitest-pool-workers in /rust/sync-service by @dependabot[bot] in https://github.com/macro-inc/macro/pull/1127
-* chore(email-service): Remove email_attachments_macro table by @evanhutnik in https://github.com/macro-inc/macro/pull/1128
-* fix(ai): dnd to chat by @ehayes2000 in https://github.com/macro-inc/macro/pull/1125
-* chore(ai): Require code execution for math calculations by @ehayes2000 in https://github.com/macro-inc/macro/pull/1116
-* feat: initial local environment support by @whutchinson98 in https://github.com/macro-inc/macro/pull/1131
-* fix: add in missing env var by @whutchinson98 in https://github.com/macro-inc/macro/pull/1132
-* fix: stripe premium price id secret string by @whutchinson98 in https://github.com/macro-inc/macro/pull/1133
-* chore: remove authentication_service_client from comms_service by @whutchinson98 in https://github.com/macro-inc/macro/pull/1135
-* fix(logging): log lexical responses by @ehayes2000 in https://github.com/macro-inc/macro/pull/1136
-* feat(user): add same domain and dm recency boost to user search fields by @sedson in https://github.com/macro-inc/macro/pull/1134
-* fix(md): fix corner nit on document preview by @sedson in https://github.com/macro-inc/macro/pull/1141
-* feat(comms): add in pg outbound port for user repo by @whutchinson98 in https://github.com/macro-inc/macro/pull/1139
-* fix: handle ip context automatically for local environment by @whutchinson98 in https://github.com/macro-inc/macro/pull/1143
-* chg(list): enable optimistic updating on all view by @synoet in https://github.com/macro-inc/macro/pull/1144
-* feat: local cookies by @whutchinson98 in https://github.com/macro-inc/macro/pull/1145
-* chore: update local service ports to match docker compose by @whutchinson98 in https://github.com/macro-inc/macro/pull/1148
-* approval by @whutchinson98 in https://github.com/macro-inc/macro/pull/1151
-* feat(tasks): update front end signal filter with task logic by @sedson in https://github.com/macro-inc/macro/pull/1138
-* basic sops file for local running against dev assets by @whutchinson98 in https://github.com/macro-inc/macro/pull/1154
-* fix: include latest 150 channel messages in AI context instead of oldest by @ehayes2000 in https://github.com/macro-inc/macro/pull/1157
-* feat(email-service): Binaries for cleaning up unused sfs images by @evanhutnik in https://github.com/macro-inc/macro/pull/1146
-* fix: focus loss due to settings panel by @peterchinman in https://github.com/macro-inc/macro/pull/1150
-* fix: include inter italic by @peterchinman in https://github.com/macro-inc/macro/pull/1161
-* feat: use item preview tanstack by @gbirman in https://github.com/macro-inc/macro/pull/1162
-* feat: update previews on rename by @gbirman in https://github.com/macro-inc/macro/pull/1164
-* fix: prefetch query so cache gets updated when the channel name is needed by @gbirman in https://github.com/macro-inc/macro/pull/1165
-* chore: remove auto approve by @whutchinson98 in https://github.com/macro-inc/macro/pull/1173
-* chore(email-service): Better logging for link manager by @evanhutnik in https://github.com/macro-inc/macro/pull/1169
-* lock all cli by @whutchinson98 in https://github.com/macro-inc/macro/pull/1175
-* feat(channels): upgrade stand-alone-mentions to document cards in channels by @sedson in https://github.com/macro-inc/macro/pull/1163
-* feat(ai): persist code execution file creation with mention pill by @ehayes2000 in https://github.com/macro-inc/macro/pull/1137
-* fix(unified-list): don't refetch on inbox filter by @synoet in https://github.com/macro-inc/macro/pull/1170
-* chore: remove dead code by @synoet in https://github.com/macro-inc/macro/pull/1167
-* fix(ai): share permissions by @ehayes2000 in https://github.com/macro-inc/macro/pull/1171
-* opt(web): low hanging optimizations for page load time by @synoet in https://github.com/macro-inc/macro/pull/1168
-* fix(email): Don't stall if init fails on signup by @evanhutnik in https://github.com/macro-inc/macro/pull/1181
-* chore: consolidate notificationdb to macrodb by @whutchinson98 in https://github.com/macro-inc/macro/pull/1178
-* chore(sync-service): update the runtime by @synoet in https://github.com/macro-inc/macro/pull/1183
-* chore(sync-service): remove qa-env by @synoet in https://github.com/macro-inc/macro/pull/1184
-* chore: freeze document-processing-types by @synoet in https://github.com/macro-inc/macro/pull/1182
-* feat: migrate contacts to macrodb by @whutchinson98 in https://github.com/macro-inc/macro/pull/1185
-* feat(properties): soup property editor modal (v0 - tasks only) by @sedson in https://github.com/macro-inc/macro/pull/1140
-* feat: make emoji-only messages big by @peterchinman in https://github.com/macro-inc/macro/pull/1180
-* fix(dpt): include in vite deps document-processing-types by @synoet in https://github.com/macro-inc/macro/pull/1186
-* chore(dpt): fix document processing types by @synoet in https://github.com/macro-inc/macro/pull/1187
-* Channel message selection by @peterchinman in https://github.com/macro-inc/macro/pull/1130
-* fix(md): fix focus loss after title editor rename by @sedson in https://github.com/macro-inc/macro/pull/1189
-* fix[mobile]: send button issue by @peterchinman in https://github.com/macro-inc/macro/pull/1191
-* fix(sync): change heartbeat config to be more lenient by @synoet in https://github.com/macro-inc/macro/pull/1190
-* fix: use model_user directly in macro_middleware crate by @whutchinson98 in https://github.com/macro-inc/macro/pull/1192
-* flag(channel/md): flag off document cards in channels until fixed by @sedson in https://github.com/macro-inc/macro/pull/1193
-* flag(md): flag off ai generate plugin until fixed by @sedson in https://github.com/macro-inc/macro/pull/1194
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.1.21.0...v2026.1.26.0
-    </Update>
-
-    <Update label="v2026.1.21.0">
-## What's Changed
-* fix(subscription): Invalidate user info after trial signup by @synoet in https://github.com/macro-inc/macro/pull/1107
-* feat(properties): add properties to soup queries. by @cowlicks in https://github.com/macro-inc/macro/pull/952
-* refactor(search): remove use of service_clients from search in step to make hexifying easier by @whutchinson98 in https://github.com/macro-inc/macro/pull/1109
-* fix: dss url by @synoet in https://github.com/macro-inc/macro/pull/1110
-* feat: Add code execution tool support by @ehayes2000 in https://github.com/macro-inc/macro/pull/1077
-* refactor(email): Inbox and All Mail thread previews by @evanhutnik in https://github.com/macro-inc/macro/pull/1083
-* chg(ai): Improve AI prompt to use tools and personalize responses by @ehayes2000 in https://github.com/macro-inc/macro/pull/1108
-* feat(ai): nested tool subcontext + docs + gen by @ehayes2000 in https://github.com/macro-inc/macro/pull/1112
-* feat(ai): remove rewrite tool  by @ehayes2000 in https://github.com/macro-inc/macro/pull/1067
-* chore(service-clients): remove statefullness from service-clients by @synoet in https://github.com/macro-inc/macro/pull/1081
-* style(document): Add beveled gradient edge to document preview popup by @aidanhb in https://github.com/macro-inc/macro/pull/1084
-* Remove fade effect from read entities by @jbecke in https://github.com/macro-inc/macro/pull/1118
-* fix: no inserting splits on mobile by @peterchinman in https://github.com/macro-inc/macro/pull/1113
-* fix: handle exact match scoring for command k fuzzy library by @gbirman in https://github.com/macro-inc/macro/pull/1120
-* Add light haptic feedback to mobile dock buttons by @jbecke in https://github.com/macro-inc/macro/pull/1060
-* chore: rationalize mobile and touch checks by @peterchinman in https://github.com/macro-inc/macro/pull/1121
-* fix(mobile): fix url link sharing + deep linking by @synoet in https://github.com/macro-inc/macro/pull/1123
-* feat(notifications): add notification badge to favicon by @aidanhb in https://github.com/macro-inc/macro/pull/1115
-* flag(md): flag off markdown history until can repro and fix by @sedson in https://github.com/macro-inc/macro/pull/1111
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.1.20.0...v2026.1.21.0
-    </Update>
-
-    <Update label="v2026.1.20.0">
-## What's Changed
-* feat(devx): playwright auto auth by @whutchinson98 in https://github.com/macro-inc/macro/pull/1056
-* fix(sfs): do not allow xss for files by @whutchinson98 in https://github.com/macro-inc/macro/pull/1058
-* feat(ai): add custom scrollbar to block-chat by @jbecke in https://github.com/macro-inc/macro/pull/1059
-* do not request to enable browser notifications on localhost by @whutchinson98 in https://github.com/macro-inc/macro/pull/1057
-* chore(deps-dev): bump devalue from 5.3.2 to 5.6.2 in /rust/sync-service by @dependabot[bot] in https://github.com/macro-inc/macro/pull/1022
-* feat(ai): AI CLI by @ehayes2000 in https://github.com/macro-inc/macro/pull/1041
-* feat(sfs): enable bucket versioning on SFS bucket by @whutchinson98 in https://github.com/macro-inc/macro/pull/1064
-* chore(auth): remove rate limit on refresh by @whutchinson98 in https://github.com/macro-inc/macro/pull/1063
-* feat(ai): center AI input box by @ehayes2000 in https://github.com/macro-inc/macro/pull/1066
-* feat: remove legacy gql rpc by @synoet in https://github.com/macro-inc/macro/pull/1065
-* feat(channels): ability to create tasks directly inside of channels. by @synoet in https://github.com/macro-inc/macro/pull/1025
-* fix(userId): fix improper userId import by @synoet in https://github.com/macro-inc/macro/pull/1070
-* chore(email): Enable email sharing by @dev-rb in https://github.com/macro-inc/macro/pull/1069
-* chore(email): don't delete email draft on message send by @dev-rb in https://github.com/macro-inc/macro/pull/1068
-* fix(email): thread messages should expand down by @dev-rb in https://github.com/macro-inc/macro/pull/1074
-* fix(auth): fix queries and effects in root by @synoet in https://github.com/macro-inc/macro/pull/1072
-* refactor(middleware): remove need for email service in middleware by @whutchinson98 in https://github.com/macro-inc/macro/pull/1079
-* feat(email-service): Delay sending emails for undo functionality by @evanhutnik in https://github.com/macro-inc/macro/pull/1071
-* chg(ci): faster api type check in ci by @synoet in https://github.com/macro-inc/macro/pull/1085
-* remove comms service client from macro_middleware crate by @whutchinson98 in https://github.com/macro-inc/macro/pull/1082
-* feat: display entity name with format document name by @gbirman in https://github.com/macro-inc/macro/pull/1047
-* chore(claude): qc check by @synoet in https://github.com/macro-inc/macro/pull/1080
-* fix(auth): only clear login cookie when auth state is actually known by @synoet in https://github.com/macro-inc/macro/pull/1086
-* fix(email): incorrect enter key spacing for emails by @dev-rb in https://github.com/macro-inc/macro/pull/1078
-* fix: channel name in search should appear regardless of order by @gbirman in https://github.com/macro-inc/macro/pull/1087
-* chg(ci): biome should only check import order on generated files by @synoet in https://github.com/macro-inc/macro/pull/1090
-* chore(dcs): remove macros by @whutchinson98 in https://github.com/macro-inc/macro/pull/1091
-* fix[email]: condense long recipient list by @peterchinman in https://github.com/macro-inc/macro/pull/1088
-* fix(channel): Opening message from popup preview not flashing message by @dev-rb in https://github.com/macro-inc/macro/pull/1096
-* fix(ci): update frontend types by @synoet in https://github.com/macro-inc/macro/pull/1099
-* fix: keep entity with everything layout static on hover by @gbirman in https://github.com/macro-inc/macro/pull/1095
-* feat(tools): Soup tool by @ehayes2000 in https://github.com/macro-inc/macro/pull/1035
-* feat(ai): add soup chat input to open chat split on enter by @ehayes2000 in https://github.com/macro-inc/macro/pull/1089
-* feat(properties): add keyboard first picker for date type properties by @sedson in https://github.com/macro-inc/macro/pull/1093
-* Settings panel navigation by @peterchinman in https://github.com/macro-inc/macro/pull/1092
-* style(soup): Add random arcanum to empty states by @aidanhb in https://github.com/macro-inc/macro/pull/1019
-* fix: property status updates in soup after block-md change by @gbirman in https://github.com/macro-inc/macro/pull/1103
-* fix: lower channel mark as read debounce time by @peterchinman in https://github.com/macro-inc/macro/pull/1102
-* Channel message context menu by @peterchinman in https://github.com/macro-inc/macro/pull/1100
-* feat: make emojis optimistically update by @gbirman in https://github.com/macro-inc/macro/pull/1104
-* fix(channel): notifications not being marked as read by @dev-rb in https://github.com/macro-inc/macro/pull/1101
-* chg(ul): temporarily flag off input in unfiied list by @synoet in https://github.com/macro-inc/macro/pull/1105
-* E hotkey mark-done in split view by @peterchinman in https://github.com/macro-inc/macro/pull/1098
-* style(soup): Make topbar icons smaller by @aidanhb in https://github.com/macro-inc/macro/pull/1076
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.1.16.0...v2026.1.20.0
-    </Update>
-
-    <Update label="v2026.1.16.0">
-## What's Changed
-* fix: lower file association cardinality [TEMPORARY] by @gbirman in https://github.com/macro-inc/macro/pull/1049
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.1.15.0...v2026.1.16.0
-    </Update>
-
-    <Update label="v2026.1.15.0">
-## What's Changed
-* chore: hexify entity_access by @ehayes2000 in https://github.com/macro-inc/macro/pull/1001
-* Hotkeys/add option to add handlers same scope id+hotkey and fix soup hotkey bugs by @aquaductape in https://github.com/macro-inc/macro/pull/1006
-* chore(log): debug log sns client errors by @seanaye in https://github.com/macro-inc/macro/pull/982
-* feat(email-service): List, remove, upsert scheduled drafts by @evanhutnik in https://github.com/macro-inc/macro/pull/974
-* fix(ci): do not run gen-api unless rust files have changed by @whutchinson98 in https://github.com/macro-inc/macro/pull/1011
-* unified-list: fix multiple entity rows showing same hover state by @aquaductape in https://github.com/macro-inc/macro/pull/1012
-* fix(sfs): Don't validate owner_id for internal requests by @evanhutnik in https://github.com/macro-inc/macro/pull/1013
-* project/block: fix filters and create menu to include tasks by @aquaductape in https://github.com/macro-inc/macro/pull/1015
-* feat(email): creating drafts & sending actual attachments in email compose  by @dev-rb in https://github.com/macro-inc/macro/pull/995
-* fix(ai): list tool text by @ehayes2000 in https://github.com/macro-inc/macro/pull/987
-* feat(soup): new topbar filter first paradigm by @jbecke in https://github.com/macro-inc/macro/pull/900
-* chore(ai): move tools to new crate by @ehayes2000 in https://github.com/macro-inc/macro/pull/1009
-* Disable inbox filter by default on load by @jbecke in https://github.com/macro-inc/macro/pull/1023
-* fix(search): sort channel results by channel message updated_at by @whutchinson98 in https://github.com/macro-inc/macro/pull/1020
-* split-panel: restore ClippedPanel for accent border on active panel by @aquaductape in https://github.com/macro-inc/macro/pull/1026
-* fix(fusionauth): correct delete event for delete webhook by @whutchinson98 in https://github.com/macro-inc/macro/pull/1027
-* Swap keyboard shortcut behavior in Launcher menu by @jbecke in https://github.com/macro-inc/macro/pull/1024
-* Remove default placeholder text from GitHub PR template by @jbecke in https://github.com/macro-inc/macro/pull/1028
-* feat(search): correctly search channel names to be agnostic of order by @whutchinson98 in https://github.com/macro-inc/macro/pull/1021
-* feat: expiry seconds env var for macro api token by @gbirman in https://github.com/macro-inc/macro/pull/1030
-* enforce bun by @whutchinson98 in https://github.com/macro-inc/macro/pull/1032
-* feat: various mobile ui improvements by @peterchinman in https://github.com/macro-inc/macro/pull/1010
-* chore(tools): prompts for blud by @ehayes2000 in https://github.com/macro-inc/macro/pull/1033
-* feat(email, scrollbar): remove velocity-scaling glow effect for perf; add customscrollbar to email by @jbecke in https://github.com/macro-inc/macro/pull/929
-* feat(tools): context extraction by @ehayes2000 in https://github.com/macro-inc/macro/pull/1016
-* fix(referencium): fix channel message params, temp hide broken soup doc shared notifications by @sedson in https://github.com/macro-inc/macro/pull/1034
-* fix(email): thread scroll jumping and loading indicator by @dev-rb in https://github.com/macro-inc/macro/pull/1014
-* feat: add retry to macro api token fetch calls by @gbirman in https://github.com/macro-inc/macro/pull/1036
-* feat(unified-list): display email drafts in inbox/signal view by @dev-rb in https://github.com/macro-inc/macro/pull/1031
-* soup: use channels in post soup query by @aquaductape in https://github.com/macro-inc/macro/pull/981
-* feat(email): allow editing and sending email drafts when there is no thread by @dev-rb in https://github.com/macro-inc/macro/pull/1005
-* feat: drag/drop entities + move/copy + fix canvas mention nodes by @gbirman in https://github.com/macro-inc/macro/pull/1002
-* new paradigm: fix some regressions by @aquaductape in https://github.com/macro-inc/macro/pull/1037
-* style(core): update user-tooltip styles by @aidanhb in https://github.com/macro-inc/macro/pull/980
-* feat(email-service): Sfs delete lambda and handler by @evanhutnik in https://github.com/macro-inc/macro/pull/1018
-* fix: mobile app squish by @peterchinman in https://github.com/macro-inc/macro/pull/1029
-* chore(email-service): Lower dev invocations of sfs delete lambda by @evanhutnik in https://github.com/macro-inc/macro/pull/1043
-* fix(channel): file drop overlay issues by @dev-rb in https://github.com/macro-inc/macro/pull/1042
-* fix(soup): nav to search result message on enter by @ehayes2000 in https://github.com/macro-inc/macro/pull/1044
-* feat: mobile filter bar and dock fixes by @peterchinman in https://github.com/macro-inc/macro/pull/1045
-* fix: quick dialog fix by @peterchinman in https://github.com/macro-inc/macro/pull/1046
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.1.14.0...v2026.1.15.0
-    </Update>
-
-    <Update label="v2026.1.14.0">
-## What's Changed
-* Blake1/bac 45 comment thread reply notification service support by @cowlicks in https://github.com/macro-inc/macro/pull/722
-* chore(email): enable email sharing in dev by @dev-rb in https://github.com/macro-inc/macro/pull/988
-* feat(email): allow sending actual attachments in emails by @dev-rb in https://github.com/macro-inc/macro/pull/935
-* feat(properties): edit task properties from list, task code cleanup by @sedson in https://github.com/macro-inc/macro/pull/992
-* fix: try cache first for mobile notifications by @peterchinman in https://github.com/macro-inc/macro/pull/994
-* fix(soup): use query mutation for task mark-as-done by @sedson in https://github.com/macro-inc/macro/pull/997
-* fix(ui): fix class reactivity and add new `cn` utility for classes by @dev-rb in https://github.com/macro-inc/macro/pull/996
-* refactor(email): refactor email form states by @dev-rb in https://github.com/macro-inc/macro/pull/993
-* fix(unified-list): filter menu causing layout thrash by @dev-rb in https://github.com/macro-inc/macro/pull/1000
-* feat(chat): hotkey to create by @ehayes2000 in https://github.com/macro-inc/macro/pull/989
-* feat(channels/core):refactor channels context by @synoet in https://github.com/macro-inc/macro/pull/998
-* feat(infra) local fusionauth pulumi by @whutchinson98 in https://github.com/macro-inc/macro/pull/1003
-* chore(email-service): Clean up logs by @evanhutnik in https://github.com/macro-inc/macro/pull/984
-* refactor(email-service): Contact upserting logic by @evanhutnik in https://github.com/macro-inc/macro/pull/999
-* style(soup): move task property display to right side of soup by @sedson in https://github.com/macro-inc/macro/pull/1004
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.1.13.1...v2026.1.14.0
-    </Update>
-
-    <Update label="v2026.1.13.1">
-## What's Changed
-* add preview project block from soup and project block by @aquaductape in https://github.com/macro-inc/macro/pull/536
-* split: fix regression that broke split focus navigation by @aquaductape in https://github.com/macro-inc/macro/pull/986
-* fix(property): date display by @ehayes2000 in https://github.com/macro-inc/macro/pull/985
-* fix(comms): remove limit on get_channels endpoint by @synoet in https://github.com/macro-inc/macro/pull/990
-* fix(email-service): Only send delete messages once daily, during the night by @evanhutnik in https://github.com/macro-inc/macro/pull/991
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.1.13.0...v2026.1.13.1
-    </Update>
-
-    <Update label="v2026.1.13.0">
-## What's Changed
-* chg(properties): simpler query, use properties in frontmatter, invalidatations by @synoet in https://github.com/macro-inc/macro/pull/953
-* feat(queries/email): persistence primitives + email cache persistence to indexdb by @synoet in https://github.com/macro-inc/macro/pull/945
-* feat(email): pull out core rendering logic, setup snapshot test suite for email rendering by @synoet in https://github.com/macro-inc/macro/pull/946
-* fix browser and tauri notifications by @peterchinman in https://github.com/macro-inc/macro/pull/911
-* chore(dcs): improve prompt by @ehayes2000 in https://github.com/macro-inc/macro/pull/938
-* feat(search) support cursor for unified search by @whutchinson98 in https://github.com/macro-inc/macro/pull/892
-* chore(log): channel name err by @seanaye in https://github.com/macro-inc/macro/pull/947
-* Generate and check OpenApi types in CI. by @cowlicks in https://github.com/macro-inc/macro/pull/811
-* style(nits): make settings and chat topbars line up, make shortcuts uppercase on cheat sheet by @sedson in https://github.com/macro-inc/macro/pull/954
-* Linear ticket CSV import by @peterchinman in https://github.com/macro-inc/macro/pull/949
-* feat(soup): add channels ast literal by @seanaye in https://github.com/macro-inc/macro/pull/944
-* upgrade log by @seanaye in https://github.com/macro-inc/macro/pull/959
-* feat: fix search highlight by @gbirman in https://github.com/macro-inc/macro/pull/956
-* fix(authentication_service): refresh token speed by @whutchinson98 in https://github.com/macro-inc/macro/pull/961
-* add keypress global signal to fix keyboard vs cursor select priority in lists by @aquaductape in https://github.com/macro-inc/macro/pull/962
-* fix: filter out invalid fetch items by @gbirman in https://github.com/macro-inc/macro/pull/960
-* fix(email-service): Upsert thread history when upserting draft by @evanhutnik in https://github.com/macro-inc/macro/pull/958
-* chore(metering): remove metering service iac by @whutchinson98 in https://github.com/macro-inc/macro/pull/965
-* feat(soup): comms filter 2 by @seanaye in https://github.com/macro-inc/macro/pull/948
-* chore(claude): add in more items to rust claude.md by @whutchinson98 in https://github.com/macro-inc/macro/pull/967
-* feat(soup): comms filter 3 by @seanaye in https://github.com/macro-inc/macro/pull/957
-* chore: update types by @synoet in https://github.com/macro-inc/macro/pull/968
-* feat(properties): fully port properties to use tanstack query, + some cleanup by @synoet in https://github.com/macro-inc/macro/pull/966
-* feat(email-service): Delete expired links by @evanhutnik in https://github.com/macro-inc/macro/pull/955
-* fix(tauri): only append is_mobile if it doesn't already exist by @seanaye in https://github.com/macro-inc/macro/pull/971
-* fix(tasks): remove hard dependency on blockId in PropertyLabel by @synoet in https://github.com/macro-inc/macro/pull/973
-* fix(ai): server-tool message ordering by @ehayes2000 in https://github.com/macro-inc/macro/pull/969
-* feat(ai): web_fetch tool by @ehayes2000 in https://github.com/macro-inc/macro/pull/964
-* chore(soup): replace custom either with axum_extra either by @seanaye in https://github.com/macro-inc/macro/pull/975
-* feat(ai): list channels tool by @ehayes2000 in https://github.com/macro-inc/macro/pull/976
-* Reduce email-service pods from 5 to 3 by @evanhutnik in https://github.com/macro-inc/macro/pull/978
-* feat(md/tasks): checkbox -> task conversion plugin by @synoet in https://github.com/macro-inc/macro/pull/972
-* fix: invalidate cached auth token before it expires by @gbirman in https://github.com/macro-inc/macro/pull/977
-* Add needed icons by @aidanhb in https://github.com/macro-inc/macro/pull/979
-* fix: focus search input by @gbirman in https://github.com/macro-inc/macro/pull/983
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.1.12.0...v2026.1.13.0
-    </Update>
-
-    <Update label="v2026.1.12.0">
-## What's Changed
-* add [properties] - add isCompleted flag for documents by @danielkweon in https://github.com/macro-inc/macro/pull/748
-* feat(dcs): add oppie by @ehayes2000 in https://github.com/macro-inc/macro/pull/888
-* fix [properties-fe] - document subtype type fixes by @danielkweon in https://github.com/macro-inc/macro/pull/899
-* chore: Add Claude Code GitHub Workflow by @synoet in https://github.com/macro-inc/macro/pull/901
-* fix(ci): trigger ci checks on draft being marked ready for review by @whutchinson98 in https://github.com/macro-inc/macro/pull/902
-* chore: remove insight service by @ehayes2000 in https://github.com/macro-inc/macro/pull/897
-* chore: try signing claude commits in ci by @synoet in https://github.com/macro-inc/macro/pull/905
-* chg: disable biome import sorting by @synoet in https://github.com/macro-inc/macro/pull/907
-* feat (ai): opus + hotkeys by @ehayes2000 in https://github.com/macro-inc/macro/pull/887
-* fix notification service query param keys by @peterchinman in https://github.com/macro-inc/macro/pull/908
-* Integrate properties for tasks by @ehayes2000 in https://github.com/macro-inc/macro/pull/859
-* chore(search): remove projects from opensearch by @whutchinson98 in https://github.com/macro-inc/macro/pull/909
-* chore(deps): bump aws-sdk-sesv2 from 1.68.0 to 1.103.0 in /rust/cloud-storage by @dependabot[bot] in https://github.com/macro-inc/macro/pull/866
-* chore(deps): bump aws-sdk-ssooidc from 1.61.0 to 1.93.0 in /rust/cloud-storage by @dependabot[bot] in https://github.com/macro-inc/macro/pull/868
-* chore(deps): bump aws-sdk-sso from 1.60.0 to 1.91.0 in /rust/cloud-storage by @dependabot[bot] in https://github.com/macro-inc/macro/pull/871
-* chg(soup): arrowup & arrowdown shouldn't navigate you outside of soup by @synoet in https://github.com/macro-inc/macro/pull/912
-* sunset metering service by @whutchinson98 in https://github.com/macro-inc/macro/pull/910
-* fix(tasks): task compose close button fix by @sedson in https://github.com/macro-inc/macro/pull/906
-* refactor(email-service): Improved Get Threads endpoint logic by @evanhutnik in https://github.com/macro-inc/macro/pull/895
-* chg(channels): remove admin / owner restriction on channel participant management by @synoet in https://github.com/macro-inc/macro/pull/913
-* update claude to prefer anyhow::bail by @whutchinson98 in https://github.com/macro-inc/macro/pull/915
-* feat(email-service): Make draft attachments visible by @evanhutnik in https://github.com/macro-inc/macro/pull/891
-* fix: docx save pdf modification data by @gbirman in https://github.com/macro-inc/macro/pull/903
-* feat(md/channels): support group mentions + @here in channels by @synoet in https://github.com/macro-inc/macro/pull/914
-* fix(dss): internal auth get document by @seanaye in https://github.com/macro-inc/macro/pull/918
-* add [properties-fe] - filter and sort to unified list filter by @danielkweon in https://github.com/macro-inc/macro/pull/633
-* feat!: move sync service to this repo by @synoet in https://github.com/macro-inc/macro/pull/924
-* chore: Remove web-services infra by @whutchinson98 in https://github.com/macro-inc/macro/pull/925
-* feat(ai): split unified search tool into content + name search by @ehayes2000 in https://github.com/macro-inc/macro/pull/773
-* feat(email-service): Async link deletion handler by @evanhutnik in https://github.com/macro-inc/macro/pull/916
-* fix [properties-be] - disable organization-shared properties in property definitions list by @danielkweon in https://github.com/macro-inc/macro/pull/927
-* Shortcuts helper by @jbecke in https://github.com/macro-inc/macro/pull/917
-* feat(mention_utils): add support for group-mention m tags in rust by @synoet in https://github.com/macro-inc/macro/pull/928
-* fix(command): fix ghost hotkeys by @sedson in https://github.com/macro-inc/macro/pull/919
-* chore(search) remove names index by @whutchinson98 in https://github.com/macro-inc/macro/pull/930
-* feat(email): ui revamp by @synoet in https://github.com/macro-inc/macro/pull/898
-* fix(md): update floatWith handlers in link menu to match mentions menu by @sedson in https://github.com/macro-inc/macro/pull/920
-* fix(dcs): fix non-sync-service `md` attachments by @ehayes2000 in https://github.com/macro-inc/macro/pull/926
-* feat(notification): better collapse + testing by @seanaye in https://github.com/macro-inc/macro/pull/904
-* fix(notifications): correctly resolve sender name for emails by @synoet in https://github.com/macro-inc/macro/pull/932
-* chore(claude): add formatter hook by @synoet in https://github.com/macro-inc/macro/pull/936
-* seanaye/chore/bump tracing by @seanaye in https://github.com/macro-inc/macro/pull/922
-* feat: endpoint to get notification by id by @peterchinman in https://github.com/macro-inc/macro/pull/923
-* chore(ai): mobile buttons + include model in prompt by @ehayes2000 in https://github.com/macro-inc/macro/pull/933
-* fix(lambda): rename infra by @seanaye in https://github.com/macro-inc/macro/pull/943
-* feat(email-service): Delete link when user revokes Macro access to inbox by @evanhutnik in https://github.com/macro-inc/macro/pull/941
-* feat: disable search service with signal/noise views by @gbirman in https://github.com/macro-inc/macro/pull/942
-* fix(lambdas) by @evanhutnik in https://github.com/macro-inc/macro/pull/951
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.1.9.0...v2026.1.12.0
-    </Update>
-
-    <Update label="v2026.1.9.0">
-## What's Changed
-* unified-list: fix scroll to top keep gap bug by @aquaductape in https://github.com/macro-inc/macro/pull/850
-* feat(kommand): kommand menu ordering improvements, history live updates by @synoet in https://github.com/macro-inc/macro/pull/816
-* Get rid of bento by @jbecke in https://github.com/macro-inc/macro/pull/848
-* chore(core): mark block signals as deprecated by @synoet in https://github.com/macro-inc/macro/pull/834
-* chore: simplify js commands + scripts by @synoet in https://github.com/macro-inc/macro/pull/799
-* fix(infra): append /app to posted feature url by @synoet in https://github.com/macro-inc/macro/pull/851
-* feat(tasks): tasks in signal tab, refresh queries on task notifs by @sedson in https://github.com/macro-inc/macro/pull/779
-* fix cargo deny by @seanaye in https://github.com/macro-inc/macro/pull/846
-* remove collapse animation on desktop by @peterchinman in https://github.com/macro-inc/macro/pull/828
-* chg(ws): use platform factory by @synoet in https://github.com/macro-inc/macro/pull/853
-* feat(tauri): log js to term by @seanaye in https://github.com/macro-inc/macro/pull/845
-* add [frecency-fe] - feature flag off frecency by @danielkweon in https://github.com/macro-inc/macro/pull/854
-* add [properties-fe] - feature flag property sort & filter & display by @danielkweon in https://github.com/macro-inc/macro/pull/855
-* feat(ui): Docs && Test harness by @nickisnoble in https://github.com/macro-inc/macro/pull/781
-* fix: make unified list robust to fetch failure by @gbirman in https://github.com/macro-inc/macro/pull/842
-* feat(properties): property style overhaul first pass  by @sedson in https://github.com/macro-inc/macro/pull/861
-* fix[mobile]: mobile dock by @peterchinman in https://github.com/macro-inc/macro/pull/862
-* fix: ios screen height by @peterchinman in https://github.com/macro-inc/macro/pull/872
-* chore(frontend): complete the migration to tailwindv4 by @nickisnoble in https://github.com/macro-inc/macro/pull/863
-* chore(ai): small attachment refactor by @ehayes2000 in https://github.com/macro-inc/macro/pull/841
-* fix(soup/md): add override for quote nodes in list by @sedson in https://github.com/macro-inc/macro/pull/852
-* fix(notifications): use correct name for dm name by @synoet in https://github.com/macro-inc/macro/pull/875
-* feat(properties): use task properties by @synoet in https://github.com/macro-inc/macro/pull/762
-* chg(email): make thread seen optimistic by @synoet in https://github.com/macro-inc/macro/pull/803
-* fix(notification): fix some deserialization by @seanaye in https://github.com/macro-inc/macro/pull/857
-* chore(deps): bump aws-sdk-sqs from 1.60.0 to 1.89.0 in /rust/cloud-storage by @dependabot[bot] in https://github.com/macro-inc/macro/pull/870
-* chore(deps): bump aws-sdk-ecs from 1.67.1 to 1.104.0 in /rust/cloud-storage by @dependabot[bot] in https://github.com/macro-inc/macro/pull/869
-* soup-context: add guard to entity list navigation, rename unifiedListContext to soupContext, add open entity helper function by @aquaductape in https://github.com/macro-inc/macro/pull/843
-* soup-context: fix entity navigation button firing incorrect command by @aquaductape in https://github.com/macro-inc/macro/pull/877
-* unified-list: add meta/ctrl click to entity row to open entity in new tab by @aquaductape in https://github.com/macro-inc/macro/pull/776
-* fix(tauri): proxy fetch calls by @seanaye in https://github.com/macro-inc/macro/pull/856
-* chore: Add agents.md and claude.md to js/app by @synoet in https://github.com/macro-inc/macro/pull/878
-* chore(deps): bump aws-sdk-dynamodb from 1.66.0 to 1.98.0 in /rust/cloud-storage by @dependabot[bot] in https://github.com/macro-inc/macro/pull/867
-* chore: move md files into js/app by @synoet in https://github.com/macro-inc/macro/pull/879
-* chore: add claude default settings whitelisting common commands by @synoet in https://github.com/macro-inc/macro/pull/881
-* chg(core): only proxy fetch if tauri by @synoet in https://github.com/macro-inc/macro/pull/880
-* feat(email-service): Send attachments with emails by @evanhutnik in https://github.com/macro-inc/macro/pull/858
-* Add CSV icon and display it for .csv files in soup and block header by @aidanhb in https://github.com/macro-inc/macro/pull/876
-* chore: remove claude md from the .gitignore by @synoet in https://github.com/macro-inc/macro/pull/884
-* fix(email-service): Swagger typegen fix by @evanhutnik in https://github.com/macro-inc/macro/pull/885
-* fix(core): fix collaped UserIcon by @sedson in https://github.com/macro-inc/macro/pull/874
-* feat(tasks): task composer improve - create more, link to clipboard, title validation by @sedson in https://github.com/macro-inc/macro/pull/883
-* fix(email-service): Allow users without email enabled to see shared threads by @evanhutnik in https://github.com/macro-inc/macro/pull/882
-* feat(task/history): add upsert mutation to history query, use tan-query history in mentions menu by @sedson in https://github.com/macro-inc/macro/pull/889
-* feat(email): add generic spinner to email block by @synoet in https://github.com/macro-inc/macro/pull/886
-* fix(core): attach custom origin to sync service requests when in tauri by @synoet in https://github.com/macro-inc/macro/pull/873
-* chore(deps): bump aws-sdk-lambda from 1.69.0 to 1.104.0 in /rust/cloud-storage by @dependabot[bot] in https://github.com/macro-inc/macro/pull/865
-* chore(deps): bump aws-sdk-secretsmanager from 1.64.0 to 1.93.0 in /rust/cloud-storage by @dependabot[bot] in https://github.com/macro-inc/macro/pull/864
-* fix(channel): channel freezing when too many messages by @dev-rb in https://github.com/macro-inc/macro/pull/894
-* fix: loading doc takes forever race condition by @gbirman in https://github.com/macro-inc/macro/pull/890
-* fix(md): wrap mention menu history query in suspense by @sedson in https://github.com/macro-inc/macro/pull/896
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.1.7.3...v2026.1.9.0
-    </Update>
-
-    <Update label="v2026.1.7.3">
-## What's Changed
-* fix(infra): regex on matching previews on previous id's by @synoet in https://github.com/macro-inc/macro/pull/847
-* fix(soup): skip returning channels for now by @seanaye in https://github.com/macro-inc/macro/pull/849
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.1.7.2...v2026.1.7.3
-    </Update>
-
-    <Update label="v2026.1.7.2">
-## What's Changed
-* feat(core): improve user tooltip style by @sedson in https://github.com/macro-inc/macro/pull/812
-* feat: global sort order locally by @gbirman in https://github.com/macro-inc/macro/pull/827
-* Seanaye/revert/revert comms soup by @seanaye in https://github.com/macro-inc/macro/pull/830
-* feat(cors): add in support for preview domains by @whutchinson98 in https://github.com/macro-inc/macro/pull/832
-* chore(soup): tracing by @seanaye in https://github.com/macro-inc/macro/pull/833
-* fix(notif): deserialize by @seanaye in https://github.com/macro-inc/macro/pull/836
-* feat(infra): support feature previews by @synoet in https://github.com/macro-inc/macro/pull/835
-* fix: don't close empty thread replies on blur by @peterchinman in https://github.com/macro-inc/macro/pull/820
-* fix: non-null assertions + channel type serialization by @gbirman in https://github.com/macro-inc/macro/pull/839
-* fix: add document subtype to search mapper by @gbirman in https://github.com/macro-inc/macro/pull/837
-* fix: optimstically remove item from search results on delete by @gbirman in https://github.com/macro-inc/macro/pull/838
-* fix(core): fix some missing/broken tooltip hot keys by @sedson in https://github.com/macro-inc/macro/pull/829
-* fix(channel): Last thread in channel not displaying replies by @dev-rb in https://github.com/macro-inc/macro/pull/844
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.1.7.1...v2026.1.7.2
-    </Update>
-
-    <Update label="v2026.1.7.1">
-## What's Changed
-* Seanaye/feat/comms in soup by @seanaye in https://github.com/macro-inc/macro/pull/757
-* Revert "Seanaye/feat/comms in soup (#757)" by @seanaye in https://github.com/macro-inc/macro/pull/822
-* chore: use regular props boolean instead of accessor for thread append input by @gbirman in https://github.com/macro-inc/macro/pull/823
-* chore: prod sqlx command to check what migrations are needed by @whutchinson98 in https://github.com/macro-inc/macro/pull/824
-* fix: search name highlight for local source by @gbirman in https://github.com/macro-inc/macro/pull/826
-* fix(channel): channel not auto updating messages by @dev-rb in https://github.com/macro-inc/macro/pull/825
-
-
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.1.7.0...v2026.1.7.1
-    </Update>
-
-    <Update label="v2026.1.7.0">
-## What's Changed
-* fix(channel): Fix reactive updates to channel query data when renaming by @dev-rb in https://github.com/macro-inc/macro/pull/618
-* fix(ai): auto attachments by @ehayes2000 in https://github.com/macro-inc/macro/pull/624
-* fix[email]: rendering of certain emails with initial style tags by @peterchinman in https://github.com/macro-inc/macro/pull/655
-* add [properties-be] - extra protection against deleting system properties by @danielkweon in https://github.com/macro-inc/macro/pull/649
-* fix [properties] - only allow entity type tasks to have parent and subtask properties by @danielkweon in https://github.com/macro-inc/macro/pull/616
-* fix(email-service): Use oldest message for subject in search thread histories endpoint by @evanhutnik in https://github.com/macro-inc/macro/pull/650
-* fix(email-service): Only create index if it doesn't already exist by @evanhutnik in https://github.com/macro-inc/macro/pull/652
-* fix: bring back inbox settings by @peterchinman in https://github.com/macro-inc/macro/pull/660
-* unified-list: fix entitywitheverything component timestamp by @aquaductape in https://github.com/macro-inc/macro/pull/658
-* feat(tauri,vite): iOS mobile v1 by @nickisnoble in https://github.com/macro-inc/macro/pull/293
-* fix [properties-fe] - inject current user into contacts list for entity property selection by @danielkweon in https://github.com/macro-inc/macro/pull/662
-* fix(opensearch_client): error on invalid query creation by @whutchinson98 in https://github.com/macro-inc/macro/pull/663
-* fix(opensearch_client): remove un-needed fields from response indices by @whutchinson98 in https://github.com/macro-inc/macro/pull/664
-* refactor(dss): Created items now private by default, except MD documents by @evanhutnik in https://github.com/macro-inc/macro/pull/665
-* Seanaye/feat/remove graphql service by @seanaye in https://github.com/macro-inc/macro/pull/443
-* seanaye/fix/ios notifications by @seanaye in https://github.com/macro-inc/macro/pull/603
-* fix (chat): auto attachments fix channels, images, projects by @ehayes2000 in https://github.com/macro-inc/macro/pull/666
-* fix(md): fix single line util for single item lists by @sedson in https://github.com/macro-inc/macro/pull/661
-* fix(email-service): Declare sfs_id field as optional when fetching attachments in upsert_message by @evanhutnik in https://github.com/macro-inc/macro/pull/670
-* chg(emails): centralize email links query by @synoet in https://github.com/macro-inc/macro/pull/667
-* feat: support create block with params by @gbirman in https://github.com/macro-inc/macro/pull/668
-* fix: channel open jitters due to unstable location by @gbirman in https://github.com/macro-inc/macro/pull/669
-* fix(channel): duplicate thread messages and sending messages not updating list by @dev-rb in https://github.com/macro-inc/macro/pull/672
-* fix(auth-service): Only fallback to contact name for empty Macro name by @evanhutnik in https://github.com/macro-inc/macro/pull/674
-* feat(email-service): Queue upsert for missing message on label update by @evanhutnik in https://github.com/macro-inc/macro/pull/676
-* Revert "fix(ai): auto attachments (#624)" by @gbirman in https://github.com/macro-inc/macro/pull/683
-* feat(search): enter key selects first item, down arrow key goes to next item by @gbirman in https://github.com/macro-inc/macro/pull/680
-* fix(channels): channel scroll should highlight from soup click + not highlight unwanted target message on message send by @gbirman in https://github.com/macro-inc/macro/pull/685
-* rm(contact): remove block contact + remove from command menu by @synoet in https://github.com/macro-inc/macro/pull/686
-* feat(email-service): Backfill sfs attachments script by @evanhutnik in https://github.com/macro-inc/macro/pull/619
-* fix (soup): screen flash on j/k by @ehayes2000 in https://github.com/macro-inc/macro/pull/677
-* feat(search): separate cmd-f and / hotkeys by @gbirman in https://github.com/macro-inc/macro/pull/681
-* feat(email-service): Enable attachment syncing for all users by @evanhutnik in https://github.com/macro-inc/macro/pull/671
-* fix(ai): suspsense trigger by @ehayes2000 in https://github.com/macro-inc/macro/pull/688
-* feat(search): ignore trash when performing email search by @whutchinson98 in https://github.com/macro-inc/macro/pull/689
-* feat(search): return 400 bad request if no valid terms are provided by @whutchinson98 in https://github.com/macro-inc/macro/pull/690
-* fix(email-service): Make email signature optional in /links endpoint by @evanhutnik in https://github.com/macro-inc/macro/pull/687
-* chore(email-service): Add param to swagger by @evanhutnik in https://github.com/macro-inc/macro/pull/694
-* feat(splits): Narrow width for narrow splits and mobile UI by @jbecke in https://github.com/macro-inc/macro/pull/583
-* fix(channel): don't clear input until after collect mentions by @sedson in https://github.com/macro-inc/macro/pull/695
-* fix(email-service): Use entire message content for replyless w/o split by @evanhutnik in https://github.com/macro-inc/macro/pull/696
-* fix virtua list bugs and restore scroll by @aquaductape in https://github.com/macro-inc/macro/pull/697
-* unified-infinite-list remove logs by @aquaductape in https://github.com/macro-inc/macro/pull/699
-* display full email names for threads with single participants by @peterchinman in https://github.com/macro-inc/macro/pull/678
-* fix: tab behavior in combobox by @peterchinman in https://github.com/macro-inc/macro/pull/673
-* feat: sfs image/video support for email message attachment by @peterchinman in https://github.com/macro-inc/macro/pull/599
-* fix(channels/ai): fix pasting images by @synoet in https://github.com/macro-inc/macro/pull/682
-* feat: error on warnings biome by @gbirman in https://github.com/macro-inc/macro/pull/702
-* Seanaye/chore/user id invariants by @seanaye in https://github.com/macro-inc/macro/pull/693
-* fix(email-service): Slow `/seen` endpoint by @evanhutnik in https://github.com/macro-inc/macro/pull/705
-* fix(ai): auto attach on create new chat by @ehayes2000 in https://github.com/macro-inc/macro/pull/679
-* fix(channel): Reply input mentions menu displaying all users by @dev-rb in https://github.com/macro-inc/macro/pull/706
-* fix(email): Add horizontal padding for compose for small containers by @dev-rb in https://github.com/macro-inc/macro/pull/707
-* chore: no underscored variable for naming collision by @gbirman in https://github.com/macro-inc/macro/pull/708
-* fix: unified empty state clean up by @gbirman in https://github.com/macro-inc/macro/pull/698
-* feat(search) update search service opensearch queries to use filter by @whutchinson98 in https://github.com/macro-inc/macro/pull/709
-* chore: add sass to model file type by @gbirman in https://github.com/macro-inc/macro/pull/701
-* feat(search) sort by updated at seconds by @whutchinson98 in https://github.com/macro-inc/macro/pull/710
-* feat: do not scroll channel reply open by @gbirman in https://github.com/macro-inc/macro/pull/711
-* soup-context: update entity properties by @aquaductape in https://github.com/macro-inc/macro/pull/712
-* soup: update filters/sort scroll to top and select first entity by @aquaductape in https://github.com/macro-inc/macro/pull/703
-* refactor(email-service): Rename webhook worker to inbox_sync worker by @evanhutnik in https://github.com/macro-inc/macro/pull/714
-* Refactor(email-service): Rename refresh pubsub worker to link_manager pubsub worker by @evanhutnik in https://github.com/macro-inc/macro/pull/715
-* fix(search): sort by updated at by @whutchinson98 in https://github.com/macro-inc/macro/pull/716
-* fix(dss): update UserItemAccess for user who shared item by @whutchinson98 in https://github.com/macro-inc/macro/pull/717
-* feat(share): new ShareButton, DialogWarper, ClippedPanel Signals, and disable transitions by @Fake-User in https://github.com/macro-inc/macro/pull/704
-* feat(soup): filter file associations by @seanaye in https://github.com/macro-inc/macro/pull/718
-* fix(channel): Sending, editing, and deleting a message not updating view  by @dev-rb in https://github.com/macro-inc/macro/pull/721
-* fix(channel): scroll position jumping and flickering by @dev-rb in https://github.com/macro-inc/macro/pull/691
-* soup: fix preview regression and add entity styling state for active context menu by @aquaductape in https://github.com/macro-inc/macro/pull/719
-* fix: empty state drawer by @gbirman in https://github.com/macro-inc/macro/pull/723
-* fix(channels): better styles for multiple invites - participant selector by @sedson in https://github.com/macro-inc/macro/pull/724
-* feat: Visor and WhichKey by @peterchinman in https://github.com/macro-inc/macro/pull/273
-* feat(tasks): task compose v1 by @sedson in https://github.com/macro-inc/macro/pull/692
-* fix: Add suspense boundaries by @dev-rb in https://github.com/macro-inc/macro/pull/727
-* feat(channel): Send static attachment dimensions and use dimensions for displaying attachments by @dev-rb in https://github.com/macro-inc/macro/pull/653
-* fix(channel): Unable to send message by @dev-rb in https://github.com/macro-inc/macro/pull/730
-* fix(task): re add portal scoping for in-modal popovers by @sedson in https://github.com/macro-inc/macro/pull/728
-* fix(email-service): Proper attachment upload retry logic, backfill rate limit tiering by @evanhutnik in https://github.com/macro-inc/macro/pull/720
-* feat(email): Email compose shortcuts by @dev-rb in https://github.com/macro-inc/macro/pull/732
-* feat(hotkeys): faster hotkeys with less nesting / remove visor system by @jbecke in https://github.com/macro-inc/macro/pull/731
-* Nick/mobile nits by @nickisnoble in https://github.com/macro-inc/macro/pull/700
-* style(share): tweak padding and add fallback icon/tooltip by @sedson in https://github.com/macro-inc/macro/pull/738
-* chore(ios): console-logs by @seanaye in https://github.com/macro-inc/macro/pull/739
-* unified-list: replace virtua with tanstack virtual by @aquaductape in https://github.com/macro-inc/macro/pull/740
-* fix(auth): remove onboarding redirect completely by @synoet in https://github.com/macro-inc/macro/pull/741
-* fix: Add more suspense boundaries by @dev-rb in https://github.com/macro-inc/macro/pull/743
-* fix(md): make markdown areas safer under suspense by @sedson in https://github.com/macro-inc/macro/pull/742
-* fix: Virtual lists are reversed by @dev-rb in https://github.com/macro-inc/macro/pull/747
-* feat: Add email to `UserIcon` tooltip by @dev-rb in https://github.com/macro-inc/macro/pull/750
-* chore(ui): create @ui package by @nickisnoble in https://github.com/macro-inc/macro/pull/755
-* add [properties & tasks] - show assignee status priority in unified list by @danielkweon in https://github.com/macro-inc/macro/pull/659
-* unified-list: multi-select mark_as_done select neighboring entity by @aquaductape in https://github.com/macro-inc/macro/pull/758
-* fix(channels): fix image preview escape handling by @sedson in https://github.com/macro-inc/macro/pull/745
-* fix: lexical crash under suspense pt2 by @sedson in https://github.com/macro-inc/macro/pull/753
-* fix(email): Send email w/o marking as done & button UI by @dev-rb in https://github.com/macro-inc/macro/pull/756
-* unified-list: improve jk experience keeping scroll gap at most of entity minimum height by @aquaductape in https://github.com/macro-inc/macro/pull/754
-* feat(notifications): port notifications to query package by @synoet in https://github.com/macro-inc/macro/pull/641
-* add [properties-be] - properties crate set entity property by @danielkweon in https://github.com/macro-inc/macro/pull/749
-* refactor [properties-be] - set_entity_property to hexagonal by @danielkweon in https://github.com/macro-inc/macro/pull/752
-* [1/3] feat(anthropic): Add support for anthropic server tools by @ehayes2000 in https://github.com/macro-inc/macro/pull/725
-* feat: mobile dock by @peterchinman in https://github.com/macro-inc/macro/pull/761
-* [2/3] feat(ai): Add extension support in ai crate by @ehayes2000 in https://github.com/macro-inc/macro/pull/726
-* fix: restore dock by @peterchinman in https://github.com/macro-inc/macro/pull/766
-* feat(unified-list): Add support for signal and noise filters on all views by @dev-rb in https://github.com/macro-inc/macro/pull/764
-* feat(email): toggle quoted text in reply by @dev-rb in https://github.com/macro-inc/macro/pull/763
-* feat: include individual content hit senders in email search by @gbirman in https://github.com/macro-inc/macro/pull/765
-* add [tasks] - grant permissions to task assignee by @danielkweon in https://github.com/macro-inc/macro/pull/760
-* add [tasks] - push notifications when assigned a task by @danielkweon in https://github.com/macro-inc/macro/pull/769
-* fix(unified-list): Make channels always show with signal filter by @dev-rb in https://github.com/macro-inc/macro/pull/771
-* add [tasks] - quick create task endpoint by @danielkweon in https://github.com/macro-inc/macro/pull/675
-* refactor [tasks-fe] - use create task endpoint in compose task by @danielkweon in https://github.com/macro-inc/macro/pull/759
-* fix (ai): update search service client to match api return type by @ehayes2000 in https://github.com/macro-inc/macro/pull/772
-* chore: change leeway and reject tokens expiring and in less than by @gbirman in https://github.com/macro-inc/macro/pull/775
-* add [properties & tasks] - enable properties and tasks feature flags by @danielkweon in https://github.com/macro-inc/macro/pull/592
-* feat(md): do not allow soft enter on new line after empty linebreak by @sedson in https://github.com/macro-inc/macro/pull/774
-* feat(md): add md util for truncating around \<macro_em> search tags for soup by @sedson in https://github.com/macro-inc/macro/pull/768
-* fix: add unauthed retry to legacy api rpc client  by @gbirman in https://github.com/macro-inc/macro/pull/777
-* fix(email): Email scroll jumping, suspense issues, and refactor by @dev-rb in https://github.com/macro-inc/macro/pull/770
-* chore(ui): drastically simplify button components by @nickisnoble in https://github.com/macro-inc/macro/pull/733
-* fix(soup): file assoc cursor by @seanaye in https://github.com/macro-inc/macro/pull/780
-* fix: sort channel first iff name match by @gbirman in https://github.com/macro-inc/macro/pull/778
-* fix: missing uuid feature flag schemars by @synoet in https://github.com/macro-inc/macro/pull/786
-* fix: downloading works now for block unknown/code by @gbirman in https://github.com/macro-inc/macro/pull/785
-* (fix): internal access by @ehayes2000 in https://github.com/macro-inc/macro/pull/782
-* feat(email): Add share button to emails by @dev-rb in https://github.com/macro-inc/macro/pull/783
-* fix(channel): List is reversed for a small number of messages by @dev-rb in https://github.com/macro-inc/macro/pull/788
-* chore(soup): increase cursor size limit by @seanaye in https://github.com/macro-inc/macro/pull/791
-* chore(deps): bump rsa from 0.9.8 to 0.9.10 in /rust/cloud-storage by @dependabot[bot] in https://github.com/macro-inc/macro/pull/792
-* style(md): minified comment thread styles by @sedson in https://github.com/macro-inc/macro/pull/795
-* move from names index to querying macrodb directly by @whutchinson98 in https://github.com/macro-inc/macro/pull/793
-* fix(dcs): attachments breaking due to serialization issue by @ehayes2000 in https://github.com/macro-inc/macro/pull/796
-* refactor(email-service): Separate email api and pubsub workers into separate services by @evanhutnik in https://github.com/macro-inc/macro/pull/594
-* feat: use file type soup request filters by @gbirman in https://github.com/macro-inc/macro/pull/790
-* fix(notifications): fix reconcile in notification source by @synoet in https://github.com/macro-inc/macro/pull/801
-* feat: swipe gestures in Soup by @peterchinman in https://github.com/macro-inc/macro/pull/784
-* fix: remove collapse on name/name_content search by @whutchinson98 in https://github.com/macro-inc/macro/pull/806
-* feat: change collapsible list visible count for search content data by @gbirman in https://github.com/macro-inc/macro/pull/805
-* fix: remove type safety for get user email names by @whutchinson98 in https://github.com/macro-inc/macro/pull/807
-* fix(email): Email draft not displaying when moving between soup and email by @dev-rb in https://github.com/macro-inc/macro/pull/808
-* feat: images in emails by @peterchinman in https://github.com/macro-inc/macro/pull/789
-* fix(UI): style share modal, fix(Dock): fix brock signup wordwrap, feat(themes): added black bezel mode by @Fake-User in https://github.com/macro-inc/macro/pull/802
-* fix: share menu by @peterchinman in https://github.com/macro-inc/macro/pull/813
-* fix(user): use branded type for Macroid string with validation by @synoet in https://github.com/macro-inc/macro/pull/809
-* fix: remove all tailwind colors by @peterchinman in https://github.com/macro-inc/macro/pull/810
-* fix(soup): unread indicator wasn't showing by @synoet in https://github.com/macro-inc/macro/pull/814
-* chg/fix(notifications): use tanstack as source of truth for optimistic updating, simplifies source by @synoet in https://github.com/macro-inc/macro/pull/815
-* fix(login): login button options cleanup, better hitbox by @synoet in https://github.com/macro-inc/macro/pull/819
-* fix(email): Marking email as seen not updating in soup by @dev-rb in https://github.com/macro-inc/macro/pull/804
-* chore(email): Feature flag email sharing by @dev-rb in https://github.com/macro-inc/macro/pull/821
+Releases follow the format `vYYYY.M.D.patch`. Earlier months are in the sidebar.
+
+    <Update label="v2026.6.9.0 (Current)">
+## What's Changed
+* fix(soup): sort being shared across views by @dev-rb in https://github.com/macro-inc/macro/pull/3855
+* feat(env): add FromRef trait for narrowing config field access by @synoet in https://github.com/macro-inc/macro/pull/3854
+* Add block feature list reference documentation by @jbecke in https://github.com/macro-inc/macro/pull/3856
+* fix(calls): preview image cors issue by @whutchinson98 in https://github.com/macro-inc/macro/pull/3859
+* fix(calls): change the key used for call image preview generation by @whutchinson98 in https://github.com/macro-inc/macro/pull/3860
+* feat: increase memory frequency and use old memories by @ehayes2000 in https://github.com/macro-inc/macro/pull/3845
+* feat: auto rename chats after initial message by @ehayes2000 in https://github.com/macro-inc/macro/pull/3833
+* chore(search): point opensearch helper constants at v2 chats/call_records by @gbirman in https://github.com/macro-inc/macro/pull/3861
+* fix(md): proper reactivity for task edit, fix(md): proper permissions for task discussion by @sedson in https://github.com/macro-inc/macro/pull/3863
+* fix(calls): change call audio to support firefox by @whutchinson98 in https://github.com/macro-inc/macro/pull/3865
+* Fix keyboard shortcut escaping in blocks documentation by @jbecke in https://github.com/macro-inc/macro/pull/3866
+* fix: update search tool prompt by @ehayes2000 in https://github.com/macro-inc/macro/pull/3864
+* feat(calls): add in MISSED call type by @whutchinson98 in https://github.com/macro-inc/macro/pull/3868
+* refactor(email): rename useIsInboxOnlyLinkedChild → useIsConnectedSecondaryInbox by @gbirman in https://github.com/macro-inc/macro/pull/3869
+* fix: chat autoname prompt by @ehayes2000 in https://github.com/macro-inc/macro/pull/3867
+* fix(email): paginate email signal on filtered rows, not raw recency by @gbirman in https://github.com/macro-inc/macro/pull/3870
+* feat(home): autofocus & press enter to focus by @dev-rb in https://github.com/macro-inc/macro/pull/3871
+* feat(github): use foreign entities for task github pr by @whutchinson98 in https://github.com/macro-inc/macro/pull/3873
+* Product overview and core features by @jbecke in https://github.com/macro-inc/macro/pull/3872
+* Reorganize sidebar navigation: rename Documents to Files, move Folders to tab by @jbecke in https://github.com/macro-inc/macro/pull/3857
+* Block concepts: splits, previews, and embeds by @jbecke in https://github.com/macro-inc/macro/pull/3879
+* fix(search): exclude foreign entities from search soup view by @gbirman in https://github.com/macro-inc/macro/pull/3876
+* chore(gmail): turn down gmail auth log from error to debug by @whutchinson98 in https://github.com/macro-inc/macro/pull/3880
+* fix(github): better pr task skeleton lazy loading by @whutchinson98 in https://github.com/macro-inc/macro/pull/3877
+* fix(soup): exclude foreign entities from recently-viewed Cmd-K menu by @gbirman in https://github.com/macro-inc/macro/pull/3881
+* feat(search, multi-inbox): hook up search with multi-inbox in backend and email view by @gbirman in https://github.com/macro-inc/macro/pull/3882
+* fix(soup): notifications unrolled for email by @dev-rb in https://github.com/macro-inc/macro/pull/3878
+* feat(channels): bot webhooks by @whutchinson98 in https://github.com/macro-inc/macro/pull/3883
+* Mintlify Docs Edits by @jbecke in https://github.com/macro-inc/macro/pull/3884
+* chg(sidebar): using websocket only state for incoming calls widget by @sedson in https://github.com/macro-inc/macro/pull/3875
+* fix: put solid surface color behind user profile pictures by @peterchinman in https://github.com/macro-inc/macro/pull/3891
+* fix(tauri): proper package resolution for xcode builds by @peterchinman in https://github.com/macro-inc/macro/pull/3892
+* chore: remove deprecated list view code by @gbirman in https://github.com/macro-inc/macro/pull/3894
+* fix(tauri): plugin permissions by @peterchinman in https://github.com/macro-inc/macro/pull/3895
+* feat(split): drag entity into split header by @sedson in https://github.com/macro-inc/macro/pull/3896
+* fix(ai): broken email mentions in AI chats by @ehayes2000 in https://github.com/macro-inc/macro/pull/3899
+* Mintlify Docs Edits by @jbecke in https://github.com/macro-inc/macro/pull/3900
+* Add strict appearance and custom fonts by @jbecke in https://github.com/macro-inc/macro/pull/3901
+* Mintlify Docs Edits by @jbecke in https://github.com/macro-inc/macro/pull/3902
+* feat(crm): companies & contacts frontend behind ENABLE_CRM flag by @evanhutnik in https://github.com/macro-inc/macro/pull/3898
+* Meta tracking by @evanhutnik in https://github.com/macro-inc/macro/pull/3903
+* fix(search): go to target message on result click, reusing mention navigation by @gbirman in https://github.com/macro-inc/macro/pull/3897
+* Mintlify Docs Edits by @jbecke in https://github.com/macro-inc/macro/pull/3907
+* fix(properties): menu style alignment, fix(md): reduce debounce time for rename mutation by @sedson in https://github.com/macro-inc/macro/pull/3905
+* fix(search): match channel find-bar multi-word queries as exact phrase by @gbirman in https://github.com/macro-inc/macro/pull/3909
+* feat(empty states): add graphics to calls and automations. + styling by @aidanhb in https://github.com/macro-inc/macro/pull/3912
+* fix(ios): disable auto-update with flag by @peterchinman in https://github.com/macro-inc/macro/pull/3915
+* Enable CRM FE in dev by @evanhutnik in https://github.com/macro-inc/macro/pull/3904
+* refactor(ai): move system prompts from markdown files into new prompt crate by @ehayes2000 in https://github.com/macro-inc/macro/pull/3911
+* feat: j/k navigation from blocks when coming from inbox or email views by @dev-rb in https://github.com/macro-inc/macro/pull/3906
+* fix(md): fix link auto-match bug by @sedson in https://github.com/macro-inc/macro/pull/3914
+* fix(soup-view): save group-by as history entry state by @gbirman in https://github.com/macro-inc/macro/pull/3917
+* fix(ai): give free users haiku by @ehayes2000 in https://github.com/macro-inc/macro/pull/3913
+* Mintlify Docs Edits by @jbecke in https://github.com/macro-inc/macro/pull/3916
+* Add index page to documentation navigation by @jbecke in https://github.com/macro-inc/macro/pull/3918
+* Update Macro documentation with product refinements and cleanup by @jbecke in https://github.com/macro-inc/macro/pull/3920
+* Mintlify Docs Edits by @jbecke in https://github.com/macro-inc/macro/pull/3922
+* Revert "feat: j/k navigation from blocks when coming from inbox or email views" by @dev-rb in https://github.com/macro-inc/macro/pull/3923
+* fix(ai): email tool body rendering and clickable tool previews by @ehayes2000 in https://github.com/macro-inc/macro/pull/3924
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.6.8.0...v2026.6.9.0
+    </Update>
+
+    <Update label="v2026.6.8.0">
+## What's Changed
+* fix(soup): return notification-backed items to list on undo mark-done by @gbirman in https://github.com/macro-inc/macro/pull/3783
+* fix(email): refetch new email thread on WS notification by @gbirman in https://github.com/macro-inc/macro/pull/3789
+* fix(email): notify delegated primaries of new emails in shared inboxes by @gbirman in https://github.com/macro-inc/macro/pull/3788
+* feat(macro_service_urls): Standardize service urls in rust by @whutchinson98 in https://github.com/macro-inc/macro/pull/3772
+* chore(stripe): remove legacy stripe subscription code by @whutchinson98 in https://github.com/macro-inc/macro/pull/3790
+* chore(paywall): remove legacy plans and refactor by @dev-rb in https://github.com/macro-inc/macro/pull/3791
+* feat(authentication_service): migrate to use doppler by @whutchinson98 in https://github.com/macro-inc/macro/pull/3794
+* Product documentation updates by @mintlify[bot] in https://github.com/macro-inc/macro/pull/3795
+* feat: add descriptive subtext and docs links to empty states by @jbecke in https://github.com/macro-inc/macro/pull/3793
+* fix(authentication_service): support doppler secrets sync by @whutchinson98 in https://github.com/macro-inc/macro/pull/3796
+* remove doppler token by @whutchinson98 in https://github.com/macro-inc/macro/pull/3798
+* chore(fusionauth): destory local should remove docker volumes by @whutchinson98 in https://github.com/macro-inc/macro/pull/3797
+* refactor(crm): gate CRM service methods with capability-token receipts by @evanhutnik in https://github.com/macro-inc/macro/pull/3766
+* fix: local fusionauth idp by @whutchinson98 in https://github.com/macro-inc/macro/pull/3799
+* fix(authentication_service): try to load config from APP_SETTINGS_JSON by @whutchinson98 in https://github.com/macro-inc/macro/pull/3800
+* Mintlify Docs Edits by @mintlify[bot] in https://github.com/macro-inc/macro/pull/3804
+* Mintlify Docs Edits by @mintlify[bot] in https://github.com/macro-inc/macro/pull/3805
+* Mintlify Docs Edits by @mintlify[bot] in https://github.com/macro-inc/macro/pull/3806
+* feat: optimistic document creation by @404Wolf in https://github.com/macro-inc/macro/pull/3716
+* Mintlify Docs Edits by @mintlify[bot] in https://github.com/macro-inc/macro/pull/3808
+* fix: dont filter the golden snapshot from nix deploy builds by @404Wolf in https://github.com/macro-inc/macro/pull/3809
+* fix: deny by @whutchinson98 in https://github.com/macro-inc/macro/pull/3812
+* fix: don't show 404 blip on markdown load by @404Wolf in https://github.com/macro-inc/macro/pull/3813
+* fix: remove_link unlinks correct FA IdP link for secondary inboxes by @gbirman in https://github.com/macro-inc/macro/pull/3814
+* Mintlify Docs Edits by @mintlify[bot] in https://github.com/macro-inc/macro/pull/3816
+* update favicon to orange brand icon by @git-julia in https://github.com/macro-inc/macro/pull/3818
+* feat(documents): add document to entity_access when you are mentioned in it by @whutchinson98 in https://github.com/macro-inc/macro/pull/3817
+* Mintlify Docs Edits by @mintlify[bot] in https://github.com/macro-inc/macro/pull/3820
+* feat(call_recording): image placeholder by @whutchinson98 in https://github.com/macro-inc/macro/pull/3811
+* feat(ios): native swift livekit by @peterchinman in https://github.com/macro-inc/macro/pull/3750
+* feat(db): channel left at index by @whutchinson98 in https://github.com/macro-inc/macro/pull/3822
+* fix: wrap long unbroken words in email digest by @peterchinman in https://github.com/macro-inc/macro/pull/3663
+* remove call recording lambda by @whutchinson98 in https://github.com/macro-inc/macro/pull/3824
+* fix: clean up multi-inbox settings toast and optimistic add/remove by @gbirman in https://github.com/macro-inc/macro/pull/3815
+* fix(ai): mentions flashing in chat stream by @ehayes2000 in https://github.com/macro-inc/macro/pull/3825
+* feat(ai): bufferedStream by @ehayes2000 in https://github.com/macro-inc/macro/pull/3810
+* fix(opensearch): add search slow-log thresholds to v2 join indexes by @gbirman in https://github.com/macro-inc/macro/pull/3823
+* feat: suppress user affordances on inbox-only linked-child contacts by @gbirman in https://github.com/macro-inc/macro/pull/3819
+* fix: call recording preview handler by @whutchinson98 in https://github.com/macro-inc/macro/pull/3826
+* fix(mobile): compose task plays nice with virtual keyboard by @peterchinman in https://github.com/macro-inc/macro/pull/3803
+* feat(channel): drag entities into channel input by @peterchinman in https://github.com/macro-inc/macro/pull/3821
+* Mintlify Docs Edits by @mintlify[bot] in https://github.com/macro-inc/macro/pull/3829
+* [search] deprecate parent-child migration legacy code by @gbirman in https://github.com/macro-inc/macro/pull/3827
+* feat(calls): show placeholder image over recording by @whutchinson98 in https://github.com/macro-inc/macro/pull/3832
+* feat(infra): faster ecs deployments by @whutchinson98 in https://github.com/macro-inc/macro/pull/3830
+* fix(sidebar): Missing home shortcut by @dev-rb in https://github.com/macro-inc/macro/pull/3835
+* feat: macro config by @whutchinson98 in https://github.com/macro-inc/macro/pull/3801
+* fix: classify connected secondary inboxes as inbox-only by @gbirman in https://github.com/macro-inc/macro/pull/3831
+* perf(calls): batch-fetch call record participants by @evanhutnik in https://github.com/macro-inc/macro/pull/3836
+* fix(task): github pr loading skeleton by @whutchinson98 in https://github.com/macro-inc/macro/pull/3837
+* feat: always show profile picture upload button by @peterchinman in https://github.com/macro-inc/macro/pull/3787
+* feat: loading indicator when switching soup tabs on mobile by @peterchinman in https://github.com/macro-inc/macro/pull/3802
+* fix(environment): add aliases to environment for config loading by @whutchinson98 in https://github.com/macro-inc/macro/pull/3838
+* feat(soup): preserve filters across tabs for some views by @dev-rb in https://github.com/macro-inc/macro/pull/3834
+* Deny by @evanhutnik in https://github.com/macro-inc/macro/pull/3841
+* feat(search): add CRM company search to unified search by @evanhutnik in https://github.com/macro-inc/macro/pull/3840
+* feat(infra): add in deployment failure alarm for ecs services by @whutchinson98 in https://github.com/macro-inc/macro/pull/3839
+* fix(email): auto-refresh newly-linked inbox avatar during post-link sync by @gbirman in https://github.com/macro-inc/macro/pull/3844
+* fix(empty states): differentiate copy for signal and noice empty states by @aidanhb in https://github.com/macro-inc/macro/pull/3846
+* fix(ios): callkit compiles correctly by @peterchinman in https://github.com/macro-inc/macro/pull/3848
+* fix: feature flag for auto-update ui by @peterchinman in https://github.com/macro-inc/macro/pull/3850
+* feat(email): gate multi-inbox on the enable-multi-inbox posthog flag by @gbirman in https://github.com/macro-inc/macro/pull/3851
+* feat(settings): rework email enable/disable controls by @evanhutnik in https://github.com/macro-inc/macro/pull/3847
+* fix(ios): correct modes in plist by @peterchinman in https://github.com/macro-inc/macro/pull/3852
+* fix: channel tabs by @peterchinman in https://github.com/macro-inc/macro/pull/3853
+* feat(soup): display github pr entities by @dev-rb in https://github.com/macro-inc/macro/pull/3792
 
 ## New Contributors
-* @dependabot[bot] made their first contribution in https://github.com/macro-inc/macro/pull/792
+* @404Wolf made their first contribution in https://github.com/macro-inc/macro/pull/3716
+* @git-julia made their first contribution in https://github.com/macro-inc/macro/pull/3818
 
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2025.12.15.1...v2026.1.7.0
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.6.4.0...v2026.6.8.0
     </Update>
 
-    <Update label="v2025.12.15.1">
+    <Update label="v2026.6.4.0">
 ## What's Changed
-* fix(scrollbar): simplify scrollbar style by @Fake-User in https://github.com/macro-inc/macro/pull/637
-* fix(md): ammend [2813da97] and keep text formatting of children by @sedson in https://github.com/macro-inc/macro/pull/654
-* fix(ws): don't cleanup on close by @synoet in https://github.com/macro-inc/macro/pull/657
-* fix(soup): fix layout thrash on help drawer toggle by @sedson in https://github.com/macro-inc/macro/pull/656
+* feat(icons): restyle custom macro icons by @aidanhb in https://github.com/macro-inc/macro/pull/3756
+* feat(empty states): Add docs to empty states by @aidanhb in https://github.com/macro-inc/macro/pull/3760
+* fix(email): polish the mobile reply input by @gbirman in https://github.com/macro-inc/macro/pull/3761
+* feat(email): surface the owning inbox per thread in the entity emails view by @gbirman in https://github.com/macro-inc/macro/pull/3753
+* feat(email): render email contact photos in avatars by @gbirman in https://github.com/macro-inc/macro/pull/3755
+* fix: fix task dedup soup query by @ehayes2000 in https://github.com/macro-inc/macro/pull/3757
+* feat(iac): protect fusionauth idp resources by @whutchinson98 in https://github.com/macro-inc/macro/pull/3763
+* feat(entity-access): role-aware opt-out semantics for CRM thread grant by @evanhutnik in https://github.com/macro-inc/macro/pull/3765
+* feat(email): return inbox photo from links API for the from-inbox selector by @gbirman in https://github.com/macro-inc/macro/pull/3762
+* fix(email): verify child email_links row before graph edge in /email/init by @gbirman in https://github.com/macro-inc/macro/pull/3771
+* fix(task-dedup): improve duplicate judge prompt by @ehayes2000 in https://github.com/macro-inc/macro/pull/3770
+* fix(ai-tools): clarify activity summary tool routing by @ehayes2000 in https://github.com/macro-inc/macro/pull/3773
+* feat: configure github mcp by @ehayes2000 in https://github.com/macro-inc/macro/pull/3764
+* fix(home): can't drag and drop attachments for input by @dev-rb in https://github.com/macro-inc/macro/pull/3775
+* fix(soup): email attachments showing in documents view by @dev-rb in https://github.com/macro-inc/macro/pull/3776
+* feat(email): add inbox selector to scope the mail list by @gbirman in https://github.com/macro-inc/macro/pull/3774
+* fix(soup): can't mark done in inbox noise tab by @dev-rb in https://github.com/macro-inc/macro/pull/3779
+* feat(email): bootstrap child email_links on first link (self-link case) by @gbirman in https://github.com/macro-inc/macro/pull/3777
+* feat(mobile): improve soup navigation touch highlight by @peterchinman in https://github.com/macro-inc/macro/pull/3782
+* fix(email): stop backspace from deselecting an inbox in the selector by @gbirman in https://github.com/macro-inc/macro/pull/3780
+* fix(ai): make tool rendering stable during streaming by @ehayes2000 in https://github.com/macro-inc/macro/pull/3778
+* Mintlify Docs Edits by @mintlify[bot] in https://github.com/macro-inc/macro/pull/3786
 
 
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2025.12.15.0...v2025.12.15.1
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.6.3.2...v2026.6.4.0
     </Update>
 
-    <Update label="v2025.12.15.0">
+    <Update label="v2026.6.3.2">
 ## What's Changed
-* chore(email): add gmail auth feature by @seanaye in https://github.com/macro-inc/macro/pull/405
-* feat(email): Thread metadata in previews by @evanhutnik in https://github.com/macro-inc/macro/pull/366
-* feat(notification_service): only send notification emails to non existing users by @whutchinson98 in https://github.com/macro-inc/macro/pull/408
-* fix(sps): delete email link for SPS entity names by @whutchinson98 in https://github.com/macro-inc/macro/pull/431
-* feat(sps): speed up name index backfill script by @whutchinson98 in https://github.com/macro-inc/macro/pull/430
-* fix(opensearch): Delete from name index in delete_user_entities helper by @evanhutnik in https://github.com/macro-inc/macro/pull/432
-* fix(iac): bulk upload lambda permissions by @whutchinson98 in https://github.com/macro-inc/macro/pull/435
-* fix[channels]: new thread reply updates gated by typing by @peterchinman in https://github.com/macro-inc/macro/pull/429
-* fix[channels]: jump to reply input on tab focus by @peterchinman in https://github.com/macro-inc/macro/pull/434
-* fix: remove hard coded test stripe price id by @whutchinson98 in https://github.com/macro-inc/macro/pull/437
-* feat(email-service): Per-message contact name storage by @evanhutnik in https://github.com/macro-inc/macro/pull/438
-* fix(macrodb): Remove backfill operation from db migration by @evanhutnik in https://github.com/macro-inc/macro/pull/445
-* chore(ai): kill memory by @ehayes2000 in https://github.com/macro-inc/macro/pull/441
-* feat(macrodb): add document_task table by @whutchinson98 in https://github.com/macro-inc/macro/pull/447
-* chore(ws): add max retries for cognition, connection, storage by @synoet in https://github.com/macro-inc/macro/pull/444
-* feat(search): handle name and unified search using names index by @whutchinson98 in https://github.com/macro-inc/macro/pull/345
-* feat: update front end to handle new search types for handling name search by @gbirman in https://github.com/macro-inc/macro/pull/424
-* feat(dcs): batch id support for read tool by @ehayes2000 in https://github.com/macro-inc/macro/pull/399
-* feat(ios): applink verification by @seanaye in https://github.com/macro-inc/macro/pull/449
-* Seanaye/add/axum rpc macro by @seanaye in https://github.com/macro-inc/macro/pull/440
-* feat(dss|search|soup): update all document models to return is_task by @whutchinson98 in https://github.com/macro-inc/macro/pull/448
-* feat(dss): create/copy document handles tasks by @whutchinson98 in https://github.com/macro-inc/macro/pull/451
-* add [properties-be] - system properties for tasks and email by @danielkweon in https://github.com/macro-inc/macro/pull/436
-* fix [properties-be] - allow view access for publicly shared entities by @danielkweon in https://github.com/macro-inc/macro/pull/446
-* fix(soup) Add labels to email soup objects by @evanhutnik in https://github.com/macro-inc/macro/pull/452
-* Seanaye/add/legacy rpc interface by @seanaye in https://github.com/macro-inc/macro/pull/442
-* chore(ios+android): add app verification files by @seanaye in https://github.com/macro-inc/macro/pull/453
-* chore: remove redundant bytesEqual by @gbirman in https://github.com/macro-inc/macro/pull/398
-* fix [properties-frontend] - type check fixes by @danielkweon in https://github.com/macro-inc/macro/pull/459
-* feat: upload folders on drag and drop by @peterchinman in https://github.com/macro-inc/macro/pull/34
-* feat(notification_service): add in helper to send push notifications locally by @whutchinson98 in https://github.com/macro-inc/macro/pull/460
-* feat(auth-service): get_names_with_email endpoint by @evanhutnik in https://github.com/macro-inc/macro/pull/455
-* fix(search_service): correctly include name indice in search queries by @whutchinson98 in https://github.com/macro-inc/macro/pull/462
-* chore: remove some unused utils by @synoet in https://github.com/macro-inc/macro/pull/458
-* soup: replace dss get with post endpoint by @aquaductape in https://github.com/macro-inc/macro/pull/454
-* fix(email-service): Message contact name saving by @evanhutnik in https://github.com/macro-inc/macro/pull/463
-* feat: signal noise split for inbox by @peterchinman in https://github.com/macro-inc/macro/pull/465
-* chore(app): consolidate service clients by @synoet in https://github.com/macro-inc/macro/pull/457
-* feat(email-service): Enable contacts syncing by @evanhutnik in https://github.com/macro-inc/macro/pull/467
-* feat(notification_service): ability to mark notifications as undone by @whutchinson98 in https://github.com/macro-inc/macro/pull/466
-* Feat(email-compose): New email compose design by @dev-rb in https://github.com/macro-inc/macro/pull/469
-* fix(email-service): Better log for attachment upload create document failure by @evanhutnik in https://github.com/macro-inc/macro/pull/475
-* add [properties-be] - properties service handling system by @danielkweon in https://github.com/macro-inc/macro/pull/456
-* add [properties-be] - system properties for tasks by @danielkweon in https://github.com/macro-inc/macro/pull/461
-* chore(app): remove dead code by @synoet in https://github.com/macro-inc/macro/pull/479
-* fix(lexical): add parser for m-links in plaintext by @synoet in https://github.com/macro-inc/macro/pull/477
-* feat(notification_service): send push notification before connection gateway by @whutchinson98 in https://github.com/macro-inc/macro/pull/484
-* fix(email-service): email upload attachment endpoint issues by @evanhutnik in https://github.com/macro-inc/macro/pull/483
-* soup: replace email query with dss query by @aquaductape in https://github.com/macro-inc/macro/pull/486
-* feat(sync_service): change sync service url by @cowlicks in https://github.com/macro-inc/macro/pull/472
-* feat(documents): move from is_task to sub_type by @whutchinson98 in https://github.com/macro-inc/macro/pull/487
-* fix: Auto focus first item in recipient selector when typing and mount by @dev-rb in https://github.com/macro-inc/macro/pull/488
-* chg(kommand): deprioritize commands in Kommand Menu, remove splitting by @synoet in https://github.com/macro-inc/macro/pull/481
-* chg(kommand): disable email + search in kommand menu by @synoet in https://github.com/macro-inc/macro/pull/482
-* chore(macrodb): drop document_task by @whutchinson98 in https://github.com/macro-inc/macro/pull/491
-* fix: remove isTask by @whutchinson98 in https://github.com/macro-inc/macro/pull/495
-* change sync service url again by @cowlicks in https://github.com/macro-inc/macro/pull/494
-* feat(iac): decrease deprovisioning time to improve deployment speed by @whutchinson98 in https://github.com/macro-inc/macro/pull/492
-* fix(iac): trigger cloud-storage deploy on infra changes by @whutchinson98 in https://github.com/macro-inc/macro/pull/496
-* feat [tasks] - add tasks in create menu by @danielkweon in https://github.com/macro-inc/macro/pull/490
-* fix(email-service): Move access level into thread object by @evanhutnik in https://github.com/macro-inc/macro/pull/498
-* feat [properties-fe] - add data type icons to property labels in panel by @danielkweon in https://github.com/macro-inc/macro/pull/497
-* chore(nix): macos flake support by @seanaye in https://github.com/macro-inc/macro/pull/485
-* soup: fix mark as done in email block and update block entity navigation indicator by @aquaductape in https://github.com/macro-inc/macro/pull/474
-* Russell/feat(settings): move settings dialog to SplitLikeContainer by @Fake-User in https://github.com/macro-inc/macro/pull/476
-* Fix(comms): Use contacts as single source of truth by @dev-rb in https://github.com/macro-inc/macro/pull/450
-* soup: update dss disable logic to fix no emails on email only filter by @aquaductape in https://github.com/macro-inc/macro/pull/505
-* Russell/dialog style by @Fake-User in https://github.com/macro-inc/macro/pull/501
-* add [properties-fe] - system properties in properties panel by @danielkweon in https://github.com/macro-inc/macro/pull/500
-* fix(layout): registration time of splits during reconcile by @synoet in https://github.com/macro-inc/macro/pull/478
-* Fix: Contact names not reactive to display name fetch  by @dev-rb in https://github.com/macro-inc/macro/pull/508
-* unified-list: enable rename channel by @aquaductape in https://github.com/macro-inc/macro/pull/509
-* fix [properties-be] - bunch of fixes by @danielkweon in https://github.com/macro-inc/macro/pull/506
-* fix?(soup): remove reconcile from entity queries by @synoet in https://github.com/macro-inc/macro/pull/511
-* soup: rename unified entity action parameter by @aquaductape in https://github.com/macro-inc/macro/pull/512
-* Fix: Display names not showing in mentions menu for channel users by @dev-rb in https://github.com/macro-inc/macro/pull/513
-* feat (MentionMenu): email search by @ehayes2000 in https://github.com/macro-inc/macro/pull/507
-* unified-list: remove unified jk navigation inside project block by @aquaductape in https://github.com/macro-inc/macro/pull/514
-* fix(mention menu): arrow keys by @ehayes2000 in https://github.com/macro-inc/macro/pull/516
-* add [properties] - set property status to done for 'e' in unified list by @danielkweon in https://github.com/macro-inc/macro/pull/510
-* feat(app/email): consolidate queries package + block-email using tanstack query by @synoet in https://github.com/macro-inc/macro/pull/480
-* unified-list: project-block filter chat by project_ids by @aquaductape in https://github.com/macro-inc/macro/pull/515
-* feat: block aliases, task pseudo block, task entity types, handling several note/task forks by @sedson in https://github.com/macro-inc/macro/pull/502
-* fix [tasks] - bunch of bug fixes by @danielkweon in https://github.com/macro-inc/macro/pull/517
-* feat(email-service): Add entity properties for uploaded email attachments by @evanhutnik in https://github.com/macro-inc/macro/pull/504
-* soup: fix client noise filter logic filtering out non-email entities by @aquaductape in https://github.com/macro-inc/macro/pull/519
-* add [tasks] - automatically set pinned properties by @danielkweon in https://github.com/macro-inc/macro/pull/518
-* fix: email attachment pills only create a single macro entity by @peterchinman in https://github.com/macro-inc/macro/pull/499
-* [channels] fix: subpixel color rendering issue by @peterchinman in https://github.com/macro-inc/macro/pull/503
-* fix(tasks): fix task navigation from soup and task split preview, chg(entity): tweak as yet unuses task enity types by @sedson in https://github.com/macro-inc/macro/pull/521
-* fix(emails/soup): fix live updating in email block and in soup by @synoet in https://github.com/macro-inc/macro/pull/522
-* feat(soup): add default tasks view by @sedson in https://github.com/macro-inc/macro/pull/523
-* add [properties-fe] - entity icons for threads, emails, tasks by @danielkweon in https://github.com/macro-inc/macro/pull/524
-* add [properties-fe] - handle entity type company by @danielkweon in https://github.com/macro-inc/macro/pull/526
-* add [properties-fe] - handle entity type threads by @danielkweon in https://github.com/macro-inc/macro/pull/528
-* fix: channel message go to click from soup not working by @gbirman in https://github.com/macro-inc/macro/pull/527
-* add [properties-fe] - handle entity type tasks + task search by @danielkweon in https://github.com/macro-inc/macro/pull/529
-* fix(tasks): goto task block from ItemPreview.tsx by @sedson in https://github.com/macro-inc/macro/pull/525
-* chore: use terms not query for command k search by @gbirman in https://github.com/macro-inc/macro/pull/530
-* fix: search items stability by @gbirman in https://github.com/macro-inc/macro/pull/534
-* fix: support message tag for empty message by @gbirman in https://github.com/macro-inc/macro/pull/535
-* Fix: Channel and email scroll jumping by @dev-rb in https://github.com/macro-inc/macro/pull/533
-* chg(tasks): task tab in command, tasks are green, more task icon bug fixes, fix broken link paste by @sedson in https://github.com/macro-inc/macro/pull/537
-* chg(entity): add indication that empty message previews have attachments by @sedson in https://github.com/macro-inc/macro/pull/539
-* feat: support multi hit content matches in front end search by @gbirman in https://github.com/macro-inc/macro/pull/543
-* fix [tasks] - route task entity pills to task instead of md by @danielkweon in https://github.com/macro-inc/macro/pull/541
-* feat(search): remove legacy update entity name events by @whutchinson98 in https://github.com/macro-inc/macro/pull/351
-* feat(email-service): Upload image/video attachments to sfs by @evanhutnik in https://github.com/macro-inc/macro/pull/532
-* feat: improve email message scroll by @gbirman in https://github.com/macro-inc/macro/pull/544
-* fix: show *attached items* for empty string by @gbirman in https://github.com/macro-inc/macro/pull/551
-* feat: add format button to channel message edit input by @gbirman in https://github.com/macro-inc/macro/pull/548
-* style(launcher): make 8 cols, reduce launcher item size slightly by @sedson in https://github.com/macro-inc/macro/pull/553
-* chore: remove duplicate binary names by @whutchinson98 in https://github.com/macro-inc/macro/pull/554
-* fix: scroll channel to bottom if notification has been deleted + notify user by @gbirman in https://github.com/macro-inc/macro/pull/550
-* chore: do not show delete reply input button for non-replies by @gbirman in https://github.com/macro-inc/macro/pull/546
-* feat: channel messages multi hit content matches + fix channel goToLocationFromParams by @gbirman in https://github.com/macro-inc/macro/pull/549
-* fix: scroll to bottom for channel new message by @gbirman in https://github.com/macro-inc/macro/pull/547
-* add [properties-be] - pass in specific message id for threads by @danielkweon in https://github.com/macro-inc/macro/pull/538
-* Revert "feat(notification_service): send push notification before connection gateway" by @whutchinson98 in https://github.com/macro-inc/macro/pull/556
-* feat(soup): expose email view type to api by @seanaye in https://github.com/macro-inc/macro/pull/560
-* add [properties-fe] - search for thread in properties by @danielkweon in https://github.com/macro-inc/macro/pull/558
-* fix [properties-fe] - thread entity pills show email subject instead of id by @danielkweon in https://github.com/macro-inc/macro/pull/559
-* fix: scroll to bottom of channel on new top level message by @gbirman in https://github.com/macro-inc/macro/pull/561
-* feat(search): return pretty sender email contact info from search backend by @whutchinson98 in https://github.com/macro-inc/macro/pull/563
-* fix(chat): Attach email found from search by @ehayes2000 in https://github.com/macro-inc/macro/pull/555
-* Feat(channels): Rename channel in block view by @dev-rb in https://github.com/macro-inc/macro/pull/557
-* chore: use vendored utoipa-swagger-ui by @whutchinson98 in https://github.com/macro-inc/macro/pull/564
-* fix (model): Item type can't be deserialized by @ehayes2000 in https://github.com/macro-inc/macro/pull/545
-* feat(comms-service): Add width and height columns for message attachments by @evanhutnik in https://github.com/macro-inc/macro/pull/562
-* fix (types): deleted at must be included in project schema :( by @ehayes2000 in https://github.com/macro-inc/macro/pull/573
-* fix(iac) : infra to support bun check by @whutchinson98 in https://github.com/macro-inc/macro/pull/574
-* style(entity): style search matches, alignment fixes by @sedson in https://github.com/macro-inc/macro/pull/565
-* feat: integrate front end pretty sender into search result by @gbirman in https://github.com/macro-inc/macro/pull/571
-* fix(md): fix programmatic restore focus with checkbox bug by @sedson in https://github.com/macro-inc/macro/pull/570
-* fix: email draft issues by @peterchinman in https://github.com/macro-inc/macro/pull/566
-* style(soup): collapse email subject space when searching by @sedson in https://github.com/macro-inc/macro/pull/577
-* soup: add emailView request body param by @aquaductape in https://github.com/macro-inc/macro/pull/569
-* fix(email-service): explicitly declare optional field by @evanhutnik in https://github.com/macro-inc/macro/pull/568
-* feat(tasks): flag off task tabs in prod by @sedson in https://github.com/macro-inc/macro/pull/575
-* add [properties-fe] - navigate to thread + specific message by @danielkweon in https://github.com/macro-inc/macro/pull/580
-* fix(email-service): Get attachment document_id endpoint upload location by @evanhutnik in https://github.com/macro-inc/macro/pull/584
-* fix(iac): APNS_SANDBOX for dev by @whutchinson98 in https://github.com/macro-inc/macro/pull/588
-* feat(search): update search to use the correct uuid type by @whutchinson98 in https://github.com/macro-inc/macro/pull/579
-* feat(dcs): chat with folder backend by @ehayes2000 in https://github.com/macro-inc/macro/pull/585
-* fix [properties-fe] - hide company entity type from property creation and selection by @danielkweon in https://github.com/macro-inc/macro/pull/582
-* fix(md): plugins.useReactive util to correctly re-register plugins on reactive props by @sedson in https://github.com/macro-inc/macro/pull/587
-* feat(search): search should include searching over participants and owner of items by @whutchinson98 in https://github.com/macro-inc/macro/pull/531
-* feat (chat): chat with folder frontend by @ehayes2000 in https://github.com/macro-inc/macro/pull/586
-* chore(chat): remove ask/agent seletor by @ehayes2000 in https://github.com/macro-inc/macro/pull/572
-* fix(email-service): Upload both inline and attached email images to sfs by @evanhutnik in https://github.com/macro-inc/macro/pull/591
-* fix(email-service): Use message send times for search by @evanhutnik in https://github.com/macro-inc/macro/pull/593
-* fix(tasks): add task color to monochrome icon util by @sedson in https://github.com/macro-inc/macro/pull/596
-* feat: click search icon to focus search by @gbirman in https://github.com/macro-inc/macro/pull/578
-* feat(search): add highlight support for owner fields by @whutchinson98 in https://github.com/macro-inc/macro/pull/597
-* fix [properties-fe] - save / filter of entity type tasks by @danielkweon in https://github.com/macro-inc/macro/pull/600
-* soup: scope unified-list entity hotkeys to global by @aquaductape in https://github.com/macro-inc/macro/pull/590
-* perf(macrodb): Add email indices to improve link deletion time by @evanhutnik in https://github.com/macro-inc/macro/pull/602
-* chore(email-service): Add tests for sql queries by @evanhutnik in https://github.com/macro-inc/macro/pull/598
-* fix(email-service): Notify for new messages after attachment upload by @evanhutnik in https://github.com/macro-inc/macro/pull/608
-* fix(email-service) Handle null attachment filename during upload by @evanhutnik in https://github.com/macro-inc/macro/pull/609
-* feat(sps): use internal_date_ts for updated_at_seconds on email by @whutchinson98 in https://github.com/macro-inc/macro/pull/622
-* add [properties-be] - link parent and subtasks by @danielkweon in https://github.com/macro-inc/macro/pull/610
-* fix [properties-fe] - filter current entity from entity selection list by @danielkweon in https://github.com/macro-inc/macro/pull/615
-* add [properties-fe] - properties panel in emails by @danielkweon in https://github.com/macro-inc/macro/pull/612
-* feat(search): sort on sent_at_seconds and updated_at_seconds before score by @whutchinson98 in https://github.com/macro-inc/macro/pull/623
-* fix: no infinite soup search for query misses by @gbirman in https://github.com/macro-inc/macro/pull/605
-* fix: search has different empty state by @gbirman in https://github.com/macro-inc/macro/pull/621
-* Revert "feat(search): sort on sent_at_seconds and updated_at_seconds before score" by @whutchinson98 in https://github.com/macro-inc/macro/pull/626
-* fix: show parent project breadcrumb for folders too by @gbirman in https://github.com/macro-inc/macro/pull/607
-* chore: target descendant children svg selector for search cancel animate spin by @gbirman in https://github.com/macro-inc/macro/pull/606
-* chore: remove legacy notification email poller by @whutchinson98 in https://github.com/macro-inc/macro/pull/630
-* fix(email-service): Attachment filetype guessing logic improvement by @evanhutnik in https://github.com/macro-inc/macro/pull/628
-* feat(iac): update script for email updated_at_seconds by @whutchinson98 in https://github.com/macro-inc/macro/pull/631
-* Make viewbox aspect ratio 3:2 for all icons by @aidanhb in https://github.com/macro-inc/macro/pull/627
-* fix(email): Email compose and reply styling issues by @dev-rb in https://github.com/macro-inc/macro/pull/629
-* Feat(email): "Sent with Macro" signature for free users by @dev-rb in https://github.com/macro-inc/macro/pull/581
-* add [properties-be] - email metadata by @danielkweon in https://github.com/macro-inc/macro/pull/611
-* add [properties-fe] - properties panel in projects by @danielkweon in https://github.com/macro-inc/macro/pull/613
-* fix(styles): dialog styles, bracket fixes, share contrast, scroll container by @Fake-User in https://github.com/macro-inc/macro/pull/589
-* add [properties-be] - util for document and task isCompleted by @danielkweon in https://github.com/macro-inc/macro/pull/617
-* fix: compactify email input by @peterchinman in https://github.com/macro-inc/macro/pull/625
-* fix [email]: recipient list width bug by @peterchinman in https://github.com/macro-inc/macro/pull/620
-* fix[email]: stop email draft autofocus by @peterchinman in https://github.com/macro-inc/macro/pull/632
-* fix[email]: sending emails with appended replies by @peterchinman in https://github.com/macro-inc/macro/pull/601
-* add [properties-be] - project metadata by @danielkweon in https://github.com/macro-inc/macro/pull/614
-* fix(CimmandK): fixed corner clipping by @Fake-User in https://github.com/macro-inc/macro/pull/634
-* fix[email]: send button improvements by @peterchinman in https://github.com/macro-inc/macro/pull/638
-* fix: channels in noise tab by @peterchinman in https://github.com/macro-inc/macro/pull/639
-* chore: improve tower layers by @seanaye in https://github.com/macro-inc/macro/pull/636
-* fix(email-service): Notify search on label updates by @evanhutnik in https://github.com/macro-inc/macro/pull/635
-* fix(md): remove regex single line md in favor of lexical mutation, turn off launcher pc noise grid for now by @sedson in https://github.com/macro-inc/macro/pull/640
-* fix: channel soup scroll by @gbirman in https://github.com/macro-inc/macro/pull/644
-* fix: channel active message callout timeout directly after scroll by @gbirman in https://github.com/macro-inc/macro/pull/646
-* fix(channel): bad block name param in channel attachments by @sedson in https://github.com/macro-inc/macro/pull/645
-* fix: search invalid date by @gbirman in https://github.com/macro-inc/macro/pull/647
-* fix(email): Recipient selector losing focus on mount by @dev-rb in https://github.com/macro-inc/macro/pull/642
-* fix(ShareButton): muted styled, and use old switch statement. fix(CommandConsole): remove fts switch. by @Fake-User in https://github.com/macro-inc/macro/pull/648
-* point to new sync-service URL in prod by @cowlicks in https://github.com/macro-inc/macro/pull/595
+* fix(style): styling for homepage greeting by @aidanhb in https://github.com/macro-inc/macro/pull/3751
+* feat(crm): get_company endpoint + viewed_updated soup sort by @evanhutnik in https://github.com/macro-inc/macro/pull/3746
+* feat(email): sync profile photos for Gmail other contacts by @gbirman in https://github.com/macro-inc/macro/pull/3752
+* fix(email): move the draft to the new inbox when the sender is switched by @gbirman in https://github.com/macro-inc/macro/pull/3740
+* Mintlify Docs Edits by @mintlify[bot] in https://github.com/macro-inc/macro/pull/3754
 
 ## New Contributors
-* @cowlicks made their first contribution in https://github.com/macro-inc/macro/pull/472
+* @mintlify[bot] made their first contribution in https://github.com/macro-inc/macro/pull/3754
 
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2025.12.2.1...v2025.12.15.0
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.6.3.1...v2026.6.3.2
     </Update>
 
-    <Update label="v2025.12.2.1">
+    <Update label="v2026.6.3.1">
 ## What's Changed
-* add [properties-fe] - frontend sort component by @danielkweon in https://github.com/macro-inc/macro/pull/373
-* fix(iac): correctly grab secret string for fusionauth_client_id in notification service by @whutchinson98 in https://github.com/macro-inc/macro/pull/406
-* fix: command k tab cycle hard crash by @gbirman in https://github.com/macro-inc/macro/pull/407
-* chore(iac): bump base instance count for search service in prod by @whutchinson98 in https://github.com/macro-inc/macro/pull/409
-* unified-list: truncate unrolled channel notification message content by @aquaductape in https://github.com/macro-inc/macro/pull/412
-* fix(iac): queue alarm description by @whutchinson98 in https://github.com/macro-inc/macro/pull/413
-* feat: separate local/backend search debounce by @gbirman in https://github.com/macro-inc/macro/pull/411
-* fix: can't mark shared document as done by @dev-rb in https://github.com/macro-inc/macro/pull/415
-* fix(soup): syncservice wakeup on enity with evth mount by @sedson in https://github.com/macro-inc/macro/pull/410
-* fix(mentions): clean duped people listings by @sedson in https://github.com/macro-inc/macro/pull/417
-* feat(project-block): use dss post query to filter by project by @aquaductape in https://github.com/macro-inc/macro/pull/414
-* fix [properties-fe] - fixes for sort and display properties components by @danielkweon in https://github.com/macro-inc/macro/pull/416
-* fix: optimistically mark email thread as read by @dev-rb in https://github.com/macro-inc/macro/pull/418
-* channel scrolling fixes and styling updates by @peterchinman in https://github.com/macro-inc/macro/pull/420
-* fix: channel going blank when viewing settings modal by @dev-rb in https://github.com/macro-inc/macro/pull/423
-* feat(md): add arbitrary file upload on drop to markdown block [FRO-312] by @sedson in https://github.com/macro-inc/macro/pull/426
-* fix(soup): soup without email link by @seanaye in https://github.com/macro-inc/macro/pull/427
-* fix(soup): hide tables in soup message snippets by @sedson in https://github.com/macro-inc/macro/pull/428
-* unified-list: fix enter hotkey on tab switch and return from block by @aquaductape in https://github.com/macro-inc/macro/pull/422
+* fix(home): mobile view by @dev-rb in https://github.com/macro-inc/macro/pull/3737
+* fix(icon): render entity icons with explicit size class for Safari by @peterchinman in https://github.com/macro-inc/macro/pull/3738
+* fix: task dup detection by @ehayes2000 in https://github.com/macro-inc/macro/pull/3735
+* feat(iac): add in fusionauth idp support for google by @whutchinson98 in https://github.com/macro-inc/macro/pull/3741
+* Fix AI tools lexical client auth by @synoet in https://github.com/macro-inc/macro/pull/3742
+* fix(style): Update email disconnected and AI empty state by @aidanhb in https://github.com/macro-inc/macro/pull/3744
+* fix: task dedup frontend fixes by @ehayes2000 in https://github.com/macro-inc/macro/pull/3745
+* feat(github): update foreign entity when github pr is enriched by @whutchinson98 in https://github.com/macro-inc/macro/pull/3743
+* fix(gmail): broken email links by @whutchinson98 in https://github.com/macro-inc/macro/pull/3747
+* fix: add env var to dss by @ehayes2000 in https://github.com/macro-inc/macro/pull/3749
 
 
-**Full Changelog**: https://github.com/macro-inc/macro/compare/v2025.12.2.0...v2025.12.2.1
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.6.3.0...v2026.6.3.1
     </Update>
 
-    <Update label="v2025.12.2.0">
+    <Update label="v2026.6.3.0">
 ## What's Changed
-* fix(ci): add in bunfig.toml creation to setup-reqs-web action by @whutchinson98 in https://github.com/macro-inc/macro/pull/361
-* feat(soup): email filters by @seanaye in https://github.com/macro-inc/macro/pull/354
-* fix(ci): add in SEGMENT_WRITE_KEY to env vars through github workflow by @whutchinson98 in https://github.com/macro-inc/macro/pull/362
-* chore: bump brace-expansion to address CVE by @whutchinson98 in https://github.com/macro-inc/macro/pull/363
-* chore: bump vite to address CVE by @whutchinson98 in https://github.com/macro-inc/macro/pull/364
-* chore: bump js-yaml to address CVE by @whutchinson98 in https://github.com/macro-inc/macro/pull/365
-* fix(ci): correctly provide NPMRC_GH_TOKEN secret by @whutchinson98 in https://github.com/macro-inc/macro/pull/367
-* fix(pagination): limit after sort by @seanaye in https://github.com/macro-inc/macro/pull/368
-* fix(notifications): missing check for notification permission explicitly denied by @synoet in https://github.com/macro-inc/macro/pull/374
-* feat(notifications): handle on click for browser notifications by @synoet in https://github.com/macro-inc/macro/pull/357
-* feat(iac): add queue approxiate age of oldest message alarm by @whutchinson98 in https://github.com/macro-inc/macro/pull/375
-* feat: send token to services ws by @gbirman in https://github.com/macro-inc/macro/pull/335
-* fix(ci): use correct AWS secrets by @whutchinson98 in https://github.com/macro-inc/macro/pull/377
-* refactor(ci): refactor aws key names in ci workflows by @whutchinson98 in https://github.com/macro-inc/macro/pull/381
-* add [properties-fe] - improve display property pills styling to match sort property pill by @danielkweon in https://github.com/macro-inc/macro/pull/372
-* fix(email): properly set the sender on email notification by @synoet in https://github.com/macro-inc/macro/pull/378
-* chore(md): move instructions editor to own file by @sedson in https://github.com/macro-inc/macro/pull/380
-* fix(email-service): Filter out drafts for shared threads by @evanhutnik in https://github.com/macro-inc/macro/pull/370
-* chore(ci): improve testing by @seanaye in https://github.com/macro-inc/macro/pull/355
-* fix(iac): queue alarms by @whutchinson98 in https://github.com/macro-inc/macro/pull/383
-* feat: mark email done on send by @peterchinman in https://github.com/macro-inc/macro/pull/339
-* fix(ci): cargo test improvements by @whutchinson98 in https://github.com/macro-inc/macro/pull/382
-* feat (ai): auto attach emails by @ehayes2000 in https://github.com/macro-inc/macro/pull/379
-* chore(notifications): unify notification setting and persisted signal logic by @synoet in https://github.com/macro-inc/macro/pull/384
-* fix: sender field for soup emails falls back to email address by @peterchinman in https://github.com/macro-inc/macro/pull/385
-* add [properties-fe] - display properties as chips on row by @danielkweon in https://github.com/macro-inc/macro/pull/376
-* add [properties-fe] - display properties as chips on row compact view by @danielkweon in https://github.com/macro-inc/macro/pull/371
-* Revert "feat: send token to services ws (#335)" by @gbirman in https://github.com/macro-inc/macro/pull/386
-* chg(dock): swap new split icon, fix swapped preview mode tooltip by @sedson in https://github.com/macro-inc/macro/pull/387
-* feat(layout): support component typed meta for discriminating by @synoet in https://github.com/macro-inc/macro/pull/388
-* fix: dedupe email senders names by @peterchinman in https://github.com/macro-inc/macro/pull/389
-* inbox view: fix mark_as_done optimistic update by @aquaductape in https://github.com/macro-inc/macro/pull/393
-* fix(email): need to call init always to set link by @synoet in https://github.com/macro-inc/macro/pull/392
-* fix(notifications): notifications should focus on click and close by @synoet in https://github.com/macro-inc/macro/pull/395
-* chore: add third party licenses by @synoet in https://github.com/macro-inc/macro/pull/397
-* fix: correctly handle display name when user is only participant in email by @peterchinman in https://github.com/macro-inc/macro/pull/396
-* feat: email search linking by @gbirman in https://github.com/macro-inc/macro/pull/394
-* fix: Unable to create thread for message with deleted reply by @dev-rb in https://github.com/macro-inc/macro/pull/401
-* chore: better readme by @synoet in https://github.com/macro-inc/macro/pull/400
-* Gab/m 5245 close empty channel reply input on blur by @gbirman in https://github.com/macro-inc/macro/pull/402
-* fix(md): strange click handling in checklists [M-5311] by @sedson in https://github.com/macro-inc/macro/pull/403
-* fix(history): filter deleted items from command and mentions menus by @sedson in https://github.com/macro-inc/macro/pull/404
-* feat(email-service): Retry queue for webhook pubsub processing by @evanhutnik in https://github.com/macro-inc/macro/pull/390
+* feat(email): pick the from-inbox in the composer/reply input by @gbirman in https://github.com/macro-inc/macro/pull/3726
+* fix(graphic): make task empty state graphic more legible by @aidanhb in https://github.com/macro-inc/macro/pull/3732
+* fix(email): scope recipient self-exclusion to the active sending inbox by @gbirman in https://github.com/macro-inc/macro/pull/3731
+* feat(email): support replying from a different inbox than the thread's by @gbirman in https://github.com/macro-inc/macro/pull/3733
+* feat(email): allow changing the from-inbox when replying by @gbirman in https://github.com/macro-inc/macro/pull/3734
+* feat(home): new home view by @dev-rb in https://github.com/macro-inc/macro/pull/3730
+* chore(calls): flag off  sidebar active calls widget by @synoet in https://github.com/macro-inc/macro/pull/3736
 
-## New Contributors
-* @dev-rb made their first contribution in https://github.com/macro-inc/macro/pull/401
 
-**Full Changelog**: https://github.com/macro-inc/macro/commits/v2025.12.2.0
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.6.2.2...v2026.6.3.0
+    </Update>
+
+    <Update label="v2026.6.2.2">
+## What's Changed
+* feat(github): BE setup check for reauth with github by @whutchinson98 in https://github.com/macro-inc/macro/pull/3705
+* fix(ai): disambiguate inboxes by @ehayes2000 in https://github.com/macro-inc/macro/pull/3704
+* feat(soup): bind collapse/expand hotkeys to group-by sections by @gbirman in https://github.com/macro-inc/macro/pull/3707
+* fix(email): dedupe team-member thread copies in CRM-scoped queries by @evanhutnik in https://github.com/macro-inc/macro/pull/3709
+* feat(github): reauthenticate github toast by @whutchinson98 in https://github.com/macro-inc/macro/pull/3706
+* feat(github): rollback browser and push notifs by @whutchinson98 in https://github.com/macro-inc/macro/pull/3711
+* feat(email): union read endpoints across linked inboxes; single-inbox writes via X-Email-Link-Id by @gbirman in https://github.com/macro-inc/macro/pull/3685
+* feat(email): send X-Email-Link-Id on compose/reply mutations for non-primary inboxes by @gbirman in https://github.com/macro-inc/macro/pull/3689
+* feat(teams): move github app installation to team on team creation by @whutchinson98 in https://github.com/macro-inc/macro/pull/3712
+* feat(teams): delete team github app association on team delete by @whutchinson98 in https://github.com/macro-inc/macro/pull/3713
+* fix(user-card): fix dm btn, style user card and document preview popovers by @sedson in https://github.com/macro-inc/macro/pull/3701
+* feat(calls): improve incoming call ux - active calls area, better waiting screen, active call message by @sedson in https://github.com/macro-inc/macro/pull/3710
+* feat(github): include foreign entity id in github pr preview by @whutchinson98 in https://github.com/macro-inc/macro/pull/3715
+* seamus/macro-1614-tool-call-follow-ups by @sedson in https://github.com/macro-inc/macro/pull/3718
+* feat(email): support shared/delegated inboxes across reads and writes by @gbirman in https://github.com/macro-inc/macro/pull/3717
+* feat(icon): add company and contact icons by @aidanhb in https://github.com/macro-inc/macro/pull/3719
+* fix(icon): refine animated company icon by @aidanhb in https://github.com/macro-inc/macro/pull/3720
+* feat(channels): ai in channels by @synoet in https://github.com/macro-inc/macro/pull/3692
+* chore(lexical): bump lexical schema version by @synoet in https://github.com/macro-inc/macro/pull/3724
+* fix(tauri): bundle updater fixes by @peterchinman in https://github.com/macro-inc/macro/pull/3714
+* fix(loader): add smoother loader animation by @aidanhb in https://github.com/macro-inc/macro/pull/3722
+* fix(email): compose/reply resolves the inbox from the thread, not links[0] by @gbirman in https://github.com/macro-inc/macro/pull/3723
+* fix(compose): capture handle escape for date picker - fixes focus bug by @sedson in https://github.com/macro-inc/macro/pull/3721
+* fix(icon): Add new files icon and swap it into the unified filter dropdown by @aidanhb in https://github.com/macro-inc/macro/pull/3725
+* fix: agent tools env by @synoet in https://github.com/macro-inc/macro/pull/3728
+* feat(channels/mentions): boost agent in mentions by @synoet in https://github.com/macro-inc/macro/pull/3729
+* feat(crm): integrate CRM companies and contacts into entity_access by @evanhutnik in https://github.com/macro-inc/macro/pull/3727
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.6.2.1...v2026.6.2.2
+    </Update>
+
+    <Update label="v2026.6.2.1">
+## What's Changed
+* chore: flag task dedup by @ehayes2000 in https://github.com/macro-inc/macro/pull/3700
+* feat(ci): Improve release workflow by @whutchinson98 in https://github.com/macro-inc/macro/pull/3702
+* fix(onboarding): don't navigate the real app from the sandbox command menu by @synoet in https://github.com/macro-inc/macro/pull/3703
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.6.2.0...v2026.6.2.1
+    </Update>
+
+    <Update label="v2026.6.2.0">
+## What's Changed
+* chg(local): restyle just run_local by @synoet in https://github.com/macro-inc/macro/pull/3696
+* style(ai): restyle tool calls by @sedson in https://github.com/macro-inc/macro/pull/3694
+* fix(onboarding): keep focus on tutorial shell so hotkeys work immediately by @synoet in https://github.com/macro-inc/macro/pull/3698
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.6.1.0...v2026.6.2.0
+    </Update>
+
+    <Update label="v2026.6.1.0">
+## What's Changed
+* fix(auth): key gmail token cache by linked email, not macro_id by @gbirman in https://github.com/macro-inc/macro/pull/3640
+* feat(foreign_entity): add foreign entity to soup by @whutchinson98 in https://github.com/macro-inc/macro/pull/3626
+* style(topbar): update sort/filter icons and spacing by @sedson in https://github.com/macro-inc/macro/pull/3642
+* fix(md): remove jank legacy jk handlers from md block to fix focus bug by @sedson in https://github.com/macro-inc/macro/pull/3643
+* style(md): tweak vertical spacing in main markdown theme by @sedson in https://github.com/macro-inc/macro/pull/3645
+* feat(entity_access): update entity access to support foreign entities by @whutchinson98 in https://github.com/macro-inc/macro/pull/3644
+* fix(projects): j/k navigation not working by @dev-rb in https://github.com/macro-inc/macro/pull/3648
+* feat(soup): add crm_company entity type to soup feed by @evanhutnik in https://github.com/macro-inc/macro/pull/3523
+* feat(foreign_entity): create router and wire to dss by @whutchinson98 in https://github.com/macro-inc/macro/pull/3646
+* feat(bots): Sender, Bots, Channel Bots by @synoet in https://github.com/macro-inc/macro/pull/3647
+* feat(github): store comments and status checks by @whutchinson98 in https://github.com/macro-inc/macro/pull/3649
+* chore: remove legacy comms_service and comm_db_client code by @synoet in https://github.com/macro-inc/macro/pull/3641
+* fix(md): un-brick vertical margin changes for empty states by @sedson in https://github.com/macro-inc/macro/pull/3652
+* feat(channels): parallelize queries in attachment references by @synoet in https://github.com/macro-inc/macro/pull/3654
+* fix(soup): paginate crm_companies past the cursor by @evanhutnik in https://github.com/macro-inc/macro/pull/3651
+* chore(onboarding): Remove onboarding and welcome route by @dev-rb in https://github.com/macro-inc/macro/pull/3650
+* fix(references): use tanstack query for attachment references by @synoet in https://github.com/macro-inc/macro/pull/3655
+* feat(crm): filter companies by hidden, admin-gated in soup by @evanhutnik in https://github.com/macro-inc/macro/pull/3657
+* fix(mobile): auto-update ux by @peterchinman in https://github.com/macro-inc/macro/pull/3656
+* fix(md): format tools - add active variant to active styles by @sedson in https://github.com/macro-inc/macro/pull/3659
+* feat(soup): multi-inbox support via link_ids and Owner literal by @gbirman in https://github.com/macro-inc/macro/pull/3636
+* fix: mcp tool rendering by @ehayes2000 in https://github.com/macro-inc/macro/pull/3660
+* fix(mentions): keep intra-channel mention navigation in place on mobile by @peterchinman in https://github.com/macro-inc/macro/pull/3592
+* fix: give floating channel timestamp a solid bg-panel background by @peterchinman in https://github.com/macro-inc/macro/pull/3632
+* fix(sidepanel): fix no scroll on sidepanel mobile layout by @sedson in https://github.com/macro-inc/macro/pull/3662
+* feat(onboarding): tutorial modal by @dev-rb in https://github.com/macro-inc/macro/pull/3664
+* feat(style): improve empty state styling by @aidanhb in https://github.com/macro-inc/macro/pull/3665
+* feat(crm): Apollo.io company enrichment behind a flag by @evanhutnik in https://github.com/macro-inc/macro/pull/3666
+* Replace Business Source License with GNU AGPLv3 and update README by @jbecke in https://github.com/macro-inc/macro/pull/3669
+* feat(tasks): call wakeup for task entity by @synoet in https://github.com/macro-inc/macro/pull/3671
+* feat: duplicate task detection by @ehayes2000 in https://github.com/macro-inc/macro/pull/3635
+* fix (ai): scheduled agent goofy rendering by @ehayes2000 in https://github.com/macro-inc/macro/pull/3672
+* feat(github): backfill open prs when sync app is installed by @whutchinson98 in https://github.com/macro-inc/macro/pull/3675
+* chore(channels): remove organization channel type by @whutchinson98 in https://github.com/macro-inc/macro/pull/3674
+* refactor(sidepanel): make md properties sidepanel generic by @sedson in https://github.com/macro-inc/macro/pull/3677
+* fix(onboarding): state not resetting by @dev-rb in https://github.com/macro-inc/macro/pull/3676
+* fix(onboarding): don't call router prims outside router by @synoet in https://github.com/macro-inc/macro/pull/3673
+* feat(email): per-inbox management in multi-inbox settings by @gbirman in https://github.com/macro-inc/macro/pull/3661
+* fix(comms): update attachments fixture for removed organization channel type by @ehayes2000 in https://github.com/macro-inc/macro/pull/3680
+* fix(email): gate per-inbox sync status label behind feature flag by @gbirman in https://github.com/macro-inc/macro/pull/3681
+* fix(comments): pending send signal to disallow dupe comment send by @sedson in https://github.com/macro-inc/macro/pull/3679
+* fix(tauri): decouple debug assertions from environment by @peterchinman in https://github.com/macro-inc/macro/pull/3682
+* fix: task dedup by @ehayes2000 in https://github.com/macro-inc/macro/pull/3678
+* feat(email): add sidepanel to email block, tweak sidepanel components by @sedson in https://github.com/macro-inc/macro/pull/3683
+* feat(github): github pr notifications by @whutchinson98 in https://github.com/macro-inc/macro/pull/3686
+* fix: make image work by @ehayes2000 in https://github.com/macro-inc/macro/pull/3687
+* fix(channels): exclude removed participants from channel recipient queries by @synoet in https://github.com/macro-inc/macro/pull/3670
+* chg(local:) use RUST_LOG='info' locally by @synoet in https://github.com/macro-inc/macro/pull/3691
+* feat(crm): contact GET, soft-hide cascade, visibility-only sync by @evanhutnik in https://github.com/macro-inc/macro/pull/3690
+* fix(onboarding): not marked as complete on close, skip should close by @dev-rb in https://github.com/macro-inc/macro/pull/3693
+* chg(local): setup localstack on just run_local, make localstack setup idempotent by @synoet in https://github.com/macro-inc/macro/pull/3695
+
+
+**Full Changelog**: https://github.com/macro-inc/macro/compare/v2026.5.28.0...v2026.6.1.0
     </Update>

--- a/docs/concepts/blocks.mdx
+++ b/docs/concepts/blocks.mdx
@@ -16,7 +16,7 @@ Each split maintains its own history. Use <kbd>opt</kbd> <kbd>\[</kbd> or <kbd>o
 Create a split with <kbd>cmd</kbd>\+<kbd>\\</kbd>, focus left/right with <kbd>shift</kbd>\+<kbd>h</kbd> / <kbd>shift</kbd>\+<kbd>l</kbd>, maximize with <kbd>shift</kbd>\+<kbd>escape</kbd>, close with <kbd>cmd</kbd>\+<kbd>escape</kbd>.
 
 <Frame>
-  ![Screenshot 2026 06 09 At 4 49 29 PM](/images/Screenshot-2026-06-09-at-4.49.29-PM.png)
+  ![Multiple splits open side by side in a single Macro tab](/images/Screenshot-2026-06-09-at-4.49.29-PM.png)
 </Frame>
 
 The number of splits you can have open at once is determined by your monitor size and zoom. If there isn't room for another split, the new one replaces the rightmost split.
@@ -28,8 +28,8 @@ Most block types have on-hover previews to provide context without needing to cl
 <Frame>
   <img
     src="/images/Screenshot-2026-06-09-at-4.49.50-PM.png"
-    alt="Screenshot 2026 06 09 At 4 49 50 PM"
-    title="Screenshot 2026 06 09 At 4 49 50 PM"
+    alt="A hover preview of a task mention showing the task's status and details"
+    title="Task hover preview"
     className="mx-auto"
     style={{ width:"81%" }}
   />
@@ -40,7 +40,7 @@ Most block types have on-hover previews to provide context without needing to cl
 Most blocks embed read-only in a markdown doc, with editing and markup tools disabled. Note that, unlike mentioning docs in channels — where permissions are automatically granted to members of the channel — permissions are not auto-granted for embeds or mentions in documents. You'll have to also share the files you embed.
 
 <Frame>
-  ![Screenshot 2026 06 09 At 4 50 07 PM](/images/Screenshot-2026-06-09-at-4.50.07-PM.png)
+  ![A block embedded read-only inside a markdown document](/images/Screenshot-2026-06-09-at-4.50.07-PM.png)
 </Frame>
 
 To create an embed, first create an @mention by hitting `@` or dragging and dropping, then hover and click **Convert to embed**.
@@ -48,8 +48,8 @@ To create an embed, first create an @mention by hitting `@` or dragging and drop
 <Frame>
   <img
     src="/images/Screenshot-2026-06-09-at-4.50.18-PM.png"
-    alt="Screenshot 2026 06 09 At 4 50 18 PM"
-    title="Screenshot 2026 06 09 At 4 50 18 PM"
+    alt="The Convert to embed option shown when hovering an @mention"
+    title="Convert to embed"
     className="mx-auto"
     style={{ width:"59%" }}
   />
@@ -58,5 +58,5 @@ To create an embed, first create an @mention by hitting `@` or dragging and drop
 ## More about blocks
 
 - **References, sharing & permissions** — Every block has a References panel (backlinks to everywhere it's mentioned or embedded) and the same share dialog, with owner / editor / commenter / viewer access levels plus public links for documents.
-- **Real-time collaboration** — Collaborative blocks (docs, canvas, pdf markup) sync through **Loro CRDTs** over a **Cloudflare Durable Objects** backend: the Rust `sync-service` spins up one Durable Object "room" per document, and clients connect over WebSocket to `/document/:id`. This is what gives you multiplayer editing, presence cursors, and full offline support.
+- **Real-time collaboration** — Collaborative blocks (docs, pdf markup) sync through **Loro CRDTs** over a **Cloudflare Durable Objects** backend: the Rust `sync-service` spins up one Durable Object "room" per document, and clients connect over WebSocket to `/document/:id`. This is what gives you multiplayer editing, presence cursors, and full offline support.
 - **Search & Inbox** — One unified [Search](/product/search) index covers every block type, filterable by type and by mentioned person. The unified [Inbox](/product/inbox) pulls open notifications from across blocks into a single recency-sorted list.

--- a/docs/concepts/mentions.mdx
+++ b/docs/concepts/mentions.mdx
@@ -8,8 +8,8 @@ Mentions are the connective tissue of the workspace. Typing `@` in any rich-text
 <Frame>
   <img
     src="/images/Screenshot-2026-06-09-at-4.26.45-PM.png"
-    alt="Screenshot 2026 06 09 At 4 26 45 PM"
-    title="Screenshot 2026 06 09 At 4 26 45 PM"
+    alt="The @mention autocomplete menu open in a rich-text editor"
+    title="Mention autocomplete"
     className="mx-auto"
     style={{ width:"57%" }}
   />
@@ -20,7 +20,7 @@ Mentions are the connective tissue of the workspace. Typing `@` in any rich-text
 Mentioning entities to AI agents inserts a pointer so the AI can read the docs. In the case of markdown docs, the agent can also read images embedded in the doc. Your agents inherit the permissions you have. If you try and give an agent a doc/entity that you don't have access to, your agents won't have access either, and your agent will tell you as much.
 
 <Frame>
-  ![Screenshot 2026 06 09 At 3 59 21 PM](/images/Screenshot-2026-06-09-at-3.59.21-PM.png)
+  ![Mentioning a document in an agent chat to give the agent context](/images/Screenshot-2026-06-09-at-3.59.21-PM.png)
 </Frame>
 
 You don't _need to_ mention entities to agents. Since your agent has access to the search tool and list tool, it can find things in your workspace for itself. We recommend mentioning entities when you already know what the agent should look at — it skips a round of searching and guarantees the right context.
@@ -30,7 +30,7 @@ You don't _need to_ mention entities to agents. Since your agent has access to t
 The primary benefit of using Macro instead of Slack is that it is deeply linked to the rest of your workspace. Just mention any entity type and hit enter to insert an `@mention`. When you hit enter or press the send button, the item is shared with members of the channel. This avoids the footgun that can happen with Slack\+Notion, Slack\+Drive, etc., where you don't give the permissions and people need to ask "hey can you share \_\_ with me?"
 
 <Frame>
-  ![Screenshot 2026 06 09 At 3 59 41 PM](/images/Screenshot-2026-06-09-at-3.59.41-PM.png)
+  ![A document @mentioned in a channel message, shared with channel members](/images/Screenshot-2026-06-09-at-3.59.41-PM.png)
 </Frame>
 
 **When people are added or removed from a channel, permissions to shared items flow through accordingly.** This is really helpful when somebody joins or leaves your company, so they already have access to everything they need. This is why we recommend using Channels for each team, so that permissions for all entities your team needs are handled automatically.
@@ -38,8 +38,8 @@ The primary benefit of using Macro instead of Slack is that it is deeply linked 
 <Frame>
   <img
     src="/images/Screenshot-2026-06-09-at-4.00.02-PM.png"
-    alt="Screenshot 2026 06 09 At 4 00 02 PM"
-    title="Screenshot 2026 06 09 At 4 00 02 PM"
+    alt="A channel's participants list, which controls access to everything shared in it"
+    title="Channel participants"
     className="mx-auto"
     style={{ width:"32%" }}
   />
@@ -52,7 +52,7 @@ When you mention a document or file in a channel, a bidirectional link is create
 Mentioning people causes them to be added to cc on the email thread.
 
 <Frame>
-  ![Screenshot 2026 06 09 At 4 00 50 PM](/images/Screenshot-2026-06-09-at-4.00.50-PM.png)
+  ![An @mentioned person being added as a recipient on an email](/images/Screenshot-2026-06-09-at-4.00.50-PM.png)
 </Frame>
 
 The auto-sharing that happens when you mention in channels doesn't happen in email: because email chains can be forwarded and people added, the list of people who might need access isn't known in advance or traceable over time. Thus, you'll need to manually ensure that the recipients of your mentions in email are able to access your link. When you hit send, the @mention will appear as a plain hyperlink in other email clients.
@@ -64,8 +64,8 @@ Mentioning documents in documents is one of the fundamental ways your workspace 
 <Frame>
   <img
     src="/images/Screenshot-2026-06-09-at-4.02.53-PM.png"
-    alt="Screenshot 2026 06 09 At 4 02 53 PM"
-    title="Screenshot 2026 06 09 At 4 02 53 PM"
+    alt="A document mentioning another document as an inline pill"
+    title="Document mentions"
     className="mx-auto"
     style={{ width:"85%" }}
   />
@@ -76,7 +76,7 @@ Mentioning documents in documents is one of the fundamental ways your workspace 
 Use canvases to embed other entities on a 2D plane. This is useful for mind-mapping, technical diagrams linking to tasks, project management, or just storing/grouping files visually.
 
 <Frame>
-  ![Screenshot 2026 06 09 At 4 05 22 PM](/images/Screenshot-2026-06-09-at-4.05.22-PM.png)
+  ![A canvas with workspace blocks embedded and connected on a 2D plane](/images/Screenshot-2026-06-09-at-4.05.22-PM.png)
 </Frame>
 
 ## What happens when you mention...

--- a/docs/concepts/properties.mdx
+++ b/docs/concepts/properties.mdx
@@ -8,8 +8,8 @@ Properties are Macro's unified system for attaching structured fields to entitie
 <Frame>
   <img
     src="/images/Screenshot-2026-06-09-at-4.24.24-PM.png"
-    alt="Screenshot 2026 06 09 At 4 24 24 PM"
-    title="Screenshot 2026 06 09 At 4 24 24 PM"
+    alt="The properties card on a task showing Status, Priority, and Assignees"
+    title="Task properties"
     className="mx-auto"
     style={{ width:"71%" }}
   />
@@ -18,7 +18,7 @@ Properties are Macro's unified system for attaching structured fields to entitie
 On tasks, the default properties of Status, Priority and Assignees are visible in this card on the right. To add additional properties click `Add property`.
 
 <Frame>
-  ![Screenshot 2026 06 09 At 4 25 31 PM](/images/Screenshot-2026-06-09-at-4.25.31-PM.png)
+  ![The Add property menu listing available property types](/images/Screenshot-2026-06-09-at-4.25.31-PM.png)
 </Frame>
 
 ## Supported types

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -26,6 +26,9 @@
         "tab": "Documentation",
         "pages": [
           "index",
+          "getting-started",
+          "switch-to-macro",
+          "apps",
           {
             "group": "Features",
             "pages": [
@@ -40,10 +43,12 @@
               "product/agents",
               "product/email",
               "product/docs",
+              "product/canvas",
               "product/tasks",
               "product/channels",
               "product/calls",
-              "product/folders"
+              "product/folders",
+              "product/crm"
             ]
           },
           {
@@ -58,6 +63,7 @@
           {
             "group": "Agents",
             "pages": [
+              "AI/recipes",
               "AI/mcp/overview",
               {
                 "group": "Tool Reference",
@@ -89,6 +95,14 @@
               "integrations/github"
             ]
           },
+          {
+            "group": "Account",
+            "pages": [
+              "account/teams",
+              "account/billing"
+            ]
+          },
+          "support",
           "faq",
           "keyboard-shortcuts"
         ]
@@ -100,6 +114,22 @@
             "group": "Releases",
             "pages": [
               "changelog/introduction"
+            ]
+          },
+          {
+            "group": "2026",
+            "pages": [
+              "changelog/2026-05",
+              "changelog/2026-04",
+              "changelog/2026-03",
+              "changelog/2026-02",
+              "changelog/2026-01"
+            ]
+          },
+          {
+            "group": "2025",
+            "pages": [
+              "changelog/2025-12"
             ]
           }
         ]

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Frequently Asked Questions"
+description: "How Macro compares to Notion, Superhuman, and Slack — plus licensing, self-hosting, teams, and data questions."
 ---
 
 <AccordionGroup>

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -1,0 +1,82 @@
+---
+title: "Getting started"
+description: "Set up Macro and learn the core workflow in about 15 minutes."
+---
+
+Macro replaces the pile of tabs — email, chat, tasks, docs, calls — with one fast, keyboard-driven workspace. This guide takes you from a fresh account to a working setup.
+
+<Card title="Prefer a guided tour?" icon="calendar" href="https://cal.com/team/macro/macro-demo-call">
+  Book a live onboarding call and a member of our team will walk you through setup and answer questions.
+</Card>
+
+## 1. Connect your email
+
+Macro is an email client, not an email server — it syncs with your existing Gmail or Google Workspace account. We recommend connecting your account during signup so your inbox is ready from the first minute.
+
+Have more than one address? Add additional Gmail or Google Workspace accounts in **Settings**, and they all flow into a [single unified inbox](/product/email#multi-account-inbox). When you compose, you choose which address to send from.
+
+<Note>
+  Outlook and custom IMAP/SMTP support are planned. See the [FAQ](/faq) for details.
+</Note>
+
+## 2. Learn five keys
+
+Macro is built keyboard-first. These five get you most of the way:
+
+| Key | What it does |
+| --- | --- |
+| <kbd>c</kbd> | Open the create launcher — then <kbd>d</kbd> for a doc, <kbd>t</kbd> for a task, <kbd>e</kbd> for an email, <kbd>m</kbd> for a message, <kbd>a</kbd> for an AI chat |
+| <kbd>cmd</kbd>+<kbd>k</kbd> | Command menu — jump to anything by name |
+| <kbd>/</kbd> | [Unified search](/product/search) across email, docs, tasks, messages, calls, and files |
+| <kbd>j</kbd> / <kbd>k</kbd> | Move down / up in any list |
+| <kbd>e</kbd> | Mark done — archive an email, clear an inbox item |
+
+The full list lives in [Keyboard shortcuts](/keyboard-shortcuts).
+
+## 3. Triage from one inbox
+
+Press <kbd>g</kbd> + <kbd>i</kbd> to open the [unified inbox](/product/inbox) — the one place to check instead of seven apps. Emails, channel messages, task assignments, @mentions, and agent responses all land here, split into **Signal** (needs your attention) and **Noise** (everything else).
+
+Work the list with <kbd>j</kbd> / <kbd>k</kbd>, preview with <kbd>space</kbd>, and clear items with <kbd>e</kbd>. The list shrinks as you go.
+
+## 4. Open work side by side
+
+Macro has its own window manager. Press <kbd>cmd</kbd>+<kbd>\\</kbd> to create a *split*, and <kbd>shift</kbd>+<kbd>enter</kbd> to open any list item or @mention in a new split — your inbox on the left, the doc someone sent you on the right. Move focus with <kbd>shift</kbd>+<kbd>h</kbd> / <kbd>shift</kbd>+<kbd>l</kbd>, maximize with <kbd>shift</kbd>+<kbd>escape</kbd>. More in [Blocks](/concepts/blocks#splits).
+
+## 5. Create a team
+
+Click **Team** in the bottom left to create one. Teams unlock the collaborative layer:
+
+- **Auto-sharing** — tasks are visible to the whole team, and calls are recorded, transcribed, and shared by default. No "can you share that with me?" requests.
+- **[Team memory](/product/unified-memory)** — agents remember what your whole team is doing across email, messages, tasks, docs, and calls, not just your own chats.
+
+Then create a [channel](/product/channels) per team or project (<kbd>c</kbd> + <kbd>m</kbd>). Channels are also how [permissions](/permissions) work in Macro: anything you @mention in a channel is automatically shared with its members, and access follows people as they join or leave. You can add anyone by email, even if they don't have a Macro account yet.
+
+## 6. Put the agent to work
+
+Press <kbd>c</kbd> + <kbd>a</kbd> to start a chat with an [agent](/product/agents) that has access to your entire workspace — ask "what's the latest on the launch?" and it answers from your team's recent emails, messages, tasks, docs, and call transcripts. In any channel, mention **@Macro** to pull an agent into the conversation.
+
+You can also set up [automations](/product/agents#automations) — scheduled agent runs like a daily to-do summary delivered to your inbox.
+
+## 7. Connect your tools
+
+- **GitHub** — link your account in **Settings** under **Account**, and tasks move to In Progress → In Review → Done as you branch, open PRs, and merge. See [GitHub integration](/integrations/github).
+- **MCP connectors** — connect Notion, Slack, and other tools under **Settings → Connectors** so agents can reach them. Migrating off one of them? See [Switch to Macro](/switch-to-macro).
+- **Your coding agents** — point Claude Code, Codex, or any MCP client at your Macro workspace. See [MCP setup](/AI/mcp/overview).
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Watch the demo" icon="play" href="https://www.youtube.com/watch?v=Fn5hdzXsQQ8">
+    A full walkthrough of Macro's core features in one video.
+  </Card>
+  <Card title="Key concepts" icon="cubes" href="/concepts/blocks">
+    Blocks, mentions, and properties — the primitives everything is built from.
+  </Card>
+  <Card title="Keyboard shortcuts" icon="keyboard" href="/keyboard-shortcuts">
+    The complete reference for working at full speed.
+  </Card>
+  <Card title="FAQ" icon="circle-question" href="/faq">
+    Licensing, self-hosting, comparisons, and how Macro fits your stack.
+  </Card>
+</CardGroup>

--- a/docs/images/channel-sharing-diagram.svg
+++ b/docs/images/channel-sharing-diagram.svg
@@ -1,0 +1,68 @@
+<svg viewBox="0 0 760 400" xmlns="http://www.w3.org/2000/svg" font-family="ui-sans-serif, -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif">
+  <rect x="0" y="0" width="760" height="400" fill="#090909"/>
+
+  <!-- channel panel -->
+  <rect x="40" y="40" width="290" height="240" rx="14" fill="#121212" stroke="#2e2e2e"/>
+  <text x="64" y="76" fill="#ffffff" font-size="15" font-weight="600">#design</text>
+
+  <!-- members -->
+  <g font-size="11" text-anchor="middle">
+    <circle cx="244" cy="71" r="13" fill="#27272a" stroke="#3f3f46"/>
+    <text x="244" y="75" fill="#e8e8e8">A</text>
+    <circle cx="272" cy="71" r="13" fill="#27272a" stroke="#3f3f46"/>
+    <text x="272" y="75" fill="#e8e8e8">B</text>
+    <circle cx="300" cy="71" r="13" fill="#27272a" stroke="#3f3f46"/>
+    <text x="300" y="75" fill="#e8e8e8">C</text>
+  </g>
+  <line x1="56" y1="94" x2="314" y2="94" stroke="#242424"/>
+
+  <!-- message with mention -->
+  <rect x="64" y="116" width="242" height="64" rx="10" fill="#1a1a1a" stroke="#2e2e2e"/>
+  <text x="80" y="140" fill="#9a9a9a" font-size="12">Ana</text>
+  <text x="80" y="162" fill="#e8e8e8" font-size="13">latest spec is in</text>
+  <rect x="183" y="148" width="106" height="20" rx="6" fill="#241606" stroke="#ff8f05" stroke-width="0.75"/>
+  <text x="236" y="162" fill="#ff8f05" font-size="12" text-anchor="middle">@ Spec v2</text>
+
+  <text x="64" y="216" fill="#6f6f6f" font-size="12">mentioning a doc in the channel</text>
+  <text x="64" y="234" fill="#6f6f6f" font-size="12">shares it with every member</text>
+
+  <!-- arrow channel -> doc -->
+  <path d="M 330 158 C 380 158, 390 158, 438 158" stroke="#ff8f05" stroke-width="1.5" fill="none"/>
+  <path d="M 438 158 l -9 -5 v 10 z" fill="#ff8f05"/>
+  <text x="384" y="144" fill="#9a9a9a" font-size="12" text-anchor="middle">auto-shared</text>
+
+  <!-- doc card -->
+  <rect x="446" y="92" width="274" height="132" rx="14" fill="#121212" stroke="#2e2e2e"/>
+  <rect x="470" y="116" width="30" height="38" rx="4" fill="#1a1a1a" stroke="#3f3f46"/>
+  <line x1="476" y1="127" x2="494" y2="127" stroke="#5a5a5a"/>
+  <line x1="476" y1="135" x2="494" y2="135" stroke="#5a5a5a"/>
+  <line x1="476" y1="143" x2="488" y2="143" stroke="#5a5a5a"/>
+  <text x="514" y="130" fill="#ffffff" font-size="15" font-weight="600">Spec v2</text>
+  <text x="514" y="150" fill="#9a9a9a" font-size="12">document</text>
+  <g font-size="11" text-anchor="middle">
+    <circle cx="483" cy="190" r="13" fill="#27272a" stroke="#3f3f46"/>
+    <text x="483" y="194" fill="#e8e8e8">A</text>
+    <circle cx="511" cy="190" r="13" fill="#27272a" stroke="#3f3f46"/>
+    <text x="511" y="194" fill="#e8e8e8">B</text>
+    <circle cx="539" cy="190" r="13" fill="#27272a" stroke="#3f3f46"/>
+    <text x="539" y="194" fill="#e8e8e8">C</text>
+  </g>
+  <text x="564" y="194" fill="#9a9a9a" font-size="12">can all open it</text>
+
+  <!-- membership flow -->
+  <line x1="40" y1="312" x2="720" y2="312" stroke="#242424"/>
+
+  <g font-size="13">
+    <circle cx="60" cy="348" r="13" fill="#241606" stroke="#ff8f05"/>
+    <text x="60" y="352" fill="#ff8f05" font-size="11" text-anchor="middle">D</text>
+    <text x="84" y="345" fill="#e8e8e8">Dana joins #design</text>
+    <text x="84" y="363" fill="#9a9a9a" font-size="12">instantly gets access to everything shared in it</text>
+  </g>
+
+  <g font-size="13">
+    <circle cx="420" cy="348" r="13" fill="#1a1a1a" stroke="#3f3f46" stroke-dasharray="3 3"/>
+    <text x="420" y="352" fill="#6f6f6f" font-size="11" text-anchor="middle">B</text>
+    <text x="444" y="345" fill="#e8e8e8">Ben leaves</text>
+    <text x="444" y="363" fill="#9a9a9a" font-size="12">access to shared items is removed</text>
+  </g>
+</svg>

--- a/docs/images/unified-memory-diagram.svg
+++ b/docs/images/unified-memory-diagram.svg
@@ -1,0 +1,80 @@
+<svg viewBox="0 0 760 470" xmlns="http://www.w3.org/2000/svg" font-family="ui-sans-serif, -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif">
+  <defs>
+    <radialGradient id="coreGlow" cx="50%" cy="50%" r="60%">
+      <stop offset="0%" stop-color="#ff8f05" stop-opacity="0.14"/>
+      <stop offset="100%" stop-color="#ff8f05" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+
+  <rect x="0" y="0" width="760" height="470" fill="#090909"/>
+
+  <!-- connection lines: blocks to core -->
+  <g stroke="#3a3a3a" stroke-width="1.25">
+    <path d="M 172 80  C 250 80, 280 150, 310 178" fill="none"/>
+    <path d="M 172 170 C 230 170, 250 190, 300 200" fill="none"/>
+    <path d="M 172 260 C 230 260, 250 240, 300 228" fill="none"/>
+    <path d="M 172 350 C 250 350, 280 280, 310 250" fill="none"/>
+    <path d="M 588 80  C 510 80, 480 150, 450 178" fill="none"/>
+    <path d="M 588 170 C 530 170, 510 190, 460 200" fill="none"/>
+    <path d="M 588 260 C 530 260, 510 240, 460 228" fill="none"/>
+    <path d="M 588 350 C 510 350, 480 280, 450 250" fill="none"/>
+  </g>
+
+  <!-- agents line: core to agents -->
+  <path d="M 380 274 L 380 366" stroke="#ff8f05" stroke-width="1.5" fill="none"/>
+  <circle cx="380" cy="274" r="3" fill="#ff8f05"/>
+  <circle cx="380" cy="366" r="3" fill="#ff8f05"/>
+  <text x="392" y="326" fill="#9a9a9a" font-size="12">agents read and write everything</text>
+
+  <!-- block chips: left -->
+  <g>
+    <g>
+      <rect x="40" y="56" width="132" height="48" rx="10" fill="#161616" stroke="#2e2e2e"/>
+      <text x="106" y="85" fill="#e8e8e8" font-size="14" text-anchor="middle">Email</text>
+    </g>
+    <g>
+      <rect x="40" y="146" width="132" height="48" rx="10" fill="#161616" stroke="#2e2e2e"/>
+      <text x="106" y="175" fill="#e8e8e8" font-size="14" text-anchor="middle">Messages</text>
+    </g>
+    <g>
+      <rect x="40" y="236" width="132" height="48" rx="10" fill="#161616" stroke="#2e2e2e"/>
+      <text x="106" y="265" fill="#e8e8e8" font-size="14" text-anchor="middle">Tasks</text>
+    </g>
+    <g>
+      <rect x="40" y="326" width="132" height="48" rx="10" fill="#161616" stroke="#2e2e2e"/>
+      <text x="106" y="355" fill="#e8e8e8" font-size="14" text-anchor="middle">Docs</text>
+    </g>
+  </g>
+
+  <!-- block chips: right -->
+  <g>
+    <g>
+      <rect x="588" y="56" width="132" height="48" rx="10" fill="#161616" stroke="#2e2e2e"/>
+      <text x="654" y="85" fill="#e8e8e8" font-size="14" text-anchor="middle">Calls</text>
+    </g>
+    <g>
+      <rect x="588" y="146" width="132" height="48" rx="10" fill="#161616" stroke="#2e2e2e"/>
+      <text x="654" y="175" fill="#e8e8e8" font-size="14" text-anchor="middle">Files</text>
+    </g>
+    <g>
+      <rect x="588" y="236" width="132" height="48" rx="10" fill="#161616" stroke="#2e2e2e"/>
+      <text x="654" y="265" fill="#e8e8e8" font-size="14" text-anchor="middle">Canvas</text>
+    </g>
+    <g>
+      <rect x="588" y="326" width="132" height="48" rx="10" fill="#161616" stroke="#2e2e2e"/>
+      <text x="654" y="355" fill="#e8e8e8" font-size="14" text-anchor="middle">Pull requests</text>
+    </g>
+  </g>
+
+  <!-- core -->
+  <ellipse cx="380" cy="214" rx="170" ry="105" fill="url(#coreGlow)"/>
+  <rect x="300" y="154" width="160" height="120" rx="14" fill="#1a1208" stroke="#ff8f05" stroke-width="1.5"/>
+  <text x="380" y="204" fill="#ffffff" font-size="16" font-weight="600" text-anchor="middle">Unified memory</text>
+  <text x="380" y="228" fill="#c9c9c9" font-size="12" text-anchor="middle">one database</text>
+  <text x="380" y="246" fill="#9a9a9a" font-size="12" text-anchor="middle">personal + team</text>
+
+  <!-- agents -->
+  <rect x="296" y="366" width="168" height="52" rx="12" fill="#161616" stroke="#ff8f05" stroke-width="1.25"/>
+  <text x="380" y="389" fill="#ffffff" font-size="14" font-weight="600" text-anchor="middle">Agents</text>
+  <text x="380" y="407" fill="#9a9a9a" font-size="11" text-anchor="middle">chats · @Macro · automations</text>
+</svg>

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -7,6 +7,10 @@ description: "Extremely fast, unified interface for all your work, all linked to
 
 Macro is an integrated workspace that brings together email, messaging, tasks, documents, and files with powerful bidirectional @linking. Built with a Solid frontend and Rust backend, Macro delivers exceptional performance and a unified experience across all your work.
 
+<Card title="Getting started" icon="rocket" href="/getting-started" horizontal>
+  New to Macro? Go from a fresh account to a working setup in about 15 minutes.
+</Card>
+
 ## Core Blocks
 
 For each block, we've studied the best prior art and tried to make it even better. For example, Email is faster than Superhuman with a unified inbox. Messaging is designed to be more focused, and less noisy, than Slack. Docs are simpler than Notion. Tasks steal from Linear but are less ceremonious (cycles, points, etc. are there if you _really want_ but we advise not).
@@ -39,7 +43,7 @@ The following are the core first-party blocks available in Macro today. Each car
     Real-time collaborative, markdown-native docs using CRDTs, @mentions.
   </Card>
 
-  <Card title="Canvas" icon="diagram-project">
+  <Card title="Canvas" icon="diagram-project" href="/product/canvas">
     2D board with embedded @links to tasks, files, and emails. 
   </Card>
 
@@ -55,11 +59,11 @@ The following are the core first-party blocks available in Macro today. Each car
     Store and share files — auto-imported from email and channels, fully searchable.
   </Card>
 
-  <Card title="Pull Requests" icon="code-merge">
+  <Card title="Pull Requests" icon="code-merge" href="/integrations/github">
     Linked to tasks, embeddable in channels, available to agents.
   </Card>
 
-  <Card title="CRM" icon="chart-network">
+  <Card title="CRM" icon="chart-network" href="/product/crm">
     Customer & Contact objects, custom properties, email sync, enrichment.
   </Card>
 </CardGroup>

--- a/docs/keyboard-shortcuts.mdx
+++ b/docs/keyboard-shortcuts.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Keyboard Shortcuts"
+description: "The complete reference for driving Macro from the keyboard."
 ---
 
 ### **Global**
@@ -129,6 +130,30 @@ title: "Keyboard Shortcuts"
 <kbd>shift</kbd>\+<kbd>cmd</kbd>\+<kbd>h</kbd>  Highlight 
 
 <kbd>cmd</kbd>\+<kbd>e</kbd> Inline code
+
+### **Canvas**
+
+<kbd>v</kbd>  Select tool
+
+<kbd>h</kbd>  Hand (pan) tool
+
+<kbd>r</kbd>  Shape tool
+
+<kbd>x</kbd>  Connector tool
+
+<kbd>p</kbd>  Pencil tool
+
+<kbd>t</kbd>  Text tool
+
+<kbd>cmd</kbd>\+<kbd>=</kbd> / <kbd>cmd</kbd>\+<kbd>-</kbd>  Zoom in / out
+
+<kbd>cmd</kbd>\+<kbd>g</kbd>  Group selection
+
+<kbd>shift</kbd>\+<kbd>cmd</kbd>\+<kbd>g</kbd>  Ungroup
+
+<kbd>]</kbd> / <kbd>\[</kbd>  Bring to front / send to back
+
+<kbd>↑</kbd> <kbd>↓</kbd> <kbd>←</kbd> <kbd>→</kbd>  Nudge selection (<kbd>shift</kbd> for larger steps)
 
 ### **Split Layout / Window**
 

--- a/docs/permissions.mdx
+++ b/docs/permissions.mdx
@@ -1,8 +1,16 @@
 ---
 title: "Permissions"
+description: "Channel-based sharing: access flows from channel membership, not per-file dialogs."
 ---
 
 In Macro, who has access to what is controlled by what we call "channel-based" sharing. **When you mention something it is shared with all members of the channel.** If somebody is added to the channel, they gain access to everything shared in it; if they are removed, they lose that access.
+
+<Frame>
+  <img
+    src="/images/channel-sharing-diagram.svg"
+    alt="Diagram of channel-based sharing: a doc mentioned in a channel is shared with every member, people who join gain access, and people who leave lose it"
+  />
+</Frame>
 
 This channel-based sharing prevents footguns that occur with Notion and Slack, or Notion and Docs, etc. where people don't have access to things and need to request access. In Macro, it works like magic.
 

--- a/docs/product/agents.mdx
+++ b/docs/product/agents.mdx
@@ -16,7 +16,7 @@ Agents have access to everything in your workspace, giving them — and you — 
 Ask for summaries, clarifications, and more — the agent answers using all the information in your workspace.
 
 <Frame>
-  ![Screenshot 2026 06 03 At 5 01 06 PM](/images/Screenshot-2026-06-03-at-5.01.06-PM.png)
+  ![An agent chat answering a question using context from across the workspace](/images/Screenshot-2026-06-03-at-5.01.06-PM.png)
 </Frame>
 
 ### Automations

--- a/docs/product/canvas.mdx
+++ b/docs/product/canvas.mdx
@@ -1,0 +1,30 @@
+---
+title: "Canvas"
+description: "An infinite 2D board where sketches, shapes, and live blocks from your workspace sit side by side."
+---
+
+A canvas is Macro's whiteboard block: an infinite 2D plane for mind-mapping, technical diagrams, project planning, or just grouping files visually. What makes it different from a standalone whiteboard tool is that you can place live @mentions of anything in your workspace — tasks, docs, emails, channels, calls — directly on the board, so a diagram can point at the real work it describes.
+
+> To create a canvas use shortcut <kbd>c</kbd> + <kbd>n</kbd>
+
+<Frame>
+  ![A canvas with embedded tasks, files, and emails connected by arrows](/images/Screenshot-2026-06-09-at-4.05.22-PM.png)
+</Frame>
+
+### What you can put on a canvas
+
+- **Blocks from your workspace** — @mention any doc, task, email, channel, call, or chat. Mentions render as live pills that carry current metadata, like a task's status and priority.
+- **Shapes and text** — rectangles, ellipses, and styled text, with configurable fill, stroke, corner radius, and opacity.
+- **Connectors** — straight, curved, or stepped lines between objects, with arrowheads and other end styles on either end.
+- **Freehand drawing** — sketch with the pencil tool.
+- **Images** — paste, drag in, or pick from your files.
+
+### Working on the board
+
+Pick tools from the toolbar or by key: <kbd>v</kbd> select, <kbd>h</kbd> hand (pan), <kbd>r</kbd> shape, <kbd>x</kbd> connector, <kbd>p</kbd> pencil, <kbd>t</kbd> text. Zoom with <kbd>cmd</kbd>+<kbd>=</kbd> / <kbd>cmd</kbd>+<kbd>-</kbd> or the mouse wheel.
+
+Drag to box-select multiple objects, then use the floating menu to align them (left, center, right, top, middle, bottom). Group a selection with <kbd>cmd</kbd>+<kbd>g</kbd> and ungroup with <kbd>shift</kbd>+<kbd>cmd</kbd>+<kbd>g</kbd>. Reorder stacking with <kbd>\]</kbd> (bring to front) and <kbd>\[</kbd> (send to back). Nudge selected objects with the arrow keys, or hold <kbd>shift</kbd> for larger steps. The usual <kbd>cmd</kbd>+<kbd>c</kbd> / <kbd>cmd</kbd>+<kbd>x</kbd> / <kbd>cmd</kbd>+<kbd>v</kbd>, <kbd>cmd</kbd>+<kbd>z</kbd> undo, and <kbd>delete</kbd> all work as expected.
+
+### Sharing
+
+Canvases use the standard share dialog with owner, editor, commenter, and viewer access. When you copy a link to a canvas, your current pan and zoom position is preserved, so the link opens framed on the part of the board you were looking at. You can also download a canvas as a file, and @mention canvases anywhere else in Macro — they show up in [unified search](/product/search) like every other block.

--- a/docs/product/channels.mdx
+++ b/docs/product/channels.mdx
@@ -32,7 +32,7 @@ In Macro, you're not restricted to messaging your team — anyone can be added t
 You can also mention @Macro to call an agent into the channel. @Macro can summarize previous discussion, answer workspace questions, and more.
 
 <Frame>
-  ![Screenshot 2026 06 03 At 4 54 24 PM](/images/Screenshot-2026-06-03-at-4.54.24-PM.png)
+  ![The @Macro agent responding to a question inside a channel](/images/Screenshot-2026-06-03-at-4.54.24-PM.png)
 </Frame>
 
 ## Message Features

--- a/docs/product/crm.mdx
+++ b/docs/product/crm.mdx
@@ -1,0 +1,32 @@
+---
+title: "CRM"
+description: "Contact and company records built automatically from your team's email — no data entry."
+---
+
+<Note>
+  CRM is rolling out now. If you don't see the **Companies** view in your workspace yet, it hasn't reached your account.
+</Note>
+
+Most CRMs die because nobody fills them in. Macro's CRM builds itself: because your team's email already flows through Macro, contact and company records are created and kept up to date automatically as you work. There's no importer to run and no fields to type.
+
+### Records build themselves
+
+When someone on your team emails an external contact, Macro creates a contact record for them and groups contacts into companies by email domain — everyone `@acme.com` rolls up to one Acme record. Each contact tracks its first and last interaction, so you can see the full history of a relationship at a glance. Generic tool and vendor domains (the SaaS notification emails every company gets) are filtered out so the CRM stays about your actual customers.
+
+New companies are enriched automatically with public data: name, description, logo, website, industry, headcount, funding, location, and social links land on the record without anyone touching it.
+
+### One shared view of every relationship
+
+Open **Companies** from the sidebar to browse your team's accounts. A company page shows its domains, contacts, and email threads in one place — with **Team** and **Me** tabs so you can see either everything your team has exchanged with that account or just your own threads. Contact pages work the same way.
+
+Every company and contact also has a **discussion** thread, so deal notes and context live on the record itself instead of in a side channel. And like everything in Macro, CRM records are blocks: @mention a company or contact in a doc, task, or channel, and agents can use your CRM as context like the rest of your [team memory](/product/unified-memory).
+
+### Email sharing, with control
+
+CRM is a team feature, and it's where Macro's email auto-sharing lives. When **Email Sync** is on for a company, your team's email threads with that company become visible to teammates in the CRM — that's how sales never has to forward "see thread below" again. Turning it off for a company keeps the record but makes its threads private to their participants.
+
+Team admins can also **hide** a company or contact entirely, which removes it (and its threads) from the team's view. Members see visible records; admins and owners can edit records, toggle Email Sync, and manage hidden ones.
+
+<Info>
+  Sharing of CRM records is determined by your team, not by mentions: @mentioning a company or contact in a channel does not share it, unlike documents. See [Mentions](/concepts/mentions#what-happens-when-you-mention).
+</Info>

--- a/docs/product/docs.mdx
+++ b/docs/product/docs.mdx
@@ -32,8 +32,8 @@ For a person to receive notifications from a document, it must first be shared w
 <Frame>
   <img
     src="/images/Screenshot-2026-06-02-at-6.40.28-PM.png"
-    alt="Screenshot 2026 06 02 At 6 40 28 PM"
-    title="Screenshot 2026 06 02 At 6 40 28 PM"
+    alt="An inline comment thread in a document with an @mention notifying a teammate"
+    title="Document comments"
     className="mx-auto"
     style={{ width:"51%" }}
   />

--- a/docs/product/email.mdx
+++ b/docs/product/email.mdx
@@ -32,7 +32,7 @@ You can change senders from signal to noise or vice versa at any time by right-c
 ### Sharing
 
 <Frame>
-  ![Screenshot 2026 06 03 At 11 52 56 AM](/images/Screenshot-2026-06-03-at-11.52.56-AM.png)
+  ![Sharing an email thread into a channel from the share menu](/images/Screenshot-2026-06-03-at-11.52.56-AM.png)
 </Frame>
 
 You can forward, cc, and bcc people as normal using Macro's email client, or share an email thread inside the app using the share button.

--- a/docs/product/search.mdx
+++ b/docs/product/search.mdx
@@ -9,18 +9,20 @@ description: "Macro's unified search makes it possible to find anything in 50ms 
 
 Search is the easiest way to find specific files in Macro. When using search for multiple terms, use quotations for an exact match. Otherwise, the default is to independently match terms in a document.
 
-> Use the <kbd>/</kbd> shortcut to open up search or the <kbd>cmd k</kbd> menu to search by name.
+> Use the <kbd>/</kbd> shortcut to open up search or the <kbd>cmd</kbd>+<kbd>k</kbd> menu to search by name.
 
-Use the filter button in the upper right corner to sort results into different types (agent results, messages, etc). To see a result preview in search, use {l} to expand and {h} to close.
+Use the filter button in the upper right corner to sort results into different types (agent results, messages, etc). To see a result preview in search, use <kbd>l</kbd> to expand and <kbd>h</kbd> to close.
 
 <Frame>
   <img
     src="/images/betterFilter.png"
-    alt="Better Filter"
-    title="Better Filter"
+    alt="The search filter menu showing result type options"
+    title="Search filters"
     className="mx-auto"
     style={{ width:"33%" }}
   />
 </Frame>
 
-To further narrow search results, use your keyword(s) and @mention a specific person
+To further narrow search results, combine your keywords with an @mention of a specific person.
+
+Search doesn't stop at titles: document bodies, email threads, channel messages, call transcripts, and file contents are all indexed. And if you'd rather not search at all, ask an [agent](/product/agents) — agents use the same index to find things in your workspace for you.

--- a/docs/product/unified-memory.mdx
+++ b/docs/product/unified-memory.mdx
@@ -5,6 +5,13 @@ description: "Personal and team-level memory across mail, messages, tasks, docs 
 
 ChatGPT and Claude create memory over your chats. Macro creates memory over everything you and your team are working on — email, messages, tasks, docs, calls, and anything you've connected via MCP. There's not too much to document here because it all runs in the background with limited configurability.
 
+<Frame>
+  <img
+    src="/images/unified-memory-diagram.svg"
+    alt="Diagram of Macro's blocks — email, messages, tasks, docs, calls, files, canvas, and pull requests — all feeding one unified memory that agents read and write"
+  />
+</Frame>
+
 Every night, Macro refreshes this memory from the day's activity. When you ask an agent "what's the latest status of project alamo?", it answers from the most recent emails, messages, tasks, docs, and call transcripts — you don't have to point it at anything.
 
 ### Personal vs. team memory

--- a/docs/scripts/generate-changelog.ts
+++ b/docs/scripts/generate-changelog.ts
@@ -1,6 +1,8 @@
 /**
  * Pulls releases from macro-inc/macro matching the vYYYY.M.D.N format
- * and generates a single changelog MDX page using <Update> components.
+ * and generates changelog MDX pages using <Update> components: one
+ * landing page (introduction.mdx) with the latest month's releases, plus
+ * one archive page per month so no single route carries every release.
  *
  * Usage: bun run scripts/generate-changelog.ts
  *
@@ -59,6 +61,33 @@ function escapeForMdx(text: string): string {
   );
 }
 
+const MONTH_NAMES = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
+];
+
+/** Year and month parsed from a vYYYY.M.D.N tag. */
+function tagMonth(tag: string): { year: number; month: number } {
+  const [year, month] = tag.slice(1).split(".").map(Number);
+  return { year, month };
+}
+
+function renderUpdate(r: Release, current: boolean): string {
+  const label = current ? `${r.tag_name} (Current)` : r.tag_name;
+  const body = escapeForMdx((r.body ?? "").trim());
+  return `    <Update label="${label}">\n${body}\n    </Update>`;
+}
+
 async function main() {
   console.log(`Fetching releases from ${REPO}...`);
   const allReleases = await fetchAllReleases();
@@ -74,42 +103,84 @@ async function main() {
     `Found ${releases.length} releases matching ${TAG_PATTERN.source}`
   );
 
-  // Clean out old per-release MDX files
+  // Clean out old generated MDX files
   mkdirSync(CHANGELOG_DIR, { recursive: true });
   for (const file of readdirSync(CHANGELOG_DIR)) {
-    if (file !== "introduction.mdx") {
-      rmSync(join(CHANGELOG_DIR, file));
-    }
+    rmSync(join(CHANGELOG_DIR, file));
   }
 
-  const updates = releases.map((r, i) => {
-    const label = i === 0 ? `${r.tag_name} (Current)` : r.tag_name;
-    const body = escapeForMdx((r.body ?? "").trim());
-    return `    <Update label="${label}">\n${body}\n    </Update>`;
-  });
+  // Group releases by tag month, newest month first (releases are already
+  // sorted newest-first, so insertion order is the display order)
+  const months = new Map<string, Release[]>();
+  for (const r of releases) {
+    const { year, month } = tagMonth(r.tag_name);
+    const key = `${year}-${String(month).padStart(2, "0")}`;
+    (months.get(key) ?? months.set(key, []).get(key)!).push(r);
+  }
 
-  const mdx = `---
+  const monthKeys = [...months.keys()];
+  const [latestKey, ...archiveKeys] = monthKeys;
+
+  // Landing page: the latest month's releases
+  const latestReleases = months.get(latestKey) ?? [];
+  const latestUpdates = latestReleases.map((r, i) => renderUpdate(r, i === 0));
+
+  const intro = `---
 title: Changelog
 icon: clock-rotate-left
+description: All notable changes to Macro, pulled from GitHub Releases.
 ---
 
 All notable changes to Macro, pulled from [GitHub Releases](https://github.com/${REPO}/releases).
 
-Releases follow the format \`vYYYY.M.D.patch\`.
+Releases follow the format \`vYYYY.M.D.patch\`. Earlier months are in the sidebar.
+
+${latestUpdates.join("\n\n")}
+`;
+
+  writeFileSync(join(CHANGELOG_DIR, "introduction.mdx"), intro);
+  console.log(
+    `Wrote changelog/introduction.mdx (${latestReleases.length} releases)`
+  );
+
+  // One archive page per earlier month
+  for (const key of archiveKeys) {
+    const [year, month] = key.split("-").map(Number);
+    const title = `${MONTH_NAMES[month - 1]} ${year}`;
+    const monthReleases = months.get(key)!;
+    const updates = monthReleases.map((r) => renderUpdate(r, false));
+
+    const mdx = `---
+title: "${title}"
+description: "Macro releases from ${title}."
+---
 
 ${updates.join("\n\n")}
 `;
 
-  writeFileSync(join(CHANGELOG_DIR, "introduction.mdx"), mdx);
-  console.log("Wrote changelog/introduction.mdx");
+    writeFileSync(join(CHANGELOG_DIR, `${key}.mdx`), mdx);
+    console.log(`Wrote changelog/${key}.mdx (${monthReleases.length} releases)`);
+  }
 
-  // Update docs.json with changelog tab
+  // Update docs.json with changelog tab: latest month up top, then one
+  // group per year of archive pages
   const docsJson = JSON.parse(readFileSync(DOCS_JSON_PATH, "utf-8"));
   const tabs = docsJson.navigation.tabs as Array<Record<string, unknown>>;
 
   const filtered = tabs.filter(
     (t) => (t.tab as string).toLowerCase() !== "changelog"
   );
+
+  const yearGroups: Array<{ group: string; pages: string[] }> = [];
+  for (const key of archiveKeys) {
+    const year = key.split("-")[0];
+    let group = yearGroups.find((g) => g.group === year);
+    if (!group) {
+      group = { group: year, pages: [] };
+      yearGroups.push(group);
+    }
+    group.pages.push(`changelog/${key}`);
+  }
 
   filtered.push({
     tab: "Changelog",
@@ -118,6 +189,7 @@ ${updates.join("\n\n")}
         group: "Releases",
         pages: ["changelog/introduction"],
       },
+      ...yearGroups,
     ],
   });
 

--- a/docs/support.mdx
+++ b/docs/support.mdx
@@ -1,0 +1,55 @@
+---
+title: "Help & support"
+description: "How to get help with Macro, and fixes for the most common issues."
+---
+
+## Get help
+
+<CardGroup cols={2}>
+  <Card title="Email support" icon="envelope" href="mailto:support@macro.com">
+    Write to support@macro.com — include what you were doing and what you expected to happen.
+  </Card>
+  <Card title="Book a call" icon="calendar" href="https://cal.com/team/macro/macro-demo-call">
+    A member of our team will walk you through setup or dig into a problem live.
+  </Card>
+  <Card title="File a bug on GitHub" icon="github" href="https://github.com/macro-inc/macro/issues">
+    Macro is open source — bug reports (and pull requests) are welcome on the monorepo.
+  </Card>
+  <Card title="Watch the demo" icon="play" href="https://www.youtube.com/watch?v=Fn5hdzXsQQ8">
+    Many "how do I…" questions are answered in the product walkthrough.
+  </Card>
+</CardGroup>
+
+For specific topics: [licensing@macro.com](mailto:licensing@macro.com) for commercial licensing, [self-host@macro.com](mailto:self-host@macro.com) for HIPAA/FedRAMP and self-hosted deployments, and [teo@macro.com](mailto:teo@macro.com) if you want to contribute but aren't sure where to start.
+
+## Common issues
+
+<AccordionGroup>
+  <Accordion title="Someone referenced a doc or task I can't open">
+    You don't have access yet. Ask them to @mention it in a channel you're both in — that shares it with every member automatically — or to share it with you directly from the item's Share menu. See [Permissions](/permissions).
+  </Accordion>
+
+  <Accordion title="An email I'm expecting isn't in my inbox">
+    Check the **Noise** tab — Macro filters lower-priority senders out of Signal. If a sender is misclassified, right-click any of their threads to move them between Signal and Noise; the change sticks for future emails. See [Signal vs Noise](/product/email#signal-vs-noise).
+  </Accordion>
+
+  <Accordion title="I @mentioned someone in a doc and they weren't notified">
+    That's by design: mentions in a document's <b>body</b> don't notify or share. Mention them in a <b>comment</b>, or share the doc with them explicitly. The reasoning is covered in [Mentions](/concepts/mentions#what-happens-when-you-mention).
+  </Accordion>
+
+  <Accordion title="I don't see a feature the docs describe (Companies, splits, …)">
+    Two usual causes: some features roll out gradually, so your account may not have them yet — and some features are desktop-only, like [splits](/concepts/blocks#splits) and keyboard shortcuts. See [Apps & platforms](/apps).
+  </Accordion>
+
+  <Accordion title="A call wasn't supposed to be shared with my team">
+    Calls are shared to team memory by default. During a call, uncheck the toggle in the bottom left to keep it personal — the call still goes to your own memory, just not the team's. See [Calls](/product/calls).
+  </Accordion>
+
+  <Accordion title="My agent says it can't access something">
+    Agents inherit your permissions — if you can't open it, neither can they. Get access to the item first (see the first question above), then ask again. See [Mentions in Agents](/concepts/mentions#mentions-in-agents).
+  </Accordion>
+</AccordionGroup>
+
+<Info>
+  When reporting a bug, include your platform (web or iOS), the block type involved (email, doc, channel, …), and a link to the affected item if you have one — it cuts the back-and-forth in half.
+</Info>

--- a/docs/switch-to-macro.mdx
+++ b/docs/switch-to-macro.mdx
@@ -1,0 +1,59 @@
+---
+title: "Switch to Macro"
+description: "Migration guides for moving from Notion, Slack, Superhuman, and Linear to Macro."
+---
+
+Macro replaces several tools at once, but you don't have to cut over in one weekend. The pattern that works: connect your old tools first so nothing is lost, move your daily workflow into Macro, and let the old tools wind down to read-only. This page covers the most common starting points.
+
+## From Superhuman
+
+This is the easiest switch, because Superhuman — like Macro — is a client on top of Gmail. There's no migration at all:
+
+1. Connect your Gmail or Google Workspace account (ideally at signup, or later in **Settings**).
+2. Your mail, labels, and history are already there — Macro syncs with Gmail directly.
+3. Keep your muscle memory: the same <kbd>j</kbd> / <kbd>k</kbd> / <kbd>e</kbd> triage shortcuts work in Macro.
+
+What you gain: [multiple accounts in one inbox](/product/email#multi-account-inbox), [Signal/Noise filtering](/product/email#signal-vs-noise), an inbox that also carries your messages, tasks, and @mentions — and an [agent](/product/agents) that can draft and send email. There's no reason you can't run both during the transition, but most people stop opening Superhuman within a week.
+
+## From Notion
+
+Macro can import your Notion content with an agent:
+
+1. Go to **Settings → Connectors** and connect Notion.
+2. Open an agent chat (<kbd>c</kbd> + <kbd>a</kbd>) and ask it to import — for example:
+
+```text
+Import my Notion docs from the "Engineering" workspace as Macro docs.
+Keep the folder structure and skip anything archived.
+```
+
+The agent reads pages through the Notion connector and recreates them as [Macro documents](/product/docs). Macro docs are markdown-native, so Notion pages translate cleanly. For structured Notion databases, consider whether each one is really [tasks](/product/tasks), [CRM records](/product/crm), or a doc with [properties](/concepts/properties) — Macro has purpose-built blocks for the things people usually force into Notion databases.
+
+You can also keep Notion connected indefinitely so agents can reference legacy content without migrating it. For the full philosophical argument, see the [FAQ](/faq) or our [comparison video](https://youtu.be/hyU1XYmxkYM).
+
+## From Slack
+
+[Channels](/product/channels) in Macro are deliberately quieter than Slack — inline replies, less notification noise — and deeply linked to the rest of your workspace.
+
+1. Create a channel per team or project (<kbd>c</kbd> + <kbd>m</kbd>).
+2. Add people by email — they don't need a Macro account yet to be included.
+3. Lean on [@mentions](/concepts/mentions): mentioning a doc or task in a channel automatically shares it with every member, which replaces the Slack-and-Notion permission-request dance entirely.
+
+If you're not ready to leave Slack — archives, Slack Connect with customers — connect it under **Settings → Connectors** as an MCP connector so agents in Macro can still search it. Many teams run Macro for internal communication and keep Slack only for external channels during the transition.
+
+## From Linear
+
+Macro's tasks are openly Linear-inspired, minus the ceremony: status, priority, assignee, and not much else by default (more is there [if you really want it](/concepts/properties)).
+
+- The [GitHub integration](/integrations/github) covers the workflow you're used to — copy a branch name from a task, and the task moves to In Progress → In Review → Done as you branch, open the PR, and merge.
+- Tasks are visible to your whole team by default, and you can create them from any email or channel message in one click.
+
+For migration, most teams simply recreate their open work — finished issues rarely justify carrying over. If you do want history, connect Linear under **Settings → Connectors** and have an agent bring open issues across.
+
+## Everything else
+
+Any tool with an MCP server can be connected under **Settings → Connectors**, which makes it readable to your agents — useful both as a migration path (ask an agent to copy content over) and as a permanent bridge for tools you keep. And your files largely migrate themselves: email attachments are auto-extracted into [file storage](/product/folders), and anything you drag into a channel or doc is imported and searchable.
+
+<Card title="Want help switching?" icon="calendar" href="https://cal.com/team/macro/macro-demo-call">
+  Book a call and we'll walk your team through the migration.
+</Card>


### PR DESCRIPTION
## What changed

Fills the biggest gaps in docs.macro.com versus best-in-class product docs (Linear/Notion/Stripe patterns), plus two factual corrections requested by Jacob.

### New pages
- **Getting started** — 7-step "first 15 minutes" guide, linked from a banner card on the homepage
- **Switch to Macro** — migration guides for Superhuman, Notion, Slack, and Linear, plus a generic MCP path
- **Apps & platforms** — web + iOS (verified App Store link), desktop-only feature list, no-Android-yet
- **Teams & admin** — team creation, invites, member/admin/owner roles (verified against auth schemas)
- **Billing & plans** — Free vs Premium from `plans.ts`, Stripe portal path, self-hosting
- **Help & support** — contact channels + 6-item troubleshooting accordion, all grounded in documented behavior
- **Agent recipes** — copy-paste prompts for automations, @Macro, imports, and Claude Code via MCP
- **Canvas** — feature set verified against `js/app/packages/block-canvas/`
- **CRM** — verified against `rust/cloud-storage/crm/`; published with a rollout note since the feature is on dev.macro.com but not prod yet (per Jacob)

### Changelog restructure
`scripts/generate-changelog.ts` now emits a latest-month landing page plus per-month archive pages grouped by year, instead of one 266KB route. Regenerated: 127 releases across 7 pages (largest 74KB), picking up 33 releases the committed file was missing.

### Graphics
Two hand-built dark-theme SVG diagrams (docs palette: `#090909` / `#ff8f05`): unified memory (blocks → shared memory → agents) on the Unified Memory page, and channel-based sharing on the Permissions page.

### Fixes
- Search page: `{l}`/`{h}` were parsed as MDX JS expressions, plus a sentence that trailed off mid-thought
- **Canvas removed from real-time-collaboration claims** (`concepts/blocks.mdx`) — not shipped yet, per Jacob
- ~14 filename alt texts ("Screenshot 2026 06 09 At …") replaced with descriptive ones across 7 pages
- Canvas section added to keyboard shortcuts (verified against `CanvasController.tsx`)
- Frontmatter descriptions for FAQ/Permissions/Shortcuts; homepage Canvas/CRM/Pull Requests cards now link somewhere

## Notes for reviewers
- All 52 nav pages resolve, no orphan pages, all internal links/images check out, and every touched page compiles as MDX. `mint broken-links` itself wouldn't run locally (Node 25 unsupported), so validation was scripted.
- The repo has a Tauri desktop app with an auto-updater but no public download link I could find, so the Apps page presents desktop as the browser experience — flag if that's wrong.
- The CRM page intentionally omits the `o` hotkey and custom-properties claims (couldn't fully verify); worth a skim against dev.macro.com before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
