### PR TITLE
Add channels dashboard with live tile grid view

### DIFF
--- a/apps/web/src/components/app/split-layout/componentRegistry.tsx
+++ b/apps/web/src/components/app/split-layout/componentRegistry.tsx
@@ -1,3 +1,4 @@
+import { ChannelsDashboard } from '@app/features/channel/dashboard/ChannelsDashboard';
 import { Home } from '@app/features/home';
 import { queryStateFrom } from '@app/features/next-soup/filters/filter-store';
 import type { SetPredicatesInput } from '@app/features/next-soup/filters/filter-store/predicates-store';
@@ -23,6 +24,7 @@ import {
   LOCAL_ONLY,
 } from '@core/constant/featureFlags';
 import { useUserContext } from '@core/context/user';
+import { isMobile } from '@core/mobile/isMobile';
 import type { ViewId } from '@core/types/view';
 import { useAutomationEntities } from '@queries/agent-schedule/entities';
 import { type Component, type JSXElement, lazy, onMount, Show } from 'solid-js';
@@ -243,19 +245,39 @@ registerComponent(
   })
 );
 
+function ChannelsListView() {
+  const preset = getViewPreset('channels');
+  return (
+    <SoupView
+      viewName="Channels"
+      initialFilters={preset?.filters}
+      initialClientFilters={preset?.clientFilters}
+      initialGroupBy={preset?.groupBy}
+    />
+  );
+}
+
 registerComponent(
   'channels',
   withAuth(() => {
     usePageViewTracking('channels');
-    const preset = getViewPreset('channels');
+    // The dashboard mounts several live channels side by side, which doesn't
+    // fit a phone (and the floating mobile input regions would collide) —
+    // mobile keeps the classic list.
     return (
-      <SoupView
-        viewName="Channels"
-        initialFilters={preset?.filters}
-        initialClientFilters={preset?.clientFilters}
-        initialGroupBy={preset?.groupBy}
-      />
+      <Show when={!isMobile()} fallback={<ChannelsListView />}>
+        <ChannelsDashboard />
+      </Show>
     );
+  })
+);
+
+// The classic channels list, reachable from the dashboard's "All channels".
+registerComponent(
+  'channels-list',
+  withAuth(() => {
+    usePageViewTracking('channels-list');
+    return <ChannelsListView />;
   })
 );
 

