### PR TITLE
feat(email): restore Superhuman-style j/k/e for full-screen emails

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/create-search-state.ts
+++ b/js/app/packages/app/component/next-soup/soup-view/create-search-state.ts
@@ -137,7 +137,7 @@ interface CreateSearchStateArgs {
   soup: SoupState;
   filters: Accessor<QueryState>;
   assignees: Accessor<string[]>;
-  disableLocalSearch?: boolean;
+  disableLocalSearch?: Accessor<boolean>;
   searchPaused?: Accessor<boolean>;
   /**
    * Reactive search text. Owned by the caller so it can be wired to
@@ -248,7 +248,7 @@ export const createSearchState = ({
 
   const localFuzzyResults = createMemo(
     on(debouncedSearchForLocal, (query) => {
-      if (disableLocalSearch) return [];
+      if (disableLocalSearch?.()) return [];
       if (!query || query.length === 0) return [];
       const pool = entityPool();
       // TODO: we can optimize fresh search for small feature counts since we

--- a/js/app/packages/app/component/next-soup/soup-view/soup-view-context.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-view-context.tsx
@@ -58,6 +58,7 @@ import type { SoupPage } from '@service-storage/generated/schemas';
 import type { InfiniteData } from '@tanstack/solid-query';
 import {
   type Accessor,
+  batch,
   createContext,
   createEffect,
   createMemo,
@@ -87,8 +88,16 @@ type DataSource<T> = {
   fetchNextPage: VoidFunction;
 };
 
+type SoupViewInitializeOptions = {
+  initialQuery?: Query;
+  initialSearchText?: string;
+  disableLocalSearch?: boolean;
+  additionalEntities?: Accessor<EntityData[]>;
+};
+
 interface SoupViewContextValues {
   soup: SoupState;
+  initialize: (options?: SoupViewInitializeOptions, force?: boolean) => void;
   source: DataSource<EntityData>;
   searchText: Accessor<string>;
   setSearchText: (value: string) => void;
@@ -128,16 +137,9 @@ export const useSoupView = () => {
 
 export const useMaybeSoupView = () => useContext(SoupViewContext);
 
-interface SoupViewContextProviderProps {
+interface SoupViewContextProviderProps extends SoupViewInitializeOptions {
   soup?: SoupState;
-  initialQuery?: Query;
-  initialSearchText?: string;
-  disableLocalSearch?: boolean;
-  /**
-   * Additional client-side entities to merge into the soup item stream.
-   * Visibility is still controlled by the active client filters.
-   */
-  additionalEntities?: Accessor<EntityData[]>;
+  initialEnabled?: boolean;
 }
 
 type ApiSortMethod = NonNullable<SoupParams['sort_method']>;
@@ -152,6 +154,13 @@ export const SoupViewContextProvider: FlowComponent<
   SoupViewContextProviderProps
 > = (props) => {
   const soup = props.soup ?? createSoupState();
+  const [enabled, setEnabled] = createSignal(props.initialEnabled ?? false);
+  const [config, setConfig] = createSignal<SoupViewInitializeOptions>({
+    initialQuery: props.initialQuery,
+    initialSearchText: props.initialSearchText,
+    disableLocalSearch: props.disableLocalSearch,
+    additionalEntities: props.additionalEntities,
+  });
 
   const queryClient = useQueryClient();
 
@@ -242,6 +251,7 @@ export const SoupViewContextProvider: FlowComponent<
   };
 
   const [searchPaused, setSearchPaused] = createSignal(false);
+  const sourceSearchPaused = createMemo(() => searchPaused() || !enabled());
   const [assigneeFilter, setAssigneeFilter] = useEntryState<string[]>(
     'soup.assigneeFilter',
     { default: [] }
@@ -314,11 +324,27 @@ export const SoupViewContextProvider: FlowComponent<
     soup,
     filters: () => applyInboxFilter(queryFilters.state),
     assignees: assigneeFilter,
-    disableLocalSearch: props.disableLocalSearch,
-    searchPaused,
+    disableLocalSearch: () => config().disableLocalSearch ?? false,
+    searchPaused: sourceSearchPaused,
     searchText,
     setSearchText,
   });
+
+  const initialize = (
+    options: SoupViewInitializeOptions = {},
+    force = false
+  ) => {
+    batch(() => {
+      setConfig(options);
+      if ((!persistedFilters && options.initialQuery) || force) {
+        queryFilters.replace(options.initialQuery ?? null);
+      }
+      if ((options.initialSearchText !== undefined && !searchText()) || force) {
+        setSearchText(options.initialSearchText ?? '');
+      }
+      setEnabled(true);
+    });
+  };
 
   const notificationSource = useGlobalNotificationSource();
   const userId = useUserId();
