### PR TITLE
Migrate from Blacksmith to Namespace for CI runners and caching

### DIFF
--- a/.github/actions/deploy-cloud-storage-pulumi/action.yml
+++ b/.github/actions/deploy-cloud-storage-pulumi/action.yml
@@ -6,11 +6,12 @@ inputs:
     description: 'Whether to setup docker'
     required: false
     default: 'true'
-  use-blacksmith-builder:
+  use-namespace-builder:
     description: >-
-      Use a Blacksmith buildkit builder whose layer cache lives on a per-Dockerfile
-      sticky disk (persists the heavy base layers across runs). Only valid on
-      Blacksmith runners; defaults to the stock docker/setup-buildx-action.
+      Use a Namespace remote Docker builder (persistent layer cache, so heavy
+      bases like LibreOffice/Collabora stay warm across deploys). Requires the
+      nsc CLI (preinstalled on Namespace runners); defaults to the stock
+      docker/setup-buildx-action.
     required: false
     default: 'false'
   use-lfs:
@@ -56,11 +57,11 @@ inputs:
     required: false
     default: ''
   prebuilt-binaries-tar:
-    description: 'Optional path to a prebuilt-binaries.tar.gz already present on disk (e.g. a Blacksmith sticky-disk handoff). When set, takes precedence over prebuilt-binaries-artifact and skips the GitHub artifact download.'
+    description: 'Optional path to a prebuilt-binaries.tar.gz already present on disk (e.g. downloaded from Namespace artifact storage). When set, takes precedence over prebuilt-binaries-artifact and skips the GitHub artifact download.'
     required: false
     default: ''
   lambda-artifacts-tar:
-    description: 'Optional path to a lambda-artifacts.tar.gz already present on disk (e.g. a Blacksmith sticky-disk handoff). When set, takes precedence over lambda-artifacts and skips the GitHub artifact download.'
+    description: 'Optional path to a lambda-artifacts.tar.gz already present on disk (e.g. downloaded from Namespace artifact storage). When set, takes precedence over lambda-artifacts and skips the GitHub artifact download.'
     required: false
     default: ''
   cloud-storage-service-name:
@@ -102,9 +103,8 @@ runs:
         # Prefer an on-disk tar (sticky-disk handoff); fall back to the downloaded artifact.
         src="${TAR_PATH:-rust/cloud-storage/prebuilt-artifact/prebuilt-binaries.tar.gz}"
         if [[ ! -f "$src" ]]; then
-          echo "::error::prebuilt binaries tar missing at $src — the handoff sticky disk cloned without the build job's snapshot. Re-run this deploy job (a fresh clone usually resolves it); if it persists, re-run the service's build job too."
+          echo "::error::prebuilt binaries tar missing at $src — the handoff download/extract chain broke upstream; check this job's download step and the build job's upload receipt."
           echo "--- $(dirname "$src") contents ---"; ls -la "$(dirname "$src")" || true
-          echo "--- handoff mounts ---"; mount | grep -i handoff || true
           exit 1
         fi
         echo "handoff receipt: $(sha256sum "$src" | cut -d' ' -f1) ($(stat -c%s "$src") bytes)"
@@ -127,9 +127,8 @@ runs:
         # Prefer an on-disk tar (sticky-disk handoff); fall back to the downloaded artifact.
         src="${TAR_PATH:-rust/cloud-storage/lambda-artifact/lambda-artifacts.tar.gz}"
         if [[ ! -f "$src" ]]; then
-          echo "::error::lambda artifacts tar missing at $src — the handoff sticky disk cloned without the build job's snapshot. Re-run this deploy job (a fresh clone usually resolves it); if it persists, re-run the service's build job too."
+          echo "::error::lambda artifacts tar missing at $src — the handoff download/extract chain broke upstream; check this job's download step and the build job's upload receipt."
           echo "--- $(dirname "$src") contents ---"; ls -la "$(dirname "$src")" || true
-          echo "--- handoff mounts ---"; mount | grep -i handoff || true
           exit 1
         fi
         echo "handoff receipt: $(sha256sum "$src" | cut -d' ' -f1) ($(stat -c%s "$src") bytes)"
@@ -161,17 +160,17 @@ runs:
         AWS_SECRET_ACCESS_KEY: ${{ inputs.aws-secret-key }}
       run: .github/scripts/build-cloud-storage-lambdas.sh
 
-    # setup docker -- a Blacksmith builder keeps the buildkit layer cache on a
-    # per-Dockerfile sticky disk (so heavy bases like LibreOffice/Collabora stay
-    # warm across runs instead of re-pulling ~hundreds of MB from ECR each time);
+    # setup docker -- a Namespace remote builder keeps a persistent buildkit
+    # layer cache (so heavy bases like LibreOffice/Collabora stay warm across
+    # runs instead of re-pulling ~hundreds of MB from ECR each time);
     # otherwise the stock buildx builder. Pulumi's docker-build provider uses
     # whichever is set as the default builder.
-    - name: Set up Blacksmith Docker builder
-      if: ${{ inputs.use-docker == 'true' && inputs.use-blacksmith-builder == 'true' }}
-      uses: useblacksmith/setup-docker-builder@v1
+    - name: Set up Namespace Docker builder
+      if: ${{ inputs.use-docker == 'true' && inputs.use-namespace-builder == 'true' }}
+      uses: namespacelabs/nscloud-setup-buildx-action@d059ed7184f0bc7c8b27e8810cea153d02bcc6dd # v0.0.23
 
     - uses: docker/setup-buildx-action@v3
