### PR TITLE
chg(sps): log document_id on sync extract enqueue and index completion

### DIFF
--- a/rust/cloud-storage/search_processing_service/src/api/internal/extract_sync.rs
+++ b/rust/cloud-storage/search_processing_service/src/api/internal/extract_sync.rs
@@ -53,6 +53,12 @@ pub async fn handler(
     State(ctx): State<ApiContext>,
     extract::Json(req): extract::Json<ExtractSyncRequest>,
 ) -> Result<Response, Response> {
+    let document_ids: Vec<&str> = req
+        .documents
+        .iter()
+        .map(|d| d.document_id.as_str())
+        .collect();
+    tracing::info!(?document_ids, "extract_sync received");
     let messages: Vec<SearchQueueMessage> = documents_to_messages(req.documents);
     ctx.sqs_client
         .bulk_send_message_to_search_event_queue(messages)

--- a/rust/cloud-storage/search_processing_service/src/process/document/raw_document.rs
+++ b/rust/cloud-storage/search_processing_service/src/process/document/raw_document.rs
@@ -340,7 +340,9 @@ pub async fn update_search_with_sync_document(
 
     let upserts = generate_upserts(document_info, result).context("unable to generate upserts")?;
 
+    let chunk_count = upserts.len();
     upsert_document(opensearch_client, search_extractor_message, upserts).await?;
+    tracing::info!(document_id = %document_id, chunk_count, "sync document indexed");
 
     Ok(())
 }


### PR DESCRIPTION
Adds two INFO logs on the sync-document indexing path: `extract_sync received` (with `document_ids`) when sps is asked to index, and `sync document indexed` (with `document_id` and `chunk_count`) after the OpenSearch upsert. Both emit `document_id` as an explicit event field since the existing span-field `document_id` isn't searchable in prod, so a sync doc can be traced end to end and its indexing latency split between the external `/extract_sync` trigger and in-service processing.
