### PR TITLE
Calls gallery: paged grid instead of virtualized rows

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
@@ -40,9 +40,10 @@ import {
   useApplyPreset,
 } from '@app/component/next-soup/soup-view/soup-view-tabs';
 import {
-  CallsGalleryRow,
+  CallsGalleryView,
   CallsLayoutToggle,
   callsLayoutMode,
+  GALLERY_PAGE_SIZE,
   getCallsGalleryColumns,
 } from '@app/component/next-soup/soup-view/views/calls/CallsGallery';
 import { CompanyKanban } from '@app/component/next-soup/soup-view/views/companies/CompanyKanban';
@@ -371,14 +372,6 @@ const useSoupNotificationInvalidators = () => {
 };
 
 const SOUP_LIST_STATE_ENTRY_KEY = 'soup.listState';
-
-/**
- * One virtualizer item: a normal soup row, or (calls gallery mode) a chunk of
- * consecutive call rows rendered as one row of cards.
- */
-type DisplayRow =
-  | { kind: 'single'; row: SoupRow }
-  | { kind: 'cards'; rows: SoupRow[] };
 
 type SoupListEntryState = {
   focus: string | undefined;
@@ -854,100 +847,88 @@ export const SoupViewList = (props: SoupViewListProps) => {
     return isListViewID(id) ? id : undefined;
   });
 
-  // On desktop the calls view defaults to a gallery of call cards instead of
-  // list rows (toggleable from the header). The gallery only renders while
-  // the list column is wide enough for at least two card columns and while
-  // no search is active (hit snippets belong in the list) — otherwise the
-  // rows fall back to the normal list.
+  // On desktop the calls view defaults to a paged gallery of call cards
+  // instead of the virtualized list (toggleable from the header). Search and
+  // grouping keep the normal list — hit snippets and group headers belong
+  // there. The gallery renders a bounded page of cards with a pager, so it
+  // needs no virtualization at all.
   const [listColumnRef, setListColumnRef] = createSignal<HTMLElement>();
   const listColumnSize = createElementSize(listColumnRef);
 
