### PR TITLE
fix(lexical): collapse nested block paragraphs in single-line editors

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
@@ -629,7 +629,7 @@ export const SoupView = (props: SoupViewProps) => {
                 when={!isComponentListView('search')}
                 fallback={
                   <Layer depth={2}>
-                    <div class="grow ml-2">
+                    <div class="grow ml-2 min-w-0 [contain:inline-size]">
                       <SoupSearchbar
                         variant="secondary"
                         placeholder="Search, @mention contacts"

--- a/js/app/packages/core/component/LexicalMarkdown/plugins/single-line/singleLinePlugin.ts
+++ b/js/app/packages/core/component/LexicalMarkdown/plugins/single-line/singleLinePlugin.ts
@@ -2,7 +2,13 @@
  * @file A plugin to enforce a single line only.
  */
 import { mergeRegister } from '@lexical/utils';
-import { type LexicalEditor, LineBreakNode, RootNode } from 'lexical';
+import {
+  $isRootNode,
+  type LexicalEditor,
+  LineBreakNode,
+  ParagraphNode,
+  RootNode,
+} from 'lexical';
 
 export function singleLinePlugin() {
   return (editor: LexicalEditor) => {
@@ -14,6 +20,19 @@ export function singleLinePlugin() {
       }),
 
       editor.registerNodeTransform(LineBreakNode, (node) => {
+        node.remove();
+      }),
+
+      // Programmatic inserts (snippets, paste) can nest block paragraphs inside
+      // the single root paragraph, which the root-child check above doesn't
+      // catch. Unwrap them so a nested block's inline content collapses onto the
+      // one line instead of rendering as extra rows.
+      editor.registerNodeTransform(ParagraphNode, (node) => {
+        const parent = node.getParent();
+        if (!parent || $isRootNode(parent)) return;
+        for (const child of node.getChildren()) {
+          node.insertBefore(child);
+        }
         node.remove();
       })
     );


### PR DESCRIPTION
Two search-bar fixes: snippet insertion nested block paragraphs inside the single root paragraph (including a trailing-newline empty paragraph that rendered as an extra row), which the single-line plugin's root-child check missed — the plugin now unwraps nested block paragraphs onto the one line. Separately, a long pasted/inserted value grew the search field and pushed the title and nav controls off-screen; contain:inline-size keeps the field's width independent of its text so it truncates within the bar instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
