### PR TITLE
feat(settings): open settings in a modal rather than a split

### DIFF
--- a/js/app/packages/app/component/GlobalHotkeys.tsx
+++ b/js/app/packages/app/component/GlobalHotkeys.tsx
@@ -102,7 +102,7 @@ export default function GlobalShortcuts() {
 
   useHotkeyAnalytics();
 
-  const { openSettings, closeSettings, settingsOpen, setActiveTabId } =
+  const { openSettings, settingsOpen, setActiveTabId, toggleSettings } =
     useSettingsState();
   const logout = useLogout();
 
@@ -225,8 +225,7 @@ export default function GlobalShortcuts() {
     scopeId: 'global',
     description: 'Toggle settings',
     keyDownHandler: () => {
-      if (settingsOpen()) closeSettings();
-      else openSettingsModal();
+      toggleSettings();
       return true;
     },
     runWithInputFocused: true,

--- a/js/app/packages/app/component/GlobalHotkeys.tsx
+++ b/js/app/packages/app/component/GlobalHotkeys.tsx
@@ -209,23 +209,11 @@ export default function GlobalShortcuts() {
     keyDownHandler: createNewSplit,
   });
 
-  const openSettingsInNewSplit = (tab?: SettingsTab) => {
+  // Settings open in a modal by default; tab selection is applied even when
+  // settings are already open.
+  const openSettingsModal = (tab?: SettingsTab) => {
     if (settingsOpen()) {
       if (tab) setActiveTabId(tab);
-      return;
-    }
-    if (canFit()) {
-      if (tab) setActiveTabId(tab);
-      analytics.track('split_created', { from: 'global_hotkey' });
-      openWithSplit(
-        { type: 'component', id: 'settings' },
-        {
-          referredFrom: 'hotkey',
-          allowDuplicate: true,
-          preferNewSplit: true,
-          mergeHistory: false,
-        }
-      );
       return;
     }
     openSettings(tab);
@@ -238,7 +226,7 @@ export default function GlobalShortcuts() {
     description: 'Toggle settings',
     keyDownHandler: () => {
       if (settingsOpen()) closeSettings();
-      else openSettingsInNewSplit();
+      else openSettingsModal();
       return true;
     },
     runWithInputFocused: true,
@@ -249,7 +237,7 @@ export default function GlobalShortcuts() {
     description: 'Account',
     icon: UserIcon,
     keyDownHandler: () => {
-      openSettingsInNewSplit('Account');
+      openSettingsModal('Account');
       return true;
     },
     runWithInputFocused: true,

--- a/js/app/packages/app/component/Layout.tsx
+++ b/js/app/packages/app/component/Layout.tsx
@@ -45,6 +45,7 @@ import { MobileSearchOuter } from './mobile/MobileSearch';
 import { SwipeDownDismissKeyboard } from './mobile/SwipeDownDismissKeyboard';
 import { Paywall } from './paywall/Paywall';
 import { PropertyEditorModal } from './property-edit-modal/PropertyEditorModal';
+import { SettingsModal } from './settings/SettingsModal';
 import { useAppSquishHandlers } from './useAppSquishHandlers';
 
 const AUTH_URLS = [
@@ -155,6 +156,7 @@ function LayoutInner(props: RouteSectionProps) {
           <GlobalShareModal />
           <IosShareSheet />
           <MacroMcpSetupModal />
+          <SettingsModal />
         </Show>
         <Show
           when={

--- a/js/app/packages/app/component/app-sidebar/sidebar.tsx
+++ b/js/app/packages/app/component/app-sidebar/sidebar.tsx
@@ -863,20 +863,6 @@ export const AppSidebar = (props: AppSidebarProps) => {
       setActiveTabId(tab);
       return;
     }
-    if (globalSplitManager()?.canAppendSplit() ?? true) {
-      setActiveTabId(tab);
-      analytics.track('split_created', { from: 'sidebar' });
-      layout.openWithSplit(
-        { type: 'component', id: 'settings' },
-        {
-          referredFrom: 'sidebar',
-          allowDuplicate: true,
-          preferNewSplit: true,
-          mergeHistory: false,
-        }
-      );
-      return;
-    }
     openSettings(tab);
   };
 

--- a/js/app/packages/app/component/settings/Settings.tsx
+++ b/js/app/packages/app/component/settings/Settings.tsx
@@ -14,12 +14,18 @@ import { Shortcuts } from './Shortcuts';
 import { Team } from './Team';
 import { registerHotkey, useHotkeyDOMScope } from '@core/hotkey/hotkeys';
 import type { ValidHotkey } from '@core/hotkey/types';
-import { SideNav } from '@ui';
+import { Button, SideNav } from '@ui';
+import ColumnsPlusRight from '@phosphor/columns-plus-right.svg';
+import ArrowsOut from '@phosphor/arrows-out.svg';
+import CloseIcon from '@phosphor/x.svg';
 import {
   SplitHeaderLeft,
   SplitHeaderRight,
 } from '../split-layout/components/SplitHeader';
 import { SettingsButton } from './SettingsButton';
+
+/** Where the settings panel is mounted, which determines its header chrome. */
+export type SettingsVariant = 'split' | 'modal';
 
 export function SettingsPanelComponentWrapper() {
   return (
@@ -36,11 +42,22 @@ export function SettingsPanelComponentWrapper() {
 
 type SettingsPanelProps = {
   hide?: boolean;
+  /** Defaults to 'split' so the split-layout mount keeps its existing chrome. */
+  variant?: SettingsVariant;
 };
 
-function SettingsPanel(props: SettingsPanelProps) {
-  const { closeSettings, activeTabId, setActiveTabId } = useSettingsState();
+export function SettingsPanel(props: SettingsPanelProps) {
+  const {
+    closeSettings,
+    closeModal,
+    moveSettingsToSplit,
+    moveSettingsToModal,
+    activeTabId,
+    setActiveTabId,
+  } = useSettingsState();
   const { groups, flatTabs, isAvailable } = useSettingsTabs();
+
+  const variant = () => props.variant ?? 'split';
 
   // A tab's content renders only when it's both selected and still available
   // (gating lives solely in the settings tab config).
@@ -162,13 +179,52 @@ function SettingsPanel(props: SettingsPanelProps) {
       data-settings-panel
       ref={settingsContainerRef}
     >
-      <SplitHeaderLeft>
-        <div class="h-full flex gap-3 items-center">
-          <h1 class="font-semibold text-ink select-none text-sm shrink-0">
+      <Show when={variant() === 'split'}>
+        <SplitHeaderLeft>
+          <div class="h-full flex gap-3 items-center">
+            <h1 class="font-semibold text-ink select-none text-sm shrink-0">
+              Settings
+            </h1>
+          </div>
+        </SplitHeaderLeft>
+        {/* Pop the split back out into the modal (desktop only). */}
+        <Show when={!isMobile()}>
+          <SplitHeaderRight>
+            <Button
+              class="p-1 rounded-lg"
+              label="Open in modal"
+              onClick={() => moveSettingsToModal()}
+            >
+              <ArrowsOut class="size-4" />
+            </Button>
+          </SplitHeaderRight>
+        </Show>
+      </Show>
+
+      {/* The modal has no split header to portal into, so it renders its own. */}
+      <Show when={variant() === 'modal'}>
+        <div class="flex items-center justify-between h-11 shrink-0 px-2 border-b border-edge-muted">
+          <h1 class="font-semibold text-ink select-none text-sm pl-1">
             Settings
           </h1>
+          <div class="flex items-center gap-0.5">
+            <Button
+              class="p-1 rounded-lg"
+              label="Open in split"
+              onClick={() => moveSettingsToSplit()}
+            >
+              <ColumnsPlusRight class="size-4" />
+            </Button>
+            <Button
+              class="p-1 rounded-lg"
+              label="Close settings"
+              onClick={() => closeModal()}
+            >
+              <CloseIcon class="size-4" />
+            </Button>
+          </div>
         </div>
-      </SplitHeaderLeft>
+      </Show>
 
       <div class="flex grow min-h-1 overflow-hidden">
         <Show when={!isMobile()}>

--- a/js/app/packages/app/component/settings/SettingsModal.tsx
+++ b/js/app/packages/app/component/settings/SettingsModal.tsx
@@ -1,0 +1,27 @@
+import { useSettingsState } from '@core/constant/SettingsState';
+import { Dialog, Layer } from '@ui';
+import { SettingsPanel } from './Settings';
+
+/**
+ * Settings rendered as a scrim-backed modal overlay (the default activation).
+ * Use the "Open in split" control in its header to dock it into the split
+ * layout instead — see {@link SettingsPanelComponentWrapper}.
+ */
+export function SettingsModal() {
+  const { settingsModalOpen, closeModal } = useSettingsState();
+
+  return (
+    <Dialog
+      open={settingsModalOpen()}
+      onOpenChange={(open) => {
+        if (!open) closeModal();
+      }}
+      position="center"
+      class="w-260 h-216 max-h-[88vh] rounded-xl border border-edge bg-surface shadow-lg shadow-drop-shadow"
+    >
+      <Layer depth={2}>
+        <SettingsPanel variant="modal" />
+      </Layer>
+    </Dialog>
+  );
+}

--- a/js/app/packages/core/constant/SettingsState.tsx
+++ b/js/app/packages/core/constant/SettingsState.tsx
@@ -116,9 +116,31 @@ export const useSettingsState = () => {
     setModalOpen(true);
   };
 
+  // Focus-aware toggle: bring settings to the user rather than destroying it,
+  // and only close when settings is what they're actually looking at.
   const toggleSettings = () => {
-    if (isOpen()) closeSettings();
-    else openSettings();
+    // Modal takes priority: if it's open, close it.
+    if (modalOpen()) {
+      setModalOpen(false);
+      return;
+    }
+
+    const settingsSplit = getSettingsSplit();
+    if (settingsSplit) {
+      const manager = globalSplitManager();
+      // Docked but not the active split → bring focus to it instead of closing.
+      if (manager && manager.activeSplitId() !== settingsSplit.id) {
+        manager.activateSplit(settingsSplit.id);
+        focusSettingsPanel();
+        return;
+      }
+      // Docked and already focused → close it.
+      manager?.removeSplit(settingsSplit.id);
+      return;
+    }
+
+    // Nothing open → open the modal (mobile falls back to split internally).
+    openSettings();
   };
 
   return {

--- a/js/app/packages/core/constant/SettingsState.tsx
+++ b/js/app/packages/core/constant/SettingsState.tsx
@@ -1,6 +1,8 @@
 import { useSplitLayout } from '@app/component/split-layout/layout';
 import { globalSplitManager } from '@app/signal/splitLayout';
+import { isMobile } from '@core/mobile/isMobile';
 import { isTouchDevice } from '@core/mobile/isTouchDevice';
+import { createControlledOpenSignal } from '@core/util/createControlledOpenSignal';
 import { createMemo, createSignal } from 'solid-js';
 
 export type SettingsTab =
@@ -21,6 +23,12 @@ export type SettingsTab =
 
 const [activeTabId, setActiveTabId] = createSignal<SettingsTab>('Account');
 
+// Settings open in a scrim-backed modal by default. The focus-lock signal keeps
+// modal focus return consistent with the command menu / launcher.
+const [modalOpen, setModalOpen] = createControlledOpenSignal(false, {
+  id: 'settings',
+});
+
 export type AgentSettingsSubTab = 'connectors' | 'mcp_server';
 export const [agentSettingsSubTab, setAgentSettingsSubTab] =
   createSignal<AgentSettingsSubTab>('connectors');
@@ -37,9 +45,10 @@ export const useSettingsState = () => {
     });
   };
 
-  const isOpen = createMemo(() => {
-    return getSettingsSplit() !== undefined;
-  });
+  const splitOpen = createMemo(() => getSettingsSplit() !== undefined);
+
+  // Settings are considered open whether shown as a modal or docked in a split.
+  const isOpen = createMemo(() => modalOpen() || splitOpen());
 
   const focusSettingsPanel = () => {
     if (isTouchDevice()) return;
@@ -53,19 +62,60 @@ export const useSettingsState = () => {
     }, 10);
   };
 
+  // Default activation: open settings in a modal overlay. Mobile keeps the
+  // full-screen split behavior since the modal is sized for desktop.
   const openSettings = (activeTabId?: SettingsTab) => {
+    if (isMobile()) {
+      openSettingsInSplit(activeTabId);
+      return;
+    }
     if (activeTabId) setActiveTabId(activeTabId);
-    openWithSplit({ type: 'component', id: 'settings' }, { activate: true });
+    setModalOpen(true);
+  };
+
+  // Opt-in: dock settings into the split layout (the pre-modal behavior).
+  const openSettingsInSplit = (activeTabId?: SettingsTab) => {
+    if (activeTabId) setActiveTabId(activeTabId);
+    openWithSplit(
+      { type: 'component', id: 'settings' },
+      {
+        activate: true,
+        allowDuplicate: true,
+        preferNewSplit: true,
+        mergeHistory: false,
+      }
+    );
     focusSettingsPanel();
   };
 
-  const closeSettings = () => {
+  const closeModal = () => setModalOpen(false);
+
+  const removeSettingsSplit = () => {
     const settingsSplit = getSettingsSplit();
     if (settingsSplit) {
-      const splitManager = globalSplitManager();
-      splitManager?.removeSplit(settingsSplit.id);
+      globalSplitManager()?.removeSplit(settingsSplit.id);
     }
   };
+
+  const closeSettings = () => {
+    if (modalOpen()) setModalOpen(false);
+    removeSettingsSplit();
+  };
+
+  // Promote the modal into the split layout: close the overlay and dock it.
+  const moveSettingsToSplit = (activeTabId?: SettingsTab) => {
+    setModalOpen(false);
+    openSettingsInSplit(activeTabId);
+  };
+
+  // Pop the docked split back out into the modal. The split is removed so it
+  // doesn't keep occupying layout space — the inverse of moveSettingsToSplit.
+  const moveSettingsToModal = (activeTabId?: SettingsTab) => {
+    if (activeTabId) setActiveTabId(activeTabId);
+    removeSettingsSplit();
+    setModalOpen(true);
+  };
+
   const toggleSettings = () => {
     if (isOpen()) closeSettings();
     else openSettings();
@@ -73,8 +123,14 @@ export const useSettingsState = () => {
 
   return {
     settingsOpen: isOpen,
+    settingsModalOpen: modalOpen,
+    settingsSplitOpen: splitOpen,
     openSettings,
+    openSettingsInSplit,
     closeSettings,
+    closeModal,
+    moveSettingsToSplit,
+    moveSettingsToModal,
     activeTabId,
     setActiveTabId,
     toggleSettings,

--- a/js/app/packages/core/constant/SettingsState.tsx
+++ b/js/app/packages/core/constant/SettingsState.tsx
@@ -80,7 +80,9 @@ export const useSettingsState = () => {
       { type: 'component', id: 'settings' },
       {
         activate: true,
-        allowDuplicate: true,
+        // Single settings split only: getSettingsSplit/removeSettingsSplit
+        // assume one exists, so reuse an existing one instead of duplicating.
+        allowDuplicate: false,
         preferNewSplit: true,
         mergeHistory: false,
       }


### PR DESCRIPTION
Included behavior allowing modal to be promoted to split in layout, and vice versa.