### PR TITLE
fix(soup): consume cmd+f in search bar instead of triggering browser find

### DIFF
--- a/apps/web/src/features/next-soup/soup-view/filters-bar/soup-view-search-bar.tsx
+++ b/apps/web/src/features/next-soup/soup-view/filters-bar/soup-view-search-bar.tsx
@@ -11,6 +11,7 @@ import XIcon from '@phosphor/x.svg?component-solid';
 import { cn, Hotkey } from '@ui';
 import {
   $getRoot,
+  $selectAll,
   COMMAND_PRIORITY_HIGH,
   KEY_ARROW_DOWN_COMMAND,
 } from 'lexical';
@@ -119,8 +120,10 @@ export const SoupSearchbar = (props: SoupSearchbarProps) => {
     scopeId: panel.splitHotkeyScope,
     registrationType: 'add',
     description: 'Search',
+    runWithInputFocused: true,
     keyDownHandler: () => {
       editor.controls.focus();
+      editor.controls.getLexical().update(() => $selectAll());
       return true;
     },
   });


### PR DESCRIPTION
The soup/email search bar's `cmd+f` handler lacked `runWithInputFocused`, so pressing cmd+f while already focused in the search bar was skipped and fell through to the browser's native find. Adds `runWithInputFocused: true` so the event is consumed (and re-selects the query on cmd+f).
