### PR TITLE
fix linux desktop TLS backend packaging

### DIFF
--- a/nix/tauri-desktop.nix
+++ b/nix/tauri-desktop.nix
@@ -211,6 +211,7 @@
         buildPhase = ''
           cat > linuxdeploy-wrapper.c <<'EOF'
           #include <dirent.h>
+          #include <errno.h>
           #include <stdio.h>
           #include <stdlib.h>
           #include <sys/stat.h>
@@ -252,35 +253,67 @@
             closedir(dir);
           }
 
-          static void install_gio_tls_hook(const char *appdir) {
-            if (appdir == NULL) return;
+          static int install_gio_tls_hook(const char *appdir) {
+            if (appdir == NULL) {
+              fprintf(stderr, "cannot install TLS hook: missing --appdir\n");
+              return 1;
+            }
 
             size_t appdir_len = strlen(appdir);
             char *hooks_dir = malloc(appdir_len + strlen("/apprun-hooks") + 1);
+            if (hooks_dir == NULL) {
+              perror("malloc TLS hook directory");
+              return 1;
+            }
             sprintf(hooks_dir, "%s/apprun-hooks", appdir);
-            mkdir(hooks_dir, 0755);
+            if (mkdir(hooks_dir, 0755) != 0 && errno != EEXIST) {
+              perror("mkdir TLS hook directory");
+              free(hooks_dir);
+              return 1;
+            }
 
             char *hook_path = malloc(strlen(hooks_dir) + strlen("/macro-gio-tls.sh") + 2);
+            if (hook_path == NULL) {
+              perror("malloc TLS hook path");
+              free(hooks_dir);
+              return 1;
+            }
             sprintf(hook_path, "%s/macro-gio-tls.sh", hooks_dir);
 
             FILE *hook = fopen(hook_path, "w");
-            if (hook != NULL) {
-              fputs("#! /usr/bin/env bash\n"
-                    "export APPDIR=\"''${APPDIR:-\"$(dirname \"$(realpath \"$0\")\")\"}\"\n"
-                    "gio_modules=\"$APPDIR/usr/lib/gio/modules\"\n"
-                    "if [ -d \"$gio_modules\" ]; then\n"
-                    "  case \":''${GIO_EXTRA_MODULES:-}:\" in\n"
-                    "    *:\"$gio_modules\":*) ;;\n"
-                    "    *) export GIO_EXTRA_MODULES=\"$gio_modules''${GIO_EXTRA_MODULES:+:$GIO_EXTRA_MODULES}\" ;;\n"
-                    "  esac\n"
-                    "fi\n",
-                    hook);
-              fclose(hook);
-              chmod(hook_path, 0755);
+            if (hook == NULL) {
+              perror("fopen TLS hook");
+              free(hook_path);
+              free(hooks_dir);
+              return 1;
+            }
+
+            int failed = 0;
+            if (fputs("#! /usr/bin/env bash\n"
+                      "export APPDIR=\"''${APPDIR:-\"$(dirname \"$(realpath \"$0\")\")\"}\"\n"
+                      "gio_modules=\"$APPDIR/usr/lib/gio/modules\"\n"
+                      "if [ -d \"$gio_modules\" ]; then\n"
+                      "  case \":''${GIO_EXTRA_MODULES:-}:\" in\n"
+                      "    *:\"$gio_modules\":*) ;;\n"
+                      "    *) export GIO_EXTRA_MODULES=\"$gio_modules''${GIO_EXTRA_MODULES:+:$GIO_EXTRA_MODULES}\" ;;\n"
+                      "  esac\n"
+                      "fi\n",
+                      hook) == EOF) {
+              perror("write TLS hook");
+              failed = 1;
+            }
+            if (fclose(hook) != 0) {
+              perror("close TLS hook");
+              failed = 1;
+            }
+            if (!failed && chmod(hook_path, 0755) != 0) {
+              perror("chmod TLS hook");
+              failed = 1;
             }
 
             free(hook_path);
             free(hooks_dir);
+            return failed;
           }
 
           int main(int argc, char **argv) {
@@ -293,7 +326,9 @@
               }
             }
             sanitize_appdir(appdir);
-            install_gio_tls_hook(appdir);
+            if (install_gio_tls_hook(appdir) != 0) {
+              return 1;
+            }
 
             char *slash = strrchr(argv[0], '/');
             if (slash != NULL) {

--- a/nix/tauri-desktop.nix
+++ b/nix/tauri-desktop.nix
@@ -140,6 +140,8 @@
         '';
       };
 
+      gioTlsModulePath = "${pkgs.glib-networking}/lib/gio/modules";
+
       wrappedTauriDesktop = pkgs.symlinkJoin {
         name = "macro-tauri-desktop-${appVersion}";
         paths = [ tauri.app ];
@@ -165,8 +167,10 @@
                 pkgs.gst_all_1.gst-plugins-bad
                 pkgs.gst_all_1.gst-libav
                 pkgs.openssl
+                pkgs.glib-networking
               ]
             } \
