### PR TITLE
fix(channel): scroll sent thread reply into view in unified input mode

### DIFF
--- a/js/app/packages/channel/Channel/Channel.tsx
+++ b/js/app/packages/channel/Channel/Channel.tsx
@@ -23,6 +23,7 @@ import { toast } from '@core/component/Toast/Toast';
 import { useChannelActivity, useChannelName } from '@core/context/channels';
 import { useUserId } from '@core/context/user';
 import { isMobile } from '@core/mobile/isMobile';
+import { virtualKeyboardHeight } from '@core/mobile/virtualKeyboard';
 import type { DateValue } from '@core/util/date';
 import {
   extractUserMentions,
@@ -85,6 +86,7 @@ import { createChannelMessageActions } from './create-channel-message-actions';
 import { createDeleteMessageConfirmation } from './create-delete-message-confirmation';
 import { createMessageEditor } from './create-message-editor';
 import { createMessageSelection } from './create-message-selection';
+import { createSentReplyReveal } from './create-sent-reply-reveal';
 import {
   clearStaleRestoredChannelData,
   createTargetMessageController,
@@ -520,6 +522,12 @@ export function Channel(props: ChannelProps) {
     },
   });
 
+  const revealSentReply = createSentReplyReveal({
+    navigation: threadListNavigation,
+    obstructionHeight: () =>
+      virtualKeyboardHeight() + FloatRegions.hostHeight(),
+  });
+
   const onSend: ChannelInputProps['onSend'] = (snapshot) => {
     const senderId = userId();
     if (!senderId) return;
@@ -733,6 +741,9 @@ export function Channel(props: ChannelProps) {
                               )
                             }
                             onExit={unifiedInput.closeReply}
+                            onSent={(messageId) =>
+                              revealSentReply(threadId, messageId)
+                            }
                           />
                         )}
                       </Match>

