### PR TITLE
feat(agent): fire-and-forget agent-run observer port (+ optional 0rrery emitter)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,6 +67,7 @@ dependencies = [
  "non_empty",
  "prompt",
  "regex",
+ "reqwest 0.13.4",
  "rig-core",
  "schemars 1.2.1",
  "serde",
@@ -77,6 +78,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "utoipa",
+ "uuid",
  "workspace-hack",
 ]
 

--- a/crates/agent/Cargo.toml
+++ b/crates/agent/Cargo.toml
@@ -6,6 +6,9 @@ version = "0.1.0"
 
 [features]
 debug-messages = []
+# Ships the reference 0rrery HTTP emitter (and its reqwest dependency).
+# The AgentObserver port itself is always available.
+orrery = ["dep:reqwest"]
 
 [dependencies]
 anyhow = { workspace = true }
@@ -14,6 +17,7 @@ async-stream = { workspace = true }
 async-trait = { workspace = true }
 futures = { workspace = true }
 regex = { workspace = true }
+reqwest = { workspace = true, optional = true }
 # Macro fork of rig (upstream main + with_non_strict_tools() on Responses
 # API models). Drop back to crates.io once the patch lands upstream.
 rig-core = { git = "https://github.com/macro-inc/rig", branch = "feat/responses-api-non-strict-tools" }
@@ -23,6 +27,7 @@ serde_json = { workspace = true }
 strum = { workspace = true }
 thiserror = { workspace = true }
 utoipa = { workspace = true }
+uuid = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 ai_usage = { path = "../ai_usage" }

--- a/crates/agent/src/agent_loop.rs
+++ b/crates/agent/src/agent_loop.rs
@@ -3,6 +3,7 @@ use crate::error::AgentError;
 use crate::hook::{RegisterFn, ToolRouter};
 use crate::model::PredefinedModel;
 use crate::model::router::{ModelRouter, ProviderAgent};
+use crate::observe::{self, AgentObserver, MessageObserve, ObserveHandle};
 use crate::stream::ChatCompletionStream;
 use crate::tool_adapter::DynToolSetAdapter;
 use ai_toolset::{RequestContext, SearchableTool, ToolLoader, ToolSet as AiToolSet};
@@ -30,6 +31,7 @@ pub struct AgentLoop {
     max_turns: usize,
     max_tokens: u64,
     recorder: Arc<dyn UsageRecorder>,
+    observer: Option<Arc<dyn AgentObserver>>,
 }
 
 impl AgentLoop {
@@ -46,7 +48,21 @@ impl AgentLoop {
             max_turns: DEFAULT_MAX_TURNS,
             max_tokens: DEFAULT_MAX_TOKENS,
             recorder,
+            observer: observe::shared(),
         }
+    }
+
+    /// Override the [`AgentObserver`] (the default is resolved from the
+    /// environment; see [`observe::shared`]).
+    pub fn with_observer(mut self, observer: Arc<dyn AgentObserver>) -> Self {
+        self.observer = Some(observer);
+        self
+    }
+
+    /// Disable observation for this loop regardless of the environment.
+    pub fn without_observer(mut self) -> Self {
+        self.observer = None;
+        self
     }
 
     /// Override the model.
@@ -222,6 +238,11 @@ impl AgentLoop {
 
         let agent = build(handle, &system_prompt, self.max_turns, self.max_tokens);
 
+        let observe = self
+            .observer
+            .clone()
+            .map(|observer| ObserveHandle::start(observer, &usage_ctx, &self.model));
+
         Session {
             agent,
             history: Vec::new(),
@@ -233,6 +254,7 @@ impl AgentLoop {
             usage_ctx,
             model: self.model.clone(),
             request_context,
+            observe,
         }
     }
 
@@ -281,6 +303,8 @@ pub struct Session {
     usage_ctx: UsageContext,
     model: String,
     request_context: RequestContext,
+    /// Per-session observer state; `None` when observation is off.
+    observe: Option<Arc<ObserveHandle>>,
 }
 
 impl Session {
@@ -306,6 +330,9 @@ impl Session {
             )));
         };
 
+        let observe: Option<Arc<MessageObserve>> =
+            self.observe.as_ref().map(ObserveHandle::begin_message);
+
         let stream = self
             .agent
             .run_stream(
@@ -319,6 +346,7 @@ impl Session {
                 self.usage_ctx.clone(),
                 self.model.clone(),
                 self.request_context.clone(),
+                observe,
             )
             .await;
 

--- a/crates/agent/src/hook.rs
+++ b/crates/agent/src/hook.rs
@@ -1,6 +1,7 @@
 /// A [`rig_core::agent::PromptHook`] that bridges RIG lifecycle events into
 /// [`StreamPart`] items sent through a channel.
 use crate::AgentError;
+use crate::observe::MessageObserve;
 use crate::stream::{McpInfo, StreamPart, ToolCall, ToolResponse, Usage};
 use ai_toolset::{SearchableTool, ToolInfo};
 use rig_core::agent::{
@@ -58,6 +59,8 @@ pub struct StreamBridge {
     searchable_catalog: Arc<Vec<SearchableTool>>,
     /// the user has requested the stream stop
     cancel: CancellationToken,
+    /// Observer for this message's tool spans; `None` when observation is off.
+    observe: Option<Arc<MessageObserve>>,
 }
 
 impl StreamBridge {
@@ -74,6 +77,7 @@ impl StreamBridge {
         register_loaded: RegisterFn,
         searchable_catalog: Arc<Vec<SearchableTool>>,
         cancel: CancellationToken,
+        observe: Option<Arc<MessageObserve>>,
     ) -> (
         Self,
         mpsc::UnboundedReceiver<Result<StreamPart, AgentError>>,
@@ -87,6 +91,7 @@ impl StreamBridge {
                 register_loaded,
                 searchable_catalog,
                 cancel,
+                observe,
             },
             rx,
         )
@@ -184,6 +189,9 @@ where
                 display_name,
             },
         });