-      if: ${{ inputs.use-docker == 'true' && inputs.use-blacksmith-builder != 'true' }}
+      if: ${{ inputs.use-docker == 'true' && inputs.use-namespace-builder != 'true' }}
 
     # install bun
     - uses: oven-sh/setup-bun@v2

--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -1,9 +1,11 @@
 name: Setup Nix
 description: >-
-  Ensure a working Nix (flakes enabled, systemd daemon) is available on a
-  runner that does not ship Nix preinstalled (e.g. Blacksmith). Idempotent:
-  when /nix is already populated from a sticky disk it only re-initialises the
-  daemon and config rather than reinstalling the store.
+  Ensure a working Nix (flakes enabled, daemon running) is available on a
+  runner that does not ship Nix preinstalled. Idempotent: when /nix is already
+  populated from a cache volume it only re-initialises the daemon and config
+  rather than reinstalling the store. Init-agnostic: uses systemd units when
+  systemd is active (full VMs), otherwise starts nix-daemon directly as a
+  background process (e.g. Namespace runners, where systemd is not active).
 
 inputs:
   extra-substituters:
@@ -26,24 +28,24 @@ runs:
       run: |
         set -euo pipefail
 
-        # When /nix is mounted from a warm sticky disk the store + profiles are
-        # already present, but the systemd unit and /etc/nix config live outside
-        # /nix and are gone on a fresh runner. Detect that case and only repair
-        # the bits that don't persist on the disk.
         nix_bin="/nix/var/nix/profiles/default/bin/nix"
+        daemon_bin="/nix/var/nix/profiles/default/bin/nix-daemon"
 
-        if [[ -x "$nix_bin" ]]; then
-          echo "Found existing Nix store on sticky disk; re-initialising daemon/config only."
+        have_systemd=false
+        if [ -d /run/systemd/system ]; then have_systemd=true; fi
 
+        write_conf() {
           sudo mkdir -p /etc/nix
-          # Recreate the minimal config the Determinate installer would have written.
+          # The minimal config the Determinate installer would have written.
           {
             echo "experimental-features = nix-command flakes"
             echo "trusted-users = root runner"
             echo "build-users-group = nixbld"
           } | sudo tee /etc/nix/nix.conf >/dev/null
+        }
 
-          # The nixbld build group/users do not persist outside /nix; recreate if missing.
+        ensure_nixbld() {
+          # Build group/users do not persist outside /nix; recreate if missing.
           if ! getent group nixbld >/dev/null; then
             sudo groupadd -r nixbld || true
             for i in $(seq 1 10); do
@@ -51,20 +53,54 @@ runs:
                 "nixbld$i" 2>/dev/null || true
             done
           fi
+        }
 
-          # Reinstall the systemd units shipped in the store and start the daemon.
-          if [[ -e /nix/var/nix/profiles/default/lib/systemd/system/nix-daemon.service ]]; then
-            sudo cp /nix/var/nix/profiles/default/lib/systemd/system/nix-daemon.* /etc/systemd/system/ || true
-            sudo systemctl daemon-reload || true
+        start_daemon() {
+          if $have_systemd; then
+            if [[ -e /nix/var/nix/profiles/default/lib/systemd/system/nix-daemon.service ]]; then
+              sudo cp /nix/var/nix/profiles/default/lib/systemd/system/nix-daemon.* /etc/systemd/system/ || true
+              sudo systemctl daemon-reload || true
+            fi
+            sudo systemctl enable --now nix-daemon.socket nix-daemon.service 2>/dev/null || true
           fi
-          sudo systemctl enable --now nix-daemon.socket nix-daemon.service 2>/dev/null || true
+          # Without systemd (or if the unit failed to come up), run the daemon
+          # directly: it is just a process listening on the daemon socket.
+          if ! sudo test -S /nix/var/nix/daemon-socket/socket || ! pgrep -x nix-daemon >/dev/null 2>&1; then
+            sudo mkdir -p /nix/var/nix/daemon-socket
+            sudo rm -f /nix/var/nix/daemon-socket/socket
+            sudo sh -c "nohup '$daemon_bin' >/tmp/nix-daemon.log 2>&1 &"
+            for _ in $(seq 1 30); do
+              if sudo test -S /nix/var/nix/daemon-socket/socket; then break; fi
+              sleep 1
+            done
+            if ! sudo test -S /nix/var/nix/daemon-socket/socket; then
+              echo "nix-daemon failed to come up; log follows:" >&2
+              sudo cat /tmp/nix-daemon.log >&2 || true
+              exit 1
+            fi
+          fi
+        }
+
+        if [[ -x "$nix_bin" ]]; then
+          # Store + profiles persist on the cache volume, but config, build
+          # users, and the daemon live outside /nix and are gone on a fresh
+          # runner. Repair only those.
+          echo "Found existing Nix store on cache volume; re-initialising daemon/config only."
+          write_conf
+          ensure_nixbld
+          start_daemon
         else
-          echo "No Nix store found on sticky disk; performing a full install."
+          echo "No Nix store found on cache volume; performing a full install."
+          init_flag="none"
+          if $have_systemd; then init_flag="systemd"; fi
           curl --http1.1 --retry 5 --retry-delay 5 --retry-all-errors \
             --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | \
