### PR TITLE
fix(mobile): open macro.com app links inside the app instead of the browser

### DIFF
--- a/apps/web/src/lib/tauri/navigation.test.ts
+++ b/apps/web/src/lib/tauri/navigation.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { macroAppLinkToInternalPath } from './navigation';
+
+describe('macroAppLinkToInternalPath', () => {
+  it('converts app links to internal router paths', () => {
+    expect(
+      macroAppLinkToInternalPath(
+        'https://macro.com/app/task/019f7009-4645-763a-9a97-d2411da16659'
+      )
+    ).toBe('/task/019f7009-4645-763a-9a97-d2411da16659');
+    expect(macroAppLinkToInternalPath('https://macro.com/app/md/doc123')).toBe(
+      '/md/doc123'
+    );
+  });
+
+  it('preserves query params', () => {
+    expect(
+      macroAppLinkToInternalPath(
+        'https://macro.com/app/channel/abc?message=def&thread=ghi'
+      )
+    ).toBe('/channel/abc?message=def&thread=ghi');
+  });
+
+  it('handles the bare /app path', () => {
+    expect(macroAppLinkToInternalPath('https://macro.com/app')).toBe('/');
+    expect(macroAppLinkToInternalPath('https://macro.com/app/')).toBe('/');
+  });
+
+  it('converts dev and staging hosts', () => {
+    expect(
+      macroAppLinkToInternalPath('https://dev.macro.com/app/task/123')
+    ).toBe('/task/123');
+    expect(
+      macroAppLinkToInternalPath('https://staging.macro.com/app/task/123')
+    ).toBe('/task/123');
+  });
+
+  it('ignores non-app paths on macro.com', () => {
+    expect(macroAppLinkToInternalPath('https://macro.com/')).toBeNull();
+    expect(
+      macroAppLinkToInternalPath('https://macro.com/blog/post')
+    ).toBeNull();
+    // "/apple" must not match the "/app" prefix
+    expect(macroAppLinkToInternalPath('https://macro.com/apple')).toBeNull();
+  });
+
+  it('ignores other hosts', () => {
+    expect(
+      macroAppLinkToInternalPath('https://example.com/app/task/123')
+    ).toBeNull();
+    expect(
+      macroAppLinkToInternalPath('https://evil-macro.com/app/task/123')
+    ).toBeNull();
+    expect(
+      macroAppLinkToInternalPath('https://sub.macro.com/app/task/123')
+    ).toBeNull();
+  });
+
+  it('ignores non-http(s) schemes and invalid urls', () => {
+    expect(macroAppLinkToInternalPath('mailto:someone@macro.com')).toBeNull();
+    expect(
+      macroAppLinkToInternalPath('tauri://localhost/app/task/123')
+    ).toBeNull();
+    expect(macroAppLinkToInternalPath('/app/task/123')).toBeNull();
+    expect(macroAppLinkToInternalPath('not a url')).toBeNull();
+  });
+});

--- a/apps/web/src/lib/tauri/navigation.ts
+++ b/apps/web/src/lib/tauri/navigation.ts
@@ -1,15 +1,94 @@
 import { useNavigate } from '@solidjs/router';
 import { listen } from '@tauri-apps/api/event';
-import { createEffect, onCleanup } from 'solid-js';
+import { createEffect, onCleanup, onMount } from 'solid-js';
 
 type NavigateEvent = {
   path: string;
   query: string;
 };
 
