### PR TITLE
test(task_dedup): semantic dedup eval harness + labeled corpus (macro-2080)

### DIFF
--- a/rust/cloud-storage/.sqlx/query-9e674f758ed18ff1e79854e43a28636355d5b6bec6f2a3675b429b2ebd62317f.json
+++ b/rust/cloud-storage/.sqlx/query-9e674f758ed18ff1e79854e43a28636355d5b6bec6f2a3675b429b2ebd62317f.json
@@ -1,0 +1,35 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT\n            d.id AS \"id!\",\n            d.name AS \"title!\",\n            COALESCE(\n                (\n                    SELECT json_agg(\n                        json_build_object(\n                            'property', pd.display_name,\n                            'data_type', pd.data_type,\n                            'values', ep.values\n                        )\n                    )\n                    FROM entity_properties ep\n                    JOIN property_definitions pd ON pd.id = ep.property_definition_id\n                    WHERE ep.entity_id = d.id\n                      AND ep.entity_type = 'TASK'::property_entity_type\n                      AND ep.values IS NOT NULL\n                ),\n                '[]'::json\n            ) AS \"properties!\"\n        FROM document_sub_type dst\n        JOIN \"Document\" d ON d.id = dst.document_id\n        WHERE dst.sub_type = 'task'\n          AND d.\"deletedAt\" IS NULL\n          AND d.owner LIKE 'macro|%@macro.com'\n          AND length(btrim(d.name)) >= $1\n        ORDER BY d.\"createdAt\" DESC\n        LIMIT $2\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id!",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "title!",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "properties!",
+        "type_info": "Json"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      null
+    ]
+  },
+  "hash": "9e674f758ed18ff1e79854e43a28636355d5b6bec6f2a3675b429b2ebd62317f"
+}

--- a/rust/cloud-storage/task_dedup/Cargo.toml
+++ b/rust/cloud-storage/task_dedup/Cargo.toml
@@ -9,6 +9,11 @@ name = "backfill_task_embeddings"
 path = "src/bin/backfill_task_embeddings.rs"
 required-features = ["backfill"]
 
+[[bin]]
+name = "pull_task_corpus"
+path = "src/bin/pull_task_corpus.rs"
+required-features = ["backfill"]
+
 [features]
 # Pulls in everything the `backfill_task_embeddings` binary needs. The library
 # itself does not require any of these, so default builds stay lean.

