### PR TITLE
fix(email): restore compose state on undo send

### DIFF
--- a/js/app/packages/block-email/component/BaseInput.tsx
+++ b/js/app/packages/block-email/component/BaseInput.tsx
@@ -379,6 +379,7 @@ type UndoReplySnapshot = {
   draftId: string;
   bodyHtml: string;
   attachments: DraftFormAttachment[];
+  includeSignature: boolean;
 };
 // Set on send, persists across navigation, only consumed by undoSend.
 let undoSendSnapshot: UndoReplySnapshot | null = null;
@@ -521,6 +522,7 @@ export function BaseInput(props: {
       for (const attachment of restoredSnapshot.attachments) {
         form().attachments.add(attachment);
       }
+      setIncludeSignature(restoredSnapshot.includeSignature);
     });
   }
 
@@ -535,6 +537,7 @@ export function BaseInput(props: {
     for (const attachment of snapshot.attachments) {
       form().attachments.add(attachment);
     }
+    setIncludeSignature(snapshot.includeSignature);
   };
   onCleanup(() => {
     restoreUndoCallback = null;
@@ -576,11 +579,10 @@ export function BaseInput(props: {
             };
           }
         );
-        // Mark stale so next navigation fetches fresh data
-        queryClient.invalidateQueries({
-          queryKey: emailKeys.threadMessages(threadId).queryKey,
-          refetchType: 'none',
-        });
+        // Wipe the thread cache on unmount so the next visit fetches fresh
+        // data (with the restored draft). Deferred to avoid Suspense DOM
+        // detach while the thread is open.
+        markThreadDraftSaved(threadId);
       }
 
       const snapshot = undoSendSnapshot;
@@ -1024,6 +1026,7 @@ export function BaseInput(props: {
           draftId: snapshotDraftId,
           bodyHtml: snapshotHtml,
           attachments: [...form().attachments.list()],
+          includeSignature: includeSignature(),
         };
       }
     }

--- a/js/app/packages/block-email/component/compose/Compose.tsx
+++ b/js/app/packages/block-email/component/compose/Compose.tsx
@@ -12,7 +12,10 @@ import {
   createEmailFormState,
   type DraftFormAttachment,
 } from '@block-email/component/createEmailFormState';
-import { useMaybeEmailContext } from '@block-email/component/EmailContext';
+import {
+  markThreadDraftSaved,
+  useMaybeEmailContext,
+} from '@block-email/component/EmailContext';
 import { MACRO_EMAIL_SIGNATURE } from '@block-email/constants';
 import { decodeBase64Utf8 } from '@block-email/util/decodeBase64';
 import { plainTextToHtml } from '@block-email/util/plainTextToHtml';
@@ -95,6 +98,7 @@ type UndoComposeSnapshot = {
   subject: string;
   bodyHtml: string;
   attachments: DraftFormAttachment[];
+  includeSignature: boolean;
 };
 
 let undoComposeSnapshot: UndoComposeSnapshot | null = null;
@@ -196,6 +200,7 @@ export function EmailCompose(props: EmailComposeProps) {
     for (const attachment of restoredSnapshot.attachments) {
       form.attachments.add(attachment);
     }
+    setIncludeSignature(restoredSnapshot.includeSignature);
     undoComposeSnapshot = null;
   }
 
