### PR TITLE
feat(cmd): add option to ask ai when no results

### DIFF
--- a/js/app/packages/app/component/ChatWithAgentButton.tsx
+++ b/js/app/packages/app/component/ChatWithAgentButton.tsx
@@ -1,4 +1,6 @@
 import { globalSplitManager } from '@app/signal/splitLayout';
+import { DEFAULT_MODEL } from '@core/component/AI/constant';
+import { setPendingSendData } from '@core/component/AI/signal/pendingSend';
 import type { Attachment } from '@core/component/AI/types';
 import { storeChatStateImmediate } from '@core/component/AI/util/storage';
 import { toast } from '@core/component/Toast/Toast';
@@ -55,6 +57,8 @@ function buildAttachment(entity: ChatWithAgentEntity): Attachment | undefined {
 async function createAndOpenChat(seed: {
   input?: string;
   attachments?: Attachment[];
+  /** When set, sent immediately when the chat opens instead of seeding the input */
+  message?: string;
 }) {
   const result = await createChat();
   if ('error' in result || !result.chatId) {
@@ -63,7 +67,16 @@ async function createAndOpenChat(seed: {
     return;
   }
 
-  storeChatStateImmediate(result.chatId, seed);
+  const { message, ...stored } = seed;
+  if (message) {
+    setPendingSendData({
+      content: message,
+      attachments: seed.attachments ?? [],
+      model: DEFAULT_MODEL,
+    });
+  } else {
+    storeChatStateImmediate(result.chatId, stored);
+  }
   globalSplitManager()?.openWithSplit(
     { type: 'chat', id: result.chatId },
     { activate: true, preferNewSplit: true }
@@ -82,6 +95,11 @@ export async function openChatWithAgent(entity: ChatWithAgentEntity) {
 
 export async function openChatWithInput(initialInput: string) {
   await createAndOpenChat({ input: initialInput });
+}
+
+/** Open a new chat and immediately send `message` (the chat picks it up via pending send) */
+export async function openChatWithMessage(message: string) {
+  await createAndOpenChat({ message });
 }
 
 export function ChatWithAgentButton(props: { entity: ChatWithAgentEntity }) {

--- a/js/app/packages/app/component/command/CommandItem.tsx
+++ b/js/app/packages/app/component/command/CommandItem.tsx
@@ -2,6 +2,7 @@ import { useFeatureFlag } from '@app/lib/analytics/posthog';
 import { hasValidHotkey } from '@core/hotkey/utils';
 import { Entity, type EntityData } from '@entity';
 import SearchIcon from '@icon/macro-magnifying-glass.svg';
+import WideStar from '@icon/wide-star.svg';
 import Terminal from '@phosphor-icons/core/regular/terminal.svg?component-solid';
 import {
   BULK_DOCUMENT_WAKEUP_FEATURE_FLAG,
@@ -13,7 +14,9 @@ import { createEffect, For, Match, Show, Switch } from 'solid-js';
 import { Dynamic } from 'solid-js/web';
 import type { DisplayHotkeyStep } from './types';
 import {
+  type AskAiItem,
   type CommandMenuItem,
+  isAskAiItem,
   isCommandItem,
   isEntityItem,
   isSearchItem,
@@ -151,11 +154,27 @@ function SearchDisplay(props: { item: SearchItem }) {
   );
 }
 
+function AskAiDisplay(props: { item: AskAiItem }) {
+  return (
+    <div class="flex items-center gap-2 flex-1 min-w-0">
+      <div class="size-5 flex items-center justify-center text-ink-muted shrink-0">
+        <WideStar class="size-4" />
+      </div>
+      <span class="truncate text-ink">
+        Ask AI about <span class="text-ink">“{props.item.query}”</span>
+      </span>
+    </div>
+  );
+}
+
 function ItemDisplay(props: { item: CommandMenuItem }) {
   return (
     <Switch>
       <Match when={isSearchItem(props.item) && props.item}>
         {(item) => <SearchDisplay item={item()} />}
+      </Match>
+      <Match when={isAskAiItem(props.item) && props.item}>
+        {(item) => <AskAiDisplay item={item()} />}
       </Match>
       <Match when={isCommandItem(props.item) && props.item}>
         {(item) => <CommandDisplay item={item()} />}

--- a/js/app/packages/app/component/command/CommandMenu.tsx
+++ b/js/app/packages/app/component/command/CommandMenu.tsx
@@ -1,6 +1,6 @@
 import { useAnalytics } from '@app/component/analytics-context';
 import { getViewPreset } from '@app/component/app-sidebar/soup-filter-presets';
-import { openChatWithInput } from '@app/component/ChatWithAgentButton';
+import { openChatWithMessage } from '@app/component/ChatWithAgentButton';
 import { getSearchSplit } from '@app/component/next-soup/soup-view/search-controllers';
 import { isListViewID } from '@app/constants/list-views';
 import { globalSplitManager } from '@app/signal/splitLayout';
@@ -251,8 +251,8 @@ export function CommandMenuInner(props: {
     }
 
     if (isAskAiItem(item)) {
-      // Opens a new chat split with the query seeded into the input.
-      openChatWithInput(item.query);
+      // Opens a new chat split and sends the query immediately.
+      openChatWithMessage(item.query);
       CommandState.close();
       CommandState.setQuery('');
       return;

--- a/js/app/packages/app/component/command/CommandMenu.tsx
+++ b/js/app/packages/app/component/command/CommandMenu.tsx
@@ -1,5 +1,6 @@
 import { useAnalytics } from '@app/component/analytics-context';
 import { getViewPreset } from '@app/component/app-sidebar/soup-filter-presets';
+import { openChatWithInput } from '@app/component/ChatWithAgentButton';
 import { getSearchSplit } from '@app/component/next-soup/soup-view/search-controllers';
 import { isListViewID } from '@app/constants/list-views';
 import { globalSplitManager } from '@app/signal/splitLayout';
@@ -36,6 +37,7 @@ import { CommandState } from './state';
 import type { CategoryFilter } from './types';
 import {
   type CommandMenuItem,
+  isAskAiItem,
   isCommandItem,
   isEntityItem,
   isSearchItem,
@@ -80,7 +82,7 @@ export function CommandMenu() {
   });
 
   const handleSelect = (item: CommandMenuItem) => {
-    if (isSearchItem(item)) suppressCloseAutoFocus = true;
+    if (isSearchItem(item) || isAskAiItem(item)) suppressCloseAutoFocus = true;
   };
 
   return (
@@ -148,8 +150,12 @@ export function CommandMenuInner(props: {
     on([query, CommandState.categoryFilter], () => {
       const items = filteredItems();
       const firstIsSearch = items[0] && isSearchItem(items[0]);
+      // Skip past the search row only onto a real result — when the query has
+      // no results the rows below are fallbacks (ask AI), and the search row
+      // should stay the default.
+      const secondIsResult = items[1] && !isAskAiItem(items[1]);
       setShouldScrollSelectedIntoView(false);
-      CommandState.setSelectedIndex(firstIsSearch && items.length > 1 ? 1 : 0);
+      CommandState.setSelectedIndex(firstIsSearch && secondIsResult ? 1 : 0);
     })
   );
 
@@ -170,6 +176,10 @@ export function CommandMenuInner(props: {
   const selectedIsSearch = () => {
     const item = selectedItem();
     return item && isSearchItem(item);
+  };
+  const selectedIsAskAi = () => {
+    const item = selectedItem();
+    return item && isAskAiItem(item);
   };
 
   function handleItemAction(item: CommandMenuItem, openInNewSplit = false) {
@@ -235,6 +245,14 @@ export function CommandMenuInner(props: {
           );
         }
       }
+      CommandState.close();
+      CommandState.setQuery('');
+      return;
+    }
+
+    if (isAskAiItem(item)) {
+      // Opens a new chat split with the query seeded into the input.
+      openChatWithInput(item.query);
       CommandState.close();
       CommandState.setQuery('');
       return;
@@ -605,6 +623,9 @@ export function CommandMenuInner(props: {
                 label="Search in new split"
               />
             </Show>
+          </Match>
+          <Match when={selectedIsAskAi()}>
+            <HotkeyHint command={confirmHotkey} label="Ask AI" />
           </Match>
           <Match when={selectedIsEntity()}>
             <HotkeyHint command={confirmHotkey} label="Open" />

--- a/js/app/packages/app/component/command/useCommandItems.ts
+++ b/js/app/packages/app/component/command/useCommandItems.ts
@@ -49,8 +49,19 @@ type SearchItem = {
   category: CategoryFilter;
 };
 
+/** Ask-AI item: opens a new AI chat seeded with the query */
+type AskAiItem = {
+  id: string;
+  kind: 'ask-ai';
+  bucket: 'ask-ai';
+  searchText: string;
+  sortTimestamp: number;
+  timestamps: TimestampedItem;
+  query: string;
+};
+
 /** Combined item type for command menu (quickAccess items + commands) */
-type CommandMenuItem = QuickAccessItem | CommandItem | SearchItem;
+type CommandMenuItem = QuickAccessItem | CommandItem | SearchItem | AskAiItem;
 
 function isCommandItem(item: CommandMenuItem): item is CommandItem {
   return item.kind === 'command';
@@ -66,6 +77,10 @@ function _isUserItem(item: CommandMenuItem): item is UserItem {
 
 function isSearchItem(item: CommandMenuItem): item is SearchItem {
   return item.kind === 'search';
+}
+
+function isAskAiItem(item: CommandMenuItem): item is AskAiItem {
+  return item.kind === 'ask-ai';
 }
 
 /** Categories that surface a "Search for [query]" row in the command menu */
@@ -89,6 +104,18 @@ function makeSearchItem(query: string, category: CategoryFilter): SearchItem {
     timestamps: { viewedAt: undefined, updatedAt: undefined },
     query,
     category,
+  };
+}
+
+function makeAskAiItem(query: string): AskAiItem {
+  return {
+    id: `ask-ai:${query}`,
+    kind: 'ask-ai',
+    bucket: 'ask-ai',
+    searchText: query,
+    sortTimestamp: 0,
+    timestamps: { viewedAt: undefined, updatedAt: undefined },
+    query,
   };
 }
 
@@ -287,6 +314,11 @@ export function useCommandItems(
     const ranked = q ? search()(items, q).map((result) => result.item) : items;
 
     if (shouldShowSearchRow(q)) {
+      // With no direct results the menu would only offer search, so also
+      // offer handing the query to AI.
+      if (ranked.length === 0) {
+        return [makeSearchItem(q, categoryFilter()), makeAskAiItem(q)];
+      }
       return [makeSearchItem(q, categoryFilter()), ...ranked];
     }
 
@@ -296,5 +328,5 @@ export function useCommandItems(
   return filteredItems;
 }
 
-export type { CommandMenuItem, SearchItem };
-export { isCommandItem, isEntityItem, isSearchItem };
+export type { AskAiItem, CommandMenuItem, SearchItem };
+export { isAskAiItem, isCommandItem, isEntityItem, isSearchItem };

--- a/js/app/packages/app/component/mobile/MobileSearch.tsx
+++ b/js/app/packages/app/component/mobile/MobileSearch.tsx
@@ -1,5 +1,6 @@
 /** Mobile Search is based on Command Menu. */
 
+import { openChatWithInput } from '@app/component/ChatWithAgentButton';
 import { openEntityInSplitFromUnifiedList } from '@app/component/next-soup/utils';
 import { Tabs } from '@core/component/Tabs';
 import { TailSpinner } from '@core/component/TailSpinner';
@@ -35,6 +36,7 @@ import { CommandItem } from '../command/CommandItem';
 import type { CategoryFilter } from '../command/types';
 import {
   type CommandMenuItem,
+  isAskAiItem,
   isCommandItem,
   isEntityItem,
   useCommandItems,
@@ -135,6 +137,14 @@ function MobileSearchInner() {
           );
         }
       }
+      SearchState.close();
+      SearchState.setQuery('');
+      return;
+    }
+
+    if (isAskAiItem(item)) {
+      // Opens a new chat split with the query seeded into the input.
+      openChatWithInput(item.query);
       SearchState.close();
       SearchState.setQuery('');
       return;

--- a/js/app/packages/app/component/mobile/MobileSearch.tsx
+++ b/js/app/packages/app/component/mobile/MobileSearch.tsx
@@ -1,6 +1,6 @@
 /** Mobile Search is based on Command Menu. */
 
-import { openChatWithInput } from '@app/component/ChatWithAgentButton';
+import { openChatWithMessage } from '@app/component/ChatWithAgentButton';
 import { openEntityInSplitFromUnifiedList } from '@app/component/next-soup/utils';
 import { Tabs } from '@core/component/Tabs';
 import { TailSpinner } from '@core/component/TailSpinner';
@@ -143,8 +143,8 @@ function MobileSearchInner() {
     }
 
     if (isAskAiItem(item)) {
-      // Opens a new chat split with the query seeded into the input.
-      openChatWithInput(item.query);
+      // Opens a new chat split and sends the query immediately.
+      openChatWithMessage(item.query);
       SearchState.close();
       SearchState.setQuery('');
       return;


### PR DESCRIPTION
When a command menu query has no direct results, the only option offered today is dispatching a search. This adds an "Ask AI about “query”" row below the search row in that case.

- New `ask-ai` item kind in `useCommandItems`, appended after the search row only when the ranked results are empty.
- Selecting it creates a new chat and sends the query immediately via the pending-send mechanism (same as the cmd+j soup chat input), so the chat opens already streaming a response. Added as `openChatWithMessage` alongside the existing `openChatWithInput`.
- Default selection stays on the search row in the no-results case, so Enter still dispatches a search as before; an "Ask AI" enter-hint shows in the footer when the row is selected.
- Mobile search shares `useCommandItems`, so its item handler was wired up for the new row as well.

Session: https://claude.ai/code/session_01T2gZRd6WYyAEL7ZZj69DXV