### PR TITLE
docs: document outline, inline tags, CRM views/Signal filter, team domain auto-join

### DIFF
--- a/apps/docs/account/teams.mdx
+++ b/apps/docs/account/teams.mdx
@@ -16,6 +16,10 @@ Click **Team** in the bottom left to create a team. You can add the first member
   There's no free plan for teams; every member needs a paid seat. See [Billing & plans](/account/billing).
 </Note>
 
+## Auto-join on domain
+
+Rather than invite coworkers one at a time, admins and owners can turn on **Auto-join on domain** from **Settings → Team**. When it's on, anyone who signs up for Macro with an email on the team owner's domain (for example `@acme.com`) is added to the team automatically. Toggle it off at any time to return to invite-only; existing members are unaffected either way.
+
 ## Roles
 
 Teams have three roles, in increasing order of access:

--- a/apps/docs/product/crm.mdx
+++ b/apps/docs/product/crm.mdx
@@ -50,6 +50,12 @@ The list trades cards for rows. Every company appears in a table with **Stage**,
   Have CRM in Macro but can't see your leads? It needs to be enabled for your team — turn it on in your team settings, or contact your team admin to enable it.
 </Note>
 
+### Saved views
+
+Once you've shaped the board or list with the **Group** and **Filter** controls, save that arrangement as a **view** so you don't have to rebuild it each time. Open the **Views** menu in the topbar to save the current setup, switch between saved views, and manage them. Views come in two kinds: **personal** views that only you see, and **team** views shared with everyone (team views are created and managed by admins and owners).
+
+Pin a view as your **default** with the push-pin action on any saved view, and Customers opens straight to it. A personal default takes precedence over a team default, so you can override the team's starting point with your own.
+
 ### Records build themselves
 
 When someone on your team emails an external contact, Macro creates a contact record for them and groups contacts into companies by email domain (everyone `@acme.com` rolls up to one Acme record). Each contact tracks its first and last interaction, so you can see the full history of a relationship at a glance. Generic tool and vendor domains (the SaaS notification emails every company gets) are filtered out so the CRM stays focused on your actual customers.
@@ -58,7 +64,7 @@ New companies are enriched automatically with public data: name, description, lo
 
 ### One shared view of every relationship
 
-Open **Customers** from the sidebar to browse your team's accounts. A company page shows its domains, contacts, and email threads in one place. The **Team** and **Me** tabs let you see either everything your team has exchanged with that account or just your own threads. Contact pages work the same way.
+Open **Customers** from the sidebar to browse your team's accounts. A company page shows its domains, contacts, and email threads in one place. The **Team** and **Me** tabs let you see either everything your team has exchanged with that account or just your own threads. A **Signal / All** toggle sits alongside them: **Signal** narrows the list to the important threads (the same importance filter as the mail view's Signal tab), while **All** shows every thread. The two toggles combine, so you can look at just the important email you've personally exchanged, or everything the whole team ever has. Contact pages work the same way.
 
 Every company and contact also has a **discussion** thread, so deal notes and context live on the record itself instead of in a side channel. Like everything in Macro, CRM records are blocks: @mention a company or contact in a doc, task, or channel, and agents can use your CRM as context like the rest of your [team memory](/product/unified-memory).
 

--- a/apps/docs/product/docs.mdx
+++ b/apps/docs/product/docs.mdx
@@ -32,6 +32,14 @@ The editor supports the full set of block nodes: paragraphs, Heading 1/2/3, bull
 
 Markdown autoformatting works as you type (`#`/`##`/`###`, `-`, `1.`, `[]`, `>`, `---`, and backticks), `:shortcode:` emoji are supported, blocks can be dragged to reorder, <kbd>tab</kbd>/<kbd>shift</kbd>\+<kbd>tab</kbd> indent and outdent, and find & replace (<kbd>cmd</kbd>\+<kbd>f</kbd>) supports regex and replace-one/replace-all. The slash menu (`/`, or the command menu) inserts any of these: Normal text, Heading 1/2/3, Blockquote, Code block, Bullet/Numbered/Checklist, **Task** (an inline task with mentions), Image, Video, Link, Equation (`/latex` or `/math`), Table (5×3), and Divider. @mentions render in the body as collapsible inline pills. Typing `;` opens the [snippets](/product/snippets) menu to insert reusable content.
 
