### PR TITLE
feat(email): add 'Add inbox' row to inbox selector

### DIFF
--- a/js/app/packages/app/component/AddInboxDialog.tsx
+++ b/js/app/packages/app/component/AddInboxDialog.tsx
@@ -1,0 +1,72 @@
+import { useAddInboxFlow } from '@core/email-link';
+import { Button, Dialog, Panel } from '@ui';
+import { createSignal, onCleanup } from 'solid-js';
+
+const [isOpen, setIsOpen] = createSignal(false);
+
+/**
+ * Requests the add-inbox confirmation dialog. The dialog itself is rendered
+ * by the settings Account panel, so callers elsewhere (e.g. the mail inbox
+ * selector) open settings first and the dialog appears once it mounts.
+ */
+export const openAddInboxDialog = () => setIsOpen(true);
+
+/**
+ * Confirmation step before the add-inbox OAuth redirect. Confirming kicks off
+ * `useAddInboxFlow`, which navigates the page to Google's consent screen.
+ */
+export function AddInboxDialog() {
+  const addInbox = useAddInboxFlow();
+  const [pending, setPending] = createSignal(false);
+
+  onCleanup(() => setIsOpen(false));
+
+  const handleConfirm = async () => {
+    if (pending()) return;
+    setPending(true);
+    await addInbox();
+    setPending(false);
+  };
+
+  return (
+    <Dialog
+      open={isOpen()}
+      onOpenChange={setIsOpen}
+      position="center"
+      class="w-120"
+    >
+      <Panel active depth={2} class="rounded-xl">
+        <Panel.Header class="px-6">
+          <Dialog.Title class="text-ink text-sm font-semibold">
+            Add an inbox
+          </Dialog.Title>
+        </Panel.Header>
+        <Panel.Body class="p-6 font-sans flex flex-col gap-3">
+          <Dialog.Description class="text-ink-muted text-sm/tight font-normal">
+            Connect another Gmail account to Macro. You'll be redirected to
+            Google to choose the account and approve access — its mail will then
+            sync alongside your existing inboxes.
+          </Dialog.Description>
+          <div class="pt-3 justify-end items-center gap-3 inline-flex">
+            <Button
+              variant="base"
+              depth={3}
+              disabled={pending()}
+              onClick={() => setIsOpen(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="active"
+              depth={3}
+              disabled={pending()}
+              onClick={handleConfirm}
+            >
+              Continue to Google
+            </Button>
+          </div>
+        </Panel.Body>
+      </Panel>
+    </Dialog>
+  );
+}

--- a/js/app/packages/app/component/AddInboxDialog.tsx
+++ b/js/app/packages/app/component/AddInboxDialog.tsx
@@ -38,12 +38,12 @@ export function AddInboxDialog() {
       <Panel active depth={2} class="rounded-xl">
         <Panel.Header class="px-6">
           <Dialog.Title class="text-ink text-sm font-semibold">
-            Add an inbox
+            Add inbox
           </Dialog.Title>
         </Panel.Header>
         <Panel.Body class="p-6 font-sans flex flex-col gap-3">
           <Dialog.Description class="text-ink-muted text-sm/tight font-normal">
-            Connect another Gmail account to Macro.
+            Connect another Gmail account to Macro?
           </Dialog.Description>
           <div class="pt-3 justify-end items-center gap-3 inline-flex">
             <Button
@@ -60,7 +60,7 @@ export function AddInboxDialog() {
               disabled={pending()}
               onClick={handleConfirm}
             >
-              Continue to Google
+              Add inbox
             </Button>
           </div>
         </Panel.Body>

--- a/js/app/packages/app/component/AddInboxDialog.tsx
+++ b/js/app/packages/app/component/AddInboxDialog.tsx
@@ -43,9 +43,7 @@ export function AddInboxDialog() {
         </Panel.Header>
         <Panel.Body class="p-6 font-sans flex flex-col gap-3">
           <Dialog.Description class="text-ink-muted text-sm/tight font-normal">
-            Connect another Gmail account to Macro. You'll be redirected to
-            Google to choose the account and approve access — its mail will then
-            sync alongside your existing inboxes.
+            Connect another Gmail account to Macro.
           </Dialog.Description>
           <div class="pt-3 justify-end items-center gap-3 inline-flex">
             <Button

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/inbox-selector.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/inbox-selector.tsx
@@ -1,6 +1,11 @@
 import { useSoupView } from '@app/component/next-soup/soup-view/soup-view-context';
+import { useFeatureFlag } from '@app/lib/analytics/posthog';
+import { ENABLE_MULTI_INBOX_OVERRIDE } from '@core/constant/featureFlags';
+import { useSettingsState } from '@core/constant/SettingsState';
+import { useAddInboxFlow } from '@core/email-link';
 import { Combobox } from '@kobalte/core/combobox';
 import CaretDownIcon from '@phosphor/caret-down.svg';
+import PlusIcon from '@phosphor/plus.svg';
 import TrayIcon from '@phosphor/tray.svg';
 import { Button } from '@ui';
 import { Show } from 'solid-js';
@@ -9,9 +14,10 @@ import { SearchableMultiSelect } from './searchable-multi-select';
 
 /**
  * Scopes the list to a subset of the user's linked inboxes. Multi-select,
- * default = all (no clause). Hidden entirely for single-inbox users so they
- * see no change. Selection is held in soup-view's `inboxFilter` and compiled
- * into `Owner` email literals.
+ * default = all (no clause). Shown whenever the multi-inbox flag is on (or
+ * the user already has multiple inboxes) so the "Add inbox" action row is
+ * discoverable even with zero or one inbox connected. Selection is held in
+ * soup-view's `inboxFilter` and compiled into `Owner` email literals.
  */
 export function InboxSelector() {
   const { inboxFilter, setInboxFilter } = useSoupView();
@@ -19,6 +25,11 @@ export function InboxSelector() {
     selectedIds: inboxFilter,
     setSelectedIds: setInboxFilter,
   });
+  const multiInboxFlag = useFeatureFlag('enable-multi-inbox', {
+    enabledOverride: ENABLE_MULTI_INBOX_OVERRIDE,
+  });
+  const { openSettings } = useSettingsState();
+  const addInbox = useAddInboxFlow();
 
   const label = () => {
     const ids = inboxFilter();
@@ -30,7 +41,7 @@ export function InboxSelector() {
   };
 
   return (
-    <Show when={picker.hasMultiple()}>
+    <Show when={multiInboxFlag().enabled || picker.hasMultiple()}>
       <SearchableMultiSelect
         options={picker.options}
         activeIds={picker.activeIds}
@@ -38,6 +49,18 @@ export function InboxSelector() {
         onOnly={picker.selectOnly}
         placeholder="Search inboxes..."
         preserveOrder
+        action={
+          multiInboxFlag().enabled
+            ? {
+                label: 'Add inbox',
+                icon: () => <PlusIcon class="size-4" />,
+                onSelect: () => {
+                  openSettings('Account');
+                  void addInbox();
+                },
+              }
+            : undefined
+        }
       >
         <Combobox.Trigger
           as={Button}

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/inbox-selector.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/inbox-selector.tsx
@@ -1,8 +1,8 @@
+import { openAddInboxDialog } from '@app/component/AddInboxDialog';
 import { useSoupView } from '@app/component/next-soup/soup-view/soup-view-context';
 import { useFeatureFlag } from '@app/lib/analytics/posthog';
 import { ENABLE_MULTI_INBOX_OVERRIDE } from '@core/constant/featureFlags';
 import { useSettingsState } from '@core/constant/SettingsState';
-import { useAddInboxFlow } from '@core/email-link';
 import { Combobox } from '@kobalte/core/combobox';
 import CaretDownIcon from '@phosphor/caret-down.svg';
 import PlusIcon from '@phosphor/plus.svg';
@@ -29,7 +29,6 @@ export function InboxSelector() {
     enabledOverride: ENABLE_MULTI_INBOX_OVERRIDE,
   });
   const { openSettings } = useSettingsState();
-  const addInbox = useAddInboxFlow();
 
   const label = () => {
     const ids = inboxFilter();
@@ -56,7 +55,7 @@ export function InboxSelector() {
                 icon: () => <PlusIcon class="size-4" />,
                 onSelect: () => {
                   openSettings('Account');
-                  void addInbox();
+                  openAddInboxDialog();
                 },
               }
             : undefined

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/searchable-multi-select.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/searchable-multi-select.tsx
@@ -19,6 +19,20 @@ export type SearchableOption = {
   icon?: () => JSX.Element;
 };
 
+export type SearchableSelectAction = {
+  label: string;
+  icon?: () => JSX.Element;
+  onSelect: () => void;
+};
+
+/**
+ * Sentinel id for the action row. It rides the option collection so kobalte's
+ * arrow-key highlighting and Enter-to-select reach it like any other row, but
+ * "selecting" it fires `action.onSelect` and closes the menu instead of
+ * toggling the multi-select value.
+ */
+const ACTION_ID = '__searchable-multi-select-action__';
+
 const ITEM_HEIGHT = 36;
 const LISTBOX_CLASS = 'max-h-[240px] overflow-y-auto scrollbar-hidden';
 
@@ -41,6 +55,8 @@ type SearchableMultiSelectProps = {
   preserveOrder?: boolean;
   /** Render a per-row "Only" action that narrows the selection to that row. */
   onOnly?: (id: string) => void;
+  /** Non-toggling action row appended after the options. */
+  action?: SearchableSelectAction;
   open?: Accessor<boolean>;
   onOpenChange?: (open: boolean) => void;
   children: JSX.Element;
@@ -54,17 +70,19 @@ const SearchableMultiSelectItem = (itemProps: {
     item={itemProps.item}
     class="w-full flex items-center gap-2.5 px-3 py-2 rounded-md text-left text-xs data-highlighted:bg-ink/5 group cursor-default"
   >
-    <span
-      class={cn(
-        'size-3.5 flex items-center justify-center shrink-0 rounded-sm border text-surface',
-        'border-transparent group-hover:not-hover:border-edge-muted group-data-highlighted:not-hover:border-edge-muted hover:border-accent',
-        'group-data-selected:bg-accent group-data-selected:border-accent'
-      )}
-    >
-      <Combobox.ItemIndicator>
-        <CheckIcon class="size-2.5" />
-      </Combobox.ItemIndicator>
-    </span>
+    <Show when={itemProps.item.rawValue.id !== ACTION_ID}>
+      <span
+        class={cn(
+          'size-3.5 flex items-center justify-center shrink-0 rounded-sm border text-surface',
+          'border-transparent group-hover:not-hover:border-edge-muted group-data-highlighted:not-hover:border-edge-muted hover:border-accent',
+          'group-data-selected:bg-accent group-data-selected:border-accent'
+        )}
+      >
+        <Combobox.ItemIndicator>
+          <CheckIcon class="size-2.5" />
+        </Combobox.ItemIndicator>
+      </span>
+    </Show>
     <Show when={itemProps.item.rawValue.icon}>
       {(icon) => (
         <span class="size-4 flex items-center justify-center shrink-0">
@@ -75,7 +93,11 @@ const SearchableMultiSelectItem = (itemProps: {
     <Combobox.ItemLabel class="flex-1 truncate text-ink-muted group-data-selected:text-ink">
       {itemProps.item.rawValue.label}
     </Combobox.ItemLabel>
-    <Show when={itemProps.onOnly}>
+    <Show
+      when={
+        itemProps.item.rawValue.id !== ACTION_ID ? itemProps.onOnly : undefined
+      }
+    >
       {(onOnly) => (
         <button
           type="button"
@@ -171,7 +193,6 @@ export const SearchableMultiSelect = (props: SearchableMultiSelectProps) => {
   };
 
   const activeOptions = useActiveOptions(props.options, props.activeIds);
-  const hasMatches = useHasMatches(props.options, searchQuery);
   const selectedFirstOptions = useSelectedFirst({
     items: props.options,
     selectedIds: props.activeIds,
@@ -181,14 +202,28 @@ export const SearchableMultiSelect = (props: SearchableMultiSelectProps) => {
   });
   const sortedOptions = () =>
     props.preserveOrder ? props.options() : selectedFirstOptions();
-
-  const handleChange = (selected: SearchableOption[]) => {
-    props.onChange(selected.map((o) => o.id));
-  };
+  const displayOptions = createMemo(() => {
+    const action = props.action;
+    if (!action) return sortedOptions();
+    return [
+      ...sortedOptions(),
+      { id: ACTION_ID, label: action.label, icon: action.icon },
+    ];
+  });
+  const hasMatches = useHasMatches(displayOptions, searchQuery);
 
   const handleOpenChange = (open: boolean) => {
     setIsOpen(open);
     if (!open) setSearchQuery('');
+  };
+
+  const handleChange = (selected: SearchableOption[]) => {
+    if (props.action && selected.some((o) => o.id === ACTION_ID)) {
+      handleOpenChange(false);
+      props.action.onSelect();
+      return;
+    }
+    props.onChange(selected.map((o) => o.id));
   };
 
   return (
@@ -197,7 +232,7 @@ export const SearchableMultiSelect = (props: SearchableMultiSelectProps) => {
       selectionBehavior="toggle"
       closeOnSelection={false}
       open={isOpen()}
-      options={sortedOptions()}
+      options={displayOptions()}
       value={activeOptions()}
       onChange={handleChange}
       onInputChange={setSearchQuery}
@@ -243,7 +278,7 @@ export const SearchableMultiSelect = (props: SearchableMultiSelectProps) => {
                 }
               >
                 <VirtualizedListbox
-                  options={sortedOptions()}
+                  options={displayOptions()}
                   class={props.listboxClass}
                   onOnly={props.onOnly}
                 />

--- a/js/app/packages/app/component/settings/Account.tsx
+++ b/js/app/packages/app/component/settings/Account.tsx
@@ -56,11 +56,8 @@ import { useSettingsState } from '@core/constant/SettingsState';
 import PaywallComponent from '../paywall/PaywallComponent';
 import PaywallTeamMemberView from '../paywall/PaywallTeamMemberView';
 import PaywallTeamOwnerView from '../paywall/PaywallTeamOwnerView';
-import {
-  useAddInboxFlow,
-  useEmailLinks,
-  useEmailLinksStatus,
-} from '@core/email-link';
+import { useEmailLinks, useEmailLinksStatus } from '@core/email-link';
+import { AddInboxDialog, openAddInboxDialog } from '../AddInboxDialog';
 import { useRemoveInboxMutation } from '@queries/email/link';
 import {
   type SupportedNotificationSettings,
@@ -349,7 +346,6 @@ export function Account() {
     setIsEmailActionPending(false);
   };
 
-  const handleAddInbox = useAddInboxFlow();
 
   const handleResyncInbox = async (linkId: string) => {
     setResyncingIds((prev) => new Set(prev).add(linkId));
@@ -651,7 +647,7 @@ export function Account() {
                             variant="base"
                             size="sm"
                             depth={3}
-                            onClick={handleAddInbox}
+                            onClick={openAddInboxDialog}
                             aria-label="Add inbox"
                           >
                             <PlusIcon class="size-4" />
@@ -816,6 +812,8 @@ export function Account() {
                 </Panel.Body>
               </Panel>
             </Dialog>
+
+            <AddInboxDialog />
 
             <Show when={isNativeMobilePlatform()}>
               <div class="border-t border-edge pt-4">

--- a/js/app/packages/app/component/settings/Account.tsx
+++ b/js/app/packages/app/component/settings/Account.tsx
@@ -56,9 +56,11 @@ import { useSettingsState } from '@core/constant/SettingsState';
 import PaywallComponent from '../paywall/PaywallComponent';
 import PaywallTeamMemberView from '../paywall/PaywallTeamMemberView';
 import PaywallTeamOwnerView from '../paywall/PaywallTeamOwnerView';
-import { ROUTER_BASE_CONCAT } from '@app/constants/routerBase';
-import { useEmailLinks, useEmailLinksStatus } from '@core/email-link';
-import { useInitGmailLink } from '@queries/auth';
+import {
+  useAddInboxFlow,
+  useEmailLinks,
+  useEmailLinksStatus,
+} from '@core/email-link';
 import { useRemoveInboxMutation } from '@queries/email/link';
 import {
   type SupportedNotificationSettings,
@@ -347,16 +349,7 @@ export function Account() {
     setIsEmailActionPending(false);
   };
 
-  const initGmailLink = useInitGmailLink();
-  const handleAddInbox = async () => {
-    const callbackUrl = `${window.location.origin}${ROUTER_BASE_CONCAT}inbox-link-callback`;
-    const result = await initGmailLink.mutateAsync(callbackUrl);
-    if (result.isOk()) {
-      window.location.href = result.value.authorization_url;
-    } else {
-      toast.failure('Failed to start Gmail link flow');
-    }
-  };
+  const handleAddInbox = useAddInboxFlow();
 
   const handleResyncInbox = async (linkId: string) => {
     setResyncingIds((prev) => new Set(prev).add(linkId));

--- a/js/app/packages/core/email-link/index.ts
+++ b/js/app/packages/core/email-link/index.ts
@@ -5,7 +5,9 @@ import {
   type TimeoutError,
 } from '@core/auth/channel';
 import { openEmailAuthPopup } from '@core/auth/email';
+import { toast } from '@core/component/Toast/Toast';
 
+import { useInitGmailLink } from '@queries/auth';
 import { invalidateUserInfo } from '@queries/auth/user-info';
 import { invalidateEmailLinks, useEmailLinksQuery } from '@queries/email/link';
 import { emailClient, SHARED_INBOX_CONFLICT_CODE } from '@service-email/client';
@@ -188,6 +190,24 @@ export function initAndStartEmailSync() {
   };
 
   return initEmailLink().map(startEmailPolling).map(invalidations);
+}
+
+/**
+ * Starts the add-inbox flow: fetches the Gmail link authorization URL and
+ * navigates the browser to the OAuth consent page. The callback returns to
+ * `/inbox-link-callback`, which provisions the new link.
+ */
+export function useAddInboxFlow() {
+  const initGmailLink = useInitGmailLink();
+  return async () => {
+    const callbackUrl = `${window.location.origin}${ROUTER_BASE_CONCAT}inbox-link-callback`;
+    const result = await initGmailLink.mutateAsync(callbackUrl);
+    if (result.isOk()) {
+      window.location.href = result.value.authorization_url;
+    } else {
+      toast.failure('Failed to start Gmail link flow');
+    }
+  };
 }
 
 /**


### PR DESCRIPTION
Adds an "Add inbox" action row to the bottom of the mail inbox selector, shown whenever the multi-inbox flag is on (including 0/1-inbox users) so the feature is discoverable outside settings. Selecting it (mouse or arrow keys + Enter) closes the dropdown, opens Settings → Account, and starts the same Gmail OAuth link flow as the settings button, now factored into a shared `useAddInboxFlow()` hook.
