### PR TITLE
fix(tags): add label menu

### DIFF
--- a/apps/web/src/features/property/tags/TagPicker.tsx
+++ b/apps/web/src/features/property/tags/TagPicker.tsx
@@ -256,26 +256,12 @@ function TagPickerBody(props: {
     });
   };
 
-  const optionScope = (optionId: string): TagScope | undefined =>
-    initialTagState().optionScopes.get(optionId);
-
   const persistSelection = async () => {
     if (saved()) return true;
     setSaved(true);
 
     try {
-      const nextSelectedIds = selectedIds();
-      for (const tag of initialAppliedTags()) {
-        if (!nextSelectedIds.has(tag.optionId)) {
-          await props.docTags.removeTag(tag.scope, tag.optionId);
-        }
-      }
-
-      for (const optionId of nextSelectedIds) {
-        if (initialAppliedIds().has(optionId)) continue;
-        const scope = optionScope(optionId);
-        if (scope) await props.docTags.applyTag(scope, optionId);
-      }
+      await props.docTags.setTagSelection(selectedIds());
       return true;
     } catch (error) {
       setSaved(false);
@@ -289,7 +275,9 @@ function TagPickerBody(props: {
   };
 
   const saveAndClose = async () => {
-    if (await save()) props.onClose();
+    const savePromise = save();
+    props.onClose();
+    await savePromise;
   };
 
   const filteredItems = createMemo(() => {

--- a/apps/web/src/features/property/tags/TagPicker.tsx
+++ b/apps/web/src/features/property/tags/TagPicker.tsx
@@ -120,6 +120,7 @@ export function TagPicker(props: {
           registerSave={(handler) => {
             saveAndClose = handler;
           }}
+          suppressInitialOutsideEvents={false}
         />
       </Show>
     </Popover>
@@ -166,6 +167,7 @@ export function TagPickerPopover(props: {
           registerSave={(handler) => {
             saveAndClose = handler;
           }}
+          suppressInitialOutsideEvents
         />
       </Show>
     </Popover>
@@ -176,6 +178,7 @@ function TagPickerBody(props: {
   docTags: DocTags;
   onClose: () => void;
   registerSave: (handler: (() => Promise<void>) | undefined) => void;
+  suppressInitialOutsideEvents: boolean;
 }) {
   const [search, setSearch] = createSignal('');
   const [saved, setSaved] = createSignal(false);
@@ -190,6 +193,10 @@ function TagPickerBody(props: {
   const addOption = useAddPropertyOptionMutation();
   const ensureTagSet = useEnsureTagSetMutation();
   let scrollContainerRef: HTMLDivElement | undefined;
+  const [initialOutsideEventGuard, setInitialOutsideEventGuard] =
+    createSignal(true);
+  const shouldIgnoreOutsideEvent = () =>
+    props.suppressInitialOutsideEvents && initialOutsideEventGuard();
 
   const initialAppliedTags = createMemo(() => props.docTags.appliedTags());
   const initialAppliedIds = createMemo(
@@ -491,6 +498,10 @@ function TagPickerBody(props: {
   onMount(() => {
     props.registerSave(saveAndClose);
     document.addEventListener('keydown', handleKeyDown);
+    const timeout = setTimeout(() => {
+      setInitialOutsideEventGuard(false);
+    }, 100);
+    onCleanup(() => clearTimeout(timeout));
   });
 
   onCleanup(() => {
@@ -504,6 +515,12 @@ function TagPickerBody(props: {
         <Popover.Content
           class="z-modal w-64 rounded-xl bg-surface text-sm shadow-menu ring ring-edge-muted menu-open-animation"
           onCloseAutoFocus={(event) => event.preventDefault()}
+          onFocusOutside={(event) => {
+            if (shouldIgnoreOutsideEvent()) event.preventDefault();
+          }}
+          onInteractOutside={(event) => {
+            if (shouldIgnoreOutsideEvent()) event.preventDefault();
+          }}
         >
           <Show
             when={createStep()}

--- a/apps/web/src/features/property/tags/useDocTags.ts
+++ b/apps/web/src/features/property/tags/useDocTags.ts
@@ -1,6 +1,8 @@
 import {
-  useAddEntityPropertyOptionMutation,
-  useRemoveEntityPropertyOptionMutation,
+  BulkUpdateEntityPropertyOptionsError,
+  getEntityPropertyOptionDeltas,
+  rollbackEntityPropertyOptionDelta,
+  useBulkUpdateEntityPropertyOptionsMutation,
 } from '@queries/properties/entity';
 import {
   useEnsureTagSetMutation,
@@ -55,14 +57,43 @@ function definitionDomain(
   };
 }
 
+type TagSelectionUpdate = {
+  definition: PropertyDefinitionDetailResponse;
+  currentOptionIds: string[];
+  nextOptionIds: string[];
+};
+
+type PersistTagSelection = (
+  updates: TagSelectionUpdate[]
+) => Promise<void> | void;
+
 type SetTagOptionIdsForDefinition = (
   definition: PropertyDefinitionDetailResponse,
   optionIds: string[]
 ) => Promise<void> | void;
 
+function usePersistTagSelection(
+  entityId: string,
+  entityType: EntityType
+): PersistTagSelection {
+  const mutation = useBulkUpdateEntityPropertyOptionsMutation();
+
+  return async (updates) => {
+    await mutation.mutateAsync({
+      entityId,
+      entityType,
+      properties: updates.map((update) => ({
+        property: definitionDomain(update.definition),
+        currentOptionIds: update.currentOptionIds,
+        nextOptionIds: update.nextOptionIds,
+      })),
+    });
+  };
+}
+
 function createDocTags(
   appliedOptionIdsForDefinition: (definitionId: string) => string[],
-  setTagOptionIdsForDefinition: SetTagOptionIdsForDefinition
+  persistTagSelection: PersistTagSelection
 ) {
   const tagsQuery = useTagsQuery();
   const ensureTagSet = useEnsureTagSetMutation();
@@ -178,39 +209,83 @@ function createDocTags(
     });
   };
 
-  const applyTag = async (scope: TagScope, optionId: string) => {
-    const definition = await resolveDefinition(scope);
-    const current = visibleOptionIdsForDefinition(definition.id);
-    if (current.includes(optionId)) return;
-    const nextOptionIds = [...current, optionId];
-    updatePendingOptionIds(definition.id, () => nextOptionIds);
+  const commitTagSelection = async (updates: TagSelectionUpdate[]) => {
+    if (updates.length === 0) return;
+
+    setPendingOptionIdsByDefinition((prev) => {
+      const next = new Map(prev);
+      for (const update of updates) {
+        next.set(update.definition.id, update.nextOptionIds);
+      }
+      return next;
+    });
 
     try {
-      await setTagOptionIdsForDefinition(definition, nextOptionIds);
+      await persistTagSelection(updates);
     } catch (error) {
-      updatePendingOptionIds(definition.id, (optionIds) =>
-        optionIds.filter((id) => id !== optionId)
-      );
+      const failed =
+        error instanceof BulkUpdateEntityPropertyOptionsError
+          ? error.failedDeltas.flatMap(({ updateIndex, delta }) => {
+              const update = updates[updateIndex];
+              return update ? [{ update, delta }] : [];
+            })
+          : updates.flatMap((update) =>
+              getEntityPropertyOptionDeltas(
+                update.currentOptionIds,
+                update.nextOptionIds
+              ).map((delta) => ({ update, delta }))
+            );
+
+      for (const { update, delta } of failed) {
+        updatePendingOptionIds(update.definition.id, (optionIds) =>
+          rollbackEntityPropertyOptionDelta(optionIds, delta)
+        );
+      }
       throw error;
     }
+  };
+
+  const applyTag = async (scope: TagScope, optionId: string) => {
+    const definition = await resolveDefinition(scope);
+    const currentOptionIds = visibleOptionIdsForDefinition(definition.id);
+    if (currentOptionIds.includes(optionId)) return;
+    await commitTagSelection([
+      {
+        definition,
+        currentOptionIds,
+        nextOptionIds: [...currentOptionIds, optionId],
+      },
+    ]);
   };
 
   const removeTag = async (scope: TagScope, optionId: string) => {
     const definition = definitionByScope().get(scope);
     if (!definition) return;
-    const current = visibleOptionIdsForDefinition(definition.id);
-    if (!current.includes(optionId)) return;
-    const nextOptionIds = current.filter((id) => id !== optionId);
-    updatePendingOptionIds(definition.id, () => nextOptionIds);
+    const currentOptionIds = visibleOptionIdsForDefinition(definition.id);
+    if (!currentOptionIds.includes(optionId)) return;
+    await commitTagSelection([
+      {
+        definition,
+        currentOptionIds,
+        nextOptionIds: currentOptionIds.filter((id) => id !== optionId),
+      },
+    ]);
+  };
 
-    try {
-      await setTagOptionIdsForDefinition(definition, nextOptionIds);
-    } catch (error) {
-      updatePendingOptionIds(definition.id, (optionIds) =>
-        optionIds.includes(optionId) ? optionIds : [...optionIds, optionId]
+  const setTagSelection = async (selectedOptionIds: ReadonlySet<string>) => {
+    const options = optionById();
+    const updates = [...definitionByScope().values()].flatMap((definition) => {
+      const currentOptionIds = visibleOptionIdsForDefinition(definition.id);
+      const nextOptionIds = [...selectedOptionIds].filter(
+        (optionId) =>
+          options.get(optionId)?.propertyDefinitionId === definition.id
       );
-      throw error;
-    }
+
+      return sameOptionIds(currentOptionIds, nextOptionIds)
+        ? []
+        : [{ definition, currentOptionIds, nextOptionIds }];
+    });
+    await commitTagSelection(updates);
   };
 
   const toggleTag = async (scope: TagScope, optionId: string) => {
@@ -228,49 +303,19 @@ function createDocTags(
   ) => {
     if (currentTag.optionId === nextOptionId) return;
 
-    const currentDefinition = definitionByScope().get(currentTag.scope);
-    const nextDefinition = await resolveDefinition(nextScope);
-    if (!currentDefinition) return;
-
-    const previousOverrides = pendingOptionIdsByDefinition();
+    await resolveDefinition(nextScope);
     const previousDisplayOrder = displayOptionOrder();
-    const currentIds = visibleOptionIdsForDefinition(currentDefinition.id);
-    const nextIds = visibleOptionIdsForDefinition(nextDefinition.id);
-
-    setDisplayOptionOrder(
+    const nextSelection = new Set(
       appliedTags().map((tag) =>
         tag.optionId === currentTag.optionId ? nextOptionId : tag.optionId
       )
     );
 
-    setPendingOptionIdsByDefinition((prev) => {
-      const next = new Map(prev);
-      next.set(
-        currentDefinition.id,
-        currentIds.filter((id) => id !== currentTag.optionId)
-      );
-      if (currentDefinition.id === nextDefinition.id) {
-        next.set(
-          currentDefinition.id,
-          currentIds.map((id) =>
-            id === currentTag.optionId ? nextOptionId : id
-          )
-        );
-      } else if (!nextIds.includes(nextOptionId)) {
-        next.set(nextDefinition.id, [...nextIds, nextOptionId]);
-      }
-      return next;
-    });
+    setDisplayOptionOrder([...nextSelection]);
 
     try {
-      await removeTag(currentTag.scope, currentTag.optionId);
-      if (
-        !appliedOptionIdsForDefinition(nextDefinition.id).includes(nextOptionId)
-      ) {
-        await applyTag(nextScope, nextOptionId);
-      }
+      await setTagSelection(nextSelection);
     } catch (error) {
-      setPendingOptionIdsByDefinition(previousOverrides);
       setDisplayOptionOrder(previousDisplayOrder);
       throw error;
     }
@@ -285,58 +330,25 @@ function createDocTags(
     applyTag,
     removeTag,
     replaceTag,
+    setTagSelection,
     toggleTag,
   };
 }
 
 export function useDocTags(entityId: string, entityType: EntityType) {
   const { properties } = useEntityProperties(entityId, entityType, false);
-  const addOption = useAddEntityPropertyOptionMutation();
-  const removeOption = useRemoveEntityPropertyOptionMutation();
+  const appliedOptionIdsForDefinition = (definitionId: string) => {
+    const property = properties().find(
+      (prop) => prop.propertyDefinitionId === definitionId
+    );
+    if (!property) return [];
+    return property.valueType === 'SELECT_STRING' && property.value
+      ? property.value
+      : [];
+  };
+  const persistTagSelection = usePersistTagSelection(entityId, entityType);
 
-  return createDocTags(
-    (definitionId) => {
-      const property = properties().find(
-        (prop) => prop.propertyDefinitionId === definitionId
-      );
-      if (!property) return [];
-      return property.valueType === 'SELECT_STRING' && property.value
-        ? property.value
-        : [];
-    },
-    async (definition, optionIds) => {
-      const property = definitionDomain(definition);
-      const current = (() => {
-        const source = properties().find(
-          (prop) => prop.propertyDefinitionId === definition.id
-        );
-        return source?.valueType === 'SELECT_STRING' && source.value
-          ? source.value
-          : [];
-      })();
-      const added = optionIds.find((id) => !current.includes(id));
-      if (added) {
-        await addOption.mutateAsync({
-          entityId,
-          entityType,
-          property,
-          optionId: added,
-          optimisticOptionIds: optionIds,
-        });
-        return;
-      }
-      const removed = current.find((id) => !optionIds.includes(id));
-      if (removed) {
-        await removeOption.mutateAsync({
-          entityId,
-          entityType,
-          property,
-          optionId: removed,
-          optimisticOptionIds: optionIds,
-        });
-      }
-    }
-  );
+  return createDocTags(appliedOptionIdsForDefinition, persistTagSelection);
 }
 
 /**
@@ -349,55 +361,27 @@ export function useSoupDocTags(
   entityType: EntityType,
   properties: Accessor<SoupProperty[] | undefined>
 ) {
-  const addOption = useAddEntityPropertyOptionMutation();
-  const removeOption = useRemoveEntityPropertyOptionMutation();
+  const appliedOptionIdsForDefinition = (definitionId: string) => {
+    const property = properties()?.find(
+      (prop) => prop.definition.id === definitionId
+    );
+    const value = property?.value;
+    return value?.type === 'SelectOption' ? value.value : [];
+  };
+  const persistTagSelection = usePersistTagSelection(entityId, entityType);
 
-  return createDocTags(
-    (definitionId) => {
-      const property = properties()?.find(
-        (prop) => prop.definition.id === definitionId
-      );
-      const value = property?.value;
-      return value?.type === 'SelectOption' ? value.value : [];
-    },
-    async (definition, optionIds) => {
-      const property = definitionDomain(definition);
-      const source = properties()?.find(
-        (prop) => prop.definition.id === definition.id
-      );
-      const current =
-        source?.value?.type === 'SelectOption' ? source.value.value : [];
-      const added = optionIds.find((id) => !current.includes(id));
-      if (added) {
-        await addOption.mutateAsync({
-          entityId,
-          entityType,
-          property,
-          optionId: added,
-          optimisticOptionIds: optionIds,
-        });
-        return;
-      }
-      const removed = current.find((id) => !optionIds.includes(id));
-      if (removed) {
-        await removeOption.mutateAsync({
-          entityId,
-          entityType,
-          property,
-          optionId: removed,
-          optimisticOptionIds: optionIds,
-        });
-      }
-    }
-  );
+  return createDocTags(appliedOptionIdsForDefinition, persistTagSelection);
 }
 
 export function useLocalDocTags(
   appliedOptionIdsForDefinition: (definitionId: string) => string[],
   setTagOptionIdsForDefinition: SetTagOptionIdsForDefinition
 ) {
-  return createDocTags(
-    appliedOptionIdsForDefinition,
-    setTagOptionIdsForDefinition
-  );
+  return createDocTags(appliedOptionIdsForDefinition, async (updates) => {
+    await Promise.all(
+      updates.map((update) =>
+        setTagOptionIdsForDefinition(update.definition, update.nextOptionIds)
+      )
+    );
+  });
 }

--- a/apps/web/src/features/property/tags/useDocTags.ts
+++ b/apps/web/src/features/property/tags/useDocTags.ts
@@ -165,22 +165,52 @@ function createDocTags(
     return provisioned.definition;
   };
 
+  const updatePendingOptionIds = (
+    definitionId: string,
+    update: (optionIds: string[]) => string[]
+  ) => {
+    setPendingOptionIdsByDefinition((prev) => {
+      const next = new Map(prev);
+      const current =
+        prev.get(definitionId) ?? appliedOptionIdsForDefinition(definitionId);
+      next.set(definitionId, update(current));
+      return next;
+    });
+  };
+
   const applyTag = async (scope: TagScope, optionId: string) => {
     const definition = await resolveDefinition(scope);
-    const current = appliedOptionIdsForDefinition(definition.id);
+    const current = visibleOptionIdsForDefinition(definition.id);
     if (current.includes(optionId)) return;
-    await setTagOptionIdsForDefinition(definition, [...current, optionId]);
+    const nextOptionIds = [...current, optionId];
+    updatePendingOptionIds(definition.id, () => nextOptionIds);
+
+    try {
+      await setTagOptionIdsForDefinition(definition, nextOptionIds);
+    } catch (error) {
+      updatePendingOptionIds(definition.id, (optionIds) =>
+        optionIds.filter((id) => id !== optionId)
+      );
+      throw error;
+    }
   };
 
   const removeTag = async (scope: TagScope, optionId: string) => {
     const definition = definitionByScope().get(scope);
     if (!definition) return;
-    const current = appliedOptionIdsForDefinition(definition.id);
+    const current = visibleOptionIdsForDefinition(definition.id);
     if (!current.includes(optionId)) return;
-    await setTagOptionIdsForDefinition(
-      definition,
-      current.filter((id) => id !== optionId)
-    );
+    const nextOptionIds = current.filter((id) => id !== optionId);
+    updatePendingOptionIds(definition.id, () => nextOptionIds);
+
+    try {
+      await setTagOptionIdsForDefinition(definition, nextOptionIds);
+    } catch (error) {
+      updatePendingOptionIds(definition.id, (optionIds) =>
+        optionIds.includes(optionId) ? optionIds : [...optionIds, optionId]
+      );
+      throw error;
+    }
   };
 
   const toggleTag = async (scope: TagScope, optionId: string) => {

--- a/apps/web/src/lib/queries/properties/entity.ts
+++ b/apps/web/src/lib/queries/properties/entity.ts
@@ -87,10 +87,12 @@ function getPropertyDefinitionId(
     : property.id;
 }
 
-function optimisticUpdateSoupEntityProperty(
+function optimisticUpdateSoupEntityProperties(
   entityId: string,
-  property: Property | PropertyDefinitionDomain,
-  value: SoupPropertyValue
+  updates: {
+    property: Property | PropertyDefinitionDomain;
+    value: SoupPropertyValue;
+  }[]
 ): SoupTransaction | undefined {
   const current = getSoupEntityById(entityId);
   // channel / call / foreign entities are property-less.
@@ -105,36 +107,29 @@ function optimisticUpdateSoupEntityProperty(
     return undefined;
   }
 
-  const propertyDefinitionId = getPropertyDefinitionId(property);
-  const existing = current.data.properties;
-  const existingProp = existing.find(
-    (prop) => prop.definition.id === propertyDefinitionId
-  );
+  const nextProperties = [...current.data.properties];
+  for (const { property, value } of updates) {
+    const propertyDefinitionId = getPropertyDefinitionId(property);
+    const index = nextProperties.findIndex(
+      (prop) => prop.definition.id === propertyDefinitionId
+    );
+    const existingProp = nextProperties[index];
+    const nextProp: SoupProperty = existingProp
+      ? {
+          ...existingProp,
+          definition: {
+            ...existingProp.definition,
+            // HACK (seamus): we need to change something other than value in
+            // order to get normy to update the cache. Changing
+            // definition.updated_at is INCORRECT, but it's currently harmless.
+            updated_at: new Date().toISOString(),
+          },
+          value,
+        }
+      : buildSoupProperty(property, value);
 
-  const nextProp: SoupProperty = existingProp
-    ? {
-        ...existingProp,
-        definition: {
-          ...existingProp.definition,
-          // HACK (seamus): we need to change something other than value in
-          // order to get normy to update the cache. Changing
-          // definition.updated_at is INCORRECT, but it's currently harmless.
-          updated_at: new Date().toISOString(),
-        },
-        value,
-      }
-    : buildSoupProperty(property, value);
-
-  const nextProperties = existing.map((prop) =>
-    prop.definition.id === nextProp.definition.id ? nextProp : prop
-  );
-
-  if (
-    nextProperties.every(
-      (prop) => prop.definition.id !== nextProp.definition.id
-    )
-  ) {
-    nextProperties.push(nextProp);
+    if (index === -1) nextProperties.push(nextProp);
+    else nextProperties[index] = nextProp;
   }
 
   return optimisticUpdateSoupEntity({
@@ -145,6 +140,14 @@ function optimisticUpdateSoupEntityProperty(
     },
     frecency_score: current.frecency_score,
   });
+}
+
+function optimisticUpdateSoupEntityProperty(
+  entityId: string,
+  property: Property | PropertyDefinitionDomain,
+  value: SoupPropertyValue
+): SoupTransaction | undefined {
+  return optimisticUpdateSoupEntityProperties(entityId, [{ property, value }]);
 }
 
 function buildSoupProperty(
@@ -404,6 +407,207 @@ export function useRemoveEntityPropertyOptionMutation(
       );
     },
     ...entityPropertyOptionCallbacks('Failed to remove tag', callbacks),
+  }));
+}
+
+export type EntityPropertyOptionDelta = {
+  type: 'add' | 'remove';
+  optionId: string;
+};
+
+export function getEntityPropertyOptionDeltas(
+  currentOptionIds: string[],
+  nextOptionIds: string[]
+): EntityPropertyOptionDelta[] {
+  const current = new Set(currentOptionIds);
+  const next = new Set(nextOptionIds);
+  return [
+    ...currentOptionIds
+      .filter((optionId) => !next.has(optionId))
+      .map((optionId) => ({ type: 'remove' as const, optionId })),
+    ...nextOptionIds
+      .filter((optionId) => !current.has(optionId))
+      .map((optionId) => ({ type: 'add' as const, optionId })),
+  ];
+}
+
+export function rollbackEntityPropertyOptionDelta(
+  optionIds: string[],
+  delta: EntityPropertyOptionDelta
+): string[] {
+  if (delta.type === 'add') {
+    return optionIds.filter((id) => id !== delta.optionId);
+  }
+  return optionIds.includes(delta.optionId)
+    ? optionIds
+    : [...optionIds, delta.optionId];
+}
+
+type BulkUpdateEntityPropertyOptionsParams = {
+  entityId: string;
+  entityType: EntityType;
+  properties: Array<{
+    property: Property | PropertyDefinitionDomain;
+    currentOptionIds: string[];
+    nextOptionIds: string[];
+  }>;
+};
+
+export type FailedEntityPropertyOptionDelta = {
+  updateIndex: number;
+  delta: EntityPropertyOptionDelta;
+};
+
+export class BulkUpdateEntityPropertyOptionsError extends Error {
+  constructor(readonly failedDeltas: FailedEntityPropertyOptionDelta[]) {
+    super('Failed to update some tags');
+    this.name = 'BulkUpdateEntityPropertyOptionsError';
+  }
+}
+
+type BulkUpdateEntityPropertyOptionsContext = {
+  soupTxn?: SoupTransaction;
+};
+
+function optionIdsFromSoupProperty(property: SoupProperty | undefined) {
+  return property?.value?.type === 'SelectOption' ? property.value.value : [];
+}
+
+function rollbackFailedOptionDeltas(
+  variables: BulkUpdateEntityPropertyOptionsParams,
+  failedDeltas: FailedEntityPropertyOptionDelta[]
+) {
+  const failedByUpdate = new Map<number, EntityPropertyOptionDelta[]>();
+  for (const { updateIndex, delta } of failedDeltas) {
+    const deltas = failedByUpdate.get(updateIndex) ?? [];
+    deltas.push(delta);
+    failedByUpdate.set(updateIndex, deltas);
+  }
+
+  const current = getSoupEntityById(variables.entityId);
+  const updates: {
+    property: Property | PropertyDefinitionDomain;
+    value: SoupPropertyValue;
+  }[] = [];
+  for (const [updateIndex, deltas] of failedByUpdate) {
+    const update = variables.properties[updateIndex];
+    if (!update) continue;
+    const propertyDefinitionId = getPropertyDefinitionId(update.property);
+    const soupProperty =
+      current &&
+      current.tag !== 'channel' &&
+      current.tag !== 'call' &&
+      current.tag !== 'foreignEntity' &&
+      current.tag !== 'channelThread'
+        ? current.data.properties?.find(
+            (property) => property.definition.id === propertyDefinitionId
+          )
+        : undefined;
+    const optionIds = deltas.reduce(
+      rollbackEntityPropertyOptionDelta,
+      optionIdsFromSoupProperty(soupProperty)
+    );
+    updates.push({
+      property: update.property,
+      value:
+        optionIds.length > 0
+          ? { type: 'SelectOption', value: optionIds }
+          : null,
+    });
+  }
+
+  optimisticUpdateSoupEntityProperties(variables.entityId, updates);
+}
+
+/**
+ * Applies a complete multi-select change with one optimistic soup transaction.
+ * The service currently exposes only idempotent delta endpoints, so persistence
+ * fans out until a true bulk endpoint is available.
+ */
+export function useBulkUpdateEntityPropertyOptionsMutation(
+  callbacks?: MutationCallbacks<
+    void,
+    Error,
+    BulkUpdateEntityPropertyOptionsParams,
+    BulkUpdateEntityPropertyOptionsContext
+  >
+) {
+  return useMutation(() => ({
+    mutationFn: async (variables: BulkUpdateEntityPropertyOptionsParams) => {
+      const operations = variables.properties.flatMap((update, updateIndex) =>
+        getEntityPropertyOptionDeltas(
+          update.currentOptionIds,
+          update.nextOptionIds
+        ).map((delta) => ({ update, updateIndex, delta }))
+      );
+      const results = await Promise.allSettled(
+        operations.map(({ update, delta }) => {
+          const params = {
+            entity_type: variables.entityType,
+            entity_id: variables.entityId,
+            property_id: getPropertyDefinitionId(update.property),
+            option_id: delta.optionId,
+          };
+          return throwOnErr(async () =>
+            delta.type === 'add'
+              ? await propertiesServiceClient.addEntityPropertyOption(params)
+              : await propertiesServiceClient.removeEntityPropertyOption(params)
+          );
+        })
+      );
+      const failedDeltas = results.flatMap((result, index) =>
+        result.status === 'rejected'
+          ? [
+              {
+                updateIndex: operations[index].updateIndex,
+                delta: operations[index].delta,
+              },
+            ]
+          : []
+      );
+      if (failedDeltas.length > 0) {
+        throw new BulkUpdateEntityPropertyOptionsError(failedDeltas);
+      }
+    },
+    ...withCallbacks<
+      void,
+      Error,
+      BulkUpdateEntityPropertyOptionsParams,
+      BulkUpdateEntityPropertyOptionsContext
+    >(
+      {
+        onMutate: (variables) => {
+          const soupTxn = optimisticUpdateSoupEntityProperties(
+            variables.entityId,
+            variables.properties.map((update) => ({
+              property: update.property,
+              value:
+                update.nextOptionIds.length > 0
+                  ? { type: 'SelectOption', value: update.nextOptionIds }
+                  : null,
+            }))
+          );
+          return { soupTxn };
+        },
+        onError: (error, variables, context) => {
+          if (error instanceof BulkUpdateEntityPropertyOptionsError) {
+            rollbackFailedOptionDeltas(variables, error.failedDeltas);
+          } else {
+            context?.soupTxn?.rollback();
+          }
+          console.error('Failed to update tags', error);
+          toast.failure('Failed to update tags');
+        },
+        onSettled: (_data, _error, variables) => {
+          invalidatePropertiesForEntity(
+            variables.entityType,
+            variables.entityId
+          );
+          invalidateSoupEntity(variables.entityId);
+        },
+      },
+      callbacks
+    ),
   }));
 }
 


### PR DESCRIPTION
Fixes the context-menu to tag-picker handoff so Add label opens reliably.

Persists a staged tag selection through one query-layer mutation with one optimistic soup update, parallel idempotent option deltas, and per-delta rollback on partial failure.

Verification:
- `bun check`
- targeted Biome check
- browser: picker handoff 10/10; row updated while two requests were blocked; injected partial failure preserved the successful label
- `bun run test`: 1,738 passed; 12 unrelated failures require `Promise.withResolvers` in the local runtime