### PR TITLE
fix(tasks): ai created tasks get assigned team task id

### DIFF
--- a/rust/cloud-storage/documents/src/domain/create/mod.rs
+++ b/rust/cloud-storage/documents/src/domain/create/mod.rs
@@ -164,12 +164,12 @@ pub enum MarkdownSubtype {
 
 impl MarkdownSubtype {
     /// Convert a simple task flag into the default markdown subtype.
-    pub fn from_task_flag(is_task: bool) -> Self {
+    pub fn from_task_flag(is_task: bool, team_id: Option<uuid::Uuid>) -> Self {
         if is_task {
             Self::Task {
                 property_values: None,
                 share_with_team: true,
-                team_id: None,
+                team_id,
             }
         } else {
             Self::Note
@@ -301,8 +301,8 @@ impl<FileTypeState, TextState> NewPlainTextDocumentBuilder<FileTypeState, TextSt
     }
 
     /// Set the markdown subtype from a simple task flag.
-    pub fn task_flag(self, is_task: bool) -> Self {
-        self.markdown_subtype(MarkdownSubtype::from_task_flag(is_task))
+    pub fn task_flag(self, is_task: bool, team_id: Option<uuid::Uuid>) -> Self {
+        self.markdown_subtype(MarkdownSubtype::from_task_flag(is_task, team_id))
     }
 }
 
@@ -711,7 +711,7 @@ mod tests {
         let err = NewPlainTextDocument::builder(metadata())
             .file_type(FileType::Txt)
             .text("hello")
-            .markdown_subtype(MarkdownSubtype::from_task_flag(true))
+            .markdown_subtype(MarkdownSubtype::from_task_flag(true, None))
             .build()
             .unwrap_err();
 
@@ -726,7 +726,7 @@ mod tests {
         NewPlainTextDocument::builder(metadata())
             .file_type(FileType::Md)
             .text("# hello")
-            .task_flag(true)
+            .task_flag(true, None)
             .build()
             .unwrap();
     }

--- a/rust/cloud-storage/documents/src/inbound/toolset/create_document.rs
+++ b/rust/cloud-storage/documents/src/inbound/toolset/create_document.rs
@@ -82,11 +82,22 @@ where
             })?;
         let user_id: MacroUserIdStr<'static> = request_context.user_id.clone();
 
+        // gets the members team if exists so we can track the task number correctly
+        let maybe_team = service_context
+            .entity_access_service
+            .get_user_team(&user_id)
+            .await
+            .map(|t| t.map(|tt| tt.team_id))
+            .map_err(|e| ToolCallError {
+                description: "failed to get users team".to_string(),
+                internal_error: e.into(),
+            })?;
+
         let document =
             NewPlainTextDocument::builder(NewDocumentMetadata::new(self.document_name.clone()))
                 .file_type(parsed_file_type)
                 .text(self.file_content.clone())
-                .task_flag(self.is_task)
+                .task_flag(self.is_task, maybe_team)
                 .build()
                 .map_err(failed_to_create_document)?;
 

--- a/rust/cloud-storage/documents/src/inbound/toolset/create_document.rs
+++ b/rust/cloud-storage/documents/src/inbound/toolset/create_document.rs
@@ -83,15 +83,19 @@ where
         let user_id: MacroUserIdStr<'static> = request_context.user_id.clone();
 
         // gets the members team if exists so we can track the task number correctly
-        let maybe_team = service_context
-            .entity_access_service
-            .get_user_team(&user_id)
-            .await
-            .map(|t| t.map(|tt| tt.team_id))
-            .map_err(|e| ToolCallError {
-                description: "failed to get users team".to_string(),
-                internal_error: e.into(),
-            })?;
+        let maybe_team = if self.is_task {
+            service_context
+                .entity_access_service
+                .get_user_team(&user_id)
+                .await
+                .map(|t| t.map(|tt| tt.team_id))
+                .map_err(|e| ToolCallError {
+                    description: "failed to get users team".to_string(),
+                    internal_error: e.into(),
+                })?
+        } else {
+            None
+        };
 
         let document =
             NewPlainTextDocument::builder(NewDocumentMetadata::new(self.document_name.clone()))


### PR DESCRIPTION
AI toolset `create_document` was not correctly generating a team_id for tasks despite forceably setting `share_with_team` to true. We now associate the task with the team if present.