### PR TITLE
fix(macro_config): support LocalOrRemoteSecret

### DIFF
--- a/.github/workspace-dep-closures.json
+++ b/.github/workspace-dep-closures.json
@@ -2159,6 +2159,9 @@
     "macro_config": [
       "macro_config",
       "macro_config_derive",
+      "macro_env",
+      "macro_env_var",
+      "remote_env_var",
       "workspace-hack"
     ],
     "macro_config_derive": [

--- a/rust/cloud-storage/Cargo.lock
+++ b/rust/cloud-storage/Cargo.lock
@@ -6780,11 +6780,13 @@ name = "macro_config"
 version = "0.1.0"
 dependencies = [
  "macro_config_derive",
+ "macro_env",
  "macro_env_var",
  "remote_env_var",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "tokio",
  "tracing",
  "workspace-hack",
 ]

--- a/rust/cloud-storage/document_storage_service/src/main.rs
+++ b/rust/cloud-storage/document_storage_service/src/main.rs
@@ -113,8 +113,12 @@ async fn main() -> anyhow::Result<()> {
         aws_sdk_secretsmanager::Client::new(&aws_config),
     );
 
-    // Parse our configuration from the environment.
-    let config = Config::from_env().context("expected to be able to generate config")?;
+    // Parse our configuration from the environment, then resolve any secret-manager backed values.
+    let config = Config::from_env()
+        .context("expected to be able to generate config")?
+        .resolve_remote_secrets(env, &secretsmanager_client)
+        .await
+        .context("expected to be able to resolve config secrets")?;
 
     tracing::trace!("initialized config");
 

--- a/rust/cloud-storage/macro_config/Cargo.toml
+++ b/rust/cloud-storage/macro_config/Cargo.toml
@@ -6,6 +6,8 @@ version = "0.1.0"
 
 [dependencies]
 macro_config_derive = { path = "../macro_config_derive" }
+macro_env = { path = "../macro_env" }
+remote_env_var = { path = "../remote_env_var" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }
@@ -14,4 +16,4 @@ workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
 [dev-dependencies]
 macro_env_var = { path = "../macro_env_var" }
-remote_env_var = { path = "../remote_env_var" }
+tokio = { workspace = true, features = ["macros", "rt"] }

--- a/rust/cloud-storage/macro_config/src/lib.rs
+++ b/rust/cloud-storage/macro_config/src/lib.rs
@@ -13,6 +13,10 @@ use serde_json::Value;
 use std::fmt::Display;
 
 #[doc(hidden)]
+pub use macro_env as __macro_env;
+#[doc(hidden)]
+pub use remote_env_var as __remote_env_var;
+#[doc(hidden)]
 pub use serde as __serde;
 use std::str::FromStr;
 

--- a/rust/cloud-storage/macro_config/src/test.rs
+++ b/rust/cloud-storage/macro_config/src/test.rs
@@ -1,6 +1,6 @@
 use super::*;
 use serde::Deserialize;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 static ENV_LOCK: Mutex<()> = Mutex::new(());
 
@@ -208,7 +208,7 @@ struct EnvVarFieldConfig {
     missing_optional_secret: Option<OptionalConfigSecret>,
 }
 
-#[derive(Deserialize)]
+#[derive(MacroConfig)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 struct RemoteSecretFieldConfig {
     remote_config_secret: remote_env_var::LocalOrRemoteSecret<ConfigSecret>,
@@ -324,6 +324,62 @@ fn load_deserializes_local_or_remote_macro_env_var_fields() {
     assert_eq!(
         config.optional_remote_config_secret.as_str(),
         Some("optional-remote-secret-name")
+    );
+    assert_eq!(config.missing_remote_config_secret.as_str(), None);
+}
+
+#[derive(Debug)]
+struct TestSecretManagerError;
+
+impl std::fmt::Display for TestSecretManagerError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("test secret manager error")
+    }
+}
+
+impl std::error::Error for TestSecretManagerError {}
+
+struct TestSecretManager;
+
+impl remote_env_var::SecretManager for TestSecretManager {
+    type Err = TestSecretManagerError;
+
+    async fn get_secret_value<T: AsRef<str> + Send>(
+        &self,
+        secret_name: T,
+    ) -> Result<Arc<str>, Self::Err> {
+        Ok(Arc::from(format!("resolved-{}", secret_name.as_ref())))
+    }
+}
+
+#[tokio::test]
+async fn macro_config_derived_resolve_remote_secrets_resolves_local_or_remote_fields() {
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    let env = EnvGuard::new(&[
+        "APP_SECRETS_JSON",
+        "REMOTE_CONFIG_SECRET",
+        "OPTIONAL_REMOTE_CONFIG_SECRET",
+        "MISSING_REMOTE_CONFIG_SECRET",
+    ]);
+    env.set("REMOTE_CONFIG_SECRET", "remote-secret-name");
+    env.set(
+        "OPTIONAL_REMOTE_CONFIG_SECRET",
+        "optional-remote-secret-name",
+    );
+
+    let config = ConfigLoader::load::<RemoteSecretFieldConfig>().expect("config should load");
+    let config = config
+        .resolve_remote_secrets(macro_env::Environment::Develop, &TestSecretManager)
+        .await
+        .expect("remote secrets should resolve");
+
+    assert_eq!(
+        config.remote_config_secret.as_ref(),
+        "resolved-remote-secret-name"
+    );
+    assert_eq!(
+        config.optional_remote_config_secret.as_str(),
+        Some("resolved-optional-remote-secret-name")
     );
     assert_eq!(config.missing_remote_config_secret.as_str(), None);
 }

