### PR TITLE
feat(tags): folder row tag placement, folders tag facet, chat properties side panel

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/search/search-facets.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/search/search-facets.tsx
@@ -465,9 +465,9 @@ export function useSearchFacets(
     },
   });
 
-  // Tags show only where tagging applies (all/documents/tasks/emails/agents),
-  // gated behind both the broad tags flag and the search-view rollout flag,
-  // and hidden when the caller has no tags defined.
+  // Tags show only where tagging applies (all/documents/tasks/emails/agents/
+  // folders), gated behind both the broad tags flag and the search-view
+  // rollout flag, and hidden when the caller has no tags defined.
   const tagFacets = (): SearchFacetVM[] =>
     searchTags() && tagSource.enabled() && tagSource.hasTags() ? [tags] : [];
 
@@ -492,6 +492,7 @@ export function useSearchFacets(
         ];
       case 'document-or-file':
       case 'agent':
+      case 'folders':
       case 'all':
         return [type, ...tagFacets()];
       default:

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/search/search-filters-state.ts
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/search/search-filters-state.ts
@@ -26,14 +26,15 @@ export type SearchIndexId =
 export type SearchTypeValue = SearchIndexId | 'all';
 
 /** Search types where tag filtering applies: documents/tasks, emails, chats,
- * plus the mixed `all` view (tags there narrow the taggable result types and
- * leave the rest untouched). */
+ * folders, plus the mixed `all` view (tags there narrow the taggable result
+ * types and leave the rest untouched). */
 export const TAG_SEARCH_TYPES = new Set<SearchTypeValue>([
   'all',
   'task',
   'document-or-file',
   'email',
   'agent',
+  'folders',
 ]);
 
 /**

--- a/js/app/packages/app/component/side-panel/FileSidePanelSections.tsx
+++ b/js/app/packages/app/component/side-panel/FileSidePanelSections.tsx
@@ -108,7 +108,7 @@ function DetailsSectionContent() {
   );
 }
 
-function FolderLink(props: { projectId: string; projectName: string }) {
+export function FolderLink(props: { projectId: string; projectName: string }) {
   const open = createCallback((e: MouseEvent) => {
     openDocument('project', props.projectId, undefined, !e.shiftKey);
   });
@@ -129,7 +129,7 @@ function FolderLink(props: { projectId: string; projectName: string }) {
   );
 }
 
-function OwnerValue(props: { ownerId: string }) {
+export function OwnerValue(props: { ownerId: string }) {
   const [displayName] = useDisplayName(tryMacroId(props.ownerId));
 
   return (
@@ -140,7 +140,7 @@ function OwnerValue(props: { ownerId: string }) {
   );
 }
 
-function DateValueDisplay(props: { value: DateValue }) {
+export function DateValueDisplay(props: { value: DateValue }) {
   return (
     <SidePanel.Pill>
       <span class="truncate">

--- a/js/app/packages/app/component/side-panel/index.ts
+++ b/js/app/packages/app/component/side-panel/index.ts
@@ -1,8 +1,11 @@
 export type {} from './context';
 export {
+  DateValueDisplay,
   FileDetailsSection,
   FilePropertiesSection,
   FileSidePanelSections,
+  FolderLink,
+  OwnerValue,
 } from './FileSidePanelSections';
 export {
   GithubPullRequestChecksContent,

--- a/js/app/packages/block-chat/component/Block.tsx
+++ b/js/app/packages/block-chat/component/Block.tsx
@@ -1,5 +1,6 @@
 import { useGlobalNotificationSource } from '@app/component/GlobalAppState';
 import { useBlockEntityCommands } from '@app/component/next-soup/actions';
+import { SidePanel } from '@app/component/side-panel';
 import { DEFAULT_CHAT_NAME } from '@block-chat/definition';
 import { useBlockId } from '@core/block';
 import { DocumentBlockContainer } from '@core/component/DocumentBlockContainer';
@@ -9,6 +10,7 @@ import { Show } from 'solid-js';
 import { chatBlockData } from '../signal/chatBlockData';
 import { Chat } from './Chat';
 import { ModalsProvider } from './ModalsProvider';
+import { ChatSidePanelSections } from './sidepanel/ChatSidePanelSections';
 
 export default function ChatBlock() {
   useBlockEntityCommands();
@@ -24,7 +26,12 @@ export default function ChatBlock() {
           entity={{ type: 'chat', id: blockId }}
         />
         <ModalsProvider>
-          <Show when={chatBlockData()}>{(data) => <Chat data={data()} />}</Show>
+          <SidePanel.Layout defaultOpen={false}>
+            <ChatSidePanelSections />
+            <Show when={chatBlockData()}>
+              {(data) => <Chat data={data()} />}
+            </Show>
+          </SidePanel.Layout>
         </ModalsProvider>
       </div>
     </DocumentBlockContainer>

--- a/js/app/packages/block-chat/component/sidepanel/ChatSidePanelSections.tsx
+++ b/js/app/packages/block-chat/component/sidepanel/ChatSidePanelSections.tsx
@@ -1,0 +1,97 @@
+import {
+  DateValueDisplay,
+  FolderLink,
+  OwnerValue,
+  SidePanel,
+} from '@app/component/side-panel';
+import { EntityPropertiesSection } from '@app/component/side-panel/properties';
+import { useBlockId } from '@core/block';
+import { useCanEdit } from '@core/signal/permissions';
+import { useChatDataQuery } from '@queries/cognition/chat-data';
+import { useProjectDataQuery } from '@queries/storage/project-data';
+import { createMemo, Show, Suspense } from 'solid-js';
+
+export function ChatSidePanelSections() {
+  const chatId = useBlockId();
+  const canEdit = useCanEdit();
+
+  return (
+    <>
+      <SidePanel.Section id="details" title="Details" defaultOpen order={10}>
+        <Suspense fallback={<SidePanel.Loading />}>
+          <ChatDetailsContent chatId={chatId} />
+        </Suspense>
+      </SidePanel.Section>
+      <SidePanel.Section
+        id="properties"
+        title="Properties"
+        defaultOpen
+        order={20}
+      >
+        <Suspense fallback={<SidePanel.Loading />}>
+          <ChatPropertiesContent chatId={chatId} canEdit={canEdit()} />
+        </Suspense>
+      </SidePanel.Section>
+    </>
+  );
+}
+
+function ChatDetailsContent(props: { chatId: string }) {
+  const query = useChatDataQuery(() => props.chatId);
+  const chat = createMemo(() => query.data);
+  const projectQuery = useProjectDataQuery(
+    () => chat()?.projectId ?? undefined
+  );
+
+  return (
+    <SidePanel.Grid>
+      <Show when={chat()?.userId}>
+        {(ownerId) => (
+          <SidePanel.Row label="Owner">
+            <OwnerValue ownerId={ownerId()} />
+          </SidePanel.Row>
+        )}
+      </Show>
+      <Show
+        when={(() => {
+          const id = chat()?.projectId;
+          const name = projectQuery.data?.name;
+          return id && name ? { id, name } : undefined;
+        })()}
+      >
+        {(folder) => (
+          <SidePanel.Row label="Folder">
+            <FolderLink projectId={folder().id} projectName={folder().name} />
+          </SidePanel.Row>
+        )}
+      </Show>
+      <Show when={chat()?.createdAt}>
+        {(created) => (
+          <SidePanel.Row label="Created">
+            <DateValueDisplay value={created()} />
+          </SidePanel.Row>
+        )}
+      </Show>
+      <Show when={chat()?.updatedAt}>
+        {(updated) => (
+          <SidePanel.Row label="Last updated">
+            <DateValueDisplay value={updated()} />
+          </SidePanel.Row>
+        )}
+      </Show>
+    </SidePanel.Grid>
+  );
+}
+
+function ChatPropertiesContent(props: { chatId: string; canEdit: boolean }) {
+  const query = useChatDataQuery(() => props.chatId);
+
+  return (
+    <EntityPropertiesSection
+      entityId={props.chatId}
+      entityType="CHAT"
+      canEdit={props.canEdit}
+      documentName={query.data?.name}
+    />
+  );
+}

--- a/js/app/packages/core/component/DetailsDrawer.tsx
+++ b/js/app/packages/core/component/DetailsDrawer.tsx
@@ -1,9 +1,7 @@
-import { EntityPropertiesSection } from '@app/component/side-panel/properties';
 import { SplitDrawer } from '@app/component/split-layout/components/SplitDrawer';
 import { EntityIcon } from '@core/component/EntityIcon';
 import { openDocument } from '@core/component/LexicalMarkdown/component/core/BlockLink';
 import { UserIcon } from '@core/component/UserIcon';
-import { useCanEdit } from '@core/signal/permissions';
 import { tryMacroId, useDisplayName } from '@core/user';
 import { type DateValue, formatDate } from '@core/util/date';
 import { useSplitNavigationHandler } from '@core/util/useSplitNavigationHandler';
@@ -86,29 +84,18 @@ function ChatDetails(props: { chatId: string }) {
   const projectQuery = useProjectDataQuery(
     () => chat()?.projectId ?? undefined
   );
-  const canEdit = useCanEdit();
 
   return (
-    <>
-      <DetailsGrid
-        owner={() => chat()?.userId}
-        folder={() => {
-          const id = chat()?.projectId;
-          const name = projectQuery.data?.name;
-          return id && name ? { id, name } : undefined;
-        }}
-        createdAt={() => chat()?.createdAt}
-        updatedAt={() => chat()?.updatedAt}
-      />
-      <div class="px-2 py-2">
-        <EntityPropertiesSection
-          entityId={props.chatId}
-          entityType="CHAT"
-          canEdit={canEdit()}
-          documentName={chat()?.name}
-        />
-      </div>
-    </>
+    <DetailsGrid
+      owner={() => chat()?.userId}
+      folder={() => {
+        const id = chat()?.projectId;
+        const name = projectQuery.data?.name;
+        return id && name ? { id, name } : undefined;
+      }}
+      createdAt={() => chat()?.createdAt}
+      updatedAt={() => chat()?.updatedAt}
+    />
   );
 }
 

--- a/js/app/packages/entity/src/composed/list-entity/wide-layout.tsx
+++ b/js/app/packages/entity/src/composed/list-entity/wide-layout.tsx
@@ -155,6 +155,19 @@ export function WideLayout(props: LayoutProps) {
         </Switch>
       </Entity.Slot>
       <Entity.Slot placement="meta" class="flex items-center gap-2">
+        <Show
+          when={
+            rowTagsVisible() && isProjectEntity(props.entity) && props.entity
+          }
+        >
+          {(entity) => (
+            <RowTags
+              entityId={entity().id}
+              entityType={EntityType.PROJECT}
+              properties={entity().properties}
+            />
+          )}
+        </Show>
         <Show when={isProjectContainedEntity(props.entity) && props.entity}>
           {(entity) => (
             <span class="ph-no-capture text-ink-extra-muted text-xs">
@@ -220,19 +233,6 @@ export function WideLayout(props: LayoutProps) {
             <EntityRowTags
               entityId={entity().id}
               entityType={EntityType.THREAD}
-              properties={entity().properties}
-            />
-          )}
-        </Show>
-        <Show
-          when={
-            rowTagsVisible() && isProjectEntity(props.entity) && props.entity
-          }
-        >
-          {(entity) => (
-            <RowTags
-              entityId={entity().id}
-              entityType={EntityType.PROJECT}
               properties={entity().properties}
             />
           )}


### PR DESCRIPTION
Folder row tag chips now render to the left of the project breadcrumb, the Folders search type gets the tag facet (backend already filters the projects leg by tag_option_ids), and AI chats get the same Details/Properties side panel as folders, with the properties section removed from the chat details drawer.