--- a/rust/cloud-storage/task_dedup/fixtures/eval/prod.json
+++ b/rust/cloud-storage/task_dedup/fixtures/eval/prod.json
@@ -1,0 +1,11042 @@
+{
+  "tasks": [
+    {
+      "id": "019f1e4c-ee88-71fd-91a3-106a313a05dc",
+      "title": "Customizable sidebar: edit defaults and add pins",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|jacob@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000002"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f1dee-42ec-729e-b7fe-0bfa152c689f",
+      "title": "virtualize the recipient selector list",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|seamus@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f1a95-9bef-7e60-8b9f-44be9fb45f3d",
+      "title": "latex issue sending dollar signs in channel message",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|seamus@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000002"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f1a93-9eba-7978-b00c-6060eeb4f3b8",
+      "title": "admins can perform CRUD on team membership",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|hutch@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000003"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f1a3d-5040-7601-8098-6855781c711a",
+      "title": "[fix][chat] AI keeps reading itself with the read tool",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|eric.hayes@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f1a35-7731-766e-bbcb-c064cf314808",
+      "title": "triggering split navigation should close settings dialog",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|aidan@macro.com",
+                "entity_type": "USER"
+              },
+              {
+                "entity_id": "macro|peter@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000002"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f1a25-f81b-7fb5-8c87-1f3ef90ae6a1",
+      "title": "[tags] fix tag deletion",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|gab@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000004"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000003"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f1a21-cf61-70ee-84e5-79be5facf783",
+      "title": "[tags] tag filters in soup and search",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|gab@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000003"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f19fb-ad55-7b6a-b67c-4a5d66f4ca39",
+      "title": "improve search semantics in share menu",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|gab@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000003"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f19f6-fb17-708c-9a3c-39fe239a9bbb",
+      "title": "mark done from inside email",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|peter@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000004"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f19ed-6865-73cc-abed-b556238a8693",
+      "title": "make ipad usable",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|peter@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000004"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f19c0-9297-7be4-b722-6c4a5263576c",
+      "title": "loading channel sometimes slow / animation fucked",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|peter@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000004"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f199a-21b9-73c1-99e8-f43331932c60",
+      "title": "begin using MacroEventBroker",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|hutch@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000003"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f1999-c675-7eab-87c8-7e0ce1c82386",
+      "title": "setup kafka support for local running",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|hutch@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000003"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f1999-8b48-7be5-ba71-0615f28141ec",
+      "title": "create kafka cluster and topics",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|hutch@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000003"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000003"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f1999-55dd-7cc5-8771-08e1a4d599a4",
+      "title": "Support github linked to multiple accounts",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|hutch@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000002"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000003"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f1981-78f8-7fb0-957d-b8984e0136a8",
+      "title": "[fix][chat] parallel tool execution",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|eric.hayes@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f1977-01b4-7b41-90ad-0a67d100b413",
+      "title": "fix(ai): loading state for uploaded attachments",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|teo@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000004"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f1969-4cdf-7d2c-b3e2-8a4887479e5c",
+      "title": "https://us.posthog.com/project/299018/replay/019f17b2-dc37-7a12-ad98-7...",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|evan@macro.com",
+                "entity_type": "USER"
+              },
+              {
+                "entity_id": "macro|teo@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f1968-aac2-78dd-83db-ed81590a135a",
+      "title": "chore(ci): migrate assign author & labels to workflow + namespace",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|teo@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000004"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f1963-c176-74ce-a66b-260098545611",
+      "title": "email has wrong padding at the top I think ?",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|evan@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000005"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f195c-8cef-7a95-8a40-6a050a7fcb83",
+      "title": "Bump document name character limit and show a more helpful toast when the limit is exceeded",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|gab@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000004"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000003"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f1956-7954-70cc-8165-36a4c66ccd89",
+      "title": "[feat][chat] AI onboarding",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|eric.hayes@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000004"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f1947-0e19-71f0-8b4c-5f91e1ff848a",
+      "title": "New user gets error when trying to upload file i think to AI",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|eric.hayes@macro.com",
+                "entity_type": "USER"
+              },
+              {
+                "entity_id": "macro|teo@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000002"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f192d-5ea1-7f44-830f-1728f5e964cf",
+      "title": "[fix][ai] search for channel Id when told to send message",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|eric.hayes@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f192a-20e8-713a-ad1f-6d8cf2f96a4e",
+      "title": "little treat",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|eric.hayes@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f192a-2099-77b7-a985-65eae68119c0",
+      "title": "little treat",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|gab@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f192a-1f31-7988-9183-c22e4a3eed1f",
+      "title": "little treat",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|seamus@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f1929-2944-78ad-94a4-9e5f5070c874",
+      "title": "[fix][ai] Ai does weird formatting in channels",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|macro@macro.com",
+                "entity_type": "USER"
+              },
+              {
+                "entity_id": "macro|eric.hayes@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f1926-dba3-738b-a089-bc680e31d8f2",
+      "title": "Empty comment flashes when switching splits; comment disappears on click outside",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|seamus@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f1917-34c6-7ef3-893c-ee22efaacad7",
+      "title": "[fix] blud isn't correctly mentioning people in tasks",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|eric.hayes@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f1914-c274-7927-a754-e8e5039b8924",
+      "title": "Theme mentions are bricked",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|aidan@macro.com",
+                "entity_type": "USER"
+              },
+              {
+                "entity_id": "macro|seamus@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f18f2-f084-7dfb-9a2d-4e8a5cf23da4",
+      "title": "collapsible list re-collapsing after you click expand",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|gab@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000002"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f18da-ca25-78f5-85ef-188d3434df6a",
+      "title": "sidebar unchudding round 2",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|seamus@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000004"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f18ab-c89d-754b-abf6-fa54f1b79c00",
+      "title": "[feat][chat] Better streaming",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|eric.hayes@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f1665-9b3c-7e1d-85f9-8b39ed0f19f2",
+      "title": "fix: emails shared from share menu don't show up in referencium",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|teo@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f1580-32e1-734f-8b15-a1ae37fb13fd",
+      "title": "what happens to web socket when you close app and come back",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|peter@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000004"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000004"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f155b-3d2b-7f0d-8640-72a6dc59ea26",
+      "title": "Delete confirmation dialog for channel messages",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|peter@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000004"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000002"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f1529-a683-7643-af43-fb765a53df60",
+      "title": "[properties] tags v0",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|gab@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000004"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000003"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f14fa-947e-785e-82f9-2c1bed8c28d0",
+      "title": "handle team subscription trialing status",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|hutch@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000004"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000003"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f14e5-8ca6-7de6-ad6a-b0b80de848a6",
+      "title": "[bug][soup] Marking as done in inbox is slow, used to be fast/optimistic",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|rahul@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f14d6-4d2b-7b62-a9a3-6dd53cef7b60",
+      "title": "[feat][dyn ui] make dyn ui a markdown node",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|eric.hayes@macro.com",
+                "entity_type": "USER"
+              },
+              {
+                "entity_id": "macro|seamus@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f14ca-a959-796c-92f5-2c04bf6e88ec",
+      "title": "scrolling is weird",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|evan@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f14ca-8600-76ec-920b-2388e75fd91f",
+      "title": "macro emails still look bad!",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|evan@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f14be-74b7-78c4-b1e8-14ba4396b6f6",
+      "title": "Better contact importing from email",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|evan@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000004"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f14b4-0bc5-7f7c-b755-ee81bec8b1d5",
+      "title": "Inbox: browser back button doesn't preserve Noise/All view",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|gab@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f1499-85ec-7b23-9adc-76a615e60c6a",
+      "title": "unable to invite user to team",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|hutch@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000004"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000004"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f1472-6643-7bba-96eb-b6c640cc0090",
+      "title": "[fix][chat] subagent tool doesn't render until response",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|eric.hayes@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000004"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f1458-f790-74cf-8aab-1edea3246cdc",
+      "title": "email formatting",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|evan@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f1427-b2ab-79b8-be0c-68bfb852bca3",
+      "title": "users who log in for the first time see a connect your email screen",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|evan@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000003"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000003"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f1417-25b2-7073-ac78-10b1fa0a0e7a",
+      "title": "[fix][chat] free users only see haiku",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|teo@macro.com",
+                "entity_type": "USER"
+              },
+              {
+                "entity_id": "macro|eric.hayes@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000004"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f13bf-7819-731e-b591-b3ab794fa98c",
+      "title": "Profile drop up much better",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|seamus@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f13bf-4910-708c-939b-ce47b08ec026",
+      "title": "lower opacity read in signal",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|seamus@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f13bf-1bb4-7f82-b077-b940f7cb5f7f",
+      "title": "Decrease contrast on borders",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|seamus@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f13b8-d860-7cfc-8635-b66c79234f31",
+      "title": "[fix][automations] dynamic UI doesn't work in automations",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|eric.hayes@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f13b1-6224-7c80-87a9-7c9fd1f2cb4f",
+      "title": "[feat][md] reset all inline styles on new paragraph (for the weak-minded)",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|seamus@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f13ad-9047-7d01-ac95-a1a34b6219d4",
+      "title": "John Waters welcomes you to The Shadow Realm",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|austin@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000004"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f13ad-8ffa-7d3d-8923-d38a3b9026c3",
+      "title": "John Waters welcomes you to The Shadow Realm",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|austin@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000004"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f13ad-8fab-75be-a7ca-463c977d597a",
+      "title": "John Waters welcomes you to The Shadow Realm",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|austin@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000004"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f13ad-8f61-721a-b4e8-ba66f75c77f8",
+      "title": "John Waters welcomes you to The Shadow Realm",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|austin@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000004"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f13ad-8f0d-7b4a-9621-b34586cbcc3d",
+      "title": "John Waters welcomes you to The Shadow Realm",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|austin@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000004"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f13ad-8ec1-7b4b-b48a-bf51c8a5c65f",
+      "title": "John Waters welcomes you to The Shadow Realm",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|austin@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000004"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f13ad-8e6f-7227-9115-5eaada36cc2f",
+      "title": "John Waters welcomes you to The Shadow Realm",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|austin@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000004"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f13ad-8e13-78ab-88d1-a93f88a1aaaa",
+      "title": "John Waters welcomes you to The Shadow Realm",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|austin@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000004"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f13ad-8dba-7879-8765-8d546985179c",
+      "title": "John Waters welcomes you to The Shadow Realm",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|austin@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000004"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f13ad-8d5b-7041-a1d6-df20aea9ab2d",
+      "title": "John Waters welcomes you to The Shadow Realm",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|austin@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000004"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f13ad-1f23-798f-9b75-e5e6499eb3a8",
+      "title": "John Waters welcomes you to The Shadow Realm",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|austin@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000004"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f13ad-1ec3-78c8-969a-221ea8a883e1",
+      "title": "John Waters welcomes you to The Shadow Realm",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|austin@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000004"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f13ad-1e6f-7b63-a6bf-b9a7926ea49f",
+      "title": "John Waters welcomes you to The Shadow Realm",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|austin@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000004"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f13ad-1e13-7097-8e6b-1c5758591222",
+      "title": "John Waters welcomes you to The Shadow Realm",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|austin@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000004"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f13ad-1db0-7875-9b9a-5454db883228",
+      "title": "John Waters welcomes you to The Shadow Realm",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|austin@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000004"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f13ad-1ccb-7f1f-b8cb-a71b114c7541",
+      "title": "John Waters welcomes you to The Shadow Realm",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|austin@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000004"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f13ad-1c46-7b96-88c7-7b3bfd7696f2",
+      "title": "John Waters welcomes you to The Shadow Realm",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|austin@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000004"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f13ad-1bde-75c6-9032-084ab067e72f",
+      "title": "John Waters welcomes you to The Shadow Realm",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|austin@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000004"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f13ad-1b71-734f-8854-f1010b639075",
+      "title": "John Waters welcomes you to The Shadow Realm",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|austin@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000004"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f13ad-1a97-7885-8ec5-732a3af24a6b",
+      "title": "John Waters welcomes you to The Shadow Realm",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|austin@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000004"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f13ac-0cd2-728c-8a47-edd885102255",
+      "title": "Blank AI",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|eric.hayes@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f137e-0869-7912-9a61-1638409cb237",
+      "title": "macro event webhooks",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|hutch@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000004"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000003"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f100a-d47b-733c-8da8-66418d5ec991",
+      "title": "[fix][chat] GetProperties is rendering a false failure",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|eric.hayes@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f1003-73be-7629-891a-64ff399fdf70",
+      "title": "[feat][ai] Macro agent",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|eric.hayes@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f0fef-9090-77f7-983e-d6fd5f45dc5f",
+      "title": "[feat][chat] Cooperative Stream Cancellation",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|eric.hayes@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000004"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f0fee-0a08-763f-a517-dc15b69e2ae8",
+      "title": "[fix] Fix task dedup",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|eric.hayes@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f0fd7-149c-7eba-87c3-d437752aefb7",
+      "title": "[feat][ai] Composed Memory",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|eric.hayes@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f0921-e492-7a86-bec4-2d261fc2a1ff",
+      "title": "Set up deploy preview GitHub workflow for solid-site repo",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|aidan@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000003"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f06a6-da09-74b8-ac1b-6e468c99792a",
+      "title": "[feat][chat] orchestration",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|eric.hayes@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000003"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f0464-c38c-749f-bc39-63722b8c39de",
+      "title": "drag down to refresh",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|peter@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000003"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f044c-8a63-79c3-8da2-7abbafc80ee7",
+      "title": "toggle open not working for create menu",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|peter@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000004"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000004"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f0446-aed1-7b5e-9b22-5b479b5cbdb1",
+      "title": "settings nit: placeholder text should use text-placeholder",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|aidan@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f0436-6de4-7af5-ad1f-8cd85c234f4c",
+      "title": "Show tooltips toggle doesn't do anything in settings",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|aidan@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f0433-3a61-7275-b0d3-e7f2888d39ef",
+      "title": "call controls showed under the nav bar on mobile (web version)",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|peter@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000003"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f01d0-e3bf-7635-b492-06737c5a147d",
+      "title": "[search] improve search pagination user experience",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|gab@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000003"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f00ce-fb4f-7c6b-bfa6-ccab4444b81d",
+      "title": "[search] Quoted single-token search not forcing exact match",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|gab@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000004"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f0095-4e95-7baf-9f37-c6dc41d961ef",
+      "title": "[search] Reduce O(N^2) highlight cost in multi-term content search",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|gab@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f0095-2ab3-7763-8a66-3ee3028d8014",
+      "title": "[search] Dynamic K-of-N matching for long content queries",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|gab@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f0081-1421-7348-ab53-b17cf3ca9796",
+      "title": "[search] Unified search: cross-page ordering inversions + duplicate email threads",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|gab@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000003"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f002f-b095-7e71-8d21-5282fe360ced",
+      "title": "[bug][md] numeric list merging bricked ahhhhhhhh",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|seamus@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f0014-d6c2-78ca-afbf-a30ca8f7aa93",
+      "title": "on fresh app install, macro appears empty after logging in",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|peter@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000004"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f0006-f044-7926-87ef-07ab05197f9b",
+      "title": "split header make better and kill second bar on documents",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|seamus@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f0006-8610-7dd0-8ea8-2e9f4502846d",
+      "title": "ask macro button above document title",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|seamus@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f0006-05e3-7d11-988c-21078ff0fb97",
+      "title": "simple create menu",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|seamus@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000003"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f0005-b90f-7c99-a38f-0c397a7b31a8",
+      "title": "dropdown restyle",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|seamus@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000004"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f0005-14f0-716f-af3e-aaedfac9fffc",
+      "title": "update sidebar styles and sizing",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|seamus@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000004"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019f0001-c15e-7c31-80d5-64202c2a3410",
+      "title": "[fix] model selector",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|eric.hayes@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000004"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000004"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019efffc-7a34-77cb-8e4e-bd2e008fb738",
+      "title": "moldau",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|julia@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019effe3-c76c-7e5e-9d9a-17b490f3cfe4",
+      "title": "animated icon for `Home` in sidebar?",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|aidan@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019effd0-7e3d-7036-8188-75dd0080798d",
+      "title": "[search] multi-term search not treating entity count correctly for cursor",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|gab@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000004"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000003"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019effc0-0bdb-7315-b7cf-1e5961dd7009",
+      "title": "[fix][ai] Docs created with MCP don't show up in soup or search",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|eric.hayes@macro.com",
+                "entity_type": "USER"
+              },
+              {
+                "entity_id": "macro|hutch@macro.com",
+                "entity_type": "USER"
+              },
+              {
+                "entity_id": "macro|wolf@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000002"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019effbd-0e1b-770c-b319-0edc35786ed2",
+      "title": "[feat][ai] Tool permissions — implementation plan",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|eric.hayes@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000005"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019effb8-61c9-7f9d-99c7-256545d395fe",
+      "title": "[bug][mentions-menu] inconsistent vertical space",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|seamus@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019effa8-4e3a-77f8-9db4-41c087f3924a",
+      "title": "sidebar text should be 13px",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|teo@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019effa8-4e36-7b07-a420-8188fa09b947",
+      "title": "sidebar icons should be 14px",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|teo@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019eff97-daa6-7de3-a888-889a798d5b5d",
+      "title": "[feat][chat] collapse consecutive AI thoughts/tool calls",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|eric.hayes@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019eff71-a39f-7ed1-ae34-712f38e97827",
+      "title": "[feat][md] Create paragraph between videos / photos / codefences",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|eric.hayes@macro.com",
+                "entity_type": "USER"
+              },
+              {
+                "entity_id": "macro|seamus@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019eff28-072c-756c-a04a-eaec6951c452",
+      "title": "[feat][md] Mention PR's",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|eric.hayes@macro.com",
+                "entity_type": "USER"
+              },
+              {
+                "entity_id": "macro|seamus@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019efeef-2776-78b6-b152-089d4f2e150f",
+      "title": "This is a bit weird",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|evan@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000005"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019efba2-40ea-7cde-a06a-7ca496ad50eb",
+      "title": "Mentions looking weird on mobile while typing",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|seamus@macro.com",
+                "entity_type": "USER"
+              },
+              {
+                "entity_id": "macro|peter@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000002"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019efba1-81f0-780f-a175-4d946605761a",
+      "title": "[fix] paste node doesn't correctly convert to md",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|eric.hayes@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000004"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019efb92-91fb-7070-b1c3-7e9c28a56589",
+      "title": "Remove settings dropup from sidebar",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|aidan@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019efb5d-8446-76c5-bcb4-3389cf179bc9",
+      "title": "update all services internal auth to no longer use a LocalOrRemoteSecret",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|hutch@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000004"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000003"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019efad1-51f6-7d07-8bb5-2bc6db9f515e",
+      "title": "feat(bots): macro agent auto respond",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|teo@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019efab2-174d-7540-8667-c13f10239b64",
+      "title": "Add thread labels to GetThread ai tool response",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|gab@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000004"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000002"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019efab0-61fe-7059-a7d2-22f15035fde8",
+      "title": "update thread labels ai tool is broken",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|gab@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000004"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000002"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019efaa6-9edf-70b7-b114-667bf3d7f17a",
+      "title": "[bug][soup] moving between group by views, sometimes causes weird blanking",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|rahul@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019efa9b-a492-7a76-9259-7ae93895c69a",
+      "title": "copy id command not working for email",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|gab@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000002"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019efa95-80b5-75e8-9076-a8913390dd7a",
+      "title": "Ability to comment on PR's in macro",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|hutch@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019efa75-9612-7eb5-8728-ee746bc99865",
+      "title": "Can't filter messages by person - just shows all channels",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019efa6e-57a2-715e-989a-d91dbf5ba4ad",
+      "title": "[fix] model access errors",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|eric.hayes@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019efa6b-99ef-7b40-bf6f-74ebf22d6ec9",
+      "title": "[feat][ai] Edit document tool",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|eric.hayes@macro.com",
+                "entity_type": "USER"
+              },
+              {
+                "entity_id": "macro|wolf@macro.com",
+                "entity_type": "USER"
+              },
+              {
+                "entity_id": "macro|hutch@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000005"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000003"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019efa69-02fd-7877-9dcb-21d6b70cc43d",
+      "title": "[fix][chat] slow ai stream",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|eric.hayes@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019efa60-a12d-7105-8e5a-5a944b20774d",
+      "title": "[search] channel search sort by global message order",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|gab@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000002"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019efa5b-6fde-7626-abf9-7ced571de831",
+      "title": "support more code extensions in code block",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|gab@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019efa57-f799-752d-b8d0-a112aa95ca76",
+      "title": "[chore][ai] config.rs in mcp_server and agent-schedule-service",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|eric.hayes@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000004"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019efa55-e411-71aa-bb99-53441a974eff",
+      "title": "[fix] lazy or ambiguous issue report, no action needed",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000005"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019efa49-3014-715b-897d-16eb9e8fca17",
+      "title": "[feat][chat] Dynamic UI charts",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|eric.hayes@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019efa46-efe2-77c6-bf7b-3991e87b1546",
+      "title": "[fix][chat] Dyanmic UI row overflow",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|eric.hayes@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019efa42-2a0c-7204-8fbc-3b76240efd5c",
+      "title": "[nit] remove duplicate dismissed toast",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|gab@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019efa40-e31c-78bd-90df-98870cfa31d0",
+      "title": "[search] search text not preserved on back navigation",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|gab@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000004"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000003"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019efa3a-e0f1-73d2-acb6-08d4028ad434",
+      "title": "remove old containerEnvVar from pulumi service args",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|hutch@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000002"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019efa26-0d37-7c03-bd45-172e1a6d2d88",
+      "title": "Mentions menu should be kept out of unsafe top area",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|peter@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000003"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019efa16-d8bd-746c-9b7f-4bd6016b561a",
+      "title": "Fix mobile notification nav",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|peter@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000005"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000003"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019efa04-5a41-7214-a085-67770c2f2c78",
+      "title": "[nit][md] make the static md code accessory `select_none`",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|seamus@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000004"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019ef9fe-0bf2-7223-8146-f3198284ca2a",
+      "title": "mobile inbox view degradation",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|peter@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000004"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019ef724-a12a-78bc-ac45-17a5ee2bbee9",
+      "title": "localhost:3000 not working on gab's phone",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|eric.hayes@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000005"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000004"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019ef6db-3e06-7ac1-8cb8-b6839553c727",
+      "title": "[feat][md] Better paste node",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|eric.hayes@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019ef6d9-4ffb-78be-bc2b-93d4b94bc919",
+      "title": "This is a task",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|teo@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019ef6cd-2745-77f1-b6c6-16385555777f",
+      "title": "bug(soup): cant open pr's in soup preview mode",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|teo@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000004"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019ef686-5f34-786f-9f84-3fca11f03634",
+      "title": "[feat] Unfurl links",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019ef66d-dd54-7d25-b80d-573d65e9495d",
+      "title": "scroll to bottom button broken in firefox",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|teo@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000001"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000002"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019ef66c-42b2-74c1-9ffe-707fe8b5d019",
+      "title": "new markdown occasionally shows up in tasks grouping",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|rahul@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000005"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0003-000000000002"
+            ]
+          }
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    },
+    {
+      "id": "019ef64d-4177-7762-96c1-9624860c5f42",
+      "title": "this one seems to have slipped thru, we should tighten up this check",
+      "body": "",
+      "source": "prod",
+      "properties": [
+        {
+          "data_type": "ENTITY",
+          "property": "Assignees",
+          "values": {
+            "type": "EntityReference",
+            "value": [
+              {
+                "entity_id": "macro|evan@macro.com",
+                "entity_type": "USER"
+              }
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Status",
+          "values": {
+            "type": "SelectOption",
+            "value": [
+              "00000001-0000-0000-0002-000000000005"
+            ]
+          }
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Priority",
+          "values": null
+        },
+        {
+          "data_type": "DATE",
+          "property": "Due Date",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Parent Task",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Subtasks",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Depends On",
+          "values": null
+        },
+        {
+          "data_type": "SELECT_STRING",
+          "property": "Effort",
+          "values": null
+        },
+        {
+          "data_type": "NUMBER",
+          "property": "Story Points",
+          "values": null
+        },
+        {
+          "data_type": "ENTITY",
+          "property": "Relevant Documents",
+          "values": null
+        }
+      ]
+    }
+  ],
+  "pairs": []
+}

