### PR TITLE
feat(email): turn the email watermark into a referral link

### DIFF
--- a/apps/web/src/components/ui/signals/signals.ts
+++ b/apps/web/src/components/ui/signals/signals.ts
@@ -18,3 +18,14 @@ export const [monochromeIcons, setMonochromeIcons] = makePersisted(
   createSignal<boolean>(false),
   { name: 'enable-monochrome-icons' }
 );
+
+/**
+ * Whether paid users append the "Sent from my Macro" referral-link watermark
+ * to outgoing emails. Free users always get the watermark regardless of this
+ * setting. Defaults on; paid users can turn it off from the compose footer
+ * (with a confirmation) or Settings → Email.
+ */
+export const [emailWatermarkEnabled, setEmailWatermarkEnabled] = makePersisted(
+  createSignal<boolean>(true),
+  { name: 'email.watermarkEnabled' }
+);

--- a/apps/web/src/features/auth/EmailForm.tsx
+++ b/apps/web/src/features/auth/EmailForm.tsx
@@ -1,6 +1,7 @@
 import { SERVER_HOSTS } from '@core/constant/servers';
 import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import { virtualKeyboardVisible } from '@core/mobile/virtualKeyboard';
+import { resolveReferralCode } from '@core/referral';
 import { platformFetch } from '@core/util/platformFetch';
 import ArrowLeft from '@phosphor/arrow-left.svg';
 import ArrowRight from '@phosphor/arrow-right.svg';
