### PR TITLE
fix(calls): noise suppression in calls

### DIFF
--- a/js/app/packages/channel/Call/CallContext.tsx
+++ b/js/app/packages/channel/Call/CallContext.tsx
@@ -102,8 +102,11 @@ function normalizeNoiseSuppressionMode(
   value: unknown
 ): MicNoiseSuppressionMode {
   if (value === false || value === 'false' || value === 'off') return 'off';
+  if (value === 'krisp') return 'krisp';
   if (value === 'browser') return 'browser';
-  return 'krisp';
+  // Legacy boolean `true` ("NS on", which predated the engine choice) and any
+  // unrecognized value fall back to the current default engine, 'browser'.
+  return 'browser';
 }
 
 function effectiveCaptureModeForPreferredMode(
@@ -117,6 +120,29 @@ function isNoiseSuppressionEnabled(mode: MicNoiseSuppressionMode): boolean {
   return mode !== 'off';
 }
 
+// User-facing noise-suppression options, ordered least → most aggressive.
+// Exported so the call-control menus render the same set the context applies.
+export const NOISE_SUPPRESSION_OPTIONS: {
+  mode: MicNoiseSuppressionMode;
+  label: string;
+}[] = [
+  { mode: 'off', label: 'Off' },
+  { mode: 'browser', label: 'Browser' },
+  { mode: 'krisp', label: 'Krisp' },
+];
+
+// AGC normalizes capture loudness so a normal-distance talker isn't published
+// quiet/distant — the main fidelity gap vs Google Meet, which keeps AGC on.
+// Enable it for 'off' and 'browser', but keep it OFF under Krisp: Krisp is a
+// fixed-strength DNN denoiser (its suppression level is hardcoded to max in
+// @livekit/krisp-noise-filter and is not exposed by its API), so a downstream
+// gain stage re-amplifies the residual noise floor it leaves during quiet
+// passages — exactly the "background noise gets louder" artifact we want to
+// avoid stacking on top of Krisp.
+function autoGainControlForMode(mode: MicNoiseSuppressionMode): boolean {
+  return mode !== 'krisp';
+}
+
 function microphoneCaptureOptions(
   mode: MicNoiseSuppressionMode,
   deviceId?: string | null
@@ -124,11 +150,8 @@ function microphoneCaptureOptions(
   const useBrowserProcessing = mode === 'browser';
 
   return {
-    // AGC can raise residual background artifacts during quiet speech/silence.
-    // Keep it disabled for every mode; Krisp/browser NS should not be stacked
-    // with a gain stage that makes suppressed noise audible again.
     ...(supportsNativeAudioProcessingConstraint('autoGainControl')
-      ? { autoGainControl: false }
+      ? { autoGainControl: autoGainControlForMode(mode) }
       : {}),
     echoCancellation: true,
     ...(supportsNativeAudioProcessingConstraint('noiseSuppression')
@@ -148,7 +171,7 @@ function nativeAudioProcessingConstraints(
 
   return {
     ...(supportsNativeAudioProcessingConstraint('autoGainControl')
-      ? { autoGainControl: false }
+      ? { autoGainControl: autoGainControlForMode(mode) }
       : {}),
     ...(supportsNativeAudioProcessingConstraint('noiseSuppression')
       ? { noiseSuppression: useBrowserProcessing }
@@ -284,10 +307,13 @@ const [persistedBackgroundEffect, setPersistedBackgroundEffect] = makePersisted(
 
 // Persisted across reloads — users with hardware noise cancellation (e.g.
 // AirPods Pro, Bose) need to disable app/browser-side NS to avoid cascading
-// filters that attenuate voice. Defaults to Krisp to match existing behavior.
-// The custom deserializer migrates the previous boolean format.
+// filters that attenuate voice. Defaults to 'browser' (WebRTC NS + AGC, like
+// Google Meet): Krisp runs at a non-configurable max suppression level that
+// over-attenuates/muffles some voices, so it is now opt-in. The custom
+// deserializer preserves an explicit 'krisp'/'off'/'browser' choice and
+// migrates the previous boolean format ("on" → browser).
 const [persistedNoiseSuppressionMode, setPersistedNoiseSuppressionMode] =
-  makePersisted(createSignal<MicNoiseSuppressionMode>('krisp'), {
+  makePersisted(createSignal<MicNoiseSuppressionMode>('browser'), {
     name: 'call.noiseSuppression',
     deserialize(data) {
       try {
@@ -362,6 +388,8 @@ export type CallState = {
   isNoiseSuppressed: () => boolean;
   /** Toggle mic noise suppression on/off */
   toggleNoiseSuppression: () => Promise<void>;
+  /** Set the mic noise suppression mode explicitly (off | browser | krisp) */
+  setNoiseSuppressionMode: (mode: MicNoiseSuppressionMode) => Promise<void>;
   /** Begin an optimistic join to a channel */
   beginOptimisticJoin: (channelId: string) => void;
   /** Rollback an optimistic join to a channel */
@@ -467,6 +495,25 @@ function createCallState() {
       | NativeAudioProcessingConstraints
       | undefined;
 
+    // Detect out-of-band processing (e.g. macOS Control Center "Voice
+    // Isolation" or hardware NS) that ignores our getUserMedia constraints: if
+    // we asked for a processor to be OFF but the track reports it ON, a second
+    // NS/AGC stage is cascading on top of ours, which muffles voice and pumps
+    // steady noise. This can't be disabled in-app; surface it for support.
+    const osOverrides: string[] = [];
+    if (constraints?.autoGainControl === false && settings?.autoGainControl)
+      osOverrides.push('autoGainControl');
+    if (constraints?.noiseSuppression === false && settings?.noiseSuppression)
+      osOverrides.push('noiseSuppression');
+    if (constraints?.voiceIsolation === false && settings?.voiceIsolation)
+      osOverrides.push('voiceIsolation');
+    if (osOverrides.length > 0) {
+      console.warn(
+        '[call] mic processing overridden by OS/hardware (e.g. macOS Voice Isolation)',
+        { event, osOverrides }
+      );
+    }
+
     console.debug('[call] mic audio processing', {
       event,
       preferredMode: persistedNoiseSuppressionMode(),
@@ -548,6 +595,10 @@ function createCallState() {
       // `quality` is model size/CPU cost, not suppression strength. The default
       // medium model avoids the CPU pressure/dropouts that made voices sound
       // muddy on busy machines while still enabling Krisp when supported.
+      // NOTE: Krisp's suppression *level* is hardcoded to max (100) in the SDK
+      // and is not exposed by @livekit/krisp-noise-filter's options, so its
+      // aggressiveness cannot be dialed back here. Users who find Krisp over-
+      // suppresses / muffles their voice should switch to the 'browser' mode.
       const krisp = KrispNoiseFilter({ quality: 'medium' });
       setKrispFilter(krisp);
       await micTrack.setProcessor(krisp);
@@ -1086,30 +1137,34 @@ function createCallState() {
     setStore('isSharedWithTeam', value);
   }
 
-  async function toggleNoiseSuppression() {
-    const newMode: MicNoiseSuppressionMode = isNoiseSuppressionEnabled(
-      store.noiseSuppressionMode
-    )
-      ? 'off'
-      : 'krisp';
-
-    setStore('noiseSuppressionMode', newMode);
-    setPersistedNoiseSuppressionMode(newMode);
+  async function setNoiseSuppressionMode(mode: MicNoiseSuppressionMode) {
+    setStore('noiseSuppressionMode', mode);
+    setPersistedNoiseSuppressionMode(mode);
 
     const r = room();
     if (!r) return;
 
     try {
-      if (newMode === 'off') {
+      if (mode === 'off') {
         await detachKrispFromMicTrack(r);
+        // 'off' still re-applies native constraints (AGC back on, NS/VI off).
         await applyNativeAudioProcessingToMicTrack(r, 'off');
-        logMicAudioProcessing('noise-suppression-toggled-off', r);
+        logMicAudioProcessing('noise-suppression-set-off', r);
       } else {
+        // ensureNoiseSuppressionOnMicTrack reads the freshly-persisted mode and
+        // (de)attaches Krisp + applies the right native AGC/NS constraints for
+        // 'browser' vs 'krisp'.
         await ensureNoiseSuppressionOnMicTrack(r);
       }
     } catch (e) {
-      console.error('failed to toggle noise suppression', e);
+      console.error('failed to set noise suppression mode', e);
     }
+  }
+
+  async function toggleNoiseSuppression() {
+    await setNoiseSuppressionMode(
+      isNoiseSuppressionEnabled(store.noiseSuppressionMode) ? 'off' : 'browser'
+    );
   }
 
   // --- optimistic join ---
@@ -1219,6 +1274,7 @@ function createCallState() {
     isNoiseSuppressed: () =>
       isNoiseSuppressionEnabled(store.noiseSuppressionMode),
     toggleNoiseSuppression,
+    setNoiseSuppressionMode,
     beginOptimisticJoin,
     rollbackOptimisticJoin,
     joinError: currentJoinError,

--- a/js/app/packages/channel/Call/CallControls/CallControlsDefaultAndPanelRow.tsx
+++ b/js/app/packages/channel/Call/CallControls/CallControlsDefaultAndPanelRow.tsx
@@ -8,7 +8,11 @@ import VideoCamera from '@phosphor/video-camera.svg';
 import VideoCameraSlash from '@phosphor/video-camera-slash.svg';
 import { Button, Dropdown, SingleSelectCheck } from '@ui';
 import { For, type JSX, Show } from 'solid-js';
-import { BACKGROUND_IMAGES, useCallContext } from '../CallContext';
+import {
+  BACKGROUND_IMAGES,
+  NOISE_SUPPRESSION_OPTIONS,
+  useCallContext,
+} from '../CallContext';
 import { CallDeviceList } from '../CallDeviceList';
 
 export type CallControlsDefaultAndPanelRowProps = {
@@ -235,16 +239,22 @@ export function CallControlsDefaultAndPanelRow(
               />
             </Dropdown.Group>
             <Dropdown.Group>
-              <Dropdown.GroupLabel>Audio processing</Dropdown.GroupLabel>
-              <Dropdown.Item
-                closeOnSelect={false}
-                onSelect={() => void callCtx.toggleNoiseSuppression()}
-              >
-                <span class="flex-1 truncate">Noise suppression</span>
-                <SingleSelectCheck
-                  active={callCtx.noiseSuppressionMode() !== 'off'}
-                />
-              </Dropdown.Item>
+              <Dropdown.GroupLabel>Noise suppression</Dropdown.GroupLabel>
+              <For each={NOISE_SUPPRESSION_OPTIONS}>
+                {(option) => (
+                  <Dropdown.Item
+                    closeOnSelect={false}
+                    onSelect={() =>
+                      void callCtx.setNoiseSuppressionMode(option.mode)
+                    }
+                  >
+                    <span class="flex-1 truncate">{option.label}</span>
+                    <SingleSelectCheck
+                      active={callCtx.noiseSuppressionMode() === option.mode}
+                    />
+                  </Dropdown.Item>
+                )}
+              </For>
             </Dropdown.Group>
             <Show when={isBackgroundBlurSupported()}>
               <BackgroundEffectSelector />

--- a/js/app/packages/channel/Call/CallControls/CallControlsPanelSmallRow.tsx
+++ b/js/app/packages/channel/Call/CallControls/CallControlsPanelSmallRow.tsx
@@ -5,10 +5,9 @@ import MicrophoneSlash from '@phosphor/microphone-slash.svg';
 import Screencast from '@phosphor/screencast.svg';
 import VideoCamera from '@phosphor/video-camera.svg';
 import VideoCameraSlash from '@phosphor/video-camera-slash.svg';
-import { cn, Dropdown, InlineCheckbox } from '@ui';
-import { Show } from 'solid-js';
-import { match } from 'ts-pattern';
-import { useCallContext } from '../CallContext';
+import { cn, Dropdown, InlineCheckbox, SingleSelectCheck } from '@ui';
+import { For, Show } from 'solid-js';
+import { NOISE_SUPPRESSION_OPTIONS, useCallContext } from '../CallContext';
 import { CallDeviceList } from '../CallDeviceList';
 import { useToggleShareWithTeam } from '../use-toggle-share-with-team';
 import { MenuDivider, MenuLabel } from './CallMenuPrimitives';
@@ -19,12 +18,6 @@ export function CallControlsPanelSmallRow() {
   const callCtx = useCallContext();
   const isConnecting = () => callCtx.isConnecting();
   const handleToggleShareWithTeam = useToggleShareWithTeam();
-  const noiseSuppressionModeLabel = () =>
-    match(callCtx.noiseSuppressionMode())
-      .with('krisp', () => 'Krisp')
-      .with('browser', () => 'Browser')
-      .with('off', () => 'Off')
-      .exhaustive();
 
   const anyMediaActive = () =>
     !callCtx.isAudioMuted() ||
@@ -91,16 +84,22 @@ export function CallControlsPanelSmallRow() {
 
             <MenuDivider />
 
-            <MenuLabel>Audio processing</MenuLabel>
-            <Dropdown.Item
-              closeOnSelect={false}
-              onSelect={() => void callCtx.toggleNoiseSuppression()}
-            >
-              <span class="flex-1 truncate">Noise suppression</span>
-              <span class="text-xs text-ink-muted">
-                {noiseSuppressionModeLabel()}
-              </span>
-            </Dropdown.Item>
+            <MenuLabel>Noise suppression</MenuLabel>
+            <For each={NOISE_SUPPRESSION_OPTIONS}>
+              {(option) => (
+                <Dropdown.Item
+                  closeOnSelect={false}
+                  onSelect={() =>
+                    void callCtx.setNoiseSuppressionMode(option.mode)
+                  }
+                >
+                  <span class="flex-1 truncate">{option.label}</span>
+                  <SingleSelectCheck
+                    active={callCtx.noiseSuppressionMode() === option.mode}
+                  />
+                </Dropdown.Item>
+              )}
+            </For>
 
             <MenuDivider />
 

--- a/js/app/packages/core/component/TopBar/ShareButton.tsx
+++ b/js/app/packages/core/component/TopBar/ShareButton.tsx
@@ -291,7 +291,7 @@ function MobileShareDrawer(props: MobileShareDrawerProps) {
 
   const mobileTabs = createMemo((): TabItem[] => {
     const tabs: TabItem[] = [{ value: 'share', label: 'Share' }];
-    if ((props.recipients?.length ?? 0) > 0 || !!props.owner)
+    if ((props.recipients?.length ?? 0) > 0 || props.owner)
       tabs.push({ value: 'people', label: 'People' });
     if (
       props.userPermissions === Permissions.OWNER &&

--- a/js/bun.lock
+++ b/js/bun.lock
@@ -883,7 +883,7 @@
 
     "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
 
-    "@inkibra/tauri-plugins": ["@inkibra/tauri-plugins@github:macro-inc/tauri-plugins#26537c8", { "dependencies": { "react": "^18.3.1", "react-dom": "^18.3.1" } }, "macro-inc-tauri-plugins-26537c8"],
+    "@inkibra/tauri-plugins": ["@inkibra/tauri-plugins@github:macro-inc/tauri-plugins#26537c8", { "dependencies": { "react": "^18.3.1", "react-dom": "^18.3.1" } }, "macro-inc-tauri-plugins-26537c8", "sha512-6p5xQAkS6Uw6J8Uh0vlj6MjKZXWps5E1Gu0hciBFq1E2BfPBZAgdeeafKnR3diNb4SXWK0JML49nAr+o5PhwKw=="],
 
     "@inquirer/external-editor": ["@inquirer/external-editor@1.0.3", "", { "dependencies": { "chardet": "^2.1.1", "iconv-lite": "^0.7.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA=="],
 
@@ -2613,7 +2613,7 @@
 
     "pathval": ["pathval@2.0.1", "", {}, "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ=="],
 
-    "pdfjs-dist": ["pdfjs-dist@github:macro-inc/pdf.js#f9b2ce6", { "dependencies": { "dommatrix": "^1.0.3", "web-streams-polyfill": "^3.2.1" }, "peerDependencies": { "worker-loader": "^3.0.8" }, "optionalPeers": ["worker-loader"] }, "macro-inc-pdf.js-f9b2ce6"],
+    "pdfjs-dist": ["pdfjs-dist@github:macro-inc/pdf.js#f9b2ce6", { "dependencies": { "dommatrix": "^1.0.3", "web-streams-polyfill": "^3.2.1" }, "peerDependencies": { "worker-loader": "^3.0.8" }, "optionalPeers": ["worker-loader"] }, "macro-inc-pdf.js-f9b2ce6", "sha512-HDFaPbCxLG2GHpf1smUG97nku5aPGBGaCcIbK05dGdp07TBLUlDcXsM4WcE82mO5W4RBPIBVYobX5N/6M6NFrA=="],
 
     "performance-now": ["performance-now@2.1.0", "", {}, "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="],
 


### PR DESCRIPTION
CallContext.tsx
- autoGainControlForMode() — AGC on for off/browser, off for krisp.
- Default NS mode 'krisp' → 'browser' (WebRTC NS + AGC, Meet-like).
- normalizeNoiseSuppressionMode() migration: preserves an explicit 'krisp'/'off'/'browser', maps legacy boolean true → 'browser', unknown → 'browser'.
- setNoiseSuppressionMode(mode) + exported NOISE_SUPPRESSION_OPTIONS; toggleNoiseSuppression now targets browser when turning on.
- OS-override console.warn in logMicAudioProcessing (catches macOS Voice Isolation cascade).
- Corrected comment documenting that Krisp's level is hardcoded to max and not tunable.

CallControlsPanelSmallRow.tsx / CallControlsDefaultAndPanelRow.tsx
- Both menus now show explicit Off / Browser / Krisp options (Krisp is now opt-in but one click away).

Who this actually affects (migration nuance)

- Never touched the setting (no stored call.noiseSuppression) → now get Browser. This is the majority, and almost certainly includes your muffled user.
- Legacy boolean "on" → migrated to Browser.
- Explicitly stored 'krisp' (toggled NS on under recent builds) → keep Krisp, since the stored string is indistinguishable from a deliberate choice. They can switch to Browser via the menu.