### PR TITLE
Add Agents Hub with side panel for automations and sessions

### DIFF
--- a/apps/web/src/components/app/split-layout/componentRegistry.tsx
+++ b/apps/web/src/components/app/split-layout/componentRegistry.tsx
@@ -1,3 +1,4 @@
+import { AgentsHub } from '@app/features/agents-hub/agents-hub';
 import { Home } from '@app/features/home';
 import { queryStateFrom } from '@app/features/next-soup/filters/filter-store';
 import type { SetPredicatesInput } from '@app/features/next-soup/filters/filter-store/predicates-store';
@@ -23,6 +24,7 @@ import {
   LOCAL_ONLY,
 } from '@core/constant/featureFlags';
 import { useUserContext } from '@core/context/user';
+import { isMobile } from '@core/mobile/isMobile';
 import type { ViewId } from '@core/types/view';
 import { useAutomationEntities } from '@queries/agent-schedule/entities';
 import { type Component, type JSXElement, lazy, onMount, Show } from 'solid-js';
@@ -157,24 +159,33 @@ registerComponent(
   })
 );
 
+/** Mobile keeps the soup list; the bento hub needs desktop width. */
+const AgentsSoupView = () => {
+  const user = useUserContext();
+  const preset = getViewPreset('agents', undefined, {
+    userId: user.userId(),
+    isTeamAdmin: false,
+  });
+  const automationEntities = useAutomationEntities();
+  return (
+    <SoupView
+      viewName="Agents"
+      initialFilters={preset?.filters}
+      initialClientFilters={preset?.clientFilters}
+      initialGroupBy={preset?.groupBy}
+      additionalEntities={automationEntities}
+    />
+  );
+};
+
 registerComponent(
   'agents',
   withAuth(() => {
     usePageViewTracking('agents');
-    const user = useUserContext();
-    const preset = getViewPreset('agents', undefined, {
-      userId: user.userId(),
-      isTeamAdmin: false,
-    });
-    const automationEntities = useAutomationEntities();
     return (
-      <SoupView
-        viewName="Agents"
-        initialFilters={preset?.filters}
-        initialClientFilters={preset?.clientFilters}
-        initialGroupBy={preset?.groupBy}
-        additionalEntities={automationEntities}
-      />
+      <Show when={!isMobile()} fallback={<AgentsSoupView />}>
+        <AgentsHub />
+      </Show>
     );
   })
 );

--- a/apps/web/src/features/agents-hub/agents-hub.tsx
+++ b/apps/web/src/features/agents-hub/agents-hub.tsx
@@ -1,0 +1,45 @@
+import { NewChatComposer } from '@app/features/home/new-chat-composer';
+import { SplitHeaderLeft } from '@components/app/split-layout/components/SplitHeader';
+import { useSplitPanelOrThrow } from '@components/app/split-layout/layoutUtils';
+import { DragDropWrapper } from '@core/component/AI/component/DragDrop';
+import { ChatInputProvider } from '@core/component/AI/context';
+import { createEffect } from 'solid-js';
+import { AgentsSidePanel } from './agents-side-panel';
+
+/**
+ * Desktop Agents view: a fresh chat composer front and center, with a side
+ * panel of automations and recent agent sessions on the right. Mobile keeps
+ * the soup list (see the `agents` registration in componentRegistry).
+ */
+export const AgentsHub = () => {
+  const panel = useSplitPanelOrThrow();
+
+  createEffect(() => {
+    panel.handle.setDisplayName('Agents');
+  });
+
+  return (
+    <ChatInputProvider>
+      <DragDropWrapper class="relative size-full">
+        <SplitHeaderLeft>
+          <div class="h-full flex items-center">
+            <span class="text-sm font-semibold">Agents</span>
+          </div>
+        </SplitHeaderLeft>
+        <div class="flex size-full min-h-0 bg-surface">
+          <main class="flex min-w-0 flex-1 flex-col">
+            <div class="flex min-h-0 flex-1 flex-col items-center justify-center px-4">
+              <div class="flex w-full max-w-2xl flex-col gap-4">
+                <h1 class="px-1 text-xl font-normal tracking-tight text-ink">
+                  What should your agent work on?
+                </h1>
+                <NewChatComposer />
+              </div>
+            </div>
+          </main>
+          <AgentsSidePanel />
+        </div>
+      </DragDropWrapper>
+    </ChatInputProvider>
+  );
+};

