### PR TITLE
fix(ci): resolve self-deadlock cancelling all on-push dev deploys

### DIFF
--- a/.github/workflows/deploy-cloud-storage-on-push.yml
+++ b/.github/workflows/deploy-cloud-storage-on-push.yml
@@ -24,13 +24,12 @@ on:
       - 'flake.nix'
       - 'flake.lock'
 
-# Same repo-global group as dev dispatches of deploy-all-services, so a push
-# deploy and a manual dev deploy queue instead of racing the same Pulumi
-# stacks. cancel-in-progress stays false: a running deploy finishes, and
-# GitHub coalesces queued pushes down to the newest one.
-concurrency:
-  group: deploy-all-services-dev
-  cancel-in-progress: false
+# NOTE: deliberately no concurrency block here. The called workflow's own
+# top-level group (deploy-all-services-${{ inputs.environment }}) IS honored
+# for workflow_call runs and is what serializes push deploys against manual
+# dev dispatches (running deploys finish; queued pushes coalesce to the
+# newest). Declaring the same group in this wrapper makes GitHub detect a
+# self-deadlock ("between a top level workflow and ...") and cancel the run.
 
 jobs:
   deploy-all:


### PR DESCRIPTION
A called workflow's top-level concurrency group is honored for workflow_call runs — so the on-push wrapper declaring the same deploy-all-services-dev group as the workflow it calls made every run acquire the group twice; GitHub detects this as a deadlock and cancels ('between a top level workflow and Deploy Cloud Storage Services'), leaving dev without deploys since the merge.

Drop the wrapper's concurrency block: the called workflow's group alone provides the per-environment serialization (and queued-push coalescing) the wrapper duplicated. release-production never hit this because its caller-level group string differs from the callee's.

https://claude.ai/code/session_0144BqNCnE75AX6LSyEBoGtL