### PR TITLE
test: reject email sql injection vectors

### DIFF
--- a/rust/cloud-storage/macro_user_id/src/email.rs
+++ b/rust/cloud-storage/macro_user_id/src/email.rs
@@ -18,12 +18,12 @@ use serde::{Deserialize, Serialize};
 #[cfg(test)]
 mod tests;
 
-// Parser for domain labels
+/// Parser for domain labels
 fn domain_label(input: &str) -> IResult<&str, &str> {
     take_while1(|c: char| c.is_ascii_alphanumeric() || c == '-').parse(input)
 }
 
-// Parser for the domain part
+/// Parser for the domain part
 fn domain(input: &str) -> IResult<&str, &str> {
     recognize(verify(
         separated_list1(char('.'), domain_label),
@@ -33,7 +33,7 @@ fn domain(input: &str) -> IResult<&str, &str> {
     .parse(input)
 }
 
-// Parser for local part (before @)
+/// Parser for local part (before @)
 fn atom(input: &str) -> IResult<&str, &str> {
     take_while1(|c: char| c.is_ascii_alphanumeric() || "!#$%&'*+/=?^_`{|}~-".contains(c))
         .parse(input)

--- a/rust/cloud-storage/macro_user_id/src/email/tests.rs
+++ b/rust/cloud-storage/macro_user_id/src/email/tests.rs
@@ -26,6 +26,9 @@ fn it_should_fail() {
         "sean..aye@macro.com",
         "sean@@macro.com",
         r#"foo"@macro.com"@example.com"#,
+        // cannot have single quote in domain part
+        "sean@mac'ro.com",
+        "se'an@mac'ro.com",
     ];
     invalid_emails
         .iter()
@@ -34,6 +37,34 @@ fn it_should_fail() {
         .for_each(|res| {
             res.unwrap_err();
         });
+}
+
+#[test]
+fn known_sql_injection_payloads_are_not_valid_email_addresses() {
+    let sql_injection_vectors = [
+        "sean' OR '1'='1@macro.com",
+        "sean' UNION SELECT password FROM users--@macro.com",
+        "sean@macro.com'; DROP TABLE users; --",
+        "sean@macro.com' OR '1'='1",
+        "sean'@macro.com OR 1=1",
+        "sean'\nOR '1'='1@macro.com",
+    ];
+
+    for input in sql_injection_vectors {
+        assert!(
+            Email::parse_from_str(input).is_err(),
+            "parsed Email must not be constructible from SQL injection vector: {input}"
+        );
+    }
+}
+
+#[test]
+fn local_part_may_contain_single_quote_without_being_sql_injection() {
+    let email = Email::parse_from_str("o'connor@macro.com").unwrap();
+
+    assert_eq!(email.email_str(), "o'connor@macro.com");
+    assert_eq!(email.local_part(), "o'connor");
+    assert_eq!(email.domain_part(), "macro.com");
 }
 
 #[test]


### PR DESCRIPTION
This PR adds unit tests to assert that it is not possible for a parsed `macro_user_id::Email` struct to contain a sql injection string.

There is no behaviour change to the code, we were never vulnerable to this, but the tests codify this and guard against regressions.
