### PR TITLE
feat(email): HTML signature UI — settings editor + compose/reply/AI previews (flag-gated)

### DIFF
--- a/js/app/package.json
+++ b/js/app/package.json
@@ -97,6 +97,7 @@
     "nanoid": "^3.3.7",
     "neverthrow": "^8.2.0",
     "posthog-js": "^1.387.0",
+    "quill": "^2.0.3",
     "short-uuid": "^5.2.0",
     "signature_pad": "^5.0.10",
     "solid-gesture": "^0.0.3",

--- a/js/app/packages/app/component/settings/Email.tsx
+++ b/js/app/packages/app/component/settings/Email.tsx
@@ -3,6 +3,7 @@ import { match } from 'ts-pattern';
 import { Button, Dialog, Panel, Tooltip } from '@ui';
 import { useFeatureFlag } from '@app/lib/analytics/posthog';
 import {
+  ENABLE_EMAIL_SIGNATURES,
   ENABLE_INBOX_RESYNC,
   ENABLE_INBOX_SYNC_STATUS,
   ENABLE_MULTI_INBOX_OVERRIDE,
@@ -11,6 +12,7 @@ import GmailIcon from '@icon/mcp-gmail.svg';
 import XIcon from '@phosphor-icons/core/regular/x.svg?component-solid';
 import ArrowsClockwiseIcon from '@phosphor-icons/core/regular/arrows-clockwise.svg?component-solid';
 import PlusIcon from '@phosphor-icons/core/regular/plus.svg?component-solid';
+import SignatureIcon from '@phosphor-icons/core/regular/signature.svg?component-solid';
 import {
   type BackfillJob,
   BackfillJobStatus,
@@ -38,6 +40,12 @@ import {
 import { useRemoveInboxMutation } from '@queries/email/link';
 import { IntegrationRow, SettingsCard, SettingsRow } from './primitives';
 import { ConnectAction, StatusDot } from './integration-ui';
+import {
+  clearSignatureState,
+  isSignatureExpanded,
+  SignatureSection,
+  toggleSignatureExpanded,
+} from './SignatureSection';
 
 /**
  * Gmail integration as a single Connected-accounts card: a header row with the
@@ -77,7 +85,10 @@ export function EmailCard() {
     latestBackfillByLinkId().get(linkId)?.status === BackfillJobStatus.Complete;
 
   const removeInboxMutation = useRemoveInboxMutation({
-    onSuccess: () => toast.success('Inbox removed'),
+    onSuccess: (_data, linkId) => {
+      clearSignatureState(linkId);
+      toast.success('Inbox removed');
+    },
     onError: () => toast.failure('Failed to remove inbox. Please try again.'),
   });
   const [removeTarget, setRemoveTarget] = createSignal<{
@@ -379,107 +390,132 @@ function InboxRow(props: {
   onReconnect: () => void;
   onRemove: () => void;
 }) {
+  const showSignature = () => isSignatureExpanded(props.link.id);
+  const signatureSectionId = `signature-section-${props.link.id}`;
   return (
-    <div class="bg-surface flex items-center justify-between gap-3 min-h-15.25 py-2 px-6">
-      <div class="min-w-0 flex flex-col gap-0.5">
-        <div class="flex items-center gap-2 min-w-0">
-          <span class="ph-no-capture text-sm truncate">
-            {props.link.email_address}
-          </span>
-          <Show when={props.isPrimary}>
-            <Chip label="Primary" />
-          </Show>
-          <Show when={!props.isPrimary && !props.isOwn}>
-            <Chip label="Shared" />
-          </Show>
-        </div>
-        <Show when={ENABLE_INBOX_SYNC_STATUS}>
-          <Switch
-            fallback={
-              <Show when={props.link.sync_status !== SyncStatus.UP_TO_DATE}>
-                <span
-                  class="flex items-center gap-1 text-xs"
-                  classList={{
-                    'text-failure':
-                      props.link.sync_status === SyncStatus.ERROR ||
-                      props.link.sync_status === SyncStatus.NEEDS_REAUTH,
-                    'text-ink-muted':
-                      props.link.sync_status !== SyncStatus.ERROR &&
-                      props.link.sync_status !== SyncStatus.NEEDS_REAUTH,
-                  }}
-                >
-                  <Show when={props.link.sync_status === SyncStatus.SYNCING}>
-                    <ArrowsClockwiseIcon class="size-3 animate-spin" />
-                  </Show>
-                  {syncStatusLabel(props.link.sync_status)}
-                </span>
-              </Show>
-            }
-          >
-            {/* Live backfill progress (connection gateway) wins over the coarse
-                sync_status while a backfill is actively running. */}
-            <Match when={getBackfillProgress(props.link.id)}>
-              {(progress) => <BackfillProgressBar progress={progress()} />}
-            </Match>
-            {/* Settled inbox with a completed backfill from the BE list. */}
-            <Match
-              when={
-                props.link.sync_status === SyncStatus.UP_TO_DATE &&
-                props.hasCompletedBackfill
+    <div class="bg-surface flex flex-col">
+      <div class="flex items-center justify-between gap-3 min-h-15.25 py-2 px-6">
+        <div class="min-w-0 flex flex-col gap-0.5">
+          <div class="flex items-center gap-2 min-w-0">
+            <span class="ph-no-capture text-sm truncate">
+              {props.link.email_address}
+            </span>
+            <Show when={props.isPrimary}>
+              <Chip label="Primary" />
+            </Show>
+            <Show when={!props.isPrimary && !props.isOwn}>
+              <Chip label="Shared" />
+            </Show>
+          </div>
+          <Show when={ENABLE_INBOX_SYNC_STATUS}>
+            <Switch
+              fallback={
+                <Show when={props.link.sync_status !== SyncStatus.UP_TO_DATE}>
+                  <span
+                    class="flex items-center gap-1 text-xs"
+                    classList={{
+                      'text-failure':
+                        props.link.sync_status === SyncStatus.ERROR ||
+                        props.link.sync_status === SyncStatus.NEEDS_REAUTH,
+                      'text-ink-muted':
+                        props.link.sync_status !== SyncStatus.ERROR &&
+                        props.link.sync_status !== SyncStatus.NEEDS_REAUTH,
+                    }}
+                  >
+                    <Show when={props.link.sync_status === SyncStatus.SYNCING}>
+                      <ArrowsClockwiseIcon class="size-3 animate-spin" />
+                    </Show>
+                    {syncStatusLabel(props.link.sync_status)}
+                  </span>
+                </Show>
               }
             >
-              <span class="text-xs text-ink-muted">Initial sync complete</span>
-            </Match>
-          </Switch>
-        </Show>
-      </div>
-      <div class="flex items-center gap-2 shrink-0">
-        <Show
-          when={
-            ENABLE_INBOX_SYNC_STATUS &&
-            props.link.sync_status === SyncStatus.NEEDS_REAUTH
-          }
-        >
-          <Button
-            variant="active"
-            size="sm"
-            depth={3}
-            onClick={props.onReconnect}
-            aria-label={`Reconnect ${props.link.email_address}`}
+              {/* Live backfill progress (connection gateway) wins over the coarse
+                  sync_status while a backfill is actively running. */}
+              <Match when={getBackfillProgress(props.link.id)}>
+                {(progress) => <BackfillProgressBar progress={progress()} />}
+              </Match>
+              {/* Settled inbox with a completed backfill from the BE list. */}
+              <Match
+                when={
+                  props.link.sync_status === SyncStatus.UP_TO_DATE &&
+                  props.hasCompletedBackfill
+                }
+              >
+                <span class="text-xs text-ink-muted">Initial sync complete</span>
+              </Match>
+            </Switch>
+          </Show>
+        </div>
+        <div class="flex items-center gap-2 shrink-0">
+          <Show when={ENABLE_EMAIL_SIGNATURES && props.isOwn}>
+            <Tooltip label="Edit signature">
+              <Button
+                variant="base"
+                size="icon-sm"
+                depth={3}
+                onClick={() => toggleSignatureExpanded(props.link.id)}
+                aria-label={`Edit signature for ${props.link.email_address}`}
+                aria-expanded={showSignature()}
+                aria-controls={signatureSectionId}
+              >
+                <SignatureIcon class="size-4" />
+              </Button>
+            </Tooltip>
+          </Show>
+          <Show
+            when={
+              ENABLE_INBOX_SYNC_STATUS &&
+              props.link.sync_status === SyncStatus.NEEDS_REAUTH
+            }
           >
-            Reconnect
-          </Button>
-        </Show>
-        <Show when={ENABLE_INBOX_RESYNC}>
-          <Tooltip label="Force sync">
+            <Button
+              variant="active"
+              size="sm"
+              depth={3}
+              onClick={props.onReconnect}
+              aria-label={`Reconnect ${props.link.email_address}`}
+            >
+              Reconnect
+            </Button>
+          </Show>
+          <Show when={ENABLE_INBOX_RESYNC}>
+            <Tooltip label="Force sync">
+              <Button
+                variant="base"
+                size="icon-sm"
+                depth={3}
+                disabled={
+                  props.resyncing ||
+                  (ENABLE_INBOX_SYNC_STATUS &&
+                    props.link.sync_status === SyncStatus.SYNCING)
+                }
+                onClick={props.onResync}
+                aria-label={`Force sync ${props.link.email_address}`}
+              >
+                <ArrowsClockwiseIcon class="size-4" />
+              </Button>
+            </Tooltip>
+          </Show>
+          <Tooltip label="Remove inbox">
             <Button
               variant="base"
               size="icon-sm"
               depth={3}
-              disabled={
-                props.resyncing ||
-                (ENABLE_INBOX_SYNC_STATUS &&
-                  props.link.sync_status === SyncStatus.SYNCING)
-              }
-              onClick={props.onResync}
-              aria-label={`Force sync ${props.link.email_address}`}
+              onClick={props.onRemove}
+              aria-label={`Remove ${props.link.email_address}`}
             >
-              <ArrowsClockwiseIcon class="size-4" />
+              <XIcon class="size-4" />
             </Button>
           </Tooltip>
-        </Show>
-        <Tooltip label="Remove inbox">
-          <Button
-            variant="base"
-            size="icon-sm"
-            depth={3}
-            onClick={props.onRemove}
-            aria-label={`Remove ${props.link.email_address}`}
-          >
-            <XIcon class="size-4" />
-          </Button>
-        </Tooltip>
+        </div>
       </div>
+      <Show when={ENABLE_EMAIL_SIGNATURES && props.isOwn && showSignature()}>
+        <div id={signatureSectionId} class="px-6 pb-4">
+          <SignatureSection link={props.link} />
+        </div>
+      </Show>
     </div>
   );
 }
+

--- a/js/app/packages/app/component/settings/SignatureEditor.css
+++ b/js/app/packages/app/component/settings/SignatureEditor.css
@@ -1,0 +1,258 @@
+/* Theme Quill's "snow" editor with the app's design tokens so it reads in both
+   light and dark, and round its corners to match surrounding panels. Scoped to
+   .signature-editor so it never leaks to any other Quill instance. */
+
+.signature-editor .ql-toolbar.ql-snow,
+.signature-editor .ql-container.ql-snow {
+  border-color: var(--color-edge-muted);
+}
+
+.signature-editor .ql-toolbar.ql-snow {
+  border-top-left-radius: 0.5rem;
+  border-top-right-radius: 0.5rem;
+}
+
+.signature-editor .ql-container.ql-snow {
+  border-bottom-left-radius: 0.5rem;
+  border-bottom-right-radius: 0.5rem;
+  font-family: inherit;
+  font-size: 0.875rem;
+}
+
+/* Each toolbar control is wrapped in the app tooltip's inline-flex trigger
+   <span>; keep those wrappers aligned with the rest of the toolbar row. */
+.signature-editor .ql-toolbar .ql-formats > span {
+  vertical-align: middle;
+}
+
+.signature-editor .ql-editor {
+  min-height: 8rem;
+  color: var(--color-ink);
+}
+
+.signature-editor .ql-editor img {
+  max-width: 100%;
+}
+
+/* Drag-to-resize overlay for a selected image — styled to match the document
+   block's resizer: a subtle selection ring with an ink edge-bar handle that
+   brightens and scales on hover/drag. The box is click-through
+   (pointer-events: none) so the image stays selectable; only the handle is
+   interactive. Positioned by signatureImageResizer.ts within .ql-container. */
+.signature-editor .ql-image-resizer {
+  position: absolute;
+  display: none;
+  box-sizing: border-box;
+  box-shadow: 0 0 0 2px var(--color-edge-muted);
+  pointer-events: none;
+  z-index: 1;
+}
+.signature-editor .ql-image-resizer-handle {
+  position: absolute;
+  top: 0;
+  right: -8px;
+  width: 16px;
+  height: 100%;
+  cursor: col-resize;
+  touch-action: none;
+  pointer-events: auto;
+}
+/* The visible pill bar (matches the doc block's bg-ink / ring-surface bar). */
+.signature-editor .ql-image-resizer-handle::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  right: 6px;
+  width: 4px;
+  height: 50%;
+  min-height: 2rem;
+  transform: translateY(-50%);
+  background-color: var(--color-ink);
+  box-shadow: 0 0 0 2px var(--color-surface);
+  border-radius: 9999px;
+  opacity: 0.5;
+  transition: all 200ms ease;
+  pointer-events: none;
+}
+.signature-editor .ql-image-resizer-handle:hover::before {
+  opacity: 0.8;
+}
+.signature-editor
+  .ql-image-resizer.dragging
+  .ql-image-resizer-handle::before {
+  opacity: 0.8;
+  transform: translateY(-50%) scale(1.2);
+}
+
+.signature-editor .ql-editor.ql-blank::before {
+  color: var(--color-ink-muted);
+  font-style: normal;
+}
+
+/* Toolbar icons + labels follow the theme instead of Quill's hard-coded grey. */
+.signature-editor .ql-snow .ql-stroke {
+  stroke: var(--color-ink-muted);
+}
+.signature-editor .ql-snow .ql-fill {
+  fill: var(--color-ink-muted);
+}
+.signature-editor .ql-snow .ql-picker {
+  color: var(--color-ink-muted);
+}
+
+.signature-editor .ql-snow.ql-toolbar button:hover .ql-stroke,
+.signature-editor .ql-snow.ql-toolbar button.ql-active .ql-stroke,
+.signature-editor .ql-snow .ql-picker-label:hover .ql-stroke {
+  stroke: var(--color-ink);
+}
+.signature-editor .ql-snow.ql-toolbar button:hover .ql-fill,
+.signature-editor .ql-snow.ql-toolbar button.ql-active .ql-fill {
+  fill: var(--color-ink);
+}
+.signature-editor .ql-snow.ql-toolbar button:hover,
+.signature-editor .ql-snow.ql-toolbar button.ql-active,
+.signature-editor .ql-snow .ql-picker-label:hover,
+.signature-editor .ql-snow .ql-picker-label.ql-active {
+  color: var(--color-ink);
+}
+
+/* Dropdown panels (header levels, color swatches, font/size lists). */
+.signature-editor .ql-snow .ql-picker-options {
+  background-color: var(--color-surface);
+  border-color: var(--color-edge-muted);
+}
+
+/* Font + size picker labels. The snow theme only labels its own presets, so
+   every custom option (see FONT_OPTIONS / SIZE_OPTIONS in SignatureEditor.tsx)
+   needs a label rule; the item rules also preview the font/size. `false`
+   (default) is already labelled "Sans Serif" / "Normal" by the base theme. */
+
+/* Compact, single-line picker labels so long names (e.g. "Times New Roman")
+   don't wrap out of the toolbar. */
+.signature-editor .ql-picker {
+  font-size: 0.8125rem;
+}
+/* Font + size pickers size to their selected label (dynamic) rather than fixed
+   boxes, so "Sans Serif" isn't padded out to fit "Times New Roman". width:auto on
+   both the picker and its label removes the circular 100% sizing; the right
+   padding keeps the label text clear of the absolutely-positioned dropdown caret
+   (and gives a bit of breathing room after it). The options panel still expands
+   to the widest item via the theme's min-width:100% + nowrap. */
+.signature-editor .ql-picker.ql-font,
+.signature-editor .ql-picker.ql-size,
+.signature-editor .ql-picker.ql-font .ql-picker-label,
+.signature-editor .ql-picker.ql-size .ql-picker-label {
+  width: auto;
+}
+.signature-editor .ql-picker.ql-font .ql-picker-label,
+.signature-editor .ql-picker.ql-size .ql-picker-label {
+  padding-right: 24px;
+}
+.signature-editor .ql-picker.ql-font .ql-picker-label,
+.signature-editor .ql-picker.ql-font .ql-picker-item,
+.signature-editor .ql-picker.ql-size .ql-picker-label,
+.signature-editor .ql-picker.ql-size .ql-picker-item {
+  white-space: nowrap;
+}
+
+/* Tighten group spacing + button width so every control fits one row in the
+   narrow settings column (max-w-[710px]). */
+.signature-editor .ql-toolbar.ql-snow .ql-formats {
+  margin-right: 6px;
+}
+.signature-editor .ql-snow.ql-toolbar button {
+  width: 24px;
+  padding: 3px;
+}
+
+.signature-editor .ql-picker.ql-font .ql-picker-label[data-value="Arial"]::before,
+.signature-editor .ql-picker.ql-font .ql-picker-item[data-value="Arial"]::before {
+  content: "Arial";
+}
+.signature-editor .ql-picker.ql-font .ql-picker-item[data-value="Arial"]::before {
+  font-family: Arial, sans-serif;
+}
+
+.signature-editor .ql-picker.ql-font .ql-picker-label[data-value="Georgia"]::before,
+.signature-editor .ql-picker.ql-font .ql-picker-item[data-value="Georgia"]::before {
+  content: "Georgia";
+}
+.signature-editor .ql-picker.ql-font .ql-picker-item[data-value="Georgia"]::before {
+  font-family: Georgia, serif;
+}
+
+.signature-editor
+  .ql-picker.ql-font
+  .ql-picker-label[data-value="Times New Roman"]::before,
+.signature-editor
+  .ql-picker.ql-font
+  .ql-picker-item[data-value="Times New Roman"]::before {
+  content: "Times New Roman";
+}
+.signature-editor
+  .ql-picker.ql-font
+  .ql-picker-item[data-value="Times New Roman"]::before {
+  font-family: "Times New Roman", serif;
+}
+
+.signature-editor
+  .ql-picker.ql-font
+  .ql-picker-label[data-value="Courier New"]::before,
+.signature-editor
+  .ql-picker.ql-font
+  .ql-picker-item[data-value="Courier New"]::before {
+  content: "Courier New";
+}
+.signature-editor
+  .ql-picker.ql-font
+  .ql-picker-item[data-value="Courier New"]::before {
+  font-family: "Courier New", monospace;
+}
+
+.signature-editor .ql-picker.ql-font .ql-picker-label[data-value="Verdana"]::before,
+.signature-editor .ql-picker.ql-font .ql-picker-item[data-value="Verdana"]::before {
+  content: "Verdana";
+}
+.signature-editor .ql-picker.ql-font .ql-picker-item[data-value="Verdana"]::before {
+  font-family: Verdana, sans-serif;
+}
+
+.signature-editor .ql-picker.ql-size .ql-picker-label[data-value="12px"]::before,
+.signature-editor .ql-picker.ql-size .ql-picker-item[data-value="12px"]::before {
+  content: "12px";
+}
+.signature-editor .ql-picker.ql-size .ql-picker-item[data-value="12px"]::before {
+  font-size: 12px;
+}
+
+.signature-editor .ql-picker.ql-size .ql-picker-label[data-value="14px"]::before,
+.signature-editor .ql-picker.ql-size .ql-picker-item[data-value="14px"]::before {
+  content: "14px";
+}
+.signature-editor .ql-picker.ql-size .ql-picker-item[data-value="14px"]::before {
+  font-size: 14px;
+}
+
+.signature-editor .ql-picker.ql-size .ql-picker-label[data-value="16px"]::before,
+.signature-editor .ql-picker.ql-size .ql-picker-item[data-value="16px"]::before {
+  content: "16px";
+}
+.signature-editor .ql-picker.ql-size .ql-picker-item[data-value="16px"]::before {
+  font-size: 16px;
+}
+
+.signature-editor .ql-picker.ql-size .ql-picker-label[data-value="20px"]::before,
+.signature-editor .ql-picker.ql-size .ql-picker-item[data-value="20px"]::before {
+  content: "20px";
+}
+.signature-editor .ql-picker.ql-size .ql-picker-item[data-value="20px"]::before {
+  font-size: 20px;
+}
+
+.signature-editor .ql-picker.ql-size .ql-picker-label[data-value="24px"]::before,
+.signature-editor .ql-picker.ql-size .ql-picker-item[data-value="24px"]::before {
+  content: "24px";
+}
+.signature-editor .ql-picker.ql-size .ql-picker-item[data-value="24px"]::before {
+  font-size: 24px;
+}

