### PR TITLE
fix(email): open search thread results at latest message expanded

### DIFF
--- a/apps/web/src/features/block-email/component/Email.tsx
+++ b/apps/web/src/features/block-email/component/Email.tsx
@@ -332,6 +332,8 @@ function EmailContent(props: EmailViewProps) {
   async function handleTargetMessage(messageId: string) {
     const messages = untrack(context.messages.list);
     if (!messages) return;
+    // Expand the target so the navigated-to hit isn't a collapsed row
+    context.messages.setExpandedBodyId(messageId, true);
     const targetIndex = messages.findIndex((m) => m.db_id === messageId);
 
     // Case 1: Message not in current loaded batch - need to load more

--- a/apps/web/src/features/next-soup/utils.ts
+++ b/apps/web/src/features/next-soup/utils.ts
@@ -29,6 +29,7 @@ import {
   type ChannelClickTarget,
   type EntityData,
   getSnippetHit,
+  isEmailEntity,
   isGithubPrEntity,
   isHitSnippetEntity,
   isSearchEntity,
@@ -465,7 +466,10 @@ export const openEntityInSplitFromUnifiedList = async (
   const { allowDuplicate, openInNewSplit, splitHandle, mergeHistory } = options;
   let { location } = options;
 
-  if (!location && isHitSnippetEntity(entity)) {
+  // Email rows open like plain soup rows — at the latest message, expanded —
+  // so only non-email snippet entities (calls) fall back to their row hit.
+  // Clicking a specific content hit still passes an explicit location.
+  if (!location && isHitSnippetEntity(entity) && !isEmailEntity(entity)) {
     location = getSnippetHit(entity)?.location;
   }
 


### PR DESCRIPTION
## Summary

Clicking an email thread row in search results landed at the oldest matched message with every message collapsed. It now behaves like opening a thread from the soup view (Superhuman-style): land on the newest message (or first unread), which renders expanded.

## Root cause

- `openEntityInSplitFromUnifiedList` promoted the row's best snippet hit into a navigation target for email rows, setting the `email_message_id` param. The email block then scrolled to that (often oldest) matched message.
- Messages only render expanded when they are the last message, unread, or manually expanded — so the targeted old message also appeared collapsed.

## Changes

- `next-soup/utils.ts`: the snippet-hit fallback on plain row clicks now skips email entities, so email rows open with the block's default initial scroll (first unread, else latest — both expanded). Call rows keep the fallback, and clicking a specific content-hit snippet still passes an explicit location and navigates to that exact message.
- `block-email/Email.tsx`: `handleTargetMessage` expands the target message body before scrolling, so explicit hit navigation never lands on a collapsed row.