### PR TITLE
feat(email): gmail-style forward composer with collapsible quoted content

### DIFF
--- a/js/app/packages/block-email/component/BaseInput.tsx
+++ b/js/app/packages/block-email/component/BaseInput.tsx
@@ -105,7 +105,7 @@ import {
 } from '@ui';
 import { iosCursorScrollPlugin } from 'core/component/LexicalMarkdown/plugins/ios-cursor-scroll';
 import { registerHotkey, useHotkeyDOMScope } from 'core/hotkey/hotkeys';
-import { $getRoot } from 'lexical';
+import { $addUpdateTag, $getRoot } from 'lexical';
 import {
   type Accessor,
   createEffect,
@@ -536,6 +536,11 @@ export function BaseInput(props: {
 
   const [bodyMacro, setBodyMacro] = createSignal<string>('');
   const [scrollContainer, setScrollContainer] = createSignal<HTMLElement>();
+  // Gmail-style sizing: the composer opens compact and grows to the full cap
+  // once the user scrolls the content
+  const [composerExpanded, setComposerExpanded] = createSignal(false);
+  // Appended quoted thread starts hidden behind a "⋯" pill (desktop)
+  const [quoteCollapsed, setQuoteCollapsed] = createSignal(true);
   const [showExpandedRecipients, setShowExpandedRecipients] =
     createSignal<boolean>(false);
   const [isDragging, setIsDragging] = createSignal<boolean>();
@@ -633,7 +638,11 @@ export function BaseInput(props: {
     form().setCapturedEditor(currentEditor);
     const html = initialHtml();
     if (html) {
-      setEditorStateFromHtml(currentEditor, html);
+      // Restore content without letting selection reconciliation grab focus
+      currentEditor.update(() => {
+        $addUpdateTag('skip-dom-selection');
+        setEditorStateFromHtml(currentEditor, html, true);
+      });
     }
   };
 
@@ -781,6 +790,52 @@ export function BaseInput(props: {
     }
   }
 
+  // Lexical setup after the quote append (decorator mounts, mutation flushes)
+  // keeps flushing stale selections into the editor, yanking focus out of the
+  // To field. While armed, bounce those grabs back to To; any deliberate user
+  // interaction (pointer, Tab/Escape, focus leaving the composer) disarms it.
+  let bounceEditorFocusGrabs = false;
+
+  onMount(() => {
+    const disarm = () => {
+      bounceEditorFocusGrabs = false;
+    };
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Tab' || e.key === 'Escape') disarm();
+    };
+    const onFocusIn = (e: FocusEvent) => {
+      if (!bounceEditorFocusGrabs) return;
+      const target = e.target as Node;
+      if (!composeContainerRef?.contains(target)) {
+        disarm();
+        return;
+      }
+      if (scrollContainer()?.contains(target)) {
+        toRef()?.focus();
+      }
+    };
+    document.addEventListener('pointerdown', disarm, true);
+    document.addEventListener('keydown', onKeyDown, true);
+    document.addEventListener('focusin', onFocusIn, true);
+    onCleanup(() => {
+      document.removeEventListener('pointerdown', disarm, true);
+      document.removeEventListener('keydown', onKeyDown, true);
+      document.removeEventListener('focusin', onFocusIn, true);
+    });
+  });
+
+  const focusForwardRecipients = () => {
+    setShowExpandedRecipients(true);
+    setTimeout(() => {
+      if (toRef()) {
+        bounceEditorFocusGrabs = true;
+        toRef()?.focus();
+      }
+      // After the quoted thread is appended, keep the send bar in view
+      bottomBarRef?.scrollIntoView({ block: 'nearest' });
+    }, 100);
+  };
+
   // Attach side-effect handlers on mount; they replay against current state
   onMount(() => {
     form().setOnDirty(() => {
@@ -788,16 +843,14 @@ export function BaseInput(props: {
     });
 
     form().setOnReplyTypeApplied((rt) => {
+      setComposerExpanded(false);
       if (rt === 'forward') {
-        setShowExpandedRecipients(true);
-        setTimeout(() => {
-          if (toRef()) {
-            toRef()?.focus();
-          }
-        }, 100);
+        setQuoteCollapsed(true);
+        focusForwardRecipients();
       } else if (rt === 'reply' || rt === 'reply-all') {
         setTimeout(() => {
           editor()?.focus();
+          bottomBarRef?.scrollIntoView({ block: 'nearest' });
         }, 100);
       }
     });
@@ -1002,8 +1055,15 @@ export function BaseInput(props: {
 
     if (form().replyType() !== requestReplyType) {
       form().setReplyType(requestReplyType);
+    } else if (requestReplyType === 'forward') {
+      // setReplyType is skipped when the type is unchanged, so land the
+      // cursor in the To field explicitly
+      focusForwardRecipients();
     }
-    form().setShouldFocusInput(true);
+    // Forwards focus the To field; focusing the editor would steal it back
+    if (requestReplyType !== 'forward') {
+      form().setShouldFocusInput(true);
+    }
     ctx.replyRequest.clear();
   });
 
@@ -1091,6 +1151,7 @@ export function BaseInput(props: {
   const [attachComposeHotkeys, composeHotkeyScope] =
     useHotkeyDOMScope('compose-message');
   let composeContainerRef: HTMLDivElement | undefined;
+  let bottomBarRef: HTMLDivElement | undefined;
   useTouchOutsideToDismissKeyboard(() => composeContainerRef);
   const [isFocused, setIsFocused] = createSignal(false);
 
@@ -1407,6 +1468,12 @@ export function BaseInput(props: {
       form().setShouldFocusInput(false);
       return;
     }
+    // Forwards focus the To field; a stale flag consumed here after the
+    // editor mounts would move the caret into the editor body instead.
+    if (effectiveReplyType() === 'forward') {
+      form().setShouldFocusInput(false);
+      return;
+    }
     const ed = editor();
     if (!ed) return;
     requestAnimationFrame(() => {
@@ -1594,6 +1661,8 @@ export function BaseInput(props: {
 
     const currentlyAppended = form().replyAppended();
     form().setReplyAppended(!currentlyAppended);
+    // Explicitly showing quoted text via the toolbar reveals it uncollapsed
+    if (!currentlyAppended) setQuoteCollapsed(false);
 
     editor()?.dispatchCommand(TOGGLE_APPEND_EMAIL_THREAD_COMMAND, {
       replyingTo,
@@ -1605,6 +1674,60 @@ export function BaseInput(props: {
       $getRoot().getFirstChild()?.selectStart();
     });
   };
+
+  const AttachmentsRow = (rowProps?: { class?: string }) => (
+    <Show when={form().attachments.list().length > 0}>
+      <div
+        class={cn(
+          'ph-no-capture shrink-0 flex gap-1 flex-wrap w-full py-2',
+          rowProps?.class
+        )}
+      >
+        <For each={form().attachments.list()}>
+          {(attachment) => (
+            <Switch>
+              <Match when={attachment.type === 'local' && attachment}>
+                {(attachment) => (
+                  <EmailAttachmentPill
+                    attachment={{
+                      fileName: attachment().file.name,
+                      mimeType: attachment().file.type,
+                    }}
+                    removable
+                    onRemove={() => handleRemoveAttachment(attachment())}
+                  />
+                )}
+              </Match>
+              <Match when={attachment.type === 'remote' && attachment}>
+                {(attachment) => (
+                  <EmailAttachmentPill
+                    attachment={{
+                      fileName: attachment().fileName,
+                      mimeType: attachment().contentType,
+                    }}
+                    removable
+                    onRemove={() => handleRemoveAttachment(attachment())}
+                  />
+                )}
+              </Match>
+              <Match when={attachment.type === 'forwarded' && attachment}>
+                {(attachment) => (
+                  <EmailAttachmentPill
+                    attachment={{
+                      fileName: attachment().fileName,
+                      mimeType: attachment().mimeType,
+                    }}
+                    removable
+                    onRemove={() => handleRemoveAttachment(attachment())}
+                  />
+                )}
+              </Match>
+            </Switch>
+          )}
+        </For>
+      </div>
+    </Show>
+  );
 
   const AttachButton = (buttonProps?: {
     variant?: 'ghost' | 'base';
@@ -1835,6 +1958,7 @@ export function BaseInput(props: {
                       To
                     </div>
                     <RecipientSelector<EmailRecipient['kind']>
+                      openOnFocus={false}
                       class="min-w-0 bg-transparent rounded-none! [&_input]:ml-0!"
                       inputRef={setToRef}
                       options={ctx.recipientOptions}
@@ -1864,6 +1988,7 @@ export function BaseInput(props: {
                         Cc
                       </div>
                       <RecipientSelector<EmailRecipient['kind']>
+                        openOnFocus={false}
                         class="min-w-0 bg-transparent rounded-none! [&_input]:ml-0!"
                         inputRef={setCcRef}
                         options={ctx.recipientOptions}
@@ -1894,6 +2019,7 @@ export function BaseInput(props: {
                         Bcc
                       </div>
                       <RecipientSelector<EmailRecipient['kind']>
+                        openOnFocus={false}
                         class="min-w-0 bg-transparent rounded-none! [&_input]:ml-0!"
                         inputRef={setBccRef}
                         options={ctx.recipientOptions}
@@ -1945,6 +2071,7 @@ export function BaseInput(props: {
           >
             <div class="shrink-0 text-ink-placeholder">To:</div>
             <RecipientSelector<EmailRecipient['kind']>
+              openOnFocus={false}
               class={mobileRecipientSelectorClass}
               inputRef={setToRef}
               options={ctx.recipientOptions}
@@ -1987,6 +2114,7 @@ export function BaseInput(props: {
             >
               <div class="shrink-0 text-ink-placeholder">Cc:</div>
               <RecipientSelector<EmailRecipient['kind']>
+                openOnFocus={false}
                 class={mobileRecipientSelectorClass}
                 inputRef={setCcRef}
                 options={ctx.recipientOptions}
@@ -2015,6 +2143,7 @@ export function BaseInput(props: {
             >
               <div class="shrink-0 text-ink-placeholder">Bcc:</div>
               <RecipientSelector<EmailRecipient['kind']>
+                openOnFocus={false}
                 class={mobileRecipientSelectorClass}
                 inputRef={setBccRef}
                 options={ctx.recipientOptions}
@@ -2090,8 +2219,23 @@ export function BaseInput(props: {
             'relative min-h-18 w-full flex flex-col placeholder:text-ink-placeholder placeholder:opacity-50 px-4 py-1',
             isMobileDrawer()
               ? 'max-h-none flex-1 overflow-visible px-5 pt-6 pb-4'
-              : 'max-h-[calc(60*var(--dvh,1dvh))] overflow-y-auto mobile:max-h-[calc(32*var(--dvh,1dvh))]'
+              : cn(
+                  'overflow-y-auto mobile:max-h-[calc(32*var(--dvh,1dvh))]',
+                  composerExpanded()
+                    ? // Cap to the thread viewport (minus composer chrome) so the
+                      // recipients row and send bar stay on screen together
+                      'max-h-[min(calc(60*var(--dvh,1dvh)),calc(var(--thread-height,9999px)-14rem))]'
+                    : 'max-h-56'
+                )
           )}
+          onScroll={(e) => {
+            if (composerExpanded() || e.currentTarget.scrollTop <= 0) return;
+            setComposerExpanded(true);
+            // Keep the send bar pinned while the box grows
+            requestAnimationFrame(() => {
+              bottomBarRef?.scrollIntoView({ block: 'nearest' });
+            });
+          }}
           onclick={() => {
             editor()?.focus();
           }}
@@ -2132,6 +2276,10 @@ export function BaseInput(props: {
             class={cn(
               'ph-no-capture cursor-text wrap-break-word text-ink h-auto overflow-visible',
               isMobileDrawer() ? 'text-[17px] leading-6' : 'text-sm',
+              // Quoted thread collapses behind the "⋯" pill below
+              // (rule lives in LexicalMarkdown/styles.css — Tailwind arbitrary
+              // variants turn the underscore in .macro_quote into a space)
+              !isMobileDrawer() && quoteCollapsed() && 'quote-collapsed',
               isDragging() && 'blur'
             )}
             disabled={sendMutation.isPending}
@@ -2145,6 +2293,27 @@ export function BaseInput(props: {
             refFn={(el) => props.markdownDomRef?.(el)}
             onConnect={handleEditorConnect}
           />
+          <Show
+            when={
+              !isMobileDrawer() && form().replyAppended() && quoteCollapsed()
+            }
+          >
+            <div class="flex items-center py-1.5">
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                class="rounded-md text-ink-extra-muted hover:text-ink-muted hover:bg-active"
+                tooltip="Show quoted text"
+                onclick={(e: MouseEvent) => {
+                  e.stopPropagation();
+                  setQuoteCollapsed(false);
+                  setComposerExpanded(true);
+                }}
+              >
+                <DotsThree />
+              </Button>
+            </div>
+          </Show>
           <Show when={isMobileDrawer() && props.replyingTo()}>
             <div
               class="shrink-0 pt-2 pb-1"
@@ -2176,50 +2345,9 @@ export function BaseInput(props: {
               <MacroSignatureButton />
             </div>
           </Show>
-          <div class="ph-no-capture flex gap-1 flex-wrap w-full py-2">
-            <For each={form().attachments.list()}>
-              {(attachment) => (
-                <Switch>
-                  <Match when={attachment.type === 'local' && attachment}>
-                    {(attachment) => (
-                      <EmailAttachmentPill
-                        attachment={{
-                          fileName: attachment().file.name,
-                          mimeType: attachment().file.type,
-                        }}
-                        removable
-                        onRemove={() => handleRemoveAttachment(attachment())}
-                      />
-                    )}
-                  </Match>
-                  <Match when={attachment.type === 'remote' && attachment}>
-                    {(attachment) => (
-                      <EmailAttachmentPill
-                        attachment={{
-                          fileName: attachment().fileName,
-                          mimeType: attachment().contentType,
-                        }}
-                        removable
-                        onRemove={() => handleRemoveAttachment(attachment())}
-                      />
-                    )}
-                  </Match>
-                  <Match when={attachment.type === 'forwarded' && attachment}>
-                    {(attachment) => (
-                      <EmailAttachmentPill
-                        attachment={{
-                          fileName: attachment().fileName,
-                          mimeType: attachment().mimeType,
-                        }}
-                        removable
-                        onRemove={() => handleRemoveAttachment(attachment())}
-                      />
-                    )}
-                  </Match>
-                </Switch>
-              )}
-            </For>
-          </div>
+          <Show when={isMobileDrawer()}>
+            <AttachmentsRow />
+          </Show>
           <Show when={scrollAreaSignatureHtml()}>
             {(html) => (
               <SignaturePreview
@@ -2230,6 +2358,8 @@ export function BaseInput(props: {
           </Show>
         </div>
         <Show when={!isMobileDrawer()}>
+          {/* Below the scroll area so quoted email content can never overlap it */}
+          <AttachmentsRow class="px-4" />
           <Show when={footerSignatureHtml()}>
             {(html) => (
               <SignaturePreview
@@ -2241,7 +2371,10 @@ export function BaseInput(props: {
           {/* No fixed height: the send button (size-7.5) is taller than the icon
               buttons, and a fixed h-9 minus the vertical padding left it 4px short
               — with items-end it bled upward over the signature bar above. */}
-          <div class="shrink-0 flex flex-row w-full justify-between items-end space-x-2 px-2 pb-2 pt-1.5">
+          <div
+            ref={bottomBarRef}
+            class="shrink-0 flex flex-row w-full justify-between items-end space-x-2 px-2 pb-2 pt-1.5"
+          >
             <div class="flex flex-row items-center gap-1">
               <div class="relative flex">
                 <AttachButton />

--- a/js/app/packages/block-email/component/BaseInput.tsx
+++ b/js/app/packages/block-email/component/BaseInput.tsx
@@ -2279,7 +2279,7 @@ export function BaseInput(props: {
               // Quoted thread collapses behind the "⋯" pill below
               // (rule lives in LexicalMarkdown/styles.css — Tailwind arbitrary
               // variants turn the underscore in .macro_quote into a space)
-              !isMobileDrawer() && quoteCollapsed() && 'quote-collapsed',
+              quoteCollapsed() && 'quote-collapsed',
               isDragging() && 'blur'
             )}
             disabled={sendMutation.isPending}
@@ -2293,11 +2293,7 @@ export function BaseInput(props: {
             refFn={(el) => props.markdownDomRef?.(el)}
             onConnect={handleEditorConnect}
           />
-          <Show
-            when={
-              !isMobileDrawer() && form().replyAppended() && quoteCollapsed()
-            }
-          >
+          <Show when={form().replyAppended() && quoteCollapsed()}>
             <div class="flex items-center py-1.5">
               <Button
                 variant="ghost"
@@ -2314,7 +2310,14 @@ export function BaseInput(props: {
               </Button>
             </div>
           </Show>
-          <Show when={isMobileDrawer() && props.replyingTo()}>
+          <Show
+            when={
+              isMobileDrawer() &&
+              props.replyingTo() &&
+              // The collapse pill above already covers this state
+              !(form().replyAppended() && quoteCollapsed())
+            }
+          >
             <div
               class="shrink-0 pt-2 pb-1"
               data-corvu-no-drag=""

--- a/js/app/packages/block-email/component/EmailMessageBody.tsx
+++ b/js/app/packages/block-email/component/EmailMessageBody.tsx
@@ -98,13 +98,25 @@ export function EmailMessageBody(props: EmailMessageBodyProps) {
       : parsedBodyReplyless();
   };
 
+  // Sent-from-Macro messages strip the quoted thread from body_macro at send
+  // time, and the backend skips replyless trimming for "Fwd:" subjects — so a
+  // quote in the full html means there is hidden content regardless of
+  // body_replyless.
+  const bodyHtmlHasQuote = createMemo(() => {
+    const html = props.message.body_html_sanitized;
+    if (!html || !props.message.body_macro) return false;
+    const doc = new DOMParser().parseFromString(html.toString(), 'text/html');
+    return doc.body.querySelector('.macro_quote') !== null;
+  });
+
   const hasHiddenReplyStructure = () => {
     return (
       !isPlaintext() &&
-      ((bodyReplyless() &&
-        bodyReplyless().toString().replace(/\s+/g, '').length !==
-          props.message.body_html_sanitized?.toString().replace(/\s+/g, '')
-            .length) ||
+      (bodyHtmlHasQuote() ||
+        (bodyReplyless() &&
+          bodyReplyless().toString().replace(/\s+/g, '').length !==
+            props.message.body_html_sanitized?.toString().replace(/\s+/g, '')
+              .length) ||
         source()?.signature)
     );
   };

--- a/js/app/packages/block-email/component/MessageList.tsx
+++ b/js/app/packages/block-email/component/MessageList.tsx
@@ -55,6 +55,8 @@ export function MessageList(props: MessageListProps) {
         '--thread-bottom-pad',
         `${Math.round(list.clientHeight * LAST_MESSAGE_REST_FRACTION)}px`
       );
+      // Lets the inline composer cap its height to the visible thread area
+      list.style.setProperty('--thread-height', `${list.clientHeight}px`);
     });
     observer.observe(list);
     onCleanup(() => observer.disconnect());

--- a/js/app/packages/block-email/component/createEmailFormState.ts
+++ b/js/app/packages/block-email/component/createEmailFormState.ts
@@ -260,7 +260,10 @@ export function createEmailFormState(
       if (rt === 'forward') {
         setState('withQuotedText', true);
         const editor = capturedEditor();
-        if (editor) {
+        // The captured editor can be a stale one from an unmounted composer
+        // (this state outlives the component); dispatching into it is a no-op,
+        // so defer the append to the next editor capture instead.
+        if (editor?.getRootElement()?.isConnected) {
           editor.dispatchCommand(TOGGLE_APPEND_EMAIL_THREAD_COMMAND, {
             replyingTo: replyingTo,
             replyType: rt,

--- a/js/app/packages/block-email/util/prepareEmailBody.ts
+++ b/js/app/packages/block-email/util/prepareEmailBody.ts
@@ -173,9 +173,11 @@ const $appendPreviousEmail = (
   } else {
     const parser = new DOMParser();
     const dom = parser.parseFromString(replyingToBodyHTML, 'text/html');
-    // We are checking if the appended reply contains a table. This is not exact, but is a good indicator that an email will contain content that we can not render correctly, in which case the appended reply will be a non-editable HTML Render Node.
+    // Forwards always embed the original as a non-editable HTML Render Node so
+    // the recipient gets the exact original markup. For replies, a table is a
+    // good indicator of content we can't convert into editable nodes correctly.
     const hasTable = Boolean(dom.querySelector('table'));
-    if (hasTable) {
+    if (replyType === 'forward' || hasTable) {
       const htmlNode = $createHtmlRenderNode({ html: replyingToBodyHTML });
       quoteNode.append(htmlNode);
     } else {

--- a/js/app/packages/block-email/util/prepareEmailBody.ts
+++ b/js/app/packages/block-email/util/prepareEmailBody.ts
@@ -12,11 +12,13 @@ import {
 } from '@lexical-core';
 import type { ApiMessage } from '@service-email/generated/schemas';
 import {
+  $addUpdateTag,
   $createLineBreakNode,
   $createParagraphNode,
   $createTextNode,
   $getRoot,
   $isLineBreakNode,
+  $setSelection,
   COMMAND_PRIORITY_EDITOR,
   createCommand,
   type LexicalEditor,
@@ -109,11 +111,22 @@ function $generateHeaderNodes(
 ): LexicalNode[] {
   const descriptor = buildHeaderDescriptor(replyingTo, replyType);
   if (descriptor.kind === 'forward') {
-    return descriptor.lines.map((line) => {
-      const p = $createParagraphNode();
-      p.append($createTextNode(line));
-      return p;
+    // Match Gmail's forward markup: headers live in a gmail_attr div inside
+    // the gmail_quote — quote-trimming (ours and Gmail's) keys off it
+    const emailHeader = $createClassedBlockNode({
+      tag: 'div',
+      classes: ['gmail_attr'],
+      attributes: replyingTo.replying_to_id
+        ? {
+            [REPLYING_TO_ID_ATTRIBUTE]: replyingTo.replying_to_id,
+          }
+        : undefined,
     });
+    descriptor.lines.forEach((line, i) => {
+      if (i > 0) emailHeader.append($createLineBreakNode());
+      emailHeader.append($createTextNode(line));
+    });
+    return [emailHeader];
   }
   const emailHeader = $createClassedBlockNode({
     tag: 'div',
@@ -208,6 +221,7 @@ function removeAppendedThread(
 
   editor.update(
     () => {
+      $addUpdateTag('skip-dom-selection');
       for (const node of $findPreviousEmailNode(replyingToID)) {
         if (!node) continue;
 
@@ -222,6 +236,9 @@ export function registerToggleAppendedThread(editor: LexicalEditor) {
   return editor.registerCommand(
     TOGGLE_APPEND_EMAIL_THREAD_COMMAND,
     ({ replyingTo, visible, replyType }) => {
+      // Programmatic content change: don't let selection reconciliation
+      // move DOM focus into the editor
+      $addUpdateTag('skip-dom-selection');
       const replyingToID = replyingTo?.replying_to_id ?? undefined;
 
       if (!visible) {
@@ -230,6 +247,9 @@ export function registerToggleAppendedThread(editor: LexicalEditor) {
       }
 
       $appendPreviousEmail(editor, replyingTo, replyType);
+      // Appending leaves a dirty selection inside the quote; any later
+      // update would flush it to the DOM and steal focus into the editor
+      $setSelection(null);
 
       return true;
     },
@@ -489,6 +509,15 @@ export function prepareEmailBody(
   // Convert Macro document mentions to HTML links in the parsed DOM
   const mentions = convertMentionsToLinks(parsed.body);
 
+  // HtmlRenderNode exports as declarative shadow DOM; email clients and the
+  // backend sanitizer drop template content, so inline it
+  for (const host of parsed.body.querySelectorAll('div[data-html-render]')) {
+    const template = host.querySelector('template[shadowrootmode]');
+    if (template instanceof HTMLTemplateElement) {
+      host.replaceChildren(template.content.cloneNode(true));
+    }
+  }
+
   if (appendReply && !parsed.body.querySelector('.macro_quote')) {
     const appendedReplyElement = getAppendedReplyElement(
       appendReply.replyingTo,
@@ -534,8 +563,10 @@ export function hasDraftContent(
 }
 
 export function prepareMacroBody(bodyMacro: string): string {
-  // Remove macro-quote blocks from the markdown string
+  // Remove appended-quote blocks from the markdown string
   // We want these in the HTML, but not in body_macro
   // TODO (seamus + peter) Add logic for binding a markdown signal that skips certain transforms
-  return bodyMacro.replace(/<macro-quote>.*?<\/macro-quote>/gs, '').trim();
+  return bodyMacro
+    .replace(/<m-email-thread-embed>.*?<\/m-email-thread-embed>/gs, '')
+    .trim();
 }

--- a/js/app/packages/core/component/LexicalMarkdown/component/decorator/HtmlRender.tsx
+++ b/js/app/packages/core/component/LexicalMarkdown/component/decorator/HtmlRender.tsx
@@ -30,7 +30,13 @@ export const HtmlRender: Component<HtmlRenderDecoratorProps> = (props) => {
     <>
       <div ref={marker} style={{ display: 'contents' }} />
       <Portal mount={shadowContainer()}>
-        <div data-html-render="true" innerHTML={props.html} />
+        {/* contain: floats/positioned content in email HTML must size and
+            paint within this node, not over siblings below the editor */}
+        <div
+          data-html-render="true"
+          style={{ contain: 'layout' }}
+          innerHTML={props.html}
+        />
       </Portal>
     </>
   );

--- a/js/app/packages/core/component/LexicalMarkdown/styles.css
+++ b/js/app/packages/core/component/LexicalMarkdown/styles.css
@@ -13,6 +13,11 @@
   display: contents;
 }
 
+/* Email composer collapses the appended quoted thread behind an expander pill */
+.quote-collapsed .macro_quote {
+  display: none;
+}
+
 .md * {
   caret-color: currentcolor;
 }

--- a/js/app/packages/core/component/RecipientSelector.tsx
+++ b/js/app/packages/core/component/RecipientSelector.tsx
@@ -266,6 +266,8 @@ type RecipientSelectorProps<K extends CombinedRecipientKind> = {
   inputRef?: (ref: HTMLInputElement) => void;
   inputId?: string;
   focusOnMount?: boolean;
+  /** Open the suggestions dropdown when the input gains focus (default true) */
+  openOnFocus?: boolean;
   triggerMode?: ComboboxTriggerMode;
   hideBorder?: boolean;
   noPadding?: boolean;
@@ -758,7 +760,9 @@ export function RecipientSelector<K extends CombinedRecipientKind>(
                     }}
                     class="flex-1 min-h-7 p-1 min-w-50 outline-none placeholder:text-ink-placeholder"
                     classList={{ 'ml-1': selectedLen() === 0 }}
-                    onFocus={() => setIsOpen(true)}
+                    onFocus={() => {
+                      if (props.openOnFocus ?? true) setIsOpen(true);
+                    }}
                     onKeyDown={(e) => {
                       if (
                         (e.key === 'a' && e.ctrlKey) ||

--- a/js/lexical-core/nodes/HtmlRenderNode.ts
+++ b/js/lexical-core/nodes/HtmlRenderNode.ts
@@ -83,7 +83,12 @@ export class HtmlRenderNode extends DecoratorBlockNode<
 
   static importDOM(): DOMConversionMap<HTMLDivElement> | null {
     const convert = (domNode: HTMLElement) => {
-      if (!domNode.hasAttribute('data-html-render')) {
+      // The backend sanitizer strips data-* attributes but keeps classes, so
+      // the class marker is what survives a draft save/restore round-trip
+      if (
+        !domNode.hasAttribute('data-html-render') &&
+        !domNode.classList.contains('macro_html_render')
+      ) {
         return null;
       }
 
@@ -107,6 +112,7 @@ export class HtmlRenderNode extends DecoratorBlockNode<
   exportDOM() {
     const host = document.createElement('div');
     host.setAttribute('data-html-render', 'true');
+    host.className = 'macro_html_render';
 
     const template = document.createElement('template');
     template.setAttribute('shadowrootmode', 'open');

--- a/js/lexical-core/tests/htmlRender.test.ts
+++ b/js/lexical-core/tests/htmlRender.test.ts
@@ -1,0 +1,89 @@
+import {
+  $convertFromMarkdownString,
+  $convertToMarkdownString,
+} from '@lexical/markdown';
+import { $createQuoteNode } from '@lexical/rich-text';
+import { $dfsIterator } from '@lexical/utils';
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  createEditor,
+} from 'lexical';
+import { describe, expect, it } from 'vitest';
+import { SupportedNodeTypes } from '../node-list';
+import { $createClassedBlockNode } from '../nodes/ClassedBlockNode';
+import { $isHtmlRenderNode, HtmlRenderNode } from '../nodes/HtmlRenderNode';
+import { INTERNAL_TRANSFORMERS } from '../transformers';
+
+const QUOTED_HTML =
+  '<table><tbody><tr><td><a href="https://example.com">Join</a> the meeting</td></tr></tbody></table>';
+
+function $buildForwardEditorState() {
+  const root = $getRoot();
+  const paragraph = $createParagraphNode();
+  paragraph.append($createTextNode('should i go'));
+  root.append(paragraph);
+
+  // Same shape the composer builds for a forward: quote wrapper containing
+  // the header lines and a blockquote holding the rendered original email.
+  const wrapper = $createClassedBlockNode({
+    tag: 'div',
+    classes: ['macro_quote', 'gmail_quote'],
+  });
+  const header = $createParagraphNode();
+  header.append($createTextNode('---------- Forwarded message ----------'));
+  wrapper.append(header);
+
+  const quote = $createQuoteNode();
+  quote.append(new HtmlRenderNode(QUOTED_HTML));
+  wrapper.append(quote);
+  root.append(wrapper);
+}
+
+describe('HtmlRenderNode - m-html-render transformer', () => {
+  it('round-trips rendered email html nested in a forward quote', async () => {
+    const editor = createEditor({
+      nodes: SupportedNodeTypes,
+      onError: console.error,
+    });
+
+    await new Promise<void>((resolve) => {
+      editor.update(() => $buildForwardEditorState(), {
+        onUpdate: () => resolve(),
+      });
+    });
+
+    let markdown = '';
+    editor.getEditorState().read(() => {
+      markdown = $convertToMarkdownString(INTERNAL_TRANSFORMERS);
+    });
+
+    // The quoted html must survive serialization (angle brackets escaped)
+    expect(markdown).toContain('<m-html-render>');
+    expect(markdown).toContain('</m-html-render>');
+    expect(markdown).not.toContain('<table>');
+    expect(markdown).toContain('\\u003ctable\\u003e');
+
+    // Import back and verify the node is restored with the original html
+    const editor2 = createEditor({
+      nodes: SupportedNodeTypes,
+      onError: console.error,
+    });
+    await new Promise<void>((resolve) => {
+      editor2.update(
+        () => $convertFromMarkdownString(markdown, INTERNAL_TRANSFORMERS),
+        { onUpdate: () => resolve() }
+      );
+    });
+
+    editor2.getEditorState().read(() => {
+      const htmlNodes = [];
+      for (const { node } of $dfsIterator()) {
+        if ($isHtmlRenderNode(node)) htmlNodes.push(node);
+      }
+      expect(htmlNodes).toHaveLength(1);
+      expect(htmlNodes[0].exportComponentProps().html).toBe(QUOTED_HTML);
+    });
+  });
+});

--- a/js/lexical-core/transformers/classedBlock.ts
+++ b/js/lexical-core/transformers/classedBlock.ts
@@ -14,6 +14,7 @@ import {
   isAllowedTagName,
 } from '../nodes/ClassedBlockNode';
 import { CUSTOM_TRANSFORMERS } from './customTransformers';
+import { I_HTML_RENDER } from './htmlRender';
 import { I_EQUATION_NODE } from './katex';
 import {
   I_CONTACT_MENTION,
@@ -34,6 +35,7 @@ const REG_EXP_HTML_BLOCKQUOTE_TAG = /<\/?blockquote\b[^>]*>/gi;
 
 // Transformers used inside macro_quote blocks
 const MACRO_QUOTE_TRANSFORMERS = [
+  I_HTML_RENDER,
   ...CUSTOM_TRANSFORMERS,
   I_EQUATION_NODE,
   I_USER_MENTION,
@@ -45,6 +47,7 @@ const MACRO_QUOTE_TRANSFORMERS = [
 function htmlBlockquoteTransformers() {
   return [
     HTML_BLOCKQUOTE,
+    I_HTML_RENDER,
     ...CUSTOM_TRANSFORMERS,
     I_EQUATION_NODE,
     I_USER_MENTION,
@@ -234,7 +237,11 @@ export const I_MACRO_QUOTE: ElementTransformer = {
 
       const metadata = JSON.parse(metadataMatch[1]);
       const { tag, classes } = metadata;
-      if (typeof tag !== 'string' || !isAllowedTagName(tag) || !Array.isArray(classes)) {
+      if (
+        typeof tag !== 'string' ||
+        !isAllowedTagName(tag) ||
+        !Array.isArray(classes)
+      ) {
         throw new Error('Invalid macro-quote metadata');
       }
 

--- a/js/lexical-core/transformers/customTransformers.ts
+++ b/js/lexical-core/transformers/customTransformers.ts
@@ -1,3 +1,4 @@
+import { $isListNode } from '@lexical/list';
 import {
   CHECK_LIST,
   type ElementTransformer,
@@ -6,7 +7,6 @@ import {
   type Transformer,
   UNORDERED_LIST,
 } from '@lexical/markdown';
-import { $isListNode } from '@lexical/list';
 import { $isHeadingNode } from '@lexical/rich-text';
 import { $isElementNode, type ElementNode, type LexicalNode } from 'lexical';
 

--- a/js/lexical-core/transformers/htmlRender.ts
+++ b/js/lexical-core/transformers/htmlRender.ts
@@ -1,0 +1,47 @@
+import type { TextMatchTransformer } from '@lexical/markdown';
+import type { TextNode } from 'lexical';
+import {
+  $createHtmlRenderNode,
+  $isHtmlRenderNode,
+  HtmlRenderNode,
+} from '../nodes/HtmlRenderNode';
+import {
+  replaceTextWithUnknownMention,
+  UnknownMentionNode,
+} from './unknownFallback';
+
+// Internal transformer — carries the raw HTML payload so rendered email
+// content (e.g. a forwarded message with tables) survives the markdown
+// round-trip. Text-match rather than element: element transformers only run
+// on top-level nodes, and this node lives nested inside blockquotes, where
+// only text-match transformers are consulted.
+export const I_HTML_RENDER: TextMatchTransformer = {
+  dependencies: [HtmlRenderNode, UnknownMentionNode],
+  type: 'text-match',
+  regExp: /<m-html-render>(.*?)<\/m-html-render>/,
+  importRegExp: /<m-html-render>(.*?)<\/m-html-render>/,
+  export: (node) => {
+    if (!$isHtmlRenderNode(node)) return null;
+
+    // Escape angle brackets as unicode escapes so tags inside the HTML don't
+    // get matched by other transformers during import. JSON.parse handles
+    // them natively.
+    const data = JSON.stringify(node.exportComponentProps())
+      .replace(/</g, '\\u003c')
+      .replace(/>/g, '\\u003e');
+
+    return `<m-html-render>${data}</m-html-render>`;
+  },
+  replace: (node: TextNode, match: RegExpMatchArray) => {
+    try {
+      const data = JSON.parse(match[1] ?? '');
+      if (typeof data.html !== 'string') {
+        throw new Error('Missing html field');
+      }
+      node.replace($createHtmlRenderNode({ html: data.html }));
+    } catch (e) {
+      console.error('Failed to parse m-html-render:', e);
+      replaceTextWithUnknownMention(node, 'Unknown Content');
+    }
+  },
+};

--- a/js/lexical-core/transformers/index.ts
+++ b/js/lexical-core/transformers/index.ts
@@ -2,6 +2,7 @@ import type { Transformer } from '@lexical/markdown';
 import { I_AWAIT_NODE } from './await';
 import { HTML_BLOCKQUOTE, I_MACRO_QUOTE } from './classedBlock';
 import { CUSTOM_TRANSFORMERS } from './customTransformers';
+import { I_HTML_RENDER } from './htmlRender';
 import { I_IMAGE_CONSTRAINED, IMAGE } from './image';
 import {
   E_BLOCK_EQUATION_NODE,
@@ -53,6 +54,7 @@ export { isConversionOnlyTransformer };
 export const INTERNAL_TRANSFORMERS: Transformer[] = [
   I_SNAPSHOT_NODE, // Must be before mentions to avoid matching inner tags in snapshot content
   I_PASTE_NODE, // Must be before mentions to avoid matching inner tags in paste content
+  I_HTML_RENDER,
   PRESERVE_LINES,
   LINK_XML, // Prefer internal xml link to handle []() in link text
   MARK_XML,
@@ -118,6 +120,7 @@ export const EXTERNAL_TRANSFORMERS: Transformer[] = [
 export const ALL_TRANSFORMERS: Transformer[] = [
   I_SNAPSHOT_NODE, // Must be before mentions to avoid matching inner tags in snapshot content
   I_PASTE_NODE, // Must be before mentions to avoid matching inner tags in paste content
+  I_HTML_RENDER,
   E_PASTE_NODE,
   PRESERVE_LINES,
   LINK_XML, // Prefer internal xml link to handle []() in link text


### PR DESCRIPTION
Makes forwarding an email work like Gmail: the composer opens compact with the send bar visible, the quoted thread collapses behind a "…" button, and the forwarded HTML actually survives the trip to the recipient (and back into Macro's own message view).

## Composer UX

- **Compact-grow sizing**: the reply box opens small (`max-h-56`) with the send bar pinned on screen; on first scroll it expands to ~60% of the thread height. The thread height is published as a `--thread-height` CSS var from `MessageList`'s ResizeObserver.
- **Collapsed quote**: forwarded/quoted content is hidden behind a "…" button (styled to match the message-view expander). Clicking it reveals the quote and expands the composer.
- **Attachments strip**: attachment pills render below the scroll area on desktop instead of overlapping the email content.
- **Forward focus**: pressing `f` (or the Forward button) always puts the text cursor in the To: field without opening the recipient dropdown (`openOnFocus` prop on `RecipientSelector`). A focus-ownership guard bounces Lexical's asynchronous selection flushes — Lexical re-asserts dirty selections on later update commits, which previously stole focus back to the editor. The guard disarms on any user pointer/Tab/Escape interaction.
- **Re-forward after trashing a draft**: the cached form state held a reference to a dead editor, so the second forward silently dropped the quoted content. Appending is now deferred until a live editor connects.

## Send path

- **`body_macro` no longer contains the quoted thread**: `prepareMacroBody` was stripping an obsolete `<macro-quote>` tag instead of `<m-email-thread-embed>`, so raw quoted HTML leaked into the markdown body and broke rendering of sent forwards. Forwards now match replies: `body_macro` is just what you typed.
- **Shadow-DOM templates inlined**: `HtmlRenderNode` exports declarative shadow DOM (`<template shadowrootmode>`), which sanitizers drop (template content is an inert fragment). The template content is inlined into the host div at send/draft-save time so the forwarded body survives sanitization in any client.
- **Gmail-compatible quote markup**: forward headers are emitted as `div.gmail_attr` inside the `gmail_quote` wrapper, so recipients' clients (and our own backend replyless splitter) recognize and trim the quoted section.
- **New `m-html-render` transformer** (`lexical-core`): round-trips `HtmlRenderNode`'s raw HTML through the markdown serialization used for drafts. Implemented as a text-match transformer because element transformers only run on top-level nodes and this node lives nested inside blockquotes. Registered in the internal registries and in `I_MACRO_QUOTE`'s hardcoded child-transformer lists, with a round-trip regression test.

## Message rendering

- Sent forwards now show the "…" expander: the backend deliberately skips replyless trimming for `Fwd:` subjects, so `body_replyless` always equals the full body and the old length-comparison gate never fired. For Macro-sent messages the expander now also shows when the full HTML contains a `.macro_quote` block that the markdown view doesn't render.
- `HtmlRender` decorator content gets `contain: layout` so transient shadow-DOM layout can't disturb the thread scroll.
- `.quote-collapsed .macro_quote { display: none }` lives in plain CSS — the Tailwind arbitrary variant `[&_.macro_quote]:hidden` silently compiles underscores to spaces.
