### PR TITLE
feat(chat): delegate ShowResults to fast subagent (macro-1993)

### DIFF
--- a/js/app/packages/core/component/AI/component/tool/Delegated.tsx
+++ b/js/app/packages/core/component/AI/component/tool/Delegated.tsx
@@ -1,0 +1,44 @@
+import type { ToolName } from '@service-cognition/generated/tools/tool';
+import { type Component, Show } from 'solid-js';
+import type { RenderContext, ToolRenderContext } from './ToolRenderer';
+import { createToolRenderer } from './ToolRenderer';
+
+/**
+ * A delegated tool is one the PRIMARY agent calls name-only (no arguments). A
+ * fast secondary agent fills in the real arguments, which come back inside the
+ * tool RESPONSE as `{ args, result }` (see the Rust `DelegatedTool<T>` /
+ * `DelegatedToolResponse`). The delegation is an implementation detail — to the
+ * user it must look exactly as if the primary agent had called the underlying
+ * tool directly.
+ *
+ * `createDelegatedToolRenderer` builds a tool handler that renders transparently
+ * from the delegated response's `args` (the underlying tool's call arguments),
+ * so the same UI shows regardless of who produced the arguments.
+ */
+export function createDelegatedToolRenderer<TName extends ToolName>(config: {
+  name: TName;
+  /**
+   * Render the underlying tool from the arguments the secondary agent produced
+   * (the `args` field of the delegated response). `args` is `undefined` until
+   * the response arrives — render a pending state if needed.
+   */
+  render: Component<{ args: Record<string, unknown> } & RenderContext>;
+}) {
+  const Render: Component<ToolRenderContext<TName> & RenderContext> = (ctx) => {
+    // The delegated response is `{ args, result }`; the underlying tool's
+    // arguments live in `args`. Until the secondary agent finishes there is no
+    // response yet, so `args` is undefined — render nothing until then so the
+    // delegation (and its brief latency) is invisible.
+    const args = () =>
+      (ctx.response as { args?: Record<string, unknown> } | undefined)?.args;
+    return (
+      <Show when={args()}>
+        {(resolved) => (
+          <config.render args={resolved()} renderContext={ctx.renderContext} />
+        )}
+      </Show>
+    );
+  };
+
+  return createToolRenderer<TName>({ name: config.name, render: Render });
+}

--- a/js/app/packages/core/component/AI/component/tool/DisplayResults.tsx
+++ b/js/app/packages/core/component/AI/component/tool/DisplayResults.tsx
@@ -1,19 +1,22 @@
 import { DashboardToolView } from '@app/component/dynamic-ui/DashboardToolView.lazy';
-import { createToolRenderer } from './ToolRenderer';
+import { createDelegatedToolRenderer } from './Delegated';
 
 /**
- * `displayResults` renders the AI-composed view from the tool CALL arguments
- * (`ctx.tool.data.view`) using the dynamic-ui component library. The tool
- * RESPONSE is intentionally not rendered.
+ * `DisplayResults` is a DELEGATED tool: the primary agent calls it name-only,
+ * and a fast secondary agent composes the dynamic-UI `view`. The composed view
+ * arrives in the tool RESPONSE (`args.view`), not the call arguments, so we
+ * render from the delegated response's `args`. The delegation is invisible — the
+ * user sees the same dashboard as if the primary agent had produced the view
+ * directly.
  *
  * `DashboardToolView` is imported from `@app` already wrapped in `lazy()` — the
  * dynamic-ui tree is entity-heavy and lives in a module-init cycle, so the lazy
  * boundary (owned by `@app`, like the split-layout component registry) keeps it
  * out of the eager startup graph. See `DashboardToolView.lazy.ts`.
  */