@@ -361,7 +387,7 @@ export const SoupViewContextProvider: FlowComponent<
     () => {
       const view = activeListView();
       return {
-        enabled: !search.isSearching(),
+        enabled: enabled() && !search.isSearching(),
         showSupportedForeignEntities: showSupportedForeignEntitiesFF().enabled,
         meta: {
           itemFilter: (item) => soupItemMatchesListView(item, view),
@@ -383,7 +409,7 @@ export const SoupViewContextProvider: FlowComponent<
           isWithNotification(e) ? e : attachNotifications(e)
         ) as SoupEntity[];
 
-        const extras = props.additionalEntities?.() ?? [];
+        const extras = config().additionalEntities?.() ?? [];
 
         if (extras.length === 0) return base;
 
@@ -483,7 +509,7 @@ export const SoupViewContextProvider: FlowComponent<
     queryOptions: () => {
       const view = activeListView();
       return {
-        enabled: !search.isSearching(),
+        enabled: enabled() && !search.isSearching(),
         meta: {
           itemFilter: (item) => soupItemMatchesListView(item, view),
         },
@@ -584,6 +610,7 @@ export const SoupViewContextProvider: FlowComponent<
 
   const context = {
     soup,
+    initialize,
     source: {
       data: entities,
       isLoading: () => itemsQuery.isLoading,
@@ -593,12 +620,16 @@ export const SoupViewContextProvider: FlowComponent<
       isFetchingNextPage: () =>
         itemsQuery.isFetchingNextPage || searchQuery.isFetchingNextPage,
       hasNextPage: () => {
+        if (!enabled()) return false;
+
         return (
           (itemsQuery.isEnabled && itemsQuery.hasNextPage) ||
           (searchQuery.isEnabled && searchQuery.hasNextPage)
         );
       },
       fetchNextPage: () => {
+        if (!enabled()) return;
+
         if (itemsQuery.isEnabled) {
           itemsQuery.fetchNextPage();
         }
@@ -611,7 +642,7 @@ export const SoupViewContextProvider: FlowComponent<
     rows,
     searchText: search.searchText,
     setSearchText: search.setSearchText,
-    searchPaused,
+    searchPaused: sourceSearchPaused,
     setSearchPaused,
     featuredIds: search.featuredIds,
     isSearchServiceLoading: search.isSearchServiceLoading,

--- a/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
@@ -28,10 +28,7 @@ import {
   persistSoupNavigationTouchHighlight,
   soupNavigationTouchHighlight,
 } from '@app/component/next-soup/soup-view/soup-navigation-touch-highlight';
-import {
-  SoupViewContextProvider,
-  useSoupView,
-} from '@app/component/next-soup/soup-view/soup-view-context';
+import { useSoupView } from '@app/component/next-soup/soup-view/soup-view-context';
 import { SoupViewCreateButton } from '@app/component/next-soup/soup-view/soup-view-create-button';
 import { SoupViewFileDropzone } from '@app/component/next-soup/soup-view/soup-view-file-dropzone';
 import { SoupViewMobileCreateButton } from '@app/component/next-soup/soup-view/soup-view-mobile-create-button';
@@ -340,6 +337,19 @@ interface SoupViewProps {
 export const SoupView = (props: SoupViewProps) => {
   const soup = useSoup();
   const panel = useSplitPanelOrThrow();
+  const soupView = useSoupView();
+
+  onMount(() => {
+    soupView.initialize(
+      {
+        initialQuery: props.initialFilters,
+        initialSearchText: props.initialSearchText,
+        disableLocalSearch: props.disableLocalSearch,
+        additionalEntities: props.additionalEntities,
+      },
+      true
+    );
+  });
 
   createEffect(() => {
     panel.handle.setDisplayName(props.viewName);
@@ -425,161 +435,149 @@ export const SoupView = (props: SoupViewProps) => {
             : undefined,
       }}
     >
-      <SoupViewContextProvider
-        soup={soup}
-        initialQuery={props.initialFilters}
-        initialSearchText={props.initialSearchText}
-        disableLocalSearch={props.disableLocalSearch}
-        additionalEntities={props.additionalEntities}
-      >
-        <div class="size-full flex flex-col" data-list-view={activeListView()}>
-          <div class="flex flex-col w-full">
-            <SplitHeaderLeft>
-              <div
-                class={cn('h-full flex gap-3 items-center', {
-                  'shrink-0': !narrowSearchExpanded(),
-                  'flex-1 min-w-0': narrowSearchExpanded(),
-                })}
+      <div class="size-full flex flex-col" data-list-view={activeListView()}>
+        <div class="flex flex-col w-full">
+          <SplitHeaderLeft>
+            <div
+              class={cn('h-full flex gap-3 items-center', {
+                'shrink-0': !narrowSearchExpanded(),
+                'flex-1 min-w-0': narrowSearchExpanded(),
+              })}
+            >
+              <Show when={!isMobile() && !narrowSearchExpanded()}>
+                <span class="text-base font-bold">{props.viewName}</span>
+              </Show>
+              <Show
+                when={!narrowSearchExpanded() && !isComponentListView('search')}
               >
-                <Show when={!isMobile() && !narrowSearchExpanded()}>
-                  <span class="text-base font-bold">{props.viewName}</span>
+                <Show when={!isMobile()}>
+                  <CollapsibleHeaderItem
+                    id="tabs"
+                    priority={1}
+                    expanded={() => <SoupViewTabs />}
+                    collapsed={() => <CollapsedSoupViewTabs />}
+                    containerClass="h-full"
+                  />
                 </Show>
-                <Show
-                  when={
-                    !narrowSearchExpanded() && !isComponentListView('search')
-                  }
-                >
-                  <Show when={!isMobile()}>
-                    <CollapsibleHeaderItem
-                      id="tabs"
-                      priority={1}
-                      expanded={() => <SoupViewTabs />}
-                      collapsed={() => <CollapsedSoupViewTabs />}
-                      containerClass="h-full"
+              </Show>
+              <Show
+                when={
+                  !isMobile() &&
+                  !narrowSearchExpanded() &&
+                  isComponentListView('mail')
+                }
+              >
+                <InboxSelector />
+              </Show>
+            </div>
+          </SplitHeaderLeft>
+          <Show when={!isMobile()}>
+            <SplitHeaderRight>
+              <Show
+                when={!narrowSearchExpanded() && !isComponentListView('search')}
+              >
+                <SoupViewCreateButton />
+              </Show>
+              <Show when={narrowSearchExpanded()}>
+                <Layer depth={2}>
+                  <div class="flex-1 min-w-0">
+                    <SoupSearchbar
+                      variant="secondary"
+                      autoFocus
+                      initialValue={props.initialSearchText}
+                      onDismiss={() => setNarrowSearchExpanded(false)}
                     />
-                  </Show>
-                </Show>
-                <Show
-                  when={
-                    !isMobile() &&
-                    !narrowSearchExpanded() &&
-                    isComponentListView('mail')
-                  }
-                >
-                  <InboxSelector />
-                </Show>
-              </div>
-            </SplitHeaderLeft>
-            <Show when={!isMobile()}>
-              <SplitHeaderRight>
-                <Show
-                  when={
-                    !narrowSearchExpanded() && !isComponentListView('search')
-                  }
-                >
-                  <SoupViewCreateButton />
-                </Show>
-                <Show when={narrowSearchExpanded()}>
+                  </div>
+                </Layer>
+              </Show>
+              <Show
+                when={!isComponentListView('search')}
+                fallback={
                   <Layer depth={2}>
-                    <div class="flex-1 min-w-0">
+                    <div class="grow ml-2">
                       <SoupSearchbar
                         variant="secondary"
-                        autoFocus
+                        placeholder="Search, @mention contacts"
                         initialValue={props.initialSearchText}
-                        onDismiss={() => setNarrowSearchExpanded(false)}
                       />
                     </div>
                   </Layer>
-                </Show>
-                <Show
-                  when={!isComponentListView('search')}
-                  fallback={
+                }
+              >
+                <CollapsibleHeaderItem
+                  id="search"
+                  priority={0}
+                  onCollapsedChange={(isCollapsed) => {
+                    setSearchIsCollapsed(isCollapsed);
+                    if (!isCollapsed) setNarrowSearchExpanded(false);
+                  }}
+                  expanded={() => (
                     <Layer depth={2}>
-                      <div class="grow ml-2">
+                      <div class="w-60 ml-2">
                         <SoupSearchbar
                           variant="secondary"
-                          placeholder="Search, @mention contacts"
                           initialValue={props.initialSearchText}
                         />
                       </div>
                     </Layer>
-                  }
-                >
-                  <CollapsibleHeaderItem
-                    id="search"
-                    priority={0}
-                    onCollapsedChange={(isCollapsed) => {
-                      setSearchIsCollapsed(isCollapsed);
-                      if (!isCollapsed) setNarrowSearchExpanded(false);
-                    }}
-                    expanded={() => (
-                      <Layer depth={2}>
-                        <div class="w-60 ml-2">
-                          <SoupSearchbar
-                            variant="secondary"
-                            initialValue={props.initialSearchText}
-                          />
-                        </div>
-                      </Layer>
-                    )}
-                    collapsed={() => (
-                      <Show when={!narrowSearchExpanded()}>
-                        <Tooltip label="Search" hotkey={TOKENS.soup.openSearch}>
-                          <Button
-                            variant="base"
-                            class="p-1 size-7 rounded-lg ml-2 bg-surface"
-                            onClick={() => setNarrowSearchExpanded(true)}
-                            depth={2}
-                          >
-                            <SearchIcon class="size-4 touch:size-6" />
-                          </Button>
-                        </Tooltip>
-                      </Show>
-                    )}
-                  />
-                </Show>
-              </SplitHeaderRight>
-            </Show>
-            <SoupFiltersBar />
-          </div>
-          <div class="relative grow min-h-1 flex max-sm:flex-col flex-row size-full">
-            <Suspense>
-              <SoupViewFileDropzone>
-                <SoupViewList
-                  initialClientFilters={props.initialClientFilters}
-                  initialGroupBy={props.initialGroupBy}
-                  onScrollOffsetBaseline={resetFloatingButtonScrollTracking}
-                  onScrollOffsetChange={handleSoupScrollOffsetChange}
+                  )}
+                  collapsed={() => (
+                    <Show when={!narrowSearchExpanded()}>
+                      <Tooltip label="Search" hotkey={TOKENS.soup.openSearch}>
+                        <Button
+                          variant="base"
+                          class="p-1 size-7 rounded-lg ml-2 bg-surface"
+                          onClick={() => setNarrowSearchExpanded(true)}
+                          depth={2}
+                        >
+                          <SearchIcon class="size-4 touch:size-6" />
+                        </Button>
+                      </Tooltip>
+                    </Show>
+                  )}
                 />
-              </SoupViewFileDropzone>
-            </Suspense>
-            <Show when={isMobile()}>
-              <SoupViewMobileSettingsButton visible={floatingButtonsVisible} />
-              <SoupViewMobileSearchButton
-                open={mobileSearchOpen}
-                visible={floatingButtonsVisible}
-                onOpen={() => setMobileSearchOpen(true)}
+              </Show>
+            </SplitHeaderRight>
+          </Show>
+          <SoupFiltersBar />
+        </div>
+        <div class="relative grow min-h-1 flex max-sm:flex-col flex-row size-full">
+          <Suspense>
+            <SoupViewFileDropzone>
+              <SoupViewList
+                initialClientFilters={props.initialClientFilters}
+                initialGroupBy={props.initialGroupBy}
+                onScrollOffsetBaseline={resetFloatingButtonScrollTracking}
+                onScrollOffsetChange={handleSoupScrollOffsetChange}
               />
-              <SoupViewMobileCreateButton
-                activeView={activeListView}
-                visible={floatingButtonsVisible}
-              />
-              <SoupViewMobileSearchBar
-                open={mobileSearchOpen}
-                onClose={() => setMobileSearchOpen(false)}
-              />
-            </Show>
-          </div>
+            </SoupViewFileDropzone>
+          </Suspense>
           <Show when={isMobile()}>
-            <MobileSoupViewTabs />
+            <SoupViewMobileSettingsButton visible={floatingButtonsVisible} />
+            <SoupViewMobileSearchButton
+              open={mobileSearchOpen}
+              visible={floatingButtonsVisible}
+              onOpen={() => setMobileSearchOpen(true)}
+            />
+            <SoupViewMobileCreateButton
+              activeView={activeListView}
+              visible={floatingButtonsVisible}
+            />
+            <SoupViewMobileSearchBar
+              open={mobileSearchOpen}
+              onClose={() => setMobileSearchOpen(false)}
+            />
           </Show>
         </div>
-        <Suspense>
-          <Show when={ENABLE_UNIFIED_LIST_AI_INPUT && !isMobile()}>
-            <SoupChatInput />
-          </Show>
-        </Suspense>
-      </SoupViewContextProvider>
+        <Show when={isMobile()}>
+          <MobileSoupViewTabs />
+        </Show>
+      </div>
+      <Suspense>
+        <Show when={ENABLE_UNIFIED_LIST_AI_INPUT && !isMobile()}>
+          <SoupChatInput />
+        </Show>
+      </Suspense>
     </SplitPanelContext.Provider>
   );
 };
@@ -688,14 +686,17 @@ export const SoupViewList = (props: SoupViewListProps) => {
   });
 
   // Register navigation hotkeys on the active list scope (usually the split
-  // scope), but dispose them with the mounted SoupViewList. This keeps j/k
-  // available while the list split is active without leaking into opened blocks
-  // after the list unmounts.
+  // scope). Most handlers are disposed with SoupViewList, but j/k intentionally
+  // remain on the split scope so an entity opened from the list can continue to
+  // drive list navigation and update the split content.
   useSoupNavigationHotkeys({
     scopeId: scopeId(),
     soup,
     splitHandle: panel.handle,
     virtualizerHandle,
+    hasNextPage: source.hasNextPage,
+    isFetchingNextPage: source.isFetchingNextPage,
+    fetchNextPage: source.fetchNextPage,
   });
 
   // Register entity action hotkeys
@@ -784,6 +785,7 @@ export const SoupViewList = (props: SoupViewListProps) => {
         openInNewSplit: event.shiftKey,
         location,
         splitHandle: panel.handle,
+        referredFrom: currentView(),
       });
     } finally {
       finishTouchHighlight?.();

--- a/js/app/packages/app/component/next-soup/soup-view/use-soup-navigation-hotkeys.ts
+++ b/js/app/packages/app/component/next-soup/soup-view/use-soup-navigation-hotkeys.ts
@@ -1,10 +1,11 @@
 import { openEntityInSplitFromUnifiedList } from '@app/component/next-soup/utils';
 import type { SplitHandle } from '@app/component/split-layout/layoutManager';
+import { isListViewID } from '@app/constants/list-views';
 import { entityIdSelector } from '@core/dom-selectors';
 import { createHotkeyGroup, registerHotkey } from '@core/hotkey/hotkeys';
 import { TOKENS } from '@core/hotkey/tokens';
 import type { EntityData } from '@entity';
-import { type Accessor, onCleanup } from 'solid-js';
+import { type Accessor, createMemo, onCleanup } from 'solid-js';
 import type { VirtualizerHandle } from 'virtua/solid';
 import type { SoupState } from '../create-soup-state';
 
@@ -13,6 +14,9 @@ type UseSoupNavigationHotkeysOptions = {
   soup: SoupState;
   splitHandle: SplitHandle;
   virtualizerHandle: Accessor<VirtualizerHandle | undefined>;
+  hasNextPage?: Accessor<boolean>;
+  isFetchingNextPage?: Accessor<boolean>;
+  fetchNextPage?: () => void;
 };
 
 export const useSoupNavigationHotkeys = (
@@ -30,6 +34,17 @@ export const useSoupNavigationHotkeys = (
     });
   };
 
+  const navigationReferredFrom = createMemo(() => {
+    const content = splitHandle.content();
+
+    if (content.type === 'component' && isListViewID(content.id)) {
+      return content.id;
+    }
+
+    const referredFrom = splitHandle.referredFrom();
+    return isListViewID(referredFrom) ? referredFrom : undefined;
+  });
+
   const openEntity = (entity: EntityData) => {
     const handleContent = splitHandle.content().type;
 
@@ -38,6 +53,7 @@ export const useSoupNavigationHotkeys = (
     openEntityInSplitFromUnifiedList(entity, {
       splitHandle,
       mergeHistory: true,
+      referredFrom: navigationReferredFrom(),
     });
   };
 
@@ -95,13 +111,30 @@ export const useSoupNavigationHotkeys = (
 
   const group = createHotkeyGroup();
 
+  const { fetchNextPage, isFetchingNextPage, hasNextPage } = options;
+
+  const LOAD_MORE_DISTANCE_FROM_END = 3;
+
+  const fetchNextPageIfNeeded = () => {
+    if (!hasNextPage?.() || isFetchingNextPage?.()) return;
+    fetchNextPage?.();
+  };
+
   const navigateDown = () => {
+    const rowCount = soup.rows().length;
     const next = soup.navigate.down();
 
-    if (!next) return true;
+    if (!next) {
+      fetchNextPageIfNeeded();
+      return true;
+    }
 
     scrollTo(next.index);
     openEntity(next.row.original);
+
+    if (next.index >= rowCount - 1 - LOAD_MORE_DISTANCE_FROM_END) {
+      fetchNextPageIfNeeded();
+    }
 
     return true;
   };
@@ -117,14 +150,30 @@ export const useSoupNavigationHotkeys = (
     return true;
   };
 
+  const canRunListNavigation = () => {
+    const contentType = splitHandle.content().type;
+    if (contentType === 'component' || contentType === 'project') return true;
+
+    // After the list unmounts, j/k stay live only while the opened entity is
+    // an email (Superhuman-style). Other block types keep their own keys.
+    const referredFrom = navigationReferredFrom();
+    if (referredFrom !== 'inbox' && referredFrom !== 'mail') return false;
+
+    return soup.focus.item()?.type === 'email';
+  };
+
+  // Keep j/k registered on the split scope after the list unmounts. When an
+  // entity is opened from a list into the same split, this lets j/k continue
+  // navigating the originating soup list and update the split content.
   registerHotkey({
     hotkey: ['j'],
     scopeId,
     description: 'Down',
     hotkeyToken: TOKENS.entity.step.end,
+    condition: canRunListNavigation,
     keyDownHandler: navigateDown,
     hide: true,
-  }).withGroup(group);
+  });
 
   registerHotkey({
     hotkey: ['arrowdown'],
@@ -134,14 +183,18 @@ export const useSoupNavigationHotkeys = (
     hide: true,
   }).withGroup(group);
 
+  // Keep j/k registered on the split scope after the list unmounts. When an
+  // entity is opened from a list into the same split, this lets j/k continue
+  // navigating the originating soup list and update the split content.
   registerHotkey({
     hotkey: ['k'],
     scopeId,
     hotkeyToken: TOKENS.entity.step.start,
     description: 'Up',
+    condition: canRunListNavigation,
     keyDownHandler: navigateUp,
     hide: true,
-  }).withGroup(group);
+  });
 
   registerHotkey({
     hotkey: ['arrowup'],

--- a/js/app/packages/app/component/next-soup/soup-view/use-soup-view-hotkeys.ts
+++ b/js/app/packages/app/component/next-soup/soup-view/use-soup-view-hotkeys.ts
@@ -181,6 +181,7 @@ export const useSoupViewHotkeys = (options: UseSoupViewHotkeysOptions) => {
       openEntityInSplitFromUnifiedList(entity, {
         splitHandle,
         location,
+        referredFrom: currentView(),
       });
       return true;
     },
@@ -234,6 +235,7 @@ export const useSoupViewHotkeys = (options: UseSoupViewHotkeysOptions) => {
 
       openEntityInSplitFromUnifiedList(entity, {
         splitHandle,
+        referredFrom: currentView(),
       });
       return true;
     },
@@ -343,6 +345,7 @@ export const useSoupViewHotkeys = (options: UseSoupViewHotkeysOptions) => {
       openEntityInSplitFromUnifiedList(entity, {
         splitHandle,
         openInNewSplit: true,
+        referredFrom: currentView(),
       });
       return true;
     },

--- a/js/app/packages/app/component/next-soup/utils.ts
+++ b/js/app/packages/app/component/next-soup/utils.ts
@@ -1,4 +1,8 @@
-import type { SplitHandle } from '@app/component/split-layout/layoutManager';
+import type {
+  ReferredFrom,
+  SplitHandle,
+} from '@app/component/split-layout/layoutManager';
+import { isListViewID } from '@app/constants/list-views';
 import { globalSplitManager } from '@app/signal/splitLayout';
 import { URL_PARAMS as CALL_PARAMS } from '@block-call/constants';
 import { URL_PARAMS as CHANNEL_PARAMS } from '@block-channel/constants';
@@ -308,6 +312,7 @@ interface OpenEntityOptions {
   splitHandle?: SplitHandle;
   mergeHistory?: boolean;
   allowDuplicate?: boolean;
+  referredFrom?: ReferredFrom;
 }
 
 /**
@@ -355,10 +360,19 @@ export const openEntityInSplitFromUnifiedList = async (
     params = { [CALL_PARAMS.transcriptId]: location.transcriptId };
   }
 
+  const sourceContent =
+    splitHandle?.content() ?? splitManager.activeSplit()?.content();
+
+  const sourceListView =
+    sourceContent?.type === 'component' && isListViewID(sourceContent.id)
+      ? sourceContent.id
+      : undefined;
+  const referredFrom = options.referredFrom ?? sourceListView;
+
   splitManager.openWithSplit(
     { ...content, params },
     {
-      referredFrom: 'list-view',
+      referredFrom,
       activate: true,
       preferNewSplit: openInNewSplit,
       handle: splitHandle,

--- a/js/app/packages/app/component/split-layout/components/SplitHeader.tsx
+++ b/js/app/packages/app/component/split-layout/components/SplitHeader.tsx
@@ -1,3 +1,4 @@
+import { useSoup } from '@app/component/next-soup/soup-context';
 import { openEntityInSplitFromUnifiedList } from '@app/component/next-soup/utils';
 import { isListViewID } from '@app/constants/list-views';
 import type { BlockName } from '@core/block';
@@ -7,8 +8,10 @@ import { isMobile } from '@core/mobile/isMobile';
 import type { EntityDragEvent } from '@entity';
 import CollapseIcon from '@phosphor/arrows-in.svg';
 import ExpandIcon from '@phosphor/arrows-out.svg';
+import CaretDown from '@phosphor/caret-down.svg';
 import CaretLeft from '@phosphor/caret-left.svg';
 import CaretRight from '@phosphor/caret-right.svg';
+import CaretUp from '@phosphor/caret-up.svg';
 import CloseIcon from '@phosphor/x.svg';
 import { mergeRefs } from '@solid-primitives/refs';
 import { createDroppable, useDragDropContext } from '@thisbeyond/solid-dnd';
@@ -137,6 +140,82 @@ function SplitCloseButton() {
   );
 }
 
+function SoupNavigationButtons() {
+  const context = useContext(SplitPanelContext);
+  const soup = useSoup();
+  if (!context) return null;
+
+  const rows = createMemo(() => soup.rows());
+  const currentIndex = () => soup.focus.index();
+
+  const navigationReferredFrom = createMemo(() => {
+    const referredFrom = context.handle.referredFrom();
+    if (referredFrom !== 'inbox' && referredFrom !== 'mail') {
+      return;
+    }
+
+    return referredFrom;
+  });
+
+  const shouldShow = createMemo(() => {
+    const referredFrom = navigationReferredFrom();
+    const isNavigableListView =
+      referredFrom === 'inbox' || referredFrom === 'mail';
+
+    // List navigation from an open block is email-only, so only advertise
+    // the controls while an email is focused.
+    return (
+      isNavigableListView &&
+      rows().length > 0 &&
+      soup.focus.item()?.type === 'email'
+    );
+  });
+
+  const canNavigateUp = createMemo(() => {
+    return rows().length > 0 && currentIndex() !== 0;
+  });
+
+  const canNavigateDown = createMemo(() => {
+    return rows().length > 0 && currentIndex() !== rows().length - 1;
+  });
+
+  const navigate = (offset: number) => {
+    const next = soup.navigate.by(offset);
+    if (!next) return;
+
+    void openEntityInSplitFromUnifiedList(next.row.original, {
+      splitHandle: context.handle,
+      mergeHistory: true,
+      referredFrom: navigationReferredFrom(),
+    });
+  };
+
+  return (
+    <Show when={shouldShow()}>
+      <div class="flex items-center gap-0.5 pl-1">
+        <Button
+          class="p-1 rounded-lg"
+          label="Previous item"
+          hotkey={TOKENS.entity.step.start}
+          disabled={!canNavigateUp()}
+          onClick={() => navigate(-1)}
+        >
+          <CaretUp class="size-4" />
+        </Button>
+        <Button
+          class="p-1 rounded-lg"
+          label="Next item"
+          hotkey={TOKENS.entity.step.end}
+          disabled={!canNavigateDown()}
+          onClick={() => navigate(1)}
+        >
+          <CaretDown class="size-4" />
+        </Button>
+      </div>
+    </Show>
+  );
+}
+
 export function SplitHeader(props: { ref: Setter<HTMLDivElement | null> }) {
   const panel = useContext(SplitPanelContext);
   if (!panel) {
@@ -233,12 +312,15 @@ export function SplitHeader(props: { ref: Setter<HTMLDivElement | null> }) {
           </div>
         </Show>*/}
 
-        <div
-          class="min-w-4 h-full grow shrink flex items-center justify-end gap-0.5 px-2"
-          ref={(ref) => {
-            panel.layoutRefs.headerRight = ref;
-          }}
-        />
+        <div class="min-w-4 h-full grow shrink flex items-center justify-end gap-0.5 px-2">
+          <div
+            class="contents"
+            ref={(ref) => {
+              panel.layoutRefs.headerRight = ref;
+            }}
+          />
+          <SoupNavigationButtons />
+        </div>
       </div>
     </div>
   );

--- a/js/app/packages/app/component/split-layout/components/SplitPanel.tsx
+++ b/js/app/packages/app/component/split-layout/components/SplitPanel.tsx
@@ -1,5 +1,6 @@
 import { createSoupState } from '@app/component/next-soup/create-soup-state';
 import { SoupContextProvider } from '@app/component/next-soup/soup-context';
+import { SoupViewContextProvider } from '@app/component/next-soup/soup-view/soup-view-context';
 import { isListViewID, LIST_VIEW_ID } from '@app/constants/list-views';
 import { globalSplitManager } from '@app/signal/splitLayout';
 import { splitContainerAttribute } from '@core/dom-selectors';
@@ -142,73 +143,75 @@ export function SplitPanel(props: SplitPanelProps) {
           panelRef,
         }}
       >
-        <SplitDrawerGroup contentOffsetTop={offsetTop} panelSize={panelSize}>
-          <Show when={props.handle.isSpotLight()}>
+        <SoupViewContextProvider soup={nextSoup}>
+          <SplitDrawerGroup contentOffsetTop={offsetTop} panelSize={panelSize}>
+            <Show when={props.handle.isSpotLight()}>
+              <div
+                class="fixed inset-0 w-screen h-screen z-modal-overlay bg-modal-overlay pattern-diagonal-4 pattern-edge-muted"
+                onClick={() => props.handle.toggleSpotlight(false)}
+              />
+              <div class="fixed inset-16 bg-surface shadow-xl" />
+            </Show>
+
             <div
-              class="fixed inset-0 w-screen h-screen z-modal-overlay bg-modal-overlay pattern-diagonal-4 pattern-edge-muted"
-              onClick={() => props.handle.toggleSpotlight(false)}
-            />
-            <div class="fixed inset-16 bg-surface shadow-xl" />
-          </Show>
-
-          <div
-            class="relative"
-            classList={{
-              'fixed inset-16 z-modal-overlay isolate opacity-50':
-                props.handle.isSpotLight(),
-              'opacity-100': props.active || props.handle.isSpotLight(),
-              'size-full': !props.handle.isSpotLight(),
-            }}
-            ref={(ref) => {
-              setPanelRef(ref);
-              props.setPanelRef(ref);
-              attachHotKeys(ref);
-            }}
-            data-split-id={props.split.id}
-            {...splitContainerAttribute}
-            data-modal={props.handle.isSpotLight()}
-            tabindex={-1}
-          >
-            <Panel
-              active={
-                !isMobile() &&
-                props.active &&
-                multipleSplits() &&
-                !props.handle.isSpotLight()
-              }
-              class="rounded-xl mobile:rounded-none mobile:after:hidden mobile:!border-0"
-              depth={1}
+              class="relative"
+              classList={{
+                'fixed inset-16 z-modal-overlay isolate opacity-50':
+                  props.handle.isSpotLight(),
+                'opacity-100': props.active || props.handle.isSpotLight(),
+                'size-full': !props.handle.isSpotLight(),
+              }}
+              ref={(ref) => {
+                setPanelRef(ref);
+                props.setPanelRef(ref);
+                attachHotKeys(ref);
+              }}
+              data-split-id={props.split.id}
+              {...splitContainerAttribute}
+              data-modal={props.handle.isSpotLight()}
+              tabindex={-1}
             >
-              <Panel.Header
-                class={cn(
-                  'block min-h-10.25 touch:min-h-11.25 p-0 overflow-visible',
-                  shouldHideSplitHeader() && 'hidden'
-                )}
+              <Panel
+                active={
+                  !isMobile() &&
+                  props.active &&
+                  multipleSplits() &&
+                  !props.handle.isSpotLight()
+                }
+                class="rounded-xl mobile:rounded-none mobile:after:hidden mobile:!border-0"
+                depth={1}
               >
-                <SplitHeader ref={setHeaderRef} />
-              </Panel.Header>
+                <Panel.Header
+                  class={cn(
+                    'block min-h-10.25 touch:min-h-11.25 p-0 overflow-visible',
+                    shouldHideSplitHeader() && 'hidden'
+                  )}
+                >
+                  <SplitHeader ref={setHeaderRef} />
+                </Panel.Header>
 
-              <Panel.Toolbar
-                class={cn(
-                  'items-start py-2 overflow-visible',
-                  !hasToolbarContent() && 'hidden',
-                  !previewState() &&
-                    'border-b-0' /* scuffed: this is shit, but we are blinded by linear */
-                )}
-              >
-                <SplitToolbar ref={setToolbarRef} />
-              </Panel.Toolbar>
+                <Panel.Toolbar
+                  class={cn(
+                    'items-start py-2 overflow-visible',
+                    !hasToolbarContent() && 'hidden',
+                    !previewState() &&
+                      'border-b-0' /* scuffed: this is shit, but we are blinded by linear */
+                  )}
+                >
+                  <SplitToolbar ref={setToolbarRef} />
+                </Panel.Toolbar>
 
-              <Panel.Body>
-                <div class="@container/split size-full overflow-hidden relative">
-                  <Suspense>
-                    <Dynamic component={props.split.mount.element} />
-                  </Suspense>
-                </div>
-              </Panel.Body>
-            </Panel>
-          </div>
-        </SplitDrawerGroup>
+                <Panel.Body>
+                  <div class="@container/split size-full overflow-hidden relative">
+                    <Suspense>
+                      <Dynamic component={props.split.mount.element} />
+                    </Suspense>
+                  </div>
+                </Panel.Body>
+              </Panel>
+            </div>
+          </SplitDrawerGroup>
+        </SoupViewContextProvider>
       </SplitPanelContext.Provider>
     </SoupContextProvider>
   );

--- a/js/app/packages/app/component/split-layout/layoutManager.ts
+++ b/js/app/packages/app/component/split-layout/layoutManager.ts
@@ -1,4 +1,4 @@
-import { LIST_VIEW_ID } from '@app/constants/list-views';
+import { LIST_VIEW_ID, type ListView } from '@app/constants/list-views';
 import type {
   BlockAlias,
   BlockAliasContext,
@@ -116,7 +116,7 @@ export type PopoverSplitHandle = {
 };
 
 export type ReferredFrom =
-  | 'list-view'
+  | ListView
   | 'kommand-menu'
   | 'mention'
   | 'attachment'
@@ -128,7 +128,6 @@ export type ReferredFrom =
   | 'hotkey'
   | 'quick-access'
   | 'file-upload'
-  | 'search'
   | null;
 
 export type SplitState = {

--- a/js/app/packages/block-email/component/Email.tsx
+++ b/js/app/packages/block-email/component/Email.tsx
@@ -358,6 +358,7 @@ function EmailContent(props: EmailViewProps) {
   onMount(() => {
     registerEmailHotkeys(scopeId(), {
       blockSender: context.blockSender,
+      markDone: context.archiveThread,
       markSenderSignal: context.markSenderSignal,
       markSenderNoise: context.markSenderNoise,
       navigateToPreviousMessage,

--- a/js/app/packages/block-email/component/EmailContext.tsx
+++ b/js/app/packages/block-email/component/EmailContext.tsx
@@ -1,6 +1,8 @@
 import { useGlobalNotificationSource } from '@app/component/GlobalAppState';
 import { makeMarkDoneAction } from '@app/component/next-soup/actions';
 import { useMaybeSoup } from '@app/component/next-soup/soup-context';
+import { openEntityInSplitFromUnifiedList } from '@app/component/next-soup/utils';
+import { useSplitPanel } from '@app/component/split-layout/layoutUtils';
 import { URL_PARAMS } from '@block-email/constants';
 import { convertContactInfoToEmailRecipient } from '@block-email/util/recipientConversion';
 import {
@@ -317,6 +319,7 @@ export function EmailProvider(props: FlowProps<{ threadID: string }>) {
   };
 
   const soup = useMaybeSoup();
+  const splitPanel = useSplitPanel();
 
   const userId = useUserId();
 
@@ -350,7 +353,25 @@ export function EmailProvider(props: FlowProps<{ threadID: string }>) {
 
     if (selectedRow) {
       if (soup) {
-        markAsDoneAction.executeWithSoup([selectedRow.original], soup);
+        markAsDoneAction.executeWithSoup(
+          [selectedRow.original],
+          soup,
+          (nextEntity) => {
+            const splitHandle = splitPanel?.handle;
+            if (!splitHandle) return;
+            // Only advance the split when it shows this email full screen.
+            // In preview mode the split still holds the list and the soup
+            // selection moves on its own.
+            const contentType = splitHandle.content().type;
+            if (contentType === 'component' || contentType === 'project')
+              return;
+            void openEntityInSplitFromUnifiedList(nextEntity, {
+              splitHandle,
+              mergeHistory: true,
+              referredFrom: splitHandle.referredFrom(),
+            });
+          }
+        );
       } else {
         markAsDoneAction.execute([selectedRow.original]);
       }

--- a/js/app/packages/block-email/util/emailHotkeys.ts
+++ b/js/app/packages/block-email/util/emailHotkeys.ts
@@ -3,6 +3,7 @@ import { registerHotkey } from 'core/hotkey/hotkeys';
 
 interface EmailHotkeyHandlers {
   blockSender: () => boolean;
+  markDone: () => boolean;
   markSenderSignal: () => boolean;
   markSenderNoise: () => boolean;
   navigateToPreviousMessage: () => boolean;
@@ -47,6 +48,14 @@ export function registerEmailHotkeys(
     },
     hotkeyToken: TOKENS.email.forward,
     displayPriority: 7,
+  });
+  registerHotkey({
+    hotkey: 'e',
+    scopeId,
+    description: 'Mark done',
+    keyDownHandler: handlers.markDone,
+    hotkeyToken: TOKENS.entity.action.markDone,
+    displayPriority: 10,
   });
   registerHotkey({
     scopeId: scopeId,

--- a/js/app/packages/block-project/component/Block.tsx
+++ b/js/app/packages/block-project/component/Block.tsx
@@ -196,6 +196,7 @@ const ProjectEntityList = (props: {
     <SoupContextProvider soup={props.soup}>
       <SoupViewContextProvider
         soup={props.soup}
+        initialEnabled
         initialQuery={defineQueryFilters({
           include: {
             // Filter documents by project


### PR DESCRIPTION
Re-applies the j/k list-navigation-from-blocks infrastructure from #3906
(reverted in #3923), narrowed to emails only:

- Hoist SoupViewContextProvider to SplitPanel with an initialize()/enabled
  lifecycle so the soup list state survives opening an entity full screen
  in the same split.
- Track typed referredFrom (list view ids) through split navigation.
- Keep j/k registered on the split scope after the list unmounts, but only
  while the focused entity is an email opened from inbox/mail; other block
  types are untouched and keep their own keys.
- Register 'e' (mark done) on the email block scope; archiving a
  full-screen email advances to the next item, while preview mode keeps
  its existing list-driven behavior.
- Show prev/next header buttons only while an email is focused.

Unlike #3906, this does not add 'e' to all blocks and does not suppress
input autofocus in chat/notebook/channel blocks, since j/k are inert there.

https://claude.ai/code/session_01XwSz5UKemkXMhgMi5mqJVT