### PR TITLE
fix(search): bound unified_search query size to prevent OOM

### DIFF
--- a/rust/cloud-storage/search_service/src/api/search/simple/mod.rs
+++ b/rust/cloud-storage/search_service/src/api/search/simple/mod.rs
@@ -35,6 +35,9 @@ pub enum SearchError {
     /// Invalid query size
     #[error("query must be at least 3 characters")]
     InvalidQuerySize,
+    /// Query expands into too many search terms
+    #[error("query has too many terms (max 50)")]
+    TooManyTerms,
     /// No query or terms provided
     #[error("query or terms must be provided and at least 3 characters")]
     NoQueryOrTermsProvided,
@@ -64,6 +67,7 @@ impl IntoResponse for SearchError {
             SearchError::NoUserId | SearchError::InvalidUserId(_) => StatusCode::UNAUTHORIZED,
             SearchError::InvalidPageSize
             | SearchError::InvalidQuerySize
+            | SearchError::TooManyTerms
             | SearchError::InvalidCursor
             | SearchError::InvalidCrmCompanyId(_)
             | SearchError::NoQueryOrTermsProvided

--- a/rust/cloud-storage/search_service/src/api/search/simple/simple_unified.rs
+++ b/rust/cloud-storage/search_service/src/api/search/simple/simple_unified.rs
@@ -82,6 +82,32 @@ fn compute_next_cursor(
 
 use crate::api::search::terms::split_search_terms;
 
+/// Per-request cap on whitespace-delimited search terms. Each term expands
+/// into its own `has_child` clause and is embedded in every clause's highlight
+/// query, so query-build cost is quadratic in the term count across the
+/// join-shape indices — an unbounded paste can OOM the service.
+const MAX_SEARCH_TERMS: usize = 50;
+
+/// Per-term character cap. Body size also scales with summed term length; real
+/// tokens fall well under this, so longer ones are truncated rather than
+/// rejected.
+const MAX_TERM_CHARS: usize = 80;
+
+/// Enforce [`MAX_SEARCH_TERMS`] and [`MAX_TERM_CHARS`] on tokenized terms
+/// before they fan out into per-index OpenSearch queries.
+fn enforce_term_limits(terms: Vec<String>) -> Result<Vec<String>, SearchError> {
+    if terms.len() > MAX_SEARCH_TERMS {
+        return Err(SearchError::TooManyTerms);
+    }
+    Ok(terms
+        .into_iter()
+        .map(|term| match term.char_indices().nth(MAX_TERM_CHARS) {
+            Some((byte_idx, _)) => term[..byte_idx].to_string(),
+            None => term,
+        })
+        .collect())
+}
+
 /// Creates a unified search request and performs the search
 /// by calling individual simple search endpoints for each entity type
 #[tracing::instrument(skip(ctx, user_context, query_params), fields(user_id = %user_context.user_id), err)]
@@ -133,6 +159,7 @@ pub(in crate::api::search) async fn perform_unified_search(
         return Err(SearchError::InvalidQuerySize);
     }
     let terms: Vec<String> = vec![query];
+    let search_terms = enforce_term_limits(split_search_terms(&terms))?;
 
     let match_type = req.match_type;
 
@@ -156,7 +183,7 @@ pub(in crate::api::search) async fn perform_unified_search(
     let should_include_projects = search_filters.should_include_projects;
     let should_include_emails = search_filters.should_include_emails;
     let should_include_call_records = search_filters.should_include_call_records;
-    let email_terms = split_search_terms(&terms);
+    let email_terms = search_terms.clone();
 
     // Await all tasks in parallel
     let (
@@ -214,11 +241,11 @@ pub(in crate::api::search) async fn perform_unified_search(
     // appear in the same message via bool.must. Documents, chats, and
     // call records are join-shape, where each term becomes a separate
     // has_child clause ANDed via bool.must.
-    filter_document_response.terms = split_search_terms(&terms);
-    filter_channel_response.terms = split_search_terms(&terms);
-    filter_chat_response.terms = split_search_terms(&terms);
+    filter_document_response.terms = search_terms.clone();
+    filter_channel_response.terms = search_terms.clone();
+    filter_chat_response.terms = search_terms.clone();
     filter_email_response.terms = email_terms.clone();
-    filter_call_record_response.terms = split_search_terms(&terms);
+    filter_call_record_response.terms = search_terms.clone();
 
     // Widen the email access filter to every inbox the caller can reach (their
     // own plus delegated). Connected secondary inboxes share the owner's

--- a/rust/cloud-storage/search_service/src/api/search/simple/simple_unified/test.rs
+++ b/rust/cloud-storage/search_service/src/api/search/simple/simple_unified/test.rs
@@ -441,3 +441,41 @@ fn test_cursor_logic_crm_included_advances_cursor() {
         ),
     }
 }
+
+#[test]
+fn enforce_term_limits_accepts_at_max() {
+    let terms: Vec<String> = (0..MAX_SEARCH_TERMS).map(|i| format!("t{i}")).collect();
+    let out = enforce_term_limits(terms.clone()).expect("at-limit term count should pass");
+    assert_eq!(out, terms);
+}
+
+#[test]
+fn enforce_term_limits_rejects_over_max() {
+    let terms: Vec<String> = (0..=MAX_SEARCH_TERMS).map(|i| format!("t{i}")).collect();
+    assert_eq!(terms.len(), MAX_SEARCH_TERMS + 1);
+    assert!(matches!(
+        enforce_term_limits(terms),
+        Err(SearchError::TooManyTerms)
+    ));
+}
+
+#[test]
+fn enforce_term_limits_truncates_long_term() {
+    let long = "a".repeat(MAX_TERM_CHARS + 25);
+    let out = enforce_term_limits(vec![long]).expect("single term is under the count cap");
+    assert_eq!(out[0].chars().count(), MAX_TERM_CHARS);
+}
+
+#[test]
+fn enforce_term_limits_leaves_short_terms_untouched() {
+    let terms = vec!["hello".to_string(), "world".to_string()];
+    let out = enforce_term_limits(terms.clone()).expect("short terms pass");
+    assert_eq!(out, terms);
+}
+
+#[test]
+fn enforce_term_limits_truncates_on_char_boundary() {
+    let long = "é".repeat(MAX_TERM_CHARS + 10);
+    let out = enforce_term_limits(vec![long]).expect("single term is under the count cap");
+    assert_eq!(out[0].chars().count(), MAX_TERM_CHARS);
+}


### PR DESCRIPTION
`unified_search` had no max query size — a large free-text paste tokenizes into N terms, each becoming a separate `has_child` clause embedding an all-terms highlight query, making query-build O(N²) across the join-shape indices, which OOM-killed cloud-storage-service. Rejects queries above 50 terms (400) and truncates each term to 80 chars.
