### PR TITLE
chore(team): suppress no team error log in get_team call

### DIFF
--- a/js/app/packages/queries/team/teams.ts
+++ b/js/app/packages/queries/team/teams.ts
@@ -32,7 +32,7 @@ export function useTeamQuery(teamId: Accessor<string>) {
   }));
 }
 
-/** The current user's team (`getTeam()` always returns it). */
+/** The current user's team, or `null` if they don't belong to one. */
 export function useCurrentTeamQuery() {
   return useQuery(() => ({
     queryKey: teamKeys.currentTeam.queryKey,
@@ -52,7 +52,9 @@ export function useIsTeamAdmin(): Accessor<boolean> {
     const uid = userId();
     if (!uid) return false;
     if (!queryReadyGate(teamQuery)) return false;
-    const member = teamQuery.data.members.find((m) => m.user_id === uid);
+    const team = teamQuery.data;
+    if (!team) return false;
+    const member = team.members.find((m) => m.user_id === uid);
     return member?.role === TeamRole.admin || member?.role === TeamRole.owner;
   };
 }

--- a/js/app/packages/service-clients/service-auth/client.ts
+++ b/js/app/packages/service-clients/service-auth/client.ts
@@ -638,10 +638,18 @@ export const authServiceClient = {
 
   async getTeam() {
     return (
-      await fetchWithAuth<TeamWithMembers>(`${authHost}/team`, {
-        method: 'GET',
-      })
-    ).map((result) => result);
+      (
+        await fetchWithAuth<TeamWithMembers>(`${authHost}/team`, {
+          method: 'GET',
+        })
+      )
+        // A user with no team gets a 204 No Content, which `safeFetch`
+        // surfaces as an empty object. Normalize that to `null` so callers
+        // don't dereference a non-existent `team`/`members`.
+        .map((result): TeamWithMembers | null =>
+          'team' in result ? result : null
+        )
+    );
   },
 
   async getTeamInvites() {

--- a/js/app/packages/service-clients/service-auth/generated/client.ts
+++ b/js/app/packages/service-clients/service-auth/generated/client.ts
@@ -1991,6 +1991,11 @@ export type getTeamResponse200 = {
   status: 200;
 };
 
+export type getTeamResponse204 = {
+  data: void;
+  status: 204;
+};
+
 export type getTeamResponse400 = {
   data: ErrorResponse;
   status: 400;
@@ -2011,7 +2016,10 @@ export type getTeamResponse500 = {
   status: 500;
 };
 
-export type getTeamResponseSuccess = getTeamResponse200 & {
+export type getTeamResponseSuccess = (
+  | getTeamResponse200
+  | getTeamResponse204
+) & {
   headers: Headers;
 };
 export type getTeamResponseError = (

--- a/js/app/packages/service-clients/service-auth/openapi.json
+++ b/js/app/packages/service-clients/service-auth/openapi.json
@@ -1680,6 +1680,9 @@
               }
             }
           },
+          "204": {
+            "description": ""
+          },
           "400": {
             "description": "",
             "content": {

--- a/js/bun.lock
+++ b/js/bun.lock
@@ -848,7 +848,7 @@
 
     "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
 
-    "@inkibra/tauri-plugins": ["@inkibra/tauri-plugins@github:macro-inc/tauri-plugins#26537c8", { "dependencies": { "react": "^18.3.1", "react-dom": "^18.3.1" } }, "macro-inc-tauri-plugins-26537c8"],
+    "@inkibra/tauri-plugins": ["@inkibra/tauri-plugins@github:macro-inc/tauri-plugins#26537c8", { "dependencies": { "react": "^18.3.1", "react-dom": "^18.3.1" } }, "macro-inc-tauri-plugins-26537c8", "sha512-6p5xQAkS6Uw6J8Uh0vlj6MjKZXWps5E1Gu0hciBFq1E2BfPBZAgdeeafKnR3diNb4SXWK0JML49nAr+o5PhwKw=="],
 
     "@inquirer/external-editor": ["@inquirer/external-editor@1.0.3", "", { "dependencies": { "chardet": "^2.1.1", "iconv-lite": "^0.7.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA=="],
 
@@ -2560,7 +2560,7 @@
 
     "pathval": ["pathval@2.0.1", "", {}, "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ=="],
 
-    "pdfjs-dist": ["pdfjs-dist@github:macro-inc/pdf.js#f9b2ce6", { "dependencies": { "dommatrix": "^1.0.3", "web-streams-polyfill": "^3.2.1" }, "peerDependencies": { "worker-loader": "^3.0.8" }, "optionalPeers": ["worker-loader"] }, "macro-inc-pdf.js-f9b2ce6"],
+    "pdfjs-dist": ["pdfjs-dist@github:macro-inc/pdf.js#f9b2ce6", { "dependencies": { "dommatrix": "^1.0.3", "web-streams-polyfill": "^3.2.1" }, "peerDependencies": { "worker-loader": "^3.0.8" }, "optionalPeers": ["worker-loader"] }, "macro-inc-pdf.js-f9b2ce6", "sha512-HDFaPbCxLG2GHpf1smUG97nku5aPGBGaCcIbK05dGdp07TBLUlDcXsM4WcE82mO5W4RBPIBVYobX5N/6M6NFrA=="],
 
     "performance-now": ["performance-now@2.1.0", "", {}, "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="],
 

--- a/rust/cloud-storage/teams/src/inbound/axum_router/get_team.rs
+++ b/rust/cloud-storage/teams/src/inbound/axum_router/get_team.rs
@@ -1,4 +1,9 @@
-use axum::{Json, extract::State};
+use axum::{
+    Json,
+    extract::State,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+};
 use entity_access::{
     domain::{models::MemberTeamRole, ports::EntityAccessService},
     inbound::axum_extractors::OptionalMacroUserTeamExtractor,
@@ -19,6 +24,7 @@ use super::TeamRouterState;
     operation_id = "get_team",
     responses(
         (status = 200, body = TeamWithMembers),
+        (status = 204),
         (status = 400, body = ErrorResponse),
         (status = 401, body = ErrorResponse),
         (status = 404, body = ErrorResponse),
@@ -29,10 +35,10 @@ use super::TeamRouterState;
 pub async fn handler<T: TeamService, Eas: EntityAccessService>(
     access: OptionalMacroUserTeamExtractor<MemberTeamRole, Eas>,
     State(state): State<TeamRouterState<T, Eas>>,
-) -> Result<Json<TeamWithMembers>, TeamError> {
-    let receipt = access
-        .entity_access_receipt
-        .ok_or(TeamError::TeamDoesNotExist)?;
+) -> Result<Response, TeamError> {
+    let Some(receipt) = access.entity_access_receipt else {
+        return Ok(StatusCode::NO_CONTENT.into_response());
+    };
     let team = state.service.get_team(receipt).await?;
-    Ok(Json(team))
+    Ok(Json(team).into_response())
 }


### PR DESCRIPTION
Our FE calls get_team a lot. Anytime this is called for a user without a team we got an error in our datadog logs that the team does not exist. This updates the endpoint to return `204 NO CONTENT` if the user is not in a team to prevent drowning our logs