### PR TITLE
fix(teams): bugs when viewing, accepting, and rejecting invites

### DIFF
--- a/js/app/packages/app/component/TeamInviteAcceptance.tsx
+++ b/js/app/packages/app/component/TeamInviteAcceptance.tsx
@@ -2,6 +2,7 @@ import { ShowFeatureFlag } from '@app/lib/analytics/posthog';
 import { LoadingBlock } from '@core/component/LoadingBlock';
 import { PcNoiseGrid } from '@core/component/PcNoiseGrid';
 import { ENABLE_TEAMS_OVERRIDE } from '@core/constant/featureFlags';
+import { tryMacroId, useDisplayName } from '@core/user';
 import LogoIcon from '@icon/macro-logo.svg';
 import EnvelopeIcon from '@phosphor/envelope.svg';
 import SpinnerIcon from '@phosphor/spinner.svg';
@@ -129,7 +130,6 @@ function TeamInviteAcceptanceContent() {
                 <Match when={isLoading()}>
                   <LoadingBlock />
                 </Match>
-
                 <Match when={!invite()}>
                   <InviteNotFound />
                 </Match>
@@ -233,6 +233,8 @@ function InviteDetails(props: {
   };
   const isDisabled = () => props.isJoining || props.isDeclining;
 
+  const [invitedBy] = useDisplayName(tryMacroId(props.invitedBy));
+
   return (
     <div class="flex flex-col items-center gap-6 text-center w-full">
       <div class="flex flex-col gap-2">
@@ -241,9 +243,8 @@ function InviteDetails(props: {
           Join {displayTeamName()}
         </h2>
         <p class="text-sm text-ink-muted">
-          <span class="text-ink">{props.invitedBy}</span> has invited you to
-          join as a <span class="font-medium text-accent">{roleDisplay()}</span>
-          .
+          <span class="text-ink">{invitedBy()}</span> has invited you to join as
+          a <span class="font-medium text-accent">{roleDisplay()}</span>.
         </p>
       </div>
 

--- a/js/app/packages/app/component/auth/EmailForm.tsx
+++ b/js/app/packages/app/component/auth/EmailForm.tsx
@@ -89,10 +89,10 @@ export const sendEmailCode = action(async (formData: FormData) => {
 
 export function useResetEmailCode(setStage: (next: Stage) => void) {
   const submission = useSubmission(sendEmailCode);
-  return createCallback(() => {
+  return () => {
     submission.clear();
     setStage(Stage.Email);
-  });
+  };
 }
 
 export function EmailForm(props: { setStage: (next: Stage) => void }) {

--- a/js/app/packages/app/component/settings/Team.tsx
+++ b/js/app/packages/app/component/settings/Team.tsx
@@ -494,12 +494,7 @@ function UserInviteRow(props: {
           variant="active"
           class="px-2 py-1 rounded-xs"
           disabled={props.isAccepting || props.isDeclining}
-          tooltip={
-            props.requiresUpgrade
-              ? 'Joining a team requires a paid plan'
-              : undefined
-          }
-          onClick={props.requiresUpgrade ? props.onUpgrade : props.onAccept}
+          onClick={props.onAccept}
         >
           <Show when={props.isAccepting} fallback="Join">
             <SpinnerIcon class="size-4 animate-spin" />

--- a/js/app/packages/queries/team/invitations.ts
+++ b/js/app/packages/queries/team/invitations.ts
@@ -35,36 +35,13 @@ type JoinTeamCallbacks = MutationCallbacks<
 
 export function useJoinTeamMutation(callbacks?: JoinTeamCallbacks) {
   return useMutation(() => ({
+    mutationKey: teamKeys.acceptInvite.queryKey,
     mutationFn: async ({ teamInviteId }: JoinTeamArgs) => {
       await throwOnErr(() => authServiceClient.joinTeam(teamInviteId));
     },
 
     ...withCallbacks<void, Error, JoinTeamArgs, JoinTeamContext>(
       {
-        onMutate: async ({ teamInviteId }) => {
-          await queryClient.cancelQueries({
-            queryKey: teamKeys.userInvites.queryKey,
-          });
-
-          const previousInvites = queryClient.getQueryData<TeamInvitesResponse>(
-            teamKeys.userInvites.queryKey
-          );
-
-          queryClient.setQueryData<TeamInvitesResponse>(
-            teamKeys.userInvites.queryKey,
-            (old) =>
-              old
-                ? {
-                    invites: old.invites.filter(
-                      (invite) => invite.id !== teamInviteId
-                    ),
-                  }
-                : undefined
-          );
-
-          return { previousInvites };
-        },
-
         onSuccess: () => {
           invalidateUserTeams();
           invalidateUserInvites();
@@ -103,6 +80,7 @@ export function useRejectInvitationMutation(
   callbacks?: RejectInvitationCallbacks
 ) {
   return useMutation(() => ({
+    mutationKey: teamKeys.rejectInvite.queryKey,
     mutationFn: async ({ teamInviteId }: RejectInvitationArgs) => {
       await throwOnErr(() => authServiceClient.rejectInvitation(teamInviteId));
     },
@@ -114,30 +92,6 @@ export function useRejectInvitationMutation(
       RejectInvitationContext
     >(
       {
-        onMutate: async ({ teamInviteId }) => {
-          await queryClient.cancelQueries({
-            queryKey: teamKeys.userInvites.queryKey,
-          });
-
-          const previousInvites = queryClient.getQueryData<TeamInvitesResponse>(
-            teamKeys.userInvites.queryKey
-          );
-
-          queryClient.setQueryData<TeamInvitesResponse>(
-            teamKeys.userInvites.queryKey,
-            (old) =>
-              old
-                ? {
-                    invites: old.invites.filter(
-                      (invite) => invite.id !== teamInviteId
-                    ),
-                  }
-                : undefined
-          );
-
-          return { previousInvites };
-        },
-
         onSuccess: () => {
           invalidateUserInvites();
           toast.success('Invitation declined');

--- a/js/app/packages/queries/team/keys.ts
+++ b/js/app/packages/queries/team/keys.ts
@@ -4,6 +4,8 @@ export const teamKeys = createQueryKeys('team', {
   userTeams: null,
   userInvites: null,
   currentTeam: null,
+  acceptInvite: null,
+  rejectInvite: null,
   detail: (teamId: string) => [teamId],
   invites: (teamId: string) => [teamId],
 });

--- a/js/app/packages/queries/team/teams.ts
+++ b/js/app/packages/queries/team/teams.ts
@@ -60,8 +60,11 @@ export function useIsTeamAdmin(): Accessor<boolean> {
 }
 
 export function invalidateUserTeams() {
-  return queryClient.invalidateQueries({
+  queryClient.invalidateQueries({
     queryKey: teamKeys.userTeams.queryKey,
+  });
+  queryClient.invalidateQueries({
+    queryKey: teamKeys.currentTeam.queryKey,
   });
 }
 


### PR DESCRIPTION
- Fixes id showing on invite view instead of name/email
- Fixes transition to wrong view before accept/reject finish. This was caused by the optimistic update, removed now.
- Removes requirement for being on a paid plan to accept a team invite
- Possibly fixes "Change email" button on login page