### PR TITLE
feat: add unread notification badge to Inbox sidebar link

### DIFF
--- a/apps/web/src/components/app/app-sidebar/sidebar.tsx
+++ b/apps/web/src/components/app/app-sidebar/sidebar.tsx
@@ -93,6 +93,7 @@ import { debounce } from '@solid-primitives/scheduled';
 import { makePersisted } from '@solid-primitives/storage';
 import { useLocation } from '@solidjs/router';
 import { Button, cn, Dropdown, Hotkey, NavRow } from '@ui';
+import { startOfDay, subDays } from 'date-fns';
 import {
   type Component,
   type ComponentProps,
@@ -103,6 +104,7 @@ import {
   For,
   type JSX,
   onCleanup,
+  onMount,
   Show,
   Suspense,
 } from 'solid-js';
@@ -1700,21 +1702,46 @@ const SidebarLink = (props: SidebarLinkProps) => {
 };
 
 /**
+ * The Inbox badge only counts notifications from the last
+ * `INBOX_UNREAD_WINDOW_DAYS` calendar days — the inbox view's Today /
+ * Yesterday / "Last 7 days" date buckets (see `dateBucket`, which includes a
+ * date when `differenceInCalendarDays(now, date) < 7`).
+ */
+const INBOX_UNREAD_WINDOW_DAYS = 7;
+
+/** Timestamp of the oldest calendar day inside the unread-count window. */
+const inboxUnreadCutoff = () =>
+  subDays(startOfDay(new Date()), INBOX_UNREAD_WINDOW_DAYS - 1).getTime();
+
+/**
  * The Inbox sidebar link, showing a badge with the number of unread inbox
  * items at its right edge — the spot the "g i" hotkey hint takes over on
  * hover. Counts distinct entities rather than raw notifications, since an
- * entity with several unread notifications is still one inbox row.
+ * entity with several unread notifications is still one inbox row, and only
+ * those from the last `INBOX_UNREAD_WINDOW_DAYS` calendar days.
  */
 const SidebarInboxLink = (props: SidebarLinkProps) => {
   const notificationSource = useGlobalNotificationSource();
   const unreadNotifications = useUnreadNotifications(notificationSource);
 
-  const unreadCount = createMemo(
-    () =>
-      new Set(
-        unreadNotifications().map((n) => compositeEntity(notificationEntity(n)))
-      ).size
-  );
+  // The cutoff is a signal rather than an inline `new Date()` so the window
+  // slides while the app stays open. Signals don't propagate unchanged
+  // values, so the interval is inert except at midnight — the count memo
+  // otherwise re-runs only when the notification cache changes.
+  const [cutoff, setCutoff] = createSignal(inboxUnreadCutoff());
+  onMount(() => {
+    const interval = setInterval(() => setCutoff(inboxUnreadCutoff()), 60_000);
+    onCleanup(() => clearInterval(interval));
+  });
+
+  const unreadCount = createMemo(() => {
+    const entities = new Set<string>();
+    for (const n of unreadNotifications()) {
+      if (new Date(n.created_at).getTime() < cutoff()) continue;
+      entities.add(compositeEntity(notificationEntity(n)));
+    }
+    return entities.size;
+  });
 
   return (
     <SidebarLink

--- a/apps/web/src/components/app/app-sidebar/sidebar.tsx
+++ b/apps/web/src/components/app/app-sidebar/sidebar.tsx
@@ -30,6 +30,7 @@ import {
   SidebarPromoCard,
   SidebarPromoHint,
 } from '@components/app/app-sidebar/sidebar-promo';
+import { useGlobalNotificationSource } from '@components/app/GlobalAppState';
 import { useSplitLayout } from '@components/app/split-layout/layout';
 import type {
   ReferredFrom,
@@ -71,6 +72,11 @@ import { AnimatedSearchIcon } from '@icon/wide-search';
 import { AnimatedStarIcon } from '@icon/wide-star';
 import { AnimatedTaskIcon } from '@icon/wide-task';
 import { ContextMenu } from '@kobalte/core/context-menu';
+import {
+  compositeEntity,
+  notificationEntity,
+  useUnreadNotifications,
+} from '@notifications';
 import CaretRightIcon from '@phosphor/caret-right.svg';
 import CaretUpIcon from '@phosphor/caret-up.svg';
 import DotsThreeIcon from '@phosphor/dots-three.svg';
@@ -1111,7 +1117,13 @@ export const AppSidebar = (props: AppSidebarProps) => {
 
   const renderSidebarLink = (link: SidebarItem) => (
     <Dynamic
-      component={link.id === 'mail' ? SidebarMailLink : SidebarLink}
+      component={
+        link.id === 'mail'
+          ? SidebarMailLink
+          : link.id === 'inbox'
+            ? SidebarInboxLink
+            : SidebarLink
+      }
       {...link}
       sidebarState={sidebarDisplayState()}
       hotkeyVisible={goToHotkeyVisible()}
@@ -1478,6 +1490,12 @@ interface SidebarLinkProps extends SidebarItem {
    * Email link's expand chevron.
    */
   trailingWhenActive?: JSX.Element;
+  /**
+   * Rendered at the link's right edge while the row is idle — not hovered and
+   * no "go to" leader key pending — where the hover hotkey hints appear, e.g.
+   * the Inbox link's unread count. Hidden in the slim sidebar.
+   */
+  trailingWhenIdle?: JSX.Element;
 }
 
 const SidebarLink = (props: SidebarLinkProps) => {
@@ -1616,6 +1634,19 @@ const SidebarLink = (props: SidebarLinkProps) => {
 
           <Show
             when={
+              props.trailingWhenIdle !== undefined &&
+              !isHovering() &&
+              !props.hotkeyVisible &&
+              !(isActive() && props.trailingWhenActive !== undefined)
+            }
+          >
+            <div class="group-data-[slim=true]/sidebar:hidden ml-auto flex items-center">
+              {props.trailingWhenIdle}
+            </div>
+          </Show>
+
+          <Show
+            when={
               isHovering() &&
               !props.hotkeyVisible &&
               !(isActive() && props.trailingWhenActive !== undefined)
@@ -1665,6 +1696,40 @@ const SidebarLink = (props: SidebarLinkProps) => {
         </ContextMenuContent>
       </ContextMenu.Portal>
     </ContextMenu>
+  );
+};
+
+/**
+ * The Inbox sidebar link, showing a badge with the number of unread inbox
+ * items at its right edge — the spot the "g i" hotkey hint takes over on
+ * hover. Counts distinct entities rather than raw notifications, since an
+ * entity with several unread notifications is still one inbox row.
+ */
+const SidebarInboxLink = (props: SidebarLinkProps) => {
+  const notificationSource = useGlobalNotificationSource();
+  const unreadNotifications = useUnreadNotifications(notificationSource);
+
+  const unreadCount = createMemo(
+    () =>
+      new Set(
+        unreadNotifications().map((n) => compositeEntity(notificationEntity(n)))
+      ).size
+  );
+
+  return (
+    <SidebarLink
+      {...props}
+      trailingWhenIdle={
+        unreadCount() > 0 ? (
+          <span
+            data-sidebar-inbox-unread-count
+            class="shrink-0 min-w-5 h-5 px-1.5 flex items-center justify-center text-xs font-medium bg-ink/6 text-ink-muted rounded-md"
+          >
+            {unreadCount() > 99 ? '99+' : unreadCount()}
+          </span>
+        ) : undefined
+      }
+    />
   );
 };
 


### PR DESCRIPTION
## Summary
Adds an unread notification count badge to the Inbox sidebar link that displays the number of distinct unread entities in the user's inbox. The badge appears at the right edge of the link when idle and is hidden when the link is hovered or in slim sidebar mode.

## Key Changes
- **New `SidebarInboxLink` component**: Specialized sidebar link for the Inbox that displays an unread count badge
  - Integrates with the global notification source to fetch unread notifications
  - Counts distinct entities (using `compositeEntity`) rather than raw notifications, since multiple notifications for the same entity should count as one inbox row
  - Badge displays the count (capped at "99+") in a styled container
  
- **Enhanced `SidebarLink` component**: Added support for `trailingWhenIdle` prop
  - New optional prop to render content at the link's right edge when the row is idle (not hovered, no hotkey pending, and no active trailing element)
  - Hidden in slim sidebar mode to maintain compact layout
  - Complements existing `trailingWhenActive` prop for hover states

- **Updated sidebar link rendering logic**: Modified `renderSidebarLink` to use `SidebarInboxLink` for inbox navigation items instead of the generic `SidebarLink`

## Implementation Details
- The unread count is computed as a memo that deduplicates notifications by their composite entity identifier
- The badge styling uses Tailwind classes with ink color scheme and rounded corners
- The badge respects sidebar state (hidden in slim mode) and interaction states (hidden on hover/hotkey)

https://claude.ai/code/session_01PQgdvX2zBxhc8MhwLh8UnV