### PR TITLE
fix(channels): prevent removal of channel owners from participants

### DIFF
--- a/js/app/packages/channel/Participants/ChannelParticipantsTab.tsx
+++ b/js/app/packages/channel/Participants/ChannelParticipantsTab.tsx
@@ -56,6 +56,9 @@ export function ChannelParticipantsTab(props: { channelId: string }) {
   const removeParticipant = (participantId: string) => {
     if (!isEditable()) return;
 
+    const participant = participants().find((p) => p.user_id === participantId);
+    if (participant?.role === 'owner') return;
+
     removeParticipantsMutation.mutate({
       channelId: props.channelId,
       participants: [participantId],

--- a/js/app/packages/channel/Participants/ParticipantsListItem.tsx
+++ b/js/app/packages/channel/Participants/ParticipantsListItem.tsx
@@ -15,7 +15,9 @@ export function ParticipantsListItem(props: {
   onRemove: () => void;
 }) {
   const canRemove =
-    props.editable && props.currentUserId !== props.participant.user_id;
+    props.editable &&
+    props.currentUserId !== props.participant.user_id &&
+    props.participant.role !== 'owner';
 
   const navigationHandlers = useSplitNavigationHandler<HTMLButtonElement>(
     async (event) => {

--- a/rust/cloud-storage/channels/src/domain/service.rs
+++ b/rust/cloud-storage/channels/src/domain/service.rs
@@ -987,6 +987,19 @@ where
                 "cannot add or remove participants from direct message channel".to_string(),
             ));
         }
+        let active_participants = self
+            .repo
+            .get_participants(channel_id)
+            .await
+            .map_err(|e| ChannelMutationErr::Repo(e.into()))?;
+        let targets_owner = active_participants
+            .iter()
+            .any(|p| p.role == ParticipantRole::Owner && req.participants.contains(&p.user_id));
+        if targets_owner {
+            return Err(ChannelMutationErr::Unauthorized(
+                "cannot remove the channel owner".to_string(),
+            ));
+        }
         for participant in req.participants {
             self.repo
                 .remove_participant(channel_id, participant)

--- a/rust/cloud-storage/channels/src/domain/service/test.rs
+++ b/rust/cloud-storage/channels/src/domain/service/test.rs
@@ -289,6 +289,7 @@ struct FakeMutationRepoState {
     attachments: Vec<MutatedAttachment>,
     patched_content: Option<String>,
     activity_upserts: usize,
+    removed_participants: Vec<String>,
 }
 
 impl FakeMutationRepo {
@@ -333,6 +334,7 @@ impl FakeMutationRepo {
                 attachments: vec![],
                 patched_content: None,
                 activity_upserts: 0,
+                removed_participants: vec![],
             })),
         }
     }
@@ -535,8 +537,13 @@ impl ChannelRepo for FakeMutationRepo {
     async fn remove_participant(
         &self,
         _channel_id: Uuid,
-        _user_id: String,
+        user_id: String,
     ) -> Result<(), Self::Err> {
+        self.state
+            .lock()
+            .unwrap()
+            .removed_participants
+            .push(user_id);
         Ok(())
     }
 
@@ -1529,4 +1536,58 @@ async fn thread_replies_resolve_and_hydrate() {
     assert_eq!(replies[1].id, reply_2.id);
     assert_eq!(replies[1].reactions.len(), 0);
     assert_eq!(replies[1].attachments.len(), 1);
+}
+
+#[tokio::test]
+async fn remove_participants_rejects_removing_channel_owner() {
+    let channel_id = Uuid::new_v4();
+    let repo = FakeMutationRepo::new(channel_id, "macro|sender@test.com");
+    let svc = mutation_service(
+        repo.clone(),
+        FakeEvents::default(),
+        FakeReferenceSharing::default(),
+    );
+
+    let err = svc
+        .remove_participants(
+            sender("macro|recipient@test.com"),
+            channel_id,
+            RemoveParticipantsRequest {
+                participants: vec![
+                    "macro|sender@test.com".to_string(),
+                    "macro|recipient@test.com".to_string(),
+                ],
+            },
+        )
+        .await
+        .unwrap_err();
+
+    assert!(matches!(err, ChannelMutationErr::Unauthorized(_)));
+    assert!(repo.state.lock().unwrap().removed_participants.is_empty());
+}
+
+#[tokio::test]
+async fn remove_participants_allows_removing_non_owner() {
+    let channel_id = Uuid::new_v4();
+    let repo = FakeMutationRepo::new(channel_id, "macro|sender@test.com");
+    let svc = mutation_service(
+        repo.clone(),
+        FakeEvents::default(),
+        FakeReferenceSharing::default(),
+    );
+
+    svc.remove_participants(
+        sender("macro|sender@test.com"),
+        channel_id,
+        RemoveParticipantsRequest {
+            participants: vec!["macro|recipient@test.com".to_string()],
+        },
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        repo.state.lock().unwrap().removed_participants,
+        vec!["macro|recipient@test.com".to_string()]
+    );
 }


### PR DESCRIPTION
## Summary
This PR adds validation to prevent channel owners from being removed as participants. The change is implemented across both the backend service layer and frontend UI to ensure consistent behavior.

## Key Changes

**Backend (Rust)**
- Added `removed_participants` tracking to `FakeMutationRepoState` for testing
- Implemented validation in `remove_participants` service method to check if any target participants have the Owner role
- Returns `Unauthorized` error if attempting to remove a channel owner
- Updated `FakeMutationRepo::remove_participant` to track removed participants for test assertions

**Frontend (TypeScript/React)**
- Modified `ParticipantsListItem` to disable the remove button for owner-role participants
- Added defensive check in `ChannelParticipantsTab.removeParticipant` to prevent API calls for owner participants
- Updated `canRemove` logic to consider participant role in addition to editability and user ID checks

**Tests**
- Added `remove_participants_rejects_removing_channel_owner` test to verify authorization error when attempting to remove an owner
- Added `remove_participants_allows_removing_non_owner` test to verify successful removal of non-owner participants
- Tests verify that no participants are removed when the request targets an owner

## Implementation Details
The validation occurs at the service layer before any repository operations, ensuring the business rule is enforced at the API boundary. The frontend provides immediate UX feedback by disabling the remove action for owners, with an additional safety check before making the API request.

https://claude.ai/code/session_018EhAZbScxEDhd8AbXMc4Mm