### PR TITLE
feat(crm): show no-team and CRM-disabled empty states on the board view

### DIFF
--- a/apps/web/src/features/companies/crm/team-crm-config.ts
+++ b/apps/web/src/features/companies/crm/team-crm-config.ts
@@ -257,6 +257,18 @@ export function useCrmPermissions() {
 }
 
 /**
+ * True once the current-team query resolves to no team (null) or a team
+ * with CRM disabled — the companies views swap in an explanatory empty
+ * state and keep bottom chrome like the AI bar. Stays false while the
+ * query loads so enabled teams don't flash the empty state.
+ */
+export function useCrmUnavailable(): Accessor<boolean> {
+  const teamQuery = useCurrentTeamQuery();
+  return () =>
+    teamQuery.data === null || teamQuery.data?.team.crm_enabled === false;
+}
+
+/**
  * The set of stage option ids considered "closed" — explicit config when
  * present, else a label heuristic over the active stages.
  */

--- a/apps/web/src/features/next-soup/soup-view/empty-states.tsx
+++ b/apps/web/src/features/next-soup/soup-view/empty-states.tsx
@@ -81,7 +81,9 @@ export function EmptyState(props: {
   // CRM is disabled by default per team; the companies list has a dedicated
   // empty state that points admins to the toggle in Settings › CRM. A user
   // with no team at all (data resolves to null) is pointed to team settings
-  // instead, since CRM can only be enabled on a team.
+  // instead, since CRM can only be enabled on a team. Branches wait for the
+  // query to resolve so enabled teams don't flash the disabled copy.
+  const teamResolved = () => teamQuery.data !== undefined;
   const crmEnabled = () => teamQuery.data?.team.crm_enabled ?? false;
   const hasNoTeam = () => teamQuery.data === null;
 
@@ -243,6 +245,9 @@ export function EmptyState(props: {
 
       <Match when={props.listView === 'companies'}>
         <Switch>
+          {/* Render nothing until the team query resolves — showing a wrong
+              panel for a moment is worse than a brief blank. */}
+          <Match when={!teamResolved()}>{null}</Match>
           <Match when={hasNoTeam()}>
             <EmptyStatePanel
               graphic={EmptyStateCompaniesGraphic}

--- a/apps/web/src/features/next-soup/soup-view/empty-states.tsx
+++ b/apps/web/src/features/next-soup/soup-view/empty-states.tsx
@@ -21,7 +21,7 @@ import EmptyStateTasksGraphic from '@design/empty-state-tasks.svg';
 import PlusIcon from '@phosphor/plus.svg';
 import { useCurrentTeamQuery, useIsTeamAdmin } from '@queries/team/teams';
 import { EmptyStatePanel, FilteredHiddenBanner } from '@ui';
-import { type Component, type JSXElement, Match, Show, Switch } from 'solid-js';
+import { type Component, type JSXElement, Match, Switch } from 'solid-js';
 import { FolderDropZone } from './FolderDropZone';
 import { useSoupView } from './soup-view-context';
 
@@ -79,8 +79,11 @@ export function EmptyState(props: {
   const { openSettings } = useSettingsState();
 
   // CRM is disabled by default per team; the companies list has a dedicated
-  // empty state that points admins to the toggle in Settings › CRM.
+  // empty state that points admins to the toggle in Settings › CRM. A user
+  // with no team at all (data resolves to null) is pointed to team settings
+  // instead, since CRM can only be enabled on a team.
   const crmEnabled = () => teamQuery.data?.team.crm_enabled ?? false;
+  const hasNoTeam = () => teamQuery.data === null;
 
   const onConnectEmail = () => {
     void startAddInbox();
@@ -239,9 +242,19 @@ export function EmptyState(props: {
       </Match>
 
       <Match when={props.listView === 'companies'}>
-        <Show
-          when={crmEnabled()}
-          fallback={
+        <Switch>
+          <Match when={hasNoTeam()}>
+            <EmptyStatePanel
+              graphic={EmptyStateCompaniesGraphic}
+              title="Join a team to enable CRM"
+              description="Create or join a team in Settings > Team."
+              primaryAction={{
+                label: 'Open team settings',
+                onClick: () => openSettings('Team'),
+              }}
+            />
+          </Match>
+          <Match when={!crmEnabled()}>
             <EmptyStatePanel
               graphic={EmptyStateCompaniesGraphic}
               title="CRM is disabled"
@@ -259,14 +272,15 @@ export function EmptyState(props: {
                   : undefined
               }
             />
-          }
-        >
-          <EmptyStatePanel
-            graphic={EmptyStateCompaniesGraphic}
-            title="No customers yet"
-            description="Customers your team emails will appear here."
-          />
-        </Show>
+          </Match>
+          <Match when={true}>
+            <EmptyStatePanel
+              graphic={EmptyStateCompaniesGraphic}
+              title="No customers yet"
+              description="Customers your team emails will appear here."
+            />
+          </Match>
+        </Switch>
       </Match>
 
       <Match

--- a/apps/web/src/features/next-soup/soup-view/soup-view.tsx
+++ b/apps/web/src/features/next-soup/soup-view/soup-view.tsx
@@ -60,6 +60,7 @@ import { usePreference } from '@app/preferences/use-preference';
 import { useDealStages } from '@companies/crm/deal-stages';
 import { CrmStageIcon } from '@companies/crm/StageIcon';
 import type { CrmViewConfig } from '@companies/crm/saved-views';
+import { useCrmUnavailable } from '@companies/crm/team-crm-config';
 import {
   useGlobalBlockOrchestrator,
   useGlobalNotificationSource,
@@ -578,6 +579,12 @@ export const SoupView = (props: SoupViewProps) => {
     () => activeListView() === 'companies' && soupView.viewMode() === 'board'
   );
 
+  // When CRM is unavailable (no team / disabled) the board renders the
+  // empty state instead of columns, so board-only chrome tweaks (like
+  // hiding the AI bar) shouldn't apply.
+  const crmUnavailable = useCrmUnavailable();
+  const isBoardRendered = createMemo(() => isBoardMode() && !crmUnavailable());
+
   const [narrowSearchExpanded, setNarrowSearchExpanded] = createSignal(false);
   const [mobileSearchOpen, setMobileSearchOpen] = createSignal(false);
   const [searchIsCollapsed, setSearchIsCollapsed] = createSignal(false);
@@ -778,7 +785,7 @@ export const SoupView = (props: SoupViewProps) => {
             ENABLE_UNIFIED_LIST_AI_INPUT &&
             !isMobile() &&
             !isNewInboxEnabled() &&
-            !isBoardMode()
+            !isBoardRendered()
           }
         >
           <SoupChatInput />

--- a/apps/web/src/features/next-soup/soup-view/views/companies/CompanyKanban.tsx
+++ b/apps/web/src/features/next-soup/soup-view/views/companies/CompanyKanban.tsx
@@ -1,4 +1,5 @@
 import { NO_STAGE } from '@app/features/next-soup/filters/configs/';
+import { EmptyState } from '@app/features/next-soup/soup-view/empty-states';
 import { SoupEntityContextMenu } from '@app/features/next-soup/soup-view/soup-entity-context-menu';
 import { useSoupView } from '@app/features/next-soup/soup-view/soup-view-context';
 import { usePreviewPaneVisiblity } from '@app/features/next-soup/soup-view/use-preview-pane-visibility';
@@ -8,6 +9,7 @@ import { CrmStageIcon } from '@companies/crm/StageIcon';
 import {
   useClosedStageIds,
   useCrmPermissions,
+  useCrmUnavailable,
 } from '@companies/crm/team-crm-config';
 import { useGlobalBlockOrchestrator } from '@components/app/GlobalAppState';
 import { PreviewPanel } from '@components/app/PreviewPanel';
@@ -66,6 +68,9 @@ export function CompanyKanban() {
   const { stages, filterStages, stageProperty, resolveStage } = useDealStages();
   const { canEditCrm, canMoveClosedDeals } = useCrmPermissions();
   const closedStageIds = useClosedStageIds(stages);
+
+  // Mirror the list view's no-team / CRM-disabled empty states.
+  const crmUnavailable = useCrmUnavailable();
 
   const stageColumns = createMemo((): StageColumn[] => {
     // Candidates in canonical pipeline order: the filterable set (active
@@ -180,152 +185,158 @@ export function CompanyKanban() {
   };
 
   return (
-    <Resize.Zone direction="horizontal" gutter={0}>
-      <Resize.Panel id="company-kanban" minSize={200}>
-        {/* Relative wrapper anchors the horizontal scrollbar to the board's
+    <Show
+      when={!crmUnavailable()}
+      fallback={<EmptyState listView="companies" />}
+    >
+      <Resize.Zone direction="horizontal" gutter={0}>
+        <Resize.Panel id="company-kanban" minSize={200}>
+          {/* Relative wrapper anchors the horizontal scrollbar to the board's
             bottom edge when the split is too narrow for all columns. */}
-        <div
-          class={cn(
-            'relative size-full min-w-0',
-            paneVisible() && 'border-r border-edge-muted'
-          )}
-        >
           <div
-            ref={setScrollRef}
-            class="size-full overflow-x-auto overflow-y-hidden scrollbar-hidden"
-          >
-            <div class="flex h-full gap-3 p-3">
-              <For each={columns()}>
-                {(column, columnIndex) => (
-                  <div
-                    class={cn(
-                      // Fallback sizing until the board is measured; after
-                      // that the snapping columnWidth() takes over.
-                      'flex h-full min-w-56 flex-1 flex-col rounded-lg border border-edge-muted bg-surface',
-                      dropTarget() === column.key &&
-                        draggedId() &&
-                        'border-accent/50 bg-accent/5'
-                    )}
-                    style={
-                      columnWidth() !== undefined
-                        ? { width: `${columnWidth()}px`, flex: 'none' }
-                        : undefined
-                    }
-                    onDragOver={(e) => {
-                      if (!draggedId()) return;
-                      e.preventDefault();
-                      setDropTarget(column.key);
-                    }}
-                    onDragLeave={(e) => {
-                      if (
-                        e.relatedTarget instanceof Node &&
-                        e.currentTarget.contains(e.relatedTarget)
-                      ) {
-                        return;
-                      }
-                      if (dropTarget() === column.key) setDropTarget(undefined);
-                    }}
-                    onDrop={(e) => {
-                      e.preventDefault();
-                      const id =
-                        draggedId() ?? e.dataTransfer?.getData('text/plain');
-                      setDropTarget(undefined);
-                      setDraggedId(undefined);
-                      if (id) moveToStage(id, column.key);
-                    }}
-                  >
-                    <div class="flex items-center gap-2 px-3 py-2.5 text-xs font-semibold text-ink-muted">
-                      <Show
-                        when={column.key !== NO_STAGE_KEY}
-                        fallback={
-                          <CircleDashed class="size-3.5 text-ink-extra-muted" />
-                        }
-                      >
-                        <CrmStageIcon
-                          optionId={column.key}
-                          index={columnIndex()}
-                          class="size-3.5"
-                        />
-                      </Show>
-                      <span class="truncate">{column.label}</span>
-                    </div>
-                    <div class="min-h-0 flex-1 overflow-y-auto scrollbar-hidden flex flex-col gap-2 px-2 pb-2">
-                      <For each={column.entities}>
-                        {(entity) => (
-                          // The context-menu trigger is h-full (sized for list
-                          // rows); an auto-height wrapper resolves that to the
-                          // card's content height instead of the column's.
-                          <div class="shrink-0">
-                            <SoupEntityContextMenu entity={entity}>
-                              <CompanyKanbanCard
-                                entity={entity}
-                                draggable={canDragFrom(column.key)}
-                                dragging={draggedId() === entity.id}
-                                onDragStart={(e) => {
-                                  e.dataTransfer?.setData(
-                                    'text/plain',
-                                    entity.id
-                                  );
-                                  if (e.dataTransfer) {
-                                    e.dataTransfer.effectAllowed = 'move';
-                                  }
-                                  setDraggedId(entity.id);
-                                }}
-                                onDragEnd={() => {
-                                  setDraggedId(undefined);
-                                  setDropTarget(undefined);
-                                }}
-                                onClick={(e) => openCompany(entity, e)}
-                              />
-                            </SoupEntityContextMenu>
-                          </div>
-                        )}
-                      </For>
-                    </div>
-                  </div>
-                )}
-              </For>
-            </div>
-          </div>
-          {/* watchContent: columns mount after the initial measurement, so
-              overflow must be re-detected as they load in. */}
-          <CustomScrollbar
-            scrollContainer={scrollRef}
-            horizontal
-            revealZone={48}
-            gutterSize={20}
-            watchContent
-          />
-        </div>
-      </Resize.Panel>
-      <Show when={paneVisible()}>
-        <Resize.Panel
-          id="soup-preview"
-          minSize={500}
-          target={{ kind: 'percent', percent: 70 }}
-        >
-          <Show
-            when={selectedEntity()}
-            fallback={
-              <EmptyStatePanel
-                graphic={EmptyStatePreviewIcon}
-                title="Nothing selected"
-                description="Select a card from the board to preview it here"
-                centered
-              />
-            }
-          >
-            {(entity) => (
-              <PreviewPanel
-                selectedEntity={entity()}
-                orchestrator={orchestrator}
-                splitPanelContext={panel}
-              />
+            class={cn(
+              'relative size-full min-w-0',
+              paneVisible() && 'border-r border-edge-muted'
             )}
-          </Show>
+          >
+            <div
+              ref={setScrollRef}
+              class="size-full overflow-x-auto overflow-y-hidden scrollbar-hidden"
+            >
+              <div class="flex h-full gap-3 p-3">
+                <For each={columns()}>
+                  {(column, columnIndex) => (
+                    <div
+                      class={cn(
+                        // Fallback sizing until the board is measured; after
+                        // that the snapping columnWidth() takes over.
+                        'flex h-full min-w-56 flex-1 flex-col rounded-lg border border-edge-muted bg-surface',
+                        dropTarget() === column.key &&
+                          draggedId() &&
+                          'border-accent/50 bg-accent/5'
+                      )}
+                      style={
+                        columnWidth() !== undefined
+                          ? { width: `${columnWidth()}px`, flex: 'none' }
+                          : undefined
+                      }
+                      onDragOver={(e) => {
+                        if (!draggedId()) return;
+                        e.preventDefault();
+                        setDropTarget(column.key);
+                      }}
+                      onDragLeave={(e) => {
+                        if (
+                          e.relatedTarget instanceof Node &&
+                          e.currentTarget.contains(e.relatedTarget)
+                        ) {
+                          return;
+                        }
+                        if (dropTarget() === column.key)
+                          setDropTarget(undefined);
+                      }}
+                      onDrop={(e) => {
+                        e.preventDefault();
+                        const id =
+                          draggedId() ?? e.dataTransfer?.getData('text/plain');
+                        setDropTarget(undefined);
+                        setDraggedId(undefined);
+                        if (id) moveToStage(id, column.key);
+                      }}
+                    >
+                      <div class="flex items-center gap-2 px-3 py-2.5 text-xs font-semibold text-ink-muted">
+                        <Show
+                          when={column.key !== NO_STAGE_KEY}
+                          fallback={
+                            <CircleDashed class="size-3.5 text-ink-extra-muted" />
+                          }
+                        >
+                          <CrmStageIcon
+                            optionId={column.key}
+                            index={columnIndex()}
+                            class="size-3.5"
+                          />
+                        </Show>
+                        <span class="truncate">{column.label}</span>
+                      </div>
+                      <div class="min-h-0 flex-1 overflow-y-auto scrollbar-hidden flex flex-col gap-2 px-2 pb-2">
+                        <For each={column.entities}>
+                          {(entity) => (
+                            // The context-menu trigger is h-full (sized for list
+                            // rows); an auto-height wrapper resolves that to the
+                            // card's content height instead of the column's.
+                            <div class="shrink-0">
+                              <SoupEntityContextMenu entity={entity}>
+                                <CompanyKanbanCard
+                                  entity={entity}
+                                  draggable={canDragFrom(column.key)}
+                                  dragging={draggedId() === entity.id}
+                                  onDragStart={(e) => {
+                                    e.dataTransfer?.setData(
+                                      'text/plain',
+                                      entity.id
+                                    );
+                                    if (e.dataTransfer) {
+                                      e.dataTransfer.effectAllowed = 'move';
+                                    }
+                                    setDraggedId(entity.id);
+                                  }}
+                                  onDragEnd={() => {
+                                    setDraggedId(undefined);
+                                    setDropTarget(undefined);
+                                  }}
+                                  onClick={(e) => openCompany(entity, e)}
+                                />
+                              </SoupEntityContextMenu>
+                            </div>
+                          )}
+                        </For>
+                      </div>
+                    </div>
+                  )}
+                </For>
+              </div>
+            </div>
+            {/* watchContent: columns mount after the initial measurement, so
+              overflow must be re-detected as they load in. */}
+            <CustomScrollbar
+              scrollContainer={scrollRef}
+              horizontal
+              revealZone={48}
+              gutterSize={20}
+              watchContent
+            />
+          </div>
         </Resize.Panel>
-      </Show>
-    </Resize.Zone>
+        <Show when={paneVisible()}>
+          <Resize.Panel
+            id="soup-preview"
+            minSize={500}
+            target={{ kind: 'percent', percent: 70 }}
+          >
+            <Show
+              when={selectedEntity()}
+              fallback={
+                <EmptyStatePanel
+                  graphic={EmptyStatePreviewIcon}
+                  title="Nothing selected"
+                  description="Select a card from the board to preview it here"
+                  centered
+                />
+              }
+            >
+              {(entity) => (
+                <PreviewPanel
+                  selectedEntity={entity()}
+                  orchestrator={orchestrator}
+                  splitPanelContext={panel}
+                />
+              )}
+            </Show>
+          </Resize.Panel>
+        </Show>
+      </Resize.Zone>
+    </Show>
   );
 }
 


### PR DESCRIPTION
## Summary

The Customers board view previously rendered empty stage columns when CRM was disabled or the user had no team — the empty-state handling lives in `SoupViewList`, which the board replaces entirely, so it never showed. The board now shows the same empty states as the list view.

## Changes

- **Board empty states** (`CompanyKanban.tsx`): when CRM is unavailable, the board renders the shared companies `EmptyState` instead of stage columns.
- **Shared `useCrmUnavailable()` hook** (`team-crm-config.ts`): true once the current-team query resolves to no team (`null`) or a team with `crm_enabled: false`. Stays false while the query is loading so enabled teams don't flash the empty state on the board.
- **New no-team empty state** (`empty-states.tsx`): the companies branch is now a three-way switch — no team / CRM disabled / no customers. Users without a team see "You must be part of a team to enable CRM" with an **Open team settings** action (the Team settings page has its own create-team flow), instead of falling into the "CRM is disabled" copy.
- **AI chat bar** (`soup-view.tsx`): the bar is now hidden only when the actual board is rendered (`isBoardMode() && !crmUnavailable()`), where it would float over the board's horizontal scrollbar. While the board shows an empty state, the bar stays at the bottom like in the list view.