### PR TITLE
feat(email): open mailto links in the in-app composer

### DIFF
--- a/apps/web/src/components/app/Layout.tsx
+++ b/apps/web/src/components/app/Layout.tsx
@@ -36,6 +36,7 @@ import {
   GoToHotkeys,
   type SidebarState,
 } from '@components/app/app-sidebar/sidebar';
+import { mountMailtoInterceptor } from '@components/app/mailto-interceptor';
 import {
   isSidebarVisible,
   SidebarCollapseContext,
@@ -347,6 +348,8 @@ function LayoutInner(props: RouteSectionProps) {
   });
 
   mountGlobalFocusListener();
+
+  mountMailtoInterceptor();
 
   attachGlobalDOMScope(document.body);
 

--- a/apps/web/src/components/app/mailto-interceptor.ts
+++ b/apps/web/src/components/app/mailto-interceptor.ts
@@ -26,7 +26,8 @@ export function mountMailtoInterceptor() {
           (el): el is HTMLAnchorElement =>
             el instanceof HTMLAnchorElement && el.href.startsWith('mailto:')
         );
-      if (!anchor) return;
+      // Links inside editors: let the click place the cursor instead.
+      if (!anchor || anchor.isContentEditable) return;
       const parsed = parseMailto(anchor.href);
       if (!parsed) return;
       // Not ready yet — let the OS mail client handle it.

--- a/apps/web/src/components/app/mailto-interceptor.ts
+++ b/apps/web/src/components/app/mailto-interceptor.ts
@@ -1,0 +1,48 @@
+import { globalSplitManager } from '@app/signal/splitLayout';
+import { parseMailto } from '@block-email/util/mailto';
+import { getOwner, onCleanup, onMount } from 'solid-js';
+
+/**
+ * Opens mailto: links in the in-app email composer instead of the OS mail
+ * client. Capture-phase listener so links inside email-body shadow roots and
+ * editors are caught; composedPath crosses the shadow boundaries.
+ */
+export function mountMailtoInterceptor() {
+  const owner = getOwner();
+  if (!owner) {
+    console.error(
+      'No owner. mountMailtoInterceptor should be called once - from within the component tree.'
+    );
+    return;
+  }
+  onMount(() => {
+    const onClick = (e: MouseEvent) => {
+      if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) {
+        return;
+      }
+      const anchor = e
+        .composedPath()
+        .find(
+          (el): el is HTMLAnchorElement =>
+            el instanceof HTMLAnchorElement && el.href.startsWith('mailto:')
+        );
+      if (!anchor) return;
+      const parsed = parseMailto(anchor.href);
+      if (!parsed) return;
+      // Not ready yet — let the OS mail client handle it.
+      const manager = globalSplitManager();
+      if (!manager) return;
+      e.preventDefault();
+      manager.openWithSplit({
+        type: 'component',
+        id: 'email-compose',
+        params: parsed.to.length ? { initialTo: parsed.to } : undefined,
+        preserveParams: true,
+      });
+    };
+    document.addEventListener('click', onClick, { capture: true });
+    onCleanup(() =>
+      document.removeEventListener('click', onClick, { capture: true })
+    );
+  });
+}

