### PR TITLE
fix(teams): allow team admins (not just owners) to remove members

### DIFF
--- a/apps/web/src/features/settings/Team.tsx
+++ b/apps/web/src/features/settings/Team.tsx
@@ -37,6 +37,7 @@ import { useRemoveUserFromTeamMutation } from '@queries/team/members';
 import {
   useCreateTeamWithInvitesMutation,
   useDeleteTeamMutation,
+  useIsTeamAdmin,
   usePatchTeamMutation,
   useTeamQuery,
   useUserTeamsQuery,
@@ -302,6 +303,8 @@ function InviteEmailsInput(props: {
 function MemberRow(props: {
   member: TeamMember;
   isOwner: boolean;
+  /** Owner or admin — allowed to remove members (but not the owner, and not themselves). */
+  canRemoveMembers: boolean;
   isCurrentUser: boolean;
   onRemove: () => void;
   onRoleChange: (role: TeamRole) => void;
@@ -346,7 +349,7 @@ function MemberRow(props: {
         >
           <RoleSelect value={props.member.role} onChange={props.onRoleChange} />
         </Show>
-        <Show when={props.isOwner}>
+        <Show when={props.canRemoveMembers}>
           <Show
             when={!props.isCurrentUser && !isMemberOwner()}
             fallback={
@@ -841,6 +844,7 @@ function TeamManagement(props: {
   ownerId: string;
 }) {
   const userId = useUserId();
+  const isTeamAdmin = useIsTeamAdmin();
 
   const teamQuery = useTeamQuery(() => props.teamId);
   const invitesQuery = useTeamInvitesQuery(() => props.teamId);
@@ -974,6 +978,11 @@ function TeamManagement(props: {
     if (!currentUserId) return false;
     return props.ownerId === currentUserId;
   });
+
+  // Owners and admins can remove members (the backend already allows
+  // `AdminTeamRole` for this action — only the frontend was gating it to
+  // owner-only). The owner themselves can never be removed.
+  const canRemoveMembers = createMemo(() => isOwner() || isTeamAdmin());
 
   const handleSaveTeamName = () => {
     const newName = editingTeamName()?.trim();
@@ -1320,6 +1329,7 @@ function TeamManagement(props: {
                     <MemberRow
                       member={member}
                       isOwner={isOwner()}
+                      canRemoveMembers={canRemoveMembers()}
                       isCurrentUser={member.user_id === userId()}
                       onRemove={() => setShowRemoveModal(member)}
                       onRoleChange={(newRole) => {

--- a/apps/web/src/features/settings/Team.tsx
+++ b/apps/web/src/features/settings/Team.tsx
@@ -982,7 +982,7 @@ function TeamManagement(props: {
   // Owners and admins can remove members (the backend already allows
   // `AdminTeamRole` for this action — only the frontend was gating it to
   // owner-only). The owner themselves can never be removed.
-  const canRemoveMembers = createMemo(() => isOwner() || isTeamAdmin());
+  const canRemoveMembers = () => isOwner() || isTeamAdmin();
 
   const handleSaveTeamName = () => {
     const newName = editingTeamName()?.trim();


### PR DESCRIPTION
## Summary
- Team admins could not remove team members — the remove-member button was gated to `isOwner()` only in `apps/web/src/features/settings/Team.tsx`.
- The backend already permits admin-level removal (`MacroUserTeamExtractor<AdminTeamRole, Eas>` on the remove-member route, same as invite/patch-team routes) — this was a frontend-only gating bug.

## Why prioritized
Reported in an internal bug-reports discussion: a team admin couldn't remove members and had to ask the owner to do it instead. Quick, low-risk fix with an existing pattern to follow. Filed as MACRO-2420.

## Change
`apps/web/src/features/settings/Team.tsx`:
- Added `useIsTeamAdmin()` (existing hook, already used elsewhere for admin-gated UI) alongside `isOwner()`.
- Added a `canRemoveMembers = isOwner() || isTeamAdmin()` check, threaded through as a new `canRemoveMembers` prop on `MemberRow`.
- Swapped the remove-button's `<Show when={props.isOwner}>` gate for `<Show when={props.canRemoveMembers}>`.
- Left invite/role-select/other owner-only UI, and existing self-removal / owner-removal protections, untouched — out of scope for this fix.

## Test plan
- [x] `bunx --bun biome check` on the changed file — clean.
- [ ] Manually verify: as a team admin (non-owner), the remove-member action is now visible and works; as a regular member, it remains hidden; owner cannot be removed.

Note: full `tsc`/dev-server verification wasn't possible in this sandbox (private git deps `pdf.js`/`tauri-plugins` aren't reachable), so please give this a spin in dev before merging.
MACRO-2420

---
_Generated by [Claude Code](https://claude.ai/code/session_019VEs6kwhiKK1UWci3TddCR)_