### PR TITLE
fix(channel): mark-done should not conflate channel and channel_thread

### DIFF
--- a/js/app/packages/app/component/next-soup/actions/make-mark-done-action.ts
+++ b/js/app/packages/app/component/next-soup/actions/make-mark-done-action.ts
@@ -7,14 +7,8 @@ import {
   restoreSoupFocus,
 } from '@app/component/next-soup/utils';
 import { useMaybePreviewPanel } from '@app/component/PreviewPanel';
-import { useSplitPanel } from '@app/component/split-layout/layoutUtils';
 import type { ListView } from '@app/constants/list-views';
-import { useFeatureFlag } from '@app/lib/analytics/posthog';
 import { toast } from '@core/component/Toast/Toast';
-import {
-  ENABLE_NEW_INBOX_FLAG,
-  ENABLE_NEW_INBOX_OVERRIDE,
-} from '@core/constant/featureFlags';
 import type { HotkeyGroup } from '@core/hotkey/types';
 import type { EntityData } from '@entity';
 import type { NotificationSource } from '@notifications';
@@ -61,24 +55,6 @@ type MarkDoneExecuteOpts = Pick<MarkDoneVariables, 'silent' | 'onUndoHandle'>;
 
 /** Must be invoked inside a component tree that provides MutationUndoProvider. */
 export const makeMarkDoneAction = (options: MakeMarkDoneOptions) => {
-  const splitPanel = useSplitPanel();
-
-  const newInboxFlag = useFeatureFlag(ENABLE_NEW_INBOX_FLAG, {
-    enabledOverride: ENABLE_NEW_INBOX_OVERRIDE,
-  });
-
-  // Channel and channel_thread entities share the same notification bucket.
-  // The new inbox renders them as separate rows, so marking a channel as done
-  // should not clear thread notifications.
-  //
-  // TODO: This should probably be the default case after the new inbox is released
-  // or we should rework how notifications are sent to not be under just the 'channel'
-  // entity
-  const scopeChannelNotificationsToEntity = () =>
-    newInboxFlag().enabled &&
-    (splitPanel?.handle.content().id === 'inbox' ||
-      splitPanel?.handle.referredFrom() === 'inbox');
-
   const { notificationSource, hotkeyGroup } = options;
   const previewPanel = useMaybePreviewPanel();
   const inPreview = previewPanel !== undefined;
@@ -175,7 +151,7 @@ export const makeMarkDoneAction = (options: MakeMarkDoneOptions) => {
       return false;
     }
     if (entity.type === 'channel_thread') {
-      return scopeChannelNotificationsToEntity();
+      return true;
     }
     if (
       entity.type === 'email' ||
@@ -199,7 +175,10 @@ export const makeMarkDoneAction = (options: MakeMarkDoneOptions) => {
     const { emailIds, notificationIds } = resolveMarkEntitiesDoneVariables({
       entities,
       notificationSource: notificationSource(),
-      scopeChannelNotificationsToEntity: scopeChannelNotificationsToEntity(),
+      // Channel and channel_thread entities share the same notification
+      // bucket: scope so marking a channel done doesn't clear thread
+      // notifications, and marking a thread done only targets that thread.
+      scopeChannelNotificationsToEntity: true,
     });
     await mutation.mutateAsync({
       entities,


### PR DESCRIPTION
## Why

Two related internal bug reports:
- "not able to mark Channel Threads as done"
- "marking the main channel as done, marks the Channel Thread as done"

Channel and channel_thread entities share the same notification bucket. The scoping logic that separates them (`resolveMarkEntitiesDoneVariables` / `scopeChannelNotificationsForEntity` in `utils.ts`) already existed and is already tested, but it was only applied when an unrelated new-inbox feature flag was on *and* the action was invoked from the Inbox split panel specifically. Everywhere else, marking a channel_thread done was disabled outright (`canExecute` returned `false`), and marking a channel done cleared its threads' notifications along with it.

## What changed

In `make-mark-done-action.ts`:
- `channel_thread` entities can now always execute mark-done (dropped the feature-flag + split-panel gate).
- `scopeChannelNotificationsToEntity` is now always passed as `true`, so channel and channel_thread mark-done are independent — matching a TODO already left in the code ("This should probably be the default case after the new inbox is released").

No backend/schema change — the notification metadata this relies on (`thread_id`/`message_id`) was already populated.

Fixes MACRO-2232.

## Test plan
- [ ] Mark a channel done → its channel_thread notifications remain
- [ ] Mark a channel_thread done directly → only that thread's notifications clear
- [ ] Undo still restores both cases correctly

🤖 Generated by an automated quick-wins routine. I'm watching this PR and will act on review comments.