--- a/apps/web/src/features/channel/dashboard/AddChannelCombobox.tsx
+++ b/apps/web/src/features/channel/dashboard/AddChannelCombobox.tsx
@@ -1,0 +1,160 @@
+import { useSenderName } from '@components/app/app-sidebar/utils';
+import { EntityIcon } from '@core/component/EntityIcon';
+import { UserIcon } from '@core/component/UserIcon';
+import { useUserId } from '@core/context/user';
+import { compareDateDesc } from '@core/util/date';
+import {
+  Combobox,
+  type ComboboxRootItemComponentProps,
+} from '@kobalte/core/combobox';
+import PlusIcon from '@phosphor/plus.svg';
+import type { ApiChannelWithLatest } from '@service-storage/channel-list-types';
+import { ChannelTypeEnum } from '@service-storage/client';
+import { Surface } from '@ui';
+import { createMemo, createSignal, Show } from 'solid-js';
+
+type AddChannelOption = {
+  id: string;
+  /** Search/label text; DMs fall back to the recipient's email handle. */
+  name: string;
+  isDM: boolean;
+  dmRecipientId?: string;
+  unreadCount: number;
+};
+
+function dmFallbackName(userId: string | undefined) {
+  if (userId?.startsWith('macro|')) return userId.slice(6).split('@')[0]!;
+  return 'Direct message';
+}
+
+function OptionRow(props: ComboboxRootItemComponentProps<AddChannelOption>) {
+  const option = () => props.item.rawValue;
+  // Resolve the pretty display name for DMs; option.name stays the
+  // deterministic fallback so filtering works before the fetch lands.
+  const senderName = useSenderName(option().dmRecipientId);
+  const label = () =>
+    option().isDM ? (senderName() ?? option().name) : option().name;
+
+  return (
+    <Combobox.Item
+      item={props.item}
+      class="flex w-full cursor-default items-center gap-2 rounded-lg px-2 py-1.5 text-left text-sm text-ink outline-none data-highlighted:bg-hover"
+    >
+      <Show
+        when={option().isDM && option().dmRecipientId}
+        fallback={
+          <EntityIcon
+            targetType="channel"
+            size="xs"
+            class="size-3.5 shrink-0"
+          />
+        }
+      >
+        {(recipientId) => (
+          <UserIcon
+            id={recipientId()}
+            size="sm"
+            suppressClick
+            showTooltip={false}
+          />
+        )}
+      </Show>
+      <Combobox.ItemLabel class="ph-no-capture min-w-0 flex-1 truncate">
+        {label()}
+      </Combobox.ItemLabel>
+      <Show when={option().unreadCount > 0}>
+        <span class="flex h-5 min-w-5 shrink-0 items-center justify-center rounded-md bg-accent px-1.5 text-xs font-medium text-surface">
+          {option().unreadCount}
+        </span>
+      </Show>
+    </Combobox.Item>
+  );
+}
+
+/**
+ * Searchable picker for adding a channel tile to the dashboard. Options are
+ * the channels without a tile, unread first then most recently active.
+ */
+export function AddChannelCombobox(props: {
+  channels: ApiChannelWithLatest[];
+  excludeIds: string[];
+  unreadCounts: ReadonlyMap<string, number>;
+  onAdd: (channelId: string) => void;
+}) {
+  const userId = useUserId();
+  // Kobalte keeps the selected option as controlled state; reset it after
+  // every pick so the same channel can be removed and re-added.
+  const [selected, setSelected] = createSignal<AddChannelOption | null>(null);
+
+  const options = createMemo<AddChannelOption[]>(() => {
+    const excluded = new Set(props.excludeIds);
+    return props.channels
+      .filter((channel) => !excluded.has(channel.id))
+      .sort((a, b) => {
+        const aUnread = (props.unreadCounts.get(a.id) ?? 0) > 0 ? 1 : 0;
+        const bUnread = (props.unreadCounts.get(b.id) ?? 0) > 0 ? 1 : 0;
+        if (aUnread !== bUnread) return bUnread - aUnread;
+        return compareDateDesc(
+          a.latest_message?.created_at ?? a.updated_at,
+          b.latest_message?.created_at ?? b.updated_at
+        );
+      })
+      .map((channel) => {
+        const isDM = channel.channel_type === ChannelTypeEnum.DirectMessage;
+        const dmRecipientId = isDM
+          ? channel.participants.find((p) => p.user_id !== userId())?.user_id
+          : undefined;
+        return {
+          id: channel.id,
+          name: isDM
+            ? dmFallbackName(dmRecipientId)
+            : channel.name?.trim() || 'New Channel',
+          isDM,
+          dmRecipientId,
+          unreadCount: props.unreadCounts.get(channel.id) ?? 0,
+        };
+      });
+  });
+
+  return (
+    <Combobox<AddChannelOption>
+      options={options()}
+      value={selected()}
+      optionValue={(option) => option.id}
+      optionLabel={(option) => option.name}
+      optionTextValue={(option) => option.name}
+      onChange={(option) => {
+        if (!option) return;
+        props.onAdd(option.id);
+        setSelected(null);
+      }}
+      placeholder="Add channel"
+      itemComponent={OptionRow}
+      placement="bottom-end"
+      allowsEmptyCollection
+    >
+      <Combobox.Control class="flex h-7 w-44 items-center gap-1.5 rounded-md border border-edge-muted px-2 focus-within:border-accent">
+        <PlusIcon class="size-3.5 shrink-0 text-ink-muted" />
+        <Combobox.Input class="ph-no-capture min-w-0 flex-1 bg-transparent text-sm outline-none placeholder:text-ink-placeholder" />
+      </Combobox.Control>
+      <Combobox.Portal>
+        <Combobox.Content
+          as={Surface}
+          depth={3}
+          class="z-action-menu mt-1 w-72 rounded-xl bg-menu p-1.5 shadow-menu"
+        >
+          <Show
+            when={options().length > 0}
+            fallback={
+              <div class="px-2 py-5 text-center text-xs text-ink-muted">
+                Every channel is already on the dashboard
+              </div>
+            }
+          >
+            <Combobox.Listbox class="max-h-72 overflow-y-auto" />
+          </Show>
+        </Combobox.Content>
+      </Combobox.Portal>
+    </Combobox>
+  );
+}

