### PR TITLE
feat(channel): add copy-text button to desktop message action menu

### DIFF
--- a/js/app/packages/channel/Message/ActionMenu.tsx
+++ b/js/app/packages/channel/Message/ActionMenu.tsx
@@ -2,6 +2,7 @@ import { recordEmojiUsage } from '@core/component/Emoji/emojiUsage';
 import StarIcon from '@icon/wide-star.svg';
 import TaskIcon from '@icon/wide-task.svg';
 import ReplyIcon from '@phosphor/arrow-bend-up-left.svg';
+import CopyIcon from '@phosphor/copy.svg';
 import LinkIcon from '@phosphor/link.svg';
 import EditIcon from '@phosphor/pencil-simple.svg';
 import AddEmojiIcon from '@phosphor/smiley.svg';
@@ -19,6 +20,7 @@ const QUICK_REACTION_EMOJIS = ['❤️', '👍', '😂'] as const;
 type ActionId =
   | 'reply'
   | 'copy-link'
+  | 'copy-message-text'
   | 'create-task'
   | 'chat'
   | 'edit'
@@ -102,6 +104,13 @@ export function ActionMenu(props: ActionMenuProps) {
       label: 'Copy Link',
       icon: LinkIcon,
       onClick: actions?.onCopyLink,
+      iconClass: 'size-3.5',
+    },
+    {
+      id: 'copy-message-text',
+      label: 'Copy Text',
+      icon: CopyIcon,
+      onClick: actions?.onCopyMessageText,
       iconClass: 'size-3.5',
     },
     {


### PR DESCRIPTION
## Why

Internal feature request: "copy text button for channel message ribbon?"

Turns out this was already fully built server-side of the UI: `onCopyMessageText` is implemented in `createChannelMessageActions` (clipboard copy + success/failure toasts), and mobile's `ActionDrawer.tsx` already has a `copy-message-text` button wired to it. Desktop's hover `ActionMenu.tsx` just never added the equivalent button — a parity gap, not missing plumbing.

## What changed

Added a "Copy Text" button to the desktop message hover action menu, mirroring the mobile action drawer's existing action 1:1 (same `@phosphor/copy.svg` icon, same `onCopyMessageText` handler).

Fixes MACRO-2271.

## Test plan
- [ ] Hover a channel message on desktop → "Copy Text" button appears next to "Copy Link"
- [ ] Click it → message text copied to clipboard, success toast shown
- [ ] Deleted / empty messages → button does not appear (handler is `undefined` when `!isDeleted && message.content` is false, same guard as before)

🤖 Generated by an automated quick-wins routine. I'm watching this PR and will act on review comments.