### PR TITLE
feat(email): show owning inbox icon in narrow email list rows

### DIFF
--- a/js/app/packages/entity/src/composed/list-entity/narrow-layout.tsx
+++ b/js/app/packages/entity/src/composed/list-entity/narrow-layout.tsx
@@ -9,9 +9,11 @@ import { SearchSender } from '../../extractors-search/search-sender';
 import {
   isChannelEntity,
   isChannelMessageEntity,
+  isEmailEntity,
   isTaskEntity,
 } from '../../types/entity';
 import { isSearchEntity } from '../../types/search';
+import { EmailInboxChip } from './email';
 import type { LayoutProps } from './shared';
 
 export function NarrowLayout(props: LayoutProps) {
@@ -83,6 +85,9 @@ export function NarrowLayout(props: LayoutProps) {
               </span>
             );
           }}
+        </Show>
+        <Show when={isEmailEntity(props.entity) && props.entity}>
+          {(entity) => <EmailInboxChip entity={entity()} class="ml-auto" />}
         </Show>
       </Entity.Slot>
 


### PR DESCRIPTION
The narrow desktop list layout did not show which inbox an email belongs to when multiple inboxes are connected, unlike the wide and mobile layouts. Adds the same `EmailInboxChip` to `NarrowLayout` email rows, right-aligned next to the timestamp.
