### PR TITLE
fix(themes): reorganize theme settings

### DIFF
--- a/apps/web/src/components/app/GlobalHotkeys.tsx
+++ b/apps/web/src/components/app/GlobalHotkeys.tsx
@@ -48,8 +48,9 @@ import { ThemeChips } from '@theme/components/ThemeChips';
 import {
   setDarkModeTheme,
   setLightModeTheme,
-  setThemeShouldMatchSystem,
-  themeShouldMatchSystem,
+  setThemeMode,
+  systemMode,
+  themeMode,
   themes,
 } from '@theme/signals/themeSignals';
 import type { ThemeV2 } from '@theme/types/themeTypes';
@@ -437,9 +438,11 @@ export default function GlobalShortcuts() {
   registerHotkey({
     scopeId: 'global',
     description: () =>
-      `${themeShouldMatchSystem() ? 'Turn off a' : 'A'}uto-detect color scheme`,
+      `${themeMode() === 'system' ? 'Turn off a' : 'A'}uto-detect color scheme`,
     keyDownHandler: () => {
-      setThemeShouldMatchSystem((prev) => !prev);
+      // Toggle system (auto-detect) on/off; turning it off pins the theme to the
+      // OS's current scheme so the appearance doesn't visibly change.
+      setThemeMode((prev) => (prev === 'system' ? systemMode() : 'system'));
       return true;
     },
     runWithInputFocused: true,

--- a/apps/web/src/features/settings/Appearance.tsx
+++ b/apps/web/src/features/settings/Appearance.tsx
@@ -4,16 +4,10 @@ import { DropdownMenu as KobalteDropdownMenu } from '@kobalte/core/dropdown-menu
 import ClipboardIcon from '@phosphor/clipboard.svg';
 import PencilIcon from '@phosphor/pencil-simple.svg';
 import PlusIcon from '@phosphor/plus.svg';
-import ShuffleIcon from '@phosphor/shuffle.svg';
 import TrashIcon from '@phosphor/trash.svg';
-import XIcon from '@phosphor/x.svg';
 import { ThemeChipPill } from '@theme/components/ThemeChipPill';
 import { ThemeChips } from '@theme/components/ThemeChips';
-import { ThemeEditorAdvanced } from '@theme/components/ThemeEditorAdvanced';
-import {
-  randomizeTheme,
-  ThemeEditorBasic,
-} from '@theme/components/ThemeEditorBasic';
+import { ThemeEditor } from '@theme/components/ThemeEditor';
 import { DEFAULT_THEMES } from '@theme/constants';
 import {
   currentThemeId,
@@ -41,7 +35,7 @@ import {
   saveTheme,
   updateTheme,
 } from '@theme/utils/themeUtils';
-import { Button, Dropdown, Layer, ToggleSwitch } from '@ui';
+import { Dropdown, Layer, ToggleSwitch } from '@ui';
 import {
   monochromeIcons,
   setMonochromeIcons,
@@ -55,8 +49,6 @@ import {
   SettingsRow,
   SettingsSection,
 } from './primitives';
-
-type EditorTab = 'basic' | 'advanced';
 
 /** Copies a theme's JSON to the clipboard (for sharing / importing elsewhere). */
 function CopyThemeButton(props: { themeId: string; name: string }) {
@@ -129,7 +121,6 @@ function ThemeSelectorRow(props: {
   onSelect: (id: string) => void;
   filter: (theme: ThemeV2) => boolean;
 }) {
-  const [editorTab, setEditorTab] = createSignal<EditorTab>('basic');
   const [editorOpen, setEditorOpen] = createSignal(false);
   // The custom theme being edited (saving writes back to it); undefined for a
   // brand-new theme.
@@ -153,7 +144,6 @@ function ThemeSelectorRow(props: {
     setEditingThemeId(undefined);
     setIsThemeSaved(false);
     setThemeName('New Theme');
-    setEditorTab('basic');
     setEditorOpen(true);
   };
 
@@ -173,7 +163,6 @@ function ThemeSelectorRow(props: {
       setIsThemeSaved(false);
       setThemeName(`${source?.name ?? 'Theme'} copy`);
     }
-    setEditorTab('basic');
     setEditorOpen(true);
   };
 
@@ -230,72 +219,15 @@ function ThemeSelectorRow(props: {
         />
       </SettingsRow>
 
-      {/* The theme editor opens inline beneath its selector as a distinct
-          active-editing block: a neutral, slightly elevated surface (one step
-          lighter than the card via Layer depth), inset + rounded so it reads as
-          a nested element. No color-forward accent. */}
+      {/* The theme editor opens inline beneath its selector; it mounts fresh
+          each time (resetting to the Basic tab). */}
       <Show when={editorOpen()}>
-        <Layer depth={3}>
-          <div class="mx-3 my-2 flex flex-col gap-3 rounded-xl border border-ink/[0.05] bg-surface px-4 py-4">
-            <div class="flex items-center gap-2">
-              <Button
-                label="Close editor"
-                onClick={closeEditor}
-                variant="ghost"
-                size="icon-sm"
-              >
-                <XIcon class="size-4" />
-              </Button>
-              <input
-                type="text"
-                value={themeName()}
-                onInput={(e) => setThemeName(e.currentTarget.value)}
-                spellcheck={false}
-                placeholder="Theme name"
-                aria-label="Theme name"
-                class="w-40 min-w-0 rounded-md border border-edge-muted bg-transparent px-2 py-1 text-xs text-ink outline-none placeholder:text-ink-extra-muted focus:border-accent"
-              />
-              <div class="flex-1" />
-              <Button
-                label="Randomize theme"
-                onPointerDown={randomizeTheme}
-                variant="ghost"
-                size="icon-sm"
-              >
-                <ShuffleIcon class="size-4" />
-              </Button>
-              <TabsInset
-                depth={3}
-                onChange={(value) => setEditorTab(value as EditorTab)}
-                list={[
-                  { value: 'basic', label: 'Basic' },
-                  { value: 'advanced', label: 'Variables' },
-                ]}
-                value={editorTab()}
-                defaultValue="basic"
-              />
-            </div>
-            <div class="relative overflow-hidden rounded-lg">
-              {/* The Basic view defines the box height; it stays mounted (just
-                  hidden) on the Variables tab so the variables list scrolls
-                  within that same height. Basic rows use dividers only; the
-                  Variables list keeps a bordered container. */}
-              <div classList={{ invisible: editorTab() !== 'basic' }}>
-                <ThemeEditorBasic />
-              </div>
-              <Show when={editorTab() === 'advanced'}>
-                <div class="absolute inset-0 overflow-y-auto rounded-lg border border-ink/[0.05] bg-surface">
-                  <ThemeEditorAdvanced />
-                </div>
-              </Show>
-            </div>
-            <div class="flex justify-end">
-              <Button variant="base" size="sm" onClick={saveCurrentTheme}>
-                Save theme
-              </Button>
-            </div>
-          </div>
-        </Layer>
+        <ThemeEditor
+          name={themeName()}
+          onNameChange={setThemeName}
+          onClose={closeEditor}
+          onSave={saveCurrentTheme}
+        />
       </Show>
     </>
   );

--- a/apps/web/src/features/settings/Appearance.tsx
+++ b/apps/web/src/features/settings/Appearance.tsx
@@ -130,10 +130,25 @@ function ThemeSelectorRow(props: {
   // The editable name of the theme being edited.
   const [themeName, setThemeName] = createSignal('New Theme');
 
+  const closeEditor = () => {
+    setEditorOpen(false);
+    setEditingThemeId(undefined);
+  };
+
+  // Abandon any in-progress edits: resync the live tokens with the active theme
+  // (via resolveActiveThemeId) so a draft/preview doesn't linger, then close.
+  // Shared by every edit-abandoning exit — the pill's edit toggle, the editor's
+  // close button, and picking a different theme.
+  const discardAndCloseEditor = () => {
+    applyTheme(resolveActiveThemeId());
+    closeEditor();
+  };
+
   const chooseTheme = (id: string) => {
     props.onSelect(id);
-    setEditingThemeId(undefined);
-    setEditorOpen(false);
+    // Resync with the (now possibly newly-selected) active theme rather than
+    // leaving the dropdown's draft/preview tokens applied, then close.
+    discardAndCloseEditor();
   };
 
   const startNewTheme = () => {
@@ -164,18 +179,6 @@ function ThemeSelectorRow(props: {
       setThemeName(`${source?.name ?? 'Theme'} copy`);
     }
     setEditorOpen(true);
-  };
-
-  const closeEditor = () => {
-    setEditorOpen(false);
-    setEditingThemeId(undefined);
-  };
-
-  // Toggling the pill's edit button while the editor is open scraps the
-  // in-progress edits: restore the active theme's live tokens and close.
-  const discardAndCloseEditor = () => {
-    applyTheme(resolveActiveThemeId());
-    closeEditor();
   };
 
   // Save the live theme: update the bound custom theme in place, or create a new
@@ -225,7 +228,7 @@ function ThemeSelectorRow(props: {
         <ThemeEditor
           name={themeName()}
           onNameChange={setThemeName}
-          onClose={closeEditor}
+          onClose={discardAndCloseEditor}
           onSave={saveCurrentTheme}
         />
       </Show>

--- a/apps/web/src/features/settings/Appearance.tsx
+++ b/apps/web/src/features/settings/Appearance.tsx
@@ -22,8 +22,9 @@ import {
   setDarkModeTheme,
   setIsThemeSaved,
   setLightModeTheme,
-  setThemeShouldMatchSystem,
-  themeShouldMatchSystem,
+  setThemeMode,
+  type ThemeMode,
+  themeMode,
   themes,
   userThemes,
 } from '@theme/signals/themeSignals';
@@ -36,10 +37,11 @@ import {
   getLiveTheme,
   isTokensDark,
   previewTheme,
+  resolveActiveThemeId,
   saveTheme,
   updateTheme,
 } from '@theme/utils/themeUtils';
-import { Button, cn, Dropdown, Layer, ToggleSwitch } from '@ui';
+import { Button, Dropdown, Layer, ToggleSwitch } from '@ui';
 import {
   monochromeIcons,
   setMonochromeIcons,
@@ -113,78 +115,189 @@ function ThemePillActions(props: {
   );
 }
 
-/** A default/preferred-theme picker row, shown indented beneath auto-detect. */
-function ThemePreferenceRow(props: {
+/**
+ * One per-mode theme picker row (Light or Dark): a full theme picker filtered to
+ * this mode's themes, with copy/edit/delete affordances and a "New theme"
+ * action, plus its own inline theme editor that opens beneath the row. Picking a
+ * theme sets this mode's stored theme; if the mode is currently active, the
+ * change applies live via systemThemeEffect.
+ */
+function ThemeSelectorRow(props: {
   label: string;
+  description?: string;
   value: () => string;
-  options: () => ThemeV2[];
   onSelect: (id: string) => void;
-  // Default themes only take effect while auto-detect is on, so the control is
-  // dimmed and non-interactive otherwise.
-  disabled?: () => boolean;
+  filter: (theme: ThemeV2) => boolean;
 }) {
-  const selectedTheme = () =>
-    themes().find((theme) => theme.id === props.value());
+  const [editorTab, setEditorTab] = createSignal<EditorTab>('basic');
+  const [editorOpen, setEditorOpen] = createSignal(false);
+  // The custom theme being edited (saving writes back to it); undefined for a
+  // brand-new theme.
+  const [editingThemeId, setEditingThemeId] = createSignal<string | undefined>(
+    undefined
+  );
+  // The editable name of the theme being edited.
+  const [themeName, setThemeName] = createSignal('New Theme');
+
+  const chooseTheme = (id: string) => {
+    props.onSelect(id);
+    setEditingThemeId(undefined);
+    setEditorOpen(false);
+  };
+
+  const startNewTheme = () => {
+    // Seed the new theme from the current live tokens (already shown in the
+    // editor); mark it unsaved so the editor treats it as a new, nameable theme.
+    // Revert any hover preview first so it doesn't become the starting point.
+    clearThemePreview();
+    setEditingThemeId(undefined);
+    setIsThemeSaved(false);
+    setThemeName('New Theme');
+    setEditorTab('basic');
+    setEditorOpen(true);
+  };
+
+  // Edit a theme: apply it (so the editor shows it live), then open the editor.
+  // Custom themes bind to their id so saving updates them in place; default
+  // themes can't be edited in place, so the editor opens as a new (forked) theme
+  // seeded from the default's now-live tokens.
+  const editTheme = (id: string) => {
+    applyTheme(id);
+    const source = themes().find((t) => t.id === id);
+    const isCustom = userThemes().some((t) => t.id === id);
+    if (isCustom) {
+      setEditingThemeId(id);
+      setThemeName(source?.name ?? 'Theme');
+    } else {
+      setEditingThemeId(undefined);
+      setIsThemeSaved(false);
+      setThemeName(`${source?.name ?? 'Theme'} copy`);
+    }
+    setEditorTab('basic');
+    setEditorOpen(true);
+  };
+
+  const closeEditor = () => {
+    setEditorOpen(false);
+    setEditingThemeId(undefined);
+  };
+
+  // Toggling the pill's edit button while the editor is open scraps the
+  // in-progress edits: restore the active theme's live tokens and close.
+  const discardAndCloseEditor = () => {
+    applyTheme(resolveActiveThemeId());
+    closeEditor();
+  };
+
+  // Save the live theme: update the bound custom theme in place, or create a new
+  // one, point this mode at it, and keep editing it.
+  const saveCurrentTheme = () => {
+    const name = themeName().trim() || 'New Theme';
+    const editing = editingThemeId();
+    if (editing) {
+      updateTheme(editing, name);
+    } else {
+      saveTheme(name);
+      const newId = currentThemeId();
+      setEditingThemeId(newId);
+      props.onSelect(newId);
+    }
+    toast.success('Theme saved');
+  };
+
+  const deleteThemeById = (theme: ThemeV2) => {
+    // The delete button sits inside the theme's (hovered, so previewed) row and
+    // closes the dropdown programmatically, which skips onOpenChange — revert
+    // the preview here so the deleted theme's colors don't linger.
+    clearThemePreview();
+    deleteTheme(theme.id);
+    // If the editor was open on the deleted theme, close it.
+    if (editingThemeId() === theme.id) closeEditor();
+  };
 
   return (
-    <div
-      class={cn(
-        // Nested under the auto-detect toggle: the indent marks these as
-        // sub-settings that only apply while auto-detect is on.
-        'bg-surface flex items-center justify-between h-12 px-6 pl-10 transition-opacity',
-        props.disabled?.() && 'opacity-50 pointer-events-none'
-      )}
-      aria-disabled={props.disabled?.()}
-    >
-      <div class="text-sm">{props.label}</div>
-      <div class="flex items-center gap-1">
-        {/* Preview only lasts while browsing: picking a default doesn't change
-            the active theme, so closing always restores the live tokens. */}
-        <Dropdown onOpenChange={(open) => !open && clearThemePreview()}>
-          <KobalteDropdownMenu.Trigger
-            as={ThemeChipPill}
-            class="h-auto text-xs rounded-lg border border-edge-muted py-1 pl-1 pr-2 hover:bg-ink/4"
-            disabled={props.disabled?.()}
-            theme={selectedTheme()}
-            name={selectedTheme()?.name ?? props.value()}
-          />
-          <Dropdown.Content
-            as="div"
-            class="overflow-hidden border border-ink/[0.05] bg-surface shadow-menu"
-          >
-            <Layer depth={3}>
-              <Dropdown.Group>
-                <For each={props.options()}>
-                  {(theme) => (
-                    <Dropdown.Item
-                      class="group touch:min-h-10"
-                      onSelect={() => props.onSelect(theme.id)}
-                      onFocus={() => previewTheme(theme.id)}
-                    >
-                      <span class="flex min-w-0 flex-1 items-center gap-2">
-                        <ThemeChips theme={theme} size="sm" />
-                        <span class="truncate">{theme.name}</span>
-                      </span>
-                      <span class="ml-2 shrink-0 text-ink-extra-muted opacity-0 group-hover:opacity-100 touch:opacity-100">
-                        <CopyThemeButton themeId={theme.id} name={theme.name} />
-                      </span>
-                    </Dropdown.Item>
-                  )}
-                </For>
-              </Dropdown.Group>
-            </Layer>
-          </Dropdown.Content>
-        </Dropdown>
-        {/* Default rows expose copy only — editing a per-mode default happens
-            from the main Interface theme picker. */}
-        <span class="flex shrink-0 items-center text-ink-extra-muted">
-          <CopyThemeButton
-            themeId={props.value()}
-            name={selectedTheme()?.name ?? props.value()}
-          />
-        </span>
-      </div>
-    </div>
+    <>
+      <SettingsRow label={props.label} description={props.description}>
+        <InterfaceThemeSelect
+          value={props.value}
+          filter={props.filter}
+          onPick={chooseTheme}
+          onEdit={editTheme}
+          onDelete={deleteThemeById}
+          onNewTheme={startNewTheme}
+          editorOpen={editorOpen}
+          onCloseEditor={discardAndCloseEditor}
+        />
+      </SettingsRow>
+
+      {/* The theme editor opens inline beneath its selector as a distinct
+          active-editing block: a neutral, slightly elevated surface (one step
+          lighter than the card via Layer depth), inset + rounded so it reads as
+          a nested element. No color-forward accent. */}
+      <Show when={editorOpen()}>
+        <Layer depth={3}>
+          <div class="mx-3 my-2 flex flex-col gap-3 rounded-xl border border-ink/[0.05] bg-surface px-4 py-4">
+            <div class="flex items-center gap-2">
+              <Button
+                label="Close editor"
+                onClick={closeEditor}
+                variant="ghost"
+                size="icon-sm"
+              >
+                <XIcon class="size-4" />
+              </Button>
+              <input
+                type="text"
+                value={themeName()}
+                onInput={(e) => setThemeName(e.currentTarget.value)}
+                spellcheck={false}
+                placeholder="Theme name"
+                aria-label="Theme name"
+                class="w-40 min-w-0 rounded-md border border-edge-muted bg-transparent px-2 py-1 text-xs text-ink outline-none placeholder:text-ink-extra-muted focus:border-accent"
+              />
+              <div class="flex-1" />
+              <Button
+                label="Randomize theme"
+                onPointerDown={randomizeTheme}
+                variant="ghost"
+                size="icon-sm"
+              >
+                <ShuffleIcon class="size-4" />
+              </Button>
+              <TabsInset
+                depth={3}
+                onChange={(value) => setEditorTab(value as EditorTab)}
+                list={[
+                  { value: 'basic', label: 'Basic' },
+                  { value: 'advanced', label: 'Variables' },
+                ]}
+                value={editorTab()}
+                defaultValue="basic"
+              />
+            </div>
+            <div class="relative overflow-hidden rounded-lg">
+              {/* The Basic view defines the box height; it stays mounted (just
+                  hidden) on the Variables tab so the variables list scrolls
+                  within that same height. Basic rows use dividers only; the
+                  Variables list keeps a bordered container. */}
+              <div classList={{ invisible: editorTab() !== 'basic' }}>
+                <ThemeEditorBasic />
+              </div>
+              <Show when={editorTab() === 'advanced'}>
+                <div class="absolute inset-0 overflow-y-auto rounded-lg border border-ink/[0.05] bg-surface">
+                  <ThemeEditorAdvanced />
+                </div>
+              </Show>
+            </div>
+            <div class="flex justify-end">
+              <Button variant="base" size="sm" onClick={saveCurrentTheme}>
+                Save theme
+              </Button>
+            </div>
+          </div>
+        </Layer>
+      </Show>
+    </>
   );
 }
 
@@ -193,17 +306,26 @@ function ThemePreferenceRow(props: {
  * scrollable dropdown of Default then Custom themes, plus a "New theme" action.
  */
 function InterfaceThemeSelect(props: {
+  value: () => string;
   onPick: (id: string) => void;
   onEdit: (id: string) => void;
   onDelete: (theme: ThemeV2) => void;
   onNewTheme: () => void;
+  // Restricts the listed themes to this mode's themes (light or dark). The
+  // selected value's swatch is always shown, even if it falls outside the filter.
+  filter?: (theme: ThemeV2) => boolean;
+  // Whether this selector's inline editor is open — makes the pill's edit button
+  // a toggle that scraps edits and closes via onCloseEditor.
+  editorOpen?: () => boolean;
+  onCloseEditor?: () => void;
 }) {
   const [filter, setFilter] = createSignal('');
   const [open, setOpen] = createSignal(false);
   let inputRef: HTMLInputElement | undefined;
 
-  const current = () => themes().find((theme) => theme.id === currentThemeId());
+  const current = () => themes().find((theme) => theme.id === props.value());
   const matches = (theme: ThemeV2) =>
+    (props.filter?.(theme) ?? true) &&
     theme.name.toLowerCase().includes(filter().trim().toLowerCase());
   const defaults = () =>
     (DEFAULT_THEMES as unknown as ThemeV2[]).filter(matches);
@@ -363,9 +485,13 @@ function InterfaceThemeSelect(props: {
       </Dropdown>
       <Show when={current()}>
         <ThemePillActions
-          themeId={currentThemeId()}
+          themeId={props.value()}
           name={current()?.name ?? 'Theme'}
-          onEdit={() => props.onEdit(currentThemeId())}
+          onEdit={() =>
+            props.editorOpen?.()
+              ? props.onCloseEditor?.()
+              : props.onEdit(props.value())
+          }
         />
       </Show>
     </div>
@@ -373,201 +499,46 @@ function InterfaceThemeSelect(props: {
 }
 
 export function Appearance() {
-  const [editorTab, setEditorTab] = createSignal<EditorTab>('basic');
-  const [editorOpen, setEditorOpen] = createSignal(false);
-  // The custom theme being edited (saving writes back to it); undefined for a
-  // brand-new theme.
-  const [editingThemeId, setEditingThemeId] = createSignal<string | undefined>(
-    undefined
-  );
-  // The editable name of the theme being edited.
-  const [themeName, setThemeName] = createSignal('New Theme');
-
-  const lightThemes = () =>
-    themes().filter((theme) => !isTokensDark(theme.tokens));
-  const darkThemes = () =>
-    themes().filter((theme) => isTokensDark(theme.tokens));
-
-  const chooseTheme = (id: string) => {
-    applyTheme(id);
-    setEditingThemeId(undefined);
-    setEditorOpen(false);
-  };
-
-  const startNewTheme = () => {
-    // Initialize the new theme from the current theme's variables (already live
-    // in the editor); mark it unsaved so the editor treats it as a new, nameable
-    // theme rather than the saved one it was copied from. Any hover preview is
-    // reverted first so it doesn't become the new theme's starting point.
-    clearThemePreview();
-    setEditingThemeId(undefined);
-    setIsThemeSaved(false);
-    setThemeName('New Theme');
-    setEditorTab('basic');
-    setEditorOpen(true);
-  };
-
-  // Edit a theme: apply it, then open the inline editor. Custom themes bind to
-  // their id so saving updates them in place; default themes can't be edited in
-  // place, so the editor opens as a new (forked) theme seeded from the default's
-  // now-live tokens.
-  const editTheme = (id: string) => {
-    applyTheme(id);
-    const source = themes().find((t) => t.id === id);
-    const isCustom = userThemes().some((t) => t.id === id);
-    if (isCustom) {
-      setEditingThemeId(id);
-      setThemeName(source?.name ?? 'Theme');
-    } else {
-      setEditingThemeId(undefined);
-      setIsThemeSaved(false);
-      setThemeName(`${source?.name ?? 'Theme'} copy`);
-    }
-    setEditorTab('basic');
-    setEditorOpen(true);
-  };
-
-  const closeEditor = () => {
-    setEditorOpen(false);
-    setEditingThemeId(undefined);
-  };
-
-  // Save the live theme: update the bound custom theme in place, or create a
-  // new one (then keep editing it).
-  const saveCurrentTheme = () => {
-    const name = themeName().trim() || 'New Theme';
-    const editing = editingThemeId();
-    if (editing) {
-      updateTheme(editing, name);
-    } else {
-      saveTheme(name);
-      setEditingThemeId(currentThemeId());
-    }
-    toast.success('Theme saved');
-  };
-
-  const deleteThemeById = (theme: ThemeV2) => {
-    // The delete button sits inside the theme's (hovered, so previewed) row and
-    // closes the dropdown programmatically, which skips onOpenChange — revert
-    // the preview here so the deleted theme's colors don't linger.
-    clearThemePreview();
-    deleteTheme(theme.id);
-    // If the editor was open on the deleted theme, close it.
-    if (editingThemeId() === theme.id) closeEditor();
-  };
-
   return (
     // Soften any stray `b4` edge in the theme editor to the muted `b3` tone.
     <div class="h-full" style={{ '--b4l': 'var(--b3l)' }}>
       <SettingsPage title="Appearance">
         <SettingsSection title="Color Theme">
           <SettingsCard>
+            {/* Active theme: pin a light or dark theme, or follow the OS. */}
             <SettingsRow
-              label="Interface theme"
-              description="The color theme used across the app."
+              label="Active theme"
+              description="Use a light theme, a dark theme, or follow your system."
             >
-              <InterfaceThemeSelect
-                onPick={chooseTheme}
-                onEdit={editTheme}
-                onDelete={deleteThemeById}
-                onNewTheme={startNewTheme}
+              <TabsInset
+                depth={2}
+                onChange={(value) => setThemeMode(value as ThemeMode)}
+                list={[
+                  { value: 'light', label: 'Light' },
+                  { value: 'dark', label: 'Dark' },
+                  { value: 'system', label: 'System' },
+                ]}
+                value={themeMode()}
+                defaultValue={themeMode()}
               />
             </SettingsRow>
 
-            {/* The theme editor opens inline beneath "Interface theme" as a
-                distinct active-editing block: a neutral, slightly elevated
-                surface (one step lighter than the card via Layer depth), inset +
-                rounded so it reads as a nested element. No color-forward accent. */}
-            <Show when={editorOpen()}>
-              <Layer depth={3}>
-                <div class="mx-3 my-2 flex flex-col gap-3 rounded-xl border border-ink/[0.05] bg-surface px-4 py-4">
-                  <div class="flex items-center gap-2">
-                    <Button
-                      label="Close editor"
-                      onClick={closeEditor}
-                      variant="ghost"
-                      size="icon-sm"
-                    >
-                      <XIcon class="size-4" />
-                    </Button>
-                    <input
-                      type="text"
-                      value={themeName()}
-                      onInput={(e) => setThemeName(e.currentTarget.value)}
-                      spellcheck={false}
-                      placeholder="Theme name"
-                      aria-label="Theme name"
-                      class="w-40 min-w-0 rounded-md border border-edge-muted bg-transparent px-2 py-1 text-xs text-ink outline-none placeholder:text-ink-extra-muted focus:border-accent"
-                    />
-                    <div class="flex-1" />
-                    <Button
-                      label="Randomize theme"
-                      onPointerDown={randomizeTheme}
-                      variant="ghost"
-                      size="icon-sm"
-                    >
-                      <ShuffleIcon class="size-4" />
-                    </Button>
-                    <TabsInset
-                      depth={3}
-                      onChange={(value) => setEditorTab(value as EditorTab)}
-                      list={[
-                        { value: 'basic', label: 'Basic' },
-                        { value: 'advanced', label: 'Variables' },
-                      ]}
-                      value={editorTab()}
-                      defaultValue="basic"
-                    />
-                  </div>
-                  <div class="relative overflow-hidden rounded-lg">
-                    {/* The Basic view defines the box height; it stays mounted
-                      (just hidden) on the Variables tab so the variables list
-                      scrolls within that same height. Basic rows use dividers
-                      only; the Variables list keeps a bordered container. */}
-                    <div classList={{ invisible: editorTab() !== 'basic' }}>
-                      <ThemeEditorBasic />
-                    </div>
-                    <Show when={editorTab() === 'advanced'}>
-                      <div class="absolute inset-0 overflow-y-auto rounded-lg border border-ink/[0.05] bg-surface">
-                        <ThemeEditorAdvanced />
-                      </div>
-                    </Show>
-                  </div>
-                  <div class="flex justify-end">
-                    <Button variant="base" size="sm" onClick={saveCurrentTheme}>
-                      Save theme
-                    </Button>
-                  </div>
-                </div>
-              </Layer>
-            </Show>
-
-            <SettingsRow
-              label="Auto-detect color scheme"
-              description="Switch theme with your system's light/dark mode."
-            >
-              <ToggleSwitch
-                size="md"
-                onChange={setThemeShouldMatchSystem}
-                checked={themeShouldMatchSystem()}
-              />
-            </SettingsRow>
-
-            {/* Sub-settings collapse away while auto-detect is off. */}
-            <Show when={themeShouldMatchSystem()}>
-              <ThemePreferenceRow
-                label="Default light theme"
-                value={lightModeTheme}
-                options={lightThemes}
-                onSelect={setLightModeTheme}
-              />
-              <ThemePreferenceRow
-                label="Default dark theme"
-                value={darkModeTheme}
-                options={darkThemes}
-                onSelect={setDarkModeTheme}
-              />
-            </Show>
+            {/* Each selector chooses its mode's theme and hosts its own inline
+                editor; the pick applies live when that mode is active. */}
+            <ThemeSelectorRow
+              label="Light theme"
+              description="Used when Active theme is Light, or your system is light."
+              value={lightModeTheme}
+              onSelect={setLightModeTheme}
+              filter={(theme) => !isTokensDark(theme.tokens)}
+            />
+            <ThemeSelectorRow
+              label="Dark theme"
+              description="Used when Active theme is Dark, or your system is dark."
+              value={darkModeTheme}
+              onSelect={setDarkModeTheme}
+              filter={(theme) => isTokensDark(theme.tokens)}
+            />
           </SettingsCard>
         </SettingsSection>
 

--- a/apps/web/src/features/theme/components/ThemeEditor.tsx
+++ b/apps/web/src/features/theme/components/ThemeEditor.tsx
@@ -1,0 +1,95 @@
+import { TabsInset } from '@core/component/TabsInset';
+import ShuffleIcon from '@phosphor/shuffle.svg';
+import XIcon from '@phosphor/x.svg';
+import { Button, Layer } from '@ui';
+import { createSignal, Show } from 'solid-js';
+import { ThemeEditorAdvanced } from './ThemeEditorAdvanced';
+import { randomizeTheme, ThemeEditorBasic } from './ThemeEditorBasic';
+
+type EditorTab = 'basic' | 'advanced';
+
+/**
+ * The inline theme-editing panel: a toolbar (close, name, randomize, Basic /
+ * Variables tabs) over the Basic and Advanced (variables) editors, plus a save
+ * action. Rendered beneath a theme selector while its editor is open — mounting
+ * fresh each time resets the tab to Basic.
+ *
+ * Editing mutates the live theme tokens directly (via the Basic/Advanced
+ * editors); the parent owns open/close, the editable name, and what save does.
+ */
+export function ThemeEditor(props: {
+  /** The editable theme name (controlled by the parent). */
+  name: string;
+  onNameChange: (name: string) => void;
+  onClose: () => void;
+  onSave: () => void;
+}) {
+  const [editorTab, setEditorTab] = createSignal<EditorTab>('basic');
+
+  return (
+    // A distinct active-editing block: a neutral, slightly elevated surface (one
+    // step lighter than the card via Layer depth), inset + rounded so it reads as
+    // a nested element. No color-forward accent.
+    <Layer depth={3}>
+      <div class="mx-3 my-2 flex flex-col gap-3 rounded-xl border border-ink/[0.05] bg-surface px-4 py-4">
+        <div class="flex items-center gap-2">
+          <Button
+            label="Close editor"
+            onClick={props.onClose}
+            variant="ghost"
+            size="icon-sm"
+          >
+            <XIcon class="size-4" />
+          </Button>
+          <input
+            type="text"
+            value={props.name}
+            onInput={(e) => props.onNameChange(e.currentTarget.value)}
+            spellcheck={false}
+            placeholder="Theme name"
+            aria-label="Theme name"
+            class="w-40 min-w-0 rounded-md border border-edge-muted bg-transparent px-2 py-1 text-xs text-ink outline-none placeholder:text-ink-extra-muted focus:border-accent"
+          />
+          <div class="flex-1" />
+          <Button
+            label="Randomize theme"
+            onPointerDown={randomizeTheme}
+            variant="ghost"
+            size="icon-sm"
+          >
+            <ShuffleIcon class="size-4" />
+          </Button>
+          <TabsInset
+            depth={3}
+            onChange={(value) => setEditorTab(value as EditorTab)}
+            list={[
+              { value: 'basic', label: 'Basic' },
+              { value: 'advanced', label: 'Variables' },
+            ]}
+            value={editorTab()}
+            defaultValue="basic"
+          />
+        </div>
+        <div class="relative overflow-hidden rounded-lg">
+          {/* The Basic view defines the box height; it stays mounted (just
+              hidden) on the Variables tab so the variables list scrolls within
+              that same height. Basic rows use dividers only; the Variables list
+              keeps a bordered container. */}
+          <div classList={{ invisible: editorTab() !== 'basic' }}>
+            <ThemeEditorBasic />
+          </div>
+          <Show when={editorTab() === 'advanced'}>
+            <div class="absolute inset-0 overflow-y-auto rounded-lg border border-ink/[0.05] bg-surface">
+              <ThemeEditorAdvanced />
+            </div>
+          </Show>
+        </div>
+        <div class="flex justify-end">
+          <Button variant="base" size="sm" onClick={props.onSave}>
+            Save theme
+          </Button>
+        </div>
+      </div>
+    </Layer>
+  );
+}

--- a/apps/web/src/features/theme/signals/themeSignals.ts
+++ b/apps/web/src/features/theme/signals/themeSignals.ts
@@ -54,8 +54,25 @@ export const [darkModeTheme, setDarkModeTheme] = makePersisted(
  *  live — see resolveActiveThemeId / systemThemeEffect in themeUtils. */
 export type ThemeMode = 'light' | 'dark' | 'system';
 
+/** Fallback for the initial themeMode, migrating the pre-"Active theme" setting
+ *  (`macro-theme-should-match-system`) so returning users keep their appearance:
+ *  auto-detect on → 'system'; auto-detect off (a pinned theme) → the fixed
+ *  light/dark mode matching the previously-selected theme. Only used until the
+ *  new `macro-theme-mode` key is written. */
+function initialThemeMode(): ThemeMode {
+  if (typeof localStorage === 'undefined') { return 'system' }
+  const legacy = localStorage.getItem('macro-theme-should-match-system');
+  // New/already-migrated users, and anyone who had auto-detect on: follow the OS.
+  if (legacy !== 'false') { return 'system' }
+  // Auto-detect was off: pin to the mode matching the previously-selected theme
+  // (dark when its text is lighter than its background — see isTokensDark).
+  const pinned = themes().find((theme) => theme.id === currentThemeId());
+  if (!pinned) { return 'system' }
+  return pinned.tokens.c0.l > pinned.tokens.b0.l ? 'dark' : 'light';
+}
+
 export const [themeMode, setThemeMode] = makePersisted(
-  createSignal<ThemeMode>('system'),
+  createSignal<ThemeMode>(initialThemeMode()),
   {name: 'macro-theme-mode'}
 );
 

--- a/apps/web/src/features/theme/signals/themeSignals.ts
+++ b/apps/web/src/features/theme/signals/themeSignals.ts
@@ -35,9 +35,10 @@ export const themes = createMemo<ThemeV2[]>(() => [
   ...userThemes(),
 ]);
 
-// Per-mode theme preferences, persisted to localStorage. Applied by
-// systemThemeEffect (themeUtils.ts) when themeShouldMatchSystem is on and the OS
-// color scheme is (or becomes) the matching mode.
+// Per-mode theme preferences, persisted to localStorage. The active one is
+// applied by systemThemeEffect / resolveActiveThemeId (themeUtils.ts): the light
+// theme when themeMode is 'light' (or 'system' + OS light), the dark theme when
+// 'dark' (or 'system' + OS dark).
 export const [lightModeTheme, setLightModeTheme] = makePersisted(
   createSignal<string>(DEFAULT_LIGHT_THEME),
   {name: 'macro-light-mode-theme'}
@@ -48,16 +49,21 @@ export const [darkModeTheme, setDarkModeTheme] = makePersisted(
   {name: 'macro-dark-mode-theme'}
 );
 
-export const [themeShouldMatchSystem, setThemeShouldMatchSystem] = makePersisted(
-  createSignal<boolean>(true),
-  {name: 'macro-theme-should-match-system'}
+/** The "Active theme" mode: pin a fixed light or dark theme, or follow the OS
+ *  ('system'). Drives which per-mode theme (lightModeTheme/darkModeTheme) is
+ *  live — see resolveActiveThemeId / systemThemeEffect in themeUtils. */
+export type ThemeMode = 'light' | 'dark' | 'system';
+
+export const [themeMode, setThemeMode] = makePersisted(
+  createSignal<ThemeMode>('system'),
+  {name: 'macro-theme-mode'}
 );
 
 const supportsMatchMedia =
   typeof window !== 'undefined' && typeof window.matchMedia === 'function';
 
-// Tracks the OS color scheme so the active theme can follow it when
-// themeShouldMatchSystem is on.
+// Tracks the OS color scheme so the active theme can follow it when themeMode is
+// 'system'.
 export const [systemMode, setSystemMode] = createSignal<'dark' | 'light'>(
   supportsMatchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
     ? 'dark'

--- a/apps/web/src/features/theme/utils/themeUtils.ts
+++ b/apps/web/src/features/theme/utils/themeUtils.ts
@@ -1,4 +1,4 @@
-import { currentThemeId, darkModeTheme, lightModeTheme, setCurrentThemeId, setDarkModeTheme, setHtmlColor, setIsThemeSaved, setLightModeTheme, setThemeDepth, setUserThemes, systemMode, themeDepth, themes, themeShouldMatchSystem, userThemes} from '../signals/themeSignals';
+import { currentThemeId, darkModeTheme, lightModeTheme, setCurrentThemeId, setDarkModeTheme, setHtmlColor, setIsThemeSaved, setLightModeTheme, setThemeDepth, setUserThemes, systemMode, themeDepth, themeMode, themes, userThemes} from '../signals/themeSignals';
 import { semanticTokens, type ThemeV2, type ThemeV2Tokens } from '../types/themeTypes';
 import { themeReactive } from '../signals/themeReactive';
 import { toast } from '@core/component/Toast/Toast';
@@ -139,24 +139,26 @@ export function clearThemePreview(): void{
   previewSnapshot = null;
 }
 
-/** When auto-detect is on, keeps the active theme in sync with the OS color
- *  scheme by applying the preferred light or dark theme as the system flips.
- *  Call once from a reactive root (see Root.tsx). */
+/** Resolves the theme id that should be live for the current "Active theme"
+ *  mode: the pinned light/dark theme, or — in system mode — whichever matches
+ *  the OS color scheme. Read inside a reactive scope, it subscribes to the mode,
+ *  the OS scheme (system mode only), and the relevant per-mode theme. */
+export function resolveActiveThemeId(): string{
+  const resolved = themeMode() === 'system' ? systemMode() : themeMode();
+  return resolved === 'dark' ? darkModeTheme() : lightModeTheme();
+}
+
+/** Keeps the active theme in sync with the "Active theme" mode: applies the
+ *  pinned light/dark theme, or follows the OS color scheme in system mode.
+ *  Re-applies whenever the mode, the OS scheme, or the *active* mode's theme
+ *  changes — but not when the inactive mode's theme changes (that id isn't read
+ *  by resolveActiveThemeId, so it isn't tracked). Call once from a reactive root
+ *  (see Root.tsx). */
 export function systemThemeEffect(): void{
   createEffect(
     on(
-      // Only react to the OS color scheme flipping or auto-detect turning on —
-      // deliberately NOT to darkModeTheme/lightModeTheme. `on` runs its callback
-      // untracked, so reading the defaults below does not subscribe to them. This
-      // keeps "Set default light/dark theme" from re-applying the current mode's
-      // default and clobbering the active theme; a new default takes effect on the
-      // next mode change (or when auto-detect is toggled on).
-      [themeShouldMatchSystem, systemMode],
-      () => {
-        if(themeShouldMatchSystem()){
-          applyTheme(systemMode() === 'dark' ? darkModeTheme() : lightModeTheme());
-        }
-      },
+      resolveActiveThemeId,
+      (id) => applyTheme(id),
       { defer: true }
     )
   );

--- a/apps/web/src/routes/Root.tsx
+++ b/apps/web/src/routes/Root.tsx
@@ -92,10 +92,10 @@ import {
   type RouterProps,
   useSearchParams,
 } from '@solidjs/router';
-import { currentThemeId } from '@theme/signals/themeSignals';
 import {
   applyTheme,
   ensureMinimalThemeContrast,
+  resolveActiveThemeId,
   systemThemeEffect,
 } from '@theme/utils/themeUtils';
 import { Button } from '@ui';
@@ -569,7 +569,7 @@ export function Root() {
   });
 
   onMount(() => {
-    applyTheme(currentThemeId());
+    applyTheme(resolveActiveThemeId());
     ensureMinimalThemeContrast();
   });
 


### PR DESCRIPTION
Before:
<img width="706" height="318" alt="Screenshot 2026-07-14 at 12 47 53 PM" src="https://github.com/user-attachments/assets/eded4121-31d2-4d6a-95a8-67e1e5bc638b" />

After:
<img width="693" height="279" alt="Screenshot 2026-07-14 at 12 48 28 PM" src="https://github.com/user-attachments/assets/83f579b8-02d3-4a1c-bfda-0d0178b17e69" />