--- a/rust/cloud-storage/macro_config_derive/src/lib.rs
+++ b/rust/cloud-storage/macro_config_derive/src/lib.rs
@@ -177,6 +177,50 @@ fn expand_macro_config(input: DeriveInput) -> syn::Result<TokenStream2> {
         }
     });
 
+    let (inherent_impl_generics, inherent_ty_generics, inherent_where_clause) =
+        input.generics.split_for_impl();
+    let remote_secret_resolver_impl = if field_data
+        .iter()
+        .any(|field| is_remote_secret_type(&field.ty))
+    {
+        let bindings = field_data.iter().map(|field| &field.ident);
+        let field_initializers = field_data.iter().map(|field| {
+            let ident = &field.ident;
+            if is_remote_secret_type(&field.ty) {
+                quote! {
+                    #ident: #ident.resolve_from_secret_manager(environment, secret_manager).await?,
+                }
+            } else {
+                quote! { #ident, }
+            }
+        });
+
+        quote! {
+            impl #inherent_impl_generics #struct_name #inherent_ty_generics #inherent_where_clause {
+                #[doc = "Resolve all `LocalOrRemoteSecret` fields through the provided secret manager."]
+                pub async fn resolve_remote_secrets<__MacroConfigSecretManager>(
+                    self,
+                    environment: ::macro_config::__macro_env::Environment,
+                    secret_manager: &__MacroConfigSecretManager,
+                ) -> ::core::result::Result<
+                    Self,
+                    <__MacroConfigSecretManager as ::macro_config::__remote_env_var::SecretManager>::Err,
+                >
+                where
+                    __MacroConfigSecretManager: ::macro_config::__remote_env_var::SecretManager,
+                {
+                    let Self { #(#bindings),* } = self;
+
+                    ::core::result::Result::Ok(Self {
+                        #(#field_initializers)*
+                    })
+                }
+            }
+        }
+    } else {
+        quote! {}
+    };
+
     Ok(quote! {
         impl #impl_generics ::macro_config::__serde::Deserialize<'de> for #struct_name #ty_generics #where_clause {
             fn deserialize<__D>(deserializer: __D) -> Result<Self, __D::Error>
@@ -252,6 +296,8 @@ fn expand_macro_config(input: DeriveInput) -> syn::Result<TokenStream2> {
         }
 
         #(#from_ref_impls)*
+
+        #remote_secret_resolver_impl
     })
 }
 
@@ -367,6 +413,19 @@ fn to_screaming_snake_case(value: &str) -> String {
     }
 
     out
+}
+
+fn is_remote_secret_type(ty: &Type) -> bool {
+    let Type::Path(path) = ty else {
+        return false;
+    };
+
+    let Some(segment) = path.path.segments.last() else {
+        return false;
+    };
+
+    let ident = segment.ident.to_string();
+    ident == "LocalOrRemoteSecret" || ident == "OptionalLocalOrRemoteSecret"
 }
 
 fn is_option_type(ty: &Type) -> bool {


### PR DESCRIPTION
remote secrets weren't getting resolved automatically in the macro_config. this fixes that by allowing you to resolve the secrets after the config is created.