### PR TITLE
fix(github): don't notify users about their own PR activity

### DIFF
--- a/crates/github/src/domain/service/sync/notify_pr.rs
+++ b/crates/github/src/domain/service/sync/notify_pr.rs
@@ -30,6 +30,18 @@ struct PullRequestStatusTransition {
     status: GithubPullRequestStatus,
 }
 
+/// The webhook actor resolved to Macro users via `github_links`.
+///
+/// `sender_id` is the single Macro user a notification is attributed to. A
+/// GitHub account may be linked to several Macro users, so `actor_user_ids`
+/// carries every linked user; `send_github_notification` excludes all of them
+/// from recipients so nobody is notified about their own GitHub activity.
+#[derive(Default)]
+pub(super) struct NotificationSender {
+    sender_id: Option<MacroUserIdStr<'static>>,
+    actor_user_ids: HashSet<MacroUserIdStr<'static>>,
+}
+
 impl<
     D: DocumentService,
     R: GithubSyncRepo,
@@ -65,7 +77,7 @@ impl<
             return;
         }
 
-        let sender_id = self.notification_sender_id(event).await;
+        let sender = self.notification_sender(event).await;
         for (upsert, transition) in transitions {
             let recipient_ids = self
                 .participant_scoped_recipient_ids(&upsert.source, &participant_user_ids)
@@ -90,7 +102,7 @@ impl<
             self.send_github_notification(
                 notification,
                 upsert.foreign_entity_id,
-                sender_id.clone(),
+                &sender,
                 recipient_ids,
             )
             .await;
@@ -99,20 +111,35 @@ impl<
 
     /// Send a GitHub pull request notification over the connection gateway,
     /// logging (rather than propagating) delivery failures.
+    ///
+    /// Every Macro user linked to the actor's GitHub account is dropped from
+    /// the recipients: users should not be notified about their own GitHub
+    /// activity, and the notification service's sender exclusion only knows
+    /// the single attributed `sender_id`.
     pub(super) async fn send_github_notification<T: Notification + Clone + 'static>(
         &self,
         notification: T,
         foreign_entity_id: uuid::Uuid,
-        sender_id: Option<MacroUserIdStr<'static>>,
-        recipient_ids: HashSet<MacroUserIdStr<'static>>,
+        sender: &NotificationSender,
+        mut recipient_ids: HashSet<MacroUserIdStr<'static>>,
     ) {
+        recipient_ids.retain(|recipient| !sender.actor_user_ids.contains(recipient));
+        if recipient_ids.is_empty() {
+            tracing::trace!(
+                notification_type=%T::TYPE_NAME,
+                foreign_entity_id=%foreign_entity_id,
+                "skipping GitHub PR notification with no recipients besides the actor"
+            );
+            return;
+        }
+
         let notification_entity =
             EntityType::ForeignEntity.with_entity_string(foreign_entity_id.to_string());
         let request = SendNotificationRequestBuilder {
             notification_entity,
             secondary_notification_entity: None,
             notification,
-            sender_id,
+            sender_id: sender.sender_id.clone(),
             recipient_ids,
         }
         .into_request()
@@ -300,11 +327,13 @@ impl<
         }
     }
 
-    pub(super) async fn notification_sender_id(
+    pub(super) async fn notification_sender(
         &self,
         event: &ValidatedGithubWebhookEvent,
-    ) -> Option<MacroUserIdStr<'static>> {
-        let github_user_id = event.sender_github_user_id()?;
+    ) -> NotificationSender {
+        let Some(github_user_id) = event.sender_github_user_id() else {
+            return NotificationSender::default();
+        };
         let links = match self
             .repo
             .get_macro_ids_by_github_user_ids(std::slice::from_ref(&github_user_id))
@@ -317,26 +346,34 @@ impl<
                     sender_github_user_id=%github_user_id,
                     "failed to map GitHub PR notification sender"
                 );
-                return None;
+                return NotificationSender::default();
             }
         };
 
