### PR TITLE
fix(analytics): stop PostHog test-account filter from hiding native app users

### DIFF
--- a/apps/web/src/lib/analytics/analytics.ts
+++ b/apps/web/src/lib/analytics/analytics.ts
@@ -3,6 +3,7 @@ import {
   type GoogleConversionAction,
   googleConversionSendTo,
 } from '@app/lib/analytics/googleConversions';
+import { normalizeNativeAppUrls } from '@app/lib/analytics/nativeAppUrls';
 import {
   initializeGoogleAnalytics,
   initializeMetaPixel,
@@ -114,6 +115,10 @@ const initializePosthog = (instance: PostHog) => {
     defaults: '2026-01-30',
     before_send: (cr) => {
       if (cr) {
+        // Tauri apps report tauri://localhost URLs, which PostHog's test
+        // account filter treats as internal traffic (see nativeAppUrls.ts).
+        normalizeNativeAppUrls(cr);
+
         cr.properties.env = DEV_MODE_ENV
           ? 'DEV'
           : PROD_MODE_ENV

--- a/apps/web/src/lib/analytics/nativeAppUrls.test.ts
+++ b/apps/web/src/lib/analytics/nativeAppUrls.test.ts
@@ -1,0 +1,168 @@
+import type { CaptureResult } from 'posthog-js';
+import { describe, expect, it } from 'vitest';
+import { canonicalizeTauriUrl, normalizeNativeAppUrls } from './nativeAppUrls';
+
+function makeEvent(
+  properties: Record<string, unknown>,
+  setOnce?: Record<string, unknown>
+): CaptureResult {
+  return {
+    uuid: '019f0000-0000-7000-8000-000000000000',
+    event: '$pageview',
+    properties,
+    ...(setOnce ? { $set_once: setOnce } : {}),
+  } as CaptureResult;
+}
+
+describe('canonicalizeTauriUrl', () => {
+  it('maps hash routes to the web /app path', () => {
+    expect(canonicalizeTauriUrl('tauri://localhost#/component/inbox')).toBe(
+      'https://macro.com/app/component/inbox'
+    );
+    expect(canonicalizeTauriUrl('tauri://localhost/#/component/inbox')).toBe(
+      'https://macro.com/app/component/inbox'
+    );
+  });
+
+  it('maps the Windows origin', () => {
+    expect(
+      canonicalizeTauriUrl('https://tauri.localhost/#/component/inbox')
+    ).toBe('https://macro.com/app/component/inbox');
+  });
+
+  it('preserves query params inside the hash route', () => {
+    expect(canonicalizeTauriUrl('tauri://localhost#/chat/123?foo=1')).toBe(
+      'https://macro.com/app/chat/123?foo=1'
+    );
+  });
+
+  it('maps root urls to /app/', () => {
+    expect(canonicalizeTauriUrl('tauri://localhost')).toBe(
+      'https://macro.com/app/'
+    );
+    expect(canonicalizeTauriUrl('tauri://localhost/')).toBe(
+      'https://macro.com/app/'
+    );
+    expect(canonicalizeTauriUrl('tauri://localhost#/')).toBe(
+      'https://macro.com/app/'
+    );
+  });
+
+  it('leaves non-tauri urls unchanged', () => {
+    for (const url of [
+      'https://macro.com/app/component/inbox',
+      'https://macro.com/?utm_source=ig',
+      'http://localhost:3000/app',
+      'https://tauri.localhost.evil.com/phish',
+      '$direct',
+    ]) {
+      expect(canonicalizeTauriUrl(url)).toBe(url);
+    }
+  });
+});
+
+describe('normalizeNativeAppUrls', () => {
+  it('rewrites url, host, and pathname together', () => {
+    const event = makeEvent({
+      $current_url: 'tauri://localhost#/component/inbox',
+      $host: 'localhost',
+      $pathname: '/',
+    });
+
+    normalizeNativeAppUrls(event);
+
+    expect(event.properties).toMatchObject({
+      $current_url: 'https://macro.com/app/component/inbox',
+      $host: 'macro.com',
+      $pathname: '/app/component/inbox',
+    });
+  });
+
+  it('rewrites session entry properties', () => {
+    const event = makeEvent({
+      $session_entry_url: 'tauri://localhost#/',
+      $session_entry_host: 'localhost',
+      $session_entry_pathname: '/',
+      $session_entry_referrer: 'tauri://localhost#/component/inbox',
+      $session_entry_referring_domain: 'localhost',
+    });
+
+    normalizeNativeAppUrls(event);
+
+    expect(event.properties).toMatchObject({
+      $session_entry_url: 'https://macro.com/app/',
+      $session_entry_host: 'macro.com',
+      $session_entry_pathname: '/app/',
+      $session_entry_referrer: 'https://macro.com/app/component/inbox',
+      $session_entry_referring_domain: 'macro.com',
+    });
+  });
+
+  it('rewrites initial person properties in $set_once', () => {
+    const event = makeEvent(
+      {
+        $current_url: 'tauri://localhost#/',
+        $set_once: {
+          $initial_current_url: 'tauri://localhost#/component/inbox',
+          $initial_host: 'localhost',
+          $initial_pathname: '/',
+        },
+      },
+      {
+        $initial_person_info: {
+          r: '$direct',
+          u: 'tauri://localhost#/component/inbox',
+        },
+      }
+    );
+
+    normalizeNativeAppUrls(event);
+
+    expect(event.properties.$set_once).toMatchObject({
+      $initial_current_url: 'https://macro.com/app/component/inbox',
+      $initial_host: 'macro.com',
+      $initial_pathname: '/app/component/inbox',
+    });
+    expect(event.$set_once).toMatchObject({
+      $initial_person_info: {
+        r: '$direct',
+        u: 'https://macro.com/app/component/inbox',
+      },
+    });
+  });
+
+  it('does not touch web events', () => {
+    const properties = {
+      $current_url: 'https://macro.com/app/component/inbox',
+      $host: 'macro.com',
+      $pathname: '/app/component/inbox',
+      $referrer: 'https://www.google.com/',
+      $referring_domain: 'www.google.com',
+    };
+    const event = makeEvent({ ...properties });
+
+    normalizeNativeAppUrls(event);
+
+    expect(event.properties).toMatchObject(properties);
+  });
+
+  it('does not misclassify a localhost dev server as the native app', () => {
+    const event = makeEvent({
+      $current_url: 'http://localhost:3000/app/component/inbox',
+      $host: 'localhost:3000',
+      $pathname: '/app/component/inbox',
+    });
+
+    normalizeNativeAppUrls(event);
+
+    expect(event.properties).toMatchObject({
+      $current_url: 'http://localhost:3000/app/component/inbox',
+      $host: 'localhost:3000',
+    });
+  });
+
+  it('handles events without properties', () => {
+    const event = { event: 'x' } as CaptureResult;
+    expect(() => normalizeNativeAppUrls(event)).not.toThrow();
+  });
+});

--- a/apps/web/src/lib/analytics/nativeAppUrls.ts
+++ b/apps/web/src/lib/analytics/nativeAppUrls.ts
@@ -1,0 +1,148 @@
+import type { CaptureResult } from 'posthog-js';
+
+/**
+ * URL normalization for analytics events sent from the Tauri apps.
+ *
+ * The native apps serve the SPA from a custom origin — `tauri://localhost`
+ * on macOS/Linux/iOS/Android and `https://tauri.localhost` on Windows — so
+ * posthog-js reports `$host` as `localhost`/`tauri.localhost` and
+ * `$current_url` as `tauri://localhost#/...`. PostHog's project-level
+ * "filter test accounts" filter excludes events whose `$host` matches
+ * `^(localhost|127.0.0.1)($|:)`, which classifies every native-app user as
+ * internal test traffic: their events vanish from test-filtered insights
+ * and their session recordings are hidden from the filtered replay list.
+ * Rewriting the URL-shaped properties to the canonical web origin keeps
+ * native-app traffic attributed to macro.com like every other user, and
+ * makes URL-based breakdowns meaningful for app sessions.
+ */
+
+const TAURI_ORIGINS = ['tauri://localhost', 'https://tauri.localhost'] as const;
+
+// Same check as DEV_MODE_ENV in @core/constant/featureFlags, inlined so this
+// module stays dependency-free (featureFlags transitively constructs the
+// analytics singleton, which this module must not depend on).
+const WEB_APP_ORIGIN =
+  import.meta.env.MODE === 'development'
+    ? 'https://dev.macro.com'
+    : 'https://macro.com';
+
+type PropertyBag = Record<string, unknown>;
+
+interface UrlPropertyGroup {
+  /** Property holding a full URL; rewriting it drives the group. */
+  url: string;
+  /** Property holding the URL's host, kept in sync when `url` is rewritten. */
+  host?: string;
+  /** Property holding the URL's pathname, kept in sync when `url` is rewritten. */
+  pathname?: string;
+  /** Property holding a referring domain, kept in sync when `url` is rewritten. */
+  domain?: string;
+}
+
+const EVENT_URL_GROUPS: UrlPropertyGroup[] = [
+  { url: '$current_url', host: '$host', pathname: '$pathname' },
+  {
+    url: '$session_entry_url',
+    host: '$session_entry_host',
+    pathname: '$session_entry_pathname',
+  },
+  { url: '$referrer', domain: '$referring_domain' },
+  {
+    url: '$session_entry_referrer',
+    domain: '$session_entry_referring_domain',
+  },
+];
+
+const SET_ONCE_URL_GROUPS: UrlPropertyGroup[] = [
+  {
+    url: '$initial_current_url',
+    host: '$initial_host',
+    pathname: '$initial_pathname',
+  },
+  { url: '$initial_referrer', domain: '$initial_referring_domain' },
+];
+
+function matchTauriOrigin(url: string): string | undefined {
+  return TAURI_ORIGINS.find((origin) => {
+    if (!url.startsWith(origin)) return false;
+    const next = url.charAt(origin.length);
+    return next === '' || next === '/' || next === '#' || next === '?';
+  });
+}
+
+/**
+ * Maps a Tauri-origin URL to its canonical web equivalent. The native apps
+ * use hash routing at the root, while the web app serves the same routes
+ * under `/app`, so `tauri://localhost#/chat/123` becomes
+ * `https://macro.com/app/chat/123`. Non-Tauri URLs are returned unchanged.
+ */
+export function canonicalizeTauriUrl(url: string): string {
+  const origin = matchTauriOrigin(url);
+  if (!origin) return url;
+
+  const rest = url.slice(origin.length);
+  const hashIndex = rest.indexOf('#');
+  const route = hashIndex >= 0 ? rest.slice(hashIndex + 1) : rest;
+  const path = route === '' || route === '/' ? '/' : route;
+  return `${WEB_APP_ORIGIN}/app${path.startsWith('/') ? path : `/${path}`}`;
+}
+
+function normalizeGroups(bag: PropertyBag, groups: UrlPropertyGroup[]): void {
+  for (const group of groups) {
+    const raw = bag[group.url];
+    if (typeof raw !== 'string') continue;
+
+    const canonical = canonicalizeTauriUrl(raw);
+    if (canonical === raw) continue;
+    bag[group.url] = canonical;
+
+    const parsed = new URL(canonical);
+    if (group.host && typeof bag[group.host] === 'string') {
+      bag[group.host] = parsed.host;
+    }
+    if (group.pathname && typeof bag[group.pathname] === 'string') {
+      bag[group.pathname] = parsed.pathname;
+    }
+    if (group.domain && typeof bag[group.domain] === 'string') {
+      bag[group.domain] = parsed.host;
+    }
+  }
+}
+
+/**
+ * Recent posthog-js versions send initial person info in a compact
+ * `$initial_person_info: { r: referrer, u: url }` shape that the server
+ * expands into `$initial_*` person properties.
+ */
+function normalizePersonInfo(setOnce: PropertyBag): void {
+  const info = setOnce.$initial_person_info;
+  if (!info || typeof info !== 'object') return;
+
+  const record = info as PropertyBag;
+  for (const key of ['u', 'r']) {
+    const value = record[key];
+    if (typeof value === 'string') {
+      record[key] = canonicalizeTauriUrl(value);
+    }
+  }
+}
+
+/**
+ * Rewrites all Tauri-origin URL properties on a captured event (including
+ * `$set_once` initial person properties) to the canonical web origin.
+ * Intended to run in posthog's `before_send`; mutates the event in place.
+ * Events without Tauri-origin URLs are left untouched, so this is safe to
+ * run on every platform.
+ */
+export function normalizeNativeAppUrls(event: CaptureResult): void {
+  if (event.properties) {
+    normalizeGroups(event.properties, EVENT_URL_GROUPS);
+  }
+
+  for (const setOnce of [event.properties?.$set_once, event.$set_once]) {
+    if (setOnce && typeof setOnce === 'object') {
+      normalizeGroups(setOnce as PropertyBag, SET_ONCE_URL_GROUPS);
+      normalizePersonInfo(setOnce as PropertyBag);
+    }
+  }
+}

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -70,6 +70,13 @@ export default defineConfig({
         },
       },
       {
+        plugins: [tsconfigPaths()],
+        test: {
+          include: ['src/lib/analytics/**/*.{test,spec}.{ts,tsx}'],
+          name: 'analytics',
+        },
+      },
+      {
         test: {
           environment: 'jsdom',
           globals: true,


### PR DESCRIPTION
# Why

The daily signup review automation keeps reporting "no session recordings" for new signups, and the replay list looks the same way in the PostHog UI. The recordings actually exist — they're being **hidden, not lost**.

Root cause: the Tauri apps serve the SPA from a custom origin (`tauri://localhost` on macOS/iOS/Android/Linux, `https://tauri.localhost` on Windows), so posthog-js reports `$host` as `localhost`. The PostHog project's test-account filter excludes events whose `$host` matches `^(localhost|127.0.0.1)($|:)`, which classifies **every native-app user as internal test traffic**. Any query or view with "filter out internal and test users" enabled (the replay list toggle, `filter_test_accounts: true` in API queries — which the signup-review automation uses by default) silently drops all app sessions.

Verified against production data: 10 signups flagged "no recordings" in the Jul 19 review post have 19 recordings between them, almost all with `tauri://localhost` start URLs; re-running the same query with `filter_test_accounts: true` drops exactly the tauri ones and keeps only the `https://macro.com/...` web sessions.

# What

- Add `nativeAppUrls.ts`, which rewrites Tauri-origin URL properties on captured events to the canonical web origin, mapping hash routes to their `/app` path equivalents (`tauri://localhost#/chat/123` → `https://macro.com/app/chat/123`). Covers `$current_url`/`$host`/`$pathname`, the `$session_entry_*` variants, `$referrer`/`$referring_domain`, and the `$initial_*` person properties (both expanded and compact `$initial_person_info` forms).
- Hook it into the existing `before_send` in `analytics.ts`. Events without Tauri-origin URLs are untouched, so web traffic (including genuine `localhost:3000` dev servers, which stay excluded as test traffic) is unaffected.
- Unit tests + a vitest project entry for `src/lib/analytics`.

Beyond un-hiding recordings, this also makes URL/host-based analytics (web analytics, entry paths, URL breakdowns) meaningful for native-app sessions, which currently all report `localhost`.

# Notes

- This fixes events going forward. Recordings captured before the deploy still carry `$host = localhost` on their events and stay hidden behind the test-account filter until they age out of the 30-day replay retention; querying with test-account filtering off shows them in the meantime.
- The replay player will still display `tauri://localhost` start URLs (those come from the rrweb snapshot payload, not event properties); only discoverability/filtering was affected.

# Test plan

- `bun test src/lib/analytics/nativeAppUrls.test.ts` — 11 tests pass, covering hash-route mapping, Windows origin, query params, root URLs, session-entry/initial property groups, and non-Tauri URLs (web + localhost dev server) staying untouched.
- Biome check clean on changed files.

---
_Generated by [Claude Code](https://claude.ai/code/session_016bGVuab4acCgvLNERbroJn)_