+        if let Some(observe) = &self.observe {
+            observe.tool_started(&id, tool_name);
+        }
         let _ = self.tx.send(Ok(StreamPart::ToolCall(ToolCall {
             id,
             name: tool_name.to_owned(),
@@ -226,6 +234,13 @@ where
                 description: result.to_owned(),
             },
         };
+        if let Some(observe) = &self.observe {
+            let (id, ok) = match &response {
+                ToolResponse::Json { id, .. } => (id, true),
+                ToolResponse::Err { id, .. } => (id, false),
+            };
+            observe.tool_finished(id, tool_name, ok);
+        }
         let _ = self.tx.send(Ok(StreamPart::ToolResponse(response)));
         HookAction::Continue
     }

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -9,6 +9,8 @@ mod convert;
 mod error;
 mod hook;
 mod model;
+/// Fire-and-forget observation of agent runs (0rrery emitter).
+pub mod observe;
 mod stream;
 /// Structured output via prompted JSON generation.
 pub mod structured_output;

--- a/crates/agent/src/model/router.rs
+++ b/crates/agent/src/model/router.rs
@@ -36,6 +36,7 @@ use super::openai::{OpenAiChatCompletionsModel, OpenAiResponsesModel};
 use super::types::Model;
 use crate::error::AgentError;
 use crate::hook::{RegisterFn, StreamBridge, ToolRouter};
+use crate::observe::MessageObserve;
 use crate::stream::{ChatCompletionStream, StreamPart};
 
 env_var! {
@@ -149,6 +150,7 @@ impl ProviderAgent {
         usage_ctx: UsageContext,
         model: String,
         request_context: RequestContext,
+        observe: Option<Arc<MessageObserve>>,
     ) -> ChatCompletionStream<'static> {
         match self {
             ProviderAgent::Anthropic(agent) => {
@@ -164,6 +166,7 @@ impl ProviderAgent {
                     usage_ctx,
                     model,
                     request_context.clone(),
+                    observe.clone(),
                 )
                 .await
             }
@@ -180,6 +183,7 @@ impl ProviderAgent {
                     usage_ctx,
                     model,
                     request_context.clone(),
+                    observe.clone(),
                 )
                 .await
             }
@@ -196,6 +200,7 @@ impl ProviderAgent {
                     usage_ctx,
                     model,
                     request_context.clone(),
+                    observe.clone(),
                 )
                 .await
             }
@@ -213,6 +218,7 @@ impl ProviderAgent {
                         usage_ctx,
                         model,
                         request_context.clone(),
+                        observe.clone(),
                     )
                     .await
             }
@@ -407,6 +413,7 @@ async fn drive_stream<M>(
     usage_ctx: UsageContext,
     model: String,
     request_context: RequestContext,
+    observe: Option<Arc<MessageObserve>>,
 ) -> ChatCompletionStream<'static>
 where
     M: CompletionModel + 'static,
@@ -418,6 +425,7 @@ where
         register_loaded,
         request_context.searchable_tools.clone(),
         request_context.cancel.clone(),
+        observe.clone(),
     );
     // Driver-side sender for parts derived from rig stream items (thinking,
     // usage, errors). The lifecycle hooks (text, tool call, tool response) send
@@ -443,6 +451,7 @@ where
     // finishes.
     let driver = tokio::spawn(async move {
         let mut thinking_buf = String::new();
+        let mut stream_errored = false;
 
         while let Some(item) = rig_stream.next().await {
             match item {
@@ -465,12 +474,16 @@ where
                                 usage.input_tokens,
                                 usage.output_tokens,
                             ));
+                            if let Some(observe) = &observe {
+                                observe.llm_usage(&model, usage.input_tokens, usage.output_tokens);
+                            }
                             let _ = driver_tx.send(Ok(StreamPart::Usage(crate::stream::Usage {
                                 input_tokens: usage.input_tokens,
                                 output_tokens: usage.output_tokens,
                             })));
                         }
                         Err(e) => {
+                            stream_errored = true;
                             let _ = driver_tx.send(Err(AgentError::Streaming(e)));
                         }
                         _ => {}
@@ -480,6 +493,9 @@ where
         }
         if !thinking_buf.is_empty() {
             let _ = driver_tx.send(Ok(StreamPart::Thinking(std::mem::take(&mut thinking_buf))));
+        }
+        if let Some(observe) = &observe {
+            observe.finish(!stream_errored);
         }
         // Dropping `rig_stream` (and with it the hook's sender) plus `driver_tx`
         // here closes the channel, ending the consumer stream below.
