### PR TITLE
Clean stale CMake cache from inherited cargoArtifacts

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -470,6 +470,25 @@
             export ZIG_GLOBAL_CACHE_DIR="$TMPDIR/zig-cache"
             export ZIG_LOCAL_CACHE_DIR="$TMPDIR/zig-cache"
             export XDG_CACHE_HOME="$TMPDIR/xdg"
+
+            # Inherited cargoArtifacts can carry CMake configure state
+            # (CMakeCache.txt / CMakeFiles) from the deps-only layer. Its
+            # CMAKE_C_COMPILER points at a cargo-zigbuild wrapper script under
+            # $TMPDIR whose hash-suffixed name need not exist in this sandbox,
+            # and CMake hard-fails validating a cached compiler that is gone
+            # ("is not a full path to an existing compiler tool"). Drop the
+            # configure state so a build-script re-run reconfigures cleanly;
+            # crates whose fingerprints are clean never read it, so this costs
+            # nothing on the cached path. (Today aws-lc-sys is the only cmake
+            # crate in the graph, via AWS_LC_SYS_CMAKE_BUILDER below.)
+            tdir="''${CARGO_TARGET_DIR:-target}"
+            if [ -d "$tdir" ]; then
+              while IFS= read -r -d "" cache; do
+                dir="$(dirname "$cache")"
+                echo "purging stale cmake configure state in $dir"
+                rm -rf "$dir/CMakeFiles" "$cache"
+              done < <(find "$tdir" -name CMakeCache.txt -print0)
+            fi
           '';
         };
 


### PR DESCRIPTION
## Summary
This change adds logic to purge stale CMake configure state from the build environment when using inherited `cargoArtifacts` from a deps-only layer. This prevents CMake hard-failures when cached compiler paths no longer exist in the current sandbox.

## Key Changes
- Added a shell script block that detects and removes stale `CMakeCache.txt` files and their associated `CMakeFiles` directories from the cargo target directory
- The cleanup runs before the build, ensuring CMake reconfigures cleanly when needed
- Uses `find` with null-delimited output to safely handle file paths

## Implementation Details
- Iterates through all `CMakeCache.txt` files in the target directory (or `$CARGO_TARGET_DIR` if set)
- For each cache file found, removes both the cache file and its corresponding `CMakeFiles` directory
- Includes informative logging to indicate which directories are being cleaned
- The cleanup is a no-op for crates with clean fingerprints that don't re-run build scripts, so it has no performance impact on the cached path
- Addresses issues with cmake-based crates (currently `aws-lc-sys` via `AWS_LC_SYS_CMAKE_BUILDER`) that fail when CMake validates a cached compiler path that no longer exists

https://claude.ai/code/session_0144BqNCnE75AX6LSyEBoGtL