### PR TITLE
fix(mobile): call controls no longer hidden under nav bar

### DIFF
--- a/js/app/packages/channel/Call/CallOverlay.tsx
+++ b/js/app/packages/channel/Call/CallOverlay.tsx
@@ -262,7 +262,7 @@ export function CallOverlay(props: { onLeave: () => void }) {
   };
 
   return (
-    <div class="flex flex-col h-full">
+    <div class="flex flex-col h-full mobile:pb-(--mobile-content-inset-bottom)">
       {/* Screen share area */}
       <Show when={hasAnyScreenShare()}>
         <div class="flex-1 min-h-0 pt-2">


### PR DESCRIPTION
## Bug

On mobile web, the in-call controls bar (mute/camera/screen-share/leave) rendered underneath the bottom navigation bar, making it hard or impossible to use during a call.

Team task #2072 / report: "call controls showed under the nav bar on mobile (web version)"

## Root cause

On mobile, the bottom dock/nav bar is rendered by `FloatRegionHost`, which is positioned `absolute` (not part of normal document flow) and overlays on top of the main content area. Other full-bleed mobile surfaces (e.g. `ActiveCallMessage`, `Settings`, `soup-view`) account for this by reserving bottom clearance with the `--mobile-content-inset-bottom` CSS variable (published by `FloatRegionHost` to reflect the dock's actual height).

`CallOverlay` (the in-call UI shown in the channel's Call tab, including `CallControls`) did not reserve this space, so its controls row — which sits at the very bottom of the flex column — ended up positioned underneath the nav bar overlay on mobile.

## Fix

Add the same `mobile:pb-(--mobile-content-inset-bottom)` pattern already used elsewhere in the mobile UI (e.g. `MobileDrawer`'s `pb-(--safe-bottom)` handling, `ActiveCallMessage.tsx`) to `CallOverlay`'s root container, reserving room at the bottom for the floating nav bar so the controls render above it instead of underneath.

This is a scoped, low-risk CSS-only change — no structural changes to the call UI or nav bar.

## Confidence

High confidence in the diagnosis: the codebase has a well-established, consistent pattern (`--mobile-content-inset-bottom`) specifically for this class of "content covered by the floating mobile dock" issue, and `CallOverlay` was the one call-adjacent full-bleed surface missing it. I was not able to attach a repro screenshot/video for this session, so please verify visually on a mobile viewport if possible.

## Testing

- `bunx biome lint` on the changed file: clean.
- `bun run type-check`: pre-existing `TS2688` errors for missing `@types` packages (`facebook-pixel`, `gtag.js`, `vite-plugin-solid-svg`, `vite/client`, `wicg-file-system-access`) are present on `main` as well (verified by stashing this change and re-running) — unrelated to this change, no new errors introduced.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AAWCTjRJfF9DRMwwMyUSFQ)_