--- a/apps/web/src/components/app/split-layout/componentRegistry.tsx
+++ b/apps/web/src/components/app/split-layout/componentRegistry.tsx
@@ -386,7 +386,15 @@ registerComponent('channel-compose', () => {
 });
 registerComponent('email-compose', (params) => {
   usePageViewTracking('email-compose');
-  return <EmailCompose draftID={params?.draftID} />;
+  // mailto: links land here as `component/email-compose?to=a@x.com,b@y.com`.
+  const toParam = new URLSearchParams(window.location.search).get('to');
+  const initialTo =
+    params?.initialTo ??
+    toParam
+      ?.split(',')
+      .map((e) => e.trim())
+      .filter(Boolean);
+  return <EmailCompose draftID={params?.draftID} initialTo={initialTo} />;
 });
 registerComponent('task-compose', (params) => {
   usePageViewTracking('task-compose');

--- a/apps/web/src/features/block-email/component/compose/Compose.tsx
+++ b/apps/web/src/features/block-email/component/compose/Compose.tsx
@@ -38,6 +38,8 @@ import { WrapUnlessMobile } from '@core/mobile/WrapUnlessMobile';
 import { useCombinedRecipients } from '@core/signal/useCombinedRecipient';
 import {
   type ContactInfo,
+  emailToId,
+  recipientEntityMapper,
   tryMacroId,
   useDisplayName,
   type WithCustomUserInput,
@@ -75,6 +77,7 @@ import { emailClient } from '@service-email/client';
 import { debounce } from '@solid-primitives/scheduled';
 import { Surface } from '@ui';
 
+import * as EmailValidator from 'email-validator';
 import type { LexicalEditor } from 'lexical';
 import {
   createEffect,
@@ -109,6 +112,8 @@ let undoComposeSnapshot: UndoComposeSnapshot | null = null;
 
 type EmailComposeProps = {
   draftID?: string;
+  /** Prefill for the To field (e.g. from an intercepted mailto: link). Ignored when editing an existing draft. */
+  initialTo?: string[];
 };
 
 export function EmailCompose(props: EmailComposeProps) {
@@ -209,6 +214,19 @@ export function EmailCompose(props: EmailComposeProps) {
     }
     setIncludeSignature(restoredSnapshot.includeSignature);
     undoComposeSnapshot = null;
+  }
+
+  if (!props.draftID && props.initialTo?.length) {
+    form.setRecipients(
+      'to',
+      props.initialTo.map((email) =>
+        recipientEntityMapper('custom')({
+          id: emailToId(email),
+          email,
+          invalid: !EmailValidator.validate(email),
+        })
+      )
+    );
   }
 
   // --- Draft persistence ---

--- a/apps/web/src/features/block-email/util/mailto.test.ts
+++ b/apps/web/src/features/block-email/util/mailto.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { parseMailto } from './mailto';
+
+describe('parseMailto', () => {
+  it('parses a single recipient', () => {
+    expect(parseMailto('mailto:alice@example.com')).toEqual({
+      to: ['alice@example.com'],
+    });
+  });
+
+  it('parses comma-separated recipients', () => {
+    expect(parseMailto('mailto:alice@example.com,bob@example.com')).toEqual({
+      to: ['alice@example.com', 'bob@example.com'],
+    });
+  });
+
+  it('decodes percent-encoded addresses', () => {
+    expect(parseMailto('mailto:alice%40example.com')).toEqual({
+      to: ['alice@example.com'],
+    });
+  });
+
+  it('merges the non-standard ?to= param', () => {
+    expect(parseMailto('mailto:alice@example.com?to=bob@example.com')).toEqual({
+      to: ['alice@example.com', 'bob@example.com'],
+    });
+  });
+
+  it('handles an empty address (bare mailto:)', () => {
+    expect(parseMailto('mailto:')).toEqual({ to: [] });
+  });
+
+  it('ignores other query params', () => {
+    expect(
+      parseMailto('mailto:alice@example.com?subject=Hi&body=Hello')
+    ).toEqual({ to: ['alice@example.com'] });
+  });
+
+  it('returns null for non-mailto URLs', () => {
+    expect(parseMailto('https://example.com')).toBeNull();
+  });
+
+  it('returns null for unparseable input', () => {
+    expect(parseMailto('not a url')).toBeNull();
+  });
+});

--- a/apps/web/src/features/block-email/util/mailto.ts
+++ b/apps/web/src/features/block-email/util/mailto.ts
@@ -1,0 +1,44 @@
+/** Recipients extracted from a mailto: URL. */
+export type ParsedMailto = {
+  to: string[];
+};
+
+function safeDecode(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+/**
+ * Parses a mailto: URL into its recipients. Returns null for anything that
+ * isn't a valid mailto: URL. Addresses come from the path
+ * (`mailto:a@x.com,b@y.com`) plus the non-standard but common `?to=` param.
+ */
+export function parseMailto(href: string): ParsedMailto | null {
+  let url: URL;
+  try {
+    url = new URL(href);
+  } catch {
+    return null;
+  }
+  if (url.protocol !== 'mailto:') return null;
+
+  const to = url.pathname
+    .split(',')
+    .map((addr) => safeDecode(addr).trim())
+    .filter(Boolean);
+
+  const toParam = url.searchParams.get('to');
+  if (toParam) {
+    to.push(
+      ...toParam
+        .split(',')
+        .map((addr) => addr.trim())
+        .filter(Boolean)
+    );
+  }
+
+  return { to };
+}


### PR DESCRIPTION
## Summary

Clicking a `mailto:` link anywhere in the app now opens the in-app email composer with the To field prefilled, instead of launching the OS mail client.

## How it works

- **`mountMailtoInterceptor`** (mounted in `Layout`): capture-phase document click listener that walks `e.composedPath()` to find `mailto:` anchors, so links inside email-body shadow roots are caught too. Skips modified/non-left clicks, and falls back to the OS handler if the split manager isn't initialized yet.
- **`parseMailto`**: extracts recipients from the mailto path (`mailto:a@x.com,b@y.com`, percent-decoded) plus the non-standard but common `?to=` param. `subject`/`body`/`cc` params are intentionally dropped for now.
- **`EmailCompose`** gains an `initialTo` prop: on a fresh compose (no `draftID`), recipients are seeded as `custom` pills in the same shape `RecipientSelector` creates, including the `email-validator` check so malformed addresses render as invalid pills instead of being silently dropped.
- The `email-compose` split factory also reads `?to=` from the URL (same pattern as `?crmView=` on the companies split), so `component/email-compose?to=a@x.com,b@y.com` works for direct navigation — groundwork for later registering the app as a mailto protocol handler (`navigator.registerProtocolHandler`).