### PR TITLE
feat(email): theme-adapt forwarded html in the compose quote

### DIFF
--- a/apps/web/src/features/block-email/component/BaseInput.tsx
+++ b/apps/web/src/features/block-email/component/BaseInput.tsx
@@ -97,6 +97,7 @@ import {
   Switch,
   untrack,
 } from 'solid-js';
+import { isPersonalMessage } from '../util/isPersonalMessage';
 import { makeAttachmentPublic } from '../util/makeAttachmentPublic';
 import { getFirstName } from '../util/name';
 import {
@@ -1485,6 +1486,11 @@ export function BaseInput(props: {
       replyingTo,
       replyType: effectiveReplyType(),
       visible: !currentlyAppended,
+      isPersonal: isPersonalMessage(
+        replyingTo,
+        userEmail(),
+        ctx.messages.personalSenders()
+      ),
     });
 
     editor()?.update(() => {

--- a/apps/web/src/features/block-email/component/Email.tsx
+++ b/apps/web/src/features/block-email/component/Email.tsx
@@ -8,7 +8,7 @@ import { SidePanel } from '@components/app/side-panel';
 import { useSplitLayout } from '@components/app/split-layout/layout';
 import { useSplitPanel } from '@components/app/split-layout/layoutUtils';
 import { CustomScrollbar } from '@core/component/CustomScrollbar';
-import { useUserContext } from '@core/context/user';
+import { useEmail, useUserContext } from '@core/context/user';
 import { TOKENS } from '@core/hotkey/tokens';
 import { registerScopeSignalHotkey } from '@core/hotkey/utils';
 import { isMobile } from '@core/mobile/isMobile';
@@ -35,6 +35,7 @@ import {
 } from 'solid-js';
 import { isScrollingToMessage } from '../signal/scrollState';
 import { registerEmailHotkeys } from '../util/emailHotkeys';
+import { isPersonalMessage } from '../util/isPersonalMessage';
 import type { ReplyType } from '../util/replyType';
 import { scrollToMessage } from '../util/scrollToMessage';
 import { BottomReplyButtons } from './BottomReplyButtons';
@@ -82,6 +83,7 @@ function EmailContent(props: EmailViewProps) {
   const context = useEmailContext();
   const splitPanel = useSplitPanel();
   const { isLoading: isUserLoading } = useUserContext();
+  const userEmail = useEmail();
 
   const [isScrolled, setIsScrolled] = createSignal(false);
 
@@ -684,6 +686,12 @@ function EmailContent(props: EmailViewProps) {
                   context.messages.unfiltered().find((m) => m.db_id === id),
                 getDraftForMessageReply: context.drafts.getDraftForMessage,
                 onRecipientsChange: context.onRecipientsChange,
+                isPersonalMessage: (message) =>
+                  isPersonalMessage(
+                    message,
+                    userEmail(),
+                    context.messages.personalSenders()
+                  ),
               }}
             >
               {/* Edge-to-edge on mobile: the message list carries its own

--- a/apps/web/src/features/block-email/component/EmailMessageBody.tsx
+++ b/apps/web/src/features/block-email/component/EmailMessageBody.tsx
@@ -23,6 +23,7 @@ import {
 } from 'solid-js';
 import { themeReactive } from '../../theme/signals/themeReactive';
 import { themeUpdate } from '../../theme/signals/themeSignals';
+import { isPersonalMessage } from '../util/isPersonalMessage';
 import {
   fetchImagesViaPlatform,
   resolveCidImages,
@@ -122,15 +123,9 @@ export function EmailMessageBody(props: EmailMessageBodyProps) {
   };
 
   // TODO it might be nice to do some additional checks here, e.g. check if this message was sent from a user that the user has sent a message to before.
-  const isPersonal = createMemo(() => {
-    const senderEmail = props.message.from?.email?.toLowerCase();
-    return (
-      (senderEmail !== undefined &&
-        senderEmail === userEmail()?.toLowerCase()) ||
-      props.message.labels.some((l) => l.name === 'CATEGORY_PERSONAL') ||
-      (senderEmail !== undefined && props.personalSenders().has(senderEmail))
-    );
-  });
+  const isPersonal = createMemo(() =>
+    isPersonalMessage(props.message, userEmail(), props.personalSenders())
+  );
 
   const isMacroSender = createMemo(() => {
     const senderEmail = props.message.from?.email?.toLowerCase();

--- a/apps/web/src/features/block-email/component/createEmailFormState.ts
+++ b/apps/web/src/features/block-email/component/createEmailFormState.ts
@@ -47,6 +47,9 @@ export interface EmailFormStateOptions {
   getMessageByID: (id: string) => ApiMessage | undefined;
   getDraftForMessageReply: (id: string) => ApiMessage | undefined;
   onRecipientsChange?: (next: EmailRecipient[]) => void;
+  /** Whether a message is personal (see isPersonalMessage); drives
+   * theme-adapted rendering of quoted html in the composer */
+  isPersonalMessage?: (message: ApiMessage) => boolean;
 }
 
 type EmailFormState = {
@@ -268,6 +271,7 @@ export function createEmailFormState(
             replyingTo: replyingTo,
             replyType: rt,
             visible: true,
+            isPersonal: options?.isPersonalMessage?.(msg),
           });
         } else {
           pendingForwardAppend = true;
@@ -386,6 +390,9 @@ export function createEmailFormState(
             replyingTo,
             replyType: 'forward',
             visible: true,
+            isPersonal: replyingTo
+              ? options?.isPersonalMessage?.(replyingTo)
+              : undefined,
           });
         }, 0);
       }

