### PR TITLE
feat(tags): enable tag creation on non-markdown documents and email threads

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/search/search-facets.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/search/search-facets.tsx
@@ -463,8 +463,8 @@ export function useSearchFacets(
     },
   });
 
-  // Tags show only where tagging applies (documents/tasks), gated behind the
-  // tags feature flag, and hidden when the caller has no tags defined.
+  // Tags show only where tagging applies (all/documents/tasks), gated behind
+  // the tags feature flag, and hidden when the caller has no tags defined.
   const tagFacets = (): SearchFacetVM[] =>
     tagSource.enabled() && tagSource.hasTags() ? [tags] : [];
 
@@ -488,6 +488,7 @@ export function useSearchFacets(
           ...tagFacets(),
         ];
       case 'document-or-file':
+      case 'all':
         return [type, ...tagFacets()];
       default:
         return [type];

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/search/search-filters-state.ts
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/search/search-filters-state.ts
@@ -25,8 +25,11 @@ export type SearchIndexId =
 
 export type SearchTypeValue = SearchIndexId | 'all';
 
-/** Search types whose results are documents/tasks, where tag filtering applies. */
+/** Search types where tag filtering applies: documents/tasks plus the mixed
+ * `all` view (tags there narrow the taggable result types and leave the
+ * rest untouched). */
 export const TAG_SEARCH_TYPES = new Set<SearchTypeValue>([
+  'all',
   'task',
   'document-or-file',
 ]);
