### PR TITLE
fix(email): stop html2text panics from crashing search indexing workers

### DIFF
--- a/rust/cloud-storage/Cargo.lock
+++ b/rust/cloud-storage/Cargo.lock
@@ -4929,6 +4929,7 @@ dependencies = [
  "lazy_static",
  "regex",
  "scraper",
+ "tracing",
  "workspace-hack",
 ]
 
@@ -6239,12 +6240,12 @@ dependencies = [
 
 [[package]]
 name = "html2text"
-version = "0.15.5"
+version = "0.16.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389acaa5a86952dcdc88a43bc18021009cb9885b0ff8c2fff1cc44e4f34c2fae"
+checksum = "12d23156ea4dbe6b37ad48fab2da56ff27b0f6192fb5db210c44eb07bfe6e787"
 dependencies = [
- "html5ever 0.35.0",
- "tendril 0.4.3",
+ "html5ever 0.38.0",
+ "tendril 0.5.0",
  "thiserror 2.0.18",
  "unicode-width 0.2.2",
 ]
@@ -6265,13 +6266,12 @@ dependencies = [
 
 [[package]]
 name = "html5ever"
-version = "0.35.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55d958c2f74b664487a2035fe1dadb032c48718a03b63f3ab0b8537db8549ed4"
+checksum = "1054432bae2f14e0061e33d23402fbaa67a921d319d56adc6bcf887ddad1cbc2"
 dependencies = [
  "log",
- "markup5ever 0.35.0",
- "match_token",
+ "markup5ever 0.38.0",
 ]
 
 [[package]]
@@ -8061,13 +8061,13 @@ dependencies = [
 
 [[package]]
 name = "markup5ever"
-version = "0.35.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "311fe69c934650f8f19652b3946075f0fc41ad8757dbb68f1ca14e7900ecc1c3"
+checksum = "8983d30f2915feeaaab2d6babdd6bc7e9ed1a00b66b5e6d74df19aa9c0e91862"
 dependencies = [
  "log",
- "tendril 0.4.3",
- "web_atoms 0.1.3",
+ "tendril 0.5.0",
+ "web_atoms",
 ]
 
 [[package]]
@@ -8078,18 +8078,7 @@ checksum = "7122d987ec5f704ee56f6e5b41a7d93722e9aae27ae07cafa4036c4d3f9757de"
 dependencies = [
  "log",
  "tendril 0.5.0",
- "web_atoms 0.2.5",
-]
-
-[[package]]
-name = "match_token"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac84fd3f360fcc43dc5f5d186f02a94192761a080e8bc58621ad4d12296a58cf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "web_atoms",
 ]
 
 [[package]]
@@ -10054,16 +10043,6 @@ checksum = "4fb1c3a8bc4dd4e5cfce29b44ffc14bedd2ee294559a294e2a4d4c9e9a6a13cd"
 dependencies = [
  "phf_generator 0.10.0",
  "phf_shared 0.10.0",
-]
-
-[[package]]
-name = "phf_codegen"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
-dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
 ]
 
 [[package]]
@@ -14793,18 +14772,6 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "web_atoms"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57ffde1dc01240bdf9992e3205668b235e59421fd085e8a317ed98da0178d414"
-dependencies = [
- "phf 0.11.3",
- "phf_codegen 0.11.3",
- "string_cache 0.8.9",
- "string_cache_codegen 0.5.4",
 ]
 
 [[package]]

--- a/rust/cloud-storage/Cargo.lock
+++ b/rust/cloud-storage/Cargo.lock
@@ -15426,6 +15426,7 @@ dependencies = [
  "num-traits",
  "once_cell",
  "percent-encoding",
+ "phf 0.13.1",
  "phf_shared 0.10.0",
  "phf_shared 0.13.1",
  "prettyplease",

--- a/rust/cloud-storage/email_utils/Cargo.toml
+++ b/rust/cloud-storage/email_utils/Cargo.toml
@@ -6,8 +6,9 @@ edition = "2024"
 
 [dependencies]
 ego-tree = { workspace = true }
-html2text = "0.15.1"
+html2text = "0.16.5"
 lazy_static = { workspace = true }
 regex = { workspace = true }
 scraper = { workspace = true }
+tracing = { workspace = true }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }

--- a/rust/cloud-storage/email_utils/src/body_parsed.rs
+++ b/rust/cloud-storage/email_utils/src/body_parsed.rs
@@ -58,8 +58,15 @@ pub fn html_to_plaintext(html: &str) -> Option<String> {
 }
 
 fn parse_html_to_text(html: &str, config: Config<PlainDecorator>) -> Option<String> {
-    match config.string_from_read(html.as_bytes(), usize::MAX) {
-        Ok(text) => {
+    // html2text panics on some malformed-but-real email HTML (e.g. a table
+    // rowspan overhanging past the last row, or rowspan="0"). A panic here
+    // takes down the whole message-processing worker, so contain it and treat
+    // the body as unparseable instead.
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        config.string_from_read(html.as_bytes(), usize::MAX)
+    }));
+    match result {
+        Ok(Ok(text)) => {
             let trimmed = text
                 .lines()
                 .map(|line| line.trim())
@@ -68,7 +75,14 @@ fn parse_html_to_text(html: &str, config: Config<PlainDecorator>) -> Option<Stri
                 .join("\n");
             Some(trimmed)
         }
-        Err(_) => None,
+        Ok(Err(_)) => None,
+        Err(_) => {
+            tracing::warn!(
+                html_len = html.len(),
+                "html2text panicked converting email body"
+            );
+            None
+        }
     }
 }
 
