### PR TITLE
fix(preview): only re-target the previewed channel when the selection changes

### DIFF
--- a/js/app/packages/app/component/PreviewPanel.tsx
+++ b/js/app/packages/app/component/PreviewPanel.tsx
@@ -14,8 +14,10 @@ import {
 import { createContextProvider } from '@solid-primitives/context';
 import {
   type Component,
+  createMemo,
   createRenderEffect,
   createSignal,
+  on,
   Show,
   Suspense,
 } from 'solid-js';
@@ -115,19 +117,16 @@ const PreviewPanelContent: Component<NonNullableFields<PreviewPanel>> = (
   };
   const [interactedWith, setInteractedWith] = createSignal(false);
 
-  createRenderEffect((prevId: string) => {
-    const id = props.selectedEntity.id;
-    if (id !== prevId) {
+  // Key on the id: the entity object is live, and unrelated notification
+  // churn must not re-target the previewed channel.
+  const selectedEntityId = createMemo(() => props.selectedEntity.id);
+
+  createRenderEffect(
+    on(selectedEntityId, () => {
       setInteractedWith(false);
-    }
-
-    void navigateChannelEntityToTarget(
-      props.selectedEntity,
-      props.orchestrator
-    );
-
-    return id;
-  }, props.selectedEntity.id);
+      navigateChannelEntityToTarget(props.selectedEntity, props.orchestrator);
+    })
+  );
 
   createRenderEffect(() => {
     // noop: previously we constrained toolbarLeft width based on the main split's


### PR DESCRIPTION
The preview panel's navigation effect tracked the live selected entity object and its `notifications()` accessor, so unrelated notification churn (e.g. opening an email in another split) re-ran it and re-targeted the previewed channel at a message the user had already dismissed. Key the effect on the selected entity's id via an equality-gated memo — `on` untracks the navigation body, and same-row re-activation is already handled imperatively by the soup click path.
