### PR TITLE
fix(soup): scope inbox foreign-entity query to GitHub PRs

### DIFF
--- a/js/app/packages/app/component/app-sidebar/soup-filter-presets.ts
+++ b/js/app/packages/app/component/app-sidebar/soup-filter-presets.ts
@@ -49,6 +49,14 @@ const getExcludedDocumentSubTypes = (...subTypes: string[]) =>
 const getDisabledSnippetSubtypeExclude = (): Query['exclude'] =>
   ENABLE_SNIPPETS() ? {} : { subType: ['snippet'] };
 
+/**
+ * The only foreign-entity source we currently surface in the soup. Scoping the
+ * inbox query to this source keeps other foreign-entity types (added in the
+ * future) out of the request rather than relying on a client-side predicate to
+ * drop them. Mirrors the backend `GITHUB_PULL_REQUEST_FOREIGN_ENTITY_SOURCE`.
+ */
+const GITHUB_PULL_REQUEST_SOURCE = 'github_pull_request';
+
 /** Filters for inbox/signal: not done, importance=true for emails, 2-week window */
 const getInboxSignalFilters = () => {
   const twoWeeksAgo = subWeeks(startOfDay(new Date()), 2).toISOString();
@@ -66,9 +74,11 @@ const getInboxSignalFilters = () => {
       folderUpdatedAt: { gte: twoWeeksAgo },
       // Foreign entities (e.g. GitHub PRs) with a not-done notification.
       // Referencing `fef` also opts them into the signal query (otherwise
-      // defineQueryFilters excludes unreferenced entity types). Rendering is
-      // still gated on the supported-foreign-entities flag client-side.
+      // defineQueryFilters excludes unreferenced entity types). The source
+      // scope keeps non-GitHub foreign entities out of the request; rendering
+      // is still gated on the supported-foreign-entities flag client-side.
       foreignEntityDone: false,
+      foreignEntitySource: [GITHUB_PULL_REQUEST_SOURCE],
       emailShared: 'exclude',
     },
     exclude: getDisabledSnippetSubtypeExclude(),
@@ -106,8 +116,16 @@ export const VIEW_TAB_PRESETS: Record<ListView, ViewTabConfig> = {
       }),
       all: () => ({
         filters: {
-          // crm companies aren't surfaced outside the Companies view.
-          include: { crmCompanyId: [NIL_UUID] },
+          include: {
+            // crm companies aren't surfaced outside the Companies view.
+            crmCompanyId: [NIL_UUID],
+            // When the override opts foreign entities in (via the exclude
+            // below), scope them to GitHub PRs so other foreign sources don't
+            // leak into the request.
+            ...(ENABLE_SUPPORTED_SOUP_FOREIGN_ENTITIES_OVERRIDE
+              ? { foreignEntitySource: [GITHUB_PULL_REQUEST_SOURCE] }
+              : {}),
+          },
           exclude: {
             documentId: [NIL_UUID],
             threadId: [NIL_UUID],

--- a/js/app/packages/app/component/next-soup/filters/filter-store/compile.ts
+++ b/js/app/packages/app/component/next-soup/filters/filter-store/compile.ts
@@ -114,6 +114,7 @@ const FIELD_CONFIG: Record<
   callStatus: { target: 'callf', field: 'Status' },
   callAttended: { target: 'callf', field: 'Attended' },
   foreignEntityRecordId: { target: 'fef', field: 'id' },
+  foreignEntitySource: { target: 'fef', field: 'fes' },
   foreignEntitySeen: { target: 'fef', field: 'ns' },
   foreignEntityDone: { target: 'fef', field: 'nd' },
   crmCompanyId: { target: 'ccf', field: 'id' },

--- a/js/app/packages/app/component/next-soup/filters/filter-store/types.ts
+++ b/js/app/packages/app/component/next-soup/filters/filter-store/types.ts
@@ -46,6 +46,7 @@ export type ArrayFieldFilters = {
   callChannelId?: string[];
   callSpeakerId?: string[];
   foreignEntityRecordId?: string[];
+  foreignEntitySource?: string[];
   crmCompanyId?: string[];
   properties?: PropertyFilter[];
 };


### PR DESCRIPTION
Follow-up to #4107 (review feedback).

The inbox query opens the foreign-entity target broadly, so any foreign-entity source we add in the future would be pulled into the soup request and only dropped client-side by the predicate. This scopes the request itself to the GitHub PR source.

**How**
- Add a `foreignEntitySource` query field mapped to the `fef` target's `fes` literal — already supported end-to-end by the soup AST backend (`ForeignEntityLiteral::ForeignEntitySource` → JSONPath `$.foreignEntitySource == "github_pull_request"`).
- Scope the inbox **signal** preset (and the override-gated **all** tab) to the `github_pull_request` source.

Frontend-only; no backend changes required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cw7oJXnoXiJrnwrLtQ7P6C

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cw7oJXnoXiJrnwrLtQ7P6C)_