### PR TITLE
fix(splits): deliver one-shot content params on fresh forward navigation

### DIFF
--- a/apps/web/src/components/app/PreviewPanel.tsx
+++ b/apps/web/src/components/app/PreviewPanel.tsx
@@ -1,4 +1,8 @@
-import { navigateChannelEntityToTarget } from '@app/features/next-soup/utils';
+import {
+  getChannelEntityTarget,
+  navigateChannelEntityToTarget,
+} from '@app/features/next-soup/utils';
+import { getChannelParams } from '@block-channel/utils/link';
 import type { BlockAliasContext, BlockName } from '@core/block';
 import { fileTypeToResolvedBlockName } from '@core/constant/allBlocks';
 import { USE_MACRO_PR_SUMMARY_BLOCK } from '@core/constant/featureFlags';
@@ -20,6 +24,7 @@ import {
   on,
   Show,
   Suspense,
+  untrack,
 } from 'solid-js';
 import { Dynamic } from 'solid-js/web';
 import {
@@ -111,8 +116,21 @@ const PreviewPanelContent: Component<NonNullableFields<PreviewPanel>> = (
       blockId = props.selectedEntity.id;
     }
 
+    // Sample the target untracked so notification churn can't remount the
+    // block. Mounting a channel with its target params makes the first
+    // messages fetch the load_around one, instead of latest-page (visible
+    // flash) followed by the id-keyed re-target below.
+    const channelTarget =
+      blockType === 'channel'
+        ? untrack(() => getChannelEntityTarget(props.selectedEntity))
+        : undefined;
+
     return props.orchestrator.createBlockInstance(blockType, blockId, {
       aliasContext,
+      params:
+        channelTarget?.kind === 'message'
+          ? getChannelParams(channelTarget.messageId, channelTarget.threadId)
+          : undefined,
     });
   };
   const [interactedWith, setInteractedWith] = createSignal(false);

--- a/apps/web/src/components/app/split-layout/layoutManager.ts
+++ b/apps/web/src/components/app/split-layout/layoutManager.ts
@@ -669,15 +669,26 @@ export function createSplitLayout(
     };
   }
 
+  /**
+   * `deliverParams` marks a fresh forward navigation, which delivers the
+   * one-shot `content.params` to the new mount. History-driven reattaches
+   * (back/forward, removeFromHistory, reset) leave it unset so re-visiting an
+   * entry doesn't re-fire its params (e.g. re-target a channel message).
+   */
   function reattach(
     split: SplitState,
     next: SplitContent,
     referredFrom?: ReferredFrom,
-    cause: NavigationCause = 'fresh'
+    cause: NavigationCause = 'fresh',
+    deliverParams = false
   ) {
     const otherSplits = state.splits.filter((s) => s.id !== split.id);
     let content = attachAliasContext(next);
-    if (!content.preserveParams && content.params !== undefined) {
+    if (
+      !deliverParams &&
+      !content.preserveParams &&
+      content.params !== undefined
+    ) {
       content = { ...content, params: undefined };
     }
     if (isDuplicateSplit(otherSplits, next)) return;
@@ -830,7 +841,8 @@ export function createSplitLayout(
         split,
         content,
         referredFrom,
-        mergeHistory ? 'replace' : 'fresh'
+        mergeHistory ? 'replace' : 'fresh',
+        true
       );
     });
   }

--- a/apps/web/src/components/app/split-layout/tests/layoutManager.test.ts
+++ b/apps/web/src/components/app/split-layout/tests/layoutManager.test.ts
@@ -186,6 +186,106 @@ describe('layoutManager', () => {
     });
   });
 