--- a/apps/web/src/features/channel/dashboard/ChannelTile.tsx
+++ b/apps/web/src/features/channel/dashboard/ChannelTile.tsx
@@ -1,0 +1,178 @@
+import { Channel as ChannelView } from '@channel/Channel/Channel';
+import { useSenderName } from '@components/app/app-sidebar/utils';
+import { useGlobalNotificationSource } from '@components/app/GlobalAppState';
+import { EntityIcon } from '@core/component/EntityIcon';
+import { EntityPermissionsGate } from '@core/component/EntityPermissionsGate';
+import { UserIcon } from '@core/component/UserIcon';
+import { useChannel } from '@core/context/channels';
+import { useUserId } from '@core/context/user';
+import { markNotificationForEntityIdAsRead } from '@notifications';
+import ArrowSquareOutIcon from '@phosphor/arrow-square-out.svg';
+import ArrowsInSimpleIcon from '@phosphor/arrows-in-simple.svg';
+import ArrowsOutSimpleIcon from '@phosphor/arrows-out-simple.svg';
+import PushPinIcon from '@phosphor/push-pin.svg';
+import PushPinSlashIcon from '@phosphor/push-pin-slash.svg';
+import XIcon from '@phosphor/x.svg';
+import { ChannelTypeEnum } from '@service-storage/client';
+import { Button, cn, Tooltip } from '@ui';
+import { Show } from 'solid-js';
+
+export type ChannelTileProps = {
+  channelId: string;
+  unreadCount: number;
+  isPinned: boolean;
+  isExpanded: boolean;
+  onToggleExpanded: () => void;
+  onTogglePinned: () => void;
+  onRemove: () => void;
+  onOpenFull: () => void;
+};
+
+function TileIcon(props: { channelId: string }) {
+  const channel = useChannel(props.channelId);
+  const userId = useUserId();
+  const dmRecipient = () => {
+    if (channel()?.channel_type !== ChannelTypeEnum.DirectMessage)
+      return undefined;
+    return channel()?.participants.find((p) => p.user_id !== userId());
+  };
+
+  return (
+    <Show
+      when={dmRecipient()}
+      fallback={
+        <EntityIcon targetType="channel" size="xs" class="size-3.5 shrink-0" />
+      }
+    >
+      {(recipient) => (
+        <UserIcon
+          id={recipient().user_id}
+          size="sm"
+          suppressClick
+          showTooltip={false}
+        />
+      )}
+    </Show>
+  );
+}
+
+export function useChannelTileName(channelId: string) {
+  const channel = useChannel(channelId);
+  const userId = useUserId();
+  const dmRecipientId = () => {
+    if (channel()?.channel_type !== ChannelTypeEnum.DirectMessage)
+      return undefined;
+    return channel()?.participants.find((p) => p.user_id !== userId())?.user_id;
+  };
+  const recipientName = useSenderName(dmRecipientId());
+
+  return () => {
+    const current = channel();
+    if (current?.channel_type === ChannelTypeEnum.DirectMessage) {
+      return recipientName() ?? 'Direct message';
+    }
+    return current?.name?.trim() || 'New Channel';
+  };
+}
+
+/**
+ * One dashboard cell: a slim header (channel identity, unread badge, tile
+ * actions) over a fully live channel view — message list plus composer — so
+ * every visible channel can be read and replied to in place.
+ */
+export function ChannelTile(props: ChannelTileProps) {
+  const notificationSource = useGlobalNotificationSource();
+  const channelName = useChannelTileName(props.channelId);
+
+  // Interacting with a tile counts as reading it: clear its unread
+  // notifications so the badge reflects what the user has actually seen.
+  const markRead = () => {
+    if (props.unreadCount === 0) return;
+    void markNotificationForEntityIdAsRead(notificationSource, props.channelId);
+  };
+
+  return (
+    <section
+      class={cn(
+        'flex min-h-0 min-w-0 flex-col overflow-hidden rounded-xl bg-surface ring-1',
+        props.unreadCount > 0 ? 'ring-accent' : 'ring-edge',
+        props.isExpanded && 'absolute inset-2 z-20 shadow-menu'
+      )}
+      onFocusIn={markRead}
+      data-channel-tile={props.channelId}
+    >
+      <header
+        class="flex h-9 shrink-0 items-center gap-1.5 border-b border-edge-muted px-2"
+        onDblClick={props.onToggleExpanded}
+      >
+        <TileIcon channelId={props.channelId} />
+        <span class="ph-no-capture min-w-0 truncate text-sm font-medium text-ink">
+          {channelName()}
+        </span>
+        <Show when={props.unreadCount > 0}>
+          <span class="flex h-5 min-w-5 shrink-0 items-center justify-center rounded-md bg-accent px-1.5 text-xs font-medium text-surface">
+            {props.unreadCount}
+          </span>
+        </Show>
+        <div class="flex-1" />
+        <div class="flex shrink-0 items-center gap-0.5 text-ink-muted">
+          <Tooltip label={props.isPinned ? 'Unpin' : 'Pin to dashboard'}>
+            <Button
+              variant="ghost"
+              size="icon-xs"
+              onClick={props.onTogglePinned}
+              aria-label={props.isPinned ? 'Unpin' : 'Pin to dashboard'}
+            >
+              <Show
+                when={props.isPinned}
+                fallback={<PushPinIcon class="size-3.5" />}
+              >
+                <PushPinSlashIcon class="size-3.5" />
+              </Show>
+            </Button>
+          </Tooltip>
+          <Tooltip label="Open full channel">
+            <Button
+              variant="ghost"
+              size="icon-xs"
+              onClick={props.onOpenFull}
+              aria-label="Open full channel"
+            >
+              <ArrowSquareOutIcon class="size-3.5" />
+            </Button>
+          </Tooltip>
+          <Tooltip label={props.isExpanded ? 'Back to grid' : 'Expand'}>
+            <Button
+              variant="ghost"
+              size="icon-xs"
+              onClick={props.onToggleExpanded}
+              aria-label={props.isExpanded ? 'Back to grid' : 'Expand'}
+            >
+              <Show
+                when={props.isExpanded}
+                fallback={<ArrowsOutSimpleIcon class="size-3.5" />}
+              >
+                <ArrowsInSimpleIcon class="size-3.5" />
+              </Show>
+            </Button>
+          </Tooltip>
+          <Tooltip label="Remove from dashboard">
+            <Button
+              variant="ghost"
+              size="icon-xs"
+              onClick={props.onRemove}
+              aria-label="Remove from dashboard"
+            >
+              <XIcon class="size-3.5" />
+            </Button>
+          </Tooltip>
+        </div>
+      </header>
+      <div class="min-h-0 flex-1 px-2">
+        <EntityPermissionsGate entityType="channel" entityId={props.channelId}>
+          <ChannelView channelId={props.channelId} autofocus={false} />
+        </EntityPermissionsGate>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/features/channel/dashboard/ChannelsDashboard.tsx
+++ b/apps/web/src/features/channel/dashboard/ChannelsDashboard.tsx
@@ -1,0 +1,179 @@
+import {
+  SplitHeaderLeft,
+  SplitHeaderRight,
+} from '@components/app/split-layout/components/SplitHeader';
+import { useSplitPanelOrThrow } from '@components/app/split-layout/layoutUtils';
+import { LoadingBlock } from '@core/component/LoadingBlock';
+import ListIcon from '@phosphor/list.svg';
+import PlusIcon from '@phosphor/plus.svg';
+import { Button, EmptyStatePanel, Tooltip } from '@ui';
+import { createMemo, createSignal, For, Show } from 'solid-js';
+import { AddChannelCombobox } from './AddChannelCombobox';
+import { ChannelTile, useChannelTileName } from './ChannelTile';
+import { createChannelsDashboard } from './use-dashboard-channels';
+
+const UNREAD_ELSEWHERE_CHIP_LIMIT = 8;
+
+function UnreadElsewhereChip(props: {
+  channelId: string;
+  count: number;
+  onOpen: () => void;
+}) {
+  const name = useChannelTileName(props.channelId);
+  return (
+    <button
+      type="button"
+      class="flex h-6 shrink-0 items-center gap-1.5 rounded-md bg-ink/[0.055] px-2 text-xs text-ink hover:bg-hover"
+      onClick={props.onOpen}
+    >
+      <span class="ph-no-capture max-w-40 truncate">{name()}</span>
+      <span class="flex h-4 min-w-4 items-center justify-center rounded bg-accent px-1 text-xxs font-medium text-surface">
+        {props.count}
+      </span>
+      <PlusIcon class="size-3 text-ink-muted" />
+    </button>
+  );
+}
+
+/**
+ * The channels tab as a live dashboard: a grid of channels you can read and
+ * reply to side by side, unread-first, with per-tile expand ("fullscreen"
+ * within the tab) and escape hatches to the full channel block and the
+ * classic list view.
+ */
+export function ChannelsDashboard() {
+  const dashboard = createChannelsDashboard();
+  const splitPanel = useSplitPanelOrThrow();
+  const [expandedId, setExpandedId] = createSignal<string | null>(null);
+
+  const openFullChannel = (channelId: string) => {
+    splitPanel.handle.replace({ next: { type: 'channel', id: channelId } });
+  };
+
+  const openChannelsList = () => {
+    splitPanel.handle.replace({
+      next: { type: 'component', id: 'channels-list' },
+    });
+  };
+
+  const openNewChannelCompose = () => {
+    splitPanel.handle.replace({
+      next: { type: 'component', id: 'channel-compose' },
+    });
+  };
+
+  const removeChannel = (channelId: string) => {
+    if (expandedId() === channelId) setExpandedId(null);
+    dashboard.removeChannel(channelId);
+  };
+
+  const unreadChips = createMemo(() =>
+    dashboard.unreadElsewhere().slice(0, UNREAD_ELSEWHERE_CHIP_LIMIT)
+  );
+
+  return (
+    <div class="flex h-full min-h-0 flex-col">
+      <SplitHeaderLeft>
+        <div class="flex h-full shrink-0 items-center">
+          <span class="text-sm font-semibold">Channels</span>
+        </div>
+      </SplitHeaderLeft>
+      <SplitHeaderRight>
+        <div class="flex h-full items-center gap-1.5">
+          <AddChannelCombobox
+            channels={dashboard.channels()}
+            excludeIds={dashboard.displayedIds()}
+            unreadCounts={dashboard.unreadCounts()}
+            onAdd={dashboard.addChannel}
+          />
+          <Tooltip label="All channels">
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              onClick={openChannelsList}
+              aria-label="All channels"
+            >
+              <ListIcon class="size-4" />
+            </Button>
+          </Tooltip>
+        </div>
+      </SplitHeaderRight>
+
+      {/* Unread channels without a tile — one click promotes them into view. */}
+      <Show when={unreadChips().length > 0}>
+        <div class="flex shrink-0 items-center gap-1.5 overflow-x-auto px-3 py-1.5">
+          <span class="shrink-0 text-xs text-ink-muted">Also unread</span>
+          <For each={unreadChips()}>
+            {(entry) => (
+              <UnreadElsewhereChip
+                channelId={entry.channel.id}
+                count={entry.count}
+                onOpen={() => dashboard.addChannel(entry.channel.id)}
+              />
+            )}
+          </For>
+        </div>
+      </Show>
+
+      <Show
+        when={dashboard.displayedIds().length > 0}
+        fallback={
+          <Show when={!dashboard.isLoading()} fallback={<LoadingBlock />}>
+            <Show
+              when={dashboard.channels().length > 0}
+              fallback={
+                <EmptyStatePanel
+                  centered
+                  title="No channels yet"
+                  description="Create a channel to start the conversation."
+                  primaryAction={{
+                    label: 'New channel',
+                    onClick: openNewChannelCompose,
+                  }}
+                />
+              }
+            >
+              <EmptyStatePanel
+                centered
+                title="Nothing on the dashboard"
+                description="Use “Add channel” above to bring channels onto the dashboard."
+              />
+            </Show>
+          </Show>
+        }
+      >
+        <div class="relative min-h-0 flex-1">
+          <div class="h-full overflow-y-auto p-2 pt-0.5">
+            <div
+              class="grid min-h-full gap-2"
+              style={{
+                'grid-template-columns':
+                  'repeat(auto-fit, minmax(min(26rem, 100%), 1fr))',
+                'grid-auto-rows': 'minmax(22rem, 1fr)',
+              }}
+            >
+              <For each={dashboard.displayedIds()}>
+                {(channelId) => (
+                  <ChannelTile
+                    channelId={channelId}
+                    unreadCount={dashboard.unreadCounts().get(channelId) ?? 0}
+                    isPinned={dashboard.isPinned(channelId)}
+                    isExpanded={expandedId() === channelId}
+                    onToggleExpanded={() =>
+                      setExpandedId((prev) =>
+                        prev === channelId ? null : channelId
+                      )
+                    }
+                    onTogglePinned={() => dashboard.togglePinned(channelId)}
+                    onRemove={() => removeChannel(channelId)}
+                    onOpenFull={() => openFullChannel(channelId)}
+                  />
+                )}
+              </For>
+            </div>
+          </div>
+        </div>
+      </Show>
+    </div>
+  );
+}

--- a/apps/web/src/features/channel/dashboard/dashboard-state.test.ts
+++ b/apps/web/src/features/channel/dashboard/dashboard-state.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import { rankDashboardChannels } from './dashboard-state';
+
+const channel = (id: string, activityAt?: string) => ({
+  id,
+  activityAt: activityAt ?? null,
+});
+
+describe('rankDashboardChannels', () => {
+  it('puts unread channels before read ones, then sorts by recency', () => {
+    const result = rankDashboardChannels({
+      channels: [
+        channel('read-new', '2026-07-14T12:00:00Z'),
+        channel('unread-old', '2026-07-01T12:00:00Z'),
+        channel('read-old', '2026-07-02T12:00:00Z'),
+        channel('unread-new', '2026-07-13T12:00:00Z'),
+      ],
+      unreadCounts: new Map([
+        ['unread-old', 2],
+        ['unread-new', 1],
+      ]),
+      pinnedIds: [],
+      limit: 6,
+    });
+
+    expect(result).toEqual([
+      'unread-new',
+      'unread-old',
+      'read-new',
+      'read-old',
+    ]);
+  });
+
+  it('keeps pinned channels first in pinned order and fills the rest', () => {
+    const result = rankDashboardChannels({
+      channels: [
+        channel('a', '2026-07-14T12:00:00Z'),
+        channel('b', '2026-07-13T12:00:00Z'),
+        channel('c', '2026-07-12T12:00:00Z'),
+        channel('d', '2026-07-11T12:00:00Z'),
+      ],
+      unreadCounts: new Map([['d', 3]]),
+      pinnedIds: ['c', 'a'],
+      limit: 3,
+    });
+
+    expect(result).toEqual(['c', 'a', 'd']);
+  });
+
+  it('ignores pinned ids for channels that no longer exist', () => {
+    const result = rankDashboardChannels({
+      channels: [channel('a')],
+      unreadCounts: new Map(),
+      pinnedIds: ['gone', 'a'],
+      limit: 2,
+    });
+
+    expect(result).toEqual(['a']);
+  });
+
+  it('keeps every pin even when pins exceed the limit', () => {
+    const result = rankDashboardChannels({
+      channels: [channel('a'), channel('b'), channel('c')],
+      unreadCounts: new Map(),
+      pinnedIds: ['a', 'b', 'c'],
+      limit: 2,
+    });
+
+    expect(result).toEqual(['a', 'b', 'c']);
+  });
+
+  it('caps auto-filled channels at the limit', () => {
+    const result = rankDashboardChannels({
+      channels: [
+        channel('a', '2026-07-14T12:00:00Z'),
+        channel('b', '2026-07-13T12:00:00Z'),
+        channel('c', '2026-07-12T12:00:00Z'),
+      ],
+      unreadCounts: new Map(),
+      pinnedIds: [],
+      limit: 2,
+    });
+
+    expect(result).toEqual(['a', 'b']);
+  });
+
+  it('treats channels without activity as oldest', () => {
+    const result = rankDashboardChannels({
+      channels: [
+        channel('no-activity'),
+        channel('recent', '2026-07-14T12:00:00Z'),
+      ],
+      unreadCounts: new Map(),
+      pinnedIds: [],
+      limit: 6,
+    });
+
+    expect(result).toEqual(['recent', 'no-activity']);
+  });
+});

--- a/apps/web/src/features/channel/dashboard/dashboard-state.ts
+++ b/apps/web/src/features/channel/dashboard/dashboard-state.ts
@@ -1,0 +1,76 @@
+/**
+ * State helpers for the channels dashboard: which channels get a tile and in
+ * what order. Ranking is a pure function so it can be unit tested; the pinned
+ * set is a module-level persisted signal (same mechanism as other sticky view
+ * settings) so every consumer sees updates immediately.
+ */
+
+import type { DateValue } from '@core/util/date';
+import { compareDateDesc } from '@core/util/date';
+import { makePersisted } from '@solid-primitives/storage';
+import { createSignal } from 'solid-js';
+
+/** How many tiles the dashboard seeds itself with when unpinned. */
+export const DASHBOARD_AUTO_FILL_LIMIT = 6;
+
+export type DashboardRankableChannel = {
+  id: string;
+  /** Timestamp of the channel's most recent activity, for recency ranking. */
+  activityAt: DateValue | null | undefined;
+};
+
+const [pinnedChannelIds, setPinnedChannelIds] = makePersisted(
+  createSignal<string[]>([]),
+  { name: 'macro:pref:channels:dashboard-pinned' }
+);
+
+export function useDashboardPinnedChannels() {
+  const isPinned = (channelId: string) =>
+    pinnedChannelIds().includes(channelId);
+
+  const togglePinned = (channelId: string) => {
+    setPinnedChannelIds((prev) =>
+      prev.includes(channelId)
+        ? prev.filter((id) => id !== channelId)
+        : [...prev, channelId]
+    );
+  };
+
+  const unpin = (channelId: string) => {
+    setPinnedChannelIds((prev) =>
+      prev.includes(channelId) ? prev.filter((id) => id !== channelId) : prev
+    );
+  };
+
+  return { pinnedChannelIds, isPinned, togglePinned, unpin };
+}
+
+/**
+ * Picks the channels shown as dashboard tiles: pinned channels first (in
+ * pinned order), then channels with unread messages, then the most recently
+ * active — filled up to `limit` total (pins beyond the limit all stay).
+ */
+export function rankDashboardChannels(options: {
+  channels: DashboardRankableChannel[];
+  unreadCounts: ReadonlyMap<string, number>;
+  pinnedIds: string[];
+  limit: number;
+}): string[] {
+  const byId = new Map(
+    options.channels.map((channel) => [channel.id, channel])
+  );
+  const pinned = options.pinnedIds.filter((id) => byId.has(id));
+  const pinnedSet = new Set(pinned);
+
+  const rest = options.channels
+    .filter((channel) => !pinnedSet.has(channel.id))
+    .sort((a, b) => {
+      const aHasUnread = (options.unreadCounts.get(a.id) ?? 0) > 0 ? 1 : 0;
+      const bHasUnread = (options.unreadCounts.get(b.id) ?? 0) > 0 ? 1 : 0;
+      if (aHasUnread !== bHasUnread) return bHasUnread - aHasUnread;
+      return compareDateDesc(a.activityAt, b.activityAt);
+    });
+
+  const fillCount = Math.max(options.limit - pinned.length, 0);
+  return [...pinned, ...rest.slice(0, fillCount).map((channel) => channel.id)];
+}

--- a/apps/web/src/features/channel/dashboard/use-dashboard-channels.ts
+++ b/apps/web/src/features/channel/dashboard/use-dashboard-channels.ts
@@ -1,0 +1,125 @@
+/**
+ * Reactive state for the channels dashboard. The tile set is seeded once when
+ * the channel list (and notifications) finish loading, then only changes
+ * through explicit user actions — tiles must not reshuffle or vanish while
+ * someone is mid-reply just because a channel was marked read.
+ */
+
+import { useGlobalNotificationSource } from '@components/app/GlobalAppState';
+import { useChannelsContext } from '@core/context/channels';
+import { isChannelNotification } from '@notifications/notification-helpers';
+import type { ApiChannelWithLatest } from '@service-storage/channel-list-types';
+import { type Accessor, createMemo, createSignal } from 'solid-js';
+import {
+  DASHBOARD_AUTO_FILL_LIMIT,
+  rankDashboardChannels,
+  useDashboardPinnedChannels,
+} from './dashboard-state';
+
+/** Per-channel count of unread (not viewed, not done) channel notifications. */
+function useChannelUnreadCounts(): Accessor<ReadonlyMap<string, number>> {
+  const notificationSource = useGlobalNotificationSource();
+  return createMemo(() => {
+    const counts = new Map<string, number>();
+    for (const notification of notificationSource.notifications()) {
+      if (!isChannelNotification(notification)) continue;
+      if (notification.viewed_at || notification.done) continue;
+      counts.set(
+        notification.entity_id,
+        (counts.get(notification.entity_id) ?? 0) + 1
+      );
+    }
+    return counts;
+  });
+}
+
+function channelActivityAt(channel: ApiChannelWithLatest) {
+  return channel.latest_message?.created_at ?? channel.updated_at;
+}
+
+export function createChannelsDashboard() {
+  const channelsContext = useChannelsContext();
+  const notificationSource = useGlobalNotificationSource();
+  const unreadCounts = useChannelUnreadCounts();
+  const { pinnedChannelIds, isPinned, togglePinned, unpin } =
+    useDashboardPinnedChannels();
+
+  const isLoading = () =>
+    channelsContext.isLoading() || notificationSource.isLoading();
+
+  // Latches the ranked seed on the first computation where data is ready;
+  // afterwards it returns the previous value without touching any reactive
+  // sources, so later unread/pin changes can't reorder the open dashboard.
+  const seededIds = createMemo<string[] | undefined>((prev) => {
+    if (prev) return prev;
+    if (isLoading()) return undefined;
+    return rankDashboardChannels({
+      channels: channelsContext.channels().map((channel) => ({
+        id: channel.id,
+        activityAt: channelActivityAt(channel),
+      })),
+      unreadCounts: unreadCounts(),
+      pinnedIds: pinnedChannelIds(),
+      limit: DASHBOARD_AUTO_FILL_LIMIT,
+    });
+  }, undefined);
+
+  const [addedIds, setAddedIds] = createSignal<string[]>([]);
+  const [removedIds, setRemovedIds] = createSignal<ReadonlySet<string>>(
+    new Set()
+  );
+
+  const displayedIds = createMemo(() => {
+    const seeded = seededIds() ?? [];
+    const removed = removedIds();
+    const seededSet = new Set(seeded);
+    return [
+      ...seeded.filter((id) => !removed.has(id)),
+      ...addedIds().filter((id) => !removed.has(id) && !seededSet.has(id)),
+    ];
+  });
+
+  const addChannel = (channelId: string) => {
+    setRemovedIds((prev) => {
+      if (!prev.has(channelId)) return prev;
+      const next = new Set(prev);
+      next.delete(channelId);
+      return next;
+    });
+    setAddedIds((prev) =>
+      prev.includes(channelId) ? prev : [...prev, channelId]
+    );
+  };
+
+  const removeChannel = (channelId: string) => {
+    setRemovedIds((prev) => new Set(prev).add(channelId));
+    unpin(channelId);
+  };
+
+  /** Channels with unread messages that don't currently have a tile. */
+  const unreadElsewhere = createMemo(() => {
+    const displayed = new Set(displayedIds());
+    const counts = unreadCounts();
+    const channelsById = channelsContext.channelsById();
+    return [...counts.entries()]
+      .filter(([id, count]) => count > 0 && !displayed.has(id))
+      .map(([id, count]) => ({ channel: channelsById[id], count }))
+      .filter(
+        (entry): entry is { channel: ApiChannelWithLatest; count: number } =>
+          entry.channel != null
+      )
+      .sort((a, b) => b.count - a.count);
+  });
+
+  return {
+    isLoading,
+    displayedIds,
+    addChannel,
+    removeChannel,
+    isPinned,
+    togglePinned,
+    unreadCounts,
+    unreadElsewhere,
+    channels: channelsContext.channels,
+  };
+}


### PR DESCRIPTION
## Summary

Introduces a new channels dashboard view that displays channels as a responsive grid of live tiles, allowing users to read and reply to multiple channels simultaneously. This replaces the classic list view on desktop while maintaining the list view on mobile.

## Key Changes

- **ChannelsDashboard component**: Main dashboard view with a responsive grid layout that auto-fills with unread channels first, then most recently active channels
- **ChannelTile component**: Individual channel tile with live message list and composer, header with unread badge, and action buttons (pin, expand, open full, remove)
- **AddChannelCombobox component**: Searchable dropdown to add channels to the dashboard, sorted by unread status then recency
- **Dashboard state management**: 
  - `rankDashboardChannels()`: Pure ranking function that prioritizes pinned channels, then unread, then recent activity
  - `useDashboardPinnedChannels()`: Persisted signal for pinned channel preferences
  - `createChannelsDashboard()`: Reactive state hook managing displayed tiles, unread counts, and user interactions
- **Unread elsewhere indicator**: Shows chips for unread channels not currently on the dashboard with one-click promotion
- **Mobile fallback**: Desktop shows dashboard, mobile shows classic channels list view
- **Component registry updates**: Registers new dashboard and channels-list components, with mobile detection to route appropriately

## Implementation Details

- Dashboard tiles are seeded once on load and only change through explicit user actions (add/remove/pin), preventing reshuffling during active replies
- Unread counts are tracked reactively from notifications and displayed on tiles and in the add combobox
- Tiles support expand mode for fullscreen viewing within the dashboard
- Double-click tile header to expand, or use expand button
- Responsive grid uses CSS `auto-fit` with `minmax(26rem, 1fr)` for flexible column layout
- Comprehensive unit tests for the ranking algorithm covering pinned channels, unread prioritization, and recency sorting

https://claude.ai/code/session_01T8bJZTVpat5y6UApsWvCC5