### PR TITLE
Add hierarchical folder tree view to soup folders list

### DIFF
--- a/js/app/package.json
+++ b/js/app/package.json
@@ -55,6 +55,7 @@
 		"@lukemorales/query-key-factory": "^1.3.4",
 		"@normy/query-core": "^0.21.0",
 		"@phosphor-icons/core": "^2.1.1",
+		"@pierre/trees": "^1.0.0-beta.4",
 		"@solid-primitives/broadcast-channel": "^0.1.1",
 		"@solid-primitives/context": "^0.3.2",
 		"@solid-primitives/event-bus": "^1.1.2",

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/soup-filters-bar.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/soup-filters-bar.tsx
@@ -6,13 +6,20 @@ import { SoupViewContextSort } from '@app/component/next-soup/soup-view/filters-
 import { UnifiedFilterDropdown } from '@app/component/next-soup/soup-view/filters-bar/unified-filter-dropdown';
 import { useFilterRefinements } from '@app/component/next-soup/soup-view/filters-bar/use-filter-refinements';
 import {
+  type FoldersViewMode,
+  useSoupView,
+} from '@app/component/next-soup/soup-view/soup-view-context';
+import {
   SplitToolbarLeft,
   SplitToolbarRight,
 } from '@app/component/split-layout/components/SplitToolbar';
 import { useSplitPanelOrThrow } from '@app/component/split-layout/layoutUtils';
+import { TabsInset } from '@core/component/TabsInset';
 import { registerHotkey } from '@core/hotkey/hotkeys';
 import { TOKENS } from '@core/hotkey/tokens';
 import { isMobile } from '@core/mobile/isMobile';
+import RowsIcon from '@phosphor/rows.svg';
+import TreeViewIcon from '@phosphor/tree-view.svg';
 import EyeIcon from '@phosphor-icons/core/regular/eye.svg?component-solid';
 import EyeSlashIcon from '@phosphor-icons/core/regular/eye-slash.svg?component-solid';
 import { Button, Tooltip } from '@ui';
@@ -58,36 +65,80 @@ export function SoupFiltersBar() {
     return content.type === 'component' && content.id === 'search';
   });
 
+  const isFoldersView = createMemo(() => {
+    const content = panel.handle.content();
+    return content.type === 'component' && content.id === 'folders';
+  });
+
+  const { foldersViewMode, setFoldersViewMode } = useSoupView();
+
+  // Sort/group/filter/preview act on the soup list, which isn't shown while
+  // the folders hierarchy tree is active, so hide them in that mode.
+  const folderTreeActive = createMemo(
+    () => isFoldersView() && foldersViewMode() === 'tree'
+  );
+
   return (
     <Show when={!isMobile()}>
       <SplitToolbarLeft>
         <div class="flex items-start gap-1 min-w-0 flex-1">
           <Show when={!isSearchView()} fallback={<SearchFiltersRow />}>
-            <SoupViewContextSort />
-            <SoupViewContextGroup />
-            <UnifiedFilterDropdown
-              open={filterDropdownOpen}
-              onOpenChange={setFilterDropdownOpen}
-            />
+            <Show when={!folderTreeActive()}>
+              <SoupViewContextSort />
+              <SoupViewContextGroup />
+              <UnifiedFilterDropdown
+                open={filterDropdownOpen}
+                onOpenChange={setFilterDropdownOpen}
+              />
+            </Show>
           </Show>
         </div>
       </SplitToolbarLeft>
       <SplitToolbarRight>
-        <Tooltip hotkey={TOKENS.unifiedList.togglePreview} label="Preview">
-          <Button
-            onClick={togglePreview}
-            variant="base"
-            size="sm"
+        <Show when={isFoldersView()}>
+          <TabsInset
             depth={2}
-            class="bg-surface"
-          >
-            {soup.previewEntity() ? <EyeSlashIcon /> : <EyeIcon />}
-            <span>Preview</span>
-          </Button>
-        </Tooltip>
+            list={[
+              {
+                value: 'list',
+                label: (
+                  <span class="flex items-center gap-1">
+                    <RowsIcon class="size-3.5" />
+                    List
+                  </span>
+                ),
+              },
+              {
+                value: 'tree',
+                label: (
+                  <span class="flex items-center gap-1">
+                    <TreeViewIcon class="size-3.5" />
+                    Tree
+                  </span>
+                ),
+              },
+            ]}
+            value={foldersViewMode()}
+            onChange={(value) => setFoldersViewMode(value as FoldersViewMode)}
+          />
+        </Show>
+        <Show when={!folderTreeActive()}>
+          <Tooltip hotkey={TOKENS.unifiedList.togglePreview} label="Preview">
+            <Button
+              onClick={togglePreview}
+              variant="base"
+              size="sm"
+              depth={2}
+              class="bg-surface"
+            >
+              {soup.previewEntity() ? <EyeSlashIcon /> : <EyeIcon />}
+              <span>Preview</span>
+            </Button>
+          </Tooltip>
+        </Show>
       </SplitToolbarRight>
       {/* Active filters bar - shown below the toolbar when there are filters */}
-      <Show when={!isSearchView()}>
+      <Show when={!isSearchView() && !folderTreeActive()}>
         <SoupActiveFiltersBar
           filters={consolidatedFiltersList()}
           onClearAll={resetToTabDefaults}

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/soup-filters-bar.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/soup-filters-bar.tsx
@@ -5,21 +5,15 @@ import { SoupViewContextGroup } from '@app/component/next-soup/soup-view/filters
 import { SoupViewContextSort } from '@app/component/next-soup/soup-view/filters-bar/soup-view-context-sort';
 import { UnifiedFilterDropdown } from '@app/component/next-soup/soup-view/filters-bar/unified-filter-dropdown';
 import { useFilterRefinements } from '@app/component/next-soup/soup-view/filters-bar/use-filter-refinements';
-import {
-  type FoldersViewMode,
-  useSoupView,
-} from '@app/component/next-soup/soup-view/soup-view-context';
+import { useSoupView } from '@app/component/next-soup/soup-view/soup-view-context';
 import {
   SplitToolbarLeft,
   SplitToolbarRight,
 } from '@app/component/split-layout/components/SplitToolbar';
 import { useSplitPanelOrThrow } from '@app/component/split-layout/layoutUtils';
-import { TabsInset } from '@core/component/TabsInset';
 import { registerHotkey } from '@core/hotkey/hotkeys';
 import { TOKENS } from '@core/hotkey/tokens';
 import { isMobile } from '@core/mobile/isMobile';
-import RowsIcon from '@phosphor/rows.svg';
-import TreeViewIcon from '@phosphor/tree-view.svg';
 import EyeIcon from '@phosphor-icons/core/regular/eye.svg?component-solid';
 import EyeSlashIcon from '@phosphor-icons/core/regular/eye-slash.svg?component-solid';
 import { Button, Tooltip } from '@ui';
@@ -65,18 +59,9 @@ export function SoupFiltersBar() {
     return content.type === 'component' && content.id === 'search';
   });
 
-  const isFoldersView = createMemo(() => {
-    const content = panel.handle.content();
-    return content.type === 'component' && content.id === 'folders';
-  });
-
-  const { foldersViewMode, setFoldersViewMode } = useSoupView();
-
   // Sort/group/filter/preview act on the soup list, which isn't shown while
