### PR TITLE
feat(tags): add label picker to entity row context menu

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/create-soup-entity-actions.ts
+++ b/js/app/packages/app/component/next-soup/soup-view/create-soup-entity-actions.ts
@@ -59,6 +59,9 @@ type BuildActionGroups = (
     activeTab: string | undefined;
     /** Set when the list is a folder's contents (project block view) */
     viewedProjectId?: string;
+    // Provided only where the menu host can anchor a tag picker for the
+    // right-clicked row.
+    openTagPicker?: () => void;
   }
 ) => SoupEntityActionGroup[];
 
@@ -113,7 +116,7 @@ export function createSoupEntityActions(): {
   const buildActionGroups: BuildActionGroups = (
     soup,
     entities,
-    { activeTab, activeListView, viewedProjectId }
+    { activeTab, activeListView, viewedProjectId, openTagPicker }
   ) => {
     const canExecuteAll = (canExecute: (e: EntityData) => boolean) =>
       entities.length > 0 && entities.every(canExecute);
@@ -253,6 +256,14 @@ export function createSoupEntityActions(): {
         label: allFavorited ? 'Unfavorite' : 'Favorite',
         hotkeyToken: TOKENS.entity.action.favorite,
         onClick: handle(favoriteAction.executeWithSoup),
+      });
+    }
+
+    if (entities.length === 1 && openTagPicker) {
+      middleItems.push({
+        id: 'add-label',
+        label: 'Add label',
+        onClick: openTagPicker,
       });
     }
 

--- a/js/app/packages/app/component/next-soup/soup-view/soup-entity-actions-menu.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-entity-actions-menu.tsx
@@ -13,6 +13,7 @@ interface SoupEntityActionsMenuProps {
   entities: EntityData[];
   soup: SoupState;
   onActionComplete?: () => void;
+  onEditTags?: () => void;
 }
 
 export const SoupEntityActionsMenu = (props: SoupEntityActionsMenuProps) => {
@@ -26,6 +27,7 @@ export const SoupEntityActionsMenu = (props: SoupEntityActionsMenuProps) => {
       activeTab: activeTab(),
       activeListView: content.id,
       viewedProjectId: viewedProjectIdFromContent(content),
+      openTagPicker: props.onEditTags,
     });
   };
 

--- a/js/app/packages/app/component/next-soup/soup-view/soup-entity-context-menu.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-entity-context-menu.tsx
@@ -1,14 +1,7 @@
 import { ContextMenuContent } from '@core/component/ContextMenu';
 import { touchHandler } from '@core/directive/touchHandler';
 import { isMobile } from '@core/mobile/isMobile';
-import {
-  type EntityData,
-  isChatEntity,
-  isDocumentEntity,
-  isEmailEntity,
-  isProjectEntity,
-  isTaskEntity,
-} from '@entity';
+import { type EntityData, isTaskEntity } from '@entity';
 import { ContextMenu } from '@kobalte/core/context-menu';
 import { TagPickerPopover, useSoupDocTags } from '@property/tags';
 import { EntityType } from '@service-properties/generated/schemas/entityType';
@@ -21,6 +14,7 @@ import {
   Show,
   Switch,
 } from 'solid-js';
+import { match } from 'ts-pattern';
 import { useRowTagsVisible } from './filters-bar/search/search-tags-flag';
 import { useSoupEntityActionDrawer } from './soup-entity-action-drawer-context';
 import { SoupEntityActionsMenu } from './soup-entity-actions-menu';
