### PR TITLE
fix(soup): limit 'e' mark done in blocks to inbox/mail referrals

### DIFF
--- a/js/app/packages/app/component/next-soup/actions/use-block-entity-commands.ts
+++ b/js/app/packages/app/component/next-soup/actions/use-block-entity-commands.ts
@@ -95,20 +95,24 @@ export const useBlockEntityCommands = () => {
     if (!entity) return false;
     if (!markDone.canExecute(entity)) return false;
 
+    // Plain mark done, no advance: the command-menu registration outside the
+    // triage flow, or the entity is no longer in the surviving soup list.
     const selectedRow = soup?.items.get(entity.id);
-    if (canUseMarkDoneHotkey() && soup && selectedRow) {
-      markDone.executeWithSoup([selectedRow.original], soup, (nextEntity) => {
-        const splitHandle = splitPanel?.handle;
-        if (!splitHandle) return;
-        void openEntityInSplitFromUnifiedList(nextEntity, {
-          splitHandle,
-          mergeHistory: true,
-          referredFrom: splitHandle.referredFrom(),
-        });
-      });
-    } else {
+    if (!canUseMarkDoneHotkey() || !soup || !selectedRow) {
       markDone.execute([entity]);
+      return true;
     }
+
+    // Triage flow: mark done and advance to the next item in the list.
+    markDone.executeWithSoup([selectedRow.original], soup, (nextEntity) => {
+      const splitHandle = splitPanel?.handle;
+      if (!splitHandle) return;
+      void openEntityInSplitFromUnifiedList(nextEntity, {
+        splitHandle,
+        mergeHistory: true,
+        referredFrom: splitHandle.referredFrom(),
+      });
+    });
 
     return true;
   };

--- a/js/app/packages/app/component/next-soup/actions/use-block-entity-commands.ts
+++ b/js/app/packages/app/component/next-soup/actions/use-block-entity-commands.ts
@@ -1,6 +1,7 @@
 import { useGlobalNotificationSource } from '@app/component/GlobalAppState';
 import { useMaybeSoup } from '@app/component/next-soup/soup-context';
 import { openEntityInSplitFromUnifiedList } from '@app/component/next-soup/utils';
+import { useMaybePreviewPanel } from '@app/component/PreviewPanel';
 import { useAllProperties } from '@app/component/property-edit-modal/hooks/useAllProperties';
 import { openPropertyEditor } from '@app/component/property-edit-modal/state/propertyEditor';
 import { useSplitPanel } from '@app/component/split-layout/layoutUtils';
@@ -39,6 +40,7 @@ export const useBlockEntityCommands = () => {
   const notificationSource = useGlobalNotificationSource();
   const soup = useMaybeSoup();
   const splitPanel = useSplitPanel();
+  const previewPanel = useMaybePreviewPanel();
 
   const markDone = makeMarkDoneAction({
     userId: () => userId(),
@@ -78,44 +80,69 @@ export const useBlockEntityCommands = () => {
     }
   };
 
+  // The 'e' hotkey from inside a block is reserved for entities opened full
+  // screen from the inbox/mail lists, mirroring the j/k gating in
+  // use-soup-navigation-hotkeys. Blocks rendered in the preview panel fall
+  // through to the originating list's own 'e' registration.
+  const canUseMarkDoneHotkey = () => {
+    if (previewPanel) return false;
+    const referredFrom = splitPanel?.handle.referredFrom();
+    return referredFrom === 'inbox' || referredFrom === 'mail';
+  };
+
+  const runMarkDone = () => {
+    const entity = getEntity();
+    if (!entity) return false;
+    if (!markDone.canExecute(entity)) return false;
+
+    const selectedRow = soup?.items.get(entity.id);
+    if (canUseMarkDoneHotkey() && soup && selectedRow) {
+      markDone.executeWithSoup([selectedRow.original], soup, (nextEntity) => {
+        const splitHandle = splitPanel?.handle;
+        if (!splitHandle) return;
+        void openEntityInSplitFromUnifiedList(nextEntity, {
+          splitHandle,
+          mergeHistory: true,
+          referredFrom: splitHandle.referredFrom(),
+        });
+      });
+    } else {
+      markDone.execute([entity]);
+    }
+
+    return true;
+  };
+
   createEffect(() => {
     const scopeId = blockHotkeyScopeSignal.get();
     if (!scopeId) return;
 
     const group = createHotkeyGroup();
 
+    // Mark done - 'e', only when coming from the inbox or mail views
     registerHotkey({
       hotkey: ['e'],
       hotkeyToken: TOKENS.entity.action.markDone,
       scopeId,
       description: 'Mark done',
-      keyDownHandler: () => {
-        const entity = getEntity();
-        if (!entity) return false;
-        if (!markDone.canExecute(entity)) return false;
-
-        const selectedRow = soup?.items.get(entity.id);
-        if (soup && selectedRow) {
-          markDone.executeWithSoup(
-            [selectedRow.original],
-            soup,
-            (nextEntity) => {
-              const splitHandle = splitPanel?.handle;
-              if (!splitHandle) return;
-              void openEntityInSplitFromUnifiedList(nextEntity, {
-                splitHandle,
-                mergeHistory: true,
-                referredFrom: splitHandle.referredFrom(),
-              });
-            }
-          );
-        } else {
-          markDone.execute([entity]);
-        }
-
-        return true;
-      },
+      keyDownHandler: runMarkDone,
       condition: () => {
+        if (!canUseMarkDoneHotkey()) return false;
+        const entity = getEntity();
+        return entity !== undefined && markDone.canExecute(entity);
+      },
+      displayPriority: 10,
+      tags: [HotkeyTags.SelectionModification],
+    }).withGroup(group);
+
+    // Mark done without a keybinding everywhere else, so it stays reachable
+    // from the command menu
+    registerHotkey({
+      scopeId,
+      description: 'Mark done',
+      keyDownHandler: runMarkDone,
+      condition: () => {
+        if (canUseMarkDoneHotkey()) return false;
         const entity = getEntity();
         return entity !== undefined && markDone.canExecute(entity);
       },


### PR DESCRIPTION
## Summary
Fixes the `'e'` (mark done) hotkey being available from inside any block regardless of origin. #3935 re-added the j/k/e triage flow from within blocks and gated j/k on coming from the inbox or mail views (`canRunListNavigation` in `use-soup-navigation-hotkeys`), but the `'e'` it added to the block hotkey scope had no such check — so e.g. a document opened full screen from the documents view could be marked done with `'e'`.

## Key Changes
- Added `canUseMarkDoneHotkey()` in `use-block-entity-commands.ts`, mirroring the j/k gating: the split's `referredFrom()` must be `'inbox'` or `'mail'`, and blocks rendered in the preview panel are excluded so the originating list's own gated `'e'` registration keeps handling that case
- Split the registration in two:
  - `'e'` keybinding: active only when `canUseMarkDoneHotkey()` is true
  - No keybinding: active everywhere else, so "Mark done" stays reachable from the block's command menu from any view (its pre-#3935 behavior)
- Extracted the shared handler into `runMarkDone()`; the archive-then-advance split navigation (`executeWithSoup` + `openEntityInSplitFromUnifiedList`) now only runs in the inbox/mail flow — invoking mark done from the command menu elsewhere just marks done without navigating the split

## Verification
`bun type-check` and `biome check` pass.

https://claude.ai/code/session_019ivXTNG6hqX57iJv8BJmSv