### PR TITLE
fix(discussion): blur delete button to prevent scroll jump

### DIFF
--- a/js/app/packages/core/comments/discussion/Discussion.tsx
+++ b/js/app/packages/core/comments/discussion/Discussion.tsx
@@ -148,7 +148,12 @@ export function DiscussionThreadView(props: { thread: ViewThread }) {
         : undefined,
       onDelete:
         own && canEdit()
-          ? async () => {
+          ? async ({ event }) => {
+              // The delete button is still focused when it's removed from the
+              // DOM after the comment unmounts, which makes the browser reset
+              // the nearest scroll container to the top. Blurring first keeps
+              // deletion from disturbing scroll position.
+              (event?.currentTarget as HTMLElement | null)?.blur();
               await source.deleteComment(comment);
             }
           : undefined,


### PR DESCRIPTION
## What

Deleting a reply in a task's Discussion section scrolled the whole task view back to the top. Sending a new reply doesn't have this problem.

## Why

The delete button in `Message/ActionMenu.tsx` is always mounted (only hidden via `group-hover` CSS), so a real click leaves it focused. `Discussion.tsx`'s `onDelete` handler awaits `source.deleteComment(comment)`, which removes the comment — and the still-focused delete button — from the DOM. Removing the focused element from the document makes the browser reset the nearest scrollable ancestor's scroll position to the top.

Sending doesn't repro this because the Send button gets `disabled` (which synchronously blurs it) before the async send resolves and the composer unmounts, so nothing focused is being removed from the DOM at that point.

## Fix

Blur the triggering element synchronously before awaiting the delete, in `Discussion.tsx`'s `makeActions().onDelete`.

## Prioritization

Picked up by the review-incoming-work routine: a user-reported bug ("sending message on task scrolls u to top" / "interestingly sending a message doesnt scroll me up but deleting does") with a filed-but-unstarted task and no PR in progress. One-line, localized fix using the same implicit blur-before-unmount pattern the Send button already benefits from.

MACRO-cBKSLLb1nr1YxmXMQpvTd

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01K4gnMoPtrQ8uMv6ezXBdBH)_