### PR TITLE
style(email): restyle email compose for mobile

### DIFF
--- a/js/app/packages/app/component/split-layout/back-interceptor.ts
+++ b/js/app/packages/app/component/split-layout/back-interceptor.ts
@@ -1,0 +1,20 @@
+import { createSignal, onCleanup } from 'solid-js';
+
+/** Returns true to consume the back press instead of navigating. */
+type SplitBackInterceptor = () => boolean;
+
+const [interceptor, setInterceptor] = createSignal<SplitBackInterceptor | null>(
+  null
+);
+
+export const splitBackInterceptor = interceptor;
+
+/**
+ * Lets the active view intercept the split header's back button (e.g. the
+ * mobile composer confirming a draft before leaving). One interceptor at a
+ * time; cleared when the registering owner is disposed.
+ */
+export function useSplitBackInterceptor(fn: SplitBackInterceptor) {
+  setInterceptor(() => fn);
+  onCleanup(() => setInterceptor(null));
+}

--- a/js/app/packages/app/component/split-layout/components/SplitHeader.tsx
+++ b/js/app/packages/app/component/split-layout/components/SplitHeader.tsx
@@ -162,6 +162,10 @@ function SoupNavigationButtons() {
   });
 
   const shouldShow = createMemo(() => {
+    // The mobile swipe layout doesn't handle mergeHistory navigations, so
+    // these controls would silently no-op there.
+    if (isMobile()) return false;
+
     const referredFrom = navigationReferredFrom();
     const isNavigableListView =
       referredFrom === 'inbox' || referredFrom === 'mail';

--- a/js/app/packages/app/component/split-layout/components/SplitHeader.tsx
+++ b/js/app/packages/app/component/split-layout/components/SplitHeader.tsx
@@ -24,6 +24,7 @@ import {
   useContext,
 } from 'solid-js';
 import { Portal } from 'solid-js/web';
+import { splitBackInterceptor } from '../back-interceptor';
 import { SplitLayoutContext, SplitPanelContext } from '../context';
 import type { SplitContent } from '../layoutManager';
 import { canSpotlight } from '../utils/canSpotlight';
@@ -65,7 +66,10 @@ function SplitBackButton() {
       label="Go Back"
       hotkey={TOKENS.split.go.back}
       disabled={!context.handle.canGoBack()}
-      onClick={context.handle.goBack}
+      onClick={() => {
+        if (splitBackInterceptor()?.()) return;
+        context.handle.goBack();
+      }}
     >
       <CaretLeft class="h-4" />
     </Button>

--- a/js/app/packages/block-email/component/compose/Compose.tsx
+++ b/js/app/packages/block-email/component/compose/Compose.tsx
@@ -1,8 +1,11 @@
+import { MobileDrawer } from '@app/component/mobile/MobileDrawer';
+import { useSplitBackInterceptor } from '@app/component/split-layout/back-interceptor';
 import { SplitHeaderLeft } from '@app/component/split-layout/components/SplitHeader';
 import {
   SplitHeaderBadge,
   StaticSplitLabel,
 } from '@app/component/split-layout/components/SplitLabel';
+import { SplitPanelContext } from '@app/component/split-layout/context';
 import { useSplitLayout } from '@app/component/split-layout/layout';
 import type { EmailFormRecipients } from '@block-email/component/createEmailFormState';
 import {
@@ -64,7 +67,14 @@ import { debounce } from '@solid-primitives/scheduled';
 import { Surface } from '@ui';
 
 import type { LexicalEditor } from 'lexical';
-import { createEffect, createMemo, createSignal, on, Show } from 'solid-js';
+import {
+  createEffect,
+  createMemo,
+  createSignal,
+  on,
+  Show,
+  useContext,
+} from 'solid-js';
 import { unwrap } from 'solid-js/store';
 import {
   type ComposeContextValue,
@@ -672,6 +682,23 @@ export function EmailCompose(props: EmailComposeProps) {
     hasPaidAccess,
   };
 
+  const panel = useContext(SplitPanelContext);
+  const [draftBackMenuOpen, setDraftBackMenuOpen] = createSignal(false);
+
+  if (isMobile()) {
+    // Backing out of a compose that has a draft asks whether to keep it.
+    useSplitBackInterceptor(() => {
+      if (!ctxValue.hasDraft()) return false;
+      setDraftBackMenuOpen(true);
+      return true;
+    });
+  }
+
+  const leaveCompose = () => {
+    setDraftBackMenuOpen(false);
+    panel?.handle.goBack();
+  };
+
   return (
     <ComposeProvider value={ctxValue}>
       <Show when={!isMobile()}>
@@ -705,6 +732,41 @@ export function EmailCompose(props: EmailComposeProps) {
           </WrapUnlessMobile>
         </div>
       </div>
+      <Show when={isMobile()}>
+        <MobileDrawer
+          side="bottom"
+          open={draftBackMenuOpen()}
+          onOpenChange={setDraftBackMenuOpen}
+          preventScroll={false}
+          preventScrollbarShift={false}
+        >
+          <MobileDrawer.Portal>
+            <MobileDrawer.Overlay class="fixed inset-0 z-modal-overlay bg-modal-overlay pattern-diagonal-4 pattern-edge-muted" />
+            <MobileDrawer.Content aria-label="Draft options">
+              <MobileDrawer.Handle />
+              <MobileDrawer.Section class="mb-3">
+                <button
+                  type="button"
+                  class="w-full bg-surface px-3 py-3.5 text-sm font-medium text-failure text-center not-last:mb-px"
+                  onClick={() => {
+                    void deleteDraftAndReset();
+                    leaveCompose();
+                  }}
+                >
+                  Delete Draft
+                </button>
+                <button
+                  type="button"
+                  class="w-full bg-surface px-3 py-3.5 text-sm font-medium text-center"
+                  onClick={leaveCompose}
+                >
+                  Save Draft
+                </button>
+              </MobileDrawer.Section>
+            </MobileDrawer.Content>
+          </MobileDrawer.Portal>
+        </MobileDrawer>
+      </Show>
     </ComposeProvider>
   );
 }

--- a/js/app/packages/block-email/component/compose/Compose.tsx
+++ b/js/app/packages/block-email/component/compose/Compose.tsx
@@ -61,7 +61,7 @@ import {
   useSendMessageMutation,
   useUnscheduleMessageMutation,
 } from '@queries/email/thread';
-import { invalidateSoupEntity } from '@queries/soup/cache';
+import { invalidateSoupEntity, refetchSoupEntity } from '@queries/soup/cache';
 import { emailClient } from '@service-email/client';
 import { debounce } from '@solid-primitives/scheduled';
 import { Surface } from '@ui';
@@ -161,6 +161,19 @@ export function EmailCompose(props: EmailComposeProps) {
     props.draftID
   );
 
+  // Thread the draft currently lives under; switching the sending inbox
+  // re-homes the draft server-side, so the previous thread's soup row must
+  // be dropped after the save.
+  const [currentThreadID, setCurrentThreadID] = createSignal<
+    string | undefined
+  >(
+    props.draftID
+      ? emailContext?.messages
+          .unfiltered()
+          .find((m) => m.db_id === props.draftID)?.thread_db_id
+      : undefined
+  );
+
   // Restore form state from undo-send snapshot if available
   const restoredSnapshot =
     undoComposeSnapshot?.draftId === props.draftID ? undoComposeSnapshot : null;
@@ -225,6 +238,7 @@ export function EmailCompose(props: EmailComposeProps) {
       return;
     }
 
+    const previousThreadID = currentThreadID();
     const draftResponse = await saveDraftMutation.mutateAsync({
       draft: {
         ...draftToSave,
@@ -232,6 +246,13 @@ export function EmailCompose(props: EmailComposeProps) {
       },
       linkId: headerLinkId(),
     });
+
+    const newThreadID = draftResponse.draft.thread_db_id ?? undefined;
+    if (previousThreadID && previousThreadID !== newThreadID) {
+      invalidateSoupEntity(previousThreadID);
+      refetchSoupEntity(previousThreadID, 'emailThread');
+    }
+    setCurrentThreadID(newThreadID);
 
     const draftId = draftResponse.draft.db_id;
     if (draftId) {
@@ -689,7 +710,14 @@ export function EmailCompose(props: EmailComposeProps) {
     fromAddress: () => link()?.email_address,
     fromInboxes: () => emailLinksQuery.data?.links ?? [],
     selectedFromLinkId: () => link()?.id,
-    onSelectFromLink: form.setSelectedFromLink,
+    // Persist immediately on a sender switch so the draft moves to the new
+    // inbox even without a text edit.
+    onSelectFromLink: (linkId) => {
+      form.setSelectedFromLink(linkId);
+      setDraftDirty(true);
+      scheduleDraftSave.clear();
+      void executeSaveDraft();
+    },
     hasPaidAccess,
   };
 

--- a/js/app/packages/block-email/component/compose/Compose.tsx
+++ b/js/app/packages/block-email/component/compose/Compose.tsx
@@ -262,9 +262,18 @@ export function EmailCompose(props: EmailComposeProps) {
     }
   }
 
+  // Edits since the composer opened; an untouched existing draft can be
+  // left without the keep-or-delete prompt.
+  const [draftDirty, setDraftDirty] = createSignal(false);
+
   const scheduleDraftSave = debounce(() => {
     void executeSaveDraft();
   }, DRAFT_DEBOUNCE_MS);
+
+  const markDirtyAndScheduleSave = () => {
+    setDraftDirty(true);
+    scheduleDraftSave();
+  };
 
   // --- Attachment handling ---
 
@@ -276,10 +285,11 @@ export function EmailCompose(props: EmailComposeProps) {
     for (const attachment of attachments) {
       form.attachments.add(attachment);
     }
-    scheduleDraftSave();
+    markDirtyAndScheduleSave();
   };
 
   const handleRemoveAttachment = (attachment: DraftFormAttachment) => {
+    setDraftDirty(true);
     if (attachment.type === 'local') {
       form.attachments.removeByFile(attachment.file);
     } else if (attachment.type === 'forwarded') {
@@ -315,7 +325,7 @@ export function EmailCompose(props: EmailComposeProps) {
       firstChangeConsumed = true;
       return;
     }
-    scheduleDraftSave();
+    markDirtyAndScheduleSave();
   };
 
   // --- Send ---
@@ -489,6 +499,7 @@ export function EmailCompose(props: EmailComposeProps) {
   });
 
   const handleSendTimeChange = async (date: Date | null) => {
+    setDraftDirty(true);
     const currentSendTime = form.sendTime();
     const currentDraft = currentDraftID();
 
@@ -637,11 +648,11 @@ export function EmailCompose(props: EmailComposeProps) {
     // Form state (write)
     setRecipients: (field, value) => {
       form.setRecipients(field, value);
-      scheduleDraftSave();
+      markDirtyAndScheduleSave();
     },
     setSubject: (value) => {
       form.setSubject(value);
-      scheduleDraftSave();
+      markDirtyAndScheduleSave();
     },
     onContentChange,
     onAddAttachments: handleAddAttachments,
@@ -688,7 +699,7 @@ export function EmailCompose(props: EmailComposeProps) {
   if (isMobile()) {
     // Backing out of a compose that has a draft asks whether to keep it.
     useSplitBackInterceptor(() => {
-      if (!ctxValue.hasDraft()) return false;
+      if (!ctxValue.hasDraft() || !draftDirty()) return false;
       setDraftBackMenuOpen(true);
       return true;
     });

--- a/js/app/packages/block-email/component/compose/Compose.tsx
+++ b/js/app/packages/block-email/component/compose/Compose.tsx
@@ -787,8 +787,15 @@ export function EmailCompose(props: EmailComposeProps) {
                 <button
                   type="button"
                   class="w-full bg-surface px-3 py-3.5 text-sm font-medium text-failure text-center not-last:mb-px"
-                  onClick={() => {
-                    void deleteDraftAndReset();
+                  onClick={async () => {
+                    // Navigate only once the deletion landed; the mutation
+                    // toasts on failure and the composer stays put.
+                    try {
+                      await deleteDraftAndReset();
+                    } catch {
+                      setDraftBackMenuOpen(false);
+                      return;
+                    }
                     leaveCompose();
                   }}
                 >

--- a/js/app/packages/block-email/component/compose/ComposeLayout.tsx
+++ b/js/app/packages/block-email/component/compose/ComposeLayout.tsx
@@ -160,7 +160,7 @@ export function ComposeLayout(props: {
     displayPriority: 10,
   });
   // On mobile the Cc/Bcc/From rows fold back into the combined row when the
-  // user moves focus on without having added any Cc/Bcc recipients (iOS Mail).
+  // user moves focus on without having added any Cc/Bcc recipients.
   // Uncommitted text in either field also blocks the fold so it isn't
   // silently discarded.
   const collapseCcBccIfEmpty = () => {

--- a/js/app/packages/block-email/component/compose/ComposeLayout.tsx
+++ b/js/app/packages/block-email/component/compose/ComposeLayout.tsx
@@ -161,7 +161,7 @@ export function ComposeLayout(props: {
   return (
     <div ref={registerRef('containerRef')} class={props.class}>
       <div class="pb-1 w-full h-max shrink-0">
-        <div class="mb-4 h-6 flex items-center justify-between">
+        <div class="mb-4 h-6 flex items-center justify-between gap-3">
           <Show
             when={props.header}
             fallback={
@@ -176,8 +176,8 @@ export function ComposeLayout(props: {
                 }
               >
                 <Show when={ctx.fromAddress?.()}>
-                  <div class="text-xs text-ink-extra-muted/50 flex items-center gap-1">
-                    <span>from</span>
+                  <div class="text-xs text-ink-extra-muted/50 flex items-center gap-1 min-w-0">
+                    <span class="shrink-0">from</span>
                     <FromInboxSelector
                       links={ctx.fromInboxes?.() ?? []}
                       activeLinkId={ctx.selectedFromLinkId?.()}
@@ -190,25 +190,25 @@ export function ComposeLayout(props: {
           >
             {props.header}
           </Show>
-          <div class="flex gap-2 ml-auto">
+          <div class="flex items-center gap-3 ml-auto shrink-0">
             <Show when={!isCcVisible()}>
               <button
                 type="button"
-                class="text-ink-muted hover:text-ink hover:bg-hover"
+                class="px-1.5 -mx-1.5 py-1 rounded-md text-sm text-ink-muted hover:text-ink hover:bg-hover"
                 onClick={() => setShowCc(true)}
                 disabled={ctx.disabled()}
               >
-                + Cc
+                Cc
               </button>
             </Show>
             <Show when={!isBccVisible()}>
               <button
                 type="button"
-                class="text-ink-muted hover:text-ink hover:bg-hover"
+                class="px-1.5 -mx-1.5 py-1 rounded-md text-sm text-ink-muted hover:text-ink hover:bg-hover"
                 onClick={() => setShowBcc(true)}
                 disabled={ctx.disabled()}
               >
-                + Bcc
+                Bcc
               </button>
             </Show>
           </div>

--- a/js/app/packages/block-email/component/compose/ComposeLayout.tsx
+++ b/js/app/packages/block-email/component/compose/ComposeLayout.tsx
@@ -1,6 +1,7 @@
 import { CircleSpinner } from '@core/component/CircleSpinner';
 import { registerHotkey, useHotkeyDOMScope } from '@core/hotkey/hotkeys';
 import { TOKENS } from '@core/hotkey/tokens';
+import { isMobile } from '@core/mobile/isMobile';
 import { createSignal, type JSX, onMount, Show, Suspense } from 'solid-js';
 import { FromInboxSelector } from '../FromInboxSelector';
 import { ComposeBody } from './ComposeBody';
@@ -158,10 +159,23 @@ export function ComposeLayout(props: {
     hotkeyToken: 'email.send',
     displayPriority: 10,
   });
+  // On mobile the Cc/Bcc/From rows fold back into the combined row when the
+  // user moves focus on without having added any Cc/Bcc recipients (iOS Mail).
+  const collapseCcBccIfEmpty = () => {
+    if (!isMobile()) return;
+    if (ctx.recipients().cc.length > 0 || ctx.recipients().bcc.length > 0)
+      return;
+    setShowCc(false);
+    setShowBcc(false);
+  };
+
   return (
     <div ref={registerRef('containerRef')} class={props.class}>
       <div class="pb-1 w-full h-max shrink-0">
-        <div class="mb-4 h-6 flex items-center justify-between gap-3">
+        <div
+          class="mb-4 h-6 flex items-center justify-between gap-3"
+          classList={{ hidden: isMobile() && !props.header }}
+        >
           <Show
             when={props.header}
             fallback={
@@ -190,7 +204,10 @@ export function ComposeLayout(props: {
           >
             {props.header}
           </Show>
-          <div class="flex items-center gap-3 ml-auto shrink-0">
+          <div
+            class="flex items-center gap-3 ml-auto shrink-0"
+            classList={{ hidden: isMobile() }}
+          >
             <Show when={!isCcVisible()}>
               <button
                 type="button"
@@ -224,7 +241,9 @@ export function ComposeLayout(props: {
           setShowBcc={setShowBcc}
         />
 
-        <ComposeSubject inputRef={registerRef('subjectInput')} />
+        <div onFocusIn={collapseCcBccIfEmpty}>
+          <ComposeSubject inputRef={registerRef('subjectInput')} />
+        </div>
       </div>
 
       <div class="size-full flex flex-col min-h-0 mt-4">

--- a/js/app/packages/block-email/component/compose/ComposeLayout.tsx
+++ b/js/app/packages/block-email/component/compose/ComposeLayout.tsx
@@ -161,10 +161,19 @@ export function ComposeLayout(props: {
   });
   // On mobile the Cc/Bcc/From rows fold back into the combined row when the
   // user moves focus on without having added any Cc/Bcc recipients (iOS Mail).
+  // Uncommitted text in either field also blocks the fold so it isn't
+  // silently discarded.
   const collapseCcBccIfEmpty = () => {
     if (!isMobile()) return;
     if (ctx.recipients().cc.length > 0 || ctx.recipients().bcc.length > 0)
       return;
+    const hasPendingInput = [
+      refs().ccRecipientsSelector,
+      refs().bccRecipientsSelector,
+    ].some(
+      (el) => el instanceof HTMLInputElement && el.value.trim().length > 0
+    );
+    if (hasPendingInput) return;
     setShowCc(false);
     setShowBcc(false);
   };
@@ -239,6 +248,7 @@ export function ComposeLayout(props: {
           setShowCc={setShowCc}
           showBcc={showBcc}
           setShowBcc={setShowBcc}
+          onToRowFocusIn={collapseCcBccIfEmpty}
         />
 
         <div onFocusIn={collapseCcBccIfEmpty}>

--- a/js/app/packages/block-email/component/compose/ComposeRecipients.tsx
+++ b/js/app/packages/block-email/component/compose/ComposeRecipients.tsx
@@ -1,6 +1,8 @@
 import type { EmailRecipient } from '@block-email/component/EmailContext';
 import { RecipientSelector } from '@core/component/RecipientSelector';
 import { isMobile } from '@core/mobile/isMobile';
+import PlusIcon from '@phosphor/plus.svg';
+import { Button, cn } from '@ui';
 import { createSignal, type JSX, Show } from 'solid-js';
 import { FromInboxSelector } from '../FromInboxSelector';
 import { type RecipientFieldId, useCompose } from './ComposeContext';
@@ -20,6 +22,7 @@ function ComposeFieldRow(props: {
     sourceField: RecipientFieldId
   ) => void;
   onRowFocusIn?: () => void;
+  trailing?: JSX.Element;
 }) {
   const [isDragOver, setIsDragOver] = createSignal(false);
 
@@ -45,17 +48,28 @@ function ComposeFieldRow(props: {
 
   return (
     <div
-      class="flex items-center gap-2 py-1 border-b border-edge-muted focus-within:border-accent"
+      class={cn(
+        'flex gap-2 py-1 border-b border-edge-muted focus-within:border-accent',
+        isMobile() ? 'items-start' : 'items-center'
+      )}
       classList={{ 'border-accent bg-accent/10': isDragOver() }}
       onDragOver={handleDragOver}
       onDragLeave={handleDragLeave}
       onDrop={handleDrop}
       onFocusIn={() => props.onRowFocusIn?.()}
     >
-      <div class="text-sm w-14 shrink-0 text-ink-placeholder">
+      <div
+        class={cn(
+          'text-sm shrink-0 text-ink-placeholder',
+          isMobile() ? 'min-h-9 flex items-center' : 'w-14'
+        )}
+      >
         {props.label}
       </div>
       <div class="flex-1 min-w-0">{props.children}</div>
+      <Show when={props.trailing}>
+        <div class="shrink-0 min-h-9 flex items-center">{props.trailing}</div>
+      </Show>
     </div>
   );
 }
@@ -110,13 +124,18 @@ export function ComposeRecipients(props: {
     if (targetField === 'bcc') props.setShowBcc(true);
   };
 
+  const inputEls: Partial<Record<RecipientFieldId, HTMLElement>> = {};
+
   const recipientSelector = (
     field: RecipientFieldId,
-    inputRef?: (el: HTMLElement) => void,
+    forwardRef?: (el: HTMLElement) => void,
     opts?: { focusOnMount?: boolean; includeSelf?: boolean }
   ) => (
     <RecipientSelector
-      inputRef={inputRef}
+      inputRef={(el) => {
+        inputEls[field] = el;
+        forwardRef?.(el);
+      }}
       options={ctx.recipientOptions}
       selfEmail={ctx.fromAddress?.()}
       selectedOptions={ctx.recipients()[field]}
@@ -124,7 +143,10 @@ export function ComposeRecipients(props: {
       placeholder={isMobile() ? '' : 'Macro users or email addresses'}
       focusOnMount={opts?.focusOnMount}
       hideBorder
-      class="bg-transparent [&_input]:ml-0!"
+      class={cn(
+        'bg-transparent [&_input]:ml-0!',
+        isMobile() && '[&_input]:min-w-16!'
+      )}
       noPadding
       disabled={ctx.disabled()}
       includeSelf={opts?.includeSelf}
@@ -133,11 +155,23 @@ export function ComposeRecipients(props: {
     />
   );
 
+  const addRecipientButton = (field: RecipientFieldId) => (
+    <Button
+      size="icon-sm"
+      aria-label={`Add ${field} recipient`}
+      disabled={ctx.disabled()}
+      onClick={() => inputEls[field]?.focus()}
+    >
+      <PlusIcon />
+    </Button>
+  );
+
   const fieldRow = (
     field: RecipientFieldId,
     label: string,
     children: JSX.Element,
-    onRowFocusIn?: () => void
+    onRowFocusIn?: () => void,
+    trailing?: JSX.Element
   ) => (
     <ComposeFieldRow
       label={label}
@@ -147,6 +181,7 @@ export function ComposeRecipients(props: {
         handleRecipientDrop(field, recipient, sourceField)
       }
       onRowFocusIn={onRowFocusIn}
+      trailing={trailing}
     >
       {children}
     </ComposeFieldRow>
@@ -166,10 +201,10 @@ export function ComposeRecipients(props: {
     props.setShowBcc(true);
   };
 
-  const toRow = (onRowFocusIn?: () => void) =>
+  const toRow = (onRowFocusIn?: () => void, trailing?: JSX.Element) =>
     fieldRow(
       'to',
-      'To',
+      isMobile() ? 'To:' : 'To',
       <>
         {recipientSelector('to', props.toRef, {
           focusOnMount: ctx.focusRecipientsOnMount,
@@ -181,13 +216,26 @@ export function ComposeRecipients(props: {
           )}
         </Show>
       </>,
-      onRowFocusIn
+      onRowFocusIn,
+      trailing
     );
 
-  const ccRow = () =>
-    fieldRow('cc', 'Cc', recipientSelector('cc', props.ccRef));
-  const bccRow = () =>
-    fieldRow('bcc', 'Bcc', recipientSelector('bcc', props.bccRef));
+  const ccRow = (trailing?: JSX.Element) =>
+    fieldRow(
+      'cc',
+      isMobile() ? 'Cc:' : 'Cc',
+      recipientSelector('cc', props.ccRef),
+      undefined,
+      trailing
+    );
+  const bccRow = (trailing?: JSX.Element) =>
+    fieldRow(
+      'bcc',
+      isMobile() ? 'Bcc:' : 'Bcc',
+      recipientSelector('bcc', props.bccRef),
+      undefined,
+      trailing
+    );
 
   return (
     <Show
@@ -201,7 +249,7 @@ export function ComposeRecipients(props: {
       }
     >
       <div class="flex flex-col gap-2">
-        {toRow(collapseIfEmpty)}
+        {toRow(collapseIfEmpty, addRecipientButton('to'))}
         <Show
           when={isCcVisible() || isBccVisible()}
           fallback={
@@ -211,7 +259,7 @@ export function ComposeRecipients(props: {
               onClick={expand}
             >
               <span class="text-sm shrink-0 text-ink-placeholder min-h-9 flex items-center">
-                Cc/Bcc, From
+                Cc/Bcc, From:
               </span>
               <span class="ph-no-capture text-sm text-ink-muted truncate min-h-9 flex items-center">
                 {ctx.fromAddress?.()}
@@ -219,10 +267,10 @@ export function ComposeRecipients(props: {
             </button>
           }
         >
-          {ccRow()}
-          {bccRow()}
+          {ccRow(addRecipientButton('cc'))}
+          {bccRow(addRecipientButton('bcc'))}
           <div class="flex items-center gap-2 py-1 border-b border-edge-muted">
-            <div class="text-sm w-14 shrink-0 text-ink-placeholder">From</div>
+            <div class="text-sm shrink-0 text-ink-placeholder">From:</div>
             <div class="flex-1 min-w-0 min-h-9 flex items-center">
               <FromInboxSelector
                 links={ctx.fromInboxes?.() ?? []}

--- a/js/app/packages/block-email/component/compose/ComposeRecipients.tsx
+++ b/js/app/packages/block-email/component/compose/ComposeRecipients.tsx
@@ -42,13 +42,15 @@ function ComposeFieldRow(props: {
 
   return (
     <div
-      class="flex items-center gap-2 border-b border-edge-muted focus-within:border-accent"
+      class="flex items-center gap-2 py-1 border-b border-edge-muted focus-within:border-accent"
       classList={{ 'border-accent bg-accent/10': isDragOver() }}
       onDragOver={handleDragOver}
       onDragLeave={handleDragLeave}
       onDrop={handleDrop}
     >
-      <div class="text-sm w-7 shrink-0 text-ink-placeholder">{props.label}</div>
+      <div class="text-sm w-14 shrink-0 text-ink-placeholder">
+        {props.label}
+      </div>
       <div class="flex-1">{props.children}</div>
     </div>
   );
@@ -123,7 +125,8 @@ export function ComposeRecipients(props: {
           placeholder="Macro users or email addresses"
           focusOnMount={ctx.focusRecipientsOnMount}
           hideBorder
-          class="bg-transparent"
+          class="bg-transparent [&_input]:ml-0!"
+          noPadding
           disabled={ctx.disabled()}
           includeSelf={ctx.includeSelf}
           onChipDragStart={(option, e) => handleChipDragStart('to', option, e)}
@@ -153,7 +156,8 @@ export function ComposeRecipients(props: {
             setSelectedOptions={(next) => ctx.setRecipients('cc', next)}
             placeholder="Macro users or email addresses"
             hideBorder
-            class="bg-transparent"
+            class="bg-transparent [&_input]:ml-0!"
+            noPadding
             disabled={ctx.disabled()}
             onChipDragStart={(option, e) =>
               handleChipDragStart('cc', option, e)
@@ -180,7 +184,8 @@ export function ComposeRecipients(props: {
             setSelectedOptions={(next) => ctx.setRecipients('bcc', next)}
             placeholder="Macro users or email addresses"
             hideBorder
-            class="bg-transparent"
+            class="bg-transparent [&_input]:ml-0!"
+            noPadding
             disabled={ctx.disabled()}
             onChipDragStart={(option, e) =>
               handleChipDragStart('bcc', option, e)

--- a/js/app/packages/block-email/component/compose/ComposeRecipients.tsx
+++ b/js/app/packages/block-email/component/compose/ComposeRecipients.tsx
@@ -1,8 +1,7 @@
 import type { EmailRecipient } from '@block-email/component/EmailContext';
 import { RecipientSelector } from '@core/component/RecipientSelector';
 import { isMobile } from '@core/mobile/isMobile';
-import PlusIcon from '@phosphor/plus.svg';
-import { Button, cn } from '@ui';
+import { cn } from '@ui';
 import { createSignal, type JSX, Show } from 'solid-js';
 import { FromInboxSelector } from '../FromInboxSelector';
 import { type RecipientFieldId, useCompose } from './ComposeContext';
@@ -22,7 +21,6 @@ function ComposeFieldRow(props: {
     sourceField: RecipientFieldId
   ) => void;
   onRowFocusIn?: () => void;
-  trailing?: JSX.Element;
 }) {
   const [isDragOver, setIsDragOver] = createSignal(false);
 
@@ -67,9 +65,6 @@ function ComposeFieldRow(props: {
         {props.label}
       </div>
       <div class="flex-1 min-w-0">{props.children}</div>
-      <Show when={props.trailing}>
-        <div class="shrink-0 min-h-9 flex items-center">{props.trailing}</div>
-      </Show>
     </div>
   );
 }
@@ -124,18 +119,13 @@ export function ComposeRecipients(props: {
     if (targetField === 'bcc') props.setShowBcc(true);
   };
 
-  const inputEls: Partial<Record<RecipientFieldId, HTMLElement>> = {};
-
   const recipientSelector = (
     field: RecipientFieldId,
-    forwardRef?: (el: HTMLElement) => void,
+    inputRef?: (el: HTMLElement) => void,
     opts?: { focusOnMount?: boolean; includeSelf?: boolean }
   ) => (
     <RecipientSelector
-      inputRef={(el) => {
-        inputEls[field] = el;
-        forwardRef?.(el);
-      }}
+      inputRef={inputRef}
       options={ctx.recipientOptions}
       selfEmail={ctx.fromAddress?.()}
       selectedOptions={ctx.recipients()[field]}
@@ -155,23 +145,11 @@ export function ComposeRecipients(props: {
     />
   );
 
-  const addRecipientButton = (field: RecipientFieldId) => (
-    <Button
-      size="icon-sm"
-      aria-label={`Add ${field} recipient`}
-      disabled={ctx.disabled()}
-      onClick={() => inputEls[field]?.focus()}
-    >
-      <PlusIcon />
-    </Button>
-  );
-
   const fieldRow = (
     field: RecipientFieldId,
     label: string,
     children: JSX.Element,
-    onRowFocusIn?: () => void,
-    trailing?: JSX.Element
+    onRowFocusIn?: () => void
   ) => (
     <ComposeFieldRow
       label={label}
@@ -181,7 +159,6 @@ export function ComposeRecipients(props: {
         handleRecipientDrop(field, recipient, sourceField)
       }
       onRowFocusIn={onRowFocusIn}
-      trailing={trailing}
     >
       {children}
     </ComposeFieldRow>
@@ -201,7 +178,7 @@ export function ComposeRecipients(props: {
     props.setShowBcc(true);
   };
 
-  const toRow = (onRowFocusIn?: () => void, trailing?: JSX.Element) =>
+  const toRow = (onRowFocusIn?: () => void) =>
     fieldRow(
       'to',
       isMobile() ? 'To:' : 'To',
@@ -216,25 +193,20 @@ export function ComposeRecipients(props: {
           )}
         </Show>
       </>,
-      onRowFocusIn,
-      trailing
+      onRowFocusIn
     );
 
-  const ccRow = (trailing?: JSX.Element) =>
+  const ccRow = () =>
     fieldRow(
       'cc',
       isMobile() ? 'Cc:' : 'Cc',
-      recipientSelector('cc', props.ccRef),
-      undefined,
-      trailing
+      recipientSelector('cc', props.ccRef)
     );
-  const bccRow = (trailing?: JSX.Element) =>
+  const bccRow = () =>
     fieldRow(
       'bcc',
       isMobile() ? 'Bcc:' : 'Bcc',
-      recipientSelector('bcc', props.bccRef),
-      undefined,
-      trailing
+      recipientSelector('bcc', props.bccRef)
     );
 
   return (
@@ -249,7 +221,7 @@ export function ComposeRecipients(props: {
       }
     >
       <div class="flex flex-col gap-2">
-        {toRow(collapseIfEmpty, addRecipientButton('to'))}
+        {toRow(collapseIfEmpty)}
         <Show
           when={isCcVisible() || isBccVisible()}
           fallback={
@@ -267,8 +239,8 @@ export function ComposeRecipients(props: {
             </button>
           }
         >
-          {ccRow(addRecipientButton('cc'))}
-          {bccRow(addRecipientButton('bcc'))}
+          {ccRow()}
+          {bccRow()}
           <div class="flex items-center gap-2 py-1 border-b border-edge-muted">
             <div class="text-sm shrink-0 text-ink-placeholder">From:</div>
             <div class="flex-1 min-w-0 min-h-9 flex items-center">

--- a/js/app/packages/block-email/component/compose/ComposeRecipients.tsx
+++ b/js/app/packages/block-email/component/compose/ComposeRecipients.tsx
@@ -138,7 +138,7 @@ export function ComposeRecipients(props: {
   };
 
   // On mobile an unfocused row with recipients collapses to a "Name, Name &
-  // N more…" summary; tapping it brings the chips and input back (iOS Mail).
+  // N more…" summary; tapping it brings the chips and input back.
   const [activeField, setActiveField] = createSignal<RecipientFieldId | null>(
     null
   );

--- a/js/app/packages/block-email/component/compose/ComposeRecipients.tsx
+++ b/js/app/packages/block-email/component/compose/ComposeRecipients.tsx
@@ -147,10 +147,12 @@ export function ComposeRecipients(props: {
   const showSummary = (field: RecipientFieldId) =>
     isMobile() && activeField() !== field && ctx.recipients()[field].length > 0;
 
-  const summaryText = (field: RecipientFieldId) => {
+  const summaryParts = (field: RecipientFieldId) => {
     const names = ctx.recipients()[field].map(recipientName).filter(Boolean);
-    if (names.length <= 2) return names.join(', ');
-    return `${names[0]}, ${names[1]} & ${names.length - 2} more…`;
+    return {
+      names: names.slice(0, 2).join(', '),
+      extra: Math.max(0, names.length - 2),
+    };
   };
 
   const activate = (field: RecipientFieldId) => {
@@ -229,7 +231,12 @@ export function ComposeRecipients(props: {
           class="ph-no-capture w-full min-h-9 flex items-center text-sm text-ink text-left"
           onClick={() => activate(field)}
         >
-          <span class="truncate">{summaryText(field)}</span>
+          <span class="truncate">{summaryParts(field).names}</span>
+          <Show when={summaryParts(field).extra > 0}>
+            <span class="shrink-0 whitespace-pre">
+              {` & ${summaryParts(field).extra} more…`}
+            </span>
+          </Show>
         </button>
       }
     >

--- a/js/app/packages/block-email/component/compose/ComposeRecipients.tsx
+++ b/js/app/packages/block-email/component/compose/ComposeRecipients.tsx
@@ -1,6 +1,8 @@
 import type { EmailRecipient } from '@block-email/component/EmailContext';
 import { RecipientSelector } from '@core/component/RecipientSelector';
-import { createSignal, Show } from 'solid-js';
+import { isMobile } from '@core/mobile/isMobile';
+import { createSignal, type JSX, Show } from 'solid-js';
+import { FromInboxSelector } from '../FromInboxSelector';
 import { type RecipientFieldId, useCompose } from './ComposeContext';
 
 type DragState = {
@@ -10,13 +12,14 @@ type DragState = {
 
 function ComposeFieldRow(props: {
   label: string;
-  children: import('solid-js').JSX.Element;
+  children: JSX.Element;
   fieldId?: RecipientFieldId;
   dragState?: () => DragState | null;
   onRecipientDrop?: (
     recipient: EmailRecipient,
     sourceField: RecipientFieldId
   ) => void;
+  onRowFocusIn?: () => void;
 }) {
   const [isDragOver, setIsDragOver] = createSignal(false);
 
@@ -47,11 +50,12 @@ function ComposeFieldRow(props: {
       onDragOver={handleDragOver}
       onDragLeave={handleDragLeave}
       onDrop={handleDrop}
+      onFocusIn={() => props.onRowFocusIn?.()}
     >
       <div class="text-sm w-14 shrink-0 text-ink-placeholder">
         {props.label}
       </div>
-      <div class="flex-1">{props.children}</div>
+      <div class="flex-1 min-w-0">{props.children}</div>
     </div>
   );
 }
@@ -106,94 +110,129 @@ export function ComposeRecipients(props: {
     if (targetField === 'bcc') props.setShowBcc(true);
   };
 
-  return (
-    <div class="flex flex-col gap-2">
-      <ComposeFieldRow
-        label="To"
-        fieldId="to"
-        dragState={recipientDragState}
-        onRecipientDrop={(recipient, sourceField) =>
-          handleRecipientDrop('to', recipient, sourceField)
-        }
-      >
-        <RecipientSelector
-          inputRef={props.toRef}
-          options={ctx.recipientOptions}
-          selfEmail={ctx.fromAddress?.()}
-          selectedOptions={ctx.recipients().to}
-          setSelectedOptions={(next) => ctx.setRecipients('to', next)}
-          placeholder="Macro users or email addresses"
-          focusOnMount={ctx.focusRecipientsOnMount}
-          hideBorder
-          class="bg-transparent [&_input]:ml-0!"
-          noPadding
-          disabled={ctx.disabled()}
-          includeSelf={ctx.includeSelf}
-          onChipDragStart={(option, e) => handleChipDragStart('to', option, e)}
-          onChipDragEnd={handleChipDragEnd}
-        />
+  const recipientSelector = (
+    field: RecipientFieldId,
+    inputRef?: (el: HTMLElement) => void,
+    opts?: { focusOnMount?: boolean; includeSelf?: boolean }
+  ) => (
+    <RecipientSelector
+      inputRef={inputRef}
+      options={ctx.recipientOptions}
+      selfEmail={ctx.fromAddress?.()}
+      selectedOptions={ctx.recipients()[field]}
+      setSelectedOptions={(next) => ctx.setRecipients(field, next)}
+      placeholder={isMobile() ? '' : 'Macro users or email addresses'}
+      focusOnMount={opts?.focusOnMount}
+      hideBorder
+      class="bg-transparent [&_input]:ml-0!"
+      noPadding
+      disabled={ctx.disabled()}
+      includeSelf={opts?.includeSelf}
+      onChipDragStart={(option, e) => handleChipDragStart(field, option, e)}
+      onChipDragEnd={handleChipDragEnd}
+    />
+  );
+
+  const fieldRow = (
+    field: RecipientFieldId,
+    label: string,
+    children: JSX.Element,
+    onRowFocusIn?: () => void
+  ) => (
+    <ComposeFieldRow
+      label={label}
+      fieldId={field}
+      dragState={recipientDragState}
+      onRecipientDrop={(recipient, sourceField) =>
+        handleRecipientDrop(field, recipient, sourceField)
+      }
+      onRowFocusIn={onRowFocusIn}
+    >
+      {children}
+    </ComposeFieldRow>
+  );
+
+  // Collapse the expanded Cc/Bcc/From rows back into the combined row when
+  // the user moves on without entering any Cc/Bcc recipients (iOS Mail).
+  const collapseIfEmpty = () => {
+    if (ctx.recipients().cc.length === 0 && ctx.recipients().bcc.length === 0) {
+      props.setShowCc(false);
+      props.setShowBcc(false);
+    }
+  };
+
+  const expand = () => {
+    props.setShowCc(true);
+    props.setShowBcc(true);
+  };
+
+  const toRow = (onRowFocusIn?: () => void) =>
+    fieldRow(
+      'to',
+      'To',
+      <>
+        {recipientSelector('to', props.toRef, {
+          focusOnMount: ctx.focusRecipientsOnMount,
+          includeSelf: ctx.includeSelf,
+        })}
         <Show when={ctx.validationError('no_recipient')}>
           {(err) => (
             <div class="text-failure-ink text-sm mt-1">{err().message}</div>
           )}
         </Show>
-      </ComposeFieldRow>
+      </>,
+      onRowFocusIn
+    );
 
-      <Show when={isCcVisible()}>
-        <ComposeFieldRow
-          label="Cc"
-          fieldId="cc"
-          dragState={recipientDragState}
-          onRecipientDrop={(recipient, sourceField) =>
-            handleRecipientDrop('cc', recipient, sourceField)
+  const ccRow = () =>
+    fieldRow('cc', 'Cc', recipientSelector('cc', props.ccRef));
+  const bccRow = () =>
+    fieldRow('bcc', 'Bcc', recipientSelector('bcc', props.bccRef));
+
+  return (
+    <Show
+      when={isMobile()}
+      fallback={
+        <div class="flex flex-col gap-2">
+          {toRow()}
+          <Show when={isCcVisible()}>{ccRow()}</Show>
+          <Show when={isBccVisible()}>{bccRow()}</Show>
+        </div>
+      }
+    >
+      <div class="flex flex-col gap-2">
+        {toRow(collapseIfEmpty)}
+        <Show
+          when={isCcVisible() || isBccVisible()}
+          fallback={
+            <button
+              type="button"
+              class="w-full flex items-center gap-2 py-1 border-b border-edge-muted text-left"
+              onClick={expand}
+            >
+              <span class="text-sm shrink-0 text-ink-placeholder min-h-9 flex items-center">
+                Cc/Bcc, From
+              </span>
+              <span class="ph-no-capture text-sm text-ink-muted truncate min-h-9 flex items-center">
+                {ctx.fromAddress?.()}
+              </span>
+            </button>
           }
         >
-          <RecipientSelector
-            inputRef={props.ccRef}
-            options={ctx.recipientOptions}
-            selfEmail={ctx.fromAddress?.()}
-            selectedOptions={ctx.recipients().cc}
-            setSelectedOptions={(next) => ctx.setRecipients('cc', next)}
-            placeholder="Macro users or email addresses"
-            hideBorder
-            class="bg-transparent [&_input]:ml-0!"
-            noPadding
-            disabled={ctx.disabled()}
-            onChipDragStart={(option, e) =>
-              handleChipDragStart('cc', option, e)
-            }
-            onChipDragEnd={handleChipDragEnd}
-          />
-        </ComposeFieldRow>
-      </Show>
-
-      <Show when={isBccVisible()}>
-        <ComposeFieldRow
-          label="Bcc"
-          fieldId="bcc"
-          dragState={recipientDragState}
-          onRecipientDrop={(recipient, sourceField) =>
-            handleRecipientDrop('bcc', recipient, sourceField)
-          }
-        >
-          <RecipientSelector
-            inputRef={props.bccRef}
-            options={ctx.recipientOptions}
-            selfEmail={ctx.fromAddress?.()}
-            selectedOptions={ctx.recipients().bcc}
-            setSelectedOptions={(next) => ctx.setRecipients('bcc', next)}
-            placeholder="Macro users or email addresses"
-            hideBorder
-            class="bg-transparent [&_input]:ml-0!"
-            noPadding
-            disabled={ctx.disabled()}
-            onChipDragStart={(option, e) =>
-              handleChipDragStart('bcc', option, e)
-            }
-            onChipDragEnd={handleChipDragEnd}
-          />
-        </ComposeFieldRow>
-      </Show>
-    </div>
+          {ccRow()}
+          {bccRow()}
+          <div class="flex items-center gap-2 py-1 border-b border-edge-muted">
+            <div class="text-sm w-14 shrink-0 text-ink-placeholder">From</div>
+            <div class="flex-1 min-w-0 min-h-9 flex items-center">
+              <FromInboxSelector
+                links={ctx.fromInboxes?.() ?? []}
+                activeLinkId={ctx.selectedFromLinkId?.()}
+                onSelect={(id) => ctx.onSelectFromLink?.(id)}
+              />
+            </div>
+          </div>
+        </Show>
+      </div>
+    </Show>
   );
 }

--- a/js/app/packages/block-email/component/compose/ComposeRecipients.tsx
+++ b/js/app/packages/block-email/component/compose/ComposeRecipients.tsx
@@ -2,7 +2,7 @@ import type { EmailRecipient } from '@block-email/component/EmailContext';
 import { RecipientSelector } from '@core/component/RecipientSelector';
 import { isMobile } from '@core/mobile/isMobile';
 import { cn } from '@ui';
-import { createSignal, type JSX, Show } from 'solid-js';
+import { createSignal, type JSX, onCleanup, Show } from 'solid-js';
 import { FromInboxSelector } from '../FromInboxSelector';
 import { type RecipientFieldId, useCompose } from './ComposeContext';
 
@@ -158,11 +158,19 @@ export function ComposeRecipients(props: {
     requestAnimationFrame(() => inputEls[field]?.focus());
   };
 
+  // Collapsing is deferred so the transient blur of tapping a suggestion
+  // (whose selection lands via a debounced onChange) doesn't fold the row
+  // mid-entry — picking a recipient cancels the pending collapse and
+  // refocuses the input for the next one.
+  let collapseTimer: ReturnType<typeof setTimeout> | undefined;
+  onCleanup(() => clearTimeout(collapseTimer));
+
   const rowFocusHandlers = (
     field: RecipientFieldId,
     extraFocusIn?: () => void
   ): RowFocusHandlers => ({
     onRowFocusIn: () => {
+      clearTimeout(collapseTimer);
       setActiveField(field);
       extraFocusIn?.();
     },
@@ -170,7 +178,10 @@ export function ComposeRecipients(props: {
       const row = e.currentTarget as HTMLElement;
       if (e.relatedTarget instanceof Node && row.contains(e.relatedTarget))
         return;
-      setActiveField((active) => (active === field ? null : active));
+      clearTimeout(collapseTimer);
+      collapseTimer = setTimeout(() => {
+        setActiveField((active) => (active === field ? null : active));
+      }, 250);
     },
   });
 
@@ -187,7 +198,13 @@ export function ComposeRecipients(props: {
       options={ctx.recipientOptions}
       selfEmail={ctx.fromAddress?.()}
       selectedOptions={ctx.recipients()[field]}
-      setSelectedOptions={(next) => ctx.setRecipients(field, next)}
+      setSelectedOptions={(next) => {
+        ctx.setRecipients(field, next);
+        if (isMobile()) {
+          clearTimeout(collapseTimer);
+          activate(field);
+        }
+      }}
       placeholder={isMobile() ? '' : 'Macro users or email addresses'}
       focusOnMount={opts?.focusOnMount}
       hideBorder

--- a/js/app/packages/block-email/component/compose/ComposeRecipients.tsx
+++ b/js/app/packages/block-email/component/compose/ComposeRecipients.tsx
@@ -123,6 +123,7 @@ export function ComposeRecipients(props: {
           placeholder="Macro users or email addresses"
           focusOnMount={ctx.focusRecipientsOnMount}
           hideBorder
+          class="bg-transparent"
           disabled={ctx.disabled()}
           includeSelf={ctx.includeSelf}
           onChipDragStart={(option, e) => handleChipDragStart('to', option, e)}
@@ -152,6 +153,7 @@ export function ComposeRecipients(props: {
             setSelectedOptions={(next) => ctx.setRecipients('cc', next)}
             placeholder="Macro users or email addresses"
             hideBorder
+            class="bg-transparent"
             disabled={ctx.disabled()}
             onChipDragStart={(option, e) =>
               handleChipDragStart('cc', option, e)
@@ -178,6 +180,7 @@ export function ComposeRecipients(props: {
             setSelectedOptions={(next) => ctx.setRecipients('bcc', next)}
             placeholder="Macro users or email addresses"
             hideBorder
+            class="bg-transparent"
             disabled={ctx.disabled()}
             onChipDragStart={(option, e) =>
               handleChipDragStart('bcc', option, e)

--- a/js/app/packages/block-email/component/compose/ComposeRecipients.tsx
+++ b/js/app/packages/block-email/component/compose/ComposeRecipients.tsx
@@ -135,7 +135,7 @@ export function ComposeRecipients(props: {
       hideBorder
       class={cn(
         'bg-transparent [&_input]:ml-0!',
-        isMobile() && '[&_input]:min-w-16!'
+        isMobile() && '[&_input]:min-w-16! [&_input]:min-h-9!'
       )}
       noPadding
       disabled={ctx.disabled()}

--- a/js/app/packages/block-email/component/compose/ComposeRecipients.tsx
+++ b/js/app/packages/block-email/component/compose/ComposeRecipients.tsx
@@ -77,6 +77,7 @@ export function ComposeRecipients(props: {
   setShowCc: (v: boolean) => void;
   showBcc: () => boolean;
   setShowBcc: (v: boolean) => void;
+  onToRowFocusIn?: () => void;
 }) {
   const ctx = useCompose();
 
@@ -164,24 +165,17 @@ export function ComposeRecipients(props: {
     </ComposeFieldRow>
   );
 
-  // Collapse the expanded Cc/Bcc/From rows back into the combined row when
-  // the user moves on without entering any Cc/Bcc recipients (iOS Mail).
-  const collapseIfEmpty = () => {
-    if (ctx.recipients().cc.length === 0 && ctx.recipients().bcc.length === 0) {
-      props.setShowCc(false);
-      props.setShowBcc(false);
-    }
-  };
-
   const expand = () => {
     props.setShowCc(true);
     props.setShowBcc(true);
   };
 
+  const fieldLabel = (text: string) => (isMobile() ? `${text}:` : text);
+
   const toRow = (onRowFocusIn?: () => void) =>
     fieldRow(
       'to',
-      isMobile() ? 'To:' : 'To',
+      fieldLabel('To'),
       <>
         {recipientSelector('to', props.toRef, {
           focusOnMount: ctx.focusRecipientsOnMount,
@@ -197,17 +191,9 @@ export function ComposeRecipients(props: {
     );
 
   const ccRow = () =>
-    fieldRow(
-      'cc',
-      isMobile() ? 'Cc:' : 'Cc',
-      recipientSelector('cc', props.ccRef)
-    );
+    fieldRow('cc', fieldLabel('Cc'), recipientSelector('cc', props.ccRef));
   const bccRow = () =>
-    fieldRow(
-      'bcc',
-      isMobile() ? 'Bcc:' : 'Bcc',
-      recipientSelector('bcc', props.bccRef)
-    );
+    fieldRow('bcc', fieldLabel('Bcc'), recipientSelector('bcc', props.bccRef));
 
   return (
     <Show
@@ -221,7 +207,7 @@ export function ComposeRecipients(props: {
       }
     >
       <div class="flex flex-col gap-2">
-        {toRow(collapseIfEmpty)}
+        {toRow(props.onToRowFocusIn)}
         <Show
           when={isCcVisible() || isBccVisible()}
           fallback={

--- a/js/app/packages/block-email/component/compose/ComposeRecipients.tsx
+++ b/js/app/packages/block-email/component/compose/ComposeRecipients.tsx
@@ -11,6 +11,11 @@ type DragState = {
   sourceField: RecipientFieldId;
 };
 
+type RowFocusHandlers = {
+  onRowFocusIn?: () => void;
+  onRowFocusOut?: (e: FocusEvent) => void;
+};
+
 function ComposeFieldRow(props: {
   label: string;
   children: JSX.Element;
@@ -21,6 +26,7 @@ function ComposeFieldRow(props: {
     sourceField: RecipientFieldId
   ) => void;
   onRowFocusIn?: () => void;
+  onRowFocusOut?: (e: FocusEvent) => void;
 }) {
   const [isDragOver, setIsDragOver] = createSignal(false);
 
@@ -55,6 +61,7 @@ function ComposeFieldRow(props: {
       onDragLeave={handleDragLeave}
       onDrop={handleDrop}
       onFocusIn={() => props.onRowFocusIn?.()}
+      onFocusOut={(e) => props.onRowFocusOut?.(e)}
     >
       <div
         class={cn(
@@ -67,6 +74,16 @@ function ComposeFieldRow(props: {
       <div class="flex-1 min-w-0">{props.children}</div>
     </div>
   );
+}
+
+function recipientName(recipient: EmailRecipient) {
+  switch (recipient.kind) {
+    case 'user':
+    case 'contact':
+      return recipient.data.name || recipient.data.email;
+    case 'custom':
+      return recipient.data.email;
+  }
 }
 
 export function ComposeRecipients(props: {
@@ -120,13 +137,53 @@ export function ComposeRecipients(props: {
     if (targetField === 'bcc') props.setShowBcc(true);
   };
 
+  // On mobile an unfocused row with recipients collapses to a "Name, Name &
+  // N more…" summary; tapping it brings the chips and input back (iOS Mail).
+  const [activeField, setActiveField] = createSignal<RecipientFieldId | null>(
+    null
+  );
+  const inputEls: Partial<Record<RecipientFieldId, HTMLElement>> = {};
+
+  const showSummary = (field: RecipientFieldId) =>
+    isMobile() && activeField() !== field && ctx.recipients()[field].length > 0;
+
+  const summaryText = (field: RecipientFieldId) => {
+    const names = ctx.recipients()[field].map(recipientName).filter(Boolean);
+    if (names.length <= 2) return names.join(', ');
+    return `${names[0]}, ${names[1]} & ${names.length - 2} more…`;
+  };
+
+  const activate = (field: RecipientFieldId) => {
+    setActiveField(field);
+    requestAnimationFrame(() => inputEls[field]?.focus());
+  };
+
+  const rowFocusHandlers = (
+    field: RecipientFieldId,
+    extraFocusIn?: () => void
+  ): RowFocusHandlers => ({
+    onRowFocusIn: () => {
+      setActiveField(field);
+      extraFocusIn?.();
+    },
+    onRowFocusOut: (e) => {
+      const row = e.currentTarget as HTMLElement;
+      if (e.relatedTarget instanceof Node && row.contains(e.relatedTarget))
+        return;
+      setActiveField((active) => (active === field ? null : active));
+    },
+  });
+
   const recipientSelector = (
     field: RecipientFieldId,
     inputRef?: (el: HTMLElement) => void,
     opts?: { focusOnMount?: boolean; includeSelf?: boolean }
   ) => (
     <RecipientSelector
-      inputRef={inputRef}
+      inputRef={(el) => {
+        inputEls[field] = el;
+        inputRef?.(el);
+      }}
       options={ctx.recipientOptions}
       selfEmail={ctx.fromAddress?.()}
       selectedOptions={ctx.recipients()[field]}
@@ -146,11 +203,28 @@ export function ComposeRecipients(props: {
     />
   );
 
+  const summarizable = (field: RecipientFieldId, selector: JSX.Element) => (
+    <Show
+      when={!showSummary(field)}
+      fallback={
+        <button
+          type="button"
+          class="ph-no-capture w-full min-h-9 flex items-center text-sm text-ink text-left"
+          onClick={() => activate(field)}
+        >
+          <span class="truncate">{summaryText(field)}</span>
+        </button>
+      }
+    >
+      {selector}
+    </Show>
+  );
+
   const fieldRow = (
     field: RecipientFieldId,
     label: string,
     children: JSX.Element,
-    onRowFocusIn?: () => void
+    handlers?: RowFocusHandlers
   ) => (
     <ComposeFieldRow
       label={label}
@@ -159,7 +233,8 @@ export function ComposeRecipients(props: {
       onRecipientDrop={(recipient, sourceField) =>
         handleRecipientDrop(field, recipient, sourceField)
       }
-      onRowFocusIn={onRowFocusIn}
+      onRowFocusIn={handlers?.onRowFocusIn}
+      onRowFocusOut={handlers?.onRowFocusOut}
     >
       {children}
     </ComposeFieldRow>
@@ -172,28 +247,41 @@ export function ComposeRecipients(props: {
 
   const fieldLabel = (text: string) => (isMobile() ? `${text}:` : text);
 
-  const toRow = (onRowFocusIn?: () => void) =>
+  const toRow = (handlers?: RowFocusHandlers) =>
     fieldRow(
       'to',
       fieldLabel('To'),
       <>
-        {recipientSelector('to', props.toRef, {
-          focusOnMount: ctx.focusRecipientsOnMount,
-          includeSelf: ctx.includeSelf,
-        })}
+        {summarizable(
+          'to',
+          recipientSelector('to', props.toRef, {
+            focusOnMount: ctx.focusRecipientsOnMount,
+            includeSelf: ctx.includeSelf,
+          })
+        )}
         <Show when={ctx.validationError('no_recipient')}>
           {(err) => (
             <div class="text-failure-ink text-sm mt-1">{err().message}</div>
           )}
         </Show>
       </>,
-      onRowFocusIn
+      handlers
     );
 
-  const ccRow = () =>
-    fieldRow('cc', fieldLabel('Cc'), recipientSelector('cc', props.ccRef));
-  const bccRow = () =>
-    fieldRow('bcc', fieldLabel('Bcc'), recipientSelector('bcc', props.bccRef));
+  const ccRow = (handlers?: RowFocusHandlers) =>
+    fieldRow(
+      'cc',
+      fieldLabel('Cc'),
+      summarizable('cc', recipientSelector('cc', props.ccRef)),
+      handlers
+    );
+  const bccRow = (handlers?: RowFocusHandlers) =>
+    fieldRow(
+      'bcc',
+      fieldLabel('Bcc'),
+      summarizable('bcc', recipientSelector('bcc', props.bccRef)),
+      handlers
+    );
 
   return (
     <Show
@@ -207,7 +295,7 @@ export function ComposeRecipients(props: {
       }
     >
       <div class="flex flex-col gap-2">
-        {toRow(props.onToRowFocusIn)}
+        {toRow(rowFocusHandlers('to', props.onToRowFocusIn))}
         <Show
           when={isCcVisible() || isBccVisible()}
           fallback={
@@ -225,8 +313,8 @@ export function ComposeRecipients(props: {
             </button>
           }
         >
-          {ccRow()}
-          {bccRow()}
+          {ccRow(rowFocusHandlers('cc'))}
+          {bccRow(rowFocusHandlers('bcc'))}
           <div class="flex items-center gap-2 py-1 border-b border-edge-muted">
             <div class="text-sm shrink-0 text-ink-placeholder">From:</div>
             <div class="flex-1 min-w-0 min-h-9 flex items-center">

--- a/js/app/packages/block-email/component/compose/ComposeSubject.tsx
+++ b/js/app/packages/block-email/component/compose/ComposeSubject.tsx
@@ -1,30 +1,96 @@
 import { isMobile } from '@core/mobile/isMobile';
-import { Show } from 'solid-js';
+import { cn } from '@ui';
+import { createSignal, Show } from 'solid-js';
 import { useCompose } from './ComposeContext';
+
+function autosize(el: HTMLTextAreaElement) {
+  el.style.height = 'auto';
+  el.style.height = `${el.scrollHeight}px`;
+}
 
 export function ComposeSubject(props: {
   inputRef?: (el: HTMLElement) => void;
 }) {
   const ctx = useCompose();
 
+  // On mobile the subject wraps and grows while edited, and folds to a single
+  // truncated line on blur so the body starts near the top (iOS Mail).
+  const [editing, setEditing] = createSignal(false);
+  let textareaRef: HTMLTextAreaElement | undefined;
+
+  const showSummary = () =>
+    isMobile() && !editing() && ctx.subject().length > 0;
+
   return (
-    <div class="w-full flex items-center gap-2 border-b border-edge-muted focus-within:border-accent py-2">
+    <div
+      class={cn(
+        'w-full flex gap-2 border-b border-edge-muted focus-within:border-accent py-2',
+        isMobile() ? 'items-start' : 'items-center'
+      )}
+    >
       <div
-        class="text-sm shrink-0 text-ink-placeholder"
-        classList={{ 'w-14': !isMobile() }}
+        class={cn(
+          'text-sm shrink-0 text-ink-placeholder',
+          isMobile() ? 'min-h-7 flex items-center' : 'w-14'
+        )}
       >
         {isMobile() ? 'Subject:' : 'Subject'}
       </div>
-      <div class="flex-1">
-        <input
-          ref={props.inputRef}
-          type="text"
-          value={ctx.subject()}
-          placeholder={isMobile() ? '' : 'Subject'}
-          class="w-full resize-none text-sm placeholder:text-ink-placeholder p-1"
-          onInput={(e) => ctx.setSubject(e.currentTarget.value)}
-          disabled={ctx.disabled()}
-        />
+      <div class="flex-1 min-w-0">
+        <Show
+          when={isMobile()}
+          fallback={
+            <input
+              ref={props.inputRef}
+              type="text"
+              value={ctx.subject()}
+              placeholder="Subject"
+              class="w-full resize-none text-sm placeholder:text-ink-placeholder p-1"
+              onInput={(e) => ctx.setSubject(e.currentTarget.value)}
+              disabled={ctx.disabled()}
+            />
+          }
+        >
+          <Show
+            when={!showSummary()}
+            fallback={
+              <button
+                type="button"
+                class="ph-no-capture w-full min-h-7 flex items-center text-sm text-ink text-left"
+                onClick={() => {
+                  setEditing(true);
+                  requestAnimationFrame(() => textareaRef?.focus());
+                }}
+              >
+                <span class="truncate">{ctx.subject()}</span>
+              </button>
+            }
+          >
+            <textarea
+              ref={(el) => {
+                textareaRef = el;
+                props.inputRef?.(el);
+                requestAnimationFrame(() => autosize(el));
+              }}
+              rows="1"
+              value={ctx.subject()}
+              class="w-full resize-none overflow-hidden text-sm p-1"
+              onInput={(e) => {
+                ctx.setSubject(e.currentTarget.value.replace(/\n/g, ' '));
+                autosize(e.currentTarget);
+              }}
+              onFocus={() => setEditing(true)}
+              onBlur={() => setEditing(false)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  e.currentTarget.blur();
+                }
+              }}
+              disabled={ctx.disabled()}
+            />
+          </Show>
+        </Show>
       </div>
       <Show when={ctx.validationError('no_subject')}>
         {(err) => (

--- a/js/app/packages/block-email/component/compose/ComposeSubject.tsx
+++ b/js/app/packages/block-email/component/compose/ComposeSubject.tsx
@@ -14,7 +14,7 @@ export function ComposeSubject(props: {
   const ctx = useCompose();
 
   // On mobile the subject wraps and grows while edited, and folds to a single
-  // truncated line on blur so the body starts near the top (iOS Mail).
+  // truncated line on blur so the body starts near the top.
   const [editing, setEditing] = createSignal(false);
   let textareaRef: HTMLTextAreaElement | undefined;
 

--- a/js/app/packages/block-email/component/compose/ComposeSubject.tsx
+++ b/js/app/packages/block-email/component/compose/ComposeSubject.tsx
@@ -9,7 +9,12 @@ export function ComposeSubject(props: {
 
   return (
     <div class="w-full flex items-center gap-2 border-b border-edge-muted focus-within:border-accent py-2">
-      <div class="text-sm w-14 shrink-0 text-ink-placeholder">Subject</div>
+      <div
+        class="text-sm shrink-0 text-ink-placeholder"
+        classList={{ 'w-14': !isMobile() }}
+      >
+        {isMobile() ? 'Subject:' : 'Subject'}
+      </div>
       <div class="flex-1">
         <input
           ref={props.inputRef}

--- a/js/app/packages/block-email/component/compose/ComposeSubject.tsx
+++ b/js/app/packages/block-email/component/compose/ComposeSubject.tsx
@@ -8,14 +8,14 @@ export function ComposeSubject(props: {
 
   return (
     <div class="w-full flex items-center gap-2 border-b border-edge-muted focus-within:border-accent py-2">
-      <div class="shrink-0 text-ink-placeholder">Subject</div>
+      <div class="text-sm w-14 shrink-0 text-ink-placeholder">Subject</div>
       <div class="flex-1">
         <input
           ref={props.inputRef}
           type="text"
           value={ctx.subject()}
           placeholder="Subject"
-          class="w-full resize-none placeholder:text-ink-placeholder p-1 ml-1"
+          class="w-full resize-none text-sm placeholder:text-ink-placeholder p-1"
           onInput={(e) => ctx.setSubject(e.currentTarget.value)}
           disabled={ctx.disabled()}
         />

--- a/js/app/packages/block-email/component/compose/ComposeSubject.tsx
+++ b/js/app/packages/block-email/component/compose/ComposeSubject.tsx
@@ -1,3 +1,4 @@
+import { isMobile } from '@core/mobile/isMobile';
 import { Show } from 'solid-js';
 import { useCompose } from './ComposeContext';
 
@@ -14,7 +15,7 @@ export function ComposeSubject(props: {
           ref={props.inputRef}
           type="text"
           value={ctx.subject()}
-          placeholder="Subject"
+          placeholder={isMobile() ? '' : 'Subject'}
           class="w-full resize-none text-sm placeholder:text-ink-placeholder p-1"
           onInput={(e) => ctx.setSubject(e.currentTarget.value)}
           disabled={ctx.disabled()}

--- a/js/app/packages/block-email/component/compose/ComposeToolbar.tsx
+++ b/js/app/packages/block-email/component/compose/ComposeToolbar.tsx
@@ -11,7 +11,6 @@ import PaperclipIcon from '@phosphor/paperclip.svg?component-solid';
 import TextAa from '@phosphor/text-aa.svg';
 import Trash from '@phosphor/trash.svg';
 import DotsThreeIcon from '@phosphor-icons/core/bold/dots-three-bold.svg?component-solid';
-import PaperclipHorizontalIcon from '@phosphor-icons/core/regular/paperclip-horizontal.svg?component-solid';
 import { Button, Dropdown, SendButton, Tooltip } from '@ui';
 import { defaultSelectionData } from 'core/component/LexicalMarkdown/plugins';
 import {
@@ -188,7 +187,7 @@ function MobileToolbar(props: {
             class="aspect-square p-1"
             disabled={ctx.disabled()}
           >
-            <PaperclipHorizontalIcon class="h-5" />
+            <PaperclipIcon class="h-5" />
           </Button>
         </div>
         <Show when={ENABLE_EMAIL_SCHEDULED_SEND && ctx.onSendTimeChange}>

--- a/js/app/packages/block-email/component/compose/ComposeToolbar.tsx
+++ b/js/app/packages/block-email/component/compose/ComposeToolbar.tsx
@@ -10,8 +10,7 @@ import { plural } from '@core/util/string';
 import PaperclipIcon from '@phosphor/paperclip.svg?component-solid';
 import TextAa from '@phosphor/text-aa.svg';
 import Trash from '@phosphor/trash.svg';
-import DotsThreeIcon from '@phosphor-icons/core/bold/dots-three-bold.svg?component-solid';
-import { Button, Dropdown, SendButton, Tooltip } from '@ui';
+import { Button, SendButton, Tooltip } from '@ui';
 import { defaultSelectionData } from 'core/component/LexicalMarkdown/plugins';
 import {
   NODE_TRANSFORM,
@@ -174,7 +173,7 @@ function MobileToolbar(props: {
 
   return (
     <SplitHeaderRight>
-      <div class="flex items-center pl-2">
+      <div class="flex items-center gap-1 pl-2">
         <div class="relative" ref={props.attachButtonRef}>
           <Button
             ref={(el) =>
@@ -184,10 +183,10 @@ function MobileToolbar(props: {
               }))
             }
             tooltip="Attach"
-            class="aspect-square p-1"
+            size="icon-sm"
             disabled={ctx.disabled()}
           >
-            <PaperclipIcon class="h-5" />
+            <PaperclipIcon />
           </Button>
         </div>
         <Show when={ENABLE_EMAIL_SCHEDULED_SEND && ctx.onSendTimeChange}>
@@ -223,18 +222,16 @@ function MobileToolbar(props: {
             tooltip="Send email"
           />
         </Tooltip>
-        <Dropdown placement="bottom-end">
-          <Dropdown.Trigger class="aspect-square p-1">
-            <DotsThreeIcon class="h-4.5" />
-          </Dropdown.Trigger>
-          <Dropdown.Content>
-            <Dropdown.Group>
-              <Dropdown.Item disabled={!ctx.hasDraft()} onSelect={ctx.onDelete}>
-                <span class="flex-1 truncate">Delete Draft</span>
-              </Dropdown.Item>
-            </Dropdown.Group>
-          </Dropdown.Content>
-        </Dropdown>
+        <Show when={ctx.hasDraft()}>
+          <Button
+            tooltip="Delete draft"
+            size="icon-sm"
+            disabled={ctx.disabled()}
+            onClick={ctx.onDelete}
+          >
+            <Trash />
+          </Button>
+        </Show>
       </div>
     </SplitHeaderRight>
   );

--- a/js/app/packages/block-email/component/compose/ComposeToolbar.tsx
+++ b/js/app/packages/block-email/component/compose/ComposeToolbar.tsx
@@ -222,16 +222,6 @@ function MobileToolbar(props: {
             tooltip="Send email"
           />
         </Tooltip>
-        <Show when={ctx.hasDraft()}>
-          <Button
-            tooltip="Delete draft"
-            size="icon-sm"
-            disabled={ctx.disabled()}
-            onClick={ctx.onDelete}
-          >
-            <Trash />
-          </Button>
-        </Show>
       </div>
     </SplitHeaderRight>
   );

--- a/js/app/packages/core/component/RecipientSelector.tsx
+++ b/js/app/packages/core/component/RecipientSelector.tsx
@@ -39,6 +39,7 @@ import {
   For,
   type JSX,
   Match,
+  on,
   onMount,
   Show,
   Switch,
@@ -278,6 +279,20 @@ export function RecipientSelector<K extends CombinedRecipientKind>(
   const [disabled, setDisabled] = createSignal(false);
 
   const [listboxRef, setListboxRef] = createSignal<HTMLElement | undefined>();
+
+  // The chips container caps its height and scrolls; keep the input's line
+  // visible as chips push it down.
+  createEffect(
+    on(
+      () => props.selectedOptions.length,
+      () => {
+        requestAnimationFrame(() => {
+          inputRef()?.scrollIntoView({ block: 'nearest' });
+        });
+      },
+      { defer: true }
+    )
+  );
 
   const debouncedHandleChange = debounce(handleChange, 100);
 

--- a/js/app/packages/core/component/RecipientSelector.tsx
+++ b/js/app/packages/core/component/RecipientSelector.tsx
@@ -548,7 +548,7 @@ export function RecipientSelector<K extends CombinedRecipientKind>(
                 <div
                   ref={props.horizontalScroll ? setChipsScrollRef : undefined}
                   class={cn(
-                    'flex gap-1.5 text-ink scrollbar-hidden',
+                    'flex items-center gap-1.5 text-ink scrollbar-hidden',
                     props.horizontalScroll
                       ? 'flex-nowrap overflow-x-auto sm:flex-wrap sm:overflow-x-hidden sm:max-h-37.5 sm:overflow-y-auto pb-0.5 sm:pb-0'
                       : 'flex-wrap max-h-37.5 overflow-y-auto'

--- a/js/app/packages/queries/email/draft.ts
+++ b/js/app/packages/queries/email/draft.ts
@@ -50,6 +50,11 @@ export function useSaveDraftMutation(
           const threadId = data.draft.thread_db_id;
           if (!threadId) return;
           refetchSoupEntity(threadId, 'emailThread');
+          // Reopening the thread reads the messages cache; drop it so the
+          // saved draft body isn't served stale.
+          queryClient.invalidateQueries({
+            queryKey: emailKeys.threadMessages(threadId).queryKey,
+          });
         },
       },
       callbacks


### PR DESCRIPTION
Restyles the email composer around iOS Mail behaviors, mostly on mobile: colon-labeled field rows with a combined "Cc/Bcc, From" row that expands/collapses, unfocused recipient rows summarizing to "Name, Name & N more" with continuous entry across suggestion picks, an autosizing subject that folds to one line on blur, a unified toolbar, and a back-press Delete/Save Draft menu (skipped when an opened draft is untouched). Also persists sender switches in the standalone composer so the draft re-homes to the new inbox, keeps the recipient input visible as chips overflow, and aligns field columns on desktop.