-        // A notification has a single sender; many Macro users may share one
-        // GitHub account, so pick the first mapped user.
-        let macro_id = links.get(&github_user_id).and_then(|ids| ids.first())?;
-
-        match MacroUserIdStr::try_from(macro_id.clone()) {
-            Ok(sender_id) => Some(sender_id),
-            Err(error) => {
-                tracing::warn!(
-                    error=?error,
-                    macro_id=%macro_id,
-                    sender_github_user_id=%github_user_id,
-                    "GitHub PR notification sender mapping is not a valid Macro user ID"
-                );
-                None
+        let mut sender = NotificationSender::default();
+        for macro_id in links.get(&github_user_id).into_iter().flatten() {
+            match MacroUserIdStr::try_from(macro_id.clone()) {
+                Ok(user_id) => {
+                    // A notification has a single sender; many Macro users may
+                    // share one GitHub account, so attribute to the first
+                    // mapped user but track all of them as the actor.
+                    if sender.sender_id.is_none() {
+                        sender.sender_id = Some(user_id.clone());
+                    }
+                    sender.actor_user_ids.insert(user_id);
+                }
+                Err(error) => {
+                    tracing::warn!(
+                        error=?error,
+                        macro_id=%macro_id,
+                        sender_github_user_id=%github_user_id,
+                        "GitHub PR notification sender mapping is not a valid Macro user ID"
+                    );
+                }
             }
         }
+
+        sender
     }
 
     /// Build the metadata fields shared by every GitHub pull request notification type.

--- a/crates/github/src/domain/service/sync/notify_pr_activity.rs
+++ b/crates/github/src/domain/service/sync/notify_pr_activity.rs
@@ -76,7 +76,7 @@ impl<
         }
 
         let reviewer_login = Self::payload_string(&event.payload, &["requested_reviewer", "login"]);
