### PR TITLE
fix(channel): target thread-reply mentions that omit the thread id

### DIFF
--- a/js/app/packages/block-channel/component/NewChannelBlockAdapter.tsx
+++ b/js/app/packages/block-channel/component/NewChannelBlockAdapter.tsx
@@ -46,6 +46,11 @@ import { useChannelName, useChannelType } from '@core/context/channels';
 import { awaitCondition, createMethodRegistration } from '@core/orchestrator';
 import { blockHandleSignal } from '@core/signal/load';
 import { useActiveCallQuery } from '@queries/call/call';
+import {
+  fetchResolvedChannelMessage,
+  findThreadIdInChannelMessages,
+  findTopLevelMessageInChannelMessages,
+} from '@queries/channel/channel-messages';
 import { useChannelParticipantsQuery } from '@queries/channel/channel-participants';
 import { ChannelTypeEnum } from '@service-storage/client';
 import { useSearchParams } from '@solidjs/router';
@@ -309,6 +314,47 @@ export function NewChannelBlockAdapter(props: BlockChannelProps) {
     };
   };
 
+  // A mention/link to a thread reply may carry only the message id (the reply)
+  // without its thread id. Left as-is `convertTargetMessage` would treat that
+  // reply as a top-level message, which never loads, so the target is never
+  // highlighted. When only a message id is present, resolve it: a thread reply
+  // targets its parent thread with the reply id, a top-level message stays as
+  // itself. An explicit thread id is already unambiguous, so trust it.
+  const resolveTargetMessage = async (
+    params: ChannelTargetMessageParams
+  ): Promise<ChannelPropsTargetMessage> => {
+    const messageId = params[URL_PARAMS.message] as string | undefined;
+    const threadId = params[URL_PARAMS.thread] as string | undefined;
+    if (threadId || !messageId) return convertTargetMessage(params);
+
+    // Cache-first: an already-open channel has the clicked message warm, so a
+    // plain send (the common inbox-row click) or a reply in a loaded thread
+    // preview resolves synchronously with no roundtrip. Only a genuinely
+    // unknown id — an old mention/link opening a cold channel — pays a resolve.
+    if (findTopLevelMessageInChannelMessages(channelId, messageId)) {
+      return { targetMessageId: messageId, targetMessageReplyId: undefined };
+    }
+    const cachedThreadId = findThreadIdInChannelMessages(channelId, messageId);
+    if (cachedThreadId) {
+      return {
+        targetMessageId: cachedThreadId,
+        targetMessageReplyId: messageId,
+      };
+    }
+
+    const resolved = await fetchResolvedChannelMessage(
+      channelId,
+      messageId
+    ).catch(() => undefined);
+    if (resolved?.kind === 'threadReply') {
+      return {
+        targetMessageId: resolved.thread_id,
+        targetMessageReplyId: messageId,
+      };
+    }
+    return { targetMessageId: messageId, targetMessageReplyId: undefined };
+  };
+
   // The Messages tab may not have mounted yet (e.g. right after the split
   // opens). Wait for its handle via the orchestrator's availability primitive.
   const awaitMessagesHandle = async () => {
@@ -328,7 +374,7 @@ export function NewChannelBlockAdapter(props: BlockChannelProps) {
       }
 
       const { targetMessageId, targetMessageReplyId } =
-        convertTargetMessage(params);
+        await resolveTargetMessage(params);
 
       if (targetMessageId) {
         setActiveTab(DEFAULT_CHANNEL_TAB);

--- a/js/app/packages/queries/channel/channel-messages.ts
+++ b/js/app/packages/queries/channel/channel-messages.ts
@@ -1,6 +1,7 @@
 import { ThrownResultError, throwOnErr } from '@core/util/result';
 import {
   type ApiChannelMessage,
+  type ApiResolvedChannelMessage,
   type ApiThreadReply,
   type ChannelMessagesPage,
   storageServiceClient,
@@ -59,6 +60,29 @@ export function isMissingChannelMessageError(error: unknown): boolean {
     error instanceof ThrownResultError &&
     error.errors.some(({ code }) => code === 'NOT_FOUND' || code === 'GONE')
   );
+}
+
+/**
+ * Resolve any channel message id to its position in the channel/thread model.
+ * A bare message id is ambiguous — it may be a top-level message or a thread
+ * reply — and the resolution (kind + parent thread id) never changes for a
+ * given message, so cache it indefinitely.
+ */
+export function fetchResolvedChannelMessage(
+  channelId: string,
+  messageId: string
+): Promise<ApiResolvedChannelMessage> {
+  return queryClient.fetchQuery({
+    queryKey: channelKeys.resolveMessage(channelId, messageId).queryKey,
+    queryFn: () =>
+      throwOnErr(() =>
+        storageServiceClient.resolveChannelMessage({
+          channel_id: channelId,
+          message_id: messageId,
+        })
+      ),
+    staleTime: Infinity,
+  });
 }
 
 export function channelMessagesQueryOptions(
@@ -568,7 +592,7 @@ export function restoreThreadPreviewReplyInChannelMessages(
 }
 
 /** Finds a top-level message across all cached variants for a channel. */
-function _findTopLevelMessageInChannelMessages(
+export function findTopLevelMessageInChannelMessages(
   channelId: string,
   messageId: string
 ): ApiChannelMessage | undefined {

--- a/js/app/packages/queries/channel/keys.ts
+++ b/js/app/packages/queries/channel/keys.ts
@@ -25,6 +25,9 @@ export const channelKeys = createQueryKeys('channel', {
   threadReplies: (channelID: string, messageID: string) => ({
     queryKey: [channelID, messageID],
   }),
+  resolveMessage: (channelID: string, messageID: string) => ({
+    queryKey: [channelID, messageID],
+  }),
   activity: null,
   listChannels: null,
 });

--- a/js/app/packages/service-clients/service-storage/client.ts
+++ b/js/app/packages/service-clients/service-storage/client.ts
@@ -231,6 +231,7 @@ export type { ApiChannelContextMessage } from './generated/schemas/apiChannelCon
 export type { ApiChannelMessage } from './generated/schemas/apiChannelMessage';
 export type { ApiChannelMessagesPage as ChannelMessagesPage } from './generated/schemas/apiChannelMessagesPage';
 export type { ApiChannelParticipant } from './generated/schemas/apiChannelParticipant';
+export type { ApiResolvedChannelMessage } from './generated/schemas/apiResolvedChannelMessage';
 export type { ApiThreadReply } from './generated/schemas/apiThreadReply';
 export type { GetOrCreateChannelResponse } from './generated/schemas/getOrCreateChannelResponse';
 


### PR DESCRIPTION
A mention or link to a thread reply may carry only `channel_message_id` (the reply) without `channel_thread_id`, so `goToLocationFromParams` treated it as a top-level message that never loads and the reply was never highlighted; navigation now resolves a bare message id to its channel/thread position and targets the reply within its parent thread. Resolution is cache-first, so the common inbox-row click on an already-open channel highlights with no network roundtrip and only a genuinely unknown id (an old mention opening a cold channel) hits `resolveChannelMessage`.
