### PR TITLE
fix(ios): show channel name instead of participant in CallKit incoming call UI

### DIFF
--- a/js/app/tauri/callkit_plugin/ios/Sources/IncomingCallCoordinator.swift
+++ b/js/app/tauri/callkit_plugin/ios/Sources/IncomingCallCoordinator.swift
@@ -320,7 +320,10 @@ final class IncomingCallCoordinator: NSObject, CXProviderDelegate, PKPushRegistr
 
         let update = CXCallUpdate()
         update.remoteHandle = CXHandle(type: .generic, value: channelName ?? channelId)
-        update.localizedCallerName = callerName
+        // CallKit renders localizedCallerName as the headline of the incoming
+        // call UI; show the channel so a group call isn't mistaken for a
+        // personal call from whoever started it.
+        update.localizedCallerName = channelName ?? callerName
         update.hasVideo = true
 
         // Must happen from the PushKit delegate; otherwise iOS can terminate us.


### PR DESCRIPTION
## What

In the VoIP push handler (`IncomingCallCoordinator.swift`), set `CXCallUpdate.localizedCallerName` to the **channel name** (falling back to the caller name when the payload has no channel name), instead of always the participant who started the call.

## Why

Reported by Jacob in #bug-reports (2026-07-02): *"On iOS call sheet, says 'Teo Nys' instead of call with Macro. I accidentally joined huddle bc i thought teo was personally calling me."* Peter filed the task "ios callkit should show channel name, not participant" for this.

`localizedCallerName` is the headline CallKit renders on the incoming-call sheet. `remoteHandle` was already set to the channel name; this brings the visible label in line with it. The `channelName` field is already threaded through the push payload, so no plumbing changes — a one-line behavioral fix plus a comment.

## Notes

- DM channels: the payload's `channelName` for a DM is the counterpart's name, so 1:1 calls should still show the person. Worth a quick sanity check on-device by someone with an iOS build (I can't run the iOS app in this environment).

## Prioritization

Picked up by the review-incoming-work routine as a quick win: task filed but not started, misleading UX that caused an accidental call join, single-line fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B7mdd1E3cLDeqdgnS992Z8

---
_Generated by [Claude Code](https://claude.ai/code/session_01B7mdd1E3cLDeqdgnS992Z8)_