### PR TITLE
fix(notifications): stop stale fetches clobbering channel mark-read

### DIFF
--- a/apps/web/src/features/channel/sidebar/channels-unread-widget.tsx
+++ b/apps/web/src/features/channel/sidebar/channels-unread-widget.tsx
@@ -241,11 +241,6 @@ function ChannelGroupItem(props: {
     if (!manager) return;
     const notification = latestNotification();
     openNotification(notification, manager, newSplit);
-    // Opening a group acknowledges it. Mount-driven per-message marking only
-    // reaches rows the virtualizer renders, so notifications for messages
-    // above the viewport would otherwise keep the group alive after the
-    // click (macro-1620).
-    notificationSource.bulkMarkAsRead(props.group.notifications);
   };
 
   const openInCurrentSplit = () => {
@@ -391,7 +386,6 @@ function filterUnreadNotDone(notifications: UnifiedNotification[]) {
 }
 
 function ChannelGroupDropdownItem(props: { group: ChannelGroup }) {
-  const notificationSource = useGlobalNotificationSource();
   const senderName = useSenderName(props.group.latestSenderId);
   const count = () => props.group.notifications.length;
   const displayName = () => {
@@ -405,9 +399,7 @@ function ChannelGroupDropdownItem(props: { group: ChannelGroup }) {
       class="min-h-8 gap-2 px-2.5 text-[13px]"
       onSelect={() => {
         const manager = globalSplitManager();
-        if (!manager) return;
-        openNotification(latestNotification(), manager, false);
-        notificationSource.bulkMarkAsRead(props.group.notifications);
+        if (manager) openNotification(latestNotification(), manager, false);
       }}
     >
       <Show

--- a/apps/web/src/features/channel/sidebar/channels-unread-widget.tsx
+++ b/apps/web/src/features/channel/sidebar/channels-unread-widget.tsx
@@ -241,6 +241,11 @@ function ChannelGroupItem(props: {
     if (!manager) return;
     const notification = latestNotification();
     openNotification(notification, manager, newSplit);
+    // Opening a group acknowledges it. Mount-driven per-message marking only
+    // reaches rows the virtualizer renders, so notifications for messages
+    // above the viewport would otherwise keep the group alive after the
+    // click (macro-1620).
+    notificationSource.bulkMarkAsRead(props.group.notifications);
   };
 
   const openInCurrentSplit = () => {
@@ -386,6 +391,7 @@ function filterUnreadNotDone(notifications: UnifiedNotification[]) {
 }
 
 function ChannelGroupDropdownItem(props: { group: ChannelGroup }) {
+  const notificationSource = useGlobalNotificationSource();
   const senderName = useSenderName(props.group.latestSenderId);
   const count = () => props.group.notifications.length;
   const displayName = () => {
@@ -399,7 +405,9 @@ function ChannelGroupDropdownItem(props: { group: ChannelGroup }) {
       class="min-h-8 gap-2 px-2.5 text-[13px]"
       onSelect={() => {
         const manager = globalSplitManager();
-        if (manager) openNotification(latestNotification(), manager, false);
+        if (!manager) return;
+        openNotification(latestNotification(), manager, false);
+        notificationSource.bulkMarkAsRead(props.group.notifications);
       }}
     >
       <Show

--- a/apps/web/src/features/notifications/components/MarkMessageNotifications.tsx
+++ b/apps/web/src/features/notifications/components/MarkMessageNotifications.tsx
@@ -5,7 +5,7 @@ import {
 } from '@notifications/notification-helpers';
 import type { UnifiedNotification } from '@notifications/types';
 import type { JSXElement } from 'solid-js';
-import { createEffect } from 'solid-js';
+import { createEffect, createSignal } from 'solid-js';
 
 const MAX_MARK_ATTEMPTS = 3;
 
@@ -25,8 +25,9 @@ export function MarkMessageNotifications(props: {
 
   // Not a one-shot latch: a stale refetch can land after the optimistic write
   // and flip the notification back to unviewed while this row stays mounted,
-  // so re-mark whenever the cache regresses, bounded per mount.
-  let inFlight = false;
+  // so re-mark whenever the cache regresses, bounded per mount. inFlight is a
+  // signal so a regression that lands mid-mark re-runs the effect on settle.
+  const [inFlight, setInFlight] = createSignal(false);
   let attempts = 0;
 
   createEffect(() => {
@@ -34,15 +35,15 @@ export function MarkMessageNotifications(props: {
     if (
       !existing ||
       existing.viewed_at ||
-      inFlight ||
+      inFlight() ||
       attempts >= MAX_MARK_ATTEMPTS
     ) {
       return;
     }
-    inFlight = true;
     attempts += 1;
+    setInFlight(true);
     notificationSource.markAsRead(existing).finally(() => {
-      inFlight = false;
+      setInFlight(false);
     });
   });
 

--- a/apps/web/src/features/notifications/components/MarkMessageNotifications.tsx
+++ b/apps/web/src/features/notifications/components/MarkMessageNotifications.tsx
@@ -7,6 +7,8 @@ import type { UnifiedNotification } from '@notifications/types';
 import type { JSXElement } from 'solid-js';
 import { createEffect } from 'solid-js';
 
+const MAX_MARK_ATTEMPTS = 3;
+
 export function MarkMessageNotifications(props: {
   messageId: string;
   channelId: string;
@@ -21,15 +23,27 @@ export function MarkMessageNotifications(props: {
     isChannelNotification(n) &&
     n.notification_metadata.content.messageId === props.messageId;
 
-  let marked = false;
+  // Not a one-shot latch: a stale refetch can land after the optimistic write
+  // and flip the notification back to unviewed while this row stays mounted,
+  // so re-mark whenever the cache regresses, bounded per mount.
+  let inFlight = false;
+  let attempts = 0;
 
   createEffect(() => {
-    if (marked) return;
     const existing = notifications().find(isMessageNotification);
-    if (existing && !existing.viewed_at) {
-      marked = true;
-      notificationSource.markAsRead(existing);
+    if (
+      !existing ||
+      existing.viewed_at ||
+      inFlight ||
+      attempts >= MAX_MARK_ATTEMPTS
+    ) {
+      return;
     }
+    inFlight = true;
+    attempts += 1;
+    notificationSource.markAsRead(existing).finally(() => {
+      inFlight = false;
+    });
   });
 
   return <>{props.children}</>;

--- a/apps/web/src/features/notifications/notification-helpers.ts
+++ b/apps/web/src/features/notifications/notification-helpers.ts
@@ -224,7 +224,10 @@ export async function executeMarkNotificationsDone(
   notificationIds: string[]
 ): Promise<void> {
   setDoneOverride(notificationIds, true);
-  await queryClient.cancelQueries({ queryKey: notificationKeys.user._def });
+  await queryClient.cancelQueries(
+    { queryKey: notificationKeys.user._def },
+    { revert: false }
+  );
   try {
     await bulkMarkNotificationsAsDone(notificationIds);
   } catch (err) {
@@ -247,7 +250,10 @@ export async function executeMarkNotificationsUndone(
   notificationIds: string[]
 ): Promise<void> {
   setDoneOverride(notificationIds, false);
-  await queryClient.cancelQueries({ queryKey: notificationKeys.user._def });
+  await queryClient.cancelQueries(
+    { queryKey: notificationKeys.user._def },
+    { revert: false }
+  );
   try {
     await bulkMarkNotificationsAsUndone(notificationIds);
   } catch (err) {

--- a/apps/web/src/features/notifications/notification-helpers.ts
+++ b/apps/web/src/features/notifications/notification-helpers.ts
@@ -224,10 +224,6 @@ export async function executeMarkNotificationsDone(
   notificationIds: string[]
 ): Promise<void> {
   setDoneOverride(notificationIds, true);
-  await queryClient.cancelQueries(
-    { queryKey: notificationKeys.user._def },
-    { revert: false }
-  );
   try {
     await bulkMarkNotificationsAsDone(notificationIds);
   } catch (err) {
@@ -250,10 +246,6 @@ export async function executeMarkNotificationsUndone(
   notificationIds: string[]
 ): Promise<void> {
   setDoneOverride(notificationIds, false);
-  await queryClient.cancelQueries(
-    { queryKey: notificationKeys.user._def },
-    { revert: false }
-  );
   try {
     await bulkMarkNotificationsAsUndone(notificationIds);
   } catch (err) {

--- a/apps/web/src/features/notifications/notification-source.ts
+++ b/apps/web/src/features/notifications/notification-source.ts
@@ -129,9 +129,13 @@ export function createNotificationSource(
   const markNotificationsAsSeenMutation = useMarkNotificationsAsSeenMutation();
   const markNotificationsAsDoneMutation = useMarkNotificationsAsDoneMutation();
 
+  // Gate on data presence, not isSuccess: a failed or cancelled background
+  // refetch flips status to error while the cached pages remain, and blanking
+  // every unread surface over a transient refetch is worse than showing the
+  // cached state.
   const notifications = createMemo(() => {
-    if (!notificationsQuery.isSuccess) return [];
     const raw = notificationsQuery.data;
+    if (!raw) return [];
     const overrides = doneOverrides();
     if (overrides.size === 0) return raw;
     return raw.map((n) => {
@@ -147,8 +151,8 @@ export function createNotificationSource(
   // pre-mutation value and a stale fetch could flip it back before the
   // API lands.
   createEffect(() => {
-    if (!notificationsQuery.isSuccess) return;
     const raw = notificationsQuery.data;
+    if (!raw) return;
     const overrides = doneOverrides();
     if (overrides.size === 0) return;
     const presentIds = new Set(raw.map((n) => n.id));
@@ -173,7 +177,7 @@ export function createNotificationSource(
   });
 
   createEffect(() => {
-    if (!notificationsQuery.isSuccess) return;
+    if (!notificationsQuery.data) return;
     if (notificationsQuery.hasNextPage && !notificationsQuery.isFetching) {
       notificationsQuery.fetchNextPage();
     }

--- a/apps/web/src/features/notifications/notification-source.ts
+++ b/apps/web/src/features/notifications/notification-source.ts
@@ -245,13 +245,18 @@ export function createNotificationSource(
     optimisticInsertNotification(parsedNotification);
   });
 
+  // Skip empty batches: entity-level read markers fire regardless of whether
+  // the entity has notifications, and an empty mutation still runs the
+  // onMutate cancel — which can kill the initial notification fetch.
   const bulkMarkAsDone = async (notifications: UnifiedNotification[]) => {
+    if (notifications.length === 0) return;
     await markNotificationsAsDoneMutation.mutateAsync({
       notificationIds: notifications.map((n) => n.id),
     });
   };
 
   const bulkMarkAsRead = async (notifications: UnifiedNotification[]) => {
+    if (notifications.length === 0) return;
     await markNotificationsAsSeenMutation.mutateAsync({
       notificationIds: notifications.map((n) => n.id),
     });

--- a/apps/web/src/features/notifications/notification-source.ts
+++ b/apps/web/src/features/notifications/notification-source.ts
@@ -298,14 +298,21 @@ export function createNotificationSource(
     optimisticInsertNotification(parsedNotification);
   });
 
-  // Skip empty batches: entity-level read markers fire regardless of whether
-  // the entity has notifications, and an empty mutation still runs the
-  // onMutate cancel — which can kill the initial notification fetch.
+  // Skip empty batches: entity-level read markers fire on mount regardless
+  // of whether the entity has notifications, and an empty batch would still
+  // POST a no-op mutation.
   const bulkMarkAsDone = async (notifications: UnifiedNotification[]) => {
     if (notifications.length === 0) return;
-    await markNotificationsAsDoneMutation.mutateAsync({
-      notificationIds: notifications.map((n) => n.id),
-    });
+    const ids = notifications.map((n) => n.id);
+    setDoneOverride(ids, true);
+    try {
+      await markNotificationsAsDoneMutation.mutateAsync({
+        notificationIds: ids,
+      });
+    } catch (err) {
+      setDoneOverride(ids, false);
+      throw err;
+    }
   };
 
   const bulkMarkAsRead = async (notifications: UnifiedNotification[]) => {

--- a/apps/web/src/features/notifications/notification-source.ts
+++ b/apps/web/src/features/notifications/notification-source.ts
@@ -115,6 +115,29 @@ export function setDoneOverride(
   });
 }
 
+// Client-asserted seen state, the `doneOverrides` twin for `viewed_at`. Seen
+// is monotone (there is no unsee API), so once a mark is initiated no fetch
+// snapshot may present the notification as unread: a full refetch reads its
+// pages over several seconds and a page read before the mark's POST commits
+// resurrects pre-write state when it lands. Entries are removed on mutation
+// failure (that rollback is deliberate) and pruned once the cache confirms
+// the seen state at a quiet moment.
+const [seenOverrides, setSeenOverrides] = createRoot(() =>
+  createSignal<ReadonlyMap<string, string>>(new Map())
+);
+
+function setSeenOverride(ids: readonly string[], viewedAt: string | undefined) {
+  if (ids.length === 0) return;
+  setSeenOverrides((prev) => {
+    const next = new Map(prev);
+    for (const id of ids) {
+      if (viewedAt === undefined) next.delete(id);
+      else next.set(id, viewedAt);
+    }
+    return next;
+  });
+}
+
 export function createNotificationSource(
   ws: ConnectionGatewayWebsocket,
   onNotification?: (notification: UnifiedNotification) => void
@@ -136,11 +159,18 @@ export function createNotificationSource(
   const notifications = createMemo(() => {
     const raw = notificationsQuery.data;
     if (!raw) return [];
-    const overrides = doneOverrides();
-    if (overrides.size === 0) return raw;
+    const done = doneOverrides();
+    const seen = seenOverrides();
+    if (done.size === 0 && seen.size === 0) return raw;
     return raw.map((n) => {
-      const override = overrides.get(n.id);
-      return override !== undefined ? { ...n, done: override } : n;
+      const doneOverride = done.get(n.id);
+      const seenOverride = n.viewed_at ? undefined : seen.get(n.id);
+      if (doneOverride === undefined && seenOverride === undefined) return n;
+      return {
+        ...n,
+        ...(doneOverride !== undefined ? { done: doneOverride } : {}),
+        ...(seenOverride !== undefined ? { viewed_at: seenOverride } : {}),
+      };
     });
   });
 
@@ -161,6 +191,29 @@ export function createNotificationSource(
       if (!presentIds.has(id)) toPrune.push(id);
     }
     if (toPrune.length > 0) setDoneOverride(toPrune, undefined);
+  });
+
+  // Prune seen overrides once they stop being load-bearing: the id left the
+  // cache, or the cache row itself is seen at a quiet moment. Quiet matters —
+  // while a mark is in flight the seen cache row is the optimistic write, and
+  // a fetch that is still running may hold a pre-write snapshot that will
+  // land later; in both cases the override must survive.
+  createEffect(() => {
+    const raw = notificationsQuery.data;
+    if (!raw) return;
+    const seen = seenOverrides();
+    if (seen.size === 0) return;
+    const quiet =
+      !notificationsQuery.isFetching &&
+      !markNotificationsAsSeenMutation.isPending;
+    const byId = new Map(raw.map((n) => [n.id, n]));
+    const toPrune: string[] = [];
+    for (const id of seen.keys()) {
+      const row = byId.get(id);
+      if (!row) toPrune.push(id);
+      else if (row.viewed_at && quiet) toPrune.push(id);
+    }
+    if (toPrune.length > 0) setSeenOverride(toPrune, undefined);
   });
 
   const notificationsByEntity = createMemo(() => {
@@ -257,9 +310,16 @@ export function createNotificationSource(
 
   const bulkMarkAsRead = async (notifications: UnifiedNotification[]) => {
     if (notifications.length === 0) return;
-    await markNotificationsAsSeenMutation.mutateAsync({
-      notificationIds: notifications.map((n) => n.id),
-    });
+    const ids = notifications.map((n) => n.id);
+    setSeenOverride(ids, new Date().toISOString());
+    try {
+      await markNotificationsAsSeenMutation.mutateAsync({
+        notificationIds: ids,
+      });
+    } catch (err) {
+      setSeenOverride(ids, undefined);
+      throw err;
+    }
   };
 
   const markAsDone = async (notification: UnifiedNotification) => {

--- a/apps/web/src/lib/queries/notification/user-notifications.ts
+++ b/apps/web/src/lib/queries/notification/user-notifications.ts
@@ -275,6 +275,14 @@ function notificationsMutationSuccessCallback<T>(
   _: T,
   _params: NotificationsMutationParams
 ) {
+  // A fetch that is still in flight when the server write lands read its
+  // pages before that write, so letting it resolve would replace the cache
+  // with a pre-write snapshot. Discard it without reverting cache data; the
+  // query stays stale and refetches fresh on the next trigger.
+  queryClient.cancelQueries(
+    { queryKey: notificationKeys.user._def },
+    { revert: false }
+  );
   queryClient.invalidateQueries({
     queryKey: notificationKeys.user._def,
     refetchType: 'none',
@@ -286,9 +294,13 @@ function createNotificationsMutateFn(
   updaterFn: NotificationsUpdater
 ): NotificationsOnMutateFn {
   return async (params) => {
-    await queryClient.cancelQueries({
-      queryKey: notificationKeys.user._def,
-    });
+    // revert: false — reverting would restore the pre-fetch snapshot and wipe
+    // writes that landed while that fetch was in flight (websocket inserts,
+    // other optimistic marks).
+    await queryClient.cancelQueries(
+      { queryKey: notificationKeys.user._def },
+      { revert: false }
+    );
 
     const previousData = queryClient.getQueriesData<
       NotificationData<UserNotificationsPageParam>

--- a/apps/web/src/lib/queries/notification/user-notifications.ts
+++ b/apps/web/src/lib/queries/notification/user-notifications.ts
@@ -275,18 +275,36 @@ function notificationsMutationSuccessCallback<T>(
   _: T,
   _params: NotificationsMutationParams
 ) {
-  // A fetch that is still in flight when the server write lands read its
-  // pages before that write, so letting it resolve would replace the cache
-  // with a pre-write snapshot. Discard it without reverting cache data; the
-  // query stays stale and refetches fresh on the next trigger.
-  queryClient.cancelQueries(
-    { queryKey: notificationKeys.user._def },
-    { revert: false }
-  );
   queryClient.invalidateQueries({
     queryKey: notificationKeys.user._def,
     refetchType: 'none',
   });
+}
+
+/**
+ * Discards any fetch still in flight when the server write commits (it read
+ * its pages pre-write, so letting it resolve would replace the cache with a
+ * pre-write snapshot) and re-applies the mutation's patch. The re-apply
+ * matters beyond the data: a non-reverting cancel transitions the query to
+ * error status, and the manual write flips it back to success — the cancel is
+ * awaited so its error dispatch cannot land after the write. The query stays
+ * stale and refetches fresh on the next trigger.
+ */
+function createNotificationsReassertFn(updaterFn: NotificationsUpdater) {
+  return async (_: unknown, params: NotificationsMutationParams) => {
+    await queryClient.cancelQueries(
+      { queryKey: notificationKeys.user._def },
+      { revert: false }
+    );
+    queryClient.setQueriesData(
+      { queryKey: notificationKeys.user._def },
+      (input) =>
+        updaterFn(
+          input as Maybe<NotificationData<UserNotificationsPageParam>>,
+          params
+        )
+    );
+  };
 }
 
 /** Creates an optimistic update handler that snapshots previous data for rollback. */
@@ -384,6 +402,7 @@ export const useMarkNotificationsAsSeenMutation = createNotificationsMutation(
     }),
   {
     onMutate: createNotificationsMutateFn(mapNotificationsAsSeen),
+    onSuccess: createNotificationsReassertFn(mapNotificationsAsSeen),
     onError: notificationsMutationErrorFn,
   }
 );
@@ -411,6 +430,7 @@ export const useMarkNotificationsAsDoneMutation = createNotificationsMutation(
     }),
   {
     onMutate: createNotificationsMutateFn(filterOutDoneNotifications),
+    onSuccess: createNotificationsReassertFn(filterOutDoneNotifications),
     onError: notificationsMutationErrorFn,
   }
 );

--- a/apps/web/src/lib/queries/notification/user-notifications.ts
+++ b/apps/web/src/lib/queries/notification/user-notifications.ts
@@ -364,44 +364,16 @@ function notificationsMutationSuccessCallback<T>(
 }
 
 /**
- * Discards any fetch still in flight when the server write commits (it read
- * its pages pre-write, so letting it resolve would replace the cache with a
- * pre-write snapshot) and re-applies the mutation's patch. The re-apply
- * matters beyond the data: a non-reverting cancel transitions the query to
- * error status, and the manual write flips it back to success — the cancel is
- * awaited so its error dispatch cannot land after the write. The query stays
- * stale and refetches fresh on the next trigger.
+ * Creates an optimistic update handler that snapshots previous data for
+ * rollback. In-flight fetches are deliberately left alone: seen/done
+ * overrides and unconfirmed-insert preservation make a completing stale
+ * snapshot harmless, so refetches always run to completion and freshness is
+ * never sacrificed for write consistency.
  */
-function createNotificationsReassertFn(updaterFn: NotificationsUpdater) {
-  return async (_: unknown, params: NotificationsMutationParams) => {
-    await queryClient.cancelQueries(
-      { queryKey: notificationKeys.user._def },
-      { revert: false }
-    );
-    queryClient.setQueriesData(
-      { queryKey: notificationKeys.user._def },
-      (input) =>
-        updaterFn(
-          input as Maybe<NotificationData<UserNotificationsPageParam>>,
-          params
-        )
-    );
-  };
-}
-
-/** Creates an optimistic update handler that snapshots previous data for rollback. */
 function createNotificationsMutateFn(
   updaterFn: NotificationsUpdater
 ): NotificationsOnMutateFn {
   return async (params) => {
-    // revert: false — reverting would restore the pre-fetch snapshot and wipe
-    // writes that landed while that fetch was in flight (websocket inserts,
-    // other optimistic marks).
-    await queryClient.cancelQueries(
-      { queryKey: notificationKeys.user._def },
-      { revert: false }
-    );
-
     const previousData = queryClient.getQueriesData<
       NotificationData<UserNotificationsPageParam>
     >({
@@ -484,7 +456,6 @@ export const useMarkNotificationsAsSeenMutation = createNotificationsMutation(
     }),
   {
     onMutate: createNotificationsMutateFn(mapNotificationsAsSeen),
-    onSuccess: createNotificationsReassertFn(mapNotificationsAsSeen),
     onError: notificationsMutationErrorFn,
   }
 );
@@ -519,7 +490,6 @@ export const useMarkNotificationsAsDoneMutation = createNotificationsMutation(
       retireUnconfirmedInserts(params.notificationIds);
       return await markNotificationsAsDoneMutateFn(params);
     },
-    onSuccess: createNotificationsReassertFn(filterOutDoneNotifications),
     onError: notificationsMutationErrorFn,
   }
 );

--- a/apps/web/src/lib/queries/notification/user-notifications.ts
+++ b/apps/web/src/lib/queries/notification/user-notifications.ts
@@ -34,6 +34,88 @@ const DEFAULT_NOTIFICATION_LIMIT = 20;
 const NOTIFICATION_STALE_TIME = 5 * 60 * 1000; // 5 minutes
 const NOTIFICATION_GC_TIME = 10 * 60 * 1000; // 10 minutes
 
+// Websocket-inserted notifications young enough that a fetch snapshot may
+// predate them: a full refetch reads its pages over several seconds and
+// commits atomically, so a snapshot begun before the insert lands without
+// the row and would silently drop it from the cache. A query-cache
+// subscription re-prepends tracked rows after every non-manual success
+// commit (solid-query hard-disables structuralSharing, so a commit-time
+// merge hook is not available). Entries retire by TTL, realtime delete, or
+// done removal — not by cache containment, since our own optimistic writes
+// also contain the row and are not server confirmation.
+const UNCONFIRMED_INSERT_TTL_MS = 5 * 60 * 1000;
+const MAX_UNCONFIRMED_INSERTS = 200;
+const unconfirmedInserts = new Map<
+  string,
+  { item: NotificationItem; insertedAt: number }
+>();
+
+let unconfirmedInsertsSubscribed = false;
+
+// Subscribed lazily on the first tracked insert so importing this module
+// never touches the query client (test setups mock it after import).
+function ensureUnconfirmedInsertReapply() {
+  if (unconfirmedInsertsSubscribed || typeof window === 'undefined') return;
+  unconfirmedInsertsSubscribed = true;
+  queryClient.getQueryCache().subscribe((event) => {
+    if (event.type !== 'updated') return;
+    const action = event.action as { type: string; manual?: boolean };
+    if (action.type !== 'success' || action.manual) return;
+    const key = event.query.queryKey;
+    if (!Array.isArray(key) || key[0] !== 'notification' || key[1] !== 'user')
+      return;
+    reapplyUnconfirmedInserts(key);
+  });
+}
+
+function trackUnconfirmedInsert(item: NotificationItem) {
+  ensureUnconfirmedInsertReapply();
+  unconfirmedInserts.delete(item.id);
+  unconfirmedInserts.set(item.id, { item, insertedAt: Date.now() });
+  while (unconfirmedInserts.size > MAX_UNCONFIRMED_INSERTS) {
+    const oldest = unconfirmedInserts.keys().next().value;
+    if (oldest === undefined) break;
+    unconfirmedInserts.delete(oldest);
+  }
+}
+
+function retireUnconfirmedInserts(ids: Iterable<string>) {
+  for (const id of ids) unconfirmedInserts.delete(id);
+}
+
+function pruneExpiredUnconfirmedInserts() {
+  const now = Date.now();
+  for (const [id, entry] of unconfirmedInserts) {
+    if (now - entry.insertedAt > UNCONFIRMED_INSERT_TTL_MS) {
+      unconfirmedInserts.delete(id);
+    }
+  }
+}
+
+function reapplyUnconfirmedInserts(queryKey: readonly unknown[]) {
+  pruneExpiredUnconfirmedInserts();
+  if (unconfirmedInserts.size === 0) return;
+  queryClient.setQueryData<NotificationData<UserNotificationsPageParam>>(
+    queryKey,
+    (data) => {
+      if (!data?.pages?.length) return data;
+      const presentIds = new Set(
+        data.pages.flatMap((page) => page.items.map((n) => n.id))
+      );
+      const missing = [...unconfirmedInserts.values()]
+        .map((entry) => entry.item)
+        .filter((item) => !presentIds.has(item.id));
+      if (missing.length === 0) return data;
+      return {
+        ...data,
+        pages: data.pages.map((page, index) =>
+          index === 0 ? { ...page, items: [...missing, ...page.items] } : page
+        ),
+      };
+    }
+  );
+}
+
 function normalizeLimit(limit?: number): number {
   return limit && limit > 0 && limit <= 500
     ? limit
@@ -422,6 +504,10 @@ const filterOutDoneNotifications = (
   );
 };
 
+const markNotificationsAsDoneMutateFn = createNotificationsMutateFn(
+  filterOutDoneNotifications
+);
+
 /** Marks notifications as done (removes from list) with optimistic update. */
 export const useMarkNotificationsAsDoneMutation = createNotificationsMutation(
   async (params: NotificationsMutationParams) =>
@@ -429,7 +515,10 @@ export const useMarkNotificationsAsDoneMutation = createNotificationsMutation(
       notificationIds: params.notificationIds,
     }),
   {
-    onMutate: createNotificationsMutateFn(filterOutDoneNotifications),
+    onMutate: async (params) => {
+      retireUnconfirmedInserts(params.notificationIds);
+      return await markNotificationsAsDoneMutateFn(params);
+    },
     onSuccess: createNotificationsReassertFn(filterOutDoneNotifications),
     onError: notificationsMutationErrorFn,
   }
@@ -520,6 +609,8 @@ export function applyNotificationStatusUpdate(
       .map((patch) => patch.id)
   );
   const removeIds = new Set([...deleteIds, ...doneIds]);
+
+  retireUnconfirmedInserts(removeIds);
 
   queryClient.setQueriesData<NotificationData<UserNotificationsPageParam>>(
     { queryKey: notificationKeys.user._def },
@@ -655,6 +746,8 @@ export function optimisticInsertNotification(
 ) {
   const item = notification as NotificationItem;
   const soupTag = notificationEntityTypeToSoupTag(notification.entity_type);
+
+  trackUnconfirmedInsert(item);
 
   queryClient.setQueriesData<NotificationData<UserNotificationsPageParam>>(
     { queryKey: notificationKeys.user._def },


### PR DESCRIPTION
Fixes the stuck unread widget by enforcing invariants at merge time instead of suppressing fetches. Seen is monotone (no unsee API), so a `seenOverrides` map (twin of the existing `doneOverrides`) overlays client-asserted `viewed_at` over whatever the cache says — a stale refetch snapshot or a `fetchNextPage` append committing pre-write pages can land freely without regressing unread surfaces, and overrides retire once the cache confirms seen at a quiet moment. Unconfirmed websocket inserts are re-prepended after fetch commits so a snapshot that predates them can't silently drop the row. With both invariants in place, all fetch cancellation around mark mutations is removed: refetches always run to completion, so marking never costs freshness. Also un-latches `MarkMessageNotifications` (signal-gated bounded retry), gates unread surfaces on data presence instead of `isSuccess`, and skips empty bulk marks.

Verified in dev against real races: a throttled mark racing a full 16-page refetch (refetch completes, widget never regresses, second refetch converges and prunes), a synthetic WS insert mid-refetch surviving two commits, a mark fired when 1/16 crawl pages had loaded with the crawl finishing uninterrupted, mark-API failure rolling back truthfully with bounded retries, and two-tab convergence through server truth.