--- a/apps/web/src/features/block-email/util/isPersonalMessage.ts
+++ b/apps/web/src/features/block-email/util/isPersonalMessage.ts
@@ -1,0 +1,17 @@
+import type { ApiMessage } from '@service-email/generated/schemas';
+
+/** Personal messages get theme-adapted rendering (vs the forced white panel
+ * for table-layout marketing emails). Mirrored between the message view and
+ * the compose quote. */
+export function isPersonalMessage(
+  message: ApiMessage,
+  userEmail: string | undefined,
+  personalSenders: Set<string>
+): boolean {
+  const senderEmail = message.from?.email?.toLowerCase();
+  return (
+    (senderEmail !== undefined && senderEmail === userEmail?.toLowerCase()) ||
+    message.labels.some((l) => l.name === 'CATEGORY_PERSONAL') ||
+    (senderEmail !== undefined && personalSenders.has(senderEmail))
+  );
+}

--- a/apps/web/src/features/block-email/util/prepareEmailBody.ts
+++ b/apps/web/src/features/block-email/util/prepareEmailBody.ts
@@ -43,6 +43,9 @@ export const TOGGLE_APPEND_EMAIL_THREAD_COMMAND = createCommand<{
   replyingTo: ApiMessage | undefined;
   replyType?: ReplyType;
   visible: boolean;
+  /** Whether the quoted message is personal (drives theme-adapted rendering
+   * of the quoted html, matching the message view) */
+  isPersonal?: boolean;
 }>('TOGGLE_APPEND_EMAIL_THREAD_COMMAND');
 
 type HeaderDescriptor =
