### PR TITLE
chore(infra): bump prod OpenSearch EBS to 400GB/node

### DIFF
--- a/infra/stacks/opensearch/index.ts
+++ b/infra/stacks/opensearch/index.ts
@@ -128,8 +128,11 @@ const opensearchDomain = new aws.opensearch.Domain(
     // per instance storage
     ebsOptions: {
       ebsEnabled: true,
-      volumeSize: stack === 'prod' ? 256 : 50,
+      volumeSize: stack === 'prod' ? 400 : 50,
       volumeType: 'gp3',
+      // Pin prod gp3 IOPS/throughput to the live values so a size change
+      // doesn't reset throughput to the gp3 default (125 MB/s).
+      ...(stack === 'prod' ? { iops: 3000, throughput: 250 } : {}),
     },
     nodeToNodeEncryption: {
       enabled: true,


### PR DESCRIPTION
Prod OpenSearch data nodes are running at ~80–89% disk (~30–47 GB free each). The millisecond-timestamp backfill of the 46M-doc `emails` index — and the `emails_v2` reindex in #4898 — rewrites the whole index, which transiently needs roughly 1× its size in headroom; at current capacity that crossed the 95% flood-stage watermark and briefly put indices into read-only. This grows prod gp3 volumes **256 → 400 GB** per data node (+432 GB total, ~$53/mo at $0.122/GB-mo) to give safe headroom, and can be scaled back once the millis-only migration shrinks the index.

Also pins prod gp3 `iops: 3000` / `throughput: 250` (the current live values) explicitly, so the size change can't reset throughput to the gp3 default (125 MB/s). Dev is unchanged.

Confirm the `pulumi preview` on this PR shows only the volumeSize increase (no throughput/instance changes) before applying via the deploy-pulumi-stack workflow (opensearch / prod). The gp3 resize is an online modify — no downtime.
