### PR TITLE
fix(email): preview signatures on white and inline paragraph margins

### DIFF
--- a/js/app/packages/app/component/settings/SignatureEditor.css
+++ b/js/app/packages/app/component/settings/SignatureEditor.css
@@ -25,9 +25,18 @@
   vertical-align: middle;
 }
 
+/* The editor surface is always white with near-black text, regardless of app
+   theme: the signature is sent as HTML email and recipients see it on white, so
+   the editor previews exactly that — and pasted light-UI content (e.g. Gmail
+   signatures with white text backgrounds) doesn't render as white boxes in dark
+   mode. */
+.signature-editor .ql-container.ql-snow {
+  background-color: white;
+}
+
 .signature-editor .ql-editor {
   min-height: 8rem;
-  color: var(--color-ink);
+  color: #1f1f1f;
 }
 
 .signature-editor .ql-editor img {
@@ -43,7 +52,7 @@
   position: absolute;
   display: none;
   box-sizing: border-box;
-  box-shadow: 0 0 0 2px var(--color-edge-muted);
+  box-shadow: 0 0 0 2px rgba(0 0 0 / 0.15);
   pointer-events: none;
   z-index: 1;
 }
@@ -57,7 +66,8 @@
   touch-action: none;
   pointer-events: auto;
 }
-/* The visible pill bar (matches the doc block's bg-ink / ring-surface bar). */
+/* The visible pill bar (matches the doc block's bg-ink / ring-surface bar).
+   Fixed colors, not ink/surface tokens: the editor surface is always white. */
 .signature-editor .ql-image-resizer-handle::before {
   content: '';
   position: absolute;
@@ -67,8 +77,8 @@
   height: 50%;
   min-height: 2rem;
   transform: translateY(-50%);
-  background-color: var(--color-ink);
-  box-shadow: 0 0 0 2px var(--color-surface);
+  background-color: #1f1f1f;
+  box-shadow: 0 0 0 2px white;
   border-radius: 9999px;
   opacity: 0.5;
   transition: all 200ms ease;
@@ -84,8 +94,10 @@
   transform: translateY(-50%) scale(1.2);
 }
 
+/* Fixed grey (not the theme's muted ink, which is light in dark mode and would
+   vanish on the always-white surface). */
 .signature-editor .ql-editor.ql-blank::before {
-  color: var(--color-ink-muted);
+  color: #8a8a8a;
   font-style: normal;
 }
 

