### PR TITLE
fix(crm): wipe cached company emails on hide/email-sync toggle

### DIFF
--- a/js/app/packages/queries/crm/companies.ts
+++ b/js/app/packages/queries/crm/companies.ts
@@ -4,7 +4,7 @@ import type { CrmCompanyEntity } from '@entity';
 import { storageServiceClient } from '@service-storage/client';
 import type { CrmCompanyResponse } from '@service-storage/generated/schemas/crmCompanyResponse';
 import type { CrmContactResponse } from '@service-storage/generated/schemas/crmContactResponse';
-import { useMutation, useQuery } from '@tanstack/solid-query';
+import { type QueryKey, useMutation, useQuery } from '@tanstack/solid-query';
 import { type Accessor, createMemo } from 'solid-js';
 import { queryClient } from '../client';
 import { soupKeys } from '../soup/keys';
@@ -83,6 +83,47 @@ function responseToEntity(response: CrmCompanyResponse): CrmCompanyEntity {
   };
 }
 
+// Matches the company-email soup queries built by `useCompanyEmailsQuery`
+// (packages/companies/Company): the Team view's `ecd` domain widener and the
+// Me view's `ef` tree, both keyed on the company's email domains. astItems key
+// shape is ['soup', 'astItems', params, body, groupBy], so the body is at [3].
+function isCompanyEmailQueryKey(
+  queryKey: QueryKey,
+  domains: string[]
+): boolean {
+  const body = queryKey[3] as { ecd?: unknown; ef?: unknown } | undefined;
+  if (!body) return false;
+  if (
+    Array.isArray(body.ecd) &&
+    body.ecd.some((d) => domains.includes(d as string))
+  ) {
+    return true;
+  }
+  if (body.ef != null) {
+    const serialized = JSON.stringify(body.ef);
+    // Quote-wrap each domain so "example.com" can't match "sub.example.com".
+    return domains.some((d) => serialized.includes(JSON.stringify(d)));
+  }
+  return false;
+}
+
+// Wipe (not just invalidate) the company's cached email threads. Invalidate
+// keeps serving the stale rows — and won't refetch once the panel navigates
+// away on hide — so toggling hidden/email-sync left old emails on screen until
+// a full refresh. Removing forces a cold reload, the same as that refresh did.
+function wipeCompanyEmailCache(companyId: string): void {
+  const company = queryClient.getQueryData<CrmCompanyResponse>(
+    crmKeys.company(companyId).queryKey
+  );
+  const domains = company?.domains.map((d) => d.domain) ?? [];
+  if (domains.length === 0) return;
+
+  queryClient.removeQueries({
+    queryKey: soupKeys.astItems._def,
+    predicate: (query) => isCompanyEmailQueryKey(query.queryKey, domains),
+  });
+}
+
 /**
  * Toggles `crm_companies.hidden` via `PUT /crm/companies/{id}/hidden`. Hiding
  * also disables `email_sync` and soft-hides the company's contacts; un-hide
@@ -102,13 +143,15 @@ export function useSetCompanyHiddenMutation() {
       throwOnErr(() =>
         storageServiceClient.setCompanyHidden({ companyId, hidden })
       ),
-    onSuccess: (_data, { companyId }) =>
-      Promise.all([
+    onSuccess: (_data, { companyId }) => {
+      wipeCompanyEmailCache(companyId);
+      return Promise.all([
         queryClient.invalidateQueries({ queryKey: soupKeys._def }),
         queryClient.invalidateQueries({
           queryKey: crmKeys.company(companyId).queryKey,
         }),
-      ]),
+      ]);
+    },
   }));
 }
 
@@ -130,16 +173,20 @@ export function useSetEmailSyncMutation() {
       throwOnErr(() =>
         storageServiceClient.setEmailSync({ companyId, emailSync })
       ),
-    // Return the invalidation promise so the mutation stays pending until the
-    // refetches resolve — the company entity, empty-state message, and emails
-    // list flip in one beat. Soup carries the team-wide email visibility change;
-    // the company detail query backs the panel's `emailSync` empty-state text.
-    onSuccess: (_data, { companyId }) =>
-      Promise.all([
+    // Wipe the cached email threads first so disabling sync can't leave stale
+    // rows on screen, then return the invalidation promise so the mutation stays
+    // pending until the refetches resolve — the company entity, empty-state
+    // message, and emails list flip in one beat. Soup carries the team-wide
+    // email visibility change; the company detail query backs the panel's
+    // `emailSync` empty-state text.
+    onSuccess: (_data, { companyId }) => {
+      wipeCompanyEmailCache(companyId);
+      return Promise.all([
         queryClient.invalidateQueries({ queryKey: soupKeys._def }),
         queryClient.invalidateQueries({
           queryKey: crmKeys.company(companyId).queryKey,
         }),
-      ]),
+      ]);
+    },
   }));
 }


### PR DESCRIPTION
## Problem

In the company (CRM) block, hiding/unhiding a company or enabling/disabling email sync left stale email threads on screen until a full page refresh. The two mutations (`useSetCompanyHiddenMutation`, `useSetEmailSyncMutation`) only **invalidated** the soup queries.

`invalidateQueries` marks queries stale but keeps the cached rows and serves them stale-while-revalidate. On hide, the panel also navigates away to the companies list, so the now-inactive email query never refetched — the old emails just sat in the cache. Only a hard refresh (which clears the entire in-memory query cache) made them disappear.

## Fix

Both mutations now **remove** (wipe) the company's cached email soup queries in addition to the existing invalidations, so the data is physically gone and reloads cold — the same effect the refresh had.

The email threads come from `useCompanyEmailsQuery` (`soup/ast` `astItems` queries): the Team view's `ecd` domain widener and the Me view's `ef` filter tree. A predicate matches those queries by the company's email domains (read from the cached company detail response) and `removeQueries` clears them.

## Notes

- Existing soup / company-detail invalidations are unchanged, so the company still drops out of / returns to listings as before.
- Domains are quote-wrapped when matching the `ef` tree so e.g. `example.com` can't match `sub.example.com`.