-  // the folders hierarchy tree is active, so hide them in that mode.
-  const folderTreeActive = createMemo(
-    () => isFoldersView() && foldersViewMode() === 'tree'
-  );
+  // the folder hierarchy tree is active, so hide them in that mode.
+  const { folderTreeActive } = useSoupView();
 
   return (
     <Show when={!isMobile()}>
@@ -95,33 +80,6 @@ export function SoupFiltersBar() {
         </div>
       </SplitToolbarLeft>
       <SplitToolbarRight>
-        <Show when={isFoldersView()}>
-          <TabsInset
-            depth={2}
-            list={[
-              {
-                value: 'list',
-                label: (
-                  <span class="flex items-center gap-1">
-                    <RowsIcon class="size-3.5" />
-                    List
-                  </span>
-                ),
-              },
-              {
-                value: 'tree',
-                label: (
-                  <span class="flex items-center gap-1">
-                    <TreeViewIcon class="size-3.5" />
-                    Tree
-                  </span>
-                ),
-              },
-            ]}
-            value={foldersViewMode()}
-            onChange={(value) => setFoldersViewMode(value as FoldersViewMode)}
-          />
-        </Show>
         <Show when={!folderTreeActive()}>
           <Tooltip hotkey={TOKENS.unifiedList.togglePreview} label="Preview">
             <Button

--- a/js/app/packages/app/component/next-soup/soup-view/folder-tree-index.test.ts
+++ b/js/app/packages/app/component/next-soup/soup-view/folder-tree-index.test.ts
@@ -1,0 +1,96 @@
+import type { Project } from '@service-storage/generated/schemas/project';
+import { describe, expect, it } from 'vitest';
+import { buildFolderTreeIndex } from './folder-tree-index';
+
+const project = (
+  id: string,
+  name: string,
+  parentId: string | null = null,
+  userId = 'user-1'
+): Project => ({
+  id,
+  name,
+  parentId,
+  type: 'project',
+  userId,
+});
+
+describe('buildFolderTreeIndex', () => {
+  it('builds nested directory paths from parentId links', () => {
+    const index = buildFolderTreeIndex([
+      project('a', 'Alpha'),
+      project('b', 'Beta', 'a'),
+      project('c', 'Gamma', 'b'),
+    ]);
+
+    expect(index.paths).toEqual(['Alpha/', 'Alpha/Beta/', 'Alpha/Beta/Gamma/']);
+    expect(index.idByPath.get('Alpha/Beta/Gamma/')).toBe('c');
+    expect(index.pathById.get('b')).toBe('Alpha/Beta/');
+  });
+
+  it('sorts siblings by name then id', () => {
+    const index = buildFolderTreeIndex([
+      project('1', 'zebra'),
+      project('2', 'Apple'),
+      project('3', 'mango'),
+    ]);
+
+    expect(index.paths).toEqual(['Apple/', 'mango/', 'zebra/']);
+  });
+
+  it('treats folders with missing parents as roots', () => {
+    const index = buildFolderTreeIndex([
+      project('a', 'Orphan', 'gone'),
+      project('b', 'Root'),
+    ]);
+
+    expect(index.paths).toEqual(['Orphan/', 'Root/']);
+  });
+
+  it('keeps paths unique when sibling names collide', () => {
+    const index = buildFolderTreeIndex([
+      project('a1', 'Notes'),
+      project('a2', 'Notes'),
+      project('a3', 'Notes'),
+    ]);
+
+    expect(index.paths).toEqual(['Notes/', 'Notes (2)/', 'Notes (3)/']);
+    // Suffixes are assigned in id order, so they are stable across rebuilds.
+    expect(index.idByPath.get('Notes/')).toBe('a1');
+    expect(index.idByPath.get('Notes (3)/')).toBe('a3');
+  });
+
+  it('sanitizes path separators and blank names', () => {
+    const index = buildFolderTreeIndex([
+      project('a', 'Q3/Q4 Planning'),
+      project('b', '   '),
+    ]);
+
+    expect(index.paths).toEqual(['Q3∕Q4 Planning/', 'Untitled/']);
+    expect(index.idByPath.get('Q3∕Q4 Planning/')).toBe('a');
+  });
+
+  it('filters to an owner but keeps ancestors of owned folders', () => {
+    const index = buildFolderTreeIndex(
+      [
+        project('shared-root', 'Team', null, 'someone-else'),
+        project('mine', 'Mine', 'shared-root', 'user-1'),
+        project('theirs', 'Theirs', 'shared-root', 'someone-else'),
+        project('top', 'Top', null, 'user-1'),
+      ],
+      { ownerId: 'user-1' }
+    );
+
+    expect(index.paths).toEqual(['Team/', 'Team/Mine/', 'Top/']);
+  });
+
+  it('drops folders trapped in parentId cycles without looping', () => {
+    const index = buildFolderTreeIndex([
+      project('a', 'A', 'b'),
+      project('b', 'B', 'a'),
+      project('ok', 'Ok'),
+    ]);
+
+    expect(index.paths).toEqual(['Ok/']);
+  });
+});

--- a/js/app/packages/app/component/next-soup/soup-view/folder-tree-index.test.ts
+++ b/js/app/packages/app/component/next-soup/soup-view/folder-tree-index.test.ts
@@ -84,6 +84,23 @@ describe('buildFolderTreeIndex', () => {
     expect(index.paths).toEqual(['Team/', 'Team/Mine/', 'Top/']);
   });
 
+  it('scopes paths to a subtree when rootId is given', () => {
+    const index = buildFolderTreeIndex(
+      [
+        project('a', 'Alpha'),
+        project('b', 'Beta', 'a'),
+        project('c', 'Gamma', 'b'),
+        project('d', 'Delta'),
+        // Orphans belong at the top level, never inside the subtree.
+        project('o', 'Orphan', 'gone'),
+      ],
+      { rootId: 'a' }
+    );
+
+    expect(index.paths).toEqual(['Beta/', 'Beta/Gamma/']);
+    expect(index.idByPath.get('Beta/Gamma/')).toBe('c');
+  });
+
   it('drops folders trapped in parentId cycles without looping', () => {
     const index = buildFolderTreeIndex([
       project('a', 'A', 'b'),

--- a/js/app/packages/app/component/next-soup/soup-view/folder-tree-index.ts
+++ b/js/app/packages/app/component/next-soup/soup-view/folder-tree-index.ts
@@ -1,0 +1,111 @@
+import type { Project } from '@service-storage/generated/schemas/project';
+
+/**
+ * Derived mapping between folder (project) entities and the canonical
+ * path strings used by `@pierre/trees`, which keys all tree state by path.
+ * Every folder renders as a directory, so every path ends with `/`.
+ */
+export interface FolderTreeIndex {
+  /** Canonical directory paths for every included folder. */
+  paths: string[];
+  /** Canonical path -> project id. */
+  idByPath: Map<string, string>;
+  /** Project id -> canonical path. */
+  pathById: Map<string, string>;
+  /** Project id -> source project. */
+  projectById: Map<string, Project>;
+}
+
+/**
+ * Folder names become path segments, so the path separator is swapped for a
+ * lookalike (U+2215 division slash) and blank names get a placeholder.
+ */
+const toPathSegment = (name: string) => {
+  const sanitized = name.replace(/\//g, '∕').trim();
+  return sanitized.length > 0 ? sanitized : 'Untitled';
+};
+
+/**
+ * Builds the path index for the folder hierarchy.
+ *
+ * - `ownerId` keeps only folders owned by that user, plus any ancestors
+ *   needed to render them in their real position in the hierarchy.
+ * - A folder whose `parentId` is missing from the input (e.g. deleted or
+ *   not visible) is treated as a root folder.
+ * - Duplicate sibling names get a ` (2)`, ` (3)`… suffix because paths must
+ *   be unique. Siblings are visited in (name, id) order so suffix
+ *   assignment is stable across rebuilds.
+ * - Folders trapped in a `parentId` cycle are unreachable from the root and
+ *   are dropped rather than looping forever; the server does not produce
+ *   cycles.
+ */
+export function buildFolderTreeIndex(
+  projects: Project[],
+  options: { ownerId?: string } = {}
+): FolderTreeIndex {
+  const byId = new Map(projects.map((project) => [project.id, project]));
+
+  let included: Set<string> | undefined;
+  if (options.ownerId !== undefined) {
+    included = new Set<string>();
+    for (const project of projects) {
+      if (project.userId !== options.ownerId) continue;
+      let current: Project | undefined = project;
+      while (current && !included.has(current.id)) {
+        included.add(current.id);
+        current = current.parentId ? byId.get(current.parentId) : undefined;
+      }
+    }
+  }
+
+  const ROOT = '';
+  const childrenOf = new Map<string, Project[]>();
+  for (const project of projects) {
+    if (included && !included.has(project.id)) continue;
+    const hasParent =
+      project.parentId != null &&
+      byId.has(project.parentId) &&
+      (!included || included.has(project.parentId));
+    const parentKey = hasParent ? (project.parentId as string) : ROOT;
+    const siblings = childrenOf.get(parentKey);
+    if (siblings) siblings.push(project);
+    else childrenOf.set(parentKey, [project]);
+  }
+
+  const paths: string[] = [];
+  const idByPath = new Map<string, string>();
+  const pathById = new Map<string, string>();
+  const projectById = new Map<string, Project>();
+
+  const visit = (parentKey: string, parentPath: string) => {
+    const children = childrenOf.get(parentKey);
+    if (!children) return;
+    // Sort by the displayed segment (not the raw name) so suffix
+    // assignment follows the visual order.
+    const ordered = children
+      .map((project) => ({ project, base: toPathSegment(project.name) }))
+      .sort(
+        (a, b) =>
+          a.base.localeCompare(b.base, undefined, { sensitivity: 'base' }) ||
+          a.project.id.localeCompare(b.project.id)
+      );
+    const usedSegments = new Set<string>();
+    for (const { project: child, base } of ordered) {
+      let segment = base;
+      for (let n = 2; usedSegments.has(segment); n++) {
+        segment = `${base} (${n})`;
+      }
+      usedSegments.add(segment);
+
+      const path = `${parentPath}${segment}/`;
+      paths.push(path);
+      idByPath.set(path, child.id);
+      pathById.set(child.id, path);
+      projectById.set(child.id, child);
+      visit(child.id, path);
+    }
+  };
+  visit(ROOT, '');
+
+  return { paths, idByPath, pathById, projectById };
+}

--- a/js/app/packages/app/component/next-soup/soup-view/folder-tree-index.ts
+++ b/js/app/packages/app/component/next-soup/soup-view/folder-tree-index.ts
@@ -28,6 +28,8 @@ const toPathSegment = (name: string) => {
 /**
  * Builds the path index for the folder hierarchy.
  *
+ * - `rootId` scopes the tree to the descendants of that folder, with paths
+ *   relative to it (the root folder itself is not included).
  * - `ownerId` keeps only folders owned by that user, plus any ancestors
  *   needed to render them in their real position in the hierarchy.
  * - A folder whose `parentId` is missing from the input (e.g. deleted or
@@ -41,7 +43,7 @@ const toPathSegment = (name: string) => {
  */
 export function buildFolderTreeIndex(
   projects: Project[],
-  options: { ownerId?: string } = {}
+  options: { ownerId?: string; rootId?: string } = {}
 ): FolderTreeIndex {
   const byId = new Map(projects.map((project) => [project.id, project]));
 
@@ -58,6 +60,9 @@ export function buildFolderTreeIndex(
     }
   }
 
+  // Synthetic key folders attach to when they have no resolvable parent.
+  // Distinct from `rootId`: orphans belong at the top level of the full
+  // hierarchy, not inside whatever subtree is being rendered.
   const ROOT = '';
   const childrenOf = new Map<string, Project[]>();
   for (const project of projects) {
@@ -105,7 +110,7 @@ export function buildFolderTreeIndex(
       visit(child.id, path);
     }
   };
-  visit(ROOT, '');
+  visit(options.rootId ?? ROOT, '');
 
   return { paths, idByPath, pathById, projectById };
 }

--- a/js/app/packages/app/component/next-soup/soup-view/folder-view-mode.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/folder-view-mode.tsx
@@ -1,0 +1,53 @@
+import { usePreference } from '@app/preferences/use-preference';
+import { TabsInset } from '@core/component/TabsInset';
+import RowsIcon from '@phosphor/rows.svg';
+import TreeViewIcon from '@phosphor/tree-view.svg';
+
+/** How a folder hierarchy surface renders: flat list or tree. */
+export type FoldersViewMode = 'list' | 'tree';
+
+/**
+ * The sticky cross-session preference behind every List/Tree toggle.
+ * Surfaces that show the toggle in different component trees (soup views,
+ * the project block) each create their own instance with this shared key;
+ * the value is read on mount, so simultaneously visible instances don't
+ * live-sync — same trade-off as the soup sort preferences.
+ */
+export const useFolderViewModePreference = () =>
+  usePreference<FoldersViewMode>('macro:pref:soup:folders:view-mode', {
+    default: 'list',
+  });
+
+/** Segmented List/Tree control used in folder-surface top bars. */
+export const FolderViewModeToggle = (props: {
+  value: FoldersViewMode;
+  onChange: (mode: FoldersViewMode) => void;
+}) => {
+  return (
+    <TabsInset
+      depth={2}
+      list={[
+        {
+          value: 'list',
+          label: (
+            <span class="flex items-center gap-1">
+              <RowsIcon class="size-3.5" />
+              List
+            </span>
+          ),
+        },
+        {
+          value: 'tree',
+          label: (
+            <span class="flex items-center gap-1">
+              <TreeViewIcon class="size-3.5" />
+              Tree
+            </span>
+          ),
+        },
+      ]}
+      value={props.value}
+      onChange={(value) => props.onChange(value as FoldersViewMode)}
+    />
+  );
+};

--- a/js/app/packages/app/component/next-soup/soup-view/soup-folder-tree-view.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-folder-tree-view.tsx
@@ -9,6 +9,7 @@ import { useSplitPanelOrThrow } from '@app/component/split-layout/layoutUtils';
 import { LoadingBlock } from '@core/component/LoadingBlock';
 import { toast } from '@core/component/Toast/Toast';
 import { useUserId } from '@core/context/user';
+import EmptyStateFolderIcon from '@design/empty-state-folder.svg';
 import {
   FileTree,
   type FileTreeDirectoryHandle,
@@ -25,6 +26,7 @@ import {
 import { storageServiceClient } from '@service-storage/client';
 import type { Project } from '@service-storage/generated/schemas/project';
 import { refetchResources } from '@service-storage/util/refetchResources';
+import { EmptyStatePanel } from '@ui';
 import {
   createEffect,
   createMemo,
@@ -32,17 +34,22 @@ import {
   on,
   onCleanup,
   onMount,
+  Show,
   Switch,
 } from 'solid-js';
 
 /**
- * Hierarchical rendering of the folders view, built on `@pierre/trees`.
+ * Hierarchical rendering of a folder surface, built on `@pierre/trees`.
  * Folders come from the projects query (the soup query is paginated, so it
  * can't guarantee the ancestors a tree needs); the Owned/All tabs still
  * apply. Folders can be re-parented by dragging — including dropping onto
  * empty space to move a subfolder up to the top level.
+ *
+ * With `rootProjectId` the tree is scoped to that folder's subtree (used
+ * inside an open folder); dropping onto empty space then moves the dragged
+ * folder directly under the root folder.
  */
-export const SoupFolderTreeView = () => {
+export const SoupFolderTreeView = (props: { rootProjectId?: string }) => {
   const { activeTab } = useSoupView();
   const userId = useUserId();
   const projects = useProjectsQuery();
@@ -52,6 +59,7 @@ export const SoupFolderTreeView = () => {
     if (!data) return undefined;
     return buildFolderTreeIndex(data, {
       ownerId: activeTab() === 'owned' ? userId() : undefined,
+      rootId: props.rootProjectId,
     });
   });
 
@@ -59,10 +67,23 @@ export const SoupFolderTreeView = () => {
     <div class="size-full min-h-0 bg-surface">
       <Switch>
         <Match when={treeIndex()?.paths.length}>
-          <FolderTreeCanvas index={treeIndex} />
+          <FolderTreeCanvas
+            index={treeIndex}
+            rootProjectId={props.rootProjectId}
+          />
         </Match>
         <Match when={treeIndex() || projects.isError}>
-          <EmptyState listView="folders" />
+          <Show
+            when={props.rootProjectId}
+            fallback={<EmptyState listView="folders" />}
+          >
+            <EmptyStatePanel
+              align="center"
+              graphic={EmptyStateFolderIcon}
+              title="No subfolders"
+              description="Folders created inside this folder will appear here."
+            />
+          </Show>
         </Match>
         <Match when={true}>
           <LoadingBlock />
@@ -91,6 +112,7 @@ const isDirectoryHandle = (
 
 const FolderTreeCanvas = (props: {
   index: () => FolderTreeIndex | undefined;
+  rootProjectId?: string;
 }) => {
   const panel = useSplitPanelOrThrow();
   const { searchText } = useSoupView();
@@ -98,9 +120,17 @@ const FolderTreeCanvas = (props: {
   let container!: HTMLDivElement;
   let tree: FileTree | undefined;
 
+  // A drop at the tree root means "top level" for the full hierarchy and
+  // "directly inside this folder" for a rooted subtree.
   const dropTargetParentId = (target: FileTreeDropContext['target']) => {
-    if (target.kind === 'root' || !target.directoryPath) return null;
-    return props.index()?.idByPath.get(target.directoryPath) ?? null;
+    if (target.kind === 'root' || !target.directoryPath) {
+      return props.rootProjectId ?? null;
+    }
+    return (
+      props.index()?.idByPath.get(target.directoryPath) ??
+      props.rootProjectId ??
+      null
+    );
   };
 
   // The tree applies drops to its own model before calling onDropComplete,

--- a/js/app/packages/app/component/next-soup/soup-view/soup-folder-tree-view.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-folder-tree-view.tsx
@@ -1,0 +1,319 @@
+import { EmptyState } from '@app/component/next-soup/soup-view/empty-states';
+import {
+  buildFolderTreeIndex,
+  type FolderTreeIndex,
+} from '@app/component/next-soup/soup-view/folder-tree-index';
+import { useSoupView } from '@app/component/next-soup/soup-view/soup-view-context';
+import { openEntityInSplitFromUnifiedList } from '@app/component/next-soup/utils';
+import { useSplitPanelOrThrow } from '@app/component/split-layout/layoutUtils';
+import { LoadingBlock } from '@core/component/LoadingBlock';
+import { toast } from '@core/component/Toast/Toast';
+import { useUserId } from '@core/context/user';
+import {
+  FileTree,
+  type FileTreeDirectoryHandle,
+  type FileTreeDropContext,
+  type FileTreeDropResult,
+  type FileTreeItemHandle,
+} from '@pierre/trees';
+import { queryClient } from '@queries/client';
+import { storageKeys } from '@queries/storage/keys';
+import {
+  invalidateProjects,
+  useProjectsQuery,
+} from '@queries/storage/projects';
+import { storageServiceClient } from '@service-storage/client';
+import type { Project } from '@service-storage/generated/schemas/project';
+import { refetchResources } from '@service-storage/util/refetchResources';
+import {
+  createEffect,
+  createMemo,
+  Match,
+  on,
+  onCleanup,
+  onMount,
+  Switch,
+} from 'solid-js';
+
+/**
+ * Hierarchical rendering of the folders view, built on `@pierre/trees`.
+ * Folders come from the projects query (the soup query is paginated, so it
+ * can't guarantee the ancestors a tree needs); the Owned/All tabs still
+ * apply. Folders can be re-parented by dragging — including dropping onto
+ * empty space to move a subfolder up to the top level.
+ */
+export const SoupFolderTreeView = () => {
+  const { activeTab } = useSoupView();
+  const userId = useUserId();
+  const projects = useProjectsQuery();
+
+  const treeIndex = createMemo<FolderTreeIndex | undefined>(() => {
+    const data = projects.data;
+    if (!data) return undefined;
+    return buildFolderTreeIndex(data, {
+      ownerId: activeTab() === 'owned' ? userId() : undefined,
+    });
+  });
+
+  return (
+    <div class="size-full min-h-0 bg-surface">
+      <Switch>
+        <Match when={treeIndex()?.paths.length}>
+          <FolderTreeCanvas index={treeIndex} />
+        </Match>
+        <Match when={treeIndex() || projects.isError}>
+          <EmptyState listView="folders" />
+        </Match>
+        <Match when={true}>
+          <LoadingBlock />
+        </Match>
+      </Switch>
+    </div>
+  );
+};
+
+/** Parent directory of a canonical path: `a/b/` -> `a/`, `b/` -> ``. */
+const parentPathOf = (path: string) => {
+  const trimmed = path.endsWith('/') ? path.slice(0, -1) : path;
+  const lastSlash = trimmed.lastIndexOf('/');
+  return lastSlash === -1 ? '' : trimmed.slice(0, lastSlash + 1);
+};
+
+/** Final segment of a canonical path: `a/b/` -> `b/`. */
+const basenameOf = (path: string) => path.slice(parentPathOf(path).length);
+
+const samePaths = (a: readonly string[], b: readonly string[]) =>
+  a.length === b.length && a.every((path, i) => path === b[i]);
+
+const isDirectoryHandle = (
+  item: FileTreeItemHandle
+): item is FileTreeDirectoryHandle => item.isDirectory();
+
+const FolderTreeCanvas = (props: {
+  index: () => FolderTreeIndex | undefined;
+}) => {
+  const panel = useSplitPanelOrThrow();
+  const { searchText } = useSoupView();
+
+  let container!: HTMLDivElement;
+  let tree: FileTree | undefined;
+
+  const dropTargetParentId = (target: FileTreeDropContext['target']) => {
+    if (target.kind === 'root' || !target.directoryPath) return null;
+    return props.index()?.idByPath.get(target.directoryPath) ?? null;
+  };
+
+  // The tree applies drops to its own model before calling onDropComplete,
+  // so persist the new parent and re-sync from the server — which confirms
+  // the move, or snaps the tree back if the server rejected it.
+  const persistMove = async (movedIds: string[], parentId: string | null) => {
+    queryClient.setQueryData<{ projects: Project[]; pending: Project[] }>(
+      storageKeys.projects.list.queryKey,
+      (old) => {
+        if (!old) return old;
+        const reparent = (p: Project) =>
+          movedIds.includes(p.id) ? { ...p, parentId } : p;
+        return {
+          projects: old.projects.map(reparent),
+          pending: old.pending.map(reparent),
+        };
+      }
+    );
+
+    let failures = 0;
+    try {
+      const results = await Promise.all(
+        movedIds.map((id) =>
+          storageServiceClient.projects.edit({
+            id,
+            projectParentId: parentId,
+          })
+        )
+      );
+      failures = results.filter((result) => result.isErr()).length;
+    } catch {
+      failures = movedIds.length;
+    }
+
+    if (failures > 0) {
+      toast.failure(
+        failures === 1
+          ? 'Could not move folder'
+          : `Could not move ${failures} folders`
+      );
+    }
+
+    await invalidateProjects();
+    refetchResources();
+  };
+
+  // Mirror a move the tree has already applied to itself into the index
+  // maps, so expansion capture keeps working in the window before the
+  // projects cache catches up and the index is rebuilt.
+  const remapMovedPaths = (
+    index: FolderTreeIndex,
+    from: string,
+    to: string
+  ) => {
+    const moved: Array<[oldPath: string, newPath: string, id: string]> = [];
+    for (const [path, id] of index.idByPath) {
+      if (path === from || path.startsWith(from)) {
+        moved.push([path, `${to}${path.slice(from.length)}`, id]);
+      }
+    }
+    for (const [oldPath, newPath, id] of moved) {
+      index.idByPath.delete(oldPath);
+      index.idByPath.set(newPath, id);
+      index.pathById.set(id, newPath);
+    }
+  };
+
+  const handleDrop = (result: FileTreeDropResult) => {
+    const index = props.index();
+    if (!index) return;
+
+    // `draggedPaths` are the pre-move paths; the tree has already moved them
+    // under the target. Resolve ids before remapping the index to match.
+    const targetDirPath =
+      result.target.kind === 'root' ? '' : (result.target.directoryPath ?? '');
+    const parentId = dropTargetParentId(result.target);
+    const movedIds: string[] = [];
+    for (const oldPath of result.draggedPaths) {
+      const id = index.idByPath.get(oldPath);
+      if (id === undefined) continue;
+      movedIds.push(id);
+      remapMovedPaths(index, oldPath, `${targetDirPath}${basenameOf(oldPath)}`);
+    }
+    if (movedIds.length === 0) return;
+
+    void persistMove(movedIds, parentId);
+  };
+
+  const expandedPathsFor = (
+    nextIndex: FolderTreeIndex,
+    prevIndex: FolderTreeIndex
+  ) => {
+    if (!tree) return [];
+    const expanded: string[] = [];
+    for (const [path, id] of prevIndex.idByPath) {
+      const item = tree.getItem(path);
+      if (!item || !isDirectoryHandle(item) || !item.isExpanded()) continue;
+      const nextPath = nextIndex.pathById.get(id);
+      if (nextPath) expanded.push(nextPath);
+    }
+    return expanded;
+  };
+
+  onMount(() => {
+    const index = props.index();
+    if (!index) return;
+
+    tree = new FileTree({
+      paths: index.paths,
+      initialExpansion: 'open',
+      stickyFolders: true,
+      search: false,
+      dragAndDrop: {
+        // Dropping items where they already live is a no-op; suppress the
+        // drop affordance instead of erroring.
+        canDrop: ({ draggedPaths, target }) => {
+          const targetPath =
+            target.kind === 'root' ? '' : (target.directoryPath ?? '');
+          return draggedPaths.some((path) => parentPathOf(path) !== targetPath);
+        },
+        onDropComplete: handleDrop,
+        onDropError: () => toast.failure('Could not move folder'),
+      },
+    });
+
+    tree.render({ containerWrapper: container });
+
+    const initialSearch = searchText();
+    if (initialSearch) tree.setSearch(initialSearch);
+  });
+
+  onCleanup(() => {
+    tree?.cleanUp();
+    tree = undefined;
+  });
+
+  // Rebuild the tree when the underlying folder set changes (create, delete,
+  // rename, move, tab switch), carrying expansion over by folder id.
+  createEffect(
+    on(
+      () => props.index(),
+      (index, prevIndex) => {
+        if (!tree || !index || !prevIndex) return;
+        if (samePaths(index.paths, prevIndex.paths)) return;
+        tree.resetPaths(index.paths, {
+          initialExpandedPaths: expandedPathsFor(index, prevIndex),
+        });
+      },
+      { defer: true }
+    )
+  );
+
+  // The soup search bar drives the tree's search session, which filters to
+  // matching folders.
+  createEffect(
+    on(
+      searchText,
+      (text) => {
+        if (!tree) return;
+        if (text) tree.setSearch(text);
+        else if (tree.isSearchOpen()) tree.closeSearch();
+      },
+      { defer: true }
+    )
+  );
+
+  // Double-clicking a row opens the folder in this split (single click is
+  // expand/collapse + selection, handled by the tree itself). Tree rows live
+  // in a shadow root, so resolve the row via the composed event path.
+  const openFocusedFolder = (event: MouseEvent) => {
+    if (!tree) return;
+    const onRow = event
+      .composedPath()
+      .some(
+        (node) =>
+          node instanceof Element && node.getAttribute('role') === 'treeitem'
+      );
+    if (!onRow) return;
+
+    const path = tree.getFocusedPath();
+    const index = props.index();
+    if (!path || !index) return;
+    const id = index.idByPath.get(path) ?? index.idByPath.get(`${path}/`);
+    const project = id ? index.projectById.get(id) : undefined;
+    if (!project) return;
+
+    void openEntityInSplitFromUnifiedList(
+      {
+        type: 'project',
+        id: project.id,
+        name: project.name,
+        ownerId: project.userId,
+      },
+      { splitHandle: panel.handle }
+    );
+  };
+
+  return (
+    <div
+      ref={container}
+      class="size-full min-h-0 overflow-hidden"
+      onDblClick={openFocusedFolder}
+      style={{
+        '--trees-bg-override': 'var(--color-surface)',
+        '--trees-fg-override': 'var(--color-ink)',
+        '--trees-fg-muted-override': 'var(--color-ink-muted)',
+        '--trees-accent-override': 'var(--color-accent)',
+        '--trees-border-color-override': 'var(--color-edge-muted)',
+        '--trees-selected-bg-override': 'var(--color-accent-bg)',
+        '--trees-selected-fg-override': 'var(--color-ink)',
+        '--trees-focus-ring-color-override': 'var(--color-accent)',
+        '--trees-font-family-override': 'var(--font-sans)',
+      }}
+    />
+  );
+};

--- a/js/app/packages/app/component/next-soup/soup-view/soup-view-context.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-view-context.tsx
@@ -29,6 +29,7 @@ import {
   soupItemMatchesListView,
 } from '@app/constants/list-views';
 import { useFeatureFlag } from '@app/lib/analytics/posthog';
+import { usePreference } from '@app/preferences/use-preference';
 import {
   ENABLE_FEATURED_SEARCH_RESULTS,
   ENABLE_SUPPORTED_SOUP_FOREIGN_ENTITIES_FLAG,
@@ -83,6 +84,9 @@ type DataSource<T> = {
   fetchNextPage: VoidFunction;
 };
 
+/** How the folders list view renders its results. */
+export type FoldersViewMode = 'list' | 'tree';
+
 interface SoupViewContextValues {
   soup: SoupState;
   source: DataSource<EntityData>;
@@ -102,6 +106,8 @@ interface SoupViewContextValues {
   setInboxFilter: Setter<string[] | undefined>;
   activeTab: Accessor<string | undefined>;
   setActiveTab: Setter<string | undefined>;
+  foldersViewMode: Accessor<FoldersViewMode>;
+  setFoldersViewMode: Setter<FoldersViewMode>;
   groupByField: Accessor<GroupByField | undefined>;
   fetchNextGroupPage: (groupKey: string) => Promise<void>;
   isFetchingGroupPage: (groupKey: string) => boolean;
@@ -249,6 +255,14 @@ export const SoupViewContextProvider: FlowComponent<
   const [activeTab, setActiveTab] = useEntryState<string | undefined>(
     'soup.tab',
     { default: undefined }
+  );
+
+  // Sticky choice between the flat list and the hierarchy tree on the
+  // folders view. A cross-session preference (not entry state) so the
+  // chosen mode applies every time the user lands on folders.
+  const [foldersViewMode, setFoldersViewMode] = usePreference<FoldersViewMode>(
+    'macro:pref:soup:folders:view-mode',
+    { default: 'list' }
   );
 
   const groupByField = createMemo((): GroupByField | undefined => {
@@ -606,6 +620,8 @@ export const SoupViewContextProvider: FlowComponent<
     setInboxFilter,
     activeTab,
     setActiveTab,
+    foldersViewMode,
+    setFoldersViewMode,
     groupByField,
     fetchNextGroupPage,
     isFetchingGroupPage,

--- a/js/app/packages/app/component/next-soup/soup-view/soup-view-context.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-view-context.tsx
@@ -20,6 +20,10 @@ import {
 } from '@app/component/next-soup/filters/filter-store/query-store';
 import { createGroupedSoupQueries } from '@app/component/next-soup/soup-view/create-grouped-soup-queries';
 import { createSearchState } from '@app/component/next-soup/soup-view/create-search-state';
+import {
+  type FoldersViewMode,
+  useFolderViewModePreference,
+} from '@app/component/next-soup/soup-view/folder-view-mode';
 import { deduplicateEntities } from '@app/component/next-soup/utils';
 import { useEntryState } from '@app/component/split-layout/entry-state';
 import { useSplitPanelOrThrow } from '@app/component/split-layout/layoutUtils';
@@ -29,13 +33,13 @@ import {
   soupItemMatchesListView,
 } from '@app/constants/list-views';
 import { useFeatureFlag } from '@app/lib/analytics/posthog';
-import { usePreference } from '@app/preferences/use-preference';
 import {
   ENABLE_FEATURED_SEARCH_RESULTS,
   ENABLE_SUPPORTED_SOUP_FOREIGN_ENTITIES_FLAG,
   ENABLE_SUPPORTED_SOUP_FOREIGN_ENTITIES_OVERRIDE,
 } from '@core/constant/featureFlags';
 import { useUserId } from '@core/context/user';
+import { isMobile } from '@core/mobile/isMobile';
 import {
   type EntityData,
   getPropertyOptionLabel,
@@ -84,9 +88,6 @@ type DataSource<T> = {
   fetchNextPage: VoidFunction;
 };
 
-/** How the folders list view renders its results. */
-export type FoldersViewMode = 'list' | 'tree';
-
 interface SoupViewContextValues {
   soup: SoupState;
   source: DataSource<EntityData>;
@@ -108,6 +109,14 @@ interface SoupViewContextValues {
   setActiveTab: Setter<string | undefined>;
   foldersViewMode: Accessor<FoldersViewMode>;
   setFoldersViewMode: Setter<FoldersViewMode>;
+  /**
+   * True when the current view is a folder-hierarchy surface that offers
+   * the List/Tree toggle: the folders list view, or the documents (Files)
+   * view with its Folders tab selected. Desktop only.
+   */
+  folderTreeAvailable: Accessor<boolean>;
+  /** True when the toggle is available and tree mode is selected. */
+  folderTreeActive: Accessor<boolean>;
   groupByField: Accessor<GroupByField | undefined>;
   fetchNextGroupPage: (groupKey: string) => Promise<void>;
   isFetchingGroupPage: (groupKey: string) => boolean;
@@ -257,13 +266,10 @@ export const SoupViewContextProvider: FlowComponent<
     { default: undefined }
   );
 
-  // Sticky choice between the flat list and the hierarchy tree on the
-  // folders view. A cross-session preference (not entry state) so the
-  // chosen mode applies every time the user lands on folders.
-  const [foldersViewMode, setFoldersViewMode] = usePreference<FoldersViewMode>(
-    'macro:pref:soup:folders:view-mode',
-    { default: 'list' }
-  );
+  // Sticky choice between the flat list and the hierarchy tree on folder
+  // surfaces. A cross-session preference (not entry state) so the chosen
+  // mode applies every time the user lands on a folder view.
+  const [foldersViewMode, setFoldersViewMode] = useFolderViewModePreference();
 
   const groupByField = createMemo((): GroupByField | undefined => {
     const id = soup.grouping.activeGroupId();
@@ -348,6 +354,18 @@ export const SoupViewContextProvider: FlowComponent<
     if (content.type !== 'component') return;
     return isListViewID(content.id) ? content.id : undefined;
   });
+
+  const folderTreeAvailable = createMemo(() => {
+    if (isMobile()) return false;
+    const view = activeListView();
+    return (
+      view === 'folders' || (view === 'documents' && activeTab() === 'folders')
+    );
+  });
+
+  const folderTreeActive = createMemo(
+    () => folderTreeAvailable() && foldersViewMode() === 'tree'
+  );
 
   const itemsQuery = useSoupAstItemsQuery(
     () => ({
@@ -622,6 +640,8 @@ export const SoupViewContextProvider: FlowComponent<
     setActiveTab,
     foldersViewMode,
     setFoldersViewMode,
+    folderTreeAvailable,
+    folderTreeActive,
     groupByField,
     fetchNextGroupPage,
     isFetchingGroupPage,

--- a/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
@@ -21,6 +21,7 @@ import { InboxSelector } from '@app/component/next-soup/soup-view/filters-bar/in
 import { SoupFiltersBar } from '@app/component/next-soup/soup-view/filters-bar/soup-filters-bar';
 import { SoupSearchbar } from '@app/component/next-soup/soup-view/filters-bar/soup-view-search-bar';
 import { useFilterRefinements } from '@app/component/next-soup/soup-view/filters-bar/use-filter-refinements';
+import { FolderViewModeToggle } from '@app/component/next-soup/soup-view/folder-view-mode';
 import { MaybeSoupEntityActionDrawerManager } from '@app/component/next-soup/soup-view/SoupEntityActionDrawerManager';
 import type { SystemSortOption } from '@app/component/next-soup/soup-view/sort-options';
 import { SoupEntityContextMenu } from '@app/component/next-soup/soup-view/soup-entity-context-menu';
@@ -478,6 +479,7 @@ export const SoupView = (props: SoupViewProps) => {
                     !narrowSearchExpanded() && !isComponentListView('search')
                   }
                 >
+                  <SoupHeaderFolderViewToggle />
                   <SoupViewCreateButton />
                 </Show>
                 <Show when={narrowSearchExpanded()}>
@@ -546,7 +548,6 @@ export const SoupView = (props: SoupViewProps) => {
           <div class="relative grow min-h-1 flex max-sm:flex-col flex-row size-full">
             <Suspense>
               <SoupViewListOrFolderTree
-                activeListView={activeListView}
                 initialClientFilters={props.initialClientFilters}
                 initialGroupBy={props.initialGroupBy}
                 onScrollOffsetBaseline={resetFloatingButtonScrollTracking}
@@ -594,20 +595,31 @@ interface SoupViewListProps {
 }
 
 /**
- * Renders the folders view as a hierarchy tree when that mode is toggled
- * on (desktop only), and the regular soup list otherwise. The tree is not
+ * List/Tree toggle in the split header, shown on folder-hierarchy surfaces
+ * (the folders view, or the Files view with the Folders tab selected).
+ */
+const SoupHeaderFolderViewToggle = () => {
+  const { folderTreeAvailable, foldersViewMode, setFoldersViewMode } =
+    useSoupView();
+
+  return (
+    <Show when={folderTreeAvailable()}>
+      <FolderViewModeToggle
+        value={foldersViewMode()}
+        onChange={setFoldersViewMode}
+      />
+    </Show>
+  );
+};
+
+/**
+ * Renders folder-hierarchy surfaces as a tree when that mode is toggled on
+ * (desktop only), and the regular soup list otherwise. The tree is not
  * wrapped in the file dropzone: tree rows use native HTML5 drag for
  * re-parenting, which the dropzone would intercept as an invalid file drag.
  */
-const SoupViewListOrFolderTree = (
-  props: SoupViewListProps & { activeListView: Accessor<ListView | undefined> }
-) => {
-  const { foldersViewMode } = useSoupView();
-
-  const folderTreeActive = () =>
-    props.activeListView() === 'folders' &&
-    foldersViewMode() === 'tree' &&
-    !isMobile();
+const SoupViewListOrFolderTree = (props: SoupViewListProps) => {
+  const { folderTreeActive } = useSoupView();
 
   return (
     <Show

--- a/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
@@ -24,6 +24,7 @@ import { useFilterRefinements } from '@app/component/next-soup/soup-view/filters
 import { MaybeSoupEntityActionDrawerManager } from '@app/component/next-soup/soup-view/SoupEntityActionDrawerManager';
 import type { SystemSortOption } from '@app/component/next-soup/soup-view/sort-options';
 import { SoupEntityContextMenu } from '@app/component/next-soup/soup-view/soup-entity-context-menu';
+import { SoupFolderTreeView } from '@app/component/next-soup/soup-view/soup-folder-tree-view';
 import {
   persistSoupNavigationTouchHighlight,
   soupNavigationTouchHighlight,
@@ -544,14 +545,13 @@ export const SoupView = (props: SoupViewProps) => {
           </div>
           <div class="relative grow min-h-1 flex max-sm:flex-col flex-row size-full">
             <Suspense>
-              <SoupViewFileDropzone>
-                <SoupViewList
-                  initialClientFilters={props.initialClientFilters}
-                  initialGroupBy={props.initialGroupBy}
-                  onScrollOffsetBaseline={resetFloatingButtonScrollTracking}
-                  onScrollOffsetChange={handleSoupScrollOffsetChange}
-                />
-              </SoupViewFileDropzone>
+              <SoupViewListOrFolderTree
+                activeListView={activeListView}
+                initialClientFilters={props.initialClientFilters}
+                initialGroupBy={props.initialGroupBy}
+                onScrollOffsetBaseline={resetFloatingButtonScrollTracking}
+                onScrollOffsetChange={handleSoupScrollOffsetChange}
+              />
             </Suspense>
             <Show when={isMobile()}>
               <SoupViewMobileSettingsButton visible={floatingButtonsVisible} />
@@ -592,6 +592,41 @@ interface SoupViewListProps {
   onScrollOffsetBaseline?: (offset: number) => void;
   onScrollOffsetChange?: (offset: number) => void;
 }
+
+/**
+ * Renders the folders view as a hierarchy tree when that mode is toggled
+ * on (desktop only), and the regular soup list otherwise. The tree is not
+ * wrapped in the file dropzone: tree rows use native HTML5 drag for
+ * re-parenting, which the dropzone would intercept as an invalid file drag.
+ */
+const SoupViewListOrFolderTree = (
+  props: SoupViewListProps & { activeListView: Accessor<ListView | undefined> }
+) => {
+  const { foldersViewMode } = useSoupView();
+
+  const folderTreeActive = () =>
+    props.activeListView() === 'folders' &&
+    foldersViewMode() === 'tree' &&
+    !isMobile();
+
+  return (
+    <Show
+      when={folderTreeActive()}
+      fallback={
+        <SoupViewFileDropzone>
+          <SoupViewList
+            initialClientFilters={props.initialClientFilters}
+            initialGroupBy={props.initialGroupBy}
+            onScrollOffsetBaseline={props.onScrollOffsetBaseline}
+            onScrollOffsetChange={props.onScrollOffsetChange}
+          />
+        </SoupViewFileDropzone>
+      }
+    >
+      <SoupFolderTreeView />
+    </Show>
+  );
+};
 
 export const SoupViewList = (props: SoupViewListProps) => {
   const panel = useSplitPanelOrThrow();

--- a/js/app/packages/block-project/component/Block.tsx
+++ b/js/app/packages/block-project/component/Block.tsx
@@ -6,6 +6,8 @@ import {
 } from '@app/component/next-soup/create-soup-state';
 import { defineQueryFilters } from '@app/component/next-soup/filters/filter-store';
 import { SoupContextProvider } from '@app/component/next-soup/soup-context';
+import { useFolderViewModePreference } from '@app/component/next-soup/soup-view/folder-view-mode';
+import { SoupFolderTreeView } from '@app/component/next-soup/soup-view/soup-folder-tree-view';
 import { SoupViewList } from '@app/component/next-soup/soup-view/soup-view';
 import { SoupViewContextProvider } from '@app/component/next-soup/soup-view/soup-view-context';
 import { useMaybePreviewPanel } from '@app/component/PreviewPanel';
@@ -20,6 +22,7 @@ import { fileFolderDrop } from '@core/directive/fileFolderDrop';
 import { fileSelector } from '@core/directive/fileSelector';
 import { registerHotkey } from '@core/hotkey/hotkeys';
 import { TOKENS } from '@core/hotkey/tokens';
+import { isMobile } from '@core/mobile/isMobile';
 import { blockHotkeyScopeSignal } from '@core/signal/blockElement';
 import {
   handleFileFolderDrop,
@@ -97,6 +100,13 @@ const Block: Component = () => {
   const splitPanelContext = useSplitPanelOrThrow();
   const analytics = useAnalytics();
 
+  // List/Tree toggle for this folder's subfolder hierarchy. Shares the
+  // sticky preference with the soup folder views. Desktop only, and not
+  // offered on the special root/trash projects.
+  const [folderViewMode, setFolderViewMode] = useFolderViewModePreference();
+  const folderTreeActive = () =>
+    !isSpecialProject && !isMobile() && folderViewMode() === 'tree';
+
   const projectSoup = createSoupState({
     initialPredicates: { and: ['project-content'] },
     predicateConfigs: [
@@ -141,20 +151,30 @@ const Block: Component = () => {
           onDrop: (fileEntries, folderEntries) => {
             handleFileFolderDrop(fileEntries, folderEntries, handleFileUpload);
           },
-          disabled: isSpecialProject,
+          // Tree rows re-parent via native text/plain drags, which this
+          // dropzone would otherwise treat as a drag-in and cover with the
+          // upload overlay.
+          disabled: isSpecialProject || folderTreeActive(),
         }}
       >
         <ModalsProvider>
           <Show when={isDragging() && !isSpecialProject}>
             <FileDropOverlay>Upload to this folder</FileDropOverlay>
           </Show>
-          <TopBar />
+          <TopBar
+            folderViewToggle={
+              !isSpecialProject
+                ? { mode: folderViewMode(), onChange: setFolderViewMode }
+                : undefined
+            }
+          />
           <Show
             when={ENABLE_PROJECT_VIEW_PREVIEW}
             fallback={
               <ProjectEntityList
                 projectId={projectId}
                 soup={projectSoup}
+                folderTreeActive={folderTreeActive}
                 // Scope is already attached by the block container so we can use that
                 // Change this when we remove blocks
                 scopeId={blockHotkeyScopeSignal.get()}
@@ -174,6 +194,7 @@ const Block: Component = () => {
                 <ProjectEntityList
                   projectId={projectId}
                   soup={projectSoup}
+                  folderTreeActive={folderTreeActive}
                   // Scope is already attached by the block container so we can use that
                   // Change this when we remove blocks
                   scopeId={blockHotkeyScopeSignal.get()}
@@ -191,6 +212,7 @@ const ProjectEntityList = (props: {
   scopeId: string;
   projectId: string;
   soup: SoupState;
+  folderTreeActive: () => boolean;
 }) => {
   return (
     <SoupContextProvider soup={props.soup}>
@@ -209,7 +231,17 @@ const ProjectEntityList = (props: {
           },
         })}
       >
-        <SoupViewList customScrollbarHidden={true} scopeId={props.scopeId} />
+        <Show
+          when={props.folderTreeActive()}
+          fallback={
+            <SoupViewList
+              customScrollbarHidden={true}
+              scopeId={props.scopeId}
+            />
+          }
+        >
+          <SoupFolderTreeView rootProjectId={props.projectId} />
+        </Show>
       </SoupViewContextProvider>
     </SoupContextProvider>
   );

--- a/js/app/packages/block-project/component/TopBar.tsx
+++ b/js/app/packages/block-project/component/TopBar.tsx
@@ -4,6 +4,10 @@ import {
   openChatWithAgent,
 } from '@app/component/ChatWithAgentButton';
 import {
+  type FoldersViewMode,
+  FolderViewModeToggle,
+} from '@app/component/next-soup/soup-view/folder-view-mode';
+import {
   type BlockTool,
   ResponsivePermissionsBadge,
   ToolButton,
@@ -48,7 +52,13 @@ import { ProjectCreateMenu, useProjectCreateTools } from './ProjectCreateMenu';
 // TODO (SEAMUS) : Revisit this file when we figure out what we wanna do
 //     with folder block.
 
-export function TopBar() {
+export function TopBar(props: {
+  /** When set, shows the List/Tree toggle for this folder's contents. */
+  folderViewToggle?: {
+    mode: FoldersViewMode;
+    onChange: (mode: FoldersViewMode) => void;
+  };
+}) {
   const splitPanelContext = useSplitPanelOrThrow();
   const [preview] = splitPanelContext.previewState;
   const id = useBlockId();
@@ -149,6 +159,14 @@ export function TopBar() {
             </SplitToolbarLeft>
             <Show when={showToolbarRight()}>
               <SplitToolbarRight>
+                <Show when={props.folderViewToggle}>
+                  {(toggle) => (
+                    <FolderViewModeToggle
+                      value={toggle().mode}
+                      onChange={toggle().onChange}
+                    />
+                  )}
+                </Show>
                 <For each={tools}>
                   {(tool) => (
                     <Show when={!tool.condition || tool.condition()}>

--- a/js/bun.lock
+++ b/js/bun.lock
@@ -43,6 +43,7 @@
         "@lukemorales/query-key-factory": "^1.3.4",
         "@normy/query-core": "^0.21.0",
         "@phosphor-icons/core": "^2.1.1",
+        "@pierre/trees": "^1.0.0-beta.4",
         "@solid-primitives/broadcast-channel": "^0.1.1",
         "@solid-primitives/context": "^0.3.2",
         "@solid-primitives/event-bus": "^1.1.2",
@@ -842,7 +843,7 @@
 
     "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
 
-    "@inkibra/tauri-plugins": ["@inkibra/tauri-plugins@github:macro-inc/tauri-plugins#26537c8", { "dependencies": { "react": "^18.3.1", "react-dom": "^18.3.1" } }, "macro-inc-tauri-plugins-26537c8"],
+    "@inkibra/tauri-plugins": ["@inkibra/tauri-plugins@github:macro-inc/tauri-plugins#26537c8", { "dependencies": { "react": "^18.3.1", "react-dom": "^18.3.1" } }, "macro-inc-tauri-plugins-26537c8", "sha512-6p5xQAkS6Uw6J8Uh0vlj6MjKZXWps5E1Gu0hciBFq1E2BfPBZAgdeeafKnR3diNb4SXWK0JML49nAr+o5PhwKw=="],
 
     "@inquirer/external-editor": ["@inquirer/external-editor@1.0.3", "", { "dependencies": { "chardet": "^2.1.1", "iconv-lite": "^0.7.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA=="],
 
@@ -1097,6 +1098,8 @@
     "@paralleldrive/cuid2": ["@paralleldrive/cuid2@2.3.1", "", { "dependencies": { "@noble/hashes": "^1.1.5" } }, "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw=="],
 
     "@phosphor-icons/core": ["@phosphor-icons/core@2.1.1", "", {}, "sha512-v4ARvrip4qBCImOE5rmPUylOEK4iiED9ZyKjcvzuezqMaiRASCHKcRIuvvxL/twvLpkfnEODCOJp5dM4eZilxQ=="],
+
+    "@pierre/trees": ["@pierre/trees@1.0.0-beta.4", "", { "dependencies": { "preact": "11.0.0-beta.0", "preact-render-to-string": "6.6.5" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-OfT1yk9ne8Te5+GB5zUY8yqE6B8BqjBHQJleH4lu8ltwNpoocZl4vXt1AzlEExpxI/pp+AFX5QG+lR3JjtTEag=="],
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 
@@ -2570,7 +2573,7 @@
 
     "pathval": ["pathval@2.0.1", "", {}, "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ=="],
 
-    "pdfjs-dist": ["pdfjs-dist@github:macro-inc/pdf.js#f9b2ce6", { "dependencies": { "dommatrix": "^1.0.3", "web-streams-polyfill": "^3.2.1" }, "peerDependencies": { "worker-loader": "^3.0.8" }, "optionalPeers": ["worker-loader"] }, "macro-inc-pdf.js-f9b2ce6"],
+    "pdfjs-dist": ["pdfjs-dist@github:macro-inc/pdf.js#f9b2ce6", { "dependencies": { "dommatrix": "^1.0.3", "web-streams-polyfill": "^3.2.1" }, "peerDependencies": { "worker-loader": "^3.0.8" }, "optionalPeers": ["worker-loader"] }, "macro-inc-pdf.js-f9b2ce6", "sha512-HDFaPbCxLG2GHpf1smUG97nku5aPGBGaCcIbK05dGdp07TBLUlDcXsM4WcE82mO5W4RBPIBVYobX5N/6M6NFrA=="],
 
     "performance-now": ["performance-now@2.1.0", "", {}, "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="],
 
@@ -2592,7 +2595,9 @@
 
     "posthog-js": ["posthog-js@1.370.1", "", { "dependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/api-logs": "^0.208.0", "@opentelemetry/exporter-logs-otlp-http": "^0.208.0", "@opentelemetry/resources": "^2.2.0", "@opentelemetry/sdk-logs": "^0.208.0", "@posthog/core": "1.26.0", "@posthog/types": "1.370.1", "core-js": "^3.38.1", "dompurify": "^3.3.2", "fflate": "^0.4.8", "preact": "^10.28.2", "query-selector-shadow-dom": "^1.0.1", "web-vitals": "^5.1.0" } }, "sha512-cj9V6L0qyf0htMfBshBdwvcUEfhTfqUEQPI/ly2dN4kZx4QmhmKERcelSI9CMKoBD1gX5Fp+f/cNTwKvzDvjsQ=="],
 
-    "preact": ["preact@10.29.1", "", {}, "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg=="],
+    "preact": ["preact@11.0.0-beta.0", "", {}, "sha512-IcODoASASYwJ9kxz7+MJeiJhvLriwSb4y4mHIyxdgaRZp6kPUud7xytrk/6GZw8U3y6EFJaRb5wi9SrEK+8+lg=="],
+
+    "preact-render-to-string": ["preact-render-to-string@6.6.5", "", { "peerDependencies": { "preact": ">=10 || >= 11.0.0-0" } }, "sha512-O6MHzYNIKYaiSX3bOw0gGZfEbOmlIDtDfWwN1JJdc/T3ihzRT6tGGSEWE088dWrEDGa1u7101q+6fzQnO9XCPA=="],
 
     "prefix-style": ["prefix-style@2.0.1", "", {}, "sha512-gdr1MBNVT0drzTq95CbSNdsrBDoHGlb2aDJP/FoY+1e+jSDPOb1Cv554gH2MGiSr2WTcXi/zu+NaFzfcHQkfBQ=="],
 
@@ -3411,6 +3416,8 @@
     "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "posthog-js/fflate": ["fflate@0.4.8", "", {}, "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA=="],
+
+    "posthog-js/preact": ["preact@10.29.1", "", {}, "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg=="],
 
     "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 


### PR DESCRIPTION
## Summary
Adds a new hierarchical tree view for the folders list in the soup component, allowing users to visualize and interact with folder hierarchies. Users can toggle between a traditional list view and a new tree view for the folders tab.

## Key Changes
- **New folder tree view component** (`SoupFolderTreeView`): Renders folders as a hierarchical tree using the `@pierre/trees` library, with support for:
  - Drag-and-drop folder re-parenting
  - Search filtering
  - Double-click to open folders in split view
  - Expansion state persistence across rebuilds
  
- **Folder tree index builder** (`buildFolderTreeIndex`): Derives canonical path strings and mappings from project entities:
  - Handles nested folder hierarchies via `parentId` links
  - Supports owner filtering while preserving ancestor folders
  - Sanitizes path separators and handles duplicate sibling names with numeric suffixes
  - Detects and drops folders trapped in `parentId` cycles
  
- **View mode toggle**: Added `foldersViewMode` state to `SoupViewContext` to switch between 'list' and 'tree' modes, persisted via user preferences
  
- **UI updates**:
  - Added list/tree toggle buttons in the filters bar when folders view is active
  - Hides sort/group/filter controls when tree view is active (they don't apply to the hierarchy)
  - Conditionally renders tree view or list view based on active mode
  - Tree view excluded from file dropzone to avoid intercepting native drag-and-drop for folder re-parenting

- **Comprehensive test coverage**: Added unit tests for the folder tree index builder covering nesting, sorting, deduplication, sanitization, filtering, and cycle detection

## Notable Implementation Details
- Tree state (expansion, selection) is keyed by canonical paths; when the folder set changes, expansion is carried over by folder ID to maintain UX continuity
- Folder moves are optimistically applied to the tree and index, then persisted to the server; failures trigger a toast and re-sync from the server
- The tree uses CSS custom properties for theming to match the application's design system
- Desktop-only feature (tree view is hidden on mobile)

https://claude.ai/code/session_01Wnr6DeWQbE1mY33AyxvoTA