### PR TITLE
fix(files): add Folder option to Files view create dropdown

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/soup-view-create-button.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-view-create-button.tsx
@@ -21,7 +21,7 @@ import { NewCallButton } from './NewCallButton';
 const VIEW_CREATE_BLOCKNAMES: Partial<
   Record<ListView, (BlockName | BlockAlias)[]>
 > = {
-  documents: ['md', 'snippet', 'canvas', 'code'],
+  documents: ['md', 'snippet', 'canvas', 'code', 'project'],
   tasks: ['task'],
   agents: ['chat', 'automation'],
   mail: ['email'],


### PR DESCRIPTION
## What

Adds a **Folder** entry to the Files view's create dropdown by including `'project'` in the `documents` allowlist in `VIEW_CREATE_BLOCKNAMES` (`soup-view-create-button.tsx`).

## Why

Reported by Evan in #bug-reports (2026-07-02): *"no option to create a folder in `Files` create dropdown."*

Folder creation already exists everywhere else — the global launcher (`CREATABLE_BLOCKS` has a Folder entry), the in-folder `ProjectCreateMenu`, and the Files empty state all offer it — so this was just an omission from this one view's allowlist. The option reuses the existing `runCreateAction('project')` plumbing and `EntityIcon` lookup; no new code paths.

## Prioritization

Picked up by the review-incoming-work routine as a quick win: clear user report, one-line fix, no open PR or in-progress task covering it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B7mdd1E3cLDeqdgnS992Z8

---
_Generated by [Claude Code](https://claude.ai/code/session_01B7mdd1E3cLDeqdgnS992Z8)_