+### Outline
+
+Longer documents show an **outline** on the left edge: a column of dashes, one per heading, that tracks your place as you scroll, with the dash for the section you're reading highlighted. Hover the outline to expand the full list of headings, and click any heading to jump straight to it. The outline appears once a document has at least three headings and the window is wide enough to fit it, and stays out of the way on mobile and while browsing version history.
+
+### Tags
+
+Type `#` in a document — in the title or the body — to open the tag menu. Pick an existing tag or create a new one, choosing its color and whether it's a **personal** tag or one shared with your **team**. Tags render inline as colored pills; click one to see everything else carrying it. Tagging turns a set of documents into a lightweight database: filter your files and [search](/product/search#filtering-by-tags) by tag to slice your workspace the way you would in a Notion database. See [Properties](/concepts/properties) for how tags fit into the wider property system.
+
 ### Comments & history
 
 Comments are inline and thread-based, anchored to a text selection. You can reply, resolve and unresolve, draft, and edit or delete your own. Full version history is available via time-travel: browse historical states grouped by user and time, and **fork** a document at any past version into a new doc.


### PR DESCRIPTION
## Summary

Updates `docs.macro.com` (the Mintlify site under `apps/docs`) to cover the user-facing changes merged in the last day. cc @jbecke for review.

I reviewed all PRs merged to `main` in the last 24 hours, identified the ones that change user-facing behavior or add a feature, and drafted docs for each on the appropriate product page.

## Documentation changes

**Documents** (`product/docs.mdx`)
- **Outline** — new subsection describing the left-edge heading outline: a dash per heading that tracks scroll position, hover to expand, click to jump. Appears at ≥3 headings on a wide-enough window. Documents #4834.
- **Tags** — new subsection: type `#` in a title or body to open the tag menu, pick or create a tag (with a color and personal/team scope), rendered as clickable inline pills. Links out to search-by-tag and the properties system. Documents #4901.

**CRM** (`product/crm.mdx`)
- **Saved views** — new subsection covering the restored Views menu: saving a board/list arrangement, personal vs. team views, and pinning a default (personal default wins over team). Documents #4885.
- **Signal/All email filter** — extended the company/contact section to describe the new Signal / All toggle alongside Team / Me, and how the two combine. Documents #4862.

**Teams & Admin** (`account/teams.mdx`)
- **Auto-join on domain** — new section: admins/owners can toggle automatic team membership for new sign-ups on the owner's email domain. Documents #4860.

## Considered but not documented

- **feat(ai): make Sonnet 5 the paid default (#4844)** — user-facing, but the docs currently have no model-selection surface to attach it to; adding one for a single volatile model name would go stale quickly. Left out pending a broader "which model your agent uses" section.
- The monthly **changelog** pages are generated from tagged GitHub releases (version labels + compare links). I didn't hand-author a July page to avoid inventing version numbers; that flow is best left to the release automation.
- The remaining merged PRs were bug fixes, performance/infra work, internal refactors (soup/GraphQL, hex-architecture ports, CI), and already-documented items — no user-facing doc impact.

## Notes
- All new internal links resolve to existing pages/anchors (`/product/search#filtering-by-tags`, `/concepts/properties`).
- Prose follows the `apps/docs/AGENTS.md` style guide (second person, sentence-case headings, bold for UI elements, "block"/"@mention"/"channel" terminology).

---
_Generated by [Claude Code](https://claude.ai/code/session_01J2k8F72j1nTTQaXNx47ooL)_