### PR TITLE
fix(ai): draft emails via the email tool (macro-1913)

### DIFF
--- a/js/app/packages/service-clients/service-cognition/generated/tools/types.ts
+++ b/js/app/packages/service-clients/service-cognition/generated/tools/types.ts
@@ -2330,7 +2330,7 @@ export interface SearchToolResponse {
   results: UnifiedSearchResponseItem[];
 }
 /**
- * Compose and send an email. Creates the message and immediately queues it for delivery. To reply to an existing message, provide the replying_to_id. Write the body in Markdown — use **bold**, *italics*, lists, links, and other standard Markdown formatting. The draft composer renders the Markdown for the user to review and edit; the composer produces HTML that is sent as the actual email body.
+ * Draft, compose, and send an email. ALWAYS use this tool whenever the user asks you to draft, write, compose, or send an email (or reply to one) — never write the email as plain text in the chat. This tool opens the email draft in the composer for the user to review, edit, and confirm before it is sent, so it is the correct tool even when the user only wants a draft. To reply to an existing message, provide the replying_to_id. Write the body in Markdown — use **bold**, *italics*, lists, links, and other standard Markdown formatting. The draft composer renders the Markdown for the user to review and edit; the composer produces HTML that is sent as the actual email body.
  */
 export interface SendEmail {
   /**

--- a/rust/cloud-storage/email/src/inbound/toolset/send_email.rs
+++ b/rust/cloud-storage/email/src/inbound/toolset/send_email.rs
@@ -39,7 +39,7 @@ impl From<EmailRecipient> for ContactInfo {
 #[derive(Debug, Deserialize, JsonSchema, Clone)]
 #[schemars(
     title = "SendEmail",
-    description = "Compose and send an email. Creates the message and immediately queues it for delivery. To reply to an existing message, provide the replying_to_id. Write the body in Markdown — use **bold**, *italics*, lists, links, and other standard Markdown formatting. The draft composer renders the Markdown for the user to review and edit; the composer produces HTML that is sent as the actual email body."
+    description = "Draft, compose, and send an email. ALWAYS use this tool whenever the user asks you to draft, write, compose, or send an email (or reply to one) — never write the email as plain text in the chat. This tool opens the email draft in the composer for the user to review, edit, and confirm before it is sent, so it is the correct tool even when the user only wants a draft. To reply to an existing message, provide the replying_to_id. Write the body in Markdown — use **bold**, *italics*, lists, links, and other standard Markdown formatting. The draft composer renders the Markdown for the user to review and edit; the composer produces HTML that is sent as the actual email body."
 )]
 #[serde(rename_all = "camelCase")]
 pub struct SendEmail {

--- a/rust/cloud-storage/prompt/src/tool_usage.rs
+++ b/rust/cloud-storage/prompt/src/tool_usage.rs
@@ -27,6 +27,13 @@ static INSTRUCTIONS: &str = r##"## Tone and Style Additions
   using XML mention tags (e.g. `<m-document-mention>`). Always use a mention if the tool
   returns anything relavent. IMPORTANT
 
+- IMPORTANT: When the user asks you to draft, write, compose, or send an email (or reply to one),
+  you MUST use the `SendEmail` tool to produce it. NEVER write the email body as plain text in the
+  chat. The `SendEmail` tool opens a real draft in the email composer that the user can review,
+  edit, and send — writing the email inline in chat does none of that and is wrong. Drafting and
+  sending are the same tool: it always creates a draft for the user to confirm before anything is
+  sent, so use it even when the user only wants a draft.
+
 - IMPORTANT: The code execution tools (`bash_code_execution`, and `text_editor_code_execution`) should only be used
 when the user explicitely asks you to _execute_ code.
 
@@ -50,7 +57,8 @@ users workspace. If the user asks you to create a document, write a code file, o
 
 static INTENT: &str = "The model proactively uses tools with precise filters instead of \
 claiming it lacks context, cites relevant tool results with mention tags, reserves code \
-execution for explicit requests, and uses CreateDocument for files in the user's workspace.";
+execution for explicit requests, uses the SendEmail tool to draft or send emails instead of \
+writing them inline in chat, and uses CreateDocument for files in the user's workspace.";
 
 /// The tool-use prompt.
 pub static PROMPT: StaticPrompt<'static> = StaticPrompt::borrowed(TITLE, INSTRUCTIONS, INTENT);


### PR DESCRIPTION
## What

macro-1913 — "ai drafts email without using email drafting technology"

When a user asked the AI to draft an email, it would sometimes write the email body as plain text inline in the chat instead of using the `SendEmail` tool (which opens a real, reviewable draft in the email composer).

This is a prompt-engineering fix. Two changes:

1. **`prompt/src/tool_usage.rs`** — Added an explicit `IMPORTANT` rule to the Tool Use section: whenever the user asks to draft, write, compose, send, or reply to an email, the AI MUST use the `SendEmail` tool and NEVER write the email body inline as chat text. Clarified that drafting and sending are the same tool — it always creates a draft for the user to confirm before sending, so it's correct even when the user only wants a draft. Also updated the section `INTENT` summary.

2. **`email/src/inbound/toolset/send_email.rs`** — Strengthened the `SendEmail` tool description so the tool itself signals it must be used for drafting requests, not just sending.

## Testing

- `cargo check -p prompt -p email` passes (SQLX_OFFLINE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)