### PR TITLE
feat(teams): support enterprise contract teams

### DIFF
--- a/.sqlx/query-14df98e291c38661eb60224a93d61fda30583f9fafae4fde8b1ba73974e4d914.json
+++ b/.sqlx/query-14df98e291c38661eb60224a93d61fda30583f9fafae4fde8b1ba73974e4d914.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT enterprise\n            FROM team\n            WHERE id = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "enterprise",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "14df98e291c38661eb60224a93d61fda30583f9fafae4fde8b1ba73974e4d914"
+}

--- a/.sqlx/query-58e9a0467f6c0795abbf9ebba05ee30f28de0dee4cc6d1c7a84b0c55ca05d27c.json
+++ b/.sqlx/query-58e9a0467f6c0795abbf9ebba05ee30f28de0dee4cc6d1c7a84b0c55ca05d27c.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            INSERT INTO team (id, name, owner_id, seat_count, subscription_id, paying)\n            VALUES ($1, $2, $3, 1, $4, TRUE)\n            RETURNING id, name, slug, owner_id\n            ",
+  "query": "\n            INSERT INTO team (id, name, owner_id, seat_count, subscription_id, paying)\n            VALUES ($1, $2, $3, 1, $4, TRUE)\n            RETURNING id, name, slug, owner_id, enterprise\n            ",
   "describe": {
     "columns": [
       {
@@ -22,6 +22,11 @@
         "ordinal": 3,
         "name": "owner_id",
         "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "enterprise",
+        "type_info": "Bool"
       }
     ],
     "parameters": {
@@ -36,8 +41,9 @@
       false,
       false,
       false,
+      false,
       false
     ]
   },
-  "hash": "b3908e74b7e17fe7a0910abf70f933a832d32ef6df78eb3e327b4fe282dd67ed"
+  "hash": "58e9a0467f6c0795abbf9ebba05ee30f28de0dee4cc6d1c7a84b0c55ca05d27c"
 }

--- a/.sqlx/query-8412cb4e4925bf7d8ff2ebf5ece3a13570a0df3f222d81e7ff90a1e27c564697.json
+++ b/.sqlx/query-8412cb4e4925bf7d8ff2ebf5ece3a13570a0df3f222d81e7ff90a1e27c564697.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            SELECT t.id, t.name, t.slug, t.owner_id, t.auto_join_domain,\n                COALESCE(tcs.crm_enabled, FALSE) AS \"crm_enabled!\"\n            FROM team t\n            LEFT JOIN team_crm_settings tcs ON tcs.team_id = t.id\n            WHERE t.id = $1\n            ",
+  "query": "\n            SELECT t.id, t.name, t.slug, t.owner_id, t.auto_join_domain, t.enterprise,\n                COALESCE(tcs.crm_enabled, FALSE) AS \"crm_enabled!\"\n            FROM team t\n            LEFT JOIN team_crm_settings tcs ON tcs.team_id = t.id\n            WHERE t.id = $1\n            ",
   "describe": {
     "columns": [
       {
@@ -30,6 +30,11 @@
       },
       {
         "ordinal": 5,
+        "name": "enterprise",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 6,
         "name": "crm_enabled!",
         "type_info": "Bool"
       }
@@ -45,8 +50,9 @@
       false,
       false,
       true,
+      false,
       null
     ]
   },
-  "hash": "f9a6fffccca132ccefa2654e7e08d87320c51e5103e589615b475f18c3f07f68"
+  "hash": "8412cb4e4925bf7d8ff2ebf5ece3a13570a0df3f222d81e7ff90a1e27c564697"
 }

--- a/.sqlx/query-9c06e7ff3bf17ac4951964b0b9b4c191b8a66e46b15c1b19f93416650f8ea1ea.json
+++ b/.sqlx/query-9c06e7ff3bf17ac4951964b0b9b4c191b8a66e46b15c1b19f93416650f8ea1ea.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            SELECT t.id, t.name, t.slug, t.owner_id, t.auto_join_domain,\n                COALESCE(tcs.crm_enabled, FALSE) AS \"crm_enabled!\"\n            FROM team t\n            JOIN team_user tu ON t.id = tu.team_id\n            LEFT JOIN team_crm_settings tcs ON tcs.team_id = t.id\n            WHERE tu.user_id = $1\n            ",
+  "query": "\n            SELECT t.id, t.name, t.slug, t.owner_id, t.auto_join_domain, t.enterprise,\n                COALESCE(tcs.crm_enabled, FALSE) AS \"crm_enabled!\"\n            FROM team t\n            JOIN team_user tu ON t.id = tu.team_id\n            LEFT JOIN team_crm_settings tcs ON tcs.team_id = t.id\n            WHERE tu.user_id = $1\n            ",
   "describe": {
     "columns": [
       {
@@ -30,6 +30,11 @@
       },
       {
         "ordinal": 5,
+        "name": "enterprise",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 6,
         "name": "crm_enabled!",
         "type_info": "Bool"
       }
@@ -45,8 +50,9 @@
       false,
       false,
       true,
+      false,
       null
     ]
   },
-  "hash": "bbf73370ac43c4f2378584e005b10a8d854b7c0203978dfb28c2fa7a70996bdd"
+  "hash": "9c06e7ff3bf17ac4951964b0b9b4c191b8a66e46b15c1b19f93416650f8ea1ea"
 }

