### PR TITLE
Update CRM documentation and add keyboard shortcuts

### DIFF
--- a/docs/account/teams.mdx
+++ b/docs/account/teams.mdx
@@ -10,7 +10,7 @@ Macro works solo, but everything is better with friends. Teams get auto-shared t
 
 ## Create a team and invite people
 
-Click **Team** in the bottom left to create a team. You can add the first members right there, or invite more later by email from **Settings → Team**. Invitees see the pending invitation when they sign in.
+Click **Team** in the bottom left to create a team. You can add the first members right there, or invite more later by email from **Settings → Team**. Invitees see the pending invitation when they sign in. Owners can also copy an invite link for any pending invite and share it directly, instead of relying on email.
 
 <Note>
   There's no free plan for teams; every member needs a paid seat. See [Billing & plans](/account/billing).

--- a/docs/keyboard-shortcuts.mdx
+++ b/docs/keyboard-shortcuts.mdx
@@ -14,6 +14,8 @@ description: "The complete reference for driving Macro from the keyboard."
 
 <kbd>cmd</kbd>\+<kbd>;</kbd>  Toggle settings
 
+<kbd>cmd</kbd>\+<kbd>.</kbd>  Toggle sidebar and side panels
+
 <kbd>cmd</kbd>\+<kbd>z</kbd>  Undo
 
 <kbd>shift</kbd>\+<kbd>cmd</kbd>\+ <kbd>z</kbd> Redo

--- a/docs/product/crm.mdx
+++ b/docs/product/crm.mdx
@@ -5,7 +5,7 @@ description: "Contact and company records built automatically from your team's e
 ---
 
 <Note>
-  CRM is rolling out now. If you don't see the **Companies** view in your workspace yet, it hasn't reached your account.
+  CRM is rolling out now. If you don't see the **Customers** view in your workspace yet, it hasn't reached your account.
 </Note>
 
 Most CRMs die because nobody fills them in. Macro's CRM builds itself: because your team's email already flows through Macro, contact and company records are created and kept up to date automatically as you work. You don't have to run an importer or type in fields.
@@ -18,9 +18,15 @@ New companies are enriched automatically with public data: name, description, lo
 
 ### One shared view of every relationship
 
-Open **Companies** from the sidebar to browse your team's accounts. A company page shows its domains, contacts, and email threads in one place. The **Team** and **Me** tabs let you see either everything your team has exchanged with that account or just your own threads. Contact pages work the same way.
+Open **Customers** from the sidebar to browse your team's accounts. A company page shows its domains, contacts, and email threads in one place. The **Team** and **Me** tabs let you see either everything your team has exchanged with that account or just your own threads. Contact pages work the same way.
 
 Every company and contact also has a **discussion** thread, so deal notes and context live on the record itself instead of in a side channel. Like everything in Macro, CRM records are blocks: @mention a company or contact in a doc, task, or channel, and agents can use your CRM as context like the rest of your [team memory](/product/unified-memory).
+
+### Stage, ownership, and revenue
+
+Every customer record comes with three properties out of the box: **Stage** (Lead, Qualified, Demo, Trial, Negotiation, Customer, Churned), **Owner** (a teammate responsible for the account), and **Revenue**. Edit them inline from the list, or from the record's **Properties** panel — the same editors used on tasks. A **Last Interaction** column tracks the most recent synced email automatically, so you don't have to update it by hand. See [Properties](/concepts/properties) for how the shared property system works.
+
+Switch between **list** and **kanban** from the toggle in the topbar. The board lays out one column per Stage; drag a card to a new column to update it. From either view, group and filter by **Stage** (the default) or **Owner** to focus on a segment of accounts.
 
 ### Email sharing
 


### PR DESCRIPTION
## Summary
This PR updates documentation across three files to reflect CRM feature updates, team invitation improvements, and new keyboard shortcuts.

## Key Changes

- **CRM documentation (docs/product/crm.mdx)**
  - Renamed "Companies" view to "Customers" throughout the CRM section
  - Added new section "Stage, ownership, and revenue" documenting three new out-of-box customer record properties: Stage, Owner, and Revenue
  - Documented list and kanban view toggle functionality with grouping and filtering capabilities by Stage or Owner
  - Added note about "Last Interaction" column that automatically tracks the most recent synced email

- **Team documentation (docs/account/teams.mdx)**
  - Enhanced team invitation documentation to mention that owners can copy and share invite links directly, as an alternative to email-based invitations

- **Keyboard shortcuts (docs/keyboard-shortcuts.mdx)**
  - Added new keyboard shortcut: `cmd` + `.` to toggle sidebar and side panels

## Notable Details
The CRM changes reflect a product rename from "Companies" to "Customers" view and introduce new customer relationship management capabilities including stage tracking, ownership assignment, and revenue properties with both list and kanban board views.

https://claude.ai/code/session_01AAozBoxKsyRht2Tk2gwakF