+/**
+ * Hosts of the hosted web app. Hyperlinks to `/app/...` paths on these hosts
+ * (e.g. https://macro.com/app/task/<id>) are app links and must open inside
+ * the app instead of the web browser.
+ * Keep in sync with APP_LINK_DOMAINS in tauri/src-tauri/src/lib.rs and the
+ * universal link hosts in tauri.conf.json.
+ */
+const APP_LINK_HOSTS = new Set([
+  'macro.com',
+  'dev.macro.com',
+  'staging.macro.com',
+]);
+
+/**
+ * Converts an app link (https://macro.com/app/task/<id>) into the equivalent
+ * internal router path (/task/<id>), mirroring how universal links are
+ * remapped by MacroScheme::from_url on the Rust side (the Tauri router is
+ * based at '/', so the '/app' prefix is stripped).
+ *
+ * Returns null when the url is not an app link.
+ */
+export function macroAppLinkToInternalPath(href: string): string | null {
+  let url: URL;
+  try {
+    url = new URL(href);
+  } catch {
+    return null;
+  }
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') return null;
+  if (!APP_LINK_HOSTS.has(url.hostname)) return null;
+  const path = url.pathname;
+  if (path !== '/app' && !path.startsWith('/app/')) return null;
+  const internalPath = path.slice('/app'.length) || '/';
+  return `${internalPath}${url.search}`;
+}
+
+/**
+ * Intercepts clicks on hyperlinks to the hosted web app and performs an
+ * in-app navigation instead of letting the webview hand them to the OS
+ * (which opens the web browser). Registered on the document in the capture
+ * phase so it runs before per-editor link handlers call window.open.
+ */
+function useAppLinkClickIntercept() {
+  const navigate = useNavigate();
+
+  const handleClick = (e: MouseEvent) => {
+    if (e.defaultPrevented || e.button !== 0) return;
+    if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+
+    // composedPath resolves the real target inside shadow roots (email bodies)
+    const target = e.composedPath()[0];
+    if (!(target instanceof Element)) return;
+    const anchor = target.closest('a[href]');
+    if (!anchor) return;
+    // mention pills already navigate in-app via their own handlers
+    if (anchor.classList.contains('internal-link')) return;
+    // links inside editors open the link-edit popover instead of navigating
+    if ((anchor as HTMLElement).isContentEditable) return;
+
+    const internalPath = macroAppLinkToInternalPath(
+      (anchor as HTMLAnchorElement).href
+    );
+    if (internalPath === null) return;
+
+    e.preventDefault();
+    e.stopPropagation();
+    navigate(internalPath);
+  };
+
+  onMount(() => {
+    document.addEventListener('click', handleClick, { capture: true });
+    onCleanup(() => {
+      document.removeEventListener('click', handleClick, { capture: true });
+    });
+  });
+}
+
 /// this must be used as a child of router
 export function useTauriNavigationEffect() {
   const navigate = useNavigate();
+
+  useAppLinkClickIntercept();
 
   createEffect(() => {
     let unsubscribe: () => void | undefined;

--- a/apps/web/tauri/navigation_plugin/src/lib.rs
+++ b/apps/web/tauri/navigation_plugin/src/lib.rs
@@ -2,7 +2,7 @@ use crate::scheme::MacroScheme;
 use logger::Logger;
 use serde::{Deserialize, Serialize};
 use std::{borrow::Cow, collections::HashMap, path::PathBuf, sync::Arc};
-use tauri::{Manager, Runtime, plugin::Plugin};
+use tauri::{Emitter, Manager, Runtime, plugin::Plugin};
 use tauri_plugin_opener::OpenerExt;
 use url::Url;
 
@@ -53,6 +53,11 @@ pub enum Platform {
 #[derive(Clone)]
 pub struct MacroNavigationPlugin {
     internal_domains: Arc<[Url]>,
+    /// Origins of the hosted web app (e.g. https://macro.com). Navigations to
+    /// `/app/...` paths on these origins are app links: they are converted to
+    /// an in-app `navigate` event instead of loading in the webview or the
+    /// system browser.
+    app_link_domains: Arc<[Url]>,
     allowed_file_prefix: Option<PathBuf>,
 }
 
@@ -77,8 +82,20 @@ impl MacroNavigationPlugin {
                 .iter()
                 .map(|s| s.parse())
                 .collect::<Result<Arc<_>, _>>()?,
+            app_link_domains: Arc::new([]),
             allowed_file_prefix: None,
         })
+    }
+
+    pub fn with_app_link_domains(
+        mut self,
+        domains: &'static [&'static str],
+    ) -> Result<Self, url::ParseError> {
+        self.app_link_domains = domains
+            .iter()
+            .map(|s| s.parse())
+            .collect::<Result<Arc<_>, _>>()?;
+        Ok(self)
     }
 
     pub fn with_allowed_file_prefix(mut self, prefix: PathBuf) -> Self {
@@ -99,6 +116,29 @@ impl MacroNavigationPlugin {
             },
             None => NavigationOutput::Internal(internal),
         }
+    }
+
+    /// Returns the [MacroScheme] conversion for links that point at the hosted
+    /// web app (e.g. `https://macro.com/app/task/<id>`), so they can be routed
+    /// inside the app like a deep link instead of leaving the bundle.
+    #[tracing::instrument(ret, level = tracing::Level::DEBUG, skip(self))]
+    fn as_app_link(&self, url: &Url) -> Option<MacroScheme> {
+        if !matches!(url.scheme(), "http" | "https") {
+            return None;
+        }
+        let is_app_domain = self.app_link_domains.iter().any(|cur| {
+            cur.scheme().eq(url.scheme())
+                && cur.domain().eq(&url.domain())
+                && cur.port().eq(&url.port())
+        });
+        if !is_app_domain {
+            return None;
+        }
+        let path = url.path();
+        if path != "/app" && !path.starts_with("/app/") {
+            return None;
+        }
+        MacroScheme::from_url(url).ok()
     }
 
     #[tracing::instrument(ret, level = tracing::Level::DEBUG, skip(self))]
