### PR TITLE
fix(sidebar): apply inbox account selection on the first click

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/soup-view-context.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-view-context.tsx
@@ -253,8 +253,12 @@ export const SoupViewContextProvider: FlowComponent<
   );
 
   // Expose the mail view's inbox filter to consumers outside the split tree
-  // (the sidebar's nested account rows read and set it by split id).
-  {
+  // (the sidebar's nested account rows read and set it by split id). The
+  // provider outlives content swaps within a split, so track the live content
+  // reactively and (un)register as the mail list becomes / stops being the
+  // shown view — registering also flushes any filter the sidebar queued while
+  // navigating here, so a sidebar inbox selection takes on the first click.
+  createEffect(() => {
     const content = panel.handle.content();
     if (content.type === 'component' && content.id === 'mail') {
       const dispose = registerInboxFilterSplit(panel.handle.id, {
@@ -263,7 +267,7 @@ export const SoupViewContextProvider: FlowComponent<
       });
       onCleanup(dispose);
     }
-  }
+  });
   const [activeTab, setActiveTab] = useEntryState<string | undefined>(
     'soup.tab',
     { default: undefined }


### PR DESCRIPTION
The mail SoupViewContextProvider persists across content swaps within a split, so the once-at-mount inbox-filter registration never ran for a split that mounted as a non-mail view — clicking a sidebar inbox row then queued a filter that was never consumed. Making the registration a reactive createEffect (un)registers as the mail list is shown and flushes the queued filter, so a sidebar inbox selection applies on the first click.
