### PR TITLE
fix(channel): drag over reply input reliably shows the drop overlay

### DIFF
--- a/js/app/packages/core/directive/fileFolderDrop.ts
+++ b/js/app/packages/core/directive/fileFolderDrop.ts
@@ -34,6 +34,8 @@ function fileToFileSystemFileEntry(file: File): FileSystemFileEntry {
 }
 
 // differs from fileDrop in that it handles both files and folders
+// With undefined options the directive stays passive: it cancels the default
+// drop navigation but lets drag events propagate to ancestor drop zones.
 export function fileFolderDrop(
   element: HTMLElement,
   accessor: Accessor<FileFolderDropDirectiveOptions | undefined>
@@ -42,8 +44,10 @@ export function fileFolderDrop(
   let internalDragActivated = false;
 
   const handleDragOver = (e: DragEvent) => {
-    if (accessor()?.disabled) return;
+    const options = accessor();
+    if (options?.disabled) return;
     e.preventDefault();
+    if (!options) return;
     e.stopPropagation();
 
     // Upgrade an internal drag to active once the 20px threshold is exceeded.
@@ -53,18 +57,19 @@ export function fileFolderDrop(
       internalDragExceedsThreshold()
     ) {
       internalDragActivated = true;
-      accessor()?.onDragStart?.(true);
+      options.onDragStart?.(true);
     }
   };
 
   const handleDragEnter = (e: DragEvent) => {
-    if (accessor()?.disabled) return;
+    const options = accessor();
+    if (options?.disabled) return;
     e.preventDefault();
+    if (!options) return;
     e.stopPropagation();
     dragCounter++;
 
     if (dragCounter === 1) {
-      const options = accessor();
       const items = e.dataTransfer?.items;
 
       // Mark drag start call back as valid if we're dragging a file.
@@ -96,24 +101,26 @@ export function fileFolderDrop(
   };
 
   const handleDragLeave = (e: DragEvent) => {
-    if (accessor()?.disabled) return;
+    const options = accessor();
+    if (options?.disabled) return;
     e.preventDefault();
+    if (!options) return;
     e.stopPropagation();
     dragCounter--;
 
     if (dragCounter === 0) {
       internalDragActivated = false;
-      const options = accessor();
-      options?.onDragEnd?.();
+      options.onDragEnd?.();
     }
   };
 
   const handleDrop = async (e: DragEvent) => {
-    if (accessor()?.disabled) return;
+    const options = accessor();
+    if (options?.disabled) return;
     e.preventDefault();
+    if (!options) return;
     e.stopPropagation();
 
-    const options = accessor();
     dragCounter = 0;
     internalDragActivated = false;
     options?.onDragEnd?.();


### PR DESCRIPTION
MarkdownShell applies `use:fileFolderDrop` with undefined options on editors without a file drop config (channel and reply inputs included), and the directive still stopped propagation of every drag event, so drags entering over the editor content never reached the input's DropZone and the drop overlay only triggered when the drag happened to cross the thin padding or footer band around the editor. The directive is now passive when no options are provided: it keeps cancelling the default drop navigation but lets drag events propagate to ancestor drop zones, so the reply (and main) input overlay shows reliably across the full input area and drops attach.
