### PR TITLE
feat(sidebar): channels dropdown with unread/recent toggle

### DIFF
--- a/js/app/packages/app/component/app-sidebar/channels-unread-widget.tsx
+++ b/js/app/packages/app/component/app-sidebar/channels-unread-widget.tsx
@@ -1,4 +1,3 @@
-import type { SidebarState } from '@app/component/app-sidebar/sidebar';
 import { useSenderName } from '@app/component/app-sidebar/utils';
 import { useGlobalNotificationSource } from '@app/component/GlobalAppState';
 import { globalSplitManager } from '@app/signal/splitLayout';
@@ -8,16 +7,15 @@ import { compareDateDesc } from '@core/util/date';
 import { ContextMenu } from '@kobalte/core/context-menu';
 import { openNotification } from '@notifications';
 import { isChannelNotification } from '@notifications/notification-helpers';
-import { getChannelNotificationParams } from '@notifications/notification-navigation';
 import type { UnifiedNotification } from '@notifications/types';
-import { Avatar, Button, cn, Tooltip } from '@ui';
+import { Avatar, Button, Tooltip } from '@ui';
 import {
+  type Accessor,
   createEffect,
   createMemo,
   createSignal,
   For,
   on,
-  onMount,
   Show,
 } from 'solid-js';
 
@@ -38,7 +36,7 @@ function getChannelInfo(notification: UnifiedNotification): {
   return { channelName, channelType, isDM };
 }
 
