### PR TITLE
fix(tags): sort applied tag chips alphabetically

### DIFF
--- a/js/app/packages/property/src/tags/useDocTags.ts
+++ b/js/app/packages/property/src/tags/useDocTags.ts
@@ -27,6 +27,14 @@ function optionLabel(option: PropertyOptionResponse): string {
   return option.value.type === 'string' ? option.value.value : '';
 }
 
+function compareTags(a: ResolvedTag, b: ResolvedTag): number {
+  return (
+    a.label.localeCompare(b.label) ||
+    a.scope.localeCompare(b.scope) ||
+    a.optionId.localeCompare(b.optionId)
+  );
+}
+
 function definitionDomain(
   definition: PropertyDefinitionDetailResponse
 ): PropertyDefinitionDomain {
@@ -87,7 +95,7 @@ function createDocTags(
         if (tag) resolved.push(tag);
       }
     }
-    return resolved;
+    return resolved.sort(compareTags);
   });
 
   const isApplied = (optionId: string): boolean =>


### PR DESCRIPTION
Applied tag chips rendered in application order, so labels looked shuffled and differed between rows. Sorts `appliedTags` alphabetically by label (scope then option id as tie-breakers) in the shared `createDocTags` core, so row chips, the overflow hover list, and the side-panel tags row all share one stable order across every taggable entity type.
