### PR TITLE
docs: document call tagging and CRM backfill choice

### DIFF
--- a/apps/docs/product/calls.mdx
+++ b/apps/docs/product/calls.mdx
@@ -34,3 +34,7 @@ To opt out of a call being shared with the team, uncheck the button in the botto
 After a call ends, it's auto-transcribed and an AI summary is generated. The recording and a readable transcript are always available at the bottom of the call.
 
 From the calls tab, you can ask AI to help you work through your calls: searching transcripts, summarizing, and more.
+
+### Tag and filter calls
+
+Calls carry [tags](/concepts/properties) like the rest of your blocks. Add tags from a call's row in the calls feed or from its side panel to group related conversations — for example, a customer name or a project. The calls feed lets you filter down to a tag, and tagged calls show up when you filter [Search](/product/search#filtering-by-tags) by the same tag, so a call sits alongside the docs, emails, and tasks that share its context.

--- a/apps/docs/product/crm.mdx
+++ b/apps/docs/product/crm.mdx
@@ -28,6 +28,15 @@ Every customer record comes with three properties out of the box: **Stage** (Lea
 
 Switch between **list** and **kanban** from the toggle in the topbar. The board lays out one column per Stage; drag a card to a new column to update it. From either view, group and filter by **Stage** (the default) or **Owner** to focus on a segment of accounts.
 
+### Turning on the CRM
+
+A team admin turns the CRM on or off from the CRM section of team settings. When you enable it, Macro asks how to seed your records:
+
+- **Backfill existing emails** builds contacts and companies from your team's email history right away, so the CRM opens already populated.
+- **Start from now** flips the CRM on without scanning past mail — records fill in from new activity going forward.
+
+Either way, the CRM keeps building itself from email as your team works.
+
 ### Email sharing
 
 CRM is a team feature, and it's where Macro's email auto-sharing lives. When **Email Sync** is on for a company, your team's email threads with that company become visible to teammates in the CRM, so nobody has to forward a thread just to share context. Turning it off for a company keeps the record but makes its threads private to their participants.


### PR DESCRIPTION
## What

Routine review of PRs merged in the last 24h for user-facing changes that need docs (`apps/docs`, the Mintlify source for docs.macro.com). Two shipped changes warranted documentation updates:

### Calls — tag and filter calls
Documents call-record tagging, added in #4703 (with the soup-feed hydration fix in #4786). Adds a **Tag and filter calls** section to `product/calls.mdx` covering the row and side-panel tag editors, filtering the calls feed by tag, and finding tagged calls through Search's tag filter.

### CRM — backfill choice on enable
Documents the new choice presented when a team admin enables the CRM (#4778): **Backfill existing emails** vs **Start from now**. Adds a **Turning on the CRM** section to `product/crm.mdx`.

## Files
- `apps/docs/product/calls.mdx`
- `apps/docs/product/crm.mdx`

## Notes on what was left out
Of the ~40 PRs merged in the window, most were bug fixes, styling tweaks, refactors, CI/infra, and internal backend changes with no user-facing surface. A few borderline items were considered and deliberately skipped:

- **Theme preview / theme chip edit buttons** (#4745, #4768) — enhancements to a themes feature that isn't documented today; not enough standalone content to justify a new page under the docs' "no placeholder pages" boundary.
- **CRM settings trim** (#4765) — removed the Deal stages / Company properties / Permissions settings sections, which the current docs never described, so there's nothing to correct.
- Small UI touches like the call mute icon (#4746) and forwarded-email theme adaptation (#4753) are display polish without a documentable behavior change.

The changelog pages were not touched: they're generated from GitHub Releases by `scripts/generate-changelog.ts`, not hand-edited.

---
_Generated by [Claude Code](https://claude.ai/code/session_014XiDJ63LLXk4qPRYrouSyT)_