-interface ChannelGroup {
+export interface ChannelGroup {
   entityId: string;
   channelName: string | null;
   channelType: string | null;
@@ -47,29 +45,35 @@ interface ChannelGroup {
   latestSenderId: string | null;
 }
 
-function computeChannelLetters(groups: ChannelGroup[]): Map<string, string> {
+/**
+ * Single-letter (or two-letter on first-letter collisions) avatar labels for
+ * non-DM channels, keyed by channel id.
+ */
+export function computeChannelLetters(
+  items: Array<{ id: string; name: string | null; isDM: boolean }>
+): Map<string, string> {
   const result = new Map<string, string>();
   const firstLetterCount = new Map<string, number>();
 
-  for (const group of groups) {
-    if (group.isDM || !group.channelName) continue;
-    const first = group.channelName[0]?.toUpperCase() ?? '';
+  for (const item of items) {
+    if (item.isDM || !item.name) continue;
+    const first = item.name[0]?.toUpperCase() ?? '';
     firstLetterCount.set(first, (firstLetterCount.get(first) ?? 0) + 1);
   }
 
-  for (const group of groups) {
-    if (group.isDM || !group.channelName) continue;
-    const name = group.channelName;
+  for (const item of items) {
+    if (item.isDM || !item.name) continue;
+    const name = item.name;
     const first = name[0]?.toUpperCase() ?? '';
     const needsTwo = (firstLetterCount.get(first) ?? 0) > 1 && name.length > 1;
     const letters = needsTwo ? first + name[1].toUpperCase() : first;
-    result.set(group.entityId, letters);
+    result.set(item.id, letters);
   }
 
   return result;
 }
 
-function ChannelLetterIcon(props: { letters: string }) {
+export function ChannelLetterIcon(props: { letters: string }) {
   return (
     <Avatar size="md" class="bg-ink-extra-muted/15 text-ink-muted">
       <Avatar.Fallback>{props.letters}</Avatar.Fallback>
@@ -77,7 +81,7 @@ function ChannelLetterIcon(props: { letters: string }) {
   );
 }
 
-function groupByChannel(
+export function groupByChannel(
   notifications: UnifiedNotification[]
 ): Map<string, ChannelGroup> {
   const groups = new Map<string, ChannelGroup>();
@@ -111,181 +115,22 @@ function groupByChannel(
   return groups;
 }
 
-function ChannelGroupItem(props: {
-  group: ChannelGroup;
-  animate?: boolean;
-  isSlim?: boolean;
-  channelLetters?: string;
-}) {
-  const notificationSource = useGlobalNotificationSource();
-  const [isVisible, setIsVisible] = createSignal(!props.animate);
-
-  onMount(() => {
-    if (props.animate) {
-      requestAnimationFrame(() => {
-        setIsVisible(true);
-      });
-    }
-  });
-
-  const senderName = useSenderName(props.group.latestSenderId);
-  const count = () => props.group.notifications.length;
-
-  const isDM = () => props.group.isDM;
-  const senderId = () => props.group.latestSenderId;
-
-  const displayName = () => {
-    if (props.group.isDM) {
-      return senderName() ?? 'Direct Message';
-    }
-    return props.group.channelName
-      ? `#${props.group.channelName}`
-      : 'Unknown Channel';
-  };
-
-  const latestNotification = () => props.group.notifications[0];
-
-  const canOpenInNewSplit = () =>
-    globalSplitManager()?.canAppendSplit() ?? false;
-
-  const navigateToLatestNotification = (newSplit = false) => {
-    const manager = globalSplitManager();
-    if (!manager) return;
-    const notification = latestNotification();
-    openNotification(notification, manager, newSplit);
-  };
-
-  const openInCurrentSplit = () => {
-    navigateToLatestNotification(false);
-  };
-
-  const openInNewSplit = () => {
-    if (!canOpenInNewSplit()) return;
-    navigateToLatestNotification(true);
-  };
-
-  const markAllAsDone = () => {
-    void notificationSource.bulkMarkAsDone(props.group.notifications);
-  };
-
-  const markAllAsRead = () => {
-    void notificationSource.bulkMarkAsRead(props.group.notifications);
-  };
-
-  const _openFullscreen = () => {
-    const { params } = getChannelNotificationParams(latestNotification());
-    globalSplitManager()?.createPopoverSplit({
-      content: {
-        type: 'channel',
-        id: props.group.entityId,
-        params,
-      },
-    });
-  };
-
-  const isSlim = () => props.isSlim ?? false;
-
-  const ButtonContent = () => (
-    <Button
-      class={cn(
-        'flex items-center cursor-default rounded-md text-ink-extra-muted not-disabled:hover:bg-ink/3',
-        isSlim()
-          ? 'justify-center size-8'
-          : 'justify-start gap-2 w-full h-8 py-1'
-      )}
-      draggable={false}
-      variant="ghost"
-      size="sm"
-      classList={{
-        'opacity-0 -translate-y-2': !isVisible(),
-        'opacity-100 translate-y-0': isVisible(),
-      }}
-      onMouseDown={(e) => {
-        if (e.button !== 0) return;
-        e.preventDefault();
-        navigateToLatestNotification(e.shiftKey);
-      }}
-    >
-      <div class="relative flex items-center justify-center shrink-0 size-5">
-        <Show
-          when={isDM() && senderId()}
-          fallback={<ChannelLetterIcon letters={props.channelLetters ?? '?'} />}
-        >
-          <UserIcon
-            id={senderId()!}
-            size="md"
-            suppressClick
-            showTooltip={false}
-          />
-        </Show>
-        <Show when={isSlim()}>
-          <div class="absolute -top-0.5 -right-0.5 size-1.5 bg-accent rounded-full ring-surface ring-2" />
-        </Show>
-      </div>
-
-      <Show when={!isSlim()}>
-        <span class="text-sm font-medium truncate">{displayName()}</span>
-
-        <Show when={count() > 0}>
-          <span class="shrink-0 min-w-5 h-5 px-1.5 flex items-center justify-center text-xs font-medium bg-ink/6 text-ink-muted rounded-md ml-auto">
-            {count()}
-          </span>
-        </Show>
-      </Show>
-    </Button>
-  );
-
-  return (
-    <ContextMenu>
-      <ContextMenu.Trigger class="w-full">
-        <Show
-          when={!isSlim()}
-          fallback={
-            <Tooltip label={displayName()} placement="right">
-              <ButtonContent />
-            </Tooltip>
-          }
-        >
-          <ButtonContent />
-        </Show>
-      </ContextMenu.Trigger>
-
-      <ContextMenu.Portal>
-        <ContextMenuContent class="text-xs text-ink-muted">
-          <MenuItem
-            text="Open in new split"
-            onClick={openInNewSplit}
-            disabled={!canOpenInNewSplit()}
-          />
-          {/* FIXME: this doesn't work yet */}
-          {/* <MenuItem text="Open fullscreen" onClick={openFullscreen} /> */}
-          <MenuItem text="Open in current split" onClick={openInCurrentSplit} />
-          <MenuItem text="Mark all as read" onClick={markAllAsRead} />
-          <MenuItem text="Mark all as done" onClick={markAllAsDone} />
-        </ContextMenuContent>
-      </ContextMenu.Portal>
-    </ContextMenu>
-  );
-}
-
-function filterUnreadNotDone(notifications: UnifiedNotification[]) {
+export function filterUnreadNotDone(notifications: UnifiedNotification[]) {
   return notifications.filter((n) => !n.viewed_at && !n.done);
 }
 
-export const ChannelsUnreadWidget = (props: { sidebarState: SidebarState }) => {
-  const notificationSource = useGlobalNotificationSource();
-  const allNotifications = () => [...notificationSource.notifications()];
-
-  const filteredNotifications = () => filterUnreadNotDone(allNotifications());
-
-  const channelGroupsMap = createMemo(() =>
-    groupByChannel(filteredNotifications())
-  );
-
+/**
+ * Orders unread channel groups without reshuffling on every notification:
+ * newly-unread channels enter at the top (newest first), channels already in
+ * the list keep their position, and channels with no unreads left drop out.
+ */
+export function createStableOrderedGroups(
+  groupsMap: Accessor<Map<string, ChannelGroup>>
+): Accessor<ChannelGroup[]> {
   const [orderedIds, setOrderedIds] = createSignal<string[]>([]);
 
   createEffect(
-    on(channelGroupsMap, (groups) => {
+    on(groupsMap, (groups) => {
       const currentIds = new Set(groups.keys());
       const prev = orderedIds();
       const kept = prev.filter((id) => currentIds.has(id));
@@ -304,64 +149,146 @@ export const ChannelsUnreadWidget = (props: { sidebarState: SidebarState }) => {
     })
   );
 
-  const channelGroups = createMemo(() => {
-    const groups = channelGroupsMap();
+  return createMemo(() => {
+    const groups = groupsMap();
     return orderedIds()
       .map((id) => groups.get(id))
       .filter((g): g is ChannelGroup => g != null);
   });
+}
 
-  const channelLettersMap = createMemo(() =>
-    computeChannelLetters(channelGroups())
+function SlimChannelItem(props: {
+  group: ChannelGroup;
+  channelLetters?: string;
+}) {
+  const notificationSource = useGlobalNotificationSource();
+  const senderName = useSenderName(props.group.latestSenderId);
+
+  const displayName = () => {
+    if (props.group.isDM) {
+      return senderName() ?? 'Direct Message';
+    }
+    return props.group.channelName
+      ? `#${props.group.channelName}`
+      : 'Unknown Channel';
+  };
+
+  const canOpenInNewSplit = () =>
+    globalSplitManager()?.canAppendSplit() ?? false;
+
+  const navigateToLatestNotification = (newSplit = false) => {
+    const manager = globalSplitManager();
+    if (!manager) return;
+    openNotification(props.group.notifications[0], manager, newSplit);
+  };
+
+  return (
+    <ContextMenu>
+      <ContextMenu.Trigger class="w-full">
+        <Tooltip label={displayName()} placement="right">
+          <Button
+            class="flex items-center justify-center size-8 cursor-default rounded-md text-ink-extra-muted not-disabled:hover:bg-ink/3"
+            draggable={false}
+            variant="ghost"
+            size="sm"
+            onMouseDown={(e) => {
+              if (e.button !== 0) return;
+              e.preventDefault();
+              navigateToLatestNotification(e.shiftKey);
+            }}
+          >
+            <div class="relative flex items-center justify-center shrink-0 size-5">
+              <Show
+                when={props.group.isDM && props.group.latestSenderId}
+                fallback={
+                  <ChannelLetterIcon letters={props.channelLetters ?? '?'} />
+                }
+              >
+                <UserIcon
+                  id={props.group.latestSenderId!}
+                  size="md"
+                  suppressClick
+                  showTooltip={false}
+                />
+              </Show>
+              <div class="absolute -top-0.5 -right-0.5 size-1.5 bg-accent rounded-full ring-surface ring-2" />
+            </div>
+          </Button>
+        </Tooltip>
+      </ContextMenu.Trigger>
+
+      <ContextMenu.Portal>
+        <ContextMenuContent class="text-xs text-ink-muted">
+          <MenuItem
+            text="Open in new split"
+            onClick={() => navigateToLatestNotification(true)}
+            disabled={!canOpenInNewSplit()}
+          />
+          <MenuItem
+            text="Open in current split"
+            onClick={() => navigateToLatestNotification(false)}
+          />
+          <MenuItem
+            text="Mark all as read"
+            onClick={() =>
+              void notificationSource.bulkMarkAsRead(props.group.notifications)
+            }
+          />
+          <MenuItem
+            text="Mark all as done"
+            onClick={() =>
+              void notificationSource.bulkMarkAsDone(props.group.notifications)
+            }
+          />
+        </ContextMenuContent>
+      </ContextMenu.Portal>
+    </ContextMenu>
+  );
+}
+
+/**
+ * Slim-sidebar strip of unread channel avatars (up to 4, plus a "+N"
+ * overflow). The expanded-sidebar channel list lives nested under the
+ * Channels nav tab instead — see `SidebarChannelsList`.
+ */
+export const ChannelsUnreadWidget = () => {
+  const notificationSource = useGlobalNotificationSource();
+
+  const channelGroupsMap = createMemo(() =>
+    groupByChannel(filterUnreadNotDone([...notificationSource.notifications()]))
   );
 
-  const isSlim = () => props.sidebarState === 'slim';
+  const channelGroups = createStableOrderedGroups(channelGroupsMap);
+
+  const channelLettersMap = createMemo(() =>
+    computeChannelLetters(
+      channelGroups().map((g) => ({
+        id: g.entityId,
+        name: g.channelName,
+        isDM: g.isDM,
+      }))
+    )
+  );
+
   const SLIM_MAX = 4;
   const slimVisible = () => channelGroups().slice(0, SLIM_MAX);
   const slimOverflow = () => Math.max(0, channelGroups().length - SLIM_MAX);
 
   return (
     <Show when={channelGroups().length > 0}>
-      <Show
-        when={!isSlim()}
-        fallback={
-          <section class="w-full p-2 flex flex-col items-center">
-            <For each={slimVisible()}>
-              {(group) => (
-                <ChannelGroupItem
-                  group={group}
-                  animate={false}
-                  isSlim
-                  channelLetters={channelLettersMap().get(group.entityId)}
-                />
-              )}
-            </For>
-            <Show when={slimOverflow() > 0}>
-              <span class="text-xxs text-ink-muted mt-1">
-                +{slimOverflow()}
-              </span>
-            </Show>
-          </section>
-        }
-      >
-        <section class="size-full flex flex-col justify-center px-2 py-1.5">
-          <header class="text-xs font-medium text-ink-muted ml-2 mb-1">
-            <h1>Unread</h1>
-          </header>
-
-          <div class="flex-1">
-            <For each={channelGroups()}>
-              {(group) => (
-                <ChannelGroupItem
-                  group={group}
-                  animate={false}
-                  channelLetters={channelLettersMap().get(group.entityId)}
-                />
-              )}
-            </For>
-          </div>
-        </section>
-      </Show>
+      <section class="w-full p-2 flex flex-col items-center">
+        <For each={slimVisible()}>
+          {(group) => (
+            <SlimChannelItem
+              group={group}
+              channelLetters={channelLettersMap().get(group.entityId)}
+            />
+          )}
+        </For>
+        <Show when={slimOverflow() > 0}>
+          <span class="text-xxs text-ink-muted mt-1">+{slimOverflow()}</span>
+        </Show>
+      </section>
     </Show>
   );
 };

--- a/js/app/packages/app/component/app-sidebar/sidebar-channels.tsx
+++ b/js/app/packages/app/component/app-sidebar/sidebar-channels.tsx
@@ -1,0 +1,290 @@
+import {
+  type ChannelGroup,
+  ChannelLetterIcon,
+  computeChannelLetters,
+  createStableOrderedGroups,
+  filterUnreadNotDone,
+  groupByChannel,
+} from '@app/component/app-sidebar/channels-unread-widget';
+import { useSenderName } from '@app/component/app-sidebar/utils';
+import { useGlobalNotificationSource } from '@app/component/GlobalAppState';
+import { globalSplitManager } from '@app/signal/splitLayout';
+import { ContextMenuContent, MenuItem } from '@core/component/ContextMenu';
+import { UserIcon } from '@core/component/UserIcon';
+import { useUserId } from '@core/context/user';
+import { ContextMenu } from '@kobalte/core/context-menu';
+import { openNotification } from '@notifications';
+import { useListChannelsQuery } from '@queries/channel/channels';
+import type { ApiChannelWithLatest } from '@service-storage/channel-list-types';
+import { makePersisted } from '@solid-primitives/storage';
+import { Button, cn } from '@ui';
+import { createMemo, createSignal, For, Show } from 'solid-js';
+
+/** How many channels the "all" (recent) mode shows. */
+const RECENT_CHANNELS_MAX = 20;
+
+/**
+ * Whether the nested channel list under the Channels nav tab is open. A plain
+ * user toggle (chevron / clicking the active Channels tab), persisted across
+ * reloads — never collapsed by navigation. Default open, since unread-only
+ * mode matches the always-visible widget this list replaces.
+ */
+export const [channelsListExpanded, setChannelsListExpanded] = makePersisted(
+  createSignal(true),
+  { name: 'sidebar-channels-expanded' }
+);
+
+/**
+ * Unread-only (default) vs the 20 most recent channels — flipped by the
+ * toggle switch on the Channels row, persisted across reloads.
+ */
+export const [channelsUnreadOnly, setChannelsUnreadOnly] = makePersisted(
+  createSignal(true),
+  { name: 'sidebar-channels-unread-only' }
+);
+
+type ChannelItem = {
+  id: string;
+  name: string | null;
+  isDM: boolean;
+  dmUserId: string | null;
+  unreadCount: number;
+  /** Unread notification group, when the channel has unreads. */
+  group: ChannelGroup | undefined;
+};
+
+function channelRecency(channel: ApiChannelWithLatest): number {
+  return Math.max(
+    Date.parse(channel.updated_at) || 0,
+    Date.parse(channel.interacted_at ?? '') || 0,
+    Date.parse(channel.viewed_at ?? '') || 0
+  );
+}
+
+function SidebarChannelRow(props: {
+  item: ChannelItem;
+  letters: string | undefined;
+  visible: boolean;
+  index: number;
+}) {
+  const notificationSource = useGlobalNotificationSource();
+  const senderName = useSenderName(props.item.dmUserId);
+
+  const displayName = () => {
+    if (props.item.isDM) return senderName() ?? 'Direct Message';
+    return props.item.name ? `#${props.item.name}` : 'Unknown Channel';
+  };
+
+  const unread = () => props.item.unreadCount > 0;
+
+  const canOpenInNewSplit = () =>
+    globalSplitManager()?.canAppendSplit() ?? false;
+
+  // Unread channels open at their latest notification's message; read ones
+  // just open (or re-activate) the channel block.
+  const open = (newSplit: boolean) => {
+    const manager = globalSplitManager();
+    if (!manager) return;
+    const latest = props.item.group?.notifications[0];
+    if (latest) {
+      openNotification(latest, manager, newSplit);
+      return;
+    }
+    const existing = manager.getSplitByContent('channel', props.item.id);
+    if (existing && !newSplit) {
+      existing.activate();
+      return;
+    }
+    manager.openWithSplit(
+      { type: 'channel', id: props.item.id },
+      { activate: true, referredFrom: 'sidebar', preferNewSplit: newSplit }
+    );
+  };
+
+  return (
+    <li
+      class={cn(
+        'flex items-center justify-center first:mt-1 transition-[opacity,transform] duration-200 ease-out',
+        props.visible ? 'opacity-100 translate-y-0' : 'opacity-0 -translate-y-2'
+      )}
+      style={{
+        'transition-delay': props.visible ? `${props.index * 20}ms` : '0ms',
+      }}
+    >
+      <ContextMenu>
+        <ContextMenu.Trigger class="w-full">
+          <Button
+            draggable={false}
+            variant="ghost"
+            disabled={!props.visible}
+            data-sidebar-channel={props.item.id}
+            class="flex items-center justify-start text-sm gap-2 cursor-default w-full h-8 rounded-md py-1 pl-6 text-ink-extra-muted not-disabled:hover:bg-ink/3"
+            onMouseDown={(e) => {
+              if (e.button !== 0) return;
+              e.preventDefault();
+              open(e.shiftKey);
+            }}
+          >
+            <div class="relative flex items-center justify-center shrink-0 size-5">
+              <Show
+                when={props.item.isDM && props.item.dmUserId}
+                fallback={<ChannelLetterIcon letters={props.letters ?? '?'} />}
+              >
+                <UserIcon
+                  id={props.item.dmUserId!}
+                  size="md"
+                  suppressClick
+                  showTooltip={false}
+                />
+              </Show>
+            </div>
+
+            <span class={cn('truncate', unread() && 'font-medium text-ink')}>
+              {displayName()}
+            </span>
+
+            {/* Unread-only mode shows counts (every row is unread); recent
+                mode marks unread rows with a dot, per Google Chat. */}
+            <Show when={unread()}>
+              <Show
+                when={channelsUnreadOnly()}
+                fallback={
+                  <span class="shrink-0 size-1.5 bg-accent rounded-full ml-auto mr-1.5" />
+                }
+              >
+                <span class="shrink-0 min-w-5 h-5 px-1.5 flex items-center justify-center text-xs font-medium bg-ink/6 text-ink-muted rounded-md ml-auto">
+                  {props.item.unreadCount}
+                </span>
+              </Show>
+            </Show>
+          </Button>
+        </ContextMenu.Trigger>
+
+        <ContextMenu.Portal>
+          <ContextMenuContent class="text-xs text-ink-muted">
+            <MenuItem
+              text="Open in new split"
+              onClick={() => open(true)}
+              disabled={!canOpenInNewSplit()}
+            />
+            <MenuItem
+              text="Open in current split"
+              onClick={() => open(false)}
+            />
+            <Show when={props.item.group}>
+              {(group) => (
+                <>
+                  <MenuItem
+                    text="Mark all as read"
+                    onClick={() =>
+                      void notificationSource.bulkMarkAsRead(
+                        group().notifications
+                      )
+                    }
+                  />
+                  <MenuItem
+                    text="Mark all as done"
+                    onClick={() =>
+                      void notificationSource.bulkMarkAsDone(
+                        group().notifications
+                      )
+                    }
+                  />
+                </>
+              )}
+            </Show>
+          </ContextMenuContent>
+        </ContextMenu.Portal>
+      </ContextMenu>
+    </li>
+  );
+}
+
+/**
+ * The channel list nested under the Channels nav tab (expanded sidebar only).
+ * Unread-only mode mirrors the old unread widget: one row per channel with
+ * unread notifications, count pills, stable ordering. "All" mode shows the
+ * 20 most recently active channels with unread rows bolded and dotted.
+ * Empty unread mode renders nothing — the toggle on the Channels row remains
+ * the way back to "all".
+ */
+export function SidebarChannelsList() {
+  const notificationSource = useGlobalNotificationSource();
+  const channelsQuery = useListChannelsQuery();
+  const userId = useUserId();
+
+  const groupsMap = createMemo(() =>
+    groupByChannel(filterUnreadNotDone([...notificationSource.notifications()]))
+  );
+
+  const orderedGroups = createStableOrderedGroups(groupsMap);
+
+  const unreadItems = (): ChannelItem[] =>
+    orderedGroups().map((group) => ({
+      id: group.entityId,
+      name: group.channelName,
+      isDM: group.isDM,
+      dmUserId: group.latestSenderId,
+      unreadCount: group.notifications.length,
+      group,
+    }));
+
+  const recentItems = (): ChannelItem[] => {
+    const groups = groupsMap();
+    const me = userId();
+    return [...(channelsQuery.data ?? [])]
+      .sort((a, b) => channelRecency(b) - channelRecency(a))
+      .slice(0, RECENT_CHANNELS_MAX)
+      .map((channel) => {
+        const group = groups.get(channel.id);
+        const isDM = channel.channel_type === 'direct_message';
+        const dmUserId = isDM
+          ? (channel.participants.find((p) => p.user_id !== me)?.user_id ??
+            group?.latestSenderId ??
+            null)
+          : null;
+        return {
+          id: channel.id,
+          name: channel.name ?? null,
+          isDM,
+          dmUserId,
+          unreadCount: group?.notifications.length ?? 0,
+          group,
+        };
+      });
+  };
+
+  const items = createMemo(() =>
+    channelsUnreadOnly() ? unreadItems() : recentItems()
+  );
+
+  const lettersMap = createMemo(() =>
+    computeChannelLetters(
+      items().map((i) => ({ id: i.id, name: i.name, isDM: i.isDM }))
+    )
+  );
+
+  return (
+    <Show when={items().length > 0}>
+      <div
+        class="grid w-full transition-[grid-template-rows] duration-200 ease-out"
+        style={{ 'grid-template-rows': channelsListExpanded() ? '1fr' : '0fr' }}
+      >
+        <div class="min-h-0 overflow-hidden">
+          <ul class="flex flex-col gap-0.5 max-h-80 overflow-y-auto">
+            <For each={items()}>
+              {(item, index) => (
+                <SidebarChannelRow
+                  item={item}
+                  letters={lettersMap().get(item.id)}
+                  visible={channelsListExpanded()}
+                  index={index()}
+                />
+              )}
+            </For>
+          </ul>
+        </div>
+      </div>
+    </Show>
+  );
+}

--- a/js/app/packages/app/component/app-sidebar/sidebar.tsx
+++ b/js/app/packages/app/component/app-sidebar/sidebar.tsx
@@ -6,6 +6,13 @@ import {
   setInviteModalOpen,
 } from '@app/component/app-sidebar/invite-modal';
 import {
+  channelsListExpanded,
+  channelsUnreadOnly,
+  SidebarChannelsList,
+  setChannelsListExpanded,
+  setChannelsUnreadOnly,
+} from '@app/component/app-sidebar/sidebar-channels';
+import {
   SidebarPromoCard,
   SidebarPromoHint,
 } from '@app/component/app-sidebar/sidebar-promo';
@@ -91,7 +98,7 @@ import { useEmailLinksQuery } from '@queries/email/link';
 import { debounce } from '@solid-primitives/scheduled';
 import { makePersisted } from '@solid-primitives/storage';
 import { useLocation } from '@solidjs/router';
-import { Button, cn, Dropdown, Hotkey } from '@ui';
+import { Button, cn, Dropdown, Hotkey, ToggleSwitch, Tooltip } from '@ui';
 import {
   type Component,
   createEffect,
@@ -1024,7 +1031,13 @@ export const AppSidebar = (props: AppSidebarProps) => {
             {(link) => (
               <li class="flex flex-col items-center justify-center">
                 <Dynamic
-                  component={link.id === 'mail' ? SidebarMailLink : SidebarLink}
+                  component={
+                    link.id === 'mail'
+                      ? SidebarMailLink
+                      : link.id === 'channels'
+                        ? SidebarChannelsLink
+                        : SidebarLink
+                  }
                   {...link}
                   sidebarState={props.sidebarState ?? 'expanded'}
                   hotkeyVisible={hotkeyVisible()}
@@ -1039,9 +1052,11 @@ export const AppSidebar = (props: AppSidebarProps) => {
         <hr class="border-transparent my-2" />
       </div>
 
-      <div class="block max-h-[clamp(10%,60%,20rem)]">
-        <ChannelsUnreadWidget sidebarState={props.sidebarState ?? 'expanded'} />
-      </div>
+      <Show when={isSlim()}>
+        <div class="block max-h-[clamp(10%,60%,20rem)]">
+          <ChannelsUnreadWidget />
+        </div>
+      </Show>
 
       <div class="mt-auto">
         <Show when={ENABLE_CALLS()}>
@@ -1170,6 +1185,11 @@ interface SidebarLinkProps extends SidebarItem {
    * Email link's expand chevron.
    */
   trailingWhenActive?: JSX.Element;
+  /**
+   * Never show the hover hotkey hints — used when a sibling overlays its own
+   * controls (e.g. the Channels row's toggle + chevron) on the right edge.
+   */
+  suppressHoverHints?: boolean;
 }
 
 const SidebarLink = (props: SidebarLinkProps) => {
@@ -1316,6 +1336,7 @@ const SidebarLink = (props: SidebarLinkProps) => {
             when={
               isHovering() &&
               !props.hotkeyVisible &&
+              !props.suppressHoverHints &&
               !(isActive() && props.trailingWhenActive !== undefined)
             }
           >
@@ -1528,6 +1549,72 @@ const SidebarMailLink = (props: SidebarLinkProps) => {
             </For>
           </ul>
         </div>
+      </Show>
+    </>
+  );
+};
+
+/**
+ * The Channels sidebar link with its nested channel list (see
+ * `SidebarChannelsList` for the list itself and the unread-only/recent
+ * modes). The row overlays two controls at its right edge — a Google
+ * Chat-style unread/all toggle and a collapse chevron — rendered as siblings
+ * of the link's button rather than inside it, so interactive elements don't
+ * nest in a <button> and their clicks never navigate. Clicking the
+ * already-active Channels row also toggles the list open/closed.
+ */
+const SidebarChannelsLink = (props: SidebarLinkProps) => {
+  const showControls = () =>
+    props.sidebarState === 'expanded' && !props.hotkeyVisible;
+
+  const toggleExpanded = () => setChannelsListExpanded((p) => !p);
+
+  return (
+    <>
+      <div class="relative w-full">
+        <SidebarLink
+          {...props}
+          suppressHoverHints={showControls()}
+          onActiveClick={toggleExpanded}
+        />
+        <Show when={showControls()}>
+          <div class="absolute right-1.5 top-1/2 -translate-y-1/2 flex items-center gap-1.5">
+            <Show when={channelsListExpanded()}>
+              <Tooltip
+                label={
+                  channelsUnreadOnly()
+                    ? 'Showing unread only — switch to recent channels'
+                    : 'Showing recent channels — switch to unread only'
+                }
+                placement="top"
+              >
+                <ToggleSwitch
+                  checked={channelsUnreadOnly()}
+                  onChange={(checked) => setChannelsUnreadOnly(checked)}
+                />
+              </Tooltip>
+            </Show>
+            <Button
+              variant="ghost"
+              class="p-0.5 rounded-sm text-ink-muted hover:bg-ink/6"
+              onMouseDown={(e) => {
+                if (e.button !== 0) return;
+                e.preventDefault();
+                toggleExpanded();
+              }}
+            >
+              <CaretDownIcon
+                class={cn(
+                  'size-3 transition-transform duration-200',
+                  channelsListExpanded() && 'rotate-180'
+                )}
+              />
+            </Button>
+          </div>
+        </Show>
+      </div>
+      <Show when={props.sidebarState === 'expanded'}>
+        <SidebarChannelsList />
       </Show>
     </>
   );


### PR DESCRIPTION
## What

Follow-up to #3945 — the Channels nav tab gets the same nested-dropdown treatment as Email, replacing the standalone "Unread" section with a Google Chat-style list:

- **Toggle switch** at the right edge of the Channels row flips between **unread-only** (default) and **all** modes. Unread-only mirrors the old widget's behavior: one row per channel with unread notifications, count pills, stable insertion ordering (new unreads enter at the top, existing rows keep their position). All mode shows the **20 most recently active channels** (max of `updated_at` / `interacted_at` / `viewed_at`), with unread rows **bolded + accent-dotted**.
- **Chevron** next to the toggle collapses/expands the list; clicking the already-active Channels row does the same. Both the open state and the mode are persisted in localStorage and never reset by navigation.
- Rows are nested/indented like the email account rows, with the unread widget's conventions retained: DM avatars via `UserIcon` (other participant in all mode, latest sender in unread mode), letter avatars for named channels, shift-click for new split, and the mark-all-as-read/done context menu on unread rows.
- Click-through is notification-aware: unread channels open at their latest notification's message; read ones open (or re-activate) the channel block.
- Empty unread mode renders nothing, matching the old widget; the toggle stays reachable on the row.
- **Slim sidebar unchanged**: the icon strip (up to 4 unread avatars + "+N") survives, now gated to slim mode at the call site.

## How

- New [sidebar-channels.tsx](js/app/packages/app/component/app-sidebar/sidebar-channels.tsx): module-level persisted `channelsListExpanded` / `channelsUnreadOnly` signals (shared by the nav row controls and the list), `SidebarChannelsList`, and the row component. Recent channels come from `useListChannelsQuery`; unread state from the same `useGlobalNotificationSource` grouping the old widget used.
- [channels-unread-widget.tsx](js/app/packages/app/component/app-sidebar/channels-unread-widget.tsx) slims down to the slim-mode strip and exports the shared helpers (`groupByChannel`, `filterUnreadNotDone`, `createStableOrderedGroups`, `computeChannelLetters`, `ChannelLetterIcon`). `computeChannelLetters` is generalized to take `{id, name, isDM}` so both surfaces can use it.
- `sidebar.tsx`: `SidebarChannelsLink` wraps the nav row. The toggle and chevron are **overlaid as siblings** of the row's `<button>` (absolutely positioned) rather than rendered inside it — interactive elements can't legally nest in a button, and this guarantees their clicks never navigate. New `suppressHoverHints` prop hides the `[G][C]` hover hints while the controls occupy that space; the hints yield to the go-to-mode badge as before.

## Reviewer notes

- The expand/collapse uses the same `grid-template-rows 0fr→1fr` + staggered row fade pattern as the email dropdown; rows are `disabled` while collapsed so they can't be clicked or tabbed mid-animation.
- The list is capped at `max-h-80` with `overflow-y-auto` for users with many unreads (the old widget relied on an outer clamp).
- `bun type-check` and biome pass. Multi-channel/unread behavior needs a workspace with channel activity to exercise manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)