### PR TITLE
docs: document tag filtering, channel message actions, and mobile refresh

### DIFF
--- a/docs/product/channels.mdx
+++ b/docs/product/channels.mdx
@@ -51,6 +51,15 @@ Compose messages using Macro's unified rich text editor:
 
 React with emoji instead of sending another message.
 
+### Message actions
+
+Hover over any message on desktop to reveal its action menu. Alongside reactions and replies, you can:
+
+- **Copy Link** — copy a link straight to that message so you can paste it into a doc, task, or another channel.
+- **Copy Text** — copy the message's text content to your clipboard.
+
+On mobile, the same actions live in the message action drawer — long-press a message to open it.
+
 ### Thread Replies
 
 Keep conversations organized by replying in threads:

--- a/docs/product/inbox.mdx
+++ b/docs/product/inbox.mdx
@@ -40,3 +40,11 @@ You can think of the Signal view as your _action list_. It's the tab you'll have
 ## How we use it
 
 The Superhuman email client popularized the concept of "Inbox Zero", and we stole it here and applied it to your entire workspace. We strongly recommend using <kbd>e</kbd> to mark-done notifications when you've viewed them. If you get a little behind you can use <kbd>shift</kbd> <kbd>↓</kbd> to select multiple notifications then <kbd>e</kbd> to mark all as done.
+
+## Date grouping
+
+Your inbox and email lists group items by date, so recent activity stays together at the top and older items fall into their own sections as you scroll. This keeps a busy list scannable without changing any of your filters or sorting.
+
+## On mobile
+
+On mobile, pull down from the top of any list — inbox, mail, documents, tasks, customers, or search — to refresh it. A spinner drops in while the list refetches and retracts once it's up to date.

--- a/docs/product/search.mdx
+++ b/docs/product/search.mdx
@@ -27,3 +27,12 @@ Use the filter button in the upper right corner to sort results into different t
 To further narrow search results, combine your keywords with an @mention of a specific person.
 
 Search covers more than titles: document bodies, email threads, channel messages, call transcripts, and file contents are all indexed. You can also ask an [agent](/product/agents) to find things for you; agents use the same index.
+
+## Filtering by tags
+
+Open the filter menu and select the **Tags** chip to narrow results to items carrying specific [tags](/concepts/properties). Once you've selected two or more tags, a match-mode toggle appears on the chip:
+
+- **Any** — return items that have any of the selected tags. This is the default.
+- **All** — return items that have every selected tag.
+
+Use **All** to zero in on the intersection of several tags (for example, everything tagged both `urgent` and `finance`), and **Any** to cast a wider net across related tags.


### PR DESCRIPTION
## Summary

Automated docs refresh: reviewed pull requests merged in the last 24 hours and updated the docs.macro.com feature pages for the changes that affect user-facing behavior. Only clearly shipped, non-flagged features are documented here; internal/infra work, refactors, and feature-flagged or in-progress work were intentionally left out per the docs project's "don't document internal tooling or unreleased features" guideline.

## Changes

- **`product/search.mdx`** — New "Filtering by tags" section covering the Tags filter chip and the **Any** / **All** match-mode toggle that appears once two or more tags are selected (from #4677).
- **`product/channels.mdx`** — New "Message actions" subsection documenting the hover action menu on desktop (**Copy Link**, **Copy Text**) and the equivalent mobile action drawer (from #4651).
- **`product/inbox.mdx`** — New "Date grouping" section (inbox/email lists grouped by date, from #4691) and "On mobile" section describing pull-to-refresh across all lists (from #4645).

## Merged PRs reviewed but not documented

The remaining ~40 merged PRs were reviewed and judged not to need doc changes: UI/styling tweaks, bug fixes, backend refactors (hexagonal-architecture splits, ACL/authorization internals), reliability fixes, dev-environment/nix changes, and feature-flagged or reverted work. Notably deferred:

- **Revised home page + AI projections** — parts are behind feature flags and still rolling out.
- **Typed webhook filters / webhook consumer** — developer-facing webhook support is still in progress and has no page on the docs site yet.
- **Settings split-layout** — behavioral change with no clear documentation surface.

These can be documented once they're fully released.

## Testing

Docs-only change (MDX content). No code paths affected; new links point to existing pages (`/concepts/properties`, `/product/agents`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KaNAWcdedRwHm4wqGByEs3)_