### PR TITLE
fix(soup): propagate in-place item edits to grouped list caches

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/create-grouped-soup-queries.ts
+++ b/js/app/packages/app/component/next-soup/soup-view/create-grouped-soup-queries.ts
@@ -2,6 +2,7 @@ import { createInfiniteQueries } from '@app/component/next-soup/soup-view/create
 import { throwOnErr } from '@core/util/result';
 import type { EntityData } from '@entity';
 import { useQueryClient } from '@queries/client';
+import { groupedCacheVersion } from '@queries/soup/cache';
 import {
   parseGroupMeta,
   serializeGroupByField,
@@ -189,6 +190,9 @@ export function createGroupedSoupQueries(args: CreateGroupedSoupQueriesArgs) {
       ...query,
       data: () => {
         groupDataVersion();
+        // External cache patches (optimistic property edits, WS inserts)
+        // bump this since query.data is read untracked.
+        groupedCacheVersion();
         return untrack(query.data);
       },
       fetchNextPage: async () => {

--- a/js/app/packages/queries/soup/normalized-cache/grouped-operations.ts
+++ b/js/app/packages/queries/soup/normalized-cache/grouped-operations.ts
@@ -1,5 +1,6 @@
 import type { SoupApiItem } from '@service-storage/generated/schemas';
 import type { InfiniteData } from '@tanstack/solid-query';
+import { createSignal } from 'solid-js';
 
 import { queryClient } from '../../client';
 import {
@@ -18,6 +19,20 @@ type GroupedGroupPage = {
 };
 
 type GroupedGroupInfiniteData = InfiniteData<GroupedGroupPage, unknown>;
+
+const [groupedCacheVersionSignal, setGroupedCacheVersion] = createSignal(0);
+
+/**
+ * Bumped whenever grouped soup caches are patched outside the query lifecycle
+ * (optimistic updates, WS inserts/removals). Grouped views read group data
+ * untracked behind a local version signal, so they subscribe to this to pick
+ * up external patches.
+ */
+export const groupedCacheVersion = groupedCacheVersionSignal;
+
+function bumpGroupedCacheVersion() {
+  setGroupedCacheVersion((version) => version + 1);
+}
 
 /** Runtime guard for the normalized grouped parent page shape. */
 function isGroupedPage(page: unknown): page is SoupAstItemsGroupedPage {
@@ -137,6 +152,7 @@ export function syncGroupedParents(entityId: string, entity: SoupApiItem) {
     if (!changed) continue;
 
     query.setData({ ...prev, pages }, { manual: true });
+    bumpGroupedCacheVersion();
   }
 }
 
@@ -200,12 +216,26 @@ export function syncGroupQueries(entityId: string, entity: SoupApiItem) {
         continue;
       }
 
+      // Membership unchanged: still refresh the item's data so in-place
+      // edits (e.g. a property change that doesn't move it between groups)
+      // reach the rendered rows.
+      if (shouldHave && hasEntity && page.items[entityId] !== entity) {
+        changed = true;
+        pages.push({
+          ...page,
+          items: { ...page.items, [entityId]: entity },
+        });
+        index += 1;
+        continue;
+      }
+
       pages.push(page);
       index += 1;
     }
 
     if (changed) {
       query.setData({ ...prev, pages }, { manual: true });
+      bumpGroupedCacheVersion();
     }
   }
 }
@@ -287,6 +317,7 @@ export function insertGroupQueries(item: SoupApiItem, itemId: string) {
       },
       { manual: true }
     );
+    bumpGroupedCacheVersion();
   }
 }
 
@@ -375,6 +406,7 @@ export function removeGroupQueries(entityIds: Set<string>) {
 
     if (changed) {
       query.setData({ ...prev, pages }, { manual: true });
+      bumpGroupedCacheVersion();
     }
   }
 }
@@ -422,7 +454,14 @@ function syncMembership(
     );
   }
 
-  if (!changed) return page;
+  // Data-only refresh: membership is unchanged but the cached item is stale
+  // (e.g. a property edit that doesn't move it between groups).
+  const dataChanged =
+    nextGroups.size > 0 &&
+    page.items[entityId] !== undefined &&
+    page.items[entityId] !== entity;
+
+  if (!changed && !dataChanged) return page;
 
   const newGroupsExist = nextGroups.size > 0;
   const nextItems: Record<string, SoupApiItem> = {};

--- a/js/app/packages/queries/soup/normalized-cache/index.ts
+++ b/js/app/packages/queries/soup/normalized-cache/index.ts
@@ -1,3 +1,4 @@
+export { groupedCacheVersion } from './grouped-operations';
 export { initSoupNormalizer } from './normalizer';
 export {
   getSoupEntityById,

--- a/js/app/packages/queries/soup/normalized-cache/operations.test.ts
+++ b/js/app/packages/queries/soup/normalized-cache/operations.test.ts
@@ -756,6 +756,35 @@ describe('optimisticUpdateSoupEntity — cross-group move', () => {
     expect(after.pages[0].groups[0].itemIds).toEqual(['a-1']);
     expect(after.pages[0].groups[0].totalCount).toBe(1);
   });
+
+  it('refreshes item data when membership is unchanged', () => {
+    const items = [mockTaskItem('a-1', 'in_progress')];
+    const groups = [buildGroup('in_progress', ['a-1'], 1, 0)];
+    const key = seedGroupedAstQuery(mockGroupedParentCache(items, groups));
+
+    // Same group, new data (e.g. a tag/property edit that doesn't move it).
+    const merged = mockTaskItem('a-1', 'in_progress');
+    (merged as unknown as { data: { title: string } }).data.title =
+      'task a-1 (edited)';
+    mockNormalizer.getObjectById.mockReturnValue(merged);
+
+    optimisticUpdateSoupEntity({
+      tag: 'document',
+      data: { id: 'a-1' },
+      frecency_score: 1,
+    } as unknown as Parameters<typeof optimisticUpdateSoupEntity>[0]);
+
+    const after =
+      testQueryClient.getQueryData<
+        InfiniteData<SoupAstItemsGroupedPage, unknown>
+      >(key)!;
+    const page = after.pages[0];
+    expect(
+      (page.items['a-1'] as unknown as { data: { title: string } }).data.title
+    ).toBe('task a-1 (edited)');
+    expect(page.groups[0].itemIds).toEqual(['a-1']);
+    expect(page.groups[0].totalCount).toBe(1);
+  });
 });
 
 describe('optimisticUpdateSoupEntity — parent item filter gate', () => {


### PR DESCRIPTION
Toggling a tag (or any edit that doesn't move an item between groups) updated the soup caches but never the rendered rows — grouped cache sync only reconciled group membership, leaving the stale item in place, and grouped views read group data untracked so even parent-page patches went unseen. Refreshes the item data on membership-unchanged syncs and bumps a version signal from the grouped cache mutators that grouped views subscribe to.
