### PR TITLE
fix(chat): allow sending with only an image attached (macro-1912)

### DIFF
--- a/js/app/packages/core/component/AI/component/input/ChatInput.tsx
+++ b/js/app/packages/core/component/AI/component/input/ChatInput.tsx
@@ -124,9 +124,12 @@ export function ChatInput(props: ChatInputComponentProps) {
   });
 
   const isEmptyInput = () => markdownText().trim().length === 0;
+  const hasAttachedFiles = () => attachments.attached().length > 0;
   const hasUploadingAttachments = () => uploadQueue.uploading().length > 0;
   const canSendMessage = () =>
-    !isEmptyInput() && !generating() && !hasUploadingAttachments();
+    (!isEmptyInput() || hasAttachedFiles()) &&
+    !generating() &&
+    !hasUploadingAttachments();
 
   const LINE_HEIGHT_THRESHOLD = 40;
   let mdRef: undefined | HTMLDivElement;

--- a/js/app/packages/core/component/AI/component/message/UserMessage.tsx
+++ b/js/app/packages/core/component/AI/component/message/UserMessage.tsx
@@ -60,7 +60,7 @@ export function UserMessage(props: {
 
   const content = () => {
     const rawContent = cn()[1];
-    return rawContent || undefined;
+    return rawContent?.trim() ? rawContent : undefined;
   };
 
   const imageAttachments = () =>


### PR DESCRIPTION
## macro-1912 — Can't send with just an image

### Problem
The chat input box grayed out and would not let the user send a message when an image (or other file) was attached but the text field was empty.

### Cause
In `ChatInput.tsx`, `canSendMessage()` required non-empty text:

```ts
const canSendMessage = () =>
  !isEmptyInput() && !generating() && !hasUploadingAttachments();
```

So the send button stayed disabled whenever the text was empty, regardless of attachments.

### Fix
Allow sending when there is text **or** at least one attached file, while keeping send disabled when there is neither (and still blocking while generating or while uploads are in flight):

```ts
const hasAttachedFiles = () => attachments.attached().length > 0;
const canSendMessage = () =>
  (!isEmptyInput() || hasAttachedFiles()) &&
  !generating() &&
  !hasUploadingAttachments();
```

### Testing
- `bun run type-check` passes in `js/app`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)