### PR TITLE
fix(multi-inbox): collapse inbox selector to icon when split is narrow

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/inbox-selector.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/inbox-selector.tsx
@@ -3,6 +3,7 @@ import {
   useAddInboxGate,
 } from '@app/component/AddInboxDialog';
 import { useSoupView } from '@app/component/next-soup/soup-view/soup-view-context';
+import { CollapsibleHeaderItem } from '@app/component/split-layout/components/CollapsibleHeaderItem';
 import { useFeatureFlag } from '@app/lib/analytics/posthog';
 import { ENABLE_MULTI_INBOX_OVERRIDE } from '@core/constant/featureFlags';
 import { useSettingsState } from '@core/constant/SettingsState';
@@ -10,7 +11,7 @@ import { Combobox } from '@kobalte/core/combobox';
 import CaretDownIcon from '@phosphor/caret-down.svg';
 import PlusIcon from '@phosphor/plus.svg';
 import TrayIcon from '@phosphor/tray.svg';
-import { Button } from '@ui';
+import { Button, cn } from '@ui';
 import { Show } from 'solid-js';
 import { useInboxPicker } from './inbox-picker';
 import { SearchableMultiSelect } from './searchable-multi-select';
@@ -43,41 +44,57 @@ export function InboxSelector() {
     return `${ids.length} inboxes`;
   };
 
+  const Selector = (selectorProps: { hideLabel?: boolean }) => (
+    <SearchableMultiSelect
+      options={picker.options}
+      activeIds={picker.activeIds}
+      onChange={(ids) => (ids.length ? picker.onChange(ids) : picker.reset())}
+      onOnly={picker.selectOnly}
+      placeholder="Search inboxes..."
+      preserveOrder
+      action={
+        multiInboxFlag().enabled
+          ? {
+              label: 'Add inbox',
+              icon: () => <PlusIcon class="size-4" />,
+              onSelect: () =>
+                guardAddInbox(() => {
+                  openSettings('Connected');
+                  openAddInboxDialog();
+                }),
+            }
+          : undefined
+      }
+    >
+      <Combobox.Trigger
+        as={Button}
+        variant="base"
+        size="sm"
+        depth={2}
+        aria-label={selectorProps.hideLabel ? label() : undefined}
+        class={cn(
+          'bg-surface gap-1',
+          selectorProps.hideLabel ? 'px-1' : 'max-w-50'
+        )}
+      >
+        <TrayIcon />
+        <Show when={!selectorProps.hideLabel}>
+          <span class="truncate">{label()}</span>
+        </Show>
+        <CaretDownIcon class="size-3 shrink-0" />
+      </Combobox.Trigger>
+    </SearchableMultiSelect>
+  );
+
   return (
     <Show when={multiInboxFlag().enabled || picker.hasMultiple()}>
-      <SearchableMultiSelect
-        options={picker.options}
-        activeIds={picker.activeIds}
-        onChange={(ids) => (ids.length ? picker.onChange(ids) : picker.reset())}
-        onOnly={picker.selectOnly}
-        placeholder="Search inboxes..."
-        preserveOrder
-        action={
-          multiInboxFlag().enabled
-            ? {
-                label: 'Add inbox',
-                icon: () => <PlusIcon class="size-4" />,
-                onSelect: () =>
-                  guardAddInbox(() => {
-                    openSettings('Connected');
-                    openAddInboxDialog();
-                  }),
-              }
-            : undefined
-        }
-      >
-        <Combobox.Trigger
-          as={Button}
-          variant="base"
-          size="sm"
-          depth={2}
-          class="bg-surface gap-1 max-w-50"
-        >
-          <TrayIcon />
-          <span class="truncate">{label()}</span>
-          <CaretDownIcon class="size-3 shrink-0" />
-        </Combobox.Trigger>
-      </SearchableMultiSelect>
+      <CollapsibleHeaderItem
+        id="inbox-selector"
+        priority={3}
+        containerClass="h-full"
+        expanded={() => <Selector />}
+        collapsed={() => <Selector hideLabel />}
+      />
     </Show>
   );
 }


### PR DESCRIPTION
In a narrow split the inbox selector pill kept its width while the compose button shrank, so the orange button overlapped the "All inboxes" pill. Register the inbox selector as a `CollapsibleHeaderItem` (like the tabs/search/compose neighbors) so it collapses to an icon-only trigger when the header runs out of room, keeping its `aria-label` and dropdown intact.
