### PR TITLE
fix(tags): AI tool schema mismatches, doc routing, tag colors

### DIFF
--- a/js/app/packages/core/component/AI/component/tool/ListEntities.tsx
+++ b/js/app/packages/core/component/AI/component/tool/ListEntities.tsx
@@ -1,4 +1,5 @@
 import { EntityIcon } from '@core/component/EntityIcon';
+import { fileTypeToBlockName } from '@core/constant/allBlocks';
 import WideChannel from '@icon/wide-channel.svg';
 import WideFileMd from '@icon/wide-file-md.svg';
 import List from '@phosphor-icons/core/regular/list.svg';
@@ -68,7 +69,10 @@ const ListEntitiesToolResponse = (props: {
     switch (item.type) {
       case 'document':
         return () => {
-          replaceOrInsertSplit({ type: 'unknown', id: item.id });
+          replaceOrInsertSplit({
+            type: fileTypeToBlockName(item.subType ?? item.fileType),
+            id: item.id,
+          });
         };
       case 'aiChat':
         return () => {

--- a/js/app/packages/core/component/AI/component/tool/ListTags.tsx
+++ b/js/app/packages/core/component/AI/component/tool/ListTags.tsx
@@ -1,4 +1,5 @@
 import Tag from '@phosphor-icons/core/regular/tag.svg';
+import { TagDot } from '@property/tags/TagDot';
 import type { NamedTool } from '@service-cognition/generated/tools/tool';
 import { createSignal, For } from 'solid-js';
 import { BaseTool } from './BaseTool';
@@ -13,7 +14,7 @@ const ListTagsToolResponse = (props: { tagSets: ListTagsSet[] }) => (
       {(set) => (
         <For each={set.tags}>
           {(tag) => (
-            <Tool.ListItem icon={<Tag class="size-4" />}>
+            <Tool.ListItem icon={<TagDot color={tag.color ?? undefined} />}>
               <div class="flex min-w-0 flex-1 items-center justify-between gap-2">
                 <span class="truncate text-xs text-ink">{tag.label}</span>
                 <span class="shrink-0 text-2xs text-ink-muted">

--- a/js/app/packages/service-clients/service-cognition/generated/tools/schemas.ts
+++ b/js/app/packages/service-clients/service-cognition/generated/tools/schemas.ts
@@ -670,13 +670,15 @@ export const GetEntityPropertiesResponse = z.object({
       displayName: z.string(),
       isMultiSelect: z.boolean(),
       isSystem: z.boolean(),
-      options: z.array(
-        z.object({
-          displayOrder: z.number().int(),
-          displayValue: z.string(),
-          id: z.string().uuid(),
-        })
-      ),
+      options: z
+        .array(
+          z.object({
+            displayOrder: z.number().int(),
+            displayValue: z.string(),
+            id: z.string().uuid(),
+          })
+        )
+        .optional(),
       propertyDefinitionId: z.string().uuid(),
       scope: z
         .union([
@@ -919,119 +921,129 @@ export const ListEntitiesResponse = z.object({
     z.any().superRefine((x, ctx) => {
       const schemas = [
         z.object({
+          fileType: z.union([z.string(), z.null()]).optional(),
           id: z.string().uuid(),
           name: z.string(),
-          tags: z.array(
-            z.object({
-              label: z.string(),
-              scope: z.any().superRefine((x, ctx) => {
-                const schemas = [z.literal('personal'), z.literal('team')];
-                const errors = schemas.reduce<z.ZodError[]>(
-                  (errors, schema) =>
-                    ((result) =>
-                      result.error ? [...errors, result.error] : errors)(
-                      schema.safeParse(x)
-                    ),
-                  []
-                );
-                if (schemas.length - errors.length !== 1) {
-                  ctx.addIssue({
-                    path: ctx.path,
-                    code: 'invalid_union',
-                    unionErrors: errors,
-                    message: 'Invalid input: Should pass single schema',
-                  });
-                }
-              }),
-            })
-          ),
+          subType: z.union([z.string(), z.null()]).optional(),
+          tags: z
+            .array(
+              z.object({
+                label: z.string(),
+                scope: z.any().superRefine((x, ctx) => {
+                  const schemas = [z.literal('personal'), z.literal('team')];
+                  const errors = schemas.reduce<z.ZodError[]>(
+                    (errors, schema) =>
+                      ((result) =>
+                        result.error ? [...errors, result.error] : errors)(
+                        schema.safeParse(x)
+                      ),
+                    []
+                  );
+                  if (schemas.length - errors.length !== 1) {
+                    ctx.addIssue({
+                      path: ctx.path,
+                      code: 'invalid_union',
+                      unionErrors: errors,
+                      message: 'Invalid input: Should pass single schema',
+                    });
+                  }
+                }),
+              })
+            )
+            .optional(),
           type: z.literal('document'),
         }),
         z.object({
           id: z.string().uuid(),
           name: z.string(),
-          tags: z.array(
-            z.object({
-              label: z.string(),
-              scope: z.any().superRefine((x, ctx) => {
-                const schemas = [z.literal('personal'), z.literal('team')];
-                const errors = schemas.reduce<z.ZodError[]>(
-                  (errors, schema) =>
-                    ((result) =>
-                      result.error ? [...errors, result.error] : errors)(
-                      schema.safeParse(x)
-                    ),
-                  []
-                );
-                if (schemas.length - errors.length !== 1) {
-                  ctx.addIssue({
-                    path: ctx.path,
-                    code: 'invalid_union',
-                    unionErrors: errors,
-                    message: 'Invalid input: Should pass single schema',
-                  });
-                }
-              }),
-            })
-          ),
+          tags: z
+            .array(
+              z.object({
+                label: z.string(),
+                scope: z.any().superRefine((x, ctx) => {
+                  const schemas = [z.literal('personal'), z.literal('team')];
+                  const errors = schemas.reduce<z.ZodError[]>(
+                    (errors, schema) =>
+                      ((result) =>
+                        result.error ? [...errors, result.error] : errors)(
+                        schema.safeParse(x)
+                      ),
+                    []
+                  );
+                  if (schemas.length - errors.length !== 1) {
+                    ctx.addIssue({
+                      path: ctx.path,
+                      code: 'invalid_union',
+                      unionErrors: errors,
+                      message: 'Invalid input: Should pass single schema',
+                    });
+                  }
+                }),
+              })
+            )
+            .optional(),
           type: z.literal('aiChat'),
         }),
         z.object({
           id: z.string().uuid(),
           name: z.string(),
-          tags: z.array(
-            z.object({
-              label: z.string(),
-              scope: z.any().superRefine((x, ctx) => {
-                const schemas = [z.literal('personal'), z.literal('team')];
-                const errors = schemas.reduce<z.ZodError[]>(
-                  (errors, schema) =>
-                    ((result) =>
-                      result.error ? [...errors, result.error] : errors)(
-                      schema.safeParse(x)
-                    ),
-                  []
-                );
-                if (schemas.length - errors.length !== 1) {
-                  ctx.addIssue({
-                    path: ctx.path,
-                    code: 'invalid_union',
-                    unionErrors: errors,
-                    message: 'Invalid input: Should pass single schema',
-                  });
-                }
-              }),
-            })
-          ),
+          tags: z
+            .array(
+              z.object({
+                label: z.string(),
+                scope: z.any().superRefine((x, ctx) => {
+                  const schemas = [z.literal('personal'), z.literal('team')];
+                  const errors = schemas.reduce<z.ZodError[]>(
+                    (errors, schema) =>
+                      ((result) =>
+                        result.error ? [...errors, result.error] : errors)(
+                        schema.safeParse(x)
+                      ),
+                    []
+                  );
+                  if (schemas.length - errors.length !== 1) {
+                    ctx.addIssue({
+                      path: ctx.path,
+                      code: 'invalid_union',
+                      unionErrors: errors,
+                      message: 'Invalid input: Should pass single schema',
+                    });
+                  }
+                }),
+              })
+            )
+            .optional(),
           type: z.literal('project'),
         }),
         z.object({
           id: z.string().uuid(),
           subject: z.union([z.string(), z.null()]).optional(),
-          tags: z.array(
-            z.object({
-              label: z.string(),
-              scope: z.any().superRefine((x, ctx) => {
-                const schemas = [z.literal('personal'), z.literal('team')];
-                const errors = schemas.reduce<z.ZodError[]>(
-                  (errors, schema) =>
-                    ((result) =>
-                      result.error ? [...errors, result.error] : errors)(
-                      schema.safeParse(x)
-                    ),
-                  []
-                );
-                if (schemas.length - errors.length !== 1) {
-                  ctx.addIssue({
-                    path: ctx.path,
-                    code: 'invalid_union',
-                    unionErrors: errors,
-                    message: 'Invalid input: Should pass single schema',
-                  });
-                }
-              }),
-            })
-          ),
+          tags: z
+            .array(
+              z.object({
+                label: z.string(),
+                scope: z.any().superRefine((x, ctx) => {
+                  const schemas = [z.literal('personal'), z.literal('team')];
+                  const errors = schemas.reduce<z.ZodError[]>(
+                    (errors, schema) =>
+                      ((result) =>
+                        result.error ? [...errors, result.error] : errors)(
+                        schema.safeParse(x)
+                      ),
+                    []
+                  );
+                  if (schemas.length - errors.length !== 1) {
+                    ctx.addIssue({
+                      path: ctx.path,
+                      code: 'invalid_union',
+                      unionErrors: errors,
+                      message: 'Invalid input: Should pass single schema',
+                    });
+                  }
+                }),
+              })
+            )
+            .optional(),
           type: z.literal('email'),
         }),
         z.object({

--- a/js/app/packages/service-clients/service-cognition/generated/tools/types.ts
+++ b/js/app/packages/service-clients/service-cognition/generated/tools/types.ts
@@ -147,6 +147,10 @@ export type EmailPreset = 'signal';
 export type EntityItem =
   | {
       /**
+       * The document's file type (e.g. md, pdf, docx), when known.
+       */
+      fileType?: string | null;
+      /**
        * Document id.
        */
       id: string;
@@ -155,9 +159,13 @@ export type EntityItem =
        */
       name: string;
       /**
+       * The document's sub type: "task" for Macro tasks, "snippet" for snippets.
+       */
+      subType?: string | null;
+      /**
        * Tags on the document visible to the user.
        */
-      tags: AppliedTag[];
+      tags?: AppliedTag[];
       type: 'document';
     }
   | {
@@ -172,7 +180,7 @@ export type EntityItem =
       /**
        * Tags on the chat visible to the user.
        */
-      tags: AppliedTag[];
+      tags?: AppliedTag[];
       type: 'aiChat';
     }
   | {
@@ -187,7 +195,7 @@ export type EntityItem =
       /**
        * Tags on the project visible to the user.
        */
-      tags: AppliedTag[];
+      tags?: AppliedTag[];
       type: 'project';
     }
   | {
@@ -202,7 +210,7 @@ export type EntityItem =
       /**
        * Tags on the thread visible to the user.
        */
-      tags: AppliedTag[];
+      tags?: AppliedTag[];
       type: 'email';
     }
   | {
@@ -1518,7 +1526,7 @@ export interface ToolPropertyItem {
   /**
    * Available options for select-type properties.
    */
-  options: ToolPropertyOption[];
+  options?: ToolPropertyOption[];
   /**
    * The property definition ID. Use this when calling SetEntityProperty.
    */

--- a/rust/cloud-storage/properties/src/inbound/toolset/get_entity_properties.rs
+++ b/rust/cloud-storage/properties/src/inbound/toolset/get_entity_properties.rs
@@ -92,7 +92,7 @@ pub struct ToolPropertyItem {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub scope: Option<TagScope>,
     /// Available options for select-type properties.
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub options: Vec<ToolPropertyOption>,
 }
 

--- a/rust/cloud-storage/soup/src/inbound/toolset/list_entities.rs
+++ b/rust/cloud-storage/soup/src/inbound/toolset/list_entities.rs
@@ -27,7 +27,7 @@ use models_pagination::{SimpleSortMethod, TypeEraseCursor};
 use models_properties::DataType;
 use models_properties::service::property_value::PropertyValue;
 use models_properties::service::tag_sets::{AppliedTag, CallerTagSets, TagFilter};
-use models_soup::{SoupProperty, item::SoupItem};
+use models_soup::{SoupProperty, document::SoupDocumentSubType, item::SoupItem};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -115,8 +115,14 @@ pub enum EntityItem {
         id: Uuid,
         /// Document name.
         name: String,
+        /// The document's file type (e.g. md, pdf, docx), when known.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        file_type: Option<String>,
+        /// The document's sub type: "task" for Macro tasks, "snippet" for snippets.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        sub_type: Option<String>,
         /// Tags on the document visible to the user.
-        #[serde(skip_serializing_if = "Vec::is_empty")]
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
         tags: Vec<AppliedTag>,
     },
     /// AI chat item.
@@ -127,7 +133,7 @@ pub enum EntityItem {
         /// Chat name.
         name: String,
         /// Tags on the chat visible to the user.
-        #[serde(skip_serializing_if = "Vec::is_empty")]
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
         tags: Vec<AppliedTag>,
     },
     /// Project item.
@@ -138,7 +144,7 @@ pub enum EntityItem {
         /// Project name.
         name: String,
         /// Tags on the project visible to the user.
-        #[serde(skip_serializing_if = "Vec::is_empty")]
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
         tags: Vec<AppliedTag>,
     },
     /// Email thread item.
@@ -149,7 +155,7 @@ pub enum EntityItem {
         /// Email subject, when present.
         subject: Option<String>,
         /// Tags on the thread visible to the user.
-        #[serde(skip_serializing_if = "Vec::is_empty")]
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
         tags: Vec<AppliedTag>,
     },
     /// Channel item.
@@ -195,6 +201,14 @@ impl EntityItem {
         match item {
             SoupItem::Document(doc) => EntityItem::Document {
                 id: doc.id,
+                sub_type: doc.sub_type.as_ref().map(|sub_type| {
+                    match sub_type {
+                        SoupDocumentSubType::Task { .. } => "task",
+                        SoupDocumentSubType::Snippet {} => "snippet",
+                    }
+                    .to_string()
+                }),
+                file_type: doc.file_type,
                 name: doc.name,
                 tags: resolve_applied_tags(&doc.properties, tag_map),
             },

--- a/rust/cloud-storage/soup/src/inbound/toolset/test.rs
+++ b/rust/cloud-storage/soup/src/inbound/toolset/test.rs
@@ -199,11 +199,15 @@ fn test_build_summary_with_items() {
         EntityItem::Document {
             id: Uuid::new_v4(),
             name: "test.md".to_string(),
+            file_type: Some("md".to_string()),
+            sub_type: None,
             tags: vec![],
         },
         EntityItem::Document {
             id: Uuid::new_v4(),
             name: "other.md".to_string(),
+            file_type: Some("md".to_string()),
+            sub_type: Some("task".to_string()),
             tags: vec![],
         },
         EntityItem::Email {


### PR DESCRIPTION
Follow-up fixes from live testing of #4626: `serde(default)` on the skip-serialized `options`/`tags` arrays so the generated tool schemas stop requiring keys the payload omits (GetEntityProperties and ListEntities responses failed frontend zod parsing and rendered as "Failed"), ListEntities documents now carry `fileType`/`subType` so the renderer opens tasks and typed documents instead of the dead `unknown` split, and ListTags renders tag colors via TagDot.