-  const galleryColumns = createMemo(() => {
-    if (isMobile() || currentView() !== 'calls') return 0;
-    if (callsLayoutMode() !== 'gallery') return 0;
-    if (searchText()) return 0;
-    return getCallsGalleryColumns(listColumnSize.width ?? 0);
-  });
-
-  // What the virtualizer actually renders: plain rows in list mode; in
-  // gallery mode consecutive call rows are chunked into card rows of
-  // `galleryColumns` while group headers and load-more rows stay full-width.
-  const displayRows = createMemo<DisplayRow[]>(() => {
-    const columns = galleryColumns();
-    const allRows = rows();
-
-    if (columns === 0) {
-      return allRows.map((row): DisplayRow => ({ kind: 'single', row }));
-    }
-
-    const out: DisplayRow[] = [];
-    let chunk: SoupRow[] = [];
-    const flush = () => {
-      if (chunk.length) {
-        out.push({ kind: 'cards', rows: chunk });
-        chunk = [];
-      }
-    };
-
-    for (const row of allRows) {
-      if (row.getIsGrouped() || row.getIsLoadMore()) {
-        flush();
-        out.push({ kind: 'single', row });
-        continue;
-      }
-      // Rows of collapsed groups render as empty items in list mode; skip
-      // them here so they don't leave blank cells in a card row.
-      if (row.group && !row.group.isExpanded()) continue;
-      if (row.original.type !== 'call') {
-        flush();
-        out.push({ kind: 'single', row });
-        continue;
-      }
-      chunk.push(row);
-      if (chunk.length === columns) flush();
-    }
-    flush();
-    return out;
-  });
-
-  const displayIndexByRowIndex = createMemo(() => {
-    const map = new Map<number, number>();
-    displayRows().forEach((displayRow, displayIndex) => {
-      if (displayRow.kind === 'single') {
-        map.set(displayRow.row.index, displayIndex);
-      } else {
-        for (const row of displayRow.rows) map.set(row.index, displayIndex);
-      }
-    });
-    return map;
-  });
-
-  // Navigation code scrolls by index into the full rows() array, but the
-  // virtualizer holds display rows (in gallery mode several calls share one
-  // card row) — remap so scroll targets stay aligned.
-  const adjustedVirtualizerHandle = createMemo<VirtualizerHandle | undefined>(
-    () => {
-      const handle = virtualizerHandle();
-      if (!handle) return handle;
-
-      return new Proxy(handle, {
-        get(target, prop) {
-          if (prop === 'scrollToIndex') {
-            return (
-              index: number,
-              opts?: Parameters<VirtualizerHandle['scrollToIndex']>[1]
-            ) =>
-              target.scrollToIndex(
-                displayIndexByRowIndex().get(index) ?? index,
-                opts
-              );
-          }
-          const value = Reflect.get(target, prop);
-          return typeof value === 'function' ? value.bind(target) : value;
-        },
-      });
-    }
+  const wantsCallsGallery = createMemo(
+    () =>
+      !isMobile() &&
+      currentView() === 'calls' &&
+      callsLayoutMode() === 'gallery' &&
+      !searchText() &&
+      !soup.grouping.activeGroupId()
   );
+
+  const galleryColumns = createMemo(() => {
+    if (!wantsCallsGallery()) return 0;
+    const width = listColumnSize.width;
+    if (width == null) return 0;
+    return getCallsGalleryColumns(width);
+  });
+
+  // Until the first width measurement neither layout is known — rendering
+  // the list for that frame would flash it before the gallery swaps in.
+  const galleryPending = () =>
+    wantsCallsGallery() && listColumnSize.width == null;
+
+  const galleryActive = () => galleryColumns() > 0;
+
+  const galleryRows = createMemo(() =>
+    galleryActive()
+      ? rows().filter(
+          (row) =>
+            !row.getIsGrouped() &&
+            !row.getIsLoadMore() &&
+            row.original.type === 'call'
+        )
+      : []
+  );
+
+  const [galleryScrollerRef, setGalleryScrollerRef] = createSignal<
+    HTMLElement | undefined
+  >();
+
+  const [galleryPageRaw, setGalleryPage] = createSignal(0);
+  const galleryPageCount = () =>
+    Math.max(1, Math.ceil(galleryRows().length / GALLERY_PAGE_SIZE));
+  const galleryPage = () => Math.min(galleryPageRaw(), galleryPageCount() - 1);
+
+  const changeGalleryPage = (page: number) => {
+    setGalleryPage(page);
+    // Move focus with the page so j/k continue from what's on screen.
+    const firstRow = galleryRows()[page * GALLERY_PAGE_SIZE];
+    if (firstRow) soup.focus.set(firstRow.id);
+  };
+
+  // Keep a couple of pages of headroom loaded so Next is instant.
+  createEffect(() => {
+    if (!galleryActive()) return;
+    const needed = (galleryPage() + 2) * GALLERY_PAGE_SIZE;
+    if (galleryRows().length >= needed) return;
+    if (
+      !source.hasNextPage() ||
+      source.isFetching() ||
+      source.isFetchingNextPage()
+    )
+      return;
+    source.fetchNextPage();
+  });
+
+  // j/k move focus through the full row list; follow it across pages.
+  createEffect(() => {
+    if (!galleryActive()) return;
+    const focusedId = soup.focus.id();
+    if (!focusedId) return;
+    const position = galleryRows().findIndex((row) => row.id === focusedId);
+    if (position === -1) return;
+    const page = Math.floor(position / GALLERY_PAGE_SIZE);
+    if (page !== galleryPage()) setGalleryPage(page);
+  });
 
   const focusFirstEntity = () => {
     const allRows = rows();
@@ -966,7 +947,7 @@ export const SoupViewList = (props: SoupViewListProps) => {
     }
 
     if (result) {
-      adjustedVirtualizerHandle()?.scrollToIndex(result.index, {
+      virtualizerHandle()?.scrollToIndex(result.index, {
         align: 'nearest',
       });
     }
@@ -1041,7 +1022,7 @@ export const SoupViewList = (props: SoupViewListProps) => {
     scopeId: scopeId(),
     soup,
     splitHandle: panel.handle,
-    virtualizerHandle: adjustedVirtualizerHandle,
+    virtualizerHandle,
     hasNextPage: source.hasNextPage,
     isFetching: source.isFetching,
     isFetchingNextPage: source.isFetchingNextPage,
@@ -1074,7 +1055,7 @@ export const SoupViewList = (props: SoupViewListProps) => {
     scopeId: scopeId(),
     soup,
     splitHandle: panel.handle,
-    virtualizerHandle: adjustedVirtualizerHandle,
+    virtualizerHandle,
     previewState: () => !!soup.previewEntity(),
     currentView,
     activeTab,
@@ -1331,6 +1312,12 @@ export const SoupViewList = (props: SoupViewListProps) => {
     if (handle) restoreListState();
   };
 
+  // The gallery renders without SoupList, so the virtualizer ref that
+  // normally triggers restore/focus bootstrapping never fires — run it here.
+  createEffect(() => {
+    if (galleryActive()) restoreListState();
+  });
+
   const featuredCount = createMemo(() => featuredIds().length);
 
   const isWideSplitPanel = createMemo(() => {
@@ -1439,6 +1426,42 @@ export const SoupViewList = (props: SoupViewListProps) => {
                       />
                     </div>
                   </Match>
+                  <Match when={rows().length && galleryPending()}>
+                    {/* Width not measured yet — render neither layout for
+                        this frame so the list doesn't flash before the
+                        gallery swaps in. */}
+                    <div class="flex-1 min-h-0" />
+                  </Match>
+                  <Match when={rows().length && galleryActive()}>
+                    <CallsGalleryView
+                      rows={galleryRows()}
+                      columns={galleryColumns()}
+                      page={galleryPage()}
+                      hasMore={source.hasNextPage()}
+                      isFetchingMore={
+                        source.isFetching() || source.isFetchingNextPage()
+                      }
+                      onPageChange={changeGalleryPage}
+                      scrollerRef={setGalleryScrollerRef}
+                      onEntityClick={(row, event) => {
+                        onEntityClick({
+                          type: 'entity',
+                          entity: row.original,
+                          event,
+                          location: undefined,
+                          rowIndex: row.index,
+                        });
+                      }}
+                      onEntityMouseMove={(row) => {
+                        if (isKeypressActive()) return;
+                        if (soup.previewEntity() || isNewInboxEnabled()) return;
+                        soup.focus.setIndex(row.index);
+                      }}
+                    />
+                    <Show when={!props.customScrollbarHidden}>
+                      <CustomScrollbar scrollContainer={galleryScrollerRef} />
+                    </Show>
+                  </Match>
                   <Match when={rows().length}>
                     <ListLayoutProvider ref={localEntityListRef}>
                       <Show when={currentView() === 'tasks' && !isMobile()}>
@@ -1484,42 +1507,9 @@ export const SoupViewList = (props: SoupViewListProps) => {
                           virtualizerRef={registerVirtualizerHandler}
                           onScrollBottom={debouncedFetchMore}
                           scrollBottomOffset={300}
-                          rows={displayRows()}
+                          rows={rows()}
                         >
-                          {(displayRow, i) => {
-                            if (displayRow.kind === 'cards') {
-                              return (
-                                <>
-                                  <CallsGalleryRow
-                                    rows={displayRow.rows}
-                                    columns={galleryColumns()}
-                                    onEntityClick={(row, event) => {
-                                      onEntityClick({
-                                        type: 'entity',
-                                        entity: row.original,
-                                        event,
-                                        location: undefined,
-                                        rowIndex: row.index,
-                                      });
-                                    }}
-                                    onEntityMouseMove={(row) => {
-                                      if (isKeypressActive()) return;
-                                      if (
-                                        soup.previewEntity() ||
-                                        isNewInboxEnabled()
-                                      )
-                                        return;
-                                      soup.focus.setIndex(row.index);
-                                    }}
-                                  />
-                                  <Show when={i() === displayRows().length - 1}>
-                                    <div class="h-15 mobile:hidden" />
-                                  </Show>
-                                </>
-                              );
-                            }
-
-                            const row = displayRow.row;
+                          {(row, i) => {
                             const timestamp = () => {
                               if (row.original.sortTs)
                                 return row.original.sortTs;
@@ -1720,7 +1710,7 @@ export const SoupViewList = (props: SoupViewListProps) => {
                                 </Switch>
                                 <Show
                                   when={
-                                    i() === displayRows().length - 1 &&
+                                    i() === rows().length - 1 &&
                                     isSearchServiceLoading()
                                   }
                                 >
@@ -1729,7 +1719,7 @@ export const SoupViewList = (props: SoupViewListProps) => {
                                     Searching...
                                   </div>
                                 </Show>
-                                <Show when={i() === displayRows().length - 1}>
+                                <Show when={i() === rows().length - 1}>
                                   {/* Desktop-only: mobile clearance comes
                                       from the in-scroll trailing spacer. */}
                                   <div class="h-15 mobile:hidden" />
@@ -1821,11 +1811,11 @@ interface SoupListProps {
   virtualizerClass?: string;
   itemSize?: number;
   overscan?: number;
-  children: (row: DisplayRow, index: Accessor<number>) => JSX.Element;
+  children: (row: SoupRow, index: Accessor<number>) => JSX.Element;
   onScrollOffsetChange?: (offset: number) => void;
   onScrollBottom?: VoidFunction;
   scrollBottomOffset?: number;
-  rows: DisplayRow[];
+  rows: SoupRow[];
   cache?: CacheSnapshot;
 }
 

--- a/js/app/packages/app/component/next-soup/soup-view/views/calls/CallsGallery.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/views/calls/CallsGallery.tsx
@@ -8,13 +8,16 @@ import { UserIcon } from '@core/component/UserIcon';
 import { CallRecordName } from '@entity/components/CallRecordName';
 import { Entity } from '@entity/entity';
 import type { CallEntity } from '@entity/types/entity';
+import CaretLeftIcon from '@phosphor/caret-left.svg';
+import CaretRightIcon from '@phosphor/caret-right.svg';
 import ListIcon from '@phosphor/list.svg';
+import SpinnerIcon from '@phosphor/spinner.svg';
 import SquaresFourIcon from '@phosphor/squares-four.svg';
 import { usePropertyEntityDisplay } from '@property/hooks';
 import { useCallRecordQuery } from '@queries/call/call';
 import { EntityType } from '@service-properties/generated/schemas/entityType';
-import { cn, Tooltip } from '@ui';
-import { createSignal, For, onCleanup, Show } from 'solid-js';
+import { Button, cn, Tooltip } from '@ui';
+import { createEffect, createSignal, For, on, onCleanup, Show } from 'solid-js';
 
 export type CallsLayoutMode = 'gallery' | 'list';
 
@@ -222,35 +225,111 @@ function CallCard(props: {
 }
 
 /**
- * One virtualized row of the calls gallery: up to `columns` call cards laid
- * out on a fixed grid. Cards keep click/focus/context-menu parity with list
- * rows.
+ * Cards shown per gallery page. A page renders as a plain grid with no
+ * virtualization — a bounded page keeps the DOM small by construction, which
+ * sidesteps the estimate-vs-measured churn a virtualizer hits with tall
+ * variable-height cards.
  */
-export function CallsGalleryRow(props: {
+export const GALLERY_PAGE_SIZE = 12;
+
+/**
+ * Paged gallery of call cards with a pager at the bottom. `rows` is every
+ * call row loaded so far; the view slices out the current page. Cards keep
+ * click/focus/context-menu parity with list rows.
+ */
+export function CallsGalleryView(props: {
   rows: SoupRow[];
   columns: number;
+  page: number;
+  /** More rows exist beyond what's loaded (soup query has another page). */
+  hasMore: boolean;
+  isFetchingMore: boolean;
+  onPageChange: (page: number) => void;
   onEntityClick: (row: SoupRow, event: MouseEvent) => void;
   onEntityMouseMove?: (row: SoupRow) => void;
+  scrollerRef?: (el: HTMLElement) => void;
 }) {
+  let scroller: HTMLDivElement | undefined;
+
+  const pageCount = () =>
+    Math.max(1, Math.ceil(props.rows.length / GALLERY_PAGE_SIZE));
+  const pageRows = () =>
+    props.rows.slice(
+      props.page * GALLERY_PAGE_SIZE,
+      (props.page + 1) * GALLERY_PAGE_SIZE
+    );
+  const hasNext = () => props.page + 1 < pageCount();
+
+  createEffect(
+    on(
+      () => props.page,
+      () => scroller?.scrollTo({ top: 0 })
+    )
+  );
+
   return (
     <div
-      class="grid items-stretch gap-2 px-2 py-1"
-      style={{
-        'grid-template-columns': `repeat(${props.columns}, minmax(0, 1fr))`,
+      ref={(el) => {
+        scroller = el;
+        props.scrollerRef?.(el);
       }}
+      class="flex-1 min-h-0 overflow-y-auto overscroll-none scrollbar-hidden"
     >
-      <For each={props.rows}>
-        {(row) => (
-          <SoupEntityContextMenu entity={row.original}>
-            <CallCard
-              entity={row.original as CallEntity}
-              highlighted={row.isFocused()}
-              onClick={(event) => props.onEntityClick(row, event)}
-              onMouseMove={() => props.onEntityMouseMove?.(row)}
-            />
-          </SoupEntityContextMenu>
-        )}
-      </For>
+      <div
+        class="grid items-stretch gap-2 px-2 py-2"
+        style={{
+          'grid-template-columns': `repeat(${props.columns}, minmax(0, 1fr))`,
+        }}
+      >
+        <For each={pageRows()}>
+          {(row) => (
+            <SoupEntityContextMenu entity={row.original}>
+              <CallCard
+                entity={row.original as CallEntity}
+                highlighted={row.isFocused()}
+                onClick={(event) => props.onEntityClick(row, event)}
+                onMouseMove={() => props.onEntityMouseMove?.(row)}
+              />
+            </SoupEntityContextMenu>
+          )}
+        </For>
+      </div>
+      <div class="flex items-center justify-center gap-2 py-2">
+        <Button
+          variant="base"
+          size="sm"
+          depth={2}
+          class="bg-surface"
+          disabled={props.page === 0}
+          onClick={() => props.onPageChange(props.page - 1)}
+          label="Previous page"
+        >
+          <CaretLeftIcon class="size-2.5" />
+          Prev
+        </Button>
+        <span class="px-2 text-xs text-ink-muted tabular-nums">
+          Page {props.page + 1} of {pageCount()}
+          {props.hasMore ? '+' : ''}
+        </span>
+        <Button
+          variant="base"
+          size="sm"
+          depth={2}
+          class="bg-surface"
+          disabled={!hasNext()}
+          onClick={() => props.onPageChange(props.page + 1)}
+          label="Next page"
+        >
+          Next
+          <CaretRightIcon class="size-2.5" />
+        </Button>
+        <Show when={props.isFetchingMore && !hasNext()}>
+          <SpinnerIcon class="size-3 animate-spin text-ink-extra-muted" />
+        </Show>
+      </div>
+      {/* Clearance for the floating AI input that overlays the panel bottom
+          (same as the list's trailing spacer). */}
+      <div class="h-15" />
     </div>
   );
 }

--- a/js/app/packages/app/component/next-soup/soup-view/views/calls/CallsGallery.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/views/calls/CallsGallery.tsx
@@ -16,6 +16,7 @@ import SquaresFourIcon from '@phosphor/squares-four.svg';
 import { usePropertyEntityDisplay } from '@property/hooks';
 import { useCallRecordQuery } from '@queries/call/call';
 import { EntityType } from '@service-properties/generated/schemas/entityType';
+import { Key } from '@solid-primitives/keyed';
 import { Button, cn, Tooltip } from '@ui';
 import { createEffect, createSignal, For, on, onCleanup, Show } from 'solid-js';
 
@@ -281,18 +282,24 @@ export function CallsGalleryView(props: {
           'grid-template-columns': `repeat(${props.columns}, minmax(0, 1fr))`,
         }}
       >
-        <For each={pageRows()}>
+        {/* Key by entity id, not row reference: the soup store rebuilds
+            every SoupRow object whenever a page settles (initial load and
+            each prefetch), so a reference-keyed <For> would remount every
+            card — resetting the preview fetch and re-decoding the <img>,
+            which flashes. Keying by id keeps instances mounted across those
+            rebuilds; only genuinely new calls mount. */}
+        <Key each={pageRows()} by={(row) => row.original.id}>
           {(row) => (
-            <SoupEntityContextMenu entity={row.original}>
+            <SoupEntityContextMenu entity={row().original}>
               <CallCard
-                entity={row.original as CallEntity}
-                highlighted={row.isFocused()}
-                onClick={(event) => props.onEntityClick(row, event)}
-                onMouseMove={() => props.onEntityMouseMove?.(row)}
+                entity={row().original as CallEntity}
+                highlighted={row().isFocused()}
+                onClick={(event) => props.onEntityClick(row(), event)}
+                onMouseMove={() => props.onEntityMouseMove?.(row())}
               />
             </SoupEntityContextMenu>
           )}
-        </For>
+        </Key>
       </div>
       <div class="flex items-center justify-center gap-2 py-2">
         <Button


### PR DESCRIPTION
Follow-up to #4555 (merged). That PR shipped the calls gallery, but the final revision — swapping the virtualized card rows for a paged grid — didn't make it into the squash-merge, so this pushes it as a fresh change on top of the current `main` (which now also carries the Customers/Kanban work).

## Problem

Running the card gallery through the shared list virtualizer caused **blanking on scroll and flicker on load**: the list's 10px item-size estimate is ~30x off for ~300px card rows, so scroll math jumped and re-measure churn thrashed, and the list→gallery data swap remounted everything.

## Change

- The gallery now renders a **bounded page of 12 cards as a plain grid** with a Prev/Next pager at the bottom — no virtualization involved, so there's no scroll math to break.
- The soup query keeps **two pages of headroom prefetched** so Next is instant; the page count shows a `+` while more pages exist server-side, with a spinner if you outrun the prefetch.
- **Keyboard focus follows page changes and vice versa** (j/k navigation crosses pages).
- The layout **waits for the first width measurement** instead of flashing the list before the gallery swaps in.
- **List mode reverts to the untouched virtua path** with plain `SoupRow` data — the `DisplayRow` chunking and the scroll-index remapping proxy from the previous revision are gone, so list behavior is unchanged from before the gallery work.

Columns still adapt to the actual list-column width (4 wide / 2 narrow), and the gallery still falls back to list rows when too narrow, on mobile, while searching, and when grouping is active.

## Testing

- `bun type-check` and `biome check` pass on the changed files.
- No vitest project covers `packages/app`, so there are no unit tests to run for this area.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01957VjPwLRF4L658r4s6nyB

---
_Generated by [Claude Code](https://claude.ai/code/session_01957VjPwLRF4L658r4s6nyB)_