### PR TITLE
feat(email): refetch links on photo_synced, drop avatar sync poll

### DIFF
--- a/js/app/packages/queries/email/link.ts
+++ b/js/app/packages/queries/email/link.ts
@@ -4,10 +4,7 @@ import { invalidateUserInfo } from '@queries/auth/user-info';
 import { queryClient } from '@queries/client';
 import { invalidateAllSoup } from '@queries/soup/normalized-cache';
 import { emailClient } from '@service-email/client';
-import {
-  type ListLinksResponse,
-  SyncStatus,
-} from '@service-email/generated/schemas';
+import type { ListLinksResponse } from '@service-email/generated/schemas';
 import { useMutation, useQuery } from '@tanstack/solid-query';
 import { createMemo } from 'solid-js';
 import { type MutationCallbacks, withCallbacks } from '../utils';
@@ -15,25 +12,12 @@ import { emailKeys } from './keys';
 
 const LINK_STALE_TIME = 5 * 60 * 1000;
 
-// A newly-linked inbox's avatar (`photo_url`) is written async, so poll the links
-// list while any inbox is still syncing; polling stops on its own once none are,
-// leaving steady-state/single-inbox users with no extra fetches.
-const LINK_SYNC_POLL_INTERVAL = 2_000;
-
-function isAnyInboxSyncing(data: ListLinksResponse | undefined): boolean {
-  return (
-    data?.links.some((link) => link.sync_status === SyncStatus.SYNCING) ?? false
-  );
-}
-
 export function useEmailLinksQuery() {
   return useQuery(() => ({
     queryKey: emailKeys.links.queryKey,
     queryFn: async () => throwOnErr(async () => await emailClient.getLinks()),
     staleTime: LINK_STALE_TIME,
     refetchOnWindowFocus: 'always',
-    refetchInterval: (query) =>
-      isAnyInboxSyncing(query.state.data) ? LINK_SYNC_POLL_INTERVAL : false,
   }));
 }
 

--- a/js/app/packages/queries/email/sync.ts
+++ b/js/app/packages/queries/email/sync.ts
@@ -4,6 +4,7 @@ import { invalidateAllSoup } from '@queries/soup/normalized-cache';
 import {
   BackfillStatus,
   type RefreshEmailEvent,
+  RefreshEmailEventOneOfOneoneEvent,
 } from '@service-email/generated/schemas';
 import { leadingAndTrailing, throttle } from '@solid-primitives/scheduled';
 import { invalidateEmailLinks } from './link';
@@ -27,15 +28,18 @@ function asRefreshEmailEvent(payload: unknown): RefreshEmailEvent | undefined {
 }
 
 /**
- * Handles `refresh_email` websocket events. Only `backfill` events act here:
- * steady-state mutations (`upsert_message`, `update_labels`, `delete_message`)
- * already invalidate soup through the notification-driven path, and reacting to
- * them again would double-refetch.
+ * Handles `refresh_email` websocket events. Steady-state mutations
+ * (`upsert_message`, `update_labels`, `delete_message`) already invalidate soup
+ * through the notification-driven path, and reacting to them again would
+ * double-refetch, so only `backfill`, `link_removed`, and `photo_synced` act
+ * here.
  *
  * Backfill produces no notifications, so this is its only refresh signal.
  * `progress` refetches soup, throttled because the backend emits one event per
  * batch of threads. `complete`/`failed` additionally refetch the links list so
  * the inbox's `sync_status` settles out of `SYNCING`, and surface a toast.
+ * `photo_synced` refetches the links list so the inbox's derived `photo_url`
+ * lands once its self-contact photo finishes uploading.
  */
 export function handleRefreshEmail(payload: unknown): void {
   const event = asRefreshEmailEvent(payload);
@@ -46,6 +50,13 @@ export function handleRefreshEmail(payload: unknown): void {
   // done; refetching on the delete request itself races the cascade delete.
   if (event.event === 'link_removed') {
     invalidateAllSoup();
+    invalidateEmailLinks();
+    return;
+  }
+
+  // The inbox's own photo finished uploading; refetch links to pick up the
+  // newly-derived `photo_url`.
+  if (event.event === RefreshEmailEventOneOfOneoneEvent.photo_synced) {
     invalidateEmailLinks();
     return;
   }


### PR DESCRIPTION
Stacked on #4065. Handles the `photo_synced` `refresh_email` event by refetching the email links list, and removes the interim 2s links poll that ran while any inbox was syncing. Merge after the backend PR deploys to dev.
