### PR TITLE
Disable PostHog event logging in dev and local environments

### DIFF
--- a/js/app/packages/app/lib/analytics/analytics.ts
+++ b/js/app/packages/app/lib/analytics/analytics.ts
@@ -113,6 +113,12 @@ const initializePosthog = (instance: PostHog) => {
     ui_host: 'https://us.posthog.com',
     defaults: '2026-01-30',
     before_send: (cr) => {
+      // Disable PostHog event logging on local and dev environments. PostHog
+      // stays initialized so feature flags still resolve on dev, but every
+      // captured event (autocapture, pageviews, custom, $identify, $exception)
+      // is dropped so non-prod traffic never reaches PostHog.
+      if (DEV_MODE_ENV) return null;
+
       if (cr?.event !== '$exception') return cr;
 
       const exceptionValues = cr.properties.$exception_values;


### PR DESCRIPTION
## Summary
This change prevents PostHog from capturing and sending events in development and local environments while keeping the SDK initialized for feature flag resolution.

## Key Changes
- Added a `before_send` hook check that returns `null` for all events when `DEV_MODE_ENV` is true
- This filters out all PostHog events (autocapture, pageviews, custom events, $identify, and $exceptions) in non-production environments
- Feature flags continue to resolve normally since PostHog remains initialized

## Implementation Details
The filter is applied at the earliest point in the event pipeline via the `before_send` callback, ensuring that non-production traffic never reaches PostHog's servers while maintaining feature flag functionality for development and testing.

https://claude.ai/code/session_01MSBhn3ABCbCdrRs8sYwGJj