### PR TITLE
fix(email): shorten undo-send window to 5 seconds

### DIFF
--- a/apps/web/src/features/block-email/component/BaseInput.tsx
+++ b/apps/web/src/features/block-email/component/BaseInput.tsx
@@ -561,7 +561,7 @@ export function BaseInput(props: {
               },
             ]
           : undefined,
-        duration: 10_000,
+        duration: 5_000,
       });
       pendingMentions.forEach((mention) => {
         trackMention(blockId, 'document', mention.documentId);

--- a/apps/web/src/features/block-email/component/compose/Compose.tsx
+++ b/apps/web/src/features/block-email/component/compose/Compose.tsx
@@ -431,7 +431,7 @@ export function EmailCompose(props: EmailComposeProps) {
               },
             ]
           : undefined,
-        duration: 8_000,
+        duration: 5_000,
       });
       if (data.message.thread_db_id) {
         replaceSplit({


### PR DESCRIPTION
## Summary

Shortens the frontend undo-send window for email messages to 5 seconds.

The undo window is the duration of the "Email sent" toast that carries the **Undo** action:

- `Compose.tsx` (new-thread compose): 8s → 5s
- `BaseInput.tsx` (thread reply): 10s → 5s

Both paths now use a consistent 5-second window.