@@ -159,6 +173,25 @@ mod tests {
             html_to_plaintext("<div>Thanks</div><div>Alice</div>"),
             Some("Thanks\nAlice".to_string())
         );
+    }
+
+    #[test]
+    fn test_rowspan_overhang_does_not_panic() {
+        // html2text 0.15.x panicked with "capacity overflow" on a rowspan
+        // extending past the last table row (tot_width underflow).
+        let body = Some("<table><th rowspan=\"5\"><tr>".to_string());
+        let result = compute_body_parsed_linkless(true, &body);
+        assert_eq!(result, Some(String::new()));
+    }
+
+    #[test]
+    fn test_rowspan_zero_does_not_panic() {
+        // html2text panics with a divide-by-zero on rowspan="0" (still
+        // unfixed upstream as of 0.16.5). The catch_unwind wrapper must
+        // contain it and treat the body as unparseable.
+        let body = Some("<table><td rowspan=\"0\">x".to_string());
+        let result = compute_body_parsed_linkless(true, &body);
+        assert_eq!(result, None);
     }
 
     #[test]

--- a/rust/cloud-storage/email_utils/src/body_parsed.rs
+++ b/rust/cloud-storage/email_utils/src/body_parsed.rs
@@ -64,7 +64,13 @@ fn parse_html_to_text(html: &str, config: Config<PlainDecorator>) -> Option<Stri
     // the body as unparseable instead.
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         config.string_from_read(html.as_bytes(), usize::MAX)
-    }));
+    }))
+    .inspect_err(|_| {
+        tracing::warn!(
+            html_len = html.len(),
+            "html2text panicked converting email body"
+        );
+    });
     match result {
         Ok(Ok(text)) => {
             let trimmed = text
@@ -75,132 +81,9 @@ fn parse_html_to_text(html: &str, config: Config<PlainDecorator>) -> Option<Stri
                 .join("\n");
             Some(trimmed)
         }
-        Ok(Err(_)) => None,
-        Err(_) => {
-            tracing::warn!(
-                html_len = html.len(),
-                "html2text panicked converting email body"
-            );
-            None
-        }
+        Ok(Err(_)) | Err(_) => None,
     }
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_plaintext_passthrough() {
-        let body = Some("Hello, world!".to_string());
-        let result = compute_body_parsed(false, &body);
-        assert_eq!(result, Some("Hello, world!".to_string()));
-    }
-
-    #[test]
-    fn test_none_body() {
-        assert_eq!(compute_body_parsed(false, &None), None);
-        assert_eq!(compute_body_parsed(true, &None), None);
-    }
-
-    #[test]
-    fn test_html_to_text() {
-        let body = Some("<html><body><p>Hello, world!</p></body></html>".to_string());
-        let result = compute_body_parsed(true, &body);
-        assert_eq!(result, Some("Hello, world!".to_string()));
-    }
-
-    #[test]
-    fn test_empty_html() {
-        let body = Some("".to_string());
-        let result = compute_body_parsed(true, &body);
-        assert_eq!(result, Some("".to_string()));
-    }
-
-    #[test]
-    fn test_malformed_html() {
-        let body = Some("<p>Unclosed paragraph<div>Nested content</p>".to_string());
-        let result = compute_body_parsed(true, &body);
-        assert!(result.is_some());
-        let text = result.unwrap();
-        assert!(text.contains("Unclosed paragraph"));
-        assert!(text.contains("Nested content"));
-    }
-
-    #[test]
-    fn test_formatted_email() {
-        let body = Some(
-            r#"
-            <html>
-                <body>
-                    <div>
-                        <p>Hi John,</p>
-                        <p>Thank you for your inquiry about our services.</p>
-                        <p>Our team will get back to you within 24 hours.</p>
-                        <hr>
-                        <div style="color: gray; font-size: 12px;">
-                            <p>Example Corp.</p>
-                            <p>123 Business St.<br>Suite 100<br>San Francisco, CA 94107</p>
-                            <p>Phone: (555) 555-5555</p>
-                        </div>
-                    </div>
-                </body>
-            </html>
-        "#
-            .to_string(),
-        );
-
-        let result = compute_body_parsed(true, &body);
-        assert!(result.is_some());
-        let text = result.unwrap();
-        assert!(text.contains("Hi John,"));
-        assert!(text.contains("Thank you for your inquiry"));
-        assert!(text.contains("Example Corp."));
-        assert!(text.contains("123 Business St."));
-    }
-
-    #[test]
-    fn test_html_to_plaintext_inline_vs_block() {
-        // Inline tags stay on one line — no spurious break between the runs.
-        // Emphasis renders as markdown markers, matching the rest of our
-        // HTML->plaintext conversion.
-        assert_eq!(
-            html_to_plaintext("<div>Thanks <strong>Alice</strong></div>"),
-            Some("Thanks **Alice**".to_string())
-        );
-        // Block elements are separated by newlines.
-        assert_eq!(
-            html_to_plaintext("<div>Thanks</div><div>Alice</div>"),
-            Some("Thanks\nAlice".to_string())
-        );
-    }
-
-    #[test]
-    fn test_rowspan_overhang_does_not_panic() {
-        // html2text 0.15.x panicked with "capacity overflow" on a rowspan
-        // extending past the last table row (tot_width underflow).
-        let body = Some("<table><th rowspan=\"5\"><tr>".to_string());
-        let result = compute_body_parsed_linkless(true, &body);
-        assert_eq!(result, Some(String::new()));
-    }
-
-    #[test]
-    fn test_rowspan_zero_does_not_panic() {
-        // html2text panics with a divide-by-zero on rowspan="0" (still
-        // unfixed upstream as of 0.16.5). The catch_unwind wrapper must
-        // contain it and treat the body as unparseable.
-        let body = Some("<table><td rowspan=\"0\">x".to_string());
-        let result = compute_body_parsed_linkless(true, &body);
-        assert_eq!(result, None);
-    }
-
-    #[test]
-    fn test_linkless_strips_brackets() {
-        let body = Some("<p>Visit <a href=\"https://example.com\">example</a></p>".to_string());
-        let result = compute_body_parsed_linkless(true, &body);
-        assert!(result.is_some());
-        let text = result.unwrap();
-        assert!(!text.contains('['));
-        assert!(!text.contains(']'));
-    }
-}
+mod test;

