### PR TITLE
fix(settings): wire up "Show tooltips" toggle

### DIFF
--- a/js/app/packages/ui/components/Tooltip.tsx
+++ b/js/app/packages/ui/components/Tooltip.tsx
@@ -5,8 +5,8 @@ import { Surface } from '@ui';
 import type { ParentProps } from 'solid-js';
 import { createEffect, createSignal, For, on, onCleanup, Show } from 'solid-js';
 import { Hotkey } from '../../ui/components/Hotkey';
-import { cn } from '../utils/classname';
 import { tooltipsEnabled } from '../signals/signals';
+import { cn } from '../utils/classname';
 
 type TooltipProps = ParentProps<{
   hotkey?: HotkeyToken | HotkeyToken[];

--- a/js/app/packages/ui/components/Tooltip.tsx
+++ b/js/app/packages/ui/components/Tooltip.tsx
@@ -6,6 +6,7 @@ import type { ParentProps } from 'solid-js';
 import { createEffect, createSignal, For, on, onCleanup, Show } from 'solid-js';
 import { Hotkey } from '../../ui/components/Hotkey';
 import { cn } from '../utils/classname';
+import { tooltipsEnabled } from '../signals/signals';
 
 type TooltipProps = ParentProps<{
   hotkey?: HotkeyToken | HotkeyToken[];
@@ -102,7 +103,7 @@ export function Tooltip(props: TooltipProps) {
       closeDelay={0}
       flip={true}
       gutter={4}
-      disabled={props.disabled}
+      disabled={props.disabled || !tooltipsEnabled()}
     >
       <KobalteTooltip.Trigger
         ref={(ref) => {


### PR DESCRIPTION
## Summary

The "Show tooltips" toggle in Settings > Appearance updated a persisted signal (`tooltipsEnabled` in `packages/ui/signals/signals.ts`), but nothing in the app ever read that signal — so flipping the toggle had no visible effect (task #2073).

The app already has a single shared `Tooltip` component (exported from `@ui`, used at ~60+ call sites throughout the app) that wraps Kobalte's tooltip primitive and already supports a `disabled` prop for suppressing an individual tooltip. This PR wires the global setting into that one choke point: the shared `Tooltip` component now also disables itself when `tooltipsEnabled()` is `false`, in addition to respecting the existing per-instance `disabled` prop.

## Scope / limitations

- This intentionally only touches the shared `Tooltip` component in `packages/ui`, since it's the single place all app tooltips flow through — no call sites needed to change.
- Out of scope: any bespoke/one-off tooltip-like UI that doesn't use the shared `Tooltip` component (none were found during this investigation, but if one exists elsewhere it would need separate wiring).

## Test plan

- [ ] Toggle "Show tooltips" off in Settings > Appearance and confirm hovering over buttons/controls across the app no longer shows tooltips.
- [ ] Toggle it back on and confirm tooltips reappear after the configured hover delay.
- `bun run type-check` and `biome lint` pass for the changed file (full monorepo type-check has pre-existing, unrelated failures caused by two private git dependencies — `pdfjs-dist` and `@inkibra/tauri-plugins` — that could not be resolved in the review sandbox; no errors were introduced in the touched files).


---
_Generated by [Claude Code](https://claude.ai/code/session_01AAWCTjRJfF9DRMwwMyUSFQ)_