### PR TITLE
feat(web): only signal emails in the Firehose

### DIFF
--- a/apps/web/src/features/activity-timeline/activity-view.tsx
+++ b/apps/web/src/features/activity-timeline/activity-view.tsx
@@ -14,7 +14,7 @@ import { makePersisted } from '@solid-primitives/storage';
 import { createMemo, createSignal, type JSX, Show } from 'solid-js';
 import type { TimelineRow } from './collapse';
 import { EntityEventRow } from './entity-event-row';
-import { mapMyActivityEntity, mapSharedEmailEntity } from './entity-events';
+import { mapEmailActivityEntity, mapMyActivityEntity } from './entity-events';
 import {
   createNotificationTimelineFeed,
   createSoupTimelineFeed,
@@ -68,6 +68,10 @@ const myActionsItemFilter: SoupApiItemFilter = (item) =>
 
 const emailOnlyItemFilter: SoupApiItemFilter = (item) =>
   item.tag === 'emailThread';
+
+/** Firehose email gate: threads only, and only signal (`is_signal`) ones. */
+const signalEmailItemFilter: SoupApiItemFilter = (item) =>
+  item.tag === 'emailThread' && item.data.isImportant;
 
 /**
  * A notification row (or collapsed run of them). Single notifications render
@@ -147,9 +151,9 @@ function MyActivityPane(props: { trailing?: JSX.Element }) {
  * Notifications supply the per-event records — every channel message (with
  * its text), thread replies, mentions, document comments, task assignments,
  * calls, and GitHub PR events (opened/merged/closed, reviews, comments).
- * CRM-shared email threads are merged in from soup so team email traffic
- * (visibility inherited from CRM permissions) shows up even though it never
- * notifies this user directly.
+ * Email activity is merged in from soup, filtered to signal threads only:
+ * the user's inbox arrivals plus CRM-shared team threads (visibility
+ * inherited from CRM permissions), which never notify this user directly.
  */
 function FirehosePane(props: { trailing?: JSX.Element }) {
   const resolveChannel = useChannelLookup();
@@ -159,14 +163,29 @@ function FirehosePane(props: { trailing?: JSX.Element }) {
     // is history, so fetch both and merge.
     createNotificationTimelineFeed({}),
     createNotificationTimelineFeed({ done: true }),
+    // Email activity, signal only (`emailImportance` compiles to the
+    // classifier's per-thread `is_signal` flag — the same definition as the
+    // inbox Signal tab). Two feeds because Shared scoping is disjoint:
+    // CRM-shared team threads, and the user's own inbox arrivals, which
+    // used to come from `new_email` notifications that carry no
+    // signal/noise flag.
     createSoupTimelineFeed({
       query: () =>
         defineQueryFilters({
-          include: { emailShared: 'only' },
+          include: { emailShared: 'only', emailImportance: true },
           emailView: 'all',
         }),
-      map: mapSharedEmailEntity,
-      itemFilter: emailOnlyItemFilter,
+      map: mapEmailActivityEntity,
+      itemFilter: signalEmailItemFilter,
+    }),
+    createSoupTimelineFeed({
+      query: () =>
+        defineQueryFilters({
+          include: { emailShared: 'exclude', emailImportance: true },
+          emailView: 'inbox',
+        }),
+      map: mapEmailActivityEntity,
+      itemFilter: signalEmailItemFilter,
     }),
   ]);
 

--- a/apps/web/src/features/activity-timeline/entity-events.test.ts
+++ b/apps/web/src/features/activity-timeline/entity-events.test.ts
@@ -1,6 +1,6 @@
 import type { DocumentEntity, EmailEntity } from '@entity';
 import { describe, expect, it } from 'vitest';
-import { mapMyActivityEntity } from './entity-events';
+import { mapEmailActivityEntity, mapMyActivityEntity } from './entity-events';
 
 const USER = 'macro|me@test.com';
 
@@ -69,28 +69,47 @@ describe('mapMyActivityEntity — documents', () => {
   });
 });
 
