### PR TITLE
feat(soup): persist group state in history

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/create-grouped-soup-queries.test.ts
+++ b/js/app/packages/app/component/next-soup/soup-view/create-grouped-soup-queries.test.ts
@@ -1,0 +1,158 @@
+import type { GroupMeta } from '@queries/soup/grouped/types';
+import type { SoupApiItem } from '@service-storage/generated/schemas';
+import type { InfiniteData } from '@tanstack/solid-query';
+import { describe, expect, it } from 'vitest';
+import {
+  buildRestoredGroupQueryData,
+  type GroupedSoupQueriesSnapshot,
+  type GroupQueryPage,
+} from './grouped-query-snapshot';
+
+const makeItem = (id: string) => ({ id }) as unknown as SoupApiItem;
+
+const makeGroup = (
+  key: string,
+  itemIds: string[],
+  nextCursor: string | null = null
+): GroupMeta => ({
+  key,
+  label: key,
+  displayOrder: null,
+  totalCount: itemIds.length,
+  itemIds,
+  nextCursor,
+});
+
+const makePage = (
+  groupKey: string,
+  itemIds: string[],
+  nextCursor: string | null = null
+): GroupQueryPage => ({
+  items: Object.fromEntries(itemIds.map((id) => [id, makeItem(id)])),
+  group: makeGroup(groupKey, itemIds, nextCursor),
+});
+
+const makeData = (
+  pages: GroupQueryPage[],
+  pageParams: (string | null)[]
+): InfiniteData<GroupQueryPage, string | null> => ({
+  pages,
+  pageParams,
+});
+
+describe('buildRestoredGroupQueryData', () => {
+  it('uses only the fresh initial page without a snapshot', () => {
+    const initialPage = makePage('status:open', ['fresh-1'], 'next');
+
+    expect(
+      buildRestoredGroupQueryData({
+        initialPage,
+        groupBy: 'date',
+        groupKey: 'status:open',
+        scopeKey: 'scope-a',
+      })
+    ).toEqual(makeData([initialPage], [null]));
+  });
+
+  it('ignores snapshots from a different groupBy', () => {
+    const initialPage = makePage('status:open', ['fresh-1'], 'next');
+    const oldSecondPage = makePage('status:open', ['old-2']);
+
+    const snapshot: GroupedSoupQueriesSnapshot = {
+      groupBy: 'entity_type',
+      scopeKey: 'scope-a',
+      groups: {
+        'status:open': makeData([initialPage, oldSecondPage], [null, 'next']),
+      },
+    };
+
+    expect(
+      buildRestoredGroupQueryData({
+        initialPage,
+        groupBy: 'date',
+        groupKey: 'status:open',
+        scopeKey: 'scope-a',
+        snapshot,
+      })
+    ).toEqual(makeData([initialPage], [null]));
+  });
+
+  it('ignores snapshots from a different query scope', () => {
+    const initialPage = makePage('status:open', ['fresh-1'], 'next');
+    const oldSecondPage = makePage('status:open', ['old-2']);
+
+    const snapshot: GroupedSoupQueriesSnapshot = {
+      groupBy: 'date',
+      scopeKey: 'scope-a',
+      groups: {
+        'status:open': makeData([initialPage, oldSecondPage], [null, 'next']),
+      },
+    };
+
+    expect(
+      buildRestoredGroupQueryData({
+        initialPage,
+        groupBy: 'date',
+        groupKey: 'status:open',
+        scopeKey: 'scope-b',
+        snapshot,
+      })
+    ).toEqual(makeData([initialPage], [null]));
+  });
+
+  it('keeps the fresh initial page and restores previously loaded extra pages', () => {
+    const freshInitialPage = makePage('status:open', ['fresh-1'], 'next');
+    const staleInitialPage = makePage('status:open', ['stale-1'], 'next');
+    const oldSecondPage = makePage('status:open', ['old-2'], 'next-2');
+    const oldThirdPage = makePage('status:open', ['old-3']);
+
+    const snapshot: GroupedSoupQueriesSnapshot = {
+      groupBy: 'date',
+      scopeKey: 'scope-a',
+      groups: {
+        'status:open': makeData(
+          [staleInitialPage, oldSecondPage, oldThirdPage],
+          [null, 'next', 'next-2']
+        ),
+      },
+    };
+
+    expect(
+      buildRestoredGroupQueryData({
+        initialPage: freshInitialPage,
+        groupBy: 'date',
+        groupKey: 'status:open',
+        scopeKey: 'scope-a',
+        snapshot,
+      })
+    ).toEqual(
+      makeData(
+        [freshInitialPage, oldSecondPage, oldThirdPage],
+        [null, 'next', 'next-2']
+      )
+    );
+  });
+
+  it('does not restore snapshots that have only the initial page', () => {
+    const freshInitialPage = makePage('status:open', ['fresh-1'], 'next');
+    const staleInitialPage = makePage('status:open', ['stale-1'], 'next');
+
+    const snapshot: GroupedSoupQueriesSnapshot = {
+      groupBy: 'date',
+      scopeKey: 'scope-a',
+      groups: {
+        'status:open': makeData([staleInitialPage], [null]),
+      },
+    };
+
+    expect(
+      buildRestoredGroupQueryData({
+        initialPage: freshInitialPage,
+        groupBy: 'date',
+        groupKey: 'status:open',
+        scopeKey: 'scope-a',
+        snapshot,
+      })
+    ).toEqual(makeData([freshInitialPage], [null]));
+  });
+});

