### PR TITLE
fix(email): remove refresh subtext from inbox connected toast

### DIFF
--- a/js/app/packages/app/component/EmailAuth.tsx
+++ b/js/app/packages/app/component/EmailAuth.tsx
@@ -123,9 +123,7 @@ function EmailLinkCallback(props: Pick<EmailAuthParams, 'successPath'>) {
         // callback so the inbox panel shows it immediately on return rather
         // than flashing a stale list until its own refetch lands.
         await query.refetch();
-        toast.success('Inbox connected', {
-          subtext: 'Syncing emails — refresh to see them',
-        });
+        toast.success('Inbox connected');
         navigateToAccountSettings();
       },
       async (err) => {


### PR DESCRIPTION
Drop the "Syncing emails — refresh to see them" subtext from the inbox connected toast.
