### PR TITLE
fix(mcp): honor paid subscription roles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8682,7 +8682,6 @@ dependencies = [
  "macro_auth",
  "macro_aws_config",
  "macro_config",
- "macro_db_client",
  "macro_entrypoint",
  "macro_env",
  "macro_env_var",

--- a/crates/roles_and_permissions/src/domain/model.rs
+++ b/crates/roles_and_permissions/src/domain/model.rs
@@ -109,6 +109,24 @@ impl Display for RoleId {
     }
 }
 
+impl RoleId {
+    /// Whether this role represents an active paid Macro subscription.
+    pub fn is_paid_subscription(&self) -> bool {
+        matches!(
+            self,
+            Self::ProfessionalSubscriber
+                | Self::TeamSubscriber
+                | Self::Corporate
+                | Self::SubHaiku
+                | Self::SubSonnet
+                | Self::SubOpus
+        )
+    }
+}
+
+#[cfg(test)]
+mod test;
+
 /// All valid permissions that exist in our system
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum PermissionId {

--- a/crates/roles_and_permissions/src/domain/model/test.rs
+++ b/crates/roles_and_permissions/src/domain/model/test.rs
@@ -1,0 +1,33 @@
+use super::RoleId;
+
+#[test]
+fn paid_subscription_roles_include_legacy_and_pricing_tiers() {
+    for role in [
+        RoleId::ProfessionalSubscriber,
+        RoleId::TeamSubscriber,
+        RoleId::Corporate,
+        RoleId::SubHaiku,
+        RoleId::SubSonnet,
+        RoleId::SubOpus,
+    ] {
+        assert!(
+            role.is_paid_subscription(),
+            "{role} should have paid access"
+        );
+    }
+}
+
+#[test]
+fn non_subscription_roles_do_not_grant_paid_access() {
+    for role in [
+        RoleId::SelfServe,
+        RoleId::SuperAdmin,
+        RoleId::AiSubscriber,
+        RoleId::EditorUser,
+    ] {
+        assert!(
+            !role.is_paid_subscription(),
+            "{role} should not grant paid access"
+        );
+    }
+}

--- a/services/mcp_service/Cargo.toml
+++ b/services/mcp_service/Cargo.toml
@@ -37,7 +37,6 @@ http = { workspace = true }
 lexical_client = { path = "../../crates/lexical_client" }
 mcp_auth_proxy = { path = "../mcp_auth_proxy" }
 macro_auth = { path = "../../crates/macro_auth" }
-macro_db_client = { path = "../../crates/macro_db_client" }
 macro_aws_config = { path = "../../crates/macro_aws_config", features = ["s3"] }
 macro_entrypoint = { path = "../../crates/macro_entrypoint" }
 macro_config = { path = "../../crates/macro_config" }

--- a/services/mcp_service/src/context.rs
+++ b/services/mcp_service/src/context.rs
@@ -38,6 +38,9 @@ use mcp_auth_proxy::{
 };
 use notification::domain::service::{NotificationReaderService, PlatformArnConfig};
 use notification::outbound::repository::DbNotificationRepository;
+use roles_and_permissions::{
+    domain::service::UserRolesAndPermissionsServiceImpl, outbound::pgpool::MacroDB,
+};
 use search_service_client::SearchServiceClient;
 use secretsmanager_client::LocalOrRemoteSecret;
 use soup::domain::service::SoupImpl;
@@ -53,7 +56,7 @@ pub struct McpContext {
     pub tool_context: ToolServiceContext,
     pub auth_proxy: McpAuthProxyServiceImpl<RedisInflightAuth>,
     pub mcp_public_host: String,
-    pub db: PgPool,
+    pub user_roles_and_permissions_service: UserRolesAndPermissionsServiceImpl<MacroDB, MacroDB>,
 }
 
 pub async fn build_context(config: &Config) -> anyhow::Result<McpContext> {
@@ -108,12 +111,16 @@ pub async fn build_context(config: &Config) -> anyhow::Result<McpContext> {
         .context("MCP_PUBLIC_URL has no host")?
         .to_owned();
 
+    let roles_repository = MacroDB::new(db.clone());
+    let user_roles_and_permissions_service =
+        UserRolesAndPermissionsServiceImpl::new(roles_repository.clone(), roles_repository);
+
     Ok(McpContext {
         jwt_args,
         tool_context,
         auth_proxy,
         mcp_public_host,
-        db,
+        user_roles_and_permissions_service,
     })
 }
 

--- a/services/mcp_service/src/main.rs
+++ b/services/mcp_service/src/main.rs
@@ -42,7 +42,7 @@ async fn main() -> anyhow::Result<()> {
             Ok(AuthenticatedToolService::new(
                 tools.toolset,
                 context.tool_context.clone(),
-                context.db.clone(),
+                context.user_roles_and_permissions_service.clone(),
                 item_base_url.clone(),
             ))
         },

--- a/services/mcp_service/src/tool_service.rs
+++ b/services/mcp_service/src/tool_service.rs
@@ -6,8 +6,7 @@ use rmcp::{
         Content, ListToolsResult, PaginatedRequestParams, ServerCapabilities, ServerInfo, Tool,
     },
 };
-use roles_and_permissions::domain::model::PermissionId;
-use sqlx::PgPool;
+use roles_and_permissions::domain::port::UserRolesAndPermissionsService;
 use std::sync::Arc;
 
 /// MCP server handler that extracts authenticated user identity from HTTP
@@ -16,28 +15,31 @@ use std::sync::Arc;
     dead_code,
     reason = "fields used via ServerHandler trait impl dispatched by rmcp"
 )]
