### PR TITLE
fix(tags): exclude Tag definitions from property pickers

### DIFF
--- a/js/app/packages/app/component/property-edit-modal/PropertyEditorModal.tsx
+++ b/js/app/packages/app/component/property-edit-modal/PropertyEditorModal.tsx
@@ -365,7 +365,7 @@ function PropertyValueEditor(props: {
     value: string | number | boolean | Date | EntityReference
   ) => {
     const type = propertyType();
-    if (!type) return;
+    if (!type || type === 'TAG') return;
     let apiValues = toPropertyApiValue({ valueType: type }, value);
     if (!apiValues) return;
     props.onSave(apiValues);

--- a/js/app/packages/property/src/hooks/usePropertySelection.ts
+++ b/js/app/packages/property/src/hooks/usePropertySelection.ts
@@ -27,7 +27,7 @@ export function usePropertySelection(
         property.specificEntityType !== 'COMPANY' &&
         // Tag definitions are managed through the dedicated Tags UI, never the
         // generic property pickers.
-        (property.valueType as string) !== 'TAG'
+        property.valueType !== 'TAG'
     );
 
     // Then apply search filter

--- a/js/app/packages/property/src/hooks/usePropertySelection.ts
+++ b/js/app/packages/property/src/hooks/usePropertySelection.ts
@@ -24,7 +24,10 @@ export function usePropertySelection(
         property.id &&
         !existingIds.has(property.id) &&
         // COMPANY entity properties not yet implemented
-        property.specificEntityType !== 'COMPANY'
+        property.specificEntityType !== 'COMPANY' &&
+        // Tag definitions are managed through the dedicated Tags UI, never the
+        // generic property pickers.
+        (property.valueType as string) !== 'TAG'
     );
 
     // Then apply search filter

--- a/js/app/packages/property/src/types.ts
+++ b/js/app/packages/property/src/types.ts
@@ -15,6 +15,7 @@
  */
 import type { BlockName } from '@core/block';
 import type { DateValue } from '@core/util/date';
+import type { DataType } from '@service-properties/generated/schemas/dataType';
 import type { EntityReference } from '@service-properties/generated/schemas/entityReference';
 import type { EntityType } from '@service-properties/generated/schemas/entityType';
 import type { PropertyOption } from '@service-properties/generated/schemas/propertyOption';
@@ -103,8 +104,9 @@ export type SelectProperty = SelectStringProperty | SelectNumberProperty;
  * This is the UI layer representation of a property definition.
  * Use `toPropertyDefinitionDomain` to transform from API types.
  *
- * Note: Uses `valueType` to match the `Property` type, enabling shared
- * components like `PropertyDataTypeIcon` to work with both types.
+ * Note: `valueType` carries the definition's full `DataType` (including
+ * `TAG`), a superset of the narrow value discriminator on `Property`. The
+ * shared name lets components like `PropertyDataTypeIcon` accept both types.
  *
  * @see PropertyDefinition - Generated API type (snake_case)
  * @see Property - Domain type for property instances with values
@@ -112,7 +114,7 @@ export type SelectProperty = SelectStringProperty | SelectNumberProperty;
 export type PropertyDefinitionDomain = {
   id: string;
   displayName: string;
-  valueType: ValueType;
+  valueType: DataType;
   isMultiSelect: boolean;
   isMetadata: boolean;
   isSystem: boolean;

--- a/js/app/packages/property/src/utils/PropertyDataTypeIcon.tsx
+++ b/js/app/packages/property/src/utils/PropertyDataTypeIcon.tsx
@@ -17,10 +17,10 @@ import type { Component } from 'solid-js';
 import { Dynamic } from 'solid-js/web';
 import { twMerge } from 'tailwind-merge';
 import { match } from 'ts-pattern';
-import type { Property } from '../types';
+import type { PropertyDefinitionDomain } from '../types';
 
 const EntityDataTypeIcon: Component<{
-  property: Pick<Property, 'specificEntityType'>;
+  property: Pick<PropertyDefinitionDomain, 'specificEntityType'>;
   class?: string;
 }> = (props) => {
   const iconClass = () => twMerge('size-4 text-ink-muted', props.class);
@@ -40,7 +40,7 @@ const EntityDataTypeIcon: Component<{
 };
 
 export const PropertyDataTypeIcon: Component<{
-  property: Pick<Property, 'valueType' | 'specificEntityType'>;
+  property: Pick<PropertyDefinitionDomain, 'valueType' | 'specificEntityType'>;
   class?: string;
 }> = (props) => {
   const iconClass = () => twMerge('size-4 text-ink-muted', props.class);

--- a/js/app/packages/property/src/utils/transforms.ts
+++ b/js/app/packages/property/src/utils/transforms.ts
@@ -1,7 +1,6 @@
 import type { PropertyDefinition } from '@service-properties/generated/schemas/propertyDefinition';
 import type { PropertyOption } from '@service-properties/generated/schemas/propertyOption';
-import { nanoid } from 'nanoid';
-import type { Property, PropertyDefinitionDomain, ValueType } from '../types';
+import type { PropertyDefinitionDomain } from '../types';
 
 /**
  * Transforms a backend PropertyDefinition (snake_case) to the frontend
@@ -20,7 +19,7 @@ export function toPropertyDefinitionDomain(
   return {
     id: definition.id,
     displayName: definition.display_name,
-    valueType: definition.data_type as ValueType,
+    valueType: definition.data_type,
     isMultiSelect: definition.is_multi_select,
     isMetadata: definition.is_metadata,
     isSystem: definition.is_system,
@@ -29,25 +28,5 @@ export function toPropertyDefinitionDomain(
     options,
     createdAt: definition.created_at,
     updatedAt: definition.updated_at,
-  };
-}
-
-function _propertyDefinitionDomainToProperty(
-  propertyDefinition: PropertyDefinitionDomain
-): Property {
-  return {
-    propertyId: nanoid(8),
-    propertyDefinitionId: propertyDefinition.id,
-    displayName: propertyDefinition.displayName,
-    isMultiSelect: propertyDefinition.isMultiSelect,
-    isMetadata: propertyDefinition.isMetadata,
-    isSystemProperty: propertyDefinition.isSystem,
-    options: propertyDefinition.options,
-    owner: propertyDefinition.owner,
-    specificEntityType: propertyDefinition.specificEntityType,
-    createdAt: propertyDefinition.createdAt,
-    updatedAt: propertyDefinition.updatedAt,
-    valueType: propertyDefinition.valueType,
-    value: null,
   };
 }


### PR DESCRIPTION
The property pickers ("Add a property…" and "Choose a property…") listed Tag-typed definitions, surfacing duplicate "Tags" rows since tags are managed through their own dedicated UI. Filter them out of the shared property selection hook alongside the existing COMPANY exclusion.

Second commit types `PropertyDefinitionDomain.valueType` as the backend `DataType` (which legitimately includes `TAG`) instead of the narrow value discriminator, dropping the casts this required and removing some dead code.
