### PR TITLE
fix(tags): show row tags to the left of the project breadcrumb

### DIFF
--- a/js/app/packages/entity/src/composed/list-entity/wide-layout.tsx
+++ b/js/app/packages/entity/src/composed/list-entity/wide-layout.tsx
@@ -168,16 +168,6 @@ export function WideLayout(props: LayoutProps) {
             />
           )}
         </Show>
-        <Show when={isProjectContainedEntity(props.entity) && props.entity}>
-          {(entity) => (
-            <span class="ph-no-capture text-ink-extra-muted text-xs">
-              <ProjectBreadCrumb
-                entity={entity()}
-                onClick={props.onProjectClick}
-              />
-            </span>
-          )}
-        </Show>
         <Show
           when={
             props.isShared && !owningInbox() && !isGithubPrEntity(props.entity)
@@ -246,6 +236,16 @@ export function WideLayout(props: LayoutProps) {
               entityType={EntityType.CHAT}
               properties={entity().properties}
             />
+          )}
+        </Show>
+        <Show when={isProjectContainedEntity(props.entity) && props.entity}>
+          {(entity) => (
+            <span class="ph-no-capture text-ink-extra-muted text-xs">
+              <ProjectBreadCrumb
+                entity={entity()}
+                onClick={props.onProjectClick}
+              />
+            </span>
           )}
         </Show>
       </Entity.Slot>


### PR DESCRIPTION
Follow-up to #4611: the tags-left-of-breadcrumb placement was only applied to project rows. Move ProjectBreadCrumb to the end of the row meta slot so document/email/chat tags render to its left too (e.g. files inside a folder).
