### PR TITLE
feat(soup): channel_thread participants filter

### DIFF
--- a/js/app/packages/service-clients/service-search/generated/models/channelThreadFilters.ts
+++ b/js/app/packages/service-clients/service-search/generated/models/channelThreadFilters.ts
@@ -11,6 +11,11 @@
 export interface ChannelThreadFilters {
   /** Channel IDs containing the thread. Empty to include threads from all accessible channels. */
   channel_ids?: string[];
+  /** Thread participant user IDs. A participant is the root message sender, anyone
+who replied in the thread, or anyone @-mentioned in the thread; a group mention
+(e.g. @here) makes every active channel member a participant. Empty to include
+threads regardless of participants. */
+  participant_ids?: string[];
   /** Sender IDs for the root thread message. Empty to include all root senders. */
   root_sender_ids?: string[];
   /** Channel thread parent message IDs to include. Empty to include all accessible threads. */

--- a/js/app/packages/service-clients/service-search/generated/models/channelThreadFilters.ts
+++ b/js/app/packages/service-clients/service-search/generated/models/channelThreadFilters.ts
@@ -12,9 +12,9 @@ export interface ChannelThreadFilters {
   /** Channel IDs containing the thread. Empty to include threads from all accessible channels. */
   channel_ids?: string[];
   /** Thread participant user IDs. A participant is the root message sender, anyone
-who replied in the thread, or anyone @-mentioned in the thread; a group mention
-(e.g. @here) makes every active channel member a participant. Empty to include
-threads regardless of participants. */
+who replied in the thread, or anyone @-mentioned in the thread (group mentions
+like @here count through their per-user expansion at send time). Empty to
+include threads regardless of participants. */
   participant_ids?: string[];
   /** Sender IDs for the root thread message. Empty to include all root senders. */
   root_sender_ids?: string[];

--- a/js/app/packages/service-clients/service-search/openapi.json
+++ b/js/app/packages/service-clients/service-search/openapi.json
@@ -639,7 +639,7 @@
             "items": {
               "type": "string"
             },
-            "description": "Thread participant user IDs. A participant is the root message sender, anyone\nwho replied in the thread, or anyone @-mentioned in the thread; a group mention\n(e.g. @here) makes every active channel member a participant. Empty to include\nthreads regardless of participants."
+            "description": "Thread participant user IDs. A participant is the root message sender, anyone\nwho replied in the thread, or anyone @-mentioned in the thread (group mentions\nlike @here count through their per-user expansion at send time). Empty to\ninclude threads regardless of participants."
           },
           "root_sender_ids": {
             "type": "array",

--- a/js/app/packages/service-clients/service-search/openapi.json
+++ b/js/app/packages/service-clients/service-search/openapi.json
@@ -634,6 +634,13 @@
             },
             "description": "Channel IDs containing the thread. Empty to include threads from all accessible channels."
           },
