### PR TITLE
fix(ui): close dropdowns on swipe, not just tap

### DIFF
--- a/js/app/packages/ui/components/Dropdown.tsx
+++ b/js/app/packages/ui/components/Dropdown.tsx
@@ -1,3 +1,4 @@
+import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import { DropdownMenu as KobalteDropdownMenu } from '@kobalte/core/dropdown-menu';
 import CheckIcon from '@phosphor/check.svg';
 import { type ComponentProps, onCleanup, splitProps } from 'solid-js';
@@ -88,6 +89,77 @@ function installKeyboardNavigation(el: HTMLElement) {
   onCleanup(cleanup);
 }
 
+// Kobalte's dismissable layer deliberately defers "outside interaction"
+// dismissal on touch devices until a `click` event fires, so that a
+// scroll/swipe passing over the trigger isn't mistaken for a tap (see
+// createInteractOutside in @kobalte/core). A tap outside naturally produces
+// that click, so it still closes the menu. But a swipe (e.g. scrolling a
+// list behind the dropdown, or a swipe gesture that passes near it) never
+// produces a click, so it's left open — anywhere a tap dismisses the menu,
+// a swipe should too.
+//
+// We detect a swipe as touch movement past a small threshold that starts
+// outside the menu content, then dispatch a synthetic Escape keydown — the
+// same signal Kobalte's DismissableLayer already uses to close the
+// top-most open layer — rather than synthesizing a `click`, which could
+// wrongly activate whatever element the swipe happened to pass over.
+const SWIPE_DISMISS_THRESHOLD_PX = 10;
+
+function installSwipeToDismiss(contentEl: HTMLElement) {
+  if (!isTouchDevice()) return;
+
+  let startX = 0;
+  let startY = 0;
+  let tracking = false;
+
+  function onTouchStart(e: TouchEvent) {
+    const touch = e.touches[0];
+    const target = e.target as Node | null;
+    if (!touch || !target || contentEl.contains(target)) {
+      tracking = false;
+      return;
+    }
+    startX = touch.clientX;
+    startY = touch.clientY;
+    tracking = true;
+  }
+
+  function onTouchMove(e: TouchEvent) {
+    if (!tracking) return;
+    const touch = e.touches[0];
+    if (!touch) return;
+
+    const dx = touch.clientX - startX;
+    const dy = touch.clientY - startY;
+    if (Math.hypot(dx, dy) < SWIPE_DISMISS_THRESHOLD_PX) return;
+
+    tracking = false;
+    document.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'Escape',
+        bubbles: true,
+        cancelable: true,
+      })
+    );
+  }
+
+  function stopTracking() {
+    tracking = false;
+  }
+
+  document.addEventListener('touchstart', onTouchStart, { passive: true });
+  document.addEventListener('touchmove', onTouchMove, { passive: true });
+  document.addEventListener('touchend', stopTracking, { passive: true });
+  document.addEventListener('touchcancel', stopTracking, { passive: true });
+
+  onCleanup(() => {
+    document.removeEventListener('touchstart', onTouchStart);
+    document.removeEventListener('touchmove', onTouchMove);
+    document.removeEventListener('touchend', stopTracking);
+    document.removeEventListener('touchcancel', stopTracking);
+  });
+}
+
 function callRef<T>(ref: ((el: T) => void) | undefined, el: T) {
   ref?.(el);
 }
@@ -104,6 +176,7 @@ function DropdownContent(props: DropdownContentProps) {
   ]);
   const setContentRef = (el: HTMLElement) => {
     installKeyboardNavigation(el);
+    installSwipeToDismiss(el);
     callRef(local.ref, el);
   };
 
@@ -144,6 +217,7 @@ function DropdownSubContent(props: DropdownSubContentProps) {
   ]);
   const setContentRef = (el: HTMLElement) => {
     installKeyboardNavigation(el);
+    installSwipeToDismiss(el);
     callRef(local.ref, el);
   };
 


### PR DESCRIPTION
## Summary

On mobile, dropdown menus only close when the user taps outside them — a swipe (e.g. scrolling a list behind the open menu, or a swipe gesture that passes near it) leaves the menu open and floating over content the user has already scrolled past.

The underlying cause is in `@kobalte/core`'s dismissable-layer primitive, which the app's `Dropdown` component (`js/app/packages/ui/components/Dropdown.tsx`) is built on. On touch devices, Kobalte intentionally defers "outside interaction" dismissal until a `click` event fires, since browsers only synthesize a `click` for a tap without significant movement — this is meant to avoid closing the menu mid-scroll. The tradeoff is that a genuine swipe never produces that click, so the dismiss handler never runs and the menu stays open.

## Fix

Added a small, scoped touch listener to the dropdown's content and sub-content elements that:
- Tracks touch movement that starts outside the menu content.
- Once the movement exceeds a small threshold (treating it as a swipe rather than a tap), dispatches a synthetic `Escape` keydown event.

This reuses the exact same top-most-layer dismissal path Kobalte already wires up for the Escape key, rather than synthesizing a `click` — which risked wrongly activating whatever button/link the swipe happened to pass over.

The change is isolated to `js/app/packages/ui/components/Dropdown.tsx` (the app's shared dropdown wrapper), so it doesn't touch the vendored `@kobalte/core` dependency or affect other overlay types (dialogs, selects, popovers, etc.).

## Test plan
- [ ] On a touch device/emulator, open a dropdown menu and swipe over the background (e.g. scroll a list behind it) — the menu should close.
- [ ] On a touch device/emulator, tap outside a dropdown menu — it should still close as before.
- [ ] On desktop, click outside a dropdown menu — it should still close as before (unaffected, since the new listener only activates on touch devices).
- [ ] Open a submenu and swipe outside it — it should close correctly.
- [ ] `bun run type-check` and `biome check` pass for the changed file.

https://claude.ai/code/session_01AAWCTjRJfF9DRMwwMyUSFQ


---
_Generated by [Claude Code](https://claude.ai/code/session_01AAWCTjRJfF9DRMwwMyUSFQ)_