### PR TITLE
fix(email): keep a bootstrapped inbox's login identity on its own user

### DIFF
--- a/rust/cloud-storage/authentication_service/src/api/oauth2/google.rs
+++ b/rust/cloud-storage/authentication_service/src/api/oauth2/google.rs
@@ -62,7 +62,26 @@ async fn link_user(
             )
         })?;
 
-    // Attempt to create the FA IdP link for the calling user. Three terminal cases:
+    // The IdP link doubles as the linked email's LOGIN identity: a Google identity binds to
+    // exactly one FusionAuth user, and sign-in resolves through that link. When the linked
+    // email belongs to an existing macro user, the link must therefore live on THAT user's FA
+    // account — attaching it to the requester would capture the owner's sign-in. Only
+    // mailboxes with no macro user of their own link under the requester.
+    let idp_link_owner =
+        match macro_db_client::user::get::get_macro_user_id_by_email(&ctx.db, &user_info_email)
+            .await
+        {
+            Ok(Some(mailbox_owner_fa)) => mailbox_owner_fa.to_string(),
+            Ok(None) => macro_user_id.to_string(),
+            Err(e) => {
+                return Err((
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("unable to look up mailbox owner for linked email {e}"),
+                ));
+            }
+        };
+
+    // Attempt to create the FA IdP link. Three terminal cases:
     //   Ok                                  → fresh link created; data-source path downstream.
     //   Err(alreadyLinked, owned by self)  → idempotent relink; data-source path no-ops downstream.
     //   Err(alreadyLinked, owned by other) → cross-account add; init promotes to graph edge.
@@ -75,7 +94,7 @@ async fn link_user(
                 display_name: user_info_email.clone(),
                 identity_provider_id: Cow::Borrowed(identity_provider_id),
                 identity_provider_user_id: Cow::Borrowed(&user_info.sub),
-                user_id: Cow::Borrowed(&macro_user_id.to_string()),
+                user_id: Cow::Borrowed(&idp_link_owner),
                 token: Cow::Borrowed(&token_response.refresh_token),
             },
         })
@@ -84,7 +103,7 @@ async fn link_user(
         Ok(()) => {}
         Err(FusionAuthClientError::IdentityProviderLinkAlreadyExists) => {
             tracing::info!(
-                fusion_user_id = %macro_user_id,
+                fusion_user_id = %idp_link_owner,
                 linked_email = %user_info_email,
                 "idp link already exists, skipping creation"
             );

--- a/rust/cloud-storage/email_service/src/api/email/init.rs
+++ b/rust/cloud-storage/email_service/src/api/email/init.rs
@@ -259,12 +259,15 @@ pub async fn handler(
             // Access for the primary comes from the macro_user_links edge alone.
             let child_macro_id_owned = MacroUserIdStr::try_from(child_macro_id.to_string())?;
 
+            // `existing_owner` proved a User row exists for this email, so a miss here means
+            // the child account vanished mid-flight. Abort rather than fall back to the
+            // requester's fusion id, which would provision the link under the wrong identity.
             let child_fusion_id =
                 macro_db_client::user::get::get_macro_user_id_by_email(&ctx.db, &linked_email)
                     .await
                     .context("Failed to look up child's fusion id for self-link bootstrap")?
-                    .map(|id| id.to_string())
-                    .unwrap_or_else(|| user_context.fusion_user_id.clone());
+                    .context("child macro user disappeared before self-link bootstrap")?
+                    .to_string();
 
             let gmail_token =
                 fetch_gmail_token_for_email(&ctx, &child_fusion_id, &linked_email).await?;

--- a/rust/cloud-storage/email_service/src/api/email/init.rs
+++ b/rust/cloud-storage/email_service/src/api/email/init.rs
@@ -252,14 +252,22 @@ pub async fn handler(
             }
 
             // Self-link bootstrap: the child macro_user exists but never connected an inbox.
-            // Provision its email_links row with the child's macro_id (inbox ownership) but the
-            // primary's fusionauth_user_id — the OAuth grant lives under the primary's fusion id,
-            // and token resolution, message/thread scoping, and backfill rate-limiting key off it.
+            // Provision its email_links row entirely under the child's identity: the OAuth
+            // grant (FA IdP link) is attached to the child's fusion user at the OAuth
+            // callback — it is also the child's login identity, so it cannot live under the
+            // primary — and token resolution, scoping, and backfill rate-limiting key off it.
+            // Access for the primary comes from the macro_user_links edge alone.
             let child_macro_id_owned = MacroUserIdStr::try_from(child_macro_id.to_string())?;
 
+            let child_fusion_id =
+                macro_db_client::user::get::get_macro_user_id_by_email(&ctx.db, &linked_email)
+                    .await
+                    .context("Failed to look up child's fusion id for self-link bootstrap")?
+                    .map(|id| id.to_string())
+                    .unwrap_or_else(|| user_context.fusion_user_id.clone());
+
             let gmail_token =
-                fetch_gmail_token_for_email(&ctx, &user_context.fusion_user_id, &linked_email)
-                    .await?;
+                fetch_gmail_token_for_email(&ctx, &child_fusion_id, &linked_email).await?;
             let watch_response = ctx.gmail_client.register_watch(&gmail_token).await?;
 
             // All writes commit atomically so a partial failure leaves no dangling link,
@@ -272,7 +280,7 @@ pub async fn handler(
 
             let link = enable_gmail_sync_for(
                 tx.as_mut(),
-                &user_context.fusion_user_id,
+                &child_fusion_id,
                 child_macro_id_owned,
                 &linked_email,
                 &watch_response.history_id,
@@ -582,8 +590,8 @@ async fn fetch_gmail_token_for_email(
 /// Gmail watch. Runs on a caller-provided connection so the writes can join a wider
 /// transaction; callers register the watch (external IO) beforehand and pass its `history_id`.
 /// Caller-provided identifiers let this serve the JWT-driven new-user signup, the
-/// `link_id`-driven add-inbox flow, and the self-link bootstrap (where `macro_id` is the
-/// child's but `fusion_user_id` is the primary's).
+/// `link_id`-driven add-inbox flow, and the self-link bootstrap (where both `macro_id`
+/// and `fusion_user_id` are the child's — the grant lives with the mailbox's own account).
 #[tracing::instrument(skip(conn), err)]
 async fn enable_gmail_sync_for(
     conn: &mut sqlx::PgConnection,


### PR DESCRIPTION
Bootstrapping an existing macro user's inbox (self-link bootstrap) attached the Google IdP link to the requester's FusionAuth user; since a Google identity binds to exactly one FusionAuth user and login resolves through that link, the mailbox owner could no longer sign in (observed with gabtest2@ on dev). The OAuth callback now attaches the IdP link to the mailbox owner's FusionAuth user when one exists, and init provisions the bootstrap link under the child's fusion id — delegated access continues to come from the macro_user_links edge.
