### PR TITLE
fix(email): shorten send toast and show error on failed undo

### DIFF
--- a/js/app/packages/block-email/component/BaseInput.tsx
+++ b/js/app/packages/block-email/component/BaseInput.tsx
@@ -521,7 +521,13 @@ export function BaseInput(props: {
 
   const undoSend = async (draftId: string) => {
     try {
-      await emailClient.unscheduleMessage({ draftID: draftId });
+      const result = await emailClient.unscheduleMessage({ draftID: draftId });
+      // A non-2xx response comes back as an Err Result (it doesn't throw), so
+      // bail before reverting the send appearance in the UI.
+      if (result.isErr()) {
+        toast.failure('Failed to undo send');
+        return;
+      }
       queryClient.invalidateQueries({
         queryKey: emailKeys.previews._def,
       });

--- a/js/app/packages/block-email/component/BaseInput.tsx
+++ b/js/app/packages/block-email/component/BaseInput.tsx
@@ -521,7 +521,10 @@ export function BaseInput(props: {
 
   const undoSend = async (draftId: string) => {
     try {
-      const result = await emailClient.unscheduleMessage({ draftID: draftId });
+      const result = await emailClient.unscheduleMessage(
+        { draftID: draftId },
+        headerLinkId()
+      );
       // A non-2xx response comes back as an Err Result (it doesn't throw), so
       // bail before reverting the send appearance in the UI.
       if (result.isErr()) {

--- a/js/app/packages/block-email/component/compose/Compose.tsx
+++ b/js/app/packages/block-email/component/compose/Compose.tsx
@@ -358,7 +358,16 @@ export function EmailCompose(props: EmailComposeProps) {
 
   const undoSend = async (draftId: string) => {
     try {
-      await emailClient.unscheduleMessage({ draftID: draftId }, headerLinkId());
+      const result = await emailClient.unscheduleMessage(
+        { draftID: draftId },
+        headerLinkId()
+      );
+      // A non-2xx response comes back as an Err Result (it doesn't throw), so
+      // bail before reverting the send appearance in the UI.
+      if (result.isErr()) {
+        toast.failure('Failed to undo send');
+        return;
+      }
       queryClient.invalidateQueries({
         queryKey: emailKeys.previews._def,
       });
@@ -392,7 +401,7 @@ export function EmailCompose(props: EmailComposeProps) {
               },
             ]
           : undefined,
-        duration: 10_000,
+        duration: 8_000,
         mobile: true,
       });
       if (data.message.thread_db_id) {


### PR DESCRIPTION
## Summary

Two changes to the "Email sent" toast (with the **Undo** button) shown after sending an email.

### Shorter toast duration
The new-thread compose toast now lives for **8s** instead of 10s (`Compose.tsx`).

### Handle a failed undo
`emailClient.unscheduleMessage` returns a neverthrow `Result` and does **not** throw on a non-2xx response. The old `undoSend` only `await`ed it inside a `try/catch`, so a non-2xx response fell through and reverted the send appearance in the UI anyway — reopening the compose / removing the message from the thread cache — while falsely showing "Send cancelled".

Now we check `result.isErr()` and surface a `Failed to undo send` error toast, bailing before any UI revert. Thrown/network errors remain handled by the existing `catch`.

Applied to both undo flows that had the issue:
- `Compose.tsx` — new-thread compose
- `BaseInput.tsx` — inline thread reply
