### PR TITLE
fix(call): give BlockContainer a single root element

### DIFF
--- a/apps/web/src/features/block-call/component/CallBlockAdapter.tsx
+++ b/apps/web/src/features/block-call/component/CallBlockAdapter.tsx
@@ -57,8 +57,8 @@ export function CallBlockAdapter(props: CallBlockProps) {
   // whenever the container renders this content.
   return (
     <DocumentBlockContainer>
-      <ModalsProvider>
-        <div class="h-full flex flex-col @container">
+      <div class="h-full flex flex-col @container">
+        <ModalsProvider>
           <Show when={callRecord.data}>
             {(data) => (
               <SidePanel.Layout>
@@ -72,8 +72,8 @@ export function CallBlockAdapter(props: CallBlockProps) {
               </SidePanel.Layout>
             )}
           </Show>
-        </div>
-      </ModalsProvider>
+        </ModalsProvider>
+      </div>
     </DocumentBlockContainer>
   );
 }


### PR DESCRIPTION
The Option A change (#4790) wrapped the call block in DocumentBlockContainer, whose BlockContainer requires its children to resolve to a single HTMLElement — but ModalsProvider renders sibling overlays, so the block rendered nothing and logged "BlockContainer must be used with a single HTMLElement". Nest ModalsProvider inside the root div (its drawer/modal portal out of flow) so the container sees one element.
