### PR TITLE
fix(email): autofocus To and align body placeholder in mobile compose

### DIFF
--- a/js/app/packages/app/component/Launcher.tsx
+++ b/js/app/packages/app/component/Launcher.tsx
@@ -1,6 +1,7 @@
 import { analytics } from '@app/lib/analytics';
 import { useFeatureFlag } from '@app/lib/analytics/posthog';
 import { setAutomationComposerOpen } from '@block-automation/component';
+import { EMAIL_COMPOSE_TO_INPUT_ID } from '@block-email/constants';
 import type { BlockAlias, BlockName } from '@core/block';
 import { getIconConfig } from '@core/component/EntityIcon';
 import {
@@ -8,6 +9,7 @@ import {
   ENABLE_SNIPPETS_FLAG,
   ENABLE_SNIPPETS_OVERRIDE,
 } from '@core/constant/featureFlags';
+import { triggerFocusInput } from '@core/directive/focusInput';
 import {
   createHotkeyGroup,
   registerHotkey,
@@ -207,6 +209,11 @@ export function runCreateAction(
       });
       return;
     case 'email':
+      // Focus the "To" field within this gesture so the iOS keyboard opens;
+      // the compose mounts asynchronously, so this waits for the input.
+      triggerFocusInput(() =>
+        document.getElementById(EMAIL_COMPOSE_TO_INPUT_ID)
+      );
       createComponent({
         componentId: 'email-compose',
         shouldInsert,

--- a/js/app/packages/block-email/component/compose/ComposeBody.tsx
+++ b/js/app/packages/block-email/component/compose/ComposeBody.tsx
@@ -139,7 +139,7 @@ export function ComposeBody(props: {
     <>
       <div class="size-full min-h-0 sm:max-h-full mobile:flex-1 flex flex-col flex-1">
         <div
-          class="grow size-full flex flex-col cursor-text placeholder:text-ink-placeholder placeholder:opacity-50 overflow-hidden relative"
+          class="grow size-full flex flex-col cursor-text placeholder:text-ink-placeholder placeholder:opacity-50 overflow-hidden relative [&_.text-ink-placeholder]:left-0 [&_.text-ink-placeholder>p]:my-0"
           ref={bodyDiv}
           onclick={() => {
             editor()?.focus();

--- a/js/app/packages/block-email/component/compose/ComposeRecipients.tsx
+++ b/js/app/packages/block-email/component/compose/ComposeRecipients.tsx
@@ -1,4 +1,5 @@
 import type { EmailRecipient } from '@block-email/component/EmailContext';
+import { EMAIL_COMPOSE_TO_INPUT_ID } from '@block-email/constants';
 import { RecipientSelector } from '@core/component/RecipientSelector';
 import { isMobile } from '@core/mobile/isMobile';
 import { cn } from '@ui';
@@ -190,13 +191,14 @@ export function ComposeRecipients(props: {
   const recipientSelector = (
     field: RecipientFieldId,
     inputRef?: (el: HTMLElement) => void,
-    opts?: { focusOnMount?: boolean; includeSelf?: boolean }
+    opts?: { focusOnMount?: boolean; includeSelf?: boolean; inputId?: string }
   ) => (
     <RecipientSelector
       inputRef={(el) => {
         inputEls[field] = el;
         inputRef?.(el);
       }}
+      inputId={opts?.inputId}
       options={ctx.recipientOptions}
       selfEmail={ctx.fromAddress?.()}
       selectedOptions={ctx.recipients()[field]}
@@ -281,6 +283,7 @@ export function ComposeRecipients(props: {
           recipientSelector('to', props.toRef, {
             focusOnMount: ctx.focusRecipientsOnMount,
             includeSelf: ctx.includeSelf,
+            inputId: EMAIL_COMPOSE_TO_INPUT_ID,
           })
         )}
         <Show when={ctx.validationError('no_recipient')}>

--- a/js/app/packages/block-email/constants.ts
+++ b/js/app/packages/block-email/constants.ts
@@ -5,3 +5,7 @@ export const URL_PARAMS = {
 export const MACRO_EMAIL_SIGNATURE = '-- Sent with Macro';
 
 export const MAX_ATTACHMENTS_BYTES_SIZE = 18_000_000;
+
+// Stable id for the compose "To" input so the create gesture can focus it
+// synchronously on iOS (the virtual keyboard only opens within a user gesture).
+export const EMAIL_COMPOSE_TO_INPUT_ID = 'email-compose-to-input';

--- a/js/app/packages/core/component/RecipientSelector.tsx
+++ b/js/app/packages/core/component/RecipientSelector.tsx
@@ -254,6 +254,7 @@ type RecipientSelectorProps<K extends CombinedRecipientKind> = {
   triedToSubmit?: Accessor<boolean>;
   placeholder?: string | JSX.Element;
   inputRef?: (ref: HTMLInputElement) => void;
+  inputId?: string;
   focusOnMount?: boolean;
   triggerMode?: ComboboxTriggerMode;
   hideBorder?: boolean;
@@ -671,6 +672,7 @@ export function RecipientSelector<K extends CombinedRecipientKind>(
                     }}
                   </For>
                   <Combobox.Input
+                    id={props.inputId}
                     disabled={disabled()}
                     ref={(el) => {
                       setInputRef(el);


### PR DESCRIPTION
Two mobile email-compose nits. The To field now autofocuses when compose opens via the create button: `triggerFocusInput` runs in `runCreateAction('email')` so the iOS keyboard opens within the gesture, then focus transfers to the To input once it mounts (the old `setTimeout` focus never opened the keyboard on iOS). The "Use `@` to reference files" hint is also aligned to the caret instead of sitting ~6px below it.

Verified on the iOS simulator and in Chrome mobile emulation.
