### PR TITLE
fix(contacts): preserve explicit email contact relationships

### DIFF
--- a/.sqlx/query-beeb3f92cd18664a6d748be12f52f8051602e6d2aaf7d5194af235e77902265b.json
+++ b/.sqlx/query-beeb3f92cd18664a6d748be12f52f8051602e6d2aaf7d5194af235e77902265b.json
@@ -26,7 +26,7 @@
       ]
     },
     "nullable": [
-      true,
+      null,
       null,
       null
     ]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,8 @@ camelCased rather than snake_cased (use `/dump-schema` or check the migration fi
 When a column is camelCased, you need to cast it as the snake_cased version when reading from the database. E.g.
 `SELECT "userId" as "user_id" FROM "UserInsights"`.
 Any time you make changes to the SQL code in rust, you need to run `just prepare_db` to
-update the `.sqlx` directory. Run it **only** from the repository root — do not run it from
+update the `.sqlx` directory. Always run it inside `nix develop` and **only** from the
+repository root (for example, `nix develop --command just prepare_db`) — do not run it from
 individual crate directories anymore. The workspace-level recipe handles every crate that
 has sqlx queries.
 

--- a/crates/contacts/src/domain/models/messages.rs
+++ b/crates/contacts/src/domain/models/messages.rs
@@ -2,9 +2,53 @@ use macro_user_id::user_id::MacroUserIdStr;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 
-/// A contacts SQS message carrying the list of user IDs to connect.
+#[cfg(test)]
+mod test;
+
+/// A contacts SQS message carrying the list of user IDs to connect. All users in the set will
+/// get connected with all other users in the set.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ContactsNodes {
     /// User IDs whose pairwise connections should be upserted.
     pub users: HashSet<MacroUserIdStr<'static>>,
+}
+
+/// An explicit undirected relationship between two contacts users.
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub struct ContactConnection {
+    /// One endpoint of the relationship.
+    pub first: MacroUserIdStr<'static>,
+    /// The other endpoint of the relationship.
+    pub second: MacroUserIdStr<'static>,
+}
+
+impl ContactConnection {
+    /// Creates an explicit relationship between two users.
+    pub fn new(first: MacroUserIdStr<'static>, second: MacroUserIdStr<'static>) -> Self {
+        Self { first, second }
+    }
+}
+
+/// A contacts SQS message carrying only explicitly requested relationships.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ContactConnections {
+    /// Relationships to upsert.
+    pub connections: Vec<ContactConnection>,
+}
+
+impl ContactConnections {
+    /// Creates an explicit-relationships message.
+    pub fn new(connections: Vec<ContactConnection>) -> Self {
+        Self { connections }
+    }
+}
+
+/// A message accepted by the contacts queue consumer.
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub enum ContactsMessage {
+    /// The existing complete-graph message.
+    Nodes(ContactsNodes),
+    /// A message containing explicit relationships.
+    Connections(ContactConnections),
 }

--- a/crates/contacts/src/domain/models/messages.rs
+++ b/crates/contacts/src/domain/models/messages.rs
@@ -8,6 +8,7 @@ mod test;
 /// A contacts SQS message carrying the list of user IDs to connect. All users in the set will
 /// get connected with all other users in the set.
 #[derive(Serialize, Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct ContactsNodes {
     /// User IDs whose pairwise connections should be upserted.
     pub users: HashSet<MacroUserIdStr<'static>>,
