### PR TITLE
Add ClickUp migration guide to Switch to Macro documentation

### DIFF
--- a/docs/images/switch-from-clickup.svg
+++ b/docs/images/switch-from-clickup.svg
@@ -1,0 +1,20 @@
+<svg viewBox="0 0 760 270" xmlns="http://www.w3.org/2000/svg" font-family="ui-sans-serif, -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif">
+  <rect x="0" y="0" width="760" height="270" fill="#090909"/>
+
+  <!-- ClickUp tile -->
+  <rect x="130" y="50" width="140" height="140" rx="32" fill="#121212" stroke="#2e2e2e"/>
+  <g transform="translate(164 84) scale(3)">
+    <path fill="#e8e8e8" d="M2 18.439l3.69-2.828c1.961 2.56 4.044 3.739 6.363 3.739 2.307 0 4.33-1.166 6.203-3.704L22 18.405c-2.7 3.66-6.054 5.594-9.946 5.594-3.879 0-7.245-1.923-10.054-5.56zM12.04 6.15L5.475 11.81l-3.05-3.539L12.057 0l9.573 8.297-3.058 3.525z"/>
+  </g>
+  <text x="200" y="222" fill="#6f6f6f" font-size="14" text-anchor="middle">ClickUp</text>
+
+  <!-- arrow -->
+  <path d="M325 109h78v-15l34 26-34 26v-15h-78z" fill="#ff8f05"/>
+
+  <!-- Macro tile -->
+  <rect x="490" y="50" width="140" height="140" rx="32" fill="#121212" stroke="#2e2e2e"/>
+  <g transform="translate(524 84) scale(3)">
+    <path fill="#fbefe9" d="m6.25 4.038-2.242 0.8792v5.8184l-1.756-1.6582-2.242 0.8792v6.6766c0 0.2568 0.106 0.502 0.292 0.6784l2.794 2.6422 2.244-0.879v-5.8184l7.084 6.6974 2.244-0.879v-5.8184l7.086 6.6976 2.24-0.8792v-6.6766c0-0.2568-0.104-0.5022-0.292-0.6784l-8.124-7.6816-2.244 0.879v5.8184z"/>
+  </g>
+  <text x="560" y="222" fill="#6f6f6f" font-size="14" text-anchor="middle">Macro</text>
+</svg>

--- a/docs/switch-to-macro.mdx
+++ b/docs/switch-to-macro.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Switch to Macro"
 icon: "arrow-right-arrow-left"
-description: "Migration guides for moving from Superhuman, Notion, Slack, and Linear to Macro — what maps to what, and what changes."
+description: "Migration guides for moving from Superhuman, Notion, Slack, Linear, and ClickUp to Macro — what maps to what, and what changes."
 ---
 
 Macro replaces several tools at once, but you don't have to cut over in one weekend. The pattern that works: connect your old tools first so nothing is lost, move your daily workflow into Macro, and let the old tools wind down to read-only. This page covers the most common starting points.
@@ -14,6 +14,7 @@ At a glance, here's what maps to what:
 | Notion      | [Docs](/product/docs), plus purpose-built [tasks](/product/tasks) and [CRM](/product/crm) |
 | Slack       | [Channels](/product/channels) |
 | Linear      | [Tasks](/product/tasks) |
+| ClickUp     | [Tasks](/product/tasks), with [docs](/product/docs), [CRM](/product/crm), and [channels](/product/channels) replacing the rest of the suite |
 | Google Drive / Dropbox | [File storage](/product/folders) |
 | Zoom / Meet | [Calls](/product/calls) |
 
@@ -96,6 +97,25 @@ Macro's tasks are openly Linear-inspired: status, priority, assignee, keyboard-f
 The difference is adjacency. Tasks live next to your email, channels, and docs, so you can turn an email or a channel message into a task in one click, and non-engineers see engineering work without needing a seat in a separate tool. Fields are minimal by default, with more available [if you want it](/concepts/properties) — less workflow configuration to maintain.
 
 For migration, most teams simply recreate their open work — finished issues rarely justify carrying over. If you do want history, connect Linear under **Settings → Connectors** and have an agent bring open issues across.
+
+## From ClickUp
+
+<Frame>
+  <img
+    src="/images/switch-from-clickup.svg"
+    alt="The ClickUp app icon with an arrow pointing to the Macro app icon"
+  />
+</Frame>
+
+ClickUp tries to be everything — tasks, docs, chat, goals, whiteboards — through a deep stack of spaces, folders, lists, and custom statuses you configure yourself. Macro covers the same ground, but as purpose-built [tasks](/product/tasks), [docs](/product/docs), [channels](/product/channels), and [CRM](/product/crm) that share one data model instead of one configurable database. The trade is less setup and fewer knobs for tools that already behave the way each job needs. Tasks keep the essentials — status, priority, assignee, [properties](/concepts/properties) when you want them — and your [agents](/product/agents) can read across all of it as unified context.
+
+The biggest day-to-day change is that work stops living in a silo: tasks sit next to your email, channels, and docs, so you can turn a message or an email into a task in one click, and @mentioning a task in a channel shares it automatically.
+
+To switch:
+
+1. Recreate your active lists as Macro tasks — most teams skip closed work, since finished ClickUp tasks rarely earn their migration.
+2. If you want history or a gradual cutover, connect ClickUp under **Settings → Connectors** as an MCP connector and ask an agent to bring open tasks across.
+3. Move ClickUp Docs over the same way Notion pages come in — they're markdown-native, so an agent can recreate them as [Macro documents](/product/docs).
 
 ## Everything else
 


### PR DESCRIPTION
## Summary
Added comprehensive migration documentation for users switching from ClickUp to Macro, including a visual comparison diagram and step-by-step migration instructions.

## Key Changes
- Updated the "Switch to Macro" page description to include ClickUp as a supported migration source
- Added ClickUp to the at-a-glance comparison table, mapping ClickUp's multi-tool functionality to Macro's purpose-built features (tasks, docs, CRM, and channels)
- Created a new "From ClickUp" section with:
  - Visual icon comparison diagram (`switch-from-clickup.svg`)
  - Explanation of how ClickUp's all-in-one approach differs from Macro's modular design
  - Key behavioral differences (integration with email, channels, and docs)
  - Step-by-step migration instructions covering active task recreation, historical data import via MCP connectors, and document migration

## Implementation Details
- The new SVG diagram follows the existing visual style used for other tool comparisons (dark background, tool icons, directional arrow)
- Migration guidance emphasizes Macro's key differentiator: breaking work out of silos by integrating tasks with email, channels, and docs
- Instructions leverage existing Macro features (agents, MCP connectors, properties) to facilitate smooth transitions from ClickUp's custom configuration model

https://claude.ai/code/session_01NPKGaw2ZkHQDQqUz6fqnQV