--- a/rust/cloud-storage/task_dedup/fixtures/eval/prod_pairs.json
+++ b/rust/cloud-storage/task_dedup/fixtures/eval/prod_pairs.json
@@ -1,0 +1,33 @@
+{
+  "tasks": [],
+  "pairs": [
+    {
+      "a": "019f1a25-f81b-7fb5-8c87-1f3ef90ae6a1",
+      "b": "019f1a21-cf61-70ee-84e5-79be5facf783",
+      "expected_duplicate": false,
+      "case": "prod_observed",
+      "note": "Both in the tags feature area, but 'fix tag deletion' and 'tag filters in soup and search' are different actions."
+    },
+    {
+      "a": "019f00ce-fb4f-7c6b-bfa6-ccab4444b81d",
+      "b": "019f0095-4e95-7baf-9f37-c6dc41d961ef",
+      "expected_duplicate": false,
+      "case": "prod_observed",
+      "note": "Both in search, but one is a quoted-single-token exact-match bug and the other is a highlight-cost perf fix."
+    },
+    {
+      "a": "019efab2-174d-7540-8667-c13f10239b64",
+      "b": "019efab0-61fe-7059-a7d2-22f15035fde8",
+      "expected_duplicate": false,
+      "case": "prod_observed",
+      "note": "Both about thread-label AI tools, but one adds labels to GetThread's response and the other fixes a broken update-labels tool."
+    },
+    {
+      "a": "019f01d0-e3bf-7635-b492-06737c5a147d",
+      "b": "019efa40-e31c-78bd-90df-98870cfa31d0",
+      "expected_duplicate": false,
+      "case": "prod_observed",
+      "note": "Both search UX, but pagination experience vs. preserving search text on back navigation are different issues."
+    }
+  ]
+}

