### PR TITLE
fix: collapse Similar Tasks pills to icons so task names stay readable

### DIFF
--- a/js/app/packages/block-md/component/TaskDuplicateList.tsx
+++ b/js/app/packages/block-md/component/TaskDuplicateList.tsx
@@ -5,7 +5,7 @@ import {
   ENABLE_TASK_DUPLICATES_FLAG,
   ENABLE_TASK_DUPLICATES_OVERRIDE,
 } from '@core/constant/featureFlags';
-import { isTaskClosed, isTaskEntity, ListLayoutProvider } from '@entity';
+import { ListLayoutProvider } from '@entity';
 import CaretRightIcon from '@phosphor/caret-right.svg';
 import CopyIcon from '@phosphor/copy.svg';
 import { useSoupItemsQuery } from '@queries/soup/items';
@@ -66,13 +66,11 @@ function SimilarTasksInner(props: {
     () => ({ enabled: ids().length > 0, staleTime: 30 * 1000 })
   );
 
-  // Keep the similarity ranking order. Completed/canceled tasks are not
-  // useful duplicate candidates, so drop them.
+  // Keep the similarity ranking order.
   const entities = () => {
     const order = new Map(ids().map((id, index) => [id, index] as const));
     return [...(soup.data ?? [])]
       .filter((entity) => order.has(entity.id))
-      .filter((entity) => !(isTaskEntity(entity) && isTaskClosed(entity)))
       .sort((a, b) => (order.get(a.id) ?? 0) - (order.get(b.id) ?? 0));
   };
 

--- a/js/app/packages/block-md/component/TaskDuplicateList.tsx
+++ b/js/app/packages/block-md/component/TaskDuplicateList.tsx
@@ -5,7 +5,7 @@ import {
   ENABLE_TASK_DUPLICATES_FLAG,
   ENABLE_TASK_DUPLICATES_OVERRIDE,
 } from '@core/constant/featureFlags';
-import { ListLayoutProvider } from '@entity';
+import { isTaskClosed, isTaskEntity, ListLayoutProvider } from '@entity';
 import CaretRightIcon from '@phosphor/caret-right.svg';
 import CopyIcon from '@phosphor/copy.svg';
 import { useSoupItemsQuery } from '@queries/soup/items';
@@ -66,11 +66,13 @@ function SimilarTasksInner(props: {
     () => ({ enabled: ids().length > 0, staleTime: 30 * 1000 })
   );
 
-  // Keep the similarity ranking order.
+  // Keep the similarity ranking order. Completed/canceled tasks are not
+  // useful duplicate candidates, so drop them.
   const entities = () => {
     const order = new Map(ids().map((id, index) => [id, index] as const));
     return [...(soup.data ?? [])]
       .filter((entity) => order.has(entity.id))
+      .filter((entity) => !(isTaskEntity(entity) && isTaskClosed(entity)))
       .sort((a, b) => (order.get(a.id) ?? 0) - (order.get(b.id) ?? 0));
   };
 
@@ -93,9 +95,12 @@ function SimilarTasksInner(props: {
         </button>
         <Show when={expanded()}>
           <ListLayoutProvider ref={listRef}>
+            {/* Named `u-list` container so the task rows pick up the narrow
+                (<=840px) container queries and collapse status/priority/
+                assignee pills to icons, leaving the width for task names. */}
             <div
               ref={setListRef}
-              class="flex max-h-48 flex-col overflow-y-auto scrollbar-hidden"
+              class="@container/u-list flex max-h-48 flex-col overflow-y-auto scrollbar-hidden"
             >
               <For each={entities()}>
                 {(entity) => (

--- a/js/app/packages/entity/src/index.ts
+++ b/js/app/packages/entity/src/index.ts
@@ -43,6 +43,7 @@ export {
   getPropertyOptionLabel,
   getTaskAssigneeIds,
   getTaskStatusOptionId,
+  isTaskClosed,
 } from './utils/task-properties';
 export {
   formatDateAndTime,

--- a/js/app/packages/entity/src/index.ts
+++ b/js/app/packages/entity/src/index.ts
@@ -43,7 +43,6 @@ export {
   getPropertyOptionLabel,
   getTaskAssigneeIds,
   getTaskStatusOptionId,
-  isTaskClosed,
 } from './utils/task-properties';
 export {
   formatDateAndTime,


### PR DESCRIPTION
## Summary
In the task composer's Similar Tasks section, the status/priority/assignee pills rendered at full width, truncating task names down to a few characters. Task names are the most important part of a duplicate candidate, so the pills now collapse to icon-only in constrained widths.

## Key Changes
- **Declare the `u-list` container**: Applied `@container/u-list` to the Similar Tasks list wrapper in `TaskDuplicateList.tsx`. The task rows already ship container queries that collapse status/priority pills to icons and assignees to a lone avatar below 840px — they just never matched here because the named container only existed in the main soup view.

## Implementation Details
No new styling was written — this reuses the exact compact layout the main task list uses on narrow screens. The collapse is responsive: if the composer is expanded past 840px, the pill labels return since there's room for both.

Filtering of completed/canceled tasks is handled on the backend in #4470, so no client-side filter is needed (an earlier revision of this PR added one; it has been removed).

https://claude.ai/code/session_01PqctUpnHsoe3QBWPPtnjzP