### PR TITLE
Add embed support for X, YouTube, and Figma content

### DIFF
--- a/js/app/packages/block-md/component/MarkdownEditor.tsx
+++ b/js/app/packages/block-md/component/MarkdownEditor.tsx
@@ -26,6 +26,10 @@ import { FloatingEquationMenu } from '@core/component/LexicalMarkdown/component/
 import { FloatingLinkMenu } from '@core/component/LexicalMarkdown/component/menu/FloatingLinkMenu';
 import { GenerateMenu } from '@core/component/LexicalMarkdown/component/menu/GenerateMenu';
 import { MentionsMenu } from '@core/component/LexicalMarkdown/component/menu/MentionsMenu/MentionsMenu';
+import {
+  PasteAsMenu,
+  type PasteAsMenuState,
+} from '@core/component/LexicalMarkdown/component/menu/PasteAsMenu';
 import { SnippetsMenu } from '@core/component/LexicalMarkdown/component/menu/SnippetsMenu';
 import TableActionMenu, {
   anchorElemRefSignal,
@@ -55,6 +59,7 @@ import {
   documentMetadataPlugin,
   draggableBlockPlugin,
   dragInsertPlugin,
+  embedPastePlugin,
   filePastePlugin,
   generatePlugin,
   horizontalRulePlugin,
@@ -309,6 +314,8 @@ export function MarkdownEditor(props: {
   const emojiMenuOperations = createMenuOperations();
   const actionsMenuOperations = createMenuOperations();
   const snippetsMenuOperations = createMenuOperations();
+  const [pasteAsMenuState, setPasteAsMenuState] =
+    createSignal<PasteAsMenuState>(null);
 
   // store for the drag insert pluign.
   const [dragInsertStore, setDragInsertStore] = createDragInsertStore();
@@ -585,6 +592,7 @@ export function MarkdownEditor(props: {
       })
     )
     .use(textPastePlugin())
+    .use(embedPastePlugin({ onPaste: setPasteAsMenuState }))
     .use(restoreFocusPlugin())
     .use(markdownPastePlugin())
     .use(normalizeEnterPlugin())
@@ -1080,6 +1088,12 @@ export function MarkdownEditor(props: {
             sourceDocumentId: blockId,
             sourceBlockName: blockName,
           }}
+        />
+
+        <PasteAsMenu
+          editor={editor}
+          state={pasteAsMenuState}
+          setState={setPasteAsMenuState}
         />
 
         <FloatingMenuGroup>

--- a/js/app/packages/channel/Message/ChannelMessage.tsx
+++ b/js/app/packages/channel/Message/ChannelMessage.tsx
@@ -65,6 +65,7 @@ function MessageFooter(props: { messageEditor?: MessageEditor }) {
 
   return (
     <Show when={!isEditingMessage(props.messageEditor, message().id)}>
+      <Message.Embeds />
       <Message.Attachments />
       <Message.Reactions />
     </Show>

--- a/js/app/packages/channel/Message/Embeds.tsx
+++ b/js/app/packages/channel/Message/Embeds.tsx
@@ -1,0 +1,31 @@
+import { EmbedFrame } from '@core/component/LexicalMarkdown/component/decorator/MarkdownEmbed';
+import { findEmbedUrls } from '@lexical-core';
+import { createMemo, For, Show } from 'solid-js';
+import { useMessage } from './context';
+
+const MAX_EMBEDS_PER_MESSAGE = 3;
+
+type EmbedsProps = {
+  class?: string;
+};
+
+/**
+ * Embeds for links in the message body (X posts, YouTube videos, Figma
+ * files), rendered below the content — the link itself stays inline.
+ */
+export function Embeds(props: EmbedsProps) {
+  const message = useMessage();
+  const embeds = createMemo(() =>
+    findEmbedUrls(message().content ?? '', MAX_EMBEDS_PER_MESSAGE)
+  );
+
+  return (
+    <Show when={embeds().length > 0}>
+      <div class={props.class ?? 'flex flex-col gap-2 mt-1 max-w-full'}>
+        <For each={embeds()}>
+          {(embed) => <EmbedFrame provider={embed.provider} url={embed.url} />}
+        </For>
+      </div>
+    </Show>
+  );
+}

--- a/js/app/packages/channel/Message/Message.ts
+++ b/js/app/packages/channel/Message/Message.ts
@@ -4,6 +4,7 @@ import { Attachments } from './Attachments';
 import { Content } from './Content';
 import { DateDivider } from './DateDivider';
 import { EditedIndicator } from './EditedIndicator';
+import { Embeds } from './Embeds';
 import { FromPill } from './FromPill';
 import { HoverActions } from './HoverActions';
 import { Layout } from './Layout';
@@ -27,6 +28,7 @@ export const Message = {
   SenderIcon,
   Timestamp,
   Content,
+  Embeds,
   Attachments,
   DateDivider,
   NewDivider,

--- a/js/app/packages/core/component/LexicalMarkdown/component/core/StaticMarkdown.tsx
+++ b/js/app/packages/core/component/LexicalMarkdown/component/core/StaticMarkdown.tsx
@@ -24,6 +24,7 @@ import {
   type HorizontalRuleNode,
   type ImageNode,
   isSupportedLanguage,
+  type LinkMentionNode,
   normalizedLanguage,
   type PasteNode,
   type SnapshotNode,
@@ -80,6 +81,7 @@ import { DocumentMention as DocumentMentionDecorator } from '../decorator/Docume
 import { Equation as EquationDecorator } from '../decorator/Equation';
 import { GroupMention as GroupMentionDecorator } from '../decorator/GroupMention';
 import { LazyDecorator } from '../decorator/LazyDecorator';
+import { LinkMention as LinkMentionDecorator } from '../decorator/LinkMention';
 import { MarkdownEmbed as EmbedDecorator } from '../decorator/MarkdownEmbed';
 import { MarkdownImage as ImageDecorator } from '../decorator/MarkdownImage';
 import { MarkdownVideo as VideoDecorator } from '../decorator/MarkdownVideo';
@@ -458,6 +460,20 @@ const UnknownMention: RenderableEntity<UnknownMentionNode> = {
   ),
 };
 
+const LinkMention: RenderableEntity<LinkMentionNode> = {
+  guard: (node: LexicalNode): node is LinkMentionNode =>
+    node.__type === 'link-mention',
+  render: (props) => (
+    <span>
+      {LinkMentionDecorator({
+        ...props.node.exportComponentProps(),
+        key: props.node.getKey(),
+        theme: props.theme,
+      })}
+    </span>
+  ),
+};
+
 const Image: RenderableEntity<ImageNode> = {
   guard: (node: LexicalNode): node is ImageNode => node.__type === 'image',
   render: (props) => ImageDecorator(props.node.exportComponentProps()),
@@ -794,6 +810,7 @@ const InlineEntities: Array<RenderableEntity> = [
   ContactMention,
   DateMention,
   GroupMention,
+  LinkMention,
   Await,
   Snapshot,
   Image,

--- a/js/app/packages/core/component/LexicalMarkdown/component/core/StaticMarkdown.tsx
+++ b/js/app/packages/core/component/LexicalMarkdown/component/core/StaticMarkdown.tsx
@@ -18,6 +18,7 @@ import {
   DEFAULT_LANGUAGE,
   type DocumentCardNode,
   type DocumentMentionNode,
+  type EmbedNode,
   type EquationNode,
   type GroupMentionNode,
   type HorizontalRuleNode,
@@ -79,6 +80,7 @@ import { DocumentMention as DocumentMentionDecorator } from '../decorator/Docume
 import { Equation as EquationDecorator } from '../decorator/Equation';
 import { GroupMention as GroupMentionDecorator } from '../decorator/GroupMention';
 import { LazyDecorator } from '../decorator/LazyDecorator';
+import { MarkdownEmbed as EmbedDecorator } from '../decorator/MarkdownEmbed';
 import { MarkdownImage as ImageDecorator } from '../decorator/MarkdownImage';
 import { MarkdownVideo as VideoDecorator } from '../decorator/MarkdownVideo';
 import { PasteNode as PasteNodeDecorator } from '../decorator/PasteNode';
@@ -252,6 +254,7 @@ type ElementNodeComponent<T extends ElementNode = ElementNode> = ParentProps &
 
 type StaticRenderOptions = {
   lazy: boolean;
+  embedsAsLinks: boolean;
 };
 
 type RenderableEntity<T extends LexicalNode = LexicalNode> = {
@@ -463,6 +466,25 @@ const Image: RenderableEntity<ImageNode> = {
 const Video: RenderableEntity<VideoNode> = {
   guard: (node: LexicalNode): node is VideoNode => node.__type === 'video',
   render: (props) => VideoDecorator(props.node.exportComponentProps()),
+};
+
+const Embed: RenderableEntity<EmbedNode> = {
+  guard: (node: LexicalNode): node is EmbedNode => node.__type === 'embed',
+  render: (props, options) => {
+    const url = props.node.getUrl();
+    if (options.embedsAsLinks) {
+      return (
+        <LinkWithPreview url={url} class={props.theme.link} title={url}>
+          {url}
+        </LinkWithPreview>
+      );
+    }
+    return EmbedDecorator({
+      ...props.node.exportComponentProps(),
+      key: props.node.getKey(),
+      theme: props.theme,
+    });
+  },
 };
 
 const Paragraph: RenderableElement<ParagraphNode> = {
@@ -776,6 +798,7 @@ const InlineEntities: Array<RenderableEntity> = [
   Snapshot,
   Image,
   Video,
+  Embed,
   HorizontalRule,
   Equation,
   ThemeMention,
@@ -803,6 +826,11 @@ const Elements: RenderableElement[] = [
 function Render(
   props: (NodeComponent | ElementNodeComponent) & StaticRenderOptions
 ) {
+  const options: StaticRenderOptions = {
+    lazy: props.lazy,
+    embedsAsLinks: props.embedsAsLinks,
+  };
+
   let entity = InlineEntities.find((entity) => entity.guard(props.node));
   if (entity) {
     return entity.render(
@@ -810,7 +838,7 @@ function Render(
         ...props,
         theme: props.theme,
       },
-      { lazy: props.lazy }
+      options
     );
   }
 
@@ -825,10 +853,11 @@ function Render(
           children: elemNode.getChildren(),
           theme: props.theme,
           lazy: props.lazy,
+          embedsAsLinks: props.embedsAsLinks,
         }),
         theme: props.theme,
       },
-      { lazy: props.lazy }
+      options
     );
   }
 
@@ -840,9 +869,15 @@ function MapRender(props: {
   children: LexicalNode[];
   theme: EditorThemeClasses;
   lazy: boolean;
+  embedsAsLinks: boolean;
 }) {
   return props.children.map((child) => (
-    <Render node={child} theme={props.theme} lazy={props.lazy} />
+    <Render
+      node={child}
+      theme={props.theme}
+      lazy={props.lazy}
+      embedsAsLinks={props.embedsAsLinks}
+    />
   ));
 }
 
@@ -850,6 +885,7 @@ function Document(props: {
   rootNode: RootNode;
   theme: EditorThemeClasses;
   lazy: boolean;
+  embedsAsLinks: boolean;
   rootRef?: (ref: HTMLDivElement) => void;
   singleLine?: boolean;
 }): JSX.Element {
@@ -866,6 +902,7 @@ function Document(props: {
         children={props.rootNode.getChildren()}
         theme={props.theme}
         lazy={props.lazy}
+        embedsAsLinks={props.embedsAsLinks}
       />
     </div>
   );
@@ -886,6 +923,8 @@ export function StaticMarkdown(props: {
   target?: 'internal' | 'external' | 'both';
   singleLine?: boolean;
   lazy?: boolean;
+  /** Render embed nodes as plain links, for compact contexts like search results. */
+  embedsAsLinks?: boolean;
 }) {
   let {
     editor: contextEditor,
@@ -952,6 +991,7 @@ export function StaticMarkdown(props: {
         rootNode: $getRoot(),
         theme: mergedTheme(),
         lazy: lazy(),
+        embedsAsLinks: props.embedsAsLinks ?? false,
         rootRef: props.rootRef,
       });
     });

--- a/js/app/packages/core/component/LexicalMarkdown/component/decorator/LinkMention.tsx
+++ b/js/app/packages/core/component/LexicalMarkdown/component/decorator/LinkMention.tsx
@@ -1,0 +1,163 @@
+import { HoverCard } from '@core/component/HoverCard';
+import { UnfurlLink } from '@core/component/Link';
+import { useUnfurl } from '@core/signal/unfurl';
+import {
+  $isLinkMentionNode,
+  getXHandle,
+  type LinkMentionDecoratorProps,
+  parseEmbedUrl,
+} from '@lexical-core';
+import FigmaIcon from '@phosphor/figma-logo.svg';
+import LinkIcon from '@phosphor/link.svg';
+import XLogoIcon from '@phosphor/x-logo.svg';
+import YouTubeIcon from '@phosphor/youtube-logo.svg';
+import { cn, Surface } from '@ui';
+import {
+  $getNodeByKey,
+  COMMAND_PRIORITY_NORMAL,
+  KEY_ENTER_COMMAND,
+} from 'lexical';
+import { type Component, createEffect, createMemo, useContext } from 'solid-js';
+import { Dynamic } from 'solid-js/web';
+import { LexicalWrapperContext } from '../../context/LexicalWrapperContext';
+import { autoRegister } from '../../plugins';
+import { MentionTooltip } from './MentionTooltip';
+
+function linkMentionIcon(url: string): Component<{ class?: string }> {
+  switch (parseEmbedUrl(url)?.provider) {
+    case 'x':
+      return XLogoIcon;
+    case 'youtube':
+      return YouTubeIcon;
+    case 'figma':
+      return FigmaIcon;
+    default:
+      return LinkIcon;
+  }
+}
+
+function fallbackTitle(url: string): string {
+  switch (parseEmbedUrl(url)?.provider) {
+    case 'x': {
+      const handle = getXHandle(url);
+      return handle ? `@${handle} on X` : 'Post on X';
+    }
+    case 'youtube':
+      return 'YouTube video';
+    case 'figma':
+      return 'Figma file';
+    default:
+      try {
+        return new URL(url).hostname;
+      } catch {
+        return url;
+      }
+  }
+}
+
+export function LinkMention(props: LinkMentionDecoratorProps) {
+  const lexicalWrapper = useContext(LexicalWrapperContext);
+  const editor = lexicalWrapper?.editor;
+  const selection = () => lexicalWrapper?.selection;
+
+  const [unfurlData] = useUnfurl(
+    props.title || lexicalWrapper?.skipPreviewFetch ? undefined : props.url
+  );
+
+  const unfurlTitle = () => {
+    const data = unfurlData();
+    if (data?.type !== 'success') return undefined;
+    return data.data.title || undefined;
+  };
+
+  const title = createMemo(
+    () => props.title || unfurlTitle() || fallbackTitle(props.url)
+  );
+
+  const unfurled = createMemo(() => {
+    const data = unfurlData();
+    if (data?.type === 'success') return data.data;
+    return { url: props.url, title: title() };
+  });
+
+  // Persist the resolved title so exports and future renders have it.
+  createEffect(() => {
+    const nextTitle = unfurlTitle();
+    if (!editor || !nextTitle) return;
+
+    editor.update(
+      () => {
+        const node = $getNodeByKey(props.key);
+        if ($isLinkMentionNode(node) && !node.getTitle()) {
+          node.setTitle(nextTitle);
+        }
+      },
+      { tag: 'historic', discrete: true }
+    );
+  });
+
+  const isSelectedAsNode = () => {
+    const sel = selection();
+    if (!sel) return false;
+    return sel.type === 'node' && sel.nodeKeys.has(props.key);
+  };
+
+  const open = () => {
+    window.open(props.url, '_blank');
+  };
+
+  if (editor) {
+    autoRegister(
+      editor.registerCommand(
+        KEY_ENTER_COMMAND,
+        () => {
+          if (isSelectedAsNode()) {
+            open();
+            return true;
+          }
+          return false;
+        },
+        COMMAND_PRIORITY_NORMAL
+      )
+    );
+  }
+
+  return (
+    <HoverCard
+      trigger={
+        <span class="relative">
+          <span
+            class={cn(
+              'size-full py-0.5 cursor-default rounded-xs hover:bg-hover focus:bg-active',
+              isSelectedAsNode() && 'bg-active text-ink'
+            )}
+            data-link-mention="true"
+            data-link-mention-url={props.url}
+            onClick={(e) => {
+              e.stopPropagation();
+              open();
+            }}
+          >
+            <span class="relative top-[0.125em] size-[1em] inline-flex mx-1">
+              <Dynamic
+                component={linkMentionIcon(props.url)}
+                class="size-full"
+              />
+            </span>
+            <span class="underline decoration-current/20 decoration-[max(1px,0.1em)] underline-offset-2">
+              {title()}
+            </span>
+          </span>
+          <MentionTooltip show={isSelectedAsNode()} text="Open" />
+        </span>
+      }
+      content={
+        <div class="select-none overflow-hidden w-72 text-ink">
+          <Surface depth={3} class="rounded-xl shadow-lg shadow-drop-shadow">
+            <UnfurlLink unfurled={unfurled()} />
+          </Surface>
+        </div>
+      }
+    />
+  );
+}

--- a/js/app/packages/core/component/LexicalMarkdown/component/decorator/MarkdownEmbed.tsx
+++ b/js/app/packages/core/component/LexicalMarkdown/component/decorator/MarkdownEmbed.tsx
@@ -165,6 +165,23 @@ function FigmaFrame(props: { url: string }) {
   );
 }
 
+/** The bare provider iframe for an embed, reusable outside the editor. */
+export function EmbedFrame(props: { provider: EmbedProvider; url: string }) {
+  return (
+    <>
+      {match(props.provider)
+        .with('x', () => <TweetFrame url={props.url} />)
+        .with('youtube', () => <YouTubeFrame url={props.url} />)
+        .with('figma', () => <FigmaFrame url={props.url} />)
+        .otherwise(() => (
+          <a href={props.url} target="_blank" rel="noopener">
+            {props.url}
+          </a>
+        ))}
+    </>
+  );
+}
+
 export function MarkdownEmbed(props: EmbedDecoratorProps) {
   let containerRef!: HTMLDivElement;
 
@@ -213,15 +230,7 @@ export function MarkdownEmbed(props: EmbedDecoratorProps) {
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
     >
-      {match(props.provider)
-        .with('x', () => <TweetFrame url={props.url} />)
-        .with('youtube', () => <YouTubeFrame url={props.url} />)
-        .with('figma', () => <FigmaFrame url={props.url} />)
-        .otherwise(() => (
-          <a href={props.url} target="_blank" rel="noopener">
-            {props.url}
-          </a>
-        ))}
+      <EmbedFrame provider={props.provider} url={props.url} />
       <Show when={isSelectedAsNode() || hovered()}>
         <MediaButtons
           delete={interactable() ? deleteEmbed : undefined}

--- a/js/app/packages/core/component/LexicalMarkdown/component/decorator/MarkdownEmbed.tsx
+++ b/js/app/packages/core/component/LexicalMarkdown/component/decorator/MarkdownEmbed.tsx
@@ -1,0 +1,236 @@
+import {
+  $isEmbedNode,
+  type EmbedDecoratorProps,
+  type EmbedProvider,
+  getTweetId,
+  getYouTubeStartSeconds,
+  getYouTubeVideoId,
+} from '@lexical-core';
+import FigmaIcon from '@phosphor/figma-logo.svg';
+import LoadingSpinner from '@phosphor/spinner.svg';
+import XLogoIcon from '@phosphor/x-logo.svg';
+import YouTubeIcon from '@phosphor/youtube-logo.svg';
+import { getLiveTheme, isTokensDark } from '@theme/utils/themeUtils';
+import { cn } from '@ui';
+import { $createNodeSelection, $setSelection } from 'lexical';
+import {
+  type Component,
+  createMemo,
+  createSignal,
+  onCleanup,
+  onMount,
+  Show,
+  useContext,
+} from 'solid-js';
+import { match } from 'ts-pattern';
+import { LexicalWrapperContext } from '../../context/LexicalWrapperContext';
+import { removeNodeAndRestoreSelection } from '../../plugins/shared/removeNodeAndRestoreSelection';
+import { MediaButtons } from './MediaButtons';
+
+const IFRAME_SANDBOX =
+  'allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox allow-presentation';
+
+const PROVIDER_ICONS: Record<EmbedProvider, Component<{ class?: string }>> = {
+  x: XLogoIcon,
+  youtube: YouTubeIcon,
+  figma: FigmaIcon,
+};
+
+function EmbedLoading(props: { provider: EmbedProvider }) {
+  const Icon = PROVIDER_ICONS[props.provider];
+  return (
+    <div class="absolute top-0 left-0 size-full flex flex-col justify-center items-center gap-2 text-ink-extra-muted bg-hover/50">
+      <Icon class="size-5" />
+      <div class="animate-spin size-5">
+        <LoadingSpinner class="size-5" />
+      </div>
+    </div>
+  );
+}
+
+function TweetFrame(props: { url: string }) {
+  let iframeRef!: HTMLIFrameElement;
+  let revealTimeout: ReturnType<typeof setTimeout> | undefined;
+  const [height, setHeight] = createSignal(0);
+  const [loaded, setLoaded] = createSignal(false);
+
+  const dark = createMemo(() => isTokensDark(getLiveTheme().tokens));
+  const src = createMemo(() => {
+    const id = getTweetId(props.url);
+    const theme = dark() ? 'dark' : 'light';
+    return `https://platform.twitter.com/embed/Tweet.html?dnt=true&id=${id}&theme=${theme}`;
+  });
+
+  // The tweet iframe reports its rendered height via postMessage.
+  const onMessage = (event: MessageEvent) => {
+    if (event.origin !== 'https://platform.twitter.com') return;
+    if (event.source !== iframeRef.contentWindow) return;
+    const embed = event.data?.['twttr.embed'];
+    if (embed?.method !== 'twttr.private.resize') return;
+    const reportedHeight = embed.params?.[0]?.height;
+    if (typeof reportedHeight === 'number' && reportedHeight > 0) {
+      setHeight(reportedHeight);
+      setLoaded(true);
+    }
+  };
+
+  onMount(() => {
+    window.addEventListener('message', onMessage);
+  });
+  onCleanup(() => {
+    window.removeEventListener('message', onMessage);
+    clearTimeout(revealTimeout);
+  });
+
+  return (
+    <div class="relative w-full max-w-[550px]">
+      <iframe
+        ref={iframeRef}
+        title="X post"
+        src={src()}
+        sandbox={IFRAME_SANDBOX}
+        referrerpolicy="strict-origin-when-cross-origin"
+        loading="lazy"
+        class={cn('w-full border-none', !loaded() && 'invisible')}
+        style={{ height: `${height() || 250}px` }}
+        onLoad={() => {
+          // Unavailable tweets never post a resize — reveal the frame anyway.
+          revealTimeout = setTimeout(() => setLoaded(true), 1500);
+        }}
+      />
+      <Show when={!loaded()}>
+        <EmbedLoading provider="x" />
+      </Show>
+    </div>
+  );
+}
+
+function YouTubeFrame(props: { url: string }) {
+  const [loaded, setLoaded] = createSignal(false);
+
+  const src = createMemo(() => {
+    const id = getYouTubeVideoId(props.url);
+    const start = getYouTubeStartSeconds(props.url);
+    return `https://www.youtube-nocookie.com/embed/${id}${
+      start ? `?start=${start}` : ''
+    }`;
+  });
+
+  return (
+    <div class="relative w-full max-w-[640px] aspect-video">
+      <iframe
+        title="YouTube video"
+        src={src()}
+        sandbox={IFRAME_SANDBOX}
+        referrerpolicy="strict-origin-when-cross-origin"
+        loading="lazy"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+        allowfullscreen
+        class={cn('size-full border-none', !loaded() && 'invisible')}
+        onLoad={() => setLoaded(true)}
+      />
+      <Show when={!loaded()}>
+        <EmbedLoading provider="youtube" />
+      </Show>
+    </div>
+  );
+}
+
+function FigmaFrame(props: { url: string }) {
+  const [loaded, setLoaded] = createSignal(false);
+
+  const src = createMemo(
+    () =>
+      `https://www.figma.com/embed?embed_host=macro&url=${encodeURIComponent(
+        props.url
+      )}`
+  );
+
+  return (
+    <div class="relative w-full max-w-[800px] h-112">
+      <iframe
+        title="Figma file"
+        src={src()}
+        sandbox={IFRAME_SANDBOX}
+        referrerpolicy="strict-origin-when-cross-origin"
+        loading="lazy"
+        allowfullscreen
+        class={cn('size-full border-none', !loaded() && 'invisible')}
+        onLoad={() => setLoaded(true)}
+      />
+      <Show when={!loaded()}>
+        <EmbedLoading provider="figma" />
+      </Show>
+    </div>
+  );
+}
+
+export function MarkdownEmbed(props: EmbedDecoratorProps) {
+  let containerRef!: HTMLDivElement;
+
+  const lexicalWrapper = useContext(LexicalWrapperContext);
+  const selection = () => lexicalWrapper?.selection;
+  const editor = () => lexicalWrapper?.editor;
+  const interactable = () => lexicalWrapper?.isInteractable() ?? false;
+
+  const [hovered, setHovered] = createSignal(false);
+
+  const isSelectedAsNode = () => {
+    const sel = selection();
+    if (!sel) return false;
+    return sel.type === 'node' && sel.nodeKeys.has(props.key);
+  };
+
+  const clickHandler = () => {
+    const currentEditor = editor();
+    if (currentEditor === undefined) return;
+    if (!currentEditor.isEditable()) return;
+    if (isSelectedAsNode()) return;
+    currentEditor.update(() => {
+      const sel = $createNodeSelection();
+      sel.add(props.key);
+      $setSelection(sel);
+    });
+  };
+
+  const deleteEmbed = () => {
+    const currentEditor = editor();
+    if (currentEditor === undefined) return;
+    removeNodeAndRestoreSelection(currentEditor, props.key, $isEmbedNode);
+  };
+
+  return (
+    <div
+      ref={containerRef}
+      class={cn(
+        'relative my-4 rounded-md',
+        isSelectedAsNode() && 'ring-3 ring-edge-muted'
+      )}
+      onClick={(e: MouseEvent) => {
+        e.preventDefault();
+        clickHandler();
+      }}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+    >
+      {match(props.provider)
+        .with('x', () => <TweetFrame url={props.url} />)
+        .with('youtube', () => <YouTubeFrame url={props.url} />)
+        .with('figma', () => <FigmaFrame url={props.url} />)
+        .otherwise(() => (
+          <a href={props.url} target="_blank" rel="noopener">
+            {props.url}
+          </a>
+        ))}
+      <Show when={isSelectedAsNode() || hovered()}>
+        <MediaButtons
+          delete={interactable() ? deleteEmbed : undefined}
+          newTab={() => {
+            window.open(props.url, '_blank');
+          }}
+          containerRef={containerRef}
+        />
+      </Show>
+    </div>
+  );
+}

--- a/js/app/packages/core/component/LexicalMarkdown/component/menu/PasteAsMenu.tsx
+++ b/js/app/packages/core/component/LexicalMarkdown/component/menu/PasteAsMenu.tsx
@@ -1,0 +1,229 @@
+import { ScopedPortal } from '@core/component/ScopedPortal';
+import clickOutside from '@core/directive/clickOutside';
+import { $createLinkNode } from '@lexical/link';
+import {
+  $createEmbedNode,
+  $isLinkMentionNode,
+  type EmbedProvider,
+} from '@lexical-core';
+import AtIcon from '@phosphor/at.svg';
+import FigmaIcon from '@phosphor/figma-logo.svg';
+import LinkIcon from '@phosphor/link.svg';
+import XLogoIcon from '@phosphor/x-logo.svg';
+import YouTubeIcon from '@phosphor/youtube-logo.svg';
+import { cn, Surface } from '@ui';
+import {
+  $createNodeSelection,
+  $createTextNode,
+  $getNodeByKey,
+  $setSelection,
+  type LexicalEditor,
+} from 'lexical';
+import {
+  type Accessor,
+  type Component,
+  createEffect,
+  createSignal,
+  For,
+  onCleanup,
+  Show,
+} from 'solid-js';
+import { Dynamic } from 'solid-js/web';
+import { floatWithElement } from '../../directive/floatWithElement';
+import type { EmbedPasteInfo } from '../../plugins/embed';
+import { useMenuKeyboardNavigation } from './useMenuKeyboardNavigation';
+
+false && clickOutside;
+false && floatWithElement;
+
+export type PasteAsMenuState = EmbedPasteInfo | null;
+
+type PasteAsMenuProps = {
+  editor: LexicalEditor;
+  state: Accessor<PasteAsMenuState>;
+  setState: (state: PasteAsMenuState) => void;
+};
+
+type PasteAsOption = {
+  id: 'mention' | 'url' | 'embed';
+  label: string;
+  icon: Component<{ class?: string }>;
+};
+
+const EMBED_OPTIONS: Record<
+  EmbedProvider,
+  { label: string; icon: Component<{ class?: string }> }
+> = {
+  x: { label: 'Embed post', icon: XLogoIcon },
+  youtube: { label: 'Embed video', icon: YouTubeIcon },
+  figma: { label: 'Embed design', icon: FigmaIcon },
+};
+
+/**
+ * "Paste as" menu shown after pasting an embeddable link. The link is pasted
+ * as a mention by default; this menu offers to switch it to a plain url or a
+ * full embed. Escape (or clicking/typing elsewhere) keeps the mention.
+ */
+export function PasteAsMenu(props: PasteAsMenuProps) {
+  const [selectedIndex, setSelectedIndex] = createSignal(0);
+
+  const options = (): PasteAsOption[] => {
+    const provider = props.state()?.provider;
+    const embed = provider ? EMBED_OPTIONS[provider] : undefined;
+    return [
+      { id: 'mention', label: 'Mention', icon: AtIcon },
+      { id: 'url', label: 'URL', icon: LinkIcon },
+      {
+        id: 'embed',
+        label: embed?.label ?? 'Embed',
+        icon: embed?.icon ?? LinkIcon,
+      },
+    ];
+  };
+
+  const close = () => {
+    props.setState(null);
+  };
+
+  createEffect(() => {
+    if (props.state()) setSelectedIndex(0);
+  });
+
+  // Close if the pasted mention disappears (e.g. undo).
+  createEffect(() => {
+    const state = props.state();
+    if (!state) return;
+    const cleanup = props.editor.registerUpdateListener(({ editorState }) => {
+      const exists = editorState.read(
+        () => $getNodeByKey(state.nodeKey) !== null
+      );
+      if (!exists) close();
+    });
+    onCleanup(cleanup);
+  });
+
+  const anchorElement = () => {
+    const state = props.state();
+    if (!state) return undefined;
+    return props.editor.getElementByKey(state.nodeKey) ?? undefined;
+  };
+
+  const apply = (id: PasteAsOption['id']) => {
+    const state = props.state();
+    if (!state) return;
+
+    if (id === 'url') {
+      props.editor.update(() => {
+        const node = $getNodeByKey(state.nodeKey);
+        if (!$isLinkMentionNode(node)) return;
+        const linkNode = $createLinkNode(state.url);
+        linkNode.append($createTextNode(state.url));
+        node.replace(linkNode);
+        linkNode.selectEnd();
+      });
+    }
+
+    if (id === 'embed') {
+      props.editor.update(() => {
+        const node = $getNodeByKey(state.nodeKey);
+        if (!$isLinkMentionNode(node)) return;
+        const embedNode = $createEmbedNode({
+          provider: state.provider,
+          url: state.url,
+        });
+        const block = node.getTopLevelElement();
+        const blockOnlyHoldsMention =
+          block?.getTextContent().trim() === node.getTextContent().trim();
+        if (block && blockOnlyHoldsMention) {
+          block.replace(embedNode);
+        } else {
+          node.remove();
+          block?.insertAfter(embedNode);
+        }
+        const selection = $createNodeSelection();
+        selection.add(embedNode.getKey());
+        $setSelection(selection);
+      });
+    }
+
+    close();
+  };
+
+  useMenuKeyboardNavigation({
+    isActive: () => props.state() !== null,
+    onUp: () => {
+      setSelectedIndex(
+        (selectedIndex() - 1 + options().length) % options().length
+      );
+    },
+    onDown: () => {
+      setSelectedIndex((selectedIndex() + 1) % options().length);
+    },
+    onSelect: () => {
+      apply(options()[selectedIndex()].id);
+    },
+    onClose: close,
+    onOtherKey: close,
+  });
+
+  return (
+    <Show when={props.state()}>
+      <ScopedPortal>
+        <div
+          class="cursor-default select-none w-44 z-modal-content menu-open-animation absolute"
+          use:floatWithElement={{
+            element: anchorElement,
+            spacing: 6,
+          }}
+          use:clickOutside={close}
+          on:touchstart={(e) => e.stopPropagation()}
+        >
+          <Surface
+            depth={2}
+            class="py-1.5 shadow-lg shadow-drop-shadow rounded-xl"
+          >
+            <div class="flex flex-col px-1.5 w-full">
+              <div class="px-1.5 py-1 text-xs text-ink-muted">Paste as</div>
+              <For each={options()}>
+                {(option, index) => (
+                  <div
+                    class={cn(
+                      'group flex items-center px-1.5 py-1 rounded-md',
+                      {
+                        'bg-ink/5': selectedIndex() === index(),
+                      }
+                    )}
+                    on:mouseover={() => setSelectedIndex(index())}
+                    on:mouseup={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                    }}
+                    on:mousedown={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                    }}
+                    on:click={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      apply(option.id);
+                    }}
+                  >
+                    <p class="flex flex-row gap-2 items-center w-full">
+                      <Dynamic
+                        component={option.icon}
+                        class="size-4 shrink-0 text-ink-muted"
+                      />
+                      <span class="text-ink text-sm grow overflow-hidden text-nowrap truncate">
+                        {option.label}
+                      </span>
+                    </p>
+                  </div>
+                )}
+              </For>
+            </div>
+          </Surface>
+        </div>
+      </ScopedPortal>
+    </Show>
+  );
+}

--- a/js/app/packages/core/component/LexicalMarkdown/init.ts
+++ b/js/app/packages/core/component/LexicalMarkdown/init.ts
@@ -11,6 +11,7 @@ import {
   HorizontalRuleNode,
   HtmlRenderNode,
   ImageNode,
+  LinkMentionNode,
   PasteNode as PasteNodeClass,
   PullRequestMentionNode,
   SnapshotNode,
@@ -31,6 +32,7 @@ import { Equation } from './component/decorator/Equation';
 import { GroupMention } from './component/decorator/GroupMention';
 import { HorizontalRule } from './component/decorator/HorizontalRule';
 import { HtmlRender } from './component/decorator/HtmlRender';
+import { LinkMention } from './component/decorator/LinkMention';
 import { MarkdownEmbed } from './component/decorator/MarkdownEmbed';
 import { MarkdownImage } from './component/decorator/MarkdownImage';
 import { MarkdownVideo } from './component/decorator/MarkdownVideo';
@@ -55,6 +57,7 @@ export function initializeLexical() {
   setDecorator(DocumentCardNode, DocumentCard);
   setDecorator(PasteNodeClass, PasteNode);
   setDecorator(PullRequestMentionNode, PullRequestMention);
+  setDecorator(LinkMentionNode, LinkMention);
   setDecorator(ContactMentionNode, ContactMention);
   setDecorator(DateMentionNode, DateMention);
   setDecorator(DiffInsertNode, DiffInsert);

--- a/js/app/packages/core/component/LexicalMarkdown/init.ts
+++ b/js/app/packages/core/component/LexicalMarkdown/init.ts
@@ -5,6 +5,7 @@ import {
   DiffInsertNode,
   DocumentCardNode,
   DocumentMentionNode,
+  EmbedNode,
   EquationNode,
   GroupMentionNode,
   HorizontalRuleNode,
@@ -30,6 +31,7 @@ import { Equation } from './component/decorator/Equation';
 import { GroupMention } from './component/decorator/GroupMention';
 import { HorizontalRule } from './component/decorator/HorizontalRule';
 import { HtmlRender } from './component/decorator/HtmlRender';
+import { MarkdownEmbed } from './component/decorator/MarkdownEmbed';
 import { MarkdownImage } from './component/decorator/MarkdownImage';
 import { MarkdownVideo } from './component/decorator/MarkdownVideo';
 import { PasteNode } from './component/decorator/PasteNode';
@@ -58,6 +60,7 @@ export function initializeLexical() {
   setDecorator(DiffInsertNode, DiffInsert);
   setDecorator(ImageNode, MarkdownImage);
   setDecorator(VideoNode, MarkdownVideo);
+  setDecorator(EmbedNode, MarkdownEmbed);
   setDecorator(EquationNode, Equation);
   setDecorator(SnapshotNode, Snapshot);
   setDecorator(HtmlRenderNode, HtmlRender);

--- a/js/app/packages/core/component/LexicalMarkdown/plugins/embed/embedPastePlugin.ts
+++ b/js/app/packages/core/component/LexicalMarkdown/plugins/embed/embedPastePlugin.ts
@@ -1,0 +1,116 @@
+import { $wrapNodeInElement, mergeRegister } from '@lexical/utils';
+import {
+  $createLinkMentionNode,
+  type EmbedProvider,
+  isLoneEmbedUrl,
+  LinkMentionNode,
+  parseEmbedUrl,
+} from '@lexical-core';
+import { $isChildOfCode } from '@lexical-core/utils';
+import {
+  $createParagraphNode,
+  $getSelection,
+  $insertNodes,
+  $isRangeSelection,
+  $isRootOrShadowRoot,
+  COMMAND_PRIORITY_HIGH,
+  type LexicalEditor,
+  type NodeKey,
+  PASTE_COMMAND,
+} from 'lexical';
+
+export type EmbedPasteInfo = {
+  nodeKey: NodeKey;
+  url: string;
+  provider: EmbedProvider;
+};
+
+type EmbedPastePluginProps = {
+  /** Called after a pasted embeddable url was inserted as a link mention. */
+  onPaste: (info: EmbedPasteInfo) => void;
+};
+
+/**
+ * Pasting a lone embeddable URL (X post, YouTube video, Figma file) inserts
+ * a link mention pill and notifies the caller so a "Paste as" menu can offer
+ * to keep the mention or switch to a plain link or an embed.
+ */
+function registerEmbedPastePlugin(
+  editor: LexicalEditor,
+  props: EmbedPastePluginProps
+) {
+  let shiftDown = false;
+  const onKeyDown = (event: KeyboardEvent) => {
+    if (event.key === 'Shift') {
+      shiftDown = true;
+    }
+  };
+  const onKeyUp = (event: KeyboardEvent) => {
+    if (event.key === 'Shift') {
+      shiftDown = false;
+    }
+  };
+  window.addEventListener('keydown', onKeyDown);
+  window.addEventListener('keyup', onKeyUp);
+
+  return mergeRegister(
+    editor.registerCommand(
+      PASTE_COMMAND,
+      (event: InputEvent | ClipboardEvent) => {
+        // Shift-paste keeps the raw text, matching the markdown paste plugin.
+        if (shiftDown) return false;
+        if (!editor.hasNodes([LinkMentionNode])) return false;
+        if (!(event instanceof ClipboardEvent)) return false;
+
+        const clipboard = event.clipboardData;
+        if (!clipboard) return false;
+        // Do not handle richer clipboards.
+        if (clipboard.getData('application/x-lexical-clipboard')) return false;
+        if (clipboard.getData('text/html')) return false;
+
+        const pastedText = clipboard.getData('text/plain');
+        if (!pastedText || !isLoneEmbedUrl(pastedText)) return false;
+        const embed = parseEmbedUrl(pastedText);
+        if (!embed) return false;
+
+        const selection = $getSelection();
+        // Pasting over selected text turns it into a link via the links
+        // plugin — only handle collapsed selections here.
+        if (!$isRangeSelection(selection) || !selection.isCollapsed()) {
+          return false;
+        }
+        if ($isChildOfCode(selection.anchor.getNode())) return false;
+
+        event.preventDefault();
+
+        const mentionNode = $createLinkMentionNode({ url: embed.url });
+        $insertNodes([mentionNode]);
+        if ($isRootOrShadowRoot(mentionNode.getParentOrThrow())) {
+          $wrapNodeInElement(mentionNode, $createParagraphNode);
+        }
+        mentionNode.selectEnd();
+
+        const nodeKey = mentionNode.getKey();
+        // Defer until after the update commits so the menu can anchor to the
+        // mention's DOM element.
+        queueMicrotask(() => {
+          props.onPaste({
+            nodeKey,
+            url: embed.url,
+            provider: embed.provider,
+          });
+        });
+        return true;
+      },
+      COMMAND_PRIORITY_HIGH
+    ),
+    () => {
+      window.removeEventListener('keydown', onKeyDown);
+      window.removeEventListener('keyup', onKeyUp);
+    }
+  );
+}
+
+export function embedPastePlugin(props: EmbedPastePluginProps) {
+  return (editor: LexicalEditor) => registerEmbedPastePlugin(editor, props);
+}

--- a/js/app/packages/core/component/LexicalMarkdown/plugins/embed/index.ts
+++ b/js/app/packages/core/component/LexicalMarkdown/plugins/embed/index.ts
@@ -1,0 +1,1 @@
+export * from './embedPastePlugin';

--- a/js/app/packages/core/component/LexicalMarkdown/plugins/index.ts
+++ b/js/app/packages/core/component/LexicalMarkdown/plugins/index.ts
@@ -11,6 +11,7 @@ export * from './document-metadata';
 export * from './drag-insert';
 export * from './draggable-block';
 export * from './element-event';
+export * from './embed';
 export * from './emojis';
 export * from './file-paste';
 export * from './find-and-replace';

--- a/js/app/packages/core/component/LexicalMarkdown/plugins/markdown-paste/markdownPastePlugin.ts
+++ b/js/app/packages/core/component/LexicalMarkdown/plugins/markdown-paste/markdownPastePlugin.ts
@@ -1,6 +1,10 @@
 import { mergeRegister } from '@lexical/utils';
+import { EmbedNode, isLoneEmbedUrl } from '@lexical-core';
 import {
+  $getSelection,
   $insertNodes,
+  $isParagraphNode,
+  $isRangeSelection,
   $parseSerializedNode,
   COMMAND_PRIORITY_LOW,
   createEditor,
@@ -48,6 +52,26 @@ function registerMarkdownPastePlugin(editor: LexicalEditor) {
           const pastedText = clipboard.getData('text/plain');
           if (!pastedText) {
             return false;
+          }
+
+          // A pasted lone embeddable URL becomes an embed block through the
+          // markdown parse below. Only allow that on an empty top-level
+          // paragraph — pasting into surrounding text keeps the URL inline.
+          if (editor.hasNodes([EmbedNode]) && isLoneEmbedUrl(pastedText)) {
+            const selection = $getSelection();
+            if ($isRangeSelection(selection)) {
+              const anchorBlock = selection.isCollapsed()
+                ? selection.anchor.getNode().getTopLevelElement()
+                : null;
+              const onEmptyParagraph =
+                $isParagraphNode(anchorBlock) &&
+                anchorBlock.getTextContent().trim() === '';
+              if (!onEmptyParagraph) {
+                event.preventDefault();
+                selection.insertText(pastedText.trim());
+                return true;
+              }
+            }
           }
 
           event.preventDefault();

--- a/js/app/packages/core/component/LexicalMarkdown/plugins/markdown-paste/markdownPastePlugin.ts
+++ b/js/app/packages/core/component/LexicalMarkdown/plugins/markdown-paste/markdownPastePlugin.ts
@@ -1,10 +1,6 @@
 import { mergeRegister } from '@lexical/utils';
-import { EmbedNode, isLoneEmbedUrl } from '@lexical-core';
 import {
-  $getSelection,
   $insertNodes,
-  $isParagraphNode,
-  $isRangeSelection,
   $parseSerializedNode,
   COMMAND_PRIORITY_LOW,
   createEditor,
@@ -52,26 +48,6 @@ function registerMarkdownPastePlugin(editor: LexicalEditor) {
           const pastedText = clipboard.getData('text/plain');
           if (!pastedText) {
             return false;
-          }
-
-          // A pasted lone embeddable URL becomes an embed block through the
-          // markdown parse below. Only allow that on an empty top-level
-          // paragraph — pasting into surrounding text keeps the URL inline.
-          if (editor.hasNodes([EmbedNode]) && isLoneEmbedUrl(pastedText)) {
-            const selection = $getSelection();
-            if ($isRangeSelection(selection)) {
-              const anchorBlock = selection.isCollapsed()
-                ? selection.anchor.getNode().getTopLevelElement()
-                : null;
-              const onEmptyParagraph =
-                $isParagraphNode(anchorBlock) &&
-                anchorBlock.getTextContent().trim() === '';
-              if (!onEmptyParagraph) {
-                event.preventDefault();
-                selection.insertText(pastedText.trim());
-                return true;
-              }
-            }
           }
 
           event.preventDefault();

--- a/js/app/packages/core/component/LexicalMarkdown/utils.ts
+++ b/js/app/packages/core/component/LexicalMarkdown/utils.ts
@@ -22,6 +22,7 @@ import {
 } from '@lexical/utils';
 import {
   $isDocumentMentionNode,
+  $isEmbedNode,
   $isMentionNode,
   $isWatermarkNode,
   ALL_TRANSFORMERS,
@@ -1226,6 +1227,13 @@ export function forceSingleLine(editor: LexicalEditor) {
       let firstChild: ElementNode | null = null;
 
       for (const child of rootChildren) {
+        // Embeds render as full iframes — show their URL in single-line mode.
+        if ($isEmbedNode(child)) {
+          firstChild = $createParagraphNode().append(
+            $createTextNode(child.getUrl())
+          );
+          break;
+        }
         if (!$isElementNode(child)) continue;
         const normalized = $singleLineNode(child);
         if (normalized) {

--- a/js/app/packages/core/component/LexicalMarkdown/version.ts
+++ b/js/app/packages/core/component/LexicalMarkdown/version.ts
@@ -12,5 +12,6 @@
  * Version 1.4 - Jun 2, 2026. Added persisted await placeholders for pending agent messages.
  * Version 2.0 - Jun 19, 2026. Added PullRequestMentionNode.
  * Version 2.1 - Jun 23, 2026. Added PasteNode
+ * Version 3.0 - Jul 2, 2026. Added EmbedNode (X/YouTube/Figma embeds).
  */
-export const MARKDOWN_VERSION_COUNTER = 2.1;
+export const MARKDOWN_VERSION_COUNTER = 3.0;

--- a/js/app/packages/core/component/LexicalMarkdown/version.ts
+++ b/js/app/packages/core/component/LexicalMarkdown/version.ts
@@ -12,6 +12,7 @@
  * Version 1.4 - Jun 2, 2026. Added persisted await placeholders for pending agent messages.
  * Version 2.0 - Jun 19, 2026. Added PullRequestMentionNode.
  * Version 2.1 - Jun 23, 2026. Added PasteNode
- * Version 3.0 - Jul 2, 2026. Added EmbedNode (X/YouTube/Figma embeds).
+ * Version 3.0 - Jul 2, 2026. Added EmbedNode (X/YouTube/Figma embeds) and
+ *     LinkMentionNode (mention pills for external links).
  */
 export const MARKDOWN_VERSION_COUNTER = 3.0;

--- a/js/app/packages/core/component/NotificationRenderer.tsx
+++ b/js/app/packages/core/component/NotificationRenderer.tsx
@@ -89,7 +89,7 @@ export function NotificationRenderer(props: NotificationRendererProps) {
 
             <Show when={content()}>
               <div class="text-xs text-ink-muted">
-                <StaticMarkdown markdown={content() || ''} />
+                <StaticMarkdown markdown={content() || ''} embedsAsLinks />
               </div>
             </Show>
 

--- a/js/app/packages/core/component/References.tsx
+++ b/js/app/packages/core/component/References.tsx
@@ -167,6 +167,7 @@ function ChannelReferenceRow(props: {
           <StaticMarkdown
             markdown={props.reference.message_content || ''}
             theme={twoLineClampMarkdownTheme}
+            embedsAsLinks
           />
         ) : undefined
       }

--- a/js/app/packages/entity/src/extractors-search/search-content.tsx
+++ b/js/app/packages/entity/src/extractors-search/search-content.tsx
@@ -36,7 +36,11 @@ export function SearchContent(props: SearchContentProps) {
           fallback={<span class="italic text-ink-disabled">No content</span>}
         >
           {(trimmedContent) => (
-            <StaticMarkdown markdown={trimmedContent()} theme={theme()} />
+            <StaticMarkdown
+              markdown={trimmedContent()}
+              theme={theme()}
+              embedsAsLinks
+            />
           )}
         </Show>
       )}

--- a/js/lexical-core/decoratorRegistry.ts
+++ b/js/lexical-core/decoratorRegistry.ts
@@ -20,6 +20,7 @@ import type {
   DocumentMentionDecoratorProps,
   DocumentMentionNode,
 } from './nodes/DocumentMentionNode';
+import type { EmbedDecoratorProps, EmbedNode } from './nodes/EmbedNode';
 import type {
   EquationDecoratorProps,
   EquationNode,
@@ -126,6 +127,10 @@ export interface NodeDecoratorMap {
   VideoNode: {
     klass: typeof VideoNode;
     props: VideoDecoratorProps;
+  };
+  EmbedNode: {
+    klass: typeof EmbedNode;
+    props: EmbedDecoratorProps;
   };
   HtmlRenderNode: {
     klass: typeof HtmlRenderNode;

--- a/js/lexical-core/decoratorRegistry.ts
+++ b/js/lexical-core/decoratorRegistry.ts
@@ -38,6 +38,10 @@ import type {
   HtmlRenderNode,
 } from './nodes/HtmlRenderNode';
 import type { ImageDecoratorProps, ImageNode } from './nodes/ImageNode';
+import type {
+  LinkMentionDecoratorProps,
+  LinkMentionNode,
+} from './nodes/LinkMentionNode';
 import type { PasteNode, PasteNodeDecoratorProps } from './nodes/PasteNode';
 import type {
   PullRequestMentionDecoratorProps,
@@ -111,6 +115,10 @@ export interface NodeDecoratorMap {
   PullRequestMentionNode: {
     klass: typeof PullRequestMentionNode;
     props: PullRequestMentionDecoratorProps;
+  };
+  LinkMentionNode: {
+    klass: typeof LinkMentionNode;
+    props: LinkMentionDecoratorProps;
   };
   EquationNode: {
     klass: typeof EquationNode;

--- a/js/lexical-core/index.ts
+++ b/js/lexical-core/index.ts
@@ -15,6 +15,7 @@ export * from './nodes/DiffInsertNode';
 export * from './nodes/DiffNode';
 export * from './nodes/DocumentCardNode';
 export * from './nodes/DocumentMentionNode';
+export * from './nodes/EmbedNode';
 export * from './nodes/EquationNode';
 export * from './nodes/GroupMentionNode';
 export * from './nodes/HorizontalRuleNode';
@@ -36,5 +37,6 @@ export * from './plugins/nodeIdPlugin';
 export * from './plugins/peerIdPlugin';
 
 export * from './transformers';
+export * from './utils/embed';
 export * from './utils/markdown-state';
 export * from './utils/mentions';

--- a/js/lexical-core/index.ts
+++ b/js/lexical-core/index.ts
@@ -22,6 +22,7 @@ export * from './nodes/HorizontalRuleNode';
 export * from './nodes/HtmlRenderNode';
 export * from './nodes/ImageNode';
 export * from './nodes/InlineSearchNode';
+export * from './nodes/LinkMentionNode';
 export * from './nodes/MediaNode';
 export * from './nodes/PasteNode';
 export * from './nodes/PullRequestMentionNode';

--- a/js/lexical-core/node-list.ts
+++ b/js/lexical-core/node-list.ts
@@ -25,6 +25,7 @@ import { DiffInsertNode } from './nodes/DiffInsertNode';
 import { DiffNode } from './nodes/DiffNode';
 import { DocumentCardNode } from './nodes/DocumentCardNode';
 import { DocumentMentionNode } from './nodes/DocumentMentionNode';
+import { EmbedNode } from './nodes/EmbedNode';
 import { EquationNode } from './nodes/EquationNode';
 import { GroupMentionNode } from './nodes/GroupMentionNode';
 import { HorizontalRuleNode } from './nodes/HorizontalRuleNode';
@@ -84,6 +85,7 @@ export const SupportedNodeTypes = [
   TabNode,
   ImageNode,
   VideoNode,
+  EmbedNode,
   TableNode,
   TableCellNode,
   TableRowNode,
@@ -126,6 +128,6 @@ export const RegisteredNodesByType: { [K in EditorType]: ValidNode[] } = {
   'plain-text': [ParagraphNode, TextNode],
   markdown: [...SupportedNodeTypes],
   'markdown-sync': [...SupportedNodeTypes],
-  chat: exclude([ImageNode, VideoNode]),
+  chat: exclude([ImageNode, VideoNode, EmbedNode]),
   title: [ParagraphNode, TextNode, InlineSearchNode],
 } as const;

--- a/js/lexical-core/node-list.ts
+++ b/js/lexical-core/node-list.ts
@@ -32,6 +32,7 @@ import { HorizontalRuleNode } from './nodes/HorizontalRuleNode';
 import { HtmlRenderNode } from './nodes/HtmlRenderNode';
 import { ImageNode } from './nodes/ImageNode';
 import { InlineSearchNode } from './nodes/InlineSearchNode';
+import { LinkMentionNode } from './nodes/LinkMentionNode';
 import { PasteNode } from './nodes/PasteNode';
 import { PullRequestMentionNode } from './nodes/PullRequestMentionNode';
 import { SearchMatchNode } from './nodes/SearchMatchNode';
@@ -78,6 +79,7 @@ export const SupportedNodeTypes = [
   ContactMentionNode,
   DateMentionNode,
   PullRequestMentionNode,
+  LinkMentionNode,
   GroupMentionNode,
   InlineSearchNode,
   UnlinkedTextNode,

--- a/js/lexical-core/nodes/EmbedNode.ts
+++ b/js/lexical-core/nodes/EmbedNode.ts
@@ -1,0 +1,149 @@
+import {
+  $applyNodeReplacement,
+  type DOMConversionMap,
+  type EditorConfig,
+  type EditorThemeClasses,
+  type LexicalEditor,
+  type LexicalNode,
+  type NodeKey,
+  type SerializedLexicalNode,
+  type Spread,
+} from 'lexical';
+import { type DecoratorComponent, getDecorator } from '../decoratorRegistry';
+import { $applyIdFromSerialized } from '../plugins/nodeIdPlugin';
+import {
+  type EmbedData,
+  type EmbedProvider,
+  parseEmbedUrl,
+} from '../utils/embed';
+import { DecoratorBlockNode } from './DecoratorBlockNode';
+
+export type SerializedEmbedNode = Spread<EmbedData, SerializedLexicalNode>;
+
+export type EmbedDecoratorProps = EmbedData & {
+  key: NodeKey;
+  theme: EditorThemeClasses;
+};
+
+export class EmbedNode extends DecoratorBlockNode<
+  DecoratorComponent<EmbedDecoratorProps> | undefined
+> {
+  __provider: EmbedProvider;
+  __url: string;
+
+  static getType() {
+    return 'embed';
+  }
+
+  isKeyboardSelectable(): boolean {
+    return true;
+  }
+
+  static clone(node: EmbedNode) {
+    return new EmbedNode(node.__provider, node.__url, node.__key);
+  }
+
+  constructor(provider: EmbedProvider, url: string, key?: NodeKey) {
+    super('left', key);
+    this.__provider = provider;
+    this.__url = url;
+  }
+
+  static importJSON(serializedNode: SerializedEmbedNode) {
+    const node = $createEmbedNode({
+      provider: serializedNode.provider,
+      url: serializedNode.url,
+    });
+    $applyIdFromSerialized(node, serializedNode);
+    return node;
+  }
+
+  exportJSON(): SerializedEmbedNode {
+    return {
+      ...super.exportJSON(),
+      provider: this.__provider,
+      url: this.__url,
+      type: EmbedNode.getType(),
+      version: 1,
+    };
+  }
+
+  exportComponentProps(): EmbedData {
+    return {
+      provider: this.__provider,
+      url: this.__url,
+    };
+  }
+
+  createDOM(_config: EditorConfig): HTMLElement {
+    const container = document.createElement('div');
+    container.style.display = 'block';
+    return container;
+  }
+
+  updateDOM(): boolean {
+    return false;
+  }
+
+  static importDOM(): DOMConversionMap<HTMLDivElement> | null {
+    return {
+      div: (domNode: HTMLDivElement) => {
+        const url = domNode.getAttribute('data-embed-url');
+        if (!url) return null;
+        const embed = parseEmbedUrl(url);
+        if (!embed) return null;
+        return {
+          conversion: () => ({ node: $createEmbedNode(embed) }),
+          priority: 1,
+        };
+      },
+    };
+  }
+
+  exportDOM() {
+    const element = document.createElement('div');
+    element.setAttribute('data-embed-provider', this.__provider);
+    element.setAttribute('data-embed-url', this.__url);
+    const anchor = document.createElement('a');
+    anchor.setAttribute('href', this.__url);
+    anchor.textContent = this.__url;
+    element.appendChild(anchor);
+    return { element };
+  }
+
+  getTextContent(): string {
+    return this.__url;
+  }
+
+  getProvider(): EmbedProvider {
+    return this.__provider;
+  }
+
+  getUrl(): string {
+    return this.__url;
+  }
+
+  decorate(_: LexicalEditor, config: EditorConfig) {
+    const decorator = getDecorator<EmbedDecoratorProps>(EmbedNode);
+    if (decorator) {
+      return () =>
+        decorator({
+          provider: this.__provider,
+          url: this.__url,
+          key: this.getKey(),
+          theme: config.theme,
+        });
+    }
+  }
+}
+
+export function $createEmbedNode(params: EmbedData): EmbedNode {
+  const node = new EmbedNode(params.provider, params.url);
+  return $applyNodeReplacement(node);
+}
+
+export function $isEmbedNode(
+  node: LexicalNode | null | undefined
+): node is EmbedNode {
+  return node instanceof EmbedNode;
+}

--- a/js/lexical-core/nodes/LinkMentionNode.ts
+++ b/js/lexical-core/nodes/LinkMentionNode.ts
@@ -1,0 +1,182 @@
+import {
+  $applyNodeReplacement,
+  DecoratorNode,
+  type DOMConversion,
+  type DOMConversionMap,
+  type EditorConfig,
+  type EditorThemeClasses,
+  type LexicalEditor,
+  type LexicalNode,
+  type NodeKey,
+  type SerializedLexicalNode,
+  type Spread,
+} from 'lexical';
+import { type DecoratorComponent, getDecorator } from '../decoratorRegistry';
+import { $applyIdFromSerialized } from '../plugins/nodeIdPlugin';
+
+const VERSION = 1;
+
+export type LinkMentionInfo = {
+  url: string;
+  title?: string;
+};
+
+export type SerializedLinkMentionNode = Spread<
+  LinkMentionInfo,
+  SerializedLexicalNode
+>;
+
+export type LinkMentionDecoratorProps = LinkMentionInfo & {
+  key: NodeKey;
+  theme: EditorThemeClasses;
+};
+
+/**
+ * An inline mention pill for an external link — shows the linked content's
+ * title (e.g. a video or file name) instead of the raw url.
+ */
+export class LinkMentionNode extends DecoratorNode<
+  DecoratorComponent<LinkMentionDecoratorProps> | undefined
+> {
+  __url: string;
+  __title: string | undefined;
+
+  static getType() {
+    return 'link-mention';
+  }
+
+  isInline(): boolean {
+    return true;
+  }
+
+  isKeyboardSelectable(): boolean {
+    return true;
+  }
+
+  static clone(node: LinkMentionNode) {
+    return new LinkMentionNode(node.__url, node.__title, node.__key);
+  }
+
+  constructor(url: string, title?: string, key?: NodeKey) {
+    super(key);
+    this.__url = url;
+    this.__title = title;
+  }
+
+  static importJSON(serializedNode: SerializedLinkMentionNode) {
+    const node = $createLinkMentionNode({
+      url: serializedNode.url,
+      title: serializedNode.title,
+    });
+    $applyIdFromSerialized(node, serializedNode);
+    return node;
+  }
+
+  exportJSON(): SerializedLinkMentionNode {
+    return {
+      ...super.exportJSON(),
+      url: this.__url,
+      title: this.__title,
+      type: LinkMentionNode.getType(),
+      version: VERSION,
+    };
+  }
+
+  exportComponentProps(): LinkMentionInfo {
+    return {
+      url: this.__url,
+      title: this.__title,
+    };
+  }
+
+  createDOM(_config: EditorConfig): HTMLElement {
+    const span = document.createElement('span');
+    span.setAttribute('data-link-mention', 'true');
+    return span;
+  }
+
+  updateDOM(_prevNode: LinkMentionNode, _dom: HTMLElement): boolean {
+    return false;
+  }
+
+  static importDOM(): DOMConversionMap<HTMLElement> | null {
+    const convert = (domNode: HTMLElement) => {
+      const url = domNode.getAttribute('data-link-mention-url');
+      const title =
+        domNode.getAttribute('data-link-mention-title') || undefined;
+
+      if (url) {
+        return { node: $createLinkMentionNode({ url, title }) };
+      }
+
+      return null;
+    };
+
+    const wrapInCheck = (conversion: DOMConversion) => {
+      return (node: HTMLElement) =>
+        node.hasAttribute('data-link-mention') ? conversion : null;
+    };
+
+    return {
+      span: wrapInCheck({ conversion: convert, priority: 1 }),
+      a: wrapInCheck({ conversion: convert, priority: 1 }),
+    };
+  }
+
+  exportDOM() {
+    const element = document.createElement('a');
+    element.setAttribute('data-link-mention', 'true');
+    element.setAttribute('data-link-mention-url', this.__url);
+    if (this.__title) {
+      element.setAttribute('data-link-mention-title', this.__title);
+    }
+    element.setAttribute('href', this.__url);
+    element.textContent = this.getTextContent();
+    return { element };
+  }
+
+  getTextContent(): string {
+    return this.__title || this.__url;
+  }
+
+  getSearchText(): string {
+    return this.getTextContent();
+  }
+
+  getUrl(): string {
+    return this.__url;
+  }
+
+  getTitle(): string | undefined {
+    return this.__title;
+  }
+
+  setTitle(title: string | undefined) {
+    const self = this.getWritable();
+    self.__title = title;
+  }
+
+  decorate(_: LexicalEditor, config: EditorConfig) {
+    const Component = getDecorator<LinkMentionDecoratorProps>(LinkMentionNode);
+
+    if (!Component) return undefined;
+
+    return () =>
+      Component({
+        ...this.exportComponentProps(),
+        key: this.getKey(),
+        theme: config.theme,
+      });
+  }
+}
+
+export function $createLinkMentionNode(params: LinkMentionInfo) {
+  const node = new LinkMentionNode(params.url, params.title);
+  return $applyNodeReplacement(node);
+}
+
+export function $isLinkMentionNode(
+  node: LinkMentionNode | LexicalNode | null | undefined
+): node is LinkMentionNode {
+  return node instanceof LinkMentionNode;
+}

--- a/js/lexical-core/tests/embed.test.ts
+++ b/js/lexical-core/tests/embed.test.ts
@@ -1,0 +1,255 @@
+import {
+  $convertFromMarkdownString,
+  $convertToMarkdownString,
+} from '@lexical/markdown';
+import { $getRoot, $isParagraphNode, createEditor } from 'lexical';
+import { describe, expect, it } from 'vitest';
+import { SupportedNodeTypes } from '../node-list';
+import { $createEmbedNode, $isEmbedNode } from '../nodes/EmbedNode';
+import { EXTERNAL_TRANSFORMERS, INTERNAL_TRANSFORMERS } from '../transformers';
+import {
+  getTweetId,
+  getYouTubeStartSeconds,
+  getYouTubeVideoId,
+  isLoneEmbedUrl,
+  parseEmbedUrl,
+} from '../utils/embed';
+
+function makeEditor() {
+  return createEditor({
+    nodes: SupportedNodeTypes,
+    onError: console.error,
+  });
+}
+
+async function importMarkdown(
+  markdown: string,
+  transformers = INTERNAL_TRANSFORMERS
+) {
+  const editor = makeEditor();
+  await new Promise<void>((resolve) => {
+    editor.update(
+      () => {
+        $convertFromMarkdownString(markdown, transformers);
+      },
+      { onUpdate: () => resolve() }
+    );
+  });
+  return editor;
+}
+
+describe('parseEmbedUrl', () => {
+  it('recognizes X/Twitter status urls', () => {
+    expect(
+      parseEmbedUrl('https://x.com/lulumeservey/status/1234567890123456789')
+    ).toEqual({
+      provider: 'x',
+      url: 'https://x.com/lulumeservey/status/1234567890123456789',
+    });
+    expect(
+      parseEmbedUrl('https://twitter.com/someuser/status/123456?s=20')?.provider
+    ).toBe('x');
+    expect(
+      parseEmbedUrl('https://mobile.twitter.com/someuser/status/123456')
+        ?.provider
+    ).toBe('x');
+    expect(getTweetId('https://x.com/a/status/987654321')).toBe('987654321');
+  });
+
+  it('recognizes YouTube urls', () => {
+    expect(
+      parseEmbedUrl('https://www.youtube.com/watch?v=dQw4w9WgXcQ')?.provider
+    ).toBe('youtube');
+    expect(parseEmbedUrl('https://youtu.be/dQw4w9WgXcQ')?.provider).toBe(
+      'youtube'
+    );
+    expect(
+      parseEmbedUrl('https://youtube.com/shorts/dQw4w9WgXcQ')?.provider
+    ).toBe('youtube');
+    expect(
+      getYouTubeVideoId('https://www.youtube.com/watch?list=abc&v=dQw4w9WgXcQ')
+    ).toBe('dQw4w9WgXcQ');
+    expect(getYouTubeVideoId('https://youtu.be/dQw4w9WgXcQ?t=90')).toBe(
+      'dQw4w9WgXcQ'
+    );
+  });
+
+  it('parses YouTube start times', () => {
+    expect(getYouTubeStartSeconds('https://youtu.be/dQw4w9WgXcQ?t=90')).toBe(
+      90
+    );
+    expect(
+      getYouTubeStartSeconds(
+        'https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=1h2m3s'
+      )
+    ).toBe(3723);
+    expect(
+      getYouTubeStartSeconds('https://www.youtube.com/watch?v=dQw4w9WgXcQ')
+    ).toBeNull();
+  });
+
+  it('recognizes Figma urls', () => {
+    expect(
+      parseEmbedUrl('https://www.figma.com/design/AbC123/My-File?node-id=1-2')
+        ?.provider
+    ).toBe('figma');
+    expect(
+      parseEmbedUrl('https://figma.com/file/AbC123/My-File')?.provider
+    ).toBe('figma');
+    expect(
+      parseEmbedUrl('https://www.figma.com/proto/AbC123/Prototype')?.provider
+    ).toBe('figma');
+    expect(
+      parseEmbedUrl('https://www.figma.com/board/AbC123/FigJam')?.provider
+    ).toBe('figma');
+  });
+
+  it('rejects non-embeddable urls', () => {
+    expect(parseEmbedUrl('https://example.com')).toBeNull();
+    expect(parseEmbedUrl('https://x.com/someuser')).toBeNull();
+    expect(parseEmbedUrl('https://www.youtube.com/@channel')).toBeNull();
+    expect(parseEmbedUrl('https://www.figma.com/community')).toBeNull();
+    expect(parseEmbedUrl('not a url')).toBeNull();
+  });
+
+  it('isLoneEmbedUrl requires a single embeddable url', () => {
+    expect(isLoneEmbedUrl(' https://youtu.be/dQw4w9WgXcQ ')).toBe(true);
+    expect(isLoneEmbedUrl('check https://youtu.be/dQw4w9WgXcQ')).toBe(false);
+    expect(isLoneEmbedUrl('https://example.com')).toBe(false);
+  });
+});
+
+describe('embed transformer import', () => {
+  it('imports a bare provider url line as an embed node', async () => {
+    for (const url of [
+      'https://x.com/someuser/status/1234567890',
+      'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+      'https://www.figma.com/design/AbC123/My-File',
+    ]) {
+      const editor = await importMarkdown(url);
+      editor.getEditorState().read(() => {
+        const node = $getRoot().getChildren().find($isEmbedNode);
+        expect(node).toBeDefined();
+        expect(node?.getUrl()).toBe(url);
+      });
+    }
+  });
+
+  it('imports an auto-linked lone provider url as an embed node', async () => {
+    const url = 'https://x.com/someuser/status/1234567890';
+    const markdown = `<m-link>${JSON.stringify({
+      url,
+      text: url,
+      title: '',
+    })}</m-link>`;
+    const editor = await importMarkdown(markdown);
+    editor.getEditorState().read(() => {
+      const node = $getRoot().getChildren().find($isEmbedNode);
+      expect(node).toBeDefined();
+      expect(node?.getProvider()).toBe('x');
+    });
+  });
+
+  it('imports a protocol-less auto-linked url as an embed node', async () => {
+    const markdown = `<m-link>${JSON.stringify({
+      url: 'https://youtu.be/dQw4w9WgXcQ',
+      text: 'youtu.be/dQw4w9WgXcQ',
+      title: '',
+    })}</m-link>`;
+    const editor = await importMarkdown(markdown);
+    editor.getEditorState().read(() => {
+      expect($getRoot().getChildren().find($isEmbedNode)).toBeDefined();
+    });
+  });
+
+  it('keeps titled links as links', async () => {
+    const markdown = `<m-link>${JSON.stringify({
+      url: 'https://youtu.be/dQw4w9WgXcQ',
+      text: 'watch this video',
+      title: '',
+    })}</m-link>`;
+    const editor = await importMarkdown(markdown);
+    editor.getEditorState().read(() => {
+      const root = $getRoot();
+      expect(root.getChildren().find($isEmbedNode)).toBeUndefined();
+      expect(root.getTextContent()).toContain('watch this video');
+    });
+  });
+
+  it('does not embed urls inside surrounding text', async () => {
+    const markdown = 'check out https://youtu.be/dQw4w9WgXcQ today';
+    const editor = await importMarkdown(markdown);
+    editor.getEditorState().read(() => {
+      const root = $getRoot();
+      expect(root.getChildren().find($isEmbedNode)).toBeUndefined();
+      expect(root.getTextContent()).toContain('check out');
+    });
+  });
+
+  it('keeps non-embeddable url lines intact', async () => {
+    const markdown = 'https://example.com/some/page';
+    const editor = await importMarkdown(markdown);
+    editor.getEditorState().read(() => {
+      const root = $getRoot();
+      expect(root.getChildren().find($isEmbedNode)).toBeUndefined();
+      expect(root.getTextContent()).toBe(markdown);
+    });
+  });
+
+  it('keeps non-embeddable m-link lines as links', async () => {
+    const url = 'https://example.com/some/page';
+    const markdown = `<m-link>${JSON.stringify({
+      url,
+      text: url,
+      title: '',
+    })}</m-link>`;
+    const editor = await importMarkdown(markdown);
+    editor.getEditorState().read(() => {
+      const root = $getRoot();
+      expect(root.getChildren().find($isEmbedNode)).toBeUndefined();
+      expect(root.getTextContent()).toBe(url);
+    });
+  });
+});
+
+describe('embed transformer export', () => {
+  it('exports embed nodes as their plain url and round-trips', async () => {
+    const url = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ';
+    const editor = makeEditor();
+    await new Promise<void>((resolve) => {
+      editor.update(
+        () => {
+          const root = $getRoot();
+          root.clear();
+          root.append($createEmbedNode({ provider: 'youtube', url }));
+        },
+        { onUpdate: () => resolve() }
+      );
+    });
+
+    let internal = '';
+    let external = '';
+    editor.getEditorState().read(() => {
+      internal = $convertToMarkdownString(INTERNAL_TRANSFORMERS);
+      external = $convertToMarkdownString(EXTERNAL_TRANSFORMERS);
+    });
+    expect(internal).toBe(url);
+    expect(external).toBe(url);
+
+    const reimported = await importMarkdown(internal);
+    reimported.getEditorState().read(() => {
+      const node = $getRoot().getChildren().find($isEmbedNode);
+      expect(node?.getUrl()).toBe(url);
+      expect(node?.getProvider()).toBe('youtube');
+    });
+  });
+
+  it('leaves regular paragraphs untouched', async () => {
+    const editor = await importMarkdown('just some text');
+    editor.getEditorState().read(() => {
+      const [child] = $getRoot().getChildren();
+      expect($isParagraphNode(child)).toBe(true);
+      expect(child.getTextContent()).toBe('just some text');
+    });
+  });
+});

--- a/js/lexical-core/tests/embed.test.ts
+++ b/js/lexical-core/tests/embed.test.ts
@@ -8,7 +8,9 @@ import { SupportedNodeTypes } from '../node-list';
 import { $createEmbedNode, $isEmbedNode } from '../nodes/EmbedNode';
 import { EXTERNAL_TRANSFORMERS, INTERNAL_TRANSFORMERS } from '../transformers';
 import {
+  findEmbedUrls,
   getTweetId,
+  getXHandle,
   getYouTubeStartSeconds,
   getYouTubeVideoId,
   isLoneEmbedUrl,
@@ -54,6 +56,9 @@ describe('parseEmbedUrl', () => {
         ?.provider
     ).toBe('x');
     expect(getTweetId('https://x.com/a/status/987654321')).toBe('987654321');
+    expect(getXHandle('https://x.com/lulumeservey/status/987654321')).toBe(
+      'lulumeservey'
+    );
   });
 
   it('recognizes YouTube urls', () => {
@@ -119,101 +124,45 @@ describe('parseEmbedUrl', () => {
   });
 });
 
-describe('embed transformer import', () => {
-  it('imports a bare provider url line as an embed node', async () => {
-    for (const url of [
-      'https://x.com/someuser/status/1234567890',
-      'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
-      'https://www.figma.com/design/AbC123/My-File',
-    ]) {
-      const editor = await importMarkdown(url);
-      editor.getEditorState().read(() => {
-        const node = $getRoot().getChildren().find($isEmbedNode);
-        expect(node).toBeDefined();
-        expect(node?.getUrl()).toBe(url);
-      });
-    }
+describe('findEmbedUrls', () => {
+  it('finds embeddable urls in plain text and link tags', () => {
+    const text = [
+      'check this out https://youtu.be/dQw4w9WgXcQ wow',
+      `<m-link>${JSON.stringify({
+        url: 'https://x.com/someuser/status/123456',
+        text: 'https://x.com/someuser/status/123456',
+        title: '',
+      })}</m-link>`,
+      'not embeddable: https://example.com/page',
+    ].join('\n');
+
+    expect(findEmbedUrls(text)).toEqual([
+      { provider: 'youtube', url: 'https://youtu.be/dQw4w9WgXcQ' },
+      { provider: 'x', url: 'https://x.com/someuser/status/123456' },
+    ]);
   });
 
-  it('imports an auto-linked lone provider url as an embed node', async () => {
-    const url = 'https://x.com/someuser/status/1234567890';
-    const markdown = `<m-link>${JSON.stringify({
-      url,
-      text: url,
-      title: '',
-    })}</m-link>`;
-    const editor = await importMarkdown(markdown);
-    editor.getEditorState().read(() => {
-      const node = $getRoot().getChildren().find($isEmbedNode);
-      expect(node).toBeDefined();
-      expect(node?.getProvider()).toBe('x');
-    });
+  it('dedupes repeated urls and respects the limit', () => {
+    const url = 'https://youtu.be/dQw4w9WgXcQ';
+    expect(findEmbedUrls(`${url}\n${url}`)).toHaveLength(1);
+
+    const many = [
+      'https://youtu.be/dQw4w9WgXc1',
+      'https://youtu.be/dQw4w9WgXc2',
+      'https://youtu.be/dQw4w9WgXc3',
+    ].join('\n');
+    expect(findEmbedUrls(many, 2)).toHaveLength(2);
   });
 
-  it('imports a protocol-less auto-linked url as an embed node', async () => {
-    const markdown = `<m-link>${JSON.stringify({
-      url: 'https://youtu.be/dQw4w9WgXcQ',
-      text: 'youtu.be/dQw4w9WgXcQ',
-      title: '',
-    })}</m-link>`;
-    const editor = await importMarkdown(markdown);
-    editor.getEditorState().read(() => {
-      expect($getRoot().getChildren().find($isEmbedNode)).toBeDefined();
-    });
-  });
-
-  it('keeps titled links as links', async () => {
-    const markdown = `<m-link>${JSON.stringify({
-      url: 'https://youtu.be/dQw4w9WgXcQ',
-      text: 'watch this video',
-      title: '',
-    })}</m-link>`;
-    const editor = await importMarkdown(markdown);
-    editor.getEditorState().read(() => {
-      const root = $getRoot();
-      expect(root.getChildren().find($isEmbedNode)).toBeUndefined();
-      expect(root.getTextContent()).toContain('watch this video');
-    });
-  });
-
-  it('does not embed urls inside surrounding text', async () => {
-    const markdown = 'check out https://youtu.be/dQw4w9WgXcQ today';
-    const editor = await importMarkdown(markdown);
-    editor.getEditorState().read(() => {
-      const root = $getRoot();
-      expect(root.getChildren().find($isEmbedNode)).toBeUndefined();
-      expect(root.getTextContent()).toContain('check out');
-    });
-  });
-
-  it('keeps non-embeddable url lines intact', async () => {
-    const markdown = 'https://example.com/some/page';
-    const editor = await importMarkdown(markdown);
-    editor.getEditorState().read(() => {
-      const root = $getRoot();
-      expect(root.getChildren().find($isEmbedNode)).toBeUndefined();
-      expect(root.getTextContent()).toBe(markdown);
-    });
-  });
-
-  it('keeps non-embeddable m-link lines as links', async () => {
-    const url = 'https://example.com/some/page';
-    const markdown = `<m-link>${JSON.stringify({
-      url,
-      text: url,
-      title: '',
-    })}</m-link>`;
-    const editor = await importMarkdown(markdown);
-    editor.getEditorState().read(() => {
-      const root = $getRoot();
-      expect(root.getChildren().find($isEmbedNode)).toBeUndefined();
-      expect(root.getTextContent()).toBe(url);
-    });
+  it('ignores trailing punctuation', () => {
+    expect(findEmbedUrls('see https://youtu.be/dQw4w9WgXcQ.')).toEqual([
+      { provider: 'youtube', url: 'https://youtu.be/dQw4w9WgXcQ' },
+    ]);
   });
 });
 
-describe('embed transformer export', () => {
-  it('exports embed nodes as their plain url and round-trips', async () => {
+describe('embed transformer', () => {
+  it('round-trips embed nodes through internal markdown', async () => {
     const url = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ';
     const editor = makeEditor();
     await new Promise<void>((resolve) => {
@@ -233,7 +182,9 @@ describe('embed transformer export', () => {
       internal = $convertToMarkdownString(INTERNAL_TRANSFORMERS);
       external = $convertToMarkdownString(EXTERNAL_TRANSFORMERS);
     });
-    expect(internal).toBe(url);
+    expect(internal).toContain('<m-embed>');
+    expect(internal).toContain(url);
+    // External markdown degrades to the plain url.
     expect(external).toBe(url);
 
     const reimported = await importMarkdown(internal);
@@ -241,6 +192,44 @@ describe('embed transformer export', () => {
       const node = $getRoot().getChildren().find($isEmbedNode);
       expect(node?.getUrl()).toBe(url);
       expect(node?.getProvider()).toBe('youtube');
+    });
+  });
+
+  it('derives the provider from the url on import', async () => {
+    const url = 'https://x.com/someuser/status/123456';
+    const markdown = `<m-embed>${JSON.stringify({
+      provider: 'youtube',
+      url,
+    })}</m-embed>`;
+    const editor = await importMarkdown(markdown);
+    editor.getEditorState().read(() => {
+      const node = $getRoot().getChildren().find($isEmbedNode);
+      expect(node?.getProvider()).toBe('x');
+    });
+  });
+
+  it('does not auto-convert bare url lines', async () => {
+    const markdown = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ';
+    const editor = await importMarkdown(markdown);
+    editor.getEditorState().read(() => {
+      const root = $getRoot();
+      expect(root.getChildren().find($isEmbedNode)).toBeUndefined();
+      expect(root.getTextContent()).toBe(markdown);
+    });
+  });
+
+  it('does not auto-convert lone link tags', async () => {
+    const url = 'https://youtu.be/dQw4w9WgXcQ';
+    const markdown = `<m-link>${JSON.stringify({
+      url,
+      text: url,
+      title: '',
+    })}</m-link>`;
+    const editor = await importMarkdown(markdown);
+    editor.getEditorState().read(() => {
+      const root = $getRoot();
+      expect(root.getChildren().find($isEmbedNode)).toBeUndefined();
+      expect(root.getTextContent()).toBe(url);
     });
   });
 

--- a/js/lexical-core/tests/linkMention.test.ts
+++ b/js/lexical-core/tests/linkMention.test.ts
@@ -1,0 +1,112 @@
+import {
+  $convertFromMarkdownString,
+  $convertToMarkdownString,
+} from '@lexical/markdown';
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  $isElementNode,
+  createEditor,
+  type LexicalNode,
+} from 'lexical';
+import { describe, expect, it } from 'vitest';
+import { SupportedNodeTypes } from '../node-list';
+import {
+  $createLinkMentionNode,
+  $isLinkMentionNode,
+  type LinkMentionInfo,
+  type LinkMentionNode,
+} from '../nodes/LinkMentionNode';
+import { EXTERNAL_TRANSFORMERS, INTERNAL_TRANSFORMERS } from '../transformers';
+
+function makeEditor() {
+  return createEditor({
+    nodes: SupportedNodeTypes,
+    onError: console.error,
+  });
+}
+
+async function editorWithMention(info: LinkMentionInfo) {
+  const editor = makeEditor();
+  await new Promise<void>((resolve) => {
+    editor.update(
+      () => {
+        const root = $getRoot();
+        root.clear();
+        const paragraph = $createParagraphNode();
+        paragraph.append(
+          $createTextNode('before '),
+          $createLinkMentionNode(info),
+          $createTextNode(' after')
+        );
+        root.append(paragraph);
+      },
+      { onUpdate: () => resolve() }
+    );
+  });
+  return editor;
+}
+
+function $findMention(): LinkMentionNode | undefined {
+  const inline: LexicalNode[] = [];
+  for (const child of $getRoot().getChildren()) {
+    if ($isElementNode(child)) inline.push(...child.getChildren());
+  }
+  return inline.find($isLinkMentionNode);
+}
+
+describe('LinkMentionNode transformers', () => {
+  it('round-trips through internal markdown', async () => {
+    const url = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ';
+    const title = 'Never Gonna Give You Up';
+    const editor = await editorWithMention({ url, title });
+
+    let internal = '';
+    editor.getEditorState().read(() => {
+      internal = $convertToMarkdownString(INTERNAL_TRANSFORMERS);
+    });
+    expect(internal).toContain('<m-link-mention>');
+    expect(internal).toContain(url);
+
+    const reimported = makeEditor();
+    await new Promise<void>((resolve) => {
+      reimported.update(
+        () => {
+          $convertFromMarkdownString(internal, INTERNAL_TRANSFORMERS);
+        },
+        { onUpdate: () => resolve() }
+      );
+    });
+    reimported.getEditorState().read(() => {
+      const mention = $findMention();
+      expect(mention).toBeDefined();
+      expect(mention?.getUrl()).toBe(url);
+      expect(mention?.getTitle()).toBe(title);
+      expect($getRoot().getTextContent()).toContain('before');
+      expect($getRoot().getTextContent()).toContain('after');
+    });
+  });
+
+  it('exports to external markdown as a titled link', async () => {
+    const url = 'https://www.figma.com/design/AbC123/My-File';
+    const editor = await editorWithMention({ url, title: 'My File' });
+
+    let external = '';
+    editor.getEditorState().read(() => {
+      external = $convertToMarkdownString(EXTERNAL_TRANSFORMERS);
+    });
+    expect(external).toBe(`before [My File](${url}) after`);
+  });
+
+  it('exports untitled mentions as the bare url', async () => {
+    const url = 'https://x.com/someuser/status/123456';
+    const editor = await editorWithMention({ url });
+
+    let external = '';
+    editor.getEditorState().read(() => {
+      external = $convertToMarkdownString(EXTERNAL_TRANSFORMERS);
+    });
+    expect(external).toBe(`before ${url} after`);
+  });
+});

--- a/js/lexical-core/transformers/embed.ts
+++ b/js/lexical-core/transformers/embed.ts
@@ -1,0 +1,80 @@
+import type { ElementTransformer } from '@lexical/markdown';
+import { $isTextNode, type ElementNode, type LexicalNode } from 'lexical';
+import { $createEmbedNode, $isEmbedNode, EmbedNode } from '../nodes/EmbedNode';
+import { parseEmbedUrl } from '../utils/embed';
+
+const M_LINK_LINE_REGEX = /^<m-link>(\{.*\})<\/m-link>\s*$/;
+const BARE_URL_LINE_REGEX = /^(https?:\/\/\S+)\s*$/;
+
+/** Strip protocol and www so pasted links compare equal to their display text. */
+function normalizeUrlForComparison(url: string): string {
+  return url
+    .trim()
+    .replace(/^https?:\/\//i, '')
+    .replace(/^www\./i, '');
+}
+
+/**
+ * Extract the URL from a line that consists solely of a link — either a bare
+ * URL or a single <m-link> whose text is the URL itself (a pasted link, not a
+ * deliberately titled one).
+ */
+function extractLoneUrl(line: string): string | null {
+  const mLink = line.match(M_LINK_LINE_REGEX);
+  if (mLink) {
+    try {
+      const data = JSON.parse(mLink[1]);
+      if (typeof data.url !== 'string' || !data.url) return null;
+      const text = typeof data.text === 'string' ? data.text.trim() : '';
+      if (
+        text &&
+        normalizeUrlForComparison(text) !== normalizeUrlForComparison(data.url)
+      ) {
+        return null;
+      }
+      return data.url;
+    } catch {
+      return null;
+    }
+  }
+  return line.match(BARE_URL_LINE_REGEX)?.[1] ?? null;
+}
+
+/**
+ * Embed transformer. Exports embed nodes as their plain URL so the markdown
+ * degrades to a link everywhere else, and imports lines that consist solely
+ * of an embeddable URL (bare or auto-linked) as embed nodes.
+ */
+export const I_EMBED: ElementTransformer = {
+  dependencies: [EmbedNode],
+  type: 'element',
+  regExp: /^(?:<m-link>\{.*\}<\/m-link>|https?:\/\/\S+)\s*$/,
+  export: (node: LexicalNode) => {
+    if (!$isEmbedNode(node)) return null;
+    return node.getUrl();
+  },
+  replace: (
+    parentNode: ElementNode,
+    children: Array<LexicalNode>,
+    match: Array<string>,
+    isImport: boolean
+  ) => {
+    if (!isImport) return false;
+    const restoreAndBail = () => {
+      // The importer slices the match off the text node before calling
+      // replace, so put the line back for the remaining transformers.
+      const textNode = children?.[0];
+      if (textNode && $isTextNode(textNode)) {
+        textNode.setTextContent(match[0]);
+      }
+      return false;
+    };
+
+    const url = extractLoneUrl(match[0]);
+    if (!url) return restoreAndBail();
+    const embed = parseEmbedUrl(url);
+    if (!embed) return restoreAndBail();
+
+    parentNode.replace($createEmbedNode(embed));
+  },
+};

--- a/js/lexical-core/transformers/embed.ts
+++ b/js/lexical-core/transformers/embed.ts
@@ -1,80 +1,61 @@
 import type { ElementTransformer } from '@lexical/markdown';
-import { $isTextNode, type ElementNode, type LexicalNode } from 'lexical';
+import type { ElementNode, LexicalNode } from 'lexical';
 import { $createEmbedNode, $isEmbedNode, EmbedNode } from '../nodes/EmbedNode';
 import { parseEmbedUrl } from '../utils/embed';
+import { wrapXml, xmlMatcher } from './transformers';
 
-const M_LINK_LINE_REGEX = /^<m-link>(\{.*\})<\/m-link>\s*$/;
-const BARE_URL_LINE_REGEX = /^(https?:\/\/\S+)\s*$/;
-
-/** Strip protocol and www so pasted links compare equal to their display text. */
-function normalizeUrlForComparison(url: string): string {
-  return url
-    .trim()
-    .replace(/^https?:\/\//i, '')
-    .replace(/^www\./i, '');
-}
-
-/**
- * Extract the URL from a line that consists solely of a link — either a bare
- * URL or a single <m-link> whose text is the URL itself (a pasted link, not a
- * deliberately titled one).
- */
-function extractLoneUrl(line: string): string | null {
-  const mLink = line.match(M_LINK_LINE_REGEX);
-  if (mLink) {
-    try {
-      const data = JSON.parse(mLink[1]);
-      if (typeof data.url !== 'string' || !data.url) return null;
-      const text = typeof data.text === 'string' ? data.text.trim() : '';
-      if (
-        text &&
-        normalizeUrlForComparison(text) !== normalizeUrlForComparison(data.url)
-      ) {
-        return null;
-      }
-      return data.url;
-    } catch {
-      return null;
-    }
-  }
-  return line.match(BARE_URL_LINE_REGEX)?.[1] ?? null;
-}
-
-/**
- * Embed transformer. Exports embed nodes as their plain URL so the markdown
- * degrades to a link everywhere else, and imports lines that consist solely
- * of an embeddable URL (bare or auto-linked) as embed nodes.
- */
+// Internal transformer — always uses <m-embed> for unambiguous round-tripping.
 export const I_EMBED: ElementTransformer = {
   dependencies: [EmbedNode],
   type: 'element',
-  regExp: /^(?:<m-link>\{.*\}<\/m-link>|https?:\/\/\S+)\s*$/,
+  regExp: xmlMatcher('m-embed'),
   export: (node: LexicalNode) => {
     if (!$isEmbedNode(node)) return null;
-    return node.getUrl();
+    if (!node.getUrl()) return null;
+    return wrapXml('m-embed', {
+      provider: node.getProvider(),
+      url: node.getUrl(),
+    });
   },
   replace: (
     parentNode: ElementNode,
-    children: Array<LexicalNode>,
+    _children: Array<LexicalNode>,
     match: Array<string>,
-    isImport: boolean
+    _isImport: boolean
   ) => {
-    if (!isImport) return false;
-    const restoreAndBail = () => {
-      // The importer slices the match off the text node before calling
-      // replace, so put the line back for the remaining transformers.
-      const textNode = children?.[0];
-      if (textNode && $isTextNode(textNode)) {
-        textNode.setTextContent(match[0]);
+    try {
+      const data = JSON.parse(match[1]);
+      if (typeof data.url !== 'string' || !data.url) {
+        throw new Error('Missing or invalid url field');
       }
-      return false;
-    };
+      // Derive the provider from the url so a bad payload can't pick a
+      // renderer that doesn't match its content.
+      const embed = parseEmbedUrl(data.url);
+      if (!embed) {
+        throw new Error('Url is not embeddable');
+      }
+      parentNode.replace($createEmbedNode(embed));
+    } catch (e) {
+      console.error('Failed to parse m-embed:', e);
+    }
+  },
+};
 
-    const url = extractLoneUrl(match[0]);
-    if (!url) return restoreAndBail();
-    const embed = parseEmbedUrl(url);
-    if (!embed) return restoreAndBail();
-
-    parentNode.replace($createEmbedNode(embed));
+// External export — embeds degrade to their plain url.
+export const E_EMBED: ElementTransformer = {
+  dependencies: [EmbedNode],
+  type: 'element',
+  regExp: /$^/,
+  export: (node: LexicalNode) => {
+    if (!$isEmbedNode(node)) return null;
+    return node.getUrl() || null;
+  },
+  replace: (
+    _parentNode: ElementNode,
+    _children: Array<LexicalNode>,
+    _match: Array<string>,
+    _isImport: boolean
+  ) => {
+    return false;
   },
 };

--- a/js/lexical-core/transformers/index.ts
+++ b/js/lexical-core/transformers/index.ts
@@ -2,6 +2,7 @@ import type { Transformer } from '@lexical/markdown';
 import { I_AWAIT_NODE } from './await';
 import { HTML_BLOCKQUOTE, I_MACRO_QUOTE } from './classedBlock';
 import { CUSTOM_TRANSFORMERS } from './customTransformers';
+import { I_EMBED } from './embed';
 import { I_IMAGE_CONSTRAINED, IMAGE } from './image';
 import {
   E_BLOCK_EQUATION_NODE,
@@ -58,6 +59,7 @@ export const INTERNAL_TRANSFORMERS: Transformer[] = [
   MARK_XML,
   SEARCH_MATCH,
   HR,
+  I_EMBED,
   I_VIDEO,
   I_IMAGE_CONSTRAINED,
   IMAGE, // Standard markdown images (fallback)
@@ -85,6 +87,7 @@ export const INTERNAL_TRANSFORMERS: Transformer[] = [
 export const EXTERNAL_TRANSFORMERS: Transformer[] = [
   HR,
   MARK_XML,
+  I_EMBED,
   I_VIDEO,
   IMAGE,
   BR_TAG_TO_LINE_BREAK,
@@ -124,6 +127,7 @@ export const ALL_TRANSFORMERS: Transformer[] = [
   MARK_XML,
   SEARCH_MATCH,
   HR,
+  I_EMBED,
   I_VIDEO,
   I_IMAGE_CONSTRAINED,
   IMAGE,

--- a/js/lexical-core/transformers/index.ts
+++ b/js/lexical-core/transformers/index.ts
@@ -2,7 +2,7 @@ import type { Transformer } from '@lexical/markdown';
 import { I_AWAIT_NODE } from './await';
 import { HTML_BLOCKQUOTE, I_MACRO_QUOTE } from './classedBlock';
 import { CUSTOM_TRANSFORMERS } from './customTransformers';
-import { I_EMBED } from './embed';
+import { E_EMBED, I_EMBED } from './embed';
 import { I_IMAGE_CONSTRAINED, IMAGE } from './image';
 import {
   E_BLOCK_EQUATION_NODE,
@@ -10,6 +10,7 @@ import {
   E_MULTILINE_BLOCK_EQUATION_NODE,
   I_EQUATION_NODE,
 } from './katex';
+import { E_LINK_MENTION, I_LINK_MENTION } from './linkMention';
 import {
   E_CONTACT_MENTION,
   E_DATE_MENTION,
@@ -68,6 +69,7 @@ export const INTERNAL_TRANSFORMERS: Transformer[] = [
   I_DOCUMENT_MENTION,
   I_DOCUMENT_CARD,
   I_PR_MENTION,
+  I_LINK_MENTION,
   I_CONTACT_MENTION,
   I_DATE_MENTION,
   I_AWAIT_NODE,
@@ -87,7 +89,7 @@ export const INTERNAL_TRANSFORMERS: Transformer[] = [
 export const EXTERNAL_TRANSFORMERS: Transformer[] = [
   HR,
   MARK_XML,
-  I_EMBED,
+  E_EMBED,
   I_VIDEO,
   IMAGE,
   BR_TAG_TO_LINE_BREAK,
@@ -102,6 +104,7 @@ export const EXTERNAL_TRANSFORMERS: Transformer[] = [
   E_DOCUMENT_CARD,
   I_PR_MENTION,
   E_PR_MENTION,
+  E_LINK_MENTION,
   E_CONTACT_MENTION,
   E_DATE_MENTION,
   // order matters
@@ -128,6 +131,7 @@ export const ALL_TRANSFORMERS: Transformer[] = [
   SEARCH_MATCH,
   HR,
   I_EMBED,
+  E_EMBED,
   I_VIDEO,
   I_IMAGE_CONSTRAINED,
   IMAGE,
@@ -146,6 +150,8 @@ export const ALL_TRANSFORMERS: Transformer[] = [
   E_DOCUMENT_CARD,
   I_PR_MENTION,
   E_PR_MENTION,
+  I_LINK_MENTION,
+  E_LINK_MENTION,
   I_CONTACT_MENTION,
   E_CONTACT_MENTION,
   I_DATE_MENTION,

--- a/js/lexical-core/transformers/linkMention.ts
+++ b/js/lexical-core/transformers/linkMention.ts
@@ -1,0 +1,56 @@
+import type { TextMatchTransformer } from '@lexical/markdown';
+import type { TextNode } from 'lexical';
+import {
+  $createLinkMentionNode,
+  LinkMentionNode,
+} from '../nodes/LinkMentionNode';
+import { wrapXml, xmlMatcher } from './transformers';
+
+// Internal Link Mentions
+export const I_LINK_MENTION: TextMatchTransformer = {
+  dependencies: [LinkMentionNode],
+  type: 'text-match',
+  regExp: xmlMatcher('m-link-mention'),
+  importRegExp: xmlMatcher('m-link-mention'),
+  export: (node) => {
+    if (!(node instanceof LinkMentionNode)) return null;
+    return wrapXml('m-link-mention', {
+      url: node.getUrl(),
+      title: node.getTitle() || '',
+    });
+  },
+  replace: (node: TextNode, match: RegExpMatchArray) => {
+    try {
+      const data = JSON.parse(match[1]);
+      if (typeof data.url !== 'string' || !data.url) {
+        throw new Error('Missing or invalid url field');
+      }
+      const linkMentionNode = $createLinkMentionNode({
+        url: data.url,
+        title:
+          typeof data.title === 'string' && data.title ? data.title : undefined,
+      });
+      node.replace(linkMentionNode);
+    } catch (e) {
+      console.error('Error in I_LINK_MENTION replace:', e);
+    }
+  },
+};
+
+// External Link Mentions — degrade to a regular markdown link. Export-only:
+// inline decorator nodes are exported through text-match transformers.
+export const E_LINK_MENTION: TextMatchTransformer = {
+  dependencies: [LinkMentionNode],
+  type: 'text-match',
+  regExp: /$^/,
+  export: (node) => {
+    if (!(node instanceof LinkMentionNode)) return null;
+
+    const url = node.getUrl();
+    if (!url) return null;
+
+    const title = node.getTitle();
+    if (!title) return url;
+    return `[${title.replace(/([[\]])/g, '\\$1')}](${url})`;
+  },
+};

--- a/js/lexical-core/utils/embed.ts
+++ b/js/lexical-core/utils/embed.ts
@@ -1,0 +1,75 @@
+/**
+ * URL parsing for embeddable third-party content (X/Twitter posts, YouTube
+ * videos, Figma files). Shared by the embed markdown transformer, the paste
+ * handling, and the embed render components.
+ */
+
+export type EmbedProvider = 'x' | 'youtube' | 'figma';
+
+export type EmbedData = {
+  provider: EmbedProvider;
+  url: string;
+};
+
+const X_STATUS_REGEX =
+  /^https?:\/\/(?:www\.|mobile\.)?(?:twitter\.com|x\.com)\/(?:#!\/)?\w{1,15}\/status(?:es)?\/(\d+)/i;
+
+const YOUTUBE_WATCH_REGEX =
+  /^https?:\/\/(?:www\.|m\.)?youtube\.com\/watch\?(?:[^#\s]*&)?v=([\w-]{11})/i;
+const YOUTUBE_SHORT_URL_REGEX = /^https?:\/\/(?:www\.)?youtu\.be\/([\w-]{11})/i;
+const YOUTUBE_PATH_REGEX =
+  /^https?:\/\/(?:www\.|m\.)?youtube\.com\/(?:shorts|live|embed)\/([\w-]{11})/i;
+
+const FIGMA_FILE_REGEX =
+  /^https?:\/\/(?:www\.)?figma\.com\/(?:file|design|proto|board|slides|deck)\/[\w-]+/i;
+
+export function getTweetId(url: string): string | null {
+  return url.match(X_STATUS_REGEX)?.[1] ?? null;
+}
+
+export function getYouTubeVideoId(url: string): string | null {
+  return (
+    url.match(YOUTUBE_WATCH_REGEX)?.[1] ??
+    url.match(YOUTUBE_SHORT_URL_REGEX)?.[1] ??
+    url.match(YOUTUBE_PATH_REGEX)?.[1] ??
+    null
+  );
+}
+
+/** Parse a YouTube `t`/`start` parameter ("90", "90s", "1h2m30s") to seconds. */
+export function getYouTubeStartSeconds(url: string): number | null {
+  const raw = url.match(/[?&](?:t|start)=([\dhms]+)/i)?.[1];
+  if (!raw) return null;
+  if (/^\d+$/.test(raw)) return parseInt(raw, 10);
+  const match = raw.match(/^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/i);
+  if (!match || (!match[1] && !match[2] && !match[3])) return null;
+  const [, hours, minutes, seconds] = match;
+  return (
+    (hours ? parseInt(hours, 10) * 3600 : 0) +
+    (minutes ? parseInt(minutes, 10) * 60 : 0) +
+    (seconds ? parseInt(seconds, 10) : 0)
+  );
+}
+
+function isFigmaFileUrl(url: string): boolean {
+  return FIGMA_FILE_REGEX.test(url);
+}
+
+/**
+ * Check whether a URL points to embeddable third-party content.
+ * Returns the provider and the original URL, or null when not embeddable.
+ */
+export function parseEmbedUrl(url: string): EmbedData | null {
+  const trimmed = url.trim();
+  if (getTweetId(trimmed)) return { provider: 'x', url: trimmed };
+  if (getYouTubeVideoId(trimmed)) return { provider: 'youtube', url: trimmed };
+  if (isFigmaFileUrl(trimmed)) return { provider: 'figma', url: trimmed };
+  return null;
+}
+
+/** True when the text is a single line containing only an embeddable URL. */
+export function isLoneEmbedUrl(text: string): boolean {
+  const trimmed = text.trim();
+  if (!trimmed || /\s/.test(trimmed)) return false;
+  return parseEmbedUrl(trimmed) !== null;
+}

--- a/js/lexical-core/utils/embed.ts
+++ b/js/lexical-core/utils/embed.ts
@@ -73,3 +73,32 @@ export function isLoneEmbedUrl(text: string): boolean {
   if (!trimmed || /\s/.test(trimmed)) return false;
   return parseEmbedUrl(trimmed) !== null;
 }
+
+/** The @handle from an X/Twitter status URL, e.g. "lulumeservey". */
+export function getXHandle(url: string): string | null {
+  return (
+    url.match(
+      /^https?:\/\/(?:www\.|mobile\.)?(?:twitter\.com|x\.com)\/(?:#!\/)?(\w{1,15})\/status/i
+    )?.[1] ?? null
+  );
+}
+
+const URL_SCAN_REGEX = /https?:\/\/[^\s"'<>)\]]+/g;
+
+/**
+ * Find embeddable URLs anywhere in a text (markdown, link tags, plain text),
+ * deduped and in order of appearance.
+ */
+export function findEmbedUrls(text: string, limit = Infinity): EmbedData[] {
+  const results: EmbedData[] = [];
+  const seen = new Set<string>();
+  for (const match of text.matchAll(URL_SCAN_REGEX)) {
+    const candidate = match[0].replace(/[.,;:!?]+$/, '');
+    const embed = parseEmbedUrl(candidate);
+    if (!embed || seen.has(embed.url)) continue;
+    seen.add(embed.url);
+    results.push(embed);
+    if (results.length >= limit) break;
+  }
+  return results;
+}

--- a/js/lexical-core/utils/index.ts
+++ b/js/lexical-core/utils/index.ts
@@ -3,6 +3,7 @@ import { $findMatchingParent } from '@lexical/utils';
 import type { LexicalNode } from 'lexical';
 
 export * from './document';
+export * from './embed';
 export * from './languageSupport';
 export * from './media';
 export * from './mentions';


### PR DESCRIPTION
## Summary
Adds support for X/Twitter posts, YouTube videos, and Figma files in documents and channel messages, with a Notion-style paste flow.

**Documents (markdown block):**
- Pasting an embeddable link inserts an **@mention pill** by default — a new inline `LinkMentionNode` showing the content's title (video name, file name, `@handle on X`) with a provider icon and a hover preview card. Titles resolve through the unfurl service and are persisted on the node.
- A **"Paste as" menu** opens anchored to the pill with three options — **Mention / URL / Embed** (provider-specific label + icon). Arrow keys navigate, Enter applies, Escape/clicking away/typing keeps the mention.
- Choosing **URL** swaps the pill for a plain link; choosing **Embed** replaces the line with a full embed block (X post iframe with theme matching + height auto-resize, YouTube player with start-time support, Figma viewer).

**Channel messages:**
- Links stay links in the composer and in the sent message body; the **embed renders below the message content after send** (`Message.Embeds`, capped at 3 per message). Works for old messages and agent replies too, since extraction happens at render time.

## Key Changes

### lexical-core
- `nodes/LinkMentionNode.ts`: inline mention pill node (`url` + persisted `title`); serializes to `<m-link-mention>` internally, degrades to `[title](url)` in external markdown
- `nodes/EmbedNode.ts`: decorator block node for embeds; round-trips as explicit `<m-embed>` tags internally, degrades to the plain URL externally — bare URL lines are **not** auto-converted anywhere
- `utils/embed.ts`: provider URL parsing (tweet ID, video ID + start time, Figma files) and `findEmbedUrls` for scanning message markdown
- `transformers/{embed,linkMention}.ts` + registration in node lists / transformer sets

### App
- `component/decorator/LinkMention.tsx`: pill UI — provider icon, unfurl-resolved title with write-back, hover unfurl card, Enter-to-open when node-selected
- `component/menu/PasteAsMenu.tsx`: floating "Paste as" menu (keyboard navigation via `useMenuKeyboardNavigation`, `floatWithElement` anchoring, click-outside/typing dismissal)
- `plugins/embed/embedPastePlugin.ts`: intercepts lone-embeddable-URL pastes in the document editor, inserts the mention pill, and opens the menu; skips code blocks, expanded selections, and shift-paste
- `component/decorator/MarkdownEmbed.tsx`: provider iframes (X embed with postMessage height resize + dark/light theme, `youtube-nocookie` player, Figma embed) with select/delete/open affordances; exports a reusable `EmbedFrame`
- `StaticMarkdown`: renders both new nodes; `embedsAsLinks` option keeps compact contexts (search results, notifications, references) iframe-free
- Markdown version counter bumped to 3.0 for the two new node types

### Channel
- `Message/Embeds.tsx` rendered in the message footer before attachments; the inline link is untouched

### Testing
- `js/lexical-core/tests/embed.test.ts` + `linkMention.test.ts`: URL parsing, `findEmbedUrls` extraction/dedupe/limits, `<m-embed>` and `<m-link-mention>` round-trips, external markdown degradation, and no-auto-conversion guarantees (85 tests passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SMDJvYd73NGR2dMQXJrdjU