-        let sender_id = self.notification_sender_id(event).await;
+        let sender = self.notification_sender(event).await;
         for upsert in upserts {
             let recipients = self.notification_recipient_ids(&upsert.source).await;
             let scoped_reviewers: HashSet<_> =
@@ -99,7 +99,7 @@ impl<
             self.send_github_notification(
                 notification,
                 upsert.foreign_entity_id,
-                sender_id.clone(),
+                &sender,
                 scoped_reviewers,
             )
             .await;
@@ -145,7 +145,7 @@ impl<
             .pull_request_participant_macro_user_ids(pull_request, upserts)
             .await;
         let snippet = GithubPrNotificationCommon::snippet(&body);
-        let sender_id = self.notification_sender_id(event).await;
+        let sender = self.notification_sender(event).await;
         for upsert in upserts {
             let source_recipients = self.notification_recipient_ids(&upsert.source).await;
 
@@ -171,7 +171,7 @@ impl<
                 self.send_github_notification(
                     notification,
                     upsert.foreign_entity_id,
-                    sender_id.clone(),
+                    &sender,
                     mention_recipients,
                 )
                 .await;
@@ -188,7 +188,7 @@ impl<
                 self.send_github_notification(
                     notification,
                     upsert.foreign_entity_id,
-                    sender_id.clone(),
+                    &sender,
                     comment_recipients,
                 )
                 .await;
@@ -245,7 +245,7 @@ impl<
             (!body.trim().is_empty()).then(|| GithubPrNotificationCommon::snippet(&body));
 
         let mentioned_users = self.mentioned_macro_users(&body).await;
-        let sender_id = self.notification_sender_id(event).await;
+        let sender = self.notification_sender(event).await;
         for upsert in upserts {
             let recipients = self.notification_recipient_ids(&upsert.source).await;
 
@@ -262,7 +262,7 @@ impl<
                 self.send_github_notification(
                     notification,
                     upsert.foreign_entity_id,
-                    sender_id.clone(),
+                    &sender,
                     review_recipients.clone(),
                 )
                 .await;
@@ -285,7 +285,7 @@ impl<
                 self.send_github_notification(
                     notification,
                     upsert.foreign_entity_id,
-                    sender_id.clone(),
+                    &sender,
                     mention_recipients,
                 )
                 .await;
@@ -344,7 +344,7 @@ impl<
 
         let comment_url = Self::payload_string(&event.payload, &["pull_request", "html_url"]);
         let snippet = GithubPrNotificationCommon::snippet(&body);
-        let sender_id = self.notification_sender_id(event).await;
+        let sender = self.notification_sender(event).await;
         for upsert in upserts {
             let recipients = self.notification_recipient_ids(&upsert.source).await;
             let mention_recipients: HashSet<_> =
@@ -363,7 +363,7 @@ impl<
             self.send_github_notification(
                 notification,
                 upsert.foreign_entity_id,
-                sender_id.clone(),
+                &sender,
                 mention_recipients,
             )
             .await;

--- a/crates/github/src/domain/service/sync/notify_pr_checks.rs
+++ b/crates/github/src/domain/service/sync/notify_pr_checks.rs
@@ -53,7 +53,7 @@ impl<
             return;
         }
 
-        let sender_id = self.notification_sender_id(event).await;
+        let sender = self.notification_sender(event).await;
         for upsert in upserts {
             let recipient_ids = self
                 .participant_scoped_recipient_ids(&upsert.source, &participant_user_ids)
@@ -77,7 +77,7 @@ impl<
             self.send_github_notification(
                 notification,
                 upsert.foreign_entity_id,
-                sender_id.clone(),
+                &sender,
                 recipient_ids,
             )
             .await;

--- a/crates/github/src/domain/service/sync/test.rs
+++ b/crates/github/src/domain/service/sync/test.rs
@@ -2243,12 +2243,10 @@ async fn github_pr_status_changed_opened_team_source_notifies_participant_team_m
             .and_then(|value| value.as_str()),
         Some("macro|alice@user.com")
     );
+    // Alice triggered the event, so she is not notified about her own activity.
     assert_eq!(
         notification_request_recipients(request),
-        vec![
-            "macro|alice@user.com".to_string(),
-            "macro|bob@user.com".to_string(),
-        ]
+        vec!["macro|bob@user.com".to_string()]
     );
 
     let content = notification_request_content(request);
@@ -2459,6 +2457,88 @@ async fn github_pr_status_changed_user_source_does_not_notify_nonparticipant() {
 }
 
 #[tokio::test]
+async fn github_pr_status_changed_does_not_notify_any_macro_user_linked_to_actor() {
+    let team_id: uuid::Uuid = "dddddddd-dddd-dddd-dddd-dddddddddddd".parse().unwrap();
+    let repo = StubSyncRepo::new()
+        .with_installation_sources("12345", vec![GithubAppInstallationSource::Team(team_id)])
+        .with_team_members(
+            team_id,
+            vec![
+                "macro|alice@user.com",
+                "macro|alice-work@user.com",
+                "macro|bob@user.com",
+            ],
+        )
+        .with_github_link("222", "macro|alice@user.com")
+        .with_github_link("222", "macro|alice-work@user.com")
+        .with_github_link("333", "macro|bob@user.com");
+    let service = make_sync_service_with_repo(repo);
+    let event = notification_pull_request_event_with_participants(
+        "opened",
+        "Add GitHub notifications",
+        "open",
+        false,
+        None,
+        222,
+        "octocat",
+        PullRequestWebhookParticipants {
+            author: Some((222, "octocat")),
+            requested_reviewers: &[(333, "bob-gh")],
+            assignees: &[],
+        },
+    );
+
+    service.process_webhook_event(&event).await.unwrap();
+
+    let requests = service.notification_ingress.requests();
+    assert_eq!(requests.len(), 1);
+    // The actor's GitHub account is linked to two Macro users; both are
+    // excluded from recipients, not just the attributed sender.
+    assert_eq!(
+        requests[0]
+            .pointer("/req/sender_id")
+            .and_then(|value| value.as_str()),
+        Some("macro|alice@user.com")
+    );
+    assert_eq!(
+        notification_request_recipients(&requests[0]),
+        vec!["macro|bob@user.com".to_string()]
+    );
+}
+
+#[tokio::test]
+async fn github_pr_status_changed_actor_as_only_participant_does_not_notify() {
+    let repo = StubSyncRepo::new()
+        .with_installation_sources(
+            "12345",
+            vec![GithubAppInstallationSource::User(
+                "macro|author@user.com".to_string(),
+            )],
+        )
+        .with_github_link("222", "macro|author@user.com");
+    let service = make_sync_service_with_repo(repo);
+    let event = notification_pull_request_event_with_participants(
+        "opened",
+        "Add GitHub notifications",
+        "open",
+        false,
+        None,
+        222,
+        "octocat",
+        PullRequestWebhookParticipants {
+            author: Some((222, "octocat")),
+            requested_reviewers: &[],
+            assignees: &[],
+        },
+    );
+
+    service.process_webhook_event(&event).await.unwrap();
+
+    assert_eq!(service.foreign_entity_service.foreign_entities().len(), 1);
+    assert!(service.notification_ingress.requests().is_empty());
+}
+
+#[tokio::test]
 async fn github_pr_status_changed_missing_participants_does_not_notify_team_members() {
     let team_id: uuid::Uuid = "dddddddd-dddd-dddd-dddd-dddddddddddd".parse().unwrap();
     let repo = StubSyncRepo::new()
@@ -2565,8 +2645,8 @@ async fn github_pr_status_changed_send_failure_does_not_fail_webhook_processing(
         "open",
         false,
         None,
-        222,
-        "octocat",
+        333,
+        "other-dev",
         PullRequestWebhookParticipants {
             author: Some((222, "octocat")),
             requested_reviewers: &[],
@@ -4652,11 +4732,9 @@ async fn mention_login_linked_to_multiple_users_notifies_all_in_team() {
             "macro|carol@user.com".to_string(),
         ]
     );
-    assert_eq!(comments.len(), 1);
-    assert_eq!(
-        notification_request_recipients(&comments[0]),
-        vec!["macro|alice@user.com".to_string()]
-    );
+    // The only non-mentioned participant is Alice, who wrote the comment, so
+    // no github_pr_comment notification goes out.
+    assert_eq!(comments.len(), 0);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

When you open, merge, comment on, or review a PR, you can receive a notification for your own activity in the GitHub soup view.

GitHub PR notifications relied entirely on the notification service's `IsSender` exclusion to keep the actor out of the recipient set. That exclusion only knows the single attributed `sender_id` — but `github_links` allows several Macro users per GitHub account (since the `20260630200839_allow_multiple_users_per_github_link` migration), and the sender lookup picks the attributed user via `.first()` on an un-`ORDER BY`ed query. So which linked user got excluded was nondeterministic, and the others received notifications for their own actions.

## Fix

Resolve the webhook actor to **every** Macro user linked to their GitHub account and subtract them all from the recipient set centrally in `send_github_notification`, skipping the send when nobody else remains. This covers all six GitHub PR notification types (status changes, check runs, review requests, comments, mentions, reviews).

- New `NotificationSender` struct in the `github` crate's sync domain service: the attributed `sender_id` (first mapped user, unchanged semantics) plus `actor_user_ids` (all linked users).
- The downstream `IsSender` filter in the notification service remains as a backstop.
- No inbound/outbound adapter or schema changes; identity mapping is read through the existing `GithubSyncRepo` port.

## Tests

- New regression test: when a GitHub account is linked to two Macro users, both are excluded while other participants are still notified.
- New test: an event whose only participant is the actor sends no notification at all.
- Updated three tests that asserted the old behavior — two of them asserted notifications whose only recipient was the actor, which the notification service would have discarded downstream anyway.

`cargo test -p github`: 216 passed. Note this prevents new self-notifications; anything already stored will still render until done.