### PR TITLE
fix(notifications): keep notification list expanded across soup row remounts

### DIFF
--- a/js/app/packages/entity/src/components/CollapsibleList.tsx
+++ b/js/app/packages/entity/src/components/CollapsibleList.tsx
@@ -44,7 +44,16 @@ interface CollapsibleListProps<T> {
   children: (item: T, index?: number, count?: number) => JSX.Element;
   expandText?: (count: number) => string;
   togglePosition?: 'top' | 'bottom';
+  /**
+   * When set, the expanded/collapsed choice is kept under this key outside the
+   * component instance. A consumer living inside a list row that virtua remounts
+   * on data refetch (e.g. notification stacks) would otherwise reset to collapsed
+   * on every remount. The new instance re-seeds from the user's last toggle.
+   */
+  persistKey?: string;
 }
+
+const persistedExpandState = new Map<string, boolean>();
 
 /**
  * Generic collapsible list component
@@ -58,7 +67,11 @@ interface CollapsibleListProps<T> {
  * in the parent component using reconcile() or proper memoization.
  */
 export function CollapsibleList<T>(props: CollapsibleListProps<T>) {
-  const [showAll, setShowAll] = createSignal(false);
+  const [showAll, setShowAll] = createSignal(
+    props.persistKey !== undefined
+      ? (persistedExpandState.get(props.persistKey) ?? false)
+      : false
+  );
 
   const visibleCount = () => props.visibleCount ?? 3;
 
@@ -82,7 +95,13 @@ export function CollapsibleList<T>(props: CollapsibleListProps<T>) {
   // drift across expand/collapse cycles.
   const toggle = (e: MouseEvent) => {
     e.stopPropagation();
-    setShowAll((prev) => !prev);
+    setShowAll((prev) => {
+      const next = !prev;
+      if (props.persistKey !== undefined) {
+        persistedExpandState.set(props.persistKey, next);
+      }
+      return next;
+    });
   };
 
   const toggleButtonProps = () => ({

--- a/js/app/packages/entity/src/extractors-notification/mobile-notification-stacks.tsx
+++ b/js/app/packages/entity/src/extractors-notification/mobile-notification-stacks.tsx
@@ -210,6 +210,7 @@ export function MobileNotificationStacks(props: MobileNotificationStacksProps) {
           visibleCount={props.visibleCount ?? 3}
           togglePosition="bottom"
           expandText={(count) => `Show ${count} more`}
+          persistKey={`notif-stacks:${props.entity.id}`}
         >
           {(stack) => (
             <MobileStackRow

--- a/js/app/packages/entity/src/extractors-notification/notification-stacks.tsx
+++ b/js/app/packages/entity/src/extractors-notification/notification-stacks.tsx
@@ -203,6 +203,7 @@ export function NotificationStacks(props: NotificationStacksProps) {
             items={stacks}
             visibleCount={props.visibleCount ?? DEFAULT_VISIBLE_COUNT}
             togglePosition="bottom"
+            persistKey={`notif-stacks:${props.entity.id}`}
           >
             {(stack) => (
               <NotificationStackRow


### PR DESCRIPTION
The notification "Show N more" list kept its expanded state in a local signal, so any notification-driven soup refetch remounted the row and snapped it back to collapsed. Persists the expand choice per entity so it survives the remount.
