### PR TITLE
feat(email): gate email signatures behind a PostHog feature flag

### DIFF
--- a/apps/web/src/features/block-email/component/BaseInput.tsx
+++ b/apps/web/src/features/block-email/component/BaseInput.tsx
@@ -1,3 +1,4 @@
+import { useFeatureFlag } from '@app/lib/analytics/posthog';
 import { EmailAttachmentPill } from '@block-email/component/AttachmentPill';
 import type { DraftFormAttachment } from '@block-email/component/createEmailFormState';
 import { EmailDateSelector } from '@block-email/component/email-date-selector';
@@ -23,7 +24,8 @@ import { RecipientSelector } from '@core/component/RecipientSelector';
 import { toast } from '@core/component/Toast/Toast';
 import {
   ENABLE_EMAIL_SCHEDULED_SEND,
-  ENABLE_EMAIL_SIGNATURES,
+  ENABLE_EMAIL_SIGNATURES_FLAG,
+  ENABLE_EMAIL_SIGNATURES_OVERRIDE,
 } from '@core/constant/featureFlags';
 import { useEmail } from '@core/context/user';
 import { fileFolderDrop } from '@core/directive/fileFolderDrop';
@@ -328,6 +330,9 @@ export function BaseInput(props: {
     emailLinksQuery.data?.links.find((l) => l.id === activeLinkId())
   );
   const signature = useEmailSignature(activeLinkId);
+  const emailSignaturesFlag = useFeatureFlag(ENABLE_EMAIL_SIGNATURES_FLAG, {
+    enabledOverride: ENABLE_EMAIL_SIGNATURES_OVERRIDE,
+  });
   // Whether this reply includes the signature. Defaults on, reset per reply,
   // and dismissable via the preview ✕.
   const [includeSignature, setIncludeSignature] = createSignal(true);
@@ -336,7 +341,7 @@ export function BaseInput(props: {
   // and the user hasn't dismissed it. The backend does the actual injection on
   // send — this just mirrors when that will happen.
   const replySignatureHtml = (): string | undefined =>
-    ENABLE_EMAIL_SIGNATURES &&
+    emailSignaturesFlag().enabled &&
     props.replyingTo() &&
     includeSignature() &&
     sendingLink()?.settings.signature_on_replies_forwards

--- a/apps/web/src/features/block-email/component/compose/Compose.tsx
+++ b/apps/web/src/features/block-email/component/compose/Compose.tsx
@@ -1,3 +1,4 @@
+import { useFeatureFlag } from '@app/lib/analytics/posthog';
 import type { EmailFormRecipients } from '@block-email/component/createEmailFormState';
 import {
   createEmailFormState,
@@ -28,7 +29,10 @@ import { useSplitLayout } from '@components/app/split-layout/layout';
 import { useHasPaidAccess } from '@core/auth';
 import { EmailPermissionsBanner } from '@core/component/EmailPermissionsBanner';
 import { toast } from '@core/component/Toast/Toast';
-import { ENABLE_EMAIL_SIGNATURES } from '@core/constant/featureFlags';
+import {
+  ENABLE_EMAIL_SIGNATURES_FLAG,
+  ENABLE_EMAIL_SIGNATURES_OVERRIDE,
+} from '@core/constant/featureFlags';
 import { isMobile } from '@core/mobile/isMobile';
 import { WrapUnlessMobile } from '@core/mobile/WrapUnlessMobile';
 import { useCombinedRecipients } from '@core/signal/useCombinedRecipient';
@@ -157,6 +161,9 @@ export function EmailCompose(props: EmailComposeProps) {
   // message. The backend injects it on send (see include_signature below); the
   // FE only renders the preview and signals an explicit dismiss.
   const signature = useEmailSignature(() => link()?.id);
+  const emailSignaturesFlag = useFeatureFlag(ENABLE_EMAIL_SIGNATURES_FLAG, {
+    enabledOverride: ENABLE_EMAIL_SIGNATURES_OVERRIDE,
+  });
   const [includeSignature, setIncludeSignature] = createSignal(true);
 
   const hasLinkError = createMemo(() => {
@@ -768,7 +775,11 @@ export function EmailCompose(props: EmailComposeProps) {
     // dismiss. Shown only when the sending inbox has a signature and it hasn't
     // been dismissed.
     signaturePreview: () => (
-      <Show when={ENABLE_EMAIL_SIGNATURES && includeSignature() && signature()}>
+      <Show
+        when={
+          emailSignaturesFlag().enabled && includeSignature() && signature()
+        }
+      >
         {(html) => (
           <SignaturePreview
             html={html()}

--- a/apps/web/src/features/settings/Email.tsx
+++ b/apps/web/src/features/settings/Email.tsx
@@ -2,7 +2,8 @@ import { openAddInboxDialog } from '@app/features/inbox/AddInboxDialog';
 import { useFeatureFlag } from '@app/lib/analytics/posthog';
 import { toast } from '@core/component/Toast/Toast';
 import {
-  ENABLE_EMAIL_SIGNATURES,
+  ENABLE_EMAIL_SIGNATURES_FLAG,
+  ENABLE_EMAIL_SIGNATURES_OVERRIDE,
   ENABLE_INBOX_RESYNC,
   ENABLE_INBOX_SYNC_STATUS,
   ENABLE_MULTI_INBOX_OVERRIDE,
@@ -383,6 +384,9 @@ function InboxRow(props: {
   onReconnect: () => void;
   onRemove: () => void;
 }) {
+  const emailSignaturesFlag = useFeatureFlag(ENABLE_EMAIL_SIGNATURES_FLAG, {
+    enabledOverride: ENABLE_EMAIL_SIGNATURES_OVERRIDE,
+  });
   const showSignature = () => isSignatureExpanded(props.link.id);
   const signatureSectionId = `signature-section-${props.link.id}`;
   return (
@@ -443,7 +447,7 @@ function InboxRow(props: {
           </Show>
         </div>
         <div class="flex items-center gap-2 shrink-0">
-          <Show when={ENABLE_EMAIL_SIGNATURES && props.isOwn}>
+          <Show when={emailSignaturesFlag().enabled && props.isOwn}>
             <Tooltip label="Edit signature">
               <Button
                 variant="base"
@@ -505,7 +509,9 @@ function InboxRow(props: {
           </Tooltip>
         </div>
       </div>
-      <Show when={ENABLE_EMAIL_SIGNATURES && props.isOwn && showSignature()}>
+      <Show
+        when={emailSignaturesFlag().enabled && props.isOwn && showSignature()}
+      >
         <div id={signatureSectionId} class="px-6 pb-4">
           <SignatureSection link={props.link} />
         </div>

--- a/apps/web/src/lib/analytics/posthog.tsx
+++ b/apps/web/src/lib/analytics/posthog.tsx
@@ -50,7 +50,9 @@ export function useFeatureFlag<T extends JsonType>(
 
       const flag = posthog.instance.getFeatureFlagResult(key);
 
-      const enabled = flag?.enabled || (enabledOverride ?? false);
+      // A defined override wins in both directions: an explicit `false`
+      // disables even when PostHog reports the flag on.
+      const enabled = enabledOverride ?? flag?.enabled ?? false;
       const payload = (flag?.payload as T) ?? fallbackPayload;
 
       return { enabled, payload };

--- a/apps/web/src/lib/core/component/AI/component/tool/email/ChatCompose.tsx
+++ b/apps/web/src/lib/core/component/AI/component/tool/email/ChatCompose.tsx
@@ -1,3 +1,4 @@
+import { useFeatureFlag } from '@app/lib/analytics/posthog';
 import {
   ComposeLayout,
   EmailComposeToolbar,
@@ -16,7 +17,10 @@ import { convertContactInfoToEmailRecipient } from '@block-email/util/recipientC
 import { useChatContext } from '@core/component/AI/context';
 import type { AssistantMessagePart } from '@core/component/AI/types';
 import { toast } from '@core/component/Toast/Toast';
-import { ENABLE_EMAIL_SIGNATURES } from '@core/constant/featureFlags';
+import {
+  ENABLE_EMAIL_SIGNATURES_FLAG,
+  ENABLE_EMAIL_SIGNATURES_OVERRIDE,
+} from '@core/constant/featureFlags';
 
 import { useChatQuery } from '@queries/chat';
 import { useEmailLinksQuery, useEmailSignature } from '@queries/email/link';
@@ -171,6 +175,9 @@ export function ComposeTool(props: ComposeToolProps) {
   const sendingLink = createMemo(() => emailLinksQuery.data?.links?.[0]);
   const fromAddress = () => sendingLink()?.email_address;
   const signature = useEmailSignature(() => sendingLink()?.id);
+  const emailSignaturesFlag = useFeatureFlag(ENABLE_EMAIL_SIGNATURES_FLAG, {
+    enabledOverride: ENABLE_EMAIL_SIGNATURES_OVERRIDE,
+  });
   // Whether this email includes the signature. Defaults on; the preview's ✕
   // drops it for this one message. Mirrors the normal composer.
   // Initialize from the persisted tool args so a dismiss survives re-render /
@@ -184,7 +191,7 @@ export function ComposeTool(props: ComposeToolProps) {
   // on. Hidden once dismissed and in the read-only (sent) state. Shown during
   // streaming too — the composer's overlay blocks interaction until it ends.
   const previewSignatureHtml = (): string | undefined => {
-    if (!ENABLE_EMAIL_SIGNATURES) return undefined;
+    if (!emailSignaturesFlag().enabled) return undefined;
     if (props.readOnly) return undefined;
     if (!includeSignature()) return undefined;
     const sig = signature();

--- a/apps/web/src/lib/core/constant/featureFlags.ts
+++ b/apps/web/src/lib/core/constant/featureFlags.ts
@@ -126,8 +126,11 @@ export const ENABLE_EMAIL = resolveFeatureFlag('ENABLE_EMAIL', true);
 // previews, and the per-message include toggle. PostHog-gated with a dev-mode
 // default; override with VITE_ENABLE_EMAIL_SIGNATURES.
 export const ENABLE_EMAIL_SIGNATURES_FLAG = 'enable-email-signatures';
+// Honor an explicit VITE_ENABLE_EMAIL_SIGNATURES=false (don't coerce it to
+// undefined), else default on in dev and defer to PostHog in prod.
 export const ENABLE_EMAIL_SIGNATURES_OVERRIDE =
-  resolveFeatureFlag('ENABLE_EMAIL_SIGNATURES', DEV_MODE_ENV) || undefined;
+  getFeatureFlagOverride('ENABLE_EMAIL_SIGNATURES') ??
+  (DEV_MODE_ENV ? true : undefined);
 
 /**
  * Non-reactive check for imperative call sites. For reactive UI, prefer

--- a/apps/web/src/lib/core/constant/featureFlags.ts
+++ b/apps/web/src/lib/core/constant/featureFlags.ts
@@ -123,12 +123,24 @@ export const ENABLE_MARKDOWN_LIVE_COLLABORATION = resolveFeatureFlag(
 export const ENABLE_EMAIL = resolveFeatureFlag('ENABLE_EMAIL', true);
 
 // Email signatures: the settings editor, the compose / reply / AI-chat signature
-// previews, and the per-message include toggle. Dev/local only for now; override
-// with VITE_ENABLE_EMAIL_SIGNATURES.
-export const ENABLE_EMAIL_SIGNATURES = resolveFeatureFlag(
-  'ENABLE_EMAIL_SIGNATURES',
-  DEV_MODE_ENV
-);
+// previews, and the per-message include toggle. PostHog-gated with a dev-mode
+// default; override with VITE_ENABLE_EMAIL_SIGNATURES.
+export const ENABLE_EMAIL_SIGNATURES_FLAG = 'enable-email-signatures';
+export const ENABLE_EMAIL_SIGNATURES_OVERRIDE =
+  resolveFeatureFlag('ENABLE_EMAIL_SIGNATURES', DEV_MODE_ENV) || undefined;
+
+/**
+ * Non-reactive check for imperative call sites. For reactive UI, prefer
+ * `useFeatureFlag(ENABLE_EMAIL_SIGNATURES_FLAG, { enabledOverride: ENABLE_EMAIL_SIGNATURES_OVERRIDE })`.
+ */
+export function ENABLE_EMAIL_SIGNATURES(): boolean {
+  if (ENABLE_EMAIL_SIGNATURES_OVERRIDE !== undefined) {
+    return ENABLE_EMAIL_SIGNATURES_OVERRIDE;
+  }
+  return (
+    analytics.posthog.isFeatureEnabled(ENABLE_EMAIL_SIGNATURES_FLAG) ?? false
+  );
+}
 
 // CRM companies & contacts frontend: the Companies view + sidebar entry, the
 // company/contact detail blocks, CRM mentions / quick-access, and CRM rows in


### PR DESCRIPTION
## Summary

Converts `ENABLE_EMAIL_SIGNATURES` from a dev-only env constant to the PostHog-gated pattern used by `ENABLE_CRM`:

- `ENABLE_EMAIL_SIGNATURES_FLAG = 'enable-email-signatures'` — the PostHog flag key (needs to be created in the PostHog interface)
- `ENABLE_EMAIL_SIGNATURES_OVERRIDE` — defaults on in dev mode; overridable locally with `VITE_ENABLE_EMAIL_SIGNATURES`
- `ENABLE_EMAIL_SIGNATURES()` — non-reactive check for imperative call sites

All four call sites (settings signature editor, thread reply preview, compose preview, AI chat compose preview) now resolve the flag reactively via `useFeatureFlag` with the dev override, matching the CRM call-site pattern.

## Rollout

Requires creating an `enable-email-signatures` boolean flag in PostHog, targeted the same way as `enable-crm` (Macro team in prod).