### PR TITLE
feat(chat): AI onboarding via SelfKnowledge tool (macro-2112)

### DIFF
--- a/infra/.gitignore
+++ b/infra/.gitignore
@@ -6,6 +6,7 @@
 !**/appRouteLambda/**/*.js
 !**/contentEncodingLambda/**/*.js
 package-lock.json
+local/generated
 
 node_modules
 dist

--- a/js/app/packages/core/component/AI/component/tool/SelfKnowledge.tsx
+++ b/js/app/packages/core/component/AI/component/tool/SelfKnowledge.tsx
@@ -1,0 +1,20 @@
+import MacroLogo from '@icon/macro.svg';
+import { BaseTool } from './BaseTool';
+import { createToolRenderer } from './ToolRenderer';
+
+/**
+ * `SelfKnowledge` renders as a standard tool row: the Macro mark and a "Self
+ * knowledge" label. The about-Macro page it returns is self-reflection the
+ * model did, not an action the user needs to inspect, so the result is hidden
+ * and the row has no expand toggle.
+ */
+const handler = createToolRenderer({
+  name: 'SelfKnowledge',
+  render: (ctx) => (
+    <BaseTool icon={MacroLogo} renderContext={ctx.renderContext} type="call">
+      Self knowledge
+    </BaseTool>
+  ),
+});
+
+export const selfKnowledgeHandler = handler;

--- a/js/app/packages/core/component/AI/component/tool/handler.tsx
+++ b/js/app/packages/core/component/AI/component/tool/handler.tsx
@@ -36,6 +36,7 @@ import { readThreadHandler } from './ReadThread';
 import { renameDocumentHandler } from './RenameDocument';
 import { contentSearchHandler, nameSearchHandler } from './Search';
 import { searchToolsHandler } from './SearchTools';
+import { selfKnowledgeHandler } from './SelfKnowledge';
 import { sendChannelMessageHandler } from './SendChannelMessage';
 import { sendEmailHandler } from './SendEmail';
 import { subagentHandler } from './Subagent';
