### PR TITLE
refactor(channel): unify channel-message navigation behind goToChannelMessage

### DIFF
--- a/js/app/packages/app/component/next-soup/soup-view/create-soup-entity-actions.ts
+++ b/js/app/packages/app/component/next-soup/soup-view/create-soup-entity-actions.ts
@@ -3,7 +3,10 @@ import { useGlobalNotificationSource } from '@app/component/GlobalAppState';
 import { canExecuteMarkDoneOnView } from '@app/component/next-soup/actions/make-mark-done-action';
 import { isListViewID } from '@app/constants/list-views';
 import { globalSplitManager } from '@app/signal/splitLayout';
-import { getChannelParams } from '@block-channel/utils/link';
+import {
+  getChannelParams,
+  goToChannelMessage,
+} from '@block-channel/utils/link';
 import { fileTypeToBlockName, itemToBlockName } from '@core/constant/allBlocks';
 import { useUserId } from '@core/context/user';
 import { type HotkeyToken, TOKENS } from '@core/hotkey/tokens';
@@ -30,6 +33,7 @@ import {
   makeShareAction,
 } from '../actions';
 import type { SoupState } from '../create-soup-state';
+import { getChannelEntityTarget } from '../utils';
 
 const SIGNAL_TABS = new Set<string | undefined>([
   undefined,
@@ -185,23 +189,27 @@ export function createSoupEntityActions(): {
           entity.type === 'channel_message' ||
           entity.type === 'channel_thread'
         ) {
+          // Thread rows are keyed by their root; getChannelEntityTarget
+          // recovers the clicked reply from the driving notification so the
+          // new split lands on it rather than the root message.
+          const target = getChannelEntityTarget(entity) ?? {
+            messageId: entity.messageId,
+            threadId: entity.threadId,
+          };
           splitManager.createNewSplit({
             content: {
               type: 'channel',
               id: entity.channelId,
-              params: getChannelParams(entity.messageId, entity.threadId),
+              params: getChannelParams(target.messageId, target.threadId),
             },
             referredFrom: 'entity-actions-menu',
           });
 
-          const orchestrator = splitManager.getOrchestrator();
-          const blockHandle = await orchestrator.getBlockHandle(
+          await goToChannelMessage(
+            splitManager.getOrchestrator(),
             entity.channelId,
-            'channel'
-          );
-
-          await blockHandle?.goToLocationFromParams(
-            getChannelParams(entity.messageId, entity.threadId)
+            target.messageId,
+            target.threadId
           );
         } else if (entity.type === 'crm_company') {
           splitManager.createNewSplit({

--- a/js/app/packages/app/component/next-soup/utils.ts
+++ b/js/app/packages/app/component/next-soup/utils.ts
@@ -6,7 +6,10 @@ import { isListViewID } from '@app/constants/list-views';
 import { globalSplitManager } from '@app/signal/splitLayout';
 import { URL_PARAMS as CALL_PARAMS } from '@block-call/constants';
 import { URL_PARAMS as CHANNEL_PARAMS } from '@block-channel/constants';
-import { getChannelParams } from '@block-channel/utils/link';
+import {
+  getChannelParams,
+  goToChannelMessage,
+} from '@block-channel/utils/link';
 import { URL_PARAMS as EMAIL_PARAMS } from '@block-email/constants';
 import { URL_PARAMS as MD_PARAMS } from '@block-md/constants';
 import { URL_PARAMS as PDF_PARAMS } from '@block-pdf/signal/location';
@@ -394,9 +397,11 @@ export async function navigateChannelEntityToTarget(
         : undefined;
   if (!channelId) return;
 
-  const handle = await blockOrchestrator.getBlockHandle(channelId);
-  await handle?.goToLocationFromParams(
-    getChannelParams(target.messageId, target.threadId)
+  await goToChannelMessage(
+    blockOrchestrator,
+    channelId,
+    target.messageId,
+    target.threadId
   );
 }
 

--- a/js/app/packages/block-channel/utils/link.ts
+++ b/js/app/packages/block-channel/utils/link.ts
@@ -17,19 +17,6 @@ export function getChannelParams(
   return params;
 }
 
-export function getUrlToMessage(
-  channelId: string,
-  messageId: string,
-  threadId?: string
-) {
-  const origin = window.location.origin;
-  let url = `${origin}/app/channel/${channelId}?${URL_PARAMS.message}=${messageId}`;
-  if (threadId) {
-    url += `&${URL_PARAMS.thread}=${threadId}`;
-  }
-  return url;
-}
-
 /**
  * Drive an (already-mounted) channel block to a target message through its
  * block handle. The shared last mile for every "go to a channel message"

--- a/js/app/packages/block-channel/utils/link.ts
+++ b/js/app/packages/block-channel/utils/link.ts
@@ -30,6 +30,22 @@ export function getUrlToMessage(
   return url;
 }
 
+/**
+ * Drive an (already-mounted) channel block to a target message through its
+ * block handle. The shared last mile for every "go to a channel message"
+ * caller — always keyed on the `'channel'` block type so a stale id can't
+ * resolve the wrong block.
+ */
+export async function goToChannelMessage(
+  orchestrator: BlockOrchestrator,
+  channelId: string,
+  messageId: string,
+  threadId?: string
+) {
+  const handle = await orchestrator.getBlockHandle(channelId, 'channel');
+  await handle?.goToLocationFromParams(getChannelParams(messageId, threadId));
+}
+
 export async function navigateToChannelMessage(
   orchestrator: BlockOrchestrator,
   channelId: string,
@@ -40,7 +56,6 @@ export async function navigateToChannelMessage(
     preferNewSplit?: boolean;
   }
 ) {
-  const params = getChannelParams(messageId, threadId);
   const splitManager = options?.splitManager ?? globalSplitManager();
   if (!splitManager) return;
 
@@ -49,7 +64,11 @@ export async function navigateToChannelMessage(
     existing.activate();
   } else {
     splitManager.openWithSplit(
-      { type: 'channel', id: channelId, params },
+      {
+        type: 'channel',
+        id: channelId,
+        params: getChannelParams(messageId, threadId),
+      },
       {
         activate: true,
         referredFrom: null,
@@ -58,6 +77,5 @@ export async function navigateToChannelMessage(
     );
   }
 
-  const handle = await orchestrator.getBlockHandle(channelId, 'channel');
-  await handle?.goToLocationFromParams(params);
+  await goToChannelMessage(orchestrator, channelId, messageId, threadId);
 }


### PR DESCRIPTION
Consolidates the duplicated channel-message navigation paths behind a single `goToChannelMessage` primitive (each caller still opens/activates its split how it needs to; the block-handle target navigation is shared and always keyed on the `'channel'` block type). Also fixes soup "Open in new split" to land on the clicked reply instead of the thread root, and removes the unused `getUrlToMessage`. Stacked on #4711.
