### PR TITLE
fix(soup): hydrate tags on call records in the soup feed

### DIFF
--- a/crates/soup/src/domain/service.rs
+++ b/crates/soup/src/domain/service.rs
@@ -494,23 +494,35 @@ where
             return Ok(Either::Left(None.into_iter()));
         };
 
-        let user_id = req.user_id.as_ref().to_string();
+        let user_id = req.user_id.clone();
+        let user_id_str = user_id.as_ref().to_string();
 
-        Ok(Either::Right(
-            self.call_record_service
-                .get_user_call_records(req)
+        let mut items: Vec<SoupItem> = self
+            .call_record_service
+            .get_user_call_records(req)
+            .await
+            .map_err(|_| SoupErr::CallErr)?
+            .into_iter()
+            .map(|record| {
+                SoupItem::Call(SoupCallRecord::from_record_for_user(record, &user_id_str))
+            })
+            .collect();
+
+        // Calls are fetched outside the main soup queries (which hydrate their
+        // own items), so attach entity properties (tags) here, like CRM.
+        if !items.is_empty() {
+            self.soup_storage
+                .populate_properties(user_id, &mut items)
                 .await
-                .map_err(|_| SoupErr::CallErr)
-                .map(|records| {
-                    records.into_iter().map(move |record| {
-                        let soup_record = SoupCallRecord::from_record_for_user(record, &user_id);
-                        FrecencySoupItem {
-                            item: SoupItem::Call(soup_record),
-                            frecency_score: None,
-                        }
-                    })
-                })?,
-        ))
+                .map_err(anyhow::Error::from)?;
+        }
+
+        Ok(Either::Right(items.into_iter().map(|item| {
+            FrecencySoupItem {
+                item,
+                frecency_score: None,
+            }
+        })))
     }
 
     #[tracing::instrument(err, skip(self, source_ids, query))]


### PR DESCRIPTION
Calls are a foreign soup entity fetched from the call service and chained into the feed, so they bypassed the native `populate_properties` pass that hydrates documents/chats/projects. Their `properties` came back empty, so tag chips never rendered and the client-side tag gate matched nothing. Populate entity properties on the call items after fetch, mirroring the CRM-company handler. Follow-up to #4703.
