### PR TITLE
feat: re-order mail view tabs to have Sent before Calendar

### DIFF
--- a/apps/web/src/features/next-soup/soup-view/soup-view-tabs.tsx
+++ b/apps/web/src/features/next-soup/soup-view/soup-view-tabs.tsx
@@ -55,8 +55,8 @@ export const VIEW_TAB_LISTS: Record<TabbedListView, TabItem[]> = {
   mail: [
     { value: 'important', label: 'Signal' },
     { value: 'noise', label: 'Noise' },
-    { value: 'calendar', label: 'Calendar' },
     { value: 'sent', label: 'Sent' },
+    { value: 'calendar', label: 'Calendar' },
     { value: 'drafts', label: 'Drafts' },
     { value: 'shared', label: 'Shared' },
     { value: 'all', label: 'All' },

--- a/apps/web/tests/e2e/local-sidebar.spec.ts
+++ b/apps/web/tests/e2e/local-sidebar.spec.ts
@@ -19,7 +19,7 @@ const SIDEBAR_LIST_VIEWS = [
   {
     id: 'mail',
     label: 'Email',
-    tabs: ['Signal', 'Noise', 'Calendar', 'Sent', 'Drafts', 'Shared', 'All'],
+    tabs: ['Signal', 'Noise', 'Sent', 'Calendar', 'Drafts', 'Shared', 'All'],
   },
   {
     id: 'documents',


### PR DESCRIPTION
Re-orders the mail view tabs so **Sent** appears before **Calendar**.

New order: Signal, Noise, Sent, Calendar, Drafts, Shared, All.

## Changes
- `apps/web/src/features/next-soup/soup-view/soup-view-tabs.tsx` — swapped the `sent` and `calendar` entries in the `mail` tab list.
- `apps/web/tests/e2e/local-sidebar.spec.ts` — updated the expected mail tabs array to match the new display order.

The filter presets (`soup-filter-presets.ts`) are keyed by tab value, so no change was needed there.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EucN5YDkzQgiWTgfkQKmsM)_