@@ -32,13 +26,13 @@ interface SoupEntityContextMenuProps {
 }
 
 function tagEntityType(entity: EntityData): EntityType | undefined {
-  if (isDocumentEntity(entity)) {
-    return isTaskEntity(entity) ? EntityType.TASK : EntityType.DOCUMENT;
-  }
-  if (isEmailEntity(entity)) return EntityType.THREAD;
-  if (isProjectEntity(entity)) return EntityType.PROJECT;
-  if (isChatEntity(entity)) return EntityType.CHAT;
-  return undefined;
+  return match(entity)
+    .when(isTaskEntity, () => EntityType.TASK)
+    .with({ type: 'document' }, () => EntityType.DOCUMENT)
+    .with({ type: 'email' }, () => EntityType.THREAD)
+    .with({ type: 'project' }, () => EntityType.PROJECT)
+    .with({ type: 'chat' }, () => EntityType.CHAT)
+    .otherwise(() => undefined);
 }
 
 // Detached tag picker anchored at the position the context menu opened from.

--- a/js/app/packages/app/component/next-soup/soup-view/soup-entity-context-menu.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-entity-context-menu.tsx
@@ -1,9 +1,27 @@
 import { ContextMenuContent } from '@core/component/ContextMenu';
 import { touchHandler } from '@core/directive/touchHandler';
 import { isMobile } from '@core/mobile/isMobile';
-import type { EntityData } from '@entity';
+import {
+  type EntityData,
+  isChatEntity,
+  isDocumentEntity,
+  isEmailEntity,
+  isProjectEntity,
+  isTaskEntity,
+} from '@entity';
 import { ContextMenu } from '@kobalte/core/context-menu';
-import { type FlowComponent, Match, Show, Switch } from 'solid-js';
+import { TagPickerPopover, useSoupDocTags } from '@property/tags';
+import { EntityType } from '@service-properties/generated/schemas/entityType';
+import type { SoupProperty } from '@service-storage/generated/schemas/soupProperty';
+import {
+  type Accessor,
+  createSignal,
+  type FlowComponent,
+  Match,
+  Show,
+  Switch,
+} from 'solid-js';
+import { useRowTagsVisible } from './filters-bar/search/search-tags-flag';
 import { useSoupEntityActionDrawer } from './soup-entity-action-drawer-context';
 import { SoupEntityActionsMenu } from './soup-entity-actions-menu';
 import { useSoupView } from './soup-view-context';
@@ -13,11 +31,55 @@ interface SoupEntityContextMenuProps {
   onOpenChange?: (open: boolean) => void;
 }
 
+function tagEntityType(entity: EntityData): EntityType | undefined {
+  if (isDocumentEntity(entity)) {
+    return isTaskEntity(entity) ? EntityType.TASK : EntityType.DOCUMENT;
+  }
+  if (isEmailEntity(entity)) return EntityType.THREAD;
+  if (isProjectEntity(entity)) return EntityType.PROJECT;
+  if (isChatEntity(entity)) return EntityType.CHAT;
+  return undefined;
+}
+
+// Detached tag picker anchored at the position the context menu opened from.
+// Mounted only while open, so picker state resets on every invocation.
+function RowTagPicker(props: {
+  entityId: string;
+  entityType: EntityType;
+  properties: Accessor<SoupProperty[] | undefined>;
+  position: { x: number; y: number } | undefined;
+  onClose: () => void;
+}) {
+  const docTags = useSoupDocTags(
+    props.entityId,
+    props.entityType,
+    props.properties
+  );
+
+  return (
+    <TagPickerPopover
+      docTags={docTags}
+      open
+      onOpenChange={(open) => {
+        if (!open) props.onClose();
+      }}
+      getAnchorRect={() => props.position}
+    />
+  );
+}
+
 export const SoupEntityContextMenu: FlowComponent<
   SoupEntityContextMenuProps
 > = (props) => {
   const { soup } = useSoupView();
   const drawerManager = useSoupEntityActionDrawer();
+  const rowTagsVisible = useRowTagsVisible();
+
+  const [tagPickerOpen, setTagPickerOpen] = createSignal(false);
+  const [menuPosition, setMenuPosition] = createSignal<{
+    x: number;
+    y: number;
+  }>();
 
   // If the right-clicked row is part of a multi-selection, act on the whole
   // selection; otherwise act on just that row.
@@ -28,6 +90,9 @@ export const SoupEntityContextMenu: FlowComponent<
     }
     return [props.entity];
   };
