### PR TITLE
fix(soup): keep move-to-folder selection in sync with visible items

### DIFF
--- a/apps/web/src/features/entity/bulk-edit/BulkMoveToProjectView.tsx
+++ b/apps/web/src/features/entity/bulk-edit/BulkMoveToProjectView.tsx
@@ -306,15 +306,21 @@ export const BulkMoveToProjectView = (props: {
       newItems = result;
     }
 
-    // Reset focus when items change — use newItems directly to avoid re-tracking
+    // Reset selection when it's no longer visible (e.g. filtered out by
+    // search) — use untrack/newItems directly to avoid re-tracking
     const fi = untrack(focusedIndex);
-    if (newItems.length > 0 && fi === -1) {
-      setFocusedIndex(0);
-      setSelectedProject(newItems[0]);
-    } else if (fi >= newItems.length) {
-      const newIndex = Math.max(0, newItems.length - 1);
-      setFocusedIndex(newIndex);
-      setSelectedProject(newItems[newIndex] || null);
+    const selected = untrack(selectedProject);
+    const selectionVisible =
+      selected != null && newItems.some((item) => item.id === selected.id);
+    if (!selectionVisible) {
+      if (newItems.length > 0) {
+        const newIndex = Math.min(Math.max(fi, 0), newItems.length - 1);
+        setFocusedIndex(newIndex);
+        setSelectedProject(newItems[newIndex]);
+      } else {
+        setFocusedIndex(-1);
+        setSelectedProject(null);
+      }
     }
   };
 


### PR DESCRIPTION
## Summary

Fixes a bug in the bulk "Move to folder" modal (opened from soup) where searching for a folder and pressing Enter moved the items into the wrong folder.

## Problem

The modal tracks the highlighted row (`focusedIndex`) and the actual move target (`selectedProject`) as separate state. When the modal opens, the first folder in the list is auto-selected. Typing a search rebuilds the visible list, but the reset logic only updated the selection when `focusedIndex` was `-1` or past the end of the new list. With one search result and `focusedIndex` still `0`, neither condition hit — so the filtered folder got the highlight while `selectedProject` silently stayed on the original first folder. Pressing Enter (or clicking Move) then moved the items into that stale folder.

## Fix

`updateFlattenedProjects` now checks whether the currently selected folder is still present in the new visible list. If it was filtered out (or hidden by a collapse), the selection moves to the item at the clamped focused index; if the list is empty, the selection clears entirely so the Move button disables.

The new-folder flow is unaffected: `createProject` awaits `invalidateProjects()` before returning, so the created folder is already in the list when the modal re-selects it and the visibility check leaves that selection alone.