### PR TITLE
fix(ai): hide duplicate chat attachments

### DIFF
--- a/apps/web/src/lib/core/component/AI/component/input/Attachment.test.tsx
+++ b/apps/web/src/lib/core/component/AI/component/input/Attachment.test.tsx
@@ -1,0 +1,38 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import type { Attachment } from '@core/component/AI/types';
+import { render } from '@solidjs/testing-library';
+import { describe, expect, it, vi } from 'vitest';
+import { AttachmentList } from './Attachment';
+
+vi.mock('@core/component/ImagePreview', () => ({
+  ImagePreview: (props: { image: { id: string } }) => (
+    <div data-testid="image-attachment" data-id={props.image.id} />
+  ),
+}));
+
+describe('AttachmentList', () => {
+  it('renders images without duplicating mentioned entities', () => {
+    const attachments: Attachment[] = [
+      { entity_id: 'image-id', entity_type: 'static_file' },
+      { entity_id: 'document-id', entity_type: 'document' },
+      { entity_id: 'channel-id', entity_type: 'channel' },
+      { entity_id: 'project-id', entity_type: 'project' },
+      { entity_id: 'email-id', entity_type: 'email_thread' },
+    ];
+
+    const { getAllByTestId } = render(() => (
+      <AttachmentList
+        attached={() => attachments}
+        removeAttachment={vi.fn()}
+        uploading={() => []}
+      />
+    ));
+
+    const rendered = getAllByTestId('image-attachment');
+    expect(rendered).toHaveLength(1);
+    expect(rendered[0]?.dataset.id).toBe('image-id');
+  });
+});

--- a/apps/web/src/lib/core/component/AI/component/input/Attachment.tsx
+++ b/apps/web/src/lib/core/component/AI/component/input/Attachment.tsx
@@ -1,12 +1,9 @@
 import type { Attachment, AttachmentPreview } from '@core/component/AI/types';
 import { isImageAttachment } from '@core/component/AI/util/attachment';
 import { ImagePreview } from '@core/component/ImagePreview';
-import { ItemPreview } from '@core/component/ItemPreview';
 import { toast } from '@core/component/Toast/Toast';
 import XIcon from '@phosphor/x.svg';
 import Spinner from '@phosphor-icons/core/bold/spinner-gap-bold.svg?component-solid';
-import Close from '@phosphor-icons/core/regular/x.svg?component-solid';
-import type { ItemType } from '@service-storage/client';
 import type { Accessor } from 'solid-js';
 import { createSignal, For, Match, Show, Suspense, Switch } from 'solid-js';
 
@@ -19,10 +16,10 @@ type AttachmentListProps = {
 export function AttachmentList(props: AttachmentListProps) {
   return (
     <div class="flex flex-row w-full space-x-2 items-end flex-wrap overflow-x-hidden pb-1">
-      <For each={props.attached()}>
+      <For each={props.attached().filter(isImageAttachment)}>
         {(attachment) => (
           <Suspense>
-            <ChatAttachment
+            <ImageAttachment
               attachment={attachment}
               onRemove={() => props.removeAttachment(attachment.entity_id)}
             />
@@ -95,54 +92,5 @@ function ImageAttachment(props: {
         }}
       />
     </div>
-  );
-}
-
-function ChatAttachment(props: {
-  attachment: Attachment;
-  onRemove: () => void;
-}) {
-  return (
-    <Switch>
-      <Match when={props.attachment.entity_type === 'static_file'}>
-        <ImageAttachment
-          attachment={props.attachment}
-          onRemove={props.onRemove}
-        />
-      </Match>
-      <Match
-        when={['document', 'channel', 'project', 'email_thread'].includes(
-          props.attachment.entity_type
-        )}
-      >
-        <div class="flex items-center px-1 space-x-1 hover:bg-hover hover-transition-bg cursor-default text-sm border border-edge-muted rounded-xs max-w-full min-w-0">
-          <ItemPreview
-            id={props.attachment.entity_id}
-            type={
-              (props.attachment.entity_type === 'email_thread'
-                ? 'email'
-                : props.attachment.entity_type) as ItemType
-            }
-            class="flex items-center gap-1 text-sm ring-0"
-            textClass="truncate"
-            iconSize="xs"
-            disableHoverCard
-          />
-          <div
-            class="hover:bg-hover hover-transition-bg rounded-md p-1 items-center flex"
-            onClick={(e) => {
-              e.stopPropagation();
-              props.onRemove?.();
-            }}
-          >
-            <Close
-              width={12}
-              height={12}
-              class="text-ink-muted group-hover:text-failure"
-            />
-          </div>
-        </div>
-      </Match>
-    </Switch>
   );
 }

--- a/apps/web/src/lib/core/component/AI/component/input/ChatInput.tsx
+++ b/apps/web/src/lib/core/component/AI/component/input/ChatInput.tsx
@@ -9,6 +9,7 @@ import {
 } from '@core/component/AI/constant';
 import { useChatInputContext } from '@core/component/AI/context';
 import type { ToolSet } from '@core/component/AI/types';
+import { isImageAttachment } from '@core/component/AI/util/attachment';
 import type { EditorConfigBuilder } from '@core/component/LexicalMarkdown/builder/MarkdownConfigBuilder';
 import { MarkdownShell } from '@core/component/LexicalMarkdown/builder/MarkdownShell';
 import { toast } from '@core/component/Toast/Toast';
@@ -194,7 +195,8 @@ export function ChatInput(props: ChatInputComponentProps) {
     });
 
   const hasAttachments = () =>
-    attachments.attached().length > 0 || uploadQueue.uploading().length > 0;
+    attachments.attached().some(isImageAttachment) ||
+    uploadQueue.uploading().length > 0;
 
   const LeftButton = () => (
     <Button


### PR DESCRIPTION
Hides duplicate non-image attachment previews from the AI composer for task cC3V94k1mYzC2dfkxfw3b while preserving image previews and the full request payload.