### PR TITLE
fix(soup): scope property groups to canonical entity types

### DIFF
--- a/crates/soup/src/outbound/pg_soup_repo/expanded/dynamic.rs
+++ b/crates/soup/src/outbound/pg_soup_repo/expanded/dynamic.rs
@@ -78,7 +78,11 @@ static GROUPED_DOCUMENT_TOP_CLAUSE: &str = r#"
                         WHEN 'created_at' THEN d."createdAt"
                         ELSE d."updatedAt"
                     END::timestamptz as sort_ts,
-                    d."projectId"::text as project_id
+                    d."projectId"::text as project_id,
+                    CASE
+                        WHEN dt.sub_type = 'task' THEN 'TASK'::property_entity_type
+                        ELSE 'DOCUMENT'::property_entity_type
+                    END as property_entity_type
                 FROM AccessibleItems ai
                 INNER JOIN "Document" d ON d.id = ai.item_id AND ai.item_type = 'document'
                 LEFT JOIN document_sub_type dt ON dt.document_id = d.id
@@ -94,7 +98,8 @@ static GROUPED_CHAT_TOP_CLAUSE: &str = r#"
                         WHEN 'created_at' THEN c."createdAt"
                         ELSE c."updatedAt"
                     END::timestamptz as sort_ts,
-                    c."projectId"::text as project_id
+                    c."projectId"::text as project_id,
+                    'CHAT'::property_entity_type as property_entity_type
                 FROM AccessibleItems ai
                 INNER JOIN "Chat" c ON c.id = ai.item_id AND ai.item_type = 'chat'
                 LEFT JOIN "UserHistory" uh ON uh."itemId" = c.id AND uh."itemType" = 'chat' AND uh."userId" = $1
@@ -111,7 +116,8 @@ static GROUPED_PROJECT_TOP_CLAUSE: &str = r#"
                         WHEN 'created_at' THEN p."createdAt"
                         ELSE p."updatedAt"
                     END::timestamptz as sort_ts,
-                    p."parentId"::text as project_id
+                    p."parentId"::text as project_id,
+                    'PROJECT'::property_entity_type as property_entity_type
                 FROM AccessibleItems ai
                 INNER JOIN "Project" p ON p.id = ai.item_id AND ai.item_type = 'project'
                 LEFT JOIN "UserHistory" uh
@@ -1724,7 +1730,7 @@ fn build_grouped_query<'a>(
     // TopItems CTE: lightweight id + sort_ts + project_id with filters, cursor, and limit
     builder.push("TopItems AS (");
     builder.push(
-        "SELECT all_items.item_type, all_items.id, all_items.sort_ts, all_items.project_id FROM (",
+        "SELECT all_items.item_type, all_items.id, all_items.sort_ts, all_items.project_id, all_items.property_entity_type FROM (",
     );
 
     let mut needs_separator = false;
@@ -1766,7 +1772,7 @@ fn build_grouped_query<'a>(
     // Fallback when all entity types are filtered out
     if !needs_separator {
         builder.push(
-            "SELECT 'document'::text as item_type, NULL::text as id, NULL::timestamptz as sort_ts, NULL::text as project_id WHERE false",
+            "SELECT 'document'::text as item_type, NULL::text as id, NULL::timestamptz as sort_ts, NULL::text as project_id, NULL::property_entity_type as property_entity_type WHERE false",
         );
     }
 

