### PR TITLE
perf(preview): pull receipt so warm boots skip mirrored images

### DIFF
--- a/.github/workflows/preview-fly.yml
+++ b/.github/workflows/preview-fly.yml
@@ -293,8 +293,12 @@ jobs:
             # A suspended preview needs demand before SSH is reachable.
             curl -s -o /dev/null --max-time 10 "https://$APP_NAME.fly.dev/" || true
             for _ in $(seq 1 12); do
+              # `--command` is exec'd directly, NOT run through a shell —
+              # a bare `if [ -f ...` dies with `exec: "if": not found`, so
+              # the marker never parsed and every push silently rehydrated
+              # (~7 min) instead of going hot (~3 min). Hence the sh -c.
               marker=$(flyctl ssh console --app "$APP_NAME" --machine "$machine_id" \
-                --quiet --command 'if [ -f /var/lib/docker/.macro-preview/deployment.json ]; then cat /var/lib/docker/.macro-preview/deployment.json; else echo __NO_MARKER__; fi' \
+                --quiet --command 'sh -c "if [ -f /var/lib/docker/.macro-preview/deployment.json ]; then cat /var/lib/docker/.macro-preview/deployment.json; else echo __NO_MARKER__; fi"' \
                 2>/dev/null || true)
               if echo "$marker" | jq -e \
                   --arg key "$snapshot_key" \

--- a/infra/preview/entrypoint.sh
+++ b/infra/preview/entrypoint.sh
@@ -47,11 +47,25 @@ if [ -f /srv/macro/preload/manifest.txt ]; then
   fi
   log "pulling stack images (parallel, warm store aware)"
   t0=$(date +%s)
+  # The manifest's IDs are the RUNNER's view of each image (for hub images
+  # under the containerd store, the source registry's index digest). Pulling
+  # the mirror yields a different manifest and therefore a different local
+  # .Id, so the inspect check below never matches mirrored images and every
+  # boot re-pulled all 16 (66s of pure round-trips on a fully warm volume).
+  # The receipt is our own volume-persisted record of which (runner id, tag)
+  # pairs this store already satisfied — written only after a fully
+  # successful pass, carried along by template-volume forks, and at worst
+  # stale in the direction of one redundant pull.
+  receipt="$state_dir/pulled.txt"
   pids=""
   while read -r id tag ref; do
     have=$(docker image inspect -f '{{.Id}}' "$tag" 2>/dev/null || true)
     if [ "$have" = "$id" ]; then
       log "already present: $tag"
+      continue
+    fi
+    if [ -n "$have" ] && grep -qxF "$id $tag" "$receipt" 2>/dev/null; then
+      log "already present (receipt): $tag"
       continue
     fi
     (docker pull -q "$ref" && docker tag "$ref" "$tag" && docker rmi "$ref" >/dev/null) &
@@ -60,6 +74,8 @@ if [ -f /srv/macro/preload/manifest.txt ]; then
   rc=0
   for pid in $pids; do wait "$pid" || rc=1; done
   [ "$rc" = 0 ] || { log "image pull failed"; exit 1; }
+  awk '{print $1, $2}' /srv/macro/preload/manifest.txt > "$receipt.next" \
+    && mv "$receipt.next" "$receipt"
   log "images pulled in $(($(date +%s) - t0))s"
 fi
 

--- a/infra/preview/hot-update.sh
+++ b/infra/preview/hot-update.sh
@@ -108,6 +108,11 @@ install -m 0755 "$staging/xtask" /srv/macro/bin/xtask.next
 mv -f /srv/macro/bin/xtask.next /srv/macro/bin/xtask
 install -m 0644 "$staging/deployment.json" "$STATE_FILE.next"
 mv -f "$STATE_FILE.next" "$STATE_FILE"
+# The aux refreshes above satisfied the carrier manifest, so record it in the
+# boot pull receipt — otherwise the next real boot re-pulls what this update
+# already delivered (see the receipt logic in entrypoint.sh).
+awk '{print $1, $2}' "$staging/manifest.txt" > "$STATE_DIR/pulled.txt.next" \
+  && mv "$STATE_DIR/pulled.txt.next" "$STATE_DIR/pulled.txt"
 
 # Retain the current carrier's layers for the next incremental pull, but remove
 # older carrier tags and their now-unreferenced layers from the persistent store.

