### PR TITLE
fix(search): scope result tags to the viewer

### DIFF
--- a/rust/cloud-storage/Cargo.lock
+++ b/rust/cloud-storage/Cargo.lock
@@ -12000,6 +12000,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "strum",
+ "system_properties",
  "thiserror 2.0.18",
  "tokio",
  "tower 0.5.3",

--- a/rust/cloud-storage/search_service/Cargo.toml
+++ b/rust/cloud-storage/search_service/Cargo.toml
@@ -37,6 +37,7 @@ models_soup = { path = "../models_soup" }
 properties = { path = "../properties", default-features = false, features = [
   "outbound",
 ] }
+system_properties = { path = "../system_properties" }
 readonly_pool = { path = "../readonly_pool" }
 macro_env = { path = "../macro_env" }
 macro_env_var = { path = "../macro_env_var" }

--- a/rust/cloud-storage/search_service/src/api/search/chat.rs
+++ b/rust/cloud-storage/search_service/src/api/search/chat.rs
@@ -1,6 +1,7 @@
 use crate::api::context::SearchHandlerState;
 use crate::api::search::simple::SearchError;
 use indexmap::IndexMap;
+use macro_user_id::user_id::MacroUserIdStr;
 use models_properties::{EntityReference, EntityType};
 use models_search::chat::{
     ChatMessageSearchResult, ChatSearchResponseItem, ChatSearchResponseItemWithMetadata,
@@ -9,6 +10,7 @@ use models_soup::SoupProperty;
 use opensearch_client::search::model::SearchGotoContent;
 use sqlx::types::Uuid;
 use std::collections::HashMap;
+use system_properties::SystemPropertyKey;
 
 /// Enriches chat search results with metadata
 #[tracing::instrument(skip(ctx, results), err)]
@@ -40,10 +42,16 @@ pub(in crate::api::search) async fn enrich_chats(
         .iter()
         .map(|id| EntityReference::new(id.to_string(), EntityType::Chat))
         .collect();
+    // Scope tags to the viewer so another user's personal tags never leak into
+    // the response. System properties still ride along via the key list.
+    let viewer_user_id = MacroUserIdStr::parse_from_str(user_id)
+        .map_err(|_| SearchError::InvalidUserId(user_id.to_string()))?;
     let properties_map: HashMap<String, Vec<SoupProperty>> =
-        properties::outbound::entity_properties_get_query::get_bulk_entity_properties_values(
+        properties::outbound::entity_properties_get_query::get_bulk_entity_properties_values_filtered(
             &ctx.db,
             &chat_entity_refs,
+            SystemPropertyKey::all_system_property_keys(),
+            Some(&viewer_user_id),
         )
         .await
         .inspect_err(|e| tracing::error!(error=?e, "failed to fetch chat properties"))

--- a/rust/cloud-storage/search_service/src/api/search/document.rs
+++ b/rust/cloud-storage/search_service/src/api/search/document.rs
@@ -1,5 +1,6 @@
 use crate::api::search::simple::SearchError;
 use indexmap::IndexMap;
+use macro_user_id::user_id::MacroUserIdStr;
 use models_opensearch::SearchEntityType;
 use models_properties::{EntityReference, EntityType};
 use models_search::SearchHighlight;
@@ -11,6 +12,7 @@ use name_search::highlight_name;
 use opensearch_client::search::model::SearchGotoContent;
 use sqlx::types::Uuid;
 use std::collections::HashMap;
+use system_properties::SystemPropertyKey;
 
 use crate::api::context::SearchHandlerState;
 
@@ -54,10 +56,16 @@ pub(in crate::api::search) async fn enrich_documents(
         })
         .collect();
 
+    // Scope tags to the viewer so another user's personal tags never leak into
+    // the response. System properties still ride along via the key list.
+    let viewer_user_id = MacroUserIdStr::parse_from_str(user_id)
+        .map_err(|_| SearchError::InvalidUserId(user_id.to_string()))?;
     let properties_map = if !entity_refs.is_empty() {
-        properties::outbound::entity_properties_get_query::get_bulk_entity_properties_values(
+        properties::outbound::entity_properties_get_query::get_bulk_entity_properties_values_filtered(
             &ctx.db,
             &entity_refs,
+            SystemPropertyKey::all_system_property_keys(),
+            Some(&viewer_user_id),
         )
         .await
         .inspect_err(|e| tracing::error!(error=?e, "failed to fetch entity properties"))

--- a/rust/cloud-storage/search_service/src/api/search/email.rs
+++ b/rust/cloud-storage/search_service/src/api/search/email.rs
@@ -2,6 +2,7 @@ use crate::api::context::SearchHandlerState;
 use crate::api::search::simple::SearchError;
 use email_db_client::contacts::get::ThreadContactsMap;
 use indexmap::IndexMap;
+use macro_user_id::user_id::MacroUserIdStr;
 use models_email::service::message::{MessageSenderInfo, ThreadHistoryInfo};
 use models_properties::{EntityReference, EntityType};
 use models_search::email::{
@@ -12,6 +13,7 @@ use models_soup::SoupProperty;
 use opensearch_client::search::model::SearchGotoContent;
 use sqlx::types::Uuid;
 use std::collections::HashMap;
+use system_properties::SystemPropertyKey;
 
 /// Enriches email search results with metadata
 #[tracing::instrument(skip(ctx, results), err)]
@@ -79,10 +81,16 @@ pub(in crate::api::search) async fn enrich_emails(
         .iter()
         .map(|id| EntityReference::new(id.to_string(), EntityType::Thread))
         .collect();
+    // Scope tags to the viewer so another user's personal tags never leak into
+    // the response. System properties still ride along via the key list.
+    let viewer_user_id = MacroUserIdStr::parse_from_str(user_id)
+        .map_err(|_| SearchError::InvalidUserId(user_id.to_string()))?;
     let properties_map: HashMap<String, Vec<SoupProperty>> =
-        properties::outbound::entity_properties_get_query::get_bulk_entity_properties_values(
+        properties::outbound::entity_properties_get_query::get_bulk_entity_properties_values_filtered(
             &ctx.db,
             &thread_entity_refs,
+            SystemPropertyKey::all_system_property_keys(),
+            Some(&viewer_user_id),
         )
         .await
         .inspect_err(|e| tracing::error!(error=?e, "failed to fetch thread properties"))

--- a/rust/cloud-storage/search_service/src/api/search/project.rs
+++ b/rust/cloud-storage/search_service/src/api/search/project.rs
@@ -1,5 +1,6 @@
 use crate::api::search::simple::SearchError;
 use indexmap::IndexMap;
+use macro_user_id::user_id::MacroUserIdStr;
 use models_properties::{EntityReference, EntityType};
 use models_search::project::{
     ProjectSearchResponseItem, ProjectSearchResponseItemWithMetadata, ProjectSearchResult,
@@ -7,6 +8,7 @@ use models_search::project::{
 use models_soup::SoupProperty;
 use sqlx::types::Uuid;
 use std::collections::HashMap;
+use system_properties::SystemPropertyKey;
 
 use crate::api::context::SearchHandlerState;
 
@@ -44,10 +46,16 @@ pub(in crate::api::search) async fn enrich_projects(
         .iter()
         .map(|id| EntityReference::new(id.to_string(), EntityType::Project))
         .collect();
+    // Scope tags to the viewer so another user's personal tags never leak into
+    // the response. System properties still ride along via the key list.
+    let viewer_user_id = MacroUserIdStr::parse_from_str(user_id)
+        .map_err(|_| SearchError::InvalidUserId(user_id.to_string()))?;
     let properties_map: HashMap<String, Vec<SoupProperty>> =
-        properties::outbound::entity_properties_get_query::get_bulk_entity_properties_values(
+        properties::outbound::entity_properties_get_query::get_bulk_entity_properties_values_filtered(
             &ctx.db,
             &project_entity_refs,
+            SystemPropertyKey::all_system_property_keys(),
+            Some(&viewer_user_id),
         )
         .await
         .inspect_err(|e| tracing::error!(error=?e, "failed to fetch project properties"))


### PR DESCRIPTION
Document, email, AI chat, and project search enrichment fetched entity properties with the unfiltered getter, so another user's personal tags applied to a shared entity were serialized into the raw search response (the frontend second-gates rendering against the viewer's own tag sets, so it wasn't visible in-app, but the tag labels were still sent to the client). Switch these paths to the viewer-scoped `get_bulk_entity_properties_values_filtered` — system-property keys plus `Some(viewer)` — exactly like the soup path, so only the caller's own/team tags are returned while system properties (Status/Priority/etc.) stay intact.
