### PR TITLE
fix(email): don't drop signature when replying to a signed message

### DIFF
--- a/rust/cloud-storage/email/src/domain/service/signature.rs
+++ b/rust/cloud-storage/email/src/domain/service/signature.rs
@@ -9,18 +9,21 @@ mod test;
 /// Marker class wrapping an injected signature.
 const SIGNATURE_CLASS: &str = "macro-email-signature";
 
-/// Whether the body already carries an injected signature, so the caller can
-/// stay idempotent across a client that still bakes it in and across re-sends.
+/// Whether the body already carries our signature in its own content (idempotency
+/// for re-sends / an old client that still bakes it in). A signature inside a
+/// quoted thread (`.macro_quote`) is the replied-to message's and is ignored.
 pub(crate) fn has_signature(body_html: &str) -> bool {
-    Selector::parse(&format!(".{SIGNATURE_CLASS}"))
-        .ok()
-        .map(|sel| {
-            Html::parse_fragment(body_html)
-                .select(&sel)
-                .next()
-                .is_some()
+    let Ok(sig_sel) = Selector::parse(&format!(".{SIGNATURE_CLASS}")) else {
+        return false;
+    };
+    Html::parse_fragment(body_html).select(&sig_sel).any(|el| {
+        !el.ancestors().any(|node| {
+            node.value()
+                .as_element()
+                .and_then(|e| e.attr("class"))
+                .is_some_and(|class| class.split_whitespace().any(|c| c == "macro_quote"))
         })
-        .unwrap_or(false)
+    })
 }
 
 /// Injects the (already-sanitized) signature into the outgoing HTML body,

--- a/rust/cloud-storage/email/src/domain/service/signature/test.rs
+++ b/rust/cloud-storage/email/src/domain/service/signature/test.rs
@@ -38,6 +38,17 @@ fn is_idempotent_when_signature_already_present() {
 }
 
 #[test]
+fn ignores_signature_inside_quoted_thread() {
+    // Replying to a previously-signed message: the quote carries that message's
+    // signature, which must not count as "already signed" for this reply.
+    let reply = r#"<body><p>My reply</p><div class="macro_quote"><p>Old</p><div class="macro-email-signature">Ryan</div></div></body>"#;
+    assert!(!has_signature(reply));
+    // A signature in the reply's own content (above the quote) still counts.
+    let signed = r#"<body><div class="macro-email-signature">Me</div><div class="macro_quote"><p>Old</p></div></body>"#;
+    assert!(has_signature(signed));
+}
+
+#[test]
 fn plain_text_joins_block_nodes_with_newlines() {
     // Block boundaries become newlines (not run together as "ThanksAlice").
     assert_eq!(


### PR DESCRIPTION
## Problem

`has_signature` — the idempotency guard for server-side signature injection — matched `.macro-email-signature` *anywhere* in the email body, including inside the quoted/forwarded thread (`.macro_quote`).

When replying to a message that already carried a signature, the quoted copy of that signature made the new reply look "already signed", so `maybe_inject_signature` short-circuited and the reply went out **without** the sender's signature — even with "add to replies & forwards" enabled. Compose was unaffected (it has no quote).

## Fix

`has_signature` now ignores any `.macro-email-signature` nested under a `.macro_quote`; only a signature in the reply's *own* content gates idempotency. A signature baked in above the quote (an old client, or a re-send) is still detected, so the cutover/re-send protection is intact.

Added a regression test (`ignores_signature_inside_quoted_thread`).

## Follow-up (not in this PR)

`strip_signature` (used to honor `include_signature = false`) has the same quote-blindness — it removes *every* `.macro-email-signature`, so dismissing the signature on a reply to a signed message would also strip the quoted original's signature. Narrower trigger; can be addressed separately.
