### PR TITLE
fix(ai): fall back to the Smart model's bare api id for unroutable model ids

### DIFF
--- a/crates/agent/src/model/router.rs
+++ b/crates/agent/src/model/router.rs
@@ -15,7 +15,6 @@
 //! `groq/llama-3.3-70b`); routing picks the provider from the segment, never by
 //! sniffing the id. Unroutable ids fall back to the default model.
 
-use std::borrow::Cow;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex, OnceLock};
 
@@ -362,13 +361,16 @@ impl ModelRouter {
         self.route(model).unwrap_or_else(|_| self.default_model())
     }
 
-    /// The default model: native Anthropic serving [`AgentModel::default`].
+    /// The fallback model: native Anthropic serving [`PredefinedModel::Smart`].
+    ///
+    /// Built via `From<PredefinedModel>` so the bound [`Model`] carries the
+    /// bare api id — `PredefinedModel`'s `Display` is the provider-qualified
+    /// routing id, which the Anthropic API rejects as a model name.
     fn default_model(&self) -> RoutedModel<'static> {
-        let model = Model {
-            provider: Cow::Borrowed(ANTHROPIC_PROVIDER),
-            name: Cow::Owned(PredefinedModel::default().to_string()),
-        };
-        RoutedModel::Anthropic(AnthropicModel::new(model, self.anthropic.clone()))
+        RoutedModel::Anthropic(AnthropicModel::new(
+            PredefinedModel::Smart.into(),
+            self.anthropic.clone(),
+        ))
     }
 }
 

--- a/crates/agent/src/test/test_router.rs
+++ b/crates/agent/src/test/test_router.rs
@@ -1,4 +1,6 @@
+use crate::model::PredefinedModel;
 use crate::model::router::*;
+use crate::model::types::Model;
 use rig_core::providers::{anthropic, openai};
 
 fn test_router() -> ModelRouter {
@@ -27,6 +29,39 @@ fn openai_provider_routes_to_responses() {
         router.route("openai/gpt-5.5").unwrap(),
         RoutedModel::OpenAiResponses(_)
     ));
+}
+
+#[test]
+fn unroutable_ids_fall_back_to_the_smart_model() {
+    let router = test_router();
+
+    // Ids stored before dynamic model routing (bare api names, semantic tier
+    // names) and ids naming an unregistered provider are all unroutable. Each
+    // must fail to route, then fall back to the known Smart model — and the
+    // fallback must put the *bare* api id on the wire: a provider-qualified
+    // `anthropic/...` string 404s on the Anthropic API.
+    let unroutable = [
+        "claude-opus-4-6", // bare api id of a retired model
+        "claude-opus-4-8", // bare api id of a current model
+        "smart",           // semantic tier name
+        "",                // empty
+        "unregistered-provider/some-model",
+    ];
+
+    let smart = Model::from(PredefinedModel::Smart);
+    for id in unroutable {
+        assert!(router.route(id).is_err(), "`{id}` should not route");
+
+        let RoutedModel::Anthropic(fallback) = router.route_or_default(id) else {
+            panic!("`{id}` fallback should be native Anthropic");
+        };
+        let wire_id = fallback.completion().model;
+        assert_eq!(
+            wire_id,
+            smart.name(),
+            "`{id}` must fall back to the Smart model's bare api id, got `{wire_id}`"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
Unroutable model ids (bare legacy ids like `claude-opus-4-6` or `smart`, stored by automations created before dynamic model routing) now fall back to the Smart model with its bare api id on the wire, instead of a provider-qualified `anthropic/claude-opus-4-8` string that the Anthropic API 404s on.