@@ -524,6 +540,7 @@ pub(crate) trait DynStreamAgent: Send + Sync {
         usage_ctx: UsageContext,
         model: String,
         request_context: RequestContext,
+        observe: Option<Arc<MessageObserve>>,
     ) -> std::pin::Pin<
         Box<dyn std::future::Future<Output = ChatCompletionStream<'static>> + Send + 'a>,
     >;
@@ -547,6 +564,7 @@ where
         usage_ctx: UsageContext,
         model: String,
         request_context: RequestContext,
+        observe: Option<Arc<MessageObserve>>,
     ) -> std::pin::Pin<
         Box<dyn std::future::Future<Output = ChatCompletionStream<'static>> + Send + 'a>,
     > {
@@ -562,6 +580,7 @@ where
             usage_ctx,
             model,
             request_context,
+            observe,
         ))
     }
 }

--- a/crates/agent/src/observe.rs
+++ b/crates/agent/src/observe.rs
@@ -1,0 +1,368 @@
+//! Agent-run observability: a fire-and-forget observer port over the agent
+//! loop lifecycle, plus an outbound adapter that ships events to a local
+//! [0rrery](https://github.com/0ponn/0rrery) collector.
+//!
+//! The port mirrors [`ai_usage::UsageRecorder`]'s contract: every method is
+//! infallible and best-effort — an observer must never slow down or fail the
+//! originating agent call. The default observer is resolved from the
+//! environment once per process (like `ModelRouter::shared`): when
+//! `ORRERY_URL` is unset, [`shared`] is `None` and the loop runs exactly as
+//! before.
+
+use ai_usage::UsageContext;
+#[cfg(feature = "orrery")]
+use macro_env_var::maybe_env_var;
+use std::sync::Arc;
+#[cfg(feature = "orrery")]
+use std::sync::OnceLock;
+use std::sync::atomic::{AtomicU64, Ordering};
+#[cfg(feature = "orrery")]
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// The `source`/`project` this emitter reports to 0rrery.
+#[cfg(feature = "orrery")]
+const MACRO_SOURCE: &str = "macro";
+/// Per-post budget: a slow collector drops events, never delays the agent.
+#[cfg(feature = "orrery")]
+const EMIT_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(500);
+
+#[cfg(feature = "orrery")]
+maybe_env_var! {
+    /// Base URL of a 0rrery collector (e.g. `http://localhost:7317`). Setting
+    /// it turns agent-run observation on; unset (the default) disables it.
+    pub struct OrreryUrl;
+}
+#[cfg(feature = "orrery")]
+maybe_env_var! {
+    /// Optional bearer token for the 0rrery collector's ingest endpoint.
+    pub struct OrreryToken;
+}
+
+/// The constant attributes of one agent session, reported on
+/// [`AgentObserver::session_started`].
+#[derive(Debug)]
+pub struct SessionMeta<'a> {
+    /// The AI feature running the session (e.g. `chat`).
+    pub feature: &'a str,
+    /// The user the session runs for.
+    pub user: &'a str,
+    /// The entity the session relates to, if any.
+    pub entity: Option<String>,
+    /// The model api id serving the session.
+    pub model: &'a str,
+}
+
+/// Observes the agent-loop lifecycle. All methods are fire-and-forget: they
+/// must be cheap, must not block, and must never fail the originating call.
+pub trait AgentObserver: Send + Sync {
+    /// A session was created.
+    fn session_started(&self, session_id: &str, meta: &SessionMeta<'_>);
+    /// One `send_message` exchange began; `span_id` identifies it.
+    fn message_started(&self, session_id: &str, span_id: &str);
+    /// The model requested a tool call.
+    fn tool_started(&self, session_id: &str, parent_span_id: &str, call_id: &str, name: &str);
+    /// A tool call produced its result (`ok` = the tool returned valid output).
+    fn tool_finished(
+        &self,
+        session_id: &str,
+        parent_span_id: &str,
+        call_id: &str,
+        name: &str,
+        ok: bool,
+    );
+    /// A completion round-trip finished with the given token usage.
+    fn llm_usage(
+        &self,
+        session_id: &str,
+        parent_span_id: &str,
+        span_id: &str,
+        model: &str,
+        input_tokens: u64,
+        output_tokens: u64,
+    );
+    /// The `send_message` exchange ended (`ok` = the stream ended without error).
+    fn message_finished(&self, session_id: &str, span_id: &str, ok: bool);
+    /// The session was dropped.
+    fn session_ended(&self, session_id: &str);
+}
+
+/// The process-wide observer, resolved from the environment on first use.
+/// `None` (the default, when `ORRERY_URL` is unset) means observation is off.
+pub(crate) fn shared() -> Option<Arc<dyn AgentObserver>> {
+    #[cfg(feature = "orrery")]
+    {
+        static OBSERVER: OnceLock<Option<Arc<dyn AgentObserver>>> = OnceLock::new();
+        OBSERVER
+            .get_or_init(|| {
+                OrreryObserver::from_env().map(|o| Arc::new(o) as Arc<dyn AgentObserver>)
+            })
+            .clone()
+    }
+    #[cfg(not(feature = "orrery"))]
+    None
+}
+
+/// Per-session observer state: owns the session id and emits `session_ended`
+/// when the last holder (the session or an in-flight stream driver) drops it.
+pub(crate) struct ObserveHandle {
+    observer: Arc<dyn AgentObserver>,
+    session_id: String,
+    messages: AtomicU64,
+}
+
+impl ObserveHandle {
+    /// Create the handle and report `session_started`.
+    pub(crate) fn start(
+        observer: Arc<dyn AgentObserver>,
+        usage_ctx: &UsageContext,
+        model: &str,
+    ) -> Arc<Self> {
+        let session_id = format!("macro:{}", uuid::Uuid::now_v7());
+        let feature = usage_ctx.feature.to_string();
+        observer.session_started(
+            &session_id,
+            &SessionMeta {
+                feature: &feature,
+                user: usage_ctx.user.as_ref(),
+                entity: usage_ctx.entity.map(|e| e.to_string()),
+                model,
+            },
+        );
+        Arc::new(Self {
+            observer,
+            session_id,
+            messages: AtomicU64::new(0),
+        })
+    }
+
+    /// Begin one `send_message` exchange and report `message_started`.
+    pub(crate) fn begin_message(self: &Arc<Self>) -> Arc<MessageObserve> {
+        let n = self.messages.fetch_add(1, Ordering::Relaxed);
+        let span_id = format!("{}:msg:{n}", self.session_id);
+        self.observer.message_started(&self.session_id, &span_id);
+        Arc::new(MessageObserve {
+            handle: self.clone(),
+            span_id,
+            llm_calls: AtomicU64::new(0),
+        })
+    }
+}
+
+impl Drop for ObserveHandle {
+    fn drop(&mut self) {
+        self.observer.session_ended(&self.session_id);
+    }
+}
+
+/// Observer state for one `send_message` exchange, shared by the stream bridge
+/// (tool spans) and the stream driver (usage, finish).
+pub(crate) struct MessageObserve {
+    handle: Arc<ObserveHandle>,
+    span_id: String,
+    llm_calls: AtomicU64,
+}
+
+impl MessageObserve {
+    /// Report a tool call starting.
+    pub(crate) fn tool_started(&self, call_id: &str, name: &str) {
+        self.handle
+            .observer
+            .tool_started(&self.handle.session_id, &self.span_id, call_id, name);
+    }
+
+    /// Report a tool call finishing.
+    pub(crate) fn tool_finished(&self, call_id: &str, name: &str, ok: bool) {
+        self.handle.observer.tool_finished(
+            &self.handle.session_id,
+            &self.span_id,
+            call_id,
+            name,
+            ok,
+        );
+    }
+
+    /// Report one completion round-trip's token usage.
+    pub(crate) fn llm_usage(&self, model: &str, input_tokens: u64, output_tokens: u64) {
+        let n = self.llm_calls.fetch_add(1, Ordering::Relaxed);
+        self.handle.observer.llm_usage(
+            &self.handle.session_id,
+            &self.span_id,
+            &format!("{}:llm:{n}", self.span_id),
+            model,
+            input_tokens,
+            output_tokens,
+        );
+    }
+
+    /// Report the exchange finishing.
+    pub(crate) fn finish(&self, ok: bool) {
+        self.handle
+            .observer
+            .message_finished(&self.handle.session_id, &self.span_id, ok);
+    }
+}
+
+/// Milliseconds since the Unix epoch.
+#[cfg(feature = "orrery")]
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Ships observer events to a 0rrery collector as `IngestOp` batches on
+/// `POST {ORRERY_URL}/api/ingest`. Posts are spawned fire-and-forget with a
+/// short timeout, mirroring 0rrery's own emitter semantics: a slow or absent
+/// collector drops events, never the agent call.
+#[cfg(feature = "orrery")]
+pub struct OrreryObserver {
+    ingest_url: String,
+    token: Option<String>,
+    client: reqwest::Client,
+}
+
+#[cfg(feature = "orrery")]
+impl OrreryObserver {
+    /// Build from `ORRERY_URL` / `ORRERY_TOKEN`, or `None` when unset.
+    pub fn from_env() -> Option<Self> {
+        let url = OrreryUrl::new()?;
+        let base = url.value()?.trim_end_matches('/').to_string();
+        let client = reqwest::Client::builder()
+            .timeout(EMIT_TIMEOUT)
+            .build()
+            .ok()?;
+        Some(Self {
+            ingest_url: format!("{base}/api/ingest"),
+            token: OrreryToken::new().and_then(|t| t.value().map(str::to_string)),
+            client,
+        })
+    }
+
+    fn post(&self, ops: Vec<serde_json::Value>) {
+        // Observation must never block or fail the agent call: skip when no
+        // runtime is available (e.g. a session dropped outside tokio).
+        let Ok(runtime) = tokio::runtime::Handle::try_current() else {
+            return;
+        };
+        let mut request = self.client.post(&self.ingest_url).json(&ops);
+        if let Some(token) = &self.token {
+            request = request.bearer_auth(token);
+        }
+        runtime.spawn(async move {
+            if let Err(e) = request.send().await {
+                tracing::debug!(error = ?e, "0rrery ingest post failed (dropped)");
+            }
+        });
+    }
+}
+
+#[cfg(feature = "orrery")]
+impl AgentObserver for OrreryObserver {
+    fn session_started(&self, session_id: &str, meta: &SessionMeta<'_>) {
+        self.post(vec![serde_json::json!({
+            "op": "session.start",
+            "sessionId": session_id,
+            "source": MACRO_SOURCE,
+            "project": MACRO_SOURCE,
+            "ts": now_ms(),
+            "meta": {
+                "feature": meta.feature,
+                "user": meta.user,
+                "entity": meta.entity,
+                "model": meta.model,
+            },
+        })]);
+    }
+
+    fn message_started(&self, session_id: &str, span_id: &str) {
+        self.post(vec![serde_json::json!({
+            "op": "span.start",
+            "id": span_id,
+            "sessionId": session_id,
+            "parentId": null,
+            "kind": "agent",
+            "name": "send_message",
+            "ts": now_ms(),
+        })]);
+    }
+
+    fn tool_started(&self, session_id: &str, parent_span_id: &str, call_id: &str, name: &str) {
+        self.post(vec![serde_json::json!({
+            "op": "span.start",
+            "id": format!("{parent_span_id}:tool:{call_id}"),
+            "sessionId": session_id,
+            "parentId": parent_span_id,
+            "kind": "tool",
+            "name": name,
+            "ts": now_ms(),
+        })]);
+    }
+
+    fn tool_finished(
+        &self,
+        _session_id: &str,
+        parent_span_id: &str,
+        call_id: &str,
+        _name: &str,
+        ok: bool,
+    ) {
+        self.post(vec![serde_json::json!({
+            "op": "span.end",
+            "id": format!("{parent_span_id}:tool:{call_id}"),
+            "ts": now_ms(),
+            "status": if ok { "ok" } else { "error" },
+        })]);
+    }
+
+    fn llm_usage(
+        &self,
+        session_id: &str,
+        parent_span_id: &str,
+        span_id: &str,
+        model: &str,
+        input_tokens: u64,
+        output_tokens: u64,
+    ) {
+        let ts = now_ms();
+        self.post(vec![
+            serde_json::json!({
+                "op": "span.start",
+                "id": span_id,
+                "sessionId": session_id,
+                "parentId": parent_span_id,
+                "kind": "llm",
+                "name": model,
+                "ts": ts,
+            }),
+            serde_json::json!({
+                "op": "span.end",
+                "id": span_id,
+                "ts": ts,
+                "status": "ok",
+                "attrs": {
+                    "model": model,
+                    "input_tokens": input_tokens,
+                    "output_tokens": output_tokens,
+                },
+            }),
+        ]);
+    }
+
+    fn message_finished(&self, _session_id: &str, span_id: &str, ok: bool) {
+        self.post(vec![serde_json::json!({
+            "op": "span.end",
+            "id": span_id,
+            "ts": now_ms(),
+            "status": if ok { "ok" } else { "error" },
+        })]);
+    }
+
+    fn session_ended(&self, session_id: &str) {
+        self.post(vec![serde_json::json!({
+            "op": "session.end",
+            "sessionId": session_id,
+            "ts": now_ms(),
+        })]);
+    }
+}

--- a/crates/agent/src/observe.rs
+++ b/crates/agent/src/observe.rs
@@ -15,7 +15,7 @@ use macro_env_var::maybe_env_var;
 use std::sync::Arc;
 #[cfg(feature = "orrery")]
 use std::sync::OnceLock;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 #[cfg(feature = "orrery")]
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -144,6 +144,7 @@ impl ObserveHandle {
             handle: self.clone(),
             span_id,
             llm_calls: AtomicU64::new(0),
+            finished: AtomicBool::new(false),
         })
     }
 }
