### PR TITLE
fix(channels): thread reply input focus only on intent

### DIFF
--- a/js/app/packages/channel/Channel/Channel.tsx
+++ b/js/app/packages/channel/Channel/Channel.tsx
@@ -280,6 +280,7 @@ export function Channel(props: ChannelProps) {
     const threadId = message.thread_id ?? message.id;
     const state = threadManager.getOrCreateThreadState(threadId);
     state.setIsReplying(true);
+    state.replyInputFocusRequest.request();
     return state;
   };
 
@@ -303,7 +304,10 @@ export function Channel(props: ChannelProps) {
     state.setReplyInputState(nextSnapshot);
     state.setIsReplying(true);
     requestAnimationFrame(() => {
-      state.replyInputHandle?.()?.restoreSnapshot(nextSnapshot);
+      state.replyInputHandle?.()?.restoreSnapshot(nextSnapshot, {
+        focus: false,
+      });
+      state.replyInputFocusRequest.request();
     });
   };
 
@@ -525,6 +529,9 @@ export function Channel(props: ChannelProps) {
                                 setReplyInputState={state.setReplyInputState}
                                 setReplyInputEl={state.setReplyInputEl}
                                 setReplyInputHandle={state.setReplyInputHandle}
+                                replyInputFocusRequest={
+                                  state.replyInputFocusRequest
+                                }
                                 listMeta={listMetaByMessageId()[item.id]}
                                 messageEditor={messageEditor}
                                 participants={participants.users}

--- a/js/app/packages/channel/Channel/thread-manager.ts
+++ b/js/app/packages/channel/Channel/thread-manager.ts
@@ -2,6 +2,7 @@ import type { InputHandle, InputSnapshot } from '@channel/Input';
 import { batch, createSignal, type Setter } from 'solid-js';
 import { createStore } from 'solid-js/store';
 import type { ThreadState } from '../Thread';
+import { createFocusRequest } from '../Thread/focus-request';
 
 type ThreadStore = Record<string, ThreadState>;
 export function createThreadManager() {
@@ -19,6 +20,7 @@ export function createThreadManager() {
     const [replyInputHandle, setReplyInputHandle] = createSignal<
       InputHandle | undefined
     >();
+    const replyInputFocusRequest = createFocusRequest();
 
     /** If you set replying from false -> true this means it must be expanded **/
     const setIsReplying: Setter<boolean> = (val) => {
@@ -46,6 +48,7 @@ export function createThreadManager() {
       setReplyInputEl,
       replyInputHandle,
       setReplyInputHandle,
+      replyInputFocusRequest,
     };
 
     setThreadStore(threadId, state);

--- a/js/app/packages/channel/Input/ChannelInput.tsx
+++ b/js/app/packages/channel/Input/ChannelInput.tsx
@@ -49,6 +49,7 @@ import type {
   InputData,
   InputHandle,
   InputPersistenceKey,
+  InputSnapshot,
 } from './types';
 import { isReplyInput } from './types';
 import { uploadInputAttachments } from './upload-attachments';
@@ -176,24 +177,43 @@ export function ChannelInput(props: ChannelInputProps) {
   const isCollapsed = () => !!props.collapsible && collapsedInput.isCollapsed();
 
   let isEditorConnected = false;
-  let pendingRestoreSnapshot:
-    | Parameters<InputHandle['restoreSnapshot']>[0]
+  let pendingRestore:
+    | {
+        snapshot: InputSnapshot;
+        options?: { focus?: boolean };
+      }
     | undefined;
+  let pendingFocus = false;
 
   const applySnapshot = (
-    snapshot: Parameters<InputHandle['restoreSnapshot']>[0]
+    snapshot: InputSnapshot,
+    options?: { focus?: boolean }
   ) => {
     markdownEditor.controls.setMarkdown(snapshot.value);
     attachmentTracker.setAttachments(snapshot.attachments);
     mentionsTracker.setMentions(snapshot.mentions);
-    markdownEditor.controls.focus();
+    if (options?.focus !== false) markdownEditor.controls.focus();
   };
 
   const flushPendingRestore = () => {
-    const snapshot = pendingRestoreSnapshot;
-    pendingRestoreSnapshot = undefined;
-    if (!snapshot) return;
-    queueMicrotask(() => applySnapshot(snapshot));
+    const restore = pendingRestore;
+    pendingRestore = undefined;
+    if (!restore) return;
+    queueMicrotask(() => applySnapshot(restore.snapshot, restore.options));
+  };
+
+  const focusEditor = () => {
+    if (!isEditorConnected) {
+      pendingFocus = true;
+      return;
+    }
+    markdownEditor.controls.focus();
+  };
+
+  const flushPendingFocus = () => {
+    if (!pendingFocus) return;
+    pendingFocus = false;
+    queueMicrotask(() => markdownEditor.controls.focus());
   };
 
   // Macro AI is mentionable in every channel. It is surfaced through the same
@@ -315,18 +335,18 @@ export function ChannelInput(props: ChannelInputProps) {
 
   props.onReady?.({
     clear: () => markdownEditor.controls.clear(),
-    focus: () => markdownEditor.controls.focus(),
+    focus: focusEditor,
     send: () => inputState.commands.send(),
     attachFiles: (files) => inputState.commands.attachFiles(files),
     insertEntityMention,
     previewEntityMentionInsertion,
     clearEntityMentionInsertionPreview,
-    restoreSnapshot: (snapshot) => {
+    restoreSnapshot: (snapshot, options) => {
       if (!isEditorConnected) {
-        pendingRestoreSnapshot = snapshot;
+        pendingRestore = { snapshot, options };
         return;
       }
-      applySnapshot(snapshot);
+      applySnapshot(snapshot, options);
     },
   });
 
@@ -429,6 +449,7 @@ export function ChannelInput(props: ChannelInputProps) {
                   onConnect={() => {
                     isEditorConnected = true;
                     flushPendingRestore();
+                    flushPendingFocus();
                   }}
                 />
                 <DragInsertIndicator

--- a/js/app/packages/channel/Input/types.ts
+++ b/js/app/packages/channel/Input/types.ts
@@ -80,7 +80,10 @@ export type InputHandle = {
   focus: () => void;
   send: () => Promise<boolean>;
   attachFiles: (files: File[]) => Promise<void>;
-  restoreSnapshot: (snapshot: InputSnapshot) => void;
+  restoreSnapshot: (
+    snapshot: InputSnapshot,
+    options?: { focus?: boolean }
+  ) => void;
   /**
    * Inserts a mention for a dragged soup entity into the editor. Only provided
    * by inputs that support entity drag-and-drop (e.g. channel inputs).

--- a/js/app/packages/channel/StandaloneThread/EditableThread.tsx
+++ b/js/app/packages/channel/StandaloneThread/EditableThread.tsx
@@ -50,7 +50,12 @@ function EditableThreadInner() {
           attachments: current?.attachments ?? [],
         };
         setReplyInputState(nextSnapshot);
-        replyInputHandle()?.restoreSnapshot(nextSnapshot);
+        requestAnimationFrame(() => {
+          replyInputHandle()?.restoreSnapshot(nextSnapshot, { focus: false });
+          ctx.replyInputFocusRequest.request();
+        });
+      } else {
+        ctx.replyInputFocusRequest.request();
       }
 
       ctx.setIsReplying(true);
@@ -77,6 +82,7 @@ function EditableThreadInner() {
           setReplyInputState={setReplyInputState}
           setIsReplying={ctx.setIsReplying}
           setReplyInputHandle={setReplyInputHandle}
+          focusRequest={ctx.replyInputFocusRequest}
         />
       </Show>
     </>

--- a/js/app/packages/channel/StandaloneThread/Replies.tsx
+++ b/js/app/packages/channel/StandaloneThread/Replies.tsx
@@ -40,9 +40,16 @@ export function Replies(props: RepliesProps) {
   const shouldShowCollapsedIndicator = () =>
     !ctx.isReplying() && !ctx.isExpanded() && collapsedRepliesCount() > 0;
 
+  const replyAction = () => {
+    const parent = ctx.parent();
+    if (!parent) return undefined;
+    return props.getMessageActions?.(parent)?.onReply;
+  };
+
   const shouldShowReplyButton = () =>
     !!props.showReplyButton &&
     ctx.hasReplies() &&
+    !!replyAction() &&
     !ctx.isReplying() &&
     !shouldShowCollapsedIndicator();
 
@@ -134,7 +141,11 @@ export function Replies(props: RepliesProps) {
               <Show when={shouldShowReplyButton()}>
                 <Thread.ReplyButton
                   getFocusTarget={() => null}
-                  onClick={() => ctx.setIsReplying(true)}
+                  onClick={(event) => {
+                    const parent = ctx.parent();
+                    if (!parent) return;
+                    replyAction()?.({ message: parent, event });
+                  }}
                   aria-label="Reply"
                 />
               </Show>

--- a/js/app/packages/channel/StandaloneThread/Root.tsx
+++ b/js/app/packages/channel/StandaloneThread/Root.tsx
@@ -4,6 +4,7 @@ import { useThreadRepliesQuery } from '@queries/channel/thread-replies';
 import type { ApiChannelMessage } from '@service-storage/generated/schemas/apiChannelMessage';
 import type { ApiThreadReply } from '@service-storage/generated/schemas/apiThreadReply';
 import { createSignal, type ParentProps, Show } from 'solid-js';
+import { createFocusRequest } from '../Thread/focus-request';
 import { ThreadRail } from '../Thread/ThreadRail';
 import { DEFAULT_VISIBLE_REPLY_COUNT } from '../Thread/utils/thread-reply-indicator-helpers';
 import { StandaloneThreadContext } from './context';
@@ -25,6 +26,7 @@ export function Root(props: RootProps) {
 function RootInner(props: RootProps) {
   const [isExpanded, setIsExpanded] = createSignal(false);
   const [isReplying, setIsReplying] = createSignal(false);
+  const replyInputFocusRequest = createFocusRequest();
 
   const parentQuery = useChannelMessagesByIdsQuery(
     () => props.channelId,
@@ -64,6 +66,7 @@ function RootInner(props: RootProps) {
         setIsExpanded,
         isReplying,
         setIsReplying,
+        replyInputFocusRequest,
       }}
     >
       <div class="relative">

--- a/js/app/packages/channel/StandaloneThread/context.ts
+++ b/js/app/packages/channel/StandaloneThread/context.ts
@@ -6,6 +6,7 @@ import {
   type Setter,
   useContext,
 } from 'solid-js';
+import type { FocusRequest } from '../Thread/focus-request';
 
 export type StandaloneThreadContextValue = {
   channelId: Accessor<string>;
@@ -18,6 +19,7 @@ export type StandaloneThreadContextValue = {
   setIsExpanded: Setter<boolean>;
   isReplying: Accessor<boolean>;
   setIsReplying: Setter<boolean>;
+  replyInputFocusRequest: FocusRequest;
 };
 
 const StandaloneThreadContext = createContext<StandaloneThreadContextValue>();

--- a/js/app/packages/channel/Thread/ChannelThread.tsx
+++ b/js/app/packages/channel/Thread/ChannelThread.tsx
@@ -147,8 +147,12 @@ export function ChannelThread(props: ThreadProps) {
     getThreadLatestReplyAt(thread().latest_reply_at, activeReplies());
   const shouldShowCollapsedIndicator = () =>
     !props.isReplying() && !props.isExpanded() && collapsedRepliesCount() > 0;
+  const replyAction = () => props.getMessageActions?.(props.data())?.onReply;
   const shouldShowReplyButton = () =>
-    hasReplies() && !props.isReplying() && !shouldShowCollapsedIndicator();
+    hasReplies() &&
+    !!replyAction() &&
+    !props.isReplying() &&
+    !shouldShowCollapsedIndicator();
   const [replyListHandle, setReplyListHandle] =
     createSignal<ThreadReplyListHandle>();
 
@@ -292,6 +296,7 @@ export function ChannelThread(props: ThreadProps) {
                         setIsReplying={props.setIsReplying}
                         setReplyInputEl={props.setReplyInputEl}
                         setReplyInputHandle={props.setReplyInputHandle}
+                        focusRequest={props.replyInputFocusRequest}
                       />
                     </div>
                   </Show>
@@ -318,7 +323,9 @@ export function ChannelThread(props: ThreadProps) {
                               '[contenteditable]'
                             ) ?? null
                           }
-                          onClick={() => props.setIsReplying(true)}
+                          onClick={(event) =>
+                            replyAction()?.({ message: props.data(), event })
+                          }
                           aria-label="Reply"
                         />
                       </Show>

--- a/js/app/packages/channel/Thread/ThreadReplyInput.tsx
+++ b/js/app/packages/channel/Thread/ThreadReplyInput.tsx
@@ -6,12 +6,19 @@ import { useChannelParticipants } from '@channel/use-channel-participants';
 import { useUserId } from '@core/context/user';
 import { useSendMessageMutation } from '@queries/channel/message';
 import { usePostTypingUpdateMutation } from '@queries/channel/typing';
-import { type Accessor, createSignal, onCleanup, type Setter } from 'solid-js';
+import {
+  type Accessor,
+  createEffect,
+  createSignal,
+  onCleanup,
+  type Setter,
+} from 'solid-js';
 import { createEntityDropZone } from '../Channel/create-entity-drop-zone';
 import type { InputHandle, InputSnapshot } from '../Input';
 import { ChannelInput, createInputAttachmentTracker } from '../Input';
 import { buildPostMessageSendPayload } from '../Input/message-payload';
 import { hasSendableInputContent } from '../Input/utils/sendable-content';
+import type { FocusRequest } from './focus-request';
 import { ThreadReplyInputConnector } from './ThreadReplyInputConnector';
 import { replyInputOffsetX } from './utils/thread-rail-geometry';
 
@@ -23,6 +30,7 @@ type ThreadReplyInputProps = {
   setIsReplying: Setter<boolean>;
   setReplyInputEl?: Setter<HTMLElement | undefined>;
   setReplyInputHandle?: Setter<InputHandle | undefined>;
+  focusRequest?: FocusRequest;
 };
 
 export function ThreadReplyInput(props: ThreadReplyInputProps) {
@@ -48,6 +56,19 @@ export function ThreadReplyInput(props: ThreadReplyInputProps) {
   const [replyInputHandle, setLocalReplyInputHandle] =
     createSignal<InputHandle>();
 
+  const focusIfRequested = () => {
+    const handle = replyInputHandle();
+    if (!handle) return;
+    if (!props.focusRequest?.consume()) return;
+
+    handle.focus();
+  };
+
+  createEffect(() => {
+    props.focusRequest?.pending();
+    focusIfRequested();
+  });
+
   const entityDropZone = createEntityDropZone({
     droppableId: `thread-reply-entity-drop-${props.messageId}`,
     onDropEntity: (entity, coordinates) =>
@@ -63,8 +84,10 @@ export function ThreadReplyInput(props: ThreadReplyInputProps) {
     props.setReplyInputHandle?.(handle);
 
     const snapshot = props.replyInputState();
-    if (!snapshot) return;
-    requestAnimationFrame(() => handle.restoreSnapshot(snapshot));
+    requestAnimationFrame(() => {
+      if (snapshot) handle.restoreSnapshot(snapshot, { focus: false });
+      focusIfRequested();
+    });
   };
 
   return (
@@ -97,6 +120,7 @@ export function ThreadReplyInput(props: ThreadReplyInputProps) {
                 threadId: props.messageId,
               })}
               markdownNamespace={`thread-reply-input-${props.messageId}-markdown`}
+              autofocus={false}
               onReady={setReplyInputHandle}
               onChange={(snapshot) => void props.setReplyInputState(snapshot)}
               onStartTyping={() =>

--- a/js/app/packages/channel/Thread/focus-request.ts
+++ b/js/app/packages/channel/Thread/focus-request.ts
@@ -1,25 +1,25 @@
-import { type Accessor, createSignal } from "solid-js";
+import { type Accessor, createSignal } from 'solid-js';
 
 export type FocusRequest = {
-	pending: Accessor<number | undefined>;
-	request: () => void;
-	consume: () => boolean;
+  pending: Accessor<number | undefined>;
+  request: () => void;
+  consume: () => boolean;
 };
 
 export function createFocusRequest(): FocusRequest {
-	const [pending, setPending] = createSignal<number | undefined>();
-	let nextId = 0;
+  const [pending, setPending] = createSignal<number | undefined>();
+  let nextId = 0;
 
-	return {
-		pending,
-		request: () => {
-			nextId += 1;
-			setPending(nextId);
-		},
-		consume: () => {
-			if (pending() === undefined) return false;
-			setPending(undefined);
-			return true;
-		},
-	};
+  return {
+    pending,
+    request: () => {
+      nextId += 1;
+      setPending(nextId);
+    },
+    consume: () => {
+      if (pending() === undefined) return false;
+      setPending(undefined);
+      return true;
+    },
+  };
 }

--- a/js/app/packages/channel/Thread/focus-request.ts
+++ b/js/app/packages/channel/Thread/focus-request.ts
@@ -1,0 +1,25 @@
+import { type Accessor, createSignal } from "solid-js";
+
+export type FocusRequest = {
+	pending: Accessor<number | undefined>;
+	request: () => void;
+	consume: () => boolean;
+};
+
+export function createFocusRequest(): FocusRequest {
+	const [pending, setPending] = createSignal<number | undefined>();
+	let nextId = 0;
+
+	return {
+		pending,
+		request: () => {
+			nextId += 1;
+			setPending(nextId);
+		},
+		consume: () => {
+			if (pending() === undefined) return false;
+			setPending(undefined);
+			return true;
+		},
+	};
+}

--- a/js/app/packages/channel/Thread/types.ts
+++ b/js/app/packages/channel/Thread/types.ts
@@ -9,6 +9,7 @@ import type {
   MessageActions,
   MessageData,
 } from '../Message';
+import type { FocusRequest } from './focus-request';
 
 export type ThreadActions = {
   onDismissNewMessages?: () => void;
@@ -25,6 +26,7 @@ export type ThreadState = {
   setReplyInputEl?: Setter<HTMLElement | undefined>;
   replyInputHandle?: Accessor<InputHandle | undefined>;
   setReplyInputHandle?: Setter<InputHandle | undefined>;
+  replyInputFocusRequest: FocusRequest;
 };
 
 export type MessageEditState = {


### PR DESCRIPTION
Thread reply inputs were focused automatically on mount. This caused problematic behavior while scrolling the virtualized list—every time a reply input was mounted it would steal focus. This has caused centuries of havoc on mobile. Additionally created strange behavior on channel history restoration.

Now, thread reply inputs focus only when user express focus intent, via the `onReply` message action.