### PR TITLE
fix(email/mobile): scope forward recipient dropdowns to the drawer

### DIFF
--- a/apps/web/src/features/block-email/component/BaseInput.tsx
+++ b/apps/web/src/features/block-email/component/BaseInput.tsx
@@ -1828,6 +1828,7 @@ export function BaseInput(props: {
             <div class="shrink-0 text-ink-placeholder">To:</div>
             <RecipientSelector<EmailRecipient['kind']>
               openOnFocus={false}
+              portalScope={composePortalScope()}
               class={mobileRecipientSelectorClass}
               inputRef={setToRef}
               options={ctx.recipientOptions}
@@ -1871,6 +1872,7 @@ export function BaseInput(props: {
               <div class="shrink-0 text-ink-placeholder">Cc:</div>
               <RecipientSelector<EmailRecipient['kind']>
                 openOnFocus={false}
+                portalScope={composePortalScope()}
                 class={mobileRecipientSelectorClass}
                 inputRef={setCcRef}
                 options={ctx.recipientOptions}
@@ -1900,6 +1902,7 @@ export function BaseInput(props: {
               <div class="shrink-0 text-ink-placeholder">Bcc:</div>
               <RecipientSelector<EmailRecipient['kind']>
                 openOnFocus={false}
+                portalScope={composePortalScope()}
                 class={mobileRecipientSelectorClass}
                 inputRef={setBccRef}
                 options={ctx.recipientOptions}

--- a/apps/web/src/features/block-email/component/MobileEmailComposeDrawer.tsx
+++ b/apps/web/src/features/block-email/component/MobileEmailComposeDrawer.tsx
@@ -47,6 +47,13 @@ export function MobileEmailComposeDrawer(props: {
           preventScroll={false}
           preventScrollbarShift={false}
           breakPoints={[0.85]}
+          // corvu's focus trap runs a MutationObserver that re-grabs focus to
+          // the drawer's first focusable element whenever the subtree mutates
+          // and activeElement is <body>. Tapping a recipient suggestion blurs
+          // the input (→ body) and mutates the DOM (dropdown closes / chip
+          // inserts), so focus is stolen and the selection is torn down before
+          // it lands. Disable the trap so recipient selection works on mobile.
+          trapFocus={false}
         >
           <MobileDrawer.Portal>
             <MobileDrawer.Overlay class="fixed inset-0 z-modal-overlay bg-modal-overlay pattern-diagonal-4 pattern-edge-muted" />

--- a/apps/web/src/lib/core/component/RecipientSelector.tsx
+++ b/apps/web/src/lib/core/component/RecipientSelector.tsx
@@ -296,13 +296,19 @@ export function RecipientSelector<K extends CombinedRecipientKind>(
   const [portalSearchRef, setPortalSearchRef] = createSignal<
     HTMLDivElement | undefined
   >();
+  const [portalMount, setPortalMount] = createSignal<HTMLElement | undefined>();
 
-  const portalMount = () => {
-    if (props.portalScope !== 'local') return undefined;
-    return (
+  // Resolve the local portal target once the anchor is attached to the DOM.
+  // `.closest()` on a not-yet-connected node returns null, so resolving this as
+  // a derived getter during render would permanently see no `.portal-scope` and
+  // the dropdown would never mount.
+  onMount(() => {
+    if (props.portalScope !== 'local') return;
+    setPortalMount(
       portalSearchRef()?.closest<HTMLElement>('.portal-scope') ?? undefined
     );
-  };
+  });
+
   const shouldRenderPortal = () =>
     props.portalScope !== 'local' || portalMount() !== undefined;
 

--- a/apps/web/src/lib/core/component/RecipientSelector.tsx
+++ b/apps/web/src/lib/core/component/RecipientSelector.tsx
@@ -815,7 +815,13 @@ export function RecipientSelector<K extends CombinedRecipientKind>(
         <Show when={shouldRenderPortal()}>
           <Combobox.Portal mount={portalMount()}>
             <Layer depth={2}>
-              <Combobox.Content class="z-modal-content bg-surface translate-y-1 border-edge p-2 rounded-xl shadow-lg shadow-drop-shadow ring ring-edge">
+              <Combobox.Content
+                // When portaled into a corvu drawer (mobile reply/forward), the
+                // drawer treats a touch on the dropdown as a drag (0.3px
+                // threshold) and cancels the tap. Opt this subtree out of drag.
+                data-corvu-no-drag=""
+                class="z-modal-content bg-surface translate-y-1 border-edge p-2 rounded-xl shadow-lg shadow-drop-shadow ring ring-edge"
+              >
                 <Combobox.Listbox
                   ref={setListboxRef}
                   class="flex flex-col gap-1"

--- a/apps/web/src/lib/core/component/RecipientSelector.tsx
+++ b/apps/web/src/lib/core/component/RecipientSelector.tsx
@@ -820,6 +820,15 @@ export function RecipientSelector<K extends CombinedRecipientKind>(
                 // drawer treats a touch on the dropdown as a drag (0.3px
                 // threshold) and cancels the tap. Opt this subtree out of drag.
                 data-corvu-no-drag=""
+                // On touch, Kobalte selects a listbox option on `click`, but
+                // tapping a (non-focusable) option first blurs the input, which
+                // tears down the listbox before that click lands — so nothing is
+                // selected. Preventing the pointerdown default keeps input focus
+                // (suppresses the compat mousedown/blur) while the click still
+                // fires, so the option selects.
+                onPointerDown={(e) => {
+                  if (e.pointerType !== 'mouse') e.preventDefault();
+                }}
                 class="z-modal-content bg-surface translate-y-1 border-edge p-2 rounded-xl shadow-lg shadow-drop-shadow ring ring-edge"
               >
                 <Combobox.Listbox


### PR DESCRIPTION
## Problem

On **mobile only**, in the email reply/forward drawer, picking a recipient from the To/Cc/Bcc suggestion dropdown did nothing — the chip never populated the field. Instead you'd see the email thread behind the drawer flicker/reset its scroll, as if the tap landed on the content underneath.

## Root cause

The mobile reply/forward composer renders inside a corvu `Drawer.Content` modal (which carries the `.portal-scope` class). The To/Cc/Bcc `RecipientSelector`s were portaling their suggestion dropdown to `document.body` — *outside* the drawer modal — because they didn't pass a `portalScope`.

On touch, tapping an option that lives outside the modal is treated as an interaction with the content behind the drawer: the thread receives the touch (scroll resets) and the combobox's selection never completes, so the field stays empty.

The sibling popovers in the same drawer — `FromInboxSelector` and the body `@`-mention selector — already pass `portalScope="local"` so their dropdowns mount inside `.portal-scope`. The recipient selectors were added later (in the forward-composer PR #4717) and missed that convention.

## Fix

Pass `portalScope={composePortalScope()}` to the three mobile-drawer To/Cc/Bcc `RecipientSelector`s. `composePortalScope()` resolves to `"local"` inside the drawer, so their dropdowns now mount inside the drawer's `.portal-scope` and taps land on the option instead of the thread behind it.

Desktop is unaffected — it doesn't render the composer inside the drawer modal.
