### PR TITLE
fix(soup): include root projects in negated project-id filters

### DIFF
--- a/rust/cloud-storage/soup/src/outbound/pg_soup_repo/expanded/dynamic.rs
+++ b/rust/cloud-storage/soup/src/outbound/pg_soup_repo/expanded/dynamic.rs
@@ -614,6 +614,12 @@ fn build_task_include_cbm_atm_nc_clause() -> String {
     .to_string()
 }
 
+/// NULL-safe equality for nullable columns: FALSE (not UNKNOWN) on NULL, so
+/// `NOT` includes NULL rows — e.g. root projects under a negated `pid` filter.
+fn nullable_eq(col: &str, val: impl std::fmt::Display) -> String {
+    format!("({col} = '{val}' AND {col} IS NOT NULL)")
+}
+
 fn date_predicate(col: &str, lit: &DateLiteral) -> String {
     match lit {
         DateLiteral::GreaterThan(dt) => format!("{col} > '{}'::timestamptz", dt.to_rfc3339()),
@@ -639,7 +645,7 @@ fn build_document_filter(ast: Option<&Expr<DocumentLiteral>>) -> String {
         }
         filter_ast::ExprFrame::Literal(DocumentLiteral::Id(i)) => format!("d.id = '{i}'"),
         filter_ast::ExprFrame::Literal(DocumentLiteral::ProjectId(p)) => {
-            format!(r#"d."projectId" = '{p}'"#)
+            nullable_eq(r#"d."projectId""#, p)
         }
         filter_ast::ExprFrame::Literal(DocumentLiteral::Owner(o)) => format!("d.owner = '{o}'"),
         filter_ast::ExprFrame::Literal(DocumentLiteral::Importance(true)) => {
@@ -721,7 +727,7 @@ fn build_chat_filter(ast: Option<&Expr<ChatLiteral>>) -> String {
         filter_ast::ExprFrame::Or(a, b) => format!("({a} OR {b})"),
         filter_ast::ExprFrame::Not(a) => format!("(NOT {a})"),
         filter_ast::ExprFrame::Literal(ChatLiteral::ProjectId(p)) => {
-            format!(r#"c."projectId" = '{p}'"#)
+            nullable_eq(r#"c."projectId""#, p)
         }
         // todo? I'm not sure what a chat role filter looks like.
         // No-op literals render as TRUE, not an empty string — an empty
@@ -765,7 +771,7 @@ fn build_project_filter(ast: Option<&Expr<ProjectLiteral>>) -> String {
         filter_ast::ExprFrame::Or(a, b) => format!("({a} OR {b})"),
         filter_ast::ExprFrame::Not(a) => format!("(NOT {a})"),
         filter_ast::ExprFrame::Literal(ProjectLiteral::ProjectId(p)) => {
-            format!(r#"p."parentId" = '{p}'"#)
+            nullable_eq(r#"p."parentId""#, p)
         }
         filter_ast::ExprFrame::Literal(ProjectLiteral::ProjectIdSelf(p)) => {
             format!(r#"p.id = '{p}'"#)

--- a/rust/cloud-storage/soup/src/outbound/pg_soup_repo/expanded/tests.rs
+++ b/rust/cloud-storage/soup/src/outbound/pg_soup_repo/expanded/tests.rs
@@ -1254,6 +1254,66 @@ async fn test_filter_by_project_ids_include_root(db: PgPool) -> anyhow::Result<(
     Ok(())
 }
 
+// The frontend's "all folders" filter is `pf: !(pid = nil)`. Root projects
+// have a NULL parentId, so the negated equality must not drop them.
+#[sqlx::test(
+    fixtures(
+        path = "../../../../../macro_db_client/fixtures",
+        scripts("entity_filter_tests")
+    ),
+    migrator = "MACRO_DB_MIGRATIONS"
+)]
+async fn test_negated_project_id_filter_includes_root_projects(db: PgPool) -> anyhow::Result<()> {
+    let user_id = MacroUserIdStr::parse_from_str("macro|user-1@test.com").unwrap();
+
+    // Mirror the folders-view request: docs and chats excluded via nil-id
+    // literals, projects included via a negated nil parent-id literal.
+    let filters = EntityFilterAst {
+        document_filter: Some(Arc::new(Expr::Literal(DocumentLiteral::Id(Uuid::nil())))),
+        chat_filter: Some(Arc::new(Expr::Literal(ChatLiteral::ChatId(Uuid::nil())))),
+        project_filter: Some(Arc::new(Expr::is_not(Expr::Literal(
+            ProjectLiteral::ProjectId(Uuid::nil()),
+        )))),
+        ..Default::default()
+    };
+
+    let items = expanded_dynamic_cursor_soup(
+        &db,
+        ExpandedDynamicCursorArgs {
+            user_id: user_id.copied(),
+            limit: 20,
+            cursor: Query::Sort(SimpleSortMethod::CreatedAt, filters),
+            exclude_frecency: false,
+        },
+    )
+    .await?;
+
+    let project_ids: HashSet<Uuid> = items
+        .iter()
+        .map(|item| match item {
+            SoupItem::Project(p) => p.id,
+            other => panic!("expected only projects, got {other:?}"),
+        })
+        .collect();
+
+    let expected_ids: HashSet<Uuid> = [
+        "11111111-1111-1111-1111-111111111111", // Project A (root, NULL parentId)
+        "22222222-2222-2222-2222-222222222222", // Project B (child of A)
+        "33333333-3333-3333-3333-333333333333", // Project C (child of B)
+        "44444444-4444-4444-4444-444444444444", // Project D (root, NULL parentId)
+    ]
+    .iter()
+    .map(|&s| Uuid::parse_str(s).unwrap())
+    .collect();
+
+    assert_eq!(
+        project_ids, expected_ids,
+        "negated pid filter should include root (NULL-parent) projects"
+    );
+
+    Ok(())
+}
+
 // Test combined filters across multiple entity types
 #[sqlx::test(
     fixtures(


### PR DESCRIPTION
## Problem

Root-level projects never show up in the folders soup view. The frontend's "all folders" filter (`_isFolder`) sends `pf: {"!": {"l": {"pid": "00000000-0000-0000-0000-000000000000"}}}`, which the expanded soup query builder compiles to:

```sql
NOT p."parentId" = '00000000-0000-0000-0000-000000000000'
```

Root projects have `parentId = NULL`, and under SQL three-valued logic `NULL = '<uuid>'` is UNKNOWN, so `NOT UNKNOWN` is still UNKNOWN and the row is silently dropped by the WHERE clause. The filter effectively returned only sub-projects.

## Fix

Add a `nullable_eq()` helper in `expanded/dynamic.rs` that renders equality on nullable columns as:

```sql
(col = '<uuid>' AND col IS NOT NULL)
```

This evaluates to FALSE (not UNKNOWN) on NULL, so negation includes NULL rows — equivalent to `IS DISTINCT FROM`, but it keeps the bare `=` conjunct so the planner can still use an index for the common positive "children of project X" case.

Applied to the three literals with the same hazard:

- `ProjectLiteral::ProjectId` → `p."parentId"` (the reported bug)
- `DocumentLiteral::ProjectId` → `d."projectId"` (negated "not in project X" was dropping root-level documents)
- `ChatLiteral::ProjectId` → `c."projectId"` (same for chats)

The grouped soup endpoint shares these builders. The frecency query builder is unaffected — it renders these literals as `entity_id IN (subquery)` where `entity_id` is non-null, so its negation was already NULL-safe. The unexpanded path has no AST filter builder.

## Testing

Added `test_negated_project_id_filter_includes_root_projects`, which mirrors the exact folders-view request (nil-id excludes for docs/chats, negated nil `pid` for projects) and asserts the fixture's root projects come back alongside nested ones, while a no-access root stays excluded by access control.