### PR TITLE
fix: default sidebar to expanded for new desktop users

### DIFF
--- a/js/app/packages/app/component/Layout.tsx
+++ b/js/app/packages/app/component/Layout.tsx
@@ -64,7 +64,7 @@ const AUTH_URLS = [
 ];
 
 const [sidebarState, setSidebarState] = makePersisted(
-  createSignal<SidebarState>(!isMobile() ? 'slim' : 'hidden'),
+  createSignal<SidebarState>(!isMobile() ? 'expanded' : 'hidden'),
   {
     name: 'sidebar-state',
   }


### PR DESCRIPTION
## Summary

New users were seeing the icon-only collapsed ("slim") sidebar on first load. The persisted `sidebar-state` signal in `js/app/packages/app/component/Layout.tsx` initialized to `'slim'` on desktop, and `makePersisted` only uses that initial value when nothing is in localStorage yet — i.e., exactly the fresh-signup case.

## Change

- Desktop default sidebar state changed from `'slim'` to `'expanded'` (mobile stays `'hidden'`).
- Existing users are unaffected: their persisted preference always wins over the default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pa2Ls4xkpn5egV77GWDCCH

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pa2Ls4xkpn5egV77GWDCCH)_