### PR TITLE
feat(email): show "Connect another email" when one inbox is linked

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/inbox-selector.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/inbox-selector.tsx
@@ -91,6 +91,7 @@ export function InboxSelector() {
       size="sm"
       depth={2}
       aria-label={buttonProps.hideLabel ? 'Connect another email' : undefined}
+      tooltip={buttonProps.hideLabel ? 'Connect another email' : undefined}
       class={cn('bg-surface gap-1', buttonProps.hideLabel && 'px-1')}
       onClick={startAddInboxFlow}
     >

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/inbox-selector.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/inbox-selector.tsx
@@ -16,9 +16,11 @@ import { SearchableMultiSelect } from './searchable-multi-select';
 /**
  * Scopes the list to a subset of the user's linked inboxes. Multi-select,
  * default = all (no clause). Shown whenever the multi-inbox flag is on (or
- * the user already has multiple inboxes) so the "Add inbox" action row is
- * discoverable even with zero or one inbox connected. Selection is held in
- * soup-view's `inboxFilter` and compiled into `Owner` email literals.
+ * the user already has multiple inboxes). With exactly one inbox connected
+ * there is nothing to filter, so the dropdown is replaced by a "Connect
+ * another email" button that jumps straight into the add-inbox flow.
+ * Selection is held in soup-view's `inboxFilter` and compiled into `Owner`
+ * email literals.
  */
 export function InboxSelector() {
   const { inboxFilter, setInboxFilter } = useSoupView();
@@ -30,6 +32,11 @@ export function InboxSelector() {
     enabledOverride: ENABLE_MULTI_INBOX_OVERRIDE,
   });
   const { openSettings } = useSettingsState();
+
+  const startAddInboxFlow = () => {
+    openSettings('Connected');
+    openAddInboxDialog();
+  };
 
   const label = () => {
     const ids = inboxFilter();
@@ -53,10 +60,7 @@ export function InboxSelector() {
           ? {
               label: 'Add inbox',
               icon: () => <PlusIcon class="size-4" />,
-              onSelect: () => {
-                openSettings('Connected');
-                openAddInboxDialog();
-              },
+              onSelect: startAddInboxFlow,
             }
           : undefined
       }
@@ -81,14 +85,41 @@ export function InboxSelector() {
     </SearchableMultiSelect>
   );
 
+  const ConnectAnotherEmail = (buttonProps: { hideLabel?: boolean }) => (
+    <Button
+      variant="base"
+      size="sm"
+      depth={2}
+      aria-label={buttonProps.hideLabel ? 'Connect another email' : undefined}
+      class={cn('bg-surface gap-1', buttonProps.hideLabel && 'px-1')}
+      onClick={startAddInboxFlow}
+    >
+      <TrayIcon />
+      <Show when={!buttonProps.hideLabel}>
+        <span class="truncate">Connect another email</span>
+      </Show>
+    </Button>
+  );
+
+  const showConnectButton = () =>
+    multiInboxFlag().enabled && picker.options().length === 1;
+
   return (
     <Show when={multiInboxFlag().enabled || picker.hasMultiple()}>
       <CollapsibleHeaderItem
         id="inbox-selector"
         priority={3}
         containerClass="h-full"
-        expanded={() => <Selector />}
-        collapsed={() => <Selector hideLabel />}
+        expanded={() => (
+          <Show when={showConnectButton()} fallback={<Selector />}>
+            <ConnectAnotherEmail />
+          </Show>
+        )}
+        collapsed={() => (
+          <Show when={showConnectButton()} fallback={<Selector hideLabel />}>
+            <ConnectAnotherEmail hideLabel />
+          </Show>
+        )}
       />
     </Show>
   );


### PR DESCRIPTION
## Summary

In the email tab's top bar, the inbox dropdown has nothing to filter when only one email account is connected. This PR replaces the dropdown in that state with a **"Connect another email"** button (tray/inbox icon) that jumps straight into the existing add-inbox flow (`openSettings('Connected')` + `openAddInboxDialog()`).

Behavior by state (multi-inbox flag on):
- **1 inbox connected** → "Connect another email" button instead of the dropdown
- **0 inboxes** → dropdown unchanged (keeps the "Add inbox" action row discoverable)
- **2+ inboxes** → dropdown unchanged

With the flag off, behavior is unchanged. The button keeps the `CollapsibleHeaderItem` responsive treatment: icon-only with an `aria-label` when the header collapses, matching the dropdown trigger's styling (`variant="base" size="sm" depth={2}`).

## Changes

- `js/app/packages/app/component/next-soup/soup-view/filters-bar/inbox-selector.tsx`: add the `ConnectAnotherEmail` button and the `showConnectButton` condition (flag enabled && exactly one linked inbox); extract the shared `startAddInboxFlow` helper reused by the dropdown's "Add inbox" action.

## Testing

- `tsc --noEmit` on the app project: no errors in changed code (pre-existing failures only in `block-pdf`/`tauri` packages, caused by private git deps not installable in this environment — unrelated to this change)
- `biome check` on the changed file: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JXwdaq9DEx3sYQtMZ4oDFt

---
_Generated by [Claude Code](https://claude.ai/code/session_01JXwdaq9DEx3sYQtMZ4oDFt)_