### PR TITLE
fix(email): blank line above injected signature, reply toolbar overlap, sticky dismiss

### DIFF
--- a/js/app/packages/block-email/component/BaseInput.tsx
+++ b/js/app/packages/block-email/component/BaseInput.tsx
@@ -853,10 +853,13 @@ export function BaseInput(props: {
   // After a send, the bottom input stays mounted and its replyingTo flips to
   // the just-sent message once the thread refetches. Cancel the inhibited
   // post-send save and re-enable saves so a fresh edit under the new form
-  // context can be persisted.
+  // context can be persisted. The memo gates on the db_id *value*: replyingTo
+  // is recreated on every thread/draft refetch (e.g. after a debounced draft
+  // save), and resetting on those would resurrect a dismissed signature.
+  const replyingToDbId = createMemo(() => props.replyingTo()?.db_id);
   createEffect(
     on(
-      () => props.replyingTo()?.db_id,
+      replyingToDbId,
       () => {
         if (draftSaveTimer) window.clearTimeout(draftSaveTimer);
         pendingSend = false;
@@ -1804,7 +1807,10 @@ export function BaseInput(props: {
             />
           )}
         </Show>
-        <div class="flex flex-row w-full h-9 justify-between items-end px-2 pb-2 pt-0.5 space-x-2">
+        {/* No fixed height: the send button (size-7.5) is taller than the icon
+            buttons, and a fixed h-9 minus the vertical padding left it 4px short
+            — with items-end it bled upward over the signature bar above. */}
+        <div class="flex flex-row w-full justify-between items-end px-2 pb-2 pt-1.5 space-x-2">
           <div class="flex flex-row items-center gap-1">
             <div class="relative flex">
               <Button

--- a/rust/cloud-storage/email/src/domain/service/signature.rs
+++ b/rust/cloud-storage/email/src/domain/service/signature.rs
@@ -33,7 +33,11 @@ pub(crate) fn has_signature(body_html: &str) -> bool {
 /// matches (e.g. a bare fragment with no `<body>`), it is appended to the end so
 /// the signature is never silently dropped.
 pub(crate) fn inject_signature(body_html: &str, signature_html: &str) -> String {
-    let wrapped = format!(r#"<div class="{SIGNATURE_CLASS}">{signature_html}</div>"#);
+    // The leading <div><br></div> is a blank line separating the signature from
+    // the message body (the text/plain part gets "\n\n" for the same reason).
+    // It sits inside the marker div so strip_signature removes it too.
+    let wrapped =
+        format!(r#"<div class="{SIGNATURE_CLASS}"><div><br></div>{signature_html}</div>"#);
 
     let has_quote = Selector::parse(".macro_quote")
         .ok()

--- a/rust/cloud-storage/email/src/domain/service/signature/test.rs
+++ b/rust/cloud-storage/email/src/domain/service/signature/test.rs
@@ -9,6 +9,15 @@ fn appends_to_body_after_message_when_no_quote() {
 }
 
 #[test]
+fn separates_signature_from_message_with_blank_line() {
+    let out = inject_signature("<body><p>Hi there</p></body>", "<p>Regards</p>");
+    assert!(
+        out.contains(r#"<div class="macro-email-signature"><div><br></div><p>Regards</p></div>"#),
+        "got: {out}"
+    );
+}
+
+#[test]
 fn inserts_above_quote_for_replies_and_forwards() {
     let body = r#"<body><p>My reply</p><div class="macro_quote"><p>Quoted</p></div></body>"#;
     let out = inject_signature(body, "<p>Regards</p>");


### PR DESCRIPTION
## Problem

Three signature issues found testing #4442 end-to-end:

1. **No breathing room**: the backend injects the signature immediately below the last line of the message body — received emails read `hello` with the signature jammed right under it.
2. **Send button overlapping the signature bar** in the reply input: the bottom toolbar row had a fixed `h-9` (36px) with 10px of vertical padding, leaving 26px for the 30px send button; with `items-end` the extra 4px bled upward over the signature preview bar.
3. **Dismissed signature resurrecting**: pressing ✕ on the reply signature bar removed it, but it reappeared a second or two after typing resumed.

## Changes

**`signature.rs` — spacer above the injected signature**
- `inject_signature` now wraps the signature as `<div class="macro-email-signature"><div><br></div>…</div>` — one Gmail-style blank line between message and signature.
- The spacer lives inside the marker div, so `strip_signature` (used for `include_signature: false` and re-send idempotency) removes it too — no stray blank lines accumulate on re-sends.
- The `text/plain` alternative already separates with `\n\n`, so it's untouched. Test added; all signature tests pass.

**`BaseInput.tsx` — toolbar overlap**
- The bottom toolbar row no longer has a fixed height: it sizes to its tallest child (the send button) with real top padding, so nothing bleeds over the signature bar. Compose was already flexible-height, which is why it didn't exhibit this.

**`BaseInput.tsx` — sticky dismiss**
- The "reset signature for each new reply" effect was keyed on `props.replyingTo()?.db_id` via `on(...)`, but Solid's `on` re-runs on any dependency update without comparing the derived value. Every debounced draft save refetched the thread, recreated `replyingTo` for the same message, and re-ran `setIncludeSignature(true)`.
- The reset is now gated on a `createMemo` of the `db_id`, which only propagates on a real value change — so ✕ sticks for the rest of that reply, and the signature still returns after an actual send (when `db_id` genuinely changes to the just-sent message).
