### PR TITLE
fix(chat): persist model selector draft across reloads (macro-1966)

### DIFF
--- a/js/app/packages/app/component/SoupChatInput.tsx
+++ b/js/app/packages/app/component/SoupChatInput.tsx
@@ -9,6 +9,10 @@ import {
 import { useGetChatAttachmentInfo } from '@core/component/AI/signal/attachment';
 import { setPendingSendData } from '@core/component/AI/signal/pendingSend';
 import { deriveChatName } from '@core/component/AI/util/deriveName';
+import {
+  getSoupInputStoredModel,
+  storeSoupInputModel,
+} from '@core/component/AI/util/storage';
 import { PaywallKey, usePaywallState } from '@core/constant/PaywallState';
 import { TOKENS } from '@core/hotkey/tokens';
 import { isPaymentError } from '@core/util/handlePaymentError';
@@ -18,7 +22,7 @@ import { invalidateAllSoup } from '@queries/soup/cache';
 import { cognitionApiServiceClient } from '@service-cognition/client';
 import { ChatInput } from 'core/component/AI/component/input/ChatInput';
 import { registerHotkey, useHotkeyDOMScope } from 'core/hotkey/hotkeys';
-import { onMount } from 'solid-js';
+import { createEffect, onMount } from 'solid-js';
 import { useSplitPanelOrThrow } from './split-layout/layoutUtils';
 
 function SoupChatInputInner() {
@@ -37,6 +41,14 @@ function SoupChatInputInner() {
     },
     block: 'chat',
     showOpenTabs: true,
+  });
+
+  // Persist the model the user picks in the new-chat composer so it survives
+  // reload/navigation, matching how the existing-chat draft model is restored.
+  // ChatInput may reconcile to an available model if the user isn't entitled to
+  // the stored one, and that corrected value flows through here too.
+  createEffect(() => {
+    storeSoupInputModel(input.model());
   });
 
   const [attachHotkeys] = useHotkeyDOMScope('soup.chatInput');
@@ -138,8 +150,12 @@ function SoupChatInputInner() {
 }
 
 export function SoupChatInput() {
+  // Seed the selector from the persisted soup draft model so the user's last
+  // choice in the new-chat composer is restored. ChatInputProvider falls back
+  // to DEFAULT_MODEL when this is undefined.
+  const initialModel = getSoupInputStoredModel();
   return (
-    <ChatInputProvider>
+    <ChatInputProvider model={initialModel}>
       <SoupChatInputInner />
     </ChatInputProvider>
   );

--- a/js/app/packages/block-chat/component/Chat.tsx
+++ b/js/app/packages/block-chat/component/Chat.tsx
@@ -58,14 +58,19 @@ export function Chat(props: { data: ChatData }) {
   const loadedState = getChatInputStoredState(props.data.chat.id);
   const { showPaywall } = usePaywallState();
 
-  // Seed the selector from the model the user just picked in the soup chat
-  // input (carried over the new-chat redirect via the pending send), then the
-  // chat's stored model, then the local draft, then the default. The chat input
-  // reconciles to an available model if the user isn't entitled to this one.
+  // Seed the model selector, highest priority first:
+  //  1. peekPendingSend — the model the user just sent with in the soup chat
+  //     input, carried over the new-chat redirect and reflected in the new chat.
+  //  2. loadedState.model — the per-chat draft: a model picked in this chat's
+  //     input but not yet sent (persisted per chat id, so it survives reload /
+  //     navigation, just like the draft text and attachments).
+  //  3. the chat's stored model.
+  // The chat input reconciles to an available model if the user isn't entitled
+  // to this one.
   const initialModel =
     peekPendingSend()?.model ??
-    parseModel(props.data.chat.model) ??
-    loadedState.model;
+    loadedState.model ??
+    parseModel(props.data.chat.model);
 
   return (
     <ChatInputProvider

--- a/js/app/packages/core/component/AI/util/storage.ts
+++ b/js/app/packages/core/component/AI/util/storage.ts
@@ -1,6 +1,6 @@
 import type { Attachment, Model } from '@core/component/AI/types';
 import { makePersisted } from '@solid-primitives/storage';
-import { untrack } from 'solid-js';
+import { createSignal, untrack } from 'solid-js';
 import { createStore, reconcile } from 'solid-js/store';
 import { DEFAULT_MODEL } from '../constant';
 import { parseModel } from './parse';
@@ -78,4 +78,23 @@ export function getChatInputStoredState(id: string): Partial<StoredStuff> {
     ...storedStuff,
     model,
   };
+}
+
+// The new-chat soup composer has no chat id to key off of, so its draft model
+// gets its own persisted slot (kept out of the LRU-bounded chat-state store so
+// it's never purged). Like the per-chat draft model, this lets a model the user
+// picked but hasn't sent yet survive reload/navigation.
+const [soupModel, setSoupModel] = makePersisted(
+  createSignal<Model | undefined>(undefined),
+  {
+    name: 'soup-chat-input-model',
+  }
+);
+
+export function getSoupInputStoredModel(): Model | undefined {
+  return parseModel(untrack(soupModel));
+}
+
+export function storeSoupInputModel(model: Model) {
+  setSoupModel(model);
 }


### PR DESCRIPTION
Persists the chat model selector's draft state across reloads and navigation for both the existing-chat composer and the new-chat soup composer, mirroring how draft text and attachments are already restored (macro-1966).