### PR TITLE
fix(email): pasted email mentions no longer show as deleted after a new-email notification

### DIFF
--- a/js/app/packages/notifications/notification-resolvers.ts
+++ b/js/app/packages/notifications/notification-resolvers.ts
@@ -3,7 +3,7 @@ import { itemToResolvedBlockName } from '@core/constant/allBlocks';
 import type { EntityType } from '@core/types';
 import { macroIdToEmail, tryMacroId, useDisplayName } from '@core/user';
 import { getItemPreview, isAccessiblePreviewItem } from '@queries/preview';
-import type { ItemType } from '@service-storage/client';
+import { stringToItemType } from '@service-storage/client';
 import { raceTimeout, until } from '@solid-primitives/promise';
 
 export type UserNameResolver = (id: string) => Promise<string | undefined>;
@@ -30,8 +30,10 @@ export const DefaultUserNameResolver: UserNameResolver = async (id: string) => {
 };
 
 const getPreview = async (id: string, type: EntityType) => {
+  const itemType = stringToItemType(type);
+  if (!itemType) return undefined;
   return await raceTimeout(
-    getItemPreview({ id, type: type as ItemType }),
+    getItemPreview({ id, type: itemType }),
     RESOLVER_TIMEOUT
   );
 };

--- a/js/app/packages/notifications/tests/notification-resolvers.test.ts
+++ b/js/app/packages/notifications/tests/notification-resolvers.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const getItemPreview = vi.fn();
+
+vi.mock('@queries/preview', () => ({
+  getItemPreview: (...args: unknown[]) => getItemPreview(...args),
+  isAccessiblePreviewItem: (item: { loading: boolean; access?: string }) =>
+    !item.loading && item.access === 'access',
+}));
+
+vi.mock('@core/user', () => ({
+  tryMacroId: () => undefined,
+  macroIdToEmail: () => undefined,
+  useDisplayName: () => [() => undefined],
+}));
+
+vi.mock('@core/constant/allBlocks', () => ({
+  itemToResolvedBlockName: () => undefined,
+}));
+
+// Importing the resolver pulls in @service-storage/client, whose module init
+// opens a websocket; stub it out before the dynamic import.
+vi.stubGlobal(
+  'WebSocket',
+  class {
+    addEventListener() {}
+    close() {}
+  }
+);
+
+const { DefaultDocumentNameResolver } = await import(
+  '../notification-resolvers'
+);
+
+describe('DefaultDocumentNameResolver', () => {
+  beforeEach(() => {
+    getItemPreview.mockReset();
+  });
+
+  it('maps email_thread entity type to the email item type', async () => {
+    getItemPreview.mockResolvedValue({
+      id: 'thread-1',
+      type: 'email',
+      loading: false,
+      access: 'access',
+      name: 'Test Subject',
+      rawName: 'Test Subject',
+    });
+
+    const name = await DefaultDocumentNameResolver('thread-1', 'email_thread');
+
+    expect(getItemPreview).toHaveBeenCalledWith({
+      id: 'thread-1',
+      type: 'email',
+    });
+    expect(name).toBe('Test Subject');
+  });
+
+  it('skips the preview fetch for entity types without a preview fetcher', async () => {
+    const name = await DefaultDocumentNameResolver('team-1', 'team');
+
+    expect(getItemPreview).not.toHaveBeenCalled();
+    expect(name).toBeUndefined();
+  });
+});

--- a/js/app/packages/queries/preview/dataloader.ts
+++ b/js/app/packages/queries/preview/dataloader.ts
@@ -34,13 +34,15 @@ class PreviewDataLoader {
           const requests = this.pendingRequests.get(key);
 
           if (requests) {
+            // A missing batch entry means no fetcher handled this item, not
+            // that it was deleted — only fetchers may report 'does_not_exist'.
             const preview =
               results.get(item.id) ??
               ({
                 id: item.id,
                 type: item.type ?? DEFAULT_ITEM_TYPE,
                 loading: false,
-                access: 'does_not_exist',
+                access: 'no_access',
               } as PreviewItem);
 
             for (const request of requests) {

--- a/js/app/packages/queries/preview/tests/dataloader.test.ts
+++ b/js/app/packages/queries/preview/tests/dataloader.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { PreviewItem } from '../types';
+
+const fetchPreviewBatch = vi.fn();
+
+vi.mock('../fetchers', () => ({
+  fetchPreviewBatch: (...args: unknown[]) => fetchPreviewBatch(...args),
+}));
+
+vi.mock('@service-storage/client', () => ({
+  DEFAULT_ITEM_TYPE: 'document',
+}));
+
+import { previewDataLoader } from '../dataloader';
+
+describe('previewDataLoader', () => {
+  beforeEach(() => {
+    fetchPreviewBatch.mockReset();
+  });
+
+  it('resolves items missing from the batch result as no_access, not does_not_exist', async () => {
+    fetchPreviewBatch.mockResolvedValue(new Map());
+
+    const preview = await previewDataLoader.load({
+      id: 'thread-1',
+      type: 'email',
+    });
+
+    expect(preview).toEqual({
+      id: 'thread-1',
+      type: 'email',
+      loading: false,
+      access: 'no_access',
+    });
+  });
+
+  it('resolves items present in the batch result with the fetched preview', async () => {
+    const fetched: PreviewItem = {
+      id: 'doc-1',
+      type: 'document',
+      loading: false,
+      access: 'does_not_exist',
+    };
+    fetchPreviewBatch.mockResolvedValue(new Map([['doc-1', fetched]]));
+
+    const preview = await previewDataLoader.load({
+      id: 'doc-1',
+      type: 'document',
+    });
+
+    expect(preview).toEqual(fetched);
+  });
+});

--- a/js/app/packages/service-clients/service-storage/client.ts
+++ b/js/app/packages/service-clients/service-storage/client.ts
@@ -279,7 +279,8 @@ export function blockNameToItemType(
 export function stringToItemType(str: string): ItemType | undefined {
   switch (str) {
     case 'email':
-    case 'thread': {
+    case 'thread':
+    case 'email_thread': {
       return 'email';
     }
     case 'call':
@@ -287,6 +288,7 @@ export function stringToItemType(str: string): ItemType | undefined {
     case 'document':
     case 'project':
     case 'channel':
+    case 'crm_company':
       return str;
     default:
       return undefined;


### PR DESCRIPTION
Notification resolvers requested previews with entity type `email_thread`, which no preview fetcher handles, so the dataloader cached `does_not_exist` under the id-keyed preview query for 24h and pasting the email's URL rendered the mention as Deleted. Maps EntityType to ItemType before fetching, skips unroutable types, and falls back to `no_access` for ids missing from a batch result so only fetcher responses can report deletion.
