### PR TITLE
fix(soup): black screen navigating back to soup for team-less users

### DIFF
--- a/js/app/packages/queries/team/teams.ts
+++ b/js/app/packages/queries/team/teams.ts
@@ -11,6 +11,7 @@ import type { Accessor } from 'solid-js';
 
 import { authKeys } from '../auth';
 import { queryClient } from '../client';
+import { queryReadyGate } from '../gate';
 import { type MutationCallbacks, withCallbacks } from '../utils';
 
 import { teamKeys } from './keys';
@@ -50,7 +51,8 @@ export function useIsTeamAdmin(): Accessor<boolean> {
   return () => {
     const uid = userId();
     if (!uid) return false;
-    const member = teamQuery.data?.members.find((m) => m.user_id === uid);
+    if (!queryReadyGate(teamQuery)) return false;
+    const member = teamQuery.data.members.find((m) => m.user_id === uid);
     return member?.role === TeamRole.admin || member?.role === TeamRole.owner;
   };
 }

--- a/rust/cloud-storage/teams/src/inbound/axum_router/get_team.rs
+++ b/rust/cloud-storage/teams/src/inbound/axum_router/get_team.rs
@@ -1,7 +1,7 @@
 use axum::{Json, extract::State};
 use entity_access::{
     domain::{models::MemberTeamRole, ports::EntityAccessService},
-    inbound::axum_extractors::MacroUserTeamExtractor,
+    inbound::axum_extractors::OptionalMacroUserTeamExtractor,
 };
 use model_error_response::ErrorResponse;
 
@@ -27,9 +27,12 @@ use super::TeamRouterState;
 )]
 #[tracing::instrument(skip_all, err)]
 pub async fn handler<T: TeamService, Eas: EntityAccessService>(
-    access: MacroUserTeamExtractor<MemberTeamRole, Eas>,
+    access: OptionalMacroUserTeamExtractor<MemberTeamRole, Eas>,
     State(state): State<TeamRouterState<T, Eas>>,
 ) -> Result<Json<TeamWithMembers>, TeamError> {
-    let team = state.service.get_team(access.entity_access_receipt).await?;
+    let receipt = access
+        .entity_access_receipt
+        .ok_or(TeamError::TeamDoesNotExist)?;
+    let team = state.service.get_team(receipt).await?;
     Ok(Json(team))
 }


### PR DESCRIPTION
Navigating back to a soup view black-screened the whole split pane for ~2.4s for users without a team: `useIsTeamAdmin` read the pending team query under the fallback-less SplitPanel Suspense, while `GET /team` 401'd ("not in a team") and the client burned through jwt refresh+retry cycles that can never succeed. `GET /team` now resolves membership via the optional extractor and returns 404 when the user has no team, and `useIsTeamAdmin` gates the read with `queryReadyGate` so it resolves to `false` instead of suspending.
