### PR TITLE
feat(search): gate search-view tag surfaces behind enable-tags-search-fe

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/search/search-facets.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/search/search-facets.tsx
@@ -18,6 +18,7 @@ import type {
   SearchIndexId,
   SearchTypeValue,
 } from './search-filters-state';
+import { useSearchTagsFlag } from './search-tags-flag';
 
 export const SEARCH_INDEX_OPTIONS: {
   value: SearchIndexId;
@@ -288,6 +289,7 @@ export function useSearchFacets(
   });
 
   const tagSource = useTagOptions();
+  const searchTags = useSearchTagsFlag();
 
   const type = singleFacet({
     id: 'type',
@@ -464,9 +466,10 @@ export function useSearchFacets(
   });
 
   // Tags show only where tagging applies (all/documents/tasks), gated behind
-  // the tags feature flag, and hidden when the caller has no tags defined.
+  // both the broad tags flag and the search-view rollout flag, and hidden
+  // when the caller has no tags defined.
   const tagFacets = (): SearchFacetVM[] =>
-    tagSource.enabled() && tagSource.hasTags() ? [tags] : [];
+    searchTags() && tagSource.enabled() && tagSource.hasTags() ? [tags] : [];
 
   return createMemo(() => {
     switch (controller.type()) {

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/search/search-filters-state.ts
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/search/search-filters-state.ts
@@ -233,9 +233,9 @@ export function createSearchFiltersController() {
       }));
     });
 
