### PR TITLE
fix(soup): apply context menu actions to full multi-selection

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/soup-entity-context-menu.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-entity-context-menu.tsx
@@ -19,6 +19,16 @@ export const SoupEntityContextMenu: FlowComponent<
   const { soup } = useSoupView();
   const drawerManager = useSoupEntityActionDrawer();
 
+  // If the right-clicked row is part of a multi-selection, act on the whole
+  // selection; otherwise act on just that row.
+  const menuEntities = () => {
+    const selected = soup.selection.selected();
+    if (selected.length > 1 && soup.selection.isSelected(props.entity.id)) {
+      return selected;
+    }
+    return [props.entity];
+  };
+
   return (
     <Switch>
       <Match when={isMobile()}>
@@ -41,14 +51,9 @@ export const SoupEntityContextMenu: FlowComponent<
           </ContextMenu.Trigger>
           <ContextMenu.Portal>
             <Show when={props.entity}>
-              {(selectedEntity) => (
-                <ContextMenuContent class="text-xs text-ink-muted">
-                  <SoupEntityActionsMenu
-                    entities={[selectedEntity()]}
-                    soup={soup}
-                  />
-                </ContextMenuContent>
-              )}
+              <ContextMenuContent class="text-xs text-ink-muted">
+                <SoupEntityActionsMenu entities={menuEntities()} soup={soup} />
+              </ContextMenuContent>
             </Show>
           </ContextMenu.Portal>
         </ContextMenu>


### PR DESCRIPTION
## Summary

Right-clicking a row in next-soup while multiple rows were selected only performed the chosen action on the right-clicked row, ignoring the rest of the selection.

`SoupEntityContextMenu` always rendered `SoupEntityActionsMenu` with just the right-clicked entity, even though the actions menu and `buildActionGroups` already fully support multiple entities (this is how cmd+k and the selection toolbar do bulk actions).

## Changes

- `SoupEntityContextMenu` now passes the whole selection to the actions menu when the right-clicked row is part of a multi-selection.
- Right-clicking a row *outside* the current selection still acts on only that row (standard file-browser behavior).
- Single-entity-only actions (share, copy branch name, etc.) automatically drop out of the menu for multi-selections since `buildActionGroups` already gates them on `entities.length === 1`.

## Notes

- `CallsGallery` uses the same component, so the gallery view gets the fix as well.
- The mobile long-press action drawer still operates on a single entity — its context API (`soup-entity-action-drawer-context.ts`) is typed to one entity, so that's left for a follow-up.