### PR TITLE
Add document similarity search surface

### DIFF
--- a/js/app/packages/block-md/component/SimilarDocuments.tsx
+++ b/js/app/packages/block-md/component/SimilarDocuments.tsx
@@ -1,0 +1,73 @@
+import { SidePanel } from '@app/component/side-panel';
+import { useFeatureFlag } from '@app/lib/analytics/posthog';
+import { useBlockId } from '@core/block';
+import { DocumentMention } from '@core/component/LexicalMarkdown/component/decorator/DocumentMention';
+import {
+  ENABLE_SIMILAR_DOCUMENTS_FLAG,
+  ENABLE_SIMILAR_DOCUMENTS_OVERRIDE,
+} from '@core/constant/featureFlags';
+import { useSimilarDocumentsQuery } from '@queries/storage/similar-documents';
+import type { SimilarDocument } from '@service-storage/client';
+import { cn } from '@ui';
+import { createMemo, For, Show, Suspense } from 'solid-js';
+
+/**
+ * "Similar Documents" side-panel section for plain markdown documents.
+ *
+ * Uses the same embedding similarity system as task duplicate detection to
+ * surface related documents. Collapsed by default — the header shows just the
+ * match count — and only mounted when there is at least one match.
+ */
+export function SimilarDocumentsSidePanelSection() {
+  const flag = useFeatureFlag(ENABLE_SIMILAR_DOCUMENTS_FLAG, {
+    enabledOverride: ENABLE_SIMILAR_DOCUMENTS_OVERRIDE,
+  });
+  const blockId = useBlockId();
+  const query = useSimilarDocumentsQuery(
+    () => blockId,
+    () => flag().enabled
+  );
+
+  const documents = createMemo(() => query.data ?? []);
+  const count = createMemo(() => documents().length);
+
+  return (
+    <Show when={flag().enabled}>
+      <Suspense>
+        <Show when={count() > 0}>
+          <SidePanel.Section
+            id="similar-documents"
+            title={
+              <SidePanel.CountTitle label="Similar Documents" count={count()} />
+            }
+            order={55}
+          >
+            <div class="flex flex-col gap-1">
+              <For each={documents()}>
+                {(document) => <SimilarDocumentRow document={document} />}
+              </For>
+            </div>
+          </SidePanel.Section>
+        </Show>
+      </Suspense>
+    </Show>
+  );
+}
+
+function SimilarDocumentRow(props: { document: SimilarDocument }) {
+  return (
+    <div class={cn('rounded-lg px-2 py-1.5', 'hover:bg-surface-hover')}>
+      <div class="flex min-w-0 items-center">
+        <span class="min-w-0 flex-1 truncate text-xs">
+          <DocumentMention
+            key={props.document.documentId}
+            documentId={props.document.documentId}
+            documentName={props.document.documentName || 'Untitled document'}
+            blockName="md"
+            theme={{}}
+          />
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/js/app/packages/block-md/component/sidepanel/MarkdownSidePanelSections.tsx
+++ b/js/app/packages/block-md/component/sidepanel/MarkdownSidePanelSections.tsx
@@ -53,6 +53,7 @@ import {
   Show,
 } from 'solid-js';
 import { mdStore } from '../../signal/markdownBlockData';
+import { SimilarDocumentsSidePanelSection } from '../SimilarDocuments';
 import { TaskDuplicateMatchesSidePanelSection } from '../TaskDuplicateMatches';
 
 interface MarkdownSidePanelSectionsProps {
@@ -105,6 +106,9 @@ export function MarkdownSidePanelSections(
       <GithubSectionConditional documentId={blockId} isTask={isTask()} />
       <NotificationsSectionConditional entity={entity()} />
       <ReferencesSectionConditional documentId={blockId} />
+      <Show when={!isTask() && !isSnippet()}>
+        <SimilarDocumentsSidePanelSection />
+      </Show>
       <Show when={isTask()}>
         <TaskDuplicateMatchesSidePanelSection />
       </Show>

--- a/js/app/packages/core/constant/featureFlags.ts
+++ b/js/app/packages/core/constant/featureFlags.ts
@@ -387,6 +387,13 @@ export const ENABLE_SOUP_GROUP_BY_OVERRIDE = DEV_MODE_ENV ? true : undefined;
 export const ENABLE_TASK_DUPLICATES_FLAG = 'enable-task-duplicates';
 export const ENABLE_TASK_DUPLICATES_OVERRIDE = DEV_MODE_ENV ? true : undefined;
 
+// Similar Documents side-panel section in the document view, powered by the
+// same embedding similarity system as task duplicate detection.
+export const ENABLE_SIMILAR_DOCUMENTS_FLAG = 'enable-similar-documents';
+export const ENABLE_SIMILAR_DOCUMENTS_OVERRIDE = DEV_MODE_ENV
+  ? true
+  : undefined;
+
 // Snippets: reusable markdown documents, the `c` launcher entry, and the `;`
 // insert menu. PostHog-gated (currently targeted at the Macro team) with a
 // dev-mode default; override with VITE_ENABLE_SNIPPETS.

--- a/js/app/packages/queries/storage/keys.ts
+++ b/js/app/packages/queries/storage/keys.ts
@@ -73,6 +73,9 @@ export const entityKeys = createQueryKeys('entity', {
   taskDuplicates: (documentId: string) => ({
     queryKey: [documentId, 'duplicates'],
   }),
+  similarDocuments: (documentId: string) => ({
+    queryKey: [documentId, 'similarDocuments'],
+  }),
   documentTeamShare: (documentId: string) => ({
     queryKey: [documentId, 'teamShare'],
   }),

--- a/js/app/packages/queries/storage/similar-documents.ts
+++ b/js/app/packages/queries/storage/similar-documents.ts
@@ -1,0 +1,31 @@
+import {
+  type SimilarDocument,
+  storageServiceClient,
+} from '@service-storage/client';
+import { useQuery } from '@tanstack/solid-query';
+import type { Accessor } from 'solid-js';
+import { entityKeys } from './keys';
+
+async function fetchSimilarDocuments(
+  documentId: string
+): Promise<SimilarDocument[]> {
+  const result = await storageServiceClient.getSimilarDocuments({ documentId });
+  if (result.isErr()) {
+    throw new Error('Failed to fetch similar documents');
+  }
+  return result.value;
+}
+
+export function useSimilarDocumentsQuery(
+  documentId: Accessor<string>,
+  enabled?: Accessor<boolean>
+) {
+  return useQuery(() => ({
+    queryKey: entityKeys.similarDocuments(documentId()).queryKey,
+    queryFn: () => fetchSimilarDocuments(documentId()),
+    enabled: !!documentId() && (enabled?.() ?? true),
+    // Each fetch embeds the document server-side before searching, so keep
+    // results around longer than cheap metadata queries.
+    staleTime: 5 * 60 * 1000,
+  }));
+}

--- a/js/app/packages/service-clients/service-storage/client.ts
+++ b/js/app/packages/service-clients/service-storage/client.ts
@@ -251,6 +251,16 @@ export type TaskSimilaritySearchResponse = {
   results: TaskSimilarityResult[];
 };
 
+export type SimilarDocument = {
+  documentId: string;
+  documentName: string;
+  vectorScore: number;
+};
+
+export type SimilarDocumentsResponse = {
+  results: SimilarDocument[];
+};
+
 type WithBotId = { bot_id: string };
 type WithChannelId = { channel_id: string };
 type WithMessageId = { message_id: string };
@@ -1210,6 +1220,14 @@ export const storageServiceClient = {
         `/documents/${params.documentId}/duplicates`
       )
     ).map((result) => result.duplicates);
+  },
+
+  async getSimilarDocuments(params: { documentId: string }) {
+    return (
+      await dssFetch<SimilarDocumentsResponse>(
+        `/documents/${params.documentId}/similar_documents`
+      )
+    ).map((result) => result.results);
   },
 
   async searchSimilarTasks(params: { taskName: string; markdown?: string }) {

--- a/rust/cloud-storage/.sqlx/query-2cec3182bb047c4f431cc931dcd39641b26bde5c9054a08b5f0d72a8f67d912f.json
+++ b/rust/cloud-storage/.sqlx/query-2cec3182bb047c4f431cc931dcd39641b26bde5c9054a08b5f0d72a8f67d912f.json
@@ -1,0 +1,17 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO document_similarity_embedding (document_id, search_key, content, embedding)\n            SELECT $1, sk, ct, emb::vector\n            FROM unnest($2::text[], $3::text[], $4::text[]) AS t(sk, ct, emb)\n            ON CONFLICT (document_id, search_key) DO UPDATE\n            SET content = EXCLUDED.content,\n                embedding = EXCLUDED.embedding,\n                updated_at = NOW()\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "TextArray",
+        "TextArray",
+        "TextArray"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "2cec3182bb047c4f431cc931dcd39641b26bde5c9054a08b5f0d72a8f67d912f"
+}

--- a/rust/cloud-storage/.sqlx/query-769f393027d77ef38b6b72cc258aea3b723b18c43bc16d6f6f009922206b4ab9.json
+++ b/rust/cloud-storage/.sqlx/query-769f393027d77ef38b6b72cc258aea3b723b18c43bc16d6f6f009922206b4ab9.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT d.id\n        FROM \"Document\" d\n        WHERE d.\"fileType\" = 'md'\n          AND d.\"deletedAt\" IS NULL\n          AND NOT EXISTS (\n              SELECT 1\n              FROM document_sub_type dst\n              WHERE dst.document_id = d.id\n          )\n          AND (\n              $1\n              OR NOT EXISTS (\n                  SELECT 1\n                  FROM document_similarity_embedding dse\n                  WHERE dse.document_id = d.id\n              )\n          )\n        LIMIT $2\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Bool",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "769f393027d77ef38b6b72cc258aea3b723b18c43bc16d6f6f009922206b4ab9"
+}

--- a/rust/cloud-storage/.sqlx/query-c779eec279a911ebeb7d6f5e42f3d7d8a2fef955c7b09bf790fca1671cb6a901.json
+++ b/rust/cloud-storage/.sqlx/query-c779eec279a911ebeb7d6f5e42f3d7d8a2fef955c7b09bf790fca1671cb6a901.json
@@ -1,0 +1,51 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            WITH query AS (\n                SELECT key, vec::vector AS vec\n                FROM unnest($1::text[], $2::text[]) AS t(key, vec)\n            ),\n            scored AS (\n                SELECT\n                    e.document_id,\n                    e.search_key,\n                    e.content,\n                    e.embedding::text AS embedding_text,\n                    MAX(1 - (e.embedding <=> q.vec))::real AS score\n                FROM document_similarity_embedding e\n                JOIN \"Document\" d ON d.id = e.document_id\n                CROSS JOIN query q\n                WHERE d.\"deletedAt\" IS NULL\n                  AND d.\"fileType\" = 'md'\n                  AND NOT EXISTS (\n                    SELECT 1\n                    FROM document_sub_type dst\n                    WHERE dst.document_id = d.id\n                  )\n                  AND ($4::text IS NULL OR e.document_id <> $4)\n                  AND (\n                    d.owner = $3\n                    OR EXISTS (\n                        SELECT 1\n                        FROM entity_access ea\n                        WHERE ea.entity_id::text = e.document_id\n                          AND ea.entity_type = 'document'\n                          AND (\n                            (ea.source_type = 'user' AND ea.source_id = $3)\n                            OR (\n                                $5::text IS NOT NULL\n                                AND ea.source_type = 'team'\n                                AND ea.source_id = $5\n                            )\n                          )\n                    )\n                  )\n                GROUP BY e.document_id, e.search_key, e.content, e.embedding\n            ),\n            ranked AS (\n                SELECT document_id, MAX(score) AS best\n                FROM scored\n                GROUP BY document_id\n                ORDER BY best DESC\n                LIMIT $6\n            )\n            SELECT\n                s.document_id AS \"document_id!\",\n                s.search_key AS \"search_key!\",\n                s.content AS \"content!\",\n                s.embedding_text AS \"embedding_text!\",\n                s.score AS \"score!\"\n            FROM scored s\n            JOIN ranked r ON r.document_id = s.document_id\n            ORDER BY r.best DESC, s.document_id, s.score DESC\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "document_id!",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "search_key!",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "content!",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "embedding_text!",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "score!",
+        "type_info": "Float4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "TextArray",
+        "TextArray",
+        "Text",
+        "Text",
+        "Text",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      null
+    ]
+  },
+  "hash": "c779eec279a911ebeb7d6f5e42f3d7d8a2fef955c7b09bf790fca1671cb6a901"
+}

--- a/rust/cloud-storage/.sqlx/query-f7181874d25a3c66ba2988c4544bf0d21a2730f154753dd69b273909388d819b.json
+++ b/rust/cloud-storage/.sqlx/query-f7181874d25a3c66ba2988c4544bf0d21a2730f154753dd69b273909388d819b.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "TRUNCATE TABLE document_similarity_embedding",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": []
+  },
+  "hash": "f7181874d25a3c66ba2988c4544bf0d21a2730f154753dd69b273909388d819b"
+}

