### PR TITLE
disable background throttling

### DIFF
--- a/js/app/tauri/src-tauri/tauri.conf.json
+++ b/js/app/tauri/src-tauri/tauri.conf.json
@@ -6,8 +6,14 @@
   "build": {
     "frontendDist": "../../packages/app/dist",
     "devUrl": "http://localhost:3000",
-    "beforeDevCommand": { "script": "just dev-tauri", "cwd": "../.." },
-    "beforeBuildCommand": { "script": "just build-tauri", "cwd": "../.." }
+    "beforeDevCommand": {
+      "script": "just dev-tauri",
+      "cwd": "../.."
+    },
+    "beforeBuildCommand": {
+      "script": "just build-tauri",
+      "cwd": "../.."
+    }
   },
   "app": {
     "windows": [
@@ -16,7 +22,8 @@
         "width": 800,
         "height": 600,
         "resizable": true,
-        "fullscreen": false
+        "fullscreen": false,
+        "backgroundThrottling": "disabled"
       }
     ],
     "security": {
@@ -53,24 +60,34 @@
     "deep-link": {
       "mobile": [
         {
-          "scheme": ["macro"],
+          "scheme": [
+            "macro"
+          ],
           "appLink": false
         },
         {
           "host": "macro.com",
-          "pathPrefix": ["/app"]
+          "pathPrefix": [
+            "/app"
+          ]
         },
         {
           "host": "dev.macro.com",
-          "pathPrefix": ["/app"]
+          "pathPrefix": [
+            "/app"
+          ]
         },
         {
           "host": "staging.macro.com",
-          "pathPrefix": ["/app"]
+          "pathPrefix": [
+            "/app"
+          ]
         }
       ],
       "desktop": {
-        "schemes": ["macro"]
+        "schemes": [
+          "macro"
+        ]
       }
     }
   }


### PR DESCRIPTION
This PR attempts to fix an issue with tauri websockets where the FE can be suspended but the tungstenite socket is still connected and receiving messages.

Because the websocket plugin is implemented as fire and forget with no ack or backpressure this causes messages to be silently dropped from the perspective of the js frontend.

By preventing webview suspension (ios 17+) we can hopefully circumvent this situation without a more invasive fix. 