--- a/crates/soup/src/outbound/pg_soup_repo/grouping.rs
+++ b/crates/soup/src/outbound/pg_soup_repo/grouping.rs
@@ -60,6 +60,8 @@ pub struct GroupJoinClause {
 /// per element, so multi-value properties (e.g. assignees) place each item into
 /// every group it belongs to. Items without a matching row, or with an empty
 /// array / scalar value, produce a single row with NULL `val` (→ "Not Set").
+/// Property rows are also matched to the Soup item's canonical property entity
+/// type, so a task ignores legacy `DOCUMENT` assignments for the same id.
 pub fn group_join_clause(field: &GroupByField) -> Option<GroupJoinClause> {
     match field {
         GroupByField::Property {
@@ -83,6 +85,7 @@ pub fn group_join_clause(field: &GroupByField) -> Option<GroupJoinClause> {
                             END
                         ) elem(val) ON TRUE
                         WHERE ep.entity_id = t.id::text
+                          AND ep.entity_type = t.property_entity_type
                           AND ep.property_definition_id = '{}'
                           {}
                     ) ep_group ON TRUE",

--- a/crates/soup/src/outbound/pg_soup_repo/grouping/test.rs
+++ b/crates/soup/src/outbound/pg_soup_repo/grouping/test.rs
@@ -7,7 +7,7 @@ use macro_db_migrator::MACRO_DB_MIGRATIONS;
 use macro_user_id::{cowlike::CowLike, user_id::MacroUserIdStr};
 use models_grouping::date_bucket_sql_key;
 use models_grouping::{GroupingConfig, date_bucket_order};
-use models_pagination::{Query, SimpleSortMethod};
+use models_pagination::{Identify, Query, SimpleSortMethod};
 use sqlx::{Pool, Postgres};
 
 #[test]
@@ -53,6 +53,86 @@ fn property_join_includes_definition_id() {
     let join = group_join_clause(&field).unwrap();
     assert!(join.sql.contains("ep_group"));
     assert!(join.sql.contains(&uuid::Uuid::nil().to_string()));
+}
+
+#[sqlx::test(
+    fixtures(
+        path = "../../../../../macro_db_client/fixtures",
+        scripts("mixed_items_expanded")
+    ),
+    migrator = "MACRO_DB_MIGRATIONS"
+)]
+async fn property_grouping_uses_canonical_task_entity_type(
+    pool: Pool<Postgres>,
+) -> anyhow::Result<()> {
+    const TASK_ID: &str = "11111111-0000-0000-0000-000000000000";
+    const STATUS_PROPERTY_ID: uuid::Uuid = uuid::uuid!("00000001-0000-0000-0000-000000000002");
+    const IN_PROGRESS_OPTION_ID: &str = "00000001-0000-0000-0002-000000000002";
+
+    sqlx::query!(
+        r#"
+        INSERT INTO document_sub_type (document_id, sub_type)
+        VALUES ('11111111-0000-0000-0000-000000000000', 'task')
+        "#
+    )
+    .execute(&pool)
+    .await?;
+
+    // A task and its canonical Document share an id. Legacy data can contain
+    // assignments under both storage types; only the TASK value is relevant.
+    sqlx::query!(
+        r#"
+        INSERT INTO entity_properties
+            (id, entity_id, entity_type, property_definition_id, values)
+        VALUES
+            (
+                'e0000000-0000-0000-0000-000000000001',
+                '11111111-0000-0000-0000-000000000000',
+                'DOCUMENT',
+                '00000001-0000-0000-0000-000000000002',
+                '{"type":"SelectOption","value":["00000001-0000-0000-0002-000000000001"]}'::jsonb
+            ),
+            (
+                'e0000000-0000-0000-0000-000000000002',
+                '11111111-0000-0000-0000-000000000000',
+                'TASK',
+                '00000001-0000-0000-0000-000000000002',
+                '{"type":"SelectOption","value":["00000001-0000-0000-0002-000000000002"]}'::jsonb
+            )
+        "#
+    )
+    .execute(&pool)
+    .await?;
+
+    let user_id = MacroUserIdStr::parse_from_str("macro|user-1@test.com").unwrap();
+    let items = expanded_dynamic_cursor_soup_grouped(
+        &pool,
+        GroupedDynamicCursorArgs {
+            user_id: user_id.copied(),
+            limit: 50,
+            cursor: Query::Sort(
+                SimpleSortMethod::ViewedUpdated,
+                EntityFilterAst::mock_empty(),
+            ),
+            exclude_frecency: false,
+            grouping: GroupingConfig {
+                field: GroupByField::Property {
+                    property_definition_id: STATUS_PROPERTY_ID,
+                    entity_type: None,
+                },
+                group_key: None,
+                per_group_limit: None,
+            },
+        },
+    )
+    .await?
+    .filter(|item| item.item.id().to_string() == TASK_ID)
+    .collect::<Vec<_>>();
+
+    assert_eq!(items.len(), 1, "task must belong to exactly one status bin");
+    assert_eq!(items[0].key, IN_PROGRESS_OPTION_ID);
+
+    Ok(())
 }
 
 #[sqlx::test(


### PR DESCRIPTION
Fixes an issue with properties grouping which can cause the same thing to exist in multiple bins. e.g. 

```
   same entity ID | DOCUMENT | Status | Not Started
   same entity ID | TASK     | Status | In Progress
```