### PR TITLE
fix(channel): prevent empty-list flash when navigating to a message

### DIFF
--- a/js/app/packages/channel/Channel/Channel.tsx
+++ b/js/app/packages/channel/Channel/Channel.tsx
@@ -349,25 +349,6 @@ export function Channel(props: ChannelProps) {
     targetMessageController.goToMessage(messageId, replyId);
   };
 
-  // Navigating to a message highlights it by selecting it. When the target
-  // isn't in the initially loaded page (e.g. opening an old message from
-  // search), that selection is auto-cleared by create-message-selection before
-  // the load-around resolves. Re-assert it once the target message has loaded.
-  // Tracked per-target so it applies only to the active navigation, not after
-  // the user selects something else.
-  let highlightedNavigationTarget: string | undefined;
-  createEffect(() => {
-    const targetId = targetMessageController.activeTargetMessageId();
-    if (!targetId || targetMessageController.activeTargetMessageReplyId()) {
-      highlightedNavigationTarget = undefined;
-      return;
-    }
-    if (highlightedNavigationTarget === targetId) return;
-    if (!messageIndex.keys.includes(targetId)) return;
-    highlightedNavigationTarget = targetId;
-    selectMessage(targetId);
-  });
-
   const findBar = createChannelFindBar({
     channelId: () => props.channelId,
     goToMessage,

--- a/js/app/packages/core/component/AI/component/tool/Search.tsx
+++ b/js/app/packages/core/component/AI/component/tool/Search.tsx
@@ -1,3 +1,4 @@
+import { navigateToChannelMessage } from '@block-channel/utils/link';
 import { getEntityClickContent } from '@channel/Attachments/attachment-utils';
 import {
   type EntityData,
@@ -82,15 +83,20 @@ const UnifiedSearchToolResponse = (props: {
   );
 
   const openEntity = async (entity: SearchEntity) => {
-    const content = getEntityClickContent(entity);
-    insertSplit(content);
-
-    if (content.params) {
-      const blockHandle = await globalSplitManager()
-        ?.getOrchestrator()
-        .getBlockHandle(content.id);
-      await blockHandle?.goToLocationFromParams(content.params);
+    if (entity.type === 'channel_message') {
+      const orchestrator = globalSplitManager()?.getOrchestrator();
+      if (orchestrator) {
+        await navigateToChannelMessage(
+          orchestrator,
+          entity.channelId,
+          entity.messageId,
+          entity.threadId
+        );
+        return;
+      }
     }
+
+    insertSplit(getEntityClickContent(entity));
   };
 
   return (

--- a/js/app/packages/queries/channel/channel-messages.ts
+++ b/js/app/packages/queries/channel/channel-messages.ts
@@ -84,6 +84,11 @@ export function channelMessagesQueryOptions(
       );
       return normalizeChannelMessagesPageSenders(page);
     },
+    placeholderData: (
+      prev: ChannelMessagesData | undefined,
+      prevQuery: { queryKey: ChannelMessagesQueryKey } | undefined
+    ): ChannelMessagesData | undefined =>
+      prevQuery?.queryKey.includes(channelId) ? prev : undefined,
     initialPageParam: null as ChannelMessagesPageParam | null,
     getNextPageParam: (lastPage: ChannelMessagesPage) =>
       lastPage.next_cursor


### PR DESCRIPTION
Adds `keepPreviousData` to the channel messages query so navigating to an unloaded message keeps the prior page visible while the centered page loads, instead of flashing the list empty and clearing the pending message selection (the placeholder is scoped to the same channel so switching channels never shows another channel's pages). This makes the highlight re-assert `createEffect` redundant, so it's removed, and search channel-message hits now route through `navigateToChannelMessage` to match the reference-click path.
