### PR TITLE
fix(calls): apply mobile content inset to call recording body

### DIFF
--- a/js/app/packages/block-call/component/CallRecording/CallRecordingBody.tsx
+++ b/js/app/packages/block-call/component/CallRecording/CallRecordingBody.tsx
@@ -160,7 +160,7 @@ export function CallRecordingBody(props: {
           class="h-full min-h-0 overflow-y-auto scrollbar-hidden"
           ref={setScrollRef}
         >
-          <div class="mx-auto max-w-3xl min-w-0 px-6 pt-12 pb-16">
+          <div class="mx-auto max-w-3xl min-w-0 px-6 pt-12 pb-16 mobile:pt-(--mobile-content-inset-top) mobile:pb-(--mobile-content-inset-bottom)">
             <div class="flex flex-col gap-10">
               <header>
                 <Show when={!isMobile()}>


### PR DESCRIPTION
## What
The call recording detail view (`CallRecordingBody.tsx`) didn't account for the mobile floating header/nav chrome, so the call title text ended up clipped/obscured behind it on mobile.

Adds the same `mobile:pt-(--mobile-content-inset-top) mobile:pb-(--mobile-content-inset-bottom)` padding that every other mobile-aware surface already uses (e.g. `Chat.tsx`, `Email.tsx`, `Block.tsx`, `HtmlPreview.tsx`, `Settings.tsx`) to keep content clear of that chrome.

## Why prioritized
Found during a routine sweep of open bug reports with no PR or in-progress work covering it yet. One-line, localized, matches an established pattern elsewhere in the codebase.

MACRO-2168


---
_Generated by [Claude Code](https://claude.ai/code/session_01845v4EkLy6N5QsCYDnzJ2F)_