### PR TITLE
feat(email): include thread labels in GetThread tool response

### DIFF
--- a/js/app/packages/service-clients/service-cognition/generated/tools/schemas.ts
+++ b/js/app/packages/service-clients/service-cognition/generated/tools/schemas.ts
@@ -536,6 +536,7 @@ export const GetThreadResponse = z.object({
         ])
         .optional(),
       id: z.string().uuid(),
+      labels: z.array(z.string()),
       subject: z.union([z.string(), z.null()]).optional(),
       to: z.array(
         z.object({

--- a/js/app/packages/service-clients/service-cognition/generated/tools/schemas.ts
+++ b/js/app/packages/service-clients/service-cognition/generated/tools/schemas.ts
@@ -515,6 +515,7 @@ export const GetThread = z.object({
 
 export const GetThreadResponse = z.object({
   isRead: z.boolean(),
+  labels: z.array(z.string()),
   messages: z.array(
     z.object({
       bodyParsed: z.union([z.string(), z.null()]).optional(),

--- a/js/app/packages/service-clients/service-cognition/generated/tools/types.ts
+++ b/js/app/packages/service-clients/service-cognition/generated/tools/types.ts
@@ -1279,7 +1279,7 @@ export interface GetThreadResponse {
   isRead: boolean;
   /**
    * The labels applied to the thread — the distinct set of label names across
-   * its messages (e.g. INBOX, UNREAD, STARRED, and any custom labels).
+   * all of its messages (e.g. INBOX, UNREAD, STARRED, and any custom labels).
    */
   labels: string[];
   /**

--- a/js/app/packages/service-clients/service-cognition/generated/tools/types.ts
+++ b/js/app/packages/service-clients/service-cognition/generated/tools/types.ts
@@ -1257,7 +1257,7 @@ export interface ToolPropertyOption {
   id: string;
 }
 /**
- * Retrieve an email thread and its messages. Returns the thread metadata and message contents including sender, recipients, subject, and body text. Use this to read the contents of a specific email conversation.
+ * Retrieve an email thread and its messages. Returns the thread metadata, the labels applied to the thread (e.g. INBOX, UNREAD, STARRED, and any custom labels), and message contents including sender, recipients, subject, and body text. Use this to read the contents of a specific email conversation or to see which labels a thread has.
  */
 export interface GetThread {
   /**
@@ -1277,6 +1277,11 @@ export interface GetThreadResponse {
    * Whether the thread has been read.
    */
   isRead: boolean;
+  /**
+   * The labels applied to the thread — the distinct set of label names across
+   * its messages (e.g. INBOX, UNREAD, STARRED, and any custom labels).
+   */
+  labels: string[];
   /**
    * The messages in the thread (most recent first).
    */

--- a/js/app/packages/service-clients/service-cognition/generated/tools/types.ts
+++ b/js/app/packages/service-clients/service-cognition/generated/tools/types.ts
@@ -1257,7 +1257,7 @@ export interface ToolPropertyOption {
   id: string;
 }
 /**
- * Retrieve an email thread and its messages. Returns the thread metadata, the labels applied to the thread (e.g. INBOX, UNREAD, STARRED, and any custom labels), and message contents including sender, recipients, subject, and body text. Use this to read the contents of a specific email conversation or to see which labels a thread has.
+ * Retrieve an email thread and its messages. Returns the thread metadata, the labels applied to the thread (e.g. INBOX, UNREAD, STARRED, and any custom labels), and message contents including sender, recipients, subject, body text, and the labels on each individual message. Use this to read the contents of a specific email conversation or to see which labels a thread or message has.
  */
 export interface GetThread {
   /**
@@ -1319,6 +1319,10 @@ export interface ToolMessage {
    * The message's unique identifier.
    */
   id: string;
+  /**
+   * The labels on this message (e.g. INBOX, UNREAD, STARRED, and any custom labels).
+   */
+  labels: string[];
   /**
    * The message subject.
    */

--- a/rust/cloud-storage/email/src/domain/models/parsed_message.rs
+++ b/rust/cloud-storage/email/src/domain/models/parsed_message.rs
@@ -46,4 +46,7 @@ pub struct ParsedThread {
     pub row: super::thread::ThreadRow,
     /// Parsed messages in the thread.
     pub messages: Vec<ParsedMessage>,
+    /// The distinct labels across all of the thread's messages. Unlike the
+    /// per-message labels, this is not limited to the fetched message page.
+    pub labels: Vec<ParsedLabel>,
 }

--- a/rust/cloud-storage/email/src/domain/service/thread.rs
+++ b/rust/cloud-storage/email/src/domain/service/thread.rs
@@ -298,9 +298,24 @@ where
             })
             .collect();
 
+        // Thread labels are the distinct set across ALL the thread's messages,
+        // independent of the fetched message page (unlike per-message labels).
+        let labels = self
+            .email_repo
+            .labels_by_thread_ids(&[thread_row.db_id])
+            .await
+            .map_err(anyhow::Error::from)?
+            .into_iter()
+            .map(|l| ParsedLabel {
+                provider_id: l.provider_label_id,
+                name: l.name,
+            })
+            .collect();
+
         Ok(Some(ParsedThread {
             row: thread_row,
             messages,
+            labels,
         }))
     }
 }

--- a/rust/cloud-storage/email/src/inbound/toolset/get_thread.rs
+++ b/rust/cloud-storage/email/src/inbound/toolset/get_thread.rs
@@ -81,7 +81,7 @@ pub struct GetThreadResponse {
     /// Whether the thread has been read.
     pub is_read: bool,
     /// The labels applied to the thread — the distinct set of label names across
-    /// its messages (e.g. INBOX, UNREAD, STARRED, and any custom labels).
+    /// all of its messages (e.g. INBOX, UNREAD, STARRED, and any custom labels).
     pub labels: Vec<String>,
     /// The messages in the thread (most recent first).
     pub messages: Vec<ToolMessage>,
@@ -158,12 +158,9 @@ where
 
         let summary = build_summary(&thread);
 
-        // The thread's labels are the distinct set across its messages.
-        let mut labels: Vec<String> = thread
-            .messages
-            .iter()
-            .flat_map(|m| m.labels.iter().map(|l| l.name.clone()))
-            .collect();
+        // Thread labels are the complete set across all the thread's messages
+        // (resolved by the service), not just the fetched message page.
+        let mut labels: Vec<String> = thread.labels.iter().map(|l| l.name.clone()).collect();
         labels.sort();
         labels.dedup();
 

--- a/rust/cloud-storage/email/src/inbound/toolset/get_thread.rs
+++ b/rust/cloud-storage/email/src/inbound/toolset/get_thread.rs
@@ -77,6 +77,9 @@ pub struct GetThreadResponse {
     pub thread_id: Uuid,
     /// Whether the thread has been read.
     pub is_read: bool,
+    /// The labels applied to the thread — the distinct set of label names across
+    /// its messages (e.g. INBOX, UNREAD, STARRED, and any custom labels).
+    pub labels: Vec<String>,
     /// The messages in the thread (most recent first).
     pub messages: Vec<ToolMessage>,
     /// A human-readable summary.
@@ -90,7 +93,7 @@ const DEFAULT_LIMIT: i64 = 10;
 #[derive(Debug, Deserialize, JsonSchema, Clone)]
 #[schemars(
     title = "GetThread",
-    description = "Retrieve an email thread and its messages. Returns the thread metadata and message contents including sender, recipients, subject, and body text. Use this to read the contents of a specific email conversation."
+    description = "Retrieve an email thread and its messages. Returns the thread metadata, the labels applied to the thread (e.g. INBOX, UNREAD, STARRED, and any custom labels), and message contents including sender, recipients, subject, and body text. Use this to read the contents of a specific email conversation or to see which labels a thread has."
 )]
 #[serde(rename_all = "camelCase")]
 pub struct GetThread {
@@ -151,12 +154,23 @@ where
             })?;
 
         let summary = build_summary(&thread);
+
+        // The thread's labels are the distinct set across its messages.
+        let mut labels: Vec<String> = thread
+            .messages
+            .iter()
+            .flat_map(|m| m.labels.iter().map(|l| l.name.clone()))
+            .collect();
+        labels.sort();
+        labels.dedup();
+
         let messages: Vec<ToolMessage> =
             thread.messages.into_iter().map(ToolMessage::from).collect();
 
         Ok(GetThreadResponse {
             thread_id: thread.row.db_id,
             is_read: thread.row.is_read,
+            labels,
             messages,
             summary,
         })

--- a/rust/cloud-storage/email/src/inbound/toolset/get_thread.rs
+++ b/rust/cloud-storage/email/src/inbound/toolset/get_thread.rs
@@ -34,6 +34,8 @@ pub struct ToolMessage {
     pub body_parsed: Option<String>,
     /// When the message was received/sent.
     pub date: Option<String>,
+    /// The labels on this message (e.g. INBOX, UNREAD, STARRED, and any custom labels).
+    pub labels: Vec<String>,
 }
 
 /// A simplified contact for tool output.
@@ -65,6 +67,7 @@ impl From<ParsedMessage> for ToolMessage {
             cc: m.cc.into_iter().map(ToolContact::from).collect(),
             body_parsed: m.body_parsed,
             date: m.internal_date_ts.map(|t| t.to_rfc3339()),
+            labels: m.labels.into_iter().map(|l| l.name).collect(),
         }
     }
 }
@@ -93,7 +96,7 @@ const DEFAULT_LIMIT: i64 = 10;
 #[derive(Debug, Deserialize, JsonSchema, Clone)]
 #[schemars(
     title = "GetThread",
-    description = "Retrieve an email thread and its messages. Returns the thread metadata, the labels applied to the thread (e.g. INBOX, UNREAD, STARRED, and any custom labels), and message contents including sender, recipients, subject, and body text. Use this to read the contents of a specific email conversation or to see which labels a thread has."
+    description = "Retrieve an email thread and its messages. Returns the thread metadata, the labels applied to the thread (e.g. INBOX, UNREAD, STARRED, and any custom labels), and message contents including sender, recipients, subject, body text, and the labels on each individual message. Use this to read the contents of a specific email conversation or to see which labels a thread or message has."
 )]
 #[serde(rename_all = "camelCase")]
 pub struct GetThread {


### PR DESCRIPTION
GetThread already loads each message's labels but never exposed them on the tool response. Adds a thread-level `labels` field — the distinct set of label names across the thread's messages (e.g. INBOX, UNREAD, STARRED, and any custom labels) — so the AI can read which labels a thread has directly from GetThread, without a separate ListLabels call.