### PR TITLE
fix(soup): restore search text from the history entry directly on mount

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/soup-view-search-bar.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/soup-view-search-bar.tsx
@@ -49,7 +49,7 @@ export const SoupSearchbar = (props: SoupSearchbarProps) => {
 
   // Open the editor with the text persisted on this history entry. Read the
   // entry blob directly rather than the provider's searchText() signal: the soup
-  // provider persists across content swaps (#3935), so on re-entry the signal can
+  // provider persists across content swaps, so on re-entry the signal can
   // lag the per-entry restore, and the editor reads its initial value only once
   // (it would open empty and never recover). Fall back to the signal, then the
   // explicit initialValue prop.

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/soup-view-search-bar.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/soup-view-search-bar.tsx
@@ -47,10 +47,17 @@ export const SoupSearchbar = (props: SoupSearchbarProps) => {
   const soup = useSoup();
   const panel = useSplitPanelOrThrow();
 
-  // Read the current search-text signal once at mount so the editor opens
-  // with whatever was captured into per-entry state by the last visit.
-  // Falls back to the explicit `initialValue` prop when entry state is empty.
-  const initialEditorValue = searchText() || props.initialValue;
+  // Open the editor with the text persisted on this history entry. Read the
+  // entry blob directly rather than the provider's searchText() signal: the soup
+  // provider persists across content swaps (#3935), so on re-entry the signal can
+  // lag the per-entry restore, and the editor reads its initial value only once
+  // (it would open empty and never recover). Fall back to the signal, then the
+  // explicit initialValue prop.
+  const persistedSearchText = panel.handle.currentEntryState()?.['search.text'];
+  const initialEditorValue =
+    (typeof persistedSearchText === 'string' && persistedSearchText) ||
+    searchText() ||
+    props.initialValue;
 
   const [hasContent, setHasContent] = createSignal(false);
   const [latestMarkdown, setLatestMarkdown] = createSignal('');

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/soup-view-search-bar.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/soup-view-search-bar.tsx
@@ -55,9 +55,9 @@ export const SoupSearchbar = (props: SoupSearchbarProps) => {
   // explicit initialValue prop.
   const persistedSearchText = panel.handle.currentEntryState()?.['search.text'];
   const initialEditorValue =
-    (typeof persistedSearchText === 'string' && persistedSearchText) ||
-    searchText() ||
-    props.initialValue;
+    typeof persistedSearchText === 'string'
+      ? persistedSearchText
+      : searchText() || props.initialValue;
 
   const [hasContent, setHasContent] = createSignal(false);
   const [latestMarkdown, setLatestMarkdown] = createSignal('');


### PR DESCRIPTION
The search editor reads its initial text once at mount from the provider's `searchText()` signal, but the soup provider persists across content swaps (#3935), so on re-entry that signal can lag the per-entry restore and the editor opens empty with no recovery. Read the persisted search text off the history entry directly so the editor opens with it regardless of restore ordering.
