### PR TITLE
fix(chat): stream tool calls before their response lands (macro-2094)

### DIFF
--- a/rust/cloud-storage/agent/src/hook.rs
+++ b/rust/cloud-storage/agent/src/hook.rs
@@ -77,6 +77,15 @@ impl StreamBridge {
             rx,
         )
     }
+
+    /// Clone the sending half of the bridge's channel.
+    ///
+    /// Lets the stream driver push parts derived from rig stream items
+    /// (buffered thinking, usage, errors) into the same ordered channel the
+    /// lifecycle hooks send through, so all parts share one FIFO order.
+    pub(crate) fn sender(&self) -> mpsc::UnboundedSender<Result<StreamPart, AgentError>> {
+        self.tx.clone()
+    }
 }
 
 impl<M> PromptHook<M> for StreamBridge

--- a/rust/cloud-storage/agent/src/model/router.rs
+++ b/rust/cloud-storage/agent/src/model/router.rs
@@ -418,6 +418,10 @@ where
         register_loaded,
         request_context.cancel.clone(),
     );
+    // Driver-side sender for parts derived from rig stream items (thinking,
+    // usage, errors). The lifecycle hooks (text, tool call, tool response) send
+    // through their own clone inside `bridge`; both feed the same FIFO channel.
+    let driver_tx = bridge.sender();
 
     let mut rig_stream = agent
         .stream_prompt(prompt)
@@ -426,13 +430,19 @@ where
         .with_hook(bridge)
         .await;
 
-    let stream = async_stream::stream! {
+    // Drive the rig stream on its own task. The hook emits a tool call the
+    // moment the model finishes it — *before* the (often slow) tool executes —
+    // but rig runs that execution inside a single `rig_stream.next()` poll, so
+    // draining the channel only between polls would hold the pending tool call
+    // hidden until its response landed. Polling the rig stream here, off the
+    // consumer's path, lets every hook-emitted part flow through `rx` and out
+    // to the client as soon as it is produced — so a tool call renders in its
+    // pending state immediately and its response renders when execution
+    // finishes.
+    let driver = tokio::spawn(async move {
         let mut thinking_buf = String::new();
 
         while let Some(item) = rig_stream.next().await {
-            while let Ok(part) = rx.try_recv() {
-                yield part;
-            }
             match item {
                 Ok(MultiTurnStreamItem::StreamAssistantItem(
                     StreamedAssistantContent::ReasoningDelta { reasoning, .. },
@@ -441,7 +451,8 @@ where
                 }
                 other => {
                     if !thinking_buf.is_empty() {
-                        yield Ok(StreamPart::Thinking(std::mem::take(&mut thinking_buf)));
+                        let _ = driver_tx
+                            .send(Ok(StreamPart::Thinking(std::mem::take(&mut thinking_buf))));
                     }
                     match other {
                         Ok(MultiTurnStreamItem::FinalResponse(final_resp)) => {
@@ -452,13 +463,13 @@ where
                                 usage.input_tokens,
                                 usage.output_tokens,
                             ));
-                            yield Ok(StreamPart::Usage(crate::stream::Usage {
+                            let _ = driver_tx.send(Ok(StreamPart::Usage(crate::stream::Usage {
                                 input_tokens: usage.input_tokens,
                                 output_tokens: usage.output_tokens,
-                            }));
+                            })));
                         }
                         Err(e) => {
-                            yield Err(AgentError::Streaming(e));
+                            let _ = driver_tx.send(Err(AgentError::Streaming(e)));
                         }
                         _ => {}
                     }
@@ -466,9 +477,26 @@ where
             }
         }
         if !thinking_buf.is_empty() {
-            yield Ok(StreamPart::Thinking(std::mem::take(&mut thinking_buf)));
+            let _ = driver_tx.send(Ok(StreamPart::Thinking(std::mem::take(&mut thinking_buf))));
         }
-        while let Ok(part) = rx.try_recv() {
+        // Dropping `rig_stream` (and with it the hook's sender) plus `driver_tx`
+        // here closes the channel, ending the consumer stream below.
+    });
+
+    // Abort the driver when the consumer drops the returned stream (e.g. on
+    // cancellation), which drops `rig_stream` and cancels any in-flight tool —
+    // matching the prior behaviour where the rig stream lived inline.
+    struct AbortOnDrop(tokio::task::JoinHandle<()>);
+    impl Drop for AbortOnDrop {
+        fn drop(&mut self) {
+            self.0.abort();
+        }
+    }
+    let guard = AbortOnDrop(driver);
+
+    let stream = async_stream::stream! {
+        let _guard = guard;
+        while let Some(part) = rx.recv().await {
             yield part;
         }
     };


### PR DESCRIPTION
Drives the agent's rig stream on its own task so a tool call is streamed to the client the moment the model emits it—before the (often slow) tool executes—instead of staying hidden until rig's next stream yield delivers it alongside the response, so tool calls now render in their pending state immediately and update with the response when execution finishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)