### PR TITLE
fix(email): dedup concurrent inbox connect backfills

### DIFF
--- a/rust/cloud-storage/email_service/src/api/email/init.rs
+++ b/rust/cloud-storage/email_service/src/api/email/init.rs
@@ -536,6 +536,24 @@ pub async fn handler(
         (link, email)
     };
 
+    // Concurrent /email/init calls for the same inbox upsert the same link (ON CONFLICT)
+    // and would each enqueue a backfill. If one is already in flight for this link, reuse
+    // it instead of starting (and history-logging) a duplicate.
+    if let Some(existing) =
+        email_db_client::backfill::job::get::get_active_backfill_job(&ctx.db, link.id)
+            .await
+            .context("Failed to check for an in-flight backfill job")?
+    {
+        return Ok((
+            StatusCode::OK,
+            Json(InitResponse {
+                link_id: link.id,
+                backfill_job_id: Some(existing.id),
+            }),
+        )
+            .into_response());
+    }
+
     // Record link creation in history table for tracking (best-effort)
     email_db_client::links_history::insert::insert_email_link_history(
         &ctx.db,


### PR DESCRIPTION
Concurrent `/email/init` calls for the same inbox upsert the same link and each enqueued a backfill, so one connect could start two duplicate in-flight backfills plus duplicate `email_links_history` rows (wasteful double Gmail sync, and the seed for the rate-limit churn fixed in #4093). Before creating the job, reuse an existing `Init`/`InProgress` backfill for the link instead of starting a second. A small concurrency window remains between the check and the insert; a partial unique index on `(link_id) WHERE status IN ('Init','InProgress')` would close it fully.
