### PR TITLE
feat: autofocus new Agent input on mobile

### DIFF
--- a/apps/web/src/features/command/Launcher.tsx
+++ b/apps/web/src/features/command/Launcher.tsx
@@ -1,6 +1,7 @@
 import { useFeatureFlag } from '@app/lib/analytics/posthog';
 import { setAutomationComposerOpen } from '@block-automation/component';
 import { EMAIL_COMPOSE_TO_INPUT_ID } from '@block-email/constants';
+import { CHAT_INPUT_TEXT_AREA_ID } from '@core/component/AI/component/input/ChatInput';
 import { openNewChannelModal } from '@channel/CreateChannelModal';
 import { useSplitLayout } from '@components/app/split-layout/layout';
 import type { BlockAlias, BlockName } from '@core/block';
@@ -237,6 +238,16 @@ export function runCreateAction(
       });
       return;
     case 'chat':
+      // On mobile the chat input doesn't autofocus on mount, so arm focus
+      // within this gesture (iOS only raises the keyboard for a synchronous
+      // focus). The chat mounts asynchronously, so this waits for the input.
+      if (isMobile()) {
+        triggerFocusInput(() =>
+          document
+            .getElementById(CHAT_INPUT_TEXT_AREA_ID)
+            ?.querySelector<HTMLElement>('[contenteditable="true"]')
+        );
+      }
       createBlock({
         blockName: 'chat',
         createFn: async () => {

--- a/apps/web/src/features/command/Launcher.tsx
+++ b/apps/web/src/features/command/Launcher.tsx
@@ -1,10 +1,10 @@
 import { useFeatureFlag } from '@app/lib/analytics/posthog';
 import { setAutomationComposerOpen } from '@block-automation/component';
 import { EMAIL_COMPOSE_TO_INPUT_ID } from '@block-email/constants';
-import { CHAT_INPUT_TEXT_AREA_ID } from '@core/component/AI/component/input/ChatInput';
 import { openNewChannelModal } from '@channel/CreateChannelModal';
 import { useSplitLayout } from '@components/app/split-layout/layout';
 import type { BlockAlias, BlockName } from '@core/block';
+import { CHAT_INPUT_TEXT_AREA_ID } from '@core/component/AI/component/input/ChatInput';
 import { getIconConfig } from '@core/component/EntityIcon';
 import {
   ENABLE_ANIMATED_ICONS,

--- a/apps/web/src/lib/core/component/AI/component/input/ChatInput.tsx
+++ b/apps/web/src/lib/core/component/AI/component/input/ChatInput.tsx
@@ -29,6 +29,12 @@ import { AttachmentList } from './Attachment';
 import { ChatAttachMenu } from './ChatAttachMenu';
 import { useAiDataConsentGate } from './useAiDataConsent';
 
+/**
+ * Id of the chat input's text-area wrapper. Exposed so callers (e.g. the
+ * mobile Create menu) can arm focus on the contenteditable before it mounts.
+ */
+export const CHAT_INPUT_TEXT_AREA_ID = 'chat-input-text-area';
+
 type ChatInputProps = {
   onSend: (args: ChatSendInput) => void;
   onStop?: () => void;
@@ -337,7 +343,7 @@ export function ChatInput(props: ChatInputComponentProps) {
               </div>
             </Show>
             <div
-              id="chat-input-text-area"
+              id={CHAT_INPUT_TEXT_AREA_ID}
               class={cn('text-sm sm:text-sm text-ink')}
               classList={{
                 'pl-8': !isMultiline() && !isTallVariant(),


### PR DESCRIPTION
Selecting **Agent** from the mobile Create menu now auto-focuses the chat input so the keyboard opens and the user can start typing immediately.

## How
- In `runCreateAction`'s `chat` case (`Launcher.tsx`), arm focus with `triggerFocusInput` (`focusInput.ts`) inside the tap gesture, mirroring the existing `email` case. This satisfies iOS's synchronous-focus requirement while the chat mounts asynchronously — the utility's `MutationObserver` focuses the input once it appears.
- Guarded with `isMobile()` since desktop already autofocuses the chat input on mount (mobile intentionally suppresses that).
- Exposed the chat input text-area id as `CHAT_INPUT_TEXT_AREA_ID` so the Launcher can target the contenteditable before it exists.

Linear: [macro-2486](https://linear.app/issue/macro-2486)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KFVhxe9ZB9dtmrbMzjpYjd)_