@@ -78,6 +79,7 @@ const toolHandlers: ToolHandlerMap<RenderContext> = {
   ReadMetadata: readMetadataHandler,
   RenameDocument: renameDocumentHandler,
   SearchTools: searchToolsHandler,
+  SelfKnowledge: selfKnowledgeHandler,
   SendChannelMessage: sendChannelMessageHandler,
   SendEmail: sendEmailHandler,
   SetEntityProperty: setEntityPropertyHandler,

--- a/js/app/packages/service-clients/service-cognition/generated/tools/schemas.ts
+++ b/js/app/packages/service-clients/service-cognition/generated/tools/schemas.ts
@@ -1978,6 +1978,10 @@ export const SearchToolsResponse = z.object({
   results: z.array(z.object({ description: z.string(), name: z.string() })),
 });
 
+export const SelfKnowledge = z.record(z.any());
+
+export const SelfKnowledgeResponse = z.object({ about: z.string() });
+
 export const SendChannelMessage = z.object({
   channel_id: z.string().uuid(),
   content: z.string(),

--- a/js/app/packages/service-clients/service-cognition/generated/tools/tool.ts
+++ b/js/app/packages/service-clients/service-cognition/generated/tools/tool.ts
@@ -85,6 +85,10 @@ type ToolParserMap = {
     response: types.RenameDocumentResponse;
   };
   SearchTools: { call: types.SearchTools; response: types.SearchToolsResponse };
+  SelfKnowledge: {
+    call: types.SelfKnowledge;
+    response: types.SelfKnowledgeResponse;
+  };
   SendChannelMessage: {
     call: types.SendChannelMessage;
     response: types.SendChannelMessageResponse;
@@ -200,6 +204,10 @@ const toolParserMap = {
     call: schemas.SearchTools,
     response: schemas.SearchToolsResponse,
   },
+  SelfKnowledge: {
+    call: schemas.SelfKnowledge,
+    response: schemas.SelfKnowledgeResponse,
+  },
   SendChannelMessage: {
     call: schemas.SendChannelMessage,
     response: schemas.SendChannelMessageResponse,
@@ -308,6 +316,10 @@ type ToolDataMap = {
     response: types.RenameDocumentResponse;
   };
   SearchTools: { call: types.SearchTools; response: types.SearchToolsResponse };
+  SelfKnowledge: {
+    call: types.SelfKnowledge;
+    response: types.SelfKnowledgeResponse;
+  };
   SendChannelMessage: {
     call: types.SendChannelMessage;
     response: types.SendChannelMessageResponse;

--- a/js/app/packages/service-clients/service-cognition/generated/tools/types.ts
+++ b/js/app/packages/service-clients/service-cognition/generated/tools/types.ts
@@ -2610,6 +2610,19 @@ export interface SearchToolsResponse {
   results: ToolMatch[];
 }
 /**
+ * Learn what Macro is and how it works. Call this whenever the user asks an open-ended question about Macro itself — what it is, what it's for, what it can do, or how to do something in Macro — instead of answering from memory (your training data may be stale). Takes no arguments. Returns an overview of Macro and a map of links into the official docs at docs.macro.com; every docs page is readable as Markdown (append `.md` to its URL), so follow up with WebFetch on the relevant page for details and cite it.
+ */
+export type SelfKnowledge = {};
+/**
+ * The response for the [`SelfKnowledge`] tool: a single Markdown about-page.
+ */
+export interface SelfKnowledgeResponse {
+  /**
+   * An overview of Macro and a routing map into the docs at docs.macro.com.
+   */
+  about: string;
+}
+/**
  * Send or reply to a channel on behalf of the user. Only use this when explicitly asked to send a message
  */
 export interface SendChannelMessage {

--- a/js/bun.lock
+++ b/js/bun.lock
@@ -884,7 +884,7 @@
 
     "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
 
-    "@inkibra/tauri-plugins": ["@inkibra/tauri-plugins@github:macro-inc/tauri-plugins#26537c8", { "dependencies": { "react": "^18.3.1", "react-dom": "^18.3.1" } }, "macro-inc-tauri-plugins-26537c8"],
+    "@inkibra/tauri-plugins": ["@inkibra/tauri-plugins@github:macro-inc/tauri-plugins#26537c8", { "dependencies": { "react": "^18.3.1", "react-dom": "^18.3.1" } }, "macro-inc-tauri-plugins-26537c8", "sha512-6p5xQAkS6Uw6J8Uh0vlj6MjKZXWps5E1Gu0hciBFq1E2BfPBZAgdeeafKnR3diNb4SXWK0JML49nAr+o5PhwKw=="],
 
     "@inquirer/external-editor": ["@inquirer/external-editor@1.0.3", "", { "dependencies": { "chardet": "^2.1.1", "iconv-lite": "^0.7.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA=="],
 
@@ -2626,7 +2626,7 @@
 
     "pathval": ["pathval@2.0.1", "", {}, "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ=="],
 
-    "pdfjs-dist": ["pdfjs-dist@github:macro-inc/pdf.js#f9b2ce6", { "dependencies": { "dommatrix": "^1.0.3", "web-streams-polyfill": "^3.2.1" }, "peerDependencies": { "worker-loader": "^3.0.8" }, "optionalPeers": ["worker-loader"] }, "macro-inc-pdf.js-f9b2ce6"],
+    "pdfjs-dist": ["pdfjs-dist@github:macro-inc/pdf.js#f9b2ce6", { "dependencies": { "dommatrix": "^1.0.3", "web-streams-polyfill": "^3.2.1" }, "peerDependencies": { "worker-loader": "^3.0.8" }, "optionalPeers": ["worker-loader"] }, "macro-inc-pdf.js-f9b2ce6", "sha512-HDFaPbCxLG2GHpf1smUG97nku5aPGBGaCcIbK05dGdp07TBLUlDcXsM4WcE82mO5W4RBPIBVYobX5N/6M6NFrA=="],
 
     "performance-now": ["performance-now@2.1.0", "", {}, "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="],
 

--- a/rust/cloud-storage/ai_tools/src/lib.rs
+++ b/rust/cloud-storage/ai_tools/src/lib.rs
@@ -11,6 +11,7 @@ mod display_results;
 mod schemas;
 pub mod search;
 mod search_tools;
+mod self_knowledge;
 pub mod serde_utils;
 mod subagent;
 mod tool_context;
@@ -27,6 +28,7 @@ use notification::inbound::ai_tool::notification_toolset;
 use properties::inbound::toolset::properties_toolset;
 use schemas::read;
 use search_tools::{LoadTools, SearchTools};
+use self_knowledge::SelfKnowledge;
 use soup::inbound::toolset::{ListEntities, SoupToolContext};
 use std::sync::Arc;
 use subagent::Subagent;
@@ -74,6 +76,7 @@ impl ToolSchemaGenerator for ToolSetWithPrompt {
 pub(crate) fn subagent_toolset() -> AiToolSet {
     AsyncToolCollection::new()
         .add_toolset(search_toolset())
+        .add_tool::<SelfKnowledge, ToolServiceContext>()
         .add_tool::<ListEntities, SoupToolContext<ToolSoupService, ToolEmailService>>()
         .add_subtoolset::<ToolDocumentToolContext>(document_toolset())
         .add_subtoolset::<ToolPropertiesToolContext>(properties_toolset())

--- a/rust/cloud-storage/ai_tools/src/self_knowledge.rs
+++ b/rust/cloud-storage/ai_tools/src/self_knowledge.rs
@@ -1,0 +1,127 @@
+use ai_toolset::{AsyncTool, RequestContext, ServiceContext, ToolResult};
+use async_trait::async_trait;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::ToolServiceContext;
+
+/// The "about Macro" page returned by [`SelfKnowledge`].
+///
+/// Modeled on the Claude Code self-knowledge skill: rather than baking a large
+/// product description into the system prompt, the model calls this tool to pull
+/// in an overview plus a routing map into the live docs at docs.macro.com. Every
+/// docs page is also served as plain Markdown (append `.md` to its URL), so the
+/// model can read any page with the WebFetch tool — no special docs integration
+/// is needed.
+static ABOUT_MACRO: &str = r##"# About Macro
+
+Macro is a single, fast workspace that unifies the tools a team uses to get work
+done — email, messaging, tasks, documents, and more — into one linked database.
+Everything can reference everything else: a task can link to an email, a doc can
+@mention a channel message, and so on. The backend is Rust and the frontend is
+Solid, so it is built for speed.
+
+## What's in Macro
+
+Macro is organized into "blocks":
+
+- **Email** — email, integrated directly into the workspace.
+- **Channels** — Slack-like messaging channels; the default way people communicate.
+- **Chat** — AI conversations (this is what "chat" refers to).
+- **Tasks** — task and project tracking.
+- **Docs** — collaborative documents.
+- **Canvas** — a freeform visual canvas.
+- **Calls** — calls and call records.
+- **CRM** — customer relationship management.
+- **Folders** — file storage.
+- **Agents** — AI agents that can act across the workspace.
+
+Cross-cutting concepts: the **Unified Inbox** (recent items across every block,
+read via the ListEntities tool), **Unified Search**, **Unified Memory**,
+bidirectional **@mentions / linking**, and **permissions** that inherit from
+channels.
+
+## Core principles — read before answering questions about Macro
+
+1. **Accuracy over guessing.** Your training data may be outdated or wrong about
+   Macro. When a user asks what Macro is, what a feature does, or how to do
+   something in Macro, treat the official docs as the source of truth.
+2. **Read the docs.** Macro's docs are published at docs.macro.com. Every page is
+   also served as plain Markdown — append `.md` to the page URL — so you can read
+   it with the WebFetch tool.
+3. **Cite the docs.** Link the user to the specific docs page you used.
+
+## How to find the right page
+
+- **Full index of every page:** https://docs.macro.com/llms.txt — fetch this
+  first when you are unsure which page covers the question, then open the page it
+  points to.
+- Any page is readable as Markdown by appending `.md`, e.g.
+  https://docs.macro.com/product/tasks.md
+
+### Quick links (all readable as Markdown with a trailing `.md`)
+
+- Get started: https://docs.macro.com/getting-started.md
+- Products (https://docs.macro.com/product/<name>.md): email, channels, tasks,
+  docs, canvas, calls, crm, folders, agents, inbox, search, snippets,
+  unified-memory
+- Concepts (https://docs.macro.com/concepts/<name>.md): blocks, mentions,
+  properties
+- AI & MCP: https://docs.macro.com/AI/mcp/overview.md ·
+  tool reference https://docs.macro.com/AI/mcp/tools/index.md ·
+  recipes https://docs.macro.com/AI/recipes.md
+- Account: https://docs.macro.com/account/billing.md ·
+  https://docs.macro.com/account/teams.md
+- Other (https://docs.macro.com/<name>.md): permissions, keyboard-shortcuts,
+  faq, switch-to-macro, apps, support, integrations/github
+- Changelog: https://docs.macro.com/changelog/introduction.md
+
+## Workflow for "what is Macro / how do I…" questions
+
+1. Identify what the user is asking about (a block, a concept, billing, etc.).
+2. Fetch the relevant docs.macro.com `.md` page with WebFetch (or llms.txt first
+   if you are unsure which page to read).
+3. Answer concisely, grounded in the docs, and link the page you used.
+4. If you are still uncertain, point the user to the docs: "For the most current
+   details, see <URL>.""##;
+
+/// `selfKnowledge` returns an overview of Macro plus a routing map into the live
+/// docs at docs.macro.com. It takes no arguments and does no I/O — it hands the
+/// model a curated about-page so it can answer "what is Macro / how do I…"
+/// questions accurately instead of guessing from stale training data, and then
+/// read specific docs pages with WebFetch for detail.
+#[derive(Debug, Deserialize, JsonSchema, Clone, Default)]
+#[schemars(
+    title = "SelfKnowledge",
+    description = "\
+Learn what Macro is and how it works. Call this whenever the user asks an open-ended \
+question about Macro itself — what it is, what it's for, what it can do, or how to do \
+something in Macro — instead of answering from memory (your training data may be stale). \
+Takes no arguments. Returns an overview of Macro and a map of links into the official \
+docs at docs.macro.com; every docs page is readable as Markdown (append `.md` to its URL), \
+so follow up with WebFetch on the relevant page for details and cite it."
+)]
+pub struct SelfKnowledge {}
+
+/// The response for the [`SelfKnowledge`] tool: a single Markdown about-page.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct SelfKnowledgeResponse {
+    /// An overview of Macro and a routing map into the docs at docs.macro.com.
+    pub about: String,
+}
+
+#[async_trait]
+impl AsyncTool<ToolServiceContext> for SelfKnowledge {
+    type Output = SelfKnowledgeResponse;
+
+    #[tracing::instrument(skip_all, err)]
+    async fn call(
+        &self,
+        _service_context: ServiceContext<ToolServiceContext>,
+        _request_context: RequestContext,
+    ) -> ToolResult<Self::Output> {
+        Ok(SelfKnowledgeResponse {
+            about: ABOUT_MACRO.to_string(),
+        })
+    }
+}

--- a/rust/cloud-storage/prompt/src/about_macro.rs
+++ b/rust/cloud-storage/prompt/src/about_macro.rs
@@ -1,10 +1,31 @@
-//! Macro-specific terminology and product context.
+//! Macro product overview and terminology.
+//!
+//! Kept deliberately small: it sketches what Macro is, tells the model to call
+//! the `SelfKnowledge` tool (and read docs.macro.com) for anything more, and
+//! pins down the terminology the model is most likely to confuse.
 
 use crate::types::StaticPrompt;
 
-static TITLE: &str = "Terms";
+static TITLE: &str = "About Macro";
 
-static INSTRUCTIONS: &str = r##"- Channel - a slack-like messaging channel
+static INSTRUCTIONS: &str = r##"Macro is a single, fast workspace that unifies email, channels (messaging), chats
+(AI), tasks, docs, canvas, calls, CRM, and folders in one linked database.
+
+When a user asks an open-ended question about Macro itself — what it is, what it's
+for, what it can do, or how to do something in Macro — call the SelfKnowledge tool.
+It returns an overview of Macro plus links into the docs (docs.macro.com) that you
+can read with WebFetch. Do not answer these questions from memory; your training
+data may be stale.
+
+Watch for ambiguity. A message like "what is this for?" could mean "what is Macro
+for?" or could refer to something the user forgot to attach. Don't guess, and don't
+just tell them to attach something — ask which they meant, e.g. "Did you mean to
+attach something, or would you like to learn about Macro?" If they want to learn
+about Macro, use SelfKnowledge.
+
+## Terms
+
+- Channel - a slack-like messaging channel
 - Chat - An AI conversation
 - Email - Email messages
 - Inbox - the "unified inbox", the user's workspace of recent items accessible via the ListEntities tool
@@ -15,8 +36,6 @@ if a user is searching for seomething in a past AI conversation.
 Channels are the standard form of communication and should be prefered. If a user refers to "A message"
 assume they mean a channel message.
 
-Additional info about how macro works can be found at docs.macro.com
-
 Email is email.
 
 When a user refers to their "inbox", they mean the unified inbox accessible via the ListEntities
@@ -24,9 +43,10 @@ tool — not their email inbox. Only treat "inbox" as the email inbox when the u
 "email" (e.g. "email inbox").
 "##;
 
-static INTENT: &str = "The model uses Macro terminology correctly: channels for messaging, \
-chats only for past AI conversations, and \"inbox\" as the unified inbox unless the user \
-explicitly says email.";
+static INTENT: &str = "The model knows what Macro is at a high level, calls the SelfKnowledge \
+tool for open-ended questions about Macro instead of guessing, disambiguates vague prompts like \
+\"what is this for?\", and uses Macro terminology correctly: channels for messaging, chats only \
+for past AI conversations, and \"inbox\" as the unified inbox unless the user explicitly says email.";
 
-/// about macro promp
+/// The "About Macro" system prompt section.
 pub static PROMPT: StaticPrompt<'static> = StaticPrompt::borrowed(TITLE, INSTRUCTIONS, INTENT);


### PR DESCRIPTION
Adds a no-arg `SelfKnowledge` tool that returns an "About Macro" page linking into docs.macro.com so the AI can answer open-ended "what is Macro / what is this for?" questions instead of floundering, and slims the about-macro prompt to trigger it (and disambiguate vague prompts).
