### PR TITLE
fix(soup): group by queries mapping, invalidation, consolidation, and other issues

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/create-grouped-soup-queries.ts
+++ b/js/app/packages/app/component/next-soup/soup-view/create-grouped-soup-queries.ts
@@ -1,6 +1,7 @@
 import { createInfiniteQueries } from '@app/component/next-soup/soup-view/create-infinite-queries';
 import { throwOnErr } from '@core/util/result';
 import type { EntityData } from '@entity';
+import { useQueryClient } from '@queries/client';
 import {
   parseGroupMeta,
   serializeGroupByField,
@@ -21,7 +22,16 @@ import {
 import { useInstructionsMdIdQuery } from '@queries/storage/instructions-md';
 import { storageServiceClient } from '@service-storage/client';
 import type { SoupApiItem } from '@service-storage/generated/schemas';
-import { type Accessor, createEffect, on } from 'solid-js';
+import type { InfiniteData } from '@tanstack/solid-query';
+import {
+  type Accessor,
+  batch,
+  createEffect,
+  createMemo,
+  createSignal,
+  on,
+  untrack,
+} from 'solid-js';
 
 type InitialGroupPage = {
   items: SoupAstItemsGroupedPage['items'];
@@ -31,6 +41,10 @@ type InitialGroupPage = {
 export type GroupQueryPage = {
   items: InitialGroupPage['items'];
   group: GroupMeta;
+};
+
+export type GroupQueryData = {
+  entities: EntityData[];
 };
 
 type CreateGroupedSoupQueriesArgs = {
@@ -50,6 +64,7 @@ type CreateGroupedSoupQueriesArgs = {
 
 export function createGroupedSoupQueries(args: CreateGroupedSoupQueriesArgs) {
   const instructionsIdQuery = useInstructionsMdIdQuery();
+  const queryClient = useQueryClient();
 
   const mapItemToEntity = (item: SoupApiItem) => {
     if (!isDisplayableSoupItem(item)) return;
@@ -58,16 +73,12 @@ export function createGroupedSoupQueries(args: CreateGroupedSoupQueriesArgs) {
     return mapApiSoupItemToEntity(item);
   };
 
-  const mapPageToEntities = (
-    page: GroupQueryPage,
-    itemFilter: SoupApiItemFilter | undefined
-  ): EntityData[] => {
+  const mapPageToEntities = (page: GroupQueryPage): EntityData[] => {
     const entities: EntityData[] = [];
 
     for (const id of page.group.itemIds) {
       const item = page.items[id];
       if (!item) continue;
-      if (itemFilter && !itemFilter(item)) continue;
 
       const entity = mapItemToEntity(item);
       if (entity) entities.push(entity);
@@ -76,7 +87,29 @@ export function createGroupedSoupQueries(args: CreateGroupedSoupQueriesArgs) {
     return entities;
   };
 
-  const queries = createInfiniteQueries<GroupQueryPage, EntityData[]>(() => {
+  const combineGroupPages = (
+    pages: GroupQueryPage[]
+  ): GroupQueryData | undefined => {
+    if (pages.length === 0) return;
+
+    return {
+      entities: pages.flatMap(mapPageToEntities),
+    };
+  };
+
+  const makeInitialPage = (
+    initialGroupedPage: InitialGroupPage,
+    group: GroupMeta
+  ): GroupQueryPage => {
+    const groupItems: InitialGroupPage['items'] = {};
+    for (const id of group.itemIds) {
+      const item = initialGroupedPage.items[id];
+      if (item) groupItems[id] = item;
+    }
+    return { items: groupItems, group };
+  };
+
+  const configs = createMemo(() => {
     const field = args.groupByField();
     const initialGroupedPage = args.initialPage();
 
@@ -87,7 +120,7 @@ export function createGroupedSoupQueries(args: CreateGroupedSoupQueriesArgs) {
     const options = args.queryOptions();
 
     return initialGroupedPage.groups.map((group) => {
-      const initialPage = { items: initialGroupedPage.items, group };
+      const initialPage = makeInitialPage(initialGroupedPage, group);
 
       return {
         key: group.key,
@@ -122,33 +155,88 @@ export function createGroupedSoupQueries(args: CreateGroupedSoupQueriesArgs) {
         getNextPageParam: (lastPage: GroupQueryPage): string | null => {
           return lastPage.group.nextCursor;
         },
-        select: (pages) =>
-          pages.flatMap((page) =>
-            mapPageToEntities(page, options.meta?.itemFilter)
-          ),
+        select: combineGroupPages,
+        initialData: {
+          pages: [initialPage],
+          pageParams: [null],
+        },
         enabled: false,
         meta: {
           ...options.meta,
           groupBy: field,
           groupKey: group.key,
-          normalize: true,
+          normalize: false,
         },
         staleTime: Infinity,
       };
     });
   });
 
+  const queries = createInfiniteQueries<
+    GroupQueryPage,
+    GroupQueryData | undefined
+  >(configs);
+
+  const [groupDataVersion, setGroupDataVersion] = createSignal(0);
+
+  const list = createMemo(() =>
+    queries.list().map((query) => ({
+      ...query,
+      data: () => {
+        groupDataVersion();
+        return untrack(query.data);
+      },
+      fetchNextPage: async () => {
+        const result = await query.fetchNextPage();
+        setGroupDataVersion((version) => version + 1);
+        return result;
+      },
+    }))
+  );
+
+  const map = createMemo(() => {
+    const next = new Map<string, ReturnType<typeof list>[number]>();
+    for (const query of list()) {
+      next.set(query.key, query);
+    }
+    return next;
+  });
+
   createEffect(
     on(
       () => args.initialPage(),
-      () => {
-        for (const query of queries.list()) {
-          query.refetch();
-        }
+      (initialGroupedPage) => {
+        const field = args.groupByField();
+        if (!field || !initialGroupedPage) return;
+
+        batch(() => {
+          for (const group of initialGroupedPage.groups) {
+            const initialPage = makeInitialPage(initialGroupedPage, group);
+            const queryKey = soupKeys.groupedGroup({
+              params: args.soupParams(),
+              body: args.soupBody(),
+              groupBy: field,
+              groupKey: group.key,
+            }).queryKey;
+
+            queryClient.setQueryData<
+              InfiniteData<GroupQueryPage, string | null>
+            >(queryKey, {
+              pages: [initialPage],
+              pageParams: [null],
+            });
+          }
+
+          setGroupDataVersion((version) => version + 1);
+        });
       },
       { defer: true }
     )
   );
 
-  return queries;
+  return {
+    ...queries,
+    list,
+    map,
+  };
 }

--- a/js/app/packages/app/component/next-soup/soup-view/create-grouped-soup-queries.ts
+++ b/js/app/packages/app/component/next-soup/soup-view/create-grouped-soup-queries.ts
@@ -21,7 +21,7 @@ import {
 import { useInstructionsMdIdQuery } from '@queries/storage/instructions-md';
 import { storageServiceClient } from '@service-storage/client';
 import type { SoupApiItem } from '@service-storage/generated/schemas';
-import type { Accessor } from 'solid-js';
+import { type Accessor, createEffect, on } from 'solid-js';
 
 type InitialGroupPage = {
   items: SoupAstItemsGroupedPage['items'];
@@ -76,7 +76,7 @@ export function createGroupedSoupQueries(args: CreateGroupedSoupQueriesArgs) {
     return entities;
   };
 
-  return createInfiniteQueries<GroupQueryPage, EntityData[]>(() => {
+  const queries = createInfiniteQueries<GroupQueryPage, EntityData[]>(() => {
     const field = args.groupByField();
     const initialGroupedPage = args.initialPage();
 
@@ -122,15 +122,11 @@ export function createGroupedSoupQueries(args: CreateGroupedSoupQueriesArgs) {
         getNextPageParam: (lastPage: GroupQueryPage): string | null => {
           return lastPage.group.nextCursor;
         },
-        placeholderData: {
-          pages: [initialPage],
-          pageParams: [null],
-        },
         select: (pages) =>
           pages.flatMap((page) =>
             mapPageToEntities(page, options.meta?.itemFilter)
           ),
-        enabled: options.enabled,
+        enabled: false,
         meta: {
           ...options.meta,
           groupBy: field,
@@ -141,4 +137,18 @@ export function createGroupedSoupQueries(args: CreateGroupedSoupQueriesArgs) {
       };
     });
   });
+
+  createEffect(
+    on(
+      () => args.initialPage(),
+      () => {
+        for (const query of queries.list()) {
+          query.refetch();
+        }
+      },
+      { defer: true }
+    )
+  );
+
+  return queries;
 }

--- a/js/app/packages/app/component/next-soup/soup-view/create-infinite-queries.ts
+++ b/js/app/packages/app/component/next-soup/soup-view/create-infinite-queries.ts
@@ -2,6 +2,7 @@ import {
   createInfiniteQuery,
   type InfiniteData,
   type InfiniteQueryObserverResult,
+  type QueryObserverResult,
 } from '@tanstack/solid-query';
 import {
   type Accessor,
@@ -36,6 +37,9 @@ type InfiniteQueryResult<TData, TSelect> = {
       InfiniteData<TData | null, string | null>,
       Error
     >
+  >;
+  refetch: () => Promise<
+    QueryObserverResult<InfiniteData<TData | null, string | null>, Error>
   >;
 };
 
@@ -114,6 +118,7 @@ export function createInfiniteQueries<TData, TSelect = TData[]>(
         hasNextPage: () => query.hasNextPage ?? false,
         isFetchingNextPage: () => query.isFetchingNextPage,
         fetchNextPage: () => query.fetchNextPage(),
+        refetch: () => query.refetch(),
       };
     });
 

--- a/js/app/packages/app/component/next-soup/soup-view/soup-view-context.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-view-context.tsx
@@ -388,7 +388,7 @@ export const SoupViewContextProvider: FlowComponent<
       if (!searching) {
         const data = itemsQuery.data;
 
-        if (!data) return prev;
+        if (!data || data.groups) return prev;
 
         const base = data.entities.map((e) =>
           isWithNotification(e) ? e : attachNotifications(e)

--- a/js/app/packages/app/component/next-soup/soup-view/soup-view-context.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-view-context.tsx
@@ -482,12 +482,12 @@ export const SoupViewContextProvider: FlowComponent<
   };
 
   const groupQueries = createGroupedSoupQueries({
-    initialPage: () => {
+    initialPage: createMemo(() => {
       const groups = itemsQuery.data?.groups;
       const items = itemsQuery.data?.itemsById;
       if (!groups || !items) return;
       return { groups, items };
-    },
+    }),
     groupByField,
     soupParams,
     soupBody,
@@ -543,7 +543,7 @@ export const SoupViewContextProvider: FlowComponent<
       const groupMeta = buildGroupMeta(apiGroup);
       const groupData = groupQueryFor(apiGroup.key)?.data();
       const groupEntities =
-        groupData?.map(
+        groupData?.entities?.map(
           (entity) =>
             (isWithNotification(entity)
               ? entity

--- a/js/app/packages/app/component/next-soup/soup-view/soup-view-tabs.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-view-tabs.tsx
@@ -105,7 +105,7 @@ const useCurrentListView = () => {
   });
 };
 
-const PRESERVE_FILTERS_ON_TAB_CHANGE: ListView[] = ['documents'];
+const PRESERVE_FILTERS_ON_TAB_CHANGE: ListView[] = ['documents', 'tasks'];
 
 export const shouldPreserveFiltersOnTabChange = (view: ListView) =>
   PRESERVE_FILTERS_ON_TAB_CHANGE.includes(view);

--- a/js/app/packages/app/component/split-layout/components/SplitPanel.tsx
+++ b/js/app/packages/app/component/split-layout/components/SplitPanel.tsx
@@ -143,75 +143,75 @@ export function SplitPanel(props: SplitPanelProps) {
           panelRef,
         }}
       >
-        <SoupViewContextProvider soup={nextSoup}>
-          <SplitDrawerGroup contentOffsetTop={offsetTop} panelSize={panelSize}>
-            <Show when={props.handle.isSpotLight()}>
-              <div
-                class="fixed inset-0 w-screen h-screen z-modal-overlay bg-modal-overlay pattern-diagonal-4 pattern-edge-muted"
-                onClick={() => props.handle.toggleSpotlight(false)}
-              />
-              <div class="fixed inset-16 bg-surface shadow-xl" />
-            </Show>
-
+        <SplitDrawerGroup contentOffsetTop={offsetTop} panelSize={panelSize}>
+          <Show when={props.handle.isSpotLight()}>
             <div
-              class="relative"
-              classList={{
-                'fixed inset-16 z-modal-overlay isolate opacity-50':
-                  props.handle.isSpotLight(),
-                'opacity-100': props.active || props.handle.isSpotLight(),
-                'size-full': !props.handle.isSpotLight(),
-              }}
-              ref={(ref) => {
-                setPanelRef(ref);
-                props.setPanelRef(ref);
-                attachHotKeys(ref);
-              }}
-              data-split-id={props.split.id}
-              {...splitContainerAttribute}
-              data-modal={props.handle.isSpotLight()}
-              tabindex={-1}
+              class="fixed inset-0 w-screen h-screen z-modal-overlay bg-modal-overlay pattern-diagonal-4 pattern-edge-muted"
+              onClick={() => props.handle.toggleSpotlight(false)}
+            />
+            <div class="fixed inset-16 bg-surface shadow-xl" />
+          </Show>
+
+          <div
+            class="relative"
+            classList={{
+              'fixed inset-16 z-modal-overlay isolate opacity-50':
+                props.handle.isSpotLight(),
+              'opacity-100': props.active || props.handle.isSpotLight(),
+              'size-full': !props.handle.isSpotLight(),
+            }}
+            ref={(ref) => {
+              setPanelRef(ref);
+              props.setPanelRef(ref);
+              attachHotKeys(ref);
+            }}
+            data-split-id={props.split.id}
+            {...splitContainerAttribute}
+            data-modal={props.handle.isSpotLight()}
+            tabindex={-1}
+          >
+            <Panel
+              active={
+                !isMobile() &&
+                props.active &&
+                multipleSplits() &&
+                !props.handle.isSpotLight()
+              }
+              class="rounded-xl mobile:rounded-none mobile:after:hidden mobile:!border-0"
+              depth={1}
             >
-              <Panel
-                active={
-                  !isMobile() &&
-                  props.active &&
-                  multipleSplits() &&
-                  !props.handle.isSpotLight()
-                }
-                class="rounded-xl mobile:rounded-none mobile:after:hidden mobile:!border-0"
-                depth={1}
+              <Panel.Header
+                class={cn(
+                  'block min-h-10.25 touch:min-h-11.25 p-0 overflow-visible',
+                  shouldHideSplitHeader() && 'hidden'
+                )}
               >
-                <Panel.Header
-                  class={cn(
-                    'block min-h-10.25 touch:min-h-11.25 p-0 overflow-visible',
-                    shouldHideSplitHeader() && 'hidden'
-                  )}
-                >
-                  <SplitHeader ref={setHeaderRef} />
-                </Panel.Header>
+                <SplitHeader ref={setHeaderRef} />
+              </Panel.Header>
 
-                <Panel.Toolbar
-                  class={cn(
-                    'items-start py-2 overflow-visible',
-                    !hasToolbarContent() && 'hidden',
-                    !previewState() &&
-                      'border-b-0' /* scuffed: this is shit, but we are blinded by linear */
-                  )}
-                >
-                  <SplitToolbar ref={setToolbarRef} />
-                </Panel.Toolbar>
+              <Panel.Toolbar
+                class={cn(
+                  'items-start py-2 overflow-visible',
+                  !hasToolbarContent() && 'hidden',
+                  !previewState() &&
+                    'border-b-0' /* scuffed: this is shit, but we are blinded by linear */
+                )}
+              >
+                <SplitToolbar ref={setToolbarRef} />
+              </Panel.Toolbar>
 
-                <Panel.Body>
-                  <div class="@container/split size-full overflow-hidden relative">
-                    <Suspense>
+              <Panel.Body>
+                <div class="@container/split size-full overflow-hidden relative">
+                  <Suspense>
+                    <SoupViewContextProvider soup={nextSoup}>
                       <Dynamic component={props.split.mount.element} />
-                    </Suspense>
-                  </div>
-                </Panel.Body>
-              </Panel>
-            </div>
-          </SplitDrawerGroup>
-        </SoupViewContextProvider>
+                    </SoupViewContextProvider>
+                  </Suspense>
+                </div>
+              </Panel.Body>
+            </Panel>
+          </div>
+        </SplitDrawerGroup>
       </SplitPanelContext.Provider>
     </SoupContextProvider>
   );

--- a/js/app/packages/queries/soup/items.ts
+++ b/js/app/packages/queries/soup/items.ts
@@ -235,7 +235,11 @@ export const useSoupAstItemsQuery = (
 
           return mapSoupPageToEntityList(
             { items: page.items, next_cursor: null },
-            { instructionsIdQuery }
+            {
+              instructionsIdQuery,
+              showSupportedForeignEntities:
+                options?.().showSupportedForeignEntities,
+            }
           );
         });
 


### PR DESCRIPTION
- Fix task filters not preserving across tabs correctly
- Fix foreign entities not rendering
- Move soup view context provider inside Suspense boundary
- Fix stale initial data persisting across different group by changes causing invalid data to be shown for a different group by field
- Update group queries invalidation/refetch when initial page changes and updates tracking reads to avoid rerunning the rows memo too frequently