### PR TITLE
fix(email): clean up reply draft when the body is emptied

### DIFF
--- a/js/app/packages/block-email/component/BaseInput.tsx
+++ b/js/app/packages/block-email/component/BaseInput.tsx
@@ -690,10 +690,7 @@ export function BaseInput(props: {
       !hasDraftContent(
         prepared.bodyText,
         form().subject(),
-        form().attachments.list().length,
-        form().recipients().to.length +
-          form().recipients().cc.length +
-          form().recipients().bcc.length
+        form().attachments.list().length
       )
     ) {
       return null;

--- a/js/app/packages/block-email/component/BaseInput.tsx
+++ b/js/app/packages/block-email/component/BaseInput.tsx
@@ -717,6 +717,7 @@ export function BaseInput(props: {
       if (draftId) {
         await deleteDraftMutation.mutateAsync({
           draftId,
+          threadId: ctx.thread()?.db_id,
           linkId: headerLinkId(),
         });
         refetchThreadMessages();
@@ -1089,6 +1090,7 @@ export function BaseInput(props: {
       if (draftId) {
         await deleteDraftMutation.mutateAsync({
           draftId,
+          threadId: ctx.thread()?.db_id,
           linkId: headerLinkId(),
         });
         refetchThreadMessages();

--- a/js/app/packages/block-email/component/compose/Compose.tsx
+++ b/js/app/packages/block-email/component/compose/Compose.tsx
@@ -231,6 +231,7 @@ export function EmailCompose(props: EmailComposeProps) {
       if (draftID) {
         await deleteDraftMutation.mutateAsync({
           draftId: draftID,
+          threadId: currentThreadID(),
           linkId: headerLinkId(),
         });
       }
@@ -602,6 +603,7 @@ export function EmailCompose(props: EmailComposeProps) {
     if (draftId) {
       await deleteDraftMutation.mutateAsync({
         draftId,
+        threadId: currentThreadID(),
         linkId: headerLinkId(),
       });
     }

--- a/js/app/packages/block-email/util/prepareEmailBody.ts
+++ b/js/app/packages/block-email/util/prepareEmailBody.ts
@@ -509,7 +509,9 @@ export function prepareEmailBody(
 
 /**
  * Returns true if the draft has meaningful user content worth saving.
- * Auto-filled reply/forward subjects alone don't count.
+ * Auto-filled reply/forward subjects alone don't count. Pass recipientCount
+ * only when recipients are user-entered (compose) and should keep the draft
+ * alive — reply recipients are auto-derived, so the reply path omits it.
  */
 export function hasDraftContent(
   bodyText: string,

--- a/js/app/packages/queries/email/draft.ts
+++ b/js/app/packages/queries/email/draft.ts
@@ -1,6 +1,6 @@
 import { toast } from '@core/component/Toast/Toast';
 import { throwOnErr } from '@core/util/result';
-import { invalidateSoupEntity, refetchSoupEntity } from '@queries/soup/cache';
+import { refetchSoupEntity } from '@queries/soup/cache';
 import { emailClient } from '@service-email/client';
 import type {
   ApiDraftInput,
@@ -64,6 +64,8 @@ export function useSaveDraftMutation(
 
 type DeleteDraftParams = {
   draftId: string;
+  /** Thread the draft belonged to, refetched so it leaves the drafts tab. */
+  threadId?: string;
   /** Target inbox for a non-primary inbox; sent as the X-Email-Link-Id header. */
   linkId?: string;
 };
@@ -91,7 +93,13 @@ export function useDeleteDraftMutation(
           queryClient.invalidateQueries({
             queryKey: emailKeys.previews._def,
           });
-          invalidateSoupEntity(vars.draftId);
+          // Refetch the thread (not the deleted draft) so it drops from the
+          // drafts tab without a manual refresh. No-op for compose drafts,
+          // whose thread is deleted along with the draft, so the refetch
+          // finds nothing to update.
+          if (vars.threadId) {
+            refetchSoupEntity(vars.threadId, 'emailThread');
+          }
         },
       },
       callbacks


### PR DESCRIPTION
Emptying a reply's body left an empty draft behind because `hasDraftContent` counted the auto-derived reply recipients as content, so `collectDraft` never returned null and the draft was re-saved instead of deleted. The reply path now omits recipients from the content check (compose still counts user-entered recipients), so clearing a reply deletes its draft. Verified in-app: typing creates a draft, clearing the body removes it.
