### PR TITLE
fix: video recording playback

### DIFF
--- a/apps/web/src/features/block-call/component/CallRecording/CallRecordingVideo.test.tsx
+++ b/apps/web/src/features/block-call/component/CallRecording/CallRecordingVideo.test.tsx
@@ -73,6 +73,7 @@ function dispatchUnsupportedMediaError(video: HTMLVideoElement): void {
 }
 
 beforeEach(() => {
+  vi.spyOn(HTMLMediaElement.prototype, 'load').mockImplementation(() => {});
   Object.defineProperty(URL, 'createObjectURL', {
     configurable: true,
     value: vi.fn(() => posterBlobUrl),
@@ -84,6 +85,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.restoreAllMocks();
   vi.unstubAllGlobals();
 });
 
@@ -100,6 +102,8 @@ describe('CallRecordingVideo', () => {
       <CallRecordingVideo url={recordingUrl} posterUrl={posterUrl} />
     ));
     const video = getVideo(container);
+
+    expect(video.load).toHaveBeenCalledOnce();
 
     await waitFor(() =>
       expect(video.getAttribute('poster')).toBe(posterBlobUrl)
@@ -122,6 +126,7 @@ describe('CallRecordingVideo', () => {
     expect(fallbackLink.hasAttribute('download')).toBe(true);
 
     expect(video.hasAttribute('controls')).toBe(true);
+    expect(video.getAttribute('preload')).toBe('metadata');
     expect(video.getAttribute('crossorigin')).toBe('anonymous');
     expect(video.getAttribute('poster')).toBe(posterBlobUrl);
     expect(video.getAttribute('src')).toBe(recordingUrl);

--- a/apps/web/src/features/block-call/component/CallRecording/CallRecordingVideo.tsx
+++ b/apps/web/src/features/block-call/component/CallRecording/CallRecordingVideo.tsx
@@ -1,5 +1,5 @@
 import type { JSX } from 'solid-js';
-import { createEffect, createSignal, onCleanup, Show } from 'solid-js';
+import { createEffect, createSignal, onCleanup, onMount, Show } from 'solid-js';
 
 export function CallRecordingVideo(props: {
   url: string;
@@ -16,6 +16,7 @@ export function CallRecordingVideo(props: {
   const hasVisibleVideo = () =>
     isLoaded() || !!posterBlobUrl() || playbackError();
   let rafId: number | null = null;
+  let videoRef: HTMLVideoElement | undefined;
 
   createEffect<string | undefined>((previousUrl) => {
     const url = props.url;
@@ -91,18 +92,23 @@ export function CallRecordingVideo(props: {
     setPlaybackError(true);
   }
 
+  onMount(() => videoRef?.load());
   onCleanup(stopTicking);
 
   return (
     <div class="p-4 flex flex-col justify-center items-center gap-3 overflow-hidden">
       <video
-        ref={props.setVideoRef}
+        ref={(element) => {
+          videoRef = element;
+          props.setVideoRef?.(element);
+        }}
         class="max-w-full max-h-full rounded transition-opacity duration-200"
         classList={{
           'opacity-0': !hasVisibleVideo(),
           'opacity-100': hasVisibleVideo(),
         }}
         controls
+        preload="metadata"
         crossorigin="anonymous"
         poster={posterBlobUrl()}
         src={props.url}


### PR DESCRIPTION
 - Set preload="metadata".
 - Explicitly call video.load() when the component mounts.
 - Preserve the external video ref callback.
 - Keep crossorigin="anonymous".