### PR TITLE
fix(ios): invalidate queries on websocket reconnect

### DIFF
--- a/apps/web/src/lib/queries/invalidate-on-reconnect.ts
+++ b/apps/web/src/lib/queries/invalidate-on-reconnect.ts
@@ -1,6 +1,6 @@
+import { createReconnectEffect } from '@macro-inc/collaboration/websocket';
 import { ws } from '@service-connection/websocket';
 import { queryClient } from './client';
-import { createReconnectEffect } from '@macro-inc/collaboration/websocket';
 
 export function useInvalidateQueriesOnReconnect(): void {
   createReconnectEffect(ws, () => {

--- a/apps/web/src/lib/queries/invalidate-on-reconnect.ts
+++ b/apps/web/src/lib/queries/invalidate-on-reconnect.ts
@@ -1,4 +1,3 @@
-
 import { ws } from '@service-connection/websocket';
 import { queryClient } from './client';
 import { createReconnectEffect } from '@macro-inc/collaboration/websocket';

--- a/apps/web/src/lib/queries/invalidate-on-reconnect.ts
+++ b/apps/web/src/lib/queries/invalidate-on-reconnect.ts
@@ -1,0 +1,11 @@
+
+import { ws } from '@service-connection/websocket';
+import { queryClient } from './client';
+import { createReconnectEffect } from '@macro-inc/collaboration/websocket';
+
+export function useInvalidateQueriesOnReconnect(): void {
+  createReconnectEffect(ws, () => {
+    // Marks cached queries as stale and automatically refetches active queries in the background
+    void queryClient.invalidateQueries();
+  });
+}

--- a/apps/web/src/lib/tauri/PushNotification.tsx
+++ b/apps/web/src/lib/tauri/PushNotification.tsx
@@ -12,7 +12,6 @@ import {
   PlatformNotificationProvider,
   triggerNotificationNavigation,
 } from '@notifications';
-import { invalidateUserNotifications } from '@queries/notification/user-notifications';
 import { notificationServiceClient } from '@service-notification/client';
 import { makePersisted } from '@solid-primitives/storage';
 import {
@@ -180,7 +179,6 @@ export function MaybePushNotificationRegistration(props: {
     if (!tapped) return;
     if (!notificationId) return;
 
-    invalidateUserNotifications();
     triggerNotificationNavigation(notificationId);
   });
 

--- a/apps/web/src/routes/Root.tsx
+++ b/apps/web/src/routes/Root.tsx
@@ -397,7 +397,7 @@ function ConfiguredGlobalAppStateProvider(props: ParentProps) {
   useReopenTrackedEntitiesOnReconnect();
 
   if (isNativeMobilePlatform()) {
-      useInvalidateQueriesOnReconnect();
+    useInvalidateQueriesOnReconnect();
   }
 
   const onNotification = (notification: UnifiedNotification) => {

--- a/apps/web/src/routes/Root.tsx
+++ b/apps/web/src/routes/Root.tsx
@@ -17,6 +17,7 @@ import {
 } from '@app/lib/analytics/analytics-context';
 import { PosthogProvider, usePosthog } from '@app/lib/analytics/posthog';
 import { trackSignupCompletion } from '@app/lib/analytics/signupCompletion';
+import { useInvalidateQueriesOnReconnect } from '@app/lib/queries/invalidate-on-reconnect';
 import {
   useEmailSoupBackfill,
   useSoupBackfill,
@@ -77,7 +78,6 @@ import {
 } from '@queries/auth/user-info';
 import { useChatRenameWebsocketSync } from '@queries/chat';
 import { prefetchHistory } from '@queries/history/history';
-import { invalidateUserNotifications } from '@queries/notification/user-notifications';
 import { QuerySyncProvider } from '@queries/sync/SyncProvider';
 import { MutationUndoProvider } from '@queries/undo';
 import { useReopenTrackedEntitiesOnReconnect } from '@service-connection/client';
@@ -396,6 +396,10 @@ function ConfiguredGlobalAppStateProvider(props: ParentProps) {
   useChatRenameWebsocketSync();
   useReopenTrackedEntitiesOnReconnect();
 
+  if (isNativeMobilePlatform()) {
+      useInvalidateQueriesOnReconnect();
+  }
+
   const onNotification = (notification: UnifiedNotification) => {
     if (notifInterface === 'not-supported') return;
     const layoutManager = globalSplitManager();
@@ -410,18 +414,6 @@ function ConfiguredGlobalAppStateProvider(props: ParentProps) {
     connectionGatewayWebsocket,
     onNotification
   );
-
-  if (isNativeMobilePlatform()) {
-    const onVisibilityChange = () => {
-      if (document.visibilityState === 'visible') {
-        invalidateUserNotifications();
-      }
-    };
-    document.addEventListener('visibilitychange', onVisibilityChange);
-    onCleanup(() =>
-      document.removeEventListener('visibilitychange', onVisibilityChange)
-    );
-  }
 
   const blockOrchestrator = createBlockOrchestrator();
   usePendingNotificationNavigationEffect(notificationSource);


### PR DESCRIPTION
If you get disconnected from web socket, and then reconnect, any messages that were sent to you in the interim are, currently, simply gone. Here we implement a quick & dirty recovery mechanism: whenever websocket disconnects, we invalidate all queries. This marks all cached queries as stale and forces any active (i.e. currently mounted) queries to refetch in the background.

Currently this behavior is gated to the ios app only (though we also have no recovery mechanism on desktop, or on mobile web).