+          "participant_ids": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Thread participant user IDs. A participant is the root message sender, anyone\nwho replied in the thread, or anyone @-mentioned in the thread; a group mention\n(e.g. @here) makes every active channel member a participant. Empty to include\nthreads regardless of participants."
+          },
           "root_sender_ids": {
             "type": "array",
             "items": {

--- a/js/app/packages/service-clients/service-storage/generated/schemas/channelThreadFilters.ts
+++ b/js/app/packages/service-clients/service-storage/generated/schemas/channelThreadFilters.ts
@@ -11,6 +11,11 @@
 export interface ChannelThreadFilters {
   /** Channel IDs containing the thread. Empty to include threads from all accessible channels. */
   channel_ids?: string[];
+  /** Thread participant user IDs. A participant is the root message sender, anyone
+who replied in the thread, or anyone @-mentioned in the thread; a group mention
+(e.g. @here) makes every active channel member a participant. Empty to include
+threads regardless of participants. */
+  participant_ids?: string[];
   /** Sender IDs for the root thread message. Empty to include all root senders. */
   root_sender_ids?: string[];
   /** Channel thread parent message IDs to include. Empty to include all accessible threads. */

--- a/js/app/packages/service-clients/service-storage/generated/schemas/channelThreadFilters.ts
+++ b/js/app/packages/service-clients/service-storage/generated/schemas/channelThreadFilters.ts
@@ -12,9 +12,9 @@ export interface ChannelThreadFilters {
   /** Channel IDs containing the thread. Empty to include threads from all accessible channels. */
   channel_ids?: string[];
   /** Thread participant user IDs. A participant is the root message sender, anyone
-who replied in the thread, or anyone @-mentioned in the thread; a group mention
-(e.g. @here) makes every active channel member a participant. Empty to include
-threads regardless of participants. */
+who replied in the thread, or anyone @-mentioned in the thread (group mentions
+like @here count through their per-user expansion at send time). Empty to
+include threads regardless of participants. */
   participant_ids?: string[];
   /** Sender IDs for the root thread message. Empty to include all root senders. */
   root_sender_ids?: string[];

--- a/js/app/packages/service-clients/service-storage/generated/zod.ts
+++ b/js/app/packages/service-clients/service-storage/generated/zod.ts
@@ -8353,6 +8353,12 @@ export const postItemsSoupBody = zod
           .describe(
             'Channel IDs containing the thread. Empty to include threads from all accessible channels.'
           ),
+        participant_ids: zod
+          .array(zod.string())
+          .optional()
+          .describe(
+            'Thread participant user IDs. A participant is the root message sender, anyone\nwho replied in the thread, or anyone @-mentioned in the thread; a group mention\n(e.g. @here) makes every active channel member a participant. Empty to include\nthreads regardless of participants.'
+          ),
         root_sender_ids: zod
           .array(zod.string())
           .optional()

--- a/js/app/packages/service-clients/service-storage/generated/zod.ts
+++ b/js/app/packages/service-clients/service-storage/generated/zod.ts
@@ -8357,7 +8357,7 @@ export const postItemsSoupBody = zod
           .array(zod.string())
           .optional()
           .describe(
-            'Thread participant user IDs. A participant is the root message sender, anyone\nwho replied in the thread, or anyone @-mentioned in the thread; a group mention\n(e.g. @here) makes every active channel member a participant. Empty to include\nthreads regardless of participants.'
+            'Thread participant user IDs. A participant is the root message sender, anyone\nwho replied in the thread, or anyone @-mentioned in the thread (group mentions\nlike @here count through their per-user expansion at send time). Empty to\ninclude threads regardless of participants.'
           ),
         root_sender_ids: zod
           .array(zod.string())

--- a/js/app/packages/service-clients/service-storage/openapi.json
+++ b/js/app/packages/service-clients/service-storage/openapi.json
@@ -11433,6 +11433,13 @@
             },
             "description": "Channel IDs containing the thread. Empty to include threads from all accessible channels."
           },
+          "participant_ids": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Thread participant user IDs. A participant is the root message sender, anyone\nwho replied in the thread, or anyone @-mentioned in the thread; a group mention\n(e.g. @here) makes every active channel member a participant. Empty to include\nthreads regardless of participants."
+          },
           "root_sender_ids": {
             "type": "array",
             "items": {

--- a/js/app/packages/service-clients/service-storage/openapi.json
+++ b/js/app/packages/service-clients/service-storage/openapi.json
@@ -11438,7 +11438,7 @@
             "items": {
               "type": "string"
             },
-            "description": "Thread participant user IDs. A participant is the root message sender, anyone\nwho replied in the thread, or anyone @-mentioned in the thread; a group mention\n(e.g. @here) makes every active channel member a participant. Empty to include\nthreads regardless of participants."
+            "description": "Thread participant user IDs. A participant is the root message sender, anyone\nwho replied in the thread, or anyone @-mentioned in the thread (group mentions\nlike @here count through their per-user expansion at send time). Empty to\ninclude threads regardless of participants."
           },
           "root_sender_ids": {
             "type": "array",

--- a/rust/cloud-storage/channels/fixtures/channels_repo.sql
+++ b/rust/cloud-storage/channels/fixtures/channels_repo.sql
@@ -127,8 +127,10 @@ INSERT INTO comms_channel_participants (channel_id, user_id, role, joined_at, le
 --   t41 (10:00): user-c replied (10:05); left-user replied (10:06); a soft-deleted
 --       reply from user-e (10:07) that must NOT make user-e a participant
 --   t42 (11:00): user-c is @-mentioned in the root message
---   t43 (12:00): root message contains a group mention (@here)
---   t44 (13:00): plain root; a reply (13:05) contains a group mention (@here)
+--   t43 (12:00): root message contains a group mention (@here), stored as the
+--       client-side expansion: one user mention row per member at send time
+--   t44 (13:00): plain root; a reply (13:05) contains a group mention (@here),
+--       likewise expanded into per-user mention rows
 INSERT INTO comms_channels (id, name, channel_type, org_id, owner_id, created_at, updated_at) VALUES
   ('00000000-0000-0000-0000-000000000c04', 'participant-filter', 'public', NULL, 'macro|user-b@test.com',
    '2024-01-02 00:00:00+00', '2024-01-02 00:00:00+00');
@@ -172,6 +174,26 @@ INSERT INTO comms_messages (id, channel_id, thread_id, sender_id, content, creat
 INSERT INTO comms_entity_mentions (id, source_entity_type, source_entity_id, entity_type, entity_id, user_id, created_at) VALUES
   ('00000000-0000-0000-0000-00000000e042', 'message', '00000000-0000-0000-0000-000000000042',
    'user', 'macro|user-c@test.com', NULL, '2024-01-02 11:00:00+00');
+
+-- @here in t43's root message and t44's reply, as sent by the client: expanded into
+-- one user mention row per channel member at send time (left-user had not left yet)
+INSERT INTO comms_entity_mentions (id, source_entity_type, source_entity_id, entity_type, entity_id, user_id, created_at) VALUES
+  ('00000000-0000-0000-0000-00000000e431', 'message', '00000000-0000-0000-0000-000000000043',
+   'user', 'macro|user-b@test.com', NULL, '2024-01-02 12:00:00+00'),
+  ('00000000-0000-0000-0000-00000000e432', 'message', '00000000-0000-0000-0000-000000000043',
+   'user', 'macro|user-c@test.com', NULL, '2024-01-02 12:00:00+00'),
+  ('00000000-0000-0000-0000-00000000e433', 'message', '00000000-0000-0000-0000-000000000043',
+   'user', 'macro|user-e@test.com', NULL, '2024-01-02 12:00:00+00'),
+  ('00000000-0000-0000-0000-00000000e434', 'message', '00000000-0000-0000-0000-000000000043',
+   'user', 'macro|left-user@test.com', NULL, '2024-01-02 12:00:00+00'),
+  ('00000000-0000-0000-0000-00000000e441', 'message', '00000000-0000-0000-0000-00000000b044',
+   'user', 'macro|user-b@test.com', NULL, '2024-01-02 13:05:00+00'),
+  ('00000000-0000-0000-0000-00000000e442', 'message', '00000000-0000-0000-0000-00000000b044',
+   'user', 'macro|user-c@test.com', NULL, '2024-01-02 13:05:00+00'),
+  ('00000000-0000-0000-0000-00000000e443', 'message', '00000000-0000-0000-0000-00000000b044',
+   'user', 'macro|user-e@test.com', NULL, '2024-01-02 13:05:00+00'),
+  ('00000000-0000-0000-0000-00000000e444', 'message', '00000000-0000-0000-0000-00000000b044',
+   'user', 'macro|left-user@test.com', NULL, '2024-01-02 13:05:00+00');
 
 -- entity mentions (used by attachment-references tests)
 -- doc-mention is mentioned inside msg3 (a message source → channel reference, gated by participation)

--- a/rust/cloud-storage/channels/fixtures/channels_repo.sql
+++ b/rust/cloud-storage/channels/fixtures/channels_repo.sql
@@ -120,6 +120,59 @@ INSERT INTO comms_channel_participants (channel_id, user_id, role, joined_at, le
   ('00000000-0000-0000-0000-000000000c03', 'macro|user-a@test.com', 'owner', '2024-01-01 00:00:00+00', NULL),
   ('00000000-0000-0000-0000-000000000c03', 'macro|left-user@test.com', 'member', '2024-01-01 00:03:00+00', '2024-01-05 00:00:00+00');
 
+-- Channel ch4: participant-filter fixture (no user-a so ch4 threads stay out of the
+-- user-a listing assertions above).
+-- Participants: user-b (owner), user-c (member), user-e (member), left-user (left).
+-- Threads (all rooted by user-b):
+--   t41 (10:00): user-c replied (10:05); left-user replied (10:06); a soft-deleted
+--       reply from user-e (10:07) that must NOT make user-e a participant
+--   t42 (11:00): user-c is @-mentioned in the root message
+--   t43 (12:00): root message contains a group mention (@here)
+--   t44 (13:00): plain root; a reply (13:05) contains a group mention (@here)
+INSERT INTO comms_channels (id, name, channel_type, org_id, owner_id, created_at, updated_at) VALUES
+  ('00000000-0000-0000-0000-000000000c04', 'participant-filter', 'public', NULL, 'macro|user-b@test.com',
+   '2024-01-02 00:00:00+00', '2024-01-02 00:00:00+00');
+
+INSERT INTO comms_channel_participants (channel_id, user_id, role, joined_at, left_at) VALUES
+  ('00000000-0000-0000-0000-000000000c04', 'macro|user-b@test.com', 'owner', '2024-01-02 00:00:00+00', NULL),
+  ('00000000-0000-0000-0000-000000000c04', 'macro|user-c@test.com', 'member', '2024-01-02 00:01:00+00', NULL),
+  ('00000000-0000-0000-0000-000000000c04', 'macro|user-e@test.com', 'member', '2024-01-02 00:02:00+00', NULL),
+  ('00000000-0000-0000-0000-000000000c04', 'macro|left-user@test.com', 'member', '2024-01-02 00:03:00+00', '2024-01-05 00:00:00+00');
+
+INSERT INTO comms_messages (id, channel_id, thread_id, sender_id, content, created_at, updated_at, edited_at, deleted_at) VALUES
+  -- t41: replies determine participants
+  ('00000000-0000-0000-0000-000000000041', '00000000-0000-0000-0000-000000000c04', NULL,
+   'macro|user-b@test.com', 'participant thread parent', '2024-01-02 10:00:00+00', '2024-01-02 10:00:00+00', NULL, NULL),
+  ('00000000-0000-0000-0000-00000000b041', '00000000-0000-0000-0000-000000000c04',
+   '00000000-0000-0000-0000-000000000041', 'macro|user-c@test.com', 'reply from user-c',
+   '2024-01-02 10:05:00+00', '2024-01-02 10:05:00+00', NULL, NULL),
+  ('00000000-0000-0000-0000-00000000b042', '00000000-0000-0000-0000-000000000c04',
+   '00000000-0000-0000-0000-000000000041', 'macro|left-user@test.com', 'reply from departed user',
+   '2024-01-02 10:06:00+00', '2024-01-02 10:06:00+00', NULL, NULL),
+  ('00000000-0000-0000-0000-00000000b043', '00000000-0000-0000-0000-000000000c04',
+   '00000000-0000-0000-0000-000000000041', 'macro|user-e@test.com', 'deleted reply from user-e',
+   '2024-01-02 10:07:00+00', '2024-01-02 10:07:00+00', NULL, '2024-01-02 10:08:00+00'),
+  -- t42: @-mention determines participants (mention row below)
+  ('00000000-0000-0000-0000-000000000042', '00000000-0000-0000-0000-000000000c04', NULL,
+   'macro|user-b@test.com', 'mentioning <m-user-mention>{"userId":"macro|user-c@test.com","email":"user-c@test.com"}</m-user-mention>',
+   '2024-01-02 11:00:00+00', '2024-01-02 11:00:00+00', NULL, NULL),
+  -- t43: group mention in the root message
+  ('00000000-0000-0000-0000-000000000043', '00000000-0000-0000-0000-000000000c04', NULL,
+   'macro|user-b@test.com', 'heads up <m-group-mention>{"groupAlias":"here"}</m-group-mention>',
+   '2024-01-02 12:00:00+00', '2024-01-02 12:00:00+00', NULL, NULL),
+  -- t44: group mention in a reply
+  ('00000000-0000-0000-0000-000000000044', '00000000-0000-0000-0000-000000000c04', NULL,
+   'macro|user-b@test.com', 'plain parent', '2024-01-02 13:00:00+00', '2024-01-02 13:00:00+00', NULL, NULL),
+  ('00000000-0000-0000-0000-00000000b044', '00000000-0000-0000-0000-000000000c04',
+   '00000000-0000-0000-0000-000000000044', 'macro|user-b@test.com',
+   'pinging <m-group-mention>{"groupAlias":"here"}</m-group-mention>',
+   '2024-01-02 13:05:00+00', '2024-01-02 13:05:00+00', NULL, NULL);
+
+-- user-c is @-mentioned in t42's root message
+INSERT INTO comms_entity_mentions (id, source_entity_type, source_entity_id, entity_type, entity_id, user_id, created_at) VALUES
+  ('00000000-0000-0000-0000-00000000e042', 'message', '00000000-0000-0000-0000-000000000042',
+   'user', 'macro|user-c@test.com', NULL, '2024-01-02 11:00:00+00');
+
 -- entity mentions (used by attachment-references tests)
 -- doc-mention is mentioned inside msg3 (a message source → channel reference, gated by participation)
 -- doc-generic is mentioned by a non-message source (doc → generic reference, not gated)

--- a/rust/cloud-storage/channels/src/outbound/pg_channels_repo.rs
+++ b/rust/cloud-storage/channels/src/outbound/pg_channels_repo.rs
@@ -854,6 +854,9 @@ fn push_channel_thread_filter_expr(
             builder.push("m.sender_id = ");
             builder.push_bind(sender.as_ref().to_string());
         }
+        Expr::Literal(ChannelThreadLiteral::Participant(participant)) => {
+            push_channel_thread_participant_filter_expr(builder, participant);
+        }
         Expr::Literal(ChannelThreadLiteral::NotificationDone(done)) => {
             push_channel_thread_notification_filter_expr(
                 builder,
@@ -877,6 +880,67 @@ fn push_channel_thread_filter_expr(
             );
         }
     }
+}
+
+/// SQL LIKE pattern matching a group mention tag (e.g. @here) in message content.
+/// Group mentions are only persisted inside the message body as
+/// `<m-group-mention>{"groupAlias":"..."}</m-group-mention>` tags (see the
+/// `mention_utils` crate); they have no rows in `comms_entity_mentions`.
+#[cfg(feature = "list")]
+const GROUP_MENTION_LIKE_PATTERN: &str = "%<m-group-mention>%";
+
+/// A user is a participant of a thread when they are still an active member of the
+/// channel AND they sent the root message or any reply, were @-mentioned anywhere in
+/// the thread, or the thread contains a group mention (e.g. @here), which makes every
+/// active channel member a participant.
+#[cfg(feature = "list")]
+fn push_channel_thread_participant_filter_expr(
+    builder: &mut QueryBuilder<'static, Postgres>,
+    participant: &MacroUserIdStr<'_>,
+) {
+    let participant = participant.as_ref().to_string();
+    builder.push(
+        r#"(EXISTS (
+            SELECT 1
+            FROM comms_channel_participants pcp
+            WHERE pcp.channel_id = m.channel_id
+              AND pcp.user_id = "#,
+    );
+    builder.push_bind(participant.clone());
+    builder.push(
+        r#"
+              AND pcp.left_at IS NULL
+        ) AND EXISTS (
+            SELECT 1
+            FROM comms_messages tm
+            WHERE (tm.id = m.id OR tm.thread_id = m.id)
+              AND tm.deleted_at IS NULL
+              AND (
+                tm.sender_id = "#,
+    );
+    builder.push_bind(participant.clone());
+    builder.push(
+        r#"
+                OR tm.content LIKE "#,
+    );
+    builder.push_bind(GROUP_MENTION_LIKE_PATTERN);
+    builder.push(
+        r#"
+                OR EXISTS (
+                    SELECT 1
+                    FROM comms_entity_mentions em
+                    WHERE em.source_entity_type = 'message'
+                      AND em.source_entity_id = tm.id::text
+                      AND em.entity_type = 'user'
+                      AND em.entity_id = "#,
+    );
+    builder.push_bind(participant);
+    builder.push(
+        r#"
+                )
+              )
+        ))"#,
+    );
 }
 
 #[cfg(feature = "list")]

--- a/rust/cloud-storage/channels/src/outbound/pg_channels_repo.rs
+++ b/rust/cloud-storage/channels/src/outbound/pg_channels_repo.rs
@@ -882,17 +882,19 @@ fn push_channel_thread_filter_expr(
     }
 }
 
-/// SQL LIKE pattern matching a group mention tag (e.g. @here) in message content.
-/// Group mentions are only persisted inside the message body as
-/// `<m-group-mention>{"groupAlias":"..."}</m-group-mention>` tags (see the
-/// `mention_utils` crate); they have no rows in `comms_entity_mentions`.
-#[cfg(feature = "list")]
-const GROUP_MENTION_LIKE_PATTERN: &str = "%<m-group-mention>%";
-
 /// A user is a participant of a thread when they are still an active member of the
-/// channel AND they sent the root message or any reply, were @-mentioned anywhere in
-/// the thread, or the thread contains a group mention (e.g. @here), which makes every
-/// active channel member a participant.
+/// channel AND they sent the root message or any reply, or were @-mentioned anywhere
+/// in the thread.
+///
+/// Group mentions (e.g. @here) are covered indirectly: the client expands them into
+/// per-user mention rows for every channel member at send time, so they match the
+/// mention arm below. That expansion is a send-time snapshot made by a single
+/// producer (the web client) — members who join the channel later, and messages from
+/// producers that don't expand (bots, webhooks), are missed. TODO: persist group
+/// mentions as `entity_type = 'group'` rows in `comms_entity_mentions` (parsed
+/// server-side from the `<m-group-mention>` content tag, see `mention_utils`) and
+/// add an arm here treating every active channel member as a participant of threads
+/// containing one.
 #[cfg(feature = "list")]
 fn push_channel_thread_participant_filter_expr(
     builder: &mut QueryBuilder<'static, Postgres>,
@@ -919,11 +921,6 @@ fn push_channel_thread_participant_filter_expr(
                 tm.sender_id = "#,
     );
     builder.push_bind(participant.clone());
-    builder.push(
-        r#"
-                OR tm.content LIKE "#,
-    );
-    builder.push_bind(GROUP_MENTION_LIKE_PATTERN);
     builder.push(
         r#"
                 OR EXISTS (

--- a/rust/cloud-storage/channels/src/outbound/pg_channels_repo/tests.rs
+++ b/rust/cloud-storage/channels/src/outbound/pg_channels_repo/tests.rs
@@ -402,9 +402,8 @@ async fn threads_matching_participant(
 async fn channel_thread_rows_filter_by_participant_reply_and_mention(
     pool: Pool<Postgres>,
 ) -> anyhow::Result<()> {
-    // user-c replied in t41, is @-mentioned in t42, and is an active ch4 member so the
-    // group mentions in t43/t44 include them too. No ch1 threads match despite user-c
-    // being a ch1 member.
+    // user-c replied in t41, is @-mentioned in t42, and is in the @here expansion
+    // rows on t43/t44. No ch1 threads match despite user-c being a ch1 member.
     let parent_ids = threads_matching_participant(pool, USER_B, USER_C).await?;
     assert_eq!(parent_ids, vec![T44, T43, T42, T41]);
     Ok(())
@@ -417,8 +416,8 @@ async fn channel_thread_rows_filter_by_participant_reply_and_mention(
 async fn channel_thread_rows_filter_by_participant_group_mention(
     pool: Pool<Postgres>,
 ) -> anyhow::Result<()> {
-    // user-e never posted or got @-mentioned (their only reply is soft-deleted), so
-    // only the group-mention threads match: t43 (root @here) and t44 (reply @here).
+    // user-e's only reply is soft-deleted, so they match only through the @here
+    // expansion rows: t43 (root @here) and t44 (reply @here).
     let parent_ids = threads_matching_participant(pool, USER_B, USER_E).await?;
     assert_eq!(parent_ids, vec![T44, T43]);
     Ok(())
@@ -445,8 +444,8 @@ async fn channel_thread_rows_filter_by_participant_root_sender(
 async fn channel_thread_rows_filter_by_participant_excludes_departed_users(
     pool: Pool<Postgres>,
 ) -> anyhow::Result<()> {
-    // left-user replied in t41 and the channel has group mentions, but they left the
-    // channel, so nothing matches.
+    // left-user replied in t41 and sits in the @here expansion rows on t43/t44, but
+    // they left the channel, so nothing matches.
     let parent_ids = threads_matching_participant(pool, USER_B, LEFT_USER).await?;
     assert!(parent_ids.is_empty());
     Ok(())

--- a/rust/cloud-storage/channels/src/outbound/pg_channels_repo/tests.rs
+++ b/rust/cloud-storage/channels/src/outbound/pg_channels_repo/tests.rs
@@ -39,8 +39,15 @@ const REPLY4: Uuid = Uuid::from_u128(0x00000000_0000_0000_0000_00000000b005);
 const DELETED_MSG_ATTACHMENT: Uuid = Uuid::from_u128(0x00000000_0000_0000_0000_00000000a004);
 const USER_A: &str = "macro|user-a@test.com";
 const USER_B: &str = "macro|user-b@test.com";
+const USER_C: &str = "macro|user-c@test.com";
 const NON_MEMBER: &str = "macro|user-d@test.com";
+const USER_E: &str = "macro|user-e@test.com";
 const LEFT_USER: &str = "macro|left-user@test.com";
+// Participant-filter fixture threads in ch4 (see channels_repo.sql).
+const T41: Uuid = Uuid::from_u128(0x00000000_0000_0000_0000_000000000041);
+const T42: Uuid = Uuid::from_u128(0x00000000_0000_0000_0000_000000000042);
+const T43: Uuid = Uuid::from_u128(0x00000000_0000_0000_0000_000000000043);
+const T44: Uuid = Uuid::from_u128(0x00000000_0000_0000_0000_000000000044);
 
 fn repo(pool: Pool<Postgres>) -> PgChannelsRepo {
     PgChannelsRepo::new(pool)
@@ -363,6 +370,85 @@ async fn channel_thread_rows_filter_by_root_sender(pool: Pool<Postgres>) -> anyh
 
     let parent_ids = rows.iter().map(|row| row.id).collect::<Vec<_>>();
     assert_eq!(parent_ids, vec![MSG3, MSG1, MSG31]);
+    Ok(())
+}
+
+async fn threads_matching_participant(
+    pool: Pool<Postgres>,
+    querying_user: &str,
+    participant: &str,
+) -> anyhow::Result<Vec<Uuid>> {
+    let rows = repo(pool)
+        .get_thread_messages(
+            thread_rows_request(
+                querying_user,
+                thread_filter(ChannelThreadLiteral::Participant(macro_user_id(
+                    participant,
+                ))),
+                SimpleSortMethod::UpdatedAt,
+                50,
+            )
+            .into_params(),
+        )
+        .await
+        .map_err(report_err)?;
+    Ok(rows.iter().map(|row| row.id).collect())
+}
+
+#[sqlx::test(
+    fixtures(path = "../../../fixtures", scripts("channels_repo")),
+    migrator = "MACRO_DB_MIGRATIONS"
+)]
+async fn channel_thread_rows_filter_by_participant_reply_and_mention(
+    pool: Pool<Postgres>,
+) -> anyhow::Result<()> {
+    // user-c replied in t41, is @-mentioned in t42, and is an active ch4 member so the
+    // group mentions in t43/t44 include them too. No ch1 threads match despite user-c
+    // being a ch1 member.
+    let parent_ids = threads_matching_participant(pool, USER_B, USER_C).await?;
+    assert_eq!(parent_ids, vec![T44, T43, T42, T41]);
+    Ok(())
+}
+
+#[sqlx::test(
+    fixtures(path = "../../../fixtures", scripts("channels_repo")),
+    migrator = "MACRO_DB_MIGRATIONS"
+)]
+async fn channel_thread_rows_filter_by_participant_group_mention(
+    pool: Pool<Postgres>,
+) -> anyhow::Result<()> {
+    // user-e never posted or got @-mentioned (their only reply is soft-deleted), so
+    // only the group-mention threads match: t43 (root @here) and t44 (reply @here).
+    let parent_ids = threads_matching_participant(pool, USER_B, USER_E).await?;
+    assert_eq!(parent_ids, vec![T44, T43]);
+    Ok(())
+}
+
+#[sqlx::test(
+    fixtures(path = "../../../fixtures", scripts("channels_repo")),
+    migrator = "MACRO_DB_MIGRATIONS"
+)]
+async fn channel_thread_rows_filter_by_participant_root_sender(
+    pool: Pool<Postgres>,
+) -> anyhow::Result<()> {
+    // user-b rooted every ch4 thread and replied to msg1 in ch1; msg3 doesn't match
+    // because channel membership alone doesn't make a participant.
+    let parent_ids = threads_matching_participant(pool, USER_B, USER_B).await?;
+    assert_eq!(parent_ids, vec![T44, T43, T42, T41, MSG1]);
+    Ok(())
+}
+
+#[sqlx::test(
+    fixtures(path = "../../../fixtures", scripts("channels_repo")),
+    migrator = "MACRO_DB_MIGRATIONS"
+)]
+async fn channel_thread_rows_filter_by_participant_excludes_departed_users(
+    pool: Pool<Postgres>,
+) -> anyhow::Result<()> {
+    // left-user replied in t41 and the channel has group mentions, but they left the
+    // channel, so nothing matches.
+    let parent_ids = threads_matching_participant(pool, USER_B, LEFT_USER).await?;
+    assert!(parent_ids.is_empty());
     Ok(())
 }
 

--- a/rust/cloud-storage/graphql_soup/src/inputs.rs
+++ b/rust/cloud-storage/graphql_soup/src/inputs.rs
@@ -632,6 +632,7 @@ enum GraphqlChannelThreadLiteral {
     ThreadId(ID),
     ChannelId(ID),
     RootSender(String),
+    Participant(String),
     NotificationDone(bool),
     NotificationSeen(bool),
 }
@@ -643,6 +644,9 @@ impl IntoFilterExpr<ChannelThreadLiteral> for GraphqlChannelThreadLiteral {
             Self::ChannelId(id) => ChannelThreadLiteral::ChannelId(parse_id(id, "channelId")?),
             Self::RootSender(sender) => {
                 ChannelThreadLiteral::RootSender(parse_macro_user_id(sender, "rootSender")?)
+            }
+            Self::Participant(participant) => {
+                ChannelThreadLiteral::Participant(parse_macro_user_id(participant, "participant")?)
             }
             Self::NotificationDone(done) => ChannelThreadLiteral::NotificationDone(done),
             Self::NotificationSeen(seen) => ChannelThreadLiteral::NotificationSeen(seen),

--- a/rust/cloud-storage/item_filters/src/ast/channel.rs
+++ b/rust/cloud-storage/item_filters/src/ast/channel.rs
@@ -150,6 +150,10 @@ pub enum ChannelThreadLiteral {
     ChannelId(Uuid),
     /// The sender of the root thread message must be the included user.
     RootSender(MacroUserIdStr<'static>),
+    /// The included user must be a participant of the thread: the root message sender,
+    /// anyone who replied in the thread, or anyone @-mentioned in the thread. A group
+    /// mention (e.g. @here) makes every active channel member a participant.
+    Participant(MacroUserIdStr<'static>),
     /// this node value filters by notification done state for the thread notification.
     NotificationDone(bool),
     /// this node value filters by notification seen state for the thread notification.
@@ -166,6 +170,7 @@ impl ExpandFrame<ChannelThreadLiteral> for ChannelThreadFilters {
             thread_ids,
             channel_ids,
             root_sender_ids,
+            participant_ids,
         } = filter_request;
 
         let thread_ids = thread_ids
@@ -183,7 +188,12 @@ impl ExpandFrame<ChannelThreadLiteral> for ChannelThreadFilters {
             .map(|s| MacroUserIdStr::parse_from_str(s).map(CowLike::into_owned))
             .try_expand(|r| r.map(ChannelThreadLiteral::RootSender), Expr::or)?;
 
-        Ok([thread_ids, channel_ids, root_sender_ids]
+        let participant_ids = participant_ids
+            .iter()
+            .map(|s| MacroUserIdStr::parse_from_str(s).map(CowLike::into_owned))
+            .try_expand(|r| r.map(ChannelThreadLiteral::Participant), Expr::or)?;
+
+        Ok([thread_ids, channel_ids, root_sender_ids, participant_ids]
             .into_iter()
             .fold_with(Expr::and))
     }

--- a/rust/cloud-storage/item_filters/src/ast/channel.rs
+++ b/rust/cloud-storage/item_filters/src/ast/channel.rs
@@ -151,8 +151,8 @@ pub enum ChannelThreadLiteral {
     /// The sender of the root thread message must be the included user.
     RootSender(MacroUserIdStr<'static>),
     /// The included user must be a participant of the thread: the root message sender,
-    /// anyone who replied in the thread, or anyone @-mentioned in the thread. A group
-    /// mention (e.g. @here) makes every active channel member a participant.
+    /// anyone who replied in the thread, or anyone @-mentioned in the thread (group
+    /// mentions like @here count through their per-user expansion at send time).
     Participant(MacroUserIdStr<'static>),
     /// this node value filters by notification done state for the thread notification.
     NotificationDone(bool),

--- a/rust/cloud-storage/item_filters/src/ast/tests.rs
+++ b/rust/cloud-storage/item_filters/src/ast/tests.rs
@@ -344,6 +344,7 @@ fn it_expands_channel_thread_filters() {
             thread_ids: vec![thread_id.to_string()],
             channel_ids: vec![channel_id.to_string()],
             root_sender_ids: vec!["macro|hello@test.com".to_string()],
+            participant_ids: vec!["macro|participant@test.com".to_string()],
         },
         ..Default::default()
     };
@@ -385,6 +386,35 @@ fn it_expands_single_channel_thread_id() {
     let exp = json!({
         "l": {
             "ThreadId": thread_id
+        }
+    });
+
+    assert_eq!(json, exp);
+}
+
+#[test]
+fn it_expands_single_channel_thread_participant() {
+    let f = EntityFilters {
+        channel_thread_filters: crate::ChannelThreadFilters {
+            participant_ids: vec!["macro|participant@test.com".to_string()],
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let ast = Arc::into_inner(
+        EntityFilterAst::new_from_filters(f)
+            .unwrap()
+            .unwrap()
+            .channel_thread_filter
+            .unwrap(),
+    )
+    .unwrap();
+
+    let json = serde_json::to_value(ast).unwrap();
+    let exp = json!({
+        "l": {
+            "Participant": "macro|participant@test.com"
         }
     });
 

--- a/rust/cloud-storage/item_filters/src/lib.rs
+++ b/rust/cloud-storage/item_filters/src/lib.rs
@@ -487,6 +487,13 @@ pub struct ChannelThreadFilters {
     /// Sender IDs for the root thread message. Empty to include all root senders.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub root_sender_ids: Vec<String>,
+
+    /// Thread participant user IDs. A participant is the root message sender, anyone
+    /// who replied in the thread, or anyone @-mentioned in the thread; a group mention
+    /// (e.g. @here) makes every active channel member a participant. Empty to include
+    /// threads regardless of participants.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub participant_ids: Vec<String>,
 }
 
 impl IsEmpty for ChannelThreadFilters {
@@ -495,8 +502,12 @@ impl IsEmpty for ChannelThreadFilters {
             thread_ids,
             channel_ids,
             root_sender_ids,
+            participant_ids,
         } = self;
-        thread_ids.is_empty() && channel_ids.is_empty() && root_sender_ids.is_empty()
+        thread_ids.is_empty()
+            && channel_ids.is_empty()
+            && root_sender_ids.is_empty()
+            && participant_ids.is_empty()
     }
 }
 

--- a/rust/cloud-storage/item_filters/src/lib.rs
+++ b/rust/cloud-storage/item_filters/src/lib.rs
@@ -489,9 +489,9 @@ pub struct ChannelThreadFilters {
     pub root_sender_ids: Vec<String>,
 
     /// Thread participant user IDs. A participant is the root message sender, anyone
-    /// who replied in the thread, or anyone @-mentioned in the thread; a group mention
-    /// (e.g. @here) makes every active channel member a participant. Empty to include
-    /// threads regardless of participants.
+    /// who replied in the thread, or anyone @-mentioned in the thread (group mentions
+    /// like @here count through their per-user expansion at send time). Empty to
+    /// include threads regardless of participants.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub participant_ids: Vec<String>,
 }

--- a/rust/cloud-storage/schema.graphql
+++ b/rust/cloud-storage/schema.graphql
@@ -65,6 +65,7 @@ input GraphqlChannelThreadLiteral @oneOf {
 	threadId: ID
 	channelId: ID
 	rootSender: String
+	participant: String
 	notificationDone: Boolean
 	notificationSeen: Boolean
 }


### PR DESCRIPTION
Adds a `participants` filter to the `channel_thread` entity across all three soup surfaces (regular typed filters, AST endpoint, and GraphQL).

A user is a **participant** of a thread when they are still an active member of the channel AND any of:
- they sent the root message or any reply in the thread,
- they were @-mentioned anywhere in the thread.

Group mentions (`@here`) are covered by the second arm: the client expands them into per-user mention rows for every channel member at send time. That expansion is a send-time snapshot from the web client only, so members who join later and messages from non-expanding producers (bots, webhooks) are missed — a TODO on the filter documents the follow-up of persisting group mentions as `entity_type = 'group'` rows in `comms_entity_mentions` (parsed server-side from the `<m-group-mention>` content tag) and treating every active member as a participant of threads containing one.

**How**
- `item_filters`: new `participant_ids` field on `ChannelThreadFilters` and a `Participant` variant on `ChannelThreadLiteral`. The AST endpoint (`cthf`) and MCP toolset pick the new literal up automatically.
- `channels`: `push_channel_thread_filter_expr` compiles the literal to an `EXISTS` subquery over the thread's non-deleted messages (senders) and `comms_entity_mentions` user mentions, gated on active channel membership (`left_at IS NULL`), mirroring the semantics of `get_channel_participants_for_thread_id`.
- `graphql_soup`: `participant` oneof field on `GraphqlChannelThreadLiteral`; `schema.graphql` regenerated.
- `service-clients`: `openapi.json` + generated types updated for the new field (storage and search).