### PR TITLE
fix(search): cancel in-flight requests when query changes

### DIFF
--- a/js/app/packages/queries/soup/search.ts
+++ b/js/app/packages/queries/soup/search.ts
@@ -64,10 +64,13 @@ export const useSearchSoupQuery = (
     queryFn: async (ctx) => {
       return throwOnErr(
         async () =>
-          await searchClient.search({
-            params: ctx.pageParam,
-            request: { ...request() },
-          })
+          await searchClient.search(
+            {
+              params: ctx.pageParam,
+              request: { ...request() },
+            },
+            { signal: ctx.signal }
+          )
       );
     },
     initialPageParam: {
@@ -141,10 +144,13 @@ export const useSearchChannelQuery = (
     queryFn: async (ctx) => {
       return throwOnErr(
         async () =>
-          await searchClient.searchChannel({
-            params: ctx.pageParam,
-            request: { ...request() },
-          })
+          await searchClient.searchChannel(
+            {
+              params: ctx.pageParam,
+              request: { ...request() },
+            },
+            { signal: ctx.signal }
+          )
       );
     },
     initialPageParam: {


### PR DESCRIPTION
Wire TanStack's `ctx.signal` into `searchClient.search` and `searchClient.searchChannel` so a pending search request is aborted when the query term changes. This restores the request cancellation that was dropped when search moved to `useSearchSoupQuery` in the soup rewrite (#1248).
