### PR TITLE
docs: rewrite docs in plainer, first-person voice

### DIFF
--- a/docs/AI/mcp/overview.mdx
+++ b/docs/AI/mcp/overview.mdx
@@ -10,7 +10,7 @@ Macro's MCP endpoint is:
 https://mcp-server.macro.com/mcp
 ```
 
-The server is remote — no local process is required. Authentication happens through Macro's OAuth flow when the client connects.
+The server is remote; no local process is required. Authentication happens through Macro's OAuth flow when the client connects.
 
 ## Claude Code
 

--- a/docs/AI/recipes.mdx
+++ b/docs/AI/recipes.mdx
@@ -4,7 +4,7 @@ icon: "book-open"
 description: "Copy-paste prompts for the most useful things agents can do in your Macro workspace."
 ---
 
-Agents in Macro aren't a side feature — they sit on top of [unified memory](/product/unified-memory), so one prompt can reach your email, messages, tasks, docs, calls, and connectors. These recipes are starting points: paste them into an agent chat (<kbd>c</kbd> + <kbd>a</kbd>), an [automation](/product/agents#automations), a channel via **@Macro**, or any [MCP client](/AI/mcp/overview) connected to your workspace.
+Agents in Macro sit on top of [unified memory](/product/unified-memory), so one prompt can reach your email, messages, tasks, docs, calls, and connectors. These recipes are starting points: paste them into an agent chat (<kbd>c</kbd> + <kbd>a</kbd>), an [automation](/product/agents#automations), a channel via **@Macro**, or any [MCP client](/AI/mcp/overview) connected to your workspace.
 
 ## Daily inbox brief
 
@@ -20,7 +20,7 @@ The result lands in your inbox at the scheduled time, every day.
 
 ## Project status on demand
 
-Ask in any agent chat — no need to point it at anything, since memory is refreshed from your team's activity:
+Ask in any agent chat. You don't need to point it at anything, since memory is refreshed from your team's activity:
 
 ```text
 What's the latest status of [project]? Check recent tasks, channel
@@ -28,14 +28,14 @@ discussion, and call transcripts, and tell me what changed this week
 and what's blocking.
 ```
 
-You can @mention a specific channel, doc, or task in the prompt to skip the search and guarantee the right context — see [Mentions in Agents](/concepts/mentions#mentions-in-agents).
+You can @mention a specific channel, doc, or task in the prompt to skip the search and guarantee the right context. See [Mentions in Agents](/concepts/mentions#mentions-in-agents).
 
 ## Weekly team recap
 
 An automation for Friday afternoons:
 
 ```text
-Every Friday at 4pm: write a recap of the week for @#general —
+Every Friday at 4pm: write a recap of the week for @#general:
 tasks completed, tasks started, key decisions from calls, and
 anything that slipped. Link to the relevant items.
 ```
@@ -57,7 +57,7 @@ Draft a reply to @[email thread]. Tone: warm but brief. We can do
 the June 20 date, but ask them to send the revised scope first.
 ```
 
-Review the draft, then tell the agent to send it — or send it yourself from the composer.
+Review the draft, then tell the agent to send it, or send it yourself from the composer.
 
 ## Answer questions inside a channel
 
@@ -81,7 +81,7 @@ See [Switch to Macro](/switch-to-macro) for tool-by-tool migration guides.
 
 ## Use your workspace from Claude Code
 
-Once you've [connected the Macro MCP server](/AI/mcp/overview), your coding agent has the same reach — it can search your workspace, read threads and docs, create documents, send email, and update task properties with the [MCP tools](/AI/mcp/tools/index):
+Once you've [connected the Macro MCP server](/AI/mcp/overview), your coding agent has the same reach. It can search your workspace, read threads and docs, create documents, send email, and update task properties with the [MCP tools](/AI/mcp/tools/index):
 
 ```text
 Find the Macro task for the bug I'm fixing, read the linked channel
@@ -95,5 +95,5 @@ send) a reply explaining the fix that shipped in today's release.
 ```
 
 <Tip>
-  Agents inherit your permissions: they can only see what you can see, and anything they create or send is attributed to you. Start prompts with "draft, don't send" while you calibrate trust.
+  Agents inherit your permissions: they can only see what you can see, and anything they create or send is attributed to you. Start prompts with "draft, don't send" until you're comfortable letting them send.
 </Tip>

--- a/docs/account/billing.mdx
+++ b/docs/account/billing.mdx
@@ -4,7 +4,7 @@ icon: "credit-card"
 description: "Macro's free and premium plans, and how to manage your subscription."
 ---
 
-Macro has one paid plan, priced per person — the same whether you're solo or on a team.
+Macro has one paid plan, priced per person. The price is the same whether you're solo or on a team.
 
 |  | Free | Premium |
 | --- | --- | --- |
@@ -13,7 +13,7 @@ Macro has one paid plan, priced per person — the same whether you're solo or o
 | AI tool calls | Limited | Unlimited |
 | Storage | 5 GB | 1 TB |
 
-Teams require a paid seat for every member — there's no free plan for teams. Your current plan is shown in **Settings → Account**, with an **Upgrade** button if you're on the free plan.
+Teams require a paid seat for every member; there's no free plan for teams. Your current plan is shown in **Settings → Account**, with an **Upgrade** button if you're on the free plan.
 
 ## Managing your subscription
 
@@ -21,4 +21,4 @@ Subscriptions are handled through Stripe. From **Settings → Account**, choose 
 
 ## Self-hosting
 
-Macro is open source under the AGPLv3, and self-hosting is free — though some bundled services require your own licenses, and it isn't our primary focus yet. See the [FAQ](/faq) for the current state of self-hosting, and contact [licensing@macro.com](mailto:licensing@macro.com) if you want to build on Macro under a different license.
+Macro is open source under the AGPLv3, and self-hosting is free, though some bundled services require your own licenses and it isn't our primary focus yet. See the [FAQ](/faq) for the current state of self-hosting, and contact [licensing@macro.com](mailto:licensing@macro.com) if you want to build on Macro under a different license.

--- a/docs/account/teams.mdx
+++ b/docs/account/teams.mdx
@@ -4,7 +4,7 @@ icon: "users"
 description: "Creating a team, inviting members, roles, and what admins can do."
 ---
 
-Macro works solo, but teams unlock the collaborative layer: auto-shared tasks and calls, the [CRM](/product/crm), and [team memory](/product/unified-memory) for your agents.
+Macro works solo, but everything is better with friends. Teams get auto-shared tasks and calls, the [CRM](/product/crm), and [team memory](/product/unified-memory) for your agents.
 
 <iframe src="https://www.youtube.com/embed/5d2K_NYs50k" title="YouTube video player" frameborder="0" className="w-full aspect-video rounded-xl" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen />
 

--- a/docs/account/teams.mdx
+++ b/docs/account/teams.mdx
@@ -10,10 +10,10 @@ Macro works solo, but teams unlock the collaborative layer: auto-shared tasks an
 
 ## Create a team and invite people
 
-Click **Team** in the bottom left to create a team — you can add the first members right there, or invite more later by email from **Settings → Team**. Invitees see the pending invitation when they sign in.
+Click **Team** in the bottom left to create a team. You can add the first members right there, or invite more later by email from **Settings → Team**. Invitees see the pending invitation when they sign in.
 
 <Note>
-  There's no free plan for teams — every member needs a paid seat. See [Billing & plans](/account/billing).
+  There's no free plan for teams; every member needs a paid seat. See [Billing & plans](/account/billing).
 </Note>
 
 ## Roles
@@ -23,14 +23,14 @@ Teams have three roles, in increasing order of access:
 | Role | What it adds |
 | --- | --- |
 | **Member** | Everything shared with the team: team tasks, shared calls, visible CRM records |
-| **Admin** | Manage CRM visibility — toggle [Email Sync](/product/crm) per company, hide or unhide records |
+| **Admin** | Manage CRM visibility: toggle [Email Sync](/product/crm) per company, hide or unhide records |
 | **Owner** | Everything above, plus inviting and removing members |
 
-Owners can remove any member except themselves. When someone is removed, access flows out the same way it flowed in: they lose team-shared content automatically, and removing them from [channels](/permissions) revokes everything that was shared there.
+Owners can remove any member except themselves. When someone is removed, they lose team-shared content automatically, and removing them from [channels](/permissions) revokes everything that was shared there.
 
 ## What's shared with a team
 
-Joining a team changes the default sharing for a few block types — everything else stays private until you share it:
+Joining a team changes the default sharing for a few block types. Everything else stays private until you share it:
 
 - **Tasks** are visible to the whole team by default.
 - **Calls** are recorded, transcribed, and shared to team memory by default; anyone can opt a call out, which keeps it in their personal memory only.
@@ -41,4 +41,4 @@ See [Permissions](/permissions) for the full sharing model.
 
 ## Sign-in and enterprise
 
-Macro signs in with your Google account — the same one your Gmail or Google Workspace email syncs from. For enterprise requirements like HIPAA, FedRAMP, or running Macro on your own infrastructure, contact [self-host@macro.com](mailto:self-host@macro.com).
+Macro signs in with your Google account, the same one your Gmail or Google Workspace email syncs from. For enterprise requirements like HIPAA, FedRAMP, or running Macro on your own infrastructure, contact [self-host@macro.com](mailto:self-host@macro.com).

--- a/docs/apps.mdx
+++ b/docs/apps.mdx
@@ -6,22 +6,22 @@ description: "Where you can use Macro: web, iOS, and what's different on each."
 
 ## Web
 
