### PR TITLE
Calls tab: gallery view by default with a gallery/list toggle

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/soup-filters-bar.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/soup-filters-bar.tsx
@@ -78,6 +78,15 @@ export function SoupFiltersBar() {
     return content.type === 'component' && content.id === 'search';
   });
 
+  // The calls view has no sort/group/filter chips, so its toolbar would hold
+  // only the preview button — skip both toolbar portals there so the empty
+  // bar collapses entirely (SplitPanel hides a toolbar with no content).
+  // Space still toggles the preview via the hotkey above.
+  const isCallsView = createMemo(() => {
+    const content = panel.handle.content();
+    return content.type === 'component' && content.id === 'calls';
+  });
+
   // The new inbox hides sort (it's fixed to updated_at for this view).
   const newInboxFlag = useFeatureFlag(ENABLE_NEW_INBOX_FLAG, {
     enabledOverride: ENABLE_NEW_INBOX_OVERRIDE,
@@ -93,34 +102,36 @@ export function SoupFiltersBar() {
 
   return (
     <Show when={!isMobile()}>
-      <SplitToolbarLeft>
-        <div class="flex items-start gap-1 min-w-0 flex-1">
-          <Show when={!isSearchView()} fallback={<SearchFiltersRow />}>
-            <Show when={!isNewInbox()}>
-              <SoupViewContextSort />
+      <Show when={!isCallsView()}>
+        <SplitToolbarLeft>
+          <div class="flex items-start gap-1 min-w-0 flex-1">
+            <Show when={!isSearchView()} fallback={<SearchFiltersRow />}>
+              <Show when={!isNewInbox()}>
+                <SoupViewContextSort />
+              </Show>
+              <SoupViewContextGroup />
+              <UnifiedFilterDropdown
+                open={filterDropdownOpen}
+                onOpenChange={setFilterDropdownOpen}
+              />
             </Show>
-            <SoupViewContextGroup />
-            <UnifiedFilterDropdown
-              open={filterDropdownOpen}
-              onOpenChange={setFilterDropdownOpen}
-            />
-          </Show>
-        </div>
-      </SplitToolbarLeft>
-      <SplitToolbarRight>
-        <Tooltip hotkey={TOKENS.unifiedList.togglePreview} label="Preview">
-          <Button
-            onClick={togglePreview}
-            variant="base"
-            size="sm"
-            depth={2}
-            class="bg-surface"
-          >
-            {soup.previewEntity() ? <EyeSlashIcon /> : <EyeIcon />}
-            <span>Preview</span>
-          </Button>
-        </Tooltip>
-      </SplitToolbarRight>
+          </div>
+        </SplitToolbarLeft>
+        <SplitToolbarRight>
+          <Tooltip hotkey={TOKENS.unifiedList.togglePreview} label="Preview">
+            <Button
+              onClick={togglePreview}
+              variant="base"
+              size="sm"
+              depth={2}
+              class="bg-surface"
+            >
+              {soup.previewEntity() ? <EyeSlashIcon /> : <EyeIcon />}
+              <span>Preview</span>
+            </Button>
+          </Tooltip>
+        </SplitToolbarRight>
+      </Show>
       {/* Active filters bar - shown below the toolbar when there are filters */}
       <Show when={!isSearchView()}>
         <SoupActiveFiltersBar

--- a/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
@@ -40,10 +40,11 @@ import {
   useApplyPreset,
 } from '@app/component/next-soup/soup-view/soup-view-tabs';
 import {
-  CALLS_GRID_COUNT,
-  CALLS_GRID_MIN_WIDTH,
-  CallsGrid,
-} from '@app/component/next-soup/soup-view/views/calls/CallsGrid';
+  CallsGalleryRow,
+  CallsLayoutToggle,
+  callsLayoutMode,
+  getCallsGalleryColumns,
+} from '@app/component/next-soup/soup-view/views/calls/CallsGallery';
 import { InboxListEntity } from '@app/component/next-soup/soup-view/views/inbox/InboxListEntity';
 import { TaskListEntity } from '@app/component/next-soup/soup-view/views/tasks/TaskListEntity';
 import { ResponsiveTaskListHeader } from '@app/component/next-soup/soup-view/views/tasks/TaskListHeader';
@@ -364,6 +365,14 @@ const useSoupNotificationInvalidators = () => {
 
 const SOUP_LIST_STATE_ENTRY_KEY = 'soup.listState';
 
+/**
+ * One virtualizer item: a normal soup row, or (calls gallery mode) a chunk of
+ * consecutive call rows rendered as one row of cards.
+ */
+type DisplayRow =
+  | { kind: 'single'; row: SoupRow }
+  | { kind: 'cards'; rows: SoupRow[] };
+
 type SoupListEntryState = {
   focus: string | undefined;
   virtualCache?: CacheSnapshot;
@@ -611,6 +620,9 @@ export const SoupView = (props: SoupViewProps) => {
                     collapsed={() => <CollapsedSoupViewTabs />}
                     containerClass="h-full"
                   />
+                  <Show when={isComponentListView('calls')}>
+                    <CallsLayoutToggle />
+                  </Show>
                 </Show>
               </Show>
               <Show
@@ -775,42 +787,77 @@ export const SoupViewList = (props: SoupViewListProps) => {
     return isListViewID(id) ? id : undefined;
   });
 
-  // On desktop the calls view lifts the most recent calls out of the list and
-  // shows them as a card grid above it — but only while the list column is
-  // wide enough for at least two card columns, and only for a flat,
-  // unsearched list (group headers and search hits stay in the list, where
-  // their context lives).
+  // On desktop the calls view defaults to a gallery of call cards instead of
+  // list rows (toggleable from the header). The gallery only renders while
+  // the list column is wide enough for at least two card columns and while
+  // no search is active (hit snippets belong in the list) — otherwise the
+  // rows fall back to the normal list.
   const [listColumnRef, setListColumnRef] = createSignal<HTMLElement>();
   const listColumnSize = createElementSize(listColumnRef);
 
-  const callsGridRows = createMemo<SoupRow[]>(() => {
-    if (isMobile() || currentView() !== 'calls') return [];
-    if (searchText()) return [];
-    if ((listColumnSize.width ?? 0) < CALLS_GRID_MIN_WIDTH) return [];
-
-    const gridRows: SoupRow[] = [];
-    for (const row of rows()) {
-      if (
-        row.getIsGrouped() ||
-        row.getIsLoadMore() ||
-        row.original.type !== 'call'
-      ) {
-        break;
-      }
-      gridRows.push(row);
-      if (gridRows.length === CALLS_GRID_COUNT) break;
-    }
-    return gridRows;
+  const galleryColumns = createMemo(() => {
+    if (isMobile() || currentView() !== 'calls') return 0;
+    if (callsLayoutMode() !== 'gallery') return 0;
+    if (searchText()) return 0;
+    return getCallsGalleryColumns(listColumnSize.width ?? 0);
   });
 
-  const listRows = createMemo(() => {
-    const gridCount = callsGridRows().length;
-    return gridCount ? rows().slice(gridCount) : rows();
+  // What the virtualizer actually renders: plain rows in list mode; in
+  // gallery mode consecutive call rows are chunked into card rows of
+  // `galleryColumns` while group headers and load-more rows stay full-width.
+  const displayRows = createMemo<DisplayRow[]>(() => {
+    const columns = galleryColumns();
+    const allRows = rows();
+
+    if (columns === 0) {
+      return allRows.map((row): DisplayRow => ({ kind: 'single', row }));
+    }
+
+    const out: DisplayRow[] = [];
+    let chunk: SoupRow[] = [];
+    const flush = () => {
+      if (chunk.length) {
+        out.push({ kind: 'cards', rows: chunk });
+        chunk = [];
+      }
+    };
+
+    for (const row of allRows) {
+      if (row.getIsGrouped() || row.getIsLoadMore()) {
+        flush();
+        out.push({ kind: 'single', row });
+        continue;
+      }
+      // Rows of collapsed groups render as empty items in list mode; skip
+      // them here so they don't leave blank cells in a card row.
+      if (row.group && !row.group.isExpanded()) continue;
+      if (row.original.type !== 'call') {
+        flush();
+        out.push({ kind: 'single', row });
+        continue;
+      }
+      chunk.push(row);
+      if (chunk.length === columns) flush();
+    }
+    flush();
+    return out;
+  });
+
+  const displayIndexByRowIndex = createMemo(() => {
+    const map = new Map<number, number>();
+    displayRows().forEach((displayRow, displayIndex) => {
+      if (displayRow.kind === 'single') {
+        map.set(displayRow.row.index, displayIndex);
+      } else {
+        for (const row of displayRow.rows) map.set(row.index, displayIndex);
+      }
+    });
+    return map;
   });
 
   // Navigation code scrolls by index into the full rows() array, but the
-  // virtualizer only holds the rows after the calls grid — shift indexes
-  // back by the extracted count so scroll targets stay aligned.
+  // virtualizer holds display rows (in gallery mode several calls share one
+  // card row) — remap so scroll targets stay aligned.
   const adjustedVirtualizerHandle = createMemo<VirtualizerHandle | undefined>(
     () => {
       const handle = virtualizerHandle();
@@ -824,7 +871,7 @@ export const SoupViewList = (props: SoupViewListProps) => {
               opts?: Parameters<VirtualizerHandle['scrollToIndex']>[1]
             ) =>
               target.scrollToIndex(
-                Math.max(0, index - callsGridRows().length),
+                displayIndexByRowIndex().get(index) ?? index,
                 opts
               );
           }
@@ -1321,26 +1368,6 @@ export const SoupViewList = (props: SoupViewListProps) => {
                     </div>
                   </Match>
                   <Match when={rows().length}>
-                    <Show when={callsGridRows().length > 0}>
-                      <CallsGrid
-                        rows={callsGridRows()}
-                        onEntityClick={(row, event) => {
-                          onEntityClick({
-                            type: 'entity',
-                            entity: row.original,
-                            event,
-                            location: undefined,
-                            rowIndex: row.index,
-                          });
-                        }}
-                        onEntityMouseMove={(row) => {
-                          if (isKeypressActive()) return;
-                          if (soup.previewEntity() || isNewInboxEnabled())
-                            return;
-                          soup.focus.setIndex(row.index);
-                        }}
-                      />
-                    </Show>
                     <ListLayoutProvider ref={localEntityListRef}>
                       <Show when={currentView() === 'tasks' && !isMobile()}>
                         <ResponsiveTaskListHeader class="shrink-0" />
@@ -1382,9 +1409,42 @@ export const SoupViewList = (props: SoupViewListProps) => {
                           virtualizerRef={registerVirtualizerHandler}
                           onScrollBottom={debouncedFetchMore}
                           scrollBottomOffset={300}
-                          rows={listRows()}
+                          rows={displayRows()}
                         >
-                          {(row, i) => {
+                          {(displayRow, i) => {
+                            if (displayRow.kind === 'cards') {
+                              return (
+                                <>
+                                  <CallsGalleryRow
+                                    rows={displayRow.rows}
+                                    columns={galleryColumns()}
+                                    onEntityClick={(row, event) => {
+                                      onEntityClick({
+                                        type: 'entity',
+                                        entity: row.original,
+                                        event,
+                                        location: undefined,
+                                        rowIndex: row.index,
+                                      });
+                                    }}
+                                    onEntityMouseMove={(row) => {
+                                      if (isKeypressActive()) return;
+                                      if (
+                                        soup.previewEntity() ||
+                                        isNewInboxEnabled()
+                                      )
+                                        return;
+                                      soup.focus.setIndex(row.index);
+                                    }}
+                                  />
+                                  <Show when={i() === displayRows().length - 1}>
+                                    <div class="h-15 mobile:hidden" />
+                                  </Show>
+                                </>
+                              );
+                            }
+
+                            const row = displayRow.row;
                             const timestamp = () => {
                               if (row.original.sortTs)
                                 return row.original.sortTs;
@@ -1585,7 +1645,7 @@ export const SoupViewList = (props: SoupViewListProps) => {
                                 </Switch>
                                 <Show
                                   when={
-                                    i() === listRows().length - 1 &&
+                                    i() === displayRows().length - 1 &&
                                     isSearchServiceLoading()
                                   }
                                 >
@@ -1594,7 +1654,7 @@ export const SoupViewList = (props: SoupViewListProps) => {
                                     Searching...
                                   </div>
                                 </Show>
-                                <Show when={i() === listRows().length - 1}>
+                                <Show when={i() === displayRows().length - 1}>
                                   {/* Desktop-only: mobile clearance comes
                                       from the in-scroll trailing spacer. */}
                                   <div class="h-15 mobile:hidden" />
@@ -1686,11 +1746,11 @@ interface SoupListProps {
   virtualizerClass?: string;
   itemSize?: number;
   overscan?: number;
-  children: (row: SoupRow, index: Accessor<number>) => JSX.Element;
+  children: (row: DisplayRow, index: Accessor<number>) => JSX.Element;
   onScrollOffsetChange?: (offset: number) => void;
   onScrollBottom?: VoidFunction;
   scrollBottomOffset?: number;
-  rows: SoupRow[];
+  rows: DisplayRow[];
   cache?: CacheSnapshot;
 }
 

--- a/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
@@ -39,6 +39,11 @@ import {
   SoupViewTabs,
   useApplyPreset,
 } from '@app/component/next-soup/soup-view/soup-view-tabs';
+import {
+  CALLS_GRID_COUNT,
+  CALLS_GRID_MIN_WIDTH,
+  CallsGrid,
+} from '@app/component/next-soup/soup-view/views/calls/CallsGrid';
 import { InboxListEntity } from '@app/component/next-soup/soup-view/views/inbox/InboxListEntity';
 import { TaskListEntity } from '@app/component/next-soup/soup-view/views/tasks/TaskListEntity';
 import { ResponsiveTaskListHeader } from '@app/component/next-soup/soup-view/views/tasks/TaskListHeader';
@@ -770,6 +775,66 @@ export const SoupViewList = (props: SoupViewListProps) => {
     return isListViewID(id) ? id : undefined;
   });
 
+  // On desktop the calls view lifts the most recent calls out of the list and
+  // shows them as a card grid above it — but only while the list column is
+  // wide enough for at least two card columns, and only for a flat,
+  // unsearched list (group headers and search hits stay in the list, where
+  // their context lives).
+  const [listColumnRef, setListColumnRef] = createSignal<HTMLElement>();
+  const listColumnSize = createElementSize(listColumnRef);
+
+  const callsGridRows = createMemo<SoupRow[]>(() => {
+    if (isMobile() || currentView() !== 'calls') return [];
+    if (searchText()) return [];
+    if ((listColumnSize.width ?? 0) < CALLS_GRID_MIN_WIDTH) return [];
+
+    const gridRows: SoupRow[] = [];
+    for (const row of rows()) {
+      if (
+        row.getIsGrouped() ||
+        row.getIsLoadMore() ||
+        row.original.type !== 'call'
+      ) {
+        break;
+      }
+      gridRows.push(row);
+      if (gridRows.length === CALLS_GRID_COUNT) break;
+    }
+    return gridRows;
+  });
+
+  const listRows = createMemo(() => {
+    const gridCount = callsGridRows().length;
+    return gridCount ? rows().slice(gridCount) : rows();
+  });
+
+  // Navigation code scrolls by index into the full rows() array, but the
+  // virtualizer only holds the rows after the calls grid — shift indexes
+  // back by the extracted count so scroll targets stay aligned.
+  const adjustedVirtualizerHandle = createMemo<VirtualizerHandle | undefined>(
+    () => {
+      const handle = virtualizerHandle();
+      if (!handle) return handle;
+
+      return new Proxy(handle, {
+        get(target, prop) {
+          if (prop === 'scrollToIndex') {
+            return (
+              index: number,
+              opts?: Parameters<VirtualizerHandle['scrollToIndex']>[1]
+            ) =>
+              target.scrollToIndex(
+                Math.max(0, index - callsGridRows().length),
+                opts
+              );
+          }
+          const value = Reflect.get(target, prop);
+          return typeof value === 'function' ? value.bind(target) : value;
+        },
+      });
+    }
+  );
+
   const focusFirstEntity = () => {
     const allRows = rows();
     const firstEntityIndex = allRows.findIndex(
@@ -783,7 +848,9 @@ export const SoupViewList = (props: SoupViewListProps) => {
     soup.setPreviewEntity(result?.row.id);
 
     if (result) {
-      virtualizerHandle()?.scrollToIndex(result.index, { align: 'nearest' });
+      adjustedVirtualizerHandle()?.scrollToIndex(result.index, {
+        align: 'nearest',
+      });
     }
   };
 
@@ -856,7 +923,7 @@ export const SoupViewList = (props: SoupViewListProps) => {
     scopeId: scopeId(),
     soup,
     splitHandle: panel.handle,
-    virtualizerHandle,
+    virtualizerHandle: adjustedVirtualizerHandle,
     hasNextPage: source.hasNextPage,
     isFetching: source.isFetching,
     isFetchingNextPage: source.isFetchingNextPage,
@@ -888,7 +955,7 @@ export const SoupViewList = (props: SoupViewListProps) => {
     scopeId: scopeId(),
     soup,
     splitHandle: panel.handle,
-    virtualizerHandle,
+    virtualizerHandle: adjustedVirtualizerHandle,
     previewState: () => !!soup.previewEntity(),
     currentView,
     activeTab,
@@ -1206,6 +1273,7 @@ export const SoupViewList = (props: SoupViewListProps) => {
             maxSize={previewPaneVisible() ? 840 : undefined}
           >
             <div
+              ref={setListColumnRef}
               class={cn(
                 '@container/u-list size-full unified-list-root flex flex-col relative',
                 soup.previewEntity() !== undefined &&
@@ -1253,6 +1321,26 @@ export const SoupViewList = (props: SoupViewListProps) => {
                     </div>
                   </Match>
                   <Match when={rows().length}>
+                    <Show when={callsGridRows().length > 0}>
+                      <CallsGrid
+                        rows={callsGridRows()}
+                        onEntityClick={(row, event) => {
+                          onEntityClick({
+                            type: 'entity',
+                            entity: row.original,
+                            event,
+                            location: undefined,
+                            rowIndex: row.index,
+                          });
+                        }}
+                        onEntityMouseMove={(row) => {
+                          if (isKeypressActive()) return;
+                          if (soup.previewEntity() || isNewInboxEnabled())
+                            return;
+                          soup.focus.setIndex(row.index);
+                        }}
+                      />
+                    </Show>
                     <ListLayoutProvider ref={localEntityListRef}>
                       <Show when={currentView() === 'tasks' && !isMobile()}>
                         <ResponsiveTaskListHeader class="shrink-0" />
@@ -1294,7 +1382,7 @@ export const SoupViewList = (props: SoupViewListProps) => {
                           virtualizerRef={registerVirtualizerHandler}
                           onScrollBottom={debouncedFetchMore}
                           scrollBottomOffset={300}
-                          rows={rows()}
+                          rows={listRows()}
                         >
                           {(row, i) => {
                             const timestamp = () => {
@@ -1446,7 +1534,7 @@ export const SoupViewList = (props: SoupViewListProps) => {
                                         ) =>
                                           handleMultiSelectChecked({
                                             entity: row.original,
-                                            entityIndex: i(),
+                                            entityIndex: row.index,
                                             next,
                                             shiftKey: shiftKey ?? false,
                                           })
@@ -1497,7 +1585,7 @@ export const SoupViewList = (props: SoupViewListProps) => {
                                 </Switch>
                                 <Show
                                   when={
-                                    i() === rows().length - 1 &&
+                                    i() === listRows().length - 1 &&
                                     isSearchServiceLoading()
                                   }
                                 >
@@ -1506,7 +1594,7 @@ export const SoupViewList = (props: SoupViewListProps) => {
                                     Searching...
                                   </div>
                                 </Show>
-                                <Show when={i() === rows().length - 1}>
+                                <Show when={i() === listRows().length - 1}>
                                   {/* Desktop-only: mobile clearance comes
                                       from the in-scroll trailing spacer. */}
                                   <div class="h-15 mobile:hidden" />

--- a/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
@@ -892,7 +892,11 @@ export const SoupViewList = (props: SoupViewListProps) => {
 
     const result = soup.navigate.toIndex(firstEntityIndex);
 
-    soup.setPreviewEntity(result?.row.id);
+    // The calls view has no preview button in its chrome, so never auto-open
+    // the pane there — only keep an already-open pane (Space) in sync.
+    if (currentView() !== 'calls' || soup.previewEntity()) {
+      soup.setPreviewEntity(result?.row.id);
+    }
 
     if (result) {
       adjustedVirtualizerHandle()?.scrollToIndex(result.index, {

--- a/js/app/packages/app/component/next-soup/soup-view/views/calls/CallsGallery.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/views/calls/CallsGallery.tsx
@@ -1,26 +1,80 @@
 import type { SoupRow } from '@app/component/next-soup/create-soup-state';
 import { SoupEntityContextMenu } from '@app/component/next-soup/soup-view/soup-entity-context-menu';
+import { usePreference } from '@app/preferences/use-preference';
 import { formatCallDuration } from '@block-call/utils';
 import { EntityIcon } from '@core/component/EntityIcon';
+import { TabsInset } from '@core/component/TabsInset';
 import { UserIcon } from '@core/component/UserIcon';
 import { CallRecordName } from '@entity/components/CallRecordName';
 import { Entity } from '@entity/entity';
 import type { CallEntity } from '@entity/types/entity';
+import ListIcon from '@phosphor/list.svg';
+import SquaresFourIcon from '@phosphor/squares-four.svg';
 import { usePropertyEntityDisplay } from '@property/hooks';
 import { useCallRecordQuery } from '@queries/call/call';
 import { EntityType } from '@service-properties/generated/schemas/entityType';
-import { cn } from '@ui';
+import { cn, Tooltip } from '@ui';
 import { createSignal, For, Show } from 'solid-js';
 
-/** How many of the most recent calls are lifted out of the list into cards. */
-export const CALLS_GRID_COUNT = 4;
+export type CallsLayoutMode = 'gallery' | 'list';
 
 /**
- * Narrowest list-column width (px) the card grid renders at. Below this the
- * two-column grid would collapse to a single column, so the grid turns off
- * and the calls render as normal list rows instead.
+ * Module-scope so the header toggle and the list body read the same reactive
+ * source (usePreference creates an independent signal per call, so two
+ * component-level calls with the same key would not stay in sync live).
  */
-export const CALLS_GRID_MIN_WIDTH = 520;
+const [callsLayoutMode, setCallsLayoutMode] = usePreference<CallsLayoutMode>(
+  'macro:pref:soup:calls:layout',
+  { default: 'gallery' }
+);
+
+export { callsLayoutMode };
+
+/**
+ * Narrowest list-column width (px) the gallery renders at. Below this the
+ * two-column grid would collapse to a single column, so the gallery falls
+ * back to normal list rows regardless of the toggle.
+ */
+const CALLS_GALLERY_MIN_WIDTH = 520;
+const CALLS_GALLERY_FOUR_COLUMN_WIDTH = 896;
+
+/** Card columns for a given list-column width; 0 disables the gallery. */
+export function getCallsGalleryColumns(width: number): number {
+  if (width < CALLS_GALLERY_MIN_WIDTH) return 0;
+  return width < CALLS_GALLERY_FOUR_COLUMN_WIDTH ? 2 : 4;
+}
+
+/** Finder-style gallery/list switch shown in the calls view header. */
+export function CallsLayoutToggle() {
+  return (
+    <TabsInset
+      list={[
+        {
+          value: 'gallery',
+          label: (
+            <Tooltip label="Gallery view" as="span">
+              <span class="flex items-center" aria-label="Gallery view">
+                <SquaresFourIcon class="size-3.5" />
+              </span>
+            </Tooltip>
+          ),
+        },
+        {
+          value: 'list',
+          label: (
+            <Tooltip label="List view" as="span">
+              <span class="flex items-center" aria-label="List view">
+                <ListIcon class="size-3.5" />
+              </span>
+            </Tooltip>
+          ),
+        },
+      ]}
+      value={callsLayoutMode()}
+      onChange={(value) => setCallsLayoutMode(value as CallsLayoutMode)}
+    />
+  );
+}
 
 const MAX_ATTENDEE_PILLS = 3;
 
@@ -141,17 +195,23 @@ function CallCard(props: {
 }
 
 /**
- * Card grid for the most recent calls, shown above the calls list on desktop.
- * Two columns by default, four when the list column is @4xl wide. The rows
- * passed here are removed from the list by the caller.
+ * One virtualized row of the calls gallery: up to `columns` call cards laid
+ * out on a fixed grid. Cards keep click/focus/context-menu parity with list
+ * rows.
  */
-export function CallsGrid(props: {
+export function CallsGalleryRow(props: {
   rows: SoupRow[];
+  columns: number;
   onEntityClick: (row: SoupRow, event: MouseEvent) => void;
   onEntityMouseMove?: (row: SoupRow) => void;
 }) {
   return (
-    <div class="grid shrink-0 grid-cols-2 items-stretch gap-2 px-2 pb-1 pt-2 @4xl/u-list:grid-cols-4">
+    <div
+      class="grid items-stretch gap-2 px-2 py-1"
+      style={{
+        'grid-template-columns': `repeat(${props.columns}, minmax(0, 1fr))`,
+      }}
+    >
       <For each={props.rows}>
         {(row) => (
           <SoupEntityContextMenu entity={row.original}>

--- a/js/app/packages/app/component/next-soup/soup-view/views/calls/CallsGallery.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/views/calls/CallsGallery.tsx
@@ -14,7 +14,7 @@ import { usePropertyEntityDisplay } from '@property/hooks';
 import { useCallRecordQuery } from '@queries/call/call';
 import { EntityType } from '@service-properties/generated/schemas/entityType';
 import { cn, Tooltip } from '@ui';
-import { createSignal, For, Show } from 'solid-js';
+import { createSignal, For, onCleanup, Show } from 'solid-js';
 
 export type CallsLayoutMode = 'gallery' | 'list';
 
@@ -95,12 +95,38 @@ function AttendeePill(props: { userId: string }) {
 }
 
 /**
+ * Don't fetch a card's record until it has stayed mounted this long —
+ * flinging the scrollbar through a large calls list mounts and unmounts
+ * hundreds of cards, and those fetches are heavy (full transcript) and
+ * uncancellable. Cards scrolled past never fetch.
+ */
+const CARD_FETCH_SETTLE_MS = 150;
+
+/**
+ * Treat a fetched record as fresh for this long so scrolling a card back
+ * into view reuses the cache instead of refetching. The preview image is a
+ * presigned URL with a 1h TTL, so a 10-minute window is comfortably safe;
+ * the opened call entity uses its own observer with the default staleTime
+ * and still refetches fresh data.
+ */
+const CARD_RECORD_STALE_MS = 10 * 60 * 1000;
+const CARD_RECORD_GC_MS = 30 * 60 * 1000;
+
+/**
  * The recording preview only exists on the full call record — the soup list
  * payload doesn't carry it — so each card fetches its record (shared with the
  * cache the opened call entity uses) and renders the presigned poster image.
  */
 function CallCardPreview(props: { entity: CallEntity }) {
-  const record = useCallRecordQuery(() => props.entity.id);
+  const [settled, setSettled] = createSignal(false);
+  const settleTimer = setTimeout(() => setSettled(true), CARD_FETCH_SETTLE_MS);
+  onCleanup(() => clearTimeout(settleTimer));
+
+  const record = useCallRecordQuery(() => props.entity.id, {
+    enabled: settled,
+    staleTime: CARD_RECORD_STALE_MS,
+    gcTime: CARD_RECORD_GC_MS,
+  });
   const [failed, setFailed] = createSignal(false);
   const previewUrl = () =>
     failed() ? undefined : record.data?.recordingPreviewUrl;
@@ -122,6 +148,7 @@ function CallCardPreview(props: { entity: CallEntity }) {
             src={url()}
             alt=""
             draggable={false}
+            loading="lazy"
             onError={() => setFailed(true)}
             class="size-full object-cover"
           />

--- a/js/app/packages/app/component/next-soup/soup-view/views/calls/CallsGrid.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/views/calls/CallsGrid.tsx
@@ -1,0 +1,169 @@
+import type { SoupRow } from '@app/component/next-soup/create-soup-state';
+import { SoupEntityContextMenu } from '@app/component/next-soup/soup-view/soup-entity-context-menu';
+import { formatCallDuration } from '@block-call/utils';
+import { EntityIcon } from '@core/component/EntityIcon';
+import { UserIcon } from '@core/component/UserIcon';
+import { CallRecordName } from '@entity/components/CallRecordName';
+import { Entity } from '@entity/entity';
+import type { CallEntity } from '@entity/types/entity';
+import { usePropertyEntityDisplay } from '@property/hooks';
+import { useCallRecordQuery } from '@queries/call/call';
+import { EntityType } from '@service-properties/generated/schemas/entityType';
+import { cn } from '@ui';
+import { createSignal, For, Show } from 'solid-js';
+
+/** How many of the most recent calls are lifted out of the list into cards. */
+export const CALLS_GRID_COUNT = 4;
+
+/**
+ * Narrowest list-column width (px) the card grid renders at. Below this the
+ * two-column grid would collapse to a single column, so the grid turns off
+ * and the calls render as normal list rows instead.
+ */
+export const CALLS_GRID_MIN_WIDTH = 520;
+
+const MAX_ATTENDEE_PILLS = 3;
+
+function AttendeePill(props: { userId: string }) {
+  const { name } = usePropertyEntityDisplay(
+    () => props.userId,
+    () => EntityType.USER,
+    { fallbackIcon: null }
+  );
+  return (
+    <span class="inline-flex min-w-0 items-center gap-1.5 rounded-full border border-edge-muted bg-surface py-0.5 pl-0.5 pr-2 text-xs leading-none text-ink-muted">
+      <span class="size-4 shrink-0 overflow-hidden rounded-full">
+        <UserIcon id={props.userId} isDeleted={false} size="fill" />
+      </span>
+      <span class="ph-no-capture max-w-24 truncate">{name()}</span>
+    </span>
+  );
+}
+
+/**
+ * The recording preview only exists on the full call record — the soup list
+ * payload doesn't carry it — so each card fetches its record (shared with the
+ * cache the opened call entity uses) and renders the presigned poster image.
+ */
+function CallCardPreview(props: { entity: CallEntity }) {
+  const record = useCallRecordQuery(() => props.entity.id);
+  const [failed, setFailed] = createSignal(false);
+  const previewUrl = () =>
+    failed() ? undefined : record.data?.recordingPreviewUrl;
+
+  return (
+    <div class="relative aspect-video w-full shrink-0 overflow-hidden bg-ink/5">
+      <Show
+        when={previewUrl()}
+        fallback={
+          <div class="grid size-full place-items-center">
+            <span class="size-7 text-ink-extra-muted">
+              <EntityIcon targetType="call" size="fill" theme="monochrome" />
+            </span>
+          </div>
+        }
+      >
+        {(url) => (
+          <img
+            src={url()}
+            alt=""
+            draggable={false}
+            onError={() => setFailed(true)}
+            class="size-full object-cover"
+          />
+        )}
+      </Show>
+      <Show when={props.entity.durationMs}>
+        {(ms) => (
+          <span class="absolute bottom-1.5 right-1.5 rounded bg-black/60 px-1.5 py-0.5 text-[10px] font-medium tabular-nums text-white">
+            {formatCallDuration(ms())}
+          </span>
+        )}
+      </Show>
+    </div>
+  );
+}
+
+function CallCard(props: {
+  entity: CallEntity;
+  highlighted: boolean;
+  onClick: (event: MouseEvent) => void;
+  onMouseMove?: () => void;
+}) {
+  const overflowCount = () =>
+    props.entity.participantIds.length - MAX_ATTENDEE_PILLS;
+
+  return (
+    <div
+      role="button"
+      data-highlighted={props.highlighted || undefined}
+      onClick={props.onClick}
+      onMouseMove={props.onMouseMove}
+      class={cn(
+        'flex size-full min-w-0 cursor-pointer flex-col overflow-hidden rounded-xl border border-edge-muted bg-surface text-left',
+        'hover:bg-hover/30 data-highlighted:border-accent/40 data-highlighted:bg-hover/30'
+      )}
+    >
+      <CallCardPreview entity={props.entity} />
+      <div class="flex min-h-0 flex-1 flex-col gap-1.5 p-3">
+        <div class="flex items-baseline gap-2">
+          <span class="ph-no-capture min-w-0 flex-1 truncate text-sm font-semibold">
+            <CallRecordName entity={props.entity} />
+          </span>
+          <span class="shrink-0 text-xs font-medium text-ink-extra-muted">
+            <Entity.Timestamp entity={props.entity} />
+          </span>
+        </div>
+        <Show when={props.entity.summary}>
+          {(summary) => (
+            <p class="ph-no-capture line-clamp-3 text-xs leading-relaxed text-ink/60">
+              {summary()}
+            </p>
+          )}
+        </Show>
+        <Show when={props.entity.participantIds.length > 0}>
+          <div class="mt-auto flex min-w-0 flex-wrap items-center gap-1 pt-1">
+            <For
+              each={props.entity.participantIds.slice(0, MAX_ATTENDEE_PILLS)}
+            >
+              {(userId) => <AttendeePill userId={userId} />}
+            </For>
+            <Show when={overflowCount() > 0}>
+              <span class="rounded-full bg-ink/10 px-1.5 py-1 text-xs leading-none text-ink-extra-muted tabular-nums">
+                +{overflowCount()}
+              </span>
+            </Show>
+          </div>
+        </Show>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Card grid for the most recent calls, shown above the calls list on desktop.
+ * Two columns by default, four when the list column is @4xl wide. The rows
+ * passed here are removed from the list by the caller.
+ */
+export function CallsGrid(props: {
+  rows: SoupRow[];
+  onEntityClick: (row: SoupRow, event: MouseEvent) => void;
+  onEntityMouseMove?: (row: SoupRow) => void;
+}) {
+  return (
+    <div class="grid shrink-0 grid-cols-2 items-stretch gap-2 px-2 pb-1 pt-2 @4xl/u-list:grid-cols-4">
+      <For each={props.rows}>
+        {(row) => (
+          <SoupEntityContextMenu entity={row.original}>
+            <CallCard
+              entity={row.original as CallEntity}
+              highlighted={row.isFocused()}
+              onClick={(event) => props.onEntityClick(row, event)}
+              onMouseMove={() => props.onEntityMouseMove?.(row)}
+            />
+          </SoupEntityContextMenu>
+        )}
+      </For>
+    </div>
+  );
+}

--- a/js/app/packages/queries/call/call.ts
+++ b/js/app/packages/queries/call/call.ts
@@ -145,11 +145,24 @@ export function useLeaveCallMutation() {
   }));
 }
 
-export function useCallRecordQuery(callId: Accessor<string>) {
+export function useCallRecordQuery(
+  callId: Accessor<string>,
+  options?: {
+    /** Gate the fetch (e.g. until a virtualized card settles in view). */
+    enabled?: Accessor<boolean>;
+    /** How long cached data counts as fresh for this observer (ms). */
+    staleTime?: number;
+    /** How long unobserved data stays cached (ms). */
+    gcTime?: number;
+  }
+) {
   return useQuery(() => ({
     queryKey: callKeys.record(callId()).queryKey,
     queryFn: async () =>
       await throwOnErr(() => callServiceClient.getCallRecord(callId())),
+    enabled: options?.enabled ? options.enabled() : true,
+    staleTime: options?.staleTime,
+    gcTime: options?.gcTime,
   }));
 }
 


### PR DESCRIPTION
## Summary

- The desktop calls tab now defaults to a **gallery view**: calls render as cards with the recording preview image (presigned poster from the call record, with a duration chip overlay), title, up to 3 lines of the AI summary, attendee pills (first 3 + "+N" overflow), and date. Clicking a card opens the call entity through the same path as a list row, and cards keep context-menu and keyboard-focus parity.
- A **Finder-style segmented toggle** (phosphor `squares-four` / `list` icons) sits next to the All/Missed/Unattended tabs and switches between gallery and list. The choice is persisted as a preference (`macro:pref:soup:calls:layout`).
- The gallery is **paged, not virtualized**: it renders a bounded page of 12 cards as a plain grid with a Prev/Next pager at the bottom. (An earlier revision ran cards through the shared virtualizer, which blanked on scroll and flickered on load — the list's 10px item-size estimate is ~30x off for ~300px card rows.) The soup query keeps two pages of headroom prefetched so Next is instant; the page count shows a "+" while more pages exist server-side; keyboard focus follows page changes and vice versa. Columns adapt to the actual list-column width (4 wide / 2 narrow).
- The gallery **falls back to normal list rows** when the column is too narrow for two card columns (< 520px), on mobile, while searching (hit snippets belong in the list), and when grouping is active. The layout waits for the first width measurement instead of flashing the list before the gallery swaps in.
- The **toolbar preview button is removed on the calls view** — calls have no sort/group/filter chips, so the toolbar portals are skipped there and the empty bar collapses entirely. The Space hotkey still toggles the preview pane, and the calls view no longer auto-opens the preview pane on load.
- **Scale hardening**: card record fetches are treated as fresh for 10 minutes (presign TTL is 1h) so revisiting a page never refetches, and a card only fetches after staying mounted 150ms, so paging quickly past calls fires no requests.

## Notes

- The calls list API payload carries no thumbnail; the preview image only exists as `recordingPreviewUrl` on the full call record, so each card fetches its record via the existing `useCallRecordQuery` (shared with the cache used when the call is opened). A lightweight access-checked batch preview endpoint would be the right backend follow-up — the existing `POST /call/record/preview` deliberately skips per-entity access checks, so the presigned URL can't be added to it as-is.

## Testing

- `bun type-check` and `biome check` pass on the changed files.
- No vitest project covers `packages/app`, so there are no unit tests to run for this area.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01957VjPwLRF4L658r4s6nyB