### PR TITLE
fix(inbox): resolve channel row click target and highlight correctly

### DIFF
--- a/apps/web/src/features/block-channel/component/NewChannelBlockAdapter.tsx
+++ b/apps/web/src/features/block-channel/component/NewChannelBlockAdapter.tsx
@@ -1,6 +1,7 @@
 import { useBlockEntityCommands } from '@app/features/next-soup/actions';
 import { globalSplitManager } from '@app/signal/splitLayout';
 import { URL_PARAMS } from '@block-channel/constants';
+import { convertTargetMessage } from '@block-channel/utils/target-message';
 import { ChannelAttachmentsTab } from '@channel/Attachments/ChannelAttachmentsTab';
 import { useCallContextOptional } from '@channel/Call/CallContext';
 import { CallEventSync } from '@channel/Call/CallEventSync';
@@ -293,24 +294,6 @@ export function NewChannelBlockAdapter(props: BlockChannelProps) {
       { replace: true }
     );
   });
-
-  const convertTargetMessage = (
-    params: ChannelTargetMessageParams
-  ): ChannelPropsTargetMessage => {
-    const messageId = params[URL_PARAMS.message] as string | undefined;
-    const threadId = params[URL_PARAMS.thread] as string | undefined;
-
-    // For compatibility the naming is a little strange here.
-    // New channels index by top level message and then separately handle replies.
-    // If we have a threadId that is actually the top level message and the reply is the message id.
-    const topLevelMessageId = threadId ? threadId : messageId;
-    const messageReplyId = threadId ? messageId : threadId;
-
-    return {
-      targetMessageId: topLevelMessageId,
-      targetMessageReplyId: messageReplyId,
-    };
-  };
 
   // A mention/link to a thread reply may carry only the message id (the reply)
   // without its thread id. Left as-is `convertTargetMessage` would treat that

--- a/apps/web/src/features/block-channel/utils/link.ts
+++ b/apps/web/src/features/block-channel/utils/link.ts
@@ -33,6 +33,21 @@ export async function goToChannelMessage(
   await handle?.goToLocationFromParams(getChannelParams(messageId, threadId));
 }
 
