### PR TITLE
fix(split-layout): nav button sync and drop sidebar history matching

### DIFF
--- a/js/app/packages/app/component/app-sidebar/sidebar.tsx
+++ b/js/app/packages/app/component/app-sidebar/sidebar.tsx
@@ -303,11 +303,6 @@ type SidebarHotkeyDeps = {
 
 type OpenWithSplitFn = ReturnType<typeof useSplitLayout>['openWithSplit'];
 
-const isComponentEntry =
-  (id: string) =>
-  (entry: SplitContent): boolean =>
-    entry.type === 'component' && entry.id === id;
-
 const isMarkdownDocumentsParams = (
   params: SidebarItem['params'] | undefined
 ): boolean => {
@@ -319,12 +314,9 @@ const isMarkdownDocumentsParams = (
 };
 
 /**
- * Navigate to a sidebar view, preserving prior state when possible.
- *
- * If the active split's history already contains an entry for this view, jump
- * back to it so search text, filters, preview state, etc. are restored from
- * that entry. Otherwise push a fresh entry. Holding shift bypasses the lookup
- * and forces a new entry / new split.
+ * Navigate to a sidebar view by pushing a fresh entry into the active split.
+ * Holding shift opens it in a new split. Use in-app back/forward to return to
+ * prior entries.
  */
 function navigateToSidebarView(args: {
   viewId: SidebarItem['id'];
@@ -351,14 +343,6 @@ function navigateToSidebarView(args: {
       controller.toggleMarkdownFilter();
       return activeSplit;
     }
-  }
-
-  if (
-    !params &&
-    !shiftKey &&
-    activeSplit?.goToEntry(isComponentEntry(viewId))
-  ) {
-    return activeSplit;
   }
 
   return openWithSplit(

--- a/js/app/packages/app/component/split-layout/components/PopoverSplitRenderer.tsx
+++ b/js/app/packages/app/component/split-layout/components/PopoverSplitRenderer.tsx
@@ -70,7 +70,6 @@ function PopoverSplitModal(props: {
     isPopover: () => true,
     replace: () => {},
     removeFromHistory: () => {},
-    goToEntry: () => false,
     registerContentChangeListener: () => {},
     unregisterContentChangeListener: () => {},
     previousContent: () => null,

--- a/js/app/packages/app/component/split-layout/history.ts
+++ b/js/app/packages/app/component/split-layout/history.ts
@@ -15,13 +15,6 @@ export type History<T extends object> = {
    * (e.g. captured per-entry state) before navigating away.
    */
   replaceCurrent: (next: T) => void;
-  /**
-   * Jump the current index to `n` (clamped to the valid range). Returns the
-   * item at that position, or null if the history is empty. Use this to
-   * navigate to a known prior entry in one step rather than walking via
-   * `back()`/`forward()`.
-   */
-  goToIndex: (n: number) => T | null;
   remove: (predicate: (item: T) => boolean) => T | null;
 };
 
@@ -83,13 +76,6 @@ export function createHistory<T extends object>(): History<T> {
     return items[index()];
   };
 
-  const goToIndex = (n: number) => {
-    if (items.length === 0) return null;
-    const clamped = Math.max(0, Math.min(items.length - 1, n));
-    setIndex(clamped);
-    return items[clamped];
-  };
-
   const remove = (predicate: (item: T) => boolean) => {
     const prevItems = items;
     const prevIndex = index();
@@ -133,7 +119,6 @@ export function createHistory<T extends object>(): History<T> {
     push,
     merge,
     replaceCurrent,
-    goToIndex,
     forward,
     canGoBack,
     canGoForward,

--- a/js/app/packages/app/component/split-layout/layoutManager.ts
+++ b/js/app/packages/app/component/split-layout/layoutManager.ts
@@ -925,8 +925,14 @@ export function createSplitLayout(
       id: currentSplit.id,
       content,
       activate: () => activateSplit(currentSplit.id),
-      canGoBack: () => currentSplit.history.canGoBack(),
-      canGoForward: () => currentSplit.history.canGoForward(),
+      // Re-resolve the split by id rather than reading the captured
+      // `currentSplit`. reconcileSplits can replace the SplitState (fresh
+      // history, same id) while this handle instance persists, so the captured
+      // reference goes stale and the button would report the old history.
+      canGoBack: () =>
+        (findSplitById(currentSplit.id) ?? currentSplit).history.canGoBack(),
+      canGoForward: () =>
+        (findSplitById(currentSplit.id) ?? currentSplit).history.canGoForward(),
       goBack: () => back(currentSplit.id),
       reset: () => reset(currentSplit.id),
       goForward: () => forward(currentSplit.id),

--- a/js/app/packages/app/component/split-layout/layoutManager.ts
+++ b/js/app/packages/app/component/split-layout/layoutManager.ts
@@ -372,16 +372,6 @@ export type SplitHandle<TMeta extends ComponentMeta = ComponentMeta> = {
     referredFrom?: ReferredFrom;
   }) => void;
   removeFromHistory: (predicate: (content: SplitContent) => boolean) => void;
-  /**
-   * Jump to the most-recent prior history entry matching `predicate` (or
-   * forward to the closest match if none earlier). Captures current entry
-   * state first, like back/forward. Returns true if a match was found and
-   * navigated to; false if no match (history left unchanged).
-   *
-   * Use for "open this view if it's already in my history, otherwise fall
-   * back to a fresh push" patterns (e.g. sidebar nav).
-   */
-  goToEntry: (predicate: (content: SplitContent) => boolean) => boolean;
   toggleSpotlight: (force?: boolean) => void;
   setDisplayName: (name: string) => void;
   canGoForward: () => boolean;
@@ -769,48 +759,6 @@ export function createSplitLayout(
     reattach(split, next, undefined, 'replace');
   }
 
-  function goToEntry(
-    id: SplitId,
-    predicate: (content: SplitContent) => boolean
-  ): boolean {
-    const i = splitIndexById(id);
-    if (i < 0) {
-      console.error(`Split with id ${id} not found`);
-      return false;
-    }
-    const split = state.splits[i];
-    const items = split.history.items;
-    const currentIdx = split.history.index;
-    if (items.length === 0) return false;
-
-    // Prefer the closest match looking backwards (more common case — the
-    // user just came from there). Fall back to looking forward.
-    let targetIdx = -1;
-    for (let j = currentIdx - 1; j >= 0; j--) {
-      if (predicate(items[j])) {
-        targetIdx = j;
-        break;
-      }
-    }
-    if (targetIdx === -1) {
-      for (let j = currentIdx + 1; j < items.length; j++) {
-        if (predicate(items[j])) {
-          targetIdx = j;
-          break;
-        }
-      }
-    }
-    if (targetIdx === -1 || targetIdx === currentIdx) return false;
-
-    captureCurrentEntryState(split);
-    const target = split.history.goToIndex(targetIdx);
-    if (!target) return false;
-    const cause: NavigationCause =
-      targetIdx < currentIdx ? 'history-back' : 'history-forward';
-    reattach(split, target, undefined, cause);
-    return true;
-  }
-
   /**
    * Replace the content of a split with the provided content. If mergeHistory is true, the current history index will be replaced with the new content.
    */
@@ -941,8 +889,6 @@ export function createSplitLayout(
       removeFromHistory: (predicate: (content: SplitContent) => boolean) => {
         removeFromHistory(currentSplit.id, predicate);
       },
-      goToEntry: (predicate: (content: SplitContent) => boolean) =>
-        goToEntry(currentSplit.id, predicate),
       previousContent: () => {
         const s = findSplitById(currentSplit.id);
         if (!s) return null;


### PR DESCRIPTION
Two split-layout navigation fixes. The in-app back/forward buttons no longer go stale after a URL-driven layout rebuild — `canGoBack`/`canGoForward` re-resolve the current split instead of reading a handle captured at creation. And the sidebar no longer jumps to a prior matching history entry (which scrambled per-split back/forward); it always pushes a fresh entry. Persisting search/filter state across browser back/forward is deferred.
