### PR TITLE
perf(soup): reduce mail view request limit from 100 to 30

### DIFF
--- a/apps/web/src/features/next-soup/soup-view/soup-view-context.tsx
+++ b/apps/web/src/features/next-soup/soup-view/soup-view-context.tsx
@@ -226,11 +226,11 @@ export const SoupViewContextProvider: FlowComponent<
 
   const panel = useSplitPanelOrThrow();
 
-  const activeListView = createMemo<ListView | undefined>(() => {
+  const activeListView = (): ListView | undefined => {
     const content = panel.handle.content();
     if (content.type !== 'component') return;
     return isListViewID(content.id) ? content.id : undefined;
-  });
+  };
 
   const soupParams = createMemo(() => {
     const sortId = soup.sort.active()[0]?.id ?? 'updated_at';

--- a/apps/web/src/features/next-soup/soup-view/soup-view-context.tsx
+++ b/apps/web/src/features/next-soup/soup-view/soup-view-context.tsx
@@ -224,6 +224,14 @@ export const SoupViewContextProvider: FlowComponent<
   const resolveTransport = (groupBy: GroupByField | undefined) =>
     useGraphqlSoupFF().enabled && !groupBy ? 'graphql' : undefined;
 
+  const panel = useSplitPanelOrThrow();
+
+  const activeListView = createMemo<ListView | undefined>(() => {
+    const content = panel.handle.content();
+    if (content.type !== 'component') return;
+    return isListViewID(content.id) ? content.id : undefined;
+  });
+
   const soupParams = createMemo(() => {
     const sortId = soup.sort.active()[0]?.id ?? 'updated_at';
 
@@ -233,12 +241,11 @@ export const SoupViewContextProvider: FlowComponent<
       : 'created_at';
 
     return {
-      limit: 100,
+      // Mail views use a smaller page size
+      limit: activeListView() === 'mail' ? 30 : 100,
       sort_method: sortMethod,
     };
   });
-
-  const panel = useSplitPanelOrThrow();
 
   const store = createQueryStore({
     initial: props.initialQuery,
@@ -409,12 +416,6 @@ export const SoupViewContextProvider: FlowComponent<
     dealStages.resolveStage(
       entity as Parameters<typeof dealStages.resolveStage>[0]
     );
-
-  const activeListView = createMemo<ListView | undefined>(() => {
-    const content = panel.handle.content();
-    if (content.type !== 'component') return;
-    return isListViewID(content.id) ? content.id : undefined;
-  });
 
   // CRM companies come back from a dedicated soup request (not the dynamic
   // query the server-side grouped path is built on), so property grouping on


### PR DESCRIPTION
## Summary

Reduces the soup page size from 100 to 30 for the Mail view tabs (Signal, Noise, Calendar, Sent, Drafts, Shared, All). All other soup views keep the existing limit of 100.

## Changes

- `soup-view-context.tsx`: moved the existing `activeListView` memo above `soupParams` and made the request `limit` conditional on the active list view (`'mail'` → 30, otherwise 100).

Since `soupParams` feeds the flat, grouped, and reactive GraphQL query paths, all mail requests pick up the smaller page size. The limit is part of the query key, so mail views get separate cache entries and pagination continues to fetch 30 at a time via `fetchNextPage`.

Note: the Inbox view's Signal/Noise/All tabs (mixed entities, not mail-only) are unchanged and still request 100.