### PR TITLE
fix(ci): bundle pdfium lib into document-text-extractor lambda zip

### DIFF
--- a/.github/scripts/build-cloud-storage-lambdas-nix.sh
+++ b/.github/scripts/build-cloud-storage-lambdas-nix.sh
@@ -65,6 +65,13 @@ for lambda in "${LAMBDAS[@]}"; do
   if [[ "$lambda" == "call_recording_preview_handler" ]]; then
     test -f "$OUTPUT_DIR/target/lambda/$lambda/ffmpeg-layer.zip"
   fi
+  # document_text_extractor dlopen's ./pdfium-lib/linux/libpdfium.so at runtime,
+  # so the blob has to be bundled inside bootstrap.zip (see deployLambdaPackage
+  # in flake.nix) -- guard against shipping the binary without it.
+  if [[ "$lambda" == "document_text_extractor" ]]; then
+    unzip -l "$OUTPUT_DIR/target/lambda/$lambda/bootstrap.zip" | grep -q 'pdfium-lib/linux/libpdfium.so' \
+      || { echo "document_text_extractor bootstrap.zip is missing pdfium-lib/linux/libpdfium.so" >&2; exit 1; }
+  fi
 done
 
 tar -C "$OUTPUT_DIR" -czf lambda-artifacts.tar.gz target

--- a/flake.nix
+++ b/flake.nix
@@ -547,6 +547,14 @@
                 cp "target/${lambdaTarget}/release/${lambdaName}" bootstrap
                 ${pkgs.binutils}/bin/strip bootstrap || true
                 ${pkgs.zip}/bin/zip -j -X "$out/${lambdaName}/bootstrap.zip" bootstrap
+                ${pkgs.lib.optionalString (lambdaName == "document_text_extractor") ''
+                  # Mirror the handler justfile's `cargo lambda build --include
+                  # ./pdfium-lib/linux`: at runtime the binary dlopen's
+                  # ./pdfium-lib/linux/libpdfium.so relative to the Lambda task
+                  # root, so the blob has to ride along in bootstrap.zip at that
+                  # same relative path.
+                  ( cd ${lambdaName} && ${pkgs.zip}/bin/zip -r -X "$out/${lambdaName}/bootstrap.zip" pdfium-lib/linux )
+                ''}
                 ${pkgs.lib.optionalString (lambdaName == "call_recording_preview_handler") ''
                   cp "${callRecordingPreviewFfmpegLayer}/${lambdaName}/ffmpeg-layer.zip" "$out/${lambdaName}/ffmpeg-layer.zip"
                 ''}


### PR DESCRIPTION
The nix/crane lambda packaging from #3948 zipped only the bootstrap binary and never replicated document_text_extractor's `cargo lambda build --include ./pdfium-lib/linux`, so the deployed package shipped without libpdfium.so and the handler failed to dlopen it on startup (`LoadLibraryError` at main.rs:57). This adds `pdfium-lib/linux/` back into the lambda's bootstrap.zip at the relative path the runtime expects; confirmed the live dev package was missing it. document_text_extractor is the only deployed lambda using `--include`.
