### PR TITLE
feat(crm): board-first customers view with team-scoped owner pickers and CRM entity actions

### DIFF
--- a/apps/web/src/features/companies/crm/display-options.ts
+++ b/apps/web/src/features/companies/crm/display-options.ts
@@ -1,38 +1,27 @@
 /**
  * Personal display options for the CRM Customers view: which property
- * columns show in the list and which fields show on kanban cards.
- * Persisted per-user (localStorage preference), same mechanism as other
- * sticky view settings.
+ * columns show in the list. Persisted per-user (localStorage preference),
+ * same mechanism as other sticky view settings.
  */
 
 import { makePersisted } from '@solid-primitives/storage';
 import { createSignal } from 'solid-js';
 
 export type CrmListColumnId = 'stage' | 'owner' | 'revenue';
-export type CrmKanbanFieldId = 'owner' | 'domain' | 'lastInteraction';
 
 export type CrmDisplayOptions = {
   /** Visible list columns (order stays fixed; this only hides/shows). */
   listColumns: Record<CrmListColumnId, boolean>;
-  /** Fields rendered on kanban cards. */
-  kanbanFields: Record<CrmKanbanFieldId, boolean>;
 };
 
 export const DEFAULT_CRM_DISPLAY_OPTIONS: CrmDisplayOptions = {
   listColumns: { stage: true, owner: true, revenue: true },
-  kanbanFields: { owner: true, domain: true, lastInteraction: true },
 };
 
 export const CRM_LIST_COLUMN_LABELS: Record<CrmListColumnId, string> = {
   stage: 'Stage',
   owner: 'Owner',
   revenue: 'Revenue',
-};
-
-export const CRM_KANBAN_FIELD_LABELS: Record<CrmKanbanFieldId, string> = {
-  owner: 'Owner',
-  domain: 'Domain',
-  lastInteraction: 'Last interaction',
 };
 
 // One shared signal for the whole app (module-level), so toggling in the
@@ -54,10 +43,6 @@ export function useCrmDisplayOptions() {
       ...DEFAULT_CRM_DISPLAY_OPTIONS.listColumns,
       ...options().listColumns,
     },
-    kanbanFields: {
-      ...DEFAULT_CRM_DISPLAY_OPTIONS.kanbanFields,
-      ...options().kanbanFields,
-    },
   });
 
   const toggleListColumn = (column: CrmListColumnId) => {
@@ -71,16 +56,5 @@ export function useCrmDisplayOptions() {
     });
   };
 
-  const toggleKanbanField = (field: CrmKanbanFieldId) => {
-    const current = merged();
-    setOptions({
-      ...current,
-      kanbanFields: {
-        ...current.kanbanFields,
-        [field]: !current.kanbanFields[field],
-      },
-    });
-  };
-
-  return { options: merged, toggleListColumn, toggleKanbanField };
+  return { options: merged, toggleListColumn };
 }

--- a/apps/web/src/features/next-soup/actions/index.ts
+++ b/apps/web/src/features/next-soup/actions/index.ts
@@ -12,6 +12,7 @@ export { makeMarkSenderNoiseAction } from './make-mark-sender-noise-action';
 export { makeMoveToProjectAction } from './make-move-to-project-action';
 export { makeRemoveFromProjectAction } from './make-remove-from-project-action';
 export { makeRenameAction } from './make-rename-action';
+export { makeSetCompanyPropertyAction } from './make-set-company-property-action';
 export { makeShareAction } from './make-share-action';
 export { useBlockEntityCommands } from './use-block-entity-commands';
 export { useEntityActionHotkeys } from './use-entity-action-hotkeys';

--- a/apps/web/src/features/next-soup/actions/make-set-company-property-action.ts
+++ b/apps/web/src/features/next-soup/actions/make-set-company-property-action.ts
@@ -1,0 +1,49 @@
+import { openPropertyEditor } from '@app/features/property/editor/state/propertyEditor';
+import { useDealStages } from '@companies/crm/deal-stages';
+import type { EntityData } from '@entity';
+import { buildCompanyDefaultProperties } from '@entity/extractors-property';
+import { SYSTEM_PROPERTY_IDS } from '@property/constants';
+import type { Property } from '@property/types';
+
+/** Builtin CRM company fields settable from entity action menus. */
+export type CompanyCrmField = 'stage' | 'owner' | 'revenue';
+
+type MakeSetCompanyPropertyOptions = {
+  // Admin/owner-only on the FE, matching row-level CRM editing; the
+  // backend independently enforces write access on property saves.
+  isTeamAdmin: () => boolean;
+};
+
+/**
+ * "Set stage / owner / revenue" for CRM company rows: opens the global
+ * property editor (the same one task status/priority/assignee commands
+ * use) targeting the builtin CRM property, editing the whole selection.
+ */
+export const makeSetCompanyPropertyAction = (
+  options: MakeSetCompanyPropertyOptions
+) => {
+  const dealStages = useDealStages();
+
+  const canExecute = (entity: EntityData): boolean =>
+    entity.type === 'crm_company' && options.isTeamAdmin();
+
+  const propertyFor = (field: CompanyCrmField): Property | undefined => {
+    // Stage resolves through the active deal-stage set (the team's own
+    // definition when customized) so edits write to the active definition.
+    if (field === 'stage') return dealStages.stageProperty();
+    const definitionId =
+      field === 'owner'
+        ? SYSTEM_PROPERTY_IDS.COMPANY_OWNER
+        : SYSTEM_PROPERTY_IDS.REVENUE;
+    return buildCompanyDefaultProperties().find(
+      (property) => property.propertyDefinitionId === definitionId
+    );
+  };
+
+  const execute = (entities: EntityData[], field: CompanyCrmField) => {
+    const property = propertyFor(field);
+    if (property) openPropertyEditor(entities, 'direct', property);
+  };
+
+  return { canExecute, execute };
+};

--- a/apps/web/src/features/next-soup/actions/use-entity-action-hotkeys.ts
+++ b/apps/web/src/features/next-soup/actions/use-entity-action-hotkeys.ts
@@ -13,6 +13,7 @@ import { TOKENS } from '@core/hotkey/tokens';
 import { type EntityData, isTaskEntity } from '@entity';
 import { SYSTEM_PROPERTY_IDS } from '@property/constants';
 import type { Property, PropertyDefinitionDomain } from '@property/types';
+import { useIsTeamAdmin } from '@queries/team/teams';
 import { onCleanup } from 'solid-js';
 import type { SoupState } from '../create-soup-state';
 import {
@@ -25,6 +26,7 @@ import {
   makeMarkDoneAction,
   makeMoveToProjectAction,
   makeRenameAction,
+  makeSetCompanyPropertyAction,
   makeShareAction,
 } from './index';
 
@@ -75,6 +77,11 @@ export const useEntityActionHotkeys = (
   const shareAction = makeShareAction();
 
   const favoriteAction = makeFavoriteAction();
+
+  const isTeamAdmin = useIsTeamAdmin();
+  const setCompanyPropertyAction = makeSetCompanyPropertyAction({
+    isTeamAdmin: () => isTeamAdmin(),
+  });
 
   const getEntitiesForAction = (): EntityData[] => {
     if (
@@ -470,6 +477,42 @@ export const useEntityActionHotkeys = (
     },
     scopeId,
   }).withGroup(group);
+
+  // Set stage / owner / revenue for CRM companies (command menu only, no
+  // keybindings) — company counterpart of the task property commands above.
+  const companyPropertyCommands = [
+    { token: TOKENS.entity.action.stage, field: 'stage', label: 'Set stage' },
+    { token: TOKENS.entity.action.owner, field: 'owner', label: 'Set owner' },
+    {
+      token: TOKENS.entity.action.revenue,
+      field: 'revenue',
+      label: 'Set revenue',
+    },
+  ] as const;
+  for (const { token, field, label } of companyPropertyCommands) {
+    registerHotkey({
+      hotkeyToken: token,
+      tags: [HotkeyTags.SelectionModification],
+      displayPriority: 10,
+      description: label,
+      keyDownHandler: () => {
+        const entities = getEntitiesForAction();
+        if (entities.length === 0) return false;
+        if (!entities.every(setCompanyPropertyAction.canExecute)) return false;
+        setCompanyPropertyAction.execute(entities, field);
+        return true;
+      },
+      condition: () => {
+        if (condition && !condition()) return false;
+        const entities = getEntitiesForAction();
+        return (
+          entities.length > 0 &&
+          entities.every(setCompanyPropertyAction.canExecute)
+        );
+      },
+      scopeId,
+    }).withGroup(group);
+  }
 
   onCleanup(() => group.dispose());
 

--- a/apps/web/src/features/next-soup/soup-view/create-soup-entity-actions.ts
+++ b/apps/web/src/features/next-soup/soup-view/create-soup-entity-actions.ts
@@ -30,6 +30,7 @@ import {
   makeMoveToProjectAction,
   makeRemoveFromProjectAction,
   makeRenameAction,
+  makeSetCompanyPropertyAction,
   makeShareAction,
 } from '../actions';
 import type { SoupState } from '../create-soup-state';
@@ -116,6 +117,9 @@ export function createSoupEntityActions(): {
     isTeamAdmin: () => isTeamAdmin(),
     setHidden: (companyId, hidden) =>
       hiddenMutation.mutateAsync({ companyId, hidden }),
+  });
+  const setCompanyPropertyAction = makeSetCompanyPropertyAction({
+    isTeamAdmin: () => isTeamAdmin(),
   });
 
   const buildActionGroups: BuildActionGroups = (
@@ -370,8 +374,29 @@ export function createSoupEntityActions(): {
       });
     }
 
