### PR TITLE
feat(search): add inbox facet to the search filter row

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/inbox-picker.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/inbox-picker.tsx
@@ -1,0 +1,48 @@
+import { inboxIconProps } from '@core/component/inboxIcon';
+import { UserIcon } from '@core/component/UserIcon';
+import { useEmailLinksQuery } from '@queries/email/link';
+import { type Accessor, createMemo } from 'solid-js';
+import type { SearchableOption } from './searchable-multi-select';
+
+/**
+ * Shared mechanics for a multi-select over the user's linked inboxes (mail
+ * toolbar selector, search facet). The selection is tri-state: `undefined` =
+ * all inboxes (default — every box checked), `[]` = explicitly none, a
+ * subset = those. Re-checking every inbox collapses back to the default, so
+ * a checked box always means the inbox is included. Callers own where the
+ * selection lives and how the value is rendered.
+ */
+export function useInboxPicker(args: {
+  selectedIds: Accessor<string[] | undefined>;
+  setSelectedIds: (ids: string[] | undefined) => void;
+}) {
+  const linksQuery = useEmailLinksQuery();
+
+  const options = createMemo((): SearchableOption[] =>
+    (linksQuery.data?.links ?? [])
+      .map((link) => ({
+        id: link.id,
+        label: link.email_address,
+        icon: () => (
+          <UserIcon
+            {...inboxIconProps(link.email_address)}
+            photoUrl={link.photo_url ?? undefined}
+            size="sm"
+            suppressClick
+            showTooltip={false}
+          />
+        ),
+      }))
+      .sort((a, b) => a.label.localeCompare(b.label))
+  );
+
+  return {
+    options,
+    hasMultiple: () => options().length > 1,
+    activeIds: () => args.selectedIds() ?? options().map((o) => o.id),
+    onChange: (ids: string[]) =>
+      args.setSelectedIds(ids.length === options().length ? undefined : ids),
+    isDefault: () => args.selectedIds() === undefined,
+    reset: () => args.setSelectedIds(undefined),
+  };
+}

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/inbox-picker.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/inbox-picker.tsx
@@ -42,6 +42,7 @@ export function useInboxPicker(args: {
     activeIds: () => args.selectedIds() ?? options().map((o) => o.id),
     onChange: (ids: string[]) =>
       args.setSelectedIds(ids.length === options().length ? undefined : ids),
+    selectOnly: (id: string) => args.setSelectedIds([id]),
     isDefault: () => args.selectedIds() === undefined,
     reset: () => args.setSelectedIds(undefined),
   };

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/inbox-selector.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/inbox-selector.tsx
@@ -35,6 +35,7 @@ export function InboxSelector() {
         options={picker.options}
         activeIds={picker.activeIds}
         onChange={picker.onChange}
+        onOnly={picker.selectOnly}
         placeholder="Search inboxes..."
         preserveOrder
       >

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/inbox-selector.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/inbox-selector.tsx
@@ -1,16 +1,11 @@
 import { useSoupView } from '@app/component/next-soup/soup-view/soup-view-context';
-import { inboxIconProps } from '@core/component/inboxIcon';
-import { UserIcon } from '@core/component/UserIcon';
 import { Combobox } from '@kobalte/core/combobox';
 import CaretDownIcon from '@phosphor/caret-down.svg';
 import TrayIcon from '@phosphor/tray.svg';
-import { useEmailLinksQuery } from '@queries/email/link';
 import { Button } from '@ui';
-import { createMemo, Show } from 'solid-js';
-import {
-  SearchableMultiSelect,
-  type SearchableOption,
-} from './searchable-multi-select';
+import { Show } from 'solid-js';
+import { useInboxPicker } from './inbox-picker';
+import { SearchableMultiSelect } from './searchable-multi-select';
 
 /**
  * Scopes the list to a subset of the user's linked inboxes. Multi-select,
@@ -19,51 +14,27 @@ import {
  * into `Owner` email literals.
  */
 export function InboxSelector() {
-  const linksQuery = useEmailLinksQuery();
-  const links = () => linksQuery.data?.links ?? [];
   const { inboxFilter, setInboxFilter } = useSoupView();
-
-  const options = createMemo((): SearchableOption[] =>
-    links()
-      .map((link) => ({
-        id: link.id,
-        label: link.email_address,
-        icon: () => (
-          <UserIcon
-            {...inboxIconProps(link.email_address)}
-            photoUrl={link.photo_url ?? undefined}
-            size="sm"
-            suppressClick
-            showTooltip={false}
-          />
-        ),
-      }))
-      .sort((a, b) => a.label.localeCompare(b.label))
-  );
-
-  const activeIds = createMemo(() => {
-    const selected = inboxFilter();
-    return selected === undefined ? links().map((l) => l.id) : selected;
+  const picker = useInboxPicker({
+    selectedIds: inboxFilter,
+    setSelectedIds: setInboxFilter,
   });
-
-  const onChange = (ids: string[]) =>
-    setInboxFilter(ids.length === links().length ? undefined : ids);
 
   const label = () => {
     const ids = inboxFilter();
     if (ids === undefined) return 'All inboxes';
     if (ids.length === 0) return 'No inboxes';
     if (ids.length === 1)
-      return links().find((l) => l.id === ids[0])?.email_address ?? '1 inbox';
+      return picker.options().find((o) => o.id === ids[0])?.label ?? '1 inbox';
     return `${ids.length} inboxes`;
   };
 
   return (
-    <Show when={links().length > 1}>
+    <Show when={picker.hasMultiple()}>
       <SearchableMultiSelect
-        options={options}
-        activeIds={activeIds}
-        onChange={onChange}
+        options={picker.options}
+        activeIds={picker.activeIds}
+        onChange={picker.onChange}
         placeholder="Search inboxes..."
         preserveOrder
       >

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/search/search-facet-chip.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/search/search-facet-chip.tsx
@@ -105,6 +105,7 @@ const MultiValueSegment = (props: {
       options={props.facet.options}
       activeIds={props.facet.activeIds}
       onChange={props.facet.onChange}
+      onOnly={props.facet.onOnly}
       placeholder={props.facet.placeholder}
       preserveOrder={props.facet.preserveOrder}
       placement="bottom-start"

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/search/search-facet-chip.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/search/search-facet-chip.tsx
@@ -106,6 +106,7 @@ const MultiValueSegment = (props: {
       activeIds={props.facet.activeIds}
       onChange={props.facet.onChange}
       placeholder={props.facet.placeholder}
+      preserveOrder={props.facet.preserveOrder}
       placement="bottom-start"
       open={open}
       onOpenChange={(v) => {

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/search/search-facets.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/search/search-facets.tsx
@@ -234,6 +234,46 @@ function multiFacet(args: {
 }
 
 /**
+ * Multi facet over a small closed set where the default state shows every
+ * option checked, so a checked box always means "included". `undefined` =
+ * all (default), `[]` = explicitly none, a subset = those. Re-checking every
+ * option collapses back to the default.
+ */
+function allCheckedMultiFacet(args: {
+  id: string;
+  label: string;
+  allLabel: string;
+  noneLabel: string;
+  placeholder: string;
+  options: Accessor<SearchableOption[]>;
+  selectedIds: Accessor<string[] | undefined>;
+  onChange: (ids: string[] | undefined) => void;
+}): SearchFacetVM {
+  return {
+    kind: 'multi',
+    id: args.id,
+    label: args.label,
+    options: args.options,
+    activeIds: () => args.selectedIds() ?? args.options().map((o) => o.id),
+    onChange: (ids) =>
+      args.onChange(ids.length === args.options().length ? undefined : ids),
+    placeholder: args.placeholder,
+    isDefault: () => args.selectedIds() === undefined,
+    reset: () => args.onChange(undefined),
+    values: () => {
+      const ids = args.selectedIds();
+      if (ids === undefined) return [{ id: 'all', label: args.allLabel }];
+      if (ids.length === 0) return [{ id: 'none', label: args.noneLabel }];
+      const options = args.options();
+      return ids.map((id) => {
+        const option = options.find((o) => o.id === id);
+        return { id, label: option?.label ?? id, icon: option?.icon };
+      });
+    },
+  };
+}
+
+/**
  * Materializes the facet registry against the controller. Each facet is
  * defined once; which ones render follows the active type. Adding a facet =
  * one definition here + its compile line in `compileSearchQuery`.
@@ -280,13 +320,14 @@ export function useSearchFacets(
       controller.setEmailImportance(id === 'all' ? undefined : id === 'signal'),
   });
 
-  const inbox = multiFacet({
+  const inbox = allCheckedMultiFacet({
     id: 'email-inbox',
     label: 'Inbox',
-    neutralLabel: 'All inboxes',
+    allLabel: 'All inboxes',
+    noneLabel: 'No inboxes',
     placeholder: 'Search inboxes...',
     options: inboxOptions,
-    activeIds: controller.emailInbox,
+    selectedIds: controller.emailInbox,
     onChange: controller.setEmailInbox,
   });
 

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/search/search-facets.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/search/search-facets.tsx
@@ -95,6 +95,7 @@ export type SearchFacetVM = FacetBase &
         onChange: (ids: string[]) => void;
         placeholder: string;
         preserveOrder?: boolean;
+        onOnly?: (id: string) => void;
       }
   );
 
@@ -266,6 +267,7 @@ export function useSearchFacets(
     options: inboxPicker.options,
     activeIds: inboxPicker.activeIds,
     onChange: inboxPicker.onChange,
+    onOnly: inboxPicker.selectOnly,
     placeholder: 'Search inboxes...',
     preserveOrder: true,
     isDefault: inboxPicker.isDefault,

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/search/search-facets.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/search/search-facets.tsx
@@ -1,12 +1,11 @@
 import type { CallStatus } from '@app/component/next-soup/filters/filter-store/types';
 import { EntityIcon } from '@core/component/EntityIcon';
-import { inboxIconProps } from '@core/component/inboxIcon';
 import { UserIcon } from '@core/component/UserIcon';
 import { useQuickAccess } from '@core/context/quickAccess';
 import { useUserId } from '@core/context/user';
 import { EntityIcon as EntityIconWithAvatar } from '@entity/extractors/entity-icon';
-import { useEmailLinksQuery } from '@queries/email/link';
 import { type Accessor, createMemo, type JSX } from 'solid-js';
+import { useInboxPicker } from '../inbox-picker';
 import type { SearchableOption } from '../searchable-multi-select';
 import type {
   SearchFiltersController,
@@ -95,6 +94,7 @@ export type SearchFacetVM = FacetBase &
         activeIds: Accessor<string[]>;
         onChange: (ids: string[]) => void;
         placeholder: string;
+        preserveOrder?: boolean;
       }
   );
 
@@ -154,29 +154,6 @@ function usePersonPicker(): Accessor<SearchableOption[]> {
   });
 }
 
-/** Picker for the email "Inbox" chip — the user's linked inboxes. */
-function useInboxPicker(): Accessor<SearchableOption[]> {
-  const linksQuery = useEmailLinksQuery();
-
-  return createMemo(() =>
-    (linksQuery.data?.links ?? [])
-      .map((link) => ({
-        id: link.id,
-        label: link.email_address,
-        icon: () => (
-          <UserIcon
-            {...inboxIconProps(link.email_address)}
-            photoUrl={link.photo_url ?? undefined}
-            size="sm"
-            suppressClick
-            showTooltip={false}
-          />
-        ),
-      }))
-      .sort((a, b) => a.label.localeCompare(b.label))
-  );
-}
-
 function singleFacet(args: {
   id: string;
   label: string;
@@ -234,46 +211,6 @@ function multiFacet(args: {
 }
 
 /**
- * Multi facet over a small closed set where the default state shows every
- * option checked, so a checked box always means "included". `undefined` =
- * all (default), `[]` = explicitly none, a subset = those. Re-checking every
- * option collapses back to the default.
- */
-function allCheckedMultiFacet(args: {
-  id: string;
-  label: string;
-  allLabel: string;
-  noneLabel: string;
-  placeholder: string;
-  options: Accessor<SearchableOption[]>;
-  selectedIds: Accessor<string[] | undefined>;
-  onChange: (ids: string[] | undefined) => void;
-}): SearchFacetVM {
-  return {
-    kind: 'multi',
-    id: args.id,
-    label: args.label,
-    options: args.options,
-    activeIds: () => args.selectedIds() ?? args.options().map((o) => o.id),
-    onChange: (ids) =>
-      args.onChange(ids.length === args.options().length ? undefined : ids),
-    placeholder: args.placeholder,
-    isDefault: () => args.selectedIds() === undefined,
-    reset: () => args.onChange(undefined),
-    values: () => {
-      const ids = args.selectedIds();
-      if (ids === undefined) return [{ id: 'all', label: args.allLabel }];
-      if (ids.length === 0) return [{ id: 'none', label: args.noneLabel }];
-      const options = args.options();
-      return ids.map((id) => {
-        const option = options.find((o) => o.id === id);
-        return { id, label: option?.label ?? id, icon: option?.icon };
-      });
-    },
-  };
-}
-
-/**
  * Materializes the facet registry against the controller. Each facet is
  * defined once; which ones render follows the active type. Adding a facet =
  * one definition here + its compile line in `compileSearchQuery`.
@@ -283,8 +220,10 @@ export function useSearchFacets(
 ): Accessor<SearchFacetVM[]> {
   const channelOptions = useChannelPicker();
   const personOptions = usePersonPicker();
-  const inboxOptions = useInboxPicker();
-  const hasMultipleInboxes = createMemo(() => inboxOptions().length > 1);
+  const inboxPicker = useInboxPicker({
+    selectedIds: controller.emailInbox,
+    setSelectedIds: controller.setEmailInbox,
+  });
 
   const type = singleFacet({
     id: 'type',
@@ -320,16 +259,28 @@ export function useSearchFacets(
       controller.setEmailImportance(id === 'all' ? undefined : id === 'signal'),
   });
 
-  const inbox = allCheckedMultiFacet({
+  const inbox: SearchFacetVM = {
+    kind: 'multi',
     id: 'email-inbox',
     label: 'Inbox',
-    allLabel: 'All inboxes',
-    noneLabel: 'No inboxes',
+    options: inboxPicker.options,
+    activeIds: inboxPicker.activeIds,
+    onChange: inboxPicker.onChange,
     placeholder: 'Search inboxes...',
-    options: inboxOptions,
-    selectedIds: controller.emailInbox,
-    onChange: controller.setEmailInbox,
-  });
+    preserveOrder: true,
+    isDefault: inboxPicker.isDefault,
+    reset: inboxPicker.reset,
+    values: () => {
+      const ids = controller.emailInbox();
+      if (ids === undefined) return [{ id: 'all', label: 'All inboxes' }];
+      if (ids.length === 0) return [{ id: 'none', label: 'No inboxes' }];
+      const options = inboxPicker.options();
+      return ids.map((id) => {
+        const option = options.find((o) => o.id === id);
+        return { id, label: option?.label ?? id, icon: option?.icon };
+      });
+    },
+  };
 
   const channelIn = multiFacet({
     id: 'channel-in',
@@ -390,7 +341,7 @@ export function useSearchFacets(
   return createMemo(() => {
     switch (controller.type()) {
       case 'email':
-        return hasMultipleInboxes()
+        return inboxPicker.hasMultiple()
           ? [type, importance, inbox]
           : [type, importance];
       case 'channels':

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/search/search-facets.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/search/search-facets.tsx
@@ -1,9 +1,11 @@
 import type { CallStatus } from '@app/component/next-soup/filters/filter-store/types';
 import { EntityIcon } from '@core/component/EntityIcon';
+import { inboxIconProps } from '@core/component/inboxIcon';
 import { UserIcon } from '@core/component/UserIcon';
 import { useQuickAccess } from '@core/context/quickAccess';
 import { useUserId } from '@core/context/user';
 import { EntityIcon as EntityIconWithAvatar } from '@entity/extractors/entity-icon';
+import { useEmailLinksQuery } from '@queries/email/link';
 import { type Accessor, createMemo, type JSX } from 'solid-js';
 import type { SearchableOption } from '../searchable-multi-select';
 import type {
@@ -152,6 +154,29 @@ function usePersonPicker(): Accessor<SearchableOption[]> {
   });
 }
 
+/** Picker for the email "Inbox" chip — the user's linked inboxes. */
+function useInboxPicker(): Accessor<SearchableOption[]> {
+  const linksQuery = useEmailLinksQuery();
+
+  return createMemo(() =>
+    (linksQuery.data?.links ?? [])
+      .map((link) => ({
+        id: link.id,
+        label: link.email_address,
+        icon: () => (
+          <UserIcon
+            {...inboxIconProps(link.email_address)}
+            photoUrl={link.photo_url ?? undefined}
+            size="sm"
+            suppressClick
+            showTooltip={false}
+          />
+        ),
+      }))
+      .sort((a, b) => a.label.localeCompare(b.label))
+  );
+}
+
 function singleFacet(args: {
   id: string;
   label: string;
@@ -218,6 +243,8 @@ export function useSearchFacets(
 ): Accessor<SearchFacetVM[]> {
   const channelOptions = useChannelPicker();
   const personOptions = usePersonPicker();
+  const inboxOptions = useInboxPicker();
+  const hasMultipleInboxes = createMemo(() => inboxOptions().length > 1);
 
   const type = singleFacet({
     id: 'type',
@@ -251,6 +278,16 @@ export function useSearchFacets(
     },
     onSelect: (id) =>
       controller.setEmailImportance(id === 'all' ? undefined : id === 'signal'),
+  });
+
+  const inbox = multiFacet({
+    id: 'email-inbox',
+    label: 'Inbox',
+    neutralLabel: 'All inboxes',
+    placeholder: 'Search inboxes...',
+    options: inboxOptions,
+    activeIds: controller.emailInbox,
+    onChange: controller.setEmailInbox,
   });
 
   const channelIn = multiFacet({
@@ -312,7 +349,9 @@ export function useSearchFacets(
   return createMemo(() => {
     switch (controller.type()) {
       case 'email':
-        return [type, importance];
+        return hasMultipleInboxes()
+          ? [type, importance, inbox]
+          : [type, importance];
       case 'channels':
         return [type, channelIn, channelFrom];
       case 'calls':

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/search/search-filters-state.ts
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/search/search-filters-state.ts
@@ -40,7 +40,7 @@ export const SEARCH_INDEX_SEEDS: Record<SearchIndexId, Query> = {
 };
 
 export type SearchFiltersSections = {
-  email: { importance: boolean | undefined };
+  email: { importance: boolean | undefined; inboxIds: string[] };
   channels: { in: string[]; from: string[] };
   calls: { in: string[]; from: string[]; status: CallStatus | undefined };
 };
@@ -50,7 +50,7 @@ export type SearchFiltersState = SearchFiltersSections & {
 };
 
 export const DEFAULT_SECTIONS: SearchFiltersSections = {
-  email: { importance: undefined },
+  email: { importance: undefined, inboxIds: [] },
   channels: { in: [], from: [] },
   calls: { in: [], from: [], status: undefined },
 };
@@ -79,6 +79,7 @@ export function compileSearchQuery(state: SearchFiltersState): Query {
     if (state.email.importance !== undefined) {
       include.emailImportance = state.email.importance;
     }
+    if (state.email.inboxIds.length) include.emailLinkId = state.email.inboxIds;
   } else if (state.type === 'channels') {
     if (state.channels.in.length) include.channelId = state.channels.in;
     if (state.channels.from.length) {
@@ -117,6 +118,7 @@ export function createSearchFiltersController() {
     (ids ?? []).filter((id) => id !== NIL_UUID);
 
   const emailImportance = () => include().emailImportance;
+  const emailInbox = createMemo(() => withoutNil(include().emailLinkId));
   const channelIn = createMemo(() => withoutNil(include().channelId));
   const channelFrom = createMemo(() => withoutNil(include().channelSenderId));
   const callIn = createMemo(() => withoutNil(include().callChannelId));
@@ -125,7 +127,7 @@ export function createSearchFiltersController() {
     include().callStatus ?? callStatusFromAttended(include().callAttended);
 
   const currentSections = (): SearchFiltersSections => ({
-    email: { importance: emailImportance() },
+    email: { importance: emailImportance(), inboxIds: emailInbox() },
     channels: { in: channelIn(), from: channelFrom() },
     calls: { in: callIn(), from: callFrom(), status: callStatus() },
   });
@@ -151,7 +153,10 @@ export function createSearchFiltersController() {
     if (next === current) return;
 
     if (current === 'email') {
-      stash = { ...stash, email: { importance: emailImportance() } };
+      stash = {
+        ...stash,
+        email: { importance: emailImportance(), inboxIds: emailInbox() },
+      };
     } else if (current === 'channels') {
       stash = { ...stash, channels: { in: channelIn(), from: channelFrom() } };
     } else if (current === 'calls') {
@@ -169,7 +174,12 @@ export function createSearchFiltersController() {
     setType,
     emailImportance,
     setEmailImportance: (importance: boolean | undefined) =>
-      applySections({ email: { importance } }),
+      applySections({ email: { importance, inboxIds: emailInbox() } }),
+    emailInbox,
+    setEmailInbox: (ids: string[]) =>
+      applySections({
+        email: { importance: emailImportance(), inboxIds: ids },
+      }),
     channelIn,
     setChannelIn: (ids: string[]) =>
       applySections({ channels: { in: ids, from: channelFrom() } }),

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/search/search-filters-state.ts
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/search/search-filters-state.ts
@@ -40,7 +40,9 @@ export const SEARCH_INDEX_SEEDS: Record<SearchIndexId, Query> = {
 };
 
 export type SearchFiltersSections = {
-  email: { importance: boolean | undefined; inboxIds: string[] };
+  // inboxIds: `undefined` = all inboxes (default), `[]` = explicitly none,
+  // a subset = those inboxes — same model as the mail view's inbox filter.
+  email: { importance: boolean | undefined; inboxIds: string[] | undefined };
   channels: { in: string[]; from: string[] };
   calls: { in: string[]; from: string[]; status: CallStatus | undefined };
 };
@@ -50,7 +52,7 @@ export type SearchFiltersState = SearchFiltersSections & {
 };
 
 export const DEFAULT_SECTIONS: SearchFiltersSections = {
-  email: { importance: undefined, inboxIds: [] },
+  email: { importance: undefined, inboxIds: undefined },
   channels: { in: [], from: [] },
   calls: { in: [], from: [], status: undefined },
 };
@@ -79,7 +81,11 @@ export function compileSearchQuery(state: SearchFiltersState): Query {
     if (state.email.importance !== undefined) {
       include.emailImportance = state.email.importance;
     }
-    if (state.email.inboxIds.length) include.emailLinkId = state.email.inboxIds;
+    if (state.email.inboxIds !== undefined) {
+      include.emailLinkId = state.email.inboxIds.length
+        ? state.email.inboxIds
+        : [NIL_UUID];
+    }
   } else if (state.type === 'channels') {
     if (state.channels.in.length) include.channelId = state.channels.in;
     if (state.channels.from.length) {
@@ -118,7 +124,10 @@ export function createSearchFiltersController() {
     (ids ?? []).filter((id) => id !== NIL_UUID);
 
   const emailImportance = () => include().emailImportance;
-  const emailInbox = createMemo(() => withoutNil(include().emailLinkId));
+  const emailInbox = createMemo<string[] | undefined>(() => {
+    const ids = include().emailLinkId;
+    return ids === undefined ? undefined : withoutNil(ids);
+  });
   const channelIn = createMemo(() => withoutNil(include().channelId));
   const channelFrom = createMemo(() => withoutNil(include().channelSenderId));
   const callIn = createMemo(() => withoutNil(include().callChannelId));
@@ -176,7 +185,7 @@ export function createSearchFiltersController() {
     setEmailImportance: (importance: boolean | undefined) =>
       applySections({ email: { importance, inboxIds: emailInbox() } }),
     emailInbox,
-    setEmailInbox: (ids: string[]) =>
+    setEmailInbox: (ids: string[] | undefined) =>
       applySections({
         email: { importance: emailImportance(), inboxIds: ids },
       }),

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/searchable-multi-select.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/searchable-multi-select.tsx
@@ -39,6 +39,8 @@ type SearchableMultiSelectProps = {
   listboxClass?: string;
   /** Keep `options` in their given order instead of pinning selected first. */
   preserveOrder?: boolean;
+  /** Render a per-row "Only" action that narrows the selection to that row. */
+  onOnly?: (id: string) => void;
   open?: Accessor<boolean>;
   onOpenChange?: (open: boolean) => void;
   children: JSX.Element;
@@ -46,6 +48,7 @@ type SearchableMultiSelectProps = {
 
 const SearchableMultiSelectItem = (itemProps: {
   item: CollectionNode<SearchableOption>;
+  onOnly?: (id: string) => void;
 }) => (
   <Combobox.Item
     item={itemProps.item}
@@ -72,12 +75,32 @@ const SearchableMultiSelectItem = (itemProps: {
     <Combobox.ItemLabel class="flex-1 truncate text-ink-muted group-data-selected:text-ink">
       {itemProps.item.rawValue.label}
     </Combobox.ItemLabel>
+    <Show when={itemProps.onOnly}>
+      {(onOnly) => (
+        <button
+          type="button"
+          class="shrink-0 text-xxs text-ink-muted opacity-0 group-hover:opacity-100 group-data-highlighted:opacity-100 hover:text-ink"
+          onPointerDown={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+          }}
+          onPointerUp={(e) => e.stopPropagation()}
+          onClick={(e) => {
+            e.stopPropagation();
+            onOnly()(itemProps.item.rawValue.id);
+          }}
+        >
+          Only
+        </button>
+      )}
+    </Show>
   </Combobox.Item>
 );
 
 const VirtualizedListbox = (props: {
   options: SearchableOption[];
   class?: string;
+  onOnly?: (id: string) => void;
 }) => {
   let handle: VirtualizerHandle | undefined;
   return (
@@ -96,7 +119,9 @@ const VirtualizedListbox = (props: {
           data={[...items()]}
           itemSize={ITEM_HEIGHT}
         >
-          {(item) => <SearchableMultiSelectItem item={item} />}
+          {(item) => (
+            <SearchableMultiSelectItem item={item} onOnly={props.onOnly} />
+          )}
         </Virtualizer>
       )}
     </Combobox.Listbox>
@@ -220,6 +245,7 @@ export const SearchableMultiSelect = (props: SearchableMultiSelectProps) => {
                 <VirtualizedListbox
                   options={sortedOptions()}
                   class={props.listboxClass}
+                  onOnly={props.onOnly}
                 />
               </Show>
             </div>


### PR DESCRIPTION
Adds an Inbox facet to the search filter row: a multi-select shown when the email type is active and the account has more than one linked inbox, defaulting to All inboxes and compiling to `email_filters.link_ids`. State derives from `queryFilters` like the other facets, and the ✕ resets it to All inboxes.
