### PR TITLE
fix(ci): global sccache cache tag + tolerate zero-test filters

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -5,3 +5,4 @@ self-hosted-runner:
     - namespace-profile-linux-mid
     - namespace-profile-linux-small
     - namespace-profile-linux-rust-ci
+    - namespace-profile-linux-rust-ci;overrides.cache-tag=sccache-ci

--- a/.github/workflows/code_check_cloud_storage.yml
+++ b/.github/workflows/code_check_cloud_storage.yml
@@ -110,7 +110,7 @@ jobs:
     needs:
     - path-check
     if: needs.path-check.outputs.should_run == 'true' && github.event.pull_request.draft == false
-    runs-on: namespace-profile-linux-rust-ci
+    runs-on: namespace-profile-linux-rust-ci;overrides.cache-tag=sccache-ci
     env:
       RUSTFLAGS: '-Dwarnings -Dclippy::disallowed_methods -C link-arg=-fuse-ld=mold'
       RUSTDOCFLAGS: '-Dwarnings'
@@ -193,7 +193,7 @@ jobs:
     needs:
     - path-check
     if: needs.path-check.outputs.should_run == 'true' && github.event.pull_request.draft == false
-    runs-on: namespace-profile-linux-rust-ci
+    runs-on: namespace-profile-linux-rust-ci;overrides.cache-tag=sccache-ci
     env:
       NEXTEST_FILTER: ${{ needs.path-check.outputs.nextest_filter }}
       NEXTEST_TEST_THREADS: '32'
@@ -265,7 +265,9 @@ jobs:
       run: |
         cd rust/cloud-storage
 
-        args=(--all-features --lib --bins --tests --test-threads "$NEXTEST_TEST_THREADS")
+        # --no-tests=pass: a package filter (e.g. an xtask/tooling-only PR -> rdeps(=xtask))
+        # can legitimately select zero tests; treat that as success, not nextest's default error.
+        args=(--all-features --lib --bins --tests --no-tests=pass --test-threads "$NEXTEST_TEST_THREADS")
         if [ -n "$NEXTEST_FILTER" ]; then
           args+=(-E "$NEXTEST_FILTER")
         fi

--- a/rust/cloud-storage/tools/xtask/src/workflows/code_check_cloud_storage.rs
+++ b/rust/cloud-storage/tools/xtask/src/workflows/code_check_cloud_storage.rs
@@ -58,7 +58,7 @@ fn path_check() -> Job {
 /// fmt + clippy (and Doppler-config validation).
 fn check() -> Job {
     steps::gated_job()
-        .runs_on(runners::Runner::LinuxRustCi.to_string())
+        .runs_on(runners::Runner::LinuxRustCi.with_cache_tag(vars::CI_CACHE_TAG))
         .add_env((
             "RUSTFLAGS",
             "-Dwarnings -Dclippy::disallowed_methods -C link-arg=-fuse-ld=mold",
@@ -78,7 +78,7 @@ fn check() -> Job {
 /// cargo nextest against postgres + redis service containers.
 fn test() -> Job {
     steps::gated_job()
-        .runs_on(runners::Runner::LinuxRustCi.to_string())
+        .runs_on(runners::Runner::LinuxRustCi.with_cache_tag(vars::CI_CACHE_TAG))
         .add_env((
             "NEXTEST_FILTER",
             "${{ needs.path-check.outputs.nextest_filter }}",

--- a/rust/cloud-storage/tools/xtask/src/workflows/runners.rs
+++ b/rust/cloud-storage/tools/xtask/src/workflows/runners.rs
@@ -28,3 +28,19 @@ impl fmt::Display for Runner {
         })
     }
 }
+
+impl Runner {
+    /// Render the `runs-on` label with an explicit, branch-independent cache
+    /// *tag* (`<profile>;overrides.cache-tag=<tag>`).
+    ///
+    /// By default Namespace scopes a profile's cache volume per branch: a fresh
+    /// branch can only inherit the *default* branch's cache, so any branch whose
+    /// workflow never runs on `main` starts cold every time. Pinning a fixed tag
+    /// makes every branch read/write the *same* volume — one global cache, like
+    /// the old shared S3 sccache bucket. sccache entries are content-addressed,
+    /// so concurrent writers never corrupt each other; the worst case is an
+    /// occasional miss that simply recompiles.
+    pub fn with_cache_tag(self, tag: &str) -> String {
+        format!("{self};overrides.cache-tag={tag}")
+    }
+}

--- a/rust/cloud-storage/tools/xtask/src/workflows/scripts/run_tests.sh
+++ b/rust/cloud-storage/tools/xtask/src/workflows/scripts/run_tests.sh
@@ -1,6 +1,8 @@
 cd rust/cloud-storage
 
-args=(--all-features --lib --bins --tests --test-threads "$NEXTEST_TEST_THREADS")
+# --no-tests=pass: a package filter (e.g. an xtask/tooling-only PR -> rdeps(=xtask))
+# can legitimately select zero tests; treat that as success, not nextest's default error.
+args=(--all-features --lib --bins --tests --no-tests=pass --test-threads "$NEXTEST_TEST_THREADS")
 if [ -n "$NEXTEST_FILTER" ]; then
   args+=(-E "$NEXTEST_FILTER")
 fi

--- a/rust/cloud-storage/tools/xtask/src/workflows/vars.rs
+++ b/rust/cloud-storage/tools/xtask/src/workflows/vars.rs
@@ -19,6 +19,11 @@ secret!(DOPPLER_TOKEN);
 /// smaller.
 pub const NEXTEST_TEST_THREADS: u32 = 32;
 
+/// Explicit Namespace cache tag for the heavy compile jobs (check + test). A
+/// fixed tag (instead of the default per-branch scoping) makes the cache volume
+/// global across all branches — see [`crate::workflows::runners::Runner::with_cache_tag`].
+pub const CI_CACHE_TAG: &str = "sccache-ci";
+
 /// Directory sccache uses for its local-disk cache. Lives on the Namespace cache
 /// volume so it persists across runs — this is what replaces the S3 bucket.
 pub const SCCACHE_VOLUME_DIR: &str = "/sccache";


### PR DESCRIPTION
Fixes two CI regressions exposed by tooling-only PRs (a PR that only touches `xtask`, e.g. #4294's cargo-deny port).

### 1. `test` fails with "no tests to run" on tooling-only PRs
The nextest package filter narrows an xtask-only change to `rdeps(=xtask)`, which selects **zero** tests — and nextest's default exits `error: no tests to run` (exit 4). Add `--no-tests=pass` so an empty selection is a pass; a tooling change legitimately affects no tests.

### 2. New branches start with a cold cache
The Namespace cache volume is scoped **per branch**, and check/test only run on `pull_request` (never on `main`), so a fresh branch has no default-branch cache to inherit and recompiles the whole workspace from scratch (~5–6 min).

Pin an explicit **`sccache-ci`** cache tag on the check/test runner (`runs-on: namespace-profile-linux-rust-ci;overrides.cache-tag=sccache-ci`) so every branch reads/writes **one global volume** — the way the old shared S3 sccache bucket did. sccache entries are content-addressed, so concurrent writers can't corrupt each other; worst case is an occasional miss that recompiles.

> Note: the tag's volume is brand-new, so the *first* run on any branch is still cold — the global-warm payoff kicks in once it's seeded.

**Regenerate:** `cargo x workflows` from `rust/cloud-storage` (`--check` verifies sync).

🤖 Generated with [Claude Code](https://claude.com/claude-code)