--- a/js/app/packages/app/component/next-soup/soup-view/create-grouped-soup-queries.ts
+++ b/js/app/packages/app/component/next-soup/soup-view/create-grouped-soup-queries.ts
@@ -32,15 +32,15 @@ import {
   on,
   untrack,
 } from 'solid-js';
+import {
+  buildRestoredGroupQueryData,
+  type GroupedSoupQueriesSnapshot,
+  type GroupQueryPage,
+} from './grouped-query-snapshot';
 
 type InitialGroupPage = {
   items: SoupAstItemsGroupedPage['items'];
   groups: GroupMeta[];
-};
-
-export type GroupQueryPage = {
-  items: InitialGroupPage['items'];
-  group: GroupMeta;
 };
 
 export type GroupQueryData = {
@@ -56,6 +56,7 @@ type CreateGroupedSoupQueriesArgs = {
     }
   >;
   soupBody: Accessor<SoupAstBody>;
+  initialSnapshot?: Accessor<GroupedSoupQueriesSnapshot | undefined>;
   queryOptions: Accessor<{
     enabled?: boolean;
     meta?: {
@@ -111,6 +112,27 @@ export function createGroupedSoupQueries(args: CreateGroupedSoupQueriesArgs) {
       if (item) groupItems[id] = item;
     }
     return { items: groupItems, group };
+  };
+
+  const groupBySnapshotKey = (field: GroupByField) =>
+    JSON.stringify(serializeGroupByField(field));
+
+  const snapshotScopeKey = (field: GroupByField) =>
+    JSON.stringify(
+      soupKeys.astItems({
+        params: args.soupParams(),
+        body: args.soupBody(),
+        groupBy: field,
+      }).queryKey
+    );
+
+  const snapshotKeys = () => {
+    const field = args.groupByField();
+    if (!field) return;
+    return {
+      groupBy: groupBySnapshotKey(field),
+      scopeKey: snapshotScopeKey(field),
+    };
   };
 
   const configs = createMemo(() => {
@@ -207,12 +229,32 @@ export function createGroupedSoupQueries(args: CreateGroupedSoupQueriesArgs) {
     return next;
   });
 
+  const getSnapshot = (): GroupedSoupQueriesSnapshot | undefined => {
+    const keys = snapshotKeys();
+    if (!keys) return undefined;
+
+    const groups: GroupedSoupQueriesSnapshot['groups'] = {};
+
+    for (const config of configs()) {
+      const data = queryClient.getQueryData<
+        InfiniteData<GroupQueryPage, string | null>
+      >(config.queryKey);
+      if (!data || data.pages.length <= 1) continue;
+      groups[config.key] = data;
+    }
+
+    return Object.keys(groups).length > 0 ? { ...keys, groups } : undefined;
+  };
+
   createEffect(
     on(
       () => args.initialPage(),
       (initialGroupedPage) => {
         const field = args.groupByField();
         if (!field || !initialGroupedPage) return;
+        const groupBy = groupBySnapshotKey(field);
+        const scopeKey = snapshotScopeKey(field);
+        const snapshot = args.initialSnapshot?.();
 
         batch(() => {
           for (const group of initialGroupedPage.groups) {
@@ -226,10 +268,16 @@ export function createGroupedSoupQueries(args: CreateGroupedSoupQueriesArgs) {
 
             queryClient.setQueryData<
               InfiniteData<GroupQueryPage, string | null>
-            >(queryKey, {
-              pages: [initialPage],
-              pageParams: [null],
-            });
+            >(
+              queryKey,
+              buildRestoredGroupQueryData({
+                initialPage,
+                groupBy,
+                groupKey: group.key,
+                scopeKey,
+                snapshot,
+              })
+            );
           }
 
           setGroupDataVersion((version) => version + 1);
@@ -243,5 +291,6 @@ export function createGroupedSoupQueries(args: CreateGroupedSoupQueriesArgs) {
     ...queries,
     list,
     map,
+    getSnapshot,
   };
 }

--- a/js/app/packages/app/component/next-soup/soup-view/grouped-query-snapshot.ts
+++ b/js/app/packages/app/component/next-soup/soup-view/grouped-query-snapshot.ts
@@ -1,0 +1,40 @@
+import type { GroupMeta } from '@queries/soup/grouped/types';
+import type { SoupApiItem } from '@service-storage/generated/schemas';
+import type { InfiniteData } from '@tanstack/solid-query';
+
+export type GroupQueryPage = {
+  items: Record<string, SoupApiItem>;
+  group: GroupMeta;
+};
+
+export type GroupedSoupQueriesSnapshot = {
+  groupBy: string;
+  scopeKey: string;
+  groups: Record<string, InfiniteData<GroupQueryPage, string | null>>;
+};
+
+export function buildRestoredGroupQueryData(input: {
+  initialPage: GroupQueryPage;
+  groupBy: string;
+  groupKey: string;
+  scopeKey: string;
+  snapshot?: GroupedSoupQueriesSnapshot;
+}): InfiniteData<GroupQueryPage, string | null> {
+  const savedData =
+    input.snapshot?.groupBy === input.groupBy &&
+    input.snapshot.scopeKey === input.scopeKey
+      ? input.snapshot.groups[input.groupKey]
+      : undefined;
+
+  if (savedData && savedData.pages.length > 1) {
+    return {
+      pages: [input.initialPage, ...savedData.pages.slice(1)],
+      pageParams: [null, ...savedData.pageParams.slice(1)],
+    };
+  }
+
+  return {
+    pages: [input.initialPage],
+    pageParams: [null],
+  };
+}

--- a/js/app/packages/app/component/next-soup/soup-view/soup-view-context.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-view-context.tsx
@@ -20,6 +20,7 @@ import {
 } from '@app/component/next-soup/filters/filter-store/query-store';
 import { createGroupedSoupQueries } from '@app/component/next-soup/soup-view/create-grouped-soup-queries';
 import { createSearchState } from '@app/component/next-soup/soup-view/create-search-state';
+import type { GroupedSoupQueriesSnapshot } from '@app/component/next-soup/soup-view/grouped-query-snapshot';
 import {
   INBOX_FILTER_ENTRY_KEY,
   registerInboxFilterSplit,
@@ -92,6 +93,7 @@ type SoupViewInitializeOptions = {
   initialQuery?: Query;
   initialClientFilters?: SetPredicatesInput<string>;
   initialSearchText?: string;
+  initialGroupedQuerySnapshot?: GroupedSoupQueriesSnapshot;
   disableLocalSearch?: boolean;
   additionalEntities?: Accessor<EntityData[]>;
 };
@@ -117,6 +119,7 @@ interface SoupViewContextValues {
   activeTab: Accessor<string | undefined>;
   setActiveTab: Setter<string | undefined>;
   groupByField: Accessor<GroupByField | undefined>;
+  getGroupedQuerySnapshot: () => GroupedSoupQueriesSnapshot | undefined;
   fetchNextGroupPage: (groupKey: string) => Promise<void>;
   isFetchingGroupPage: (groupKey: string) => boolean;
   hasNextGroupPage: (groupKey: string) => boolean;
@@ -163,6 +166,7 @@ export const SoupViewContextProvider: FlowComponent<
     initialQuery: props.initialQuery,
     initialClientFilters: props.initialClientFilters,
     initialSearchText: props.initialSearchText,
+    initialGroupedQuerySnapshot: props.initialGroupedQuerySnapshot,
     disableLocalSearch: props.disableLocalSearch,
     additionalEntities: props.additionalEntities,
   });
@@ -498,6 +502,7 @@ export const SoupViewContextProvider: FlowComponent<
       return { groups, items };
     }),
     groupByField,
+    initialSnapshot: () => config().initialGroupedQuerySnapshot,
     soupParams,
     soupBody,
     queryOptions: () => {
@@ -649,6 +654,7 @@ export const SoupViewContextProvider: FlowComponent<
     activeTab,
     setActiveTab,
     groupByField,
+    getGroupedQuerySnapshot: groupQueries.getSnapshot,
     fetchNextGroupPage,
     isFetchingGroupPage,
     hasNextGroupPage,

--- a/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
@@ -24,6 +24,7 @@ import { InboxSelector } from '@app/component/next-soup/soup-view/filters-bar/in
 import { SoupFiltersBar } from '@app/component/next-soup/soup-view/filters-bar/soup-filters-bar';
 import { SoupSearchbar } from '@app/component/next-soup/soup-view/filters-bar/soup-view-search-bar';
 import { useFilterRefinements } from '@app/component/next-soup/soup-view/filters-bar/use-filter-refinements';
+import type { GroupedSoupQueriesSnapshot } from '@app/component/next-soup/soup-view/grouped-query-snapshot';
 import { MaybeSoupEntityActionDrawerManager } from '@app/component/next-soup/soup-view/SoupEntityActionDrawerManager';
 import { SoupEntityContextMenu } from '@app/component/next-soup/soup-view/soup-entity-context-menu';
 import {
@@ -360,6 +361,14 @@ const listStateCache = new Map<
   }
 >();
 
+const SOUP_GROUP_STATE_ENTRY_KEY = 'soup.groupState';
+
+type SoupGroupEntryState = {
+  activeGroupId: string | null;
+  collapsedGroupKeys: string[];
+  loadedGroups?: GroupedSoupQueriesSnapshot;
+};
+
 interface SoupViewProps {
   viewName: string;
   initialClientFilters?: SetPredicatesInput<string>;
@@ -397,16 +406,11 @@ export const SoupView = (props: SoupViewProps) => {
 
   const persistedSearchText = entryState?.['search.text'] as string | undefined;
 
-  const persistedGroupBy = entryState?.['soup.groupBy'] as
-    | string
-    | null
+  const persistedGroupState = entryState?.[SOUP_GROUP_STATE_ENTRY_KEY] as
+    | SoupGroupEntryState
     | undefined;
 
   const persistedActiveTab = entryState?.['soup.tab'] as string | undefined;
-
-  const persistedCollapsedGroups = entryState?.['soup.collapsedGroups'] as
-    | string[]
-    | undefined;
 
   const [sortPref, setSortPref] = usePreference<string[]>(
     `macro:pref:soup:${contentId}:sort`,
@@ -431,11 +435,15 @@ export const SoupView = (props: SoupViewProps) => {
         initialQuery: persistedFilters ?? props.initialFilters,
         initialClientFilters: persistedPredicates ?? props.initialClientFilters,
         initialSearchText: persistedSearchText ?? props.initialSearchText,
+        initialGroupedQuerySnapshot: persistedGroupState?.loadedGroups,
         disableLocalSearch: props.disableLocalSearch,
         additionalEntities: props.additionalEntities,
       });
 
-      const initialGroupBy = persistedGroupBy ?? props.initialGroupBy;
+      let initialGroupBy = props.initialGroupBy;
+      if (persistedGroupState) {
+        initialGroupBy = persistedGroupState.activeGroupId ?? undefined;
+      }
 
       let initialSortIds = sortPref();
       if (initialSortIds.length === 0) {
@@ -449,7 +457,7 @@ export const SoupView = (props: SoupViewProps) => {
       }
 
       soup.grouping.setActiveGroupId(initialGroupBy);
-      soup.grouping.collapseAll(persistedCollapsedGroups ?? []);
+      soup.grouping.collapseAll(persistedGroupState?.collapsedGroupKeys ?? []);
 
       soup.sort.setAll(
         initialSortIds as Parameters<typeof soup.sort.setAll>[0]
@@ -724,6 +732,7 @@ export const SoupViewList = (props: SoupViewListProps) => {
     isLocalSearchSettling,
     activeTab,
     fetchNextGroupPage,
+    getGroupedQuerySnapshot,
     isFetchingGroupPage,
   } = useSoupView();
   const { hasActiveRefinements, hasHiddenItems, resetToTabDefaults } =
@@ -1027,23 +1036,17 @@ export const SoupViewList = (props: SoupViewListProps) => {
   );
   onCleanup(previewCaptorTeardown);
 
-  // Which groups are collapsed is also per-entry state: captured on nav-away
-  // and restored on back/forward.
-  const collapsedCaptorTeardown = panel.handle.registerEntryStateCaptor(
-    'soup.collapsedGroups',
-    () => [...soup.grouping.collapsedGroups()]
+  // Grouping is per-entry state too, including the active grouping, collapsed
+  // group labels, and per-group pages loaded via "Load more".
+  const groupStateCaptorTeardown = panel.handle.registerEntryStateCaptor(
+    SOUP_GROUP_STATE_ENTRY_KEY,
+    (): SoupGroupEntryState => ({
+      activeGroupId: soup.grouping.activeGroupId() ?? null,
+      collapsedGroupKeys: [...soup.grouping.collapsedGroups()],
+      loadedGroups: getGroupedQuerySnapshot(),
+    })
   );
-  onCleanup(collapsedCaptorTeardown);
-
-  // Active grouping is per-entry state too, so back/forward restores the
-  // grouping the user left each entry with. `null` (vs. key absent) records
-  // an explicit "no grouping" choice, which would otherwise be
-  // indistinguishable from a fresh entry.
-  const groupByCaptorTeardown = panel.handle.registerEntryStateCaptor(
-    'soup.groupBy',
-    () => soup.grouping.activeGroupId() ?? null
-  );
-  onCleanup(groupByCaptorTeardown);
+  onCleanup(groupStateCaptorTeardown);
 
   onCleanup(() => {
     if (isProjectList) return;


### PR DESCRIPTION
Persists Grouped By multi-page cache state in split history.