### PR TITLE
feat(soup): graphql email content backfill

### DIFF
--- a/apps/web/src/lib/queries/soup/backfill.ts
+++ b/apps/web/src/lib/queries/soup/backfill.ts
@@ -7,8 +7,12 @@ import {
 import { useQuery } from '@tanstack/solid-query';
 import type { Accessor } from 'solid-js';
 
-const BACKFILL_VERSION = 1;
+// Bump when a default backfill input changes so persisted opaque cursors
+// cannot retain the previous server-side filters.
+const BACKFILL_VERSION = 2;
 const PAGE_LIMIT = 250;
+// The email-content DataLoader rejects operations with more than 20 threads.
+const EMAIL_CONTENT_PAGE_LIMIT = 20;
 const PAGE_DELAY_MS = 2_000;
 const INITIAL_RETRY_DELAY_MS = 1_000;
 const MAX_RETRY_DELAY_MS = 30_000;
@@ -19,7 +23,7 @@ export type SoupBackfillParams = {
   checkpointId: string;
   /** Soup input shared by every page. The backfill manages the cursor. */
   input: Omit<GraphqlSoupInput, 'cursor'>;
-  /** Delay between successful pages. Defaults to five seconds. */
+  /** Delay between successful pages. Defaults to two seconds. */
   pageDelayMs?: number;
 };
 
@@ -31,6 +35,7 @@ export const ALL_SOUP_BACKFILL_PARAMS: SoupBackfillParams = {
     sortMethod: 'VIEWED_UPDATED',
     emailView: 'ALL',
     filters: {
+      callFilter: { literal: { callId: EXCLUDED_ENTITY_ID } },
       emailFilter: { tree: { literal: { threadId: EXCLUDED_ENTITY_ID } } },
       channelThreadFilter: { literal: { threadId: EXCLUDED_ENTITY_ID } },
     },
@@ -38,13 +43,14 @@ export const ALL_SOUP_BACKFILL_PARAMS: SoupBackfillParams = {
 };
 
 /**
- * Fetches email threads while excluding every other entity variant with an
- * impossible id filter.
+ * Fetches email threads and their newest content message while excluding every
+ * other entity variant with an impossible id filter.
  */
 export const EMAIL_SOUP_BACKFILL_PARAMS: SoupBackfillParams = {
-  checkpointId: 'email-all',
+  // This namespace must not reuse checkpoints from the old metadata-only pass.
+  checkpointId: 'email-content-all',
   input: {
-    limit: PAGE_LIMIT,
+    limit: EMAIL_CONTENT_PAGE_LIMIT,
     expand: true,
     sortMethod: 'VIEWED_UPDATED',
     emailView: 'ALL',
@@ -359,7 +365,7 @@ export function useSoupBackfill(
   });
 }
 
-/** Backfills only email threads using an independent persisted checkpoint. */
+/** Backfills email thread metadata and content with an independent checkpoint. */
 export function useEmailSoupBackfill(userId: Accessor<string | undefined>) {
   return useSoupBackfill(userId, () => EMAIL_SOUP_BACKFILL_PARAMS);
 }

--- a/apps/web/src/lib/service-clients/service-storage/graphql/generated/graphql.ts
+++ b/apps/web/src/lib/service-clients/service-storage/graphql/generated/graphql.ts
@@ -3,275 +3,490 @@ type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 /** Internal type. DO NOT USE DIRECTLY. */
 export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
 import type { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
+/** The two operands of a recursive `CallFilterExpr` binary expression. */
 export type GraphqlCallBinaryExpr = {
+  /** The left-hand expression. */
   left: GraphqlCallExpr;
+  /** The right-hand expression. */
   right: GraphqlCallExpr;
 };
 
+/** A recursive `CallFilterExpr` filter expression. */
 export type GraphqlCallExpr =
-  {   and: GraphqlCallBinaryExpr; literal?: never; not?: never; or?: never; }
-  |  { and?: never;   literal: GraphqlCallLiteral; not?: never; or?: never; }
-  |  { and?: never; literal?: never;   not: GraphqlCallExpr; or?: never; }
-  |  { and?: never; literal?: never; not?: never;   or: GraphqlCallBinaryExpr; };
+  {   /** Matches when both expressions match. */
+  and: GraphqlCallBinaryExpr; literal?: never; not?: never; or?: never; }
+  |  { and?: never;   /** Matches a domain-specific literal condition. */
+  literal: GraphqlCallLiteral; not?: never; or?: never; }
+  |  { and?: never; literal?: never;   /** Negates an expression. */
+  not: GraphqlCallExpr; or?: never; }
+  |  { and?: never; literal?: never; not?: never;   /** Matches when either expression matches. */
+  or: GraphqlCallBinaryExpr; };
 
+/** GraphQL input representing the call literal. */
 export type GraphqlCallLiteral =
-  {   attended: boolean; callId?: never; channelId?: never; speaker?: never; status?: never; }
-  |  { attended?: never;   callId: string | number; channelId?: never; speaker?: never; status?: never; }
-  |  { attended?: never; callId?: never;   channelId: string | number; speaker?: never; status?: never; }
-  |  { attended?: never; callId?: never; channelId?: never;   speaker: string; status?: never; }
-  |  { attended?: never; callId?: never; channelId?: never; speaker?: never;   status: GraphqlCallStatus; };
+  {   /** The attended option. */
+  attended: boolean; callId?: never; channelId?: never; speaker?: never; status?: never; }
+  |  { attended?: never;   /** The call id option. */
+  callId: string | number; channelId?: never; speaker?: never; status?: never; }
+  |  { attended?: never; callId?: never;   /** The channel id option. */
+  channelId: string | number; speaker?: never; status?: never; }
+  |  { attended?: never; callId?: never; channelId?: never;   /** The speaker option. */
+  speaker: string; status?: never; }
+  |  { attended?: never; callId?: never; channelId?: never; speaker?: never;   /** The status option. */
+  status: GraphqlCallStatus; };
 
+/** GraphQL input representing the call status. */
 export type GraphqlCallStatus =
+  /** The attended option. */
   | 'ATTENDED'
+  /** The missed option. */
   | 'MISSED'
+  /** The unattended option. */
   | 'UNATTENDED';
 
+/** The two operands of a recursive `ChannelFilterExpr` binary expression. */
 export type GraphqlChannelBinaryExpr = {
+  /** The left-hand expression. */
   left: GraphqlChannelExpr;
+  /** The right-hand expression. */
   right: GraphqlChannelExpr;
 };
 
+/** A recursive `ChannelFilterExpr` filter expression. */
 export type GraphqlChannelExpr =
-  {   and: GraphqlChannelBinaryExpr; literal?: never; not?: never; or?: never; }
-  |  { and?: never;   literal: GraphqlChannelLiteral; not?: never; or?: never; }
-  |  { and?: never; literal?: never;   not: GraphqlChannelExpr; or?: never; }
-  |  { and?: never; literal?: never; not?: never;   or: GraphqlChannelBinaryExpr; };
+  {   /** Matches when both expressions match. */
+  and: GraphqlChannelBinaryExpr; literal?: never; not?: never; or?: never; }
+  |  { and?: never;   /** Matches a domain-specific literal condition. */
+  literal: GraphqlChannelLiteral; not?: never; or?: never; }
+  |  { and?: never; literal?: never;   /** Negates an expression. */
+  not: GraphqlChannelExpr; or?: never; }
+  |  { and?: never; literal?: never; not?: never;   /** Matches when either expression matches. */
+  or: GraphqlChannelBinaryExpr; };
 
+/** GraphQL input representing the channel literal. */
 export type GraphqlChannelLiteral =
-  {   channelId: string | number; channelType?: never; importance?: never; mention?: never; notificationDone?: never; notificationSeen?: never; organizationId?: never; sender?: never; teamId?: never; threadId?: never; }
-  |  { channelId?: never;   channelType: GraphqlChannelTypeFilter; importance?: never; mention?: never; notificationDone?: never; notificationSeen?: never; organizationId?: never; sender?: never; teamId?: never; threadId?: never; }
-  |  { channelId?: never; channelType?: never;   importance: boolean; mention?: never; notificationDone?: never; notificationSeen?: never; organizationId?: never; sender?: never; teamId?: never; threadId?: never; }
-  |  { channelId?: never; channelType?: never; importance?: never;   mention: string; notificationDone?: never; notificationSeen?: never; organizationId?: never; sender?: never; teamId?: never; threadId?: never; }
-  |  { channelId?: never; channelType?: never; importance?: never; mention?: never;   notificationDone: boolean; notificationSeen?: never; organizationId?: never; sender?: never; teamId?: never; threadId?: never; }
-  |  { channelId?: never; channelType?: never; importance?: never; mention?: never; notificationDone?: never;   notificationSeen: boolean; organizationId?: never; sender?: never; teamId?: never; threadId?: never; }
-  |  { channelId?: never; channelType?: never; importance?: never; mention?: never; notificationDone?: never; notificationSeen?: never;   organizationId: number; sender?: never; teamId?: never; threadId?: never; }
-  |  { channelId?: never; channelType?: never; importance?: never; mention?: never; notificationDone?: never; notificationSeen?: never; organizationId?: never;   sender: string; teamId?: never; threadId?: never; }
-  |  { channelId?: never; channelType?: never; importance?: never; mention?: never; notificationDone?: never; notificationSeen?: never; organizationId?: never; sender?: never;   teamId: string | number; threadId?: never; }
-  |  { channelId?: never; channelType?: never; importance?: never; mention?: never; notificationDone?: never; notificationSeen?: never; organizationId?: never; sender?: never; teamId?: never;   threadId: string | number; };
+  {   /** The channel id option. */
+  channelId: string | number; channelType?: never; importance?: never; mention?: never; notificationDone?: never; notificationSeen?: never; organizationId?: never; sender?: never; teamId?: never; threadId?: never; }
+  |  { channelId?: never;   /** The channel type option. */
+  channelType: GraphqlChannelTypeFilter; importance?: never; mention?: never; notificationDone?: never; notificationSeen?: never; organizationId?: never; sender?: never; teamId?: never; threadId?: never; }
+  |  { channelId?: never; channelType?: never;   /** The importance option. */
+  importance: boolean; mention?: never; notificationDone?: never; notificationSeen?: never; organizationId?: never; sender?: never; teamId?: never; threadId?: never; }
+  |  { channelId?: never; channelType?: never; importance?: never;   /** The mention option. */
+  mention: string; notificationDone?: never; notificationSeen?: never; organizationId?: never; sender?: never; teamId?: never; threadId?: never; }
+  |  { channelId?: never; channelType?: never; importance?: never; mention?: never;   /** The notification done option. */
+  notificationDone: boolean; notificationSeen?: never; organizationId?: never; sender?: never; teamId?: never; threadId?: never; }
+  |  { channelId?: never; channelType?: never; importance?: never; mention?: never; notificationDone?: never;   /** The notification seen option. */
+  notificationSeen: boolean; organizationId?: never; sender?: never; teamId?: never; threadId?: never; }
+  |  { channelId?: never; channelType?: never; importance?: never; mention?: never; notificationDone?: never; notificationSeen?: never;   /** The organization id option. */
+  organizationId: number; sender?: never; teamId?: never; threadId?: never; }
+  |  { channelId?: never; channelType?: never; importance?: never; mention?: never; notificationDone?: never; notificationSeen?: never; organizationId?: never;   /** The sender option. */
+  sender: string; teamId?: never; threadId?: never; }
+  |  { channelId?: never; channelType?: never; importance?: never; mention?: never; notificationDone?: never; notificationSeen?: never; organizationId?: never; sender?: never;   /** The team id option. */
+  teamId: string | number; threadId?: never; }
+  |  { channelId?: never; channelType?: never; importance?: never; mention?: never; notificationDone?: never; notificationSeen?: never; organizationId?: never; sender?: never; teamId?: never;   /** The thread id option. */
+  threadId: string | number; };
 
+/** The two operands of a recursive `ChannelThreadFilterExpr` binary expression. */
 export type GraphqlChannelThreadBinaryExpr = {
+  /** The left-hand expression. */
   left: GraphqlChannelThreadExpr;
+  /** The right-hand expression. */
   right: GraphqlChannelThreadExpr;
 };
 
+/** A recursive `ChannelThreadFilterExpr` filter expression. */
 export type GraphqlChannelThreadExpr =
-  {   and: GraphqlChannelThreadBinaryExpr; literal?: never; not?: never; or?: never; }
-  |  { and?: never;   literal: GraphqlChannelThreadLiteral; not?: never; or?: never; }
-  |  { and?: never; literal?: never;   not: GraphqlChannelThreadExpr; or?: never; }
-  |  { and?: never; literal?: never; not?: never;   or: GraphqlChannelThreadBinaryExpr; };
+  {   /** Matches when both expressions match. */
+  and: GraphqlChannelThreadBinaryExpr; literal?: never; not?: never; or?: never; }
+  |  { and?: never;   /** Matches a domain-specific literal condition. */
+  literal: GraphqlChannelThreadLiteral; not?: never; or?: never; }
+  |  { and?: never; literal?: never;   /** Negates an expression. */
+  not: GraphqlChannelThreadExpr; or?: never; }
+  |  { and?: never; literal?: never; not?: never;   /** Matches when either expression matches. */
+  or: GraphqlChannelThreadBinaryExpr; };
 
+/** GraphQL input representing the channel thread literal. */
 export type GraphqlChannelThreadLiteral =
-  {   channelId: string | number; notificationDone?: never; notificationSeen?: never; participant?: never; rootSender?: never; threadId?: never; }
-  |  { channelId?: never;   notificationDone: boolean; notificationSeen?: never; participant?: never; rootSender?: never; threadId?: never; }
-  |  { channelId?: never; notificationDone?: never;   notificationSeen: boolean; participant?: never; rootSender?: never; threadId?: never; }
-  |  { channelId?: never; notificationDone?: never; notificationSeen?: never;   participant: string; rootSender?: never; threadId?: never; }
-  |  { channelId?: never; notificationDone?: never; notificationSeen?: never; participant?: never;   rootSender: string; threadId?: never; }
-  |  { channelId?: never; notificationDone?: never; notificationSeen?: never; participant?: never; rootSender?: never;   threadId: string | number; };
+  {   /** The channel id option. */
+  channelId: string | number; notificationDone?: never; notificationSeen?: never; participant?: never; rootSender?: never; threadId?: never; }
+  |  { channelId?: never;   /** The notification done option. */
+  notificationDone: boolean; notificationSeen?: never; participant?: never; rootSender?: never; threadId?: never; }
+  |  { channelId?: never; notificationDone?: never;   /** The notification seen option. */
+  notificationSeen: boolean; participant?: never; rootSender?: never; threadId?: never; }
+  |  { channelId?: never; notificationDone?: never; notificationSeen?: never;   /** The participant option. */
+  participant: string; rootSender?: never; threadId?: never; }
+  |  { channelId?: never; notificationDone?: never; notificationSeen?: never; participant?: never;   /** The root sender option. */
+  rootSender: string; threadId?: never; }
+  |  { channelId?: never; notificationDone?: never; notificationSeen?: never; participant?: never; rootSender?: never;   /** The thread id option. */
+  threadId: string | number; };
 
+/** GraphQL input representing the channel type filter. */
 export type GraphqlChannelTypeFilter =
+  /** The direct message option. */
   | 'DIRECT_MESSAGE'
+  /** The private option. */
   | 'PRIVATE'
+  /** The public option. */
   | 'PUBLIC'
+  /** The team option. */
   | 'TEAM';
 
+/** The two operands of a recursive `ChatFilterExpr` binary expression. */
 export type GraphqlChatBinaryExpr = {
+  /** The left-hand expression. */
   left: GraphqlChatExpr;
+  /** The right-hand expression. */
   right: GraphqlChatExpr;
 };
 
+/** A recursive `ChatFilterExpr` filter expression. */
 export type GraphqlChatExpr =
-  {   and: GraphqlChatBinaryExpr; literal?: never; not?: never; or?: never; }
-  |  { and?: never;   literal: GraphqlChatLiteral; not?: never; or?: never; }
-  |  { and?: never; literal?: never;   not: GraphqlChatExpr; or?: never; }
-  |  { and?: never; literal?: never; not?: never;   or: GraphqlChatBinaryExpr; };
+  {   /** Matches when both expressions match. */
+  and: GraphqlChatBinaryExpr; literal?: never; not?: never; or?: never; }
+  |  { and?: never;   /** Matches a domain-specific literal condition. */
+  literal: GraphqlChatLiteral; not?: never; or?: never; }
+  |  { and?: never; literal?: never;   /** Negates an expression. */
+  not: GraphqlChatExpr; or?: never; }
+  |  { and?: never; literal?: never; not?: never;   /** Matches when either expression matches. */
+  or: GraphqlChatBinaryExpr; };
 
+/** GraphQL input representing the chat literal. */
 export type GraphqlChatLiteral =
-  {   chatId: string | number; createdAt?: never; importance?: never; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never; role?: never; updatedAt?: never; }
-  |  { chatId?: never;   createdAt: GraphqlDateLiteral; importance?: never; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never; role?: never; updatedAt?: never; }
-  |  { chatId?: never; createdAt?: never;   importance: boolean; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never; role?: never; updatedAt?: never; }
-  |  { chatId?: never; createdAt?: never; importance?: never;   notificationDone: boolean; notificationSeen?: never; owner?: never; projectId?: never; role?: never; updatedAt?: never; }
-  |  { chatId?: never; createdAt?: never; importance?: never; notificationDone?: never;   notificationSeen: boolean; owner?: never; projectId?: never; role?: never; updatedAt?: never; }
-  |  { chatId?: never; createdAt?: never; importance?: never; notificationDone?: never; notificationSeen?: never;   owner: string; projectId?: never; role?: never; updatedAt?: never; }
-  |  { chatId?: never; createdAt?: never; importance?: never; notificationDone?: never; notificationSeen?: never; owner?: never;   projectId: string | number; role?: never; updatedAt?: never; }
-  |  { chatId?: never; createdAt?: never; importance?: never; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never;   role: GraphqlChatRole; updatedAt?: never; }
-  |  { chatId?: never; createdAt?: never; importance?: never; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never; role?: never;   updatedAt: GraphqlDateLiteral; };
+  {   /** The chat id option. */
+  chatId: string | number; createdAt?: never; importance?: never; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never; role?: never; updatedAt?: never; }
+  |  { chatId?: never;   /** The created at option. */
+  createdAt: GraphqlDateLiteral; importance?: never; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never; role?: never; updatedAt?: never; }
+  |  { chatId?: never; createdAt?: never;   /** The importance option. */
+  importance: boolean; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never; role?: never; updatedAt?: never; }
+  |  { chatId?: never; createdAt?: never; importance?: never;   /** The notification done option. */
+  notificationDone: boolean; notificationSeen?: never; owner?: never; projectId?: never; role?: never; updatedAt?: never; }
+  |  { chatId?: never; createdAt?: never; importance?: never; notificationDone?: never;   /** The notification seen option. */
+  notificationSeen: boolean; owner?: never; projectId?: never; role?: never; updatedAt?: never; }
+  |  { chatId?: never; createdAt?: never; importance?: never; notificationDone?: never; notificationSeen?: never;   /** The owner option. */
+  owner: string; projectId?: never; role?: never; updatedAt?: never; }
+  |  { chatId?: never; createdAt?: never; importance?: never; notificationDone?: never; notificationSeen?: never; owner?: never;   /** The project id option. */
+  projectId: string | number; role?: never; updatedAt?: never; }
+  |  { chatId?: never; createdAt?: never; importance?: never; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never;   /** The role option. */
+  role: GraphqlChatRole; updatedAt?: never; }
+  |  { chatId?: never; createdAt?: never; importance?: never; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never; role?: never;   /** The updated at option. */
+  updatedAt: GraphqlDateLiteral; };
 
+/** GraphQL input representing the chat role. */
 export type GraphqlChatRole =
+  /** The assistant option. */
   | 'ASSISTANT'
+  /** The system option. */
   | 'SYSTEM'
+  /** The user option. */
   | 'USER';
 
+/** The two operands of a recursive `CrmCompanyFilterExpr` binary expression. */
 export type GraphqlCrmCompanyBinaryExpr = {
+  /** The left-hand expression. */
   left: GraphqlCrmCompanyExpr;
+  /** The right-hand expression. */
   right: GraphqlCrmCompanyExpr;
 };
 
+/** A recursive `CrmCompanyFilterExpr` filter expression. */
 export type GraphqlCrmCompanyExpr =
-  {   and: GraphqlCrmCompanyBinaryExpr; literal?: never; not?: never; or?: never; }
-  |  { and?: never;   literal: GraphqlCrmCompanyLiteral; not?: never; or?: never; }
-  |  { and?: never; literal?: never;   not: GraphqlCrmCompanyExpr; or?: never; }
-  |  { and?: never; literal?: never; not?: never;   or: GraphqlCrmCompanyBinaryExpr; };
+  {   /** Matches when both expressions match. */
+  and: GraphqlCrmCompanyBinaryExpr; literal?: never; not?: never; or?: never; }
+  |  { and?: never;   /** Matches a domain-specific literal condition. */
+  literal: GraphqlCrmCompanyLiteral; not?: never; or?: never; }
+  |  { and?: never; literal?: never;   /** Negates an expression. */
+  not: GraphqlCrmCompanyExpr; or?: never; }
+  |  { and?: never; literal?: never; not?: never;   /** Matches when either expression matches. */
+  or: GraphqlCrmCompanyBinaryExpr; };
 
+/** GraphQL input representing the crm company literal. */
 export type GraphqlCrmCompanyLiteral =
-  {   hidden: boolean; id?: never; }
-  |  { hidden?: never;   id: string | number; };
+  {   /** The hidden option. */
+  hidden: boolean; id?: never; }
+  |  { hidden?: never;   /** The id option. */
+  id: string | number; };
 
+/** GraphQL input representing the crm scope. */
 export type GraphqlCrmScope =
-  {   addresses: Array<string>; domains?: never; }
-  |  { addresses?: never;   domains: Array<string>; };
+  {   /** The addresses option. */
+  addresses: Array<string>; domains?: never; }
+  |  { addresses?: never;   /** The domains option. */
+  domains: Array<string>; };
 
+/** GraphQL input representing the date literal. */
 export type GraphqlDateLiteral =
-  {   gt: string; gte?: never; lt?: never; lte?: never; }
-  |  { gt?: never;   gte: string; lt?: never; lte?: never; }
-  |  { gt?: never; gte?: never;   lt: string; lte?: never; }
-  |  { gt?: never; gte?: never; lt?: never;   lte: string; };
+  {   /** The gt option. */
+  gt: string; gte?: never; lt?: never; lte?: never; }
+  |  { gt?: never;   /** The gte option. */
+  gte: string; lt?: never; lte?: never; }
+  |  { gt?: never; gte?: never;   /** The lt option. */
+  lt: string; lte?: never; }
+  |  { gt?: never; gte?: never; lt?: never;   /** The lte option. */
+  lte: string; };
 
+/** The two operands of a recursive `DocumentFilterExpr` binary expression. */
 export type GraphqlDocumentBinaryExpr = {
+  /** The left-hand expression. */
   left: GraphqlDocumentExpr;
+  /** The right-hand expression. */
   right: GraphqlDocumentExpr;
 };
 
+/** A recursive `DocumentFilterExpr` filter expression. */
 export type GraphqlDocumentExpr =
-  {   and: GraphqlDocumentBinaryExpr; literal?: never; not?: never; or?: never; }
-  |  { and?: never;   literal: GraphqlDocumentLiteral; not?: never; or?: never; }
-  |  { and?: never; literal?: never;   not: GraphqlDocumentExpr; or?: never; }
-  |  { and?: never; literal?: never; not?: never;   or: GraphqlDocumentBinaryExpr; };
+  {   /** Matches when both expressions match. */
+  and: GraphqlDocumentBinaryExpr; literal?: never; not?: never; or?: never; }
+  |  { and?: never;   /** Matches a domain-specific literal condition. */
+  literal: GraphqlDocumentLiteral; not?: never; or?: never; }
+  |  { and?: never; literal?: never;   /** Negates an expression. */
+  not: GraphqlDocumentExpr; or?: never; }
+  |  { and?: never; literal?: never; not?: never;   /** Matches when either expression matches. */
+  or: GraphqlDocumentBinaryExpr; };
 
+/** GraphQL input representing the document literal. */
 export type GraphqlDocumentLiteral =
-  {   createdAt: GraphqlDateLiteral; fileAssoc?: never; fileType?: never; id?: never; importance?: never; includeCbmAtmNc?: never; isEmailAttachment?: never; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never; subType?: never; updatedAt?: never; }
-  |  { createdAt?: never;   fileAssoc: string; fileType?: never; id?: never; importance?: never; includeCbmAtmNc?: never; isEmailAttachment?: never; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never; subType?: never; updatedAt?: never; }
-  |  { createdAt?: never; fileAssoc?: never;   fileType: string; id?: never; importance?: never; includeCbmAtmNc?: never; isEmailAttachment?: never; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never; subType?: never; updatedAt?: never; }
-  |  { createdAt?: never; fileAssoc?: never; fileType?: never;   id: string | number; importance?: never; includeCbmAtmNc?: never; isEmailAttachment?: never; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never; subType?: never; updatedAt?: never; }
-  |  { createdAt?: never; fileAssoc?: never; fileType?: never; id?: never;   importance: boolean; includeCbmAtmNc?: never; isEmailAttachment?: never; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never; subType?: never; updatedAt?: never; }
-  |  { createdAt?: never; fileAssoc?: never; fileType?: never; id?: never; importance?: never;   includeCbmAtmNc: boolean; isEmailAttachment?: never; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never; subType?: never; updatedAt?: never; }
-  |  { createdAt?: never; fileAssoc?: never; fileType?: never; id?: never; importance?: never; includeCbmAtmNc?: never;   isEmailAttachment: boolean; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never; subType?: never; updatedAt?: never; }
-  |  { createdAt?: never; fileAssoc?: never; fileType?: never; id?: never; importance?: never; includeCbmAtmNc?: never; isEmailAttachment?: never;   notificationDone: boolean; notificationSeen?: never; owner?: never; projectId?: never; subType?: never; updatedAt?: never; }
-  |  { createdAt?: never; fileAssoc?: never; fileType?: never; id?: never; importance?: never; includeCbmAtmNc?: never; isEmailAttachment?: never; notificationDone?: never;   notificationSeen: boolean; owner?: never; projectId?: never; subType?: never; updatedAt?: never; }
-  |  { createdAt?: never; fileAssoc?: never; fileType?: never; id?: never; importance?: never; includeCbmAtmNc?: never; isEmailAttachment?: never; notificationDone?: never; notificationSeen?: never;   owner: string; projectId?: never; subType?: never; updatedAt?: never; }
-  |  { createdAt?: never; fileAssoc?: never; fileType?: never; id?: never; importance?: never; includeCbmAtmNc?: never; isEmailAttachment?: never; notificationDone?: never; notificationSeen?: never; owner?: never;   projectId: string | number; subType?: never; updatedAt?: never; }
-  |  { createdAt?: never; fileAssoc?: never; fileType?: never; id?: never; importance?: never; includeCbmAtmNc?: never; isEmailAttachment?: never; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never;   subType: GraphqlDocumentSubType; updatedAt?: never; }
-  |  { createdAt?: never; fileAssoc?: never; fileType?: never; id?: never; importance?: never; includeCbmAtmNc?: never; isEmailAttachment?: never; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never; subType?: never;   updatedAt: GraphqlDateLiteral; };
+  {   /** The created at option. */
+  createdAt: GraphqlDateLiteral; fileAssoc?: never; fileType?: never; id?: never; importance?: never; includeCbmAtmNc?: never; isEmailAttachment?: never; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never; subType?: never; updatedAt?: never; }
+  |  { createdAt?: never;   /** The file assoc option. */
+  fileAssoc: string; fileType?: never; id?: never; importance?: never; includeCbmAtmNc?: never; isEmailAttachment?: never; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never; subType?: never; updatedAt?: never; }
+  |  { createdAt?: never; fileAssoc?: never;   /** The file type option. */
+  fileType: string; id?: never; importance?: never; includeCbmAtmNc?: never; isEmailAttachment?: never; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never; subType?: never; updatedAt?: never; }
+  |  { createdAt?: never; fileAssoc?: never; fileType?: never;   /** The id option. */
+  id: string | number; importance?: never; includeCbmAtmNc?: never; isEmailAttachment?: never; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never; subType?: never; updatedAt?: never; }
+  |  { createdAt?: never; fileAssoc?: never; fileType?: never; id?: never;   /** The importance option. */
+  importance: boolean; includeCbmAtmNc?: never; isEmailAttachment?: never; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never; subType?: never; updatedAt?: never; }
+  |  { createdAt?: never; fileAssoc?: never; fileType?: never; id?: never; importance?: never;   /** The include cbm atm nc option. */
+  includeCbmAtmNc: boolean; isEmailAttachment?: never; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never; subType?: never; updatedAt?: never; }
+  |  { createdAt?: never; fileAssoc?: never; fileType?: never; id?: never; importance?: never; includeCbmAtmNc?: never;   /** The is email attachment option. */
+  isEmailAttachment: boolean; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never; subType?: never; updatedAt?: never; }
+  |  { createdAt?: never; fileAssoc?: never; fileType?: never; id?: never; importance?: never; includeCbmAtmNc?: never; isEmailAttachment?: never;   /** The notification done option. */
+  notificationDone: boolean; notificationSeen?: never; owner?: never; projectId?: never; subType?: never; updatedAt?: never; }
+  |  { createdAt?: never; fileAssoc?: never; fileType?: never; id?: never; importance?: never; includeCbmAtmNc?: never; isEmailAttachment?: never; notificationDone?: never;   /** The notification seen option. */
+  notificationSeen: boolean; owner?: never; projectId?: never; subType?: never; updatedAt?: never; }
+  |  { createdAt?: never; fileAssoc?: never; fileType?: never; id?: never; importance?: never; includeCbmAtmNc?: never; isEmailAttachment?: never; notificationDone?: never; notificationSeen?: never;   /** The owner option. */
+  owner: string; projectId?: never; subType?: never; updatedAt?: never; }
+  |  { createdAt?: never; fileAssoc?: never; fileType?: never; id?: never; importance?: never; includeCbmAtmNc?: never; isEmailAttachment?: never; notificationDone?: never; notificationSeen?: never; owner?: never;   /** The project id option. */
+  projectId: string | number; subType?: never; updatedAt?: never; }
+  |  { createdAt?: never; fileAssoc?: never; fileType?: never; id?: never; importance?: never; includeCbmAtmNc?: never; isEmailAttachment?: never; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never;   /** The sub type option. */
+  subType: GraphqlDocumentSubType; updatedAt?: never; }
+  |  { createdAt?: never; fileAssoc?: never; fileType?: never; id?: never; importance?: never; includeCbmAtmNc?: never; isEmailAttachment?: never; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never; subType?: never;   /** The updated at option. */
+  updatedAt: GraphqlDateLiteral; };
 
+/** GraphQL input representing the document sub type. */
 export type GraphqlDocumentSubType =
+  /** The snippet option. */
   | 'SNIPPET'
+  /** The task option. */
   | 'TASK';
 
+/** The two operands of a recursive `EmailFilterExpr` binary expression. */
 export type GraphqlEmailBinaryExpr = {
+  /** The left-hand expression. */
   left: GraphqlEmailExpr;
+  /** The right-hand expression. */
   right: GraphqlEmailExpr;
 };
 
+/** A recursive `EmailFilterExpr` filter expression. */
 export type GraphqlEmailExpr =
-  {   and: GraphqlEmailBinaryExpr; literal?: never; not?: never; or?: never; }
-  |  { and?: never;   literal: GraphqlEmailLiteral; not?: never; or?: never; }
-  |  { and?: never; literal?: never;   not: GraphqlEmailExpr; or?: never; }
-  |  { and?: never; literal?: never; not?: never;   or: GraphqlEmailBinaryExpr; };
+  {   /** Matches when both expressions match. */
+  and: GraphqlEmailBinaryExpr; literal?: never; not?: never; or?: never; }
+  |  { and?: never;   /** Matches a domain-specific literal condition. */
+  literal: GraphqlEmailLiteral; not?: never; or?: never; }
+  |  { and?: never; literal?: never;   /** Negates an expression. */
+  not: GraphqlEmailExpr; or?: never; }
+  |  { and?: never; literal?: never; not?: never;   /** Matches when either expression matches. */
+  or: GraphqlEmailBinaryExpr; };
 
+/** GraphQL input representing the email filter ast. */
 export type GraphqlEmailFilterAst = {
+  /** The crm scope. */
   crmScope?: GraphqlCrmScope | null | undefined;
+  /** The tree. */
   tree?: GraphqlEmailExpr | null | undefined;
 };
 
+/** GraphQL input representing the email literal. */
 export type GraphqlEmailLiteral =
-  {   bcc: GraphqlEmailValue; calendarOnly?: never; cc?: never; createdAt?: never; importance?: never; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never; recipient?: never; sender?: never; shared?: never; threadId?: never; updatedAt?: never; }
-  |  { bcc?: never;   calendarOnly: boolean; cc?: never; createdAt?: never; importance?: never; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never; recipient?: never; sender?: never; shared?: never; threadId?: never; updatedAt?: never; }
-  |  { bcc?: never; calendarOnly?: never;   cc: GraphqlEmailValue; createdAt?: never; importance?: never; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never; recipient?: never; sender?: never; shared?: never; threadId?: never; updatedAt?: never; }
-  |  { bcc?: never; calendarOnly?: never; cc?: never;   createdAt: GraphqlDateLiteral; importance?: never; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never; recipient?: never; sender?: never; shared?: never; threadId?: never; updatedAt?: never; }
-  |  { bcc?: never; calendarOnly?: never; cc?: never; createdAt?: never;   importance: boolean; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never; recipient?: never; sender?: never; shared?: never; threadId?: never; updatedAt?: never; }
-  |  { bcc?: never; calendarOnly?: never; cc?: never; createdAt?: never; importance?: never;   notificationDone: boolean; notificationSeen?: never; owner?: never; projectId?: never; recipient?: never; sender?: never; shared?: never; threadId?: never; updatedAt?: never; }
-  |  { bcc?: never; calendarOnly?: never; cc?: never; createdAt?: never; importance?: never; notificationDone?: never;   notificationSeen: boolean; owner?: never; projectId?: never; recipient?: never; sender?: never; shared?: never; threadId?: never; updatedAt?: never; }
-  |  { bcc?: never; calendarOnly?: never; cc?: never; createdAt?: never; importance?: never; notificationDone?: never; notificationSeen?: never;   owner: string | number; projectId?: never; recipient?: never; sender?: never; shared?: never; threadId?: never; updatedAt?: never; }
-  |  { bcc?: never; calendarOnly?: never; cc?: never; createdAt?: never; importance?: never; notificationDone?: never; notificationSeen?: never; owner?: never;   projectId: string; recipient?: never; sender?: never; shared?: never; threadId?: never; updatedAt?: never; }
-  |  { bcc?: never; calendarOnly?: never; cc?: never; createdAt?: never; importance?: never; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never;   recipient: GraphqlEmailValue; sender?: never; shared?: never; threadId?: never; updatedAt?: never; }
-  |  { bcc?: never; calendarOnly?: never; cc?: never; createdAt?: never; importance?: never; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never; recipient?: never;   sender: GraphqlEmailValue; shared?: never; threadId?: never; updatedAt?: never; }
-  |  { bcc?: never; calendarOnly?: never; cc?: never; createdAt?: never; importance?: never; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never; recipient?: never; sender?: never;   shared: GraphqlSharedEmailFilter; threadId?: never; updatedAt?: never; }
-  |  { bcc?: never; calendarOnly?: never; cc?: never; createdAt?: never; importance?: never; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never; recipient?: never; sender?: never; shared?: never;   threadId: string | number; updatedAt?: never; }
-  |  { bcc?: never; calendarOnly?: never; cc?: never; createdAt?: never; importance?: never; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never; recipient?: never; sender?: never; shared?: never; threadId?: never;   updatedAt: GraphqlDateLiteral; };
+  {   /** The bcc option. */
+  bcc: GraphqlEmailValue; calendarOnly?: never; cc?: never; createdAt?: never; importance?: never; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never; recipient?: never; sender?: never; shared?: never; threadId?: never; updatedAt?: never; }
+  |  { bcc?: never;   /** The calendar only option. */
+  calendarOnly: boolean; cc?: never; createdAt?: never; importance?: never; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never; recipient?: never; sender?: never; shared?: never; threadId?: never; updatedAt?: never; }
+  |  { bcc?: never; calendarOnly?: never;   /** The cc option. */
+  cc: GraphqlEmailValue; createdAt?: never; importance?: never; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never; recipient?: never; sender?: never; shared?: never; threadId?: never; updatedAt?: never; }
+  |  { bcc?: never; calendarOnly?: never; cc?: never;   /** The created at option. */
+  createdAt: GraphqlDateLiteral; importance?: never; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never; recipient?: never; sender?: never; shared?: never; threadId?: never; updatedAt?: never; }
+  |  { bcc?: never; calendarOnly?: never; cc?: never; createdAt?: never;   /** The importance option. */
+  importance: boolean; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never; recipient?: never; sender?: never; shared?: never; threadId?: never; updatedAt?: never; }
+  |  { bcc?: never; calendarOnly?: never; cc?: never; createdAt?: never; importance?: never;   /** The notification done option. */
+  notificationDone: boolean; notificationSeen?: never; owner?: never; projectId?: never; recipient?: never; sender?: never; shared?: never; threadId?: never; updatedAt?: never; }
+  |  { bcc?: never; calendarOnly?: never; cc?: never; createdAt?: never; importance?: never; notificationDone?: never;   /** The notification seen option. */
+  notificationSeen: boolean; owner?: never; projectId?: never; recipient?: never; sender?: never; shared?: never; threadId?: never; updatedAt?: never; }
+  |  { bcc?: never; calendarOnly?: never; cc?: never; createdAt?: never; importance?: never; notificationDone?: never; notificationSeen?: never;   /** The owner option. */
+  owner: string | number; projectId?: never; recipient?: never; sender?: never; shared?: never; threadId?: never; updatedAt?: never; }
+  |  { bcc?: never; calendarOnly?: never; cc?: never; createdAt?: never; importance?: never; notificationDone?: never; notificationSeen?: never; owner?: never;   /** The project id option. */
+  projectId: string; recipient?: never; sender?: never; shared?: never; threadId?: never; updatedAt?: never; }
+  |  { bcc?: never; calendarOnly?: never; cc?: never; createdAt?: never; importance?: never; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never;   /** The recipient option. */
+  recipient: GraphqlEmailValue; sender?: never; shared?: never; threadId?: never; updatedAt?: never; }
+  |  { bcc?: never; calendarOnly?: never; cc?: never; createdAt?: never; importance?: never; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never; recipient?: never;   /** The sender option. */
+  sender: GraphqlEmailValue; shared?: never; threadId?: never; updatedAt?: never; }
+  |  { bcc?: never; calendarOnly?: never; cc?: never; createdAt?: never; importance?: never; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never; recipient?: never; sender?: never;   /** The shared option. */
+  shared: GraphqlSharedEmailFilter; threadId?: never; updatedAt?: never; }
+  |  { bcc?: never; calendarOnly?: never; cc?: never; createdAt?: never; importance?: never; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never; recipient?: never; sender?: never; shared?: never;   /** The thread id option. */
+  threadId: string | number; updatedAt?: never; }
+  |  { bcc?: never; calendarOnly?: never; cc?: never; createdAt?: never; importance?: never; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never; recipient?: never; sender?: never; shared?: never; threadId?: never;   /** The updated at option. */
+  updatedAt: GraphqlDateLiteral; };
 
+/** GraphQL input representing the email value. */
 export type GraphqlEmailValue =
-  {   complete: string; domain?: never; partial?: never; }
-  |  { complete?: never;   domain: string; partial?: never; }
-  |  { complete?: never; domain?: never;   partial: string; };
+  {   /** The complete option. */
+  complete: string; domain?: never; partial?: never; }
+  |  { complete?: never;   /** The domain option. */
+  domain: string; partial?: never; }
+  |  { complete?: never; domain?: never;   /** The partial option. */
+  partial: string; };
 
+/** GraphQL input representing the email view. */
 export type GraphqlEmailView =
+  /** The all option. */
   | 'ALL'
+  /** The drafts option. */
   | 'DRAFTS'
+  /** The important option. */
   | 'IMPORTANT'
+  /** The inbox option. */
   | 'INBOX'
+  /** The other option. */
   | 'OTHER'
+  /** The sent option. */
   | 'SENT'
+  /** The starred option. */
   | 'STARRED';
 
 /** GraphQL input mirroring `item_filters::ast::EntityFilterAst`. */
 export type GraphqlEntityFilterAst = {
+  /** The call filter to apply. */
   callFilter?: GraphqlCallExpr | null | undefined;
+  /** The channel filter to apply. */
   channelFilter?: GraphqlChannelExpr | null | undefined;
+  /** The channel thread filter to apply. */
   channelThreadFilter?: GraphqlChannelThreadExpr | null | undefined;
+  /** The chat filter to apply. */
   chatFilter?: GraphqlChatExpr | null | undefined;
+  /** The crm company filter to apply. */
   crmCompanyFilter?: GraphqlCrmCompanyExpr | null | undefined;
+  /** The document filter to apply. */
   documentFilter?: GraphqlDocumentExpr | null | undefined;
+  /** The email filter to apply. */
   emailFilter?: GraphqlEmailFilterAst | null | undefined;
+  /** The foreign entity filter to apply. */
   foreignEntityFilter?: GraphqlForeignEntityExpr | null | undefined;
+  /** The project filter to apply. */
   projectFilter?: GraphqlProjectExpr | null | undefined;
+  /** The properties filter to apply. */
   propertiesFilter?: GraphqlPropertiesExpr | null | undefined;
 };
 
+/** Input identifying an entity referenced by a property value. */
 export type GraphqlEntityReferenceInput = {
+  /** Identifier of the referenced entity. */
   entityId: string;
+  /** Type of the referenced entity. */
   entityType: GraphqlPropertyEntityType;
+  /** Specific message when the reference targets a thread message. */
   specificMessageId?: string | number | null | undefined;
 };
 
+/** The two operands of a recursive `ForeignEntityFilterExpr` binary expression. */
 export type GraphqlForeignEntityBinaryExpr = {
+  /** The left-hand expression. */
   left: GraphqlForeignEntityExpr;
+  /** The right-hand expression. */
   right: GraphqlForeignEntityExpr;
 };
 
+/** A recursive `ForeignEntityFilterExpr` filter expression. */
 export type GraphqlForeignEntityExpr =
-  {   and: GraphqlForeignEntityBinaryExpr; literal?: never; not?: never; or?: never; }
-  |  { and?: never;   literal: GraphqlForeignEntityLiteral; not?: never; or?: never; }
-  |  { and?: never; literal?: never;   not: GraphqlForeignEntityExpr; or?: never; }
-  |  { and?: never; literal?: never; not?: never;   or: GraphqlForeignEntityBinaryExpr; };
+  {   /** Matches when both expressions match. */
+  and: GraphqlForeignEntityBinaryExpr; literal?: never; not?: never; or?: never; }
+  |  { and?: never;   /** Matches a domain-specific literal condition. */
+  literal: GraphqlForeignEntityLiteral; not?: never; or?: never; }
+  |  { and?: never; literal?: never;   /** Negates an expression. */
+  not: GraphqlForeignEntityExpr; or?: never; }
+  |  { and?: never; literal?: never; not?: never;   /** Matches when either expression matches. */
+  or: GraphqlForeignEntityBinaryExpr; };
 
+/** GraphQL input representing the foreign entity literal. */
 export type GraphqlForeignEntityLiteral =
-  {   foreignEntityId: string; foreignEntitySource?: never; id?: never; includesMe?: never; notificationDone?: never; notificationSeen?: never; }
-  |  { foreignEntityId?: never;   foreignEntitySource: string; id?: never; includesMe?: never; notificationDone?: never; notificationSeen?: never; }
-  |  { foreignEntityId?: never; foreignEntitySource?: never;   id: string | number; includesMe?: never; notificationDone?: never; notificationSeen?: never; }
-  |  { foreignEntityId?: never; foreignEntitySource?: never; id?: never;   includesMe: boolean; notificationDone?: never; notificationSeen?: never; }
-  |  { foreignEntityId?: never; foreignEntitySource?: never; id?: never; includesMe?: never;   notificationDone: boolean; notificationSeen?: never; }
-  |  { foreignEntityId?: never; foreignEntitySource?: never; id?: never; includesMe?: never; notificationDone?: never;   notificationSeen: boolean; };
+  {   /** The foreign entity id option. */
+  foreignEntityId: string; foreignEntitySource?: never; id?: never; includesMe?: never; notificationDone?: never; notificationSeen?: never; }
+  |  { foreignEntityId?: never;   /** The foreign entity source option. */
+  foreignEntitySource: string; id?: never; includesMe?: never; notificationDone?: never; notificationSeen?: never; }
+  |  { foreignEntityId?: never; foreignEntitySource?: never;   /** The id option. */
+  id: string | number; includesMe?: never; notificationDone?: never; notificationSeen?: never; }
+  |  { foreignEntityId?: never; foreignEntitySource?: never; id?: never;   /** The includes me option. */
+  includesMe: boolean; notificationDone?: never; notificationSeen?: never; }
+  |  { foreignEntityId?: never; foreignEntitySource?: never; id?: never; includesMe?: never;   /** The notification done option. */
+  notificationDone: boolean; notificationSeen?: never; }
+  |  { foreignEntityId?: never; foreignEntitySource?: never; id?: never; includesMe?: never; notificationDone?: never;   /** The notification seen option. */
+  notificationSeen: boolean; };
 
+/** The two operands of a recursive `ProjectFilterExpr` binary expression. */
 export type GraphqlProjectBinaryExpr = {
+  /** The left-hand expression. */
   left: GraphqlProjectExpr;
+  /** The right-hand expression. */
   right: GraphqlProjectExpr;
 };
 
+/** A recursive `ProjectFilterExpr` filter expression. */
 export type GraphqlProjectExpr =
-  {   and: GraphqlProjectBinaryExpr; literal?: never; not?: never; or?: never; }
-  |  { and?: never;   literal: GraphqlProjectLiteral; not?: never; or?: never; }
-  |  { and?: never; literal?: never;   not: GraphqlProjectExpr; or?: never; }
-  |  { and?: never; literal?: never; not?: never;   or: GraphqlProjectBinaryExpr; };
+  {   /** Matches when both expressions match. */
+  and: GraphqlProjectBinaryExpr; literal?: never; not?: never; or?: never; }
+  |  { and?: never;   /** Matches a domain-specific literal condition. */
+  literal: GraphqlProjectLiteral; not?: never; or?: never; }
+  |  { and?: never; literal?: never;   /** Negates an expression. */
+  not: GraphqlProjectExpr; or?: never; }
+  |  { and?: never; literal?: never; not?: never;   /** Matches when either expression matches. */
+  or: GraphqlProjectBinaryExpr; };
 
+/** GraphQL input representing the project literal. */
 export type GraphqlProjectLiteral =
-  {   createdAt: GraphqlDateLiteral; importance?: never; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never; projectIdSelf?: never; updatedAt?: never; }
-  |  { createdAt?: never;   importance: boolean; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never; projectIdSelf?: never; updatedAt?: never; }
-  |  { createdAt?: never; importance?: never;   notificationDone: boolean; notificationSeen?: never; owner?: never; projectId?: never; projectIdSelf?: never; updatedAt?: never; }
-  |  { createdAt?: never; importance?: never; notificationDone?: never;   notificationSeen: boolean; owner?: never; projectId?: never; projectIdSelf?: never; updatedAt?: never; }
-  |  { createdAt?: never; importance?: never; notificationDone?: never; notificationSeen?: never;   owner: string; projectId?: never; projectIdSelf?: never; updatedAt?: never; }
-  |  { createdAt?: never; importance?: never; notificationDone?: never; notificationSeen?: never; owner?: never;   projectId: string | number; projectIdSelf?: never; updatedAt?: never; }
-  |  { createdAt?: never; importance?: never; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never;   projectIdSelf: string | number; updatedAt?: never; }
-  |  { createdAt?: never; importance?: never; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never; projectIdSelf?: never;   updatedAt: GraphqlDateLiteral; };
+  {   /** The created at option. */
+  createdAt: GraphqlDateLiteral; importance?: never; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never; projectIdSelf?: never; updatedAt?: never; }
+  |  { createdAt?: never;   /** The importance option. */
+  importance: boolean; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never; projectIdSelf?: never; updatedAt?: never; }
+  |  { createdAt?: never; importance?: never;   /** The notification done option. */
+  notificationDone: boolean; notificationSeen?: never; owner?: never; projectId?: never; projectIdSelf?: never; updatedAt?: never; }
+  |  { createdAt?: never; importance?: never; notificationDone?: never;   /** The notification seen option. */
+  notificationSeen: boolean; owner?: never; projectId?: never; projectIdSelf?: never; updatedAt?: never; }
+  |  { createdAt?: never; importance?: never; notificationDone?: never; notificationSeen?: never;   /** The owner option. */
+  owner: string; projectId?: never; projectIdSelf?: never; updatedAt?: never; }
+  |  { createdAt?: never; importance?: never; notificationDone?: never; notificationSeen?: never; owner?: never;   /** The project id option. */
+  projectId: string | number; projectIdSelf?: never; updatedAt?: never; }
+  |  { createdAt?: never; importance?: never; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never;   /** The project id self option. */
+  projectIdSelf: string | number; updatedAt?: never; }
+  |  { createdAt?: never; importance?: never; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never; projectIdSelf?: never;   /** The updated at option. */
+  updatedAt: GraphqlDateLiteral; };
 
+/** The two operands of a recursive `PropertiesFilterExpr` binary expression. */
 export type GraphqlPropertiesBinaryExpr = {
+  /** The left-hand expression. */
   left: GraphqlPropertiesExpr;
+  /** The right-hand expression. */
   right: GraphqlPropertiesExpr;
 };
 
+/** A recursive `PropertiesFilterExpr` filter expression. */
 export type GraphqlPropertiesExpr =
-  {   and: GraphqlPropertiesBinaryExpr; literal?: never; not?: never; or?: never; }
-  |  { and?: never;   literal: GraphqlPropertiesLiteral; not?: never; or?: never; }
-  |  { and?: never; literal?: never;   not: GraphqlPropertiesExpr; or?: never; }
-  |  { and?: never; literal?: never; not?: never;   or: GraphqlPropertiesBinaryExpr; };
+  {   /** Matches when both expressions match. */
+  and: GraphqlPropertiesBinaryExpr; literal?: never; not?: never; or?: never; }
+  |  { and?: never;   /** Matches a domain-specific literal condition. */
+  literal: GraphqlPropertiesLiteral; not?: never; or?: never; }
+  |  { and?: never; literal?: never;   /** Negates an expression. */
+  not: GraphqlPropertiesExpr; or?: never; }
+  |  { and?: never; literal?: never; not?: never;   /** Matches when either expression matches. */
+  or: GraphqlPropertiesBinaryExpr; };
 
 /** GraphQL input for matching a property value on an entity. */
 export type GraphqlPropertiesLiteral = {
@@ -332,21 +547,36 @@ export type GraphqlPropertyMatchValue =
   |  { entityRef?: never;   /** Select option id to match. */
   selectOption: string | number; };
 
+/** A typed value accepted when setting an entity property. */
 export type GraphqlSetPropertyValue =
-  {   boolean: boolean; date?: never; entityReference?: never; link?: never; multiEntityReference?: never; multiLink?: never; multiSelectOption?: never; number?: never; selectOption?: never; string?: never; }
-  |  { boolean?: never;   date: string; entityReference?: never; link?: never; multiEntityReference?: never; multiLink?: never; multiSelectOption?: never; number?: never; selectOption?: never; string?: never; }
-  |  { boolean?: never; date?: never;   entityReference: GraphqlEntityReferenceInput; link?: never; multiEntityReference?: never; multiLink?: never; multiSelectOption?: never; number?: never; selectOption?: never; string?: never; }
-  |  { boolean?: never; date?: never; entityReference?: never;   link: string; multiEntityReference?: never; multiLink?: never; multiSelectOption?: never; number?: never; selectOption?: never; string?: never; }
-  |  { boolean?: never; date?: never; entityReference?: never; link?: never;   multiEntityReference: Array<GraphqlEntityReferenceInput>; multiLink?: never; multiSelectOption?: never; number?: never; selectOption?: never; string?: never; }
-  |  { boolean?: never; date?: never; entityReference?: never; link?: never; multiEntityReference?: never;   multiLink: Array<string>; multiSelectOption?: never; number?: never; selectOption?: never; string?: never; }
-  |  { boolean?: never; date?: never; entityReference?: never; link?: never; multiEntityReference?: never; multiLink?: never;   multiSelectOption: Array<string | number>; number?: never; selectOption?: never; string?: never; }
-  |  { boolean?: never; date?: never; entityReference?: never; link?: never; multiEntityReference?: never; multiLink?: never; multiSelectOption?: never;   number: number; selectOption?: never; string?: never; }
-  |  { boolean?: never; date?: never; entityReference?: never; link?: never; multiEntityReference?: never; multiLink?: never; multiSelectOption?: never; number?: never;   selectOption: string | number; string?: never; }
-  |  { boolean?: never; date?: never; entityReference?: never; link?: never; multiEntityReference?: never; multiLink?: never; multiSelectOption?: never; number?: never; selectOption?: never;   string: string; };
+  {   /** A Boolean value. */
+  boolean: boolean; date?: never; entityReference?: never; link?: never; multiEntityReference?: never; multiLink?: never; multiSelectOption?: never; number?: never; selectOption?: never; string?: never; }
+  |  { boolean?: never;   /** An RFC 3339 date-time value. */
+  date: string; entityReference?: never; link?: never; multiEntityReference?: never; multiLink?: never; multiSelectOption?: never; number?: never; selectOption?: never; string?: never; }
+  |  { boolean?: never; date?: never;   /** A single entity reference. */
+  entityReference: GraphqlEntityReferenceInput; link?: never; multiEntityReference?: never; multiLink?: never; multiSelectOption?: never; number?: never; selectOption?: never; string?: never; }
+  |  { boolean?: never; date?: never; entityReference?: never;   /** A single URL value. */
+  link: string; multiEntityReference?: never; multiLink?: never; multiSelectOption?: never; number?: never; selectOption?: never; string?: never; }
+  |  { boolean?: never; date?: never; entityReference?: never; link?: never;   /** Multiple entity references. */
+  multiEntityReference: Array<GraphqlEntityReferenceInput>; multiLink?: never; multiSelectOption?: never; number?: never; selectOption?: never; string?: never; }
+  |  { boolean?: never; date?: never; entityReference?: never; link?: never; multiEntityReference?: never;   /** Multiple URL values. */
+  multiLink: Array<string>; multiSelectOption?: never; number?: never; selectOption?: never; string?: never; }
+  |  { boolean?: never; date?: never; entityReference?: never; link?: never; multiEntityReference?: never; multiLink?: never;   /** Multiple selected option identifiers. */
+  multiSelectOption: Array<string | number>; number?: never; selectOption?: never; string?: never; }
+  |  { boolean?: never; date?: never; entityReference?: never; link?: never; multiEntityReference?: never; multiLink?: never; multiSelectOption?: never;   /** A numeric value. */
+  number: number; selectOption?: never; string?: never; }
+  |  { boolean?: never; date?: never; entityReference?: never; link?: never; multiEntityReference?: never; multiLink?: never; multiSelectOption?: never; number?: never;   /** A single selected option identifier. */
+  selectOption: string | number; string?: never; }
+  |  { boolean?: never; date?: never; entityReference?: never; link?: never; multiEntityReference?: never; multiLink?: never; multiSelectOption?: never; number?: never; selectOption?: never;   /** A string value. */
+  string: string; };
 
+/** GraphQL input representing the shared email filter. */
 export type GraphqlSharedEmailFilter =
+  /** The exclude option. */
   | 'EXCLUDE'
+  /** The include option. */
   | 'INCLUDE'
+  /** The only option. */
   | 'ONLY';
 
 /** GraphQL representation of supported simple Soup sorts. */
@@ -389,9 +619,13 @@ export type GraphqlSoupEntityType =
   /** User entity. */
   | 'USER';
 
+/** Input for assigning or updating an entity property. */
 export type SetEntityPropertyInput = {
+  /** Identifier of the entity receiving the property. */
   entityId: string;
+  /** Type of entity receiving the property. */
   entityType: GraphqlPropertyEntityType;
+  /** Identifier of the property definition to assign. */
   propertyDefinitionId: string | number;
   /** Omit or pass null to attach the property without a value. */
   value?: GraphqlSetPropertyValue | null | undefined;
@@ -483,7 +717,7 @@ export type SoupQuery = { user: { id: string, soup: { nextCursor: string | null,
                 | { __typename: 'GraphqlNumberPropertyValue', numberValue: number }
                 | { __typename: 'GraphqlSelectOptionPropertyValue', optionIds: Array<string> }
                 | { __typename: 'GraphqlStringPropertyValue', stringValue: string }
-               | null }>, notifications: Array<{ id: string, eventType: string, entityType: GraphqlSoupEntityType, entityId: string, sent: boolean, done: boolean, seen: boolean, createdAt: string, viewedAt: string | null, updatedAt: string, senderId: string | null, metadata: unknown }> }
+               | null }>, notifications: Array<{ id: string, eventType: string, entityType: GraphqlSoupEntityType, entityId: string, sent: boolean, done: boolean, seen: boolean, createdAt: string, viewedAt: string | null, updatedAt: string, senderId: string | null, metadata: unknown }>, latestContentMessage: { __typename: 'GraphqlSoupEmailMessage', id: string, threadId: string, linkId: string, subject: string | null, snippet: string | null, internalDateTs: string | null, sentAt: string | null, isRead: boolean, isStarred: boolean, isSent: boolean, hasAttachments: boolean, bodyParsed: string | null, bodyText: string | null, bodyHtmlSanitized: string | null, bodyMacro: string | null, bodyReplyless: string | null, createdAt: string, updatedAt: string, from: { email: string, name: string | null, photoUrl: string | null } | null, to: Array<{ email: string, name: string | null, photoUrl: string | null }>, cc: Array<{ email: string, name: string | null, photoUrl: string | null }>, bcc: Array<{ email: string, name: string | null, photoUrl: string | null }>, labels: Array<{ providerLabelId: string, name: string }> } | null }
           | { __typename: 'GraphqlSoupForeignEntity', id: string, foreignEntityId: string, foreignEntitySource: string, storedForId: string, storedForAuthEntity: string, metadata: unknown, createdAt: string, updatedAt: string, notifications: Array<{ id: string, eventType: string, entityType: GraphqlSoupEntityType, entityId: string, sent: boolean, done: boolean, seen: boolean, createdAt: string, viewedAt: string | null, updatedAt: string, senderId: string | null, metadata: unknown }> }
           | { __typename: 'GraphqlSoupProject', id: string, ownerId: string, parentId: string | null, createdAt: string, updatedAt: string, viewedAt: string | null, deletedAt: string | null, projectName: string, properties: Array<{ id: string, propertyDefinitionId: string, displayName: string, dataType: GraphqlPropertyDataType, isMultiSelect: boolean, specificEntityType: GraphqlPropertyEntityType | null, isSystem: boolean, isMetadata: boolean, value:
                 | { __typename: 'GraphqlBooleanPropertyValue', boolValue: boolean }
@@ -514,4 +748,4 @@ export const SoupPropertyFieldsFragmentDoc = {"kind":"Document","definitions":[{
 export const SoupChannelMessageFieldsFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"SoupChannelMessageFields"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"GraphqlSoupChannelMessage"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"threadId"}},{"kind":"Field","name":{"kind":"Name","value":"senderId"}},{"kind":"Field","name":{"kind":"Name","value":"content"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}},{"kind":"Field","name":{"kind":"Name","value":"updatedAt"}},{"kind":"Field","name":{"kind":"Name","value":"deletedAt"}},{"kind":"Field","name":{"kind":"Name","value":"mentions"}}]}}]} as unknown as DocumentNode<SoupChannelMessageFieldsFragment, unknown>;
 export const SoupNotificationFieldsFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"SoupNotificationFields"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"GraphqlSoupNotification"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"eventType"}},{"kind":"Field","name":{"kind":"Name","value":"entityType"}},{"kind":"Field","name":{"kind":"Name","value":"entityId"}},{"kind":"Field","name":{"kind":"Name","value":"sent"}},{"kind":"Field","name":{"kind":"Name","value":"done"}},{"kind":"Field","name":{"kind":"Name","value":"seen"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}},{"kind":"Field","name":{"kind":"Name","value":"viewedAt"}},{"kind":"Field","name":{"kind":"Name","value":"updatedAt"}},{"kind":"Field","name":{"kind":"Name","value":"senderId"}},{"kind":"Field","name":{"kind":"Name","value":"metadata"}}]}}]} as unknown as DocumentNode<SoupNotificationFieldsFragment, unknown>;
 export const SetEntityPropertyDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"SetEntityProperty"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"SetEntityPropertyInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"setEntityProperty"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"SoupPropertyFields"}}]}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"SoupPropertyFields"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"GraphqlProperty"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"propertyDefinitionId"}},{"kind":"Field","name":{"kind":"Name","value":"displayName"}},{"kind":"Field","name":{"kind":"Name","value":"dataType"}},{"kind":"Field","name":{"kind":"Name","value":"isMultiSelect"}},{"kind":"Field","name":{"kind":"Name","value":"specificEntityType"}},{"kind":"Field","name":{"kind":"Name","value":"isSystem"}},{"kind":"Field","name":{"kind":"Name","value":"isMetadata"}},{"kind":"Field","name":{"kind":"Name","value":"value"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"__typename"}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"GraphqlBooleanPropertyValue"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","alias":{"kind":"Name","value":"boolValue"},"name":{"kind":"Name","value":"value"}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"GraphqlNumberPropertyValue"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","alias":{"kind":"Name","value":"numberValue"},"name":{"kind":"Name","value":"value"}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"GraphqlStringPropertyValue"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","alias":{"kind":"Name","value":"stringValue"},"name":{"kind":"Name","value":"value"}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"GraphqlDatePropertyValue"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","alias":{"kind":"Name","value":"dateValue"},"name":{"kind":"Name","value":"value"}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"GraphqlSelectOptionPropertyValue"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"optionIds"}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"GraphqlEntityReferencePropertyValue"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"references"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"entityId"}},{"kind":"Field","name":{"kind":"Name","value":"entityType"}},{"kind":"Field","name":{"kind":"Name","value":"specificMessageId"}}]}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"GraphqlLinkPropertyValue"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"urls"}}]}}]}}]}}]} as unknown as DocumentNode<SetEntityPropertyMutation, SetEntityPropertyMutationVariables>;
