### PR TITLE
feat(email): paywall multi-inbox behind professional subscription

### DIFF
--- a/js/app/packages/app/component/AddInboxDialog.tsx
+++ b/js/app/packages/app/component/AddInboxDialog.tsx
@@ -1,3 +1,5 @@
+import { useHasPaidAccess } from '@core/auth';
+import { PaywallKey, usePaywallState } from '@core/constant/PaywallState';
 import { useAddInboxFlow } from '@core/email-link';
 import { Button, Dialog, Panel } from '@ui';
 import { createSignal, onCleanup } from 'solid-js';
@@ -10,6 +12,23 @@ const [isOpen, setIsOpen] = createSignal(false);
  * selector) open settings first and the dialog appears once it mounts.
  */
 export const openAddInboxDialog = () => setIsOpen(true);
+
+/**
+ * Connecting more than one inbox is a paid feature. Returns a guard that runs
+ * `proceed` for paid users and otherwise opens the paywall, so every add-inbox
+ * entry point gates on the same key.
+ */
+export function useAddInboxGate() {
+  const hasPaidAccess = useHasPaidAccess();
+  const { showPaywall } = usePaywallState();
+  return (proceed: () => void) => {
+    if (!hasPaidAccess()) {
+      showPaywall(PaywallKey.MULTI_INBOX);
+      return;
+    }
+    proceed();
+  };
+}
 
 /**
  * Confirmation step before the add-inbox OAuth redirect. Confirming kicks off

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/inbox-selector.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/inbox-selector.tsx
@@ -1,4 +1,7 @@
-import { openAddInboxDialog } from '@app/component/AddInboxDialog';
+import {
+  openAddInboxDialog,
+  useAddInboxGate,
+} from '@app/component/AddInboxDialog';
 import { useSoupView } from '@app/component/next-soup/soup-view/soup-view-context';
 import { useFeatureFlag } from '@app/lib/analytics/posthog';
 import { ENABLE_MULTI_INBOX_OVERRIDE } from '@core/constant/featureFlags';
@@ -29,6 +32,7 @@ export function InboxSelector() {
     enabledOverride: ENABLE_MULTI_INBOX_OVERRIDE,
   });
   const { openSettings } = useSettingsState();
+  const guardAddInbox = useAddInboxGate();
 
   const label = () => {
     const ids = inboxFilter();
@@ -53,10 +57,11 @@ export function InboxSelector() {
             ? {
                 label: 'Add inbox',
                 icon: () => <PlusIcon class="size-4" />,
-                onSelect: () => {
-                  openSettings('Email');
-                  openAddInboxDialog();
-                },
+                onSelect: () =>
+                  guardAddInbox(() => {
+                    openSettings('Email');
+                    openAddInboxDialog();
+                  }),
               }
             : undefined
         }

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/mobile-filter-drawer.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/mobile-filter-drawer.tsx
@@ -1,3 +1,4 @@
+import { useAddInboxGate } from '@app/component/AddInboxDialog';
 import {
   MobileDrawer,
   scrollToFocusedInput,
@@ -106,6 +107,7 @@ export const MobileFilterDrawer = () => {
     enabledOverride: ENABLE_MULTI_INBOX_OVERRIDE,
   });
   const addInbox = useAddInboxFlow();
+  const guardAddInbox = useAddInboxGate();
 
   // Mirrors the desktop InboxSelector's visibility rule so the "Add inbox"
   // action stays discoverable with zero or one inbox connected. Also stays
@@ -418,7 +420,7 @@ export const MobileFilterDrawer = () => {
                           <button
                             type="button"
                             class="w-full flex items-center gap-3 px-3 py-2.5 text-sm hover:bg-hover transition-colors text-left bg-surface not-last:mb-px"
-                            onClick={() => void addInbox()}
+                            onClick={() => guardAddInbox(() => void addInbox())}
                           >
                             <span class="size-4 flex items-center justify-center shrink-0">
                               <PlusIcon class="size-4 text-ink-muted" />

--- a/js/app/packages/app/component/settings/Email.tsx
+++ b/js/app/packages/app/component/settings/Email.tsx
@@ -18,7 +18,11 @@ import {
 import { useEmail, useUserId } from '@core/context/user';
 import { createMemo, createSignal, For, Show } from 'solid-js';
 import { useEmailLinks, useEmailLinksStatus } from '@core/email-link';
-import { AddInboxDialog, openAddInboxDialog } from '../AddInboxDialog';
+import {
+  AddInboxDialog,
+  openAddInboxDialog,
+  useAddInboxGate,
+} from '../AddInboxDialog';
 import { useRemoveInboxMutation } from '@queries/email/link';
 import {
   ConnectionHero,
@@ -32,6 +36,7 @@ export function Email() {
   const multiInboxFlag = useFeatureFlag('enable-multi-inbox', {
     enabledOverride: ENABLE_MULTI_INBOX_OVERRIDE,
   });
+  const guardAddInbox = useAddInboxGate();
 
   const {
     query: emailLinksQuery,
@@ -204,7 +209,7 @@ export function Email() {
                 size="sm"
                 depth={3}
                 class="ml-auto shrink-0"
-                onClick={openAddInboxDialog}
+                onClick={() => guardAddInbox(openAddInboxDialog)}
               >
                 <PlusIcon class="size-4" />
                 Add inbox

--- a/js/app/packages/core/constant/PaywallState.tsx
+++ b/js/app/packages/core/constant/PaywallState.tsx
@@ -12,6 +12,7 @@ export enum PaywallKey {
   CANVAS_CLIKED = 'CANVAS_CLIKED',
   SAVED_PROMPT = 'SAVED_PROMPT',
   REMOVE_SIGNATURE = 'REMOVE_SIGNATURE',
+  MULTI_INBOX = 'MULTI_INBOX',
 }
 
 export const PaywallMessages: Record<PaywallKey, string> = {
@@ -30,6 +31,7 @@ export const PaywallMessages: Record<PaywallKey, string> = {
     'Saved prompts are a paid feature. Please upgrade to continue.',
   [PaywallKey.REMOVE_SIGNATURE]:
     'Upgrade your plan to remove the Macro signature.',
+  [PaywallKey.MULTI_INBOX]: 'Upgrade your plan to connect more than one inbox.',
 };
 
 const [paywallOpen, setPaywallOpen] = createSignal(false);

--- a/js/app/packages/service-clients/service-auth/generated/client.ts
+++ b/js/app/packages/service-clients/service-auth/generated/client.ts
@@ -811,6 +811,11 @@ export type initGmailLinkResponse401 = {
   status: 401;
 };
 
+export type initGmailLinkResponse402 = {
+  data: ErrorResponse;
+  status: 402;
+};
+
 export type initGmailLinkResponse429 = {
   data: ErrorResponse;
   status: 429;
@@ -827,6 +832,7 @@ export type initGmailLinkResponseSuccess = initGmailLinkResponse200 & {
 export type initGmailLinkResponseError = (
   | initGmailLinkResponse400
   | initGmailLinkResponse401
+  | initGmailLinkResponse402
   | initGmailLinkResponse429
   | initGmailLinkResponse500
 ) & {

--- a/js/app/packages/service-clients/service-auth/openapi.json
+++ b/js/app/packages/service-clients/service-auth/openapi.json
@@ -657,6 +657,16 @@
               }
             }
           },
+          "402": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
           "429": {
             "description": "",
             "content": {

--- a/rust/cloud-storage/authentication_service/src/api/link/gmail.rs
+++ b/rust/cloud-storage/authentication_service/src/api/link/gmail.rs
@@ -8,6 +8,7 @@ use axum::{
 use macro_middleware::tracking::ClientIp;
 use model::response::ErrorResponse;
 use model_user::axum_extractor::MacroUserExtractor;
+use roles_and_permissions::domain::model::PermissionId;
 use serde_utils::urlencode::UrlEncoded;
 use url::Url;
 
@@ -33,6 +34,9 @@ pub enum InitGmailLinkError {
     /// Too many in-progress links
     #[error("too many in progress links")]
     TooManyInProgressLinks,
+    /// The user lacks the subscription required to link an additional inbox
+    #[error("a professional subscription is required to link an additional inbox")]
+    PaymentRequired,
     /// Internal error
     #[error("internal error occurred")]
     InternalError(#[from] anyhow::Error),
@@ -46,6 +50,7 @@ impl IntoResponse for InitGmailLinkError {
         let message = self.to_string();
         let status_code: StatusCode = match &self {
             InitGmailLinkError::TooManyInProgressLinks => StatusCode::TOO_MANY_REQUESTS,
+            InitGmailLinkError::PaymentRequired => StatusCode::PAYMENT_REQUIRED,
             InitGmailLinkError::InternalError(_) | InitGmailLinkError::IdentityProviderNotFound => {
                 StatusCode::INTERNAL_SERVER_ERROR
             }
@@ -79,6 +84,7 @@ pub(crate) struct InitGmailLinkQueryParams {
         responses(
             (status = 200, body=InitGmailLinkResponse),
             (status = 400, body=ErrorResponse),
+            (status = 402, body=ErrorResponse),
             (status = 429, body=ErrorResponse),
             (status = 401, body=ErrorResponse),
             (status = 500, body=ErrorResponse),
@@ -92,6 +98,18 @@ pub async fn init_gmail_link_handler(
     user_context: MacroUserExtractor,
 ) -> Result<Json<InitGmailLinkResponse>, InitGmailLinkError> {
     let Query(InitGmailLinkQueryParams { original_url }) = query;
+
+    let has_professional_access =
+        user_context
+            .user_context
+            .permissions
+            .as_ref()
+            .is_some_and(|permissions| {
+                permissions.contains(&PermissionId::ReadProfessionalFeatures.to_string())
+            });
+    if !has_professional_access {
+        return Err(InitGmailLinkError::PaymentRequired);
+    }
 
     let count =
         macro_db_client::in_progress_user_link::count_existing_in_progress_user_links_for_user(


### PR DESCRIPTION
Gates connecting additional inboxes behind the professional subscription, matching other paywalled features — the "Add inbox" entry points show the paywall for non-paid users, and `/link/gmail` returns 402 without `read:professional_features`. The first/primary inbox stays free.
