### PR TITLE
fix(crm): allow all team members to use CRM entity context menu actions

### DIFF
--- a/apps/web/src/features/next-soup/actions/make-hide-company-action.ts
+++ b/apps/web/src/features/next-soup/actions/make-hide-company-action.ts
@@ -5,17 +5,16 @@ import type { SoupState } from '../create-soup-state';
 import { restoreSoupFocus } from '../utils';
 
 type MakeHideCompanyOptions = {
-  // Admin/owner-only on the FE; the backend independently enforces
+  // Available to all team members; the backend enforces
   // EditAccessLevel on PUT /crm/companies/{id}/hidden.
-  isTeamAdmin: () => boolean;
   setHidden: (companyId: string, hidden: boolean) => Promise<unknown>;
 };
 
 export const makeHideCompanyAction = (options: MakeHideCompanyOptions) => {
-  const { isTeamAdmin, setHidden } = options;
+  const { setHidden } = options;
 
   const canExecute = (entity: EntityData): boolean =>
-    entity.type === 'crm_company' && isTeamAdmin();
+    entity.type === 'crm_company';
 
   const previewPanel = useMaybePreviewPanel();
 

--- a/apps/web/src/features/next-soup/actions/make-set-company-property-action.ts
+++ b/apps/web/src/features/next-soup/actions/make-set-company-property-action.ts
@@ -8,24 +8,18 @@ import type { Property } from '@property/types';
 /** Builtin CRM company fields settable from entity action menus. */
 export type CompanyCrmField = 'stage' | 'owner' | 'revenue';
 
-type MakeSetCompanyPropertyOptions = {
-  // Admin/owner-only on the FE, matching row-level CRM editing; the
-  // backend independently enforces write access on property saves.
-  isTeamAdmin: () => boolean;
-};
-
 /**
  * "Set stage / owner / revenue" for CRM company rows: opens the global
  * property editor (the same one task status/priority/assignee commands
  * use) targeting the builtin CRM property, editing the whole selection.
+ * Available to all team members; the backend enforces write access on
+ * property saves.
  */
-export const makeSetCompanyPropertyAction = (
-  options: MakeSetCompanyPropertyOptions
-) => {
+export const makeSetCompanyPropertyAction = () => {
   const dealStages = useDealStages();
 
   const canExecute = (entity: EntityData): boolean =>
-    entity.type === 'crm_company' && options.isTeamAdmin();
+    entity.type === 'crm_company';
 
   const propertyFor = (field: CompanyCrmField): Property | undefined => {
     // Stage resolves through the active deal-stage set (the team's own

--- a/apps/web/src/features/next-soup/actions/use-entity-action-hotkeys.ts
+++ b/apps/web/src/features/next-soup/actions/use-entity-action-hotkeys.ts
@@ -13,7 +13,6 @@ import { TOKENS } from '@core/hotkey/tokens';
 import { type EntityData, isTaskEntity } from '@entity';
 import { SYSTEM_PROPERTY_IDS } from '@property/constants';
 import type { Property, PropertyDefinitionDomain } from '@property/types';
-import { useIsTeamAdmin } from '@queries/team/teams';
 import { onCleanup } from 'solid-js';
 import type { SoupState } from '../create-soup-state';
 import {
@@ -78,10 +77,7 @@ export const useEntityActionHotkeys = (
 
   const favoriteAction = makeFavoriteAction();
 
-  const isTeamAdmin = useIsTeamAdmin();
-  const setCompanyPropertyAction = makeSetCompanyPropertyAction({
-    isTeamAdmin: () => isTeamAdmin(),
-  });
+  const setCompanyPropertyAction = makeSetCompanyPropertyAction();
 
   const getEntitiesForAction = (): EntityData[] => {
     if (

--- a/apps/web/src/features/next-soup/soup-view/create-soup-entity-actions.ts
+++ b/apps/web/src/features/next-soup/soup-view/create-soup-entity-actions.ts
@@ -13,7 +13,6 @@ import { type HotkeyToken, TOKENS } from '@core/hotkey/tokens';
 import { isMobile } from '@core/mobile/isMobile';
 import type { EntityData } from '@entity';
 import { useSetCompanyHiddenMutation } from '@queries/crm/companies';
-import { useIsTeamAdmin } from '@queries/team/teams';
 import type { Component, JSX } from 'solid-js';
 import {
   makeBlockSenderAction,
@@ -86,7 +85,6 @@ export function createSoupEntityActions(): {
   const analytics = useAnalytics();
   const userId = useUserId();
   const notificationSource = useGlobalNotificationSource();
-  const isTeamAdmin = useIsTeamAdmin();
   const hiddenMutation = useSetCompanyHiddenMutation();
 
   const markDone = makeMarkDoneAction({
@@ -114,13 +112,10 @@ export function createSoupEntityActions(): {
   const markSenderSignalAction = makeMarkSenderSignalAction();
   const markSenderNoiseAction = makeMarkSenderNoiseAction();
   const hideCompanyAction = makeHideCompanyAction({
-    isTeamAdmin: () => isTeamAdmin(),
     setHidden: (companyId, hidden) =>
       hiddenMutation.mutateAsync({ companyId, hidden }),
   });
-  const setCompanyPropertyAction = makeSetCompanyPropertyAction({
-    isTeamAdmin: () => isTeamAdmin(),
-  });
+  const setCompanyPropertyAction = makeSetCompanyPropertyAction();
 
   const buildActionGroups: BuildActionGroups = (
     soup,
@@ -377,8 +372,8 @@ export function createSoupEntityActions(): {
       });
     }
 
-    // CRM group (admin/owner only): Set stage/owner/revenue on the whole
-    // company selection, Hide / Unhide for a single company.
+    // CRM group: Set stage/owner/revenue on the whole company
+    // selection, Hide / Unhide for a single company.
     const crmItems: SoupEntityActionItem[] = [];
 
     if (canExecuteAll(setCompanyPropertyAction.canExecute)) {


### PR DESCRIPTION
## Summary

The right-click CRM actions on company rows — **Set stage / Set owner / Set revenue** and **Hide / Unhide company** — were gated to team admins/owners on the frontend, so regular members stopped seeing them entirely. These actions should be available to everyone on the team.

The gate was frontend-only: the backend enforces entity-level `EditAccessLevel` on `PUT /crm/companies/{id}/hidden` and on property saves, which regular team members already satisfy.

## Changes

- `make-set-company-property-action.ts` / `make-hide-company-action.ts`: drop the `isTeamAdmin` option; `canExecute` now only requires a `crm_company` entity
- `create-soup-entity-actions.ts` / `use-entity-action-hotkeys.ts`: remove the now-unused `useIsTeamAdmin` wiring

Note: `useCrmPermissions().canEditCrm` (team-crm-config.ts) still gates inline board editing (kanban stage drag, owner pickers) to admins/owners — left untouched here, can be relaxed in a follow-up if we want all CRM editing open to members.