### PR TITLE
fix(soup): hover-to-focus only blocked by preview, not new inbox

### DIFF
--- a/apps/web/src/features/next-soup/soup-view/soup-view.tsx
+++ b/apps/web/src/features/next-soup/soup-view/soup-view.tsx
@@ -1538,11 +1538,7 @@ export const SoupViewList = (props: SoupViewListProps) => {
                                           highlighted={row.isFocused()}
                                           onMouseMove={() => {
                                             if (isKeypressActive()) return;
-                                            if (
-                                              previewOpen() ||
-                                              isNewInboxEnabled()
-                                            )
-                                              return;
+                                            if (previewOpen()) return;
                                             soup.focus.setIndex(row.index);
                                           }}
                                           showUnrollNotifications={


### PR DESCRIPTION
## Summary
- Restores hover-to-focus in soup list rows whenever the preview pane is closed, including in the new inbox.
- `onMouseMove` previously bailed whenever `isNewInboxEnabled()` was true, regardless of whether the preview pane (`previewOpen()`) was actually open — so hovering an item no longer set focus in the new inbox at all, even with preview collapsed.
- This broke a workflow several people relied on: hover an item, press `e` to mark it done without clicking to select it first.

## Why prioritized
Reported in an internal bug-reports/feature-requests discussion: "when you are in inbox, and not in preview mode, you used to be able to set the selection on hover, such that you could hover items and press `e`... I love this feature and used it constantly." A task (MACRO-2357) was already filed for it and had no PR yet.

## Change
`apps/web/src/features/next-soup/soup-view/soup-view.tsx`: drop the `isNewInboxEnabled()` check from the `onMouseMove` bail condition, keeping only `previewOpen()` — matching the intent described in the task ("doesn't work in preview-mode... but if it's possible to be in non-preview state, it'd be nice if it worked").

## Test plan
- [ ] In the new inbox, with the preview pane closed, hover a row and press `e` — item should be marked done without clicking.
- [ ] With the preview pane open, hovering should not steal focus/preview from keyboard navigation (unchanged behavior).
- [ ] `bunx --bun biome lint` passes on the changed file.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LsPs2wMqW72L3JkbtfsQWR)_