### PR TITLE
feat(email): shift+e marks thread not done; undoable archive toasts

### DIFF
--- a/apps/web/src/features/block-email/component/Email.tsx
+++ b/apps/web/src/features/block-email/component/Email.tsx
@@ -508,6 +508,7 @@ function EmailContent(props: EmailViewProps) {
       forwardFocusedMessage: () => openHotkeyTarget('forward'),
       blockSender: context.blockSender,
       markDone: context.archiveThread,
+      markNotDone: context.markNotDone,
       markSenderSignal: context.markSenderSignal,
       markSenderNoise: context.markSenderNoise,
       navigateToPreviousMessage,

--- a/apps/web/src/features/block-email/component/EmailContext.tsx
+++ b/apps/web/src/features/block-email/component/EmailContext.tsx
@@ -401,8 +401,10 @@ export function EmailProvider(props: FlowProps<{ threadID: string }>) {
         onRedone: showToast,
       };
     },
-    onError: () => {
-      toast.failure('Failed to archive thread');
+    onError: (params) => {
+      toast.failure(
+        params.archive ? 'Failed to mark as done' : 'Failed to mark as not done'
+      );
     },
   });
 

--- a/apps/web/src/features/block-email/component/EmailContext.tsx
+++ b/apps/web/src/features/block-email/component/EmailContext.tsx
@@ -22,6 +22,7 @@ import {
 } from '@core/user';
 import { whenSettled } from '@core/util/whenSettled';
 import { createEffectOnEntityTypeNotification } from '@notifications';
+import ArrowCounterClockwise from '@phosphor-icons/core/regular/arrow-counter-clockwise.svg?component-solid';
 import { queryClient } from '@queries/client';
 import { emailKeys } from '@queries/email/keys';
 import { useNonPrimaryEmailLinkIdHeader } from '@queries/email/link';
@@ -30,8 +31,8 @@ import {
   markSenderNoiseWithToast,
   markSenderSignalWithToast,
   trackExternalThreadArchive,
-  useArchiveThreadMutation,
   useThreadQuery,
+  useUndoableArchiveThreadMutation,
 } from '@queries/email/thread';
 import { getSoupEntityById } from '@queries/soup/cache';
 import { mapApiSoupItemToEntity } from '@queries/soup/transform-utils';
@@ -135,6 +136,7 @@ type EmailContextValues = {
   };
 
   archiveThread: (opts?: ArchiveThreadOptions) => boolean;
+  markNotDone: () => boolean;
   getMarkDoneNavigationTargetId: () => string | undefined;
   blockSender: () => boolean;
   markSenderSignal: () => boolean;
@@ -364,7 +366,41 @@ export function EmailProvider(props: FlowProps<{ threadID: string }>) {
     userId,
   });
 