-  // With the rollout flag off, strip tag filters restored from an earlier
-  // session out of the query state so tagFilters never reaches either data
-  // path (soup AST or search-service request).
+  // Restored state is already stripped at soup-view init. This covers the
+  // rollout flag turning off mid-session, so the hidden facet never leaves
+  // an invisible tag filter applied.
   createEffect(() => {
     if (!searchTags() && include().tagFilters?.length) {
       apply({ type: type(), tags: [], ...currentSections() });

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/search/search-filters-state.ts
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/search/search-filters-state.ts
@@ -12,7 +12,8 @@ import {
 } from '@app/component/next-soup/filters/filter-store/types';
 import { useSoupView } from '@app/component/next-soup/soup-view/soup-view-context';
 import { SYSTEM_PROPERTY_IDS } from '@property/constants';
-import { batch, createMemo } from 'solid-js';
+import { batch, createEffect, createMemo } from 'solid-js';
+import { useSearchTagsFlag } from './search-tags-flag';
 
 export type SearchIndexId =
   | 'channels'
@@ -162,6 +163,7 @@ export function compileSearchQuery(state: SearchFiltersState): Query {
  */
 export function createSearchFiltersController() {
   const { soup, queryFilters } = useSoupView();
+  const searchTags = useSearchTagsFlag();
 
   const type = createMemo<SearchTypeValue>(
     () =>
@@ -198,7 +200,9 @@ export function createSearchFiltersController() {
     taskProperty(SYSTEM_PROPERTY_IDS.ASSIGNEES)
   );
   const taskCreatedBy = createMemo(() => withoutNil(include().documentOwnerId));
-  const tags = createMemo<PropertyFilter[]>(() => include().tagFilters ?? []);
+  const tags = createMemo<PropertyFilter[]>(() =>
+    searchTags() ? (include().tagFilters ?? []) : []
+  );
 
   const currentSections = (): SearchFiltersSections => ({
     email: { importance: emailImportance(), inboxIds: emailInbox() },
@@ -228,6 +232,15 @@ export function createSearchFiltersController() {
         or: state.type === 'all' ? [] : [state.type],
       }));
     });
+
+  // With the rollout flag off, strip tag filters restored from an earlier
+  // session out of the query state so tagFilters never reaches either data
+  // path (soup AST or search-service request).
+  createEffect(() => {
+    if (!searchTags() && include().tagFilters?.length) {
+      apply({ type: type(), tags: [], ...currentSections() });
+    }
+  });
 
   const applySections = (sections: Partial<SearchFiltersSections>) =>
     apply({ type: type(), tags: tags(), ...currentSections(), ...sections });

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/search/search-filters-state.ts
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/search/search-filters-state.ts
@@ -12,8 +12,7 @@ import {
 } from '@app/component/next-soup/filters/filter-store/types';
 import { useSoupView } from '@app/component/next-soup/soup-view/soup-view-context';
 import { SYSTEM_PROPERTY_IDS } from '@property/constants';
-import { batch, createEffect, createMemo } from 'solid-js';
-import { useSearchTagsFlag } from './search-tags-flag';
+import { batch, createMemo } from 'solid-js';
 
 export type SearchIndexId =
   | 'channels'
@@ -163,7 +162,6 @@ export function compileSearchQuery(state: SearchFiltersState): Query {
  */
 export function createSearchFiltersController() {
   const { soup, queryFilters } = useSoupView();
-  const searchTags = useSearchTagsFlag();
 
   const type = createMemo<SearchTypeValue>(
     () =>
@@ -200,9 +198,7 @@ export function createSearchFiltersController() {
     taskProperty(SYSTEM_PROPERTY_IDS.ASSIGNEES)
   );
   const taskCreatedBy = createMemo(() => withoutNil(include().documentOwnerId));
-  const tags = createMemo<PropertyFilter[]>(() =>
-    searchTags() ? (include().tagFilters ?? []) : []
-  );
+  const tags = createMemo<PropertyFilter[]>(() => include().tagFilters ?? []);
 
   const currentSections = (): SearchFiltersSections => ({
     email: { importance: emailImportance(), inboxIds: emailInbox() },
@@ -232,15 +228,6 @@ export function createSearchFiltersController() {
         or: state.type === 'all' ? [] : [state.type],
       }));
     });
-
-  // Restored state is already stripped at soup-view init. This covers the
-  // rollout flag turning off mid-session, so the hidden facet never leaves
-  // an invisible tag filter applied.
-  createEffect(() => {
-    if (!searchTags() && include().tagFilters?.length) {
-      apply({ type: type(), tags: [], ...currentSections() });
-    }
-  });
 
   const applySections = (sections: Partial<SearchFiltersSections>) =>
     apply({ type: type(), tags: tags(), ...currentSections(), ...sections });

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/search/search-tags-flag.ts
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/search/search-tags-flag.ts
@@ -1,0 +1,34 @@
+import { useSplitPanel } from '@app/component/split-layout/layoutUtils';
+import { useFeatureFlag } from '@app/lib/analytics/posthog';
+import {
+  ENABLE_TAGS_SEARCH_FE_FLAG,
+  ENABLE_TAGS_SEARCH_FE_OVERRIDE,
+} from '@core/constant/featureFlags';
+import type { Accessor } from 'solid-js';
+
+/**
+ * Rollout gate for the search-view tag surfaces (tag facet + row chips),
+ * layered on top of enable-tags-fe so tagging elsewhere can ship while the
+ * search view stays dark until its index backfills complete.
+ */
+export function useSearchTagsFlag(): Accessor<boolean> {
+  const flag = useFeatureFlag(ENABLE_TAGS_SEARCH_FE_FLAG, {
+    enabledOverride: ENABLE_TAGS_SEARCH_FE_OVERRIDE,
+  });
+  return () => flag().enabled;
+}
+
+/**
+ * Whether tag chips may render on list rows in the current split. Rows in
+ * the search view follow the rollout gate, rows everywhere else always may.
+ */
+export function useRowTagsVisible(): Accessor<boolean> {
+  const panel = useSplitPanel();
+  const searchTags = useSearchTagsFlag();
+  return () => {
+    const content = panel?.handle.content();
+    const inSearchView =
+      content?.type === 'component' && content.id === 'search';
+    return !inSearchView || searchTags();
+  };
+}

--- a/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
@@ -21,6 +21,7 @@ import { useSoup } from '@app/component/next-soup/soup-context';
 import { registerDocumentsFilterSplit } from '@app/component/next-soup/soup-view/documents-filter-controllers';
 import { EmptyState } from '@app/component/next-soup/soup-view/empty-states';
 import { InboxSelector } from '@app/component/next-soup/soup-view/filters-bar/inbox-selector';
+import { useSearchTagsFlag } from '@app/component/next-soup/soup-view/filters-bar/search/search-tags-flag';
 import { SoupFiltersBar } from '@app/component/next-soup/soup-view/filters-bar/soup-filters-bar';
 import { SoupSearchbar } from '@app/component/next-soup/soup-view/filters-bar/soup-view-search-bar';
 import { useFilterRefinements } from '@app/component/next-soup/soup-view/filters-bar/use-filter-refinements';
@@ -408,6 +409,22 @@ export const SoupView = (props: SoupViewProps) => {
   const entryState = panel.handle.currentEntryState();
   const contentId = panel.handle.content().id;
 
+  const searchTags = useSearchTagsFlag();
+
+  // The search view must not initialize with tag filters while the rollout
+  // flag is off. Raw readers (soup AST body, search request, WS insert guard)
+  // consume queryFilters directly, so restored or param-provided tag filters
+  // have to be stripped at the source, not scrubbed after the fact.
+  const stripGatedTagFilters = (
+    query: Query | undefined
+  ): Query | undefined => {
+    if (contentId !== 'search' || searchTags()) return query;
+    if (!query?.include?.tagFilters?.length) return query;
+    const include = { ...query.include };
+    delete include.tagFilters;
+    return { ...query, include };
+  };
+
   const persistedFilters = entryState?.['search.filters'] as Query | undefined;
 
   const persistedPredicates = entryState?.['search.predicates'] as
@@ -447,7 +464,9 @@ export const SoupView = (props: SoupViewProps) => {
     init = true;
     batch(() => {
       soupView.initialize({
-        initialQuery: persistedFilters ?? props.initialFilters,
+        initialQuery: stripGatedTagFilters(
+          persistedFilters ?? props.initialFilters
+        ),
         initialClientFilters: persistedPredicates ?? props.initialClientFilters,
         initialSearchText: persistedSearchText ?? props.initialSearchText,
         disableLocalSearch: props.disableLocalSearch,

--- a/js/app/packages/core/constant/featureFlags.ts
+++ b/js/app/packages/core/constant/featureFlags.ts
@@ -475,3 +475,11 @@ export const ENABLE_NEW_INBOX_OVERRIDE =
 export const ENABLE_TAGS_FE_FLAG = 'enable-tags-fe';
 export const ENABLE_TAGS_FE_OVERRIDE =
   resolveFeatureFlag('ENABLE_TAGS_FE', DEV_MODE_ENV) || undefined;
+
+// Narrow rollout gate for the search-view tag surfaces (facet row + row
+// chips), layered on top of enable-tags-fe. PostHog-controlled per
+// environment with a dev-mode default. Override with
+// VITE_ENABLE_TAGS_SEARCH_FE.
+export const ENABLE_TAGS_SEARCH_FE_FLAG = 'enable-tags-search-fe';
+export const ENABLE_TAGS_SEARCH_FE_OVERRIDE =
+  resolveFeatureFlag('ENABLE_TAGS_SEARCH_FE', DEV_MODE_ENV) || undefined;

--- a/js/app/packages/entity/src/composed/list-entity/wide-layout.tsx
+++ b/js/app/packages/entity/src/composed/list-entity/wide-layout.tsx
@@ -1,3 +1,4 @@
+import { useRowTagsVisible } from '@app/component/next-soup/soup-view/filters-bar/search/search-tags-flag';
 import { useRowTagFilter } from '@app/component/next-soup/soup-view/filters-bar/use-row-tag-filter';
 import { useMaybeSoupView } from '@app/component/next-soup/soup-view/soup-view-context';
 import { EntityRowTags } from '@property/tags';
@@ -50,6 +51,7 @@ function RowTags(props: {
 
 export function WideLayout(props: LayoutProps) {
   const soupView = useMaybeSoupView();
+  const rowTagsVisible = useRowTagsVisible();
   // When a thread resolves to one of the user's inboxes the inbox chip already
   // conveys ownership, so the generic "shared" badge would be redundant.
   const owningInbox = useOwningInbox(() =>
@@ -186,7 +188,11 @@ export function WideLayout(props: LayoutProps) {
         <Show when={isTaskEntity(props.entity) && props.entity}>
           {(entity) => <Entity.Properties entity={entity()} />}
         </Show>
-        <Show when={isDocumentEntity(props.entity) && props.entity}>
+        <Show
+          when={
+            rowTagsVisible() && isDocumentEntity(props.entity) && props.entity
+          }
+        >
           {(entity) => {
             const properties = () => {
               const doc = entity();
@@ -203,7 +209,9 @@ export function WideLayout(props: LayoutProps) {
             );
           }}
         </Show>
-        <Show when={isEmailEntity(props.entity) && props.entity}>
+        <Show
+          when={rowTagsVisible() && isEmailEntity(props.entity) && props.entity}
+        >
           {(entity) => (
             // No filter-by-tag affordance. The soup email path does not apply
             // tag filters, so filtering would leave email rows unfiltered.


### PR DESCRIPTION
Adds a `enable-tags-search-fe` PostHog flag (layered on top of `enable-tags-fe`) gating the tag surfaces in the search view: with the flag off, the tags facet is hidden, `tagFilters`/`tag_option_ids` are never compiled into either data path (stale restored filters get stripped), and rows in the search view render no tag chips. Tag surfaces outside the search view are unaffected.
