### PR TITLE
fix(web): keep ingested files out of the Things I did timeline

### DIFF
--- a/apps/web/src/features/activity-timeline/activity-view.tsx
+++ b/apps/web/src/features/activity-timeline/activity-view.tsx
@@ -6,6 +6,7 @@ import { ENABLE_SNIPPETS } from '@core/constant/featureFlags';
 import { useUserId } from '@core/context/user';
 import { getTypeNoun } from '@entity/extractors-notification/notification-description-helpers';
 import { NotificationRow } from '@entity/extractors-notification/notification-row';
+import type { SoupApiItemFilter } from '@queries/soup/items';
 import type { TimelineRow } from './collapse';
 import { EntityEventRow } from './entity-event-row';
 import { mapMyActivityEntity, mapSharedEmailEntity } from './entity-events';
@@ -23,12 +24,19 @@ import { useChannelLookup } from './use-channel-lookup';
  * chats and folders they own, and calls they attended — plus, via the email
  * view, the emails they sent. Drafts live in a separate email view, so they
  * are a second query merged in below.
+ *
+ * Documents are restricted to the types the user authors in Macro (md and
+ * canvas, which includes tasks). Ingested files — email-auto-parsed PDFs,
+ * attachment uploads, bulk imports — are actions a pipeline took, not the
+ * user, and their updatedAt also moves on viewer activity, so they are
+ * excluded entirely rather than shown as created/edited.
  */
 const getMyActionsQuery = (userId: string): Query =>
   defineQueryFilters({
     include: {
       channelThreadParticipantId: [userId],
       documentOwnerId: [userId],
+      fileType: ['md', 'canvas'],
       isEmailAttachment: false,
       chatOwnerId: [userId],
       folderOwnerId: [userId],
@@ -40,6 +48,21 @@ const getMyActionsQuery = (userId: string): Query =>
 
 const getMyDraftsQuery = (): Query =>
   defineQueryFilters({ emailView: 'drafts' });
+
+/**
+ * Websocket-insert gates mirroring the server queries above (the cache layer
+ * bypasses the server AST — see `createSoupTimelineFeed.itemFilter`). The
+ * document arm mirrors the authorable-types restriction; the mapper drops
+ * anything else that slips through.
+ */
+const myActionsItemFilter: SoupApiItemFilter = (item) =>
+  item.tag !== 'document' ||
+  item.data.subType?.type === 'task' ||
+  item.data.fileType === 'md' ||
+  item.data.fileType === 'canvas';
+
+const emailOnlyItemFilter: SoupApiItemFilter = (item) =>
+  item.tag === 'emailThread';
 
 /**
  * A notification row (or collapsed run of them). Single notifications render
@@ -87,11 +110,13 @@ function MyActivityPane() {
       query: () => getMyActionsQuery(userId() ?? ''),
       map: (entity) => mapMyActivityEntity(entity, userId()),
       enabled: () => userId() !== undefined,
+      itemFilter: myActionsItemFilter,
     }),
     createSoupTimelineFeed({
       query: getMyDraftsQuery,
       map: (entity) => mapMyActivityEntity(entity, userId()),
       enabled: () => userId() !== undefined,
+      itemFilter: emailOnlyItemFilter,
     }),
   ]);
 
@@ -135,6 +160,7 @@ function FirehosePane() {
           emailView: 'all',
         }),
       map: mapSharedEmailEntity,
+      itemFilter: emailOnlyItemFilter,
     }),
   ]);
 

--- a/apps/web/src/features/activity-timeline/activity-view.tsx
+++ b/apps/web/src/features/activity-timeline/activity-view.tsx
@@ -2,6 +2,7 @@ import {
   defineQueryFilters,
   type Query,
 } from '@app/features/next-soup/filters/filter-store';
+import { useSplitPanelOrThrow } from '@components/app/split-layout/layoutUtils';
 import type { TabItem } from '@core/component/Tabs';
 import { TabsInset } from '@core/component/TabsInset';
 import { ENABLE_SNIPPETS } from '@core/constant/featureFlags';
@@ -10,7 +11,7 @@ import { getTypeNoun } from '@entity/extractors-notification/notification-descri
 import { NotificationRow } from '@entity/extractors-notification/notification-row';
 import type { SoupApiItemFilter } from '@queries/soup/items';
 import { makePersisted } from '@solid-primitives/storage';
-import { createSignal, type JSX, Show } from 'solid-js';
+import { createMemo, createSignal, type JSX, Show } from 'solid-js';
 import type { TimelineRow } from './collapse';
 import { EntityEventRow } from './entity-event-row';
 import { mapMyActivityEntity, mapSharedEmailEntity } from './entity-events';
@@ -197,15 +198,29 @@ const ACTIVITY_TABS: TabItem[] = [
 ];
 
 /**
- * The Activity tab: one pane at a time with a Me/Team toggle — "Things I
- * did" (the user's own action timeline) vs the team Firehose. A single
- * column keeps the view usable inside narrow splits; the toggle matches the
- * segmented tabs other list views use.
+ * Minimum split width for showing both timelines side by side. Below it
+ * (half-splits, mobile) each pane would be too cramped to read, so the view
+ * collapses to one pane with a Me/Team toggle. At or above it (e.g. a
+ * full-width window on a 13" laptop) both panes render and the toggle is
+ * hidden.
+ */
+const DUAL_PANE_MIN_SPLIT_WIDTH = 1024;
+
+/**
+ * The Activity tab: "Things I did" (the user's own action timeline) and the
+ * team Firehose. Side by side when the split is wide enough; otherwise one
+ * pane at a time behind a Me/Team segmented toggle (the same control other
+ * list views use), persisted across sessions.
  */
 export function ActivityView() {
+  const panel = useSplitPanelOrThrow();
   const [tab, setTab] = makePersisted(createSignal<ActivityTab>('me'), {
     name: 'activity-view-tab',
   });
+
+  const isDualPane = createMemo(
+    () => (panel.panelSize.width ?? 0) >= DUAL_PANE_MIN_SPLIT_WIDTH
+  );
 
   // A factory rather than a shared element: each pane mount gets its own
   // node instead of re-parenting one instance across Show branches.
@@ -220,10 +235,24 @@ export function ActivityView() {
 
   return (
     <Show
-      when={tab() === 'team'}
-      fallback={<MyActivityPane trailing={tabs()} />}
+      when={isDualPane()}
+      fallback={
+        <Show
+          when={tab() === 'team'}
+          fallback={<MyActivityPane trailing={tabs()} />}
+        >
+          <FirehosePane trailing={tabs()} />
+        </Show>
+      }
     >
-      <FirehosePane trailing={tabs()} />
+      <div class="flex h-full min-h-0">
+        <div class="min-h-0 min-w-0 flex-1 border-r border-edge-muted">
+          <MyActivityPane />
+        </div>
+        <div class="min-h-0 min-w-0 flex-1">
+          <FirehosePane />
+        </div>
+      </div>
     </Show>
   );
 }

--- a/apps/web/src/features/activity-timeline/activity-view.tsx
+++ b/apps/web/src/features/activity-timeline/activity-view.tsx
@@ -2,11 +2,15 @@ import {
   defineQueryFilters,
   type Query,
 } from '@app/features/next-soup/filters/filter-store';
+import type { TabItem } from '@core/component/Tabs';
+import { TabsInset } from '@core/component/TabsInset';
 import { ENABLE_SNIPPETS } from '@core/constant/featureFlags';
 import { useUserId } from '@core/context/user';
 import { getTypeNoun } from '@entity/extractors-notification/notification-description-helpers';
 import { NotificationRow } from '@entity/extractors-notification/notification-row';
 import type { SoupApiItemFilter } from '@queries/soup/items';
+import { makePersisted } from '@solid-primitives/storage';
+import { createSignal, type JSX, Show } from 'solid-js';
 import type { TimelineRow } from './collapse';
 import { EntityEventRow } from './entity-event-row';
 import { mapMyActivityEntity, mapSharedEmailEntity } from './entity-events';
@@ -101,7 +105,7 @@ function NotificationTimelineRow(props: { row: TimelineRow }) {
  * created/edited, tasks and folders created, agent sessions, and calls
  * attended.
  */
-function MyActivityPane() {
+function MyActivityPane(props: { trailing?: JSX.Element }) {
   const userId = useUserId();
   const resolveChannel = useChannelLookup();
 
@@ -132,6 +136,7 @@ function MyActivityPane() {
       renderRow={renderRow}
       emptyTitle="No activity yet"
       emptyDescription="Messages and emails you send, documents you edit, and tasks you create will appear here."
+      trailing={props.trailing}
     />
   );
 }
@@ -145,7 +150,7 @@ function MyActivityPane() {
  * (visibility inherited from CRM permissions) shows up even though it never
  * notifies this user directly.
  */
-function FirehosePane() {
+function FirehosePane(props: { trailing?: JSX.Element }) {
   const resolveChannel = useChannelLookup();
 
   const feed = mergeTimelineFeeds([
@@ -179,23 +184,46 @@ function FirehosePane() {
       renderRow={renderRow}
       emptyTitle="Nothing happening yet"
       emptyDescription="Messages, replies, comments, shared emails, calls, and pull request activity from across your team will appear here."
+      trailing={props.trailing}
     />
   );
 }
 
+type ActivityTab = 'me' | 'team';
+
+const ACTIVITY_TABS: TabItem[] = [
+  { value: 'me', label: 'Me' },
+  { value: 'team', label: 'Team' },
+];
+
 /**
- * The Activity tab: "Things I did" (the user's own action timeline) on the
- * left, the team Firehose on the right, each scrolling independently.
+ * The Activity tab: one pane at a time with a Me/Team toggle — "Things I
+ * did" (the user's own action timeline) vs the team Firehose. A single
+ * column keeps the view usable inside narrow splits; the toggle matches the
+ * segmented tabs other list views use.
  */
 export function ActivityView() {
+  const [tab, setTab] = makePersisted(createSignal<ActivityTab>('me'), {
+    name: 'activity-view-tab',
+  });
+
+  // A factory rather than a shared element: each pane mount gets its own
+  // node instead of re-parenting one instance across Show branches.
+  const tabs = () => (
+    <TabsInset
+      list={ACTIVITY_TABS}
+      value={tab()}
+      defaultValue="me"
+      onChange={(value) => setTab(value as ActivityTab)}
+    />
+  );
+
   return (
-    <div class="flex h-full min-h-0 flex-col md:flex-row">
-      <div class="min-h-0 min-w-0 flex-1 border-b border-edge-muted md:border-b-0 md:border-r">
-        <MyActivityPane />
-      </div>
-      <div class="min-h-0 min-w-0 flex-1">
-        <FirehosePane />
-      </div>
-    </div>
+    <Show
+      when={tab() === 'team'}
+      fallback={<MyActivityPane trailing={tabs()} />}
+    >
+      <FirehosePane trailing={tabs()} />
+    </Show>
   );
 }

--- a/apps/web/src/features/activity-timeline/entity-events.test.ts
+++ b/apps/web/src/features/activity-timeline/entity-events.test.ts
@@ -1,0 +1,96 @@
+import type { DocumentEntity, EmailEntity } from '@entity';
+import { describe, expect, it } from 'vitest';
+import { mapMyActivityEntity } from './entity-events';
+
+const USER = 'macro|me@test.com';
+
+const HOUR_MS = 60 * 60 * 1000;
+const CREATED = new Date('2026-07-01T12:00:00Z');
+const at = (offsetMs: number) => new Date(CREATED.getTime() + offsetMs);
+
+function doc(overrides: Partial<DocumentEntity> = {}): DocumentEntity {
+  return {
+    type: 'document',
+    id: 'doc-1',
+    name: 'Doc',
+    ownerId: USER,
+    fileType: 'md',
+    createdAt: CREATED,
+    updatedAt: CREATED,
+    ...overrides,
+  } as DocumentEntity;
+}
+
+describe('mapMyActivityEntity — documents', () => {
+  it('maps a fresh markdown doc to a single created event', () => {
+    const events = mapMyActivityEntity(doc(), USER);
+    expect(events.map((e) => e.kind === 'entity-event' && e.verb)).toEqual([
+      'created-document',
+    ]);
+  });
+
+  it('splits an older-edited markdown doc into edited + created events', () => {
+    const events = mapMyActivityEntity(
+      doc({ updatedAt: at(2 * HOUR_MS) }),
+      USER
+    );
+    expect(events.map((e) => e.kind === 'entity-event' && e.verb)).toEqual([
+      'edited-document',
+      'created-document',
+    ]);
+    expect(events[0]!.ts).toBe(at(2 * HOUR_MS).getTime());
+    expect(events[1]!.ts).toBe(CREATED.getTime());
+    expect(events[0]!.id).not.toBe(events[1]!.id);
+  });
+
+  it('maps tasks to task verbs', () => {
+    const events = mapMyActivityEntity(
+      doc({ subType: { type: 'task' }, updatedAt: at(2 * HOUR_MS) }),
+      USER
+    );
+    expect(events.map((e) => e.kind === 'entity-event' && e.verb)).toEqual([
+      'edited-task',
+      'created-task',
+    ]);
+  });
+
+  it('emits nothing for ingested file types like pdf', () => {
+    // Email-auto-parsed and uploaded files are pipeline output, and their
+    // updatedAt moves when the file is merely viewed — no created/edited
+    // events for them.
+    expect(mapMyActivityEntity(doc({ fileType: 'pdf' }), USER)).toEqual([]);
+    expect(
+      mapMyActivityEntity(
+        doc({ fileType: 'pdf', updatedAt: at(2 * HOUR_MS) }),
+        USER
+      )
+    ).toEqual([]);
+    expect(mapMyActivityEntity(doc({ fileType: undefined }), USER)).toEqual([]);
+  });
+});
+
+describe('mapMyActivityEntity — emails', () => {
+  it('distinguishes drafts from sent email', () => {
+    const email = (isDraft: boolean): EmailEntity =>
+      ({
+        type: 'email',
+        id: 'thread-1',
+        name: 'Subject',
+        ownerId: USER,
+        isDraft,
+        createdAt: CREATED,
+        updatedAt: CREATED,
+      }) as EmailEntity;
+
+    expect(
+      mapMyActivityEntity(email(false), USER).map(
+        (e) => e.kind === 'entity-event' && e.verb
+      )
+    ).toEqual(['sent-email']);
+    expect(
+      mapMyActivityEntity(email(true), USER).map(
+        (e) => e.kind === 'entity-event' && e.verb
+      )
+    ).toEqual(['drafted-email']);
+  });
+});

--- a/apps/web/src/features/activity-timeline/entity-events.ts
+++ b/apps/web/src/features/activity-timeline/entity-events.ts
@@ -11,6 +11,21 @@ import type { EntityEventVerb, TimelineItem } from './timeline-types';
  */
 const EDIT_SPLIT_WINDOW_MS = 60 * 1000;
 
+/**
+ * Document types the user actually authors inside Macro. Other file types
+ * (pdf, docx, images, …) mostly reach the workspace through ingestion
+ * pipelines — email-attachment parsing, bulk-upload extraction — and their
+ * updatedAt also moves on viewer activity (e.g. opening a PDF), so treating
+ * them as created/edited would fabricate actions the user never took.
+ */
+const AUTHORABLE_FILE_TYPES: ReadonlySet<string> = new Set(['md', 'canvas']);
+
+function isAuthorableDocument(entity: EntityData): boolean {
+  if (entity.type !== 'document') return false;
+  if (entity.subType?.type === 'task') return true;
+  return AUTHORABLE_FILE_TYPES.has(entity.fileType ?? '');
+}
+
 function tsOf(value: DateValue | null | undefined): number | undefined {
   if (value == null) return undefined;
   const ms = new Date(value).getTime();
@@ -102,6 +117,7 @@ export function mapMyActivityEntity(
           ),
         ];
       case 'document':
+        if (!isAuthorableDocument(entity)) return [];
         return entity.subType?.type === 'task'
           ? documentEvents(entity, 'created-task', 'edited-task')
           : documentEvents(entity, 'created-document', 'edited-document');

--- a/apps/web/src/features/activity-timeline/feeds.ts
+++ b/apps/web/src/features/activity-timeline/feeds.ts
@@ -6,7 +6,10 @@ import {
 import type { EntityData } from '@entity';
 import type { UnifiedNotification } from '@notifications';
 import { useUserNotificationsQuery } from '@queries/notification/user-notifications';
-import { useSoupAstItemsQuery } from '@queries/soup/items';
+import {
+  type SoupApiItemFilter,
+  useSoupAstItemsQuery,
+} from '@queries/soup/items';
 import { createMemo } from 'solid-js';
 import { entitySortTs } from './entity-events';
 import type { TimelineFeed, TimelineItem } from './timeline-types';
@@ -87,13 +90,23 @@ export function createSoupTimelineFeed(args: {
   query: () => Query;
   map: (entity: EntityData) => TimelineItem[];
   enabled?: () => boolean;
+  /**
+   * Mirror of the server query for the websocket cache layer: optimistic
+   * inserts bypass the server AST, so without this gate any entity the user
+   * touches (e.g. an auto-ingested attachment doc bumped by viewing it) gets
+   * prepended into this feed's cache.
+   */
+  itemFilter?: SoupApiItemFilter;
 }): TimelineFeed {
   const query = useSoupAstItemsQuery(
     () => ({
       params: { limit: PAGE_SIZE, sort_method: 'updated_at' },
       body: compileToAst(queryStateFrom(args.query())),
     }),
-    () => ({ enabled: args.enabled?.() ?? true })
+    () => ({
+      enabled: args.enabled?.() ?? true,
+      meta: args.itemFilter ? { itemFilter: args.itemFilter } : undefined,
+    })
   );
 
   const entities = createMemo((): EntityData[] => query.data?.entities ?? []);

--- a/apps/web/src/features/activity-timeline/timeline-view.tsx
+++ b/apps/web/src/features/activity-timeline/timeline-view.tsx
@@ -5,6 +5,7 @@ import { EmptyStatePanel } from '@ui';
 import {
   createEffect,
   createMemo,
+  createSignal,
   For,
   type JSX,
   onCleanup,
@@ -37,9 +38,16 @@ function sectionize(rows: TimelineRow[]): TimelineSection[] {
   return sections;
 }
 
+function rowIdentity(row: TimelineRow): string {
+  let identity = `${row.key}:${row.ts}`;
+  for (const item of row.items) identity += `,${item.id}`;
+  return identity;
+}
+
 /**
  * One scrolling activity pane: a titled, date-sectioned, infinite feed of
- * compact event rows. Row rendering is supplied by the caller.
+ * compact event rows. Row rendering is supplied by the caller; `trailing`
+ * renders at the header's right edge (e.g. the Me/Team toggle).
  */
 export function TimelinePane(props: {
   title: string;
@@ -48,19 +56,52 @@ export function TimelinePane(props: {
   renderRow: (row: TimelineRow) => JSX.Element;
   emptyTitle: string;
   emptyDescription: string;
+  trailing?: JSX.Element;
 }) {
-  const sections = createMemo(() =>
-    sectionize(collapseTimeline(props.feed.items()))
-  );
+  // Row and section objects are rebuilt on every feed update; reusing the
+  // previous object when a row's identity is unchanged lets <For> keep its
+  // DOM. Without this, each loaded page re-rendered every existing row —
+  // hundreds of markdown previews — which compounded until the pane froze.
+  let prevRows = new Map<string, TimelineRow>();
+  const rows = createMemo((): TimelineRow[] => {
+    const next = collapseTimeline(props.feed.items());
+    const reused = next.map((row) => {
+      const identity = rowIdentity(row);
+      const prev = prevRows.get(identity);
+      return prev ?? row;
+    });
+    prevRows = new Map(reused.map((row) => [rowIdentity(row), row]));
+    return reused;
+  });
+
+  let prevSections = new Map<string, TimelineSection>();
+  const sections = createMemo((): TimelineSection[] => {
+    const next = sectionize(rows());
+    const reused = next.map((section) => {
+      const prev = prevSections.get(section.key);
+      const unchanged =
+        prev &&
+        prev.rows.length === section.rows.length &&
+        prev.rows.every((row, index) => row === section.rows[index]);
+      return unchanged ? prev : section;
+    });
+    prevSections = new Map(reused.map((section) => [section.key, section]));
+    return reused;
+  });
+
+  // Load-more must keep firing while the sentinel stays in view:
+  // IntersectionObserver only reports threshold *crossings*, so if a loaded
+  // page doesn't push the sentinel out of the margin the observer alone
+  // never fires again and the feed stalls. Track visibility as a signal and
+  // re-attempt whenever a fetch settles while it is still visible.
+  const [sentinelVisible, setSentinelVisible] = createSignal(false);
 
   let sentinel: HTMLDivElement | undefined;
   createEffect(() => {
     if (!sentinel) return;
     const observer = new IntersectionObserver(
       (entries) => {
-        if (entries.some((entry) => entry.isIntersecting)) {
-          props.feed.fetchMore();
-        }
+        setSentinelVisible(entries.some((entry) => entry.isIntersecting));
       },
       { rootMargin: '600px' }
     );
@@ -68,11 +109,23 @@ export function TimelinePane(props: {
     onCleanup(() => observer.disconnect());
   });
 
+  createEffect(() => {
+    if (!sentinelVisible()) return;
+    if (props.feed.isLoading() || props.feed.isFetchingMore()) return;
+    if (!props.feed.hasMore()) return;
+    props.feed.fetchMore();
+  });
+
   return (
     <div class="flex h-full min-h-0 flex-col">
-      <div class="shrink-0 px-6 pb-2 pt-5">
-        <h2 class="text-base font-semibold text-ink">{props.title}</h2>
-        <p class="text-xs text-ink-muted">{props.description}</p>
+      <div class="shrink-0 flex items-start justify-between gap-3 px-6 pb-2 pt-5">
+        <div class="min-w-0">
+          <h2 class="text-base font-semibold text-ink">{props.title}</h2>
+          <p class="text-xs text-ink-muted">{props.description}</p>
+        </div>
+        <Show when={props.trailing}>
+          <div class="shrink-0">{props.trailing}</div>
+        </Show>
       </div>
       <div class="min-h-0 flex-1 overflow-y-auto">
         <div class="mx-auto flex w-full max-w-2xl flex-col px-3 pb-10 mobile:pb-(--mobile-content-inset-bottom)">


### PR DESCRIPTION
Follow-up to #4931 fixing two false-positive classes in the "Things I did" pane of the Activity tab:

## 1. Email-auto-parsed PDFs showed as "You created/edited …"

Invoices, receipts, and other auto-ingested files appeared as personal actions even though a pipeline created them. The existing `isEmailAttachment: false` filter only excludes documents linked via `document_email`, which these rows lack.

Document events are now restricted to the types the user actually authors in Macro — markdown and canvas (which includes tasks) — enforced in three places:
- the server soup query (`fileType: ['md', 'canvas']`),
- the entity→event mapper (non-authorable docs emit no events),
- a new per-feed websocket `itemFilter`, since optimistic cache inserts bypass the server AST and could inject a just-viewed attachment doc into the feed.

## 2. Viewing a PDF showed as "You edited …"

Viewer activity bumps `updatedAt` on non-authorable file types, so a mere view minted an "edited" event. Since those types no longer emit created/edited events at all, a view can't fabricate an edit. Authorable (md/canvas) docs keep the created/edited split from #4931.

## Trade-off

Deliberate manual file uploads also stop appearing in the feed — there is no stored marker distinguishing them from pipeline-ingested files (attachment docs are only detectable via `document_email` links, which the auto-parsed rows are missing). If upload events matter, the clean fix is backend: a creation-source column on `Document` (or reliably linking every ingestion path through `document_email`).

## Testing

- New unit tests for the mapper (`entity-events.test.ts`): pdf/unknown types emit nothing; md docs split into created+edited; tasks map to task verbs; draft vs sent email verbs.
- `bun type-check`, `biome check`, and the full web vitest suite pass (the only 2 failures are the long-pre-existing websocket reconnect tests, which fail identically on `main`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01R5eCx1aJFQ94eCxH3sryDB)_