+
+  const canEditTags = () =>
+    rowTagsVisible() && tagEntityType(props.entity) !== undefined;
 
   return (
     <Switch>
@@ -46,17 +111,49 @@ export const SoupEntityContextMenu: FlowComponent<
       </Match>
       <Match when={true}>
         <ContextMenu onOpenChange={props.onOpenChange}>
-          <ContextMenu.Trigger class="size-full group/cm-trigger">
+          <ContextMenu.Trigger
+            class="size-full group/cm-trigger"
+            // Kobalte's trigger consumes the onContextMenu prop without
+            // calling it, so capture the pointer position natively.
+            on:contextmenu={(event: MouseEvent) =>
+              setMenuPosition({ x: event.clientX, y: event.clientY })
+            }
+          >
             {props.children}
           </ContextMenu.Trigger>
           <ContextMenu.Portal>
             <Show when={props.entity}>
               <ContextMenuContent class="text-xs text-ink-muted">
-                <SoupEntityActionsMenu entities={menuEntities()} soup={soup} />
+                <SoupEntityActionsMenu
+                  entities={menuEntities()}
+                  soup={soup}
+                  // Deferred so the menu finishes closing (and its focus
+                  // handoff settles) before the picker popover mounts, else
+                  // the popover dismisses itself on focus-outside.
+                  onEditTags={
+                    canEditTags()
+                      ? () => setTimeout(() => setTagPickerOpen(true), 0)
+                      : undefined
+                  }
+                />
               </ContextMenuContent>
             </Show>
           </ContextMenu.Portal>
         </ContextMenu>
+        <Show when={tagPickerOpen() && tagEntityType(props.entity)}>
+          {(entityType) => (
+            <RowTagPicker
+              entityId={props.entity.id}
+              entityType={entityType()}
+              properties={() => {
+                const entity = props.entity;
+                return 'properties' in entity ? entity.properties : undefined;
+              }}
+              position={menuPosition()}
+              onClose={() => setTagPickerOpen(false)}
+            />
+          )}
+        </Show>
       </Match>
     </Switch>
   );

