### PR TITLE
fix(search): do not block search view render on initial all-soup call

### DIFF
--- a/apps/web/src/features/next-soup/soup-view/soup-view-context.tsx
+++ b/apps/web/src/features/next-soup/soup-view/soup-view-context.tsx
@@ -654,6 +654,14 @@ export const SoupViewContextProvider: FlowComponent<
     }
   );
 
+  // Reading `.data` on a query with no data yet suspends the nearest
+  // <Suspense> (SplitPanel's, which wraps the whole view — chrome included)
+  // until the fetch settles. Branch on the loading state first so a cold
+  // initial soup call leaves the view shell rendered and only the list
+  // region waits on data.
+  const itemsQueryData = () =>
+    itemsQuery.isLoading ? undefined : itemsQuery.data;
+
   /**
    * Unified soup items surface: the reactive urql query when active, the
    * TanStack infinite query otherwise. Grouped data (`groups`/`itemsById`)
@@ -661,7 +669,7 @@ export const SoupViewContextProvider: FlowComponent<
    */
   const itemsSource = {
     data: () =>
-      reactiveActive() ? reactiveItemsQuery.data() : itemsQuery.data,
+      reactiveActive() ? reactiveItemsQuery.data() : itemsQueryData(),
     isLoading: () =>
       reactiveActive() ? reactiveItemsQuery.isLoading() : itemsQuery.isLoading,
     isFetching: () =>
@@ -800,8 +808,8 @@ export const SoupViewContextProvider: FlowComponent<
     initialPage: createMemo(() => {
       if (itemsQuery.isPlaceholderData) return;
 
-      const groups = itemsQuery.data?.groups;
-      const items = itemsQuery.data?.itemsById;
+      const groups = itemsQueryData()?.groups;
+      const items = itemsQueryData()?.itemsById;
       if (!groups || !items) return;
       return { groups, items };
     }),

--- a/apps/web/src/features/next-soup/soup-view/soup-view-context.tsx
+++ b/apps/web/src/features/next-soup/soup-view/soup-view-context.tsx
@@ -655,10 +655,9 @@ export const SoupViewContextProvider: FlowComponent<
   );
 
   // Reading `.data` on a query with no data yet suspends the nearest
-  // <Suspense> (SplitPanel's, which wraps the whole view — chrome included)
-  // until the fetch settles. Branch on the loading state first so a cold
-  // initial soup call leaves the view shell rendered and only the list
-  // region waits on data.
+  // <Suspense> until the fetch settles. Branch on the loading state first
+  // so a cold initial soup call leaves the view shell rendered and only
+  // the list region waits on data.
   const itemsQueryData = () =>
     itemsQuery.isLoading ? undefined : itemsQuery.data;
 


### PR DESCRIPTION
On a cold load, the soup provider's memos read `itemsQuery.data` before any data exists, which suspends SplitPanel's `<Suspense>` and blanks the entire view (search bar and filters included) until the initial all-soup call resolves. Guard the read on `isLoading` so the chrome renders immediately and only the list region waits on data — the search bar is usable (and returns search-service results) while the initial feed is still in flight.