--- a/apps/web/src/features/agents-hub/agents-side-panel.tsx
+++ b/apps/web/src/features/agents-hub/agents-side-panel.tsx
@@ -1,0 +1,199 @@
+import { runCreateAction } from '@app/features/command/Launcher';
+import { useRecentChatSessions } from '@app/features/home/home-recent-sessions';
+import { useSplitPanelOrThrow } from '@components/app/split-layout/layoutUtils';
+import { useChatInputContext } from '@core/component/AI/context';
+import { EntityIcon } from '@core/component/EntityIcon';
+import type { AutomationEntity } from '@entity';
+import PlusIcon from '@phosphor/plus.svg';
+import { useAutomationEntities } from '@queries/agent-schedule/entities';
+import { cn, Tooltip } from '@ui';
+import { formatDistanceToNowStrict } from 'date-fns';
+import {
+  ErrorBoundary,
+  For,
+  type JSX,
+  type ParentProps,
+  Show,
+  Suspense,
+} from 'solid-js';
+
+const RECENT_SESSIONS_LIMIT = 8;
+
+/** A titled bento card in the Agents side panel. */
+const Bento = (props: ParentProps<{ title: string; action?: JSX.Element }>) => (
+  <section class="flex flex-col rounded-xl border border-edge-muted bg-active">
+    <div class="flex items-center justify-between px-3 pt-2.5 pb-1.5">
+      <span class="text-xs font-medium text-ink-muted">{props.title}</span>
+      {props.action}
+    </div>
+    <div class="flex flex-col gap-0.5 px-1.5 pb-1.5">{props.children}</div>
+  </section>
+);
+
+const BentoRow = (
+  props: ParentProps<{ onClick: () => void; label: string }>
+) => (
+  <button
+    type="button"
+    aria-label={props.label}
+    class="group flex w-full items-center gap-2.5 rounded-lg px-1.5 py-1.5 text-left transition-colors hover:bg-hover"
+    onClick={props.onClick}
+  >
+    {props.children}
+  </button>
+);
+
+const BentoEmpty = (props: { message: string }) => (
+  <div class="px-1.5 pb-1 text-xs text-ink-extra-muted">{props.message}</div>
+);
+
+const automationStatus = (automation: AutomationEntity) => {
+  if (automation.isRunning) return 'Running…';
+  if (!automation.enabled) return 'Paused';
+  if (automation.nextRunAt) {
+    return `Runs ${formatDistanceToNowStrict(new Date(automation.nextRunAt), {
+      addSuffix: true,
+    })}`;
+  }
+  return 'Scheduled';
+};
+
+const AutomationsBento = () => {
+  const panel = useSplitPanelOrThrow();
+  const automations = useAutomationEntities();
+
+  const openAutomation = (id: string) => {
+    panel.handle.replace({ next: { type: 'automation', id } });
+  };
+
+  return (
+    <Bento
+      title="Automations"
+      action={
+        <Tooltip label="New automation">
+          <button
+            type="button"
+            aria-label="New automation"
+            class="rounded-md p-1 text-ink-extra-muted transition-colors hover:bg-hover hover:text-ink-muted"
+            onClick={() => runCreateAction('automation')}
+          >
+            <PlusIcon class="size-3.5" />
+          </button>
+        </Tooltip>
+      }
+    >
+      <Show
+        when={automations().length > 0}
+        fallback={<BentoEmpty message="No automations yet." />}
+      >
+        <For each={automations()}>
+          {(automation) => (
+            <BentoRow
+              label={`Open automation ${automation.name}`}
+              onClick={() => openAutomation(automation.id)}
+            >
+              <span
+                class={cn(
+                  'size-1.5 shrink-0 rounded-full',
+                  automation.isRunning
+                    ? 'bg-success animate-pulse'
+                    : automation.enabled
+                      ? 'bg-accent'
+                      : 'bg-ink/20'
+                )}
+              />
+              <span class="min-w-0 flex-1">
+                <span class="block truncate text-sm text-ink">
+                  {automation.name}
+                </span>
+                <span class="block truncate text-xs text-ink-extra-muted">
+                  {automationStatus(automation)}
+                </span>
+              </span>
+            </BentoRow>
+          )}
+        </For>
+      </Show>
+    </Bento>
+  );
+};
+
+const SessionsBento = () => {
+  const panel = useSplitPanelOrThrow();
+  const sessions = useRecentChatSessions(RECENT_SESSIONS_LIMIT);
+
+  const openChat = (id: string) => {
+    panel.handle.replace({ next: { type: 'chat', id } });
+  };
+
+  return (
+    <Bento title="Agents">
+      <Show
+        when={sessions().length > 0}
+        fallback={<BentoEmpty message="No sessions yet — start one below." />}
+      >
+        <For each={sessions()}>
+          {(session) => (
+            <BentoRow
+              label={`Open session ${session.name}`}
+              onClick={() => openChat(session.id)}
+            >
+              <EntityIcon targetType="chat" size="xs" class="shrink-0" />
+              <span class="min-w-0 flex-1 truncate text-sm text-ink">
+                {session.name}
+              </span>
+              <Show when={session.updatedAt}>
+                {(updatedAt) => (
+                  <span class="shrink-0 text-xs tabular-nums text-ink-extra-muted">
+                    {formatDistanceToNowStrict(updatedAt(), {
+                      addSuffix: true,
+                    })}
+                  </span>
+                )}
+              </Show>
+            </BentoRow>
+          )}
+        </For>
+      </Show>
+    </Bento>
+  );
+};
+
+/**
+ * Right-hand side panel of the Agents hub: a "New session" entry followed by
+ * bento cards for automations and recent agent sessions.
+ */
+export const AgentsSidePanel = () => {
+  const input = useChatInputContext();
+
+  // Clearing the pending draft resets and focuses the hub composer — a
+  // "new session" is just an empty composer ready for input.
+  const startNewSession = () => input.setPendingDraft('');
+
+  return (
+    <aside class="flex w-72 shrink-0 flex-col gap-3 overflow-y-auto border-l border-edge-muted p-3">
+      <button
+        type="button"
+        class="flex w-full items-center gap-2.5 rounded-xl border border-edge-muted bg-active px-3 py-2.5 text-left text-sm font-medium text-ink transition-colors hover:bg-hover"
+        onClick={startNewSession}
+      >
+        <span class="flex size-5 items-center justify-center rounded-full bg-accent/10 text-accent">
+          <PlusIcon class="size-3" />
+        </span>
+        New session
+      </button>
+
+      <ErrorBoundary fallback={() => null}>
+        <Suspense fallback={null}>
+          <AutomationsBento />
+        </Suspense>
+      </ErrorBoundary>
+
+      <ErrorBoundary fallback={() => null}>
+        <Suspense fallback={null}>
+          <SessionsBento />
+        </Suspense>
+      </ErrorBoundary>
+    </aside>
+  );
+};

