### PR TITLE
fix(multi-inbox): unchecking the last inbox selects all instead of none

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/inbox-selector.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/inbox-selector.tsx
@@ -48,7 +48,7 @@ export function InboxSelector() {
       <SearchableMultiSelect
         options={picker.options}
         activeIds={picker.activeIds}
-        onChange={picker.onChange}
+        onChange={(ids) => (ids.length ? picker.onChange(ids) : picker.reset())}
         onOnly={picker.selectOnly}
         placeholder="Search inboxes..."
         preserveOrder

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/mobile-filter-drawer.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/mobile-filter-drawer.tsx
@@ -121,11 +121,10 @@ export const MobileFilterDrawer = () => {
 
   const toggleInbox = (id: string) => {
     const current = picker.activeIds();
-    picker.onChange(
-      current.includes(id)
-        ? current.filter((activeId) => activeId !== id)
-        : [...current, id]
-    );
+    const next = current.includes(id)
+      ? current.filter((activeId) => activeId !== id)
+      : [...current, id];
+    return next.length ? picker.onChange(next) : picker.reset();
   };
 
   const VIEW_SORT_OPTIONS: Partial<Record<ListView, SortOption[]>> = {

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/search/search-facets.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/search/search-facets.tsx
@@ -266,7 +266,8 @@ export function useSearchFacets(
     label: 'Inbox',
     options: inboxPicker.options,
     activeIds: inboxPicker.activeIds,
-    onChange: inboxPicker.onChange,
+    onChange: (ids) =>
+      ids.length ? inboxPicker.onChange(ids) : inboxPicker.reset(),
     onOnly: inboxPicker.selectOnly,
     placeholder: 'Search inboxes...',
     preserveOrder: true,


### PR DESCRIPTION
Unchecking the only selected inbox produced an empty "No inboxes" view; now an empty selection collapses back to the all-inboxes default. Applied to the email view inbox selector (incl. the mobile drawer) and the search inbox facet in separate commits.