@@ -160,6 +161,7 @@ pub(crate) struct MessageObserve {
     handle: Arc<ObserveHandle>,
     span_id: String,
     llm_calls: AtomicU64,
+    finished: AtomicBool,
 }
 
 impl MessageObserve {
@@ -194,11 +196,24 @@ impl MessageObserve {
         );
     }
 
-    /// Report the exchange finishing.
+    /// Report the exchange finishing. Idempotent: only the first call emits.
     pub(crate) fn finish(&self, ok: bool) {
+        if self.finished.swap(true, Ordering::Relaxed) {
+            return;
+        }
         self.handle
             .observer
             .message_finished(&self.handle.session_id, &self.span_id, ok);
+    }
+}
+
+/// Fallback close: an aborted stream (client drop / cancellation) never reaches
+/// the driver's `finish` call, so close the span as not-ok here. The `Arc` to
+/// the session's [`ObserveHandle`] is still held at this point, so this always
+/// emits before `session_ended`.
+impl Drop for MessageObserve {
+    fn drop(&mut self) {
+        self.finish(false);
     }
 }
 

--- a/crates/agent/src/test/agent_loop/mod.rs
+++ b/crates/agent/src/test/agent_loop/mod.rs
@@ -7,5 +7,6 @@ mod util;
 
 mod test_cooperative_cancellation;
 mod test_eager_tools;
