### PR TITLE
fix(settings): focus panel on mount so Escape works immediately

### DIFF
--- a/js/app/packages/app/component/settings/Settings.tsx
+++ b/js/app/packages/app/component/settings/Settings.tsx
@@ -109,6 +109,11 @@ export function SettingsPanel(props: SettingsPanelProps) {
   onMount(() => {
     if (!settingsContainerRef) return;
     attachHotkeys(settingsContainerRef);
+    // Activate the "settings" hotkey scope immediately so Escape (and the
+    // other settings hotkeys) work as soon as the panel opens, rather than
+    // only after the user clicks into it (the scope only activates on
+    // `focusin`).
+    settingsContainerRef.focus();
     resizeObserver = new ResizeObserver((entries) => {
       const width = entries[0]?.contentRect.width;
       if (width) setPanelWidth(width);


### PR DESCRIPTION
## What

The settings panel registers its hotkeys (including Escape to close) on a DOM-scoped hotkey scope via `useHotkeyDOMScope('settings')`. That scope only activates on a `focusin` event on its container, but nothing ever focused the container on mount — so Escape (and the other settings-panel hotkeys) silently did nothing until the user clicked somewhere inside the panel first.

This mirrors the fix already used by `InteractiveOnboarding` and `Paywall`, which call `.focus()` on their container right after `attachHotkeys()` for the same reason.

## Fix

Focus the settings container immediately after attaching hotkeys in `onMount`, so the scope (and Escape) is active as soon as the panel opens. The container already had `outline-none`, so this doesn't introduce a visible focus ring.

## Why prioritized

Reported in #bug-reports: "when I open settings panel, `esc` hotkey doesn't work, until I click on the settings panel." Small, isolated, low-risk fix for a real everyday annoyance.

MACRO-2306

## Test plan

- [ ] Open Settings (from any entry point) without clicking inside the panel, press `Escape` — panel should close.
- [ ] Confirm no visible focus ring appears around the settings panel on open.
- [ ] Confirm other settings hotkeys (Tab / Shift+Tab / number keys to switch tabs) still work immediately on open.


---
_Generated by [Claude Code](https://claude.ai/code/session_015JFraUhMbUpLdBGinKUZbL)_