### PR TITLE
Fix typos and grammar issues in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ For each block, we studied the best prior art and tried to make it even better. 
 
 | Block | What it does |
 | --- | --- |
-| [Email](https://docs.macro.com/product/email) | Multi-account unified inbox, keyboard shortcuts, and shared inboxes. Gmail. |
+| [Email](https://docs.macro.com/product/email) | Multi-account unified inbox, keyboard shortcuts, and shared inboxes. |
 | [Messages](https://docs.macro.com/product/channels) | Channels and direct messages designed for focused technical discussions. |
 | [Tasks](https://docs.macro.com/product/tasks) | Linear-inspired tasks, tightly integrated with channels, email, and agents. |
 | [Docs](https://docs.macro.com/product/docs) | Real-time collaborative, markdown-native docs built on CRDTs, with @mentions. |
@@ -94,7 +94,7 @@ Core contributors: [@whutchinson98](https://github.com/whutchinson98), [@gbirman
   <img width="100%" alt="Watch the Macro demo" src="https://img.youtube.com/vi/hZRin23hRKc/maxresdefault.jpg" />
 </a>
 
-Want to see it in the wild? Watch [how Desync runs their engineer-heavy company on Macro](https://www.youtube.com/watch?v=fZFIW2toHwk).
+Want to see it in the wild? Watch [how Desync runs their engineering-heavy company on Macro](https://www.youtube.com/watch?v=fZFIW2toHwk).
 
 # Security
 


### PR DESCRIPTION
## Summary
Fixed two typos and grammar issues found in the README.md file.

## Changes
1. **Line 41 - Removed stray text**: Removed the incomplete "Gmail." at the end of the Email block description in the feature table. The sentence now properly ends with "shared inboxes." instead of "shared inboxes. Gmail."

2. **Line 97 - Grammar improvement**: Changed "engineer-heavy" to "engineering-heavy" for better grammar in the sentence about how Desync runs their company on Macro.

## Details
- **Spelling mistakes**: None found
- **Grammar issues**: 1 (engineer-heavy → engineering-heavy)
- **Punctuation/formatting errors**: 1 (stray "Gmail." text removed)

These are minor but important corrections that improve the clarity and professionalism of the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)