### PR TITLE
Add shadow styling to group hover preview tooltip

### DIFF
--- a/apps/web/src/features/channel/sidebar/channels-unread-widget.tsx
+++ b/apps/web/src/features/channel/sidebar/channels-unread-widget.tsx
@@ -184,7 +184,7 @@ function UnreadHoverCard(
         </KobalteTooltip.Trigger>
         <KobalteTooltip.Portal>
           <KobalteTooltip.Content class="z-tool-tip max-w-[calc(100vw-32px)] menu-open-animation">
-            <Surface depth={3}>
+            <Surface depth={3} class="shadow-menu">
               <GroupHoverPreview group={props.group} />
             </Surface>
           </KobalteTooltip.Content>

--- a/apps/web/src/features/channel/sidebar/channels-unread-widget.tsx
+++ b/apps/web/src/features/channel/sidebar/channels-unread-widget.tsx
@@ -184,7 +184,11 @@ function UnreadHoverCard(
         </KobalteTooltip.Trigger>
         <KobalteTooltip.Portal>
           <KobalteTooltip.Content class="z-tool-tip max-w-[calc(100vw-32px)] menu-open-animation">
-            <Surface depth={3} class="shadow-menu">
+            <Surface
+              depth={3}
+              hideBorder
+              class="shadow-menu ring ring-edge rounded-xl"
+            >
               <GroupHoverPreview group={props.group} />
             </Surface>
           </KobalteTooltip.Content>


### PR DESCRIPTION
## Summary
Added the `shadow-menu` CSS class to the Surface component in the UnreadHoverCard tooltip to apply consistent menu shadow styling to the group hover preview.

## Changes
- Added `class="shadow-menu"` to the `<Surface>` component wrapping the `<GroupHoverPreview>` in the tooltip content
- This ensures the group preview tooltip has the same shadow styling as other menu elements in the application

## Details
The change is a minor styling enhancement that improves visual consistency by applying the standard menu shadow to the group hover preview tooltip that appears when users interact with unread channel indicators.

https://claude.ai/code/session_01Seu8LPT26x4sDsug9zYBvc