### PR TITLE
feat(crm): add Signal/All email filter to company and contact pages

### DIFF
--- a/apps/web/src/features/companies/Company/CompanyEmailsSection.tsx
+++ b/apps/web/src/features/companies/Company/CompanyEmailsSection.tsx
@@ -3,6 +3,7 @@ import { TabsInset } from '@core/component/TabsInset';
 import { type CrmCompanyEntity, ListEntity, ListLayoutProvider } from '@entity';
 import { createMemo, createSignal, For, Show } from 'solid-js';
 import {
+  type EmailSignalView,
   type EmailView,
   useCompanyEmailsQuery,
 } from './use-company-emails-query';
@@ -13,7 +14,8 @@ export function CompanyEmailsSection(props: { company?: CrmCompanyEntity }) {
     () => props.company?.domains.map((domain) => domain.domain) ?? []
   );
   const [view, setView] = createSignal<EmailView>('team');
-  const emailsQuery = useCompanyEmailsQuery(domains, view);
+  const [signalView, setSignalView] = createSignal<EmailSignalView>('all');
+  const emailsQuery = useCompanyEmailsQuery(domains, view, signalView);
   const emails = () => emailsQuery.data?.entities ?? [];
 
   const [listRef, setListRef] = createSignal<HTMLElement>();
