### PR TITLE
fix(email): don't fail link teardown when FA IdP unlink fails

### DIFF
--- a/rust/cloud-storage/email_service/src/pubsub/link_manager/process.rs
+++ b/rust/cloud-storage/email_service/src/pubsub/link_manager/process.rs
@@ -325,17 +325,17 @@ async fn handle_delete(
     // remove google fusionauth link with gmail inbox permissions. best-effort: the FA user may
     // already be gone (e.g. account deleted before we delete their email), so we warn and keep
     // going rather than failing the message and retrying.
-    if let Err(e) = ctx
-        .auth_service_client
+    ctx.auth_service_client
         .remove_link(
             &link.fusionauth_user_id,
             link.email_address.0.as_ref(),
             "google_gmail",
         )
         .await
-    {
-        tracing::warn!(error=?e, "Failed to remove FusionAuth IdP link");
-    }
+        .inspect_err(|e| {
+            tracing::warn!(error=?e, "Failed to remove FusionAuth IdP link");
+        })
+        .ok();
 
     // inform search of deletion so it can wipe the email records from OS
     ctx.sqs_client

--- a/rust/cloud-storage/email_service/src/pubsub/link_manager/process.rs
+++ b/rust/cloud-storage/email_service/src/pubsub/link_manager/process.rs
@@ -322,17 +322,20 @@ async fn handle_delete(
         tracing::debug!("Skipping Gmail stop_watch - no access token available");
     }
 
-    // remove google fusionauth link with gmail inbox permissions. must succeed before we delete
-    // the email_links row below, otherwise a failure leaves a stale FA IdP link with no macrodb
-    // counterpart (and the message is retried instead).
-    ctx.auth_service_client
+    // remove google fusionauth link with gmail inbox permissions. best-effort: the FA user may
+    // already be gone (e.g. account deleted before we delete their email), so we warn and keep
+    // going rather than failing the message and retrying.
+    if let Err(e) = ctx
+        .auth_service_client
         .remove_link(
             &link.fusionauth_user_id,
             link.email_address.0.as_ref(),
             "google_gmail",
         )
         .await
-        .context("Failed to remove FusionAuth IdP link")?;
+    {
+        tracing::warn!(error=?e, "Failed to remove FusionAuth IdP link");
+    }
 
     // inform search of deletion so it can wipe the email records from OS
     ctx.sqs_client


### PR DESCRIPTION
## Summary

In the email link teardown path (`link_manager/process.rs`), removing the Google/Gmail FusionAuth IdP link was a hard requirement — a failure propagated via `?`, failing the message and causing it to be retried.

But the FusionAuth user may legitimately already be gone (e.g. the account was deleted before we get around to deleting their email link). In that case `remove_link` errors permanently, and the message retries forever while the `email_links` row never gets cleaned up.

## Change

Make the FA IdP unlink best-effort: on error, log a `warn!` and continue with the rest of the teardown rather than bailing out. This matches the surrounding best-effort steps (Gmail `stop_watch`, search-queue notification, CRM teardown), all of which already warn-and-continue.