### PR TITLE
feat(email): add include_signature override to the SendEmail AI tool

### DIFF
--- a/js/app/packages/service-clients/service-cognition/generated/tools/schemas.ts
+++ b/js/app/packages/service-clients/service-cognition/generated/tools/schemas.ts
@@ -2007,6 +2007,7 @@ export const SendEmail = z.object({
       })
     )
     .optional(),
+  includeSignature: z.union([z.boolean(), z.null()]).default(null),
   replyingToId: z.union([z.string().uuid(), z.null()]).default(null),
   subject: z.string(),
   to: z.array(

--- a/js/app/packages/service-clients/service-cognition/generated/tools/types.ts
+++ b/js/app/packages/service-clients/service-cognition/generated/tools/types.ts
@@ -2650,6 +2650,13 @@ export interface SendEmail {
    */
   cc?: EmailRecipient[];
   /**
+   * Per-message signature override, set by the composer's signature preview —
+   * not normally by you. Omit to use the inbox's default policy (always on a
+   * new email; on replies/forwards only when the user enabled it). `false`
+   * excludes the signature for this one email.
+   */
+  includeSignature?: boolean | null;
+  /**
    * The ID of a message to reply to (optional). When set, the email is
    * sent as a reply within the same thread.
    */

--- a/rust/cloud-storage/email/src/inbound/toolset/send_email.rs
+++ b/rust/cloud-storage/email/src/inbound/toolset/send_email.rs
@@ -62,6 +62,12 @@ pub struct SendEmail {
     /// sent as a reply within the same thread.
     #[serde(default)]
     pub replying_to_id: Option<Uuid>,
+    /// Per-message signature override, set by the composer's signature preview —
+    /// not normally by you. Omit to use the inbox's default policy (always on a
+    /// new email; on replies/forwards only when the user enabled it). `false`
+    /// excludes the signature for this one email.
+    #[serde(default)]
+    pub include_signature: Option<bool>,
 }
 
 /// Response from the SendEmail tool.
@@ -120,8 +126,9 @@ where
             body_macro: None,
             headers_json: None,
             send_time: None,
-            // None = let the backend apply the default signature policy.
-            include_signature: None,
+            // Composer override when present; otherwise None lets the backend
+            // apply the default signature policy.
+            include_signature: self.include_signature,
         };
 
         let sent = service_context


### PR DESCRIPTION
## What

Adds an optional `include_signature` field to the `SendEmail` AI tool and threads it through to the draft input, so the chat email composer's signature preview can drop the signature for a single AI-drafted email.

## Why

The `SendEmail` tool always passed `include_signature: None`, so an AI-composed email couldn't opt out of the inbox signature. With this field the composer can send `false` when the user dismisses the signature; omitting it preserves the existing default policy (signed on a new email; on replies/forwards only when the inbox's "add to replies & forwards" setting is enabled).

## Changes

- `send_email.rs`: add `include_signature: Option<bool>` to the `SendEmail` tool struct and pass it to `CreateDraftInput` (was hardcoded `None`).
- Regenerated the cognition tool types — `SendEmail` gains `includeSignature?: boolean | null`.

## Compatibility

Purely additive: the type field is optional and the zod schema field is `.default(null)`, so existing `SendEmail` tool calls (which omit it) still parse and behave exactly as before. The frontend consumer (the composer's signature preview + dismiss) lands separately.
