### PR TITLE
feat(themes): restyle theme menu for clarity

### DIFF
--- a/js/app/packages/app/component/GlobalHotkeys.tsx
+++ b/js/app/packages/app/component/GlobalHotkeys.tsx
@@ -25,12 +25,9 @@ import { debounce } from '@solid-primitives/scheduled';
 import { ThemeChips } from '@theme/components/ThemeChips';
 import type { ThemeV2 } from '@theme/types/themeTypes';
 import { registerHotkey } from 'core/hotkey/hotkeys';
-import { type Component, createMemo, onCleanup } from 'solid-js';
+import { type Component, onCleanup } from 'solid-js';
 import {
-  setDarkModeTheme,
-  setLightModeTheme,
-  setThemeShouldMatchSystem,
-  themeShouldMatchSystem,
+  setThemeMode,
   themes,
 } from '../../theme/signals/themeSignals';
 
@@ -297,62 +294,31 @@ export default function GlobalShortcuts() {
     });
   });
 
-  const setPreferredLightScope = registerHotkey({
+  registerHotkey({
     scopeId: 'global',
-    description: 'Set preferred light mode theme',
+    description: 'Light mode',
     keyDownHandler: () => {
+      setThemeMode('light');
       return true;
     },
-    activateCommandScope: true,
     runWithInputFocused: true,
-  });
-
-  themes().forEach((theme) => {
-    registerHotkey({
-      scopeId: setPreferredLightScope.commandScopeId,
-      description: `${theme.name}`,
-      keyDownHandler: () => {
-        setLightModeTheme(theme.id);
-        analytics.track('theme_changed', { themeId: theme.id });
-        return true;
-      },
-      runWithInputFocused: true,
-      displayComponent: () => <ThemeDisplay theme={theme} />,
-    });
-  });
-
-  const setPreferredDarkScope = registerHotkey({
-    scopeId: 'global',
-    description: 'Set preferred dark mode theme',
-    keyDownHandler: () => {
-      return true;
-    },
-    activateCommandScope: true,
-    runWithInputFocused: true,
-  });
-
-  themes().forEach((theme) => {
-    registerHotkey({
-      scopeId: setPreferredDarkScope.commandScopeId,
-      description: `${theme.name}`,
-      keyDownHandler: () => {
-        setDarkModeTheme(theme.id);
-        analytics.track('theme_changed', { themeId: theme.id });
-        return true;
-      },
-      runWithInputFocused: true,
-      displayComponent: () => <ThemeDisplay theme={theme} />,
-    });
   });
 
   registerHotkey({
     scopeId: 'global',
-    description: createMemo(
-      () =>
-        `${themeShouldMatchSystem() ? 'Turn off a' : 'A'}uto detect color scheme`
-    ),
+    description: 'Dark mode',
     keyDownHandler: () => {
-      setThemeShouldMatchSystem((prev) => !prev);
+      setThemeMode('dark');
+      return true;
+    },
+    runWithInputFocused: true,
+  });
+
+  registerHotkey({
+    scopeId: 'global',
+    description: 'System color scheme',
+    keyDownHandler: () => {
+      setThemeMode('system');
       return true;
     },
     runWithInputFocused: true,

--- a/js/app/packages/app/component/GlobalHotkeys.tsx
+++ b/js/app/packages/app/component/GlobalHotkeys.tsx
@@ -26,7 +26,7 @@ import { ThemeChips } from '@theme/components/ThemeChips';
 import type { ThemeV2 } from '@theme/types/themeTypes';
 import { registerHotkey } from 'core/hotkey/hotkeys';
 import { type Component, onCleanup } from 'solid-js';
-import { setThemeMode, themes } from '../../theme/signals/themeSignals';
+import { themes } from '../../theme/signals/themeSignals';
 
 import { applyTheme } from '../../theme/utils/themeUtils';
 import { globalSplitManager } from '../signal/splitLayout';
@@ -289,36 +289,6 @@ export default function GlobalShortcuts() {
       runWithInputFocused: true,
       displayComponent: () => <ThemeDisplay theme={theme} />,
     });
-  });
-
-  registerHotkey({
-    scopeId: 'global',
-    description: 'Light mode',
-    keyDownHandler: () => {
-      setThemeMode('light');
-      return true;
-    },
-    runWithInputFocused: true,
-  });
-
-  registerHotkey({
-    scopeId: 'global',
-    description: 'Dark mode',
-    keyDownHandler: () => {
-      setThemeMode('dark');
-      return true;
-    },
-    runWithInputFocused: true,
-  });
-
-  registerHotkey({
-    scopeId: 'global',
-    description: 'System color scheme',
-    keyDownHandler: () => {
-      setThemeMode('system');
-      return true;
-    },
-    runWithInputFocused: true,
   });
 
   registerHotkey({

--- a/js/app/packages/app/component/GlobalHotkeys.tsx
+++ b/js/app/packages/app/component/GlobalHotkeys.tsx
@@ -26,10 +26,7 @@ import { ThemeChips } from '@theme/components/ThemeChips';
 import type { ThemeV2 } from '@theme/types/themeTypes';
 import { registerHotkey } from 'core/hotkey/hotkeys';
 import { type Component, onCleanup } from 'solid-js';
-import {
-  setThemeMode,
-  themes,
-} from '../../theme/signals/themeSignals';
+import { setThemeMode, themes } from '../../theme/signals/themeSignals';
 
 import { applyTheme } from '../../theme/utils/themeUtils';
 import { globalSplitManager } from '../signal/splitLayout';

--- a/js/app/packages/app/component/Root.tsx
+++ b/js/app/packages/app/component/Root.tsx
@@ -85,7 +85,7 @@ import { currentThemeId } from '../../theme/signals/themeSignals';
 import {
   applyTheme,
   ensureMinimalThemeContrast,
-  systemThemeEffect,
+  systemModeEffect,
 } from '../../theme/utils/themeUtils';
 import { Login } from './auth/Login';
 import { setCookie } from './auth/Shared';
@@ -501,7 +501,7 @@ export function Root() {
   });
 
   onMount(() => {
-    systemThemeEffect();
+    systemModeEffect();
     applyTheme(currentThemeId());
     ensureMinimalThemeContrast();
   });

--- a/js/app/packages/app/component/Root.tsx
+++ b/js/app/packages/app/component/Root.tsx
@@ -85,7 +85,6 @@ import { currentThemeId } from '../../theme/signals/themeSignals';
 import {
   applyTheme,
   ensureMinimalThemeContrast,
-  systemModeEffect,
 } from '../../theme/utils/themeUtils';
 import { Login } from './auth/Login';
 import { setCookie } from './auth/Shared';
@@ -501,7 +500,6 @@ export function Root() {
   });
 
   onMount(() => {
-    systemModeEffect();
     applyTheme(currentThemeId());
     ensureMinimalThemeContrast();
   });

--- a/js/app/packages/app/component/settings/Appearance.tsx
+++ b/js/app/packages/app/component/settings/Appearance.tsx
@@ -1,12 +1,14 @@
 import { monochromeIcons, setMonochromeIcons, setTooltipsEnabled, tooltipsEnabled } from '@ui/signals/signals';
 import { ThemeEditorAdvanced } from '@theme/components/ThemeEditorAdvanced';
-import { ThemeEditorBasic } from '@theme/components/ThemeEditorBasic';
+import { ThemeEditorBasic, randomizeTheme } from '@theme/components/ThemeEditorBasic';
 import ThemeTools from '@theme/components/ThemeTools';
 import ThemeList from '@theme/components/ThemeList';
 import { isMobile } from '@core/mobile/isMobile';
 import { createSignal, Show } from 'solid-js';
 import { TabsInset } from '@core/component/TabsInset';
-import { Panel, ToggleSwitch } from '@ui';
+import IconDice from '@phosphor-icons/core/regular/dice-five.svg?component-solid';
+import { setShowDarkThemes, setShowLightThemes, showDarkThemes, showLightThemes } from '@theme/signals/themeSignals';
+import { Button, InlineCheckbox, Panel, ToggleSwitch } from '@ui';
 
 type PanelA = 'basic' | 'advanced';
 type PanelB ='themes' | 'ui'
@@ -43,7 +45,9 @@ export function Appearance() {
       <div
         class="max-w-200 size-full"
         style={{
-          'grid-template-rows': `${isMobile() ? '322.5px' : '432.5px'} 1fr`,
+          // Basic editor shrinks to fit its content; Advanced needs a fixed,
+          // scrollable height since its per-token list is taller than the panel.
+          'grid-template-rows': `${activeTabA() === 'advanced' ? (isMobile() ? '322.5px' : '432.5px') : 'min-content'} 1fr`,
           'grid-template-columns': '1fr',
           'overflow': 'hidden',
           'display': 'grid',
@@ -72,7 +76,7 @@ export function Appearance() {
             </Panel.Toolbar>
           </Show>
 
-          <Panel.Body scroll>
+          <Panel.Body scroll={activeTabA() === 'advanced'}>
             <Show when={activeTabA() === 'basic'}>
               <ThemeEditorBasic />
             </Show>
@@ -93,7 +97,37 @@ export function Appearance() {
               value={activeTabB()}
               defaultValue="list"
             />
+            <div class="flex-1" />
+            <Button
+              label="Randomize Theme"
+              onPointerDown={randomizeTheme}
+              variant="ghost"
+              size="icon-sm"
+            >
+              <IconDice />
+            </Button>
           </Panel.Header>
+          <Show when={activeTabB() === 'themes'}>
+            <Panel.Toolbar class="gap-4 pl-5">
+              <span class="text-xs text-ink-extra-muted">Filter themes</span>
+              <button
+                type="button"
+                class="inline-flex items-center gap-1.5 text-xs text-ink-muted hover:text-ink"
+                onClick={() => setShowLightThemes((v) => !v)}
+              >
+                <InlineCheckbox checked={showLightThemes()} />
+                Light
+              </button>
+              <button
+                type="button"
+                class="inline-flex items-center gap-1.5 text-xs text-ink-muted hover:text-ink"
+                onClick={() => setShowDarkThemes((v) => !v)}
+              >
+                <InlineCheckbox checked={showDarkThemes()} />
+                Dark
+              </button>
+            </Panel.Toolbar>
+          </Show>
           <Panel.Body scroll>
             <Show when={activeTabB() === 'themes'}>
               <ThemeList />

--- a/js/app/packages/app/component/settings/Appearance.tsx
+++ b/js/app/packages/app/component/settings/Appearance.tsx
@@ -7,6 +7,7 @@ import { isMobile } from '@core/mobile/isMobile';
 import { createSignal, Show } from 'solid-js';
 import { TabsInset } from '@core/component/TabsInset';
 import IconDice from '@phosphor-icons/core/regular/dice-five.svg?component-solid';
+import IconFunnel from '@phosphor-icons/core/regular/funnel-simple.svg?component-solid';
 import { setShowDarkThemes, setShowLightThemes, showDarkThemes, showLightThemes } from '@theme/signals/themeSignals';
 import { Button, InlineCheckbox, Panel, ToggleSwitch } from '@ui';
 
@@ -39,6 +40,7 @@ function UserInterface() {
 export function Appearance() {
   const [activeTabA, setActiveTabA] = createSignal<PanelA>('basic');
   const [activeTabB, setActiveTabB] = createSignal<PanelB>('themes');
+  const [showFilters, setShowFilters] = createSignal(false);
 
   return (
     <div class="h-full overflow-hidden flex justify-center p-2">
@@ -98,16 +100,27 @@ export function Appearance() {
               defaultValue="list"
             />
             <div class="flex-1" />
+            <Show when={activeTabB() === 'themes'}>
+              <Button
+                label="Filter Themes"
+                onPointerDown={() => setShowFilters((v) => !v)}
+                variant={showFilters() ? 'cta' : 'ghost'}
+                size="icon-sm"
+              >
+                <IconFunnel />
+              </Button>
+            </Show>
             <Button
               label="Randomize Theme"
               onPointerDown={randomizeTheme}
               variant="ghost"
               size="icon-sm"
+              class="ml-1.5"
             >
               <IconDice />
             </Button>
           </Panel.Header>
-          <Show when={activeTabB() === 'themes'}>
+          <Show when={activeTabB() === 'themes' && showFilters()}>
             <Panel.Toolbar class="gap-4 pl-5">
               <span class="text-xs text-ink-extra-muted">Filter themes</span>
               <button

--- a/js/app/packages/theme/components/ThemeChips.tsx
+++ b/js/app/packages/theme/components/ThemeChips.tsx
@@ -3,16 +3,25 @@ import IconTextT from '@phosphor-icons/core/regular/text-t.svg?component-solid';
 
 type Token = { l: number; c: number; h: number };
 
-/** A theme swatch: an encompassing square of the theme's background color with
- *  the accent and ink (T) inside. Always shows the theme's original intended
- *  colors — each theme is intrinsically light or dark. */
+/** A theme swatch: an encompassing square of the theme's panel surface with the
+ *  accent and ink (T) inside. Always shows the theme's original intended colors
+ *  — each theme is intrinsically light or dark. */
 export function ThemeChips(props: { theme: ThemeV2 }) {
   const oklch = (token: Token) => {
     if (!token) { return 'transparent'; }
     return `oklch(${token.l} ${token.c} ${token.h}deg)`;
   };
 
-  const bg = () => oklch(props.theme.tokens.b0);
+  // Approximate the app's prevalent panel surface rather than the darkest base
+  // background: lift b0's lightness by the theme's depth, matching how Layer
+  // elevates surfaces (b0l + (layer/5) * themeDepth) at a typical panel depth.
+  // Flat b0 made the swatches read too dark and blend together.
+  const PANEL_LAYER = 2;
+  const bg = () => {
+    const b0 = props.theme.tokens.b0;
+    const l = b0.l + (PANEL_LAYER / 5) * (props.theme.depth ?? 0.15);
+    return `oklch(${l} ${b0.c} ${b0.h}deg)`;
+  };
   const accent = () => oklch(props.theme.tokens.a0);
   const ink = () => oklch(props.theme.tokens.c0);
 
@@ -20,13 +29,13 @@ export function ThemeChips(props: { theme: ThemeV2 }) {
   return (
     <span
       class="inline-flex items-center rounded-sm border border-edge-muted"
-      style={{ 'background-color': bg(), padding: '6px', gap: '6px' }}
+      style={{ 'background-color': bg(), padding: '8px', gap: '8px' }}
     >
       <span
         class="inline-block rounded-xs"
-        style={{ 'background-color': accent(), width: '12px', height: '12px' }}
+        style={{ 'background-color': accent(), width: '13px', height: '13px' }}
       />
-      <IconTextT style={{ color: ink(), width: '14px', height: '14px' }} />
+      <IconTextT style={{ color: ink(), width: '18px', height: '18px' }} />
     </span>
   );
 }

--- a/js/app/packages/theme/components/ThemeChips.tsx
+++ b/js/app/packages/theme/components/ThemeChips.tsx
@@ -1,29 +1,32 @@
-import type { ThemeV2 } from "@theme/types/themeTypes";
+import type { ThemeV2 } from '@theme/types/themeTypes';
+import IconTextT from '@phosphor-icons/core/regular/text-t.svg?component-solid';
 
+type Token = { l: number; c: number; h: number };
+
+/** A theme swatch: an encompassing square of the theme's background color with
+ *  the accent and ink (T) inside. Always shows the theme's original intended
+ *  colors — each theme is intrinsically light or dark. */
 export function ThemeChips(props: { theme: ThemeV2 }) {
-  const oklch = (token: { l: number; c: number; h: number }) => {
-    if (!token) return 'transparent';
+  const oklch = (token: Token) => {
+    if (!token) { return 'transparent'; }
     return `oklch(${token.l} ${token.c} ${token.h}deg)`;
   };
 
-  const a0 = () => oklch(props.theme.tokens.a0);
-  const b0 = () => oklch(props.theme.tokens.b0);
-  const c0 = () => oklch(props.theme.tokens.c0);
+  const bg = () => oklch(props.theme.tokens.b0);
+  const accent = () => oklch(props.theme.tokens.a0);
+  const ink = () => oklch(props.theme.tokens.c0);
 
+  // Uniform padding around and gap between the items so the spacing reads evenly.
   return (
-    <span class="inline-flex items-center gap-0.5">
+    <span
+      class="inline-flex items-center rounded-sm border border-edge-muted"
+      style={{ 'background-color': bg(), padding: '6px', gap: '6px' }}
+    >
       <span
-        class="inline-block size-2.5 rounded-xs border border-edge-muted"
-        style={{ 'background-color': a0() }}
+        class="inline-block rounded-xs"
+        style={{ 'background-color': accent(), width: '12px', height: '12px' }}
       />
-      <span
-        class="inline-block size-2.5 rounded-xs border border-edge-muted"
-        style={{ 'background-color': b0() }}
-      />
-      <span
-        class="inline-block size-2.5 rounded-xs border border-edge-muted"
-        style={{ 'background-color': c0() }}
-      />
+      <IconTextT style={{ color: ink(), width: '14px', height: '14px' }} />
     </span>
-  )
+  );
 }

--- a/js/app/packages/theme/components/ThemeChips.tsx
+++ b/js/app/packages/theme/components/ThemeChips.tsx
@@ -1,10 +1,10 @@
 import type { ThemeV2 } from '@theme/types/themeTypes';
-import IconTextT from '@phosphor-icons/core/regular/text-t.svg?component-solid';
+import IconTextA from '@phosphor-icons/core/regular/text-a-underline.svg?component-solid';
 
 type Token = { l: number; c: number; h: number };
 
 /** A theme swatch: an encompassing square of the theme's panel surface with the
- *  accent and ink (T) inside. Always shows the theme's original intended colors
+ *  accent and ink (A) inside. Always shows the theme's original intended colors
  *  — each theme is intrinsically light or dark. */
 export function ThemeChips(props: { theme: ThemeV2 }) {
   const oklch = (token: Token) => {
@@ -35,7 +35,7 @@ export function ThemeChips(props: { theme: ThemeV2 }) {
         class="inline-block rounded-xs"
         style={{ 'background-color': accent(), width: '13px', height: '13px' }}
       />
-      <IconTextT style={{ color: ink(), width: '18px', height: '18px' }} />
+      <IconTextA style={{ color: ink(), width: '18px', height: '18px' }} />
     </span>
   );
 }

--- a/js/app/packages/theme/components/ThemeCrud.tsx
+++ b/js/app/packages/theme/components/ThemeCrud.tsx
@@ -19,6 +19,7 @@ export function ThemeCrud(props: ThemeCrudProps) {
       class="flex shrink-0 items-center gap-0.5"
       onClick={stop}
       onPointerDown={stop}
+      onKeyDown={stop}
     >
       <Button
         label="Copy To Clipboard"

--- a/js/app/packages/theme/components/ThemeCrud.tsx
+++ b/js/app/packages/theme/components/ThemeCrud.tsx
@@ -16,18 +16,7 @@ export function ThemeCrud(props: ThemeCrudProps) {
 
   return (
     <div
-      style="
-        grid-auto-columns: min-content;
-        background-color: var(--b0);
-        grid-auto-flow: column;
-        box-sizing: border-box;
-        align-items: center;
-        direction: rtl;
-        padding: 0 12px;
-        display: grid;
-        height: 100%;
-        gap: 4.5px;
-      "
+      class="flex shrink-0 items-center gap-0.5"
       onClick={stop}
       onPointerDown={stop}
     >

--- a/js/app/packages/theme/components/ThemeEditorBasic.tsx
+++ b/js/app/packages/theme/components/ThemeEditorBasic.tsx
@@ -1,7 +1,9 @@
-import { batch, createEffect, createSignal, onCleanup, onMount, untrack } from 'solid-js';
+import { batch, createEffect, createSignal, type JSX, onCleanup, onMount, untrack } from 'solid-js';
 import { setThemeDepth, themeDepth } from '../signals/themeSignals';
 import { themeReactive } from '../signals/themeReactive';
+import { flipLightDark } from '../utils/themeUtils';
 import { isMobile } from '@core/mobile/isMobile';
+import IconFlip from '@phosphor-icons/core/regular/circle-half-tilt.svg?component-solid';
 
 function setLightness(lightness: number) {
   batch(() => {
@@ -124,6 +126,7 @@ function NumberInput(props: {
   max: number;
   displayMin?: number;
   displayMax?: number;
+  action?: JSX.Element;
 }) {
   const dMin = () => props.displayMin ?? 0;
   const dMax = () => props.displayMax ?? 100;
@@ -143,36 +146,50 @@ function NumberInput(props: {
 
   return (
     <div style="display: flex; align-items: center; gap: 4px; flex: none;">
-      <input
-        class="theme-editor-basic-num"
-        type="number"
-        value={text()}
-        min={dMin()}
-        max={dMax()}
-        step={1}
-        onInput={(e) => {
-          const raw = e.currentTarget.value;
-          setIsSetByInput(true);
-          setText(raw);
-          const d = parseFloat(raw);
-          if (!Number.isNaN(d)) { props.set(fromDisplay(Math.max(dMin(), Math.min(dMax(), d)))); }
-        }}
-        onBlur={() => setText(Math.round(toDisplay(props.get())).toString())}
+      <div
         style="
-          font-family: var(--font-mono);
           background-color: var(--b1);
           border: 1px solid var(--b4);
           box-sizing: border-box;
+          align-items: center;
           border-radius: 4px;
-          text-align: right;
-          color: var(--c0);
           padding: 3px 6px;
-          font-size: 12px;
-          flex: none;
-          width: 7ch;
-          outline: none;
+          display: flex;
+          width: 8ch;
+          gap: 3px;
         "
-      />
+      >
+        {props.action}
+        <input
+          class="theme-editor-basic-num"
+          type="number"
+          value={text()}
+          min={dMin()}
+          max={dMax()}
+          step={1}
+          onInput={(e) => {
+            const raw = e.currentTarget.value;
+            setIsSetByInput(true);
+            setText(raw);
+            const d = parseFloat(raw);
+            if (!Number.isNaN(d)) { props.set(fromDisplay(Math.max(dMin(), Math.min(dMax(), d)))); }
+          }}
+          onBlur={() => setText(Math.round(toDisplay(props.get())).toString())}
+          style="
+            font-family: var(--font-mono);
+            background: transparent;
+            box-sizing: border-box;
+            text-align: right;
+            color: var(--c0);
+            font-size: 12px;
+            min-width: 0;
+            outline: none;
+            border: none;
+            padding: 0;
+            flex: 1;
+          "
+        />
+      </div>
       <span style="color: var(--c2); font-size: 12px;">%</span>
     </div>
   );
@@ -409,11 +426,11 @@ export function ThemeEditorBasic(){
           font-size: 12px;
         "
       >
-       <div class="grid gap-5 @2xl:grid-cols-2 @2xl:items-stretch">
+       <div class="grid gap-5 @2xl:grid-cols-2 @2xl:items-start">
         <div
           onPointerDown={handleCanvasPointerDown}
           ref={canvasContainerRef}
-          class={`${isMobile() ? 'h-[140px]' : 'h-[250px]'} @2xl:h-full`}
+          class={isMobile() ? 'h-[140px]' : 'h-[250px]'}
           style={{
             'border': '1px solid var(--b4)',
             'border-radius': '6px',
@@ -718,6 +735,17 @@ export function ThemeEditorBasic(){
             max={0.8}
             displayMin={-100}
             displayMax={100}
+            action={
+              <button
+                type="button"
+                aria-label="Flip light / dark"
+                onPointerDown={flipLightDark}
+                class="flex shrink-0 cursor-pointer items-center justify-center text-ink-muted hover:text-ink"
+                style="width: 14px; height: 14px; padding: 0; border: none; background: none;"
+              >
+                <IconFlip style={{ width: '14px', height: '14px' }} />
+              </button>
+            }
           />
           </div>
           </div>

--- a/js/app/packages/theme/components/ThemeEditorBasic.tsx
+++ b/js/app/packages/theme/components/ThemeEditorBasic.tsx
@@ -1,4 +1,4 @@
-import { batch, createEffect, createSignal, onCleanup, onMount } from 'solid-js';
+import { batch, createEffect, createSignal, onCleanup, onMount, untrack } from 'solid-js';
 import { setThemeDepth, themeDepth } from '../signals/themeSignals';
 import { themeReactive } from '../signals/themeReactive';
 import { isMobile } from '@core/mobile/isMobile';
@@ -110,6 +110,72 @@ export function randomizeTheme(){
     setSaturation(randSaturation);
     setThemeDepth(randDepth);
   });
+}
+
+/** Numeric value box shown to the right of each slider. Displays/edits the value
+ *  on a display scale (default 0-100) mapped from the control's internal range.
+ *  Pass displayMin/displayMax for a centered scale, e.g. -100..100 for Contrast.
+ *  Keeps its own text state while typing (mirroring ThemeEditorAdvanced) so
+ *  reactive updates from the slider don't fight the user's input. */
+function NumberInput(props: {
+  get: () => number;
+  set: (n: number) => void;
+  min: number;
+  max: number;
+  displayMin?: number;
+  displayMax?: number;
+}) {
+  const dMin = () => props.displayMin ?? 0;
+  const dMax = () => props.displayMax ?? 100;
+  const toDisplay = (v: number) =>
+    dMin() + ((v - props.min) / (props.max - props.min)) * (dMax() - dMin());
+  const fromDisplay = (d: number) =>
+    props.min + ((d - dMin()) / (dMax() - dMin())) * (props.max - props.min);
+
+  const [text, setText] = createSignal('');
+  const [isSetByInput, setIsSetByInput] = createSignal(false);
+
+  createEffect(() => {
+    const value = props.get();
+    if (untrack(isSetByInput)) { setIsSetByInput(false); }
+    else { setText(Math.round(toDisplay(value)).toString()); }
+  });
+
+  return (
+    <div style="display: flex; align-items: center; gap: 4px; flex: none;">
+      <input
+        class="theme-editor-basic-num"
+        type="number"
+        value={text()}
+        min={dMin()}
+        max={dMax()}
+        step={1}
+        onInput={(e) => {
+          const raw = e.currentTarget.value;
+          setIsSetByInput(true);
+          setText(raw);
+          const d = parseFloat(raw);
+          if (!Number.isNaN(d)) { props.set(fromDisplay(Math.max(dMin(), Math.min(dMax(), d)))); }
+        }}
+        onBlur={() => setText(Math.round(toDisplay(props.get())).toString())}
+        style="
+          font-family: var(--font-mono);
+          background-color: var(--b1);
+          border: 1px solid var(--b4);
+          box-sizing: border-box;
+          border-radius: 4px;
+          text-align: right;
+          color: var(--c0);
+          padding: 3px 6px;
+          font-size: 12px;
+          flex: none;
+          width: 7ch;
+          outline: none;
+        "
+      />
+      <span style="color: var(--c2); font-size: 12px;">%</span>
+    </div>
+  );
 }
 
 export function ThemeEditorBasic(){
@@ -321,9 +387,18 @@ export function ThemeEditorBasic(){
         .theme-editor-basic-slider::-moz-range-thumb {
           opacity: 0;
         }
+        .theme-editor-basic-num::-webkit-inner-spin-button,
+        .theme-editor-basic-num::-webkit-outer-spin-button {
+          -webkit-appearance: none;
+          margin: 0;
+        }
+        .theme-editor-basic-num {
+          -moz-appearance: textfield;
+        }
       `}</style>
 
       <div
+        class="@container"
         style="
           font-family: var(--font-sans);
           padding: 8px 20px 12px 20px;
@@ -332,15 +407,14 @@ export function ThemeEditorBasic(){
           height: min-content;
           font-weight: 500;
           font-size: 12px;
-          display: grid;
-          gap: 20px;
         "
       >
+       <div class="grid gap-5 @2xl:grid-cols-2 @2xl:items-stretch">
         <div
           onPointerDown={handleCanvasPointerDown}
           ref={canvasContainerRef}
+          class={`${isMobile() ? 'h-[140px]' : 'h-[250px]'} @2xl:h-full`}
           style={{
-            'height': isMobile() ? '140px' : '250px',
             'border': '1px solid var(--b4)',
             'border-radius': '6px',
             'position': 'relative',
@@ -376,31 +450,22 @@ export function ThemeEditorBasic(){
 
         <div
           style="
-            grid-template-columns: 11ch 1fr;
             height: min-content;
-            gap: 20px 10px;
             display: grid;
             width: 100%;
+            gap: 20px;
           "
         >
-          <div style="position: relative;">
-            <div
-              style="
-                transform: translateY(-50%);
-                position: absolute;
-                top: 50%;
-                left: 0;
-              "
-            >
-              Chroma
-            </div>
-          </div>
+          <div style="display: grid; gap: 3px;">
+          <div>Chroma</div>
+          <div style="display: flex; align-items: center; gap: 12px;">
           <div
             style="
               box-sizing: border-box;
               position: relative;
               height: 10px;
-              width: 100%;
+              min-width: 0;
+              flex: 1;
             "
           >
             <div
@@ -457,25 +522,25 @@ export function ThemeEditorBasic(){
               min="0.0"
             />
           </div>
-
-          <div style="position: relative;">
-            <div
-              style="
-                transform: translateY(-50%);
-                position: absolute;
-                top: 50%;
-                left: 0;
-              "
-            >
-              Saturation
-            </div>
+          <NumberInput
+            get={() => themeReactive.a0.c[0]()}
+            set={(n) => setChroma(n, parseFloat(sliderSaturationRef.value))}
+            min={0}
+            max={0.37}
+          />
           </div>
+          </div>
+
+          <div style="display: grid; gap: 3px;">
+          <div>Tint</div>
+          <div style="display: flex; align-items: center; gap: 12px;">
           <div
             style="
               box-sizing: border-box;
               position: relative;
               height: 10px;
-              width: 100%;
+              min-width: 0;
+              flex: 1;
             "
           >
             <div
@@ -548,25 +613,28 @@ export function ThemeEditorBasic(){
               min="0.0"
             />
           </div>
-
-          <div style="position: relative;">
-            <div
-              style="
-                transform: translateY(-50%);
-                position: absolute;
-                top: 50%;
-                left: 0;
-              "
-            >
-              Contrast
-            </div>
+          <NumberInput
+            get={() => {
+              const denom = themeReactive.a0.c[0]() * 0.37 * 0.6;
+              return denom ? themeReactive.b0.c[0]() / denom : 0;
+            }}
+            set={(n) => setSaturation(n)}
+            min={0}
+            max={1}
+          />
           </div>
+          </div>
+
+          <div style="display: grid; gap: 3px;">
+          <div>Contrast</div>
+          <div style="display: flex; align-items: center; gap: 12px;">
           <div
             style="
               box-sizing: border-box;
               position: relative;
               height: 10px;
-              width: 100%;
+              min-width: 0;
+              flex: 1;
             "
           >
             <div
@@ -645,27 +713,27 @@ export function ThemeEditorBasic(){
               min="0.0"
             />
           </div>
-
-
-
-          <div style="position: relative;">
-            <div
-              style="
-                transform: translateY(-50%);
-                position: absolute;
-                top: 50%;
-                left: 0;
-              "
-            >
-              Depth
-            </div>
+          <NumberInput
+            get={() => getContrastFromY(themeReactive.b0.l[0]())}
+            set={(n) => setContrast(n)}
+            min={0}
+            max={0.8}
+            displayMin={-100}
+            displayMax={100}
+          />
           </div>
+          </div>
+
+          <div style="display: grid; gap: 3px;">
+          <div>Depth</div>
+          <div style="display: flex; align-items: center; gap: 12px;">
           <div
             style="
               box-sizing: border-box;
               position: relative;
               height: 10px;
-              width: 100%;
+              min-width: 0;
+              flex: 1;
             "
           >
             <div
@@ -740,7 +808,16 @@ export function ThemeEditorBasic(){
               min="0.0"
             />
           </div>
+          <NumberInput
+            get={() => themeDepth()}
+            set={(n) => setThemeDepth(n)}
+            min={0}
+            max={0.4}
+          />
+          </div>
+          </div>
         </div>
+       </div>
       </div>
     </>
   );

--- a/js/app/packages/theme/components/ThemeEditorBasic.tsx
+++ b/js/app/packages/theme/components/ThemeEditorBasic.tsx
@@ -450,6 +450,7 @@ export function ThemeEditorBasic(){
 
         <div
           style="
+            --b4: color-mix(in oklch, oklch(var(--b4l) var(--b4c) var(--b4h)), oklch(var(--c4l) var(--c4c) var(--c4h)) 30%);
             height: min-content;
             display: grid;
             width: 100%;

--- a/js/app/packages/theme/components/ThemeEditorBasic.tsx
+++ b/js/app/packages/theme/components/ThemeEditorBasic.tsx
@@ -449,17 +449,14 @@ export function ThemeEditorBasic(){
         </div>
 
         <div
+          class="grid h-min w-full gap-3 @2xl:gap-5"
           style="
             --b4: color-mix(in oklch, oklch(var(--b4l) var(--b4c) var(--b4h)), oklch(var(--c4l) var(--c4c) var(--c4h)) 30%);
-            height: min-content;
-            display: grid;
-            width: 100%;
-            gap: 20px;
           "
         >
-          <div style="display: grid; gap: 3px;">
-          <div>Chroma</div>
-          <div style="display: flex; align-items: center; gap: 12px;">
+          <div class="flex items-center gap-3 @2xl:flex-col @2xl:items-stretch @2xl:gap-[3px]">
+          <div class="w-[9ch] shrink-0 @2xl:w-auto">Chroma</div>
+          <div class="flex flex-1 items-center gap-3 min-w-0 @2xl:flex-none">
           <div
             style="
               box-sizing: border-box;
@@ -494,7 +491,7 @@ export function ThemeEditorBasic(){
                 'border-radius': '2px',
                 'position': 'absolute',
                 'height': '18px',
-                'width': '18px',
+                'width': '9px',
                 'top': '50%',
               }}
             />
@@ -532,9 +529,9 @@ export function ThemeEditorBasic(){
           </div>
           </div>
 
-          <div style="display: grid; gap: 3px;">
-          <div>Tint</div>
-          <div style="display: flex; align-items: center; gap: 12px;">
+          <div class="flex items-center gap-3 @2xl:flex-col @2xl:items-stretch @2xl:gap-[3px]">
+          <div class="w-[9ch] shrink-0 @2xl:w-auto">Tint</div>
+          <div class="flex flex-1 items-center gap-3 min-w-0 @2xl:flex-none">
           <div
             style="
               box-sizing: border-box;
@@ -584,7 +581,7 @@ export function ThemeEditorBasic(){
                 'border-radius': '2px',
                 'position': 'absolute',
                 'height': '18px',
-                'width': '18px',
+                'width': '9px',
                 'top': '50%',
               }}
             />
@@ -626,9 +623,9 @@ export function ThemeEditorBasic(){
           </div>
           </div>
 
-          <div style="display: grid; gap: 3px;">
-          <div>Contrast</div>
-          <div style="display: flex; align-items: center; gap: 12px;">
+          <div class="flex items-center gap-3 @2xl:flex-col @2xl:items-stretch @2xl:gap-[3px]">
+          <div class="w-[9ch] shrink-0 @2xl:w-auto">Contrast</div>
+          <div class="flex flex-1 items-center gap-3 min-w-0 @2xl:flex-none">
           <div
             style="
               box-sizing: border-box;
@@ -682,7 +679,7 @@ export function ThemeEditorBasic(){
                 'border-radius': '2px',
                 'position': 'absolute',
                 'height': '18px',
-                'width': '18px',
+                'width': '9px',
                 'top': '50%',
               }}
             />
@@ -725,9 +722,9 @@ export function ThemeEditorBasic(){
           </div>
           </div>
 
-          <div style="display: grid; gap: 3px;">
-          <div>Depth</div>
-          <div style="display: flex; align-items: center; gap: 12px;">
+          <div class="flex items-center gap-3 @2xl:flex-col @2xl:items-stretch @2xl:gap-[3px]">
+          <div class="w-[9ch] shrink-0 @2xl:w-auto">Depth</div>
+          <div class="flex flex-1 items-center gap-3 min-w-0 @2xl:flex-none">
           <div
             style="
               box-sizing: border-box;
@@ -777,7 +774,7 @@ export function ThemeEditorBasic(){
                 'border-radius': '2px',
                 'position': 'absolute',
                 'height': '18px',
-                'width': '18px',
+                'width': '9px',
                 'top': '50%',
               }}
             />

--- a/js/app/packages/theme/components/ThemeList.tsx
+++ b/js/app/packages/theme/components/ThemeList.tsx
@@ -23,15 +23,26 @@ function ThemeList() {
           <For each={visibleThemes()}>
             {(theme) => {
               const selected = () => theme.id === currentThemeId() && isThemeSaved();
+              const select = () => {
+                analytics.track('theme_changed', { themeId: theme.id })
+                applyTheme(theme.id)
+              };
               return (
+                // role="button" (not <button>) because the card contains ThemeCrud's
+                // own buttons, and nesting native buttons is invalid HTML.
                 <div
+                  role="button"
+                  tabIndex={0}
                   class={cn(
                     'flex min-w-0 cursor-pointer items-center gap-2 rounded-lg border bg-surface p-2 transition-colors',
                     selected() ? 'border-accent' : 'border-edge-muted hover:border-ink-muted'
                   )}
-                  onClick={() => {
-                    analytics.track('theme_changed', { themeId: theme.id })
-                    applyTheme(theme.id)
+                  onClick={select}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault()
+                      select()
+                    }
                   }}
                 >
                   <ThemeChips theme={theme} />

--- a/js/app/packages/theme/components/ThemeList.tsx
+++ b/js/app/packages/theme/components/ThemeList.tsx
@@ -3,6 +3,7 @@ import { useAnalytics } from 'app/component/analytics-context';
 import { applyTheme } from '../utils/themeUtils';
 import { ThemeChips } from './ThemeChips';
 import { ThemeCrud } from './ThemeCrud';
+import { cn } from '@ui';
 
 import { createMemo, For } from 'solid-js';
 
@@ -17,77 +18,38 @@ function ThemeList() {
   );
 
   return (
-      <>
-        <style>{`
-          .theme-list-item-name.current-theme{
-            transition: none !important;
-            color: var(--a0) !important;
-          }
-
-          @media(hover){
-            .theme-list-item-name:hover{
-              transition: none !important;
-              color: var(--a0) !important;
-            }
-          }
-        `}</style>
-
-        <div
-          style="
-            grid-template-columns: min-content 1fr min-content;
-            background-color: var(--b3);
-            box-sizing: border-box;
-            grid-auto-rows: 61px;
-            overflow-x: hidden;
-            font-size: 14px;
-            display: grid;
-            gap: 1px 0px;
-          "
-        >
+      <div class="@container p-2">
+        <div class="grid grid-cols-1 gap-2 @md:grid-cols-2 @2xl:grid-cols-3">
           <For each={visibleThemes()}>
-            {(theme) => (
-              <>
+            {(theme) => {
+              const selected = () => theme.id === currentThemeId() && isThemeSaved();
+              return (
                 <div
-                  style="
-                    background-color: var(--b0);
-                    box-sizing: border-box;
-                    align-items: center;
-                    padding: 0 20px;
-                    display: flex;
-                    height: 100%;
-                    width: 100%;
-                    gap: 5px;
-                  "
-                >
-                  <ThemeChips theme={theme} />
-                </div>
-                <div
-                  class={`theme-list-item-name ${theme.id === currentThemeId() && isThemeSaved() ? 'current-theme' : ''}`}
+                  class={cn(
+                    'flex min-w-0 cursor-pointer items-center gap-2 rounded-lg border bg-surface p-2 transition-colors',
+                    selected() ? 'border-accent' : 'border-edge-muted hover:border-ink-muted'
+                  )}
                   onClick={() => {
-                    analytics.track('theme_changed', {themeId: theme.id})
+                    analytics.track('theme_changed', { themeId: theme.id })
                     applyTheme(theme.id)
                   }}
-                  style="
-                    transition: color var(--transition);
-                    background-color: var(--b0);
-                    box-sizing: border-box;
-                    white-space: nowrap;
-                    align-items: center;
-                    padding: 0 20px;
-                    cursor: pointer;
-                    display: flex;
-                    height: 100%;
-                    width: 100%;
-                  "
                 >
-                  {theme.name}
+                  <ThemeChips theme={theme} />
+                  <span
+                    class={cn(
+                      'min-w-0 flex-1 truncate text-sm',
+                      selected() ? 'text-accent' : 'text-ink'
+                    )}
+                  >
+                    {theme.name}
+                  </span>
+                  <ThemeCrud themeId={theme.id} />
                 </div>
-                <ThemeCrud themeId={theme.id} />
-              </>
-            )}
+              )
+            }}
           </For>
         </div>
-      </>
+      </div>
   );
 }
 

--- a/js/app/packages/theme/components/ThemeList.tsx
+++ b/js/app/packages/theme/components/ThemeList.tsx
@@ -33,7 +33,7 @@ function ThemeList() {
                   role="button"
                   tabIndex={0}
                   class={cn(
-                    'flex min-w-0 cursor-pointer items-center gap-2 rounded-lg border bg-surface p-2 transition-colors',
+                    'flex min-w-0 cursor-pointer items-center gap-2 rounded-lg border bg-surface p-2 transition-colors duration-[var(--transition)]',
                     selected() ? 'border-accent' : 'border-edge-muted hover:border-ink-muted'
                   )}
                   onClick={select}

--- a/js/app/packages/theme/components/ThemeList.tsx
+++ b/js/app/packages/theme/components/ThemeList.tsx
@@ -1,6 +1,6 @@
 import { currentThemeId, isThemeSaved, showDarkThemes, showLightThemes, themes } from '../signals/themeSignals';
 import { useAnalytics } from 'app/component/analytics-context';
-import { applyTheme } from '../utils/themeUtils';
+import { applyTheme, isTokensDark } from '../utils/themeUtils';
 import { ThemeChips } from './ThemeChips';
 import { ThemeCrud } from './ThemeCrud';
 import { cn } from '@ui';
@@ -10,10 +10,9 @@ import { createMemo, For } from 'solid-js';
 function ThemeList() {
   const analytics = useAnalytics()
 
-  // A theme is intrinsically dark when its text is lighter than its background.
   const visibleThemes = createMemo(() =>
     themes().filter((theme) =>
-      theme.tokens.c0.l > theme.tokens.b0.l ? showDarkThemes() : showLightThemes()
+      isTokensDark(theme.tokens) ? showDarkThemes() : showLightThemes()
     )
   );
 

--- a/js/app/packages/theme/components/ThemeList.tsx
+++ b/js/app/packages/theme/components/ThemeList.tsx
@@ -1,13 +1,20 @@
-import { currentThemeId, isThemeSaved, themes } from '../signals/themeSignals';
+import { currentThemeId, isThemeSaved, showDarkThemes, showLightThemes, themes } from '../signals/themeSignals';
 import { useAnalytics } from 'app/component/analytics-context';
 import { applyTheme } from '../utils/themeUtils';
-import { ColorSwatch } from './ColorSwatch';
+import { ThemeChips } from './ThemeChips';
 import { ThemeCrud } from './ThemeCrud';
 
-import { For } from 'solid-js';
+import { createMemo, For } from 'solid-js';
 
 function ThemeList() {
   const analytics = useAnalytics()
+
+  // A theme is intrinsically dark when its text is lighter than its background.
+  const visibleThemes = createMemo(() =>
+    themes().filter((theme) =>
+      theme.tokens.c0.l > theme.tokens.b0.l ? showDarkThemes() : showLightThemes()
+    )
+  );
 
   return (
       <>
@@ -37,7 +44,7 @@ function ThemeList() {
             gap: 1px 0px;
           "
         >
-          <For each={themes()}>
+          <For each={visibleThemes()}>
             {(theme) => (
               <>
                 <div
@@ -52,18 +59,7 @@ function ThemeList() {
                     gap: 5px;
                   "
                 >
-                  <ColorSwatch
-                    color={`oklch(${theme.tokens.a0.l} ${theme.tokens.a0.c} ${theme.tokens.a0.h}deg)`}
-                    width={'10px'}
-                  />
-                  <ColorSwatch
-                    color={`oklch(${theme.tokens.b0.l} ${theme.tokens.b0.c} ${theme.tokens.b0.h}deg)`}
-                    width={'10px'}
-                  />
-                  <ColorSwatch
-                    color={`oklch(${theme.tokens.c0.l} ${theme.tokens.c0.c} ${theme.tokens.c0.h}deg)`}
-                    width={'10px'}
-                  />
+                  <ThemeChips theme={theme} />
                 </div>
                 <div
                   class={`theme-list-item-name ${theme.id === currentThemeId() && isThemeSaved() ? 'current-theme' : ''}`}

--- a/js/app/packages/theme/components/ThemeTools.tsx
+++ b/js/app/packages/theme/components/ThemeTools.tsx
@@ -1,7 +1,6 @@
 import { currentThemeId, isThemeSaved, themes } from '../signals/themeSignals';
-import { isThemeDark, saveTheme, setMode } from '../utils/themeUtils';
+import { saveTheme } from '../utils/themeUtils';
 import IconSave from '@phosphor-icons/core/regular/floppy-disk-back.svg?component-solid';
-import { TabsInset } from '@core/component/TabsInset';
 import { createMemo, Show } from 'solid-js';
 import { Button, cn } from '@ui';
 
@@ -41,15 +40,6 @@ function ThemeTools(props: { class?: string }) {
           <IconSave />
         </Button>
       </Show>
-
-      <TabsInset
-        onChange={(value) => setMode(value as 'light' | 'dark')}
-        list={[
-          { value: 'light', label: 'Light' },
-          { value: 'dark', label: 'Dark' },
-        ]}
-        value={isThemeDark() ? 'dark' : 'light'}
-      />
 
       <div
         onKeyDown={(e) => {

--- a/js/app/packages/theme/components/ThemeTools.tsx
+++ b/js/app/packages/theme/components/ThemeTools.tsx
@@ -1,6 +1,7 @@
 import { currentThemeId, isThemeSaved, themes } from '../signals/themeSignals';
-import { saveTheme } from '../utils/themeUtils';
+import { isThemeDark, saveTheme, setMode } from '../utils/themeUtils';
 import IconSave from '@phosphor-icons/core/regular/floppy-disk-back.svg?component-solid';
+import { TabsInset } from '@core/component/TabsInset';
 import { createMemo, Show } from 'solid-js';
 import { Button, cn } from '@ui';
 
@@ -40,6 +41,15 @@ function ThemeTools(props: { class?: string }) {
           <IconSave />
         </Button>
       </Show>
+
+      <TabsInset
+        onChange={(value) => setMode(value as 'light' | 'dark')}
+        list={[
+          { value: 'light', label: 'Light' },
+          { value: 'dark', label: 'Dark' },
+        ]}
+        value={isThemeDark() ? 'dark' : 'light'}
+      />
 
       <div
         onKeyDown={(e) => {

--- a/js/app/packages/theme/components/ThemeTools.tsx
+++ b/js/app/packages/theme/components/ThemeTools.tsx
@@ -1,9 +1,7 @@
-import { currentThemeId, isThemeSaved, themes } from '../signals/themeSignals';
-import IconLightDark from '@icon/macro-light-dark.svg';
-import { invertTheme, saveTheme } from '../utils/themeUtils';
-import { randomizeTheme } from './ThemeEditorBasic';
-import IconDice from '@phosphor-icons/core/regular/dice-five.svg?component-solid';
+import { currentThemeId, isThemeSaved, setThemeMode, themeMode, themes } from '../signals/themeSignals';
+import { saveTheme } from '../utils/themeUtils';
 import IconSave from '@phosphor-icons/core/regular/floppy-disk-back.svg?component-solid';
+import { TabsInset } from '@core/component/TabsInset';
 import { createMemo, Show } from 'solid-js';
 import { Button, cn } from '@ui';
 
@@ -44,23 +42,15 @@ function ThemeTools(props: { class?: string }) {
         </Button>
       </Show>
 
-      <Button
-        label="Randomize Theme"
-        onPointerDown={randomizeTheme}
-        variant="ghost"
-        size="icon-sm"
-      >
-        <IconDice />
-      </Button>
-
-      <Button
-        label="Toggle Light / Dark"
-        onPointerDown={invertTheme}
-        variant="ghost"
-        size="icon-sm"
-      >
-        <IconLightDark />
-      </Button>
+      <TabsInset
+        onChange={(value) => setThemeMode(value as 'light' | 'dark' | 'system')}
+        list={[
+          { value: 'light', label: 'Light' },
+          { value: 'dark', label: 'Dark' },
+          { value: 'system', label: 'System' },
+        ]}
+        value={themeMode()}
+      />
 
       <div
         onKeyDown={(e) => {

--- a/js/app/packages/theme/components/ThemeTools.tsx
+++ b/js/app/packages/theme/components/ThemeTools.tsx
@@ -1,7 +1,6 @@
-import { currentThemeId, isThemeSaved, setThemeMode, themeMode, themes } from '../signals/themeSignals';
+import { currentThemeId, isThemeSaved, themes } from '../signals/themeSignals';
 import { saveTheme } from '../utils/themeUtils';
 import IconSave from '@phosphor-icons/core/regular/floppy-disk-back.svg?component-solid';
-import { TabsInset } from '@core/component/TabsInset';
 import { createMemo, Show } from 'solid-js';
 import { Button, cn } from '@ui';
 
@@ -41,16 +40,6 @@ function ThemeTools(props: { class?: string }) {
           <IconSave />
         </Button>
       </Show>
-
-      <TabsInset
-        onChange={(value) => setThemeMode(value as 'light' | 'dark' | 'system')}
-        list={[
-          { value: 'light', label: 'Light' },
-          { value: 'dark', label: 'Dark' },
-          { value: 'system', label: 'System' },
-        ]}
-        value={themeMode()}
-      />
 
       <div
         onKeyDown={(e) => {

--- a/js/app/packages/theme/signals/themeSignals.ts
+++ b/js/app/packages/theme/signals/themeSignals.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_DARK_THEME, DEFAULT_LIGHT_THEME, DEFAULT_THEMES } from '../constants';
+import { DEFAULT_DARK_THEME, DEFAULT_THEMES } from '../constants';
 import { createMemo, createSignal } from 'solid-js';
 import type { ThemeV0, ThemeV1, ThemeV2 } from '../types/themeTypes';
 import { convertThemev0v1, convertThemev1v2 } from '../utils/themeMigrations';
@@ -25,35 +25,28 @@ setUserThemes(
   })
 );
 
-export const [currentThemeId, setCurrentThemeId_] = makePersisted(
+export const [currentThemeId, setCurrentThemeId] = makePersisted(
   createSignal<string>(DEFAULT_DARK_THEME),
   {name: 'macro-selected-theme'}
 );
 
-// If theme should match system, when we set current theme, we also set the corresponding mode's theme
-// This avoids the issue where a user sets a theme, and then refreshes, and gets reverted to their preferred mode's theme.
-export const setCurrentThemeId = ( ...args: Parameters<typeof setCurrentThemeId_> ) => {
-  setCurrentThemeId_(...args);
-  if(themeShouldMatchSystem()){
-    systemMode() === 'dark' ? setDarkModeTheme(...args) : setLightModeTheme(...args);
-  }
-};
-
 export const themes = createMemo(() => [...DEFAULT_THEMES, ...userThemes()]);
 
-export const [lightModeTheme, setLightModeTheme] = makePersisted(
-  createSignal<string>(DEFAULT_LIGHT_THEME),
-  {name: 'macro-light-mode-theme'}
-);
-
-export const [darkModeTheme, setDarkModeTheme] = makePersisted(
-  createSignal<string>(DEFAULT_DARK_THEME),
-  {name: 'macro-dark-mode-theme'}
-);
-
-export const [themeShouldMatchSystem, setThemeShouldMatchSystem] = makePersisted(
+// Theme-list filters: whether light and/or dark themes are shown in the list.
+export const [showLightThemes, setShowLightThemes] = makePersisted(
   createSignal<boolean>(true),
-  {name: 'macro-theme-should-match-system'}
+  {name: 'macro-show-light-themes'}
+);
+export const [showDarkThemes, setShowDarkThemes] = makePersisted(
+  createSignal<boolean>(true),
+  {name: 'macro-show-dark-themes'}
+);
+
+// Persistent light/dark mode. 'system' follows the OS preference; 'light'/'dark'
+// force the displayed theme into that mode by inverting its lightness when needed.
+export const [themeMode, setThemeMode] = makePersisted(
+  createSignal<'light' | 'dark' | 'system'>('system'),
+  {name: 'macro-theme-mode'}
 );
 
 const supportsMatchMedia =
@@ -71,5 +64,11 @@ if (supportsMatchMedia) {
     setSystemMode(e.matches ? 'dark' : 'light');
   });
 }
+
+// Resolves 'system' to the live OS preference, so the rest of the theme code
+// only ever deals with a concrete 'light' | 'dark'.
+export const effectiveMode = createMemo<'light' | 'dark'>(() =>
+  themeMode() === 'system' ? systemMode() : themeMode()
+);
 
 export const [themeDepth, setThemeDepth] = createSignal<number>(0.15);

--- a/js/app/packages/theme/signals/themeSignals.ts
+++ b/js/app/packages/theme/signals/themeSignals.ts
@@ -42,8 +42,9 @@ export const [showDarkThemes, setShowDarkThemes] = makePersisted(
   {name: 'macro-show-dark-themes'}
 );
 
-// Persistent light/dark mode. 'system' follows the OS preference; 'light'/'dark'
-// force the displayed theme into that mode by inverting its lightness when needed.
+// Light/dark mode plumbing. NOTE: user-facing and automatic (system) switching is
+// currently disabled — nothing wires these into the UI or the OS listener effect.
+// Kept intact so we can re-enable mode switching later without rebuilding it.
 export const [themeMode, setThemeMode] = makePersisted(
   createSignal<'light' | 'dark' | 'system'>('system'),
   {name: 'macro-theme-mode'}
@@ -67,8 +68,9 @@ if (supportsMatchMedia) {
 
 // Resolves 'system' to the live OS preference, so the rest of the theme code
 // only ever deals with a concrete 'light' | 'dark'.
-export const effectiveMode = createMemo<'light' | 'dark'>(() =>
-  themeMode() === 'system' ? systemMode() : themeMode()
-);
+export const effectiveMode = createMemo<'light' | 'dark'>(() => {
+  const mode = themeMode();
+  return mode === 'system' ? systemMode() : mode;
+});
 
 export const [themeDepth, setThemeDepth] = createSignal<number>(0.15);

--- a/js/app/packages/theme/signals/themeSignals.ts
+++ b/js/app/packages/theme/signals/themeSignals.ts
@@ -42,35 +42,4 @@ export const [showDarkThemes, setShowDarkThemes] = makePersisted(
   {name: 'macro-show-dark-themes'}
 );
 
-// Light/dark mode plumbing. NOTE: user-facing and automatic (system) switching is
-// currently disabled — nothing wires these into the UI or the OS listener effect.
-// Kept intact so we can re-enable mode switching later without rebuilding it.
-export const [themeMode, setThemeMode] = makePersisted(
-  createSignal<'light' | 'dark' | 'system'>('system'),
-  {name: 'macro-theme-mode'}
-);
-
-const supportsMatchMedia =
-  typeof window !== 'undefined' && typeof window.matchMedia === 'function';
-
-export const [systemMode, setSystemMode] = createSignal<'dark' | 'light'>(
-  supportsMatchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
-    ? 'dark'
-    : 'light'
-);
-
-if (supportsMatchMedia) {
-  const darkModeQuery = window.matchMedia('(prefers-color-scheme: dark)');
-  darkModeQuery.addEventListener('change', (e: MediaQueryListEvent) => {
-    setSystemMode(e.matches ? 'dark' : 'light');
-  });
-}
-
-// Resolves 'system' to the live OS preference, so the rest of the theme code
-// only ever deals with a concrete 'light' | 'dark'.
-export const effectiveMode = createMemo<'light' | 'dark'>(() => {
-  const mode = themeMode();
-  return mode === 'system' ? systemMode() : mode;
-});
-
 export const [themeDepth, setThemeDepth] = createSignal<number>(0.15);

--- a/js/app/packages/theme/utils/themeUtils.ts
+++ b/js/app/packages/theme/utils/themeUtils.ts
@@ -78,8 +78,8 @@ export function applyTheme(id: string): void{
       }
     );
     setThemeDepth(theme!.depth ?? 0.15);
-    // Track the theme's intrinsic light/dark polarity (no inversion happens — mode
-    // switching is currently disabled; this just keeps themeMode in sync).
+    // Selecting a theme adopts its intrinsic light/dark as the active mode. Tokens
+    // load as-is (no inversion here); the Light/Dark toggle flips via enforceModeLive.
     setThemeMode(isTokensDark(theme!.tokens) ? 'dark' : 'light');
     queueMicrotask(() => {/* scuffed af */
       setIsThemeSaved(true);
@@ -98,8 +98,8 @@ function syncHtmlColor(): void{
 function invertLightness(): void{
   batch(() => {
     themeReactive.b0.l[1](1 - themeReactive.b0.l[0]());
-    themeReactive.b2.l[1](1 - themeReactive.b2.l[0]());
     themeReactive.b1.l[1](1 - themeReactive.b1.l[0]());
+    themeReactive.b2.l[1](1 - themeReactive.b2.l[0]());
     themeReactive.b3.l[1](1 - themeReactive.b3.l[0]());
     themeReactive.b4.l[1](1 - themeReactive.b4.l[0]());
     themeReactive.c0.l[1](1 - themeReactive.c0.l[0]());
@@ -179,8 +179,8 @@ export function isThemeDark(): boolean {
   return themeReactive.c0.l[0]() > themeReactive.b0.l[0]();
 }
 
-/** Same intrinsic-darkness test, against a stored token set rather than the live signals. */
-function isTokensDark(tokens: ThemeV2Tokens): boolean {
+/** Intrinsic darkness of a stored theme: dark when text is lighter than background. */
+export function isTokensDark(tokens: ThemeV2Tokens): boolean {
   return tokens.c0.l > tokens.b0.l;
 }
 

--- a/js/app/packages/theme/utils/themeUtils.ts
+++ b/js/app/packages/theme/utils/themeUtils.ts
@@ -110,9 +110,9 @@ function invertLightness(): void{
   });
 }
 
-/** Dormant plumbing: inverts the live theme to match the current effective mode,
- *  only if it doesn't already match. Idempotent and saved-state preserving.
- *  Nothing calls this today (mode switching disabled). */
+/** Inverts the live theme to match the current effective mode, only if it doesn't
+ *  already match. Idempotent and saved-state preserving (toggling never marks the
+ *  theme as a new/unsaved theme). */
 export function enforceModeLive(): void{
   if(isThemeDark() === (effectiveMode() === 'dark')){return}
   const wasSaved = isThemeSaved();
@@ -121,6 +121,13 @@ export function enforceModeLive(): void{
     setIsThemeSaved(wasSaved); /* preserve saved state across the unsave effect, mirroring applyTheme */
     syncHtmlColor();
   });
+}
+
+/** Switches the displayed theme to light or dark, inverting its lightness when it
+ *  doesn't already match. Backs the Light/Dark toggle. */
+export function setMode(mode: 'light' | 'dark'): void{
+  setThemeMode(mode);
+  enforceModeLive();
 }
 
 function getCurrentTokens(): ThemeV2Tokens{
@@ -167,8 +174,8 @@ export function deleteTheme(id: string): void{
   }
 }
 
-/** Returns true when the live theme is dark (text lighter than background). */
-function isThemeDark(): boolean {
+/** Returns true when the live theme is dark (text lighter than background). Reactive. */
+export function isThemeDark(): boolean {
   return themeReactive.c0.l[0]() > themeReactive.b0.l[0]();
 }
 

--- a/js/app/packages/theme/utils/themeUtils.ts
+++ b/js/app/packages/theme/utils/themeUtils.ts
@@ -49,9 +49,9 @@ function isThemeV2(value: unknown): value is ThemeV2 {
   });
 }
 
-/** Re-applies the current light/dark mode to the live theme whenever the mode
- *  (or, in 'system' mode, the OS preference) changes. enforceModeLive is
- *  idempotent, so firing on an unrelated change is a harmless no-op. */
+/** Dormant plumbing: re-applies the current light/dark mode to the live theme
+ *  whenever the mode (or, in 'system' mode, the OS preference) changes. Kept for
+ *  if/when mode switching is re-enabled — nothing calls this today. */
 export function systemModeEffect(){
   createEffect(
     on(
@@ -78,8 +78,8 @@ export function applyTheme(id: string): void{
       }
     );
     setThemeDepth(theme!.depth ?? 0.15);
-    // Each theme is intrinsically light or dark — adopt the theme's natural mode
-    // rather than forcing it into the previously-selected light/dark mode.
+    // Track the theme's intrinsic light/dark polarity (no inversion happens — mode
+    // switching is currently disabled; this just keeps themeMode in sync).
     setThemeMode(isTokensDark(theme!.tokens) ? 'dark' : 'light');
     queueMicrotask(() => {/* scuffed af */
       setIsThemeSaved(true);
@@ -110,9 +110,9 @@ function invertLightness(): void{
   });
 }
 
-/** Inverts the live theme to match the current effective mode, but only if it
- *  doesn't already match. Idempotent. Preserves the saved/unsaved state so
- *  toggling mode never renames a preset (or discards unsaved custom edits). */
+/** Dormant plumbing: inverts the live theme to match the current effective mode,
+ *  only if it doesn't already match. Idempotent and saved-state preserving.
+ *  Nothing calls this today (mode switching disabled). */
 export function enforceModeLive(): void{
   if(isThemeDark() === (effectiveMode() === 'dark')){return}
   const wasSaved = isThemeSaved();
@@ -122,7 +122,6 @@ export function enforceModeLive(): void{
     syncHtmlColor();
   });
 }
-
 
 function getCurrentTokens(): ThemeV2Tokens{
   const themeTokens: ThemeV2Tokens = {

--- a/js/app/packages/theme/utils/themeUtils.ts
+++ b/js/app/packages/theme/utils/themeUtils.ts
@@ -123,11 +123,30 @@ export function enforceModeLive(): void{
   });
 }
 
-/** Switches the displayed theme to light or dark, inverting its lightness when it
- *  doesn't already match. Backs the Light/Dark toggle. */
-export function setMode(mode: 'light' | 'dark'): void{
-  setThemeMode(mode);
-  enforceModeLive();
+/** Flips the theme between light and dark by inverting the background/text lightness
+ *  — the same axis as the contrast slider's sign. Treated as an edit: marks the theme
+ *  unsaved, unless the flip lands back on the stored theme (then it's saved again). */
+export function flipLightDark(): void{
+  invertLightness();
+  queueMicrotask(() => {
+    setIsThemeSaved(liveMatchesStoredTheme());
+    syncHtmlColor();
+  });
+}
+
+/** True when the live theme equals the currently-selected stored theme, within a
+ *  float tolerance (1 − (1 − l) from a double flip isn't bit-exact). */
+function liveMatchesStoredTheme(): boolean{
+  const stored = themes().find((t) => t.id === currentThemeId());
+  if(!stored){return false}
+  const live = getCurrentTokens();
+  const close = (a: number, b: number) => Math.abs(a - b) < 1e-6;
+  const tokensMatch = (Object.keys(stored.tokens) as Array<keyof ThemeV2Tokens>).every((k) =>
+    close(live[k].l, stored.tokens[k].l) &&
+    close(live[k].c, stored.tokens[k].c) &&
+    close(live[k].h, stored.tokens[k].h)
+  );
+  return tokensMatch && close(themeDepth(), stored.depth ?? 0.15);
 }
 
 function getCurrentTokens(): ThemeV2Tokens{

--- a/js/app/packages/theme/utils/themeUtils.ts
+++ b/js/app/packages/theme/utils/themeUtils.ts
@@ -1,8 +1,8 @@
-import { currentThemeId, effectiveMode, isThemeSaved, setCurrentThemeId, setHtmlColor, setIsThemeSaved, setThemeDepth, setThemeMode, setUserThemes, systemMode, themeDepth, themeMode, themes, userThemes} from '../signals/themeSignals';
+import { currentThemeId, setCurrentThemeId, setHtmlColor, setIsThemeSaved, setThemeDepth, setUserThemes, themeDepth, themes, userThemes} from '../signals/themeSignals';
 import type { ThemeV2, ThemeV2Tokens } from '../types/themeTypes';
 import { themeReactive } from '../signals/themeReactive';
 import { toast } from '@core/component/Toast/Toast';
-import { batch, createEffect, on } from 'solid-js';
+import { batch } from 'solid-js';
 import { DEFAULT_DARK_THEME } from '../constants';
 
 export function exportTheme(themeId?: string){
@@ -49,19 +49,6 @@ function isThemeV2(value: unknown): value is ThemeV2 {
   });
 }
 
-/** Dormant plumbing: re-applies the current light/dark mode to the live theme
- *  whenever the mode (or, in 'system' mode, the OS preference) changes. Kept for
- *  if/when mode switching is re-enabled — nothing calls this today. */
-export function systemModeEffect(){
-  createEffect(
-    on(
-      [themeMode, systemMode],
-      () => { enforceModeLive(); },
-      { defer: true }
-    )
-  );
-}
-
 export function applyTheme(id: string): void{
   let theme = themes().find((t) => t.id === id);
   if(!theme){
@@ -78,9 +65,6 @@ export function applyTheme(id: string): void{
       }
     );
     setThemeDepth(theme!.depth ?? 0.15);
-    // Selecting a theme adopts its intrinsic light/dark as the active mode. Tokens
-    // load as-is (no inversion here); the Light/Dark toggle flips via enforceModeLive.
-    setThemeMode(isTokensDark(theme!.tokens) ? 'dark' : 'light');
     queueMicrotask(() => {/* scuffed af */
       setIsThemeSaved(true);
       syncHtmlColor();
@@ -107,19 +91,6 @@ function invertLightness(): void{
     themeReactive.c2.l[1](1 - themeReactive.c2.l[0]());
     themeReactive.c3.l[1](1 - themeReactive.c3.l[0]());
     themeReactive.c4.l[1](1 - themeReactive.c4.l[0]());
-  });
-}
-
-/** Inverts the live theme to match the current effective mode, only if it doesn't
- *  already match. Idempotent and saved-state preserving (toggling never marks the
- *  theme as a new/unsaved theme). */
-export function enforceModeLive(): void{
-  if(isThemeDark() === (effectiveMode() === 'dark')){return}
-  const wasSaved = isThemeSaved();
-  invertLightness();
-  queueMicrotask(() => {
-    setIsThemeSaved(wasSaved); /* preserve saved state across the unsave effect, mirroring applyTheme */
-    syncHtmlColor();
   });
 }
 
@@ -191,11 +162,6 @@ export function deleteTheme(id: string): void{
     setIsThemeSaved(false);
     setCurrentThemeId('');
   }
-}
-
-/** Returns true when the live theme is dark (text lighter than background). Reactive. */
-export function isThemeDark(): boolean {
-  return themeReactive.c0.l[0]() > themeReactive.b0.l[0]();
 }
 
 /** Intrinsic darkness of a stored theme: dark when text is lighter than background. */

--- a/js/app/packages/theme/utils/themeUtils.ts
+++ b/js/app/packages/theme/utils/themeUtils.ts
@@ -1,4 +1,4 @@
-import { currentThemeId, darkModeTheme, lightModeTheme, setCurrentThemeId, setHtmlColor, setIsThemeSaved, setThemeDepth, setUserThemes, systemMode, themeDepth, themeShouldMatchSystem, themes, userThemes} from '../signals/themeSignals';
+import { currentThemeId, effectiveMode, isThemeSaved, setCurrentThemeId, setHtmlColor, setIsThemeSaved, setThemeDepth, setThemeMode, setUserThemes, systemMode, themeDepth, themeMode, themes, userThemes} from '../signals/themeSignals';
 import type { ThemeV2, ThemeV2Tokens } from '../types/themeTypes';
 import { themeReactive } from '../signals/themeReactive';
 import { toast } from '@core/component/Toast/Toast';
@@ -49,15 +49,14 @@ function isThemeV2(value: unknown): value is ThemeV2 {
   });
 }
 
-export function systemThemeEffect(){
+/** Re-applies the current light/dark mode to the live theme whenever the mode
+ *  (or, in 'system' mode, the OS preference) changes. enforceModeLive is
+ *  idempotent, so firing on an unrelated change is a harmless no-op. */
+export function systemModeEffect(){
   createEffect(
     on(
-      [themeShouldMatchSystem, systemMode, darkModeTheme, lightModeTheme],
-      () => {
-        if(themeShouldMatchSystem()){
-          applyTheme(systemMode() === 'dark' ? darkModeTheme() : lightModeTheme());
-        }
-      },
+      [themeMode, systemMode],
+      () => { enforceModeLive(); },
       { defer: true }
     )
   );
@@ -79,14 +78,24 @@ export function applyTheme(id: string): void{
       }
     );
     setThemeDepth(theme!.depth ?? 0.15);
+    // Each theme is intrinsically light or dark — adopt the theme's natural mode
+    // rather than forcing it into the previously-selected light/dark mode.
+    setThemeMode(isTokensDark(theme!.tokens) ? 'dark' : 'light');
     queueMicrotask(() => {/* scuffed af */
       setIsThemeSaved(true);
-      setHtmlColor({color: `oklch(${themeReactive.b0.l[0]()} ${themeReactive.b0.c[0]()} ${themeReactive.b0.h[0]()}deg)`});
+      syncHtmlColor();
     });
   });
 }
 
-export function invertTheme(): void{
+/** Persists the live background color, used for the pre-hydration first paint. */
+function syncHtmlColor(): void{
+  setHtmlColor({color: `oklch(${themeReactive.b0.l[0]()} ${themeReactive.b0.c[0]()} ${themeReactive.b0.h[0]()}deg)`});
+}
+
+/** Flips the lightness of every background (b*) and text (c*) token, leaving
+ *  chroma and hue untouched. The shared primitive behind light/dark mode. */
+function invertLightness(): void{
   batch(() => {
     themeReactive.b0.l[1](1 - themeReactive.b0.l[0]());
     themeReactive.b2.l[1](1 - themeReactive.b2.l[0]());
@@ -100,6 +109,20 @@ export function invertTheme(): void{
     themeReactive.c4.l[1](1 - themeReactive.c4.l[0]());
   });
 }
+
+/** Inverts the live theme to match the current effective mode, but only if it
+ *  doesn't already match. Idempotent. Preserves the saved/unsaved state so
+ *  toggling mode never renames a preset (or discards unsaved custom edits). */
+export function enforceModeLive(): void{
+  if(isThemeDark() === (effectiveMode() === 'dark')){return}
+  const wasSaved = isThemeSaved();
+  invertLightness();
+  queueMicrotask(() => {
+    setIsThemeSaved(wasSaved); /* preserve saved state across the unsave effect, mirroring applyTheme */
+    syncHtmlColor();
+  });
+}
+
 
 function getCurrentTokens(): ThemeV2Tokens{
   const themeTokens: ThemeV2Tokens = {
@@ -145,9 +168,14 @@ export function deleteTheme(id: string): void{
   }
 }
 
-/** Returns true when the current theme has a dark background (ink lightness > panel lightness). */
-function _isThemeDark(): boolean {
+/** Returns true when the live theme is dark (text lighter than background). */
+function isThemeDark(): boolean {
   return themeReactive.c0.l[0]() > themeReactive.b0.l[0]();
+}
+
+/** Same intrinsic-darkness test, against a stored token set rather than the live signals. */
+function isTokensDark(tokens: ThemeV2Tokens): boolean {
+  return tokens.c0.l > tokens.b0.l;
 }
 
 /** Checks if the theme contrast is too low, and if so, applies a readable theme. This is to prevent malicious actors sending "Theme Viruses" which make a user's theme unusable. */


### PR DESCRIPTION
Restyle theme menu.
- Toggling light / dark is moved to contrast control, as that's all the toggling logic changes currently.
- Make color field and sliders take up less space
- Rename "saturation" (basically synonymous with chroma) to "tint" (how much the accent tints the neutrals)
- Add light / dark filters on saved theme list
- Redesign swatches to better display background, accent, and text
- Make card grid for themes rather than rows