### PR TITLE
feat(email): rest latest thread message toward middle of view

### DIFF
--- a/js/app/packages/block-email/component/Email.tsx
+++ b/js/app/packages/block-email/component/Email.tsx
@@ -362,12 +362,13 @@ function EmailContent(props: EmailViewProps) {
         pinInitialScroll(messageId);
       });
     }
-
     // Case 3: Message is in current batch with sufficient context
-    setTimeout(() => {
-      performScrollToMessage(messageId, { behavior: 'instant' });
-      pinInitialScroll(messageId);
-    });
+    else {
+      setTimeout(() => {
+        performScrollToMessage(messageId, { behavior: 'instant' });
+        pinInitialScroll(messageId);
+      });
+    }
   }
 
   // If there is a focused message id, but it does not currently exist in the message list, it is because the user has just sent a message. When it does come into existence, we want to scroll to the bottom.

--- a/js/app/packages/block-email/component/Email.tsx
+++ b/js/app/packages/block-email/component/Email.tsx
@@ -49,6 +49,8 @@ import { TopBar } from './TopBar';
 const TARGET_MESSAGE_HIGHLIGHT_MS = 800;
 const SCROLL_ANIMATION_MS = 1000;
 const SCROLL_AFTER_SEND_DELAY_MS = 100;
+const SCROLL_SETTLE_STABLE_FRAMES = 15;
+const SCROLL_SETTLE_MAX_MS = 2000;
 
 type EmailViewProps = {
   title: string;
@@ -199,6 +201,56 @@ function EmailContent(props: EmailViewProps) {
     return true;
   };
 
+  // Message bodies keep resizing briefly after render (images load, inline
+  // cid: images fail and collapse), so a scroll computed against that
+  // transient layout gets displaced — browser scroll anchoring can clamp it
+  // to the very top of the thread. Re-assert the initial scroll whenever the
+  // content height changes until layout settles or the user scrolls.
+  let cancelActiveScrollPin: (() => void) | undefined;
+  const pinInitialScroll = (messageId: string) => {
+    cancelActiveScrollPin?.();
+    const list = untrack(context.messagesListRef);
+    if (!list) return;
+
+    let cancelled = false;
+    let stableFrames = 0;
+    let lastHeight = list.scrollHeight;
+    const startedAt = performance.now();
+
+    const cancel = () => {
+      cancelled = true;
+      list.removeEventListener('wheel', cancel);
+      list.removeEventListener('touchstart', cancel);
+      list.removeEventListener('pointerdown', cancel);
+    };
+    cancelActiveScrollPin = cancel;
+    list.addEventListener('wheel', cancel, { passive: true });
+    list.addEventListener('touchstart', cancel, { passive: true });
+    list.addEventListener('pointerdown', cancel, { passive: true });
+
+    const tick = () => {
+      if (cancelled || !list.isConnected) return cancel();
+      if (list.scrollHeight !== lastHeight) {
+        lastHeight = list.scrollHeight;
+        stableFrames = 0;
+        performScrollToMessage(messageId, {
+          behavior: 'instant',
+          focus: false,
+        });
+      } else {
+        stableFrames++;
+      }
+      if (
+        stableFrames >= SCROLL_SETTLE_STABLE_FRAMES ||
+        performance.now() - startedAt > SCROLL_SETTLE_MAX_MS
+      ) {
+        return cancel();
+      }
+      requestAnimationFrame(tick);
+    };
+    requestAnimationFrame(tick);
+  };
+
   const scrollToLastMessage = (
     behavior: ScrollBehavior = 'instant',
     focus = false
@@ -254,14 +306,17 @@ function EmailContent(props: EmailViewProps) {
       const lastUnreadMessageId_ = untrack(firstUnreadMessageId);
       // Check if there is an unread message
       if (lastUnreadMessageId_) {
-        setTimeout(() =>
+        setTimeout(() => {
           performScrollToMessage(lastUnreadMessageId_!, {
             behavior: 'instant',
-          })
-        );
+          });
+          pinInitialScroll(lastUnreadMessageId_!);
+        });
         context.messages.setFocused(lastUnreadMessageId_!);
       } else {
         scrollToLastMessage('instant', false);
+        const lastMessageId = untrack(context.messages.list).at(-1)?.db_id;
+        if (lastMessageId) pinInitialScroll(lastMessageId);
       }
     }
 
