### PR TITLE
fix(email): don't strip light backgrounds layered on colored elements

### DIFF
--- a/js/app/packages/core/email/tests/transform-email-colors.test.ts
+++ b/js/app/packages/core/email/tests/transform-email-colors.test.ts
@@ -4,6 +4,7 @@ import {
   normalizeRGBA,
   parseRGBA,
   rgbaToOklch,
+  stripContentBackgrounds,
 } from '../transform-email-colors';
 
 describe('parseRGBA', () => {
@@ -86,6 +87,64 @@ describe('rgbaToOklch', () => {
   it('returns null for null input', () => {
     const result = rgbaToOklch(null);
     expect(result).toBeNull();
+  });
+});
+
+describe('stripContentBackgrounds', () => {
+  function render(html: string): HTMLElement {
+    const root = document.createElement('div');
+    root.innerHTML = html;
+    document.body.appendChild(root);
+    return root;
+  }
+
+  function bg(el: Element | null) {
+    return (el as HTMLElement).style.backgroundColor;
+  }
+
+  it('strips light page-like backgrounds', () => {
+    const root = render(
+      '<div id="page" style="background-color:#ffffff">text</div>'
+    );
+    stripContentBackgrounds(root);
+    expect(bg(root.querySelector('#page'))).toBe('transparent');
+    root.remove();
+  });
+
+  it('keeps dark/colored backgrounds', () => {
+    const root = render(
+      '<a id="btn" style="background-color:#7e82c9;color:#ffffff">button</a>'
+    );
+    stripContentBackgrounds(root);
+    expect(bg(root.querySelector('#btn'))).toBe('rgb(126, 130, 201)');
+    root.remove();
+  });
+
+  it('keeps a light background layered on a kept colored ancestor (1px-border button trick)', () => {
+    // Outer div is a colored "border", inner anchor is the light button face
+    // with text color matching the border. Stripping the face would leave
+    // same-on-same invisible text.
+    const root = render(
+      '<div id="border" style="background-color:#51b1e7;padding:1px">' +
+        '<a id="face" style="background-color:#e4ecf2;color:#51b1e7">Very disappointed</a>' +
+        '</div>'
+    );
+    stripContentBackgrounds(root);
+    expect(bg(root.querySelector('#border'))).toBe('rgb(81, 177, 231)');
+    expect(bg(root.querySelector('#face'))).toBe('rgb(228, 236, 242)');
+    root.remove();
+  });
+
+  it('strips nested light backgrounds once the ancestor light bg is stripped', () => {
+    const root = render(
+      '<div id="outer" style="background-color:#ffffff">' +
+        '<div id="inner" style="background-color:#f2f2f2">text</div>' +
+        '</div>'
+    );
+    stripContentBackgrounds(root);
+    expect(bg(root.querySelector('#outer'))).toBe('transparent');
+    expect(bg(root.querySelector('#inner'))).toBe('transparent');
+    root.remove();
   });
 });
 

--- a/js/app/packages/core/email/transform-email-colors.ts
+++ b/js/app/packages/core/email/transform-email-colors.ts
@@ -107,7 +107,7 @@ const LIGHT_BG_THRESHOLD = 0.85;
 
 /** Remove light/white backgrounds from all elements, preserving colored/dark backgrounds (buttons, banners).
  *  Uses getComputedStyle to resolve all color formats (named colors, hex, rgb, etc.) */
-function stripContentBackgrounds(root: Node) {
+export function stripContentBackgrounds(root: Node) {
   const walker = document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT);
   let el = walker.nextNode();
   while (el) {
@@ -117,7 +117,11 @@ function stripContentBackgrounds(root: Node) {
         const rgba = normalizeRGBA(parseRGBA(bgColor));
         if (rgba && rgba.a > 0) {
           const oklch = rgbaToOklch(rgba);
-          if (oklch && oklch.l > LIGHT_BG_THRESHOLD) {
+          if (
+            oklch &&
+            oklch.l > LIGHT_BG_THRESHOLD &&
+            !hasOpaqueAncestorBackground(el, root)
+          ) {
             el.style.setProperty(
               'background-color',
               'transparent',
@@ -130,6 +134,23 @@ function stripContentBackgrounds(root: Node) {
     }
     el = walker.nextNode();
   }
+}
+
+/** True if an ancestor still has an opaque background. Parents are visited
+ *  before children, so any remaining opaque ancestor bg is one we kept
+ *  (non-light) — a light bg layered on it is content (e.g. a button face
+ *  inside a colored border div), not page chrome, and stripping it would
+ *  expose the colored bg behind text that wasn't styled to contrast with it. */
+function hasOpaqueAncestorBackground(el: HTMLElement, root: Node): boolean {
+  let ancestor = el.parentElement;
+  while (ancestor && ancestor !== root) {
+    const bg = normalizeRGBA(
+      parseRGBA(getComputedStyle(ancestor).backgroundColor)
+    );
+    if (bg && bg.a > 0) return true;
+    ancestor = ancestor.parentElement;
+  }
+  return false;
 }
 
 export function rgbaToOklch(rgba: RGBA | null): OKLCH | null {


### PR DESCRIPTION
## Problem

Some HTML emails render buttons with invisible text. Example: Superhuman's NPS survey email, where the "Very disappointed" / "Somewhat disappointed" / "Not disappointed" buttons appear as solid blue chips with no visible label.

These buttons use a common email-HTML trick to fake a 1px border:

```html
<div style="background:#51b1e7;padding:1px;border-radius:4px">   <!-- blue "border" -->
  <a style="color:#51b1e7 !important;background-color:#e4ecf2"> <!-- light face, blue text -->
```

`stripContentBackgrounds` in `processEmailColors` removes any background lighter than OKLCH L 0.85, assuming light = page chrome. The anchor's `#e4ecf2` face (L=0.939) gets stripped, exposing the wrapper's `#51b1e7` (L=0.725, kept) directly behind text that is also `#51b1e7` — identical colors, invisible in both themes. The contrast-fix pass then skips these text nodes because it finds an opaque ancestor background and "trusts the sender's choices" — a background the sender never intended text to sit on.

## Fix

Before stripping a light background, check whether an opaque ancestor background remains. Since the tree walker visits parents before children, any opaque ancestor background at that point is one the pass kept (colored/dark) — so a light background layered on it is content (a button face, a card on a banner), not page chrome, and is left alone.

Behavior preserved in both directions:

- Light/white page wrappers with nothing opaque behind them are still stripped, so emails blend into the theme panel.
- Nested light-on-light still strips fully: once the outer light background is stripped, the inner one sees no opaque ancestor and strips too.

## Tests

Added unit tests for `stripContentBackgrounds` (jsdom), including a reproduction of the 1px-border button trick with the exact colors from the offending email.
