### PR TITLE
refactor(env_vars): add in database_env_vars crate

### DIFF
--- a/.github/workspace-dep-closures.json
+++ b/.github/workspace-dep-closures.json
@@ -179,6 +179,7 @@
       "macro_entrypoint",
       "macro_env",
       "macro_env_var",
+      "macro_env_vars/database_env_vars",
       "macro_middleware",
       "macro_redis",
       "macro_service_urls",
@@ -772,6 +773,7 @@
       "macro_entrypoint",
       "macro_env",
       "macro_env_var",
+      "macro_env_vars/database_env_vars",
       "macro_middleware",
       "macro_service_urls",
       "macro_user_id",
@@ -883,6 +885,11 @@
       "models_permissions",
       "non_empty",
       "unfurl",
+      "workspace-hack"
+    ],
+    "database_env_vars": [
+      "macro_env_var",
+      "macro_env_vars/database_env_vars",
       "workspace-hack"
     ],
     "dataloss_prevention_handler": [

--- a/rust/cloud-storage/Cargo.lock
+++ b/rust/cloud-storage/Cargo.lock
@@ -675,6 +675,7 @@ dependencies = [
  "comms_db_client",
  "cookie",
  "cool_asserts",
+ "database_env_vars",
  "document_storage_service_client",
  "doppleganger",
  "doppler-config",
@@ -2598,6 +2599,7 @@ dependencies = [
  "aws-sdk-sqs",
  "axum",
  "contacts",
+ "database_env_vars",
  "http-body-util",
  "macro_auth",
  "macro_aws_config",
@@ -3118,6 +3120,15 @@ name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "database_env_vars"
+version = "0.1.0"
+dependencies = [
+ "macro_env_var",
+ "tracing",
+ "workspace-hack",
+]
 
 [[package]]
 name = "dataloss_prevention_handler"

--- a/rust/cloud-storage/authentication_service/Cargo.toml
+++ b/rust/cloud-storage/authentication_service/Cargo.toml
@@ -130,6 +130,7 @@ utoipa-swagger-ui = { workspace = true }
 uuid = { workspace = true }
 doppler-config = { workspace = true }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
+database_env_vars = { path = "../macro_env_vars/database_env_vars" }
 
 [dev-dependencies]
 cool_asserts = "2"

--- a/rust/cloud-storage/authentication_service/src/config.rs
+++ b/rust/cloud-storage/authentication_service/src/config.rs
@@ -1,6 +1,7 @@
 use std::sync::LazyLock;
 
 use anyhow::Context;
+use database_env_vars::{DatabaseUrl, RedisUri};
 pub use macro_env::Environment;
 use macro_env_var::{env_vars, maybe_env_vars};
 
@@ -12,8 +13,6 @@ pub static BASE_URL: LazyLock<String> = LazyLock::new(|| {
 
 env_vars! {
     pub struct BaseUrl;
-    pub struct DatabaseUrl;
-    pub struct RedisUri;
     pub struct FusionAuthTenantId;
     pub struct FusionAuthApiSecretKey;
     pub struct FusionAuthClientId;

--- a/rust/cloud-storage/contacts_service/Cargo.toml
+++ b/rust/cloud-storage/contacts_service/Cargo.toml
@@ -44,6 +44,7 @@ macro_service_urls = { path = "../macro_service_urls" }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 macro_env_var = { path = "../macro_env_var" }
 macro_config = { path = "../macro_config" }
+database_env_vars = { path = "../macro_env_vars/database_env_vars" }
 
 [features]
 mock = []

--- a/rust/cloud-storage/contacts_service/src/config.rs
+++ b/rust/cloud-storage/contacts_service/src/config.rs
@@ -1,11 +1,10 @@
 use anyhow::Context;
+use database_env_vars::{DatabaseUrl, RedisUri};
 pub use macro_env::Environment;
 use macro_env_var::{env_vars, maybe_env_vars};
 
 env_vars! {
     pub struct BaseUrl;
-    pub struct DatabaseUrl;
-    pub struct RedisUri;
     pub struct ContactsQueue;
 }
 
@@ -47,8 +46,8 @@ impl Config {
         Config {
             port: 0,
             environment: Environment::Local,
-            database_url: DatabaseUrl::new_testing(""),
-            redis_uri: RedisUri::new_testing(""),
+            database_url: DatabaseUrl::Comptime(""),
+            redis_uri: RedisUri::Comptime(""),
             contacts_queue: ContactsQueue::new_testing(""),
             contacts_queue_max_messages: ContactsQueueMaxMessages::new_unset(),
             contacts_queue_wait_time_seconds: ContactsQueueWaitTimeSeconds::new_unset(),

--- a/rust/cloud-storage/macro_env_vars/database_env_vars/Cargo.toml
+++ b/rust/cloud-storage/macro_env_vars/database_env_vars/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+edition = "2024"
+name = "database_env_vars"
+publish = false
+version = "0.1.0"
+
+[dependencies]
+tracing = { workspace = true }
+macro_env_var = { path = "../../macro_env_var" }
+workspace-hack = { version = "0.1", path = "../../workspace-hack" }

--- a/rust/cloud-storage/macro_env_vars/database_env_vars/src/lib.rs
+++ b/rust/cloud-storage/macro_env_vars/database_env_vars/src/lib.rs
@@ -1,0 +1,14 @@
+//! This crate contains the macro_env_var structs for our databases.
+//! This allows us to standardize how we configure a service to use these databases.
+//! Each value in this crate should match the key name of the environment variable you provide in
+//! the doppler configuration.
+#![deny(missing_docs)]
+
+use macro_env_var::env_vars;
+
+env_vars! {
+/// MacroDB database url
+pub struct DatabaseUrl;
+/// MacroCache redis uri
+pub struct RedisUri;
+}


### PR DESCRIPTION
Starting to group common environment variables across services in crates so we can use the same env var for all config values which will improve usability with the macro_config::from_ref_all macro.