--- a/js/app/packages/channel/Channel/UnifiedReplyInput.tsx
+++ b/js/app/packages/channel/Channel/UnifiedReplyInput.tsx
@@ -22,6 +22,8 @@ export function UnifiedReplyInput(props: {
   getTargetMessage: () => MessageData | undefined;
   onNavigateToTarget: () => void;
   onExit: () => void;
+  /** Called after a reply send is dispatched, with its optimistic id. */
+  onSent?: (messageId: string) => void;
 }) {
   return (
     <div
@@ -57,6 +59,7 @@ export function UnifiedReplyInput(props: {
         host="unified"
         collapsible
         onExit={() => props.onExit()}
+        onSent={props.onSent}
       />
     </div>
   );

--- a/js/app/packages/channel/Channel/create-sent-reply-reveal.ts
+++ b/js/app/packages/channel/Channel/create-sent-reply-reveal.ts
@@ -1,0 +1,80 @@
+import { type Accessor, onCleanup } from 'solid-js';
+import {
+  getMessageElement,
+  scrollElementAboveObstruction,
+} from '../scroll-utils';
+import type { ThreadListNavigation } from './ThreadList';
+
+/**
+ * How many frames to wait for the sent reply's row to render before giving
+ * up — covers the optimistic-insert flush, plus a virtua mount when the
+ * thread had to be scrolled back into view first.
+ */
+const MAX_REVEAL_FRAMES = 24;
+
+type CreateSentReplyRevealOptions = {
+  navigation: Accessor<ThreadListNavigation | undefined>;
+  /**
+   * Height of whatever covers the bottom of the screen — the floating input
+   * chrome, plus the virtual keyboard while it is up. Read at scroll time,
+   * since the keyboard is often mid-dismissal right after a send.
+   */
+  obstructionHeight: Accessor<number>;
+};
+
+/**
+ * Scrolls a just-sent thread reply into view (unified-input mode). The reply
+ * renders optimistically at the end of its thread, which the viewport does
+ * not follow: it can sit below the fold, behind the floating input and
+ * keyboard, or in a thread that was scrolled away from (and virtualized out
+ * of the DOM) while composing. The reveal waits for the reply's row to
+ * render — jumping to the thread first when its row isn't mounted — then
+ * scrolls the reply into view, clear of the bottom chrome. Already-visible
+ * replies are left alone.
+ */
+export function createSentReplyReveal(options: CreateSentReplyRevealOptions) {
+  let frame: number | undefined;
+
+  const cancel = () => {
+    if (frame === undefined) return;
+    cancelAnimationFrame(frame);
+    frame = undefined;
+  };
+
+  onCleanup(cancel);
+
+  return (threadId: string, messageId: string) => {
+    // A newer send owns the reveal.
+    cancel();
+
+    let didScrollToThread = false;
+    let framesLeft = MAX_REVEAL_FRAMES;
+
+    const tick = () => {
+      frame = undefined;
+
+      const element = getMessageElement(messageId);
+      if (element) {
+        element.scrollIntoView({ block: 'nearest' });
+        scrollElementAboveObstruction(element, options.obstructionHeight());
+        return;
+      }
+
+      // The reply isn't rendered yet. If its whole thread is out of the DOM,
+      // jump there so the reply's row can mount; when the thread is mounted
+      // the reply is at most an optimistic-insert flush away, so just wait.
+      if (!didScrollToThread && !getMessageElement(threadId)) {
+        const navigation = options.navigation();
+        if (navigation) {
+          didScrollToThread = true;
+          navigation.scrollToId(threadId, { align: 'end' });
+        }
+      }
+
+      framesLeft -= 1;
+      if (framesLeft > 0) frame = requestAnimationFrame(tick);
+    };
+
+    frame = requestAnimationFrame(tick);
+  };
+}

--- a/js/app/packages/channel/Channel/tests/create-sent-reply-reveal.test.ts
+++ b/js/app/packages/channel/Channel/tests/create-sent-reply-reveal.test.ts
@@ -1,0 +1,163 @@
+import { createRoot } from 'solid-js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createSentReplyReveal } from '../create-sent-reply-reveal';
+import type { ThreadListNavigation } from '../ThreadList';
+
+const THREAD_ID = 'thread-1';
+const REPLY_ID = 'reply-1';
+
+function addMessageElement(
+  messageId: string,
+  parent: HTMLElement = document.body
+) {
+  const element = document.createElement('div');
+  element.setAttribute('data-message-id', messageId);
+  element.scrollIntoView = vi.fn();
+  parent.appendChild(element);
+  return element;
+}
+
+function makeNavigation(): ThreadListNavigation {
+  return {
+    scrollToId: vi.fn(() => true),
+  } as unknown as ThreadListNavigation;
+}
+
+function makeReveal(options?: {
+  navigation?: ThreadListNavigation;
+  obstructionHeight?: () => number;
+}) {
+  let reveal!: ReturnType<typeof createSentReplyReveal>;
+  const dispose = createRoot((dispose) => {
+    reveal = createSentReplyReveal({
+      navigation: () => options?.navigation,
+      obstructionHeight: options?.obstructionHeight ?? (() => 0),
+    });
+    return dispose;
+  });
+  return { reveal, dispose };
+}
+
+describe('createSentReplyReveal', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({
+      toFake: ['requestAnimationFrame', 'cancelAnimationFrame'],
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    document.body.innerHTML = '';
+  });
+
+  it('scrolls the reply into view once its row renders', () => {
+    const navigation = makeNavigation();
+    const { reveal, dispose } = makeReveal({ navigation });
+    addMessageElement(THREAD_ID);
+
+    reveal(THREAD_ID, REPLY_ID);
+    // The optimistic reply has not rendered yet; the thread is mounted, so
+    // the reveal must wait rather than jump the viewport to the thread.
+    vi.advanceTimersToNextFrame();
+    expect(navigation.scrollToId).not.toHaveBeenCalled();
+
+    const reply = addMessageElement(REPLY_ID);
+    vi.advanceTimersToNextFrame();
+    expect(reply.scrollIntoView).toHaveBeenCalledWith({ block: 'nearest' });
+
+    // The reveal is one-shot: no re-scroll on later frames.
+    vi.advanceTimersToNextFrame();
+    expect(reply.scrollIntoView).toHaveBeenCalledTimes(1);
+
+    dispose();
+  });
+
+  it('jumps to the thread when its row is not in the DOM', () => {
+    const navigation = makeNavigation();
+    const { reveal, dispose } = makeReveal({ navigation });
+
+    reveal(THREAD_ID, REPLY_ID);
+    vi.advanceTimersToNextFrame();
+    expect(navigation.scrollToId).toHaveBeenCalledExactlyOnceWith(THREAD_ID, {
+      align: 'end',
+    });
+
+    // Only one jump, even while the row is still mounting.
+    vi.advanceTimersToNextFrame();
+    expect(navigation.scrollToId).toHaveBeenCalledTimes(1);
+
+    const reply = addMessageElement(REPLY_ID);
+    vi.advanceTimersToNextFrame();
+    expect(reply.scrollIntoView).toHaveBeenCalledWith({ block: 'nearest' });
+
+    dispose();
+  });
+
+  it('scrolls the revealed reply above the bottom obstruction', () => {
+    const container = document.createElement('div');
+    container.setAttribute('data-channel-scroll', '');
+    document.body.appendChild(container);
+    const reply = addMessageElement(REPLY_ID, container);
+
+    const bottom = window.innerHeight;
+    vi.spyOn(container, 'getBoundingClientRect').mockReturnValue({
+      bottom,
+    } as DOMRect);
+    // The reply sits 8px above the screen bottom — behind a 100px obstruction.
+    vi.spyOn(reply, 'getBoundingClientRect').mockReturnValue({
+      bottom: bottom - 8,
+    } as DOMRect);
+
+    const { reveal, dispose } = makeReveal({ obstructionHeight: () => 100 });
+    reveal(THREAD_ID, REPLY_ID);
+    vi.advanceTimersToNextFrame();
+
+    // elBottom (bottom - 8) - visibleBottom (bottom - 100) + 8px offset.
+    expect(container.scrollTop).toBe(100);
+
+    dispose();
+  });
+
+  it('gives up quietly when the reply never renders', () => {
+    const navigation = makeNavigation();
+    const { reveal, dispose } = makeReveal({ navigation });
+
+    reveal(THREAD_ID, REPLY_ID);
+    for (let i = 0; i < 30; i++) vi.advanceTimersToNextFrame();
+
+    // The frame budget is exhausted: a row rendering later is left alone.
+    const reply = addMessageElement(REPLY_ID);
+    vi.advanceTimersToNextFrame();
+    expect(reply.scrollIntoView).not.toHaveBeenCalled();
+
+    dispose();
+  });
+
+  it('lets a newer send take over the reveal', () => {
+    const { reveal, dispose } = makeReveal({ navigation: makeNavigation() });
+
+    reveal(THREAD_ID, 'reply-a');
+    reveal(THREAD_ID, 'reply-b');
+
+    const replyA = addMessageElement('reply-a');
+    const replyB = addMessageElement('reply-b');
+    vi.advanceTimersToNextFrame();
+    vi.advanceTimersToNextFrame();
+
+    expect(replyA.scrollIntoView).not.toHaveBeenCalled();
+    expect(replyB.scrollIntoView).toHaveBeenCalledTimes(1);
+
+    dispose();
+  });
+
+  it('cancels a pending reveal on dispose', () => {
+    const { reveal, dispose } = makeReveal({ navigation: makeNavigation() });
+    const reply = addMessageElement(REPLY_ID);
+
+    reveal(THREAD_ID, REPLY_ID);
+    dispose();
+    vi.advanceTimersToNextFrame();
+
+    expect(reply.scrollIntoView).not.toHaveBeenCalled();
+  });
+});

--- a/js/app/packages/channel/Thread/ThreadReplyChannelInput.tsx
+++ b/js/app/packages/channel/Thread/ThreadReplyChannelInput.tsx
@@ -33,6 +33,11 @@ type ThreadReplyChannelInputProps = {
   focusRequest?: FocusRequest;
   /** Exit reply mode. Called on close and (immediately) on send. */
   onExit: () => void;
+  /**
+   * Called after a send is dispatched, with the sent reply's optimistic
+   * message id (the id its row renders with until the server responds).
+   */
+  onSent?: (messageId: string) => void;
   /** Where the reply input is hosted. Defaults to 'inline' (in the thread). */
   host?: 'inline' | 'unified';
   collapsible?: boolean;
@@ -140,11 +145,12 @@ export function ThreadReplyChannelInput(props: ThreadReplyChannelInputProps) {
           participantIds: participants.ids(),
         });
 
+        const optimisticId = crypto.randomUUID();
         sendMessageMutation.mutate(
           {
             channelID: props.channelId,
             senderId,
-            optimisticId: crypto.randomUUID(),
+            optimisticId,
             ...payload,
           },
           {
@@ -164,6 +170,7 @@ export function ThreadReplyChannelInput(props: ThreadReplyChannelInputProps) {
         // toast plus the draft restore above cover the error case.
         props.setReplyInputState(undefined);
         props.onExit();
+        props.onSent?.(optimisticId);
       }}
     />
   );

--- a/js/app/packages/channel/scroll-utils.ts
+++ b/js/app/packages/channel/scroll-utils.ts
@@ -1,4 +1,4 @@
-function getMessageElement(messageId: string) {
+export function getMessageElement(messageId: string) {
   return document.querySelector<HTMLElement>(
     `[data-message-id="${messageId}"]`
   );


### PR DESCRIPTION
On mobile (unified input mode), sending a thread reply left the viewport where it was: the optimistic reply rendered at the end of its thread — below the fold, behind the floating input and keyboard, or in a thread row virtualized out of the DOM when the user scrolled away while composing (MACRO-2295).

After a send is dispatched, `ThreadReplyChannelInput` now reports the optimistic message id through a new `onSent` callback, wired up only for the unified-input host. A new `createSentReplyReveal` helper waits a bounded number of frames for the reply's row to render — first jumping to its thread via `ThreadListNavigation.scrollToId` when the row is unmounted — then scrolls the reply into view clear of the floating input and virtual keyboard, reusing the existing scroll utilities. Already-visible replies aren't moved, a newer send cancels a pending reveal, and inline (desktop) thread replies are unchanged. Unit-tested in `create-sent-reply-reveal.test.ts`.

Session: https://claude.ai/code/session_01LAJjSPZM39fRL5QUtXewmn