### PR TITLE
fix(email): mount add-inbox dialog at app root

### DIFF
--- a/js/app/packages/app/component/AddInboxDialog.tsx
+++ b/js/app/packages/app/component/AddInboxDialog.tsx
@@ -5,9 +5,9 @@ import { createSignal, onCleanup } from 'solid-js';
 const [isOpen, setIsOpen] = createSignal(false);
 
 /**
- * Requests the add-inbox confirmation dialog. The dialog itself is rendered
- * by the settings Account panel, so callers elsewhere (e.g. the mail inbox
- * selector) open settings first and the dialog appears once it mounts.
+ * Requests the add-inbox confirmation dialog. Rendered at the app root
+ * (Layout), gated on this signal, so it opens immediately and independent of
+ * the settings surface.
  *
  * Entitlement is enforced by the backend: `POST /link/gmail` answers 402 when
  * the user isn't allowed another inbox, and `useAddInboxFlow` maps that to the
@@ -15,6 +15,8 @@ const [isOpen, setIsOpen] = createSignal(false);
  * without a client-side gate that would have to mirror the backend's rule.
  */
 export const openAddInboxDialog = () => setIsOpen(true);
+
+export const isAddInboxDialogOpen = isOpen;
 
 /**
  * Confirmation step before the add-inbox OAuth redirect. Confirming kicks off

--- a/js/app/packages/app/component/Layout.tsx
+++ b/js/app/packages/app/component/Layout.tsx
@@ -28,6 +28,7 @@ import {
   Show,
   Suspense,
 } from 'solid-js';
+import { AddInboxDialog, isAddInboxDialogOpen } from './AddInboxDialog';
 import { BundleUpdateProgressBar } from './BundleUpdateProgressBar';
 import Banner from './banner/Banner';
 import { GlobalBulkEditEntityModal } from './bulk-edit-entity/BulkEditEntityModal';
@@ -153,6 +154,9 @@ function LayoutInner(props: RouteSectionProps) {
           <GlobalShareModal />
           <IosShareSheet />
           <MacroMcpSetupModal />
+          <Show when={isAddInboxDialogOpen()}>
+            <AddInboxDialog />
+          </Show>
         </Show>
         <Show
           when={

--- a/js/app/packages/app/component/settings/Email.tsx
+++ b/js/app/packages/app/component/settings/Email.tsx
@@ -33,7 +33,7 @@ import {
 import { Button, Dialog, Panel, Tooltip } from '@ui';
 import { createMemo, createSignal, For, Match, Show, Switch } from 'solid-js';
 import { match } from 'ts-pattern';
-import { AddInboxDialog, openAddInboxDialog } from '../AddInboxDialog';
+import { openAddInboxDialog } from '../AddInboxDialog';
 import { ConnectAction, StatusDot } from './integration-ui';
 import { IntegrationRow, SettingsCard, SettingsRow } from './primitives';
 import {
@@ -233,8 +233,6 @@ export function EmailCard() {
           </Show>
         </Show>
       </SettingsCard>
-
-      <AddInboxDialog />
 
       <Dialog
         open={removeTarget() !== null}


### PR DESCRIPTION
Moves the add-inbox confirmation dialog from inside `EmailCard` to the `Layout` app root, gated on its open signal, so it opens immediately instead of waiting for the settings Connected surface to mount through Suspense.
