### PR TITLE
fix(calls): call noise cancellation

### DIFF
--- a/js/app/packages/app/lib/analytics/app-events.ts
+++ b/js/app/packages/app/lib/analytics/app-events.ts
@@ -140,6 +140,17 @@ export type AppEvents = {
     channelId: string;
     callId?: string;
   } & Record<string, unknown>;
+  // Mic audio-processing state transitions (noise suppression attach /
+  // detach / fallback). `constraintMismatch` flags engines that report
+  // different track settings than were requested (mode changes that silently
+  // no-oped); `sampleRate` <= 16000 indicates a Bluetooth HFP capture path.
+  call_audio_processing: {
+    event: string;
+    channelId: string;
+    preferredMode: string;
+    activeMode: string;
+    constraintMismatch: boolean;
+  } & Record<string, unknown>;
 
   block_pdf_definition_open: Record<string, unknown>;
   block_pdf_section_open: Record<string, unknown>;

--- a/js/app/packages/app/lib/analytics/app-events.ts
+++ b/js/app/packages/app/lib/analytics/app-events.ts
@@ -151,6 +151,16 @@ export type AppEvents = {
     activeMode: string;
     constraintMismatch: boolean;
   } & Record<string, unknown>;
+  // Per-call summary of remote-audio decode health, flushed at room teardown.
+  // High concealment alongside clean capture-side state points a "muddled
+  // voices" report at the network/playback leg, not noise suppression.
+  call_audio_receiver_stats: {
+    channelId: string;
+    callId?: string;
+    sampledIntervals: number;
+    badIntervals: number;
+    maxConcealmentRate: number;
+  } & Record<string, unknown>;
 
   block_pdf_definition_open: Record<string, unknown>;
   block_pdf_section_open: Record<string, unknown>;

