### PR TITLE
feat(sidebar): show unread message preview on hover in Unread widget

### DIFF
--- a/js/app/packages/app/component/app-sidebar/channels-unread-widget.tsx
+++ b/js/app/packages/app/component/app-sidebar/channels-unread-widget.tsx
@@ -1,22 +1,24 @@
 import type { SidebarState } from '@app/component/app-sidebar/sidebar';
 import { useSenderName } from '@app/component/app-sidebar/utils';
-import { useGlobalNotificationSource } from '@app/component/GlobalAppState';
+import {
+  useGlobalBlockOrchestrator,
+  useGlobalNotificationSource,
+} from '@app/component/GlobalAppState';
 import { globalSplitManager } from '@app/signal/splitLayout';
+import { navigateToChannelMessage } from '@block-channel/utils/link';
+import { ReadonlyThread } from '@channel/StandaloneThread';
 import { ContextMenuContent, MenuItem } from '@core/component/ContextMenu';
 import { UserIcon } from '@core/component/UserIcon';
-import { compareDateDesc, formatDate } from '@core/util/date';
+import { isTouchDevice } from '@core/mobile/isTouchDevice';
+import { compareDateDesc } from '@core/util/date';
 import { ContextMenu } from '@kobalte/core/context-menu';
-import { markdownToPlainText } from '@lexical-core';
-import {
-  getNotificationAction,
-  getNotificationContent,
-  openNotification,
-} from '@notifications';
+import { Tooltip as KobalteTooltip } from '@kobalte/core/tooltip';
+import { openNotification } from '@notifications';
 import { isChannelNotification } from '@notifications/notification-helpers';
 import { getChannelNotificationParams } from '@notifications/notification-navigation';
 import type { UnifiedNotification } from '@notifications/types';
 import { createElementSize } from '@solid-primitives/resize-observer';