--- a/rust/cloud-storage/document_storage_service/src/main.rs
+++ b/rust/cloud-storage/document_storage_service/src/main.rs
@@ -88,10 +88,11 @@ use std::sync::Arc;
 use sync_service_client::SyncServiceClient;
 use system_properties::{PgSystemPropertiesRepository, SystemPropertiesServiceImpl};
 use task_dedup::{
-    TaskDedupService,
+    DocumentSimilarityService, TaskDedupService,
     outbound::{
         cohere::CohereReranker,
         connection_gateway::ConnectionGatewayTaskDedupNotifier,
+        document_postgres::PgDocumentVectorDb,
         judge::AgentDuplicateJudge,
         postgres::{PgTaskMatchRepo, PgTaskVectorDb},
     },
@@ -601,14 +602,23 @@ async fn main() -> anyhow::Result<()> {
         "Cohere API key is required for task dedup reranking",
     );
     let task_dedup_service = Arc::new(TaskDedupService::new(
-        TextEmbedding3Small::new(openai_api_key),
+        TextEmbedding3Small::new(openai_api_key.clone()),
         PgTaskVectorDb::new(db.clone()),
-        CohereReranker::new(cohere_api_key),
+        CohereReranker::new(cohere_api_key.clone()),
         Arc::new(AgentDuplicateJudge::new(ai_usage::pg_recorder(db.clone()))),
         Arc::new(ConnectionGatewayTaskDedupNotifier::new(
             conn_gateway_client.clone(),
         )),
         Arc::new(PgTaskMatchRepo::new(db.clone())),
+    ));
+    // Document similarity search shares task dedup's embedder and reranker
+    // vendors but runs over its own document embedding store.
+    let document_vector_db = PgDocumentVectorDb::new(db.clone());
+    let document_similarity_service = Arc::new(DocumentSimilarityService::new(
+        TextEmbedding3Small::new(openai_api_key),
+        document_vector_db.clone(),
+        CohereReranker::new(cohere_api_key),
+        Arc::new(document_vector_db),
     ));
     let channels_repo = PgChannelsRepo::new(db.clone());
     let bots_repo = bots::outbound::pg_bots_repo::PgBotsRepo::new(db.clone());
@@ -708,6 +718,7 @@ async fn main() -> anyhow::Result<()> {
             access_service: entity_access_service.clone(),
             pool: db.clone(),
             task_dedup_service,
+            document_similarity_service,
             lexical_client: lexical_client.clone(),
             creator: documents_hex::domain::create::DocumentCreator::new(
                 document_service,

--- a/rust/cloud-storage/documents/src/inbound/axum_router.rs
+++ b/rust/cloud-storage/documents/src/inbound/axum_router.rs
@@ -31,6 +31,7 @@ pub mod get_github_pull_requests;
 pub mod get_location;
 pub mod get_short_id;
 pub mod put_snapshot;
+pub mod similar_documents;
 pub mod task_duplicates;
 pub mod team_share;
 
@@ -49,7 +50,7 @@ use lexical_client::LexicalClient;
 use model_error_response::ErrorResponse;
 use serde::Deserialize;
 use sqlx::PgPool;
-use task_dedup::PgTaskDedupService;
+use task_dedup::{PgDocumentSimilarityService, PgTaskDedupService};
 
 #[cfg(feature = "document_create")]
 use self::create_markdown::create_markdown_handler;
@@ -68,6 +69,7 @@ use self::{
     get_location::get_location_v3_handler,
     get_short_id::get_short_id_handler,
     put_snapshot::put_snapshot_handler,
+    similar_documents::get_similar_documents_handler,
     task_duplicates::{
         delete_this_duplicate_task_handler, dismiss_task_duplicates_handler,
         get_task_duplicates_handler, task_similarity_search_handler,
@@ -152,6 +154,8 @@ pub struct DocumentRouterState<T, Svc> {
     pub pool: PgPool,
     /// Task duplicate detection service.
     pub task_dedup_service: Arc<PgTaskDedupService>,
+    /// Document similarity search service.
+    pub document_similarity_service: Arc<PgDocumentSimilarityService>,
     /// Lexical service client, used to fetch embedding-format markdown for
     /// task duplicate detection.
     pub lexical_client: Arc<LexicalClient>,
@@ -170,6 +174,7 @@ impl<T, Svc> Clone for DocumentRouterState<T, Svc> {
             access_service: self.access_service.clone(),
             pool: self.pool.clone(),
             task_dedup_service: self.task_dedup_service.clone(),
+            document_similarity_service: self.document_similarity_service.clone(),
             lexical_client: self.lexical_client.clone(),
             #[cfg(feature = "document_create_adapters")]
             creator: self.creator.clone(),
@@ -228,6 +233,10 @@ where
         .route(
             "/{document_id}/duplicates",
             axum::routing::get(get_task_duplicates_handler::<T, Svc>),
+        )
+        .route(
+            "/{document_id}/similar_documents",
+            axum::routing::get(get_similar_documents_handler::<T, Svc>),
         )
         .route(
             "/{document_id}/duplicates/dismiss",

--- a/rust/cloud-storage/documents/src/inbound/axum_router/similar_documents.rs
+++ b/rust/cloud-storage/documents/src/inbound/axum_router/similar_documents.rs
@@ -1,0 +1,107 @@
+//! Similar documents endpoint.
+
+use axum::{
+    Extension, Json,
+    extract::{Path, State},
+};
+use entity_access::domain::models::MemberTeamRole;
+use entity_access::domain::ports::EntityAccessService;
+use entity_access::inbound::axum_extractors::{
+    DocumentAccessExtractor, OptionalMacroUserTeamExtractor,
+};
+use model::document::DocumentBasic;
+use model_user::axum_extractor::MacroUserExtractor;
+use models_permissions::share_permission::access_level::ViewAccessLevel;
+use serde::{Deserialize, Serialize};
+use task_dedup::{EmbeddingMarkdown, SimilarDocument, SimilarDocumentsQuery};
+
+use super::task_duplicates::task_dedup_error;
+use super::{DocumentRouterState, Params};
+use crate::domain::models::DocumentError;
+use crate::domain::ports::DocumentService;
+
+/// Response for similar document lookup.
+#[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "axum", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
+pub struct SimilarDocumentsResponse {
+    /// Existing documents similar to the requested document, ordered from most
+    /// to least relevant.
+    pub results: Vec<SimilarDocument>,
+}
+
+/// Handler for `GET /documents/{document_id}/similar_documents`.
+///
+/// Returns existing documents similar to the one being viewed, using the same
+/// embed → vector search → rerank pipeline as task duplicate detection but
+/// over the document embedding store. Nothing is judged or persisted beyond
+/// the viewed document's own embedding, which is refreshed as a side effect so
+/// the corpus keeps itself up to date.
+#[utoipa::path(
+    tag = "document",
+    get,
+    path = "/documents/{document_id}/similar_documents",
+    params(("document_id" = String, Path, description = "Document id")),
+    responses(
+        (status = 200, body = inline(SimilarDocumentsResponse)),
+        (status = 401, body = model_error_response::ErrorResponse),
+        (status = 404, body = model_error_response::ErrorResponse),
+        (status = 500, body = model_error_response::ErrorResponse),
+    )
+)]
+#[tracing::instrument(skip(state, _access, user, optional_team, doc), fields(user_id=?user.macro_user_id), err)]
+pub async fn get_similar_documents_handler<T: DocumentService, Svc: EntityAccessService>(
+    _access: DocumentAccessExtractor<ViewAccessLevel, Svc>,
+    State(state): State<DocumentRouterState<T, Svc>>,
+    user: MacroUserExtractor,
+    optional_team: OptionalMacroUserTeamExtractor<MemberTeamRole, Svc>,
+    doc: Extension<DocumentBasic>,
+    Path(Params { document_id }): Path<Params>,
+) -> Result<Json<SimilarDocumentsResponse>, DocumentError> {
+    // Only plain markdown documents participate: tasks and snippets have their
+    // own surfaces, and other file types have no markdown body to embed.
+    if doc.sub_type.is_some() || doc.file_type.as_deref() != Some("md") {
+        return Ok(Json(SimilarDocumentsResponse {
+            results: Vec::new(),
+        }));
+    }
+
+    // Like task duplicate search, scope to the user's whole team rather than
+    // just their own documents. Users without a team fall back to
+    // owner-plus-direct-shares scope.
+    let team_id = optional_team
+        .entity_access_receipt
+        .map(|team| macro_uuid::string_to_uuid(&team.entity().entity_id).unwrap());
+
+    // A document whose body cannot be fetched still gets a title-only search
+    // rather than an error: the panel is best-effort.
+    let markdown = match state
+        .lexical_client
+        .get_embedding_markdown(&document_id)
+        .await
+    {
+        Ok(markdown) => markdown,
+        Err(error) => {
+            tracing::warn!(
+                error=?error,
+                document_id=%document_id,
+                "failed to fetch embedding markdown for similar documents; searching title only"
+            );
+            EmbeddingMarkdown::empty()
+        }
+    };
+
+    let results = state
+        .document_similarity_service
+        .similar_documents(SimilarDocumentsQuery {
+            document_id,
+            user: user.macro_user_id.as_ref().to_string(),
+            team_id,
+            title: doc.document_name.clone(),
+            markdown,
+        })
+        .await
+        .map_err(task_dedup_error)?;
+
+    Ok(Json(SimilarDocumentsResponse { results }))
+}

--- a/rust/cloud-storage/documents/src/inbound/axum_router/task_duplicates.rs
+++ b/rust/cloud-storage/documents/src/inbound/axum_router/task_duplicates.rs
@@ -211,7 +211,7 @@ pub fn spawn_task_duplicate_detection(
     });
 }
 
-fn task_dedup_error(error: TaskDedupError) -> DocumentError {
+pub(super) fn task_dedup_error(error: TaskDedupError) -> DocumentError {
     match error {
         TaskDedupError::MatchNotFound => {
             DocumentError::NotFound("duplicate match not found".to_string())

--- a/rust/cloud-storage/embedding/src/entity/document.rs
+++ b/rust/cloud-storage/embedding/src/entity/document.rs
@@ -1,0 +1,63 @@
+//! Document embedding
+use crate::Embeddable;
+use std::borrow::Cow;
+
+static TITLE: &str = "title";
+static BODY: &str = "body";
+
+/// A markdown document
+pub struct Document<'a> {
+    /// document name
+    pub title: Cow<'a, str>,
+    /// document body, as internal markdown
+    pub body: Cow<'a, str>,
+}
+
+impl<'a> Embeddable for Document<'a> {
+    fn embedding_content(&self) -> Vec<(crate::SearchKey, crate::Content<'a>)> {
+        let mut fields = Vec::with_capacity(2);
+        if !self.title.trim().is_empty() {
+            fields.push((TITLE, self.title.clone()));
+        }
+        if !self.body.trim().is_empty() {
+            fields.push((BODY, self.body.clone()));
+        }
+        fields
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn keys_and_text(document: &Document<'_>) -> Vec<(&'static str, String)> {
+        document
+            .embedding_content()
+            .into_iter()
+            .map(|(key, text)| (key, text.into_owned()))
+            .collect()
+    }
+
+    #[test]
+    fn embeds_title_when_document_has_no_body() {
+        let document = Document {
+            title: Cow::Borrowed("Title"),
+            body: Cow::Borrowed(""),
+        };
+
+        assert_eq!(
+            keys_and_text(&document),
+            vec![("title", "Title".to_string())]
+        );
+    }
+
+    #[test]
+    fn embeds_nothing_when_document_has_no_title_or_body() {
+        let document = Document {
+            title: Cow::Borrowed(" "),
+            body: Cow::Borrowed("\n\t"),
+        };
+
+        assert!(keys_and_text(&document).is_empty());
+    }
+}

--- a/rust/cloud-storage/embedding/src/entity/mod.rs
+++ b/rust/cloud-storage/embedding/src/entity/mod.rs
@@ -1,3 +1,5 @@
 //! Embeddable impls for entities
+mod document;
 mod task;
+pub use document::*;
 pub use task::*;

--- a/rust/cloud-storage/macro_db_client/migrations/20260703160940_document_similarity_embedding.sql
+++ b/rust/cloud-storage/macro_db_client/migrations/20260703160940_document_similarity_embedding.sql
@@ -1,0 +1,21 @@
+-- Embedding store for the "similar documents" surface. Mirrors
+-- task_duplicate_embedding (one row per (document_id, search_key) field) but
+-- holds plain markdown documents instead of tasks so document similarity search
+-- does not pollute task duplicate detection, and vice versa.
+CREATE TABLE document_similarity_embedding (
+    document_id TEXT NOT NULL,
+    search_key TEXT NOT NULL,
+    content TEXT NOT NULL,
+    embedding vector(1536) NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (document_id, search_key)
+);
+
+-- HNSW pairs with pgvector iterative index scans for filtered queries (the
+-- search filters by owner/access after the index scan). Enable iterative scans
+-- at query time, e.g. per transaction:
+--   SET LOCAL hnsw.iterative_scan = relaxed_order;
+CREATE INDEX document_similarity_embedding_vector_idx
+    ON document_similarity_embedding
+    USING hnsw (embedding vector_cosine_ops);

--- a/rust/cloud-storage/task_dedup/Cargo.toml
+++ b/rust/cloud-storage/task_dedup/Cargo.toml
@@ -10,6 +10,11 @@ path = "src/bin/backfill_task_embeddings.rs"
 required-features = ["backfill"]
 
 [[bin]]
+name = "backfill_document_embeddings"
+path = "src/bin/backfill_document_embeddings.rs"
+required-features = ["backfill"]
+
+[[bin]]
 name = "pull_task_corpus"
 path = "src/bin/pull_task_corpus.rs"
 required-features = ["backfill"]

--- a/rust/cloud-storage/task_dedup/src/bin/backfill_document_embeddings.rs
+++ b/rust/cloud-storage/task_dedup/src/bin/backfill_document_embeddings.rs
@@ -1,0 +1,435 @@
+//! Backfills document embeddings into the `document_similarity_embedding`
+//! pgvector table so the "similar documents" surface has a corpus before lazy
+//! view-time indexing catches up. Mirrors `backfill_task_embeddings`.
+
+use std::borrow::Cow;
+use std::io::Write;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use anyhow::Context as _;
+use anyhow::{Result, anyhow, bail};
+use clap::Parser;
+use embedding::embedding_provider::openai::TextEmbedding3Small;
+use embedding::entity::Document;
+use embedding::{EmbeddingModel, VectorStore};
+use futures::StreamExt;
+use lexical_client::LexicalClient;
+use macro_env_var::env_var;
+use macro_service_urls::LexicalServiceUrl;
+use secretsmanager_client::{SecretManager, SecretsManager};
+use task_dedup::outbound::document_postgres::PgDocumentVectorDb;
+
+/// Target environment for the backfill.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+enum Env {
+    /// Local development: read all config from the environment / `.env`.
+    Local,
+    /// Dev environment: resolve DB URL and secrets from AWS.
+    Dev,
+    /// Production environment: resolve DB URL and secrets from AWS.
+    Prod,
+}
+
+impl Env {
+    /// The environment suffix used in per-environment secret names
+    /// (e.g. `macrodb-password-dev`).
+    fn suffix(self) -> &'static str {
+        match self {
+            Env::Local => "local",
+            Env::Dev => "dev",
+            Env::Prod => "prod",
+        }
+    }
+
+    /// Resolve the lexical-service URL for the environment.
+    fn lexical_service_url(self) -> Result<String> {
+        let environment = match self {
+            Env::Local => macro_service_urls::macro_env::Environment::Local,
+            Env::Dev => macro_service_urls::macro_env::Environment::Develop,
+            Env::Prod => macro_service_urls::macro_env::Environment::Production,
+        };
+
+        Ok(LexicalServiceUrl::new_for_environment(environment)?.to_string())
+    }
+}
+
+/// Backfills document embeddings into the `document_similarity_embedding`
+/// pgvector table.
+#[derive(Debug, clap::Parser)]
+#[command(name = "backfill_document_embeddings", about, long_about = None)]
+struct Args {
+    /// Environment to run against: local | dev | prod.
+    #[arg(value_enum)]
+    env: Env,
+    /// Re-embed every document, including ones that already have an embedding.
+    #[arg(long)]
+    force: bool,
+    /// Count work without fetching content, embedding, or writing.
+    #[arg(long)]
+    dry_run: bool,
+    /// Delete existing embedding set
+    #[arg(long)]
+    clear: bool,
+    /// Optional cap on the number of documents processed (handy for a smoke test).
+    #[arg(long)]
+    limit: Option<usize>,
+    /// Number of documents to embed and write concurrently.
+    #[arg(long, default_value_t = 8)]
+    concurrency: usize,
+}
+
+/// Running tallies for the backfill. Failures are all retryable by re-running
+/// (the embedding client does not distinguish permanent rejections).
+#[derive(Default)]
+struct Counters {
+    /// Embeddings successfully written.
+    succeeded: AtomicUsize,
+    /// Failed
+    failed: AtomicUsize,
+    /// Total
+    total: AtomicUsize,
+}
+
+#[derive(Default, Clone)]
+struct Stats(Arc<Counters>);
+
+impl Stats {
+    /// Records a failure and returns the running count of documents processed so far.
+    pub fn fail(&self) -> usize {
+        self.0.failed.fetch_add(1, Ordering::Relaxed);
+        self.0.total.fetch_add(1, Ordering::Relaxed) + 1
+    }
+
+    /// Records a success and returns the running count of documents processed so far.
+    pub fn success(&self) -> usize {
+        self.0.succeeded.fetch_add(1, Ordering::Relaxed);
+        self.0.total.fetch_add(1, Ordering::Relaxed) + 1
+    }
+
+    pub fn summary(&self) {
+        println!("________________________________________");
+        println!(
+            "succeeded: {}/{}",
+            self.0.succeeded.load(Ordering::Relaxed),
+            self.0.total.load(Ordering::Relaxed)
+        );
+        println!(
+            "failed: {}/{}",
+            self.0.failed.load(Ordering::Relaxed),
+            self.0.total.load(Ordering::Relaxed)
+        );
+        println!("________________________________________");
+    }
+}
+
+fn confirm(s: &str) -> Result<()> {
+    println!("{}", s);
+    print!("Confirm [y/n]: ");
+    std::io::stdout().flush()?;
+    let mut buf = String::new();
+    std::io::stdin().read_line(&mut buf)?;
+    if buf.to_lowercase().trim() == "y" {
+        Ok(())
+    } else {
+        Err(anyhow!("declined"))
+    }
+}
+
+env_var! {
+    struct Vars {
+        DatabaseUrl,
+        InternalApiSecretKey,
+        OpenaiApiKey,
+    }
+}
+
+/// The fully-resolved config the backfill needs, regardless of where each value
+/// came from (local env vars vs. AWS Secrets Manager).
+struct ResolvedConfig {
+    database_url: String,
+    lexical_service_url: String,
+    internal_api_secret_key: String,
+    openai_api_key: String,
+}
+
+impl ResolvedConfig {
+    /// Local config: every value comes straight from the environment / `.env`,
+    /// matching the original setup.
+    fn local() -> Result<Self> {
+        let vars = Vars::new()?;
+        Ok(Self {
+            // The repo `.env` ships the docker-network DB host (`@postgres`),
+            // which isn't resolvable from the host shell, so hardcode the
+            // localhost URL for local runs.
+            database_url: "postgres://user:password@localhost:5432/macrodb".to_string(),
+            // Resolve through macro_service_urls so local runs use the host-reachable URL.
+            lexical_service_url: Env::Local.lexical_service_url()?,
+            internal_api_secret_key: vars.internal_api_secret_key.as_ref().to_string(),
+            openai_api_key: vars.openai_api_key.as_ref().to_string(),
+        })
+    }
+
+    /// Dev/prod config, resolved from AWS: the lexical URL is hard-coded per
+    /// environment, the database URL is read from the `macro-db-<env>` secret via
+    /// the `aws` CLI (the same primary-writer secret the deployed services use),
+    /// and the OpenAI and internal-auth secrets are fetched from Secrets Manager
+    /// with the in-process SDK.
+    async fn remote(env: Env) -> Result<Self> {
+        // Make sure AWS calls target real AWS rather than a LocalStack override
+        // that may be lingering in the env.
+        // SAFETY: runs once at startup before any other thread reads the env.
+        unsafe { std::env::remove_var("LOCAL_AWS_URL") };
+
+        let database_url = fetch_database_url(env)?;
+
+        let secrets = SecretsManager::new(aws_sdk_secretsmanager::Client::new(
+            &macro_aws_config::get_macro_aws_config().await,
+        ));
+        let openai_api_key = secrets.get_secret_value("openai-key").await?;
+        let internal_api_secret_key = secrets
+            .get_secret_value(format!(
+                "document-storage-service-auth-key-{}",
+                env.suffix()
+            ))
+            .await?;
+
+        Ok(Self {
+            database_url,
+            lexical_service_url: env.lexical_service_url()?,
+            internal_api_secret_key: internal_api_secret_key.as_ref().to_string(),
+            openai_api_key: openai_api_key.as_ref().to_string(),
+        })
+    }
+
+    fn print(&self) {
+        println!("________________________________________");
+        println!("DATABASE_URL: {}", masked_db_url(&self.database_url));
+        println!("lexical service URL: {}", self.lexical_service_url);
+        println!("________________________________________");
+    }
+}
+
+/// Masks the password in a `postgres://user:password@host/...` URL for logging.
+fn masked_db_url(url: &str) -> String {
+    url.split_once("://")
+        .and_then(|(scheme, rest)| {
+            let (creds, host) = rest.split_once('@')?;
+            let user = creds.split_once(':').map_or(creds, |(user, _)| user);
+            Some(format!("{scheme}://{user}:******@{host}"))
+        })
+        .unwrap_or_else(|| url.to_string())
+}
+
+/// Fetches the full `DATABASE_URL` for `env` from AWS Secrets Manager by shelling
+/// out to the `aws` CLI. Reads the `macro-db-<env>` secret — the primary-writer
+/// connection string the deployed services use — which already contains a
+/// ready-to-use `postgres://…` URL, so nothing needs to be assembled.
+///
+/// The `aws` CLI must be on `PATH` and authenticated (e.g. `aws sso login`).
+fn fetch_database_url(env: Env) -> Result<String> {
+    let secret_id = format!("macro-db-{}", env.suffix());
+    println!("fetching DATABASE_URL from secret {secret_id}");
+
+    let output = std::process::Command::new("aws")
+        .args([
+            "secretsmanager",
+            "get-secret-value",
+            "--secret-id",
+            &secret_id,
+            "--query",
+            "SecretString",
+            "--output",
+            "text",
+            "--region",
+            "us-east-1",
+        ])
+        .output()
+        .with_context(|| format!("failed to run `aws` to read secret {secret_id}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!(
+            "`aws secretsmanager get-secret-value` failed for {secret_id} \
+             (check AWS auth / permissions): {}",
+            stderr.trim()
+        );
+    }
+
+    let database_url = String::from_utf8(output.stdout)
+        .context("aws output was not valid UTF-8")?
+        .trim()
+        .to_string();
+    if database_url.is_empty() {
+        bail!("secret {secret_id} resolved to an empty value");
+    }
+    Ok(database_url)
+}
+
+struct Context {
+    pg: sqlx::PgPool,
+    lexical: LexicalClient,
+    embedder: TextEmbedding3Small,
+    vector_db: PgDocumentVectorDb,
+}
+
+impl Context {
+    async fn connect(config: ResolvedConfig) -> Result<Self> {
+        let pg = sqlx::PgPool::connect(&config.database_url)
+            .await
+            .map_err(anyhow::Error::from)?;
+        let lexical =
+            LexicalClient::new(config.internal_api_secret_key, config.lexical_service_url);
+        let embedder = TextEmbedding3Small::new(config.openai_api_key);
+        let vector_db = PgDocumentVectorDb::new(pg.clone());
+        Ok(Self {
+            pg,
+            lexical,
+            embedder,
+            vector_db,
+        })
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let args = Args::parse();
+
+    // Local reads everything from the environment / `.env`; dev and prod hard-code
+    // their URLs and pull secrets from AWS Secrets Manager.
+    let config = match args.env {
+        Env::Local => ResolvedConfig::local()?,
+        env => ResolvedConfig::remote(env).await?,
+    };
+    config.print();
+    let context = Context::connect(config).await?;
+
+    if args.clear {
+        confirm("Are you sure you want to clear all vectors")?;
+        confirm("Are you really sure")?;
+        return clear_vectors(&context).await;
+    }
+
+    let document_set = fetch_document_set(&context, &args).await?;
+    let total = document_set.len();
+    println!("found {total} document(s) to embed");
+    if args.dry_run {
+        return Ok(());
+    }
+
+    // Embed and store each document concurrently, capped at `--concurrency`.
+    // Each document is independent, so a single failure is recorded and the
+    // rest carry on; re-running picks up whatever did not get written. The
+    // running "<n>/<total>" reflects completion order, not input order.
+    let stats = Stats::default();
+    futures::stream::iter(document_set)
+        .for_each_concurrent(args.concurrency, |document_id| {
+            let context = &context;
+            let stats = stats.clone();
+            async move {
+                match embed_and_store(context, &document_id).await {
+                    Ok(()) => {
+                        let n = stats.success();
+                        println!("{n}/{total} success");
+                    }
+                    Err(error) => {
+                        let n = stats.fail();
+                        println!("{n}/{total} failure");
+                        println!("{error:#}");
+                    }
+                }
+            }
+        })
+        .await;
+
+    stats.summary();
+    Ok(())
+}
+
+/// Returns the document ids of the plain markdown documents to embed (no
+/// `document_sub_type` row — tasks and snippets have their own surfaces).
+///
+/// With `--force` this is every such document. Otherwise it's only the ones
+/// that do not yet have any row in `document_similarity_embedding`, so a re-run
+/// picks up where a previous one left off. `--limit` caps the result for smoke
+/// tests.
+async fn fetch_document_set(ctx: &Context, args: &Args) -> Result<Vec<String>> {
+    // LIMIT needs a bind value; map "no cap" to i64::MAX so the same query
+    // serves both the capped and uncapped cases. `force` is bound too, so a
+    // single query covers both modes: when true it short-circuits the
+    // NOT EXISTS filter and returns every document.
+    let limit = args.limit.map_or(i64::MAX, |n| n as i64);
+
+    sqlx::query_scalar!(
+        r#"
+        SELECT d.id
+        FROM "Document" d
+        WHERE d."fileType" = 'md'
+          AND d."deletedAt" IS NULL
+          AND NOT EXISTS (
+              SELECT 1
+              FROM document_sub_type dst
+              WHERE dst.document_id = d.id
+          )
+          AND (
+              $1
+              OR NOT EXISTS (
+                  SELECT 1
+                  FROM document_similarity_embedding dse
+                  WHERE dse.document_id = d.id
+              )
+          )
+        LIMIT $2
+        "#,
+        args.force,
+        limit
+    )
+    .fetch_all(&ctx.pg)
+    .await
+    .map_err(anyhow::Error::from)
+}
+
+/// Embeds a single document and upserts its field embeddings into the vector
+/// db.
+///
+/// Builds the embeddable [`Document`], runs it through the OpenAI embedder, and
+/// hands the resulting per-field embeddings to the [`PgDocumentVectorDb`]
+/// vector store — the same insert path the live similar-documents endpoint
+/// uses. A document with no embeddable text (empty title and body) is a no-op.
+async fn embed_and_store(ctx: &Context, document_id: &str) -> Result<()> {
+    let document = fetch_md_document(ctx, document_id).await?;
+    let embeddings = ctx.embedder.embed(&document).await?;
+    if embeddings.is_empty() {
+        return Ok(());
+    }
+    ctx.vector_db
+        .upsert_embeddings(document_id.to_string(), embeddings)
+        .await?;
+    Ok(())
+}
+
+/// Builds the embeddable [`Document`] for a single document: its
+/// `Document.name` becomes the title and the lexical service's
+/// embedding-format markdown becomes the body — the same format the live
+/// endpoint embeds. Map this over a document set to get the entities to embed.
+async fn fetch_md_document(ctx: &Context, document_id: &str) -> Result<Document<'static>> {
+    let title = sqlx::query_scalar!(r#"SELECT name FROM "Document" WHERE id = $1"#, document_id)
+        .fetch_one(&ctx.pg)
+        .await
+        .map_err(anyhow::Error::from)?;
+
+    let body = ctx.lexical.get_embedding_markdown(document_id).await?;
+
+    Ok(Document {
+        title: Cow::Owned(title),
+        body: Cow::Owned(body.into_string()),
+    })
+}
+
+async fn clear_vectors(ctx: &Context) -> Result<()> {
+    sqlx::query!("TRUNCATE TABLE document_similarity_embedding")
+        .execute(&ctx.pg)
+        .await
+        .map_err(anyhow::Error::from)?;
+    Ok(())
+}

--- a/rust/cloud-storage/task_dedup/src/domain/document_similarity.rs
+++ b/rust/cloud-storage/task_dedup/src/domain/document_similarity.rs
@@ -1,0 +1,214 @@
+//! Domain service for the "similar documents" surface.
+//!
+//! Reuses the task-dedup retrieval pipeline (embed → vector search → rerank →
+//! score floor) over a separate document embedding store. Unlike task duplicate
+//! detection there is no LLM judge and no persisted match graph: results are
+//! computed on demand, exactly like the task composer's draft similarity
+//! search.
+
+#[cfg(test)]
+mod test;
+
+use std::borrow::Cow;
+use std::sync::Arc;
+
+use embedding::entity::Document;
+use embedding::{EmbeddingModel, KeyedEmbedding, RerankModel, VectorStore};
+use lexical_client::parse_markdown::EmbeddingMarkdown;
+use uuid::Uuid;
+
+use super::models::{DocumentSearchParameters, SimilarDocument, TaskDedupError};
+use super::ports::DocumentNameRepo;
+use super::retrieval::{self, full_text};
+
+/// Configuration for the document similarity pipeline.
+#[derive(Debug, Clone)]
+pub struct DocumentSimilarityConfig {
+    /// Maximum vector candidates to retrieve.
+    pub vector_candidate_limit: i64,
+    /// Maximum similar documents to return.
+    pub result_limit: i64,
+    /// Minimum vector similarity for a candidate to be considered.
+    pub min_vector_similarity: f64,
+    /// Minimum rerank score for a result to be returned. There is no LLM judge
+    /// on this surface, so the reranker's score is the only relevance gate;
+    /// the floor matches the task draft similarity search, which was tuned low
+    /// (see `eval_similarity_rerank_floor`) to keep recall high.
+    pub min_rerank_score: f64,
+}
+
+impl Default for DocumentSimilarityConfig {
+    fn default() -> Self {
+        Self {
+            vector_candidate_limit: 24,
+            result_limit: 10,
+            min_vector_similarity: 0.35,
+            min_rerank_score: 0.05,
+        }
+    }
+}
+
+/// The document a user is viewing, as the query of a similarity search.
+#[derive(Debug, Clone)]
+pub struct SimilarDocumentsQuery {
+    /// Document id of the viewed document.
+    pub document_id: String,
+    /// Requesting user id; results are scoped to documents they can see.
+    pub user: String,
+    /// The user's team, when they belong to one, widening scope to documents
+    /// shared with the team.
+    pub team_id: Option<Uuid>,
+    /// Document display name.
+    pub title: String,
+    /// Document body as [embedding-format markdown](EmbeddingMarkdown).
+    pub markdown: EmbeddingMarkdown,
+}
+
+/// Document similarity service.
+///
+/// Embedding (`E`), vector storage (`V`), and reranking (`R`) are supplied by
+/// the [`embedding`] crate's traits, generic for the same reason as
+/// [`TaskDedupService`](super::service::TaskDedupService): those traits are not
+/// object-safe. Name resolution remains a `dyn` port.
+#[derive(Clone)]
+pub struct DocumentSimilarityService<const DIMS: usize, E, V, R> {
+    config: DocumentSimilarityConfig,
+    embedder: E,
+    vector_db: V,
+    reranker: R,
+    names: Arc<dyn DocumentNameRepo>,
+}
+
+impl<const DIMS: usize, E, V, R> DocumentSimilarityService<DIMS, E, V, R>
+where
+    E: EmbeddingModel<DIMS> + Send + Sync,
+    V: VectorStore<DIMS, Metadata = String, SearchParameters = DocumentSearchParameters>
+        + Send
+        + Sync,
+    V::Error: Into<anyhow::Error>,
+    R: RerankModel<DIMS> + Send + Sync,
+{
+    /// Creates a service with the production configuration.
+    ///
+    /// The pipeline owns its tuning: consumers get the pinned
+    /// [`DocumentSimilarityConfig::default`] and cannot vary it. Tests that
+    /// need non-default limits use [`with_config`](Self::with_config).
+    pub fn new(embedder: E, vector_db: V, reranker: R, names: Arc<dyn DocumentNameRepo>) -> Self {
+        Self::with_config(
+            DocumentSimilarityConfig::default(),
+            embedder,
+            vector_db,
+            reranker,
+            names,
+        )
+    }
+
+    /// Creates a service with an explicit config.
+    ///
+    /// Not part of the supported consumer API — production builds the service
+    /// with [`new`](Self::new), which pins the config. This exists only for
+    /// the crate's own tests.
+    #[doc(hidden)]
+    pub fn with_config(
+        config: DocumentSimilarityConfig,
+        embedder: E,
+        vector_db: V,
+        reranker: R,
+        names: Arc<dyn DocumentNameRepo>,
+    ) -> Self {
+        Self {
+            config,
+            embedder,
+            vector_db,
+            reranker,
+            names,
+        }
+    }
+
+    /// Finds existing documents similar to the one the user is viewing.
+    ///
+    /// Embeds the document, upserts the embedding into the store (so the
+    /// corpus stays fresh without a separate indexing pipeline: every viewed
+    /// document re-indexes itself), then runs vector retrieval + rerank over
+    /// the other documents the user can see. Results are ordered by the
+    /// reranker's relevance score.
+    pub async fn similar_documents(
+        &self,
+        query: SimilarDocumentsQuery,
+    ) -> Result<Vec<SimilarDocument>, TaskDedupError> {
+        let embeddable = Document {
+            title: Cow::Borrowed(query.title.as_str()),
+            body: Cow::Borrowed(query.markdown.as_ref()),
+        };
+        let labeled = self.embedder.embed(&embeddable).await?;
+        if labeled.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // Build the search query before moving the labeled embeddings into the
+        // store; the vectors are `Copy` so this borrows rather than clones.
+        let search_query: Vec<KeyedEmbedding<DIMS>> = labeled
+            .iter()
+            .map(|field| KeyedEmbedding {
+                search_key: field.search_key,
+                embedding: field.embedding,
+            })
+            .collect();
+
+        self.vector_db
+            .upsert_embeddings(query.document_id.clone(), labeled)
+            .await
+            .map_err(|error| TaskDedupError::Dependency(error.into()))?;
+
+        let params = DocumentSearchParameters {
+            user: query.user.clone(),
+            team_id: query.team_id,
+            limit: self.config.vector_candidate_limit,
+            exclude_document_id: Some(query.document_id.clone()),
+        };
+        let results = self
+            .vector_db
+            .cosine_search(search_query, params)
+            .await
+            .map_err(|error| TaskDedupError::Dependency(error.into()))?;
+
+        // No judge runs on this surface, so the rerank score is the only
+        // relevance gate; results below the floor are noise the panel
+        // shouldn't show. Reranked results are ordered by score, so the floor
+        // trims a suffix.
+        let query_content = full_text(&query.title, query.markdown.as_ref());
+        let ranked = retrieval::rerank(
+            &self.reranker,
+            &query_content,
+            results,
+            self.config.min_vector_similarity,
+        )
+        .await?
+        .into_iter()
+        .filter(|(_, rerank_score)| f64::from(*rerank_score) >= self.config.min_rerank_score)
+        .map(|(candidate, _)| candidate)
+        .take(self.config.result_limit.max(0) as usize)
+        .collect::<Vec<_>>();
+
+        let document_ids = ranked
+            .iter()
+            .map(|candidate| candidate.document_id.clone())
+            .collect::<Vec<_>>();
+        let names = self.names.document_names(&document_ids).await?;
+
+        // A document whose name lookup came back empty was deleted between the
+        // search and the lookup; drop it rather than show a nameless row.
+        Ok(ranked
+            .into_iter()
+            .filter_map(|candidate| {
+                names
+                    .get(&candidate.document_id)
+                    .map(|name| SimilarDocument {
+                        document_name: name.clone(),
+                        document_id: candidate.document_id,
+                        vector_score: candidate.vector_score,
+                    })
+            })
+            .collect())
+    }
+}

--- a/rust/cloud-storage/task_dedup/src/domain/document_similarity/test.rs
+++ b/rust/cloud-storage/task_dedup/src/domain/document_similarity/test.rs
@@ -1,0 +1,368 @@
+//! Service-level pipeline tests against in-memory mock dependencies.
+//!
+//! These exercise [`DocumentSimilarityService`] end to end without a database:
+//! the embedder, vector store, reranker, and name repo are all mocked here so
+//! the embed → upsert → retrieve → rerank → floor pipeline can be asserted in
+//! isolation.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use embedding::{
+    Content, Embeddable, EmbeddingModel, KeyedEmbedding, LabeledEmbedding, Match, RerankModel,
+    Reranked, SearchResults, VectorStore,
+};
+use uuid::Uuid;
+
+use super::{DocumentSimilarityConfig, DocumentSimilarityService, SimilarDocumentsQuery};
+use crate::EmbeddingMarkdown;
+use crate::domain::models::{DocumentSearchParameters, TaskDedupError};
+use crate::domain::ports::DocumentNameRepo;
+
+/// Small embedding width so mock vectors stay tiny.
+const DIMS: usize = 4;
+
+type MockService = DocumentSimilarityService<DIMS, MockEmbedder, MockVectorDb, MockReranker>;
+
+const USER: &str = "macro|user@user.com";
+const TEAM_ID: Uuid = uuid::uuid!("a0000000-0000-0000-0000-000000000001");
+const VIEWED_DOCUMENT: &str = "d1000000-0000-0000-0000-000000000001";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+/// Embedder that emits a zero vector per field exposed by the content.
+struct MockEmbedder;
+
+impl EmbeddingModel<DIMS> for MockEmbedder {
+    async fn embed(
+        &self,
+        content: &(dyn Embeddable + Sync),
+    ) -> anyhow::Result<Vec<LabeledEmbedding<'static, DIMS>>> {
+        Ok(content
+            .embedding_content()
+            .into_iter()
+            .map(|(search_key, text)| LabeledEmbedding {
+                search_key,
+                content: Content::Owned(text.into_owned()),
+                embedding: [0.0; DIMS],
+            })
+            .collect())
+    }
+}
+
+/// Vector store returning preset `(document_id, content, score)` candidates,
+/// each as a single-field [`SearchResults`]. Records upserts and the last
+/// search parameters so the pipeline can be asserted.
+#[derive(Clone, Default)]
+struct MockVectorDb {
+    inner: Arc<MockVectorDbInner>,
+}
+
+#[derive(Default)]
+struct MockVectorDbInner {
+    results: Vec<(String, String, f32)>,
+    upserted: Mutex<Vec<String>>,
+    last_params: Mutex<Option<DocumentSearchParameters>>,
+}
+
+impl MockVectorDb {
+    fn with_results(results: Vec<(&str, &str, f32)>) -> Self {
+        Self {
+            inner: Arc::new(MockVectorDbInner {
+                results: results
+                    .into_iter()
+                    .map(|(id, content, score)| (id.to_string(), content.to_string(), score))
+                    .collect(),
+                ..Default::default()
+            }),
+        }
+    }
+
+    fn upserted(&self) -> Vec<String> {
+        self.inner.upserted.lock().unwrap().clone()
+    }
+
+    fn last_params(&self) -> Option<DocumentSearchParameters> {
+        self.inner.last_params.lock().unwrap().clone()
+    }
+}
+
+impl VectorStore<DIMS> for MockVectorDb {
+    type Error = anyhow::Error;
+    type Metadata = String;
+    type SearchParameters = DocumentSearchParameters;
+
+    async fn upsert_embeddings<'a>(
+        &self,
+        metadata: String,
+        _embeddings: Vec<LabeledEmbedding<'a, DIMS>>,
+    ) -> anyhow::Result<()> {
+        self.inner.upserted.lock().unwrap().push(metadata);
+        Ok(())
+    }
+
+    async fn cosine_search(
+        &self,
+        _query: Vec<KeyedEmbedding<DIMS>>,
+        params: DocumentSearchParameters,
+    ) -> anyhow::Result<Vec<SearchResults<String, DIMS>>> {
+        *self.inner.last_params.lock().unwrap() = Some(params);
+        Ok(self
+            .inner
+            .results
+            .iter()
+            .map(|(id, content, score)| SearchResults {
+                metadata: id.clone(),
+                matches: vec![Match {
+                    score: *score,
+                    embedding: LabeledEmbedding {
+                        search_key: "title",
+                        content: Content::Owned(content.clone()),
+                        embedding: [0.0; DIMS],
+                    },
+                }],
+            })
+            .collect())
+    }
+}
+
+/// Reranker that scores candidates from a content→score map (default 0.0),
+/// returning them sorted by descending score.
+#[derive(Clone, Default)]
+struct MockReranker {
+    scores: Arc<HashMap<String, f64>>,
+}
+
+impl MockReranker {
+    fn new(scores: &[(&str, f64)]) -> Self {
+        Self {
+            scores: Arc::new(scores.iter().map(|(k, v)| (k.to_string(), *v)).collect()),
+        }
+    }
+}
+
+impl<const D: usize> RerankModel<D> for MockReranker {
+    async fn rerank<'a, T: Send>(
+        &self,
+        _query: Content<'a>,
+        candidates: Vec<SearchResults<T, D>>,
+    ) -> anyhow::Result<Vec<Reranked<T>>> {
+        let mut scored = candidates
+            .into_iter()
+            .map(|result| {
+                let content = result
+                    .matches
+                    .iter()
+                    .map(|matched| matched.embedding.content.as_ref())
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                let score = self.scores.get(&content).copied().unwrap_or(0.0) as f32;
+                Reranked {
+                    item: result.metadata,
+                    score,
+                }
+            })
+            .collect::<Vec<_>>();
+        scored.sort_by(|a, b| {
+            b.score
+                .partial_cmp(&a.score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+        Ok(scored)
+    }
+}
+
+/// Name repo backed by a fixed map; documents absent from the map are treated
+/// as deleted.
+#[derive(Default)]
+struct MockNames {
+    names: HashMap<String, String>,
+}
+
+impl MockNames {
+    fn new(names: &[(&str, &str)]) -> Self {
+        Self {
+            names: names
+                .iter()
+                .map(|(id, name)| (id.to_string(), name.to_string()))
+                .collect(),
+        }
+    }
+}
+
+#[async_trait]
+impl DocumentNameRepo for MockNames {
+    async fn document_names(
+        &self,
+        document_ids: &[String],
+    ) -> Result<HashMap<String, String>, TaskDedupError> {
+        Ok(document_ids
+            .iter()
+            .filter_map(|id| self.names.get(id).map(|name| (id.clone(), name.clone())))
+            .collect())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn service(vector_db: MockVectorDb, reranker: MockReranker, names: MockNames) -> MockService {
+    DocumentSimilarityService::new(MockEmbedder, vector_db, reranker, Arc::new(names))
+}
+
+fn query() -> SimilarDocumentsQuery {
+    SimilarDocumentsQuery {
+        document_id: VIEWED_DOCUMENT.to_string(),
+        user: USER.to_string(),
+        team_id: Some(TEAM_ID),
+        title: "Roadmap 2026".to_string(),
+        markdown: EmbeddingMarkdown::from_client_trusted(
+            "Plans for the next two quarters.".to_string(),
+        ),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn returns_results_in_rerank_order_with_names() {
+    let vector_db = MockVectorDb::with_results(vec![
+        ("doc-a", "quarterly planning", 0.9),
+        ("doc-b", "roadmap draft", 0.8),
+    ]);
+    let reranker = MockReranker::new(&[("quarterly planning", 0.3), ("roadmap draft", 0.7)]);
+    let names = MockNames::new(&[("doc-a", "Quarterly Planning"), ("doc-b", "Roadmap Draft")]);
+    let service = service(vector_db.clone(), reranker, names);
+
+    let results = service.similar_documents(query()).await.unwrap();
+
+    let ids: Vec<&str> = results
+        .iter()
+        .map(|result| result.document_id.as_str())
+        .collect();
+    assert_eq!(ids, vec!["doc-b", "doc-a"], "rerank order wins");
+    assert_eq!(results[0].document_name, "Roadmap Draft");
+    assert!((results[0].vector_score - 0.8).abs() < 1e-6);
+
+    // The viewed document was indexed and excluded from its own results.
+    assert_eq!(vector_db.upserted(), vec![VIEWED_DOCUMENT.to_string()]);
+    let params = vector_db.last_params().unwrap();
+    assert_eq!(params.exclude_document_id.as_deref(), Some(VIEWED_DOCUMENT));
+    assert_eq!(params.user, USER);
+    assert_eq!(params.team_id, Some(TEAM_ID));
+}
+
+#[tokio::test]
+async fn drops_results_below_the_rerank_floor() {
+    let vector_db = MockVectorDb::with_results(vec![
+        ("doc-a", "quarterly planning", 0.9),
+        ("doc-b", "grocery list", 0.6),
+    ]);
+    // The floor is 0.05; "grocery list" scores below it.
+    let reranker = MockReranker::new(&[("quarterly planning", 0.4), ("grocery list", 0.01)]);
+    let names = MockNames::new(&[("doc-a", "Quarterly Planning"), ("doc-b", "Grocery List")]);
+    let service = service(vector_db, reranker, names);
+
+    let results = service.similar_documents(query()).await.unwrap();
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].document_id, "doc-a");
+}
+
+#[tokio::test]
+async fn drops_results_below_the_vector_similarity_floor() {
+    // 0.2 is below the 0.35 vector floor, so it never reaches the reranker.
+    let vector_db = MockVectorDb::with_results(vec![("doc-a", "quarterly planning", 0.2)]);
+    let reranker = MockReranker::new(&[("quarterly planning", 0.9)]);
+    let names = MockNames::new(&[("doc-a", "Quarterly Planning")]);
+    let service = service(vector_db, reranker, names);
+
+    let results = service.similar_documents(query()).await.unwrap();
+
+    assert!(results.is_empty());
+}
+
+#[tokio::test]
+async fn drops_results_whose_document_was_deleted() {
+    let vector_db = MockVectorDb::with_results(vec![
+        ("doc-a", "quarterly planning", 0.9),
+        ("doc-gone", "old roadmap", 0.8),
+    ]);
+    let reranker = MockReranker::new(&[("quarterly planning", 0.5), ("old roadmap", 0.4)]);
+    // "doc-gone" has no name row: deleted between search and lookup.
+    let names = MockNames::new(&[("doc-a", "Quarterly Planning")]);
+    let service = service(vector_db, reranker, names);
+
+    let results = service.similar_documents(query()).await.unwrap();
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].document_id, "doc-a");
+}
+
+#[tokio::test]
+async fn embeds_nothing_and_searches_nothing_for_an_empty_document() {
+    let vector_db = MockVectorDb::with_results(vec![("doc-a", "quarterly planning", 0.9)]);
+    let reranker = MockReranker::default();
+    let names = MockNames::default();
+    let service = service(vector_db.clone(), reranker, names);
+
+    let mut empty = query();
+    empty.title = " ".to_string();
+    empty.markdown = EmbeddingMarkdown::from_client_trusted("\n".to_string());
+
+    let results = service.similar_documents(empty).await.unwrap();
+
+    assert!(results.is_empty());
+    assert!(vector_db.upserted().is_empty(), "no embedding to persist");
+    assert!(vector_db.last_params().is_none(), "no search should run");
+}
+
+#[tokio::test]
+async fn caps_results_at_the_configured_limit() {
+    let candidates: Vec<(String, String, f32)> = (0..15)
+        .map(|index| {
+            (
+                format!("doc-{index}"),
+                format!("content {index}"),
+                0.9_f32 - index as f32 * 0.01,
+            )
+        })
+        .collect();
+    let vector_db = MockVectorDb::with_results(
+        candidates
+            .iter()
+            .map(|(id, content, score)| (id.as_str(), content.as_str(), *score))
+            .collect(),
+    );
+    let scores: Vec<(String, f64)> = candidates
+        .iter()
+        .enumerate()
+        .map(|(index, (_, content, _))| (content.clone(), 1.0 - index as f64 * 0.01))
+        .collect();
+    let reranker = MockReranker::new(
+        &scores
+            .iter()
+            .map(|(content, score)| (content.as_str(), *score))
+            .collect::<Vec<_>>(),
+    );
+    let names = MockNames::new(
+        &candidates
+            .iter()
+            .map(|(id, _, _)| (id.as_str(), id.as_str()))
+            .collect::<Vec<_>>(),
+    );
+    let service = service(vector_db, reranker, names);
+
+    let results = service.similar_documents(query()).await.unwrap();
+
+    assert_eq!(
+        results.len(),
+        DocumentSimilarityConfig::default().result_limit as usize
+    );
+}

--- a/rust/cloud-storage/task_dedup/src/domain/mod.rs
+++ b/rust/cloud-storage/task_dedup/src/domain/mod.rs
@@ -1,5 +1,8 @@
-//! Domain model, ports, and service for task duplicate detection.
+//! Domain model, ports, and services for task duplicate detection and document
+//! similarity search.
 
+pub mod document_similarity;
 pub mod models;
 pub mod ports;
+pub(crate) mod retrieval;
 pub mod service;

--- a/rust/cloud-storage/task_dedup/src/domain/models.rs
+++ b/rust/cloud-storage/task_dedup/src/domain/models.rs
@@ -85,6 +85,40 @@ pub struct TaskSimilarityResult {
     pub vector_score: f64,
 }
 
+/// Filters applied to a document vector search.
+///
+/// This is the
+/// [`VectorStore::SearchParameters`](embedding::VectorStore::SearchParameters)
+/// for the document similarity store: it scopes a cosine search to the plain
+/// markdown documents a user can see (their own plus ones shared with them
+/// directly or through their team) and excludes the query document itself.
+#[derive(Debug, Clone)]
+pub struct DocumentSearchParameters {
+    /// User whose accessible documents are in scope.
+    pub user: String,
+    /// Team whose shared documents are also in scope, when set.
+    pub team_id: Option<Uuid>,
+    /// Maximum number of candidate documents to return.
+    pub limit: i64,
+    /// Document id to exclude from results (the query document itself), when
+    /// set.
+    pub exclude_document_id: Option<String>,
+}
+
+/// A similar existing document computed for the document a user is viewing,
+/// returned to the similar-documents surface without persisting any match
+/// state.
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SimilarDocument {
+    /// The matching existing document.
+    pub document_id: String,
+    /// The matching document's display name.
+    pub document_name: String,
+    /// Cosine similarity from vector search.
+    pub vector_score: f64,
+}
+
 /// Output from a duplicate judge.
 #[derive(Debug, Clone)]
 pub struct JudgeResult {

--- a/rust/cloud-storage/task_dedup/src/domain/ports.rs
+++ b/rust/cloud-storage/task_dedup/src/domain/ports.rs
@@ -84,6 +84,17 @@ pub trait TaskMatchRepo: Send + Sync {
     ) -> Result<HashMap<String, String>, TaskDedupError>;
 }
 
+/// Resolves display names for the documents surfaced by similarity search.
+#[async_trait]
+pub trait DocumentNameRepo: Send + Sync {
+    /// Returns the display name of each requested document, keyed by document
+    /// id. Missing or deleted documents are omitted.
+    async fn document_names(
+        &self,
+        document_ids: &[String],
+    ) -> Result<HashMap<String, String>, TaskDedupError>;
+}
+
 /// Sends live updates for documents whose duplicate state changed.
 #[async_trait]
 pub trait TaskDedupNotifier: Send + Sync {

--- a/rust/cloud-storage/task_dedup/src/domain/retrieval.rs
+++ b/rust/cloud-storage/task_dedup/src/domain/retrieval.rs
@@ -1,0 +1,100 @@
+//! Vector-retrieval helpers shared by task duplicate detection and document
+//! similarity search: collapsing per-field search results into scored
+//! candidates and reranking them against the query text.
+
+use std::collections::HashMap;
+
+use embedding::{Content, RerankModel, SearchResults};
+
+use super::models::TaskDedupError;
+
+/// A candidate entity surfaced by vector retrieval, collapsed from the
+/// per-field [`SearchResults`] into a single score and a reconstructed text
+/// used for reranking and judging.
+pub(crate) struct Candidate {
+    pub(crate) document_id: String,
+    /// The candidate's stored field contents joined back together.
+    pub(crate) content: String,
+    /// Best cosine similarity across the query × stored field cross-product.
+    pub(crate) vector_score: f64,
+}
+
+/// Collapses a single entity's per-field [`SearchResults`] into a
+/// [`Candidate`]: the vector score is the best similarity across the query ×
+/// stored-field cross-product, and the content is the entity's matched field
+/// texts joined back together for judging. Returns `None` when the entity
+/// falls below `min_vector_similarity`.
+pub(crate) fn collapse<const DIMS: usize>(
+    result: &SearchResults<String, DIMS>,
+    min_vector_similarity: f64,
+) -> Option<Candidate> {
+    let vector_score = result
+        .matches
+        .iter()
+        .map(|matched| matched.score as f64)
+        .fold(f64::NEG_INFINITY, f64::max);
+    if !vector_score.is_finite() || vector_score < min_vector_similarity {
+        return None;
+    }
+    let content = result
+        .matches
+        .iter()
+        .map(|matched| matched.embedding.content.as_ref())
+        .collect::<Vec<_>>()
+        .join("\n");
+    Some(Candidate {
+        document_id: result.metadata.clone(),
+        content,
+        vector_score,
+    })
+}
+
+/// Drops results below the similarity floor, reranks the survivors against
+/// `query`, and returns them as [`Candidate`]s (paired with their rerank
+/// score) ordered by descending relevance. The reranker only carries each
+/// result's `document_id` through, so the collapsed content and vector score
+/// are looked back up afterwards. An empty survivor set skips the reranker
+/// entirely.
+pub(crate) async fn rerank<const DIMS: usize, R>(
+    reranker: &R,
+    query: &str,
+    results: Vec<SearchResults<String, DIMS>>,
+    min_vector_similarity: f64,
+) -> Result<Vec<(Candidate, f32)>, TaskDedupError>
+where
+    R: RerankModel<DIMS> + Send + Sync,
+{
+    let mut lookup: HashMap<String, Candidate> = HashMap::new();
+    let mut survivors: Vec<SearchResults<String, DIMS>> = Vec::new();
+    for result in results {
+        let Some(candidate) = collapse(&result, min_vector_similarity) else {
+            continue;
+        };
+        lookup.insert(candidate.document_id.clone(), candidate);
+        survivors.push(result);
+    }
+
+    if survivors.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let reranked = reranker
+        .rerank(Content::Borrowed(query), survivors)
+        .await
+        .map_err(TaskDedupError::Dependency)?;
+
+    Ok(reranked
+        .into_iter()
+        .filter_map(|scored| {
+            lookup
+                .remove(&scored.item)
+                .map(|candidate| (candidate, scored.score))
+        })
+        .collect())
+}
+
+/// Builds the full entity text used as the rerank/judge query, joining the
+/// title and body the same way they read to a user.
+pub(crate) fn full_text(title: &str, markdown: &str) -> String {
+    format!("{}\n{}", title.trim(), markdown.trim())
+}

--- a/rust/cloud-storage/task_dedup/src/domain/service.rs
+++ b/rust/cloud-storage/task_dedup/src/domain/service.rs
@@ -4,11 +4,11 @@
 mod test;
 
 use std::borrow::Cow;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use embedding::entity::Task;
-use embedding::{Content, EmbeddingModel, KeyedEmbedding, RerankModel, SearchResults, VectorStore};
+use embedding::{EmbeddingModel, KeyedEmbedding, RerankModel, SearchResults, VectorStore};
 use futures::StreamExt;
 use lexical_client::parse_markdown::EmbeddingMarkdown;
 use uuid::Uuid;
@@ -17,6 +17,7 @@ use super::models::{
     JudgeResult, NewTask, TaskDedupError, TaskDuplicate, TaskSearchParameters, TaskSimilarityResult,
 };
 use super::ports::{TaskDedupNotifier, TaskDuplicateJudge, TaskMatchRepo};
+use super::retrieval::{self, Candidate, full_text};
 
 /// Configuration for the task duplicate detection pipeline.
 #[derive(Debug, Clone)]
@@ -58,17 +59,6 @@ impl Default for TaskDedupConfig {
             judge_concurrency: 4,
         }
     }
-}
-
-/// A candidate task surfaced by vector retrieval, collapsed from the per-field
-/// [`SearchResults`] into a single score and a reconstructed text used for
-/// reranking and judging.
-struct Candidate {
-    document_id: String,
-    /// The candidate's stored field contents joined back together.
-    content: String,
-    /// Best cosine similarity across the query × stored field cross-product.
-    vector_score: f64,
 }
 
 /// Task duplicate detection service.
@@ -399,72 +389,21 @@ where
         Ok(active_document_ids)
     }
 
-    /// Collapses a single entity's per-field [`SearchResults`] into a
-    /// [`Candidate`]: the vector score is the best similarity across the query ×
-    /// stored-field cross-product, and the content is the entity's matched field
-    /// texts joined back together for judging. Returns `None` when the entity
-    /// falls below the configured similarity floor.
-    fn collapse(&self, result: &SearchResults<String, DIMS>) -> Option<Candidate> {
-        let vector_score = result
-            .matches
-            .iter()
-            .map(|matched| matched.score as f64)
-            .fold(f64::NEG_INFINITY, f64::max);
-        if !vector_score.is_finite() || vector_score < self.config.min_vector_similarity {
-            return None;
-        }
-        let content = result
-            .matches
-            .iter()
-            .map(|matched| matched.embedding.content.as_ref())
-            .collect::<Vec<_>>()
-            .join("\n");
-        Some(Candidate {
-            document_id: result.metadata.clone(),
-            content,
-            vector_score,
-        })
-    }
-
     /// Drops results below the similarity floor, reranks the survivors against
     /// `query`, and returns them as [`Candidate`]s (paired with their rerank
-    /// score) ordered by descending relevance. The reranker only carries each
-    /// result's `document_id` through, so the collapsed content and vector score
-    /// are looked back up afterwards. An empty survivor set skips the reranker
-    /// entirely.
+    /// score) ordered by descending relevance. See [`retrieval::rerank`].
     async fn rerank(
         &self,
         query: &str,
         results: Vec<SearchResults<String, DIMS>>,
     ) -> Result<Vec<(Candidate, f32)>, TaskDedupError> {
-        let mut lookup: HashMap<String, Candidate> = HashMap::new();
-        let mut survivors: Vec<SearchResults<String, DIMS>> = Vec::new();
-        for result in results {
-            let Some(candidate) = self.collapse(&result) else {
-                continue;
-            };
-            lookup.insert(candidate.document_id.clone(), candidate);
-            survivors.push(result);
-        }
-
-        if survivors.is_empty() {
-            return Ok(Vec::new());
-        }
-
-        let reranked = self
-            .reranker
-            .rerank(Content::Borrowed(query), survivors)
-            .await
-            .map_err(TaskDedupError::Dependency)?;
-
-        Ok(reranked
-            .into_iter()
-            .filter_map(|scored| {
-                lookup
-                    .remove(&scored.item)
-                    .map(|candidate| (candidate, scored.score))
-            })
-            .collect())
+        retrieval::rerank(
+            &self.reranker,
+            query,
+            results,
+            self.config.min_vector_similarity,
+        )
+        .await
     }
 
     async fn notify_documents<I>(&self, document_ids: I)
@@ -509,12 +448,6 @@ where
         component.sort();
         Ok(component)
     }
-}
-
-/// Builds the full task text used as the rerank/judge query, joining the title
-/// and body the same way they read to a user.
-fn full_text(title: &str, markdown: &str) -> String {
-    format!("{}\n{}", title.trim(), markdown.trim())
 }
 
 /// Returns a stable ordered pair.

--- a/rust/cloud-storage/task_dedup/src/lib.rs
+++ b/rust/cloud-storage/task_dedup/src/lib.rs
@@ -1,10 +1,14 @@
 #![deny(missing_docs)]
-//! Task duplicate detection.
+//! Task duplicate detection and document similarity search.
 //!
 //! The crate keeps the duplicate-detection workflow behind ports so the judge,
 //! match persistence, and live-update transport can be swapped independently.
 //! Embedding, reranking, and vector storage are provided by the [`embedding`]
 //! crate's traits and injected as generic parameters into [`TaskDedupService`].
+//!
+//! [`DocumentSimilarityService`] reuses the same retrieval pipeline (embed →
+//! vector search → rerank) over a separate document embedding store to power
+//! the "similar documents" surface — no judge and no persisted match state.
 
 pub mod domain;
 pub mod eval;
@@ -12,8 +16,12 @@ pub mod outbound;
 
 use embedding::embedding_provider::openai::{DIMS, TextEmbedding3Small};
 
+pub use domain::document_similarity::{
+    DocumentSimilarityConfig, DocumentSimilarityService, SimilarDocumentsQuery,
+};
 pub use domain::models::{
-    JudgeResult, NewTask, TaskDedupError, TaskDuplicate, TaskSearchParameters, TaskSimilarityResult,
+    DocumentSearchParameters, JudgeResult, NewTask, SimilarDocument, TaskDedupError, TaskDuplicate,
+    TaskSearchParameters, TaskSimilarityResult,
 };
 pub use domain::service::{TaskDedupConfig, TaskDedupService};
 /// The embedding-format markdown newtype required by [`NewTask`] and
@@ -22,6 +30,7 @@ pub use domain::service::{TaskDedupConfig, TaskDedupService};
 /// client-trusted wrapper, so wrong-format bodies cannot reach the embedder.
 pub use lexical_client::parse_markdown::EmbeddingMarkdown;
 use outbound::cohere::CohereReranker;
+use outbound::document_postgres::PgDocumentVectorDb;
 use outbound::postgres::PgTaskVectorDb;
 
 /// The production task-dedup service: OpenAI `text-embedding-3-small` embeddings,
@@ -30,3 +39,11 @@ use outbound::postgres::PgTaskVectorDb;
 /// axum state and handler signatures.
 pub type PgTaskDedupService =
     TaskDedupService<DIMS, TextEmbedding3Small, PgTaskVectorDb, CohereReranker>;
+
+/// The production document-similarity service: the same OpenAI embeddings,
+/// Postgres/pgvector storage, and Cohere reranker as task dedup, over the
+/// document embedding store. Consumers depend on this concrete type so the
+/// generic [`DocumentSimilarityService`] parameters do not leak into axum
+/// state and handler signatures.
+pub type PgDocumentSimilarityService =
+    DocumentSimilarityService<DIMS, TextEmbedding3Small, PgDocumentVectorDb, CohereReranker>;

--- a/rust/cloud-storage/task_dedup/src/outbound/document_postgres.rs
+++ b/rust/cloud-storage/task_dedup/src/outbound/document_postgres.rs
@@ -1,0 +1,253 @@
+//! Postgres adapters for document similarity search.
+//!
+//! [`PgDocumentVectorDb`] implements the embedding crate's
+//! [`VectorStore`](embedding::VectorStore) over the
+//! `document_similarity_embedding` table (one row per `(document_id,
+//! search_key)` field) and doubles as the
+//! [`DocumentNameRepo`](crate::domain::ports::DocumentNameRepo) used to resolve
+//! result display names.
+
+#[cfg(test)]
+mod test;
+
+use std::collections::HashMap;
+
+use anyhow::Context;
+use async_trait::async_trait;
+use embedding::embedding_provider::openai::DIMS;
+use embedding::{Content, KeyedEmbedding, LabeledEmbedding, Match, SearchResults, VectorStore};
+use sqlx::PgPool;
+
+use crate::domain::models::{DocumentSearchParameters, TaskDedupError};
+use crate::domain::ports::DocumentNameRepo;
+
+use super::postgres::{parse_vector, search_key_static, vector_sql_literal};
+
+/// Postgres/pgvector implementation of [`VectorStore`] for document embeddings.
+///
+/// Each document contributes one row per embeddable field (`title`, `body`);
+/// the composite primary key `(document_id, search_key)` keeps them distinct.
+#[derive(Clone)]
+pub struct PgDocumentVectorDb {
+    pool: PgPool,
+}
+
+impl PgDocumentVectorDb {
+    /// Creates a store over `pool`.
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+impl VectorStore<DIMS> for PgDocumentVectorDb {
+    type Error = anyhow::Error;
+    type Metadata = String;
+    type SearchParameters = DocumentSearchParameters;
+
+    async fn upsert_embeddings<'a>(
+        &self,
+        metadata: String,
+        embeddings: Vec<LabeledEmbedding<'a, DIMS>>,
+    ) -> anyhow::Result<()> {
+        if embeddings.is_empty() {
+            return Ok(());
+        }
+
+        let search_keys: Vec<String> = embeddings
+            .iter()
+            .map(|field| field.search_key.to_string())
+            .collect();
+        let contents: Vec<String> = embeddings
+            .iter()
+            .map(|field| field.content.as_ref().to_string())
+            .collect();
+        let vectors: Vec<String> = embeddings
+            .iter()
+            .map(|field| vector_sql_literal(&field.embedding))
+            .collect();
+
+        sqlx::query!(
+            r#"
+            INSERT INTO document_similarity_embedding (document_id, search_key, content, embedding)
+            SELECT $1, sk, ct, emb::vector
+            FROM unnest($2::text[], $3::text[], $4::text[]) AS t(sk, ct, emb)
+            ON CONFLICT (document_id, search_key) DO UPDATE
+            SET content = EXCLUDED.content,
+                embedding = EXCLUDED.embedding,
+                updated_at = NOW()
+            "#,
+            metadata,
+            &search_keys,
+            &contents,
+            &vectors,
+        )
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    async fn cosine_search(
+        &self,
+        query: Vec<KeyedEmbedding<DIMS>>,
+        params: DocumentSearchParameters,
+    ) -> anyhow::Result<Vec<SearchResults<String, DIMS>>> {
+        if query.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let query_keys: Vec<String> = query.iter().map(|q| q.search_key.to_string()).collect();
+        let query_vectors: Vec<String> = query
+            .iter()
+            .map(|q| vector_sql_literal(&q.embedding))
+            .collect();
+        let team_id = params.team_id.map(|team_id| team_id.to_string());
+
+        // Each candidate field is scored by its best similarity to ANY query
+        // field, giving the full query × stored cross-product (title↔title,
+        // title↔body, body↔title, body↔body). Entities are ranked by their
+        // best field score and capped at `limit`; all of a kept entity's field
+        // rows are returned so the service can reconstruct its text.
+        //
+        // Scope: plain markdown documents (no `document_sub_type` row — tasks
+        // and snippets have their own surfaces) that the user owns or that are
+        // shared with them directly or through their team via `entity_access`.
+        // The `entity_access` join goes through `entity_id::text`, which is
+        // covered by `idx_entity_access_entity_text_type_source`.
+        //
+        // Iterative index scan keeps recall high despite the access and
+        // sub-type filters dropping rows after the HNSW scan. SET LOCAL binds
+        // to the transaction's connection, so the search must run in the same
+        // transaction to see it.
+        let mut tx = self.pool.begin().await?;
+        sqlx::query!("SET LOCAL hnsw.iterative_scan = relaxed_order")
+            .execute(&mut *tx)
+            .await?;
+        let rows = sqlx::query!(
+            r#"
+            WITH query AS (
+                SELECT key, vec::vector AS vec
+                FROM unnest($1::text[], $2::text[]) AS t(key, vec)
+            ),
+            scored AS (
+                SELECT
+                    e.document_id,
+                    e.search_key,
+                    e.content,
+                    e.embedding::text AS embedding_text,
+                    MAX(1 - (e.embedding <=> q.vec))::real AS score
+                FROM document_similarity_embedding e
+                JOIN "Document" d ON d.id = e.document_id
+                CROSS JOIN query q
+                WHERE d."deletedAt" IS NULL
+                  AND d."fileType" = 'md'
+                  AND NOT EXISTS (
+                    SELECT 1
+                    FROM document_sub_type dst
+                    WHERE dst.document_id = d.id
+                  )
+                  AND ($4::text IS NULL OR e.document_id <> $4)
+                  AND (
+                    d.owner = $3
+                    OR EXISTS (
+                        SELECT 1
+                        FROM entity_access ea
+                        WHERE ea.entity_id::text = e.document_id
+                          AND ea.entity_type = 'document'
+                          AND (
+                            (ea.source_type = 'user' AND ea.source_id = $3)
+                            OR (
+                                $5::text IS NOT NULL
+                                AND ea.source_type = 'team'
+                                AND ea.source_id = $5
+                            )
+                          )
+                    )
+                  )
+                GROUP BY e.document_id, e.search_key, e.content, e.embedding
+            ),
+            ranked AS (
+                SELECT document_id, MAX(score) AS best
+                FROM scored
+                GROUP BY document_id
+                ORDER BY best DESC
+                LIMIT $6
+            )
+            SELECT
+                s.document_id AS "document_id!",
+                s.search_key AS "search_key!",
+                s.content AS "content!",
+                s.embedding_text AS "embedding_text!",
+                s.score AS "score!"
+            FROM scored s
+            JOIN ranked r ON r.document_id = s.document_id
+            ORDER BY r.best DESC, s.document_id, s.score DESC
+            "#,
+            &query_keys,
+            &query_vectors,
+            params.user,
+            params.exclude_document_id,
+            team_id,
+            params.limit,
+        )
+        .fetch_all(&mut *tx)
+        .await?;
+        tx.commit().await?;
+
+        // Group the flat (document_id, field) rows into one SearchResults per
+        // entity, preserving the best-first order established by the query.
+        let mut results: Vec<SearchResults<String, DIMS>> = Vec::new();
+        for row in rows {
+            let Some(search_key) = search_key_static(&row.search_key) else {
+                tracing::warn!(
+                    search_key = %row.search_key,
+                    document_id = %row.document_id,
+                    "skipping document embedding row with unknown search_key"
+                );
+                continue;
+            };
+            let embedding = parse_vector(&row.embedding_text)
+                .with_context(|| format!("invalid stored embedding for {}", row.document_id))?;
+            let matched = Match {
+                score: row.score,
+                embedding: LabeledEmbedding {
+                    search_key,
+                    content: Content::Owned(row.content),
+                    embedding,
+                },
+            };
+            match results.last_mut() {
+                Some(last) if last.metadata == row.document_id => last.matches.push(matched),
+                _ => results.push(SearchResults {
+                    metadata: row.document_id,
+                    matches: vec![matched],
+                }),
+            }
+        }
+        Ok(results)
+    }
+}
+
+#[async_trait]
+impl DocumentNameRepo for PgDocumentVectorDb {
+    async fn document_names(
+        &self,
+        document_ids: &[String],
+    ) -> Result<HashMap<String, String>, TaskDedupError> {
+        if document_ids.is_empty() {
+            return Ok(HashMap::new());
+        }
+        let rows = sqlx::query!(
+            r#"
+            SELECT id, name
+            FROM "Document"
+            WHERE id = ANY($1)
+              AND "deletedAt" IS NULL
+            "#,
+            document_ids,
+        )
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows.into_iter().map(|row| (row.id, row.name)).collect())
+    }
+}

--- a/rust/cloud-storage/task_dedup/src/outbound/document_postgres/test.rs
+++ b/rust/cloud-storage/task_dedup/src/outbound/document_postgres/test.rs
@@ -1,0 +1,470 @@
+use std::sync::Arc;
+
+use embedding::embedding_provider::openai::DIMS;
+use embedding::{
+    Content, Embeddable, EmbeddingModel, KeyedEmbedding, LabeledEmbedding, RerankModel, Reranked,
+    SearchResults, VectorStore,
+};
+use macro_db_migrator::MACRO_DB_MIGRATIONS;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use super::*;
+use crate::EmbeddingMarkdown;
+use crate::domain::document_similarity::{DocumentSimilarityService, SimilarDocumentsQuery};
+use crate::domain::models::DocumentSearchParameters;
+use crate::outbound::postgres::vector_sql_literal;
+
+const OWNER: &str = "macro|user@user.com";
+const TEAMMATE: &str = "macro|teammate1@user.com";
+const TEAM_ID: Uuid = uuid::uuid!("a0000000-0000-0000-0000-000000000001");
+const DOC_ONE: &str = "d2000000-0000-0000-0000-000000000001";
+const DOC_TWO: &str = "d2000000-0000-0000-0000-000000000002";
+const DOC_THREE: &str = "d2000000-0000-0000-0000-000000000003";
+const DOC_OTHER: &str = "d2000000-0000-0000-0000-000000000004";
+
+type TestService = DocumentSimilarityService<DIMS, LocalEmbedder, PgDocumentVectorDb, NoOpReranker>;
+
+/// Test-only reranker that preserves the upstream vector-similarity ordering,
+/// carrying each candidate's best vector score through unchanged, so these
+/// tests exercise the store rather than a reranking model.
+#[derive(Clone, Copy)]
+struct NoOpReranker;
+
+impl<const D: usize> RerankModel<D> for NoOpReranker {
+    async fn rerank<'a, T: Send>(
+        &self,
+        _query: Content<'a>,
+        candidates: Vec<SearchResults<T, D>>,
+    ) -> anyhow::Result<Vec<Reranked<T>>> {
+        Ok(candidates
+            .into_iter()
+            .map(|result| {
+                let score = result
+                    .matches
+                    .iter()
+                    .map(|matched| matched.score)
+                    .fold(f32::NEG_INFINITY, f32::max);
+                Reranked {
+                    item: result.metadata,
+                    score,
+                }
+            })
+            .collect())
+    }
+}
+
+/// Deterministic, offline embedder so similarity logic can be exercised without
+/// calling OpenAI. Each field is embedded independently with
+/// [`local_embedding`].
+struct LocalEmbedder;
+
+impl EmbeddingModel<DIMS> for LocalEmbedder {
+    async fn embed(
+        &self,
+        content: &(dyn Embeddable + Sync),
+    ) -> anyhow::Result<Vec<LabeledEmbedding<'static, DIMS>>> {
+        Ok(content
+            .embedding_content()
+            .into_iter()
+            .map(|(search_key, text)| LabeledEmbedding {
+                search_key,
+                embedding: local_embedding(text.as_ref()),
+                content: Content::Owned(text.into_owned()),
+            })
+            .collect())
+    }
+}
+
+/// Deterministic local embedding used only by tests. Hashes each token into a
+/// fixed bucket so semantically identical inputs produce identical vectors,
+/// which is enough for the pgvector similarity tests.
+fn local_embedding(text: &str) -> [f32; DIMS] {
+    let mut vector = [0.0_f32; DIMS];
+    for token in text
+        .split(|ch: char| !ch.is_alphanumeric())
+        .map(str::to_lowercase)
+        .filter(|token| token.len() > 2)
+    {
+        let mut hash = 1469598103934665603_u64;
+        for byte in token.as_bytes() {
+            hash ^= u64::from(*byte);
+            hash = hash.wrapping_mul(1099511628211);
+        }
+        let idx = (hash as usize) % DIMS;
+        let sign = if hash & 1 == 0 { 1.0 } else { -1.0 };
+        vector[idx] += sign;
+    }
+
+    let norm = vector
+        .iter()
+        .map(|value| value * value)
+        .sum::<f32>()
+        .sqrt()
+        .max(1.0);
+    for value in &mut vector {
+        *value /= norm;
+    }
+    vector
+}
+
+fn service(pool: PgPool) -> TestService {
+    let vector_db = PgDocumentVectorDb::new(pool);
+    DocumentSimilarityService::new(
+        LocalEmbedder,
+        vector_db.clone(),
+        NoOpReranker,
+        Arc::new(vector_db),
+    )
+}
+
+async fn insert_document(pool: &PgPool, id: &str, name: &str, owner: &str) {
+    sqlx::query!(
+        r#"
+        INSERT INTO "Document" (id, name, "fileType", owner)
+        VALUES ($1, $2, 'md', $3)
+        "#,
+        id,
+        name,
+        owner,
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+async fn insert_task(pool: &PgPool, id: &str, name: &str, owner: &str) {
+    insert_document(pool, id, name, owner).await;
+    sqlx::query!(
+        r#"
+        INSERT INTO document_sub_type (document_id, sub_type)
+        VALUES ($1, 'task')
+        "#,
+        id,
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+/// Grants `source_id` view access on a document through `entity_access`, the
+/// way document sharing stores direct and team grants.
+async fn grant_access(pool: &PgPool, document_id: &str, source_id: &str, source_type: &str) {
+    sqlx::query(
+        r#"
+        INSERT INTO entity_access (entity_id, entity_type, source_id, source_type, access_level)
+        VALUES ($1::uuid, 'document', $2, $3::entity_access_source_type, 'view')
+        "#,
+    )
+    .bind(document_id)
+    .bind(source_id)
+    .bind(source_type)
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+/// Seeds the two per-field embeddings (`title`, `body`) a document would have
+/// after the live pipeline embedded it.
+async fn insert_document_embedding(pool: &PgPool, document_id: &str, title: &str, body: &str) {
+    for (search_key, text) in [("title", title), ("body", body)] {
+        let embedding = vector_sql_literal(&local_embedding(text));
+        sqlx::query!(
+            r#"
+            INSERT INTO document_similarity_embedding (document_id, search_key, content, embedding)
+            VALUES ($1, $2, $3, $4::text::vector)
+            "#,
+            document_id,
+            search_key,
+            text,
+            embedding,
+        )
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+}
+
+const ROADMAP_TITLE: &str = "Roadmap for embedding search";
+const ROADMAP_BODY: &str = "Ship pgvector embedding retrieval across document surfaces.";
+
+fn roadmap_query(document_id: &str, team_id: Option<Uuid>) -> SimilarDocumentsQuery {
+    SimilarDocumentsQuery {
+        document_id: document_id.to_string(),
+        user: OWNER.to_string(),
+        team_id,
+        title: ROADMAP_TITLE.to_string(),
+        markdown: EmbeddingMarkdown::from_client_trusted(ROADMAP_BODY.to_string()),
+    }
+}
+
+fn search_params(
+    user: &str,
+    team_id: Option<Uuid>,
+    exclude: Option<&str>,
+) -> DocumentSearchParameters {
+    DocumentSearchParameters {
+        user: user.to_string(),
+        team_id,
+        limit: 10,
+        exclude_document_id: exclude.map(str::to_string),
+    }
+}
+
+fn roadmap_search_query() -> Vec<KeyedEmbedding<DIMS>> {
+    vec![
+        KeyedEmbedding {
+            search_key: "title",
+            embedding: local_embedding(ROADMAP_TITLE),
+        },
+        KeyedEmbedding {
+            search_key: "body",
+            embedding: local_embedding(ROADMAP_BODY),
+        },
+    ]
+}
+
+fn result_ids(results: &[SearchResults<String, DIMS>]) -> Vec<&str> {
+    results
+        .iter()
+        .map(|result| result.metadata.as_str())
+        .collect()
+}
+
+#[sqlx::test(
+    migrator = "MACRO_DB_MIGRATIONS",
+    fixtures(
+        path = "../../../../documents/fixtures",
+        scripts("documents_test_data")
+    )
+)]
+async fn upsert_embeddings_inserts_and_updates(pool: PgPool) {
+    insert_document(&pool, DOC_ONE, "Roadmap", OWNER).await;
+    let vector_db = PgDocumentVectorDb::new(pool.clone());
+
+    vector_db
+        .upsert_embeddings(
+            DOC_ONE.to_string(),
+            vec![LabeledEmbedding {
+                search_key: "title",
+                content: Content::Owned("first title".to_string()),
+                embedding: local_embedding("first title"),
+            }],
+        )
+        .await
+        .unwrap();
+
+    // Upserting the same field again replaces the stored content.
+    vector_db
+        .upsert_embeddings(
+            DOC_ONE.to_string(),
+            vec![LabeledEmbedding {
+                search_key: "title",
+                content: Content::Owned("second title".to_string()),
+                embedding: local_embedding("second title"),
+            }],
+        )
+        .await
+        .unwrap();
+
+    let rows = sqlx::query!(
+        r#"
+        SELECT search_key, content
+        FROM document_similarity_embedding
+        WHERE document_id = $1
+        ORDER BY search_key
+        "#,
+        DOC_ONE,
+    )
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].search_key, "title");
+    assert_eq!(rows[0].content, "second title");
+}
+
+#[sqlx::test(
+    migrator = "MACRO_DB_MIGRATIONS",
+    fixtures(
+        path = "../../../../documents/fixtures",
+        scripts("documents_test_data")
+    )
+)]
+async fn cosine_search_scopes_to_own_shared_and_team_documents(pool: PgPool) {
+    // The user's own document.
+    insert_document(&pool, DOC_ONE, "Embedding roadmap", OWNER).await;
+    insert_document_embedding(&pool, DOC_ONE, ROADMAP_TITLE, ROADMAP_BODY).await;
+
+    // A teammate's documents: one unshared, one shared with the user directly,
+    // one shared with the team.
+    insert_document(&pool, DOC_TWO, "Private teammate doc", TEAMMATE).await;
+    insert_document_embedding(&pool, DOC_TWO, ROADMAP_TITLE, ROADMAP_BODY).await;
+
+    insert_document(&pool, DOC_THREE, "Directly shared doc", TEAMMATE).await;
+    insert_document_embedding(&pool, DOC_THREE, ROADMAP_TITLE, ROADMAP_BODY).await;
+    grant_access(&pool, DOC_THREE, OWNER, "user").await;
+
+    insert_document(&pool, DOC_OTHER, "Team shared doc", TEAMMATE).await;
+    insert_document_embedding(&pool, DOC_OTHER, ROADMAP_TITLE, ROADMAP_BODY).await;
+    grant_access(&pool, DOC_OTHER, &TEAM_ID.to_string(), "team").await;
+
+    let vector_db = PgDocumentVectorDb::new(pool);
+
+    let results = vector_db
+        .cosine_search(
+            roadmap_search_query(),
+            search_params(OWNER, Some(TEAM_ID), None),
+        )
+        .await
+        .unwrap();
+    let mut ids = result_ids(&results);
+    ids.sort();
+    assert_eq!(
+        ids,
+        vec![DOC_ONE, DOC_THREE, DOC_OTHER],
+        "own + direct-share + team-share are in scope; unshared teammate doc is not"
+    );
+
+    // Without a team, the team-shared document falls out of scope.
+    let results = vector_db
+        .cosine_search(roadmap_search_query(), search_params(OWNER, None, None))
+        .await
+        .unwrap();
+    let mut ids = result_ids(&results);
+    ids.sort();
+    assert_eq!(ids, vec![DOC_ONE, DOC_THREE]);
+}
+
+#[sqlx::test(
+    migrator = "MACRO_DB_MIGRATIONS",
+    fixtures(
+        path = "../../../../documents/fixtures",
+        scripts("documents_test_data")
+    )
+)]
+async fn cosine_search_excludes_self_tasks_and_deleted_documents(pool: PgPool) {
+    insert_document(&pool, DOC_ONE, "Embedding roadmap", OWNER).await;
+    insert_document_embedding(&pool, DOC_ONE, ROADMAP_TITLE, ROADMAP_BODY).await;
+
+    // A task with identical content: excluded because tasks have their own
+    // duplicate surface.
+    insert_task(&pool, DOC_TWO, "Embedding roadmap task", OWNER).await;
+    insert_document_embedding(&pool, DOC_TWO, ROADMAP_TITLE, ROADMAP_BODY).await;
+
+    // A deleted document with identical content.
+    insert_document(&pool, DOC_THREE, "Deleted roadmap", OWNER).await;
+    insert_document_embedding(&pool, DOC_THREE, ROADMAP_TITLE, ROADMAP_BODY).await;
+    sqlx::query!(
+        r#"UPDATE "Document" SET "deletedAt" = NOW() WHERE id = $1"#,
+        DOC_THREE,
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let vector_db = PgDocumentVectorDb::new(pool);
+
+    // Searching from DOC_ONE excludes the query document itself, the task, and
+    // the deleted document.
+    let results = vector_db
+        .cosine_search(
+            roadmap_search_query(),
+            search_params(OWNER, None, Some(DOC_ONE)),
+        )
+        .await
+        .unwrap();
+    assert!(result_ids(&results).is_empty());
+
+    // Without the self-exclusion the owned live document comes back.
+    let results = vector_db
+        .cosine_search(roadmap_search_query(), search_params(OWNER, None, None))
+        .await
+        .unwrap();
+    assert_eq!(result_ids(&results), vec![DOC_ONE]);
+}
+
+#[sqlx::test(
+    migrator = "MACRO_DB_MIGRATIONS",
+    fixtures(
+        path = "../../../../documents/fixtures",
+        scripts("documents_test_data")
+    )
+)]
+async fn document_names_resolves_live_documents_only(pool: PgPool) {
+    insert_document(&pool, DOC_ONE, "Embedding roadmap", OWNER).await;
+    insert_document(&pool, DOC_TWO, "Deleted doc", OWNER).await;
+    sqlx::query!(
+        r#"UPDATE "Document" SET "deletedAt" = NOW() WHERE id = $1"#,
+        DOC_TWO,
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let repo = PgDocumentVectorDb::new(pool);
+    let names = repo
+        .document_names(&[DOC_ONE.to_string(), DOC_TWO.to_string()])
+        .await
+        .unwrap();
+
+    assert_eq!(names.len(), 1);
+    assert_eq!(
+        names.get(DOC_ONE).map(String::as_str),
+        Some("Embedding roadmap")
+    );
+}
+
+#[sqlx::test(
+    migrator = "MACRO_DB_MIGRATIONS",
+    fixtures(
+        path = "../../../../documents/fixtures",
+        scripts("documents_test_data")
+    )
+)]
+async fn similar_documents_indexes_the_viewed_document_and_returns_matches(pool: PgPool) {
+    // An existing similar document and an unrelated one.
+    insert_document(&pool, DOC_TWO, "Embedding retrieval plan", OWNER).await;
+    insert_document_embedding(
+        &pool,
+        DOC_TWO,
+        "Embedding retrieval plan",
+        "Ship pgvector embedding retrieval across document surfaces.",
+    )
+    .await;
+    insert_document(&pool, DOC_THREE, "Grocery list", OWNER).await;
+    insert_document_embedding(&pool, DOC_THREE, "Grocery list", "eggs milk bread butter").await;
+
+    // The viewed document exists but has no embedding yet.
+    insert_document(&pool, DOC_ONE, ROADMAP_TITLE, OWNER).await;
+
+    let service = service(pool.clone());
+    let results = service
+        .similar_documents(roadmap_query(DOC_ONE, Some(TEAM_ID)))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        results.len(),
+        1,
+        "only the related document clears the floor"
+    );
+    assert_eq!(results[0].document_id, DOC_TWO);
+    assert_eq!(results[0].document_name, "Embedding retrieval plan");
+
+    // Viewing the document indexed it, so it is now retrievable from the
+    // other document's perspective.
+    let embedded = sqlx::query_scalar!(
+        r#"
+        SELECT COUNT(*) AS "count!"
+        FROM document_similarity_embedding
+        WHERE document_id = $1
+        "#,
+        DOC_ONE,
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(embedded, 2, "title and body rows were upserted");
+}

