### PR TITLE
fix(ai): resolve email via name search before searching emails (macro-1915)

### DIFF
--- a/rust/cloud-storage/prompt/src/tool_usage.rs
+++ b/rust/cloud-storage/prompt/src/tool_usage.rs
@@ -46,6 +46,16 @@ users workspace. If the user asks you to create a document, write a code file, o
    asking for something specifi like "someone mentioned ..." prefer search
    if they are asking for summaries of messages or emails prefer listing.
    After collecting information read the appropriate resource using the read tool.
+
+2. Finding a person's emails — resolve the email address first:
+   When the user asks about emails to/from a person by NAME (e.g. "find emails
+   from Jane Smith", "what did Bob say"), DO NOT search emails by the person's
+   name. Name matching only catches addresses where that exact display name
+   happens to appear, so it misses most of the thread. Instead, first run a
+   NameSearch (or NameSearch on contacts) to resolve the person's email address,
+   then run a ContentSearch for that email address (wrap it in double quotes,
+   e.g. `"jane@example.com"`) to get comprehensive hits across sender/recipient/
+   cc/bcc. Only fall back to searching by name if you cannot resolve an address.
 "##;
 
 static INTENT: &str = "The model proactively uses tools with precise filters instead of \

--- a/rust/cloud-storage/prompt/tests/compose.rs
+++ b/rust/cloud-storage/prompt/tests/compose.rs
@@ -46,7 +46,8 @@ fn tool_use_prompt_appends_tool_section_to_base() {
     assert!(
         rendered
             .trim_end()
-            .ends_with("read the appropriate resource using the read tool.")
+            .ends_with("Only fall back to searching by name if you cannot resolve an address.")
     );
     assert!(rendered.contains("# Tool Use"));
+    assert!(rendered.contains("read the appropriate resource using the read tool."));
 }


### PR DESCRIPTION
## What

Fixes **macro-1915 "Failing to find emails"**.

The AI was searching for a person's emails by their NAME, which only matches messages where that display name literally appears on an address — so most of the thread was missed.

## Fix

Prompt-engineering only. Adds explicit guidance steering the model to a two-step workflow when looking for a person's emails:

1. First run a name search to resolve the person's **email address**.
2. Then `ContentSearch` for that quoted address (e.g. `"jane@example.com"`) to get comprehensive hits across sender/recipient/cc/bcc.

Falls back to name search only when an address can't be resolved.

### Changed

- `rust/cloud-storage/prompt/src/tool_usage.rs` — new "Finding a person's emails" tool-usage pattern in the system prompt.
- `rust/cloud-storage/ai_tools/src/search/search_service/content.rs` — reinforces the same guidance in the `ContentSearch` tool description (where the model picks its query).

## Testing

- `cargo check -p prompt -p ai_tools` passes.
- `cargo test -p ai_tools content_search_schema` passes (tool schema still validates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)