### PR TITLE
fix(email): promote CATEGORY_PERSONAL per-sender across thread

### DIFF
--- a/js/app/packages/block-email/component/EmailContext.tsx
+++ b/js/app/packages/block-email/component/EmailContext.tsx
@@ -96,6 +96,8 @@ type EmailContextValues = {
     setReplyingToMessageId: (id: string | undefined) => void;
     bottomReplyOpen: Accessor<boolean>;
     setBottomReplyOpen: (open: boolean) => void;
+    // Sender emails (lowercased) with a CATEGORY_PERSONAL message in the thread
+    personalSenders: Accessor<Set<string>>;
   };
   thread: Accessor<ApiThread | undefined>;
   permissions: Accessor<{
@@ -583,6 +585,21 @@ export function EmailProvider(props: FlowProps<{ threadID: string }>) {
             setTargetMessageID: setTargetMessageId,
             list: createMemo(() => threadQuery.data?.filtered ?? []),
             unfiltered: createMemo(() => threadQuery.data?.messages ?? []),
+            // Google's CATEGORY_PERSONAL classification is inconsistent across
+            // identical messages, so promote it per-sender across the thread
+            personalSenders: createMemo(() => {
+              const senders = new Set<string>();
+              for (const message of threadQuery.data?.messages ?? []) {
+                const email = message.from?.email?.toLowerCase();
+                if (!email) continue;
+                if (
+                  message.labels.some((l) => l.name === 'CATEGORY_PERSONAL')
+                ) {
+                  senders.add(email);
+                }
+              }
+              return senders;
+            }),
             expandedBodyIds: expandedMessageBodyIds,
             setExpandedBodyId: onExpandMessageBody,
             isBodyExpanded: (id: string) => expandedMessageBodyIds[id] ?? false,

--- a/js/app/packages/block-email/component/EmailMessageBody.tsx
+++ b/js/app/packages/block-email/component/EmailMessageBody.tsx
@@ -113,7 +113,8 @@ export function EmailMessageBody(props: EmailMessageBodyProps) {
   const isPersonal = createMemo(() => {
     const senderEmail = props.message.from?.email?.toLowerCase();
     return (
-      props.message.from?.email === userEmail() ||
+      (senderEmail !== undefined &&
+        senderEmail === userEmail()?.toLowerCase()) ||
       props.message.labels.some((l) => l.name === 'CATEGORY_PERSONAL') ||
       (senderEmail !== undefined && props.personalSenders().has(senderEmail))
     );

--- a/js/app/packages/block-email/component/EmailMessageBody.tsx
+++ b/js/app/packages/block-email/component/EmailMessageBody.tsx
@@ -30,6 +30,8 @@ import {
 
 interface EmailMessageBodyProps {
   message: ApiMessage;
+  /** Sender emails (lowercased) with a CATEGORY_PERSONAL message in the thread */
+  personalSenders: Accessor<Set<string>>;
   isBodyExpanded: Accessor<boolean>;
   setExpandedMessageBody: (id: string) => void;
   setFocusedMessageId: (messageID: string | undefined) => void;
@@ -109,9 +111,11 @@ export function EmailMessageBody(props: EmailMessageBodyProps) {
 
   // TODO it might be nice to do some additional checks here, e.g. check if this message was sent from a user that the user has sent a message to before.
   const isPersonal = createMemo(() => {
+    const senderEmail = props.message.from?.email?.toLowerCase();
     return (
       props.message.from?.email === userEmail() ||
-      props.message.labels.some((l) => l.name === 'CATEGORY_PERSONAL')
+      props.message.labels.some((l) => l.name === 'CATEGORY_PERSONAL') ||
+      (senderEmail !== undefined && props.personalSenders().has(senderEmail))
     );
   });
 

--- a/js/app/packages/block-email/component/MessageContainer.tsx
+++ b/js/app/packages/block-email/component/MessageContainer.tsx
@@ -267,6 +267,7 @@ export function MessageContainer(props: MessageContainerProps) {
               <Message.Body>
                 <EmailMessageBody
                   message={props.message}
+                  personalSenders={context.messages.personalSenders}
                   isBodyExpanded={isBodyExpanded}
                   setExpandedMessageBody={(id) =>
                     context.messages.setExpandedBodyId(id, true)


### PR DESCRIPTION
## Problem

Whether an email gets theme-adaptive rendering (background stripping, color remapping) or the as-designed white card depends on Gmail's `CATEGORY_PERSONAL` label. Google classifies per message and is inconsistent: in a reported thread of three near-identical fly.io deploy-failure emails, the second and third carried `CATEGORY_PERSONAL` but the first only had `CATEGORY_UPDATES` — so it rendered as a white card sandwiched between two dark-themed messages.

## Fix

Promote the label per sender across the thread: once any message from a sender in the thread is labeled `CATEGORY_PERSONAL`, every message from that sender is treated as personal.

- `EmailContext` exposes `messages.personalSenders`, a memo over the thread's messages collecting lowercased sender emails that have at least one `CATEGORY_PERSONAL`-labeled message.
- `MessageContainer` passes it into `EmailMessageBody`, whose `isPersonal` now also checks set membership alongside the existing self-sent and per-message-label checks.

Promotion comes only from the label, never from a message being self-sent, so the user's own replies in a thread don't change how other senders' messages render.

## Notes

- The promoted message also gets the personal-path system-font normalization, keeping messages from the same sender visually consistent.
- The set is reactive to the thread query, so if personal-labeled messages arrive in a later page of a paginated thread, earlier messages re-process automatically.