+mod test_observe;
 mod test_tool;
 mod test_tool_search;

--- a/crates/agent/src/test/agent_loop/test_observe.rs
+++ b/crates/agent/src/test/agent_loop/test_observe.rs
@@ -9,6 +9,7 @@ use rig_core::test_utils::{MockCompletionModel, MockStreamEvent};
 use schemars::JsonSchema;
 use serde::Deserialize;
 use std::sync::{Arc, Mutex};
+use tokio::sync::Notify;
 
 /// A tool that echoes its input.
 #[derive(Deserialize, JsonSchema)]
@@ -188,4 +189,96 @@ async fn without_observer_changes_nothing() {
     let collected = util::drive(&mut session, "call the tool").await;
     assert!(collected.error.is_none());
     assert_eq!(collected.content(), "done");
+}
+
+/// A tool that blocks until the test drops the stream. `started` lets the test
+/// wait until the tool is genuinely mid-flight before cancelling.
+#[derive(Deserialize, JsonSchema)]
+#[schemars(title = "stall_tool", description = "Blocks until cancelled.")]
+struct StallTool {}
+
+#[async_trait]
+impl AsyncTool<Arc<Notify>> for StallTool {
+    type Output = serde_json::Value;
+
+    async fn call(
+        &self,
+        service_context: ServiceContext<Arc<Notify>>,
+        _request_context: RequestContext,
+    ) -> ToolResult<Self::Output> {
+        service_context.notify_one();
+        std::future::pending::<()>().await;
+        unreachable!("pending future never resolves")
+    }
+}
+
+/// Dropping the stream mid-tool (abrupt cancellation) must still close the
+/// message span — `message_finished ok=false` — and end the session exactly
+/// once. This is the `Drop` fallback on `MessageObserve`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn dropped_stream_still_finishes_the_message_span() {
+    let model = MockCompletionModel::from_stream_turns([vec![
+        MockStreamEvent::tool_call("call-1", "stall_tool", serde_json::json!({})),
+        MockStreamEvent::final_response_with_default_usage(),
+    ]]);
+    let recording = Arc::new(Recording::default());
+    let started = Arc::new(Notify::new());
+    let mut session = util::test_loop()
+        .with_observer(recording.clone())
+        .test_session(
+            util::single_tool_set::<StallTool, Arc<Notify>>(),
+            Arc::new(started.clone()),
+            "test preamble",
+            util::usage_ctx(),
+            model,
+        )
+        .await;
+
+    let mut stream = session
+        .send_message(vec![crate::Message::user("stall")])
+        .await
+        .expect("stream starts");
+    // Drain until the tool is running, then drop the stream (client abort).
+    while util::next_within(&mut stream, std::time::Duration::from_secs(5))
+        .await
+        .is_some()
+    {
+        if recording
+            .events()
+            .iter()
+            .any(|e| e.starts_with("tool_started"))
+        {
+            break;
+        }
+    }
+    started.notified().await;
+    drop(stream);
+    drop(session);
+    tokio::task::yield_now().await;
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    let events = recording.events();
+    let finishes: Vec<&String> = events
+        .iter()
+        .filter(|e| e.starts_with("message_finished"))
+        .collect();
+    assert_eq!(
+        finishes.len(),
+        1,
+        "exactly one message_finished: {events:?}"
+    );
+    assert!(
+        finishes[0].ends_with("ok=false"),
+        "aborted message closes as not-ok: {events:?}"
+    );
+    assert_eq!(
+        events.iter().filter(|e| *e == "session_ended").count(),
+        1,
+        "{events:?}"
+    );
+    assert_eq!(
+        events.last().map(String::as_str),
+        Some("session_ended"),
+        "{events:?}"
+    );
 }

