### PR TITLE
fix(tags): render tag chips as the leftmost meta accessory for all entity rows

### DIFF
--- a/js/app/packages/entity/src/composed/list-entity/wide-layout.tsx
+++ b/js/app/packages/entity/src/composed/list-entity/wide-layout.tsx
@@ -170,31 +170,6 @@ export function WideLayout(props: LayoutProps) {
         </Show>
         <Show
           when={
-            props.isShared && !owningInbox() && !isGithubPrEntity(props.entity)
-          }
-        >
-          <SharedBadge ownerId={props.entity.ownerId} />
-        </Show>
-        <Show when={isGithubPrEntity(props.entity) && props.entity}>
-          {(entity) => <GithubPullRequestPills entity={entity()} />}
-        </Show>
-        <Show when={isCallEntity(props.entity) && props.entity}>
-          {(entity) => (
-            <>
-              <Show when={(soupView?.activeTab() ?? 'all') === 'all'}>
-                <CallStatusBadge status={entity().status} />
-              </Show>
-              <span class="flex w-10 shrink-0 justify-end">
-                <CallParticipants participantIds={entity().participantIds} />
-              </span>
-            </>
-          )}
-        </Show>
-        <Show when={isTaskEntity(props.entity) && props.entity}>
-          {(entity) => <Entity.Properties entity={entity()} />}
-        </Show>
-        <Show
-          when={
             rowTagsVisible() && isDocumentEntity(props.entity) && props.entity
           }
         >
@@ -237,6 +212,31 @@ export function WideLayout(props: LayoutProps) {
               properties={entity().properties}
             />
           )}
+        </Show>
+        <Show
+          when={
+            props.isShared && !owningInbox() && !isGithubPrEntity(props.entity)
+          }
+        >
+          <SharedBadge ownerId={props.entity.ownerId} />
+        </Show>
+        <Show when={isGithubPrEntity(props.entity) && props.entity}>
+          {(entity) => <GithubPullRequestPills entity={entity()} />}
+        </Show>
+        <Show when={isCallEntity(props.entity) && props.entity}>
+          {(entity) => (
+            <>
+              <Show when={(soupView?.activeTab() ?? 'all') === 'all'}>
+                <CallStatusBadge status={entity().status} />
+              </Show>
+              <span class="flex w-10 shrink-0 justify-end">
+                <CallParticipants participantIds={entity().participantIds} />
+              </span>
+            </>
+          )}
+        </Show>
+        <Show when={isTaskEntity(props.entity) && props.entity}>
+          {(entity) => <Entity.Properties entity={entity()} />}
         </Show>
         <Show when={isProjectContainedEntity(props.entity) && props.entity}>
           {(entity) => (


### PR DESCRIPTION
Follow-up to #4648: move the document/email/chat tag blocks to the top of the row meta slot so tag chips are the leftmost accessory for every entity type. Previously task rows rendered their status/priority/assignee editors before the tags (visible in search), so tags were not left-aligned like other rows.
