### PR TITLE
fix(ai): teach prompt to link channel messages

### DIFF
--- a/rust/cloud-storage/prompt/src/mentions.rs
+++ b/rust/cloud-storage/prompt/src/mentions.rs
@@ -1,20 +1,23 @@
-//! Rules for mentioning whole entities with XML mention tags.
+//! Rules for mentioning entities with XML mention tags.
 
 use crate::types::StaticPrompt;
 
-static TITLE: &str = "Mentioning documents, channels, chats, projects, and email threads";
+static TITLE: &str =
+    "Mentioning documents, channels, channel messages, chats, projects, and email threads";
 
 static INSTRUCTIONS: &str = r##"When referencing a document, channel, chat, project, or email thread, use XML mention tags with a JSON payload.
 The AI does not need to know the name — an empty string is fine and the frontend will resolve it.
 
 - Document mention: `<m-document-mention>{"documentId":"{id}","documentName":"","blockName":"md","blockParams":{}}</m-document-mention>`
 - Channel mention: `<m-document-mention>{"documentId":"{id}","documentName":"","blockName":"channel","blockParams":{}}</m-document-mention>`
+- Channel message mention: `<m-document-mention>{"documentId":"{channel_id}","documentName":"","blockName":"channel","blockParams":{"channel_message_id":"{message_id}"}}</m-document-mention>`
 - Chat mention: `<m-document-mention>{"documentId":"{id}","documentName":"","blockName":"chat","blockParams":{}}</m-document-mention>`
 - Project mention: `<m-document-mention>{"documentId":"{id}","documentName":"","blockName":"project","blockParams":{}}</m-document-mention>`
 - Task mention: `<m-document-mention>{"documentId":"{id}","documentName":"","blockName":"task","blockParams":{}}</m-document-mention>`
 - Email thread mention: `<m-document-mention>{"documentId":"{thread_id}","documentName":"","blockName":"email","blockParams":{}}</m-document-mention>`
 
 The `blockName` for an email thread is always exactly `email` — never `thread` or `email_thread`, which the frontend cannot resolve.
+When a tool returns both a channel id and a channel message id, link the specific message using the channel message mention format. Do not link only the channel unless you are referring to the whole channel.
 
 ### Example Response
 
@@ -22,9 +25,9 @@ If no inline or node ids are present:
 “See the document for details<m-document-mention>{“documentId”:”6a2b138d-dfbe-439a-a78b-282471a1e165”,”documentName”:””,”blockName”:”md”,”blockParams”:{}}</m-document-mention>.”
 "##;
 
-static INTENT: &str = "Whole entities are referenced with correctly formatted \
-<m-document-mention> XML tags using the right blockName for each entity type, including \
-exactly \"email\" for email threads.";
+static INTENT: &str = "Entities and channel messages are referenced with correctly formatted \
+<m-document-mention> XML tags using the right blockName and blockParams for each entity type, \
+including exactly \"email\" for email threads and channel_message_id for specific channel messages.";
 
 /// The entity-mention prompt.
 pub static PROMPT: StaticPrompt<'static> = StaticPrompt::borrowed(TITLE, INSTRUCTIONS, INTENT);

--- a/rust/cloud-storage/prompt/tests/compose.rs
+++ b/rust/cloud-storage/prompt/tests/compose.rs
@@ -6,7 +6,7 @@ const BASE_TITLES: [&str; 6] = [
     "# Tone and Style",
     "# Math Rendering Rules",
     "# Citation Rules",
-    "# Mentioning documents, channels, chats, projects, and email threads",
+    "# Mentioning documents, channels, channel messages, chats, projects, and email threads",
     "# Do Not Rules",
     "# Terms",
 ];
@@ -22,6 +22,21 @@ fn base_prompt_renders_all_sections_in_order() {
         last += position + title.len();
     }
     assert!(!rendered.contains("# Tool Use"));
+}
+
+#[test]
+fn base_prompt_includes_channel_message_mention_format() {
+    let rendered = BASE_PROMPT.to_string();
+    assert!(
+        rendered.contains(
+            r#""blockName":"channel","blockParams":{"channel_message_id":"{message_id}"}"#
+        )
+    );
+    assert!(
+        rendered.contains(
+            "Do not link only the channel unless you are referring to the whole channel."
+        )
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add the native channel-message mention format to the shared AI mention prompt
- tell the model to prefer specific message links when tools return both channel and message ids
- add prompt composition coverage for the channel_message_id instruction

## Test
- cargo test -p prompt