### PR TITLE
fix(search): skip unknown <m-*> tags instead of failing channel message indexing

### DIFF
--- a/rust/cloud-storage/mention_utils/src/parse.rs
+++ b/rust/cloud-storage/mention_utils/src/parse.rs
@@ -3,9 +3,9 @@ use macro_user_id::user_id::BorrowedUserIdStr;
 use nom::{
     Finish, IResult, Parser,
     branch::alt,
-    bytes::complete::{tag, tag_no_case, take_till1},
+    bytes::complete::{tag, tag_no_case, take_till1, take_while1},
     character::complete::anychar,
-    combinator::{eof, peek, recognize},
+    combinator::{eof, peek, recognize, verify},
     multi::{many_till, many0},
     sequence::delimited,
 };
@@ -151,6 +151,42 @@ fn parse_xml_tag(s: &str) -> IResult<&str, XmlTag<'_>> {
     .parse(s)
 }
 
+fn is_recognized_tag_name(name: &str) -> bool {
+    [
+        ParsedLink::TAG_NAME,
+        ParsedDocumentMention::TAG_NAME,
+        ParsedUserMention::TAG_NAME,
+        ParsedContactMention::TAG_NAME,
+        ParsedDateMention::TAG_NAME,
+        ParsedGroupMention::TAG_NAME,
+    ]
+    .iter()
+    .any(|recognized| recognized.eq_ignore_ascii_case(name))
+}
+
+/// Consumes and discards an `<m-*>…</m-*>` tag whose name is not one of the
+/// recognized mention tags. Tags with a recognized name are rejected here so a
+/// recognized tag carrying malformed content still surfaces as a parse error.
+fn parse_unknown_xml_tag(s: &str) -> IResult<&str, ()> {
+    let (after_open, name) = delimited(
+        tag("<"),
+        verify(
+            recognize((
+                tag_no_case("m-"),
+                take_while1(|c: char| c.is_ascii_alphanumeric() || c == '-'),
+            )),
+            |name: &str| !is_recognized_tag_name(name),
+        ),
+        tag(">"),
+    )
+    .parse(s)?;
+
+    let (rest, _) =
+        many_till(anychar, (tag("</"), tag_no_case(name), tag(">"))).parse(after_open)?;
+
+    Ok((rest, ()))
+}
+
 #[derive(Debug)]
 pub enum TextSegment<'de> {
     Xml(XmlTag<'de>),
@@ -167,14 +203,15 @@ pub struct ParseErr(#[from] nom::error::Error<String>);
 impl<'de> ParsedXmlText<'de> {
     pub fn parse(s: &'de str) -> Result<Self, ParseErr> {
         let (_, (out, _)) = many0(alt((
-            parse_xml_tag.map(TextSegment::Xml),
-            take_till1(|c| c == '<').map(TextSegment::Plain),
+            parse_xml_tag.map(|xml| Some(TextSegment::Xml(xml))),
+            take_till1(|c| c == '<').map(|text| Some(TextSegment::Plain(text))),
+            parse_unknown_xml_tag.map(|()| None),
         )))
         .and(eof)
         .parse(s)
         .finish()
         .map_err(|e| e.cloned())?;
-        Ok(ParsedXmlText(out))
+        Ok(ParsedXmlText(out.into_iter().flatten().collect()))
     }
 }
 

--- a/rust/cloud-storage/mention_utils/src/parse.rs
+++ b/rust/cloud-storage/mention_utils/src/parse.rs
@@ -7,7 +7,7 @@ use nom::{
     character::complete::anychar,
     combinator::{eof, peek, recognize, verify},
     multi::{many_till, many0},
-    sequence::delimited,
+    sequence::{delimited, preceded},
 };
 use serde::Deserialize;
 use std::{
@@ -164,11 +164,12 @@ fn is_recognized_tag_name(name: &str) -> bool {
     .any(|recognized| recognized.eq_ignore_ascii_case(name))
 }
 
-/// Consumes and discards an `<m-*>…</m-*>` tag whose name is not one of the
-/// recognized mention tags. Tags with a recognized name are rejected here so a
-/// recognized tag carrying malformed content still surfaces as a parse error.
+/// Consumes and discards an unrecognized `<m-*>` tag, either self-closing
+/// (`<m-*/>`) or a `<m-*>…</m-*>` pair. Tags with a recognized name are rejected
+/// here so a recognized tag carrying malformed content still surfaces as a parse
+/// error.
 fn parse_unknown_xml_tag(s: &str) -> IResult<&str, ()> {
-    let (after_open, name) = delimited(
+    let (after_name, name) = preceded(
         tag("<"),
         verify(
             recognize((
@@ -177,12 +178,18 @@ fn parse_unknown_xml_tag(s: &str) -> IResult<&str, ()> {
             )),
             |name: &str| !is_recognized_tag_name(name),
         ),
-        tag(">"),
     )
     .parse(s)?;
 
-    let (rest, _) =
-        many_till(anychar, (tag("</"), tag_no_case(name), tag(">"))).parse(after_open)?;
+    let (rest, _) = alt((
+        tag("/>").map(|_| ()),
+        (
+            tag(">"),
+            many_till(anychar, (tag("</"), tag_no_case(name), tag(">"))),
+        )
+            .map(|_| ()),
+    ))
+    .parse(after_name)?;
 
     Ok((rest, ()))
 }

--- a/rust/cloud-storage/mention_utils/src/tests.rs
+++ b/rust/cloud-storage/mention_utils/src/tests.rs
@@ -670,3 +670,53 @@ fn parse_group_mention_with_user_mention() {
         assert_eq!(email.as_ref(), "a@b.com");
     });
 }
+
+// =============================================================================
+// Unknown / unrecognized tag tests
+// =============================================================================
+
+#[test]
+fn parse_await_tag_is_skipped() {
+    let input = r#"<m-await>{"awaitId":"a1","text":"Macro is thinking…","inline":true}</m-await>"#;
+    let out = ParsedXmlText::parse(input).unwrap();
+    assert!(out.0.is_empty());
+}
+
+#[test]
+fn parse_await_tag_with_surrounding_text() {
+    let input = r#"before <m-await>{"text":"Macro is thinking…","inline":true}</m-await> after"#;
+    let out = ParsedXmlText::parse(input).unwrap();
+    assert_matches!(
+        out.0,
+        [TextSegment::Plain("before "), TextSegment::Plain(" after"),]
+    );
+}
+
+#[test]
+fn parse_empty_await_tag_is_skipped() {
+    let input = r#"hi <m-await></m-await>"#;
+    let out = ParsedXmlText::parse(input).unwrap();
+    assert_matches!(out.0, [TextSegment::Plain("hi ")]);
+}
+
+#[test]
+fn parse_arbitrary_unknown_tag_is_skipped() {
+    let input = r#"hello <m-foo>{"bar":1}</m-foo> world"#;
+    let out = ParsedXmlText::parse(input).unwrap();
+    assert_matches!(
+        out.0,
+        [TextSegment::Plain("hello "), TextSegment::Plain(" world"),]
+    );
+}
+
+#[test]
+fn parse_unknown_tag_mixed_with_recognized() {
+    let input = r#"<m-await>{"text":"thinking"}</m-await> Hi <m-user-mention>{"userId":"macro|a@b.com","email":"a@b.com"}</m-user-mention>"#;
+    let out = ParsedXmlText::parse(input).unwrap();
+    assert_matches!(out.0, [
+        TextSegment::Plain(" Hi "),
+        TextSegment::Xml(XmlTag::User(ParsedUserMention { email, .. })),
+    ] => {
+        assert_eq!(email.as_ref(), "a@b.com");
+    });
+}

--- a/rust/cloud-storage/mention_utils/src/tests.rs
+++ b/rust/cloud-storage/mention_utils/src/tests.rs
@@ -710,6 +710,23 @@ fn parse_arbitrary_unknown_tag_is_skipped() {
 }
 
 #[test]
+fn parse_self_closing_unknown_tag_is_skipped() {
+    let input = r#"hello <m-foo/> world"#;
+    let out = ParsedXmlText::parse(input).unwrap();
+    assert_matches!(
+        out.0,
+        [TextSegment::Plain("hello "), TextSegment::Plain(" world"),]
+    );
+}
+
+#[test]
+fn parse_self_closing_unknown_tag_alone_is_skipped() {
+    let input = r#"<m-await/>"#;
+    let out = ParsedXmlText::parse(input).unwrap();
+    assert!(out.0.is_empty());
+}
+
+#[test]
 fn parse_unknown_tag_mixed_with_recognized() {
     let input = r#"<m-await>{"text":"thinking"}</m-await> Hi <m-user-mention>{"userId":"macro|a@b.com","email":"a@b.com"}</m-user-mention>"#;
     let out = ParsedXmlText::parse(input).unwrap();


### PR DESCRIPTION
A channel message containing an `<m-await>` node (or any unknown `<m-*>` tag) failed to parse in `mention_utils`, so `process_channel_message_update` returned `Err` and the SQS message was retried into the DLQ instead of being indexed. This skips unrecognized `<m-*>` tags during parsing while leaving recognized tags, malformed-JSON cases, and stray `<` exactly as before; it also fixes the same failure in push-notification body rendering, which shares the parser.