### PR TITLE
fix(search): exclude crm entities from search view, filter ws-inserted entities client-side

### DIFF
--- a/js/app/packages/app/component/app-sidebar/soup-filter-presets.ts
+++ b/js/app/packages/app/component/app-sidebar/soup-filter-presets.ts
@@ -5,10 +5,7 @@ import {
   type Query,
 } from '@app/component/next-soup/filters/filter-store';
 import type { ListView } from '@app/constants/list-views';
-import {
-  ENABLE_CRM,
-  ENABLE_SUPPORTED_SOUP_FOREIGN_ENTITIES_OVERRIDE,
-} from '@core/constant/featureFlags';
+import { ENABLE_SUPPORTED_SOUP_FOREIGN_ENTITIES_OVERRIDE } from '@core/constant/featureFlags';
 import { PROPERTY_OPTION_IDS, SYSTEM_PROPERTY_IDS } from '@property/constants';
 import { startOfDay, subWeeks } from 'date-fns';
 
@@ -420,17 +417,17 @@ export const VIEW_TAB_PRESETS: Record<ListView, ViewTabConfig> = {
       all: () => ({
         // Temporary: search has no full-text index over foreign entities yet,
         // so always exclude them (matching no record id) until search supports
-        // them. CRM companies are included only when the CRM feature is enabled
-        // (the nil-uuid sentinel excludes them otherwise).
-        filters: ENABLE_CRM
-          ? { include: { foreignEntityRecordId: [NIL_UUID] } }
-          : {
-              include: {
-                foreignEntityRecordId: [NIL_UUID],
-                crmCompanyId: [NIL_UUID],
-              },
-            },
-        clientFilters: {},
+        // them. CRM rows are NIL-excluded the same way. `search-supported`
+        // mirrors these exclusions client-side so entities that enter the
+        // soup cache outside this query (e.g. websocket-driven inserts)
+        // don't surface in the search feed.
+        filters: {
+          include: {
+            foreignEntityRecordId: [NIL_UUID],
+            crmCompanyId: [NIL_UUID],
+          },
+        },
+        clientFilters: { and: ['search-supported'] },
       }),
     },
   },

--- a/js/app/packages/app/component/command/CommandMenu.tsx
+++ b/js/app/packages/app/component/command/CommandMenu.tsx
@@ -1,4 +1,5 @@
 import { useAnalytics } from '@app/component/analytics-context';
+import { getViewPreset } from '@app/component/app-sidebar/soup-filter-presets';
 import { getSearchSplit } from '@app/component/next-soup/soup-view/search-controllers';
 import { isListViewID } from '@app/constants/list-views';
 import { globalSplitManager } from '@app/signal/splitLayout';
