### PR TITLE
fix(soup): gate split-panel soup items query behind view initialization

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/soup-view-context.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-view-context.tsx
@@ -521,7 +521,7 @@ export const SoupViewContextProvider: FlowComponent<
     () => {
       const view = activeListView();
       return {
-        enabled: !search.isSearching(),
+        enabled: enabled() && !search.isSearching(),
         showSupportedForeignEntities: showSupportedForeignEntitiesFF().enabled,
         meta: {
           itemFilter: (item) =>


### PR DESCRIPTION
## Problem

Opening **any** non-soup content in a new split fires a wasted `POST /items/soup/ast`. Easiest repro: `c` → `shift+e` (compose email in new split) with the network tab filtered to `soup`.

## Cause

Every `SplitPanel` wraps its content in a `SoupViewContextProvider` (so soup state survives content swaps within a split), and the provider's base items query was enabled unconditionally on mount:

```ts
enabled: !search.isSearching(),
```

For splits whose content is not a soup list (compose, settings, documents, home), `initialize()` never runs, so the query fetched the default unconfigured body — no filters, `limit: 100`, `sort_method: 'updated_at'` — and nothing ever rendered the result.

## Fix

Gate the items query on the provider's `enabled()` signal, which is set by `SoupView.initialize()` (all list routes) or the `initialEnabled` prop (project blocks in `block-project/Block.tsx`). The grouped soup queries a few lines below already use exactly this gate:

```ts
enabled: enabled() && !search.isSearching(),
```

Real soup views are unaffected: `SoupView` calls `initialize()` in a `createRenderEffect` before mount, so the query is enabled before first render.
