### PR TITLE
fix(split-layout): collapse header items by priority and recover via trial-expand

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
@@ -542,25 +542,25 @@ export const SoupView = (props: SoupViewProps) => {
                   </Layer>
                 }
               >
-                <CollapsibleHeaderItem
-                  id="search"
-                  priority={0}
-                  onCollapsedChange={(isCollapsed) => {
-                    setSearchIsCollapsed(isCollapsed);
-                    if (!isCollapsed) setNarrowSearchExpanded(false);
-                  }}
-                  expanded={() => (
-                    <Layer depth={2}>
-                      <div class="w-60 ml-2">
-                        <SoupSearchbar
-                          variant="secondary"
-                          initialValue={props.initialSearchText}
-                        />
-                      </div>
-                    </Layer>
-                  )}
-                  collapsed={() => (
-                    <Show when={!narrowSearchExpanded()}>
+                <Show when={!narrowSearchExpanded()}>
+                  <CollapsibleHeaderItem
+                    id="search"
+                    priority={0}
+                    onCollapsedChange={(isCollapsed) => {
+                      setSearchIsCollapsed(isCollapsed);
+                      if (!isCollapsed) setNarrowSearchExpanded(false);
+                    }}
+                    expanded={() => (
+                      <Layer depth={2}>
+                        <div class="w-60 ml-2">
+                          <SoupSearchbar
+                            variant="secondary"
+                            initialValue={props.initialSearchText}
+                          />
+                        </div>
+                      </Layer>
+                    )}
+                    collapsed={() => (
                       <Tooltip label="Search" hotkey={TOKENS.soup.openSearch}>
                         <Button
                           variant="base"
@@ -571,9 +571,9 @@ export const SoupView = (props: SoupViewProps) => {
                           <SearchIcon class="size-4 touch:size-6" />
                         </Button>
                       </Tooltip>
-                    </Show>
-                  )}
-                />
+                    )}
+                  />
+                </Show>
               </Show>
             </SplitHeaderRight>
           </Show>

--- a/js/app/packages/app/component/split-layout/components/CollapsibleHeaderItem.tsx
+++ b/js/app/packages/app/component/split-layout/components/CollapsibleHeaderItem.tsx
@@ -17,7 +17,7 @@ export function CollapsibleHeaderItem(props: CollapsibleHeaderItemProps) {
     null
   );
 
-  const [isCollapsed] = useRegisterCollapsibleHeaderItem({
+  const isCollapsed = useRegisterCollapsibleHeaderItem({
     id: props.id,
     priority: props.priority,
     ref: expandedRef,

--- a/js/app/packages/app/component/split-layout/context.ts
+++ b/js/app/packages/app/component/split-layout/context.ts
@@ -11,7 +11,8 @@ export type CollapsibleRegistration = {
   id: string;
   priority: number; // lower = higher priority to collapse first
   collapsed: Accessor<boolean>;
-  setCollapsed: Setter<boolean>;
+  // silent skips onCollapsedChange — used for pre-paint trial measurements
+  setCollapsed: (value: boolean, opts?: { silent?: boolean }) => void;
   ref: Accessor<HTMLElement | null | undefined>; // uncollapsed element — measured before collapse
   collapsedRef?: Accessor<HTMLElement | null | undefined>; // collapsed element — measured while collapsed
 };

--- a/js/app/packages/app/component/split-layout/layoutUtils.ts
+++ b/js/app/packages/app/component/split-layout/layoutUtils.ts
@@ -8,8 +8,6 @@ import {
   createMemo,
   createSignal,
   onCleanup,
-  type Setter,
-  type Signal,
   useContext,
 } from 'solid-js';
 import {
@@ -159,17 +157,13 @@ function _createIsActiveSplitContentMemo(
 
 export function useRegisterCollapsibleHeaderItem(
   input: CollapsibleItemInput
-): Signal<boolean> {
+): Accessor<boolean> {
   const [collapsed, setCollapsedInner] = createSignal(false);
-  const setCollapsed: Setter<boolean> = (
-    next?: boolean | ((prev: boolean) => boolean)
-  ) => {
-    const value =
-      typeof next === 'function' ? next(collapsed()) : (next ?? false);
-    setCollapsedInner(value as boolean);
-    input.onCollapsedChange?.(value as boolean);
-    return value as boolean;
+  const setCollapsed = (value: boolean, opts?: { silent?: boolean }) => {
+    setCollapsedInner(value);
+    if (!opts?.silent) input.onCollapsedChange?.(value);
   };
+  input.onCollapsedChange?.(false);
   const ctx = useSplitPanelOrThrow();
   const cleanup = ctx.headerCollapser.register({
     ...input,
@@ -177,5 +171,5 @@ export function useRegisterCollapsibleHeaderItem(
     setCollapsed,
   });
   onCleanup(cleanup);
-  return [collapsed, setCollapsed];
+  return collapsed;
 }

--- a/js/app/packages/app/component/split-layout/utils/createHeaderCollapser.ts
+++ b/js/app/packages/app/component/split-layout/utils/createHeaderCollapser.ts
@@ -3,7 +3,7 @@ import { createStore, produce } from 'solid-js/store';
 import type { CollapsibleRegistration, HeaderCollapser } from '../context';
 
 const OVERFLOW_EPSILON_PX = 2;
-const UNCOLLAPSE_HYSTERESIS_PX = 12;
+const RETRY_PANEL_GROWTH_PX = 12;
 
 function getContentWidth(container: HTMLElement): number {
   let itemTotal = 0;
@@ -36,7 +36,8 @@ export function createHeaderCollapser(
   let observer: ResizeObserver | null = null;
   let rafId: number | null = null;
   let evaluateQueued = false;
-  let requiredPanelWidth: number | null = null;
+  let lastFailedExpand: { contentWidth: number; panelWidth: number } | null =
+    null;
 
   const scheduleEvaluate = () => {
     if (evaluateQueued) return;
@@ -48,11 +49,8 @@ export function createHeaderCollapser(
     });
   };
 
-  const setAllCollapsed = (value: boolean) => {
-    for (const item of items) {
-      if (item.collapsed() !== value) item.setCollapsed(value);
-    }
-  };
+  const overflows = (headerLeft: HTMLElement) =>
+    getContentWidth(headerLeft) - headerLeft.offsetWidth > OVERFLOW_EPSILON_PX;
 
   const evaluate = () => {
     const headerLeft = getContainer();
@@ -67,28 +65,49 @@ export function createHeaderCollapser(
 
     const contentWidth = getContentWidth(headerLeft);
     const availableWidth = headerLeft.offsetWidth;
-    const overflowAmount = contentWidth - availableWidth;
-    const overflow = overflowAmount > OVERFLOW_EPSILON_PX;
     const panelWidth = panelSizeWidth() ?? availableWidth;
 
-    const anyUncollapsed = items.some((i) => !i.collapsed());
-    const anyCollapsed = items.some((i) => i.collapsed());
-
-    if (overflow && anyUncollapsed) {
-      requiredPanelWidth = panelWidth + Math.max(0, overflowAmount);
-      setAllCollapsed(true);
-      scheduleEvaluate();
+    if (contentWidth - availableWidth > OVERFLOW_EPSILON_PX) {
+      const byCollapseOrder = items
+        .filter((i) => !i.collapsed())
+        .sort((a, b) => a.priority - b.priority);
+      for (const item of byCollapseOrder) {
+        item.setCollapsed(true);
+        if (!overflows(headerLeft)) break;
+      }
+      lastFailedExpand = {
+        contentWidth: getContentWidth(headerLeft),
+        panelWidth,
+      };
       return;
     }
 
+    const byExpandOrder = items
+      .filter((i) => i.collapsed())
+      .sort((a, b) => b.priority - a.priority);
+    if (byExpandOrder.length === 0) return;
+
     if (
-      anyCollapsed &&
-      requiredPanelWidth !== null &&
-      panelWidth >= requiredPanelWidth + UNCOLLAPSE_HYSTERESIS_PX
+      lastFailedExpand &&
+      contentWidth === lastFailedExpand.contentWidth &&
+      panelWidth < lastFailedExpand.panelWidth + RETRY_PANEL_GROWTH_PX
     ) {
-      setAllCollapsed(false);
-      requiredPanelWidth = null;
-      scheduleEvaluate();
+      return;
+    }
+
+    // Trial expansion runs between layout and paint, so a reverted attempt is
+    // never visible; silent keeps onCollapsedChange from firing for it.
+    for (const item of byExpandOrder) {
+      item.setCollapsed(false, { silent: true });
+      if (overflows(headerLeft)) {
+        item.setCollapsed(true, { silent: true });
+        lastFailedExpand = {
+          contentWidth: getContentWidth(headerLeft),
+          panelWidth,
+        };
+        break;
+      }
+      item.setCollapsed(false);
     }
   };
 
@@ -112,6 +131,7 @@ export function createHeaderCollapser(
   return {
     register(reg: CollapsibleRegistration) {
       setItems(produce((arr: CollapsibleRegistration[]) => arr.push(reg)));
+      lastFailedExpand = null;
       return () => {
         setItems(
           produce((arr: CollapsibleRegistration[]) => {
@@ -119,6 +139,7 @@ export function createHeaderCollapser(
             if (idx !== -1) arr.splice(idx, 1);
           })
         );
+        lastFailedExpand = null;
       };
     },
   };


### PR DESCRIPTION
Selecting a single inbox widened the inbox selector label, which made the header collapser collapse the whole top bar (tabs, compose, search) and latch there permanently, since it only un-collapsed on panel growth. The collapser now collapses items one at a time by their declared priority and recovers via a silent pre-paint trial expansion, so the bar restores itself when the selection (or panel size) frees up space.
