### PR TITLE
fix(search): restore per-view search bar text across navigation

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
@@ -395,6 +395,8 @@ export const SoupView = (props: SoupViewProps) => {
     | SetPredicatesInput<string>
     | undefined;
 
+  const persistedSearchText = entryState?.['search.text'] as string | undefined;
+
   const persistedGroupBy = entryState?.['soup.groupBy'] as
     | string
     | null
@@ -428,7 +430,7 @@ export const SoupView = (props: SoupViewProps) => {
       soupView.initialize({
         initialQuery: persistedFilters ?? props.initialFilters,
         initialClientFilters: persistedPredicates ?? props.initialClientFilters,
-        initialSearchText: props.initialSearchText,
+        initialSearchText: persistedSearchText ?? props.initialSearchText,
         disableLocalSearch: props.disableLocalSearch,
         additionalEntities: props.additionalEntities,
       });

--- a/js/app/tests/e2e/local-search-state.spec.ts
+++ b/js/app/tests/e2e/local-search-state.spec.ts
@@ -1,0 +1,87 @@
+import { expect, type Page, test } from '@playwright/test';
+
+import {
+  entityIdSelector,
+  soupListContainerSelector,
+  splitContainerSelector,
+} from '../../packages/core/dom-selectors';
+import { localE2ESeed } from './fixtures/local-e2e-seed';
+import { gotoApp, LOCAL_E2E } from './helpers/local-app';
+
+const SEARCH_BAR = '[data-soup-search]';
+const SEEDED_DOCUMENT = localE2ESeed.smoke.projectRoadmap;
+
+test.skip(
+  !LOCAL_E2E,
+  'local search state tests require LOCAL_E2E=true and seeded local data'
+);
+
+test.describe('local search bar state', () => {
+  test.describe.configure({ timeout: 60_000 });
+
+  test('restores the query after opening a result and going back', async ({
+    page,
+  }) => {
+    await gotoApp(page, '/component/search');
+    await search(page, SEEDED_DOCUMENT.document_name);
+
+    await openFocusedResult(page);
+    await expect(page).not.toHaveURL(/\/component\/search$/);
+
+    await goBack(page);
+
+    await expect(page).toHaveURL(/\/component\/search$/);
+    await expectSearchText(page, SEEDED_DOCUMENT.document_name);
+  });
+
+  test('restores the query after switching sidebar views and going back', async ({
+    page,
+  }) => {
+    await gotoApp(page, '/component/search');
+    await search(page, SEEDED_DOCUMENT.document_name);
+
+    await page.locator('nav [data-sidebar-link="documents"]').first().click();
+    await expect(page).toHaveURL(/\/component\/documents$/);
+
+    await goBack(page);
+
+    await expect(page).toHaveURL(/\/component\/search$/);
+    await expectSearchText(page, SEEDED_DOCUMENT.document_name);
+  });
+});
+
+async function search(page: Page, text: string) {
+  const input = page.locator(`${SEARCH_BAR} [contenteditable]`).first();
+  await expect(input).toBeVisible({ timeout: 30_000 });
+  await input.click();
+  await input.pressSequentially(text);
+
+  // Wait for the seeded result so we know the query produced output before we
+  // navigate away from the view.
+  await expect(
+    page.locator(
+      `${soupListContainerSelector} ${entityIdSelector(SEEDED_DOCUMENT.document_id)}`
+    )
+  ).toBeVisible({ timeout: 30_000 });
+}
+
+// A single click in the soup list selects the row; pressing Enter on the
+// focused row opens it, which navigates the panel to that entity.
+async function openFocusedResult(page: Page) {
+  await page.locator(splitContainerSelector).first().focus();
+  await page.keyboard.press('ArrowDown');
+  await page.keyboard.press('Enter');
+}
+
+// In-app history back (the split history is what restores per-entry state;
+// the browser back button drives a separate URL-reconcile path).
+async function goBack(page: Page) {
+  await page.locator(splitContainerSelector).first().focus();
+  await page.keyboard.press('Alt+BracketLeft');
+}
+
+async function expectSearchText(page: Page, text: string) {
+  await expect(page.locator(SEARCH_BAR).first()).toContainText(text, {
+    timeout: 10_000,
+  });
+}


### PR DESCRIPTION
Since the soup view provider was hoisted to the split panel (#3906/#3935), its search-text signal lives for the panel's lifetime, and `soup-view.tsx` restored `search.filters`/`search.predicates` from the history entry but seeded search text from props only — so each view reset to empty and back/forward no longer restored a view's own query. This reads `search.text` from the entry, mirroring filters/predicates, and adds local e2e coverage for opening a result and switching sidebar views.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