-            sh -s -- install linux --no-confirm --init systemd \
+            sh -s -- install linux --no-confirm --init "$init_flag" \
             --extra-conf "experimental-features = nix-command flakes" \
             --extra-conf "trusted-users = root runner"
+          # With --init none the installer lays out the multi-user store but
+          # starts no service; bring the daemon up ourselves.
+          start_daemon
         fi
 
         # Make nix discoverable in subsequent (non-login) steps.
@@ -73,14 +109,20 @@ runs:
         export NIX_REMOTE=daemon
         echo "NIX_REMOTE=daemon" >> "$GITHUB_ENV"
 
-        # Append fallback substituters (e.g. Cachix) so a cold sticky disk pulls
-        # prebuilt artifacts instead of compiling from source.
+        # Append fallback substituters (e.g. Cachix) so a cold cache volume
+        # pulls prebuilt artifacts instead of compiling from source.
         if [[ -n "${EXTRA_SUBSTITUTERS}" ]]; then
           {
             echo "extra-substituters = ${EXTRA_SUBSTITUTERS}"
             echo "extra-trusted-public-keys = ${EXTRA_TRUSTED_PUBLIC_KEYS}"
           } | sudo tee -a /etc/nix/nix.conf >/dev/null
-          sudo systemctl restart nix-daemon.service 2>/dev/null || true
+          if $have_systemd; then
+            sudo systemctl restart nix-daemon.service 2>/dev/null || true
+          else
+            sudo pkill -x nix-daemon 2>/dev/null || true
+            sleep 1
+            start_daemon
+          fi
         fi
 
         "$nix_bin" --version || nix --version

--- a/.github/actions/teardown-nix/action.yml
+++ b/.github/actions/teardown-nix/action.yml
@@ -1,9 +1,9 @@
 name: Teardown Nix
 description: >-
-  Stop the Nix daemon(s) so a /nix sticky disk can be unmounted and committed.
+  Stop the Nix daemon(s) so a /nix cache volume can be unmounted and committed.
   The Determinate Nix daemon runs out of /nix, which keeps the mount busy and
-  makes the Blacksmith sticky-disk commit fail with "target is busy". Run this
-  as the final (always()) step of any job that mounts /nix as a sticky disk.
+  can make the cache-volume commit fail with "target is busy". Run this
+  as the final (always()) step of any job that mounts /nix as a cache volume.
 
 runs:
   using: composite
@@ -18,6 +18,10 @@ runs:
           determinate-nixd.service determinate-nixd.socket; do
           sudo systemctl stop "$unit" 2>/dev/null
         done
+        # Non-systemd runners (e.g. Namespace): the daemon was started
+        # directly by setup-nix; stop it the same way.
+        sudo pkill -x nix-daemon 2>/dev/null
+        sudo pkill -x determinate-nixd 2>/dev/null
         # Backstop: free any remaining handles so the umount can succeed.
         sudo fuser -km /nix 2>/dev/null
         sync

--- a/.github/workflows/deploy-all-services.yml
+++ b/.github/workflows/deploy-all-services.yml
@@ -75,7 +75,7 @@ jobs:
     name: Warm shared binary deps onto sticky disk
     needs: setup
     if: ${{ needs.setup.outputs.binaries != '[]' }}
-    runs-on: namespace-profile-linux-small
+    runs-on: namespace-profile-linux-mid
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
@@ -118,7 +118,7 @@ jobs:
     name: Warm shared lambda deps onto sticky disk
     needs: setup
     if: ${{ needs.setup.outputs.lambdas != '[]' }}
-    runs-on: namespace-profile-linux-small
+    runs-on: namespace-profile-linux-mid
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
@@ -163,7 +163,7 @@ jobs:
     if: ${{ needs.setup.outputs.binaries != '[]' }}
     # Clones the warm /nix cache volume populated by warm-binaries so only
     # each service's own crate compiles (cold volume -> Cachix substitution).
-    runs-on: namespace-profile-linux-small
+    runs-on: namespace-profile-linux-mid
     strategy:
       fail-fast: false
       # No max-parallel: all binary services build concurrently (they only clone
@@ -246,7 +246,7 @@ jobs:
     # of a service's handlers via `nix build .#deploy-lambda-<name>`, cloning the
     # warm lambda /nix disk committed by warm-lambdas. Unchanged handlers are
     # pure cache hits (substituted from the disk/Cachix, no recompile).
-    runs-on: namespace-profile-linux-small
+    runs-on: namespace-profile-linux-mid
     strategy:
       fail-fast: false
       # No max-parallel: runners autoscale, so all lambda services

--- a/.github/workflows/deploy-all-services.yml
+++ b/.github/workflows/deploy-all-services.yml
@@ -75,7 +75,7 @@ jobs:
     name: Warm shared binary deps onto sticky disk
     needs: setup
     if: ${{ needs.setup.outputs.binaries != '[]' }}
-    runs-on: namespace-profile-default
+    runs-on: namespace-profile-linux-small
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
@@ -118,7 +118,7 @@ jobs:
     name: Warm shared lambda deps onto sticky disk
     needs: setup
     if: ${{ needs.setup.outputs.lambdas != '[]' }}
-    runs-on: namespace-profile-default
+    runs-on: namespace-profile-linux-small
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
@@ -163,7 +163,7 @@ jobs:
     if: ${{ needs.setup.outputs.binaries != '[]' }}
     # Clones the warm /nix cache volume populated by warm-binaries so only
     # each service's own crate compiles (cold volume -> Cachix substitution).