--- a/rust/cloud-storage/task_dedup/src/outbound/mod.rs
+++ b/rust/cloud-storage/task_dedup/src/outbound/mod.rs
@@ -1,6 +1,8 @@
-//! Outbound adapters for task duplicate detection.
+//! Outbound adapters for task duplicate detection and document similarity
+//! search.
 
 pub mod cohere;
 pub mod connection_gateway;
+pub mod document_postgres;
 pub mod judge;
 pub mod postgres;

--- a/rust/cloud-storage/task_dedup/src/outbound/postgres.rs
+++ b/rust/cloud-storage/task_dedup/src/outbound/postgres.rs
@@ -527,7 +527,7 @@ pub fn vector_sql_literal(embedding: &[f32]) -> String {
 }
 
 /// Parses a pgvector text literal (`[a,b,c]`) back into a fixed-size embedding.
-fn parse_vector(text: &str) -> anyhow::Result<[f32; DIMS]> {
+pub(crate) fn parse_vector(text: &str) -> anyhow::Result<[f32; DIMS]> {
     let inner = text.trim().trim_start_matches('[').trim_end_matches(']');
     let mut embedding = [0.0_f32; DIMS];
     let mut count = 0usize;
@@ -557,7 +557,7 @@ fn parse_vector(text: &str) -> anyhow::Result<[f32; DIMS]> {
 /// build, or bad data). Callers skip those rows rather than leaking the string
 /// into `'static`, which would grow the heap permanently on a mixed-version
 /// rollout.
-fn search_key_static(key: &str) -> Option<&'static str> {
+pub(crate) fn search_key_static(key: &str) -> Option<&'static str> {
     match key {
         "title" => Some("title"),
         "body" => Some("body"),


### PR DESCRIPTION
## Summary
Implements a "similar documents" feature that surfaces existing markdown documents related to the one being viewed, using the same embedding-based retrieval pipeline as task duplicate detection but over a separate document embedding store.

## Key Changes

### Backend (Rust)
- **New domain service**: `DocumentSimilarityService` in `task_dedup/src/domain/document_similarity.rs` that reuses the embed → vector search → rerank pipeline for documents
- **Postgres adapter**: `PgDocumentVectorDb` implementing `VectorStore` trait over the new `document_similarity_embedding` pgvector table, with per-field (title/body) embeddings
- **Database migration**: Creates `document_similarity_embedding` table with composite key `(document_id, search_key)` and pgvector column for embeddings
- **Backfill tool**: `backfill_document_embeddings` binary to populate embeddings for existing documents, mirroring the task backfill utility
- **HTTP endpoint**: `GET /documents/{document_id}/similar_documents` in the documents service that returns ranked similar documents
- **Shared retrieval logic**: Extracted common candidate collapsing and reranking logic into `task_dedup/src/domain/retrieval.rs` for reuse between task and document similarity
- **Document embedding**: Added `Document` struct implementing `Embeddable` trait for title and body fields
- **Comprehensive tests**: Service-level tests with mocks and integration tests against real Postgres with pgvector

### Frontend (TypeScript/SolidJS)
- **React component**: `SimilarDocumentsSidePanelSection` that displays similar documents in a collapsible side panel
- **Query hook**: `useSimilarDocumentsQuery` for fetching similar documents with caching
- **Feature flag**: `ENABLE_SIMILAR_DOCUMENTS_FLAG` to control rollout
- **Type definitions**: Added `SimilarDocument` and `SimilarDocumentsResponse` types to the storage service client

## Implementation Details

- **Access control**: Results are scoped to documents the user owns or that are shared with them directly or through their team via `entity_access`
- **Scope filtering**: Only plain markdown documents are included (excludes tasks and snippets which have their own surfaces)
- **Self-exclusion**: The query document itself is automatically excluded from results
- **Deterministic testing**: Local embedder and no-op reranker for tests enable reproducible similarity testing without external API calls
- **Configuration**: Tunable limits for vector candidates (24), result limit (10), minimum vector similarity (0.35), and rerank score floor (0.05)
- **Lazy indexing**: The corpus is backfilled initially but kept current through view-time embedding refreshes

https://claude.ai/code/session_01KBqz8WPmYpfCUEK8jzzfNn