### PR TITLE
Gate CRM settings tab behind ENABLE_CRM feature flag

### DIFF
--- a/js/app/packages/core/constant/settingsTabsConfig.tsx
+++ b/js/app/packages/core/constant/settingsTabsConfig.tsx
@@ -16,6 +16,7 @@ import { isTouchDevice } from '../mobile/isTouchDevice';
 import {
   DEV_MODE_ENV,
   ENABLE_APP_STORE_QR_CODE,
+  ENABLE_CRM,
   ENABLE_TEAMS_OVERRIDE,
 } from './featureFlags';
 import { PERMISSION_IDS } from './permissions';
@@ -144,8 +145,12 @@ export const useSettingsTabAvailable = () => {
       case 'Billing':
         return true;
       case 'Team':
-      case 'CRM':
         return teamsFlag().enabled;
+      // CRM is still rolling out (Macro-internal only); keep the settings tab
+      // behind the same ENABLE_CRM gate as every other CRM surface so it never
+      // leaks into teams that can't actually use the CRM.
+      case 'CRM':
+        return teamsFlag().enabled && ENABLE_CRM;
       case 'Connected':
         return true;
       case 'Shortcuts':


### PR DESCRIPTION
## Summary
Added feature flag gating to the CRM settings tab to prevent it from appearing in teams that don't have access to the CRM feature during its rollout phase.

## Changes
- Imported the `ENABLE_CRM` feature flag constant
- Modified the CRM settings tab availability check to require both `teamsFlag().enabled` AND `ENABLE_CRM` to be true
- Separated the CRM case from the Team case in the settings tab availability logic
- Added clarifying comments explaining that CRM is still rolling out and needs to be gated consistently across all CRM surfaces

## Implementation Details
The CRM settings tab now uses a stricter availability condition (`teamsFlag().enabled && ENABLE_CRM`) compared to the Team settings tab (`teamsFlag().enabled`). This ensures the CRM settings tab remains hidden from teams that don't have the feature enabled, maintaining consistency with other CRM UI surfaces that are already behind the same feature flag.

https://claude.ai/code/session_01VKxtgKvEno7sdYwJgXCLZs