### PR TITLE
fix(email): configure gmail_ops_queue for the AI tools email service

### DIFF
--- a/infra/packages/shared/src/ai_tools.ts
+++ b/infra/packages/shared/src/ai_tools.ts
@@ -60,6 +60,13 @@ export function getAiToolsInfra(): AiToolsInfra {
     .getOutput('scheduledQueueArn')
     .apply((v) => v as string);
 
+  const gmailOpsQueueName: pulumi.Output<string> = emailServiceStack
+    .getOutput('gmailOpsQueueName')
+    .apply((v) => v as string);
+  const gmailOpsQueueArn: pulumi.Output<string> = emailServiceStack
+    .getOutput('gmailOpsQueueArn')
+    .apply((v) => v as string);
+
   const cloudfrontDistributionUrl: pulumi.Output<string> = linksharingStack
     .getOutput('cloudfrontDistributionUrl')
     .apply((v) => v as string);
@@ -159,6 +166,10 @@ export function getAiToolsInfra(): AiToolsInfra {
       value: pulumi.interpolate`${emailScheduledQueueName}`,
     },
     {
+      name: 'GMAIL_OPS_QUEUE',
+      value: pulumi.interpolate`${gmailOpsQueueName}`,
+    },
+    {
       name: 'DOCUMENT_STORAGE_SERVICE_CLOUDFRONT_DISTRIBUTION_URL',
       value: pulumi.interpolate`${cloudfrontDistributionUrl}`,
     },
@@ -203,7 +214,7 @@ export function getAiToolsInfra(): AiToolsInfra {
       cloudfrontPrivateKeySecretArn,
       mcpCredentialsKeyArn,
     ],
-    queueArns: [emailScheduledQueueArn],
+    queueArns: [emailScheduledQueueArn, gmailOpsQueueArn],
     bucketArns: [documentStorageBucketArn, docxUploadBucketArn],
   };
 }

--- a/rust/cloud-storage/ai_tools/src/build_context.rs
+++ b/rust/cloud-storage/ai_tools/src/build_context.rs
@@ -61,6 +61,7 @@ env_var! {
 maybe_env_var! {
     struct ToolContextMaybeEnvVars {
         NotificationQueue,
+        GmailOpsQueue,
     }
 }
 
@@ -84,6 +85,7 @@ maybe_env_var! {
 ///
 /// Optional env vars:
 /// - `NOTIFICATION_QUEUE` (if omitted, notification status updates skip push clearing)
+/// - `GMAIL_OPS_QUEUE` (if omitted, thread-label updates can't enqueue Gmail sync ops)
 #[tracing::instrument(skip(pool), err)]
 pub async fn build_tool_service_context_from_env(
     pool: sqlx::PgPool,
@@ -98,8 +100,11 @@ pub async fn build_tool_service_context_from_env(
 
     let aws_config = macro_aws_config::get_macro_aws_config().await;
     let aws_sqs_client = aws_sdk_sqs::Client::new(&aws_config);
-    let sqs_client = sqs_client::SQS::new(aws_sqs_client.clone())
+    let mut sqs_client = sqs_client::SQS::new(aws_sqs_client.clone())
         .email_scheduled_queue(&env.email_scheduled_queue);
+    if let Some(gmail_ops_queue) = maybe_env.gmail_ops_queue.as_ref() {
+        sqs_client = sqs_client.gmail_ops_queue(gmail_ops_queue);
+    }
     let notification_queue = maybe_env
         .notification_queue
         .as_ref()


### PR DESCRIPTION
`UpdateThreadLabels` enqueues Gmail label changes to the `gmail_ops` worker, but the AI tools context built its SQS client without the `gmail_ops` queue URL, so the enqueue failed with "gmail_ops_queue is not configured" (after the earlier token fix). Wires `GMAIL_OPS_QUEUE` (optional env) onto the SQS client in `build_context`, and provisions it in the ai-tools infra from the email-service stack's gmail-ops queue (name as the env var, arn added to `queueArns` for send permission).