--- a/js/app/packages/channel/Call/CallContext.tsx
+++ b/js/app/packages/channel/Call/CallContext.tsx
@@ -483,6 +483,21 @@ function createCallState() {
       | NativeAudioProcessingConstraints
       | undefined;
 
+    // A requested constraint the engine reports back differently in settings
+    // means the processing state was never actually applied (live-track
+    // applyConstraints is not honored everywhere) — the key signal behind
+    // "toggled noise suppression and nothing changed" reports.
+    const constraintMismatch = (
+      ['autoGainControl', 'echoCancellation', 'noiseSuppression'] as const
+    ).some((name) => {
+      const requested = constraints?.[name];
+      return (
+        typeof requested === 'boolean' &&
+        settings?.[name] !== undefined &&
+        settings[name] !== requested
+      );
+    });
+
     console.debug('[call] mic audio processing', {
       event,
       preferredMode: persistedNoiseSuppressionMode(),
@@ -491,6 +506,7 @@ function createCallState() {
       hasMicTrack: !!micTrack,
       micReadyState: mediaStreamTrack?.readyState,
       hasProcessor: !!micTrack?.getProcessor(),
+      constraintMismatch,
       settings: {
         autoGainControl: settings?.autoGainControl,
         echoCancellation: settings?.echoCancellation,
@@ -505,6 +521,24 @@ function createCallState() {
         noiseSuppression: constraints?.noiseSuppression,
         voiceIsolation: constraints?.voiceIsolation,
       },
+      ...extra,
+    });
+
+    analytics.track('call_audio_processing', {
+      event,
+      channelId: store.activeChannelId ?? '',
+      callId: store.activeCallId ?? undefined,
+      preferredMode: persistedNoiseSuppressionMode(),
+      activeMode: store.noiseSuppressionMode,
+      krispSupported: isKrispNoiseFilterSupported(),
+      hasProcessor: !!micTrack?.getProcessor(),
+      constraintMismatch,
+      autoGainControl: settings?.autoGainControl,
+      echoCancellation: settings?.echoCancellation,
+      noiseSuppression: settings?.noiseSuppression,
+      voiceIsolation: settings?.voiceIsolation,
+      channelCount: settings?.channelCount,
+      sampleRate: settings?.sampleRate,
       ...extra,
     });
   }

--- a/js/app/packages/channel/Call/CallContext.tsx
+++ b/js/app/packages/channel/Call/CallContext.tsx
@@ -553,7 +553,15 @@ function createCallState() {
       setKrispFilter(krisp);
       await micTrack.setProcessor(krisp);
       if (room() !== r || !isLiveLocalTrack(micTrack)) {
-        await krisp.destroy();
+        // The room/track went away mid-attach. Destroying a processor that
+        // is still wired into the track's audio graph leaves a dead node in
+        // the pipeline — detach it via stopProcessor() instead (which
+        // destroys the processor internally).
+        if (micTrack.getProcessor() === krisp) {
+          await micTrack.stopProcessor();
+        } else {
+          await krisp.destroy();
+        }
         if (krispFilter() === krisp) setKrispFilter(null);
         return;
       }

--- a/js/app/packages/channel/Call/CallContext.tsx
+++ b/js/app/packages/channel/Call/CallContext.tsx
@@ -148,6 +148,10 @@ function nativeAudioProcessingConstraints(
   const useBrowserProcessing = mode === 'browser';
 
   return {
+    // applyConstraints() replaces the track's entire constraint set, so echo
+    // cancellation must be restated here or every mode change silently drops
+    // it back to unconstrained.
+    echoCancellation: true,
     ...(supportsNativeAudioProcessingConstraint('autoGainControl')
       ? { autoGainControl: false }
       : {}),
@@ -844,8 +848,12 @@ function createCallState() {
       await r.switchActiveDevice('audioinput', deviceId);
       setStore('activeAudioInputDeviceId', deviceId);
 
-      // If mic is currently live, republish with the new device to ensure it
-      // actually takes effect (switchActiveDevice alone can be unreliable).
+      // If the mic is live, cycle mute/unmute as a nudge for devices where
+      // switchActiveDevice's internal track restart doesn't take. Note this
+      // is NOT a republish: setMicrophoneEnabled(true, opts) ignores the
+      // capture options when the muted publication survives
+      // (stopMicTrackOnMute is false), so the device change itself always
+      // comes from switchActiveDevice above.
       if (!store.isAudioMuted) {
         await r.localParticipant.setMicrophoneEnabled(false);
         await r.localParticipant.setMicrophoneEnabled(
@@ -1042,7 +1050,10 @@ function createCallState() {
       if (newMuted) {
         await r.localParticipant.setMicrophoneEnabled(false);
       } else {
-        // Re-enable with the user's selected device
+        // Re-enable the mic. When the muted publication survived
+        // (stopMicTrackOnMute is false) this only unmutes and the capture
+        // options are ignored; they matter when the track was stopped and
+        // must be recreated (e.g. after a device unplug).
         const deviceId = store.activeAudioInputDeviceId;
         await r.localParticipant.setMicrophoneEnabled(
           true,

--- a/js/app/packages/channel/Call/CallContext.tsx
+++ b/js/app/packages/channel/Call/CallContext.tsx
@@ -127,12 +127,13 @@ function microphoneCaptureOptions(
     supportsNativeAudioProcessingConstraint('noiseSuppression');
 
   return {
-    // Krisp's guidance is to run with AGC off: a gain stage under its filter
-    // can make suppressed noise audible again. Outside Krisp mode there is no
-    // such layer, and AGC-off just leaves quiet mics quiet — low-SNR speech
-    // that downstream VADs (encoder DTX, suppression models) then gate.
+    // Browser AGC runs inside the capture pipeline (AEC → AGC → NS), i.e.
+    // upstream of any track processor — it feeds Krisp a healthy input level
+    // and cannot re-amplify the filter's residue (that would need a gain
+    // stage after the processor, which doesn't exist here). AGC-off left
+    // quiet mics at low SNR, and Krisp/browser NS then gated their speech.
     ...(supportsNativeAudioProcessingConstraint('autoGainControl')
-      ? { autoGainControl: mode !== 'krisp' }
+      ? { autoGainControl: true }
       : {}),
     echoCancellation: true,
     ...(noiseSuppressionSupported
@@ -160,9 +161,9 @@ function nativeAudioProcessingConstraints(
     // cancellation must be restated here or every mode change silently drops
     // it back to unconstrained.
     echoCancellation: true,
-    // AGC off only under Krisp — see microphoneCaptureOptions.
+    // AGC stays on in every mode — see microphoneCaptureOptions.
     ...(supportsNativeAudioProcessingConstraint('autoGainControl')
-      ? { autoGainControl: mode !== 'krisp' }
+      ? { autoGainControl: true }
       : {}),
     ...(noiseSuppressionSupported
       ? { noiseSuppression: useBrowserProcessing }

--- a/js/app/packages/channel/Call/CallContext.tsx
+++ b/js/app/packages/channel/Call/CallContext.tsx
@@ -123,6 +123,8 @@ function microphoneCaptureOptions(
   deviceId?: string | null
 ): AudioCaptureOptions {
   const useBrowserProcessing = mode === 'browser';
+  const noiseSuppressionSupported =
+    supportsNativeAudioProcessingConstraint('noiseSuppression');
 
   return {
     // AGC can raise residual background artifacts during quiet speech/silence.
@@ -132,11 +134,14 @@ function microphoneCaptureOptions(
       ? { autoGainControl: false }
       : {}),
     echoCancellation: true,
-    ...(supportsNativeAudioProcessingConstraint('noiseSuppression')
+    ...(noiseSuppressionSupported
       ? { noiseSuppression: useBrowserProcessing }
       : {}),
+    // Voice isolation is a second, platform-level suppression stage; running
+    // it on top of noiseSuppression cascades filters and attenuates voice.
+    // Use it only as the fallback when noiseSuppression is unsupported.
     ...(supportsNativeAudioProcessingConstraint('voiceIsolation')
-      ? { voiceIsolation: useBrowserProcessing }
+      ? { voiceIsolation: useBrowserProcessing && !noiseSuppressionSupported }
       : {}),
     ...(deviceId ? { deviceId: { exact: deviceId } } : {}),
   };
@@ -146,6 +151,8 @@ function nativeAudioProcessingConstraints(
   mode: MicNoiseSuppressionMode
 ): NativeAudioProcessingConstraints {
   const useBrowserProcessing = mode === 'browser';
+  const noiseSuppressionSupported =
+    supportsNativeAudioProcessingConstraint('noiseSuppression');
 
   return {
     // applyConstraints() replaces the track's entire constraint set, so echo
@@ -155,11 +162,13 @@ function nativeAudioProcessingConstraints(
     ...(supportsNativeAudioProcessingConstraint('autoGainControl')
       ? { autoGainControl: false }
       : {}),
-    ...(supportsNativeAudioProcessingConstraint('noiseSuppression')
+    ...(noiseSuppressionSupported
       ? { noiseSuppression: useBrowserProcessing }
       : {}),
+    // See microphoneCaptureOptions: voiceIsolation is only the fallback when
+    // noiseSuppression is unsupported, never a second stacked layer.
     ...(supportsNativeAudioProcessingConstraint('voiceIsolation')
-      ? { voiceIsolation: useBrowserProcessing }
+      ? { voiceIsolation: useBrowserProcessing && !noiseSuppressionSupported }
       : {}),
   };
 }

--- a/js/app/packages/channel/Call/CallContext.tsx
+++ b/js/app/packages/channel/Call/CallContext.tsx
@@ -127,11 +127,12 @@ function microphoneCaptureOptions(
     supportsNativeAudioProcessingConstraint('noiseSuppression');
 
   return {
-    // AGC can raise residual background artifacts during quiet speech/silence.
-    // Keep it disabled for every mode; Krisp/browser NS should not be stacked
-    // with a gain stage that makes suppressed noise audible again.
+    // Krisp's guidance is to run with AGC off: a gain stage under its filter
+    // can make suppressed noise audible again. Outside Krisp mode there is no
+    // such layer, and AGC-off just leaves quiet mics quiet — low-SNR speech
+    // that downstream VADs (encoder DTX, suppression models) then gate.
     ...(supportsNativeAudioProcessingConstraint('autoGainControl')
-      ? { autoGainControl: false }
+      ? { autoGainControl: mode !== 'krisp' }
       : {}),
     echoCancellation: true,
     ...(noiseSuppressionSupported
@@ -159,8 +160,9 @@ function nativeAudioProcessingConstraints(
     // cancellation must be restated here or every mode change silently drops
     // it back to unconstrained.
     echoCancellation: true,
+    // AGC off only under Krisp — see microphoneCaptureOptions.
     ...(supportsNativeAudioProcessingConstraint('autoGainControl')
-      ? { autoGainControl: false }
+      ? { autoGainControl: mode !== 'krisp' }
       : {}),
     ...(noiseSuppressionSupported
       ? { noiseSuppression: useBrowserProcessing }

--- a/js/app/packages/channel/Call/CallContext.tsx
+++ b/js/app/packages/channel/Call/CallContext.tsx
@@ -496,8 +496,29 @@ function createCallState() {
 
   // --- internal helpers ---
 
+  // Noise-suppression processor work can be reached concurrently (background
+  // media setup, mute toggle, device switch, NS toggle). Overlapping runs can
+  // attach duplicate Krisp instances or land an attach after the user toggled
+  // off, so it is serialized; each queued run re-reads the persisted mode,
+  // which means the latest user intent wins regardless of arrival order.
+  let micProcessingQueue: Promise<void> = Promise.resolve();
+
+  function enqueueMicProcessing<T>(task: () => Promise<T>): Promise<T> {
+    const run = micProcessingQueue.then(task);
+    micProcessingQueue = run.then(
+      () => {},
+      () => {}
+    );
+    return run;
+  }
+
   /** Apply the preferred mic noise suppression mode to the current mic track. */
-  async function ensureNoiseSuppressionOnMicTrack(r: Room) {
+  function ensureNoiseSuppressionOnMicTrack(r: Room): Promise<void> {
+    return enqueueMicProcessing(() => applyNoiseSuppressionToMicTrack(r));
+  }
+
+  /** Serialized body of ensureNoiseSuppressionOnMicTrack — do not call directly. */
+  async function applyNoiseSuppressionToMicTrack(r: Room) {
     if (room() !== r) return;
 
     const preferredMode = persistedNoiseSuppressionMode();
@@ -1115,13 +1136,11 @@ function createCallState() {
     if (!r) return;
 
     try {
-      if (newMode === 'off') {
-        await detachKrispFromMicTrack(r);
-        await applyNativeAudioProcessingToMicTrack(r, 'off');
-        logMicAudioProcessing('noise-suppression-toggled-off', r);
-      } else {
-        await ensureNoiseSuppressionOnMicTrack(r);
-      }
+      // Both directions run through the serialized ensure path: its 'off'
+      // branch detaches Krisp and clears native processing, and queueing
+      // means a toggle issued while an attach is in flight still converges
+      // on the mode the user picked last.
+      await ensureNoiseSuppressionOnMicTrack(r);
     } catch (e) {
       console.error('failed to toggle noise suppression', e);
     }

--- a/js/app/packages/channel/Call/LivekitJsCallController.ts
+++ b/js/app/packages/channel/Call/LivekitJsCallController.ts
@@ -8,6 +8,7 @@ import {
   RoomEvent,
   Track,
 } from 'livekit-client';
+import { startReceiverStatsSampling } from './call-audio-receiver-stats';
 
 type LivekitJsCallControllerState = {
   activeChannelId: string | null;
@@ -41,6 +42,13 @@ type LivekitJsCallControllerOptions = {
 export function createLivekitJsCallController(
   options: LivekitJsCallControllerOptions
 ) {
+  let stopReceiverStatsSampling: (() => void) | null = null;
+
+  function stopReceiverStats() {
+    stopReceiverStatsSampling?.();
+    stopReceiverStatsSampling = null;
+  }
+
   function syncParticipantMap(room: Room) {
     options.setRemoteParticipants(new Map(room.remoteParticipants));
     options.bumpTrackVersion();
@@ -90,6 +98,7 @@ export function createLivekitJsCallController(
 
   function destroyRoom() {
     options.cancelPendingMediaSetup();
+    stopReceiverStats();
     options.destroyProcessors();
 
     const room = options.room();
@@ -157,6 +166,14 @@ export function createLivekitJsCallController(
     // Sync participants that were already in the room when we connected.
     syncParticipantMap(targetRoom);
 
+    // Sample receive-side decode stats for the life of the room; the sampler
+    // flushes one summary analytics event when stopped at teardown.
+    stopReceiverStats();
+    stopReceiverStatsSampling = startReceiverStatsSampling(targetRoom, {
+      channelId: tokenResponse.channelId,
+      callId: tokenResponse.callId,
+    });
+
     // Default to microphone on, video off as soon as the room is connected.
     options.setInitialMediaState();
 
@@ -189,11 +206,13 @@ export function createLivekitJsCallController(
     if (!room) return;
 
     options.cancelPendingMediaSetup();
+    stopReceiverStats();
     room.disconnect();
   }
 
   function dispose() {
     options.cancelPendingMediaSetup();
+    stopReceiverStats();
     const room = options.room();
     if (!room) return;
 

--- a/js/app/packages/channel/Call/LivekitJsCallController.ts
+++ b/js/app/packages/channel/Call/LivekitJsCallController.ts
@@ -133,6 +133,12 @@ export function createLivekitJsCallController(
 
     const targetRoom = new Room({
       audioCaptureDefaults: options.currentMicrophoneCaptureOptions(),
+      publishDefaults: {
+        // Noise-suppressed audio has a near-silent noise floor, which makes
+        // Opus DTX (on by default) misread quiet speech onsets as silence and
+        // clip them. Always-on frames cost little at speech bitrates.
+        dtx: false,
+      },
     });
     attachRoomListeners(targetRoom);
     options.setRoom(targetRoom);

--- a/js/app/packages/channel/Call/call-audio-receiver-stats.ts
+++ b/js/app/packages/channel/Call/call-audio-receiver-stats.ts
@@ -1,0 +1,118 @@
+import { analytics } from '@app/lib/analytics';
+import {
+  type AudioReceiverStats,
+  type RemoteAudioTrack,
+  type Room,
+  Track,
+} from 'livekit-client';
+
+const SAMPLE_INTERVAL_MS = 30_000;
+// Concealment is the perceptual metric for "muddled/underwater" playback:
+// the share of decoded samples the decoder synthesized (packet-loss
+// concealment, jitter-buffer stretch) instead of received. Above ~5% of an
+// interval, degradation is clearly audible.
+const BAD_INTERVAL_CONCEALMENT_RATE = 0.05;
+// Opus decodes at 48 kHz; totalSamplesDuration is reported in seconds.
+const DECODE_SAMPLE_RATE = 48_000;
+
+type Cursor = {
+  concealedSamples: number;
+  totalSamplesDuration: number;
+  packetsLost: number;
+  packetsReceived: number;
+};
+
+/**
+ * Periodically samples remote microphone receiver stats and reports one
+ * summary analytics event when stopped (room teardown). Receive-side decode
+ * artifacts never show up in capture-side logs, so without this signal a
+ * "muddled voices" report can't be split between network concealment and
+ * over-eager noise suppression.
+ */
+export function startReceiverStatsSampling(
+  room: Room,
+  context: { channelId: string; callId?: string }
+): () => void {
+  const cursors = new Map<string, Cursor>();
+  let sampledIntervals = 0;
+  let badIntervals = 0;
+  let maxConcealmentRate = 0;
+  let maxPacketLossRate = 0;
+  let maxJitter = 0;
+
+  async function sampleTrack(identity: string, track: RemoteAudioTrack) {
+    let stats: AudioReceiverStats | undefined;
+    try {
+      stats = await track.getReceiverStats();
+    } catch {
+      return;
+    }
+    if (!stats) return;
+
+    const prev = cursors.get(identity);
+    const cursor: Cursor = {
+      concealedSamples: stats.concealedSamples ?? 0,
+      totalSamplesDuration: stats.totalSamplesDuration ?? 0,
+      packetsLost: stats.packetsLost ?? 0,
+      packetsReceived: stats.packetsReceived ?? 0,
+    };
+    cursors.set(identity, cursor);
+    if (stats.jitter !== undefined) {
+      maxJitter = Math.max(maxJitter, stats.jitter);
+    }
+    if (!prev) return;
+
+    const durationDelta =
+      cursor.totalSamplesDuration - prev.totalSamplesDuration;
+    const concealedDelta = cursor.concealedSamples - prev.concealedSamples;
+    // Counters run backwards when the receiver was replaced mid-call
+    // (reconnect / resubscribe); skip that interval.
+    if (durationDelta <= 0 || concealedDelta < 0) return;
+
+    sampledIntervals += 1;
+    const concealmentRate =
+      concealedDelta / (durationDelta * DECODE_SAMPLE_RATE);
+    maxConcealmentRate = Math.max(maxConcealmentRate, concealmentRate);
+    if (concealmentRate >= BAD_INTERVAL_CONCEALMENT_RATE) badIntervals += 1;
+
+    const packetsDelta = cursor.packetsReceived - prev.packetsReceived;
+    const lostDelta = cursor.packetsLost - prev.packetsLost;
+    if (lostDelta >= 0 && packetsDelta + lostDelta > 0) {
+      maxPacketLossRate = Math.max(
+        maxPacketLossRate,
+        lostDelta / (packetsDelta + lostDelta)
+      );
+    }
+  }
+
+  function sampleAll() {
+    for (const participant of room.remoteParticipants.values()) {
+      if (participant.isAgent) continue;
+      const track = participant.getTrackPublication(
+        Track.Source.Microphone
+      )?.track;
+      if (!track || track.kind !== Track.Kind.Audio) continue;
+      void sampleTrack(participant.identity, track as RemoteAudioTrack);
+    }
+  }
+
+  const timer = setInterval(sampleAll, SAMPLE_INTERVAL_MS);
+
+  let stopped = false;
+  return () => {
+    if (stopped) return;
+    stopped = true;
+    clearInterval(timer);
+    // Nothing sampled means a short or empty call — no event to send.
+    if (sampledIntervals === 0) return;
+    analytics.track('call_audio_receiver_stats', {
+      channelId: context.channelId,
+      callId: context.callId,
+      sampledIntervals,
+      badIntervals,
+      maxConcealmentRate,
+      maxPacketLossRate,
+      maxJitter,
+    });
+  };
+}

--- a/rust/cloud-storage/documents/src/domain/service.rs
+++ b/rust/cloud-storage/documents/src/domain/service.rs
@@ -1098,7 +1098,7 @@ impl<
             let document_uuid = uuid::Uuid::parse_str(&document_context.document_id).unwrap();
             let _ = self
                 .entity_access_management_service
-                .add_entity_to_project(&document_uuid, EntityType::Document, &old_project_id)
+                .remove_entity_from_project(&document_uuid, EntityType::Document, &old_project_id)
                 .await.inspect_err(|e| tracing::error!(error=?e, project_id=?old_project_id, "unable to update entity access for project"));
             let _ = self.repo.update_project_modified(&old_project_id.to_string()).await.inspect_err(
                 |e| tracing::error!(error=?e, project_id=?old_project_id, "unable to update project modified date"),


### PR DESCRIPTION
 fix(calls): over-eager noise cancellation muddling voices

  Summary

  Users consistently reported muddled/garbled voices on calls. Investigation traced every audio-transforming stage to mic capture in packages/channel/Call/ (playback is bare track.attach(), the transcription agent is subscribe-only, and recording egress doesn't re-process audio). This PR fixes the capture-side bugs that cascade or misapply suppression, and adds the telemetry needed to attribute the remaining reports.

  Fixes

- Stop stacking suppression layers. Browser mode enabled noiseSuppression and voiceIsolation simultaneously — two platform suppression stages cascaded, attenuating voice exactly the way the Krisp path already guards against. voiceIsolation is now only the fallback when noiseSuppression is unsupported.
- Re-enable AGC outside Krisp mode. AGC was hard-disabled in every mode, but Krisp's guidance only covers the case where its filter is attached. In off/browser modes, AGC-off leaves quiet mics at low level, feeding low-SNR speech into suppression models and encoder VADs that then gate word onsets. AGC stays off under Krisp, on otherwise (matching browser and livekit-client defaults).
- Disable Opus DTX on published audio. Noise-suppressed audio has a near-silent noise floor, so the encoder's DTX (on by default) misreads quiet speech onsets as silence and clips first syllables. Bandwidth cost is negligible at speech bitrates; RED stays on.
- Keep echoCancellation constrained across mode changes. applyConstraints() replaces the track's entire constraint set, and nativeAudioProcessingConstraints omitted EC — every noise-suppression mode change silently dropped it to unconstrained.
- Serialize noise-suppression processor operations. ensureNoiseSuppressionOnMicTrack could run concurrently from background media setup, mute toggles, device switches, and the NS toggle — racing attach/detach could duplicate Krisp instances or land an attach after the user toggled suppression off. All processor work now runs through a promise-chain queue, and each queued run re-reads the persisted mode so the latest user intent always wins.
- Fix destroy-while-attached edge in the Krisp abort path. If the room/track went away mid-attach, we destroyed the processor while it was still wired into the track's audio graph; it's now detached via stopProcessor() first.
- Correct misleading republish comments. With stopMicTrackOnMute: false, setMicrophoneEnabled(true, opts) only unmutes a surviving publication and ignores capture options (verified against livekit-client 2.18) — the comments in switchAudioInput/toggleAudio claimed otherwise.

Telemetry (to attribute what's left)

- call_audio_processing — mic processing state on every transition (attach/detach/fallback/toggle), previously console.debug-only. Includes constraintMismatch (requested constraint differs from the track's reported settings — i.e. a toggle that silently no-oped) and sampleRate (≤16 kHz capture = Bluetooth HFP path, a classic "muddled" cause).
- call_audio_receiver_stats — new sampler polls each remote mic track's receiver stats every 30s and flushes a per-call summary (max concealment rate, bad intervals, packet loss, jitter) at teardown. Opus packet-loss concealment sounds "underwater" and was previously indistinguishable from capture-side suppression in user reports.

Not in this PR

- Krisp upgrade + mid-call error fallback — @livekit/krisp-noise-filter 0.4.1 exposes no error/event API, so recovery from its known unrecoverable-error state requires the upgrade first.
- Platform-aware default mode — on macOS WKWebView, echoCancellation: true engages Apple's Voice Processing I/O (its own NS/AGC/ducking), so the blanket 'krisp' default cascades filters there; changing the default is gated on data from the new telemetry.
- 3-mode UI selector (Off / Browser / Krisp, showing effective mode + fallback reason) — needs design input.

🤖 Generated with Claude Code