-const handler = createToolRenderer({
+const handler = createDelegatedToolRenderer({
   name: 'DisplayResults',
-  render: (ctx) => <DashboardToolView view={ctx.tool.data.view} />,
+  render: (ctx) => <DashboardToolView view={ctx.args?.view} />,
 });
 
 export const displayResultsHandler = handler;

--- a/js/app/packages/service-clients/service-cognition/generated/tools/schemas.ts
+++ b/js/app/packages/service-clients/service-cognition/generated/tools/schemas.ts
@@ -470,9 +470,12 @@ export const CreateDocumentResponse = z.object({
   documentId: z.string().uuid(),
 });
 
-export const DisplayResults = z.object({ view: z.any() });
+export const DisplayResults = z.object({}).strict();
 
-export const DisplayResultsResponse = z.object({ message: z.string() });
+export const DelegatedToolResponse = z.object({
+  args: z.any(),
+  result: z.object({ message: z.string() }),
+});
 
 export const GetEntityProperties = z.object({
   entity_id: z.string(),

--- a/js/app/packages/service-clients/service-cognition/generated/tools/tool.ts
+++ b/js/app/packages/service-clients/service-cognition/generated/tools/tool.ts
@@ -22,7 +22,7 @@ type ToolParserMap = {
   };
   DisplayResults: {
     call: types.DisplayResults;
-    response: types.DisplayResultsResponse;
+    response: types.DelegatedToolResponse;
   };
   GetEntityProperties: {
     call: types.GetEntityProperties;
@@ -118,7 +118,7 @@ const toolParserMap = {
   },
   DisplayResults: {
     call: schemas.DisplayResults,
-    response: schemas.DisplayResultsResponse,
+    response: schemas.DelegatedToolResponse,
   },
   GetEntityProperties: {
     call: schemas.GetEntityProperties,
@@ -237,7 +237,7 @@ type ToolDataMap = {
   };
   DisplayResults: {
     call: types.DisplayResults;
-    response: types.DisplayResultsResponse;
+    response: types.DelegatedToolResponse;
   };
   GetEntityProperties: {
     call: types.GetEntityProperties;

--- a/js/app/packages/service-clients/service-cognition/generated/tools/types.ts
+++ b/js/app/packages/service-clients/service-cognition/generated/tools/types.ts
@@ -967,19 +967,28 @@ export interface CrmCompanySearchResponseItem {
   updatedAt: string;
 }
 /**
- * Present results to the user as a rich view. The `view` argument is a dynamic-UI view object (a title plus an ordered list of widgets) following the dynamic-UI schema provided to you. The view is rendered immediately in the chat; this tool returns as soon as it is dispatched.
+ * The result the primary agent (and the frontend) receive from a delegated
+ * tool: the arguments the secondary agent produced, plus the underlying tool's
+ * own output. The frontend renders from `args`; the model reads `result`.
  */
-export interface DisplayResults {
+export interface DelegatedToolResponse {
   /**
-   * The dynamic-UI view to render: an object with an optional `title` and a `widgets` array, per the provided dynamic-UI schema.
+   * The arguments the secondary agent produced for the underlying tool. The
+   * frontend renders the delegated tool from this exactly as if the primary
+   * agent had supplied them directly.
    */
-  view: {
+  args: {
     [k: string]: unknown;
   };
+  result: DisplayResultsResponse;
 }
 export interface DisplayResultsResponse {
   message: string;
 }
+/**
+ * Present results to the user as a rich view. The `view` argument is a dynamic-UI view object (a title plus an ordered list of widgets) following the dynamic-UI schema provided to you. The view is rendered immediately in the chat; this tool returns as soon as it is dispatched.
+ */
+export type DisplayResults = {};
 /**
  * API-visible content lifecycle and location metadata.
  */

--- a/rust/cloud-storage/agent/src/agent_loop.rs
+++ b/rust/cloud-storage/agent/src/agent_loop.rs
@@ -103,9 +103,15 @@ impl AgentLoop {
                 buffer.lock().expect("loaded_buffer poisoned").extend(tools)
             })
         };
-        let request_context = Arc::new(RwLock::new(
-            RequestContext::new(usage_ctx.user.clone()).with_tool_search(Arc::new(catalog), loader),
-        ));
+        // Shared accumulator of the in-flight assistant response. The stream
+        // bridge appends parts as they stream; tool calls (e.g. delegated
+        // tools) read it back through their `RequestContext` to see what the
+        // assistant has produced so far in the current turn.
+        let assistant_context = ai_toolset::AssistantContext::new();
+        let mut request_context =
+            RequestContext::new(usage_ctx.user.clone()).with_tool_search(Arc::new(catalog), loader);
+        request_context.assistant_context = assistant_context.clone();
+        let request_context = Arc::new(RwLock::new(request_context));
 
         // Keep a handle to the toolset so the stream bridge can resolve MCP
         // routing info (service / display name) for tool calls. This is the
@@ -209,6 +215,7 @@ impl AgentLoop {
             recorder: self.recorder.clone(),
             usage_ctx,
             model: self.model.clone(),
+            assistant_context,
         }
     }
 }
@@ -226,6 +233,9 @@ pub struct Session {
     recorder: Arc<dyn UsageRecorder>,
     usage_ctx: UsageContext,
     model: String,
+    /// Accumulator of the in-flight assistant response, shared with the tool
+    /// call `RequestContext` so delegated tools can read the current turn.
+    assistant_context: ai_toolset::AssistantContext,
 }
 
 impl Session {
@@ -258,6 +268,7 @@ impl Session {
                 self.recorder.clone(),
                 self.usage_ctx.clone(),
                 self.model.clone(),
+                self.assistant_context.clone(),
             )
             .await;
 

--- a/rust/cloud-storage/agent/src/hook.rs
+++ b/rust/cloud-storage/agent/src/hook.rs
@@ -5,7 +5,7 @@ mod test;
 
 use crate::AgentError;
 use crate::stream::{McpInfo, StreamPart, ToolCall, ToolResponse, Usage};
-use ai_toolset::{SearchableTool, ToolInfo};
+use ai_toolset::{AssistantContext, AssistantContextPart, SearchableTool, ToolInfo};
 use rig_core::agent::{HookAction, PromptHook, ToolCallHookAction};
 use rig_core::completion::{CompletionModel, GetTokenUsage};
 use rig_core::message::Message;
@@ -41,6 +41,9 @@ pub struct StreamBridge {
     loaded_buffer: Arc<Mutex<Vec<SearchableTool>>>,
     /// Registers drained tools with the live tool server.
     register_loaded: RegisterFn,
+    /// Accumulates the assistant's parts for the current turn so that tool
+    /// calls (e.g. delegated tools) can read the in-flight response as context.
+    assistant_context: AssistantContext,
 }
 
 impl StreamBridge {
@@ -50,11 +53,14 @@ impl StreamBridge {
     /// tagged as such (see [`ToolRouter`]). `loaded_buffer` / `register_loaded`
     /// power on-demand tool loading: `SearchTools` pushes matches into the
     /// buffer, and the bridge registers them after the tool result, before the
-    /// next turn (see [`Self::on_tool_result`]).
+    /// next turn (see [`Self::on_tool_result`]). `assistant_context` is the
+    /// shared accumulator that mirrors the in-flight assistant response into the
+    /// tool call [`ai_toolset::RequestContext`].
     pub fn channel(
         routing: ToolRouter,
         loaded_buffer: Arc<Mutex<Vec<SearchableTool>>>,
         register_loaded: RegisterFn,
+        assistant_context: AssistantContext,
     ) -> (
         Self,
         mpsc::UnboundedReceiver<Result<StreamPart, AgentError>>,
@@ -66,6 +72,7 @@ impl StreamBridge {
                 routing,
                 loaded_buffer,
                 register_loaded,
+                assistant_context,
             },
             rx,
         )
@@ -78,6 +85,8 @@ where
     M::StreamingResponse: GetTokenUsage + Send + Sync,
 {
     async fn on_text_delta(&self, text_delta: &str, _aggregated_text: &str) -> HookAction {
+        self.assistant_context
+            .push(AssistantContextPart::Text(text_delta.to_owned()));
         let _ = self.tx.send(Ok(StreamPart::Content(text_delta.to_owned())));
         HookAction::Continue
     }
@@ -90,6 +99,10 @@ where
         args: &str,
     ) -> ToolCallHookAction {
         let json = serde_json::from_str(args).unwrap_or(serde_json::Value::Null);
+        self.assistant_context.push(AssistantContextPart::ToolCall {
+            name: tool_name.to_owned(),
+            args: json.clone(),
+        });
         let id = tool_call_id.unwrap_or_else(|| internal_call_id.to_owned());
         let mcp = (self.routing)(tool_name).map(|i| match i {
             ToolInfo::ExternalTool {

--- a/rust/cloud-storage/agent/src/hook/test.rs
+++ b/rust/cloud-storage/agent/src/hook/test.rs
@@ -34,7 +34,8 @@ async fn on_tool_result_drains_buffer_and_registers_loaded_tools() {
     ]));
     let (register, registered) = recording_register();
     let routing: ToolRouter = Arc::new(|_| None);
-    let (bridge, _rx) = StreamBridge::channel(routing, buffer.clone(), register);
+    let (bridge, _rx) =
+        StreamBridge::channel(routing, buffer.clone(), register, AssistantContext::new());
 
     let action = <StreamBridge as PromptHook<AnthropicModel>>::on_tool_result(
         &bridge,
@@ -65,7 +66,7 @@ async fn on_tool_result_registers_nothing_when_buffer_empty() {
     let buffer = Arc::new(Mutex::new(Vec::new()));
     let (register, registered) = recording_register();
     let routing: ToolRouter = Arc::new(|_| None);
-    let (bridge, _rx) = StreamBridge::channel(routing, buffer, register);
+    let (bridge, _rx) = StreamBridge::channel(routing, buffer, register, AssistantContext::new());
 
     let _ = <StreamBridge as PromptHook<AnthropicModel>>::on_tool_result(
         &bridge,

--- a/rust/cloud-storage/agent/src/model/router.rs
+++ b/rust/cloud-storage/agent/src/model/router.rs
@@ -19,7 +19,7 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex, OnceLock};
 
-use ai_toolset::SearchableTool;
+use ai_toolset::{AssistantContext, SearchableTool};
 use ai_usage::{UsageContext, UsageRecorder};
 use futures::StreamExt;
 use macro_env_var::env_var;
@@ -144,6 +144,7 @@ impl ProviderAgent {
         recorder: Arc<dyn UsageRecorder>,
         usage_ctx: UsageContext,
         model: String,
+        assistant_context: AssistantContext,
     ) -> ChatCompletionStream<'static> {
         match self {
             ProviderAgent::Anthropic(agent) => {
@@ -158,6 +159,7 @@ impl ProviderAgent {
                     recorder,
                     usage_ctx,
                     model,
+                    assistant_context,
                 )
                 .await
             }
@@ -173,6 +175,7 @@ impl ProviderAgent {
                     recorder,
                     usage_ctx,
                     model,
+                    assistant_context,
                 )
                 .await
             }
@@ -188,6 +191,7 @@ impl ProviderAgent {
                     recorder,
                     usage_ctx,
                     model,
+                    assistant_context,
                 )
                 .await
             }
@@ -381,12 +385,14 @@ async fn drive_stream<M>(
     recorder: Arc<dyn UsageRecorder>,
     usage_ctx: UsageContext,
     model: String,
+    assistant_context: AssistantContext,
 ) -> ChatCompletionStream<'static>
 where
     M: CompletionModel + 'static,
     M::StreamingResponse: GetTokenUsage + Send + Sync,
 {
-    let (bridge, mut rx) = StreamBridge::channel(routing, loaded_buffer, register_loaded);
+    let (bridge, mut rx) =
+        StreamBridge::channel(routing, loaded_buffer, register_loaded, assistant_context);
 
     let mut rig_stream = agent
         .stream_prompt(prompt)

--- a/rust/cloud-storage/ai_tools/src/delegated.rs
+++ b/rust/cloud-storage/ai_tools/src/delegated.rs
@@ -1,0 +1,245 @@
+//! Delegated tools: a reusable pattern for keeping large, slow tool arguments
+//! out of the primary agent's generation.
+//!
+//! A [`DelegatedTool<T>`] wraps any tool `T`. To the **primary** agent it is
+//! exposed as a *name-only* tool — `T`'s title and description, but an empty
+//! argument schema. The primary agent decides *whether* to call it without
+//! paying the (potentially huge) input-token cost of producing `T`'s arguments.
+//!
+//! When the primary agent calls a delegated tool, [`DelegatedTool::call`] spins
+//! up a **secondary, fast** agent whose sole job is to produce the arguments for
+//! the real tool `T`. The secondary agent is given:
+//!
+//! - the full input schema of `T` (so it knows exactly what to emit), and
+//! - the primary agent's in-flight assistant response (text, thinking, and tool
+//!   calls so far this turn) as context — see [`ai_toolset::AssistantContext`].
+//!
+//! The secondary agent runs on [`PredefinedModel::Fast`] using
+//! [`agent::structured_output::dynamic_structured_completion`], which is the
+//! "one tool, must call it" pattern collapsed into a single schema-constrained
+//! completion: there is exactly one possible output (a valid `T`), so a tool
+//! loop would be wasted round-trips.
+//!
+//! The resulting arguments are then dispatched through `T::call`, and the
+//! produced arguments are returned to the primary agent **as the tool result**.
+//! The frontend renders the delegated tool from that result, so the delegation
+//! is invisible — it looks exactly as if the primary agent had called `T`
+//! directly.
+//!
+//! The only concrete instance today is `DisplayResults` (Dynamic UI), but the
+//! abstraction is fully generic over `T`.
+
+use agent::Message;
+use agent::PredefinedModel;
+use agent::structured_output::{DynamicSchema, dynamic_structured_completion};
+use ai_toolset::{AsyncTool, RequestContext, ServiceContext, ToolCallError, ToolResult};
+use async_trait::async_trait;
+use schemars::JsonSchema;
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use std::marker::PhantomData;
+
+use crate::ToolServiceContext;
+
+/// The model the secondary "fast subagent" uses to fill in a delegated tool's
+/// arguments. Delegation exists to be cheap and fast, so it always uses the
+/// fast tier.
+const DELEGATE_MODEL: PredefinedModel = PredefinedModel::Fast;
+
+/// Marker trait for a tool that can be delegated to a fast secondary agent.
+///
+/// Implemented for any tool that the secondary agent can fully specify from the
+/// primary agent's response context. Carries the human-facing instruction shown
+/// to the secondary agent describing *how* to call the tool.
+pub trait Delegable: JsonSchema + DeserializeOwned + Send + Sync + 'static {
+    /// Instructions for the secondary agent describing how to produce this
+    /// tool's arguments from the provided context. Lives in the `prompt` crate.
+    fn delegate_instructions() -> &'static str;
+}
+
+/// Wraps a tool `T` so the primary agent sees only its name and description
+/// (no arguments). See the [module docs](self) for the full flow.
+pub struct DelegatedTool<T> {
+    _phantom: PhantomData<fn() -> T>,
+}
+
+/// The primary agent calls a delegated tool with no arguments. This is the
+/// (empty) deserialization target; any extra fields the model emits are ignored.
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct NoArgs {}
+
+impl<'de, T> Deserialize<'de> for DelegatedTool<T> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        // Accept (and discard) any/empty object the primary agent emits.
+        let _ = NoArgs::deserialize(deserializer);
+        Ok(DelegatedTool {
+            _phantom: PhantomData,
+        })
+    }
+}
+
+impl<T: JsonSchema> JsonSchema for DelegatedTool<T> {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        // Same name as the underlying tool: the primary agent (and the frontend
+        // tool registry, keyed by name) see an indistinguishable tool.
+        T::schema_name()
+    }
+
+    fn json_schema(generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        // Reuse the underlying tool's title and description so the primary agent
+        // knows what the tool is for, but strip the properties: this is a
+        // name-only tool that takes no arguments.
+        let underlying = T::json_schema(generator);
+        let title = underlying
+            .get("title")
+            .cloned()
+            .unwrap_or_else(|| serde_json::Value::String(T::schema_name().into_owned()));
+        let description = underlying
+            .get("description")
+            .cloned()
+            .unwrap_or(serde_json::Value::String(String::new()));
+
+        schemars::json_schema!({
+            "type": "object",
+            "title": title,
+            "description": description,
+            "properties": {},
+            "additionalProperties": false,
+        })
+    }
+}
+
+/// The result the primary agent (and the frontend) receive from a delegated
+/// tool: the arguments the secondary agent produced, plus the underlying tool's
+/// own output. The frontend renders from `args`; the model reads `result`.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct DelegatedToolResponse<O> {
+    /// The arguments the secondary agent produced for the underlying tool. The
+    /// frontend renders the delegated tool from this exactly as if the primary
+    /// agent had supplied them directly.
+    pub args: serde_json::Value,
+    /// The underlying tool's own output, so the primary agent can continue.
+    pub result: O,
+}
+
+#[async_trait]
+impl<T> AsyncTool<ToolServiceContext> for DelegatedTool<T>
+where
+    T: Delegable + AsyncTool<ToolServiceContext>,
+    T::Output: Serialize + JsonSchema + 'static,
+{
+    type Output = DelegatedToolResponse<T::Output>;
+
+    #[tracing::instrument(skip_all, err)]
+    async fn call(
+        &self,
+        service_context: ServiceContext<ToolServiceContext>,
+        request_context: RequestContext,
+    ) -> ToolResult<Self::Output> {
+        // 1. The secondary agent needs the full input schema of the real tool —
+        //    the same validated, provider-ready schema the primary agent would
+        //    have seen had the tool not been delegated.
+        let validated =
+            ai_toolset::schema::generate_validated_input_schema::<T>().map_err(|e| {
+                ToolCallError {
+                    description: "failed to build delegated tool schema".to_string(),
+                    internal_error: anyhow::anyhow!("{e:?}"),
+                }
+            })?;
+        let schema_value = serde_json::to_value(&validated.schema).map_err(|e| ToolCallError {
+            description: "failed to build delegated tool schema".to_string(),
+            internal_error: anyhow::Error::from(e),
+        })?;
+
+        // 2. Context for the secondary agent: everything the primary agent has
+        //    produced so far in this response. Without it there is nothing to
+        //    delegate from, so treat an empty context as an error the primary
+        //    agent can recover from.
+        let Some(transcript) = request_context.assistant_context.to_transcript() else {
+            return Err(ToolCallError {
+                description: "nothing to display yet; produce the results first, \
+                              then call this tool"
+                    .to_string(),
+                internal_error: anyhow::anyhow!("empty assistant context for delegated tool"),
+            });
+        };
+
+        // 3. Run the fast secondary agent. It has exactly one job — emit valid
+        //    arguments for `T` — so a schema-constrained completion is the
+        //    "one tool, must call it" pattern without the tool-loop overhead.
+        let args = dynamic_structured_completion(
+            DELEGATE_MODEL.api_id(),
+            T::delegate_instructions(),
+            vec![Message::user(transcript)],
+            DynamicSchema {
+                name: T::schema_name().into_owned(),
+                description: None,
+                schema: schema_value,
+            },
+            service_context.recorder.as_ref(),
+            service_context.usage_context.clone(),
+        )
+        .await
+        .map_err(|e| ToolCallError {
+            description: "the display subagent failed to produce a view".to_string(),
+            internal_error: e,
+        })?;
+
+        // 4. Dispatch the real tool with the secondary agent's arguments.
+        let tool: T = serde_json::from_value(args.clone()).map_err(|e| ToolCallError {
+            description: "the display subagent produced invalid arguments".to_string(),
+            internal_error: anyhow::Error::from(e),
+        })?;
+        let result = tool.call(service_context, request_context).await?;
+
+        Ok(DelegatedToolResponse { args, result })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ai_toolset::schema::generate_validated_input_schema;
+
+    /// A tool with a real argument, used to verify delegation strips it.
+    #[derive(serde::Deserialize, JsonSchema)]
+    #[schemars(title = "Sample", description = "A sample tool with arguments.")]
+    #[allow(dead_code)]
+    struct Sample {
+        /// A field the delegated wrapper must hide from the primary agent.
+        field: String,
+    }
+
+    #[test]
+    fn delegated_tool_keeps_name_and_description() {
+        let validated =
+            generate_validated_input_schema::<DelegatedTool<Sample>>().expect("valid schema");
+        assert_eq!(validated.name, "Sample");
+        assert_eq!(validated.description, "A sample tool with arguments.");
+    }
+
+    #[test]
+    fn delegated_tool_exposes_no_arguments() {
+        let validated =
+            generate_validated_input_schema::<DelegatedTool<Sample>>().expect("valid schema");
+        let schema = serde_json::to_value(&validated.schema).expect("serialize");
+        // The primary agent must see a name-only tool: an object with no
+        // properties (the real `field` is hidden behind delegation).
+        let props = schema
+            .get("properties")
+            .and_then(|p| p.as_object())
+            .expect("properties present");
+        assert!(props.is_empty(), "delegated tool must expose no arguments");
+    }
+
+    #[test]
+    fn delegated_tool_accepts_empty_args() {
+        // The primary agent calls the tool with `{}`; deserialization succeeds.
+        serde_json::from_value::<DelegatedTool<Sample>>(serde_json::json!({}))
+            .expect("empty object deserializes");
+    }
+}

--- a/rust/cloud-storage/ai_tools/src/display_results.rs
+++ b/rust/cloud-storage/ai_tools/src/display_results.rs
@@ -4,6 +4,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::ToolServiceContext;
+use crate::delegated::Delegable;
 
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct DisplayResultsResponse {
@@ -48,5 +49,16 @@ impl AsyncTool<ToolServiceContext> for DisplayResults {
         Ok(DisplayResultsResponse {
             message: "The results have been displayed to the user.".to_string(),
         })
+    }
+}
+
+/// `DisplayResults` is delegated: the primary agent calls it name-only, and a
+/// fast secondary agent composes the (large, slow) dynamic-UI `view` from the
+/// primary agent's response. See [`crate::delegated`].
+impl Delegable for DisplayResults {
+    fn delegate_instructions() -> &'static str {
+        prompt::DISPLAY_RESULTS_DELEGATE_PROMPT
+            .instructions
+            .as_ref()
     }
 }

--- a/rust/cloud-storage/ai_tools/src/lib.rs
+++ b/rust/cloud-storage/ai_tools/src/lib.rs
@@ -7,6 +7,7 @@ use ai_toolset::schema::{FrontendSchemas, ToolSchemaGenerator, frontend_schemas_
 mod test;
 
 mod build_context;
+pub mod delegated;
 mod display_results;
 mod schemas;
 pub mod search;
@@ -20,6 +21,7 @@ use anthropic::toolset::anthropic_toolset;
 use call::inbound::toolset::call_toolset;
 use channels::inbound::toolset::channel_toolset;
 use chat::inbound::toolset::chat_toolset;
+use delegated::DelegatedTool;
 use display_results::DisplayResults;
 use documents::inbound::toolset::document_toolset;
 use email::inbound::toolset::{email_toolset, mcp_toolset as email_mcp_toolset};
@@ -91,7 +93,10 @@ pub fn all_tools() -> ToolSetWithPrompt {
         .add_tool::<Subagent, ToolServiceContext>()
         .add_tool::<SearchTools, ToolServiceContext>()
         .add_tool::<LoadTools, ToolServiceContext>()
-        .add_tool::<DisplayResults, ToolServiceContext>();
+        // `DisplayResults` is delegated: the primary agent sees a name-only
+        // tool; a fast secondary agent composes the dynamic-UI view. See the
+        // `delegated` module.
+        .add_tool::<DelegatedTool<DisplayResults>, ToolServiceContext>();
     let toolset = Arc::new(toolset);
     ToolSetWithPrompt {
         toolset,

--- a/rust/cloud-storage/ai_toolset/src/context.rs
+++ b/rust/cloud-storage/ai_toolset/src/context.rs
@@ -1,7 +1,7 @@
 use crate::tool_search::{SearchableTool, ToolLoader};
 use macro_user_id::user_id::MacroUserIdStr;
 use std::ops::{Deref, DerefMut};
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
 /// Service context wrapper for shared state passed to tools.
 ///
@@ -24,6 +24,88 @@ impl<S> DerefMut for ServiceContext<S> {
     }
 }
 
+/// A single part of the assistant's response, captured as it streams so that
+/// tools running mid-turn can see what the primary agent has produced so far.
+///
+/// This is a self-contained, dependency-free mirror of the streamed assistant
+/// content (the `agent` crate maps its richer stream parts onto this). It backs
+/// the "delegated tool" pattern, where a name-only tool call is fulfilled by a
+/// secondary agent that needs the current assistant response as context.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum AssistantContextPart {
+    /// Plain text produced by the assistant in this turn.
+    Text(String),
+    /// Reasoning / thinking text produced by the assistant in this turn.
+    Thinking(String),
+    /// A tool call the assistant made in this turn, rendered as
+    /// `name(json-args)` for context.
+    ToolCall {
+        /// The tool name.
+        name: String,
+        /// The JSON arguments the assistant passed.
+        args: serde_json::Value,
+    },
+}
+
+/// Accumulates the assistant message parts of the in-flight response.
+///
+/// Shared (via [`Arc`]) between the agent stream — which appends parts as they
+/// stream — and the [`RequestContext`] handed to tool calls, so a tool can read
+/// everything the assistant has emitted in the current turn. Cleared at the
+/// start of each new turn by the producer.
+#[derive(Clone, Debug, Default)]
+pub struct AssistantContext(Arc<RwLock<Vec<AssistantContextPart>>>);
+
+impl AssistantContext {
+    /// Create an empty assistant context.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Append a part produced by the assistant.
+    pub fn push(&self, part: AssistantContextPart) {
+        if let Ok(mut parts) = self.0.write() {
+            parts.push(part);
+        }
+    }
+
+    /// Snapshot the parts accumulated so far in the current turn.
+    pub fn snapshot(&self) -> Vec<AssistantContextPart> {
+        self.0.read().map(|p| p.clone()).unwrap_or_default()
+    }
+
+    /// Render the accumulated parts as a plain-text transcript suitable for
+    /// feeding to a secondary agent as context. Returns `None` if empty.
+    pub fn to_transcript(&self) -> Option<String> {
+        let parts = self.snapshot();
+        if parts.is_empty() {
+            return None;
+        }
+        let mut out = String::new();
+        for part in parts {
+            match part {
+                AssistantContextPart::Text(text) => {
+                    out.push_str(&text);
+                    out.push('\n');
+                }
+                AssistantContextPart::Thinking(thinking) => {
+                    out.push_str("[thinking] ");
+                    out.push_str(&thinking);
+                    out.push('\n');
+                }
+                AssistantContextPart::ToolCall { name, args } => {
+                    out.push_str("[tool call] ");
+                    out.push_str(&name);
+                    out.push('(');
+                    out.push_str(&args.to_string());
+                    out.push_str(")\n");
+                }
+            }
+        }
+        Some(out)
+    }
+}
+
 /// Request context passed into tool calls, containing per-request data like user identity.
 #[derive(Clone, Debug)]
 pub struct RequestContext {
@@ -36,16 +118,26 @@ pub struct RequestContext {
     /// Loader used by `SearchTools` to load matched tools into the active
     /// request. `None` when tool search is not wired up (e.g. non-agent callers).
     pub tool_loader: Option<ToolLoader>,
+    /// The assistant message parts produced so far in the current response.
+    ///
+    /// Populated by the agent stream as the assistant generates; read by tools
+    /// (e.g. delegated tools) that need the current response as context. Empty
+    /// for non-streaming dispatch paths.
+    pub assistant_context: AssistantContext,
 }
 
 impl RequestContext {
     /// Create a request context for `user_id` with no tool-search wiring (no
-    /// searchable catalog, no loader).
+    /// searchable catalog, no loader) and an empty assistant context.
+    ///
+    /// Use this on non-streaming dispatch paths (single tool calls outside the
+    /// agent loop) where no in-flight assistant response exists.
     pub fn new(user_id: MacroUserIdStr<'static>) -> Self {
         Self {
             user_id,
             searchable_tools: Arc::new(Vec::new()),
             tool_loader: None,
+            assistant_context: AssistantContext::new(),
         }
     }
 
@@ -58,5 +150,29 @@ impl RequestContext {
         self.searchable_tools = searchable_tools;
         self.tool_loader = Some(tool_loader);
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_assistant_context_has_no_transcript() {
+        assert_eq!(AssistantContext::new().to_transcript(), None);
+    }
+
+    #[test]
+    fn transcript_renders_parts_in_order() {
+        let ctx = AssistantContext::new();
+        ctx.push(AssistantContextPart::Text("found 3 results".into()));
+        ctx.push(AssistantContextPart::ToolCall {
+            name: "Search".into(),
+            args: serde_json::json!({ "query": "macro" }),
+        });
+        let transcript = ctx.to_transcript().expect("non-empty");
+        assert!(transcript.contains("found 3 results"));
+        assert!(transcript.contains("[tool call] Search("));
+        assert!(transcript.contains("macro"));
     }
 }

--- a/rust/cloud-storage/ai_toolset/src/lib.rs
+++ b/rust/cloud-storage/ai_toolset/src/lib.rs
@@ -135,7 +135,7 @@ mod tool;
 pub mod tool_search;
 mod toolset;
 
-pub use context::{RequestContext, ServiceContext};
+pub use context::{AssistantContext, AssistantContextPart, RequestContext, ServiceContext};
 pub use tool::{AsyncTool, NoContext, ToolCallError, ToolResult};
 pub use tool_search::{SearchableTool, ToolLoader};
 pub use toolset::{

--- a/rust/cloud-storage/prompt/src/display_results_delegate.rs
+++ b/rust/cloud-storage/prompt/src/display_results_delegate.rs
@@ -1,0 +1,30 @@
+//! Instructions for the fast secondary agent that fills in the `DisplayResults`
+//! (Dynamic UI) tool when the primary agent delegates it.
+//!
+//! The primary agent calls `DisplayResults` name-only; this prompt drives the
+//! secondary agent that turns the primary agent's response into the actual
+//! dynamic-UI `view` argument. The dynamic-UI schema itself is supplied to the
+//! secondary agent out-of-band as the structured-output schema, so this prompt
+//! only describes the task, not the schema.
+
+use crate::types::StaticPrompt;
+
+static TITLE: &str = "Display Results";
+
+static INSTRUCTIONS: &str = r##"You compose a rich visual view from another agent's findings.
+
+You are given the assistant's response so far: its text, reasoning, and tool calls/results gathered while answering the user. Your job is to produce the arguments for the `DisplayResults` tool — a dynamic-UI `view` object that presents those findings to the user.
+
+- Output ONLY the tool arguments, matching the provided JSON schema exactly.
+- Build the `view` from the information already present in the response. Do not invent facts, entities, or figures that are not supported by the response.
+- Choose the widgets and layout that present the findings most clearly. Prefer concise, scannable views over walls of text.
+- Preserve entity references, links, and identifiers exactly as they appear in the response.
+- Do not add commentary, explanations, or markdown fences — emit only the JSON arguments.
+"##;
+
+static INTENT: &str = "The secondary agent renders the primary agent's findings as a \
+dynamic-UI view, using only information present in the response and matching the provided schema.";
+
+/// Instructions for the `DisplayResults` delegation secondary agent.
+pub static DISPLAY_RESULTS_DELEGATE_PROMPT: StaticPrompt<'static> =
+    StaticPrompt::borrowed(TITLE, INSTRUCTIONS, INTENT);

--- a/rust/cloud-storage/prompt/src/lib.rs
+++ b/rust/cloud-storage/prompt/src/lib.rs
@@ -9,6 +9,7 @@ pub mod about_macro;
 pub mod channel_mention;
 pub mod citations;
 pub mod connected_toolsets;
+pub mod display_results_delegate;
 pub mod do_not;
 pub mod email;
 pub mod math;
@@ -18,6 +19,7 @@ pub mod tone;
 pub mod tool_usage;
 mod types;
 
+pub use display_results_delegate::DISPLAY_RESULTS_DELEGATE_PROMPT;
 pub use types::{ComposedPrompt, Section, StaticPrompt};
 
 /// The base prompt: tone, math, citations, mentions, do-not rules, and Macro


### PR DESCRIPTION
Adds a reusable delegated-tool pattern in which the primary agent calls a name-only tool and a fast secondary agent composes the real arguments from the current assistant response, and converts the DisplayResults (Dynamic UI) tool to use it so the slow, token-heavy view is generated by the fast subagent instead of the primary agent.

Task: macro-1993

🤖 Generated with [Claude Code](https://claude.com/claude-code)