-export const SoupDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"Soup"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"SoupInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"user"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"soup"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"items"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"entityType"}},{"kind":"Field","name":{"kind":"Name","value":"frecencyScore"}},{"kind":"Field","name":{"kind":"Name","value":"entity"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"__typename"}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"GraphqlSoupDocument"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","alias":{"kind":"Name","value":"documentName"},"name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"ownerId"}},{"kind":"Field","name":{"kind":"Name","value":"fileType"}},{"kind":"Field","name":{"kind":"Name","value":"projectId"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}},{"kind":"Field","name":{"kind":"Name","value":"updatedAt"}},{"kind":"Field","name":{"kind":"Name","value":"viewedAt"}},{"kind":"Field","name":{"kind":"Name","value":"deletedAt"}},{"kind":"Field","name":{"kind":"Name","value":"subType"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"kind"}},{"kind":"Field","name":{"kind":"Name","value":"isCompleted"}}]}},{"kind":"Field","name":{"kind":"Name","value":"properties"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"SoupPropertyFields"}}]}},{"kind":"Field","name":{"kind":"Name","value":"notifications"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"SoupNotificationFields"}}]}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"GraphqlSoupChat"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","alias":{"kind":"Name","value":"chatName"},"name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"ownerId"}},{"kind":"Field","name":{"kind":"Name","value":"projectId"}},{"kind":"Field","name":{"kind":"Name","value":"isPersistent"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}},{"kind":"Field","name":{"kind":"Name","value":"updatedAt"}},{"kind":"Field","name":{"kind":"Name","value":"viewedAt"}},{"kind":"Field","name":{"kind":"Name","value":"deletedAt"}},{"kind":"Field","name":{"kind":"Name","value":"properties"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"SoupPropertyFields"}}]}},{"kind":"Field","name":{"kind":"Name","value":"notifications"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"SoupNotificationFields"}}]}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"GraphqlSoupProject"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","alias":{"kind":"Name","value":"projectName"},"name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"ownerId"}},{"kind":"Field","name":{"kind":"Name","value":"parentId"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}},{"kind":"Field","name":{"kind":"Name","value":"updatedAt"}},{"kind":"Field","name":{"kind":"Name","value":"viewedAt"}},{"kind":"Field","name":{"kind":"Name","value":"deletedAt"}},{"kind":"Field","name":{"kind":"Name","value":"properties"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"SoupPropertyFields"}}]}},{"kind":"Field","name":{"kind":"Name","value":"notifications"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"SoupNotificationFields"}}]}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"GraphqlSoupEmailThread"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"providerId"}},{"kind":"Field","name":{"kind":"Name","value":"ownerId"}},{"kind":"Field","name":{"kind":"Name","value":"inboxVisible"}},{"kind":"Field","name":{"kind":"Name","value":"linkId"}},{"kind":"Field","alias":{"kind":"Name","value":"emailName"},"name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"snippet"}},{"kind":"Field","name":{"kind":"Name","value":"senderEmail"}},{"kind":"Field","name":{"kind":"Name","value":"senderName"}},{"kind":"Field","name":{"kind":"Name","value":"senderPhotoUrl"}},{"kind":"Field","name":{"kind":"Name","value":"isRead"}},{"kind":"Field","name":{"kind":"Name","value":"isDraft"}},{"kind":"Field","name":{"kind":"Name","value":"isImportant"}},{"kind":"Field","name":{"kind":"Name","value":"projectId"}},{"kind":"Field","name":{"kind":"Name","value":"sortTs"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}},{"kind":"Field","name":{"kind":"Name","value":"updatedAt"}},{"kind":"Field","name":{"kind":"Name","value":"viewedAt"}},{"kind":"Field","name":{"kind":"Name","value":"participants"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"linkId"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"email"}},{"kind":"Field","name":{"kind":"Name","value":"sfsPhotoUrl"}}]}},{"kind":"Field","name":{"kind":"Name","value":"attachments"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"messageId"}},{"kind":"Field","name":{"kind":"Name","value":"providerAttachmentId"}},{"kind":"Field","name":{"kind":"Name","value":"filename"}},{"kind":"Field","name":{"kind":"Name","value":"mimeType"}},{"kind":"Field","name":{"kind":"Name","value":"sizeBytes"}},{"kind":"Field","name":{"kind":"Name","value":"contentId"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}}]}},{"kind":"Field","name":{"kind":"Name","value":"labels"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"linkId"}},{"kind":"Field","name":{"kind":"Name","value":"providerLabelId"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}},{"kind":"Field","name":{"kind":"Name","value":"messageListVisibility"}},{"kind":"Field","name":{"kind":"Name","value":"labelListVisibility"}},{"kind":"Field","name":{"kind":"Name","value":"type"}}]}},{"kind":"Field","name":{"kind":"Name","value":"properties"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"SoupPropertyFields"}}]}},{"kind":"Field","name":{"kind":"Name","value":"notifications"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"SoupNotificationFields"}}]}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"GraphqlSoupChannel"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","alias":{"kind":"Name","value":"channelName"},"name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"channelType"}},{"kind":"Field","name":{"kind":"Name","value":"ownerId"}},{"kind":"Field","name":{"kind":"Name","value":"organizationId"}},{"kind":"Field","alias":{"kind":"Name","value":"channelTeamId"},"name":{"kind":"Name","value":"teamId"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}},{"kind":"Field","name":{"kind":"Name","value":"updatedAt"}},{"kind":"Field","name":{"kind":"Name","value":"viewedAt"}},{"kind":"Field","name":{"kind":"Name","value":"interactedAt"}},{"kind":"Field","name":{"kind":"Name","value":"participants"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"channelId"}},{"kind":"Field","name":{"kind":"Name","value":"userId"}},{"kind":"Field","name":{"kind":"Name","value":"role"}},{"kind":"Field","name":{"kind":"Name","value":"joinedAt"}},{"kind":"Field","name":{"kind":"Name","value":"leftAt"}}]}},{"kind":"Field","name":{"kind":"Name","value":"latestMessage"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"SoupChannelMessageFields"}}]}},{"kind":"Field","name":{"kind":"Name","value":"latestNonThreadMessage"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"SoupChannelMessageFields"}}]}},{"kind":"Field","name":{"kind":"Name","value":"notifications"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"SoupNotificationFields"}}]}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"GraphqlSoupChannelThread"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"channelId"}},{"kind":"Field","name":{"kind":"Name","value":"senderId"}},{"kind":"Field","name":{"kind":"Name","value":"content"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}},{"kind":"Field","name":{"kind":"Name","value":"updatedAt"}},{"kind":"Field","name":{"kind":"Name","value":"effectiveUpdatedAt"}},{"kind":"Field","name":{"kind":"Name","value":"replyCount"}},{"kind":"Field","name":{"kind":"Name","value":"notifications"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"SoupNotificationFields"}}]}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"GraphqlSoupCall"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"channelId"}},{"kind":"Field","name":{"kind":"Name","value":"channelName"}},{"kind":"Field","name":{"kind":"Name","value":"createdBy"}},{"kind":"Field","name":{"kind":"Name","value":"customName"}},{"kind":"Field","name":{"kind":"Name","value":"summary"}},{"kind":"Field","name":{"kind":"Name","value":"startedAt"}},{"kind":"Field","name":{"kind":"Name","value":"endedAt"}},{"kind":"Field","name":{"kind":"Name","value":"durationMs"}},{"kind":"Field","name":{"kind":"Name","value":"isActive"}},{"kind":"Field","name":{"kind":"Name","value":"status"}},{"kind":"Field","name":{"kind":"Name","value":"attended"}},{"kind":"Field","name":{"kind":"Name","value":"participants"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"userId"}},{"kind":"Field","name":{"kind":"Name","value":"joinedAt"}},{"kind":"Field","name":{"kind":"Name","value":"leftAt"}}]}},{"kind":"Field","name":{"kind":"Name","value":"properties"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"SoupPropertyFields"}}]}},{"kind":"Field","name":{"kind":"Name","value":"notifications"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"SoupNotificationFields"}}]}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"GraphqlSoupCrmCompany"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","alias":{"kind":"Name","value":"crmTeamId"},"name":{"kind":"Name","value":"teamId"}},{"kind":"Field","alias":{"kind":"Name","value":"crmCompanyName"},"name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"description"}},{"kind":"Field","name":{"kind":"Name","value":"emailSync"}},{"kind":"Field","name":{"kind":"Name","value":"hidden"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}},{"kind":"Field","name":{"kind":"Name","value":"updatedAt"}},{"kind":"Field","name":{"kind":"Name","value":"viewedAt"}},{"kind":"Field","name":{"kind":"Name","value":"domains"}},{"kind":"Field","name":{"kind":"Name","value":"properties"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"SoupPropertyFields"}}]}},{"kind":"Field","name":{"kind":"Name","value":"notifications"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"SoupNotificationFields"}}]}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"GraphqlSoupForeignEntity"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"foreignEntityId"}},{"kind":"Field","name":{"kind":"Name","value":"foreignEntitySource"}},{"kind":"Field","name":{"kind":"Name","value":"storedForId"}},{"kind":"Field","name":{"kind":"Name","value":"storedForAuthEntity"}},{"kind":"Field","name":{"kind":"Name","value":"metadata"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}},{"kind":"Field","name":{"kind":"Name","value":"updatedAt"}},{"kind":"Field","name":{"kind":"Name","value":"notifications"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"SoupNotificationFields"}}]}}]}}]}}]}},{"kind":"Field","name":{"kind":"Name","value":"nextCursor"}},{"kind":"Field","name":{"kind":"Name","value":"hasMore"}}]}}]}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"SoupPropertyFields"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"GraphqlProperty"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"propertyDefinitionId"}},{"kind":"Field","name":{"kind":"Name","value":"displayName"}},{"kind":"Field","name":{"kind":"Name","value":"dataType"}},{"kind":"Field","name":{"kind":"Name","value":"isMultiSelect"}},{"kind":"Field","name":{"kind":"Name","value":"specificEntityType"}},{"kind":"Field","name":{"kind":"Name","value":"isSystem"}},{"kind":"Field","name":{"kind":"Name","value":"isMetadata"}},{"kind":"Field","name":{"kind":"Name","value":"value"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"__typename"}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"GraphqlBooleanPropertyValue"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","alias":{"kind":"Name","value":"boolValue"},"name":{"kind":"Name","value":"value"}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"GraphqlNumberPropertyValue"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","alias":{"kind":"Name","value":"numberValue"},"name":{"kind":"Name","value":"value"}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"GraphqlStringPropertyValue"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","alias":{"kind":"Name","value":"stringValue"},"name":{"kind":"Name","value":"value"}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"GraphqlDatePropertyValue"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","alias":{"kind":"Name","value":"dateValue"},"name":{"kind":"Name","value":"value"}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"GraphqlSelectOptionPropertyValue"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"optionIds"}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"GraphqlEntityReferencePropertyValue"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"references"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"entityId"}},{"kind":"Field","name":{"kind":"Name","value":"entityType"}},{"kind":"Field","name":{"kind":"Name","value":"specificMessageId"}}]}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"GraphqlLinkPropertyValue"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"urls"}}]}}]}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"SoupNotificationFields"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"GraphqlSoupNotification"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"eventType"}},{"kind":"Field","name":{"kind":"Name","value":"entityType"}},{"kind":"Field","name":{"kind":"Name","value":"entityId"}},{"kind":"Field","name":{"kind":"Name","value":"sent"}},{"kind":"Field","name":{"kind":"Name","value":"done"}},{"kind":"Field","name":{"kind":"Name","value":"seen"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}},{"kind":"Field","name":{"kind":"Name","value":"viewedAt"}},{"kind":"Field","name":{"kind":"Name","value":"updatedAt"}},{"kind":"Field","name":{"kind":"Name","value":"senderId"}},{"kind":"Field","name":{"kind":"Name","value":"metadata"}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"SoupChannelMessageFields"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"GraphqlSoupChannelMessage"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"threadId"}},{"kind":"Field","name":{"kind":"Name","value":"senderId"}},{"kind":"Field","name":{"kind":"Name","value":"content"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}},{"kind":"Field","name":{"kind":"Name","value":"updatedAt"}},{"kind":"Field","name":{"kind":"Name","value":"deletedAt"}},{"kind":"Field","name":{"kind":"Name","value":"mentions"}}]}}]} as unknown as DocumentNode<SoupQuery, SoupQueryVariables>;
+export const SoupDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"Soup"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"SoupInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"user"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"soup"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"items"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"entityType"}},{"kind":"Field","name":{"kind":"Name","value":"frecencyScore"}},{"kind":"Field","name":{"kind":"Name","value":"entity"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"__typename"}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"GraphqlSoupDocument"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","alias":{"kind":"Name","value":"documentName"},"name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"ownerId"}},{"kind":"Field","name":{"kind":"Name","value":"fileType"}},{"kind":"Field","name":{"kind":"Name","value":"projectId"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}},{"kind":"Field","name":{"kind":"Name","value":"updatedAt"}},{"kind":"Field","name":{"kind":"Name","value":"viewedAt"}},{"kind":"Field","name":{"kind":"Name","value":"deletedAt"}},{"kind":"Field","name":{"kind":"Name","value":"subType"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"kind"}},{"kind":"Field","name":{"kind":"Name","value":"isCompleted"}}]}},{"kind":"Field","name":{"kind":"Name","value":"properties"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"SoupPropertyFields"}}]}},{"kind":"Field","name":{"kind":"Name","value":"notifications"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"SoupNotificationFields"}}]}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"GraphqlSoupChat"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","alias":{"kind":"Name","value":"chatName"},"name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"ownerId"}},{"kind":"Field","name":{"kind":"Name","value":"projectId"}},{"kind":"Field","name":{"kind":"Name","value":"isPersistent"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}},{"kind":"Field","name":{"kind":"Name","value":"updatedAt"}},{"kind":"Field","name":{"kind":"Name","value":"viewedAt"}},{"kind":"Field","name":{"kind":"Name","value":"deletedAt"}},{"kind":"Field","name":{"kind":"Name","value":"properties"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"SoupPropertyFields"}}]}},{"kind":"Field","name":{"kind":"Name","value":"notifications"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"SoupNotificationFields"}}]}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"GraphqlSoupProject"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","alias":{"kind":"Name","value":"projectName"},"name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"ownerId"}},{"kind":"Field","name":{"kind":"Name","value":"parentId"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}},{"kind":"Field","name":{"kind":"Name","value":"updatedAt"}},{"kind":"Field","name":{"kind":"Name","value":"viewedAt"}},{"kind":"Field","name":{"kind":"Name","value":"deletedAt"}},{"kind":"Field","name":{"kind":"Name","value":"properties"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"SoupPropertyFields"}}]}},{"kind":"Field","name":{"kind":"Name","value":"notifications"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"SoupNotificationFields"}}]}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"GraphqlSoupEmailThread"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"providerId"}},{"kind":"Field","name":{"kind":"Name","value":"ownerId"}},{"kind":"Field","name":{"kind":"Name","value":"inboxVisible"}},{"kind":"Field","name":{"kind":"Name","value":"linkId"}},{"kind":"Field","alias":{"kind":"Name","value":"emailName"},"name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"snippet"}},{"kind":"Field","name":{"kind":"Name","value":"senderEmail"}},{"kind":"Field","name":{"kind":"Name","value":"senderName"}},{"kind":"Field","name":{"kind":"Name","value":"senderPhotoUrl"}},{"kind":"Field","name":{"kind":"Name","value":"isRead"}},{"kind":"Field","name":{"kind":"Name","value":"isDraft"}},{"kind":"Field","name":{"kind":"Name","value":"isImportant"}},{"kind":"Field","name":{"kind":"Name","value":"projectId"}},{"kind":"Field","name":{"kind":"Name","value":"sortTs"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}},{"kind":"Field","name":{"kind":"Name","value":"updatedAt"}},{"kind":"Field","name":{"kind":"Name","value":"viewedAt"}},{"kind":"Field","name":{"kind":"Name","value":"participants"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"linkId"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"email"}},{"kind":"Field","name":{"kind":"Name","value":"sfsPhotoUrl"}}]}},{"kind":"Field","name":{"kind":"Name","value":"attachments"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"messageId"}},{"kind":"Field","name":{"kind":"Name","value":"providerAttachmentId"}},{"kind":"Field","name":{"kind":"Name","value":"filename"}},{"kind":"Field","name":{"kind":"Name","value":"mimeType"}},{"kind":"Field","name":{"kind":"Name","value":"sizeBytes"}},{"kind":"Field","name":{"kind":"Name","value":"contentId"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}}]}},{"kind":"Field","name":{"kind":"Name","value":"labels"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"linkId"}},{"kind":"Field","name":{"kind":"Name","value":"providerLabelId"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}},{"kind":"Field","name":{"kind":"Name","value":"messageListVisibility"}},{"kind":"Field","name":{"kind":"Name","value":"labelListVisibility"}},{"kind":"Field","name":{"kind":"Name","value":"type"}}]}},{"kind":"Field","name":{"kind":"Name","value":"properties"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"SoupPropertyFields"}}]}},{"kind":"Field","name":{"kind":"Name","value":"notifications"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"SoupNotificationFields"}}]}},{"kind":"Field","name":{"kind":"Name","value":"latestContentMessage"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"__typename"}},{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"threadId"}},{"kind":"Field","name":{"kind":"Name","value":"linkId"}},{"kind":"Field","name":{"kind":"Name","value":"subject"}},{"kind":"Field","name":{"kind":"Name","value":"snippet"}},{"kind":"Field","name":{"kind":"Name","value":"internalDateTs"}},{"kind":"Field","name":{"kind":"Name","value":"sentAt"}},{"kind":"Field","name":{"kind":"Name","value":"isRead"}},{"kind":"Field","name":{"kind":"Name","value":"isStarred"}},{"kind":"Field","name":{"kind":"Name","value":"isSent"}},{"kind":"Field","name":{"kind":"Name","value":"hasAttachments"}},{"kind":"Field","name":{"kind":"Name","value":"from"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"email"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"photoUrl"}}]}},{"kind":"Field","name":{"kind":"Name","value":"to"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"email"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"photoUrl"}}]}},{"kind":"Field","name":{"kind":"Name","value":"cc"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"email"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"photoUrl"}}]}},{"kind":"Field","name":{"kind":"Name","value":"bcc"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"email"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"photoUrl"}}]}},{"kind":"Field","name":{"kind":"Name","value":"labels"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"providerLabelId"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}},{"kind":"Field","name":{"kind":"Name","value":"bodyParsed"}},{"kind":"Field","name":{"kind":"Name","value":"bodyText"}},{"kind":"Field","name":{"kind":"Name","value":"bodyHtmlSanitized"}},{"kind":"Field","name":{"kind":"Name","value":"bodyMacro"}},{"kind":"Field","name":{"kind":"Name","value":"bodyReplyless"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}},{"kind":"Field","name":{"kind":"Name","value":"updatedAt"}}]}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"GraphqlSoupChannel"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","alias":{"kind":"Name","value":"channelName"},"name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"channelType"}},{"kind":"Field","name":{"kind":"Name","value":"ownerId"}},{"kind":"Field","name":{"kind":"Name","value":"organizationId"}},{"kind":"Field","alias":{"kind":"Name","value":"channelTeamId"},"name":{"kind":"Name","value":"teamId"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}},{"kind":"Field","name":{"kind":"Name","value":"updatedAt"}},{"kind":"Field","name":{"kind":"Name","value":"viewedAt"}},{"kind":"Field","name":{"kind":"Name","value":"interactedAt"}},{"kind":"Field","name":{"kind":"Name","value":"participants"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"channelId"}},{"kind":"Field","name":{"kind":"Name","value":"userId"}},{"kind":"Field","name":{"kind":"Name","value":"role"}},{"kind":"Field","name":{"kind":"Name","value":"joinedAt"}},{"kind":"Field","name":{"kind":"Name","value":"leftAt"}}]}},{"kind":"Field","name":{"kind":"Name","value":"latestMessage"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"SoupChannelMessageFields"}}]}},{"kind":"Field","name":{"kind":"Name","value":"latestNonThreadMessage"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"SoupChannelMessageFields"}}]}},{"kind":"Field","name":{"kind":"Name","value":"notifications"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"SoupNotificationFields"}}]}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"GraphqlSoupChannelThread"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"channelId"}},{"kind":"Field","name":{"kind":"Name","value":"senderId"}},{"kind":"Field","name":{"kind":"Name","value":"content"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}},{"kind":"Field","name":{"kind":"Name","value":"updatedAt"}},{"kind":"Field","name":{"kind":"Name","value":"effectiveUpdatedAt"}},{"kind":"Field","name":{"kind":"Name","value":"replyCount"}},{"kind":"Field","name":{"kind":"Name","value":"notifications"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"SoupNotificationFields"}}]}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"GraphqlSoupCall"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"channelId"}},{"kind":"Field","name":{"kind":"Name","value":"channelName"}},{"kind":"Field","name":{"kind":"Name","value":"createdBy"}},{"kind":"Field","name":{"kind":"Name","value":"customName"}},{"kind":"Field","name":{"kind":"Name","value":"summary"}},{"kind":"Field","name":{"kind":"Name","value":"startedAt"}},{"kind":"Field","name":{"kind":"Name","value":"endedAt"}},{"kind":"Field","name":{"kind":"Name","value":"durationMs"}},{"kind":"Field","name":{"kind":"Name","value":"isActive"}},{"kind":"Field","name":{"kind":"Name","value":"status"}},{"kind":"Field","name":{"kind":"Name","value":"attended"}},{"kind":"Field","name":{"kind":"Name","value":"participants"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"userId"}},{"kind":"Field","name":{"kind":"Name","value":"joinedAt"}},{"kind":"Field","name":{"kind":"Name","value":"leftAt"}}]}},{"kind":"Field","name":{"kind":"Name","value":"properties"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"SoupPropertyFields"}}]}},{"kind":"Field","name":{"kind":"Name","value":"notifications"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"SoupNotificationFields"}}]}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"GraphqlSoupCrmCompany"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","alias":{"kind":"Name","value":"crmTeamId"},"name":{"kind":"Name","value":"teamId"}},{"kind":"Field","alias":{"kind":"Name","value":"crmCompanyName"},"name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"description"}},{"kind":"Field","name":{"kind":"Name","value":"emailSync"}},{"kind":"Field","name":{"kind":"Name","value":"hidden"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}},{"kind":"Field","name":{"kind":"Name","value":"updatedAt"}},{"kind":"Field","name":{"kind":"Name","value":"viewedAt"}},{"kind":"Field","name":{"kind":"Name","value":"domains"}},{"kind":"Field","name":{"kind":"Name","value":"properties"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"SoupPropertyFields"}}]}},{"kind":"Field","name":{"kind":"Name","value":"notifications"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"SoupNotificationFields"}}]}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"GraphqlSoupForeignEntity"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"foreignEntityId"}},{"kind":"Field","name":{"kind":"Name","value":"foreignEntitySource"}},{"kind":"Field","name":{"kind":"Name","value":"storedForId"}},{"kind":"Field","name":{"kind":"Name","value":"storedForAuthEntity"}},{"kind":"Field","name":{"kind":"Name","value":"metadata"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}},{"kind":"Field","name":{"kind":"Name","value":"updatedAt"}},{"kind":"Field","name":{"kind":"Name","value":"notifications"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"SoupNotificationFields"}}]}}]}}]}}]}},{"kind":"Field","name":{"kind":"Name","value":"nextCursor"}},{"kind":"Field","name":{"kind":"Name","value":"hasMore"}}]}}]}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"SoupPropertyFields"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"GraphqlProperty"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"propertyDefinitionId"}},{"kind":"Field","name":{"kind":"Name","value":"displayName"}},{"kind":"Field","name":{"kind":"Name","value":"dataType"}},{"kind":"Field","name":{"kind":"Name","value":"isMultiSelect"}},{"kind":"Field","name":{"kind":"Name","value":"specificEntityType"}},{"kind":"Field","name":{"kind":"Name","value":"isSystem"}},{"kind":"Field","name":{"kind":"Name","value":"isMetadata"}},{"kind":"Field","name":{"kind":"Name","value":"value"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"__typename"}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"GraphqlBooleanPropertyValue"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","alias":{"kind":"Name","value":"boolValue"},"name":{"kind":"Name","value":"value"}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"GraphqlNumberPropertyValue"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","alias":{"kind":"Name","value":"numberValue"},"name":{"kind":"Name","value":"value"}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"GraphqlStringPropertyValue"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","alias":{"kind":"Name","value":"stringValue"},"name":{"kind":"Name","value":"value"}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"GraphqlDatePropertyValue"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","alias":{"kind":"Name","value":"dateValue"},"name":{"kind":"Name","value":"value"}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"GraphqlSelectOptionPropertyValue"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"optionIds"}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"GraphqlEntityReferencePropertyValue"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"references"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"entityId"}},{"kind":"Field","name":{"kind":"Name","value":"entityType"}},{"kind":"Field","name":{"kind":"Name","value":"specificMessageId"}}]}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"GraphqlLinkPropertyValue"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"urls"}}]}}]}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"SoupNotificationFields"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"GraphqlSoupNotification"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"eventType"}},{"kind":"Field","name":{"kind":"Name","value":"entityType"}},{"kind":"Field","name":{"kind":"Name","value":"entityId"}},{"kind":"Field","name":{"kind":"Name","value":"sent"}},{"kind":"Field","name":{"kind":"Name","value":"done"}},{"kind":"Field","name":{"kind":"Name","value":"seen"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}},{"kind":"Field","name":{"kind":"Name","value":"viewedAt"}},{"kind":"Field","name":{"kind":"Name","value":"updatedAt"}},{"kind":"Field","name":{"kind":"Name","value":"senderId"}},{"kind":"Field","name":{"kind":"Name","value":"metadata"}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"SoupChannelMessageFields"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"GraphqlSoupChannelMessage"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"threadId"}},{"kind":"Field","name":{"kind":"Name","value":"senderId"}},{"kind":"Field","name":{"kind":"Name","value":"content"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}},{"kind":"Field","name":{"kind":"Name","value":"updatedAt"}},{"kind":"Field","name":{"kind":"Name","value":"deletedAt"}},{"kind":"Field","name":{"kind":"Name","value":"mentions"}}]}}]} as unknown as DocumentNode<SoupQuery, SoupQueryVariables>;

--- a/apps/web/src/lib/service-clients/service-storage/graphql/soup.graphql
+++ b/apps/web/src/lib/service-clients/service-storage/graphql/soup.graphql
@@ -114,6 +114,51 @@ query Soup($input: SoupInput!) {
 						notifications {
 							...SoupNotificationFields
 						}
+						latestContentMessage {
+							__typename
+							id
+							threadId
+							linkId
+							subject
+							snippet
+							internalDateTs
+							sentAt
+							isRead
+							isStarred
+							isSent
+							hasAttachments
+							from {
+								email
+								name
+								photoUrl
+							}
+							to {
+								email
+								name
+								photoUrl
+							}
+							cc {
+								email
+								name
+								photoUrl
+							}
+							bcc {
+								email
+								name
+								photoUrl
+							}
+							labels {
+								providerLabelId
+								name
+							}
+							bodyParsed
+							bodyText
+							bodyHtmlSanitized
+							bodyMacro
+							bodyReplyless
+							createdAt
+							updatedAt
+						}
 					}
 					... on GraphqlSoupChannel {
 						id


### PR DESCRIPTION
- Adds fetching the latest content message for emails with the email backfill

Still requires the email to use the cache. TODO in another PR