-    runs-on: namespace-profile-default
+    runs-on: namespace-profile-linux-small
     strategy:
       fail-fast: false
       # No max-parallel: all binary services build concurrently (they only clone
@@ -246,7 +246,7 @@ jobs:
     # of a service's handlers via `nix build .#deploy-lambda-<name>`, cloning the
     # warm lambda /nix disk committed by warm-lambdas. Unchanged handlers are
     # pure cache hits (substituted from the disk/Cachix, no recompile).
-    runs-on: namespace-profile-default
+    runs-on: namespace-profile-linux-small
     strategy:
       fail-fast: false
       # No max-parallel: runners autoscale, so all lambda services
@@ -319,7 +319,7 @@ jobs:
     if: ${{ needs.setup.outputs.matrix != '[]' }}
     # Deploys via Pulumi + Docker; AWS auth is via explicit static keys
     # (configure-aws-credentials).
-    runs-on: namespace-profile-default
+    runs-on: namespace-profile-linux-small
     # Pin PULUMI_HOME to a fixed path (outside the workspace, which the deploy
     # action's checkout cleans) so the plugins subdir can be backed by a sticky
     # disk. Propagates into the composite action's pulumi step via the job env.

--- a/.github/workflows/deploy-all-services.yml
+++ b/.github/workflows/deploy-all-services.yml
@@ -224,16 +224,15 @@ jobs:
           # Receipt: the deploy job logs the same hash on read.
           echo "handoff receipt: $(sha256sum prebuilt-binaries.tar.gz | cut -d' ' -f1) ($(stat -c%s prebuilt-binaries.tar.gz) bytes)"
 
-      # Handoff to the matching deploy job via a run-scoped GitHub artifact:
-      # strongly consistent across jobs (no snapshot-visibility races) and
-      # provider-portable. Run-scoped name; deploy-services downloads it.
+      # Handoff to the matching deploy job via Namespace artifact storage:
+      # strongly consistent object storage (no snapshot-visibility races),
+      # rides Namespace's network rather than the GitHub artifacts API.
+      # Attempt-scoped path so re-runs never collide with stale uploads.
       - name: Upload handoff artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
-        with:
-          name: handoff-binaries-${{ matrix.service }}
-          path: prebuilt-binaries.tar.gz
-          retention-days: 1
-          overwrite: true
+        shell: bash
+        env:
+          DEST: handoff/${{ github.run_id }}-${{ github.run_attempt }}/${{ matrix.service }}/prebuilt-binaries.tar.gz
+        run: nsc artifact upload prebuilt-binaries.tar.gz "$DEST" --expires_in=24h
 
       - name: Teardown Nix (free cache volume for commit)
         if: always()
@@ -290,14 +289,12 @@ jobs:
           # root; the deploy job logs the same hash on read.
           echo "handoff receipt: $(sha256sum lambda-artifacts.tar.gz | cut -d' ' -f1) ($(stat -c%s lambda-artifacts.tar.gz) bytes)"
 
-      # Handoff via run-scoped GitHub artifact (see build-service-binaries).
+      # Handoff via Namespace artifact storage (see build-service-binaries).
       - name: Upload handoff artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
-        with:
-          name: handoff-lambdas-${{ matrix.service }}
-          path: lambda-artifacts.tar.gz
-          retention-days: 1
-          overwrite: true
+        shell: bash
+        env:
+          DEST: handoff/${{ github.run_id }}-${{ github.run_attempt }}/${{ matrix.service }}/lambda-artifacts.tar.gz
+        run: nsc artifact upload lambda-artifacts.tar.gz "$DEST" --expires_in=24h
 
       - name: Teardown Nix (free cache volume for commit)
         if: always()
@@ -352,6 +349,30 @@ jobs:
           echo "has_binaries=$has_binaries" >> "$GITHUB_OUTPUT"
           echo "has_lambdas=$has_lambdas" >> "$GITHUB_OUTPUT"
 
+      # Pull the handoff tars from Namespace artifact storage into runner.temp
+      # (outside the workspace, which the composite action's checkout cleans).
+      # The composite's tar-path branch handles receipts + the extract guard.
+      - name: Download handoff artifacts
+        if: ${{ steps.check-artifacts.outputs.has_binaries == 'true' || steps.check-artifacts.outputs.has_lambdas == 'true' }}
+        shell: bash
+        env:
+          HAS_BINARIES: ${{ steps.check-artifacts.outputs.has_binaries }}
+          HAS_LAMBDAS: ${{ steps.check-artifacts.outputs.has_lambdas }}
+          BASE: handoff/${{ github.run_id }}-${{ github.run_attempt }}/${{ matrix.service }}
+        run: |
+          set -euo pipefail
+          if ! command -v nsc >/dev/null 2>&1; then
+            echo "::error::nsc CLI not found — this job expects a Namespace runner (or add namespacelabs/nscloud-setup)"
+            exit 1
+          fi
+          mkdir -p "$RUNNER_TEMP/handoff"
+          if [[ "$HAS_BINARIES" == "true" ]]; then
+            nsc artifact download "$BASE/prebuilt-binaries.tar.gz" "$RUNNER_TEMP/handoff/prebuilt-binaries.tar.gz"
+          fi
+          if [[ "$HAS_LAMBDAS" == "true" ]]; then
+            nsc artifact download "$BASE/lambda-artifacts.tar.gz" "$RUNNER_TEMP/handoff/lambda-artifacts.tar.gz"
+          fi
+
       # Cache Pulumi's provider plugins ($PULUMI_HOME/plugins) on a Namespace
       # cache volume. Plugins are version-pinned by infra/ and identical across
       # services. Optimization-only: a cold volume just re-downloads (~45s).
