### PR TITLE
feat(email): emit throttled refresh_email events during inbox backfill

### DIFF
--- a/rust/cloud-storage/email_service/src/pubsub/backfill/increment_counters.rs
+++ b/rust/cloud-storage/email_service/src/pubsub/backfill/increment_counters.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 
 use crate::pubsub::context::PubSubContext;
+use crate::pubsub::util::cg_refresh_email;
 use contacts::domain::ports::ContactsIngress;
 use macro_user_id::user_id::MacroUserIdStr;
 use models_email::db::address::EmailRecipientType;
@@ -15,6 +16,10 @@ use models_email::service::link::Link;
 use models_email::service::pubsub::{DetailedError, FailureReason, ProcessingError};
 use uuid::Uuid;
 
+/// Emit a `refresh_email` event once per this many completed threads, plus
+/// once at job completion, rather than per-thread.
+const REFRESH_EMAIL_THREAD_INTERVAL: i32 = 50;
+
 /// called when a thread has completed processing. checks if it is the last thread to be processed
 /// for the job, and if so, performs the necessary actions for job completion.
 #[tracing::instrument(skip(ctx))]
@@ -23,7 +28,7 @@ pub async fn incr_completed_threads(
     link: &Link,
     job_id: Uuid,
 ) -> Result<(), ProcessingError> {
-    let all_threads_processed = ctx
+    let progress = ctx
         .redis_client
         .incr_completed_threads(job_id)
         .await
@@ -34,7 +39,16 @@ pub async fn incr_completed_threads(
             })
         })?;
 
-    if all_threads_processed {
+    if progress.job_complete || progress.completed_threads % REFRESH_EMAIL_THREAD_INTERVAL == 0 {
+        cg_refresh_email(
+            &ctx.connection_gateway_client,
+            link.macro_id.as_ref(),
+            "backfill",
+        )
+        .await;
+    }
+
+    if progress.job_complete {
         tracing::info!(
             job_id = job_id.to_string(),
             "All threads for job have been processed"

--- a/rust/cloud-storage/email_service/src/util/redis/backfill.rs
+++ b/rust/cloud-storage/email_service/src/util/redis/backfill.rs
@@ -3,6 +3,14 @@ use anyhow::Context;
 use redis::AsyncCommands;
 use uuid::Uuid;
 
+/// Snapshot of a backfill job's thread progress after an increment.
+pub struct BackfillJobProgress {
+    /// Number of threads completed so far, including this increment.
+    pub completed_threads: i32,
+    /// Whether every thread in the job has now been processed.
+    pub job_complete: bool,
+}
+
 impl RedisClient {
     fn job_status_key(job_id: Uuid) -> String {
         format!("bf_job_status:{}", job_id)
@@ -36,8 +44,11 @@ impl RedisClient {
         Ok(())
     }
 
-    /// Increment completed threads count and return true if job is complete, deleting redis entry for job if so
-    pub async fn incr_completed_threads(&self, job_id: Uuid) -> anyhow::Result<bool> {
+    /// Increment completed threads count and return the resulting progress, deleting redis entry for job if complete
+    pub async fn incr_completed_threads(
+        &self,
+        job_id: Uuid,
+    ) -> anyhow::Result<BackfillJobProgress> {
         let key = Self::job_status_key(job_id);
 
         let mut redis_connection = self
@@ -76,7 +87,10 @@ impl RedisClient {
             });
         }
 
-        Ok(job_complete)
+        Ok(BackfillJobProgress {
+            completed_threads,
+            job_complete,
+        })
     }
 
     pub async fn delete_backfill_job_progress(&self, job_id: Uuid) -> anyhow::Result<()> {


### PR DESCRIPTION
Backfill thread completion now emits a `refresh_email` ("backfill") connection-gateway event every 50 completed threads and once at job completion, so clients can refresh newly-backfilled threads without per-thread websocket traffic. `incr_completed_threads` returns the thread-progress count (via a small `BackfillJobProgress` struct) so the emit can be throttled off it. The frontend handler that consumes these events ships separately in #4026.