-import { Avatar, cn, HoverCard, NavRow, Tooltip } from '@ui';
+import { Avatar, cn, NavRow, Surface, Tooltip } from '@ui';
 import {
   createEffect,
   createMemo,
@@ -25,6 +27,7 @@ import {
   on,
   onCleanup,
   onMount,
+  type ParentProps,
   Show,
 } from 'solid-js';
 
@@ -120,47 +123,90 @@ function groupByChannel(
 
 const HOVER_PREVIEW_COUNT = 3;
 
-function NotificationPreviewRow(props: { notification: UnifiedNotification }) {
-  const senderName = useSenderName(props.notification.sender_id);
-  const preview = () => {
-    const content = getNotificationContent(props.notification);
-    return content
-      ? markdownToPlainText(content)
-      : getNotificationAction(props.notification);
-  };
+// Unique thread roots (a reply previews its whole thread), newest first.
+function getPreviewThreadRoots(group: ChannelGroup): string[] {
+  const roots: string[] = [];
+  const seen = new Set<string>();
+  for (const notification of group.notifications) {
+    const { messageId, threadId } = getChannelNotificationParams(notification);
+    const rootId = threadId ?? messageId;
+    if (!rootId || seen.has(rootId)) continue;
+    seen.add(rootId);
+    roots.push(rootId);
+  }
+  return roots;
+}
+
+function GroupHoverPreview(props: { group: ChannelGroup }) {
+  const orchestrator = useGlobalBlockOrchestrator();
+  const roots = () => getPreviewThreadRoots(props.group);
+  // Show the latest few threads oldest → newest, like the channel reads.
+  const visible = () => roots().slice(0, HOVER_PREVIEW_COUNT).reverse();
+  const hiddenCount = () => roots().length - visible().length;
 
   return (
-    <div class="min-w-0 flex flex-col gap-0.5">
-      <div class="flex items-baseline gap-2">
-        <span class="min-w-0 truncate font-medium text-ink">
-          {senderName() ?? 'Someone'}
+    <div class="w-90 min-h-12 max-h-96 overflow-y-auto overscroll-contain flex flex-col py-1">
+      <Show when={hiddenCount() > 0}>
+        <span class="px-3 py-1 text-xs text-ink-extra-muted">
+          +{hiddenCount()} earlier
         </span>
-        <span class="ml-auto shrink-0 text-ink-extra-muted">
-          {formatDate(props.notification.created_at)}
-        </span>
-      </div>
-      <p class="text-ink-muted wrap-break-word line-clamp-3">{preview()}</p>
+      </Show>
+      <For each={visible()}>
+        {(rootMessageId) => (
+          <ReadonlyThread
+            channelId={props.group.entityId}
+            messageId={rootMessageId}
+            onClickMessage={(clickedMessageId, e) => {
+              e.stopPropagation();
+              const isReply = clickedMessageId !== rootMessageId;
+              navigateToChannelMessage(
+                orchestrator,
+                props.group.entityId,
+                clickedMessageId,
+                isReply ? rootMessageId : undefined
+              );
+            }}
+          />
+        )}
+      </For>
     </div>
   );
 }
 
-function GroupHoverPreview(props: { group: ChannelGroup }) {
-  // Notifications arrive newest-first; show the latest few oldest → newest.
-  const visible = () =>
-    props.group.notifications.slice(0, HOVER_PREVIEW_COUNT).reverse();
-  const hiddenCount = () => props.group.notifications.length - visible().length;
+function UnreadHoverCard(
+  props: ParentProps<{ group: ChannelGroup; disabled?: boolean }>
+) {
+  const [hovered, setHovered] = createSignal(false);
+  const open = () => hovered() && !props.disabled;
 
   return (
-    <div class="w-64 flex flex-col gap-2 text-xs">
-      <Show when={hiddenCount() > 0}>
-        <span class="text-ink-extra-muted">+{hiddenCount()} earlier</span>
-      </Show>
-      <For each={visible()}>
-        {(notification) => (
-          <NotificationPreviewRow notification={notification} />
-        )}
-      </For>
-    </div>
+    <Show when={!isTouchDevice()} fallback={props.children}>
+      <KobalteTooltip
+        open={open()}
+        onOpenChange={setHovered}
+        placement="right"
+        overflowPadding={16}
+        fitViewport={true}
+        closeDelay={250}
+        openDelay={1000}
+        flip={true}
+        gutter={4}
+      >
+        <KobalteTooltip.Trigger
+          class="inline-flex items-center w-full"
+          as="div"
+        >
+          {props.children}
+        </KobalteTooltip.Trigger>
+        <KobalteTooltip.Portal>
+          <KobalteTooltip.Content class="z-tool-tip max-w-[calc(100vw-32px)] menu-open-animation">
+            <Surface depth={3}>
+              <GroupHoverPreview group={props.group} />
+            </Surface>
+          </KobalteTooltip.Content>
+        </KobalteTooltip.Portal>
+      </KobalteTooltip>
+    </Show>
   );
 }
 
@@ -305,15 +351,9 @@ function ChannelGroupItem(props: {
             </Tooltip>
           }
         >
-          <HoverCard
-            placement="right"
-            triggerClass="w-full"
-            contentClass="items-stretch p-3"
-            content={<GroupHoverPreview group={props.group} />}
-            disabled={contextMenuOpen()}
-          >
+          <UnreadHoverCard group={props.group} disabled={contextMenuOpen()}>
             <ButtonContent />
-          </HoverCard>
+          </UnreadHoverCard>
         </Show>
       </ContextMenu.Trigger>
 

--- a/js/app/packages/app/component/app-sidebar/channels-unread-widget.tsx
+++ b/js/app/packages/app/component/app-sidebar/channels-unread-widget.tsx
@@ -4,14 +4,19 @@ import { useGlobalNotificationSource } from '@app/component/GlobalAppState';
 import { globalSplitManager } from '@app/signal/splitLayout';
 import { ContextMenuContent, MenuItem } from '@core/component/ContextMenu';
 import { UserIcon } from '@core/component/UserIcon';
-import { compareDateDesc } from '@core/util/date';
+import { compareDateDesc, formatDate } from '@core/util/date';
 import { ContextMenu } from '@kobalte/core/context-menu';
-import { openNotification } from '@notifications';
+import { markdownToPlainText } from '@lexical-core';
+import {
+  getNotificationAction,
+  getNotificationContent,
+  openNotification,
+} from '@notifications';
 import { isChannelNotification } from '@notifications/notification-helpers';
 import { getChannelNotificationParams } from '@notifications/notification-navigation';
 import type { UnifiedNotification } from '@notifications/types';
 import { createElementSize } from '@solid-primitives/resize-observer';
-import { Avatar, cn, NavRow, Tooltip } from '@ui';
+import { Avatar, cn, HoverCard, NavRow, Tooltip } from '@ui';
 import {
   createEffect,
   createMemo,
@@ -111,6 +116,52 @@ function groupByChannel(
   }
 
   return groups;
+}
+
+const HOVER_PREVIEW_COUNT = 3;
+
+function NotificationPreviewRow(props: { notification: UnifiedNotification }) {
+  const senderName = useSenderName(props.notification.sender_id);
+  const preview = () => {
+    const content = getNotificationContent(props.notification);
+    return content
+      ? markdownToPlainText(content)
+      : getNotificationAction(props.notification);
+  };
+
+  return (
+    <div class="min-w-0 flex flex-col gap-0.5">
+      <div class="flex items-baseline gap-2">
+        <span class="min-w-0 truncate font-medium text-ink">
+          {senderName() ?? 'Someone'}
+        </span>
+        <span class="ml-auto shrink-0 text-ink-extra-muted">
+          {formatDate(props.notification.created_at)}
+        </span>
+      </div>
+      <p class="text-ink-muted wrap-break-word line-clamp-3">{preview()}</p>
+    </div>
+  );
+}
+
+function GroupHoverPreview(props: { group: ChannelGroup }) {
+  // Notifications arrive newest-first; show the latest few oldest → newest.
+  const visible = () =>
+    props.group.notifications.slice(0, HOVER_PREVIEW_COUNT).reverse();
+  const hiddenCount = () => props.group.notifications.length - visible().length;
+
+  return (
+    <div class="w-64 flex flex-col gap-2 text-xs">
+      <Show when={hiddenCount() > 0}>
+        <span class="text-ink-extra-muted">+{hiddenCount()} earlier</span>
+      </Show>
+      <For each={visible()}>
+        {(notification) => (
+          <NotificationPreviewRow notification={notification} />
+        )}
+      </For>
+    </div>
+  );
 }
 
 function ChannelGroupItem(props: {
@@ -239,8 +290,10 @@ function ChannelGroupItem(props: {
     </NavRow>
   );
 
+  const [contextMenuOpen, setContextMenuOpen] = createSignal(false);
+
   return (
-    <ContextMenu>
+    <ContextMenu onOpenChange={setContextMenuOpen}>
       <ContextMenu.Trigger
         class={cn(isSlim() ? 'flex justify-center' : 'w-full')}
       >
@@ -252,7 +305,15 @@ function ChannelGroupItem(props: {
             </Tooltip>
           }
         >
-          <ButtonContent />
+          <HoverCard
+            placement="right"
+            triggerClass="w-full"
+            contentClass="items-stretch p-3"
+            content={<GroupHoverPreview group={props.group} />}
+            disabled={contextMenuOpen()}
+          >
+            <ButtonContent />
+          </HoverCard>
         </Show>
       </ContextMenu.Trigger>
 


### PR DESCRIPTION
Hovering an Unread row now opens a hover card (placed to the right) previewing the latest unread notifications for that channel/DM: sender name, timestamp, and a plain-text snippet of the message content, with a "+N earlier" line when more are pending. The card defers to the row's context menu while it is open.


Claude-Session: https://claude.ai/code/session_015A3hSpKkRMoXjKfFHhpyi9