+            --prefix GIO_EXTRA_MODULES : "${gioTlsModulePath}" \
             --prefix XDG_DATA_DIRS : "${pkgs.gsettings-desktop-schemas}/share/gsettings-schemas/${pkgs.gsettings-desktop-schemas.name}:${pkgs.gtk3}/share/gsettings-schemas/${pkgs.gtk3.name}" \
             --prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "${
               lib.makeSearchPathOutput "lib" "lib/gstreamer-1.0" [
@@ -209,6 +213,7 @@
           #include <dirent.h>
           #include <stdio.h>
           #include <stdlib.h>
+          #include <sys/stat.h>
           #include <string.h>
           #include <unistd.h>
 
@@ -247,6 +252,37 @@
             closedir(dir);
           }
 
+          static void install_gio_tls_hook(const char *appdir) {
+            if (appdir == NULL) return;
+
+            size_t appdir_len = strlen(appdir);
+            char *hooks_dir = malloc(appdir_len + strlen("/apprun-hooks") + 1);
+            sprintf(hooks_dir, "%s/apprun-hooks", appdir);
+            mkdir(hooks_dir, 0755);
+
+            char *hook_path = malloc(strlen(hooks_dir) + strlen("/macro-gio-tls.sh") + 2);
+            sprintf(hook_path, "%s/macro-gio-tls.sh", hooks_dir);
+
+            FILE *hook = fopen(hook_path, "w");
+            if (hook != NULL) {
+              fputs("#! /usr/bin/env bash\n"
+                    "export APPDIR=\"''${APPDIR:-\"$(dirname \"$(realpath \"$0\")\")\"}\"\n"
+                    "gio_modules=\"$APPDIR/usr/lib/gio/modules\"\n"
+                    "if [ -d \"$gio_modules\" ]; then\n"
+                    "  case \":''${GIO_EXTRA_MODULES:-}:\" in\n"
+                    "    *:\"$gio_modules\":*) ;;\n"
+                    "    *) export GIO_EXTRA_MODULES=\"$gio_modules''${GIO_EXTRA_MODULES:+:$GIO_EXTRA_MODULES}\" ;;\n"
+                    "  esac\n"
+                    "fi\n",
+                    hook);
+              fclose(hook);
+              chmod(hook_path, 0755);
+            }
+
+            free(hook_path);
+            free(hooks_dir);
+          }
+
           int main(int argc, char **argv) {
             const char *appdir = NULL;
             for (int i = 1; i < argc; i++) {
@@ -257,6 +293,7 @@
               }
             }
             sanitize_appdir(appdir);
+            install_gio_tls_hook(appdir);
 
             char *slash = strrchr(argv[0], '/');
             if (slash != NULL) {
@@ -347,6 +384,7 @@
         pkgs.gst_all_1.gst-plugins-bad
         pkgs.gst_all_1.gst-libav
         pkgs.openssl
+        pkgs.glib-networking
       ];
       tauriRuntimeLibraryPath = lib.makeLibraryPath tauriRuntimeLibraries;
       tauriRuntimeClosure = pkgs.closureInfo {
@@ -364,6 +402,10 @@
           linux.appimage.files = {
             "/usr/bin/xdg-mime" = "${pkgs.xdg-utils}/bin/xdg-mime";
             "/usr/bin/xdg-open" = "${pkgs.xdg-utils}/bin/xdg-open";
+            "/usr/lib/gio/modules/giomodule.cache" = "${pkgs.glib-networking}/lib/gio/modules/giomodule.cache";
+            "/usr/lib/gio/modules/libgiognomeproxy.so" = "${pkgs.glib-networking}/lib/gio/modules/libgiognomeproxy.so";
+            "/usr/lib/gio/modules/libgiognutls.so" = "${pkgs.glib-networking}/lib/gio/modules/libgiognutls.so";
+            "/usr/lib/gio/modules/libgiolibproxy.so" = "${pkgs.glib-networking}/lib/gio/modules/libgiolibproxy.so";
           };
         };
       };


### PR DESCRIPTION
This PR adds the missing TLS implementation to the linux desktop runtime such that the macro desktop app webview is able to create https connections.