### PR TITLE
fix(ai): loading state for uploaded attachments

### DIFF
--- a/js/app/packages/core/component/AI/component/input/Attachment.tsx
+++ b/js/app/packages/core/component/AI/component/input/Attachment.tsx
@@ -1,9 +1,5 @@
 import type { Attachment, AttachmentPreview } from '@core/component/AI/types';
-import {
-  isDssImage,
-  isImageAttachment,
-} from '@core/component/AI/util/attachment';
-import { EntityIcon } from '@core/component/EntityIcon';
+import { isImageAttachment } from '@core/component/AI/util/attachment';
 import { ImagePreview } from '@core/component/ImagePreview';
 import { ItemPreview } from '@core/component/ItemPreview';
 import { toast } from '@core/component/Toast/Toast';
@@ -40,21 +36,31 @@ export function AttachmentList(props: AttachmentListProps) {
   );
 }
 
+function uploadingFilename(preview: AttachmentPreview): string {
+  const metadata = preview.metadata;
+  if (!metadata) return 'File';
+  if (metadata.type === 'document' && 'document_name' in metadata) {
+    return metadata.document_name;
+  }
+  if (metadata.type === 'image' && 'image_name' in metadata) {
+    return metadata.image_name;
+  }
+  return 'File';
+}
+
 function UploadingAttachment(props: AttachmentPreview) {
   return (
     <Switch>
       <Match when={isImageAttachment(props)}>
         <div class="flex flex-col items-center justify-center gap-2 size-15 border border-edge rounded-md bg-surface">
-          <Spinner class="size-4 animate-spin" />
+          <Spinner class="size-4 animate-spin text-ink-muted" />
         </div>
       </Match>
-      <Match when={isDssImage(props) && props.metadata}>
-        {(metadata) => (
-          <div class="flex gap-1 items-center text-sm cursor-default">
-            <EntityIcon targetType={metadata().document_type} />
-            <div>{metadata().document_name}</div>
-          </div>
-        )}
+      <Match when={!isImageAttachment(props)}>
+        <div class="flex items-center gap-1 px-1 py-0.5 text-sm cursor-default border border-edge-muted rounded-xs max-w-full min-w-0">
+          <Spinner class="size-4 shrink-0 animate-spin text-ink-muted" />
+          <span class="truncate">{uploadingFilename(props)}</span>
+        </div>
       </Match>
     </Switch>
   );

--- a/js/app/packages/core/component/AI/util/attachment.ts
+++ b/js/app/packages/core/component/AI/util/attachment.ts
@@ -1,6 +1,6 @@
 import { SUPPORTED_IMAGE_ATTACHMENT_EXTENSIONS } from '@core/component/AI/constant';
 import { FileType as FileTypeMap } from '@service-cognition/generated/schemas/fileType';
-import type { AttachmentMetadata, AttachmentPreview, FileType } from '../types';
+import type { AttachmentPreview, FileType } from '../types';
 
 const FILE_TYPE_SET = new Set(Object.keys(FileTypeMap));
 
@@ -25,15 +25,4 @@ export const isImageAttachment = (attachment: AttachmentPreview) => {
     return false;
   }
   return false;
-};
-
-// returns true for dss image and false for sfs image
-export const isDssImage = (
-  attachment: AttachmentPreview
-): attachment is {
-  entity_type: 'document';
-  metadata: Extract<AttachmentMetadata, { type: 'document' }>;
-} => {
-  if (!isImageAttachment(attachment)) return false;
-  return attachment.metadata?.type === 'document';
 };


### PR DESCRIPTION
## Problem

When uploading a file into an AI chat (via drag-and-drop or the attach menu), document files showed **no pending/loading state** while uploading.

The chat input's `UploadingAttachment` only handled images. Non-image documents (pdf/docx/etc.) fell through to a second `<Match when={isDssImage(...)}>` branch that is a strict subset of the `isImageAttachment` branch above it — so it was dead code and nothing rendered while a document uploaded.

## Fix

- Replace the dead `isDssImage` branch with a `!isImageAttachment` document chip that renders a spinner + filename, mirroring the loading-state pattern already used in the channels input.
- Remove the now-unused `isDssImage` helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)