### PR TITLE
feat(channel): add channel created element at top of channel rail

### DIFF
--- a/js/app/packages/channel/Channel/Channel.tsx
+++ b/js/app/packages/channel/Channel/Channel.tsx
@@ -279,7 +279,13 @@ export function Channel(props: ChannelProps) {
   });
 
   const listMetaByMessageId = createMemo(() =>
-    buildChannelMessageListMeta(messages(), activityTracker.isNewMessage)
+    buildChannelMessageListMeta(
+      messages(),
+      activityTracker.isNewMessage,
+      // Once there are no older pages left to fetch, the oldest loaded message
+      // (index 0) is the true first message in the channel.
+      !messagesQuery.hasNextPage
+    )
   );
 
   const attachmentTracker = createInputAttachmentTracker({

--- a/js/app/packages/channel/Channel/message-list-meta.ts
+++ b/js/app/packages/channel/Channel/message-list-meta.ts
@@ -4,7 +4,8 @@ import { shouldGroupWithPreviousMessage } from './message-grouping-meta';
 
 export function buildChannelMessageListMeta(
   messages: ApiChannelMessage[],
-  isNewMessageFn: (message: ApiChannelMessage) => boolean
+  isNewMessageFn: (message: ApiChannelMessage) => boolean,
+  reachedStart: boolean
 ): Record<string, ChannelMessageListMeta> {
   const metaByMessageId: Record<string, ChannelMessageListMeta> = {};
   let previousTopLevelCreatedAt: string | undefined;
@@ -28,6 +29,7 @@ export function buildChannelMessageListMeta(
         message,
         previousMessage
       ),
+      reachedStart,
     };
 
     previousTopLevelCreatedAt = message.created_at;

--- a/js/app/packages/channel/Channel/tests/message-list-meta.test.ts
+++ b/js/app/packages/channel/Channel/tests/message-list-meta.test.ts
@@ -36,7 +36,7 @@ describe('buildChannelMessageListMeta', () => {
       createMessage('m3', '2026-02-21T09:00:00.000Z'),
     ];
 
-    const meta = buildChannelMessageListMeta(messages, () => false);
+    const meta = buildChannelMessageListMeta(messages, () => false, true);
 
     expect(meta.m1).toEqual({
       index: 0,
@@ -44,6 +44,7 @@ describe('buildChannelMessageListMeta', () => {
       isFirstNewMessage: false,
       previousTopLevelCreatedAt: undefined,
       isGroupedWithPrevious: false,
+      reachedStart: true,
     });
     expect(meta.m2.previousTopLevelCreatedAt).toBe('2026-02-20T09:00:00.000Z');
     expect(meta.m3.previousTopLevelCreatedAt).toBe('2026-02-20T10:00:00.000Z');
@@ -58,7 +59,8 @@ describe('buildChannelMessageListMeta', () => {
 
     const meta = buildChannelMessageListMeta(
       messages,
-      (message) => message.id === 'm2' || message.id === 'm3'
+      (message) => message.id === 'm2' || message.id === 'm3',
+      true
     );
 
     expect(meta.m1.isFirstNewMessage).toBe(false);
@@ -75,7 +77,7 @@ describe('buildChannelMessageListMeta', () => {
       createMessage('m3', '2026-02-20T09:05:01.000Z'),
     ];
 
-    const meta = buildChannelMessageListMeta(messages, () => false);
+    const meta = buildChannelMessageListMeta(messages, () => false, true);
 
     expect(meta.m1.isGroupedWithPrevious).toBe(false);
     expect(meta.m2.isGroupedWithPrevious).toBe(true);
@@ -114,7 +116,7 @@ describe('buildChannelMessageListMeta', () => {
       ),
     ];
 
-    const meta = buildChannelMessageListMeta(messages, () => false);
+    const meta = buildChannelMessageListMeta(messages, () => false, true);
 
     expect(meta.m2.isGroupedWithPrevious).toBe(false);
     expect(meta.m3.isGroupedWithPrevious).toBe(true);

--- a/js/app/packages/channel/Message/ChannelCreatedIndicator.tsx
+++ b/js/app/packages/channel/Message/ChannelCreatedIndicator.tsx
@@ -1,0 +1,64 @@
+import { useChannel } from '@core/context/channels';
+import { formatDate } from '@core/util/date';
+import ChannelIcon from '@icon/wide-channel.svg';
+import { ChannelTypeEnum } from '@service-storage/client';
+import { Avatar } from '@ui';
+import { Show } from 'solid-js';
+
+type ChannelCreatedIndicatorProps = {
+  channelId: string;
+};
+
+/**
+ * Rendered once at the very top of a channel thread (the oldest message, once
+ * the first page has loaded). Shows a channel-glyph avatar alongside a
+ * "Channel <name> created" label and the creation timestamp. Skipped for DMs
+ * and for channels without a name.
+ */
+export function ChannelCreatedIndicator(props: ChannelCreatedIndicatorProps) {
+  const channel = useChannel(props.channelId);
+
+  const shouldRender = () => {
+    const c = channel();
+    return !!c && !!c.name && c.channel_type !== ChannelTypeEnum.DirectMessage;
+  };
+
+  return (
+    <Show when={shouldRender() && channel()}>
+      {(c) => (
+        <div class="relative w-full pr-2 pl-(--message-padding-x) pt-4 pb-2">
+          {/* Rail connector: runs from the circle's center down to the bottom
+              edge so it meets the thread rail on the message below. Sits behind
+              the avatar (which has a solid bg), so it only shows below it. */}
+          <div
+            class="pointer-events-none absolute bottom-0 -z-1 border-l border-rail"
+            style={{
+              left: 'var(--left-of-connector)',
+              top: 'calc(1rem + var(--user-icon-width) / 2)',
+            }}
+          />
+          <div
+            class="grid min-w-0 items-center gap-x-2"
+            style={{
+              'grid-template-columns': 'var(--user-icon-width) minmax(0, 1fr)',
+            }}
+          >
+            <Avatar class="size-(--user-icon-width) bg-surface text-ink-muted ring ring-edge-muted">
+              <Avatar.Fallback>
+                <ChannelIcon class="size-4" />
+              </Avatar.Fallback>
+            </Avatar>
+            <div class="flex min-w-0 flex-col justify-center">
+              <span class="text-sm text-ink">
+                Channel <span class="font-semibold">{c().name}</span> created
+              </span>
+              <span class="text-xs text-ink-placeholder">
+                {formatDate(c().created_at, { showTime: true })}
+              </span>
+            </div>
+          </div>
+        </div>
+      )}
+    </Show>
+  );
+}

--- a/js/app/packages/channel/Message/index.ts
+++ b/js/app/packages/channel/Message/index.ts
@@ -8,6 +8,7 @@ import {
 
 export { ActionMenu } from './ActionMenu';
 export { Attachments } from './Attachments';
+export { ChannelCreatedIndicator } from './ChannelCreatedIndicator';
 export { ChannelMessage } from './ChannelMessage';
 export type { SearchHighlightTermsLookup } from './context';
 export { DateDivider } from './DateDivider';

--- a/js/app/packages/channel/Message/list-meta.ts
+++ b/js/app/packages/channel/Message/list-meta.ts
@@ -4,4 +4,9 @@ export type ChannelMessageListMeta = {
   isFirstNewMessage: boolean;
   previousTopLevelCreatedAt?: string;
   isGroupedWithPrevious?: boolean;
+  /**
+   * True once the oldest page has loaded, so `index === 0` is the true first
+   * message in the channel rather than just the oldest currently-loaded one.
+   */
+  reachedStart?: boolean;
 };

--- a/js/app/packages/channel/Thread/ChannelThread.tsx
+++ b/js/app/packages/channel/Thread/ChannelThread.tsx
@@ -266,6 +266,7 @@ export function ChannelThread(props: ThreadProps) {
   return (
     <DebugSuspense name="ChannelThread.root">
       <Thread.Row
+        channelId={props.channelId()}
         message={props.data()}
         listMeta={props.listMeta}
         onDismissNewMessages={props.threadActions?.onDismissNewMessages}

--- a/js/app/packages/channel/Thread/ThreadRow.tsx
+++ b/js/app/packages/channel/Thread/ThreadRow.tsx
@@ -1,6 +1,7 @@
 import type { ApiChannelMessage } from '@service-storage/generated/schemas/apiChannelMessage';
-import type { ParentProps } from 'solid-js';
+import { type ParentProps, Show } from 'solid-js';
 import {
+  ChannelCreatedIndicator,
   type ChannelMessageListMeta,
   DateDivider,
   NewDivider,
@@ -8,15 +9,25 @@ import {
 import { ThreadRail } from './ThreadRail';
 
 type ThreadRowProps = ParentProps & {
+  /** Present only in channel threads; other consumers (calls, PRs, comments) omit it. */
+  channelId?: string;
   message: ApiChannelMessage;
   listMeta?: ChannelMessageListMeta;
   onDismissNewMessages?: () => void;
 };
 
 export function ThreadRow(props: ThreadRowProps) {
+  const channelCreatedId = () =>
+    props.listMeta?.index === 0 && props.listMeta?.reachedStart
+      ? props.channelId
+      : undefined;
+
   return (
     <div class="w-full flex justify-center">
       <div class="macro-message-width w-full relative">
+        <Show when={channelCreatedId()}>
+          {(id) => <ChannelCreatedIndicator channelId={id()} />}
+        </Show>
         <NewDivider
           listMeta={props.listMeta}
           onDismiss={props.onDismissNewMessages}

--- a/js/app/packages/core/context/channels.ts
+++ b/js/app/packages/core/context/channels.ts
@@ -60,6 +60,11 @@ export const [ChannelsContextProvider, useChannelsContext] =
     };
   });
 
+export function useChannel(channelId: string) {
+  const ctx = useChannelsContext();
+  return createMemo(() => ctx.channelsById()[channelId]);
+}
+
 export function useChannelName(channelId: string, fallback?: string) {
   const ctx = useChannelsContext();
   return createMemo(() => ctx.channelsById()[channelId]?.name ?? fallback);


### PR DESCRIPTION
At the very beginning of a channel, display a creation timestamp
<img width="972" height="479" alt="Screenshot 2026-07-10 at 11 47 40 AM" src="https://github.com/user-attachments/assets/bc3bd0b4-8aba-4815-b3ae-9656f03d86d7" />
