### PR TITLE
chore(search): per-branch spans for accessible-items queries

### DIFF
--- a/crates/macro_db_client/src/item_access/get_accessible_items.rs
+++ b/crates/macro_db_client/src/item_access/get_accessible_items.rs
@@ -46,6 +46,7 @@ fn to_items(ids: Vec<String>, item_type: &str) -> Vec<UserAccessibleItem> {
         .collect()
 }
 
+#[tracing::instrument(skip(db), err)]
 async fn accessible_documents(
     db: &Pool<Postgres>,
     user_id: &str,
@@ -79,6 +80,7 @@ async fn accessible_documents(
     Ok(to_items(ids, "document"))
 }
 
+#[tracing::instrument(skip(db), err)]
 async fn accessible_chats(
     db: &Pool<Postgres>,
     user_id: &str,
@@ -112,6 +114,7 @@ async fn accessible_chats(
     Ok(to_items(ids, "chat"))
 }
 
+#[tracing::instrument(skip(db), err)]
 async fn accessible_projects(
     db: &Pool<Postgres>,
     user_id: &str,


### PR DESCRIPTION
Adds `#[tracing::instrument]` spans to the three per-type accessible-items queries. The outer `get_user_accessible_items` span (still present, emitted on cache miss only) covers all three sequential queries on the all-types path, so it can't show where the time goes; per-branch spans make the search path's three calls individually visible and expose the sequential stacking on the all-types path — the data needed to decide whether to parallelize it.
