### PR TITLE
fix(analytics): fire Meta CompleteRegistration server-side via Conversions API

### DIFF
--- a/apps/web/src/lib/analytics/analytics.ts
+++ b/apps/web/src/lib/analytics/analytics.ts
@@ -162,7 +162,8 @@ const createAnalytics = () => {
   const sendEvent = (
     provider: AnalyticsProvider,
     event: EventName,
-    data?: Record<string, unknown>
+    data?: Record<string, unknown>,
+    options?: { eventID?: string }
   ) => {
     if (disabled) return;
 
@@ -181,7 +182,12 @@ const createAnalytics = () => {
           const fbqMethod = META_STANDARD_EVENTS.has(event)
             ? 'track'
             : 'trackCustom';
-          fbq(fbqMethod, event, enriched);
+          fbq(
+            fbqMethod,
+            event,
+            enriched,
+            options?.eventID ? { eventID: options.eventID } : undefined
+          );
         })
         .with('posthog', () => {
           posthog.capture(event, enriched);
@@ -219,12 +225,18 @@ const createAnalytics = () => {
    *
    * For the rare event with no standard equivalent, fall back to
    * `track(event, data, ['meta-pixel'])` — that path uses `trackCustom`.
+   *
+   * Pass `options.eventID` when the backend fires the same event through the
+   * Conversions API — Meta dedupes browser and server fires that share an
+   * event name + event id, so the pair counts once while keeping the
+   * browser's click-id cookies for attribution.
    */
   const trackMeta = (
     event: MetaStandardEvent,
-    data?: Record<string, unknown>
+    data?: Record<string, unknown>,
+    options?: { eventID?: string }
   ) => {
-    sendEvent('meta-pixel', event, data);
+    sendEvent('meta-pixel', event, data, options);
   };
 
   /**
@@ -339,7 +351,11 @@ const createAnalytics = () => {
 export type AnalyticsInterface = {
   posthog: PostHog;
   track: TrackFn;
-  trackMeta: (event: MetaStandardEvent, data?: Record<string, unknown>) => void;
+  trackMeta: (
+    event: MetaStandardEvent,
+    data?: Record<string, unknown>,
+    options?: { eventID?: string }
+  ) => void;
   trackGoogleConversion: (
     action: GoogleConversionAction,
     data?: { value?: number; currency?: string; transaction_id?: string }

--- a/apps/web/src/lib/analytics/signupCompletion.ts
+++ b/apps/web/src/lib/analytics/signupCompletion.ts
@@ -124,15 +124,18 @@ export function trackSignupCompletion(
 
   analytics.trackMeta(
     'CompleteRegistration',
+    // Must mirror the server-side payload in create_user_webhook.rs exactly:
+    // the create-user webhook fires this same event through the Conversions
+    // API with the same event id, and Meta keeps whichever of the deduped
+    // pair lands first (almost always the server). Accounts are always free
+    // at creation, so both sides report the flat signup value; the tier-based
+    // value below stays on the Google conversion, which is browser-only.
     {
       content_name: 'account_created',
-      content_category: tier,
-      value,
+      content_category: 'free',
+      value: SIGNUP_LEAD_VALUE_DEFAULT,
       currency: 'USD',
     },
-    // The create-user webhook fires this same event server-side with this
-    // exact event id; Meta keeps one of the pair and merges the browser's
-    // click-id cookies into the match.
     { eventID: `signup:${user.id}` }
   );
   analytics.trackGoogleConversion('signup', {

--- a/apps/web/src/lib/analytics/signupCompletion.ts
+++ b/apps/web/src/lib/analytics/signupCompletion.ts
@@ -7,14 +7,21 @@
  * sends people). The ad-platform conversions were even further off: they fired
  * when the (now optional) interactive tutorial modal closed.
  *
- * The authoritative product-analytics `sign_up` (PostHog) is emitted
- * server-side from the create-user webhook, so every creation path counts
- * exactly once even if the user never returns to the app. What remains here
- * is the browser-only half: the ad-platform conversions (Meta pixel, Google
- * Ads) plus the GA sign_up event, which need the click-id cookies and consent
- * context that only exist in the browser. The auth service appends
- * `signed_up=true` to the post-auth redirect; this module consumes that param
- * once and fires them, regardless of which page or device started the flow.
+ * The authoritative signup events are emitted server-side from the
+ * create-user webhook, so every creation path counts exactly once even if
+ * the user never returns to the app: `sign_up` (PostHog) and
+ * `CompleteRegistration` (Meta Conversions API). Only a minority of new
+ * accounts ever load the web app with the `signed_up=true` marker, so a
+ * browser-only Meta fire undercounts badly — and Meta's delivery algorithm
+ * starves when spend scales past the trickle it can see.
+ *
+ * What remains here is the browser half: the GA sign_up event and Google Ads
+ * conversion (browser-only), plus a duplicate Meta CompleteRegistration that
+ * exists to contribute the click-id cookies (_fbc/_fbp) only the browser
+ * holds — Meta dedupes it against the server fire via the shared
+ * `signup:{user_id}` event id. The auth service appends `signed_up=true` to
+ * the post-auth redirect; this module consumes that param once and fires
+ * them, regardless of which page or device started the flow.
  */
 import type { AnalyticsInterface } from './analytics';
 import {
@@ -115,12 +122,19 @@ export function trackSignupCompletion(
     'free';
   const value = SIGNUP_LEAD_VALUE_BY_TIER[tier] ?? SIGNUP_LEAD_VALUE_DEFAULT;
 
-  analytics.trackMeta('CompleteRegistration', {
-    content_name: 'account_created',
-    content_category: tier,
-    value,
-    currency: 'USD',
-  });
+  analytics.trackMeta(
+    'CompleteRegistration',
+    {
+      content_name: 'account_created',
+      content_category: tier,
+      value,
+      currency: 'USD',
+    },
+    // The create-user webhook fires this same event server-side with this
+    // exact event id; Meta keeps one of the pair and merges the browser's
+    // click-id cookies into the match.
+    { eventID: `signup:${user.id}` }
+  );
   analytics.trackGoogleConversion('signup', {
     value,
     currency: 'USD',

--- a/services/authentication_service/src/api/webhooks/user/create_user_webhook.rs
+++ b/services/authentication_service/src/api/webhooks/user/create_user_webhook.rs
@@ -190,11 +190,14 @@ async fn create_user_webhook(ctx: &ApiContext, req: FusionAuthUserWebhook) -> an
                     MetaActionSource::Website,
                     Some(&format!("signup:{user_id}")),
                     serde_json::json!({
+                        // Must mirror the browser payload in the web app's
+                        // signupCompletion.ts: Meta keeps whichever of the
+                        // deduped pair lands first, so diverging payloads
+                        // would report a value that depends on race timing.
+                        // Accounts are always free at creation (value =
+                        // SIGNUP_LEAD_VALUE_DEFAULT in leadValues.ts); paid
+                        // value is tracked separately via the Stripe events.
                         "content_name": "account_created",
-                        // Accounts are always free at creation; paid value is
-                        // tracked separately via the Stripe webhook events.
-                        // Keep value in sync with SIGNUP_LEAD_VALUE_BY_TIER in
-                        // the web app's leadValues.ts.
                         "content_category": "free",
                         "value": 20,
                         "currency": "USD",

--- a/services/authentication_service/src/api/webhooks/user/create_user_webhook.rs
+++ b/services/authentication_service/src/api/webhooks/user/create_user_webhook.rs
@@ -1,3 +1,4 @@
+use analytics_client::{MetaActionSource, MetaUserData};
 use anyhow::Context;
 use axum::{
     extract::{self, State},
@@ -147,14 +148,21 @@ async fn create_user_webhook(ctx: &ApiContext, req: FusionAuthUserWebhook) -> an
         .await
         .inspect_err(|e| tracing::error!(error=?e, "unable to mark user as just signed up"));
 
-    // Authoritative product-analytics signup event: fired here so every
-    // creation path (SSO, passwordless, iOS) counts exactly once, even if the
-    // user never returns to the app. The browser fires the ad-platform
-    // conversions instead — it holds the click-id cookies. Uses the same
-    // distinct id ("macro|{email}") the app identifies with. Fire-and-forget.
+    // Authoritative signup analytics: fired here so every creation path
+    // (SSO, passwordless, iOS) counts exactly once, even if the user never
+    // returns to the app. Meta's CompleteRegistration fires here too
+    // (Conversions API) — only a minority of new accounts ever load the web
+    // app with the `signed_up=true` marker, so the browser pixel alone
+    // misses most signups. The browser still fires the same event with the
+    // shared `signup:{user_id}` event id purely to contribute click-id
+    // cookies for attribution; Meta dedupes the pair on that id (see the
+    // web app's signupCompletion.ts). Uses the same distinct id
+    // ("macro|{email}") the app identifies with. Fire-and-forget.
     tokio::spawn({
         let analytics_client = ctx.analytics_client.clone();
         let user_id = user_id.clone();
+        let email = email.clone();
+        let ip_address = ip_address.clone();
         let verified = req.event.user.verified;
         let has_organization = organization_id.is_some();
         async move {
@@ -169,6 +177,33 @@ async fn create_user_webhook(ctx: &ApiContext, req: FusionAuthUserWebhook) -> an
                 )
                 .await
                 .inspect_err(|e| tracing::warn!(error=?e, "failed to track PostHog sign_up event"));
+
+            let user_data = MetaUserData {
+                email: Some(email),
+                client_ip_address: Some(ip_address),
+                ..Default::default()
+            };
+            let _ = analytics_client
+                .track_meta(
+                    "CompleteRegistration",
+                    &user_data,
+                    MetaActionSource::Website,
+                    Some(&format!("signup:{user_id}")),
+                    serde_json::json!({
+                        "content_name": "account_created",
+                        // Accounts are always free at creation; paid value is
+                        // tracked separately via the Stripe webhook events.
+                        // Keep value in sync with SIGNUP_LEAD_VALUE_BY_TIER in
+                        // the web app's leadValues.ts.
+                        "content_category": "free",
+                        "value": 20,
+                        "currency": "USD",
+                    }),
+                )
+                .await
+                .inspect_err(|e| {
+                    tracing::warn!(error=?e, "failed to track Meta CompleteRegistration");
+                });
         }
     });
 


### PR DESCRIPTION
## Problem

Meta ad campaigns optimize on the `CompleteRegistration` pixel event, but it only fires when a fresh account later loads the web app with the `signed_up=true` redirect marker. Only ~10 of ~60 daily signups ever do (the just-signed-up Redis marker can lose the race with the auth callback, and many signups never return to the browser). Once ad spend scaled (~3x on July 14), reported cost-per-registration exploded while actual signups hit an all-time high — Meta simply cannot see most conversions, and its delivery optimization starves.

## Fix

- **Server-side conversion (authoritative):** the FusionAuth create-user webhook now fires `CompleteRegistration` via the Meta Conversions API for every account creation, matching on hashed email + registration IP. Reuses the existing `analytics_client` Meta provider (already configured in this service for cal.com Lead events). Fire-and-forget: a Meta API failure never blocks signup.
- **Browser/server dedup:** the browser keeps firing the same event when the redirect marker does arrive, now with a shared `signup:{user_id}` event id — Meta counts the pair once and merges in the click-id cookies (`_fbc`/`_fbp`) only the browser holds.
- `trackMeta` gains an optional `options.eventID` param (no behavior change for other call sites).

## Expected effect

Events Manager should report ~55-60+ registrations/day (matching the server-side PostHog `sign_up` count) instead of ~10. Attributed registrations in Ads Manager will jump on deploy — that is the undercount closing, not a performance change.

## Notes

- GA / Google Ads signup conversions are still browser-only and share the same undercount; same pattern can be applied in a follow-up.
- Verified: `bun type-check` + biome clean. Rust side hand-checked against the `analytics_client` API — please let CI run `cargo check`/clippy (no Rust toolchain on the authoring machine).
- Post-deploy check: Meta Events Manager -> `CompleteRegistration` volume vs PostHog `sign_up`; `META_TEST_EVENT_CODE` is supported for test-event verification.