### PR TITLE
Conditionally display share modal header based on user permissions

### DIFF
--- a/js/app/packages/core/component/TopBar/ShareButton.tsx
+++ b/js/app/packages/core/component/TopBar/ShareButton.tsx
@@ -989,10 +989,15 @@ export function ShareModal(props: ShareModalProps) {
                 <Panel depth={2} class="rounded-xl">
                   <Panel.Header class="px-4">
                     <span class="text-sm font-medium">
-                      People with access to this{' '}
-                      {props.itemType === 'email'
-                        ? 'email thread'
-                        : props.itemType}
+                      <Show
+                        when={props.userPermissions === Permissions.OWNER}
+                        fallback="Document owner"
+                      >
+                        People with access to this{' '}
+                        {props.itemType === 'email'
+                          ? 'email thread'
+                          : props.itemType}
+                      </Show>
                     </span>
                   </Panel.Header>
                   <Panel.Body class="text-ink">


### PR DESCRIPTION
## Summary
Updated the ShareModal component to conditionally render the access list header based on the user's permission level. When the user is not the owner, a simplified "Document owner" message is displayed instead of the detailed access information.

## Key Changes
- Wrapped the "People with access" header text in a `Show` component that checks if the user has `OWNER` permissions
- When user is the owner: displays the original detailed message ("People with access to this [item type]")
- When user is not the owner: displays a fallback message ("Document owner")

## Implementation Details
- Uses Solid.js's `Show` component for conditional rendering
- Maintains the existing logic for differentiating between email threads and other item types
- The permission check is based on `props.userPermissions === Permissions.OWNER`

https://claude.ai/code/session_01P9sbpmXEyBuK78sxxseQ9c