### PR TITLE
chore(email): temporarily raise inbox connect limits to 10 for testing

### DIFF
--- a/services/authentication_service/src/api/link/gmail.rs
+++ b/services/authentication_service/src/api/link/gmail.rs
@@ -119,7 +119,7 @@ pub async fn init_gmail_link_handler(
         )
         .await?;
 
-    if count >= 5 {
+    if count >= 10 {
         return Err(InitGmailLinkError::TooManyInProgressLinks);
     }
 

--- a/services/email_service/src/api/email/init.rs
+++ b/services/email_service/src/api/email/init.rs
@@ -722,7 +722,7 @@ async fn init_user(
         .into_response())
 }
 
-/// Rejects a connect when this Gmail identity already has 3+ recent backfill jobs in
+/// Rejects a connect when this Gmail identity already has 10+ recent backfill jobs in
 /// the last 24h (`@macro.com` is exempt). Enforced before the link and Gmail watch are
 /// created so a rejected connect never has to tear down a half-provisioned inbox.
 async fn enforce_backfill_rate_limit(
@@ -737,7 +737,7 @@ async fn enforce_backfill_rate_limit(
     .await
     .context("Failed to fetch recent backfill jobs")?;
 
-    if recent_jobs.len() >= 3 && !email_address.ends_with("@macro.com") {
+    if recent_jobs.len() >= 10 && !email_address.ends_with("@macro.com") {
         return Err(InitError::TooManyJobs);
     }
 


### PR DESCRIPTION
Temporary bump of the two limits that block multi-inbox connects — the backfill connect rate limit (3→10 in `email_service`) and the Gmail in-progress link cap (5→10 in `authentication_service`) — so multi-inbox can be tested end-to-end and affected users unblocked with a more robust fix coming later. It's a little high but should account for most regular usage for now. 