### PR TITLE
fix(split-layout): show close button on lone non-list split

### DIFF
--- a/apps/web/src/components/app/split-layout/components/SplitHeader.tsx
+++ b/apps/web/src/components/app/split-layout/components/SplitHeader.tsx
@@ -180,7 +180,16 @@ function SplitCloseButton() {
   });
 
   return (
-    <Show when={layout.manager.splits().length > 1}>
+    // Show whenever there's more than one split (always closeable), or the
+    // lone split isn't the home/unified-list view (the "Return to list" case
+    // handled by `label` above) — otherwise a split left showing a deleted
+    // or inaccessible document has no mouse-driven way to leave it.
+    <Show
+      when={
+        layout.manager.splits().length > 1 ||
+        !isListViewID(context.handle.content().id)
+      }
+    >
       <Button
         class="p-1 rounded-lg"
         label={label()}


### PR DESCRIPTION
## Summary
- `SplitCloseButton` (in `SplitHeader.tsx`) already computes a "Return to list" label for the single-split, non-unified-list case (`isOnlySplit && isNotUnifiedList`), but the surrounding `<Show>` only rendered the button when more than one split was open (`splits().length > 1`) — so in the common single-split layout, the button never rendered at all, label logic notwithstanding.
- When the split's document then errors out (deleted/unauthorized/gone), `DocumentBlockContainer` swaps in a bare error view with none of the document's own chrome (no title bar, no `SplitFileMenu`), leaving a completely chromeless panel with no mouse-driven way to close/leave it (only a `cmd+escape` hotkey happens to work, since it isn't gated the same way).
- Fixed by widening the `<Show>` condition to match the label's own logic: render whenever there's more than one split, **or** the lone split isn't showing the unified list/home view.

## Why
Reported by Gab in #bug-reports: "can't delete split after deleting the doc." Filed as MACRO-2503 since no task existed yet.

## Test plan
- [ ] Open a document in the only split, have it deleted (or navigate to a doc you've lost access to), confirm a "Return to list" button now appears in the split header and works.
- [ ] Confirm normal single-split browsing of a valid document still doesn't show a stray close button when it shouldn't (e.g. still hidden for the actual unified list/home view).
- [ ] Confirm multi-split "Close" behavior is unchanged.
- `bunx biome check` on the changed file is clean.
- Couldn't run the frontend dev server in my sandbox (private git deps unresolvable) — please give it a real spin in dev before merging.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WJrYZPoPByczqaDM2uPR4X)_