### PR TITLE
fix(search): target the clicked channel search hit, not the channel's notification

### DIFF
--- a/apps/web/src/features/entity/types/entity.ts
+++ b/apps/web/src/features/entity/types/entity.ts
@@ -69,6 +69,17 @@ type ChannelEntityLatestMessage = {
   mentions: string[];
 };
 
+/**
+ * The message a channel-family row activates when opened. Stamped at row
+ * construction by producers whose row stands for one specific message (e.g.
+ * search hits). Rows without a target are containers — the driving
+ * notification decides at click time.
+ */
+export type ChannelEntityTarget = {
+  messageId: string;
+  threadId?: string;
+};
+
 export type ChannelEntity = EntityBase & {
   type: 'channel';
   channelType: 'direct_message' | 'private' | 'public' | 'team';
@@ -76,6 +87,7 @@ export type ChannelEntity = EntityBase & {
   participantIds?: string[];
   latestMessage?: ChannelEntityLatestMessage;
   latestRootMessage?: ChannelEntityLatestMessage;
+  target?: ChannelEntityTarget;
 };
 
 export type ChannelMessageEntity = EntityBase & {
@@ -87,6 +99,7 @@ export type ChannelMessageEntity = EntityBase & {
   threadId?: string;
   senderId: string;
   content: string;
+  target?: ChannelEntityTarget;
 };
 
 export type ChannelThreadEntity = EntityBase & {
@@ -95,6 +108,7 @@ export type ChannelThreadEntity = EntityBase & {
   channelType?: ChannelEntity['channelType'];
   messageId: string;
   threadId: string;
+  target?: ChannelEntityTarget;
   senderId: string;
   sender: SoupMessageSender;
   content: string;

--- a/apps/web/src/features/next-soup/utils.test.ts
+++ b/apps/web/src/features/next-soup/utils.test.ts
@@ -13,7 +13,7 @@ vi.mock('@service-connection/websocket', () => ({
   createConnectionWebsocketEffect: vi.fn(),
 }));
 
-import type { EntityData } from '@entity';
+import type { ChannelEntityTarget, EntityData } from '@entity';
 import type { UnifiedNotification } from '@notifications';
 import { getChannelEntityTarget } from './utils';
 
@@ -45,53 +45,79 @@ const replyNotification = (
     },
   }) as unknown as UnifiedNotification;
 
-const channelMessageHit = (notifications?: UnifiedNotification[]): EntityData =>
+const channelMessageRow = (opts?: {
+  target?: ChannelEntityTarget;
+  notifications?: UnifiedNotification[];
+}): EntityData =>
   ({
     type: 'channel_message',
     id: 'channel-1:hit-msg',
     channelId: 'channel-1',
     messageId: 'hit-msg',
     threadId: 'hit-thread',
-    ...(notifications ? { notifications: () => notifications } : {}),
+    ...(opts?.target ? { target: opts.target } : {}),
+    ...(opts?.notifications ? { notifications: () => opts.notifications } : {}),
   }) as unknown as EntityData;
 
-const channelRow = (notifications?: UnifiedNotification[]): EntityData =>
+const channelRow = (opts?: {
+  target?: ChannelEntityTarget;
+  notifications?: UnifiedNotification[];
+}): EntityData =>
   ({
     type: 'channel',
     id: 'channel-1',
-    ...(notifications ? { notifications: () => notifications } : {}),
+    ...(opts?.target ? { target: opts.target } : {}),
+    ...(opts?.notifications ? { notifications: () => opts.notifications } : {}),
   }) as unknown as EntityData;
 
-const channelThreadRow = (notifications?: UnifiedNotification[]): EntityData =>
+const channelThreadRow = (opts?: {
+  target?: ChannelEntityTarget;
+  notifications?: UnifiedNotification[];
+}): EntityData =>
   ({
     type: 'channel_thread',
     id: 'root-msg',
     channelId: 'channel-1',
     messageId: 'root-msg',
     threadId: 'root-msg',
-    ...(notifications ? { notifications: () => notifications } : {}),
+    ...(opts?.target ? { target: opts.target } : {}),
+    ...(opts?.notifications ? { notifications: () => opts.notifications } : {}),
   }) as unknown as EntityData;
 
 describe('getChannelEntityTarget', () => {
-  it('targets the hit itself for a channel_message row, ignoring attached channel notifications', () => {
-    const entity = channelMessageHit([
-      sendNotification('n1', 'recent-unread-msg'),
-    ]);
+  it('activates a stamped target over attached channel notifications (search message hit)', () => {
+    const entity = channelMessageRow({
+      target: { messageId: 'hit-msg', threadId: 'hit-thread' },
+      notifications: [sendNotification('n1', 'recent-unread-msg')],
+    });
     expect(getChannelEntityTarget(entity)).toEqual({
       messageId: 'hit-msg',
       threadId: 'hit-thread',
     });
   });
 
-  it('targets the hit for a channel_message row without notifications', () => {
-    expect(getChannelEntityTarget(channelMessageHit())).toEqual({
+  it('activates a stamped target on a channel_thread row over notifications (future thread hit)', () => {
+    const entity = channelThreadRow({
+      target: { messageId: 'hit-reply', threadId: 'root-msg' },
+      notifications: [replyNotification('n1', 'newest-reply', 'root-msg')],
+    });
+    expect(getChannelEntityTarget(entity)).toEqual({
+      messageId: 'hit-reply',
+      threadId: 'root-msg',
+    });
+  });
+
+  it('falls back to own ids for an unstamped channel_message row without notifications', () => {
+    expect(getChannelEntityTarget(channelMessageRow())).toEqual({
       messageId: 'hit-msg',
       threadId: 'hit-thread',
     });
   });
 
   it('targets the driving notification for a channel row', () => {
-    const entity = channelRow([sendNotification('n1', 'notif-msg')]);
+    const entity = channelRow({
+      notifications: [sendNotification('n1', 'notif-msg')],
+    });
     expect(getChannelEntityTarget(entity)).toEqual({
       messageId: 'notif-msg',
       threadId: undefined,
@@ -103,17 +129,19 @@ describe('getChannelEntityTarget', () => {
   });
 
   it('skips thread-reply notifications for a channel row', () => {
-    const entity = channelRow([
-      replyNotification('n1', 'reply-msg', 'other-thread'),
-    ]);
+    const entity = channelRow({
+      notifications: [replyNotification('n1', 'reply-msg', 'other-thread')],
+    });
     expect(getChannelEntityTarget(entity)).toBeUndefined();
   });
 
   it('targets the reply notification scoped to a channel_thread row', () => {
-    const entity = channelThreadRow([
-      replyNotification('n1', 'reply-in-other-thread', 'other-thread'),
-      replyNotification('n2', 'reply-msg', 'root-msg'),
-    ]);
+    const entity = channelThreadRow({
+      notifications: [
+        replyNotification('n1', 'reply-in-other-thread', 'other-thread'),
+        replyNotification('n2', 'reply-msg', 'root-msg'),
+      ],
+    });
     expect(getChannelEntityTarget(entity)).toEqual({
       messageId: 'reply-msg',
       threadId: 'root-msg',
@@ -121,9 +149,9 @@ describe('getChannelEntityTarget', () => {
   });
 
   it('falls back to the thread root when no notification matches the thread', () => {
-    const entity = channelThreadRow([
-      replyNotification('n1', 'reply-msg', 'other-thread'),
-    ]);
+    const entity = channelThreadRow({
+      notifications: [replyNotification('n1', 'reply-msg', 'other-thread')],
+    });
     expect(getChannelEntityTarget(entity)).toEqual({
       messageId: 'root-msg',
       threadId: 'root-msg',

--- a/apps/web/src/features/next-soup/utils.test.ts
+++ b/apps/web/src/features/next-soup/utils.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// utils.ts transitively imports the websocket client modules, which open real
+// sockets at module scope and reject under jsdom.
+vi.mock('@service-storage/websocket', () => ({
+  storageWS: { reconnectIfDisconnected: vi.fn() },
+  createWebSocketJob: vi.fn(),
+}));
+vi.mock('@service-connection/websocket', () => ({
+  ws: { addEventListener: vi.fn(), send: vi.fn() },
+  state: () => 'closed',
+  createConnectionBlockWebsocketEffect: vi.fn(),
+  createConnectionWebsocketEffect: vi.fn(),
+}));
+
+import type { EntityData } from '@entity';
+import type { UnifiedNotification } from '@notifications';
+import { getChannelEntityTarget } from './utils';
+
+const sendNotification = (id: string, messageId: string): UnifiedNotification =>
+  ({
+    id,
+    entity_type: 'channel',
+    entity_id: 'channel-1',
+    notification_event_type: 'channel_message_send',
+    notification_metadata: {
+      tag: 'channel_message_send',
+      content: { messageId },
+    },
+  }) as unknown as UnifiedNotification;
+
+const replyNotification = (
+  id: string,
+  messageId: string,
+  threadId: string
+): UnifiedNotification =>
+  ({
+    id,
+    entity_type: 'channel',
+    entity_id: 'channel-1',
+    notification_event_type: 'channel_message_reply',
+    notification_metadata: {
+      tag: 'channel_message_reply',
+      content: { messageId, threadId },
+    },
+  }) as unknown as UnifiedNotification;
+
+const channelMessageHit = (notifications?: UnifiedNotification[]): EntityData =>
+  ({
+    type: 'channel_message',
+    id: 'channel-1:hit-msg',
+    channelId: 'channel-1',
+    messageId: 'hit-msg',
+    threadId: 'hit-thread',
+    ...(notifications ? { notifications: () => notifications } : {}),
+  }) as unknown as EntityData;
+
+const channelRow = (notifications?: UnifiedNotification[]): EntityData =>
+  ({
+    type: 'channel',
+    id: 'channel-1',
+    ...(notifications ? { notifications: () => notifications } : {}),
+  }) as unknown as EntityData;
+
+const channelThreadRow = (notifications?: UnifiedNotification[]): EntityData =>
+  ({
+    type: 'channel_thread',
+    id: 'root-msg',
+    channelId: 'channel-1',
+    messageId: 'root-msg',
+    threadId: 'root-msg',
+    ...(notifications ? { notifications: () => notifications } : {}),
+  }) as unknown as EntityData;
+
+describe('getChannelEntityTarget', () => {
+  it('targets the hit itself for a channel_message row, ignoring attached channel notifications', () => {
+    const entity = channelMessageHit([
+      sendNotification('n1', 'recent-unread-msg'),
+    ]);
+    expect(getChannelEntityTarget(entity)).toEqual({
+      messageId: 'hit-msg',
+      threadId: 'hit-thread',
+    });
+  });
+
+  it('targets the hit for a channel_message row without notifications', () => {
+    expect(getChannelEntityTarget(channelMessageHit())).toEqual({
+      messageId: 'hit-msg',
+      threadId: 'hit-thread',
+    });
+  });
+
+  it('targets the driving notification for a channel row', () => {
+    const entity = channelRow([sendNotification('n1', 'notif-msg')]);
+    expect(getChannelEntityTarget(entity)).toEqual({
+      messageId: 'notif-msg',
+      threadId: undefined,
+    });
+  });
+
+  it('returns no target for a channel row without notifications', () => {
+    expect(getChannelEntityTarget(channelRow())).toBeUndefined();
+  });
+
+  it('skips thread-reply notifications for a channel row', () => {
+    const entity = channelRow([
+      replyNotification('n1', 'reply-msg', 'other-thread'),
+    ]);
+    expect(getChannelEntityTarget(entity)).toBeUndefined();
+  });
+
+  it('targets the reply notification scoped to a channel_thread row', () => {
+    const entity = channelThreadRow([
+      replyNotification('n1', 'reply-in-other-thread', 'other-thread'),
+      replyNotification('n2', 'reply-msg', 'root-msg'),
+    ]);
+    expect(getChannelEntityTarget(entity)).toEqual({
+      messageId: 'reply-msg',
+      threadId: 'root-msg',
+    });
+  });
+
+  it('falls back to the thread root when no notification matches the thread', () => {
+    const entity = channelThreadRow([
+      replyNotification('n1', 'reply-msg', 'other-thread'),
+    ]);
+    expect(getChannelEntityTarget(entity)).toEqual({
+      messageId: 'root-msg',
+      threadId: 'root-msg',
+    });
+  });
+
+  it('returns undefined for non-channel entities', () => {
+    const entity = { type: 'email', id: 'e1' } as unknown as EntityData;
+    expect(getChannelEntityTarget(entity)).toBeUndefined();
+  });
+});

--- a/apps/web/src/features/next-soup/utils.ts
+++ b/apps/web/src/features/next-soup/utils.ts
@@ -330,6 +330,14 @@ interface OpenEntityOptions {
 /**
  * Resolve which channel message to activate when a channel row is opened.
  *
+ * The row's type decides where its target lives:
+ *
+ * A `channel_message` row only ever comes from a search hit, so its
+ * messageId/threadId ARE the matched message — always target them.
+ * Notifications must never override a hit: the unified list attaches a
+ * channel-wide notifications() accessor to every row (search results
+ * included), so their presence says nothing about why this row exists.
+ *
  * Inbox rows are keyed by the channel or thread, not by the message that was
  * actually sent — a `channel` row is the whole channel and a `channel_thread`
  * row is keyed by its root, so neither carries the id of the new message/reply.
@@ -337,20 +345,17 @@ interface OpenEntityOptions {
  * renders), so read the target from there, exactly like the old inbox did via
  * getChannelNotificationParams. Notifications are scoped to the row first
  * (top-level sends for a channel, this thread's replies for a thread) and the
- * most recent one wins.
- *
- * Search hits are the other caller: a `channel_message` hit carries a real,
- * distinct messageId and has no notification, so fall back to the entity's ids.
- * A `channel` row with no notification has no message to target — open latest.
+ * most recent one wins. A `channel_thread` row with no notification falls back
+ * to its root; a `channel` row has no message to target — open latest.
  */
 export function getChannelEntityTarget(
   entity: EntityData
 ): { messageId: string; threadId?: string } | undefined {
-  if (
-    entity.type !== 'channel' &&
-    entity.type !== 'channel_message' &&
-    entity.type !== 'channel_thread'
-  ) {
+  if (entity.type === 'channel_message') {
+    return { messageId: entity.messageId, threadId: entity.threadId };
+  }
+
+  if (entity.type !== 'channel' && entity.type !== 'channel_thread') {
     return undefined;
   }
 

--- a/apps/web/src/features/next-soup/utils.ts
+++ b/apps/web/src/features/next-soup/utils.ts
@@ -25,6 +25,7 @@ import { throwOnErr } from '@core/util/result';
 import { waitForFrames } from '@core/util/sleep';
 import { openExternalUrl } from '@core/util/url';
 import {
+  type ChannelEntityTarget,
   type EntityData,
   getSnippetHit,
   isGithubPrEntity,
@@ -330,34 +331,35 @@ interface OpenEntityOptions {
 /**
  * Resolve which channel message to activate when a channel row is opened.
  *
- * The row's type decides where its target lives:
+ * A row with an explicit `target` (stamped at construction, e.g. a search hit
+ * standing for one matched message) always activates it. Notifications must
+ * never override a stamped target: the unified list attaches a channel-wide
+ * notifications() accessor to every row (search results included), so their
+ * presence says nothing about why a row exists.
  *
- * A `channel_message` row only ever comes from a search hit, so its
- * messageId/threadId ARE the matched message — always target them.
- * Notifications must never override a hit: the unified list attaches a
- * channel-wide notifications() accessor to every row (search results
- * included), so their presence says nothing about why this row exists.
- *
- * Inbox rows are keyed by the channel or thread, not by the message that was
- * actually sent — a `channel` row is the whole channel and a `channel_thread`
- * row is keyed by its root, so neither carries the id of the new message/reply.
- * That id lives only on the driving notification (the same data the card
- * renders), so read the target from there, exactly like the old inbox did via
- * getChannelNotificationParams. Notifications are scoped to the row first
- * (top-level sends for a channel, this thread's replies for a thread) and the
- * most recent one wins. A `channel_thread` row with no notification falls back
- * to its root; a `channel` row has no message to target — open latest.
+ * Rows without a target are containers — a `channel` row is the whole channel
+ * and a `channel_thread` row is keyed by its root, so neither carries the id
+ * of the message/reply that put it in the inbox. That id lives only on the
+ * driving notification (the same data the card renders), so read the target
+ * from there, exactly like the old inbox did via getChannelNotificationParams.
+ * Notifications are scoped to the row first (top-level sends for a channel,
+ * this thread's replies for a thread) and the most recent one wins. With no
+ * notification either, fall back to the row's own ids — a `channel_thread`
+ * row opens at its root and a `channel` row has no message to target (open
+ * latest).
  */
 export function getChannelEntityTarget(
   entity: EntityData
-): { messageId: string; threadId?: string } | undefined {
-  if (entity.type === 'channel_message') {
-    return { messageId: entity.messageId, threadId: entity.threadId };
-  }
-
-  if (entity.type !== 'channel' && entity.type !== 'channel_thread') {
+): ChannelEntityTarget | undefined {
+  if (
+    entity.type !== 'channel' &&
+    entity.type !== 'channel_message' &&
+    entity.type !== 'channel_thread'
+  ) {
     return undefined;
   }
+
+  if (entity.target) return entity.target;
 
   const fallback =
     entity.type === 'channel'

--- a/apps/web/src/lib/queries/soup/transform-utils.ts
+++ b/apps/web/src/lib/queries/soup/transform-utils.ts
@@ -270,6 +270,10 @@ export function mapChannelSearchResultItem(
         channelType,
         messageId: msg.message_id!,
         threadId: msg.thread_id ?? undefined,
+        target: {
+          messageId: msg.message_id!,
+          threadId: msg.thread_id ?? undefined,
+        },
         senderId: msg.sender_id!,
         content,
         name: channelName,


### PR DESCRIPTION
A channel search hit in a channel with notifications navigated to the notification's message instead of the clicked hit: the unified list attaches a channel-wide notifications() accessor to every row (search results included), and getChannelEntityTarget let any notification override the hit. Channel-family rows now carry an explicit `target` stamped at construction — the search mapper stamps the matched message — and the resolver activates a stamped target unconditionally, only falling back to the driving notification (inbox behavior, unchanged) for container rows without one.
