### PR TITLE
fix(search): include tasks in the local fuzzy search pool

### DIFF
--- a/js/app/packages/app/component/next-soup/search-context.tsx
+++ b/js/app/packages/app/component/next-soup/search-context.tsx
@@ -12,6 +12,7 @@ const SEARCH_ENTITY_TYPES = [
   EntityType.CHAT,
   EntityType.DOCUMENT,
   EntityType.PROJECT,
+  EntityType.TASK,
 ] as const;
 
 type SearchEntityType = (typeof SEARCH_ENTITY_TYPES)[number];


### PR DESCRIPTION
Adds TASK to the search view's local fuzzy pool so recent/just-created tasks match by title from quick access even before the service indexes them. This is the local-fuzzy half only — full task search coverage still depends on the service index plus the separate create-menu indexing fix (019f1f63).
