### PR TITLE
fix(block-unknown): constrain share/download icon size

### DIFF
--- a/js/app/packages/block-unknown/component/Block.tsx
+++ b/js/app/packages/block-unknown/component/Block.tsx
@@ -63,11 +63,11 @@ const Unknown = () => {
 
         <div class="flex flex-row gap-2 items-center">
           <Button variant="active" onClick={shareCtx.open}>
-            <ShareFat /> Share
+            <ShareFat class="size-4" /> Share
           </Button>
 
           <Button variant="active" onClick={downloadDocument}>
-            <DownloadSimple /> Download
+            <DownloadSimple class="size-4" /> Download
           </Button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Fixes the Share/Download buttons in the unknown-file-block empty state ("No preview available for...") where the icon and text rendered outside the button's background.
- These buttons use the `Button` component's default `md` size, which (unlike every other size) has no CSS rule constraining child SVG size. The icon SVGs declare `width="100%" height="100%"` with no other bound, so absent a constraint they rendered at their default replaced-element size instead of icon size, blowing past the button's background.
- Explicitly size the icons with `size-4`, matching the convention already used elsewhere in the codebase for icon+text buttons at the default size (e.g. `LoginNew.tsx`'s `<ArrowRight class="size-4" />`).

https://claude.ai/code/session_018pSuQRsdbTrrTRHJbytnGL


---
_Generated by [Claude Code](https://claude.ai/code/session_018pSuQRsdbTrrTRHJbytnGL)_