### PR TITLE
feat(analytics): add granular product events for docs, tasks, sharing…

### DIFF
--- a/js/app/packages/app/component/bulk-edit-entity/BulkMoveToProjectView.tsx
+++ b/js/app/packages/app/component/bulk-edit-entity/BulkMoveToProjectView.tsx
@@ -1,7 +1,8 @@
+import { analytics } from '@app/lib/analytics';
 import { EntityIcon } from '@core/component/EntityIcon';
 import { toast } from '@core/component/Toast/Toast';
 import { scrollToKeepGap } from '@core/util/scrollToKeepGap';
-import { type EntityData, InlineEntity } from '@entity';
+import { type EntityData, InlineEntity, isTaskEntity } from '@entity';
 import { Dialog } from '@kobalte/core/dialog';
 import { createBulkMoveToProjectDssEntityMutation } from '@macro-entity';
 import FolderPlusIcon from '@phosphor-icons/core/regular/folder-plus.svg?component-solid';
@@ -403,6 +404,17 @@ export const BulkMoveToProjectView = (props: {
           })),
           project: { id: projectId, name: projectName },
         });
+
+        const isBulk = props.entities.length > 1;
+        for (const task of props.entities.filter(isTaskEntity)) {
+          analytics.track('task_moved_to_project', {
+            entityId: task.id,
+            newProjectId: projectId,
+            isBulk,
+            bulkCount: props.entities.length,
+            source: 'bulk_move',
+          });
+        }
 
         props.onFinish();
       } catch (error) {

--- a/js/app/packages/app/lib/analytics/app-events.ts
+++ b/js/app/packages/app/lib/analytics/app-events.ts
@@ -1,3 +1,37 @@
+/** Block/entity types tracked across the create/share/lifecycle events. */
+export type TrackedEntityType =
+  | 'md'
+  | 'task'
+  | 'snippet'
+  | 'code'
+  | 'canvas'
+  | 'pdf'
+  | 'chat'
+  | 'project'
+  | 'email';
+
+/**
+ * Surface an action was initiated from. Open-ended (`string & {}`) so call
+ * sites can pass a new source without a type change, while keeping autocomplete
+ * for the common ones.
+ */
+export type TrackedSource =
+  | 'launcher'
+  | 'mobile_dock'
+  | 'command_menu'
+  | 'context_menu'
+  | 'detail_view'
+  | 'list_view'
+  | 'checkbox_conversion'
+  | 'share_modal'
+  | 'forward_to_channel'
+  | 'api'
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  | (string & {});
+
+/** Mirrors the storage AccessLevel enum; null = made private. */
+export type ShareAccessLevel = 'view' | 'comment' | 'edit' | 'owner' | null;
+
 export type AppEvents = {
   sign_up: Record<string, unknown>; // payload - include link status
   sign_out: Record<string, unknown>;
@@ -76,6 +110,157 @@ export type AppEvents = {
 
   block_pdf_definition_open: Record<string, unknown>;
   block_pdf_section_open: Record<string, unknown>;
+
+  // --- Entity creation ---------------------------------------------------
+  // Fired at the create.ts / projects.ts chokepoints so they capture EVERY
+  // creation path (launcher, mobile dock, hotkey, checkbox conversion, API),
+  // unlike the legacy `create_entity` which only fires from two UI surfaces.
+  document_created: {
+    entityType: Extract<TrackedEntityType, 'md' | 'snippet' | 'code' | 'canvas'>;
+    entityId: string;
+    projectId?: string;
+    source?: TrackedSource;
+    /** Set for code files. */
+    extension?: string;
+  };
+  task_created: {
+    entityId: string;
+    projectId?: string;
+    source?: TrackedSource;
+    hasAssignee: boolean;
+    hasDueDate: boolean;
+    hasPriority: boolean;
+    isSubtask: boolean;
+  };
+  chat_created: {
+    entityId: string;
+    source?: TrackedSource;
+  };
+  project_created: {
+    entityId: string;
+    parentId?: string;
+    source?: TrackedSource;
+  };
+
+  // --- Document / file lifecycle -----------------------------------------
+  // `entityType` here is the coarse storage ItemType ('document' | 'chat' |
+  // 'project' | 'email' | ...) — the fine block subtype is not known at the
+  // file-operations layer. Left open-ended to match ItemType without coupling.
+  document_renamed: {
+    entityType: TrackedEntityType | (string & {});
+    entityId: string;
+    source?: TrackedSource;
+  };
+  document_moved: {
+    entityType: TrackedEntityType | (string & {});
+    entityId: string;
+    destProjectId?: string;
+    source?: TrackedSource;
+  };
+  document_duplicated: {
+    entityType: TrackedEntityType | (string & {});
+    sourceId: string;
+    newId?: string;
+    source?: TrackedSource;
+  };
+  document_deleted: {
+    entityType: TrackedEntityType | (string & {});
+    entityId: string;
+    deleteType: 'soft' | 'permanent';
+    source?: TrackedSource;
+  };
+
+  // --- Sharing -----------------------------------------------------------
+  // Typed, complete replacement path for the inconsistent `share_entity`
+  // (which still fires alongside these until it is retired).
+  document_shared: {
+    // Coarse storage ItemType ('document' | 'project' | ...); the share layer
+    // does not resolve the fine block subtype.
+    entityType: TrackedEntityType | (string & {});
+    entityId: string;
+    shareMethod: 'public_link' | 'channel' | 'forward_to_channel' | 'user_invite';
+    /** null = made private (untracked by the legacy event). */
+    accessLevel?: ShareAccessLevel;
+    targetType?: 'public' | 'channel' | 'user';
+  };
+  chat_shared: {
+    entityId: string;
+    shareMethod: 'public_link' | 'channel' | 'forward_to_channel' | 'user_invite';
+    accessLevel?: ShareAccessLevel;
+    targetType?: 'public' | 'channel' | 'user';
+  };
+  email_shared: {
+    entityId: string;
+    shareMethod: 'channel' | 'forward_to_channel' | 'attachment_public';
+    targetType?: 'channel' | 'user';
+    /** true when a file attachment was shared rather than the thread itself. */
+    attachmentShared?: boolean;
+  };
+
+  // --- Task lifecycle ----------------------------------------------------
+  // Fired at the property-save chokepoint (queries/properties/entity.ts),
+  // gated to task entities.
+  task_status_changed: {
+    entityId: string;
+    previousStatus?: string;
+    newStatus: string;
+    source?: TrackedSource;
+  };
+  task_completed: {
+    entityId: string;
+    source?: TrackedSource;
+  };
+  task_assignee_changed: {
+    entityId: string;
+    assigneeCount: number;
+    source?: TrackedSource;
+  };
+  task_priority_changed: {
+    entityId: string;
+    newPriority?: string;
+    source?: TrackedSource;
+  };
+  task_due_date_changed: {
+    entityId: string;
+    hasDueDate: boolean;
+    source?: TrackedSource;
+  };
+  task_moved_to_project: {
+    entityId?: string;
+    newProjectId?: string;
+    isBulk: boolean;
+    bulkCount?: number;
+    source?: TrackedSource;
+  };
+
+  // --- Calls (frontend intent + controls) --------------------------------
+  // `call_started` here is a frontend proxy: it fires from the starter's client
+  // when they join a channel that had no call in progress. Authoritative
+  // lifecycle (ended / recording / summary) is deferred to server-side tracking
+  // in the Rust call service, since those are webhook/background-job driven.
+  call_started: {
+    channelId: string;
+  };
+  call_join_clicked: {
+    channelId: string;
+    isExistingCall: boolean;
+  };
+  call_joined: {
+    callId?: string;
+    channelId: string;
+    joinDurationMs?: number;
+  };
+  call_left: {
+    callId?: string;
+    channelId: string;
+    callDurationSeconds?: number;
+    leaveReason?: string;
+  };
+  call_screen_share_toggled: {
+    callId?: string;
+    channelId: string;
+    enabled: boolean;
+  };
 };
 
 export type AppEventNames = keyof AppEvents;

--- a/js/app/packages/block-email/util/makeAttachmentPublic.ts
+++ b/js/app/packages/block-email/util/makeAttachmentPublic.ts
@@ -1,3 +1,4 @@
+import { analytics } from '@app/lib/analytics';
 import { toast } from '@core/component/Toast/Toast';
 
 import { logger } from '@observability';
@@ -23,6 +24,11 @@ export const makeAttachmentPublic = async (attachmentId: string) => {
   if (!result.isErr()) {
     toast.success('Recipients can now view this file', {
       subtext: 'File share permissions have been updated to public view-only',
+    });
+    analytics.track('email_shared', {
+      entityId: attachmentId,
+      shareMethod: 'attachment_public',
+      attachmentShared: true,
     });
   } else {
     toast.alert('Recipients may not be able to view this file', {

--- a/js/app/packages/channel/Call/CallContext.tsx
+++ b/js/app/packages/channel/Call/CallContext.tsx
@@ -1,3 +1,4 @@
+import { analytics } from '@app/lib/analytics';
 import {
   isKrispNoiseFilterSupported,
   KrispNoiseFilter,
@@ -1077,6 +1078,11 @@ function createCallState() {
     try {
       await r.localParticipant.setScreenShareEnabled(newSharing);
       setStore('isScreenSharing', newSharing);
+      analytics.track('call_screen_share_toggled', {
+        callId: store.activeCallId ?? undefined,
+        channelId: store.activeChannelId ?? '',
+        enabled: newSharing,
+      });
     } catch (e) {
       console.error('failed to toggle screen share', e);
     }

--- a/js/app/packages/channel/Call/ChannelCallButton.tsx
+++ b/js/app/packages/channel/Call/ChannelCallButton.tsx
@@ -1,3 +1,4 @@
+import { analytics } from '@app/lib/analytics';
 import { useChannelTab } from '@channel/Channel/ChannelTabContext';
 import { isMobile } from '@core/mobile/isMobile';
 import PhoneIcon from '@icon/wide-call.svg';
@@ -28,8 +29,18 @@ export function ChannelCallButton(props: { channelId: string }) {
 
   const handleClick = async () => {
     if (call.isJoining()) return;
+    const wasExistingCall = isCallInProgress();
+    analytics.track('call_join_clicked', {
+      channelId: props.channelId,
+      isExistingCall: isCallInProgress(),
+    });
     try {
       await call.joinCall();
+      // A successful join with no call previously in progress means this user
+      // started the call. Fires once, from the starter's client.
+      if (!wasExistingCall) {
+        analytics.track('call_started', { channelId: props.channelId });
+      }
     } catch (e) {
       console.error('Call action failed', e);
     }

--- a/js/app/packages/channel/Call/use-call.ts
+++ b/js/app/packages/channel/Call/use-call.ts
@@ -1,3 +1,4 @@
+import { analytics } from '@app/lib/analytics';
 import { useChannelsContext } from '@core/context/channels';
 import { throwOnErr } from '@core/util/result';
 import {
@@ -196,6 +197,7 @@ export function useCall(channelId: () => string, options?: UseCallOptions) {
       clearAutoRejoinTimer();
       void invalidateActiveCallQueries();
       attachDisconnectListener();
+      analytics.track('call_joined', { channelId: channelId() });
     },
     // Keep this handler synchronous: we undo the optimistic join and show the
     // error message right away. LiveKit disconnect and the server leave call
@@ -266,6 +268,10 @@ export function useCall(channelId: () => string, options?: UseCallOptions) {
       try {
         await callCtx.disconnectSession(leaveOptions);
         options?.onLeave?.();
+        analytics.track('call_left', {
+          channelId: id,
+          leaveReason: 'user_initiated',
+        });
       } finally {
         await leaveMutation.mutateAsync(id);
       }

--- a/js/app/packages/core/component/FileList/itemOperations.ts
+++ b/js/app/packages/core/component/FileList/itemOperations.ts
@@ -127,6 +127,11 @@ export async function renameItem(args: {
     return false;
   }
 
+  analytics.track('document_renamed', {
+    entityType: itemType,
+    entityId: id,
+  });
+
   return true;
 }
 
@@ -199,6 +204,12 @@ export async function deleteItem(args: {
     const removed = await removeHistoryItem(itemType, id);
     if (!removed) return false;
   }
+
+  analytics.track('document_deleted', {
+    entityType: itemType,
+    entityId: id,
+    deleteType: 'soft',
+  });
 
   refetchResources();
   return true;
@@ -287,6 +298,13 @@ export async function moveToFolder(args: {
   if (result.isErr()) {
     return false;
   }
+
+  analytics.track('document_moved', {
+    entityType: itemType,
+    entityId: id,
+    destProjectId: folderId,
+  });
+
   refetchResources();
   return true;
 }
@@ -369,6 +387,12 @@ export async function copyItem(args: {
     default:
       return null;
   }
+
+  analytics.track('document_duplicated', {
+    entityType: itemType,
+    sourceId: id,
+    newId,
+  });
 
   refetchResources();
   return newId;
@@ -508,6 +532,11 @@ export async function permanentlyDelete(args: {
   }
 
   analytics.track('delete_entity', { entityType: itemType });
+  analytics.track('document_deleted', {
+    entityType: itemType,
+    entityId: id,
+    deleteType: 'permanent',
+  });
   return true;
 }
 

--- a/js/app/packages/core/component/ForwardToChannel.tsx
+++ b/js/app/packages/core/component/ForwardToChannel.tsx
@@ -287,6 +287,34 @@ export function ForwardToChannel(props: ForwardToChannelProps) {
     };
   };
 
+  // Typed replacement for the generic `share_entity` forward event: records the
+  // actual entity type and target, which `share_entity` (location-only) loses.
+  const trackForwardShare = (targetType: 'channel' | 'user') => {
+    const itemType =
+      blockName != null ? blockNameToItemType(blockName) : undefined;
+    const entityId = blockId ?? '';
+    if (itemType === 'email') {
+      analytics.track('email_shared', {
+        entityId,
+        shareMethod: 'forward_to_channel',
+        targetType,
+      });
+    } else if (itemType === 'chat') {
+      analytics.track('chat_shared', {
+        entityId,
+        shareMethod: 'forward_to_channel',
+        targetType,
+      });
+    } else if (itemType != null) {
+      analytics.track('document_shared', {
+        entityType: itemType,
+        entityId,
+        shareMethod: 'forward_to_channel',
+        targetType,
+      });
+    }
+  };
+
   function handleSubmit() {
     let options = selectedOptions();
     if (!options || options.length === 0) {
@@ -318,6 +346,7 @@ export function ForwardToChannel(props: ForwardToChannelProps) {
             ],
           });
           analytics.track('share_entity', { location: 'forward_to_channel' });
+          trackForwardShare('user');
         });
       } else {
         toast.failure('Message failed to send');
@@ -354,6 +383,7 @@ export function ForwardToChannel(props: ForwardToChannelProps) {
               analytics.track('share_entity', {
                 location: 'forward_to_channel',
               });
+              trackForwardShare('channel');
             }),
           ]);
         } else {
@@ -383,6 +413,7 @@ export function ForwardToChannel(props: ForwardToChannelProps) {
               });
             }
             analytics.track('share_entity', { location: 'forward_to_channel' });
+            trackForwardShare('user');
           });
         }
       }

--- a/js/app/packages/core/component/TopBar/ShareButton.tsx
+++ b/js/app/packages/core/component/TopBar/ShareButton.tsx
@@ -785,6 +785,32 @@ export function ShareModal(props: ShareModalProps) {
             subtext: accessLevelText(accessLevel),
           });
         }
+
+        if (props.itemType === 'email') {
+          analytics.track('email_shared', {
+            entityId: props.id,
+            shareMethod: 'channel',
+            targetType: 'channel',
+          });
+        } else if (props.itemType === 'chat') {
+          analytics.track('chat_shared', {
+            entityId: props.id,
+            shareMethod: 'channel',
+            accessLevel,
+            targetType: 'channel',
+          });
+        } else if (
+          props.itemType === 'document' ||
+          props.itemType === 'project'
+        ) {
+          analytics.track('document_shared', {
+            entityType: props.itemType,
+            entityId: props.id,
+            shareMethod: 'channel',
+            accessLevel,
+            targetType: 'channel',
+          });
+        }
       } else {
         toast.alert('Failed to change channel access', {
           subtext: 'Please try again',
@@ -832,6 +858,13 @@ export function ShareModal(props: ShareModalProps) {
               isPublic: true,
             });
           }
+
+          analytics.track('chat_shared', {
+            entityId: props.id,
+            shareMethod: 'public_link',
+            accessLevel,
+            targetType: 'public',
+          });
         } else {
           toast.alert('Failed to change chat access', {
             subtext: 'Please try again',
@@ -863,6 +896,14 @@ export function ShareModal(props: ShareModalProps) {
               isPublic: true,
             });
           }
+
+          analytics.track('document_shared', {
+            entityType: 'document',
+            entityId: props.id,
+            shareMethod: 'public_link',
+            accessLevel,
+            targetType: 'public',
+          });
         } else {
           toast.alert('Failed to change document access', {
             subtext: 'Please try again',
@@ -894,6 +935,14 @@ export function ShareModal(props: ShareModalProps) {
               isPublic: true,
             });
           }
+
+          analytics.track('document_shared', {
+            entityType: 'project',
+            entityId: props.id,
+            shareMethod: 'public_link',
+            accessLevel,
+            targetType: 'public',
+          });
         } else {
           toast.alert('Failed to change folder access', {
             subtext: 'Please try again',

--- a/js/app/packages/core/util/create.ts
+++ b/js/app/packages/core/util/create.ts
@@ -1,3 +1,5 @@
+import { analytics } from '@app/lib/analytics';
+import type { TrackedSource } from '@app/lib/analytics/app-events';
 import { DEFAULT_CHAT_NAME } from '@block-chat/definition';
 import type { CodeFileExtension } from '@block-code/util/languageSupport';
 import { PaywallKey, usePaywallState } from '@core/constant/PaywallState';
@@ -29,6 +31,7 @@ type CreateMarkdownFileArgs = {
   title?: string;
   content?: string;
   projectId?: string;
+  source?: TrackedSource;
 };
 
 /**
@@ -63,6 +66,14 @@ export async function createMarkdownFile(
     fileType: 'md',
   });
   refetchSoupEntity(documentId, 'document');
+
+  analytics.track('document_created', {
+    entityType: 'md',
+    entityId: documentId,
+    projectId: args?.projectId,
+    source: args?.source,
+  });
+
   return documentId;
 }
 
@@ -71,6 +82,7 @@ type CreateTaskArgs = {
   content?: string;
   projectId?: string;
   propertyValues?: PropertyInput[];
+  source?: TrackedSource;
 };
 
 /**
@@ -126,6 +138,25 @@ export async function createTask(
     subType: { type: 'task', is_completed: false },
   });
   refetchSoupEntity(documentId, 'document');
+
+  analytics.track('task_created', {
+    entityId: documentId,
+    projectId: args?.projectId,
+    source: args?.source,
+    hasAssignee: propertyValues.some(
+      (p) => p.propertyId === SYSTEM_PROPERTY_IDS.ASSIGNEES
+    ),
+    hasDueDate: propertyValues.some(
+      (p) => p.propertyId === SYSTEM_PROPERTY_IDS.DUE_DATE
+    ),
+    hasPriority: propertyValues.some(
+      (p) => p.propertyId === SYSTEM_PROPERTY_IDS.PRIORITY
+    ),
+    isSubtask: propertyValues.some(
+      (p) => p.propertyId === SYSTEM_PROPERTY_IDS.PARENT_TASK
+    ),
+  });
+
   return documentId;
 }
 
@@ -133,6 +164,7 @@ type CreateSnippetArgs = {
   title?: string;
   content?: string;
   projectId?: string;
+  source?: TrackedSource;
 };
 
 /**
@@ -163,6 +195,14 @@ export async function createSnippet(
     subType: { type: 'snippet' },
   });
   refetchSoupEntity(documentId, 'document');
+
+  analytics.track('document_created', {
+    entityType: 'snippet',
+    entityId: documentId,
+    projectId: args?.projectId,
+    source: args?.source,
+  });
+
   return documentId;
 }
 
@@ -171,11 +211,13 @@ export async function createCodeFileFromText({
   extension,
   language,
   title,
+  source,
 }: {
   code: string;
   title?: string;
   extension?: CodeFileExtension;
   language?: string;
+  source?: TrackedSource;
 }) {
   const encoder = new TextEncoder();
   const buffer = encoder.encode(code);
@@ -244,6 +286,14 @@ export async function createCodeFileFromText({
     fileType: finalExtension,
   });
   refetchSoupEntity(document.metadata.documentId, 'document');
+
+  analytics.track('document_created', {
+    entityType: 'code',
+    entityId: document.metadata.documentId,
+    source,
+    extension: finalExtension,
+  });
+
   return ok({ documentId: document.metadata.documentId });
 }
 
@@ -251,8 +301,9 @@ export async function createCanvasFileFromJsonString(args: {
   json: string;
   title?: string;
   projectId?: string;
+  source?: TrackedSource;
 }) {
-  const { json, title, projectId } = args;
+  const { json, title, projectId, source } = args;
   const encoder = new TextEncoder();
   const buffer = encoder.encode(json);
   const sha = await contentHash(buffer);
@@ -284,10 +335,21 @@ export async function createCanvasFileFromJsonString(args: {
     fileType: 'canvas',
   });
   refetchSoupEntity(canvas.metadata.documentId, 'document');
+
+  analytics.track('document_created', {
+    entityType: 'canvas',
+    entityId: canvas.metadata.documentId,
+    projectId,
+    source,
+  });
+
   return { documentId: canvas.metadata.documentId };
 }
 
-export async function createChat(args?: CreateChatRequest) {
+export async function createChat(
+  args?: CreateChatRequest,
+  opts?: { source?: TrackedSource }
+) {
   const { showPaywall } = usePaywallState();
 
   const maybeChat = await cognitionApiServiceClient.createChat(args ?? {});
@@ -307,6 +369,12 @@ export async function createChat(args?: CreateChatRequest) {
     name: args?.name ?? DEFAULT_CHAT_NAME,
   });
   refetchSoupEntity(chat.id, 'chat');
+
+  analytics.track('chat_created', {
+    entityId: chat.id,
+    source: opts?.source,
+  });
+
   return { chatId: chat.id };
 }
 

--- a/js/app/packages/queries/properties/entity.ts
+++ b/js/app/packages/queries/properties/entity.ts
@@ -1,5 +1,7 @@
+import { analytics } from '@app/lib/analytics';
 import { toast } from '@core/component/Toast/Toast';
 import { throwOnErr } from '@core/util/result';
+import { PROPERTY_OPTION_IDS, SYSTEM_PROPERTY_IDS } from '@property/constants';
 import {
   entityPropertyFromApi,
   propertyValueToApi,
@@ -296,6 +298,70 @@ type BulkSaveEntityPropertiesContext = {
   soupTxns: SoupTransaction[];
 };
 
+/**
+ * Emits task lifecycle analytics for a saved property value. Gated on the
+ * property being a task system property (STATUS / PRIORITY / ASSIGNEES /
+ * DUE_DATE), so non-task entities never fire these. Call only on save success.
+ */
+function trackTaskPropertyChange(
+  entityId: string,
+  propertyId: string,
+  apiValues: PropertyApiValues
+) {
+  switch (propertyId) {
+    case SYSTEM_PROPERTY_IDS.STATUS: {
+      const newStatus =
+        apiValues.valueType === 'SELECT_STRING'
+          ? (apiValues.values?.[0] ?? '')
+          : '';
+      if (!newStatus) break;
+      analytics.track('task_status_changed', {
+        entityId,
+        newStatus,
+        source: 'property_editor',
+      });
+      if (newStatus === PROPERTY_OPTION_IDS.STATUS.COMPLETED) {
+        analytics.track('task_completed', {
+          entityId,
+          source: 'property_editor',
+        });
+      }
+      break;
+    }
+    case SYSTEM_PROPERTY_IDS.PRIORITY: {
+      analytics.track('task_priority_changed', {
+        entityId,
+        newPriority:
+          apiValues.valueType === 'SELECT_STRING'
+            ? (apiValues.values?.[0] ?? undefined)
+            : undefined,
+        source: 'property_editor',
+      });
+      break;
+    }
+    case SYSTEM_PROPERTY_IDS.ASSIGNEES: {
+      analytics.track('task_assignee_changed', {
+        entityId,
+        assigneeCount:
+          apiValues.valueType === 'ENTITY' ? (apiValues.refs?.length ?? 0) : 0,
+        source: 'property_editor',
+      });
+      break;
+    }
+    case SYSTEM_PROPERTY_IDS.DUE_DATE: {
+      analytics.track('task_due_date_changed', {
+        entityId,
+        hasDueDate:
+          apiValues.valueType === 'DATE' ? apiValues.value != null : false,
+        source: 'property_editor',
+      });
+      break;
+    }
+    default:
+      break;
+  }
+}
+
 /** Saves multiple entity properties in bulk using parallel requests */
 export function useBulkSaveEntityPropertiesMutation(
   callbacks?: MutationCallbacks<
@@ -380,6 +446,15 @@ export function useBulkSaveEntityPropertiesMutation(
               invalidateSoupEntity(p.entityId);
             }
           });
+          if (!error) {
+            for (const p of variables.properties) {
+              trackTaskPropertyChange(
+                p.entityId,
+                getPropertyDefinitionId(p.property),
+                p.apiValues
+              );
+            }
+          }
         },
       },
       callbacks