--- a/apps/web/src/features/home/home.tsx
+++ b/apps/web/src/features/home/home.tsx
@@ -1,40 +1,20 @@
-import { useAnalytics } from '@app/lib/analytics/analytics-context';
 import { ShowFeatureFlag } from '@app/lib/analytics/posthog';
 import { FloatRegionOrInline } from '@components/app/mobile/float-regions/FloatRegion';
-import { useSplitPanelOrThrow } from '@components/app/split-layout/layoutUtils';
 import { DragDropWrapper } from '@core/component/AI/component/DragDrop';
-import { buildChatEditor } from '@core/component/AI/component/input/buildChatEditor';
-import type { ChatSendInput } from '@core/component/AI/component/input/buildRequest';
-import { ChatInput } from '@core/component/AI/component/input/ChatInput';
-import {
-  ChatInputProvider,
-  useChatInputContext,
-} from '@core/component/AI/context';
-import { useGetChatAttachmentInfo } from '@core/component/AI/signal/attachment';
-import { setPendingSendData } from '@core/component/AI/signal/pendingSend';
-import { deriveChatName } from '@core/component/AI/util/deriveName';
+import { ChatInputProvider } from '@core/component/AI/context';
 import {
   ENABLE_HOME_OVERRIDE,
   ENABLE_HOME_RECOMMENDATIONS_FLAG,
   ENABLE_HOME_RECOMMENDATIONS_OVERRIDE,
 } from '@core/constant/featureFlags';
