### PR TITLE
fix(style): Adjust call recording callback button to not look huge

### DIFF
--- a/js/app/packages/block-call/component/CallRecording/CallRecordingSplitHeader.tsx
+++ b/js/app/packages/block-call/component/CallRecording/CallRecordingSplitHeader.tsx
@@ -140,7 +140,7 @@ export function CallRecordingSplitHeader(props: {
               <Button
                 depth={2}
                 variant="base"
-                size="icon-sm"
+                size="icon-xs"
                 class="bg-surface"
                 tooltip="Call Again"
                 onClick={() => call.joinCall()}

--- a/js/app/packages/ui/components/Button.tsx
+++ b/js/app/packages/ui/components/Button.tsx
@@ -36,7 +36,15 @@ export type ButtonProps = ButtonRootProps<'button'> &
     tooltipDisabled?: boolean;
   };
 
-export type ButtonSize = 'xs' | 'icon-xs' | 'sm' | 'icon-sm' | 'md' | 'icon-md' | 'lg' | 'icon-lg';
+export type ButtonSize =
+  | 'xs'
+  | 'icon-xs'
+  | 'sm'
+  | 'icon-sm'
+  | 'md'
+  | 'icon-md'
+  | 'lg'
+  | 'icon-lg';
 
 export type ButtonVariant =
   | 'ghost'

--- a/js/app/packages/ui/components/Button.tsx
+++ b/js/app/packages/ui/components/Button.tsx
@@ -36,7 +36,7 @@ export type ButtonProps = ButtonRootProps<'button'> &
     tooltipDisabled?: boolean;
   };
 
-export type ButtonSize = 'sm' | 'icon-sm' | 'md' | 'icon-md' | 'lg' | 'icon-lg';
+export type ButtonSize = 'xs' | 'icon-xs' | 'sm' | 'icon-sm' | 'md' | 'icon-md' | 'lg' | 'icon-lg';
 
 export type ButtonVariant =
   | 'ghost'
@@ -63,6 +63,8 @@ const variantStyles: Record<ButtonVariant, string> = {
 };
 
 const sizeStyles: Record<ButtonSize, string> = {
+  xs: '          p-1  [&_:where(svg)]:size-3 gap-1   text-xs',
+  'icon-xs': 'size-5   p-2.75  [&_:where(svg)]:size-4                  ',
   lg: '          p-2.5  [&_:where(svg)]:size-5 gap-2   text-base',
   md: '          p-2                           gap-1.5 text-sm  ' /* scuffed */,
   sm: 'h-6       px-2   [&_:where(svg)]:size-4 gap-1   text-xs  ',

--- a/js/app/packages/ui/components/ButtonGroup.tsx
+++ b/js/app/packages/ui/components/ButtonGroup.tsx
@@ -50,6 +50,8 @@ const dividerVariantStyles: Record<ButtonVariant, string> = {
 /* explicit cross-axis size so the group's outer box matches a standalone
    Button of the same size (border-box absorbs the 1px outer border) */
 const groupHorizontalSize: Record<ButtonSize, string> = {
+  xs: '',
+  'icon-xs': 'h-5',
   lg: '',
   md: '',
   sm: 'h-6',
@@ -59,6 +61,8 @@ const groupHorizontalSize: Record<ButtonSize, string> = {
 };
 
 const groupVerticalSize: Record<ButtonSize, string> = {
+  xs: '',
+  'icon-xs': 'w-5',
   lg: '',
   md: '',
   sm: '',


### PR DESCRIPTION
Add new icon-xs class for our Button component to size it consistent with other header buttons