### PR TITLE
fix: mobile channel message sending bug

### DIFF
--- a/apps/web/src/components/app/mobile/SwipableRow.tsx
+++ b/apps/web/src/components/app/mobile/SwipableRow.tsx
@@ -512,8 +512,13 @@ export function SwipableRow(
     onCleanup(() => ctx.unregisterRowHandler(entityId));
   });
 
-  onCleanup(() => {
-    ctx.clearState(props.id);
+  // `props.id` can resolve through a parent getter chain (e.g. a message row
+  // inside a `<Show>` accessor) that is already stale by the time this row is
+  // disposed, so it must not be read inside onCleanup; capture it while
+  // mounted and clear with the captured value.
+  createEffect(() => {
+    const id = props.id;
+    onCleanup(() => ctx.clearState(id));
   });
 
   const swipePhase = () => rowState().phase;

--- a/apps/web/src/features/block-email/component/EmailContext.tsx
+++ b/apps/web/src/features/block-email/component/EmailContext.tsx
@@ -585,13 +585,19 @@ export function EmailProvider(props: FlowProps<{ threadID: string }>) {
   // We can't invalidate/refetch while mounted because any query state change
   // triggers SolidQuery's createClientSubscriber → Resource.refetch() → Suspense
   // DOM detach, which resets scroll position.
-  onCleanup(() => {
-    if (draftSavedThreadIds.has(props.threadID)) {
-      draftSavedThreadIds.delete(props.threadID);
-      queryClient.removeQueries({
-        queryKey: emailKeys.threadMessages(props.threadID).queryKey,
-      });
-    }
+  // `props.threadID` chains through the email block's non-keyed
+  // `<Show when={threadId()}>` accessor, which is already stale during
+  // disposal; capture it while mounted instead of reading it in the cleanup.
+  createEffect(() => {
+    const threadID = props.threadID;
+    onCleanup(() => {
+      if (draftSavedThreadIds.has(threadID)) {
+        draftSavedThreadIds.delete(threadID);
+        queryClient.removeQueries({
+          queryKey: emailKeys.threadMessages(threadID).queryKey,
+        });
+      }
+    });
   });
 
   return (


### PR DESCRIPTION
Bug caused by reading `prop` narrowed by a `<Show>` in a downstream `onCleanup()`. Also fixed same pattern in `EmailContext.tsx`.