--- a/js/app/packages/app/component/settings/SignatureEditor.tsx
+++ b/js/app/packages/app/component/settings/SignatureEditor.tsx
@@ -1,0 +1,246 @@
+import 'quill/dist/quill.snow.css';
+import './SignatureEditor.css';
+import { toast } from '@core/component/Toast/Toast';
+import { staticFileIdEndpoint } from '@core/constant/servers';
+import { createStaticUploadFile, createUploadFile } from '@core/util/uploadFile';
+import { Tooltip } from '@ui';
+import Quill, { type Parchment } from 'quill';
+import { createEffect, For, onCleanup, onMount } from 'solid-js';
+import { setupImageResizer } from './signatureImageResizer';
+
+// Quill's built-in font/size formats ship with hard whitelists (font:
+// serif/monospace; size: 10/18/32px), and the paste clipboard enforces them —
+// so any other pasted font-family / font-size is silently dropped. Swap in the
+// style-based attributors with the whitelist cleared, so pasted fonts and sizes
+// are kept as inline styles (which the backend HTML sanitizer allows). The
+// clipboard matches against these exact singletons, so clearing their whitelist
+// is what makes paste retain arbitrary values. Runs once when this lazy chunk
+// loads; registration is global and idempotent.
+for (const path of ['attributors/style/font', 'attributors/style/size']) {
+  const attributor = Quill.import(path) as Parchment.Attributor;
+  attributor.whitelist = undefined;
+  Quill.register(attributor, true);
+}
+
+// Font/size options offered in the toolbar. The style attributors registered
+// above apply these as inline `font-family` / `font-size` (which the sanitizer
+// keeps), and `false` is the "default" reset. Each value needs a matching label
+// rule in SignatureEditor.css (the snow theme only ships labels for its own
+// presets). Values with spaces are valid multi-identifier CSS family names.
+const FONT_OPTIONS: (string | false)[] = [
+  false,
+  'Arial',
+  'Georgia',
+  'Times New Roman',
+  'Courier New',
+  'Verdana',
+];
+const SIZE_OPTIONS: (string | false)[] = [
+  false,
+  '12px',
+  '14px',
+  '16px',
+  '20px',
+  '24px',
+];
+
+// Image types accepted by the toolbar picker and by paste/drop upload.
+const IMAGE_MIME_TYPES = ['image/png', 'image/jpeg', 'image/gif', 'image/webp'];
+
+// A toolbar button wrapped in the app's tooltip. `as="span"` keeps the wrapper
+// inline so Quill still finds the <button> inside and wires its handler/icon.
+// `aria-label` gives the icon-only button an accessible name.
+function ToolbarButton(props: {
+  format: string;
+  value?: string;
+  label: string;
+  shortcut?: string;
+}) {
+  return (
+    <Tooltip label={props.label} shortcut={props.shortcut} as="span">
+      <button
+        type="button"
+        class={`ql-${props.format}`}
+        value={props.value}
+        aria-label={props.label}
+      />
+    </Tooltip>
+  );
+}
+
+export default function SignatureEditor(props: {
+  /** Persisted signature HTML. Seeds the editor, and reseeds it (while blurred)
+   * if it changes externally — e.g. the links query resolves after mount. */
+  value: string;
+  /** Fires with the editor's current HTML on every edit; '' when emptied. */
+  onInput: (html: string) => void;
+  placeholder?: string;
+  /** Exposes an imperative handle once mounted so commit actions (Save/Remove)
+   * can set the editor content deterministically, not via the reactive value. */
+  onReady?: (handle: { setContent: (html: string) => void }) => void;
+}) {
+  let toolbarEl!: HTMLDivElement;
+  let editorEl!: HTMLDivElement;
+  let quill: Quill | undefined;
+  let teardownResizer: (() => void) | undefined;
+
+  const currentHtml = (): string => {
+    if (!quill) return '';
+    // A blank editor still serializes to "<p></p>"; treat no text as empty so
+    // the caller can clear the signature (the backend reads '' as "clear").
+    if (quill.getText().trim().length === 0) return '';
+    return quill.getSemanticHTML();
+  };
+
+  const setHtml = (html: string) => {
+    if (!quill) return;
+    // 'silent' so seeding/reseeding doesn't fire text-change (which would call
+    // onInput and falsely mark the form dirty). For empty html clear explicitly:
+    // Quill's convert('') yields an empty delta that setContents leaves as a
+    // no-op, so it wouldn't actually clear an existing signature.
+    if (!html) {
+      quill.setContents([{ insert: '\n' }], 'silent');
+      return;
+    }
+    const delta = quill.clipboard.convert({ html });
+    quill.setContents(delta, 'silent');
+  };
+
+  // Uploads each image to the static-file-service and inserts it at `index` as
+  // an <img> with the returned https URL. We never insert base64 `data:` URLs —
+  // the signature sanitizer's url_schemes allowlist rejects them.
+  const uploadAndInsertImages = async (
+    index: number,
+    length: number,
+    files: File[]
+  ) => {
+    if (!quill) return;
+    if (length > 0) quill.deleteText(index, length, 'user');
+    let at = index;
+    for (const file of files) {
+      try {
+        const id = await createStaticUploadFile(createUploadFile(file));
+        quill.insertEmbed(at, 'image', staticFileIdEndpoint(id), 'user');
+        at += 1;
+      } catch {
+        toast.failure('Failed to upload image');
+      }
+    }
+    quill.setSelection(at, 0, 'silent');
+  };
+
+  // Toolbar image button: pick a file, then upload + insert at the cursor.
+  const pickAndUploadImage = () => {
+    if (!quill) return;
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = IMAGE_MIME_TYPES.join(',');
+    input.addEventListener('change', () => {
+      const file = input.files?.[0];
+      if (!file || !quill) return;
+      const index = quill.getSelection(true)?.index ?? quill.getLength();
+      void uploadAndInsertImages(index, 0, [file]);
+    });
+    input.click();
+  };
+
+  onMount(() => {
+    // Hand Quill our own JSX toolbar (each control wrapped in the app Tooltip)
+    // instead of the array config, so the buttons get the app's styled tooltips.
+    // Quill still builds the icons/pickers into it and wires the default handlers.
+    quill = new Quill(editorEl, {
+      theme: 'snow',
+      placeholder: props.placeholder ?? 'Add a signature…',
+      modules: {
+        toolbar: {
+          container: toolbarEl,
+          handlers: { image: pickAndUploadImage },
+        },
+        // Route pasted/dropped images through SFS instead of Quill's default
+        // base64 insert (which the sanitizer would strip).
+        uploader: {
+          mimetypes: IMAGE_MIME_TYPES,
+          handler: (range: { index: number; length: number }, files: File[]) =>
+            void uploadAndInsertImages(range.index, range.length, files),
+        },
+      },
+    });
+    setHtml(props.value);
+    quill.on('text-change', () => props.onInput(currentHtml()));
+    teardownResizer = setupImageResizer(quill);
+    props.onReady?.({ setContent: (html) => setHtml(html) });
+  });
+
+  // Reseed the editor when `props.value` changes. The draft store keeps
+  // `props.value` equal to the editor's own content while typing, so this is a
+  // no-op then and never clobbers an in-progress edit; it only diverges after
+  // Save/Remove (a button click, not active typing), where reseeding right away
+  // is exactly what reflects the sanitized result or clears the box.
+  createEffect(() => {
+    const next = props.value;
+    if (!quill || currentHtml() === next) return;
+    setHtml(next);
+  });
+
+  onCleanup(() => {
+    teardownResizer?.();
+    // Quill 2 has no destroy(); dropping the ref lets it GC with its DOM node.
+    quill = undefined;
+  });
+
+  return (
+    <div class="signature-editor">
+      <div ref={toolbarEl}>
+        <span class="ql-formats">
+          <Tooltip label="Font" as="span">
+            <select class="ql-font" aria-label="Font">
+              <For each={FONT_OPTIONS}>
+                {(font) =>
+                  font === false ? <option /> : <option value={font} />
+                }
+              </For>
+            </select>
+          </Tooltip>
+          <Tooltip label="Size" as="span">
+            <select class="ql-size" aria-label="Font size">
+              <For each={SIZE_OPTIONS}>
+                {(size) =>
+                  size === false ? <option /> : <option value={size} />
+                }
+              </For>
+            </select>
+          </Tooltip>
+        </span>
+        <span class="ql-formats">
+          <ToolbarButton format="bold" label="Bold" shortcut="cmd+b" />
+          <ToolbarButton format="italic" label="Italic" shortcut="cmd+i" />
+          <ToolbarButton
+            format="underline"
+            label="Underline"
+            shortcut="cmd+u"
+          />
+        </span>
+        <span class="ql-formats">
+          <Tooltip label="Text color" as="span">
+            <select class="ql-color" aria-label="Text color" />
+          </Tooltip>
+          <Tooltip label="Highlight color" as="span">
+            <select class="ql-background" aria-label="Highlight color" />
+          </Tooltip>
+        </span>
+        <span class="ql-formats">
+          <ToolbarButton format="list" value="ordered" label="Numbered list" />
+          <ToolbarButton format="list" value="bullet" label="Bulleted list" />
+        </span>
+        <span class="ql-formats">
+          <ToolbarButton format="link" label="Link" />
+          <ToolbarButton format="image" label="Image" />
+        </span>
+        <span class="ql-formats">
+          <ToolbarButton format="clean" label="Clear formatting" />
+        </span>
+      </div>
+      <div ref={editorEl} />
+    </div>
+  );
+}

