### PR TITLE
chore(channel): remove dead channel-wide drag overlay plumbing

### DIFF
--- a/js/app/packages/channel/Channel/Channel.tsx
+++ b/js/app/packages/channel/Channel/Channel.tsx
@@ -645,9 +645,6 @@ export function Channel(props: ChannelProps) {
                         mode: 'channel',
                         id: `channel-input-${props.channelId}`,
                         placeholder: 'Message channel',
-                        isDraggingOverChannel:
-                          dragState.isDraggingOverChannel(),
-                        isValidChannelDrag: dragState.isValidChannelDrag(),
                       }}
                       participants={participants.users}
                       attachmentTracker={attachmentTracker}

--- a/js/app/packages/channel/Channel/ChannelDropZone.tsx
+++ b/js/app/packages/channel/Channel/ChannelDropZone.tsx
@@ -17,11 +17,6 @@ export function ChannelDropZone(props: ChannelDropZoneProps) {
     <div
       class="relative h-full flex flex-col"
       use:fileFolderDrop={{
-        onDragStart: (valid) => {
-          props.dragState.setIsDraggingOverChannel(true);
-          props.dragState.setIsValidChannelDrag(valid);
-        },
-        onDragEnd: () => props.dragState.setIsDraggingOverChannel(false),
         onDrop: (files, folders) => {
           handleFileFolderDrop(files, folders, (entries) => {
             void props.dragState.attachFilesToChannel?.(

--- a/js/app/packages/channel/Channel/create-channel-drag-state.ts
+++ b/js/app/packages/channel/Channel/create-channel-drag-state.ts
@@ -1,5 +1,4 @@
 import type { EntityData } from '@entity';
-import { type Accessor, createSignal } from 'solid-js';
 import {
   createEntityDropZone,
   type EntityDropCoordinates,
@@ -11,10 +10,6 @@ type CreateChannelDragStateOptions = {
 
 export type ChannelDragState = {
   entityDropZone: ReturnType<typeof createEntityDropZone>;
-  isDraggingOverChannel: Accessor<boolean>;
-  isValidChannelDrag: Accessor<boolean>;
-  setIsDraggingOverChannel: (value: boolean) => void;
-  setIsValidChannelDrag: (value: boolean) => void;
   attachFilesToChannel: ((files: File[]) => Promise<void>) | undefined;
   setAttachFilesToChannel: (fn: (files: File[]) => Promise<void>) => void;
   setEntityMentionInputHandlers: (handlers: {
@@ -32,9 +27,6 @@ export type ChannelDragState = {
 export function createChannelDragState(
   options: CreateChannelDragStateOptions
 ): ChannelDragState {
-  const [isDraggingOverChannel, setIsDraggingOverChannel] = createSignal(false);
-  const [isValidChannelDrag, setIsValidChannelDrag] = createSignal(true);
-
   let entityMentionInputHandlers: Parameters<
     ChannelDragState['setEntityMentionInputHandlers']
   >[0] = {};
@@ -53,11 +45,6 @@ export function createChannelDragState(
 
   return {
     entityDropZone,
-    isDraggingOverChannel: () =>
-      isDraggingOverChannel() || entityDropZone.isDraggingOver(),
-    isValidChannelDrag,
-    setIsDraggingOverChannel,
-    setIsValidChannelDrag,
     get attachFilesToChannel() {
       return attachFilesToChannel;
     },

--- a/js/app/packages/channel/Channel/create-entity-drop-zone.ts
+++ b/js/app/packages/channel/Channel/create-entity-drop-zone.ts
@@ -1,6 +1,5 @@
-import type { EntityData, EntityDragData, EntityDragEvent } from '@entity';
+import type { EntityData, EntityDragEvent } from '@entity';
 import { createDroppable, useDragDropContext } from '@thisbeyond/solid-dnd';
-import { type Accessor, createMemo } from 'solid-js';
 
 export type EntityDropCoordinates = {
   clientX: number;
@@ -22,7 +21,6 @@ type CreateEntityDropZoneOptions = {
 
 type EntityDropZone = {
   droppable: ReturnType<typeof createDroppable>;
-  isDraggingOver: Accessor<boolean>;
 };
 
 export function createEntityDropZone(
@@ -48,22 +46,6 @@ export function createEntityDropZone(
     droppable.isActiveDroppable ||
     state?.active.droppable?.id === options.droppableId;
 
-  const entityDragData = createMemo(() => {
-    const draggable = state?.active.draggable;
-    if (!draggable) return;
-    const dragData = draggable.data;
-    if (!dragData || dragData.dragType !== 'entity') return;
-    return dragData as EntityDragData;
-  });
-
-  const isDraggingOver = createMemo(() => {
-    const dragData = entityDragData();
-    if (!dragData) return false;
-
-    const activeDroppable = state?.active.droppable;
-    return !!activeDroppable && activeDroppable.id === options.droppableId;
-  });
-
   onDragEnd((event: EntityDragEvent) => {
     const data = event.draggable?.data;
     if (!data || data.dragType !== 'entity') return;
@@ -88,5 +70,5 @@ export function createEntityDropZone(
     options.onDragEntityMove?.(coordinates);
   });
 
-  return { droppable, isDraggingOver };
+  return { droppable };
 }

--- a/js/app/packages/channel/Input/DropOverlay.tsx
+++ b/js/app/packages/channel/Input/DropOverlay.tsx
@@ -1,48 +1,30 @@
 import { cn } from '@ui';
 import { children, type JSX, Show, splitProps } from 'solid-js';
 import { useInput } from './context';
-import { isReplyInput } from './types';
 
 type DropOverlayProps = JSX.HTMLAttributes<HTMLDivElement> & {
-  invalidMessage?: string;
   hint?: string;
 };
 
 export function DropOverlay(props: DropOverlayProps) {
   const input = useInput();
-  const [local, rest] = splitProps(props, [
-    'class',
-    'children',
-    'invalidMessage',
-    'hint',
-  ]);
+  const [local, rest] = splitProps(props, ['class', 'children', 'hint']);
   const resolved = children(() => local.children);
 
-  const open = () =>
-    !!input().isDraggedOver ||
-    (!!input().isDraggingOverChannel && !isReplyInput(input()));
-  const valid = () => input().isValidChannelDrag !== false;
-
   return (
-    <Show when={open()}>
+    <Show when={input().isDraggedOver}>
       <div
         class={cn(
-          'absolute inset-0 z-20 bg-modal-overlay pattern-diagonal-8 flex items-center justify-center',
-          valid() ? 'pattern-edge-muted' : 'pattern-failure-bg',
+          'absolute inset-0 z-20 bg-modal-overlay pattern-diagonal-8 pattern-edge-muted flex items-center justify-center',
           local.class
         )}
         data-input-drop-overlay
         {...rest}
       >
         <div class="bg-surface border border-edge px-8 py-4 text-xs text-ink-muted shadow-md font-mono">
-          <Show
-            when={valid()}
-            fallback={local.invalidMessage ?? 'Invalid file'}
-          >
-            {resolved() ??
-              local.hint ??
-              'Drop any file here to add it to the conversation'}
-          </Show>
+          {resolved() ??
+            local.hint ??
+            'Drop any file here to add it to the conversation'}
         </div>
       </div>
     </Show>

--- a/js/app/packages/channel/Input/tests/input-slots.test.tsx
+++ b/js/app/packages/channel/Input/tests/input-slots.test.tsx
@@ -320,19 +320,13 @@ describe('Input slots', () => {
     expect(onSend.mock.calls[0]?.[0]?.value).toBe('handle send');
   });
 
-  it('shows invalid state in drop overlay', () => {
+  it('shows the drop overlay when dragged over', () => {
     render(() => (
-      <Root
-        input={{
-          ...baseInput,
-          isDraggedOver: true,
-          isValidChannelDrag: false,
-        }}
-      >
-        <DropOverlay invalidMessage="[!] Invalid attachment file" />
+      <Root input={{ ...baseInput, isDraggedOver: true }}>
+        <DropOverlay hint="Drop files to attach" />
       </Root>
     ));
 
-    expect(screen.getByText('[!] Invalid attachment file')).toBeTruthy();
+    expect(screen.getByText('Drop files to attach')).toBeTruthy();
   });
 });

--- a/js/app/packages/channel/Input/types.ts
+++ b/js/app/packages/channel/Input/types.ts
@@ -27,8 +27,6 @@ type InputDataBase = {
   placeholder?: string;
   value?: string;
   isDraggedOver?: boolean;
-  isDraggingOverChannel?: boolean;
-  isValidChannelDrag?: boolean;
   showFormatRibbon?: boolean;
   hasPendingAttachments?: boolean;
   attachments?: InputAttachmentData[];

--- a/js/app/packages/channel/Thread/ThreadReplyInput.tsx
+++ b/js/app/packages/channel/Thread/ThreadReplyInput.tsx
@@ -110,7 +110,6 @@ export function ThreadReplyInput(props: ThreadReplyInputProps) {
                 placeholder: 'Send a reply',
                 value: props.replyInputState()?.value,
                 attachments: props.replyInputState()?.attachments,
-                isDraggingOverChannel: entityDropZone.isDraggingOver(),
                 mode: 'reply',
               }}
               participants={participants.users}


### PR DESCRIPTION
The channel-wide drag overlay (`isDraggingOverChannel`/`isValidChannelDrag`) has never fired since the PR #1761 input rewrite: the values flow through `createInputState`'s one-time `initialInput` snapshot, so `DropOverlay` always sees `false`. Rather than making the input reactive we're killing the feature — this removes the dead signal plumbing end to end (input fields, drag-state signals, `ChannelDropZone` drag callbacks, `DropOverlay` channel branch and its unreachable invalid-state UI, and the now-unconsumed `entityDropZone.isDraggingOver`). Dropping a file on the message list still attaches it to the main input, and the input's own drag-over overlay is untouched.
