### PR TITLE
fix(email): connect inbox via /link/gmail instead of /login/sso

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/empty-states.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/empty-states.tsx
@@ -3,8 +3,7 @@ import { DOCS_BASE } from '@app/constants/docs-links';
 import type { ListView } from '@app/constants/list-views';
 import type { BlockAlias, BlockName } from '@core/block';
 import { McpSetupCards } from '@core/component/AI/component/McpSetupCards';
-import { toast } from '@core/component/Toast/Toast';
-import { useEmailLinks, useEmailLinksStatus } from '@core/email-link';
+import { useAddInboxFlow, useEmailLinksStatus } from '@core/email-link';
 import EmptyStateAiIcon from '@design/empty-state-ai.svg';
 import EmptyStateAutomationsIcon from '@design/empty-state-automations.svg';
 import EmptyStateCallsIcon from '@design/empty-state-calls.svg';
@@ -80,14 +79,11 @@ export function EmptyState(props: {
   onClearFilters?: () => void;
 }) {
   const emailActive = useEmailLinksStatus();
-  const { connect } = useEmailLinks();
+  const startAddInbox = useAddInboxFlow();
   const soup = useSoupView();
 
   const onConnectEmail = () => {
-    connect().match(
-      () => {},
-      () => toast.failure('Failed to connect email')
-    );
+    void startAddInbox();
   };
 
   return (

--- a/js/app/packages/app/component/settings/Email.tsx
+++ b/js/app/packages/app/component/settings/Email.tsx
@@ -44,7 +44,6 @@ export function Email() {
 
   const {
     query: emailLinksQuery,
-    connect: connectEmail,
     disconnect: disconnectEmail,
     resyncInbox,
   } = useEmailLinks();
@@ -83,11 +82,11 @@ export function Email() {
   const onConnectEmail = async () => {
     if (isEmailActionPending()) return;
     setIsEmailActionPending(true);
-    await connectEmail().match(
-      () => {},
-      () => toast.failure('Failed to connect email')
-    );
-    setIsEmailActionPending(false);
+    try {
+      await startAddInbox();
+    } finally {
+      setIsEmailActionPending(false);
+    }
   };
 
   const onDisconnectEmail = async () => {

--- a/js/app/packages/core/email-link/index.ts
+++ b/js/app/packages/core/email-link/index.ts
@@ -1,10 +1,5 @@
 import { ROUTER_BASE_CONCAT } from '@app/constants/routerBase';
 import { updateUserAuth } from '@core/auth';
-import {
-  authenticateWithEmailPermissions,
-  type TimeoutError,
-} from '@core/auth/channel';
-import { openEmailAuthPopup } from '@core/auth/email';
 import { toast } from '@core/component/Toast/Toast';
 
 import { getNativeMobilePlatform } from '@core/util/platform';
@@ -168,20 +163,6 @@ function resyncInbox(
 }
 
 /**
- * Connects to the email service and authenticates with email permissions.
- *
- * @returns A promise that resolves when the auth success message is received.
- */
-function connectEmail(): ResultAsync<void, TimeoutError> {
-  openEmailAuthPopup({
-    idpName: 'google_gmail',
-    returnPath: `${ROUTER_BASE_CONCAT}login/popup/success`,
-  });
-
-  return authenticateWithEmailPermissions();
-}
-
-/**
  * Initializes email syncing, starts polling, and invalidates relevant queries.
  * Unlike useEmailLinks().initEmailLink, this does not require SolidJS context.
  */
@@ -301,11 +282,6 @@ export function useEmailLinks() {
     isConnected: () => hasEmailLinks(query),
     initEmailLink: (args?: { linkId?: string; forceShare?: boolean }) =>
       initEmailLink(args).map(startEmailPolling).map(invalidations),
-    connect: () =>
-      connectEmail()
-        .andThen(() => initEmailLink())
-        .map(startEmailPolling)
-        .andTee(invalidations),
     disconnect: () => disconnectEmail().andTee(invalidations),
     resyncInbox: (linkId: string) =>
       resyncInbox(linkId).andTee(() => invalidateEmailLinks()),

--- a/rust/cloud-storage/authentication_service/src/api/link/gmail.rs
+++ b/rust/cloud-storage/authentication_service/src/api/link/gmail.rs
@@ -101,8 +101,14 @@ pub async fn init_gmail_link_handler(
 ) -> Result<Json<InitGmailLinkResponse>, InitGmailLinkError> {
     let Query(InitGmailLinkQueryParams { original_url }) = query;
 
+    // First inbox is free; additional inboxes require a professional subscription.
     if !permissions.contains(&PermissionId::ReadProfessionalFeatures.to_string()) {
-        return Err(InitGmailLinkError::PaymentRequired);
+        let has_own_inbox =
+            macro_db_client::email::check_user_email_link(&ctx.db, &user_context.macro_user_id)
+                .await?;
+        if has_own_inbox {
+            return Err(InitGmailLinkError::PaymentRequired);
+        }
     }
 
     let count =


### PR DESCRIPTION
In-app inbox connect now uses `/link/gmail` (attach) instead of `/login/sso` (login), so connecting a Gmail no longer re-authenticates and silently switches the logged-in account when the connected Google identity belongs to another macro account (e.g. aliased accounts). First inbox stays free; additional inboxes still require Professional.