--- a/rust/cloud-storage/email_utils/src/body_parsed/test.rs
+++ b/rust/cloud-storage/email_utils/src/body_parsed/test.rs
@@ -1,0 +1,115 @@
+use super::*;
+
+#[test]
+fn test_plaintext_passthrough() {
+    let body = Some("Hello, world!".to_string());
+    let result = compute_body_parsed(false, &body);
+    assert_eq!(result, Some("Hello, world!".to_string()));
+}
+
+#[test]
+fn test_none_body() {
+    assert_eq!(compute_body_parsed(false, &None), None);
+    assert_eq!(compute_body_parsed(true, &None), None);
+}
+
+#[test]
+fn test_html_to_text() {
+    let body = Some("<html><body><p>Hello, world!</p></body></html>".to_string());
+    let result = compute_body_parsed(true, &body);
+    assert_eq!(result, Some("Hello, world!".to_string()));
+}
+
+#[test]
+fn test_empty_html() {
+    let body = Some("".to_string());
+    let result = compute_body_parsed(true, &body);
+    assert_eq!(result, Some("".to_string()));
+}
+
+#[test]
+fn test_malformed_html() {
+    let body = Some("<p>Unclosed paragraph<div>Nested content</p>".to_string());
+    let result = compute_body_parsed(true, &body);
+    assert!(result.is_some());
+    let text = result.unwrap();
+    assert!(text.contains("Unclosed paragraph"));
+    assert!(text.contains("Nested content"));
+}
+
+#[test]
+fn test_formatted_email() {
+    let body = Some(
+        r#"
+        <html>
+            <body>
+                <div>
+                    <p>Hi John,</p>
+                    <p>Thank you for your inquiry about our services.</p>
+                    <p>Our team will get back to you within 24 hours.</p>
+                    <hr>
+                    <div style="color: gray; font-size: 12px;">
+                        <p>Example Corp.</p>
+                        <p>123 Business St.<br>Suite 100<br>San Francisco, CA 94107</p>
+                        <p>Phone: (555) 555-5555</p>
+                    </div>
+                </div>
+            </body>
+        </html>
+    "#
+        .to_string(),
+    );
+
+    let result = compute_body_parsed(true, &body);
+    assert!(result.is_some());
+    let text = result.unwrap();
+    assert!(text.contains("Hi John,"));
+    assert!(text.contains("Thank you for your inquiry"));
+    assert!(text.contains("Example Corp."));
+    assert!(text.contains("123 Business St."));
+}
+
+#[test]
+fn test_html_to_plaintext_inline_vs_block() {
+    // Inline tags stay on one line — no spurious break between the runs.
+    // Emphasis renders as markdown markers, matching the rest of our
+    // HTML->plaintext conversion.
+    assert_eq!(
+        html_to_plaintext("<div>Thanks <strong>Alice</strong></div>"),
+        Some("Thanks **Alice**".to_string())
+    );
+    // Block elements are separated by newlines.
+    assert_eq!(
+        html_to_plaintext("<div>Thanks</div><div>Alice</div>"),
+        Some("Thanks\nAlice".to_string())
+    );
+}
+
+#[test]
+fn test_rowspan_overhang_does_not_panic() {
+    // html2text 0.15.x panicked with "capacity overflow" on a rowspan
+    // extending past the last table row (tot_width underflow).
+    let body = Some("<table><th rowspan=\"5\"><tr>".to_string());
+    let result = compute_body_parsed_linkless(true, &body);
+    assert_eq!(result, Some(String::new()));
+}
+
+#[test]
+fn test_rowspan_zero_does_not_panic() {
+    // html2text panics with a divide-by-zero on rowspan="0" (still
+    // unfixed upstream as of 0.16.5). The catch_unwind wrapper must
+    // contain it and treat the body as unparseable.
+    let body = Some("<table><td rowspan=\"0\">x".to_string());
+    let result = compute_body_parsed_linkless(true, &body);
+    assert_eq!(result, None);
+}
+
+#[test]
+fn test_linkless_strips_brackets() {
+    let body = Some("<p>Visit <a href=\"https://example.com\">example</a></p>".to_string());
+    let result = compute_body_parsed_linkless(true, &body);
+    assert!(result.is_some());
+    let text = result.unwrap();
+    assert!(!text.contains('['));
+    assert!(!text.contains(']'));
+}

