### PR TITLE
docs: July 2026 changelog + doc updates for merged PRs

### DIFF
--- a/apps/docs/changelog/2026-07.mdx
+++ b/apps/docs/changelog/2026-07.mdx
@@ -1,0 +1,61 @@
+---
+title: "July 2026"
+description: "Macro releases from July 2026."
+---
+
+<Update label="July 2026">
+
+## Channels
+
+- **Create private channels from a new modal.** Start a private channel with any set of participants — or none at all — and add people later. Press <kbd>c</kbd> + <kbd>m</kbd> to open it. ([#4796](https://github.com/macro-inc/macro/pull/4796))
+- **Share a channel with an invite link.** Group channels now support reusable invite links. Copy a link to let people join by code instead of adding each participant by email; joining is idempotent, so following a link you've already used is a no-op. ([#4815](https://github.com/macro-inc/macro/pull/4815))
+- Call notifications no longer include the `#` prefix in the channel title. ([#4794](https://github.com/macro-inc/macro/pull/4794))
+
+## CRM
+
+- **Board-first Customers view.** The Customers view now opens on the board by default, with **List** and **Board** tabs in the top bar. Owner pickers are scoped to your team roster, and you can edit company properties from the right-click menu, command palette, and mobile drawer. ([#4808](https://github.com/macro-inc/macro/pull/4808))
+- **Show hidden companies** moved into the display-options menu as a checkbox for team admins and owners, replacing the old Active/Hidden tabs. Kanban cards now always show owner, domain, and last interaction. ([#4808](https://github.com/macro-inc/macro/pull/4808))
+- Board polish: a working horizontal scrollbar, whole-column snapping, and a trimmed set of default stages. ([#4822](https://github.com/macro-inc/macro/pull/4822))
+- Loading a company's email threads is significantly faster. ([#4839](https://github.com/macro-inc/macro/pull/4839))
+
+## Agents & AI
+
+- **Collapsible activity groups.** Consecutive agent thinking and tool calls now collapse into expandable groups with a live streaming preview, so long runs are easier to follow. ([#4800](https://github.com/macro-inc/macro/pull/4800))
+- **Agents can manage tags.** New create, edit, and delete tag tools let an agent set up and maintain tags for you, not just apply existing ones. Each is scoped to a personal or team owner. ([#4802](https://github.com/macro-inc/macro/pull/4802))
+- Agents no longer pull the chat you're currently in into their open context. ([#4801](https://github.com/macro-inc/macro/pull/4801))
+- The task-creation modal now shows only the top few similar-task suggestions. ([#4799](https://github.com/macro-inc/macro/pull/4799))
+
+## Themes & appearance
+
+- **Reorganized theme settings** that are clearer and more intuitive to navigate, with the theme picker reflected in the command palette. ([#4814](https://github.com/macro-inc/macro/pull/4814), [#4833](https://github.com/macro-inc/macro/pull/4833), [#4842](https://github.com/macro-inc/macro/pull/4842), [#4797](https://github.com/macro-inc/macro/pull/4797))
+- Restored the previous dark-mode palette. ([#4817](https://github.com/macro-inc/macro/pull/4817))
+- The active split is now more clearly emphasized. ([#4807](https://github.com/macro-inc/macro/pull/4807), [#4818](https://github.com/macro-inc/macro/pull/4818))
+- Tags now live in their own side-panel section with improved styling. ([#4835](https://github.com/macro-inc/macro/pull/4835))
+
+## Email & inbox
+
+- The inbox preview now opens by default reliably. ([#4838](https://github.com/macro-inc/macro/pull/4838))
+- Your latest channel message appears immediately after you send it. ([#4825](https://github.com/macro-inc/macro/pull/4825))
+- Fixed channel row click targets and highlighting in the inbox. ([#4816](https://github.com/macro-inc/macro/pull/4816))
+- Sending email from the preview panel no longer opens the entity in a new split. ([#4836](https://github.com/macro-inc/macro/pull/4836))
+
+## Calls
+
+- The permission badge on a call now reflects your real access level instead of always showing "Viewer". ([#4790](https://github.com/macro-inc/macro/pull/4790))
+- Fixed a call block rendering issue. ([#4810](https://github.com/macro-inc/macro/pull/4810))
+
+## Mobile
+
+- Restored the thread reply button. ([#4829](https://github.com/macro-inc/macro/pull/4829))
+- iOS now re-syncs your data when the connection reconnects. ([#4821](https://github.com/macro-inc/macro/pull/4821))
+
+## GitHub integration
+
+- You no longer receive notifications about your own pull request activity — opening, merging, commenting on, or reviewing a PR. ([#4832](https://github.com/macro-inc/macro/pull/4832))
+
+## Other fixes
+
+- The sidebar's **open full screen** action now behaves consistently. ([#4830](https://github.com/macro-inc/macro/pull/4830))
+- Focus now lands where you expect it in the create-channel modal and after marking an item done. ([#4841](https://github.com/macro-inc/macro/pull/4841), [#4845](https://github.com/macro-inc/macro/pull/4845), [#4805](https://github.com/macro-inc/macro/pull/4805))
+
+</Update>

--- a/apps/docs/concepts/properties.mdx
+++ b/apps/docs/concepts/properties.mdx
@@ -54,4 +54,4 @@ Some blocks ship with their own system properties:
 
 ## Agent access
 
-Agents read and write properties through the MCP entity tools: `GetEntityProperties` to read, `SetEntityProperty` to update (status, assignee, dates, custom fields), and `ListEntities` to browse. See the [tool reference](/AI/mcp/tools/index).
+Agents read and write properties through the MCP entity tools: `GetEntityProperties` to read, `SetEntityProperty` to update (status, assignee, dates, custom fields), and `ListEntities` to browse. Agents can also create, edit, and delete tags themselves — not just apply existing ones — scoped to your personal or team workspace. See the [tool reference](/AI/mcp/tools/index).

--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -116,6 +116,7 @@
           {
             "group": "2026",
             "pages": [
+              "changelog/2026-07",
               "changelog/2026-05",
               "changelog/2026-04",
               "changelog/2026-03",

--- a/apps/docs/product/channels.mdx
+++ b/apps/docs/product/channels.mdx
@@ -30,6 +30,8 @@ Anyone can be added to a channel by entering their email, even if they're not on
 
 > To create a channel use shortcut <kbd>c</kbd> \+ <kbd>m</kbd>
 
+The create-channel modal lets you start a **private channel** with any participants you choose — or none at all, so you can set one up and add people later.
+
 You can also mention @Macro to call an agent into the channel. @Macro can summarize previous discussions, answer workspace questions, and more.
 
 <Frame>
@@ -135,6 +137,10 @@ Manage channel membership:
 - Add or remove participants
 - View all channel members
 - See participant status and presence
+
+### Invite links
+
+Group channels support reusable **invite links**. Copy a channel's invite link and share it so people can join by code instead of being added one email at a time. Following a link you've already used simply reopens the channel, so links are safe to reshare.
 
 ## Integration with Macro
 

--- a/apps/docs/product/crm.mdx
+++ b/apps/docs/product/crm.mdx
@@ -26,13 +26,13 @@ Every company and contact also has a **discussion** thread, so deal notes and co
 
 Every customer record comes with three properties out of the box: **Stage** (Lead, Qualified, Demo, Trial, Negotiation, Customer, Churned), **Owner** (a teammate responsible for the account), and **Revenue**. Edit them inline from the list, or from the record's **Properties** panel — the same editors used on tasks. A **Last Interaction** column tracks the most recent synced email automatically, so you don't have to update it by hand. See [Properties](/concepts/properties) for how the shared property system works.
 
-Switch between **list** and **kanban** from the toggle in the topbar. The board lays out one column per Stage; drag a card to a new column to update it. From either view, group and filter by **Stage** (the default) or **Owner** to focus on a segment of accounts.
+Switch between **List** and **Board** from the tabs in the top bar. The Customers view opens on the board by default: it lays out one column per Stage, and dragging a card to a new column updates it. Board columns snap into place as you scroll, and each card shows the account's owner, domain, and last interaction. In list mode you can group and filter by **Stage** (the default) or **Owner** to focus on a segment of accounts; the board is always grouped by Stage, so the group control is hidden there.
 
 ### Email sharing
 
 CRM is a team feature, and it's where Macro's email auto-sharing lives. When **Email Sync** is on for a company, your team's email threads with that company become visible to teammates in the CRM, so nobody has to forward a thread just to share context. Turning it off for a company keeps the record but makes its threads private to their participants.
 
-Team admins can also **hide** a company or contact entirely, which removes it (and its threads) from the team's view. Members see visible records; admins and owners can edit records, toggle Email Sync, and manage hidden ones.
+Team admins can also **hide** a company or contact entirely, which removes it (and its threads) from the team's view. To review hidden records, admins and owners turn on **Show hidden companies** in the display-options menu. Members see visible records; admins and owners can edit records, toggle Email Sync, and manage hidden ones.
 
 <Info>
   Sharing of CRM records is determined by your team, not by mentions: @mentioning a company or contact in a channel does not share it, unlike documents. See [Mentions](/concepts/mentions#what-happens-when-you-mention).


### PR DESCRIPTION
## Summary

Reviewed the pull requests merged into `main` in the last day (2026-07-14 → 2026-07-15, 43 PRs) and updated the `docs.macro.com` Mintlify site (`apps/docs`) to reflect the user-facing changes. Internal/infra-only PRs (Kafka spawn rework, Tauri cache backend, GraphQL backfill/soup plumbing, bot access receipts, test-only changes, temporary testing limits) were intentionally excluded.

## Changes

**New: `changelog/2026-07.mdx`** — a July 2026 changelog entry summarizing user-facing changes organized by category (Channels, CRM, Agents & AI, Themes & appearance, Email & inbox, Calls, Mobile, GitHub integration, Other fixes). Registered at the top of the 2026 group in `docs.json`.

**Product & concept pages updated where behavior actually changed:**

- **`product/channels.mdx`** — documented creating private channels from the new create-channel modal (with optional/no participants) and reusable **invite links** for group channels.
- **`product/crm.mdx`** — updated the Customers view section for the board-first layout: **List**/**Board** tabs, board as the default view, column snapping, and the **Show hidden companies** display-option that replaced the Active/Hidden tabs.
- **`concepts/properties.mdx`** — noted that agents can now create, edit, and delete tags (not just apply existing ones) via the new tag AI tools.

Auto-generated MCP tool-reference pages under `AI/mcp/tools/` were left untouched, since per `apps/docs/AGENTS.md` they are generated from the Rust schemas rather than hand-edited.

## PRs reflected

Channels #4796, #4815, #4794 · CRM #4808, #4822, #4839 · Agents & AI #4800, #4802, #4801, #4799 · Themes #4814, #4833, #4842, #4797, #4817, #4807, #4818, #4835 · Email & inbox #4838, #4825, #4816, #4836 · Calls #4790, #4810 · Mobile #4829, #4821 · GitHub #4832 · Misc fixes #4830, #4841, #4845, #4805

## Notes

- `docs.json` validated as well-formed JSON.
- Changelog prose was rewritten from PR titles; no internal task IDs, PII, or internal-channel details are included.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NS248dxBKoQfVmvDsjqdzp)_