### PR TITLE
fix(email): init email link for new users who skip the login route

### DIFF
--- a/js/app/packages/app/component/Root.tsx
+++ b/js/app/packages/app/component/Root.tsx
@@ -22,6 +22,7 @@ import {
   useUserId,
   useUserInfo,
 } from '@core/context/user';
+import { initAndStartEmailSync } from '@core/email-link';
 import { IosPushNotificationModal } from '@core/mobile/IosPushNotificationModal';
 import { isNativeMobilePlatform } from '@core/mobile/isNativeMobilePlatform';
 import { createBlockOrchestrator } from '@core/orchestrator';
@@ -487,6 +488,28 @@ function InitialInteractiveOnboardingModal() {
     if (modalOpen()) {
       setOnboardingStarted(true);
     }
+  });
+
+  // First-time users (tutorial not yet completed) reach the app without passing
+  // through a login route that inits the email link — e.g. marketing SSO returns to
+  // /app, not /login — so kick off email sync once here. Idempotent on the backend;
+  // AlreadyInitialized is ignored. Keyed by user id (not a bare flag) so a native
+  // mobile logout→login of a different user in the same session still inits.
+  let emailInitForUserId: string | undefined;
+  createEffect(() => {
+    const data = userInfoQuery.data;
+    if (data?.authenticated !== true || data.tutorialComplete !== false) return;
+    if (emailInitForUserId === data.id) return;
+    emailInitForUserId = data.id;
+
+    void initAndStartEmailSync().match(
+      () => {},
+      (err) => {
+        if (err.tag !== 'AlreadyInitialized') {
+          console.error('Failed to init email link for new user', err);
+        }
+      }
+    );
   });
 
   const handleOpenChange = (nextOpen: boolean) => {


### PR DESCRIPTION
## Problem

New signups can reach the app already authenticated without passing through a login route that inits the email link, so `POST /email/init` is never called and their inbox is never provisioned.

`initEmailLink()` (which fires `POST /email/init`) isn't a side effect of authentication — it's hand-wired into specific login UIs: the `/login` `?token=` SSO-return effect, the email-code `onComplete`, the iOS native branch, and the signup/add-inbox callbacks. A signup that arrives already authenticated on `/app` (e.g. marketing SSO setting `original_url` to the app root rather than `/login`) redirects straight to `/component/inbox` and shows the onboarding tutorial, without passing through any of those routes — so init never runs.

## Fix

Trigger the email-link init once for first-time users from `InitialInteractiveOnboardingModal`, which already gates on the first-time-user condition (`authenticated && tutorialComplete === false`) to decide whether to show the onboarding tutorial.

- Scoped to first-time users via `tutorialComplete === false` — the same population that sees the onboarding popup — so it never fires for established users, including those who deliberately have no inbox connected.
- Uses the existing, previously-unused `initAndStartEmailSync()`.
- Fires once via a closure guard; the post-init `invalidateUserInfo()` re-runs the effect but it bails immediately, so there's no loop.
- Swallows `AlreadyInitialized` as a guard against racing a login-route init.
