### PR TITLE
Fix README typos (macro-agent-test)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The docs are open source too — the site is built from [`docs/`](docs) in this 
 
 # About
 
-Macro has raised $30m led by a16z. We are based in NYC.
+Macro has raised $30m, led by a16z. We are based in NYC.
 
 Core contributors: [@whutchinson98](https://github.com/whutchinson98), [@gbirman](https://github.com/gbirman), [@synoet](https://github.com/synoet), [@sedson](https://github.com/sedson), [@evanhutnik](https://github.com/evanhutnik), [@peterchinman](https://github.com/peterchinman), [@ehayes2000](https://github.com/ehayes2000), [@seanaye](https://github.com/seanaye), [@dev-rb](https://github.com/dev-rb), [@danielkweon](https://github.com/danielkweon), and [@aquaductape](https://github.com/aquaductape).
 


### PR DESCRIPTION
## Summary
Fixed grammar typo in README.

## Changes
- `$30m led by a16z` → `$30m, led by a16z` (added missing comma)

## Test plan
- Verified README renders correctly
- No functional changes, documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)