### PR TITLE
feat(tags): extend tags and properties to AI chats

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/search/search-facets.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/search/search-facets.tsx
@@ -465,9 +465,9 @@ export function useSearchFacets(
     },
   });
 
-  // Tags show only where tagging applies (all/documents/tasks/emails), gated
-  // behind both the broad tags flag and the search-view rollout flag, and
-  // hidden when the caller has no tags defined.
+  // Tags show only where tagging applies (all/documents/tasks/emails/agents),
+  // gated behind both the broad tags flag and the search-view rollout flag,
+  // and hidden when the caller has no tags defined.
   const tagFacets = (): SearchFacetVM[] =>
     searchTags() && tagSource.enabled() && tagSource.hasTags() ? [tags] : [];
 
@@ -491,6 +491,7 @@ export function useSearchFacets(
           ...tagFacets(),
         ];
       case 'document-or-file':
+      case 'agent':
       case 'all':
         return [type, ...tagFacets()];
       default:

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/search/search-filters-state.ts
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/search/search-filters-state.ts
@@ -25,14 +25,15 @@ export type SearchIndexId =
 
 export type SearchTypeValue = SearchIndexId | 'all';
 
-/** Search types where tag filtering applies: documents/tasks, emails, plus
- * the mixed `all` view (tags there narrow the taggable result types and leave
- * the rest untouched). */
+/** Search types where tag filtering applies: documents/tasks, emails, chats,
+ * plus the mixed `all` view (tags there narrow the taggable result types and
+ * leave the rest untouched). */
 export const TAG_SEARCH_TYPES = new Set<SearchTypeValue>([
   'all',
   'task',
   'document-or-file',
   'email',
+  'agent',
 ]);
 
 /**

--- a/js/app/packages/app/component/side-panel/properties/EntityPropertiesSection.tsx
+++ b/js/app/packages/app/component/side-panel/properties/EntityPropertiesSection.tsx
@@ -69,6 +69,7 @@ const TAGGABLE_ENTITY_TYPES: ReadonlySet<EntityType> = new Set<EntityType>([
   'TASK',
   'THREAD',
   'PROJECT',
+  'CHAT',
 ]);
 
 export function EntityPropertiesSection(props: EntityPropertiesSectionProps) {

--- a/js/app/packages/core/component/DetailsDrawer.tsx
+++ b/js/app/packages/core/component/DetailsDrawer.tsx
@@ -1,7 +1,9 @@
+import { EntityPropertiesSection } from '@app/component/side-panel/properties';
 import { SplitDrawer } from '@app/component/split-layout/components/SplitDrawer';
 import { EntityIcon } from '@core/component/EntityIcon';
 import { openDocument } from '@core/component/LexicalMarkdown/component/core/BlockLink';
 import { UserIcon } from '@core/component/UserIcon';
+import { useCanEdit } from '@core/signal/permissions';
 import { tryMacroId, useDisplayName } from '@core/user';
 import { type DateValue, formatDate } from '@core/util/date';
 import { useSplitNavigationHandler } from '@core/util/useSplitNavigationHandler';
@@ -84,18 +86,29 @@ function ChatDetails(props: { chatId: string }) {
   const projectQuery = useProjectDataQuery(
     () => chat()?.projectId ?? undefined
   );
+  const canEdit = useCanEdit();
 
   return (
-    <DetailsGrid
-      owner={() => chat()?.userId}
-      folder={() => {
-        const id = chat()?.projectId;
-        const name = projectQuery.data?.name;
-        return id && name ? { id, name } : undefined;
-      }}
-      createdAt={() => chat()?.createdAt}
-      updatedAt={() => chat()?.updatedAt}
-    />
+    <>
+      <DetailsGrid
+        owner={() => chat()?.userId}
+        folder={() => {
+          const id = chat()?.projectId;
+          const name = projectQuery.data?.name;
+          return id && name ? { id, name } : undefined;
+        }}
+        createdAt={() => chat()?.createdAt}
+        updatedAt={() => chat()?.updatedAt}
+      />
+      <div class="px-2 py-2">
+        <EntityPropertiesSection
+          entityId={props.chatId}
+          entityType="CHAT"
+          canEdit={canEdit()}
+          documentName={chat()?.name}
+        />
+      </div>
+    </>
   );
 }
 

--- a/js/app/packages/entity/src/composed/list-entity/wide-layout.tsx
+++ b/js/app/packages/entity/src/composed/list-entity/wide-layout.tsx
@@ -16,6 +16,7 @@ import {
   isCallEntity,
   isChannelEntity,
   isChannelMessageEntity,
+  isChatEntity,
   isDocumentEntity,
   isEmailEntity,
   isGithubPrEntity,
@@ -232,6 +233,17 @@ export function WideLayout(props: LayoutProps) {
             <RowTags
               entityId={entity().id}
               entityType={EntityType.PROJECT}
+              properties={entity().properties}
+            />
+          )}
+        </Show>
+        <Show
+          when={rowTagsVisible() && isChatEntity(props.entity) && props.entity}
+        >
+          {(entity) => (
+            <RowTags
+              entityId={entity().id}
+              entityType={EntityType.CHAT}
               properties={entity().properties}
             />
           )}

--- a/js/app/packages/entity/src/types/entity.ts
+++ b/js/app/packages/entity/src/types/entity.ts
@@ -114,6 +114,7 @@ export type ChannelThreadEntity = EntityBase & {
 export type ChatEntity = EntityBase & {
   type: 'chat';
   projectId?: string;
+  properties?: SoupProperty[];
 };
 
 /** Named sub types - 'task' and 'snippet' */
@@ -356,7 +357,7 @@ export const isChannelThreadEntity = (
   return entity.type === 'channel_thread';
 };
 
-const _isChatEntity = (entity: EntityData): entity is ChatEntity => {
+export const isChatEntity = (entity: EntityData): entity is ChatEntity => {
   return entity.type === 'chat';
 };
 

--- a/js/app/packages/queries/soup/transform-utils.ts
+++ b/js/app/packages/queries/soup/transform-utils.ts
@@ -416,6 +416,7 @@ export const useSearchResponseItemMapper = () => {
             createdAt: result.metadata?.created_at,
             updatedAt: result.metadata?.updated_at,
             projectId: result.metadata?.project_id ?? undefined,
+            properties: result.properties ?? undefined,
             search,
           },
         ];


### PR DESCRIPTION
Adds the properties + tags section to the chat Details drawer (`entityType="CHAT"`) and adds CHAT to the taggable entity types. Adds `agent` to the tag-applicable search types and the facet switch, and plumbs `properties` through the chat entity mappers so tagged chats render row chips and survive the client-side tag-filter guard on both the soup and search paths.
