### PR TITLE
fix(email): wire gmail_ops_queue into mcp_service and DCS sqs clients

### DIFF
--- a/rust/cloud-storage/document_cognition_service/src/config.rs
+++ b/rust/cloud-storage/document_cognition_service/src/config.rs
@@ -11,6 +11,7 @@ env_vars!(
     pub struct DocumentTextExtractorQueue;
     pub struct ChatDeleteQueue;
     pub struct EmailScheduledQueue;
+    pub struct GmailOpsQueue;
     pub struct NotificationQueue;
     pub struct DocumentStorageServiceAuthKey;
     pub struct SearchEventQueue;
@@ -55,6 +56,8 @@ pub struct Config {
     pub chat_delete_queue: ChatDeleteQueue,
     /// The sqs queue to enqueue outbound email sends
     pub email_scheduled_queue: EmailScheduledQueue,
+    /// The sqs queue to enqueue Gmail label/sync operations
+    pub gmail_ops_queue: GmailOpsQueue,
     /// The sqs queue to send notifications to
     pub notification_queue: NotificationQueue,
     pub search_event_queue: SearchEventQueue,
@@ -102,6 +105,7 @@ impl Config {
             ),
             chat_delete_queue: ChatDeleteQueue::Comptime("CHAT_DELETE_QUEUE"),
             email_scheduled_queue: EmailScheduledQueue::Comptime("EMAIL_SCHEDULED_QUEUE"),
+            gmail_ops_queue: GmailOpsQueue::Comptime("GMAIL_OPS_QUEUE"),
             notification_queue: NotificationQueue::Comptime("NOTIFICATION_QUEUE"),
             search_event_queue: SearchEventQueue::Comptime("SEARCH_EVENT_QUEUE"),
             ai_projection_queue: AiProjectionQueue::Comptime("AI_PROJECTION_QUEUE"),

--- a/rust/cloud-storage/document_cognition_service/src/main.rs
+++ b/rust/cloud-storage/document_cognition_service/src/main.rs
@@ -99,6 +99,7 @@ async fn main() -> anyhow::Result<()> {
         .document_text_extractor_queue(&config.document_text_extractor_queue)
         .chat_delete_queue(&config.chat_delete_queue)
         .email_scheduled_queue(&config.email_scheduled_queue)
+        .gmail_ops_queue(&config.gmail_ops_queue)
         .search_event_queue(&config.search_event_queue)
         .ai_projection_queue(&config.ai_projection_queue);
 

--- a/rust/cloud-storage/mcp_service/src/config.rs
+++ b/rust/cloud-storage/mcp_service/src/config.rs
@@ -14,6 +14,9 @@ pub use macro_middleware::auth::internal_access::InternalApiSecretKey;
 env_vars! {
     /// SQS URL for the email scheduled queue, consumed by the AI tools.
     pub struct EmailScheduledQueue;
+    /// SQS URL for the Gmail ops queue, consumed by the AI tools to enqueue
+    /// Gmail label/sync operations.
+    pub struct GmailOpsQueue;
     /// Auth key used by the document storage / search / lexical clients.
     pub struct DocumentStorageServiceAuthKey;
     /// Secrets Manager secret name for the sync service auth key.
@@ -65,6 +68,7 @@ pub struct Config {
     /// The connection URL for the Postgres database this application uses.
     pub database_url: DatabaseUrl,
     pub email_scheduled_queue: EmailScheduledQueue,
+    pub gmail_ops_queue: GmailOpsQueue,
     pub document_storage_service_auth_key: DocumentStorageServiceAuthKey,
     pub sync_service_auth_key: SyncServiceAuthKey,
     pub document_storage_bucket: DocumentStorageBucket,

--- a/rust/cloud-storage/mcp_service/src/context.rs
+++ b/rust/cloud-storage/mcp_service/src/context.rs
@@ -66,7 +66,8 @@ pub async fn build_context(config: &Config) -> anyhow::Result<McpContext> {
     let aws_config = macro_aws_config::get_macro_aws_config().await;
     let queue_aws_client = aws_sdk_sqs::Client::new(&aws_config);
     let sqs_client = sqs_client::SQS::new(queue_aws_client)
-        .email_scheduled_queue(config.email_scheduled_queue.as_ref());
+        .email_scheduled_queue(config.email_scheduled_queue.as_ref())
+        .gmail_ops_queue(config.gmail_ops_queue.as_ref());
 
     let secretsmanager_client = secretsmanager_client::SecretsManager::new(
         aws_sdk_secretsmanager::Client::new(&aws_config),


### PR DESCRIPTION
The AI email tools that enqueue Gmail label operations run inside the `mcp_service` and `document_cognition_service` binaries, which each build their own SQS client. Neither wired up the gmail_ops queue, so `UpdateThreadLabels` failed at the enqueue step with `gmail_ops_queue is not configured`. This adds the `GMAIL_OPS_QUEUE` config field to both services and passes it to their SQS clients. The var is already present in Doppler (dev + prd) for both projects.