@@ -129,6 +169,28 @@ impl MacroNavigationPlugin {
             Err(ExternalUrl(Cow::Borrowed(url)))
         }
     }
+}
+
+#[derive(Clone, Serialize, Debug)]
+struct NavigatePayload<'a> {
+    path: &'a str,
+    query: &'a str,
+}
+
+/// Emits the `navigate` event the frontend router listens for, performing an
+/// in-app (client side) navigation to the path of the given [MacroScheme].
+/// We send an event instead of calling `Webview::navigate` because the latter
+/// performs a full browser navigation and reloads the app.
+pub fn emit_navigate<R: Runtime>(
+    handle: &tauri::AppHandle<R>,
+    macro_scheme: &MacroScheme,
+) -> tauri::Result<()> {
+    let payload = NavigatePayload {
+        path: macro_scheme.path(),
+        query: macro_scheme.query().unwrap_or_default(),
+    };
+    tracing::trace!("emitting navigate event {payload:?}");
+    handle.emit("navigate", payload)
 }
 
 #[tracing::instrument(ret, level = tracing::Level::DEBUG)]
@@ -185,6 +247,14 @@ impl<R: Runtime> Plugin<R> for MacroNavigationPlugin {
     }
 
     fn on_navigation(&mut self, webview: &tauri::Webview<R>, url: &tauri::Url) -> bool {
+        // Links to the hosted web app (e.g. https://macro.com/app/task/<id>)
+        // are routed in-app like deep links, rather than letting the webview
+        // navigate away from the bundle or opening the system browser.
+        if let Some(macro_scheme) = self.as_app_link(url) {
+            emit_navigate(webview.app_handle(), &macro_scheme).log_and_consume();
+            return false;
+        }
+
         let dest = self.get_destination(url);
 
         match dest {

--- a/apps/web/tauri/navigation_plugin/src/tests.rs
+++ b/apps/web/tauri/navigation_plugin/src/tests.rs
@@ -71,6 +71,74 @@ fn transform_external_url_preserves_existing_is_mobile_false() {
     );
 }
 
+fn plugin_with_app_links() -> MacroNavigationPlugin {
+    MacroNavigationPlugin::new(&["https://macro.com", "http://localhost:3000"])
+        .unwrap()
+        .with_app_link_domains(&["https://macro.com", "https://dev.macro.com"])
+        .unwrap()
+}
+
+#[test]
+fn as_app_link_converts_app_path_on_app_domain() {
+    let plugin = plugin_with_app_links();
+    let url =
+        Url::parse("https://macro.com/app/task/019f7009-4645-763a-9a97-d2411da16659").unwrap();
+    let result = plugin.as_app_link(&url).unwrap();
+    assert_eq!(result.path(), "/task/019f7009-4645-763a-9a97-d2411da16659");
+    assert_eq!(result.query(), None);
+}
+
+#[test]
+fn as_app_link_preserves_query() {
+    let plugin = plugin_with_app_links();
+    let url = Url::parse("https://macro.com/app/channel/abc?message=def").unwrap();
+    let result = plugin.as_app_link(&url).unwrap();
+    assert_eq!(result.path(), "/channel/abc");
+    assert_eq!(result.query(), Some("message=def"));
+}
+
+#[test]
+fn as_app_link_handles_dev_domain() {
+    let plugin = plugin_with_app_links();
+    let url = Url::parse("https://dev.macro.com/app/md/doc123").unwrap();
+    let result = plugin.as_app_link(&url).unwrap();
+    assert_eq!(result.path(), "/md/doc123");
+}
+
+#[test]
+fn as_app_link_ignores_non_app_paths() {
+    let plugin = plugin_with_app_links();
+    let url = Url::parse("https://macro.com/blog/some-post").unwrap();
+    assert!(plugin.as_app_link(&url).is_none());
+    // "/apple" must not match the "/app" prefix
+    let url = Url::parse("https://macro.com/apple").unwrap();
+    assert!(plugin.as_app_link(&url).is_none());
+}
+
+#[test]
+fn as_app_link_ignores_other_domains() {
+    let plugin = plugin_with_app_links();
+    let url = Url::parse("https://example.com/app/task/123").unwrap();
+    assert!(plugin.as_app_link(&url).is_none());
+    // internal (bundle/dev server) origins are not app link origins
+    let url = Url::parse("http://localhost:3000/app/task/123").unwrap();
+    assert!(plugin.as_app_link(&url).is_none());
+}
+
+#[test]
+fn as_app_link_ignores_non_http_schemes() {
+    let plugin = plugin_with_app_links();
+    let url = Url::parse("tauri://localhost/app/task/123").unwrap();
+    assert!(plugin.as_app_link(&url).is_none());
+}
+
+#[test]
+fn as_app_link_without_configured_domains_matches_nothing() {
+    let plugin = MacroNavigationPlugin::new(&["https://macro.com"]).unwrap();
+    let url = Url::parse("https://macro.com/app/task/123").unwrap();
+    assert!(plugin.as_app_link(&url).is_none());
+}
+
 #[test]
 fn transform_external_url_preserves_other_query_params() {
     let url = Url::parse("https://example.com/path?foo=bar&baz=qux").unwrap();
@@ -88,4 +156,3 @@ fn transform_external_url_preserves_other_query_params() {
         Some((Cow::Borrowed("is_mobile"), Cow::Borrowed("true")))
     );
 }
-

--- a/apps/web/tauri/src-tauri/src/lib.rs
+++ b/apps/web/tauri/src-tauri/src/lib.rs
@@ -9,14 +9,13 @@ use navigation_plugin::scheme::MacroScheme;
 use reqwest::cookie::CookieStore;
 use reqwest::header::{COOKIE, ORIGIN};
 use rootcause::{Report, report};
-use serde::Serialize;
 use share_target::{
     PendingShareFilesState, clear_shared_files, get_pending_share_filenames,
     maybe_handle_share_deep_link, pop_shared_files, read_shared_file_text,
 };
 use staged_upload::cleanup_stale_staged_files;
 use tauri::http::{HeaderMap, HeaderValue};
-use tauri::{AppHandle, Emitter, Manager, RunEvent, Runtime};
+use tauri::{AppHandle, Manager, RunEvent, Runtime};
 
 mod tauri_protocol;
 
@@ -74,6 +73,16 @@ fn embedded_bundle_build() -> u64 {
 /// This module provides debuging utilities and should not be compiled in prodiction builds
 #[cfg(debug_assertions)] // do not remove this
 mod debug;
+
+/// origins of the hosted web app. hyperlinks to `/app/...` paths on these
+/// origins (e.g. https://macro.com/app/task/<id>) are treated as deep links
+/// and routed inside the app instead of opening the web browser.
+/// Keep in sync with the universal link hosts in tauri.conf.json.
+static APP_LINK_DOMAINS: &[&str] = &[
+    "https://macro.com",
+    "https://dev.macro.com",
+    "https://staging.macro.com",
+];
 
 /// domains which the tauri webview can render.
 /// This should be as restrictive as possible.
@@ -171,7 +180,12 @@ pub fn run() {
                 .build(),
         )
         .plugin(tauri_plugin_opener::init())
-        .plugin(MacroNavigationPlugin::new(ALLOWED_DOMAINS).expect("Domains must be valid urls"))
+        .plugin(
+            MacroNavigationPlugin::new(ALLOWED_DOMAINS)
+                .expect("Domains must be valid urls")
+                .with_app_link_domains(APP_LINK_DOMAINS)
+                .expect("App link domains must be valid urls"),
+        )
         .plugin(
             macro_bundle_updater_plugin::inbound::plugin::MacroBundleUpdaterPlugin::new(
                 AppEnvironment::current()
@@ -392,21 +406,7 @@ fn attach_deep_link_handler(app: &mut tauri::App) {
             }
         };
 
-        #[derive(Clone, Serialize, Debug)]
-        struct NavigatePayload<'a> {
-            path: &'a str,
-            query: &'a str,
-        }
-
-        let payload = NavigatePayload {
-            path: macro_scheme.0.path(),
-            query: macro_scheme.0.query().unwrap_or_default(),
-        };
-        // we send a navigate event instead of calling navigate directly
-        // because navigate performs a full browser navigation
-
-        tracing::trace!("{payload:?}");
-        Ok(handle.emit("navigate", payload)?)
+        Ok(navigation_plugin::emit_navigate(handle, &macro_scheme)?)
     }
 
     app.deep_link().on_open_url({

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -142,6 +142,14 @@ export default defineConfig({
         },
       },
       {
+        extends: './src/lib/core/vitest.config.ts',
+        test: {
+          environment: 'jsdom',
+          include: ['src/lib/tauri/**/*.{test,spec}.{ts,tsx}'],
+          name: 'tauri',
+        },
+      },
+      {
         // App-shell and feature tests without a specialized environment.
         extends: './src/lib/core/vitest.config.ts',
         test: {


### PR DESCRIPTION
## Summary

Tapping a hyperlink to `https://macro.com/app/...` inside the mobile app (e.g. a task link in a channel message) opened the web browser instead of navigating inside the app. Only @mention pills were routed in-app; plain hyperlinks were not.

cc @jbecke @evanhutnik

This PR intercepts app links at two layers so every path a link click can take ends in an in-app navigation:

### Frontend (`apps/web/src/lib/tauri/navigation.ts`)
- New `macroAppLinkToInternalPath()` converts `https://{macro,dev.macro,staging.macro}.com/app/<rest>` into the internal router path `/<rest>` (query preserved), mirroring `MacroScheme::from_url` on the Rust side (the Tauri router is based at `/`).
- A Tauri-only, capture-phase `click` listener on `document` resolves the clicked anchor (via `composedPath()`, so links inside shadow-DOM email bodies are covered), and performs a client-side `navigate()` instead of letting the default action / `window.open` hand the URL to the OS. It skips:
  - `.internal-link` mention pills (already handled in-app — this adds the same behavior for links that are *not* @mentions),
  - links inside `contenteditable` editors (clicking those opens the link-edit popover),
  - modified clicks (meta/ctrl/shift/alt) and non-left buttons.

### Tauri navigation plugin (`apps/web/tauri/navigation_plugin`)
- `MacroNavigationPlugin` now takes `with_app_link_domains(...)`; in `on_navigation`, a webview navigation to an app link is cancelled and converted into the same `navigate` event that universal links use. This covers native-level navigations the DOM handler can't see — e.g. the iOS long-press → **Open Link** action — and stops the webview from ever leaving the bundle for the remote macro.com site.
- Extracted a shared `emit_navigate()` helper, now used by both the deep-link handler in `src-tauri/src/lib.rs` and the plugin, so the payload can't drift.

### Note on the mailto: precedent
The request mentioned following the recent `mailto:` intercept, but I could not find one anywhere in `main`, the git history, or any PR (all `mailto` hits are `emailToMacroId` false-positives) — it may not be merged yet. This implementation instead follows the existing universal-link/deep-link pattern (`MacroScheme` → `navigate` event → `useTauriNavigationEffect`), which is the same funnel a scheme intercept would use. Happy to align with the mailto approach if someone can point me at it.

## Testing
- `cargo test -p navigation_plugin`: 15 tests pass, including 7 new tests for app-link classification (app paths, query preservation, dev domain, `/apple` non-prefix, foreign/bundle origins, non-http schemes, unconfigured default).
- `cargo check -p app` and `cargo clippy` pass; `cargo fmt` applied.
- Added `navigation.test.ts` (new `tauri` vitest project) covering the URL→path mapping, including `mailto:`/`tauri:` schemes, look-alike hosts, and bare `/app`. I could not run vitest in this environment (`bun install` 403s on the private `tauri-plugins`/`pdf.js` git deps), but the same 17 cases were verified against the implementation with a standalone bun script; please let CI confirm.
- Not verified on a device — a quick check on an iOS build (tap a macro.com task link in a channel, plus long-press → Open Link) would be appreciated before merging.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw4T8aHJRAph2n48GzmgQp)_