### PR TITLE
chore(search): trim unified search tracing to accessible-items and opensearch spans

### DIFF
--- a/crates/email_db_client/src/links/get.rs
+++ b/crates/email_db_client/src/links/get.rs
@@ -112,7 +112,6 @@ pub async fn fetch_link_by_macro_id_and_email_address(
 /// inboxes delegated via macro_user_links. The union is the read-side half of the
 /// multi-inbox narrow-graph design — it surfaces both the user's own inboxes
 /// (same macro_id) and inboxes belonging to other macro users they've been delegated.
-#[tracing::instrument(skip(pool), err)]
 pub async fn fetch_inboxes_for_macro_id(
     pool: &PgPool,
     macro_id: &str,

--- a/crates/opensearch_client/src/search/channels.rs
+++ b/crates/opensearch_client/src/search/channels.rs
@@ -18,7 +18,6 @@ use chrono::Utc;
 use models_opensearch::{OpenSearchEntityType, SearchEntityType, SearchIndex};
 use models_search_cursor::{SearchCursorOption, SearchMethodCursor};
 use opensearch_query_builder::*;
-use tracing::Instrument;
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub(crate) struct ChannelMessageIndex {
@@ -230,28 +229,20 @@ pub(crate) async fn search_channel(
     exclude_source_content(&mut search_request);
 
     let index = SearchIndex::Channels.as_ref();
-    let response = async {
-        client
-            .search(opensearch::SearchParts::Index(&[index]))
-            .body(search_request)
-            .send()
-            .await
-            .map_client_error()
-            .await
-    }
-    .instrument(tracing::info_span!("opensearch_http_request"))
-    .await?;
+    let response = client
+        .search(opensearch::SearchParts::Index(&[index]))
+        .body(search_request)
+        .send()
+        .await
+        .map_client_error()
+        .await?;
 
-    let bytes = async {
-        response
-            .bytes()
-            .await
-            .map_err(|e| OpensearchClientError::HttpBytesError {
-                details: e.to_string(),
-            })
-    }
-    .instrument(tracing::info_span!("opensearch_read_response_body"))
-    .await?;
+    let bytes = response
+        .bytes()
+        .await
+        .map_err(|e| OpensearchClientError::HttpBytesError {
+            details: e.to_string(),
+        })?;
 
     let result: DefaultSearchResponse<ChannelMessageIndex> = serde_json::from_slice(&bytes)
         .map_err(|e| OpensearchClientError::SearchDeserializationFailed {

--- a/crates/opensearch_client/src/search/unified.rs
+++ b/crates/opensearch_client/src/search/unified.rs
@@ -31,7 +31,6 @@ use crate::{
 };
 use chrono::Utc;
 use models_search_cursor::{SearchCursorOption, SearchMethodCursor};
-use tracing::Instrument;
 
 use models_opensearch::{OpenSearchEntityType, SearchEntityType};
 use opensearch_query_builder::*;
@@ -812,39 +811,26 @@ pub(crate) async fn search_unified(
 
     let search_indices: Vec<&str> = args.search_indices.iter().map(|i| i.index_name()).collect();
 
-    let response = async {
-        client
-            .search(opensearch::SearchParts::Index(&search_indices))
-            .body(search_request)
-            .send()
-            .await
-            .map_client_error()
-            .await
-    }
-    .instrument(tracing::info_span!("opensearch_http_request"))
-    .await?;
+    let response = client
+        .search(opensearch::SearchParts::Index(&search_indices))
+        .body(search_request)
+        .send()
+        .await
+        .map_client_error()
+        .await?;
 
-    let bytes = async {
-        response
-            .bytes()
-            .await
-            .map_err(|e| OpensearchClientError::HttpBytesError {
-                details: e.to_string(),
-            })
-    }
-    .instrument(tracing::info_span!("opensearch_read_response_body"))
-    .await?;
+    let bytes = response
+        .bytes()
+        .await
+        .map_err(|e| OpensearchClientError::HttpBytesError {
+            details: e.to_string(),
+        })?;
 
-    let result: DefaultSearchResponse<UnifiedSearchIndex> = {
-        let _span = tracing::info_span!("opensearch_deserialize_response", body_size = bytes.len())
-            .entered();
-        serde_json::from_slice(&bytes).map_err(|e| {
-            OpensearchClientError::SearchDeserializationFailed {
-                details: e.to_string(),
-                raw_body: String::from_utf8_lossy(&bytes).to_string(),
-            }
-        })?
-    };
+    let result: DefaultSearchResponse<UnifiedSearchIndex> = serde_json::from_slice(&bytes)
+        .map_err(|e| OpensearchClientError::SearchDeserializationFailed {
+            details: e.to_string(),
+            raw_body: String::from_utf8_lossy(&bytes).to_string(),
+        })?;
 
     tracing::info!(
         response_body_bytes = bytes.len(),

--- a/crates/search_service/src/api/search/simple/simple_unified.rs
+++ b/crates/search_service/src/api/search/simple/simple_unified.rs
@@ -529,9 +529,6 @@ pub(in crate::api::search) async fn perform_unified_search(
     let crm_count = crm_hits.len();
 
     let final_tagged = {
-        let _span = tracing::info_span!("combine_and_sort_results", chat_name_count, content_count)
-            .entered();
-
         // Wrap results with source tags
         let mut combined: Vec<TaggedSearchHit> = Vec::new();
         combined.extend(chat_hits.into_iter().map(|hit| TaggedSearchHit {
@@ -547,8 +544,6 @@ pub(in crate::api::search) async fn perform_unified_search(
             source: SearchSource::CrmCompany,
         }));
 
-        tracing::debug!(total_combined = combined.len(), "combined all results");
-
         // Sort: updated_at DESC (None to bottom), entity_id DESC as tiebreaker
         combined.sort_by(|a, b| match (&b.hit.updated_at, &a.hit.updated_at) {
             (Some(b_ts), Some(a_ts)) => b_ts
@@ -562,19 +557,10 @@ pub(in crate::api::search) async fn perform_unified_search(
         // Take the first page_size distinct entities (keeping all of each
         // entity's hits), not the first page_size hits.
         let page_size_usize = page_size as usize;
-        let final_tagged: Vec<TaggedSearchHit> = take_first_n_entities(combined, page_size_usize);
-
-        tracing::debug!(
-            final_count = final_tagged.len(),
-            "final results after pagination"
-        );
-
-        final_tagged
+        take_first_n_entities(combined, page_size_usize)
     };
 
     let next_cursor = {
-        let _span = tracing::info_span!("compute_pagination_cursors").entered();
-
         // Count included results by source
         let included_chat_names = final_tagged
             .iter()

--- a/crates/search_service/src/api/search/unified.rs
+++ b/crates/search_service/src/api/search/unified.rs
@@ -76,10 +76,7 @@ pub async fn handler(
         project,
         call_record,
         crm_company,
-    } = {
-        let _span = tracing::info_span!("split_search_response_by_type").entered();
-        results.into_iter().split_search_response()
-    };
+    } = results.into_iter().split_search_response();
 
     let (
         enriched_document_results,
@@ -137,8 +134,6 @@ pub async fn handler(
     .map_err(|e| SearchError::InternalError(anyhow::anyhow!("tokio error: {:?}", e)))?;
 
     let results = {
-        let _span = tracing::info_span!("combine_and_sort_enriched_results").entered();
-
         let mut results = vec![];
 
         results.extend(enriched_document_results);
@@ -160,7 +155,6 @@ pub async fn handler(
 
 /// Sorts the unified results
 /// This method is so we can more easily test sorting
-#[tracing::instrument(skip(results), fields(count = results.len()))]
 fn sort_unified_search_results(
     mut results: Vec<UnifiedSearchResponseItem>,
 ) -> Vec<UnifiedSearchResponseItem> {


### PR DESCRIPTION
Trims the unified search trace tree to the two spans worth comparing — `get_user_accessible_items` (access-check DB time) and the single `search_unified`/`search_channel` OpenSearch span — by dropping the combine/sort, pagination-cursor, split-by-type, opensearch HTTP sub-spans, and the inbox-fetch span. These are INFO spans, so prod won't emit them until the `RUST_LOG` Doppler var opens the search targets at info (`warn,search_service::api::search=info,opensearch_client::search=info,macro_db_client::item_access=info`).
