### PR TITLE
fix: toasts appearing under settings

### DIFF
--- a/js/app/packages/app/index.css
+++ b/js/app/packages/app/index.css
@@ -200,6 +200,8 @@
      from inside a modal render on top of it, below tooltips. */
   --z-index-action-menu:   150;
   --z-index-tool-tip:      200;
+  /* Toasts sit above everything (incl. full-screen modals) so they stay visible. */
+  --z-index-toast-region:  250;
 
   /* Soft drop shadow for floating menus/popovers (use the `shadow-menu` utility). */
   --shadow-menu: 0 8px 24px -16px rgb(0 0 0 / 0.24), 0 2px 8px -6px rgb(0 0 0 / 0.18);


### PR DESCRIPTION
## Summary

Toasts rendered *behind* the new full-screen Settings panel, making them invisible to the user. This makes them render on top.

## Root cause

The app generates Tailwind `z-*` utilities from two sources:

1. The legacy `tailwind-plugins/zIndex.ts` plugin, which derives utilities from the relative scale in `stackingContext.ts` (low values, e.g. `z-toast-region` = 29).
2. The `@theme { --z-index-*: … }` block in `packages/app/index.css`, which the modal layer was migrated onto (`z-modal` = 110, `z-modal-content` = 120, `z-action-menu` = 150, `z-tool-tip` = 200).

When both systems define the same class, the `@theme` value wins. The modal layer moved to the `@theme` scale, but `toast-region` was never given a `@theme` entry — so `z-toast-region` fell through to the plugin's value of **29**, well below the modal's **110**.

With a normal centered modal the bottom-right toasts still peeked out beside it, so this went unnoticed. The full-screen Settings `Dialog` (`fullscreen` → `inset-0` at `z-modal`) covers the entire viewport, hiding the toasts completely.

## Fix

Add `--z-index-toast-region: 250` to the `@theme` scale, above the tooltip layer. `z-toast-region` now resolves to 250 and the toast region (a fixed, body-portaled sibling of the dialog) renders above the full-screen Settings panel — and above any other modal/menu/tooltip, which is the conventional always-visible behavior for toasts.
