### PR TITLE
fix(macro_entrypoint): decouple otel trace filter from RUST_LOG

### DIFF
--- a/crates/macro_entrypoint/src/lib.rs
+++ b/crates/macro_entrypoint/src/lib.rs
@@ -5,11 +5,13 @@
 mod datadog_fmt;
 
 use macro_env::Environment;
-use macro_env_var::{env_vars, maybe_env_var};
+use macro_env_var::{env_vars, maybe_env_vars};
 use opentelemetry::trace::TracerProvider as _;
 use opentelemetry_otlp::WithExportConfig;
 use opentelemetry_sdk::trace::SdkTracerProvider;
-use tracing_subscriber::{EnvFilter, Registry, layer::SubscriberExt, util::SubscriberInitExt};
+use tracing_subscriber::{
+    EnvFilter, Layer, Registry, filter::LevelFilter, layer::SubscriberExt, util::SubscriberInitExt,
+};
 use tracing_tree::HierarchicalLayer;
 
 env_vars! {
@@ -17,8 +19,9 @@ env_vars! {
     pub struct DdEnv;
 }
 
-maybe_env_var! {
+maybe_env_vars! {
     pub struct RustLog;
+    pub struct OtelTraceFilter;
 }
 
 /// Build an [`EnvFilter`] from `RUST_LOG`, honoring values injected via `APP_SECRETS_JSON`.
@@ -31,6 +34,20 @@ fn rust_log_env_filter() -> EnvFilter {
     match RustLog::new() {
         Some(value) => EnvFilter::builder().parse_lossy(value),
         None => EnvFilter::from_default_env(),
+    }
+}
+
+/// Build an [`EnvFilter`] for the OpenTelemetry span exporter from `OTEL_TRACE_FILTER`.
+///
+/// Traces are filtered independently of `RUST_LOG` so that lowering log verbosity (e.g.
+/// `RUST_LOG=warn`) cannot silence APM traces — `#[tracing::instrument]` spans default to INFO
+/// and a global filter would drop them before the otel layer sees them. Defaults to `info` when
+/// `OTEL_TRACE_FILTER` is unset or contains no valid directives.
+fn otel_env_filter() -> EnvFilter {
+    let builder = EnvFilter::builder().with_default_directive(LevelFilter::INFO.into());
+    match OtelTraceFilter::new() {
+        Some(value) => builder.parse_lossy(value),
+        None => builder.parse_lossy(""),
     }
 }
 
@@ -119,7 +136,9 @@ impl MacroEntrypoint {
                     .unwrap_or_else(|_| "unknown-service".to_string());
 
                 let tracer = tracer_provider.tracer(service_name);
-                let otel_layer = tracing_opentelemetry::layer().with_tracer(tracer);
+                let otel_layer = tracing_opentelemetry::layer()
+                    .with_tracer(tracer)
+                    .with_filter(otel_env_filter());
 
                 // Build the JSON event format, then wrap it with DatadogFormat
                 // to inject dd.trace_id / dd.span_id for trace-log correlation.
@@ -134,13 +153,10 @@ impl MacroEntrypoint {
                 let fmt_layer = tracing_subscriber::fmt::layer()
                     .with_ansi(false)
                     .fmt_fields(tracing_subscriber::fmt::format::JsonFields::new())
-                    .event_format(datadog_fmt::DatadogFormat { inner: json_format });
+                    .event_format(datadog_fmt::DatadogFormat { inner: json_format })
+                    .with_filter(rust_log_env_filter());
 
-                Registry::default()
-                    .with(rust_log_env_filter())
-                    .with(fmt_layer)
-                    .with(otel_layer)
-                    .init();
+                Registry::default().with(fmt_layer).with(otel_layer).init();
 
                 InitializedEntrypoint {
                     tracer_provider: Some(tracer_provider),


### PR DESCRIPTION
The `RUST_LOG` `EnvFilter` was attached at the Registry level, so lowering it to `warn` in Doppler dropped `#[tracing::instrument]` spans (INFO by default) before the otel layer saw them — this is what killed cloud-storage APM traces on 7/15. Filters are now per-layer: logs keep following `RUST_LOG`, spans follow the new optional `OTEL_TRACE_FILTER` (EnvFilter syntax, defaults to `info` when unset or invalid).