+/**
+ * Drive an (already-mounted) channel block to its latest message via the
+ * block handle — a scroll-to-bottom with no highlight. Used for channel rows
+ * that open at their latest activity rather than a targeted message; forces
+ * the scroll even when the channel is already open (where `reopen: 'latest'`
+ * would otherwise just reactivate the parked split).
+ */
+export async function goToChannelLatest(
+  orchestrator: BlockOrchestrator,
+  channelId: string
+) {
+  const handle = await orchestrator.getBlockHandle(channelId, 'channel');
+  await handle?.goToLatest();
+}
+
 export async function navigateToChannelMessage(
   orchestrator: BlockOrchestrator,
   channelId: string,

--- a/apps/web/src/features/block-channel/utils/target-message.test.ts
+++ b/apps/web/src/features/block-channel/utils/target-message.test.ts
@@ -1,0 +1,46 @@
+import { URL_PARAMS } from '@block-channel/constants';
+import { describe, expect, it } from 'vitest';
+import { convertTargetMessage } from './target-message';
+
+describe('convertTargetMessage', () => {
+  it('treats a bare message id as a top-level message', () => {
+    expect(convertTargetMessage({ [URL_PARAMS.message]: 'msg-1' })).toEqual({
+      targetMessageId: 'msg-1',
+      targetMessageReplyId: undefined,
+    });
+  });
+
+  it('treats message-within-thread as a reply', () => {
+    expect(
+      convertTargetMessage({
+        [URL_PARAMS.message]: 'reply-1',
+        [URL_PARAMS.thread]: 'root-1',
+      })
+    ).toEqual({
+      targetMessageId: 'root-1',
+      targetMessageReplyId: 'reply-1',
+    });
+  });
+
+  it('treats a thread root targeting itself (thread === message) as top-level, not a reply', () => {
+    // A thread row falls back to its own ids, where messageId === threadId.
+    // That must resolve to the root as a top-level message so it highlights,
+    // rather than a reply-within-itself that matches nothing.
+    expect(
+      convertTargetMessage({
+        [URL_PARAMS.message]: 'root-1',
+        [URL_PARAMS.thread]: 'root-1',
+      })
+    ).toEqual({
+      targetMessageId: 'root-1',
+      targetMessageReplyId: undefined,
+    });
+  });
+
+  it('returns no target for empty params', () => {
+    expect(convertTargetMessage({})).toEqual({
+      targetMessageId: undefined,
+      targetMessageReplyId: undefined,
+    });
+  });
+});

--- a/apps/web/src/features/block-channel/utils/target-message.ts
+++ b/apps/web/src/features/block-channel/utils/target-message.ts
@@ -1,0 +1,44 @@
+import { URL_PARAMS } from '@block-channel/constants';
+
+/** Channel navigation params: a message id, optionally within a thread root. */
+export type ChannelTargetParams = {
+  [URL_PARAMS.message]?: string;
+  [URL_PARAMS.thread]?: string;
+};
+
+/** The message the channel block should activate. */
+export type ChannelMessageTarget = {
+  targetMessageId?: string;
+  targetMessageReplyId?: string;
+};
+
+/**
+ * Decode channel target params (`{message, thread}`) into the block's target.
+ *
+ * The params encode a reply as `message` (the reply) within `thread` (its
+ * root); a bare `message` with no `thread` is a top-level message. A message
+ * whose thread root is itself (`thread === message`) is therefore also a
+ * top-level message, not a reply — every thread root satisfies this in the
+ * entity model. Sending it as a reply-within-itself matches neither the root
+ * nor any real reply, so nothing scrolls or highlights; collapse it to a
+ * top-level target here, the one place these params are decoded, so every
+ * caller (URLs, mentions, search hits, notifications) is covered.
+ */
+export function convertTargetMessage(
+  params: ChannelTargetParams
+): ChannelMessageTarget {
+  const messageId = params[URL_PARAMS.message];
+  const rawThreadId = params[URL_PARAMS.thread];
+  const threadId = rawThreadId === messageId ? undefined : rawThreadId;
+
+  // New channels index by top-level message and handle replies separately:
+  // when a thread is present it is the top-level message and message is the
+  // reply.
+  const topLevelMessageId = threadId ? threadId : messageId;
+  const messageReplyId = threadId ? messageId : threadId;
+
+  return {
+    targetMessageId: topLevelMessageId,
+    targetMessageReplyId: messageReplyId,
+  };
+}

--- a/apps/web/src/features/channel/Channel/Channel.tsx
+++ b/apps/web/src/features/channel/Channel/Channel.tsx
@@ -480,6 +480,13 @@ export function Channel(props: ChannelProps) {
   // fully loaded data.
   createEffect(() => {
     if (!pendingScrollToLatest()) return;
+    // A specific message navigation supersedes scroll-to-latest: once a target
+    // scroll is pending, abandon the latest-scroll so it can't yank the view
+    // back to the bottom.
+    if (targetMessageController.pendingScrollTargetId()) {
+      setPendingScrollToLatest(false);
+      return;
+    }
     const navigation = threadListNavigation();
     const scrollState = threadListScrollState();
     if (!navigation || !scrollState?.didInitialScroll) return;

--- a/apps/web/src/features/channel/Channel/ThreadList.tsx
+++ b/apps/web/src/features/channel/Channel/ThreadList.tsx
@@ -200,10 +200,17 @@ export function ThreadList(props: ThreadListProps) {
 
   const scrollToTarget = (
     handle: VirtualizerHandle,
-    target: ThreadListScrollTarget
+    target: ThreadListScrollTarget,
+    options: { cancelPin?: boolean } = {}
   ): boolean => {
     const index = resolveTargetIndex(target);
     if (index < 0) return false;
+    // A deliberate navigation to a specific target aborts an in-flight
+    // pinToBottom settle loop, which would otherwise yank the view back to the
+    // bottom frame-by-frame and strand the target (e.g. opening a channel at
+    // latest, then clicking a message/thread row within its settle window).
+    // pinToBottom opts out so it doesn't cancel the loop it is establishing.
+    if (options.cancelPin !== false) cancelPinToBottom?.();
     const align = getTargetAlign(target);
     handle.scrollToIndex(index, { align, offset: insetAlignOffset(align) });
     return true;
@@ -309,7 +316,11 @@ export function ThreadList(props: ThreadListProps) {
   const pinToBottom = (handle: VirtualizerHandle): boolean => {
     cancelPinToBottom?.();
 
-    const didScroll = scrollToTarget(handle, { tag: 'bottom', align: 'end' });
+    const didScroll = scrollToTarget(
+      handle,
+      { tag: 'bottom', align: 'end' },
+      { cancelPin: false }
+    );
     const el = scrollRef;
     if (!didScroll || !el) return didScroll;
 

--- a/apps/web/src/features/entity/types/entity.ts
+++ b/apps/web/src/features/entity/types/entity.ts
@@ -80,6 +80,18 @@ export type ChannelEntityTarget = {
   threadId?: string;
 };
 
+/**
+ * The resolved click intent for a channel-family row. Either a specific
+ * message to jump to and highlight, or `latest` — open the channel at its
+ * newest message with no highlight. A whole `channel` row with no unread
+ * notification resolves to `latest` so the click lands where the row's
+ * preview points (the latest message, which may be your own send) instead of
+ * an older notification or nothing at all.
+ */
+export type ChannelClickTarget =
+  | { kind: 'message'; messageId: string; threadId?: string }
+  | { kind: 'latest' };
+
 export type ChannelEntity = EntityBase & {
   type: 'channel';
   channelType: 'direct_message' | 'private' | 'public' | 'team';

--- a/apps/web/src/features/next-soup/soup-view/create-soup-entity-actions.ts
+++ b/apps/web/src/features/next-soup/soup-view/create-soup-entity-actions.ts
@@ -191,11 +191,14 @@ export function createSoupEntityActions(): {
         ) {
           // Thread rows are keyed by their root; getChannelEntityTarget
           // recovers the clicked reply from the driving notification so the
-          // new split lands on it rather than the root message.
-          const target = getChannelEntityTarget(entity) ?? {
-            messageId: entity.messageId,
-            threadId: entity.threadId,
-          };
+          // new split lands on it rather than the root message. These rows
+          // always resolve to a message target (their own ids at worst), never
+          // `latest`, which only a whole-channel row produces.
+          const resolved = getChannelEntityTarget(entity);
+          const target =
+            resolved?.kind === 'message'
+              ? resolved
+              : { messageId: entity.messageId, threadId: entity.threadId };
           splitManager.createNewSplit({
             content: {
               type: 'channel',

--- a/apps/web/src/features/next-soup/utils.test.ts
+++ b/apps/web/src/features/next-soup/utils.test.ts
@@ -45,6 +45,12 @@ const replyNotification = (
     },
   }) as unknown as UnifiedNotification;
 
+const asRead = (notification: UnifiedNotification): UnifiedNotification =>
+  ({
+    ...notification,
+    viewed_at: '2026-07-14T00:00:00.000Z',
+  }) as unknown as UnifiedNotification;
+
 const channelMessageRow = (opts?: {
   target?: ChannelEntityTarget;
   notifications?: UnifiedNotification[];
@@ -91,6 +97,7 @@ describe('getChannelEntityTarget', () => {
       notifications: [sendNotification('n1', 'recent-unread-msg')],
     });
     expect(getChannelEntityTarget(entity)).toEqual({
+      kind: 'message',
       messageId: 'hit-msg',
       threadId: 'hit-thread',
     });
@@ -102,6 +109,7 @@ describe('getChannelEntityTarget', () => {
       notifications: [replyNotification('n1', 'newest-reply', 'root-msg')],
     });
     expect(getChannelEntityTarget(entity)).toEqual({
+      kind: 'message',
       messageId: 'hit-reply',
       threadId: 'root-msg',
     });
@@ -109,30 +117,53 @@ describe('getChannelEntityTarget', () => {
 
   it('falls back to own ids for an unstamped channel_message row without notifications', () => {
     expect(getChannelEntityTarget(channelMessageRow())).toEqual({
+      kind: 'message',
       messageId: 'hit-msg',
       threadId: 'hit-thread',
     });
   });
 
-  it('targets the driving notification for a channel row', () => {
+  it('targets the driving unread notification for a channel row', () => {
     const entity = channelRow({
       notifications: [sendNotification('n1', 'notif-msg')],
     });
     expect(getChannelEntityTarget(entity)).toEqual({
+      kind: 'message',
       messageId: 'notif-msg',
       threadId: undefined,
     });
   });
 
-  it('returns no target for a channel row without notifications', () => {
-    expect(getChannelEntityTarget(channelRow())).toBeUndefined();
+  it('opens a channel row at latest when it has no notifications', () => {
+    expect(getChannelEntityTarget(channelRow())).toEqual({ kind: 'latest' });
   });
 
-  it('skips thread-reply notifications for a channel row', () => {
+  it('opens a channel row at latest, skipping read notifications (latest send is your own)', () => {
+    const entity = channelRow({
+      notifications: [asRead(sendNotification('n1', 'read-msg'))],
+    });
+    expect(getChannelEntityTarget(entity)).toEqual({ kind: 'latest' });
+  });
+
+  it('targets the newest unread notification, skipping newer read ones', () => {
+    const entity = channelRow({
+      notifications: [
+        asRead(sendNotification('n1', 'read-newer-msg')),
+        sendNotification('n2', 'unread-older-msg'),
+      ],
+    });
+    expect(getChannelEntityTarget(entity)).toEqual({
+      kind: 'message',
+      messageId: 'unread-older-msg',
+      threadId: undefined,
+    });
+  });
+
+  it('opens a channel row at latest when its only notification is a thread reply', () => {
     const entity = channelRow({
       notifications: [replyNotification('n1', 'reply-msg', 'other-thread')],
     });
-    expect(getChannelEntityTarget(entity)).toBeUndefined();
+    expect(getChannelEntityTarget(entity)).toEqual({ kind: 'latest' });
   });
 
   it('targets the reply notification scoped to a channel_thread row', () => {
@@ -143,6 +174,18 @@ describe('getChannelEntityTarget', () => {
       ],
     });
     expect(getChannelEntityTarget(entity)).toEqual({
+      kind: 'message',
+      messageId: 'reply-msg',
+      threadId: 'root-msg',
+    });
+  });
+
+  it('targets a read reply notification on a channel_thread row (read state only gates channel rows)', () => {
+    const entity = channelThreadRow({
+      notifications: [asRead(replyNotification('n1', 'reply-msg', 'root-msg'))],
+    });
+    expect(getChannelEntityTarget(entity)).toEqual({
+      kind: 'message',
       messageId: 'reply-msg',
       threadId: 'root-msg',
     });
@@ -152,7 +195,11 @@ describe('getChannelEntityTarget', () => {
     const entity = channelThreadRow({
       notifications: [replyNotification('n1', 'reply-msg', 'other-thread')],
     });
+    // The row carries its own ids (root === root). Collapsing that to a
+    // top-level target is the decoder's job (see convertTargetMessage), so
+    // here it passes through unchanged.
     expect(getChannelEntityTarget(entity)).toEqual({
+      kind: 'message',
       messageId: 'root-msg',
       threadId: 'root-msg',
     });

--- a/apps/web/src/features/next-soup/utils.ts
+++ b/apps/web/src/features/next-soup/utils.ts
@@ -4,6 +4,7 @@ import { URL_PARAMS as CALL_PARAMS } from '@block-call/constants';
 import { URL_PARAMS as CHANNEL_PARAMS } from '@block-channel/constants';
 import {
   getChannelParams,
+  goToChannelLatest,
   goToChannelMessage,
 } from '@block-channel/utils/link';
 import { URL_PARAMS as EMAIL_PARAMS } from '@block-email/constants';
@@ -25,7 +26,7 @@ import { throwOnErr } from '@core/util/result';
 import { waitForFrames } from '@core/util/sleep';
 import { openExternalUrl } from '@core/util/url';
 import {
-  type ChannelEntityTarget,
+  type ChannelClickTarget,
   type EntityData,
   getSnippetHit,
   isGithubPrEntity,
@@ -42,6 +43,7 @@ import {
   getAllNotificationsFromGroup,
   getChannelNotificationParams,
   type NotificationSource,
+  notificationIsRead,
   setDoneOverride,
   stackNotifications,
   type UnifiedNotification,
@@ -343,14 +345,24 @@ interface OpenEntityOptions {
  * driving notification (the same data the card renders), so read the target
  * from there, exactly like the old inbox did via getChannelNotificationParams.
  * Notifications are scoped to the row first (top-level sends for a channel,
- * this thread's replies for a thread) and the most recent one wins. With no
- * notification either, fall back to the row's own ids — a `channel_thread`
- * row opens at its root and a `channel` row has no message to target (open
- * latest).
+ * this thread's replies for a thread) and the most recent one wins.
+ *
+ * Read state only changes a whole-`channel` row: its notifications are skipped
+ * when read, because a channel aggregates many messages and the newest unread
+ * one (never your own send) can sit far above the latest — jumping there feels
+ * wrong once the row looks read. A `channel_thread`/`channel_message` row is
+ * scoped to one message, so it targets its driving notification read or not —
+ * that is the reply the row stands for and the message to highlight.
+ *
+ * With no aiming notification, fall back to the row's own semantics: a
+ * `channel_thread`/`channel_message` row opens at its own root/message, and a
+ * whole `channel` row opens at `latest` — landing on the newest message the
+ * row's preview shows (which may be your own send) rather than an older
+ * notification or nothing.
  */
 export function getChannelEntityTarget(
   entity: EntityData
-): ChannelEntityTarget | undefined {
+): ChannelClickTarget | undefined {
   if (
     entity.type !== 'channel' &&
     entity.type !== 'channel_message' &&
@@ -359,12 +371,22 @@ export function getChannelEntityTarget(
     return undefined;
   }
 
-  if (entity.target) return entity.target;
+  if (entity.target) {
+    return {
+      kind: 'message',
+      messageId: entity.target.messageId,
+      threadId: entity.target.threadId,
+    };
+  }
 
-  const fallback =
+  const fallback: ChannelClickTarget =
     entity.type === 'channel'
-      ? undefined
-      : { messageId: entity.messageId, threadId: entity.threadId };
+      ? { kind: 'latest' }
+      : {
+          kind: 'message',
+          messageId: entity.messageId,
+          threadId: entity.threadId,
+        };
 
   if (!isWithNotification(entity)) return fallback;
 
@@ -373,8 +395,14 @@ export function getChannelEntityTarget(
     entity.notifications?.() ?? []
   );
   for (const notification of scoped) {
+    // Read notifications only stop aiming a whole-`channel` row, which would
+    // otherwise jump to a stale message far above the latest (your own sends
+    // never notify you). A thread/message row is scoped to a single message,
+    // so it targets its driving notification regardless of read state — that
+    // is the reply the row stands for and the one to highlight.
+    if (entity.type === 'channel' && notificationIsRead(notification)) continue;
     const { messageId, threadId } = getChannelNotificationParams(notification);
-    if (messageId) return { messageId, threadId };
+    if (messageId) return { kind: 'message', messageId, threadId };
   }
 
   return fallback;
@@ -403,6 +431,11 @@ export async function navigateChannelEntityToTarget(
         ? entity.channelId
         : undefined;
   if (!channelId) return;
+
+  if (target.kind === 'latest') {
+    await goToChannelLatest(blockOrchestrator, channelId);
+    return;
+  }
 
   await goToChannelMessage(
     blockOrchestrator,
@@ -461,12 +494,18 @@ export const openEntityInSplitFromUnifiedList = async (
   const content = getEntitySplitContent(entity);
 
   const channelTarget = getChannelEntityTarget(entity);
+  const channelMessageTarget =
+    channelTarget?.kind === 'message' ? channelTarget : undefined;
+  const openChannelAtLatest = channelTarget?.kind === 'latest';
 
   let params: Record<string, string> | undefined;
   if (entity.type === 'channel' && location?.type === 'channel') {
     params = getChannelParams(location.messageId, location.threadId);
-  } else if (channelTarget) {
-    params = getChannelParams(channelTarget.messageId, channelTarget.threadId);
+  } else if (channelMessageTarget) {
+    params = getChannelParams(
+      channelMessageTarget.messageId,
+      channelMessageTarget.threadId
+    );
   } else if (entity.type === 'call' && location?.type === 'call_record') {
     params = { [CALL_PARAMS.transcriptId]: location.transcriptId };
   }
@@ -490,7 +529,7 @@ export const openEntityInSplitFromUnifiedList = async (
       mergeHistory,
       allowDuplicate,
       reopen:
-        entity.type === 'channel' && !location && !channelTarget
+        entity.type === 'channel' && !location && openChannelAtLatest
           ? 'latest'
           : undefined,
     }
@@ -499,17 +538,22 @@ export const openEntityInSplitFromUnifiedList = async (
   // Navigate to specific location if provided
   if (location) {
     await navigateToLocation(content.id, location, blockOrchestrator);
-  } else if (channelTarget) {
+  } else if (channelMessageTarget) {
     // NOTE: This will force target message navigation in case the split is already open.
     await navigateToLocation(
       content.id,
       {
         type: 'channel',
-        messageId: channelTarget.messageId,
-        threadId: channelTarget.threadId,
+        messageId: channelMessageTarget.messageId,
+        threadId: channelMessageTarget.threadId,
       },
       blockOrchestrator
     );
+  } else if (openChannelAtLatest) {
+    // Force the scroll-to-bottom even when the channel is already open in a
+    // (preview) split, where reopen: 'latest' only reactivates the parked
+    // split without re-pinning it to the newest message.
+    await goToChannelLatest(blockOrchestrator, content.id);
   }
 };
 

--- a/apps/web/src/features/next-soup/utils.ts
+++ b/apps/web/src/features/next-soup/utils.ts
@@ -395,11 +395,17 @@ export function getChannelEntityTarget(
     entity.notifications?.() ?? []
   );
   for (const notification of scoped) {
-    // Read notifications only stop aiming a whole-`channel` row, which would
-    // otherwise jump to a stale message far above the latest (your own sends
-    // never notify you). A thread/message row is scoped to a single message,
-    // so it targets its driving notification regardless of read state — that
-    // is the reply the row stands for and the one to highlight.
+    // For a whole-`channel` row, ignore notifications you have already read:
+    // the row stands for the entire channel, so once read it should open at
+    // the latest message, not scroll up to an already-seen one. (Read ones
+    // are skipped here; if all are read the loop falls through to the
+    // `latest` fallback.) A read notification is also usually well above the
+    // latest message — you are never notified of your own sends, so the newest
+    // notification is someone else's and predates any message you sent after.
+    //
+    // A thread/message row stands for one specific message, so it always jumps
+    // to its notification's message, read or not — that is the message the row
+    // is about and the one to highlight.
     if (entity.type === 'channel' && notificationIsRead(notification)) continue;
     const { messageId, threadId } = getChannelNotificationParams(notification);
     if (messageId) return { kind: 'message', messageId, threadId };


### PR DESCRIPTION
Channel inbox rows resolved their click target inconsistently: a read whole-channel row jumped to a stale notification far above the latest instead of opening at the bottom, and read thread rows fell back to `{root, root}` — which the channel decoder reads as a reply-within-itself, matching nothing and highlighting nothing. Now a whole-channel row with no unread notification opens at latest, thread/message rows target their driving notification regardless of read state, and `convertTargetMessage` (extracted into a pure, unit-tested module) collapses a message that is its own thread root to a top-level target so it highlights.
