### PR TITLE
[fix] paste node doesn't correctly convert to md

### DIFF
--- a/js/lexical-core/nodes/PasteNode.ts
+++ b/js/lexical-core/nodes/PasteNode.ts
@@ -1,3 +1,5 @@
+import { $convertFromMarkdownString } from '@lexical/markdown';
+import { $unwrapNode } from '@lexical/utils';
 import {
   $applyNodeReplacement,
   $createParagraphNode,
@@ -12,6 +14,7 @@ import {
 } from 'lexical';
 import { type DecoratorComponent, getDecorator } from '../decoratorRegistry';
 import { $applyIdFromSerialized } from '../plugins/nodeIdPlugin';
+import { ALL_TRANSFORMERS } from '../transformers';
 import { DecoratorBlockNode } from './DecoratorBlockNode';
 
 const VERSION = 1;
@@ -165,14 +168,18 @@ export function $isPasteNode(
 }
 
 /**
- * Convert a PasteNode (block) into plain in-document text, inserting the
- * content exactly the way a normal plain-text paste does — i.e. as text with
- * line breaks inside a single paragraph (via `insertRawText`) rather than the
- * block-level PasteNode the large-paste handler would otherwise create.
+ * Convert a PasteNode (block) into in-document content, parsing the held text
+ * as markdown exactly the way pasting that same text directly would — just
+ * without re-wrapping the result in a PasteNode. The content is parsed into a
+ * temporary paragraph wrapper which is then unwrapped so the resulting nodes
+ * sit at the paste node's former level.
  */
 export function $convertPasteToText(pasteNode: PasteNode): void {
   const content = pasteNode.getContent();
-  const paragraph = $createParagraphNode();
-  pasteNode.replace(paragraph);
-  paragraph.select().insertRawText(content);
+  const wrapper = $createParagraphNode();
+  pasteNode.replace(wrapper);
+  $convertFromMarkdownString(content, ALL_TRANSFORMERS, wrapper, false);
+  const lastChild = wrapper.getLastChild();
+  $unwrapNode(wrapper);
+  lastChild?.selectEnd();
 }

--- a/js/lexical-core/tests/paste.test.ts
+++ b/js/lexical-core/tests/paste.test.ts
@@ -128,9 +128,8 @@ describe('PasteNode - external transformer', () => {
 });
 
 describe('PasteNode - convert to text', () => {
-  it('converts a paste node into paragraphs of plain text', async () => {
+  async function convertPaste(content: string) {
     const editor = makeEditor();
-    const content = 'first line\nsecond line';
 
     await new Promise<void>((resolve) => {
       editor.update(
@@ -154,11 +153,40 @@ describe('PasteNode - convert to text', () => {
       );
     });
 
+    return editor;
+  }
+
+  it('converts a paste node into in-document text', async () => {
+    const editor = await convertPaste('first line\nsecond line');
+
     editor.getEditorState().read(() => {
       const root = $getRoot();
       expect(root.getChildren().some($isPasteNode)).toBe(false);
       expect(root.getTextContent()).toContain('first line');
       expect(root.getTextContent()).toContain('second line');
     });
+  });
+
+  it('parses the content as markdown, just like a normal paste', async () => {
+    const content = '# Heading\n\n- one\n- two';
+    const editor = await convertPaste(content);
+
+    let markdown = '';
+    editor.getEditorState().read(() => {
+      const root = $getRoot();
+      expect(root.getChildren().some($isPasteNode)).toBe(false);
+      // The heading marker and list markers should be parsed into structural
+      // nodes rather than left as literal text.
+      const types = root.getChildren().map((node) => node.getType());
+      expect(types).toContain('heading');
+      markdown = $convertToMarkdownString(INTERNAL_TRANSFORMERS);
+    });
+
+    // Round-tripping the resulting nodes back to markdown reproduces the
+    // original markdown, confirming it was parsed (not inserted as raw text).
+    expect(markdown).not.toContain('<m-paste>');
+    expect(markdown).toContain('# Heading');
+    expect(markdown).toContain('- one');
+    expect(markdown).toContain('- two');
   });
 });


### PR DESCRIPTION
Makes a paste node's "convert to text" parse its held content as Markdown the same way a normal paste would, just without re-wrapping the result in a paste node.

Task: 019efba1-81f0-780f-a175-4d946605761a (macro-2051)