--- a/rust/cloud-storage/task_dedup/fixtures/eval/synthetic.json
+++ b/rust/cloud-storage/task_dedup/fixtures/eval/synthetic.json
@@ -1,0 +1,268 @@
+{
+  "tasks": [
+    {
+      "id": "syn-darkmode-toggle",
+      "title": "Add dark mode toggle to settings",
+      "body": "Let users switch the app between light and dark themes from the settings page. Persist the choice across sessions.",
+      "source": "synthetic"
+    },
+    {
+      "id": "syn-darkmode-theme-switcher",
+      "title": "Implement light/dark theme switcher in preferences",
+      "body": "Users should be able to choose a dark or light appearance in preferences and have it remembered when they come back.",
+      "source": "synthetic"
+    },
+    {
+      "id": "syn-darkmode-respect-os",
+      "title": "Respect the OS dark/light setting by default",
+      "body": "On first load, follow the operating system appearance setting until the user explicitly picks a theme.",
+      "source": "synthetic"
+    },
+    {
+      "id": "syn-billing-proration",
+      "title": "Fix incorrect proration on plan upgrade",
+      "body": "When a user upgrades their subscription mid-cycle the prorated charge is computed wrong. Correct the calculation.",
+      "source": "synthetic"
+    },
+    {
+      "id": "syn-billing-proration-reword",
+      "title": "Proration amount is wrong when upgrading a subscription",
+      "body": "Upgrading a plan partway through the billing period charges the wrong prorated amount; make the proration correct.",
+      "source": "synthetic"
+    },
+    {
+      "id": "syn-onboarding-tour",
+      "title": "Add welcome tour for new users",
+      "body": "Introduce new users to the core features with a short guided tour the first time they sign in.",
+      "source": "synthetic"
+    },
+    {
+      "id": "syn-onboarding-walkthrough",
+      "title": "Build a first-run product walkthrough for new signups",
+      "body": "New signups should get a step-by-step walkthrough of the main features on their first session.",
+      "source": "synthetic"
+    },
+    {
+      "id": "syn-export-data",
+      "title": "Export data",
+      "body": "Allow exporting all workspace tasks to a CSV file from the tasks page.",
+      "source": "synthetic"
+    },
+    {
+      "id": "syn-export-csv-download",
+      "title": "CSV download for tasks",
+      "body": "Users need a button to download every task in the workspace as a CSV file.",
+      "source": "synthetic"
+    },
+    {
+      "id": "syn-attach-dragdrop",
+      "title": "Allow drag-and-drop file upload to chat",
+      "body": "Let users drag a file onto the chat window to attach and upload it to the conversation.",
+      "source": "synthetic"
+    },
+    {
+      "id": "syn-attach-drag-files",
+      "title": "Support dragging files into the chat to attach them",
+      "body": "Dropping a file into the chat should attach it and upload it to the current thread.",
+      "source": "synthetic"
+    },
+    {
+      "id": "syn-avatar-broken",
+      "title": "Fix broken avatar images on profile",
+      "body": "Profile avatars intermittently fail to load and show a broken-image icon. Fix the loading.",
+      "source": "synthetic"
+    },
+    {
+      "id": "syn-avatar-not-loading",
+      "title": "Profile avatars not loading",
+      "body": "Avatar images on the profile page frequently do not render. Investigate and fix.",
+      "source": "synthetic"
+    },
+    {
+      "id": "syn-email-group-by-date",
+      "title": "Group inbox emails by date like Superhuman",
+      "body": "Split the inbox into Today, Yesterday, Past 7 days, and older sections, similar to Superhuman.",
+      "source": "synthetic"
+    },
+    {
+      "id": "syn-email-jk-nav",
+      "title": "Restore j/k keyboard navigation for emails",
+      "body": "Bring back j/k shortcuts to move the selection up and down the email list.",
+      "source": "synthetic"
+    },
+    {
+      "id": "syn-doppler-dss",
+      "title": "Use new doppler config: dss",
+      "body": "Switch document_storage_service to read configuration from the new doppler project.",
+      "source": "synthetic"
+    },
+    {
+      "id": "syn-doppler-dcs",
+      "title": "Use new doppler config: dcs",
+      "body": "Switch document_cognition_service to read configuration from the new doppler project.",
+      "source": "synthetic"
+    },
+    {
+      "id": "syn-search-debounce",
+      "title": "Debounce task search input",
+      "body": "Debounce the task search box so we don't fire a request on every keystroke.",
+      "source": "synthetic"
+    },
+    {
+      "id": "syn-search-ranking",
+      "title": "Improve task search result ranking",
+      "body": "Tune the relevance ranking so the most relevant tasks show up first in search.",
+      "source": "synthetic"
+    },
+    {
+      "id": "syn-retry-sqs",
+      "title": "Add retry with backoff to the SQS consumer in notification_service",
+      "body": "Wrap the notification_service SQS consumer with retry and exponential backoff on transient failures.",
+      "source": "synthetic"
+    },
+    {
+      "id": "syn-retry-email",
+      "title": "Add retry with backoff to email sending in email_service",
+      "body": "Add exponential backoff retries around the outbound email send path in email_service.",
+      "source": "synthetic"
+    },
+    {
+      "id": "syn-notif-mute",
+      "title": "Add mute setting for channel notifications",
+      "body": "Let a user mute notifications for a specific channel so they stop getting pinged.",
+      "source": "synthetic"
+    },
+    {
+      "id": "syn-notif-badge",
+      "title": "Show unread badge count on channel notifications",
+      "body": "Display a numeric unread badge on each channel in the sidebar.",
+      "source": "synthetic"
+    },
+    {
+      "id": "syn-oauth-google",
+      "title": "Add Google OAuth login",
+      "body": "Let users sign in with their Google account via OAuth.",
+      "source": "synthetic"
+    },
+    {
+      "id": "syn-oauth-microsoft",
+      "title": "Add Microsoft OAuth login",
+      "body": "Let users sign in with their Microsoft account via OAuth.",
+      "source": "synthetic"
+    }
+  ],
+  "pairs": [
+    {
+      "a": "syn-darkmode-toggle",
+      "b": "syn-darkmode-theme-switcher",
+      "expected_duplicate": true,
+      "case": "rephrasing",
+      "note": "Same work (a persisted light/dark theme control), different wording."
+    },
+    {
+      "a": "syn-billing-proration",
+      "b": "syn-billing-proration-reword",
+      "expected_duplicate": true,
+      "case": "rephrasing",
+      "note": "Identical bug (wrong proration on upgrade), reworded."
+    },
+    {
+      "a": "syn-onboarding-tour",
+      "b": "syn-onboarding-walkthrough",
+      "expected_duplicate": true,
+      "case": "rephrasing",
+      "note": "Same deliverable: a guided first-run tour for new users."
+    },
+    {
+      "a": "syn-export-data",
+      "b": "syn-export-csv-download",
+      "expected_duplicate": true,
+      "case": "rephrasing",
+      "note": "Same work stated with terse, different titles; the body carries the signal (CSV export of all tasks)."
+    },
+    {
+      "a": "syn-attach-dragdrop",
+      "b": "syn-attach-drag-files",
+      "expected_duplicate": true,
+      "case": "rephrasing",
+      "note": "Same feature: drag-and-drop file attach in chat."
+    },
+    {
+      "a": "syn-avatar-broken",
+      "b": "syn-avatar-not-loading",
+      "expected_duplicate": true,
+      "case": "rephrasing",
+      "note": "Same bug: profile avatars fail to load."
+    },
+    {
+      "a": "syn-email-group-by-date",
+      "b": "syn-email-jk-nav",
+      "expected_duplicate": false,
+      "case": "same_project_different_action",
+      "note": "Both touch the email list and reference Superhuman, but one is date grouping and the other is keyboard navigation."
+    },
+    {
+      "a": "syn-search-debounce",
+      "b": "syn-search-ranking",
+      "expected_duplicate": false,
+      "case": "same_project_different_action",
+      "note": "Both about task search, but debouncing input vs. ranking relevance are different actions."
+    },
+    {
+      "a": "syn-notif-mute",
+      "b": "syn-notif-badge",
+      "expected_duplicate": false,
+      "case": "same_project_different_action",
+      "note": "Both about channel notifications, but muting vs. showing an unread badge are different deliverables."
+    },
+    {
+      "a": "syn-doppler-dss",
+      "b": "syn-doppler-dcs",
+      "expected_duplicate": false,
+      "case": "same_action_different_integration",
+      "note": "Same action (adopt new doppler config) but in two different services; distinct work assigned to different areas."
+    },
+    {
+      "a": "syn-retry-sqs",
+      "b": "syn-retry-email",
+      "expected_duplicate": false,
+      "case": "same_action_different_integration",
+      "note": "Same pattern (retry with backoff) applied to different subsystems (SQS consumer vs. email send)."
+    },
+    {
+      "a": "syn-oauth-google",
+      "b": "syn-oauth-microsoft",
+      "expected_duplicate": false,
+      "case": "same_action_different_integration",
+      "note": "Same action (OAuth login) against different identity providers; separate integrations."
+    },
+    {
+      "a": "syn-darkmode-toggle",
+      "b": "syn-doppler-dss",
+      "expected_duplicate": false,
+      "case": "unrelated",
+      "note": "Completely different areas."
+    },
+    {
+      "a": "syn-billing-proration",
+      "b": "syn-email-jk-nav",
+      "expected_duplicate": false,
+      "case": "unrelated",
+      "note": "Completely different areas."
+    },
+    {
+      "a": "syn-onboarding-tour",
+      "b": "syn-retry-sqs",
+      "expected_duplicate": false,
+      "case": "unrelated",
+      "note": "Completely different areas."
+    },
+    {
+      "a": "syn-export-data",
+      "b": "syn-notif-badge",
+      "expected_duplicate": false,
+      "case": "unrelated",
+      "note": "Completely different areas."
+    }
+  ]
+}