@@ -367,7 +372,7 @@ export function EmailCompose(props: EmailComposeProps) {
   const [validationError, setValidationError] =
     createSignal<ComposeValidationError | null>(null);
 
-  const undoSend = async (draftId: string) => {
+  const undoSend = async (draftId: string, threadId?: string) => {
     try {
       const result = await emailClient.unscheduleMessage(
         { draftID: draftId },
@@ -382,11 +387,17 @@ export function EmailCompose(props: EmailComposeProps) {
       queryClient.invalidateQueries({
         queryKey: emailKeys.previews._def,
       });
+      // Wipe the new thread's cache when its view unmounts (replaceSplit
+      // below) so the next visit fetches fresh data without the sent message.
+      if (threadId) markThreadDraftSaved(threadId);
       replaceSplit({
         content: {
           type: 'component',
           id: 'email-compose',
           params: { draftID: draftId },
+          // reattach() strips params by default; keep draftID so the compose
+          // remount can restore the undo snapshot.
+          preserveParams: true,
         },
       });
       toast.success('Send cancelled');
@@ -399,6 +410,7 @@ export function EmailCompose(props: EmailComposeProps) {
   const sendMutation = useSendMessageMutation({
     onSuccess: (data) => {
       const draftId = data.message.db_id;
+      const threadId = data.message.thread_db_id;
       const toastId = toast.success('Email sent', {
         actions: draftId
           ? [
@@ -407,7 +419,7 @@ export function EmailCompose(props: EmailComposeProps) {
                 icon: ArrowCounterClockwise,
                 onClick: () => {
                   if (toastId != null) toast.dismiss(toastId);
-                  void undoSend(draftId);
+                  void undoSend(draftId, threadId ?? undefined);
                 },
               },
             ]
@@ -431,24 +443,6 @@ export function EmailCompose(props: EmailComposeProps) {
     setValidationError(null);
 
     const currentEditor = editor();
-
-    // Snapshot editor state before watermark so undo-send can restore it
-    if (currentEditor) {
-      const snapshotHtml = currentEditor.read(() =>
-        $generateHtmlFromNodes(currentEditor)
-      );
-      const draftId = currentDraftID();
-      if (draftId) {
-        undoComposeSnapshot = {
-          draftId,
-          recipients: structuredClone(unwrap(form.recipients())),
-          subject: form.subject(),
-          bodyHtml: snapshotHtml,
-          attachments: [...form.attachments.list()],
-        };
-      }
-    }
-
     const currentLink = link();
     const recipients = form.recipients();
 
@@ -487,6 +481,33 @@ export function EmailCompose(props: EmailComposeProps) {
     // Failsafe: don't send if a scheduled send time is set
     if (form.sendTime()) {
       return;
+    }
+
+    // Ensure the draft is saved before sending so undo-send always has a
+    // draft id to snapshot and restore (the send reuses the draft's db_id).
+    scheduleDraftSave.clear();
+    try {
+      await executeSaveDraft();
+    } catch {
+      // Draft save is best-effort; the send still works without one.
+    }
+
+    // Snapshot editor state before watermark so undo-send can restore it
+    if (currentEditor) {
+      const snapshotHtml = currentEditor.read(() =>
+        $generateHtmlFromNodes(currentEditor)
+      );
+      const draftId = currentDraftID();
+      if (draftId) {
+        undoComposeSnapshot = {
+          draftId,
+          recipients: structuredClone(unwrap(form.recipients())),
+          subject: form.subject(),
+          bodyHtml: snapshotHtml,
+          attachments: [...form.attachments.list()],
+          includeSignature: includeSignature(),
+        };
+      }
     }
 
     // Append watermark after all validation passes so failed sends don't

--- a/js/app/packages/core/component/HoverCard.tsx
+++ b/js/app/packages/core/component/HoverCard.tsx
@@ -53,6 +53,12 @@ type HoverCardComponentProps = {
   triggerTabIndex?: number;
   /** Whether to disable the hover card */
   disabled?: boolean;
+  /**
+   * Don't open from the synthetic pointerenter fired when the trigger mounts
+   * under a stationary cursor (e.g. a chip inserted via keyboard); require
+   * real pointer movement first.
+   */
+  requirePointerMovement?: boolean;
   /** Callback when open state changes */
   onOpenChange?: (open: boolean) => void;
   /**
@@ -102,7 +108,34 @@ export function HoverCard(props: HoverCardComponentProps) {
 
   const isTopLevel = parentNestedContext === undefined;
 
+  // Distinguish real hovers from the synthetic pointerenter browsers fire
+  // when the trigger mounts under a stationary cursor: only coordinate
+  // changes across pointermove events count as movement (synthetic moves
+  // repeat the same position).
+  let pointerMoved = false;
+  if (props.requirePointerMovement) {
+    let lastX: number | undefined;
+    let lastY: number | undefined;
+    const onPointerMove = (e: PointerEvent) => {
+      if (lastX !== undefined && (e.screenX !== lastX || e.screenY !== lastY)) {
+        pointerMoved = true;
+        window.removeEventListener('pointermove', onPointerMove, true);
+        return;
+      }
+      lastX = e.screenX;
+      lastY = e.screenY;
+    };
+    window.addEventListener('pointermove', onPointerMove, true);
+    onCleanup(() =>
+      window.removeEventListener('pointermove', onPointerMove, true)
+    );
+  }
+
   const handleOpenChange = (open: boolean) => {
+    if (open && props.requirePointerMovement && !pointerMoved) {
+      return;
+    }
+
     if (!open && nestedOpenCount() > 0) {
       return;
     }

--- a/js/app/packages/core/component/HoverCard.tsx
+++ b/js/app/packages/core/component/HoverCard.tsx
@@ -125,7 +125,10 @@ export function HoverCard(props: HoverCardComponentProps) {
       lastX = e.screenX;
       lastY = e.screenY;
     };
-    window.addEventListener('pointermove', onPointerMove, true);
+    window.addEventListener('pointermove', onPointerMove, {
+      capture: true,
+      passive: true,
+    });
     onCleanup(() =>
       window.removeEventListener('pointermove', onPointerMove, true)
     );

--- a/js/app/packages/core/component/RecipientSelector.tsx
+++ b/js/app/packages/core/component/RecipientSelector.tsx
@@ -59,6 +59,9 @@ function ChipWithUserTooltip(props: {
       triggerAs="div"
       trigger={props.chip}
       content={props.renderTooltip(() => setOpen(false))}
+      // Chips mount under the cursor when a recipient is picked via keyboard;
+      // don't treat that as a hover.
+      requirePointerMovement
     />
   );
 }


### PR DESCRIPTION
## Summary

Undo send from the composer opened a blank compose view instead of restoring the message. Root cause: `reattach()` in the split layout strips navigation `params` by default (since #4178), so the remounted composer never received its `draftID` and the undo snapshot never matched.

### Undo-send restore (`Compose.tsx`, `BaseInput.tsx`)
- Pass `preserveParams: true` on the undo-send `replaceSplit` so `draftID` survives to the compose remount.
- Save the draft before sending (mirrors `BaseInput`), so an undo snapshot always exists and the send reuses the draft's `db_id` — previously a send that beat the 500ms autosave debounce had no draft id, producing no snapshot and a fresh backend message id.
- Carry the signature-bar dismissal through the undo snapshots (compose + reply) so an undone send doesn't resurrect a dismissed signature.
- Wipe the thread's query cache after undo (deferred to unmount via `markThreadDraftSaved`) so reopening the thread fetches fresh server state with the restored draft.

### Recipient chip hover cards (`HoverCard.tsx`, `RecipientSelector.tsx`)
Picking a recipient with Enter mounts the pill directly under the stationary cursor; the browser fires a synthetic `pointerenter` that opened the contact hover card uninvited. `HoverCard` gains an opt-in `requirePointerMovement` guard that blocks opens until genuine pointer movement (coordinate change across `pointermove` events) is observed; recipient chips opt in.