### PR TITLE
fix(debug-service): add skill frontmatter

### DIFF
--- a/.agents/skills/debug-service/SKILL.md
+++ b/.agents/skills/debug-service/SKILL.md
@@ -1,3 +1,10 @@
+---
+name: debug-service
+description: Debug local Rust services in this repository by starting the crate's binary with debug logging, tailing service logs, and using those logs to answer runtime questions. Use when Codex needs to investigate service startup, runtime behavior, errors, or logs for a Rust binary in a crate.
+---
+
+# Debug Service
+
 You are going to help me interactively debug the rust binary
 that's in this crate.
 
@@ -7,4 +14,3 @@ RUST_LOG=<name_of_bin>=debug,info
   just run > /tmp/<name_of_bin>.log 2>&1 & tail -f /tmp/<name_of_bin>.log
 
 Use the log tail to answer questions as appropriate
-


### PR DESCRIPTION
## Summary
- add required YAML frontmatter to the debug-service skill
- add a markdown heading while preserving the existing debugging instructions

## Validation
- ruby YAML parse confirmed the frontmatter includes name and description
- note: skill-creator quick_validate.py could not run because this environment is missing PyYAML