### PR TITLE
fix(tags): preserve tag filter when switching task tabs

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/soup-view-tabs.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-view-tabs.tsx
@@ -177,6 +177,16 @@ export const useApplyPreset = () => {
         mergedFilters = mergeQuery(mergedFilters, query);
       }
 
+      // Tags are a query-only refinement with no backing predicate, so the
+      // predicate-driven reconstruction above never carries them. Preserve the
+      // active selection explicitly like any other refinement.
+      const activeTagFilters = queryFilters.state.include.tagFilters;
+      if (activeTagFilters?.length) {
+        mergedFilters = mergeQuery(mergedFilters, {
+          include: { tagFilters: activeTagFilters.map((t) => ({ ...t })) },
+        });
+      }
+
       nextFilters = mergedFilters;
 
       nextClientFilters = {


### PR DESCRIPTION
Tag filters were lost when switching between the task tabs while every other filter carried over. The tab-switch preservation in `applyTabPreset` rebuilds the query from `soup.predicates` refinements, but tags are a query-only refinement with no backing predicate, so they were dropped. Carry the active `tagFilters` forward explicitly.
