### PR TITLE
fix(email): stop double email init on login

### DIFF
--- a/js/app/packages/app/component/auth/Login.tsx
+++ b/js/app/packages/app/component/auth/Login.tsx
@@ -45,17 +45,10 @@ export function Login() {
 
 function PostLoginRedirect() {
   const navigate = useNavigate();
-  const { initEmailLink } = useEmailLinks();
 
-  onMount(async () => {
-    await initEmailLink().match(
-      () => {},
-      (err) => {
-        if (err.tag !== 'AlreadyInitialized') {
-          console.error('Failed to init email link on login', err);
-        }
-      }
-    );
+  // Login init is owned by the per-method handlers (the session-token effect and
+  // onComplete); this redirect only navigates, so login doesn't fire init twice.
+  onMount(() => {
     navigate('/', { replace: true });
   });
 

--- a/js/app/packages/app/component/auth/LoginNew.tsx
+++ b/js/app/packages/app/component/auth/LoginNew.tsx
@@ -45,17 +45,10 @@ import { useSsoLogin } from './useSsoLogin';
 
 function PostLoginRedirect() {
   const navigate = useNavigate();
-  const { initEmailLink } = useEmailLinks();
 
-  onMount(async () => {
-    await initEmailLink().match(
-      () => {},
-      (err) => {
-        if (err.tag !== 'AlreadyInitialized') {
-          console.error('Failed to init email link on login', err);
-        }
-      }
-    );
+  // Login init is owned by the per-method handlers (the session-token effect and
+  // onComplete); this redirect only navigates, so login doesn't fire init twice.
+  onMount(() => {
     navigate('/', { replace: true });
   });
 


### PR DESCRIPTION
Login fired `initEmailLink()` from both the per-method handlers (the session-token `createEffect` / `onComplete`) and `PostLoginRedirect`'s `onMount` — which mounts the instant auth completes — so every login double-POSTed `/ni` and could start duplicate backfills. Make the per-method handlers the sole init owner and have `PostLoginRedirect` only navigate (in both `LoginNew` and the flag-fallback `LoginOld`). Signup is unaffected — `PostSignupRedirect` is its only init, so there was never a duplicate there.
