### PR TITLE
fix(soup): preview panel visible too long on narrow split

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/use-preview-pane-visibility.ts
+++ b/js/app/packages/app/component/next-soup/soup-view/use-preview-pane-visibility.ts
@@ -8,7 +8,7 @@ import {
 } from '@core/constant/featureFlags';
 import { createMemo } from 'solid-js';
 
-export const WIDE_SPLIT_PANEL_BREAKPOINT = 512;
+export const WIDE_SPLIT_PANEL_BREAKPOINT = 640;
 
 export function useIsNewInboxEnabled() {
   const panel = useSplitPanelOrThrow();


### PR DESCRIPTION
Increase trigger breakpoint