### PR TITLE
fix(email): drop unused Gmail token fetch from UpdateThreadLabels tool

### DIFF
--- a/rust/cloud-storage/email/src/inbound/toolset/update_thread_labels.rs
+++ b/rust/cloud-storage/email/src/inbound/toolset/update_thread_labels.rs
@@ -102,17 +102,13 @@ where
                 internal_error: anyhow::anyhow!("no owned link for thread"),
             })?;
 
-        let access_token = service_context.resolve_access_token(&link).await?;
-
+        // No Gmail token needed here. Label changes are written to the DB and the
+        // Gmail API calls are enqueued to the gmail_ops worker, which fetches its
+        // own token. The AI tool context has a no-op token provider, so fetching
+        // one here would always fail.
         let result = service_context
             .service
-            .update_thread_labels(
-                &access_token,
-                &link,
-                self.thread_id,
-                self.label_id,
-                self.add,
-            )
+            .update_thread_labels("", &link, self.thread_id, self.label_id, self.add)
             .await
             .map_err(|e| ToolCallError {
                 description: format!("Failed to update thread labels: {e}"),


### PR DESCRIPTION
`UpdateThreadLabels` fetched a Gmail access token via the tool context's token provider before applying labels, but the AI tool context wires a no-op provider, so it always failed with "Gmail token provider not configured" — on every inbox, primary or delegated. The token is unused: label changes are persisted to the DB and the actual Gmail API calls are enqueued to the `gmail_ops` worker, which fetches its own token. The tool now skips the fetch and works on any inbox. The HTTP route is unchanged.