### PR TITLE
feat(documents): raise document name limit to 200, surface name-too-long toast

### DIFF
--- a/js/app/packages/core/util/upload.ts
+++ b/js/app/packages/core/util/upload.ts
@@ -282,6 +282,8 @@ class UnsupportedFileTypeError extends Error {
 }
 
 class UploadError extends Error {
+  public readonly originalError?: Error | string;
+
   constructor(
     file: { name: string },
     destination?: UploadDestination,
@@ -290,6 +292,8 @@ class UploadError extends Error {
     const fileName = getFileName(file);
     const message = `Upload failed: ${fileName}`;
     super(message);
+
+    this.originalError = originalError;
 
     console.error(
       `upload${destination ? ` to ${destination}` : ''} failed:`,
@@ -518,7 +522,19 @@ export async function uploadFiles(
 }
 
 function isNameTooLongError(error: Error): boolean {
-  return error.message.toLowerCase().includes('name too long');
+  const messages = [error.message];
+  // The backend message can be wrapped by UploadError (whose own message is the
+  // generic "Upload failed: <file>"), so also inspect the preserved original.
+  if (error instanceof UploadError && error.originalError != null) {
+    messages.push(
+      error.originalError instanceof Error
+        ? error.originalError.message
+        : error.originalError
+    );
+  }
+  return messages.some((message) =>
+    message.toLowerCase().includes('name too long')
+  );
 }
 
 function handleUploadError(error: Error): void {

--- a/js/app/packages/core/util/upload.ts
+++ b/js/app/packages/core/util/upload.ts
@@ -31,6 +31,7 @@ import {
   filenameWithoutExtension,
 } from '@service-storage/util/filename';
 import {
+  DocumentNameTooLongError,
   type UploadFileOptions as DssUploadFileOptions,
   type UploadSuccess as DssUploadSuccessResult,
   upload as dssUpload,
@@ -521,32 +522,28 @@ export async function uploadFiles(
   return uploadResults;
 }
 
-// Returns the backend's "name too long" message (which carries the authoritative
-// character limit so the copy never drifts from the API), or null if this isn't
-// that error. The message can be wrapped by UploadError, whose own message is the
-// generic "Upload failed: <file>", so the preserved original is inspected too.
-function nameTooLongMessage(error: Error): string | null {
-  const candidates = [error.message];
-  if (error instanceof UploadError && error.originalError != null) {
-    candidates.push(
-      error.originalError instanceof Error
-        ? error.originalError.message
-        : error.originalError
-    );
+function asNameTooLongError(error: Error): DocumentNameTooLongError | null {
+  if (error instanceof DocumentNameTooLongError) return error;
+  // The typed error can be wrapped by UploadError, which preserves the original.
+  if (
+    error instanceof UploadError &&
+    error.originalError instanceof DocumentNameTooLongError
+  ) {
+    return error.originalError;
   }
-  const match = candidates.find((message) =>
-    message.toLowerCase().includes('name too long')
-  );
-  if (match == null) return null;
-  const cleaned = match.replace(/^bad request:\s*/i, '').trim();
-  return cleaned.charAt(0).toUpperCase() + cleaned.slice(1);
+  return null;
 }
 
 function handleUploadError(error: Error): void {
   console.error('Upload error:', error);
-  const nameTooLong = nameTooLongMessage(error);
+  const nameTooLong = asNameTooLongError(error);
   if (nameTooLong != null) {
-    toast.failure(nameTooLong);
+    const { maxLength } = nameTooLong;
+    toast.failure(
+      maxLength != null
+        ? `Name too long (max ${maxLength} characters)`
+        : 'Name too long'
+    );
     return;
   }
   if (

--- a/js/app/packages/core/util/upload.ts
+++ b/js/app/packages/core/util/upload.ts
@@ -521,26 +521,32 @@ export async function uploadFiles(
   return uploadResults;
 }
 
-function isNameTooLongError(error: Error): boolean {
-  const messages = [error.message];
-  // The backend message can be wrapped by UploadError (whose own message is the
-  // generic "Upload failed: <file>"), so also inspect the preserved original.
+// Returns the backend's "name too long" message (which carries the authoritative
+// character limit so the copy never drifts from the API), or null if this isn't
+// that error. The message can be wrapped by UploadError, whose own message is the
+// generic "Upload failed: <file>", so the preserved original is inspected too.
+function nameTooLongMessage(error: Error): string | null {
+  const candidates = [error.message];
   if (error instanceof UploadError && error.originalError != null) {
-    messages.push(
+    candidates.push(
       error.originalError instanceof Error
         ? error.originalError.message
         : error.originalError
     );
   }
-  return messages.some((message) =>
+  const match = candidates.find((message) =>
     message.toLowerCase().includes('name too long')
   );
+  if (match == null) return null;
+  const cleaned = match.replace(/^bad request:\s*/i, '').trim();
+  return cleaned.charAt(0).toUpperCase() + cleaned.slice(1);
 }
 
 function handleUploadError(error: Error): void {
   console.error('Upload error:', error);
-  if (isNameTooLongError(error)) {
-    toast.failure('Name too long (max 200 characters)');
+  const nameTooLong = nameTooLongMessage(error);
+  if (nameTooLong != null) {
+    toast.failure(nameTooLong);
     return;
   }
   if (

--- a/js/app/packages/core/util/upload.ts
+++ b/js/app/packages/core/util/upload.ts
@@ -540,7 +540,7 @@ function isNameTooLongError(error: Error): boolean {
 function handleUploadError(error: Error): void {
   console.error('Upload error:', error);
   if (isNameTooLongError(error)) {
-    toast.failure('Name is too long. Please shorten it and try again.');
+    toast.failure('Name too long (max 200 characters)');
     return;
   }
   if (

--- a/js/app/packages/core/util/upload.ts
+++ b/js/app/packages/core/util/upload.ts
@@ -517,8 +517,16 @@ export async function uploadFiles(
   return uploadResults;
 }
 
+function isNameTooLongError(error: Error): boolean {
+  return error.message.toLowerCase().includes('name too long');
+}
+
 function handleUploadError(error: Error): void {
   console.error('Upload error:', error);
+  if (isNameTooLongError(error)) {
+    toast.failure('Name is too long. Please shorten it and try again.');
+    return;
+  }
   if (
     error instanceof UploadError ||
     error instanceof FileSizeExceededError ||

--- a/js/app/packages/service-clients/service-storage/client.ts
+++ b/js/app/packages/service-clients/service-storage/client.ts
@@ -352,6 +352,9 @@ const enhancements = {
 
 const { showPaywall } = usePaywallState();
 
+/** Machine-readable code the backend returns when a document name is too long. */
+export const DOCUMENT_NAME_TOO_LONG_CODE = 'DOCUMENT_NAME_TOO_LONG' as const;
+
 export const storageServiceClient = {
   async ping() {
     return (await dssFetch<SuccessResponse>(`/ping`)).map(
@@ -1008,42 +1011,49 @@ export const storageServiceClient = {
   },
 
   async createDocument(request: CreateDocumentRequest) {
-    const result = await fetchWithToken<CreateDocumentResponse>(
-      `${dssHost}/documents`,
-      {
-        method: 'POST',
-        body: JSON.stringify(request),
-        // A custom handler replaces safeFetch's default status mapping, so the 400
-        // body message (e.g. "name too long") reaches callers. 403 is preserved
-        // explicitly and other statuses keep the HTTP_ERROR shape callers branch on.
-        errorResponseHandler: async (response) => {
-          if (response.status === 400) {
-            const body = (await response.json().catch(() => null)) as {
-              message?: string;
-            } | null;
-            return {
-              code: 'HTTP_ERROR',
-              message: body?.message ?? 'Bad request',
-            };
-          }
-          if (response.status === 403) {
-            return { code: 'FORBIDDEN', message: 'Forbidden' };
-          }
+    const result = await fetchWithToken<
+      CreateDocumentResponse,
+      typeof DOCUMENT_NAME_TOO_LONG_CODE
+    >(`${dssHost}/documents`, {
+      method: 'POST',
+      body: JSON.stringify(request),
+      // A custom handler replaces safeFetch's default status mapping. For an
+      // over-length name the backend returns a machine-readable code plus the
+      // limit; forward both (limit carried as JSON in message, since ResultError
+      // is only { code, message }) so the UI can render its own copy without
+      // hardcoding the number. 403 is preserved explicitly; other statuses keep
+      // the HTTP_ERROR shape callers branch on.
+      errorResponseHandler: async (response) => {
+        const body = (await response.json().catch(() => null)) as {
+          code?: string;
+          maxLength?: number;
+        } | null;
+        if (body?.code === DOCUMENT_NAME_TOO_LONG_CODE) {
           return {
-            code: 'HTTP_ERROR',
-            message: `HTTP error! status: ${response.status}`,
+            code: DOCUMENT_NAME_TOO_LONG_CODE,
+            message: JSON.stringify({ maxLength: body.maxLength }),
           };
-        },
-      }
-    );
+        }
+        if (response.status === 403) {
+          return { code: 'FORBIDDEN', message: 'Forbidden' };
+        }
+        return {
+          code: 'HTTP_ERROR',
+          message: `HTTP error! status: ${response.status}`,
+        };
+      },
+    });
 
     if (!result.isOk()) {
-      const errors = result.error;
+      // The DOCUMENT_NAME_TOO_LONG code is carried at runtime for callers to
+      // branch on, but it is not part of the generated client's error union, so
+      // narrow back to it to satisfy StorageServiceClient.
+      const errors = result.error as ResultError<FetchWithTokenErrorCode>[];
 
       if (errors[0].message.includes('403')) {
         showPaywall(PaywallKey.FILE_LIMIT);
       }
-      return err(result.error);
+      return err(errors);
     }
 
     const { data } = result.value;

--- a/js/app/packages/service-clients/service-storage/client.ts
+++ b/js/app/packages/service-clients/service-storage/client.ts
@@ -1008,10 +1008,34 @@ export const storageServiceClient = {
   },
 
   async createDocument(request: CreateDocumentRequest) {
-    const result = await dssFetch<CreateDocumentResponse>(`/documents`, {
-      method: 'POST',
-      body: JSON.stringify(request),
-    });
+    const result = await fetchWithToken<CreateDocumentResponse>(
+      `${dssHost}/documents`,
+      {
+        method: 'POST',
+        body: JSON.stringify(request),
+        // A custom handler replaces safeFetch's default status mapping, so the 400
+        // body message (e.g. "name too long") reaches callers. 403 is preserved
+        // explicitly and other statuses keep the HTTP_ERROR shape callers branch on.
+        errorResponseHandler: async (response) => {
+          if (response.status === 400) {
+            const body = (await response.json().catch(() => null)) as {
+              message?: string;
+            } | null;
+            return {
+              code: 'HTTP_ERROR',
+              message: body?.message ?? 'Bad request',
+            };
+          }
+          if (response.status === 403) {
+            return { code: 'FORBIDDEN', message: 'Forbidden' };
+          }
+          return {
+            code: 'HTTP_ERROR',
+            message: `HTTP error! status: ${response.status}`,
+          };
+        },
+      }
+    );
 
     if (!result.isOk()) {
       const errors = result.error;

--- a/js/app/packages/service-clients/service-storage/openapi.json
+++ b/js/app/packages/service-clients/service-storage/openapi.json
@@ -4640,6 +4640,16 @@
               }
             }
           },
+          "422": {
+            "description": "Document name exceeds the maximum length",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
           "500": {
             "description": "",
             "content": {

--- a/js/app/packages/service-clients/service-storage/util/upload.ts
+++ b/js/app/packages/service-clients/service-storage/util/upload.ts
@@ -7,7 +7,10 @@ import type { ResultError } from '@core/util/result';
 import { toaster } from '@kobalte/core/toast';
 import { waitForDocumentContentReady } from '@queries/storage/document-location';
 import { waitBulkUploadStatus } from '@service-connection/bulkUpload';
-import { storageServiceClient } from '@service-storage/client';
+import {
+  DOCUMENT_NAME_TOO_LONG_CODE,
+  storageServiceClient,
+} from '@service-storage/client';
 import { filenameWithoutExtension } from '@service-storage/util/filename';
 import { uploadToPresignedUrl } from '@service-storage/util/uploadToPresignedUrl';
 import { storageWS } from '@service-storage/websocket';
@@ -18,6 +21,17 @@ import { uploadDocx } from './uploadDocx';
 const dismissToast = (toastId: number | null) => {
   if (toastId !== null) toaster.dismiss(toastId);
 };
+
+/**
+ * Thrown when the backend rejects a document name as too long. Carries the
+ * limit so the UI can render its own copy without hardcoding the number.
+ */
+export class DocumentNameTooLongError extends Error {
+  constructor(public readonly maxLength?: number) {
+    super('Document name too long');
+    this.name = 'DocumentNameTooLongError';
+  }
+}
 
 const uploadWithPresignedUrl = async (params: {
   presignedUrl: string;
@@ -73,6 +87,17 @@ export async function upload(
     toastId: number | null
   ) => {
     dismissToast(toastId);
+
+    if (Array.isArray(err) && err[0]?.code === DOCUMENT_NAME_TOO_LONG_CODE) {
+      let maxLength: number | undefined;
+      try {
+        maxLength = (JSON.parse(err[0].message) as { maxLength?: number })
+          .maxLength;
+      } catch {
+        maxLength = undefined;
+      }
+      throw new DocumentNameTooLongError(maxLength);
+    }
 
     const isPaywallError = Array.isArray(err) && err[0].message.includes('403');
 

--- a/rust/cloud-storage/documents/src/domain/models.rs
+++ b/rust/cloud-storage/documents/src/domain/models.rs
@@ -41,6 +41,12 @@ pub enum DocumentError {
     /// A bad request was made.
     #[error("bad request: {0}")]
     BadRequest(String),
+    /// The provided document name exceeds the maximum allowed length.
+    #[error("name too long")]
+    NameTooLong {
+        /// Maximum allowed name length, in grapheme clusters.
+        max: usize,
+    },
     /// An internal error occurred.
     #[error("{0}")]
     Internal(#[from] anyhow::Error),

--- a/rust/cloud-storage/documents/src/domain/service.rs
+++ b/rust/cloud-storage/documents/src/domain/service.rs
@@ -880,7 +880,9 @@ impl<
         job_id: Option<String>,
     ) -> Result<CreateDocumentResponseData, DocumentError> {
         if args.document_name.graphemes(true).count() > MAX_DOCUMENT_NAME_GRAPHEMES {
-            return Err(DocumentError::BadRequest("name too long".to_string()));
+            return Err(DocumentError::BadRequest(format!(
+                "name too long (max {MAX_DOCUMENT_NAME_GRAPHEMES} characters)"
+            )));
         }
 
         let file_type = args.file_type;
@@ -1017,7 +1019,9 @@ impl<
         if let Some(name) = args.document_name.as_ref()
             && name.graphemes(true).count() > MAX_DOCUMENT_NAME_GRAPHEMES
         {
-            return Err(DocumentError::BadRequest("name too long".to_string()));
+            return Err(DocumentError::BadRequest(format!(
+                "name too long (max {MAX_DOCUMENT_NAME_GRAPHEMES} characters)"
+            )));
         }
 
         // Check owner-only restrictions for authenticated users
@@ -1145,7 +1149,9 @@ impl<
         use model::document::response::DocumentResponseMetadata;
 
         if document_name.graphemes(true).count() > MAX_DOCUMENT_NAME_GRAPHEMES {
-            return Err(DocumentError::BadRequest("name too long".to_string()));
+            return Err(DocumentError::BadRequest(format!(
+                "name too long (max {MAX_DOCUMENT_NAME_GRAPHEMES} characters)"
+            )));
         }
 
         if document_context.deleted_at.is_some() {

--- a/rust/cloud-storage/documents/src/domain/service.rs
+++ b/rust/cloud-storage/documents/src/domain/service.rs
@@ -120,6 +120,8 @@ fn pending_content_for_file_type(file_type: Option<FileType>) -> DocumentContent
 
 const GITHUB_PULL_REQUEST_FOREIGN_ENTITY_SOURCE: &str = "github_pull_request";
 
+const MAX_DOCUMENT_NAME_GRAPHEMES: usize = 200;
+
 fn short_id_for_entity_id(entity_id: &str) -> Result<String, DocumentError> {
     let uuid = macro_uuid::string_to_uuid(entity_id)
         .map_err(|e| DocumentError::BadRequest(format!("invalid entity_id: {e}")))?;
@@ -877,7 +879,7 @@ impl<
         args: CreateDocumentRepoArgs,
         job_id: Option<String>,
     ) -> Result<CreateDocumentResponseData, DocumentError> {
-        if args.document_name.graphemes(true).count() > 100 {
+        if args.document_name.graphemes(true).count() > MAX_DOCUMENT_NAME_GRAPHEMES {
             return Err(DocumentError::BadRequest("name too long".to_string()));
         }
 
@@ -1013,7 +1015,7 @@ impl<
         args: EditDocumentServiceArgs,
     ) -> Result<(), DocumentError> {
         if let Some(name) = args.document_name.as_ref()
-            && name.graphemes(true).count() > 100
+            && name.graphemes(true).count() > MAX_DOCUMENT_NAME_GRAPHEMES
         {
             return Err(DocumentError::BadRequest("name too long".to_string()));
         }
@@ -1142,7 +1144,7 @@ impl<
     ) -> Result<DocumentResponse, DocumentError> {
         use model::document::response::DocumentResponseMetadata;
 
-        if document_name.graphemes(true).count() > 100 {
+        if document_name.graphemes(true).count() > MAX_DOCUMENT_NAME_GRAPHEMES {
             return Err(DocumentError::BadRequest("name too long".to_string()));
         }
 

--- a/rust/cloud-storage/documents/src/domain/service.rs
+++ b/rust/cloud-storage/documents/src/domain/service.rs
@@ -880,9 +880,9 @@ impl<
         job_id: Option<String>,
     ) -> Result<CreateDocumentResponseData, DocumentError> {
         if args.document_name.graphemes(true).count() > MAX_DOCUMENT_NAME_GRAPHEMES {
-            return Err(DocumentError::BadRequest(format!(
-                "name too long (max {MAX_DOCUMENT_NAME_GRAPHEMES} characters)"
-            )));
+            return Err(DocumentError::NameTooLong {
+                max: MAX_DOCUMENT_NAME_GRAPHEMES,
+            });
         }
 
         let file_type = args.file_type;
@@ -1019,9 +1019,9 @@ impl<
         if let Some(name) = args.document_name.as_ref()
             && name.graphemes(true).count() > MAX_DOCUMENT_NAME_GRAPHEMES
         {
-            return Err(DocumentError::BadRequest(format!(
-                "name too long (max {MAX_DOCUMENT_NAME_GRAPHEMES} characters)"
-            )));
+            return Err(DocumentError::NameTooLong {
+                max: MAX_DOCUMENT_NAME_GRAPHEMES,
+            });
         }
 
         // Check owner-only restrictions for authenticated users
@@ -1149,9 +1149,9 @@ impl<
         use model::document::response::DocumentResponseMetadata;
 
         if document_name.graphemes(true).count() > MAX_DOCUMENT_NAME_GRAPHEMES {
-            return Err(DocumentError::BadRequest(format!(
-                "name too long (max {MAX_DOCUMENT_NAME_GRAPHEMES} characters)"
-            )));
+            return Err(DocumentError::NameTooLong {
+                max: MAX_DOCUMENT_NAME_GRAPHEMES,
+            });
         }
 
         if document_context.deleted_at.is_some() {

--- a/rust/cloud-storage/documents/src/inbound/axum_router.rs
+++ b/rust/cloud-storage/documents/src/inbound/axum_router.rs
@@ -80,14 +80,41 @@ use crate::domain::ports::DocumentService;
 #[cfg(feature = "document_create")]
 use crate::domain::ports::create::DocumentCreationService;
 
+/// Stable machine-readable error code for an over-length document name. Clients
+/// branch on this instead of the human message and render their own copy.
+pub const DOCUMENT_NAME_TOO_LONG_CODE: &str = "DOCUMENT_NAME_TOO_LONG";
+
+/// Structured 422 body for [`DocumentError::NameTooLong`]. Carries the limit so
+/// clients can show it without hardcoding a value that could drift from the API.
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct NameTooLongErrorResponse {
+    code: &'static str,
+    max_length: usize,
+    message: &'static str,
+}
+
 impl IntoResponse for DocumentError {
     fn into_response(self) -> axum::response::Response {
+        if let DocumentError::NameTooLong { max } = &self {
+            return (
+                StatusCode::UNPROCESSABLE_ENTITY,
+                Json(NameTooLongErrorResponse {
+                    code: DOCUMENT_NAME_TOO_LONG_CODE,
+                    max_length: *max,
+                    message: "name too long",
+                }),
+            )
+                .into_response();
+        }
+
         let status_code = match &self {
             DocumentError::NotFound(_) => StatusCode::NOT_FOUND,
             DocumentError::Unauthorized => StatusCode::UNAUTHORIZED,
             DocumentError::Gone => StatusCode::GONE,
             DocumentError::Conflict(_) => StatusCode::CONFLICT,
             DocumentError::BadRequest(_) => StatusCode::BAD_REQUEST,
+            DocumentError::NameTooLong { .. } => StatusCode::UNPROCESSABLE_ENTITY,
             DocumentError::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
             DocumentError::JwtEncoding(_) => StatusCode::INTERNAL_SERVER_ERROR,
         };

--- a/rust/cloud-storage/documents/src/inbound/axum_router/create_document.rs
+++ b/rust/cloud-storage/documents/src/inbound/axum_router/create_document.rs
@@ -30,6 +30,7 @@ use crate::domain::response::CreateDocumentResponse;
         (status = 400, body = model_error_response::ErrorResponse),
         (status = 401, body = model_error_response::ErrorResponse),
         (status = 409, body = model_error_response::ErrorResponse),
+        (status = 422, description = "Document name exceeds the maximum length", body = model_error_response::ErrorResponse),
         (status = 500, body = model_error_response::ErrorResponse),
     )
 )]

--- a/rust/cloud-storage/documents/src/inbound/toolset/create_document.rs
+++ b/rust/cloud-storage/documents/src/inbound/toolset/create_document.rs
@@ -20,6 +20,9 @@ use super::DocumentToolContext;
 fn failed_to_create_document(error: DocumentError) -> ToolCallError {
     let description = match &error {
         DocumentError::BadRequest(message) => message.clone(),
+        DocumentError::NameTooLong { max } => {
+            format!("name too long (max {max} characters)")
+        }
         _ => "failed to create document".to_string(),
     };
 


### PR DESCRIPTION
Raises the document name limit from 100 to 200 grapheme clusters (shared constant across the create/edit/copy checks; grapheme counting unchanged). Also surfaces the backend's 400 body message from `createDocument` so a too-long name shows a specific "Name is too long" toast instead of the generic upload-failed one. The separate chat and project name limits live in other crates with their own inline `100` checks and were left unchanged.
