### PR TITLE
Run pubsub workers locally

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -203,6 +203,27 @@ services:
       start_period: 10s
 
   # ============================================================================
+  # email_pubsub_workers (local worker)
+  # Consumes the email SQS queues (backfill, scheduled, gmail sync/ops, sfs,
+  # link manager). Runs as its own deployment in prod; locally it's its own
+  # container alongside email_service. No HTTP port — pure SQS consumer.
+  # ============================================================================
+  email_pubsub_workers:
+    <<: [*common-env, *rust-services-image]
+    command: ["/app/out/pubsub_workers"]
+    depends_on:
+      - postgres
+      - redis
+      - authentication-service
+      - document_storage_service
+      - connection_gateway
+      - static_file_service
+      - email_service
+    networks:
+      - databases
+      - services
+
+  # ============================================================================
   # notification_service (Port 8089)
   # User notifications - NotificationDB
   # ============================================================================

--- a/rust/cloud-storage/Dockerfile.dev
+++ b/rust/cloud-storage/Dockerfile.dev
@@ -22,6 +22,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=shared \
         --bin document_storage_service \
         --bin document_upload_finalizer_local_worker \
         --bin email_service \
+        --bin pubsub_workers \
         --bin notification_service \
         --bin static_file_service \
         --bin unfurl_service \
@@ -34,6 +35,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=shared \
     && cp /app/target/debug/document_storage_service /app/out/ \
     && cp /app/target/debug/document_upload_finalizer_local_worker /app/out/ \
     && cp /app/target/debug/email_service /app/out/ \
+    && cp /app/target/debug/pubsub_workers /app/out/ \
     && cp /app/target/debug/notification_service /app/out/ \
     && cp /app/target/debug/static_file_service /app/out/ \
     && cp /app/target/debug/unfurl_service /app/out/ \


### PR DESCRIPTION
Needed for email pubsub operations (backfill, inbox sync, message sending, etc)