### PR TITLE
fix(channel): drop # from call notification title

### DIFF
--- a/apps/web/src/features/channel/Call/CallStartedNotifier.tsx
+++ b/apps/web/src/features/channel/Call/CallStartedNotifier.tsx
@@ -279,7 +279,7 @@ async function emitCallStartedNotification(args: {
   const callerName =
     (createdBy ? await DefaultUserNameResolver(createdBy) : undefined) ??
     'Someone';
-  const target = channelName ? ` in #${channelName}` : '';
+  const target = channelName ? ` in ${channelName}` : '';
 
   const handle = await notif.showNotification({
     title: `Incoming call${target}`,


### PR DESCRIPTION
## Summary
- The "Incoming call" desktop/OS notification rendered its target as `Incoming call in #general`. Dropped the `#` so it reads `Incoming call in general`.

## Why prioritized
Raised in an internal feature-requests discussion: "do we need the # before the channel names? i feel like it hurts the readability of the notifs" — a teammate agreed it could be removed, but no follow-up change had landed yet. Small, low-risk text fix.

## Change
`apps/web/src/features/channel/Call/CallStartedNotifier.tsx`: remove the `#` from the notification title template.

## Test plan
- [ ] Trigger an incoming call notification and confirm the title reads "Incoming call in &lt;channel name&gt;" without a `#`.
- [ ] `bunx --bun biome lint` passes on the changed file.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LsPs2wMqW72L3JkbtfsQWR)_