@@ -31,6 +32,7 @@ impl ContactConnection {
 
 /// A contacts SQS message carrying only explicitly requested relationships.
 #[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ContactConnections {
     /// Relationships to upsert.
     pub connections: Vec<ContactConnection>,

--- a/crates/contacts/src/domain/models/messages/test.rs
+++ b/crates/contacts/src/domain/models/messages/test.rs
@@ -1,0 +1,42 @@
+use super::*;
+
+fn user(email: &str) -> MacroUserIdStr<'static> {
+    MacroUserIdStr::try_from_email(email).unwrap()
+}
+
+#[test]
+fn explicit_connections_are_a_separate_message_shape() {
+    let connections = vec![ContactConnection::new(
+        user("owner@example.com"),
+        user("contact@example.com"),
+    )];
+    let serialized = serde_json::to_value(ContactConnections::new(connections.clone())).unwrap();
+
+    assert!(serialized.get("users").is_none());
+    assert_eq!(
+        serde_json::from_value::<ContactConnections>(serialized)
+            .unwrap()
+            .connections,
+        connections
+    );
+}
+
+#[test]
+fn consumer_deserializes_existing_nodes_message() {
+    let message: ContactsMessage = serde_json::from_str(
+        r#"{"users":["macro|owner@example.com","macro|contact@example.com"]}"#,
+    )
+    .unwrap();
+
+    assert!(matches!(message, ContactsMessage::Nodes(_)));
+}
+
+#[test]
+fn consumer_deserializes_explicit_connections_message() {
+    let message: ContactsMessage = serde_json::from_str(
+        r#"{"connections":[{"first":"macro|owner@example.com","second":"macro|contact@example.com"}]}"#,
+    )
+    .unwrap();
+
+    assert!(matches!(message, ContactsMessage::Connections(_)));
+}

--- a/crates/contacts/src/domain/models/messages/test.rs
+++ b/crates/contacts/src/domain/models/messages/test.rs
@@ -32,6 +32,15 @@ fn consumer_deserializes_existing_nodes_message() {
 }
 
 #[test]
+fn consumer_rejects_message_with_both_shapes() {
+    let message = serde_json::from_str::<ContactsMessage>(
+        r#"{"users":["macro|owner@example.com"],"connections":[]}"#,
+    );
+
+    assert!(message.is_err());
+}
+
+#[test]
 fn consumer_deserializes_explicit_connections_message() {
     let message: ContactsMessage = serde_json::from_str(
         r#"{"connections":[{"first":"macro|owner@example.com","second":"macro|contact@example.com"}]}"#,

--- a/crates/contacts/src/domain/ports.rs
+++ b/crates/contacts/src/domain/ports.rs
@@ -1,4 +1,4 @@
-use crate::domain::models::messages::ContactsNodes;
+use crate::domain::models::messages::{ContactConnection, ContactConnections, ContactsNodes};
 use macro_user_id::user_id::MacroUserIdStr;
 use rootcause::Report;
 use sqlx::types::Uuid;
@@ -30,8 +30,17 @@ pub trait ContactsNotifier: Send + Sync + 'static {
 
 /// Port trait for publishing a contacts message to the ingress queue.
 pub trait ContactsIngressQueue: Send + Sync + 'static {
-    /// Publish a contacts message to the queue.
-    fn publish(&self, message: ContactsNodes) -> impl Future<Output = Result<(), Report>> + Send;
+    /// Publishes a complete-graph contacts message to the queue.
+    fn publish_nodes(
+        &self,
+        message: ContactsNodes,
+    ) -> impl Future<Output = Result<(), Report>> + Send;
+
+    /// Publishes explicit contact relationships to the queue.
+    fn publish_connections(
+        &self,
+        message: ContactConnections,
+    ) -> impl Future<Output = Result<(), Report>> + Send;
 }
 
 /// Port trait for enqueuing contacts messages for async processing.
@@ -40,6 +49,12 @@ pub trait ContactsIngress: Send + Sync + 'static {
     fn enqueue_contacts(
         &self,
         users: HashSet<MacroUserIdStr<'static>>,
+    ) -> impl Future<Output = Result<(), Report>> + Send;
+
+    /// Enqueues only the supplied contact relationships for upsert.
+    fn enqueue_contact_connections(
+        &self,
+        connections: Vec<ContactConnection>,
     ) -> impl Future<Output = Result<(), Report>> + Send;
 }
 

--- a/crates/contacts/src/domain/service.rs
+++ b/crates/contacts/src/domain/service.rs
@@ -1,5 +1,7 @@
 use crate::domain::models::graph::{UndirectedGraph, Vertex};