-    // CRM group: Hide / Unhide (admin/owner only, single company)
+    // CRM group (admin/owner only): Set stage/owner/revenue on the whole
+    // company selection, Hide / Unhide for a single company.
     const crmItems: SoupEntityActionItem[] = [];
+
+    if (canExecuteAll(setCompanyPropertyAction.canExecute)) {
+      crmItems.push(
+        {
+          id: 'set-stage',
+          label: 'Set stage',
+          onClick: () => setCompanyPropertyAction.execute(entities, 'stage'),
+        },
+        {
+          id: 'set-owner',
+          label: 'Set owner',
+          onClick: () => setCompanyPropertyAction.execute(entities, 'owner'),
+        },
+        {
+          id: 'set-revenue',
+          label: 'Set revenue',
+          onClick: () => setCompanyPropertyAction.execute(entities, 'revenue'),
+        }
+      );
+    }
 
     const singleEntity = entities.length === 1 ? entities[0] : undefined;
     if (

--- a/apps/web/src/features/next-soup/soup-view/filters-bar/soup-view-context-group.tsx
+++ b/apps/web/src/features/next-soup/soup-view/filters-bar/soup-view-context-group.tsx
@@ -13,7 +13,7 @@ import { createMemo, createSignal, Show } from 'solid-js';
 
 export const SoupViewContextGroup = () => {
   const panel = useSplitPanelOrThrow();
-  const { soup } = useSoupView();
+  const { soup, viewMode } = useSoupView();
   const groupByEnabled = useFeatureFlag('enable-soup-group-by', {
     enabledOverride: ENABLE_SOUP_GROUP_BY_OVERRIDE,
   });
@@ -55,7 +55,9 @@ export const SoupViewContextGroup = () => {
           onOpenChange={setGroupOpen}
         />
       </Show>
-      <Show when={isComponentListView('companies')}>
+      {/* The board is inherently grouped by stage columns, so grouping only
+          applies to the list mode. */}
+      <Show when={isComponentListView('companies') && viewMode() === 'list'}>
         <GroupDropdown
           value={value}
           onChange={onChange}

--- a/apps/web/src/features/next-soup/soup-view/filters-bar/unified-filter-dropdown.tsx
+++ b/apps/web/src/features/next-soup/soup-view/filters-bar/unified-filter-dropdown.tsx
@@ -34,6 +34,7 @@ import {
 import { useUserId } from '@core/context/user';
 import { registerHotkey } from '@core/hotkey/hotkeys';
 import { TOKENS } from '@core/hotkey/tokens';
+import { idToDisplayName } from '@core/user/util';
 import CaretRightIcon from '@phosphor/caret-right.svg';
 import CheckIcon from '@phosphor/check.svg';
 import CircleDashedIcon from '@phosphor/circle-dashed.svg';
@@ -42,6 +43,7 @@ import { PropertyValueIcon } from '@property/component/propertyValue/PropertyVal
 import { PROPERTY_OPTION_IDS, SYSTEM_PROPERTY_IDS } from '@property/constants';
 import { useGithubLinkStatusQuery } from '@queries/auth';
 import { useContacts } from '@queries/contacts/contacts';
+import { useCurrentTeamQuery } from '@queries/team/teams';
 import { cn, Dropdown, Tooltip } from '@ui';
 import {
   type Accessor,
@@ -554,6 +556,7 @@ export const UnifiedFilterDropdown = (
     setReadFilter,
   } = useSoupView();
   const contacts = useContacts();
+  const teamQuery = useCurrentTeamQuery();
   const userId = useUserId();
   const dealStages = useDealStages();
 
@@ -715,7 +718,9 @@ export const UnifiedFilterDropdown = (
     });
   };
 
-  // Owner options for the Customers view (contacts, plus a "No owner" row).
+  // Owner options for the Customers view (team members, plus a "No owner"
+  // row) — company owners are always teammates, so the broader contacts
+  // list (anyone ever interacted with) would mostly be noise here.
   const ownerOptions = createMemo((): SearchableOption[] => {
     const currentUserId = userId();
     const noOwnerOption: SearchableOption = {
@@ -724,31 +729,27 @@ export const UnifiedFilterDropdown = (
       icon: () => <CircleDashedIcon class="size-3.5 text-ink-muted" />,
     };
     let meOption: SearchableOption | undefined;
-    const otherContactOptions: SearchableOption[] = [];
-    for (const contact of contacts()) {
+    const memberOptions: SearchableOption[] = [];
+    for (const member of teamQuery.data?.members ?? []) {
+      const id = member.user_id;
       const opt: SearchableOption = {
-        id: contact.id,
-        label: buildContactLabel(contact, currentUserId),
+        id,
+        label: buildContactLabel(
+          { id, name: idToDisplayName(id) },
+          currentUserId
+        ),
         icon: () => (
-          <UserIcon
-            id={contact.id}
-            size="sm"
-            suppressClick
-            showTooltip={false}
-          />
+          <UserIcon id={id} size="sm" suppressClick showTooltip={false} />
         ),
       };
-      if (contact.id === currentUserId) {
+      if (id === currentUserId) {
         meOption = opt;
       } else {
-        otherContactOptions.push(opt);
+        memberOptions.push(opt);
       }
     }
-    return [
-      ...(meOption ? [meOption] : []),
-      noOwnerOption,
-      ...otherContactOptions,
-    ];
+    memberOptions.sort((a, b) => a.label.localeCompare(b.label));
+    return [...(meOption ? [meOption] : []), noOwnerOption, ...memberOptions];
   });
 
   // Owner filtering is a client-side predicate (companies come back from a
@@ -780,11 +781,23 @@ export const UnifiedFilterDropdown = (
     },
   ]);
 
+  // The stage submenu reflects what's on screen: an empty filter shows
+  // every stage, so everything reads as checked.
+  const effectiveStageFilter = () =>
+    stageFilter().length > 0
+      ? stageFilter()
+      : stageOptions().map((option) => option.id);
+
   // Stage filtering is a client-side predicate, mirroring the owner filter.
   const handleStageChange = (ids: string[]) => {
+    // Checking every stage is the same as no filter — store it as empty so
+    // the predicate deactivates.
+    const next = stageOptions().every((option) => ids.includes(option.id))
+      ? []
+      : ids;
     batch(() => {
-      setStageFilter(ids);
-      const shouldBeActive = ids.length > 0;
+      setStageFilter(next);
+      const shouldBeActive = next.length > 0;
       if (shouldBeActive !== soup.predicates.isActive('company-stage')) {
         soup.predicates.toggle({ and: ['company-stage'] });
       }
@@ -945,7 +958,7 @@ export const UnifiedFilterDropdown = (
                     <SearchableFilterSubmenu
                       label="Stage"
                       options={stageOptions}
-                      activeIds={stageFilter}
+                      activeIds={effectiveStageFilter}
                       onChange={handleStageChange}
                       placeholder="Filter stages..."
                     />

--- a/apps/web/src/features/next-soup/soup-view/soup-view-context.tsx
+++ b/apps/web/src/features/next-soup/soup-view/soup-view-context.tsx
@@ -50,6 +50,7 @@ import {
   ENABLE_SUPPORTED_SOUP_FOREIGN_ENTITIES_OVERRIDE,
 } from '@core/constant/featureFlags';
 import { useUserId } from '@core/context/user';
+import { idToDisplayName } from '@core/user/util';
 import {
   COMPANY_STAGE_OPTIONS,
   type EntityData,
@@ -119,6 +120,9 @@ type SoupViewInitializeOptions = {
 
 export type ReadFilter = 'all' | 'unread' | 'read';
 
+/** List/board display mode — currently only the Customers view offers a board. */
+export type SoupViewMode = 'list' | 'board';
+
 interface SoupViewContextValues {
   soup: SoupState;
   initialize: (options?: SoupViewInitializeOptions) => void;
@@ -145,6 +149,8 @@ interface SoupViewContextValues {
   setInboxFilter: Setter<string[] | undefined>;
   activeTab: Accessor<string | undefined>;
   setActiveTab: Setter<string | undefined>;
+  viewMode: Accessor<SoupViewMode>;
+  setViewMode: Setter<SoupViewMode>;
   readFilter: Accessor<ReadFilter>;
   setReadFilter: Setter<ReadFilter>;
   groupByField: Accessor<GroupByField | undefined>;
@@ -328,6 +334,11 @@ export const SoupViewContextProvider: FlowComponent<
     'soup.tab',
     { default: undefined }
   );
+  // List/board display mode — per-entry state so back/forward restores the
+  // mode the user left each entry with.
+  const [viewMode, setViewMode] = useEntryState<SoupViewMode>('soup.viewMode', {
+    default: 'board',
+  });
   const [readFilter, setReadFilter] = useEntryState<ReadFilter>(
     'soup.readFilter',
     { default: 'unread' }
@@ -794,11 +805,23 @@ export const SoupViewContextProvider: FlowComponent<
     );
   };
 
+  const isOwnerGrouping = () => {
+    const field = groupByField();
+    return (
+      field?.type === 'property' &&
+      field.propertyDefinitionId === SYSTEM_PROPERTY_IDS.COMPANY_OWNER
+    );
+  };
+
   // Group-key → label, preferring the active deal-stage set for stage
   // groupings (custom option ids are unknown to the static option table).
   const resolveGroupLabel = (key: string): string | undefined => {
     if (isStageGrouping()) {
       return dealStages.stageLabel(key) ?? getPropertyOptionLabel(key);
+    }
+    // Owner group keys are user ids — resolve to the display name.
+    if (isOwnerGrouping()) {
+      return idToDisplayName(key) || undefined;
     }
     return getPropertyOptionLabel(key);
   };
@@ -1113,6 +1136,8 @@ export const SoupViewContextProvider: FlowComponent<
     setInboxFilter,
     activeTab,
     setActiveTab,
+    viewMode,
+    setViewMode,
     readFilter,
     setReadFilter,
     groupByField,

--- a/apps/web/src/features/next-soup/soup-view/soup-view-tabs.tsx
+++ b/apps/web/src/features/next-soup/soup-view/soup-view-tabs.tsx
@@ -13,7 +13,10 @@ import {
 } from '@app/features/next-soup/sidebar/soup-filter-presets';
 import { useSoup } from '@app/features/next-soup/soup-context';
 import { MobileFilterDrawer } from '@app/features/next-soup/soup-view/filters-bar/mobile-filter-drawer';
-import { useSoupView } from '@app/features/next-soup/soup-view/soup-view-context';
+import {
+  type SoupViewMode,
+  useSoupView,
+} from '@app/features/next-soup/soup-view/soup-view-context';
 import { PillTabs } from '@components/app/mobile/PillTabs';
 import { useSplitPanelOrThrow } from '@components/app/split-layout/layoutUtils';
 import type { TabItem } from '@core/component/Tabs';
@@ -21,7 +24,7 @@ import { TabsInset } from '@core/component/TabsInset';
 import { TabsInsetDropdown } from '@core/component/TabsInsetDropdown';
 import { useUserContext } from '@core/context/user';
 import { useIsTeamAdmin } from '@queries/team/teams';
-import { batch, createMemo, For, Match, Switch } from 'solid-js';
+import { batch, createMemo, For, Match, Show, Switch } from 'solid-js';
 
 /** Views that have tab definitions. Shared between VIEW_TAB_LISTS and VIEW_TAB_PRESETS. */
 export type TabbedListView = Extract<
@@ -33,7 +36,6 @@ export type TabbedListView = Extract<
   | 'tasks'
   | 'channels'
   | 'calls'
-  | 'companies'
   | 'folders'
 >;
 
@@ -80,13 +82,6 @@ export const VIEW_TAB_LISTS: Record<TabbedListView, TabItem[]> = {
     { value: 'all', label: 'All' },
     { value: 'missed', label: 'Missed' },
     { value: 'unattended', label: 'Unattended' },
-  ],
-  companies: [
-    { value: 'active', label: 'Active' },
-    // The 'hidden' tab is gated to admin/owner team members — see
-    // `filterTabsForUser` below and the preset resolver in
-    // soup-filter-presets.ts.
-    { value: 'hidden', label: 'Hidden' },
   ],
   folders: [
     { value: 'owned', label: 'Owned' },
@@ -215,6 +210,9 @@ export const SoupViewTabs = () => {
 
   return (
     <Switch>
+      <Match when={listView() === 'companies'}>
+        <CompanyModeTabs />
+      </Match>
       <For each={Object.keys(VIEW_TAB_LISTS) as TabbedListView[]}>
         {(v) => (
           <Match when={listView() === v}>
@@ -226,28 +224,32 @@ export const SoupViewTabs = () => {
   );
 };
 
-/** Drops admin-only tabs for non-admin users (currently: companies → hidden). */
-function filterTabsForUser(
-  view: TabbedListView,
-  list: TabItem[],
-  isTeamAdmin: boolean
-): TabItem[] {
-  if (view === 'companies' && !isTeamAdmin) {
-    return list.filter((t) => t.value !== 'hidden');
-  }
-  return list;
-}
+/** The Customers view swaps filter tabs for a board/list mode switch. */
+const COMPANY_MODE_TABS: TabItem[] = [
+  { value: 'board', label: 'Board' },
+  { value: 'list', label: 'List' },
+];
+
+const CompanyModeTabs = () => {
+  const { viewMode, setViewMode } = useSoupView();
+
+  return (
+    <TabsInset
+      list={COMPANY_MODE_TABS}
+      value={viewMode()}
+      defaultValue="board"
+      onChange={(value) => setViewMode(value as SoupViewMode)}
+    />
+  );
+};
 
 const ViewTabs = (props: { view: TabbedListView }) => {
   const { applyTabPreset } = useApplyPreset();
   const { activeTab } = useSoupView();
-  const isTeamAdmin = useIsTeamAdmin();
-  const list = () =>
-    filterTabsForUser(props.view, VIEW_TAB_LISTS[props.view], isTeamAdmin());
 
   return (
     <TabsInset
-      list={list()}
+      list={VIEW_TAB_LISTS[props.view]}
       value={activeTab()}
       defaultValue={VIEW_TAB_PRESETS[props.view].default}
       onChange={(value) => applyTabPreset(props.view, value)}
@@ -259,8 +261,7 @@ const ViewTabs = (props: { view: TabbedListView }) => {
 export const CollapsedSoupViewTabs = () => {
   const listView = useCurrentListView();
   const { applyTabPreset } = useApplyPreset();
-  const { activeTab } = useSoupView();
-  const isTeamAdmin = useIsTeamAdmin();
+  const { activeTab, viewMode, setViewMode } = useSoupView();
 
   const view = createMemo(() => {
     const v = listView();
@@ -269,7 +270,7 @@ export const CollapsedSoupViewTabs = () => {
 
   const list = createMemo(() => {
     const v = view();
-    return v ? filterTabsForUser(v, VIEW_TAB_LISTS[v], isTeamAdmin()) : [];
+    return v ? VIEW_TAB_LISTS[v] : [];
   });
 
   const defaultValue = createMemo(() => {
@@ -278,17 +279,29 @@ export const CollapsedSoupViewTabs = () => {
   });
 
   return (
-    <TabsInsetDropdown
-      list={list()}
-      value={activeTab()}
-      defaultValue={defaultValue()}
-      onChange={(value) => {
-        const v = view();
-        if (v) {
-          applyTabPreset(v, value);
-        }
-      }}
-    />
+    <Show
+      when={listView() !== 'companies'}
+      fallback={
+        <TabsInsetDropdown
+          list={COMPANY_MODE_TABS}
+          value={viewMode()}
+          defaultValue="board"
+          onChange={(value) => setViewMode(value as SoupViewMode)}
+        />
+      }
+    >
+      <TabsInsetDropdown
+        list={list()}
+        value={activeTab()}
+        defaultValue={defaultValue()}
+        onChange={(value) => {
+          const v = view();
+          if (v) {
+            applyTabPreset(v, value);
+          }
+        }}
+      />
+    </Show>
   );
 };
 
@@ -299,6 +312,9 @@ export const MobileSoupViewTabs = () => {
     <div class="flex items-center px-(--mobile-chrome-gutter)">
       <MobileFilterDrawer />
       <Switch>
+        <Match when={listView() === 'companies'}>
+          <MobileCompanyModeTabs />
+        </Match>
         <For
           each={Object.keys(VIEW_TAB_LISTS) as (keyof typeof VIEW_TAB_LISTS)[]}
         >
@@ -313,18 +329,28 @@ export const MobileSoupViewTabs = () => {
   );
 };
 
+const MobileCompanyModeTabs = () => {
+  const { viewMode, setViewMode } = useSoupView();
+
+  return (
+    <PillTabs
+      class="pl-2"
+      items={COMPANY_MODE_TABS}
+      value={viewMode()}
+      onChange={(value) => setViewMode(value as SoupViewMode)}
+    />
+  );
+};
+
 const MobileViewTabs = (props: { view: TabbedListView }) => {
   const { applyTabPreset } = useApplyPreset();
   const { activeTab } = useSoupView();
-  const isTeamAdmin = useIsTeamAdmin();
-  const list = () =>
-    filterTabsForUser(props.view, VIEW_TAB_LISTS[props.view], isTeamAdmin());
   const activeValue = () => activeTab() ?? VIEW_TAB_PRESETS[props.view].default;
 
   return (
     <PillTabs
       class="pl-2"
-      items={list()}
+      items={VIEW_TAB_LISTS[props.view]}
       value={activeValue()}
       onChange={(value) => applyTabPreset(props.view, value)}
     />

--- a/apps/web/src/features/next-soup/soup-view/soup-view.tsx
+++ b/apps/web/src/features/next-soup/soup-view/soup-view.tsx
@@ -80,7 +80,6 @@ import {
   SplitHeaderRight,
 } from '@components/app/split-layout/components/SplitHeader';
 import { SplitPanelContext } from '@components/app/split-layout/context';
-import { useEntryState } from '@components/app/split-layout/entry-state';
 import { useSplitPanelOrThrow } from '@components/app/split-layout/layoutUtils';
 import { CustomScrollbar } from '@core/component/CustomScrollbar';
 import { StaticMarkdownContext } from '@core/component/LexicalMarkdown/component/core/StaticMarkdown';
@@ -111,8 +110,6 @@ import CaretDownIcon from '@phosphor/caret-down.svg';
 import ChevronRightIcon from '@phosphor/caret-right.svg';
 import CheckIcon from '@phosphor/check.svg';
 import InfoIcon from '@phosphor/info.svg';
-import KanbanIcon from '@phosphor/kanban.svg';
-import ListIcon from '@phosphor/list.svg';
 import Spinner from '@phosphor/spinner.svg';
 import { useQueryClient } from '@queries/client';
 import { emailKeys } from '@queries/email/keys';
@@ -340,47 +337,6 @@ interface SoupViewProps {
   initialCrmView?: CrmViewConfig;
 }
 
-type SoupViewMode = 'list' | 'board';
-
-/** Segmented list/board toggle shown in the topbar of the Customers view. */
-const SoupViewModeToggle = (props: {
-  mode: SoupViewMode;
-  onChange: (mode: SoupViewMode) => void;
-}) => {
-  return (
-    <div class="flex items-center gap-0.5 rounded-lg border border-edge-muted bg-surface p-0.5">
-      <Tooltip label="List">
-        <Button
-          variant="ghost"
-          size="icon-sm"
-          label="List view"
-          class={cn(
-            'size-6 rounded-md p-1',
-            props.mode === 'list' && 'bg-active text-ink'
-          )}
-          onClick={() => props.onChange('list')}
-        >
-          <ListIcon class="size-3.5" />
-        </Button>
-      </Tooltip>
-      <Tooltip label="Board">
-        <Button
-          variant="ghost"
-          size="icon-sm"
-          label="Board view"
-          class={cn(
-            'size-6 rounded-md p-1',
-            props.mode === 'board' && 'bg-active text-ink'
-          )}
-          onClick={() => props.onChange('board')}
-        >
-          <KanbanIcon class="size-3.5" />
-        </Button>
-      </Tooltip>
-    </div>
-  );
-};
-
 export const SoupView = (props: SoupViewProps) => {
   const soup = useSoup();
   const panel = useSplitPanelOrThrow();
@@ -437,14 +393,6 @@ export const SoupView = (props: SoupViewProps) => {
     `macro:pref:soup:${contentId}:sort`,
     { default: [] }
   );
-
-  // List/board display mode — currently only the Customers view offers a
-  // board (kanban grouped by Stage). Per-entry state so back/forward
-  // restores the mode the user left each entry with. Declared before the
-  // init effect below so a shared CRM view can set it during init.
-  const [viewMode, setViewMode] = useEntryState<SoupViewMode>('soup.viewMode', {
-    default: 'list',
-  });
 
   // Shared CRM view opened via a `?crmView=` link — only honored on the
   // Customers view; its pieces win over persisted/preset values in init.
@@ -530,7 +478,7 @@ export const SoupView = (props: SoupViewProps) => {
         if (owners.length > 0 !== soup.predicates.isActive('company-owner')) {
           soup.predicates.toggle({ and: ['company-owner'] });
         }
-        setViewMode(initialCrmView.viewMode ?? 'list');
+        soupView.setViewMode(initialCrmView.viewMode ?? 'board');
       }
     });
   });
@@ -613,7 +561,7 @@ export const SoupView = (props: SoupViewProps) => {
   });
 
   const isBoardMode = createMemo(
-    () => activeListView() === 'companies' && viewMode() === 'board'
+    () => activeListView() === 'companies' && soupView.viewMode() === 'board'
   );
 
   const [narrowSearchExpanded, setNarrowSearchExpanded] = createSignal(false);
@@ -719,12 +667,8 @@ export const SoupView = (props: SoupViewProps) => {
                   !narrowSearchExpanded() && isComponentListView('companies')
                 }
               >
-                <CompanyViewsMenu
-                  viewMode={viewMode()}
-                  setViewMode={setViewMode}
-                />
+                <CompanyViewsMenu />
                 <CompanyDisplayMenu />
-                <SoupViewModeToggle mode={viewMode()} onChange={setViewMode} />
               </Show>
               <Show
                 when={!narrowSearchExpanded() && !isComponentListView('search')}

--- a/apps/web/src/features/next-soup/soup-view/views/companies/CompanyKanban.tsx
+++ b/apps/web/src/features/next-soup/soup-view/views/companies/CompanyKanban.tsx
@@ -1,11 +1,9 @@
+import { NO_STAGE } from '@app/features/next-soup/filters/configs/';
+import { SoupEntityContextMenu } from '@app/features/next-soup/soup-view/soup-entity-context-menu';
 import { useSoupView } from '@app/features/next-soup/soup-view/soup-view-context';
 import { usePreviewPaneVisiblity } from '@app/features/next-soup/soup-view/use-preview-pane-visibility';
 import { openEntityInSplitFromUnifiedList } from '@app/features/next-soup/utils';
 import { useDealStages } from '@companies/crm/deal-stages';
-import {
-  type CrmDisplayOptions,
-  useCrmDisplayOptions,
-} from '@companies/crm/display-options';
 import { CrmStageIcon } from '@companies/crm/StageIcon';
 import {
   useClosedStageIds,
@@ -14,6 +12,7 @@ import {
 import { useGlobalBlockOrchestrator } from '@components/app/GlobalAppState';
 import { PreviewPanel } from '@components/app/PreviewPanel';
 import { useSplitPanelOrThrow } from '@components/app/split-layout/layoutUtils';
+import { CustomScrollbar } from '@core/component/CustomScrollbar';
 import { Resize } from '@core/component/Resize';
 import { UserIcon } from '@core/component/UserIcon';
 import EmptyStatePreviewIcon from '@design/empty-state-doc.svg';
@@ -51,7 +50,7 @@ type StageColumn = {
  * previews the company to the side instead of replacing the split.
  */
 export function CompanyKanban() {
-  const { source, soup } = useSoupView();
+  const { source, soup, stageFilter } = useSoupView();
   const panel = useSplitPanelOrThrow();
   const saveMutation = useBulkSaveEntityPropertiesMutation();
   const orchestrator = useGlobalBlockOrchestrator();
@@ -59,14 +58,20 @@ export function CompanyKanban() {
   const { stages, stageProperty, resolveStage } = useDealStages();
   const { canEditCrm, canMoveClosedDeals } = useCrmPermissions();
   const closedStageIds = useClosedStageIds(stages);
-  // Personal display options gate which fields render on cards; read once
-  // here and passed down rather than per-card.
-  const displayOptions = useCrmDisplayOptions();
 
-  const stageColumns = createMemo((): StageColumn[] => [
-    ...stages().map((stage) => ({ key: stage.id, label: stage.label })),
-    { key: NO_STAGE_KEY, label: 'No stage' },
-  ]);
+  const stageColumns = createMemo((): StageColumn[] => {
+    const all: StageColumn[] = [
+      ...stages().map((stage) => ({ key: stage.id, label: stage.label })),
+      { key: NO_STAGE_KEY, label: 'No stage' },
+    ];
+    // An active stage filter removes the filtered-out columns entirely,
+    // not just their (already predicate-filtered) cards.
+    const filter = stageFilter();
+    if (filter.length === 0) return all;
+    return all.filter((column) =>
+      filter.includes(column.key === NO_STAGE_KEY ? NO_STAGE : column.key)
+    );
+  });
 
   const { paneVisible, selectedEntity } = usePreviewPaneVisiblity();
 
@@ -96,6 +101,7 @@ export function CompanyKanban() {
 
   const [draggedId, setDraggedId] = createSignal<string>();
   const [dropTarget, setDropTarget] = createSignal<string>();
+  const [scrollRef, setScrollRef] = createSignal<HTMLDivElement>();
 
   const moveToStage = (entityId: string, stageKey: string) => {
     const entity = companies().find((company) => company.id === entityId);
@@ -138,91 +144,110 @@ export function CompanyKanban() {
   return (
     <Resize.Zone direction="horizontal" gutter={0}>
       <Resize.Panel id="company-kanban" minSize={200}>
+        {/* Relative wrapper anchors the horizontal scrollbar to the board's
+            bottom edge when the split is too narrow for all columns. */}
         <div
           class={cn(
-            'size-full min-w-0 overflow-x-auto overflow-y-hidden',
+            'relative size-full min-w-0',
             paneVisible() && 'border-r border-edge-muted'
           )}
         >
-          <div class="flex h-full gap-3 p-3">
-            <For each={columns()}>
-              {(column, columnIndex) => (
-                <div
-                  class={cn(
-                    'flex h-full w-64 shrink-0 flex-col rounded-lg border border-edge-muted bg-surface',
-                    dropTarget() === column.key &&
-                      draggedId() &&
-                      'border-accent/50 bg-accent/5'
-                  )}
-                  onDragOver={(e) => {
-                    if (!draggedId()) return;
-                    e.preventDefault();
-                    setDropTarget(column.key);
-                  }}
-                  onDragLeave={(e) => {
-                    if (
-                      e.relatedTarget instanceof Node &&
-                      e.currentTarget.contains(e.relatedTarget)
-                    ) {
-                      return;
-                    }
-                    if (dropTarget() === column.key) setDropTarget(undefined);
-                  }}
-                  onDrop={(e) => {
-                    e.preventDefault();
-                    const id =
-                      draggedId() ?? e.dataTransfer?.getData('text/plain');
-                    setDropTarget(undefined);
-                    setDraggedId(undefined);
-                    if (id) moveToStage(id, column.key);
-                  }}
-                >
-                  <div class="flex items-center gap-2 px-3 py-2.5 text-xs font-semibold text-ink-muted">
-                    <Show
-                      when={column.key !== NO_STAGE_KEY}
-                      fallback={
-                        <CircleDashed class="size-3.5 text-ink-extra-muted" />
+          <div
+            ref={setScrollRef}
+            class="size-full overflow-x-auto overflow-y-hidden scrollbar-hidden"
+          >
+            <div class="flex h-full gap-3 p-3">
+              <For each={columns()}>
+                {(column, columnIndex) => (
+                  <div
+                    class={cn(
+                      // Columns split the available width evenly, but never
+                      // shrink below w-64 — past that the board scrolls.
+                      'flex h-full min-w-64 flex-1 flex-col rounded-lg border border-edge-muted bg-surface',
+                      dropTarget() === column.key &&
+                        draggedId() &&
+                        'border-accent/50 bg-accent/5'
+                    )}
+                    onDragOver={(e) => {
+                      if (!draggedId()) return;
+                      e.preventDefault();
+                      setDropTarget(column.key);
+                    }}
+                    onDragLeave={(e) => {
+                      if (
+                        e.relatedTarget instanceof Node &&
+                        e.currentTarget.contains(e.relatedTarget)
+                      ) {
+                        return;
                       }
-                    >
-                      <CrmStageIcon
-                        optionId={column.key}
-                        index={columnIndex()}
-                        class="size-3.5"
-                      />
-                    </Show>
-                    <span class="truncate">{column.label}</span>
-                    <span class="ml-auto shrink-0 tabular-nums px-1.5 py-px rounded-full bg-ink/10 text-ink-extra-muted font-medium">
-                      {column.entities.length}
-                    </span>
-                  </div>
-                  <div class="min-h-0 flex-1 overflow-y-auto scrollbar-hidden flex flex-col gap-2 px-2 pb-2">
-                    <For each={column.entities}>
-                      {(entity) => (
-                        <CompanyKanbanCard
-                          entity={entity}
-                          fields={displayOptions.options().kanbanFields}
-                          draggable={canDragFrom(column.key)}
-                          dragging={draggedId() === entity.id}
-                          onDragStart={(e) => {
-                            e.dataTransfer?.setData('text/plain', entity.id);
-                            if (e.dataTransfer) {
-                              e.dataTransfer.effectAllowed = 'move';
-                            }
-                            setDraggedId(entity.id);
-                          }}
-                          onDragEnd={() => {
-                            setDraggedId(undefined);
-                            setDropTarget(undefined);
-                          }}
-                          onClick={(e) => openCompany(entity, e)}
+                      if (dropTarget() === column.key) setDropTarget(undefined);
+                    }}
+                    onDrop={(e) => {
+                      e.preventDefault();
+                      const id =
+                        draggedId() ?? e.dataTransfer?.getData('text/plain');
+                      setDropTarget(undefined);
+                      setDraggedId(undefined);
+                      if (id) moveToStage(id, column.key);
+                    }}
+                  >
+                    <div class="flex items-center gap-2 px-3 py-2.5 text-xs font-semibold text-ink-muted">
+                      <Show
+                        when={column.key !== NO_STAGE_KEY}
+                        fallback={
+                          <CircleDashed class="size-3.5 text-ink-extra-muted" />
+                        }
+                      >
+                        <CrmStageIcon
+                          optionId={column.key}
+                          index={columnIndex()}
+                          class="size-3.5"
                         />
-                      )}
-                    </For>
+                      </Show>
+                      <span class="truncate">{column.label}</span>
+                      <span class="ml-auto shrink-0 tabular-nums px-1.5 py-px rounded-full bg-ink/10 text-ink-extra-muted font-medium">
+                        {column.entities.length}
+                      </span>
+                    </div>
+                    <div class="min-h-0 flex-1 overflow-y-auto scrollbar-hidden flex flex-col gap-2 px-2 pb-2">
+                      <For each={column.entities}>
+                        {(entity) => (
+                          // The context-menu trigger is h-full (sized for list
+                          // rows); an auto-height wrapper resolves that to the
+                          // card's content height instead of the column's.
+                          <div class="shrink-0">
+                            <SoupEntityContextMenu entity={entity}>
+                              <CompanyKanbanCard
+                                entity={entity}
+                                draggable={canDragFrom(column.key)}
+                                dragging={draggedId() === entity.id}
+                                onDragStart={(e) => {
+                                  e.dataTransfer?.setData(
+                                    'text/plain',
+                                    entity.id
+                                  );
+                                  if (e.dataTransfer) {
+                                    e.dataTransfer.effectAllowed = 'move';
+                                  }
+                                  setDraggedId(entity.id);
+                                }}
+                                onDragEnd={() => {
+                                  setDraggedId(undefined);
+                                  setDropTarget(undefined);
+                                }}
+                                onClick={(e) => openCompany(entity, e)}
+                              />
+                            </SoupEntityContextMenu>
+                          </div>
+                        )}
+                      </For>
+                    </div>
                   </div>
-                </div>
-              )}
-            </For>
+                )}
+              </For>
+            </div>
           </div>
+          <CustomScrollbar scrollContainer={scrollRef} horizontal />
         </div>
       </Resize.Panel>
       <Show when={paneVisible()}>
@@ -258,8 +283,6 @@ export function CompanyKanban() {
 
 function CompanyKanbanCard(props: {
   entity: EntityData;
-  /** Which optional card fields render (personal display options). */
-  fields: CrmDisplayOptions['kanbanFields'];
   draggable: boolean;
   dragging: boolean;
   onDragStart: (e: DragEvent) => void;
@@ -284,7 +307,7 @@ function CompanyKanbanCard(props: {
         onClick={props.onClick}
         class={cn(
           'flex flex-col gap-1.5 rounded-lg border border-edge-muted bg-panel p-2.5 text-sm',
-          'hover:border-edge transition-colors',
+          'hover:border-edge hover:bg-active transition-colors',
           props.dragging && 'opacity-40'
         )}
       >
@@ -295,7 +318,7 @@ function CompanyKanbanCard(props: {
           <span class="ph-no-capture truncate font-semibold min-w-0">
             <Entity.Title entity={props.entity} />
           </span>
-          <Show when={props.fields.owner && ownerId()}>
+          <Show when={ownerId()}>
             {(id) => (
               <span class="ml-auto shrink-0">
                 <UserIcon id={id()} size="sm" suppressClick />
@@ -303,19 +326,17 @@ function CompanyKanbanCard(props: {
             )}
           </Show>
         </div>
-        <Show when={props.fields.domain || props.fields.lastInteraction}>
-          <div class="flex items-center gap-2 min-w-0 text-xs text-ink-extra-muted">
-            <Show when={props.fields.domain && primaryDomain()}>
-              {(domain) => <span class="truncate min-w-0">{domain()}</span>}
-            </Show>
-            {/* Last interaction — updatedAt carries crm_companies.last_interaction. */}
-            <Show when={props.fields.lastInteraction && props.entity.updatedAt}>
-              {(ts) => (
-                <span class="ml-auto shrink-0">{formatTimestamp(ts())}</span>
-              )}
-            </Show>
-          </div>
-        </Show>
+        <div class="flex items-center gap-2 min-w-0 text-xs text-ink-extra-muted">
+          <Show when={primaryDomain()}>
+            {(domain) => <span class="truncate min-w-0">{domain()}</span>}
+          </Show>
+          {/* Last interaction — updatedAt carries crm_companies.last_interaction. */}
+          <Show when={props.entity.updatedAt}>
+            {(ts) => (
+              <span class="ml-auto shrink-0">{formatTimestamp(ts())}</span>
+            )}
+          </Show>
+        </div>
       </div>
     </Layer>
   );

--- a/apps/web/src/features/next-soup/soup-view/views/companies/CompanyViewsMenu.tsx
+++ b/apps/web/src/features/next-soup/soup-view/views/companies/CompanyViewsMenu.tsx
@@ -1,9 +1,8 @@
 import type { Query } from '@app/features/next-soup/filters/filter-store';
 import { useSoupView } from '@app/features/next-soup/soup-view/soup-view-context';
+import { useApplyPreset } from '@app/features/next-soup/soup-view/soup-view-tabs';
 import {
-  CRM_KANBAN_FIELD_LABELS,
   CRM_LIST_COLUMN_LABELS,
-  type CrmKanbanFieldId,
   type CrmListColumnId,
   useCrmDisplayOptions,
 } from '@companies/crm/display-options';
@@ -21,11 +20,10 @@ import LinkIcon from '@phosphor/link.svg';
 import SlidersIcon from '@phosphor/sliders-horizontal.svg';
 import StackIcon from '@phosphor/stack.svg';
 import TrashIcon from '@phosphor/trash.svg';
+import { useIsTeamAdmin } from '@queries/team/teams';
 import { Button, cn, Dropdown, SegmentedControl, Tooltip } from '@ui';
 import { batch, createSignal, For, type JSX, Show } from 'solid-js';
 import { unwrap } from 'solid-js/store';
-
-type SoupViewMode = 'list' | 'board';
 
 /** Copy a view's share link, with a toast either way. */
 const copyShareLink = (config: CrmViewConfig) => {
@@ -92,10 +90,7 @@ const EmptyViewsHint = (props: { children: JSX.Element }) => (
  * list/board mode, stage/owner sub-filters, tab), plus share links that
  * encode the same state into the URL (see `@companies/crm/saved-views`).
  */
-export function CompanyViewsMenu(props: {
-  viewMode: SoupViewMode;
-  setViewMode: (mode: SoupViewMode) => void;
-}) {
+export function CompanyViewsMenu() {
   const {
     soup,
     queryFilters,
@@ -107,6 +102,8 @@ export function CompanyViewsMenu(props: {
     setOwnerFilter,
     activeTab,
     setActiveTab,
+    viewMode,
+    setViewMode,
   } = useSoupView();
   const personal = usePersonalCrmViews();
   const team = useTeamCrmViews();
@@ -131,7 +128,7 @@ export function CompanyViewsMenu(props: {
     searchText: searchText(),
     groupBy: soup.grouping.activeGroupId() ?? null,
     sort: soup.sort.active().map((s) => s.id),
-    viewMode: props.viewMode,
+    viewMode: viewMode(),
     stageFilter: [...stageFilter()],
     ownerFilter: [...ownerFilter()],
     activeTab: activeTab(),
@@ -164,7 +161,7 @@ export function CompanyViewsMenu(props: {
       if (owners.length > 0 !== soup.predicates.isActive('company-owner')) {
         soup.predicates.toggle({ and: ['company-owner'] });
       }
-      props.setViewMode(config.viewMode ?? 'list');
+      setViewMode(config.viewMode ?? 'board');
       if (config.activeTab !== undefined) setActiveTab(config.activeTab);
     });
     setOpen(false);
@@ -310,12 +307,17 @@ export function CompanyViewsMenu(props: {
 
 /**
  * Personal display options for the Customers view: which property columns
- * show in the list and which fields show on board cards. Device-level
- * (preference-backed) — deliberately not captured by saved views.
+ * show in the list. Device-level (preference-backed) — deliberately not
+ * captured by saved views. Admins/owners additionally get a toggle to view
+ * the hidden-companies set (backed by the active/hidden tab presets).
  */
 export function CompanyDisplayMenu() {
-  const { options, toggleListColumn, toggleKanbanField } =
-    useCrmDisplayOptions();
+  const { options, toggleListColumn } = useCrmDisplayOptions();
+  const { activeTab } = useSoupView();
+  const { applyTabPreset } = useApplyPreset();
+  const isTeamAdmin = useIsTeamAdmin();
+
+  const showingHidden = () => activeTab() === 'hidden';
 
   return (
     <Dropdown>
@@ -342,24 +344,24 @@ export function CompanyDisplayMenu() {
             )}
           </For>
         </Dropdown.Group>
-        <Dropdown.Group>
-          <Dropdown.GroupLabel>Board card fields</Dropdown.GroupLabel>
-          <For
-            each={Object.keys(CRM_KANBAN_FIELD_LABELS) as CrmKanbanFieldId[]}
-          >
-            {(field) => (
-              <Dropdown.CheckboxItem
-                checked={options().kanbanFields[field]}
-                onChange={() => toggleKanbanField(field)}
-                closeOnSelect={false}
-              >
-                <span class="flex-1 truncate">
-                  {CRM_KANBAN_FIELD_LABELS[field]}
-                </span>
-              </Dropdown.CheckboxItem>
-            )}
-          </For>
-        </Dropdown.Group>
+        {/* Admin/owner only — the BE rejects hidden-set requests from
+            non-admins, matching the old Hidden tab's gating. */}
+        <Show when={isTeamAdmin()}>
+          <Dropdown.Group>
+            <Dropdown.CheckboxItem
+              checked={showingHidden()}
+              onChange={() =>
+                applyTabPreset(
+                  'companies',
+                  showingHidden() ? 'active' : 'hidden'
+                )
+              }
+              closeOnSelect={false}
+            >
+              <span class="flex-1 truncate">Show hidden companies</span>
+            </Dropdown.CheckboxItem>
+          </Dropdown.Group>
+        </Show>
       </Dropdown.Content>
     </Dropdown>
   );

--- a/apps/web/src/features/property/editor/PropertyEditorModal.tsx
+++ b/apps/web/src/features/property/editor/PropertyEditorModal.tsx
@@ -1,5 +1,7 @@
 import { toast } from '@core/component/Toast/Toast';
 import { registerHotkey, useHotkeyDOMScope } from '@core/hotkey/hotkeys';
+import type { IUser } from '@core/user';
+import { idToDisplayName, idToEmail } from '@core/user/util';
 import { useDateSearch } from '@core/util/dateSearch/useDateSearch';
 import { fuzzyFilter } from '@core/util/fuzzy';
 import { useIsKeyPressActive } from '@core/util/useIsKeyPressActive';
@@ -10,6 +12,7 @@ import {
 import { type EntityData, InlineEntity } from '@entity';
 import { type CombinedEntity, getEntityName, getEntityType } from '@property';
 import { PropertyValueIcon } from '@property/component/propertyValue';
+import { SYSTEM_PROPERTY_IDS } from '@property/constants';
 import { usePropertySelection } from '@property/hooks';
 import { usePropertyEntityDisplay } from '@property/hooks/usePropertyEntityDisplay';
 import type {
@@ -23,6 +26,7 @@ import {
   toPropertyApiValue,
 } from '@property/utils';
 import { useEntityPropertiesQuery } from '@queries/properties/entity';
+import { useCurrentTeamQuery } from '@queries/team/teams';
 import type { EntityReference } from '@service-properties/generated/schemas/entityReference';
 import { mergeRefs } from '@solid-primitives/refs';
 import { cn, Dialog, Hotkey, Surface } from '@ui';
@@ -527,9 +531,30 @@ function EntityPropertyEditor(props: {
   setKeybindings: (binding: ListNavActions) => void;
   setPlaceholder: Setter<string>;
 }) {
+  // Company owners are always teammates, so the owner picker offers the
+  // team roster instead of the default quick-access people pool (same as
+  // the row-cell owner editor in EntityEditor).
+  const isCompanyOwner = () => {
+    const property = props.property;
+    if (!property) return false;
+    const definitionId =
+      'propertyDefinitionId' in property
+        ? property.propertyDefinitionId
+        : property.id;
+    return definitionId === SYSTEM_PROPERTY_IDS.COMPANY_OWNER;
+  };
+  const teamQuery = useCurrentTeamQuery();
+  const teamMembers = (): IUser[] =>
+    (teamQuery.data?.members ?? []).map((member) => ({
+      id: member.user_id,
+      email: idToEmail(member.user_id),
+      name: idToDisplayName(member.user_id),
+    }));
+
   const { entities } = useEntitiesForProperty(
     () => props.property,
-    props.searchValue
+    props.searchValue,
+    { users: () => (isCompanyOwner() ? teamMembers() : undefined) }
   );
 
   createEffect(() => {

--- a/apps/web/src/features/property/editor/hooks/useEntitiesForProperty.ts
+++ b/apps/web/src/features/property/editor/hooks/useEntitiesForProperty.ts
@@ -1,5 +1,5 @@
 import { useEmail, useUserId } from '@core/context/user';
-import { useAugmentUserWithDmActivity } from '@core/user';
+import { type IUser, useAugmentUserWithDmActivity } from '@core/user';
 import { createFreshSearch } from '@core/util/freshSort';
 import type { EmailEntity } from '@entity';
 import { createEmailsInfiniteQuery } from '@entity';
@@ -28,7 +28,12 @@ import {
 
 export function useEntitiesForProperty(
   property: Accessor<Property | PropertyDefinitionDomain | undefined>,
-  searchQuery: Accessor<string>
+  searchQuery: Accessor<string>,
+  options?: {
+    /** Explicit pool for USER pickers (e.g. company owner → team members);
+     * when it returns a list, it replaces the quick-access people list. */
+    users?: Accessor<IUser[] | undefined>;
+  }
 ) {
   const [searchTerm, setSearchTerm] = createSignal('');
 
@@ -93,6 +98,16 @@ export function useEntitiesForProperty(
   // Convert quickAccess items to CombinedEntity format
   const entities = createMemo((): CombinedEntity[] => {
     const entityType = specificEntityType();
+
+    // An explicit user pool replaces the quick-access people list.
+    if (entityType === 'USER') {
+      const pool = options?.users?.();
+      if (pool) {
+        return pool.map((user) =>
+          userToEntity(augmentUserWithDmActivity(user))
+        );
+      }
+    }
 
     // For THREAD type, use email data (not in quickAccess yet)
     if (entityType === 'THREAD') {

--- a/apps/web/src/features/property/editors/popover/EntityEditor.tsx
+++ b/apps/web/src/features/property/editors/popover/EntityEditor.tsx
@@ -1,7 +1,11 @@
+import type { IUser } from '@core/user';
+import { idToDisplayName, idToEmail } from '@core/user/util';
+import { SYSTEM_PROPERTY_IDS } from '@property/constants';
 import {
   entityReferencesToIdSet,
   updateEntityReferences,
 } from '@property/utils/entityConversion';
+import { useCurrentTeamQuery } from '@queries/team/teams';
 import type { EntityReference } from '@service-properties/generated/schemas/entityReference';
 import type { EntityType } from '@service-properties/generated/schemas/entityType';
 import { createSignal, Show, Suspense } from 'solid-js';
@@ -36,6 +40,18 @@ export function EntityEditor(props: EntityEditorProps) {
 function EntityEditorBody(props: EntityEditorProps) {
   const ctx = useProperty();
   const property = ctx.property() as EntityProperty;
+
+  // Company owners are always teammates, so the owner picker offers the
+  // team roster instead of the default quick-access people pool.
+  const isCompanyOwner =
+    property.propertyDefinitionId === SYSTEM_PROPERTY_IDS.COMPANY_OWNER;
+  const teamQuery = useCurrentTeamQuery();
+  const teamMembers = (): IUser[] =>
+    (teamQuery.data?.members ?? []).map((member) => ({
+      id: member.user_id,
+      email: idToEmail(member.user_id),
+      name: idToDisplayName(member.user_id),
+    }));
 
   const initialRefs: EntityReference[] = property.value ?? [];
   const [selectedRefs, setSelectedRefs] =
@@ -83,6 +99,7 @@ function EntityEditorBody(props: EntityEditorProps) {
             placeholder: `${property.isMultiSelect ? 'Add' : 'Change'} ${property.displayName.toLowerCase()}...`,
             specificEntityType: property.specificEntityType,
             selfFilter: props.selfFilter,
+            users: isCompanyOwner ? teamMembers : undefined,
           }}
           selectedOptions={() => entityReferencesToIdSet(selectedRefs())}
           setSelectedOptions={(newOptions, entityInfo) => {

--- a/apps/web/src/features/property/editors/selectors/PropertyEntitySelector.tsx
+++ b/apps/web/src/features/property/editors/selectors/PropertyEntitySelector.tsx
@@ -189,6 +189,13 @@ export function PropertyEntitySelector(props: EntityInputProps) {
   const entities = createMemo((): CombinedEntity[] => {
     const specificEntityType = props.config.specificEntityType;
 
+    // An explicit user pool replaces the quick-access people list.
+    if (specificEntityType === 'USER' && props.config.users) {
+      return props.config
+        .users()
+        .map((user) => userToEntity(augmentUserWithDmActivity(user)));
+    }
+
     // For THREAD type, use email data (not in quickAccess yet)
     if (specificEntityType === 'THREAD') {
       return emails().map(threadMapper);

--- a/apps/web/src/features/property/editors/selectors/types.ts
+++ b/apps/web/src/features/property/editors/selectors/types.ts
@@ -1,5 +1,6 @@
+import type { IUser } from '@core/user';
 import type { EntityType } from '@service-properties/generated/schemas/entityType';
-import type { JSX } from 'solid-js';
+import type { Accessor, JSX } from 'solid-js';
 
 export type SelectableOption = { id: string; label: string };
 
@@ -17,4 +18,7 @@ export type EntitySelectorConfig = {
   placeholder: string;
   specificEntityType?: EntityType | null;
   selfFilter?: { entityType: EntityType; blockId?: string };
+  /** Explicit pool for USER pickers (e.g. company owner → team members);
+   * replaces the default quick-access people list. */
+  users?: Accessor<IUser[]>;
 };

--- a/apps/web/src/lib/core/component/CustomScrollbar.tsx
+++ b/apps/web/src/lib/core/component/CustomScrollbar.tsx
@@ -17,8 +17,9 @@ interface CustomScrollbarProps {
 const MIN_THUMB_SIZE = 24;
 const GUTTER_SIZE = 8;
 const THUMB_INSET = 3;
-const THUMB_THICKNESS = 2;
-const EDGE_INSET = 3;
+const THUMB_THICKNESS = 4;
+// Centers the thumb in the gutter: (GUTTER_SIZE - THUMB_THICKNESS) / 2.
+const EDGE_INSET = 2;
 
 export function CustomScrollbar(props: CustomScrollbarProps) {
   return (
@@ -36,6 +37,7 @@ function InnerCustomScrollbar(props: CustomScrollbarProps) {
   const [clientSize, setClientSize] = createSignal(0);
   const [isDragging, setIsDragging] = createSignal(false);
   const [isScrolling, setIsScrolling] = createSignal(false);
+  const [isHovered, setIsHovered] = createSignal(false);
 
   const [scrollLabelVisible, setScrollLabelVisible] = createSignal(
     props.labelVisibilityDebounceMs === Infinity
@@ -183,6 +185,8 @@ function InnerCustomScrollbar(props: CustomScrollbarProps) {
         onPointerMove={handlePointerMove}
         onPointerUp={handlePointerUp}
         onPointerCancel={handlePointerUp}
+        onPointerEnter={() => setIsHovered(true)}
+        onPointerLeave={() => setIsHovered(false)}
         aria-hidden="true"
       >
         {/* Thumb */}
@@ -197,9 +201,9 @@ function InnerCustomScrollbar(props: CustomScrollbarProps) {
                   bottom: `${EDGE_INSET}px`,
                   left: '0',
                   'background-color': 'var(--c4)',
-                  'border-radius': '1px',
+                  'border-radius': '2px',
                   'pointer-events': 'none',
-                  opacity: isDragging() || isScrolling() ? 1 : 0,
+                  opacity: isDragging() || isScrolling() || isHovered() ? 1 : 0,
                   transition: 'opacity 150ms ease-in-out',
                 }
               : {
@@ -209,9 +213,9 @@ function InnerCustomScrollbar(props: CustomScrollbarProps) {
                   right: `${EDGE_INSET}px`,
                   top: '0',
                   'background-color': 'var(--c4)',
-                  'border-radius': '1px',
+                  'border-radius': '2px',
                   'pointer-events': 'none',
-                  opacity: isDragging() || isScrolling() ? 1 : 0,
+                  opacity: isDragging() || isScrolling() || isHovered() ? 1 : 0,
                   transition: 'opacity 150ms ease-in-out',
                 }
           }

--- a/apps/web/src/lib/core/hotkey/tokens.ts
+++ b/apps/web/src/lib/core/hotkey/tokens.ts
@@ -59,6 +59,9 @@ export const TOKENS = {
       priority: 'entity.action.priority',
       status: 'entity.action.status',
       assignee: 'entity.action.assignee',
+      stage: 'entity.action.stage',
+      owner: 'entity.action.owner',
+      revenue: 'entity.action.revenue',
     },
   },
 


### PR DESCRIPTION
Overhauls the CRM Customers view around the board, scopes all owner pickers to the team roster, and brings company property editing into the entity action surfaces (right-click, cmd-K, mobile drawer).

## Top bar & view settings

- **List/Board tabs replace the Active/Hidden tabs** in the top bar. The mode switch renders as the standard segmented tabs (with collapsed-dropdown and mobile pill variants) and drives the same `viewMode` state the old icon toggle did; the old List/Board icon buttons next to the display menu are removed.
- **Board is the default view mode** and is listed first in the tabs. Saved views / share links that predate the `viewMode` field also fall back to board.
- **Active/Hidden moved into the view-settings (display options) dropdown** as a "Show hidden companies" checkbox, gated to team admins/owners exactly like the old Hidden tab (non-admins don't see it; the backend independently rejects hidden-set queries). It toggles between the same `active`/`hidden` tab presets, so filters/grouping behavior is unchanged.
- **Removed the "Board card fields" section** from the display options menu; kanban cards now always render owner, domain, and last interaction. The `kanbanFields` display option is deleted.
- **The Group button hides in board mode** — the board is inherently grouped by stage columns. Grouping state is preserved when switching back to the list.
- `viewMode` moved from a `SoupView`-local signal into `SoupViewContext` (still per-entry state, so back/forward restores it), since the tabs, views menu, and kanban all need it.

## Board (kanban) improvements

- **Right-clicking a card opens the same context menu as list rows** (`SoupEntityContextMenu` now wraps each card), including the mobile long-press drawer. Cards get a `shrink-0` auto-height wrapper so the trigger's `h-full` sizing doesn't stretch card spacing.
- **Stage-filtered columns are removed entirely** instead of remaining as empty shells (the "No stage" column maps to the `NO_STAGE` sentinel).
- **Columns flex to fill the board width** (`min-w-64 flex-1`): removing a column widens the rest; below 16rem per column the board falls back to horizontal scrolling.
- **Horizontal scrollbar at the bottom of the board** when columns overflow (narrow split / preview pane open), using the shared `CustomScrollbar`.
- **Cards darken on hover** (`hover:bg-active`), matching how list rows highlight.

## Company property editing from action menus

- New **Set stage / Set owner / Set revenue** actions for `crm_company` rows, available from the right-click menu, the cmd-K entity-action mode, and the mobile action drawer. They open the existing global `PropertyEditorModal` (the same flow as task status/priority/assignee), support multi-selection, and are gated to team admins/owners.
- Stage resolves through the active deal-stage set (`useDealStages().stageProperty()`), so edits write to the team's custom Stage definition when one exists.
- New `entity.action.{stage,owner,revenue}` hotkey tokens; the commands are cmd-K-only (no keybindings).

## Owner pickers scoped to team members

Company owners are always teammates, so every owner surface now offers the team roster (`useCurrentTeamQuery().data.members`, names via the display-name cache) instead of the contacts service (everyone ever interacted with):

- The **Owner filter** in the filters bar (sorted alphabetically, "Me" pinned first).
- The **owner cell editor** (list row pills, kanban, company page) — `EntitySelectorConfig` gained an optional `users` pool that replaces the quick-access people list in `PropertyEntitySelector` for USER pickers.
- The **cmd-K owner editor** — `useEntitiesForProperty` gained the same optional `users` pool, supplied by `PropertyEditorModal` for the company-owner property.

Search inside these pickers filters the team pool client-side, so external contacts can't come back through search. Task assignees and other entity pickers keep their existing behavior. A company whose owner was previously a non-teammate keeps that value, but the picker no longer offers that person.

## Stage filter UX

- The Stage submenu now **pre-checks the stages currently visible**: with no stored filter, every stage reads as checked instead of none. Checking every stage collapses back to "no filter" so the predicate deactivates rather than leaving a match-everything filter chip.

## Group headers

- Grouping by Owner now shows the owner's **display name** instead of their raw macro id, and owner groups sort alphabetically by name. Empty keys still bucket under "Not set".

## Shared component tweaks

- `CustomScrollbar` (all instances): thumb also appears while **hovering the gutter** (not just while scrolling/dragging), and is thicker — 4px (was 2px), centered in the 8px gutter with a 2px radius.

## Notes

- The tab/1–9 hotkeys no longer cycle tabs on the Customers view since its tabs are a mode switch rather than filter presets.
- Saved views are unaffected structurally: they still capture `viewMode` and `activeTab`, and applying one restores hidden-set state; a non-admin applying a shared hidden-set view gets a backend 403 (pre-existing edge).
