### PR TITLE
fix(soup): show moved items in destination folder without hard refresh

### DIFF
--- a/js/app/packages/app/component/bulk-edit-entity/BulkMoveToProjectView.tsx
+++ b/js/app/packages/app/component/bulk-edit-entity/BulkMoveToProjectView.tsx
@@ -217,9 +217,13 @@ export const BulkMoveToProjectView = (props: {
       itemMap[project.id] = { ...project, children: [] };
     }
 
-    // Second pass: attach children; projects with a missing parent become roots
+    // Second pass: attach children; projects with a missing or self-referencing parent become roots
     for (const project of allProjects) {
-      if (project.parentId && itemMap[project.parentId]) {
+      if (
+        project.parentId &&
+        project.parentId !== project.id &&
+        itemMap[project.parentId]
+      ) {
         itemMap[project.parentId].children!.push(project);
       } else {
         rootItems.push(project);

--- a/js/app/packages/app/component/bulk-edit-entity/BulkMoveToProjectView.tsx
+++ b/js/app/packages/app/component/bulk-edit-entity/BulkMoveToProjectView.tsx
@@ -212,24 +212,17 @@ export const BulkMoveToProjectView = (props: {
     const rootItems: Project[] = [];
     // Build project tree structure
 
-    // First pass: create item map and identify root items
+    // First pass: create item map
     for (const project of allProjects) {
       itemMap[project.id] = { ...project, children: [] };
-      if (!project.parentId) {
-        rootItems.push(project);
-      } else {
-        // This will be processed in second pass
-        const parentId = project.parentId;
-        if (!itemMap[parentId]) {
-          itemMap[parentId] = { ...project, children: [] };
-        }
-      }
     }
 
-    // Second pass: build parent-child relationships
+    // Second pass: attach children; projects with a missing parent become roots
     for (const project of allProjects) {
       if (project.parentId && itemMap[project.parentId]) {
         itemMap[project.parentId].children!.push(project);
+      } else {
+        rootItems.push(project);
       }
     }
 
@@ -239,8 +232,10 @@ export const BulkMoveToProjectView = (props: {
   const getProjectPath = (projectId: string): string => {
     const tree = projectTree();
     const path: string[] = [];
+    const visited = new Set<string>();
     let currentId: string | undefined = projectId;
-    while (currentId) {
+    while (currentId && !visited.has(currentId)) {
+      visited.add(currentId);
       const project: Project & { children?: Project[] } =
         tree.itemMap[currentId];
       if (project) {

--- a/js/app/packages/macro-entity/src/queries/dss.ts
+++ b/js/app/packages/macro-entity/src/queries/dss.ts
@@ -12,6 +12,7 @@ import { queryClient } from '@queries/client';
 import {
   getSoupEntityById,
   invalidateSoupEntity,
+  invalidateSoupQueriesReferencing,
   optimisticUpdateSoupEntity,
   removeSearchEntities,
   removeSoupEntities,
@@ -91,6 +92,7 @@ export function createBulkDeleteDssItemsMutation() {
 
 function invalidateAfterMove(
   entityIds: string[],
+  destinationProjectId: string,
   hasProjects: boolean,
   failed?: boolean
 ) {
@@ -98,9 +100,12 @@ function invalidateAfterMove(
     toast.failure('Failed to move item');
   }
 
+  // Covers queries already containing the entities (including the source folder's list)
   for (const id of entityIds) {
     invalidateSoupEntity(id);
   }
+  // Destination folder's list queries don't contain the entities yet, so match by project id in the key
+  invalidateSoupQueriesReferencing([destinationProjectId]);
   queryClient.invalidateQueries({ queryKey: ['entity'] });
   // If moving a project, invalidate all project queries since nested projects' breadcrumbs change too
   if (hasProjects) {
@@ -143,14 +148,14 @@ export function createMoveToProjectDssEntityMutation() {
         });
       }
     },
-    onSettled: (data, error, { entity: { id, type } }, context) => {
+    onSettled: (data, error, { entity: { id, type }, project }, context) => {
       const failed = data?.success === false || !!error;
       if (failed) {
         context?.rollback();
         console.error(`Failed to move dss item ${id}`, data, error);
       }
 
-      invalidateAfterMove([id], type === 'project', failed);
+      invalidateAfterMove([id], project.id, type === 'project', failed);
     },
   }));
 }
@@ -281,7 +286,7 @@ export function createBulkMoveToProjectDssEntityMutation() {
       });
     },
 
-    onSettled: (data, error, { entities }, context) => {
+    onSettled: (data, error, { entities, project }, context) => {
       const failed = data?.success === false || !!error;
       if (failed) {
         context?.forEach((txn) => txn.rollback());
@@ -290,6 +295,7 @@ export function createBulkMoveToProjectDssEntityMutation() {
 
       invalidateAfterMove(
         entities.map((e) => e.id),
+        project.id,
         entities.some((e) => e.type === 'project'),
         failed
       );

--- a/js/app/packages/queries/soup/normalized-cache/index.ts
+++ b/js/app/packages/queries/soup/normalized-cache/index.ts
@@ -4,6 +4,7 @@ export {
   hasSoupEntity,
   invalidateAllSoup,
   invalidateSoupEntity,
+  invalidateSoupQueriesReferencing,
   optimisticUpdateSoupEntity,
   optimisticUpdateSoupItemUpdatedAt,
   optimisticUpdateSoupItemViewedAt,

--- a/js/app/packages/queries/soup/normalized-cache/operations.ts
+++ b/js/app/packages/queries/soup/normalized-cache/operations.ts
@@ -128,6 +128,18 @@ export function invalidateSoupEntity(entityId: string): void {
   }
 }
 
+/** Mark stale soup queries whose query key references any of the given ids (e.g. project-scoped views). */
+export function invalidateSoupQueriesReferencing(ids: string[]): void {
+  if (ids.length === 0) return;
+  queryClient.invalidateQueries({
+    queryKey: ['soup'],
+    predicate: (query) => {
+      const serialized = JSON.stringify(query.queryKey);
+      return ids.some((id) => serialized.includes(id));
+    },
+  });
+}
+
 /** Mark every soup list query stale. Use `invalidateSoupEntity` when the entity ID is known. */
 export function invalidateAllSoup(): void {
   queryClient.invalidateQueries({


### PR DESCRIPTION
## Problem

Moving an item (e.g. an email) into a project/folder via the CmdK "Move to folder" flow didn't make it appear in the destination folder until a hard refresh.

Separately, typing in the move-to-folder modal's search box could freeze the entire app.

## Changes

### Destination folder cache invalidation

Both move mutations funnel into `invalidateAfterMove()` (`macro-entity/src/queries/dss.ts`), which only called `invalidateSoupEntity(id)` — a normalizer-based invalidation that touches queries *already containing* the moved entity. The destination folder's soup list query doesn't contain the item yet, so it was never marked stale.

Added `invalidateSoupQueriesReferencing(ids)` (`queries/soup/normalized-cache/operations.ts`): a targeted invalidation that runs a predicate over the `['soup']` namespace and matches queries whose serialized query key references the destination project id. Project-scoped views embed the project UUID in their compiled filter AST (`{ l: { pid } }` / `{ l: { ProjectId } }`) or as the `groupKey`, so a substring match on the UUID precisely catches every view of the destination folder without invalidating unrelated soup queries.

Source-folder views keep working through the existing `invalidateSoupEntity` path since they contain the entity.

### Move-modal freeze fix

`BulkMoveToProjectView`'s tree builder created a placeholder entry for a missing parent from a spread of the *child*, producing a self-referencing node whenever a folder's parent isn't in the loaded list (deleted, or shared child with unshared parent). `getProjectPath` walks the parent chain in a `while` loop and spun forever — triggered on the first keystroke, since search mode is the only path that computes paths for all matches.

- Folders whose parent isn't in the list are now treated as roots (also makes them visible in tree mode; previously they were unreachable).
- `getProjectPath` is cycle-guarded with a visited set as defense in depth.