-use crate::domain::models::messages::ContactsNodes;
+use crate::domain::models::messages::{
+    ContactConnection, ContactConnections, ContactsMessage, ContactsNodes,
+};
 use crate::domain::ports::{
     ContactsBackfillOutboxRepo, ContactsIngress, ContactsIngressQueue, ContactsNotifier,
     ContactsOutboxService, ContactsRepository, ContactsService,
@@ -36,26 +38,41 @@ impl<R: ContactsRepository, N: ContactsNotifier> ContactsDomainService<R, N> {
         Ok(res)
     }
 
-    /// Processes a contacts SQS message by computing all pairwise connections
-    /// from the user list and persisting them.
+    /// Processes either the existing complete-graph message or a separate
+    /// explicit-relationships message.
     #[instrument(err, skip(self))]
     pub(crate) async fn process_message(
         &self,
-        msg: ContactsNodes,
+        msg: ContactsMessage,
     ) -> Result<(), rootcause::Report> {
-        let connections: Vec<(MacroUserIdStr<'static>, MacroUserIdStr<'static>)> = {
-            let graph = UndirectedGraph::new(msg.users.iter().map(Vertex::new)).complete();
-            graph
-                .inner()
-                .edges()
-                .map(|e| (e.a().data().clone(), e.b().data().clone()))
-                .collect()
+        let (users, connections) = match msg {
+            ContactsMessage::Nodes(ContactsNodes { users }) => {
+                let graph = UndirectedGraph::new(users.iter().map(Vertex::new)).complete();
+                let connections = graph
+                    .inner()
+                    .edges()
+                    .map(|edge| (edge.a().data().clone(), edge.b().data().clone()))
+                    .collect();
+                (users, connections)
+            }
+            ContactsMessage::Connections(ContactConnections { connections }) => {
+                let users = connections
+                    .iter()
+                    .flat_map(|connection| [&connection.first, &connection.second])
+                    .cloned()
+                    .collect();
+                let connections = connections
+                    .into_iter()
+                    .map(|connection| (connection.first, connection.second))
+                    .collect();
+                (users, connections)
+            }
         };
 
         self.repository.create_connections(connections).await?;
 
         self.notifier
-            .invalidate_contacts_for_users(msg.users.into_iter().collect())
+            .invalidate_contacts_for_users(users.into_iter().collect())
             .await?;
         Ok(())
     }
@@ -70,16 +87,15 @@ impl<R: ContactsRepository, N: ContactsNotifier> ContactsService for ContactsDom
     }
 
     async fn add_contact_nodes(&self, nodes: ContactsNodes) -> Result<(), rootcause::Report> {
-        self.process_message(nodes).await
+        self.process_message(ContactsMessage::Nodes(nodes)).await
     }
 }
 
 /// Queue-backed implementation of [`ContactsIngress`].
 ///
-/// Serialises the user set into a [`ContactsMessage`] and publishes it through
-/// the provided [`ContactsIngressQueue`]. The heavy lifting (computing pairwise
-/// connections, persisting them) is done by the contacts service worker that
-/// consumes from that queue.
+/// Serialises complete-graph or explicit-relationship messages and publishes
+/// them through the provided [`ContactsIngressQueue`]. Persistence is handled
+/// by the contacts service worker that consumes from that queue.
 pub struct SqsContactsIngress<Q> {
     /// The queue used to publish contacts messages.
     pub queue: Q,
@@ -90,7 +106,16 @@ impl<Q: ContactsIngressQueue> ContactsIngress for SqsContactsIngress<Q> {
         &self,
         users: HashSet<MacroUserIdStr<'static>>,
     ) -> Result<(), Report> {
-        self.queue.publish(ContactsNodes { users }).await
+        self.queue.publish_nodes(ContactsNodes { users }).await
+    }
+
+    async fn enqueue_contact_connections(
+        &self,
+        connections: Vec<ContactConnection>,
+    ) -> Result<(), Report> {
+        self.queue
+            .publish_connections(ContactConnections::new(connections))
+            .await
     }
 }
 

--- a/crates/contacts/src/domain/service/test.rs
+++ b/crates/contacts/src/domain/service/test.rs
@@ -1,5 +1,47 @@
-#[allow(unused_imports)]
 use super::*;
