### PR TITLE
chore(ci): infra checks on linux-small — biome + tsc don't need mid

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -5,6 +5,7 @@ self-hosted-runner:
     - namespace-profile-linux-mid
     - namespace-profile-linux-mid;overrides.cache-tag=web-ci
     - namespace-profile-linux-small
+    - namespace-profile-linux-small;overrides.cache-tag=web-ci
     - namespace-profile-linux-tiny-no-cache
     - namespace-profile-linux-rust-ci
     - namespace-profile-linux-rust-ci;overrides.cache-tag=sccache-ci

--- a/.github/workflows/code_check_infra.yml
+++ b/.github/workflows/code_check_infra.yml
@@ -34,7 +34,7 @@ jobs:
     - path-check
     if: needs.path-check.outputs.should_run == 'true' && github.event.pull_request.draft == false
     name: Biome Check
-    runs-on: namespace-profile-linux-mid;overrides.cache-tag=web-ci
+    runs-on: namespace-profile-linux-small;overrides.cache-tag=web-ci
     steps:
     - name: Checkout Repo
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
@@ -59,7 +59,7 @@ jobs:
     needs:
     - path-check
     if: needs.path-check.outputs.should_run == 'true' && github.event.pull_request.draft == false
-    runs-on: namespace-profile-linux-mid;overrides.cache-tag=web-ci
+    runs-on: namespace-profile-linux-small;overrides.cache-tag=web-ci
     steps:
     - name: Checkout Repo
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10

--- a/rust/cloud-storage/tools/xtask/src/workflows/code_check_infra.rs
+++ b/rust/cloud-storage/tools/xtask/src/workflows/code_check_infra.rs
@@ -15,10 +15,12 @@ use crate::workflows::{
 };
 
 /// The infra checks need the same cache content as the web checks (Nix
-/// dev-shell closure + bun cache), so they share the `web-ci` volume — infra
-/// PRs are far rarer than js/app PRs, so the added churn is negligible.
+/// dev-shell closure + bun cache), so they share the `web-ci` volume — cache
+/// volumes are keyed workspace-wide by tag, so `small` mounts the exact same
+/// volume the web checks keep warm on `mid`. biome + tsc over infra/ are
+/// light; they don't need a mid-size machine.
 fn infra_runner() -> String {
-    runners::Runner::Mid.with_cache_tag(vars::WEB_CI_CACHE_TAG)
+    runners::Runner::Small.with_cache_tag(vars::WEB_CI_CACHE_TAG)
 }
 
 /// Build the workflow.


### PR DESCRIPTION
Follow-up to #4503: the infra check jobs (biome + `bun run check`) are light — they don't need a mid-size machine.

- `biome-check` + `check`: `namespace-profile-linux-mid;overrides.cache-tag=web-ci` → `namespace-profile-linux-small;overrides.cache-tag=web-ci`
- Cache behavior is unchanged: volumes are keyed workspace-wide by **tag**, so `small` with the `web-ci` override mounts the exact same volume the web app checks keep warm on `mid`.
- Adds the new label combination to `actionlint.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)