### PR TITLE
feat(comments): persist task discussion drafts like channels

### DIFF
--- a/apps/web/packages/block-md/comments/documentDiscussionSource.ts
+++ b/apps/web/packages/block-md/comments/documentDiscussionSource.ts
@@ -78,6 +78,7 @@ export function createDocumentDiscussionSource(): DiscussionSource {
   const targetCommentId = createMemo(() => urlParams.commentId() ?? null);
 
   return {
+    id: () => blockId,
     threads,
     canEdit: canComment,
     currentUserId: userId,

--- a/apps/web/packages/companies/Company/crmDiscussionSource.ts
+++ b/apps/web/packages/companies/Company/crmDiscussionSource.ts
@@ -106,6 +106,7 @@ export function useCrmDiscussionSource(
     );
 
   return {
+    id: entityId,
     threads,
     canEdit: () => !!userId(),
     currentUserId: userId,

--- a/apps/web/packages/core/comments/discussion/Discussion.tsx
+++ b/apps/web/packages/core/comments/discussion/Discussion.tsx
@@ -18,6 +18,7 @@ import {
   discussionCommentToApiChannelMessage,
   discussionCommentToMessageData,
 } from './messageAdapter';
+import { makeDiscussionInputPersistenceKey } from './persistence';
 import type {
   DiscussionComment,
   DiscussionThread as ViewThread,
@@ -83,6 +84,13 @@ export function Discussion() {
                     newThreadInputHandle = handle;
                   }}
                   autofocus={false}
+                  persistenceKey={
+                    source.id?.()
+                      ? makeDiscussionInputPersistenceKey({
+                          discussionId: source.id()!,
+                        })
+                      : undefined
+                  }
                 />
               </div>
             </Show>
@@ -242,6 +250,14 @@ export function DiscussionThreadView(props: { thread: ViewThread }) {
                             onReady={(handle) => {
                               replyInputHandle = handle;
                             }}
+                            persistenceKey={
+                              source.id?.()
+                                ? makeDiscussionInputPersistenceKey({
+                                    discussionId: source.id()!,
+                                    threadId: threadId(),
+                                  })
+                                : undefined
+                            }
                           />
                         </div>
                       </div>

--- a/apps/web/packages/core/comments/discussion/DiscussionInput.tsx
+++ b/apps/web/packages/core/comments/discussion/DiscussionInput.tsx
@@ -19,7 +19,9 @@ import { addMediaFromFile } from '@core/component/LexicalMarkdown/plugins/media'
 import { isMobile } from '@core/mobile/isMobile';
 import type { IUser } from '@core/user/types';
 import PaperclipIcon from '@phosphor-icons/core/regular/paperclip.svg?component-solid';
+import type { PersistenceKey } from '@queries/persistence';
 import { isIOS } from '@solid-primitives/platform';
+import { makePersisted } from '@solid-primitives/storage';
 import { Surface } from '@ui';
 import {
   type Accessor,
@@ -39,6 +41,8 @@ export type DiscussionInputProps = InputCallbacks & {
   children?: JSX.Element;
   /** Whether to auto-focus the input on mount. Defaults to `!isMobile()`. */
   autofocus?: boolean;
+  /** When set, the draft value is persisted (e.g. across reloads) under this key. */
+  persistenceKey?: PersistenceKey;
 };
 
 function AttachImagesAction() {
@@ -95,7 +99,10 @@ function DefaultActions(props: { input: InputData; isSending: boolean }) {
 
 export function DiscussionInput(props: DiscussionInputProps) {
   const [scrollContainer, setScrollContainer] = createSignal<HTMLElement>();
-  const [value, setValue] = createSignal(props.input.value ?? '');
+  const rawValueSignal = createSignal(props.input.value ?? '');
+  const [value, setValue] = props.persistenceKey
+    ? makePersisted(rawValueSignal, { name: props.persistenceKey })
+    : rawValueSignal;
   const [mentions, setMentions] = createSignal<ItemMention[]>([]);
   const [showFormatRibbon, setShowFormatRibbon] = createSignal(false);
   const [isSending, setIsSending] = createSignal(false);

--- a/apps/web/packages/core/comments/discussion/persistence.ts
+++ b/apps/web/packages/core/comments/discussion/persistence.ts
@@ -1,0 +1,19 @@
+import { createPersistenceKey, type PersistenceKey } from '@queries/persistence';
+
+type DiscussionPersistenceProps = {
+  discussionId: string;
+  threadId?: string;
+};
+
+const INPUT_VALUE_PREFIX = 'discussion-input-value';
+const INPUT_VALUE_VERSION = 0;
+
+/** Scoped like `makeInputValuePersistenceKey` for channels, one namespace per discussion (+ thread). */
+export function makeDiscussionInputPersistenceKey(
+  props: DiscussionPersistenceProps
+): PersistenceKey {
+  return createPersistenceKey(
+    `${INPUT_VALUE_PREFIX}-discussion:${props.discussionId}${props.threadId ? `-thread:${props.threadId}` : ''}`,
+    INPUT_VALUE_VERSION
+  );
+}

--- a/apps/web/packages/core/comments/discussion/persistence.ts
+++ b/apps/web/packages/core/comments/discussion/persistence.ts
@@ -1,4 +1,7 @@
-import { createPersistenceKey, type PersistenceKey } from '@queries/persistence';
+import {
+  createPersistenceKey,
+  type PersistenceKey,
+} from '@queries/persistence';
 
 type DiscussionPersistenceProps = {
   discussionId: string;

--- a/apps/web/packages/core/comments/discussion/types.ts
+++ b/apps/web/packages/core/comments/discussion/types.ts
@@ -40,6 +40,12 @@ export interface DiscussionThread {
  * discussion UI render document and CRM comments.
  */
 export interface DiscussionSource {
+  /**
+   * Stable id for the entity backing this discussion (document/task block id,
+   * CRM entity id, ...), used to scope persisted composer drafts. Omit to
+   * leave drafts unpersisted.
+   */
+  id?: Accessor<string | undefined>;
   /** Threads to render, oldest-first; each thread's comments pre-sorted. */
   threads: Accessor<DiscussionThread[]>;
   /** Whether the current user may create/edit/delete here. */


### PR DESCRIPTION
## Summary

Channel message composers persist an in-progress draft across reloads/navigation (`ChannelInput` / `ThreadReplyChannelInput` use a `persistenceKey` backed by `makePersisted`). The shared Discussion UI — used for task/document comments and CRM company/contact comments — had no equivalent, so navigating away from a task mid-comment silently loses the draft. Raised as a feature request internally; this closes that gap.

## Changes

- `DiscussionInput` accepts an optional `persistenceKey` prop, wired to `makePersisted` the same way the channel input already does.
- `DiscussionSource` gains an optional `id` field (a stable identifier for the entity backing the discussion) so `Discussion.tsx` can derive a persistence key per discussion, and per reply thread, via a new `makeDiscussionInputPersistenceKey` helper mirroring the existing channel one.
- Wired `id` through `createDocumentDiscussionSource` (task/document comments, using the block id) and `useCrmDiscussionSource` (CRM company/contact comments, using the entity id).
- The PR-comment discussion source is intentionally left without an `id` — it's an in-memory prototype already documented as throwaway, so it just keeps its current non-persisted behavior.

Edit-in-place composers are unaffected since they seed from the existing comment text rather than a blank draft.

## Test plan

- [ ] `cargo`/backend n/a — frontend-only change (`apps/web`)
- [x] `bunx --bun biome check` on all changed files (clean)
- [ ] Manual: start a task comment or reply, type a draft, navigate away and back, confirm the draft is restored (blocked in this environment — `bun install` can't resolve private `macro-inc/tauri-plugins` / `macro-inc/pdf.js` git dependencies, so I could not run the dev server or full `tsc` here; please sanity-check in CI/dev)


---
_Generated by [Claude Code](https://claude.ai/code/session_016B1Q7sXLa6YvUUjJPzqjzV)_