### PR TITLE
fix: RecipientSelector to preserve filtered-out selected options

### DIFF
--- a/js/app/packages/core/component/RecipientSelector.tsx
+++ b/js/app/packages/core/component/RecipientSelector.tsx
@@ -529,6 +529,23 @@ export function RecipientSelector<K extends CombinedRecipientKind>(
     return allOptions as CombinedRecipientItem<K>[];
   });
 
+  const visibleOptionKeys = createMemo(
+    () => new Set(options().map(getRecipientOptionValue))
+  );
+
+  // Kobalte resolves selected values against the `options` prop
+  // (getOptionsFromValues) and silently drops any selection it can't find
+  // there, so selected options that the search filtered out must stay in the
+  // collection. `defaultFilter` keeps them hidden from the dropdown.
+  const optionsWithSelected = createMemo(() => {
+    const visible = options();
+    const keys = visibleOptionKeys();
+    const hiddenSelected = (
+      props.selectedOptions as CombinedRecipientItem[]
+    ).filter((option) => !keys.has(getRecipientOptionValue(option)));
+    return [...visible, ...hiddenSelected];
+  });
+
   const [scrollToItem, setScrollToItem] = createSignal<(key: string) => void>(
     () => {}
   );
@@ -559,12 +576,14 @@ export function RecipientSelector<K extends CombinedRecipientKind>(
         onOpenChange={setIsOpen}
         disabled={props.disabled}
         validationState={invalid() ? 'invalid' : 'valid'}
-        options={options() as CombinedRecipientItem[]}
+        options={optionsWithSelected()}
         optionLabel={getRecipientOptionLabel}
         optionValue={getRecipientOptionValue}
         optionTextValue={getRecipientOptionTextValue}
         optionDisabled={getOptionDisabled}
-        defaultFilter={() => true}
+        defaultFilter={(option) =>
+          visibleOptionKeys().has(getRecipientOptionValue(option))
+        }
         value={props.selectedOptions as CombinedRecipientItem[]}
         onChange={debouncedHandleChange}
         onInputChange={onInputChange}

--- a/js/app/packages/core/component/RecipientSelector.tsx
+++ b/js/app/packages/core/component/RecipientSelector.tsx
@@ -530,7 +530,10 @@ export function RecipientSelector<K extends CombinedRecipientKind>(
   });
 
   const visibleOptionKeys = createMemo(
-    () => new Set(options().map(getRecipientOptionValue))
+    () =>
+      new Set(
+        (options() as CombinedRecipientItem[]).map(getRecipientOptionValue)
+      )
   );
 
   // Kobalte resolves selected values against the `options` prop
@@ -538,7 +541,7 @@ export function RecipientSelector<K extends CombinedRecipientKind>(
   // there, so selected options that the search filtered out must stay in the
   // collection. `defaultFilter` keeps them hidden from the dropdown.
   const optionsWithSelected = createMemo(() => {
-    const visible = options();
+    const visible = options() as CombinedRecipientItem[];
     const keys = visibleOptionKeys();
     const hiddenSelected = (
       props.selectedOptions as CombinedRecipientItem[]


### PR DESCRIPTION
## Summary
Fixed an issue in RecipientSelector where selected options that were filtered out by search would be silently dropped by Kobalte's option resolution logic.

## Key Changes
- Added `visibleOptionKeys` memo to track which options are currently visible after filtering
- Created `optionsWithSelected` memo that combines visible options with any selected options that were filtered out, ensuring Kobalte can resolve all selected values
- Updated the `defaultFilter` function to only show visible options in the dropdown while keeping filtered-out selections in the underlying options collection

## Implementation Details
The fix addresses a Kobalte behavior where it resolves selected values against the `options` prop and silently drops any selections it cannot find. By maintaining hidden selected options in the options collection and using `defaultFilter` to control visibility, we ensure:
- Selected options remain valid even when filtered out by search
- The dropdown UI only shows relevant filtered results
- No selected values are lost during search/filter operations
