### PR TITLE
chore(scripts): fix S3 extensionless-key reconcile + orphan cleanup

### DIFF
--- a/scripts/migrate-s3-keys-extensionless/.gitignore
+++ b/scripts/migrate-s3-keys-extensionless/.gitignore
@@ -1,3 +1,6 @@
 node_modules/
+__pycache__/
 *.log
 *.txt
+*.done
+*.csv

--- a/scripts/migrate-s3-keys-extensionless/delete-old-keys.ts
+++ b/scripts/migrate-s3-keys-extensionless/delete-old-keys.ts
@@ -52,7 +52,11 @@ const VERSION_WITH_EXT_REGEX = new RegExp(`${UUID_V4}/(\\d+)\\..+$`);
 const SKIP_PATTERNS = [/converted\.pdf$/, /^temp_files\//, /^ONBOARDING_DOCUMENTS\//];
 
 function stripExtension(key: string): string {
-  return key.replace(/(\d+)\..+$/, "$1");
+  // Strip the extension from only the final segment (the version). Operating on
+  // the whole key would match a digits-dot inside the owner email (e.g.
+  // user12.foo), mangling the target. Handles multipart extensions (.js.map).
+  const slash = key.lastIndexOf("/");
+  return key.slice(0, slash + 1) + key.slice(slash + 1).replace(/\..+$/, "");
 }
 
 function shouldDelete(key: string): boolean {

--- a/scripts/migrate-s3-keys-extensionless/delete-orphan-documents.py
+++ b/scripts/migrate-s3-keys-extensionless/delete-orphan-documents.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Hard-delete orphaned documents (DB row + related rows), mirroring the app's
+permanent-delete path.
+
+Use this for documents that the DB lists as active with content in object
+storage, but which have NO S3 object at all (produced by
+`reconcile-extensionless-keys.py find` cross-referenced with the DB). Because
+the blob is already gone, the app's S3-cleanup enqueue is a no-op and is
+skipped here.
+
+It reproduces `macro_db_client::document::delete_document_bulk_tsx` plus the
+permanent-delete handler's entity-mention cleanup, in one transaction per
+batch (so a batch is all-or-nothing):
+
+  Pin -> UserHistory -> SharePermission (via DocumentPermission) -> Document
+  -> entity_access -> comms_entity_mentions
+
+It does NOT remove OpenSearch entries; these docs failed indexing (NoSuchKey)
+so they are not in the index. Pass --remove-from-search to additionally enqueue
+RemoveDocument to the search queue if you want belt-and-suspenders.
+
+Connection: reads DATABASE_URL from the env, e.g.
+  export DATABASE_URL="$(aws secretsmanager get-secret-value \
+     --secret-id macro-db-prod --region us-east-1 --query SecretString --output text)?sslmode=require"
+
+Usage:
+  # blast-radius report, deletes nothing (default):
+  python3 delete-orphan-documents.py --in missing_doc_ids.txt
+  # actually delete:
+  python3 delete-orphan-documents.py --in missing_doc_ids.txt --apply
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+
+TABLES_REPORT = [
+    ('Pin', 'SELECT count(*) FROM "Pin" WHERE "pinnedItemId" IN (SELECT id FROM _ids) AND "pinnedItemType"=\'document\''),
+    ('UserHistory', 'SELECT count(*) FROM "UserHistory" WHERE "itemId" IN (SELECT id FROM _ids) AND "itemType"=\'document\''),
+    ('SharePermission', 'SELECT count(*) FROM "SharePermission" sp JOIN "DocumentPermission" dp ON dp."sharePermissionId"=sp.id WHERE dp."documentId" IN (SELECT id FROM _ids)'),
+    ('entity_access', 'SELECT count(*) FROM "entity_access" WHERE entity_id IN (SELECT id::uuid FROM _ids) AND entity_type=\'document\''),
+    ('comms_entity_mentions', 'SELECT count(*) FROM comms_entity_mentions WHERE source_entity_id IN (SELECT id FROM _ids)'),
+    ('Document', 'SELECT count(*) FROM "Document" WHERE id IN (SELECT id FROM _ids)'),
+]
+
+# Mirrors delete_document_bulk_tsx + handler entity-mention cleanup. Order matters:
+# SharePermission joins DocumentPermission so it must run before Document is deleted.
+DELETE_STMTS = [
+    'DELETE FROM "Pin" WHERE "pinnedItemId" IN (SELECT id FROM _ids) AND "pinnedItemType"=\'document\'',
+    'DELETE FROM "UserHistory" WHERE "itemId" IN (SELECT id FROM _ids) AND "itemType"=\'document\'',
+    'DELETE FROM "SharePermission" sp USING "DocumentPermission" dp WHERE dp."sharePermissionId"=sp.id AND dp."documentId" IN (SELECT id FROM _ids)',
+    'DELETE FROM "Document" WHERE id IN (SELECT id FROM _ids)',
+    'DELETE FROM "entity_access" WHERE entity_id IN (SELECT id::uuid FROM _ids) AND entity_type=\'document\'',
+    'DELETE FROM comms_entity_mentions WHERE source_entity_id IN (SELECT id FROM _ids)',
+]
+
+SEARCH_QUEUE = "https://sqs.us-east-1.amazonaws.com/569036502058/search-event-queue-prod"
+
+
+def psql(dburl, sql, extra=()):
+    r = subprocess.run(["psql", dburl, "-v", "ON_ERROR_STOP=1", "-q", "-P", "pager=off",
+                        *extra, "-c", sql], capture_output=True, text=True)
+    return r.returncode, r.stdout, r.stderr
+
+
+def values_clause(ids):
+    return ",".join("('" + i.replace("'", "''") + "')" for i in ids)
+
+
+def cmd_report(dburl, ids):
+    vals = values_clause(ids)
+    selects = " UNION ALL ".join(f"SELECT '{name}' AS tbl, ({q}) AS n" for name, q in TABLES_REPORT)
+    sql = f"CREATE TEMP TABLE _ids(id text); INSERT INTO _ids VALUES {vals}; {selects};"
+    rc, out, err = psql(dburl, sql, extra=("-At", "-F", "|"))
+    if rc != 0:
+        print(err, file=sys.stderr); sys.exit(1)
+    print(f"blast radius for {len(ids):,} ids (rows that WOULD be deleted):")
+    for ln in out.splitlines():
+        if "|" in ln:
+            name, n = ln.split("|", 1)
+            print(f"  {name:24} {int(n):>10,}")
+
+
+def cmd_apply(dburl, ids, batch, done_path, remove_from_search):
+    done = set()
+    if os.path.exists(done_path):
+        done = {x.strip() for x in open(done_path) if x.strip()}
+    todo = [i for i in ids if i not in done]
+    print(f"{len(ids):,} ids, {len(done):,} already done, {len(todo):,} to delete")
+    done_f = open(done_path, "a")
+    deleted_docs = 0
+    for start in range(0, len(todo), batch):
+        chunk = todo[start:start + batch]
+        vals = values_clause(chunk)
+        stmts = ";\n".join(DELETE_STMTS)
+        sql = (f"BEGIN;\nCREATE TEMP TABLE _ids(id text) ON COMMIT DROP;\n"
+               f"INSERT INTO _ids VALUES {vals};\n{stmts};\nCOMMIT;")
+        rc, out, err = psql(dburl, sql)
+        if rc != 0:
+            print(f"BATCH FAILED at offset {start} (rolled back): {err[:300]}", file=sys.stderr)
+            sys.exit(1)
+        for i in chunk:
+            done_f.write(i + "\n")
+        done_f.flush()
+        deleted_docs += len(chunk)
+        if remove_from_search:
+            for i in chunk:
+                subprocess.run(["aws", "sqs", "send-message", "--queue-url", SEARCH_QUEUE,
+                                "--region", "us-east-1", "--message-body",
+                                '{"RemoveDocument":{"document_id":"' + i + '"}}'],
+                               capture_output=True, text=True)
+        print(f"  committed {deleted_docs:,}/{len(todo):,}")
+    print(f"done; deleted {deleted_docs:,} documents (+ related rows)")
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--in", dest="infile", default="missing_doc_ids.txt")
+    ap.add_argument("--batch-size", type=int, default=500)
+    ap.add_argument("--apply", action="store_true", help="actually delete (default: report only)")
+    ap.add_argument("--progress", default=None, help="done-ids file for resume")
+    ap.add_argument("--remove-from-search", action="store_true",
+                    help="also enqueue RemoveDocument to the search queue")
+    args = ap.parse_args()
+
+    dburl = os.environ.get("DATABASE_URL")
+    if not dburl:
+        print("set DATABASE_URL (see header)", file=sys.stderr); sys.exit(2)
+    ids = [x.strip() for x in open(args.infile) if x.strip()]
+    if not ids:
+        print("no ids", file=sys.stderr); sys.exit(1)
+
+    if args.apply:
+        cmd_apply(dburl, ids, args.batch_size, args.progress or (args.infile + ".done"),
+                  args.remove_from_search)
+    else:
+        cmd_report(dburl, ids)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/migrate-s3-keys-extensionless/index.ts
+++ b/scripts/migrate-s3-keys-extensionless/index.ts
@@ -1,3 +1,13 @@
+/*
+ * WARNING: the full-bucket scan (migrateFromScan) crashes silently mid-scan
+ * under bun + @aws-sdk when issuing concurrent HeadObject calls — the process
+ * exits partway through with no error, stack, or completion line, so it is not
+ * a catchable JS failure. For any full-bucket pass PREFER the list-only Python
+ * tool `reconcile-extensionless-keys.py` (find/copy/delete), which does not
+ * crash. This script is only safe in KEYS_FILE mode (migrateFromFile), which
+ * reads a key list and skips the scan. The same caveat applies to
+ * delete-old-keys.ts.
+ */
 import {
   CopyObjectCommand,
   HeadObjectCommand,
@@ -99,8 +109,11 @@ function buildPrefix(): string | undefined {
 }
 
 function stripExtension(key: string): string {
-  // Strip everything after the version_id (handles multipart extensions like .js.map)
-  return key.replace(/(\d+)\..+$/, '$1');
+  // Strip the extension from only the final segment (the version). Operating on
+  // the whole key would match a digits-dot inside the owner email (e.g.
+  // user12.foo), mangling the target. Handles multipart extensions (.js.map).
+  const slash = key.lastIndexOf('/');
+  return key.slice(0, slash + 1) + key.slice(slash + 1).replace(/\..+$/, '');
 }
 
 function shouldProcess(key: string): boolean {

--- a/scripts/migrate-s3-keys-extensionless/reconcile-extensionless-keys.py
+++ b/scripts/migrate-s3-keys-extensionless/reconcile-extensionless-keys.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Reconcile S3 document keys to the extensionless convention without the
+fragile bun full-bucket scan.
+
+The bun migrator (index.ts) walks the whole bucket issuing concurrent
+HeadObject calls, which crashes silently under bun + the AWS SDK on large
+buckets. This tool splits the work into a read-only `find` pass that streams
+the bucket with list-only calls (`aws s3 ls`), and a `copy` pass that only
+touches the keys `find` flagged.
+
+A "version" is one S3 object identity `{owner}/{uuid}/{version}`. The
+migration target for `{version}.{ext}` is the extensionless `{version}`.
+A version is classified as:
+  clean  - only the extensionless key exists (already migrated)
+  both   - extensionless + leftover .ext both exist (copied, not yet deleted)
+  missed - only the .ext key exists -> the read path 404s (the gap to fix)
+
+Usage:
+  # 1. find the gap (read-only; needs s3:ListBucket)
+  python3 reconcile-extensionless-keys.py find --out missing_ext_keys.txt
+
+  # 2. copy only the missing keys to their extensionless target
+  #    (needs s3:GetObject + s3:PutObject; e.g. AWS_PROFILE=s3-migrate-prod)
+  python3 reconcile-extensionless-keys.py copy --in missing_ext_keys.txt --dry-run
+  python3 reconcile-extensionless-keys.py copy --in missing_ext_keys.txt
+
+Re-running `find` after `copy` is the verification step: missed should be 0.
+"""
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+DEFAULT_BUCKET = os.environ.get("S3_BUCKET", "macro-document-storage-prod")
+DEFAULT_PREFIX = os.environ.get("PREFIX", "macro|")
+REGION = os.environ.get("AWS_REGION", "us-east-1")
+
+UUID = r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+EXTLESS_TAIL = re.compile(r"^(\d+)$")
+EXT_TAIL = re.compile(r"^(\d+)\..+$")
+UUID_RE = re.compile(f"^{UUID}$")
+
+
+def extensionless_target(key):
+    """Strip the extension from only the final segment (the version), so dots
+    in the owner email (e.g. user12.foo) are never touched."""
+    parts = key.split("/")
+    parts[-1] = parts[-1].split(".", 1)[0]
+    return "/".join(parts)
+
+
+def parse_key(key):
+    """Return (version_identity, form, key) or None for out-of-scope keys."""
+    parts = key.split("/")
+    if len(parts) != 3 or not UUID_RE.match(parts[1]):
+        return None
+    tail = parts[2]
+    if tail == "converted.pdf":
+        return None
+    m = EXTLESS_TAIL.match(tail)
+    if m:
+        return f"{parts[0]}/{parts[1]}/{m.group(1)}", "extless", key
+    m = EXT_TAIL.match(tail)
+    if m:
+        return f"{parts[0]}/{parts[1]}/{m.group(1)}", "ext", key
+    return None
+
+
+def cmd_find(args):
+    out = open(args.out, "w")
+    proc = subprocess.Popen(
+        ["aws", "s3", "ls", f"s3://{args.bucket}/{args.prefix}",
+         "--recursive", "--region", args.region],
+        stdout=subprocess.PIPE, text=True,
+    )
+    clean = both = missed = total = 0
+    cur = None
+    forms = {}
+    t0 = time.time()
+
+    def flush():
+        nonlocal clean, both, missed
+        if cur is None:
+            return
+        if "ext" in forms and "extless" in forms:
+            both += 1
+        elif "extless" in forms:
+            clean += 1
+        elif "ext" in forms:
+            missed += 1
+            out.write(forms["ext"] + "\n")
+
+    for line in proc.stdout:
+        parts = line.rstrip("\n").split(None, 3)
+        if len(parts) < 4:
+            continue
+        total += 1
+        parsed = parse_key(parts[3])
+        if not parsed:
+            continue
+        ident, form, key = parsed
+        if ident != cur:
+            flush()
+            cur = ident
+            forms = {}
+        forms[form] = key
+        if total % 500000 == 0:
+            print(f"[{time.time()-t0:5.0f}s] scanned={total:,} clean={clean:,} "
+                  f"both={both:,} missed={missed:,}", flush=True)
+    flush()
+    out.close()
+    rc = proc.wait()
+    if rc != 0:
+        print(f"WARNING: aws s3 ls exited {rc} - results may be incomplete", file=sys.stderr)
+    print(f"\nscanned={total:,} keys")
+    print(f"  clean (extensionless only): {clean:,}")
+    print(f"  both  (leftover .ext):      {both:,}")
+    print(f"  missed (.ext only -> 404):  {missed:,}  -> wrote to {args.out}")
+    return 1 if rc != 0 else 0
+
+
+def cmd_copy(args):
+    keys = [k.strip() for k in open(args.infile) if k.strip()]
+    done_path = args.progress or (args.infile + ".done")
+    done = set()
+    if os.path.exists(done_path):
+        done = {k.strip() for k in open(done_path) if k.strip()}
+    todo = [k for k in keys if k not in done]
+    print(f"{len(keys):,} keys, {len(done):,} already done, {len(todo):,} to copy"
+          + (" (DRY RUN)" if args.dry_run else ""))
+
+    done_file = None if args.dry_run else open(done_path, "a")
+    errors = 0
+    copied = 0
+    lock_t0 = time.time()
+
+    def do_copy(src_key):
+        target = extensionless_target(src_key)
+        # Pass the source raw; the AWS CLI URL-encodes copy-source once.
+        # Pre-encoding here causes double-encoding -> spurious NoSuchKey.
+        copy_source = f"{args.bucket}/{src_key}"
+        if args.dry_run:
+            return (src_key, target, None)
+        r = subprocess.run(
+            ["aws", "s3api", "copy-object", "--bucket", args.bucket,
+             "--key", target, "--copy-source", copy_source,
+             "--region", args.region, "--no-cli-pager"],
+            capture_output=True, text=True,
+        )
+        return (src_key, target, r.returncode == 0 and None or r.stderr[:200])
+
+    with ThreadPoolExecutor(max_workers=args.concurrency) as ex:
+        for src_key, target, err in ex.map(do_copy, todo):
+            if args.dry_run:
+                if copied < 10:
+                    print(f"  would copy {src_key} -> {target}")
+                copied += 1
+                continue
+            if err:
+                errors += 1
+                print(f"ERROR {src_key}: {err}", file=sys.stderr)
+            else:
+                copied += 1
+                done_file.write(src_key + "\n")
+                if copied % 1000 == 0:
+                    done_file.flush()
+                    print(f"[{time.time()-lock_t0:5.0f}s] copied={copied:,} errors={errors}", flush=True)
+    if done_file:
+        done_file.close()
+    print(f"\n{'would copy' if args.dry_run else 'copied'}={copied:,} errors={errors}")
+    return 1 if errors else 0
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--bucket", default=DEFAULT_BUCKET)
+    ap.add_argument("--region", default=REGION)
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    f = sub.add_parser("find", help="read-only: list bucket, write .ext-only keys")
+    f.add_argument("--prefix", default=DEFAULT_PREFIX)
+    f.add_argument("--out", default="missing_ext_keys.txt")
+    f.set_defaults(func=cmd_find)
+
+    c = sub.add_parser("copy", help="copy .ext keys to their extensionless target")
+    c.add_argument("--in", dest="infile", required=True)
+    c.add_argument("--concurrency", type=int, default=20)
+    c.add_argument("--progress", default=None, help="done-keys file for resume")
+    c.add_argument("--dry-run", action="store_true")
+    c.set_defaults(func=cmd_copy)
+
+    args = ap.parse_args()
+    sys.exit(args.func(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/migrate-s3-keys-extensionless/reconcile-extensionless-keys.py
+++ b/scripts/migrate-s3-keys-extensionless/reconcile-extensionless-keys.py
@@ -5,8 +5,8 @@ fragile bun full-bucket scan.
 The bun migrator (index.ts) walks the whole bucket issuing concurrent
 HeadObject calls, which crashes silently under bun + the AWS SDK on large
 buckets. This tool splits the work into a read-only `find` pass that streams
-the bucket with list-only calls (`aws s3 ls`), and a `copy` pass that only
-touches the keys `find` flagged.
+the bucket with list-only calls (`aws s3 ls`), then `copy` / `purge` passes
+that only touch the keys `find` flagged.
 
 A "version" is one S3 object identity `{owner}/{uuid}/{version}`. The
 migration target for `{version}.{ext}` is the extensionless `{version}`.
@@ -16,18 +16,28 @@ A version is classified as:
   missed - only the .ext key exists -> the read path 404s (the gap to fix)
 
 Usage:
-  # 1. find the gap (read-only; needs s3:ListBucket)
-  python3 reconcile-extensionless-keys.py find --out missing_ext_keys.txt
+  # 1. find: write missed (.ext-only) keys, and optionally the purgeable
+  #    (doubly-stored "both") .ext keys. Read-only; needs s3:ListBucket.
+  python3 reconcile-extensionless-keys.py find \
+      --out missing_ext_keys.txt --purgeable-out purgeable_ext_keys.txt
 
-  # 2. copy only the missing keys to their extensionless target
+  # 2. copy missed keys to their extensionless target
   #    (needs s3:GetObject + s3:PutObject; e.g. AWS_PROFILE=s3-migrate-prod)
   python3 reconcile-extensionless-keys.py copy --in missing_ext_keys.txt --dry-run
   python3 reconcile-extensionless-keys.py copy --in missing_ext_keys.txt
 
+  # 3. purge the redundant .ext keys whose extensionless twin already exists
+  #    (needs s3:DeleteObject; dry-run by default, --apply to delete)
+  python3 reconcile-extensionless-keys.py purge --in purgeable_ext_keys.txt
+  python3 reconcile-extensionless-keys.py purge --in purgeable_ext_keys.txt --apply
+
 Re-running `find` after `copy` is the verification step: missed should be 0.
+Generate the purge list with `find` immediately before purging so it reflects
+current bucket state.
 """
 
 import argparse
+import json
 import os
 import re
 import subprocess
@@ -72,6 +82,7 @@ def parse_key(key):
 
 def cmd_find(args):
     out = open(args.out, "w")
+    purge_out = open(args.purgeable_out, "w") if args.purgeable_out else None
     proc = subprocess.Popen(
         ["aws", "s3", "ls", f"s3://{args.bucket}/{args.prefix}",
          "--recursive", "--region", args.region],
@@ -79,20 +90,25 @@ def cmd_find(args):
     )
     clean = both = missed = total = 0
     cur = None
-    forms = {}
+    has_extless = False
+    ext_keys = []
     t0 = time.time()
 
     def flush():
         nonlocal clean, both, missed
         if cur is None:
             return
-        if "ext" in forms and "extless" in forms:
+        if has_extless and ext_keys:
             both += 1
-        elif "extless" in forms:
+            if purge_out:
+                for k in ext_keys:
+                    purge_out.write(k + "\n")
+        elif has_extless:
             clean += 1
-        elif "ext" in forms:
+        elif ext_keys:
             missed += 1
-            out.write(forms["ext"] + "\n")
+            for k in ext_keys:
+                out.write(k + "\n")
 
     for line in proc.stdout:
         parts = line.rstrip("\n").split(None, 3)
@@ -106,19 +122,26 @@ def cmd_find(args):
         if ident != cur:
             flush()
             cur = ident
-            forms = {}
-        forms[form] = key
+            has_extless = False
+            ext_keys = []
+        if form == "extless":
+            has_extless = True
+        else:
+            ext_keys.append(key)
         if total % 500000 == 0:
             print(f"[{time.time()-t0:5.0f}s] scanned={total:,} clean={clean:,} "
                   f"both={both:,} missed={missed:,}", flush=True)
     flush()
     out.close()
+    if purge_out:
+        purge_out.close()
     rc = proc.wait()
     if rc != 0:
         print(f"WARNING: aws s3 ls exited {rc} - results may be incomplete", file=sys.stderr)
     print(f"\nscanned={total:,} keys")
     print(f"  clean (extensionless only): {clean:,}")
-    print(f"  both  (leftover .ext):      {both:,}")
+    print(f"  both  (leftover .ext):      {both:,}"
+          + (f"  -> wrote to {args.purgeable_out}" if purge_out else ""))
     print(f"  missed (.ext only -> 404):  {missed:,}  -> wrote to {args.out}")
     return 1 if rc != 0 else 0
 
@@ -175,6 +198,62 @@ def cmd_copy(args):
     return 1 if errors else 0
 
 
+def cmd_purge(args):
+    keys = [k.strip() for k in open(args.infile) if k.strip()]
+    done_path = args.progress or (args.infile + ".done")
+    done = set()
+    if os.path.exists(done_path):
+        done = {k.strip() for k in open(done_path) if k.strip()}
+    todo = [k for k in keys if k not in done]
+    print(f"{len(keys):,} .ext keys, {len(done):,} already purged, {len(todo):,} to purge"
+          + ("" if args.apply else "   (DRY RUN - pass --apply to delete)"))
+    if not args.apply:
+        for k in todo[:10]:
+            print(f"  would delete {k}  (keeps {extensionless_target(k)})")
+        return 0
+
+    def twin_exists(k):
+        r = subprocess.run(["aws", "s3api", "head-object", "--bucket", args.bucket,
+                            "--key", extensionless_target(k), "--region", args.region],
+                           capture_output=True, text=True)
+        return k if r.returncode == 0 else None
+
+    done_file = open(done_path, "a")
+    deleted = errors = skipped = 0
+    t0 = time.time()
+    for start in range(0, len(todo), 1000):
+        batch = todo[start:start + 1000]
+        if args.verify:
+            # only delete a .ext key whose extensionless twin still exists
+            with ThreadPoolExecutor(max_workers=args.concurrency) as ex:
+                verified = [k for k in ex.map(twin_exists, batch) if k]
+            skipped += len(batch) - len(verified)
+            batch = verified
+            if not batch:
+                continue
+        payload = json.dumps({"Objects": [{"Key": k} for k in batch], "Quiet": True})
+        r = subprocess.run(["aws", "s3api", "delete-objects", "--bucket", args.bucket,
+                            "--region", args.region, "--no-cli-pager", "--delete", payload],
+                           capture_output=True, text=True)
+        if r.returncode != 0:
+            print(f"BATCH FAILED at offset {start}: {r.stderr[:300]}", file=sys.stderr)
+            sys.exit(1)
+        batch_errors = json.loads(r.stdout).get("Errors", []) if r.stdout.strip() else []
+        failed = {e.get("Key") for e in batch_errors}
+        for k in batch:
+            if k not in failed:
+                done_file.write(k + "\n")
+        done_file.flush()
+        deleted += len(batch) - len(failed)
+        errors += len(failed)
+        for e in batch_errors[:5]:
+            print(f"ERROR {e.get('Key')}: {e.get('Code')} {e.get('Message')}", file=sys.stderr)
+        print(f"[{time.time()-t0:5.0f}s] purged={deleted:,} errors={errors} skipped={skipped}", flush=True)
+    done_file.close()
+    print(f"\npurged={deleted:,} errors={errors} skipped(no twin)={skipped}")
+    return 1 if errors else 0
+
+
 def main():
     ap = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
@@ -182,9 +261,11 @@ def main():
     ap.add_argument("--region", default=REGION)
     sub = ap.add_subparsers(dest="cmd", required=True)
 
-    f = sub.add_parser("find", help="read-only: list bucket, write .ext-only keys")
+    f = sub.add_parser("find", help="read-only: list bucket, write .ext-only (and optionally purgeable) keys")
     f.add_argument("--prefix", default=DEFAULT_PREFIX)
     f.add_argument("--out", default="missing_ext_keys.txt")
+    f.add_argument("--purgeable-out", default=None,
+                   help="also write doubly-stored .ext keys (twin exists) here")
     f.set_defaults(func=cmd_find)
 
     c = sub.add_parser("copy", help="copy .ext keys to their extensionless target")
@@ -193,6 +274,15 @@ def main():
     c.add_argument("--progress", default=None, help="done-keys file for resume")
     c.add_argument("--dry-run", action="store_true")
     c.set_defaults(func=cmd_copy)
+
+    p = sub.add_parser("purge", help="delete redundant .ext keys whose extensionless twin exists")
+    p.add_argument("--in", dest="infile", required=True)
+    p.add_argument("--apply", action="store_true", help="actually delete (default: report only)")
+    p.add_argument("--verify", action="store_true",
+                   help="HeadObject the extensionless twin before deleting each key")
+    p.add_argument("--concurrency", type=int, default=20, help="parallelism for --verify")
+    p.add_argument("--progress", default=None, help="done-keys file for resume")
+    p.set_defaults(func=cmd_purge)
 
     args = ap.parse_args()
     sys.exit(args.func(args))

--- a/scripts/migrate-s3-keys-extensionless/reconcile-extensionless-keys.py
+++ b/scripts/migrate-s3-keys-extensionless/reconcile-extensionless-keys.py
@@ -236,8 +236,26 @@ def cmd_purge(args):
                             "--region", args.region, "--no-cli-pager", "--delete", payload],
                            capture_output=True, text=True)
         if r.returncode != 0:
-            print(f"BATCH FAILED at offset {start}: {r.stderr[:300]}", file=sys.stderr)
-            sys.exit(1)
+            # The batch XML body was rejected (e.g. MalformedXML from one
+            # problematic key). Fall back to per-key delete-object, which sends
+            # the key as a request parameter (no XML body) and so can't hit this.
+            print(f"batch at offset {start} rejected ({r.stderr.strip()[:80]}); per-key fallback",
+                  file=sys.stderr)
+            with ThreadPoolExecutor(max_workers=args.concurrency) as ex:
+                results = list(ex.map(lambda k: (k, subprocess.run(
+                    ["aws", "s3api", "delete-object", "--bucket", args.bucket, "--key", k,
+                     "--region", args.region, "--no-cli-pager"],
+                    capture_output=True, text=True).returncode), batch))
+            for k, code in results:
+                if code == 0:
+                    done_file.write(k + "\n")
+                    deleted += 1
+                else:
+                    errors += 1
+                    print(f"ERROR (per-key) {k!r}", file=sys.stderr)
+            done_file.flush()
+            print(f"[{time.time()-t0:5.0f}s] purged={deleted:,} errors={errors} skipped={skipped}", flush=True)
+            continue
         batch_errors = json.loads(r.stdout).get("Errors", []) if r.stdout.strip() else []
         failed = {e.get("Key") for e in batch_errors}
         for k in batch:


### PR DESCRIPTION
Adds bun-free Python tooling for the S3 extensionless-key migration: `reconcile-extensionless-keys.py` (list-only find/copy — the bun full-bucket scan crashes silently under bun + aws-sdk on concurrent HeadObject) and `delete-orphan-documents.py` (app-faithful hard delete of active `object_storage` docs whose S3 blob is gone). Also fixes the `stripExtension` regex in the bun scripts, which mangled the target key for owners whose email contains a digits-then-dot sequence (e.g. `user12.foo`).
