### PR TITLE
Refactor create buttons to use simpler Plus icon and base variant

### DIFF
--- a/apps/web/src/features/next-soup/soup-view/NewCallButton.tsx
+++ b/apps/web/src/features/next-soup/soup-view/NewCallButton.tsx
@@ -5,7 +5,7 @@ import { useCombinedRecipients } from '@core/signal/useCombinedRecipient';
 import type { WithCustomUserInput } from '@core/user';
 import { getDestinationFromOptions } from '@core/util/destination';
 import PhoneCallIcon from '@icon/wide-call.svg';
-import PlusCircleIcon from '@phosphor/plus-circle.svg';
+import PlusIcon from '@phosphor/plus.svg';
 import XIcon from '@phosphor/x.svg';
 import {
   useGetOrCreateDirectMessageMutation,
@@ -78,13 +78,8 @@ export function NewCallButton() {
 
   return (
     <>
-      <Button
-        variant="active"
-        class="border-0 rounded-full px-3 py-2 pl-1 font-semibold"
-        size="sm"
-        onClick={() => setIsOpen(true)}
-      >
-        <PlusCircleIcon class="size-3.5 text-accent" />
+      <Button variant="base" size="sm" onClick={() => setIsOpen(true)}>
+        <PlusIcon class="size-3.5" />
         <span>Call</span>
       </Button>
       <Dialog

--- a/apps/web/src/features/next-soup/soup-view/soup-view-create-button.tsx
+++ b/apps/web/src/features/next-soup/soup-view/soup-view-create-button.tsx
@@ -14,9 +14,9 @@ import {
   openFolderPicker,
 } from '@core/util/upload';
 import ChevronDownIcon from '@phosphor/caret-down.svg';
-import PlusCircleIcon from '@phosphor/plus-circle.svg';
+import PlusIcon from '@phosphor/plus.svg';
 import UploadIcon from '@phosphor/upload-simple.svg';
-import { Button, cn, Dropdown } from '@ui';
+import { Button, Dropdown } from '@ui';
 import { createMemo, For, Show } from 'solid-js';
 import { NewCallButton } from './NewCallButton';
 
@@ -142,15 +142,11 @@ export const SoupViewCreateButton = () => {
 
   const SingleOptionButton = (props: { hideLabel?: boolean }) => (
     <Button
-      variant="active"
-      class={cn(
-        'border-0 rounded-full px-3 py-2 pl-1 font-semibold',
-        props.hideLabel && 'pr-1'
-      )}
+      variant="base"
       size="sm"
       onClick={() => handleSelect(options()[0])}
     >
-      <PlusCircleIcon class="size-3.5 text-accent" />
+      <PlusIcon class="size-3.5" />
       <Show when={!props.hideLabel}>
         <span>{createLabel()}</span>
       </Show>
@@ -159,14 +155,8 @@ export const SoupViewCreateButton = () => {
 
   const MultiOptionButton = (props: { hideLabel?: boolean }) => (
     <Dropdown placement="bottom-start">
-      <Dropdown.Trigger
-        variant="active"
-        class={cn(
-          'border-0 rounded-full px-3 py-2 pl-1 font-semibold',
-          props.hideLabel && 'pr-1'
-        )}
-      >
-        <PlusCircleIcon class="size-3.5" />
+      <Dropdown.Trigger>
+        <PlusIcon class="size-3.5" />
         <Show when={!props.hideLabel}>
           <span>{createLabel()}</span>
         </Show>


### PR DESCRIPTION
## Summary
Simplified the create action buttons in the soup view by replacing the `PlusCircleIcon` with a simpler `PlusIcon` and updating the button styling from the "active" variant to the "base" variant. This removes custom styling classes and icon color specifications in favor of cleaner, more maintainable button components.

## Key Changes
- **Icon replacement**: Changed from `@phosphor/plus-circle.svg` to `@phosphor/plus.svg` in both `soup-view-create-button.tsx` and `NewCallButton.tsx`
- **Button variant**: Updated button variant from `"active"` to `"base"` for both single and multi-option create buttons
- **Removed custom styling**: Eliminated custom `cn()` class compositions including:
  - `border-0 rounded-full px-3 py-2 pl-1 font-semibold`
  - Conditional `pr-1` padding adjustments
  - Icon color class `text-accent`
- **Removed unused import**: Deleted the `cn` utility import from `@ui` in `soup-view-create-button.tsx`

## Implementation Details
The changes apply consistently across:
- `SoupViewCreateButton` component's `SingleOptionButton` and `MultiOptionButton` sub-components
- `NewCallButton` component's main button

The refactoring delegates styling responsibility to the Button component's base variant, reducing component-level styling complexity and improving maintainability.

https://claude.ai/code/session_01PRozu5h3i1DFUxf1u2B2zk