### PR TITLE
feat(chat): cap chat message height with expand/collapse

### DIFF
--- a/js/app/packages/core/component/AI/component/message/CollapsibleMessage.tsx
+++ b/js/app/packages/core/component/AI/component/message/CollapsibleMessage.tsx
@@ -1,0 +1,59 @@
+import CaretRight from '@phosphor/caret-right.svg?component-solid';
+import { cn } from '@ui';
+import { createSignal, type JSX, onCleanup, onMount, Show } from 'solid-js';
+
+// Max rendered height (px) before a message in the conversation collapses.
+// Mirrors the Tailwind `max-h-80` class applied when collapsed.
+const MAX_HEIGHT = 320;
+
+/**
+ * Wraps a rendered chat message and caps its height. When the content exceeds
+ * MAX_HEIGHT it collapses and shows a "Show more" button; the user can expand
+ * it to the full height and collapse it again.
+ *
+ * This is intended for the message chain (the rendered conversation) only — it
+ * must not be used around the chat input box.
+ */
+export function CollapsibleMessage(props: { children: JSX.Element }) {
+  const [expanded, setExpanded] = createSignal(false);
+  const [overflowing, setOverflowing] = createSignal(false);
+  let contentRef!: HTMLDivElement;
+
+  const measure = () => {
+    if (!contentRef) return;
+    setOverflowing(contentRef.scrollHeight > MAX_HEIGHT + 1);
+  };
+
+  onMount(() => {
+    measure();
+    const observer = new ResizeObserver(() => measure());
+    observer.observe(contentRef);
+    onCleanup(() => observer.disconnect());
+  });
+
+  const collapsed = () => overflowing() && !expanded();
+
+  return (
+    <div class="flex w-full min-w-0 flex-col">
+      <div
+        ref={contentRef}
+        class={cn('min-w-0', collapsed() && 'max-h-80 overflow-hidden')}
+      >
+        {props.children}
+      </div>
+      <Show when={overflowing()}>
+        <button
+          type="button"
+          class="mt-1 flex items-center gap-1 self-start text-xs text-ink-extra-muted hover:text-ink-muted"
+          onClick={() => setExpanded((prev) => !prev)}
+        >
+          <CaretRight
+            class="size-3 shrink-0 transition-transform"
+            classList={{ 'rotate-90': expanded() }}
+          />
+          <span>{expanded() ? 'Show less' : 'Show more'}</span>
+        </button>
+      </Show>
+    </div>
+  );
+}

--- a/js/app/packages/core/component/AI/component/message/UserMessage.tsx
+++ b/js/app/packages/core/component/AI/component/message/UserMessage.tsx
@@ -8,6 +8,7 @@ import { Button, Layer } from '@ui';
 import { createSignal, For, Match, Show, Switch } from 'solid-js';
 import { DEFAULT_MODEL } from '../../constant';
 import { ChatMessageMarkdown } from './ChatMessageMarkdown';
+import { CollapsibleMessage } from './CollapsibleMessage';
 import { EditableChatMessage } from './EditableChatMessage';
 
 // Function to insert soft hyphens into long words / urls / etc so that they won't lock the width
@@ -120,10 +121,12 @@ export function UserMessage(props: {
             <Match when={!isEditing()}>
               <Layer depth={0}>
                 <div class="relative ml-auto max-w-[calc(100%-8rem)] whitespace-pre-line overflow-hidden rounded-lg border border-edge-muted bg-surface px-3 py-2 text-ink">
-                  <ChatMessageMarkdown
-                    generating={() => false}
-                    text={content()!}
-                  />
+                  <CollapsibleMessage>
+                    <ChatMessageMarkdown
+                      generating={() => false}
+                      text={content()!}
+                    />
+                  </CollapsibleMessage>
                   <Show when={props.edit}>
                     <div class="absolute top-1 right-1 opacity-0 transition-opacity group-hover:opacity-100">
                       <Button

--- a/js/bun.lock
+++ b/js/bun.lock
@@ -846,7 +846,7 @@
 
     "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
 
-    "@inkibra/tauri-plugins": ["@inkibra/tauri-plugins@github:macro-inc/tauri-plugins#26537c8", { "dependencies": { "react": "^18.3.1", "react-dom": "^18.3.1" } }, "macro-inc-tauri-plugins-26537c8", "sha512-6p5xQAkS6Uw6J8Uh0vlj6MjKZXWps5E1Gu0hciBFq1E2BfPBZAgdeeafKnR3diNb4SXWK0JML49nAr+o5PhwKw=="],
+    "@inkibra/tauri-plugins": ["@inkibra/tauri-plugins@github:macro-inc/tauri-plugins#26537c8", { "dependencies": { "react": "^18.3.1", "react-dom": "^18.3.1" } }, "macro-inc-tauri-plugins-26537c8"],
 
     "@inquirer/external-editor": ["@inquirer/external-editor@1.0.3", "", { "dependencies": { "chardet": "^2.1.1", "iconv-lite": "^0.7.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA=="],
 
@@ -2556,7 +2556,7 @@
 
     "pathval": ["pathval@2.0.1", "", {}, "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ=="],
 
-    "pdfjs-dist": ["pdfjs-dist@github:macro-inc/pdf.js#f9b2ce6", { "dependencies": { "dommatrix": "^1.0.3", "web-streams-polyfill": "^3.2.1" }, "peerDependencies": { "worker-loader": "^3.0.8" }, "optionalPeers": ["worker-loader"] }, "macro-inc-pdf.js-f9b2ce6", "sha512-HDFaPbCxLG2GHpf1smUG97nku5aPGBGaCcIbK05dGdp07TBLUlDcXsM4WcE82mO5W4RBPIBVYobX5N/6M6NFrA=="],
+    "pdfjs-dist": ["pdfjs-dist@github:macro-inc/pdf.js#f9b2ce6", { "dependencies": { "dommatrix": "^1.0.3", "web-streams-polyfill": "^3.2.1" }, "peerDependencies": { "worker-loader": "^3.0.8" }, "optionalPeers": ["worker-loader"] }, "macro-inc-pdf.js-f9b2ce6"],
 
     "performance-now": ["performance-now@2.1.0", "", {}, "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="],
 


### PR DESCRIPTION
Caps long messages in the rendered chat conversation at a max height with a Show more/Show less toggle, leaving the chat input box untouched.

Task: macro-1883

🤖 Generated with [Claude Code](https://claude.com/claude-code)