### PR TITLE
feat(crm): board scrollbar UX, snapping layout, trimmed default stages

### DIFF
--- a/apps/web/src/features/companies/crm/deal-stages.ts
+++ b/apps/web/src/features/companies/crm/deal-stages.ts
@@ -18,9 +18,9 @@
 import { soupPropertyToProperty } from '@entity/extractors-property';
 import { getCompanyStageOptionId } from '@entity/utils/company-properties';
 import {
+  ALL_COMPANY_STAGE_OPTIONS,
   COMPANY_STAGE_OPTIONS,
   getPropertyOptionLabel,
-  LEGACY_COMPANY_STAGE_OPTIONS,
 } from '@entity/utils/task-properties';
 import {
   CRM_TEAM_STAGE_DEFINITION_NAME,
@@ -86,7 +86,9 @@ const DEFAULT_STAGES: DealStage[] = COMPANY_STAGE_OPTIONS.map((option) => ({
   label: option.label,
 }));
 
-const LEGACY_STAGES: DealStage[] = LEGACY_COMPANY_STAGE_OPTIONS.map(
+// The filterable set on the system default: every system stage, in
+// canonical pipeline order (legacy stages included).
+const ALL_SYSTEM_STAGES: DealStage[] = ALL_COMPANY_STAGE_OPTIONS.map(
   (option) => ({
     id: option.value as string,
     label: option.label,
@@ -234,7 +236,7 @@ export function useDealStages(): DealStages {
   });
 
   const filterStages = createMemo((): DealStage[] =>
-    isCustomized() ? stages() : [...stages(), ...LEGACY_STAGES]
+    isCustomized() ? stages() : ALL_SYSTEM_STAGES
   );
 
   const stageDefinitionId = createMemo(() => {

--- a/apps/web/src/features/companies/crm/deal-stages.ts
+++ b/apps/web/src/features/companies/crm/deal-stages.ts
@@ -20,6 +20,7 @@ import { getCompanyStageOptionId } from '@entity/utils/company-properties';
 import {
   COMPANY_STAGE_OPTIONS,
   getPropertyOptionLabel,
+  LEGACY_COMPANY_STAGE_OPTIONS,
 } from '@entity/utils/task-properties';
 import {
   CRM_TEAM_STAGE_DEFINITION_NAME,
@@ -45,6 +46,12 @@ export type DealStage = {
 export type DealStages = {
   /** Active stages, in display order (team set when customized). */
   stages: Accessor<DealStage[]>;
+  /**
+   * Stages offered by stage *filters*: the active set plus, on the system
+   * default set, the retired legacy stages — companies may still carry
+   * those values and should stay reachable.
+   */
+  filterStages: Accessor<DealStage[]>;
   /** True when the team has its own stage set. */
   isCustomized: Accessor<boolean>;
   /** Definition id stage values are read from / written to. */
@@ -78,6 +85,13 @@ const DEFAULT_STAGES: DealStage[] = COMPANY_STAGE_OPTIONS.map((option) => ({
   id: option.value as string,
   label: option.label,
 }));
+
+const LEGACY_STAGES: DealStage[] = LEGACY_COMPANY_STAGE_OPTIONS.map(
+  (option) => ({
+    id: option.value as string,
+    label: option.label,
+  })
+);
 
 function optionLabel(option: PropertyOption): string {
   const value = option.value;
@@ -219,6 +233,10 @@ export function useDealStages(): DealStages {
     return customStages.length > 0 ? customStages : DEFAULT_STAGES;
   });
 
+  const filterStages = createMemo((): DealStage[] =>
+    isCustomized() ? stages() : [...stages(), ...LEGACY_STAGES]
+  );
+
   const stageDefinitionId = createMemo(() => {
     const definition = teamStageDefinition();
     return definition && stagesFromDefinition(definition).length > 0
@@ -265,6 +283,7 @@ export function useDealStages(): DealStages {
 
   return {
     stages,
+    filterStages,
     isCustomized,
     stageDefinitionId,
     stageProperty,

--- a/apps/web/src/features/entity/utils/task-properties.ts
+++ b/apps/web/src/features/entity/utils/task-properties.ts
@@ -16,27 +16,38 @@ const TASK_PRIORITY_OPTIONS = [
   { value: PROPERTY_OPTION_IDS.PRIORITY.LOW, label: 'Low' },
 ] as const;
 
-export const COMPANY_STAGE_OPTIONS = [
+// Retired from the default stage set, but companies may still carry these
+// values — labels stay resolvable and stage filters still offer them.
+const LEGACY_STAGE_IDS: ReadonlySet<string> = new Set([
+  PROPERTY_OPTION_IDS.STAGE.QUALIFIED,
+  PROPERTY_OPTION_IDS.STAGE.TRIAL,
+  PROPERTY_OPTION_IDS.STAGE.NEGOTIATION,
+]);
+
+/**
+ * Every system stage option in canonical pipeline order — fixes the
+ * display order of stage filters/columns when legacy stages are shown.
+ */
+export const ALL_COMPANY_STAGE_OPTIONS = [
   { value: PROPERTY_OPTION_IDS.STAGE.LEAD, label: 'Lead' },
+  { value: PROPERTY_OPTION_IDS.STAGE.QUALIFIED, label: 'Qualified' },
   { value: PROPERTY_OPTION_IDS.STAGE.DEMO, label: 'Demo' },
+  { value: PROPERTY_OPTION_IDS.STAGE.TRIAL, label: 'Trial' },
+  { value: PROPERTY_OPTION_IDS.STAGE.NEGOTIATION, label: 'Negotiation' },
   { value: PROPERTY_OPTION_IDS.STAGE.CUSTOMER, label: 'Customer' },
   { value: PROPERTY_OPTION_IDS.STAGE.CHURNED, label: 'Churned' },
 ] as const;
 
-// Retired from the default stage set, but companies may still carry these
-// values — keep their labels resolvable and offer them in stage filters.
-export const LEGACY_COMPANY_STAGE_OPTIONS = [
-  { value: PROPERTY_OPTION_IDS.STAGE.QUALIFIED, label: 'Qualified' },
-  { value: PROPERTY_OPTION_IDS.STAGE.TRIAL, label: 'Trial' },
-  { value: PROPERTY_OPTION_IDS.STAGE.NEGOTIATION, label: 'Negotiation' },
-] as const;
+/** The default (non-legacy) stage set, in canonical order. */
+export const COMPANY_STAGE_OPTIONS = ALL_COMPANY_STAGE_OPTIONS.filter(
+  (option) => !LEGACY_STAGE_IDS.has(option.value)
+);
 
 const PROPERTY_OPTION_LABELS: Record<string, string> = {
   ...Object.fromEntries(TASK_STATUS_OPTIONS.map((o) => [o.value, o.label])),
   ...Object.fromEntries(TASK_PRIORITY_OPTIONS.map((o) => [o.value, o.label])),
-  ...Object.fromEntries(COMPANY_STAGE_OPTIONS.map((o) => [o.value, o.label])),
   ...Object.fromEntries(
-    LEGACY_COMPANY_STAGE_OPTIONS.map((o) => [o.value, o.label])
+    ALL_COMPANY_STAGE_OPTIONS.map((o) => [o.value, o.label])
   ),
 };
 

--- a/apps/web/src/features/entity/utils/task-properties.ts
+++ b/apps/web/src/features/entity/utils/task-properties.ts
@@ -18,18 +18,26 @@ const TASK_PRIORITY_OPTIONS = [
 
 export const COMPANY_STAGE_OPTIONS = [
   { value: PROPERTY_OPTION_IDS.STAGE.LEAD, label: 'Lead' },
-  { value: PROPERTY_OPTION_IDS.STAGE.QUALIFIED, label: 'Qualified' },
   { value: PROPERTY_OPTION_IDS.STAGE.DEMO, label: 'Demo' },
-  { value: PROPERTY_OPTION_IDS.STAGE.TRIAL, label: 'Trial' },
-  { value: PROPERTY_OPTION_IDS.STAGE.NEGOTIATION, label: 'Negotiation' },
   { value: PROPERTY_OPTION_IDS.STAGE.CUSTOMER, label: 'Customer' },
   { value: PROPERTY_OPTION_IDS.STAGE.CHURNED, label: 'Churned' },
+] as const;
+
+// Retired from the default stage set, but companies may still carry these
+// values — keep their labels resolvable.
+const LEGACY_COMPANY_STAGE_OPTIONS = [
+  { value: PROPERTY_OPTION_IDS.STAGE.QUALIFIED, label: 'Qualified' },
+  { value: PROPERTY_OPTION_IDS.STAGE.TRIAL, label: 'Trial' },
+  { value: PROPERTY_OPTION_IDS.STAGE.NEGOTIATION, label: 'Negotiation' },
 ] as const;
 
 const PROPERTY_OPTION_LABELS: Record<string, string> = {
   ...Object.fromEntries(TASK_STATUS_OPTIONS.map((o) => [o.value, o.label])),
   ...Object.fromEntries(TASK_PRIORITY_OPTIONS.map((o) => [o.value, o.label])),
   ...Object.fromEntries(COMPANY_STAGE_OPTIONS.map((o) => [o.value, o.label])),
+  ...Object.fromEntries(
+    LEGACY_COMPANY_STAGE_OPTIONS.map((o) => [o.value, o.label])
+  ),
 };
 
 export const getPropertyOptionLabel = (

--- a/apps/web/src/features/entity/utils/task-properties.ts
+++ b/apps/web/src/features/entity/utils/task-properties.ts
@@ -24,8 +24,8 @@ export const COMPANY_STAGE_OPTIONS = [
 ] as const;
 
 // Retired from the default stage set, but companies may still carry these
-// values — keep their labels resolvable.
-const LEGACY_COMPANY_STAGE_OPTIONS = [
+// values — keep their labels resolvable and offer them in stage filters.
+export const LEGACY_COMPANY_STAGE_OPTIONS = [
   { value: PROPERTY_OPTION_IDS.STAGE.QUALIFIED, label: 'Qualified' },
   { value: PROPERTY_OPTION_IDS.STAGE.TRIAL, label: 'Trial' },
   { value: PROPERTY_OPTION_IDS.STAGE.NEGOTIATION, label: 'Negotiation' },

--- a/apps/web/src/features/next-soup/soup-view/filters-bar/consolidated-filter-chip.tsx
+++ b/apps/web/src/features/next-soup/soup-view/filters-bar/consolidated-filter-chip.tsx
@@ -53,6 +53,8 @@ export type ConsolidatedFilter = {
   searchPlaceholder?: string;
   isPopupOpen?: Accessor<boolean>;
   setPopupOpen?: (v: boolean) => void;
+  /** Keep options in their given order instead of pinning selected first. */
+  preserveOptionOrder?: boolean;
 };
 
 interface ConsolidatedFilterChipProps {
@@ -257,6 +259,7 @@ const SearchableValueSegment = (props: {
       placement="bottom-start"
       open={props.filter.isPopupOpen}
       onOpenChange={(v) => props.filter.setPopupOpen?.(v)}
+      preserveOrder={props.filter.preserveOptionOrder}
     >
       <Combobox.Trigger
         class={cn(

--- a/apps/web/src/features/next-soup/soup-view/filters-bar/searchable-multi-select.tsx
+++ b/apps/web/src/features/next-soup/soup-view/filters-bar/searchable-multi-select.tsx
@@ -317,6 +317,8 @@ type SearchableMultiSelectInlineProps = {
   inputRef?: (el: HTMLInputElement) => void;
   onRequestClose?: () => void;
   listboxClass?: string;
+  /** Keep `options` in their given order instead of pinning selected first. */
+  preserveOrder?: boolean;
 };
 
 /**
@@ -335,12 +337,14 @@ export const SearchableMultiSelectInline = (
   // Inline variant is freshly mounted each time the parent submenu opens,
   // so we don't need an explicit "menu opened" trigger — the memo's first
   // run captures the current selection ordering.
-  const sortedOptions = useSelectedFirst({
+  const selectedFirstOptions = useSelectedFirst({
     items: props.options,
     selectedIds: props.activeIds,
     searchQuery,
     getId: getOptionId,
   });
+  const sortedOptions = () =>
+    props.preserveOrder ? props.options() : selectedFirstOptions();
 
   const handleChange = (selected: SearchableOption[]) => {
     props.onChange(selected.map((o) => o.id));

--- a/apps/web/src/features/next-soup/soup-view/filters-bar/unified-filter-dropdown.tsx
+++ b/apps/web/src/features/next-soup/soup-view/filters-bar/unified-filter-dropdown.tsx
@@ -782,20 +782,26 @@ export const UnifiedFilterDropdown = (
     },
   ]);
 
-  // The stage submenu reflects what's on screen: an empty filter shows
-  // every stage, so everything reads as checked.
+  // The stage set shown when no filter is active: the active deal stages
+  // plus "No stage" — retired legacy stages only display when filtered in.
+  const defaultStageIds = createMemo(
+    () => new Set([...dealStages.stages().map((stage) => stage.id), NO_STAGE])
+  );
+
+  // The stage submenu reflects what's on screen: an empty filter shows the
+  // default columns, so exactly those read as checked (legacy stages don't).
   const effectiveStageFilter = () =>
-    stageFilter().length > 0
-      ? stageFilter()
-      : stageOptions().map((option) => option.id);
+    stageFilter().length > 0 ? stageFilter() : [...defaultStageIds()];
 
   // Stage filtering is a client-side predicate, mirroring the owner filter.
   const handleStageChange = (ids: string[]) => {
-    // Checking every stage is the same as no filter — store it as empty so
-    // the predicate deactivates.
-    const next = stageOptions().every((option) => ids.includes(option.id))
-      ? []
-      : ids;
+    // Checking exactly the default set is the same as no filter — store it
+    // as empty so the predicate deactivates.
+    const next =
+      ids.length === defaultStageIds().size &&
+      ids.every((id) => defaultStageIds().has(id))
+        ? []
+        : ids;
     batch(() => {
       setStageFilter(next);
       const shouldBeActive = next.length > 0;

--- a/apps/web/src/features/next-soup/soup-view/filters-bar/unified-filter-dropdown.tsx
+++ b/apps/web/src/features/next-soup/soup-view/filters-bar/unified-filter-dropdown.tsx
@@ -765,9 +765,10 @@ export const UnifiedFilterDropdown = (
   };
 
   // Stage options for the Customers view: the team's active deal-stage set
-  // plus a trailing "No stage" row.
+  // (plus retired legacy stages on the default set) and a trailing
+  // "No stage" row.
   const stageOptions = createMemo((): SearchableOption[] => [
-    ...dealStages.stages().map((stage, index) => ({
+    ...dealStages.filterStages().map((stage, index) => ({
       id: stage.id,
       label: stage.label,
       icon: () => (

--- a/apps/web/src/features/next-soup/soup-view/filters-bar/unified-filter-dropdown.tsx
+++ b/apps/web/src/features/next-soup/soup-view/filters-bar/unified-filter-dropdown.tsx
@@ -397,6 +397,8 @@ const SearchableFilterSubmenu = (props: {
   placeholder?: string;
   open?: Accessor<boolean>;
   onOpenChange?: (v: boolean) => void;
+  /** Keep `options` in their given order instead of pinning selected first. */
+  preserveOrder?: boolean;
 }) => {
   const [internalOpen, setInternalOpen] = createSignal(false);
   const isOpen = () => props.open?.() ?? internalOpen();
@@ -468,6 +470,7 @@ const SearchableFilterSubmenu = (props: {
             onChange={props.onChange}
             options={props.options}
             inputRef={setInputRef}
+            preserveOrder={props.preserveOrder}
           />
         </Dropdown.Group>
       </Dropdown.SubContent>
@@ -968,6 +971,7 @@ export const UnifiedFilterDropdown = (
                       activeIds={effectiveStageFilter}
                       onChange={handleStageChange}
                       placeholder="Filter stages..."
+                      preserveOrder
                     />
                     <SearchableFilterSubmenu
                       label="Owner"

--- a/apps/web/src/features/next-soup/soup-view/filters-bar/use-filter-refinements.tsx
+++ b/apps/web/src/features/next-soup/soup-view/filters-bar/use-filter-refinements.tsx
@@ -816,6 +816,9 @@ export function useFilterRefinements() {
             activeSearchableIds: stageFilter,
             onSearchableChange: handleStageChange,
             searchPlaceholder: 'Filter stages...',
+            // Stages read as a pipeline — keep canonical order, don't pin
+            // checked ones to the top.
+            preserveOptionOrder: true,
             isPopupOpen,
             setPopupOpen,
             onRemoveAll: () => handleStageChange([]),

--- a/apps/web/src/features/next-soup/soup-view/filters-bar/use-filter-refinements.tsx
+++ b/apps/web/src/features/next-soup/soup-view/filters-bar/use-filter-refinements.tsx
@@ -300,10 +300,11 @@ export function useFilterRefinements() {
 
   /**
    * Stage options for the Customers view's stage sub-filter: the team's
-   * active deal-stage set plus a trailing "No stage" row.
+   * active deal-stage set (plus retired legacy stages on the default set)
+   * and a trailing "No stage" row.
    */
   const stageSearchableOptions = createMemo((): SearchableOption[] => [
-    ...dealStages.stages().map((stage, index) => ({
+    ...dealStages.filterStages().map((stage, index) => ({
       id: stage.id,
       label: stage.label,
       icon: () => (

--- a/apps/web/src/features/next-soup/soup-view/soup-view-context.tsx
+++ b/apps/web/src/features/next-soup/soup-view/soup-view-context.tsx
@@ -224,6 +224,14 @@ export const SoupViewContextProvider: FlowComponent<
   const resolveTransport = (groupBy: GroupByField | undefined) =>
     useGraphqlSoupFF().enabled && !groupBy ? 'graphql' : undefined;
 
+  const panel = useSplitPanelOrThrow();
+
+  const activeListView = createMemo<ListView | undefined>(() => {
+    const content = panel.handle.content();
+    if (content.type !== 'component') return;
+    return isListViewID(content.id) ? content.id : undefined;
+  });
+
   const soupParams = createMemo(() => {
     const sortId = soup.sort.active()[0]?.id ?? 'updated_at';
 
@@ -233,12 +241,12 @@ export const SoupViewContextProvider: FlowComponent<
       : 'created_at';
 
     return {
-      limit: 100,
+      // CRM views load every company (drained eagerly below), so use the
+      // backend's max page size to cut round trips.
+      limit: activeListView() === 'companies' ? 500 : 100,
       sort_method: sortMethod,
     };
   });
-
-  const panel = useSplitPanelOrThrow();
 
   const store = createQueryStore({
     initial: props.initialQuery,
@@ -409,12 +417,6 @@ export const SoupViewContextProvider: FlowComponent<
     dealStages.resolveStage(
       entity as Parameters<typeof dealStages.resolveStage>[0]
     );
-
-  const activeListView = createMemo<ListView | undefined>(() => {
-    const content = panel.handle.content();
-    if (content.type !== 'component') return;
-    return isListViewID(content.id) ? content.id : undefined;
-  });
 
   // CRM companies come back from a dedicated soup request (not the dynamic
   // query the server-side grouped path is built on), so property grouping on
@@ -689,6 +691,16 @@ export const SoupViewContextProvider: FlowComponent<
       }
     },
   };
+
+  // CRM views (list and board) render the full company set — the board has no
+  // scroll pagination and the list groups client-side — so keep paging until
+  // the query is drained.
+  createEffect(() => {
+    if (activeListView() !== 'companies') return;
+    if (!itemsSource.isEnabled() || itemsSource.isFetching()) return;
+    if (!reactiveActive() && itemsQuery.isError) return;
+    if (itemsSource.hasNextPage()) itemsSource.fetchNextPage();
+  });
 
   const items = createMemo<SoupEntity[]>(
     (prev) => {

--- a/apps/web/src/features/next-soup/soup-view/soup-view-context.tsx
+++ b/apps/web/src/features/next-soup/soup-view/soup-view-context.tsx
@@ -224,14 +224,6 @@ export const SoupViewContextProvider: FlowComponent<
   const resolveTransport = (groupBy: GroupByField | undefined) =>
     useGraphqlSoupFF().enabled && !groupBy ? 'graphql' : undefined;
 
-  const panel = useSplitPanelOrThrow();
-
-  const activeListView = createMemo<ListView | undefined>(() => {
-    const content = panel.handle.content();
-    if (content.type !== 'component') return;
-    return isListViewID(content.id) ? content.id : undefined;
-  });
-
   const soupParams = createMemo(() => {
     const sortId = soup.sort.active()[0]?.id ?? 'updated_at';
 
@@ -241,12 +233,12 @@ export const SoupViewContextProvider: FlowComponent<
       : 'created_at';
 
     return {
-      // CRM views load every company (drained eagerly below), so use the
-      // backend's max page size to cut round trips.
-      limit: activeListView() === 'companies' ? 500 : 100,
+      limit: 100,
       sort_method: sortMethod,
     };
   });
+
+  const panel = useSplitPanelOrThrow();
 
   const store = createQueryStore({
     initial: props.initialQuery,
@@ -417,6 +409,12 @@ export const SoupViewContextProvider: FlowComponent<
     dealStages.resolveStage(
       entity as Parameters<typeof dealStages.resolveStage>[0]
     );
+
+  const activeListView = createMemo<ListView | undefined>(() => {
+    const content = panel.handle.content();
+    if (content.type !== 'component') return;
+    return isListViewID(content.id) ? content.id : undefined;
+  });
 
   // CRM companies come back from a dedicated soup request (not the dynamic
   // query the server-side grouped path is built on), so property grouping on
@@ -691,16 +689,6 @@ export const SoupViewContextProvider: FlowComponent<
       }
     },
   };
-
-  // CRM views (list and board) render the full company set — the board has no
-  // scroll pagination and the list groups client-side — so keep paging until
-  // the query is drained.
-  createEffect(() => {
-    if (activeListView() !== 'companies') return;
-    if (!itemsSource.isEnabled() || itemsSource.isFetching()) return;
-    if (!reactiveActive() && itemsQuery.isError) return;
-    if (itemsSource.hasNextPage()) itemsSource.fetchNextPage();
-  });
 
   const items = createMemo<SoupEntity[]>(
     (prev) => {

--- a/apps/web/src/features/next-soup/soup-view/soup-view.tsx
+++ b/apps/web/src/features/next-soup/soup-view/soup-view.tsx
@@ -752,9 +752,14 @@ export const SoupView = (props: SoupViewProps) => {
         </div>
       </div>
       <Suspense>
+        {/* The board hides the AI bar: it floats over the bottom edge, where
+            it would cover the board's horizontal scrollbar. */}
         <Show
           when={
-            ENABLE_UNIFIED_LIST_AI_INPUT && !isMobile() && !isNewInboxEnabled()
+            ENABLE_UNIFIED_LIST_AI_INPUT &&
+            !isMobile() &&
+            !isNewInboxEnabled() &&
+            !isBoardMode()
           }
         >
           <SoupChatInput />

--- a/apps/web/src/features/next-soup/soup-view/soup-view.tsx
+++ b/apps/web/src/features/next-soup/soup-view/soup-view.tsx
@@ -44,10 +44,7 @@ import {
 import { CompanyKanban } from '@app/features/next-soup/soup-view/views/companies/CompanyKanban';
 import { CompanyListEntity } from '@app/features/next-soup/soup-view/views/companies/CompanyListEntity';
 import { ResponsiveCompanyListHeader } from '@app/features/next-soup/soup-view/views/companies/CompanyListHeader';
-import {
-  CompanyDisplayMenu,
-  CompanyViewsMenu,
-} from '@app/features/next-soup/soup-view/views/companies/CompanyViewsMenu';
+import { CompanyDisplayMenu } from '@app/features/next-soup/soup-view/views/companies/CompanyViewsMenu';
 import { DateGroupHeader } from '@app/features/next-soup/soup-view/views/inbox/date-group-header';
 import { InboxListEntity } from '@app/features/next-soup/soup-view/views/inbox/InboxListEntity';
 import { TaskListEntity } from '@app/features/next-soup/soup-view/views/tasks/TaskListEntity';
@@ -667,7 +664,6 @@ export const SoupView = (props: SoupViewProps) => {
                   !narrowSearchExpanded() && isComponentListView('companies')
                 }
               >
-                <CompanyViewsMenu />
                 <CompanyDisplayMenu />
               </Show>
               <Show

--- a/apps/web/src/features/next-soup/soup-view/views/companies/CompanyKanban.tsx
+++ b/apps/web/src/features/next-soup/soup-view/views/companies/CompanyKanban.tsx
@@ -63,39 +63,31 @@ export function CompanyKanban() {
   const saveMutation = useBulkSaveEntityPropertiesMutation();
   const orchestrator = useGlobalBlockOrchestrator();
 
-  const { stages, stageProperty, resolveStage, stageLabel } = useDealStages();
+  const { stages, filterStages, stageProperty, resolveStage } = useDealStages();
   const { canEditCrm, canMoveClosedDeals } = useCrmPermissions();
   const closedStageIds = useClosedStageIds(stages);
 
   const stageColumns = createMemo((): StageColumn[] => {
-    const all: StageColumn[] = [
-      ...stages().map((stage) => ({ key: stage.id, label: stage.label })),
+    // Candidates in canonical pipeline order: the filterable set (active
+    // stages plus retired legacy stages on the system default), then
+    // "No stage" — checked columns always render in this fixed order.
+    const candidates: StageColumn[] = [
+      ...filterStages().map((stage) => ({ key: stage.id, label: stage.label })),
       { key: NO_STAGE_KEY, label: 'No stage' },
     ];
     // An active stage filter removes the filtered-out columns entirely,
-    // not just their (already predicate-filtered) cards.
+    // not just their (already predicate-filtered) cards. With no filter,
+    // only the active stage set shows (legacy stages are opt-in).
     const filter = stageFilter();
-    if (filter.length === 0) return all;
-    const kept = all.filter((column) =>
+    if (filter.length === 0) {
+      const active = new Set(stages().map((stage) => stage.id));
+      return candidates.filter(
+        (column) => column.key === NO_STAGE_KEY || active.has(column.key)
+      );
+    }
+    return candidates.filter((column) =>
       filter.includes(column.key === NO_STAGE_KEY ? NO_STAGE : column.key)
     );
-    // Filtered-in stages outside the active set (retired legacy stages) get
-    // their own column so their companies stay visible; keep "No stage" last.
-    const known = new Set(all.map((column) => column.key));
-    const extras = filter
-      .filter((id) => id !== NO_STAGE && !known.has(id))
-      .map((id) => ({ key: id, label: stageLabel(id) ?? 'Unknown stage' }));
-    if (extras.length === 0) return kept;
-    const noStageIndex = kept.findIndex(
-      (column) => column.key === NO_STAGE_KEY
-    );
-    return noStageIndex === -1
-      ? [...kept, ...extras]
-      : [
-          ...kept.slice(0, noStageIndex),
-          ...extras,
-          ...kept.slice(noStageIndex),
-        ];
   });
 
   const { paneVisible, selectedEntity } = usePreviewPaneVisiblity();

--- a/apps/web/src/features/next-soup/soup-view/views/companies/CompanyKanban.tsx
+++ b/apps/web/src/features/next-soup/soup-view/views/companies/CompanyKanban.tsx
@@ -63,7 +63,7 @@ export function CompanyKanban() {
   const saveMutation = useBulkSaveEntityPropertiesMutation();
   const orchestrator = useGlobalBlockOrchestrator();
 
-  const { stages, stageProperty, resolveStage } = useDealStages();
+  const { stages, stageProperty, resolveStage, stageLabel } = useDealStages();
   const { canEditCrm, canMoveClosedDeals } = useCrmPermissions();
   const closedStageIds = useClosedStageIds(stages);
 
@@ -76,9 +76,26 @@ export function CompanyKanban() {
     // not just their (already predicate-filtered) cards.
     const filter = stageFilter();
     if (filter.length === 0) return all;
-    return all.filter((column) =>
+    const kept = all.filter((column) =>
       filter.includes(column.key === NO_STAGE_KEY ? NO_STAGE : column.key)
     );
+    // Filtered-in stages outside the active set (retired legacy stages) get
+    // their own column so their companies stay visible; keep "No stage" last.
+    const known = new Set(all.map((column) => column.key));
+    const extras = filter
+      .filter((id) => id !== NO_STAGE && !known.has(id))
+      .map((id) => ({ key: id, label: stageLabel(id) ?? 'Unknown stage' }));
+    if (extras.length === 0) return kept;
+    const noStageIndex = kept.findIndex(
+      (column) => column.key === NO_STAGE_KEY
+    );
+    return noStageIndex === -1
+      ? [...kept, ...extras]
+      : [
+          ...kept.slice(0, noStageIndex),
+          ...extras,
+          ...kept.slice(noStageIndex),
+        ];
   });
 
   const { paneVisible, selectedEntity } = usePreviewPaneVisiblity();

--- a/apps/web/src/features/next-soup/soup-view/views/companies/CompanyKanban.tsx
+++ b/apps/web/src/features/next-soup/soup-view/views/companies/CompanyKanban.tsx
@@ -247,7 +247,15 @@ export function CompanyKanban() {
               </For>
             </div>
           </div>
-          <CustomScrollbar scrollContainer={scrollRef} horizontal />
+          {/* watchContent: columns mount after the initial measurement, so
+              overflow must be re-detected as they load in. */}
+          <CustomScrollbar
+            scrollContainer={scrollRef}
+            horizontal
+            revealZone={48}
+            gutterSize={20}
+            watchContent
+          />
         </div>
       </Resize.Panel>
       <Show when={paneVisible()}>

--- a/apps/web/src/features/next-soup/soup-view/views/companies/CompanyKanban.tsx
+++ b/apps/web/src/features/next-soup/soup-view/views/companies/CompanyKanban.tsx
@@ -26,11 +26,19 @@ import {
 import CircleDashed from '@phosphor/circle-dashed.svg';
 import { useBulkSaveEntityPropertiesMutation } from '@queries/properties/entity';
 import { EntityType } from '@service-properties/generated/schemas/entityType';
+import { createElementSize } from '@solid-primitives/resize-observer';
 import { cn, EmptyStatePanel, Layer } from '@ui';
 import { createMemo, createSignal, For, Show } from 'solid-js';
 
 /** Column key for companies without a Stage value. */
 const NO_STAGE_KEY = '';
+
+/** Minimum column width the snapping layout will shrink to. */
+const MIN_COLUMN_WIDTH = 224;
+/** gap-3 between columns. */
+const COLUMN_GAP = 12;
+/** p-3 on each side of the column row. */
+const BOARD_PADDING_X = 24;
 
 type StageColumn = {
   key: string;
@@ -103,6 +111,27 @@ export function CompanyKanban() {
   const [dropTarget, setDropTarget] = createSignal<string>();
   const [scrollRef, setScrollRef] = createSignal<HTMLDivElement>();
 
+  // Columns snap to a whole-column layout: as many columns as fit at the
+  // minimum width, each widened to exactly fill the viewport. Growing the
+  // board snaps in the next column once there's room; the rest scroll.
+  const boardSize = createElementSize(scrollRef);
+  const columnWidth = createMemo(() => {
+    const width = boardSize.width;
+    const count = stageColumns().length;
+    if (!width || count === 0) return undefined;
+    const usable = width - BOARD_PADDING_X;
+    const fit = Math.max(
+      1,
+      Math.min(
+        count,
+        Math.floor((usable + COLUMN_GAP) / (MIN_COLUMN_WIDTH + COLUMN_GAP))
+      )
+    );
+    // Floored so rounding can't overflow the viewport by a pixel and
+    // phantom-trigger the horizontal scrollbar.
+    return Math.floor((usable - (fit - 1) * COLUMN_GAP) / fit);
+  });
+
   const moveToStage = (entityId: string, stageKey: string) => {
     const entity = companies().find((company) => company.id === entityId);
     if (!entity) return;
@@ -161,13 +190,18 @@ export function CompanyKanban() {
                 {(column, columnIndex) => (
                   <div
                     class={cn(
-                      // Columns split the available width evenly, but never
-                      // shrink below w-64 — past that the board scrolls.
-                      'flex h-full min-w-64 flex-1 flex-col rounded-lg border border-edge-muted bg-surface',
+                      // Fallback sizing until the board is measured; after
+                      // that the snapping columnWidth() takes over.
+                      'flex h-full min-w-56 flex-1 flex-col rounded-lg border border-edge-muted bg-surface',
                       dropTarget() === column.key &&
                         draggedId() &&
                         'border-accent/50 bg-accent/5'
                     )}
+                    style={
+                      columnWidth() !== undefined
+                        ? { width: `${columnWidth()}px`, flex: 'none' }
+                        : undefined
+                    }
                     onDragOver={(e) => {
                       if (!draggedId()) return;
                       e.preventDefault();

--- a/apps/web/src/features/next-soup/soup-view/views/companies/CompanyKanban.tsx
+++ b/apps/web/src/features/next-soup/soup-view/views/companies/CompanyKanban.tsx
@@ -205,9 +205,6 @@ export function CompanyKanban() {
                         />
                       </Show>
                       <span class="truncate">{column.label}</span>
-                      <span class="ml-auto shrink-0 tabular-nums px-1.5 py-px rounded-full bg-ink/10 text-ink-extra-muted font-medium">
-                        {column.entities.length}
-                      </span>
                     </div>
                     <div class="min-h-0 flex-1 overflow-y-auto scrollbar-hidden flex flex-col gap-2 px-2 pb-2">
                       <For each={column.entities}>

--- a/apps/web/src/features/next-soup/soup-view/views/companies/CompanyViewsMenu.tsx
+++ b/apps/web/src/features/next-soup/soup-view/views/companies/CompanyViewsMenu.tsx
@@ -313,56 +313,71 @@ export function CompanyViewsMenu() {
  */
 export function CompanyDisplayMenu() {
   const { options, toggleListColumn } = useCrmDisplayOptions();
-  const { activeTab } = useSoupView();
+  const { activeTab, viewMode } = useSoupView();
   const { applyTabPreset } = useApplyPreset();
   const isTeamAdmin = useIsTeamAdmin();
 
   const showingHidden = () => activeTab() === 'hidden';
 
-  return (
-    <Dropdown>
-      <Tooltip label="Display options">
-        <Dropdown.Trigger depth={2} class="bg-surface" label="Display options">
-          <SlidersIcon />
-        </Dropdown.Trigger>
-      </Tooltip>
+  // On the board, the menu holds only the admin-gated hidden toggle — hide
+  // the trigger entirely when there'd be nothing to show.
+  const hasContent = () => viewMode() === 'list' || isTeamAdmin();
 
-      <Dropdown.Content class="w-56 shadow-menu">
-        <Dropdown.Group>
-          <Dropdown.GroupLabel>List columns</Dropdown.GroupLabel>
-          <For each={Object.keys(CRM_LIST_COLUMN_LABELS) as CrmListColumnId[]}>
-            {(column) => (
+  return (
+    <Show when={hasContent()}>
+      <Dropdown>
+        <Tooltip label="Display options">
+          <Dropdown.Trigger
+            depth={2}
+            class="bg-surface"
+            label="Display options"
+          >
+            <SlidersIcon />
+          </Dropdown.Trigger>
+        </Tooltip>
+
+        <Dropdown.Content class="w-56 shadow-menu">
+          {/* Column visibility only applies to the list. */}
+          <Show when={viewMode() === 'list'}>
+            <Dropdown.Group>
+              <Dropdown.GroupLabel>List columns</Dropdown.GroupLabel>
+              <For
+                each={Object.keys(CRM_LIST_COLUMN_LABELS) as CrmListColumnId[]}
+              >
+                {(column) => (
+                  <Dropdown.CheckboxItem
+                    checked={options().listColumns[column]}
+                    onChange={() => toggleListColumn(column)}
+                    closeOnSelect={false}
+                  >
+                    <span class="flex-1 truncate">
+                      {CRM_LIST_COLUMN_LABELS[column]}
+                    </span>
+                  </Dropdown.CheckboxItem>
+                )}
+              </For>
+            </Dropdown.Group>
+          </Show>
+          {/* Admin/owner only — the BE rejects hidden-set requests from
+            non-admins, matching the old Hidden tab's gating. */}
+          <Show when={isTeamAdmin()}>
+            <Dropdown.Group>
               <Dropdown.CheckboxItem
-                checked={options().listColumns[column]}
-                onChange={() => toggleListColumn(column)}
+                checked={showingHidden()}
+                onChange={() =>
+                  applyTabPreset(
+                    'companies',
+                    showingHidden() ? 'active' : 'hidden'
+                  )
+                }
                 closeOnSelect={false}
               >
-                <span class="flex-1 truncate">
-                  {CRM_LIST_COLUMN_LABELS[column]}
-                </span>
+                <span class="flex-1 truncate">Show hidden companies</span>
               </Dropdown.CheckboxItem>
-            )}
-          </For>
-        </Dropdown.Group>
-        {/* Admin/owner only — the BE rejects hidden-set requests from
-            non-admins, matching the old Hidden tab's gating. */}
-        <Show when={isTeamAdmin()}>
-          <Dropdown.Group>
-            <Dropdown.CheckboxItem
-              checked={showingHidden()}
-              onChange={() =>
-                applyTabPreset(
-                  'companies',
-                  showingHidden() ? 'active' : 'hidden'
-                )
-              }
-              closeOnSelect={false}
-            >
-              <span class="flex-1 truncate">Show hidden companies</span>
-            </Dropdown.CheckboxItem>
-          </Dropdown.Group>
-        </Show>
-      </Dropdown.Content>
-    </Dropdown>
+            </Dropdown.Group>
+          </Show>
+        </Dropdown.Content>
+      </Dropdown>
+    </Show>
   );
 }

--- a/apps/web/src/lib/core/component/CustomScrollbar.tsx
+++ b/apps/web/src/lib/core/component/CustomScrollbar.tsx
@@ -248,8 +248,15 @@ function InnerCustomScrollbar(props: CustomScrollbarProps) {
             : (e) => {
                 const container = props.scrollContainer();
                 if (!container) return;
-                container.scrollLeft += e.deltaX || (e.shiftKey ? e.deltaY : 0);
-                container.scrollTop += e.deltaY;
+                // Consume the event so ancestors don't also scroll, and
+                // drive only the axis this bar owns.
+                e.preventDefault();
+                if (horiz()) {
+                  container.scrollLeft +=
+                    e.deltaX || (e.shiftKey ? e.deltaY : 0);
+                } else {
+                  container.scrollTop += e.deltaY;
+                }
               }
         }
         onPointerDown={handlePointerDown}

--- a/apps/web/src/lib/core/component/CustomScrollbar.tsx
+++ b/apps/web/src/lib/core/component/CustomScrollbar.tsx
@@ -12,6 +12,22 @@ interface CustomScrollbarProps {
   enabled?: boolean;
   reverse?: boolean;
   horizontal?: boolean;
+  /**
+   * Reveal the bar when the pointer moves within this many px of the
+   * scrollbar edge, instead of only when hovering the gutter itself.
+   */
+  revealZone?: number;
+  /**
+   * Re-measure when content mounts/unmounts inside the container. Needed
+   * when content loads in after mount without resizing the container.
+   */
+  watchContent?: boolean;
+  /**
+   * Thickness (px) of the interactive gutter for clicking/dragging the bar.
+   * Defaults to 8. The thumb stays anchored to the scrollbar edge, and wheel
+   * events over an enlarged gutter are forwarded to the container.
+   */
+  gutterSize?: number;
 }
 
 const MIN_THUMB_SIZE = 24;
@@ -111,14 +127,46 @@ function InnerCustomScrollbar(props: CustomScrollbarProps) {
     };
 
     container.addEventListener('scroll', handleScroll, { passive: true });
+
+    // Proximity reveal: pointer movement near the scrollbar edge shows the
+    // bar without the gutter needing a click-stealing enlarged hit area.
+    const handleProximity = (e: PointerEvent) => {
+      const zone = props.revealZone;
+      if (zone === undefined) return;
+      const rect = container.getBoundingClientRect();
+      const dist = horiz() ? rect.bottom - e.clientY : rect.right - e.clientX;
+      setIsHovered(dist >= 0 && dist <= zone);
+    };
+    const handleProximityLeave = () => {
+      if (props.revealZone !== undefined) setIsHovered(false);
+    };
+    container.addEventListener('pointermove', handleProximity, {
+      passive: true,
+    });
+    container.addEventListener('pointerleave', handleProximityLeave);
+
     const resizeObserver = new ResizeObserver(updateScrollMetrics);
     resizeObserver.observe(container);
 
+    let mutationObserver: MutationObserver | undefined;
+    if (props.watchContent) {
+      mutationObserver = new MutationObserver(updateScrollMetrics);
+      mutationObserver.observe(container, { childList: true, subtree: true });
+    }
+
     onCleanup(() => {
       container.removeEventListener('scroll', handleScroll);
+      container.removeEventListener('pointermove', handleProximity);
+      container.removeEventListener('pointerleave', handleProximityLeave);
       resizeObserver.disconnect();
+      mutationObserver?.disconnect();
     });
   });
+
+  // Where the pointer grabbed the thumb, relative to the thumb's start.
+  // Keeps the grab point under the pointer while dragging instead of
+  // snapping the thumb's center to it.
+  let dragOffset = 0;
 
   const scrollToPointer = (clientPos: number, gutterRect: DOMRect) => {
     const container = props.scrollContainer();
@@ -128,7 +176,7 @@ function InnerCustomScrollbar(props: CustomScrollbarProps) {
     const mt = maxTop();
     if (mt <= 0) return;
     const start = horiz() ? gutterRect.left : gutterRect.top;
-    const localPos = clientPos - start - thumbSize() / 2;
+    const localPos = clientPos - start - dragOffset;
     const clamped = Math.max(0, Math.min(mt, localPos - THUMB_INSET));
     let newPos = (clamped / mt) * max;
     if (props.reverse && !horiz()) newPos = newPos - max;
@@ -148,7 +196,14 @@ function InnerCustomScrollbar(props: CustomScrollbarProps) {
     setIsDragging(true);
     setIsScrolling(true);
     const rect = gutter.getBoundingClientRect();
-    scrollToPointer(horiz() ? e.clientX : e.clientY, rect);
+    const clientPos = horiz() ? e.clientX : e.clientY;
+    const local = clientPos - (horiz() ? rect.left : rect.top);
+    const onThumb =
+      local >= thumbOffset() && local <= thumbOffset() + thumbSize();
+    // Grabbing the thumb holds it in place until dragged; clicking the
+    // track jumps there (centering the thumb on the pointer).
+    dragOffset = onThumb ? local - thumbOffset() : thumbSize() / 2;
+    if (!onThumb) scrollToPointer(clientPos, rect);
   };
 
   const handlePointerMove = (e: PointerEvent) => {
@@ -178,8 +233,24 @@ function InnerCustomScrollbar(props: CustomScrollbarProps) {
         )}
         style={
           horiz()
-            ? { height: `${GUTTER_SIZE}px`, 'touch-action': 'none' }
-            : { width: `${GUTTER_SIZE}px`, 'touch-action': 'none' }
+            ? {
+                height: `${props.gutterSize ?? GUTTER_SIZE}px`,
+                'touch-action': 'none',
+              }
+            : {
+                width: `${props.gutterSize ?? GUTTER_SIZE}px`,
+                'touch-action': 'none',
+              }
+        }
+        onWheel={
+          props.gutterSize === undefined
+            ? undefined
+            : (e) => {
+                const container = props.scrollContainer();
+                if (!container) return;
+                container.scrollLeft += e.deltaX || (e.shiftKey ? e.deltaY : 0);
+                container.scrollTop += e.deltaY;
+              }
         }
         onPointerDown={handlePointerDown}
         onPointerMove={handlePointerMove}


### PR DESCRIPTION
Follow-ups to the board-first Customers view (#4808).

## Board horizontal scrollbar

The board's `CustomScrollbar` never appeared: columns mount after the initial overflow measurement (stages/companies load async), and the floating AI chat bar sat exactly on top of the bottom-anchored gutter.

- New opt-in `watchContent` prop: a `childList` MutationObserver re-measures overflow when content mounts/unmounts inside the scroll container.
- New opt-in `revealZone` prop: pointer movement within N px of the scrollbar edge reveals the bar (proximity detection on the container — no enlarged hit area stealing clicks). The board uses 48px.
- New opt-in `gutterSize` prop: thicker click/drag hit area (board uses 20px; default stays 8px). Wheel events over an enlarged gutter are consumed (`preventDefault`) and forwarded to the container on the bar's axis only, so it doesn't dead-zone scrolling. The board's own padding keeps cards out of the enlarged band.
- The AI chat bar is hidden in board mode (back in list mode and everywhere else).
- Drag semantics now match native scrollbars everywhere: clicking the thumb grabs it in place (drags relative to the grab point) instead of snapping its center to the pointer; track clicks still jump. This is the one shared-behavior change — the three props above are opt-in and only the board passes them.

## Board layout

- Whole-column snapping: the board measures its width and sizes columns so an integer number of them exactly fills the viewport — no partial column hanging at the edge. Widening the window snaps in the next column once there's room for it at the minimum width; overflow columns scroll.
- Minimum column width lowered to 224px (was 256px).
- Column headers no longer show a company-count badge.

## Default deal stages

The uncustomized default stage set is now **Lead, Demo, Customer, Churned** (+ implicit "No stage"). Qualified/Trial/Negotiation are retired from the default set:

- A canonical `ALL_COMPANY_STAGE_OPTIONS` list (pipeline order: Lead, Qualified, Demo, Trial, Negotiation, Customer, Churned) is the single source the default set, labels, filters, and columns derive from.
- Companies still carrying retired values keep rendering their stage label (list cells, group headers, legacy→custom mapping); the Set-stage picker no longer offers them.
- Both stage filter menus (Filter dropdown and filter chip) still offer the retired stages so those companies stay reachable, listed in canonical pipeline order (`preserveOrder` opt-out of the selected-first sort, threaded through both menu variants). Checked state mirrors the displayed columns: with no filter active, exactly the default columns read as checked; checking a retired stage adds its column to the board in canonical position, and returning to exactly the default set clears the filter.
- Teams with customized stages are unaffected, and the backend system property still defines all 7 options.

## Customers top bar / menus

- The Views (saved views) button is removed from the top bar. The `CrmViewConfig` machinery and share links still work; there's just no UI entry point to create/apply saved views for now.
- The display-options menu shows "List columns" only in list mode; in board mode it holds just the admin-gated "Show hidden companies" toggle (and hides entirely for non-admins there).

## Note

An earlier commit on this branch loaded the full company set into both CRM views (500-per-page + eager pagination drain); it was reverted after it roughly 6x'd tab memory usage (resident entity copies per filter permutation plus the unvirtualized board DOM). CRM views fetch 100 per page again, and the board shows the pages loaded so far.
