### PR TITLE
fix(mobile): make settings nav consistent with soup tabs

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/soup-view-tabs.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-view-tabs.tsx
@@ -15,12 +15,13 @@ import { MobileFilterDrawer } from '@app/component/next-soup/soup-view/filters-b
 import { useSoupView } from '@app/component/next-soup/soup-view/soup-view-context';
 import { useSplitPanelOrThrow } from '@app/component/split-layout/layoutUtils';
 import { isListViewID, type ListView } from '@app/constants/list-views';
-import { type TabItem, Tabs } from '@core/component/Tabs';
+import { MobileTabs } from '@core/component/MobileTabs';
+import type { TabItem } from '@core/component/Tabs';
 import { TabsInset } from '@core/component/TabsInset';
 import { TabsInsetDropdown } from '@core/component/TabsInsetDropdown';
 import { useUserContext } from '@core/context/user';
 import { useIsTeamAdmin } from '@queries/team/teams';
-import { batch, createEffect, createMemo, For, Match, Switch } from 'solid-js';
+import { batch, createMemo, For, Match, Switch } from 'solid-js';
 
 /** Views that have tab definitions. Shared between VIEW_TAB_LISTS and VIEW_TAB_PRESETS. */
 export type TabbedListView = Extract<
@@ -310,42 +311,12 @@ const MobileViewTabs = (props: { view: TabbedListView }) => {
   const list = () =>
     filterTabsForUser(props.view, VIEW_TAB_LISTS[props.view], isTeamAdmin());
 
-  let wrapperRef: HTMLDivElement | undefined;
-
-  createEffect(() => {
-    activeTab();
-    list();
-    if (!wrapperRef) return;
-    queueMicrotask(() => {
-      const scrollEl = wrapperRef?.firstElementChild as HTMLElement | null;
-      const active = scrollEl?.querySelector(
-        '[data-checked]'
-      ) as HTMLElement | null;
-      if (!scrollEl || !active) return;
-      const itemLeft = active.offsetLeft;
-      const itemRight = itemLeft + active.offsetWidth;
-      const viewRight = scrollEl.scrollLeft + scrollEl.clientWidth;
-      if (itemLeft < scrollEl.scrollLeft) {
-        scrollEl.scrollTo({ left: itemLeft, behavior: 'smooth' });
-      } else if (itemRight > viewRight) {
-        scrollEl.scrollTo({
-          left: itemRight - scrollEl.clientWidth,
-          behavior: 'smooth',
-        });
-      }
-    });
-  });
-
   return (
-    <div ref={wrapperRef} class="h-full">
-      <Tabs
-        list={list()}
-        value={activeTab()}
-        defaultValue={VIEW_TAB_PRESETS[props.view].default}
-        onChange={(value) => applyTabPreset(props.view, value)}
-        indicatorPosition="top"
-        class="**:data-indicator:h-0.75 overflow-x-auto scrollbar-hidden [&>div]:w-max"
-      />
-    </div>
+    <MobileTabs
+      list={list()}
+      value={activeTab()}
+      defaultValue={VIEW_TAB_PRESETS[props.view].default}
+      onChange={(value) => applyTabPreset(props.view, value)}
+    />
   );
 };

--- a/js/app/packages/app/component/settings/Settings.tsx
+++ b/js/app/packages/app/component/settings/Settings.tsx
@@ -10,6 +10,7 @@ import { Admin } from './Admin';
 import { Appearance } from './Appearance';
 import { useHasPermission } from '@core/context/user';
 import { PERMISSION_IDS } from '@core/constant/permissions';
+import { MobileTabs } from '@core/component/MobileTabs';
 import { TabsInset } from '@core/component/TabsInset';
 import { TabsInsetDropdown } from '@core/component/TabsInsetDropdown';
 import { Account } from './Account';
@@ -156,14 +157,16 @@ function SettingsPanel(props: SettingsPanelProps) {
 
   function BottomTabs() {
     return (
-    <div class="bg-surface border-t border-edge-muted h-11 shrink-0 px-1 flex items-center">
-      <TabsInset
-        list={settingsTabs()}
-        value={activeTabId()}
-        defaultValue="Appearance"
-        onChange={handleTabChange}
-      />
-    </div>
+      <div class="bg-surface border-t border-edge-muted h-11 shrink-0 px-1 flex">
+        <div class="flex-1 min-w-0 h-full">
+          <MobileTabs
+            list={settingsTabs()}
+            value={activeTabId()}
+            defaultValue="Appearance"
+            onChange={handleTabChange}
+          />
+        </div>
+      </div>
     );
   }
 

--- a/js/app/packages/core/component/MobileTabs.tsx
+++ b/js/app/packages/core/component/MobileTabs.tsx
@@ -1,0 +1,59 @@
+import { cn } from '@ui';
+import { createEffect } from 'solid-js';
+import { type TabItem, Tabs } from './Tabs';
+
+/**
+ * Horizontally-scrollable tab bar for narrow/mobile layouts: the base {@link Tabs}
+ * with a thin top indicator that keeps the active tab scrolled into view. Generic
+ * and domain-free — wire it to whatever `list`/`value`/`onChange` you need.
+ */
+export const MobileTabs = (props: {
+  list: TabItem[];
+  value?: string;
+  defaultValue?: string;
+  onChange?: (value: string) => void;
+  class?: string;
+}) => {
+  let wrapperRef: HTMLDivElement | undefined;
+
+  // Keep the active tab scrolled into view as the selection or list changes.
+  createEffect(() => {
+    props.value;
+    props.list;
+    if (!wrapperRef) return;
+    queueMicrotask(() => {
+      const scrollEl = wrapperRef?.firstElementChild as HTMLElement | null;
+      const active = scrollEl?.querySelector(
+        '[data-checked]'
+      ) as HTMLElement | null;
+      if (!scrollEl || !active) return;
+      const itemLeft = active.offsetLeft;
+      const itemRight = itemLeft + active.offsetWidth;
+      const viewRight = scrollEl.scrollLeft + scrollEl.clientWidth;
+      if (itemLeft < scrollEl.scrollLeft) {
+        scrollEl.scrollTo({ left: itemLeft, behavior: 'smooth' });
+      } else if (itemRight > viewRight) {
+        scrollEl.scrollTo({
+          left: itemRight - scrollEl.clientWidth,
+          behavior: 'smooth',
+        });
+      }
+    });
+  });
+
+  return (
+    <div ref={wrapperRef} class="h-full">
+      <Tabs
+        list={props.list}
+        value={props.value}
+        defaultValue={props.defaultValue}
+        onChange={props.onChange}
+        indicatorPosition="top"
+        class={cn(
+          '**:data-indicator:h-0.75 overflow-x-auto scrollbar-hidden [&>div]:w-max',
+          props.class
+        )}
+      />
+    </div>
+  );
+};


### PR DESCRIPTION
Settings panel on mobile is stylistically inconsistent with other blocks. Refactor soup's mobile tabs component so settings can use it too.