--- a/js/app/packages/app/component/settings/SignatureEditor.tsx
+++ b/js/app/packages/app/component/settings/SignatureEditor.tsx
@@ -97,21 +97,22 @@ export default function SignatureEditor(props: {
         : op.insert != null
     );
     if (!hasContent) return '';
-    // Quill emits one bare <p> per line. The sent email carries no stylesheet,
-    // so recipients' clients would apply their default ~1em paragraph margins
-    // (the editor and previews zero them via app CSS) — inline margin:0 so the
-    // wire format matches what the editor shows.
+    // Quill emits one bare <p> per line (and bare <ul>/<ol> for lists). The
+    // sent email carries no stylesheet, so recipients' clients would apply
+    // their default ~1em block margins (the editor and previews zero them via
+    // app CSS) — inline margin:0 so the wire format matches what the editor
+    // shows.
     const doc = new DOMParser().parseFromString(
       quill.getSemanticHTML(),
       'text/html'
     );
-    for (const p of doc.body.querySelectorAll('p')) {
-      p.style.setProperty('margin', '0');
+    for (const el of doc.body.querySelectorAll<HTMLElement>('p, ul, ol')) {
+      el.style.setProperty('margin', '0');
       // getSemanticHTML drops the placeholder <br> from blank lines, and with
       // margins zeroed an empty <p> collapses to nothing — put the <br> back so
       // blank separator lines keep their one-line height in the sent email.
-      if (!p.textContent && !p.querySelector('br, img')) {
-        p.append(doc.createElement('br'));
+      if (el.tagName === 'P' && !el.textContent && !el.querySelector('br, img')) {
+        el.append(doc.createElement('br'));
       }
     }
     return doc.body.innerHTML;

--- a/js/app/packages/app/component/settings/SignatureEditor.tsx
+++ b/js/app/packages/app/component/settings/SignatureEditor.tsx
@@ -97,7 +97,24 @@ export default function SignatureEditor(props: {
         : op.insert != null
     );
     if (!hasContent) return '';
-    return quill.getSemanticHTML();
+    // Quill emits one bare <p> per line. The sent email carries no stylesheet,
+    // so recipients' clients would apply their default ~1em paragraph margins
+    // (the editor and previews zero them via app CSS) — inline margin:0 so the
+    // wire format matches what the editor shows.
+    const doc = new DOMParser().parseFromString(
+      quill.getSemanticHTML(),
+      'text/html'
+    );
+    for (const p of doc.body.querySelectorAll('p')) {
+      p.style.setProperty('margin', '0');
+      // getSemanticHTML drops the placeholder <br> from blank lines, and with
+      // margins zeroed an empty <p> collapses to nothing — put the <br> back so
+      // blank separator lines keep their one-line height in the sent email.
+      if (!p.textContent && !p.querySelector('br, img')) {
+        p.append(doc.createElement('br'));
+      }
+    }
+    return doc.body.innerHTML;
   };
 
   const setHtml = (html: string) => {

--- a/js/app/packages/block-email/component/compose/SignaturePreview.tsx
+++ b/js/app/packages/block-email/component/compose/SignaturePreview.tsx
@@ -7,13 +7,16 @@ import { createEffect, createSignal } from 'solid-js';
 // Rendered inside a shadow root so the signature's structural markup (lists,
 // headings, bold) keeps its default styling instead of being flattened by the
 // app's global CSS reset — the same isolation EmailMessageBody uses for received
-// mail. CSS custom properties still pierce the boundary, so --color-ink themes
-// any text the signature didn't color itself.
+// mail. Near-black text on the always-white surface below (not theme ink):
+// recipients see the signature on white, and pasted light-UI content would
+// otherwise show as white boxes in dark mode. Links keep the UA default blue,
+// matching what mail clients do with unstyled anchors. Paragraph margins are
+// deliberately NOT reset here: recipients' clients don't reset them either, so
+// the preview shows the signature's real spacing (the editor inlines margin:0
+// on its <p>s at save time — see SignatureEditor's currentHtml).
 const SHADOW_STYLE = `
-  :host { color: var(--color-ink); font-family: inherit; }
+  :host { color: #1f1f1f; font-family: inherit; }
   img { max-width: 100%; height: auto; }
-  p { margin: 0; }
-  a { color: inherit; }
 `;
 
 /**
@@ -86,7 +89,7 @@ export function SignaturePreview(props: {
       </div>
       <div
         ref={mountEl}
-        class="px-3 py-2 text-sm"
+        class="rounded-b-lg bg-[white] px-3 py-2 text-sm"
         classList={{ hidden: !expanded() }}
       />
     </div>


### PR DESCRIPTION
## Problem

Follow-ups to #4408, from testing with a real Gmail signature:

1. **Dark theme**: signature HTML pasted from a light UI (e.g. Gmail) carries white text-backgrounds, which rendered as white boxes behind each line in the settings editor and compose/reply previews.
2. **Sent spacing**: Quill serializes each line as a bare `<p>`. Every surface we control zeroes paragraph margins via app CSS, but the sent email carries no stylesheet — recipients' clients (and our own thread view) apply their default ~1em paragraph margins, so a tight Gmail-style signature arrived with a blank-line-sized gap after every line.

## Changes

**Preview on white (`SignatureEditor.css`, `SignaturePreview.tsx`)**
- The settings editor surface and the compose/reply/AI signature previews now render on an always-white background with near-black text, regardless of app theme — the signature is shown the way recipients will actually see it, and pasted light-UI content blends in instead of showing white boxes in dark mode.
- Placeholder text and the image-resizer overlay switch from theme tokens (invisible on white in dark mode) to fixed colors.
- The preview no longer resets `p` margins or link colors in its shadow styles: recipients' clients don't reset them either, so the preview reflects the real wire format (an unfixed old signature honestly shows its spacing problem).

**Self-describing wire format (`SignatureEditor.tsx`)**
- On save, the editor post-processes Quill's HTML to inline `margin: 0` on every `<p>` (the backend sanitizer already allows `margin`), so the sent signature keeps the editor's tight line spacing in any client.
- Quill's `getSemanticHTML()` drops the placeholder `<br>` from blank lines, and with margins zeroed an empty `<p>` collapses to nothing — the same pass re-inserts the `<br>` so intentional blank separator lines keep their one-line height.

Verified end-to-end: a Gmail signature pasted in dark theme now reads correctly in the editor, previews on white in compose, and arrives in Outlook with the original tight spacing and separator lines intact.

Existing saved signatures pick up the margin fix on their next save; a backend rewrite at injection time (to repair already-saved signatures without a re-save) is a possible follow-up.