--- a/rust/cloud-storage/task_dedup/src/bin/pull_task_corpus.rs
+++ b/rust/cloud-storage/task_dedup/src/bin/pull_task_corpus.rs
@@ -1,0 +1,235 @@
+//! Pulls a snapshot of real tasks into an [`EvalCorpus`] fixture for the
+//! semantic evaluation suite.
+//!
+//! This is read-only. It selects tasks created by Macro employees (owner
+//! `macro|…@macro.com`) — internal dogfooding data, deliberately excluding
+//! customer tasks — and writes their titles and raw property values to a JSON
+//! corpus. Task *bodies* live in the lexical service rather than Postgres, so
+//! this DB-only puller captures titles and properties; the labeled body-based
+//! cases are covered by the hand-authored synthetic corpus. Bodies could be
+//! layered in later via the same lexical path the embedding backfill uses.
+//!
+//! The emitted corpus has no labeled pairs — pair labels are a human judgement
+//! and are added by hand (or merged from the synthetic set) afterwards.
+//!
+//! Usage:
+//! ```text
+//! # against local macrodb
+//! cargo run -p task_dedup --features backfill --bin pull_task_corpus -- local --limit 150 --output <path>
+//! # against prod (reads the macro-db-prod secret via the aws CLI; requires aws auth)
+//! cargo run -p task_dedup --features backfill --bin pull_task_corpus -- prod --limit 150 --output <path>
+//! ```
+
+use std::path::PathBuf;
+
+use anyhow::{Context as _, Result, bail};
+use clap::Parser;
+use sqlx::PgPool;
+use task_dedup::eval::{CorpusTask, EvalCorpus, TaskSource};
+
+/// Target environment for the pull.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+enum Env {
+    /// Local development macrodb on localhost.
+    Local,
+    /// Dev environment: resolve the DB URL from AWS Secrets Manager.
+    Dev,
+    /// Production environment: resolve the DB URL from AWS Secrets Manager.
+    Prod,
+}
+
+impl Env {
+    fn suffix(self) -> &'static str {
+        match self {
+            Env::Local => "local",
+            Env::Dev => "dev",
+            Env::Prod => "prod",
+        }
+    }
+}
+
+/// Pulls a task snapshot into an eval corpus fixture.
+#[derive(Debug, clap::Parser)]
+#[command(name = "pull_task_corpus", about, long_about = None)]
+struct Args {
+    /// Environment to pull from: local | dev | prod.
+    #[arg(value_enum)]
+    env: Env,
+    /// Maximum number of tasks to pull (most recent first).
+    #[arg(long, default_value_t = 150)]
+    limit: i64,
+    /// Skip tasks whose trimmed title is shorter than this, to drop empty/junk
+    /// rows.
+    #[arg(long, default_value_t = 4)]
+    min_title_chars: i32,
+    /// Path to write the corpus JSON to.
+    #[arg(long)]
+    output: PathBuf,
+}
+
+/// One task row as pulled from the database.
+struct TaskRow {
+    id: String,
+    title: String,
+    properties: serde_json::Value,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let args = Args::parse();
+
+    let database_url = match args.env {
+        Env::Local => "postgres://user:password@localhost:5432/macrodb".to_string(),
+        env => fetch_database_url(env)?,
+    };
+    println!(
+        "pulling from {}: {}",
+        args.env.suffix(),
+        masked_db_url(&database_url)
+    );
+
+    let pool = PgPool::connect(&database_url)
+        .await
+        .context("failed to connect to database")?;
+
+    let rows = fetch_tasks(&pool, args.limit, args.min_title_chars).await?;
+    println!("pulled {} task(s)", rows.len());
+
+    let corpus = EvalCorpus {
+        tasks: rows
+            .into_iter()
+            .map(|row| CorpusTask {
+                id: row.id,
+                title: row.title,
+                body: String::new(),
+                source: TaskSource::Prod,
+                properties: Some(row.properties).filter(|value| !is_empty_json_array(value)),
+            })
+            .collect(),
+        pairs: Vec::new(),
+    };
+
+    let json = corpus.to_json()?;
+    std::fs::write(&args.output, json)
+        .with_context(|| format!("failed to write corpus to {}", args.output.display()))?;
+    println!(
+        "wrote {} task(s) to {}",
+        corpus.tasks.len(),
+        args.output.display()
+    );
+    Ok(())
+}
+
+/// Selects the most recent employee-created tasks with their raw property values.
+///
+/// Scoped to `owner LIKE 'macro|%@macro.com'` (internal dogfooding data only)
+/// and non-deleted task documents with a non-trivial title. Properties are
+/// aggregated as `[{property, data_type, values}]` using each definition's
+/// display name; SelectOption/EntityReference ids inside `values` are left
+/// unresolved (readable-label resolution is follow-up work).
+async fn fetch_tasks(pool: &PgPool, limit: i64, min_title_chars: i32) -> Result<Vec<TaskRow>> {
+    let rows = sqlx::query!(
+        r#"
+        SELECT
+            d.id AS "id!",
+            d.name AS "title!",
+            COALESCE(
+                (
+                    SELECT json_agg(
+                        json_build_object(
+                            'property', pd.display_name,
+                            'data_type', pd.data_type,
+                            'values', ep.values
+                        )
+                    )
+                    FROM entity_properties ep
+                    JOIN property_definitions pd ON pd.id = ep.property_definition_id
+                    WHERE ep.entity_id = d.id
+                      AND ep.entity_type = 'TASK'::property_entity_type
+                      AND ep.values IS NOT NULL
+                ),
+                '[]'::json
+            ) AS "properties!"
+        FROM document_sub_type dst
+        JOIN "Document" d ON d.id = dst.document_id
+        WHERE dst.sub_type = 'task'
+          AND d."deletedAt" IS NULL
+          AND d.owner LIKE 'macro|%@macro.com'
+          AND length(btrim(d.name)) >= $1
+        ORDER BY d."createdAt" DESC
+        LIMIT $2
+        "#,
+        min_title_chars,
+        limit,
+    )
+    .fetch_all(pool)
+    .await
+    .context("failed to query tasks")?;
+
+    Ok(rows
+        .into_iter()
+        .map(|row| TaskRow {
+            id: row.id,
+            title: row.title,
+            properties: row.properties,
+        })
+        .collect())
+}
+
+fn is_empty_json_array(value: &serde_json::Value) -> bool {
+    value.as_array().is_some_and(|array| array.is_empty())
+}
+
+/// Fetches the full `DATABASE_URL` for `env` from AWS Secrets Manager by
+/// shelling out to the `aws` CLI, reading the `macro-db-<env>` secret — the same
+/// primary-writer connection string the deployed services use. The `aws` CLI
+/// must be on `PATH` and authenticated.
+fn fetch_database_url(env: Env) -> Result<String> {
+    let secret_id = format!("macro-db-{}", env.suffix());
+    println!("fetching DATABASE_URL from secret {secret_id}");
+
+    let output = std::process::Command::new("aws")
+        .args([
+            "secretsmanager",
+            "get-secret-value",
+            "--secret-id",
+            &secret_id,
+            "--query",
+            "SecretString",
+            "--output",
+            "text",
+            "--region",
+            "us-east-1",
+        ])
+        .output()
+        .with_context(|| format!("failed to run `aws` to read secret {secret_id}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!(
+            "`aws secretsmanager get-secret-value` failed for {secret_id} \
+             (check AWS auth / permissions): {}",
+            stderr.trim()
+        );
+    }
+
+    let database_url = String::from_utf8(output.stdout)
+        .context("aws output was not valid UTF-8")?
+        .trim()
+        .to_string();
+    if database_url.is_empty() {
+        bail!("secret {secret_id} resolved to an empty value");
+    }
+    Ok(database_url)
+}
+
+/// Masks the password in a `postgres://user:password@host/...` URL for logging.
+fn masked_db_url(url: &str) -> String {
+    url.split_once("://")
+        .and_then(|(scheme, rest)| {
+            let (creds, host) = rest.split_once('@')?;
+            let user = creds.split_once(':').map_or(creds, |(user, _)| user);
+            Some(format!("{scheme}://{user}:******@{host}"))
+        })
+        .unwrap_or_else(|| url.to_string())
+}

