### PR TITLE
fix(references): go to target message on reference click in one click

### DIFF
--- a/js/app/packages/core/component/References.tsx
+++ b/js/app/packages/core/component/References.tsx
@@ -1,7 +1,7 @@
 import { useGlobalBlockOrchestrator } from '@app/component/GlobalAppState';
 import { SidePanel } from '@app/component/side-panel';
 import { useSplitLayout } from '@app/component/split-layout/layout';
-import { getChannelParams } from '@block-channel/utils/link';
+import { navigateToChannelMessage } from '@block-channel/utils/link';
 import type { BlockAlias, BlockName } from '@core/block';
 import { toast } from '@core/component/Toast/Toast';
 import { fileTypeToBlockName } from '@core/constant/allBlocks';
@@ -217,17 +217,6 @@ export function References(props: ReferenceProps) {
   const { openWithSplit } = useSplitLayout();
   const blockOrchestrator = useGlobalBlockOrchestrator();
 
-  const goToMessageLocation = async (
-    channelId: string,
-    messageId: string,
-    threadId?: string
-  ) => {
-    const blockHandle = await blockOrchestrator.getBlockHandle(channelId);
-    await blockHandle?.goToLocationFromParams(
-      getChannelParams(messageId, threadId)
-    );
-  };
-
   const navigateToItem = ({
     event,
     blockId,
@@ -254,12 +243,15 @@ export function References(props: ReferenceProps) {
     messageId: string;
     threadId?: string;
   }) => {
-    navigateToItem({
-      event,
-      blockName: 'channel',
-      blockId: channelId,
-    });
-    goToMessageLocation(channelId, messageId, threadId);
+    navigateToChannelMessage(
+      blockOrchestrator,
+      channelId,
+      messageId,
+      threadId,
+      {
+        preferNewSplit: event?.shiftKey !== true,
+      }
+    );
   };
 
   const navigateToGenericReference = (


### PR DESCRIPTION
Clicking a channel-message reference in a document's side panel required two clicks — the first opened the channel at the bottom, the second scrolled to the target message. It now lands on the target message in a single click by reusing the `navigateToChannelMessage` helper (the same approach as PR #3897), which passes the message params into `openWithSplit` and then awaits `goToLocationFromParams`, instead of opening the channel without params and racing a separate scroll call.

Closes MACRO-1827.
