### PR TITLE
perf(db): drop entity_access indexes superseded by the plain source-first index

### DIFF
--- a/crates/macro_db_client/migrations/20260715154215_drop_entity_access_source_id_index.sql
+++ b/crates/macro_db_client/migrations/20260715154215_drop_entity_access_source_id_index.sql
@@ -1,0 +1,10 @@
+-- no-transaction
+-- entity_access_source_id_idx is a strict prefix of
+-- idx_entity_access_source_type_entity_plain (source_id, entity_type,
+-- entity_id); every source_id equality predicate is served by the plain
+-- index. Deploy only after confirming the plain index is valid:
+--   SELECT indexrelid::regclass FROM pg_index WHERE NOT indisvalid;
+--
+-- Single statement on purpose: see the note in
+-- 20260715154137_add_entity_access_source_type_entity_plain_index.sql.
+DROP INDEX CONCURRENTLY IF EXISTS entity_access_source_id_idx;

--- a/crates/macro_db_client/migrations/20260715154216_drop_entity_access_source_type_entity_expression_index.sql
+++ b/crates/macro_db_client/migrations/20260715154216_drop_entity_access_source_type_entity_expression_index.sql
@@ -1,0 +1,12 @@
+-- no-transaction
+-- idx_entity_access_source_type_entity keyed its third column on the
+-- expression (entity_id::text), which Postgres never uses to satisfy a
+-- reference to entity_id, so it could not serve index-only scans and its
+-- (source_id, entity_type) index conditions are covered by
+-- idx_entity_access_source_type_entity_plain. Deploy only after confirming
+-- the plain index is valid:
+--   SELECT indexrelid::regclass FROM pg_index WHERE NOT indisvalid;
+--
+-- Single statement on purpose: see the note in
+-- 20260715154137_add_entity_access_source_type_entity_plain_index.sql.
+DROP INDEX CONCURRENTLY IF EXISTS idx_entity_access_source_type_entity;


### PR DESCRIPTION
Stacked on #4863. Drops the two entity_access indexes that PR makes redundant: `entity_access_source_id_idx` (strict prefix of the new plain index) and the expression index `idx_entity_access_source_type_entity` (its `(entity_id::text)` key can never serve index-only scans, and its index conditions are covered by the plain index). All 33 cached queries touching `entity_access.source_id` use equality predicates the plain index serves identically. Merge only after #4863's `idx_entity_access_source_type_entity_plain` is confirmed valid in prod (`SELECT indexrelid::regclass FROM pg_index WHERE NOT indisvalid;`).
