### PR TITLE
feat(search): enqueue a name refresh on document rename

### DIFF
--- a/crates/ai_tools/src/build_context.rs
+++ b/crates/ai_tools/src/build_context.rs
@@ -268,6 +268,10 @@ pub async fn build_tool_service_context_from_env(
             pool.clone(),
         )),
         macro_event_broker: macro_event_broker.clone(),
+        // AI-agent contexts don't own a search event queue (their sqs_client is
+        // configured without one), so no search-index refresh is published from
+        // here — matching the properties service built in the same context.
+        search_indexer: None,
     };
 
     let document_tool_context = DocumentToolContext::new(

--- a/crates/documents/src/domain/ports/mod.rs
+++ b/crates/documents/src/domain/ports/mod.rs
@@ -320,6 +320,21 @@ pub trait TaskPropertiesPort: Send + Sync + 'static {
     ) -> impl Future<Output = anyhow::Result<()>> + Send;
 }
 
+/// Port for refreshing a document's denormalized name in the search index.
+///
+/// A rename only changes the `document_name` on the parent doc, and nothing
+/// else re-indexes parent-only file types, so the rename must publish a
+/// targeted metadata refresh. Best-effort — callers log and continue on error.
+/// Boxed future so the port stays object-safe and can be held as
+/// `Arc<dyn DocumentSearchIndexer>` without adding a service generic.
+pub trait DocumentSearchIndexer: Send + Sync + std::fmt::Debug {
+    /// Enqueue a refresh of the document's indexed name.
+    fn enqueue_name_update(
+        &self,
+        document_id: String,
+    ) -> std::pin::Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send>>;
+}
+
 /// Service interface for document operations.
 ///
 /// Orchestrates business logic using the repository and external services.

--- a/crates/documents/src/domain/service.rs
+++ b/crates/documents/src/domain/service.rs
@@ -9,6 +9,7 @@ use models_properties::EntityReference;
 use models_properties::api::SetPropertyValue;
 use std::borrow::Cow;
 use std::str::FromStr;
+use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 use unicode_segmentation::UnicodeSegmentation;
 
@@ -51,7 +52,10 @@ use super::models::{
 };
 #[cfg(feature = "document_create")]
 use super::ports::create::DocumentCreationService;
-use super::ports::{DocumentRepo, DocumentService, PresignedUploadUrlPort, TaskPropertiesPort};
+use super::ports::{
+    DocumentRepo, DocumentSearchIndexer, DocumentService, PresignedUploadUrlPort,
+    TaskPropertiesPort,
+};
 use super::response::{
     CreateDocumentResponseData, DocumentMetadataWithContent, DocumentResponse,
     DocumentResponseMetadataWithContent, GetDocumentResponseData, LocationResponseV3,
@@ -85,6 +89,9 @@ pub struct DocumentServiceImpl<
     pub foreign_entity_service: F,
     /// Macro event broker for publishing document lifecycle events
     pub macro_event_broker: B,
+    /// Optional publisher that refreshes a document's denormalized name in the
+    /// search index after a rename.
+    pub search_indexer: Option<Arc<dyn DocumentSearchIndexer>>,
 }
 
 fn ready_content_for_file_type(file_type: Option<FileType>) -> DocumentContent {
@@ -231,6 +238,30 @@ impl<
             entity_access_management_service,
             foreign_entity_service,
             macro_event_broker,
+            search_indexer: None,
+        }
+    }
+
+    /// Attach a search-index publisher so renames refresh the denormalized
+    /// name in the search index. Builder-style so existing constructions are
+    /// unaffected.
+    pub fn with_search_indexer(mut self, search_indexer: Arc<dyn DocumentSearchIndexer>) -> Self {
+        self.search_indexer = Some(search_indexer);
+        self
+    }
+
+    /// Best-effort publish of a search-index name refresh after a rename. Logs
+    /// and continues on failure so a missed refresh never fails the edit
+    /// itself; a full re-index would eventually correct the name anyway.
+    async fn enqueue_name_update(&self, document_id: &str) {
+        let Some(search_indexer) = self.search_indexer.as_ref() else {
+            return;
+        };
+        if let Err(error) = search_indexer
+            .enqueue_name_update(document_id.to_string())
+            .await
+        {
+            tracing::warn!(error = ?error, document_id = %document_id, "failed to enqueue search name update for rename");
         }
     }
 
