### PR TITLE
fix(home): replace recommendation and example context

### DIFF
--- a/js/app/packages/app/component/home/home-composer-selection.test.ts
+++ b/js/app/packages/app/component/home/home-composer-selection.test.ts
@@ -1,0 +1,53 @@
+import type { Attachment } from '@core/component/AI/types';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  replaceHomeComposerDraft,
+  replaceHomeComposerSelection,
+} from './home-composer-selection';
+
+describe('replaceHomeComposerDraft', () => {
+  it('sets the selected draft as the complete editor value', () => {
+    const setMarkdown = vi.fn();
+
+    replaceHomeComposerDraft({ setMarkdown }, 'Selected prompt');
+
+    expect(setMarkdown).toHaveBeenCalledOnce();
+    expect(setMarkdown).toHaveBeenCalledWith('Selected prompt');
+  });
+});
+
+describe('replaceHomeComposerSelection', () => {
+  it('replaces attachments before setting the selected draft', () => {
+    const setAttached = vi.fn();
+    const setPendingDraft = vi.fn();
+    const attachment: Attachment = {
+      entity_id: 'document-1',
+      entity_type: 'document',
+    };
+
+    replaceHomeComposerSelection(
+      { attachments: { setAttached }, setPendingDraft },
+      'Review this document',
+      [attachment]
+    );
+
+    expect(setAttached).toHaveBeenCalledWith([attachment]);
+    expect(setAttached.mock.invocationCallOrder[0]).toBeLessThan(
+      setPendingDraft.mock.invocationCallOrder[0]
+    );
+    expect(setPendingDraft).toHaveBeenCalledWith('Review this document');
+  });
+
+  it('clears attachments for a selection without context', () => {
+    const setAttached = vi.fn();
+    const setPendingDraft = vi.fn();
+
+    replaceHomeComposerSelection(
+      { attachments: { setAttached }, setPendingDraft },
+      'Draft an email'
+    );
+
+    expect(setAttached).toHaveBeenCalledWith([]);
+    expect(setPendingDraft).toHaveBeenCalledWith('Draft an email');
+  });
+});

--- a/js/app/packages/app/component/home/home-composer-selection.ts
+++ b/js/app/packages/app/component/home/home-composer-selection.ts
@@ -1,0 +1,26 @@
+import type { Attachment, Attachments } from '@core/component/AI/types';
+
+type HomeComposerInput = {
+  attachments: Pick<Attachments, 'setAttached'>;
+  setPendingDraft: (text: string | null) => void;
+};
+
+type HomeComposerEditor = {
+  setMarkdown: (markdown: string) => void;
+};
+
+export function replaceHomeComposerSelection(
+  input: HomeComposerInput,
+  draft: string,
+  attachments: Attachment[] = []
+) {
+  input.attachments.setAttached(attachments);
+  input.setPendingDraft(draft);
+}
+
+export function replaceHomeComposerDraft(
+  editor: HomeComposerEditor,
+  draft: string
+) {
+  editor.setMarkdown(draft);
+}

--- a/js/app/packages/app/component/home/home-examples.tsx
+++ b/js/app/packages/app/component/home/home-examples.tsx
@@ -6,6 +6,7 @@ import { AnimatedSearchIcon } from '@icon/wide-search';
 import XIcon from '@phosphor/x.svg';
 import { createSignal, For, type JSX, Show } from 'solid-js';
 import { Dynamic } from 'solid-js/web';
+import { replaceHomeComposerSelection } from './home-composer-selection';
 import type { HomePreferences } from './home-prefs';
 
 type HomeExample = {
@@ -64,7 +65,9 @@ export function HomeExamples(props: { preferences: HomePreferences }) {
               <button
                 type="button"
                 class="group flex flex-col gap-1 rounded-xl border border-edge-muted bg-active p-3 text-left transition-colors hover:bg-hover"
-                onClick={() => input.setPendingDraft(example.prompt)}
+                onClick={() =>
+                  replaceHomeComposerSelection(input, example.prompt)
+                }
                 onMouseEnter={() => setHovered(i())}
                 onMouseLeave={() =>
                   setHovered((prev) => (prev === i() ? null : prev))

--- a/js/app/packages/app/component/home/home-hub.tsx
+++ b/js/app/packages/app/component/home/home-hub.tsx
@@ -18,6 +18,7 @@ import { useEmailLinksQuery } from '@queries/email/link';
 import { useMcpServersQuery } from '@queries/mcp-servers';
 import { useNavigate } from '@solidjs/router';
 import { For, Match, Show, Switch } from 'solid-js';
+import { replaceHomeComposerSelection } from './home-composer-selection';
 import type { HomePreferences } from './home-prefs';
 import { SetupRow } from './home-rows';
 
@@ -66,13 +67,13 @@ export function RecommendedSection() {
   };
 
   const selectRecommendation = (item: RecommendedItem) => {
-    if (ATTACHABLE_ENTITY_TYPES.has(item.entityType)) {
-      input.attachments.addAttachment({
-        entity_id: item.entityId,
-        entity_type: item.entityType,
-      });
-    }
-    input.setPendingDraft(item.prompt);
+    replaceHomeComposerSelection(
+      input,
+      item.prompt,
+      ATTACHABLE_ENTITY_TYPES.has(item.entityType)
+        ? [{ entity_id: item.entityId, entity_type: item.entityType }]
+        : undefined
+    );
   };
 
   const retry = () => {

--- a/js/app/packages/app/component/home/home.tsx
+++ b/js/app/packages/app/component/home/home.tsx
@@ -30,6 +30,7 @@ import { Navigate } from '@solidjs/router';
 import { $getRoot } from 'lexical';
 import { createEffect } from 'solid-js';
 import { HomeBackfillProgress } from './home-backfill-progress';
+import { replaceHomeComposerDraft } from './home-composer-selection';
 import { HomeExamples } from './home-examples';
 import { GettingStartedSection, RecommendedSection } from './home-hub';
 import { createHomePreferences } from './home-prefs';
@@ -184,8 +185,7 @@ const HomeChatInput = () => {
   });
 
   const applyDraft = (text: string) => {
-    const current = editor.controls.getMarkdown().trim();
-    editor.controls.setMarkdown(current ? `${current}\n\n${text}` : text);
+    replaceHomeComposerDraft(editor.controls, text);
     requestAnimationFrame(() => {
       editor.controls.focus();
       // Focus lands at the start of the document; drafts are prompt prefixes,


### PR DESCRIPTION
Replaces the Home composer draft and attachments when selecting a recommendation or example so repeated selections do not accumulate stale context.

Macro task: cBSi1fbaHQQgt5nYkWrVZ