### PR TITLE
fix(mobile channels): "Replying to thread" input when thread has existing replies

### DIFF
--- a/apps/web/src/features/channel/Channel/Channel.tsx
+++ b/apps/web/src/features/channel/Channel/Channel.tsx
@@ -753,6 +753,10 @@ export function Channel(props: ChannelProps) {
                               if (target?.replyId) return undefined;
                               return messageById().get(threadId);
                             }}
+                            threadHasReplies={() =>
+                              (messageById().get(threadId)?.thread.reply_count ??
+                                0) > 0
+                            }
                             onNavigateToTarget={() =>
                               goToMessage(
                                 threadId,

--- a/apps/web/src/features/channel/Channel/Channel.tsx
+++ b/apps/web/src/features/channel/Channel/Channel.tsx
@@ -754,8 +754,8 @@ export function Channel(props: ChannelProps) {
                               return messageById().get(threadId);
                             }}
                             threadHasReplies={() =>
-                              (messageById().get(threadId)?.thread.reply_count ??
-                                0) > 0
+                              (messageById().get(threadId)?.thread
+                                .reply_count ?? 0) > 0
                             }
                             onNavigateToTarget={() =>
                               goToMessage(

--- a/apps/web/src/features/channel/Channel/UnifiedReplyInput.tsx
+++ b/apps/web/src/features/channel/Channel/UnifiedReplyInput.tsx
@@ -20,6 +20,11 @@ export function UnifiedReplyInput(props: {
    * otherwise the thread root.
    */
   getTargetMessage: () => MessageData | undefined;
+  /**
+   * Whether the target thread already has replies. When it does, the flag
+   * reads "Replying to thread"; otherwise it names the message's sender.
+   */
+  threadHasReplies: () => boolean;
   onNavigateToTarget: () => void;
   onExit: () => void;
 }) {
@@ -31,7 +36,7 @@ export function UnifiedReplyInput(props: {
       <InputFlag
         label={
           <Show
-            when={props.getTargetMessage()}
+            when={!props.threadHasReplies() && props.getTargetMessage()}
             keyed
             fallback="Replying to thread"
           >


### PR DESCRIPTION
## Summary
Updated the unified reply input to display "Replying to thread" when the target thread already has replies, instead of showing the original message sender's name.

## Key Changes
- Added `threadHasReplies` prop to `UnifiedReplyInput` component to determine whether to show the generic "Replying to thread" label
- Modified the input flag label logic to check `threadHasReplies()` and only show the sender name when the thread has no replies
- Implemented `threadHasReplies` in the `Channel` component by checking the `reply_count` property of the target thread message

## Implementation Details
- The `threadHasReplies` callback checks if `messageById().get(threadId)?.thread.reply_count > 0`
- The label now uses a conditional: show sender name only when `!threadHasReplies() && props.getTargetMessage()` is true
- Falls back to "Replying to thread" when the thread has replies or no target message is available

https://claude.ai/code/session_018V4dJCd7VuyhbrDJ6DRvur