--- a/apps/web/src/lib/queries/team/teams.ts
+++ b/apps/web/src/lib/queries/team/teams.ts
@@ -171,12 +171,12 @@ export function useToggleAutoJoinDomainMutation(
           const applyDomain = (old: TeamWithMembers | null | undefined) =>
             old
               ? {
-                  ...old,
-                  team: {
-                    ...old.team,
-                    auto_join_domain: data.auto_join_domain ?? null,
-                  },
-                }
+                ...old,
+                team: {
+                  ...old.team,
+                  auto_join_domain: data.auto_join_domain ?? null,
+                },
+              }
               : old;
           queryClient.setQueryData<TeamWithMembers | null>(
             teamKeys.detail(teamId).queryKey,
@@ -320,6 +320,7 @@ export function useCreateTeamWithInvitesMutation(
               owner_id: userInfo.userId,
               crm_enabled: false,
               auto_join_domain: null,
+              enterprise: false,
             };
 
             queryClient.setQueryData<Team[]>(

--- a/apps/web/src/lib/queries/team/teams.ts
+++ b/apps/web/src/lib/queries/team/teams.ts
@@ -171,12 +171,12 @@ export function useToggleAutoJoinDomainMutation(
           const applyDomain = (old: TeamWithMembers | null | undefined) =>
             old
               ? {
-                ...old,
-                team: {
-                  ...old.team,
-                  auto_join_domain: data.auto_join_domain ?? null,
-                },
-              }
+                  ...old,
+                  team: {
+                    ...old.team,
+                    auto_join_domain: data.auto_join_domain ?? null,
+                  },
+                }
               : old;
           queryClient.setQueryData<TeamWithMembers | null>(
             teamKeys.detail(teamId).queryKey,

--- a/apps/web/src/lib/service-clients/service-auth/generated/schemas/team.ts
+++ b/apps/web/src/lib/service-clients/service-auth/generated/schemas/team.ts
@@ -16,6 +16,10 @@ with, when automatic domain joining is enabled (None otherwise). */
   /** Whether the CRM is enabled for this team (from `team_crm_settings`;
 `false` when no row exists). */
   crm_enabled: boolean;
+  /** Whether this team is on an enterprise license. Enterprise teams are
+billed out-of-band; membership changes skip all Stripe subscription
+bookkeeping (no seat counts, no subscription backfill, no paying check). */
+  enterprise: boolean;
   id: string;
   name: string;
   owner_id: string;

--- a/apps/web/src/lib/service-clients/service-auth/openapi.json
+++ b/apps/web/src/lib/service-clients/service-auth/openapi.json
@@ -4281,7 +4281,14 @@
       "Team": {
         "type": "object",
         "description": "The Team struct",
-        "required": ["id", "name", "slug", "owner_id", "crm_enabled"],
+        "required": [
+          "id",
+          "name",
+          "slug",
+          "owner_id",
+          "crm_enabled",
+          "enterprise"
+        ],
         "properties": {
           "auto_join_domain": {
             "type": ["string", "null"],
@@ -4290,6 +4297,10 @@
           "crm_enabled": {
             "type": "boolean",
             "description": "Whether the CRM is enabled for this team (from `team_crm_settings`;\n`false` when no row exists)."
+          },
+          "enterprise": {
+            "type": "boolean",
+            "description": "Whether this team is on an enterprise license. Enterprise teams are\nbilled out-of-band; membership changes skip all Stripe subscription\nbookkeeping (no seat counts, no subscription backfill, no paying check)."
           },
           "id": {
             "type": "string",

--- a/crates/macro_db_client/migrations/20260715190633_add_team_enterprise.sql
+++ b/crates/macro_db_client/migrations/20260715190633_add_team_enterprise.sql
@@ -1,0 +1,4 @@
+-- Enterprise teams are billed out-of-band; membership changes skip all
+-- Stripe subscription bookkeeping for them.
+ALTER TABLE team
+    ADD COLUMN enterprise BOOLEAN NOT NULL DEFAULT FALSE;

--- a/crates/teams/src/domain/model.rs
+++ b/crates/teams/src/domain/model.rs
@@ -330,6 +330,10 @@ pub struct Team {
     /// The email domain new users are automatically joined to this team
     /// with, when automatic domain joining is enabled (None otherwise).
     pub(crate) auto_join_domain: Option<String>,
+    /// Whether this team is on an enterprise license. Enterprise teams are
+    /// billed out-of-band; membership changes skip all Stripe subscription
+    /// bookkeeping (no seat counts, no subscription backfill, no paying check).
+    pub(crate) enterprise: bool,
 }
 
 impl Team {
@@ -341,6 +345,7 @@ impl Team {
         slug: String,
         owner_id: MacroUserIdStr<'static>,
         crm_enabled: bool,
+        enterprise: bool,
     ) -> Self {
         Self {
             id,
@@ -349,6 +354,7 @@ impl Team {
             owner_id,
             crm_enabled,
             auto_join_domain: None,
+            enterprise,
         }
     }
 }
@@ -382,6 +388,11 @@ impl Team {
     /// The team's auto-join domain, when automatic domain joining is enabled
     pub fn auto_join_domain(&self) -> Option<&str> {
         self.auto_join_domain.as_deref()
+    }
+
+    /// Whether this team is on an enterprise license
+    pub fn enterprise(&self) -> bool {
+        self.enterprise
     }
 }
 

--- a/crates/teams/src/domain/model/test.rs
+++ b/crates/teams/src/domain/model/test.rs
@@ -14,6 +14,36 @@ fn assert_preserves_customer_storage_error(error: impl std::fmt::Display) {
     );
 }
 
+fn team_with_enterprise_status(enterprise: bool) -> Team {
+    Team::new(
+        uuid::Uuid::nil(),
+        "Test Team".to_string(),
+        "TEST_TEAM".to_string(),
+        MacroUserIdStr::parse_from_str("macro|owner@example.com").unwrap(),
+        false,
+        enterprise,
+    )
+}
+
+#[test]
+fn team_enterprise_accessor_preserves_constructor_value() {
+    for enterprise in [false, true] {
+        assert_eq!(
+            team_with_enterprise_status(enterprise).enterprise(),
+            enterprise
+        );
+    }
+}
+
+#[test]
+fn serialized_team_preserves_enterprise_value() {
+    for enterprise in [false, true] {
+        let serialized = serde_json::to_value(team_with_enterprise_status(enterprise)).unwrap();
+
+        assert_eq!(serialized["enterprise"], enterprise);
+    }
+}
+
 #[test]
 fn invite_users_to_team_error_preserves_customer_storage_error() {
     let error = InviteUsersToTeamError::from(customer_storage_error());

--- a/crates/teams/src/domain/team_repo.rs
+++ b/crates/teams/src/domain/team_repo.rs
@@ -58,6 +58,12 @@ pub trait TeamRepository: Clone + Send + Sync + 'static {
         team_id: &uuid::Uuid,
     ) -> impl Future<Output = Result<bool, TeamError>> + Send;
 
+    /// Returns whether the team uses enterprise billing.
+    fn get_team_enterprise_status(
+        &self,
+        team_id: &uuid::Uuid,
+    ) -> impl Future<Output = Result<bool, TeamError>> + Send;
+
     /// Creates a new team
     fn create_team(
         &self,

--- a/crates/teams/src/domain/team_service.rs
+++ b/crates/teams/src/domain/team_service.rs
@@ -476,10 +476,16 @@ where
         let team_id =
             macro_uuid::string_to_uuid(&entity_access_receipt.entity().entity_id).unwrap();
 
-        if !self
+        let enterprise = self
             .team_repository
-            .get_team_payment_status(&team_id)
-            .await?
+            .get_team_enterprise_status(&team_id)
+            .await?;
+
+        if !enterprise
+            && !self
+                .team_repository
+                .get_team_payment_status(&team_id)
+                .await?
         {
             // If the team has a subscription id and they are set to not paying continue to error
             if self

--- a/crates/teams/src/domain/team_service.rs
+++ b/crates/teams/src/domain/team_service.rs
@@ -847,84 +847,110 @@ where
             .map_err(JoinTeamError::TeamError)?;
 
         let team_member = accepted_invite.member.clone();
-
-        if !self
+        let enterprise = match self
             .team_repository
-            .get_team_payment_status(&team_member.team_id)
-            .await?
+            .get_team_enterprise_status(&team_member.team_id)
+            .await
         {
-            // If the team has a subscription id and they are set to not paying continue to error
-            if self
-                .team_repository
-                .get_team_subscription_id(&accepted_invite.member.team_id)
-                .await?
-                .is_some()
-            {
+            Ok(enterprise) => enterprise,
+            Err(error) => {
                 self.team_repository
                     .rollback_accept_team_invite(&accepted_invite)
                     .await
                     .inspect_err(|rollback_err| {
                         tracing::error!(
                             error=?rollback_err,
-                            "unable to rollback accepted team invite after getting team subscription failed"
+                            "unable to rollback accepted team invite after getting enterprise status failed"
                         );
                     })
                     .ok();
-                return Err(JoinTeamError::TeamError(TeamError::TeamNotPaying));
-            }
-
-            if let Err(e) = self
-                .backfill_legacy_team_subscription(&accepted_invite.member.team_id)
-                .await
-            {
-                self.team_repository
-                    .rollback_accept_team_invite(&accepted_invite)
-                    .await
-                    .inspect_err(|rollback_err| {
-                        tracing::error!(
-                            error=?rollback_err,
-                            "unable to rollback accepted team invite after backfilling team subscription failed"
-                        );
-                    })
-                    .ok();
-                return Err(e.into_join_team_error());
-            }
-        }
-
-        let subscription_id = match self.get_team_subscription(&team_member.team_id).await {
-            Ok(subscription_id) => subscription_id,
-            Err(e) => {
-                self.team_repository
-                    .rollback_accept_team_invite(&accepted_invite)
-                    .await
-                    .inspect_err(|rollback_err| {
-                        tracing::error!(
-                            error=?rollback_err,
-                            "unable to rollback accepted team invite after getting team subscription failed"
-                        );
-                    })
-                    .ok();
-                return Err(e.into_join_team_error());
+                return Err(JoinTeamError::TeamError(error));
             }
         };
 
-        if let Err(e) = self
-            .customer_repository
-            .increment_seat_count(&subscription_id, 1)
-            .await
-        {
-            self.team_repository
-                .rollback_accept_team_invite(&accepted_invite)
+        let subscription_id = if enterprise {
+            None
+        } else {
+            if !self
+                .team_repository
+                .get_team_payment_status(&team_member.team_id)
+                .await?
+            {
+                // If the team has a subscription id and they are set to not paying continue to error
+                if self
+                    .team_repository
+                    .get_team_subscription_id(&accepted_invite.member.team_id)
+                    .await?
+                    .is_some()
+                {
+                    self.team_repository
+                        .rollback_accept_team_invite(&accepted_invite)
+                        .await
+                        .inspect_err(|rollback_err| {
+                            tracing::error!(
+                                error=?rollback_err,
+                                "unable to rollback accepted team invite after getting team subscription failed"
+                            );
+                        })
+                        .ok();
+                    return Err(JoinTeamError::TeamError(TeamError::TeamNotPaying));
+                }
+
+                if let Err(e) = self
+                    .backfill_legacy_team_subscription(&accepted_invite.member.team_id)
+                    .await
+                {
+                    self.team_repository
+                        .rollback_accept_team_invite(&accepted_invite)
+                        .await
+                        .inspect_err(|rollback_err| {
+                            tracing::error!(
+                                error=?rollback_err,
+                                "unable to rollback accepted team invite after backfilling team subscription failed"
+                            );
+                        })
+                        .ok();
+                    return Err(e.into_join_team_error());
+                }
+            }
+
+            let subscription_id = match self.get_team_subscription(&team_member.team_id).await {
+                Ok(subscription_id) => subscription_id,
+                Err(e) => {
+                    self.team_repository
+                        .rollback_accept_team_invite(&accepted_invite)
+                        .await
+                        .inspect_err(|rollback_err| {
+                            tracing::error!(
+                                error=?rollback_err,
+                                "unable to rollback accepted team invite after getting team subscription failed"
+                            );
+                        })
+                        .ok();
+                    return Err(e.into_join_team_error());
+                }
+            };
+
+            if let Err(e) = self
+                .customer_repository
+                .increment_seat_count(&subscription_id, 1)
                 .await
-                .inspect_err(|rollback_err| {
-                    tracing::error!(
-                        error=?rollback_err,
-                        "unable to rollback accepted team invite after incrementing seat count failed"
-                    );
-                })
-                .ok();
-            return Err(JoinTeamError::CustomerError(e));
-        }
+            {
+                self.team_repository
+                    .rollback_accept_team_invite(&accepted_invite)
+                    .await
+                    .inspect_err(|rollback_err| {
+                        tracing::error!(
+                            error=?rollback_err,
+                            "unable to rollback accepted team invite after incrementing seat count failed"
+                        );
+                    })
+                    .ok();
+                return Err(JoinTeamError::CustomerError(e));
+            }
+
+            Some(subscription_id)
+        };
 
         // subscribe the user to professional features from the TeamSubscriber role and the role associated with their tier
         let roles_to_add = vec![RoleId::TeamSubscriber, RoleId::SubOpus];
@@ -935,16 +961,18 @@ where
             .dangerous_upsert_roles_for_user(user_id, roles)
             .await
         {
-            self.customer_repository
-                .decrement_seat_count(&subscription_id, 1)
-                .await
-                .inspect_err(|rollback_err| {
-                    tracing::error!(
-                        error=?rollback_err,
-                        "unable to rollback customer seat count after adding team member roles failed"
-                    );
-                })
-                .ok();
+            if let Some(subscription_id) = subscription_id.as_ref() {
+                self.customer_repository
+                    .decrement_seat_count(subscription_id, 1)
+                    .await
+                    .inspect_err(|rollback_err| {
+                        tracing::error!(
+                            error=?rollback_err,
+                            "unable to rollback customer seat count after adding team member roles failed"
+                        );
+                    })
+                    .ok();
+            }
             self.team_repository
                 .rollback_accept_team_invite(&accepted_invite)
                 .await
@@ -974,16 +1002,18 @@ where
                     );
                 })
                 .ok();
-            self.customer_repository
-                .decrement_seat_count(&subscription_id, 1)
-                .await
-                .inspect_err(|rollback_err| {
-                    tracing::error!(
-                        error=?rollback_err,
-                        "unable to rollback customer seat count after adding team member to channels failed"
-                    );
-                })
-                .ok();
+            if let Some(subscription_id) = subscription_id.as_ref() {
+                self.customer_repository
+                    .decrement_seat_count(subscription_id, 1)
+                    .await
+                    .inspect_err(|rollback_err| {
+                        tracing::error!(
+                            error=?rollback_err,
+                            "unable to rollback customer seat count after adding team member to channels failed"
+                        );
+                    })
+                    .ok();
+            }
             self.team_repository
                 .rollback_accept_team_invite(&accepted_invite)
                 .await

--- a/crates/teams/src/domain/team_service.rs
+++ b/crates/teams/src/domain/team_service.rs
@@ -606,32 +606,43 @@ where
             .clone()
             .into_owned();
 
+        let enterprise = self
+            .team_repository
+            .get_team_enterprise_status(&team_id)
+            .await?;
+
         let removed_member = self
             .team_repository
             .remove_user_from_team(&team_id, user_id)
             .await?;
 
-        let subscription_id = match self.get_team_subscription(&team_id).await {
-            Ok(subscription_id) => subscription_id,
-            Err(e) => {
-                self.team_repository
-                    .rollback_remove_user_from_team(&removed_member)
-                    .await
-                    .inspect_err(|rollback_err| {
-                        tracing::error!(
-                            error=?rollback_err,
-                            "unable to rollback removed team member after getting team subscription failed"
-                        );
-                    })
-                    .ok();
-                return Err(e.into_remove_user_from_team_error());
-            }
+        let subscription_id = if enterprise {
+            None
+        } else {
+            let subscription_id = match self.get_team_subscription(&team_id).await {
+                Ok(subscription_id) => subscription_id,
+                Err(e) => {
+                    self.team_repository
+                        .rollback_remove_user_from_team(&removed_member)
+                        .await
+                        .inspect_err(|rollback_err| {
+                            tracing::error!(
+                                error=?rollback_err,
+                                "unable to rollback removed team member after getting team subscription failed"
+                            );
+                        })
+                        .ok();
+                    return Err(e.into_remove_user_from_team_error());
+                }
+            };
+            Some(subscription_id)
         };
 
-        if let Err(e) = self
-            .customer_repository
-            .decrement_seat_count(&subscription_id, 1)
-            .await
+        if let Some(subscription_id) = subscription_id.as_ref()
+            && let Err(e) = self
+                .customer_repository
+                .decrement_seat_count(subscription_id, 1)
+                .await
         {
             self.team_repository
                 .rollback_remove_user_from_team(&removed_member)
@@ -651,16 +662,18 @@ where
             .remove_team_member_from_channels(&team_id, user_id)
             .await
         {
-            self.customer_repository
-                .increment_seat_count(&subscription_id, 1)
-                .await
-                .inspect_err(|rollback_err| {
-                    tracing::error!(
-                        error=?rollback_err,
-                        "unable to rollback customer seat count after removing team member from channels failed"
-                    );
-                })
-                .ok();
+            if let Some(subscription_id) = subscription_id.as_ref() {
+                self.customer_repository
+                    .increment_seat_count(subscription_id, 1)
+                    .await
+                    .inspect_err(|rollback_err| {
+                        tracing::error!(
+                            error=?rollback_err,
+                            "unable to rollback customer seat count after removing team member from channels failed"
+                        );
+                    })
+                    .ok();
+            }
             self.team_repository
                 .rollback_remove_user_from_team(&removed_member)
                 .await
@@ -692,16 +705,18 @@ where
                     );
                 })
                 .ok();
-            self.customer_repository
-                .increment_seat_count(&subscription_id, 1)
-                .await
-                .inspect_err(|rollback_err| {
-                    tracing::error!(
-                        error=?rollback_err,
-                        "unable to rollback customer seat count after removing team member roles failed"
-                    );
-                })
-                .ok();
+            if let Some(subscription_id) = subscription_id.as_ref() {
+                self.customer_repository
+                    .increment_seat_count(subscription_id, 1)
+                    .await
+                    .inspect_err(|rollback_err| {
+                        tracing::error!(
+                            error=?rollback_err,
+                            "unable to rollback customer seat count after removing team member roles failed"
+                        );
+                    })
+                    .ok();
+            }
             self.team_repository
                 .rollback_remove_user_from_team(&removed_member)
                 .await

--- a/crates/teams/src/domain/team_service.rs
+++ b/crates/teams/src/domain/team_service.rs
@@ -886,18 +886,51 @@ where
         let subscription_id = if enterprise {
             None
         } else {
-            if !self
+            let team_payment_status = match self
                 .team_repository
                 .get_team_payment_status(&team_member.team_id)
-                .await?
+                .await
             {
+                Ok(team_payment_status) => team_payment_status,
+                Err(error) => {
+                    self.team_repository
+                        .rollback_accept_team_invite(&accepted_invite)
+                        .await
+                        .inspect_err(|rollback_err| {
+                            tracing::error!(
+                                error=?rollback_err,
+                                "unable to rollback accepted team invite after getting team payment status failed"
+                            );
+                        })
+                        .ok();
+                    return Err(JoinTeamError::TeamError(error));
+                }
+            };
+
+            if !team_payment_status {
                 // If the team has a subscription id and they are set to not paying continue to error
-                if self
+                let team_subscription_id = match self
                     .team_repository
                     .get_team_subscription_id(&accepted_invite.member.team_id)
-                    .await?
-                    .is_some()
+                    .await
                 {
+                    Ok(team_subscription_id) => team_subscription_id,
+                    Err(error) => {
+                        self.team_repository
+                            .rollback_accept_team_invite(&accepted_invite)
+                            .await
+                            .inspect_err(|rollback_err| {
+                                tracing::error!(
+                                    error=?rollback_err,
+                                    "unable to rollback accepted team invite after getting team subscription failed"
+                                );
+                            })
+                            .ok();
+                        return Err(JoinTeamError::TeamError(error));
+                    }
+                };
+
+                if team_subscription_id.is_some() {
                     self.team_repository
                         .rollback_accept_team_invite(&accepted_invite)
                         .await
@@ -1363,18 +1396,40 @@ where
         let subscription_id = if enterprise {
             None
         } else {
-            if !self
-                .team_repository
-                .get_team_payment_status(&team_id)
-                .await?
-            {
+            let team_payment_status =
+                match self.team_repository.get_team_payment_status(&team_id).await {
+                    Ok(team_payment_status) => team_payment_status,
+                    Err(error) => {
+                        self.rollback_add_user_to_team(
+                            &team_id,
+                            user_id,
+                            "getting team payment status",
+                        )
+                        .await;
+                        return Err(error.into());
+                    }
+                };
+
+            if !team_payment_status {
                 // If the team has a subscription id and they are set to not paying continue to error
-                if self
+                let team_subscription_id = match self
                     .team_repository
                     .get_team_subscription_id(&team_id)
-                    .await?
-                    .is_some()
+                    .await
                 {
+                    Ok(team_subscription_id) => team_subscription_id,
+                    Err(error) => {
+                        self.rollback_add_user_to_team(
+                            &team_id,
+                            user_id,
+                            "getting team subscription id",
+                        )
+                        .await;
+                        return Err(error.into());
+                    }
+                };
+
+                if team_subscription_id.is_some() {
                     self.rollback_add_user_to_team(&team_id, user_id, "the payment status check")
                         .await;
                     return Err(JoinTeamError::TeamError(TeamError::TeamNotPaying).into());

--- a/crates/teams/src/domain/team_service.rs
+++ b/crates/teams/src/domain/team_service.rs
@@ -1318,6 +1318,11 @@ where
             return Ok(None);
         };
 
+        let enterprise = self
+            .team_repository
+            .get_team_enterprise_status(&team_id)
+            .await?;
+
         // Mirror the seat-cap check from invite_users_to_team — an
         // auto-join must not push the team past its plan's seat cap.
         if let Some(team_plan) = self.team_repository.get_team_plan(&team_id).await? {
@@ -1340,48 +1345,58 @@ where
             return Ok(None);
         };
 
-        if !self
-            .team_repository
-            .get_team_payment_status(&team_id)
-            .await?
-        {
-            // If the team has a subscription id and they are set to not paying continue to error
-            if self
+        let subscription_id = if enterprise {
+            None
+        } else {
+            if !self
                 .team_repository
-                .get_team_subscription_id(&team_id)
+                .get_team_payment_status(&team_id)
                 .await?
-                .is_some()
             {
-                self.rollback_add_user_to_team(&team_id, user_id, "the payment status check")
+                // If the team has a subscription id and they are set to not paying continue to error
+                if self
+                    .team_repository
+                    .get_team_subscription_id(&team_id)
+                    .await?
+                    .is_some()
+                {
+                    self.rollback_add_user_to_team(&team_id, user_id, "the payment status check")
+                        .await;
+                    return Err(JoinTeamError::TeamError(TeamError::TeamNotPaying).into());
+                }
+
+                if let Err(e) = self.backfill_legacy_team_subscription(&team_id).await {
+                    self.rollback_add_user_to_team(
+                        &team_id,
+                        user_id,
+                        "backfilling team subscription",
+                    )
                     .await;
-                return Err(JoinTeamError::TeamError(TeamError::TeamNotPaying).into());
+                    return Err(e.into_join_team_error().into());
+                }
             }
 
-            if let Err(e) = self.backfill_legacy_team_subscription(&team_id).await {
-                self.rollback_add_user_to_team(&team_id, user_id, "backfilling team subscription")
-                    .await;
-                return Err(e.into_join_team_error().into());
-            }
-        }
+            let subscription_id = match self.get_team_subscription(&team_id).await {
+                Ok(subscription_id) => subscription_id,
+                Err(e) => {
+                    self.rollback_add_user_to_team(&team_id, user_id, "getting team subscription")
+                        .await;
+                    return Err(e.into_join_team_error().into());
+                }
+            };
 
-        let subscription_id = match self.get_team_subscription(&team_id).await {
-            Ok(subscription_id) => subscription_id,
-            Err(e) => {
-                self.rollback_add_user_to_team(&team_id, user_id, "getting team subscription")
+            if let Err(e) = self
+                .customer_repository
+                .increment_seat_count(&subscription_id, 1)
+                .await
+            {
+                self.rollback_add_user_to_team(&team_id, user_id, "incrementing seat count")
                     .await;
-                return Err(e.into_join_team_error().into());
+                return Err(JoinTeamError::CustomerError(e).into());
             }
+
+            Some(subscription_id)
         };
-
-        if let Err(e) = self
-            .customer_repository
-            .increment_seat_count(&subscription_id, 1)
-            .await
-        {
-            self.rollback_add_user_to_team(&team_id, user_id, "incrementing seat count")
-                .await;
-            return Err(JoinTeamError::CustomerError(e).into());
-        }
 
         // subscribe the user to professional features from the TeamSubscriber role and the role associated with their tier
         let roles_to_add = vec![RoleId::TeamSubscriber, RoleId::SubOpus];
@@ -1392,16 +1407,18 @@ where
             .dangerous_upsert_roles_for_user(user_id, roles)
             .await
         {
-            self.customer_repository
-                .decrement_seat_count(&subscription_id, 1)
-                .await
-                .inspect_err(|rollback_err| {
-                    tracing::error!(
-                        error=?rollback_err,
-                        "unable to rollback customer seat count after adding team member roles failed"
-                    );
-                })
-                .ok();
+            if let Some(subscription_id) = subscription_id.as_ref() {
+                self.customer_repository
+                    .decrement_seat_count(subscription_id, 1)
+                    .await
+                    .inspect_err(|rollback_err| {
+                        tracing::error!(
+                            error=?rollback_err,
+                            "unable to rollback customer seat count after adding team member roles failed"
+                        );
+                    })
+                    .ok();
+            }
             self.rollback_add_user_to_team(&team_id, user_id, "adding team member roles")
                 .await;
             return Err(JoinTeamError::AddRolesToUserError(e).into());
@@ -1423,16 +1440,18 @@ where
                     );
                 })
                 .ok();
-            self.customer_repository
-                .decrement_seat_count(&subscription_id, 1)
-                .await
-                .inspect_err(|rollback_err| {
-                    tracing::error!(
-                        error=?rollback_err,
-                        "unable to rollback customer seat count after adding team member to channels failed"
-                    );
-                })
-                .ok();
+            if let Some(subscription_id) = subscription_id.as_ref() {
+                self.customer_repository
+                    .decrement_seat_count(subscription_id, 1)
+                    .await
+                    .inspect_err(|rollback_err| {
+                        tracing::error!(
+                            error=?rollback_err,
+                            "unable to rollback customer seat count after adding team member to channels failed"
+                        );
+                    })
+                    .ok();
+            }
             self.rollback_add_user_to_team(&team_id, user_id, "adding team member to channels")
                 .await;
             return Err(JoinTeamError::TeamError(e).into());

--- a/crates/teams/src/domain/team_service/test.rs
+++ b/crates/teams/src/domain/team_service/test.rs
@@ -58,9 +58,12 @@ struct MockTeamRepository {
     mark_sent_calls: Arc<Mutex<Vec<Vec<uuid::Uuid>>>>,
     team_for_get_by_id: Option<Team>,
     team_subscription_id: Option<stripe::SubscriptionId>,
+    team_subscription_id_lookup_calls: Arc<Mutex<usize>>,
     backfilled_subscription_id: Arc<Mutex<Option<stripe::SubscriptionId>>>,
     stripe_customer_id: Option<stripe::CustomerId>,
+    stripe_customer_id_lookup_calls: Arc<Mutex<usize>>,
     team_payment_status: bool,
+    team_payment_status_lookup_calls: Arc<Mutex<usize>>,
     enterprise: bool,
     enterprise_status_lookup_calls: Arc<Mutex<usize>>,
     fail_enterprise_status_lookup: bool,
@@ -79,6 +82,8 @@ struct MockTeamRepository {
     payment_update_calls: Arc<Mutex<Vec<(uuid::Uuid, bool)>>>,
     fail_github_installation_move: bool,
     fail_invite_users_to_team: bool,
+    invite_users_to_team_calls: Arc<Mutex<usize>>,
+    get_team_by_id_calls: Arc<Mutex<usize>>,
     team_id_for_domain: Option<uuid::Uuid>,
     team_plan: Option<TeamPlan>,
     seat_count: i32,
@@ -98,9 +103,12 @@ impl MockTeamRepository {
             mark_sent_calls,
             team_for_get_by_id: None,
             team_subscription_id: None,
+            team_subscription_id_lookup_calls: Arc::new(Mutex::new(0)),
             backfilled_subscription_id: Arc::new(Mutex::new(None)),
             stripe_customer_id: None,
+            stripe_customer_id_lookup_calls: Arc::new(Mutex::new(0)),
             team_payment_status: true,
+            team_payment_status_lookup_calls: Arc::new(Mutex::new(0)),
             enterprise: false,
             enterprise_status_lookup_calls: Arc::new(Mutex::new(0)),
             fail_enterprise_status_lookup: false,
@@ -128,6 +136,8 @@ impl MockTeamRepository {
             payment_update_calls: Arc::new(Mutex::new(Vec::new())),
             fail_github_installation_move: false,
             fail_invite_users_to_team: false,
+            invite_users_to_team_calls: Arc::new(Mutex::new(0)),
+            get_team_by_id_calls: Arc::new(Mutex::new(0)),
             team_id_for_domain: None,
             team_plan: None,
             seat_count: 0,
@@ -157,6 +167,7 @@ impl TeamRepository for MockTeamRepository {
         &self,
         _: &MacroUserIdStr<'_>,
     ) -> impl Future<Output = Result<Option<stripe::CustomerId>, TeamError>> + Send {
+        *self.stripe_customer_id_lookup_calls.lock().unwrap() += 1;
         let customer_id = self.stripe_customer_id.clone();
         async move { Ok(customer_id) }
     }
@@ -165,6 +176,7 @@ impl TeamRepository for MockTeamRepository {
         &self,
         _: &uuid::Uuid,
     ) -> impl Future<Output = Result<Option<stripe::SubscriptionId>, TeamError>> + Send {
+        *self.team_subscription_id_lookup_calls.lock().unwrap() += 1;
         let subscription_id = self
             .backfilled_subscription_id
             .lock()
@@ -178,6 +190,7 @@ impl TeamRepository for MockTeamRepository {
         &self,
         _: &uuid::Uuid,
     ) -> impl Future<Output = Result<bool, TeamError>> + Send {
+        *self.team_payment_status_lookup_calls.lock().unwrap() += 1;
         let team_payment_status = self.team_payment_status;
         async move { Ok(team_payment_status) }
     }
@@ -244,6 +257,7 @@ impl TeamRepository for MockTeamRepository {
         _: &MacroUserIdStr<'_>,
         _: non_empty::NonEmpty<&[Email<Lowercase<'_>>]>,
     ) -> impl Future<Output = Result<Vec<TeamInvite<'_>>, InviteUsersToTeamError>> + Send {
+        *self.invite_users_to_team_calls.lock().unwrap() += 1;
         let invites = self.invites_to_return.clone();
         let fail = self.fail_invite_users_to_team;
         async move {
@@ -417,6 +431,7 @@ impl TeamRepository for MockTeamRepository {
         &self,
         _: &uuid::Uuid,
     ) -> impl Future<Output = Result<TeamWithMembers, TeamError>> + Send {
+        *self.get_team_by_id_calls.lock().unwrap() += 1;
         let team = self.team_for_get_by_id.clone();
         async move {
             let team = team.ok_or(TeamError::TeamDoesNotExist)?;
@@ -556,6 +571,7 @@ struct MockCustomerRepository {
     increment_calls: Arc<Mutex<Vec<(String, u64)>>>,
     decrement_calls: Arc<Mutex<Vec<(String, u64)>>>,
     convert_calls: Arc<Mutex<Vec<(String, uuid::Uuid, String)>>>,
+    subscription_lookup_calls: Arc<Mutex<usize>>,
     fail_increment: bool,
     fail_decrement: bool,
     no_active_subscription: bool,
@@ -568,6 +584,7 @@ impl Default for MockCustomerRepository {
             increment_calls: Arc::new(Mutex::new(Vec::new())),
             decrement_calls: Arc::new(Mutex::new(Vec::new())),
             convert_calls: Arc::new(Mutex::new(Vec::new())),
+            subscription_lookup_calls: Arc::new(Mutex::new(0)),
             fail_increment: false,
             fail_decrement: false,
             no_active_subscription: false,
@@ -594,6 +611,7 @@ impl CustomerRepository for MockCustomerRepository {
         &self,
         _: &stripe::CustomerId,
     ) -> impl Future<Output = Result<stripe::SubscriptionId, CustomerError>> + Send {
+        *self.subscription_lookup_calls.lock().unwrap() += 1;
         let no_active_subscription = self.no_active_subscription;
         let subscription_id = self.subscription_id.clone();
         async move {
@@ -1310,6 +1328,203 @@ async fn test_is_user_premium_without_active_subscription() {
     let service = build_service_for_premium_check(Some("cus_test".parse().unwrap()), true);
 
     assert!(service.is_user_premium(&user_id).await.unwrap().is_none());
+}
+
+#[tokio::test]
+async fn invite_users_to_team_enterprise_bypasses_billing_and_preserves_side_effects() {
+    let team_id = uuid::Uuid::from_u128(6000);
+    let invite_id = uuid::Uuid::from_u128(6001);
+    let invited_by = MacroUserIdStr::parse_from_str("macro|owner@example.com").unwrap();
+    let mark_sent_calls = Arc::new(Mutex::new(Vec::new()));
+    let mut team_repo = MockTeamRepository::new(
+        vec![make_invite("member@example.com", invite_id, team_id)],
+        "Enterprise Team",
+        mark_sent_calls.clone(),
+    )
+    .with_enterprise(true);
+    team_repo.team_payment_status = false;
+    team_repo.team_subscription_id = Some("sub_enterprise_sentinel".parse().unwrap());
+    team_repo.stripe_customer_id = Some("cus_enterprise_sentinel".parse().unwrap());
+    team_repo.team_plan = Some(TeamPlan::Idea);
+    team_repo.seat_count = TeamPlan::Idea.seat_cap() - 1;
+
+    let enterprise_status_lookup_calls = team_repo.enterprise_status_lookup_calls.clone();
+    let payment_status_lookup_calls = team_repo.team_payment_status_lookup_calls.clone();
+    let subscription_id_lookup_calls = team_repo.team_subscription_id_lookup_calls.clone();
+    let stripe_customer_id_lookup_calls = team_repo.stripe_customer_id_lookup_calls.clone();
+    let get_team_by_id_calls = team_repo.get_team_by_id_calls.clone();
+    let invitation_persistence_calls = team_repo.invite_users_to_team_calls.clone();
+    let subscription_update_calls = team_repo.subscription_update_calls.clone();
+    let payment_update_calls = team_repo.payment_update_calls.clone();
+
+    let customer_repo = MockCustomerRepository::default();
+    let customer_subscription_lookup_calls = customer_repo.subscription_lookup_calls.clone();
+    let convert_calls = customer_repo.convert_calls.clone();
+    let increment_calls = customer_repo.increment_calls.clone();
+    let decrement_calls = customer_repo.decrement_calls.clone();
+    let notification_ingress = Arc::new(MockNotificationIngress::new(HashSet::new()));
+    let analytics_events = Arc::new(Mutex::new(Vec::new()));
+    let service = TeamServiceImpl::new_with_analytics(
+        team_repo,
+        customer_repo,
+        MockTeamChannelsRepository::default(),
+        MockUserRolesAndPermissionsService::default(),
+        notification_ingress.clone(),
+        NoOpCrmEnqueuer,
+        NoOpTeamCrmSettingsRepository,
+        MockTeamAnalytics::new(analytics_events.clone()),
+    );
+
+    let invite_emails = vec![
+        Email::parse_from_str("member@example.com")
+            .unwrap()
+            .lowercase(),
+    ];
+    let invites = non_empty::NonEmpty::new(invite_emails.as_slice()).unwrap();
+    let receipt = test_team_receipt::<AdminTeamRole>(team_id, &invited_by);
+
+    let result = service
+        .invite_users_to_team(receipt, invites)
+        .await
+        .unwrap();
+
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].team_invite_id, invite_id);
+    assert_eq!(*enterprise_status_lookup_calls.lock().unwrap(), 1);
+    assert_eq!(*payment_status_lookup_calls.lock().unwrap(), 0);
+    assert_eq!(*subscription_id_lookup_calls.lock().unwrap(), 0);
+    assert_eq!(*stripe_customer_id_lookup_calls.lock().unwrap(), 0);
+    assert_eq!(*get_team_by_id_calls.lock().unwrap(), 0);
+    assert_eq!(*customer_subscription_lookup_calls.lock().unwrap(), 0);
+    assert!(convert_calls.lock().unwrap().is_empty());
+    assert!(subscription_update_calls.lock().unwrap().is_empty());
+    assert!(payment_update_calls.lock().unwrap().is_empty());
+    assert!(increment_calls.lock().unwrap().is_empty());
+    assert!(decrement_calls.lock().unwrap().is_empty());
+
+    assert_eq!(*invitation_persistence_calls.lock().unwrap(), 1);
+    assert_eq!(notification_ingress.call_count.load(Ordering::SeqCst), 1);
+    assert_eq!(*mark_sent_calls.lock().unwrap(), vec![vec![invite_id]]);
+
+    let events = analytics_events.lock().unwrap();
+    assert_eq!(events.len(), 1);
+    match &events[0] {
+        TeamAnalyticsEvent::TeamInvited {
+            team_id: event_team_id,
+            team_invite_id,
+            inviter_id,
+            team_name,
+        } => {
+            assert_eq!(*event_team_id, team_id);
+            assert_eq!(*team_invite_id, invite_id);
+            assert_eq!(inviter_id.as_ref(), invited_by.as_ref());
+            assert_eq!(team_name.as_deref(), Some("Enterprise Team"));
+        }
+        event => panic!("unexpected event: {event:?}"),
+    }
+}
+
+#[tokio::test]
+async fn invite_users_to_team_enterprise_enforces_team_plan_seat_cap() {
+    let team_id = uuid::Uuid::from_u128(6010);
+    let invite_id = uuid::Uuid::from_u128(6011);
+    let invited_by = MacroUserIdStr::parse_from_str("macro|owner@example.com").unwrap();
+    let mark_sent_calls = Arc::new(Mutex::new(Vec::new()));
+    let mut team_repo = MockTeamRepository::new(
+        vec![make_invite("member@example.com", invite_id, team_id)],
+        "Enterprise Team",
+        mark_sent_calls.clone(),
+    )
+    .with_enterprise(true);
+    team_repo.team_payment_status = false;
+    team_repo.team_subscription_id = Some("sub_enterprise_sentinel".parse().unwrap());
+    team_repo.team_plan = Some(TeamPlan::Idea);
+    team_repo.seat_count = TeamPlan::Idea.seat_cap();
+
+    let payment_status_lookup_calls = team_repo.team_payment_status_lookup_calls.clone();
+    let subscription_id_lookup_calls = team_repo.team_subscription_id_lookup_calls.clone();
+    let invitation_persistence_calls = team_repo.invite_users_to_team_calls.clone();
+    let notification_ingress = Arc::new(MockNotificationIngress::new(HashSet::new()));
+    let analytics_events = Arc::new(Mutex::new(Vec::new()));
+    let service = TeamServiceImpl::new_with_analytics(
+        team_repo,
+        MockCustomerRepository::default(),
+        MockTeamChannelsRepository::default(),
+        MockUserRolesAndPermissionsService::default(),
+        notification_ingress.clone(),
+        NoOpCrmEnqueuer,
+        NoOpTeamCrmSettingsRepository,
+        MockTeamAnalytics::new(analytics_events.clone()),
+    );
+
+    let invite_emails = vec![
+        Email::parse_from_str("member@example.com")
+            .unwrap()
+            .lowercase(),
+    ];
+    let invites = non_empty::NonEmpty::new(invite_emails.as_slice()).unwrap();
+    let receipt = test_team_receipt::<AdminTeamRole>(team_id, &invited_by);
+
+    let error = service
+        .invite_users_to_team(receipt, invites)
+        .await
+        .unwrap_err();
+
+    assert!(matches!(error, InviteUsersToTeamError::NotEnoughOpenSeats));
+    assert_eq!(*payment_status_lookup_calls.lock().unwrap(), 0);
+    assert_eq!(*subscription_id_lookup_calls.lock().unwrap(), 0);
+    assert_eq!(*invitation_persistence_calls.lock().unwrap(), 0);
+    assert_eq!(notification_ingress.call_count.load(Ordering::SeqCst), 0);
+    assert!(mark_sent_calls.lock().unwrap().is_empty());
+    assert!(analytics_events.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn invite_users_to_team_enterprise_status_lookup_failure_precedes_persistence() {
+    let team_id = uuid::Uuid::from_u128(6020);
+    let invite_id = uuid::Uuid::from_u128(6021);
+    let invited_by = MacroUserIdStr::parse_from_str("macro|owner@example.com").unwrap();
+    let mark_sent_calls = Arc::new(Mutex::new(Vec::new()));
+    let mut team_repo = MockTeamRepository::new(
+        vec![make_invite("member@example.com", invite_id, team_id)],
+        "Enterprise Team",
+        mark_sent_calls,
+    );
+    team_repo.fail_enterprise_status_lookup = true;
+
+    let enterprise_status_lookup_calls = team_repo.enterprise_status_lookup_calls.clone();
+    let payment_status_lookup_calls = team_repo.team_payment_status_lookup_calls.clone();
+    let invitation_persistence_calls = team_repo.invite_users_to_team_calls.clone();
+    let service = TeamServiceImpl::new(
+        team_repo,
+        MockCustomerRepository::default(),
+        MockTeamChannelsRepository::default(),
+        MockUserRolesAndPermissionsService::default(),
+        Arc::new(MockNotificationIngress::new(HashSet::new())),
+        NoOpCrmEnqueuer,
+        NoOpTeamCrmSettingsRepository,
+    );
+
+    let invite_emails = vec![
+        Email::parse_from_str("member@example.com")
+            .unwrap()
+            .lowercase(),
+    ];
+    let invites = non_empty::NonEmpty::new(invite_emails.as_slice()).unwrap();
+    let receipt = test_team_receipt::<AdminTeamRole>(team_id, &invited_by);
+
+    let error = service
+        .invite_users_to_team(receipt, invites)
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        error,
+        InviteUsersToTeamError::TeamError(TeamError::StorageLayerError(_))
+    ));
+    assert_eq!(*enterprise_status_lookup_calls.lock().unwrap(), 1);
+    assert_eq!(*payment_status_lookup_calls.lock().unwrap(), 0);
+    assert_eq!(*invitation_persistence_calls.lock().unwrap(), 0);
 }
 
 /// When one notification fails, only the successful invite IDs are passed to

--- a/crates/teams/src/domain/team_service/test.rs
+++ b/crates/teams/src/domain/team_service/test.rs
@@ -942,6 +942,84 @@ fn make_accepted_invite(
     }
 }
 
+fn make_enterprise_join_team_repository(
+    team_id: uuid::Uuid,
+    invite_id: uuid::Uuid,
+    user_id: &MacroUserIdStr<'_>,
+) -> MockTeamRepository {
+    let mark_sent_calls = Arc::new(Mutex::new(Vec::new()));
+    let mut team_repository =
+        MockTeamRepository::new(Vec::new(), "Enterprise Team", mark_sent_calls)
+            .with_enterprise(true);
+    team_repository.team_payment_status = false;
+    team_repository.team_subscription_id = Some("sub_enterprise_sentinel".parse().unwrap());
+    team_repository.accepted_invite = Some(make_accepted_invite(team_id, invite_id, user_id));
+    team_repository
+}
+
+fn assert_no_enterprise_join_team_billing_calls(
+    team_repository: &MockTeamRepository,
+    customer_repository: &MockCustomerRepository,
+) {
+    assert_eq!(
+        *team_repository
+            .team_payment_status_lookup_calls
+            .lock()
+            .unwrap(),
+        0
+    );
+    assert_eq!(
+        *team_repository
+            .team_subscription_id_lookup_calls
+            .lock()
+            .unwrap(),
+        0
+    );
+    assert_eq!(
+        *team_repository
+            .stripe_customer_id_lookup_calls
+            .lock()
+            .unwrap(),
+        0
+    );
+    assert!(
+        team_repository
+            .subscription_update_calls
+            .lock()
+            .unwrap()
+            .is_empty()
+    );
+    assert!(
+        team_repository
+            .payment_update_calls
+            .lock()
+            .unwrap()
+            .is_empty()
+    );
+    assert_eq!(
+        *customer_repository
+            .subscription_lookup_calls
+            .lock()
+            .unwrap(),
+        0
+    );
+    assert!(customer_repository.convert_calls.lock().unwrap().is_empty());
+    assert!(
+        customer_repository
+            .increment_calls
+            .lock()
+            .unwrap()
+            .is_empty()
+    );
+    assert!(
+        customer_repository
+            .decrement_calls
+            .lock()
+            .unwrap()
+            .is_empty()
+    );
+}
+
 fn build_service(
     invites: Vec<TeamInvite<'static>>,
     fail_indices: HashSet<usize>,
@@ -2169,6 +2247,206 @@ async fn test_invite_users_to_team_backfills_legacy_team_subscription() {
         vec![(team_id, subscription_id.to_string())]
     );
     assert_eq!(*payment_update_calls.lock().unwrap(), vec![(team_id, true)]);
+}
+
+#[tokio::test]
+async fn join_team_enterprise_bypasses_billing_and_preserves_membership_side_effects() {
+    let team_id = uuid::Uuid::from_u128(45);
+    let invite_id = uuid::Uuid::from_u128(450);
+    let user_id = MacroUserIdStr::parse_from_str("macro|member@example.com").unwrap();
+    let team_repository = make_enterprise_join_team_repository(team_id, invite_id, &user_id);
+    let customer_repository = MockCustomerRepository::default();
+    let channels_repository = MockTeamChannelsRepository::default();
+    let roles_service = MockUserRolesAndPermissionsService::default();
+    let crm_enqueuer = RecordingCrmEnqueuer::default();
+    let events = Arc::new(Mutex::new(Vec::new()));
+
+    let service = TeamServiceImpl::new_with_analytics(
+        team_repository.clone(),
+        customer_repository.clone(),
+        channels_repository.clone(),
+        roles_service.clone(),
+        Arc::new(MockNotificationIngress::new(HashSet::new())),
+        crm_enqueuer.clone(),
+        NoOpTeamCrmSettingsRepository,
+        MockTeamAnalytics::new(events.clone()),
+    );
+
+    let member = service.join_team(&invite_id, &user_id).await.unwrap();
+
+    assert_eq!(member.team_id, team_id);
+    assert_eq!(member.user_id, user_id);
+    assert_eq!(
+        *team_repository
+            .enterprise_status_lookup_calls
+            .lock()
+            .unwrap(),
+        1
+    );
+    assert_eq!(*team_repository.rollback_accept_calls.lock().unwrap(), 0);
+    assert_no_enterprise_join_team_billing_calls(&team_repository, &customer_repository);
+    assert_eq!(
+        *roles_service.upsert_calls.lock().unwrap(),
+        vec![(
+            user_id.as_ref().to_string(),
+            vec![RoleId::TeamSubscriber, RoleId::SubOpus]
+        )]
+    );
+    assert!(roles_service.remove_calls.lock().unwrap().is_empty());
+    assert_eq!(
+        *channels_repository.add_calls.lock().unwrap(),
+        vec![(team_id, user_id.as_ref().to_string())]
+    );
+    assert!(channels_repository.remove_calls.lock().unwrap().is_empty());
+    assert_eq!(
+        *crm_enqueuer.populated.lock().unwrap(),
+        vec![user_id.as_ref().to_string()]
+    );
+    assert_eq!(
+        *events.lock().unwrap(),
+        vec![TeamAnalyticsEvent::TeamJoined {
+            team_id,
+            team_invite_id: invite_id,
+            member_id: user_id.clone().into_owned(),
+            role: TeamRole::Member,
+        }]
+    );
+}
+
+#[tokio::test]
+async fn join_team_enterprise_rolls_back_accepted_invite_when_role_assignment_fails() {
+    let team_id = uuid::Uuid::from_u128(46);
+    let invite_id = uuid::Uuid::from_u128(460);
+    let user_id = MacroUserIdStr::parse_from_str("macro|member@example.com").unwrap();
+    let team_repository = make_enterprise_join_team_repository(team_id, invite_id, &user_id);
+    let customer_repository = MockCustomerRepository::default();
+    let channels_repository = MockTeamChannelsRepository::default();
+    let roles_service = MockUserRolesAndPermissionsService {
+        fail_upsert: true,
+        ..Default::default()
+    };
+    let crm_enqueuer = RecordingCrmEnqueuer::default();
+    let events = Arc::new(Mutex::new(Vec::new()));
+
+    let service = TeamServiceImpl::new_with_analytics(
+        team_repository.clone(),
+        customer_repository.clone(),
+        channels_repository.clone(),
+        roles_service.clone(),
+        Arc::new(MockNotificationIngress::new(HashSet::new())),
+        crm_enqueuer.clone(),
+        NoOpTeamCrmSettingsRepository,
+        MockTeamAnalytics::new(events.clone()),
+    );
+
+    let error = service.join_team(&invite_id, &user_id).await.unwrap_err();
+
+    assert!(matches!(error, JoinTeamError::AddRolesToUserError(_)));
+    assert_eq!(
+        *team_repository
+            .enterprise_status_lookup_calls
+            .lock()
+            .unwrap(),
+        1
+    );
+    assert_eq!(*team_repository.rollback_accept_calls.lock().unwrap(), 1);
+    assert_no_enterprise_join_team_billing_calls(&team_repository, &customer_repository);
+    assert_eq!(roles_service.upsert_calls.lock().unwrap().len(), 1);
+    assert!(roles_service.remove_calls.lock().unwrap().is_empty());
+    assert!(channels_repository.add_calls.lock().unwrap().is_empty());
+    assert!(crm_enqueuer.populated.lock().unwrap().is_empty());
+    assert!(events.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn join_team_enterprise_rolls_back_roles_and_invite_when_channel_add_fails() {
+    let team_id = uuid::Uuid::from_u128(47);
+    let invite_id = uuid::Uuid::from_u128(470);
+    let user_id = MacroUserIdStr::parse_from_str("macro|member@example.com").unwrap();
+    let team_repository = make_enterprise_join_team_repository(team_id, invite_id, &user_id);
+    let customer_repository = MockCustomerRepository::default();
+    let channels_repository = MockTeamChannelsRepository {
+        fail_add: true,
+        ..Default::default()
+    };
+    let roles_service = MockUserRolesAndPermissionsService::default();
+    let crm_enqueuer = RecordingCrmEnqueuer::default();
+    let events = Arc::new(Mutex::new(Vec::new()));
+
+    let service = TeamServiceImpl::new_with_analytics(
+        team_repository.clone(),
+        customer_repository.clone(),
+        channels_repository.clone(),
+        roles_service.clone(),
+        Arc::new(MockNotificationIngress::new(HashSet::new())),
+        crm_enqueuer.clone(),
+        NoOpTeamCrmSettingsRepository,
+        MockTeamAnalytics::new(events.clone()),
+    );
+
+    let error = service.join_team(&invite_id, &user_id).await.unwrap_err();
+
+    assert!(matches!(error, JoinTeamError::TeamError(_)));
+    assert_eq!(
+        *team_repository
+            .enterprise_status_lookup_calls
+            .lock()
+            .unwrap(),
+        1
+    );
+    assert_eq!(*team_repository.rollback_accept_calls.lock().unwrap(), 1);
+    assert_no_enterprise_join_team_billing_calls(&team_repository, &customer_repository);
+    assert_eq!(roles_service.upsert_calls.lock().unwrap().len(), 1);
+    assert_eq!(roles_service.remove_calls.lock().unwrap().len(), 1);
+    assert_eq!(
+        *channels_repository.add_calls.lock().unwrap(),
+        vec![(team_id, user_id.as_ref().to_string())]
+    );
+    assert!(crm_enqueuer.populated.lock().unwrap().is_empty());
+    assert!(events.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn join_team_enterprise_rolls_back_accepted_invite_when_status_read_fails() {
+    let team_id = uuid::Uuid::from_u128(48);
+    let invite_id = uuid::Uuid::from_u128(480);
+    let user_id = MacroUserIdStr::parse_from_str("macro|member@example.com").unwrap();
+    let mut team_repository = make_enterprise_join_team_repository(team_id, invite_id, &user_id);
+    team_repository.fail_enterprise_status_lookup = true;
+    let customer_repository = MockCustomerRepository::default();
+    let channels_repository = MockTeamChannelsRepository::default();
+    let roles_service = MockUserRolesAndPermissionsService::default();
+    let crm_enqueuer = RecordingCrmEnqueuer::default();
+    let events = Arc::new(Mutex::new(Vec::new()));
+
+    let service = TeamServiceImpl::new_with_analytics(
+        team_repository.clone(),
+        customer_repository.clone(),
+        channels_repository.clone(),
+        roles_service.clone(),
+        Arc::new(MockNotificationIngress::new(HashSet::new())),
+        crm_enqueuer.clone(),
+        NoOpTeamCrmSettingsRepository,
+        MockTeamAnalytics::new(events.clone()),
+    );
+
+    let error = service.join_team(&invite_id, &user_id).await.unwrap_err();
+
+    assert!(matches!(error, JoinTeamError::TeamError(_)));
+    assert_eq!(
+        *team_repository
+            .enterprise_status_lookup_calls
+            .lock()
+            .unwrap(),
+        1
+    );
+    assert_eq!(*team_repository.rollback_accept_calls.lock().unwrap(), 1);
+    assert_no_enterprise_join_team_billing_calls(&team_repository, &customer_repository);
+    assert!(roles_service.upsert_calls.lock().unwrap().is_empty());
+    assert!(roles_service.remove_calls.lock().unwrap().is_empty());
+    assert!(channels_repository.add_calls.lock().unwrap().is_empty());
+    assert!(crm_enqueuer.populated.lock().unwrap().is_empty());
+    assert!(events.lock().unwrap().is_empty());
 }
 
 #[tokio::test]

--- a/crates/teams/src/domain/team_service/test.rs
+++ b/crates/teams/src/domain/team_service/test.rs
@@ -982,6 +982,35 @@ fn make_enterprise_domain_join_team_repository(
     team_repository
 }
 
+fn make_enterprise_remove_user_repository(
+    team_id: uuid::Uuid,
+    user_id: &MacroUserIdStr<'_>,
+    role: TeamRole,
+) -> MockTeamRepository {
+    let mark_sent_calls = Arc::new(Mutex::new(Vec::new()));
+    let owner_id = MacroUserIdStr::parse_from_str("macro|owner@example.com").unwrap();
+    let team = Team::new(
+        team_id,
+        "Enterprise Team".to_string(),
+        "ENTERPRISE_TEAM".to_string(),
+        owner_id.into_owned(),
+        false,
+        true,
+    );
+    let mut team_repository =
+        MockTeamRepository::new(Vec::new(), "Enterprise Team", mark_sent_calls)
+            .with_enterprise(true)
+            .with_team(team);
+    team_repository.team_payment_status = false;
+    team_repository.stripe_customer_id = Some("cus_enterprise_sentinel".parse().unwrap());
+    team_repository.removed_member = Some(TeamMember {
+        team_id,
+        user_id: user_id.clone().into_owned(),
+        role,
+    });
+    team_repository
+}
+
 fn assert_no_enterprise_join_team_billing_calls(
     team_repository: &MockTeamRepository,
     customer_repository: &MockCustomerRepository,
@@ -1043,6 +1072,14 @@ fn assert_no_enterprise_join_team_billing_calls(
             .unwrap()
             .is_empty()
     );
+}
+
+fn assert_no_enterprise_remove_user_billing_calls(
+    team_repository: &MockTeamRepository,
+    customer_repository: &MockCustomerRepository,
+) {
+    assert_no_enterprise_join_team_billing_calls(team_repository, customer_repository);
+    assert_eq!(*team_repository.get_team_by_id_calls.lock().unwrap(), 0);
 }
 
 fn build_service(
@@ -1894,10 +1931,11 @@ async fn test_get_team_reports_crm_enabled() {
     assert!(team.team.crm_enabled());
 }
 
-/// CrmEnqueuer that records which users had a populate enqueued.
+/// CrmEnqueuer that records which users had a populate or depopulate enqueued.
 #[derive(Clone, Default)]
 struct RecordingCrmEnqueuer {
     populated: Arc<Mutex<Vec<String>>>,
+    depopulated: Arc<Mutex<Vec<(uuid::Uuid, String)>>>,
 }
 
 impl CrmEnqueuer for RecordingCrmEnqueuer {
@@ -1916,9 +1954,13 @@ impl CrmEnqueuer for RecordingCrmEnqueuer {
 
     async fn enqueue_depopulate_crm_for_user(
         &self,
-        _: &uuid::Uuid,
-        _: &MacroUserIdStr<'_>,
+        team_id: &uuid::Uuid,
+        macro_id: &MacroUserIdStr<'_>,
     ) -> Result<(), Self::Err> {
+        self.depopulated
+            .lock()
+            .unwrap()
+            .push((*team_id, macro_id.as_ref().to_string()));
         Ok(())
     }
 }
@@ -3486,6 +3528,234 @@ async fn try_join_team_by_domain_enterprise_rolls_back_roles_when_channels_fail(
         vec![(team_id, user_id.as_ref().to_string())]
     );
     assert!(crm_enqueuer.populated.lock().unwrap().is_empty());
+    assert!(events.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn remove_user_from_team_enterprise_bypasses_billing_and_preserves_side_effects() {
+    let team_id = uuid::Uuid::from_u128(91);
+    let owner_id = MacroUserIdStr::parse_from_str("macro|owner@example.com").unwrap();
+    let member_id = MacroUserIdStr::parse_from_str("macro|member@example.com").unwrap();
+    let team_repository =
+        make_enterprise_remove_user_repository(team_id, &member_id, TeamRole::Admin);
+    let customer_repository = MockCustomerRepository::default();
+    let channels_repository = MockTeamChannelsRepository::default();
+    let roles_service = MockUserRolesAndPermissionsService::default();
+    let crm_enqueuer = RecordingCrmEnqueuer::default();
+    let events = Arc::new(Mutex::new(Vec::new()));
+
+    let service = TeamServiceImpl::new_with_analytics(
+        team_repository.clone(),
+        customer_repository.clone(),
+        channels_repository.clone(),
+        roles_service.clone(),
+        Arc::new(MockNotificationIngress::new(HashSet::new())),
+        crm_enqueuer.clone(),
+        NoOpTeamCrmSettingsRepository,
+        MockTeamAnalytics::new(events.clone()),
+    );
+
+    service
+        .remove_user_from_team(
+            test_team_receipt::<AdminTeamRole>(team_id, &owner_id),
+            &member_id,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        *team_repository
+            .enterprise_status_lookup_calls
+            .lock()
+            .unwrap(),
+        1
+    );
+    assert_eq!(*team_repository.remove_user_calls.lock().unwrap(), 1);
+    assert_eq!(*team_repository.rollback_remove_calls.lock().unwrap(), 0);
+    assert_no_enterprise_remove_user_billing_calls(&team_repository, &customer_repository);
+    assert_eq!(
+        *channels_repository.remove_calls.lock().unwrap(),
+        vec![(team_id, member_id.as_ref().to_string())]
+    );
+    assert!(channels_repository.add_calls.lock().unwrap().is_empty());
+    assert_eq!(
+        *roles_service.remove_calls.lock().unwrap(),
+        vec![(
+            member_id.as_ref().to_string(),
+            vec![RoleId::TeamSubscriber, RoleId::SubOpus]
+        )]
+    );
+    assert_eq!(
+        *crm_enqueuer.depopulated.lock().unwrap(),
+        vec![(team_id, member_id.as_ref().to_string())]
+    );
+    assert_eq!(
+        *events.lock().unwrap(),
+        vec![TeamAnalyticsEvent::TeamLeft {
+            team_id,
+            member_id: member_id.clone().into_owned(),
+            removed_by_id: owner_id.into_owned(),
+            role: TeamRole::Admin,
+        }]
+    );
+}
+
+#[tokio::test]
+async fn remove_user_from_team_enterprise_rolls_back_membership_when_channel_removal_fails() {
+    let team_id = uuid::Uuid::from_u128(92);
+    let owner_id = MacroUserIdStr::parse_from_str("macro|owner@example.com").unwrap();
+    let member_id = MacroUserIdStr::parse_from_str("macro|member@example.com").unwrap();
+    let team_repository =
+        make_enterprise_remove_user_repository(team_id, &member_id, TeamRole::Member);
+    let customer_repository = MockCustomerRepository::default();
+    let channels_repository = MockTeamChannelsRepository {
+        fail_remove: true,
+        ..Default::default()
+    };
+    let roles_service = MockUserRolesAndPermissionsService::default();
+    let crm_enqueuer = RecordingCrmEnqueuer::default();
+    let events = Arc::new(Mutex::new(Vec::new()));
+
+    let service = TeamServiceImpl::new_with_analytics(
+        team_repository.clone(),
+        customer_repository.clone(),
+        channels_repository.clone(),
+        roles_service.clone(),
+        Arc::new(MockNotificationIngress::new(HashSet::new())),
+        crm_enqueuer.clone(),
+        NoOpTeamCrmSettingsRepository,
+        MockTeamAnalytics::new(events.clone()),
+    );
+
+    let error = service
+        .remove_user_from_team(
+            test_team_receipt::<AdminTeamRole>(team_id, &owner_id),
+            &member_id,
+        )
+        .await
+        .unwrap_err();
+
+    assert!(matches!(error, RemoveUserFromTeamError::TeamError(_)));
+    assert_eq!(*team_repository.remove_user_calls.lock().unwrap(), 1);
+    assert_eq!(*team_repository.rollback_remove_calls.lock().unwrap(), 1);
+    assert_no_enterprise_remove_user_billing_calls(&team_repository, &customer_repository);
+    assert_eq!(
+        *channels_repository.remove_calls.lock().unwrap(),
+        vec![(team_id, member_id.as_ref().to_string())]
+    );
+    assert!(channels_repository.add_calls.lock().unwrap().is_empty());
+    assert!(roles_service.remove_calls.lock().unwrap().is_empty());
+    assert!(crm_enqueuer.depopulated.lock().unwrap().is_empty());
+    assert!(events.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn remove_user_from_team_enterprise_rolls_back_membership_and_channels_when_role_removal_fails()
+ {
+    let team_id = uuid::Uuid::from_u128(93);
+    let owner_id = MacroUserIdStr::parse_from_str("macro|owner@example.com").unwrap();
+    let member_id = MacroUserIdStr::parse_from_str("macro|member@example.com").unwrap();
+    let team_repository =
+        make_enterprise_remove_user_repository(team_id, &member_id, TeamRole::Member);
+    let customer_repository = MockCustomerRepository::default();
+    let channels_repository = MockTeamChannelsRepository::default();
+    let roles_service = MockUserRolesAndPermissionsService {
+        fail_remove: true,
+        ..Default::default()
+    };
+    let crm_enqueuer = RecordingCrmEnqueuer::default();
+    let events = Arc::new(Mutex::new(Vec::new()));
+
+    let service = TeamServiceImpl::new_with_analytics(
+        team_repository.clone(),
+        customer_repository.clone(),
+        channels_repository.clone(),
+        roles_service.clone(),
+        Arc::new(MockNotificationIngress::new(HashSet::new())),
+        crm_enqueuer.clone(),
+        NoOpTeamCrmSettingsRepository,
+        MockTeamAnalytics::new(events.clone()),
+    );
+
+    let error = service
+        .remove_user_from_team(
+            test_team_receipt::<AdminTeamRole>(team_id, &owner_id),
+            &member_id,
+        )
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        error,
+        RemoveUserFromTeamError::RemoveRolesFromUserError(_)
+    ));
+    assert_eq!(*team_repository.remove_user_calls.lock().unwrap(), 1);
+    assert_eq!(*team_repository.rollback_remove_calls.lock().unwrap(), 1);
+    assert_no_enterprise_remove_user_billing_calls(&team_repository, &customer_repository);
+    assert_eq!(
+        *channels_repository.remove_calls.lock().unwrap(),
+        vec![(team_id, member_id.as_ref().to_string())]
+    );
+    assert_eq!(
+        *channels_repository.add_calls.lock().unwrap(),
+        vec![(team_id, member_id.as_ref().to_string())]
+    );
+    assert_eq!(roles_service.remove_calls.lock().unwrap().len(), 1);
+    assert!(crm_enqueuer.depopulated.lock().unwrap().is_empty());
+    assert!(events.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn remove_user_from_team_enterprise_status_read_precedes_membership_removal() {
+    let team_id = uuid::Uuid::from_u128(94);
+    let owner_id = MacroUserIdStr::parse_from_str("macro|owner@example.com").unwrap();
+    let member_id = MacroUserIdStr::parse_from_str("macro|member@example.com").unwrap();
+    let mut team_repository =
+        make_enterprise_remove_user_repository(team_id, &member_id, TeamRole::Member);
+    team_repository.fail_enterprise_status_lookup = true;
+    let customer_repository = MockCustomerRepository::default();
+    let channels_repository = MockTeamChannelsRepository::default();
+    let roles_service = MockUserRolesAndPermissionsService::default();
+    let crm_enqueuer = RecordingCrmEnqueuer::default();
+    let events = Arc::new(Mutex::new(Vec::new()));
+
+    let service = TeamServiceImpl::new_with_analytics(
+        team_repository.clone(),
+        customer_repository.clone(),
+        channels_repository.clone(),
+        roles_service.clone(),
+        Arc::new(MockNotificationIngress::new(HashSet::new())),
+        crm_enqueuer.clone(),
+        NoOpTeamCrmSettingsRepository,
+        MockTeamAnalytics::new(events.clone()),
+    );
+
+    let error = service
+        .remove_user_from_team(
+            test_team_receipt::<AdminTeamRole>(team_id, &owner_id),
+            &member_id,
+        )
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        error,
+        RemoveUserFromTeamError::TeamError(TeamError::StorageLayerError(_))
+    ));
+    assert_eq!(
+        *team_repository
+            .enterprise_status_lookup_calls
+            .lock()
+            .unwrap(),
+        1
+    );
+    assert_eq!(*team_repository.remove_user_calls.lock().unwrap(), 0);
+    assert_eq!(*team_repository.rollback_remove_calls.lock().unwrap(), 0);
+    assert_no_enterprise_remove_user_billing_calls(&team_repository, &customer_repository);
+    assert!(channels_repository.remove_calls.lock().unwrap().is_empty());
+    assert!(channels_repository.add_calls.lock().unwrap().is_empty());
+    assert!(roles_service.remove_calls.lock().unwrap().is_empty());
+    assert!(crm_enqueuer.depopulated.lock().unwrap().is_empty());
     assert!(events.lock().unwrap().is_empty());
 }
 

--- a/crates/teams/src/domain/team_service/test.rs
+++ b/crates/teams/src/domain/team_service/test.rs
@@ -61,6 +61,9 @@ struct MockTeamRepository {
     backfilled_subscription_id: Arc<Mutex<Option<stripe::SubscriptionId>>>,
     stripe_customer_id: Option<stripe::CustomerId>,
     team_payment_status: bool,
+    enterprise: bool,
+    enterprise_status_lookup_calls: Arc<Mutex<usize>>,
+    fail_enterprise_status_lookup: bool,
     team_members: Vec<TeamMember<'static>>,
     accepted_invite: Option<AcceptedTeamInvite<'static>>,
     removed_member: Option<TeamMember<'static>>,
@@ -98,6 +101,9 @@ impl MockTeamRepository {
             backfilled_subscription_id: Arc::new(Mutex::new(None)),
             stripe_customer_id: None,
             team_payment_status: true,
+            enterprise: false,
+            enterprise_status_lookup_calls: Arc::new(Mutex::new(0)),
+            fail_enterprise_status_lookup: false,
             team_members: Vec::new(),
             accepted_invite: None,
             removed_member: None,
@@ -135,6 +141,11 @@ impl MockTeamRepository {
         self
     }
 
+    fn with_enterprise(mut self, enterprise: bool) -> Self {
+        self.enterprise = enterprise;
+        self
+    }
+
     fn with_team_members(mut self, members: Vec<TeamMember<'static>>) -> Self {
         self.team_members = members;
         self
@@ -169,6 +180,24 @@ impl TeamRepository for MockTeamRepository {
     ) -> impl Future<Output = Result<bool, TeamError>> + Send {
         let team_payment_status = self.team_payment_status;
         async move { Ok(team_payment_status) }
+    }
+
+    fn get_team_enterprise_status(
+        &self,
+        _: &uuid::Uuid,
+    ) -> impl Future<Output = Result<bool, TeamError>> + Send {
+        *self.enterprise_status_lookup_calls.lock().unwrap() += 1;
+        let enterprise = self.enterprise;
+        let fail = self.fail_enterprise_status_lookup;
+        async move {
+            if fail {
+                Err(TeamError::StorageLayerError(anyhow::anyhow!(
+                    "enterprise status lookup failed"
+                )))
+            } else {
+                Ok(enterprise)
+            }
+        }
     }
 
     fn has_user_trialed(

--- a/crates/teams/src/domain/team_service/test.rs
+++ b/crates/teams/src/domain/team_service/test.rs
@@ -88,6 +88,7 @@ struct MockTeamRepository {
     team_plan: Option<TeamPlan>,
     seat_count: i32,
     add_user_to_team_result: Option<TeamMember<'static>>,
+    add_user_to_team_calls: Arc<Mutex<usize>>,
     remove_user_calls: Arc<Mutex<usize>>,
 }
 
@@ -142,6 +143,7 @@ impl MockTeamRepository {
             team_plan: None,
             seat_count: 0,
             add_user_to_team_result: None,
+            add_user_to_team_calls: Arc::new(Mutex::new(0)),
             remove_user_calls: Arc::new(Mutex::new(0)),
         }
     }
@@ -558,6 +560,7 @@ impl TeamRepository for MockTeamRepository {
         _: &uuid::Uuid,
         _: &MacroUserIdStr<'_>,
     ) -> impl Future<Output = Result<Option<TeamMember<'static>>, TeamError>> + Send {
+        *self.add_user_to_team_calls.lock().unwrap() += 1;
         let member = self.add_user_to_team_result.clone();
         async move { Ok(member) }
     }
@@ -954,6 +957,28 @@ fn make_enterprise_join_team_repository(
     team_repository.team_payment_status = false;
     team_repository.team_subscription_id = Some("sub_enterprise_sentinel".parse().unwrap());
     team_repository.accepted_invite = Some(make_accepted_invite(team_id, invite_id, user_id));
+    team_repository
+}
+
+fn make_enterprise_domain_join_team_repository(
+    team_id: uuid::Uuid,
+    user_id: &MacroUserIdStr<'_>,
+) -> MockTeamRepository {
+    let mark_sent_calls = Arc::new(Mutex::new(Vec::new()));
+    let member = TeamMember {
+        team_id,
+        user_id: user_id.clone().into_owned(),
+        role: TeamRole::Member,
+    };
+    let mut team_repository =
+        MockTeamRepository::new(Vec::new(), "Enterprise Team", mark_sent_calls)
+            .with_enterprise(true);
+    team_repository.team_id_for_domain = Some(team_id);
+    team_repository.team_payment_status = false;
+    team_repository.team_subscription_id = Some("sub_enterprise_sentinel".parse().unwrap());
+    team_repository.stripe_customer_id = Some("cus_enterprise_sentinel".parse().unwrap());
+    team_repository.add_user_to_team_result = Some(member.clone());
+    team_repository.removed_member = Some(member);
     team_repository
 }
 
@@ -3273,4 +3298,238 @@ async fn test_try_join_team_by_domain_rolls_back_membership_when_roles_fail() {
         vec![(subscription_id.to_string(), 1)]
     );
     assert_eq!(*remove_user_calls.lock().unwrap(), 1);
+}
+
+#[tokio::test]
+async fn try_join_team_by_domain_enterprise_bypasses_billing_and_preserves_side_effects() {
+    let team_id = uuid::Uuid::from_u128(81);
+    let user_id = MacroUserIdStr::parse_from_str("macro|member@example.com").unwrap();
+    let team_repository = make_enterprise_domain_join_team_repository(team_id, &user_id);
+    let customer_repository = MockCustomerRepository::default();
+    let channels_repository = MockTeamChannelsRepository::default();
+    let roles_service = MockUserRolesAndPermissionsService::default();
+    let crm_enqueuer = RecordingCrmEnqueuer::default();
+    let events = Arc::new(Mutex::new(Vec::new()));
+
+    let service = TeamServiceImpl::new_with_analytics(
+        team_repository.clone(),
+        customer_repository.clone(),
+        channels_repository.clone(),
+        roles_service.clone(),
+        Arc::new(MockNotificationIngress::new(HashSet::new())),
+        crm_enqueuer.clone(),
+        NoOpTeamCrmSettingsRepository,
+        MockTeamAnalytics::new(events.clone()),
+    );
+
+    let member = service
+        .try_join_team_by_domain(&user_id)
+        .await
+        .unwrap()
+        .expect("enterprise user should have been auto-joined");
+
+    assert_eq!(member.team_id, team_id);
+    assert_eq!(member.user_id, user_id);
+    assert_eq!(member.role, TeamRole::Member);
+    assert_eq!(
+        *team_repository
+            .enterprise_status_lookup_calls
+            .lock()
+            .unwrap(),
+        1
+    );
+    assert_eq!(*team_repository.add_user_to_team_calls.lock().unwrap(), 1);
+    assert_eq!(*team_repository.remove_user_calls.lock().unwrap(), 0);
+    assert_no_enterprise_join_team_billing_calls(&team_repository, &customer_repository);
+    assert_eq!(
+        *roles_service.upsert_calls.lock().unwrap(),
+        vec![(
+            user_id.as_ref().to_string(),
+            vec![RoleId::TeamSubscriber, RoleId::SubOpus]
+        )]
+    );
+    assert!(roles_service.remove_calls.lock().unwrap().is_empty());
+    assert_eq!(
+        *channels_repository.add_calls.lock().unwrap(),
+        vec![(team_id, user_id.as_ref().to_string())]
+    );
+    assert!(channels_repository.remove_calls.lock().unwrap().is_empty());
+    assert_eq!(
+        *crm_enqueuer.populated.lock().unwrap(),
+        vec![user_id.as_ref().to_string()]
+    );
+    assert!(events.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn try_join_team_by_domain_enterprise_still_enforces_local_seat_cap() {
+    let team_id = uuid::Uuid::from_u128(82);
+    let user_id = MacroUserIdStr::parse_from_str("macro|member@example.com").unwrap();
+    let mut team_repository = make_enterprise_domain_join_team_repository(team_id, &user_id);
+    team_repository.team_plan = Some(TeamPlan::Idea);
+    team_repository.seat_count = TeamPlan::Idea.seat_cap();
+    let customer_repository = MockCustomerRepository::default();
+    let channels_repository = MockTeamChannelsRepository::default();
+    let roles_service = MockUserRolesAndPermissionsService::default();
+    let crm_enqueuer = RecordingCrmEnqueuer::default();
+    let events = Arc::new(Mutex::new(Vec::new()));
+
+    let service = TeamServiceImpl::new_with_analytics(
+        team_repository.clone(),
+        customer_repository.clone(),
+        channels_repository.clone(),
+        roles_service.clone(),
+        Arc::new(MockNotificationIngress::new(HashSet::new())),
+        crm_enqueuer.clone(),
+        NoOpTeamCrmSettingsRepository,
+        MockTeamAnalytics::new(events.clone()),
+    );
+
+    let member = service.try_join_team_by_domain(&user_id).await.unwrap();
+
+    assert!(member.is_none());
+    assert_eq!(
+        *team_repository
+            .enterprise_status_lookup_calls
+            .lock()
+            .unwrap(),
+        1
+    );
+    assert_eq!(*team_repository.add_user_to_team_calls.lock().unwrap(), 0);
+    assert_eq!(*team_repository.remove_user_calls.lock().unwrap(), 0);
+    assert_no_enterprise_join_team_billing_calls(&team_repository, &customer_repository);
+    assert!(roles_service.upsert_calls.lock().unwrap().is_empty());
+    assert!(channels_repository.add_calls.lock().unwrap().is_empty());
+    assert!(crm_enqueuer.populated.lock().unwrap().is_empty());
+    assert!(events.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn try_join_team_by_domain_enterprise_rolls_back_membership_when_roles_fail() {
+    let team_id = uuid::Uuid::from_u128(83);
+    let user_id = MacroUserIdStr::parse_from_str("macro|member@example.com").unwrap();
+    let team_repository = make_enterprise_domain_join_team_repository(team_id, &user_id);
+    let customer_repository = MockCustomerRepository::default();
+    let channels_repository = MockTeamChannelsRepository::default();
+    let roles_service = MockUserRolesAndPermissionsService {
+        fail_upsert: true,
+        ..Default::default()
+    };
+    let crm_enqueuer = RecordingCrmEnqueuer::default();
+    let events = Arc::new(Mutex::new(Vec::new()));
+
+    let service = TeamServiceImpl::new_with_analytics(
+        team_repository.clone(),
+        customer_repository.clone(),
+        channels_repository.clone(),
+        roles_service.clone(),
+        Arc::new(MockNotificationIngress::new(HashSet::new())),
+        crm_enqueuer.clone(),
+        NoOpTeamCrmSettingsRepository,
+        MockTeamAnalytics::new(events.clone()),
+    );
+
+    let error = service.try_join_team_by_domain(&user_id).await.unwrap_err();
+
+    assert!(matches!(
+        error,
+        TryJoinTeamByDomainError::JoinTeamError(JoinTeamError::AddRolesToUserError(_))
+    ));
+    assert_eq!(*team_repository.add_user_to_team_calls.lock().unwrap(), 1);
+    assert_eq!(*team_repository.remove_user_calls.lock().unwrap(), 1);
+    assert_no_enterprise_join_team_billing_calls(&team_repository, &customer_repository);
+    assert_eq!(roles_service.upsert_calls.lock().unwrap().len(), 1);
+    assert!(roles_service.remove_calls.lock().unwrap().is_empty());
+    assert!(channels_repository.add_calls.lock().unwrap().is_empty());
+    assert!(crm_enqueuer.populated.lock().unwrap().is_empty());
+    assert!(events.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn try_join_team_by_domain_enterprise_rolls_back_roles_when_channels_fail() {
+    let team_id = uuid::Uuid::from_u128(84);
+    let user_id = MacroUserIdStr::parse_from_str("macro|member@example.com").unwrap();
+    let team_repository = make_enterprise_domain_join_team_repository(team_id, &user_id);
+    let customer_repository = MockCustomerRepository::default();
+    let channels_repository = MockTeamChannelsRepository {
+        fail_add: true,
+        ..Default::default()
+    };
+    let roles_service = MockUserRolesAndPermissionsService::default();
+    let crm_enqueuer = RecordingCrmEnqueuer::default();
+    let events = Arc::new(Mutex::new(Vec::new()));
+
+    let service = TeamServiceImpl::new_with_analytics(
+        team_repository.clone(),
+        customer_repository.clone(),
+        channels_repository.clone(),
+        roles_service.clone(),
+        Arc::new(MockNotificationIngress::new(HashSet::new())),
+        crm_enqueuer.clone(),
+        NoOpTeamCrmSettingsRepository,
+        MockTeamAnalytics::new(events.clone()),
+    );
+
+    let error = service.try_join_team_by_domain(&user_id).await.unwrap_err();
+
+    assert!(matches!(
+        error,
+        TryJoinTeamByDomainError::JoinTeamError(JoinTeamError::TeamError(_))
+    ));
+    assert_eq!(*team_repository.add_user_to_team_calls.lock().unwrap(), 1);
+    assert_eq!(*team_repository.remove_user_calls.lock().unwrap(), 1);
+    assert_no_enterprise_join_team_billing_calls(&team_repository, &customer_repository);
+    assert_eq!(roles_service.upsert_calls.lock().unwrap().len(), 1);
+    assert_eq!(roles_service.remove_calls.lock().unwrap().len(), 1);
+    assert_eq!(
+        *channels_repository.add_calls.lock().unwrap(),
+        vec![(team_id, user_id.as_ref().to_string())]
+    );
+    assert!(crm_enqueuer.populated.lock().unwrap().is_empty());
+    assert!(events.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn try_join_team_by_domain_enterprise_status_read_precedes_membership_mutation() {
+    let team_id = uuid::Uuid::from_u128(85);
+    let user_id = MacroUserIdStr::parse_from_str("macro|member@example.com").unwrap();
+    let mut team_repository = make_enterprise_domain_join_team_repository(team_id, &user_id);
+    team_repository.fail_enterprise_status_lookup = true;
+    let customer_repository = MockCustomerRepository::default();
+    let channels_repository = MockTeamChannelsRepository::default();
+    let roles_service = MockUserRolesAndPermissionsService::default();
+    let crm_enqueuer = RecordingCrmEnqueuer::default();
+    let events = Arc::new(Mutex::new(Vec::new()));
+
+    let service = TeamServiceImpl::new_with_analytics(
+        team_repository.clone(),
+        customer_repository.clone(),
+        channels_repository.clone(),
+        roles_service.clone(),
+        Arc::new(MockNotificationIngress::new(HashSet::new())),
+        crm_enqueuer.clone(),
+        NoOpTeamCrmSettingsRepository,
+        MockTeamAnalytics::new(events.clone()),
+    );
+
+    let error = service.try_join_team_by_domain(&user_id).await.unwrap_err();
+
+    assert!(matches!(
+        error,
+        TryJoinTeamByDomainError::TeamError(TeamError::StorageLayerError(_))
+    ));
+    assert_eq!(
+        *team_repository
+            .enterprise_status_lookup_calls
+            .lock()
+            .unwrap(),
+        1
+    );
+    assert_eq!(*team_repository.add_user_to_team_calls.lock().unwrap(), 0);
+    assert_eq!(*team_repository.remove_user_calls.lock().unwrap(), 0);
+    assert_no_enterprise_join_team_billing_calls(&team_repository, &customer_repository);
+    assert!(roles_service.upsert_calls.lock().unwrap().is_empty());
+    assert!(channels_repository.add_calls.lock().unwrap().is_empty());
+    assert!(crm_enqueuer.populated.lock().unwrap().is_empty());
+    assert!(events.lock().unwrap().is_empty());
 }

--- a/crates/teams/src/domain/team_service/test.rs
+++ b/crates/teams/src/domain/team_service/test.rs
@@ -59,11 +59,13 @@ struct MockTeamRepository {
     team_for_get_by_id: Option<Team>,
     team_subscription_id: Option<stripe::SubscriptionId>,
     team_subscription_id_lookup_calls: Arc<Mutex<usize>>,
+    fail_team_subscription_id_lookup: bool,
     backfilled_subscription_id: Arc<Mutex<Option<stripe::SubscriptionId>>>,
     stripe_customer_id: Option<stripe::CustomerId>,
     stripe_customer_id_lookup_calls: Arc<Mutex<usize>>,
     team_payment_status: bool,
     team_payment_status_lookup_calls: Arc<Mutex<usize>>,
+    fail_team_payment_status_lookup: bool,
     enterprise: bool,
     enterprise_status_lookup_calls: Arc<Mutex<usize>>,
     fail_enterprise_status_lookup: bool,
@@ -105,11 +107,13 @@ impl MockTeamRepository {
             team_for_get_by_id: None,
             team_subscription_id: None,
             team_subscription_id_lookup_calls: Arc::new(Mutex::new(0)),
+            fail_team_subscription_id_lookup: false,
             backfilled_subscription_id: Arc::new(Mutex::new(None)),
             stripe_customer_id: None,
             stripe_customer_id_lookup_calls: Arc::new(Mutex::new(0)),
             team_payment_status: true,
             team_payment_status_lookup_calls: Arc::new(Mutex::new(0)),
+            fail_team_payment_status_lookup: false,
             enterprise: false,
             enterprise_status_lookup_calls: Arc::new(Mutex::new(0)),
             fail_enterprise_status_lookup: false,
@@ -185,7 +189,16 @@ impl TeamRepository for MockTeamRepository {
             .unwrap()
             .clone()
             .or_else(|| self.team_subscription_id.clone());
-        async move { Ok(subscription_id) }
+        let fail = self.fail_team_subscription_id_lookup;
+        async move {
+            if fail {
+                Err(TeamError::StorageLayerError(anyhow::anyhow!(
+                    "team subscription id lookup failed"
+                )))
+            } else {
+                Ok(subscription_id)
+            }
+        }
     }
 
     fn get_team_payment_status(
@@ -194,7 +207,16 @@ impl TeamRepository for MockTeamRepository {
     ) -> impl Future<Output = Result<bool, TeamError>> + Send {
         *self.team_payment_status_lookup_calls.lock().unwrap() += 1;
         let team_payment_status = self.team_payment_status;
-        async move { Ok(team_payment_status) }
+        let fail = self.fail_team_payment_status_lookup;
+        async move {
+            if fail {
+                Err(TeamError::StorageLayerError(anyhow::anyhow!(
+                    "team payment status lookup failed"
+                )))
+            } else {
+                Ok(team_payment_status)
+            }
+        }
     }
 
     fn get_team_enterprise_status(
@@ -2517,6 +2539,55 @@ async fn join_team_enterprise_rolls_back_accepted_invite_when_status_read_fails(
 }
 
 #[tokio::test]
+async fn join_team_rolls_back_accepted_invite_when_billing_lookup_fails() {
+    let team_id = uuid::Uuid::from_u128(49);
+    let invite_id = uuid::Uuid::from_u128(490);
+    let user_id = MacroUserIdStr::parse_from_str("macro|member@example.com").unwrap();
+
+    for (fail_payment_status, fail_subscription_id, expected_subscription_lookups) in
+        [(true, false, 0), (false, true, 1)]
+    {
+        let mut team_repository =
+            make_enterprise_join_team_repository(team_id, invite_id, &user_id);
+        team_repository.enterprise = false;
+        team_repository.fail_team_payment_status_lookup = fail_payment_status;
+        team_repository.fail_team_subscription_id_lookup = fail_subscription_id;
+
+        let service = TeamServiceImpl::new(
+            team_repository.clone(),
+            MockCustomerRepository::default(),
+            MockTeamChannelsRepository::default(),
+            MockUserRolesAndPermissionsService::default(),
+            Arc::new(MockNotificationIngress::new(HashSet::new())),
+            NoOpCrmEnqueuer,
+            NoOpTeamCrmSettingsRepository,
+        );
+
+        let error = service.join_team(&invite_id, &user_id).await.unwrap_err();
+
+        assert!(matches!(
+            error,
+            JoinTeamError::TeamError(TeamError::StorageLayerError(_))
+        ));
+        assert_eq!(*team_repository.rollback_accept_calls.lock().unwrap(), 1);
+        assert_eq!(
+            *team_repository
+                .team_payment_status_lookup_calls
+                .lock()
+                .unwrap(),
+            1
+        );
+        assert_eq!(
+            *team_repository
+                .team_subscription_id_lookup_calls
+                .lock()
+                .unwrap(),
+            expected_subscription_lookups
+        );
+    }
+}
+
+#[tokio::test]
 async fn test_join_team_backfills_legacy_team_subscription() {
     let team_id = uuid::Uuid::from_u128(43);
     let invite_id = uuid::Uuid::from_u128(430);
@@ -3340,6 +3411,54 @@ async fn test_try_join_team_by_domain_rolls_back_membership_when_roles_fail() {
         vec![(subscription_id.to_string(), 1)]
     );
     assert_eq!(*remove_user_calls.lock().unwrap(), 1);
+}
+
+#[tokio::test]
+async fn try_join_team_by_domain_rolls_back_membership_when_billing_lookup_fails() {
+    let team_id = uuid::Uuid::from_u128(86);
+    let user_id = MacroUserIdStr::parse_from_str("macro|member@example.com").unwrap();
+
+    for (fail_payment_status, fail_subscription_id, expected_subscription_lookups) in
+        [(true, false, 0), (false, true, 1)]
+    {
+        let mut team_repository = make_enterprise_domain_join_team_repository(team_id, &user_id);
+        team_repository.enterprise = false;
+        team_repository.fail_team_payment_status_lookup = fail_payment_status;
+        team_repository.fail_team_subscription_id_lookup = fail_subscription_id;
+
+        let service = TeamServiceImpl::new(
+            team_repository.clone(),
+            MockCustomerRepository::default(),
+            MockTeamChannelsRepository::default(),
+            MockUserRolesAndPermissionsService::default(),
+            Arc::new(MockNotificationIngress::new(HashSet::new())),
+            NoOpCrmEnqueuer,
+            NoOpTeamCrmSettingsRepository,
+        );
+
+        let error = service.try_join_team_by_domain(&user_id).await.unwrap_err();
+
+        assert!(matches!(
+            error,
+            TryJoinTeamByDomainError::TeamError(TeamError::StorageLayerError(_))
+        ));
+        assert_eq!(*team_repository.add_user_to_team_calls.lock().unwrap(), 1);
+        assert_eq!(*team_repository.remove_user_calls.lock().unwrap(), 1);
+        assert_eq!(
+            *team_repository
+                .team_payment_status_lookup_calls
+                .lock()
+                .unwrap(),
+            1
+        );
+        assert_eq!(
+            *team_repository
+                .team_subscription_id_lookup_calls
+                .lock()
+                .unwrap(),
+            expected_subscription_lookups
+        );
+    }
 }
 
 #[tokio::test]

--- a/crates/teams/src/domain/team_service/test.rs
+++ b/crates/teams/src/domain/team_service/test.rs
@@ -115,6 +115,7 @@ impl MockTeamRepository {
                     .unwrap()
                     .into_owned(),
                 false,
+                false,
             ),
             github_installation_move_calls: Arc::new(Mutex::new(Vec::new())),
             subscription_update_calls: Arc::new(Mutex::new(Vec::new())),
@@ -1054,6 +1055,7 @@ async fn test_create_team_moves_github_installation_to_created_team() {
         "NEW_TEAM".to_string(),
         user_id.clone().into_owned(),
         false,
+        false,
     );
     let mark_sent_calls: Arc<Mutex<Vec<Vec<uuid::Uuid>>>> = Arc::new(Mutex::new(Vec::new()));
     let mut team_repo = MockTeamRepository::new(Vec::new(), "Test Team", mark_sent_calls);
@@ -1090,6 +1092,7 @@ async fn test_create_team_propagates_github_installation_move_failure() {
         "New Team".to_string(),
         "NEW_TEAM".to_string(),
         user_id.clone().into_owned(),
+        false,
         false,
     );
     let mark_sent_calls: Arc<Mutex<Vec<Vec<uuid::Uuid>>>> = Arc::new(Mutex::new(Vec::new()));
@@ -1130,6 +1133,7 @@ async fn team_analytics_create_team_emits_created_event_with_team_id() {
         "Analytics Team".to_string(),
         "ANALYTICS_TEAM".to_string(),
         user_id.clone().into_owned(),
+        false,
         false,
     );
     let mark_sent_calls: Arc<Mutex<Vec<Vec<uuid::Uuid>>>> = Arc::new(Mutex::new(Vec::new()));
@@ -1176,6 +1180,7 @@ async fn team_analytics_failure_is_swallowed_by_create_team() {
         "ANALYTICS_TEAM".to_string(),
         user_id.clone().into_owned(),
         false,
+        false,
     );
     let mark_sent_calls: Arc<Mutex<Vec<Vec<uuid::Uuid>>>> = Arc::new(Mutex::new(Vec::new()));
     let mut team_repo = MockTeamRepository::new(Vec::new(), "Test Team", mark_sent_calls);
@@ -1206,6 +1211,7 @@ async fn team_analytics_create_team_does_not_emit_when_side_effect_fails() {
         "Analytics Team".to_string(),
         "ANALYTICS_TEAM".to_string(),
         user_id.clone().into_owned(),
+        false,
         false,
     );
     let mark_sent_calls: Arc<Mutex<Vec<Vec<uuid::Uuid>>>> = Arc::new(Mutex::new(Vec::new()));
@@ -1519,6 +1525,7 @@ async fn test_get_team_reports_crm_enabled() {
         "TEST_TEAM".to_string(),
         owner_id.clone(),
         true,
+        false,
     );
 
     let mark_sent_calls: Arc<Mutex<Vec<Vec<uuid::Uuid>>>> = Arc::new(Mutex::new(Vec::new()));
@@ -1690,6 +1697,7 @@ async fn test_patch_team_rejects_owner_role_assignment() {
         "TEST_TEAM".to_string(),
         owner_id,
         false,
+        false,
     );
 
     let (service, role_calls, name_calls) = build_service_with_team(team);
@@ -1727,6 +1735,7 @@ async fn test_patch_team_rejects_owner_downgrade() {
         "Test Team".to_string(),
         "TEST_TEAM".to_string(),
         owner_id.clone(),
+        false,
         false,
     );
 
@@ -1766,6 +1775,7 @@ async fn test_patch_team_applies_role_updates_and_name() {
         "Old Name".to_string(),
         "OLD_NAME".to_string(),
         owner_id.clone(),
+        false,
         false,
     );
 
@@ -1825,6 +1835,7 @@ async fn test_patch_team_empty_role_updates() {
         "OLD_NAME".to_string(),
         owner_id.clone(),
         false,
+        false,
     );
 
     let (service, role_calls, name_calls) = build_service_with_team(team);
@@ -1862,6 +1873,7 @@ async fn test_invite_users_to_team_backfills_legacy_team_subscription() {
         "Legacy Team".to_string(),
         "legacy-team".to_string(),
         owner_id.clone().into_owned(),
+        false,
         false,
     ));
     team_repo.team_payment_status = false;
@@ -1931,6 +1943,7 @@ async fn test_join_team_backfills_legacy_team_subscription() {
             "legacy-team".to_string(),
             owner_id.clone().into_owned(),
             false,
+            false,
         ));
     team_repo.team_payment_status = false;
     team_repo.team_subscription_id = None;
@@ -1988,6 +2001,7 @@ async fn test_join_team_rolls_back_accept_when_backfill_fails() {
             "Legacy Team".to_string(),
             "legacy-team".to_string(),
             owner_id.into_owned(),
+            false,
             false,
         ));
     team_repo.team_payment_status = false;

--- a/crates/teams/src/outbound/team_repo.rs
+++ b/crates/teams/src/outbound/team_repo.rs
@@ -356,6 +356,22 @@ impl TeamRepository for TeamRepositoryImpl {
     }
 
     #[tracing::instrument(skip(self), err)]
+    async fn get_team_enterprise_status(&self, team_id: &uuid::Uuid) -> Result<bool, TeamError> {
+        let enterprise = sqlx::query_scalar!(
+            r#"
+            SELECT enterprise
+            FROM team
+            WHERE id = $1
+            "#,
+            team_id,
+        )
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(enterprise)
+    }
+
+    #[tracing::instrument(skip(self), err)]
     async fn create_team(
         &self,
         user_id: &MacroUserIdStr<'_>,

--- a/crates/teams/src/outbound/team_repo.rs
+++ b/crates/teams/src/outbound/team_repo.rs
@@ -148,7 +148,7 @@ impl TeamRepositoryImpl {
             r#"
             INSERT INTO team (id, name, owner_id, seat_count, subscription_id, paying)
             VALUES ($1, $2, $3, 1, $4, TRUE)
-            RETURNING id, name, slug, owner_id
+            RETURNING id, name, slug, owner_id, enterprise
             "#,
             id,
             team_name,
@@ -167,6 +167,7 @@ impl TeamRepositoryImpl {
                 crm_enabled: false,
                 // New teams start without an auto-join domain.
                 auto_join_domain: None,
+                enterprise: row.enterprise,
             })
         })
         .fetch_one(&mut *transaction)
@@ -1062,7 +1063,7 @@ impl TeamRepository for TeamRepositoryImpl {
     async fn get_team_by_id(&self, team_id: &uuid::Uuid) -> Result<TeamWithMembers, TeamError> {
         let team = sqlx::query!(
             r#"
-            SELECT t.id, t.name, t.slug, t.owner_id, t.auto_join_domain,
+            SELECT t.id, t.name, t.slug, t.owner_id, t.auto_join_domain, t.enterprise,
                 COALESCE(tcs.crm_enabled, FALSE) AS "crm_enabled!"
             FROM team t
             LEFT JOIN team_crm_settings tcs ON tcs.team_id = t.id
@@ -1080,6 +1081,7 @@ impl TeamRepository for TeamRepositoryImpl {
                     .into_owned(),
                 crm_enabled: row.crm_enabled,
                 auto_join_domain: row.auto_join_domain,
+                enterprise: row.enterprise,
             })
         })
         .fetch_one(&self.pool)
@@ -1117,7 +1119,7 @@ impl TeamRepository for TeamRepositoryImpl {
     async fn get_user_teams(&self, user_id: &MacroUserIdStr<'_>) -> Result<Vec<Team>, TeamError> {
         let teams = sqlx::query!(
             r#"
-            SELECT t.id, t.name, t.slug, t.owner_id, t.auto_join_domain,
+            SELECT t.id, t.name, t.slug, t.owner_id, t.auto_join_domain, t.enterprise,
                 COALESCE(tcs.crm_enabled, FALSE) AS "crm_enabled!"
             FROM team t
             JOIN team_user tu ON t.id = tu.team_id
@@ -1136,6 +1138,7 @@ impl TeamRepository for TeamRepositoryImpl {
                     .into_owned(),
                 crm_enabled: row.crm_enabled,
                 auto_join_domain: row.auto_join_domain,
+                enterprise: row.enterprise,
             })
         })
         .fetch_all(&self.pool)

--- a/crates/teams/src/outbound/team_repo/test.rs
+++ b/crates/teams/src/outbound/team_repo/test.rs
@@ -148,6 +148,7 @@ async fn test_create_team(pool: Pool<Postgres>) -> anyhow::Result<()> {
     assert_eq!(result.name, "team1");
     assert_eq!(result.slug, "MACRO");
     assert_eq!(result.owner_id.0.as_ref(), "macro|user3@user.com");
+    assert!(!result.enterprise());
 
     // Create team with too large a name
     let err = team_repo
@@ -1291,14 +1292,47 @@ async fn test_patch_team_plan(pool: Pool<Postgres>) -> anyhow::Result<()> {
     migrator = "MACRO_DB_MIGRATIONS",
     fixtures(path = "../../../fixtures", scripts("teams"))
 )]
-async fn test_get_team_by_id_includes_slug(pool: Pool<Postgres>) -> anyhow::Result<()> {
-    let team_repo = TeamRepositoryImpl::new(pool);
+async fn test_get_team_by_id_hydrates_enterprise_status(
+    pool: Pool<Postgres>,
+) -> anyhow::Result<()> {
+    let team_repo = TeamRepositoryImpl::new(pool.clone());
     let team_id = macro_uuid::string_to_uuid("11111111-1111-1111-1111-111111111111")?;
+
+    sqlx::query!("UPDATE team SET enterprise = TRUE WHERE id = $1", &team_id)
+        .execute(&pool)
+        .await?;
 
     let team = team_repo.get_team_by_id(&team_id).await?.team;
 
     assert_eq!(team.name(), "team1");
     assert_eq!(team.slug(), "MACRO");
+    assert!(team.enterprise());
+
+    Ok(())
+}
+
+#[sqlx::test(
+    migrator = "MACRO_DB_MIGRATIONS",
+    fixtures(path = "../../../fixtures", scripts("teams"))
+)]
+async fn test_get_user_teams_hydrates_enterprise_status(
+    pool: Pool<Postgres>,
+) -> anyhow::Result<()> {
+    let team_repo = TeamRepositoryImpl::new(pool.clone());
+    let team_id = macro_uuid::string_to_uuid("11111111-1111-1111-1111-111111111111")?;
+    let user_id = MacroUserIdStr::parse_from_str("macro|user@user.com")?;
+
+    sqlx::query!("UPDATE team SET enterprise = TRUE WHERE id = $1", &team_id)
+        .execute(&pool)
+        .await?;
+
+    let teams = team_repo.get_user_teams(&user_id).await?;
+    let team = teams
+        .iter()
+        .find(|team| team.id() == &team_id)
+        .expect("updated team should be returned for the user");
+
+    assert!(team.enterprise());
 
     Ok(())
 }

--- a/crates/teams/src/outbound/team_repo/test.rs
+++ b/crates/teams/src/outbound/team_repo/test.rs
@@ -136,6 +136,35 @@ async fn test_get_team_payment_status(pool: Pool<Postgres>) -> anyhow::Result<()
     migrator = "MACRO_DB_MIGRATIONS",
     fixtures(path = "../../../fixtures", scripts("teams"))
 )]
+async fn test_get_team_enterprise_status(pool: Pool<Postgres>) -> anyhow::Result<()> {
+    let team_repo = TeamRepositoryImpl::new(pool.clone());
+    let team_id = macro_uuid::string_to_uuid("11111111-1111-1111-1111-111111111111")?;
+
+    let enterprise = team_repo.get_team_enterprise_status(&team_id).await?;
+    assert!(!enterprise);
+
+    sqlx::query!("UPDATE team SET enterprise = TRUE WHERE id = $1", &team_id)
+        .execute(&pool)
+        .await?;
+
+    let enterprise = team_repo.get_team_enterprise_status(&team_id).await?;
+    assert!(enterprise);
+
+    let missing_team_id = macro_uuid::string_to_uuid("63333333-3333-3333-3333-333333333333")?;
+    let error = team_repo
+        .get_team_enterprise_status(&missing_team_id)
+        .await
+        .expect_err("a missing team should return an error");
+
+    assert!(matches!(error, TeamError::TeamDoesNotExist));
+
+    Ok(())
+}
+
+#[sqlx::test(
+    migrator = "MACRO_DB_MIGRATIONS",
+    fixtures(path = "../../../fixtures", scripts("teams"))
+)]
 async fn test_create_team(pool: Pool<Postgres>) -> anyhow::Result<()> {
     let team_repo = TeamRepositoryImpl::new(pool);
 


### PR DESCRIPTION
## Summary
- Add an `enterprise` flag to teams, expose it in team reads, and add a lightweight SQLx-backed repository lookup. The migration defaults existing and new teams to non-enterprise; enterprise designation remains an ops-only database change.
- Bypass payment checks, legacy subscription backfill, and Stripe seat bookkeeping for enterprise invitations, invite acceptance, domain auto-join, and member removal.
- Preserve local seat caps, membership updates, roles, channels, CRM, analytics, and rollback behavior, with coverage for success and failure paths.

## Testing
- `just setup_macrodb`
- `just prepare_db`
- `SQLX_OFFLINE=true cargo check -p teams --all-features`
- `cargo test -p teams` (141 passed)
- `just check`
- `just clippy`
- `just format`
- `just hakari`