-import { PaywallKey, usePaywallState } from '@core/constant/PaywallState';
 import { useUserContext } from '@core/context/user';
-import { registerHotkey } from '@core/hotkey/hotkeys';
-import { TOKENS } from '@core/hotkey/tokens';
-import { isPaymentError } from '@core/util/handlePaymentError';
-import { createRenameDssEntityMutation } from '@entity';
-import { invalidateAllSoup } from '@queries/soup/normalized-cache';
-import { cognitionApiServiceClient } from '@service-cognition/client';
 import { Navigate } from '@solidjs/router';
-import { $getRoot } from 'lexical';
-import { createEffect } from 'solid-js';
 import { HomeBackfillProgress } from './home-backfill-progress';
-import { replaceHomeComposerDraft } from './home-composer-selection';
 import { HomeExamples } from './home-examples';
 import { GettingStartedSection, RecommendedSection } from './home-hub';
 import { createHomePreferences } from './home-prefs';
 import { HomeSectionBoundary } from './home-section-boundary';
+import { NewChatComposer } from './new-chat-composer';
 
 const MACRO_LOGO_PATH =
   'm6.25 4.038-2.242 0.8792v5.8184l-1.756-1.6582-2.242 0.8792v6.6766c0 0.2568 0.106 0.502 0.292 0.6784l2.794 2.6422 2.244-0.879v-5.8184l7.084 6.6974 2.244-0.879v-5.8184l7.086 6.6976 2.24-0.8792v-6.6766c0-0.2568-0.104-0.5022-0.292-0.6784l-8.124-7.6816-2.244 0.879v5.8184z';
@@ -160,125 +140,9 @@ function HomeContent() {
 
       <FloatRegionOrInline region="accessory">
         <div class="mx-auto w-full max-w-3xl shrink-0 px-4 pb-3 pointer-events-auto mobile:px-(--mobile-chrome-gutter) mobile:pb-0">
-          <HomeChatInput />
+          <NewChatComposer />
         </div>
       </FloatRegionOrInline>
     </main>
   );
 }
-
-const HomeChatInput = () => {
-  const analytics = useAnalytics();
-  const splitPanelContext = useSplitPanelOrThrow();
-  const input = useChatInputContext();
-
-  const { getAttachmentFromMention } = useGetChatAttachmentInfo();
-
-  const editor = buildChatEditor().withMentions({
-    onCreate: (mention) => {
-      analytics.track('mentions_menu_use', { itemType: 'chat' });
-      const attachment = getAttachmentFromMention(mention);
-      if (attachment) input.attachments.addAttachment(attachment);
-    },
-    block: 'chat',
-    showOpenTabs: true,
-  });
-
-  const applyDraft = (text: string) => {
-    replaceHomeComposerDraft(editor.controls, text);
-    requestAnimationFrame(() => {
-      editor.controls.focus();
-      // Focus lands at the start of the document; drafts are prompt prefixes,
-      // so the caret belongs at the end, ready to complete the sentence.
-      editor.controls.getLexical().update(() => {
-        $getRoot().selectEnd();
-      });
-    });
-  };
-
-  // Drafts requested from elsewhere on the home (e.g. a suggested action row).
-  createEffect(() => {
-    const draft = input.pendingDraft();
-    if (draft != null) {
-      applyDraft(draft);
-      input.setPendingDraft(null);
-    }
-  });
-
-  registerHotkey({
-    hotkey: 'enter',
-    scopeId: splitPanelContext.splitHotkeyScope,
-    description: 'Focus Chat Input',
-    keyDownHandler: () => {
-      editor.controls.focus();
-      return true;
-    },
-    hotkeyToken: TOKENS.block.focus,
-    hide: true,
-  });
-
-  const renameMutation = createRenameDssEntityMutation();
-
-  const handleSend = async (request: ChatSendInput) => {
-    const backgroundSend = request.metaKey;
-
-    // Create a new persistent chat
-    const response = await cognitionApiServiceClient.createChat({});
-    if (response.isErr()) {
-      if (isPaymentError(response)) {
-        const { showPaywall } = usePaywallState();
-        showPaywall(PaywallKey.CHAT_LIMIT);
-      }
-      return;
-    }
-    const { id: chatId } = response.value;
-
-    // Rename via mutation for optimistic cache updates (history, preview, soup)
-    const name = deriveChatName(request.content);
-    if (name) {
-      renameMutation.mutate({
-        entity: { type: 'chat', id: chatId, name: '', ownerId: '' },
-        newName: name,
-      });
-    }
-
-    if (backgroundSend) {
-      // Send the message in the background without navigating
-      cognitionApiServiceClient.sendStreamChatMessage({
-        content: request.content,
-        model: request.model,
-        chat_id: chatId,
-        attachments:
-          request.attachments.length > 0 ? request.attachments : undefined,
-        toolset: { type: 'all' },
-      });
-      invalidateAllSoup();
-    } else {
-      // Store the pending send data for the chat to pick up
-      setPendingSendData({
-        content: request.content,
-        attachments: request.attachments,
-        model: request.model,
-      });
-
-      // Replace the soup split with the chat split
-      splitPanelContext.handle.replace({
-        next: { type: 'chat', id: chatId },
-      });
-    }
-  };
-
-  return (
-    <ChatInput
-      variant="default"
-      editor={editor}
-      onSend={handleSend}
-      onEscape={() => {
-        splitPanelContext.panelRef()?.focus();
-        return true;
-      }}
-      isPersistent={true}
-      autoFocusOnMount={true}
-    />
-  );
-};

