### PR TITLE
fix(email): show send button on mobile forward without typed body

### DIFF
--- a/js/app/packages/block-email/component/BaseInput.tsx
+++ b/js/app/packages/block-email/component/BaseInput.tsx
@@ -1937,7 +1937,13 @@ export function BaseInput(props: {
               !!form().sendTime()
             }
             pending={sendMutation.isPending}
-            hidden={isMobile() && !hasBodyText()}
+            hidden={
+              isMobile() &&
+              !hasBodyText() &&
+              // Forwards carry the quoted thread as content, so send is
+              // available without typing anything.
+              effectiveReplyType() !== 'forward'
+            }
             onClick={() => sendEmail()}
           />
         </div>


### PR DESCRIPTION
## Summary

On mobile, the send button in the thread reply input is hidden until the typed body is non-empty. That's fine for replies, but a forward already carries content: switching to forward sets `withQuotedText: true` and appends the quoted thread (plus the original message's attachments), so requiring the user to type something before send appears is wrong.

## Change

Exempt forwards from the mobile empty-body hide in `BaseInput.tsx`: the send button now shows when the typed body is non-empty **or** the compose is in forward mode. Replies and reply-alls keep the existing behavior.

The standalone compose (`Compose.tsx`) doesn't have this gating, so no change was needed there.