### PR TITLE
feat(crm): add Hide/Unhide soup context action for companies

### DIFF
--- a/js/app/packages/app/component/next-soup/actions/index.ts
+++ b/js/app/packages/app/component/next-soup/actions/index.ts
@@ -4,6 +4,7 @@ export { makeCopyBranchNameAction } from './make-copy-branch-name-action';
 export { makeCopyEntityIdAction } from './make-copy-entity-id-action';
 export { makeCopyLinkAction } from './make-copy-link-action';
 export { makeDeleteAction } from './make-delete-action';
+export { makeHideCompanyAction } from './make-hide-company-action';
 export { makeMarkDoneAction } from './make-mark-done-action';
 export { makeMarkSenderSignalAction } from './make-mark-sender-important-action';
 export { makeMarkSenderNoiseAction } from './make-mark-sender-noise-action';

--- a/js/app/packages/app/component/next-soup/actions/make-hide-company-action.ts
+++ b/js/app/packages/app/component/next-soup/actions/make-hide-company-action.ts
@@ -1,0 +1,49 @@
+import { useMaybePreviewPanel } from '@app/component/PreviewPanel';
+import { toast } from '@core/component/Toast/Toast';
+import type { EntityData } from '@entity';
+import type { SoupState } from '../create-soup-state';
+import { restoreSoupFocus } from '../utils';
+
+type MakeHideCompanyOptions = {
+  // Admin/owner-only on the FE; the backend independently enforces
+  // EditAccessLevel on PUT /crm/companies/{id}/hidden.
+  isTeamAdmin: () => boolean;
+  setHidden: (companyId: string, hidden: boolean) => Promise<unknown>;
+};
+
+export const makeHideCompanyAction = (options: MakeHideCompanyOptions) => {
+  const { isTeamAdmin, setHidden } = options;
+
+  const canExecute = (entity: EntityData): boolean =>
+    entity.type === 'crm_company' && isTeamAdmin();
+
+  const previewPanel = useMaybePreviewPanel();
+
+  const executeWithSoup = async (entities: EntityData[], soup: SoupState) => {
+    const entity = entities[0];
+    if (entity?.type !== 'crm_company') return;
+
+    // The row leaves (Hide) or joins (Unhide) the active list once soup
+    // refetches, so move focus to a neighbour first — same as delete.
+    const currentIndex = soup.focus.index();
+    const nextRow =
+      soup.items.at(currentIndex + 1) ?? soup.items.at(currentIndex - 1);
+    const inPreview = previewPanel !== undefined;
+
+    const hidden = entity.hidden;
+
+    soup.selection.clear();
+    if (nextRow) soup.focus.set(nextRow.id);
+
+    try {
+      await setHidden(entity.id, !hidden);
+      toast.success(hidden ? 'Unhidden' : 'Hidden');
+    } catch {
+      toast.failure(hidden ? 'Failed to unhide' : 'Failed to hide');
+    }
+
+    await restoreSoupFocus(nextRow?.id, inPreview);
+  };
+
+  return { canExecute, executeWithSoup };
+};

--- a/js/app/packages/app/component/next-soup/soup-view/create-soup-entity-actions.ts
+++ b/js/app/packages/app/component/next-soup/soup-view/create-soup-entity-actions.ts
@@ -8,6 +8,8 @@ import { fileTypeToBlockName, itemToBlockName } from '@core/constant/allBlocks';
 import { useUserId } from '@core/context/user';
 import { isMobile } from '@core/mobile/isMobile';
 import type { EntityData } from '@entity';
+import { useSetCompanyHiddenMutation } from '@queries/crm/companies';
+import { useIsTeamAdmin } from '@queries/team/teams';
 import {
   makeBlockSenderAction,
   makeCopyAction,
@@ -15,6 +17,7 @@ import {
   makeCopyEntityIdAction,
   makeCopyLinkAction,
   makeDeleteAction,
+  makeHideCompanyAction,
   makeMarkDoneAction,
   makeMarkSenderNoiseAction,
   makeMarkSenderSignalAction,
@@ -57,6 +60,8 @@ export function createSoupEntityActions(): {
   const analytics = useAnalytics();
   const userId = useUserId();
   const notificationSource = useGlobalNotificationSource();
+  const isTeamAdmin = useIsTeamAdmin();
+  const hiddenMutation = useSetCompanyHiddenMutation();
 
   const markDone = makeMarkDoneAction({
     userId: () => userId(),
@@ -80,6 +85,11 @@ export function createSoupEntityActions(): {
   const blockSenderAction = makeBlockSenderAction();
   const markSenderSignalAction = makeMarkSenderSignalAction();
   const markSenderNoiseAction = makeMarkSenderNoiseAction();
+  const hideCompanyAction = makeHideCompanyAction({
+    isTeamAdmin: () => isTeamAdmin(),
+    setHidden: (companyId, hidden) =>
+      hiddenMutation.mutateAsync({ companyId, hidden }),
+  });
 
   const buildActionGroups: BuildActionGroups = (
     soup,
@@ -288,6 +298,21 @@ export function createSoupEntityActions(): {
       });
     }
 
+    // CRM group: Hide / Unhide (admin/owner only, single company)
+    const crmItems: SoupEntityActionItem[] = [];
+
+    const singleEntity = entities.length === 1 ? entities[0] : undefined;
+    if (
+      singleEntity?.type === 'crm_company' &&
+      hideCompanyAction.canExecute(singleEntity)
+    ) {
+      crmItems.push({
+        id: 'hide-company',
+        label: singleEntity.hidden ? 'Unhide' : 'Hide',
+        onClick: handle(hideCompanyAction.executeWithSoup),
+      });
+    }
+
     // Delete group
     const deleteItems: SoupEntityActionItem[] = [];
 
@@ -300,7 +325,7 @@ export function createSoupEntityActions(): {
       });
     }
 
-    return [topItems, middleItems, senderItems, deleteItems]
+    return [topItems, middleItems, senderItems, crmItems, deleteItems]
       .filter((items) => items.length > 0)
       .map((items) => ({ items }));
   };


### PR DESCRIPTION
## Summary

Adds a right-click context-menu action on CRM company rows in next-soup to **Hide** / **Unhide** a company, gated to team admins/owners.

Right-clicking a company row now shows a **Hide** action for admins/owners. On the admin-only hidden-companies tab the same row shows **Unhide** instead — the label is derived per-row from the entity's `hidden` state. Members never see the action, and the backend independently enforces `EditAccessLevel` on `PUT /crm/companies/{id}/hidden`.

## How it works

- **New action factory** `make-hide-company-action.ts` follows the existing `make-*-action` shape (`canExecute` / `executeWithSoup`). `canExecute` returns true only for `crm_company` entities when `useIsTeamAdmin()`. `executeWithSoup` moves focus to a neighbouring row before the mutation (same approach as `make-delete-action`) so the cursor isn't stranded when the row leaves/joins the list on refetch, then toasts success/failure.
- **Wiring in `create-soup-entity-actions.ts`**: instantiates `useIsTeamAdmin()` and `useSetCompanyHiddenMutation()` alongside the existing hooks, adapts the mutation into a `setHidden(companyId, hidden)` thunk, and adds a single-entity `crm` group slotted between the sender group and the destructive Delete group (non-destructive styling, since the operation is reversible).

The existing `useSetCompanyHiddenMutation` already wipes the company email cache and invalidates soup + the company detail query, so the row leaves/returns to the list and any open panel reflects the new state.

## Notes

- Scoped to single-select for now (mirrors the Copy Link / Share gating); multi-select with a uniform-`hidden` check is a clean follow-up.