### PR TITLE
feat(calls): call user mute icon

### DIFF
--- a/apps/web/src/features/channel/Call/CallOverlay.tsx
+++ b/apps/web/src/features/channel/Call/CallOverlay.tsx
@@ -13,6 +13,7 @@ import {
   CALL_PANEL_VERY_NARROW_PX,
 } from './call-panel-breakpoints';
 import { LK_TRACK_SOURCE } from './livekit-loader';
+import { MutedMicrophoneBadge } from './MutedMicrophoneBadge';
 import { TrackView } from './TrackView';
 import { useToggleShareWithTeam } from './use-toggle-share-with-team';
 
@@ -104,6 +105,7 @@ function ParticipantAvatar(props: {
 function LocalParticipantTile(props: {
   isSpeaking: boolean;
   isConnecting: boolean;
+  isAudioMuted: boolean;
   isVideoMuted: boolean;
   track: Track | undefined;
   userId: string | undefined;
@@ -130,6 +132,8 @@ function LocalParticipantTile(props: {
         <TrackView track={props.track} mirror />
       </Show>
 
+      <MutedMicrophoneBadge muted={props.isAudioMuted} label="You are muted" />
+
       <Show when={props.isConnecting} fallback={<VideoTag>You</VideoTag>}>
         <div class="absolute bottom-1 left-1 px-1.5 py-0.5 rounded bg-surface/70 text-ink-muted text-xs">
           Connecting...
@@ -149,6 +153,14 @@ function ParticipantTile(props: { participant: RemoteParticipant }) {
     callCtx.trackVersion();
     const pub = props.participant.getTrackPublication(LK_TRACK_SOURCE.Camera);
     return pub?.isSubscribed && !pub.isMuted ? pub.track : undefined;
+  };
+
+  const isAudioMuted = () => {
+    callCtx.trackVersion();
+    const publication = props.participant.getTrackPublication(
+      LK_TRACK_SOURCE.Microphone
+    );
+    return publication?.isMuted ?? true;
   };
 
   const isSpeaking = () => callCtx.isParticipantSpeaking(props.participant);
@@ -177,6 +189,11 @@ function ParticipantTile(props: { participant: RemoteParticipant }) {
       >
         <TrackView track={cameraTrack()} />
       </Show>
+
+      <MutedMicrophoneBadge
+        muted={isAudioMuted()}
+        label={`${displayName()} is muted`}
+      />
 
       <VideoTag variant="truncated">{displayName()}</VideoTag>
     </ParticipantTileWrapper>
@@ -294,6 +311,7 @@ export function CallOverlay(props: { onLeave: () => void }) {
               class="size-full"
               isSpeaking={isLocalSpeaking()}
               isConnecting={isConnecting()}
+              isAudioMuted={callCtx.isAudioMuted()}
               isVideoMuted={callCtx.isVideoMuted()}
               track={localVideoTrack()}
               userId={localUserId()}
@@ -316,6 +334,7 @@ export function CallOverlay(props: { onLeave: () => void }) {
               class="size-full min-h-0"
               isSpeaking={isLocalSpeaking()}
               isConnecting={isConnecting()}
+              isAudioMuted={callCtx.isAudioMuted()}
               isVideoMuted={callCtx.isVideoMuted()}
               track={localVideoTrack()}
               userId={localUserId()}

--- a/apps/web/src/features/channel/Call/MutedMicrophoneBadge.tsx
+++ b/apps/web/src/features/channel/Call/MutedMicrophoneBadge.tsx
@@ -16,7 +16,7 @@ export function MutedMicrophoneBadge(
         aria-label={props.label}
         class="pointer-events-none absolute top-2 right-2 z-10 flex size-7 items-center justify-center rounded-full border border-edge bg-surface/90 text-failure"
       >
-        <MicrophoneSlash aria-hidden="true" class="size-4" />
+        <MicrophoneSlash aria-hidden="true" class="size-5" />
       </div>
     </Show>
   );

--- a/apps/web/src/features/channel/Call/MutedMicrophoneBadge.tsx
+++ b/apps/web/src/features/channel/Call/MutedMicrophoneBadge.tsx
@@ -1,0 +1,23 @@
+import MicrophoneSlash from '@phosphor/microphone-slash.svg';
+import { type JSX, Show } from 'solid-js';
+
+export type MutedMicrophoneBadgeProps = {
+  muted: boolean;
+  label: string;
+};
+
+export function MutedMicrophoneBadge(
+  props: MutedMicrophoneBadgeProps
+): JSX.Element {
+  return (
+    <Show when={props.muted}>
+      <div
+        role="status"
+        aria-label={props.label}
+        class="pointer-events-none absolute top-2 right-2 z-10 flex size-7 items-center justify-center rounded-full border border-edge bg-surface/90 text-failure"
+      >
+        <MicrophoneSlash aria-hidden="true" class="size-4" />
+      </div>
+    </Show>
+  );
+}

--- a/apps/web/src/features/channel/Call/tests/call-overlay-muted.test.tsx
+++ b/apps/web/src/features/channel/Call/tests/call-overlay-muted.test.tsx
@@ -1,0 +1,237 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { render, screen } from '@solidjs/testing-library';
+import type { RemoteParticipant, Track } from 'livekit-client';
+import { createSignal, type Setter } from 'solid-js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { CallState } from '../CallContext';
+import { CallOverlay } from '../CallOverlay';
+
+const mocks = vi.hoisted(() => ({
+  callContext: undefined as unknown,
+  displayNames: new Map<string, string>(),
+}));
+
+vi.mock('@components/app/split-layout/layoutUtils', () => ({
+  useSplitPanel: () => undefined,
+}));
+
+vi.mock('@core/component/UserIcon', () => ({
+  UserIcon: () => <div data-testid="user-avatar" />,
+}));
+
+vi.mock('@core/context/user', () => ({
+  useAuthor: () => () => 'Current User',
+  useUserId: () => () => 'current-user',
+}));
+
+vi.mock('@core/signal/profilePicture', () => ({
+  useProfilePictureUrl: () => [() => undefined],
+}));
+
+vi.mock('@core/user', () => ({
+  tryMacroId: (identity: string) => identity,
+  useDisplayName: (identity: string) => [
+    () => mocks.displayNames.get(identity) ?? identity,
+  ],
+}));
+
+vi.mock('@ui', () => ({
+  cn: (...classes: Array<string | false | null | undefined>) =>
+    classes.filter(Boolean).join(' '),
+  InlineCheckbox: () => null,
+  Tooltip: (props: { children: unknown }) => props.children,
+}));
+
+vi.mock('../CallContext', () => ({
+  useCallContext: () => mocks.callContext,
+}));
+
+vi.mock('../CallControls/CallControls', () => ({
+  CallControls: () => null,
+}));
+
+vi.mock('../TrackView', () => ({
+  TrackView: (props: { track?: { sid?: string } }) => (
+    <div data-testid={`track-${props.track?.sid ?? 'none'}`} />
+  ),
+}));
+
+vi.mock('../use-toggle-share-with-team', () => ({
+  useToggleShareWithTeam: () => () => undefined,
+}));
+
+type MockTrackPublication = {
+  isMuted: boolean;
+  isSubscribed: boolean;
+  track?: Track;
+};
+
+type ParticipantPublications = Record<string, MockTrackPublication | undefined>;
+
+type CallStateControls = {
+  setAudioMuted: Setter<boolean>;
+  setParticipants: Setter<Map<string, RemoteParticipant>>;
+  setTrackVersion: Setter<number>;
+};
+
+function createTrack(sid: string): Track {
+  return { sid } as unknown as Track;
+}
+
+function createRemoteParticipant(
+  identity: string,
+  publications: ParticipantPublications
+): RemoteParticipant {
+  return {
+    identity,
+    isAgent: false,
+    getTrackPublication(source: string) {
+      return publications[source];
+    },
+  } as unknown as RemoteParticipant;
+}
+
+function setUpCallState(
+  initialParticipants: RemoteParticipant[] = []
+): CallStateControls {
+  const [audioMuted, setAudioMuted] = createSignal(false);
+  const [participants, setParticipants] = createSignal(
+    new Map(
+      initialParticipants.map((participant) => [
+        participant.identity,
+        participant,
+      ])
+    )
+  );
+  const [trackVersion, setTrackVersion] = createSignal(0);
+  const localCameraTrack = createTrack('local-camera');
+
+  mocks.callContext = {
+    connectionState: () => 'connected',
+    isAudioMuted: audioMuted,
+    isConnecting: () => false,
+    isLocalSpeaking: () => false,
+    isParticipantSpeaking: () => false,
+    isScreenSharing: () => false,
+    isSharedWithTeam: () => false,
+    isVideoMuted: () => false,
+    remoteParticipants: participants,
+    room: () => ({
+      localParticipant: {
+        identity: 'current-user',
+        getTrackPublication: () => ({ track: localCameraTrack }),
+      },
+    }),
+    trackVersion,
+  } as unknown as CallState;
+
+  return { setAudioMuted, setParticipants, setTrackVersion };
+}
+
+beforeEach(() => {
+  mocks.displayNames.clear();
+});
+
+describe('CallOverlay muted microphone badges', () => {
+  it('shows local mute state on both the full tile and local PIP', () => {
+    const controls = setUpCallState();
+
+    render(() => <CallOverlay onLeave={() => undefined} />);
+
+    expect(screen.queryByRole('status', { name: 'You are muted' })).toBeNull();
+
+    controls.setAudioMuted(true);
+    const fullTileBadge = screen.getByRole('status', {
+      name: 'You are muted',
+    });
+
+    expect(
+      fullTileBadge.parentElement?.querySelector(
+        '[data-testid="track-local-camera"]'
+      )
+    ).not.toBeNull();
+    expect(fullTileBadge.parentElement?.parentElement?.className).not.toContain(
+      'bottom-4'
+    );
+
+    const remote = createRemoteParticipant('alex', {});
+    controls.setParticipants(new Map([[remote.identity, remote]]));
+
+    const pipBadge = screen.getByRole('status', { name: 'You are muted' });
+    expect(pipBadge.parentElement?.parentElement?.className).toContain(
+      'bottom-4'
+    );
+
+    controls.setAudioMuted(false);
+    expect(screen.queryByRole('status', { name: 'You are muted' })).toBeNull();
+  });
+
+  it('reacts to remote microphone mute events over video content', () => {
+    mocks.displayNames.set('alex', 'Alex Morgan');
+    const microphone: MockTrackPublication = {
+      isMuted: true,
+      isSubscribed: true,
+    };
+    const publications: ParticipantPublications = {
+      camera: {
+        isMuted: false,
+        isSubscribed: true,
+        track: createTrack('alex-camera'),
+      },
+      microphone,
+    };
+    const remote = createRemoteParticipant('alex', publications);
+    const controls = setUpCallState([remote]);
+
+    render(() => <CallOverlay onLeave={() => undefined} />);
+
+    const badge = screen.getByRole('status', {
+      name: 'Alex Morgan is muted',
+    });
+    expect(
+      badge.parentElement?.querySelector('[data-testid="track-alex-camera"]')
+    ).not.toBeNull();
+
+    microphone.isMuted = false;
+    controls.setTrackVersion((version) => version + 1);
+    expect(
+      screen.queryByRole('status', { name: 'Alex Morgan is muted' })
+    ).toBeNull();
+
+    microphone.isMuted = true;
+    controls.setTrackVersion((version) => version + 1);
+    expect(
+      screen.getByRole('status', { name: 'Alex Morgan is muted' })
+    ).toBeTruthy();
+  });
+
+  it('treats a missing remote microphone as muted over avatar content', () => {
+    mocks.displayNames.set('alex', 'Alex Morgan');
+    const publications: ParticipantPublications = {};
+    const remote = createRemoteParticipant('alex', publications);
+    const controls = setUpCallState([remote]);
+
+    render(() => <CallOverlay onLeave={() => undefined} />);
+
+    const badge = screen.getByRole('status', {
+      name: 'Alex Morgan is muted',
+    });
+    const tile = badge.parentElement;
+
+    expect(tile?.classList).toContain('relative');
+    expect(tile?.textContent).toContain('A');
+    expect(tile?.querySelector('[data-testid="track-alex-camera"]')).toBeNull();
+
+    publications.microphone = {
+      isMuted: false,
+      isSubscribed: true,
+    };
+    controls.setTrackVersion((version) => version + 1);
+    expect(
+      screen.queryByRole('status', { name: 'Alex Morgan is muted' })
+    ).toBeNull();
+  });
+});

--- a/apps/web/src/features/channel/Call/tests/muted-microphone-badge.test.tsx
+++ b/apps/web/src/features/channel/Call/tests/muted-microphone-badge.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { render, screen } from '@solidjs/testing-library';
+import { createSignal } from 'solid-js';
+import { describe, expect, it } from 'vitest';
+import { MutedMicrophoneBadge } from '../MutedMicrophoneBadge';
+
+describe('MutedMicrophoneBadge', () => {
+  it('renders nothing while the microphone is unmuted', () => {
+    const { container } = render(() => (
+      <MutedMicrophoneBadge muted={false} label="You are muted" />
+    ));
+
+    expect(container.innerHTML).toBe('');
+    expect(screen.queryByRole('status')).toBeNull();
+  });
+
+  it('renders a non-interactive, accessible status while muted', () => {
+    render(() => <MutedMicrophoneBadge muted label="Alex Morgan is muted" />);
+
+    const status = screen.getByRole('status', {
+      name: 'Alex Morgan is muted',
+    });
+    const icon = status.querySelector('svg');
+
+    expect(status.classList).toContain('pointer-events-none');
+    expect(icon).not.toBeNull();
+    expect(icon?.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('reacts to changes in the muted state and label', () => {
+    const [muted, setMuted] = createSignal(false);
+    const [label, setLabel] = createSignal('You are muted');
+
+    render(() => <MutedMicrophoneBadge muted={muted()} label={label()} />);
+
+    expect(screen.queryByRole('status')).toBeNull();
+
+    setMuted(true);
+    expect(screen.getByRole('status', { name: 'You are muted' })).toBeTruthy();
+
+    setLabel('Alex Morgan is muted');
+    expect(
+      screen.getByRole('status', { name: 'Alex Morgan is muted' })
+    ).toBeTruthy();
+
+    setMuted(false);
+    expect(screen.queryByRole('status')).toBeNull();
+  });
+});


### PR DESCRIPTION
Shows a mute icon on the user's call tile if they are muted