### PR TITLE
fix(soup): reduce date-group header padding

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/section-header.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/section-header.tsx
@@ -16,7 +16,7 @@ export const SoupSectionHeader = (props: {
         onClick={props.onClick}
         data-highlighted={props.highlighted || undefined}
         class={cn(
-          'group/header relative w-[calc(100%-0.5rem)] mx-1 my-0.5 rounded-lg px-2 py-2 flex items-center gap-2.5 text-xs font-semibold tracking-tight',
+          'group/header relative w-[calc(100%-0.5rem)] mx-1 my-0.5 rounded-lg px-2 py-1.5 flex items-center gap-2.5 text-xs font-semibold tracking-tight',
           'text-text-muted bg-surface border border-edge-muted relative',
           props.onClick && 'hover:bg-active',
           props.class,


### PR DESCRIPTION
## Why

Internal report: the date-group section header (used for inbox date dividers, task-group headers, and CRM stage headers via the shared `SoupSectionHeader`) reads noticeably taller/more padded than surrounding rows.

## What changed

Trimmed `SoupSectionHeader`'s vertical padding from `py-2` to `py-1.5`. This is a shared component, so the change applies consistently across inbox, tasks, and CRM group headers.

## Scope note

The same report also flagged the caret/chevron not feeling aligned. That's left out of this PR — the chevron is a third-party phosphor asset already centered in its own box, and nailing the alignment nit needs a visual pass against real data rather than a blind CSS change. Filed as a follow-up on MACRO-2270.

## Test plan
- [ ] Visually compare inbox date headers, task-group headers, and CRM stage headers before/after

🤖 Generated by an automated quick-wins routine. I'm watching this PR and will act on review comments.