@@ -1148,6 +1179,14 @@ impl<
             })
             .await
             .map_err(|e| DocumentError::Internal(e.into()))?;
+
+        // A rename changes the denormalized `document_name` on the parent doc in
+        // the search index; nothing else re-indexes parent-only file types, so
+        // publish a targeted refresh once the new name is committed.
+        if document_name.is_some() {
+            self.enqueue_name_update(&entity_access_receipt.entity().entity_id)
+                .await;
+        }
 
         // Update project modified timestamps. args.project_id of None means "no change",
         // so only move the document out of its old project when a different project (or

--- a/crates/documents/src/domain/service/tests.rs
+++ b/crates/documents/src/domain/service/tests.rs
@@ -332,6 +332,24 @@ impl MacroEventBroker for TestEventBroker {
     }
 }
 
+#[derive(Clone, Debug, Default)]
+struct TestDocumentSearchIndexer {
+    enqueued: Arc<Mutex<Vec<String>>>,
+}
+
+impl crate::domain::ports::DocumentSearchIndexer for TestDocumentSearchIndexer {
+    fn enqueue_name_update(
+        &self,
+        document_id: String,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = anyhow::Result<()>> + Send>> {
+        let enqueued = Arc::clone(&self.enqueued);
+        Box::pin(async move {
+            enqueued.lock().unwrap().push(document_id);
+            Ok(())
+        })
+    }
+}
+
 type TestDocumentService = DocumentServiceImpl<
     MockDocumentRepo,
     TestUploadUrlPort,
@@ -396,6 +414,29 @@ fn make_test_service_with_entity_access(
         TestEventBroker::default(),
     );
     (service, entity_access)
+}
+
+/// Build a test service along with a handle to its recording search indexer.
+fn make_test_service_with_search_indexer(
+    repo: MockDocumentRepo,
+) -> (TestDocumentService, TestDocumentSearchIndexer) {
+    let search_indexer = TestDocumentSearchIndexer::default();
+    let service = DocumentServiceImpl::new(
+        repo,
+        test_cloudfront_config(),
+        sync_service_client::SyncServiceClient::new(
+            "test-sync-key".to_string(),
+            "http://sync-service.test".to_string(),
+        ),
+        TestUploadUrlPort,
+        TestTaskPropertiesPort,
+        TestConnectionService,
+        TestEntityAccessManagementService::default(),
+        TestForeignEntityService::default(),
+        TestEventBroker::default(),
+    )
+    .with_search_indexer(Arc::new(search_indexer.clone()));
+    (service, search_indexer)
 }
 
 /// Build a test service along with a handle to its recording event broker.
