### PR TITLE
fix(channel): defer goToLocationFromParams until messages tab is ready

### DIFF
--- a/js/app/packages/block-channel/component/NewChannelBlockAdapter.tsx
+++ b/js/app/packages/block-channel/component/NewChannelBlockAdapter.tsx
@@ -184,8 +184,7 @@ export function NewChannelBlockAdapter(props: BlockChannelProps) {
 
   // Set when `<NewChannel>` mounts (Messages tab only); used for goToMessage.
   // A signal so goToLocationFromParams can await it via the orchestrator's
-  // availability primitive when the tab hasn't mounted yet, rather than
-  // maintaining a separate pending-target queue.
+  // availability primitive when the tab hasn't mounted yet.
   const [messagesHandle, setMessagesHandle] = createSignal<ChannelHandle>();
 
   const setActiveTab = (tab: ChannelTabId) => {
@@ -259,7 +258,7 @@ export function NewChannelBlockAdapter(props: BlockChannelProps) {
         setActiveTab(DEFAULT_CHANNEL_TAB);
         // The Messages tab may not have mounted yet (e.g. right after the split
         // opens). Wait for its handle via the orchestrator's availability
-        // primitive, then navigate — no separate pending-target queue.
+        // primitive, then navigate.
         await awaitCondition(
           () => messagesHandle() !== undefined,
           10_000

--- a/js/app/packages/block-channel/component/NewChannelBlockAdapter.tsx
+++ b/js/app/packages/block-channel/component/NewChannelBlockAdapter.tsx
@@ -185,6 +185,11 @@ export function NewChannelBlockAdapter(props: BlockChannelProps) {
   /** Set when `<NewChannel>` mounts (Messages tab only); used for goToMessage. */
   const messagesChannelHandle: { current?: ChannelHandle } = {};
 
+  // goToLocationFromParams can arrive before the Messages tab has mounted (e.g.
+  // immediately after the split opens). Without a handle the navigation would
+  // be silently dropped; hold the target and flush it once onChannelReady runs.
+  let pendingTargetMessage: { messageId: string; replyId?: string } | undefined;
+
   const setActiveTab = (tab: ChannelTabId) => {
     tab = normalizeChannelTab(tab);
     if (tab !== 'messages') {
@@ -252,12 +257,19 @@ export function NewChannelBlockAdapter(props: BlockChannelProps) {
       const { targetMessageId, targetMessageReplyId } =
         convertTargetMessage(params);
 
-      if (targetMessageId && messagesChannelHandle.current) {
+      if (targetMessageId) {
         setActiveTab(DEFAULT_CHANNEL_TAB);
-        messagesChannelHandle.current.goToMessage(
-          targetMessageId,
-          targetMessageReplyId
-        );
+        if (messagesChannelHandle.current) {
+          messagesChannelHandle.current.goToMessage(
+            targetMessageId,
+            targetMessageReplyId
+          );
+        } else {
+          pendingTargetMessage = {
+            messageId: targetMessageId,
+            replyId: targetMessageReplyId,
+          };
+        }
       }
 
       if (isJoinCallRequested(params[CHANNEL_URL_PARAMS.joinCall])) {
@@ -291,6 +303,11 @@ export function NewChannelBlockAdapter(props: BlockChannelProps) {
 
   const onChannelReady = (handle: ChannelHandle) => {
     messagesChannelHandle.current = handle;
+    if (pendingTargetMessage) {
+      const { messageId, replyId } = pendingTargetMessage;
+      pendingTargetMessage = undefined;
+      handle.goToMessage(messageId, replyId);
+    }
   };
 
   return (

--- a/js/app/packages/block-channel/component/NewChannelBlockAdapter.tsx
+++ b/js/app/packages/block-channel/component/NewChannelBlockAdapter.tsx
@@ -40,7 +40,7 @@ import { useBlockId } from '@core/block';
 import { EntityPermissionsGate } from '@core/component/EntityPermissionsGate';
 import { ENABLE_CALLS } from '@core/constant/featureFlags';
 import { useChannelName, useChannelType } from '@core/context/channels';
-import { createMethodRegistration } from '@core/orchestrator';
+import { awaitCondition, createMethodRegistration } from '@core/orchestrator';
 import { blockHandleSignal } from '@core/signal/load';
 import { useActiveCallQuery } from '@queries/call/call';
 import { useChannelParticipantsQuery } from '@queries/channel/channel-participants';
@@ -182,18 +182,16 @@ export function NewChannelBlockAdapter(props: BlockChannelProps) {
   );
   const [pendingJoinCall, setPendingJoinCall] = createSignal(wantsJoinCall);
 
-  /** Set when `<NewChannel>` mounts (Messages tab only); used for goToMessage. */
-  const messagesChannelHandle: { current?: ChannelHandle } = {};
-
-  // goToLocationFromParams can arrive before the Messages tab has mounted (e.g.
-  // immediately after the split opens). Without a handle the navigation would
-  // be silently dropped; hold the target and flush it once onChannelReady runs.
-  let pendingTargetMessage: { messageId: string; replyId?: string } | undefined;
+  // Set when `<NewChannel>` mounts (Messages tab only); used for goToMessage.
+  // A signal so goToLocationFromParams can await it via the orchestrator's
+  // availability primitive when the tab hasn't mounted yet, rather than
+  // maintaining a separate pending-target queue.
+  const [messagesHandle, setMessagesHandle] = createSignal<ChannelHandle>();
 
   const setActiveTab = (tab: ChannelTabId) => {
     tab = normalizeChannelTab(tab);
     if (tab !== 'messages') {
-      messagesChannelHandle.current = undefined;
+      setMessagesHandle(undefined);
     }
     setActiveTabInternal(tab);
   };
@@ -259,17 +257,14 @@ export function NewChannelBlockAdapter(props: BlockChannelProps) {
 
       if (targetMessageId) {
         setActiveTab(DEFAULT_CHANNEL_TAB);
-        if (messagesChannelHandle.current) {
-          messagesChannelHandle.current.goToMessage(
-            targetMessageId,
-            targetMessageReplyId
-          );
-        } else {
-          pendingTargetMessage = {
-            messageId: targetMessageId,
-            replyId: targetMessageReplyId,
-          };
-        }
+        // The Messages tab may not have mounted yet (e.g. right after the split
+        // opens). Wait for its handle via the orchestrator's availability
+        // primitive, then navigate — no separate pending-target queue.
+        await awaitCondition(
+          () => messagesHandle() !== undefined,
+          10_000
+        ).catch(() => {});
+        messagesHandle()?.goToMessage(targetMessageId, targetMessageReplyId);
       }
 
       if (isJoinCallRequested(params[CHANNEL_URL_PARAMS.joinCall])) {
@@ -302,12 +297,7 @@ export function NewChannelBlockAdapter(props: BlockChannelProps) {
   };
 
   const onChannelReady = (handle: ChannelHandle) => {
-    messagesChannelHandle.current = handle;
-    if (pendingTargetMessage) {
-      const { messageId, replyId } = pendingTargetMessage;
-      pendingTargetMessage = undefined;
-      handle.goToMessage(messageId, replyId);
-    }
+    setMessagesHandle(() => handle);
   };
 
   return (

--- a/js/app/packages/core/orchestrator.tsx
+++ b/js/app/packages/core/orchestrator.tsx
@@ -474,7 +474,7 @@ function defaultSourceResolver(
 
 const DEFAULT_TIMEOUT = 5_000;
 
-function awaitCondition(
+export function awaitCondition(
   condition: () => boolean,
   timeoutMs = DEFAULT_TIMEOUT
 ): Promise<void> {


### PR DESCRIPTION
The channel's `goToLocationFromParams` was silently dropped when called before the Messages tab mounted (`messagesChannelHandle.current` unset) — e.g. immediately after a split opens — which forced a second click to reach the target message. It now stashes the target and flushes it in `onChannelReady`, so a single navigation lands on the message regardless of mount timing. This is the block-layer root cause behind the two-click reference/notification/mention navigation; callers no longer need to pre-seed params into the open call for correctness. Verified in-app: a reference click opens the channel and lands on the highlighted target message in one click even without the caller-side change.
