### PR TITLE
fix(ai): stop per-entity collapse in ContentSearch/NameSearch

### DIFF
--- a/rust/cloud-storage/ai_tools/src/search/search_service/content.rs
+++ b/rust/cloud-storage/ai_tools/src/search/search_service/content.rs
@@ -62,7 +62,7 @@ impl AsyncTool<Arc<SearchServiceClient>> for ContentSearch {
             filters: entity_filters_from_include(self.entity_types.clone(), base_filters),
             search_on: models_search::SearchOn::Content,
             include_crm: false,
-            collapse: Some(true),
+            collapse: None,
         };
 
         let response = search_client

--- a/rust/cloud-storage/ai_tools/src/search/search_service/name.rs
+++ b/rust/cloud-storage/ai_tools/src/search/search_service/name.rs
@@ -62,7 +62,7 @@ impl AsyncTool<Arc<SearchServiceClient>> for NameSearch {
             filters: entity_filters_from_include(self.entity_types.clone(), base_filters),
             search_on: models_search::SearchOn::Name,
             include_crm: false,
-            collapse: Some(true),
+            collapse: None,
         };
 
         let response = search_client


### PR DESCRIPTION
`ContentSearch`/`NameSearch` passed `collapse: Some(true)`, which collapses results on the OpenSearch `entity_id` field — for channels that key is the channel id and for emails the thread id, so the AI tools returned only one message per channel/thread. Set to `None` so they return every matching message; documents/chats/call records are unaffected since the parent-child join already returns one parent per entity, making the collapse redundant there.