+  describe('navigation params', () => {
+    const channelWithTarget = {
+      type: 'channel',
+      id: 'ch-1',
+      params: { channel_message_id: 'm-1' },
+    } satisfies SplitContent;
+
+    it('delivers one-shot params on same-split forward navigation', () => {
+      createRoot((dispose) => {
+        const manager = createSplitLayout(createMockOrchestrator(), [
+          { type: 'component', id: 'inbox' },
+        ]);
+
+        const split = manager.getSplit(manager.splits()[0].id)!;
+        split.replace({ next: channelWithTarget });
+
+        expect(split.content()).toMatchObject(channelWithTarget);
+
+        dispose();
+      });
+    });
+
+    it('delivers one-shot params on mergeHistory navigation', () => {
+      createRoot((dispose) => {
+        const manager = createSplitLayout(createMockOrchestrator(), [
+          { type: 'component', id: 'inbox' },
+        ]);
+
+        const split = manager.getSplit(manager.splits()[0].id)!;
+        split.replace({ next: channelWithTarget, mergeHistory: true });
+
+        expect(split.content()).toMatchObject(channelWithTarget);
+
+        dispose();
+      });
+    });
+
+    it('strips params when re-visiting an entry via history back/forward', () => {
+      createRoot((dispose) => {
+        const manager = createSplitLayout(createMockOrchestrator(), [
+          { type: 'component', id: 'inbox' },
+        ]);
+
+        const split = manager.getSplit(manager.splits()[0].id)!;
+        split.replace({ next: channelWithTarget });
+
+        split.goBack();
+        expect(split.content()).toMatchObject({
+          type: 'component',
+          id: 'inbox',
+        });
+
+        split.goForward();
+        expect(split.content().type).toBe('channel');
+        expect(split.content().params).toBeUndefined();
+
+        dispose();
+      });
+    });
+
+    it('strips params when removeFromHistory reattaches a prior entry', () => {
+      createRoot((dispose) => {
+        const manager = createSplitLayout(createMockOrchestrator(), [
+          { type: 'component', id: 'inbox' },
+        ]);
+
+        const split = manager.getSplit(manager.splits()[0].id)!;
+        split.replace({ next: channelWithTarget });
+        split.replace({ next: { type: 'md', id: 'doc-1' } });
+
+        split.removeFromHistory((content) => content.type === 'md');
+
+        expect(split.content().type).toBe('channel');
+        expect(split.content().params).toBeUndefined();
+
+        dispose();
+      });
+    });
+
+    it('keeps params on history navigation when preserveParams is set', () => {
+      createRoot((dispose) => {
+        const manager = createSplitLayout(createMockOrchestrator(), [
+          { type: 'component', id: 'inbox' },
+        ]);
+
+        const split = manager.getSplit(manager.splits()[0].id)!;
+        split.replace({
+          next: { ...channelWithTarget, preserveParams: true },
+        });
+
+        split.goBack();
+        split.goForward();
+
+        expect(split.content()).toMatchObject(channelWithTarget);
+
+        dispose();
+      });
+    });
+  });
+
   describe('replaceAllSplits', () => {
     it('keeps the first split that already contains the target content', () => {
       createRoot((dispose) => {

--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/core/BlockLink.tsx
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/core/BlockLink.tsx
@@ -59,7 +59,7 @@ export function openDocument(
   }
 
   openWithSplit(
-    { type: targetBlock, id },
+    { type: targetBlock, id, params },
     {
       preferNewSplit: inNewSplit,
       reopen: targetBlock === 'channel' && !hasParams ? 'latest' : undefined,


### PR DESCRIPTION
Same-split navigation (`openWithSplit` → `replace()` → `reattach()`) stripped one-shot `content.params` before mount, so a channel target mounted targetless, fetched the latest page (visible flash + bottom scroll), then re-fetched with `load_around_message_id`. `reattach()` now delivers params on genuine forward navigations and still strips them on history-driven reattaches (back/forward, removeFromHistory, reset), fixing all same-split deep links (channel targets, email message ids, call transcripts, pdf locations).

The preview panel had the same bug through its own mount path (`createBlockInstance` without params + post-mount re-target), so channel previews now also mount with their target params, sampled untracked so notification churn can't remount the block.