@@ -285,9 +340,10 @@ function EmailContent(props: EmailViewProps) {
           fetchNextPage();
           await waitForQueryLoad();
           // Scroll to the message after DOM updates
-          setTimeout(() =>
-            performScrollToMessage(messageId, { behavior: 'instant' })
-          );
+          setTimeout(() => {
+            performScrollToMessage(messageId, { behavior: 'instant' });
+            pinInitialScroll(messageId);
+          });
         } else {
           // Message not found, fallback to last message
           setTimeout(() => scrollToLastMessage('instant', true));
@@ -301,15 +357,17 @@ function EmailContent(props: EmailViewProps) {
     else if (targetIndex === 0) {
       fetchNextPage();
       await waitForQueryLoad();
-      setTimeout(() =>
-        performScrollToMessage(messageId, { behavior: 'instant' })
-      );
+      setTimeout(() => {
+        performScrollToMessage(messageId, { behavior: 'instant' });
+        pinInitialScroll(messageId);
+      });
     }
 
     // Case 3: Message is in current batch with sufficient context
-    setTimeout(() =>
-      performScrollToMessage(messageId, { behavior: 'instant' })
-    );
+    setTimeout(() => {
+      performScrollToMessage(messageId, { behavior: 'instant' });
+      pinInitialScroll(messageId);
+    });
   }
 
   // If there is a focused message id, but it does not currently exist in the message list, it is because the user has just sent a message. When it does come into existence, we want to scroll to the bottom.

--- a/js/app/packages/block-email/component/MessageList.tsx
+++ b/js/app/packages/block-email/component/MessageList.tsx
@@ -3,8 +3,19 @@ import { isScrollingToMessage } from '@block-email/signal/scrollState';
 import { StaticMarkdownContext } from '@core/component/LexicalMarkdown/component/core/StaticMarkdown';
 import { isMobile } from '@core/mobile/isMobile';
 import { cn } from '@ui';
-import { createMemo, createSelector, Index, Show } from 'solid-js';
+import {
+  createEffect,
+  createMemo,
+  createSelector,
+  Index,
+  onCleanup,
+  Show,
+} from 'solid-js';
 import { MessageContainer } from './MessageContainer';
+
+// Fraction of the list height reserved below the newest message so it rests
+// toward the middle of the view instead of pinned to the bottom edge.
+const LAST_MESSAGE_REST_FRACTION = 0.4;
 
 interface MessageListProps {
   initialLoadComplete: boolean;
@@ -30,10 +41,28 @@ export function MessageList(props: MessageListProps) {
     (a, b) => a === b
   );
 
+  // Since the list is bottom-anchored (col-reverse), extra bottom padding is
+  // the only way to let the newest message rest above the bottom edge. A
+  // thread that fills the screen gets its oldest messages pushed above the
+  // fold (still one scroll away) — the newest message resting at a
+  // consistent height wins over keeping the whole thread in view.
+  createEffect(() => {
+    const list = context.messagesListRef();
+    if (!list || isMobile()) return;
+    const observer = new ResizeObserver(() => {
+      list.style.setProperty(
+        '--thread-bottom-pad',
+        `${Math.round(list.clientHeight * LAST_MESSAGE_REST_FRACTION)}px`
+      );
+    });
+    observer.observe(list);
+    onCleanup(() => observer.disconnect());
+  });
+
   return (
     <div
       class={cn(
-        'pt-1 pb-6 w-full flex flex-col-reverse items-center overflow-y-scroll overflow-x-hidden scrollbar-hidden text-sm gap-1.5',
+        'pt-1 pb-[calc(1.5rem+var(--thread-bottom-pad,0px))] w-full flex flex-col-reverse items-center overflow-y-scroll overflow-x-hidden scrollbar-hidden text-sm gap-1.5',
         // In-scroll top inset: messages rest below the floating split chrome
         // but under-scroll it.
         'mobile:pt-[calc(var(--mobile-content-inset-top,0)+0.5rem)]',


### PR DESCRIPTION
## Summary

Opening an email thread used to render the latest message flush against the bottom edge of the view, which looks unnatural for long threads. This PR makes the newest message rest toward the middle of the view instead, and fixes a pre-existing bug where reopening a cached thread landed at the very top.

### Rest position (`MessageList.tsx`)

The message list is `flex-col-reverse`, so its natural rest position is the very end of the scroll range — the newest message can't sit above the bottom edge without real scrollable space below it. A `ResizeObserver` now reserves 40% of the list height (`LAST_MESSAGE_REST_FRACTION`) as bottom padding via a `--thread-bottom-pad` CSS variable, desktop only (mobile keeps the existing insets).

The reserve is unconditional: a thread that fills the screen has its oldest messages pushed just above the fold (one scroll away) so the newest message rests at a consistent height on every screen size.

### Initial scroll pinning (`Email.tsx`)

Pre-existing bug, surfaced while testing this on a small screen: reopening a thread within the query `staleTime` renders synchronously from cache, so the initial scroll runs against unsettled layout — expanded message bodies are transiently taller (e.g. `cid:` inline images render at intrinsic size before failing and collapsing). When the content then shrinks, browser scroll anchoring compensates and clamps the scroll to the very top of the thread. First opens never hit this because the network round-trip lets layout settle first.

`pinInitialScroll(messageId)` re-asserts the initial scroll each animation frame whenever the list's `scrollHeight` changes, until the layout is stable for 15 frames (or 2s max). It cancels immediately on wheel/touch/pointer input so it never fights the user. Applies to all three initial-scroll paths: last message, first unread, and deep-link target.

## Notes

- The last message itself can never be clipped by the reserve: the initial scroll aligns its top edge into view, so a message taller than the viewport lands at its beginning.
- Tune `LAST_MESSAGE_REST_FRACTION` (0.25–0.4 is the sensible range) to adjust the rest height.