### PR TITLE
fix(search): restore search state on browser back/forward navigation

### DIFF
--- a/js/app/packages/app/component/split-layout/layoutManager.ts
+++ b/js/app/packages/app/component/split-layout/layoutManager.ts
@@ -183,22 +183,36 @@ function keyOfSplitState(s: SplitState): SplitKey {
   return `${s.content.type}:${s.content.id}`;
 }
 
-// Find the history index of the entry matching `predicate`, preferring the
-// closest match looking backward from the current index (the common back case),
-// then forward. Excludes the current index. Returns -1 if none match.
+// Find the history index of the entry matching `predicate`, excluding the
+// current index. Returns -1 if none match. By default prefers the nearest
+// backward match then forward (jumping back to a prior view). With `nearest`,
+// prefers the closest match in either direction, which browser back/forward
+// needs so a duplicate entry on the far side isn't chosen over the adjacent one.
 function findHistoryIndex(
   split: SplitState,
-  predicate: (content: SplitContent) => boolean
+  predicate: (content: SplitContent) => boolean,
+  nearest = false
 ): number {
   const items = split.history.items;
   const currentIdx = split.history.index;
+  let back = -1;
   for (let j = currentIdx - 1; j >= 0; j--) {
-    if (predicate(items[j])) return j;
+    if (predicate(items[j])) {
+      back = j;
+      break;
+    }
   }
+  let forward = -1;
   for (let j = currentIdx + 1; j < items.length; j++) {
-    if (predicate(items[j])) return j;
+    if (predicate(items[j])) {
+      forward = j;
+      break;
+    }
   }
-  return -1;
+  if (back === -1) return forward;
+  if (forward === -1) return back;
+  if (!nearest) return back;
+  return currentIdx - back <= forward - currentIdx ? back : forward;
 }
 
 export type UrlCapabilities = {
@@ -1125,8 +1139,10 @@ export function createSplitLayout(
     for (let i = 0; i < newSplits.length; i++) {
       const split = visibleSplits[i];
       if (sameContent(split.content, newSplits[i])) continue;
-      const targetIdx = findHistoryIndex(split, (item) =>
-        sameContent(item, newSplits[i])
+      const targetIdx = findHistoryIndex(
+        split,
+        (item) => sameContent(item, newSplits[i]),
+        true
       );
       if (targetIdx === -1) return false;
       plan.push({ split, targetIdx });

--- a/js/app/packages/app/component/split-layout/layoutManager.ts
+++ b/js/app/packages/app/component/split-layout/layoutManager.ts
@@ -1148,6 +1148,12 @@ export function createSplitLayout(
       plan.push({ split, targetIdx });
     }
 
+    // A simultaneous multi-split reorder (e.g. [A, B] -> [B, A]) can't be
+    // applied one split at a time without tripping reattach's duplicate guard
+    // after the index has already moved. Only walk history when a single split
+    // moved; fall back to a clean rebuild otherwise.
+    if (plan.length > 1) return false;
+
     for (const { split, targetIdx } of plan) {
       const cause: NavigationCause =
         targetIdx < split.history.index ? 'history-back' : 'history-forward';

--- a/js/app/packages/app/component/split-layout/layoutManager.ts
+++ b/js/app/packages/app/component/split-layout/layoutManager.ts
@@ -183,6 +183,24 @@ function keyOfSplitState(s: SplitState): SplitKey {
   return `${s.content.type}:${s.content.id}`;
 }
 
+// Find the history index of the entry matching `predicate`, preferring the
+// closest match looking backward from the current index (the common back case),
+// then forward. Excludes the current index. Returns -1 if none match.
+function findHistoryIndex(
+  split: SplitState,
+  predicate: (content: SplitContent) => boolean
+): number {
+  const items = split.history.items;
+  const currentIdx = split.history.index;
+  for (let j = currentIdx - 1; j >= 0; j--) {
+    if (predicate(items[j])) return j;
+  }
+  for (let j = currentIdx + 1; j < items.length; j++) {
+    if (predicate(items[j])) return j;
+  }
+  return -1;
+}
+
 export type UrlCapabilities = {
   getUrlSegments: () => string[];
   getUrl: () => string;
@@ -773,28 +791,9 @@ export function createSplitLayout(
       return false;
     }
     const split = state.splits[i];
-    const items = split.history.items;
     const currentIdx = split.history.index;
-    if (items.length === 0) return false;
-
-    // Prefer the closest match looking backwards (more common case — the
-    // user just came from there). Fall back to looking forward.
-    let targetIdx = -1;
-    for (let j = currentIdx - 1; j >= 0; j--) {
-      if (predicate(items[j])) {
-        targetIdx = j;
-        break;
-      }
-    }
-    if (targetIdx === -1) {
-      for (let j = currentIdx + 1; j < items.length; j++) {
-        if (predicate(items[j])) {
-          targetIdx = j;
-          break;
-        }
-      }
-    }
-    if (targetIdx === -1 || targetIdx === currentIdx) return false;
+    const targetIdx = findHistoryIndex(split, predicate);
+    if (targetIdx === -1) return false;
 
     captureCurrentEntryState(split);
     const target = split.history.goToIndex(targetIdx);
@@ -1108,6 +1107,41 @@ export function createSplitLayout(
     return getSplit(match.id);
   }
 
+  /**
+   * Try to satisfy a URL reconcile as in-history navigation (browser/swipe back
+   * & forward). If every position whose content changed resolves to an entry
+   * already in that split's history, walk each split's history to that entry —
+   * preserving its captured per-entry state — and return true. Returns false
+   * without changing anything if any position is not in history, so the caller
+   * can rebuild from scratch instead.
+   */
+  function tryReconcileViaHistory(
+    visibleSplits: SplitState[],
+    newSplits: SplitContent[]
+  ): boolean {
+    // Resolve a target index for every changed position before navigating, so
+    // we only take this path if the whole layout can be served from history.
+    const plan: { split: SplitState; targetIdx: number }[] = [];
+    for (let i = 0; i < newSplits.length; i++) {
+      const split = visibleSplits[i];
+      if (sameContent(split.content, newSplits[i])) continue;
+      const targetIdx = findHistoryIndex(split, (item) =>
+        sameContent(item, newSplits[i])
+      );
+      if (targetIdx === -1) return false;
+      plan.push({ split, targetIdx });
+    }
+
+    for (const { split, targetIdx } of plan) {
+      const cause: NavigationCause =
+        targetIdx < split.history.index ? 'history-back' : 'history-forward';
+      captureCurrentEntryState(split);
+      const target = split.history.goToIndex(targetIdx);
+      if (target) reattach(split, target, undefined, cause);
+    }
+    return true;
+  }
+
   function reconcileSplits(newSplits: SplitContent[]) {
     // URL segments are produced by getUrlSegments(), which excludes excluded splits.
     const visibleSplits = state.splits.filter((s) => !isExcluded(s));
@@ -1116,6 +1150,16 @@ export function createSplitLayout(
     const changed = newKeys.join(',') !== currentKeys.join(',');
 
     if (!changed) return;
+
+    // Browser/swipe back & forward reach us as a URL change. When the layout
+    // shape is unchanged, prefer walking each split's own history (which keeps
+    // its captured per-entry state) over rebuilding splits from scratch.
+    if (
+      visibleSplits.length === newSplits.length &&
+      tryReconcileViaHistory(visibleSplits, newSplits)
+    ) {
+      return;
+    }
 
     // Build the result array by position, preserving excluded splits unchanged.
     const resultSplits: SplitState[] = [];

--- a/js/app/tests/e2e/local-search-state.spec.ts
+++ b/js/app/tests/e2e/local-search-state.spec.ts
@@ -62,6 +62,7 @@ test.describe('local search bar state', () => {
     await search(page, SEEDED_DOCUMENT.document_name);
 
     await openFocusedResult(page);
+    await expect(page).not.toHaveURL(/\/component\/search$/);
     const resultUrl = page.url();
 
     await page.goBack();

--- a/js/app/tests/e2e/local-search-state.spec.ts
+++ b/js/app/tests/e2e/local-search-state.spec.ts
@@ -32,6 +32,44 @@ test.describe('local search bar state', () => {
 
     await expect(page).toHaveURL(/\/component\/search$/);
     await expectSearchText(page, SEEDED_DOCUMENT.document_name);
+    await expectResultVisible(page);
+  });
+
+  test('restores the query after opening a result and using the browser back button', async ({
+    page,
+  }) => {
+    await gotoApp(page, '/component/search');
+    await search(page, SEEDED_DOCUMENT.document_name);
+
+    await openFocusedResult(page);
+    await expect(page).not.toHaveURL(/\/component\/search$/);
+
+    // The browser back button drives the URL->layout reconcile path, distinct
+    // from the in-app split history. Going back must walk the split's own
+    // history so the search view is restored with its captured text and
+    // results, instead of being rebuilt into an empty (soup-feed) view.
+    await page.goBack();
+
+    await expect(page).toHaveURL(/\/component\/search$/);
+    await expectSearchText(page, SEEDED_DOCUMENT.document_name);
+    await expectResultVisible(page);
+  });
+
+  test('restores the result on browser forward after a browser back', async ({
+    page,
+  }) => {
+    await gotoApp(page, '/component/search');
+    await search(page, SEEDED_DOCUMENT.document_name);
+
+    await openFocusedResult(page);
+    const resultUrl = page.url();
+
+    await page.goBack();
+    await expect(page).toHaveURL(/\/component\/search$/);
+    await expectSearchText(page, SEEDED_DOCUMENT.document_name);
+
+    await page.goForward();
+    await expect(page).toHaveURL(resultUrl);
   });
 
   test('restores the query after switching sidebar views and going back', async ({
@@ -58,6 +96,13 @@ async function search(page: Page, text: string) {
 
   // Wait for the seeded result so we know the query produced output before we
   // navigate away from the view.
+  await expectResultVisible(page);
+}
+
+// The seeded result is only rendered when the search is actually executing, so
+// asserting it after navigation guards against restoring stale bar text over an
+// empty soup feed (not just an empty bar).
+async function expectResultVisible(page: Page) {
   await expect(
     page.locator(
       `${soupListContainerSelector} ${entityIdSelector(SEEDED_DOCUMENT.document_id)}`


### PR DESCRIPTION
Browser/swipe back & forward rebuilt splits from the URL with fresh history, wiping each entry's captured search text, filters, and group state. `reconcileSplits` now walks a split's own history when the target entry already exists, restoring it without re-focusing the search bar, and falls back to the old rebuild only for genuinely new layouts.