-  const archiveMutation = useArchiveThreadMutation({
+  // Only the direct-archive fallback goes through this mutation with
+  // archive=true (the mark-done action paths toast on their own).
+  const archiveMutation = useUndoableArchiveThreadMutation({
+    onPushed: (handle, params) => {
+      const message = params.archive ? 'Marked as done' : 'Marked as not done';
+      let toastId: number | undefined;
+
+      const showToast = () => {
+        toastId = toast.success(message, {
+          actions: [
+            {
+              label: 'Undo',
+              icon: ArrowCounterClockwise,
+              onClick: () => {
+                handle.undo({
+                  onError: () => toast.failure('Failed to undo'),
+                });
+              },
+            },
+          ],
+          duration: 3_000,
+          stack: true,
+          hideOnMobile: true,
+        });
+      };
+
+      showToast();
+
+      return {
+        onUndone: () => {
+          if (toastId !== undefined) toast.dismiss(toastId);
+        },
+        onRedone: showToast,
+      };
+    },
     onError: () => {
       toast.failure('Failed to archive thread');
     },
@@ -457,6 +493,18 @@ export function EmailProvider(props: FlowProps<{ threadID: string }>) {
       });
     }
 
+    return true;
+  };
+
+  const markNotDone = () => {
+    const thread = threadQuery.data;
+    if (!thread?.db_id || thread.inbox_visible) return false;
+
+    archiveMutation.mutate({
+      threadId: thread.db_id,
+      archive: false,
+      linkId: toHeaderLinkId(thread.link_id),
+    });
     return true;
   };
 
@@ -629,6 +677,7 @@ export function EmailProvider(props: FlowProps<{ threadID: string }>) {
           recipientOptions: createMemo(getRecipientOptions),
           onRecipientsChange,
           archiveThread,
+          markNotDone,
           getMarkDoneNavigationTargetId,
           blockSender,
           markSenderSignal,

--- a/apps/web/src/features/block-email/util/emailHotkeys.ts
+++ b/apps/web/src/features/block-email/util/emailHotkeys.ts
@@ -7,6 +7,7 @@ interface EmailHotkeyHandlers {
   forwardFocusedMessage: () => boolean;
   blockSender: () => boolean;
   markDone: () => boolean;
+  markNotDone: () => boolean;
   markSenderSignal: () => boolean;
   markSenderNoise: () => boolean;
   navigateToPreviousMessage: () => boolean;
@@ -51,6 +52,14 @@ export function registerEmailHotkeys(
     description: 'Mark done',
     keyDownHandler: handlers.markDone,
     hotkeyToken: TOKENS.entity.action.markDone,
+    displayPriority: 10,
+  });
+  registerHotkey({
+    hotkey: 'shift+e',
+    scopeId,
+    description: 'Mark not done',
+    keyDownHandler: handlers.markNotDone,
+    hotkeyToken: TOKENS.entity.action.markNotDone,
     displayPriority: 10,
   });
   registerHotkey({

--- a/apps/web/src/features/next-soup/actions/make-mark-done-action.ts
+++ b/apps/web/src/features/next-soup/actions/make-mark-done-action.ts
@@ -55,9 +55,15 @@ type MarkDoneVariables = {
   /** Receives the undo handle once the mark-done is pushed onto the undo
    *  stack, so callers (e.g. undo-send) can reverse it programmatically. */
   onUndoHandle?: (handle: UndoHandle) => void;
+  /** Navigates the view back to the marked entity on undo, when marking done
+   *  navigated away to the next item. */
+  navigateBack?: () => void;
 };
 
-type MarkDoneExecuteOpts = Pick<MarkDoneVariables, 'silent' | 'onUndoHandle'>;
+type MarkDoneExecuteOpts = Pick<
+  MarkDoneVariables,
+  'silent' | 'onUndoHandle' | 'navigateBack'
+>;
 
 type MarkDoneExecuteWithSoupOpts = MarkDoneExecuteOpts & {
   nextEntityId?: string;
@@ -169,6 +175,7 @@ export const makeMarkDoneAction = (options: MakeMarkDoneOptions) => {
           if (toastId !== undefined) toast.dismiss(toastId);
           variables.restoreFocus?.();
           restoreSoupFocus(firstEntityId, inPreview);
+          variables.navigateBack?.();
         },
         onRedone: showToast,
       };
@@ -213,6 +220,7 @@ export const makeMarkDoneAction = (options: MakeMarkDoneOptions) => {
       restoreFocus,
       silent: opts?.silent,
       onUndoHandle: opts?.onUndoHandle,
+      navigateBack: opts?.navigateBack,
     });
   };
 
@@ -272,7 +280,16 @@ export const makeMarkDoneAction = (options: MakeMarkDoneOptions) => {
       onNavigate?.(nextRow.original);
     }
 
-    await execute(entities, restoreFocus, opts);
+    // When marking done navigated the view to the next item, undo navigates
+    // back to the marked entity through the same callback.
+    const firstEntity = entities[0];
+    const navigateBack =
+      opts?.navigateBack ??
+      (nextRow && onNavigate && firstEntity
+        ? () => onNavigate(firstEntity)
+        : undefined);
+
+    await execute(entities, restoreFocus, { ...opts, navigateBack });
   };
 
   return { canExecute, execute, executeWithSoup };

--- a/apps/web/src/lib/core/hotkey/tokens.ts
+++ b/apps/web/src/lib/core/hotkey/tokens.ts
@@ -46,6 +46,7 @@ export const TOKENS = {
     open: 'entity.open',
     action: {
       markDone: 'entity.action.markDone',
+      markNotDone: 'entity.action.markNotDone',
       delete: 'entity.action.delete',
       rename: 'entity.action.rename',
       moveToFolder: 'entity.action.moveToFolder',

--- a/apps/web/src/lib/queries/email/thread.ts
+++ b/apps/web/src/lib/queries/email/thread.ts
@@ -358,7 +358,7 @@ export function useUndoableArchiveThreadMutation(options: {
     handle: UndoHandle,
     params: ArchiveThreadParams
   ) => { onUndone?: () => void; onRedone?: () => void } | void;
-  onError?: () => void;
+  onError?: (params: ArchiveThreadParams) => void;
 }) {
   return useUndoableMutation<
     void,
@@ -386,7 +386,7 @@ export function useUndoableArchiveThreadMutation(options: {
           context.previousData
         );
       }
-      options.onError?.();
+      options.onError?.(params);
     },
     onSettled: (_data, _error, params) => {
       queryClient.invalidateQueries({
@@ -397,7 +397,7 @@ export function useUndoableArchiveThreadMutation(options: {
     undoFn: async (params) =>
       replayThreadArchive({ ...params, archive: !params.archive }),
     redoFn: async (params) => replayThreadArchive(params),
-    undoLabel: 'Mark Done',
+    undoLabel: (params) => (params.archive ? 'Mark Done' : 'Mark Not Done'),
     onPushed: (handle, params) => options.onPushed?.(handle, params),
   }));
 }

--- a/apps/web/src/lib/queries/email/thread.ts
+++ b/apps/web/src/lib/queries/email/thread.ts
@@ -22,6 +22,7 @@ import type { Accessor } from 'solid-js';
 import { queryClient } from '../client';
 import { optimisticUpdateSoupEntity, refetchSoupEntity } from '../soup/cache';
 import { invalidateAllSoup } from '../soup/normalized-cache';
+import { type UndoHandle, useUndoableMutation } from '../undo';
 import { type MutationCallbacks, withCallbacks } from '../utils';
 import { emailKeys } from './keys';
 
@@ -279,8 +280,8 @@ export function useArchiveThreadMutation(
   >
 ) {
   return useMutation(() => ({
-    mutationFn: async (params: ArchiveThreadParams) =>
-      void throwOnErr(
+    mutationFn: async (params: ArchiveThreadParams) => {
+      await throwOnErr(
         async () =>
           await emailClient.flagArchived(
             {
@@ -289,7 +290,8 @@ export function useArchiveThreadMutation(
             },
             params.linkId
           )
-      ),
+      );
+    },
     ...withCallbacks<void, Error, ArchiveThreadParams, ArchiveThreadContext>(
       {
         onMutate: async (params) => await threadArchiveOnMutate(params),
@@ -310,6 +312,93 @@ export function useArchiveThreadMutation(
       },
       callbacks
     ),
+  }));
+}
+
+/**
+ * One archive/unarchive cycle for undo/redo replays: optimistic flip, API
+ * call, rollback on failure, invalidate on settle. Mirrors what
+ * `useUndoableArchiveThreadMutation` does through its mutation callbacks.
+ */
+async function replayThreadArchive(params: ArchiveThreadParams): Promise<void> {
+  const { previousData } = await threadArchiveOnMutate(params);
+  try {
+    await throwOnErr(
+      async () =>
+        await emailClient.flagArchived(
+          { id: params.threadId, value: params.archive },
+          params.linkId
+        )
+    );
+  } catch (err) {
+    if (previousData) {
+      queryClient.setQueryData(
+        emailKeys.threadMessages(params.threadId).queryKey,
+        previousData
+      );
+    }
+    throw err;
+  } finally {
+    queryClient.invalidateQueries({
+      queryKey: emailKeys.threadMessages(params.threadId).queryKey,
+    });
+    queryClient.invalidateQueries({ queryKey: emailKeys.previews._def });
+  }
+}
+
+/**
+ * Undoable variant of `useArchiveThreadMutation`: each successful archive or
+ * unarchive is pushed onto the mutation undo stack, and undo/redo replays the
+ * opposite call with the same optimistic cache handling.
+ * Must be used inside a MutationUndoProvider.
+ */
+export function useUndoableArchiveThreadMutation(options: {
+  /** Bind side effects (e.g. an undo toast) to the pushed undo entry. */
+  onPushed?: (
+    handle: UndoHandle,
+    params: ArchiveThreadParams
+  ) => { onUndone?: () => void; onRedone?: () => void } | void;
+  onError?: () => void;
+}) {
+  return useUndoableMutation<
+    void,
+    Error,
+    ArchiveThreadParams,
+    ArchiveThreadContext
+  >(() => ({
+    mutationFn: async (params: ArchiveThreadParams) => {
+      await throwOnErr(
+        async () =>
+          await emailClient.flagArchived(
+            {
+              id: params.threadId,
+              value: params.archive,
+            },
+            params.linkId
+          )
+      );
+    },
+    onMutate: async (params) => await threadArchiveOnMutate(params),
+    onError: (_err, params, context) => {
+      if (context?.previousData) {
+        queryClient.setQueryData(
+          emailKeys.threadMessages(params.threadId).queryKey,
+          context.previousData
+        );
+      }
+      options.onError?.();
+    },
+    onSettled: (_data, _error, params) => {
+      queryClient.invalidateQueries({
+        queryKey: emailKeys.threadMessages(params.threadId).queryKey,
+      });
+      queryClient.invalidateQueries({ queryKey: emailKeys.previews._def });
+    },
+    undoFn: async (params) =>
+      replayThreadArchive({ ...params, archive: !params.archive }),
+    redoFn: async (params) => replayThreadArchive(params),
+    undoLabel: 'Mark Done',
+    onPushed: (handle, params) => options.onPushed?.(handle, params),
   }));
 }
 

--- a/apps/web/src/lib/queries/undo.ts
+++ b/apps/web/src/lib/queries/undo.ts
@@ -193,7 +193,8 @@ export function useUndoableMutation<
   options: () => MutationOptions<TData, TError, TVariables, TContext> & {
     undoFn?: UndoHandler<TVariables, TContext>;
     redoFn?: UndoHandler<TVariables, TContext>;
-    undoLabel?: string;
+    /** Static label, or derived per entry from the mutation variables. */
+    undoLabel?: string | ((variables: TVariables) => string);
     /** Fires after the entry is pushed onto the undo stack. Returned
      *  lifecycle hooks (onUndone/onRedone) will run on this specific
      *  entry — regardless of whether it is undone via the returned
@@ -228,7 +229,10 @@ export function useUndoableMutation<
           const handle = pushUndo({
             undo: () => undoFn(variables, context),
             redo: redoFn ? () => redoFn(variables, context) : undefined,
-            label: undoLabel,
+            label:
+              typeof undoLabel === 'function'
+                ? undoLabel(variables)
+                : undoLabel,
             onUndone: () => lifecycleRef.current?.onUndone?.(),
             onRedone: () => lifecycleRef.current?.onRedone?.(),
           });


### PR DESCRIPTION
## Summary

Adds a dedicated `shift+e` "mark not done" hotkey to the email thread view and fixes feedback gaps + a race in the thread archive flow.

### Changes

- **`shift+e` marks a thread as not done** in the email thread view — the explicit inverse of `e`. No-op when the thread is already in the inbox. (New `entity.action.markNotDone` hotkey token.)
- **Undoable toasts for the direct archive fallback.** When a thread has no soup entity to drive the mark-done action (opened from a notification, direct link, search, etc.), archiving previously went through a silent `archiveMutation`. That path now uses a new `useUndoableArchiveThreadMutation`, so both directions show the same "Marked as done" / "Marked as not done" toast with an Undo button as the soup mark-done action, and entries land on the mutation undo stack (`cmd+z` works). Undo/redo replays the opposite `flagArchived` call with the same optimistic `inbox_visible` handling, preserving the `X-Email-Link-Id` header for non-primary inboxes.
- **Undo navigates back.** When a soup mark-done navigated the split to the next item, undoing now re-opens the restored entity via the same caller-provided navigation callback (guards included — no forced navigation in contexts that never navigated).
- **Fix: archive mutation didn't await its request.** `mutationFn` was `void throwOnErr(...)`, so the mutation "succeeded" instantly: the settle-time thread refetch raced the in-flight PATCH and, when the GET won, clobbered the optimistic `inbox_visible` flip — making `e` mark the same thread as done twice in a row instead of toggling. It also meant `onError` never fired on real failures. Both the existing `useArchiveThreadMutation` and the new undoable variant now await the request.
