### PR TITLE
feat(sidebar): show unread count badge on favorited channels

### DIFF
--- a/js/app/packages/app/component/app-sidebar/favorites-section.tsx
+++ b/js/app/packages/app/component/app-sidebar/favorites-section.tsx
@@ -1,5 +1,6 @@
 import type { SidebarState } from '@app/component/app-sidebar/sidebar';
 import { FavoriteIcon } from '@app/component/FavoriteIcon';
+import { useGlobalNotificationSource } from '@app/component/GlobalAppState';
 import { useSplitLayout } from '@app/component/split-layout/layout';
 import { globalSplitManager } from '@app/signal/splitLayout';
 import {
@@ -11,6 +12,7 @@ import {
 import { ContextMenuContent, MenuItem } from '@core/component/ContextMenu';
 import type { EntityIconSelector } from '@core/component/EntityIcon';
 import { ContextMenu } from '@kobalte/core/context-menu';
+import { useNotificationsForEntity } from '@notifications';
 import CaretRightIcon from '@phosphor/caret-right.svg';
 import {
   favoriteEntityKey,
@@ -171,6 +173,19 @@ const FavoriteRow = (props: { favorite: Favorite; disabled: boolean }) => {
   const displayName = useFavoriteDisplayName(props.favorite);
   const dmRecipientId = useFavoriteDmRecipientId(props.favorite);
 
+  // Mirrors the "Unread" sidebar section's count badge (see
+  // channels-unread-widget.tsx) so a favorited channel/DM shows the same
+  // at-a-glance unread indicator instead of giving no signal at all.
+  const notificationSource = useGlobalNotificationSource();
+  const channelNotifications = useNotificationsForEntity(notificationSource, {
+    id: props.favorite.entityId,
+    type: 'channel',
+  });
+  const unreadCount = () =>
+    props.favorite.entityType === 'channel'
+      ? channelNotifications().filter((n) => !n.viewed_at && !n.done).length
+      : 0;
+
   // `For` keys rows by favorite identity, so the favorite (and drag data
   // derived from it) is stable for the row's lifetime.
   //
@@ -254,6 +269,11 @@ const FavoriteRow = (props: { favorite: Favorite; disabled: boolean }) => {
           >
             <FavoriteIcon favorite={props.favorite} />
             <span class="truncate">{displayName()}</span>
+            <Show when={unreadCount() > 0}>
+              <span class="shrink-0 min-w-5 h-5 px-1.5 flex items-center justify-center text-xs font-medium bg-ink/6 text-ink-muted rounded-md ml-auto">
+                {unreadCount()}
+              </span>
+            </Show>
           </NavRow>
         </ContextMenu.Trigger>
 

--- a/js/app/packages/app/component/app-sidebar/favorites-section.tsx
+++ b/js/app/packages/app/component/app-sidebar/favorites-section.tsx
@@ -12,7 +12,7 @@ import {
 import { ContextMenuContent, MenuItem } from '@core/component/ContextMenu';
 import type { EntityIconSelector } from '@core/component/EntityIcon';
 import { ContextMenu } from '@kobalte/core/context-menu';
-import { useNotificationsForEntity } from '@notifications';
+import { notificationIsRead, useNotificationsForEntity } from '@notifications';
 import CaretRightIcon from '@phosphor/caret-right.svg';
 import {
   favoriteEntityKey,
@@ -176,6 +176,10 @@ const FavoriteRow = (props: { favorite: Favorite; disabled: boolean }) => {
   // Mirrors the "Unread" sidebar section's count badge (see
   // channels-unread-widget.tsx) so a favorited channel/DM shows the same
   // at-a-glance unread indicator instead of giving no signal at all.
+  // `notificationIsRead` (rather than a plain `!viewed_at && !done` check) is
+  // required here: some notifications attached to a channel entity aren't
+  // channel-message notifications at all, and that helper is what excludes
+  // them so the count matches what the Unread widget shows.
   const notificationSource = useGlobalNotificationSource();
   const channelNotifications = useNotificationsForEntity(notificationSource, {
     id: props.favorite.entityId,
@@ -183,7 +187,7 @@ const FavoriteRow = (props: { favorite: Favorite; disabled: boolean }) => {
   });
   const unreadCount = () =>
     props.favorite.entityType === 'channel'
-      ? channelNotifications().filter((n) => !n.viewed_at && !n.done).length
+      ? channelNotifications().filter((n) => !notificationIsRead(n)).length
       : 0;
 
   // `For` keys rows by favorite identity, so the favorite (and drag data


### PR DESCRIPTION
## What

Favorited channels/DMs in the sidebar gave no indication that they had unread messages — you had to open them to find out. The sidebar's "Unread" section (`channels-unread-widget.tsx`) already solves this with a small count badge per channel, driven by the notification source.

## Fix

`FavoriteRow` now looks up notifications for the favorite's channel via the same `useNotificationsForEntity` helper used elsewhere in the app, counts the unread/not-done ones, and renders the same badge style as the Unread widget when the count is > 0. Non-channel favorites (documents, tasks, etc.) are unaffected.

## Why prioritized

Reported in #feature-requests: "if you have a channel favourited and it gets a message, it should show the (1) like the Unread section does." Small, self-contained UI addition that reuses existing notification plumbing — no new data fetching or backend changes required.

MACRO-2307

## Test plan

- [ ] Favorite a channel, have someone send a message in it — badge with unread count should appear next to the favorite row.
- [ ] Open the channel / mark it read — badge should disappear.
- [ ] Favorite a document/task — no badge should render for it.
- [ ] Sidebar drag-reorder and remove-from-favorites still work as before.


---
_Generated by [Claude Code](https://claude.ai/code/session_015JFraUhMbUpLdBGinKUZbL)_