### PR TITLE
fix(channels): keep last participant visible above mobile safe area

### DIFF
--- a/js/app/packages/channel/Participants/ParticipantsList.tsx
+++ b/js/app/packages/channel/Participants/ParticipantsList.tsx
@@ -33,7 +33,7 @@ export function ParticipantsList(props: {
       <div ref={setListWrapperRef} class="relative h-full min-h-0">
         <VList
           data={props.participants()}
-          class="h-full scrollbar-hidden"
+          class="h-full scrollbar-hidden pb-(--safe-bottom)"
           style={{
             height: '100%',
             width: '100%',


### PR DESCRIPTION
## What

Adds `pb-(--safe-bottom)` to the participants list scroll container (`ParticipantsList.tsx`) so the last member scrolls clear of the home-indicator safe area on mobile.

## Why

Reported by Wolf in #bug-reports (2026-07-03): *"cannot see bottom member in participants list"* (screenshot in thread). Peter filed the task "channel participants needs content inset bump."

The list is a virtualized `VList` filling the panel with no bottom inset, so on devices with a bottom safe area the final row sits under the home indicator. This follows the existing `MobileDrawerContent` pattern (`pb-(--safe-bottom)`, defined in `app/index.css`); the variable resolves to `0px` on desktop, so there's no change outside mobile/Tauri.

## Prioritization

Picked up by the review-incoming-work routine as a quick win: fresh user report with a filed-but-unstarted task, CSS-only change using an established pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B7mdd1E3cLDeqdgnS992Z8

---
_Generated by [Claude Code](https://claude.ai/code/session_01B7mdd1E3cLDeqdgnS992Z8)_