### PR TITLE
fix(cmd-k): seed typed query into fresh search view

### DIFF
--- a/js/app/packages/app/component/command/CommandMenu.tsx
+++ b/js/app/packages/app/component/command/CommandMenu.tsx
@@ -315,6 +315,9 @@ export function CommandMenuInner(props: {
         {
           type: 'component',
           id: 'search',
+          // Opening search into an existing split otherwise drops these params
+          // and the field mounts empty. Entry state still wins on back/forward.
+          preserveParams: true,
           params: {
             initialQuery: item.query,
             initialFilters: filters,


### PR DESCRIPTION
cmd-k → "Search for X" opened the search view but left the text field empty unless a search split was already open. Opening search into an existing split goes through reattach, which strips `content.params` before the component mounts (added in #4178 so documents don't re-apply a stale initial snapshot on re-navigation) — so `initialQuery` was dropped. Marking only the cmd-k search content `preserveParams: true` keeps its query/filters through that navigation; entry state still wins on back/forward, and #4178's document behavior is untouched. 