@@ -378,8 +399,9 @@ jobs:
           aws-secret-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           pulumi-access-token: ${{ secrets.PULUMI_ACCESS_TOKEN }}
           pulumi-service-name: ${{ steps.project-name.outputs.project-name }}
-          prebuilt-binaries-artifact: ${{ steps.check-artifacts.outputs.has_binaries == 'true' && format('handoff-binaries-{0}', matrix.service) || '' }}
-          lambda-artifacts: ${{ steps.check-artifacts.outputs.has_lambdas == 'true' && format('handoff-lambdas-{0}', matrix.service) || '' }}
+          use-namespace-builder: 'true'
+          prebuilt-binaries-tar: ${{ steps.check-artifacts.outputs.has_binaries == 'true' && format('{0}/handoff/prebuilt-binaries.tar.gz', runner.temp) || '' }}
+          lambda-artifacts-tar: ${{ steps.check-artifacts.outputs.has_lambdas == 'true' && format('{0}/handoff/lambda-artifacts.tar.gz', runner.temp) || '' }}
           dd-app-key: ${{ secrets.DD_APP_KEY }}
           dd-api-key: ${{ secrets.DD_API_KEY }}
 

--- a/.github/workflows/deploy-all-services.yml
+++ b/.github/workflows/deploy-all-services.yml
@@ -56,7 +56,7 @@ jobs:
           cfg=.github/services-config.json
           # Full list drives deploy-services; the filtered lists keep each build
           # matrix to only the services that actually produce that artifact, so
-          # no Blacksmith job spins up Nix + a sticky disk for nothing.
+          # no build job spins up Nix + a cache volume for nothing.
           services=$(jq -c '.services | keys' "$cfg")
           binaries=$(jq -c '[.services | to_entries[] | select((.value.deploy_binaries // []) | length > 0) | .key]' "$cfg")
           lambdas=$(jq -c '[.services | to_entries[] | select((.value.deploy_lambdas // []) | length > 0) | .key]' "$cfg")
@@ -67,25 +67,26 @@ jobs:
           echo "With binaries: ${binaries}"
           echo "With lambdas: ${lambdas}"
 
-  # Warm the two shared dep closures in parallel, each onto its OWN sticky disk
-  # so the binary and lambda chains never collide on a last-write-wins commit:
-  #   - warm-binaries -> deployCargoArtifacts        on <repo>-nix-store
-  #   - warm-lambdas  -> lambdaDeployCargoArtifacts   on <repo>-nix-lambdas
-  # Each build matrix depends only on its own warm job, so a slow lambda-closure
-  # warm never blocks binary builds and vice versa.
+  # Warm the two shared dep closures in parallel. Each build matrix depends
+  # only on its own warm job, so a slow lambda-closure warm never blocks
+  # binary builds and vice versa. The /nix cache volume is an optimization;
+  # Cachix is the consistency backstop either way.
   warm-binaries:
     name: Warm shared binary deps onto sticky disk
     needs: setup
     if: ${{ needs.setup.outputs.binaries != '[]' }}
-    # NOTE: adjust to a provisioned Blacksmith runner label for the org.
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    runs-on: namespace-profile-default
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      - name: Mount Nix store sticky disk
-        uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88 # v1 before PR #58 (2b7a836c): empty-clone regression suspect
+      # Namespace cache volume backing /nix. Purely an optimization: if the
+      # profile has no cache volumes (or the mount fails), setup-nix performs
+      # a cold install and Cachix substitutes the warm layers — slower, never
+      # wrong. Hence continue-on-error.
+      - name: Mount /nix cache volume
+        continue-on-error: true
+        uses: namespacelabs/nscloud-cache-action@15799a6b54e5765f85b2aac25b3f0df43ed571c0 # v1.4.3
         with:
-          key: ${{ github.repository }}-nix-store
           path: /nix
 
       - name: Setup Nix
@@ -109,7 +110,7 @@ jobs:
           nix build --print-build-logs ".#deployCargoArtifacts"
           echo "Shared release deps realised into /nix/store; committed on job exit."
 
-      - name: Teardown Nix (free sticky disk for commit)
+      - name: Teardown Nix (free cache volume for commit)
         if: always()
         uses: ./.github/actions/teardown-nix
 
@@ -117,15 +118,18 @@ jobs:
     name: Warm shared lambda deps onto sticky disk
     needs: setup
     if: ${{ needs.setup.outputs.lambdas != '[]' }}
-    # NOTE: adjust to a provisioned Blacksmith runner label for the org.
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    runs-on: namespace-profile-default
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      - name: Mount lambda Nix store sticky disk
-        uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88 # v1 before PR #58 (2b7a836c): empty-clone regression suspect
+      # Namespace cache volume backing /nix. Purely an optimization: if the
+      # profile has no cache volumes (or the mount fails), setup-nix performs
+      # a cold install and Cachix substitutes the warm layers — slower, never
+      # wrong. Hence continue-on-error.
+      - name: Mount /nix cache volume
+        continue-on-error: true
+        uses: namespacelabs/nscloud-cache-action@15799a6b54e5765f85b2aac25b3f0df43ed571c0 # v1.4.3
         with:
-          key: ${{ github.repository }}-nix-lambdas
           path: /nix
 
       - name: Setup Nix
@@ -149,7 +153,7 @@ jobs:
           nix build --print-build-logs ".#lambdaDeployCargoArtifacts" ".#callRecordingPreviewFfmpegLayer"
           echo "Shared lambda deps realised into /nix/store; committed on job exit."
 
-      - name: Teardown Nix (free sticky disk for commit)
+      - name: Teardown Nix (free cache volume for commit)
         if: always()
         uses: ./.github/actions/teardown-nix
 
@@ -157,9 +161,9 @@ jobs:
     name: Build ${{ matrix.service }} binaries
     needs: [setup, warm-binaries]
     if: ${{ needs.setup.outputs.binaries != '[]' }}
-    # Runs on Blacksmith, cloning the warm /nix sticky disk committed by
-    # warm-binaries so only each service's own crate compiles.
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    # Clones the warm /nix cache volume populated by warm-binaries so only
+    # each service's own crate compiles (cold volume -> Cachix substitution).
+    runs-on: namespace-profile-default
     strategy:
       fail-fast: false
       # No max-parallel: all binary services build concurrently (they only clone
@@ -171,35 +175,15 @@ jobs:
         with:
           clean: false
 
-      - name: Mount Nix store sticky disk (clones warmed snapshot)
-        uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88 # v1 before PR #58 (2b7a836c): empty-clone regression suspect
+      # Namespace cache volume backing /nix. Purely an optimization: if the
+      # profile has no cache volumes (or the mount fails), setup-nix performs
+      # a cold install and Cachix substitutes the warm layers — slower, never
+      # wrong. Hence continue-on-error.
+      - name: Mount /nix cache volume
+        continue-on-error: true
+        uses: namespacelabs/nscloud-cache-action@15799a6b54e5765f85b2aac25b3f0df43ed571c0 # v1.4.3
         with:
-          key: ${{ github.repository }}-nix-store
           path: /nix
-
-      # Hand the built artifact straight to the matching deploy job over a
-      # Blacksmith sticky disk instead of GitHub Actions artifacts. The keyed
-      # snapshot is committed on job exit and cloned by deploy-services (which
-      # `needs` this job), so the ~96MB closure rides Blacksmith's co-located
-      # NVMe fabric (seconds) rather than the GitHub artifact API (~70s).
-      # Keyed per service + commit SHA: same SHA builds byte-identical (the Nix
-      # build is deploy-env-independent) so concurrent dev/prod runs are safe,
-      # different SHAs get distinct keys, and unused snapshots auto-evict after
-      # 7 days of inactivity.
-      - name: Mount binaries handoff sticky disk
-        uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88 # v1 before PR #58 (2b7a836c): empty-clone regression suspect
-        with:
-          key: ${{ github.repository }}-handoff-binaries-${{ matrix.service }}-${{ github.sha }}
-          path: /handoff-binaries
-
-      # A fresh ext4 sticky disk mounts as root:root; make it writable by the
-      # (possibly non-root) runner so the build step can write the tar. No-op
-      # when the runner already runs as root.
-      - name: Ensure binaries handoff is writable
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [ "$(id -u)" -ne 0 ]; then sudo chown -R "$(id -u):$(id -g)" /handoff-binaries; fi
 
       - name: Setup Nix
         uses: ./.github/actions/setup-nix
@@ -236,15 +220,22 @@ jobs:
           fi
 
           touch prebuilt/.keep
-          # Write straight onto the handoff sticky disk; deploy-services reads it.
-          tar -C prebuilt -czf /handoff-binaries/prebuilt-binaries.tar.gz .
-          # Receipt + flush: prove the handoff snapshot's contents in this
-          # job's log (the deploy job logs the same hash on read) and make
-          # sure bytes are on disk before the post-step commits the snapshot.
-          sync /handoff-binaries/prebuilt-binaries.tar.gz
-          echo "handoff receipt: $(sha256sum /handoff-binaries/prebuilt-binaries.tar.gz | cut -d' ' -f1) ($(stat -c%s /handoff-binaries/prebuilt-binaries.tar.gz) bytes)"
+          tar -C prebuilt -czf prebuilt-binaries.tar.gz .
+          # Receipt: the deploy job logs the same hash on read.
+          echo "handoff receipt: $(sha256sum prebuilt-binaries.tar.gz | cut -d' ' -f1) ($(stat -c%s prebuilt-binaries.tar.gz) bytes)"
 
-      - name: Teardown Nix (free sticky disk for commit)
+      # Handoff to the matching deploy job via a run-scoped GitHub artifact:
+      # strongly consistent across jobs (no snapshot-visibility races) and
+      # provider-portable. Run-scoped name; deploy-services downloads it.
+      - name: Upload handoff artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: handoff-binaries-${{ matrix.service }}
+          path: prebuilt-binaries.tar.gz
+          retention-days: 1
+          overwrite: true
+
+      - name: Teardown Nix (free cache volume for commit)
         if: always()
         uses: ./.github/actions/teardown-nix
 