--- a/js/app/packages/app/component/settings/SignatureEditor.tsx
+++ b/js/app/packages/app/component/settings/SignatureEditor.tsx
@@ -86,9 +86,17 @@ export default function SignatureEditor(props: {
 
   const currentHtml = (): string => {
     if (!quill) return '';
-    // A blank editor still serializes to "<p></p>"; treat no text as empty so
-    // the caller can clear the signature (the backend reads '' as "clear").
-    if (quill.getText().trim().length === 0) return '';
+    // A blank editor still serializes to "<p></p>"; treat it as empty so the
+    // caller can clear the signature (the backend reads '' as "clear"). Inspect
+    // the delta rather than getText(), which omits embeds — an image-only
+    // signature has no text but must still be saved.
+    const ops = quill.getContents().ops ?? [];
+    const hasContent = ops.some((op) =>
+      typeof op.insert === 'string'
+        ? op.insert.trim().length > 0
+        : op.insert != null
+    );
+    if (!hasContent) return '';
     return quill.getSemanticHTML();
   };
 

--- a/js/app/packages/app/component/settings/SignatureSection.tsx
+++ b/js/app/packages/app/component/settings/SignatureSection.tsx
@@ -1,0 +1,212 @@
+import { toast } from '@core/component/Toast/Toast';
+import { ThrownResultError } from '@core/util/result';
+import { useEmailSignature } from '@queries/email/link';
+import { useUpdateEmailSettingsMutation } from '@queries/email/settings';
+import { SIGNATURE_IMAGES_UNRESOLVED_CODE } from '@service-email/client';
+import type { Link as EmailLink } from '@service-email/generated/schemas';
+import { Button, ToggleSwitch } from '@ui';
+import { createSignal, lazy, Show, Suspense } from 'solid-js';
+
+// Quill (and its CSS) is heavy and only needed once a signature section is
+// expanded, so load it as its own chunk on demand instead of in the settings
+// bundle.
+const SignatureEditor = lazy(() => import('./SignatureEditor'));
+
+// Unsaved signature drafts and per-inbox expanded state, keyed by link id and
+// held at module scope. The settings modal unmounts the Connected Accounts tab
+// when you switch away (and the links query can recreate an inbox row on
+// refetch); keeping this outside that subtree means tabbing away and back no
+// longer closes the editor or discards unsaved edits.
+const [signatureDrafts, setSignatureDrafts] = createSignal<
+  Record<string, string>
+>({});
+const [signatureExpanded, setSignatureExpanded] = createSignal<
+  Record<string, boolean>
+>({});
+
+/** Whether an inbox's signature editor is expanded (reactive). */
+export function isSignatureExpanded(linkId: string): boolean {
+  return signatureExpanded()[linkId] ?? false;
+}
+
+/** Toggles an inbox's signature editor open/closed. */
+export function toggleSignatureExpanded(linkId: string): void {
+  setSignatureExpanded((prev) => ({
+    ...prev,
+    [linkId]: !isSignatureExpanded(linkId),
+  }));
+}
+
+/**
+ * Drops a link's draft + expanded entries so the module store doesn't retain
+ * state for an inbox that no longer exists (called when an inbox is removed).
+ */
+export function clearSignatureState(linkId: string): void {
+  setSignatureDrafts((prev) => {
+    const next = { ...prev };
+    delete next[linkId];
+    return next;
+  });
+  setSignatureExpanded((prev) => {
+    const next = { ...prev };
+    delete next[linkId];
+    return next;
+  });
+}
+
+/**
+ * Picks the inline error message for a failed signature save. The backend
+ * rejects the whole patch with a `SIGNATURE_IMAGES_UNRESOLVED` error when images
+ * can't be loaded; everything else is a generic failure.
+ */
+function saveSignatureErrorMessage(error: Error): string {
+  const unresolved =
+    error instanceof ThrownResultError
+      ? error.errors.find((e) => e.code === SIGNATURE_IMAGES_UNRESOLVED_CODE)
+      : undefined;
+  if (!unresolved) return 'Failed to save signature. Please try again.';
+
+  return 'Unable to save images. Use the image button to add images.';
+}
+
+/**
+ * Per-inbox signature editor. Reads the persisted signature from the links
+ * query (no extra fetch) into the Quill editor, tracks an unsaved draft, and
+ * patches `email_settings` on save. The "replies & forwards" toggle patches
+ * immediately (the backend patch is partial, so it leaves the signature alone).
+ */
+export function SignatureSection(props: { link: EmailLink }) {
+  const signature = useEmailSignature(() => props.link.id);
+  // Draft lives in the module-level store (keyed by link id) so it survives the
+  // settings tab unmounting; `null` means "no unsaved edit".
+  const draft = () => signatureDrafts()[props.link.id] ?? null;
+  const setDraft = (html: string | null) =>
+    setSignatureDrafts((prev) => {
+      if (html === null) {
+        const next = { ...prev };
+        delete next[props.link.id];
+        return next;
+      }
+      return { ...prev, [props.link.id]: html };
+    });
+
+  const persisted = () => signature() ?? '';
+  const isDirty = () => draft() !== null && draft() !== persisted();
+  // Enabled when there's a saved signature or unsaved draft text to clear — so
+  // "Remove" stays available even after the user manually empties the editor.
+  const hasContent = () =>
+    persisted().length > 0 || (draft()?.length ?? 0) > 0;
+
+  const updateSettings = useUpdateEmailSettingsMutation();
+  // Imperative handle to the editor, so Save/Remove sync its content directly
+  // (the reactive `value` path alone didn't reliably clear the box on Remove).
+  let editorApi: { setContent: (html: string) => void } | undefined;
+
+  // Save failure shown inline below the buttons rather than as a toast — the
+  // "images couldn't be loaded, re-add them" message is too long for a toast.
+  // Cleared when the user edits, starts a new save, or removes the signature.
+  const [saveError, setSaveError] = createSignal<string | null>(null);
+
+  const saveSignature = () => {
+    const next = draft();
+    if (next === null) return;
+    setSaveError(null);
+    updateSettings.mutate(
+      { linkId: props.link.id, settings: { signature: next } },
+      {
+        onSuccess: (data) => {
+          setDraft(null);
+          editorApi?.setContent(data.settings.signature ?? '');
+          toast.success('Signature saved');
+        },
+        // The backend rejects the whole patch (HTTP 422, nothing persisted) when
+        // a signature has images that won't render for recipients — e.g. pasted
+        // from another webmail account, so reachable only by that session. Show
+        // the (long) message inline below the buttons and keep the draft so the
+        // user can re-add those images and retry.
+        onError: (error) => setSaveError(saveSignatureErrorMessage(error)),
+      }
+    );
+  };
+
+  // Clears the stored signature. Sending an empty string is the backend's
+  // "clear" contract; the editor reseeds to empty once the cache updates.
+  const removeSignature = () => {
+    setSaveError(null);
+    updateSettings.mutate(
+      { linkId: props.link.id, settings: { signature: '' } },
+      {
+        onSuccess: () => {
+          setDraft(null);
+          editorApi?.setContent('');
+          toast.success('Signature removed');
+        },
+        onError: () =>
+          toast.failure('Failed to remove signature. Please try again.'),
+      }
+    );
+  };
+
+  const setOnRepliesForwards = (checked: boolean) => {
+    updateSettings.mutate(
+      {
+        linkId: props.link.id,
+        settings: { signature_on_replies_forwards: checked },
+      },
+      { onError: () => toast.failure('Failed to update setting.') }
+    );
+  };
+
+  return (
+    <div class="flex flex-col gap-3 rounded-xl border border-edge-muted p-3">
+      <Suspense
+        fallback={
+          <div class="h-44 animate-pulse rounded-lg border border-edge-muted" />
+        }
+      >
+        <SignatureEditor
+          value={draft() ?? persisted()}
+          onInput={(html) => {
+            setDraft(html);
+            setSaveError(null);
+          }}
+          onReady={(api) => {
+            editorApi = api;
+          }}
+        />
+      </Suspense>
+      <div class="flex items-center justify-between gap-3">
+        <ToggleSwitch
+          checked={props.link.settings.signature_on_replies_forwards ?? false}
+          onChange={setOnRepliesForwards}
+          label={
+            <span class="text-sm text-ink-muted">Add to replies & forwards</span>
+          }
+        />
+        <div class="flex items-center gap-2">
+          <Button
+            variant="base"
+            size="sm"
+            depth={3}
+            disabled={!hasContent() || updateSettings.isPending}
+            onClick={removeSignature}
+          >
+            Remove
+          </Button>
+          <Button
+            variant="active"
+            size="sm"
+            depth={3}
+            disabled={!isDirty() || updateSettings.isPending}
+            onClick={saveSignature}
+          >
+            Save
+          </Button>
+        </div>
+      </div>
+      <Show when={saveError()}>
+        {(msg) => <p class="text-right text-sm text-failure-ink">{msg()}</p>}
+      </Show>
+    </div>
+  );
+}

--- a/js/app/packages/app/component/settings/signatureImageResizer.ts
+++ b/js/app/packages/app/component/settings/signatureImageResizer.ts
@@ -87,11 +87,18 @@ export function setupImageResizer(quill: Quill): () => void {
     positionOverlay();
   };
 
-  const onPointerUp = (e: PointerEvent) => {
+  // Ends a drag from pointerup, or from pointercancel / lostpointercapture so an
+  // interrupted gesture can't leave the overlay stuck in `dragging`. The current
+  // width is already on the <img>, so commit it to the model either way.
+  const endDrag = (e: PointerEvent) => {
     if (!dragging) return;
     dragging = false;
     overlay.classList.remove('dragging');
-    handle.releasePointerCapture(e.pointerId);
+    try {
+      handle.releasePointerCapture(e.pointerId);
+    } catch {
+      // Capture may already be gone (e.g. pointercancel) — nothing to release.
+    }
     if (!activeImg) return;
     const width = activeImg.getAttribute('width');
     const blot = Quill.find(activeImg) as Parchment.Blot | null;
@@ -109,7 +116,9 @@ export function setupImageResizer(quill: Quill): () => void {
   quill.on('text-change', syncOrHide);
   handle.addEventListener('pointerdown', onPointerDown);
   handle.addEventListener('pointermove', onPointerMove);
-  handle.addEventListener('pointerup', onPointerUp);
+  handle.addEventListener('pointerup', endDrag);
+  handle.addEventListener('pointercancel', endDrag);
+  handle.addEventListener('lostpointercapture', endDrag);
 
   return () => {
     root.removeEventListener('click', onClick);

--- a/js/app/packages/app/component/settings/signatureImageResizer.ts
+++ b/js/app/packages/app/component/settings/signatureImageResizer.ts
@@ -125,6 +125,11 @@ export function setupImageResizer(quill: Quill): () => void {
     root.removeEventListener('scroll', syncOrHide);
     window.removeEventListener('resize', syncOrHide);
     quill.off('text-change', syncOrHide);
+    handle.removeEventListener('pointerdown', onPointerDown);
+    handle.removeEventListener('pointermove', onPointerMove);
+    handle.removeEventListener('pointerup', endDrag);
+    handle.removeEventListener('pointercancel', endDrag);
+    handle.removeEventListener('lostpointercapture', endDrag);
     overlay.remove();
   };
 }

--- a/js/app/packages/app/component/settings/signatureImageResizer.ts
+++ b/js/app/packages/app/component/settings/signatureImageResizer.ts
@@ -1,0 +1,121 @@
+import Quill, { type Parchment } from 'quill';
+
+const MIN_WIDTH = 24;
+
+/**
+ * Adds click-to-select + drag-to-resize for images in a Quill editor: click an
+ * image to show a corner handle, drag it to set the width (aspect ratio follows,
+ * since only `width` is set). The width is persisted into Quill's model as the
+ * <img>'s `width` attribute — which the signature sanitizer keeps — and the
+ * sync fires text-change so the form marks dirty. Returns a cleanup function.
+ *
+ * The overlay lives in `.ql-container` (position: relative) and is repositioned
+ * manually on scroll/resize/edit, since it isn't inside the scrolling editor.
+ */
+export function setupImageResizer(quill: Quill): () => void {
+  const root = quill.root;
+  const container = quill.container;
+
+  const overlay = document.createElement('div');
+  overlay.className = 'ql-image-resizer';
+  const handle = document.createElement('span');
+  handle.className = 'ql-image-resizer-handle';
+  overlay.appendChild(handle);
+  container.appendChild(overlay);
+
+  let activeImg: HTMLImageElement | null = null;
+  let dragging = false;
+  let startX = 0;
+  let startWidth = 0;
+
+  const positionOverlay = () => {
+    if (!activeImg) return;
+    const img = activeImg.getBoundingClientRect();
+    const base = container.getBoundingClientRect();
+    overlay.style.left = `${img.left - base.left}px`;
+    overlay.style.top = `${img.top - base.top}px`;
+    overlay.style.width = `${img.width}px`;
+    overlay.style.height = `${img.height}px`;
+  };
+
+  const show = (img: HTMLImageElement) => {
+    activeImg = img;
+    overlay.style.display = 'block';
+    positionOverlay();
+  };
+
+  const hide = () => {
+    activeImg = null;
+    overlay.style.display = 'none';
+  };
+
+  const onClick = (e: MouseEvent) => {
+    const target = e.target;
+    if (target instanceof HTMLImageElement && root.contains(target)) {
+      show(target);
+    } else if (target instanceof Node && !overlay.contains(target)) {
+      hide();
+    }
+  };
+
+  // Keep the overlay aligned as content scrolls/reflows; drop it if the image
+  // it tracks was deleted.
+  const syncOrHide = () => {
+    if (!activeImg) return;
+    if (root.contains(activeImg)) positionOverlay();
+    else hide();
+  };
+
+  const onPointerDown = (e: PointerEvent) => {
+    if (!activeImg) return;
+    e.preventDefault();
+    dragging = true;
+    overlay.classList.add('dragging');
+    startX = e.clientX;
+    startWidth = activeImg.getBoundingClientRect().width;
+    handle.setPointerCapture(e.pointerId);
+  };
+
+  const onPointerMove = (e: PointerEvent) => {
+    if (!dragging || !activeImg) return;
+    const width = Math.round(
+      Math.max(MIN_WIDTH, startWidth + e.clientX - startX)
+    );
+    // width only -> height auto-follows, preserving aspect ratio.
+    activeImg.setAttribute('width', String(width));
+    activeImg.removeAttribute('height');
+    positionOverlay();
+  };
+
+  const onPointerUp = (e: PointerEvent) => {
+    if (!dragging) return;
+    dragging = false;
+    overlay.classList.remove('dragging');
+    handle.releasePointerCapture(e.pointerId);
+    if (!activeImg) return;
+    const width = activeImg.getAttribute('width');
+    const blot = Quill.find(activeImg) as Parchment.Blot | null;
+    if (blot && width) {
+      // Sync into the model so the width lands in the saved HTML and marks the
+      // form dirty (formatText emits text-change).
+      quill.formatText(quill.getIndex(blot), 1, 'width', width, 'user');
+    }
+    positionOverlay();
+  };
+
+  root.addEventListener('click', onClick);
+  root.addEventListener('scroll', syncOrHide);
+  window.addEventListener('resize', syncOrHide);
+  quill.on('text-change', syncOrHide);
+  handle.addEventListener('pointerdown', onPointerDown);
+  handle.addEventListener('pointermove', onPointerMove);
+  handle.addEventListener('pointerup', onPointerUp);
+
+  return () => {
+    root.removeEventListener('click', onClick);
+    root.removeEventListener('scroll', syncOrHide);
+    window.removeEventListener('resize', syncOrHide);
+    quill.off('text-change', syncOrHide);
+    overlay.remove();
+  };
+}

--- a/js/app/packages/block-email/component/BaseInput.tsx
+++ b/js/app/packages/block-email/component/BaseInput.tsx
@@ -25,7 +25,10 @@ import type { UserMentionRecord } from '@core/component/LexicalMarkdown/utils/me
 
 import { RecipientSelector } from '@core/component/RecipientSelector';
 import { toast } from '@core/component/Toast/Toast';
-import { ENABLE_EMAIL_SCHEDULED_SEND } from '@core/constant/featureFlags';
+import {
+  ENABLE_EMAIL_SCHEDULED_SEND,
+  ENABLE_EMAIL_SIGNATURES,
+} from '@core/constant/featureFlags';
 import { useEmail } from '@core/context/user';
 import { fileFolderDrop } from '@core/directive/fileFolderDrop';
 import { fileSelector } from '@core/directive/fileSelector';
@@ -70,6 +73,7 @@ import {
 import { emailKeys } from '@queries/email/keys';
 import {
   useEmailLinksQuery,
+  useEmailSignature,
   useNonPrimaryEmailLinkIdHeader,
   usePrimaryEmailLinkId,
 } from '@queries/email/link';
@@ -129,6 +133,7 @@ import {
 } from '../util/prepareEmailBody';
 import { convertEmailRecipientToContactInfo } from '../util/recipientConversion';
 import { getReplyTypeFromDraft } from '../util/replyType';
+import { SignaturePreview } from './compose/SignaturePreview';
 import {
   type EmailRecipient,
   markThreadDraftSaved,
@@ -450,6 +455,27 @@ export function BaseInput(props: {
   const activeInboxEmail = () =>
     emailLinksQuery.data?.links.find((l) => l.id === activeLinkId())
       ?.email_address ?? userEmail();
+
+  // The full Link object for the sending inbox (for its saved signature and the
+  // "add to replies & forwards" preference).
+  const sendingLink = createMemo(() =>
+    emailLinksQuery.data?.links.find((l) => l.id === activeLinkId())
+  );
+  const signature = useEmailSignature(activeLinkId);
+  // Whether this reply includes the signature. Defaults on, reset per reply,
+  // and dismissable via the preview ✕.
+  const [includeSignature, setIncludeSignature] = createSignal(true);
+  // Signature HTML for the preview (and whether to show it): only for
+  // replies/forwards, when the inbox's "add to replies & forwards" setting is on
+  // and the user hasn't dismissed it. The backend does the actual injection on
+  // send — this just mirrors when that will happen.
+  const replySignatureHtml = (): string | undefined =>
+    ENABLE_EMAIL_SIGNATURES &&
+    props.replyingTo() &&
+    includeSignature() &&
+    sendingLink()?.settings.signature_on_replies_forwards
+      ? signature()
+      : undefined;
 
   const [bodyMacro, setBodyMacro] = createSignal<string>('');
   const [expandedRecipientsRef, setExpandedRecipientsRef] =
@@ -834,6 +860,8 @@ export function BaseInput(props: {
       () => {
         if (draftSaveTimer) window.clearTimeout(draftSaveTimer);
         pendingSend = false;
+        // Each new reply starts with the signature included again.
+        setIncludeSignature(true);
       },
       { defer: true }
     )
@@ -1046,6 +1074,9 @@ export function BaseInput(props: {
         subject: form().subject(),
         thread_db_id: currentThread?.db_id,
         to,
+        // Replies/forwards follow the inbox's "add to replies & forwards"
+        // setting on the backend; only signal an explicit per-reply dismiss.
+        include_signature: includeSignature() ? undefined : false,
       },
       linkId: toHeaderLinkId(linkId),
     });
@@ -1765,6 +1796,14 @@ export function BaseInput(props: {
             </For>
           </div>
         </div>
+        <Show when={replySignatureHtml()}>
+          {(html) => (
+            <SignaturePreview
+              html={html()}
+              onDismiss={() => setIncludeSignature(false)}
+            />
+          )}
+        </Show>
         <div class="flex flex-row w-full h-9 justify-between items-end px-2 pb-2 pt-0.5 space-x-2">
           <div class="flex flex-row items-center gap-1">
             <div class="relative flex">

--- a/js/app/packages/block-email/component/EmailMessageBody.tsx
+++ b/js/app/packages/block-email/component/EmailMessageBody.tsx
@@ -131,7 +131,11 @@ export function EmailMessageBody(props: EmailMessageBodyProps) {
       isPersonal() && !isMacroSender()
         ? `*:not(code):not(pre):not(code *):not(pre *):not([data-macro-btn]){font-family: system-ui, sans-serif !important; font-size: inherit !important; line-height: 1.5 !important;}`
         : '';
-    styleEl.textContent = `img{display: var(--macro-email-img-display, initial); max-width: 100% !important; height: auto !important;}${fontOverride}`;
+    // Let long &nbsp;-joined signature lines wrap (overflow-wrap is inherited)
+    // and fixed-width tables scroll, so a wide signature doesn't trip the
+    // fit-to-width zoom below and shrink the whole message.
+    const signatureContain = `.macro-email-signature{max-width:100%;overflow-x:auto;overflow-wrap:anywhere;}`;
+    styleEl.textContent = `img{display: var(--macro-email-img-display, initial); max-width: 100% !important; height: auto !important;}${signatureContain}${fontOverride}`;
     shadow.appendChild(styleEl);
     const messageDiv = document.createElement('div');
     messageDiv.innerHTML = source()?.mainContent ?? '';

--- a/js/app/packages/block-email/component/compose/Compose.tsx
+++ b/js/app/packages/block-email/component/compose/Compose.tsx
@@ -25,6 +25,7 @@ import { convertEmailRecipientToContactInfo } from '@block-email/util/recipientC
 import { useHasPaidAccess } from '@core/auth';
 import { EmailPermissionsBanner } from '@core/component/EmailPermissionsBanner';
 import { toast } from '@core/component/Toast/Toast';
+import { ENABLE_EMAIL_SIGNATURES } from '@core/constant/featureFlags';
 import { isMobile } from '@core/mobile/isMobile';
 import { WrapUnlessMobile } from '@core/mobile/WrapUnlessMobile';
 import { useCombinedRecipients } from '@core/signal/useCombinedRecipient';
@@ -54,6 +55,7 @@ import {
 import { emailKeys } from '@queries/email/keys';
 import {
   useEmailLinksQuery,
+  useEmailSignature,
   useNonPrimaryEmailLinkIdHeader,
   usePrimaryEmailLinkId,
 } from '@queries/email/link';
@@ -83,6 +85,7 @@ import {
 } from './ComposeContext';
 import { ComposeLayout } from './ComposeLayout';
 import { EmailComposeToolbar } from './ComposeToolbar';
+import { SignaturePreview } from './SignaturePreview';
 
 const DRAFT_DEBOUNCE_MS = 500;
 
@@ -144,6 +147,13 @@ export function EmailCompose(props: EmailComposeProps) {
   // Scope writes to the inbox this compose sends from (its X-Email-Link-Id
   // header), so a non-primary "from" inbox drafts/sends from the right account.
   const headerLinkId = () => toHeaderLinkId(link()?.id);
+
+  // The sending inbox's saved signature (empty for inboxes without one). New
+  // emails include it by default; the preview's dismiss drops it for this one
+  // message. The backend injects it on send (see include_signature below); the
+  // FE only renders the preview and signals an explicit dismiss.
+  const signature = useEmailSignature(() => link()?.id);
+  const [includeSignature, setIncludeSignature] = createSignal(true);
 
   const hasLinkError = createMemo(() => {
     if (emailLinksQuery.isPending) return false;
@@ -486,7 +496,7 @@ export function EmailCompose(props: EmailComposeProps) {
       !hasPaidAccess() ? MACRO_EMAIL_SIGNATURE : undefined
     );
 
-    const prepared = prepareEmailBody(currentEditor, undefined);
+    const prepared = prepareEmailBody(currentEditor);
     if (!prepared) {
       cleanupWatermark();
       return;
@@ -510,6 +520,9 @@ export function EmailCompose(props: EmailComposeProps) {
         body_html: prepared.bodyHtml,
         body_macro: bodyMacro,
         db_id: currentDraftID(),
+        // Backend includes the signature by default for new emails; only signal
+        // an explicit dismiss. Omitting it falls through to the backend default.
+        include_signature: includeSignature() ? undefined : false,
       },
       linkId: headerLinkId(),
     });
@@ -730,6 +743,20 @@ export function EmailCompose(props: EmailComposeProps) {
       void executeSaveDraft();
     },
     hasPaidAccess,
+
+    // Read-only preview of the signature appended on send, with a per-message
+    // dismiss. Shown only when the sending inbox has a signature and it hasn't
+    // been dismissed.
+    signaturePreview: () => (
+      <Show when={ENABLE_EMAIL_SIGNATURES && includeSignature() && signature()}>
+        {(html) => (
+          <SignaturePreview
+            html={html()}
+            onDismiss={() => setIncludeSignature(false)}
+          />
+        )}
+      </Show>
+    ),
   };
 
   const panel = useContext(SplitPanelContext);

--- a/js/app/packages/block-email/component/compose/ComposeBody.tsx
+++ b/js/app/packages/block-email/component/compose/ComposeBody.tsx
@@ -196,6 +196,7 @@ export function ComposeBody(props: {
             />
           </Scroll>
         </div>
+        {ctx.signaturePreview?.()}
         <div class="flex flex-wrap items-center gap-2">
           <For each={ctx.attachments()}>
             {(attachment) => <AttachmentItem attachment={attachment} />}

--- a/js/app/packages/block-email/component/compose/ComposeContext.ts
+++ b/js/app/packages/block-email/component/compose/ComposeContext.ts
@@ -77,6 +77,10 @@ export interface ComposeContextValue {
 
   // Toolbar slot — allows orchestrators to provide a custom toolbar
   toolbar?: () => JSX.Element;
+
+  // Signature preview slot — rendered below the body. Only the new-email
+  // composer provides this; reply/forward composers omit it.
+  signaturePreview?: () => JSX.Element;
 }
 
 const ComposeContext = createContext<ComposeContextValue>();

--- a/js/app/packages/block-email/component/compose/ComposeContext.ts
+++ b/js/app/packages/block-email/component/compose/ComposeContext.ts
@@ -78,8 +78,9 @@ export interface ComposeContextValue {
   // Toolbar slot — allows orchestrators to provide a custom toolbar
   toolbar?: () => JSX.Element;
 
-  // Signature preview slot — rendered below the body. Only the new-email
-  // composer provides this; reply/forward composers omit it.
+  // Signature preview slot — rendered below the body. Provided by the new-email
+  // composer and the AI chat composer (ChatCompose); the reply/forward input
+  // renders its own preview and omits this slot.
   signaturePreview?: () => JSX.Element;
 }
 

--- a/js/app/packages/block-email/component/compose/SignaturePreview.tsx
+++ b/js/app/packages/block-email/component/compose/SignaturePreview.tsx
@@ -23,6 +23,12 @@ const SHADOW_STYLE = `
  * this one message (the parent owns the include/exclude state).
  */
 export function SignaturePreview(props: {
+  /**
+   * Server-sanitized signature HTML. Inserted via innerHTML (the shadow root
+   * scopes CSS/DOM but does NOT block scripts), so callers MUST pass sanitized
+   * HTML — never raw user input. Today the only source is the saved inbox
+   * setting, sanitized server-side.
+   */
   html: string;
   onDismiss: () => void;
 }) {

--- a/js/app/packages/block-email/component/compose/SignaturePreview.tsx
+++ b/js/app/packages/block-email/component/compose/SignaturePreview.tsx
@@ -1,0 +1,85 @@
+import InfoIcon from '@phosphor/info.svg';
+import CaretDownIcon from '@phosphor-icons/core/regular/caret-down.svg?component-solid';
+import XIcon from '@phosphor-icons/core/regular/x.svg?component-solid';
+import { Tooltip } from '@ui';
+import { createEffect, createSignal } from 'solid-js';
+
+// Rendered inside a shadow root so the signature's structural markup (lists,
+// headings, bold) keeps its default styling instead of being flattened by the
+// app's global CSS reset — the same isolation EmailMessageBody uses for received
+// mail. CSS custom properties still pierce the boundary, so --color-ink themes
+// any text the signature didn't color itself.
+const SHADOW_STYLE = `
+  :host { color: var(--color-ink); font-family: inherit; }
+  img { max-width: 100%; height: auto; }
+  p { margin: 0; }
+  a { color: inherit; }
+`;
+
+/**
+ * Read-only preview of the signature that will be appended to the email on send.
+ * The signature is already sanitized server-side; it's rendered as-is so the
+ * preview matches what the recipient receives. The dismiss button drops it from
+ * this one message (the parent owns the include/exclude state).
+ */
+export function SignaturePreview(props: {
+  html: string;
+  onDismiss: () => void;
+}) {
+  let mountEl!: HTMLDivElement;
+  // Always starts collapsed to just the bar; the user expands to preview it.
+  const [expanded, setExpanded] = createSignal(false);
+
+  createEffect(() => {
+    const html = props.html;
+    // Lazily attach (idempotent): a shadow root can only be attached once.
+    const root = mountEl.shadowRoot ?? mountEl.attachShadow({ mode: 'open' });
+    root.innerHTML = `<style>${SHADOW_STYLE}</style>${html}`;
+    for (const a of root.querySelectorAll('a[href]')) {
+      a.setAttribute('target', '_blank');
+      a.setAttribute('rel', 'noopener noreferrer');
+    }
+  });
+
+  return (
+    <div class="mt-2 rounded-lg border border-edge-muted">
+      <div
+        class="flex items-center justify-between gap-2 px-3 py-1.5"
+        classList={{ 'border-b border-edge-muted': expanded() }}
+      >
+        <div class="flex items-center gap-1.5">
+          <button
+            type="button"
+            class="flex items-center gap-1.5 text-xs font-medium text-ink-muted hover:text-ink"
+            aria-expanded={expanded()}
+            onClick={() => setExpanded((v) => !v)}
+          >
+            <CaretDownIcon
+              class="size-3 transition-transform"
+              classList={{ '-rotate-90': !expanded() }}
+            />
+            Signature
+          </button>
+          <Tooltip label="Edit your signature in Settings." as="span">
+            <InfoIcon class="size-3.5 text-ink-muted" />
+          </Tooltip>
+        </div>
+        <Tooltip label="Don't include signature" as="span">
+          <button
+            type="button"
+            class="-m-1 rounded-md p-1 text-ink-muted hover:bg-hover hover:text-ink"
+            aria-label="Don't include signature"
+            onClick={() => props.onDismiss()}
+          >
+            <XIcon class="size-3.5" />
+          </button>
+        </Tooltip>
+      </div>
+      <div
+        ref={mountEl}
+        class="px-3 py-2 text-sm"
+        classList={{ hidden: !expanded() }}
+      />
+    </div>
+  );
+}

--- a/js/app/packages/block-email/component/compose/SignaturePreview.tsx
+++ b/js/app/packages/block-email/component/compose/SignaturePreview.tsx
@@ -66,7 +66,7 @@ export function SignaturePreview(props: {
             />
             Signature
           </button>
-          <Tooltip label="Edit your signature in Settings." as="span">
+          <Tooltip label="Edit your signature in Settings -> Connected accounts." as="span">
             <InfoIcon class="size-3.5 text-ink-muted" />
           </Tooltip>
         </div>

--- a/js/app/packages/block-email/component/compose/SignaturePreview.tsx
+++ b/js/app/packages/block-email/component/compose/SignaturePreview.tsx
@@ -66,7 +66,10 @@ export function SignaturePreview(props: {
             />
             Signature
           </button>
-          <Tooltip label="Edit your signature in Settings -> Connected accounts." as="span">
+          <Tooltip
+            label="Edit your signature in Settings -> Connected accounts."
+            as="span"
+          >
             <InfoIcon class="size-3.5 text-ink-muted" />
           </Tooltip>
         </div>

--- a/js/app/packages/core/component/AI/component/tool/email/ChatCompose.tsx
+++ b/js/app/packages/core/component/AI/component/tool/email/ChatCompose.tsx
@@ -7,6 +7,7 @@ import {
   ComposeProvider,
   type ComposeValidationError,
 } from '@block-email/component/compose/ComposeContext';
+import { SignaturePreview } from '@block-email/component/compose/SignaturePreview';
 import type { DraftFormAttachment } from '@block-email/component/createEmailFormState';
 import type { EmailRecipient } from '@block-email/component/EmailContext';
 import { decodeBase64Utf8 } from '@block-email/util/decodeBase64';
@@ -15,15 +16,16 @@ import { convertContactInfoToEmailRecipient } from '@block-email/util/recipientC
 import { useChatContext } from '@core/component/AI/context';
 import type { AssistantMessagePart } from '@core/component/AI/types';
 import { toast } from '@core/component/Toast/Toast';
+import { ENABLE_EMAIL_SIGNATURES } from '@core/constant/featureFlags';
 
 import { useChatQuery } from '@queries/chat';
-import { useEmailLinksQuery } from '@queries/email/link';
+import { useEmailLinksQuery, useEmailSignature } from '@queries/email/link';
 import { cognitionApiServiceClient } from '@service-cognition/client';
 import type { SendEmail } from '@service-cognition/generated/tools/types';
 import { debounce } from '@solid-primitives/scheduled';
 import { cn } from '@ui';
 import type { LexicalEditor } from 'lexical';
-import { createSignal, type JSX, Show } from 'solid-js';
+import { createMemo, createSignal, type JSX, Show } from 'solid-js';
 
 type ComposeToolProps = {
   chatId: string;
@@ -39,6 +41,7 @@ type ComposeToolProps = {
 type SendEmailSnapshot = {
   bcc: Array<{ email: string; name: string | null }>;
   cc: Array<{ email: string; name: string | null }>;
+  includeSignature: boolean | null;
   replyingToId: string | null;
   subject: string;
   to: Array<{ email: string; name: string | null }>;
@@ -77,6 +80,7 @@ function createSendEmailSnapshot(data: SendEmail): SendEmailSnapshot {
     })),
     subject: data.subject ?? '',
     replyingToId: data.replyingToId ?? null,
+    includeSignature: data.includeSignature ?? null,
   };
 }
 
@@ -162,9 +166,31 @@ export function ComposeTool(props: ComposeToolProps) {
     props.readOnly === true ||
     props.streamLocked === true;
   const emailLinksQuery = useEmailLinksQuery();
-  const fromAddress = () => {
-    const links = emailLinksQuery.data?.links;
-    return links && links.length > 0 ? links[0].email_address : undefined;
+  // The inbox this card sends from — always the first linked inbox (shown as
+  // "from"); the backend resolves the same default at send time.
+  const sendingLink = createMemo(() => emailLinksQuery.data?.links?.[0]);
+  const fromAddress = () => sendingLink()?.email_address;
+  const signature = useEmailSignature(() => sendingLink()?.id);
+  // Whether this email includes the signature. Defaults on; the preview's ✕
+  // drops it for this one message. Mirrors the normal composer.
+  const [includeSignature, setIncludeSignature] = createSignal(true);
+  const isReplyOrForward = () => Boolean(props.initialData.replyingToId);
+  // Signature to preview (and inject on send): a new compose always shows it; a
+  // reply/forward only when the inbox's "add to replies & forwards" setting is
+  // on. Hidden once dismissed and in the read-only (sent) state. Shown during
+  // streaming too — the composer's overlay blocks interaction until it ends.
+  const previewSignatureHtml = (): string | undefined => {
+    if (!ENABLE_EMAIL_SIGNATURES) return undefined;
+    if (props.readOnly) return undefined;
+    if (!includeSignature()) return undefined;
+    const sig = signature();
+    if (!sig) return undefined;
+    if (isReplyOrForward()) {
+      return sendingLink()?.settings.signature_on_replies_forwards
+        ? sig
+        : undefined;
+    }
+    return sig;
   };
 
   const [recipients, setRecipients] = createSignal({
@@ -198,6 +224,8 @@ export function ComposeTool(props: ComposeToolProps) {
       subject: subject(),
       body: prepareEmailBody(editor())?.bodyHtml ?? '',
       replyingToId: props.initialData.replyingToId,
+      // Omit to use the backend default policy; false only when dismissed.
+      includeSignature: includeSignature() ? undefined : false,
     };
   }
 
@@ -369,6 +397,21 @@ export function ComposeTool(props: ComposeToolProps) {
     validationError: (type) => validationErrors().find((e) => e.type === type),
     fromAddress,
     recipients,
+    // Read-only preview of the signature the backend appends on send, with a ✕
+    // to drop it for this one email (persisted via the userEdited update).
+    signaturePreview: () => (
+      <Show when={previewSignatureHtml()}>
+        {(html) => (
+          <SignaturePreview
+            html={html()}
+            onDismiss={() => {
+              setIncludeSignature(false);
+              scheduleUpdate();
+            }}
+          />
+        )}
+      </Show>
+    ),
   };
 
   return (

--- a/js/app/packages/core/component/AI/component/tool/email/ChatCompose.tsx
+++ b/js/app/packages/core/component/AI/component/tool/email/ChatCompose.tsx
@@ -173,7 +173,11 @@ export function ComposeTool(props: ComposeToolProps) {
   const signature = useEmailSignature(() => sendingLink()?.id);
   // Whether this email includes the signature. Defaults on; the preview's ✕
   // drops it for this one message. Mirrors the normal composer.
-  const [includeSignature, setIncludeSignature] = createSignal(true);
+  // Initialize from the persisted tool args so a dismiss survives re-render /
+  // reload; only an explicit false counts as dismissed.
+  const [includeSignature, setIncludeSignature] = createSignal(
+    props.initialData.includeSignature !== false
+  );
   const isReplyOrForward = () => Boolean(props.initialData.replyingToId);
   // Signature to preview (and inject on send): a new compose always shows it; a
   // reply/forward only when the inbox's "add to replies & forwards" setting is

--- a/js/app/packages/core/constant/featureFlags.ts
+++ b/js/app/packages/core/constant/featureFlags.ts
@@ -122,6 +122,14 @@ export const ENABLE_MARKDOWN_LIVE_COLLABORATION = resolveFeatureFlag(
 
 export const ENABLE_EMAIL = resolveFeatureFlag('ENABLE_EMAIL', true);
 
+// Email signatures: the settings editor, the compose / reply / AI-chat signature
+// previews, and the per-message include toggle. Dev/local only for now; override
+// with VITE_ENABLE_EMAIL_SIGNATURES.
+export const ENABLE_EMAIL_SIGNATURES = resolveFeatureFlag(
+  'ENABLE_EMAIL_SIGNATURES',
+  DEV_MODE_ENV
+);
+
 // CRM companies & contacts frontend: the Companies view + sidebar entry, the
 // company/contact detail blocks, CRM mentions / quick-access, and CRM rows in
 // global search. override with VITE_ENABLE_CRM.

--- a/js/app/packages/core/email/parse-email-html.ts
+++ b/js/app/packages/core/email/parse-email-html.ts
@@ -101,9 +101,15 @@ export function trimTrailingBrs(element: Element) {
   return element;
 }
 
+// Splits a trailing signature out of the body so the renderer can collapse it
+// behind the "…" expander. Recognizes Gmail's `.gmail_signature` as well as the
+// `.macro-email-signature` wrapper the backend injects into outgoing mail
+// (our own signatures aren't otherwise tagged as Gmail's).
 function parseGmailSignature(htmlElement: Element) {
   const signaturePrefix = htmlElement.querySelector('.gmail_signature_prefix');
-  const signatureElement = htmlElement.querySelector('.gmail_signature');
+  const signatureElement = htmlElement.querySelector(
+    '.gmail_signature, .macro-email-signature'
+  );
 
   if (signatureElement) {
     const signature = signatureElement?.outerHTML;

--- a/js/app/packages/core/email/tests/parse-email-html.test.ts
+++ b/js/app/packages/core/email/tests/parse-email-html.test.ts
@@ -82,6 +82,16 @@ describe('parseEmailContent', () => {
     expect(result.signature).toBeNull();
   });
 
+  it('extracts a Macro signature appended to outgoing mail', () => {
+    const html = `
+      <p>Hello</p>
+      <div class="macro-email-signature">Jane Doe</div>
+    `;
+    const result = parseEmailContent(html, true, false);
+    expect(result.mainContent).not.toContain('macro-email-signature');
+    expect(result.signature).toContain('Jane Doe');
+  });
+
   it('preserves style tags from head', () => {
     const html = `
       <!DOCTYPE html>

--- a/js/app/packages/queries/email/link.ts
+++ b/js/app/packages/queries/email/link.ts
@@ -6,7 +6,7 @@ import { invalidateAllSoup } from '@queries/soup/normalized-cache';
 import { emailClient } from '@service-email/client';
 import type { ListLinksResponse } from '@service-email/generated/schemas';
 import { useMutation, useQuery } from '@tanstack/solid-query';
-import { createMemo } from 'solid-js';
+import { type Accessor, createMemo } from 'solid-js';
 import { type MutationCallbacks, withCallbacks } from '../utils';
 import { emailKeys } from './keys';
 
@@ -58,6 +58,26 @@ export function usePrimaryEmailLinkId() {
     return linksQuery.data?.links.find(
       (link) => link.is_primary && link.macro_id === uid
     )?.id;
+  });
+}
+
+/**
+ * The HTML signature configured for a given inbox, read straight from the links
+ * query (`GET /email/links` → `link.settings.signature`) — no extra request.
+ * `undefined` until links load, when no link matches, or when the inbox has no
+ * signature set (the backend's `null` is normalized to `undefined`).
+ */
+export function useEmailSignature(
+  linkId: Accessor<string | undefined>
+): Accessor<string | undefined> {
+  const linksQuery = useEmailLinksQuery();
+  return createMemo(() => {
+    const id = linkId();
+    if (!id) return undefined;
+    return (
+      linksQuery.data?.links.find((link) => link.id === id)?.settings
+        .signature ?? undefined
+    );
   });
 }
 

--- a/js/app/packages/queries/email/settings.ts
+++ b/js/app/packages/queries/email/settings.ts
@@ -1,0 +1,61 @@
+import { throwOnErr } from '@core/util/result';
+import { queryClient } from '@queries/client';
+import { emailClient } from '@service-email/client';
+import type {
+  ListLinksResponse,
+  PatchSettingsResponse,
+  Settings,
+} from '@service-email/generated/schemas';
+import { useMutation } from '@tanstack/solid-query';
+import { type MutationCallbacks, withCallbacks } from '../utils';
+import { emailKeys } from './keys';
+import { useNonPrimaryEmailLinkIdHeader } from './link';
+
+type UpdateSettingsVars = { linkId: string; settings: Settings };
+
+type UpdateSettingsCallbacks = MutationCallbacks<
+  PatchSettingsResponse,
+  Error,
+  UpdateSettingsVars
+>;
+
+/**
+ * Patches one inbox's email settings (e.g. the signature). Scopes the request
+ * to `linkId` via the `X-Email-Link-Id` header, then writes the server's
+ * canonical (sanitized) settings back onto that link in the cached links list —
+ * so `useEmailSignature` and the editor reflect exactly what was stored, with no
+ * refetch. `settings` is a partial patch: omitted fields are left unchanged.
+ */
+export function useUpdateEmailSettingsMutation(
+  callbacks?: UpdateSettingsCallbacks
+) {
+  const toHeaderLinkId = useNonPrimaryEmailLinkIdHeader();
+  return useMutation(() => ({
+    mutationFn: async ({ linkId, settings }: UpdateSettingsVars) =>
+      throwOnErr(() =>
+        emailClient.patchSettings({ settings }, toHeaderLinkId(linkId))
+      ),
+
+    ...withCallbacks<PatchSettingsResponse, Error, UpdateSettingsVars>(
+      {
+        onSuccess: (result, { linkId }) => {
+          queryClient.setQueryData<ListLinksResponse>(
+            emailKeys.links.queryKey,
+            (old) =>
+              old
+                ? {
+                    ...old,
+                    links: old.links.map((link) =>
+                      link.id === linkId
+                        ? { ...link, settings: result.settings }
+                        : link
+                    ),
+                  }
+                : old
+          );
+        },
+      },
+      callbacks
+    ),
+  }));
+}

--- a/js/app/packages/queries/email/settings.ts
+++ b/js/app/packages/queries/email/settings.ts
@@ -38,18 +38,30 @@ export function useUpdateEmailSettingsMutation(
 
     ...withCallbacks<PatchSettingsResponse, Error, UpdateSettingsVars>(
       {
-        onSuccess: (result, { linkId }) => {
+        onSuccess: (result, { linkId, settings }) => {
           queryClient.setQueryData<ListLinksResponse>(
             emailKeys.links.queryKey,
             (old) =>
               old
                 ? {
                     ...old,
-                    links: old.links.map((link) =>
-                      link.id === linkId
-                        ? { ...link, settings: result.settings }
-                        : link
-                    ),
+                    links: old.links.map((link) => {
+                      if (link.id !== linkId) return link;
+                      // Apply only the keys this PATCH changed, with the
+                      // canonical (sanitized) response values — so a concurrent
+                      // partial PATCH to another field isn't clobbered by a
+                      // stale full-settings snapshot.
+                      const changed = Object.fromEntries(
+                        Object.keys(settings).map((key) => [
+                          key,
+                          result.settings[key as keyof Settings],
+                        ])
+                      ) as Partial<Settings>;
+                      return {
+                        ...link,
+                        settings: { ...link.settings, ...changed },
+                      };
+                    }),
                   }
                 : old
           );

--- a/js/app/packages/service-clients/service-email/client.ts
+++ b/js/app/packages/service-clients/service-email/client.ts
@@ -20,6 +20,8 @@ import type {
   ListEmailFiltersResponse,
   ListLabelsResponse,
   ListLinksResponse,
+  PatchSettingsRequest,
+  PatchSettingsResponse,
   ResyncResponse,
   SendMessageRequest,
   SendMessageResponse,
@@ -69,6 +71,15 @@ function emailFetch<T extends ObjectLike = never>(
  * macro user. The caller confirms with the user, then retries with `forceShare`.
  */
 export const SHARED_INBOX_CONFLICT_CODE = 'SHARED_INBOX_CONFLICT' as const;
+
+/**
+ * Error code `patchSettings` returns (HTTP 422) when a signature has images that
+ * couldn't be fetched/rehosted and would render broken for recipients. The whole
+ * patch is rejected; the error message carries the count so the UI can prompt a
+ * re-add.
+ */
+export const SIGNATURE_IMAGES_UNRESOLVED_CODE =
+  'SIGNATURE_IMAGES_UNRESOLVED' as const;
 
 export const emailClient = {
   async init(args?: { linkId?: string; forceShare?: boolean }) {
@@ -268,6 +279,38 @@ export const emailClient = {
         method: 'GET',
       })
     ).map((result) => result);
+  },
+
+  // Patches the settings for one inbox. Scoped to `linkId` via the
+  // X-Email-Link-Id header (the backend resolves the link from it); omit for
+  // the primary inbox. Partial: fields omitted from `settings` are left as-is.
+  async patchSettings(args: PatchSettingsRequest, linkId?: string) {
+    return fetchWithToken<
+      PatchSettingsResponse,
+      typeof SIGNATURE_IMAGES_UNRESOLVED_CODE
+    >(`${emailHost}/email/settings`, {
+      method: 'PATCH',
+      body: JSON.stringify(args),
+      headers: emailLinkHeaders(linkId),
+      // The 422 body carries how many signature images couldn't be loaded;
+      // surface it as the error message so the caller can prompt a re-add.
+      // Other statuses fall back to the default HTTP_ERROR shape.
+      errorResponseHandler: async (response) => {
+        if (response.status === 422) {
+          const body = (await response.json().catch(() => null)) as {
+            unresolved_image_count?: number;
+          } | null;
+          return {
+            code: SIGNATURE_IMAGES_UNRESOLVED_CODE,
+            message: String(body?.unresolved_image_count ?? 0),
+          };
+        }
+        return {
+          code: 'HTTP_ERROR',
+          message: `HTTP error! status: ${response.status}`,
+        };
+      },
+    });
   },
 
   async deleteLink(args: { linkId: string }) {

--- a/js/bun.lock
+++ b/js/bun.lock
@@ -103,6 +103,7 @@
         "nanoid": "^3.3.7",
         "neverthrow": "^8.2.0",
         "posthog-js": "^1.387.0",
+        "quill": "^2.0.3",
         "short-uuid": "^5.2.0",
         "signature_pad": "^5.0.10",
         "solid-gesture": "^0.0.3",
@@ -1991,6 +1992,8 @@
 
     "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
 
+    "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
+
     "eventid": ["eventid@2.0.1", "", { "dependencies": { "uuid": "^8.0.0" } }, "sha512-sPNTqiMokAvV048P2c9+foqVJzk49o6d4e0D/sq5jog3pw+4kBgyR0gaM1FM7Mx6Kzd9dztesh9oYz1LWWOpzw=="],
 
     "events": ["events@3.3.0", "", {}, "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="],
@@ -2004,6 +2007,8 @@
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-diff": ["fast-diff@1.3.0", "", {}, "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw=="],
 
     "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
 
@@ -2387,13 +2392,19 @@
 
     "lodash": ["lodash@4.18.1", "", {}, "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="],
 
+    "lodash-es": ["lodash-es@4.18.1", "", {}, "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A=="],
+
     "lodash.camelcase": ["lodash.camelcase@4.3.0", "", {}, "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="],
+
+    "lodash.clonedeep": ["lodash.clonedeep@4.5.0", "", {}, "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="],
 
     "lodash.includes": ["lodash.includes@4.3.0", "", {}, "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="],
 
     "lodash.isboolean": ["lodash.isboolean@3.0.3", "", {}, "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="],
 
     "lodash.isempty": ["lodash.isempty@4.4.0", "", {}, "sha512-oKMuF3xEeqDltrGMfDxAPGIVMSSRv8tbRSODbrs4KGsRRLEhrW8N8Rd4DRgB2+621hY8A8XwwrTVhXWpxFvMzg=="],
+
+    "lodash.isequal": ["lodash.isequal@4.5.0", "", {}, "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="],
 
     "lodash.isinteger": ["lodash.isinteger@4.0.4", "", {}, "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="],
 
@@ -2587,6 +2598,8 @@
 
     "pako": ["pako@1.0.11", "", {}, "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="],
 
+    "parchment": ["parchment@3.0.0", "", {}, "sha512-HUrJFQ/StvgmXRcQ1ftY6VEZUq3jA2t9ncFN4F84J/vN0/FPpQF+8FKXb3l6fLces6q0uOHj6NJn+2xvZnxO6A=="],
+
     "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
 
     "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
@@ -2670,6 +2683,10 @@
     "query-selector-shadow-dom": ["query-selector-shadow-dom@1.0.1", "", {}, "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw=="],
 
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
+
+    "quill": ["quill@2.0.3", "", { "dependencies": { "eventemitter3": "^5.0.1", "lodash-es": "^4.17.21", "parchment": "^3.0.0", "quill-delta": "^5.1.0" } }, "sha512-xEYQBqfYx/sfb33VJiKnSJp8ehloavImQ2A6564GAbqG55PGw1dAWUn1MUbQB62t0azawUS2CZZhWCjO8gRvTw=="],
+
+    "quill-delta": ["quill-delta@5.1.0", "", { "dependencies": { "fast-diff": "^1.3.0", "lodash.clonedeep": "^4.5.0", "lodash.isequal": "^4.5.0" } }, "sha512-X74oCeRI4/p0ucjb5Ma8adTXd9Scumz367kkMK5V/IatcX6A0vlgLgKbzXWy5nZmCGeNJm2oQX0d2Eqj+ZIlCA=="],
 
     "raf": ["raf@3.4.1", "", { "dependencies": { "performance-now": "^2.1.0" } }, "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA=="],
 

--- a/nix-support/node_modules-hashes.json
+++ b/nix-support/node_modules-hashes.json
@@ -1,6 +1,6 @@
 {
   "nodeModules": {
-    "aarch64-darwin": "sha256-nKmzyfYud90IlOgOsUOu8EjucFhC80q3ikgmaF2SPiI=",
-    "x86_64-linux": "sha256-4cs5WCMEty9Nl9Qu5RZc+iAw134VL4fKiQO+o0sACLU="
+    "aarch64-darwin": "sha256-IqekDwqSbla9lgmL0GZ2WFTCc/NgnRTpcJfLpFoqCYY=",
+    "x86_64-linux": "sha256-+q+yu8aFmHDc5jkHSqrE5nWiCWZLY2BARuHlAe1Hm7s="
   }
 }


### PR DESCRIPTION
## What

Frontend for HTML email signatures — settings editor plus per-message preview/dismiss in compose, reply/forward, and the AI chat composer. The whole feature is behind `ENABLE_EMAIL_SIGNATURES` (dev/local only via `DEV_MODE_ENV`; override with `VITE_ENABLE_EMAIL_SIGNATURES`).

The **backend owns injection and sanitization** (already merged) — the FE only renders a preview of what will be appended and signals an explicit per-message opt-out. Drafts never bake in the signature, so there's no stale-duplicate-signature trap.

## Changes

- **Settings** (`SignatureSection` + `SignatureEditor`): lazy-loaded Quill editor with formatting, click-to-select + drag-to-resize images, and an "Add to replies & forwards" toggle. Gated behind the flag (both the "Edit signature" button and the editor section).
- **Compose / reply / AI chat**: a collapsible `SignaturePreview` bar (collapsed by default) that mirrors the backend's include rules — always on a new email; on replies/forwards only when the inbox toggle is on. Dismiss (✕) sends `include_signature: false` for that one message; otherwise the field is omitted and the backend default applies.
- **AI chat** (`ChatCompose`): preview wired through the `SendEmail` tool's `includeSignature`; the dismiss persists across re-render via the tool snapshot, and the bar renders alongside the body (interaction blocked by the existing overlay until streaming completes).
- **Rendering**: `EmailMessageBody` width containment + `parseEmailContent` recognition of the `.macro-email-signature` wrapper so injected signatures display/collapse correctly (with a regression test).

## Notes

- `SignaturePreview` inserts server-sanitized HTML via `innerHTML` inside a shadow root — the prop documents that contract explicitly. Same pattern `EmailMessageBody` already uses for received mail.
- Signature previews are display-only; the backend is the source of truth for the final injected signature.
