### PR TITLE
fix(soup): support duplicating automations

### DIFF
--- a/apps/web/src/features/entity/queries/dss.ts
+++ b/apps/web/src/features/entity/queries/dss.ts
@@ -21,6 +21,7 @@ import {
 import { soupKeys } from '@queries/soup/keys';
 import { callServiceClient } from '@service-call/client';
 import { scheduledActionClient } from '@service-scheduled-action/client';
+import type { ScheduledAction } from '@service-scheduled-action/generated/schemas';
 import type { ItemType } from '@service-storage/client';
 import { useMutation } from '@tanstack/solid-query';
 import { type EntityData, getEntityProjectId } from '../types/entity';
@@ -271,10 +272,11 @@ function getSoupEntityProjectId(entityId: string): string | undefined {
 }
 
 export function createBulkCopyDssEntityMutation() {
-  // Only support chat + document, same as single-copy version
+  // Supports chat, document, and automation (schedules copied via the
+  // scheduled-action client, mirroring how bulk-delete special-cases them)
   const isUnsupportedEntity = (entity: EntityData) => {
     const type = entity.type;
-    return type !== 'chat' && type !== 'document';
+    return type !== 'chat' && type !== 'document' && type !== 'automation';
   };
 
   return useMutation(() => ({
@@ -289,17 +291,52 @@ export function createBulkCopyDssEntityMutation() {
         throw new Error(`Unsupported entity type provided`);
       }
 
-      const results = await Promise.all(
-        entities.map((e) =>
-          copyItem({
-            itemType: e.type as 'document' | 'chat',
-            id: e.id,
-            name: typeof name === 'function' ? name(e.name) : name,
-          })
-        )
+      const copyableItems = entities.filter(
+        (e): e is EntityData & { name: string; type: 'document' | 'chat' } =>
+          e.type === 'document' || e.type === 'chat'
       );
+      const automations = entities.filter((e) => e.type === 'automation');
 
-      if (results.some((r) => !r)) {
+      // Automations aren't backed by the generic DSS copy endpoint, so
+      // duplicate them by re-creating a schedule from the cached
+      // ScheduledAction (same source the list view renders from).
+      const scheduleList = automations.length
+        ? queryClient.getQueryData<ScheduledAction[]>(
+            scheduledActionKeys.list.queryKey
+          )
+        : undefined;
+
+      const [itemResults] = await Promise.all([
+        Promise.all(
+          copyableItems.map((e) =>
+            copyItem({
+              itemType: e.type,
+              id: e.id,
+              name: typeof name === 'function' ? name(e.name) : name,
+            })
+          )
+        ),
+        Promise.all(
+          automations.map((e) => {
+            const schedule = scheduleList?.find((s) => s.id === e.id);
+            if (!schedule) {
+              throw new Error(`Automation ${e.id} not found for copy`);
+            }
+            return throwOnErr(() =>
+              scheduledActionClient.createSchedule({
+                enabled: schedule.enabled,
+                kind: schedule.kind,
+                name: typeof name === 'function' ? name(e.name) : name,
+                schedule: schedule.schedule,
+                task: schedule.task,
+                timezone: schedule.timezone,
+              })
+            );
+          })
+        ),
+      ]);
+
+      if (itemResults.some((r) => !r)) {
         throw new Error(`One or more DSS items failed to copy`);
       }
 
@@ -330,6 +367,11 @@ export function createBulkCopyDssEntityMutation() {
         queryKey: soupKeys.astItems._def,
       });
       queryClient.invalidateQueries({ queryKey: ['entity'] });
+      if (entities.some((e) => e.type === 'automation')) {
+        queryClient.invalidateQueries({
+          queryKey: scheduledActionKeys.list.queryKey,
+        });
+      }
     },
   }));
 }


### PR DESCRIPTION
## Summary

Duplicating an automation from soup threw `Error: Unsupported entity type provided.` — reported in bug-reports, with a request to disable the Duplicate button on automations until it's fixed.

Root cause: `createBulkCopyDssEntityMutation` (`apps/web/src/features/entity/queries/dss.ts`) only supported `chat`/`document` entities via the generic document-storage `copyItem` path. Automations aren't backed by that endpoint, and nothing excludes `automation` from the Duplicate action's `canExecute`, so the button was enabled but always failed.

## Changes

Added an `automation` branch to `createBulkCopyDssEntityMutation`, mirroring how `createBulkDeleteDssItemsMutation` already special-cases automations via `scheduledActionClient` instead of the generic document-storage path:

- Look up the full cached `ScheduledAction` (schedule/kind/task/timezone — not present on the lighter `AutomationEntity` soup row) from `scheduledActionKeys.list.queryKey`.
- Re-create it via `scheduledActionClient.createSchedule(...)`.
- Invalidate the schedules list query on settle when an automation was copied.

No backend changes needed — the scheduled-action service's existing `POST /scheduled-actions` endpoint covers this.

## Why this was prioritized

Reported bug with no existing task/PR in progress; the fix turned out to be a small, mechanical, frontend-only change with an existing precedent (the delete mutation) to mirror.

## Test plan

- [x] Biome clean.
- [x] Manually traced the type flow: `ScheduledAction`'s `schedule`/`kind`/`task`/`timezone` fields line up with `CreateScheduledAction`'s required fields.
- [ ] Couldn't run the frontend dev server in my sandbox (private git-hosted deps for `tauri-plugins`/`pdf.js` aren't fetchable here) — please give this a real spin in dev before merging: select an automation in soup → Duplicate → confirm a new schedule appears with `enabled`/`kind`/`task`/`timezone` matching the original.


---
_Generated by [Claude Code](https://claude.ai/code/session_01E6mqSMnBEizV1tRwAScWDv)_