@@ -256,10 +247,10 @@ jobs:
     # of a service's handlers via `nix build .#deploy-lambda-<name>`, cloning the
     # warm lambda /nix disk committed by warm-lambdas. Unchanged handlers are
     # pure cache hits (substituted from the disk/Cachix, no recompile).
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    runs-on: namespace-profile-default
     strategy:
       fail-fast: false
-      # No max-parallel: Blacksmith autoscales runners, so all lambda services
+      # No max-parallel: runners autoscale, so all lambda services
       # build concurrently instead of batching 8.
       matrix:
         service: ${{ fromJson(needs.setup.outputs.lambdas) }}
@@ -268,28 +259,15 @@ jobs:
         with:
           clean: false
 
-      - name: Mount lambda Nix store sticky disk (clones warmed closure)
-        uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88 # v1 before PR #58 (2b7a836c): empty-clone regression suspect
+      # Namespace cache volume backing /nix. Purely an optimization: if the
+      # profile has no cache volumes (or the mount fails), setup-nix performs
+      # a cold install and Cachix substitutes the warm layers — slower, never
+      # wrong. Hence continue-on-error.
+      - name: Mount /nix cache volume
+        continue-on-error: true
+        uses: namespacelabs/nscloud-cache-action@15799a6b54e5765f85b2aac25b3f0df43ed571c0 # v1.4.3
         with:
-          key: ${{ github.repository }}-nix-lambdas
           path: /nix
-
-      # Hand the Lambda bundle to the matching deploy job over a sticky disk
-      # instead of GitHub artifacts (see build-service-binaries for rationale).
-      - name: Mount lambdas handoff sticky disk
-        uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88 # v1 before PR #58 (2b7a836c): empty-clone regression suspect
-        with:
-          key: ${{ github.repository }}-handoff-lambdas-${{ matrix.service }}-${{ github.sha }}
-          path: /handoff-lambdas
-
-      # A fresh ext4 sticky disk mounts as root:root; make it writable by the
-      # (possibly non-root) runner so the handoff copy can write the tar. No-op
-      # when the runner already runs as root.
-      - name: Ensure lambdas handoff is writable
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [ "$(id -u)" -ne 0 ]; then sudo chown -R "$(id -u):$(id -g)" /handoff-lambdas; fi
 
       - name: Setup Nix
         uses: ./.github/actions/setup-nix
@@ -304,17 +282,24 @@ jobs:
           SERVICE: ${{ matrix.service }}
         run: .github/scripts/build-cloud-storage-lambdas-nix.sh
 
-      - name: Hand off Lambda artifacts to deploy
+      - name: Log handoff receipt
         shell: bash
         run: |
           set -euo pipefail
-          # The build script writes lambda-artifacts.tar.gz to the workspace root.
-          cp lambda-artifacts.tar.gz /handoff-lambdas/lambda-artifacts.tar.gz
-          # Receipt + flush (see binaries handoff for rationale).
-          sync /handoff-lambdas/lambda-artifacts.tar.gz
-          echo "handoff receipt: $(sha256sum /handoff-lambdas/lambda-artifacts.tar.gz | cut -d' ' -f1) ($(stat -c%s /handoff-lambdas/lambda-artifacts.tar.gz) bytes)"
+          # The build script writes lambda-artifacts.tar.gz to the workspace
+          # root; the deploy job logs the same hash on read.
+          echo "handoff receipt: $(sha256sum lambda-artifacts.tar.gz | cut -d' ' -f1) ($(stat -c%s lambda-artifacts.tar.gz) bytes)"
 
-      - name: Teardown Nix (free sticky disk for commit)
+      # Handoff via run-scoped GitHub artifact (see build-service-binaries).
+      - name: Upload handoff artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: handoff-lambdas-${{ matrix.service }}
+          path: lambda-artifacts.tar.gz
+          retention-days: 1
+          overwrite: true
+
+      - name: Teardown Nix (free cache volume for commit)
         if: always()
         uses: ./.github/actions/teardown-nix
 
@@ -336,9 +321,8 @@ jobs:
     needs: [setup, build-service-binaries, build-lambda-artifacts, migrate-db]
     if: ${{ needs.setup.outputs.matrix != '[]' }}
     # Deploys via Pulumi + Docker; AWS auth is via explicit static keys
-    # (configure-aws-credentials), so no dependency on a RunsOn instance role.
-    # NOTE: adjust to a provisioned Blacksmith runner label for the org.
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    # (configure-aws-credentials).
+    runs-on: namespace-profile-default
     # Pin PULUMI_HOME to a fixed path (outside the workspace, which the deploy
     # action's checkout cleans) so the plugins subdir can be backed by a sticky
     # disk. Propagates into the composite action's pulumi step via the job env.
@@ -368,33 +352,13 @@ jobs:
           echo "has_binaries=$has_binaries" >> "$GITHUB_OUTPUT"
           echo "has_lambdas=$has_lambdas" >> "$GITHUB_OUTPUT"
 
-      # Clone the handoff snapshots committed by the build jobs (which this job
-      # `needs`). Mounted outside the workspace at /handoff-* so the composite
-      # action's own checkout (which cleans the workspace) can't touch them.
-      # Gated on the artifact flags so services with no binaries/lambdas don't
-      # mount an empty disk.
-      - name: Mount binaries handoff sticky disk
-        if: ${{ steps.check-artifacts.outputs.has_binaries == 'true' }}
-        uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88 # v1 before PR #58 (2b7a836c): empty-clone regression suspect
+      # Cache Pulumi's provider plugins ($PULUMI_HOME/plugins) on a Namespace
+      # cache volume. Plugins are version-pinned by infra/ and identical across
+      # services. Optimization-only: a cold volume just re-downloads (~45s).
+      - name: Cache Pulumi plugins
+        continue-on-error: true
+        uses: namespacelabs/nscloud-cache-action@15799a6b54e5765f85b2aac25b3f0df43ed571c0 # v1.4.3
         with:
-          key: ${{ github.repository }}-handoff-binaries-${{ matrix.service }}-${{ github.sha }}
-          path: /handoff-binaries
-
-      - name: Mount lambdas handoff sticky disk
-        if: ${{ steps.check-artifacts.outputs.has_lambdas == 'true' }}
-        uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88 # v1 before PR #58 (2b7a836c): empty-clone regression suspect
-        with:
-          key: ${{ github.repository }}-handoff-lambdas-${{ matrix.service }}-${{ github.sha }}
-          path: /handoff-lambdas
-
-      # Cache Pulumi's provider plugins ($PULUMI_HOME/plugins) on a sticky disk.
-      # Plugins are version-pinned by infra/ and identical across services, so a
-      # single stable-keyed disk is shared by every deploy job: the first run
-      # downloads + commits, later runs clone it warm and skip the ~45s pull.
-      - name: Cache Pulumi plugins (sticky disk)
-        uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88 # v1 before PR #58 (2b7a836c): empty-clone regression suspect
-        with:
-          key: ${{ github.repository }}-pulumi-plugins
           path: /pulumi/plugins
 
       # PULUMI_HOME (/pulumi) and its mounted plugins subdir come up root-owned;
@@ -410,16 +374,12 @@ jobs:
         uses: ./.github/actions/deploy-cloud-storage-pulumi
         with:
           environment: ${{ inputs.environment }}
-          # Blacksmith buildkit builder: keeps the docker layer cache on a
-          # per-Dockerfile sticky disk so heavy bases (LibreOffice/Collabora)
-          # stay warm instead of re-pulling from ECR each deploy.
-          use-blacksmith-builder: 'true'
           aws-access-key: ${{ secrets.AWS_ACCESS_KEY }}
           aws-secret-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           pulumi-access-token: ${{ secrets.PULUMI_ACCESS_TOKEN }}
           pulumi-service-name: ${{ steps.project-name.outputs.project-name }}
-          prebuilt-binaries-tar: ${{ steps.check-artifacts.outputs.has_binaries == 'true' && '/handoff-binaries/prebuilt-binaries.tar.gz' || '' }}
-          lambda-artifacts-tar: ${{ steps.check-artifacts.outputs.has_lambdas == 'true' && '/handoff-lambdas/lambda-artifacts.tar.gz' || '' }}
+          prebuilt-binaries-artifact: ${{ steps.check-artifacts.outputs.has_binaries == 'true' && format('handoff-binaries-{0}', matrix.service) || '' }}
+          lambda-artifacts: ${{ steps.check-artifacts.outputs.has_lambdas == 'true' && format('handoff-lambdas-{0}', matrix.service) || '' }}
           dd-app-key: ${{ secrets.DD_APP_KEY }}
           dd-api-key: ${{ secrets.DD_API_KEY }}
 


### PR DESCRIPTION
## Summary

Migrates the deploy pipeline from Blacksmith to Namespace: runners, caching, artifact handoff, and docker builders. Motivated by this week's operational record on Blacksmith (a regression shipped through the floating `stickydisk@v1` tag that emptied handoff disks, an identical consistency bug open upstream since April with no response, and today's major outage).

All three deploy entry points (push-to-dev, manual dispatches, prod releases) migrate together since they share `deploy-all-services.yml`. The provider-neutral core — flake layers, hakari, pruned per-artifact sources, Cachix, concurrency groups — is untouched.

## Key Changes

- **Runners**: all warm/build/deploy jobs → `namespace-profile-linux-small`. Note: smaller than Blacksmith's 32vcpu, so compile-heavy runs will be slower until profiles are upgraded; substitution-heavy runs are bootstrap-bound and largely unaffected. Upgrading later is a label change.
- **Cache volumes** (`nscloud-cache-action`, SHA-pinned) back `/nix` and `/pulumi/plugins`, declared `continue-on-error` — deliberately optimization-only. A cold or missing volume means setup-nix installs fresh and Cachix substitutes: slower, never wrong. Consistency-insensitive data only.
- **Handoff via Namespace artifact storage** (`nsc artifact upload/download`): strongly consistent object storage replaces the sticky-disk handoff that raced snapshot visibility (empty clone 41s after a verified commit). Paths are per run-attempt **and per service** (`handoff/<run_id>-<attempt>/<service>/…`, 24h expiry), so re-runs can't collide and services can't cross-read. The deploy job downloads into `runner.temp` (outside the workspace the composite's checkout cleans) and feeds the composite's existing guarded tar branch — sha256 receipts on both sides and the fail-loud extract guard carry over unchanged.
- **Docker**: the composite's Blacksmith builder branch becomes a Namespace remote builder branch (`nscloud-setup-buildx-action`, SHA-pinned) for persistent layer caching (LibreOffice/Collabora bases stay warm). Stock buildx remains the default for non-Namespace callers (`reusable-deploy-service` unaffected).
- All new third-party actions pinned by commit SHA — floating tags are how this week happened.