### PR TITLE
fix(tasks): soften duplicate-detection badge copy

### DIFF
--- a/js/app/packages/block-md/component/TaskDuplicateMatches.tsx
+++ b/js/app/packages/block-md/component/TaskDuplicateMatches.tsx
@@ -44,7 +44,7 @@ export function TaskDuplicateMatchPill() {
               title="Possible duplicate tasks"
             >
               <WarningIcon class="size-3 shrink-0" />
-              <span class="truncate">Duplicate Detected</span>
+              <span class="truncate">Possible duplicate</span>
               <CaretDownIcon class="size-3 shrink-0 text-current/70" />
             </Dropdown.Trigger>
             <Dropdown.Content class="max-w-[calc(100vw-24px)]">


### PR DESCRIPTION
## What
The task duplicate-match pill (`TaskDuplicateMatchPill` in `TaskDuplicateMatches.tsx`) labels itself "Duplicate Detected" in confident red/failure styling. The underlying matcher works off title similarity alone and can false-positive on short or generic titles, so the label overstates its own confidence. The pill's own tooltip already says "Possible duplicate tasks" — this change aligns the visible label with that same, more accurate framing ("Possible duplicate").

## Why prioritized
Reported in a bug thread where a false positive fired even after the task was given more distinguishing detail, and a teammate suggested exactly this copy change. Single string literal, no logic/query changes, gated behind the existing feature flag.

MACRO-2170


---
_Generated by [Claude Code](https://claude.ai/code/session_01845v4EkLy6N5QsCYDnzJ2F)_