### PR TITLE
feat: add delete confirmation dialog for channel messages

### DIFF
--- a/js/app/packages/app/component/bulk-edit-entity/BulkDeleteView.tsx
+++ b/js/app/packages/app/component/bulk-edit-entity/BulkDeleteView.tsx
@@ -3,7 +3,7 @@ import { Dialog } from '@kobalte/core/dialog';
 import { createBulkDeleteDssItemsMutation } from '@macro-entity';
 import CloseIcon from '@phosphor-icons/core/regular/x.svg?component-solid';
 import { Button, cn } from '@ui';
-import { For, Show } from 'solid-js';
+import { For, onMount, Show } from 'solid-js';
 
 export const BulkDeleteView = (props: {
   entities: EntityData[];
@@ -11,6 +11,15 @@ export const BulkDeleteView = (props: {
   onCancel: () => void;
 }) => {
   const bulkDelete = createBulkDeleteDssItemsMutation();
+  let deleteButton: HTMLButtonElement | undefined;
+
+  const focusDeleteButton = () => {
+    requestAnimationFrame(() =>
+      requestAnimationFrame(() => deleteButton?.focus())
+    );
+  };
+
+  onMount(focusDeleteButton);
 
   const handleDelete = async () => {
     try {
@@ -76,9 +85,8 @@ export const BulkDeleteView = (props: {
           </Button>
           <Button
             ref={(el: HTMLButtonElement) => {
-              requestAnimationFrame(() =>
-                requestAnimationFrame(() => el.focus())
-              );
+              deleteButton = el;
+              focusDeleteButton();
             }}
             type="button"
             variant="danger"

--- a/js/app/packages/channel/Channel/Channel.tsx
+++ b/js/app/packages/channel/Channel/Channel.tsx
@@ -75,6 +75,7 @@ import { createChannelDragState } from './create-channel-drag-state';
 import { createChannelFindBar } from './create-channel-find-bar';
 import { createChannelHotkeys } from './create-channel-hotkeys';
 import { createChannelMessageActions } from './create-channel-message-actions';
+import { createDeleteMessageConfirmation } from './create-delete-message-confirmation';
 import { createInlineInputKeyboardHandler } from './create-inline-input-keyboard-handler';
 import { createMainInputKeyboardHandler } from './create-main-input-keyboard-handler';
 import { createMessageEditor } from './create-message-editor';
@@ -324,10 +325,14 @@ export function Channel(props: ChannelProps) {
     });
   };
 
+  const deleteConfirmation = createDeleteMessageConfirmation(
+    deleteMessageMutation.mutate
+  );
+
   const getMessageActions = createChannelMessageActions({
     channelId: () => props.channelId,
     userId,
-    deleteMessage: deleteMessageMutation.mutate,
+    deleteMessage: deleteConfirmation.requestDelete,
     addReaction: addReactionMutation.mutate,
     removeReaction: removeReactionMutation.mutate,
     onReply: (ctx) => {
@@ -492,6 +497,7 @@ export function Channel(props: ChannelProps) {
 
   return (
     <DebugSuspense name="Channel.root">
+      <deleteConfirmation.ConfirmationDialog />
       <StaticMarkdownContext>
         <SearchHighlightTermsProvider value={findBar.getSearchTermsForMessage}>
           <MaybeMessageActionDrawerManager>

--- a/js/app/packages/channel/Channel/create-channel-message-actions.ts
+++ b/js/app/packages/channel/Channel/create-channel-message-actions.ts
@@ -34,7 +34,7 @@ type RemoveReactionInput = {
   currentReactions: MessageData['reactions'];
 };
 
-type DeleteMessageInput = {
+export type DeleteMessageInput = {
   channelID: string;
   messageID: string;
   threadID?: string;

--- a/js/app/packages/channel/Channel/create-delete-message-confirmation.tsx
+++ b/js/app/packages/channel/Channel/create-delete-message-confirmation.tsx
@@ -1,4 +1,5 @@
-import { Button, Dialog, Panel } from '@ui';
+import CloseIcon from '@phosphor-icons/core/regular/x.svg?component-solid';
+import { Button, Dialog, Surface } from '@ui';
 import { createSignal, type JSX } from 'solid-js';
 import type { DeleteMessageInput } from './create-channel-message-actions';
 
@@ -37,38 +38,43 @@ export function createDeleteMessageConfirmation(
         if (!open) close();
       }}
       position="center"
-      class="w-120"
+      class="w-[90%] max-w-120"
     >
-      <Panel depth={2} class="rounded-xl">
-        <Panel.Header class="px-6">
-          <Dialog.Title class="text-ink text-sm font-semibold">
+      <Surface depth={2} class="rounded-xl">
+        <div class="shrink-0 flex flex-row items-center px-2 gap-1 border-b border-b-edge-muted h-10">
+          <Dialog.CloseButton as={Button} variant="ghost" size="icon-sm">
+            <CloseIcon />
+          </Dialog.CloseButton>
+          <Dialog.Title as="span" class="text-sm font-medium p-0 m-0">
             Delete message
           </Dialog.Title>
-        </Panel.Header>
-        <Panel.Body class="p-6 font-sans flex flex-col gap-3">
-          <Dialog.Description class="text-ink-muted text-sm/tight font-normal">
+        </div>
+
+        <div class="p-3 flex flex-col gap-3">
+          <Dialog.Description class="text-sm text-ink-muted">
             This message will be permanently deleted. This action cannot be
             undone.
           </Dialog.Description>
-          <div class="pt-3 justify-end items-center gap-3 inline-flex">
-            <Button variant="base" depth={3} onClick={close}>
+
+          <div class="flex justify-end gap-2">
+            <Button variant="ghost" onClick={close}>
               Cancel
             </Button>
             <Button
-              variant="danger"
-              depth={3}
               ref={(el: HTMLButtonElement) => {
                 requestAnimationFrame(() =>
                   requestAnimationFrame(() => el.focus())
                 );
               }}
+              type="button"
+              variant="danger"
               onClick={confirm}
             >
               Delete
             </Button>
           </div>
-        </Panel.Body>
-      </Panel>
+        </div>
+      </Surface>
     </Dialog>
   );
 

--- a/js/app/packages/channel/Channel/create-delete-message-confirmation.tsx
+++ b/js/app/packages/channel/Channel/create-delete-message-confirmation.tsx
@@ -1,0 +1,76 @@
+import { Button, Dialog, Panel } from '@ui';
+import { createSignal, type JSX } from 'solid-js';
+import type { DeleteMessageInput } from './create-channel-message-actions';
+
+export type DeleteMessageConfirmation = {
+  /** Opens the confirmation dialog for the given delete request. */
+  requestDelete: (input: DeleteMessageInput) => void;
+  /** Renders the confirmation dialog; mount once per channel surface. */
+  ConfirmationDialog: () => JSX.Element;
+};
+
+/**
+ * Wraps a `deleteMessage` mutation with a confirmation step. Deleting a
+ * channel message is destructive, so every entry point (action menu, mobile
+ * drawer, hotkeys) routes through `requestDelete`, which opens a dialog and
+ * only fires the underlying delete once the user confirms.
+ */
+export function createDeleteMessageConfirmation(
+  deleteMessage: (input: DeleteMessageInput) => void
+): DeleteMessageConfirmation {
+  const [pending, setPending] = createSignal<DeleteMessageInput | undefined>();
+
+  const requestDelete = (input: DeleteMessageInput) => setPending(input);
+
+  const close = () => setPending(undefined);
+
+  const confirm = () => {
+    const input = pending();
+    if (input) deleteMessage(input);
+    close();
+  };
+
+  const ConfirmationDialog = () => (
+    <Dialog
+      open={!!pending()}
+      onOpenChange={(open) => {
+        if (!open) close();
+      }}
+      position="center"
+      class="w-120"
+    >
+      <Panel depth={2} class="rounded-xl">
+        <Panel.Header class="px-6">
+          <Dialog.Title class="text-ink text-sm font-semibold">
+            Delete message
+          </Dialog.Title>
+        </Panel.Header>
+        <Panel.Body class="p-6 font-sans flex flex-col gap-3">
+          <Dialog.Description class="text-ink-muted text-sm/tight font-normal">
+            This message will be permanently deleted. This action cannot be
+            undone.
+          </Dialog.Description>
+          <div class="pt-3 justify-end items-center gap-3 inline-flex">
+            <Button variant="base" depth={3} onClick={close}>
+              Cancel
+            </Button>
+            <Button
+              variant="danger"
+              depth={3}
+              ref={(el: HTMLButtonElement) => {
+                requestAnimationFrame(() =>
+                  requestAnimationFrame(() => el.focus())
+                );
+              }}
+              onClick={confirm}
+            >
+              Delete
+            </Button>
+          </div>
+        </Panel.Body>
+      </Panel>
+    </Dialog>
+  );
+
+  return { requestDelete, ConfirmationDialog };
+}

--- a/js/app/packages/channel/Channel/tests/create-delete-message-confirmation.test.tsx
+++ b/js/app/packages/channel/Channel/tests/create-delete-message-confirmation.test.tsx
@@ -1,0 +1,48 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { render, screen } from '@solidjs/testing-library';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { createDeleteMessageConfirmation } from '../create-delete-message-confirmation';
+
+const deleteInput = {
+  channelID: 'channel-1',
+  messageID: 'message-1',
+  threadID: 'thread-1',
+};
+
+describe('createDeleteMessageConfirmation', () => {
+  it('does not delete until the dialog is confirmed', async () => {
+    const deleteMessage = vi.fn();
+    const { requestDelete, ConfirmationDialog } =
+      createDeleteMessageConfirmation(deleteMessage);
+
+    render(() => <ConfirmationDialog />);
+
+    requestDelete(deleteInput);
+    await screen.findByText('Delete message');
+    expect(deleteMessage).not.toHaveBeenCalled();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    expect(deleteMessage).toHaveBeenCalledTimes(1);
+    expect(deleteMessage).toHaveBeenCalledWith(deleteInput);
+  });
+
+  it('does not delete when the dialog is cancelled', async () => {
+    const deleteMessage = vi.fn();
+    const { requestDelete, ConfirmationDialog } =
+      createDeleteMessageConfirmation(deleteMessage);
+
+    render(() => <ConfirmationDialog />);
+
+    requestDelete(deleteInput);
+    await screen.findByText('Delete message');
+
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(deleteMessage).not.toHaveBeenCalled();
+  });
+});

--- a/js/app/packages/channel/Channel/tests/create-delete-message-confirmation.test.tsx
+++ b/js/app/packages/channel/Channel/tests/create-delete-message-confirmation.test.tsx
@@ -7,6 +7,10 @@ import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 import { createDeleteMessageConfirmation } from '../create-delete-message-confirmation';
 
+vi.mock('@phosphor-icons/core/regular/x.svg?component-solid', () => ({
+  default: () => <span data-testid="close-icon" />,
+}));
+
 const deleteInput = {
   channelID: 'channel-1',
   messageID: 'message-1',

--- a/js/app/packages/channel/StandaloneThread/EditableThread.tsx
+++ b/js/app/packages/channel/StandaloneThread/EditableThread.tsx
@@ -7,6 +7,7 @@ import {
 import type { ApiChannelMessage } from '@service-storage/generated/schemas/apiChannelMessage';
 import { createSignal, Show } from 'solid-js';
 import { createChannelMessageActions } from '../Channel/create-channel-message-actions';
+import { createDeleteMessageConfirmation } from '../Channel/create-delete-message-confirmation';
 import type { InputHandle, InputSnapshot } from '../Input';
 import { Thread } from '../Thread';
 import { buildQuoteReplyValue } from '../Thread/utils/message-actions';
@@ -31,11 +32,14 @@ function EditableThreadInner() {
   const deleteMessageMutation = useDeleteMessageMutation();
   const addReactionMutation = useAddReactionMutation();
   const removeReactionMutation = useRemoveReactionMutation();
+  const deleteConfirmation = createDeleteMessageConfirmation(
+    deleteMessageMutation.mutate
+  );
 
   const getMessageActions = createChannelMessageActions({
     channelId: ctx.channelId,
     userId,
-    deleteMessage: deleteMessageMutation.mutate,
+    deleteMessage: deleteConfirmation.requestDelete,
     addReaction: addReactionMutation.mutate,
     removeReaction: removeReactionMutation.mutate,
     onReply: ({ message }) => {
@@ -69,6 +73,7 @@ function EditableThreadInner() {
 
   return (
     <>
+      <deleteConfirmation.ConfirmationDialog />
       <StandaloneThread.ParentMessage actions={parentActions()} />
       <StandaloneThread.Replies
         getMessageActions={getMessageActions}


### PR DESCRIPTION
Deleting a channel message is destructive but previously happened with a single click. This adds a confirmation dialog before the delete is performed.