-pub struct AuthenticatedToolService<Context> {
+pub struct AuthenticatedToolService<Context, RolesService> {
     toolset: Arc<AsyncToolCollection<Context>>,
     context: Context,
-    db: PgPool,
+    user_roles_and_permissions_service: RolesService,
     /// Base URL of the Macro web app used to build links to Macro items in MCP
     /// responses (e.g. `https://macro.com`). Comes from the `APP_BASE_URL`
     /// environment variable.
     item_base_url: String,
 }
 
-impl<Context> AuthenticatedToolService<Context> {
+impl<Context, RolesService> AuthenticatedToolService<Context, RolesService>
+where
+    RolesService: UserRolesAndPermissionsService,
+{
     /// Creates a new authenticated tool service.
     pub fn new(
         toolset: Arc<AsyncToolCollection<Context>>,
         context: Context,
-        db: PgPool,
+        user_roles_and_permissions_service: RolesService,
         item_base_url: String,
     ) -> Self {
         Self {
             toolset,
             context,
-            db,
+            user_roles_and_permissions_service,
             item_base_url,
         }
     }
@@ -71,17 +73,16 @@ impl<Context> AuthenticatedToolService<Context> {
         &self,
         user_id: &MacroUserIdStr<'_>,
     ) -> Result<(), rmcp::ErrorData> {
-        let permissions = macro_db_client::user::get_permissions::get_user_permissions(
-            &self.db,
-            user_id.0.as_ref(),
-        )
-        .await
-        .map_err(|e| {
-            tracing::error!(error=?e, "failed to check user permissions for MCP access");
-            rmcp::ErrorData::internal_error("failed to check permissions", None)
-        })?;
+        let roles = self
+            .user_roles_and_permissions_service
+            .get_user_roles(user_id)
+            .await
+            .map_err(|e| {
+                tracing::error!(error=?e, "failed to check user subscription roles for MCP access");
+                rmcp::ErrorData::internal_error("failed to check subscription", None)
+            })?;
 
-        let is_paid = permissions.contains(&PermissionId::WriteProAi.to_string());
+        let is_paid = roles.iter().any(|role| role.is_paid_subscription());
 
         if !is_paid {
             return Err(rmcp::ErrorData::new(
@@ -98,9 +99,10 @@ impl<Context> AuthenticatedToolService<Context> {
 #[cfg(test)]
 mod test;
 
-impl<Context> ServerHandler for AuthenticatedToolService<Context>
+impl<Context, RolesService> ServerHandler for AuthenticatedToolService<Context, RolesService>
 where
     Context: Clone + Send + Sync + 'static,
+    RolesService: UserRolesAndPermissionsService,
 {
     fn get_info(&self) -> ServerInfo {
         let mut info = ServerInfo::new(ServerCapabilities::builder().enable_tools().build());

--- a/services/mcp_service/src/tool_service/test.rs
+++ b/services/mcp_service/src/tool_service/test.rs
@@ -1,16 +1,22 @@
 use super::*;
 use ai_toolset::AsyncToolCollection;
 use rmcp::{handler::server::ServerHandler, model::ErrorCode};
+use roles_and_permissions::{
+    domain::service::UserRolesAndPermissionsServiceImpl, outbound::pgpool::MacroDB,
+};
 use sqlx::postgres::PgPoolOptions;
 
-fn empty_service() -> AuthenticatedToolService<()> {
+type TestRolesService = UserRolesAndPermissionsServiceImpl<MacroDB, MacroDB>;
+
+fn empty_service() -> AuthenticatedToolService<(), TestRolesService> {
     let db = PgPoolOptions::new()
         .connect_lazy("postgres://localhost/unused")
         .expect("lazy pool creation should not fail");
+    let roles_repository = MacroDB::new(db);
     AuthenticatedToolService::new(
         Arc::new(AsyncToolCollection::new()),
         (),
-        db,
+        UserRolesAndPermissionsServiceImpl::new(roles_repository.clone(), roles_repository),
         "https://macro.com".to_owned(),
     )
 }
@@ -99,16 +105,19 @@ fn authenticated_user_id_is_read_from_http_request_parts() {
     let mut extensions = rmcp::model::Extensions::new();
     extensions.insert(parts);
 
-    let user_id = AuthenticatedToolService::<()>::authenticated_user_id(&extensions).unwrap();
+    let user_id =
+        AuthenticatedToolService::<(), TestRolesService>::authenticated_user_id(&extensions)
+            .unwrap();
 
     assert_eq!(user_id, expected_user_id);
 }
 
 #[test]
 fn authenticated_user_id_requires_request_parts() {
-    let error =
-        AuthenticatedToolService::<()>::authenticated_user_id(&rmcp::model::Extensions::new())
-            .expect_err("missing request parts should fail auth extraction");
+    let error = AuthenticatedToolService::<(), TestRolesService>::authenticated_user_id(
+        &rmcp::model::Extensions::new(),
+    )
+    .expect_err("missing request parts should fail auth extraction");
 
     assert_eq!(error.code, ErrorCode::INTERNAL_ERROR);
     assert_eq!(error.message, "missing user identity — is auth configured?");
@@ -120,8 +129,9 @@ fn authenticated_user_id_requires_user_extension_inside_request_parts() {
     let mut extensions = rmcp::model::Extensions::new();
     extensions.insert(parts);
 
-    let error = AuthenticatedToolService::<()>::authenticated_user_id(&extensions)
-        .expect_err("missing user id should fail auth extraction");
+    let error =
+        AuthenticatedToolService::<(), TestRolesService>::authenticated_user_id(&extensions)
+            .expect_err("missing user id should fail auth extraction");
 
     assert_eq!(error.code, ErrorCode::INTERNAL_ERROR);
     assert_eq!(error.message, "missing user identity — is auth configured?");


### PR DESCRIPTION
Fixes MACRO-2441 by authorizing MCP access from paid subscription roles so legacy paid tiers continue to expose tools after the AI permission collapse.