@@ -236,9 +237,13 @@ export function CommandMenuInner(props: {
     }
 
     if (isSearchItem(item)) {
+      // Fall back to the search preset (not `{}`) so uncategorized searches
+      // keep the search view's baseline exclusions (foreign entities, CRM).
+      const preset = getViewPreset('search');
       const overrides = getCategorySearchFilters(item.category);
-      const filters = overrides?.filters ?? {};
-      const clientFilters = overrides?.clientFilters ?? {};
+      const filters = overrides?.filters ?? preset?.filters ?? {};
+      const clientFilters =
+        overrides?.clientFilters ?? preset?.clientFilters ?? {};
       const splitManager = globalSplitManager();
       const active = splitManager?.activeSplit();
       const activeContent = active?.content();

--- a/js/app/packages/app/component/command/category-search-filters.ts
+++ b/js/app/packages/app/component/command/category-search-filters.ts
@@ -33,6 +33,6 @@ export function getCategorySearchFilters(
 
   return {
     filters: SEARCH_INDEX_SEEDS[indexValue],
-    clientFilters: { or: [indexValue] },
+    clientFilters: { and: ['search-supported'], or: [indexValue] },
   };
 }

--- a/js/app/packages/app/component/next-soup/filters/configs/entity.ts
+++ b/js/app/packages/app/component/next-soup/filters/configs/entity.ts
@@ -9,6 +9,7 @@ import {
   crmCompanyFilter as crmCompanyPredicate,
   filesAndFolderFilter as filesAndFolderPredicate,
   projectFilter as projectPredicate,
+  searchSupportedFilter as searchSupportedPredicate,
   taskFilter as taskPredicate,
 } from '../predicates';
 import { config, isAgent, isNotTask, NIL_UUID } from './base';
@@ -85,4 +86,15 @@ export const crmCompanyHiddenFilter = config({
     { include: { crmCompanyHidden: true } },
     { skipTargets: ['ccf'] }
   ),
+});
+
+export const searchSupportedFilter = config({
+  id: 'search-supported',
+  predicate: searchSupportedPredicate,
+  query: {
+    include: {
+      foreignEntityRecordId: [NIL_UUID],
+      crmCompanyId: [NIL_UUID],
+    },
+  },
 });

--- a/js/app/packages/app/component/next-soup/filters/configs/index.ts
+++ b/js/app/packages/app/component/next-soup/filters/configs/index.ts
@@ -35,6 +35,7 @@ import {
   foldersFilter,
   inFolderFilter,
   notTaskFilter,
+  searchSupportedFilter,
 } from './entity';
 import { ENTITY_TYPE_FILTERS } from './entity-type';
 import {
@@ -88,6 +89,7 @@ export const SOUP_FILTERS = [
   crmCompanyHiddenFilter,
   emailAttachmentsFilter,
   inFolderFilter,
+  searchSupportedFilter,
   ...ENTITY_TYPE_FILTERS,
   ...TASK_STATUS_FILTERS,
   ...TASK_PRIORITY_FILTERS,

--- a/js/app/packages/app/component/next-soup/filters/predicates.ts
+++ b/js/app/packages/app/component/next-soup/filters/predicates.ts
@@ -113,6 +113,20 @@ export function crmCompanyFilter(entity: EntityData): boolean {
   return entity.type === 'crm_company';
 }
 
+/**
+ * Entity types the search view supports. Mirrors the search preset's
+ * server-side exclusions (foreign entities + CRM) so entities that enter
+ * the soup cache outside the query — e.g. websocket-driven optimistic
+ * inserts — don't surface in the search feed.
+ */
+export function searchSupportedFilter(entity: EntityData): boolean {
+  return (
+    entity.type !== 'foreign' &&
+    entity.type !== 'crm_company' &&
+    entity.type !== 'crm_contact'
+  );
+}
+
 export function crmCompanyActiveFilter(entity: EntityData): boolean {
   return entity.type === 'crm_company' && !entity.hidden;
 }

--- a/js/app/packages/app/component/next-soup/soup-view/create-search-state.ts
+++ b/js/app/packages/app/component/next-soup/soup-view/create-search-state.ts
@@ -195,8 +195,8 @@ export const createSearchState = ({
 
       // CRM is opt-in on the backend. A view includes CRM in search unless it
       // NIL-excludes the CRM target (the same sentinel pattern other entity
-      // types use) — so the Companies view (CRM-scoped) and the global Search
-      // view (no exclusions) search CRM, while every other view excludes it.
+      // types use) — so the Companies view (CRM-scoped) searches CRM, while
+      // every other view (including the global Search view) excludes it.
       const includeCrm = !(state.include.crmCompanyId ?? []).includes(NIL_UUID);
 
       if (!includeCrm) {
@@ -210,8 +210,8 @@ export const createSearchState = ({
 
       // CRM is opt-in on the backend. Search surfaces visible companies
       // everywhere except the admin Companies → Hidden tab, which sets
-      // `crmCompanyHidden: true` to search the hidden set. Elsewhere (global
-      // Search, Companies → Active) `crmCompanyHidden` is false/undefined →
+      // `crmCompanyHidden: true` to search the hidden set. Elsewhere
+      // (Companies → Active) `crmCompanyHidden` is false/undefined →
       // visible only. Non-CRM targets are already NIL-excluded by the
       // Companies preset.
       return {


### PR DESCRIPTION
Excludes CRM rows from the search view's soup call (alongside the existing foreign-entity exclusion) and adds a `search-supported` client filter so websocket-inserted entities (e.g. GitHub PRs) can't bypass the server filters and land in the feed. Also fixes uncategorized Cmd+K searches opening the search view with empty filters, which wiped the exclusions entirely.