--- a/rust/cloud-storage/task_dedup/src/eval/corpus.rs
+++ b/rust/cloud-storage/task_dedup/src/eval/corpus.rs
@@ -1,0 +1,197 @@
+//! The evaluation corpus data model.
+//!
+//! An [`EvalCorpus`] is a flat list of [`CorpusTask`]s plus a list of
+//! [`LabeledPair`]s referencing them by id. It serializes to JSON so a corpus
+//! can be committed as a fixture, hand-edited, or produced by the prod puller
+//! and merged with the synthetic set.
+
+use serde::{Deserialize, Serialize};
+
+/// Where a corpus task came from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TaskSource {
+    /// Pulled from a real production task created by a Macro employee.
+    Prod,
+    /// Hand-authored or generated synthetic task.
+    Synthetic,
+}
+
+/// A single task in the evaluation corpus.
+///
+/// `id` is a stable local identifier, not necessarily a real document id: the
+/// seeding step inserts each task under this id so labeled pairs can reference
+/// it. Prod snapshots use their real (opaque) document ids; synthetic tasks use
+/// readable slugs.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CorpusTask {
+    /// Stable identifier used as the seeded document id.
+    pub id: String,
+    /// Task title (`Document.name`).
+    pub title: String,
+    /// Task body as lexical embedding-format markdown. Often empty — many real
+    /// tasks are title-only.
+    #[serde(default)]
+    pub body: String,
+    /// Where the task came from.
+    pub source: TaskSource,
+    /// Raw task property values as stored in `entity_properties`, retained for
+    /// the follow-up property-embedding work. The current pipeline embeds only
+    /// title and body, so this is carried but not consumed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub properties: Option<serde_json::Value>,
+}
+
+/// The category a labeled pair exercises.
+///
+/// These mirror the cases called out in the dedup spec: the ones that must be
+/// caught (`Rephrasing`) and the ones that must *not* be flagged
+/// (`SameProjectDifferentAction`, `SameActionDifferentIntegration`), plus catch-alls
+/// for real observed pairs and obvious negatives.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PairCase {
+    /// Two rephrasings of the same underlying work — expected duplicate.
+    Rephrasing,
+    /// Same project or feature area, but a different action — expected NOT a
+    /// duplicate.
+    SameProjectDifferentAction,
+    /// Same action applied to a different integration/surface (e.g. the same
+    /// change wired into two services) — expected NOT a duplicate.
+    SameActionDifferentIntegration,
+    /// A pair drawn from the real prod snapshot and hand-labeled.
+    ProdObserved,
+    /// Two entirely unrelated tasks — expected NOT a duplicate.
+    Unrelated,
+}
+
+impl PairCase {
+    /// A short human-readable label for reports.
+    pub fn label(self) -> &'static str {
+        match self {
+            PairCase::Rephrasing => "rephrasing",
+            PairCase::SameProjectDifferentAction => "same_project_different_action",
+            PairCase::SameActionDifferentIntegration => "same_action_different_integration",
+            PairCase::ProdObserved => "prod_observed",
+            PairCase::Unrelated => "unrelated",
+        }
+    }
+}
+
+/// A labeled task pair with the ground-truth duplicate verdict.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LabeledPair {
+    /// First task id (references [`CorpusTask::id`]).
+    pub a: String,
+    /// Second task id (references [`CorpusTask::id`]).
+    pub b: String,
+    /// Ground truth: whether the two tasks are duplicates.
+    pub expected_duplicate: bool,
+    /// The category this pair exercises.
+    pub case: PairCase,
+    /// Optional note explaining the label.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub note: Option<String>,
+}
+
+/// A full evaluation corpus: tasks plus labeled pairs over them.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct EvalCorpus {
+    /// All tasks referenced by the pairs.
+    pub tasks: Vec<CorpusTask>,
+    /// Labeled task pairs.
+    #[serde(default)]
+    pub pairs: Vec<LabeledPair>,
+}
+
+impl EvalCorpus {
+    /// Parses a corpus from JSON bytes.
+    pub fn from_json(bytes: &[u8]) -> serde_json::Result<Self> {
+        serde_json::from_slice(bytes)
+    }
+
+    /// Serializes the corpus to pretty JSON.
+    pub fn to_json(&self) -> serde_json::Result<String> {
+        serde_json::to_string_pretty(self)
+    }
+
+    /// Appends another corpus's tasks and pairs to this one.
+    pub fn merge(&mut self, other: EvalCorpus) {
+        self.tasks.extend(other.tasks);
+        self.pairs.extend(other.pairs);
+    }
+
+    /// Looks up a task by id.
+    pub fn task(&self, id: &str) -> Option<&CorpusTask> {
+        self.tasks.iter().find(|task| task.id == id)
+    }
+
+    /// Returns the ids referenced by a pair that are missing from `tasks`.
+    ///
+    /// A non-empty result means the corpus is internally inconsistent (a pair
+    /// points at a task that was not included).
+    pub fn dangling_pair_ids(&self) -> Vec<String> {
+        let mut missing = Vec::new();
+        for pair in &self.pairs {
+            for id in [&pair.a, &pair.b] {
+                if self.task(id).is_none() {
+                    missing.push(id.clone());
+                }
+            }
+        }
+        missing
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn task(id: &str) -> CorpusTask {
+        CorpusTask {
+            id: id.to_string(),
+            title: format!("{id} title"),
+            body: String::new(),
+            source: TaskSource::Synthetic,
+            properties: None,
+        }
+    }
+
+    #[test]
+    fn round_trips_through_json() {
+        let corpus = EvalCorpus {
+            tasks: vec![task("a"), task("b")],
+            pairs: vec![LabeledPair {
+                a: "a".to_string(),
+                b: "b".to_string(),
+                expected_duplicate: true,
+                case: PairCase::Rephrasing,
+                note: Some("same work".to_string()),
+            }],
+        };
+
+        let json = corpus.to_json().unwrap();
+        let parsed = EvalCorpus::from_json(json.as_bytes()).unwrap();
+
+        assert_eq!(parsed.tasks.len(), 2);
+        assert_eq!(parsed.pairs.len(), 1);
+        assert!(parsed.pairs[0].expected_duplicate);
+        assert_eq!(parsed.pairs[0].case, PairCase::Rephrasing);
+    }
+
+    #[test]
+    fn detects_dangling_pair_ids() {
+        let corpus = EvalCorpus {
+            tasks: vec![task("a")],
+            pairs: vec![LabeledPair {
+                a: "a".to_string(),
+                b: "missing".to_string(),
+                expected_duplicate: false,
+                case: PairCase::Unrelated,
+                note: None,
+            }],
+        };
+
+        assert_eq!(corpus.dangling_pair_ids(), vec!["missing".to_string()]);
+    }
+}

--- a/rust/cloud-storage/task_dedup/src/eval/mod.rs
+++ b/rust/cloud-storage/task_dedup/src/eval/mod.rs
@@ -1,0 +1,24 @@
+//! Semantic-evaluation harness for task duplicate detection.
+//!
+//! Task dedup quality can only be judged against realistic, *labeled* data: the
+//! in-memory service tests exercise the pipeline's wiring, but say nothing about
+//! whether the embeddings + judge actually separate duplicates from
+//! non-duplicates. This module holds the shared corpus schema those measurements
+//! run against — a set of tasks plus hand-labeled pairs tagged with the case
+//! they exercise (rephrasing, same-project-different-action, etc.).
+//!
+//! The corpus is produced two ways and merged:
+//! - a committed snapshot of real production tasks created by Macro employees
+//!   (pulled read-only by the `pull_task_corpus` binary), and
+//! - hand-authored synthetic pairs that pin down the canonical cases from the
+//!   dedup spec.
+//!
+//! The measurement itself (embedding + judge accuracy, precision/recall) lives
+//! in the `semantic_eval` integration test, which loads a corpus, seeds it into
+//! an ephemeral database, and runs the real pipeline against it. Keeping only
+//! the data model here lets both the puller and the test share one schema
+//! without pulling the test's heavy dependencies into normal builds.
+
+pub mod corpus;
+
+pub use corpus::{CorpusTask, EvalCorpus, LabeledPair, PairCase, TaskSource};

--- a/rust/cloud-storage/task_dedup/src/lib.rs
+++ b/rust/cloud-storage/task_dedup/src/lib.rs
@@ -7,6 +7,7 @@
 //! crate's traits and injected as generic parameters into [`TaskDedupService`].
 
 pub mod domain;
+pub mod eval;
 pub mod outbound;
 
 use embedding::embedding_provider::openai::{DIMS, TextEmbedding3Small};

--- a/rust/cloud-storage/task_dedup/tests/semantic_eval.rs
+++ b/rust/cloud-storage/task_dedup/tests/semantic_eval.rs
@@ -1,0 +1,622 @@
+//! Semantic evaluation of the task duplicate-detection pipeline.
+//!
+//! Unlike the in-memory service tests (which check wiring) and the pgvector
+//! tests (which use a deterministic offline embedder), this suite runs the
+//! **real** pipeline — OpenAI `text-embedding-3-small` embeddings and the
+//! Anthropic judge — against a labeled corpus and reports how well it separates
+//! duplicates from non-duplicates. It is the measurement foundation the dedup
+//! fix iterates against.
+//!
+//! The corpus is [`EvalCorpus`] JSON merged from three committed fixtures: a
+//! read-only snapshot of real employee tasks (`prod.json`), hand-labeled pairs
+//! over those tasks (`prod_pairs.json`), and hand-authored synthetic pairs that
+//! pin the canonical cases (`synthetic.json`).
+//!
+//! # These tests are `#[ignore]` by default
+//!
+//! They cost real OpenAI + Anthropic calls and need a database, so normal CI
+//! skips them. Run them locally against the local macrodb with API keys in the
+//! environment:
+//!
+//! ```text
+//! # from a nix develop shell with DATABASE_URL + the API keys exported
+//! cargo test -p task_dedup --test semantic_eval -- --ignored --nocapture
+//! ```
+//!
+//! Required environment: `DATABASE_URL` (sqlx creates an ephemeral db per test),
+//! `OPENAI_API_KEY` (embeddings), and `ANTHROPIC_API_KEY` + `OPENAI_API_KEY` +
+//! `CEREBRAS_API_KEY` (the agent router the judge routes through). The
+//! measurement itself never touches production.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use embedding::embedding_provider::openai::TextEmbedding3Small;
+use embedding::entity::Task;
+use embedding::{EmbeddingModel, VectorStore};
+use macro_db_migrator::MACRO_DB_MIGRATIONS;
+use sqlx::PgPool;
+use task_dedup::domain::ports::{TaskDedupNotifier, TaskDuplicateJudge};
+use task_dedup::eval::{CorpusTask, EvalCorpus, LabeledPair, PairCase, TaskSource};
+use task_dedup::outbound::judge::AgentDuplicateJudge;
+use task_dedup::outbound::postgres::{PgTaskMatchRepo, PgTaskVectorDb};
+use task_dedup::outbound::reranker::NoOpReranker;
+use task_dedup::{NewTask, PgTaskDedupService, TaskDedupConfig, TaskDedupService};
+
+/// User the corpus is seeded under. The `documents_test_data` fixture creates
+/// this user, and `Document.owner` is a foreign key to it. Seeding everything
+/// under one owner makes all tasks mutually visible to the owner-scoped search
+/// without needing team rows.
+const EVAL_OWNER: &str = "macro|user@user.com";
+
+// ---------------------------------------------------------------------------
+// Corpus loading
+// ---------------------------------------------------------------------------
+
+/// Loads and merges the three committed fixtures into one corpus, panicking if
+/// any labeled pair references a task that is missing.
+fn load_corpus() -> EvalCorpus {
+    let mut corpus = EvalCorpus::from_json(include_bytes!("../fixtures/eval/prod.json"))
+        .expect("prod.json parses");
+    corpus.merge(
+        EvalCorpus::from_json(include_bytes!("../fixtures/eval/prod_pairs.json"))
+            .expect("prod_pairs.json parses"),
+    );
+    corpus.merge(
+        EvalCorpus::from_json(include_bytes!("../fixtures/eval/synthetic.json"))
+            .expect("synthetic.json parses"),
+    );
+
+    let dangling = corpus.dangling_pair_ids();
+    assert!(
+        dangling.is_empty(),
+        "labeled pairs reference missing tasks: {dangling:?}"
+    );
+    corpus
+}
+
+/// Maps each corpus task id to the document id it is seeded under.
+///
+/// Prod tasks keep their real UUID; synthetic tasks (readable slugs in the
+/// fixture) are seeded under a generated UUID-shaped id. This matters because
+/// the `task_duplicate_match_order` CHECK (`task_id < duplicate_task_id`) is
+/// evaluated in the database's collation, while the service's `ordered_pair`
+/// uses Rust byte ordering — the two disagree on strings with hyphens in
+/// non-aligned positions (e.g. `syn-attach-drag-files` vs `syn-attach-dragdrop`).
+/// Real document ids are UUIDs, whose hyphens always align, so production never
+/// hits this; seeding UUID-shaped ids keeps the eval faithful to that.
+fn seed_ids(corpus: &EvalCorpus) -> HashMap<String, String> {
+    corpus
+        .tasks
+        .iter()
+        .enumerate()
+        .map(|(index, task)| {
+            let doc_id = match task.source {
+                TaskSource::Prod => task.id.clone(),
+                TaskSource::Synthetic => {
+                    format!("e5a10000-0000-4000-8000-{index:012x}")
+                }
+            };
+            (task.id.clone(), doc_id)
+        })
+        .collect()
+}
+
+/// Joins a task's title and body the same way the service builds its judge /
+/// rerank query, so isolated judge calls see exactly what the pipeline would.
+fn full_text(title: &str, body: &str) -> String {
+    format!("{}\n{}", title.trim(), body.trim())
+}
+
+fn embeddable(task: &CorpusTask) -> Task<'_> {
+    Task {
+        title: std::borrow::Cow::Borrowed(&task.title),
+        body: std::borrow::Cow::Borrowed(&task.body),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Confusion matrix + per-case metrics (pure; unit-tested below)
+// ---------------------------------------------------------------------------
+
+/// A binary-classification tally of predicted-vs-expected duplicate verdicts.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct Confusion {
+    /// Expected duplicate, predicted duplicate.
+    tp: u32,
+    /// Expected non-duplicate, predicted duplicate (a false positive — the bug
+    /// dedup is most criticized for).
+    fp: u32,
+    /// Expected non-duplicate, predicted non-duplicate.
+    tn: u32,
+    /// Expected duplicate, predicted non-duplicate (a missed duplicate).
+    fn_: u32,
+}
+
+impl Confusion {
+    fn record(&mut self, expected: bool, predicted: bool) {
+        match (expected, predicted) {
+            (true, true) => self.tp += 1,
+            (false, true) => self.fp += 1,
+            (false, false) => self.tn += 1,
+            (true, false) => self.fn_ += 1,
+        }
+    }
+
+    fn total(&self) -> u32 {
+        self.tp + self.fp + self.tn + self.fn_
+    }
+
+    /// Fraction of predicted duplicates that were real. `None` when nothing was
+    /// predicted duplicate.
+    fn precision(&self) -> Option<f64> {
+        let denom = self.tp + self.fp;
+        (denom > 0).then(|| self.tp as f64 / denom as f64)
+    }
+
+    /// Fraction of real duplicates that were caught. `None` when there were no
+    /// real duplicates.
+    fn recall(&self) -> Option<f64> {
+        let denom = self.tp + self.fn_;
+        (denom > 0).then(|| self.tp as f64 / denom as f64)
+    }
+
+    fn f1(&self) -> Option<f64> {
+        match (self.precision(), self.recall()) {
+            (Some(p), Some(r)) if p + r > 0.0 => Some(2.0 * p * r / (p + r)),
+            _ => None,
+        }
+    }
+
+    fn accuracy(&self) -> Option<f64> {
+        let total = self.total();
+        (total > 0).then(|| (self.tp + self.tn) as f64 / total as f64)
+    }
+}
+
+fn fmt_ratio(value: Option<f64>) -> String {
+    value.map_or_else(|| "  n/a".to_string(), |v| format!("{:.1}%", v * 100.0))
+}
+
+/// A single pair's outcome, retained so the report can list the misses.
+struct PairOutcome {
+    a: String,
+    b: String,
+    case: PairCase,
+    expected: bool,
+    predicted: bool,
+    detail: String,
+}
+
+/// Builds the full text report for a set of pair outcomes: overall confusion
+/// matrix, per-case breakdown, and the list of misclassified pairs.
+fn report(title: &str, outcomes: &[PairOutcome]) -> String {
+    use std::collections::BTreeMap;
+    use std::fmt::Write as _;
+
+    let mut overall = Confusion::default();
+    let mut by_case: BTreeMap<&'static str, Confusion> = BTreeMap::new();
+    for outcome in outcomes {
+        overall.record(outcome.expected, outcome.predicted);
+        by_case
+            .entry(outcome.case.label())
+            .or_default()
+            .record(outcome.expected, outcome.predicted);
+    }
+
+    let mut out = String::new();
+    let _ = writeln!(out, "\n===== {title} =====");
+    let _ = writeln!(
+        out,
+        "pairs: {}  TP={} FP={} FN={} TN={}",
+        overall.total(),
+        overall.tp,
+        overall.fp,
+        overall.fn_,
+        overall.tn,
+    );
+    let _ = writeln!(
+        out,
+        "precision={}  recall={}  f1={}  accuracy={}",
+        fmt_ratio(overall.precision()),
+        fmt_ratio(overall.recall()),
+        fmt_ratio(overall.f1()),
+        fmt_ratio(overall.accuracy()),
+    );
+
+    let _ = writeln!(out, "\nby case:");
+    for (case, matrix) in &by_case {
+        let correct = matrix.tp + matrix.tn;
+        let _ = writeln!(
+            out,
+            "  {case:<34} {correct}/{} correct  (TP={} FP={} FN={} TN={})",
+            matrix.total(),
+            matrix.tp,
+            matrix.fp,
+            matrix.fn_,
+            matrix.tn,
+        );
+    }
+
+    let misses: Vec<&PairOutcome> = outcomes
+        .iter()
+        .filter(|o| o.expected != o.predicted)
+        .collect();
+    if misses.is_empty() {
+        let _ = writeln!(out, "\nno misclassifications.");
+    } else {
+        let _ = writeln!(out, "\nmisclassifications ({}):", misses.len());
+        for miss in misses {
+            let kind = if miss.expected {
+                "MISSED DUP  "
+            } else {
+                "FALSE POS   "
+            };
+            let _ = writeln!(
+                out,
+                "  {kind}[{}] {} <> {}\n              {}",
+                miss.case.label(),
+                miss.a,
+                miss.b,
+                miss.detail,
+            );
+        }
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Seeding + real service wiring
+// ---------------------------------------------------------------------------
+
+struct NoopNotifier;
+
+#[async_trait]
+impl TaskDedupNotifier for NoopNotifier {
+    async fn notify_matches_updated(&self, _document_id: &str) -> anyhow::Result<()> {
+        Ok(())
+    }
+}
+
+/// Inserts every corpus task as a task document owned by [`EVAL_OWNER`], under
+/// its seeded document id. Does not embed anything — the individual measurements
+/// embed as they need to.
+async fn seed_documents(pool: &PgPool, corpus: &EvalCorpus, ids: &HashMap<String, String>) {
+    for task in &corpus.tasks {
+        let doc_id = &ids[&task.id];
+        sqlx::query!(
+            r#"INSERT INTO "Document" (id, name, "fileType", owner) VALUES ($1, $2, 'md', $3)"#,
+            doc_id,
+            task.title,
+            EVAL_OWNER,
+        )
+        .execute(pool)
+        .await
+        .expect("insert document");
+
+        sqlx::query!(
+            r#"INSERT INTO document_sub_type (document_id, sub_type) VALUES ($1, 'task')"#,
+            doc_id,
+        )
+        .execute(pool)
+        .await
+        .expect("insert document_sub_type");
+    }
+}
+
+fn openai_key() -> String {
+    std::env::var("OPENAI_API_KEY").expect(
+        "OPENAI_API_KEY must be set to run the semantic eval; \
+         export it (and ANTHROPIC_API_KEY / CEREBRAS_API_KEY for the judge) first",
+    )
+}
+
+/// Builds the production service (real embedder + judge) over `pool` with the
+/// given config. The judge records usage into the ephemeral db's ai_usage table.
+fn build_service(pool: &PgPool, config: TaskDedupConfig) -> PgTaskDedupService {
+    TaskDedupService::new(
+        config,
+        TextEmbedding3Small::new(openai_key()),
+        PgTaskVectorDb::new(pool.clone()),
+        NoOpReranker,
+        Arc::new(AgentDuplicateJudge::new(ai_usage::pg_recorder(
+            pool.clone(),
+        ))),
+        Arc::new(NoopNotifier),
+        Arc::new(PgTaskMatchRepo::new(pool.clone())),
+    )
+}
+
+async fn clear_pipeline_state(pool: &PgPool) {
+    sqlx::query!("TRUNCATE TABLE task_duplicate_match")
+        .execute(pool)
+        .await
+        .expect("truncate matches");
+    sqlx::query!("TRUNCATE TABLE task_duplicate_embedding")
+        .execute(pool)
+        .await
+        .expect("truncate embeddings");
+}
+
+// ---------------------------------------------------------------------------
+// #[ignore] semantic measurements
+// ---------------------------------------------------------------------------
+
+/// End-to-end duplicate detection: for each labeled pair, seed A's embedding,
+/// run the real `detect_new_task(B)` (embed → vector-floor → judge → persist) in
+/// pairwise isolation, and check whether the pipeline links A and B. This is the
+/// headline false-positive / false-negative measurement, mirroring production
+/// behavior including the vector-similarity floor.
+#[sqlx::test(
+    migrator = "MACRO_DB_MIGRATIONS",
+    fixtures(path = "../../documents/fixtures", scripts("documents_test_data"))
+)]
+#[ignore = "hits OpenAI + Anthropic; run locally with API keys"]
+async fn end_to_end_detection_baseline(pool: PgPool) {
+    let corpus = load_corpus();
+    let ids = seed_ids(&corpus);
+    seed_documents(&pool, &corpus, &ids).await;
+
+    let seed_embedder = TextEmbedding3Small::new(openai_key());
+    let vector_db = PgTaskVectorDb::new(pool.clone());
+    let service = build_service(&pool, TaskDedupConfig::default());
+
+    let mut outcomes = Vec::new();
+    for pair in &corpus.pairs {
+        clear_pipeline_state(&pool).await;
+
+        let task_a = corpus.task(&pair.a).expect("pair task a exists");
+        let task_b = corpus.task(&pair.b).expect("pair task b exists");
+        let a_id = &ids[&task_a.id];
+        let b_id = &ids[&task_b.id];
+
+        // Seed A's embedding so it is a candidate, then detect B against it.
+        let a_embedding = seed_embedder
+            .embed(&embeddable(task_a))
+            .await
+            .expect("embed a");
+        if !a_embedding.is_empty() {
+            vector_db
+                .upsert_embeddings(a_id.clone(), a_embedding)
+                .await
+                .expect("persist a embedding");
+        }
+
+        service
+            .detect_new_task(NewTask {
+                document_id: b_id.clone(),
+                owner: EVAL_OWNER.to_string(),
+                team_id: None,
+                title: task_b.title.clone(),
+                markdown: task_b.body.clone(),
+            })
+            .await
+            .expect("detect_new_task");
+
+        let duplicates = service
+            .active_duplicates(b_id)
+            .await
+            .expect("active_duplicates");
+        let matched = duplicates.iter().find(|d| d.task_id == *a_id);
+        let predicted = matched.is_some();
+        let detail = match matched {
+            Some(d) => format!(
+                "vector_score={:.3} judge_reason={}",
+                d.vector_score,
+                d.judge_reason.as_deref().unwrap_or("<none>")
+            ),
+            None => "not linked".to_string(),
+        };
+
+        outcomes.push(PairOutcome {
+            a: pair.a.clone(),
+            b: pair.b.clone(),
+            case: pair.case,
+            expected: pair.expected_duplicate,
+            predicted,
+            detail,
+        });
+    }
+
+    let text = report(
+        "end-to-end duplicate detection (production config)",
+        &outcomes,
+    );
+    println!("{text}");
+
+    // Report-only baseline: dedup is known-imperfect, so we don't gate on
+    // quality here. Assert only that every labeled pair was measured, so a
+    // silent seeding/wiring regression still fails.
+    assert_eq!(outcomes.len(), corpus.pairs.len());
+}
+
+/// Isolated judge accuracy: calls the real judge directly on each labeled pair's
+/// full text, with no retrieval in the loop. Comparing this against the
+/// end-to-end run separates misses caused by the judge from misses caused by the
+/// vector-similarity floor dropping a candidate before the judge ever sees it.
+#[sqlx::test(migrator = "MACRO_DB_MIGRATIONS")]
+#[ignore = "hits Anthropic; run locally with API keys"]
+async fn judge_accuracy_baseline(pool: PgPool) {
+    // Ensure the router's keys are present up front with a clear message.
+    let _ = openai_key();
+    let corpus = load_corpus();
+    let judge = AgentDuplicateJudge::new(ai_usage::pg_recorder(pool.clone()));
+
+    let mut outcomes = Vec::new();
+    for pair in &corpus.pairs {
+        let task_a = corpus.task(&pair.a).expect("pair task a exists");
+        let task_b = corpus.task(&pair.b).expect("pair task b exists");
+        let result = judge
+            .judge(
+                &full_text(&task_a.title, &task_a.body),
+                &full_text(&task_b.title, &task_b.body),
+            )
+            .await;
+
+        outcomes.push(PairOutcome {
+            a: pair.a.clone(),
+            b: pair.b.clone(),
+            case: pair.case,
+            expected: pair.expected_duplicate,
+            predicted: result.is_duplicate,
+            detail: result.reason.unwrap_or_else(|| "<no reason>".to_string()),
+        });
+    }
+
+    let text = report("isolated judge accuracy (no retrieval)", &outcomes);
+    println!("{text}");
+    assert_eq!(outcomes.len(), corpus.pairs.len());
+}
+
+/// Retrieval recall: embeds the whole corpus (all ~150 real tasks act as
+/// distractors), then for each *expected-duplicate* pair checks whether B's
+/// similarity search surfaces A above the vector-similarity floor. Candidate and
+/// duplicate limits are raised so the metric reflects "is A retrievable at all",
+/// not the top-5 UI cap. Misses here are duplicates the judge would never get a
+/// chance to catch.
+#[sqlx::test(
+    migrator = "MACRO_DB_MIGRATIONS",
+    fixtures(path = "../../documents/fixtures", scripts("documents_test_data"))
+)]
+#[ignore = "hits OpenAI; run locally with API keys"]
+async fn retrieval_recall_baseline(pool: PgPool) {
+    let corpus = load_corpus();
+    let ids = seed_ids(&corpus);
+    seed_documents(&pool, &corpus, &ids).await;
+
+    let embedder = TextEmbedding3Small::new(openai_key());
+    let vector_db = PgTaskVectorDb::new(pool.clone());
+    for task in &corpus.tasks {
+        let embedding = embedder.embed(&embeddable(task)).await.expect("embed task");
+        if !embedding.is_empty() {
+            vector_db
+                .upsert_embeddings(ids[&task.id].clone(), embedding)
+                .await
+                .expect("persist embedding");
+        }
+    }
+
+    // Large limits: measure retrievability above the floor, not the UI top-5.
+    let service = build_service(
+        &pool,
+        TaskDedupConfig {
+            vector_candidate_limit: 300,
+            duplicate_limit: 300,
+            ..TaskDedupConfig::default()
+        },
+    );
+
+    let positives: Vec<&LabeledPair> = corpus
+        .pairs
+        .iter()
+        .filter(|p| p.expected_duplicate)
+        .collect();
+
+    let mut retrieved = 0usize;
+    let mut lines = Vec::new();
+    for pair in &positives {
+        let task_a = corpus.task(&pair.a).expect("task a");
+        let task_b = corpus.task(&pair.b).expect("task b");
+        let results = service
+            .similarity_search(EVAL_OWNER, None, &task_b.title, &task_b.body)
+            .await
+            .expect("similarity_search");
+        let hit = results.iter().find(|r| r.task_id == ids[&task_a.id]);
+        if hit.is_some() {
+            retrieved += 1;
+        }
+        lines.push(format!(
+            "  {:<12} [{}] {} -> {} ({} above floor)",
+            if hit.is_some() { "RETRIEVED" } else { "MISSED" },
+            pair.case.label(),
+            pair.b,
+            pair.a,
+            results.len(),
+        ));
+    }
+
+    println!("\n===== retrieval recall on expected-duplicate pairs =====");
+    println!(
+        "retrieved {}/{} ({})",
+        retrieved,
+        positives.len(),
+        fmt_ratio((!positives.is_empty()).then(|| retrieved as f64 / positives.len() as f64)),
+    );
+    for line in lines {
+        println!("{line}");
+    }
+
+    assert!(!positives.is_empty(), "corpus has no positive pairs");
+}
+
+// ---------------------------------------------------------------------------
+// Offline unit tests (run in normal CI) for the metric math
+// ---------------------------------------------------------------------------
+
+#[test]
+fn confusion_computes_precision_recall_f1() {
+    let mut c = Confusion::default();
+    c.record(true, true); // tp
+    c.record(true, true); // tp
+    c.record(true, false); // fn
+    c.record(false, true); // fp
+    c.record(false, false); // tn
+
+    assert_eq!((c.tp, c.fp, c.fn_, c.tn), (2, 1, 1, 1));
+    assert!((c.precision().unwrap() - 2.0 / 3.0).abs() < 1e-9);
+    assert!((c.recall().unwrap() - 2.0 / 3.0).abs() < 1e-9);
+    assert!((c.f1().unwrap() - 2.0 / 3.0).abs() < 1e-9);
+    assert!((c.accuracy().unwrap() - 3.0 / 5.0).abs() < 1e-9);
+}
+
+#[test]
+fn confusion_handles_empty_denominators() {
+    let empty = Confusion::default();
+    assert_eq!(empty.precision(), None);
+    assert_eq!(empty.recall(), None);
+    assert_eq!(empty.f1(), None);
+    assert_eq!(empty.accuracy(), None);
+
+    let mut only_negatives = Confusion::default();
+    only_negatives.record(false, false);
+    assert_eq!(only_negatives.precision(), None); // nothing predicted positive
+    assert_eq!(only_negatives.recall(), None); // no real positives
+}
+
+#[test]
+fn report_lists_misclassifications() {
+    let outcomes = vec![
+        PairOutcome {
+            a: "a".into(),
+            b: "b".into(),
+            case: PairCase::Rephrasing,
+            expected: true,
+            predicted: false,
+            detail: "not linked".into(),
+        },
+        PairOutcome {
+            a: "c".into(),
+            b: "d".into(),
+            case: PairCase::Unrelated,
+            expected: false,
+            predicted: false,
+            detail: "ok".into(),
+        },
+    ];
+    let text = report("t", &outcomes);
+    assert!(text.contains("MISSED DUP"));
+    assert!(text.contains("rephrasing"));
+    assert!(text.contains("misclassifications (1)"));
+}
+
+#[test]
+fn corpus_fixtures_are_consistent() {
+    // Not #[ignore]: guards the committed fixtures on every build so a bad edit
+    // (dangling pair id, malformed JSON) fails fast without any API calls.
+    let corpus = load_corpus();
+    assert!(corpus.tasks.len() > 20, "expected a non-trivial corpus");
+    assert!(!corpus.pairs.is_empty(), "expected labeled pairs");
+    assert!(corpus.pairs.iter().any(|p| p.expected_duplicate));
+    assert!(corpus.pairs.iter().any(|p| !p.expected_duplicate));
+}


