### PR TITLE
feat(email): add effective-date index for latest-message lateral

### DIFF
--- a/crates/macro_db_client/migrations/20260712191131_email_messages_effective_date_index.sql
+++ b/crates/macro_db_client/migrations/20260712191131_email_messages_effective_date_index.sql
@@ -1,0 +1,6 @@
+-- no-transaction
+-- Matches the latest-message lateral's ORDER BY COALESCE(internal_date_ts,
+-- created_at) DESC so the per-thread LIMIT 1 walks newest-first and stops at
+-- the first match instead of reading every message in the thread.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_email_messages_thread_id_effective_date_desc
+    ON email_messages (thread_id, COALESCE(internal_date_ts, created_at) DESC);


### PR DESCRIPTION
## Summary

Adds an expression index on `email_messages (thread_id, COALESCE(internal_date_ts, created_at) DESC)`.

The inbox/important-tab query (#4667, #4673) uses a per-thread lateral to fetch the latest non-excluded message, ordered by `COALESCE(internal_date_ts, created_at) DESC LIMIT 1`. No existing index matches that expression or direction (`idx_email_messages_thread_id_internal_date_asc` is on the raw column, ascending), so Postgres fetches every message in the thread — wide rows including subject and snippet — anti-joins each against the label exclusion, then sorts and takes one. In a production `EXPLAIN ANALYZE` this lateral accounted for ~62% of query time (~304ms of 489ms) and scales linearly with thread length.

With this index the lateral walks the thread newest-first and stops at the first message that survives the label anti-join, making it ~O(1) per thread.

Built `CONCURRENTLY` (with `-- no-transaction`, single statement) to avoid blocking writes on `email_messages`.