### PR TITLE
fix(notifications): open GitHub PR notifications in-app on mobile

### DIFF
--- a/js/app/packages/notifications/notification-navigation.ts
+++ b/js/app/packages/notifications/notification-navigation.ts
@@ -11,6 +11,7 @@ import {
   itemToBlockName,
   resolveBlockAlias,
 } from '@core/constant/allBlocks';
+import { USE_MACRO_PR_SUMMARY_BLOCK } from '@core/constant/featureFlags';
 import type { NotificationType } from '@core/types';
 import { openExternalUrl } from '@core/util/url';
 import { getNotificationById } from '@queries/notification/user-notifications';
@@ -251,8 +252,12 @@ function getSupportedHandler(
       ) {
         return null;
       }
-      return async () => {
-        // TODO(dev-rb/github): Route GitHub PR notifications to /pr.
+      return async (lm: SplitManager, newSplit: boolean = false) => {
+        if (USE_MACRO_PR_SUMMARY_BLOCK) {
+          openSplitIfNotOpen(lm, 'pr', notification.entity_id, { newSplit });
+          return;
+        }
+
         let url = meta.content.url;
         if (meta.tag === 'github_pr_check_run') {
           url = meta.content.checkUrl || meta.content.url;


### PR DESCRIPTION
## What

On mobile, tapping a GitHub PR row in the Inbox did nothing — the PR never opened.

## Why

Mobile Inbox rows render through the notification stack and click through to `getSupportedHandler` in `notification-navigation.ts`. Every other notification type opens in-app via `openSplitIfNotOpen`, but the GitHub PR branch still called `openExternalUrl` (`window.open(url, '_blank')`) — left over from before in-app PR viewing existed (note the `TODO(dev-rb/github): Route GitHub PR notifications to /pr.` it carried). Mobile browsers/PWAs frequently no-op a `window.open('_blank')` silently due to stricter user-activation/tab rules, which produces exactly this symptom. Desktop's primary GitHub PR click path (`openEntityInSplitFromUnifiedList` in `next-soup/utils.ts`) already opens PRs in-app via the `pr` split type when `USE_MACRO_PR_SUMMARY_BLOCK` is enabled (on by default) — this path just never matched it.

## Fix

Route the GitHub notification handler through `openSplitIfNotOpen(lm, 'pr', notification.entity_id, { newSplit })` when `USE_MACRO_PR_SUMMARY_BLOCK` is on, falling back to `openExternalUrl` otherwise — matching the desktop behavior.

## Prioritization

Picked up by the review-incoming-work routine: a fresh, concrete user report ("Clicking GitHub PRs in Inbox on mobile doesn't do anything") with no task or PR yet covering it, and a small, well-scoped fix following an established pattern already used elsewhere in the same file.

MACRO-cBKSM5z2RYbaGqmziGDjC

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01K4gnMoPtrQ8uMv6ezXBdBH)_