### PR DESCRIPTION
Adds a reusable, labeled semantic-evaluation harness for task duplicate detection — a read-only prod task-snapshot puller, committed real + synthetic labeled corpora, and an opt-in test suite that runs the real embedding + judge pipeline and reports precision/recall — with no changes to production dedup behavior (macro-2080).

## Why

Task dedup is reported to have false positives and false negatives, but there was no way to *measure* quality — the existing tests exercise wiring against mock/offline embedders. This is the "test environment is critical" foundation from the ticket: seed real + synthetic tasks locally and measure the real pipeline so fixes can be iterated against numbers instead of vibes. **This PR is measurement-only; it changes no dedup behavior.**

## What's here

- **`src/eval/`** — a shared, documented corpus schema (`EvalCorpus` = tasks + labeled `pairs`; each pair tagged with its `case`: rephrasing / same-project-different-action / same-action-different-integration / prod-observed / unrelated) with JSON load/save.
- **`src/bin/pull_task_corpus.rs`** (feature `backfill`) — read-only puller that snapshots tasks created by Macro employees (`owner LIKE 'macro|%@macro.com'`, internal dogfooding data only) into a corpus fixture. Mirrors the existing `backfill_task_embeddings` prod-connection pattern (DB URL via the `macro-db-<env>` secret through the `aws` CLI).
- **`fixtures/eval/`** — `prod.json` (150 real employee tasks + their raw property values, regenerable by the puller), `prod_pairs.json` (hand-labeled pairs over the snapshot), and `synthetic.json` (hand-authored tasks + labeled pairs pinning the canonical cases).
- **`tests/semantic_eval.rs`** — `#[ignore]` suite that seeds the corpus into an ephemeral DB and runs the **real** OpenAI embedder + Anthropic judge, decomposed into three measurements so a miss can be attributed to a stage:
  - **isolated judge accuracy** (judge only, no retrieval),
  - **retrieval recall** (does the vector stage surface the true duplicate above the floor, over all 150 real tasks as distractors),
  - **end-to-end detection** (full production pipeline, pairwise-isolated).
  The metric math (confusion matrix / precision / recall / F1 / per-case) has offline unit tests that run in normal CI; the semantic tests do not (they cost API calls and need a DB).