--- a/rust/cloud-storage/workspace-hack/Cargo.toml
+++ b/rust/cloud-storage/workspace-hack/Cargo.toml
@@ -82,6 +82,7 @@ num-integer = { version = "0.1", features = ["i128"] }
 num-traits = { version = "0.2", features = ["i128", "libm"] }
 once_cell = { version = "1" }
 percent-encoding = { version = "2" }
+phf = { version = "0.13", features = ["macros"] }
 phf_shared-594e8ee84c453af0 = { package = "phf_shared", version = "0.13" }
 phf_shared-93f6ce9d446188ac = { package = "phf_shared", version = "0.10" }
 prost = { version = "0.12", features = ["prost-derive"] }
@@ -201,6 +202,7 @@ num-integer = { version = "0.1", features = ["i128"] }
 num-traits = { version = "0.2", features = ["i128", "libm"] }
 once_cell = { version = "1" }
 percent-encoding = { version = "2" }
+phf = { version = "0.13", features = ["macros"] }
 phf_shared-594e8ee84c453af0 = { package = "phf_shared", version = "0.13" }
 phf_shared-93f6ce9d446188ac = { package = "phf_shared", version = "0.10" }
 prettyplease = { version = "0.2", default-features = false, features = ["verbatim"] }


### PR DESCRIPTION
Prod SPS workers crash-loop with a `capacity overflow` panic whenever an email's HTML contains a table rowspan overhanging the last row: html2text 0.15 underflows `tot_width` (text_renderer.rs:1929), wraps to `usize::MAX` in release, and `BorderHoriz::new` explodes. Each panic kills the up-to-10 messages sharing the worker batch, which is how ~130k email messages ended up in the search-event DLQ. Upgrades html2text to 0.16 (underflow fixed upstream, verified by 500k-iteration fuzz) and wraps the conversion in `catch_unwind` so remaining html2text panics (`rowspan="0"` divide-by-zero is still unfixed upstream) degrade to an unparseable body instead of crashing the worker.
