### PR TITLE
fix(soup): list items not rendered because of query cancellation

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/soup-view-context.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-view-context.tsx
@@ -496,7 +496,7 @@ export const SoupViewContextProvider: FlowComponent<
     queryOptions: () => {
       const view = activeListView();
       return {
-        enabled: !search.isSearching(),
+        enabled: enabled() && !search.isSearching(),
         meta: {
           itemFilter: (item) => soupItemMatchesListView(item, view),
         },

--- a/js/app/packages/queries/soup/normalized-cache/operations.ts
+++ b/js/app/packages/queries/soup/normalized-cache/operations.ts
@@ -9,6 +9,7 @@ import type { SoupPage } from '@service-storage/generated/schemas/soupPage';
 import {
   type InfiniteData,
   partialMatchKey,
+  type Query,
   type QueryKey,
 } from '@tanstack/solid-query';
 import { isAfter } from 'date-fns';
@@ -46,6 +47,19 @@ type SoupSearchInfiniteData = InfiniteData<
 >;
 
 /**
+ * Cancel in-flight soup list refetches before an optimistic cache write.
+ *
+ * Only cancels queries that already have data. Cancelling an in-flight
+ * initial fetch (data === undefined) reverts it to a stuck pending/idle
+ * state, which leaves the soup view blank on refresh.
+ */
+function cancelSoupQueries() {
+  const predicate = (query: Query) => query.state.data !== undefined;
+  queryClient.cancelQueries({ queryKey: soupKeys.items._def, predicate });
+  queryClient.cancelQueries({ queryKey: soupKeys.astItems._def, predicate });
+}
+
+/**
  * Optimistically update a single soup entity across all queries that
  * reference it. After normy's field merge, reconciles group membership in
  * every grouped cache containing this entity (`itemIds`-only mutations;
@@ -56,11 +70,11 @@ type SoupSearchInfiniteData = InfiniteData<
  * - Channels: `{ tag: 'channel', data: { channel: { id, ...fields } }, frecency_score }`
  * - Everything else: `{ tag, data: { id, ...fields }, frecency_score }`
  */
+
 export function optimisticUpdateSoupEntity<T extends SoupEntityTag>(
   partial: SoupEntityPartial<T>
 ): SoupTransaction {
-  queryClient.cancelQueries({ queryKey: soupKeys.items._def });
-  queryClient.cancelQueries({ queryKey: soupKeys.astItems._def });
+  cancelSoupQueries();
 
   const normalizer = getSoupNormalizer();
   const normKey = getNormalizationObjectKey(partial);
@@ -144,8 +158,7 @@ export function getSoupItemId(item: SoupApiItem): string {
  * and upsert into each resolvable group. Date / unresolved labels invalidate.
  */
 export function insertSoupEntity(item: SoupApiItem): SoupTransaction {
-  queryClient.cancelQueries({ queryKey: soupKeys.items._def });
-  queryClient.cancelQueries({ queryKey: soupKeys.astItems._def });
+  cancelSoupQueries();
 
   const previous = snapshotSoup();
   queryClient.setQueriesData<SoupItemsInfiniteData>(
@@ -217,8 +230,7 @@ export function insertSoupEntity(item: SoupApiItem): SoupTransaction {
 }
 
 export function removeSoupEntities(entityIds: Set<string>): SoupTransaction {
-  queryClient.cancelQueries({ queryKey: soupKeys.items._def });
-  queryClient.cancelQueries({ queryKey: soupKeys.astItems._def });
+  cancelSoupQueries();
 
   const previous = snapshotSoup();
 


### PR DESCRIPTION
If you had a split open for a block that performed a optimistic soup update on mount via the `optimisticUpdateSoupEntity` or other helpers, the query cancellation would break the soup query and prevent it from running the dependent memos needed to display the items. 

This PR changes it to only cancel queries with data so that any pending queries that may have fetched data but are still considered in the "fetching" state are not cancelled and are allowed to resolve.