### PR TITLE
fix(email): show inboxes when multi-inbox flag is off, open Email settings tab after add

### DIFF
--- a/js/app/packages/app/component/EmailAuth.tsx
+++ b/js/app/packages/app/component/EmailAuth.tsx
@@ -114,12 +114,12 @@ function EmailLinkCallback(props: Pick<EmailAuthParams, 'successPath'>) {
 
   // The desktop settings split doesn't exist on mobile, so the callback
   // returns mobile users to the list view with the toast as confirmation.
-  const navigateToAccountSettings = () => {
+  const navigateToEmailSettings = () => {
     if (isMobile()) {
       navigateToSuccess();
       return;
     }
-    setActiveTabId('Account');
+    setActiveTabId('Email');
     navigate('/component/mail/component/settings', { replace: true });
   };
 
@@ -131,12 +131,12 @@ function EmailLinkCallback(props: Pick<EmailAuthParams, 'successPath'>) {
         // than flashing a stale list until its own refetch lands.
         await query.refetch();
         toast.success('Inbox connected', { mobile: true });
-        navigateToAccountSettings();
+        navigateToEmailSettings();
       },
       async (err) => {
         if (err.tag === 'AlreadyInitialized') {
           await query.refetch();
-          navigateToAccountSettings();
+          navigateToEmailSettings();
           return;
         }
         // The mailbox is already connected by someone else. Hold the callback open

--- a/js/app/packages/app/component/settings/Email.tsx
+++ b/js/app/packages/app/component/settings/Email.tsx
@@ -73,6 +73,8 @@ export function Email() {
     return { primary, others };
   });
 
+  const hasAdditionalInboxes = createMemo(() => inboxes().others.length > 0);
+
   const onConnectEmail = async () => {
     if (isEmailActionPending()) return;
     setIsEmailActionPending(true);
@@ -125,7 +127,7 @@ export function Email() {
   return (
     <IntegrationPanelShell title="Email">
       <Show
-        when={multiInboxFlag().enabled}
+        when={multiInboxFlag().enabled || hasAdditionalInboxes()}
         fallback={
           <ConnectionHero
             icon={WideEmailIcon}
@@ -198,22 +200,24 @@ export function Email() {
                 Gmail accounts Macro can read and act on.
               </p>
             </div>
-            <Show
-              when={!emailLinksQuery.isLoading}
-              fallback={
-                <span class="ml-auto text-sm text-ink-muted">Loading…</span>
-              }
-            >
-              <Button
-                variant="active"
-                size="sm"
-                depth={3}
-                class="ml-auto shrink-0"
-                onClick={() => guardAddInbox(openAddInboxDialog)}
+            <Show when={multiInboxFlag().enabled}>
+              <Show
+                when={!emailLinksQuery.isLoading}
+                fallback={
+                  <span class="ml-auto text-sm text-ink-muted">Loading…</span>
+                }
               >
-                <PlusIcon class="size-4" />
-                Add inbox
-              </Button>
+                <Button
+                  variant="active"
+                  size="sm"
+                  depth={3}
+                  class="ml-auto shrink-0"
+                  onClick={() => guardAddInbox(openAddInboxDialog)}
+                >
+                  <PlusIcon class="size-4" />
+                  Add inbox
+                </Button>
+              </Show>
             </Show>
           </div>
 


### PR DESCRIPTION
When the multi-inbox flag is off but inboxes already exist, Settings → Email now shows the full inbox list (remove still works, the primary still re-enables) and only hides Add inbox; the inbox selector, mobile filter drawer, and search facet already degraded this way. Also repoints the post-add redirect from the Account settings tab to the new Email settings tab.
