### PR TITLE
fix(channels): make reaction ordering stable across refreshes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2587,6 +2587,7 @@ dependencies = [
  "frecency",
  "futures",
  "http-body-util",
+ "indexmap 2.14.0",
  "item_filters",
  "macro_db_migrator",
  "macro_env",

--- a/crates/channels/Cargo.toml
+++ b/crates/channels/Cargo.toml
@@ -48,6 +48,7 @@ outbound = [
   "dep:contacts",
   "dep:entity_access",
   "dep:entity_access_db_utils",
+  "dep:indexmap",
   "dep:macro_uuid",
   "dep:model-entity",
   "dep:model_notifications",
@@ -80,6 +81,7 @@ entity_access_db_utils = { path = "../entity_access_db_utils", optional = true }
 filter_ast = { path = "../filter_ast", optional = true }
 frecency = { path = "../frecency", optional = true }
 futures = { workspace = true, optional = true }
+indexmap = { workspace = true, optional = true }
 item_filters = { path = "../item_filters", optional = true }
 macro_event_broker = { path = "../macro_event_broker", default-features = false }
 macro_event_topics = { path = "../macro_event_topics" }

--- a/crates/channels/src/outbound/pg_channels_repo.rs
+++ b/crates/channels/src/outbound/pg_channels_repo.rs
@@ -39,6 +39,8 @@ use sqlx::{Executor, PgPool, Postgres};
 #[cfg(feature = "list")]
 use sqlx::{QueryBuilder, Row, postgres::PgRow};
 use std::collections::{HashMap, HashSet};
+
+use indexmap::IndexMap;
 use uuid::Uuid;
 
 /// Postgres-backed repository for channels.
@@ -1925,8 +1927,10 @@ impl ChannelRepo for PgChannelsRepo {
         .fetch_all(&self.pool)
         .await?;
 
-        // Group by message_id, then fold by emoji within each message.
-        let mut map: HashMap<Uuid, HashMap<String, Vec<String>>> = HashMap::new();
+        // Group by message_id, then fold by emoji within each message. Rows arrive
+        // ordered by created_at ASC, so an IndexMap preserves first-reacted order per
+        // emoji instead of the random order a HashMap would iterate in.
+        let mut map: HashMap<Uuid, IndexMap<String, Vec<String>>> = HashMap::new();
         for r in rows {
             map.entry(r.message_id)
                 .or_default()

--- a/crates/channels/src/outbound/pg_channels_repo/tests.rs
+++ b/crates/channels/src/outbound/pg_channels_repo/tests.rs
@@ -1001,8 +1001,17 @@ async fn reactions_grouped_by_emoji(pool: Pool<Postgres>) -> anyhow::Result<()> 
     let repo = repo(pool);
     let map = repo.get_reactions_batch(&[MSG1, MSG3]).await?;
 
-    // msg1 has thumbsup (2 users) and tada (1 user)
+    // msg1 has thumbsup (2 users) and tada (1 user), and should always come back in
+    // first-reacted-at order (thumbsup before tada) rather than shuffled, since the
+    // fixture reacts thumbsup before tada.
     let msg1_reactions = map.get(&MSG1).unwrap();
+    assert_eq!(
+        msg1_reactions
+            .iter()
+            .map(|r| r.emoji.as_str())
+            .collect::<Vec<_>>(),
+        vec!["\u{1f44d}", "\u{1f389}"]
+    );
     let thumbsup = msg1_reactions
         .iter()
         .find(|r| r.emoji == "\u{1f44d}")


### PR DESCRIPTION
## Summary

Channel message reaction pills (the emoji groups under a message) could reshuffle their order across refreshes even with no new reactions added.

`get_reactions_batch` in `crates/channels/src/outbound/pg_channels_repo.rs` fetches reaction rows already ordered by `created_at ASC`, but then grouped them per-emoji into a `HashMap<String, Vec<String>>` before collecting into the response. Rust's `HashMap` iteration order is randomized per process, so the emoji order shuffled on every request rather than staying keyed to the actual first-reacted-at order.

## Fix

Swap the inner per-message map for an `IndexMap` (already a workspace dependency), which preserves insertion order. Since rows arrive sorted by `created_at ASC`, insertion order is first-reacted-at order, so the first emoji to be reacted with stays first — stable across refreshes and consistent with the `created_at`-based ordering already used by the single-message reaction path (`group_counted_reactions`).

## Changes
- `crates/channels/Cargo.toml`: add `indexmap` as an optional dependency, enabled by the `outbound` feature.
- `crates/channels/src/outbound/pg_channels_repo.rs`: use `IndexMap<String, Vec<String>>` instead of `HashMap` when grouping reactions by emoji.
- `crates/channels/src/outbound/pg_channels_repo/tests.rs`: assert the existing `reactions_grouped_by_emoji` test returns reactions in first-reacted order (thumbsup before tada, matching fixture data).

## Why prioritized

Reported in our internal bug-reports channel — a recurring, easily reproducible visual bug (reaction order shifting on refresh). Small, isolated, low-risk fix.

## Test plan
- [x] `cargo check -p channels --features outbound`
- [x] `cargo clippy -p channels --features outbound --no-deps -- -D warnings`
- [x] `cargo fmt -p channels -- --check`
- [ ] `cargo test -p channels` — not runnable in this sandbox (no local Postgres available); relying on CI to run the updated `reactions_grouped_by_emoji` test against the fixture data.

MACRO-2452


---
_Generated by [Claude Code](https://claude.ai/code/session_011H97wJkbfiwMEtdDDBRFzg)_