+use crate::domain::models::messages::ContactConnection;
+use std::sync::Mutex;
+
+#[derive(Default)]
+struct RecordingRepository {
+    connections: Mutex<Vec<(MacroUserIdStr<'static>, MacroUserIdStr<'static>)>>,
+}
+
+impl ContactsRepository for RecordingRepository {
+    async fn get_contacts(
+        &self,
+        _user_id: MacroUserIdStr<'_>,
+    ) -> Result<Vec<MacroUserIdStr<'static>>, rootcause::Report> {
+        Ok(Vec::new())
+    }
+
+    async fn create_connections(
+        &self,
+        connections: Vec<(MacroUserIdStr<'_>, MacroUserIdStr<'_>)>,
+    ) -> Result<(), rootcause::Report> {
+        self.connections.lock().unwrap().extend(
+            connections
+                .into_iter()
+                .map(|(first, second)| (first.into_owned(), second.into_owned())),
+        );
+        Ok(())
+    }
+}
+
+struct NoopNotifier;
+
+impl ContactsNotifier for NoopNotifier {
+    async fn invalidate_contacts_for_users(
+        &self,
+        _user_ids: Vec<MacroUserIdStr<'_>>,
+    ) -> Result<(), rootcause::Report> {
+        Ok(())
+    }
+}
+
+fn user(email: &str) -> MacroUserIdStr<'static> {
+    MacroUserIdStr::try_from_email(email).unwrap()
+}
 
 #[test]
 fn test_deserialize_connections_message() {
@@ -7,6 +49,30 @@ fn test_deserialize_connections_message() {
     let msg: Option<ContactsNodes> = serde_json::from_str(input_json).ok();
     assert!(msg.is_some());
     assert_eq!(msg.unwrap().users.len(), 3);
+}
+
+#[tokio::test]
+async fn explicit_connections_do_not_create_a_complete_graph() {
+    let owner = user("owner@example.com");
+    let first = user("first@example.com");
+    let second = user("second@example.com");
+    let service = ContactsDomainService {
+        repository: RecordingRepository::default(),
+        notifier: NoopNotifier,
+    };
+
+    service
+        .process_message(ContactsMessage::Connections(ContactConnections::new(vec![
+            ContactConnection::new(owner.clone(), first.clone()),
+            ContactConnection::new(owner.clone(), second.clone()),
+        ])))
+        .await
+        .unwrap();
+
+    let connections = service.repository.connections.lock().unwrap();
+    assert_eq!(connections.len(), 2);
+    assert!(connections.contains(&(owner.clone(), first)));
+    assert!(connections.contains(&(owner, second)));
 }
 
 fn generate_sqs_message() -> aws_sdk_sqs::types::Message {
@@ -20,6 +86,8 @@ fn generate_sqs_message() -> aws_sdk_sqs::types::Message {
 fn test_message_from_aws_sqs() {
     let sqs_message = generate_sqs_message();
     let message = crate::inbound::worker::message_from_sqs(&sqs_message);
-    assert!(message.is_some(), "Could not parse body from sqs message");
-    assert_eq!(message.unwrap().users.len(), 3);
+    let Some(ContactsMessage::Nodes(message)) = message else {
+        panic!("Could not parse body as a contacts-nodes message");
+    };
+    assert_eq!(message.users.len(), 3);
 }

--- a/crates/contacts/src/domain/service/test.rs
+++ b/crates/contacts/src/domain/service/test.rs
@@ -71,8 +71,10 @@ async fn explicit_connections_do_not_create_a_complete_graph() {
 
     let connections = service.repository.connections.lock().unwrap();
     assert_eq!(connections.len(), 2);
-    assert!(connections.contains(&(owner.clone(), first)));
-    assert!(connections.contains(&(owner, second)));
+    assert!(connections.contains(&(owner.clone(), first.clone())));
+    assert!(connections.contains(&(owner, second.clone())));
+    assert!(!connections.contains(&(first.clone(), second.clone())));
+    assert!(!connections.contains(&(second, first)));
 }
 
 fn generate_sqs_message() -> aws_sdk_sqs::types::Message {

--- a/crates/contacts/src/inbound/worker.rs
+++ b/crates/contacts/src/inbound/worker.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use crate::domain::models::messages::ContactsNodes;
+use crate::domain::models::messages::ContactsMessage;
 use crate::domain::ports::{ContactsNotifier, ContactsOutboxService, ContactsRepository};
 use crate::domain::service::ContactsDomainService;
 use rootcause::report;
@@ -89,12 +89,12 @@ impl<R: ContactsRepository, N: ContactsNotifier> ContactsWorker<R, N> {
 }
 
 /// Parses a JSON string into a [`ContactsMessage`].
-fn message_from_json(body: &str) -> Option<ContactsNodes> {
+fn message_from_json(body: &str) -> Option<ContactsMessage> {
     serde_json::from_str(body).ok()
 }
 
 /// Extracts and parses the body from an SQS message.
-pub(crate) fn message_from_sqs(msg: &aws_sdk_sqs::types::Message) -> Option<ContactsNodes> {
+pub(crate) fn message_from_sqs(msg: &aws_sdk_sqs::types::Message) -> Option<ContactsMessage> {
     msg.body.as_ref().and_then(|body| message_from_json(body))
 }
 

--- a/crates/contacts/src/outbound/ingress.rs
+++ b/crates/contacts/src/outbound/ingress.rs
@@ -1,4 +1,4 @@
-use crate::domain::models::messages::ContactsNodes;
+use crate::domain::models::messages::{ContactConnections, ContactsNodes};
 use crate::domain::ports::ContactsIngressQueue;
 use rootcause::Report;
 
@@ -16,10 +16,9 @@ impl SqsContactsQueue {
     }
 }
 
-impl ContactsIngressQueue for SqsContactsQueue {
-    #[tracing::instrument(skip(self, message), err)]
-    async fn publish(&self, message: ContactsNodes) -> Result<(), Report> {
-        let body = serde_json::to_string(&message)?;
+impl SqsContactsQueue {
+    async fn publish<T: serde::Serialize>(&self, message: &T) -> Result<(), Report> {
+        let body = serde_json::to_string(message)?;
         self.client
             .send_message()
             .queue_url(&self.queue_url)
@@ -27,5 +26,17 @@ impl ContactsIngressQueue for SqsContactsQueue {
             .send()
             .await?;
         Ok(())
+    }
+}
+
+impl ContactsIngressQueue for SqsContactsQueue {
+    #[tracing::instrument(skip(self, message), err)]
+    async fn publish_nodes(&self, message: ContactsNodes) -> Result<(), Report> {
+        self.publish(&message).await
+    }
+
+    #[tracing::instrument(skip(self, message), err)]
+    async fn publish_connections(&self, message: ContactConnections) -> Result<(), Report> {
+        self.publish(&message).await
     }
 }

--- a/crates/contacts/src/outbound/repository.rs
+++ b/crates/contacts/src/outbound/repository.rs
@@ -8,6 +8,7 @@ use macro_user_id::user_id::MacroUserIdStr;
 use rootcause::Report;
 use sqlx::PgPool;
 use sqlx::types::Uuid;
+use std::collections::HashSet;
 
 /// Database-backed implementation of [`ContactsRepository`].
 pub struct DbContactsRepository {
@@ -49,7 +50,7 @@ impl ContactsRepository for DbContactsRepository {
         &self,
         connections: Vec<(MacroUserIdStr<'_>, MacroUserIdStr<'_>)>,
     ) -> Result<(), Report> {
-        let (users1, users2): (Vec<_>, Vec<_>) = connections
+        let connections: HashSet<_> = connections
             .into_iter()
             .filter(|(a, b)| a.as_ref() != b.as_ref())
             .map(|(a, b)| {
@@ -59,7 +60,8 @@ impl ContactsRepository for DbContactsRepository {
                     (b, a)
                 }
             })
-            .unzip();
+            .collect();
+        let (users1, users2): (Vec<_>, Vec<_>) = connections.into_iter().unzip();
 
         let u1: Vec<&str> = users1.iter().map(|u| u.as_ref()).collect();
         let u2: Vec<&str> = users2.iter().map(|u| u.as_ref()).collect();

--- a/crates/contacts/src/outbound/repository.rs
+++ b/crates/contacts/src/outbound/repository.rs
@@ -50,17 +50,24 @@ impl ContactsRepository for DbContactsRepository {
         &self,
         connections: Vec<(MacroUserIdStr<'_>, MacroUserIdStr<'_>)>,
     ) -> Result<(), Report> {
+        // Contacts are undirected: discard self-edges and canonicalize endpoint
+        // order so A-B and B-A deduplicate before reaching PostgreSQL.
         let connections: HashSet<_> = connections
             .into_iter()
             .filter(|(a, b)| a.as_ref() != b.as_ref())
             .map(|(a, b)| {
-                if a.as_ref() <= b.as_ref() {
+                if a.as_ref() < b.as_ref() {
                     (a, b)
                 } else {
                     (b, a)
                 }
             })
             .collect();
+
+        if connections.is_empty() {
+            return Ok(());
+        }
+
         let (users1, users2): (Vec<_>, Vec<_>) = connections.into_iter().unzip();
 
         let u1: Vec<&str> = users1.iter().map(|u| u.as_ref()).collect();

--- a/crates/contacts/src/outbound/repository/test.rs
+++ b/crates/contacts/src/outbound/repository/test.rs
@@ -42,6 +42,30 @@ async fn test_create_connections_ordering(pool: PgPool) -> sqlx::Result<()> {
     Ok(())
 }
 
+#[sqlx::test(migrator = "MACRO_DB_MIGRATIONS")]
+async fn test_create_connections_deduplicates_and_ignores_self_edges(
+    pool: PgPool,
+) -> sqlx::Result<()> {
+    let user1 = "macro|a@test.com";
+    let user2 = "macro|b@test.com";
+    let repo = DbContactsRepository::new(pool.clone());
+
+    repo.create_connections(vec![
+        (mid(user1), mid(user2)),
+        (mid(user2), mid(user1)),
+        (mid(user1), mid(user1)),
+    ])
+    .await
+    .unwrap();
+
+    let count = sqlx::query_scalar!("SELECT count(*) FROM contacts_connections")
+        .fetch_one(&pool)
+        .await?
+        .unwrap();
+    assert_eq!(count, 1);
+    Ok(())
+}
+
 #[sqlx::test(
     migrator = "MACRO_DB_MIGRATIONS",
     fixtures(path = "fixtures", scripts("user_list"))

--- a/services/email_service/src/bin/backfill_contacts/process.rs
+++ b/services/email_service/src/bin/backfill_contacts/process.rs
@@ -1,3 +1,4 @@
+use contacts::domain::models::messages::ContactConnection;
 use contacts::domain::ports::ContactsIngress;
 use contacts::domain::service::SqsContactsIngress;
 use contacts::outbound::ingress::SqsContactsQueue;
@@ -25,17 +26,16 @@ pub async fn process_macro_id(
         return Ok(());
     }
 
-    let users: std::collections::HashSet<MacroUserIdStr<'static>> =
-        std::iter::once(Ok(link.macro_id.clone()))
-            .chain(
-                contact_emails
-                    .iter()
-                    .map(|email| MacroUserIdStr::try_from_email(email)),
-            )
-            .collect::<Result<_, _>>()?;
+    let connections = contact_emails
+        .iter()
+        .map(|email| {
+            MacroUserIdStr::try_from_email(email)
+                .map(|contact| ContactConnection::new(link.macro_id.clone(), contact))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
 
     contacts_ingress
-        .enqueue_contacts(users)
+        .enqueue_contact_connections(connections)
         .await
         .map_err(|e| anyhow::anyhow!("{e:?}"))?;
 

--- a/services/email_service/src/pubsub/backfill/increment_counters.rs
+++ b/services/email_service/src/pubsub/backfill/increment_counters.rs
@@ -1,7 +1,6 @@
-use std::collections::HashSet;
-
 use crate::pubsub::context::PubSubContext;
 use crate::pubsub::util::cg_refresh_email;
+use contacts::domain::models::messages::ContactConnection;
 use contacts::domain::ports::ContactsIngress;
 use macro_user_id::user_id::MacroUserIdStr;
 use models_email::api::refresh::{BackfillStatus, RefreshEmailEvent};
@@ -189,13 +188,13 @@ async fn handle_contacts_sync(ctx: &PubSubContext, link: &Link) -> Result<(), Pr
         link.macro_id
     );
 
-    let users: HashSet<MacroUserIdStr<'static>> = std::iter::once(Ok(link.macro_id.clone()))
-        .chain(
-            email_addresses
-                .iter()
-                .map(|email| MacroUserIdStr::try_from_email(email)),
-        )
-        .collect::<Result<_, _>>()
+    let connections = email_addresses
+        .iter()
+        .map(|email| {
+            MacroUserIdStr::try_from_email(email)
+                .map(|contact| ContactConnection::new(link.macro_id.clone(), contact))
+        })
+        .collect::<Result<Vec<_>, _>>()
         .map_err(|e| {
             ProcessingError::NonRetryable(DetailedError {
                 reason: FailureReason::SqsEnqueueFailed,
@@ -204,7 +203,7 @@ async fn handle_contacts_sync(ctx: &PubSubContext, link: &Link) -> Result<(), Pr
         })?;
 
     ctx.contacts_ingress
-        .enqueue_contacts(users)
+        .enqueue_contact_connections(connections)
         .await
         .map_err(|e| {
             ProcessingError::NonRetryable(DetailedError {

--- a/services/email_service/src/pubsub/inbox_sync/operations/upsert_message.rs
+++ b/services/email_service/src/pubsub/inbox_sync/operations/upsert_message.rs
@@ -9,6 +9,7 @@ use crate::pubsub::util::{
 use crate::pubsub::util::{cg_refresh_email, publish_email_event};
 use crate::util::process_pre_insert::{process_message_pre_insert, process_threads_pre_insert};
 use crate::util::upload_attachment::{UploadAttachmentContext, upload_attachment};
+use contacts::domain::models::messages::ContactConnection;
 use contacts::domain::ports::ContactsIngress;
 use email::domain::events::{
     EmailEventOrigin, EmailMacroEvent, MessageReceivedMetadata, MessageSentMetadata,
@@ -451,23 +452,22 @@ async fn handle_contacts_sync(
         return Ok(());
     }
 
-    let users: std::collections::HashSet<MacroUserIdStr<'static>> =
-        std::iter::once(Ok(link.macro_id.clone()))
-            .chain(
-                connection_emails
-                    .iter()
-                    .map(|email| MacroUserIdStr::try_from_email(email)),
-            )
-            .collect::<Result<_, _>>()
-            .map_err(|e| {
-                ProcessingError::NonRetryable(DetailedError {
-                    reason: FailureReason::SqsEnqueueFailed,
-                    source: anyhow::anyhow!(e).context("invalid user email for contacts"),
-                })
-            })?;
+    let connections = connection_emails
+        .iter()
+        .map(|email| {
+            MacroUserIdStr::try_from_email(email)
+                .map(|contact| ContactConnection::new(link.macro_id.clone(), contact))
+        })
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| {
+            ProcessingError::NonRetryable(DetailedError {
+                reason: FailureReason::SqsEnqueueFailed,
+                source: anyhow::anyhow!(e).context("invalid user email for contacts"),
+            })
+        })?;
 
     ctx.contacts_ingress
-        .enqueue_contacts(users)
+        .enqueue_contact_connections(connections)
         .await
         .map_err(|e| {
             ProcessingError::NonRetryable(DetailedError {


### PR DESCRIPTION
## Summary

- add a distinct explicit-connections contacts queue message while preserving the existing complete-graph message
- publish owner-to-recipient edges from email sync and backfill paths so recipients are not connected to one another
- canonicalize and deduplicate undirected contact edges, ignore self-edges, and reject ambiguous queue payloads