--- a/crates/agent/src/test/agent_loop/test_observe.rs
+++ b/crates/agent/src/test/agent_loop/test_observe.rs
@@ -1,0 +1,191 @@
+//! Asserts the [`AgentObserver`] port sees the full session lifecycle: session
+//! start, per-message span, tool spans, LLM usage, message finish, and session
+//! end — and that a loop without an observer emits nothing (the default).
+use super::util;
+use crate::observe::{AgentObserver, SessionMeta};
+use ai_toolset::{AsyncTool, RequestContext, ServiceContext, ToolResult};
+use async_trait::async_trait;
+use rig_core::test_utils::{MockCompletionModel, MockStreamEvent};
+use schemars::JsonSchema;
+use serde::Deserialize;
+use std::sync::{Arc, Mutex};
+
+/// A tool that echoes its input.
+#[derive(Deserialize, JsonSchema)]
+#[schemars(title = "echo_tool", description = "Echoes its input back.")]
+struct EchoTool {
+    value: String,
+}
+
+#[async_trait]
+impl AsyncTool<()> for EchoTool {
+    type Output = serde_json::Value;
+
+    async fn call(
+        &self,
+        _service_context: ServiceContext<()>,
+        _request_context: RequestContext,
+    ) -> ToolResult<Self::Output> {
+        Ok(serde_json::json!({ "echo": self.value }))
+    }
+}
+
+/// Records every observer callback as a compact tag string, in order.
+#[derive(Default)]
+struct Recording(Mutex<Vec<String>>);
+
+impl Recording {
+    fn events(&self) -> Vec<String> {
+        self.0.lock().expect("recording poisoned").clone()
+    }
+    fn push(&self, tag: String) {
+        self.0.lock().expect("recording poisoned").push(tag);
+    }
+}
+
+impl AgentObserver for Recording {
+    fn session_started(&self, session_id: &str, meta: &SessionMeta<'_>) {
+        assert!(!session_id.is_empty());
+        self.push(format!("session_started feature={}", meta.feature));
+    }
+    fn message_started(&self, _session_id: &str, span_id: &str) {
+        self.push(format!("message_started {span_id}"));
+    }
+    fn tool_started(&self, _session_id: &str, _parent_span_id: &str, call_id: &str, name: &str) {
+        self.push(format!("tool_started {name} {call_id}"));
+    }
+    fn tool_finished(
+        &self,
+        _session_id: &str,
+        _parent_span_id: &str,
+        call_id: &str,
+        name: &str,
+        ok: bool,
+    ) {
+        self.push(format!("tool_finished {name} {call_id} ok={ok}"));
+    }
+    fn llm_usage(
+        &self,
+        _session_id: &str,
+        _parent_span_id: &str,
+        span_id: &str,
+        model: &str,
+        input_tokens: u64,
+        output_tokens: u64,
+    ) {
+        assert!(!span_id.is_empty());
+        assert!(!model.is_empty());
+        self.push(format!("llm_usage in={input_tokens} out={output_tokens}"));
+    }
+    fn message_finished(&self, _session_id: &str, span_id: &str, ok: bool) {
+        self.push(format!("message_finished {span_id} ok={ok}"));
+    }
+    fn session_ended(&self, _session_id: &str) {
+        self.push("session_ended".to_string());
+    }
+}
+
+fn tool_then_done() -> MockCompletionModel {
+    MockCompletionModel::from_stream_turns([
+        vec![
+            MockStreamEvent::tool_call("call-1", "echo_tool", serde_json::json!({"value": "hi"})),
+            MockStreamEvent::final_response_with_default_usage(),
+        ],
+        vec![
+            MockStreamEvent::text("done"),
+            MockStreamEvent::final_response_with_default_usage(),
+        ],
+    ])
+}
+
+/// The observer sees the whole lifecycle in order, and `session_ended` fires
+/// once the session (and its stream) are dropped.
+#[tokio::test]
+async fn observer_sees_session_message_tool_and_usage_lifecycle() {
+    let recording = Arc::new(Recording::default());
+    let mut session = util::test_loop()
+        .with_observer(recording.clone())
+        .test_session(
+            util::single_tool_set::<EchoTool, ()>(),
+            Arc::new(()),
+            "test preamble",
+            util::usage_ctx(),
+            tool_then_done(),
+        )
+        .await;
+
+    let collected = util::drive(&mut session, "call the tool").await;
+    assert!(collected.error.is_none());
+    drop(session);
+    // The driver task may hold the last observer handle briefly; yield to it.
+    tokio::task::yield_now().await;
+
+    // Normalize the recorded events (strip the per-run session uuid and call
+    // id) and assert the EXACT lifecycle sequence.
+    let events = recording.events();
+    let normalized: Vec<String> = events
+        .iter()
+        .map(
+            |e| match e.split_whitespace().collect::<Vec<_>>().as_slice() {
+                ["message_started", span] => format!("message_started {}", tail(span, 2)),
+                ["message_finished", span, ok] => {
+                    format!("message_finished {} {ok}", tail(span, 2))
+                }
+                ["tool_started", name, _call_id] => format!("tool_started {name}"),
+                ["tool_finished", name, _call_id, ok] => format!("tool_finished {name} {ok}"),
+                ["llm_usage", ..] => "llm_usage".to_string(),
+                _ => e.clone(),
+            },
+        )
+        .collect();
+    assert_eq!(
+        normalized,
+        [
+            "session_started feature=chat",
+            "message_started msg:0",
+            "tool_started echo_tool",
+            "tool_finished echo_tool ok=true",
+            "llm_usage",
+            "message_finished msg:0 ok=true",
+            "session_ended",
+        ],
+        "raw events: {events:?}"
+    );
+
+    // Start and finish carry the same tool call id.
+    let call_id = |e: &str| e.split_whitespace().nth(2).map(str::to_owned);
+    assert_eq!(
+        events
+            .iter()
+            .find_map(|e| e.starts_with("tool_started").then(|| call_id(e)).flatten()),
+        events
+            .iter()
+            .find_map(|e| e.starts_with("tool_finished").then(|| call_id(e)).flatten()),
+        "{events:?}"
+    );
+}
+
+/// The last `n` colon-separated segments of an id (drops the session uuid).
+fn tail(id: &str, n: usize) -> String {
+    let parts: Vec<&str> = id.split(':').collect();
+    parts[parts.len().saturating_sub(n)..].join(":")
+}
+
+/// With observation explicitly disabled the session runs exactly as before —
+/// independent of whatever `ORRERY_URL` happens to be in the test environment.
+#[tokio::test]
+async fn without_observer_changes_nothing() {
+    let mut session = util::test_loop()
+        .without_observer()
+        .test_session(
+            util::single_tool_set::<EchoTool, ()>(),
+            Arc::new(()),
+            "test preamble",
+            util::usage_ctx(),
+            tool_then_done(),
+        )
+        .await;
+    let collected = util::drive(&mut session, "call the tool").await;
+    assert!(collected.error.is_none());
+    assert_eq!(collected.content(), "done");
+}