@@ -27,25 +29,36 @@ export function CompanyEmailsSection(props: { company?: CrmCompanyEntity }) {
   });
 
   const emptyMessage = () => {
-    if (view() === 'me') return 'No emails with this company in your inbox.';
+    const kind = signalView() === 'signal' ? 'signal emails' : 'emails';
+    if (view() === 'me') return `No ${kind} with this company in your inbox.`;
     if (props.company?.emailSync === false) {
       return 'Email sync is disabled for this company.';
     }
-    return 'No emails with this company yet.';
+    return `No ${kind} with this company yet.`;
   };
 
   return (
     <div class="flex flex-col gap-2">
       <div class="flex items-center justify-between gap-2">
         <h2 class="text-sm font-medium text-ink-muted">Emails</h2>
-        <TabsInset
-          list={[
-            { value: 'team', label: 'Team' },
-            { value: 'me', label: 'Me' },
-          ]}
-          value={view()}
-          onChange={(v) => setView(v as EmailView)}
-        />
+        <div class="flex items-center gap-2.5">
+          <TabsInset
+            list={[
+              { value: 'signal', label: 'Signal' },
+              { value: 'all', label: 'All' },
+            ]}
+            value={signalView()}
+            onChange={(v) => setSignalView(v as EmailSignalView)}
+          />
+          <TabsInset
+            list={[
+              { value: 'team', label: 'Team' },
+              { value: 'me', label: 'Me' },
+            ]}
+            value={view()}
+            onChange={(v) => setView(v as EmailView)}
+          />
+        </div>
       </div>
       <Show
         when={props.company && !emailsQuery.isLoading}
@@ -61,27 +74,31 @@ export function CompanyEmailsSection(props: { company?: CrmCompanyEntity }) {
             </div>
           }
         >
-          <ListLayoutProvider ref={listRef}>
-            <div ref={setListRef} class="flex flex-col">
-              <For each={emails()}>
-                {(entity) => (
-                  <ListEntity
-                    entity={entity}
-                    timestamp={entity.updatedAt}
-                    onClick={() => openEntityInSplitFromUnifiedList(entity, {})}
-                  />
-                )}
-              </For>
-            </div>
-          </ListLayoutProvider>
-          <Show when={emailsQuery.hasNextPage}>
-            <div ref={setSentinelRef} class="h-px" />
-          </Show>
-          <Show when={emailsQuery.isFetchingNextPage}>
-            <div class="p-3 text-center text-xs text-ink-muted">
-              Loading more…
-            </div>
-          </Show>
+          <div class="max-h-96 overflow-y-auto">
+            <ListLayoutProvider ref={listRef}>
+              <div ref={setListRef} class="flex flex-col">
+                <For each={emails()}>
+                  {(entity) => (
+                    <ListEntity
+                      entity={entity}
+                      timestamp={entity.updatedAt}
+                      onClick={() =>
+                        openEntityInSplitFromUnifiedList(entity, {})
+                      }
+                    />
+                  )}
+                </For>
+              </div>
+            </ListLayoutProvider>
+            <Show when={emailsQuery.hasNextPage}>
+              <div ref={setSentinelRef} class="h-px" />
+            </Show>
+            <Show when={emailsQuery.isFetchingNextPage}>
+              <div class="p-3 text-center text-xs text-ink-muted">
+                Loading more…
+              </div>
+            </Show>
+          </div>
         </Show>
       </Show>
     </div>

--- a/apps/web/src/features/companies/Company/emailFilter.ts
+++ b/apps/web/src/features/companies/Company/emailFilter.ts
@@ -44,3 +44,17 @@ export function emailFilterForDomains(domains: string[]): unknown | undefined {
   const trees = domains.map((d) => anyDirection({ Domain: d }));
   return trees.reduce((acc, cur) => ({ '|': [acc, cur] }));
 }
+
+/** Signal-only leaf — matches the server-side `t.is_signal` flag. */
+export function emailFilterForSignal(): unknown {
+  return { l: { Importance: true } };
+}
+
+/** AND-combine filter trees, skipping undefined operands. */
+export function andEmailFilters(
+  ...trees: (unknown | undefined)[]
+): unknown | undefined {
+  const present = trees.filter((t) => t !== undefined);
+  if (present.length === 0) return undefined;
+  return present.reduce((acc, cur) => ({ '&': [acc, cur] }));
+}

--- a/apps/web/src/features/companies/Company/use-company-emails-query.ts
+++ b/apps/web/src/features/companies/Company/use-company-emails-query.ts
@@ -1,9 +1,14 @@
 import { NIL_UUID } from '@app/features/next-soup/filters/filter-store';
 import { useSoupAstItemsQuery } from '@queries/soup/items';
 import type { Accessor } from 'solid-js';
-import { emailFilterForDomains } from './emailFilter';
+import {
+  andEmailFilters,
+  emailFilterForDomains,
+  emailFilterForSignal,
+} from './emailFilter';
 
 export type EmailView = 'team' | 'me';
+export type EmailSignalView = 'signal' | 'all';
 
 /**
  * Email threads the team has exchanged with a company, fetched via the
@@ -14,10 +19,13 @@ export type EmailView = 'team' | 'me';
  * - `me`: drops `ecd` and uses a raw `ef` any-direction OR-tree across
  *   the company's domains, so the default per-user mailbox scope applies
  *   and only the current user's own emails come back.
+ * - `signal`: ANDs an Importance leaf into `ef` (the server AND-merges
+ *   `ef` with the CRM scope tree, so it composes with `ecd` too).
  */
 export function useCompanyEmailsQuery(
   domains: Accessor<string[]>,
-  view: Accessor<EmailView>
+  view: Accessor<EmailView>,
+  signalView: Accessor<EmailSignalView>
 ) {
   return useSoupAstItemsQuery(
     () => {
@@ -32,10 +40,15 @@ export function useCompanyEmailsQuery(
         fef: { l: { id: NIL_UUID } },
         emailView: 'all',
       };
+      const signal =
+        signalView() === 'signal' ? emailFilterForSignal() : undefined;
       const body =
         view() === 'me'
-          ? { ...base, ef: emailFilterForDomains(domains()) }
-          : { ...base, ecd: domains() };
+          ? {
+              ...base,
+              ef: andEmailFilters(emailFilterForDomains(domains()), signal),
+            }
+          : { ...base, ecd: domains(), ef: signal };
       return {
         params: { limit: 100, sort_method: 'updated_at' },
         body,

--- a/apps/web/src/features/contacts/Contact/ContactEmailsSection.tsx
+++ b/apps/web/src/features/contacts/Contact/ContactEmailsSection.tsx
@@ -5,6 +5,7 @@ import { ListEntity, ListLayoutProvider } from '@entity';
 import type { CrmContactResponse } from '@service-storage/generated/schemas/crmContactResponse';
 import { createSignal, For, Show } from 'solid-js';
 import {
+  type EmailSignalView,
   type EmailView,
   useContactEmailsQuery,
 } from './use-contact-emails-query';
@@ -12,7 +13,8 @@ import {
 export function ContactEmailsSection(props: { contact?: CrmContactResponse }) {
   const email = () => props.contact?.email;
   const [view, setView] = createSignal<EmailView>('team');
-  const emailsQuery = useContactEmailsQuery(email, view);
+  const [signalView, setSignalView] = createSignal<EmailSignalView>('all');
+  const emailsQuery = useContactEmailsQuery(email, view, signalView);
   const emails = () => emailsQuery.data?.entities ?? [];
 
   const [listRef, setListRef] = createSignal<HTMLElement>();
@@ -29,14 +31,24 @@ export function ContactEmailsSection(props: { contact?: CrmContactResponse }) {
     <div class="flex flex-col gap-2">
       <div class="flex items-center justify-between gap-2">
         <h2 class="text-sm font-medium text-ink-muted">Emails</h2>
-        <TabsInset
-          list={[
-            { value: 'team', label: 'Team' },
-            { value: 'me', label: 'Me' },
-          ]}
-          value={view()}
-          onChange={(v) => setView(v as EmailView)}
-        />
+        <div class="flex items-center gap-2.5">
+          <TabsInset
+            list={[
+              { value: 'signal', label: 'Signal' },
+              { value: 'all', label: 'All' },
+            ]}
+            value={signalView()}
+            onChange={(v) => setSignalView(v as EmailSignalView)}
+          />
+          <TabsInset
+            list={[
+              { value: 'team', label: 'Team' },
+              { value: 'me', label: 'Me' },
+            ]}
+            value={view()}
+            onChange={(v) => setView(v as EmailView)}
+          />
+        </div>
       </div>
       <Show
         when={props.contact && !emailsQuery.isLoading}
@@ -48,33 +60,35 @@ export function ContactEmailsSection(props: { contact?: CrmContactResponse }) {
           when={emails().length > 0}
           fallback={
             <div class="rounded-lg border border-dashed border-edge-muted p-6 text-center text-sm text-ink-muted">
-              {view() === 'me'
-                ? 'No emails with this contact in your inbox.'
-                : 'No emails with this contact yet.'}
+              {`No ${signalView() === 'signal' ? 'signal emails' : 'emails'} with this contact ${view() === 'me' ? 'in your inbox' : 'yet'}.`}
             </div>
           }
         >
-          <ListLayoutProvider ref={listRef}>
-            <div ref={setListRef} class="flex flex-col">
-              <For each={emails()}>
-                {(entity) => (
-                  <ListEntity
-                    entity={entity}
-                    timestamp={entity.updatedAt}
-                    onClick={() => openEntityInSplitFromUnifiedList(entity, {})}
-                  />
-                )}
-              </For>
-            </div>
-          </ListLayoutProvider>
-          <Show when={emailsQuery.hasNextPage}>
-            <div ref={setSentinelRef} class="h-px" />
-          </Show>
-          <Show when={emailsQuery.isFetchingNextPage}>
-            <div class="p-3 text-center text-xs text-ink-muted">
-              Loading more…
-            </div>
-          </Show>
+          <div class="max-h-96 overflow-y-auto">
+            <ListLayoutProvider ref={listRef}>
+              <div ref={setListRef} class="flex flex-col">
+                <For each={emails()}>
+                  {(entity) => (
+                    <ListEntity
+                      entity={entity}
+                      timestamp={entity.updatedAt}
+                      onClick={() =>
+                        openEntityInSplitFromUnifiedList(entity, {})
+                      }
+                    />
+                  )}
+                </For>
+              </div>
+            </ListLayoutProvider>
+            <Show when={emailsQuery.hasNextPage}>
+              <div ref={setSentinelRef} class="h-px" />
+            </Show>
+            <Show when={emailsQuery.isFetchingNextPage}>
+              <div class="p-3 text-center text-xs text-ink-muted">
+                Loading more…
+              </div>
+            </Show>
+          </div>
         </Show>
       </Show>
     </div>

--- a/apps/web/src/features/contacts/Contact/use-contact-emails-query.ts
+++ b/apps/web/src/features/contacts/Contact/use-contact-emails-query.ts
@@ -1,9 +1,14 @@
 import { NIL_UUID } from '@app/features/next-soup/filters/filter-store';
-import { emailFilterForAddress } from '@companies/Company/emailFilter';
+import {
+  andEmailFilters,
+  emailFilterForAddress,
+  emailFilterForSignal,
+} from '@companies/Company/emailFilter';
 import { useSoupAstItemsQuery } from '@queries/soup/items';
 import type { Accessor } from 'solid-js';
 
 export type EmailView = 'team' | 'me';
+export type EmailSignalView = 'signal' | 'all';
 
 /**
  * Email threads involving a single CRM contact, fetched via the
@@ -14,10 +19,13 @@ export type EmailView = 'team' | 'me';
  * - `me`: drops `eca` and uses a raw `ef` any-direction OR-tree on the
  *   contact's address, so the default per-user mailbox scope applies and
  *   only the current user's own emails come back.
+ * - `signal`: ANDs an Importance leaf into `ef` (the server AND-merges
+ *   `ef` with the CRM scope tree, so it composes with `eca` too).
  */
 export function useContactEmailsQuery(
   email: Accessor<string | undefined>,
-  view: Accessor<EmailView>
+  view: Accessor<EmailView>,
+  signalView: Accessor<EmailSignalView>
 ) {
   return useSoupAstItemsQuery(
     () => {
@@ -33,13 +41,18 @@ export function useContactEmailsQuery(
         fef: { l: { id: NIL_UUID } },
         emailView: 'all',
       };
+      const signal =
+        signalView() === 'signal' ? emailFilterForSignal() : undefined;
       const body =
         view() === 'me'
           ? {
               ...base,
-              ef: addr ? emailFilterForAddress(addr) : undefined,
+              ef: andEmailFilters(
+                addr ? emailFilterForAddress(addr) : undefined,
+                signal
+              ),
             }
-          : { ...base, eca: addr ? [addr] : [] };
+          : { ...base, eca: addr ? [addr] : [], ef: signal };
       return {
         params: { limit: 100, sort_method: 'updated_at' },
         body,

--- a/crates/soup/src/inbound/axum_router.rs
+++ b/crates/soup/src/inbound/axum_router.rs
@@ -1187,11 +1187,10 @@ impl ApiEntityFilterAst {
 
         let (email_tree, crm_scope) = match (email_filter, crm) {
             (Some(existing), Some((crm_tree, scope))) => {
-                // The Arc was freshly constructed by serde when this
-                // request body deserialized, and has not been cloned
-                // since — refcount is 1, so `try_unwrap` always succeeds.
-                let existing_owned = Arc::try_unwrap(existing)
-                    .map_err(|_| report!("internal: email_filter Arc was unexpectedly shared"))?;
+                // Callers may hold other clones of this Arc (the soup
+                // service clones the request filters before expansion),
+                // so fall back to cloning the tree when it's shared.
+                let existing_owned = Arc::try_unwrap(existing).unwrap_or_else(|arc| (*arc).clone());
                 (
                     Some(Arc::new(Expr::and(existing_owned, crm_tree))),
                     Some(scope),

--- a/crates/soup/src/inbound/axum_router.rs
+++ b/crates/soup/src/inbound/axum_router.rs
@@ -1190,7 +1190,7 @@ impl ApiEntityFilterAst {
                 // Callers may hold other clones of this Arc (the soup
                 // service clones the request filters before expansion),
                 // so fall back to cloning the tree when it's shared.
-                let existing_owned = Arc::try_unwrap(existing).unwrap_or_else(|arc| (*arc).clone());
+                let existing_owned = Arc::unwrap_or_clone(existing);
                 (
                     Some(Arc::new(Expr::and(existing_owned, crm_tree))),
                     Some(scope),

--- a/crates/soup/src/inbound/axum_router/tests.rs
+++ b/crates/soup/src/inbound/axum_router/tests.rs
@@ -1794,6 +1794,27 @@ fn ast_endpoint_crm_ands_with_existing_freeform_ef() {
 }
 
 #[test]
+fn ast_endpoint_crm_ef_merge_tolerates_shared_arc() {
+    // The soup service clones the request filters before AST expansion
+    // (`get_user_soup_internal`), so the `ef` Arc reaches the CRM
+    // AND-merge with refcount > 1. The merge must clone, not error.
+    let js = json!({
+        "ef": { "l": { "Importance": true } },
+        "ecd": ["acme.com"],
+    });
+    let api: ApiEntityFilterAst = serde_json::from_value(js).unwrap();
+    let _extra_ref = api.email_filter.clone();
+    let ast = api
+        .into_entity_ast()
+        .expect("shared ef Arc must not fail the merge");
+    let tree = ast.email_filter.tree.as_ref().expect("tree set");
+    assert!(
+        matches!(tree.as_ref(), filter_ast::Expr::And(_, _)),
+        "expected And at root after CRM AND-merge"
+    );
+}
+
+#[test]
 fn ast_endpoint_crm_domains_are_lowercased_in_scope() {
     // Mixed-case input must land in the scope as lowercase — the CRM
     // pre-check uses LOWER(domain) on the SQL side and would otherwise


### PR DESCRIPTION
## Summary

Adds a **Signal / All** toggle to the Emails section on CRM company and contact pages, alongside the existing Team / Me toggle. Signal narrows the list to important emails using the same `Importance` filter the mail view's Signal tab uses (the server-side `t.is_signal` flag). All four combinations (Team/Me x Signal/All) compose.

Also fixes a latent soup bug the new combination exposed, and makes the email list scroll inside a fixed-height box instead of growing the page.

## Frontend

- `emailFilter.ts`: new `emailFilterForSignal()` leaf (`{ l: { Importance: true } }`) and `andEmailFilters(...)` helper that AND-combines filter trees on the wire, skipping undefined operands.
- `use-company-emails-query.ts` / `use-contact-emails-query.ts`: new `signalView` accessor. In Team view the Importance leaf is passed as `ef` alongside `ecd`/`eca` (the router AND-merges them); in Me view it's ANDed into the existing any-direction domain/address tree. `All` leaves request bodies byte-identical to before.
- `CompanyEmailsSection.tsx` / `ContactEmailsSection.tsx`: second `TabsInset` (Signal/All, defaults to All), signal-aware empty states, and a `max-h-96 overflow-y-auto` wrapper so the list scrolls in place (the infinite-scroll sentinel already roots its IntersectionObserver at the nearest scrollable ancestor).

Kept `emailView: 'all'` in every case: Signal here means "important emails, ever" — archived/done threads still show, unlike the inbox Signal tab.

## Backend fix

Sending `ef` together with `ecd`/`eca` returned a 400 with `internal: email_filter Arc was unexpectedly shared`. The CRM AND-merge in `axum_router.rs` assumed the freshly-deserialized `ef` Arc had refcount 1 and hard-errored on `Arc::try_unwrap` failure — but `get_user_soup_internal` clones the request filters before AST expansion, so the Arc always arrives shared on this path. It only ever worked because no caller had combined `ef` with the CRM scope until now. The merge now falls back to cloning the tree.

Added `ast_endpoint_crm_ef_merge_tolerates_shared_arc`, which holds a second Arc reference before expansion — fails on the old code, passes now. All 24 axum_router tests pass (`cargo test -p soup --features all`).
