### PR TITLE
fix(tauri): platform fetch support for relative asset urls

### DIFF
--- a/js/app/packages/app/index.tsx
+++ b/js/app/packages/app/index.tsx
@@ -7,7 +7,10 @@ import '@fontsource-variable/playfair-display';
 import { initializeLexical } from '@core/component/LexicalMarkdown/init';
 import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import { getPlatform, isTauri } from '@core/util/platform';
-import { platformFetch } from '@core/util/platformFetch';
+import {
+  platformFetch,
+  setPlatformBrowserFetch,
+} from '@core/util/platformFetch';
 import { initMonochromeIcons } from '@ui/utils/monochromeIcons';
 import { ErrorBoundary, render } from 'solid-js/web';
 import { FatalError } from './component/FatalError';
@@ -17,6 +20,9 @@ import { Root } from './component/Root';
 // Skip localhost requests (dev server) to avoid breaking HMR
 if (isTauri()) {
   const originalFetch = window.fetch;
+  // platformFetch routes network requests through Tauri's HTTP client, but
+  // local app assets still need the WebView's original fetch for tauri://.
+  setPlatformBrowserFetch(originalFetch.bind(window));
   window.fetch = new Proxy(originalFetch, {
     apply: (target, thisArg, args) => {
       const url = args[0];

--- a/js/app/packages/core/util/platformFetch.ts
+++ b/js/app/packages/core/util/platformFetch.ts
@@ -1,12 +1,42 @@
 import { isTauri } from './platform';
 
-async function acquireFetch() {
-  // @ts-ignore: tauri adds this on the window instance
-  if (isTauri()) {
+let browserFetch: typeof fetch | undefined;
+
+export function setPlatformBrowserFetch(fetchImpl: typeof fetch) {
+  browserFetch = fetchImpl;
+}
+
+function getBrowserFetch(): typeof fetch {
+  if (browserFetch) return browserFetch;
+  if (typeof window !== 'undefined') return window.fetch.bind(window);
+  if (globalThis.fetch) return globalThis.fetch.bind(globalThis);
+  throw new Error('fetch is not available');
+}
+
+function inputUrl(input: RequestInfo | URL) {
+  if (input instanceof Request) return input.url;
+  if (input instanceof URL) return input.href;
+  return input;
+}
+
+function isNetworkUrl(input: RequestInfo | URL) {
+  try {
+    const url = new URL(inputUrl(input), window.location.href);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+async function acquireFetch(input: RequestInfo | URL) {
+  // Local Tauri assets are served through the WebView protocol handler. The
+  // Tauri HTTP plugin only supports network URLs and rejects tauri:// URLs,
+  // including relative asset URLs resolved against the tauri:// app origin.
+  if (isTauri() && isNetworkUrl(input)) {
     const { fetch } = await import('@tauri-apps/plugin-http');
     return fetch;
   }
-  return window.fetch;
+  return getBrowserFetch();
 }
 
 // async function acquireWebsocket() {
@@ -19,8 +49,8 @@ async function acquireFetch() {
 
 // export const connectPlatformWebsocket: ReturnType<typeof WebSocket["conne"]
 
-// wrapper around window.fetch which just forwards args to fetch on the web.
-// In tauri environments this forwards requests into the tauri http client
+// Wrapper around fetch which forwards network requests through the Tauri HTTP
+// client in Tauri environments. Local app assets stay on the WebView fetch.
 export const platformFetch: typeof window.fetch = (url, opts) => {
-  return acquireFetch().then((f) => f(url, opts));
+  return acquireFetch(url).then((f) => f(url, opts));
 };


### PR DESCRIPTION
Extends `platformFetch` to also account for relative asset urls.  This fixes a bug where creating a md document would fail in tauri app.