### PR TITLE
fix(channel): un-wedge ThreadList initial scroll

### DIFF
--- a/js/app/packages/channel/Channel/ThreadList.tsx
+++ b/js/app/packages/channel/Channel/ThreadList.tsx
@@ -432,6 +432,25 @@ export function ThreadList(props: ThreadListProps) {
     });
   }
 
+  let disposed = false;
+
+  // A preview-pane mount can hand over the virtualizer before layout, with a
+  // zero-height viewport — the initial scroll then lands wherever and always
+  // needs the onScrollEnd retry. Wait (bounded) for a measured viewport.
+  function scrollOnMountWhenMeasured(
+    handle: VirtualizerHandle,
+    framesLeft = 30
+  ) {
+    if (disposed || initialScrollStarted) return;
+    if (handle.viewportSize > 0 || framesLeft <= 0) {
+      scrollOnMount(handle);
+      return;
+    }
+    requestAnimationFrame(() =>
+      scrollOnMountWhenMeasured(handle, framesLeft - 1)
+    );
+  }
+
   function scrollOnMount(handle: VirtualizerHandle) {
     if (initialScrollStarted) return;
     initialScrollStarted = true;
@@ -580,7 +599,10 @@ export function ThreadList(props: ThreadListProps) {
     }
   };
 
-  onCleanup(() => cancelPinToBottom?.());
+  onCleanup(() => {
+    disposed = true;
+    cancelPinToBottom?.();
+  });
 
   return (
     <>
@@ -616,7 +638,7 @@ export function ThreadList(props: ThreadListProps) {
               props.onNavigationReady(createNavigation(ref));
             }
             resetInitialScroll();
-            scrollOnMount(ref);
+            scrollOnMountWhenMeasured(ref);
           }}
           scrollRef={scrollRef}
           startMargin={insets().start}

--- a/js/app/packages/channel/Channel/ThreadList.tsx
+++ b/js/app/packages/channel/Channel/ThreadList.tsx
@@ -474,6 +474,7 @@ export function ThreadList(props: ThreadListProps) {
         distanceFromBottom: getDistanceFromBottom(handle),
       });
       requestAnimationFrame(() => {
+        const offsetBeforeRetry = handle.scrollOffset;
         const retryScrolled = scrollToInitialTarget(
           handle,
           initialScrollTarget
@@ -482,7 +483,21 @@ export function ThreadList(props: ThreadListProps) {
           // Target disappeared between mount and retry — finalize now since
           // no scroll events will fire to trigger another onScrollEnd.
           completeInitialScroll(handle);
+          return;
         }
+        // A retry that lands on the current position moves nothing, so no
+        // scroll events (and no onScrollEnd) follow. Finalize on the next
+        // frame or `didInitialScroll` stays false for the life of the mount,
+        // deadlocking everything gated on it (target navigation, scroll
+        // pagination, goToLatest).
+        requestAnimationFrame(() => {
+          if (didInitialScroll()) return;
+          if (handle.scrollOffset !== offsetBeforeRetry) return;
+          console.debug(
+            'ThreadList: retry did not move the scroll, completing'
+          );
+          completeInitialScroll(handle);
+        });
       });
       return;
     }

--- a/js/app/packages/channel/Channel/ThreadList.tsx
+++ b/js/app/packages/channel/Channel/ThreadList.tsx
@@ -246,12 +246,17 @@ export function ThreadList(props: ThreadListProps) {
       case 'index': {
         const targetIndex = resolveTargetIndex(target);
         if (targetIndex < 0) return true; // target gone, nothing to verify
-        const currentIndex = handle.findItemIndex(
-          handle.scrollOffset + insets().start
-        );
-        // Consider correct if the target is within a reasonable range of
-        // the current viewport (within ±5 items accounts for alignment).
-        return Math.abs(currentIndex - targetIndex) <= 5;
+        // Correct when the target item intersects the usable viewport.
+        // Comparing item indexes against the top-of-viewport item breaks for
+        // center/end alignment — a target near the end of the list rests in
+        // the lower half of the viewport, so a fixed index distance from the
+        // top item reports a perfect landing as a miss.
+        const itemTop = handle.getItemOffset(targetIndex);
+        const itemBottom = itemTop + handle.getItemSize(targetIndex);
+        const viewportTop = handle.scrollOffset + insets().start;
+        const viewportBottom =
+          handle.scrollOffset + handle.viewportSize - insets().end;
+        return itemBottom > viewportTop && itemTop < viewportBottom;
       }
     }
   };


### PR DESCRIPTION
ThreadList's initial scroll could wedge permanently: the position validation compared the top-of-viewport item index to the target within ±5, which always fails for targets near the end of the list (the last message cannot be centered), and the resulting retry emits no scroll events when it lands where the list already rests — so `didInitialScroll` stayed false for the life of the mount, silently blocking target-message navigation, scroll pagination, and goToLatest. Preview-pane mounts made this near-deterministic by firing the initial scroll against a zero-height viewport. Three fixes: complete the retry when it moves nothing, validate by target visibility instead of index distance, and defer the initial scroll until the viewport is measured.
