### PR TITLE
fix(email): prompt to edit signature on desktop when on mobile

### DIFF
--- a/js/app/packages/app/component/settings/Email.tsx
+++ b/js/app/packages/app/component/settings/Email.tsx
@@ -12,7 +12,6 @@ import {
   useEmailLinks,
   useEmailLinksStatus,
 } from '@core/email-link';
-import { isMobile } from '@core/mobile/isMobile';
 import GmailIcon from '@icon/mcp-gmail.svg';
 import ArrowsClockwiseIcon from '@phosphor-icons/core/regular/arrows-clockwise.svg?component-solid';
 import PlusIcon from '@phosphor-icons/core/regular/plus.svg?component-solid';
@@ -450,15 +449,7 @@ function InboxRow(props: {
                 variant="base"
                 size="icon-sm"
                 depth={3}
-                onClick={() => {
-                  // Quill signature editing isn't supported on mobile; point
-                  // the user at desktop instead of expanding the editor.
-                  if (isMobile()) {
-                    toast.alert('Update your signature on desktop');
-                    return;
-                  }
-                  toggleSignatureExpanded(props.link.id);
-                }}
+                onClick={() => toggleSignatureExpanded(props.link.id)}
                 aria-label={`Edit signature for ${props.link.email_address}`}
                 aria-expanded={showSignature()}
                 aria-controls={signatureSectionId}
@@ -514,14 +505,7 @@ function InboxRow(props: {
           </Tooltip>
         </div>
       </div>
-      <Show
-        when={
-          ENABLE_EMAIL_SIGNATURES &&
-          props.isOwn &&
-          showSignature() &&
-          !isMobile()
-        }
-      >
+      <Show when={ENABLE_EMAIL_SIGNATURES && props.isOwn && showSignature()}>
         <div id={signatureSectionId} class="px-6 pb-4">
           <SignatureSection link={props.link} />
         </div>

--- a/js/app/packages/app/component/settings/Email.tsx
+++ b/js/app/packages/app/component/settings/Email.tsx
@@ -12,6 +12,7 @@ import {
   useEmailLinks,
   useEmailLinksStatus,
 } from '@core/email-link';
+import { isMobile } from '@core/mobile/isMobile';
 import GmailIcon from '@icon/mcp-gmail.svg';
 import ArrowsClockwiseIcon from '@phosphor-icons/core/regular/arrows-clockwise.svg?component-solid';
 import PlusIcon from '@phosphor-icons/core/regular/plus.svg?component-solid';
@@ -449,7 +450,15 @@ function InboxRow(props: {
                 variant="base"
                 size="icon-sm"
                 depth={3}
-                onClick={() => toggleSignatureExpanded(props.link.id)}
+                onClick={() => {
+                  // Quill signature editing isn't supported on mobile; point
+                  // the user at desktop instead of expanding the editor.
+                  if (isMobile()) {
+                    toast.alert('Update your signature on desktop');
+                    return;
+                  }
+                  toggleSignatureExpanded(props.link.id);
+                }}
                 aria-label={`Edit signature for ${props.link.email_address}`}
                 aria-expanded={showSignature()}
                 aria-controls={signatureSectionId}
@@ -505,7 +514,14 @@ function InboxRow(props: {
           </Tooltip>
         </div>
       </div>
-      <Show when={ENABLE_EMAIL_SIGNATURES && props.isOwn && showSignature()}>
+      <Show
+        when={
+          ENABLE_EMAIL_SIGNATURES &&
+          props.isOwn &&
+          showSignature() &&
+          !isMobile()
+        }
+      >
         <div id={signatureSectionId} class="px-6 pb-4">
           <SignatureSection link={props.link} />
         </div>

--- a/js/app/packages/app/component/settings/SignatureSection.tsx
+++ b/js/app/packages/app/component/settings/SignatureSection.tsx
@@ -1,5 +1,7 @@
 import { toast } from '@core/component/Toast/Toast';
+import { isMobile } from '@core/mobile/isMobile';
 import { ThrownResultError } from '@core/util/result';
+import SignatureIcon from '@phosphor-icons/core/regular/signature.svg?component-solid';
 import { useEmailSignature } from '@queries/email/link';
 import { useUpdateEmailSettingsMutation } from '@queries/email/settings';
 import { SIGNATURE_IMAGES_UNRESOLVED_CODE } from '@service-email/client';
@@ -158,23 +160,39 @@ export function SignatureSection(props: { link: EmailLink }) {
 
   return (
     <div class="flex flex-col gap-3 rounded-xl border border-edge-muted p-3">
-      <Suspense
+      {/* Editing (Quill) is desktop-only; on mobile the section still offers
+          the replies/forwards toggle and Remove, with a pointer to desktop. */}
+      <Show
+        when={!isMobile()}
         fallback={
-          <div class="h-44 animate-pulse rounded-lg border border-edge-muted" />
+          <div class="flex flex-col items-center gap-1.5 rounded-lg border border-dashed border-edge-muted px-3 py-6 text-center">
+            <SignatureIcon class="size-5 text-ink-muted" />
+            <p class="text-sm text-ink-muted">
+              Update your signature on desktop.
+            </p>
+          </div>
         }
       >
-        <SignatureEditor
-          value={draft() ?? persisted()}
-          onInput={(html) => {
-            setDraft(html);
-            setSaveError(null);
-          }}
-          onReady={(api) => {
-            editorApi = api;
-          }}
-        />
-      </Suspense>
-      <div class="flex items-center justify-between gap-3">
+        <Suspense
+          fallback={
+            <div class="h-44 animate-pulse rounded-lg border border-edge-muted" />
+          }
+        >
+          <SignatureEditor
+            value={draft() ?? persisted()}
+            onInput={(html) => {
+              setDraft(html);
+              setSaveError(null);
+            }}
+            onReady={(api) => {
+              editorApi = api;
+            }}
+          />
+        </Suspense>
+      </Show>
+      {/* Stacks on narrow screens so the toggle label and buttons never
+          crowd each other onto wrapped lines. */}
+      <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <ToggleSwitch
           checked={props.link.settings.signature_on_replies_forwards ?? false}
           onChange={setOnRepliesForwards}
@@ -184,7 +202,7 @@ export function SignatureSection(props: { link: EmailLink }) {
             </span>
           }
         />
-        <div class="flex items-center gap-2">
+        <div class="flex items-center justify-end gap-2">
           <Button
             variant="base"
             size="sm"
@@ -194,15 +212,17 @@ export function SignatureSection(props: { link: EmailLink }) {
           >
             Remove
           </Button>
-          <Button
-            variant="active"
-            size="sm"
-            depth={3}
-            disabled={!isDirty() || updateSettings.isPending}
-            onClick={saveSignature}
-          >
-            Save
-          </Button>
+          <Show when={!isMobile()}>
+            <Button
+              variant="active"
+              size="sm"
+              depth={3}
+              disabled={!isDirty() || updateSettings.isPending}
+              onClick={saveSignature}
+            >
+              Save
+            </Button>
+          </Show>
         </div>
       </div>
       <Show when={saveError()}>

--- a/js/app/packages/block-email/component/compose/SignaturePreview.tsx
+++ b/js/app/packages/block-email/component/compose/SignaturePreview.tsx
@@ -1,10 +1,9 @@
-import { toast } from '@core/component/Toast/Toast';
 import { isMobile } from '@core/mobile/isMobile';
 import InfoIcon from '@phosphor/info.svg';
 import CaretDownIcon from '@phosphor-icons/core/regular/caret-down.svg?component-solid';
 import XIcon from '@phosphor-icons/core/regular/x.svg?component-solid';
 import { Tooltip } from '@ui';
-import { createEffect, createSignal } from 'solid-js';
+import { createEffect, createSignal, Show } from 'solid-js';
 
 // Rendered inside a shadow root so the signature's structural markup (lists,
 // headings, bold) keeps its default styling instead of being flattened by the
@@ -71,23 +70,16 @@ export function SignaturePreview(props: {
             />
             Signature
           </button>
-          <Tooltip
-            label="Edit your signature in Settings -> Connections."
-            as="span"
-          >
-            {/* Tooltips never show on touch, so on mobile a tap surfaces the
-                guidance as a toast instead (editing is desktop-only). */}
-            <button
-              type="button"
-              class="flex items-center"
-              aria-label="Edit your signature in Settings -> Connections."
-              onClick={() => {
-                if (isMobile()) toast.alert('Update your signature on desktop');
-              }}
+          {/* Hover-only guidance; hidden on mobile where tooltips never show
+              (Settings still points mobile users to desktop). */}
+          <Show when={!isMobile()}>
+            <Tooltip
+              label="Edit your signature in Settings -> Connections."
+              as="span"
             >
               <InfoIcon class="size-3.5 text-ink-muted" />
-            </button>
-          </Tooltip>
+            </Tooltip>
+          </Show>
         </div>
         <Tooltip label="Don't include signature" as="span">
           <button

--- a/js/app/packages/block-email/component/compose/SignaturePreview.tsx
+++ b/js/app/packages/block-email/component/compose/SignaturePreview.tsx
@@ -1,3 +1,5 @@
+import { toast } from '@core/component/Toast/Toast';
+import { isMobile } from '@core/mobile/isMobile';
 import InfoIcon from '@phosphor/info.svg';
 import CaretDownIcon from '@phosphor-icons/core/regular/caret-down.svg?component-solid';
 import XIcon from '@phosphor-icons/core/regular/x.svg?component-solid';
@@ -73,7 +75,18 @@ export function SignaturePreview(props: {
             label="Edit your signature in Settings -> Connections."
             as="span"
           >
-            <InfoIcon class="size-3.5 text-ink-muted" />
+            {/* Tooltips never show on touch, so on mobile a tap surfaces the
+                guidance as a toast instead (editing is desktop-only). */}
+            <button
+              type="button"
+              class="flex items-center"
+              aria-label="Edit your signature in Settings -> Connections."
+              onClick={() => {
+                if (isMobile()) toast.alert('Update your signature on desktop');
+              }}
+            >
+              <InfoIcon class="size-3.5 text-ink-muted" />
+            </button>
           </Tooltip>
         </div>
         <Tooltip label="Don't include signature" as="span">


### PR DESCRIPTION
## Summary

Signature editing (the Quill editor) isn't supported on mobile, but the entry points still behaved as if it were. Editing is now desktop-only while the rest of the signature controls stay usable on mobile:

- **Settings > Connections**: the signature section still expands on mobile, but the editor is replaced with a placeholder card ("Update your signature on desktop."). The "Add to replies & forwards" toggle and the Remove button remain fully functional; Save is hidden since there's nothing to edit. The controls row stacks below the `sm` breakpoint so the toggle label no longer wraps against the buttons.
- **Compose/reply signature bar**: the (i) icon next to "Signature" was a hover-only tooltip, so it did nothing on touch. It's now hidden entirely on mobile (desktop hover tooltip unchanged).

## Changes

- `packages/app/component/settings/SignatureSection.tsx`: mobile renders a dashed placeholder card instead of the Quill editor and hides Save; toggle + Remove stay; responsive stacking for the controls row.
- `packages/app/component/settings/Email.tsx`: no mobile-specific gating — the section expands the same on all platforms.
- `packages/block-email/component/compose/SignaturePreview.tsx`: the info icon renders only on non-mobile.
