### PR TITLE
feat(email): flip inbox Only action to All when sole selection

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/inbox-picker.test.ts
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/inbox-picker.test.ts
@@ -1,0 +1,56 @@
+import { createRoot, createSignal } from 'solid-js';
+import { describe, expect, it, vi } from 'vitest';
+import { useInboxPicker } from './inbox-picker';
+
+vi.mock('@queries/email/link', () => ({
+  useEmailLinksQuery: () => ({
+    data: {
+      links: [
+        { id: 'a', email_address: 'a@example.com', photo_url: null },
+        { id: 'b', email_address: 'b@example.com', photo_url: null },
+        { id: 'c', email_address: 'c@example.com', photo_url: null },
+      ],
+    },
+  }),
+}));
+vi.mock('@core/component/inboxIcon', () => ({ inboxIconProps: () => ({}) }));
+vi.mock('@core/component/UserIcon', () => ({ UserIcon: () => null }));
+
+const setup = (initial?: string[]) =>
+  createRoot((dispose) => {
+    const [selectedIds, setSelectedIds] = createSignal<string[] | undefined>(
+      initial
+    );
+    const picker = useInboxPicker({ selectedIds, setSelectedIds });
+    return { picker, selectedIds, dispose };
+  });
+
+describe('useInboxPicker selectOnly', () => {
+  it('narrows to the clicked inbox from the all-selected default', () => {
+    const { picker, selectedIds, dispose } = setup(undefined);
+    picker.selectOnly('a');
+    expect(selectedIds()).toEqual(['a']);
+    dispose();
+  });
+
+  it('flips back to all when the clicked inbox is already the sole selection', () => {
+    const { picker, selectedIds, dispose } = setup(['a']);
+    picker.selectOnly('a');
+    expect(selectedIds()).toBeUndefined();
+    dispose();
+  });
+
+  it('narrows to a different inbox when another is the sole selection', () => {
+    const { picker, selectedIds, dispose } = setup(['a']);
+    picker.selectOnly('b');
+    expect(selectedIds()).toEqual(['b']);
+    dispose();
+  });
+
+  it('narrows to the clicked inbox from a multi-selection that includes it', () => {
+    const { picker, selectedIds, dispose } = setup(['a', 'b']);
+    picker.selectOnly('a');
+    expect(selectedIds()).toEqual(['a']);
+    dispose();
+  });
+});

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/inbox-picker.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/inbox-picker.tsx
@@ -9,8 +9,9 @@ import type { SearchableOption } from './searchable-multi-select';
  * toolbar selector, search facet). The selection is tri-state: `undefined` =
  * all inboxes (default — every box checked), `[]` = explicitly none, a
  * subset = those. Re-checking every inbox collapses back to the default, so
- * a checked box always means the inbox is included. Callers own where the
- * selection lives and how the value is rendered.
+ * a checked box always means the inbox is included. "Only" on the sole
+ * selected inbox flips back to all (Datadog log-explorer pattern). Callers
+ * own where the selection lives and how the value is rendered.
  */
 export function useInboxPicker(args: {
   selectedIds: Accessor<string[] | undefined>;
@@ -36,13 +37,20 @@ export function useInboxPicker(args: {
       .sort((a, b) => a.label.localeCompare(b.label))
   );
 
+  const activeIds = () => args.selectedIds() ?? options().map((o) => o.id);
+
   return {
     options,
     hasMultiple: () => options().length > 1,
-    activeIds: () => args.selectedIds() ?? options().map((o) => o.id),
+    activeIds,
     onChange: (ids: string[]) =>
       args.setSelectedIds(ids.length === options().length ? undefined : ids),
-    selectOnly: (id: string) => args.setSelectedIds([id]),
+    selectOnly: (id: string) => {
+      const active = activeIds();
+      args.setSelectedIds(
+        active.length === 1 && active[0] === id ? undefined : [id]
+      );
+    },
     isDefault: () => args.selectedIds() === undefined,
     reset: () => args.setSelectedIds(undefined),
   };

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/searchable-multi-select.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/searchable-multi-select.tsx
@@ -53,7 +53,11 @@ type SearchableMultiSelectProps = {
   listboxClass?: string;
   /** Keep `options` in their given order instead of pinning selected first. */
   preserveOrder?: boolean;
-  /** Render a per-row "Only" action that narrows the selection to that row. */
+  /**
+   * Render a per-row "Only" action that narrows the selection to that row.
+   * When the row is already the sole active one the label flips to "All" and
+   * the handler is expected to restore the full selection.
+   */
   onOnly?: (id: string) => void;
   /** Non-toggling action row appended after the options. */
   action?: SearchableSelectAction;
@@ -65,6 +69,7 @@ type SearchableMultiSelectProps = {
 const SearchableMultiSelectItem = (itemProps: {
   item: CollectionNode<SearchableOption>;
   onOnly?: (id: string) => void;
+  isSoleActive?: (id: string) => boolean;
 }) => (
   <Combobox.Item
     item={itemProps.item}
@@ -112,7 +117,9 @@ const SearchableMultiSelectItem = (itemProps: {
             onOnly()(itemProps.item.rawValue.id);
           }}
         >
-          Only
+          {itemProps.isSoleActive?.(itemProps.item.rawValue.id)
+            ? 'All'
+            : 'Only'}
         </button>
       )}
     </Show>
@@ -123,6 +130,7 @@ const VirtualizedListbox = (props: {
   options: SearchableOption[];
   class?: string;
   onOnly?: (id: string) => void;
+  isSoleActive?: (id: string) => boolean;
 }) => {
   let handle: VirtualizerHandle | undefined;
   return (
@@ -142,7 +150,11 @@ const VirtualizedListbox = (props: {
           itemSize={ITEM_HEIGHT}
         >
           {(item) => (
-            <SearchableMultiSelectItem item={item} onOnly={props.onOnly} />
+            <SearchableMultiSelectItem
+              item={item}
+              onOnly={props.onOnly}
+              isSoleActive={props.isSoleActive}
+            />
           )}
         </Virtualizer>
       )}
@@ -226,6 +238,11 @@ export const SearchableMultiSelect = (props: SearchableMultiSelectProps) => {
     props.onChange(selected.map((o) => o.id));
   };
 
+  const isSoleActive = (id: string) => {
+    const ids = props.activeIds();
+    return ids.length === 1 && ids[0] === id;
+  };
+
   return (
     <Combobox<SearchableOption>
       multiple
@@ -281,6 +298,7 @@ export const SearchableMultiSelect = (props: SearchableMultiSelectProps) => {
                   options={displayOptions()}
                   class={props.listboxClass}
                   onOnly={props.onOnly}
+                  isSoleActive={isSoleActive}
                 />
               </Show>
             </div>


### PR DESCRIPTION
Clicking "Only" on an inbox that is already the sole selection now flips back to all inboxes, and the row action label reads "All" in that state. Applies to both the mail toolbar inbox selector and the search inbox facet via the shared picker hook.
