### PR TITLE
fix(style): update theme mention chip style

### DIFF
--- a/js/app/packages/core/component/LexicalMarkdown/component/decorator/ThemeMention.tsx
+++ b/js/app/packages/core/component/LexicalMarkdown/component/decorator/ThemeMention.tsx
@@ -49,7 +49,7 @@ export function ThemeMention(props: ThemeMentionDecoratorProps) {
     >
       <Show when={theme()}>
         {(t) => (
-          <span class="-my-px -ml-px inline-flex self-stretch [&>span]:h-full">
+          <span class="rounded-md inline-flex self-stretch [&>span]:h-full [&>span]:border-0 [&>span]:rounded-[5px]">
             <ThemeChips theme={t()} size="sm" />
           </span>
         )}

--- a/js/app/packages/core/component/LexicalMarkdown/component/decorator/ThemeMention.tsx
+++ b/js/app/packages/core/component/LexicalMarkdown/component/decorator/ThemeMention.tsx
@@ -1,11 +1,12 @@
 import { useSettingsState } from '@core/constant/SettingsState';
 import type { ThemeMentionDecoratorProps } from '@lexical-core';
+import { ThemeChips } from '@theme/components/ThemeChips';
 import { setUserThemes, themes, userThemes } from '@theme/signals/themeSignals';
 import type { ThemeV2 } from '@theme/types/themeTypes';
 import { applyTheme } from '@theme/utils/themeUtils';
 import { isThemeV2 } from '@theme/utils/themeValidation';
 import { cn } from '@ui';
-import { useContext } from 'solid-js';
+import { Show, useContext } from 'solid-js';
 import { LexicalWrapperContext } from '../../context/LexicalWrapperContext';
 
 export function ThemeMention(props: ThemeMentionDecoratorProps) {
@@ -24,15 +25,6 @@ export function ThemeMention(props: ThemeMentionDecoratorProps) {
     return null;
   };
 
-  const a0 = () => theme()?.tokens.a0;
-  const b0 = () => theme()?.tokens.b0;
-  const c0 = () => theme()?.tokens.c0;
-
-  const oklch = (token: { l: number; c: number; h: number } | undefined) => {
-    if (!token) return 'transparent';
-    return `oklch(${token.l} ${token.c} ${token.h}deg)`;
-  };
-
   const handleClick = () => {
     const t = theme();
     if (!t) return;
@@ -49,27 +41,20 @@ export function ThemeMention(props: ThemeMentionDecoratorProps) {
   return (
     <button
       class={cn(
-        'pointer-events-auto mx-0.5 inline-flex items-center gap-0.75 align-baseline px-1 py-px rounded-md border border-edge-muted bg-transparent',
+        'pointer-events-auto mx-0.5 inline-flex items-stretch gap-0.75 align-baseline overflow-hidden py-0 pl-0 pr-1 rounded-md border border-edge-muted bg-transparent',
         isSelectedAsNode() && 'bg-active'
       )}
       onClick={handleClick}
       type="button"
     >
-      <span class="inline-flex items-center gap-0.5">
-        <span
-          class="inline-block size-2.5 rounded-xs border border-edge-muted"
-          style={{ 'background-color': oklch(a0()) }}
-        />
-        <span
-          class="inline-block size-2.5 rounded-xs border border-edge-muted"
-          style={{ 'background-color': oklch(b0()) }}
-        />
-        <span
-          class="inline-block size-2.5 rounded-xs border border-edge-muted"
-          style={{ 'background-color': oklch(c0()) }}
-        />
-      </span>
-      <span class="mx-0.5 cursor-default">{props.name}</span>
+      <Show when={theme()}>
+        {(t) => (
+          <span class="-my-px -ml-px inline-flex self-stretch [&>span]:h-full">
+            <ThemeChips theme={t()} size="sm" />
+          </span>
+        )}
+      </Show>
+      <span class="mx-0.5 flex items-center cursor-default">{props.name}</span>
     </button>
   );
 }

--- a/js/app/packages/theme/components/ThemeChips.tsx
+++ b/js/app/packages/theme/components/ThemeChips.tsx
@@ -14,12 +14,12 @@ const sizeStyles: Record<
   }
 > = {
   md: {
-    root: 'gap-2 p-2',
+    root: 'gap-2 p-2 rounded-sm',
     accent: 'size-[13px]',
     icon: 'size-[18px]',
   },
   sm: {
-    root: 'gap-1 p-[3px]',
+    root: 'gap-1 py-[3px] px-[5px] rounded-md',
     accent: 'size-[9px]',
     icon: 'size-3',
   },
@@ -54,7 +54,7 @@ export function ThemeChips(props: { theme: ThemeV2; size?: ThemeChipsSize }) {
   return (
     <span
       class={cn(
-        'inline-flex items-center rounded-sm border border-edge-muted',
+        'inline-flex items-center border border-edge-muted',
         styles().root
       )}
       style={{


### PR DESCRIPTION
Old:
<img width="429" height="338" alt="Screenshot 2026-06-16 at 11 53 16 AM" src="https://github.com/user-attachments/assets/4ff709db-dedc-41cc-8433-060c45d803a4" />

New:
<img width="736" height="454" alt="Screenshot 2026-06-16 at 11 53 47 AM" src="https://github.com/user-attachments/assets/6dd990c6-dc3b-4f00-8fed-e3487e3b4ac0" />
