### PR TITLE
feat(sidebar): email account dropdown under the Email tab

### DIFF
--- a/js/app/packages/app/component/app-sidebar/sidebar.tsx
+++ b/js/app/packages/app/component/app-sidebar/sidebar.tsx
@@ -12,6 +12,11 @@ import {
 import { CommandState } from '@app/component/command';
 import { InteractiveOnboardingModal } from '@app/component/interactive-onboarding/InteractiveOnboardingModal';
 import { createMenuOpen, setCreateMenuOpen } from '@app/component/Launcher';
+import {
+  getInboxFilterSplit,
+  INBOX_FILTER_ENTRY_KEY,
+  requestInboxFilter,
+} from '@app/component/next-soup/soup-view/inbox-filter-controllers';
 import { requestSearchFocus } from '@app/component/next-soup/soup-view/search-controllers';
 import { useSplitLayout } from '@app/component/split-layout/layout';
 import type {
@@ -32,6 +37,7 @@ import { InCallPanel } from '@channel/Call';
 import { useCallContextOptional } from '@channel/Call/CallContext';
 import { useHasPaidAccess } from '@core/auth';
 import { ContextMenuContent, MenuItem } from '@core/component/ContextMenu';
+import { inboxIconProps } from '@core/component/inboxIcon';
 import { UserIcon } from '@core/component/UserIcon';
 import {
   DEV_MODE_ENV,
@@ -71,6 +77,7 @@ import { AnimatedTaskIcon } from '@icon/wide-task';
 import { ContextMenu } from '@kobalte/core/context-menu';
 import { useNotificationSettings } from '@notifications';
 import BellIcon from '@phosphor/bell.svg';
+import CaretDownIcon from '@phosphor/caret-down.svg';
 import CaretUpIcon from '@phosphor/caret-up.svg';
 import DeviceMobileIcon from '@phosphor/device-mobile-speaker.svg';
 import HomeIcon from '@phosphor/house.svg';
@@ -80,6 +87,7 @@ import PlayIcon from '@phosphor/play.svg';
 import PlugIcon from '@phosphor/plug.svg';
 import UserIconPhosphor from '@phosphor/user.svg';
 import UsersThreeIcon from '@phosphor/users-three.svg';
+import { useEmailLinksQuery } from '@queries/email/link';
 import { debounce } from '@solid-primitives/scheduled';
 import { makePersisted } from '@solid-primitives/storage';
 import { useLocation } from '@solidjs/router';
@@ -1014,8 +1022,9 @@ export const AppSidebar = (props: AppSidebarProps) => {
         <ul class="size-full px-2 flex flex-col gap-1">
           <For each={visibleLinks()}>
             {(link) => (
-              <li class="flex items-center justify-center">
-                <SidebarLink
+              <li class="flex flex-col items-center justify-center">
+                <Dynamic
+                  component={link.id === 'mail' ? SidebarMailLink : SidebarLink}
                   {...link}
                   sidebarState={props.sidebarState ?? 'expanded'}
                   hotkeyVisible={hotkeyVisible()}
@@ -1148,6 +1157,19 @@ export const AppSidebar = (props: AppSidebarProps) => {
 interface SidebarLinkProps extends SidebarItem {
   sidebarState: SidebarState;
   hotkeyVisible: boolean;
+  /**
+   * Skip the active background/text even when the view is active — used when
+   * a nested row (e.g. a single selected inbox) carries the highlight instead.
+   */
+  suppressActiveStyle?: boolean;
+  /** Called when the link is clicked while its view is already active. */
+  onActiveClick?: () => void;
+  /**
+   * Rendered at the link's right edge while the view is active, in place of
+   * the hover hotkey hints (the shortcut is redundant once active) — e.g. the
+   * Email link's expand chevron.
+   */
+  trailingWhenActive?: JSX.Element;
 }
 
 const SidebarLink = (props: SidebarLinkProps) => {
@@ -1155,12 +1177,13 @@ const SidebarLink = (props: SidebarLinkProps) => {
 
   const analytics = useAnalytics();
   const layout = useSplitLayout();
-  const layoutManager = globalSplitManager();
 
   const location = useLocation();
 
+  // Always read the manager signal live: it is undefined until the split
+  // layout mounts, which happens after the sidebar.
   const isActive = () => {
-    const activeContent = layoutManager?.activeSplit()?.content();
+    const activeContent = globalSplitManager()?.activeSplit()?.content();
 
     // In case we can't match on the active split, use the url path to determine
     // if this link is active
@@ -1217,7 +1240,9 @@ const SidebarLink = (props: SidebarLinkProps) => {
           data-active={isActive() ? '' : undefined}
           class={cn(
             'flex items-center justify-start group-data-[slim=true]/sidebar:justify-center text-sm gap-2 cursor-default w-full rounded-md py-1 text-ink-extra-muted not-disabled:hover:bg-ink/3',
-            isActive() && 'bg-ink/6 not-disabled:hover:bg-ink/6 text-ink'
+            isActive() &&
+              !props.suppressActiveStyle &&
+              'bg-ink/6 not-disabled:hover:bg-ink/6 text-ink'
           )}
           tooltipPlacement="right"
           onMouseEnter={() => setIsHovering(true)}
@@ -1239,7 +1264,7 @@ const SidebarLink = (props: SidebarLinkProps) => {
             });
 
             e.preventDefault();
-            let currentContentHandle = layoutManager?.activeSplit();
+            let currentContentHandle = globalSplitManager()?.activeSplit();
 
             const currentContent = currentContentHandle?.content();
             const isSameContent =
@@ -1254,13 +1279,15 @@ const SidebarLink = (props: SidebarLinkProps) => {
                 openWithSplit: layout.openWithSplit,
                 referredFrom: 'sidebar',
               });
+            } else {
+              props.onActiveClick?.();
             }
 
             if (props.id === 'search' && currentContentHandle) {
               requestSearchFocus(currentContentHandle.id);
             }
 
-            layoutManager?.returnFocus();
+            globalSplitManager()?.returnFocus();
           }}
         >
           <Show when={props.icon}>
@@ -1273,7 +1300,25 @@ const SidebarLink = (props: SidebarLinkProps) => {
             <span class="whitespace-nowrap">{props.label}</span>
           </div>
 
-          <Show when={isHovering() && !props.hotkeyVisible}>
+          <Show
+            when={
+              isActive() &&
+              props.trailingWhenActive !== undefined &&
+              !props.hotkeyVisible
+            }
+          >
+            <div class="group-data-[slim=true]/sidebar:hidden ml-auto flex items-center text-ink-muted">
+              {props.trailingWhenActive}
+            </div>
+          </Show>
+
+          <Show
+            when={
+              isHovering() &&
+              !props.hotkeyVisible &&
+              !(isActive() && props.trailingWhenActive !== undefined)
+            }
+          >
             <div class="group-data-[slim=true]/sidebar:hidden ml-auto">
               <div class="flex gap-1 items-center text-ink-extra-muted font-normal text-xxs">
                 <Show when={!props.standaloneHotkey}>
@@ -1318,5 +1363,172 @@ const SidebarLink = (props: SidebarLinkProps) => {
         </ContextMenuContent>
       </ContextMenu.Portal>
     </ContextMenu>
+  );
+};
+
+/**
+ * The Email sidebar link, acting as a dropdown for the user's linked inboxes.
+ * With multiple inboxes linked, the active link swaps its hotkey hint for a
+ * chevron; clicking the already-active link fans out a nested row per inbox,
+ * and clicking it again collapses the rows and returns to the unified inbox
+ * (all inboxes).
+ *
+ * The open/closed state is a plain user toggle, persisted across reloads —
+ * navigating to other views or into an email block never collapses the rows.
+ *
+ * Clicking an inbox row scopes the email list to only that inbox (the same
+ * `inboxFilter` the topbar inbox dropdown drives), navigating back to the
+ * list first if some other view is active. A row carries the active highlight
+ * only when it is the single selected inbox (read from the live mail view, or
+ * from the filter its history entry captured when something else is on top),
+ * in which case the parent link yields its own.
+ */
+const SidebarMailLink = (props: SidebarLinkProps) => {
+  const layout = useSplitLayout();
+  const linksQuery = useEmailLinksQuery();
+  const [expanded, setExpanded] = makePersisted(createSignal(false), {
+    name: 'sidebar-mail-accounts-expanded',
+  });
+
+  const links = createMemo(() =>
+    [...(linksQuery.data?.links ?? [])].sort((a, b) =>
+      a.email_address.localeCompare(b.email_address)
+    )
+  );
+
+  const isMailList = (content: SplitContent | undefined) =>
+    content?.type === 'component' && content.id === 'mail';
+
+  const canShow = () => props.sidebarState === 'expanded' && links().length > 1;
+
+  const showAccounts = () => canShow() && expanded();
+
+  const selectedIds = () => {
+    // Read the manager signal live: it is undefined until the split layout
+    // mounts, which can be after the sidebar.
+    const split = globalSplitManager()?.activeSplit();
+    if (!split) return undefined;
+    // Registered only while the split's mail list view is mounted.
+    const controller = getInboxFilterSplit(split.id);
+    if (controller) return controller.inboxFilter();
+    // Something else is on top (an email block, another view) — read the
+    // filter the mail list captured into its history entry on nav-away.
+    const entries = split.history();
+    for (let i = entries.length - 1; i >= 0; i--) {
+      const entry = entries[i];
+      if (isMailList(entry)) {
+        return entry.state?.[INBOX_FILTER_ENTRY_KEY] as string[] | undefined;
+      }
+    }
+    return undefined;
+  };
+
+  const onlySelectedId = () => {
+    const ids = selectedIds();
+    return ids?.length === 1 ? ids[0] : undefined;
+  };
+
+  // Scope the list to one inbox, first returning to the mail list (restoring
+  // the history entry if there is one) when some other view is active. The
+  // filter request is queued and applied as the list mounts.
+  const selectOnly = (linkId: string) => {
+    const manager = globalSplitManager();
+    let split = manager?.activeSplit();
+    if (!isMailList(split?.content())) {
+      split = navigateToSidebarView({
+        viewId: 'mail',
+        shiftKey: false,
+        activeSplit: split,
+        openWithSplit: layout.openWithSplit,
+        referredFrom: 'sidebar',
+      });
+    }
+    if (!split) return;
+    requestInboxFilter(split.id, [linkId]);
+    manager?.returnFocus();
+  };
+
+  return (
+    <>
+      <SidebarLink
+        {...props}
+        suppressActiveStyle={showAccounts() && onlySelectedId() !== undefined}
+        onActiveClick={() => {
+          if (!canShow()) return;
+          if (!expanded()) {
+            setExpanded(true);
+            return;
+          }
+          // Collapsing also returns to the unified inbox. Only fired while
+          // the mail list is the active content, so target the active split.
+          setExpanded(false);
+          const split = globalSplitManager()?.activeSplit();
+          if (split) requestInboxFilter(split.id, undefined);
+        }}
+        trailingWhenActive={
+          canShow() ? (
+            <CaretDownIcon
+              class={cn(
+                'size-3 transition-transform duration-200',
+                expanded() && 'rotate-180'
+              )}
+            />
+          ) : undefined
+        }
+      />
+      <Show when={canShow()}>
+        <div
+          class="grid w-full transition-[grid-template-rows] duration-200 ease-out"
+          style={{ 'grid-template-rows': expanded() ? '1fr' : '0fr' }}
+        >
+          <ul class="min-h-0 overflow-hidden flex flex-col gap-1">
+            <For each={links()}>
+              {(link, index) => (
+                <li
+                  class={cn(
+                    'flex items-center justify-center first:mt-1 transition-[opacity,transform] duration-200 ease-out',
+                    expanded()
+                      ? 'opacity-100 translate-y-0'
+                      : 'opacity-0 -translate-y-2'
+                  )}
+                  style={{
+                    'transition-delay': expanded()
+                      ? `${index() * 30}ms`
+                      : '0ms',
+                  }}
+                >
+                  <Button
+                    draggable={false}
+                    variant="ghost"
+                    disabled={!expanded()}
+                    data-sidebar-mail-account={link.email_address}
+                    data-active={onlySelectedId() === link.id ? '' : undefined}
+                    class={cn(
+                      'flex items-center justify-start text-sm gap-2 cursor-default w-full rounded-md py-1 pl-6 text-ink-extra-muted not-disabled:hover:bg-ink/3',
+                      onlySelectedId() === link.id &&
+                        'bg-ink/6 not-disabled:hover:bg-ink/6 text-ink'
+                    )}
+                    onMouseDown={(e) => {
+                      if (e.button !== 0) return;
+                      e.preventDefault();
+                      selectOnly(link.id);
+                    }}
+                  >
+                    <UserIcon
+                      {...inboxIconProps(link.email_address)}
+                      photoUrl={link.photo_url ?? undefined}
+                      size="sm"
+                      suppressClick
+                      showTooltip={false}
+                    />
+                    <span class="truncate">{link.email_address}</span>
+                  </Button>
+                </li>
+              )}
+            </For>
+          </ul>
+        </div>
+      </Show>
+    </>
   );
 };

--- a/js/app/packages/app/component/next-soup/soup-view/inbox-filter-controllers.ts
+++ b/js/app/packages/app/component/next-soup/soup-view/inbox-filter-controllers.ts
@@ -1,0 +1,64 @@
+import type { SplitId } from '@app/component/split-layout/layoutManager';
+import { type Accessor, createSignal } from 'solid-js';
+
+type InboxFilterController = {
+  /** `undefined` = all inboxes; otherwise the selected email link ids. */
+  inboxFilter: Accessor<string[] | undefined>;
+  setInboxFilter: (ids: string[] | undefined) => void;
+};
+
+/**
+ * Entry-state key the mail view persists its inbox filter under. Exposed so
+ * out-of-tree consumers (the sidebar) can read the filter a mail history
+ * entry captured on nav-away — e.g. while an email block is open on top.
+ */
+export const INBOX_FILTER_ENTRY_KEY = 'soup.inboxFilter';
+
+// Signal-of-Map (with equals: false) so consumers outside the split tree —
+// the sidebar's nested account rows — re-render on register/unregister.
+const [controllers, setControllers] = createSignal(
+  new Map<SplitId, InboxFilterController>(),
+  { equals: false }
+);
+const pendingFilterBySplit = new Map<SplitId, string[] | undefined>();
+
+export function registerInboxFilterSplit(
+  splitId: SplitId,
+  controller: InboxFilterController
+): () => void {
+  setControllers((map) => map.set(splitId, controller));
+  if (pendingFilterBySplit.has(splitId)) {
+    controller.setInboxFilter(pendingFilterBySplit.get(splitId));
+    pendingFilterBySplit.delete(splitId);
+  }
+  return () => {
+    setControllers((map) => {
+      if (map.get(splitId) === controller) map.delete(splitId);
+      return map;
+    });
+  };
+}
+
+/** Reactive: tracks registration changes and re-evaluates for callers. */
+export function getInboxFilterSplit(
+  splitId: SplitId
+): InboxFilterController | undefined {
+  return controllers().get(splitId);
+}
+
+/**
+ * Set the inbox filter for the given split. If the split's mail view is
+ * already mounted, apply immediately; otherwise queue the value and apply it
+ * once the view registers (e.g. right after a sidebar navigation).
+ */
+export function requestInboxFilter(
+  splitId: SplitId,
+  ids: string[] | undefined
+) {
+  const controller = controllers().get(splitId);
+  if (controller) {
+    controller.setInboxFilter(ids);
+    return;
+  }
+  pendingFilterBySplit.set(splitId, ids);
+}

--- a/js/app/packages/app/component/next-soup/soup-view/soup-view-context.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-view-context.tsx
@@ -20,6 +20,10 @@ import {
 } from '@app/component/next-soup/filters/filter-store/query-store';
 import { createInfiniteQueries } from '@app/component/next-soup/soup-view/create-infinite-queries';
 import { createSearchState } from '@app/component/next-soup/soup-view/create-search-state';
+import {
+  INBOX_FILTER_ENTRY_KEY,
+  registerInboxFilterSplit,
+} from '@app/component/next-soup/soup-view/inbox-filter-controllers';
 import { deduplicateEntities } from '@app/component/next-soup/utils';
 import { useEntryState } from '@app/component/split-layout/entry-state';
 import { useSplitPanelOrThrow } from '@app/component/split-layout/layoutUtils';
@@ -243,9 +247,22 @@ export const SoupViewContextProvider: FlowComponent<
     { default: [] }
   );
   const [inboxFilter, setInboxFilter] = useEntryState<string[] | undefined>(
-    'soup.inboxFilter',
+    INBOX_FILTER_ENTRY_KEY,
     { default: undefined }
   );
+
+  // Expose the mail view's inbox filter to consumers outside the split tree
+  // (the sidebar's nested account rows read and set it by split id).
+  {
+    const content = panel.handle.content();
+    if (content.type === 'component' && content.id === 'mail') {
+      const dispose = registerInboxFilterSplit(panel.handle.id, {
+        inboxFilter,
+        setInboxFilter,
+      });
+      onCleanup(dispose);
+    }
+  }
   const [activeTab, setActiveTab] = useEntryState<string | undefined>(
     'soup.tab',
     { default: undefined }


### PR DESCRIPTION
## What

When a user has multiple email accounts connected, the **Email** sidebar tab becomes a dropdown:

- While Email is the active view, the tab swaps its (now redundant) `[G][E]` hotkey hint for a chevron.
- Clicking the already-active Email tab fans out a nested row per linked inbox — avatar (same `UserIcon` + `photo_url` treatment as the topbar inbox dropdown) plus address, with a `grid-template-rows` expand animation and a 30ms-staggered fade/slide per row.
- Clicking the tab again collapses the rows **and** returns the list to the unified inbox (all inboxes).
- The open/closed state is a plain user toggle, persisted in localStorage. Navigating to Tasks, into an email block, etc. never auto-collapses the rows — only the user (or losing the multi-account/expanded-sidebar preconditions) hides them.
- Clicking an inbox row scopes the email list to only that inbox; if another view is active it first navigates back to the mail list (restoring the history entry when one exists) and applies the filter as the list mounts. A row carries the sidebar active highlight only when it is the single selected inbox, in which case the parent tab yields its highlight.
- Single-account users and slim/mobile sidebar see no change.

## How

- **New `inbox-filter-controllers.ts`** — a reactive per-split registry (modeled on `search-controllers.ts`) exposing the mail view's `inboxFilter`/`setInboxFilter` to consumers outside the split tree, with queued filter requests applied when the mail view mounts. The mail soup view registers itself in `soup-view-context.tsx`.
- The selected-row highlight survives the mail list unmounting (email block open, other view active) by falling back to the filter the mail entry captured into its history `state` blob; the entry-state key is now a shared `INBOX_FILTER_ENTRY_KEY` constant.
- `SidebarLink` gains optional `suppressActiveStyle`, `onActiveClick`, and `trailingWhenActive` props; the Email entry renders through a `SidebarMailLink` wrapper.

## Bug fix worth reviewer attention

`SidebarLink` previously captured the `globalSplitManager` **signal value once at mount** — but the sidebar mounts before the split layout sets it, so the captured manager was permanently `undefined`. Active-state detection silently fell through to the URL fallback, and clicking an already-active link took the navigate path instead of being recognized as a same-view click. The signal is now read live at each use. This subtly changes behavior for all sidebar links: same-view detection and `goToEntry` history restoration now work as originally intended rather than relying on `openWithSplit` no-ops.

## Testing

- `bun type-check` and biome pass.
- Manually exercised in dev throughout: expand/collapse toggle, per-inbox filtering synced with the topbar inbox dropdown, highlight persistence while reading an email, collapse-to-unified, and state persistence across navigation. (Multi-account behavior requires ≥2 linked inboxes.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)