### PR TITLE
feat(email): refetch soup threads on refresh_email backfill events

### DIFF
--- a/js/app/packages/queries/email/sync.ts
+++ b/js/app/packages/queries/email/sync.ts
@@ -1,0 +1,23 @@
+import { invalidateAllSoup } from '@queries/soup/normalized-cache';
+import { leadingAndTrailing, throttle } from '@solid-primitives/scheduled';
+
+const BACKFILL_SOUP_REFRESH_INTERVAL = 5_000;
+
+const throttledBackfillSoupRefresh = leadingAndTrailing(
+  throttle,
+  invalidateAllSoup,
+  BACKFILL_SOUP_REFRESH_INTERVAL
+);
+
+/**
+ * Handles `refresh_email` websocket events. Only `backfill` events refetch
+ * here: steady-state mutations (`upsert_message`, `update_labels`,
+ * `delete_message`) already invalidate soup through the notification-driven
+ * path, and reacting to them again would double-refetch. Backfill produces no
+ * notifications, so this is its only refresh signal — throttled because the
+ * backend emits one event per batch of backfilled threads.
+ */
+export function handleRefreshEmail(eventType: unknown): void {
+  if (eventType !== 'backfill') return;
+  throttledBackfillSoupRefresh();
+}

--- a/js/app/packages/queries/sync/SyncProvider.tsx
+++ b/js/app/packages/queries/sync/SyncProvider.tsx
@@ -5,6 +5,7 @@ import {
 } from '@queries/channel/sync';
 import { handleCommsTyping } from '@queries/channel/typing';
 import { invalidateContacts } from '@queries/contacts/contacts';
+import { handleRefreshEmail } from '@queries/email/sync';
 import {
   applyNotificationStatusUpdate,
   notificationStatusUpdatePayloadSchema,
@@ -85,6 +86,9 @@ export function QuerySyncProvider(props: SyncProviderProps) {
           return;
         }
         applyNotificationStatusUpdate(result.data);
+      })
+      .with({ type: 'refresh_email' }, () => {
+        handleRefreshEmail(data.data);
       })
       .with({ type: 'task_duplicate_matches_updated' }, () => {
         withParsedWebsocketPayload(

--- a/js/app/packages/queries/sync/SyncProvider.tsx
+++ b/js/app/packages/queries/sync/SyncProvider.tsx
@@ -88,7 +88,7 @@ export function QuerySyncProvider(props: SyncProviderProps) {
         applyNotificationStatusUpdate(result.data);
       })
       .with({ type: 'refresh_email' }, () => {
-        handleRefreshEmail(data.data);
+        withParsedWebsocketPayload(data.type, data.data, handleRefreshEmail);
       })
       .with({ type: 'task_duplicate_matches_updated' }, () => {
         withParsedWebsocketPayload(


### PR DESCRIPTION
Re-lands the frontend handler from #4026, which was merged and then reverted in #4027. Handles the `refresh_email` websocket event in `QuerySyncProvider` by refetching soup email threads, throttled (leading + trailing, 5s) so a backfill's batched events don't double-refetch against the notification-driven invalidators. Only the `backfill` event type refetches here; steady-state types are already covered by the notification path. Backend emit is live on main (#4019).
