### PR TITLE
feat(mobile): activate full-text search on Enter in mobile search

### DIFF
--- a/js/app/packages/app/component/command/useCommandItems.ts
+++ b/js/app/packages/app/component/command/useCommandItems.ts
@@ -351,8 +351,11 @@ function useQuickAccessBuckets(): Record<
 
 export function useCommandItems(
   query: () => string,
-  categoryFilter: () => CategoryFilter
+  categoryFilter: () => CategoryFilter,
+  options?: { showSearchRow?: boolean }
 ) {
+  const showSearchRow = options?.showSearchRow ?? true;
+
   const buckets = useQuickAccessBuckets();
 
   // When in command scope or entity action mode, always show commands regardless of category filter
@@ -378,6 +381,7 @@ export function useCommandItems(
   });
 
   const shouldShowSearchRow = (q: string) => {
+    if (!showSearchRow) return false;
     if (!q.trim()) return false;
     if (CommandState.commandScopeCommands().length > 0) return false;
     if (CommandState.isEntityActionMode()) return false;
@@ -405,7 +409,9 @@ export function useCommandItems(
         const rest = ranked.filter((item) => !topCommandIds.has(item.id));
 
         return [
-          ...(trimmedQuery ? [makeSearchItem(q, categoryFilter())] : []),
+          ...(trimmedQuery && showSearchRow
+            ? [makeSearchItem(q, categoryFilter())]
+            : []),
           ...topCommands,
           ...rest,
         ];

--- a/js/app/packages/app/component/command/useCommandItems.ts
+++ b/js/app/packages/app/component/command/useCommandItems.ts
@@ -19,7 +19,7 @@ import {
   type TimestampedItem,
 } from '@core/util/freshSort';
 import { mergeSortedArrays } from '@core/util/list';
-import { createMemo } from 'solid-js';
+import { type Accessor, createMemo } from 'solid-js';
 import { getCommandLastUsedAt } from './recency';
 import { CommandState } from './state';
 import type { CategoryFilter, DisplayHotkeyStep } from './types';
@@ -250,7 +250,9 @@ function getSurfacedNestedCommands(commands: CommandWithInfo[]) {
  * selection modification commands (delete, mark done, etc.) would be filtered
  * out because their conditions check the soup's selection state.
  */
-function useCommandsList(): () => CommandItem[] {
+function useCommandsList(
+  commandScopeCommands: Accessor<CommandWithInfo[]>
+): () => CommandItem[] {
   const scopeId = activeScope() ?? '';
   const capturedCommands = getActiveCommandsFromScope(scopeId, {
     sortByScopeLevel: false,
@@ -268,7 +270,7 @@ function useCommandsList(): () => CommandItem[] {
 
   return createMemo(() => {
     // If we're in a command scope (multi-stage command), show those commands instead
-    const scopeCommands = CommandState.commandScopeCommands();
+    const scopeCommands = commandScopeCommands();
     if (scopeCommands.length > 0) {
       return commandsToItems(scopeCommands, {
         displayHotkeySequence: nestedCommandScopeDisplaySequence,
@@ -320,12 +322,11 @@ function useCommandsList(): () => CommandItem[] {
  * Hook to get items from QuickAccess organized by category.
  * Items are already sorted by recency from QuickAccess.
  */
-function useQuickAccessBuckets(): Record<
-  CategoryFilter,
-  () => CommandMenuItem[]
-> {
+function useQuickAccessBuckets(
+  commandScopeCommands: Accessor<CommandWithInfo[]>
+): Record<CategoryFilter, () => CommandMenuItem[]> {
   const quickAccess = useQuickAccess();
-  const commandsList = useCommandsList();
+  const commandsList = useCommandsList(commandScopeCommands);
   const entitiesList = quickAccess.useList(...exclude('person'));
 
   const allWithCommands = createMemo((): CommandMenuItem[] =>
@@ -352,15 +353,24 @@ function useQuickAccessBuckets(): Record<
 export function useCommandItems(
   query: () => string,
   categoryFilter: () => CategoryFilter,
-  options?: { showSearchRow?: boolean }
+  options?: {
+    showSearchRow?: boolean;
+    /**
+     * Source of multi-stage command-scope commands. Defaults to the desktop
+     * command menu state; mobile search passes its own scope state.
+     */
+    commandScopeCommands?: Accessor<CommandWithInfo[]>;
+  }
 ) {
   const showSearchRow = options?.showSearchRow ?? true;
+  const commandScopeCommands =
+    options?.commandScopeCommands ?? CommandState.commandScopeCommands;
 
-  const buckets = useQuickAccessBuckets();
+  const buckets = useQuickAccessBuckets(commandScopeCommands);
 
   // When in command scope or entity action mode, always show commands regardless of category filter
   const categoryItems = () => {
-    if (CommandState.commandScopeCommands().length > 0) {
+    if (commandScopeCommands().length > 0) {
       return buckets.commands();
     }
     if (CommandState.isEntityActionMode()) {
@@ -383,7 +393,7 @@ export function useCommandItems(
   const shouldShowSearchRow = (q: string) => {
     if (!showSearchRow) return false;
     if (!q.trim()) return false;
-    if (CommandState.commandScopeCommands().length > 0) return false;
+    if (commandScopeCommands().length > 0) return false;
     if (CommandState.isEntityActionMode()) return false;
     return SEARCHABLE_CATEGORIES.has(categoryFilter());
   };
@@ -395,7 +405,7 @@ export function useCommandItems(
     if (
       q.trim().length <= 3 &&
       categoryFilter() === 'all' &&
-      CommandState.commandScopeCommands().length === 0 &&
+      commandScopeCommands().length === 0 &&
       !CommandState.isEntityActionMode()
     ) {
       const trimmedQuery = q.trim();

--- a/js/app/packages/app/component/mobile/MobileSearch.tsx
+++ b/js/app/packages/app/component/mobile/MobileSearch.tsx
@@ -224,10 +224,22 @@ function SearchInputBar(props: { onBack: () => void }) {
         <input
           id="mobile-search-input"
           type="text"
+          enterkeyhint="search"
           class="h-full min-w-0 flex-1 border-0 bg-transparent text-ink outline-none ring-0 placeholder:text-ink-placeholder focus:outline-none focus:ring-0"
           placeholder="Search..."
           value={SearchState.query()}
           onInput={(e) => SearchState.setQuery(e.currentTarget.value)}
+          onKeyDown={(e) => {
+            // Enter (the keyboard's Search key) activates full-text search,
+            // same as the "Full-text search for ..." row. Not while an IME
+            // composition is being confirmed, and not while picking a nested
+            // command's options, where the input filters commands.
+            if (e.key !== 'Enter' || e.isComposing) return;
+            if (SearchState.isInCommandScope()) return;
+            SearchState.enableFullTextMode();
+            // Drop the virtual keyboard so the results get the full frame.
+            e.currentTarget.blur();
+          }}
         />
       </div>
     </div>

--- a/js/app/packages/app/component/mobile/MobileSearch.tsx
+++ b/js/app/packages/app/component/mobile/MobileSearch.tsx
@@ -68,6 +68,7 @@ function MobileSearchInner() {
 
   const filteredItems = useCommandItems(query, SearchState.categoryFilter, {
     showSearchRow: false,
+    commandScopeCommands: SearchState.commandScopeCommands,
   });
   const { results: fullTextResults, isLoading: isFullTextLoading } =
     useFullTextSearch(SearchState.query);
@@ -88,6 +89,9 @@ function MobileSearchInner() {
             hideShadowedCommands: false,
             hideCommandsWithoutHotkeys: false,
             limitToCurrentScope: true,
+            // Commands run from taps, not keystrokes, so the search input
+            // being focused (virtual keyboard up) shouldn't filter them.
+            ignoreInputFocused: true,
           }
         );
         SearchState.setQuery('');
@@ -95,7 +99,10 @@ function MobileSearchInner() {
         return;
       }
 
-      // Regular command - close and run
+      // Regular command - close and run. Clear any active command scope so a
+      // quick reopen (within the reset threshold) doesn't restore a stale
+      // nested-command list.
+      SearchState.clearCommandScopeCommands();
       SearchState.close();
       SearchState.setQuery('');
       runCommand(command);
@@ -274,6 +281,8 @@ function ResultsContainer(props: {
   const heightOfNameMatchList = () => props.nameMatchItems.length * rowHeight();
   const showFullTextSearchButton = () => {
     if (SearchState.isFullTextMode()) return false;
+    // In a command scope the input filters nested commands, not search.
+    if (SearchState.isInCommandScope()) return false;
     // Always show when there are no name matches (rowHeight stays 0 since list isn't rendered)
     if (props.nameMatchItems.length === 0) return true;
     const rh = rowHeight();

--- a/js/app/packages/app/component/mobile/MobileSearch.tsx
+++ b/js/app/packages/app/component/mobile/MobileSearch.tsx
@@ -66,7 +66,9 @@ function MobileSearchInner() {
 
   const query = debouncedDependent(SearchState.query, 60);
 
-  const filteredItems = useCommandItems(query, SearchState.categoryFilter);
+  const filteredItems = useCommandItems(query, SearchState.categoryFilter, {
+    showSearchRow: false,
+  });
   const { results: fullTextResults, isLoading: isFullTextLoading } =
     useFullTextSearch(SearchState.query);
 


### PR DESCRIPTION
In mobile search (opened from the mobile dock), pressing Enter did nothing — full-text search was only reachable by tapping the "Full-text search for ..." row, which can be pushed out of sight when name matches fill the screen.

Pressing Enter in the search input now activates full-text search directly (same code path as the row: `SearchState.enableFullTextMode()`), and blurs the input so the virtual keyboard drops and results get the full frame. The input also sets `enterkeyhint="search"` so mobile keyboards label the key "Search". Enter is ignored mid-IME-composition and while filtering a nested command scope's options.

Fixes MACRO-1983.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E1wgw9uJktj3GXmD7yBMar

---
_Generated by [Claude Code](https://claude.ai/code/session_01E1wgw9uJktj3GXmD7yBMar)_