--- a/infra/preview/hot-update.sh
+++ b/infra/preview/hot-update.sh
@@ -66,6 +66,15 @@ unsafe_images=
 while read -r expected_id tag registry_ref; do
   current_id=$(docker image inspect -f '{{.Id}}' "$tag" 2>/dev/null || true)
   [ "$current_id" = "$expected_id" ] && continue
+  # Mirrored images never match by .Id (the manifest carries the runner's
+  # source-registry digest; this store holds the mirror's) — same mismatch
+  # the entrypoint's pull loop handles. Honor the boot pull receipt before
+  # classifying an image as changed, or every hot update sees all 12 infra
+  # images as "non-hot-updatable drift" and needlessly rehydrates.
+  if [ -n "$current_id" ] \
+      && grep -qxF "$expected_id $tag" "$STATE_DIR/pulled.txt" 2>/dev/null; then
+    continue
+  fi
   case "$tag" in
     *-ai_editing_worker|*-lexical_service|*-sync_service|*-websocket_service)
       log "refreshing auxiliary image $tag"

--- a/tooling/xtask/crates/xtask_workflows/src/workflows/preview_fly.rs
+++ b/tooling/xtask/crates/xtask_workflows/src/workflows/preview_fly.rs
@@ -467,8 +467,12 @@ fn deploy_to_fly() -> Step<Run> {
                 # A suspended preview needs demand before SSH is reachable.
                 curl -s -o /dev/null --max-time 10 "https://$APP_NAME.fly.dev/" || true
                 for _ in $(seq 1 12); do
+                  # `--command` is exec'd directly, NOT run through a shell —
+                  # a bare `if [ -f ...` dies with `exec: "if": not found`, so
+                  # the marker never parsed and every push silently rehydrated
+                  # (~7 min) instead of going hot (~3 min). Hence the sh -c.
                   marker=$(flyctl ssh console --app "$APP_NAME" --machine "$machine_id" \
-                    --quiet --command 'if [ -f /var/lib/docker/.macro-preview/deployment.json ]; then cat /var/lib/docker/.macro-preview/deployment.json; else echo __NO_MARKER__; fi' \
+                    --quiet --command 'sh -c "if [ -f /var/lib/docker/.macro-preview/deployment.json ]; then cat /var/lib/docker/.macro-preview/deployment.json; else echo __NO_MARKER__; fi"' \
                     2>/dev/null || true)
                   if echo "$marker" | jq -e \
                       --arg key "$snapshot_key" \


### PR DESCRIPTION
## Two fixes measured from live boots

### 1. Pull receipt — warm boots re-pulled all 16 images

Even with a fully warm volume (template fork, #4954), every boot re-pulled all 16 stack images — 66s of pure manifest round-trips. Under the containerd image store, `.Id` is the digest of the manifest an image was pulled *by*: Docker Hub's index digest on the runner vs the fly.io mirror's manifest digest on the machine — they can never match, so the skip check was dead code for mirrored images.

Fix: after a successful pull pass (and after hot-update's aux refreshes) write the manifest's `(runner id, tag)` pairs to a volume-persisted receipt; skip images whose receipt line matches and whose tag exists. Receipts ride along in template forks. Stale receipt = one redundant pull, never a wrong image.

**Validated**: machine restart on this PR's preview — `images pulled in 0s` (10 skipped via receipt, 6 runner-built via .Id), full reboot **169s**.

### 2. Marker probe never parsed — every push silently rehydrated

`flyctl ssh console --command` execs its string directly, without a shell. The deployment-marker probe used `if [ -f ... ]`, which died with `exec: "if": executable file not found` on all 12 retries (~72s), so mode could never be `hot` — every push paid a full machine reboot (~7 min) instead of the in-place hot update (~3 min). The runtime/snapshot keys were verified byte-stable across builds; the fetch was the failure, not key drift. Fix: wrap the probe in `sh -c`.

**Validation**: the second commit's own preview deploy should be the first `mode: hot` run.