@@ -53,8 +54,7 @@ export const sendEmailCode = action(async (formData: FormData) => {
     return 'LoggedIn';
   }
 
-  const url = new URL(window.location.href);
-  const referral_code = url.searchParams.get('referral_code');
+  const referral_code = resolveReferralCode();
 
   const response = await platformFetch(
     `${SERVER_HOSTS['auth-service']}/login/passwordless`,

--- a/apps/web/src/features/auth/useSsoLogin.ts
+++ b/apps/web/src/features/auth/useSsoLogin.ts
@@ -3,6 +3,7 @@ import { useAnalytics } from '@app/lib/analytics/analytics-context';
 import { SERVER_HOSTS } from '@core/constant/servers';
 import { useEmailLinks } from '@core/email-link';
 import { isNativeMobilePlatform } from '@core/mobile/isNativeMobilePlatform';
+import { getStoredReferralCode } from '@core/referral';
 import type { RedirectLocation } from '@core/util/authRedirect';
 import { unsetTokenPromise } from '@core/util/fetchWithToken';
 import { getNativeMobilePlatform } from '@core/util/platform';
@@ -30,7 +31,8 @@ export function useSsoLogin(opts?: { signupMode?: boolean }) {
       new URL(window.location.href).searchParams.get('referral_code') ??
       new URLSearchParams(location.state?.originalLocation?.search).get(
         'referral_code'
-      );
+      ) ??
+      getStoredReferralCode();
 
     if (referral_code) authUrl.searchParams.set('referral_code', referral_code);
 

--- a/apps/web/src/features/block-email/component/BaseInput.tsx
+++ b/apps/web/src/features/block-email/component/BaseInput.tsx
@@ -27,7 +27,7 @@ import {
   ENABLE_EMAIL_SIGNATURES_FLAG,
   ENABLE_EMAIL_SIGNATURES_OVERRIDE,
 } from '@core/constant/featureFlags';
-import { useEmail } from '@core/context/user';
+import { useEmail, useReferralCode } from '@core/context/user';
 import { fileFolderDrop } from '@core/directive/fileFolderDrop';
 import { fileSelector } from '@core/directive/fileSelector';
 import { registerHotkey, useHotkeyDOMScope } from '@core/hotkey/hotkeys';
@@ -35,6 +35,7 @@ import { TOKENS } from '@core/hotkey/tokens';
 import { isMobile } from '@core/mobile/isMobile';
 import { isNativeMobilePlatform } from '@core/mobile/isNativeMobilePlatform';
 import { useTouchOutsideToDismissKeyboard } from '@core/mobile/useTouchOutsideToDismissKeyboard';
+import { referralLandingUrl } from '@core/referral';
 import { trackMention } from '@core/signal/mention';
 import { plural } from '@core/util/string';
 import { handleFileFolderDrop } from '@core/util/upload';
@@ -82,6 +83,7 @@ import type {
 } from '@service-email/generated/schemas';
 import { isIOS } from '@solid-primitives/platform';
 import { Button, cn, Layer, SendButton, Surface, Tooltip } from '@ui';
+import { emailWatermarkEnabled } from '@ui/signals/signals';
 import { $addUpdateTag, $getRoot } from 'lexical';
 import {
   type Accessor,
@@ -962,6 +964,7 @@ export function BaseInput(props: {
   });
 
   const hasPaidAccess = useHasPaidAccess();
+  const referralCode = useReferralCode();
 
   // Set up hotkey scope for the compose message component
   const [attachComposeHotkeys, composeHotkeyScope] =
@@ -1062,7 +1065,11 @@ export function BaseInput(props: {
     // leave orphaned watermark nodes in the editor tree.
     const cleanupWatermark = $appendWatermarkNodeToLast(
       currentEditor,
-      !hasPaidAccess() ? MACRO_EMAIL_SIGNATURE : undefined
+      !hasPaidAccess() || emailWatermarkEnabled()
+        ? MACRO_EMAIL_SIGNATURE
+        : undefined,
+      true,
+      referralLandingUrl(referralCode())
     );
 
     const replyingTo = props.replyingTo();
@@ -2085,7 +2092,7 @@ export function BaseInput(props: {
               </Tooltip>
             </div>
           </Show>
-          <Show when={!hasPaidAccess()}>
+          <Show when={!hasPaidAccess() || emailWatermarkEnabled()}>
             <div class="text-ink/50 mt-[1lh]" data-watermark>
               <MacroSignatureButton />
             </div>

--- a/apps/web/src/features/block-email/component/MacroSignatureButton.tsx
+++ b/apps/web/src/features/block-email/component/MacroSignatureButton.tsx
@@ -2,35 +2,100 @@ import { MACRO_EMAIL_SIGNATURE } from '@block-email/constants';
 import { useHasPaidAccess } from '@core/auth';
 import { PaywallKey, usePaywallState } from '@core/constant/PaywallState';
 import { useUserContext } from '@core/context/user';
-import { Tooltip } from '@ui';
-import { Show } from 'solid-js';
+import { Button, Dialog, Panel, Tooltip } from '@ui';
+import {
+  emailWatermarkEnabled,
+  setEmailWatermarkEnabled,
+} from '@ui/signals/signals';
+import { createSignal, Show } from 'solid-js';
 
 interface MacroSignatureButtonProps {
   signature?: string;
 }
 
+/**
+ * The "Sent from my Macro" watermark preview shown in the compose footer.
+ *
+ * - Free users: clicking opens the remove-signature paywall (unchanged).
+ * - Paid users: the watermark doubles as their referral link, on by default.
+ *   Clicking opens a confirmation explaining the referral reward before
+ *   letting them turn it off (re-enable any time in Settings → Connections).
+ */
 export const MacroSignatureButton = (props: MacroSignatureButtonProps) => {
   const paywall = usePaywallState();
   const hasPaidAccess = useHasPaidAccess();
   const { isLoading } = useUserContext();
+  const [confirmOpen, setConfirmOpen] = createSignal(false);
+
   return (
-    <Show when={!isLoading() && !hasPaidAccess()}>
-      <Tooltip label="Subscribe to remove watermark">
+    <Show when={!isLoading() && (!hasPaidAccess() || emailWatermarkEnabled())}>
+      <Tooltip
+        label={
+          hasPaidAccess()
+            ? 'This is your referral link — click to remove'
+            : 'Subscribe to remove watermark'
+        }
+      >
         <button
           type="button"
           class="hover:bg-hover pointer-events-all"
           tabindex={-1}
           // The text area uses non delegated events to capture on click and restore focus
-          // to the editor. We want to capture the click here so we can open the paywall.
-          // That's why we use `on:click` instead of `onClick`
+          // to the editor. We want to capture the click here so we can open the paywall
+          // (or the referral confirmation). That's why we use `on:click` instead of `onClick`
           on:click={(e) => {
             e.stopImmediatePropagation();
-            paywall.showPaywall(PaywallKey.REMOVE_SIGNATURE);
+            if (hasPaidAccess()) {
+              setConfirmOpen(true);
+            } else {
+              paywall.showPaywall(PaywallKey.REMOVE_SIGNATURE);
+            }
           }}
         >
           {props.signature ?? MACRO_EMAIL_SIGNATURE}
         </button>
       </Tooltip>
+      <Dialog
+        open={confirmOpen()}
+        onOpenChange={setConfirmOpen}
+        position="center"
+        class="w-120"
+      >
+        <Panel depth={2} class="rounded-xl">
+          <Panel.Header class="px-6">
+            <Dialog.Title class="text-ink text-sm font-semibold">
+              Remove your referral link?
+            </Dialog.Title>
+          </Panel.Header>
+          <Panel.Body class="p-6 font-sans flex flex-col gap-3">
+            <Dialog.Description class="text-ink-muted text-sm/tight font-normal">
+              "{MACRO_EMAIL_SIGNATURE}" is your personal referral link — when
+              someone signs up through it, you get $100 in credits. Removing it
+              turns it off for all future emails. You can turn it back on in
+              Settings → Connections.
+            </Dialog.Description>
+            <div class="pt-3 justify-end items-center gap-3 inline-flex">
+              <Button
+                variant="base"
+                depth={3}
+                onClick={() => setConfirmOpen(false)}
+              >
+                Keep it
+              </Button>
+              <Button
+                variant="active"
+                depth={3}
+                onClick={() => {
+                  setEmailWatermarkEnabled(false);
+                  setConfirmOpen(false);
+                }}
+              >
+                Remove
+              </Button>
+            </div>
+          </Panel.Body>
+        </Panel>
+      </Dialog>
     </Show>
   );
 };

--- a/apps/web/src/features/block-email/component/compose/Compose.tsx
+++ b/apps/web/src/features/block-email/component/compose/Compose.tsx
@@ -33,8 +33,10 @@ import {
   ENABLE_EMAIL_SIGNATURES_FLAG,
   ENABLE_EMAIL_SIGNATURES_OVERRIDE,
 } from '@core/constant/featureFlags';
+import { useReferralCode } from '@core/context/user';
 import { isMobile } from '@core/mobile/isMobile';
 import { WrapUnlessMobile } from '@core/mobile/WrapUnlessMobile';
+import { referralLandingUrl } from '@core/referral';
 import { useCombinedRecipients } from '@core/signal/useCombinedRecipient';
 import {
   type ContactInfo,
@@ -74,6 +76,7 @@ import { invalidateSoupEntity, refetchSoupEntity } from '@queries/soup/cache';
 import { emailClient } from '@service-email/client';
 import { debounce } from '@solid-primitives/scheduled';
 import { Surface } from '@ui';
+import { emailWatermarkEnabled } from '@ui/signals/signals';
 
 import type { LexicalEditor } from 'lexical';
 import {
@@ -113,6 +116,7 @@ type EmailComposeProps = {
 
 export function EmailCompose(props: EmailComposeProps) {
   const hasPaidAccess = useHasPaidAccess();
+  const referralCode = useReferralCode();
   const emailLinksQuery = useEmailLinksQuery();
   const uploadAttachmentMutation = useUploadDraftAttachmentsMutation();
   const saveDraftMutation = useSaveDraftMutation();
@@ -520,7 +524,11 @@ export function EmailCompose(props: EmailComposeProps) {
     // leave orphaned watermark nodes in the editor tree.
     const cleanupWatermark = $appendWatermarkNodeToLast(
       currentEditor,
-      !hasPaidAccess() ? MACRO_EMAIL_SIGNATURE : undefined
+      !hasPaidAccess() || emailWatermarkEnabled()
+        ? MACRO_EMAIL_SIGNATURE
+        : undefined,
+      true,
+      referralLandingUrl(referralCode())
     );
 
     const prepared = prepareEmailBody(currentEditor);

--- a/apps/web/src/features/block-email/component/compose/ComposeBody.tsx
+++ b/apps/web/src/features/block-email/component/compose/ComposeBody.tsx
@@ -170,9 +170,7 @@ export function ComposeBody(props: {
               class="text-sm wrap-break-word text-ink h-auto overflow-visible"
               editable={() => !ctx.disabled()}
               placeholder="Use `@` to reference files"
-              watermark={
-                !ctx.hasPaidAccess() ? <MacroSignatureButton /> : undefined
-              }
+              watermark={<MacroSignatureButton />}
               onChange={ctx.onContentChange}
               onUserMention={(mention) => {
                 addUserMentionToCc({

--- a/apps/web/src/features/block-email/constants.ts
+++ b/apps/web/src/features/block-email/constants.ts
@@ -2,7 +2,7 @@ export const URL_PARAMS = {
   messageId: 'email_message_id',
 };
 
-export const MACRO_EMAIL_SIGNATURE = '-- Sent with Macro';
+export const MACRO_EMAIL_SIGNATURE = 'Sent from my Macro';
 
 export const MAX_ATTACHMENTS_BYTES_SIZE = 18_000_000;
 

--- a/apps/web/src/features/settings/Email.tsx
+++ b/apps/web/src/features/settings/Email.tsx
@@ -1,5 +1,6 @@
 import { openAddInboxDialog } from '@app/features/inbox/AddInboxDialog';
 import { useFeatureFlag } from '@app/lib/analytics/posthog';
+import { useHasPaidAccess } from '@core/auth';
 import { toast } from '@core/component/Toast/Toast';
 import {
   ENABLE_EMAIL_SIGNATURES_FLAG,
@@ -32,7 +33,11 @@ import {
   type Link as EmailLink,
   SyncStatus,
 } from '@service-email/generated/schemas';
-import { Button, Dialog, Panel, Tooltip } from '@ui';
+import { Button, Dialog, Panel, ToggleSwitch, Tooltip } from '@ui';
+import {
+  emailWatermarkEnabled,
+  setEmailWatermarkEnabled,
+} from '@ui/signals/signals';
 import { createMemo, createSignal, For, Match, Show, Switch } from 'solid-js';
 import { match } from 'ts-pattern';
 import { ConnectAction, StatusDot } from './integration-ui';
@@ -53,6 +58,7 @@ import {
 export function EmailCard() {
   const email = useEmail();
   const userId = useUserId();
+  const hasPaidAccess = useHasPaidAccess();
   const multiInboxFlag = useFeatureFlag('enable-multi-inbox', {
     enabledOverride: ENABLE_MULTI_INBOX_OVERRIDE,
   });
@@ -232,6 +238,18 @@ export function EmailCard() {
               </Tooltip>
             </SettingsRow>
           </Show>
+        </Show>
+        <Show when={hasPaidAccess()}>
+          <SettingsRow
+            label="Referral link in emails"
+            description='Append "Sent from my Macro" with your referral link to outgoing emails — you get $100 in credits when someone subscribes through it.'
+          >
+            <ToggleSwitch
+              size="md"
+              onChange={setEmailWatermarkEnabled}
+              checked={emailWatermarkEnabled()}
+            />
+          </SettingsRow>
         </Show>
       </SettingsCard>
 

--- a/apps/web/src/index.tsx
+++ b/apps/web/src/index.tsx
@@ -6,6 +6,7 @@ import '@fontsource-variable/playfair-display';
 // import 'solid-devtools';
 import { initializeLexical } from '@core/component/LexicalMarkdown/init';
 import { isTouchDevice } from '@core/mobile/isTouchDevice';
+import { captureReferralCodeFromUrl } from '@core/referral';
 import { getPlatform, isTauri } from '@core/util/platform';
 import { platformFetch } from '@core/util/platformFetch';
 import { initMonochromeIcons } from '@ui/utils/monochromeIcons';
@@ -31,6 +32,9 @@ if (isTauri()) {
 
 initializeLexical();
 initMonochromeIcons();
+// Persist any ?referral_code= from the landing URL so it survives navigation
+// and is still attributed if the user signs up later.
+captureReferralCodeFromUrl();
 
 const renderApp = () => {
   const root = document.getElementById('root');

--- a/apps/web/src/lib/core/auth/email.ts
+++ b/apps/web/src/lib/core/auth/email.ts
@@ -1,5 +1,6 @@
 import { ROUTER_BASE } from '@app/constants/routerBase';
 import { SERVER_HOSTS } from '@core/constant/servers';
+import { resolveReferralCode } from '@core/referral';
 
 export const GOOGLE_GMAIL_IDP = 'google_gmail';
 type IDPName = 'google_gmail';
@@ -16,9 +17,7 @@ export function emailAuthUrl(params: EmailAuthParams) {
   const url = new URL(`${SERVER_HOSTS['auth-service']}/login/sso`);
   url.searchParams.set('idp_name', idpName);
   url.searchParams.set('original_url', returnUrl);
-  const referral_code = new URL(window.location.href).searchParams.get(
-    'referral_code'
-  );
+  const referral_code = resolveReferralCode();
   if (referral_code) url.searchParams.set('referral_code', referral_code);
   return url.toString();
 }

--- a/apps/web/src/lib/core/auth/sso.ts
+++ b/apps/web/src/lib/core/auth/sso.ts
@@ -1,5 +1,6 @@
 import { SERVER_HOSTS } from '@core/constant/servers';
 import { isNativeMobilePlatform } from '@core/mobile/isNativeMobilePlatform';
+import { resolveReferralCode } from '@core/referral';
 import { unsetTokenPromise } from '@core/util/fetchWithToken';
 
 import { getNativeMobilePlatform } from '@core/util/platform';
@@ -28,9 +29,7 @@ export async function startSsoLogin(
   const authUrl = new URL(`${SERVER_HOSTS['auth-service']}/login/sso`);
   authUrl.searchParams.set('idp_name', idpName);
 
-  const referralCode = new URL(window.location.href).searchParams.get(
-    'referral_code'
-  );
+  const referralCode = resolveReferralCode();
   if (referralCode) authUrl.searchParams.set('referral_code', referralCode);
   if (params.loginHint)
     authUrl.searchParams.set('login_hint', params.loginHint);

--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/Watermark.tsx
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/Watermark.tsx
@@ -1,14 +1,30 @@
 import type { WatermarkDecoratorProps } from '@macro-inc/lexical-core/nodes/WatermarkNode';
-import type { Component } from 'solid-js';
+import { type Component, Show } from 'solid-js';
 
 export const Watermark: Component<WatermarkDecoratorProps> = (props) => {
   return (
-    <span
-      class="select-none macro-watermark-node text-ink/50"
-      inert
-      data-watermark
+    <Show
+      when={props.href}
+      fallback={
+        <span
+          class="select-none macro-watermark-node text-ink/50"
+          inert
+          data-watermark
+        >
+          {props.content}
+        </span>
+      }
     >
-      {props.content}
-    </span>
+      <a
+        class="select-none macro-watermark-node text-ink/50 underline"
+        inert
+        data-watermark
+        href={props.href}
+        target="_blank"
+        rel="noopener"
+      >
+        {props.content}
+      </a>
+    </Show>
   );
 };

--- a/apps/web/src/lib/core/referral.ts
+++ b/apps/web/src/lib/core/referral.ts
@@ -1,0 +1,103 @@
+/**
+ * Referral-code persistence.
+ *
+ * A referral code historically only survived as a `?referral_code=` URL param,
+ * so it was lost whenever a referred visitor browsed away from the signup URL
+ * (e.g. landed on the marketing site first). These helpers persist the code
+ * (last touch wins) so it can be recovered at signup time.
+ *
+ * Storage layers, newest-touch-first on read:
+ * - `macro_ref` cookie — set with `Domain=.macro.com` when running on a
+ *   macro.com host so it is shared with the marketing site (which sets the
+ *   same cookie on landing; see solid-site). Note Safari ITP caps
+ *   JS-set cookies at ~7 days.
+ * - `macro_referral_code` localStorage — same-origin fallback (also covers
+ *   non-macro.com hosts and environments that block third-party cookies).
+ */
+
+const STORAGE_KEY = 'macro_referral_code';
+const COOKIE_NAME = 'macro_ref';
+const COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 30; // 30 days
+
+function readCookie(name: string): string | undefined {
+  try {
+    for (const part of document.cookie.split(';')) {
+      const [k, ...rest] = part.trim().split('=');
+      if (k === name) {
+        const value = decodeURIComponent(rest.join('='));
+        if (value) return value;
+      }
+    }
+  } catch {
+    // document.cookie can throw in sandboxed contexts
+  }
+  return undefined;
+}
+
+/** Persist a referral code to localStorage and (on macro.com hosts) a domain-wide cookie. Last touch wins. */
+export function persistReferralCode(code: string) {
+  if (!code) return;
+  try {
+    localStorage.setItem(STORAGE_KEY, code);
+  } catch {
+    // storage may be unavailable (private mode / blocked)
+  }
+  try {
+    const host = window.location.hostname;
+    const onMacroDomain = host === 'macro.com' || host.endsWith('.macro.com');
+    const attrs = [
+      `Max-Age=${COOKIE_MAX_AGE_SECONDS}`,
+      'Path=/',
+      'SameSite=Lax',
+      ...(onMacroDomain ? ['Domain=.macro.com', 'Secure'] : []),
+    ];
+    document.cookie = `${COOKIE_NAME}=${encodeURIComponent(code)}; ${attrs.join('; ')}`;
+  } catch {
+    // ignore — localStorage above is the fallback
+  }
+}
+
+/** Referral code previously stored by the app or the marketing site. */
+export function getStoredReferralCode(): string | undefined {
+  const fromCookie = readCookie(COOKIE_NAME);
+  if (fromCookie) return fromCookie;
+  try {
+    return localStorage.getItem(STORAGE_KEY) ?? undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * The referral code to attach to a login/signup request.
+ * The current URL's `referral_code` param wins (and is persisted as the
+ * latest touch); otherwise falls back to the stored code.
+ */
+export function resolveReferralCode(): string | undefined {
+  const fromUrl = new URL(window.location.href).searchParams.get(
+    'referral_code'
+  );
+  if (fromUrl) {
+    persistReferralCode(fromUrl);
+    return fromUrl;
+  }
+  return getStoredReferralCode();
+}
+
+/** Capture a referral code from the current URL, if present, without reading it back. */
+export function captureReferralCodeFromUrl() {
+  const fromUrl = new URL(window.location.href).searchParams.get(
+    'referral_code'
+  );
+  if (fromUrl) persistReferralCode(fromUrl);
+}
+
+/**
+ * Marketing-site landing URL carrying a referral code (used as the email
+ * watermark link). The marketing site + app persist the code so the credit
+ * survives until the recipient signs up.
+ */
+export function referralLandingUrl(code: string | undefined): string {
+  if (!code) return 'https://macro.com/';
+  return `https://macro.com/?referral_code=${encodeURIComponent(code)}`;
+}

--- a/packages/lexical-core/nodes/WatermarkNode.ts
+++ b/packages/lexical-core/nodes/WatermarkNode.ts
@@ -18,6 +18,8 @@ import { $applyIdFromSerialized } from '../plugins/nodeIdPlugin';
 
 export type WatermarkInfo = {
   content: string;
+  /** When set, the watermark is exported as a link (e.g. the sender's referral URL). */
+  href?: string;
 };
 
 export type SerializedWatermarkNode = Spread<
@@ -27,6 +29,7 @@ export type SerializedWatermarkNode = Spread<
 
 export type WatermarkDecoratorProps = {
   content: string;
+  href?: string;
   key: NodeKey;
   theme: EditorThemeClasses;
 };
@@ -35,6 +38,7 @@ export class WatermarkNode extends DecoratorNode<
   DecoratorComponent<WatermarkDecoratorProps> | undefined
 > {
   __content: string;
+  __href?: string;
 
   static getType() {
     return 'watermark';
@@ -53,17 +57,19 @@ export class WatermarkNode extends DecoratorNode<
   }
 
   static clone(node: WatermarkNode) {
-    return new WatermarkNode(node.__content, node.__key);
+    return new WatermarkNode(node.__content, node.__href, node.__key);
   }
 
-  constructor(content: string, key?: NodeKey) {
+  constructor(content: string, href?: string, key?: NodeKey) {
     super(key);
     this.__content = content;
+    this.__href = href;
   }
 
   static importJSON(serializedNode: SerializedWatermarkNode) {
     const node = $createWatermarkNode({
       content: serializedNode.content,
+      href: serializedNode.href,
     });
     $applyIdFromSerialized(node, serializedNode);
     return node;
@@ -73,6 +79,7 @@ export class WatermarkNode extends DecoratorNode<
     return {
       ...super.exportJSON(),
       content: this.__content,
+      href: this.__href,
       type: WatermarkNode.getType(),
       version: 1,
     };
@@ -81,6 +88,7 @@ export class WatermarkNode extends DecoratorNode<
   exportComponentProps(): WatermarkInfo {
     return {
       content: this.__content,
+      href: this.__href,
     };
   }
 
@@ -97,37 +105,48 @@ export class WatermarkNode extends DecoratorNode<
     return {
       'data-watermark': true,
       'data-content': this.__content,
+      ...(this.__href ? { 'data-href': this.__href } : {}),
     };
   }
 
-  static importDOM(): DOMConversionMap<HTMLSpanElement> | null {
-    return {
-      span: (domNode: HTMLSpanElement) => {
-        if (!domNode.hasAttribute('data-watermark')) {
-          return null;
-        }
-        return {
-          conversion: (domNode: HTMLElement) => {
-            const content = domNode.getAttribute('data-content');
+  static importDOM(): DOMConversionMap<HTMLElement> | null {
+    const conversionEntry = (domNode: HTMLElement) => {
+      if (!domNode.hasAttribute('data-watermark')) {
+        return null;
+      }
+      return {
+        conversion: (domNode: HTMLElement) => {
+          const content = domNode.getAttribute('data-content');
 
-            if (content) {
-              const node = $createWatermarkNode({
-                content,
-              });
-              return { node };
-            }
-            return null;
-          },
-          priority: 1,
-        };
-      },
+          if (content) {
+            const node = $createWatermarkNode({
+              content,
+              href: domNode.getAttribute('data-href') ?? undefined,
+            });
+            return { node };
+          }
+          return null;
+        },
+        priority: 1 as const,
+      };
+    };
+    return {
+      span: conversionEntry,
+      a: conversionEntry,
     };
   }
 
   exportDOM() {
-    const element = document.createElement('span');
+    const element = this.__href
+      ? document.createElement('a')
+      : document.createElement('span');
     for (const [k, v] of Object.entries(this.getDataAttrs())) {
       element.setAttribute(k, v.toString());
+    }
+    if (this.__href && element instanceof HTMLAnchorElement) {
+      element.href = this.__href;
+      element.target = '_blank';
+      element.rel = 'noopener';
     }
     element.className = 'macro-watermark-node';
     element.textContent = this.__content;
@@ -150,6 +169,10 @@ export class WatermarkNode extends DecoratorNode<
     return this.__content;
   }
 
+  getHref() {
+    return this.__href;
+  }
+
   decorate(_: LexicalEditor, config: EditorConfig) {
     const decorator = getDecorator<WatermarkDecoratorProps>(WatermarkNode);
     if (decorator) {
@@ -163,8 +186,11 @@ export class WatermarkNode extends DecoratorNode<
   }
 }
 
-export function $createWatermarkNode(params: { content: string }) {
-  const node = new WatermarkNode(params.content);
+export function $createWatermarkNode(params: {
+  content: string;
+  href?: string;
+}) {
+  const node = new WatermarkNode(params.content, params.href);
   return $applyNodeReplacement(node);
 }
 
@@ -198,7 +224,8 @@ export function $removeAllWatermarkNodes(editor: LexicalEditor | undefined) {
 export function $appendWatermarkNodeToLast(
   editor: LexicalEditor | undefined,
   content: string | undefined,
-  sync = true
+  sync = true,
+  href?: string
 ) {
   let nodeKey: string | undefined;
 
@@ -206,7 +233,7 @@ export function $appendWatermarkNodeToLast(
     () => {
       if (!content) return;
 
-      const node = $createWatermarkNode({ content });
+      const node = $createWatermarkNode({ content, href });
 
       nodeKey = node.getKey();
 

--- a/packages/lexical-core/transformers/watermark.ts
+++ b/packages/lexical-core/transformers/watermark.ts
@@ -20,6 +20,7 @@ export const I_WATERMARK: ElementTransformer = {
 
     const data = JSON.stringify({
       content: node.getContent(),
+      ...(node.getHref() ? { href: node.getHref() } : {}),
     });
 
     return `<m-watermark>${data}</m-watermark>`;
@@ -31,7 +32,10 @@ export const I_WATERMARK: ElementTransformer = {
         if (!(field in data)) throw new Error(`Missing field ${field}`);
       }
 
-      const watermarkNode = $createWatermarkNode({ content: data.content });
+      const watermarkNode = $createWatermarkNode({
+        content: data.content,
+        href: typeof data.href === 'string' ? data.href : undefined,
+      });
       parent.append(watermarkNode);
     } catch (e) {
       console.error('Error in I_WATERMARK replace:', e);


### PR DESCRIPTION
# Summary

Turns the free-user email watermark into a growth loop: **"Sent from my Macro"**, hyperlinked to the **sender's referral landing URL** (`https://macro.com/?referral_code=<code>`), and now on for **paid users too** (default-on, freely removable).

Companion PR in `solid-site` captures `?referral_code=` on the marketing site so the credit survives the homepage detour.

## What changed

**Watermark copy + link** (`constants.ts`, `WatermarkNode.ts`, `transformers/watermark.ts`, `Watermark.tsx`)
- `-- Sent with Macro` → `Sent from my Macro` (drops the `--` signature-delimiter prefix so clients don't trim it)
- `WatermarkNode` gains an optional `href`, carried through JSON / DOM / markdown serialization. Outgoing email HTML exports it as `<a href target="_blank" rel="noopener">`; `importDOM` round-trips both `span` and `a` forms (drafts re-import their HTML). Editor decorator renders it as an (inert) link.

**Paid users get the watermark too — with a graceful exit** (`MacroSignatureButton.tsx`, `signals.ts`, `settings/Email.tsx`)
- New persisted setting `email.watermarkEnabled` (default **on**)
- Free users: unchanged — click opens the remove-signature paywall
- Paid users: click opens a one-time confirm modal — "this is your personal referral link, you get **$100 in credits** when someone signs up through it" — before turning it off. Re-enable any time via a new toggle in Settings → Connections (Gmail card).

**Send paths** (`Compose.tsx`, `BaseInput.tsx`, `ComposeBody.tsx`)
- Watermark appends when `!hasPaidAccess() || emailWatermarkEnabled()`, passing `referralLandingUrl(useReferralCode())` as the href

**Referral-code persistence** (`lib/core/referral.ts` — new)
- Previously the code only survived as a URL param, so any navigation away from `/app/signup?referral_code=X` dropped the credit
- Now captured at app boot into localStorage (`macro_referral_code`) + a `.macro.com` cookie (`macro_ref`, 30-day Max-Age, last-touch wins; shared with the marketing site). Safari ITP caps JS cookies at ~7 days — localStorage covers same-origin
- All four login/SSO paths (`EmailForm.tsx`, `useSsoLogin.ts`, `auth/email.ts`, `auth/sso.ts`) now fall back to the stored code when the URL param is absent (URL param still wins)

## Notes for reviewers
- The link points at the **marketing site homepage**, not `/app/signup` — higher CTR for curious recipients; the solid-site companion PR + the persistence above make sure the code still attributes at signup.
- `body_macro` (internal markdown) also carries the href via the `<m-watermark>` transformer; the external markdown export still flattens to plain text.
- Received-email rendering of the watermark anchor is inert in-editor (no accidental navigation while composing).

## Testing
- Biome check/format passed on all touched files.
- `bun install` fails in this environment (private GitHub tarball deps return 403), so web typecheck rides CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_018w42MgveYTevk9p9Y8F425)_