--- a/apps/web/src/features/home/new-chat-composer.tsx
+++ b/apps/web/src/features/home/new-chat-composer.tsx
@@ -1,0 +1,140 @@
+import { useAnalytics } from '@app/lib/analytics/analytics-context';
+import { useSplitPanelOrThrow } from '@components/app/split-layout/layoutUtils';
+import { buildChatEditor } from '@core/component/AI/component/input/buildChatEditor';
+import type { ChatSendInput } from '@core/component/AI/component/input/buildRequest';
+import { ChatInput } from '@core/component/AI/component/input/ChatInput';
+import { useChatInputContext } from '@core/component/AI/context';
+import { useGetChatAttachmentInfo } from '@core/component/AI/signal/attachment';
+import { setPendingSendData } from '@core/component/AI/signal/pendingSend';
+import { deriveChatName } from '@core/component/AI/util/deriveName';
+import { PaywallKey, usePaywallState } from '@core/constant/PaywallState';
+import { registerHotkey } from '@core/hotkey/hotkeys';
+import { TOKENS } from '@core/hotkey/tokens';
+import { isPaymentError } from '@core/util/handlePaymentError';
+import { createRenameDssEntityMutation } from '@entity';
+import { invalidateAllSoup } from '@queries/soup/normalized-cache';
+import { cognitionApiServiceClient } from '@service-cognition/client';
+import { $getRoot } from 'lexical';
+import { createEffect } from 'solid-js';
+import { replaceHomeComposerDraft } from './home-composer-selection';
+
+/**
+ * Composer that starts a fresh persistent chat on send. Used on the home
+ * view and the Agents hub. Must be rendered under a `ChatInputProvider`
+ * and inside a split panel.
+ */
+export const NewChatComposer = () => {
+  const analytics = useAnalytics();
+  const splitPanelContext = useSplitPanelOrThrow();
+  const input = useChatInputContext();
+
+  const { getAttachmentFromMention } = useGetChatAttachmentInfo();
+
+  const editor = buildChatEditor().withMentions({
+    onCreate: (mention) => {
+      analytics.track('mentions_menu_use', { itemType: 'chat' });
+      const attachment = getAttachmentFromMention(mention);
+      if (attachment) input.attachments.addAttachment(attachment);
+    },
+    block: 'chat',
+    showOpenTabs: true,
+  });
+
+  const applyDraft = (text: string) => {
+    replaceHomeComposerDraft(editor.controls, text);
+    requestAnimationFrame(() => {
+      editor.controls.focus();
+      // Focus lands at the start of the document; drafts are prompt prefixes,
+      // so the caret belongs at the end, ready to complete the sentence.
+      editor.controls.getLexical().update(() => {
+        $getRoot().selectEnd();
+      });
+    });
+  };
+
+  // Drafts requested from elsewhere on the view (e.g. a suggested action row).
+  createEffect(() => {
+    const draft = input.pendingDraft();
+    if (draft != null) {
+      applyDraft(draft);
+      input.setPendingDraft(null);
+    }
+  });
+
+  registerHotkey({
+    hotkey: 'enter',
+    scopeId: splitPanelContext.splitHotkeyScope,
+    description: 'Focus Chat Input',
+    keyDownHandler: () => {
+      editor.controls.focus();
+      return true;
+    },
+    hotkeyToken: TOKENS.block.focus,
+    hide: true,
+  });
+
+  const renameMutation = createRenameDssEntityMutation();
+
+  const handleSend = async (request: ChatSendInput) => {
+    const backgroundSend = request.metaKey;
+
+    // Create a new persistent chat
+    const response = await cognitionApiServiceClient.createChat({});
+    if (response.isErr()) {
+      if (isPaymentError(response)) {
+        const { showPaywall } = usePaywallState();
+        showPaywall(PaywallKey.CHAT_LIMIT);
+      }
+      return;
+    }
+    const { id: chatId } = response.value;
+
+    // Rename via mutation for optimistic cache updates (history, preview, soup)
+    const name = deriveChatName(request.content);
+    if (name) {
+      renameMutation.mutate({
+        entity: { type: 'chat', id: chatId, name: '', ownerId: '' },
+        newName: name,
+      });
+    }
+
+    if (backgroundSend) {
+      // Send the message in the background without navigating
+      cognitionApiServiceClient.sendStreamChatMessage({
+        content: request.content,
+        model: request.model,
+        chat_id: chatId,
+        attachments:
+          request.attachments.length > 0 ? request.attachments : undefined,
+        toolset: { type: 'all' },
+      });
+      invalidateAllSoup();
+    } else {
+      // Store the pending send data for the chat to pick up
+      setPendingSendData({
+        content: request.content,
+        attachments: request.attachments,
+        model: request.model,
+      });
+
+      // Replace the soup split with the chat split
+      splitPanelContext.handle.replace({
+        next: { type: 'chat', id: chatId },
+      });
+    }
+  };
+
+  return (
+    <ChatInput
+      variant="default"
+      editor={editor}
+      onSend={handleSend}
+      onEscape={() => {
+        splitPanelContext.panelRef()?.focus();
+        return true;
+      }}
+      isPersistent={true}
+      autoFocusOnMount={true}
+    />
+  );
+};


