### PR TITLE
fix(soup): inbox preview should match click-highlighted message

### DIFF
--- a/apps/web/src/features/next-soup/soup-view/views/inbox/inbox-card-layouts.tsx
+++ b/apps/web/src/features/next-soup/soup-view/views/inbox/inbox-card-layouts.tsx
@@ -1,4 +1,5 @@
 import { ListPropertyValue } from '@app/features/next-soup/soup-view/views/tasks/list-property-value';
+import { getChannelDrivingNotification } from '@app/features/next-soup/utils';
 import { formatCallDuration } from '@block-call/utils';
 import { BotIcon } from '@channel/Message/BotIcon';
 import { MACRO_AI_BOT_ID, MACRO_AI_NAME } from '@channel/macroAi';
@@ -65,9 +66,16 @@ export interface InboxCardLayoutProps {
 
 type NotificationTag = ReturnType<typeof getNotificationTag>;
 
-/** The notification driving the row's action/sender (most recent first). */
+/**
+ * The notification driving the row's action/sender/preview (most recent
+ * first). For a channel-family entity this is the same notification
+ * `getChannelEntityTarget` resolves the click/highlight target from — using
+ * the same selection here keeps the preview and the click target in sync
+ * (previously this just took `notifications()[0]` unscoped, which could be a
+ * different message than the one a click would highlight).
+ */
 const getFirstNotification = (item: WithNotification<EntityData>) =>
-  item.notifications?.()?.[0];
+  getChannelDrivingNotification(item) ?? item.notifications?.()?.[0];
 
 const getGithubSender = (entity: EntityData, notification?: Notification) => {
   const meta = notification?.notification_metadata;
@@ -127,7 +135,13 @@ const getNotificationSenderFallbackName = (
 const getTimestamp = (entity: EntityData, notification?: Notification) => {
   const messageTime =
     entity.type === 'channel'
-      ? entity.latestRootMessage?.createdAt
+      ? // Only fall back to the channel's latest message when there's no
+        // driving notification (see `itemContent`/`channelMessageContent`):
+        // otherwise this would show the latest message's time next to the
+        // driving notification's (different) message content.
+        notification
+        ? undefined
+        : entity.latestRootMessage?.createdAt
       : entity.type === 'channel_message' || entity.type === 'channel_thread'
         ? (entity.createdAt ?? entity.updatedAt)
         : undefined;
@@ -546,9 +560,10 @@ export function ChannelCardLayout(props: InboxCardLayoutProps) {
 
     if (value.type !== 'channel') return;
 
-    const latestSender = value.latestRootMessage?.senderId;
-
-    return latestSender;
+    // Match the previewed message's sender to the message it actually is
+    // (see `itemContent`): the driving notification's sender when there is
+    // one, falling back to the channel's latest message otherwise.
+    return props.item.notification?.sender_id ?? value.latestRootMessage?.senderId;
   });
 
   const messageSenderName = createSenderDisplayName(messageSenderId);

--- a/apps/web/src/features/next-soup/soup-view/views/inbox/inbox-card-layouts.tsx
+++ b/apps/web/src/features/next-soup/soup-view/views/inbox/inbox-card-layouts.tsx
@@ -563,7 +563,9 @@ export function ChannelCardLayout(props: InboxCardLayoutProps) {
     // Match the previewed message's sender to the message it actually is
     // (see `itemContent`): the driving notification's sender when there is
     // one, falling back to the channel's latest message otherwise.
-    return props.item.notification?.sender_id ?? value.latestRootMessage?.senderId;
+    return (
+      props.item.notification?.sender_id ?? value.latestRootMessage?.senderId
+    );
   });
 
   const messageSenderName = createSenderDisplayName(messageSenderId);

--- a/apps/web/src/features/next-soup/soup-view/views/inbox/utils.ts
+++ b/apps/web/src/features/next-soup/soup-view/views/inbox/utils.ts
@@ -91,8 +91,22 @@ export function getNotificationTag(notification?: Notification) {
   return notification?.notification_metadata.tag;
 }
 
-const channelMessageContent = (entity: EntityData): string | undefined => {
-  if (entity.type === 'channel') return entity.latestRootMessage?.content;
+const channelMessageContent = (
+  entity: EntityData,
+  notification?: Notification
+): string | undefined => {
+  if (entity.type === 'channel') {
+    // A whole-channel row previews the message it will scroll to and
+    // highlight on click — its driving notification (see
+    // `getChannelDrivingNotification`/`getChannelEntityTarget`), when there is
+    // one. With no aiming notification (e.g. all notifications read), fall
+    // back to the channel's latest message, matching the `latest`
+    // click-target fallback.
+    const notificationMessage = notification
+      ? notificationContent(notification)
+      : undefined;
+    return notificationMessage ?? entity.latestRootMessage?.content;
+  }
   if (entity.type === 'channel_message' || entity.type === 'channel_thread') {
     return entity.content;
   }
@@ -113,7 +127,7 @@ export function itemContent(
     return;
   }
 
-  const channel = channelMessageContent(entity);
+  const channel = channelMessageContent(entity, notification);
   if (channel) return channel;
   return notification ? notificationContent(notification) : undefined;
 }

--- a/apps/web/src/features/next-soup/utils.test.ts
+++ b/apps/web/src/features/next-soup/utils.test.ts
@@ -15,7 +15,7 @@ vi.mock('@service-connection/websocket', () => ({
 
 import type { ChannelEntityTarget, EntityData } from '@entity';
 import type { UnifiedNotification } from '@notifications';
-import { getChannelEntityTarget } from './utils';
+import { getChannelDrivingNotification, getChannelEntityTarget } from './utils';
 
 const sendNotification = (id: string, messageId: string): UnifiedNotification =>
   ({
@@ -208,5 +208,49 @@ describe('getChannelEntityTarget', () => {
   it('returns undefined for non-channel entities', () => {
     const entity = { type: 'email', id: 'e1' } as unknown as EntityData;
     expect(getChannelEntityTarget(entity)).toBeUndefined();
+  });
+});
+
+describe('getChannelDrivingNotification', () => {
+  // The inbox card preview (ChannelCardLayout) renders whichever notification
+  // this returns, so it must always be the exact notification
+  // getChannelEntityTarget's messageId came from — otherwise the row can
+  // preview one message while highlighting another (MACRO-2421).
+  it('returns the same notification getChannelEntityTarget targets for a channel row', () => {
+    const notification = sendNotification('n2', 'unread-older-msg');
+    const entity = channelRow({
+      notifications: [
+        asRead(sendNotification('n1', 'read-newer-msg')),
+        notification,
+      ],
+    });
+
+    expect(getChannelDrivingNotification(entity)).toBe(notification);
+    expect(getChannelEntityTarget(entity)).toEqual({
+      kind: 'message',
+      messageId: 'unread-older-msg',
+      threadId: undefined,
+    });
+  });
+
+  it('returns undefined for a channel row with no unread notifications, matching the latest fallback', () => {
+    const entity = channelRow({
+      notifications: [asRead(sendNotification('n1', 'read-msg'))],
+    });
+
+    expect(getChannelDrivingNotification(entity)).toBeUndefined();
+    expect(getChannelEntityTarget(entity)).toEqual({ kind: 'latest' });
+  });
+
+  it('returns the scoped reply notification for a channel_thread row', () => {
+    const notification = replyNotification('n2', 'reply-msg', 'root-msg');
+    const entity = channelThreadRow({
+      notifications: [
+        replyNotification('n1', 'reply-in-other-thread', 'other-thread'),
+        notification,
+      ],
+    });
+
+    expect(getChannelDrivingNotification(entity)).toBe(notification);
   });
 });

--- a/apps/web/src/features/next-soup/utils.ts
+++ b/apps/web/src/features/next-soup/utils.ts
@@ -331,6 +331,65 @@ interface OpenEntityOptions {
 }
 
 /**
+ * The notification that determines which message a channel-family row is
+ * "about" — the same message `getChannelEntityTarget` jumps to and highlights
+ * on click. Shared with the inbox card preview (see `ChannelCardLayout` in
+ * `soup-view/views/inbox/inbox-card-layouts.tsx`) so a row never previews one
+ * message while highlighting another: previously the preview read the row's
+ * raw, unscoped `notifications()[0]` while the click target applied the
+ * scoping/read-skip rules below, so the two could disagree.
+ *
+ * Notifications are scoped to the row first (top-level sends for a channel,
+ * this thread's replies for a thread) and the most recent one wins.
+ *
+ * Read state only changes a whole-`channel` row: its notifications are skipped
+ * when read, because a channel aggregates many messages and the newest unread
+ * one (never your own send) can sit far above the latest — jumping there feels
+ * wrong once the row looks read. A `channel_thread`/`channel_message` row is
+ * scoped to one message, so it targets its driving notification read or not —
+ * that is the reply the row stands for and the message to highlight.
+ *
+ * Returns `undefined` when there's no aiming notification (e.g. a whole
+ * `channel` row whose notifications are all read) — callers fall back to the
+ * row's own semantics in that case (the channel's latest message).
+ */
+export function getChannelDrivingNotification(
+  entity: EntityData
+): UnifiedNotification | undefined {
+  if (
+    entity.type !== 'channel' &&
+    entity.type !== 'channel_message' &&
+    entity.type !== 'channel_thread'
+  ) {
+    return undefined;
+  }
+
+  if (!isWithNotification(entity)) return undefined;
+
+  const scoped = scopeChannelNotificationsForEntity(
+    entity,
+    entity.notifications?.() ?? []
+  );
+  for (const notification of scoped) {
+    // For a whole-`channel` row, ignore notifications you have already read:
+    // the row stands for the entire channel, so once read it should open at
+    // the latest message, not scroll up to an already-seen one. (Read ones
+    // are skipped here; if all are read the loop falls through to the
+    // `latest` fallback.) A read notification is also usually well above the
+    // latest message — you are never notified of your own sends, so the newest
+    // notification is someone else's and predates any message you sent after.
+    //
+    // A thread/message row stands for one specific message, so it always jumps
+    // to its notification's message, read or not — that is the message the row
+    // is about and the one to highlight.
+    if (entity.type === 'channel' && notificationIsRead(notification)) continue;
+    return notification;
+  }
+
+  return undefined;
+}
+
+/**
  * Resolve which channel message to activate when a channel row is opened.
  *
  * A row with an explicit `target` (stamped at construction, e.g. a search hit
@@ -342,17 +401,9 @@ interface OpenEntityOptions {
  * Rows without a target are containers — a `channel` row is the whole channel
  * and a `channel_thread` row is keyed by its root, so neither carries the id
  * of the message/reply that put it in the inbox. That id lives only on the
- * driving notification (the same data the card renders), so read the target
- * from there, exactly like the old inbox did via getChannelNotificationParams.
- * Notifications are scoped to the row first (top-level sends for a channel,
- * this thread's replies for a thread) and the most recent one wins.
- *
- * Read state only changes a whole-`channel` row: its notifications are skipped
- * when read, because a channel aggregates many messages and the newest unread
- * one (never your own send) can sit far above the latest — jumping there feels
- * wrong once the row looks read. A `channel_thread`/`channel_message` row is
- * scoped to one message, so it targets its driving notification read or not —
- * that is the reply the row stands for and the message to highlight.
+ * driving notification (the same data the card renders — see
+ * `getChannelDrivingNotification`), so read the target from there, exactly
+ * like the old inbox did via getChannelNotificationParams.
  *
  * With no aiming notification, fall back to the row's own semantics: a
  * `channel_thread`/`channel_message` row opens at its own root/message, and a
@@ -388,25 +439,8 @@ export function getChannelEntityTarget(
           threadId: entity.threadId,
         };
 
-  if (!isWithNotification(entity)) return fallback;
-
-  const scoped = scopeChannelNotificationsForEntity(
-    entity,
-    entity.notifications?.() ?? []
-  );
-  for (const notification of scoped) {
-    // For a whole-`channel` row, ignore notifications you have already read:
-    // the row stands for the entire channel, so once read it should open at
-    // the latest message, not scroll up to an already-seen one. (Read ones
-    // are skipped here; if all are read the loop falls through to the
-    // `latest` fallback.) A read notification is also usually well above the
-    // latest message — you are never notified of your own sends, so the newest
-    // notification is someone else's and predates any message you sent after.
-    //
-    // A thread/message row stands for one specific message, so it always jumps
-    // to its notification's message, read or not — that is the message the row
-    // is about and the one to highlight.
-    if (entity.type === 'channel' && notificationIsRead(notification)) continue;
+  const notification = getChannelDrivingNotification(entity);
+  if (notification) {
     const { messageId, threadId } = getChannelNotificationParams(notification);
     if (messageId) return { kind: 'message', messageId, threadId };
   }


### PR DESCRIPTION
## Summary
- Clicking a channel row in the inbox/soup list could scroll to and highlight a *different* message than the one shown in that row's preview snippet.
- Root cause: two independent code paths decided "which message is this row about" and had drifted apart.
  - Click/highlight target (`getChannelEntityTarget` in `apps/web/src/features/next-soup/utils.ts`) resolves the *driving notification* — scoped to the row, skipping already-read notifications and thread replies, falling back to `{kind: 'latest'}` only once nothing unread remains. This logic was tightened in #4816 the same day as the bug report.
  - Preview snippet (`ChannelCardLayout` / `toInboxCardDisplayItem` in `soup-view/views/inbox/`) used the raw unscoped `item.notifications()?.[0]` for its "first notification", and unconditionally used `entity.latestRootMessage` for content/timestamp/sender — ignoring the notification entirely.
  - So whenever a channel had an unread notification that wasn't its latest message, the snippet showed the latest message while the click jumped to the older unread one.

## Why prioritized
Reported by Evan in an internal bug-reports discussion, with a screenshot showing the mismatch. Filed as MACRO-2421.

## Change
- `apps/web/src/features/next-soup/utils.ts`: extracted the existing notification-selection logic into an exported `getChannelDrivingNotification(entity)`, used internally by `getChannelEntityTarget` (no behavior change there).
- `apps/web/src/features/next-soup/soup-view/views/inbox/inbox-card-layouts.tsx`: `getFirstNotification` now calls `getChannelDrivingNotification(item)`, falling back to the old unscoped behavior for non-`channel` rows. `getTimestamp` and `messageSenderId` now prefer the driving notification's time/sender when one exists.
- `apps/web/src/features/next-soup/soup-view/views/inbox/utils.ts`: `channelMessageContent`/`itemContent` now prefer the driving notification's content for `channel`-type entities, falling back to `latestRootMessage.content` only when there's no driving notification (matching the click-target's `'latest'` fallback).
- `channel_message`/`channel_thread` rows are unaffected — the scoping matches what was already applied to those types.

## Test plan
- [x] Added unit tests in `apps/web/src/features/next-soup/utils.test.ts` asserting `getChannelDrivingNotification` returns the same notification object `getChannelEntityTarget` derives its `messageId` from, plus "all read → latest" and channel_thread-scoping cases.
- [x] `bunx --bun biome lint` / `biome check` on all changed files — clean.
- [ ] Manually verify: a channel with an unread notification behind the latest message shows a snippet matching the message that gets highlighted on click.

Note: couldn't run the full test suite or dev server in this sandbox (`bun install` 403s on private git deps `pdf.js`/`tauri-plugins`) — please run the new tests and give this a spin in dev before merging.
MACRO-2421

---
_Generated by [Claude Code](https://claude.ai/code/session_019VEs6kwhiKK1UWci3TddCR)_