-Macro runs in any modern browser at [macro.com](https://macro.com) — no install required. Desktop is the full Macro experience: the keyboard-driven workflow, and a built-in window manager that lets you multi-task in [splits](/concepts/blocks#splits) inside a single tab, so Macro replaces a pile of browser tabs rather than adding one.
+Macro runs in any modern browser at [macro.com](https://macro.com), with no install required. Desktop is the full Macro experience: the keyboard-driven workflow, and a built-in window manager that lets you multi-task in [splits](/concepts/blocks#splits) inside a single tab, so Macro can replace a pile of browser tabs.
 
 ## iOS
 
-The Macro iOS app is on the [App Store](https://apps.apple.com/us/app/macro-app/id6743133649). It connects to the same workspace — inbox, email, channels, tasks, docs, and agents on your phone. You can also grab it from **Settings → Mobile App** in the web app, which shows a QR code.
+The Macro iOS app is on the [App Store](https://apps.apple.com/us/app/macro-app/id6743133649). It connects to the same workspace: inbox, email, channels, tasks, docs, and agents on your phone. You can also grab it from **Settings → Mobile App** in the web app, which shows a QR code.
 
 A few things stay desktop-only by design:
 
-- **Splits** — the side-by-side window manager needs screen width; on mobile you work one block at a time.
-- **Keyboard shortcuts** — the <kbd>c</kbd> launcher, <kbd>j</kbd>/<kbd>k</kbd> navigation, and friends are desktop features.
-- **Some settings** — managing email inboxes and connectors is done from desktop.
+- **Splits**: the side-by-side window manager needs screen width; on mobile you work one block at a time.
+- **Keyboard shortcuts**: the <kbd>c</kbd> launcher and <kbd>j</kbd>/<kbd>k</kbd> navigation are desktop features.
+- **Some settings**: managing email inboxes and connectors is done from desktop.
 
 ## Android
 
 An Android app isn't available yet.
 
 <Note>
-  Self-hosters: the hosted version of Macro is the one with Apple, Google Mail, and GitHub approvals — see the [FAQ](/faq) for what that means for your own deployment.
+  Self-hosters: the hosted version of Macro is the one with Apple, Google Mail, and GitHub approvals. See the [FAQ](/faq) for what that means for your own deployment.
 </Note>

--- a/docs/concepts/blocks.mdx
+++ b/docs/concepts/blocks.mdx
@@ -8,7 +8,7 @@ Everything in Macro is a **block**. The current first-party block types are `md`
 
 ## Splits
 
-On desktop — but not on mobile — Macro has its own window manager that lets you multi-task in your browser in one tab. By default when you open Macro you have one _split_.
+On desktop (not on mobile), Macro has its own window manager that lets you multi-task in your browser in one tab. By default when you open Macro you have one _split_.
 
 In general, you can press <kbd>shift</kbd> to open an @mention or list item in a new split.
 
@@ -38,7 +38,7 @@ Most block types have on-hover previews to provide context without needing to cl
 
 ## Embeds
 
-Most blocks embed read-only in a markdown doc, with editing and markup tools disabled. Note that, unlike mentioning docs in channels — where permissions are automatically granted to members of the channel — permissions are not auto-granted for embeds or mentions in documents. You'll have to also share the files you embed.
+Most blocks embed read-only in a markdown doc, with editing and markup tools disabled. Note that permissions are not auto-granted for embeds or mentions in documents, unlike mentions in channels, where channel members get access automatically. You'll have to also share the files you embed.
 
 <Frame>
   ![A block embedded read-only inside a markdown document](/images/Screenshot-2026-06-09-at-4.50.07-PM.png)
@@ -58,6 +58,6 @@ To create an embed, first create an @mention by hitting `@` or dragging and drop
 
 ## More about blocks
 
-- **References, sharing & permissions** — Every block has a References panel (backlinks to everywhere it's mentioned or embedded) and the same share dialog, with owner / editor / commenter / viewer access levels plus public links for documents.
-- **Real-time collaboration** — Collaborative blocks (docs, pdf markup) sync through **Loro CRDTs** over a **Cloudflare Durable Objects** backend: the Rust `sync-service` spins up one Durable Object "room" per document, and clients connect over WebSocket to `/document/:id`. This is what gives you multiplayer editing, presence cursors, and full offline support.
-- **Search & Inbox** — One unified [Search](/product/search) index covers every block type, filterable by type and by mentioned person. The unified [Inbox](/product/inbox) pulls open notifications from across blocks into a single recency-sorted list.
+- **References, sharing & permissions**: every block has a References panel (backlinks to everywhere it's mentioned or embedded) and the same share dialog, with owner / editor / commenter / viewer access levels plus public links for documents.
+- **Real-time collaboration**: collaborative blocks (docs, pdf markup) sync through **Loro CRDTs** over a **Cloudflare Durable Objects** backend: the Rust `sync-service` spins up one Durable Object "room" per document, and clients connect over WebSocket to `/document/:id`. This is what gives you multiplayer editing, presence cursors, and full offline support.
+- **Search & Inbox**: one unified [Search](/product/search) index covers every block type, filterable by type and by mentioned person. The unified [Inbox](/product/inbox) pulls open notifications from across blocks into a single recency-sorted list.

--- a/docs/concepts/mentions.mdx
+++ b/docs/concepts/mentions.mdx
@@ -4,7 +4,7 @@ icon: "at"
 description: "How blocks reference each other and how permissions are handled. The @mention primitive that works across every markdown surface in Macro."
 ---
 
-Mentions are the connective tissue of the workspace. Typing `@` in any rich-text surface — a [document](/product/docs), an email body, a channel message, a chat or [automation](/product/agents#automations) prompt, or a task description — opens an autocomplete that lets you reference something else in Macro. Whatever you pick renders as a live inline pill that carries its target's current metadata (a task mention, for instance, shows the task's status and priority), and the reference is recorded as a backlink in the target's [References panel](/concepts/blocks).
+Mentions are how blocks reference each other across the workspace. Typing `@` in any rich-text surface (a [document](/product/docs), an email body, a channel message, a chat or [automation](/product/agents#automations) prompt, or a task description) opens an autocomplete that lets you reference something else in Macro. Whatever you pick renders as a live inline pill that carries its target's current metadata (a task mention shows the task's status and priority, for instance), and the reference is recorded as a backlink in the target's [References panel](/concepts/blocks).
 
 <Frame>
   <img
@@ -24,7 +24,7 @@ Mentioning entities to AI agents inserts a pointer so the AI can read the docs. 
   ![Mentioning a document in an agent chat to give the agent context](/images/Screenshot-2026-06-09-at-3.59.21-PM.png)
 </Frame>
 
-You don't _need to_ mention entities to agents. Since your agent has access to the search tool and list tool, it can find things in your workspace for itself. We recommend mentioning entities when you already know what the agent should look at — it skips a round of searching and guarantees the right context.
+You don't _need to_ mention entities to agents. Since your agent has access to the search tool and list tool, it can find things in your workspace for itself. We recommend mentioning entities when you already know what the agent should look at. It skips a round of searching and guarantees the right context.
 
 ## Mentions in Channels
 
@@ -82,12 +82,12 @@ Use canvases to embed other entities on a 2D plane. This is useful for mind-mapp
 
 ## What happens when you mention...
 
-- **People** by name or email. The person will receive a notification, even if they are not an existing Macro user, if you mention them in a comment or a channel. If you mention them in the body of a task or markdown doc, they will _not_ get notified — you need to manually share it with them. We know this is a bit of a weird design decision; the reason we made it after dogfooding for a while is that, any time you want to @mention someone in a doc, you definitionally are not finished writing the doc, so you don't want them to get a notification yet. It's unclear when they _should_ receive that notification, so we determined it best that mentions in the context of documents don't notify or share with mentioned users.
-- **Documents and blocks** — any doc, task, canvas, code file, PDF, etc. In the context of a channel, the document gets shared. In a comment or a document, it does not.
-- **Contacts and company** records, rendered differently for people vs. organizations. Company and contact records are not shared when mentioned — their sharing is determined by Teams.
-- **Channels**, or a specific **message** or thread. Mentioning a channel doesn't grant permissions, and neither does mentioning a message. There is no way to share a message with someone who isn't in the channel, because the ability to view a message is determined by channel membership. If you need to share a message without adding somebody to a channel, send a screenshot. To add somebody to a channel, don't mention the channel — go to the channel and add them as a participant.
+- **People** by name or email. The person will receive a notification, even if they are not an existing Macro user, if you mention them in a comment or a channel. If you mention them in the body of a task or markdown doc, they will _not_ get notified. You need to manually share it with them. We know this is a bit of a weird design decision; the reason we made it after dogfooding for a while is that, any time you want to @mention someone in a doc, you definitionally are not finished writing the doc, so you don't want them to get a notification yet. It's unclear when they _should_ receive that notification, so we determined it best that mentions in the context of documents don't notify or share with mentioned users.
+- **Documents and blocks**: any doc, task, canvas, code file, PDF, etc. In the context of a channel, the document gets shared. In a comment or a document, it does not.
+- **Contacts and company** records, rendered differently for people vs. organizations. Company and contact records are not shared when mentioned; their sharing is determined by Teams.
+- **Channels**, or a specific **message** or thread. Mentioning a channel doesn't grant permissions, and neither does mentioning a message. There is no way to share a message with someone who isn't in the channel, because the ability to view a message is determined by channel membership. If you need to share a message without adding somebody to a channel, send a screenshot. To add somebody to a channel, don't mention the channel. Go to the channel and add them as a participant.
 - **Dates** with a date picker.
 
-In a document or chat, a mention is a navigable link and a source of context. In an **email body** it has side effects: mentioning a person adds them to CC, and mentioning a document inserts a link _and_ updates that document's permissions so recipients can open it. In a **channel** there are two special mentions layered on top of the normal ones — `@here` pings every participant, and `@Macro` invokes the agent inline.
+In a document or chat, a mention is a navigable link and a source of context. In an **email body** it has side effects: mentioning a person adds them to CC, and mentioning a document inserts a link _and_ updates that document's permissions so recipients can open it. In a **channel** there are two special mentions on top of the normal ones: `@here` pings every participant, and `@Macro` invokes the agent inline.
 
 The agent leans on mentions heavily: anything you @mention into a chat is pulled in as context, and autocomplete there surfaces your currently open tabs first.

--- a/docs/concepts/properties.mdx
+++ b/docs/concepts/properties.mdx
@@ -1,10 +1,10 @@
 ---
 title: "Properties"
 icon: "tags"
-description: "The unified property system that attaches structured fields to documents, tasks, emails, and CRM records."
+description: "Attach structured fields to documents, tasks, emails, and CRM records with one shared system."
 ---
 
-Properties are Macro's unified system for attaching structured fields to entities. The same machinery powers a document's metadata, a [task's](/product/tasks) status and assignee, an email thread's custom fields, and a CRM contact's phone number. The type system, editors, and behaviors below apply everywhere properties appear.
+Macro uses properties to attach structured data to any *entity* (email, task, doc, CRM record, etc.). The properties system is unified across blocks, so you can organize different content types using the same fields, or create different fields for different content types. Tasks and CRM obviously have very different sensible properties, but the concepts are the same and the UI is shared, so teams can work together effectively.
 
 <Frame>
   <img
@@ -26,30 +26,30 @@ On tasks, the default properties of Status, Priority and Assignees are visible i
 
 Every entity that supports properties supports the same data types:
 
-- **STRING** (text) — e.g. phone, job title, department, notes.
-- **NUMBER** — e.g. revenue, employee count, ARR.
-- **BOOLEAN** — toggles.
-- **DATE** — e.g. last contacted, contract/renewal date.
-- **SELECT\_STRING** — single/multi-select with string options (custom option colors/icons).
-- **SELECT\_NUMBER** — single/multi-select with numeric options.
-- **ENTITY** — a reference to another entity (User, Company, Contact, Document, Project, Channel, Chat, Task, Thread).
-- **LINK** — URLs (website, LinkedIn, etc.).
+- **STRING** (text): phone, job title, department, notes.
+- **NUMBER**: revenue, employee count, ARR.
+- **BOOLEAN**: toggles.
+- **DATE**: last contacted, contract/renewal date.
+- **SELECT\_STRING**: single/multi-select with string options (custom option colors/icons).
+- **SELECT\_NUMBER**: single/multi-select with numeric options.
+- **ENTITY**: a reference to another entity (User, Company, Contact, Document, Project, Channel, Chat, Task, Thread).
+- **LINK**: URLs (website, LinkedIn, etc.).
 
 ## System vs. custom
 
-A property is either **system** (built-in and non-removable — like a task's Status) or **custom** (something you add). Properties can also be flagged as **metadata**, which keeps them out of the main views. Editors come in three forms: inline (click-to-edit in a list or pill), popover (a focused dialog), and modal (batch editing across several fields).
+A property is either **system** (built in and non-removable, like a task's Status) or **custom** (something you add). Properties can also be flagged as **metadata**, which keeps them out of the main views. There are three editors: inline (click-to-edit in a list or pill), popover (a focused dialog), and modal (batch editing across several fields).
 
 ## Pinned properties
 
-Pinning a property promotes it so its value renders as a pill — under a document or task title, for example — for quick scanning and editing. Defaults are per block type: tasks pin **Status**, **Priority**, and **Assignees** out of the box.
+You can pin properties to show them in the card on the right, or in the unified list. If a property is more like hidden metadata that you don't need to see, leave it hidden. Otherwise, pin it. Each block type has its own defaults: tasks pin **Status**, **Priority**, and **Assignees** out of the box.
 
 ## Built-in fields by block
 
 Some blocks ship with their own system properties:
 
-- **Tasks** — Status, Priority, Assignees, Due Date, Parent Task / Subtasks, Depends On, Effort, Story Points, and Relevant Documents. See [Tasks](/product/tasks).
-- **CRM contacts & companies** — Email, Name, Company, interaction timestamps, Domains, Email Sync, and more.
+- **Tasks**: Status, Priority, Assignees, Due Date, Parent Task / Subtasks, Depends On, Effort, Story Points, and Relevant Documents. See [Tasks](/product/tasks).
+- **CRM contacts & companies**: Email, Name, Company, interaction timestamps, Domains, Email Sync, and more.
 
 ## Agent access
 
-Agents read and write properties through the MCP entity tools — `GetEntityProperties` to read, `SetEntityProperty` to update (status, assignee, dates, custom fields), and `ListEntities` to browse. See the [tool reference](/AI/mcp/tools/index).
+Agents read and write properties through the MCP entity tools: `GetEntityProperties` to read, `SetEntityProperty` to update (status, assignee, dates, custom fields), and `ListEntities` to browse. See the [tool reference](/AI/mcp/tools/index).

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Frequently Asked Questions"
 icon: "circle-question"
-description: "How Macro compares to Notion, Superhuman, and Slack — plus licensing, self-hosting, teams, and data questions."
+description: "How Macro compares to Notion, Superhuman, and Slack, plus licensing, self-hosting, teams, and data questions."
 ---
 
 <AccordionGroup>
@@ -20,7 +20,7 @@ description: "How Macro compares to Notion, Superhuman, and Slack — plus licen
 
     See our comparison video here: [https://youtu.be/hyU1XYmxkYM?si=iGPivxvZpQ13oig4](https://youtu.be/hyU1XYmxkYM?si=iGPivxvZpQ13oig4).
 
-    You can still **integrate** your Notion with Macro if you want, so that agents in Macro can access your Notion via MCP — go to Settings -\> Connectors -\> Notion.
+    You can still **integrate** your Notion with Macro if you want, so that agents in Macro can access your Notion via MCP. Go to Settings -\> Connectors -\> Notion.
 
     To **import** your Notion content and migrate away from Notion to Macro, just connect it using the above and then ask a Macro agent to import your Notion docs as Macro docs. You could also use Macro MCP.
   </Accordion>
@@ -56,7 +56,7 @@ description: "How Macro compares to Notion, Superhuman, and Slack — plus licen
   </Accordion>
 
   <Accordion title="Is Macro fully open source? What is the license?">
-    **Macro is fully open source.** Not "open core". We were previously source-available under the BSL but on [May 31 2026](https://x.com/j_becke/status/2061153001536975206) we moved to a fully open-source model under the AGPLv3. The AGPL is a copyleft license meaning derivative works also need to be open source. That means that if you build on top of Macro, you need to keep your code open source under the AGPLv3. If you want to build on top of Macro and not use the AGPLv3 — i.e. closed-source or an incompatible license — you need to obtain a different license from us. Contact [licensing@macro.com](mailto:licensing@macro.com) to discuss with us.
+    **Macro is fully open source.** Not "open core". We were previously source-available under the BSL but on [May 31 2026](https://x.com/j_becke/status/2061153001536975206) we moved to a fully open-source model under the AGPLv3. The AGPL is a copyleft license meaning derivative works also need to be open source. That means that if you build on top of Macro, you need to keep your code open source under the AGPLv3. If you want to build on top of Macro and not use the AGPLv3 (i.e. closed-source or an incompatible license), you need to obtain a different license from us. Contact [licensing@macro.com](mailto:licensing@macro.com) to discuss with us.
   </Accordion>
 
   <Accordion title="How do you make money if Macro is open source?">
@@ -72,7 +72,7 @@ description: "How Macro compares to Notion, Superhuman, and Slack — plus licen
     Macro is designed for solo and team use. Of course, everything is better with friends. The pricing for Macro whether you are on a team or personal plan is the same; Teams exist just to help you collaborate better as a group. Keep in mind there is no free plan for teams, however. Teams give:
 
     1. Auto-shared emails, tasks and calls, without having to explicitly share everything. For example, when you're working as a team you want all emails to be shared in our CRM module, engineering tasks should be visible by everyone, and having all calls transcribed and stored to the Team gives you a nice team-level memory of all of your conversations.
-    2. Team-level memory for your agents. Agents remember not just your personal chat history — like with Claude or ChatGPT's memory system — but they remember everything going on across tasks your team is working on, emails, docs, and calls that the team has had recently!
+    2. Team-level memory for your agents. Agents remember not just your personal chat history (like with Claude or ChatGPT's memory system), but everything going on across tasks your team is working on, emails, docs, and calls that the team has had recently!
 
     To create a team, head to "Team" in the bottom left.
   </Accordion>

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -12,7 +12,7 @@ Macro replaces the pile of tabs (email, chat, tasks, docs, calls) with one fast,
 
 ## 1. Connect your email
 
-Macro is an email client that syncs with your existing Gmail or Google Workspace account, so your mail stays in Gmail. We recommend connecting your account during signup so your inbox is ready from the first minute.
+Macro is not an email server, it's just an email client. It syncs with your existing Gmail or Google Workspace account, so your mail stays in Gmail. We recommend connecting your account during signup so your inbox is ready from the first minute.
 
 Have more than one address? Add additional Gmail or Google Workspace accounts in **Settings**, and they all flow into a [single unified inbox](/product/email#multi-account-inbox). When you compose, you choose which address to send from.
 
@@ -46,7 +46,7 @@ Macro has its own window manager. Press <kbd>cmd</kbd>+<kbd>\\</kbd> to create a
 
 ## 5. Create a team
 
-Click **Team** in the bottom left to create one. Teams unlock the collaborative layer:
+Click **Team** in the bottom left to create one. Teams exist to help you collaborate better as a group:
 
 - **Auto-sharing**: tasks are visible to the whole team, and calls are recorded, transcribed, and shared by default. No "can you share that with me?" requests.
 - **[Team memory](/product/unified-memory)**: agents remember what your whole team is doing across email, messages, tasks, docs, and calls, not just your own chats.

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -4,7 +4,7 @@ icon: "rocket"
 description: "Set up Macro and learn the core workflow in about 15 minutes."
 ---
 
-Macro replaces the pile of tabs — email, chat, tasks, docs, calls — with one fast, keyboard-driven workspace. This guide takes you from a fresh account to a working setup.
+Macro replaces the pile of tabs (email, chat, tasks, docs, calls) with one fast, keyboard-driven workspace. This guide takes you from a fresh account to a working setup.
 
 <Card title="Prefer a guided tour?" icon="calendar" href="https://cal.com/team/macro/macro-demo-call">
   Book a live onboarding call and a member of our team will walk you through setup and answer questions.
@@ -12,7 +12,7 @@ Macro replaces the pile of tabs — email, chat, tasks, docs, calls — with one
 
 ## 1. Connect your email
 
-Macro is an email client, not an email server — it syncs with your existing Gmail or Google Workspace account. We recommend connecting your account during signup so your inbox is ready from the first minute.
+Macro is an email client that syncs with your existing Gmail or Google Workspace account, so your mail stays in Gmail. We recommend connecting your account during signup so your inbox is ready from the first minute.
 
 Have more than one address? Add additional Gmail or Google Workspace accounts in **Settings**, and they all flow into a [single unified inbox](/product/email#multi-account-inbox). When you compose, you choose which address to send from.
 
@@ -26,44 +26,44 @@ Macro is built keyboard-first. These five get you most of the way:
 
 | Key | What it does |
 | --- | --- |
-| <kbd>c</kbd> | Open the create launcher — then <kbd>d</kbd> for a doc, <kbd>t</kbd> for a task, <kbd>e</kbd> for an email, <kbd>m</kbd> for a message, <kbd>a</kbd> for an AI chat |
-| <kbd>cmd</kbd>+<kbd>k</kbd> | Command menu — jump to anything by name |
+| <kbd>c</kbd> | Open the create launcher, then <kbd>d</kbd> for a doc, <kbd>t</kbd> for a task, <kbd>e</kbd> for an email, <kbd>m</kbd> for a message, <kbd>a</kbd> for an AI chat |
+| <kbd>cmd</kbd>+<kbd>k</kbd> | Command menu to jump to anything by name |
 | <kbd>/</kbd> | [Unified search](/product/search) across email, docs, tasks, messages, calls, and files |
 | <kbd>j</kbd> / <kbd>k</kbd> | Move down / up in any list |
-| <kbd>e</kbd> | Mark done — archive an email, clear an inbox item |
+| <kbd>e</kbd> | Mark done: archive an email, clear an inbox item |
 
 The full list lives in [Keyboard shortcuts](/keyboard-shortcuts).
 
 ## 3. Triage from one inbox
 
-Press <kbd>g</kbd> + <kbd>i</kbd> to open the [unified inbox](/product/inbox) — the one place to check instead of seven apps. Emails, channel messages, task assignments, @mentions, and agent responses all land here, split into **Signal** (needs your attention) and **Noise** (everything else).
+Press <kbd>g</kbd> + <kbd>i</kbd> to open the [unified inbox](/product/inbox). Emails, channel messages, task assignments, @mentions, and agent responses all land here, split into **Signal** (needs your attention) and **Noise** (everything else).
 
 Work the list with <kbd>j</kbd> / <kbd>k</kbd>, preview with <kbd>space</kbd>, and clear items with <kbd>e</kbd>. The list shrinks as you go.
 
 ## 4. Open work side by side
 
-Macro has its own window manager. Press <kbd>cmd</kbd>+<kbd>\\</kbd> to create a *split*, and <kbd>shift</kbd>+<kbd>enter</kbd> to open any list item or @mention in a new split — your inbox on the left, the doc someone sent you on the right. Move focus with <kbd>shift</kbd>+<kbd>h</kbd> / <kbd>shift</kbd>+<kbd>l</kbd>, maximize with <kbd>shift</kbd>+<kbd>escape</kbd>. More in [Blocks](/concepts/blocks#splits).
+Macro has its own window manager. Press <kbd>cmd</kbd>+<kbd>\\</kbd> to create a *split*, and <kbd>shift</kbd>+<kbd>enter</kbd> to open any list item or @mention in a new split, for example your inbox on the left and the doc someone sent you on the right. Move focus with <kbd>shift</kbd>+<kbd>h</kbd> / <kbd>shift</kbd>+<kbd>l</kbd>, maximize with <kbd>shift</kbd>+<kbd>escape</kbd>. More in [Blocks](/concepts/blocks#splits).
 
 ## 5. Create a team
 
 Click **Team** in the bottom left to create one. Teams unlock the collaborative layer:
 
-- **Auto-sharing** — tasks are visible to the whole team, and calls are recorded, transcribed, and shared by default. No "can you share that with me?" requests.
-- **[Team memory](/product/unified-memory)** — agents remember what your whole team is doing across email, messages, tasks, docs, and calls, not just your own chats.
+- **Auto-sharing**: tasks are visible to the whole team, and calls are recorded, transcribed, and shared by default. No "can you share that with me?" requests.
+- **[Team memory](/product/unified-memory)**: agents remember what your whole team is doing across email, messages, tasks, docs, and calls, not just your own chats.
 
 Then create a [channel](/product/channels) per team or project (<kbd>c</kbd> + <kbd>m</kbd>). Channels are also how [permissions](/permissions) work in Macro: anything you @mention in a channel is automatically shared with its members, and access follows people as they join or leave. You can add anyone by email, even if they don't have a Macro account yet.
 
 ## 6. Put the agent to work
 
-Press <kbd>c</kbd> + <kbd>a</kbd> to start a chat with an [agent](/product/agents) that has access to your entire workspace — ask "what's the latest on the launch?" and it answers from your team's recent emails, messages, tasks, docs, and call transcripts. In any channel, mention **@Macro** to pull an agent into the conversation.
+Press <kbd>c</kbd> + <kbd>a</kbd> to start a chat with an [agent](/product/agents) that has access to your entire workspace. Ask "what's the latest on the launch?" and it answers from your team's recent emails, messages, tasks, docs, and call transcripts. In any channel, mention **@Macro** to pull an agent into the conversation.
 
-You can also set up [automations](/product/agents#automations) — scheduled agent runs like a daily to-do summary delivered to your inbox.
+You can also set up [automations](/product/agents#automations): scheduled agent runs, like a daily to-do summary delivered to your inbox.
 
 ## 7. Connect your tools
 
-- **GitHub** — link your account in **Settings** under **Account**, and tasks move to In Progress → In Review → Done as you branch, open PRs, and merge. See [GitHub integration](/integrations/github).
-- **MCP connectors** — connect Notion, Slack, and other tools under **Settings → Connectors** so agents can reach them. Migrating off one of them? See [Switch to Macro](/switch-to-macro).
-- **Your coding agents** — point Claude Code, Codex, or any MCP client at your Macro workspace. See [MCP setup](/AI/mcp/overview).
+- **GitHub**: link your account in **Settings** under **Account**, and tasks move through In Progress, In Review, and Done as you branch, open PRs, and merge. See [GitHub integration](/integrations/github).
+- **MCP connectors**: connect Notion, Slack, and other tools under **Settings → Connectors** so agents can reach them. Migrating off one of them? See [Switch to Macro](/switch-to-macro).
+- **Your coding agents**: point Claude Code, Codex, or any MCP client at your Macro workspace. See [MCP setup](/AI/mcp/overview).
 
 ## Next steps
 
@@ -72,7 +72,7 @@ You can also set up [automations](/product/agents#automations) — scheduled age
     A full walkthrough of Macro's core features in one video.
   </Card>
   <Card title="Key concepts" icon="cubes" href="/concepts/blocks">
-    Blocks, mentions, and properties — the primitives everything is built from.
+    Blocks, mentions, and properties: the primitives everything is built from.
   </Card>
   <Card title="Keyboard shortcuts" icon="keyboard" href="/keyboard-shortcuts">
     The complete reference for working at full speed.

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -6,7 +6,7 @@ description: "Extremely fast, unified interface for all your work, all linked to
 
 <iframe src="https://www.youtube.com/embed/Fn5hdzXsQQ8" title="YouTube video player" frameborder="0" className="w-full aspect-video rounded-xl" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen />
 
-Macro is an integrated workspace that brings together email, messaging, tasks, documents, and files with bidirectional @linking. It's built with a Solid frontend and a Rust backend, so it's fast.
+Macro unifies your email, messaging, tasks, docs, and files into a single system, all linked together in one database. We built it with a Solid frontend and a Rust backend, so it's fast.
 
 <Card title="Getting started" icon="rocket" href="/getting-started" horizontal>
   New to Macro? Go from a fresh account to a working setup in about 15 minutes.
@@ -73,11 +73,11 @@ The following are the core first-party blocks available in Macro today. Each car
 
 ### Bidirectional @linking
 
-Macro's @linking system connects everything in your workspace. When you @mention a document in a channel message, both the message and document know about each other. This creates a web of context you can navigate in both directions.
+When you @mention a document in a channel message, both the message and the document know about each other, so you can always trace where something has been discussed. This works across every block type: docs, tasks, emails, files, calls, etc.
 
 ### Intelligent permissions
 
-Permissions inherit from channels. Send a document to someone and they automatically get access, without permission dialogs or sharing workflows.
+Permissions inherit from channels. @mention something in a channel and every member automatically gets access, so nobody has to ask "hey can you share this with me?"
 
 ### Built for speed
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -6,7 +6,7 @@ description: "Extremely fast, unified interface for all your work, all linked to
 
 <iframe src="https://www.youtube.com/embed/Fn5hdzXsQQ8" title="YouTube video player" frameborder="0" className="w-full aspect-video rounded-xl" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen />
 
-Macro is an integrated workspace that brings together email, messaging, tasks, documents, and files with powerful bidirectional @linking. Built with a Solid frontend and Rust backend, Macro delivers exceptional performance and a unified experience across all your work.
+Macro is an integrated workspace that brings together email, messaging, tasks, documents, and files with bidirectional @linking. It's built with a Solid frontend and a Rust backend, so it's fast.
 
 <Card title="Getting started" icon="rocket" href="/getting-started" horizontal>
   New to Macro? Go from a fresh account to a working setup in about 15 minutes.
@@ -57,7 +57,7 @@ The following are the core first-party blocks available in Macro today. Each car
   </Card>
 
   <Card title="File Storage" icon="folder" href="/product/folders">
-    Store and share files — auto-imported from email and channels, fully searchable.
+    Store and share files, auto-imported from email and channels, fully searchable.
   </Card>
 
   <Card title="Pull Requests" icon="code-merge" href="/integrations/github">
@@ -77,11 +77,11 @@ Macro's @linking system connects everything in your workspace. When you @mention
 
 ### Intelligent permissions
 
-Permissions inherit from channels. Send a document to someone and they automatically get access. No complex permission dialogs or sharing workflows.
+Permissions inherit from channels. Send a document to someone and they automatically get access, without permission dialogs or sharing workflows.
 
 ### Built for speed
 
-With a Rust backend and optimized Solid frontend, Macro is designed for performance. Instant search, real-time collaboration, and keyboard-driven workflows keep you moving fast.
+Macro has a Rust backend and a Solid frontend. Search is instant, collaboration is real-time, and everything has a keyboard shortcut.
 
 ## Demos & Case Studies
 

--- a/docs/permissions.mdx
+++ b/docs/permissions.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Permissions"
 icon: "lock"
-description: "Channel-based sharing: access flows from channel membership, not per-file dialogs."
+description: "Channel-based sharing: access comes from channel membership instead of per-file dialogs."
 ---
 
 In Macro, who has access to what is controlled by what we call "channel-based" sharing. **When you mention something it is shared with all members of the channel.** If somebody is added to the channel, they gain access to everything shared in it; if they are removed, they lose that access.

--- a/docs/product/agents.mdx
+++ b/docs/product/agents.mdx
@@ -10,11 +10,11 @@ description: "Use agents to summarize your workspace, check up on people's progr
 
 > To create a new chat use shortcut <kbd>c</kbd> \+ <kbd>a</kbd>
 
-Agents have access to everything in your workspace, giving them — and you — full context. The agents tab shows every chat you've had with your agent, and you can continue any of them where you left off.
+Agents have access to everything in your workspace, so they always have full context. The agents tab shows every chat you've had with your agent, and you can continue any of them where you left off.
 
 > Use <kbd>l</kbd> and <kbd>h</kbd> to preview different chat results and <kbd>j</kbd> and <kbd>k</kbd> to move up and down through them.
 
-Ask for summaries, clarifications, and more — the agent answers using all the information in your workspace.
+Ask for summaries, clarifications, and more. The agent answers using all the information in your workspace.
 
 <Frame>
   ![An agent chat answering a question using context from across the workspace](/images/Screenshot-2026-06-03-at-5.01.06-PM.png)
@@ -22,10 +22,10 @@ Ask for summaries, clarifications, and more — the agent answers using all the 
 
 ### Automations
 
-Agents can also run automations — scheduled jobs like daily reminders or weekly summaries. Responses from automations appear in the agents tab and in your inbox.
+Agents can also run automations: scheduled jobs like daily reminders or weekly summaries. Responses from automations appear in the agents tab and in your inbox.
 
 > Use shortcut <kbd>g</kbd> \+ <kbd>a</kbd> to go to agents
 
-To create an automation, go to the agents module and toggle to the automations tab. Select **Create an automation** and fill out the form — you can @mention channels, docs, people, and more inside it.
+To create an automation, go to the agents module and toggle to the automations tab. Select **Create an automation** and fill out the form. You can @mention channels, docs, people, and more inside it.
 
 Each time the automation runs, the result appears in your inbox. For example, a daily to-do summary will land in your inbox at the time you scheduled it each day.

--- a/docs/product/calls.mdx
+++ b/docs/product/calls.mdx
@@ -33,4 +33,4 @@ To opt out of a call being shared with the team, uncheck the button in the botto
 
 After a call ends, it's auto-transcribed and an AI summary is generated. The recording and a readable transcript are always available at the bottom of the call.
 
-From the calls tab, you can ask AI to help you work through your calls — searching transcripts, summarizing, and more.
+From the calls tab, you can ask AI to help you work through your calls: searching transcripts, summarizing, and more.

--- a/docs/product/canvas.mdx
+++ b/docs/product/canvas.mdx
@@ -4,7 +4,7 @@ icon: "diagram-project"
 description: "An infinite 2D board where sketches, shapes, and live blocks from your workspace sit side by side."
 ---
 
-A canvas is Macro's whiteboard block: an infinite 2D plane for mind-mapping, technical diagrams, project planning, or just grouping files visually. What makes it different from a standalone whiteboard tool is that you can place live @mentions of anything in your workspace — tasks, docs, emails, channels, calls — directly on the board, so a diagram can point at the real work it describes.
+A canvas is Macro's whiteboard block: an infinite 2D plane for mind-mapping, technical diagrams, project planning, or just grouping files visually. Unlike a standalone whiteboard tool, you can place live @mentions of anything in your workspace (tasks, docs, emails, channels, calls) directly on the board, so a diagram can point at the real work it describes.
 
 > To create a canvas use shortcut <kbd>c</kbd> + <kbd>n</kbd>
 
@@ -14,11 +14,11 @@ A canvas is Macro's whiteboard block: an infinite 2D plane for mind-mapping, tec
 
 ### What you can put on a canvas
 
-- **Blocks from your workspace** — @mention any doc, task, email, channel, call, or chat. Mentions render as live pills that carry current metadata, like a task's status and priority.
-- **Shapes and text** — rectangles, ellipses, and styled text, with configurable fill, stroke, corner radius, and opacity.
-- **Connectors** — straight, curved, or stepped lines between objects, with arrowheads and other end styles on either end.
-- **Freehand drawing** — sketch with the pencil tool.
-- **Images** — paste, drag in, or pick from your files.
+- **Blocks from your workspace**: @mention any doc, task, email, channel, call, or chat. Mentions render as live pills that carry current metadata, like a task's status and priority.
+- **Shapes and text**: rectangles, ellipses, and styled text, with configurable fill, stroke, corner radius, and opacity.
+- **Connectors**: straight, curved, or stepped lines between objects, with arrowheads and other end styles on either end.
+- **Freehand drawing**: sketch with the pencil tool.
+- **Images**: paste, drag in, or pick from your files.
 
 ### Working on the board
 
@@ -28,4 +28,4 @@ Drag to box-select multiple objects, then use the floating menu to align them (l
 
 ### Sharing
 
-Canvases use the standard share dialog with owner, editor, commenter, and viewer access. When you copy a link to a canvas, your current pan and zoom position is preserved, so the link opens framed on the part of the board you were looking at. You can also download a canvas as a file, and @mention canvases anywhere else in Macro — they show up in [unified search](/product/search) like every other block.
+Canvases use the standard share dialog with owner, editor, commenter, and viewer access. When you copy a link to a canvas, your current pan and zoom position is preserved, so the link opens framed on the part of the board you were looking at. You can also download a canvas as a file, and @mention canvases anywhere else in Macro. They show up in [unified search](/product/search) like every other block.

--- a/docs/product/channels.mdx
+++ b/docs/product/channels.mdx
@@ -8,7 +8,7 @@ description: "Channels are where you and your team collaborate. They serve as th
   ![Channels Screenshot](/images/channels_screenshot.png)
 </Frame>
 
-In Macro, you're not restricted to messaging your team — anyone can be added to a channel by entering their email. People without a Macro account receive an email telling them about their channel notifications.
+Anyone can be added to a channel by entering their email, even if they're not on your team. People without a Macro account receive an email telling them about their channel notifications.
 
 <CardGroup cols={2}>
   <Card title="Channels & Groups" icon="users">
@@ -117,7 +117,7 @@ Share files and media in messages:
 
 ## Typing Indicators
 
-See when other participants are typing in real-time, reducing redundant messages and improving conversation flow.
+See when other participants are typing in real time.
 
 ## Participant Management
 

--- a/docs/product/channels.mdx
+++ b/docs/product/channels.mdx
@@ -49,7 +49,7 @@ Compose messages using Macro's unified rich text editor:
 
 ### Reactions
 
-React to messages with emoji to acknowledge or respond quickly without creating additional message noise.
+React with emoji instead of sending another message.
 
 ### Thread Replies
 
@@ -65,7 +65,7 @@ Keep conversations organized by replying in threads:
 
 ## @Linking System
 
-One of Macro's most powerful features is the bidirectional @linking system in messages:
+Messages support bidirectional @links to everything in your workspace:
 
 <Steps>
   <Step title="Type @">
@@ -129,7 +129,7 @@ Manage channel membership:
 
 ## Integration with Macro
 
-Channel messages integrate seamlessly with the rest of Macro:
+Channel messages tie into the rest of Macro:
 
 - **Search**: Find messages with `type:channel` or search by content
 - **AI Chat**: Ask questions about channel conversations

--- a/docs/product/crm.mdx
+++ b/docs/product/crm.mdx
@@ -22,7 +22,7 @@ Open **Companies** from the sidebar to browse your team's accounts. A company pa
 
 Every company and contact also has a **discussion** thread, so deal notes and context live on the record itself instead of in a side channel. Like everything in Macro, CRM records are blocks: @mention a company or contact in a doc, task, or channel, and agents can use your CRM as context like the rest of your [team memory](/product/unified-memory).
 
-### Email sharing, with control
+### Email sharing
 
 CRM is a team feature, and it's where Macro's email auto-sharing lives. When **Email Sync** is on for a company, your team's email threads with that company become visible to teammates in the CRM, so nobody has to forward a thread just to share context. Turning it off for a company keeps the record but makes its threads private to their participants.
 

--- a/docs/product/crm.mdx
+++ b/docs/product/crm.mdx
@@ -1,30 +1,30 @@
 ---
 title: "CRM"
 icon: "building"
-description: "Contact and company records built automatically from your team's email — no data entry."
+description: "Contact and company records built automatically from your team's email, with no data entry."
 ---
 
 <Note>
   CRM is rolling out now. If you don't see the **Companies** view in your workspace yet, it hasn't reached your account.
 </Note>
 
-Most CRMs die because nobody fills them in. Macro's CRM builds itself: because your team's email already flows through Macro, contact and company records are created and kept up to date automatically as you work. There's no importer to run and no fields to type.
+Most CRMs die because nobody fills them in. Macro's CRM builds itself: because your team's email already flows through Macro, contact and company records are created and kept up to date automatically as you work. You don't have to run an importer or type in fields.
 
 ### Records build themselves
 
-When someone on your team emails an external contact, Macro creates a contact record for them and groups contacts into companies by email domain — everyone `@acme.com` rolls up to one Acme record. Each contact tracks its first and last interaction, so you can see the full history of a relationship at a glance. Generic tool and vendor domains (the SaaS notification emails every company gets) are filtered out so the CRM stays about your actual customers.
+When someone on your team emails an external contact, Macro creates a contact record for them and groups contacts into companies by email domain (everyone `@acme.com` rolls up to one Acme record). Each contact tracks its first and last interaction, so you can see the full history of a relationship at a glance. Generic tool and vendor domains (the SaaS notification emails every company gets) are filtered out so the CRM stays focused on your actual customers.
 
 New companies are enriched automatically with public data: name, description, logo, website, industry, headcount, funding, location, and social links land on the record without anyone touching it.
 
 ### One shared view of every relationship
 
-Open **Companies** from the sidebar to browse your team's accounts. A company page shows its domains, contacts, and email threads in one place — with **Team** and **Me** tabs so you can see either everything your team has exchanged with that account or just your own threads. Contact pages work the same way.
+Open **Companies** from the sidebar to browse your team's accounts. A company page shows its domains, contacts, and email threads in one place. The **Team** and **Me** tabs let you see either everything your team has exchanged with that account or just your own threads. Contact pages work the same way.
 
-Every company and contact also has a **discussion** thread, so deal notes and context live on the record itself instead of in a side channel. And like everything in Macro, CRM records are blocks: @mention a company or contact in a doc, task, or channel, and agents can use your CRM as context like the rest of your [team memory](/product/unified-memory).
+Every company and contact also has a **discussion** thread, so deal notes and context live on the record itself instead of in a side channel. Like everything in Macro, CRM records are blocks: @mention a company or contact in a doc, task, or channel, and agents can use your CRM as context like the rest of your [team memory](/product/unified-memory).
 
 ### Email sharing, with control
 
-CRM is a team feature, and it's where Macro's email auto-sharing lives. When **Email Sync** is on for a company, your team's email threads with that company become visible to teammates in the CRM — that's how sales never has to forward "see thread below" again. Turning it off for a company keeps the record but makes its threads private to their participants.
+CRM is a team feature, and it's where Macro's email auto-sharing lives. When **Email Sync** is on for a company, your team's email threads with that company become visible to teammates in the CRM, so nobody has to forward a thread just to share context. Turning it off for a company keeps the record but makes its threads private to their participants.
 
 Team admins can also **hide** a company or contact entirely, which removes it (and its threads) from the team's view. Members see visible records; admins and owners can edit records, toggle Email Sync, and manage hidden ones.
 

--- a/docs/product/docs.mdx
+++ b/docs/product/docs.mdx
@@ -18,13 +18,13 @@ You can @mention documents in your channels, link to them in your tasks, or ask 
 
 ### Editing & formatting
 
-The editor supports the full set of block nodes — paragraphs, Heading 1/2/3, bullet/numbered/checklist lists (with interactive checkboxes), blockquotes, code blocks (Prism syntax highlighting across 15+ languages), tables, dividers, images, videos, and links — plus inline and block math rendered with KaTeX. Inline formatting follows the usual shortcuts: bold (<kbd>cmd</kbd>+<kbd>b</kbd>), italic (<kbd>cmd</kbd>+<kbd>i</kbd>), underline (<kbd>cmd</kbd>+<kbd>u</kbd>), strikethrough (<kbd>shift</kbd>+<kbd>cmd</kbd>+<kbd>x</kbd>), highlight (<kbd>shift</kbd>+<kbd>cmd</kbd>+<kbd>h</kbd>), inline code (<kbd>cmd</kbd>+<kbd>e</kbd>), plus superscript and subscript.
+The editor supports the full set of block nodes: paragraphs, Heading 1/2/3, bullet/numbered/checklist lists (with interactive checkboxes), blockquotes, code blocks (Prism syntax highlighting across 15+ languages), tables, dividers, images, videos, and links, plus inline and block math rendered with KaTeX. Inline formatting follows the usual shortcuts: bold (<kbd>cmd</kbd>+<kbd>b</kbd>), italic (<kbd>cmd</kbd>+<kbd>i</kbd>), underline (<kbd>cmd</kbd>+<kbd>u</kbd>), strikethrough (<kbd>shift</kbd>+<kbd>cmd</kbd>+<kbd>x</kbd>), highlight (<kbd>shift</kbd>+<kbd>cmd</kbd>+<kbd>h</kbd>), inline code (<kbd>cmd</kbd>+<kbd>e</kbd>), plus superscript and subscript.
 
 Markdown autoformatting works as you type (`#`/`##`/`###`, `-`, `1.`, `[]`, `>`, `---`, and backticks), `:shortcode:` emoji are supported, blocks can be dragged to reorder, <kbd>tab</kbd>/<kbd>shift</kbd>+<kbd>tab</kbd> indent and outdent, and find & replace (<kbd>cmd</kbd>+<kbd>f</kbd>) supports regex and replace-one/replace-all. The slash menu (`/`, or the command menu) inserts any of these: Normal text, Heading 1/2/3, Blockquote, Code block, Bullet/Numbered/Checklist, **Task** (an inline task with mentions), Image, Video, Link, Equation (`/latex` or `/math`), Table (5×3), and Divider. @mentions render in the body as collapsible inline pills. Typing `;` opens the [snippets](/product/snippets) menu to insert reusable content.
 
 ### Comments & history
 
-Comments are inline and thread-based, anchored to a text selection — you can reply, resolve and unresolve, draft, and edit or delete your own. Full version history is available via time-travel: browse historical states grouped by user and time, and **fork** a document at any past version into a new doc.
+Comments are inline and thread-based, anchored to a text selection. You can reply, resolve and unresolve, draft, and edit or delete your own. Full version history is available via time-travel: browse historical states grouped by user and time, and **fork** a document at any past version into a new doc.
 
 ### Notifications
 
@@ -42,7 +42,7 @@ For a person to receive notifications from a document, it must first be shared w
 
 ### Properties
 
-On the right-hand side of your document — or inside the Info panel, depending on your split size — you can see document details (owner, folder, created and updated) as well as properties. Properties let you assign the document, link it to a task, set urgency, and more. You can pin properties so their values render as pills under the title, toggle an optional YAML front-matter display, and see a live word and character count.
+On the right-hand side of your document (or inside the Info panel, depending on your split size) you can see document details (owner, folder, created and updated) as well as properties. Properties let you assign the document, link it to a task, set urgency, and more. You can pin properties so their values render as pills under the title, toggle an optional YAML front-matter display, and see a live word and character count.
 
 <Frame>
   <img
@@ -56,6 +56,6 @@ On the right-hand side of your document — or inside the Info panel, depending 
 
 ### Sharing & export
 
-Documents use the standard access levels: owner, editor, commenter, and viewer. Document viewing is not limited to Macro users — you can share documents with people outside the app by using their email address, or by giving them a URL link if the Public Link has been enabled in the Share menu. Users who aren't signed in see a document preview without having to log in or create an account. Sharing a doc through a Macro message auto-updates its permissions so recipients can open it.
+Documents use the standard access levels: owner, editor, commenter, and viewer. You can share documents with people outside Macro by using their email address, or by giving them a URL link if the Public Link has been enabled in the Share menu. Users who aren't signed in see a document preview without having to log in or create an account. Sharing a doc through a Macro message auto-updates its permissions so recipients can open it.
 
 Copy a link with <kbd>shift</kbd>+<kbd>cmd</kbd>+<kbd>c</kbd>, export to markdown text, and upload images or video by paste, drag, or the media picker.

--- a/docs/product/email.mdx
+++ b/docs/product/email.mdx
@@ -24,7 +24,7 @@ To connect another account, go to **Settings** and add the Gmail or Google Works
 
 ### Signal vs Noise
 
-Macro splits email into Signal and Noise tabs. Signal is where your high-priority emails go — things like team member updates and customer feedback. Noise is for emails that aren't crucial to your workflow, such as newsletters and promotions.
+Macro splits email into Signal and Noise tabs. Signal is where your high-priority emails go, like team member updates and customer feedback. Noise is for emails that aren't crucial to your workflow, such as newsletters and promotions.
 
 To count as Signal in Email, threads have to clear a higher bar than in the Macro inbox: they must be **important** and **not shared** with you by someone else. Routine or shared emails won't be there.
 

--- a/docs/product/folders.mdx
+++ b/docs/product/folders.mdx
@@ -4,10 +4,10 @@ icon: "folder"
 description: "Store and share files across your workspace."
 ---
 
-Folders organize the documents and files in your workspace — markdown docs, PDFs, images, videos, code files, and canvases.
+Folders organize the documents and files in your workspace: markdown docs, PDFs, images, videos, code files, and canvases.
 
 > To create a folder use shortcut <kbd>c</kbd> \+ <kbd>f</kbd>. With an item selected in a list, press <kbd>m</kbd> to move it to a folder.
 
 Files land in your workspace automatically as you work: attachments shared in channels are imported to file storage, and email attachments are auto-extracted. Everything in a folder stays fully searchable from [unified search](/product/search).
 
-Folders use the same sharing model as other blocks — owner, editor, commenter, and viewer access levels — and folders with open notifications show up in your [inbox](/product/inbox).
+Folders use the same sharing model as other blocks (owner, editor, commenter, and viewer), and folders with open notifications show up in your [inbox](/product/inbox).

--- a/docs/product/inbox.mdx
+++ b/docs/product/inbox.mdx
@@ -22,7 +22,7 @@ Use the input box at the bottom to ask AI to summarize, explain in more detail, 
 
 ## Signal vs. Noise
 
-The Signal view is your **action list**. It surfaces the things across Macro that currently need your attention. An item shows up here when **you have an open notification:**
+The Signal view is your **action list**. It shows the things across Macro that currently need your attention. An item shows up here when **you have an open notification:**
 
 - a reply
 - a mention

--- a/docs/product/inbox.mdx
+++ b/docs/product/inbox.mdx
@@ -4,7 +4,7 @@ icon: "inbox"
 description: "The Inbox unifies all your email accounts, messages, and @mentions into a single list."
 ---
 
-The core idea behind Macro's unified inbox is that you should only have to check one thing, not 7\+ different apps, to understand what is going on at your company.
+The idea behind Macro's unified inbox is that you should only have to check one thing to understand what is going on at your company, instead of 7\+ different apps.
 
 <Frame>
   ![Inbox Screenshot](/images/inbox_screenshot.png)
@@ -12,7 +12,7 @@ The core idea behind Macro's unified inbox is that you should only have to check
 
 > The shortcut to get to your inbox is <kbd>g</kbd> \+ <kbd>i</kbd>, and pressing <kbd>space</kbd> will show you a preview of the selected notification. Use <kbd>j</kbd> and <kbd>k</kbd> to toggle up and down through different inbox items.
 
-From your inbox, you can filter by Signal or Noise — Signal holds your important notifications. Tasks assigned to you land in the inbox, along with new messages, emails, and agent responses. Select any item to jump to it.
+From your inbox, you can filter by Signal or Noise. Signal holds your important notifications. Tasks assigned to you land in the inbox, along with new messages, emails, and agent responses. Select any item to jump to it.
 
 Use the input box at the bottom to ask AI to summarize, explain in more detail, respond, and more.
 
@@ -45,4 +45,4 @@ The inbox view pulls from across the whole product into one combined, recency-so
 | **Folders** | You have an open notification on it, and it was updated recently |
 | **Email Threads** | You have an open notification on it, it was updated recently, and it's flagged important and not a shared thread |
 | **Channels** | You have an open notification on it |
-| **Calls** | _Never_ — calls are intentionally excluded from this view |
+| **Calls** | _Never_. Calls are intentionally excluded from this view |

--- a/docs/product/search.mdx
+++ b/docs/product/search.mdx
@@ -26,4 +26,4 @@ Use the filter button in the upper right corner to sort results into different t
 
 To further narrow search results, combine your keywords with an @mention of a specific person.
 
-Search doesn't stop at titles: document bodies, email threads, channel messages, call transcripts, and file contents are all indexed. And if you'd rather not search at all, ask an [agent](/product/agents) — agents use the same index to find things in your workspace for you.
+Search covers more than titles: document bodies, email threads, channel messages, call transcripts, and file contents are all indexed. You can also ask an [agent](/product/agents) to find things for you; agents use the same index.

--- a/docs/product/tasks.mdx
+++ b/docs/product/tasks.mdx
@@ -6,9 +6,9 @@ description: "Track work with priorities, statuses, and linked context."
 
 <iframe src="https://www.youtube.com/embed/gxJquVXRX5A" title="YouTube video player" frameborder="0" className="w-full aspect-video rounded-xl" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen />
 
-Tasks in Macro are built to avoid superfluous ceremony: quick to create, easy to close out.
+We built tasks to be quick to create and easy to close out.
 
-Because tasks are integrated into the rest of your workspace, there's no need for extraneous labels and categories. It's just status, priority, assignee.
+Because tasks are integrated into the rest of your workspace, there's no need for extra labels and categories. It's just status, priority, assignee.
 
 > To create a new task use shortcut <kbd>c</kbd> \+ <kbd>t</kbd>
 

--- a/docs/product/unified-memory.mdx
+++ b/docs/product/unified-memory.mdx
@@ -4,7 +4,7 @@ icon: "brain"
 description: "Personal and team-level memory across mail, messages, tasks, docs and connectors."
 ---
 
-ChatGPT and Claude create memory over your chats. Macro creates memory over everything you and your team are working on — email, messages, tasks, docs, calls, and anything you've connected via MCP. There's not too much to document here because it all runs in the background with limited configurability.
+ChatGPT and Claude create memory over your chats. Macro creates memory over everything you and your team are working on: email, messages, tasks, docs, calls, and anything you've connected via MCP. There's not too much to document here because it all runs in the background with limited configurability.
 
 <Frame>
   <img
@@ -13,14 +13,14 @@ ChatGPT and Claude create memory over your chats. Macro creates memory over ever
   />
 </Frame>
 
-Every night, Macro refreshes this memory from the day's activity. When you ask an agent "what's the latest status of project alamo?", it answers from the most recent emails, messages, tasks, docs, and call transcripts — you don't have to point it at anything.
+Every night, Macro refreshes this memory from the day's activity. When you ask an agent "what's the latest status of project alamo?", it answers from the most recent emails, messages, tasks, docs, and call transcripts. You don't have to point it at anything.
 
 ### Personal vs. team memory
 
 Everyone has a personal memory built from their own work. If you're on a team, there's also a shared team-level memory:
 
 - **Tasks** are added to team memory by default, so everyone can see what others are working on.
-- **Calls** are recorded, transcribed, and shared to team memory by default. You can opt out per call — see [Calls](/product/calls) — in which case the call goes to your personal memory only.
+- **Calls** are recorded, transcribed, and shared to team memory by default. You can opt out per call (see [Calls](/product/calls)), in which case the call goes to your personal memory only.
 - **Emails** are auto-shared with the team where it makes sense, for example in the CRM module.
 
 This is what makes agents in Macro different from a personal chat assistant: they remember what your whole team has been doing, not just your own chat history.

--- a/docs/support.mdx
+++ b/docs/support.mdx
@@ -8,13 +8,13 @@ description: "How to get help with Macro, and fixes for the most common issues."
 
 <CardGroup cols={2}>
   <Card title="Email support" icon="envelope" href="mailto:support@macro.com">
-    Write to support@macro.com — include what you were doing and what you expected to happen.
+    Write to support@macro.com. Include what you were doing and what you expected to happen.
   </Card>
   <Card title="Book a call" icon="calendar" href="https://cal.com/team/macro/macro-demo-call">
     A member of our team will walk you through setup or dig into a problem live.
   </Card>
   <Card title="File a bug on GitHub" icon="github" href="https://github.com/macro-inc/macro/issues">
-    Macro is open source — bug reports (and pull requests) are welcome on the monorepo.
+    Macro is open source, so bug reports (and pull requests) are welcome on the monorepo.
   </Card>
   <Card title="Watch the demo" icon="play" href="https://www.youtube.com/watch?v=Fn5hdzXsQQ8">
     Many "how do I…" questions are answered in the product walkthrough.
@@ -27,11 +27,11 @@ For specific topics: [licensing@macro.com](mailto:licensing@macro.com) for comme
 
 <AccordionGroup>
   <Accordion title="Someone referenced a doc or task I can't open">
-    You don't have access yet. Ask them to @mention it in a channel you're both in — that shares it with every member automatically — or to share it with you directly from the item's Share menu. See [Permissions](/permissions).
+    You don't have access yet. Ask them to @mention it in a channel you're both in (that shares it with every member automatically), or to share it with you directly from the item's Share menu. See [Permissions](/permissions).
   </Accordion>
 
   <Accordion title="An email I'm expecting isn't in my inbox">
-    Check the **Noise** tab — Macro filters lower-priority senders out of Signal. If a sender is misclassified, right-click any of their threads to move them between Signal and Noise; the change sticks for future emails. See [Signal vs Noise](/product/email#signal-vs-noise).
+    Check the **Noise** tab. Macro filters lower-priority senders out of Signal. If a sender is misclassified, right-click any of their threads to move them between Signal and Noise; the change sticks for future emails. See [Signal vs Noise](/product/email#signal-vs-noise).
   </Accordion>
 
   <Accordion title="I @mentioned someone in a doc and they weren't notified">
@@ -39,18 +39,18 @@ For specific topics: [licensing@macro.com](mailto:licensing@macro.com) for comme
   </Accordion>
 
   <Accordion title="I don't see a feature the docs describe (Companies, splits, …)">
-    Two usual causes: some features roll out gradually, so your account may not have them yet — and some features are desktop-only, like [splits](/concepts/blocks#splits) and keyboard shortcuts. See [Apps & platforms](/apps).
+    Two usual causes: some features roll out gradually, so your account may not have them yet, and some features are desktop-only, like [splits](/concepts/blocks#splits) and keyboard shortcuts. See [Apps & platforms](/apps).
   </Accordion>
 
   <Accordion title="A call wasn't supposed to be shared with my team">
-    Calls are shared to team memory by default. During a call, uncheck the toggle in the bottom left to keep it personal — the call still goes to your own memory, just not the team's. See [Calls](/product/calls).
+    Calls are shared to team memory by default. During a call, uncheck the toggle in the bottom left to keep it personal. The call still goes to your own memory, just not the team's. See [Calls](/product/calls).
   </Accordion>
 
   <Accordion title="My agent says it can't access something">
-    Agents inherit your permissions — if you can't open it, neither can they. Get access to the item first (see the first question above), then ask again. See [Mentions in Agents](/concepts/mentions#mentions-in-agents).
+    Agents inherit your permissions. If you can't open it, neither can they. Get access to the item first (see the first question above), then ask again. See [Mentions in Agents](/concepts/mentions#mentions-in-agents).
   </Accordion>
 </AccordionGroup>
 
 <Info>
-  When reporting a bug, include your platform (web or iOS), the block type involved (email, doc, channel, …), and a link to the affected item if you have one — it cuts the back-and-forth in half.
+  When reporting a bug, include your platform (web or iOS), the block type involved (email, doc, channel, …), and a link to the affected item if you have one. It cuts down the back-and-forth.
 </Info>

--- a/docs/switch-to-macro.mdx
+++ b/docs/switch-to-macro.mdx
@@ -31,6 +31,17 @@ Superhuman and Macro are both clients on top of Gmail, so there's no migration i
 
 The <kbd>j</kbd> / <kbd>k</kbd> / <kbd>e</kbd> triage shortcuts you already know work unchanged.
 
+|                                              | Superhuman | Macro |
+| :------------------------------------------- | :--------: | :---: |
+| Gmail underneath — no migration              | ✅         | ✅    |
+| <kbd>j</kbd> / <kbd>k</kbd> / <kbd>e</kbd> triage shortcuts | ✅ | ✅ |
+| Multiple accounts in one unified inbox       | —          | ✅    |
+| [Signal vs. Noise](/product/email#signal-vs-noise) split | — | ✅ |
+| Messages, tasks, and @mentions in the same inbox | —      | ✅    |
+| [Agents](/product/agents) that draft, triage, and send | — | ✅ |
+
+<iframe src="https://www.youtube.com/embed/tnsxkywzTvY" title="Email on Macro" frameborder="0" className="w-full aspect-video rounded-xl" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen />
+
 To switch:
 
 1. Connect your Gmail or Google Workspace account (ideally at signup, or later in **Settings**).
@@ -46,7 +57,18 @@ To switch:
   />
 </Frame>
 
-The structural difference: Notion gives you markdown pages and databases and asks you to assemble your own tools out of them — your CRM, your task tracker, your wiki are all databases with different views. Macro ships those as purpose-built blocks ([tasks](/product/tasks), [CRM](/product/crm), [email](/product/email), [channels](/product/channels), [files](/product/folders)) that share one data model and one search index. You give up some of Notion's freeform database flexibility; in exchange, each tool behaves like a dedicated product, and your agents can query all of it as unified context instead of paging through a rate-limited API. The longer version of this argument is in the [FAQ](/faq) and our [comparison video](https://youtu.be/hyU1XYmxkYM).
+The structural difference: Notion gives you markdown pages and databases and asks you to assemble your own tools out of them — your CRM, your task tracker, your wiki are all databases with different views. Macro ships those as purpose-built blocks ([tasks](/product/tasks), [CRM](/product/crm), [email](/product/email), [channels](/product/channels), [files](/product/folders)) that share one data model and one search index. You give up some of Notion's freeform database flexibility; in exchange, each tool behaves like a dedicated product, and your agents can query all of it as unified context instead of paging through a rate-limited API. The longer version of this argument is in the [FAQ](/faq) and the video below.
+
+|                                       | Notion          | Macro |
+| :------------------------------------ | :-------------: | :---: |
+| Markdown-native docs                  | ✅              | ✅    |
+| Tasks                                 | Build your own from databases | Purpose-built |
+| CRM                                   | Build your own from databases | Purpose-built |
+| Email and channels                    | —               | ✅    |
+| Freeform databases                    | ✅              | [Properties](/concepts/properties) on purpose-built blocks |
+| Agent access to your workspace        | Rate-limited API | One unified search index |
+
+<iframe src="https://www.youtube.com/embed/hyU1XYmxkYM" title="What We Learned from Notion" frameborder="0" className="w-full aspect-video rounded-xl" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen />
 
 For the docs themselves, the import is clean — Macro docs are markdown-native, so Notion pages translate directly:
 
@@ -75,6 +97,16 @@ The chat itself is deliberately familiar — channels, threads, emoji. What chan
 
 The bigger difference is [channel-based sharing](/permissions): [@mention](/concepts/mentions) a doc or task in a channel and every member gets access to it automatically — no "request access" dance between your chat tool and your docs tool, because they're the same tool.
 
+|                                          | Slack | Macro |
+| :--------------------------------------- | :---: | :---: |
+| Channels, threads, emoji                 | ✅    | ✅    |
+| Inline thread replies (forum-style reading) | —  | ✅    |
+| One inbox shared with your email         | —     | ✅    |
+| @mention a doc or task to share it automatically | — | ✅ |
+| External channels with customers (Slack Connect) | ✅ | Keep Slack connected as an MCP connector |
+
+<iframe src="https://www.youtube.com/embed/1gDOXUxHo0U" title="What Macro learned from Slack/Superhuman" frameborder="0" className="w-full aspect-video rounded-xl" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen />
+
 To switch:
 
 1. Create a channel per team or project (<kbd>c</kbd> + <kbd>m</kbd>).
@@ -96,6 +128,17 @@ Macro's tasks are openly Linear-inspired: status, priority, assignee, keyboard-f
 
 The difference is adjacency. Tasks live next to your email, channels, and docs, so you can turn an email or a channel message into a task in one click, and non-engineers see engineering work without needing a seat in a separate tool. Fields are minimal by default, with more available [if you want it](/concepts/properties) — less workflow configuration to maintain.
 
+|                                          | Linear | Macro |
+| :--------------------------------------- | :----: | :---: |
+| Status, priority, assignee, keyboard-first | ✅   | ✅    |
+| [GitHub integration](/integrations/github) — branch, PR, and merge move the task | ✅ | ✅ |
+| Tasks next to your email, channels, and docs | —  | ✅    |
+| Turn an email or channel message into a task in one click | — | ✅ |
+| Non-engineers see engineering work       | Separate seat in a separate tool | Same workspace |
+| Deep workflow configuration (cycles, triage, custom flows) | ✅ | Minimal by default, [properties](/concepts/properties) when you want them |
+
+<iframe src="https://www.youtube.com/embed/nHxqE2mVKrA" title="What We Learned from Linear" frameborder="0" className="w-full aspect-video rounded-xl" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen />
+
 For migration, most teams simply recreate their open work — finished issues rarely justify carrying over. If you do want history, connect Linear under **Settings → Connectors** and have an agent bring open issues across.
 
 ## From ClickUp
@@ -111,6 +154,17 @@ ClickUp tries to be everything — tasks, docs, chat, goals, whiteboards — thr
 
 The biggest day-to-day change is that work stops living in a silo: tasks sit next to your email, channels, and docs, so you can turn a message or an email into a task in one click, and @mentioning a task in a channel shares it automatically.
 
+|                                          | ClickUp | Macro |
+| :--------------------------------------- | :-----: | :---: |
+| Tasks, docs, chat                        | ✅      | ✅    |
+| Setup required                           | Spaces, folders, lists, custom statuses | Purpose-built defaults |
+| CRM                                      | Configure it yourself | [Purpose-built](/product/crm) |
+| Email                                    | —       | ✅    |
+| One data model, one search index         | —       | ✅    |
+| [Agents](/product/agents) with your whole workspace as context | — | ✅ |
+
+<iframe src="https://www.youtube.com/embed/gxJquVXRX5A" title="Tasks on Macro" frameborder="0" className="w-full aspect-video rounded-xl" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen />
+
 To switch:
 
 1. Recreate your active lists as Macro tasks — most teams skip closed work, since finished ClickUp tasks rarely earn their migration.
@@ -120,6 +174,24 @@ To switch:
 ## Everything else
 
 Any tool with an MCP server can be connected under **Settings → Connectors**, which makes it readable to your agents — useful both as a migration path (ask an agent to copy content over) and as a permanent bridge for tools you keep. And your files largely migrate themselves: email attachments are auto-extracted into [file storage](/product/folders), and anything you drag into a channel or doc is imported and searchable.
+
+## Macro vs. the world
+
+The full picture, side by side. Most of these tools have an AI assistant of their own — the difference is that Macro's [agents](/product/agents) see everything below as one context, instead of one silo at a time.
+
+|                                   | Macro | Superhuman | Notion | Slack | Linear | ClickUp |
+| :-------------------------------- | :---: | :--------: | :----: | :---: | :----: | :-----: |
+| [Email](/product/email)           | ✅    | ✅         | —      | —     | —      | —       |
+| [Channels](/product/channels)     | ✅    | —          | —      | ✅    | —      | ✅      |
+| [Tasks](/product/tasks)           | ✅    | —          | Via databases | — | ✅   | ✅      |
+| [Docs](/product/docs)             | ✅    | —          | ✅     | —     | —      | ✅      |
+| [CRM](/product/crm)               | ✅    | —          | Via databases | — | —    | Via setup |
+| [File storage](/product/folders)  | ✅    | —          | Attachments | Attachments | — | Attachments |
+| [Calls](/product/calls)           | ✅    | —          | —      | Huddles | —    | —       |
+| One inbox for email, messages, tasks, and @mentions | ✅ | — | — | — | — | —    |
+| [Agents](/product/agents) with all of the above as context | ✅ | — | — | — | — | — |
+
+<iframe src="https://www.youtube.com/embed/Fn5hdzXsQQ8" title="Macro Product Demo" frameborder="0" className="w-full aspect-video rounded-xl" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen />
 
 <Card title="Want help switching?" icon="calendar" href="https://cal.com/team/macro/macro-demo-call">
   Book a call and we'll walk your team through the migration.

--- a/docs/switch-to-macro.mdx
+++ b/docs/switch-to-macro.mdx
@@ -27,7 +27,7 @@ At a glance, here's what maps to what:
   />
 </Frame>
 
-Superhuman and Macro are both clients on top of Gmail, so there's no migration in either direction. Your mail stays in Gmail either way. Macro puts multiple accounts in [one inbox](/product/email#multi-account-inbox), splits [Signal from Noise](/product/email#signal-vs-noise) so cold outreach and notifications don't interrupt you, and puts messages, tasks, and @mentions in the same inbox as your email. [Agents](/product/agents) can also draft, triage, and send mail for you.
+Before Macro, we were Superhuman users ourselves, and we were heavily inspired by them in designing Macro's email. Both are just clients on top of Gmail, so there's no migration in either direction; your mail stays in Gmail. What Macro adds: multiple accounts in [one inbox](/product/email#multi-account-inbox), [Signal vs. Noise](/product/email#signal-vs-noise) so cold outreach and notifications don't interrupt you, and messages, tasks, and @mentions in the same inbox as your email. [Agents](/product/agents) can also draft, triage, and send mail for you.
 
 The <kbd>j</kbd> / <kbd>k</kbd> / <kbd>e</kbd> triage shortcuts you already know work unchanged.
 
@@ -57,7 +57,7 @@ To switch:
   />
 </Frame>
 
-Notion gives you markdown pages and databases and asks you to build your own tools out of them: your CRM, your task tracker, and your wiki are all databases with different views. In Macro, tasks, CRM, email, channels, and files are each their own [block](/concepts/blocks) type, and they all share one data model and one search index. You give up some of Notion's freeform database flexibility, but each tool works like a dedicated product, and agents can read all of it as one context instead of paging through a rate-limited API. There's a longer version of this argument in the [FAQ](/faq) and the video below.
+Notion asks you to build your own tools out of markdown pages and databases: your CRM, your task tracker, and your wiki are all databases with different views. We think databases are the wrong level of abstraction for this. In Macro, tasks, CRM, email, channels, and files are each their own dedicated [block](/concepts/blocks), and they all share one data model and one search index. Yes, you give up some of Notion's freeform database flexibility, but each tool works like a real product, and agents can read all of it as one context vs. paging through a rate-limited API. The longer version of this argument is in the [FAQ](/faq) and the video below.
 
 |                                       | Notion          | Macro |
 | :------------------------------------ | :-------------: | :---: |
@@ -93,9 +93,9 @@ You can also keep Notion connected indefinitely so agents can reference legacy c
   />
 </Frame>
 
-We didn't change too much vs. Slack: channels, threads, and emoji all work the way you expect. The main thing we changed is making channels less noisy and more focused for technical discussions. The first few replies in a thread show inline, so you can follow a conversation without clicking into it, and a busy channel reads more like a forum than a firehose. Channels also share an inbox with your email, so there's one place to catch up.
+We didn't change too much vs. Slack: channels, threads, and emoji all work the way you expect. The main thing we changed is making channels less noisy and more focused for technical discussions. The first few replies in a thread show inline, so you don't have to open a thread every time someone replies, and a busy channel looks more like Reddit: organized, and easy to remember where a conversation happened. Channels also share an inbox with your email, so there's one place to catch up.
 
-Channels also handle [sharing](/permissions): [@mention](/concepts/mentions) a doc or task in a channel and every member gets access to it automatically. There's no "request access" step because chat and docs are the same tool.
+The other big thing is [channel-based sharing](/permissions): [@mention](/concepts/mentions) a doc or task in a channel and every member gets access to it automatically. This avoids the Slack\+Notion footgun where people need to ask "hey can you share \_\_ with me?"
 
 |                                          | Slack | Macro |
 | :--------------------------------------- | :---: | :---: |
@@ -126,7 +126,7 @@ If you're not ready to leave Slack (archives, Slack Connect with customers), con
 
 In building Macro Tasks we were heavily inspired by Linear: status, priority, assignee, keyboard-first, and a [GitHub integration](/integrations/github) that covers the workflow you're used to. Copy a branch name from a task and it moves through In Progress, In Review, and Done as you branch, open the PR, and merge.
 
-The difference is that tasks live in the same app as your email, channels, and docs. You can turn an email or a channel message into a task in one click, and non-engineers can see engineering work without a seat in a separate tool. Fields are minimal by default, with more available [if you want them](/concepts/properties), so there's less workflow configuration to maintain.
+The difference is that tasks live in the same app as your email, channels, and docs. You can turn an email or a channel message into a task in one click, and non-engineers can see engineering work without a seat in a separate tool. Tasks are also less ceremonious: fields are minimal by default, and story points, effort, etc. are there via [properties](/concepts/properties) if you really want them, but we advise keeping it light.
 
 |                                          | Linear | Macro |
 | :--------------------------------------- | :----: | :---: |
@@ -150,7 +150,7 @@ For migration, most teams just recreate their open work; finished issues rarely 
   />
 </Frame>
 
-ClickUp covers tasks, docs, chat, goals, and whiteboards through a deep stack of spaces, folders, lists, and custom statuses that you configure yourself. Macro covers the same ground with dedicated [tasks](/product/tasks), [docs](/product/docs), [channels](/product/channels), and [CRM](/product/crm) that share one data model. There's less setup and fewer knobs because each tool already behaves the way its job needs. Tasks keep the essentials (status, priority, assignee, and [properties](/concepts/properties) when you want them), and [agents](/product/agents) can read across all of it as one context.
+ClickUp covers tasks, docs, chat, goals, and whiteboards through a deep stack of spaces, folders, lists, and custom statuses that you configure yourself. Macro covers the same ground with dedicated [tasks](/product/tasks), [docs](/product/docs), [channels](/product/channels), and [CRM](/product/crm) that share one data model. There's less setup and fewer knobs because each tool is already built for its job. Tasks keep the essentials (status, priority, assignee, and [properties](/concepts/properties) when you want them), and [agents](/product/agents) can read across all of it as one context.
 
 The biggest day-to-day change is that tasks live in the same app as your email, channels, and docs. You can turn a message or an email into a task in one click, and @mentioning a task in a channel shares it automatically.
 
@@ -177,7 +177,7 @@ Any tool with an MCP server can be connected under **Settings → Connectors**, 
 
 ## Macro vs. the world
 
-Here's the full picture side by side. Most of these tools have their own AI assistant; the difference is that Macro's [agents](/product/agents) see everything below as one context instead of one tool at a time.
+Here's the full picture side by side. Most of these tools have their own AI assistant; the difference is that Macro's [agents](/product/agents) see everything below as one context instead of one silo at a time. That's the whole point of Macro: unified context.
 
 |                                   | Macro | Superhuman | Notion | Slack | Linear | ClickUp |
 | :-------------------------------- | :---: | :--------: | :----: | :---: | :----: | :-----: |

--- a/docs/switch-to-macro.mdx
+++ b/docs/switch-to-macro.mdx
@@ -1,17 +1,17 @@
 ---
 title: "Switch to Macro"
 icon: "arrow-right-arrow-left"
-description: "Migration guides for moving from Superhuman, Notion, Slack, Linear, and ClickUp to Macro — what maps to what, and what changes."
+description: "Migration guides for moving to Macro from Superhuman, Notion, Slack, Linear, and ClickUp."
 ---
 
-Macro replaces several tools at once, but you don't have to cut over in one weekend. The pattern that works: connect your old tools first so nothing is lost, move your daily workflow into Macro, and let the old tools wind down to read-only. This page covers the most common starting points.
+Macro replaces several tools at once, but you don't have to cut over in one weekend. Most teams connect their old tools first so nothing is lost, move their daily workflow into Macro, and let the old tools wind down to read-only. This page covers the most common starting points.
 
 At a glance, here's what maps to what:
 
 | Coming from | The Macro equivalent |
 | :---------- | :------------------- |
-| Superhuman  | [Email](/product/email) and the [inbox](/product/inbox) — same Gmail underneath |
-| Notion      | [Docs](/product/docs), plus purpose-built [tasks](/product/tasks) and [CRM](/product/crm) |
+| Superhuman  | [Email](/product/email) and the [inbox](/product/inbox) (both are Gmail clients) |
+| Notion      | [Docs](/product/docs), plus built-in [tasks](/product/tasks) and [CRM](/product/crm) |
 | Slack       | [Channels](/product/channels) |
 | Linear      | [Tasks](/product/tasks) |
 | ClickUp     | [Tasks](/product/tasks), with [docs](/product/docs), [CRM](/product/crm), and [channels](/product/channels) replacing the rest of the suite |
@@ -27,26 +27,26 @@ At a glance, here's what maps to what:
   />
 </Frame>
 
-Superhuman and Macro are both clients on top of Gmail, so there's no migration in either direction — your mail stays in Gmail either way. The differences are in scope: Macro puts multiple accounts in [one inbox](/product/email#multi-account-inbox), splits [Signal from Noise](/product/email#signal-vs-noise) so cold outreach and notifications never interrupt you, and folds messages, tasks, and @mentions into the same inbox as your email — one thing to check instead of four. [Agents](/product/agents) can also draft, triage, and send mail for you.
+Superhuman and Macro are both clients on top of Gmail, so there's no migration in either direction. Your mail stays in Gmail either way. Macro puts multiple accounts in [one inbox](/product/email#multi-account-inbox), splits [Signal from Noise](/product/email#signal-vs-noise) so cold outreach and notifications don't interrupt you, and puts messages, tasks, and @mentions in the same inbox as your email. [Agents](/product/agents) can also draft, triage, and send mail for you.
 
 The <kbd>j</kbd> / <kbd>k</kbd> / <kbd>e</kbd> triage shortcuts you already know work unchanged.
 
 |                                              | Superhuman | Macro |
 | :------------------------------------------- | :--------: | :---: |
-| Gmail underneath — no migration              | ✅         | ✅    |
-| <kbd>j</kbd> / <kbd>k</kbd> / <kbd>e</kbd> triage shortcuts | ✅ | ✅ |
-| Multiple accounts in one unified inbox       | —          | ✅    |
-| [Signal vs. Noise](/product/email#signal-vs-noise) split | — | ✅ |
-| Messages, tasks, and @mentions in the same inbox | —      | ✅    |
-| [Agents](/product/agents) that draft, triage, and send | — | ✅ |
+| Built on Gmail (no migration)                | ✓         | ✓    |
+| <kbd>j</kbd> / <kbd>k</kbd> / <kbd>e</kbd> triage shortcuts | ✓ | ✓ |
+| Multiple accounts in one unified inbox       | —          | ✓    |
+| [Signal vs. Noise](/product/email#signal-vs-noise) split | — | ✓ |
+| Messages, tasks, and @mentions in the same inbox | —      | ✓    |
+| [Agents](/product/agents) that draft, triage, and send | — | ✓ |
 
 <iframe src="https://www.youtube.com/embed/tnsxkywzTvY" title="Email on Macro" frameborder="0" className="w-full aspect-video rounded-xl" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen />
 
 To switch:
 
 1. Connect your Gmail or Google Workspace account (ideally at signup, or later in **Settings**).
-2. Your mail, labels, and history are already there — Macro syncs with Gmail directly.
-3. That's it. There's no reason you can't run both during the transition, but most people stop opening Superhuman within a week.
+2. Your mail, labels, and history are already there because Macro syncs with Gmail directly.
+3. That's it. You can run both during the transition, but most people stop opening Superhuman within a week.
 
 ## From Notion
 
@@ -57,30 +57,30 @@ To switch:
   />
 </Frame>
 
-The structural difference: Notion gives you markdown pages and databases and asks you to assemble your own tools out of them — your CRM, your task tracker, your wiki are all databases with different views. Macro ships those as purpose-built blocks ([tasks](/product/tasks), [CRM](/product/crm), [email](/product/email), [channels](/product/channels), [files](/product/folders)) that share one data model and one search index. You give up some of Notion's freeform database flexibility; in exchange, each tool behaves like a dedicated product, and your agents can query all of it as unified context instead of paging through a rate-limited API. The longer version of this argument is in the [FAQ](/faq) and the video below.
+Notion gives you markdown pages and databases and asks you to build your own tools out of them: your CRM, your task tracker, and your wiki are all databases with different views. In Macro, tasks, CRM, email, channels, and files are each their own [block](/concepts/blocks) type, and they all share one data model and one search index. You give up some of Notion's freeform database flexibility, but each tool works like a dedicated product, and agents can read all of it as one context instead of paging through a rate-limited API. There's a longer version of this argument in the [FAQ](/faq) and the video below.
 
 |                                       | Notion          | Macro |
 | :------------------------------------ | :-------------: | :---: |
-| Markdown-native docs                  | ✅              | ✅    |
-| Tasks                                 | Build your own from databases | Purpose-built |
-| CRM                                   | Build your own from databases | Purpose-built |
-| Email and channels                    | —               | ✅    |
-| Freeform databases                    | ✅              | [Properties](/concepts/properties) on purpose-built blocks |
+| Markdown-native docs                  | ✓              | ✓    |
+| Tasks                                 | Build your own from databases | Built in |
+| CRM                                   | Build your own from databases | Built in |
+| Email and channels                    | —               | ✓    |
+| Freeform databases                    | ✓              | [Properties](/concepts/properties) on built-in blocks |
 | Agent access to your workspace        | Rate-limited API | One unified search index |
 
 <iframe src="https://www.youtube.com/embed/hyU1XYmxkYM" title="What We Learned from Notion" frameborder="0" className="w-full aspect-video rounded-xl" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen />
 
-For the docs themselves, the import is clean — Macro docs are markdown-native, so Notion pages translate directly:
+The docs import is clean because both sides are markdown-native:
 
 1. Go to **Settings → Connectors** and connect Notion.
-2. Open an agent chat (<kbd>c</kbd> + <kbd>a</kbd>) and ask it to import — for example:
+2. Open an agent chat (<kbd>c</kbd> + <kbd>a</kbd>) and ask it to import. For example:
 
 ```text
 Import my Notion docs from the "Engineering" workspace as Macro docs.
 Keep the folder structure and skip anything archived.
 ```
 
-The agent reads pages through the Notion connector and recreates them as [Macro documents](/product/docs). For structured Notion databases, consider whether each one is really tasks, CRM records, or a doc with [properties](/concepts/properties) — Macro has purpose-built blocks for the things people usually force into Notion databases.
+The agent reads pages through the Notion connector and recreates them as [Macro documents](/product/docs). For structured Notion databases, think about whether each one is really tasks, CRM records, or a doc with [properties](/concepts/properties). Macro has dedicated blocks for most of the things people build in Notion databases.
 
 You can also keep Notion connected indefinitely so agents can reference legacy content without migrating it.
 
@@ -93,27 +93,27 @@ You can also keep Notion connected indefinitely so agents can reference legacy c
   />
 </Frame>
 
-The chat itself is deliberately familiar — channels, threads, emoji. What changes is the noise level and what a channel can do. Replies show inline for the first few, so you're not clicking into threads to follow a conversation, and the result reads more like a forum than a firehose. Channels also share an inbox with your email, so there's one place to catch up instead of two.
+We didn't change too much vs. Slack: channels, threads, and emoji all work the way you expect. The main thing we changed is making channels less noisy and more focused for technical discussions. The first few replies in a thread show inline, so you can follow a conversation without clicking into it, and a busy channel reads more like a forum than a firehose. Channels also share an inbox with your email, so there's one place to catch up.
 
-The bigger difference is [channel-based sharing](/permissions): [@mention](/concepts/mentions) a doc or task in a channel and every member gets access to it automatically — no "request access" dance between your chat tool and your docs tool, because they're the same tool.
+Channels also handle [sharing](/permissions): [@mention](/concepts/mentions) a doc or task in a channel and every member gets access to it automatically. There's no "request access" step because chat and docs are the same tool.
 
 |                                          | Slack | Macro |
 | :--------------------------------------- | :---: | :---: |
-| Channels, threads, emoji                 | ✅    | ✅    |
-| Inline thread replies (forum-style reading) | —  | ✅    |
-| One inbox shared with your email         | —     | ✅    |
-| @mention a doc or task to share it automatically | — | ✅ |
-| External channels with customers (Slack Connect) | ✅ | Keep Slack connected as an MCP connector |
+| Channels, threads, emoji                 | ✓    | ✓    |
+| Inline thread replies (forum-style reading) | —  | ✓    |
+| One inbox shared with your email         | —     | ✓    |
+| @mention a doc or task to share it automatically | — | ✓ |
+| External channels with customers (Slack Connect) | ✓ | Keep Slack connected as an MCP connector |
 
 <iframe src="https://www.youtube.com/embed/1gDOXUxHo0U" title="What Macro learned from Slack/Superhuman" frameborder="0" className="w-full aspect-video rounded-xl" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen />
 
 To switch:
 
 1. Create a channel per team or project (<kbd>c</kbd> + <kbd>m</kbd>).
-2. Add people by email — they don't need a Macro account yet to be included.
-3. Lean on @mentions to share docs and tasks as you discuss them.
+2. Add people by email. They don't need a Macro account yet to be included.
+3. Use @mentions to share docs and tasks as you discuss them.
 
-If you're not ready to leave Slack — archives, Slack Connect with customers — connect it under **Settings → Connectors** as an MCP connector so agents in Macro can still search it. Many teams run Macro for internal communication and keep Slack only for external channels during the transition.
+If you're not ready to leave Slack (archives, Slack Connect with customers), connect it under **Settings → Connectors** as an MCP connector so agents in Macro can still search it. Many teams run Macro for internal communication and keep Slack only for external channels during the transition.
 
 ## From Linear
 
@@ -124,22 +124,22 @@ If you're not ready to leave Slack — archives, Slack Connect with customers �
   />
 </Frame>
 
-Macro's tasks are openly Linear-inspired: status, priority, assignee, keyboard-first, and a [GitHub integration](/integrations/github) that covers the workflow you're used to — copy a branch name from a task, and it moves through In Progress → In Review → Done as you branch, open the PR, and merge.
+In building Macro Tasks we were heavily inspired by Linear: status, priority, assignee, keyboard-first, and a [GitHub integration](/integrations/github) that covers the workflow you're used to. Copy a branch name from a task and it moves through In Progress, In Review, and Done as you branch, open the PR, and merge.
 
-The difference is adjacency. Tasks live next to your email, channels, and docs, so you can turn an email or a channel message into a task in one click, and non-engineers see engineering work without needing a seat in a separate tool. Fields are minimal by default, with more available [if you want it](/concepts/properties) — less workflow configuration to maintain.
+The difference is that tasks live in the same app as your email, channels, and docs. You can turn an email or a channel message into a task in one click, and non-engineers can see engineering work without a seat in a separate tool. Fields are minimal by default, with more available [if you want them](/concepts/properties), so there's less workflow configuration to maintain.
 
 |                                          | Linear | Macro |
 | :--------------------------------------- | :----: | :---: |
-| Status, priority, assignee, keyboard-first | ✅   | ✅    |
-| [GitHub integration](/integrations/github) — branch, PR, and merge move the task | ✅ | ✅ |
-| Tasks next to your email, channels, and docs | —  | ✅    |
-| Turn an email or channel message into a task in one click | — | ✅ |
+| Status, priority, assignee, keyboard-first | ✓   | ✓    |
+| [GitHub integration](/integrations/github): branch, PR, and merge move the task | ✓ | ✓ |
+| Tasks in the same app as your email, channels, and docs | —  | ✓    |
+| Turn an email or channel message into a task in one click | — | ✓ |
 | Non-engineers see engineering work       | Separate seat in a separate tool | Same workspace |
-| Deep workflow configuration (cycles, triage, custom flows) | ✅ | Minimal by default, [properties](/concepts/properties) when you want them |
+| Deep workflow configuration (cycles, triage, custom flows) | ✓ | Minimal by default, [properties](/concepts/properties) when you want them |
 
 <iframe src="https://www.youtube.com/embed/nHxqE2mVKrA" title="What We Learned from Linear" frameborder="0" className="w-full aspect-video rounded-xl" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen />
 
-For migration, most teams simply recreate their open work — finished issues rarely justify carrying over. If you do want history, connect Linear under **Settings → Connectors** and have an agent bring open issues across.
+For migration, most teams just recreate their open work; finished issues rarely justify carrying over. If you do want history, connect Linear under **Settings → Connectors** and have an agent bring open issues across.
 
 ## From ClickUp
 
@@ -150,46 +150,46 @@ For migration, most teams simply recreate their open work — finished issues ra
   />
 </Frame>
 
-ClickUp tries to be everything — tasks, docs, chat, goals, whiteboards — through a deep stack of spaces, folders, lists, and custom statuses you configure yourself. Macro covers the same ground, but as purpose-built [tasks](/product/tasks), [docs](/product/docs), [channels](/product/channels), and [CRM](/product/crm) that share one data model instead of one configurable database. The trade is less setup and fewer knobs for tools that already behave the way each job needs. Tasks keep the essentials — status, priority, assignee, [properties](/concepts/properties) when you want them — and your [agents](/product/agents) can read across all of it as unified context.
+ClickUp covers tasks, docs, chat, goals, and whiteboards through a deep stack of spaces, folders, lists, and custom statuses that you configure yourself. Macro covers the same ground with dedicated [tasks](/product/tasks), [docs](/product/docs), [channels](/product/channels), and [CRM](/product/crm) that share one data model. There's less setup and fewer knobs because each tool already behaves the way its job needs. Tasks keep the essentials (status, priority, assignee, and [properties](/concepts/properties) when you want them), and [agents](/product/agents) can read across all of it as one context.
 
-The biggest day-to-day change is that work stops living in a silo: tasks sit next to your email, channels, and docs, so you can turn a message or an email into a task in one click, and @mentioning a task in a channel shares it automatically.
+The biggest day-to-day change is that tasks live in the same app as your email, channels, and docs. You can turn a message or an email into a task in one click, and @mentioning a task in a channel shares it automatically.
 
 |                                          | ClickUp | Macro |
 | :--------------------------------------- | :-----: | :---: |
-| Tasks, docs, chat                        | ✅      | ✅    |
-| Setup required                           | Spaces, folders, lists, custom statuses | Purpose-built defaults |
-| CRM                                      | Configure it yourself | [Purpose-built](/product/crm) |
-| Email                                    | —       | ✅    |
-| One data model, one search index         | —       | ✅    |
-| [Agents](/product/agents) with your whole workspace as context | — | ✅ |
+| Tasks, docs, chat                        | ✓      | ✓    |
+| Setup required                           | Spaces, folders, lists, custom statuses | Works out of the box |
+| CRM                                      | Configure it yourself | [Built in](/product/crm) |
+| Email                                    | —       | ✓    |
+| One data model, one search index         | —       | ✓    |
+| [Agents](/product/agents) with your whole workspace as context | — | ✓ |
 
 <iframe src="https://www.youtube.com/embed/gxJquVXRX5A" title="Tasks on Macro" frameborder="0" className="w-full aspect-video rounded-xl" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen />
 
 To switch:
 
-1. Recreate your active lists as Macro tasks — most teams skip closed work, since finished ClickUp tasks rarely earn their migration.
+1. Recreate your active lists as Macro tasks. Most teams skip closed work.
 2. If you want history or a gradual cutover, connect ClickUp under **Settings → Connectors** as an MCP connector and ask an agent to bring open tasks across.
-3. Move ClickUp Docs over the same way Notion pages come in — they're markdown-native, so an agent can recreate them as [Macro documents](/product/docs).
+3. Move ClickUp Docs the same way Notion pages come in: they're markdown-native, so an agent can recreate them as [Macro documents](/product/docs).
 
 ## Everything else
 
-Any tool with an MCP server can be connected under **Settings → Connectors**, which makes it readable to your agents — useful both as a migration path (ask an agent to copy content over) and as a permanent bridge for tools you keep. And your files largely migrate themselves: email attachments are auto-extracted into [file storage](/product/folders), and anything you drag into a channel or doc is imported and searchable.
+Any tool with an MCP server can be connected under **Settings → Connectors**, which makes it readable to your agents. That works as a migration path (ask an agent to copy content over) or as a permanent bridge for tools you keep. Files mostly migrate themselves: email attachments are extracted into [file storage](/product/folders) automatically, and anything you drag into a channel or doc is imported and searchable.
 
 ## Macro vs. the world
 
-The full picture, side by side. Most of these tools have an AI assistant of their own — the difference is that Macro's [agents](/product/agents) see everything below as one context, instead of one silo at a time.
+Here's the full picture side by side. Most of these tools have their own AI assistant; the difference is that Macro's [agents](/product/agents) see everything below as one context instead of one tool at a time.
 
 |                                   | Macro | Superhuman | Notion | Slack | Linear | ClickUp |
 | :-------------------------------- | :---: | :--------: | :----: | :---: | :----: | :-----: |
-| [Email](/product/email)           | ✅    | ✅         | —      | —     | —      | —       |
-| [Channels](/product/channels)     | ✅    | —          | —      | ✅    | —      | ✅      |
-| [Tasks](/product/tasks)           | ✅    | —          | Via databases | — | ✅   | ✅      |
-| [Docs](/product/docs)             | ✅    | —          | ✅     | —     | —      | ✅      |
-| [CRM](/product/crm)               | ✅    | —          | Via databases | — | —    | Via setup |
-| [File storage](/product/folders)  | ✅    | —          | Attachments | Attachments | — | Attachments |
-| [Calls](/product/calls)           | ✅    | —          | —      | Huddles | —    | —       |
-| One inbox for email, messages, tasks, and @mentions | ✅ | — | — | — | — | —    |
-| [Agents](/product/agents) with all of the above as context | ✅ | — | — | — | — | — |
+| [Email](/product/email)           | ✓    | ✓         | —      | —     | —      | —       |
+| [Channels](/product/channels)     | ✓    | —          | —      | ✓    | —      | ✓      |
+| [Tasks](/product/tasks)           | ✓    | —          | Via databases | — | ✓   | ✓      |
+| [Docs](/product/docs)             | ✓    | —          | ✓     | —     | —      | ✓      |
+| [CRM](/product/crm)               | ✓    | —          | Via databases | — | —    | Via setup |
+| [File storage](/product/folders)  | ✓    | —          | Attachments | Attachments | — | Attachments |
+| [Calls](/product/calls)           | ✓    | —          | —      | Huddles | —    | —       |
+| One inbox for email, messages, tasks, and @mentions | ✓ | — | — | — | — | —    |
+| [Agents](/product/agents) with all of the above as context | ✓ | — | — | — | — | — |
 
 <iframe src="https://www.youtube.com/embed/Fn5hdzXsQQ8" title="Macro Product Demo" frameborder="0" className="w-full aspect-video rounded-xl" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen />
 


### PR DESCRIPTION
## Summary

A writing-style pass across the docs to cut the "LLM-ish" tone and bring pages closer to how the FAQ is written: plain language, occasional first person, opinionated where it should be, and far fewer em dashes. Also swaps the emoji checkmarks in the comparison tables for plain ✓.

This follows on from #3992 (comparison tables + demo videos), which merged before these style commits were pushed.

## What changed

- **Checkmarks**: green ✅ emoji in the Switch to Macro comparison tables are now plain ✓.
- **Voice**: removed em-dash overuse, "it's not X, it's Y" constructions, fragment-colon openers, and rhetorical flourishes ("reads like a forum, not a firehose", "the difference is adjacency", "purpose-built", etc.) across every hand-written page.
- **Switch to Macro**: each migration section now argues the way the corresponding FAQ answer does — first person, concrete comparisons ("looks more like Reddit", "just a wrapper on Gmail", "databases are the wrong level of abstraction"), and the "unified context" framing.
- **Touched pages**: `index`, `getting-started`, `switch-to-macro`, `faq`, `concepts/{blocks,mentions,properties}`, `product/{agents,calls,canvas,channels,crm,docs,email,folders,inbox,search,tasks,unified-memory}`, `account/{teams,billing}`, `apps`, `permissions`, `support`, `AI/recipes`, `AI/mcp/overview`.
- **Left alone**: the `snippets` page (already in the right voice), auto-generated MCP tool pages and changelog entries (PR titles pulled from GitHub Releases — no authored prose).

## Verification

`mint broken-links` passes with no broken links.

https://claude.ai/code/session_01DvJpjuUmXNBCNe9mXi9pw1

---
_Generated by [Claude Code](https://claude.ai/code/session_01DvJpjuUmXNBCNe9mXi9pw1)_