### PR TITLE
fix(email/mobile): recipient dropdown taps not selecting in reply/forward composer

### DIFF
--- a/apps/web/src/features/block-email/component/BaseInput.tsx
+++ b/apps/web/src/features/block-email/component/BaseInput.tsx
@@ -1839,6 +1839,7 @@ export function BaseInput(props: {
               triggerMode="input"
               hideBorder
               noPadding
+              portalScope={composePortalScope()}
               onChipDragStart={(option, e) =>
                 handleChipDragStart('to', option, e)
               }
@@ -1882,6 +1883,7 @@ export function BaseInput(props: {
                 triggerMode="input"
                 hideBorder
                 noPadding
+                portalScope={composePortalScope()}
                 onChipDragStart={(option, e) =>
                   handleChipDragStart('cc', option, e)
                 }
@@ -1911,6 +1913,7 @@ export function BaseInput(props: {
                 triggerMode="input"
                 hideBorder
                 noPadding
+                portalScope={composePortalScope()}
                 onChipDragStart={(option, e) =>
                   handleChipDragStart('bcc', option, e)
                 }

--- a/apps/web/src/lib/core/component/RecipientSelector.tsx
+++ b/apps/web/src/lib/core/component/RecipientSelector.tsx
@@ -297,11 +297,19 @@ export function RecipientSelector<K extends CombinedRecipientKind>(
     HTMLDivElement | undefined
   >();
 
-  const portalMount = () => {
-    if (props.portalScope !== 'local') return undefined;
-    return (
+  // `.portal-scope` must be resolved after mount — during render the element
+  // isn't connected yet, so `closest` finds nothing.
+  const [localPortalMount, setLocalPortalMount] = createSignal<HTMLElement>();
+  onMount(() => {
+    if (props.portalScope !== 'local') return;
+    setLocalPortalMount(
       portalSearchRef()?.closest<HTMLElement>('.portal-scope') ?? undefined
     );
+  });
+
+  const portalMount = () => {
+    if (props.portalScope !== 'local') return undefined;
+    return localPortalMount();
   };
   const shouldRenderPortal = () =>
     props.portalScope !== 'local' || portalMount() !== undefined;
@@ -809,7 +817,21 @@ export function RecipientSelector<K extends CombinedRecipientKind>(
         <Show when={shouldRenderPortal()}>
           <Combobox.Portal mount={portalMount()}>
             <Layer depth={2}>
-              <Combobox.Content class="z-modal-content bg-surface translate-y-1 border-edge p-2 rounded-xl shadow-lg shadow-drop-shadow ring ring-edge">
+              <Combobox.Content
+                // When portaled into a corvu drawer (mobile reply/forward),
+                // the drawer claims touches as drag gestures (0.3px threshold)
+                // and swallows the tap; opt this subtree out.
+                data-corvu-no-drag=""
+                // On touch, Kobalte selects an option on `click`, but the tap
+                // first blurs the input (the option isn't focusable), tearing
+                // the listbox down before the click lands. Preventing the
+                // compat `mousedown` keeps the input focused. Don't prevent
+                // `pointerdown` instead — iOS suppresses the click entirely.
+                on:mousedown={(e: MouseEvent) => {
+                  if (isMobile()) e.preventDefault();
+                }}
+                class="z-modal-content bg-surface translate-y-1 border-edge p-2 rounded-xl shadow-lg shadow-drop-shadow ring ring-edge"
+              >
                 <Combobox.Listbox
                   ref={setListboxRef}
                   class="flex flex-col gap-1"

--- a/apps/web/src/lib/core/component/RecipientSelector.tsx
+++ b/apps/web/src/lib/core/component/RecipientSelector.tsx
@@ -519,7 +519,7 @@ export function RecipientSelector<K extends CombinedRecipientKind>(
     };
   });
 
-  const options = createMemo(() => {
+  const optionsRaw = createMemo(() => {
     const { raw, emails, sorted } = recipients();
     const currentUserInput = inputValue();
 
@@ -551,6 +551,36 @@ export function RecipientSelector<K extends CombinedRecipientKind>(
     }
 
     return allOptions as CombinedRecipientItem<K>[];
+  });
+
+  // Keep the options array referentially stable across refreshes that don't
+  // change what's shown. Query-backed sources (thread participants, contacts)
+  // re-emit with fresh object identities on every refetch/draft save; without
+  // this, each emit rebuilds Kobalte's collection and the virtualized rows,
+  // replacing option DOM nodes. On touch that's fatal: selection happens on
+  // `click`, and if the node under the finger is replaced between touchstart
+  // and click, the click lands on a detached/blank node and nothing selects
+  // (Enter and desktop mouse don't hit this — they don't span that window).
+  const options = createMemo((prev: CombinedRecipientItem<K>[] | undefined) => {
+    const next = optionsRaw();
+    if (
+      prev &&
+      prev.length === next.length &&
+      next.every((nextOption, i) => {
+        const option = nextOption as CombinedRecipientItem;
+        const prevOption = prev[i] as CombinedRecipientItem;
+        return (
+          getRecipientOptionValue(option) ===
+            getRecipientOptionValue(prevOption) &&
+          getRecipientOptionTextValue(option) ===
+            getRecipientOptionTextValue(prevOption) &&
+          getOptionDisabled(option) === getOptionDisabled(prevOption)
+        );
+      })
+    ) {
+      return prev;
+    }
+    return next;
   });
 
   const visibleOptionKeys = createMemo(


### PR DESCRIPTION
## Problem

On **mobile only**, tapping a suggestion in the To/Cc/Bcc dropdowns of the reply/forward composer did nothing — the recipient never populated the field. Selecting the same suggestion with the keyboard (Enter) worked, desktop was fine, and the new-thread compose was unaffected.

## Root cause

Kobalte comboboxes select an option on `pointerdown` for mouse but on the synthesized **`click`** for touch — so a touch tap spans a long window (touchstart → click) during which the DOM must stay put.

**Primary cause — the option DOM churns mid-tap.** The forward composer's recipient options are query-backed (`ctx.recipientOptions`: thread participants, contacts, users), and forwards immediately start draft autosaves, so those queries re-emit with fresh object identities constantly. Every emit rebuilt Kobalte's collection and the virtualized (virtua) rows, replacing the option elements. When an emit lands mid-tap, the `click` fires on a detached/blank node, Solid's delegated handlers never run, and nothing selects. That's why:

- **Enter works** — it selects by focused key, no DOM involved;
- **desktop works** — mouse selects at `pointerdown`, a zero-length window;
- **new compose works** — its options don't churn (no autosave/refetch storm).

Reproduced deterministically in a WebKit touch-emulation harness (real `MobileDrawer` + `RecipientSelector`, options re-emitted during the tap): tap selects nothing on the old code, selects correctly with this fix, across no-churn / interval-churn / mid-tap-churn scenarios.

**Fix:** an identity-stabilizing memo over the options — when a refresh doesn't change what's rendered (value key, text, disabled per option), the previous array identity is returned, so Kobalte's collection and the virtualized rows are never rebuilt and the node under the finger survives.

## Secondary hardening (also in this PR)

The drawer composition had three more touch hazards, each verified in library source and addressed:

1. **Dropdown portaled outside the corvu drawer** (`document.body`): corvu dismisses on `pointerup` outside `Drawer.Content`. The three drawer `RecipientSelector`s now pass `portalScope={composePortalScope()}` like their sibling popovers, and `RecipientSelector` resolves the `.portal-scope` mount in `onMount` (resolving via `.closest()` during render always returned `null` — the node isn't connected yet — so the local-portal path never rendered; why #5010 appeared to do nothing).
2. **corvu drag-claims touches inside the drawer** (0.3 px movement threshold — normal finger jitter): `data-corvu-no-drag` on the dropdown content.
3. **Tap blurs the input** (options aren't focusable): the blur collapses the keyboard and lets the drawer focus trap steal focus, tearing the listbox down mid-tap (observed in the harness). Prevented via compat-`mousedown` `preventDefault`, gated to `isMobile()`. Deliberately *not* `pointerdown` — iOS WebKit suppresses the synthesized `click` when `pointerdown` is canceled, which is the likely reason the previous attempt (#5010) still didn't select.
