### PR TITLE
feat(inbox): group email tab by date

### DIFF
--- a/js/app/packages/app/component/app-sidebar/soup-filter-presets.test.ts
+++ b/js/app/packages/app/component/app-sidebar/soup-filter-presets.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@core/constant/featureFlags', () => ({
+  ENABLE_NEW_INBOX: () => false,
+  ENABLE_SNIPPETS: () => true,
+  ENABLE_SUPPORTED_SOUP_FOREIGN_ENTITIES_OVERRIDE: false,
+}));
+
+import { getViewPreset, VIEW_TAB_PRESETS } from './soup-filter-presets';
+
+const mailTabs = Object.keys(VIEW_TAB_PRESETS.mail.tabs);
+
+describe('mail view presets', () => {
+  it('groups every mail tab by date independently of the new inbox flag', () => {
+    for (const tab of mailTabs) {
+      expect(getViewPreset('mail', tab)?.groupBy).toBe('date');
+    }
+  });
+});

--- a/js/app/packages/app/component/app-sidebar/soup-filter-presets.ts
+++ b/js/app/packages/app/component/app-sidebar/soup-filter-presets.ts
@@ -213,6 +213,7 @@ export const VIEW_TAB_PRESETS: Record<ListView, ViewTabConfig> = {
           emailView: 'inbox',
         }),
         clientFilters: { and: ['email', 'no-drafts'] },
+        groupBy: 'date',
       }),
       noise: () => ({
         filters: defineQueryFilters({
@@ -224,6 +225,7 @@ export const VIEW_TAB_PRESETS: Record<ListView, ViewTabConfig> = {
           emailView: 'inbox',
         }),
         clientFilters: { and: ['email', 'no-drafts'] },
+        groupBy: 'date',
       }),
       calendar: () => ({
         filters: defineQueryFilters({
@@ -235,6 +237,7 @@ export const VIEW_TAB_PRESETS: Record<ListView, ViewTabConfig> = {
         }),
 
         clientFilters: { and: ['email', 'no-drafts'] },
+        groupBy: 'date',
       }),
       drafts: () => ({
         filters: defineQueryFilters({
@@ -242,6 +245,7 @@ export const VIEW_TAB_PRESETS: Record<ListView, ViewTabConfig> = {
           emailView: 'drafts',
         }),
         clientFilters: { and: ['email-drafts'] },
+        groupBy: 'date',
       }),
       // No sender filter: the 'sent' view already scopes to messages with
       // is_sent = TRUE per linked inbox, which covers multi-inbox correctly
@@ -251,6 +255,7 @@ export const VIEW_TAB_PRESETS: Record<ListView, ViewTabConfig> = {
           emailView: 'sent',
         }),
         clientFilters: { and: ['email', 'no-drafts'] },
+        groupBy: 'date',
       }),
       shared: () => ({
         filters: defineQueryFilters({
@@ -258,6 +263,7 @@ export const VIEW_TAB_PRESETS: Record<ListView, ViewTabConfig> = {
           emailView: 'all',
         }),
         clientFilters: { and: ['email', 'shared-entity'] },
+        groupBy: 'date',
       }),
       all: () => ({
         filters: defineQueryFilters({
@@ -265,6 +271,7 @@ export const VIEW_TAB_PRESETS: Record<ListView, ViewTabConfig> = {
           emailView: 'all',
         }),
         clientFilters: { and: ['email'] },
+        groupBy: 'date',
       }),
     },
   },

--- a/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/soup-view.tsx
@@ -949,7 +949,7 @@ export const SoupViewList = (props: SoupViewListProps) => {
 
   const groupHeaderComponent = () => {
     if (currentView() === 'tasks') return TaskGroupHeader;
-    if (isNewInboxEnabled()) return DateGroupHeader;
+    if (soup.grouping.activeGroupId() === 'date') return DateGroupHeader;
     return DefaultGroupHeader;
   };
 


### PR DESCRIPTION
Reuses the new inbox date-grouping flow for the dedicated email tab while preserving its existing filters and list behavior.

Macro task: cBSi3iprXQTck91HRzQ4K
