### PR TITLE
feat(soup): add Folder option to Files view New menu

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/soup-view-create-button.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-view-create-button.tsx
@@ -21,7 +21,7 @@ import { NewCallButton } from './NewCallButton';
 const VIEW_CREATE_BLOCKNAMES: Partial<
   Record<ListView, (BlockName | BlockAlias)[]>
 > = {
-  documents: ['md', 'snippet', 'canvas', 'code'],
+  documents: ['md', 'snippet', 'canvas', 'code', 'project'],
   tasks: ['task'],
   agents: ['chat', 'automation'],
   mail: ['email'],


### PR DESCRIPTION
## Summary

Adds a **Folder** option to the "New" button dropdown in the Files tab, matching the Folder entry in the sidebar's Create menu.

- Appears beneath the existing **Code** option (above Import file / Import folder)
- Uses the same folder icon as the Create menu (`EntityIcon` already maps `project` → `WideFolder`)
- Reuses the existing `project` create action, so labeling and creation behavior are identical to the Create menu and Folders view