--- a/js/app/packages/property/src/tags/TagPicker.tsx
+++ b/js/app/packages/property/src/tags/TagPicker.tsx
@@ -61,6 +61,70 @@ export function TagPicker(props: {
   onOpenChange?: (open: boolean) => void;
 }) {
   const [open, setOpen] = createSignal(false);
+
+  const handleOpenChange = (value: boolean) => {
+    setOpen(value);
+    props.onOpenChange?.(value);
+  };
+
+  return (
+    <Popover
+      open={open()}
+      onOpenChange={handleOpenChange}
+      placement="bottom-start"
+      gutter={4}
+    >
+      <Popover.Trigger
+        type="button"
+        class={props.triggerClass}
+        aria-label={props.triggerLabel}
+      >
+        {props.children}
+      </Popover.Trigger>
+      <TagPickerBody
+        docTags={props.docTags}
+        onClose={() => handleOpenChange(false)}
+      />
+    </Popover>
+  );
+}
+
+/**
+ * Trigger-less TagPicker anchored at an arbitrary point, for callers that
+ * open the picker from somewhere else (e.g. a context-menu action).
+ */
+export function TagPickerPopover(props: {
+  docTags: DocTags;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  getAnchorRect: () => { x: number; y: number } | undefined;
+}) {
+  return (
+    <Popover
+      open={props.open}
+      onOpenChange={props.onOpenChange}
+      getAnchorRect={props.getAnchorRect}
+      placement="bottom-start"
+      gutter={4}
+    >
+      <TagPickerBody
+        docTags={props.docTags}
+        onClose={() => props.onOpenChange(false)}
+        // Focus starts outside the popover (the opener, e.g. a context menu,
+        // is still tearing down when it mounts), so dismissing on
+        // focus-outside would close it immediately. Pointer-down outside and
+        // Escape still dismiss.
+        dismissOnFocusOutside={false}
+      />
+    </Popover>
+  );
+}
+
+function TagPickerBody(props: {
+  docTags: DocTags;
+  onClose: () => void;
+  dismissOnFocusOutside?: boolean;
+}) {
   const [search, setSearch] = createSignal('');
   const [createScope, setCreateScope] = createSignal<TagScope>('user');
   const [createColor, setCreateColor] = createSignal<string>(DEFAULT_TAG_COLOR);
@@ -120,109 +184,94 @@ export function TagPicker(props: {
   };
 
   const closePicker = () => {
-    setOpen(false);
     setSearch('');
     setEditingId(null);
+    props.onClose();
   };
 
   return (
-    <Popover
-      open={open()}
-      onOpenChange={(value) => {
-        setOpen(value);
-        props.onOpenChange?.(value);
-      }}
-      placement="bottom-start"
-      gutter={4}
-    >
-      <Popover.Trigger
-        type="button"
-        class={props.triggerClass}
-        aria-label={props.triggerLabel}
-      >
-        {props.children}
-      </Popover.Trigger>
-      <Popover.Portal>
-        <Layer depth={3}>
-          <Popover.Content
-            class="z-modal w-64 rounded-xl bg-surface text-sm shadow-lg ring-1 ring-edge-muted"
-            onCloseAutoFocus={(event) => event.preventDefault()}
-          >
-            <div class="flex items-center gap-2 border-b border-edge-muted px-2 py-2">
-              <SearchIcon class="size-4 text-ink-muted" />
-              <input
-                class="w-full bg-transparent caret-accent outline-none"
-                value={search()}
-                placeholder="Search or create label"
-                onInput={(event) => setSearch(event.currentTarget.value)}
-                onKeyDown={(event) => {
-                  if (event.key === 'Enter') {
-                    event.preventDefault();
-                    handleCreate();
-                  } else if (event.key === 'Escape') {
-                    event.preventDefault();
-                    closePicker();
-                  }
-                }}
-              />
-            </div>
-
-            <div class="max-h-72 scroll-pb-1.5 overflow-y-auto p-1.5">
-              <For each={['user', 'team'] as const}>
-                {(scope) => (
-                  <Show when={scope === 'user' || hasTeamSet()}>
-                    <Show when={filteredSet(scope).length > 0}>
-                      <div class="px-2 pb-1 pt-2 text-xs text-ink-extra-muted">
-                        {SCOPE_LABEL[scope]}
-                      </div>
-                      <For each={filteredSet(scope)}>
-                        {(option) => (
-                          <TagPickerRow
-                            scope={scope}
-                            option={option}
-                            docTags={props.docTags}
-                            editing={editingId() === option.id}
-                            onEdit={() => setEditingId(option.id)}
-                            onEditClose={() => setEditingId(null)}
-                          />
-                        )}
-                      </For>
-                    </Show>
-                  </Show>
-                )}
-              </For>
-
-              <Show when={search().trim() && !exactMatchExists()}>
-                <CreateRow
-                  label={search().trim()}
-                  scope={createScope()}
-                  color={createColor()}
-                  hasTeamSet={hasTeamSet()}
-                  pending={addOption.isPending || ensureTagSet.isPending}
-                  onScope={setCreateScope}
-                  onColor={setCreateColor}
-                  onCreate={handleCreate}
-                  onCancel={() => setSearch('')}
-                />
-              </Show>
-
-              <Show
-                when={
-                  props.docTags
-                    .tagSets()
-                    .every((set) => set.options.length === 0) &&
-                  !search().trim()
+    <Popover.Portal>
+      <Layer depth={3}>
+        <Popover.Content
+          class="z-modal w-64 rounded-xl bg-surface text-sm shadow-lg ring-1 ring-edge-muted"
+          onCloseAutoFocus={(event) => event.preventDefault()}
+          onFocusOutside={(event) => {
+            if (props.dismissOnFocusOutside === false) event.preventDefault();
+          }}
+        >
+          <div class="flex items-center gap-2 border-b border-edge-muted px-2 py-2">
+            <SearchIcon class="size-4 text-ink-muted" />
+            <input
+              class="w-full bg-transparent caret-accent outline-none"
+              value={search()}
+              placeholder="Search or create label"
+              onInput={(event) => setSearch(event.currentTarget.value)}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter') {
+                  event.preventDefault();
+                  handleCreate();
+                } else if (event.key === 'Escape') {
+                  event.preventDefault();
+                  closePicker();
                 }
-              >
-                <div class="px-2 py-4 text-center text-ink-muted">
-                  Type to create your first label
-                </div>
-              </Show>
-            </div>
-          </Popover.Content>
-        </Layer>
-      </Popover.Portal>
-    </Popover>
+              }}
+            />
+          </div>
+
+          <div class="max-h-72 scroll-pb-1.5 overflow-y-auto p-1.5">
+            <For each={['user', 'team'] as const}>
+              {(scope) => (
+                <Show when={scope === 'user' || hasTeamSet()}>
+                  <Show when={filteredSet(scope).length > 0}>
+                    <div class="px-2 pb-1 pt-2 text-xs text-ink-extra-muted">
+                      {SCOPE_LABEL[scope]}
+                    </div>
+                    <For each={filteredSet(scope)}>
+                      {(option) => (
+                        <TagPickerRow
+                          scope={scope}
+                          option={option}
+                          docTags={props.docTags}
+                          editing={editingId() === option.id}
+                          onEdit={() => setEditingId(option.id)}
+                          onEditClose={() => setEditingId(null)}
+                        />
+                      )}
+                    </For>
+                  </Show>
+                </Show>
+              )}
+            </For>
+
+            <Show when={search().trim() && !exactMatchExists()}>
+              <CreateRow
+                label={search().trim()}
+                scope={createScope()}
+                color={createColor()}
+                hasTeamSet={hasTeamSet()}
+                pending={addOption.isPending || ensureTagSet.isPending}
+                onScope={setCreateScope}
+                onColor={setCreateColor}
+                onCreate={handleCreate}
+                onCancel={() => setSearch('')}
+              />
+            </Show>
+
+            <Show
+              when={
+                props.docTags
+                  .tagSets()
+                  .every((set) => set.options.length === 0) && !search().trim()
+              }
+            >
+              <div class="px-2 py-4 text-center text-ink-muted">
+                Type to create your first label
+              </div>
+            </Show>
+          </div>
+        </Popover.Content>
+      </Layer>
+    </Popover.Portal>
   );
 }
 

--- a/js/app/packages/property/src/tags/index.ts
+++ b/js/app/packages/property/src/tags/index.ts
@@ -1,5 +1,5 @@
 export { EntityRowTags } from './EntityRowTags';
-export { TagPicker } from './TagPicker';
+export { TagPicker, TagPickerPopover } from './TagPicker';
 export { TagsRow } from './TagsRow';
 export { DEFAULT_TAG_COLOR, TAG_COLORS } from './tagColors';
-export { type ResolvedTag, useDocTags } from './useDocTags';
+export { type ResolvedTag, useDocTags, useSoupDocTags } from './useDocTags';


### PR DESCRIPTION
Adds an "Add label" action to the entity row right-click menu that opens the tag picker anchored at the pointer, giving rows with zero tags an entry point (and tagged rows a consistent one). Only single-selection taggable rows (documents, tasks, emails, projects, chats) get the action. Reuses the chip picker via a new detached `TagPickerPopover` that defers opening past menu teardown and ignores focus-outside so the closing menu can't dismiss it.
