### PR TITLE
docs: update docs.macro.com for changes merged over the last day

### DIFF
--- a/docs/apps.mdx
+++ b/docs/apps.mdx
@@ -13,7 +13,7 @@ Macro runs in any modern browser at [macro.com](https://macro.com), with no inst
   ![Macro Big QR](/images/Macro-Big-QR.png)
 </Frame>
 
-The Macro iOS app is on the [App Store](https://apps.apple.com/us/app/macro-app/id6743133649). It connects to the same workspace: inbox, email, channels, tasks, docs, and agents on your phone. You can also grab it from **Settings → Mobile App** in the web app, which shows a QR code.
+The Macro iOS app is on the [App Store](https://apps.apple.com/us/app/macro-app/id6743133649). It connects to the same workspace: inbox, email, channels, tasks, docs, and agents on your phone. You can also grab it from **Settings → Mobile App** in the web app, which shows a QR code. The create menu in the mobile dock includes an **Upload file** action, so you can add files to your workspace straight from your phone.
 
 A few things stay desktop-only by design:
 

--- a/docs/concepts/properties.mdx
+++ b/docs/concepts/properties.mdx
@@ -52,6 +52,16 @@ Some blocks ship with their own system properties:
 - **CRM companies (Customers)**: Stage (Lead, Qualified, Demo, Trial, Negotiation, Customer, Churned), Owner (a person on your team), and Revenue, plus a Last Interaction timestamp that updates automatically from synced workspace emails.
 - **CRM contacts & companies**: Email, Name, Company, interaction timestamps, Domains, Email Sync, and more.
 
+## Tags
+
+Tags are labels you attach to entities to group and filter them. A tag is either **personal** (only you see it) or **team** (shared with your workspace), and the same tags work across documents, tasks, emails, AI chats, projects, and folders — one label set for your whole workspace.
+
+Applied tags show up as chips on the entity's row, sorted alphabetically. To add one, right-click a row and choose **Add label**, or open the entity's **Details** panel and use the properties section. Folder rows show their tag chips to the left of the folder breadcrumb.
+
+To filter a list or [search](/product/search) by tag, open the filter menu and pick the **Tags** facet — it matches any of the selected tags. The facet is available for documents, tasks, emails, chats, and folders.
+
 ## Agent access
 
 Agents read and write properties through the MCP entity tools: `GetEntityProperties` to read, `SetEntityProperty` to update (status, assignee, dates, custom fields), and `ListEntities` to browse. See the [tool reference](/AI/mcp/tools/index).
+
+`ListEntities`, `ContentSearch`, and `NameSearch` return each item's visible tags and accept a `tags` filter, and `ListTags` returns the personal and team tags an agent can see. When editing a multi-select or tag property, `SetEntityProperty` can add or remove individual options, so concurrent edits compose instead of overwriting the whole value.

--- a/docs/integrations/github.mdx
+++ b/docs/integrations/github.mdx
@@ -6,6 +6,10 @@ description: "Link pull requests to tasks and let task statuses update themselve
 
 Macro integrates with GitHub so your tasks stay in sync with the code that closes them. To connect, link your GitHub account in **Settings** under **Account**.
 
+### Connecting
+
+There are two pieces: linking your GitHub account, and installing the Macro GitHub App on the repositories you want to track. From **Settings** you can link your account and follow the connection link to install the app. The order doesn't matter — if you install the app first and link your account afterward, Macro associates the existing installation with you automatically.
+
 ### Tasks that track your PRs
 
 Create a branch for a task and Macro keeps the task's status up to date automatically: **In Progress** when you create the branch, **In Review** when you open the pull request, and **Done** when it merges.
@@ -33,3 +37,7 @@ Every linked PR is also listed in the **GitHub** section of the task's propertie
 </Frame>
 
 Pull requests are blocks like everything else in Macro: you can @mention them in channels and docs, and agents can read them for context. See [Tasks](/product/tasks) for more on how tasks work.
+
+### Notifications
+
+Notifications for GitHub activity — a pull request opened, reviewed, or merged — are attributed to the GitHub username and avatar of whoever took the action, whether or not that person's GitHub account is linked to Macro. You're never notified about your own PR actions.

--- a/docs/product/crm.mdx
+++ b/docs/product/crm.mdx
@@ -31,3 +31,22 @@ Team admins can also **hide** a company or contact entirely, which removes it (a
 <Info>
   Sharing of CRM records is determined by your team, not by mentions: @mentioning a company or contact in a channel does not share it, unlike documents. See [Mentions](/concepts/mentions#what-happens-when-you-mention).
 </Info>
+
+### Saved views
+
+The **Companies** view has personal and team saved views. Use the views menu to switch between them, share a view with a link, and set display options for how companies are laid out. Team views are shared with everyone; personal views are yours alone.
+
+### Team settings
+
+Team admins configure CRM under **Settings → CRM**:
+
+- Turn CRM on or off for the team.
+- Customize the deal **Stage** options, including which stages count as closed.
+- Add custom **company properties** that appear on every company record.
+- Set the permission thresholds for who can edit stages and move deals out of a closed stage.
+
+See [Properties](/concepts/properties) for how company fields work.
+
+### Agent access
+
+Agents can browse and read your CRM through the MCP tools: `ListCompanies` to list companies with filtering, sorting, and pagination, and `GetCompany` to read a company's contacts, properties, and custom fields. See the [tool reference](/AI/mcp/tools/index).

--- a/docs/product/folders.mdx
+++ b/docs/product/folders.mdx
@@ -8,6 +8,8 @@ Folders organize the documents and files in your workspace: markdown docs, PDFs,
 
 > To create a folder use shortcut <kbd>c</kbd> \+ <kbd>f</kbd>. With an item selected in a list, press <kbd>m</kbd> to move it to a folder.
 
+Right-click an item (or long-press on mobile) to **Move to folder** or **Remove from folder**. Removing takes documents, chats, projects, and email threads out of their folder without deleting them.
+
 Files land in your workspace automatically as you work: attachments shared in channels are imported to file storage, and email attachments are auto-extracted. Everything in a folder stays fully searchable from [unified search](/product/search).
 
 Folders use the same sharing model as other blocks (owner, editor, commenter, and viewer), and folders with open notifications show up in your [inbox](/product/inbox).

--- a/docs/product/search.mdx
+++ b/docs/product/search.mdx
@@ -26,4 +26,6 @@ Use the filter button in the upper right corner to sort results into different t
 
 To further narrow search results, combine your keywords with an @mention of a specific person.
 
-Search covers more than titles: document bodies, email threads, channel messages, call transcripts, and file contents are all indexed. You can also ask an [agent](/product/agents) to find things for you; agents use the same index.
+Search covers more than titles: document bodies, email threads, channel messages, call transcripts, and file contents are all indexed. Files whose contents can't be read — archives, audio and video, and other binary formats — are still findable by name and can be filtered by their tags and properties. You can also ask an [agent](/product/agents) to find things for you; agents use the same index.
+
+On mobile, open search from the dock and press **Enter** to run a full-text search across everything, not just name matches.


### PR DESCRIPTION
## Summary

Reviewed pull requests merged into `main` over the last 24 hours and updated the Mintlify docs site (`docs/`, served at docs.macro.com) to cover the user-facing changes. Grouped by area below, with the PRs each update draws from.

### Tags & properties — `concepts/properties.mdx`
- New **Tags** section: personal vs. team labels, row chips, the **Add label** right-click action, the Details panel entry point, folder-row placement, and the **Tags** filter facet.
- Expanded **Agent access**: tags now surface in `ListEntities`/`ContentSearch`/`NameSearch` with a `tags` filter, the new `ListTags` tool, and atomic add/remove on `SetEntityProperty`.
- Sources: #4601, #4611, #4619, #4626, #4625, #4643

### CRM — `product/crm.mdx`
- **Saved views** (personal/team, share links, display options), **Team settings** (enable/disable, custom deal stages incl. closed stages, custom company properties, permission thresholds), and **Agent access** via the `ListCompanies`/`GetCompany` tools.
- Source: #4586

### GitHub integration — `integrations/github.mdx`
- **Connecting** section: account link + GitHub App install can happen in either order (install-before-link now associates automatically).
- **Notifications** section: GitHub activity is attributed to the actor's GitHub username/avatar regardless of account linkage.
- Sources: #4612, #4618, #4621, #4597

### Search — `product/search.mdx`
- Non-searchable file types (archives, audio/video, binaries) are now findable by name and filterable by tags/properties.
- Mobile: press **Enter** to run a full-text search.
- Sources: #4620, #4632

### Folders — `product/folders.mdx`
- Documented the **Remove from folder** context-menu action.
- Source: #4608

### Mobile app — `apps.mdx`
- Noted the **Upload file** action in the mobile dock create menu.
- Source: #4634

## Notes
- The `AI/mcp/tools/` reference pages are generated from the Rust tool schemas (per `docs/AGENTS.md`), so the new `ListTags`, `ListCompanies`, and `GetCompany` tools are referenced in prose here rather than hand-added as generated pages; regenerating those pages is a separate follow-up.
- The release changelog under `changelog/` is sourced from GitHub Releases and was left untouched.
- Skipped internal/infra-only and feature-flagged changes (e.g. the channel unified-input refactor, Loops sign-up integration, Docker/build and local-dev fixes) as not user-facing.

## Testing
`mint` is not available in this environment, so `mint broken-links` was not run. New internal links point to existing pages/anchors (`/product/search`, `/concepts/properties`, `/AI/mcp/tools/index`, `/product/agents`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WJMnTX9y7DZFXY9pykw9d2

---
_Generated by [Claude Code](https://claude.ai/code/session_01WJMnTX9y7DZFXY9pykw9d2)_