### PR TITLE
fix(collaboration): deflake websocket reconnect 'open' test

### DIFF
--- a/packages/collaboration/src/websocket/core/websocket.ts
+++ b/packages/collaboration/src/websocket/core/websocket.ts
@@ -13,7 +13,6 @@ import {
   WebsocketEvent,
   type WebsocketEventListener,
   type WebsocketEventListenerOptions,
-  type WebsocketEventListeners,
   type WebsocketEventListenerWithOptions,
   type WebsocketEventMap,
   type WebsocketEventUnion,

--- a/packages/collaboration/src/websocket/core/websocket.ts
+++ b/packages/collaboration/src/websocket/core/websocket.ts
@@ -502,14 +502,17 @@ export class Websocket<Send = WebsocketData, Receive = WebsocketData> {
     // Track by entry identity (not the listener function) so two
     // registrations of the same function - e.g. once + non-once - aren't
     // conflated.
-    const eventListeners: WebsocketEventListenerWithOptions<K, Send, Receive>[] =
-      [
-        ...(this._options.listeners[type] as WebsocketEventListenerWithOptions<
-          K,
-          Send,
-          Receive
-        >[]),
-      ];
+    const eventListeners: WebsocketEventListenerWithOptions<
+      K,
+      Send,
+      Receive
+    >[] = [
+      ...(this._options.listeners[type] as WebsocketEventListenerWithOptions<
+        K,
+        Send,
+        Receive
+      >[]),
+    ];
     const onceListeners = new Set(
       eventListeners.filter(({ options }) => options?.once)
     );

--- a/packages/collaboration/src/websocket/core/websocket.ts
+++ b/packages/collaboration/src/websocket/core/websocket.ts
@@ -500,16 +500,28 @@ export class Websocket<Send = WebsocketData, Receive = WebsocketData> {
   ) {
     // Snapshot who's registered before invoking anyone, so this dispatch's
     // once-cleanup only ever removes listeners that were actually notified.
-    const eventListeners: WebsocketEventListeners<Send, Receive>[K] =
-      this._options.listeners[type];
+    // Track by entry identity (not the listener function) so two
+    // registrations of the same function - e.g. once + non-once - aren't
+    // conflated.
+    const eventListeners: WebsocketEventListenerWithOptions<K, Send, Receive>[] =
+      [
+        ...(this._options.listeners[type] as WebsocketEventListenerWithOptions<
+          K,
+          Send,
+          Receive
+        >[]),
+      ];
     const onceListeners = new Set(
-      eventListeners
-        .filter(({ options }) => options?.once)
-        .map(({ listener }) => listener)
+      eventListeners.filter(({ options }) => options?.once)
     );
 
-    eventListeners.forEach(({ listener }) => {
-      listener(this, event); // invoke listener with event; it may call
+    eventListeners.forEach((entry) => {
+      // Skip entries a prior listener already removed during this dispatch,
+      // matching standard EventTarget semantics.
+      if (!this._options.listeners[type].includes(entry)) {
+        return;
+      }
+      entry.listener(this, event); // invoke listener with event; it may call
       // removeEventListener on itself or another listener, mutating
       // this._options.listeners[type] directly
     });
@@ -524,7 +536,7 @@ export class Websocket<Send = WebsocketData, Receive = WebsocketData> {
         Send,
         Receive
       >[]) = this._options.listeners[type].filter(
-        ({ listener }) => !onceListeners.has(listener)
+        (entry) => !onceListeners.has(entry)
       );
     }
   }

--- a/packages/collaboration/src/websocket/core/websocket.ts
+++ b/packages/collaboration/src/websocket/core/websocket.ts
@@ -498,23 +498,35 @@ export class Websocket<Send = WebsocketData, Receive = WebsocketData> {
     type: K,
     event: WebsocketEventMap<Receive>[K]
   ) {
+    // Snapshot who's registered before invoking anyone, so this dispatch's
+    // once-cleanup only ever removes listeners that were actually notified.
     const eventListeners: WebsocketEventListeners<Send, Receive>[K] =
       this._options.listeners[type];
-    const newEventListeners: WebsocketEventListeners<Send, Receive>[K] = [];
+    const onceListeners = new Set(
+      eventListeners
+        .filter(({ options }) => options?.once)
+        .map(({ listener }) => listener)
+    );
 
-    eventListeners.forEach(({ listener, options }) => {
-      listener(this, event); // invoke listener with event
-
-      if (
-        options === undefined ||
-        options.once === undefined ||
-        !options.once
-      ) {
-        newEventListeners.push({ listener, options }); // only keep listener if it isn't a once-listener
-      }
+    eventListeners.forEach(({ listener }) => {
+      listener(this, event); // invoke listener with event; it may call
+      // removeEventListener on itself or another listener, mutating
+      // this._options.listeners[type] directly
     });
 
-    this._options.listeners[type] = newEventListeners; // replace old listeners with new listeners that don't include once-listeners
+    if (onceListeners.size > 0) {
+      // Apply once-removal on top of the *current* listener list rather than
+      // rebuilding it from the pre-dispatch snapshot — otherwise any
+      // removeEventListener call made by a listener during this dispatch
+      // (e.g. a self-removing non-once listener) would be silently undone.
+      (this._options.listeners[type] as WebsocketEventListenerWithOptions<
+        K,
+        Send,
+        Receive
+      >[]) = this._options.listeners[type].filter(
+        ({ listener }) => !onceListeners.has(listener)
+      );
+    }
   }
 
   /**

--- a/packages/collaboration/src/websocket/tests/websocket.test.ts
+++ b/packages/collaboration/src/websocket/tests/websocket.test.ts
@@ -410,11 +410,12 @@ describe('Testsuite for Websocket', () => {
         expect(
           getListenersWithOptions(client, WebsocketEvent.Open)
         ).toHaveLength(1); // since the initial listener was a 'once'-listener, this should be empty
+        const reopened = untilEvent(client!, WebsocketEvent.Open);
         server?.clients.forEach((c: WsWebSocket) => c.close());
 
-        // wait for the client to reconnect after 100ms
+        // wait for the client to reconnect, then for its 'open' handler to fire
         await waitForClientToConnectToServer(server, clientTimeout);
-        await new Promise((resolve) => setTimeout(resolve, 100)); // wait some extra time for client-side event to be fired
+        await reopened;
         expect(timesOpenFired).toBe(2);
         expect(
           getListenersWithOptions(client, WebsocketEvent.Open)


### PR DESCRIPTION
## Summary

The `"Websocket shouldn't fire 'open' when it was removed from the event listeners"` test in `websocket.test.ts` waited a fixed 100ms sleep after the server-side reconnect resolved, hoping the client-side `'open'` handler had fired by then, instead of awaiting the event itself. This was diagnosed in [CI run 29514363580](https://github.com/macro-inc/macro/actions/runs/29514363580/job/87675606346?pr=4923) — the durable fix suggested there was to `await untilEvent(client, WebsocketEvent.Open)` instead of sleeping.

While applying that fix, it surfaced a real bug in `Websocket.dispatchEvent`: when a listener calls `removeEventListener` on itself during dispatch (as `untilEvent`'s handler does), that removal was silently undone. `dispatchEvent` rebuilt `this._options.listeners[type]` from a pre-dispatch snapshot *after* the notification loop finished, discarding any removal a listener made on itself (or another listener) while running. This is reproducible 100% of the time whenever a non-`once` listener self-removes during dispatch alongside another still-active listener on the same event — which is exactly what `untilEvent` does.

## Changes

- `packages/collaboration/src/websocket/tests/websocket.test.ts`: replaced the fixed 100ms sleep with `await untilEvent(client, WebsocketEvent.Open)`, matching the existing usage pattern already in this file for `WebsocketEvent.UrlResolved`.
- `packages/collaboration/src/websocket/core/websocket.ts`: fixed `dispatchEvent` to apply "once"-listener cleanup on top of the *current* listener list rather than unconditionally overwriting it with a pre-dispatch snapshot, so removals made mid-dispatch stick.

## Why this was prioritized

Flagged as a known-flaky test in Engineers chat, with the fix already diagnosed but not yet landed. Low-risk, well-scoped, and no one had picked it up.

## Test plan

- [x] Isolated run of the target test reproduced the exact `Expected length: 1, Received length: 2` failure caused by the `dispatchEvent` bug before the core fix, and passes cleanly (no assertion failures) after.
- [x] Full-suite run of `websocket.test.ts` shows the same 20-pass/28-fail split before and after this change — the remaining failures are an unrelated, pre-existing "failed to stop server" teardown timeout in this sandbox (reproduced identically on a clean checkout), not a regression from this change.
- [x] `tsc --noEmit` clean for both changed files.
- [x] Biome clean.

Note: I couldn't run the full workspace build/dev server in my sandbox (private git-hosted deps aren't fetchable here), so please give CI a look before merging.


---
_Generated by [Claude Code](https://claude.ai/code/session_01E6mqSMnBEizV1tRwAScWDv)_