### PR TITLE
docs(callkit): note side-button hangup is unoverridable iOS behavior

### DIFF
--- a/js/app/tauri/callkit_plugin/ios/Sources/IncomingCallCoordinator.swift
+++ b/js/app/tauri/callkit_plugin/ios/Sources/IncomingCallCoordinator.swift
@@ -465,6 +465,12 @@ final class IncomingCallCoordinator: NSObject, CXProviderDelegate, PKPushRegistr
         }
     }
 
+    // Besides app-requested hangups, the system sends this action unsolicited:
+    // since iOS 16.1 pressing the side/lock button during an active CallKit
+    // call ends it, matching the Phone app. No API suppresses that (video
+    // flags don't help), and the action can't be failed without also breaking
+    // End from the system call UI; the only opt-out is the user-side setting
+    // Settings > Accessibility > Touch > Prevent Lock to End Call.
     func provider(_ provider: CXProvider, perform action: CXEndCallAction) {
         let callId = action.callUUID.uuidString
         print("[CallKit] CXEndCallAction received uuid=\(callId)")


### PR DESCRIPTION
## Summary

Investigation of macro-1985 ("pressing lock button during call hangs up call"): **this cannot be overridden in-app.** Since iOS 16.1, pressing the side/lock button during an active CallKit call makes the system send an unsolicited `CXEndCallAction`, matching the native Phone app. There is no CallKit API, provider-configuration flag, or entitlement that suppresses it — our existing `supportsVideo = true` / `hasVideo = true` don't affect it, and failing the action would also break End from the system call UI, so we must fulfill it.

What does work:
- **Per-device user setting**: Settings → Accessibility → Touch → **Prevent Lock to End Call** (iOS 16+) — the side button then locks without hanging up. Apps can't read, toggle, or deep-link to it.
- Only a physical side-button press ends the call; auto-lock and AssistiveTouch's software lock don't.
- Apps that survive the button (e.g. Zoom meetings) do so by not running the active call under CallKit at all — a bad trade for us since lock-screen answer/audio and cellular-call arbitration depend on CallKit.

This PR just records that constraint as a comment on the `CXEndCallAction` handler so the recurring report lands on the explanation. A possible UX follow-up (not included): tag system-initiated ends in the `call-ended` event so the web layer can surface the accessibility-setting tip.

References: [Apple Dev Forums – CallKit ends calls on iOS 16.1 side-button press](https://developer.apple.com/forums/thread/719622), [Prevent Lock to End Call](https://www.makeuseof.com/how-to-stop-iphone-lock-from-ending-calls/)

Session: https://claude.ai/code/session_01W8C2yf9G7yjSbJFTmaywUi

---
_Generated by [Claude Code](https://claude.ai/code/session_01W8C2yf9G7yjSbJFTmaywUi)_