### PR TITLE
feat(github): use github usernames for notifications

### DIFF
--- a/js/app/packages/entity/src/extractors-notification/notification-description-helpers.ts
+++ b/js/app/packages/entity/src/extractors-notification/notification-description-helpers.ts
@@ -1,6 +1,16 @@
 import type { NotificationType } from '@core/types';
+import { GITHUB_EVENT_TYPES } from '@notifications/github-event-types';
 import { match } from 'ts-pattern';
 import type { Notification } from '../types/notification';
+
+/**
+ * Whether the notification type is one of the GitHub PR event types, whose
+ * sender is always presented as the GitHub identity.
+ * @internal
+ */
+export function isGithubNotificationType(type: NotificationType): boolean {
+  return (GITHUB_EVENT_TYPES as readonly string[]).includes(type);
+}
 
 /**
  * Gets unique sender IDs from a notification stack
@@ -17,9 +27,10 @@ export function getUniqueSenderIds(notifications: Notification[]): string[] {
 }
 
 /**
- * GitHub PR notifications are triggered by GitHub users who usually aren't Macro
- * users, so `sender_id` is empty. Their GitHub login lives in the notification
- * metadata instead. Pull it out so the description can name who acted.
+ * The GitHub login of the user who triggered a GitHub PR notification, carried
+ * in the notification metadata. GitHub notifications always name the sender by
+ * this login — never by the linked Macro user's name — even when the actor is
+ * a Macro user and the notification has a `sender_id`.
  * @internal
  */
 export function getGithubSenderLogin(
@@ -37,6 +48,33 @@ export function getGithubSenderLogin(
     return login ?? undefined;
   }
   return undefined;
+}
+
+/**
+ * The GitHub avatar for the sender of a GitHub PR notification. Prefers the
+ * avatar URL captured from the webhook, falling back to the login-derived
+ * GitHub avatar endpoint.
+ * @internal
+ */
+export function getGithubSenderAvatarUrl(
+  notification: Notification
+): string | undefined {
+  const metadata = notification.notification_metadata;
+  const content = (metadata as { content?: unknown }).content;
+  if (
+    content &&
+    typeof content === 'object' &&
+    'senderGithubAvatarUrl' in content
+  ) {
+    const url = (content as { senderGithubAvatarUrl?: string | null })
+      .senderGithubAvatarUrl;
+    if (url) return url;
+  }
+
+  const login = getGithubSenderLogin(notification);
+  return login
+    ? `https://github.com/${encodeURIComponent(login)}.png?size=80`
+    : undefined;
 }
 
 /**

--- a/js/app/packages/entity/src/extractors-notification/notification-description.tsx
+++ b/js/app/packages/entity/src/extractors-notification/notification-description.tsx
@@ -10,6 +10,7 @@ import {
   getTypePreposition,
   getUniqueGithubLogins,
   getUniqueSenderIds,
+  isGithubNotificationType,
 } from './notification-description-helpers';
 
 // Re-export helpers for backward compatibility and testing
@@ -53,27 +54,31 @@ export function NotificationDescription(props: NotificationDescriptionProps) {
     return parts.firstName() || parts.fullName();
   };
 
-  // Sender display labels for the notification/stack. Macro senders resolve to
-  // their display name; GitHub PR senders (who usually aren't Macro users and so
-  // have no `sender_id`) fall back to the GitHub login carried in the
-  // notification metadata.
+  // Sender display labels for the notification/stack. GitHub PR senders are
+  // always named by the GitHub login carried in the notification metadata —
+  // never by a linked Macro user's name, even when the notification has a
+  // `sender_id`. Macro senders resolve to their display name.
   // Memoized so the per-sender name resolution (which has side effects: it
   // queues a fetch and registers a reactive effect) runs once per dependency
   // change rather than on every call from the description() formatters.
   const senderLabels = createMemo((): string[] => {
     if (props.notification) {
+      const tag = props.notification.notification_metadata.tag;
+      if (isGithubNotificationType(tag)) {
+        const login = getGithubSenderLogin(props.notification);
+        return login ? [login] : [];
+      }
       if (props.notification.sender_id) {
         return [macroFirstName(props.notification.sender_id)];
       }
-      const login = getGithubSenderLogin(props.notification);
-      return login ? [login] : [];
+      return [];
     }
     if (props.stack) {
-      const macroIds = getUniqueSenderIds(props.stack.notifications);
-      if (macroIds.length > 0) {
-        return macroIds.map(macroFirstName);
+      if (isGithubNotificationType(props.stack.type)) {
+        return getUniqueGithubLogins(props.stack.notifications);
       }
-      return getUniqueGithubLogins(props.stack.notifications);
+      const macroIds = getUniqueSenderIds(props.stack.notifications);
+      return macroIds.map(macroFirstName);
     }
     return [];
   });

--- a/js/app/packages/entity/src/extractors-notification/notification-sender-icon.tsx
+++ b/js/app/packages/entity/src/extractors-notification/notification-sender-icon.tsx
@@ -1,8 +1,14 @@
 import { UserGroup } from '@core/component/UserGroup';
 import { UserIcon } from '@core/component/UserIcon';
 import type { NotificationStack } from '@notifications';
-import { Show } from 'solid-js';
+import { Avatar } from '@ui';
+import { Match, Show, Switch } from 'solid-js';
 import type { Notification } from '../types/notification';
+import {
+  getGithubSenderAvatarUrl,
+  getGithubSenderLogin,
+  isGithubNotificationType,
+} from './notification-description-helpers';
 
 interface NotificationSenderIconProps {
   notification?: Notification;
@@ -31,6 +37,24 @@ function getUniqueSenderIds(notifications: Notification[]): string[] {
 export function NotificationSenderIcon(props: NotificationSenderIconProps) {
   const size = () => props.size ?? 'sm';
 
+  // GitHub PR notifications always show the GitHub sender's avatar, never the
+  // linked Macro user's, mirroring how the description names the GitHub login.
+  // GitHub stacks hold a single notification, so the first one is the sender.
+  const githubSender = () => {
+    const notification = props.notification ?? props.stack?.notifications[0];
+    if (
+      !notification ||
+      !isGithubNotificationType(notification.notification_metadata.tag)
+    ) {
+      return undefined;
+    }
+
+    const imageUrl = getGithubSenderAvatarUrl(notification);
+    if (!imageUrl) return undefined;
+
+    return { imageUrl, login: getGithubSenderLogin(notification) };
+  };
+
   const senderIds = () => {
     if (props.notification?.sender_id) {
       return [props.notification.sender_id];
@@ -45,26 +69,35 @@ export function NotificationSenderIcon(props: NotificationSenderIconProps) {
   const hasMultipleSenders = () => senderIds().length > 1;
 
   return (
-    <Show when={hasSenders()}>
-      <Show
-        when={hasMultipleSenders()}
-        fallback={
-          <UserIcon
-            id={senderIds()[0]}
+    <Switch>
+      <Match when={githubSender()}>
+        {(sender) => (
+          <Avatar size={size()}>
+            <Avatar.Image src={sender().imageUrl} alt={sender().login} />
+          </Avatar>
+        )}
+      </Match>
+      <Match when={hasSenders()}>
+        <Show
+          when={hasMultipleSenders()}
+          fallback={
+            <UserIcon
+              id={senderIds()[0]}
+              size={size()}
+              suppressClick
+              showTooltip={false}
+            />
+          }
+        >
+          <UserGroup
+            userIds={senderIds()}
+            maxUsers={senderIds().length === 2 ? 2 : 1}
             size={size()}
             suppressClick
             showTooltip={false}
           />
-        }
-      >
-        <UserGroup
-          userIds={senderIds()}
-          maxUsers={senderIds().length === 2 ? 2 : 1}
-          size={size()}
-          suppressClick
-          showTooltip={false}
-        />
-      </Show>
-    </Show>
+        </Show>
+      </Match>
+    </Switch>
   );
 }

--- a/js/app/packages/entity/tests/notification-description.test.ts
+++ b/js/app/packages/entity/tests/notification-description.test.ts
@@ -1,18 +1,24 @@
+import { GITHUB_EVENT_TYPES } from '@notifications/github-event-types';
 import { describe, expect, it } from 'vitest';
 import {
   getActionVerb,
+  getGithubSenderAvatarUrl,
   getGithubSenderLogin,
   getTypeNoun,
   getUniqueGithubLogins,
   getUniqueSenderIds,
+  isGithubNotificationType,
 } from '../src/extractors-notification/notification-description-helpers';
 import type { Notification } from '../src/types/notification';
 
-const githubNotification = (login: string | null | undefined): Notification =>
+const githubNotification = (
+  login: string | null | undefined,
+  avatarUrl?: string | null
+): Notification =>
   ({
     notification_metadata: {
       tag: 'github_pr_comment',
-      content: { senderGithubLogin: login },
+      content: { senderGithubLogin: login, senderGithubAvatarUrl: avatarUrl },
     },
   }) as unknown as Notification;
 
@@ -98,6 +104,52 @@ describe('notification-description helpers', () => {
         notification_metadata: { tag: 'channel_mention', content: {} },
       } as unknown as Notification;
       expect(getGithubSenderLogin(notification)).toBeUndefined();
+    });
+  });
+
+  describe('isGithubNotificationType', () => {
+    it('returns true for every GitHub event type', () => {
+      for (const type of GITHUB_EVENT_TYPES) {
+        expect(isGithubNotificationType(type)).toBe(true);
+      }
+    });
+
+    it('returns false for non-GitHub types', () => {
+      expect(isGithubNotificationType('channel_mention')).toBe(false);
+      expect(isGithubNotificationType('new_email')).toBe(false);
+      expect(isGithubNotificationType('task_assigned')).toBe(false);
+    });
+  });
+
+  describe('getGithubSenderAvatarUrl', () => {
+    it('prefers the avatar URL from the notification metadata', () => {
+      expect(
+        getGithubSenderAvatarUrl(
+          githubNotification(
+            'octocat',
+            'https://avatars.githubusercontent.com/u/12345?v=4'
+          )
+        )
+      ).toBe('https://avatars.githubusercontent.com/u/12345?v=4');
+    });
+
+    it('derives the avatar from the login when no URL is present', () => {
+      expect(getGithubSenderAvatarUrl(githubNotification('octocat'))).toBe(
+        'https://github.com/octocat.png?size=80'
+      );
+    });
+
+    it('returns undefined without a URL or login', () => {
+      expect(
+        getGithubSenderAvatarUrl(githubNotification(null))
+      ).toBeUndefined();
+    });
+
+    it('returns undefined for non-GitHub notifications', () => {
+      const notification = {
+        notification_metadata: { tag: 'channel_mention', content: {} },
+      } as unknown as Notification;
+      expect(getGithubSenderAvatarUrl(notification)).toBeUndefined();
     });
   });
 

--- a/rust/cloud-storage/model_notifications/src/metadata.rs
+++ b/rust/cloud-storage/model_notifications/src/metadata.rs
@@ -106,10 +106,10 @@ impl GithubPrNotificationCommon {
         snippet
     }
 
-    fn actor_name(&self, sender_id: Option<MacroUserIdStr<'_>>) -> Option<String> {
-        sender_id
-            .map(|sender| sender.email_part().local_part().to_string())
-            .or_else(|| self.sender_github_login.clone())
+    /// The displayed actor is always the GitHub login, never the linked Macro
+    /// user (whose id still rides along as the notification sender).
+    fn actor_name(&self) -> Option<String> {
+        self.sender_github_login.clone()
     }
 
     /// The shared body format: the compact PR label, plus the PR title when it
@@ -175,10 +175,10 @@ impl Notification for GithubPrStatusChanged {
 impl NotificationTitle for GithubPrStatusChanged {
     fn format_title(
         &self,
-        sender_id: Option<MacroUserIdStr<'_>>,
+        _sender_id: Option<MacroUserIdStr<'_>>,
     ) -> Result<String, rootcause::Report> {
         let verb = self.action_verb();
-        let title = match self.common.actor_name(sender_id) {
+        let title = match self.common.actor_name() {
             Some(actor) => format!("{actor} {verb} a pull request"),
             None => format!("Pull request {verb}"),
         };
@@ -289,9 +289,9 @@ impl Notification for GithubReviewRequested {
 impl NotificationTitle for GithubReviewRequested {
     fn format_title(
         &self,
-        sender_id: Option<MacroUserIdStr<'_>>,
+        _sender_id: Option<MacroUserIdStr<'_>>,
     ) -> Result<String, rootcause::Report> {
-        let title = match self.common.actor_name(sender_id) {
+        let title = match self.common.actor_name() {
             Some(actor) => format!("{actor} requested your review"),
             None => "Your review was requested".to_string(),
         };
@@ -341,9 +341,9 @@ impl Notification for GithubPrComment {
 impl NotificationTitle for GithubPrComment {
     fn format_title(
         &self,
-        sender_id: Option<MacroUserIdStr<'_>>,
+        _sender_id: Option<MacroUserIdStr<'_>>,
     ) -> Result<String, rootcause::Report> {
-        let title = match self.common.actor_name(sender_id) {
+        let title = match self.common.actor_name() {
             Some(actor) => format!("{actor} commented on a pull request"),
             None => "New comment on a pull request".to_string(),
         };
@@ -397,9 +397,9 @@ impl Notification for GithubPrMention {
 impl NotificationTitle for GithubPrMention {
     fn format_title(
         &self,
-        sender_id: Option<MacroUserIdStr<'_>>,
+        _sender_id: Option<MacroUserIdStr<'_>>,
     ) -> Result<String, rootcause::Report> {
-        let title = match self.common.actor_name(sender_id) {
+        let title = match self.common.actor_name() {
             Some(actor) => format!("{actor} mentioned you on a pull request"),
             None => "You were mentioned on a pull request".to_string(),
         };
@@ -451,9 +451,9 @@ impl Notification for GithubPrReview {
 impl NotificationTitle for GithubPrReview {
     fn format_title(
         &self,
-        sender_id: Option<MacroUserIdStr<'_>>,
+        _sender_id: Option<MacroUserIdStr<'_>>,
     ) -> Result<String, rootcause::Report> {
-        let actor = self.common.actor_name(sender_id);
+        let actor = self.common.actor_name();
         let title = match (self.state, actor) {
             (GithubPrReviewState::Approved, Some(actor)) => {
                 format!("{actor} approved your pull request")

--- a/rust/cloud-storage/model_notifications/src/metadata/test.rs
+++ b/rust/cloud-storage/model_notifications/src/metadata/test.rs
@@ -107,12 +107,13 @@ fn github_pr_status_changed_tagged_content_serializes_with_type_name() {
 fn github_pr_status_changed_formats_title_and_body() {
     let event = github_pr_status_changed();
 
+    // The GitHub login names the actor even when a Macro sender id is present.
     let title = event
         .format_title(Some(uid("macro|pr.sender@macro.com")))
         .unwrap();
     let body = event.format_body(None).unwrap();
 
-    assert_eq!(title, "pr.sender merged a pull request");
+    assert_eq!(title, "octocat merged a pull request");
     assert_eq!(body, "macro/app#42: Add GitHub PR notifications");
 }
 
@@ -155,7 +156,7 @@ fn github_pr_status_changed_notif_event_deserializes_and_renders_in_app() {
         event
             .format_title(Some(uid("macro|pr.sender@macro.com")))
             .unwrap(),
-        "pr.sender merged a pull request"
+        "octocat merged a pull request"
     );
     assert_eq!(
         event.format_body(None).unwrap(),
@@ -302,15 +303,27 @@ fn github_review_requested_serializes_flat_and_formats() {
         notification
             .format_title(Some(uid("macro|pr.sender@macro.com")))
             .unwrap(),
-        "pr.sender requested your review"
-    );
-    assert_eq!(
-        notification.format_title(None).unwrap(),
         "octocat requested your review"
     );
     assert_eq!(
         notification.format_body(None).unwrap(),
         "macro/app#42: Add GitHub PR notifications"
+    );
+
+    // Without a GitHub login the title stays actor-less; the Macro sender id
+    // never substitutes for the GitHub identity.
+    let no_login = GithubReviewRequested {
+        common: GithubPrNotificationCommon {
+            sender_github_login: None,
+            ..github_pr_common()
+        },
+        ..notification
+    };
+    assert_eq!(
+        no_login
+            .format_title(Some(uid("macro|pr.sender@macro.com")))
+            .unwrap(),
+        "Your review was requested"
     );
 }
 
@@ -339,7 +352,7 @@ fn github_pr_comment_serializes_and_formats_with_snippet() {
         notification
             .format_title(Some(uid("macro|pr.sender@macro.com")))
             .unwrap(),
-        "pr.sender commented on a pull request"
+        "octocat commented on a pull request"
     );
     assert_eq!(
         notification.format_body(None).unwrap(),
@@ -380,7 +393,7 @@ fn github_pr_mention_serializes_and_formats() {
         notification
             .format_title(Some(uid("macro|pr.sender@macro.com")))
             .unwrap(),
-        "pr.sender mentioned you on a pull request"
+        "octocat mentioned you on a pull request"
     );
     assert_eq!(
         notification.format_body(None).unwrap(),
@@ -412,7 +425,7 @@ fn github_pr_review_serializes_and_formats_by_state() {
         notification
             .format_title(Some(uid("macro|pr.sender@macro.com")))
             .unwrap(),
-        "pr.sender requested changes on your pull request"
+        "octocat requested changes on your pull request"
     );
     assert_eq!(
         notification.format_body(None).unwrap(),


### PR DESCRIPTION
---
Title: fix(github notifications): always show the GitHub username, not the linked Macro user

Summary

GitHub PR notifications carry the sender's GitHub identity in their metadata (senderGithubLogin, senderGithubAvatarUrl), but when the GitHub actor was linked to a Macro account we displayed the Macro identity instead — "john merged a pull request" rather than "octocat merged a pull request". This PR makes GitHub notifications always present the GitHub identity (username and avatar), regardless of whether the actor is linked.

sender_id is still set on GitHub notifications: it's behavioral, not just display — the notification service uses it to exclude the sender from recipients so you aren't notified about your own PR actions (recipient_is_sender in notification/src/domain/models/request.rs). Only display sites changed.

Changes

Backend (model_notifications/src/metadata.rs) — affects email digest titles:
- GithubPrNotificationCommon::actor_name() no longer derives the actor from sender_id; it returns sender_github_login directly.
- The five GitHub format_title impls ignore sender_id, keeping their actor-less fallbacks ("Pull request merged", "Your review was requested") for webhooks without a sender login.

Frontend (packages/entity/src/extractors-notification/) — affects bell popover, notifications panel, stacks, mobile rows:
- NotificationDescription gates sender labels by notification type: GitHub notifications resolve to the GitHub login only and never fall back to the Macro display name; all other types are unchanged.
- NotificationSenderIcon renders the GitHub avatar for GitHub notifications (webhook avatar URL, falling back to github.com/<login>.png) instead of the linked Macro user's picture.
- New helpers isGithubNotificationType / getGithubSenderAvatarUrl; updated stale doc comments claiming GitHub senders never have a sender_id.

Not changed (verified no-ops): the inbox soup GitHub card already renders the login from metadata; browser/OS popups exclude GitHub types; GitHub types have no iOS push path; wire format is untouched so no schema regeneration.