### PR TITLE
feat(mobile): open history stack drawer on back button long-press

### DIFF
--- a/apps/web/src/components/app/split-layout/SplitLayout.tsx
+++ b/apps/web/src/components/app/split-layout/SplitLayout.tsx
@@ -39,6 +39,7 @@ import {
   createMobileSwipeLayout,
   type MobileSwipeLayout,
 } from './mobile/createMobileSwipeLayout';
+import { MobileHistoryDrawerManager } from './mobile/MobileHistoryDrawer';
 import { MobileSplitContainer } from './mobile/MobileSplitContainer';
 
 type SplitLayoutContainerProps = {
@@ -350,53 +351,55 @@ export function SplitLayoutContainer(props: SplitLayoutContainerProps) {
 
   return (
     <SplitLayoutContext.Provider value={{ manager: splitManager }}>
-      <div
-        class={cn('size-full p-2 mobile:p-0', {
-          'pl-0': isSidebarVisible() && !sidebar.isCollapsed(),
-        })}
-      >
-        <Show
-          when={isNativeMobilePlatform() && mobileSwipeLayout}
-          fallback={
-            // Desktop: side-by-side resizable splits.
-            <Resize.Zone
-              direction="horizontal"
-              gutter={8}
-              captureResizeCtx={splitManager.setResizeContext}
-            >
-              <For each={ids()}>
-                {(id, index) => (
-                  <Show when={splitManager.getSplit(id)}>
-                    {(handle) => (
-                      <Suspense>
-                        <Resize.Panel id={id} minSize={400} index={index()}>
-                          <SplitPanel
-                            split={splits()[index()]!}
-                            handle={handle()}
-                            active={activeSplitSelector(id)}
-                            setPanelRef={(panelRef) =>
-                              panelRefs.set(id, panelRef)
-                            }
-                            index={index()}
-                          />
-                        </Resize.Panel>
-                      </Suspense>
-                    )}
-                  </Show>
-                )}
-              </For>
-            </Resize.Zone>
-          }
+      <MobileHistoryDrawerManager>
+        <div
+          class={cn('size-full p-2 mobile:p-0', {
+            'pl-0': isSidebarVisible() && !sidebar.isCollapsed(),
+          })}
         >
-          {/* Mobile: stacked FG/BG layout with swipe-back gesture. */}
-          <MobileSplitContainer
-            splitManager={splitManager}
-            mobileSwipeLayout={mobileSwipeLayout!}
-            splits={splits}
-            panelRefs={panelRefs}
-          />
-        </Show>
-      </div>
+          <Show
+            when={isNativeMobilePlatform() && mobileSwipeLayout}
+            fallback={
+              // Desktop: side-by-side resizable splits.
+              <Resize.Zone
+                direction="horizontal"
+                gutter={8}
+                captureResizeCtx={splitManager.setResizeContext}
+              >
+                <For each={ids()}>
+                  {(id, index) => (
+                    <Show when={splitManager.getSplit(id)}>
+                      {(handle) => (
+                        <Suspense>
+                          <Resize.Panel id={id} minSize={400} index={index()}>
+                            <SplitPanel
+                              split={splits()[index()]!}
+                              handle={handle()}
+                              active={activeSplitSelector(id)}
+                              setPanelRef={(panelRef) =>
+                                panelRefs.set(id, panelRef)
+                              }
+                              index={index()}
+                            />
+                          </Resize.Panel>
+                        </Suspense>
+                      )}
+                    </Show>
+                  )}
+                </For>
+              </Resize.Zone>
+            }
+          >
+            {/* Mobile: stacked FG/BG layout with swipe-back gesture. */}
+            <MobileSplitContainer
+              splitManager={splitManager}
+              mobileSwipeLayout={mobileSwipeLayout!}
+              splits={splits}
+              panelRefs={panelRefs}
+            />
+          </Show>
+        </div>
+      </MobileHistoryDrawerManager>
       <PopoverSplitRenderer
         popovers={splitManager.popovers}
         onClosePopover={(id) => {

--- a/apps/web/src/components/app/split-layout/components/PopoverSplitRenderer.tsx
+++ b/apps/web/src/components/app/split-layout/components/PopoverSplitRenderer.tsx
@@ -67,6 +67,7 @@ function PopoverSplitModal(props: {
     canGoBack: () => false,
     canGoForward: () => false,
     goBack: () => {},
+    goBackToHistoryEntry: () => {},
     goForward: () => {},
     reset: () => {},
     activate: () => {},

--- a/apps/web/src/components/app/split-layout/components/SplitHeader.tsx
+++ b/apps/web/src/components/app/split-layout/components/SplitHeader.tsx
@@ -10,6 +10,7 @@ import {
 } from '@core/component/ContextMenu';
 import { toast } from '@core/component/Toast/Toast';
 import { fileTypeToBlockName } from '@core/constant/allBlocks';
+import { touchHandler } from '@core/directive/touchHandler';
 import { TOKENS } from '@core/hotkey/tokens';
 import { isMobile } from '@core/mobile/isMobile';
 import { isNativeMobilePlatform } from '@core/mobile/isNativeMobilePlatform';
@@ -41,6 +42,7 @@ import { Portal } from 'solid-js/web';
 import { splitBackInterceptor } from '../back-interceptor';
 import { SplitLayoutContext, SplitPanelContext } from '../context';
 import type { SplitContent } from '../layoutManager';
+import { useMobileHistoryDrawer } from '../mobile/MobileHistoryDrawer';
 import { canSpotlight } from '../utils/canSpotlight';
 import { HeaderIsland } from './HeaderIsland';
 
@@ -74,6 +76,7 @@ function getEntitySplitContent(data: EntityDragEvent['draggable']['data']):
 
 function SplitBackButton() {
   const context = useContext(SplitPanelContext);
+  const historyDrawer = useMobileHistoryDrawer();
   if (!context) return null;
   return (
     <Button
@@ -85,6 +88,16 @@ function SplitBackButton() {
         if (splitBackInterceptor()?.()) return;
         context.handle.goBack();
       }}
+      // Long-press opens the history stack drawer. The touch handler swallows
+      // the synthesized click after a long press, so goBack doesn't also run.
+      ref={(el: HTMLButtonElement) =>
+        touchHandler(el, () => ({
+          onLongPress: () => {
+            if (!isMobile()) return;
+            historyDrawer?.open(context.handle);
+          },
+        }))
+      }
     >
       <CaretLeft class="h-4" />
     </Button>

--- a/apps/web/src/components/app/split-layout/layoutManager.ts
+++ b/apps/web/src/components/app/split-layout/layoutManager.ts
@@ -423,6 +423,11 @@ export type SplitHandle<TMeta extends ComponentMeta = ComponentMeta> = {
   isLast: () => boolean;
   activate: () => void;
   goBack: () => void;
+  /**
+   * Jump directly back to a prior history entry, as indexed by `history()`.
+   * No-ops unless `0 <= index < history().length - 1` (i.e. a true back jump).
+   */
+  goBackToHistoryEntry: (index: number) => void;
   close: () => void;
   reset: () => void;
   /** Returns the content item one step back in this split's history, without mutating. */
@@ -780,6 +785,33 @@ export function createSplitLayout(
     });
   }
 
+  /**
+   * Step the split's history back to `targetIndex` in one navigation:
+   * intermediate entries are skipped (no reattach per step), so only the
+   * landing entry mounts.
+   */
+  function backTo(id: SplitId, targetIndex: number) {
+    const i = splitIndexById(id);
+    if (i < 0) return console.error(`Split with id ${id} not found`);
+
+    const split = state.splits[i];
+    if (targetIndex < 0 || targetIndex >= split.history.index) return;
+
+    batch(() => {
+      captureCurrentEntryState(split);
+
+      let prev: SplitContent | null = null;
+      while (split.history.index > targetIndex) {
+        const stepped = split.history.back();
+        if (!stepped) break;
+        prev = stepped;
+      }
+      if (!prev) return;
+
+      reattach(split, prev, undefined, 'history-back');
+    });
+  }
+
   function forward(id: SplitId) {
     const i = splitIndexById(id);
     if (i < 0) return console.error(`Split with id ${id} not found`);
@@ -952,6 +984,7 @@ export function createSplitLayout(
       canGoForward: () =>
         (findSplitById(currentSplit.id) ?? currentSplit).history.canGoForward(),
       goBack: () => back(currentSplit.id),
+      goBackToHistoryEntry: (index: number) => backTo(currentSplit.id, index),
       reset: () => reset(currentSplit.id),
       goForward: () => forward(currentSplit.id),
       replace: ({ next, mergeHistory = false, referredFrom }) =>

--- a/apps/web/src/components/app/split-layout/layoutManager.ts
+++ b/apps/web/src/components/app/split-layout/layoutManager.ts
@@ -797,6 +797,13 @@ export function createSplitLayout(
     const split = state.splits[i];
     if (targetIndex < 0 || targetIndex >= split.history.index) return;
 
+    // reattach refuses targets already open in another split (same check as
+    // below); preflight it so a refused jump doesn't strand the history index
+    // away from the mounted content.
+    const target = split.history.items[targetIndex];
+    const otherSplits = state.splits.filter((s) => s.id !== split.id);
+    if (isDuplicateSplit(otherSplits, target)) return;
+
     batch(() => {
       captureCurrentEntryState(split);
 

--- a/apps/web/src/components/app/split-layout/layoutManager.ts
+++ b/apps/web/src/components/app/split-layout/layoutManager.ts
@@ -768,6 +768,65 @@ export function createSplitLayout(
     });
   }
 
+  /**
+   * Whether `reattach` would refuse to land this split on `content` because
+   * the same content is already open in another split. History navigation
+   * preflights this so a refused landing can't strand the history index away
+   * from the mounted content.
+   */
+  function reattachWouldRefuse(split: SplitState, content: SplitContent) {
+    const otherSplits = state.splits.filter((s) => s.id !== split.id);
+    return isDuplicateSplit(otherSplits, content);
+  }
+
+  /**
+   * Nearest history index in `direction` whose entry can actually mount, or
+   * null when every entry on that side is held by another split.
+   */
+  function nearestLandableIndex(
+    split: SplitState,
+    direction: -1 | 1
+  ): number | null {
+    const items = split.history.items;
+    for (
+      let index = split.history.index + direction;
+      index >= 0 && index < items.length;
+      index += direction
+    ) {
+      if (!reattachWouldRefuse(split, items[index])) return index;
+    }
+    return null;
+  }
+
+  /**
+   * Land the split on history entry `targetIndex` as a single navigation:
+   * intermediate entries are stepped through without mounting, so only the
+   * landing entry reattaches. Callers must preflight the target with
+   * `reattachWouldRefuse`.
+   */
+  function landOnHistoryIndex(
+    split: SplitState,
+    targetIndex: number,
+    cause: NavigationCause
+  ) {
+    batch(() => {
+      captureCurrentEntryState(split);
+
+      let landed: SplitContent | null = null;
+      while (split.history.index !== targetIndex) {
+        const stepped =
+          split.history.index > targetIndex
+            ? split.history.back()
+            : split.history.forward();
+        if (!stepped) break;
+        landed = stepped;
+      }
+      if (!landed) return;
+
+      reattach(split, landed, undefined, cause);
+    });
+  }
+
   function back(id: SplitId) {
     const i = splitIndexById(id);
     if (i < 0) return console.error(`Split with id ${id} not found`);
@@ -775,20 +834,17 @@ export function createSplitLayout(
     const split = state.splits[i];
     if (!split.history.canGoBack()) return;
 
-    batch(() => {
-      captureCurrentEntryState(split);
+    // Entries open in another split can't mount here — step past them to the
+    // nearest previous entry that can. They stay in history and become
+    // reachable again once the other split lets go of the content.
+    const targetIndex = nearestLandableIndex(split, -1);
+    if (targetIndex === null) return;
 
-      const prev = split.history.back();
-      if (!prev) return;
-
-      reattach(split, prev, undefined, 'history-back');
-    });
+    landOnHistoryIndex(split, targetIndex, 'history-back');
   }
 
   /**
-   * Step the split's history back to `targetIndex` in one navigation:
-   * intermediate entries are skipped (no reattach per step), so only the
-   * landing entry mounts.
+   * Jump the split's history back to `targetIndex` in one navigation.
    */
   function backTo(id: SplitId, targetIndex: number) {
     const i = splitIndexById(id);
@@ -797,26 +853,11 @@ export function createSplitLayout(
     const split = state.splits[i];
     if (targetIndex < 0 || targetIndex >= split.history.index) return;
 
-    // reattach refuses targets already open in another split (same check as
-    // below); preflight it so a refused jump doesn't strand the history index
-    // away from the mounted content.
-    const target = split.history.items[targetIndex];
-    const otherSplits = state.splits.filter((s) => s.id !== split.id);
-    if (isDuplicateSplit(otherSplits, target)) return;
+    // Unlike back(), an explicit jump target is never skipped over: when it
+    // can't mount, the jump is refused outright.
+    if (reattachWouldRefuse(split, split.history.items[targetIndex])) return;
 
-    batch(() => {
-      captureCurrentEntryState(split);
-
-      let prev: SplitContent | null = null;
-      while (split.history.index > targetIndex) {
-        const stepped = split.history.back();
-        if (!stepped) break;
-        prev = stepped;
-      }
-      if (!prev) return;
-
-      reattach(split, prev, undefined, 'history-back');
-    });
+    landOnHistoryIndex(split, targetIndex, 'history-back');
   }
 
   function forward(id: SplitId) {
@@ -826,14 +867,11 @@ export function createSplitLayout(
     const split = state.splits[i];
     if (!split.history.canGoForward()) return;
 
-    batch(() => {
-      captureCurrentEntryState(split);
+    // Mirror back(): skip forward past entries held by another split.
+    const targetIndex = nearestLandableIndex(split, 1);
+    if (targetIndex === null) return;
 
-      const next = split.history.forward();
-      if (!next) return;
-
-      reattach(split, next, undefined, 'history-forward');
-    });
+    landOnHistoryIndex(split, targetIndex, 'history-forward');
   }
 
   function removeFromHistory(

--- a/apps/web/src/components/app/split-layout/mobile/MobileHistoryDrawer.tsx
+++ b/apps/web/src/components/app/split-layout/mobile/MobileHistoryDrawer.tsx
@@ -1,0 +1,239 @@
+import { MobileDrawer } from '@components/app/mobile/MobileDrawer';
+import type { BlockAlias, BlockName } from '@core/block';
+import { EntityIcon, getPreviewItemIconType } from '@core/component/EntityIcon';
+import { blockNameToDefaultFile } from '@core/constant/allBlocks';
+import IconGear from '@icon/macro-gear.svg';
+import { AnimatedActivityIcon } from '@icon/wide-activity';
+import { AnimatedCallIcon } from '@icon/wide-call';
+import { AnimatedChannelIcon } from '@icon/wide-channel';
+import { AnimatedCompanyIcon } from '@icon/wide-company';
+import { AnimatedEmailIcon } from '@icon/wide-email';
+import { AnimatedFileMdIcon } from '@icon/wide-fileMd';
+import { AnimatedFolderIcon } from '@icon/wide-folder';
+import { AnimatedInboxIcon } from '@icon/wide-inbox';
+import { AnimatedSearchIcon } from '@icon/wide-search';
+import { AnimatedStarIcon } from '@icon/wide-star';
+import { AnimatedTaskIcon } from '@icon/wide-task';
+import FileIcon from '@phosphor/file.svg';
+import HomeIcon from '@phosphor/house.svg';
+import { isAccessiblePreviewItem, useItemPreview } from '@queries/preview';
+import { blockNameToItemType } from '@service-storage/client';
+import {
+  type Component,
+  createContext,
+  createSignal,
+  For,
+  type ParentProps,
+  Show,
+  Suspense,
+  useContext,
+} from 'solid-js';
+import { Dynamic } from 'solid-js/web';
+import type { SplitContent, SplitHandle } from '../layoutManager';
+
+/**
+ * Labels/icons for `component` split contents (list views, settings,
+ * composers). Aligned with the mobile dock and sidebar naming.
+ */
+const COMPONENT_DISPLAY: Record<
+  string,
+  { label: string; icon: Component<{ class?: string }> }
+> = {
+  home: { label: 'Home', icon: HomeIcon },
+  inbox: { label: 'Inbox', icon: AnimatedInboxIcon },
+  activity: { label: 'Activity', icon: AnimatedActivityIcon },
+  search: { label: 'Search', icon: AnimatedSearchIcon },
+  agents: { label: 'Agents', icon: AnimatedStarIcon },
+  mail: { label: 'Email', icon: AnimatedEmailIcon },
+  documents: { label: 'Documents', icon: AnimatedFileMdIcon },
+  tasks: { label: 'Tasks', icon: AnimatedTaskIcon },
+  channels: { label: 'Channels', icon: AnimatedChannelIcon },
+  calls: { label: 'Calls', icon: AnimatedCallIcon },
+  companies: { label: 'Customers', icon: AnimatedCompanyIcon },
+  folders: { label: 'Folders', icon: AnimatedFolderIcon },
+  settings: { label: 'Settings', icon: IconGear },
+  'email-compose': { label: 'New email', icon: AnimatedEmailIcon },
+  'channel-compose': { label: 'New channel', icon: AnimatedChannelIcon },
+  'task-compose': { label: 'New task', icon: AnimatedTaskIcon },
+};
+
+type HistoryEntry = {
+  content: SplitContent;
+  /** Index of this entry within the split's `history()`. */
+  index: number;
+};
+
+type DrawerSession = {
+  handle: SplitHandle;
+  /** Back-stack entries snapshotted at open time, most recent first. */
+  entries: HistoryEntry[];
+};
+
+type MobileHistoryDrawerState = {
+  /** Open the drawer for a split's back stack. No-ops without prior entries. */
+  open: (handle: SplitHandle) => void;
+};
+
+const MobileHistoryDrawerContext = createContext<MobileHistoryDrawerState>();
+
+export function useMobileHistoryDrawer(): MobileHistoryDrawerState | undefined {
+  return useContext(MobileHistoryDrawerContext);
+}
+
+/**
+ * Provides the history drawer opened by long-pressing the mobile back button.
+ * Mounted outside the split panels so the drawer survives the navigation (and
+ * split teardown) triggered by selecting an entry.
+ */
+export function MobileHistoryDrawerManager(props: ParentProps) {
+  const [isOpen, setIsOpen] = createSignal(false);
+  const [session, setSession] = createSignal<DrawerSession>();
+
+  const open = (handle: SplitHandle) => {
+    const items = handle.history();
+    if (items.length <= 1) return;
+    setSession({
+      handle,
+      entries: items
+        .slice(0, -1)
+        .map((content, index) => ({ content, index }))
+        .reverse(),
+    });
+    setIsOpen(true);
+  };
+
+  return (
+    <MobileHistoryDrawerContext.Provider value={{ open }}>
+      {props.children}
+      <MobileHistoryDrawer
+        isOpen={isOpen()}
+        session={session()}
+        onClose={() => setIsOpen(false)}
+      />
+    </MobileHistoryDrawerContext.Provider>
+  );
+}
+
+function ComponentEntryContent(props: { id: string }) {
+  const display = () => COMPONENT_DISPLAY[props.id];
+  return (
+    <>
+      <span class="size-5 flex items-center justify-center shrink-0 text-ink-muted">
+        <Dynamic component={display()?.icon ?? FileIcon} class="size-4.5" />
+      </span>
+      <span class="min-w-0 truncate">{display()?.label ?? props.id}</span>
+    </>
+  );
+}
+
+function BlockEntryContent(props: {
+  type: BlockName | BlockAlias;
+  id: string;
+}) {
+  const [item] = useItemPreview(() => {
+    const type = blockNameToItemType(props.type);
+    return type === 'channel' ? { id: props.id, type } : { id: props.id, type };
+  });
+
+  const name = () => {
+    const preview = item();
+    if (isAccessiblePreviewItem(preview)) {
+      return preview.name || blockNameToDefaultFile(props.type);
+    }
+    if (!preview.loading && preview.access === 'no_access') return 'No access';
+    if (!preview.loading && preview.access === 'does_not_exist')
+      return 'Deleted';
+    return blockNameToDefaultFile(props.type);
+  };
+
+  // The preview-derived icon picks up details the raw content type lacks
+  // (task subtype, channel type); fall back to the content type while loading.
+  const iconType = () => {
+    const preview = item();
+    if (isAccessiblePreviewItem(preview))
+      return getPreviewItemIconType(preview);
+    return props.type;
+  };
+
+  return (
+    <>
+      <span class="size-5 flex items-center justify-center shrink-0">
+        <EntityIcon targetType={iconType()} size="sm" />
+      </span>
+      <span class="min-w-0 truncate">{name()}</span>
+    </>
+  );
+}
+
+function HistoryEntryButton(props: {
+  content: SplitContent;
+  onSelect: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      data-history-entry
+      class="flex items-center gap-3 px-4 py-3 text-sm text-ink hover:bg-hover hover-transition-bg text-left not-last:mb-px bg-surface"
+      onClick={() => props.onSelect()}
+    >
+      <Show
+        when={props.content.type !== 'component'}
+        fallback={<ComponentEntryContent id={props.content.id} />}
+      >
+        <BlockEntryContent
+          type={props.content.type as BlockName | BlockAlias}
+          id={props.content.id}
+        />
+      </Show>
+    </button>
+  );
+}
+
+function MobileHistoryDrawer(props: {
+  isOpen: boolean;
+  session: DrawerSession | undefined;
+  onClose: () => void;
+}) {
+  const selectEntry = (entry: HistoryEntry) => {
+    if (!props.isOpen) return;
+    const handle = props.session?.handle;
+    props.onClose();
+    handle?.goBackToHistoryEntry(entry.index);
+  };
+
+  return (
+    <MobileDrawer
+      side="bottom"
+      open={props.isOpen}
+      closeOnOutsidePointerStrategy="pointerdown"
+      onOpenChange={(open) => {
+        if (!open) props.onClose();
+      }}
+      preventScroll={false}
+      preventScrollbarShift={false}
+      restoreFocus={false}
+    >
+      <MobileDrawer.Portal>
+        <MobileDrawer.Overlay class="fixed inset-0 z-modal-overlay bg-modal-overlay pattern-diagonal-4 pattern-edge-muted" />
+        <MobileDrawer.Content aria-label="Navigation history">
+          <MobileDrawer.Handle />
+          <MobileDrawer.Label as="h2">History</MobileDrawer.Label>
+          <div class="min-h-0 flex-1 overflow-y-auto pb-2">
+            <MobileDrawer.Section class="flex flex-col">
+              <Suspense>
+                <For each={props.session?.entries ?? []}>
+                  {(entry) => (
+                    <HistoryEntryButton
+                      content={entry.content}
+                      onSelect={() => selectEntry(entry)}
+                    />
+                  )}
+                </For>
+              </Suspense>
+            </MobileDrawer.Section>
+          </div>
+        </MobileDrawer.Content>
+      </MobileDrawer.Portal>
+    </MobileDrawer>
+  );
+}

--- a/apps/web/src/components/app/split-layout/mobile/MobileSplitContainer.tsx
+++ b/apps/web/src/components/app/split-layout/mobile/MobileSplitContainer.tsx
@@ -34,6 +34,8 @@ export function MobileSplitContainer(props: MobileSplitContainerProps) {
         ...rawHandle,
         goBack: () => mobileSwipeLayout.swipeBack(),
         canGoBack: () => mobileSwipeLayout.canGoBack(),
+        goBackToHistoryEntry: (index) =>
+          mobileSwipeLayout.swipeBackToEntry(index),
       };
       return { split, handle };
     });

--- a/apps/web/src/components/app/split-layout/mobile/createMobileSwipeLayout.ts
+++ b/apps/web/src/components/app/split-layout/mobile/createMobileSwipeLayout.ts
@@ -40,6 +40,13 @@ export type MobileSwipeLayout = {
    * otherwise completes immediately. Called by the split header back button.
    */
   swipeBack: () => void;
+  /**
+   * Jump back to an arbitrary prior entry of the foreground split's history
+   * (as indexed by its `history()`). Re-prepares the background slot with the
+   * target so the standard swipe-back promotion (animation included) lands on
+   * it. Called by the mobile history drawer.
+   */
+  swipeBackToEntry: (index: number) => void;
 };
 
 export function createMobileSwipeLayout(
@@ -209,6 +216,52 @@ export function createMobileSwipeLayout(
     }
   }
 
+  function swipeBackToEntry(index: number) {
+    const currentFgId = fgSplitId();
+    const fgHandle = currentFgId
+      ? splitManager.getSplit(currentFgId)
+      : undefined;
+    if (!fgHandle) return;
+
+    const items = fgHandle.history();
+    const currentIndex = items.length - 1;
+    if (index < 0 || index >= currentIndex) return;
+
+    // The BG slot already holds the immediately-previous entry.
+    if (index === currentIndex - 1) {
+      swipeBack();
+      return;
+    }
+
+    const isFgA = fgIsSlotA();
+    const currentBgId = bgSplitId();
+    const setBgSlotId = isFgA ? setSlotBSplitId : setSlotASplitId;
+
+    // Swap the jump target into the BG slot, then run the normal swipe-back
+    // so the existing promotion path (animation, FG teardown, next BG mount
+    // from the promoted split's history) applies unchanged.
+    // Batch to ensure reactive dependencies never see intermediate state.
+    batch(() => {
+      if (currentBgId) {
+        splitManager.removeSplit(currentBgId);
+      }
+
+      // allowDuplicate: the target entry may share content identity with the
+      // current FG (e.g. A → B → A); dedup would hand back the FG split.
+      const targetHandle = splitManager.createNewSplit({
+        content: items[index],
+        initialHistory: items.slice(0, index),
+        activate: false,
+        allowDuplicate: true,
+        referredFrom: null,
+      });
+
+      setBgSlotId(targetHandle.id);
+    });
+
+    swipeBack();
+  }
+
   return {
     slotASplitId,
     slotBSplitId,
@@ -219,5 +272,6 @@ export function createMobileSwipeLayout(
     setAnimatedTrigger,
     setForwardNavigationTrigger,
     swipeBack,
+    swipeBackToEntry,
   };
 }

--- a/apps/web/src/components/app/split-layout/tests/layoutManager.test.ts
+++ b/apps/web/src/components/app/split-layout/tests/layoutManager.test.ts
@@ -459,4 +459,191 @@ describe('layoutManager', () => {
       });
     });
   });
+
+  describe('history jumps', () => {
+    it('jumps directly to a prior entry in one navigation', () => {
+      createRoot((dispose) => {
+        const manager = createSplitLayout(createMockOrchestrator(), [
+          { type: 'component', id: 'inbox' },
+        ]);
+
+        const split = manager.getSplit(manager.splits()[0].id)!;
+        split.replace({ next: { type: 'md', id: 'doc-1' } });
+        split.replace({ next: { type: 'md', id: 'doc-2' } });
+        split.replace({ next: { type: 'md', id: 'doc-3' } });
+
+        const contentChanges: unknown[] = [];
+        split.registerContentChangeListener((payload) => {
+          contentChanges.push(payload);
+        });
+
+        split.goBackToHistoryEntry(0);
+
+        expect(split.content()).toMatchObject({
+          type: 'component',
+          id: 'inbox',
+        });
+        expect(split.history()).toHaveLength(1);
+        expect(split.canGoBack()).toBe(false);
+        expect(split.canGoForward()).toBe(true);
+        expect(split.lastNavigationCause()).toBe('history-back');
+        // Intermediate entries are skipped, so only one navigation lands.
+        expect(contentChanges).toHaveLength(1);
+
+        dispose();
+      });
+    });
+
+    it('ignores out-of-range and non-back history indices', () => {
+      createRoot((dispose) => {
+        const manager = createSplitLayout(createMockOrchestrator(), [
+          { type: 'component', id: 'inbox' },
+        ]);
+
+        const split = manager.getSplit(manager.splits()[0].id)!;
+        split.replace({ next: { type: 'md', id: 'doc-1' } });
+
+        for (const index of [-1, 1, 5]) {
+          split.goBackToHistoryEntry(index);
+          expect(split.content()).toMatchObject({ type: 'md', id: 'doc-1' });
+        }
+
+        dispose();
+      });
+    });
+
+    describe('mobile swipeBackToEntry', () => {
+      function setupMobileHistory() {
+        const manager = createSplitLayout(createMockOrchestrator(), [
+          { type: 'component', id: 'inbox' },
+        ]);
+        manager.activateSplit(manager.splits()[0].id);
+        const swipeLayout = createMobileSwipeLayout(manager);
+
+        // With no animation trigger registered, navigation completes
+        // synchronously through the interceptor.
+        for (const id of ['doc-1', 'doc-2', 'doc-3']) {
+          manager.openWithSplit({ type: 'md', id }, { referredFrom: null });
+        }
+
+        const fgId = swipeLayout.fgIsSlotA()
+          ? swipeLayout.slotASplitId()
+          : swipeLayout.slotBSplitId();
+        const fg = manager.getSplit(fgId!)!;
+
+        return { manager, swipeLayout, fg };
+      }
+
+      it('jumps multiple entries back and rebuilds the background slot', () => {
+        createRoot((dispose) => {
+          const { manager, swipeLayout, fg } = setupMobileHistory();
+
+          expect(fg.history().map((c) => c.id)).toEqual([
+            'inbox',
+            'doc-1',
+            'doc-2',
+            'doc-3',
+          ]);
+
+          swipeLayout.swipeBackToEntry(1);
+
+          const newFg = manager.activeSplit()!;
+          expect(newFg.content()).toMatchObject({ type: 'md', id: 'doc-1' });
+          expect(newFg.history().map((c) => c.id)).toEqual(['inbox', 'doc-1']);
+          expect(swipeLayout.canGoBack()).toBe(true);
+          expect(manager.getVisibleSplitCount()).toBe(1);
+
+          // The rebuilt background holds the entry before the target.
+          swipeLayout.swipeBack();
+          expect(manager.activeSplit()!.content()).toMatchObject({
+            type: 'component',
+            id: 'inbox',
+          });
+          expect(swipeLayout.canGoBack()).toBe(false);
+
+          dispose();
+        });
+      });
+
+      it('jumps to the root entry and clears the back stack', () => {
+        createRoot((dispose) => {
+          const { manager, swipeLayout } = setupMobileHistory();
+
+          swipeLayout.swipeBackToEntry(0);
+
+          expect(manager.activeSplit()!.content()).toMatchObject({
+            type: 'component',
+            id: 'inbox',
+          });
+          expect(swipeLayout.canGoBack()).toBe(false);
+
+          dispose();
+        });
+      });
+
+      it('delegates single-step jumps to the standard swipe back', () => {
+        createRoot((dispose) => {
+          const { manager, swipeLayout } = setupMobileHistory();
+
+          swipeLayout.swipeBackToEntry(2);
+
+          const fg = manager.activeSplit()!;
+          expect(fg.content()).toMatchObject({ type: 'md', id: 'doc-2' });
+          expect(fg.history().map((c) => c.id)).toEqual([
+            'inbox',
+            'doc-1',
+            'doc-2',
+          ]);
+          expect(swipeLayout.canGoBack()).toBe(true);
+
+          dispose();
+        });
+      });
+
+      it('ignores out-of-range and non-back indices', () => {
+        createRoot((dispose) => {
+          const { manager, swipeLayout, fg } = setupMobileHistory();
+
+          for (const index of [-1, 3, 9]) {
+            swipeLayout.swipeBackToEntry(index);
+            expect(manager.activeSplitId()).toBe(fg.id);
+            expect(fg.content()).toMatchObject({ type: 'md', id: 'doc-3' });
+          }
+
+          dispose();
+        });
+      });
+
+      it('jumps back to an entry whose content matches the current split', () => {
+        createRoot((dispose) => {
+          const manager = createSplitLayout(createMockOrchestrator(), [
+            { type: 'md', id: 'doc-a' },
+          ]);
+          manager.activateSplit(manager.splits()[0].id);
+          const swipeLayout = createMobileSwipeLayout(manager);
+
+          for (const id of ['doc-b', 'doc-c', 'doc-a']) {
+            manager.openWithSplit({ type: 'md', id }, { referredFrom: null });
+          }
+
+          const fg = manager.activeSplit()!;
+          expect(fg.history().map((c) => c.id)).toEqual([
+            'doc-a',
+            'doc-b',
+            'doc-c',
+            'doc-a',
+          ]);
+
+          swipeLayout.swipeBackToEntry(0);
+
+          const newFg = manager.activeSplit()!;
+          expect(newFg.content()).toMatchObject({ type: 'md', id: 'doc-a' });
+          expect(newFg.history()).toHaveLength(1);
+          expect(swipeLayout.canGoBack()).toBe(false);
+
+          dispose();
+        });
+      });
+    });
+  });
 });

--- a/apps/web/src/components/app/split-layout/tests/layoutManager.test.ts
+++ b/apps/web/src/components/app/split-layout/tests/layoutManager.test.ts
@@ -512,6 +512,102 @@ describe('layoutManager', () => {
       });
     });
 
+    it('back() skips entries open in another split and lands on the nearest mountable one', () => {
+      createRoot((dispose) => {
+        const manager = createSplitLayout(createMockOrchestrator(), [
+          { type: 'component', id: 'inbox' },
+        ]);
+
+        const split = manager.getSplit(manager.splits()[0].id)!;
+        split.replace({ next: { type: 'md', id: 'doc-1' } });
+        split.replace({ next: { type: 'md', id: 'doc-2' } });
+
+        manager.createNewSplit({
+          content: { type: 'md', id: 'doc-1' },
+          referredFrom: null,
+        });
+
+        const contentChanges: unknown[] = [];
+        split.registerContentChangeListener((payload) => {
+          contentChanges.push(payload);
+        });
+
+        split.goBack();
+
+        // doc-1 is mounted in the other split, so back() steps past it.
+        expect(split.content()).toMatchObject({
+          type: 'component',
+          id: 'inbox',
+        });
+        expect(split.history()).toHaveLength(1);
+        expect(split.canGoForward()).toBe(true);
+        expect(contentChanges).toHaveLength(1);
+
+        dispose();
+      });
+    });
+
+    it('back() no-ops without moving the index when every previous entry is blocked', () => {
+      createRoot((dispose) => {
+        const manager = createSplitLayout(createMockOrchestrator(), [
+          { type: 'md', id: 'doc-1' },
+        ]);
+
+        const split = manager.getSplit(manager.splits()[0].id)!;
+        split.replace({ next: { type: 'md', id: 'doc-2' } });
+
+        manager.createNewSplit({
+          content: { type: 'md', id: 'doc-1' },
+          referredFrom: null,
+        });
+
+        split.goBack();
+
+        expect(split.content()).toMatchObject({ type: 'md', id: 'doc-2' });
+        expect(split.history().map((c) => c.id)).toEqual(['doc-1', 'doc-2']);
+        expect(split.canGoBack()).toBe(true);
+        expect(split.canGoForward()).toBe(false);
+
+        dispose();
+      });
+    });
+
+    it('forward() skips entries open in another split and lands on the nearest mountable one', () => {
+      createRoot((dispose) => {
+        const manager = createSplitLayout(createMockOrchestrator(), [
+          { type: 'component', id: 'inbox' },
+        ]);
+
+        const split = manager.getSplit(manager.splits()[0].id)!;
+        split.replace({ next: { type: 'md', id: 'doc-1' } });
+        split.replace({ next: { type: 'md', id: 'doc-2' } });
+        split.goBack();
+        split.goBack();
+        expect(split.content()).toMatchObject({
+          type: 'component',
+          id: 'inbox',
+        });
+
+        manager.createNewSplit({
+          content: { type: 'md', id: 'doc-1' },
+          referredFrom: null,
+        });
+
+        split.goForward();
+
+        // doc-1 is mounted in the other split, so forward() steps past it.
+        expect(split.content()).toMatchObject({ type: 'md', id: 'doc-2' });
+        expect(split.history().map((c) => c.id)).toEqual([
+          'inbox',
+          'doc-1',
+          'doc-2',
+        ]);
+        expect(split.canGoForward()).toBe(false);
+
+        dispose();
+      });
+    });
+
     it('leaves history untouched when the target is open in another split', () => {
       createRoot((dispose) => {
         const manager = createSplitLayout(createMockOrchestrator(), [

--- a/apps/web/src/components/app/split-layout/tests/layoutManager.test.ts
+++ b/apps/web/src/components/app/split-layout/tests/layoutManager.test.ts
@@ -512,6 +512,40 @@ describe('layoutManager', () => {
       });
     });
 
+    it('leaves history untouched when the target is open in another split', () => {
+      createRoot((dispose) => {
+        const manager = createSplitLayout(createMockOrchestrator(), [
+          { type: 'component', id: 'inbox' },
+        ]);
+
+        const split = manager.getSplit(manager.splits()[0].id)!;
+        split.replace({ next: { type: 'md', id: 'doc-1' } });
+        split.replace({ next: { type: 'md', id: 'doc-2' } });
+
+        // Duplicate detection only inspects current contents, so a past
+        // history entry's content can be opened in a second split.
+        manager.createNewSplit({
+          content: { type: 'md', id: 'doc-1' },
+          referredFrom: null,
+        });
+
+        split.goBackToHistoryEntry(1);
+
+        // reattach would refuse the duplicate target, so the jump must not
+        // move the history index away from the mounted content.
+        expect(split.content()).toMatchObject({ type: 'md', id: 'doc-2' });
+        expect(split.history().map((c) => c.id)).toEqual([
+          'inbox',
+          'doc-1',
+          'doc-2',
+        ]);
+        expect(split.canGoBack()).toBe(true);
+        expect(split.canGoForward()).toBe(false);
+
+        dispose();
+      });
+    });
+
     describe('mobile swipeBackToEntry', () => {
       function setupMobileHistory() {
         const manager = createSplitLayout(createMockOrchestrator(), [


### PR DESCRIPTION
On mobile, long-pressing the back button in the split header now opens a bottom-sheet drawer showing the current split's history stack (most recent first). Tapping an entry jumps directly back to it; a short tap on the back button still goes back one entry.

How:
- `SplitHandle.goBackToHistoryEntry(index)` in the layout manager performs a multi-step back as a single navigation (one reattach, entry state captured once), so intermediate entries never mount.
- The mobile swipe layout adds `swipeBackToEntry(index)`: it re-prepares the background slot with the jump target (with correctly truncated history), then reuses the existing animated swipe-back promotion path unchanged. Single-step jumps delegate to the normal `swipeBack`.
- New `MobileHistoryDrawer` (corvu bottom sheet, same pattern as the channel `ActionDrawer`): block entries resolve names/icons via item previews, component entries (Inbox, Email, Settings, …) use the dock/sidebar labels and icons. The drawer manager is mounted outside the split panels so it survives the split teardown its own navigation triggers.
- Long-press wiring uses the existing `touchHandler` directive on `SplitBackButton` (active on mobile only); the handler swallows the synthesized click after a long press so `goBack` doesn't also run.

Covered by new unit tests for both the generic history jump and the mobile slot rebuild (including the duplicate-content A→B→A edge case).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uq9MDy7XzQ574gVBGFajuX)_