### PR TITLE
fix(email): show "me" in soup email rows when all participants are the current user

### DIFF
--- a/apps/web/src/features/entity/extractors/entity-email-participants.tsx
+++ b/apps/web/src/features/entity/extractors/entity-email-participants.tsx
@@ -101,14 +101,6 @@ function resolveParticipants(
 ): ResolvedParticipant[] {
   if (!participants || participants.length === 0) return [];
 
-  if (
-    participants.length === 1 &&
-    userEmail &&
-    participants[0].email === userEmail
-  ) {
-    return [{ participant: participants[0], displayName: 'me' }];
-  }
-
   const seen = new Set<string>();
   const result: ResolvedParticipant[] = [];
 
@@ -123,6 +115,13 @@ function resolveParticipants(
     seen.add(displayName);
 
     result.push({ participant, displayName });
+  }
+
+  // Every participant was the current user (self-to-self threads, or
+  // duplicate own-address rows from multi-inbox accounts) — show "me".
+  if (result.length === 0) {
+    const self = participants.find((p) => userEmail && p.email === userEmail);
+    if (self) return [{ participant: self, displayName: 'me' }];
   }
 
   return result;


### PR DESCRIPTION
## Summary

Email threads in the soup emails tab showed no sender name when every participant on the thread is the current user — e.g. self-to-self threads, or multi-inbox accounts where the backend returns duplicate rows of the user's own address.

## Cause

The soup email row renders the thread's participants (`EntityEmailParticipants`), not the backend's `senderName`. `resolveParticipants` filters out any participant matching the current user's email, and its `"me"` fallback only fired when the list had exactly one participant. With two duplicate own-address rows, the special case was skipped and the filter removed everything, leaving the label empty.

## Fix

Generalized the fallback in `resolveParticipants`: after filtering, if the result is empty but one of the original participants was the current user, show `"me"`. This subsumes the previous single-participant special case.

Threads whose participants genuinely lack email addresses still render empty rather than falsely claiming "me".

Note: the backend also emits duplicate participant rows (same `id`/`linkId`) for these threads — not addressed here.