### PR TITLE
fix(email): clearer divider between message and reply input

### DIFF
--- a/apps/web/src/features/block-email/component/MessageContainer.tsx
+++ b/apps/web/src/features/block-email/component/MessageContainer.tsx
@@ -356,7 +356,15 @@ export function MessageContainer(props: MessageContainerProps) {
               </Show>
             </div>
             <Show when={showInlineReplyArea()}>
-              <div class={cn('relative -mx-4 mb-0 border-t border-edge-muted')}>
+              <div
+                class={cn(
+                  'relative -mx-4 mb-0 border-t border-ink/20',
+                  (visibleAttachments().length > 0 ||
+                    draftAttachments().length > 0 ||
+                    forwardedAttachments().length > 0) &&
+                    'mt-2'
+                )}
+              >
                 <Show when={props.isLastMessage && !isMobile()}>
                   <FloatingInputLoader
                     isLoading={context.query.isFetching}


### PR DESCRIPTION
## Summary

In the email thread view, the inline reply input bled into the received message above it — the divider between them used `border-edge-muted`, which is nearly invisible against the message card background, making it hard to tell where the received email ends and the reply starts.

## Changes

- Bump the divider between the message body and the inline reply area from `border-edge-muted` to `border-ink/20` (ink at 20% opacity), a clearly visible step up that adapts to both dark and light mode. This matches the opacity-ink border pattern already used elsewhere in the app.
- Add `mt-2` above the divider when the message renders any attachment strip (regular attachments, image/video previews, or draft/forwarded strips), so attachment pills no longer sit flush against the line. Text-only messages keep the existing spacing.

## Before / After

- Before: reply input visually merged with the quoted message; attachment pills touched the divider.
- After: a visible separation line between the received email and the reply input, with breathing room under attachments.