### PR DESCRIPTION
## Summary

Introduces a new Agents Hub view for desktop that provides a dedicated interface for starting fresh agent chats. The hub features a prominent chat composer in the center with a right-side panel displaying automations and recent agent sessions.

## Key Changes

- **New Agents Hub Component** (`agents-hub.tsx`): Desktop-only view with a centered chat composer and side panel, replacing the previous soup list view on desktop (mobile retains the soup list)

- **Agents Side Panel** (`agents-side-panel.tsx`): Right-side panel with:
  - "New session" button to start fresh chats
  - Automations bento card showing automation status (running, paused, scheduled) with ability to create new automations
  - Recent sessions bento card displaying recent chat sessions with timestamps
  - Error boundaries and suspense handling for robustness

- **Extracted Chat Composer** (`new-chat-composer.tsx`): Refactored the chat input logic from `home.tsx` into a reusable `NewChatComposer` component that:
  - Creates persistent chats on send
  - Supports draft management and mentions
  - Handles background sends (Cmd/Ctrl+Enter) and foreground navigation
  - Can be used in both home and agents hub contexts

- **Updated Home View** (`home.tsx`): Simplified by extracting chat input logic to `NewChatComposer`, reducing component complexity

- **Component Registry** (`componentRegistry.tsx`): Updated agents view registration to show `AgentsHub` on desktop and `AgentsSoupView` on mobile, with proper responsive behavior

## Implementation Details

- The side panel uses bento-style cards with consistent styling and hover states
- Automation status is dynamically computed (running with pulse animation, paused, or next run time)
- Recent sessions display with relative timestamps using `formatDistanceToNowStrict`
- The composer is wrapped in `ChatInputProvider` to manage input state across the hub
- Mobile detection via `isMobile()` ensures appropriate view selection

https://claude.ai/code/session_01WJxTtgsr4gMDBb8mn2pK3V