### PR TITLE
fix(local): run_local nix env guard and lexical-service bundling

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -461,7 +461,9 @@ services:
     # worker is run normally — wrangler/esbuild bundles it first). loro-crdt
     # stays external: bundling it emits its .wasm as a second output file
     # (breaking --outfile) and mis-wires the wasm instantiation at runtime.
-    command: ["sh", "-c", "bun build src/server.ts --target=bun --external loro-crdt --outfile=/tmp/server.js && exec bun /tmp/server.js"]
+    # The bundle must live under /app: bun resolves the external loro-crdt
+    # import relative to the bundle's path, so it needs /app/node_modules.
+    command: ["sh", "-c", "bun build src/server.ts --target=bun --external loro-crdt --outfile=/app/server.bundle.js && exec bun /app/server.bundle.js"]
     environment:
       - PORT=8096
       - INTERNAL_AUTH_KEY=${INTERNAL_API_SECRET_KEY}

--- a/js/bun.lock
+++ b/js/bun.lock
@@ -365,6 +365,10 @@
       "name": "lexical-service",
       "version": "0.0.1",
       "dependencies": {
+        "@ai-sdk/anthropic": "^3.0.85",
+        "@ai-sdk/cerebras": "^2.0.57",
+        "@ai-sdk/google": "^3.0.83",
+        "@ai-sdk/openai": "^3.0.73",
         "@lexical/code": "0.45.0",
         "@lexical/headless": "0.45.0",
         "@lexical/history": "0.45.0",
@@ -378,12 +382,21 @@
         "@lexical/selection": "0.45.0",
         "@lexical/table": "0.45.0",
         "@lexical/utils": "0.45.0",
+        "ai": "^6.0.207",
+        "bitf": "^1.0.2",
         "chanfana": "^3.3.0",
+        "diff": "^9.0.0",
+        "envsafe": "^2.0.3",
+        "fast-xml-parser": "^4.5.6",
+        "flat": "^6.0.1",
         "hono": "^4.6.20",
         "immer": "^10.0.3",
         "lexical": "0.45.0",
         "loro-crdt": "1.13.3",
         "nanoid": "^5.1.5",
+        "p-queue": "^9.3.0",
+        "random-js": "^2.1.0",
+        "ts-pattern": "^5.9.0",
         "zod": "^4.3.6",
       },
       "devDependencies": {
@@ -1023,7 +1036,7 @@
 
     "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
 
-    "@inkibra/tauri-plugins": ["@inkibra/tauri-plugins@github:macro-inc/tauri-plugins#26537c8", { "dependencies": { "react": "^18.3.1", "react-dom": "^18.3.1" } }, "macro-inc-tauri-plugins-26537c8", "sha512-6p5xQAkS6Uw6J8Uh0vlj6MjKZXWps5E1Gu0hciBFq1E2BfPBZAgdeeafKnR3diNb4SXWK0JML49nAr+o5PhwKw=="],
+    "@inkibra/tauri-plugins": ["@inkibra/tauri-plugins@github:macro-inc/tauri-plugins#26537c8", { "dependencies": { "react": "^18.3.1", "react-dom": "^18.3.1" } }, "macro-inc-tauri-plugins-26537c8"],
 
     "@inquirer/ansi": ["@inquirer/ansi@2.0.7", "", {}, "sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q=="],
 
@@ -2959,7 +2972,7 @@
 
     "pathval": ["pathval@2.0.1", "", {}, "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ=="],
 
-    "pdfjs-dist": ["pdfjs-dist@github:macro-inc/pdf.js#f9b2ce6", { "dependencies": { "dommatrix": "^1.0.3", "web-streams-polyfill": "^3.2.1" }, "peerDependencies": { "worker-loader": "^3.0.8" }, "optionalPeers": ["worker-loader"] }, "macro-inc-pdf.js-f9b2ce6", "sha512-HDFaPbCxLG2GHpf1smUG97nku5aPGBGaCcIbK05dGdp07TBLUlDcXsM4WcE82mO5W4RBPIBVYobX5N/6M6NFrA=="],
+    "pdfjs-dist": ["pdfjs-dist@github:macro-inc/pdf.js#f9b2ce6", { "dependencies": { "dommatrix": "^1.0.3", "web-streams-polyfill": "^3.2.1" }, "peerDependencies": { "worker-loader": "^3.0.8" }, "optionalPeers": ["worker-loader"] }, "macro-inc-pdf.js-f9b2ce6"],
 
     "performance-now": ["performance-now@2.1.0", "", {}, "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="],
 

--- a/js/lexical-service/package.json
+++ b/js/lexical-service/package.json
@@ -17,6 +17,10 @@
 		"check": "tsc --noEmit --project tsconfig.check.json"
 	},
 	"dependencies": {
+		"@ai-sdk/anthropic": "^3.0.85",
+		"@ai-sdk/cerebras": "^2.0.57",
+		"@ai-sdk/google": "^3.0.83",
+		"@ai-sdk/openai": "^3.0.73",
 		"@lexical/code": "0.45.0",
 		"@lexical/headless": "0.45.0",
 		"@lexical/history": "0.45.0",
@@ -30,12 +34,21 @@
 		"@lexical/selection": "0.45.0",
 		"@lexical/table": "0.45.0",
 		"@lexical/utils": "0.45.0",
+		"ai": "^6.0.207",
+		"bitf": "^1.0.2",
 		"chanfana": "^3.3.0",
+		"diff": "^9.0.0",
+		"envsafe": "^2.0.3",
+		"fast-xml-parser": "^4.5.6",
+		"flat": "^6.0.1",
 		"hono": "^4.6.20",
 		"immer": "^10.0.3",
 		"lexical": "0.45.0",
 		"loro-crdt": "1.13.3",
 		"nanoid": "^5.1.5",
+		"p-queue": "^9.3.0",
+		"random-js": "^2.1.0",
+		"ts-pattern": "^5.9.0",
 		"zod": "^4.3.6"
 	},
 	"devDependencies": {

--- a/nix/cloud-storage.nix
+++ b/nix/cloud-storage.nix
@@ -835,8 +835,9 @@
               CFLAGS_x86_64_unknown_linux_gnu = "-I${pkgs.curl.dev}/include";
               CXXFLAGS_x86_64_unknown_linux_gnu = "-I${pkgs.curl.dev}/include";
               # Default for local SQLx/cargo workflows so individual crates do
-              # not need their own .env files. The run-dev env resolver ignores
-              # this localhost default so Doppler's dev DATABASE_URL wins.
+              # not need their own .env files. The run-local/run-dev env
+              # resolver ignores this localhost default: run-dev needs
+              # Doppler's dev DATABASE_URL, run-local its container-side URL.
               DATABASE_URL = "postgres://user:password@localhost:5432/macrodb";
             }
             // pkgs.lib.optionalAttrs isLinux {

