### PR TITLE
chore(ci): move release-production web jobs to namespace

### DIFF
--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -26,17 +26,28 @@ jobs:
 
   build:
     name: Build Web App
-    runs-on: linux-extra-beefy
+    runs-on: namespace-profile-linux-mid;overrides.cache-tag=web-ci
     env:
       CI: "true"
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v6
+      # Namespace cache volume: warm Nix dev shell + bun cache shared with the
+      # web PR checks / previews / dev deploys. Optimization only, hence
+      # continue-on-error.
+      - name: Mount Namespace cache volume
+        continue-on-error: true
+        uses: namespacelabs/nscloud-cache-action@15799a6b54e5765f85b2aac25b3f0df43ed571c0 # v1.4.3
+        with:
+          cache: bun
+          path: /nix
+      # Namespace runners don't ship Nix; must run before setup-reqs-web.
+      - name: Setup Nix
+        uses: ./.github/actions/setup-nix
       - name: Setup Prereqs
         uses: ./.github/actions/setup-reqs-web
         with:
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          sccache-bucket: ${{ vars.SCCACHE_BUCKET || secrets.SCCACHE_BUCKET }}
       - name: Build for Production
         working-directory: js/app
         run: just build-prod


### PR DESCRIPTION
Targeted change per request — not the full xtask port yet. All three web jobs in `release-production.yml` move off their old runners (the v2026.7.6.1 release run sat stuck on `linux-extra-beefy` at Deploy Web App and had to be cancelled):

| Job | Before | After |
|---|---|---|
| Build Web App | `linux-extra-beefy` | `namespace-profile-linux-mid;overrides.cache-tag=web-ci` |
| Deploy Web App | `linux-extra-beefy` | `namespace-profile-linux-mid;overrides.cache-tag=web-ci` |
| Upload Release Artifacts | `ubuntu-latest` | `namespace-profile-linux-tiny-no-cache` |

- The two web jobs get the cache-volume mount + `setup-nix` before `setup-reqs-web` (namespace runners don't ship Nix — a bare label swap would fail) and share the warm dev-shell/bun volume with the PR checks / previews / dev deploys.
- Dropped the `sccache-bucket` inputs (pure vite build + pulumi deploy, nothing compiles Rust).
- Upload is checkout + tar + gh-release upload — tiny suffices.

With this, `release-production.yml` no longer references `linux-extra-beefy`; the remaining full port (xtask codegen + the `deploy-web-app-prod` concurrency-group fix) comes later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)