### PR TITLE
feat(email): make Enter reply to latest message in thread

### DIFF
--- a/apps/web/src/features/block-email/component/Email.tsx
+++ b/apps/web/src/features/block-email/component/Email.tsx
@@ -536,11 +536,8 @@ function EmailContent(props: EmailViewProps) {
         });
       }
 
-      if (markdownDomRef) {
-        markdownDomRef.focus();
-        return true;
-      }
-      return false;
+      // No message focused: reply to the latest message, same as 'r'
+      return openHotkeyTarget('reply-all');
     },
     hotkeyToken: TOKENS.block.focus,
     hide: true,


### PR DESCRIPTION
## Summary

In the email thread view, pressing **Enter** with no message focused now opens the reply composer for the latest message in the thread — the same behavior as the `r` shortcut.

## Details

The Enter hotkey handler in `Email.tsx` already handled the focused-message case (expand if collapsed, otherwise open the reply composer). But when no message was focused, it fell back to focusing `markdownDomRef` — the bottom composer's editor element, which is only mounted while the bottom reply composer is already open. On a freshly opened thread this fallback silently did nothing.

The fallback now calls `openHotkeyTarget('reply-all')`, the same path as the `r` hotkey: it targets the last message, opens the bottom reply composer via `setBottomReplyOpen(true)`, and focuses the editor through the `replyRequest` effect in `BaseInput.tsx`. The previous behavior (focusing the editor when the composer was already open) is preserved, since the reply-request effect sets `shouldFocusInput` regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)