--- a/js/app/packages/queries/storage/projects.ts
+++ b/js/app/packages/queries/storage/projects.ts
@@ -1,3 +1,5 @@
+import { analytics } from '@app/lib/analytics';
+import type { TrackedSource } from '@app/lib/analytics/app-events';
 import { ENABLE_PROJECT_SHARING } from '@core/constant/featureFlags';
 import { useUserId } from '@core/context/user';
 import { compareDateDesc } from '@core/util/date';
@@ -91,6 +93,7 @@ export async function createProject(params: {
   name: string;
   parentId?: string;
   sharePermission?: null;
+  source?: TrackedSource;
 }): Promise<string | undefined> {
   const result = await storageServiceClient.projects.create({
     name: params.name,
@@ -110,6 +113,13 @@ export async function createProject(params: {
       itemType: 'project',
     });
     await Promise.all([invalidateProjects(), refetchHistory()]);
+
+    analytics.track('project_created', {
+      entityId: projectId,
+      parentId: params.parentId,
+      source: params.source,
+    });
+
     return projectId;
   }
 


### PR DESCRIPTION
…, and calls

Adds 22 typed PostHog events alongside the existing (untouched) create_entity / share_entity events to give a clearer picture of app usage.

- Creation instrumented at the create.ts / projects.ts chokepoint so it captures every surface (launcher, mobile dock, hotkey, checkbox conversion, API): document_created, task_created, chat_created, project_created.
- Document lifecycle: document_renamed / _moved / _duplicated / _deleted.
- Sharing (typed, complete): document_shared, chat_shared, email_shared — covering public-link (incl. make-private), channel grants, forwards, and email attachment-public.
- Task lifecycle at the property-save chokepoint: task_status_changed, task_completed, task_assignee_changed, task_priority_changed, task_due_date_changed, task_moved_to_project.
- Calls (frontend): call_started, call_join_clicked, call_joined, call_left, call_screen_share_toggled.

All events are typed in app-events.ts. Changes are purely additive analytics — no existing behavior is altered (analytics.track is fire-and-forget and cannot throw). Authoritative call lifecycle (call_ended, call_recording_completed, call_summary_generated) is deferred to a backend PR.