### PR TITLE
fix(channel): restore thread reply fetch debounce

### DIFF
--- a/apps/web/src/features/channel/Channel/Channel.tsx
+++ b/apps/web/src/features/channel/Channel/Channel.tsx
@@ -679,6 +679,7 @@ export function Channel(props: ChannelProps) {
                                   channelId={() => props.channelId}
                                   isNewestThread={isNewestThread()}
                                   getMessageActions={getMessageActions}
+                                  isFindBarOpen={findBar.isOpen}
                                   targetNavigation={{
                                     targetThreadId:
                                       targetMessageController.activeTargetMessageId,

--- a/apps/web/src/features/channel/Thread/ChannelThread.tsx
+++ b/apps/web/src/features/channel/Thread/ChannelThread.tsx
@@ -19,6 +19,7 @@ import { isUnifiedInputMode } from '../unified-input-mode';
 import { createTargetReplyNavigationController } from './create-target-reply-navigation-controller';
 import { createTargetReplyScroller } from './create-target-reply-scroller';
 import { createThreadHotkeys } from './create-thread-hotkeys';
+import { createThreadRepliesFetchGate } from './create-thread-replies-fetch-gate';
 import { Thread } from './Thread';
 import type { ThreadReplyListHandle } from './ThreadReplyList';
 import { ThreadTypingIndicator } from './ThreadTypingIndicator';
@@ -37,11 +38,14 @@ export function ChannelThread(props: ThreadProps) {
   const [displayName] = useDisplayName(macroId());
   const thread = () => props.data().thread;
   const hasReplies = () => thread().reply_count > 0;
-  const fetchRepliesEnabled = () =>
-    (!!props.targetNavigation?.targetReplyId() &&
-      props.targetNavigation.targetThreadId() === props.data().id) ||
-    props.isExpanded() ||
-    (hasReplies() && thread().reply_count > DEFAULT_VISIBLE_REPLY_COUNT);
+  const fetchRepliesEnabled = createThreadRepliesFetchGate({
+    threadId: () => props.data().id,
+    replyCount: () => thread().reply_count,
+    isExpanded: props.isExpanded,
+    isFindBarOpen: props.isFindBarOpen,
+    targetThreadId: () => props.targetNavigation?.targetThreadId(),
+    targetReplyId: () => props.targetNavigation?.targetReplyId(),
+  });
 
   const isSelected = () => props.selectedMessageId?.() === props.data().id;
 

--- a/apps/web/src/features/channel/Thread/create-thread-replies-fetch-gate.ts
+++ b/apps/web/src/features/channel/Thread/create-thread-replies-fetch-gate.ts
@@ -1,0 +1,38 @@
+import { deferredGate } from '@core/util/debounce';
+import type { Accessor } from 'solid-js';
+import { DEFAULT_VISIBLE_REPLY_COUNT } from './utils/thread-reply-indicator-helpers';
+
+export const THREAD_REPLIES_FETCH_DEBOUNCE_MS = 300;
+
+type CreateThreadRepliesFetchGateOptions = {
+  threadId: Accessor<string>;
+  replyCount: Accessor<number>;
+  isExpanded: Accessor<boolean>;
+  isFindBarOpen: Accessor<boolean>;
+  targetThreadId: Accessor<string | undefined>;
+  targetReplyId: Accessor<string | undefined>;
+};
+
+/**
+ * Delays reply fetching long enough for transiently mounted threads to unmount.
+ * Cmd+F navigation is the only immediate path because it needs the targeted
+ * reply list before it can position the active search result.
+ */
+export function createThreadRepliesFetchGate(
+  options: CreateThreadRepliesFetchGateOptions
+): Accessor<boolean> {
+  const isTargetedReply = () =>
+    !!options.targetReplyId() &&
+    options.targetThreadId() === options.threadId();
+  const shouldFetchReplies = () =>
+    isTargetedReply() ||
+    options.isExpanded() ||
+    options.replyCount() > DEFAULT_VISIBLE_REPLY_COUNT;
+  const debouncedFetchReplies = deferredGate(
+    shouldFetchReplies,
+    THREAD_REPLIES_FETCH_DEBOUNCE_MS
+  );
+
+  return () =>
+    (options.isFindBarOpen() && isTargetedReply()) || debouncedFetchReplies();
+}

--- a/apps/web/src/features/channel/Thread/tests/create-thread-replies-fetch-gate.test.ts
+++ b/apps/web/src/features/channel/Thread/tests/create-thread-replies-fetch-gate.test.ts
@@ -1,0 +1,109 @@
+import { createRoot } from 'solid-js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  createThreadRepliesFetchGate,
+  THREAD_REPLIES_FETCH_DEBOUNCE_MS,
+} from '../create-thread-replies-fetch-gate';
+import { DEFAULT_VISIBLE_REPLY_COUNT } from '../utils/thread-reply-indicator-helpers';
+
+type FixtureOptions = {
+  isExpanded?: boolean;
+  isFindBarOpen?: boolean;
+  replyCount?: number;
+  targetReplyId?: string;
+  targetThreadId?: string;
+};
+
+describe('createThreadRepliesFetchGate', () => {
+  let dispose: () => void;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    dispose?.();
+    vi.useRealTimers();
+  });
+
+  const createFixture = (options: FixtureOptions = {}) => {
+    let enabled!: () => boolean;
+
+    createRoot((rootDispose) => {
+      dispose = rootDispose;
+      enabled = createThreadRepliesFetchGate({
+        threadId: () => 'thread-1',
+        replyCount: () => options.replyCount ?? 0,
+        isExpanded: () => options.isExpanded ?? false,
+        isFindBarOpen: () => options.isFindBarOpen ?? false,
+        targetThreadId: () => options.targetThreadId,
+        targetReplyId: () => options.targetReplyId,
+      });
+    });
+
+    return { enabled };
+  };
+
+  const flushEffects = async () => {
+    await Promise.resolve();
+  };
+
+  it('waits 300ms before enabling an ordinary thread reply fetch', async () => {
+    const fixture = createFixture({
+      replyCount: DEFAULT_VISIBLE_REPLY_COUNT + 1,
+    });
+    await flushEffects();
+
+    expect(fixture.enabled()).toBe(false);
+    vi.advanceTimersByTime(THREAD_REPLIES_FETCH_DEBOUNCE_MS - 1);
+    expect(fixture.enabled()).toBe(false);
+    vi.advanceTimersByTime(1);
+    expect(fixture.enabled()).toBe(true);
+  });
+
+  it('also debounces expansion and non-find-bar reply navigation', async () => {
+    const expanded = createFixture({ isExpanded: true });
+    await flushEffects();
+    expect(expanded.enabled()).toBe(false);
+
+    dispose();
+    const targeted = createFixture({
+      targetThreadId: 'thread-1',
+      targetReplyId: 'reply-1',
+    });
+    await flushEffects();
+    expect(targeted.enabled()).toBe(false);
+
+    vi.advanceTimersByTime(THREAD_REPLIES_FETCH_DEBOUNCE_MS);
+    expect(targeted.enabled()).toBe(true);
+  });
+
+  it('enables only the Cmd+F targeted reply immediately', async () => {
+    const targeted = createFixture({
+      isFindBarOpen: true,
+      targetThreadId: 'thread-1',
+      targetReplyId: 'reply-1',
+    });
+
+    expect(targeted.enabled()).toBe(true);
+
+    dispose();
+    const expanded = createFixture({
+      isFindBarOpen: true,
+      isExpanded: true,
+    });
+    await flushEffects();
+    expect(expanded.enabled()).toBe(false);
+  });
+
+  it('cancels the pending fetch when a transient thread unmounts', async () => {
+    const fixture = createFixture({ isExpanded: true });
+    await flushEffects();
+    vi.advanceTimersByTime(THREAD_REPLIES_FETCH_DEBOUNCE_MS - 1);
+
+    dispose();
+    vi.advanceTimersByTime(1);
+
+    expect(fixture.enabled()).toBe(false);
+  });
+});

--- a/apps/web/src/features/channel/Thread/types.ts
+++ b/apps/web/src/features/channel/Thread/types.ts
@@ -60,6 +60,8 @@ export type ThreadProps = {
   messageEditor?: MessageEditor;
   participants?: Accessor<IUser[]>;
   targetNavigation?: ThreadTargetNavigation;
+  /** Whether the channel's Cmd+F find bar is currently open. */
+  isFindBarOpen: Accessor<boolean>;
   /** The unified input's reply binding */
   unifiedReplyTarget?: { threadId: string; replyId?: string };
   isNewMessage?: (reply: NewMessageCheckable) => boolean;

--- a/apps/web/src/lib/core/util/debounce.ts
+++ b/apps/web/src/lib/core/util/debounce.ts
@@ -81,7 +81,10 @@ function _laggedGate(source: () => boolean, delay = 300): () => boolean {
  * @param delay the delay time in ms
  * @returns a derived signal
  */
-function _deferredGate(source: () => boolean, delay = 300): () => boolean {
+export function deferredGate(
+  source: () => boolean,
+  delay = 300
+): () => boolean {
   const [follow, setFollow] = createSignal(false);
   const up = solidDebounce(() => setFollow(true), delay);
   createEffect(() => {
@@ -92,6 +95,7 @@ function _deferredGate(source: () => boolean, delay = 300): () => boolean {
       setFollow(false);
     }
   });
+  onCleanup(() => up.clear());
   return follow;
 }
 


### PR DESCRIPTION
## What changed

- Restore a 300 ms cold-start debounce before channel thread reply queries become enabled.
- Keep the immediate path only for the currently targeted reply while the channel Cmd+F find bar is open.
- Cancel pending debounce timers when transiently mounted threads unmount.

## Why

[PR #3305](https://github.com/macro-inc/macro/pull/3305) unintentionally removed the existing reply-fetch debounce while optimizing in-channel search. That allowed transiently mounted virtualized threads to enable reply queries immediately. Normal expansion and non-search deep-link navigation are now debounced; Cmd+F retains immediate targeted-reply navigation.

## Validation

- `bunx vitest run src/features/channel/Thread/tests` — 27 tests passed
- `bun run check` — type-check and Biome passed