@@ -1265,6 +1306,65 @@ async fn test_edit_document_rename_only_keeps_project_access() {
             .is_empty()
     );
     assert!(entity_access.added_to_projects.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn test_edit_document_rename_enqueues_search_name_update() {
+    let mut repo = make_mock_repo();
+    repo.expect_edit_document()
+        .withf(|args| args.document_id == "doc-1")
+        .returning(|_| Box::pin(std::future::ready(Ok(()))));
+
+    let (service, search_indexer) = make_test_service_with_search_indexer(repo);
+
+    service
+        .edit_document(
+            edit_receipt("doc-1"),
+            task_document_context("doc-1"),
+            EditDocumentServiceArgs {
+                document_name: Some("New name".to_string()),
+                project_id: None,
+                share_permission: None,
+                file_type: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        *search_indexer.enqueued.lock().unwrap(),
+        vec!["doc-1".to_string()]
+    );
+}
+
+#[tokio::test]
+async fn test_edit_document_without_rename_does_not_enqueue_search_name_update() {
+    let document_id = uuid::Uuid::new_v4().to_string();
+    let new_project_id = uuid::Uuid::new_v4();
+
+    let mut repo = make_mock_repo();
+    repo.expect_edit_document()
+        .returning(|_| Box::pin(std::future::ready(Ok(()))));
+    repo.expect_update_project_modified()
+        .returning(|_| Box::pin(std::future::ready(Ok(()))));
+
+    let (service, search_indexer) = make_test_service_with_search_indexer(repo);
+
+    service
+        .edit_document(
+            edit_receipt(&document_id),
+            task_document_context(&document_id),
+            EditDocumentServiceArgs {
+                document_name: None,
+                project_id: Some(new_project_id.to_string()),
+                share_permission: None,
+                file_type: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    assert!(search_indexer.enqueued.lock().unwrap().is_empty());
 }
 
 #[tokio::test]

--- a/crates/opensearch_client/src/upsert/document.rs
+++ b/crates/opensearch_client/src/upsert/document.rs
@@ -373,6 +373,23 @@ pub(crate) async fn update_document_metadata(
                 method: Some("update_document_metadata".to_string()),
             })?;
 
+    // A *missing document* 404 is a no-op: the doc isn't indexed yet, so the
+    // next full index will carry the current name. A *missing index* 404
+    // (`index_not_found_exception`) is a real outage and must propagate. This
+    // mirrors `update_document_properties`.
+    if status_code.as_u16() == 404 {
+        let error_type = serde_json::from_str::<serde_json::Value>(&body)
+            .ok()
+            .and_then(|value| value["error"]["type"].as_str().map(str::to_owned));
+        if error_type.as_deref() == Some("document_missing_exception") {
+            tracing::debug!(
+                document_id=%document_id,
+                "document not indexed yet; skipping name update"
+            );
+            return Ok(());
+        }
+    }
+
     tracing::error!(
         status_code=?status_code,
         body=?body,

--- a/crates/sqs_client/src/search/mod.rs
+++ b/crates/sqs_client/src/search/mod.rs
@@ -73,6 +73,7 @@ pub enum SearchQueueMessage {
     RemoveDocument(DocumentId),
     ExtractSync(SearchExtractorMessage),
     UpdateDocumentProperties(DocumentPropertiesUpdate),
+    UpdateDocumentName(DocumentId),
     // Chat
     ChatMessage(ChatMessage),
     RemoveChatMessage(RemoveChatMessage),
@@ -103,6 +104,7 @@ impl PrimaryId for SearchQueueMessage {
             SearchQueueMessage::RemoveDocument(message) => message.document_id.clone(),
             SearchQueueMessage::ExtractSync(message) => message.document_id.clone(),
             SearchQueueMessage::UpdateDocumentProperties(message) => message.document_id.clone(),
+            SearchQueueMessage::UpdateDocumentName(message) => message.document_id.clone(),
             SearchQueueMessage::ChatMessage(message) => message.message_id.clone(), // needs
             // to be the message id to ensure it's unique for batch
             SearchQueueMessage::RemoveChatMessage(message) => message.chat_id.clone(),
@@ -143,6 +145,7 @@ impl SearchQueueMessage {
             SearchQueueMessage::RemoveDocument(_) => Operation::Remove,
             SearchQueueMessage::ExtractSync(_) => Operation::ExtractSync,
             SearchQueueMessage::UpdateDocumentProperties(_) => Operation::UpdateMetadata,
+            SearchQueueMessage::UpdateDocumentName(_) => Operation::UpdateMetadata,
             // Chat
             SearchQueueMessage::ChatMessage(_) => Operation::ExtractText,
             SearchQueueMessage::RemoveChatMessage(_) => Operation::Remove,
@@ -235,4 +238,32 @@ pub async fn bulk_enqueue_search_text_extractor(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::search::document::DocumentId;
+
+    #[test]
+    fn update_document_name_maps_to_update_metadata() {
+        let message = SearchQueueMessage::UpdateDocumentName(DocumentId {
+            document_id: "doc-1".to_string(),
+        });
+
+        assert!(matches!(message.operation(), Operation::UpdateMetadata));
+        assert_eq!(message.id(), "doc-1");
+    }
+
+    #[test]
+    fn update_document_name_round_trips() {
+        let message = SearchQueueMessage::UpdateDocumentName(DocumentId {
+            document_id: "doc-1".to_string(),
+        });
+
+        let serialized = serde_json::to_string(&message).unwrap();
+        let deserialized: SearchQueueMessage = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(message, deserialized);
+    }
 }

--- a/services/document_storage_service/src/main.rs
+++ b/services/document_storage_service/src/main.rs
@@ -398,21 +398,28 @@ async fn main() -> anyhow::Result<()> {
             .context("failed to create kafka event publisher")?,
     );
 
-    let document_service = Arc::new(DocumentServiceImpl::new(
-        document_repo,
-        cloudfront_config,
-        sync_service_client.as_ref().clone(),
-        s3_upload_adapter,
-        TaskPropertiesAdapter {
-            system_properties: system_properties_service.clone(),
-            properties: properties_service.clone(),
-            entity_access_service: entity_access_service.clone(),
-        },
-        connection_service,
-        entity_access_management_service.clone(),
-        ForeignEntityServiceImpl::new(PgForeignEntityRepo::new(db.clone())),
-        macro_event_broker.clone(),
-    ));
+    let document_service = Arc::new(
+        DocumentServiceImpl::new(
+            document_repo,
+            cloudfront_config,
+            sync_service_client.as_ref().clone(),
+            s3_upload_adapter,
+            TaskPropertiesAdapter {
+                system_properties: system_properties_service.clone(),
+                properties: properties_service.clone(),
+                entity_access_service: entity_access_service.clone(),
+            },
+            connection_service,
+            entity_access_management_service.clone(),
+            ForeignEntityServiceImpl::new(PgForeignEntityRepo::new(db.clone())),
+            macro_event_broker.clone(),
+        )
+        .with_search_indexer(Arc::new(
+            crate::service::document_search_indexer::SqsDocumentSearchIndexer::new(
+                sqs_client.clone(),
+            ),
+        )),
+    );
 
     let foreign_entity_service = Arc::new(ForeignEntityServiceImpl::new(PgForeignEntityRepo::new(
         db.clone(),

--- a/services/document_storage_service/src/service/document_search_indexer.rs
+++ b/services/document_storage_service/src/service/document_search_indexer.rs
@@ -1,0 +1,36 @@
+//! Adapter that publishes document name refreshes to the search queue.
+
+use documents_hex::domain::ports::DocumentSearchIndexer;
+use sqs_client::SQS;
+use sqs_client::search::SearchQueueMessage;
+use sqs_client::search::document::DocumentId;
+
+/// Publishes a refresh of a document's denormalized name to the shared search
+/// event queue so the search-processing service updates the indexed
+/// `document_name` after a rename.
+#[derive(Debug)]
+pub struct SqsDocumentSearchIndexer {
+    sqs: SQS,
+}
+
+impl SqsDocumentSearchIndexer {
+    pub fn new(sqs: SQS) -> Self {
+        Self { sqs }
+    }
+}
+
+impl DocumentSearchIndexer for SqsDocumentSearchIndexer {
+    fn enqueue_name_update(
+        &self,
+        document_id: String,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = anyhow::Result<()>> + Send>> {
+        let sqs = self.sqs.clone();
+        Box::pin(async move {
+            sqs.send_message_to_search_event_queue(SearchQueueMessage::UpdateDocumentName(
+                DocumentId { document_id },
+            ))
+            .await?;
+            Ok(())
+        })
+    }
+}

--- a/services/document_storage_service/src/service/mod.rs
+++ b/services/document_storage_service/src/service/mod.rs
@@ -2,6 +2,7 @@ pub mod call_search_indexer;
 pub mod conn_gateway;
 #[cfg(feature = "delete_document_worker")]
 pub mod delete_document_worker;
+pub mod document_search_indexer;
 pub mod property_search_indexer;
 pub mod s3;
 pub mod soup_favorites_reader;

--- a/services/mcp_service/src/context.rs
+++ b/services/mcp_service/src/context.rs
@@ -236,6 +236,9 @@ async fn build_tool_context(
             ),
         foreign_entity_service: ForeignEntityServiceImpl::new(PgForeignEntityRepo::new(db.clone())),
         macro_event_broker: macro_event_broker.clone(),
+        // No search event queue is configured in this context, so no
+        // search-index refresh is published from here.
+        search_indexer: None,
     };
     let lexical_client_for_tools = (*lexical_client).clone();
     let document_tool_context = DocumentToolContext::new(

--- a/services/search_processing_service/src/process/document/mod.rs
+++ b/services/search_processing_service/src/process/document/mod.rs
@@ -16,6 +16,50 @@ pub async fn process_remove_message(
     Ok(())
 }
 
+/// Refresh the denormalized `document_name` on the parent doc after a rename.
+/// The DB is the source of truth for the name, so it is fetched here rather
+/// than carried on the message — this converges to the latest name even if
+/// renames are processed out of order. A missing or soft-deleted document is a
+/// no-op: the remove path owns deletions, and a not-yet-indexed doc will pick
+/// up its name on its first full index.
+pub async fn process_update_name_message(
+    opensearch_client: &OpensearchClient,
+    db: &sqlx::Pool<sqlx::Postgres>,
+    update_message: &DocumentId,
+) -> anyhow::Result<()> {
+    let document = match macro_db_client::document::get_basic_document(
+        db,
+        update_message.document_id.as_str(),
+    )
+    .await
+    {
+        Ok(document) => document,
+        Err(sqlx::Error::RowNotFound) => {
+            tracing::debug!(
+                document_id = %update_message.document_id,
+                "document not found; skipping search name update"
+            );
+            return Ok(());
+        }
+        Err(e) => return Err(e).context("unable to get basic document for search name update"),
+    };
+
+    if document.deleted_at.is_some() {
+        tracing::debug!(
+            document_id = %update_message.document_id,
+            "document is deleted; skipping search name update"
+        );
+        return Ok(());
+    }
+
+    opensearch_client
+        .update_document_metadata(update_message.document_id.as_str(), &document.document_name)
+        .await
+        .context("failed to update document name in search index")?;
+
+    Ok(())
+}
+
 pub async fn process_extract_text_message(
     opensearch_client: &OpensearchClient,
     db: &sqlx::Pool<sqlx::Postgres>,

--- a/services/search_processing_service/src/process/mod.rs
+++ b/services/search_processing_service/src/process/mod.rs
@@ -96,6 +96,10 @@ pub async fn process_message(
             properties::process_entity_property_update(&ctx.opensearch_client, &ctx.db, &message)
                 .await?;
         }
+        SearchQueueMessage::UpdateDocumentName(message) => {
+            document::process_update_name_message(&ctx.opensearch_client, &ctx.db, &message)
+                .await?;
+        }
         SearchQueueMessage::ChatMessage(message) => {
             chat::insert_chat_message(&ctx.opensearch_client, &ctx.db, &message).await?;
         }


### PR DESCRIPTION
Renaming a document now enqueues an `UpdateDocumentName` search-queue message so the search-processing service refreshes the denormalized `document_name` on the parent doc; previously renames never re-indexed, so parent-only file types stayed findable only under their old name. The enqueue goes through a new `DocumentSearchIndexer` outbound port wired in DSS, and `update_document_metadata` now no-ops on a not-yet-indexed doc (404) like `update_document_properties`. Parents that went stale before this change need a one-time `documents` index backfill to pick up their current names.
