### PR TITLE
fix(inbox): don't target read notifications on channel row click

### DIFF
--- a/apps/web/src/features/next-soup/utils.ts
+++ b/apps/web/src/features/next-soup/utils.ts
@@ -42,6 +42,7 @@ import {
   getAllNotificationsFromGroup,
   getChannelNotificationParams,
   type NotificationSource,
+  notificationIsRead,
   setDoneOverride,
   stackNotifications,
   type UnifiedNotification,
@@ -343,10 +344,11 @@ interface OpenEntityOptions {
  * driving notification (the same data the card renders), so read the target
  * from there, exactly like the old inbox did via getChannelNotificationParams.
  * Notifications are scoped to the row first (top-level sends for a channel,
- * this thread's replies for a thread) and the most recent one wins. With no
- * notification either, fall back to the row's own ids — a `channel_thread`
- * row opens at its root and a `channel` row has no message to target (open
- * latest).
+ * this thread's replies for a thread) and the most recent unread one wins —
+ * read notifications never aim the click, so a row that looks read matches
+ * its unread indicator. With no unread notification, fall back to the row's
+ * own ids — a `channel_thread` row opens at its root and a `channel` row has
+ * no message to target (open latest).
  */
 export function getChannelEntityTarget(
   entity: EntityData
@@ -373,6 +375,7 @@ export function getChannelEntityTarget(
     entity.notifications?.() ?? []
   );
   for (const notification of scoped) {
+    if (notificationIsRead(notification)) continue;
     const { messageId, threadId } = getChannelNotificationParams(notification);
     if (messageId) return { messageId, threadId };
   }


### PR DESCRIPTION
Clicking a channel inbox row targeted the most recent notification with no regard for read state, while the row's unread indicator uses `notificationIsRead` — so a read-looking channel row still jumped to the newest other-sender notification, potentially far above the latest message (your own messages never notify you). Skip read notifications in `getChannelEntityTarget` so the click agrees with the unread dot: unread rows jump to the unread message, read rows open at latest.