+function email(overrides: Partial<EmailEntity> = {}): EmailEntity {
+  return {
+    type: 'email',
+    id: 'thread-1',
+    name: 'Subject',
+    ownerId: USER,
+    isDraft: false,
+    createdAt: CREATED,
+    updatedAt: CREATED,
+    ...overrides,
+  } as EmailEntity;
+}
+
 describe('mapMyActivityEntity — emails', () => {
   it('distinguishes drafts from sent email', () => {
-    const email = (isDraft: boolean): EmailEntity =>
-      ({
-        type: 'email',
-        id: 'thread-1',
-        name: 'Subject',
-        ownerId: USER,
-        isDraft,
-        createdAt: CREATED,
-        updatedAt: CREATED,
-      }) as EmailEntity;
-
     expect(
-      mapMyActivityEntity(email(false), USER).map(
+      mapMyActivityEntity(email(), USER).map(
         (e) => e.kind === 'entity-event' && e.verb
       )
     ).toEqual(['sent-email']);
     expect(
-      mapMyActivityEntity(email(true), USER).map(
+      mapMyActivityEntity(email({ isDraft: true }), USER).map(
         (e) => e.kind === 'entity-event' && e.verb
       )
     ).toEqual(['drafted-email']);
+  });
+});
+
+describe('mapEmailActivityEntity', () => {
+  it('maps signal threads and drops noise and drafts', () => {
+    expect(
+      mapEmailActivityEntity(email({ isImportant: true })).map(
+        (e) => e.kind === 'entity-event' && e.verb
+      )
+    ).toEqual(['email-activity']);
+    // Untriaged rows (importance not loaded) pass through — the server
+    // queries already filter on importance.
+    expect(mapEmailActivityEntity(email())).toHaveLength(1);
+    expect(mapEmailActivityEntity(email({ isImportant: false }))).toEqual([]);
+    expect(
+      mapEmailActivityEntity(email({ isDraft: true, isImportant: true }))
+    ).toEqual([]);
   });
 });

--- a/apps/web/src/features/activity-timeline/entity-events.ts
+++ b/apps/web/src/features/activity-timeline/entity-events.ts
@@ -136,12 +136,16 @@ export function mapMyActivityEntity(
 }
 
 /**
- * Map a CRM-shared email thread row to a Firehose event. These are the
- * team-visible email threads (visibility inherited from CRM permissions);
- * the row's sender/snippet describe the latest message on the thread.
+ * Map an email thread row to a Firehose event — used for both the user's
+ * signal inbox and CRM-shared team threads (visibility inherited from CRM
+ * permissions). The row's sender/snippet describe the latest message on the
+ * thread. Noise threads (`isImportant === false`, i.e. the classifier's
+ * `is_signal` flag is off) are dropped — the server queries already filter
+ * on importance, but rows can also enter through the websocket cache.
  */
-export function mapSharedEmailEntity(entity: EntityData): TimelineItem[] {
+export function mapEmailActivityEntity(entity: EntityData): TimelineItem[] {
   if (entity.type !== 'email' || entity.isDraft) return [];
+  if (entity.isImportant === false) return [];
   const item = event(entity, 'email-activity', entitySortTs(entity));
   return item ? [item] : [];
 }

--- a/apps/web/src/features/activity-timeline/feeds.ts
+++ b/apps/web/src/features/activity-timeline/feeds.ts
@@ -16,9 +16,15 @@ import type { TimelineFeed, TimelineItem } from './timeline-types';
 
 const PAGE_SIZE = 50;
 
-/** Notification event types that are plumbing rather than team activity. */
+/**
+ * Notification event types the timeline skips: plumbing rather than team
+ * activity, plus email arrivals — notifications carry no signal/noise flag
+ * client-side, so Firehose sources email activity from signal-filtered soup
+ * feeds instead (`Importance(true)` compiles to the thread's `is_signal`).
+ */
 const EXCLUDED_NOTIFICATION_TAGS: ReadonlySet<string> = new Set([
   'inbox_reauth_required',
+  'new_email',
 ]);
 
 /**


### PR DESCRIPTION
Follow-up to #4944: noise emails (newsletters, automated notifications like the Loops contact alerts) no longer show up in the Activity tab's Firehose — only signal.

## How

- **Email activity now comes from two signal-filtered soup feeds** instead of `new_email` notifications: the user's inbox arrivals (`emailShared: 'exclude'`, inbox view) and CRM-shared team threads (`emailShared: 'only'`). Both include `emailImportance: true`, which compiles to the classifier's per-thread `is_signal` flag — the exact same definition the inbox Signal tab uses.
- **`new_email` notifications are dropped from the timeline's notification stream.** Notification rows carry no signal/noise flag client-side, so they couldn't be filtered; the inbox-arrivals soup feed replaces them.
- Defense in depth: the entity→event mapper and the websocket `itemFilter` also gate on the row's `isImportant`, so noise threads can't re-enter through optimistic cache inserts.

## Behavior notes

- Inbox email rows are thread-level now (the row shows the latest message's sender + subject + snippet) rather than one notification per arriving message — visually identical in the compact rows.
- The inbox feed uses the `inbox` email view to mirror Signal-tab semantics, so archived/done threads drop out of the Firehose rather than remaining as history. If we'd rather keep archived signal threads visible in the timeline, switching that feed to the `all` view is a one-line change (at the cost of the user's own sent-only threads also appearing in the Team pane).

## Testing

- New mapper unit tests: signal threads map, `isImportant: false` and drafts drop, untriaged rows pass through (server filters already applied).
- `bun type-check`, `biome check`, full web vitest suite pass (only the two long-pre-existing websocket reconnect failures, identical on `main`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01R5eCx1aJFQ94eCxH3sryDB)_