### PR TITLE
Add Kanban board view for Tasks grouped by Status

### DIFF
--- a/apps/web/src/features/entity/index.ts
+++ b/apps/web/src/features/entity/index.ts
@@ -60,7 +60,10 @@ export {
   COMPANY_STAGE_OPTIONS,
   getPropertyOptionLabel,
   getTaskAssigneeIds,
+  getTaskDueDate,
+  getTaskPriorityOptionId,
   getTaskStatusOptionId,
+  TASK_STATUS_OPTIONS,
 } from './utils/task-properties';
 export {
   formatDateAndTime,

--- a/apps/web/src/features/entity/tests/task-properties.test.ts
+++ b/apps/web/src/features/entity/tests/task-properties.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest';
 import type { TaskEntityWithProperties } from '../types/entity';
 import {
   getTaskAssigneeIds,
+  getTaskDueDate,
   getTaskStatusOptionId,
   isCurrentUserAssigned,
   isTaskClosed,
@@ -84,6 +85,39 @@ describe('task property helpers', () => {
     it('returns undefined when status property is missing', () => {
       const entity = createTask();
       expect(getTaskStatusOptionId(entity)).toBeUndefined();
+    });
+  });
+
+  describe('getTaskDueDate', () => {
+    it('returns the stored date value', () => {
+      const entity = createTask({
+        properties: [
+          createSoupProperty(SYSTEM_PROPERTY_IDS.DUE_DATE, {
+            type: 'Date',
+            value: '2025-06-01T00:00:00Z',
+          }),
+        ],
+      });
+
+      expect(getTaskDueDate(entity)).toBe('2025-06-01T00:00:00Z');
+    });
+
+    it('returns undefined when due date property is missing', () => {
+      const entity = createTask();
+      expect(getTaskDueDate(entity)).toBeUndefined();
+    });
+
+    it('returns undefined for a non-date value', () => {
+      const entity = createTask({
+        properties: [
+          createSoupProperty(SYSTEM_PROPERTY_IDS.DUE_DATE, {
+            type: 'SelectOption',
+            value: ['not-a-date'],
+          }),
+        ],
+      });
+
+      expect(getTaskDueDate(entity)).toBeUndefined();
     });
   });
 

--- a/apps/web/src/features/entity/utils/task-properties.ts
+++ b/apps/web/src/features/entity/utils/task-properties.ts
@@ -146,6 +146,25 @@ export const getTaskPriorityOptionId = (
 };
 
 /**
+ * Gets the due date (ISO timestamp) from task properties.
+ */
+export const getTaskDueDate = (
+  entity: TaskEntityWithProperties
+): string | undefined => {
+  const dueDateProperty = getTaskPropertyByDefinitionId(
+    entity,
+    SYSTEM_PROPERTY_IDS.DUE_DATE
+  );
+
+  const value = dueDateProperty?.value;
+  if (!value || value.type !== 'Date' || typeof value.value !== 'string') {
+    return undefined;
+  }
+
+  return value.value;
+};
+
+/**
  * Checks if a task is in a closed state.
  */
 export const isTaskClosed = (entity: TaskEntityWithProperties): boolean => {

--- a/apps/web/src/features/next-soup/soup-view/soup-view-context.tsx
+++ b/apps/web/src/features/next-soup/soup-view/soup-view-context.tsx
@@ -148,6 +148,12 @@ interface SoupViewContextValues {
   readFilter: Accessor<ReadFilter>;
   setReadFilter: Setter<ReadFilter>;
   groupByField: Accessor<GroupByField | undefined>;
+  /**
+   * True while a kanban board renders instead of the list. Suppresses the
+   * server-side grouped query path so the flat `source` feeds the board.
+   */
+  boardMode: Accessor<boolean>;
+  setBoardMode: Setter<boolean>;
   fetchNextGroupPage: (groupKey: string) => Promise<void>;
   isFetchingGroupPage: (groupKey: string) => boolean;
   hasNextGroupPage: (groupKey: string) => boolean;
@@ -403,9 +409,15 @@ export const SoupViewContextProvider: FlowComponent<
       activeListView() === 'companies' && groupByField()?.type === 'property'
   );
 
+  // While a kanban board renders instead of the list (see SoupView), the
+  // board buckets the flat `source.data()` itself, so the server-side
+  // grouped query path is suppressed. The grouping state is left untouched —
+  // it applies again when the user switches back to the list.
+  const [boardMode, setBoardMode] = createSignal(false);
+
   // The group-by actually sent to the backend (drives the grouped queries).
   const serverGroupByField = createMemo(() =>
-    isClientPropertyGroup() ? undefined : groupByField()
+    isClientPropertyGroup() || boardMode() ? undefined : groupByField()
   );
 
   // The new inbox surfaces channel threads the current user participates in —
@@ -1116,6 +1128,8 @@ export const SoupViewContextProvider: FlowComponent<
     readFilter,
     setReadFilter,
     groupByField,
+    boardMode,
+    setBoardMode,
     fetchNextGroupPage,
     isFetchingGroupPage,
     hasNextGroupPage,

--- a/apps/web/src/features/next-soup/soup-view/soup-view.tsx
+++ b/apps/web/src/features/next-soup/soup-view/soup-view.tsx
@@ -50,6 +50,7 @@ import {
 } from '@app/features/next-soup/soup-view/views/companies/CompanyViewsMenu';
 import { DateGroupHeader } from '@app/features/next-soup/soup-view/views/inbox/date-group-header';
 import { InboxListEntity } from '@app/features/next-soup/soup-view/views/inbox/InboxListEntity';
+import { TaskKanban } from '@app/features/next-soup/soup-view/views/tasks/TaskKanban';
 import { TaskListEntity } from '@app/features/next-soup/soup-view/views/tasks/TaskListEntity';
 import { ResponsiveTaskListHeader } from '@app/features/next-soup/soup-view/views/tasks/TaskListHeader';
 import { TaskGroupHeader } from '@app/features/next-soup/soup-view/views/tasks/task-group-header';
@@ -342,7 +343,7 @@ interface SoupViewProps {
 
 type SoupViewMode = 'list' | 'board';
 
-/** Segmented list/board toggle shown in the topbar of the Customers view. */
+/** Segmented list/board toggle shown in the topbar of board-capable views. */
 const SoupViewModeToggle = (props: {
   mode: SoupViewMode;
   onChange: (mode: SoupViewMode) => void;
@@ -438,10 +439,10 @@ export const SoupView = (props: SoupViewProps) => {
     { default: [] }
   );
 
-  // List/board display mode — currently only the Customers view offers a
-  // board (kanban grouped by Stage). Per-entry state so back/forward
-  // restores the mode the user left each entry with. Declared before the
-  // init effect below so a shared CRM view can set it during init.
+  // List/board display mode — the Customers view offers a board grouped by
+  // Stage, the Tasks view one grouped by Status. Per-entry state so
+  // back/forward restores the mode the user left each entry with. Declared
+  // before the init effect below so a shared CRM view can set it during init.
   const [viewMode, setViewMode] = useEntryState<SoupViewMode>('soup.viewMode', {
     default: 'list',
   });
@@ -612,8 +613,14 @@ export const SoupView = (props: SoupViewProps) => {
     return view ? LIST_VIEW_DOCS_URL[view] : undefined;
   });
 
+  // Views that can render as a kanban board instead of a list.
+  const boardView = createMemo(() => {
+    const view = activeListView();
+    return view === 'companies' || view === 'tasks' ? view : undefined;
+  });
+
   const isBoardMode = createMemo(
-    () => activeListView() === 'companies' && viewMode() === 'board'
+    () => boardView() !== undefined && viewMode() === 'board'
   );
 
   const [narrowSearchExpanded, setNarrowSearchExpanded] = createSignal(false);
@@ -724,6 +731,8 @@ export const SoupView = (props: SoupViewProps) => {
                   setViewMode={setViewMode}
                 />
                 <CompanyDisplayMenu />
+              </Show>
+              <Show when={!narrowSearchExpanded() && boardView()}>
                 <SoupViewModeToggle mode={viewMode()} onChange={setViewMode} />
               </Show>
               <Show
@@ -796,7 +805,12 @@ export const SoupView = (props: SoupViewProps) => {
         <SoupFiltersBar />
         <div class="relative grow min-h-1 flex max-sm:flex-col flex-row size-full">
           <Suspense>
-            <Show when={!isBoardMode()} fallback={<CompanyKanban />}>
+            <Show
+              when={!isBoardMode()}
+              fallback={
+                boardView() === 'tasks' ? <TaskKanban /> : <CompanyKanban />
+              }
+            >
               <SoupViewList />
             </Show>
           </Suspense>

--- a/apps/web/src/features/next-soup/soup-view/soup-view.tsx
+++ b/apps/web/src/features/next-soup/soup-view/soup-view.tsx
@@ -623,6 +623,12 @@ export const SoupView = (props: SoupViewProps) => {
     () => boardView() !== undefined && viewMode() === 'board'
   );
 
+  // Tell the context while a board is displayed: it suppresses the
+  // server-side grouped query path so the flat `source.data()` the board
+  // buckets from stays populated (grouped responses never fill it).
+  createRenderEffect(() => soupView.setBoardMode(isBoardMode()));
+  onCleanup(() => soupView.setBoardMode(false));
+
   const [narrowSearchExpanded, setNarrowSearchExpanded] = createSignal(false);
   const [mobileSearchOpen, setMobileSearchOpen] = createSignal(false);
   const [searchIsCollapsed, setSearchIsCollapsed] = createSignal(false);

--- a/apps/web/src/features/next-soup/soup-view/views/tasks/TaskKanban.tsx
+++ b/apps/web/src/features/next-soup/soup-view/views/tasks/TaskKanban.tsx
@@ -1,0 +1,332 @@
+import { useSoupView } from '@app/features/next-soup/soup-view/soup-view-context';
+import { usePreviewPaneVisiblity } from '@app/features/next-soup/soup-view/use-preview-pane-visibility';
+import { openEntityInSplitFromUnifiedList } from '@app/features/next-soup/utils';
+import { useGlobalBlockOrchestrator } from '@components/app/GlobalAppState';
+import { PreviewPanel } from '@components/app/PreviewPanel';
+import { useSplitPanelOrThrow } from '@components/app/split-layout/layoutUtils';
+import { Resize } from '@core/component/Resize';
+import { UserIcon } from '@core/component/UserIcon';
+import EmptyStatePreviewIcon from '@design/empty-state-doc.svg';
+import {
+  Entity,
+  type EntityData,
+  getPropertyOptionLabel,
+  getTaskAssigneeIds,
+  getTaskDueDate,
+  getTaskPriorityOptionId,
+  getTaskStatusOptionId,
+  isTaskEntity,
+  TASK_STATUS_OPTIONS,
+  type TaskEntityWithProperties,
+} from '@entity';
+import { soupPropertyToProperty } from '@entity/extractors-property';
+import CircleDashed from '@phosphor/circle-dashed.svg';
+import { PropertyValueIcon } from '@property/component/propertyValue';
+import { SYSTEM_PROPERTY_IDS } from '@property/constants';
+import type { Property } from '@property/types';
+import { useBulkSaveEntityPropertiesMutation } from '@queries/properties/entity';
+import { EntityType } from '@service-properties/generated/schemas/entityType';
+import { cn, EmptyStatePanel, Layer } from '@ui';
+import { format, isSameYear } from 'date-fns';
+import { createMemo, createSignal, For, Show } from 'solid-js';
+
+/** Column key for tasks without a Status value. */
+const NO_STATUS_KEY = '';
+
+const STATUS_COLUMNS = [
+  ...TASK_STATUS_OPTIONS.map((option) => ({
+    key: option.value as string,
+    label: option.label,
+  })),
+  { key: NO_STATUS_KEY, label: 'No status' },
+];
+
+const EPOCH = new Date(0).toISOString();
+
+/**
+ * Status `Property` stub for saves — a task may not have the property
+ * attached yet, so builds it from the system definition (same pattern as
+ * `buildStubProperty` in the task list's grid layout).
+ */
+function buildStatusProperty(): Property {
+  return soupPropertyToProperty({
+    id: SYSTEM_PROPERTY_IDS.STATUS,
+    definition: {
+      id: SYSTEM_PROPERTY_IDS.STATUS,
+      display_name: 'Status',
+      data_type: 'SELECT_STRING',
+      is_metadata: false,
+      is_multi_select: false,
+      is_system: true,
+      owner: { scope: 'system' },
+      specific_entity_type: undefined,
+      created_at: EPOCH,
+      updated_at: EPOCH,
+    },
+  });
+}
+
+/** Due dates are calendar dates, not activity timestamps — always show the day. */
+const formatDueDate = (iso: string) => {
+  const date = new Date(iso);
+  return isSameYear(date, new Date())
+    ? format(date, 'MMM d')
+    : format(date, 'M/d/yy');
+};
+
+/**
+ * Kanban board for the Tasks view: one column per task Status option plus
+ * "No status", fed by the same filtered soup entities as the list (mirrors
+ * the Customers view's `CompanyKanban`). Cards drag between columns to
+ * update the task's Status property.
+ *
+ * Like the list, the board supports the toggleable preview pane (Preview
+ * button / space in the filters bar): while it's open, clicking a card
+ * previews the task to the side instead of replacing the split.
+ */
+export function TaskKanban() {
+  const { source, soup } = useSoupView();
+  const panel = useSplitPanelOrThrow();
+  const saveMutation = useBulkSaveEntityPropertiesMutation();
+  const orchestrator = useGlobalBlockOrchestrator();
+
+  const { paneVisible, selectedEntity } = usePreviewPaneVisiblity();
+
+  const tasks = createMemo(() => source.data().filter(isTaskEntity));
+
+  const resolveStatus = (entity: EntityData) =>
+    getTaskStatusOptionId(entity as TaskEntityWithProperties) ?? NO_STATUS_KEY;
+
+  const columns = createMemo(() => {
+    const buckets = new Map<string, EntityData[]>(
+      STATUS_COLUMNS.map((column) => [column.key, []])
+    );
+    for (const task of tasks()) {
+      const key = resolveStatus(task);
+      (buckets.get(buckets.has(key) ? key : NO_STATUS_KEY) ?? []).push(task);
+    }
+    return STATUS_COLUMNS.map((column) => ({
+      ...column,
+      entities: buckets.get(column.key) ?? [],
+    }));
+  });
+
+  const [draggedId, setDraggedId] = createSignal<string>();
+  const [dropTarget, setDropTarget] = createSignal<string>();
+
+  const moveToStatus = (entityId: string, statusKey: string) => {
+    const entity = tasks().find((task) => task.id === entityId);
+    if (!entity) return;
+    if (resolveStatus(entity) === statusKey) return;
+
+    saveMutation.mutate({
+      properties: [
+        {
+          entityId,
+          entityType: EntityType.TASK,
+          property: buildStatusProperty(),
+          apiValues: {
+            valueType: 'SELECT_STRING',
+            values: statusKey === NO_STATUS_KEY ? null : [statusKey],
+          },
+        },
+      ],
+    });
+  };
+
+  const openTask = (entity: EntityData, event: MouseEvent) => {
+    soup.focus.set(entity.id);
+
+    // While the preview pane is open, card clicks retarget it instead of
+    // replacing the split (mirrors the list view's behavior).
+    if (paneVisible()) {
+      soup.setPreviewEntity(entity.id);
+      return;
+    }
+
+    void openEntityInSplitFromUnifiedList(entity, {
+      openInNewSplit: event.shiftKey,
+      splitHandle: panel.handle,
+      referredFrom: 'tasks',
+    });
+  };
+
+  return (
+    <Resize.Zone direction="horizontal" gutter={0}>
+      <Resize.Panel id="task-kanban" minSize={200}>
+        <div
+          class={cn(
+            'size-full min-w-0 overflow-x-auto overflow-y-hidden',
+            paneVisible() && 'border-r border-edge-muted'
+          )}
+        >
+          <div class="flex h-full gap-3 p-3">
+            <For each={columns()}>
+              {(column) => (
+                <div
+                  class={cn(
+                    'flex h-full w-64 shrink-0 flex-col rounded-lg border border-edge-muted bg-surface',
+                    dropTarget() === column.key &&
+                      draggedId() &&
+                      'border-accent/50 bg-accent/5'
+                  )}
+                  onDragOver={(e) => {
+                    if (!draggedId()) return;
+                    e.preventDefault();
+                    setDropTarget(column.key);
+                  }}
+                  onDragLeave={(e) => {
+                    if (
+                      e.relatedTarget instanceof Node &&
+                      e.currentTarget.contains(e.relatedTarget)
+                    ) {
+                      return;
+                    }
+                    if (dropTarget() === column.key) setDropTarget(undefined);
+                  }}
+                  onDrop={(e) => {
+                    e.preventDefault();
+                    const id =
+                      draggedId() ?? e.dataTransfer?.getData('text/plain');
+                    setDropTarget(undefined);
+                    setDraggedId(undefined);
+                    if (id) moveToStatus(id, column.key);
+                  }}
+                >
+                  <div class="flex items-center gap-2 px-3 py-2.5 text-xs font-semibold text-ink-muted">
+                    <Show
+                      when={column.key !== NO_STATUS_KEY}
+                      fallback={
+                        <CircleDashed class="size-3.5 text-ink-extra-muted" />
+                      }
+                    >
+                      <PropertyValueIcon
+                        optionId={column.key}
+                        class="size-3.5"
+                      />
+                    </Show>
+                    <span class="truncate">{column.label}</span>
+                    <span class="ml-auto shrink-0 tabular-nums px-1.5 py-px rounded-full bg-ink/10 text-ink-extra-muted font-medium">
+                      {column.entities.length}
+                    </span>
+                  </div>
+                  <div class="min-h-0 flex-1 overflow-y-auto scrollbar-hidden flex flex-col gap-2 px-2 pb-2">
+                    <For each={column.entities}>
+                      {(entity) => (
+                        <TaskKanbanCard
+                          entity={entity}
+                          dragging={draggedId() === entity.id}
+                          onDragStart={(e) => {
+                            e.dataTransfer?.setData('text/plain', entity.id);
+                            if (e.dataTransfer) {
+                              e.dataTransfer.effectAllowed = 'move';
+                            }
+                            setDraggedId(entity.id);
+                          }}
+                          onDragEnd={() => {
+                            setDraggedId(undefined);
+                            setDropTarget(undefined);
+                          }}
+                          onClick={(e) => openTask(entity, e)}
+                        />
+                      )}
+                    </For>
+                  </div>
+                </div>
+              )}
+            </For>
+          </div>
+        </div>
+      </Resize.Panel>
+      <Show when={paneVisible()}>
+        <Resize.Panel
+          id="soup-preview"
+          minSize={500}
+          target={{ kind: 'percent', percent: 70 }}
+        >
+          <Show
+            when={selectedEntity()}
+            fallback={
+              <EmptyStatePanel
+                graphic={EmptyStatePreviewIcon}
+                title="Nothing selected"
+                description="Select a card from the board to preview it here"
+                centered
+              />
+            }
+          >
+            {(entity) => (
+              <PreviewPanel
+                selectedEntity={entity()}
+                orchestrator={orchestrator}
+                splitPanelContext={panel}
+              />
+            )}
+          </Show>
+        </Resize.Panel>
+      </Show>
+    </Resize.Zone>
+  );
+}
+
+function TaskKanbanCard(props: {
+  entity: EntityData;
+  dragging: boolean;
+  onDragStart: (e: DragEvent) => void;
+  onDragEnd: () => void;
+  onClick: (e: MouseEvent) => void;
+}) {
+  const task = () => props.entity as TaskEntityWithProperties;
+  const assigneeIds = () => getTaskAssigneeIds(task());
+  const priorityId = () => getTaskPriorityOptionId(task());
+  const dueDate = () => getTaskDueDate(task());
+
+  return (
+    <Layer depth={2}>
+      <div
+        draggable={true}
+        onDragStart={props.onDragStart}
+        onDragEnd={props.onDragEnd}
+        onClick={props.onClick}
+        class={cn(
+          'flex flex-col gap-1.5 rounded-lg border border-edge-muted bg-panel p-2.5 text-sm',
+          'hover:border-edge transition-colors',
+          props.dragging && 'opacity-40'
+        )}
+      >
+        <div class="flex items-center gap-2 min-w-0">
+          <div class="size-4 shrink-0">
+            <Entity.Icon entity={props.entity} />
+          </div>
+          <span class="ph-no-capture truncate font-semibold min-w-0">
+            <Entity.Title entity={props.entity} />
+          </span>
+          <Show when={assigneeIds().length > 0}>
+            <span class="ml-auto flex shrink-0 -space-x-1">
+              <For each={assigneeIds().slice(0, 3)}>
+                {(id) => <UserIcon id={id} size="sm" suppressClick />}
+              </For>
+            </span>
+          </Show>
+        </div>
+        <Show when={priorityId() || dueDate()}>
+          <div class="flex items-center gap-2 min-w-0 text-xs text-ink-extra-muted">
+            <Show when={priorityId()}>
+              {(id) => (
+                <span class="flex items-center gap-1 min-w-0">
+                  <PropertyValueIcon optionId={id()} class="size-3" />
+                  <span class="truncate">{getPropertyOptionLabel(id())}</span>
+                </span>
+              )}
+            </Show>
+            <Show when={dueDate()}>
+              {(date) => (
+                <span class="ml-auto shrink-0">{formatDueDate(date())}</span>
+              )}
+            </Show>
+          </div>
+        </Show>
+      </div>
+    </Layer>
+  );
+}

--- a/apps/web/src/features/next-soup/soup-view/views/tasks/TaskKanban.tsx
+++ b/apps/web/src/features/next-soup/soup-view/views/tasks/TaskKanban.tsx
@@ -28,7 +28,7 @@ import { useBulkSaveEntityPropertiesMutation } from '@queries/properties/entity'
 import { EntityType } from '@service-properties/generated/schemas/entityType';
 import { cn, EmptyStatePanel, Layer } from '@ui';
 import { format, isSameYear } from 'date-fns';
-import { createMemo, createSignal, For, Show } from 'solid-js';
+import { createEffect, createMemo, createSignal, For, Show } from 'solid-js';
 
 /** Column key for tasks without a Status value. */
 const NO_STATUS_KEY = '';
@@ -91,6 +91,14 @@ export function TaskKanban() {
   const orchestrator = useGlobalBlockOrchestrator();
 
   const { paneVisible, selectedEntity } = usePreviewPaneVisiblity();
+
+  // The board buckets the whole filtered set at once (no per-column
+  // pagination), so keep pulling flat pages while any remain.
+  createEffect(() => {
+    if (source.hasNextPage() && !source.isFetching()) {
+      source.fetchNextPage();
+    }
+  });
 
   const tasks = createMemo(() => source.data().filter(isTaskEntity));
 


### PR DESCRIPTION
## Summary
Adds a Kanban board view for the Tasks list, allowing users to visualize and manage tasks organized by their Status property. This mirrors the existing Kanban functionality in the Customers view but groups by task Status instead of company Stage.

## Key Changes
- **New TaskKanban component** (`TaskKanban.tsx`): Implements a drag-and-drop Kanban board with columns for each task Status option plus a "No status" column. Cards can be dragged between columns to update the task's Status property.
- **TaskKanbanCard component**: Displays individual task cards with title, assignee avatars, priority, and due date information.
- **New `getTaskDueDate` helper**: Extracts the due date ISO timestamp from task properties with proper type validation.
- **Updated SoupView**: 
  - Enables the list/board mode toggle for both Customers and Tasks views
  - Routes to TaskKanban when in board mode for the Tasks view
  - Updated comments to reflect board support for multiple views
- **Export new task property helpers**: Added `getTaskDueDate`, `getTaskPriorityOptionId`, and `TASK_STATUS_OPTIONS` to the public entity API.
- **Test coverage**: Added comprehensive tests for `getTaskDueDate` covering stored dates, missing properties, and invalid value types.

## Implementation Details
- The Kanban board reuses the same filtered soup entities as the list view, ensuring consistency
- Supports the toggleable preview pane: clicking a card previews it to the side when the pane is open, or opens it in the split when closed
- Due dates are formatted as calendar dates (e.g., "Jun 1" or "6/1/25") using `date-fns`
- Status property is built from system definition when saving, following the same pattern as the task list grid
- Drag-and-drop uses native HTML5 drag events with visual feedback (border and background color changes on drop targets)

https://claude.ai/code/session_01K4tfY4gpnfTJ7E7YnixXBZ