@@ -147,7 +150,8 @@ const REPLYING_TO_ID_ATTRIBUTE = 'data-replying-to-id';
 const $appendPreviousEmail = (
   editor: LexicalEditor,
   replyingTo: ApiMessage | undefined,
-  replyType: ReplyType | undefined
+  replyType: ReplyType | undefined,
+  isPersonal?: boolean
 ) => {
   if (!replyingTo) return true;
   const wrapper = $createClassedBlockNode({
@@ -178,7 +182,12 @@ const $appendPreviousEmail = (
     // good indicator of content we can't convert into editable nodes correctly.
     const hasTable = Boolean(dom.querySelector('table'));
     if (replyType === 'forward' || hasTable) {
-      const htmlNode = $createHtmlRenderNode({ html: replyingToBodyHTML });
+      const htmlNode = $createHtmlRenderNode({
+        html: replyingToBodyHTML,
+        // Same branch the message view takes: personal or table-less emails
+        // get theme-adapted colors, table-layout emails get a white panel
+        adaptColors: Boolean(isPersonal) || !hasTable,
+      });
       quoteNode.append(htmlNode);
     } else {
       const nodes = $generateNodesFromDOM(editor, dom);
@@ -237,7 +246,7 @@ function removeAppendedThread(
 export function registerToggleAppendedThread(editor: LexicalEditor) {
   return editor.registerCommand(
     TOGGLE_APPEND_EMAIL_THREAD_COMMAND,
-    ({ replyingTo, visible, replyType }) => {
+    ({ replyingTo, visible, replyType, isPersonal }) => {
       // Programmatic content change: don't let selection reconciliation
       // move DOM focus into the editor
       $addUpdateTag('skip-dom-selection');
@@ -248,7 +257,7 @@ export function registerToggleAppendedThread(editor: LexicalEditor) {
         return true;
       }
 
-      $appendPreviousEmail(editor, replyingTo, replyType);
+      $appendPreviousEmail(editor, replyingTo, replyType, isPersonal);
       // Appending leaves a dirty selection inside the quote; any later
       // update would flush it to the DOM and steal focus into the editor
       $setSelection(null);

--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/HtmlRender.tsx
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/HtmlRender.tsx
@@ -1,10 +1,24 @@
+import {
+  processEmailColors,
+  stripColorSchemeMediaQueries,
+  type ThemeColorParams,
+} from '@core/email';
 import type { HtmlRenderDecoratorProps } from '@macro-inc/lexical-core/nodes/HtmlRenderNode';
-import { type Component, createSignal, onMount } from 'solid-js';
+import { themeReactive } from '@theme/signals/themeReactive';
+import { themeUpdate } from '@theme/signals/themeSignals';
+import {
+  type Component,
+  createEffect,
+  createSignal,
+  onMount,
+  untrack,
+} from 'solid-js';
 import { Portal } from 'solid-js/web';
 
 export const HtmlRender: Component<HtmlRenderDecoratorProps> = (props) => {
   let marker: HTMLDivElement | undefined;
   const [shadowContainer, setShadowContainer] = createSignal<HTMLElement>();
+  const [content, setContent] = createSignal<HTMLDivElement>();
 
   onMount(() => {
     const host = marker?.parentElement;
@@ -13,6 +27,15 @@ export const HtmlRender: Component<HtmlRenderDecoratorProps> = (props) => {
     }
 
     const shadowRoot = host.shadowRoot ?? host.attachShadow({ mode: 'open' });
+
+    // Base style mirroring the email message view's shadow root
+    if (!shadowRoot.querySelector('style')) {
+      const styleEl = document.createElement('style');
+      styleEl.textContent =
+        'img{max-width:100% !important;height:auto !important;}' +
+        'blockquote{margin-block:0.75em!important;margin-inline-start:1.5em!important;margin-inline-end:0!important;max-width:100%!important;box-sizing:border-box;}';
+      shadowRoot.appendChild(styleEl);
+    }
 
     // Ensure a stable container for portal mounting
     let container = shadowRoot.querySelector<HTMLDivElement>(
@@ -26,6 +49,47 @@ export const HtmlRender: Component<HtmlRenderDecoratorProps> = (props) => {
     setShadowContainer(container);
   });
 
+  // Match the message view's rendering: strip light backgrounds and adapt
+  // text colors to the theme (or force a white panel for table-layout emails).
+  // Display-only — the node's raw html is what exportDOM sends.
+  createEffect(() => {
+    themeUpdate();
+    const el = content();
+    if (!el) return;
+    // Reset to the raw html so recoloring never compounds
+    el.innerHTML = props.html;
+    for (const styleEl of el.querySelectorAll('style')) {
+      styleEl.textContent = stripColorSchemeMediaQueries(
+        styleEl.textContent ?? ''
+      );
+    }
+    const adapt = props.adaptColors ?? !el.querySelector('table');
+    queueMicrotask(() => {
+      untrack(() => {
+        if (!el.isConnected) return;
+        if (adapt) {
+          el.style.removeProperty('background-color');
+          el.style.removeProperty('color');
+          const theme: ThemeColorParams = {
+            inkL: themeReactive.c0.l[0](),
+            inkC: themeReactive.c0.c[0](),
+            inkH: themeReactive.c0.h[0](),
+            panelL: themeReactive.b1.l[0](),
+            accentL: themeReactive.a0.l[0](),
+            accentC: themeReactive.a0.c[0](),
+            accentH: themeReactive.a0.h[0](),
+          };
+          processEmailColors(el, theme);
+        } else {
+          el.style.setProperty('background-color', 'white', 'important');
+          // Some emails don't set a color, so force black for readability
+          // against the forced white background
+          el.style.setProperty('color', 'black');
+        }
+      });
+    });
+  });
+
   return (
     <>
       <div ref={marker} style={{ display: 'contents' }} />
@@ -33,9 +97,9 @@ export const HtmlRender: Component<HtmlRenderDecoratorProps> = (props) => {
         {/* contain: floats/positioned content in email HTML must size and
             paint within this node, not over siblings below the editor */}
         <div
+          ref={setContent}
           data-html-render="true"
           style={{ contain: 'layout' }}
-          innerHTML={props.html}
         />
       </Portal>
     </>

--- a/apps/web/src/lib/core/component/LexicalMarkdown/version.ts
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/version.ts
@@ -12,5 +12,6 @@
  * Version 1.4 - Jun 2, 2026. Added persisted await placeholders for pending agent messages.
  * Version 2.0 - Jun 19, 2026. Added PullRequestMentionNode.
  * Version 2.1 - Jun 23, 2026. Added PasteNode
+ * Version 2.2 - Jul 13, 2026. Added optional adaptColors display hint to HtmlRenderNode.
  */
-export const MARKDOWN_VERSION_COUNTER = 2.1;
+export const MARKDOWN_VERSION_COUNTER = 2.2;

--- a/apps/web/src/lib/core/email/index.ts
+++ b/apps/web/src/lib/core/email/index.ts
@@ -1,5 +1,8 @@
 // Email body parsing utilities
-export { parseEmailContent } from './parse-email-html';
+export {
+  parseEmailContent,
+  stripColorSchemeMediaQueries,
+} from './parse-email-html';
 
 // Image proxy utilities
 

--- a/apps/web/src/lib/core/email/parse-email-html.ts
+++ b/apps/web/src/lib/core/email/parse-email-html.ts
@@ -5,7 +5,7 @@ import { proxyEmailImages } from './proxy-email-images';
  * Strips @media (prefers-color-scheme: ...) rules from CSS content.
  * This prevents email dark mode styles from conflicting with our forced backgrounds.
  */
-function stripColorSchemeMediaQueries(cssContent: string): string {
+export function stripColorSchemeMediaQueries(cssContent: string): string {
   try {
     const sheet = new CSSStyleSheet();
     sheet.replaceSync(cssContent);

--- a/packages/lexical-core/nodes/HtmlRenderNode.ts
+++ b/packages/lexical-core/nodes/HtmlRenderNode.ts
@@ -15,6 +15,9 @@ import { DecoratorBlockNode } from './DecoratorBlockNode';
 
 export type HtmlRenderData = {
   html: string;
+  /** Display-only hint: adapt colors to the app theme when rendering
+   * (mirrors the email message view). Undefined = decide from content. */
+  adaptColors?: boolean;
 };
 
 export type SerializedHtmlRenderNode = Spread<
@@ -31,6 +34,7 @@ export class HtmlRenderNode extends DecoratorBlockNode<
   DecoratorComponent<HtmlRenderDecoratorProps> | undefined
 > {
   __html: string;
+  __adaptColors?: boolean;
 
   static getType() {
     return 'html-render';
@@ -41,16 +45,20 @@ export class HtmlRenderNode extends DecoratorBlockNode<
   }
 
   static clone(node: HtmlRenderNode) {
-    return new HtmlRenderNode(node.__html, node.__key);
+    return new HtmlRenderNode(node.__html, node.__adaptColors, node.__key);
   }
 
-  constructor(html: string, key?: NodeKey) {
+  constructor(html: string, adaptColors?: boolean, key?: NodeKey) {
     super('left', key);
     this.__html = html;
+    this.__adaptColors = adaptColors;
   }
 
   static importJSON(serializedNode: SerializedHtmlRenderNode) {
-    const node = $createHtmlRenderNode({ html: serializedNode.html });
+    const node = $createHtmlRenderNode({
+      html: serializedNode.html,
+      adaptColors: serializedNode.adaptColors,
+    });
     $applyIdFromSerialized(node, serializedNode);
     return node;
   }
@@ -59,6 +67,7 @@ export class HtmlRenderNode extends DecoratorBlockNode<
     return {
       ...super.exportJSON(),
       html: this.__html,
+      adaptColors: this.__adaptColors,
       type: HtmlRenderNode.getType(),
       version: 1,
     };
@@ -67,6 +76,7 @@ export class HtmlRenderNode extends DecoratorBlockNode<
   exportComponentProps(): HtmlRenderData {
     return {
       html: this.__html,
+      adaptColors: this.__adaptColors,
     };
   }
 
@@ -100,7 +110,12 @@ export class HtmlRenderNode extends DecoratorBlockNode<
         ? dsdTemplate.innerHTML
         : (htmlFromAttr ?? domNode.innerHTML);
 
-      const node = $createHtmlRenderNode({ html: htmlString });
+      const node = $createHtmlRenderNode({
+        html: htmlString,
+        adaptColors: domNode.classList.contains('macro_html_render_adapt')
+          ? true
+          : undefined,
+      });
       return { node };
     };
 
@@ -112,7 +127,10 @@ export class HtmlRenderNode extends DecoratorBlockNode<
   exportDOM() {
     const host = document.createElement('div');
     host.setAttribute('data-html-render', 'true');
-    host.className = 'macro_html_render';
+    // Class markers survive the backend sanitizer (data-* attributes don't)
+    host.className = this.__adaptColors
+      ? 'macro_html_render macro_html_render_adapt'
+      : 'macro_html_render';
 
     const template = document.createElement('template');
     template.setAttribute('shadowrootmode', 'open');
@@ -141,6 +159,7 @@ export class HtmlRenderNode extends DecoratorBlockNode<
       return () =>
         decorator({
           html: this.__html,
+          adaptColors: this.__adaptColors,
           key: this.getKey(),
           theme: config.theme,
         });
@@ -149,7 +168,7 @@ export class HtmlRenderNode extends DecoratorBlockNode<
 }
 
 export function $createHtmlRenderNode(params: HtmlRenderData): HtmlRenderNode {
-  const node = new HtmlRenderNode(params.html);
+  const node = new HtmlRenderNode(params.html, params.adaptColors);
   return $applyNodeReplacement(node);
 }
 

--- a/packages/lexical-core/tests/htmlRender.test.ts
+++ b/packages/lexical-core/tests/htmlRender.test.ts
@@ -36,7 +36,7 @@ function $buildForwardEditorState() {
   wrapper.append(header);
 
   const quote = $createQuoteNode();
-  quote.append(new HtmlRenderNode(QUOTED_HTML));
+  quote.append(new HtmlRenderNode(QUOTED_HTML, true));
   wrapper.append(quote);
   root.append(wrapper);
 }
@@ -84,6 +84,8 @@ describe('HtmlRenderNode - m-html-render transformer', () => {
       }
       expect(htmlNodes).toHaveLength(1);
       expect(htmlNodes[0].exportComponentProps().html).toBe(QUOTED_HTML);
+      // The display hint survives the markdown round-trip too
+      expect(htmlNodes[0].exportComponentProps().adaptColors).toBe(true);
     });
   });
 });

--- a/packages/lexical-core/transformers/htmlRender.ts
+++ b/packages/lexical-core/transformers/htmlRender.ts
@@ -38,7 +38,15 @@ export const I_HTML_RENDER: TextMatchTransformer = {
       if (typeof data.html !== 'string') {
         throw new Error('Missing html field');
       }
-      node.replace($createHtmlRenderNode({ html: data.html }));
+      node.replace(
+        $createHtmlRenderNode({
+          html: data.html,
+          adaptColors:
+            typeof data.adaptColors === 'boolean'
+              ? data.adaptColors
+              : undefined,
+        })
+      );
     } catch (e) {
       console.error('Failed to parse m-html-render:', e);
       replaceTextWithUnknownMention(node, 'Unknown Content');


### PR DESCRIPTION
Follow-up to #4717. The forwarded email HTML embedded in the reply box rendered with the original sender colors (light backgrounds, blue links), while the message view strips light backgrounds and adapts text colors to the app theme. The quoted content now gets the same treatment, so the forward preview looks like the message it was forwarded from.

## What changed

**`HtmlRender` decorator (display only)**
- On mount and on every theme change, the shadow-DOM content is reset from the node's raw HTML, `prefers-color-scheme` media queries are stripped from embedded `<style>` tags (same as `parseEmailContent`), and then either:
  - `processEmailColors` runs against the current theme (strip light backgrounds, clamp/invert text lightness, accent-color chromatic links), or
  - the content gets the forced white panel + black text fallback the message view uses for table-layout marketing emails.
- The shadow root also gets the message view's base containment styles (`img { max-width: 100% }`, blockquote margin containment).
- All of this is display-only: `exportDOM` still emits the raw original HTML, so the recipient receives the unmodified markup.

**Which branch to take** mirrors the message view's `isPersonal || !hasTable` check:
- The shared `isPersonal` logic is extracted from `EmailMessageBody` into `isPersonalMessage()` (sender is you, `CATEGORY_PERSONAL`, or thread-level personal sender).
- `TOGGLE_APPEND_EMAIL_THREAD_COMMAND` carries an `isPersonal` flag, computed at the dispatch sites (form-state forward append via a new `formOptions.isPersonalMessage` callback wired in `Email.tsx`; quoted-text toggle in `BaseInput` directly).
- `$appendPreviousEmail` resolves it to an `adaptColors` hint stored on `HtmlRenderNode`.

**`HtmlRenderNode` (`lexical-core`)**
- New optional `adaptColors` field. It round-trips through draft markdown via `exportComponentProps` / the `m-html-render` transformer, and through sanitized HTML via a `macro_html_render_adapt` class marker (the sanitizer strips `data-*` but keeps classes). When the hint is missing (pre-existing drafts), the decorator falls back to the has-table heuristic, which matches what the hint would have resolved to for non-personal emails.
- Round-trip regression test extended to assert the hint survives markdown serialization.
