### PR TITLE
fix(chat): persist selected model across new-chat redirect (macro-1940)

### DIFF
--- a/js/app/packages/block-chat/component/Chat.tsx
+++ b/js/app/packages/block-chat/component/Chat.tsx
@@ -21,7 +21,10 @@ import {
 } from '@core/component/AI/context';
 import { useEntityDropAttachment } from '@core/component/AI/hook/useEntityDropAttachment';
 import { useGetChatAttachmentInfo } from '@core/component/AI/signal/attachment';
-import { getPendingSend } from '@core/component/AI/signal/pendingSend';
+import {
+  getPendingSend,
+  peekPendingSend,
+} from '@core/component/AI/signal/pendingSend';
 import { registerToolHandler } from '@core/component/AI/signal/tool';
 import { deriveChatName } from '@core/component/AI/util/deriveName';
 import { parseModel } from '@core/component/AI/util/parse';
@@ -55,10 +58,14 @@ export function Chat(props: { data: ChatData }) {
   const loadedState = getChatInputStoredState(props.data.chat.id);
   const { showPaywall } = usePaywallState();
 
-  // Seed the selector from the chat's stored model, then the local draft, then
-  // the default. The chat input reconciles to an available model if the user
-  // isn't entitled to this one.
-  const initialModel = parseModel(props.data.chat.model) ?? loadedState.model;
+  // Seed the selector from the model the user just picked in the soup chat
+  // input (carried over the new-chat redirect via the pending send), then the
+  // chat's stored model, then the local draft, then the default. The chat input
+  // reconciles to an available model if the user isn't entitled to this one.
+  const initialModel =
+    peekPendingSend()?.model ??
+    parseModel(props.data.chat.model) ??
+    loadedState.model;
 
   return (
     <ChatInputProvider

--- a/js/app/packages/core/component/AI/signal/pendingSend.ts
+++ b/js/app/packages/core/component/AI/signal/pendingSend.ts
@@ -19,6 +19,12 @@ export function getPendingSend(): PendingSend | null {
   return null;
 }
 
+// Read the pending send without clearing it. Used to seed UI state (e.g. the
+// model selector) before the pending send is consumed for the actual send.
+export function peekPendingSend(): PendingSend | null {
+  return pendingSend();
+}
+
 export function setPendingSendData(send: PendingSend): void {
   setPendingSend(send);
 }


### PR DESCRIPTION
Seeds the new chat's model selector from the soup chat input's pending send so the selected model persists across the new-chat redirect instead of resetting to the default.

Fixes macro-1940.