### PR TITLE
fix(crm): center no-team and CRM-disabled empty states

### DIFF
--- a/apps/web/src/features/next-soup/soup-view/empty-states.tsx
+++ b/apps/web/src/features/next-soup/soup-view/empty-states.tsx
@@ -250,6 +250,7 @@ export function EmptyState(props: {
           <Match when={!teamResolved()}>{null}</Match>
           <Match when={hasNoTeam()}>
             <EmptyStatePanel
+              centered
               graphic={EmptyStateCompaniesGraphic}
               title="Join a team to enable CRM"
               description="Create or join a team in Settings > Team."
@@ -261,6 +262,7 @@ export function EmptyState(props: {
           </Match>
           <Match when={!crmEnabled()}>
             <EmptyStatePanel
+              centered
               graphic={EmptyStateCompaniesGraphic}
               title="CRM is disabled"
               description={


### PR DESCRIPTION
## Summary

The empty states shown on the CRM/Companies tab when the user has no team ('Join a team to enable CRM') or when CRM is disabled ('CRM is disabled') were rendered with the default left-aligned `EmptyStatePanel` layout, which is designed for data empty states that stack with the chat input.

These two panels are settings CTAs rather than data empty states, so they now use the `centered` variant (like the search / no-filter-match panels), centering them on the page.

The 'No customers yet' state keeps the default layout to match the other list empty states.