### PR TITLE
fix(soup): email send in preview panel opening entity in new split

### DIFF
--- a/apps/web/src/features/block-email/component/BaseInput.tsx
+++ b/apps/web/src/features/block-email/component/BaseInput.tsx
@@ -260,6 +260,7 @@ export function BaseInput(props: {
   onMarkDone?: (opts?: {
     silent?: boolean;
     onUndoHandle?: (handle: UndoHandle) => void;
+    nextEntityId?: string;
   }) => void;
   setShowReply?: Setter<boolean>;
   markdownDomRef?: (ref: HTMLDivElement) => void | HTMLDivElement;
@@ -458,6 +459,7 @@ export function BaseInput(props: {
   // can reverse it. Cleared on each send: undo-send must only un-mark-done
   // when this send did the marking.
   let markDoneUndoHandle: UndoHandle | undefined;
+  let pendingMarkDoneNavigationTargetId: string | undefined;
 
   const undoSend = async (draftId: string) => {
     try {
@@ -570,7 +572,9 @@ export function BaseInput(props: {
           onUndoHandle: (handle) => {
             markDoneUndoHandle = handle;
           },
+          nextEntityId: pendingMarkDoneNavigationTargetId,
         });
+        pendingMarkDoneNavigationTargetId = undefined;
         setShouldMarkDoneOnSuccess(false);
       }
     },
@@ -578,6 +582,7 @@ export function BaseInput(props: {
       // Restore autosave so the user can keep editing after a failed send.
       if (draftSaveTimer) window.clearTimeout(draftSaveTimer);
       pendingSend = false;
+      pendingMarkDoneNavigationTargetId = undefined;
       toast.failure('Failed to send email');
     },
   });
@@ -707,7 +712,7 @@ export function BaseInput(props: {
     };
   }
 
-  async function executeSaveDraft() {
+  async function executeSaveDraft(skipSoupRefetch = false) {
     if (sendMutation.isPending || pendingDeletion || pendingSend) {
       return;
     }
@@ -719,6 +724,7 @@ export function BaseInput(props: {
           draftId,
           threadId: ctx.thread()?.db_id,
           linkId: headerLinkId(),
+          skipSoupRefetch,
         });
         refetchThreadMessages();
       }
@@ -750,6 +756,7 @@ export function BaseInput(props: {
         thread_db_id: currentThread?.db_id,
       },
       linkId: headerLinkId(),
+      skipSoupRefetch,
     });
 
     const draftId = draftResponse.draft.db_id;
@@ -1009,9 +1016,17 @@ export function BaseInput(props: {
 
     const currentEditor = editor();
 
+    // Sending a reply marks the thread done. Gated on inbox_visible because
+    // onMarkDone (archiveThread) toggles: an already-archived thread (e.g.
+    // replying from search or the sent view) would be unarchived.
+    const willMarkDone = markDone || (currentThread?.inbox_visible ?? false);
+    pendingMarkDoneNavigationTargetId = willMarkDone
+      ? ctx.getMarkDoneNavigationTargetId()
+      : undefined;
+
     // Ensure draft is saved before sending so undo-send always has a draft to restore
     if (draftSaveTimer) window.clearTimeout(draftSaveTimer);
-    await executeSaveDraft();
+    await executeSaveDraft(willMarkDone);
 
     // Snapshot editor state before watermark so undo-send can restore it.
     // Stored in undoSendSnapshot (not undoReplySnapshot) so it persists across
@@ -1062,10 +1077,6 @@ export function BaseInput(props: {
     }
 
     pendingMentions = prepared.mentions;
-    // Sending a reply marks the thread done. Gated on inbox_visible because
-    // onMarkDone (archiveThread) toggles: an already-archived thread (e.g.
-    // replying from search or the sent view) would be unarchived.
-    const willMarkDone = markDone || (currentThread?.inbox_visible ?? false);
     setShouldMarkDoneOnSuccess(willMarkDone);
     markDoneUndoHandle = undefined;
 

--- a/apps/web/src/features/block-email/component/EmailContext.tsx
+++ b/apps/web/src/features/block-email/component/EmailContext.tsx
@@ -69,6 +69,12 @@ export function markThreadDraftSaved(threadId: string) {
 }
 export type EmailRecipient = WithCustomUserInput<'user' | 'contact'>;
 
+type ArchiveThreadOptions = {
+  silent?: boolean;
+  onUndoHandle?: (handle: UndoHandle) => void;
+  nextEntityId?: string;
+};
+
 type EmailContextValues = {
   registerMessagesList: (list: HTMLElement) => void;
   messagesListRef: Accessor<HTMLElement | undefined>;
@@ -127,10 +133,8 @@ type EmailContextValues = {
     refetch: () => void;
   };
 
-  archiveThread: (opts?: {
-    silent?: boolean;
-    onUndoHandle?: (handle: UndoHandle) => void;
-  }) => boolean;
+  archiveThread: (opts?: ArchiveThreadOptions) => boolean;
+  getMarkDoneNavigationTargetId: () => string | undefined;
   blockSender: () => boolean;
   markSenderSignal: () => boolean;
   markSenderNoise: () => boolean;
@@ -367,14 +371,30 @@ export function EmailProvider(props: FlowProps<{ threadID: string }>) {
 
   const toHeaderLinkId = useNonPrimaryEmailLinkIdHeader();
 
-  const archiveThread = (opts?: {
-    silent?: boolean;
-    onUndoHandle?: (handle: UndoHandle) => void;
-  }) => {
+  const getMarkDoneNavigationTargetId = () => {
+    if (!soup) return;
+
+    const focusedId = soup.focus.id();
+    const navigationOptions = {
+      wrapNavigation: false,
+      skipGroupHeaders: true,
+      skipLoadMore: true,
+    };
+    const candidates = [
+      soup.navigate.peekOffset(1, navigationOptions)?.row,
+      soup.navigate.peekOffset(-1, navigationOptions)?.row,
+    ];
+    return candidates.find((row) => row && row.id !== focusedId)?.id;
+  };
+
+  const archiveThread = (opts?: ArchiveThreadOptions) => {
     const thread = threadQuery.data;
     // `=== true` because callers may pass this straight to an event handler.
-    const silent = opts?.silent === true;
-    const markDoneOpts = { silent, onUndoHandle: opts?.onUndoHandle };
+    const markDoneOpts = {
+      silent: opts?.silent === true,
+      onUndoHandle: opts?.onUndoHandle,
+      nextEntityId: opts?.nextEntityId,
+    };
 
     if (!thread?.db_id) return false;
 
@@ -584,6 +604,7 @@ export function EmailProvider(props: FlowProps<{ threadID: string }>) {
           recipientOptions: createMemo(getRecipientOptions),
           onRecipientsChange,
           archiveThread,
+          getMarkDoneNavigationTargetId,
           blockSender,
           markSenderSignal,
           markSenderNoise,

--- a/apps/web/src/features/block-email/component/EmailContext.tsx
+++ b/apps/web/src/features/block-email/component/EmailContext.tsx
@@ -4,6 +4,7 @@ import { openEntityInSplitFromUnifiedList } from '@app/features/next-soup/utils'
 import { URL_PARAMS } from '@block-email/constants';
 import { convertContactInfoToEmailRecipient } from '@block-email/util/recipientConversion';
 import { useGlobalNotificationSource } from '@components/app/GlobalAppState';
+import { useMaybePreviewPanel } from '@components/app/PreviewPanel';
 import { useSplitPanel } from '@components/app/split-layout/layoutUtils';
 import {
   getPermissions,
@@ -348,6 +349,7 @@ export function EmailProvider(props: FlowProps<{ threadID: string }>) {
   };
 
   const soup = useMaybeSoup();
+  const previewPanel = useMaybePreviewPanel();
   const splitPanel = useSplitPanel();
 
   const userId = useUserId();
@@ -392,7 +394,7 @@ export function EmailProvider(props: FlowProps<{ threadID: string }>) {
         soup,
         (nextEntity) => {
           const splitHandle = splitPanel?.handle;
-          if (!splitHandle) return;
+          if (!splitHandle || previewPanel !== undefined) return;
           void openEntityInSplitFromUnifiedList(nextEntity, {
             splitHandle,
             mergeHistory: true,

--- a/apps/web/src/features/next-soup/actions/make-mark-done-action.ts
+++ b/apps/web/src/features/next-soup/actions/make-mark-done-action.ts
@@ -59,6 +59,10 @@ type MarkDoneVariables = {
 
 type MarkDoneExecuteOpts = Pick<MarkDoneVariables, 'silent' | 'onUndoHandle'>;
 
+type MarkDoneExecuteWithSoupOpts = MarkDoneExecuteOpts & {
+  nextEntityId?: string;
+};
+
 /** Must be invoked inside a component tree that provides MutationUndoProvider. */
 export const makeMarkDoneAction = (options: MakeMarkDoneOptions) => {
   const splitPanel = useSplitPanel();
@@ -216,7 +220,7 @@ export const makeMarkDoneAction = (options: MakeMarkDoneOptions) => {
     entities: EntityData[],
     soup: SoupState,
     onNavigate?: (entity: EntityData) => void,
-    opts?: MarkDoneExecuteOpts
+    opts?: MarkDoneExecuteWithSoupOpts
   ) => {
     const focusedIdBeforeMarkDone = soup.focus.id();
     const markedEntityIds = new Set(entities.map((entity) => entity.id));
@@ -245,7 +249,10 @@ export const makeMarkDoneAction = (options: MakeMarkDoneOptions) => {
         return candidate.row;
       }
     };
-    const nextRow = adjacentRow(1) ?? adjacentRow(-1);
+    const fallbackNextRow = adjacentRow(1) ?? adjacentRow(-1);
+    const nextRow = opts?.nextEntityId
+      ? (soup.items.get(opts.nextEntityId) ?? fallbackNextRow)
+      : fallbackNextRow;
 
     if (soup.collapseEntity.shouldCollapse()) {
       const collapse = soup.collapseEntity.callback();

--- a/apps/web/src/lib/queries/email/draft.ts
+++ b/apps/web/src/lib/queries/email/draft.ts
@@ -16,6 +16,8 @@ type CreateDraftParams = {
   sendTime?: Date | null;
   /** Target inbox for a non-primary inbox; sent as the X-Email-Link-Id header. */
   linkId?: string;
+  /** Skip updating soup when the thread will immediately be marked done. */
+  skipSoupRefetch?: boolean;
 };
 
 /**
@@ -43,13 +45,15 @@ export function useSaveDraftMutation(
           console.error('Failed to save draft', error);
           toast.failure('Failed to save draft');
         },
-        onSuccess(data) {
+        onSuccess(data, vars) {
           queryClient.invalidateQueries({
             queryKey: emailKeys.previews._def,
           });
           const threadId = data.draft.thread_db_id;
           if (!threadId) return;
-          refetchSoupEntity(threadId, 'emailThread');
+          if (!vars.skipSoupRefetch) {
+            refetchSoupEntity(threadId, 'emailThread');
+          }
           // Reopening the thread reads the messages cache; drop it so the
           // saved draft body isn't served stale.
           queryClient.invalidateQueries({
@@ -68,6 +72,8 @@ type DeleteDraftParams = {
   threadId?: string;
   /** Target inbox for a non-primary inbox; sent as the X-Email-Link-Id header. */
   linkId?: string;
+  /** Skip updating soup when the thread will immediately be marked done. */
+  skipSoupRefetch?: boolean;
 };
 
 /**
@@ -97,7 +103,7 @@ export function useDeleteDraftMutation(
           // drafts tab without a manual refresh. No-op for compose drafts,
           // whose thread is deleted along with the draft, so the refetch
           // finds nothing to update.
-          if (vars.threadId) {
+          if (vars.threadId && !vars.skipSoupRefetch) {
             refetchSoupEntity(vars.threadId, 'emailThread');
           }
         },


### PR DESCRIPTION
It should just update the preview panel to show the next item instead. This also updates the logic for moving to the next entity after archive/mark done because sometimes it wouldn't go to the correct item