### PR TITLE
feat(tags): extend tags and properties to projects

### DIFF
--- a/js/app/packages/app/component/side-panel/properties/EntityPropertiesSection.tsx
+++ b/js/app/packages/app/component/side-panel/properties/EntityPropertiesSection.tsx
@@ -68,6 +68,7 @@ const TAGGABLE_ENTITY_TYPES: ReadonlySet<EntityType> = new Set<EntityType>([
   'DOCUMENT',
   'TASK',
   'THREAD',
+  'PROJECT',
 ]);
 
 export function EntityPropertiesSection(props: EntityPropertiesSectionProps) {

--- a/js/app/packages/block-project/component/Block.tsx
+++ b/js/app/packages/block-project/component/Block.tsx
@@ -9,6 +9,7 @@ import { SoupContextProvider } from '@app/component/next-soup/soup-context';
 import { SoupViewList } from '@app/component/next-soup/soup-view/soup-view';
 import { SoupViewContextProvider } from '@app/component/next-soup/soup-view/soup-view-context';
 import { useMaybePreviewPanel } from '@app/component/PreviewPanel';
+import { SidePanel } from '@app/component/side-panel';
 import { SplitPanelContext } from '@app/component/split-layout/context';
 import { useSplitPanelOrThrow } from '@app/component/split-layout/layoutUtils';
 import { getIsSpecialProject } from '@block-project/isSpecial';
@@ -31,6 +32,7 @@ import { refetchResources } from '@service-storage/util/refetchResources';
 import { toast } from 'core/component/Toast/Toast';
 import { type Component, createSignal, Show } from 'solid-js';
 import { ModalsProvider } from './ModalsProvider';
+import { ProjectSidePanelSections } from './sidepanel/ProjectSidePanelSections';
 import { TopBar } from './TopBar';
 
 // HACK: prevent lint error on custom directive
@@ -148,39 +150,46 @@ const Block: Component = () => {
           <Show when={isDragging() && !isSpecialProject}>
             <FileDropOverlay>Upload to this folder</FileDropOverlay>
           </Show>
-          <TopBar />
-          <Show
-            when={ENABLE_PROJECT_VIEW_PREVIEW}
-            fallback={
-              <ProjectEntityList
-                projectId={projectId}
-                soup={projectSoup}
-                // Scope is already attached by the block container so we can use that
-                // Change this when we remove blocks
-                scopeId={blockHotkeyScopeSignal.get()}
-              />
-            }
-          >
-            <div class="flex size-full">
-              <SplitPanelContext.Provider
-                value={{
-                  ...splitPanelContext,
-                  halfSplitState: () =>
-                    projectSoup.previewEntity() && projectSoup.focus.item()
-                      ? { side: 'left', percentage: 30 }
-                      : undefined,
-                }}
+          <SidePanel.Layout defaultOpen={false}>
+            <Show when={!isSpecialProject}>
+              <ProjectSidePanelSections />
+            </Show>
+            <div class="flex size-full min-w-0 flex-col overflow-hidden">
+              <TopBar />
+              <Show
+                when={ENABLE_PROJECT_VIEW_PREVIEW}
+                fallback={
+                  <ProjectEntityList
+                    projectId={projectId}
+                    soup={projectSoup}
+                    // Scope is already attached by the block container so we can use that
+                    // Change this when we remove blocks
+                    scopeId={blockHotkeyScopeSignal.get()}
+                  />
+                }
               >
-                <ProjectEntityList
-                  projectId={projectId}
-                  soup={projectSoup}
-                  // Scope is already attached by the block container so we can use that
-                  // Change this when we remove blocks
-                  scopeId={blockHotkeyScopeSignal.get()}
-                />
-              </SplitPanelContext.Provider>
+                <div class="flex size-full">
+                  <SplitPanelContext.Provider
+                    value={{
+                      ...splitPanelContext,
+                      halfSplitState: () =>
+                        projectSoup.previewEntity() && projectSoup.focus.item()
+                          ? { side: 'left', percentage: 30 }
+                          : undefined,
+                    }}
+                  >
+                    <ProjectEntityList
+                      projectId={projectId}
+                      soup={projectSoup}
+                      // Scope is already attached by the block container so we can use that
+                      // Change this when we remove blocks
+                      scopeId={blockHotkeyScopeSignal.get()}
+                    />
+                  </SplitPanelContext.Provider>
+                </div>
+              </Show>
             </div>
-          </Show>
+          </SidePanel.Layout>
         </ModalsProvider>
       </div>
     </DocumentBlockContainer>

--- a/js/app/packages/block-project/component/sidepanel/ProjectSidePanelSections.tsx
+++ b/js/app/packages/block-project/component/sidepanel/ProjectSidePanelSections.tsx
@@ -1,0 +1,47 @@
+import { SidePanel } from '@app/component/side-panel';
+import { EntityPropertiesSection } from '@app/component/side-panel/properties';
+import { useBlockId } from '@core/block';
+import { useCanEdit } from '@core/signal/permissions';
+import { useBlockDocumentName } from '@core/util/currentBlockDocumentName';
+import { Suspense } from 'solid-js';
+
+export function ProjectSidePanelSections() {
+  const projectId = useBlockId();
+  const canEdit = useCanEdit();
+  const projectName = useBlockDocumentName();
+
+  return (
+    <>
+      <SidePanel.Section id="details" title="Details" defaultOpen order={10}>
+        <Suspense fallback={<SidePanel.Loading />}>
+          <EntityPropertiesSection
+            entityId={projectId}
+            entityType="PROJECT"
+            canEdit={canEdit()}
+            documentName={projectName()}
+            includeMetadata
+            propertyFilter={(property) => property.isMetadata === true}
+            showAddProperty={false}
+            showTags={false}
+          />
+        </Suspense>
+      </SidePanel.Section>
+      <SidePanel.Section
+        id="properties"
+        title="Properties"
+        defaultOpen
+        order={20}
+      >
+        <Suspense fallback={<SidePanel.Loading />}>
+          <EntityPropertiesSection
+            entityId={projectId}
+            entityType="PROJECT"
+            canEdit={canEdit()}
+            documentName={projectName()}
+            propertyFilter={(property) => property.isMetadata !== true}
+          />
+        </Suspense>
+      </SidePanel.Section>
+    </>
+  );
+}

--- a/js/app/packages/entity/src/composed/list-entity/wide-layout.tsx
+++ b/js/app/packages/entity/src/composed/list-entity/wide-layout.tsx
@@ -20,6 +20,7 @@ import {
   isEmailEntity,
   isGithubPrEntity,
   isProjectContainedEntity,
+  isProjectEntity,
   isTaskEntity,
 } from '../../types/entity';
 import { isSearchEntity } from '../../types/search';
@@ -218,6 +219,19 @@ export function WideLayout(props: LayoutProps) {
             <EntityRowTags
               entityId={entity().id}
               entityType={EntityType.THREAD}
+              properties={entity().properties}
+            />
+          )}
+        </Show>
+        <Show
+          when={
+            rowTagsVisible() && isProjectEntity(props.entity) && props.entity
+          }
+        >
+          {(entity) => (
+            <RowTags
+              entityId={entity().id}
+              entityType={EntityType.PROJECT}
               properties={entity().properties}
             />
           )}

--- a/js/app/packages/entity/src/types/entity.ts
+++ b/js/app/packages/entity/src/types/entity.ts
@@ -192,6 +192,7 @@ export type EmailEntity = EntityBase & {
 export type ProjectEntity = EntityBase & {
   type: 'project';
   projectId?: string;
+  properties?: SoupProperty[];
 };
 
 export type CallStatus = StorageCallStatus;
@@ -363,7 +364,9 @@ export const isEmailEntity = (entity: EntityData): entity is EmailEntity => {
   return entity.type === 'email';
 };
 
-const _isProjectEntity = (entity: EntityData): entity is ProjectEntity => {
+export const isProjectEntity = (
+  entity: EntityData
+): entity is ProjectEntity => {
   return entity.type === 'project';
 };
 

--- a/js/app/packages/queries/soup/transform-utils.ts
+++ b/js/app/packages/queries/soup/transform-utils.ts
@@ -448,6 +448,7 @@ export const useSearchResponseItemMapper = () => {
             createdAt: result.created_at,
             updatedAt: result.updated_at,
             projectId: result.metadata?.parent_project_id ?? undefined,
+            properties: result.properties ?? undefined,
             search,
           },
         ];
@@ -550,6 +551,7 @@ export const mapApiSoupItemToEntity = (item: DisplayableSoupItem): SoupEntity =>
       projectId: item.data.parentId ?? undefined,
       type: item.tag,
       name: item.data.name || 'New Project',
+      properties: item.data.properties,
     }))
     .with({ tag: 'emailThread' }, (item) => {
       const participants = item.data.participants?.map((p) => ({


### PR DESCRIPTION
Adds the side panel to the project block (Details from project metadata properties, Properties + Tags with `entityType="PROJECT"`) and adds PROJECT to the taggable entity types. Also plumbs `properties` through the project entity mappers so tagged projects render row chips and survive the client-side tag-filter guard on both the soup and search paths.
