### PR TITLE
docs(teams): document team sharing for snippets

### DIFF
--- a/docs/account/teams.mdx
+++ b/docs/account/teams.mdx
@@ -35,6 +35,7 @@ Joining a team changes the default sharing for a few block types — everything 
 - **Tasks** are visible to the whole team by default.
 - **Calls** are recorded, transcribed, and shared to team memory by default; anyone can opt a call out, which keeps it in their personal memory only.
 - **Emails** with tracked customers are shared through the [CRM](/product/crm) when Email Sync is on for that company.
+- **[Snippets](/product/snippets)** stay personal until you turn on **Share with team** in the snippet's side panel; a shared snippet appears in every teammate's <kbd>;</kbd> menu and they can edit it.
 
 See [Permissions](/permissions) for the full sharing model.
 


### PR DESCRIPTION
Follow-up to #3966: adds snippets to the "What's shared with a team" list on the [Teams & Admin](https://docs.macro.com/account/teams) page — personal by default, opt-in via the **Share with team** toggle in the snippet's side panel, with a link to the new Snippets page.

`mint validate` and `mint broken-links` pass.

https://claude.ai/code/session_01VNBptQq6sxt16JeseiAYoT

---
_Generated by [Claude Code](https://claude.ai/code/session_01VNBptQq6sxt16JeseiAYoT)_