### PR TITLE
fix(search): format document names in server search results

### DIFF
--- a/js/app/packages/entity/src/extractors/entity-title.tsx
+++ b/js/app/packages/entity/src/extractors/entity-title.tsx
@@ -44,7 +44,24 @@ function extractRawTitle(entity: EntityData): JSX.Element {
 
 function extractSearchHighlight(entity: EntityData): string | undefined {
   if (!isSearchEntity(entity)) return undefined;
-  return entity.search.nameHighlight ?? undefined;
+  const highlight = entity.search.nameHighlight ?? undefined;
+  if (!highlight) return undefined;
+  return withExtensionSuffix(highlight, entity);
+}
+
+// Server name highlights are built from the unformatted document name, so
+// they lack the extension suffix formatDocumentName adds; local fuzzy
+// highlights are built from the formatted name and already carry it.
+function withExtensionSuffix(highlight: string, entity: EntityData): string {
+  if (entity.type !== 'document' || !entity.fileType) return highlight;
+  const suffix = `.${entity.fileType}`;
+  const formatted = formatDocumentName(entity.name, entity.fileType, {
+    fullyQualifiedBlockName: true,
+  });
+  if (!formatted.endsWith(suffix)) return highlight;
+  const plain = highlight.replace(/<\/?macro_em>/g, '');
+  if (plain.endsWith(suffix)) return highlight;
+  return `${highlight}${suffix}`;
 }
 
 export function EntityTitle(props: { entity: EntityData }) {

--- a/js/app/packages/entity/src/extractors/entity-title.tsx
+++ b/js/app/packages/entity/src/extractors/entity-title.tsx
@@ -44,24 +44,7 @@ function extractRawTitle(entity: EntityData): JSX.Element {
 
 function extractSearchHighlight(entity: EntityData): string | undefined {
   if (!isSearchEntity(entity)) return undefined;
-  const highlight = entity.search.nameHighlight ?? undefined;
-  if (!highlight) return undefined;
-  return withExtensionSuffix(highlight, entity);
-}
-
-// Server name highlights are built from the unformatted document name, so
-// they lack the extension suffix formatDocumentName adds; local fuzzy
-// highlights are built from the formatted name and already carry it.
-function withExtensionSuffix(highlight: string, entity: EntityData): string {
-  if (entity.type !== 'document' || !entity.fileType) return highlight;
-  const suffix = `.${entity.fileType}`;
-  const formatted = formatDocumentName(entity.name, entity.fileType, {
-    fullyQualifiedBlockName: true,
-  });
-  if (!formatted.endsWith(suffix)) return highlight;
-  const plain = highlight.replace(/<\/?macro_em>/g, '');
-  if (plain.endsWith(suffix)) return highlight;
-  return `${highlight}${suffix}`;
+  return entity.search.nameHighlight ?? undefined;
 }
 
 export function EntityTitle(props: { entity: EntityData }) {

--- a/js/app/packages/queries/soup/transform-utils.ts
+++ b/js/app/packages/queries/soup/transform-utils.ts
@@ -281,6 +281,9 @@ export function mapChannelSearchResultItem(
     });
 }
 
+const formatDisplayName = (text: string, fileType?: string | null) =>
+  formatDocumentName(text, fileType, { fullyQualifiedBlockName: true });
+
 export const useSearchResponseItemMapper = () => {
   const channelsContext = useChannelsContext();
   const channels = channelsContext.channels;
@@ -351,10 +354,9 @@ export const useSearchResponseItemMapper = () => {
         if (search.nameHighlight) {
           search = {
             ...search,
-            nameHighlight: formatDocumentName(
+            nameHighlight: formatDisplayName(
               search.nameHighlight,
-              result.file_type,
-              { fullyQualifiedBlockName: true }
+              result.file_type
             ),
           };
         }
@@ -369,10 +371,9 @@ export const useSearchResponseItemMapper = () => {
                   ? { type: 'snippet' }
                   : null,
             id: result.document_id,
-            name: formatDocumentName(
+            name: formatDisplayName(
               result.name || blockNameToDefaultFile(result.file_type),
-              result.file_type,
-              { fullyQualifiedBlockName: true }
+              result.file_type
             ),
             ownerId: result.owner_id,
             createdAt: result.metadata?.created_at,

--- a/js/app/packages/queries/soup/transform-utils.ts
+++ b/js/app/packages/queries/soup/transform-utils.ts
@@ -346,6 +346,18 @@ export const useSearchResponseItemMapper = () => {
             results: result.document_search_results,
           });
         }
+        // The index stores unformatted document names, so server name
+        // highlights lack the extension suffix the display name carries.
+        if (search.nameHighlight) {
+          search = {
+            ...search,
+            nameHighlight: formatDocumentName(
+              search.nameHighlight,
+              result.file_type,
+              { fullyQualifiedBlockName: true }
+            ),
+          };
+        }
         const properties = result.properties ?? undefined;
         return [
           {

--- a/js/app/packages/queries/soup/transform-utils.ts
+++ b/js/app/packages/queries/soup/transform-utils.ts
@@ -43,6 +43,7 @@ import type {
   SoupPage,
 } from '@service-storage/generated/schemas';
 import type { ChannelType } from '@service-storage/generated/schemas/channelType';
+import { formatDocumentName } from '@service-storage/util/filename';
 import type { UseQueryResult } from '@tanstack/solid-query';
 import { differenceInMilliseconds } from 'date-fns';
 import { match } from 'ts-pattern';
@@ -356,7 +357,11 @@ export const useSearchResponseItemMapper = () => {
                   ? { type: 'snippet' }
                   : null,
             id: result.document_id,
-            name: result.name || blockNameToDefaultFile(result.file_type),
+            name: formatDocumentName(
+              result.name || blockNameToDefaultFile(result.file_type),
+              result.file_type,
+              { fullyQualifiedBlockName: true }
+            ),
             ownerId: result.owner_id,
             createdAt: result.metadata?.created_at,
             updatedAt: result.metadata?.updated_at,


### PR DESCRIPTION
Server search result rows mapped `result.name` raw while local/history rows format names through `formatDocumentName`, so the same file rendered as "pdf copy" from the server and "pdf copy.zip" locally depending on which instance won the featured slot. Applies the same `fullyQualifiedBlockName` formatting in the search response mapper, so only unknown/code-style block types gain the extension suffix.
