### PR TITLE
fix(soup): make it impossible to enter preview mode on mobile

### DIFF
--- a/js/app/packages/app/component/next-soup/create-soup-state.test.ts
+++ b/js/app/packages/app/component/next-soup/create-soup-state.test.ts
@@ -32,10 +32,18 @@ vi.mock('@core/mobile/inputModality', () => ({
   isModality: vi.fn(() => false),
 }));
 
+// Relative specifier (not `@core/mobile/isMobile`): tsconfig aliases don't
+// resolve from test files, and it must match the import below so both hit the
+// same module id that create-soup-state.ts imports.
+vi.mock('../../../core/mobile/isMobile', () => ({
+  isMobile: vi.fn(() => false),
+}));
+
 vi.mock('@core/component/EntityIcon', () => ({
   getIconConfig: vi.fn(),
 }));
 
+import { isMobile } from '../../../core/mobile/isMobile';
 import type { EntityData } from '../../../entity/src';
 import { createSoupState } from './create-soup-state';
 
@@ -407,6 +415,31 @@ describe('createSoupState', () => {
         state.setPreviewEntity(undefined);
         expect(state.previewEntity()).toBeUndefined();
 
+        dispose();
+      });
+    });
+
+    it('should refuse to enter preview mode on mobile but still allow clearing', () => {
+      createRoot((dispose) => {
+        const state = createSoupState();
+
+        state.setPreviewEntity('entity-1');
+        expect(state.previewEntity()).toBe('entity-1');
+
+        vi.mocked(isMobile).mockReturnValue(true);
+
+        // Entering (or retargeting) preview is dropped on mobile.
+        state.setPreviewEntity('entity-2');
+        expect(state.previewEntity()).toBe('entity-1');
+
+        // Exiting preview stays possible.
+        state.setPreviewEntity(undefined);
+        expect(state.previewEntity()).toBeUndefined();
+
+        state.setPreviewEntity('entity-3');
+        expect(state.previewEntity()).toBeUndefined();
+
+        vi.mocked(isMobile).mockReturnValue(false);
         dispose();
       });
     });

--- a/js/app/packages/app/component/next-soup/create-soup-state.ts
+++ b/js/app/packages/app/component/next-soup/create-soup-state.ts
@@ -10,9 +10,16 @@ import {
 import { createSelectionState } from '@app/component/next-soup/selection-state';
 import { SORT_CONFIGS } from '@app/component/next-soup/soup-view/sort-options';
 import { isModality } from '@core/mobile/inputModality';
+import { isMobile } from '@core/mobile/isMobile';
 import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import type { EntityData, WithNotification, WithSearch } from '@entity';
-import { createMemo, createSignal, type JSX } from 'solid-js';
+import {
+  createEffect,
+  createMemo,
+  createSignal,
+  type JSX,
+  untrack,
+} from 'solid-js';
 
 /**
  * Active "focus" predicates that exclude done entities. When one of these is
@@ -160,7 +167,26 @@ export const createSoupState = <TId extends string = FilterID>(
     if (nextIndex < 0) lastFocusedRowId = undefined;
   };
 
-  const [previewEntity, setPreviewEntity] = createSignal<string | undefined>();
+  const [previewEntity, setPreviewEntityInternal] = createSignal<
+    string | undefined
+  >();
+
+  // The preview pane is a desktop-only affordance, so it must be impossible
+  // to enter preview mode on mobile: attempts to set a preview entity are
+  // dropped there (clearing is always allowed). All entry points — toggle
+  // button, space hotkey, row clicks, per-history-entry restores — funnel
+  // through this setter.
+  const setPreviewEntity = (id: string | undefined) => {
+    if (id !== undefined && untrack(isMobile)) return;
+    setPreviewEntityInternal(id);
+  };
+
+  // Exit preview mode if the viewport becomes mobile mid-preview (e.g. a
+  // phone rotating from landscape to portrait); otherwise the hidden pane's
+  // state leaks into panel layout (half-split headers, preview borders).
+  createEffect(() => {
+    if (isMobile()) setPreviewEntityInternal(undefined);
+  });
 
   const [collapseEntityCallback, setCollapseEntityCallback] = createSignal<
     ((entityId: string) => Promise<void>) | undefined

--- a/js/app/packages/app/component/next-soup/soup-view/filters-bar/soup-filters-bar.tsx
+++ b/js/app/packages/app/component/next-soup/soup-view/filters-bar/soup-filters-bar.tsx
@@ -38,6 +38,11 @@ export function SoupFiltersBar() {
   const { isWideSplitPanel } = usePreviewPaneVisiblity();
 
   const togglePreview = () => {
+    // Preview mode doesn't exist on mobile. The bar isn't rendered there but
+    // the space hotkey below stays registered, so bail before it can move
+    // focus or track a preview that the soup state would refuse anyway.
+    if (isMobile()) return;
+
     const currentPreview = soup.previewEntity();
     if (currentPreview) {
       soup.setPreviewEntity(undefined);

--- a/js/app/packages/block-project/component/Block.tsx
+++ b/js/app/packages/block-project/component/Block.tsx
@@ -21,6 +21,7 @@ import { fileFolderDrop } from '@core/directive/fileFolderDrop';
 import { fileSelector } from '@core/directive/fileSelector';
 import { registerHotkey } from '@core/hotkey/hotkeys';
 import { TOKENS } from '@core/hotkey/tokens';
+import { isMobile } from '@core/mobile/isMobile';
 import { blockHotkeyScopeSignal } from '@core/signal/blockElement';
 import {
   handleFileFolderDrop,
@@ -119,6 +120,9 @@ const Block: Component = () => {
       description: 'Toggle Preview',
       hotkeyToken: TOKENS.unifiedList.togglePreview,
       keyDownHandler: () => {
+        // Preview mode doesn't exist on mobile — let space fall through
+        // instead of tracking a preview the soup state would refuse anyway.
+        if (isMobile()) return false;
         if (projectSoup.previewEntity()) {
           projectSoup.setPreviewEntity(undefined);
           return true;


### PR DESCRIPTION
Fixes MACRO-2323.

Preview mode is desktop-only — the pane never renders on mobile (`isWideSplitPanel` is width-gated) — but its *state* could still be entered there: the `space` hotkey stays registered while the filters bar is hidden (fires with a hardware keyboard), per-history-entry `soup.preview` restores re-apply it, and rotating a phone from landscape to portrait carried it over. The orphaned state leaked into panel layout (30% half-split headers, preview borders, `BlockLoader`'s `isPreview`).

**How it's fixed:**
- `create-soup-state.ts`: every entry point (toggle button, space hotkeys, row clicks, history restores) funnels through `setPreviewEntity`, so the setter now drops non-`undefined` values when `isMobile()` — clearing is always allowed — and an effect exits preview if the viewport becomes mobile mid-preview (phone rotation).
- `soup-filters-bar.tsx` / `block-project/Block.tsx`: the preview-toggle hotkey handlers bail early on mobile so they don't move focus or track `preview_panel_use` for a no-op.
- Added a unit test covering the guard (enter refused on mobile, exit still allowed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WQiGxpoWWZ36z5V3Pd4TC7

---
_Generated by [Claude Code](https://claude.ai/code/session_01WQiGxpoWWZ36z5V3Pd4TC7)_