### PR TITLE
Gate mark done hotkey to inbox/mail views and preview panel

### DIFF
--- a/js/app/packages/app/component/next-soup/actions/use-block-entity-commands.ts
+++ b/js/app/packages/app/component/next-soup/actions/use-block-entity-commands.ts
@@ -1,6 +1,7 @@
 import { useGlobalNotificationSource } from '@app/component/GlobalAppState';
 import { useMaybeSoup } from '@app/component/next-soup/soup-context';
 import { openEntityInSplitFromUnifiedList } from '@app/component/next-soup/utils';
+import { useMaybePreviewPanel } from '@app/component/PreviewPanel';
 import { useAllProperties } from '@app/component/property-edit-modal/hooks/useAllProperties';
 import { openPropertyEditor } from '@app/component/property-edit-modal/state/propertyEditor';
 import { useSplitPanel } from '@app/component/split-layout/layoutUtils';
@@ -39,6 +40,7 @@ export const useBlockEntityCommands = () => {
   const notificationSource = useGlobalNotificationSource();
   const soup = useMaybeSoup();
   const splitPanel = useSplitPanel();
+  const previewPanel = useMaybePreviewPanel();
 
   const markDone = makeMarkDoneAction({
     userId: () => userId(),
@@ -78,44 +80,69 @@ export const useBlockEntityCommands = () => {
     }
   };
 
+  // The 'e' hotkey from inside a block is reserved for entities opened full
+  // screen from the inbox/mail lists, mirroring the j/k gating in
+  // use-soup-navigation-hotkeys. Blocks rendered in the preview panel fall
+  // through to the originating list's own 'e' registration.
+  const canUseMarkDoneHotkey = () => {
+    if (previewPanel) return false;
+    const referredFrom = splitPanel?.handle.referredFrom();
+    return referredFrom === 'inbox' || referredFrom === 'mail';
+  };
+
+  const runMarkDone = () => {
+    const entity = getEntity();
+    if (!entity) return false;
+    if (!markDone.canExecute(entity)) return false;
+
+    const selectedRow = soup?.items.get(entity.id);
+    if (canUseMarkDoneHotkey() && soup && selectedRow) {
+      markDone.executeWithSoup([selectedRow.original], soup, (nextEntity) => {
+        const splitHandle = splitPanel?.handle;
+        if (!splitHandle) return;
+        void openEntityInSplitFromUnifiedList(nextEntity, {
+          splitHandle,
+          mergeHistory: true,
+          referredFrom: splitHandle.referredFrom(),
+        });
+      });
+    } else {
+      markDone.execute([entity]);
+    }
+
+    return true;
+  };
+
   createEffect(() => {
     const scopeId = blockHotkeyScopeSignal.get();
     if (!scopeId) return;
 
     const group = createHotkeyGroup();
 
+    // Mark done - 'e', only when coming from the inbox or mail views
     registerHotkey({
       hotkey: ['e'],
       hotkeyToken: TOKENS.entity.action.markDone,
       scopeId,
       description: 'Mark done',
-      keyDownHandler: () => {
-        const entity = getEntity();
-        if (!entity) return false;
-        if (!markDone.canExecute(entity)) return false;
-
-        const selectedRow = soup?.items.get(entity.id);
-        if (soup && selectedRow) {
-          markDone.executeWithSoup(
-            [selectedRow.original],
-            soup,
-            (nextEntity) => {
-              const splitHandle = splitPanel?.handle;
-              if (!splitHandle) return;
-              void openEntityInSplitFromUnifiedList(nextEntity, {
-                splitHandle,
-                mergeHistory: true,
-                referredFrom: splitHandle.referredFrom(),
-              });
-            }
-          );
-        } else {
-          markDone.execute([entity]);
-        }
-
-        return true;
-      },
+      keyDownHandler: runMarkDone,
       condition: () => {
+        if (!canUseMarkDoneHotkey()) return false;
+        const entity = getEntity();
+        return entity !== undefined && markDone.canExecute(entity);
+      },
+      displayPriority: 10,
+      tags: [HotkeyTags.SelectionModification],
+    }).withGroup(group);
+
+    // Mark done without a keybinding everywhere else, so it stays reachable
+    // from the command menu
+    registerHotkey({
+      scopeId,
+      description: 'Mark done',
+      keyDownHandler: runMarkDone,
+      condition: () => {
+        if (canUseMarkDoneHotkey()) return false;
         const entity = getEntity();
         return entity !== undefined && markDone.canExecute(entity);
       },


### PR DESCRIPTION
## Summary
Refactored the mark done hotkey ('e') registration to be context-aware, restricting it to entities opened from inbox/mail list views while allowing it to fall through to the originating list's hotkey handler when in the preview panel.

## Key Changes
- Added `useMaybePreviewPanel` hook import to detect when viewing entities in the preview panel
- Introduced `canUseMarkDoneHotkey()` function that gates the hotkey based on:
  - Whether the entity is being viewed in the preview panel (returns false if so)
  - Whether the entity was referred from 'inbox' or 'mail' views
- Extracted mark done execution logic into a new `runMarkDone()` function to avoid duplication
- Split the hotkey registration into two handlers:
  - **Primary handler** (with 'e' keybinding): Only active when `canUseMarkDoneHotkey()` returns true, with display priority and selection modification tag
  - **Fallback handler** (no keybinding): Registered for all other contexts to keep the action accessible via command menu
- Moved the execution logic from `keyDownHandler` to a separate function and added a `condition` callback for cleaner separation of concerns

## Implementation Details
The gating logic mirrors the existing j/k navigation hotkey behavior in `use-soup-navigation-hotkeys`. When a block is rendered in the preview panel, the 'e' hotkey is disabled to allow the originating list's own 'e' registration to handle the action, preventing hotkey conflicts and ensuring consistent behavior across different view contexts.

https://claude.ai/code/session_019ivXTNG6hqX57iJv8BJmSv