### PR TITLE
fix(sidebar): clip sidebar height so favorites scrolls, not overflows

### DIFF
--- a/js/app/packages/app/component/Layout.tsx
+++ b/js/app/packages/app/component/Layout.tsx
@@ -170,7 +170,7 @@ function LayoutInner(props: RouteSectionProps) {
       <Show when={paywallOpen()}>
         <Paywall />
       </Show>
-      <div class="max-h-full grow flex">
+      <div class="max-h-full min-h-0 grow flex">
         {/* The provider spans the sidebar too so its favorites can register
             sortables with the same drag-drop context as the entity drags. */}
         <ItemDndProvider>


### PR DESCRIPTION
## What
The flex row hosting `AppSidebar` in `Layout.tsx` (`<div class="max-h-full grow flex">`) was missing `min-h-0`.

## Why this causes the bug
A flex item's default `min-height` is `auto` (content-driven) and wins over `max-height` when they conflict. Once the Favorites list has enough items, this wrapper's automatic min-size grows past `max-h-full`, inflating the whole sidebar column past the viewport *before* `AppSidebar`'s own `overflow-hidden` (or `favorites-section.tsx`'s existing `max-h-[40%] overflow-y-auto`) ever gets a chance to clip anything — so the sidebar column grows instead of the favorites list scrolling internally, pushing the Settings button out of view.

Every other analogous "clip this flex child to available space" wrapper in the app already pairs `flex-1`/`grow` with `min-h-0` (e.g. the Channels/Unread widget wiring in `sidebar.tsx`, `Settings.tsx`, `SplitPanel.tsx`, `soup-view.tsx`) — this wrapper was the outlier.

## Fix
```diff
- <div class="max-h-full grow flex">
+ <div class="max-h-full min-h-0 grow flex">
```

## Why prioritized
Reported in bug-reports: "settings button getting pushed down bc i have too many favourites" — a small, root-caused, one-line fix with no existing PR or task covering it.

MACRO-2223

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GhsVU27aD9kyDsFyghned3)_