### PR TITLE
fix(analytics): restore signup conversions on onboarding completion

### DIFF
--- a/js/app/packages/app/component/interactive-onboarding/InteractiveOnboardingModal.tsx
+++ b/js/app/packages/app/component/interactive-onboarding/InteractiveOnboardingModal.tsx
@@ -1,3 +1,8 @@
+import { useAnalytics } from '@app/component/analytics-context';
+import {
+  SIGNUP_LEAD_VALUE_BY_TIER,
+  SIGNUP_LEAD_VALUE_DEFAULT,
+} from '@app/lib/analytics/leadValues';
 import { globalSplitManager } from '@app/signal/splitLayout';
 import MacroLogo from '@core/component/MacroLogo';
 import { isMobile } from '@core/mobile/isMobile';
@@ -290,11 +295,37 @@ export function InteractiveOnboardingModal(
     props.defaultOpen ?? false
   );
   const completeTutorial = useCompleteTutorialMutation();
+  const analytics = useAnalytics();
 
   const open = () => props.open ?? internalOpen();
 
+  // Closing the modal is the single chokepoint every completion path routes
+  // through (finish lessons, skip tutorial, or dismiss), so the signup
+  // conversion fires here rather than on lesson completion — the tour is
+  // optional and most users skip it. Guarded because we send no dedup id.
+  let signupConversionFired = false;
+  const fireSignupConversion = () => {
+    if (signupConversionFired || !props.isFirstTimeOnboarding) return;
+    signupConversionFired = true;
+
+    // `type` is set on the Stripe success redirect (see
+    // use-onboarding-checkout.ts). Free users skip Stripe so the param is
+    // absent — default to 'free'.
+    const tier =
+      new URLSearchParams(window.location.search).get('type') ?? 'free';
+    const value = SIGNUP_LEAD_VALUE_BY_TIER[tier] ?? SIGNUP_LEAD_VALUE_DEFAULT;
+    analytics.trackMeta('CompleteRegistration', {
+      content_name: 'onboarding_launch',
+      content_category: tier,
+      value,
+      currency: 'USD',
+    });
+    analytics.trackGoogleConversion('signup', { value, currency: 'USD' });
+  };
+
   const setOpen = (nextOpen: boolean) => {
     if (!nextOpen) {
+      fireSignupConversion();
       completeTutorial.mutate(undefined);
     }
     setInternalOpen(nextOpen);

--- a/js/app/packages/app/lib/analytics/leadValues.ts
+++ b/js/app/packages/app/lib/analytics/leadValues.ts
@@ -14,9 +14,7 @@ export const MOBILE_WEB_SIGNUP_LEAD_VALUE = 5;
 /** Signup Lead value per subscription tier. */
 export const SIGNUP_LEAD_VALUE_BY_TIER: Record<string, number> = {
   free: 20,
-  haiku: 175,
-  sonnet: 300,
-  opus: 450,
+  premium: 300,
 };
 
 /** Fallback used when the tier query param is unrecognized. */


### PR DESCRIPTION
PR #3664 (tutorial modal) deleted lessons/launch.tsx, which fired the Meta CompleteRegistration and Google Ads signup conversions on signup. Since then, desktop signups have sent zero conversions to either ad platform.

Restore the conversions at the modal's setOpen(false) chokepoint — the single exit every completion path routes through (finish lessons, skip tutorial, or dismiss) — rather than on state.isFinished(), which the now-optional tour lets most users bypass. Guarded against double-firing since we send no dedup id, and gated on isFirstTimeOnboarding so replays don't re-fire.

Also collapse SIGNUP_LEAD_VALUE_BY_TIER to the current free/premium tiers (premium $300, free $20); the old free/haiku/sonnet/opus map no longer matches the plan system and left the values dead.