### PR TITLE
Remove duplicate content from documentation

### DIFF
--- a/docs/apps.mdx
+++ b/docs/apps.mdx
@@ -14,10 +14,6 @@ Macro runs in any modern browser at [macro.com](https://macro.com), with no inst
   ![Macro Big QR](/images/Macro-Big-QR.png)
 </Frame>
 
-<Frame>
-  ![Macro Big QR](/images/Macro-Big-QR.png)
-</Frame>
-
 The Macro iOS app is on the [App Store](https://apps.apple.com/us/app/macro-app/id6743133649). It connects to the same workspace: inbox, email, channels, tasks, docs, and agents on your phone. You can also grab it from **Settings → Mobile App** in the web app, which shows a QR code.
 
 A few things stay desktop-only by design:

--- a/docs/product/docs.mdx
+++ b/docs/product/docs.mdx
@@ -20,14 +20,6 @@ Unlike Notion Macro does not currently permit nesting of documents-within-docume
     className="mx-auto"
     style={{ width:"91%" }}
   />
-
-  <img
-    src="/images/Screenshot-2026-06-11-at-5.13.34-PM.png"
-    alt="Screenshot 2026 06 11 At 5 13 34 PM"
-    title="Screenshot 2026 06 11 At 5 13 34 PM"
-    className="mx-auto"
-    style={{ width:"91%" }}
-  />
 </Frame>
 
 You'll notice collaboration in Macro docs is really fast. Edits from your teammates seem to appear almost instantly as if working locally on the same machine. Edits even to the same line resolve and do not thrash. This is all because Macro uses CRDTs \+ durable objects to ensure that multiple teammates can type in the same doc, task, or message simultaneously and so users can keep working with no network connection.

--- a/docs/switch-to-macro.mdx
+++ b/docs/switch-to-macro.mdx
@@ -8,8 +8,6 @@ Macro replaces several tools with one unified system. But you don't have to move
 
 Most  If you want to keep some of your existing tools and just use Macro for, e.g. Email\+Tasks or Docs\+Files, or Email\+Messaging\+Docs, that's fine — you can keep your other tools connected via MCP.
 
-Most  If you want to keep some of your existing tools and just use Macro for, e.g. Email\+Tasks or Docs\+Files, or Email\+Messaging\+Docs, that's fine — you can keep your other tools connected via MCP.
-
 At a glance, here's what maps to what:
 
 | Coming from | The Macro equivalent |
@@ -23,8 +21,6 @@ At a glance, here's what maps to what:
 | Zoom / Meet | [Calls](/product/calls) |
 
 ## From Superhuman
-
-Before Macro, we were Superhuman users ourselves, and we were heavily inspired by them in designing Macro's email. The main difference is that Macro supports multiple accounts in [one inbox](/product/email#multi-account-inbox), adds more intelligent [Signal vs. Noise](/product/email#signal-vs-noise) splits and unifies messaging, tasks, @mentions and more into a single inbox..
 
 Before Macro, we were Superhuman users ourselves, and we were heavily inspired by them in designing Macro's email. The main difference is that Macro supports multiple accounts in [one inbox](/product/email#multi-account-inbox), adds more intelligent [Signal vs. Noise](/product/email#signal-vs-noise) splits and unifies messaging, tasks, @mentions and more into a single inbox..
 
@@ -47,8 +43,6 @@ The <kbd>j</kbd> / <kbd>k</kbd> / <kbd>e</kbd> triage shortcuts you already know
 
 <iframe src="https://www.youtube.com/embed/tnsxkywzTvY" title="Email on Macro" frameborder="0" className="w-full aspect-video rounded-xl" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen />
 
-<iframe src="https://www.youtube.com/embed/tnsxkywzTvY" title="Email on Macro" frameborder="0" className="w-full aspect-video rounded-xl" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen />
-
 To switch:
 
 1. Connect your Gmail or Google Workspace account (ideally at signup, or later in **Settings**).
@@ -59,13 +53,11 @@ To switch:
 
 Notion asks you to build your own tools out of markdown pages and databases: your CRM, your task tracker, and your wiki are all databases of markdown files. We think databases are the wrong level of abstraction for serious business software. Even before AI, when we scaled our last company, we migrated off of it to HubSpot, Linear, etc. as the team grew. **Markdown files and databases simply aren't powerful enough compared to domain-specific tools.** The longer version of this argument is in the [FAQ](/faq) and the video below.
 
-Notion asks you to build your own tools out of markdown pages and databases: your CRM, your task tracker, and your wiki are all databases of markdown files. We think databases are the wrong level of abstraction for serious business software. Even before AI, when we scaled our last company, we migrated off of it to HubSpot, Linear, etc. as the team grew. **Markdown files and databases simply aren't powerful enough compared to domain-specific tools.** The longer version of this argument is in the [FAQ](/faq) and the video below.
-
 <Frame>
   ![The Notion app icon with an arrow pointing to the Macro app icon](/images/switch-from-notion.svg)
 </Frame>
 
-In Macro, tasks, CRM, email, channels, and files are each their own best-in-class, purpose-built [block](/concepts/blocks), and they all share one data model and one search index. Yes, you give up some of Notion's freeform database flexibility, but **each block works like a real product**, and agents can read all of it as one context vs. paging through a rate-limited API.  In Macro, tasks, CRM, email, channels, and files are each their own best-in-class, purpose-built [block](/concepts/blocks), and they all share one data model and one search index. Yes, you give up some of Notion's freeform database flexibility, but **each block works like a real product**, and agents can read all of it as one context vs. paging through a rate-limited API.
+In Macro, tasks, CRM, email, channels, and files are each their own best-in-class, purpose-built [block](/concepts/blocks), and they all share one data model and one search index. Yes, you give up some of Notion's freeform database flexibility, but **each block works like a real product**, and agents can read all of it as one context vs. paging through a rate-limited API.
 
 |  | Notion | Macro |
 | :-- | :-: | :-: |
@@ -75,8 +67,6 @@ In Macro, tasks, CRM, email, channels, and files are each their own best-in-clas
 | Email and channels | — | ✓ |
 | Freeform databases | ✓ | [Properties](/concepts/properties) on built-in blocks |
 | Agent access to your workspace | Rate-limited API | One unified search index |
-
-<iframe src="https://www.youtube.com/embed/hyU1XYmxkYM" title="What We Learned from Notion" frameborder="0" className="w-full aspect-video rounded-xl" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen />
 
 <iframe src="https://www.youtube.com/embed/hyU1XYmxkYM" title="What We Learned from Notion" frameborder="0" className="w-full aspect-video rounded-xl" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen />
 
@@ -95,8 +85,6 @@ The agent reads pages through the Notion connector and recreates them as [Macro 
 You can also keep Notion MCP connected indefinitely so agents can reference legacy content. Don't feel the need to migrate everything — we liked starting with a clean slate!
 
 ## From Slack
-
-The main thing Macro improves on versus Slack is making channels/DM's less noisy and more focused for technical discussions. The first few replies in a thread show inline, so you don't have to open a thread every time someone replies, and a busy channel looks more like Reddit: organized, and easy to remember where a conversation happened. 
 
 The main thing Macro improves on versus Slack is making channels/DM's less noisy and more focused for technical discussions. The first few replies in a thread show inline, so you don't have to open a thread every time someone replies, and a busy channel looks more like Reddit: organized, and easy to remember where a conversation happened.
 
@@ -203,33 +191,3 @@ Here's the full picture side by side of how Macro compares to the rest of the to
 <Card title="Want help switching?" icon="calendar" href="https://cal.com/team/macro/macro-demo-call">
   Book a call and we'll walk your team through the migration.
 </Card>
-
-Channels also share a single unified inbox with your email, split into [Signal vs. Noise](/product/email#signal-vs-noise).
-
-<iframe src="https://www.youtube.com/embed/1gDOXUxHo0U" title="What Macro learned from Slack/Superhuman" frameborder="0" className="w-full aspect-video rounded-xl" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen />
-
-In building Macro Tasks we were heavily inspired by Linear: status, priority, assignee, keyboard-first, and a [GitHub integration](/integrations/github) that covers the workflow you're used to. Copy a branch name from a task and it moves through In Progress, In Review, and Done as you branch, open the PR, and merge.
-
-<iframe src="https://www.youtube.com/embed/nHxqE2mVKrA" title="What We Learned from Linear" frameborder="0" className="w-full aspect-video rounded-xl" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen />
-
-ClickUp covers tasks, docs, chat, goals, and whiteboards through a deep stack of spaces, folders, lists, and custom statuses that you configure yourself. Macro covers the same ground with dedicated [tasks](/product/tasks), [docs](/product/docs), [channels](/product/channels), and [CRM](/product/crm) that share one data model.
-
-There's less setup and fewer knobs because each tool is already built for its job. Tasks keep the essentials (status, priority, assignee, and [properties](/concepts/properties) when you want them), and [agents](/product/agents) can read across all of it as one context.
-
-<iframe src="https://www.youtube.com/embed/gxJquVXRX5A" title="Tasks on Macro" frameborder="0" className="w-full aspect-video rounded-xl" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen />
-
-Here's the full picture side by side of how Macro compares to the rest of the toolset.
-
-|  | Macro | Superhuman | Notion | Slack | Linear | ClickUp |
-| :-- | :-: | :-: | :-: | :-: | :-: | :-: |
-| [Email](/product/email) | ✓ | ✓ | — | — | — | — |
-| [Channels](/product/channels) | ✓ | — | — | ✓ | — | ✓ |
-| [Tasks](/product/tasks) | ✓ | — | Via databases | — | ✓ | ✓ |
-| [Docs](/product/docs) | ✓ | — | ✓ | — | — | ✓ |
-| [CRM](/product/crm) | ✓ | — | Via databases | — | — | Via setup |
-| [File storage](/product/folders) | ✓ | — | Attachments | Attachments | — | Attachments |
-| [Calls](/product/calls) | ✓ | — | — | Huddles | — | — |
-| [Agents](/product/agents) | ✓ | — | ✓ | — | ✓ | ✓ |
-| [Unified Inbox](/product/inbox) | ✓ | — | — | — | — | — |
-| [Unified Search](/product/search) | ✓ | — | — | — | — | — |
-| [Unified Memory](/product/unified-memory) | ✓ | — | — | — | — | — |


### PR DESCRIPTION
## Summary
This PR removes duplicate paragraphs and sections that were accidentally repeated throughout the documentation.

## Key Changes
- **docs/switch-to-macro.mdx**: Removed 8 duplicate sections including:
  - Duplicate paragraph about keeping existing tools connected via MCP
  - Duplicate Superhuman comparison paragraph
  - Duplicate YouTube iframe for "Email on Macro"
  - Duplicate Notion comparison paragraph
  - Duplicate YouTube iframe for "What We Learned from Notion"
  - Duplicate Slack comparison paragraph
  - Removed orphaned content at the end of the file (Slack channels section, Linear/ClickUp comparisons, and comparison table that appeared to be misplaced)

- **docs/product/docs.mdx**: Removed duplicate screenshot image element that was immediately following the first screenshot

- **docs/apps.mdx**: Removed duplicate QR code Frame component

## Notes
These appear to be accidental duplications, likely from copy-paste errors or merge conflicts. The removal improves documentation clarity and reduces redundancy without changing any actual content or functionality.

https://claude.ai/code/session_01XDsuYWjLBKSGa1WAL5jkLY