### PR TITLE
docs: clarify README feature summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Macro has raised $30m led by a16z. We are based in NYC.
 
 ## Features
 
-Full documentation lives at [docs.macro.com](https://docs.macro.com):
+Full documentation lives at [docs.macro.com](https://docs.macro.com), with the product areas summarized below:
  
 - **[Email](https://docs.macro.com/product/email):** the fastest, smartest email client. The best of Superhuman, Gmail, and Outlook in one keyboard-first inbox. Multi-account, unified, with shared inboxes.
 - **[Messages](https://docs.macro.com/product/channels):** team chat built for focused deep work. Channels and DMs for focused technical discussions.


### PR DESCRIPTION
### Motivation
- Clarify that the README's Features heading points to the full documentation and that the following bullets are a summary of product areas.

### Description
- Replace the line `Full documentation lives at [docs.macro.com](https://docs.macro.com):` with `Full documentation lives at [docs.macro.com](https://docs.macro.com), with the product areas summarized below:` in `README.md`.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5519b5dbb0832e8d557cd44be68474)