--- a/crates/agent/src/test/test_hook.rs
+++ b/crates/agent/src/test/test_hook.rs
@@ -40,8 +40,14 @@ async fn on_tool_result_drains_buffer_and_registers_loaded_tools() {
     let (register, registered) = recording_register();
     let routing: ToolRouter = Arc::new(|_| None);
     let token = CancellationToken::new();
-    let (bridge, _rx) =
-        StreamBridge::channel(routing, buffer.clone(), register, Arc::new(vec![]), token);
+    let (bridge, _rx) = StreamBridge::channel(
+        routing,
+        buffer.clone(),
+        register,
+        Arc::new(vec![]),
+        token,
+        None,
+    );
 
     let action = <StreamBridge as PromptHook<AnthropicModel>>::on_tool_result(
         &bridge,
@@ -73,7 +79,8 @@ async fn on_tool_result_registers_nothing_when_buffer_empty() {
     let (register, registered) = recording_register();
     let routing: ToolRouter = Arc::new(|_| None);
     let token = CancellationToken::new();
-    let (bridge, _rx) = StreamBridge::channel(routing, buffer, register, Arc::new(vec![]), token);
+    let (bridge, _rx) =
+        StreamBridge::channel(routing, buffer, register, Arc::new(vec![]), token, None);
 
     let _ = <StreamBridge as PromptHook<AnthropicModel>>::on_tool_result(
         &bridge,
@@ -114,6 +121,7 @@ async fn invalid_call_to_searchable_tool_loads_it_and_retries() {
         register,
         catalog,
         CancellationToken::new(),
+        None,
     );
 
     let action = <StreamBridge as PromptHook<AnthropicModel>>::on_invalid_tool_call(
@@ -141,6 +149,7 @@ async fn invalid_call_to_unknown_tool_retries_with_feedback_without_loading() {
         register,
         catalog,
         CancellationToken::new(),
+        None,
     );
 
     let action = <StreamBridge as PromptHook<AnthropicModel>>::on_invalid_tool_call(


### PR DESCRIPTION
# feat(agent): fire-and-forget agent-run observer port (+ optional 0rrery emitter)

## Problem

Agent runs are invisible in local dev. Today the only observability surfaces are:

- OTLP spans in `macro_entrypoint` → Datadog, **deployed envs only** (Local mode is plain fmt tracing),
- the `ai_usage` Postgres table — durable, but one row per completion with no session/tool structure.

Nothing publishes agent lifecycle events (session started, tool called, tokens spent) anywhere a developer can watch while iterating on toolsets, prompts, or the loop itself.

## Change

A small observer port over the agent loop, wired at the three seams every agent run already flows through:

- **`agent::observe::AgentObserver`** — a trait mirroring `ai_usage::UsageRecorder`'s contract (infallible, best-effort, must never block or fail the originating call; callbacks are invoked inline exactly like `UsageRecorder::record`, so the contract is documented rather than enforced — same trade-off the recorder makes). Events: `session_started/ended`, `message_started/finished`, `tool_started/finished`, `llm_usage`.
- Emit points: `Session` construction/`Drop` (`agent_loop.rs`), tool call/result in the `StreamBridge` hook, and the same driver arm in `drive_stream` that feeds `UsageRecorder` — so observed token counts are exactly what `ai_usage` records.
- **`OrreryObserver`** — a reference implementation, **behind the off-by-default `orrery` cargo feature** (which also carries the crate's only `reqwest` dependency), that POSTs event batches to a local [0rrery](https://github.com/0ponn/0rrery) collector (open-source, local-first agent-trace store). Resolved once per process from `ORRERY_URL` (mirroring the existing `ModelRouter::shared()` pattern), optional bearer via `ORRERY_TOKEN`.

**Default behavior is unchanged.** Without the `orrery` feature there is no emitter and no reqwest dep; `observe::shared()` is `None` and every emit site is a no-op. With the feature compiled in, observation still requires `ORRERY_URL` to be set, and `AgentLoop::without_observer()` opts any caller out explicitly. Emits are spawned fire-and-forget with a 500 ms budget: a slow or absent collector drops events, never delays the agent.

## Not in scope

- `complete()` / `structured_output` one-shot completions remain metered via `UsageRecorder` but unobserved (no session to attach to) — possible follow-up.
- A consumer dropping the stream mid-message leaves that message span unfinished; the collector's stale sweep handles it.

## Testing (run locally; happy to add CI hooks if wanted)

- New lifecycle test (`test_observe.rs`): scripted model + tool, asserts the **exact ordered event sequence** (normalized for ids) through the public `Session` surface, tool-call id pairing, plus an explicit `without_observer()` test that is independent of the test environment.
- `cargo test -p agent`: 75/75 with and without `--features orrery`. `cargo fmt --check` and `cargo clippy -p agent` clean under the CI flags (`-Dwarnings -Dclippy::disallowed_methods`), both feature sets.
- Local E2E on a full `just run_local` stack: a real chat (`anthropic/claude-haiku-4-5`) produced a session with nested `agent → llm`/`tool` spans in the collector, token attrs matching the `ai_usage` row for the same call exactly; re-ingest idempotent.

## Design notes

- An explicit port (vs. extending the OTLP layer) keeps the Datadog pipeline untouched, adds no OTel dependency, and gives local dev a zero-config target. Session ids are UUIDv7 (CS-01).
- The env-resolved process-wide default deliberately mirrors `ModelRouter::shared()`; `with_observer`/`without_observer` provide explicit per-loop control for callers and tests.
- If you'd rather carry only the port and keep the 0rrery emitter fully out-of-tree, happy to split the PR — the trait is the part that makes external observers possible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VSXbUGozHqjHEUKiY36mkk
