### PR TITLE
feat(crm): company Hide/Unhide action and command-menu recency filter

### DIFF
--- a/js/app/packages/app/component/command/useCommandItems.ts
+++ b/js/app/packages/app/component/command/useCommandItems.ts
@@ -83,6 +83,19 @@ function isAskAiItem(item: CommandMenuItem): item is AskAiItem {
   return item.kind === 'ask-ai';
 }
 
+/**
+ * Entities shown in the no-query recency list. Unopened CRM companies (no
+ * `viewedAt`) are excluded so the recency view sorts companies purely by when
+ * the user last opened them — without this they'd fall back to `updatedAt` and
+ * surface companies the user has never touched. They stay reachable via search.
+ */
+function showInRecencyList(item: CommandMenuItem): boolean {
+  if (item.bucket === 'crm_company') {
+    return item.timestamps.viewedAt != null;
+  }
+  return true;
+}
+
 /** Categories that surface a "Search for [query]" row in the command menu */
 const SEARCHABLE_CATEGORIES: ReadonlySet<CategoryFilter> = new Set([
   'all',
@@ -375,7 +388,9 @@ export function useCommandItems(
     const q = query();
     const items = categoryItems();
 
-    const ranked = q ? search()(items, q).map((result) => result.item) : items;
+    const ranked = q
+      ? search()(items, q).map((result) => result.item)
+      : items.filter(showInRecencyList);
 
     if (shouldShowSearchRow(q)) {
       // With no direct results the menu would only offer search, so also

--- a/js/app/packages/app/component/next-soup/actions/index.ts
+++ b/js/app/packages/app/component/next-soup/actions/index.ts
@@ -4,6 +4,7 @@ export { makeCopyBranchNameAction } from './make-copy-branch-name-action';
 export { makeCopyEntityIdAction } from './make-copy-entity-id-action';
 export { makeCopyLinkAction } from './make-copy-link-action';
 export { makeDeleteAction } from './make-delete-action';
+export { makeHideCompanyAction } from './make-hide-company-action';
 export { makeMarkDoneAction } from './make-mark-done-action';
 export { makeMarkSenderSignalAction } from './make-mark-sender-important-action';
 export { makeMarkSenderNoiseAction } from './make-mark-sender-noise-action';

--- a/js/app/packages/app/component/next-soup/actions/make-hide-company-action.ts
+++ b/js/app/packages/app/component/next-soup/actions/make-hide-company-action.ts
@@ -1,0 +1,49 @@
+import { useMaybePreviewPanel } from '@app/component/PreviewPanel';
+import { toast } from '@core/component/Toast/Toast';
+import type { EntityData } from '@entity';
+import type { SoupState } from '../create-soup-state';
+import { restoreSoupFocus } from '../utils';
+
+type MakeHideCompanyOptions = {
+  // Admin/owner-only on the FE; the backend independently enforces
+  // EditAccessLevel on PUT /crm/companies/{id}/hidden.
+  isTeamAdmin: () => boolean;
+  setHidden: (companyId: string, hidden: boolean) => Promise<unknown>;
+};
+
+export const makeHideCompanyAction = (options: MakeHideCompanyOptions) => {
+  const { isTeamAdmin, setHidden } = options;
+
+  const canExecute = (entity: EntityData): boolean =>
+    entity.type === 'crm_company' && isTeamAdmin();
+
+  const previewPanel = useMaybePreviewPanel();
+
+  const executeWithSoup = async (entities: EntityData[], soup: SoupState) => {
+    const entity = entities[0];
+    if (entity?.type !== 'crm_company') return;
+
+    // The row leaves (Hide) or joins (Unhide) the active list once soup
+    // refetches, so move focus to a neighbour first — same as delete.
+    const currentIndex = soup.focus.index();
+    const nextRow =
+      soup.items.at(currentIndex + 1) ?? soup.items.at(currentIndex - 1);
+    const inPreview = previewPanel !== undefined;
+
+    const hidden = entity.hidden;
+
+    soup.selection.clear();
+    if (nextRow) soup.focus.set(nextRow.id);
+
+    try {
+      await setHidden(entity.id, !hidden);
+      toast.success(hidden ? 'Unhidden' : 'Hidden');
+    } catch {
+      toast.failure(hidden ? 'Failed to unhide' : 'Failed to hide');
+    }
+
+    await restoreSoupFocus(nextRow?.id, inPreview);
+  };
+
+  return { canExecute, executeWithSoup };
+};

--- a/js/app/packages/app/component/next-soup/soup-view/create-soup-entity-actions.ts
+++ b/js/app/packages/app/component/next-soup/soup-view/create-soup-entity-actions.ts
@@ -8,6 +8,8 @@ import { fileTypeToBlockName, itemToBlockName } from '@core/constant/allBlocks';
 import { useUserId } from '@core/context/user';
 import { isMobile } from '@core/mobile/isMobile';
 import type { EntityData } from '@entity';
+import { useSetCompanyHiddenMutation } from '@queries/crm/companies';
+import { useIsTeamAdmin } from '@queries/team/teams';
 import {
   makeBlockSenderAction,
   makeCopyAction,
@@ -15,6 +17,7 @@ import {
   makeCopyEntityIdAction,
   makeCopyLinkAction,
   makeDeleteAction,
+  makeHideCompanyAction,
   makeMarkDoneAction,
   makeMarkSenderNoiseAction,
   makeMarkSenderSignalAction,
@@ -57,6 +60,8 @@ export function createSoupEntityActions(): {
   const analytics = useAnalytics();
   const userId = useUserId();
   const notificationSource = useGlobalNotificationSource();
+  const isTeamAdmin = useIsTeamAdmin();
+  const hiddenMutation = useSetCompanyHiddenMutation();
 
   const markDone = makeMarkDoneAction({
     userId: () => userId(),
@@ -80,6 +85,11 @@ export function createSoupEntityActions(): {
   const blockSenderAction = makeBlockSenderAction();
   const markSenderSignalAction = makeMarkSenderSignalAction();
   const markSenderNoiseAction = makeMarkSenderNoiseAction();
+  const hideCompanyAction = makeHideCompanyAction({
+    isTeamAdmin: () => isTeamAdmin(),
+    setHidden: (companyId, hidden) =>
+      hiddenMutation.mutateAsync({ companyId, hidden }),
+  });
 
   const buildActionGroups: BuildActionGroups = (
     soup,
@@ -288,6 +298,21 @@ export function createSoupEntityActions(): {
       });
     }
 
+    // CRM group: Hide / Unhide (admin/owner only, single company)
+    const crmItems: SoupEntityActionItem[] = [];
+
+    const singleEntity = entities.length === 1 ? entities[0] : undefined;
+    if (
+      singleEntity?.type === 'crm_company' &&
+      hideCompanyAction.canExecute(singleEntity)
+    ) {
+      crmItems.push({
+        id: 'hide-company',
+        label: singleEntity.hidden ? 'Unhide' : 'Hide',
+        onClick: handle(hideCompanyAction.executeWithSoup),
+      });
+    }
+
     // Delete group
     const deleteItems: SoupEntityActionItem[] = [];
 
@@ -300,7 +325,7 @@ export function createSoupEntityActions(): {
       });
     }
 
-    return [topItems, middleItems, senderItems, deleteItems]
+    return [topItems, middleItems, senderItems, crmItems, deleteItems]
       .filter((items) => items.length > 0)
       .map((items) => ({ items }));
   };


### PR DESCRIPTION
## Summary

Two CRM-company frontend changes.

### 1. Hide / Unhide soup context action for companies

Adds a `Hide` / `Unhide` action to the soup context menu for CRM companies.

- Admin/owner only on the FE (`useIsTeamAdmin`); the backend independently enforces `EditAccessLevel` on `PUT /crm/companies/{id}/hidden`.
- Single-company only.
- Toggles `hidden` via `useSetCompanyHiddenMutation`, with a success/failure toast.
- Moves focus to a neighbouring row before the mutation — the row leaves (Hide) or joins (Unhide) the active list once soup refetches — mirroring the delete action's focus handling.
- Surfaced as its own group, between the sender actions and delete.

### 2. Command menu recency: hide unopened companies

The command menu's quick-access pool pulls up to 500 visible companies. Companies the user has never opened have no `viewedAt`, so they fell back to `updatedAt` and surfaced in the no-query recency list — showing companies the user has never touched.

Unopened companies (`viewedAt == null`) are now filtered out of the **no-query** recency list, so companies sort purely by when the user last opened them. They remain fully reachable once a search term is typed.

Scoped to the command menu only — `QuickAccessProvider` is unchanged, so @-mentions and the move-to menu keep the full company pool with the `updatedAt` fallback.
