### PR TITLE
feat(email): show backfill thread count and time remaining

### DIFF
--- a/js/app/packages/app/component/settings/Email.tsx
+++ b/js/app/packages/app/component/settings/Email.tsx
@@ -19,6 +19,8 @@ import {
 } from '@service-email/generated/schemas';
 import { useEmail, useUserId } from '@core/context/user';
 import {
+  type BackfillProgress,
+  estimateEtaSeconds,
   getBackfillProgress,
   useBackfillJobsQuery,
 } from '@queries/email/backfill';
@@ -411,16 +413,35 @@ function syncStatusLabel(status: SyncStatus): string {
 // Live backfill progress bar. `completed`/`total` are the connection-gateway
 // counters; render the ratio rather than the raw counts since the priority pass
 // can inflate both slightly above the real mailbox size.
-function BackfillProgressBar(props: { completed: number; total: number }) {
+// Rough "time left" from the recent backfill rate. Rounds up and bins into
+// s / m / h so the estimate doesn't visibly jitter between progress events.
+function formatEta(seconds: number): string {
+  if (seconds < 60) return `~${Math.max(1, Math.ceil(seconds))}s left`;
+  const minutes = Math.ceil(seconds / 60);
+  if (minutes < 60) return `~${minutes}m left`;
+  const hours = Math.floor(minutes / 60);
+  const remMinutes = minutes % 60;
+  return remMinutes > 0 ? `~${hours}h ${remMinutes}m left` : `~${hours}h left`;
+}
+
+function BackfillProgressBar(props: { progress: BackfillProgress }) {
   const percent = () =>
-    props.total > 0
-      ? Math.min(100, Math.round((props.completed / props.total) * 100))
+    props.progress.total > 0
+      ? Math.min(
+          100,
+          Math.round((props.progress.completed / props.progress.total) * 100)
+        )
       : 0;
+  const etaLabel = createMemo(() => {
+    const seconds = estimateEtaSeconds(props.progress);
+    return seconds === undefined ? undefined : formatEta(seconds);
+  });
   return (
-    <div class="flex w-40 flex-col gap-1">
-      <span class="flex items-center gap-1 text-xs text-ink-muted">
-        <ArrowsClockwiseIcon class="size-3 animate-spin" />
-        Syncing… {percent()}%
+    <div class="flex w-60 flex-col gap-1">
+      <span class="flex items-center gap-1 whitespace-nowrap text-xs text-ink-muted">
+        <ArrowsClockwiseIcon class="size-3 shrink-0 animate-spin" />
+        Backfilling… {props.progress.completed}/{props.progress.total}
+        <Show when={etaLabel()}>{(label) => <>{' · '}{label()}</>}</Show>
       </span>
       <div class="h-1 w-full overflow-hidden rounded-full bg-edge-muted">
         <div
@@ -513,12 +534,7 @@ function InboxRow(props: {
             {/* Live backfill progress (connection gateway) wins over the coarse
                 sync_status while a backfill is actively running. */}
             <Match when={getBackfillProgress(props.link.id)}>
-              {(progress) => (
-                <BackfillProgressBar
-                  completed={progress().completed}
-                  total={progress().total}
-                />
-              )}
+              {(progress) => <BackfillProgressBar progress={progress()} />}
             </Match>
             {/* Settled inbox with a completed backfill from the BE list. */}
             <Match

--- a/js/app/packages/app/component/settings/Email.tsx
+++ b/js/app/packages/app/component/settings/Email.tsx
@@ -437,12 +437,17 @@ function BackfillProgressBar(props: { progress: BackfillProgress }) {
     return seconds === undefined ? undefined : formatEta(seconds);
   });
   return (
-    <div class="flex w-60 flex-col gap-1">
-      <span class="flex items-center gap-1 whitespace-nowrap text-xs text-ink-muted">
+    <div class="flex w-60 flex-col gap-2">
+      <span class="flex items-center gap-1.5 text-xs text-ink-muted">
         <ArrowsClockwiseIcon class="size-3 shrink-0 animate-spin" />
-        Backfilling… {props.progress.completed}/{props.progress.total}
-        <Show when={etaLabel()}>{(label) => <>{' · '}{label()}</>}</Show>
+        Backfilling…
       </span>
+      <div class="flex items-center gap-6 whitespace-nowrap text-xs text-ink-muted">
+        <span>
+          {props.progress.completed}/{props.progress.total}
+        </span>
+        <Show when={etaLabel()}>{(label) => <span>{label()}</span>}</Show>
+      </div>
       <div class="h-1 w-full overflow-hidden rounded-full bg-edge-muted">
         <div
           class="h-full rounded-full bg-ink transition-[width] duration-300"
@@ -495,7 +500,7 @@ function InboxRow(props: {
   onRemove: () => void;
 }) {
   return (
-    <div class="bg-surface flex items-center justify-between gap-3 h-15.25 px-6">
+    <div class="bg-surface flex items-center justify-between gap-3 min-h-15.25 py-2 px-6">
       <div class="min-w-0 flex flex-col gap-0.5">
         <div class="flex items-center gap-2 min-w-0">
           <span class="ph-no-capture text-sm truncate">

--- a/js/app/packages/app/component/settings/Email.tsx
+++ b/js/app/packages/app/component/settings/Email.tsx
@@ -425,13 +425,13 @@ function formatEta(seconds: number): string {
 }
 
 function BackfillProgressBar(props: { progress: BackfillProgress }) {
-  const percent = () =>
-    props.progress.total > 0
-      ? Math.min(
-          100,
-          Math.round((props.progress.completed / props.progress.total) * 100)
-        )
-      : 0;
+  const percent = () => {
+    if (props.progress.total <= 0) return 0;
+    // Only reach 100% at actual completion; floor otherwise so e.g. 999/1000
+    // doesn't round up and make the bar look finished early.
+    if (props.progress.completed >= props.progress.total) return 100;
+    return Math.floor((props.progress.completed / props.progress.total) * 100);
+  };
   const etaLabel = createMemo(() => {
     const seconds = estimateEtaSeconds(props.progress);
     return seconds === undefined ? undefined : formatEta(seconds);

--- a/js/app/packages/queries/email/backfill.ts
+++ b/js/app/packages/queries/email/backfill.ts
@@ -5,16 +5,29 @@ import { useQuery } from '@tanstack/solid-query';
 import { createSignal } from 'solid-js';
 import { emailKeys } from './keys';
 
+/** Most recent progress readings kept per link, for the time-remaining estimate. */
+const MAX_PROGRESS_SAMPLES = 5;
+
+/** A timestamped progress reading, used to estimate the recent backfill rate. */
+export type BackfillSample = {
+  /** Wall-clock receive time of the `backfill_progress` event, in ms. */
+  at: number;
+  /** `completed_threads` reported at that time. */
+  completed: number;
+};
+
 /**
  * How far along a link's backfill is, as last reported by a `backfill_progress`
  * websocket event. `completed`/`total` mirror the backend's `completed_threads`
  * / `total_threads`. Both can read slightly above the real mailbox size — the
  * priority pass inflates them in lockstep — so prefer the ratio over the
- * absolute numbers when rendering.
+ * absolute numbers when rendering. `samples` holds the most recent readings
+ * (oldest→newest, capped at MAX_PROGRESS_SAMPLES) used to estimate time left.
  */
 export type BackfillProgress = {
   completed: number;
   total: number;
+  samples: BackfillSample[];
 };
 
 /**
@@ -28,14 +41,23 @@ const [progressByLink, setProgressByLink] = createSignal<
   Map<string, BackfillProgress>
 >(new Map());
 
-/** Record the latest progress for a link, replacing any previous value. */
+/**
+ * Record a progress reading for a link, appending a timestamped sample (only
+ * the most recent MAX_PROGRESS_SAMPLES are kept) so time remaining can be
+ * estimated from the recent rate.
+ */
 export function setBackfillProgress(
   linkId: string,
-  progress: BackfillProgress
+  completed: number,
+  total: number
 ): void {
   setProgressByLink((prev) => {
     const next = new Map(prev);
-    next.set(linkId, progress);
+    const samples = [
+      ...(prev.get(linkId)?.samples ?? []),
+      { at: Date.now(), completed },
+    ].slice(-MAX_PROGRESS_SAMPLES);
+    next.set(linkId, { completed, total, samples });
     return next;
   });
 }
@@ -58,6 +80,30 @@ export function getBackfillProgress(
   linkId: string
 ): BackfillProgress | undefined {
   return progressByLink().get(linkId);
+}
+
+/**
+ * Estimate seconds remaining from the recent backfill rate: the threads
+ * completed and time elapsed across the sample window (the last up to
+ * MAX_PROGRESS_SAMPLES events) give a threads/ms rate, divided into the threads
+ * still left. Returns `undefined` until there are two samples, or when no
+ * forward progress has been observed across the window.
+ */
+export function estimateEtaSeconds(
+  progress: BackfillProgress
+): number | undefined {
+  const { samples, total, completed } = progress;
+  if (samples.length < 2) return undefined;
+
+  const first = samples[0];
+  const last = samples[samples.length - 1];
+  const threadsDone = last.completed - first.completed;
+  const elapsedMs = last.at - first.at;
+  if (threadsDone <= 0 || elapsedMs <= 0) return undefined;
+
+  const threadsLeft = Math.max(0, total - completed);
+  const ratePerMs = threadsDone / elapsedMs;
+  return threadsLeft / ratePerMs / 1000;
 }
 
 /**

--- a/js/app/packages/queries/email/sync.ts
+++ b/js/app/packages/queries/email/sync.ts
@@ -99,10 +99,11 @@ export function handleRefreshEmail(payload: unknown): void {
         toast.success('Inbox synced');
       }
     } else {
-      setBackfillProgress(event.link_id, {
-        completed: event.completed_threads,
-        total: event.total_threads,
-      });
+      setBackfillProgress(
+        event.link_id,
+        event.completed_threads,
+        event.total_threads
+      );
     }
   }
 }


### PR DESCRIPTION
## What

Improves the live backfill indicator in **Settings → Email**:

- "Syncing… 42%" → **"Backfilling… 250/1000"** (thread count instead of percentage).
- Adds an **estimated time remaining** — e.g. `Backfilling… 250/1000 · ~2m left`.

The visual progress bar (filled by ratio) is unchanged.

## How the ETA is computed

The progress store now keeps a small rolling history per link: each `backfill_progress` connection-gateway event appends a timestamped sample `{ at, completed }`, capped at the **last 5**. `estimateEtaSeconds` takes the oldest and newest sample in that window to get threads-done and elapsed-time → a threads/sec rate → divides into the threads still left (`total − completed`). It returns nothing until there are at least two samples or if no forward progress is seen.

It recomputes on each event (every 50 completed threads, plus the first), so it's a rolling estimate rather than a second-by-second countdown. `formatEta` bins to `s` / `m` / `h … m` and rounds up so the figure doesn't visibly jitter between events.

## Files

- `queries/email/backfill.ts` — `BackfillSample`, `samples` on `BackfillProgress`, `setBackfillProgress` now appends timestamped samples, new `estimateEtaSeconds`.
- `queries/email/sync.ts` — updated the setter call to the new `(linkId, completed, total)` signature.
- `app/component/settings/Email.tsx` — `BackfillProgressBar` shows "Backfilling… count · ETA"; added `formatEta`.

## Notes

- Counts can read slightly above the real mailbox size (the priority pass inflates `completed` and `total` in lockstep), but the ratio, rate, and threads-left stay consistent, so the bar and ETA are correct.
- Builds on the live backfill progress shipped in #4263.
