### PR TITLE
feat(tags): show tags on task and document rows

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/use-row-tag-filter.ts
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/use-row-tag-filter.ts
@@ -1,0 +1,17 @@
+import { useTagFilter } from '@app/component/next-soup/soup-view/filters-bar/tag-filter';
+import { useMaybeSoupView } from '@app/component/next-soup/soup-view/soup-view-context';
+
+/**
+ * Row-tag click handler: filter the current list to a single tag. Applied on
+ * top of the active tab and any other filters — only the tag filter itself is
+ * replaced, so it is always exactly the one clicked tag. Returns undefined
+ * outside a soup view (e.g. document embeds), where there is nothing to filter.
+ */
+export function useRowTagFilter(): ((optionId: string) => void) | undefined {
+  const soupView = useMaybeSoupView();
+  if (!soupView) return undefined;
+  const tagFilter = useTagFilter();
+  return (optionId: string) => {
+    tagFilter.onChange([optionId]);
+  };
+}

--- a/js/app/packages/app/component/next-soup/soup-view/views/tasks/task-grid-layout.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/views/tasks/task-grid-layout.tsx
@@ -1,3 +1,7 @@
+import { useMaybeSoup } from '@app/component/next-soup/soup-context';
+import { useTagFilter } from '@app/component/next-soup/soup-view/filters-bar/tag-filter';
+import { useMaybeSoupView } from '@app/component/next-soup/soup-view/soup-view-context';
+import { useApplyPreset } from '@app/component/next-soup/soup-view/soup-view-tabs';
 import { UserIcon } from '@core/component/UserIcon';
 import { tryMacroId, useDisplayNameParts } from '@core/user';
 import {
@@ -62,8 +66,27 @@ function buildStubProperty(col: TaskGridColumn): Property {
   return soupPropertyToProperty(stubSoup);
 }
 
+/**
+ * Clicking a row tag filters the tasks list to that tag: switch to the All tab
+ * then apply the tag filter alone. Only available inside a soup view (task rows
+ * also render in embeds like duplicate-task lists, where there is nothing to
+ * filter).
+ */
+function useTaskTagFilter(): ((optionId: string) => void) | undefined {
+  const soupView = useMaybeSoupView();
+  const soup = useMaybeSoup();
+  if (!soupView || !soup) return undefined;
+  const { applyTabPreset } = useApplyPreset();
+  const tagFilter = useTagFilter();
+  return (optionId: string) => {
+    applyTabPreset('tasks', 'all');
+    tagFilter.onChange([optionId]);
+  };
+}
+
 export function TaskGridLayout(props: LayoutProps) {
   const currentId = useUserId();
+  const filterByTag = useTaskTagFilter();
   const entity = () => props.entity as EntityWithProperties<EntityData>;
   const isShared = () => props.entity.ownerId !== currentId();
 
@@ -190,6 +213,7 @@ export function TaskGridLayout(props: LayoutProps) {
           <EntityRowTags
             entityId={props.entity.id}
             entityType={EntityType.TASK}
+            onFilterByTag={filterByTag}
             class="ml-auto"
           />
         </Entity.Slot>

--- a/js/app/packages/app/component/next-soup/soup-view/views/tasks/task-grid-layout.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/views/tasks/task-grid-layout.tsx
@@ -20,6 +20,7 @@ import {
   PropertiesProvider,
   type PropertySaveHandler,
 } from '@property/context/PropertiesContext';
+import { EntityRowTags } from '@property/tags';
 import type { Property, PropertyApiValues } from '@property/types';
 import { useUserId } from '@queries/auth';
 import { useBulkSaveEntityPropertiesMutation } from '@queries/properties/entity';
@@ -186,6 +187,11 @@ export function TaskGridLayout(props: LayoutProps) {
               <CreatedByBadgeSmall ownerId={props.entity.ownerId} />
             </span>
           </Show>
+          <EntityRowTags
+            entityId={props.entity.id}
+            entityType={EntityType.TASK}
+            class="ml-auto"
+          />
         </Entity.Slot>
 
         <For each={TASK_GRID_COLUMNS}>

--- a/js/app/packages/app/component/next-soup/soup-view/views/tasks/task-grid-layout.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/views/tasks/task-grid-layout.tsx
@@ -192,6 +192,7 @@ export function TaskGridLayout(props: LayoutProps) {
           <EntityRowTags
             entityId={props.entity.id}
             entityType={EntityType.TASK}
+            properties={entity().properties}
             onFilterByTag={filterByTag}
             class="ml-auto"
           />

--- a/js/app/packages/app/component/next-soup/soup-view/views/tasks/task-grid-layout.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/views/tasks/task-grid-layout.tsx
@@ -1,7 +1,4 @@
-import { useMaybeSoup } from '@app/component/next-soup/soup-context';
-import { useTagFilter } from '@app/component/next-soup/soup-view/filters-bar/tag-filter';
-import { useMaybeSoupView } from '@app/component/next-soup/soup-view/soup-view-context';
-import { useApplyPreset } from '@app/component/next-soup/soup-view/soup-view-tabs';
+import { useRowTagFilter } from '@app/component/next-soup/soup-view/filters-bar/use-row-tag-filter';
 import { UserIcon } from '@core/component/UserIcon';
 import { tryMacroId, useDisplayNameParts } from '@core/user';
 import {
@@ -66,27 +63,9 @@ function buildStubProperty(col: TaskGridColumn): Property {
   return soupPropertyToProperty(stubSoup);
 }
 
-/**
- * Clicking a row tag filters the tasks list to that tag: switch to the All tab
- * then apply the tag filter alone. Only available inside a soup view (task rows
- * also render in embeds like duplicate-task lists, where there is nothing to
- * filter).
- */
-function useTaskTagFilter(): ((optionId: string) => void) | undefined {
-  const soupView = useMaybeSoupView();
-  const soup = useMaybeSoup();
-  if (!soupView || !soup) return undefined;
-  const { applyTabPreset } = useApplyPreset();
-  const tagFilter = useTagFilter();
-  return (optionId: string) => {
-    applyTabPreset('tasks', 'all');
-    tagFilter.onChange([optionId]);
-  };
-}
-
 export function TaskGridLayout(props: LayoutProps) {
   const currentId = useUserId();
-  const filterByTag = useTaskTagFilter();
+  const filterByTag = useRowTagFilter();
   const entity = () => props.entity as EntityWithProperties<EntityData>;
   const isShared = () => props.entity.ownerId !== currentId();
 

--- a/js/app/packages/entity/src/composed/list-entity/wide-layout.tsx
+++ b/js/app/packages/entity/src/composed/list-entity/wide-layout.tsx
@@ -1,4 +1,7 @@
+import { useRowTagFilter } from '@app/component/next-soup/soup-view/filters-bar/use-row-tag-filter';
 import { useMaybeSoupView } from '@app/component/next-soup/soup-view/soup-view-context';
+import { EntityRowTags } from '@property/tags';
+import { EntityType } from '@service-properties/generated/schemas/entityType';
 import { cn } from '@ui';
 import { Match, Show, Switch } from 'solid-js';
 import { CallStatusBadge, SharedBadge } from '../../components/Badges';
@@ -11,6 +14,7 @@ import {
   isCallEntity,
   isChannelEntity,
   isChannelMessageEntity,
+  isDocumentEntity,
   isEmailEntity,
   isGithubPrEntity,
   isProjectContainedEntity,
@@ -26,6 +30,17 @@ import {
   GithubPullRequestPills,
 } from './foreign';
 import type { LayoutProps } from './shared';
+
+function DocumentRowTags(props: { entityId: string }) {
+  const filterByTag = useRowTagFilter();
+  return (
+    <EntityRowTags
+      entityId={props.entityId}
+      entityType={EntityType.DOCUMENT}
+      onFilterByTag={filterByTag}
+    />
+  );
+}
 
 export function WideLayout(props: LayoutProps) {
   const soupView = useMaybeSoupView();
@@ -164,6 +179,9 @@ export function WideLayout(props: LayoutProps) {
         </Show>
         <Show when={isTaskEntity(props.entity) && props.entity}>
           {(entity) => <Entity.Properties entity={entity()} />}
+        </Show>
+        <Show when={isDocumentEntity(props.entity) && props.entity}>
+          {(entity) => <DocumentRowTags entityId={entity().id} />}
         </Show>
       </Entity.Slot>
       <Entity.Slot

--- a/js/app/packages/entity/src/composed/list-entity/wide-layout.tsx
+++ b/js/app/packages/entity/src/composed/list-entity/wide-layout.tsx
@@ -2,6 +2,7 @@ import { useRowTagFilter } from '@app/component/next-soup/soup-view/filters-bar/
 import { useMaybeSoupView } from '@app/component/next-soup/soup-view/soup-view-context';
 import { EntityRowTags } from '@property/tags';
 import { EntityType } from '@service-properties/generated/schemas/entityType';
+import type { SoupProperty } from '@service-storage/generated/schemas/soupProperty';
 import { cn } from '@ui';
 import { Match, Show, Switch } from 'solid-js';
 import { CallStatusBadge, SharedBadge } from '../../components/Badges';
@@ -31,12 +32,16 @@ import {
 } from './foreign';
 import type { LayoutProps } from './shared';
 
-function DocumentRowTags(props: { entityId: string }) {
+function DocumentRowTags(props: {
+  entityId: string;
+  properties: SoupProperty[] | undefined;
+}) {
   const filterByTag = useRowTagFilter();
   return (
     <EntityRowTags
       entityId={props.entityId}
       entityType={EntityType.DOCUMENT}
+      properties={props.properties}
       onFilterByTag={filterByTag}
     />
   );
@@ -181,7 +186,18 @@ export function WideLayout(props: LayoutProps) {
           {(entity) => <Entity.Properties entity={entity()} />}
         </Show>
         <Show when={isDocumentEntity(props.entity) && props.entity}>
-          {(entity) => <DocumentRowTags entityId={entity().id} />}
+          {(entity) => {
+            const properties = () => {
+              const doc = entity();
+              return 'properties' in doc ? doc.properties : undefined;
+            };
+            return (
+              <DocumentRowTags
+                entityId={entity().id}
+                properties={properties()}
+              />
+            );
+          }}
         </Show>
       </Entity.Slot>
       <Entity.Slot

--- a/js/app/packages/property/src/tags/EntityRowTags.tsx
+++ b/js/app/packages/property/src/tags/EntityRowTags.tsx
@@ -1,50 +1,119 @@
+import FilterIcon from '@phosphor/funnel-simple.svg';
 import type { EntityType } from '@service-properties/generated/schemas/entityType';
 import { cn, HoverCard, Layer } from '@ui';
-import { For, Show } from 'solid-js';
+import { createSignal, For, Show } from 'solid-js';
 import { TagDot } from './TagDot';
+import { TagPicker } from './TagPicker';
 import { type ResolvedTag, useDocTags } from './useDocTags';
+
+type DocTags = ReturnType<typeof useDocTags>;
 
 const DEFAULT_MAX_VISIBLE = 3;
 const MAX_OVERFLOW_DOTS = 3;
 
 const chipClass = cn(
   'inline-flex items-center gap-1 shrink-0 max-w-[14ch]',
-  'px-1.5 py-0.5 leading-tight rounded-full bg-surface text-ink-muted text-xs'
+  'px-1.5 py-0.5 leading-tight rounded-full bg-surface text-ink-muted text-xs',
+  'hover:text-ink'
 );
 
-function TagChip(props: { tag: ResolvedTag }) {
+function HoverTagRow(props: {
+  tag: ResolvedTag;
+  onFilter?: (id: string) => void;
+}) {
+  return (
+    <Show
+      when={props.onFilter}
+      fallback={
+        <span class="flex items-center gap-1.5 whitespace-nowrap px-1.5 py-1 text-ink">
+          <TagDot color={props.tag.color} />
+          <span class="min-w-0 truncate">{props.tag.label}</span>
+        </span>
+      }
+    >
+      {(onFilter) => (
+        <button
+          type="button"
+          class="flex items-center gap-1.5 whitespace-nowrap rounded-md px-1.5 py-1 text-left text-ink hover:bg-hover"
+          onClick={() => onFilter()(props.tag.optionId)}
+        >
+          <TagDot color={props.tag.color} />
+          <span class="min-w-0 truncate">{props.tag.label}</span>
+        </button>
+      )}
+    </Show>
+  );
+}
+
+function TagChip(props: {
+  tag: ResolvedTag;
+  docTags: DocTags;
+  onFilterByTag?: (id: string) => void;
+}) {
+  const [pickerOpen, setPickerOpen] = createSignal(false);
   return (
     <Layer depth={2}>
-      <span class={chipClass}>
-        <TagDot color={props.tag.color} class="size-2" />
-        <span class="min-w-0 truncate">{props.tag.label}</span>
-      </span>
+      <HoverCard
+        placement="bottom-start"
+        disabled={pickerOpen() || !props.onFilterByTag}
+        content={
+          <button
+            type="button"
+            class="flex items-center gap-1.5 whitespace-nowrap rounded-md px-1.5 py-1 text-ink hover:bg-hover"
+            onClick={() => props.onFilterByTag?.(props.tag.optionId)}
+          >
+            <FilterIcon class="size-3.5 text-ink-muted" />
+            <span>
+              Filter by <span class="font-medium">{props.tag.label}</span>
+            </span>
+          </button>
+        }
+      >
+        <TagPicker
+          docTags={props.docTags}
+          triggerClass={chipClass}
+          triggerLabel={`Edit ${props.tag.label}`}
+          onOpenChange={setPickerOpen}
+        >
+          <TagDot color={props.tag.color} class="size-2" />
+          <span class="min-w-0 truncate">{props.tag.label}</span>
+        </TagPicker>
+      </HoverCard>
     </Layer>
   );
 }
 
-function TagOverflow(props: { tags: ResolvedTag[] }) {
+function TagOverflow(props: {
+  tags: ResolvedTag[];
+  docTags: DocTags;
+  onFilterByTag?: (id: string) => void;
+}) {
+  const [pickerOpen, setPickerOpen] = createSignal(false);
   const dots = () => props.tags.slice(0, MAX_OVERFLOW_DOTS);
   const count = () =>
     `+${props.tags.length} ${props.tags.length === 1 ? 'tag' : 'tags'}`;
 
   return (
-    <HoverCard
-      content={
-        <div class="flex flex-col gap-1.5">
-          <For each={props.tags}>
-            {(tag) => (
-              <span class="flex items-center gap-1.5 whitespace-nowrap text-ink">
-                <TagDot color={tag.color} />
-                <span>{tag.label}</span>
-              </span>
-            )}
-          </For>
-        </div>
-      }
-    >
-      <Layer depth={2}>
-        <span class={cn(chipClass, 'gap-1.5')}>
+    <Layer depth={2}>
+      <HoverCard
+        placement="bottom-end"
+        disabled={pickerOpen()}
+        content={
+          <div class="flex flex-col gap-0.5">
+            <For each={props.tags}>
+              {(tag) => (
+                <HoverTagRow tag={tag} onFilter={props.onFilterByTag} />
+              )}
+            </For>
+          </div>
+        }
+      >
+        <TagPicker
+          docTags={props.docTags}
+          triggerClass={cn(chipClass, 'gap-1.5')}
+          triggerLabel="Edit tags"
+          onOpenChange={setPickerOpen}
+        >
           <span class="flex items-center">
             <For each={dots()}>
               {(tag, index) => (
@@ -59,22 +128,24 @@ function TagOverflow(props: { tags: ResolvedTag[] }) {
             </For>
           </span>
           <span>{count()}</span>
-        </span>
-      </Layer>
-    </HoverCard>
+        </TagPicker>
+      </HoverCard>
+    </Layer>
   );
 }
 
 /**
- * Compact, read-only tag display for list rows. Shows up to `maxVisible` chips
- * then collapses the rest into a "+N tags" chip whose hover reveals the
- * remaining tags. Editing lives in the TagPicker on the entity's detail view.
+ * Compact tag display for list rows. Shows up to `maxVisible` chips then a
+ * "+N tags" chip. Clicking a chip opens the TagPicker to edit the entity's
+ * tags. Hovering a chip surfaces a "Filter by" link and hovering the overflow
+ * lists the hidden tags. onFilterByTag applies a tag filter to the list.
  */
 export function EntityRowTags(props: {
   entityId: string;
   entityType: EntityType;
   maxVisible?: number;
   class?: string;
+  onFilterByTag?: (optionId: string) => void;
 }) {
   const docTags = useDocTags(props.entityId, props.entityType);
   const maxVisible = () => props.maxVisible ?? DEFAULT_MAX_VISIBLE;
@@ -83,10 +154,25 @@ export function EntityRowTags(props: {
 
   return (
     <Show when={docTags.appliedTags().length > 0}>
-      <div class={cn('flex items-center gap-1', props.class)}>
-        <For each={visible()}>{(tag) => <TagChip tag={tag} />}</For>
+      <div
+        class={cn('flex items-center gap-1', props.class)}
+        onClick={(event) => event.stopPropagation()}
+      >
+        <For each={visible()}>
+          {(tag) => (
+            <TagChip
+              tag={tag}
+              docTags={docTags}
+              onFilterByTag={props.onFilterByTag}
+            />
+          )}
+        </For>
         <Show when={hidden().length > 0}>
-          <TagOverflow tags={hidden()} />
+          <TagOverflow
+            tags={hidden()}
+            docTags={docTags}
+            onFilterByTag={props.onFilterByTag}
+          />
         </Show>
       </div>
     </Show>

--- a/js/app/packages/property/src/tags/EntityRowTags.tsx
+++ b/js/app/packages/property/src/tags/EntityRowTags.tsx
@@ -1,12 +1,13 @@
 import FilterIcon from '@phosphor/funnel-simple.svg';
 import type { EntityType } from '@service-properties/generated/schemas/entityType';
+import type { SoupProperty } from '@service-storage/generated/schemas/soupProperty';
 import { cn, HoverCard, Layer } from '@ui';
 import { createSignal, For, Show } from 'solid-js';
 import { TagDot } from './TagDot';
 import { TagPicker } from './TagPicker';
-import { type ResolvedTag, useDocTags } from './useDocTags';
+import { type ResolvedTag, useSoupDocTags } from './useDocTags';
 
-type DocTags = ReturnType<typeof useDocTags>;
+type DocTags = ReturnType<typeof useSoupDocTags>;
 
 const DEFAULT_MAX_VISIBLE = 3;
 const MAX_OVERFLOW_DOTS = 3;
@@ -135,7 +136,8 @@ function TagOverflow(props: {
 }
 
 /**
- * Compact tag display for list rows. Shows up to `maxVisible` chips then a
+ * Compact tag display for list rows, rendered from the entity's already-loaded
+ * soup properties (no per-row fetch). Shows up to `maxVisible` chips then a
  * "+N tags" chip. Clicking a chip opens the TagPicker to edit the entity's
  * tags. Hovering a chip surfaces a "Filter by" link and hovering the overflow
  * lists the hidden tags. onFilterByTag applies a tag filter to the list.
@@ -143,11 +145,16 @@ function TagOverflow(props: {
 export function EntityRowTags(props: {
   entityId: string;
   entityType: EntityType;
+  properties: SoupProperty[] | undefined;
   maxVisible?: number;
   class?: string;
   onFilterByTag?: (optionId: string) => void;
 }) {
-  const docTags = useDocTags(props.entityId, props.entityType);
+  const docTags = useSoupDocTags(
+    props.entityId,
+    props.entityType,
+    () => props.properties
+  );
   const maxVisible = () => props.maxVisible ?? DEFAULT_MAX_VISIBLE;
   const visible = () => docTags.appliedTags().slice(0, maxVisible());
   const hidden = () => docTags.appliedTags().slice(maxVisible());

--- a/js/app/packages/property/src/tags/EntityRowTags.tsx
+++ b/js/app/packages/property/src/tags/EntityRowTags.tsx
@@ -1,0 +1,94 @@
+import type { EntityType } from '@service-properties/generated/schemas/entityType';
+import { cn, HoverCard, Layer } from '@ui';
+import { For, Show } from 'solid-js';
+import { TagDot } from './TagDot';
+import { type ResolvedTag, useDocTags } from './useDocTags';
+
+const DEFAULT_MAX_VISIBLE = 3;
+const MAX_OVERFLOW_DOTS = 3;
+
+const chipClass = cn(
+  'inline-flex items-center gap-1 shrink-0 max-w-[14ch]',
+  'px-1.5 py-0.5 leading-tight rounded-full bg-surface text-ink-muted text-xs'
+);
+
+function TagChip(props: { tag: ResolvedTag }) {
+  return (
+    <Layer depth={2}>
+      <span class={chipClass}>
+        <TagDot color={props.tag.color} class="size-2" />
+        <span class="min-w-0 truncate">{props.tag.label}</span>
+      </span>
+    </Layer>
+  );
+}
+
+function TagOverflow(props: { tags: ResolvedTag[] }) {
+  const dots = () => props.tags.slice(0, MAX_OVERFLOW_DOTS);
+  const count = () =>
+    `+${props.tags.length} ${props.tags.length === 1 ? 'tag' : 'tags'}`;
+
+  return (
+    <HoverCard
+      content={
+        <div class="flex flex-col gap-1.5">
+          <For each={props.tags}>
+            {(tag) => (
+              <span class="flex items-center gap-1.5 whitespace-nowrap text-ink">
+                <TagDot color={tag.color} />
+                <span>{tag.label}</span>
+              </span>
+            )}
+          </For>
+        </div>
+      }
+    >
+      <Layer depth={2}>
+        <span class={cn(chipClass, 'gap-1.5')}>
+          <span class="flex items-center">
+            <For each={dots()}>
+              {(tag, index) => (
+                <TagDot
+                  color={tag.color}
+                  class={cn(
+                    'size-2 ring-1 ring-surface',
+                    index() > 0 && '-ml-1'
+                  )}
+                />
+              )}
+            </For>
+          </span>
+          <span>{count()}</span>
+        </span>
+      </Layer>
+    </HoverCard>
+  );
+}
+
+/**
+ * Compact, read-only tag display for list rows. Shows up to `maxVisible` chips
+ * then collapses the rest into a "+N tags" chip whose hover reveals the
+ * remaining tags. Editing lives in the TagPicker on the entity's detail view.
+ */
+export function EntityRowTags(props: {
+  entityId: string;
+  entityType: EntityType;
+  maxVisible?: number;
+  class?: string;
+}) {
+  const docTags = useDocTags(props.entityId, props.entityType);
+  const maxVisible = () => props.maxVisible ?? DEFAULT_MAX_VISIBLE;
+  const visible = () => docTags.appliedTags().slice(0, maxVisible());
+  const hidden = () => docTags.appliedTags().slice(maxVisible());
+
+  return (
+    <Show when={docTags.appliedTags().length > 0}>
+      <div class={cn('flex items-center gap-1', props.class)}>
+        <For each={visible()}>{(tag) => <TagChip tag={tag} />}</For>
+        <Show when={hidden().length > 0}>
+          <TagOverflow tags={hidden()} />
+        </Show>
+      </div>
+    </Show>
+  );
+}

--- a/js/app/packages/property/src/tags/TagPicker.tsx
+++ b/js/app/packages/property/src/tags/TagPicker.tsx
@@ -58,6 +58,7 @@ export function TagPicker(props: {
   triggerClass?: string;
   triggerLabel: string;
   children: JSX.Element;
+  onOpenChange?: (open: boolean) => void;
 }) {
   const [open, setOpen] = createSignal(false);
   const [search, setSearch] = createSignal('');
@@ -127,7 +128,10 @@ export function TagPicker(props: {
   return (
     <Popover
       open={open()}
-      onOpenChange={setOpen}
+      onOpenChange={(value) => {
+        setOpen(value);
+        props.onOpenChange?.(value);
+      }}
       placement="bottom-start"
       gutter={4}
     >

--- a/js/app/packages/property/src/tags/index.ts
+++ b/js/app/packages/property/src/tags/index.ts
@@ -1,3 +1,4 @@
+export { EntityRowTags } from './EntityRowTags';
 export { TagPicker } from './TagPicker';
 export { TagsRow } from './TagsRow';
 export { DEFAULT_TAG_COLOR, TAG_COLORS } from './tagColors';

--- a/js/app/packages/property/src/tags/useDocTags.ts
+++ b/js/app/packages/property/src/tags/useDocTags.ts
@@ -11,7 +11,8 @@ import type { PropertyDefinitionDetailResponse } from '@service-properties/gener
 import type { PropertyOptionResponse } from '@service-properties/generated/schemas/propertyOptionResponse';
 import type { TagScope } from '@service-properties/generated/schemas/tagScope';
 import type { TagSetResponse } from '@service-properties/generated/schemas/tagSetResponse';
-import { createMemo } from 'solid-js';
+import type { SoupProperty } from '@service-storage/generated/schemas/soupProperty';
+import { type Accessor, createMemo } from 'solid-js';
 import { useEntityProperties } from '../hooks';
 import type { PropertyDefinitionDomain } from '../types';
 
@@ -42,12 +43,15 @@ function definitionDomain(
   };
 }
 
-export function useDocTags(entityId: string, entityType: EntityType) {
+function createDocTags(
+  entityId: string,
+  entityType: EntityType,
+  appliedOptionIdsForDefinition: (definitionId: string) => string[]
+) {
   const tagsQuery = useTagsQuery();
   const ensureTagSet = useEnsureTagSetMutation();
   const addOption = useAddEntityPropertyOptionMutation();
   const removeOption = useRemoveEntityPropertyOptionMutation();
-  const { properties } = useEntityProperties(entityId, entityType, false);
 
   const tagSets = (): TagSetResponse[] => tagsQuery.data ?? [];
 
@@ -73,16 +77,6 @@ export function useDocTags(entityId: string, entityType: EntityType) {
     }
     return map;
   });
-
-  const appliedOptionIdsForDefinition = (definitionId: string): string[] => {
-    const property = properties().find(
-      (prop) => prop.propertyDefinitionId === definitionId
-    );
-    if (!property) return [];
-    return property.valueType === 'SELECT_STRING' && property.value
-      ? property.value
-      : [];
-  };
 
   const appliedTags = createMemo((): ResolvedTag[] => {
     const resolved: ResolvedTag[] = [];
@@ -156,4 +150,37 @@ export function useDocTags(entityId: string, entityType: EntityType) {
     removeTag,
     toggleTag,
   };
+}
+
+export function useDocTags(entityId: string, entityType: EntityType) {
+  const { properties } = useEntityProperties(entityId, entityType, false);
+
+  return createDocTags(entityId, entityType, (definitionId) => {
+    const property = properties().find(
+      (prop) => prop.propertyDefinitionId === definitionId
+    );
+    if (!property) return [];
+    return property.valueType === 'SELECT_STRING' && property.value
+      ? property.value
+      : [];
+  });
+}
+
+/**
+ * Doc-tags backed by an entity's already-loaded soup properties instead of a
+ * per-entity fetch. List rows use this so tags render with no extra requests.
+ * Mutations patch the soup cache optimistically, so the source stays live.
+ */
+export function useSoupDocTags(
+  entityId: string,
+  entityType: EntityType,
+  properties: Accessor<SoupProperty[] | undefined>
+) {
+  return createDocTags(entityId, entityType, (definitionId) => {
+    const property = properties()?.find(
+      (prop) => prop.definition.id === definitionId
+    );
+    const value = property?.value;
+    return value?.type === 'SelectOption' ? value.value : [];
+  });
 }

--- a/rust/cloud-storage/properties_db_client/.sqlx/query-0893292d05dc339bc516ddc4e2e27ee0f730dd38e1d82bd2a049d38cb7abb275.json
+++ b/rust/cloud-storage/properties_db_client/.sqlx/query-0893292d05dc339bc516ddc4e2e27ee0f730dd38e1d82bd2a049d38cb7abb275.json
@@ -1,0 +1,58 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT\n            d.id,\n            d.name,\n            d.owner,\n            d.\"fileType\" as \"file_type\",\n            d.\"projectId\" as \"project_id\",\n            d.\"createdAt\"::timestamptz as \"created_at!\",\n            d.\"updatedAt\"::timestamptz as \"updated_at!\"\n        FROM\n            \"Document\" d\n        WHERE\n            d.id = $1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "owner",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "file_type",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "project_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "created_at!",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 6,
+        "name": "updated_at!",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true,
+      null,
+      null
+    ]
+  },
+  "hash": "0893292d05dc339bc516ddc4e2e27ee0f730dd38e1d82bd2a049d38cb7abb275"
+}

--- a/rust/cloud-storage/properties_db_client/.sqlx/query-301f5b3142a30e271df62607b5743ff019bff1a5b0142fc260ff772837db3f39.json
+++ b/rust/cloud-storage/properties_db_client/.sqlx/query-301f5b3142a30e271df62607b5743ff019bff1a5b0142fc260ff772837db3f39.json
@@ -1,0 +1,185 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\nSELECT\n    ep.id as entity_property_id,\n    ep.entity_id,\n    ep.entity_type as \"entity_type: EntityType\",\n    ep.property_definition_id,\n    ep.values as \"values: sqlx::types::JsonValue\",\n    ep.created_at as entity_property_created_at,\n    ep.updated_at as entity_property_updated_at,\n    pd.team_id as definition_team_id,\n    pd.user_id as definition_user_id,\n    pd.display_name,\n    pd.data_type as \"data_type: DataType\",\n    pd.is_multi_select,\n    pd.specific_entity_type as \"specific_entity_type: Option<EntityType>\",\n    pd.created_at as definition_created_at,\n    pd.updated_at as definition_updated_at,\n    pd.is_system as definition_is_system\nFROM entity_properties ep\nINNER JOIN property_definitions pd ON ep.property_definition_id = pd.id\nWHERE (ep.entity_id, ep.entity_type) IN (\n    SELECT * FROM UNNEST($1::TEXT[], $2::property_entity_type[])\n)\n",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_property_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "entity_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "entity_type: EntityType",
+        "type_info": {
+          "Custom": {
+            "name": "property_entity_type",
+            "kind": {
+              "Enum": [
+                "CHANNEL",
+                "CHAT",
+                "DOCUMENT",
+                "PROJECT",
+                "THREAD",
+                "USER",
+                "COMPANY",
+                "TASK"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 3,
+        "name": "property_definition_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 4,
+        "name": "values: sqlx::types::JsonValue",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 5,
+        "name": "entity_property_created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 6,
+        "name": "entity_property_updated_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 7,
+        "name": "definition_team_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 8,
+        "name": "definition_user_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 9,
+        "name": "display_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 10,
+        "name": "data_type: DataType",
+        "type_info": {
+          "Custom": {
+            "name": "property_data_type",
+            "kind": {
+              "Enum": [
+                "BOOLEAN",
+                "DATE",
+                "NUMBER",
+                "STRING",
+                "SELECT_NUMBER",
+                "SELECT_STRING",
+                "ENTITY",
+                "LINK",
+                "TAG"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 11,
+        "name": "is_multi_select",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 12,
+        "name": "specific_entity_type: Option<EntityType>",
+        "type_info": {
+          "Custom": {
+            "name": "property_entity_type",
+            "kind": {
+              "Enum": [
+                "CHANNEL",
+                "CHAT",
+                "DOCUMENT",
+                "PROJECT",
+                "THREAD",
+                "USER",
+                "COMPANY",
+                "TASK"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 13,
+        "name": "definition_created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 14,
+        "name": "definition_updated_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 15,
+        "name": "definition_is_system",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "TextArray",
+        {
+          "Custom": {
+            "name": "property_entity_type[]",
+            "kind": {
+              "Array": {
+                "Custom": {
+                  "name": "property_entity_type",
+                  "kind": {
+                    "Enum": [
+                      "CHANNEL",
+                      "CHAT",
+                      "DOCUMENT",
+                      "PROJECT",
+                      "THREAD",
+                      "USER",
+                      "COMPANY",
+                      "TASK"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      true,
+      true,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "301f5b3142a30e271df62607b5743ff019bff1a5b0142fc260ff772837db3f39"
+}

--- a/rust/cloud-storage/properties_db_client/.sqlx/query-3361ff2e8d90c65b188ef614379cdbf977e4f89f8c22603071fc169fdfa038e2.json
+++ b/rust/cloud-storage/properties_db_client/.sqlx/query-3361ff2e8d90c65b188ef614379cdbf977e4f89f8c22603071fc169fdfa038e2.json
@@ -1,0 +1,39 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        INSERT INTO property_options (\n            id,\n            property_definition_id,\n            display_order,\n            number_value,\n            string_value,\n            color\n        )\n        VALUES ($1, $2, $3, $4, $5, $6)\n        RETURNING id, created_at, updated_at\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 2,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Int4",
+        "Float8",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "3361ff2e8d90c65b188ef614379cdbf977e4f89f8c22603071fc169fdfa038e2"
+}

--- a/rust/cloud-storage/properties_db_client/.sqlx/query-3e259ea5cbdcfae4334cb0125de6423fa95a0c127fbeba0a59d7096b0177c072.json
+++ b/rust/cloud-storage/properties_db_client/.sqlx/query-3e259ea5cbdcfae4334cb0125de6423fa95a0c127fbeba0a59d7096b0177c072.json
@@ -1,0 +1,52 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT\n            p.id,\n            p.name,\n            p.\"userId\" as \"owner\",\n            p.\"parentId\" as \"parent_id\",\n            p.\"createdAt\"::timestamptz as \"created_at!\",\n            p.\"updatedAt\"::timestamptz as \"updated_at!\"\n        FROM\n            \"Project\" p\n        WHERE\n            p.id = $1 AND p.\"deletedAt\" IS NULL\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "owner",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "parent_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "created_at!",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 5,
+        "name": "updated_at!",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      null,
+      null
+    ]
+  },
+  "hash": "3e259ea5cbdcfae4334cb0125de6423fa95a0c127fbeba0a59d7096b0177c072"
+}

--- a/rust/cloud-storage/properties_db_client/.sqlx/query-3f3b5a5d8734e3748d4e29d64cfa89baff99dae621e7cbd7a10017beec9485c8.json
+++ b/rust/cloud-storage/properties_db_client/.sqlx/query-3f3b5a5d8734e3748d4e29d64cfa89baff99dae621e7cbd7a10017beec9485c8.json
@@ -1,0 +1,50 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\nSELECT\n    ep.entity_id,\n    ep.entity_type as \"entity_type: EntityType\",\n    ep.property_definition_id\nFROM entity_properties ep\nWHERE ep.id = $1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "entity_type: EntityType",
+        "type_info": {
+          "Custom": {
+            "name": "property_entity_type",
+            "kind": {
+              "Enum": [
+                "CHANNEL",
+                "CHAT",
+                "DOCUMENT",
+                "PROJECT",
+                "THREAD",
+                "USER",
+                "COMPANY",
+                "TASK"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 2,
+        "name": "property_definition_id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "3f3b5a5d8734e3748d4e29d64cfa89baff99dae621e7cbd7a10017beec9485c8"
+}

--- a/rust/cloud-storage/properties_db_client/.sqlx/query-462655d9cce541e4b25cb2d85e9d2e8ce3c84e28b4f459e4ea4ef62881278ae8.json
+++ b/rust/cloud-storage/properties_db_client/.sqlx/query-462655d9cce541e4b25cb2d85e9d2e8ce3c84e28b4f459e4ea4ef62881278ae8.json
@@ -1,0 +1,111 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT\n            id,\n            team_id,\n            user_id,\n            display_name,\n            data_type as \"data_type: DataType\",\n            is_multi_select,\n            specific_entity_type as \"specific_entity_type: Option<EntityType>\",\n            created_at,\n            updated_at,\n            is_system\n        FROM property_definitions\n        WHERE id = $1\n          AND is_system = FALSE\n          AND (\n            user_id = $2\n            OR ($3::uuid IS NOT NULL AND team_id = $3)\n          )\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "team_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "user_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "display_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "data_type: DataType",
+        "type_info": {
+          "Custom": {
+            "name": "property_data_type",
+            "kind": {
+              "Enum": [
+                "BOOLEAN",
+                "DATE",
+                "NUMBER",
+                "STRING",
+                "SELECT_NUMBER",
+                "SELECT_STRING",
+                "ENTITY",
+                "LINK",
+                "TAG"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 5,
+        "name": "is_multi_select",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 6,
+        "name": "specific_entity_type: Option<EntityType>",
+        "type_info": {
+          "Custom": {
+            "name": "property_entity_type",
+            "kind": {
+              "Enum": [
+                "CHANNEL",
+                "CHAT",
+                "DOCUMENT",
+                "PROJECT",
+                "THREAD",
+                "USER",
+                "COMPANY",
+                "TASK"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 7,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 8,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 9,
+        "name": "is_system",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      true,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "462655d9cce541e4b25cb2d85e9d2e8ce3c84e28b4f459e4ea4ef62881278ae8"
+}

--- a/rust/cloud-storage/properties_db_client/.sqlx/query-4d75ecd9c8d6f98881d44d88d10ebc20de426c8aad90b680cc8ae351118e5495.json
+++ b/rust/cloud-storage/properties_db_client/.sqlx/query-4d75ecd9c8d6f98881d44d88d10ebc20de426c8aad90b680cc8ae351118e5495.json
@@ -1,0 +1,205 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\nSELECT\n    ep.id as entity_property_id,\n    ep.entity_id,\n    ep.entity_type as \"entity_type: EntityType\",\n    ep.property_definition_id,\n    ep.values as \"values: sqlx::types::JsonValue\",\n    ep.created_at as entity_property_created_at,\n    ep.updated_at as entity_property_updated_at,\n    pd.team_id as definition_team_id,\n    pd.user_id as definition_user_id,\n    pd.display_name,\n    pd.data_type as \"data_type: DataType\",\n    pd.is_multi_select,\n    pd.specific_entity_type as \"specific_entity_type: Option<EntityType>\",\n    pd.created_at as definition_created_at,\n    pd.updated_at as definition_updated_at,\n    pd.is_system as definition_is_system\nFROM entity_properties ep\nINNER JOIN property_definitions pd ON ep.property_definition_id = pd.id\nWHERE (ep.entity_id, ep.entity_type) IN (\n    SELECT * FROM UNNEST($1::TEXT[], $2::property_entity_type[])\n)\nAND (\n    pd.id = ANY($3::UUID[])\n    OR (\n        $4::text IS NOT NULL\n        AND pd.data_type = $5\n        AND (\n            pd.user_id = $4\n            OR pd.team_id IN (SELECT tu.team_id FROM team_user tu WHERE tu.user_id = $4)\n        )\n    )\n)\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_property_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "entity_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "entity_type: EntityType",
+        "type_info": {
+          "Custom": {
+            "name": "property_entity_type",
+            "kind": {
+              "Enum": [
+                "CHANNEL",
+                "CHAT",
+                "DOCUMENT",
+                "PROJECT",
+                "THREAD",
+                "USER",
+                "COMPANY",
+                "TASK"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 3,
+        "name": "property_definition_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 4,
+        "name": "values: sqlx::types::JsonValue",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 5,
+        "name": "entity_property_created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 6,
+        "name": "entity_property_updated_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 7,
+        "name": "definition_team_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 8,
+        "name": "definition_user_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 9,
+        "name": "display_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 10,
+        "name": "data_type: DataType",
+        "type_info": {
+          "Custom": {
+            "name": "property_data_type",
+            "kind": {
+              "Enum": [
+                "BOOLEAN",
+                "DATE",
+                "NUMBER",
+                "STRING",
+                "SELECT_NUMBER",
+                "SELECT_STRING",
+                "ENTITY",
+                "LINK",
+                "TAG"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 11,
+        "name": "is_multi_select",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 12,
+        "name": "specific_entity_type: Option<EntityType>",
+        "type_info": {
+          "Custom": {
+            "name": "property_entity_type",
+            "kind": {
+              "Enum": [
+                "CHANNEL",
+                "CHAT",
+                "DOCUMENT",
+                "PROJECT",
+                "THREAD",
+                "USER",
+                "COMPANY",
+                "TASK"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 13,
+        "name": "definition_created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 14,
+        "name": "definition_updated_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 15,
+        "name": "definition_is_system",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "TextArray",
+        {
+          "Custom": {
+            "name": "property_entity_type[]",
+            "kind": {
+              "Array": {
+                "Custom": {
+                  "name": "property_entity_type",
+                  "kind": {
+                    "Enum": [
+                      "CHANNEL",
+                      "CHAT",
+                      "DOCUMENT",
+                      "PROJECT",
+                      "THREAD",
+                      "USER",
+                      "COMPANY",
+                      "TASK"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "UuidArray",
+        "Text",
+        {
+          "Custom": {
+            "name": "property_data_type",
+            "kind": {
+              "Enum": [
+                "BOOLEAN",
+                "DATE",
+                "NUMBER",
+                "STRING",
+                "SELECT_NUMBER",
+                "SELECT_STRING",
+                "ENTITY",
+                "LINK",
+                "TAG"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      true,
+      true,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "4d75ecd9c8d6f98881d44d88d10ebc20de426c8aad90b680cc8ae351118e5495"
+}

--- a/rust/cloud-storage/properties_db_client/.sqlx/query-4e7dff37296c4976495ee40673ee20a6729b6ce030222e1776a0fd22d93bafb7.json
+++ b/rust/cloud-storage/properties_db_client/.sqlx/query-4e7dff37296c4976495ee40673ee20a6729b6ce030222e1776a0fd22d93bafb7.json
@@ -1,0 +1,128 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT\n            id,\n            team_id,\n            user_id,\n            display_name,\n            data_type as \"data_type: DataType\",\n            is_multi_select,\n            specific_entity_type as \"specific_entity_type: Option<EntityType>\",\n            created_at,\n            updated_at,\n            is_system\n        FROM property_definitions\n        WHERE data_type = $3\n          AND (\n            ($1::uuid IS NOT NULL AND team_id = $1)\n            OR ($2::text IS NOT NULL AND user_id = $2)\n          )\n        LIMIT 1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "team_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "user_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "display_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "data_type: DataType",
+        "type_info": {
+          "Custom": {
+            "name": "property_data_type",
+            "kind": {
+              "Enum": [
+                "BOOLEAN",
+                "DATE",
+                "NUMBER",
+                "STRING",
+                "SELECT_NUMBER",
+                "SELECT_STRING",
+                "ENTITY",
+                "LINK",
+                "TAG"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 5,
+        "name": "is_multi_select",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 6,
+        "name": "specific_entity_type: Option<EntityType>",
+        "type_info": {
+          "Custom": {
+            "name": "property_entity_type",
+            "kind": {
+              "Enum": [
+                "CHANNEL",
+                "CHAT",
+                "DOCUMENT",
+                "PROJECT",
+                "THREAD",
+                "USER",
+                "COMPANY",
+                "TASK"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 7,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 8,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 9,
+        "name": "is_system",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        {
+          "Custom": {
+            "name": "property_data_type",
+            "kind": {
+              "Enum": [
+                "BOOLEAN",
+                "DATE",
+                "NUMBER",
+                "STRING",
+                "SELECT_NUMBER",
+                "SELECT_STRING",
+                "ENTITY",
+                "LINK",
+                "TAG"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      true,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "4e7dff37296c4976495ee40673ee20a6729b6ce030222e1776a0fd22d93bafb7"
+}

--- a/rust/cloud-storage/properties_db_client/.sqlx/query-6fd87794b687b1687b8c4f0bc0390ffcc91811ae9909ce333273e6bf77013b03.json
+++ b/rust/cloud-storage/properties_db_client/.sqlx/query-6fd87794b687b1687b8c4f0bc0390ffcc91811ae9909ce333273e6bf77013b03.json
@@ -1,0 +1,142 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        INSERT INTO property_definitions (\n            id,\n            team_id,\n            user_id,\n            display_name,\n            data_type,\n            is_multi_select,\n            specific_entity_type\n        )\n        VALUES ($1, $2, $3, $4, $5, $6, $7)\n        RETURNING\n            id,\n            team_id,\n            user_id,\n            display_name,\n            data_type as \"data_type: DataType\",\n            is_multi_select,\n            specific_entity_type as \"specific_entity_type: Option<EntityType>\",\n            created_at,\n            updated_at\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "team_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "user_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "display_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "data_type: DataType",
+        "type_info": {
+          "Custom": {
+            "name": "property_data_type",
+            "kind": {
+              "Enum": [
+                "BOOLEAN",
+                "DATE",
+                "NUMBER",
+                "STRING",
+                "SELECT_NUMBER",
+                "SELECT_STRING",
+                "ENTITY",
+                "LINK",
+                "TAG"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 5,
+        "name": "is_multi_select",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 6,
+        "name": "specific_entity_type: Option<EntityType>",
+        "type_info": {
+          "Custom": {
+            "name": "property_entity_type",
+            "kind": {
+              "Enum": [
+                "CHANNEL",
+                "CHAT",
+                "DOCUMENT",
+                "PROJECT",
+                "THREAD",
+                "USER",
+                "COMPANY",
+                "TASK"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 7,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 8,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Text",
+        "Text",
+        {
+          "Custom": {
+            "name": "property_data_type",
+            "kind": {
+              "Enum": [
+                "BOOLEAN",
+                "DATE",
+                "NUMBER",
+                "STRING",
+                "SELECT_NUMBER",
+                "SELECT_STRING",
+                "ENTITY",
+                "LINK",
+                "TAG"
+              ]
+            }
+          }
+        },
+        "Bool",
+        {
+          "Custom": {
+            "name": "property_entity_type",
+            "kind": {
+              "Enum": [
+                "CHANNEL",
+                "CHAT",
+                "DOCUMENT",
+                "PROJECT",
+                "THREAD",
+                "USER",
+                "COMPANY",
+                "TASK"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      true,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "6fd87794b687b1687b8c4f0bc0390ffcc91811ae9909ce333273e6bf77013b03"
+}

--- a/rust/cloud-storage/properties_db_client/.sqlx/query-7ae5368ee01e670dcc9804096f3d3e9dcab6dcebcb601bfb1ed190dbda0ff37f.json
+++ b/rust/cloud-storage/properties_db_client/.sqlx/query-7ae5368ee01e670dcc9804096f3d3e9dcab6dcebcb601bfb1ed190dbda0ff37f.json
@@ -1,0 +1,34 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        INSERT INTO entity_properties (id, entity_id, entity_type, property_definition_id, values)\n        VALUES ($1, $2, $3, $4, $5)\n        ON CONFLICT (entity_id, entity_type, property_definition_id) \n        DO UPDATE SET \n            values = EXCLUDED.values,\n            updated_at = NOW()\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        {
+          "Custom": {
+            "name": "property_entity_type",
+            "kind": {
+              "Enum": [
+                "CHANNEL",
+                "CHAT",
+                "DOCUMENT",
+                "PROJECT",
+                "THREAD",
+                "USER",
+                "COMPANY",
+                "TASK"
+              ]
+            }
+          }
+        },
+        "Uuid",
+        "Jsonb"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "7ae5368ee01e670dcc9804096f3d3e9dcab6dcebcb601bfb1ed190dbda0ff37f"
+}

--- a/rust/cloud-storage/properties_db_client/.sqlx/query-9d1892f8bb8ba65131fa035ffe3e79f932f8668dd7dce998e2a885bcaf0d8bbf.json
+++ b/rust/cloud-storage/properties_db_client/.sqlx/query-9d1892f8bb8ba65131fa035ffe3e79f932f8668dd7dce998e2a885bcaf0d8bbf.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        UPDATE entity_properties\n        SET\n            values = jsonb_set(\n                values,\n                '{value}',\n                COALESCE(\n                    (\n                        SELECT jsonb_agg(elem)\n                        FROM jsonb_array_elements(values -> 'value') AS elem\n                        WHERE elem <> to_jsonb($2::text)\n                    ),\n                    '[]'::jsonb\n                )\n            ),\n            updated_at = NOW()\n        WHERE property_definition_id = $1\n          AND values @> jsonb_build_object('value', jsonb_build_array($2::text))\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "9d1892f8bb8ba65131fa035ffe3e79f932f8668dd7dce998e2a885bcaf0d8bbf"
+}

--- a/rust/cloud-storage/properties_db_client/.sqlx/query-a63c0f9e0b3c58438d46cff265e3f412890402e3627b85d5dfb74a08d72787e1.json
+++ b/rust/cloud-storage/properties_db_client/.sqlx/query-a63c0f9e0b3c58438d46cff265e3f412890402e3627b85d5dfb74a08d72787e1.json
@@ -1,0 +1,109 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT\n            id,\n            team_id,\n            user_id,\n            display_name,\n            data_type as \"data_type: DataType\",\n            is_multi_select,\n            specific_entity_type as \"specific_entity_type: Option<EntityType>\",\n            created_at,\n            updated_at,\n            is_system\n        FROM property_definitions\n        WHERE id = $1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "team_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "user_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "display_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "data_type: DataType",
+        "type_info": {
+          "Custom": {
+            "name": "property_data_type",
+            "kind": {
+              "Enum": [
+                "BOOLEAN",
+                "DATE",
+                "NUMBER",
+                "STRING",
+                "SELECT_NUMBER",
+                "SELECT_STRING",
+                "ENTITY",
+                "LINK",
+                "TAG"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 5,
+        "name": "is_multi_select",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 6,
+        "name": "specific_entity_type: Option<EntityType>",
+        "type_info": {
+          "Custom": {
+            "name": "property_entity_type",
+            "kind": {
+              "Enum": [
+                "CHANNEL",
+                "CHAT",
+                "DOCUMENT",
+                "PROJECT",
+                "THREAD",
+                "USER",
+                "COMPANY",
+                "TASK"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 7,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 8,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 9,
+        "name": "is_system",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      true,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "a63c0f9e0b3c58438d46cff265e3f412890402e3627b85d5dfb74a08d72787e1"
+}

--- a/rust/cloud-storage/properties_db_client/.sqlx/query-b370ac2ac7ace6911ff13454d24ff42b906dcc72b2fb4bcd783b8cb7c06ceab4.json
+++ b/rust/cloud-storage/properties_db_client/.sqlx/query-b370ac2ac7ace6911ff13454d24ff42b906dcc72b2fb4bcd783b8cb7c06ceab4.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM entity_properties WHERE id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "b370ac2ac7ace6911ff13454d24ff42b906dcc72b2fb4bcd783b8cb7c06ceab4"
+}

--- a/rust/cloud-storage/properties_db_client/.sqlx/query-b6a900ce4ef05b399b15c5df9df622228577a112642245990b64442fb691305f.json
+++ b/rust/cloud-storage/properties_db_client/.sqlx/query-b6a900ce4ef05b399b15c5df9df622228577a112642245990b64442fb691305f.json
@@ -1,0 +1,111 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT\n            id,\n            team_id,\n            user_id,\n            display_name,\n            data_type as \"data_type: DataType\",\n            is_multi_select,\n            specific_entity_type as \"specific_entity_type: Option<EntityType>\",\n            created_at,\n            updated_at,\n            is_system\n        FROM property_definitions\n        WHERE\n            ($3 AND is_system)\n            OR (\n                ($1::uuid IS NOT NULL AND team_id = $1)\n                OR ($2::text IS NOT NULL AND user_id = $2)\n            )\n        ORDER BY LOWER(display_name) ASC\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "team_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "user_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "display_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "data_type: DataType",
+        "type_info": {
+          "Custom": {
+            "name": "property_data_type",
+            "kind": {
+              "Enum": [
+                "BOOLEAN",
+                "DATE",
+                "NUMBER",
+                "STRING",
+                "SELECT_NUMBER",
+                "SELECT_STRING",
+                "ENTITY",
+                "LINK",
+                "TAG"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 5,
+        "name": "is_multi_select",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 6,
+        "name": "specific_entity_type: Option<EntityType>",
+        "type_info": {
+          "Custom": {
+            "name": "property_entity_type",
+            "kind": {
+              "Enum": [
+                "CHANNEL",
+                "CHAT",
+                "DOCUMENT",
+                "PROJECT",
+                "THREAD",
+                "USER",
+                "COMPANY",
+                "TASK"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 7,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 8,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 9,
+        "name": "is_system",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      true,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "b6a900ce4ef05b399b15c5df9df622228577a112642245990b64442fb691305f"
+}

--- a/rust/cloud-storage/properties_db_client/.sqlx/query-be9196900ae5aa5d1bf5bdee0a4e8bb94fa15e24fe46ee1fd0cbeb9b644c80ea.json
+++ b/rust/cloud-storage/properties_db_client/.sqlx/query-be9196900ae5aa5d1bf5bdee0a4e8bb94fa15e24fe46ee1fd0cbeb9b644c80ea.json
@@ -1,0 +1,153 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT\n            pd.id,\n            pd.team_id,\n            pd.user_id,\n            pd.display_name,\n            pd.data_type as \"data_type: DataType\",\n            pd.is_multi_select,\n            pd.specific_entity_type as \"specific_entity_type: Option<EntityType>\",\n            pd.created_at,\n            pd.updated_at,\n            pd.is_system,\n            po.id as \"option_id?\",\n            po.display_order as \"option_display_order?\",\n            po.number_value as option_number_value,\n            po.string_value as option_string_value,\n            po.color as option_color,\n            po.created_at as \"option_created_at?\",\n            po.updated_at as \"option_updated_at?\"\n        FROM property_definitions pd\n        LEFT JOIN property_options po ON pd.id = po.property_definition_id\n        WHERE\n            ($3 AND pd.is_system)\n            OR (\n                ($1::uuid IS NOT NULL AND pd.team_id = $1)\n                OR ($2::text IS NOT NULL AND pd.user_id = $2)\n            )\n        ORDER BY LOWER(pd.display_name), po.display_order, po.number_value, LOWER(po.string_value)\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "team_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "user_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "display_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "data_type: DataType",
+        "type_info": {
+          "Custom": {
+            "name": "property_data_type",
+            "kind": {
+              "Enum": [
+                "BOOLEAN",
+                "DATE",
+                "NUMBER",
+                "STRING",
+                "SELECT_NUMBER",
+                "SELECT_STRING",
+                "ENTITY",
+                "LINK",
+                "TAG"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 5,
+        "name": "is_multi_select",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 6,
+        "name": "specific_entity_type: Option<EntityType>",
+        "type_info": {
+          "Custom": {
+            "name": "property_entity_type",
+            "kind": {
+              "Enum": [
+                "CHANNEL",
+                "CHAT",
+                "DOCUMENT",
+                "PROJECT",
+                "THREAD",
+                "USER",
+                "COMPANY",
+                "TASK"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 7,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 8,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 9,
+        "name": "is_system",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 10,
+        "name": "option_id?",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 11,
+        "name": "option_display_order?",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 12,
+        "name": "option_number_value",
+        "type_info": "Float8"
+      },
+      {
+        "ordinal": 13,
+        "name": "option_string_value",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 14,
+        "name": "option_color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 15,
+        "name": "option_created_at?",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 16,
+        "name": "option_updated_at?",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      true,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "be9196900ae5aa5d1bf5bdee0a4e8bb94fa15e24fe46ee1fd0cbeb9b644c80ea"
+}

--- a/rust/cloud-storage/properties_db_client/.sqlx/query-c12b511f8fbe853ce8e5489db2468ee8a07030cb234bc0a10bc014c493b8e9c2.json
+++ b/rust/cloud-storage/properties_db_client/.sqlx/query-c12b511f8fbe853ce8e5489db2468ee8a07030cb234bc0a10bc014c493b8e9c2.json
@@ -1,0 +1,31 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM entity_properties WHERE entity_id = $1 AND entity_type = $2",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        {
+          "Custom": {
+            "name": "property_entity_type",
+            "kind": {
+              "Enum": [
+                "CHANNEL",
+                "CHAT",
+                "DOCUMENT",
+                "PROJECT",
+                "THREAD",
+                "USER",
+                "COMPANY",
+                "TASK"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "c12b511f8fbe853ce8e5489db2468ee8a07030cb234bc0a10bc014c493b8e9c2"
+}

--- a/rust/cloud-storage/properties_db_client/.sqlx/query-c6f8bb6a2a9cda820cf54efb5e4ff8b048d735cfcc23716612f2ee66a8c7151c.json
+++ b/rust/cloud-storage/properties_db_client/.sqlx/query-c6f8bb6a2a9cda820cf54efb5e4ff8b048d735cfcc23716612f2ee66a8c7151c.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM property_options WHERE id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "c6f8bb6a2a9cda820cf54efb5e4ff8b048d735cfcc23716612f2ee66a8c7151c"
+}

--- a/rust/cloud-storage/properties_db_client/.sqlx/query-d09a22b5d0a049677c6fc96d0aef74260d592ae30752c12a50512ebf95592e5f.json
+++ b/rust/cloud-storage/properties_db_client/.sqlx/query-d09a22b5d0a049677c6fc96d0aef74260d592ae30752c12a50512ebf95592e5f.json
@@ -1,0 +1,178 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\nSELECT\n    ep.id as entity_property_id,\n    ep.entity_id,\n    ep.entity_type as \"entity_type: EntityType\",\n    ep.property_definition_id,\n    ep.values as \"values: sqlx::types::JsonValue\",\n    ep.created_at as entity_property_created_at,\n    ep.updated_at as entity_property_updated_at,\n    pd.team_id as definition_team_id,\n    pd.user_id as definition_user_id,\n    pd.display_name,\n    pd.data_type as \"data_type: DataType\",\n    pd.is_multi_select,\n    pd.specific_entity_type as \"specific_entity_type: Option<EntityType>\",\n    pd.created_at as definition_created_at,\n    pd.updated_at as definition_updated_at,\n    pd.is_system as definition_is_system\nFROM entity_properties ep\nINNER JOIN property_definitions pd ON ep.property_definition_id = pd.id\nWHERE ep.entity_id = $1 AND ep.entity_type = $2\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_property_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "entity_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "entity_type: EntityType",
+        "type_info": {
+          "Custom": {
+            "name": "property_entity_type",
+            "kind": {
+              "Enum": [
+                "CHANNEL",
+                "CHAT",
+                "DOCUMENT",
+                "PROJECT",
+                "THREAD",
+                "USER",
+                "COMPANY",
+                "TASK"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 3,
+        "name": "property_definition_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 4,
+        "name": "values: sqlx::types::JsonValue",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 5,
+        "name": "entity_property_created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 6,
+        "name": "entity_property_updated_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 7,
+        "name": "definition_team_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 8,
+        "name": "definition_user_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 9,
+        "name": "display_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 10,
+        "name": "data_type: DataType",
+        "type_info": {
+          "Custom": {
+            "name": "property_data_type",
+            "kind": {
+              "Enum": [
+                "BOOLEAN",
+                "DATE",
+                "NUMBER",
+                "STRING",
+                "SELECT_NUMBER",
+                "SELECT_STRING",
+                "ENTITY",
+                "LINK",
+                "TAG"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 11,
+        "name": "is_multi_select",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 12,
+        "name": "specific_entity_type: Option<EntityType>",
+        "type_info": {
+          "Custom": {
+            "name": "property_entity_type",
+            "kind": {
+              "Enum": [
+                "CHANNEL",
+                "CHAT",
+                "DOCUMENT",
+                "PROJECT",
+                "THREAD",
+                "USER",
+                "COMPANY",
+                "TASK"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 13,
+        "name": "definition_created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 14,
+        "name": "definition_updated_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 15,
+        "name": "definition_is_system",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        {
+          "Custom": {
+            "name": "property_entity_type",
+            "kind": {
+              "Enum": [
+                "CHANNEL",
+                "CHAT",
+                "DOCUMENT",
+                "PROJECT",
+                "THREAD",
+                "USER",
+                "COMPANY",
+                "TASK"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      true,
+      true,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "d09a22b5d0a049677c6fc96d0aef74260d592ae30752c12a50512ebf95592e5f"
+}

--- a/rust/cloud-storage/properties_db_client/.sqlx/query-d9521e04db4b5f1603cf5daf48a5e7216c9eee8a4c99f254b1b9471a918b884c.json
+++ b/rust/cloud-storage/properties_db_client/.sqlx/query-d9521e04db4b5f1603cf5daf48a5e7216c9eee8a4c99f254b1b9471a918b884c.json
@@ -1,0 +1,19 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        INSERT INTO property_options (\n            id,\n            property_definition_id,\n            display_order,\n            number_value,\n            string_value,\n            color\n        )\n        VALUES ($1, $2, $3, $4, $5, $6)\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Int4",
+        "Float8",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "d9521e04db4b5f1603cf5daf48a5e7216c9eee8a4c99f254b1b9471a918b884c"
+}

--- a/rust/cloud-storage/properties_db_client/.sqlx/query-dc836e7dd12a3df4a05ba072af32cb1aca7d6b8c20e636adff6fb3977577e62a.json
+++ b/rust/cloud-storage/properties_db_client/.sqlx/query-dc836e7dd12a3df4a05ba072af32cb1aca7d6b8c20e636adff6fb3977577e62a.json
@@ -1,0 +1,52 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT\n            t.id,\n            t.latest_inbound_message_ts as last_received,\n            t.latest_outbound_message_ts as last_sent,\n            first_msg.internal_date_ts as thread_started,\n            first_msg.subject,\n            (SELECT COUNT(*)::bigint FROM email_messages WHERE thread_id = t.id) as \"message_count!\"\n        FROM\n            email_threads t\n        -- LATERAL join to get subject and timestamp from the first message\n        LEFT JOIN LATERAL (\n            SELECT internal_date_ts, subject\n            FROM email_messages\n            WHERE thread_id = t.id\n            ORDER BY internal_date_ts ASC NULLS LAST\n            LIMIT 1\n        ) first_msg ON true\n        WHERE\n            t.id = $1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "last_received",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 2,
+        "name": "last_sent",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 3,
+        "name": "thread_started",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 4,
+        "name": "subject",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "message_count!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      true,
+      true,
+      true,
+      null
+    ]
+  },
+  "hash": "dc836e7dd12a3df4a05ba072af32cb1aca7d6b8c20e636adff6fb3977577e62a"
+}

--- a/rust/cloud-storage/properties_db_client/.sqlx/query-e3502d4611d734fa9d27c17c3adb0785d06317da255894345de287a654f24fc3.json
+++ b/rust/cloud-storage/properties_db_client/.sqlx/query-e3502d4611d734fa9d27c17c3adb0785d06317da255894345de287a654f24fc3.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM property_definitions WHERE id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "e3502d4611d734fa9d27c17c3adb0785d06317da255894345de287a654f24fc3"
+}

--- a/rust/cloud-storage/properties_db_client/.sqlx/query-eaf32ba063527b6af6e09f701039d2bf0fd4316d9e1280175eca27a0470c2a71.json
+++ b/rust/cloud-storage/properties_db_client/.sqlx/query-eaf32ba063527b6af6e09f701039d2bf0fd4316d9e1280175eca27a0470c2a71.json
@@ -1,0 +1,45 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT\n            property_definition_id,\n            values as \"values: serde_json::Value\"\n        FROM entity_properties\n        WHERE entity_id = $1\n          AND entity_type = $2\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "property_definition_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "values: serde_json::Value",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        {
+          "Custom": {
+            "name": "property_entity_type",
+            "kind": {
+              "Enum": [
+                "CHANNEL",
+                "CHAT",
+                "DOCUMENT",
+                "PROJECT",
+                "THREAD",
+                "USER",
+                "COMPANY",
+                "TASK"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "nullable": [
+      false,
+      true
+    ]
+  },
+  "hash": "eaf32ba063527b6af6e09f701039d2bf0fd4316d9e1280175eca27a0470c2a71"
+}

--- a/rust/cloud-storage/properties_db_client/fixtures/tags.sql
+++ b/rust/cloud-storage/properties_db_client/fixtures/tags.sql
@@ -1,0 +1,16 @@
+-- Tag definitions: per-owner label sets (user1 personal, Team 1, user2 personal).
+-- Kept separate from properties.sql so definition-count assertions stay valid.
+INSERT INTO property_definitions (id, team_id, user_id, display_name, data_type, is_multi_select, specific_entity_type)
+VALUES
+    ('aa111111-1111-1111-1111-111111111111', NULL, 'user1', 'Tags', 'TAG', true, NULL),
+    ('aa222222-2222-2222-2222-222222222222', '0e000000-0000-0000-0000-000000000001', NULL, 'Tags', 'TAG', true, NULL),
+    ('aa333333-3333-3333-3333-333333333333', NULL, 'user2', 'Tags', 'TAG', true, NULL)
+ON CONFLICT (id) DO NOTHING;
+
+-- tagdoc1 carries a regular select plus one tag application per owner above.
+INSERT INTO entity_properties (id, entity_id, entity_type, property_definition_id, values)
+VALUES
+    ('e0777777-7777-7777-7777-777777777771', 'tagdoc1', 'DOCUMENT', '11111111-1111-1111-1111-111111111111', '{"type": "SelectOption", "value": ["10111111-1111-1111-1111-111111111113"]}'),
+    ('e0777777-7777-7777-7777-777777777772', 'tagdoc1', 'DOCUMENT', 'aa111111-1111-1111-1111-111111111111', '{"type": "SelectOption", "value": ["0aa11111-1111-1111-1111-111111111111"]}'),
+    ('e0777777-7777-7777-7777-777777777773', 'tagdoc1', 'DOCUMENT', 'aa222222-2222-2222-2222-222222222222', '{"type": "SelectOption", "value": ["0aa22222-2222-2222-2222-222222222222"]}'),
+    ('e0777777-7777-7777-7777-777777777774', 'tagdoc1', 'DOCUMENT', 'aa333333-3333-3333-3333-333333333333', '{"type": "SelectOption", "value": ["0aa33333-3333-3333-3333-333333333333"]}');

--- a/rust/cloud-storage/properties_db_client/src/entity_properties/get.rs
+++ b/rust/cloud-storage/properties_db_client/src/entity_properties/get.rs
@@ -471,14 +471,16 @@ WHERE (ep.entity_id, ep.entity_type) IN (
 
 /// Gets entity properties with their definitions and values for multiple entities, filtered by property definition IDs.
 /// Returns a HashMap where the key is the entity_id and the value is Vec<EntityPropertyWithDefinition>.
-/// Only returns properties matching the specified property_ids.
+/// Only returns properties matching the specified property_ids. When `tag_viewer_user_id` is set,
+/// also returns TAG properties whose definition is owned by that user or their team.
 #[tracing::instrument(skip(db))]
 pub async fn get_bulk_entity_properties_values_filtered(
     db: &Pool<Postgres>,
     entity_refs: &[EntityReference],
     property_ids: &[Uuid],
+    tag_viewer_user_id: Option<&str>,
 ) -> Result<HashMap<String, Vec<EntityPropertyWithDefinition>>> {
-    if entity_refs.is_empty() || property_ids.is_empty() {
+    if entity_refs.is_empty() || (property_ids.is_empty() && tag_viewer_user_id.is_none()) {
         // If no property_ids specified, return empty map for each entity
         let mut result = HashMap::new();
         for entity_ref in entity_refs {
@@ -514,11 +516,23 @@ INNER JOIN property_definitions pd ON ep.property_definition_id = pd.id
 WHERE (ep.entity_id, ep.entity_type) IN (
     SELECT * FROM UNNEST($1::TEXT[], $2::property_entity_type[])
 )
-AND pd.id = ANY($3::UUID[])
+AND (
+    pd.id = ANY($3::UUID[])
+    OR (
+        $4::text IS NOT NULL
+        AND pd.data_type = $5
+        AND (
+            pd.user_id = $4
+            OR pd.team_id IN (SELECT tu.team_id FROM team_user tu WHERE tu.user_id = $4)
+        )
+    )
+)
         "#,
         &entity_ids,
         &entity_types as &[EntityType],
-        &property_ids
+        &property_ids,
+        tag_viewer_user_id,
+        DataType::Tag as DataType
     )
     .fetch_all(db)
     .await?;
@@ -1136,6 +1150,73 @@ mod tests {
         } else {
             panic!("Expected Number value");
         }
+
+        Ok(())
+    }
+
+    /// Definition ids returned for tagdoc1 given a set of requested property
+    /// ids and an optional tag viewer.
+    async fn tagdoc_definition_ids(
+        pool: &Pool<Postgres>,
+        property_ids: &[Uuid],
+        tag_viewer: Option<&str>,
+    ) -> anyhow::Result<Vec<Uuid>> {
+        let entity_refs = vec![EntityReference {
+            entity_id: "tagdoc1".to_string(),
+            entity_type: EntityType::Document,
+            specific_message_id: None,
+        }];
+        let map = get_bulk_entity_properties_values_filtered(
+            pool,
+            &entity_refs,
+            property_ids,
+            tag_viewer,
+        )
+        .await?;
+        Ok(map["tagdoc1"]
+            .iter()
+            .map(|p| p.definition.id)
+            .collect::<Vec<_>>())
+    }
+
+    #[sqlx::test(
+        migrator = "MACRO_DB_MIGRATIONS",
+        fixtures(path = "../../fixtures", scripts("properties", "tags"))
+    )]
+    async fn test_get_bulk_filtered_includes_caller_visible_tags(
+        pool: Pool<Postgres>,
+    ) -> anyhow::Result<()> {
+        const _: &sqlx::migrate::Migrator = &MACRO_DB_MIGRATIONS;
+
+        let priority = Uuid::parse_str("11111111-1111-1111-1111-111111111111")?;
+        let user1_tags = Uuid::parse_str("aa111111-1111-1111-1111-111111111111")?;
+        let team1_tags = Uuid::parse_str("aa222222-2222-2222-2222-222222222222")?;
+        let user2_tags = Uuid::parse_str("aa333333-3333-3333-3333-333333333333")?;
+
+        // user1 sees the requested id plus their own and their team's tags,
+        // never another user's personal tags.
+        let ids = tagdoc_definition_ids(&pool, &[priority], Some("user1")).await?;
+        assert_eq!(ids.len(), 3);
+        assert!(ids.contains(&priority));
+        assert!(ids.contains(&user1_tags));
+        assert!(ids.contains(&team1_tags));
+        assert!(!ids.contains(&user2_tags));
+
+        // A teammate without a personal set sees only the team tags.
+        let ids = tagdoc_definition_ids(&pool, &[priority], Some("user3")).await?;
+        assert_eq!(ids.len(), 2);
+        assert!(ids.contains(&priority));
+        assert!(ids.contains(&team1_tags));
+
+        // No viewer: only the explicitly requested ids.
+        let ids = tagdoc_definition_ids(&pool, &[priority], None).await?;
+        assert_eq!(ids, vec![priority]);
+
+        // A viewer with no requested ids still gets their tags.
+        let ids = tagdoc_definition_ids(&pool, &[], Some("user1")).await?;
+        assert_eq!(ids.len(), 2);
+        assert!(ids.contains(&user1_tags));
+        assert!(ids.contains(&team1_tags));
 
         Ok(())
     }

--- a/rust/cloud-storage/properties_service/src/api/properties/entities/get_bulk.rs
+++ b/rust/cloud-storage/properties_service/src/api/properties/entities/get_bulk.rs
@@ -71,6 +71,7 @@ async fn get_bulk_entity_properties_impl(
             &state.db,
             &request.entities,
             &request.property_ids,
+            None,
         )
         .await
     }

--- a/rust/cloud-storage/soup/src/domain/ports.rs
+++ b/rust/cloud-storage/soup/src/domain/ports.rs
@@ -4,6 +4,7 @@ use crate::domain::models::{
 };
 use either::Either;
 use entity_access::domain::models::{EntityAccessReceipt, MemberTeamRole};
+use macro_user_id::user_id::MacroUserIdStr;
 use models_pagination::{Frecency, PaginatedCursor, SimpleSortMethod};
 use models_soup::item::SoupItem;
 use serde::Serialize;
@@ -37,10 +38,12 @@ pub trait SoupRepo: Send + Sync + 'static {
         req: AdvancedSortParams<'a>,
     ) -> impl Future<Output = Result<Vec<SoupItem>, Self::Err>> + Send;
 
-    /// Populates properties for a slice of SoupItems.
-    fn populate_properties(
+    /// Populates properties for a slice of SoupItems. The user id scopes which
+    /// tag properties are visible (the caller's own and their team's).
+    fn populate_properties<'a>(
         &self,
-        items: &mut [SoupItem],
+        user_id: MacroUserIdStr<'a>,
+        items: &'a mut [SoupItem],
     ) -> impl Future<Output = Result<(), Self::Err>> + Send;
 
     /// Fetches expanded soup items with group metadata.

--- a/rust/cloud-storage/soup/src/domain/service.rs
+++ b/rust/cloud-storage/soup/src/domain/service.rs
@@ -322,6 +322,7 @@ where
     #[tracing::instrument(err, skip(self, req))]
     async fn handle_email_request(
         &self,
+        user_id: MacroUserIdStr<'_>,
         req: Option<GetEmailsRequest>,
     ) -> Result<impl Iterator<Item = FrecencySoupItem>, SoupErr> {
         use frecency::domain::models::AggregateFrecency;
@@ -360,7 +361,7 @@ where
             .collect();
 
         self.soup_storage
-            .populate_properties(&mut items)
+            .populate_properties(user_id, &mut items)
             .await
             .map_err(anyhow::Error::from)?;
 
@@ -567,7 +568,7 @@ where
                     },
                 );
 
-                let email_soup_fut = self.handle_email_request(email_request);
+                let email_soup_fut = self.handle_email_request(req.user.copied(), email_request);
 
                 let comms_soup_fut = self.handle_comms_request(comms_request);
 

--- a/rust/cloud-storage/soup/src/domain/service/tests.rs
+++ b/rust/cloud-storage/soup/src/domain/service/tests.rs
@@ -924,7 +924,7 @@ async fn it_should_not_query_frecency() {
         });
     soup_mock
         .expect_populate_properties()
-        .returning(|_| Box::pin(async { Ok(()) }));
+        .returning(|_, _| Box::pin(async { Ok(()) }));
 
     let res = SoupImpl::new(
         soup_mock,
@@ -1535,7 +1535,7 @@ async fn cursor_should_return_simple_sort() {
         });
     soup_mock
         .expect_populate_properties()
-        .returning(|_| Box::pin(async { Ok(()) }));
+        .returning(|_, _| Box::pin(async { Ok(()) }));
 
     let res = SoupImpl::new(
         soup_mock,
@@ -1669,7 +1669,7 @@ async fn it_should_return_is_completed_true_for_completed_tasks() {
         });
     soup_mock
         .expect_populate_properties()
-        .returning(|_| Box::pin(async { Ok(()) }));
+        .returning(|_, _| Box::pin(async { Ok(()) }));
 
     let res = SoupImpl::new(
         soup_mock,
@@ -1721,7 +1721,7 @@ async fn it_should_return_is_completed_false_for_incomplete_tasks() {
         });
     soup_mock
         .expect_populate_properties()
-        .returning(|_| Box::pin(async { Ok(()) }));
+        .returning(|_, _| Box::pin(async { Ok(()) }));
 
     let res = SoupImpl::new(
         soup_mock,
@@ -1773,7 +1773,7 @@ async fn it_should_return_is_completed_none_for_non_tasks() {
         });
     soup_mock
         .expect_populate_properties()
-        .returning(|_| Box::pin(async { Ok(()) }));
+        .returning(|_, _| Box::pin(async { Ok(()) }));
 
     let res = SoupImpl::new(
         soup_mock,
@@ -1837,7 +1837,7 @@ async fn it_should_preserve_is_completed_for_mixed_items() {
         });
     soup_mock
         .expect_populate_properties()
-        .returning(|_| Box::pin(async { Ok(()) }));
+        .returning(|_, _| Box::pin(async { Ok(()) }));
 
     let res = SoupImpl::new(
         soup_mock,

--- a/rust/cloud-storage/soup/src/outbound/pg_soup_repo.rs
+++ b/rust/cloud-storage/soup/src/outbound/pg_soup_repo.rs
@@ -11,7 +11,7 @@ use crate::{
     },
 };
 use either::Either;
-use macro_user_id::{cowlike::CowLike, user_id::MacroUserIdStr};
+use macro_user_id::user_id::MacroUserIdStr;
 use models_soup::{SoupProperty, item::SoupItem};
 use readonly_pool::ReadOnlyPool;
 use system_properties::SystemPropertyKey;

--- a/rust/cloud-storage/soup/src/outbound/pg_soup_repo.rs
+++ b/rust/cloud-storage/soup/src/outbound/pg_soup_repo.rs
@@ -11,6 +11,7 @@ use crate::{
     },
 };
 use either::Either;
+use macro_user_id::{cowlike::CowLike, user_id::MacroUserIdStr};
 use models_soup::{SoupProperty, item::SoupItem};
 use readonly_pool::ReadOnlyPool;
 use system_properties::SystemPropertyKey;
@@ -125,11 +126,12 @@ impl SoupRepo for PgSoupRepo {
         unexpanded::by_ids::unexpanded_soup_by_ids(&self.pool.0, req.user_id, req.entities)
     }
 
-    fn populate_properties(
+    fn populate_properties<'a>(
         &self,
-        items: &mut [SoupItem],
+        user_id: MacroUserIdStr<'a>,
+        items: &'a mut [SoupItem],
     ) -> impl Future<Output = Result<(), Self::Err>> + Send {
-        populate_properties(&self.pool.0, items)
+        populate_properties(&self.pool.0, user_id, items)
     }
 
     fn expanded_grouped_cursor_soup<'a>(
@@ -166,11 +168,13 @@ fn type_err<E: std::fmt::Display>(e: E) -> sqlx::Error {
 /// Fetches and populates properties for a slice of SoupItems.
 ///
 /// This helper collects entity references from items that support properties,
-/// fetches their properties in bulk, and assigns them to each item.
+/// fetches their properties in bulk, and assigns them to each item. System
+/// properties are always included, plus the caller's own and team tag properties.
 /// Tasks use `EntityType::Task` while regular documents use `EntityType::Document`.
 #[tracing::instrument(err, skip(db, items))]
 pub(crate) async fn populate_properties(
     db: &sqlx::PgPool,
+    user_id: MacroUserIdStr<'_>,
     items: &mut [SoupItem],
 ) -> Result<(), sqlx::Error> {
     let entity_refs = items
@@ -188,6 +192,7 @@ pub(crate) async fn populate_properties(
             db,
             &entity_refs,
             property_ids,
+            Some(user_id.as_ref()),
         )
         .await
         .map_err(|e| sqlx::Error::Decode(Box::new(e)))?;

--- a/rust/cloud-storage/soup/src/outbound/pg_soup_repo/expanded/by_cursor.rs
+++ b/rust/cloud-storage/soup/src/outbound/pg_soup_repo/expanded/by_cursor.rs
@@ -258,7 +258,7 @@ r#"
         .fetch_all(db)
         .await?;
 
-    populate_properties(db, &mut items).await?;
+    populate_properties(db, user_id.copied(), &mut items).await?;
 
     Ok(items)
 }
@@ -452,7 +452,7 @@ r#"
         .fetch_all(db)
         .await?;
 
-    populate_properties(db, &mut items).await?;
+    populate_properties(db, user_id.copied(), &mut items).await?;
 
     Ok(items)
 }

--- a/rust/cloud-storage/soup/src/outbound/pg_soup_repo/expanded/by_ids.rs
+++ b/rust/cloud-storage/soup/src/outbound/pg_soup_repo/expanded/by_ids.rs
@@ -162,7 +162,7 @@ pub async fn expanded_soup_by_ids<'a>(
     .fetch_all(db)
     .await?;
 
-    populate_properties(db, &mut items).await?;
+    populate_properties(db, user_id.copied(), &mut items).await?;
 
     Ok(items)
 }

--- a/rust/cloud-storage/soup/src/outbound/pg_soup_repo/expanded/dynamic.rs
+++ b/rust/cloud-storage/soup/src/outbound/pg_soup_repo/expanded/dynamic.rs
@@ -1589,7 +1589,7 @@ pub(crate) async fn expanded_dynamic_cursor_soup(
         .fetch_all(db)
         .await?;
 
-    populate_properties(db, &mut items).await?;
+    populate_properties(db, user_id.copied(), &mut items).await?;
 
     Ok(items)
 }
@@ -1936,7 +1936,7 @@ pub async fn expanded_dynamic_cursor_soup_grouped(
         .into_iter()
         .unzip();
 
-    populate_properties(db, &mut soup_items).await?;
+    populate_properties(db, user_id.copied(), &mut soup_items).await?;
 
     let items = soup_items
         .into_iter()

--- a/rust/cloud-storage/soup/src/outbound/pg_soup_repo/unexpanded/by_cursor.rs
+++ b/rust/cloud-storage/soup/src/outbound/pg_soup_repo/unexpanded/by_cursor.rs
@@ -207,7 +207,7 @@ pub async fn unexpanded_generic_cursor_soup(
     .fetch_all(db)
     .await?;
 
-    populate_properties(db, &mut items).await?;
+    populate_properties(db, user_id.copied(), &mut items).await?;
 
     Ok(items)
 }

--- a/rust/cloud-storage/soup/src/outbound/pg_soup_repo/unexpanded/by_ids.rs
+++ b/rust/cloud-storage/soup/src/outbound/pg_soup_repo/unexpanded/by_ids.rs
@@ -199,7 +199,7 @@ pub async fn unexpanded_soup_by_ids<'a>(
     .fetch_all(db)
     .await?;
 
-    populate_properties(db, &mut items).await?;
+    populate_properties(db, user_id.copied(), &mut items).await?;
 
     Ok(items)
 }


### PR DESCRIPTION
Renders an entity's tags as compact chips on task and document (Files) list rows — up to three chips then a `+N tags` overflow with overlapping color dots. Clicking a chip or the overflow opens the tag editor; hovering surfaces a "Filter by" link (and the overflow lists the hidden tags) that filters the current list to that tag, applied on top of the active tab and filters. Soup payloads now include the caller-visible TAG properties (own + team, resolved in SQL via team_user), so rows render tags straight from the list response with no per-row property fetches.