@@ -63,9 +66,9 @@ export type SearchFiltersSections = {
 
 export type SearchFiltersState = SearchFiltersSections & {
   type: SearchTypeValue;
-  // Selected tags. Applied only on the document/task types (TAG_SEARCH_TYPES)
+  // Selected tags. Applied only on the all/document/task types (TAG_SEARCH_TYPES)
   // and read live from the compiled query, so they persist across those types
-  // but clear when switching to a type where tags do not apply (all/email/etc).
+  // but clear when switching to a type where tags do not apply (email/channels/etc).
   // Each entry carries its owning definition id and option id; combined as one OR.
   tags: PropertyFilter[];
 };
@@ -91,17 +94,17 @@ export function compileSearchQuery(state: SearchFiltersState): Query {
   const include: FieldFilters = { ...baseline.include };
   const exclude: FieldFilters = { ...baseline.exclude };
 
+  // Tags apply on the all/document/task types only, so a tag filter never
+  // silently empties a search narrowed to emails/channels/calls.
+  if (TAG_SEARCH_TYPES.has(state.type) && state.tags.length) {
+    include.tagFilters = state.tags;
+  }
+
   if (state.type === 'all') return { include, exclude };
 
   const seed = SEARCH_INDEX_SEEDS[state.type];
   Object.assign(include, seed.include);
   Object.assign(exclude, seed.exclude);
-
-  // Tags only apply where results are already narrowed to documents/tasks, so a
-  // tag filter never silently empties an email/channel/call search.
-  if (TAG_SEARCH_TYPES.has(state.type) && state.tags.length) {
-    include.tagFilters = state.tags;
-  }
 
   if (state.type === 'email') {
     if (state.email.importance !== undefined) {

--- a/js/app/packages/app/component/next-soup/soup-view/soup-view-context.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-view-context.tsx
@@ -28,6 +28,7 @@ import { deduplicateEntities } from '@app/component/next-soup/utils';
 import { useEntryState } from '@app/component/split-layout/entry-state';
 import { useSplitPanelOrThrow } from '@app/component/split-layout/layoutUtils';
 import {
+  entityMatchesTagFilter,
   isListViewID,
   type ListView,
   soupItemMatchesListView,
@@ -561,10 +562,14 @@ export const SoupViewContextProvider: FlowComponent<
   const baseEntities = () => {
     let transformed = items();
     const ctx = getFilterContext();
+    const tagOptionIds = activeTagOptionIds();
 
     const next = [];
     for (const entity of transformed) {
       if (!soup.predicates.test(entity, ctx)) {
+        continue;
+      }
+      if (!entityMatchesTagFilter(entity, tagOptionIds)) {
         continue;
       }
       next.push(entity);

--- a/js/app/packages/app/component/side-panel/FileSidePanelSections.tsx
+++ b/js/app/packages/app/component/side-panel/FileSidePanelSections.tsx
@@ -1,0 +1,151 @@
+import { useBlockId } from '@core/block';
+import { EntityIcon } from '@core/component/EntityIcon';
+import { openDocument } from '@core/component/LexicalMarkdown/component/core/BlockLink';
+import { UserIcon } from '@core/component/UserIcon';
+import { useCanEdit } from '@core/signal/permissions';
+import { tryMacroId, useDisplayName } from '@core/user';
+import { useBlockDocumentName } from '@core/util/currentBlockDocumentName';
+import { type DateValue, formatDate } from '@core/util/date';
+import { useSplitNavigationHandler } from '@core/util/useSplitNavigationHandler';
+import { useDocumentMetadataQuery } from '@queries/storage/document-metadata';
+import { createCallback } from '@solid-primitives/rootless';
+import { createMemo, Show } from 'solid-js';
+import { EntityPropertiesSection } from './properties';
+import { SidePanel } from './SidePanel';
+
+export function FileSidePanelSections() {
+  return (
+    <>
+      <FileDetailsSection order={10} />
+      <FilePropertiesSection order={20} />
+    </>
+  );
+}
+
+export function FileDetailsSection(props: { order?: number }) {
+  return (
+    <SidePanel.Section
+      id="details"
+      title="Details"
+      defaultOpen
+      order={props.order}
+    >
+      <DetailsSectionContent />
+    </SidePanel.Section>
+  );
+}
+
+export function FilePropertiesSection(props: { order?: number }) {
+  return (
+    <SidePanel.Section
+      id="properties"
+      title="Properties"
+      defaultOpen
+      order={props.order}
+    >
+      <PropertiesSectionContent />
+    </SidePanel.Section>
+  );
+}
+
+function PropertiesSectionContent() {
+  const blockId = useBlockId();
+  const canEdit = useCanEdit();
+  const documentName = useBlockDocumentName();
+
+  return (
+    <EntityPropertiesSection
+      entityId={blockId}
+      entityType="DOCUMENT"
+      canEdit={canEdit()}
+      documentName={documentName()}
+    />
+  );
+}
+
+function DetailsSectionContent() {
+  const blockId = useBlockId();
+  const query = useDocumentMetadataQuery(() => blockId);
+  const metadata = createMemo(() => query.data);
+
+  return (
+    <SidePanel.Grid>
+      <Show when={metadata()?.owner}>
+        {(ownerId) => (
+          <SidePanel.Row label="Owner">
+            <OwnerValue ownerId={ownerId()} />
+          </SidePanel.Row>
+        )}
+      </Show>
+      <Show
+        when={(() => {
+          const id = metadata()?.projectId;
+          const name = metadata()?.projectName;
+          return id && name ? { id, name } : undefined;
+        })()}
+      >
+        {(folder) => (
+          <SidePanel.Row label="Folder">
+            <FolderLink projectId={folder().id} projectName={folder().name} />
+          </SidePanel.Row>
+        )}
+      </Show>
+      <Show when={metadata()?.createdAt}>
+        {(created) => (
+          <SidePanel.Row label="Created">
+            <DateValueDisplay value={created()} />
+          </SidePanel.Row>
+        )}
+      </Show>
+      <Show when={metadata()?.updatedAt}>
+        {(updated) => (
+          <SidePanel.Row label="Last updated">
+            <DateValueDisplay value={updated()} />
+          </SidePanel.Row>
+        )}
+      </Show>
+    </SidePanel.Grid>
+  );
+}
+
+function FolderLink(props: { projectId: string; projectName: string }) {
+  const open = createCallback((e: MouseEvent) => {
+    openDocument('project', props.projectId, undefined, !e.shiftKey);
+  });
+  const navHandlers = useSplitNavigationHandler<HTMLSpanElement>(open);
+
+  return (
+    <span
+      {...navHandlers}
+      class={SidePanel.pillClass + ' pointer-events-auto hover:bg-hover'}
+    >
+      <span class="relative size-3 shrink-0">
+        <EntityIcon targetType="project" size="fill" />
+      </span>
+      <span class="truncate underline decoration-current/20 decoration-[max(1px,0.1em)] underline-offset-2">
+        {props.projectName}
+      </span>
+    </span>
+  );
+}
+
+function OwnerValue(props: { ownerId: string }) {
+  const [displayName] = useDisplayName(tryMacroId(props.ownerId));
+
+  return (
+    <SidePanel.Pill>
+      <UserIcon id={props.ownerId} size="sm" showTooltip suppressClick />
+      <span class="truncate">{displayName()}</span>
+    </SidePanel.Pill>
+  );
+}
+
+function DateValueDisplay(props: { value: DateValue }) {
+  return (
+    <SidePanel.Pill>
+      <span class="truncate">
+        {formatDate(props.value, { showTime: true })}
+      </span>
+    </SidePanel.Pill>
+  );
+}

--- a/js/app/packages/app/component/side-panel/SidePanel.tsx
+++ b/js/app/packages/app/component/side-panel/SidePanel.tsx
@@ -47,7 +47,8 @@ const MAIN_MIN_PX = 320;
  *
  * Two rendering modes based on available width:
  *   - Wide (>= NARROW_THRESHOLD_PX, non-mobile): side panel renders as a
- *     resizable split next to the main content. Defaults to open.
+ *     resizable split next to the main content. Defaults to open unless
+ *     `defaultOpen` is false.
  *   - Narrow (mobile or narrower than threshold): side panel renders as a
  *     full-screen overlay covering the main content. Defaults to closed;
  *     the main content stays mounted underneath.
@@ -56,13 +57,13 @@ const MAIN_MIN_PX = 320;
  *
  * Sections are rendered as a Kobalte Accordion in JSX-declared order.
  */
-function Layout(props: ParentProps) {
+function Layout(props: ParentProps<{ defaultOpen?: boolean }>) {
   const [sections, setSections] = createSignal<SidePanelSectionEntry[]>([]);
   const [openIds, setOpenIds] = createSignal<string[]>([]);
   // Independent open state per mode so wide and narrow can have different
   // defaults (and the user's preference in one mode doesn't bleed into the
   // other after a resize).
-  const [isWideOpen, setIsWideOpen] = createSignal(true);
+  const [isWideOpen, setIsWideOpen] = createSignal(props.defaultOpen ?? true);
   const [isNarrowOpen, setIsNarrowOpen] = createSignal(false);
   const [isNarrow, setIsNarrow] = createSignal(isMobile());
 

--- a/js/app/packages/app/component/side-panel/index.ts
+++ b/js/app/packages/app/component/side-panel/index.ts
@@ -1,5 +1,10 @@
 export type {} from './context';
 export {
+  FileDetailsSection,
+  FilePropertiesSection,
+  FileSidePanelSections,
+} from './FileSidePanelSections';
+export {
   GithubPullRequestChecksContent,
   GithubPullRequestDetailsContent,
   GithubPullRequestDetailsRows,

--- a/js/app/packages/app/component/side-panel/properties/EntityPropertiesSection.tsx
+++ b/js/app/packages/app/component/side-panel/properties/EntityPropertiesSection.tsx
@@ -50,12 +50,19 @@ export interface EntityPropertiesSectionProps {
   propertyFilter?: (property: Property) => boolean;
   getEmptyLabel?: (property: Property) => JSX.Element | undefined;
   showAddProperty?: boolean;
+  showTags?: boolean;
   defaultPinnedPropertyIds?: () => readonly string[];
   pinnedPropertyIds?: () => string[];
   pinnedPropertyDefinitionOrder?: readonly string[];
   onPropertyPinned?: (propertyId: string) => void;
   onPropertyUnpinned?: (propertyId: string) => void;
 }
+
+const TAGGABLE_ENTITY_TYPES: ReadonlySet<EntityType> = new Set<EntityType>([
+  'DOCUMENT',
+  'TASK',
+  'THREAD',
+]);
 
 export function EntityPropertiesSection(props: EntityPropertiesSectionProps) {
   const { properties, isLoading, error, refetch } = useEntityProperties(
@@ -197,7 +204,8 @@ export function EntityPropertiesSection(props: EntityPropertiesSectionProps) {
           <Show
             when={
               tagsFlag().enabled &&
-              (props.entityType === 'DOCUMENT' || props.entityType === 'TASK')
+              props.showTags !== false &&
+              TAGGABLE_ENTITY_TYPES.has(props.entityType)
             }
           >
             <div class="mb-2 flex items-center gap-3">

--- a/js/app/packages/app/constants/list-views.ts
+++ b/js/app/packages/app/constants/list-views.ts
@@ -1,3 +1,4 @@
+import type { EntityData } from '@entity';
 import type { SoupApiItem } from '@service-storage/generated/schemas';
 import { match } from 'ts-pattern';
 
@@ -84,6 +85,32 @@ export const soupItemMatchesTagFilter = (
   if (tagOptionIds.length === 0) return true;
   const properties =
     'properties' in item.data ? item.data.properties : undefined;
+  if (!properties?.length) return false;
+  const wanted = new Set(tagOptionIds);
+  for (const { value } of properties) {
+    if (
+      value?.type === 'SelectOption' &&
+      value.value.some((id) => wanted.has(id))
+    ) {
+      return true;
+    }
+  }
+  return false;
+};
+
+/**
+ * `soupItemMatchesTagFilter` for mapped entities. Rendered rows are checked
+ * against the active tag filter because the server only tag-filters the
+ * document/chat/project soup unions and the document search leg. Entity types
+ * without loaded properties (channels, calls, search-service email results)
+ * never match, so they are excluded rather than leaking through unfiltered.
+ */
+export const entityMatchesTagFilter = (
+  entity: EntityData,
+  tagOptionIds: readonly string[]
+): boolean => {
+  if (tagOptionIds.length === 0) return true;
+  const properties = 'properties' in entity ? entity.properties : undefined;
   if (!properties?.length) return false;
   const wanted = new Set(tagOptionIds);
   for (const { value } of properties) {

--- a/js/app/packages/block-canvas/component/Block.tsx
+++ b/js/app/packages/block-canvas/component/Block.tsx
@@ -309,7 +309,7 @@ export default function BlockCanvas(props: BlockCanvasProps) {
       >
         <ModalsProvider>
           <Show when={!isNestedBlock} fallback={<CanvasBody />}>
-            <SidePanel.Layout>
+            <SidePanel.Layout defaultOpen={false}>
               <FileSidePanelSections />
               <div class="flex size-full min-w-0 flex-col overflow-hidden">
                 <TopBar />

--- a/js/app/packages/block-canvas/component/Block.tsx
+++ b/js/app/packages/block-canvas/component/Block.tsx
@@ -1,4 +1,5 @@
 import { useBlockEntityCommands } from '@app/component/next-soup/actions';
+import { FileSidePanelSections, SidePanel } from '@app/component/side-panel';
 import { createNumericParser } from '@block-canvas/util/parse';
 import {
   useBlockId,
@@ -283,6 +284,17 @@ export default function BlockCanvas(props: BlockCanvasProps) {
     return file;
   }
 
+  const CanvasBody = () => (
+    <Show when={dataState() === 'initialized'} fallback={<LoadingView />}>
+      <CanvasController>
+        <Show when={visible()}>
+          <CanvasRenderer />
+          <ToolBar />
+        </Show>
+      </CanvasController>
+    </Show>
+  );
+
   return (
     <DocumentBlockContainer>
       <div
@@ -296,16 +308,14 @@ export default function BlockCanvas(props: BlockCanvasProps) {
         }}
       >
         <ModalsProvider>
-          <Show when={!isNestedBlock}>
-            <TopBar />
-          </Show>
-          <Show when={dataState() === 'initialized'} fallback={<LoadingView />}>
-            <CanvasController>
-              <Show when={visible()}>
-                <CanvasRenderer />
-                <ToolBar />
-              </Show>
-            </CanvasController>
+          <Show when={!isNestedBlock} fallback={<CanvasBody />}>
+            <SidePanel.Layout>
+              <FileSidePanelSections />
+              <div class="flex size-full min-w-0 flex-col overflow-hidden">
+                <TopBar />
+                <CanvasBody />
+              </div>
+            </SidePanel.Layout>
           </Show>
         </ModalsProvider>
       </div>

--- a/js/app/packages/block-code/component/Block.tsx
+++ b/js/app/packages/block-code/component/Block.tsx
@@ -44,7 +44,7 @@ export default function BlockCode() {
       <Show when={!isNestedBlock} fallback={<CodeMarkdown />}>
         <div class="size-full bg-surface select-none overscroll-none overflow-hidden flex flex-col items-end relative">
           <ModalsProvider>
-            <SidePanel.Layout>
+            <SidePanel.Layout defaultOpen={false}>
               <FileSidePanelSections />
               <div class="flex size-full min-w-0 flex-col items-end overflow-hidden">
                 <TopBar

--- a/js/app/packages/block-code/component/Block.tsx
+++ b/js/app/packages/block-code/component/Block.tsx
@@ -1,4 +1,5 @@
 import { useBlockEntityCommands } from '@app/component/next-soup/actions';
+import { FileSidePanelSections, SidePanel } from '@app/component/side-panel';
 import { useIsNestedBlock } from '@core/block';
 import { DocumentBlockContainer } from '@core/component/DocumentBlockContainer';
 import { blockMetadataSignal } from '@core/signal/load';
@@ -43,16 +44,21 @@ export default function BlockCode() {
       <Show when={!isNestedBlock} fallback={<CodeMarkdown />}>
         <div class="size-full bg-surface select-none overscroll-none overflow-hidden flex flex-col items-end relative">
           <ModalsProvider>
-            <TopBar
-              isHtmlFile={isHtmlFile()}
-              mode={mode()}
-              onModeChange={setMode}
-            />
-            <Show when={mode() === 'render'} fallback={<CodeMirror />}>
-              <Suspense>
-                <HtmlPreview />
-              </Suspense>
-            </Show>
+            <SidePanel.Layout>
+              <FileSidePanelSections />
+              <div class="flex size-full min-w-0 flex-col items-end overflow-hidden">
+                <TopBar
+                  isHtmlFile={isHtmlFile()}
+                  mode={mode()}
+                  onModeChange={setMode}
+                />
+                <Show when={mode() === 'render'} fallback={<CodeMirror />}>
+                  <Suspense>
+                    <HtmlPreview />
+                  </Suspense>
+                </Show>
+              </div>
+            </SidePanel.Layout>
           </ModalsProvider>
         </div>
       </Show>

--- a/js/app/packages/block-email/component/sidepanel/EmailSidePanelSections.tsx
+++ b/js/app/packages/block-email/component/sidepanel/EmailSidePanelSections.tsx
@@ -29,6 +29,7 @@ export function EmailSidePanelSections(props: EmailSidePanelSectionsProps) {
             propertyFilter={(property) => property.isMetadata === true}
             getEmptyLabel={getEmailMetadataEmptyLabel}
             showAddProperty={false}
+            showTags={false}
           />
         </Suspense>
       </SidePanel.Section>

--- a/js/app/packages/block-image/component/Block.tsx
+++ b/js/app/packages/block-image/component/Block.tsx
@@ -1,4 +1,5 @@
 import { useBlockEntityCommands } from '@app/component/next-soup/actions';
+import { FileSidePanelSections, SidePanel } from '@app/component/side-panel';
 import { useBlockId } from '@core/block';
 import { DocumentBlockContainer } from '@core/component/DocumentBlockContainer';
 import { blockAcceptedFileExtensionToMimeType } from '@core/constant/allBlocks';
@@ -61,23 +62,28 @@ export default function BlockImage() {
     <DocumentBlockContainer>
       <div class="size-full bg-surface select-none overscroll-none overflow-hidden flex flex-col">
         <ModalsProvider>
-          <TopBar />
-          <Show
-            when={imageUrl()}
-            fallback={
-              <div class="size-full flex items-center justify-center">
-                {/* Loading state handled by DocumentBlockContainer */}
-              </div>
-            }
-          >
-            <div class="size-full flex items-center justify-center">
-              <img
-                src={imageUrl()}
-                alt={blockMetadataSignal()?.documentName || 'Image'}
-                class="max-w-full max-h-full object-contain"
-              />
+          <SidePanel.Layout>
+            <FileSidePanelSections />
+            <div class="flex size-full min-w-0 flex-col overflow-hidden">
+              <TopBar />
+              <Show
+                when={imageUrl()}
+                fallback={
+                  <div class="size-full flex items-center justify-center">
+                    {/* Loading state handled by DocumentBlockContainer */}
+                  </div>
+                }
+              >
+                <div class="size-full flex items-center justify-center">
+                  <img
+                    src={imageUrl()}
+                    alt={blockMetadataSignal()?.documentName || 'Image'}
+                    class="max-w-full max-h-full object-contain"
+                  />
+                </div>
+              </Show>
             </div>
-          </Show>
+          </SidePanel.Layout>
         </ModalsProvider>
       </div>
     </DocumentBlockContainer>

--- a/js/app/packages/block-image/component/Block.tsx
+++ b/js/app/packages/block-image/component/Block.tsx
@@ -62,7 +62,7 @@ export default function BlockImage() {
     <DocumentBlockContainer>
       <div class="size-full bg-surface select-none overscroll-none overflow-hidden flex flex-col">
         <ModalsProvider>
-          <SidePanel.Layout>
+          <SidePanel.Layout defaultOpen={false}>
             <FileSidePanelSections />
             <div class="flex size-full min-w-0 flex-col overflow-hidden">
               <TopBar />

--- a/js/app/packages/block-pdf/component/sidepanel/PdfSidePanelSections.tsx
+++ b/js/app/packages/block-pdf/component/sidepanel/PdfSidePanelSections.tsx
@@ -1,17 +1,12 @@
 import { AskMacroButton } from '@app/component/ChatWithAgentButton';
-import { SidePanel } from '@app/component/side-panel';
+import {
+  FileDetailsSection,
+  FilePropertiesSection,
+  SidePanel,
+} from '@app/component/side-panel';
 import { useBlockId } from '@core/block';
-import { EntityIcon } from '@core/component/EntityIcon';
-import { openDocument } from '@core/component/LexicalMarkdown/component/core/BlockLink';
-import { UserIcon } from '@core/component/UserIcon';
 import { blockMetadataSignal } from '@core/signal/load';
-import { tryMacroId, useDisplayName } from '@core/user';
 import { useBlockDocumentName } from '@core/util/currentBlockDocumentName';
-import { type DateValue, formatDate } from '@core/util/date';
-import { useSplitNavigationHandler } from '@core/util/useSplitNavigationHandler';
-import { useDocumentMetadataQuery } from '@queries/storage/document-metadata';
-import { createCallback } from '@solid-primitives/rootless';
-import { createMemo, Show } from 'solid-js';
 
 export function PdfSidePanelSections() {
   return (
@@ -19,9 +14,8 @@ export function PdfSidePanelSections() {
       <SidePanel.Section id="actions" title="Actions" defaultOpen order={10}>
         <ActionsSectionContent />
       </SidePanel.Section>
-      <SidePanel.Section id="details" title="Details" defaultOpen order={20}>
-        <DetailsSectionContent />
-      </SidePanel.Section>
+      <FileDetailsSection order={20} />
+      <FilePropertiesSection order={30} />
     </>
   );
 }
@@ -42,92 +36,5 @@ function ActionsSectionContent() {
         }}
       />
     </div>
-  );
-}
-
-function DetailsSectionContent() {
-  const blockId = useBlockId();
-  const query = useDocumentMetadataQuery(() => blockId);
-  const metadata = createMemo(() => query.data);
-
-  return (
-    <SidePanel.Grid>
-      <Show when={metadata()?.owner}>
-        {(ownerId) => (
-          <SidePanel.Row label="Owner">
-            <OwnerValue ownerId={ownerId()} />
-          </SidePanel.Row>
-        )}
-      </Show>
-      <Show
-        when={(() => {
-          const id = metadata()?.projectId;
-          const name = metadata()?.projectName;
-          return id && name ? { id, name } : undefined;
-        })()}
-      >
-        {(folder) => (
-          <SidePanel.Row label="Folder">
-            <FolderLink projectId={folder().id} projectName={folder().name} />
-          </SidePanel.Row>
-        )}
-      </Show>
-      <Show when={metadata()?.createdAt}>
-        {(created) => (
-          <SidePanel.Row label="Created">
-            <DateValueDisplay value={created()} />
-          </SidePanel.Row>
-        )}
-      </Show>
-      <Show when={metadata()?.updatedAt}>
-        {(updated) => (
-          <SidePanel.Row label="Last updated">
-            <DateValueDisplay value={updated()} />
-          </SidePanel.Row>
-        )}
-      </Show>
-    </SidePanel.Grid>
-  );
-}
-
-function FolderLink(props: { projectId: string; projectName: string }) {
-  const open = createCallback((e: MouseEvent) => {
-    openDocument('project', props.projectId, undefined, !e.shiftKey);
-  });
-  const navHandlers = useSplitNavigationHandler<HTMLSpanElement>(open);
-
-  return (
-    <span
-      {...navHandlers}
-      class={SidePanel.pillClass + ' pointer-events-auto hover:bg-hover'}
-    >
-      <span class="relative size-3 shrink-0">
-        <EntityIcon targetType="project" size="fill" />
-      </span>
-      <span class="truncate underline decoration-current/20 decoration-[max(1px,0.1em)] underline-offset-2">
-        {props.projectName}
-      </span>
-    </span>
-  );
-}
-
-function OwnerValue(props: { ownerId: string }) {
-  const [displayName] = useDisplayName(tryMacroId(props.ownerId));
-
-  return (
-    <SidePanel.Pill>
-      <UserIcon id={props.ownerId} size="sm" showTooltip suppressClick />
-      <span class="truncate">{displayName()}</span>
-    </SidePanel.Pill>
-  );
-}
-
-function DateValueDisplay(props: { value: DateValue }) {
-  return (
-    <SidePanel.Pill>
-      <span class="truncate">
-        {formatDate(props.value, { showTime: true })}
-      </span>
-    </SidePanel.Pill>
   );
 }

--- a/js/app/packages/block-unknown/component/Block.tsx
+++ b/js/app/packages/block-unknown/component/Block.tsx
@@ -20,7 +20,7 @@ export default function BlockUnknown() {
     <DocumentBlockContainer>
       <div class="size-full bg-surface select-none overscroll-none overflow-hidden flex flex-col relative">
         <ModalsProvider>
-          <SidePanel.Layout defaultOpen={false}>
+          <SidePanel.Layout>
             <FileSidePanelSections />
             <div class="flex size-full min-w-0 flex-col overflow-hidden">
               <div class="relative">

--- a/js/app/packages/block-unknown/component/Block.tsx
+++ b/js/app/packages/block-unknown/component/Block.tsx
@@ -20,7 +20,7 @@ export default function BlockUnknown() {
     <DocumentBlockContainer>
       <div class="size-full bg-surface select-none overscroll-none overflow-hidden flex flex-col relative">
         <ModalsProvider>
-          <SidePanel.Layout>
+          <SidePanel.Layout defaultOpen={false}>
             <FileSidePanelSections />
             <div class="flex size-full min-w-0 flex-col overflow-hidden">
               <div class="relative">

--- a/js/app/packages/block-unknown/component/Block.tsx
+++ b/js/app/packages/block-unknown/component/Block.tsx
@@ -1,3 +1,4 @@
+import { FileSidePanelSections, SidePanel } from '@app/component/side-panel';
 import { DocumentBlockContainer } from '@core/component/DocumentBlockContainer';
 import { useShareDialogContext } from '@core/component/TopBar/ShareButton';
 import {
@@ -19,12 +20,17 @@ export default function BlockUnknown() {
     <DocumentBlockContainer>
       <div class="size-full bg-surface select-none overscroll-none overflow-hidden flex flex-col relative">
         <ModalsProvider>
-          <div class="relative">
-            <TopBar />
-          </div>
-          <div class="w-full grow relative overflow-hidden">
-            <Unknown />
-          </div>
+          <SidePanel.Layout>
+            <FileSidePanelSections />
+            <div class="flex size-full min-w-0 flex-col overflow-hidden">
+              <div class="relative">
+                <TopBar />
+              </div>
+              <div class="w-full grow relative overflow-hidden">
+                <Unknown />
+              </div>
+            </div>
+          </SidePanel.Layout>
         </ModalsProvider>
       </div>
     </DocumentBlockContainer>

--- a/js/app/packages/block-video/component/Block.tsx
+++ b/js/app/packages/block-video/component/Block.tsx
@@ -1,4 +1,5 @@
 import { useBlockEntityCommands } from '@app/component/next-soup/actions';
+import { FileSidePanelSections, SidePanel } from '@app/component/side-panel';
 import { DocumentBlockContainer } from '@core/component/DocumentBlockContainer';
 import { toast } from 'core/component/Toast/Toast';
 import { createEffect, createSignal, Show } from 'solid-js';
@@ -12,12 +13,17 @@ export default function BlockVideo() {
     <DocumentBlockContainer>
       <div class="size-full bg-surface select-none overscroll-none overflow-hidden flex flex-col relative">
         <ModalsProvider>
-          <div class="relative">
-            <TopBar />
-          </div>
-          <div class="w-full grow relative overflow-hidden">
-            <Video />
-          </div>
+          <SidePanel.Layout>
+            <FileSidePanelSections />
+            <div class="flex size-full min-w-0 flex-col overflow-hidden">
+              <div class="relative">
+                <TopBar />
+              </div>
+              <div class="w-full grow relative overflow-hidden">
+                <Video />
+              </div>
+            </div>
+          </SidePanel.Layout>
         </ModalsProvider>
       </div>
     </DocumentBlockContainer>

--- a/js/app/packages/block-video/component/Block.tsx
+++ b/js/app/packages/block-video/component/Block.tsx
@@ -13,7 +13,7 @@ export default function BlockVideo() {
     <DocumentBlockContainer>
       <div class="size-full bg-surface select-none overscroll-none overflow-hidden flex flex-col relative">
         <ModalsProvider>
-          <SidePanel.Layout>
+          <SidePanel.Layout defaultOpen={false}>
             <FileSidePanelSections />
             <div class="flex size-full min-w-0 flex-col overflow-hidden">
               <div class="relative">

--- a/js/app/packages/entity/src/composed/list-entity/wide-layout.tsx
+++ b/js/app/packages/entity/src/composed/list-entity/wide-layout.tsx
@@ -32,15 +32,16 @@ import {
 } from './foreign';
 import type { LayoutProps } from './shared';
 
-function DocumentRowTags(props: {
+function RowTags(props: {
   entityId: string;
+  entityType: EntityType;
   properties: SoupProperty[] | undefined;
 }) {
   const filterByTag = useRowTagFilter();
   return (
     <EntityRowTags
       entityId={props.entityId}
-      entityType={EntityType.DOCUMENT}
+      entityType={props.entityType}
       properties={props.properties}
       onFilterByTag={filterByTag}
     />
@@ -192,12 +193,26 @@ export function WideLayout(props: LayoutProps) {
               return 'properties' in doc ? doc.properties : undefined;
             };
             return (
-              <DocumentRowTags
+              <RowTags
                 entityId={entity().id}
+                entityType={
+                  isTaskEntity(entity()) ? EntityType.TASK : EntityType.DOCUMENT
+                }
                 properties={properties()}
               />
             );
           }}
+        </Show>
+        <Show when={isEmailEntity(props.entity) && props.entity}>
+          {(entity) => (
+            // No filter-by-tag affordance. The soup email path does not apply
+            // tag filters, so filtering would leave email rows unfiltered.
+            <EntityRowTags
+              entityId={entity().id}
+              entityType={EntityType.THREAD}
+              properties={entity().properties}
+            />
+          )}
         </Show>
       </Entity.Slot>
       <Entity.Slot

--- a/js/app/packages/entity/src/types/entity.ts
+++ b/js/app/packages/entity/src/types/entity.ts
@@ -186,6 +186,7 @@ export type EmailEntity = EntityBase & {
   labels?: SoupLabel[] | ApiLabel[];
   hasIcsAttachment?: boolean;
   attachments?: EmailAttachment[];
+  properties?: SoupProperty[];
 };
 
 export type ProjectEntity = EntityBase & {

--- a/rust/cloud-storage/email/fixtures/email_dynamic_query_properties.sql
+++ b/rust/cloud-storage/email/fixtures/email_dynamic_query_properties.sql
@@ -1,0 +1,11 @@
+-- A tag definition and one applied tag on inbox thread 1, so property-filter
+-- tests can assert threads are narrowed by entity_properties conditions.
+-- Owned by the user created in email_dynamic_query.sql.
+INSERT INTO property_definitions (id, team_id, user_id, display_name, data_type, is_multi_select, specific_entity_type)
+VALUES
+    ('bb111111-1111-1111-1111-111111111111', NULL, 'macro|user1@test.com', 'Tags', 'TAG', true, NULL)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO entity_properties (id, entity_id, entity_type, property_definition_id, values)
+VALUES
+    ('e0888888-8888-8888-8888-888888888881', '20000001-0000-0000-0000-000000000001', 'THREAD', 'bb111111-1111-1111-1111-111111111111', '{"type": "SelectOption", "value": ["0bb11111-1111-1111-1111-111111111111"]}');

--- a/rust/cloud-storage/email/src/outbound/email_pg_repo/dynamic/filters.rs
+++ b/rust/cloud-storage/email/src/outbound/email_pg_repo/dynamic/filters.rs
@@ -4,6 +4,7 @@ use crate::domain::models::{PreviewView, PreviewViewStandardLabel};
 use filter_ast::Expr;
 use item_filters::ast::date::DateLiteral;
 use item_filters::ast::email::{Email, EmailLiteral};
+use item_filters::ast::properties::{PropertiesLiteral, PropertyEntityType, PropertyMatchValue};
 use recursion::CollapsibleExt;
 use uuid::Uuid;
 
@@ -35,7 +36,8 @@ pub(super) fn has_thread_literals(ast: &Expr<EmailLiteral>) -> bool {
             | EmailLiteral::ProjectId(_)
             | EmailLiteral::CalendarOnly(_)
             | EmailLiteral::CreatedAt(_)
-            | EmailLiteral::UpdatedAt(_),
+            | EmailLiteral::UpdatedAt(_)
+            | EmailLiteral::Property(_),
         ) => true,
         filter_ast::ExprFrame::Literal(EmailLiteral::Shared(_)) => false,
         filter_ast::ExprFrame::Literal(_) => false,
@@ -53,7 +55,8 @@ pub(super) fn has_message_literals(ast: &Expr<EmailLiteral>) -> bool {
             | EmailLiteral::Shared(_)
             | EmailLiteral::CalendarOnly(_)
             | EmailLiteral::CreatedAt(_)
-            | EmailLiteral::UpdatedAt(_),
+            | EmailLiteral::UpdatedAt(_)
+            | EmailLiteral::Property(_),
         ) => false,
         filter_ast::ExprFrame::Literal(_) => true,
     })
@@ -333,6 +336,7 @@ pub(super) fn build_message_email_filter(
         filter_ast::ExprFrame::Literal(EmailLiteral::CalendarOnly(_)) => SqlFragment::raw("TRUE"),
         filter_ast::ExprFrame::Literal(EmailLiteral::CreatedAt(_)) => SqlFragment::raw("TRUE"),
         filter_ast::ExprFrame::Literal(EmailLiteral::UpdatedAt(_)) => SqlFragment::raw("TRUE"),
+        filter_ast::ExprFrame::Literal(EmailLiteral::Property(_)) => SqlFragment::raw("TRUE"),
     });
 
     fragment.with_and_prefix()
@@ -779,6 +783,10 @@ pub(super) fn build_thread_email_filter(
             date_predicate(sort_ts_field, lit)
         }
 
+        filter_ast::ExprFrame::Literal(EmailLiteral::Property(ref lit)) => {
+            build_thread_property_predicate(lit)
+        }
+
         filter_ast::ExprFrame::Literal(
             EmailLiteral::Sender(_)
             | EmailLiteral::Cc(_)
@@ -792,6 +800,42 @@ pub(super) fn build_thread_email_filter(
     });
 
     fragment.with_and_prefix()
+}
+
+/// Entity-property predicate for a candidate thread: EXISTS against
+/// `entity_properties` keyed on the thread id. A literal typed to a
+/// non-thread entity can never match a thread, so it renders FALSE.
+fn build_thread_property_predicate(lit: &PropertiesLiteral) -> SqlFragment {
+    if lit
+        .entity_type
+        .is_some_and(|et| et != PropertyEntityType::Thread)
+    {
+        return SqlFragment::raw("FALSE");
+    }
+    let mut f = SqlFragment::raw(
+        r#"EXISTS (
+                SELECT 1 FROM entity_properties ep_prop
+                WHERE ep_prop.entity_id = t.id::text
+                AND ep_prop.entity_type = 'THREAD'
+                AND ep_prop.property_definition_id = "#,
+    );
+    f.extend(SqlFragment::bind_uuid(lit.property_definition_id));
+    match &lit.value {
+        PropertyMatchValue::SelectOption(option_id) => {
+            f.push_raw(" AND ep_prop.values->'value' ? ");
+            f.extend(SqlFragment::bind_string(option_id.to_string()));
+        }
+        PropertyMatchValue::EntityRef(entity_id) => {
+            f.push_raw(" AND ep_prop.values->'value' @> jsonb_build_array(jsonb_build_object('entity_id', ");
+            f.extend(SqlFragment::bind_string(entity_id.to_string()));
+            f.push_raw("::text))");
+        }
+    }
+    f.push_raw(
+        r#"
+            )"#,
+    );
+    f
 }
 
 /// Escapes special characters in LIKE patterns to prevent SQL injection

--- a/rust/cloud-storage/email/src/outbound/email_pg_repo/test/dynamic_query.rs
+++ b/rust/cloud-storage/email/src/outbound/email_pg_repo/test/dynamic_query.rs
@@ -2750,3 +2750,48 @@ async fn test_viewed_updated_sort_falls_back_to_view_timestamp(
 
     Ok(())
 }
+
+#[sqlx::test(
+    migrator = "MACRO_DB_MIGRATIONS",
+    fixtures(
+        path = "../../../../fixtures",
+        scripts("email_dynamic_query", "email_dynamic_query_properties")
+    )
+)]
+async fn test_dynamic_query_thread_property_filter(pool: Pool<Postgres>) -> anyhow::Result<()> {
+    use item_filters::ast::properties::{PropertiesLiteral, PropertyMatchValue};
+
+    let link_id = Uuid::parse_str("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")?;
+    let view = PreviewView::StandardLabel(PreviewViewStandardLabel::Inbox);
+    let definition_id = Uuid::parse_str("bb111111-1111-1111-1111-111111111111")?;
+
+    let tagged = Arc::new(Expr::Literal(EmailLiteral::Property(PropertiesLiteral {
+        property_definition_id: definition_id,
+        entity_type: None,
+        value: PropertyMatchValue::SelectOption(Uuid::parse_str(
+            "0bb11111-1111-1111-1111-111111111111",
+        )?),
+    })));
+    let query = Query::new(None, SimpleSortMethod::UpdatedAt, tagged);
+    let results =
+        dynamic::dynamic_email_thread_cursor(&pool, &[link_id], 50, &view, query, "", None).await?;
+    assert_eq!(results.len(), 1, "only the tagged inbox thread matches");
+    assert_eq!(
+        results[0].id.to_string(),
+        "20000001-0000-0000-0000-000000000001"
+    );
+
+    let unknown_option = Arc::new(Expr::Literal(EmailLiteral::Property(PropertiesLiteral {
+        property_definition_id: definition_id,
+        entity_type: None,
+        value: PropertyMatchValue::SelectOption(Uuid::parse_str(
+            "0bb99999-9999-9999-9999-999999999999",
+        )?),
+    })));
+    let query = Query::new(None, SimpleSortMethod::UpdatedAt, unknown_option);
+    let results =
+        dynamic::dynamic_email_thread_cursor(&pool, &[link_id], 50, &view, query, "", None).await?;
+    assert!(results.is_empty(), "unknown tag option matches no threads");
+
+    Ok(())
+}

--- a/rust/cloud-storage/filter_ast/src/lib.rs
+++ b/rust/cloud-storage/filter_ast/src/lib.rs
@@ -64,7 +64,7 @@ pub enum ExprFrame<A, B> {
     Literal(B),
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum Expr<B> {
     #[serde(rename = "&")]
     And(Box<Self>, Box<Self>),

--- a/rust/cloud-storage/item_filters/src/ast/email.rs
+++ b/rust/cloud-storage/item_filters/src/ast/email.rs
@@ -3,7 +3,10 @@ use macro_user_id::{cowlike::CowLike, email::EmailStr};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::{EmailFilters, SharedEmailFilter, ast::ExpandErr, ast::date::DateLiteral};
+use crate::{
+    EmailFilters, SharedEmailFilter, ast::ExpandErr, ast::date::DateLiteral,
+    ast::properties::PropertiesLiteral,
+};
 
 /// Possible email values in the ast
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -68,6 +71,12 @@ pub enum EmailLiteral {
     /// Filter by thread updated_at timestamp (view-dependent field)
     #[serde(rename = "ua")]
     UpdatedAt(DateLiteral),
+    /// Thread-level entity-property condition, checked against
+    /// `entity_properties` keyed on the thread id. Injected by the soup
+    /// service when a request carries a properties filter; never produced
+    /// by client filter expansion.
+    #[serde(rename = "prop")]
+    Property(PropertiesLiteral),
 }
 
 impl ExpandFrame<EmailLiteral> for EmailFilters {

--- a/rust/cloud-storage/item_filters/src/ast/properties.rs
+++ b/rust/cloud-storage/item_filters/src/ast/properties.rs
@@ -199,3 +199,43 @@ impl ExpandFrame<PropertiesLiteral> for Vec<PropertyFilter> {
         Ok(nodes.into_iter().fold_with(Expr::and))
     }
 }
+
+/// True when the filter could match an entity of one of the given types.
+/// Untyped literals match any type. Conservative under NOT, since a negated
+/// predicate can match anything.
+pub fn properties_filter_can_apply_to(
+    expr: &Expr<PropertiesLiteral>,
+    entity_types: &[PropertyEntityType],
+) -> bool {
+    match expr {
+        Expr::And(a, b) => {
+            properties_filter_can_apply_to(a, entity_types)
+                && properties_filter_can_apply_to(b, entity_types)
+        }
+        Expr::Or(a, b) => {
+            properties_filter_can_apply_to(a, entity_types)
+                || properties_filter_can_apply_to(b, entity_types)
+        }
+        Expr::Not(_) => true,
+        Expr::Literal(PropertiesLiteral { entity_type, .. }) => {
+            entity_type.is_none_or(|entity_type| entity_types.contains(&entity_type))
+        }
+    }
+}
+
+/// True when the filter can match an entity that has no property rows at all,
+/// i.e. the expression evaluated with every literal false. When this returns
+/// false, property-less entity types (channels, calls, CRM companies, foreign
+/// entities) can never satisfy the filter.
+pub fn properties_filter_matches_propertyless(expr: &Expr<PropertiesLiteral>) -> bool {
+    match expr {
+        Expr::And(a, b) => {
+            properties_filter_matches_propertyless(a) && properties_filter_matches_propertyless(b)
+        }
+        Expr::Or(a, b) => {
+            properties_filter_matches_propertyless(a) || properties_filter_matches_propertyless(b)
+        }
+        Expr::Not(a) => !properties_filter_matches_propertyless(a),
+        Expr::Literal(_) => false,
+    }
+}

--- a/rust/cloud-storage/item_filters/src/ast/tests.rs
+++ b/rust/cloud-storage/item_filters/src/ast/tests.rs
@@ -1467,3 +1467,66 @@ fn crm_scope_accepts_non_empty_variants_on_deserialize() {
     let addresses: CrmScope = serde_json::from_str(r#"{"Addresses":["a@acme.com"]}"#).unwrap();
     assert!(matches!(addresses, CrmScope::Addresses(a) if a == vec!["a@acme.com".to_string()]));
 }
+
+#[test]
+fn properties_filter_can_apply_to_respects_literal_entity_types() {
+    use properties::{
+        PropertiesLiteral, PropertyEntityType, PropertyMatchValue, properties_filter_can_apply_to,
+    };
+    let lit = |entity_type| {
+        Expr::Literal(PropertiesLiteral {
+            property_definition_id: Uuid::new_v4(),
+            entity_type,
+            value: PropertyMatchValue::SelectOption(Uuid::new_v4()),
+        })
+    };
+
+    let untyped = lit(None);
+    assert!(properties_filter_can_apply_to(
+        &untyped,
+        &[PropertyEntityType::Thread]
+    ));
+
+    let task_only = lit(Some(PropertyEntityType::Task));
+    assert!(!properties_filter_can_apply_to(
+        &task_only,
+        &[PropertyEntityType::Thread]
+    ));
+
+    let either = Expr::or(lit(Some(PropertyEntityType::Task)), lit(None));
+    assert!(properties_filter_can_apply_to(
+        &either,
+        &[PropertyEntityType::Thread]
+    ));
+
+    let negated = Expr::is_not(lit(Some(PropertyEntityType::Task)));
+    assert!(properties_filter_can_apply_to(
+        &negated,
+        &[PropertyEntityType::Thread]
+    ));
+}
+
+#[test]
+fn properties_filter_matches_propertyless_evaluates_literals_as_false() {
+    use properties::{
+        PropertiesLiteral, PropertyMatchValue, properties_filter_matches_propertyless,
+    };
+    let lit = || {
+        Expr::Literal(PropertiesLiteral {
+            property_definition_id: Uuid::new_v4(),
+            entity_type: None,
+            value: PropertyMatchValue::SelectOption(Uuid::new_v4()),
+        })
+    };
+
+    assert!(!properties_filter_matches_propertyless(&lit()));
+    assert!(!properties_filter_matches_propertyless(&Expr::or(
+        lit(),
+        lit()
+    )));
+    assert!(properties_filter_matches_propertyless(&Expr::is_not(lit())));
+    assert!(!properties_filter_matches_propertyless(&Expr::and(
+        lit(),
+        Expr::is_not(lit())
+    )));
+}

--- a/rust/cloud-storage/search_service/src/api/search/simple/simple_unified.rs
+++ b/rust/cloud-storage/search_service/src/api/search/simple/simple_unified.rs
@@ -230,17 +230,21 @@ pub(in crate::api::search) async fn perform_unified_search(
 
     let match_type = req.match_type;
 
-    // CRM is opt-in: it only runs when the caller resolved a team receipt
-    // (set only when `include_crm` is true and the user has a qualifying
-    // membership). `crm_company_filters` scopes/selects within the team.
-    let crm_company_filters = req.filters.crm_company_filters.clone();
-    let should_include_crm = crm_access.is_some();
-
     // Property filters live at the top level of the request and only apply to
     // the OpenSearch documents index, so capture them before the conversion
     // (which drops them) and attach them to the document search args below.
     let property_filter_args = to_property_filter_args(&req.filters.property_filters);
     let tag_option_ids = req.filters.tag_option_ids.clone();
+    // Tags are only indexed for the documents index. With a tag filter
+    // active every other source is dropped, so response pages contain only
+    // rows the filter was actually applied to.
+    let tags_active = !tag_option_ids.is_empty();
+
+    // CRM is opt-in: it only runs when the caller resolved a team receipt
+    // (set only when `include_crm` is true and the user has a qualifying
+    // membership). `crm_company_filters` scopes/selects within the team.
+    let crm_company_filters = req.filters.crm_company_filters.clone();
+    let should_include_crm = crm_access.is_some() && !tags_active;
 
     let search_filters = SearchEntityFilters::from(req.filters);
     let channel_filters = search_filters.channel_filters;
@@ -251,11 +255,11 @@ pub(in crate::api::search) async fn perform_unified_search(
     let call_filters = search_filters.call_filters;
 
     let should_include_documents = search_filters.should_include_documents;
-    let should_include_channels = search_filters.should_include_channels;
-    let should_include_chats = search_filters.should_include_chats;
-    let should_include_projects = search_filters.should_include_projects;
-    let should_include_emails = search_filters.should_include_emails;
-    let should_include_call_records = search_filters.should_include_call_records;
+    let should_include_channels = search_filters.should_include_channels && !tags_active;
+    let should_include_chats = search_filters.should_include_chats && !tags_active;
+    let should_include_projects = search_filters.should_include_projects && !tags_active;
+    let should_include_emails = search_filters.should_include_emails && !tags_active;
+    let should_include_call_records = search_filters.should_include_call_records && !tags_active;
     let email_terms = search_terms.clone();
 
     // Await all tasks in parallel

--- a/rust/cloud-storage/soup/src/domain/models.rs
+++ b/rust/cloud-storage/soup/src/domain/models.rs
@@ -19,7 +19,15 @@ use foreign_entity::domain::{
 use frecency::domain::models::{AggregateFrecency, FrecencyQueryErr};
 use item_filters::{
     EntityFilters,
-    ast::{EntityFilterAst, ExpandErr, crm_company::CrmCompanyLiteral},
+    ast::{
+        EntityFilterAst, ExpandErr,
+        crm_company::CrmCompanyLiteral,
+        email::EmailLiteral,
+        properties::{
+            PropertiesLiteral, PropertyEntityType, properties_filter_can_apply_to,
+            properties_filter_matches_propertyless,
+        },
+    },
 };
 use macro_user_id::user_id::MacroUserIdStr;
 use model_entity::Entity;
@@ -30,6 +38,7 @@ use models_pagination::{
 };
 use models_soup::item::SoupItem;
 use non_empty::IsEmpty;
+use std::sync::Arc;
 use thiserror::Error;
 use uuid::Uuid;
 
@@ -307,17 +316,20 @@ impl SoupRequest<Option<EntityFilterAst>> {
         &self,
         team_receipt: Option<EntityAccessReceipt<MemberTeamRole>>,
     ) -> Option<GetEmailsRequest> {
-        let entity_ast: Option<&EntityFilterAst> = match &self.cursor {
-            SoupQuery::Simple(SimpleQueryInner(Query::Sort(_, f))) => f.as_ref(),
-            SoupQuery::Simple(SimpleQueryInner(Query::Cursor(CursorWithValAndFilter {
-                filter,
-                ..
-            }))) => filter.as_ref(),
-            SoupQuery::Frecency(_) => None,
-        };
+        let entity_ast = self.entity_ast();
         let crm_scope = entity_ast.and_then(|a| a.email_filter.crm_scope.clone());
 
         if self.link_ids.is_empty() {
+            return None;
+        }
+
+        // A properties filter that cannot match threads makes the email
+        // branch empty, so the sub-request is skipped. Otherwise it is ANDed
+        // into the email tree so the query returns exactly matching threads.
+        let properties_filter = entity_ast.and_then(|a| a.properties_filter.as_deref());
+        if let Some(propf) = properties_filter
+            && !properties_filter_can_apply_to(propf, &[PropertyEntityType::Thread])
+        {
             return None;
         }
 
@@ -329,7 +341,10 @@ impl SoupRequest<Option<EntityFilterAst>> {
             query: match &self.cursor {
                 SoupQuery::Simple(SimpleQueryInner(Query::Sort(t, f))) => Some(Query::Sort(
                     *t,
-                    f.as_ref().and_then(|f| f.email_filter.tree.clone()),
+                    with_properties_filter(
+                        f.as_ref().and_then(|f| f.email_filter.tree.clone()),
+                        properties_filter,
+                    ),
                 )),
                 SoupQuery::Simple(SimpleQueryInner(Query::Cursor(CursorWithValAndFilter {
                     id,
@@ -340,7 +355,10 @@ impl SoupRequest<Option<EntityFilterAst>> {
                     id: *id,
                     limit: *limit,
                     val: val.clone(),
-                    filter: filter.as_ref().and_then(|f| f.email_filter.tree.clone()),
+                    filter: with_properties_filter(
+                        filter.as_ref().and_then(|f| f.email_filter.tree.clone()),
+                        properties_filter,
+                    ),
                 })),
                 // we don't yet have sort by frecency implemented for emails yet
                 SoupQuery::Frecency(_) => None,
@@ -350,7 +368,32 @@ impl SoupRequest<Option<EntityFilterAst>> {
         })
     }
 
+    /// The request's entity filter ast, regardless of cursor position.
+    fn entity_ast(&self) -> Option<&EntityFilterAst> {
+        match &self.cursor {
+            SoupQuery::Simple(SimpleQueryInner(Query::Sort(_, f))) => f.as_ref(),
+            SoupQuery::Simple(SimpleQueryInner(Query::Cursor(CursorWithValAndFilter {
+                filter,
+                ..
+            }))) => filter.as_ref(),
+            SoupQuery::Frecency(_) => None,
+        }
+    }
+
+    /// True when an active properties filter can never match an entity with
+    /// no property rows. Property-less sub-requests (channels, channel
+    /// threads, calls, CRM companies, foreign entities) are skipped so pages
+    /// only contain rows the filter applies to.
+    fn properties_filter_blocks_propertyless(&self) -> bool {
+        self.entity_ast()
+            .and_then(|a| a.properties_filter.as_deref())
+            .is_some_and(|p| !properties_filter_matches_propertyless(p))
+    }
+
     pub(crate) fn build_call_request(&self) -> Option<GetCallRecordsRequest> {
+        if self.properties_filter_blocks_propertyless() {
+            return None;
+        }
         Some(GetCallRecordsRequest {
             user_id: self.user.clone(),
             limit: self.limit as u32,
@@ -382,6 +425,9 @@ impl SoupRequest<Option<EntityFilterAst>> {
         &self,
         team_receipt: &Option<EntityAccessReceipt<MemberTeamRole>>,
     ) -> Option<GetCrmCompaniesRequest> {
+        if self.properties_filter_blocks_propertyless() {
+            return None;
+        }
         let receipt = team_receipt.as_ref()?;
         // Re-wrap the verified team receipt as the CRM capability token the
         // service now requires; a malformed receipt skips the sub-request.
@@ -450,6 +496,9 @@ impl SoupRequest<Option<EntityFilterAst>> {
     }
 
     pub(crate) fn build_comms_request(&self) -> Option<GetChannelsRequest> {
+        if self.properties_filter_blocks_propertyless() {
+            return None;
+        }
         Some(GetChannelsRequest {
             macro_id: self.user.clone(),
             limit: Some(self.limit as u32),
@@ -476,6 +525,9 @@ impl SoupRequest<Option<EntityFilterAst>> {
     }
 
     pub(crate) fn build_comms_thread_request(&self) -> Option<GetThreadReplyRowsRequest> {
+        if self.properties_filter_blocks_propertyless() {
+            return None;
+        }
         let query = match &self.cursor {
             SoupQuery::Simple(SimpleQueryInner(Query::Sort(t, f))) => Some(Query::Sort(
                 *t,
@@ -506,6 +558,9 @@ impl SoupRequest<Option<EntityFilterAst>> {
     }
 
     pub(crate) fn build_foreign_entity_query(&self) -> Option<ForeignEntityListQuery> {
+        if self.properties_filter_blocks_propertyless() {
+            return None;
+        }
         match &self.cursor {
             SoupQuery::Simple(SimpleQueryInner(Query::Sort(t, f))) => Some(Query::Sort(
                 *t,
@@ -541,6 +596,32 @@ impl SoupRequest<Option<EntityFilterAst>> {
         }
 
         source_ids
+    }
+}
+
+/// ANDs a properties filter into the email filter tree as thread-level
+/// [EmailLiteral::Property] conditions, so the email query returns exactly
+/// the threads that satisfy it.
+fn with_properties_filter(
+    tree: Option<Arc<Expr<EmailLiteral>>>,
+    properties_filter: Option<&Expr<PropertiesLiteral>>,
+) -> Option<Arc<Expr<EmailLiteral>>> {
+    let Some(propf) = properties_filter else {
+        return tree;
+    };
+    let mapped = map_properties_to_email(propf);
+    Some(Arc::new(match tree {
+        Some(tree) => Expr::and((*tree).clone(), mapped),
+        None => mapped,
+    }))
+}
+
+fn map_properties_to_email(expr: &Expr<PropertiesLiteral>) -> Expr<EmailLiteral> {
+    match expr {
+        Expr::And(a, b) => Expr::and(map_properties_to_email(a), map_properties_to_email(b)),
+        Expr::Or(a, b) => Expr::or(map_properties_to_email(a), map_properties_to_email(b)),
+        Expr::Not(a) => Expr::Not(Box::new(map_properties_to_email(a))),
+        Expr::Literal(lit) => Expr::Literal(EmailLiteral::Property(lit.clone())),
     }
 }
 


### PR DESCRIPTION
Extends tags and properties beyond markdown docs: relaxes the `TagsRow` entity-type gate to include `THREAD` so the email side panel shows tags, adds a shared `FileSidePanelSections` (Details + Properties) that block-pdf now reuses, and wires `SidePanel.Layout` into the image/video/code/canvas/unknown blocks (closed by default except unknown). Email thread rows render tag chips, document rows pass the correct `TASK` entity type, and the search view's `all` type gets the tags facet. Tag filters are now applied server-side for precise pages: the email soup query ANDs the properties filter as a new `EmailLiteral::Property` EXISTS on `entity_properties`, property-less sub-requests (channels/calls/CRM/foreign) are skipped when the filter can't match them, and unified search drops non-document legs while tags are active (rendered rows keep a client-side guard). Chats and projects are deferred to follow-up tasks.
