### PR TITLE
Enable global shortcuts to control all side panels

### DIFF
--- a/js/app/packages/app/component/app-sidebar/sidebar.tsx
+++ b/js/app/packages/app/component/app-sidebar/sidebar.tsx
@@ -20,6 +20,7 @@ import {
   requestInboxFilter,
 } from '@app/component/next-soup/soup-view/inbox-filter-controllers';
 import { requestSearchFocus } from '@app/component/next-soup/soup-view/search-controllers';
+import { setAllSidePanelsOpen } from '@app/component/side-panel/registry';
 import { useSplitLayout } from '@app/component/split-layout/layout';
 import type {
   ReferredFrom,
@@ -422,11 +423,13 @@ const registerSidebarHotkeys = ({
     hotkey: 'cmd+.',
     scopeId: 'global',
     hotkeyToken: TOKENS.global.toggleSidebar,
-    description: 'Toggle sidebar',
+    description: 'Toggle sidebar and side panels',
     runWithInputFocused: true,
     keyDownHandler: (e) => {
       e?.preventDefault();
-      onOpenChange(isSlim());
+      const show = isSlim();
+      onOpenChange(show);
+      setAllSidePanelsOpen(show);
       return true;
     },
   });

--- a/js/app/packages/app/component/side-panel/SidePanel.tsx
+++ b/js/app/packages/app/component/side-panel/SidePanel.tsx
@@ -32,6 +32,7 @@ import {
   type SidePanelContextType,
   type SidePanelSectionEntry,
 } from './context';
+import { registerSidePanelInstance } from './registry';
 
 const NARROW_THRESHOLD_PX = 1224;
 const SIDE_MIN_PX = 320;
@@ -72,6 +73,10 @@ function Layout(props: ParentProps) {
     setter(typeof next === 'function' ? next : () => next);
   };
   const toggle = () => setIsOpen((prev) => !prev);
+
+  // Let global chrome shortcuts (cmd+.) hide/show this panel alongside the
+  // app sidebar.
+  onCleanup(registerSidePanelInstance({ setIsOpen, isNarrow }));
 
   const register = (entry: SidePanelSectionEntry) => {
     setSections((prev) => {

--- a/js/app/packages/app/component/side-panel/registry.ts
+++ b/js/app/packages/app/component/side-panel/registry.ts
@@ -1,0 +1,31 @@
+/**
+ * Module-level registry of mounted SidePanel layouts so global chrome
+ * shortcuts (e.g. cmd+. "toggle sidebar") can show/hide every right-hand
+ * side panel, not just the panel owned by the focused split.
+ */
+
+type SidePanelInstance = {
+  setIsOpen: (open: boolean) => void;
+  isNarrow: () => boolean;
+};
+
+const instances = new Set<SidePanelInstance>();
+
+/** Register a mounted side panel. Returns a disposer. */
+export function registerSidePanelInstance(instance: SidePanelInstance) {
+  instances.add(instance);
+  return () => {
+    instances.delete(instance);
+  };
+}
+
+/**
+ * Show/hide every mounted side panel. Narrow layouts render the panel as a
+ * full-screen overlay, so they are only ever hidden — never force-opened.
+ */
+export function setAllSidePanelsOpen(open: boolean) {
+  for (const instance of instances) {
+    if (open && instance.isNarrow()) continue;
+    instance.setIsOpen(open);
+  }
+}


### PR DESCRIPTION
## Summary
This change enables the global `cmd+.` keyboard shortcut to toggle not only the app sidebar but also all mounted side panels throughout the application. Previously, the shortcut only affected the sidebar, leaving individual side panels uncontrolled by this global chrome shortcut.

## Key Changes
- **New registry module** (`side-panel/registry.ts`): Implements a module-level registry to track all mounted SidePanel instances, allowing global shortcuts to control them collectively
  - `registerSidePanelInstance()`: Registers a side panel and returns a disposer function
  - `setAllSidePanelsOpen()`: Toggles all registered side panels, with special handling for narrow layouts (which are only hidden, never force-opened)

- **SidePanel component integration**: Registers each mounted SidePanel instance with the global registry on mount and cleans up on unmount

- **Sidebar hotkey update**: Modified the `cmd+.` hotkey handler to call `setAllSidePanelsOpen()` in addition to toggling the sidebar, and updated the description to reflect the expanded functionality

## Implementation Details
- Narrow layouts (responsive design) are handled specially: they render as full-screen overlays and are only hidden by the global shortcut, never force-opened
- The registry uses a `Set` for efficient add/remove operations
- Each side panel instance provides `setIsOpen()` and `isNarrow()` methods to the registry
- Cleanup is handled via disposer functions returned from `registerSidePanelInstance()`

https://claude.ai/code/session_01EETF27bjX6n8VeZTuPh7UA