### PR TITLE
fix(tags): type-specific entity icons in ListEntities tool results

### DIFF
--- a/js/app/packages/core/component/AI/component/tool/ListEntities.tsx
+++ b/js/app/packages/core/component/AI/component/tool/ListEntities.tsx
@@ -1,7 +1,6 @@
 import { EntityIcon } from '@core/component/EntityIcon';
 import { fileTypeToBlockName } from '@core/constant/allBlocks';
 import WideChannel from '@icon/wide-channel.svg';
-import WideFileMd from '@icon/wide-file-md.svg';
 import List from '@phosphor-icons/core/regular/list.svg';
 import type { NamedTool } from '@service-cognition/generated/tools/tool';
 import { useSplitLayout } from 'app/component/split-layout/layout';
@@ -51,7 +50,16 @@ const ListEntitiesToolResponse = (props: {
       case 'channel':
         return <WideChannel class="size-4" />;
       case 'document':
-        return <WideFileMd class="size-4" />;
+        return (
+          <EntityIcon
+            targetType={fileTypeToBlockName(
+              item.subType ?? item.fileType,
+              true
+            )}
+            size="xs"
+            theme="monochrome"
+          />
+        );
       case 'aiChat':
         return <EntityIcon targetType="chat" size="xs" theme="monochrome" />;
       case 'project':


### PR DESCRIPTION
ListEntities tool result rows now render each document's real entity icon (task, pdf, canvas, code, ...) via EntityIcon and the item's subType/fileType, instead of a generic md icon. Search results already use EntityRowIcon so no change needed there.