--- a/rust/cloud-storage/tools/xtask/crates/xtask_local/src/local/env_layer.rs
+++ b/rust/cloud-storage/tools/xtask/crates/xtask_local/src/local/env_layer.rs
@@ -70,11 +70,12 @@ pub fn resolve(
 
     // Process env — override only keys already present, so a developer can
     // `FOO=bar just run_local` without dumping their whole environment in.
-    // For run-dev, do not let the Nix shell's localhost SQLx default replace
-    // Doppler's shared-dev database URL.
+    // Never let the Nix shell's localhost SQLx default through: run-dev needs
+    // Doppler's shared-dev database URL, and local injects this map into
+    // containers, where localhost cannot reach postgres.
     for key in env.keys().cloned().collect::<Vec<_>>() {
         if let Ok(v) = std::env::var(&key)
-            && should_overlay_process_env(mode, &key, &v)
+            && should_overlay_process_env(&key, &v)
         {
             env.insert(key, v);
         }
@@ -101,8 +102,8 @@ pub fn resolve(
     })
 }
 
-fn should_overlay_process_env(mode: Mode, key: &str, value: &str) -> bool {
-    !(mode == Mode::Dev && key == "DATABASE_URL" && is_local_database_url(value))
+fn should_overlay_process_env(key: &str, value: &str) -> bool {
+    !(key == "DATABASE_URL" && is_local_database_url(value))
 }
 
 pub(super) fn is_local_database_url(value: &str) -> bool {

--- a/rust/cloud-storage/tools/xtask/crates/xtask_local/src/local/env_layer/test.rs
+++ b/rust/cloud-storage/tools/xtask/crates/xtask_local/src/local/env_layer/test.rs
@@ -1,33 +1,21 @@
 use super::*;
 
 #[test]
-fn run_dev_keeps_doppler_database_url_when_shell_has_local_default() {
+fn keeps_resolved_database_url_when_shell_has_local_default() {
     assert!(!should_overlay_process_env(
-        Mode::Dev,
         "DATABASE_URL",
         "postgres://user:password@localhost:5432/macrodb"
     ));
     assert!(!should_overlay_process_env(
-        Mode::Dev,
         "DATABASE_URL",
         "postgres://user:password@postgres:5432/macrodb"
     ));
 }
 
 #[test]
-fn run_dev_still_allows_non_local_database_overrides() {
+fn still_allows_non_local_database_overrides() {
     assert!(should_overlay_process_env(
-        Mode::Dev,
         "DATABASE_URL",
         "postgres://user:password@dev.example.com:5432/macrodb"
-    ));
-}
-
-#[test]
-fn local_mode_keeps_local_database_override() {
-    assert!(should_overlay_process_env(
-        Mode::Local,
-        "DATABASE_URL",
-        "postgres://user:password@localhost:5432/macrodb"
     ));
 }


### PR DESCRIPTION
Fixes two run_local breakages: the nix shell's localhost DATABASE_URL default is now never overlaid onto the resolved env (it clobbered the container-side postgres URL in local mode, and Doppler's URL in dev), and lexical-service bundles to /app so its external loro-crdt import resolves against /app/node_modules, with the lexical-core deps the bundle imports added to its package.json.
