### PR TITLE
feat(email): add references section to side panel

### DIFF
--- a/js/app/packages/block-email/component/sidepanel/EmailSidePanelSections.tsx
+++ b/js/app/packages/block-email/component/sidepanel/EmailSidePanelSections.tsx
@@ -3,6 +3,7 @@ import { EntityPropertiesSection } from '@app/component/side-panel/properties';
 import { References } from '@core/component/References';
 import type { Property } from '@property/types';
 import { useAttachmentReferencesQuery } from '@queries/storage/attachment-references';
+import type { ItemType } from '@service-storage/client';
 import { Show, Suspense } from 'solid-js';
 import { useEmailContext } from '../EmailContext';
 
@@ -52,10 +53,15 @@ export function EmailSidePanelSections(props: EmailSidePanelSectionsProps) {
   );
 }
 
+// Email threads are stored as the "thread" entity type in the references
+// system (ReferencedShareItemType::EmailThread -> "thread" and the mentions
+// plugin maps email -> thread), so query/render with "thread", not "email".
+const EMAIL_REFERENCE_ENTITY_TYPE = 'thread' as ItemType;
+
 function ReferencesSectionConditional(props: { threadId: string }) {
   const references = useAttachmentReferencesQuery(
     () => props.threadId,
-    () => 'email'
+    () => EMAIL_REFERENCE_ENTITY_TYPE
   );
 
   const count = () => references.data?.length ?? 0;
@@ -69,7 +75,10 @@ function ReferencesSectionConditional(props: { threadId: string }) {
       >
         <Suspense fallback={<SidePanel.Loading />}>
           <div class="text-xs">
-            <References documentId={props.threadId} entityType="email" />
+            <References
+              documentId={props.threadId}
+              entityType={EMAIL_REFERENCE_ENTITY_TYPE}
+            />
           </div>
         </Suspense>
       </SidePanel.Section>

--- a/js/app/packages/block-email/component/sidepanel/EmailSidePanelSections.tsx
+++ b/js/app/packages/block-email/component/sidepanel/EmailSidePanelSections.tsx
@@ -1,7 +1,9 @@
 import { SidePanel } from '@app/component/side-panel';
 import { EntityPropertiesSection } from '@app/component/side-panel/properties';
+import { References } from '@core/component/References';
 import type { Property } from '@property/types';
-import { Suspense } from 'solid-js';
+import { useAttachmentReferencesQuery } from '@queries/storage/attachment-references';
+import { Show, Suspense } from 'solid-js';
 import { useEmailContext } from '../EmailContext';
 
 interface EmailSidePanelSectionsProps {
@@ -45,7 +47,37 @@ export function EmailSidePanelSections(props: EmailSidePanelSectionsProps) {
           />
         </Suspense>
       </SidePanel.Section>
+      <ReferencesSectionConditional threadId={props.threadId} />
     </>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// References Section (conditional)
+// ─────────────────────────────────────────────────────────────────────────────
+
+function ReferencesSectionConditional(props: { threadId: string }) {
+  const references = useAttachmentReferencesQuery(
+    () => props.threadId,
+    () => 'email'
+  );
+
+  const count = () => references.data?.length ?? 0;
+
+  return (
+    <Show when={count() > 0}>
+      <SidePanel.Section
+        id="references"
+        title={<SidePanel.CountTitle label="References" count={count()} />}
+        order={50}
+      >
+        <Suspense fallback={<SidePanel.Loading />}>
+          <div class="text-xs">
+            <References documentId={props.threadId} entityType="email" />
+          </div>
+        </Suspense>
+      </SidePanel.Section>
+    </Show>
   );
 }
 

--- a/js/app/packages/block-email/component/sidepanel/EmailSidePanelSections.tsx
+++ b/js/app/packages/block-email/component/sidepanel/EmailSidePanelSections.tsx
@@ -52,10 +52,6 @@ export function EmailSidePanelSections(props: EmailSidePanelSectionsProps) {
   );
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
-// References Section (conditional)
-// ─────────────────────────────────────────────────────────────────────────────
-
 function ReferencesSectionConditional(props: { threadId: string }) {
   const references = useAttachmentReferencesQuery(
     () => props.threadId,


### PR DESCRIPTION
## What

Adds the **References** section to the email block's side panel. The email block was the only block side panel missing it — the markdown and call blocks already render a References section.

## How

- Imports the shared `References` component (`@core/component/References`) and `useAttachmentReferencesQuery` (`@queries/storage/attachment-references`).
- Adds a `ReferencesSectionConditional` that queries attachment references for the thread with `entityType="email"` and renders a `SidePanel.Section` (id `references`, `order={50}`) only when there is at least one reference.
- Mirrors the existing call block implementation (`block-call/.../CallSidePanelSections.tsx`) for consistency.

## Notes

The section is conditional — it only appears when the thread has one or more references, matching the behavior of the markdown and call blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kody1TFjHiqVeF2Pfopn3F)_