### PR TITLE
fix(email): keep messages with draft replies expanded in thread view

### DIFF
--- a/apps/web/src/features/block-email/component/MessageList.tsx
+++ b/apps/web/src/features/block-email/component/MessageList.tsx
@@ -134,6 +134,15 @@ export function MessageList(props: MessageListProps) {
               );
             });
 
+            // A message with an in-progress draft reply stays expanded so the
+            // draft remains visible even after newer messages arrive (matches
+            // Gmail/Superhuman). Desktop only: mobile edits drafts in a drawer.
+            const hasDraft = createMemo(() => {
+              const messageID = message().db_id;
+              if (!messageID || isMobile()) return false;
+              return !!context.drafts.getDraftForMessage(messageID);
+            });
+
             const isExpanded = createMemo(() => {
               const messageID = message().db_id;
 
@@ -141,7 +150,12 @@ export function MessageList(props: MessageListProps) {
               const manuallyExpanded =
                 context.messages.isBodyExpanded(messageID);
 
-              return manuallyExpanded || isLastMessage() || isNewMessage();
+              return (
+                manuallyExpanded ||
+                isLastMessage() ||
+                isNewMessage() ||
+                hasDraft()
+              );
             });
 
             return (


### PR DESCRIPTION
## Summary

In the email thread view, a draft reply renders inline inside the message it replies to — but only while that message is expanded. If you started a draft on a message and then a newer message arrived, the drafted-on message collapsed (it was no longer the last/unread message) and the draft vanished from view.

Messages with an in-progress draft reply now always stay expanded, matching Gmail and Superhuman behavior.

## Changes

- Added a `hasDraft` condition to the `isExpanded` memo in `MessageList.tsx`, backed by `context.drafts.getDraftForMessage()` (a reactive store populated from the thread query, so this applies on initial load and when a draft appears later).
- Scoped to desktop only: on mobile the inline reply input never renders inside messages (drafts are edited in the compose drawer), so force-expanding there would show an expanded message with no draft attached.