### PR TITLE
feat(email): inbox sync-status UX and post-removal email invalidation

### DIFF
--- a/js/app/packages/app/component/settings/Account.tsx
+++ b/js/app/packages/app/component/settings/Account.tsx
@@ -964,14 +964,22 @@ function InboxRow(props: {
             <Chip label="Shared" />
           </Show>
         </div>
-        <Show when={ENABLE_INBOX_SYNC_STATUS}>
+        <Show
+          when={
+            ENABLE_INBOX_SYNC_STATUS &&
+            props.link.sync_status !== SyncStatus.UP_TO_DATE
+          }
+        >
           <span
-            class="text-xs"
+            class="flex items-center gap-1 text-xs"
             classList={{
               'text-failure': props.link.sync_status === SyncStatus.ERROR,
               'text-ink-muted': props.link.sync_status !== SyncStatus.ERROR,
             }}
           >
+            <Show when={props.link.sync_status === SyncStatus.SYNCING}>
+              <ArrowsClockwiseIcon class="size-3 animate-spin" />
+            </Show>
             {syncStatusLabel(props.link.sync_status)}
           </span>
         </Show>

--- a/js/app/packages/core/constant/featureFlags.ts
+++ b/js/app/packages/core/constant/featureFlags.ts
@@ -251,7 +251,7 @@ export const ENABLE_INBOX_RESYNC = resolveFeatureFlag(
 
 export const ENABLE_INBOX_SYNC_STATUS = resolveFeatureFlag(
   'ENABLE_INBOX_SYNC_STATUS',
-  false
+  true
 );
 
 const _ENABLE_TASKS_TABS = resolveFeatureFlag('ENABLE_TASKS_TABS', true);

--- a/js/app/packages/queries/email/link.ts
+++ b/js/app/packages/queries/email/link.ts
@@ -2,6 +2,7 @@ import { useUserId } from '@core/context/user';
 import { throwOnErr } from '@core/util/result';
 import { invalidateUserInfo } from '@queries/auth/user-info';
 import { queryClient } from '@queries/client';
+import { invalidateAllSoup } from '@queries/soup/normalized-cache';
 import { emailClient } from '@service-email/client';
 import {
   type ListLinksResponse,
@@ -123,6 +124,12 @@ export function useRemoveInboxMutation(callbacks?: RemoveInboxCallbacks) {
           // here would resurrect the optimistically-removed row; instead leave the
           // optimistic cache in place and let the next focus refetch reconcile once
           // teardown completes.
+          //
+          // Clears a delegated inbox's threads immediately (its removal is a
+          // synchronous edge drop). An owned inbox is torn down asynchronously,
+          // so its threads are dropped when the `refresh_email` `link_removed`
+          // event arrives after teardown — refetching now would race that.
+          invalidateAllSoup();
           await invalidateUserInfo();
         },
 

--- a/js/app/packages/queries/email/sync.ts
+++ b/js/app/packages/queries/email/sync.ts
@@ -1,0 +1,72 @@
+import { toast } from '@core/component/Toast/Toast';
+import { ENABLE_INBOX_SYNC_STATUS } from '@core/constant/featureFlags';
+import { invalidateAllSoup } from '@queries/soup/normalized-cache';
+import {
+  BackfillStatus,
+  type RefreshEmailEvent,
+} from '@service-email/generated/schemas';
+import { leadingAndTrailing, throttle } from '@solid-primitives/scheduled';
+import { invalidateEmailLinks } from './link';
+
+const BACKFILL_SOUP_REFRESH_INTERVAL = 5_000;
+
+const throttledBackfillSoupRefresh = leadingAndTrailing(
+  throttle,
+  invalidateAllSoup,
+  BACKFILL_SOUP_REFRESH_INTERVAL
+);
+
+// The gateway double-encodes the payload, so callers must JSON-parse `data.data`
+// (via `withParsedWebsocketPayload`) before passing it here.
+function asRefreshEmailEvent(payload: unknown): RefreshEmailEvent | undefined {
+  return typeof payload === 'object' &&
+    payload !== null &&
+    typeof (payload as { event?: unknown }).event === 'string'
+    ? (payload as RefreshEmailEvent)
+    : undefined;
+}
+
+/**
+ * Handles `refresh_email` websocket events. Only `backfill` events act here:
+ * steady-state mutations (`upsert_message`, `update_labels`, `delete_message`)
+ * already invalidate soup through the notification-driven path, and reacting to
+ * them again would double-refetch.
+ *
+ * Backfill produces no notifications, so this is its only refresh signal.
+ * `progress` refetches soup, throttled because the backend emits one event per
+ * batch of threads. `complete`/`failed` additionally refetch the links list so
+ * the inbox's `sync_status` settles out of `SYNCING`, and surface a toast.
+ */
+export function handleRefreshEmail(payload: unknown): void {
+  const event = asRefreshEmailEvent(payload);
+  if (!event) return;
+
+  // An inbox finished its async teardown — drop its now-deleted threads and
+  // settle its links row. This is the only reliable signal that teardown is
+  // done; refetching on the delete request itself races the cascade delete.
+  if (event.event === 'link_removed') {
+    invalidateAllSoup();
+    invalidateEmailLinks();
+    return;
+  }
+
+  if (event.event !== 'backfill') return;
+  const { status } = event;
+
+  if (status === BackfillStatus.failed) {
+    invalidateEmailLinks();
+    if (ENABLE_INBOX_SYNC_STATUS) {
+      toast.failure('Inbox sync failed');
+    }
+    return;
+  }
+
+  throttledBackfillSoupRefresh();
+
+  if (status === BackfillStatus.complete) {
+    invalidateEmailLinks();
+    if (ENABLE_INBOX_SYNC_STATUS) {
+      toast.success('Inbox synced');
+    }
+  }
+}

--- a/js/app/packages/queries/sync/SyncProvider.tsx
+++ b/js/app/packages/queries/sync/SyncProvider.tsx
@@ -5,6 +5,7 @@ import {
 } from '@queries/channel/sync';
 import { handleCommsTyping } from '@queries/channel/typing';
 import { invalidateContacts } from '@queries/contacts/contacts';
+import { handleRefreshEmail } from '@queries/email/sync';
 import {
   applyNotificationStatusUpdate,
   notificationStatusUpdatePayloadSchema,
@@ -85,6 +86,9 @@ export function QuerySyncProvider(props: SyncProviderProps) {
           return;
         }
         applyNotificationStatusUpdate(result.data);
+      })
+      .with({ type: 'refresh_email' }, () => {
+        withParsedWebsocketPayload(data.type, data.data, handleRefreshEmail);
       })
       .with({ type: 'task_duplicate_matches_updated' }, () => {
         withParsedWebsocketPayload(


### PR DESCRIPTION
Frontend consumer of the typed `refresh_email` events. Handles `backfill` (`progress` refetches soup threads, throttled; `complete`/`failed` also refetch links so `sync_status` settles, with a toast) and `link_removed` (drops the torn-down inbox's threads + links — fixes the removal race where soup refetched before the async cascade delete finished). Adds an animated syncing indicator to the settings inbox row, drops the persistent "Up to date" label, invalidates soup on delegated inbox removal, and enables `ENABLE_INBOX_SYNC_STATUS` by default. Pairs with the backend emits in #4019/#4033/#4036.