## Baseline (local run, `text-embedding-3-small` + Haiku judge)

| Measurement | Precision | Recall | F1 | Accuracy |
|---|---|---|---|---|
| Isolated judge | 100% | 100% | 100% | 100% |
| Retrieval recall (positives) | — | 66.7% | — | — |
| **End-to-end (prod config)** | **100%** | **66.7%** | **80%** | **90%** |

End-to-end confusion: **TP=4 FP=0 FN=2 TN=14** over 20 labeled pairs.

## What the data says

- **The judge is not the problem.** On this labeled set the Haiku judge is 100% — it correctly rejects every hard negative (same-project-different-action, same-action-different-integration like `doppler config: dss` vs `dcs`, and the prod-observed near-misses) and catches every rephrasing.
- **False negatives come from the vector-similarity floor, not the judge.** Both end-to-end misses (`onboarding tour` ≈ `first-run walkthrough`; `export data` ≈ `CSV download`) are cases where the true duplicate scores **below the 0.74 `min_vector_similarity` floor**, so the judge never sees it. The CSV-export miss is the "titles differ, the body carries the signal" case.
- **No false positives** were observed on this corpus — current dedup errs conservative (misses dups) rather than over-flagging.

## Recommended follow-ups (separate PRs)

1. **Tune / lower `min_vector_similarity`** (currently 0.74) and/or widen `max_judge_candidates` — the judge is accurate and cheap enough to gate more borderline candidates, which directly recovers the missed duplicates without adding false positives on this set.
2. **Embed task properties** (title + body only today) and richer body content — carry the corpus's captured `properties` into the embedding to lift borderline pairs above the floor.
3. Re-run this suite after each change to confirm the numbers move the right way.

## How to run

```
# from a nix develop shell with the local macrodb up and API keys exported
# (DATABASE_URL, OPENAI_API_KEY, ANTHROPIC_API_KEY, CEREBRAS_API_KEY)
cargo test -p task_dedup --test semantic_eval -- --ignored --nocapture

# regenerate the prod snapshot (read-only; requires aws auth)
cargo run -p task_dedup --features backfill --bin pull_task_corpus -- prod --limit 150 \
  --output rust/cloud-storage/task_dedup/fixtures/eval/prod.json
```

## Note

`fixtures/eval/prod.json` contains real internal task titles + property values (employee-created only, no customer data), committed intentionally so the eval reflects real usage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
