### PR TITLE
feat(mcp): enable Slack on the connectors list

### DIFF
--- a/.config/hakari.toml
+++ b/.config/hakari.toml
@@ -40,6 +40,9 @@ platforms = [
 # macro_sync_service_jwt and the sync-service packages must stay wasm-safe, so
 # they must not gain the workspace-hack dep, which pulls native-only features.
 workspace-members = [
+    # Standalone protocol library. Until a deployable service consumes it,
+    # ACP's schema features must not alter unrelated service build/codegen closures.
+    "agent_runtime_protocol",
     "xtask",
     # xtask command crates: dev-only automation split out of xtask so each
     # `cargo x <cmd>` compiles only its own dependency set.

--- a/.github/workspace-dep-closures.json
+++ b/.github/workspace-dep-closures.json
@@ -22,6 +22,9 @@
       "crates/remote_env_var",
       "crates/workspace-hack"
     ],
+    "agent_runtime_protocol": [
+      "crates/agent_runtime_protocol"
+    ],
     "ai_projections": [
       "crates/agent",
       "crates/ai_projections",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,13 +71,75 @@ dependencies = [
  "schemars 1.2.1",
  "serde",
  "serde_json",
- "strum",
+ "strum 0.27.2",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "tracing",
  "utoipa",
  "workspace-hack",
+]
+
+[[package]]
+name = "agent-client-protocol"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "882b815ffa67b023e1b40e7ea3bab3f05869654e8565d6811870c5545285e1d3"
+dependencies = [
+ "agent-client-protocol-derive",
+ "agent-client-protocol-schema",
+ "async-process",
+ "blocking",
+ "futures",
+ "futures-concurrency",
+ "rustc-hash 2.1.2",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "shell-words",
+ "tracing",
+ "uuid",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "agent-client-protocol-derive"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5ca63f112bd2459bcaf9eda0683b9ba95fc3b5e5fdd9036ca941c6a09345b1"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "agent-client-protocol-schema"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06679e1542356341f4550ccfb16338b64f37f6af70de2105446ef6fbb078234c"
+dependencies = [
+ "anyhow",
+ "derive_more 2.1.1",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "strum 0.28.0",
+ "tracing",
+]
+
+[[package]]
+name = "agent_runtime_protocol"
+version = "0.1.0"
+dependencies = [
+ "agent-client-protocol",
+ "futures",
+ "jsonrpsee",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -236,7 +298,7 @@ dependencies = [
  "soup",
  "sqlx",
  "sqs_client",
- "strum",
+ "strum 0.27.2",
  "sync_service_client",
  "system_properties",
  "teams",
@@ -280,7 +342,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
- "strum",
+ "strum 0.27.2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -610,6 +672,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -685,7 +759,7 @@ dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
- "strum",
+ "strum 0.27.2",
  "syn 2.0.117",
  "thiserror 2.0.18",
 ]
@@ -783,6 +857,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener 5.4.1",
+ "futures-lite 2.6.1",
+ "rustix 1.1.4",
+]
+
+[[package]]
 name = "async-recursion"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -791,6 +883,24 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix 1.1.4",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -876,6 +986,12 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
 ]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -1027,7 +1143,7 @@ dependencies = [
  "sha1 0.10.6",
  "sqlx",
  "sqs_client",
- "strum",
+ "strum 0.27.2",
  "teams",
  "thiserror 2.0.18",
  "time",
@@ -2058,6 +2174,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-task",
+ "futures-io",
+ "futures-lite 2.6.1",
+ "piper",
+]
+
+[[package]]
 name = "bollard"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2843,7 +2972,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
- "strum",
+ "strum 0.27.2",
  "tracing",
  "utoipa",
  "uuid",
@@ -2985,8 +3114,8 @@ dependencies = [
  "serde_json",
  "sqlx",
  "stream",
- "strum",
- "strum_macros",
+ "strum 0.27.2",
+ "strum_macros 0.27.2",
  "tokio",
  "tower 0.5.3",
  "tower-http",
@@ -4169,7 +4298,7 @@ dependencies = [
  "sqs_worker",
  "static_file",
  "stream",
- "strum",
+ "strum 0.27.2",
  "sync_service_client",
  "thiserror 2.0.18",
  "time",
@@ -4338,7 +4467,7 @@ dependencies = [
  "schemars 1.2.1",
  "serde",
  "sqlx",
- "strum",
+ "strum 0.27.2",
  "thiserror 2.0.18",
  "utoipa",
  "workspace-hack",
@@ -4615,7 +4744,7 @@ dependencies = [
  "macro_aws_config",
  "models_bulk_upload",
  "s3_key",
- "strum",
+ "strum 0.27.2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4741,7 +4870,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "sqlx",
- "strum",
+ "strum 0.27.2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4937,7 +5066,7 @@ dependencies = [
  "sqs_client",
  "sqs_worker",
  "static_file_service_client",
- "strum_macros",
+ "strum_macros 0.27.2",
  "system_properties",
  "thiserror 2.0.18",
  "tokio",
@@ -5003,7 +5132,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
- "strum",
+ "strum 0.27.2",
  "tokio",
  "tracing",
  "workspace-hack",
@@ -5537,7 +5666,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
- "strum",
+ "strum 0.27.2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5605,6 +5734,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-concurrency"
+version = "7.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175cd8cca9e1d45b87f18ffa75088f2099e3c4fe5e2f83e42de112560bea8ea6"
+dependencies = [
+ "fixedbitset 0.5.7",
+ "futures-core",
+ "futures-lite 2.6.1",
+ "pin-project",
+ "smallvec",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5659,7 +5801,10 @@ version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
 dependencies = [
+ "fastrand 2.4.1",
  "futures-core",
+ "futures-io",
+ "parking",
  "pin-project-lite",
 ]
 
@@ -5853,7 +5998,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yml",
- "strum_macros",
+ "strum_macros 0.27.2",
 ]
 
 [[package]]
@@ -6622,7 +6767,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e9b187a72d63adbfba487f48095306ac823049cb504ee195541e91c7775f5ad"
 dependencies = [
  "anyhow",
- "async-channel",
+ "async-channel 1.9.0",
  "base64 0.13.1",
  "futures-lite 1.13.0",
  "http 0.2.12",
@@ -7310,7 +7455,7 @@ dependencies = [
  "schemars 1.2.1",
  "serde",
  "serde_json",
- "strum",
+ "strum 0.27.2",
  "thiserror 2.0.18",
  "utoipa",
  "uuid",
@@ -7475,6 +7620,122 @@ dependencies = [
  "regex",
  "serde_json",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "jsonrpsee"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f3f48dc3e6b8bd21e15436c1ddd0bc22a6a54e8ec46fedd6adf3425f396ec6a"
+dependencies = [
+ "jsonrpsee-core",
+ "jsonrpsee-server",
+ "jsonrpsee-types",
+ "jsonrpsee-ws-client",
+ "tokio",
+]
+
+[[package]]
+name = "jsonrpsee-client-transport"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf36eb27f8e13fa93dcb50ccb44c417e25b818cfa1a481b5470cd07b19c60b98"
+dependencies = [
+ "base64 0.22.1",
+ "futures-util",
+ "http 1.4.0",
+ "jsonrpsee-core",
+ "pin-project",
+ "rustls 0.23.40",
+ "rustls-pki-types",
+ "rustls-platform-verifier 0.5.3",
+ "soketto",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tokio-util",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "jsonrpsee-core"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "316c96719901f05d1137f19ba598b5fe9c9bc39f4335f67f6be8613921946480"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-timer",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "jsonrpsee-types",
+ "parking_lot",
+ "pin-project",
+ "rand 0.9.4",
+ "rustc-hash 2.1.2",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tower 0.5.3",
+ "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-server"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c51b7c290bb68ce3af2d029648148403863b982f138484a73f02a9dd52dbd7f"
+dependencies = [
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.9.0",
+ "hyper-util",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
+ "pin-project",
+ "route-recognizer",
+ "serde",
+ "serde_json",
+ "soketto",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower 0.5.3",
+ "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-types"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc88ff4688e43cc3fa9883a8a95c6fa27aa2e76c96e610b737b6554d650d7fd5"
+dependencies = [
+ "http 1.4.0",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "jsonrpsee-ws-client"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b6fceceeb05301cc4c065ab3bd2fa990d41ff4eb44e4ca1b30fa99c057c3e79"
+dependencies = [
+ "http 1.4.0",
+ "jsonrpsee-client-transport",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
+ "tower 0.5.3",
+ "url",
 ]
 
 [[package]]
@@ -8316,7 +8577,7 @@ version = "0.1.0"
 dependencies = [
  "macro_env_var",
  "serde",
- "strum",
+ "strum 0.27.2",
  "thiserror 2.0.18",
  "tracing",
  "workspace-hack",
@@ -8988,7 +9249,7 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "sqlx",
- "strum",
+ "strum 0.27.2",
  "thiserror 2.0.18",
  "tracing",
  "utoipa",
@@ -9004,7 +9265,7 @@ dependencies = [
  "cowlike",
  "serde",
  "serde_json",
- "strum",
+ "strum 0.27.2",
  "utoipa",
  "workspace-hack",
 ]
@@ -9024,7 +9285,7 @@ version = "0.1.0"
 dependencies = [
  "serde",
  "serde_json",
- "strum",
+ "strum 0.27.2",
  "thiserror 2.0.18",
  "utoipa",
  "workspace-hack",
@@ -9047,7 +9308,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
- "strum",
+ "strum 0.27.2",
  "tracing",
  "utoipa",
  "uuid",
@@ -9080,7 +9341,7 @@ name = "models_bulk_upload"
 version = "0.1.0"
 dependencies = [
  "serde",
- "strum",
+ "strum 0.27.2",
  "utoipa",
  "workspace-hack",
 ]
@@ -9110,7 +9371,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "sqlx",
- "strum",
+ "strum 0.27.2",
  "thiserror 2.0.18",
  "utoipa",
  "uuid",
@@ -9141,7 +9402,7 @@ name = "models_opensearch"
 version = "0.1.0"
 dependencies = [
  "serde",
- "strum",
+ "strum 0.27.2",
  "workspace-hack",
 ]
 
@@ -9171,7 +9432,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
- "strum",
+ "strum 0.27.2",
  "utoipa",
  "workspace-hack",
 ]
@@ -9208,7 +9469,7 @@ dependencies = [
  "schemars 1.2.1",
  "serde",
  "serde_json",
- "strum",
+ "strum 0.27.2",
  "utoipa",
  "uuid",
  "workspace-hack",
@@ -9256,7 +9517,7 @@ dependencies = [
  "models_properties",
  "serde",
  "serde_json",
- "strum",
+ "strum 0.27.2",
  "utoipa",
  "uuid",
  "workspace-hack",
@@ -9270,7 +9531,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
- "strum",
+ "strum 0.27.2",
  "utoipa",
  "uuid",
  "workspace-hack",
@@ -9394,7 +9655,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "strum",
+ "strum 0.27.2",
  "thiserror 2.0.18",
  "tokio",
  "tower 0.5.3",
@@ -9544,7 +9805,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "sqlx",
- "strum",
+ "strum 0.27.2",
  "thiserror 2.0.18",
  "tokio",
  "tower 0.5.3",
@@ -10062,7 +10323,7 @@ dependencies = [
  "opensearch_query_builder",
  "serde",
  "serde_json",
- "strum",
+ "strum 0.27.2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -10691,6 +10952,17 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand 2.4.1",
+ "futures-io",
+]
 
 [[package]]
 name = "piston-float"
@@ -11790,7 +12062,7 @@ dependencies = [
  "quinn",
  "rustls 0.23.40",
  "rustls-pki-types",
- "rustls-platform-verifier",
+ "rustls-platform-verifier 0.7.0",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -11975,6 +12247,12 @@ checksum = "4d0df4f84d119d09b5c9c9e8db0fe9bfb5b47b04d0bb95b0763cf81bd9baa559"
 dependencies = [
  "triomphe",
 ]
+
+[[package]]
+name = "route-recognizer"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
 
 [[package]]
 name = "rowan"
@@ -12165,6 +12443,27 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19787cda76408ec5404443dc8b31795c87cd8fec49762dc75fa727740d34acc1"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni 0.21.1",
+ "log",
+ "once_cell",
+ "rustls 0.23.40",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki 0.103.13",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs 0.26.11",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
@@ -12180,7 +12479,7 @@ dependencies = [
  "rustls-webpki 0.103.13",
  "security-framework",
  "security-framework-sys",
- "webpki-root-certs",
+ "webpki-root-certs 1.0.7",
  "windows-sys 0.61.2",
 ]
 
@@ -12481,7 +12780,7 @@ dependencies = [
  "sqlx",
  "sqs_client",
  "sqs_worker",
- "strum",
+ "strum 0.27.2",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
@@ -12534,7 +12833,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
- "strum",
+ "strum 0.27.2",
  "system_properties",
  "thiserror 2.0.18",
  "tokio",
@@ -12820,6 +13119,7 @@ version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",
@@ -13120,6 +13420,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13306,6 +13612,22 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "soketto"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e859df029d160cb88608f5d7df7fb4753fd20fdfb4de5644f3d8b8440841721"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "rand 0.8.6",
+ "sha1 0.10.6",
 ]
 
 [[package]]
@@ -13604,7 +13926,7 @@ dependencies = [
  "s3_key",
  "serde",
  "serde_json",
- "strum",
+ "strum 0.27.2",
  "tracing",
  "uuid",
  "workspace-hack",
@@ -13696,7 +14018,7 @@ dependencies = [
  "serde",
  "serde_dynamo",
  "serde_json",
- "strum_macros",
+ "strum_macros 0.27.2",
  "thiserror 2.0.18",
  "tokio",
  "tower-http",
@@ -13834,7 +14156,16 @@ version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.27.2",
+]
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros 0.28.0",
 ]
 
 [[package]]
@@ -13842,6 +14173,18 @@ name = "strum_macros"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -14337,6 +14680,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -15530,6 +15874,15 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
+dependencies = [
+ "webpki-root-certs 1.0.7",
+]
+
+[[package]]
+name = "webpki-root-certs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
@@ -16067,7 +16420,7 @@ dependencies = [
  "async-trait",
  "proc-macro2",
  "quote",
- "strum",
+ "strum 0.27.2",
  "syn 2.0.117",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -16350,7 +16703,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha2 0.10.9",
- "strum",
+ "strum 0.27.2",
  "tokio",
  "xtask_paths",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 
 members = [
   "crates/agent",
+  "crates/agent_runtime_protocol",
   "crates/ai_projections",
   "crates/ai_usage",
   "crates/bot_id",
@@ -89,6 +90,7 @@ members = [
 anyhow = "1.0.100"
 apollo-compiler = "1"
 apollo-parser = "0.8"
+agent-client-protocol = "1.2.0"
 askama = "0.14"
 async-graphql = "7.2.1"
 async-lock = "3"
@@ -144,6 +146,7 @@ image = "0.25"
 indexmap = "2"
 inquire = "0.7"
 itertools = "0.14"
+jsonrpsee = { version = "0.26", features = ["server"] }
 jsonwebtoken = { git = "https://github.com/whutchinson98/jsonwebtoken", features = [
   "rust_crypto",
 ] }

--- a/apps/web/scripts/generate-dcs-tools.ts
+++ b/apps/web/scripts/generate-dcs-tools.ts
@@ -59,7 +59,7 @@ type FrontendSchemas = z.infer<typeof FrontendSchemasValidator>;
 
 async function buildAndRunSchemaGenerator(): Promise<void> {
   console.log('Building gen_tool_schemas binary...');
-  await $`cd ${rustWorkspaceDir} && SQLX_OFFLINE=true cargo build --bin gen_tool_schemas`;
+  await $`cd ${rustWorkspaceDir} && SQLX_OFFLINE=true cargo build --package ai_tools --bin gen_tool_schemas`;
   console.log('Build complete.');
 
   await $`rm -rf ${path.join(aiToolsDir, 'schemas')}`.quiet();

--- a/apps/web/src/lib/core/component/AI/constant/mcpServers.ts
+++ b/apps/web/src/lib/core/component/AI/constant/mcpServers.ts
@@ -1,4 +1,3 @@
-import { DEV_MODE_ENV } from '@core/constant/featureFlags';
 import IconDatadog from '@icon/mcp-datadog.svg';
 import IconGithub from '@icon/mcp-github.svg';
 import IconGrafana from '@icon/mcp-grafana.svg';
@@ -21,16 +20,11 @@ export const QUICK_CONNECT_SERVERS = [
     url: 'https://mcp.linear.app/mcp',
     icon: IconLinear as SvgIcon,
   },
-  // Slack is dev-only until the integration is ready for production.
-  ...(DEV_MODE_ENV
-    ? ([
-        {
-          server_name: 'Slack',
-          url: 'https://mcp.slack.com/mcp',
-          icon: IconSlack as SvgIcon,
-        },
-      ] as const)
-    : []),
+  {
+    server_name: 'Slack',
+    url: 'https://mcp.slack.com/mcp',
+    icon: IconSlack as SvgIcon,
+  },
   {
     server_name: 'Notion',
     url: 'https://mcp.notion.com/mcp',
@@ -59,8 +53,7 @@ export type QuickConnectServer = (typeof QUICK_CONNECT_SERVERS)[number];
  * Preset servers surfaced directly on the Connections page (with a one-line
  * pitch) to encourage connecting — the only catalog now that the "Add server"
  * dialog is custom-URL only. Ordered by how much we want to promote each;
- * presets absent from {@link QUICK_CONNECT_SERVERS} (e.g. dev-only Slack in
- * production) are dropped automatically.
+ * presets absent from {@link QUICK_CONNECT_SERVERS} are dropped automatically.
  */
 const FEATURED_SERVER_TAGLINES: [name: string, tagline: string][] = [
   ['Linear', 'Create and update issues without leaving Macro.'],

--- a/crates/agent_runtime_protocol/Cargo.toml
+++ b/crates/agent_runtime_protocol/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+edition = "2024"
+name = "agent_runtime_protocol"
+publish = false
+version = "0.1.0"
+
+[features]
+test-utils = []
+
+[dependencies]
+agent-client-protocol = { workspace = true }
+futures = { workspace = true }
+jsonrpsee = { workspace = true, features = ["ws-client"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["rt", "sync"] }
+tracing = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["io-std", "io-util", "macros", "rt", "rt-multi-thread", "time"] }

--- a/crates/agent_runtime_protocol/SPEC.md
+++ b/crates/agent_runtime_protocol/SPEC.md
@@ -1,0 +1,244 @@
+# Agent Runtime Protocol
+
+This is an internal design note for the protocol between our agent service and
+the runtime inside a container. It is meant to answer practical questions:
+
+- Which side connects?
+- How does the service send commands back into the container?
+- How do ACP messages get to the right agent process?
+- Can we use the same code without a WebSocket?
+
+## The problem
+
+We want a container to make one outbound connection to our service and keep it
+open for the lifetime of the container. The connection needs to carry three
+different kinds of traffic:
+
+| Message | Direction | What it is for |
+|---|---|---|
+| `SystemEvent` | Runtime → Service | Runtime and agent lifecycle updates. |
+| `Command` | Service → Runtime | An application-defined operation for the runtime. |
+| `ACP` | Both directions | The actual conversation between an ACP client and an agent. |
+
+The runtime connection should survive agent restarts. An agent is one thing
+running inside the runtime, not the owner of the runtime connection.
+
+There are two layers:
+
+1. The logical protocol is a stream of complete JSON-RPC messages:
+   `system_event`, `command`, and `acp`.
+2. The production WebSocket binding uses jsonrpsee to move those messages.
+
+The logical layer does not care about WebSockets. In Rust, its transport
+boundary is `agent_client_protocol::Channel`. Tests and local tools can connect
+the service and runtime with `Channel::duplex()` and skip networking entirely.
+
+The crate currently includes:
+
+- an in-memory setup using `Channel::duplex()`;
+- a jsonrpsee WebSocket carrier;
+- no generic `Carrier` trait. `Channel` is the abstraction boundary instead.
+
+## Why the WebSocket carrier looks a little weird
+
+The runtime initiates the WebSocket, so it is the jsonrpsee client. A jsonrpsee
+client can make requests and open subscriptions, but it cannot register a
+handler for a new request initiated by the server.
+
+That means the service cannot send a normal top-level JSON-RPC `command`
+request directly to the runtime.
+
+We solve this by tunnelling complete logical JSON-RPC messages:
+
+- the runtime opens a subscription for service → runtime traffic;
+- the service puts logical messages into subscription items;
+- the runtime uses `send` for runtime → service traffic.
+
+The nested command is still a real JSON-RPC request with its own ID. Its
+response comes back as a complete nested JSON-RPC response. The carrier does
+not reinterpret it.
+
+## WebSocket carrier
+
+The carrier has four method names:
+
+| Method | Direction | Purpose |
+|---|---|---|
+| `subscribe` | Runtime → Service | Open the service-to-runtime stream. |
+| `message` | Service → Runtime | Deliver a subscription item. |
+| `unsubscribe` | Runtime → Service | Close the stream. |
+| `send` | Runtime → Service | Deliver one logical message to the service. |
+
+### Opening the connection
+
+After opening the WebSocket, the runtime calls `subscribe` with a
+`connectionId`. The runtime chooses this identifier, and it should be unique
+to the connection attempt.
+
+### Service to runtime
+
+The service sends each logical message as a subscription item. A command has
+two IDs with different purposes:
+
+- `subscription` belongs to jsonrpsee;
+- the nested JSON-RPC request ID belongs to the logical command.
+
+Command responses are matched using the nested logical ID, not `commandId`.
+
+### Runtime to service
+
+The runtime carries each logical message with `send`, including the active
+`connectionId` and the complete nested JSON-RPC message.
+
+`send` returns `null` when the carrier accepted the nested message. That is not
+an acknowledgement of the logical notification. It only tells the runtime
+that the message reached the logical connection.
+
+If `connectionId` has no active subscription, the service returns JSON-RPC
+error `-32004`.
+
+## Startup flow
+
+The expected startup order is:
+
+```text
+Runtime                                      Service
+   │                                            │
+   ├── open WebSocket ─────────────────────────►│
+   ├── subscribe(connectionId) ────────────────►│
+   │◄────────────────────────── subscription ID ┤
+   ├── system_event(runtime/ready) ────────────►│
+   │◄──────────────── command(runtime/configure)┤
+   ├── command response ───────────────────────►│
+   │                                            │
+   ├── start agent process                      │
+   ├── system_event(agent/started) ────────────►│
+   │◄────────────────────────── acp(initialize) ┤
+   ├── acp(initialize response) ───────────────►│
+```
+
+The command and event names in this diagram are application-defined strings,
+not protocol-defined enum variants. Starting the agent process is a local
+runtime action; it is not caused by an agent-lifecycle command from the
+service.
+
+`runtime/ready` is the runtime's first logical message. The service normally
+answers with `runtime/configure` before it sends other commands or ACP traffic.
+
+The runtime opens the agent's ACP channel before emitting `agent/started`. If
+startup fails, it emits `agent/stopped` or another useful diagnostic event for
+the same Agent Instance ID.
+
+## Logical messages
+
+The logical stream has only three method names:
+
+| Method | Direction | JSON-RPC shape |
+|---|---|---|
+| `system_event` | Runtime → Service | Notification |
+| `command` | Service → Runtime | Request and response |
+| `acp` | Both directions | Notification |
+
+### SystemEvent
+
+```typescript
+interface SystemEvent {
+  eventId: string;
+  sequence: number;
+  name: SystemEventName;
+  occurredAt: string;
+  agentId?: string;
+  agentInstanceId?: string;
+  payload?: unknown;
+}
+```
+
+The protocol does not define an event-name catalog yet. The Rust enum is
+non-exhaustive and currently contains only `SystemEventName::Unknown(String)`.
+Every wire string is preserved in that variant.
+
+An agent-scoped event includes both `agentId` and `agentInstanceId`. A
+runtime-scoped event omits both.
+
+`eventId` stays the same if the same logical event is replayed. `sequence`
+increases within a runtime instance. `occurredAt` is an RFC 3339 timestamp.
+
+System events are notifications. There is no logical response or acceptance
+message.
+
+### Command
+
+```typescript
+interface Command {
+  commandId: string;
+  name: CommandName;
+  agentId?: string;
+  agentInstanceId?: string;
+  payload?: unknown;
+}
+
+type CommandResult = {
+  status: "completed";
+  value?: unknown;
+};
+```
+
+The protocol does not define a command-name catalog yet. This enum is also
+non-exhaustive and currently contains only `CommandName::Unknown(String)`.
+Every wire string round-trips unchanged. In particular, this protocol does not
+define commands for starting, stopping, or restarting agents.
+
+A command is a JSON-RPC request, so it also has a logical request ID in the
+JSON-RPC envelope. That ID is what matches the response. `commandId` is an
+application-level identifier that handlers can use for logging or
+deduplication.
+
+There is no `accepted` result. A command either completes with
+`CommandResult`, returns a JSON-RPC error, or remains pending until the
+connection closes.
+
+Commands can run concurrently and complete out of order.
+
+### ACP
+
+```typescript
+interface AcpMessage {
+  messageId: string;
+  agentId: string;
+  agentInstanceId: string;
+  message: object;
+}
+```
+
+`message` is one complete ACP `RawJsonRpcMessage`. It can be an ACP request,
+notification, success response, or error response. We do not convert it to a
+string or rewrite its request IDs.
+
+The outer `acp` message is always a notification. If the nested ACP message is
+a request, its response arrives later in another `acp` notification.
+
+## Routing ACP to agents
+
+One runtime connection can host several agent processes. ACP routes are keyed
+by both `agentId` and `agentInstanceId`.
+
+The instance ID matters because an agent may restart while keeping the same
+logical Agent ID. A message for the old process should never reach the new one.
+
+Unknown targets are discarded locally because the outer message is a
+notification and has no response. Each failed delivery is traced at `TRACE`
+level with its message, agent, and agent-instance identifiers.
+
+The Rust API returns an official `agent_client_protocol::Channel` for each
+target. This lets the service attach an official ACP `Client` and lets the
+runtime attach an official ACP `Agent` or `AcpAgent` process wrapper directly.
+
+## Connection lifecycle
+
+The runtime opens a jsonrpsee WebSocket and calls `connect_runtime`. That
+function subscribes before returning the logical `Channel`, which is then
+passed to `RuntimeConnection::connect` with a `CommandHandler`.
+
+Dropping either role connection stops its driver. Dropping the runtime also
+cancels in-flight command handlers and closes its ACP channels. Pending service
+commands fail instead of hanging forever.

--- a/crates/agent_runtime_protocol/examples/acp.rs
+++ b/crates/agent_runtime_protocol/examples/acp.rs
@@ -1,0 +1,55 @@
+//! Connect the official ACP Client and Agent through an Agent Runtime connection.
+//!
+//! Run with:
+//!
+//! ```text
+//! cargo run -p agent_runtime_protocol --example acp
+//! ```
+
+use agent_client_protocol::schema::ProtocolVersion;
+use agent_client_protocol::schema::v1::{InitializeRequest, InitializeResponse};
+use agent_client_protocol::{Agent, Channel, Client};
+use agent_runtime_protocol::connection::{AgentTarget, RuntimeConnection, ServerConnection};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let (service_channel, runtime_channel) = Channel::duplex();
+    let service = ServerConnection::connect(service_channel, ());
+    let runtime = RuntimeConnection::connect(runtime_channel, ());
+    let target = AgentTarget::new("primary", "agent-instance-1");
+
+    // These are official agent_client_protocol::Channel values. No adapter API or
+    // string serialization is needed by either ACP component.
+    let service_acp = service.acp(target.clone())?;
+    let runtime_acp = runtime.acp(target)?;
+
+    let agent = tokio::spawn(async move {
+        Agent
+            .builder()
+            .on_receive_request(
+                async move |request: InitializeRequest, responder, _connection| {
+                    responder.respond(InitializeResponse::new(request.protocol_version))
+                },
+                agent_client_protocol::on_receive_request!(),
+            )
+            .connect_to(runtime_acp)
+            .await
+    });
+
+    let response = Client
+        .connect_with(service_acp, async |connection| {
+            connection
+                .send_request(InitializeRequest::new(ProtocolVersion::V1))
+                .block_task()
+                .await
+        })
+        .await?;
+    println!(
+        "official ACP initialize completed with {:?}",
+        response.protocol_version
+    );
+
+    agent.abort();
+    let _ = agent.await;
+    Ok(())
+}

--- a/crates/agent_runtime_protocol/examples/commands_and_events.rs
+++ b/crates/agent_runtime_protocol/examples/commands_and_events.rs
@@ -1,0 +1,69 @@
+//! Exchange an application-defined command and system event in memory.
+//!
+//! Run with:
+//!
+//! ```text
+//! cargo run -p agent_runtime_protocol --example commands_and_events
+//! ```
+
+use agent_client_protocol::Channel;
+use agent_runtime_protocol::connection::{
+    CommandHandler, RuntimeConnection, ServerConnection, SystemEventHandler,
+};
+use agent_runtime_protocol::schema::v0::{
+    Command, CommandName, CommandResult, SystemEvent, SystemEventName,
+};
+use serde_json::json;
+use tokio::sync::mpsc;
+
+struct RuntimeCommands;
+
+impl CommandHandler for RuntimeCommands {
+    async fn handle(
+        &self,
+        command: Command,
+    ) -> Result<CommandResult, agent_client_protocol::Error> {
+        println!("runtime received command: {}", command.name);
+        Ok(CommandResult::completed_with(json!({
+            "handled": command.name,
+        })))
+    }
+}
+
+struct ServiceEvents(mpsc::UnboundedSender<SystemEvent>);
+
+impl SystemEventHandler for ServiceEvents {
+    async fn handle(&self, event: SystemEvent) -> Result<(), agent_client_protocol::Error> {
+        self.0
+            .send(event)
+            .map_err(agent_client_protocol::util::internal_error)
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let (service_channel, runtime_channel) = Channel::duplex();
+    let (event_sender, mut events) = mpsc::unbounded_channel();
+
+    let service = ServerConnection::connect(service_channel, ServiceEvents(event_sender));
+    let runtime = RuntimeConnection::connect(runtime_channel, RuntimeCommands);
+
+    runtime.system_event(SystemEvent::new(
+        "event-1",
+        1,
+        SystemEventName::Unknown("example/connected".to_owned()),
+        "2026-07-17T00:00:00Z",
+    ))?;
+    let event = events.recv().await.ok_or("event stream closed")?;
+    println!("service received event: {}", event.name);
+
+    let result = service
+        .command(Command::new(
+            "command-1",
+            CommandName::Unknown("example/echo".to_owned()),
+        ))
+        .await?;
+    println!("service received command result: {result:?}");
+
+    Ok(())
+}

--- a/crates/agent_runtime_protocol/examples/mock_container.rs
+++ b/crates/agent_runtime_protocol/examples/mock_container.rs
@@ -1,0 +1,223 @@
+//! Interactive end-to-end example with a mock container and Claude Code.
+//!
+//! The process contains two sides:
+//!
+//! - the service accepts a runtime-initiated WebSocket, prints protocol events,
+//!   and provides an interactive prompt on stdin;
+//! - a Tokio task stands in for a container, connects its runtime to the service,
+//!   and starts Zed's Claude Code ACP adapter with `npx`.
+//!
+//! Prerequisites:
+//!
+//! - Node.js and `npx` must be installed;
+//! - `ANTHROPIC_API_KEY` must be available to the process;
+//! - the first run may take longer while `npx` downloads the adapter.
+//!
+//! Run with:
+//!
+//! ```text
+//! cargo run -p agent_runtime_protocol --example mock_container
+//! ```
+//!
+//! Enter prompts at `you>`. Enter `/quit` or send EOF to stop.
+
+use std::error::Error;
+use std::io::{self as stdio, Write};
+use std::sync::Arc;
+
+use agent_client_protocol::schema::ProtocolVersion;
+use agent_client_protocol::schema::v1::{
+    ContentBlock, InitializeRequest, NewSessionRequest, PromptRequest, RequestPermissionOutcome,
+    RequestPermissionRequest, RequestPermissionResponse, SessionNotification, TextContent,
+};
+use agent_client_protocol::{AcpAgent, Agent, Channel, Client, ConnectTo, ConnectionTo};
+use agent_runtime_protocol::connection::{AgentTarget, RuntimeConnection, ServerConnection};
+use agent_runtime_protocol::transport::jsonrpsee::{ServerTransport, connect_runtime};
+use jsonrpsee::server::Server;
+use jsonrpsee::ws_client::WsClientBuilder;
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::sync::Notify;
+
+#[cfg(test)]
+#[path = "mock_container/test.rs"]
+mod test;
+
+type AnyError = Box<dyn Error + Send + Sync>;
+
+const CONNECTION_ID: &str = "mock-container-connection";
+const AGENT_ID: &str = "claude";
+const AGENT_INSTANCE_ID: &str = "claude-instance-1";
+const ZED_CLAUDE_CODE_ACP: &str = "@zed-industries/claude-code-acp@0.16.2";
+
+#[tokio::main]
+async fn main() -> Result<(), AnyError> {
+    let carrier = ServerTransport::new();
+    let websocket = Server::builder().build("127.0.0.1:0").await?;
+    let address = websocket.local_addr()?;
+    let websocket_handle = websocket.start(carrier.rpc_module()?);
+    println!("service listening on ws://{address}");
+
+    let acp_ready = Arc::new(Notify::new());
+    let mut container = tokio::spawn(run_mock_container(
+        format!("ws://{address}"),
+        Arc::clone(&acp_ready),
+    ));
+    let incoming = accept_runtime(&carrier, &mut container).await?;
+    println!(
+        "service accepted runtime connection {}",
+        incoming.connection_id()
+    );
+
+    let service = ServerConnection::connect(incoming.into_channel(), ());
+    wait_for_acp(&acp_ready, &mut container).await?;
+
+    let target = AgentTarget::new(AGENT_ID, AGENT_INSTANCE_ID);
+    let acp = service.acp(target)?;
+    let chat = run_interactive_client(acp);
+    tokio::pin!(chat);
+
+    let result = tokio::select! {
+        result = &mut chat => {
+            container.abort();
+            let _ = container.await;
+            result
+        }
+        container_result = &mut container => {
+            match container_result {
+                Ok(Ok(())) => Err("mock container exited unexpectedly".into()),
+                Ok(Err(error)) => Err(error),
+                Err(error) => Err(Box::new(error) as AnyError),
+            }
+        }
+    };
+
+    drop(service);
+    websocket_handle.stop()?;
+    websocket_handle.stopped().await;
+    result
+}
+
+async fn accept_runtime(
+    carrier: &ServerTransport,
+    container: &mut tokio::task::JoinHandle<Result<(), AnyError>>,
+) -> Result<agent_runtime_protocol::transport::jsonrpsee::IncomingConnection, AnyError> {
+    tokio::select! {
+        incoming = carrier.accept() => incoming
+            .ok_or_else(|| "mock container disconnected before subscribing".into()),
+        result = &mut *container => Err(container_startup_error(result)),
+    }
+}
+
+async fn wait_for_acp(
+    ready: &Notify,
+    container: &mut tokio::task::JoinHandle<Result<(), AnyError>>,
+) -> Result<(), AnyError> {
+    tokio::select! {
+        () = ready.notified() => Ok(()),
+        result = &mut *container => Err(container_startup_error(result)),
+    }
+}
+
+fn container_startup_error(
+    result: Result<Result<(), AnyError>, tokio::task::JoinError>,
+) -> AnyError {
+    match result {
+        Ok(Ok(())) => "mock container exited before startup completed".into(),
+        Ok(Err(error)) => error,
+        Err(error) => Box::new(error),
+    }
+}
+
+fn cancelled_permission_response() -> RequestPermissionResponse {
+    RequestPermissionResponse::new(RequestPermissionOutcome::Cancelled)
+}
+
+async fn run_mock_container(websocket_url: String, acp_ready: Arc<Notify>) -> Result<(), AnyError> {
+    let client = Arc::new(WsClientBuilder::default().build(websocket_url).await?);
+    let channel = connect_runtime(client, CONNECTION_ID).await?;
+    let runtime = RuntimeConnection::connect(channel, ());
+
+    let target = AgentTarget::new(AGENT_ID, AGENT_INSTANCE_ID);
+    let acp = runtime.acp(target)?;
+    acp_ready.notify_one();
+
+    // Construct the command explicitly because the SDK's convenience helper now
+    // points at the renamed package. This example intentionally runs Zed's wrapper.
+    let claude_code = AcpAgent::from_args(["npx", "-y", ZED_CLAUDE_CODE_ACP])?;
+    ConnectTo::<Client>::connect_to(claude_code, acp)
+        .await
+        .map_err(Into::into)
+}
+
+async fn run_interactive_client(acp: Channel) -> Result<(), AnyError> {
+    Client
+        .builder()
+        .on_receive_notification(
+            async move |notification: SessionNotification, _connection| {
+                println!("\n[ACP session event] {:#?}", notification.update);
+                Ok(())
+            },
+            agent_client_protocol::on_receive_notification!(),
+        )
+        .on_receive_request(
+            async move |request: RequestPermissionRequest, responder, _connection| {
+                println!("\n[ACP permission request] {request:#?}");
+                println!("[ACP permission cancelled: this example does not prompt for approval]");
+                responder.respond(cancelled_permission_response())
+            },
+            agent_client_protocol::on_receive_request!(),
+        )
+        .connect_with(acp, |connection: ConnectionTo<Agent>| async move {
+            let initialized = connection
+                .send_request(InitializeRequest::new(ProtocolVersion::V1))
+                .block_task()
+                .await?;
+            println!("[ACP initialized] {initialized:#?}");
+
+            let cwd = std::env::current_dir().map_err(|error| {
+                agent_client_protocol::Error::internal_error()
+                    .data(format!("cannot determine working directory: {error}"))
+            })?;
+            let session = connection
+                .send_request(NewSessionRequest::new(cwd))
+                .block_task()
+                .await?;
+            println!("[ACP session started] {}", session.session_id);
+            println!("type a prompt, or /quit to exit");
+
+            let mut lines = BufReader::new(tokio::io::stdin()).lines();
+            loop {
+                print!("you> ");
+                stdio::stdout()
+                    .flush()
+                    .map_err(agent_client_protocol::util::internal_error)?;
+                let Some(line) = lines
+                    .next_line()
+                    .await
+                    .map_err(agent_client_protocol::util::internal_error)?
+                else {
+                    break;
+                };
+                let line = line.trim();
+                if line == "/quit" {
+                    break;
+                }
+                if line.is_empty() {
+                    continue;
+                }
+
+                let response = connection
+                    .send_request(PromptRequest::new(
+                        session.session_id.clone(),
+                        vec![ContentBlock::Text(TextContent::new(line))],
+                    ))
+                    .block_task()
+                    .await?;
+                println!("\n[ACP prompt completed] {response:#?}");
+            }
+
+            Ok(())
+        })
+        .await?;
+    Ok(())
+}

--- a/crates/agent_runtime_protocol/examples/mock_container/test.rs
+++ b/crates/agent_runtime_protocol/examples/mock_container/test.rs
@@ -1,0 +1,42 @@
+use super::*;
+use tokio::time::{Duration, timeout};
+
+#[tokio::test]
+async fn startup_observes_container_failure_before_subscription() {
+    let carrier = ServerTransport::new();
+    let mut container = tokio::spawn(async {
+        Err::<(), AnyError>(std::io::Error::other("container startup failed").into())
+    });
+
+    let error = timeout(
+        Duration::from_secs(1),
+        accept_runtime(&carrier, &mut container),
+    )
+    .await
+    .expect("container failure should be observed promptly")
+    .expect_err("startup should fail when the container exits");
+
+    assert!(error.to_string().contains("container startup failed"));
+}
+
+#[tokio::test]
+async fn startup_observes_container_failure_before_acp_is_ready() {
+    let ready = Notify::new();
+    let mut container = tokio::spawn(async {
+        Err::<(), AnyError>(std::io::Error::other("ACP startup failed").into())
+    });
+
+    let error = timeout(Duration::from_secs(1), wait_for_acp(&ready, &mut container))
+        .await
+        .expect("container failure should be observed promptly")
+        .expect_err("startup should fail when ACP never becomes ready");
+
+    assert!(error.to_string().contains("ACP startup failed"));
+}
+
+#[test]
+fn permission_requests_are_cancelled_without_user_confirmation() {
+    let response = cancelled_permission_response();
+
+    assert_eq!(response.outcome, RequestPermissionOutcome::Cancelled);
+}

--- a/crates/agent_runtime_protocol/examples/websocket.rs
+++ b/crates/agent_runtime_protocol/examples/websocket.rs
@@ -1,0 +1,45 @@
+//! Run the logical protocol over a runtime-initiated jsonrpsee WebSocket.
+//!
+//! Run with:
+//!
+//! ```text
+//! cargo run -p agent_runtime_protocol --example websocket
+//! ```
+
+use std::sync::Arc;
+
+use agent_runtime_protocol::connection::{RuntimeConnection, ServerConnection};
+use agent_runtime_protocol::transport::jsonrpsee::{ServerTransport, connect_runtime};
+use jsonrpsee::server::Server;
+use jsonrpsee::ws_client::WsClientBuilder;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let transport = ServerTransport::new();
+    let websocket = Server::builder().build("127.0.0.1:0").await?;
+    let address = websocket.local_addr()?;
+    let server_handle = websocket.start(transport.rpc_module()?);
+
+    // The runtime initiates the WebSocket and then opens its message subscription.
+    let client = Arc::new(
+        WsClientBuilder::default()
+            .build(format!("ws://{address}"))
+            .await?,
+    );
+    let runtime_channel = connect_runtime(client, "connection-1").await?;
+    let service_channel = transport
+        .accept()
+        .await
+        .ok_or("runtime subscription closed before acceptance")?
+        .into_channel();
+
+    let service = ServerConnection::connect(service_channel, ());
+    let runtime = RuntimeConnection::connect(runtime_channel, ());
+    println!("runtime and service connected over WebSocket");
+
+    drop(runtime);
+    drop(service);
+    server_handle.stop()?;
+    server_handle.stopped().await;
+    Ok(())
+}

--- a/crates/agent_runtime_protocol/src/connection/mod.rs
+++ b/crates/agent_runtime_protocol/src/connection/mod.rs
@@ -1,0 +1,514 @@
+//! Role-oriented logical protocol connections.
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::panic::AssertUnwindSafe;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+
+use agent_client_protocol::schema::v1::RequestId;
+use agent_client_protocol::{Channel, JsonRpcMessage, JsonRpcResponse, RawJsonRpcMessage};
+use futures::channel::mpsc::UnboundedSender;
+use futures::{FutureExt, StreamExt};
+use serde_json::Value;
+use tokio::sync::{oneshot, watch};
+
+use crate::schema::v0::{
+    ACP_METHOD, AcpMessage, COMMAND_METHOD, Command, CommandResult, SYSTEM_EVENT_METHOD,
+    SystemEvent,
+};
+
+#[cfg(test)]
+mod test;
+
+type CommandReply = oneshot::Sender<Result<CommandResult, ConnectionError>>;
+type PendingCommands = Arc<Mutex<HashMap<i64, CommandReply>>>;
+
+struct PendingRequestGuard {
+    request_id: i64,
+    pending: PendingCommands,
+}
+
+impl Drop for PendingRequestGuard {
+    fn drop(&mut self) {
+        if let Ok(mut pending) = self.pending.lock() {
+            pending.remove(&self.request_id);
+        }
+    }
+}
+
+/// Identifies one execution of an ACP agent within a runtime.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct AgentTarget {
+    agent_id: String,
+    agent_instance_id: String,
+}
+
+impl AgentTarget {
+    /// Construct an agent target from its logical and process identifiers.
+    #[must_use]
+    pub fn new(agent_id: impl Into<String>, agent_instance_id: impl Into<String>) -> Self {
+        Self {
+            agent_id: agent_id.into(),
+            agent_instance_id: agent_instance_id.into(),
+        }
+    }
+
+    /// Return the stable logical agent identifier.
+    #[must_use]
+    pub fn agent_id(&self) -> &str {
+        &self.agent_id
+    }
+
+    /// Return the identifier for this execution of the agent.
+    #[must_use]
+    pub fn agent_instance_id(&self) -> &str {
+        &self.agent_instance_id
+    }
+}
+
+/// Handles a command delivered to an Agent Runtime.
+///
+/// Use `()` when the connection only carries ACP. It rejects any command as
+/// an unknown method.
+pub trait CommandHandler: Send + Sync + 'static {
+    /// Execute the command and return its logical JSON-RPC result.
+    fn handle(
+        &self,
+        command: Command,
+    ) -> impl Future<Output = Result<CommandResult, agent_client_protocol::Error>> + Send;
+}
+
+impl CommandHandler for () {
+    fn handle(
+        &self,
+        _command: Command,
+    ) -> impl Future<Output = Result<CommandResult, agent_client_protocol::Error>> + Send {
+        std::future::ready(Err(agent_client_protocol::Error::method_not_found()))
+    }
+}
+
+/// Handles a system event delivered to an Agent Service.
+///
+/// Use `()` when the connection only carries ACP. It ignores any system event.
+pub trait SystemEventHandler: Send + Sync + 'static {
+    /// Observe a runtime or agent state transition.
+    fn handle(
+        &self,
+        event: SystemEvent,
+    ) -> impl Future<Output = Result<(), agent_client_protocol::Error>> + Send;
+}
+
+impl SystemEventHandler for () {
+    fn handle(
+        &self,
+        _event: SystemEvent,
+    ) -> impl Future<Output = Result<(), agent_client_protocol::Error>> + Send {
+        std::future::ready(Ok(()))
+    }
+}
+
+/// A failure while using a logical protocol connection.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum ConnectionError {
+    /// The logical connection has closed.
+    #[error("connection closed")]
+    Closed,
+    /// A message did not conform to the role or schema expected by the receiver.
+    #[error("invalid protocol message: {0}")]
+    InvalidMessage(String),
+    /// The remote peer returned a JSON-RPC error for a command.
+    #[error("command failed: {0}")]
+    CommandFailed(#[source] agent_client_protocol::Error),
+}
+
+/// Agent Service-side access to one logical runtime connection.
+pub struct ServerConnection {
+    outbound: UnboundedSender<Result<RawJsonRpcMessage, agent_client_protocol::Error>>,
+    pending: PendingCommands,
+    next_request_id: AtomicU64,
+    acp: AcpRouter,
+    driver: tokio::task::AbortHandle,
+}
+
+impl ServerConnection {
+    /// Attach the service role to a logical message channel.
+    #[must_use]
+    pub fn connect<H>(channel: Channel, system_events: H) -> Self
+    where
+        H: SystemEventHandler,
+    {
+        let Channel { rx, tx } = channel;
+        let pending = Arc::new(Mutex::new(HashMap::new()));
+        let acp = AcpRouter::new(tx.clone());
+        let driver = tokio::spawn(run_server(
+            rx,
+            Arc::new(system_events),
+            Arc::clone(&pending),
+            acp.clone(),
+        ))
+        .abort_handle();
+
+        Self {
+            outbound: tx,
+            pending,
+            next_request_id: AtomicU64::new(1),
+            acp,
+            driver,
+        }
+    }
+
+    /// Send a correlated command request and wait for its result.
+    pub async fn command(&self, command: Command) -> Result<CommandResult, ConnectionError> {
+        let request_id = i64::try_from(self.next_request_id.fetch_add(1, Ordering::Relaxed))
+            .map_err(|_| ConnectionError::Closed)?;
+        let message = RawJsonRpcMessage::request(
+            COMMAND_METHOD.to_owned(),
+            serde_json::to_value(command)
+                .map_err(|error| ConnectionError::InvalidMessage(error.to_string()))?,
+            RequestId::Number(request_id),
+        )
+        .map_err(|error| ConnectionError::InvalidMessage(error.to_string()))?;
+        let (sender, receiver) = oneshot::channel();
+        self.pending
+            .lock()
+            .map_err(|_| ConnectionError::Closed)?
+            .insert(request_id, sender);
+        let _pending_request = PendingRequestGuard {
+            request_id,
+            pending: Arc::clone(&self.pending),
+        };
+
+        if self.outbound.unbounded_send(Ok(message)).is_err() {
+            return Err(ConnectionError::Closed);
+        }
+
+        receiver.await.unwrap_or(Err(ConnectionError::Closed))
+    }
+
+    /// Open an official ACP SDK channel for one agent execution.
+    pub fn acp(&self, target: AgentTarget) -> Result<Channel, ConnectionError> {
+        self.acp.open(target)
+    }
+}
+
+impl Drop for ServerConnection {
+    fn drop(&mut self) {
+        self.acp.close();
+        self.driver.abort();
+    }
+}
+
+/// Agent Runtime-side access to one logical service connection.
+pub struct RuntimeConnection {
+    outbound: UnboundedSender<Result<RawJsonRpcMessage, agent_client_protocol::Error>>,
+    acp: AcpRouter,
+    driver: tokio::task::AbortHandle,
+}
+
+impl RuntimeConnection {
+    /// Attach the runtime role to a logical message channel.
+    #[must_use]
+    pub fn connect<H>(channel: Channel, commands: H) -> Self
+    where
+        H: CommandHandler,
+    {
+        let Channel { rx, tx } = channel;
+        let acp = AcpRouter::new(tx.clone());
+        let driver = tokio::spawn(run_runtime(rx, tx.clone(), Arc::new(commands), acp.clone()))
+            .abort_handle();
+        Self {
+            outbound: tx,
+            acp,
+            driver,
+        }
+    }
+
+    /// Send a system event notification to the Agent Service.
+    pub fn system_event(&self, event: SystemEvent) -> Result<(), ConnectionError> {
+        let message = RawJsonRpcMessage::notification(
+            SYSTEM_EVENT_METHOD.to_owned(),
+            serde_json::to_value(event)
+                .map_err(|error| ConnectionError::InvalidMessage(error.to_string()))?,
+        )
+        .map_err(|error| ConnectionError::InvalidMessage(error.to_string()))?;
+        self.outbound
+            .unbounded_send(Ok(message))
+            .map_err(|_| ConnectionError::Closed)
+    }
+
+    /// Open an official ACP SDK channel for one agent execution.
+    pub fn acp(&self, target: AgentTarget) -> Result<Channel, ConnectionError> {
+        self.acp.open(target)
+    }
+}
+
+impl Drop for RuntimeConnection {
+    fn drop(&mut self) {
+        self.acp.close();
+        self.driver.abort();
+    }
+}
+
+type LogicalSender = UnboundedSender<Result<RawJsonRpcMessage, agent_client_protocol::Error>>;
+
+#[derive(Clone)]
+struct AcpRouter {
+    outbound: LogicalSender,
+    inbound: Arc<Mutex<HashMap<AgentTarget, LogicalSender>>>,
+    next_message_id: Arc<AtomicU64>,
+    shutdown: watch::Sender<bool>,
+}
+
+impl AcpRouter {
+    fn new(outbound: LogicalSender) -> Self {
+        let (shutdown, _) = watch::channel(false);
+        Self {
+            outbound,
+            inbound: Arc::new(Mutex::new(HashMap::new())),
+            next_message_id: Arc::new(AtomicU64::new(1)),
+            shutdown,
+        }
+    }
+
+    fn open(&self, target: AgentTarget) -> Result<Channel, ConnectionError> {
+        if *self.shutdown.borrow() {
+            return Err(ConnectionError::Closed);
+        }
+        let (peer, bridge) = Channel::duplex();
+        let Channel { mut rx, tx } = bridge;
+        let mut inbound = self.inbound.lock().map_err(|_| ConnectionError::Closed)?;
+        if inbound.contains_key(&target) {
+            return Err(ConnectionError::InvalidMessage(format!(
+                "ACP channel already open for {}/{}",
+                target.agent_id, target.agent_instance_id
+            )));
+        }
+        inbound.insert(target.clone(), tx);
+        drop(inbound);
+
+        let outbound = self.outbound.clone();
+        let inbound = Arc::clone(&self.inbound);
+        let next_message_id = Arc::clone(&self.next_message_id);
+        let mut shutdown = self.shutdown.subscribe();
+        tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    message = rx.next() => {
+                        let Some(Ok(message)) = message else {
+                            break;
+                        };
+                        let message_id = next_message_id.fetch_add(1, Ordering::Relaxed);
+                        let delivery = AcpMessage::new(
+                            format!("acp-{message_id}"),
+                            target.agent_id.clone(),
+                            target.agent_instance_id.clone(),
+                            message,
+                        );
+                        let Ok(params) = serde_json::to_value(delivery) else {
+                            break;
+                        };
+                        let Ok(message) =
+                            RawJsonRpcMessage::notification(ACP_METHOD.to_owned(), params)
+                        else {
+                            break;
+                        };
+                        if outbound.unbounded_send(Ok(message)).is_err() {
+                            break;
+                        }
+                    }
+                    _ = shutdown.changed() => break,
+                }
+            }
+
+            if let Ok(mut channels) = inbound.lock() {
+                channels.remove(&target);
+            }
+        });
+
+        Ok(peer)
+    }
+
+    #[tracing::instrument(
+        name = "route_acp_message",
+        level = "trace",
+        skip(self, delivery),
+        fields(
+            message_id = %delivery.message_id,
+            agent_id = %delivery.agent_id,
+            agent_instance_id = %delivery.agent_instance_id,
+        ),
+        err(level = "trace")
+    )]
+    fn route(&self, delivery: AcpMessage) -> Result<(), ConnectionError> {
+        let target = AgentTarget::new(delivery.agent_id, delivery.agent_instance_id);
+        let sender = self
+            .inbound
+            .lock()
+            .map_err(|_| ConnectionError::Closed)?
+            .get(&target)
+            .cloned()
+            .ok_or_else(|| {
+                ConnectionError::InvalidMessage(format!(
+                    "no ACP channel for {}/{}",
+                    target.agent_id, target.agent_instance_id
+                ))
+            })?;
+        sender
+            .unbounded_send(Ok(delivery.message))
+            .map_err(|_| ConnectionError::Closed)
+    }
+
+    fn close(&self) {
+        self.shutdown.send_replace(true);
+        if let Ok(mut channels) = self.inbound.lock() {
+            channels.clear();
+        }
+    }
+}
+
+async fn run_server<H>(
+    mut inbound: futures::channel::mpsc::UnboundedReceiver<
+        Result<RawJsonRpcMessage, agent_client_protocol::Error>,
+    >,
+    system_events: Arc<H>,
+    pending: PendingCommands,
+    acp: AcpRouter,
+) where
+    H: SystemEventHandler,
+{
+    while let Some(message) = inbound.next().await {
+        let Ok(message) = message else {
+            break;
+        };
+        let Ok(value) = serde_json::to_value(&message) else {
+            continue;
+        };
+
+        if let Some(method) = value.get("method").and_then(Value::as_str) {
+            let params = value.get("params").cloned().unwrap_or(Value::Null);
+            match method {
+                SYSTEM_EVENT_METHOD => {
+                    if let Ok(event) = SystemEvent::parse_message(method, &params) {
+                        let _ = system_events.handle(event).await;
+                    }
+                }
+                ACP_METHOD => {
+                    if let Ok(delivery) = AcpMessage::parse_message(method, &params) {
+                        let _ = acp.route(delivery);
+                    }
+                }
+                _ => {}
+            }
+            continue;
+        }
+
+        let Some(request_id) = value.get("id").and_then(Value::as_i64) else {
+            continue;
+        };
+        let sender = pending
+            .lock()
+            .ok()
+            .and_then(|mut pending| pending.remove(&request_id));
+        let Some(sender) = sender else {
+            continue;
+        };
+        let result = if let Some(result) = value.get("result") {
+            CommandResult::from_value(COMMAND_METHOD, result.clone())
+                .map_err(|error| ConnectionError::InvalidMessage(error.to_string()))
+        } else if let Some(error) = value.get("error") {
+            serde_json::from_value(error.clone())
+                .map_err(|error| {
+                    ConnectionError::InvalidMessage(format!(
+                        "invalid command error response: {error}"
+                    ))
+                })
+                .and_then(|error| Err(ConnectionError::CommandFailed(error)))
+        } else {
+            Err(ConnectionError::InvalidMessage(
+                "command response contains neither result nor error".to_owned(),
+            ))
+        };
+        let _ = sender.send(result);
+    }
+
+    if let Ok(mut commands) = pending.lock() {
+        for (_, sender) in commands.drain() {
+            let _ = sender.send(Err(ConnectionError::Closed));
+        }
+    }
+    acp.close();
+}
+
+async fn run_runtime<H>(
+    mut inbound: futures::channel::mpsc::UnboundedReceiver<
+        Result<RawJsonRpcMessage, agent_client_protocol::Error>,
+    >,
+    outbound: LogicalSender,
+    commands: Arc<H>,
+    acp: AcpRouter,
+) where
+    H: CommandHandler,
+{
+    let mut commands_in_flight = tokio::task::JoinSet::new();
+    loop {
+        let message = tokio::select! {
+            message = inbound.next() => message,
+            _ = commands_in_flight.join_next(), if !commands_in_flight.is_empty() => continue,
+        };
+        let Some(message) = message else {
+            break;
+        };
+        let Ok(message) = message else {
+            break;
+        };
+        let request_id = match &message {
+            RawJsonRpcMessage::Request(request) => Some(request.id.clone()),
+            RawJsonRpcMessage::Notification(_) | RawJsonRpcMessage::Response(_) => None,
+        };
+        let Ok(value) = serde_json::to_value(&message) else {
+            continue;
+        };
+        let Some(method) = value.get("method").and_then(Value::as_str) else {
+            continue;
+        };
+        let params = value.get("params").cloned().unwrap_or(Value::Null);
+
+        match method {
+            COMMAND_METHOD => {
+                let Some(request_id) = request_id else {
+                    continue;
+                };
+                let command = match Command::parse_message(method, &params) {
+                    Ok(command) => command,
+                    Err(error) => {
+                        let error =
+                            agent_client_protocol::Error::invalid_params().data(error.to_string());
+                        let response = RawJsonRpcMessage::response(request_id, Err(error));
+                        let _ = outbound.unbounded_send(Ok(response));
+                        continue;
+                    }
+                };
+                let commands = Arc::clone(&commands);
+                let outbound = outbound.clone();
+                commands_in_flight.spawn(async move {
+                    let result = AssertUnwindSafe(async { commands.handle(command).await })
+                        .catch_unwind()
+                        .await
+                        .unwrap_or_else(|_| Err(agent_client_protocol::Error::internal_error()))
+                        .and_then(|result| result.into_json(COMMAND_METHOD));
+                    let response = RawJsonRpcMessage::response(request_id, result);
+                    let _ = outbound.unbounded_send(Ok(response));
+                });
+            }
+            ACP_METHOD => {
+                if let Ok(delivery) = AcpMessage::parse_message(method, &params) {
+                    let _ = acp.route(delivery);
+                }
+            }
+            _ => {}
+        }
+    }
+    acp.close();
+}

--- a/crates/agent_runtime_protocol/src/connection/test.rs
+++ b/crates/agent_runtime_protocol/src/connection/test.rs
@@ -1,0 +1,583 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use agent_client_protocol::{Channel, RawJsonRpcMessage};
+use futures::StreamExt;
+use serde_json::json;
+use tokio::sync::Mutex;
+use tokio::time::{Duration, timeout};
+use tracing::field::{Field, Visit};
+use tracing::span::{Attributes, Id, Record};
+use tracing::{Event, Metadata, Subscriber};
+
+use super::*;
+use crate::schema::v0::{CommandName, SystemEventName};
+
+#[derive(Clone, Default)]
+struct TraceCapture {
+    next_span_id: Arc<AtomicU64>,
+    records: Arc<std::sync::Mutex<Vec<CapturedTrace>>>,
+}
+
+#[derive(Debug)]
+struct CapturedTrace {
+    level: tracing::Level,
+    fields: Vec<(String, String)>,
+}
+
+#[derive(Default)]
+struct FieldVisitor(Vec<(String, String)>);
+
+impl Visit for FieldVisitor {
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        self.0.push((field.name().to_owned(), format!("{value:?}")));
+    }
+}
+
+impl TraceCapture {
+    fn capture(&self, metadata: &Metadata<'_>, fields: FieldVisitor) {
+        self.records.lock().unwrap().push(CapturedTrace {
+            level: *metadata.level(),
+            fields: fields.0,
+        });
+    }
+}
+
+impl Subscriber for TraceCapture {
+    fn enabled(&self, _metadata: &Metadata<'_>) -> bool {
+        true
+    }
+
+    fn new_span(&self, attributes: &Attributes<'_>) -> Id {
+        let mut fields = FieldVisitor::default();
+        attributes.record(&mut fields);
+        self.capture(attributes.metadata(), fields);
+        Id::from_u64(self.next_span_id.fetch_add(1, Ordering::Relaxed) + 1)
+    }
+
+    fn record(&self, _span: &Id, _values: &Record<'_>) {}
+
+    fn record_follows_from(&self, _span: &Id, _follows: &Id) {}
+
+    fn event(&self, event: &Event<'_>) {
+        let mut fields = FieldVisitor::default();
+        event.record(&mut fields);
+        self.capture(event.metadata(), fields);
+    }
+
+    fn enter(&self, _span: &Id) {}
+
+    fn exit(&self, _span: &Id) {}
+}
+
+#[derive(Clone, Default)]
+struct Events(Arc<Mutex<Vec<SystemEvent>>>);
+
+impl SystemEventHandler for Events {
+    async fn handle(&self, event: SystemEvent) -> Result<(), agent_client_protocol::Error> {
+        self.0.lock().await.push(event);
+        Ok(())
+    }
+}
+
+struct Commands;
+
+impl CommandHandler for Commands {
+    async fn handle(
+        &self,
+        command: Command,
+    ) -> Result<CommandResult, agent_client_protocol::Error> {
+        Ok(CommandResult::completed_with(json!({
+            "handled": command.command_id,
+        })))
+    }
+}
+
+struct PendingCommand;
+
+impl CommandHandler for PendingCommand {
+    async fn handle(
+        &self,
+        _command: Command,
+    ) -> Result<CommandResult, agent_client_protocol::Error> {
+        std::future::pending().await
+    }
+}
+
+struct FailingCommand;
+
+impl CommandHandler for FailingCommand {
+    async fn handle(
+        &self,
+        _command: Command,
+    ) -> Result<CommandResult, agent_client_protocol::Error> {
+        Err(
+            agent_client_protocol::Error::new(-32042, "example command failure")
+                .data(json!({ "retryable": false })),
+        )
+    }
+}
+
+struct PanickingCommand;
+
+impl CommandHandler for PanickingCommand {
+    async fn handle(
+        &self,
+        _command: Command,
+    ) -> Result<CommandResult, agent_client_protocol::Error> {
+        panic!("example command handler panic")
+    }
+}
+
+fn connections() -> (ServerConnection, RuntimeConnection, Events) {
+    let (server_channel, runtime_channel) = Channel::duplex();
+    let events = Events::default();
+    let server = ServerConnection::connect(server_channel, events.clone());
+    let runtime = RuntimeConnection::connect(runtime_channel, Commands);
+    (server, runtime, events)
+}
+
+#[tokio::test]
+async fn unit_handlers_support_connections_that_only_use_acp() {
+    let (server_channel, runtime_channel) = Channel::duplex();
+    let _server = ServerConnection::connect(server_channel, ());
+    let _runtime = RuntimeConnection::connect(runtime_channel, ());
+}
+
+#[tokio::test]
+async fn command_request_round_trips_with_its_result() {
+    let (server, _runtime, _events) = connections();
+
+    let result = timeout(
+        Duration::from_secs(1),
+        server.command(Command::new(
+            "command-1",
+            CommandName::Unknown("runtime/configure".to_owned()),
+        )),
+    )
+    .await
+    .expect("command should not hang")
+    .expect("command should succeed");
+
+    assert_eq!(
+        result,
+        CommandResult::completed_with(json!({ "handled": "command-1" }))
+    );
+}
+
+#[tokio::test]
+async fn cancelling_a_command_removes_its_pending_entry() {
+    let (server_channel, _runtime_channel) = Channel::duplex();
+    let server = ServerConnection::connect(server_channel, Events::default());
+    let mut command = Box::pin(server.command(Command::new(
+        "command-1",
+        CommandName::Unknown("example/pending".to_owned()),
+    )));
+
+    assert!(futures::poll!(&mut command).is_pending());
+    assert_eq!(server.pending.lock().unwrap().len(), 1);
+
+    drop(command);
+
+    assert!(server.pending.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn command_error_preserves_jsonrpc_code_message_and_data() {
+    let (server_channel, runtime_channel) = Channel::duplex();
+    let server = ServerConnection::connect(server_channel, Events::default());
+    let _runtime = RuntimeConnection::connect(runtime_channel, FailingCommand);
+
+    let error = timeout(
+        Duration::from_secs(1),
+        server.command(Command::new(
+            "command-1",
+            CommandName::Unknown("example/fail".to_owned()),
+        )),
+    )
+    .await
+    .expect("command should not hang")
+    .expect_err("command should fail");
+
+    let ConnectionError::CommandFailed(error) = error else {
+        panic!("expected a structured command failure");
+    };
+    assert_eq!(i32::from(error.code), -32042);
+    assert_eq!(error.message, "example command failure");
+    assert_eq!(error.data, Some(json!({ "retryable": false })));
+}
+
+#[tokio::test]
+async fn runtime_preserves_string_jsonrpc_request_ids() {
+    let (mut service_channel, runtime_channel) = Channel::duplex();
+    let _runtime = RuntimeConnection::connect(runtime_channel, Commands);
+    let command = Command::new(
+        "command-1",
+        CommandName::Unknown("example/string-id".to_owned()),
+    );
+    let request = RawJsonRpcMessage::request(
+        COMMAND_METHOD.to_owned(),
+        serde_json::to_value(command).unwrap(),
+        agent_client_protocol::schema::v1::RequestId::Str("request-one".to_owned()),
+    )
+    .unwrap();
+
+    service_channel.tx.unbounded_send(Ok(request)).unwrap();
+    let response = timeout(Duration::from_secs(1), service_channel.rx.next())
+        .await
+        .expect("string-id command should receive a response")
+        .expect("runtime should keep the channel open")
+        .expect("runtime should send a valid response");
+
+    assert_eq!(
+        serde_json::to_value(response).unwrap(),
+        json!({
+            "jsonrpc": "2.0",
+            "id": "request-one",
+            "result": {
+                "status": "completed",
+                "value": { "handled": "command-1" },
+            },
+        })
+    );
+}
+
+#[tokio::test]
+async fn malformed_command_params_receive_an_invalid_params_response() {
+    let (mut service_channel, runtime_channel) = Channel::duplex();
+    let _runtime = RuntimeConnection::connect(runtime_channel, Commands);
+    let request = RawJsonRpcMessage::request(
+        COMMAND_METHOD.to_owned(),
+        json!({
+            "commandId": 123,
+            "name": "example/malformed",
+        }),
+        agent_client_protocol::schema::v1::RequestId::Str("request-one".to_owned()),
+    )
+    .unwrap();
+
+    service_channel.tx.unbounded_send(Ok(request)).unwrap();
+    let response = timeout(Duration::from_secs(1), service_channel.rx.next())
+        .await
+        .expect("malformed command should receive a response")
+        .expect("runtime should keep the channel open")
+        .expect("runtime should send a valid response");
+
+    let response = serde_json::to_value(response).unwrap();
+    assert_eq!(response["id"], "request-one");
+    assert_eq!(response["error"]["code"], -32602);
+}
+
+#[tokio::test]
+async fn panicking_command_handler_returns_an_internal_error() {
+    let (server_channel, runtime_channel) = Channel::duplex();
+    let server = ServerConnection::connect(server_channel, Events::default());
+    let _runtime = RuntimeConnection::connect(runtime_channel, PanickingCommand);
+
+    let error = timeout(
+        Duration::from_secs(1),
+        server.command(Command::new(
+            "command-1",
+            CommandName::Unknown("example/panic".to_owned()),
+        )),
+    )
+    .await
+    .expect("panicking command handler should receive a response")
+    .expect_err("panicking command handler should return an error");
+
+    let ConnectionError::CommandFailed(error) = error else {
+        panic!("expected a structured command failure");
+    };
+    assert_eq!(i32::from(error.code), -32603);
+    assert_eq!(error.message, "Internal error");
+}
+
+#[test]
+fn unroutable_acp_delivery_emits_a_trace_with_its_target() {
+    let subscriber = TraceCapture::default();
+    let records = Arc::clone(&subscriber.records);
+    let (channel, _peer) = Channel::duplex();
+    let router = AcpRouter::new(channel.tx);
+    let delivery = AcpMessage::new(
+        "message-1",
+        "missing-agent",
+        "missing-instance",
+        RawJsonRpcMessage::notification("session/cancel".to_owned(), json!({})).unwrap(),
+    );
+    let result = tracing::subscriber::with_default(subscriber, || router.route(delivery));
+    assert!(result.is_err());
+    let traces = std::mem::take(&mut *records.lock().unwrap());
+
+    assert!(
+        traces.iter().any(|trace| {
+            trace
+                .fields
+                .iter()
+                .any(|(name, value)| name == "agent_id" && value.contains("missing-agent"))
+                && trace.fields.iter().any(|(name, value)| {
+                    name == "agent_instance_id" && value.contains("missing-instance")
+                })
+        }),
+        "{traces:?}"
+    );
+    assert!(
+        traces
+            .iter()
+            .any(|trace| trace.fields.iter().any(|(name, _)| name == "error")),
+        "{traces:?}"
+    );
+    assert!(
+        traces
+            .iter()
+            .any(|trace| trace.level == tracing::Level::TRACE),
+        "{traces:?}"
+    );
+    assert!(
+        traces.iter().all(
+            |trace| trace.level != tracing::Level::WARN && trace.level != tracing::Level::ERROR
+        ),
+        "{traces:?}"
+    );
+}
+
+#[tokio::test]
+async fn concurrent_commands_are_correlated_by_jsonrpc_id() {
+    let (server, _runtime, _events) = connections();
+
+    let (first, second) = tokio::join!(
+        server.command(Command::new(
+            "command-1",
+            CommandName::Unknown("runtime/first".to_owned()),
+        )),
+        server.command(Command::new(
+            "command-2",
+            CommandName::Unknown("runtime/second".to_owned()),
+        )),
+    );
+
+    assert_eq!(
+        first.expect("first command should succeed"),
+        CommandResult::completed_with(json!({ "handled": "command-1" }))
+    );
+    assert_eq!(
+        second.expect("second command should succeed"),
+        CommandResult::completed_with(json!({ "handled": "command-2" }))
+    );
+}
+
+#[tokio::test]
+async fn dropping_runtime_fails_a_pending_command() {
+    let (server_channel, runtime_channel) = Channel::duplex();
+    let server = ServerConnection::connect(server_channel, Events::default());
+    let runtime = RuntimeConnection::connect(runtime_channel, PendingCommand);
+    let command = server.command(Command::new(
+        "command-1",
+        CommandName::Unknown("runtime/wait".to_owned()),
+    ));
+    tokio::pin!(command);
+
+    tokio::select! {
+        result = &mut command => panic!("command completed before shutdown: {result:?}"),
+        () = tokio::task::yield_now() => {}
+    }
+    drop(runtime);
+
+    let error = timeout(Duration::from_secs(1), command)
+        .await
+        .expect("pending command should not hang after shutdown")
+        .expect_err("pending command should fail");
+    assert!(matches!(error, ConnectionError::Closed));
+}
+
+#[tokio::test]
+async fn closing_an_acp_router_before_opening_a_channel_is_persistent() {
+    let (channel, _peer) = Channel::duplex();
+    let router = AcpRouter::new(channel.tx);
+
+    router.close();
+
+    let error = router
+        .open(AgentTarget::new("agent", "instance"))
+        .expect_err("closed router must reject new ACP channels");
+    assert!(matches!(error, ConnectionError::Closed));
+}
+
+#[tokio::test]
+async fn system_event_is_dispatched_without_a_response() {
+    let (_server, runtime, events) = connections();
+    runtime
+        .system_event(SystemEvent::new(
+            "event-1",
+            1,
+            SystemEventName::Unknown("runtime/ready".to_owned()),
+            "2026-07-17T00:00:00Z",
+        ))
+        .expect("event should send");
+
+    timeout(Duration::from_secs(1), async {
+        loop {
+            if events.0.lock().await.len() == 1 {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("event should be dispatched");
+
+    assert_eq!(events.0.lock().await[0].event_id, "event-1");
+}
+
+#[tokio::test]
+async fn acp_channels_carry_raw_sdk_messages_in_both_directions() {
+    let (server, runtime, _events) = connections();
+    let target = AgentTarget::new("primary", "agent-instance-1");
+    let mut server_acp = server.acp(target.clone()).expect("server ACP channel");
+    let mut runtime_acp = runtime.acp(target).expect("runtime ACP channel");
+
+    let initialize = RawJsonRpcMessage::request(
+        "initialize".to_owned(),
+        json!({ "protocolVersion": 1 }),
+        agent_client_protocol::schema::v1::RequestId::Number(1),
+    )
+    .unwrap();
+    server_acp.tx.unbounded_send(Ok(initialize)).unwrap();
+
+    let delivered = timeout(Duration::from_secs(1), runtime_acp.rx.next())
+        .await
+        .expect("ACP request should not hang")
+        .expect("ACP channel should remain open")
+        .expect("ACP request should be valid");
+    assert_eq!(
+        serde_json::to_value(delivered).unwrap(),
+        json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": { "protocolVersion": 1 },
+        })
+    );
+
+    runtime_acp
+        .tx
+        .unbounded_send(Ok(RawJsonRpcMessage::response(
+            agent_client_protocol::schema::v1::RequestId::Number(1),
+            Ok(json!({ "protocolVersion": 1 })),
+        )))
+        .unwrap();
+    let response = timeout(Duration::from_secs(1), server_acp.rx.next())
+        .await
+        .expect("ACP response should not hang")
+        .expect("ACP channel should remain open")
+        .expect("ACP response should be valid");
+    assert_eq!(
+        serde_json::to_value(response).unwrap(),
+        json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": { "protocolVersion": 1 },
+        })
+    );
+}
+
+#[tokio::test]
+async fn acp_channels_are_isolated_by_agent_and_instance() {
+    let (server, runtime, _events) = connections();
+    let first = AgentTarget::new("first", "instance-1");
+    let second = AgentTarget::new("second", "instance-1");
+    let first_server = server.acp(first.clone()).unwrap();
+    let second_server = server.acp(second.clone()).unwrap();
+    let mut first_runtime = runtime.acp(first).unwrap();
+    let mut second_runtime = runtime.acp(second).unwrap();
+
+    first_server
+        .tx
+        .unbounded_send(Ok(RawJsonRpcMessage::notification(
+            "first/message".to_owned(),
+            json!({}),
+        )
+        .unwrap()))
+        .unwrap();
+    second_server
+        .tx
+        .unbounded_send(Ok(RawJsonRpcMessage::notification(
+            "second/message".to_owned(),
+            json!({}),
+        )
+        .unwrap()))
+        .unwrap();
+
+    let first = first_runtime.rx.next().await.unwrap().unwrap();
+    let second = second_runtime.rx.next().await.unwrap().unwrap();
+    assert_eq!(
+        serde_json::to_value(first).unwrap()["method"],
+        "first/message"
+    );
+    assert_eq!(
+        serde_json::to_value(second).unwrap()["method"],
+        "second/message"
+    );
+}
+
+#[tokio::test]
+async fn dropping_a_connection_closes_its_acp_channels() {
+    let (server, runtime, _events) = connections();
+    let target = AgentTarget::new("primary", "instance-1");
+    let mut server_acp = server.acp(target.clone()).unwrap();
+    let _runtime_acp = runtime.acp(target).unwrap();
+
+    drop(runtime);
+
+    let closed = timeout(Duration::from_secs(1), server_acp.rx.next())
+        .await
+        .expect("ACP channel should close promptly");
+    assert!(closed.is_none());
+}
+
+#[tokio::test]
+async fn official_acp_client_and_agent_connect_directly_to_exposed_channels() {
+    use agent_client_protocol::schema::ProtocolVersion;
+    use agent_client_protocol::schema::v1::{InitializeRequest, InitializeResponse};
+    use agent_client_protocol::{Agent, Client};
+
+    let (server, runtime, _events) = connections();
+    let target = AgentTarget::new("primary", "agent-instance-1");
+    let server_acp = server.acp(target.clone()).expect("server ACP channel");
+    let runtime_acp = runtime.acp(target).expect("runtime ACP channel");
+
+    let agent = tokio::spawn(async move {
+        Agent
+            .builder()
+            .on_receive_request(
+                async move |request: InitializeRequest, responder, _connection| {
+                    responder.respond(InitializeResponse::new(request.protocol_version))
+                },
+                agent_client_protocol::on_receive_request!(),
+            )
+            .connect_to(runtime_acp)
+            .await
+    });
+
+    let response = timeout(
+        Duration::from_secs(1),
+        Client.connect_with(server_acp, async |connection| {
+            connection
+                .send_request(InitializeRequest::new(ProtocolVersion::V1))
+                .block_task()
+                .await
+        }),
+    )
+    .await
+    .expect("official ACP initialize should not hang")
+    .expect("official ACP initialize should succeed");
+    assert_eq!(response.protocol_version, ProtocolVersion::V1);
+
+    agent.abort();
+    assert!(
+        agent
+            .await
+            .expect_err("agent task should be cancelled")
+            .is_cancelled(),
+        "the long-lived agent driver should only be stopped explicitly"
+    );
+}

--- a/crates/agent_runtime_protocol/src/lib.rs
+++ b/crates/agent_runtime_protocol/src/lib.rs
@@ -1,0 +1,20 @@
+#![deny(missing_docs)]
+//! Agent Runtime Protocol wire types.
+//!
+//! The Agent Runtime Protocol is the outer protocol used to communicate with
+//! an agent runtime. It carries Agent Client Protocol (ACP) messages alongside
+//! runtime control messages without interpreting the wrapped ACP payloads.
+//!
+//! The normative wire specification is maintained in `SPEC.md` at the crate
+//! root.
+
+/// Role-oriented connections over a logical Agent Runtime Protocol stream.
+pub mod connection;
+/// Versioned protocol message types.
+pub mod schema;
+/// Physical transports for logical Agent Runtime Protocol messages.
+pub mod transport;
+
+/// Utilities for asserting direction-labelled JSON messages at the wire boundary.
+#[cfg(any(test, feature = "test-utils"))]
+pub mod testing;

--- a/crates/agent_runtime_protocol/src/schema/mod.rs
+++ b/crates/agent_runtime_protocol/src/schema/mod.rs
@@ -1,0 +1,4 @@
+//! Agent Runtime Protocol schema types.
+
+/// Draft `agent-runtime.v0` schema types.
+pub mod v0;

--- a/crates/agent_runtime_protocol/src/schema/v0/mod.rs
+++ b/crates/agent_runtime_protocol/src/schema/v0/mod.rs
@@ -1,0 +1,330 @@
+//! Draft `agent-runtime.v0` message types.
+//!
+//! The outer protocol messages implement the corresponding ACP SDK JSON-RPC
+//! traits. [`Command`] is a request, while [`SystemEvent`] and [`AcpMessage`]
+//! are notifications. This allows them to use the same connection and dispatch
+//! machinery as ACP messages while keeping their distinct outer method names.
+
+use agent_client_protocol::{
+    JsonRpcNotification, JsonRpcRequest, JsonRpcResponse, RawJsonRpcMessage,
+};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde_json::Value;
+use std::fmt::{self, Display, Formatter};
+
+#[cfg(test)]
+mod test;
+
+/// JSON-RPC method used to send a system event.
+pub const SYSTEM_EVENT_METHOD: &str = "system_event";
+
+/// JSON-RPC method used to send a runtime command.
+pub const COMMAND_METHOD: &str = "command";
+
+/// JSON-RPC method used to carry an ACP message.
+pub const ACP_METHOD: &str = "acp";
+
+/// The kind of runtime or agent state transition reported to the Agent Service.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum SystemEventName {
+    /// An application-defined event name.
+    Unknown(String),
+}
+
+impl SystemEventName {
+    /// Return the event name used on the wire.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Unknown(name) => name,
+        }
+    }
+}
+
+impl Display for SystemEventName {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl Serialize for SystemEventName {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for SystemEventName {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let name = String::deserialize(deserializer)?;
+        Ok(Self::Unknown(name))
+    }
+}
+
+/// A runtime or agent state transition sent to the Agent Service.
+#[derive(Debug, Clone, Serialize, JsonRpcNotification, PartialEq)]
+#[notification(method = "system_event")]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct SystemEvent {
+    /// Stable identifier reused when replaying this logical event.
+    pub event_id: String,
+    /// Monotonically increasing sequence within a runtime instance.
+    pub sequence: u64,
+    /// Typed event name with forward-compatible handling of unknown values.
+    pub name: SystemEventName,
+    /// UTC occurrence time formatted according to RFC 3339.
+    pub occurred_at: String,
+    /// Stable logical agent identifier for an agent-scoped event.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent_id: Option<String>,
+    /// Current agent-process identifier for an agent-scoped event.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent_instance_id: Option<String>,
+    /// Event-specific JSON payload.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub payload: Option<Value>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SystemEventWire {
+    event_id: String,
+    sequence: u64,
+    name: SystemEventName,
+    occurred_at: String,
+    agent_id: Option<String>,
+    agent_instance_id: Option<String>,
+    payload: Option<Value>,
+}
+
+impl<'de> Deserialize<'de> for SystemEvent {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let wire = SystemEventWire::deserialize(deserializer)?;
+        if wire.agent_id.is_some() != wire.agent_instance_id.is_some() {
+            return Err(serde::de::Error::custom(
+                "agentId and agentInstanceId must both be present or both be absent",
+            ));
+        }
+        Ok(Self {
+            event_id: wire.event_id,
+            sequence: wire.sequence,
+            name: wire.name,
+            occurred_at: wire.occurred_at,
+            agent_id: wire.agent_id,
+            agent_instance_id: wire.agent_instance_id,
+            payload: wire.payload,
+        })
+    }
+}
+
+impl SystemEvent {
+    /// Construct a runtime-scoped system event without a payload.
+    #[must_use]
+    pub fn new(
+        event_id: impl Into<String>,
+        sequence: u64,
+        name: SystemEventName,
+        occurred_at: impl Into<String>,
+    ) -> Self {
+        Self {
+            event_id: event_id.into(),
+            sequence,
+            name,
+            occurred_at: occurred_at.into(),
+            agent_id: None,
+            agent_instance_id: None,
+            payload: None,
+        }
+    }
+
+    /// Target this event at one running agent instance.
+    #[must_use]
+    pub fn agent(
+        mut self,
+        agent_id: impl Into<String>,
+        agent_instance_id: impl Into<String>,
+    ) -> Self {
+        self.agent_id = Some(agent_id.into());
+        self.agent_instance_id = Some(agent_instance_id.into());
+        self
+    }
+
+    /// Attach an event-specific JSON payload.
+    #[must_use]
+    pub fn payload(mut self, payload: impl Into<Value>) -> Self {
+        self.payload = Some(payload.into());
+        self
+    }
+}
+
+/// The operation requested by the Agent Service.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum CommandName {
+    /// An application-defined command name.
+    Unknown(String),
+}
+
+impl CommandName {
+    /// Return the command name used on the wire.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Unknown(name) => name,
+        }
+    }
+}
+
+impl Display for CommandName {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl Serialize for CommandName {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for CommandName {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let name = String::deserialize(deserializer)?;
+        Ok(Self::Unknown(name))
+    }
+}
+
+/// An operation requested by the Agent Service and handled by the Agent Runtime.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest, PartialEq)]
+#[request(method = "command", response = CommandResult)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct Command {
+    /// Stable identifier reused when retrying this logical command.
+    pub command_id: String,
+    /// Typed command name with forward-compatible handling of unknown values.
+    pub name: CommandName,
+    /// Stable logical agent identifier for an agent-scoped command.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent_id: Option<String>,
+    /// Current agent-process identifier when the command targets one execution.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent_instance_id: Option<String>,
+    /// Command-specific JSON payload.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub payload: Option<Value>,
+}
+
+impl Command {
+    /// Construct a runtime-scoped command without a payload.
+    #[must_use]
+    pub fn new(command_id: impl Into<String>, name: CommandName) -> Self {
+        Self {
+            command_id: command_id.into(),
+            name,
+            agent_id: None,
+            agent_instance_id: None,
+            payload: None,
+        }
+    }
+
+    /// Target this command at a logical agent.
+    #[must_use]
+    pub fn agent(mut self, agent_id: impl Into<String>) -> Self {
+        self.agent_id = Some(agent_id.into());
+        self
+    }
+
+    /// Restrict this command to the current execution of its target agent.
+    #[must_use]
+    pub fn agent_instance(mut self, agent_instance_id: impl Into<String>) -> Self {
+        self.agent_instance_id = Some(agent_instance_id.into());
+        self
+    }
+
+    /// Attach a command-specific JSON payload.
+    #[must_use]
+    pub fn payload(mut self, payload: impl Into<Value>) -> Self {
+        self.payload = Some(payload.into());
+        self
+    }
+}
+
+/// Result of executing a command.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse, PartialEq)]
+#[serde(tag = "status", rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum CommandResult {
+    /// The command completed synchronously.
+    Completed {
+        /// Optional command-specific result value.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        value: Option<Value>,
+    },
+}
+
+impl CommandResult {
+    /// Construct a synchronous completion without a result value.
+    #[must_use]
+    pub fn completed() -> Self {
+        Self::Completed { value: None }
+    }
+
+    /// Construct a synchronous completion with a result value.
+    #[must_use]
+    pub fn completed_with(value: impl Into<Value>) -> Self {
+        Self::Completed {
+            value: Some(value.into()),
+        }
+    }
+}
+
+/// One complete ACP JSON-RPC message routed to a running agent instance.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcNotification)]
+#[notification(method = "acp")]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct AcpMessage {
+    /// Unique identifier for this outer ACP delivery.
+    pub message_id: String,
+    /// Stable logical identifier of the target agent.
+    pub agent_id: String,
+    /// Identifier of the target agent process execution.
+    pub agent_instance_id: String,
+    /// Complete nested ACP JSON-RPC request, notification, or response.
+    pub message: RawJsonRpcMessage,
+}
+
+impl AcpMessage {
+    /// Construct an ACP delivery for one running agent instance.
+    #[must_use]
+    pub fn new(
+        message_id: impl Into<String>,
+        agent_id: impl Into<String>,
+        agent_instance_id: impl Into<String>,
+        message: RawJsonRpcMessage,
+    ) -> Self {
+        Self {
+            message_id: message_id.into(),
+            agent_id: agent_id.into(),
+            agent_instance_id: agent_instance_id.into(),
+            message,
+        }
+    }
+}

--- a/crates/agent_runtime_protocol/src/schema/v0/test.rs
+++ b/crates/agent_runtime_protocol/src/schema/v0/test.rs
@@ -1,0 +1,246 @@
+use agent_client_protocol::schema::v1::RequestId;
+use agent_client_protocol::{
+    JsonRpcMessage, JsonRpcNotification, JsonRpcRequest, JsonRpcResponse, RawJsonRpcMessage,
+};
+use serde_json::json;
+
+use super::*;
+
+fn assert_request_response_pair<Request, Response>()
+where
+    Request: JsonRpcRequest<Response = Response>,
+    Response: JsonRpcResponse,
+{
+}
+
+fn assert_notification<Notification: JsonRpcNotification>() {}
+
+#[test]
+fn request_types_use_the_acp_jsonrpc_traits() {
+    assert_request_response_pair::<Command, CommandResult>();
+    assert_notification::<SystemEvent>();
+    assert_notification::<AcpMessage>();
+
+    assert_eq!(
+        SystemEvent::new(
+            "event-1",
+            1,
+            SystemEventName::Unknown("runtime/ready".to_owned()),
+            "2026-07-17T00:00:00Z",
+        )
+        .method(),
+        SYSTEM_EVENT_METHOD
+    );
+    assert_eq!(
+        Command::new(
+            "command-1",
+            CommandName::Unknown("example/command".to_owned()),
+        )
+        .method(),
+        COMMAND_METHOD
+    );
+}
+
+#[test]
+fn rpc_methods_are_short_and_unprefixed() {
+    assert_eq!(SYSTEM_EVENT_METHOD, "system_event");
+    assert_eq!(COMMAND_METHOD, "command");
+    assert_eq!(ACP_METHOD, "acp");
+}
+
+#[test]
+fn command_and_event_names_are_opaque_wire_strings() {
+    let command_names = [
+        CommandName::Unknown("runtime/configure".to_owned()),
+        CommandName::Unknown("vendor/custom-command".to_owned()),
+    ];
+    for name in command_names {
+        let wire_name = name.as_str();
+        assert_eq!(serde_json::to_value(&name).unwrap(), json!(wire_name));
+        assert_eq!(
+            serde_json::from_value::<CommandName>(json!(wire_name)).unwrap(),
+            name
+        );
+    }
+
+    let event_names = [
+        SystemEventName::Unknown("runtime/ready".to_owned()),
+        SystemEventName::Unknown("agent/started".to_owned()),
+        SystemEventName::Unknown("vendor/custom-event".to_owned()),
+    ];
+    for name in event_names {
+        let wire_name = name.as_str();
+        assert_eq!(serde_json::to_value(&name).unwrap(), json!(wire_name));
+        assert_eq!(
+            serde_json::from_value::<SystemEventName>(json!(wire_name)).unwrap(),
+            name
+        );
+    }
+}
+
+#[test]
+fn unknown_command_and_event_names_round_trip_losslessly() {
+    let command = serde_json::from_value::<CommandName>(json!("vendor/custom-command")).unwrap();
+    assert_eq!(
+        command,
+        CommandName::Unknown("vendor/custom-command".to_owned())
+    );
+    assert_eq!(
+        serde_json::to_value(command).unwrap(),
+        json!("vendor/custom-command")
+    );
+
+    let event = serde_json::from_value::<SystemEventName>(json!("vendor/custom-event")).unwrap();
+    assert_eq!(
+        event,
+        SystemEventName::Unknown("vendor/custom-event".to_owned())
+    );
+    assert_eq!(
+        serde_json::to_value(event).unwrap(),
+        json!("vendor/custom-event")
+    );
+}
+
+#[test]
+fn system_event_has_the_specified_wire_shape() {
+    let event = SystemEvent::new(
+        "019c-event",
+        18,
+        SystemEventName::Unknown("agent/stopped".to_owned()),
+        "2026-07-17T18:42:10Z",
+    )
+    .agent("primary", "019c-agent-instance")
+    .payload(json!({
+        "reason": "process_exit",
+        "exitCode": 1,
+    }));
+
+    let message = event.to_untyped_message().unwrap();
+
+    assert_eq!(message.method(), SYSTEM_EVENT_METHOD);
+    assert_eq!(
+        message.params(),
+        &json!({
+            "eventId": "019c-event",
+            "sequence": 18,
+            "name": "agent/stopped",
+            "occurredAt": "2026-07-17T18:42:10Z",
+            "agentId": "primary",
+            "agentInstanceId": "019c-agent-instance",
+            "payload": {
+                "reason": "process_exit",
+                "exitCode": 1,
+            },
+        })
+    );
+}
+
+#[test]
+fn system_event_rejects_partially_scoped_targets() {
+    let base = json!({
+        "eventId": "event-1",
+        "sequence": 1,
+        "name": "agent/changed",
+        "occurredAt": "2026-07-17T00:00:00Z",
+    });
+
+    for partial_target in [
+        json!({ "agentId": "agent-1" }),
+        json!({ "agentInstanceId": "instance-1" }),
+    ] {
+        let mut event = base.clone();
+        event
+            .as_object_mut()
+            .unwrap()
+            .extend(partial_target.as_object().unwrap().clone());
+
+        assert!(
+            serde_json::from_value::<SystemEvent>(event).is_err(),
+            "partially scoped events must be rejected"
+        );
+    }
+}
+
+#[test]
+fn command_and_results_have_the_specified_wire_shapes() {
+    let command = Command::new(
+        "019c-command",
+        CommandName::Unknown("example/command".to_owned()),
+    )
+    .agent("primary")
+    .agent_instance("019c-agent-instance")
+    .payload(json!({ "reason": "configuration_changed" }));
+
+    let message = command.to_untyped_message().unwrap();
+    assert_eq!(message.method(), COMMAND_METHOD);
+    assert_eq!(
+        message.params(),
+        &json!({
+            "commandId": "019c-command",
+            "name": "example/command",
+            "agentId": "primary",
+            "agentInstanceId": "019c-agent-instance",
+            "payload": {
+                "reason": "configuration_changed",
+            },
+        })
+    );
+
+    assert_eq!(
+        CommandResult::completed_with(json!({ "handled": true }))
+            .into_json(COMMAND_METHOD)
+            .unwrap(),
+        json!({
+            "status": "completed",
+            "value": { "handled": true },
+        })
+    );
+    assert!(
+        serde_json::from_value::<CommandResult>(json!({ "status": "accepted" })).is_err(),
+        "the removed acceptance result must not remain wire-compatible"
+    );
+}
+
+#[test]
+fn acp_message_contains_an_acp_raw_jsonrpc_message() {
+    let nested = RawJsonRpcMessage::request(
+        "initialize".to_owned(),
+        json!({ "protocolVersion": 1 }),
+        RequestId::Number(1),
+    )
+    .unwrap();
+    let delivery = AcpMessage::new("019c-acp-message", "primary", "019c-agent-instance", nested);
+
+    let message = delivery.to_untyped_message().unwrap();
+
+    assert_eq!(message.method(), ACP_METHOD);
+    assert_eq!(
+        message.params(),
+        &json!({
+            "messageId": "019c-acp-message",
+            "agentId": "primary",
+            "agentInstanceId": "019c-agent-instance",
+            "message": {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": 1,
+                },
+            },
+        })
+    );
+
+    let parsed = AcpMessage::parse_message(message.method(), message.params()).unwrap();
+    assert_eq!(
+        serde_json::to_value(parsed.message).unwrap(),
+        json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": 1,
+            },
+        })
+    );
+}

--- a/crates/agent_runtime_protocol/src/testing/mod.rs
+++ b/crates/agent_runtime_protocol/src/testing/mod.rs
@@ -1,0 +1,316 @@
+//! Reusable utilities for asserting protocol JSON at the wire boundary.
+//!
+//! A wire test is a direction-labelled transcript of complete JSON-RPC
+//! messages represented as [`serde_json::Value`]s. It does not deserialize the
+//! messages into protocol types before comparing them. Consequently, it can
+//! catch changes to method names, field names, IDs, and JSON shapes.
+//!
+//! When testing an Agent Runtime, messages directed to the runtime are
+//! injected and messages directed to the server are asserted. When testing an
+//! Agent Service, the same transcript is interpreted in the opposite way.
+//!
+//! A conversation is defined without choosing the peer under test:
+//!
+//! ```text
+//! WireTest::new([
+//!     to_server(json!({
+//!         "jsonrpc": "2.0",
+//!         "id": 2,
+//!         "method": "send",
+//!         "params": {
+//!             "connectionId": "connection-1",
+//!             "message": {
+//!                 "jsonrpc": "2.0",
+//!                 "method": "system_event",
+//!                 "params": {
+//!                     "eventId": "event-1",
+//!                     "sequence": 1,
+//!                     "name": "runtime/stopping",
+//!                     "occurredAt": "2026-07-17T00:00:00Z"
+//!                 }
+//!             }
+//!         }
+//!     })),
+//! ])
+//! ```
+
+use std::error::Error;
+use std::fmt::{self, Display, Formatter};
+use std::future::Future;
+
+use serde_json::Value;
+
+#[cfg(test)]
+mod test;
+
+/// The destination of a JSON message on the protocol wire.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Direction {
+    /// The message travels from the Agent Service to the Agent Runtime.
+    ToRuntime,
+    /// The message travels from the Agent Runtime to the Agent Service.
+    ToServer,
+}
+
+impl Display for Direction {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ToRuntime => formatter.write_str("runtime"),
+            Self::ToServer => formatter.write_str("server"),
+        }
+    }
+}
+
+/// One complete JSON message and its destination on the protocol wire.
+#[derive(Clone, Debug, PartialEq)]
+pub struct WireMessage {
+    message: Value,
+    direction: Direction,
+}
+
+impl WireMessage {
+    /// Construct a direction-labelled wire message.
+    pub fn new(direction: Direction, message: Value) -> Self {
+        Self { message, direction }
+    }
+
+    /// Return this message's wire destination.
+    pub fn direction(&self) -> Direction {
+        self.direction
+    }
+
+    /// Borrow the complete JSON message.
+    pub fn message(&self) -> &Value {
+        &self.message
+    }
+
+    /// Consume the wrapper and return the complete JSON message.
+    pub fn into_message(self) -> Value {
+        self.message
+    }
+}
+
+/// Wrap a wire message sent from the Agent Service to the Agent Runtime.
+pub fn to_runtime(message: Value) -> WireMessage {
+    WireMessage::new(Direction::ToRuntime, message)
+}
+
+/// Wrap a wire message sent from the Agent Runtime to the Agent Service.
+pub fn to_server(message: Value) -> WireMessage {
+    WireMessage::new(Direction::ToServer, message)
+}
+
+/// The protocol peer exercised by a wire test.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PeerUnderTest {
+    /// Exercise an Agent Runtime implementation.
+    Runtime,
+    /// Exercise an Agent Service implementation.
+    Server,
+}
+
+impl PeerUnderTest {
+    fn receives(self, direction: Direction) -> bool {
+        matches!(
+            (self, direction),
+            (Self::Runtime, Direction::ToRuntime) | (Self::Server, Direction::ToServer)
+        )
+    }
+}
+
+/// An adapter between a wire test and the peer under test.
+///
+/// Implementations may drive an in-memory connection, a WebSocket, or a
+/// spawned process. They must expose complete, decoded JSON messages without
+/// translating them into typed protocol values. Sending and receiving are
+/// named relative to the subject under test, avoiding assumptions about which
+/// peer opened the connection.
+///
+/// Implementations SHOULD place a timeout around receive operations; the
+/// runner deliberately does not depend on a particular async executor.
+pub trait WireHarness: Send {
+    /// An error produced while communicating with the subject under test.
+    type Error: Error + Send + Sync + 'static;
+
+    /// Put a complete JSON message onto the wire toward the subject under test.
+    fn send_to_subject(
+        &mut self,
+        message: Value,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+
+    /// Receive the next complete JSON message emitted onto the wire by the subject.
+    fn receive_from_subject(&mut self) -> impl Future<Output = Result<Value, Self::Error>> + Send;
+}
+
+/// A direction-labelled JSON transcript that can exercise either protocol peer.
+///
+/// Outbound messages are compared using [`serde_json::Value`] equality. This
+/// asserts the complete decoded JSON value, while intentionally ignoring
+/// insignificant textual differences such as whitespace and object-key order.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct WireTest {
+    messages: Vec<WireMessage>,
+}
+
+impl WireTest {
+    /// Construct a wire test from complete JSON messages in expected wire order.
+    pub fn new(messages: impl IntoIterator<Item = WireMessage>) -> Self {
+        Self {
+            messages: messages.into_iter().collect(),
+        }
+    }
+
+    /// Borrow the direction-labelled wire transcript.
+    pub fn messages(&self) -> &[WireMessage] {
+        &self.messages
+    }
+
+    /// Run this wire test against an Agent Runtime implementation.
+    pub async fn run_runtime<H>(&self, harness: &mut H) -> Result<(), WireTestFailure<H::Error>>
+    where
+        H: WireHarness,
+    {
+        self.run(PeerUnderTest::Runtime, harness).await
+    }
+
+    /// Run this wire test against an Agent Service implementation.
+    pub async fn run_server<H>(&self, harness: &mut H) -> Result<(), WireTestFailure<H::Error>>
+    where
+        H: WireHarness,
+    {
+        self.run(PeerUnderTest::Server, harness).await
+    }
+
+    /// Run this wire test against the selected protocol peer.
+    pub async fn run<H>(
+        &self,
+        peer: PeerUnderTest,
+        harness: &mut H,
+    ) -> Result<(), WireTestFailure<H::Error>>
+    where
+        H: WireHarness,
+    {
+        for (step, expected) in self.messages.iter().enumerate() {
+            if peer.receives(expected.direction) {
+                harness
+                    .send_to_subject(expected.message.clone())
+                    .await
+                    .map_err(|source| WireTestFailure::Send {
+                        step,
+                        direction: expected.direction,
+                        source,
+                    })?;
+                continue;
+            }
+
+            let actual = harness.receive_from_subject().await.map_err(|source| {
+                WireTestFailure::Receive {
+                    step,
+                    direction: expected.direction,
+                    source,
+                }
+            })?;
+
+            if actual != expected.message {
+                return Err(WireTestFailure::Mismatch {
+                    step,
+                    direction: expected.direction,
+                    expected: expected.message.clone(),
+                    actual,
+                });
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl FromIterator<WireMessage> for WireTest {
+    fn from_iter<T: IntoIterator<Item = WireMessage>>(messages: T) -> Self {
+        Self::new(messages)
+    }
+}
+
+/// A failure while running a direction-labelled wire test.
+#[derive(Debug)]
+pub enum WireTestFailure<E> {
+    /// An inbound wire message could not be delivered to the subject.
+    Send {
+        /// Zero-based wire-test step.
+        step: usize,
+        /// Intended wire destination.
+        direction: Direction,
+        /// Harness error.
+        source: E,
+    },
+    /// The next outbound wire message could not be received from the subject.
+    Receive {
+        /// Zero-based wire-test step.
+        step: usize,
+        /// Expected wire destination.
+        direction: Direction,
+        /// Harness error.
+        source: E,
+    },
+    /// The subject emitted a different JSON value than the wire test expected.
+    Mismatch {
+        /// Zero-based wire-test step.
+        step: usize,
+        /// Expected wire destination.
+        direction: Direction,
+        /// Expected complete JSON message.
+        expected: Value,
+        /// Actual complete JSON message.
+        actual: Value,
+    },
+}
+
+impl<E> Display for WireTestFailure<E>
+where
+    E: Display,
+{
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Send {
+                step,
+                direction,
+                source,
+            } => write!(
+                formatter,
+                "wire step {}: failed to send JSON message to {direction}: {source}",
+                step + 1
+            ),
+            Self::Receive {
+                step,
+                direction,
+                source,
+            } => write!(
+                formatter,
+                "wire step {}: failed to receive JSON message to {direction}: {source}",
+                step + 1
+            ),
+            Self::Mismatch {
+                step,
+                direction,
+                expected,
+                actual,
+            } => write!(
+                formatter,
+                "wire step {}: JSON message to {direction} did not match\nexpected: {expected}\n  actual: {actual}",
+                step + 1
+            ),
+        }
+    }
+}
+
+impl<E> Error for WireTestFailure<E>
+where
+    E: Error + 'static,
+{
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Send { source, .. } | Self::Receive { source, .. } => Some(source),
+            Self::Mismatch { .. } => None,
+        }
+    }
+}

--- a/crates/agent_runtime_protocol/src/testing/test.rs
+++ b/crates/agent_runtime_protocol/src/testing/test.rs
@@ -1,0 +1,268 @@
+use std::collections::VecDeque;
+use std::error::Error;
+use std::fmt::{self, Display, Formatter};
+use std::future::{Future, ready};
+
+use serde_json::{Value, json};
+
+use super::*;
+
+#[derive(Default)]
+struct Harness {
+    sent_to_subject: Vec<Value>,
+    emitted_by_subject: VecDeque<Value>,
+}
+
+#[derive(Debug)]
+struct HarnessError;
+
+impl Display for HarnessError {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter.write_str("test harness error")
+    }
+}
+
+impl Error for HarnessError {}
+
+impl Harness {
+    fn with_emitted(messages: impl IntoIterator<Item = Value>) -> Self {
+        Self {
+            sent_to_subject: Vec::new(),
+            emitted_by_subject: messages.into_iter().collect(),
+        }
+    }
+}
+
+impl WireHarness for Harness {
+    type Error = HarnessError;
+
+    fn send_to_subject(
+        &mut self,
+        message: Value,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send {
+        self.sent_to_subject.push(message);
+        ready(Ok(()))
+    }
+
+    fn receive_from_subject(&mut self) -> impl Future<Output = Result<Value, Self::Error>> + Send {
+        let message = self
+            .emitted_by_subject
+            .pop_front()
+            .expect("fixture should provide the next emitted message");
+        ready(Ok(message))
+    }
+}
+
+fn conversation() -> WireTest {
+    WireTest::new([
+        to_server(json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "subscribe",
+            "params": {
+                "connectionId": "connection-1"
+            }
+        })),
+        to_runtime(json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": 1
+        })),
+        to_server(json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "send",
+            "params": {
+                "connectionId": "connection-1",
+                "message": {
+                    "jsonrpc": "2.0",
+                    "method": "system_event",
+                    "params": {
+                        "eventId": "event-1",
+                        "sequence": 1,
+                        "name": "runtime/ready",
+                        "occurredAt": "2026-07-17T00:00:00Z"
+                    }
+                }
+            }
+        })),
+        to_runtime(json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "result": null
+        })),
+        to_runtime(json!({
+            "jsonrpc": "2.0",
+            "method": "message",
+            "params": {
+                "subscription": 1,
+                "result": {
+                    "message": {
+                        "jsonrpc": "2.0",
+                        "id": 1,
+                        "method": "command",
+                        "params": {
+                            "commandId": "command-1",
+                            "name": "runtime/configure"
+                        }
+                    }
+                }
+            }
+        })),
+        to_server(json!({
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "send",
+            "params": {
+                "connectionId": "connection-1",
+                "message": {
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": {
+                        "status": "completed"
+                    }
+                }
+            }
+        })),
+        to_runtime(json!({
+            "jsonrpc": "2.0",
+            "id": 3,
+            "result": null
+        })),
+        to_runtime(json!({
+            "jsonrpc": "2.0",
+            "method": "message",
+            "params": {
+                "subscription": 1,
+                "result": {
+                    "message": {
+                        "jsonrpc": "2.0",
+                        "method": "acp",
+                        "params": {
+                            "messageId": "acp-1",
+                            "agentId": "primary",
+                            "agentInstanceId": "agent-instance-1",
+                            "message": {
+                                "jsonrpc": "2.0",
+                                "id": 1,
+                                "method": "initialize",
+                                "params": { "protocolVersion": 1 }
+                            }
+                        }
+                    }
+                }
+            }
+        })),
+        to_server(json!({
+            "jsonrpc": "2.0",
+            "id": 4,
+            "method": "send",
+            "params": {
+                "connectionId": "connection-1",
+                "message": {
+                    "jsonrpc": "2.0",
+                    "method": "acp",
+                    "params": {
+                        "messageId": "acp-2",
+                        "agentId": "primary",
+                        "agentInstanceId": "agent-instance-1",
+                        "message": {
+                            "jsonrpc": "2.0",
+                            "id": 1,
+                            "result": { "protocolVersion": 1 }
+                        }
+                    }
+                }
+            }
+        })),
+        to_runtime(json!({
+            "jsonrpc": "2.0",
+            "id": 4,
+            "result": null
+        })),
+    ])
+}
+
+#[tokio::test]
+async fn one_transcript_exercises_the_runtime_and_server() {
+    let test = conversation();
+
+    let mut runtime = Harness::with_emitted([
+        test.messages()[0].message().clone(),
+        test.messages()[2].message().clone(),
+        test.messages()[5].message().clone(),
+        test.messages()[8].message().clone(),
+    ]);
+    test.run_runtime(&mut runtime)
+        .await
+        .expect("runtime should satisfy transcript");
+    assert_eq!(
+        runtime.sent_to_subject,
+        [
+            test.messages()[1].message().clone(),
+            test.messages()[3].message().clone(),
+            test.messages()[4].message().clone(),
+            test.messages()[6].message().clone(),
+            test.messages()[7].message().clone(),
+            test.messages()[9].message().clone(),
+        ]
+    );
+
+    let mut server = Harness::with_emitted([
+        test.messages()[1].message().clone(),
+        test.messages()[3].message().clone(),
+        test.messages()[4].message().clone(),
+        test.messages()[6].message().clone(),
+        test.messages()[7].message().clone(),
+        test.messages()[9].message().clone(),
+    ]);
+    test.run_server(&mut server)
+        .await
+        .expect("server should satisfy transcript");
+    assert_eq!(
+        server.sent_to_subject,
+        [
+            test.messages()[0].message().clone(),
+            test.messages()[2].message().clone(),
+            test.messages()[5].message().clone(),
+            test.messages()[8].message().clone(),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn mismatch_reports_step_direction_and_values() {
+    let test = WireTest::new([to_server(json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "result": { "expected": true }
+    }))]);
+    let mut runtime = Harness::with_emitted([json!({"actual": true})]);
+
+    let failure = test
+        .run_runtime(&mut runtime)
+        .await
+        .expect_err("different JSON should fail");
+
+    let WireTestFailure::Mismatch {
+        step,
+        direction,
+        expected,
+        actual,
+    } = failure
+    else {
+        panic!("expected a mismatch failure");
+    };
+
+    assert_eq!(step, 0);
+    assert_eq!(direction, Direction::ToServer);
+    assert_eq!(
+        expected,
+        json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": { "expected": true }
+        })
+    );
+    assert_eq!(actual, json!({"actual": true}));
+}

--- a/crates/agent_runtime_protocol/src/transport/jsonrpsee/mod.rs
+++ b/crates/agent_runtime_protocol/src/transport/jsonrpsee/mod.rs
@@ -1,0 +1,356 @@
+//! jsonrpsee subscription carrier.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+
+use agent_client_protocol::{Channel, RawJsonRpcMessage};
+use jsonrpsee::RpcModule;
+use jsonrpsee::core::client::{ClientT, SubscriptionClientT};
+use jsonrpsee::core::params::ObjectParams;
+use jsonrpsee::server::SubscriptionMessage as RpcSubscriptionMessage;
+use jsonrpsee::types::ErrorObjectOwned;
+use serde::{Deserialize, Serialize};
+use tokio::sync::{mpsc, oneshot};
+
+#[cfg(test)]
+mod test;
+
+/// Runtime-to-server method carrying one complete logical JSON-RPC message.
+pub const SEND_METHOD: &str = "send";
+/// Runtime request that opens the server-to-runtime message subscription.
+pub const SUBSCRIBE_METHOD: &str = "subscribe";
+/// Server notification used for subscription items.
+pub const MESSAGE_METHOD: &str = "message";
+/// Runtime request that closes the message subscription.
+pub const UNSUBSCRIBE_METHOD: &str = "unsubscribe";
+
+/// Parameters used by a runtime to identify a logical connection subscription.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Subscribe {
+    /// Runtime-chosen identity for this physical connection attempt.
+    pub connection_id: String,
+}
+
+impl Subscribe {
+    /// Construct subscription parameters.
+    #[must_use]
+    pub fn new(connection_id: impl Into<String>) -> Self {
+        Self {
+            connection_id: connection_id.into(),
+        }
+    }
+}
+
+/// A complete logical message sent from the runtime to the server.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RuntimeMessage {
+    /// Identifies the subscription that owns this message.
+    pub connection_id: String,
+    /// Complete logical JSON-RPC request, notification, or response.
+    pub message: RawJsonRpcMessage,
+}
+
+impl RuntimeMessage {
+    /// Wrap one logical message for the runtime-to-server carrier.
+    #[must_use]
+    pub fn new(connection_id: impl Into<String>, message: RawJsonRpcMessage) -> Self {
+        Self {
+            connection_id: connection_id.into(),
+            message,
+        }
+    }
+}
+
+/// One server-to-runtime subscription item.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct SubscriptionMessage {
+    /// Complete logical JSON-RPC request, notification, or response.
+    pub message: RawJsonRpcMessage,
+}
+
+impl SubscriptionMessage {
+    /// Wrap one logical message for a subscription item.
+    #[must_use]
+    pub fn new(message: RawJsonRpcMessage) -> Self {
+        Self { message }
+    }
+}
+
+/// A logical channel accepted from a runtime subscription.
+#[derive(Debug)]
+pub struct IncomingConnection {
+    connection_id: String,
+    generation: u64,
+    channel: Channel,
+}
+
+impl IncomingConnection {
+    /// Return the runtime-chosen connection identity.
+    #[must_use]
+    pub fn connection_id(&self) -> &str {
+        &self.connection_id
+    }
+
+    /// Consume the accepted connection and return its logical channel.
+    #[must_use]
+    pub fn into_channel(self) -> Channel {
+        self.channel
+    }
+}
+
+/// A jsonrpsee server module and its stream of accepted runtime subscriptions.
+pub struct ServerTransport {
+    state: ServerState,
+    incoming: tokio::sync::Mutex<mpsc::UnboundedReceiver<IncomingConnection>>,
+}
+
+#[derive(Clone)]
+struct ServerState {
+    routes: Arc<Mutex<HashMap<String, Route>>>,
+    incoming: mpsc::UnboundedSender<IncomingConnection>,
+    generation: Arc<AtomicU64>,
+}
+
+struct Route {
+    generation: u64,
+    inbound: futures::channel::mpsc::UnboundedSender<
+        Result<RawJsonRpcMessage, agent_client_protocol::Error>,
+    >,
+    cancel: oneshot::Sender<()>,
+}
+
+impl ServerTransport {
+    /// Construct an empty server carrier.
+    #[must_use]
+    pub fn new() -> Self {
+        let (incoming_sender, incoming) = mpsc::unbounded_channel();
+        Self {
+            state: ServerState {
+                routes: Arc::new(Mutex::new(HashMap::new())),
+                incoming: incoming_sender,
+                generation: Arc::new(AtomicU64::new(1)),
+            },
+            incoming: tokio::sync::Mutex::new(incoming),
+        }
+    }
+
+    /// Build the RPC module that accepts runtime messages and subscriptions.
+    pub fn rpc_module(&self) -> Result<RpcModule<()>, jsonrpsee::core::RegisterMethodError> {
+        let mut module = RpcModule::new(());
+        let state = self.state.clone();
+        module.register_async_method(SEND_METHOD, move |params, _, _| {
+            let state = state.clone();
+            async move {
+                let delivery = params.parse::<RuntimeMessage>()?;
+                let inbound = state
+                    .routes
+                    .lock()
+                    .map_err(|_| internal_error("connection registry is unavailable"))?
+                    .get(&delivery.connection_id)
+                    .map(|route| route.inbound.clone())
+                    .ok_or_else(|| connection_not_found(&delivery.connection_id))?;
+                inbound
+                    .unbounded_send(Ok(delivery.message))
+                    .map_err(|_| connection_not_found(&delivery.connection_id))?;
+                Ok::<(), ErrorObjectOwned>(())
+            }
+        })?;
+
+        let state = self.state.clone();
+        module.register_subscription(
+            SUBSCRIBE_METHOD,
+            MESSAGE_METHOD,
+            UNSUBSCRIBE_METHOD,
+            move |params, pending, _, _| {
+                let state = state.clone();
+                async move {
+                    let subscribe = match params.parse::<Subscribe>() {
+                        Ok(subscribe) => subscribe,
+                        Err(error) => {
+                            pending.reject(error).await;
+                            return;
+                        }
+                    };
+                    let Ok(sink) = pending.accept().await else {
+                        return;
+                    };
+
+                    let generation = state.generation.fetch_add(1, Ordering::Relaxed);
+                    let (connection, carrier) = Channel::duplex();
+                    let Channel {
+                        mut rx,
+                        tx: inbound,
+                    } = carrier;
+                    let (cancel, mut cancelled) = oneshot::channel();
+                    let previous = state.routes.lock().ok().and_then(|mut routes| {
+                        routes.insert(
+                            subscribe.connection_id.clone(),
+                            Route {
+                                generation,
+                                inbound,
+                                cancel,
+                            },
+                        )
+                    });
+                    if let Some(previous) = previous {
+                        let _ = previous.cancel.send(());
+                    }
+
+                    if state
+                        .incoming
+                        .send(IncomingConnection {
+                            connection_id: subscribe.connection_id.clone(),
+                            generation,
+                            channel: connection,
+                        })
+                        .is_err()
+                    {
+                        remove_route(&state, &subscribe.connection_id, generation);
+                        return;
+                    }
+
+                    loop {
+                        tokio::select! {
+                            message = futures::StreamExt::next(&mut rx) => {
+                                let Some(Ok(message)) = message else {
+                                    break;
+                                };
+                                let Ok(message) = serde_json::value::to_raw_value(
+                                    &SubscriptionMessage::new(message),
+                                ) else {
+                                    break;
+                                };
+                                if sink.send(RpcSubscriptionMessage::from(message)).await.is_err() {
+                                    break;
+                                }
+                            }
+                            () = sink.closed() => break,
+                            _ = &mut cancelled => break,
+                        }
+                    }
+                    remove_route(&state, &subscribe.connection_id, generation);
+                }
+            },
+        )?;
+
+        Ok(module)
+    }
+
+    /// Wait for the next accepted runtime subscription.
+    pub async fn accept(&self) -> Option<IncomingConnection> {
+        let mut incoming = self.incoming.lock().await;
+        loop {
+            let connection = incoming.recv().await?;
+            let is_active = self
+                .state
+                .routes
+                .lock()
+                .ok()
+                .and_then(|routes| {
+                    routes
+                        .get(&connection.connection_id)
+                        .map(|route| route.generation == connection.generation)
+                })
+                .unwrap_or(false);
+            if is_active {
+                return Some(connection);
+            }
+        }
+    }
+}
+
+impl Default for ServerTransport {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// A failure in the jsonrpsee carrier.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum TransportError {
+    /// A jsonrpsee client operation failed.
+    #[error("jsonrpsee client failed: {0}")]
+    Client(String),
+}
+
+/// Subscribe a runtime-side jsonrpsee client and expose its logical channel.
+pub async fn connect_runtime<C>(
+    client: Arc<C>,
+    connection_id: impl Into<String>,
+) -> Result<Channel, TransportError>
+where
+    C: ClientT + SubscriptionClientT + Send + Sync + 'static,
+{
+    let connection_id = connection_id.into();
+    let mut params = ObjectParams::new();
+    params
+        .insert("connectionId", &connection_id)
+        .map_err(|error| TransportError::Client(error.to_string()))?;
+    let mut subscription = client
+        .subscribe::<SubscriptionMessage, _>(SUBSCRIBE_METHOD, params, UNSUBSCRIBE_METHOD)
+        .await
+        .map_err(|error| TransportError::Client(error.to_string()))?;
+    let (connection, carrier) = Channel::duplex();
+    let Channel {
+        mut rx,
+        tx: inbound,
+    } = carrier;
+
+    tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                message = futures::StreamExt::next(&mut subscription) => {
+                    let Some(Ok(message)) = message else {
+                        break;
+                    };
+                    if inbound.unbounded_send(Ok(message.message)).is_err() {
+                        break;
+                    }
+                }
+                message = futures::StreamExt::next(&mut rx) => {
+                    let Some(Ok(message)) = message else {
+                        break;
+                    };
+                    let mut params = ObjectParams::new();
+                    if params.insert("connectionId", &connection_id).is_err()
+                        || params.insert("message", &message).is_err()
+                    {
+                        break;
+                    }
+                    if client.request::<(), _>(SEND_METHOD, params).await.is_err() {
+                        break;
+                    }
+                }
+            }
+        }
+    });
+
+    Ok(connection)
+}
+
+fn remove_route(state: &ServerState, connection_id: &str, generation: u64) {
+    if let Ok(mut routes) = state.routes.lock() {
+        let owns_route = routes
+            .get(connection_id)
+            .is_some_and(|route| route.generation == generation);
+        if owns_route {
+            routes.remove(connection_id);
+        }
+    }
+}
+
+fn connection_not_found(connection_id: &str) -> ErrorObjectOwned {
+    ErrorObjectOwned::owned(
+        -32_004,
+        "connection not found",
+        Some(serde_json::json!({ "connectionId": connection_id })),
+    )
+}
+
+fn internal_error(message: &'static str) -> ErrorObjectOwned {
+    ErrorObjectOwned::owned(-32_603, message, None::<()>)
+}

--- a/crates/agent_runtime_protocol/src/transport/jsonrpsee/test.rs
+++ b/crates/agent_runtime_protocol/src/transport/jsonrpsee/test.rs
@@ -1,0 +1,350 @@
+use agent_client_protocol::RawJsonRpcMessage;
+use futures::StreamExt;
+use jsonrpsee::server::Server;
+use jsonrpsee::ws_client::WsClientBuilder;
+use serde_json::{Value, json};
+use tokio::time::{Duration, timeout};
+
+use super::*;
+use crate::connection::{CommandHandler, RuntimeConnection, ServerConnection, SystemEventHandler};
+use crate::schema::v0::{Command, CommandName, CommandResult, SystemEvent, SystemEventName};
+
+fn event() -> RawJsonRpcMessage {
+    RawJsonRpcMessage::notification(
+        "system_event".to_owned(),
+        json!({
+            "eventId": "event-1",
+            "sequence": 1,
+            "name": "runtime/ready",
+            "occurredAt": "2026-07-17T00:00:00Z",
+        }),
+    )
+    .unwrap()
+}
+
+fn command() -> RawJsonRpcMessage {
+    RawJsonRpcMessage::request(
+        "command".to_owned(),
+        json!({
+            "commandId": "command-1",
+            "name": "runtime/configure",
+        }),
+        agent_client_protocol::schema::v1::RequestId::Number(1),
+    )
+    .unwrap()
+}
+
+#[test]
+fn carrier_names_and_payloads_are_unprefixed_and_exact() {
+    assert_eq!(SEND_METHOD, "send");
+    assert_eq!(SUBSCRIBE_METHOD, "subscribe");
+    assert_eq!(MESSAGE_METHOD, "message");
+    assert_eq!(UNSUBSCRIBE_METHOD, "unsubscribe");
+    assert_eq!(
+        serde_json::to_value(Subscribe::new("connection-1")).unwrap(),
+        json!({ "connectionId": "connection-1" })
+    );
+    assert_eq!(
+        serde_json::to_value(RuntimeMessage::new("connection-1", event())).unwrap(),
+        json!({
+            "connectionId": "connection-1",
+            "message": {
+                "jsonrpc": "2.0",
+                "method": "system_event",
+                "params": {
+                    "eventId": "event-1",
+                    "sequence": 1,
+                    "name": "runtime/ready",
+                    "occurredAt": "2026-07-17T00:00:00Z",
+                }
+            }
+        })
+    );
+}
+
+#[tokio::test]
+async fn rpc_module_routes_both_directions_through_the_subscription() {
+    let transport = ServerTransport::new();
+    let module = transport.rpc_module().expect("RPC module should build");
+    let (_, mut subscription) = module
+        .raw_json_request(
+            r#"{"jsonrpc":"2.0","method":"subscribe","params":{"connectionId":"connection-1"},"id":1}"#,
+            1,
+        )
+        .await
+        .expect("subscription should open");
+    let incoming = timeout(Duration::from_secs(1), transport.accept())
+        .await
+        .expect("accept should not hang")
+        .expect("connection should be accepted");
+    assert_eq!(incoming.connection_id(), "connection-1");
+    let mut server = incoming.into_channel();
+
+    server.tx.unbounded_send(Ok(command())).unwrap();
+    let physical = timeout(Duration::from_secs(1), subscription.recv())
+        .await
+        .expect("subscription message should not hang")
+        .expect("subscription should remain open");
+    let physical: Value = serde_json::from_str(physical.get()).unwrap();
+    assert_eq!(physical["method"], "message");
+    assert_eq!(physical["params"]["result"]["message"]["method"], "command");
+    assert_eq!(physical["params"]["result"]["message"]["id"], 1);
+
+    let runtime_message = serde_json::to_string(&json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "send",
+        "params": RuntimeMessage::new("connection-1", event()),
+    }))
+    .unwrap();
+    module
+        .raw_json_request(&runtime_message, 1)
+        .await
+        .expect("runtime message should dispatch");
+    let delivered = timeout(Duration::from_secs(1), server.rx.next())
+        .await
+        .expect("runtime message should not hang")
+        .expect("logical channel should remain open")
+        .expect("logical message should be valid");
+    assert_eq!(
+        serde_json::to_value(delivered).unwrap()["method"],
+        "system_event"
+    );
+}
+
+#[tokio::test]
+async fn replacement_subscription_owns_the_connection_route() {
+    let transport = ServerTransport::new();
+    let module = transport.rpc_module().expect("RPC module should build");
+    let (_, mut old_subscription) = module
+        .raw_json_request(
+            r#"{"jsonrpc":"2.0","method":"subscribe","params":{"connectionId":"connection-1"},"id":1}"#,
+            1,
+        )
+        .await
+        .expect("first subscription should open");
+    let old_connection = transport.accept().await.expect("first connection");
+
+    let (_, mut new_subscription) = module
+        .raw_json_request(
+            r#"{"jsonrpc":"2.0","method":"subscribe","params":{"connectionId":"connection-1"},"id":2}"#,
+            2,
+        )
+        .await
+        .expect("replacement subscription should open");
+    let new_connection = transport.accept().await.expect("replacement connection");
+    let new_server = new_connection.into_channel();
+    new_server.tx.unbounded_send(Ok(command())).unwrap();
+
+    let replacement_message = timeout(Duration::from_secs(1), new_subscription.recv())
+        .await
+        .expect("replacement should receive promptly")
+        .expect("replacement should remain open");
+    let replacement_message: Value =
+        serde_json::from_str(replacement_message.get()).expect("message should be JSON");
+    assert_eq!(
+        replacement_message["params"]["result"]["message"]["method"],
+        "command"
+    );
+
+    let old_closed = timeout(Duration::from_secs(1), old_subscription.recv())
+        .await
+        .expect("old subscription should close promptly");
+    assert!(old_closed.is_none());
+    drop(old_connection);
+}
+
+#[tokio::test]
+async fn accept_skips_a_superseded_queued_connection() {
+    let transport = ServerTransport::new();
+    let module = transport.rpc_module().expect("RPC module should build");
+    let (_, mut old_subscription) = module
+        .raw_json_request(
+            r#"{"jsonrpc":"2.0","method":"subscribe","params":{"connectionId":"connection-1"},"id":1}"#,
+            1,
+        )
+        .await
+        .expect("first subscription should open");
+    let (_, mut new_subscription) = module
+        .raw_json_request(
+            r#"{"jsonrpc":"2.0","method":"subscribe","params":{"connectionId":"connection-1"},"id":2}"#,
+            2,
+        )
+        .await
+        .expect("replacement subscription should open");
+
+    let old_closed = timeout(Duration::from_secs(1), old_subscription.recv())
+        .await
+        .expect("superseded subscription should close promptly");
+    assert!(old_closed.is_none());
+
+    let accepted = timeout(Duration::from_secs(1), transport.accept())
+        .await
+        .expect("accept should not hang")
+        .expect("active replacement should be accepted");
+    let active = accepted.into_channel();
+    active
+        .tx
+        .unbounded_send(Ok(command()))
+        .expect("accepted connection should still own the active route");
+
+    let replacement_message = timeout(Duration::from_secs(1), new_subscription.recv())
+        .await
+        .expect("replacement should receive promptly")
+        .expect("replacement should remain open");
+    let replacement_message: Value = serde_json::from_str(replacement_message.get()).unwrap();
+    assert_eq!(
+        replacement_message["params"]["result"]["message"]["method"],
+        "command"
+    );
+}
+
+#[tokio::test]
+async fn send_rejects_an_unknown_connection() {
+    let transport = ServerTransport::new();
+    let module = transport.rpc_module().expect("RPC module should build");
+    let request = serde_json::to_string(&json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "send",
+        "params": RuntimeMessage::new("missing", event()),
+    }))
+    .unwrap();
+
+    let (response, _) = module
+        .raw_json_request(&request, 1)
+        .await
+        .expect("request should produce a JSON-RPC error");
+    let response: Value = serde_json::from_str(response.get()).unwrap();
+    assert_eq!(response["error"]["code"], -32_004);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn runtime_initiates_a_real_websocket_and_exchanges_logical_messages() {
+    let transport = ServerTransport::new();
+    let module = transport.rpc_module().expect("RPC module should build");
+    let server = Server::builder()
+        .build("127.0.0.1:0")
+        .await
+        .expect("server should bind");
+    let address = server.local_addr().expect("server address");
+    let handle = server.start(module);
+    let client = Arc::new(
+        WsClientBuilder::default()
+            .build(format!("ws://{address}"))
+            .await
+            .expect("runtime should connect"),
+    );
+
+    let mut runtime = connect_runtime(Arc::clone(&client), "connection-1")
+        .await
+        .expect("runtime should subscribe");
+    let mut server = timeout(Duration::from_secs(1), transport.accept())
+        .await
+        .expect("server accept should not hang")
+        .expect("server should accept runtime")
+        .into_channel();
+
+    runtime.tx.unbounded_send(Ok(event())).unwrap();
+    let delivered = timeout(Duration::from_secs(1), server.rx.next())
+        .await
+        .expect("runtime-to-server should not hang")
+        .expect("server logical channel should remain open")
+        .expect("event should be valid");
+    assert_eq!(
+        serde_json::to_value(delivered).unwrap()["method"],
+        "system_event"
+    );
+
+    server.tx.unbounded_send(Ok(command())).unwrap();
+    let delivered = timeout(Duration::from_secs(1), runtime.rx.next())
+        .await
+        .expect("server-to-runtime should not hang")
+        .expect("runtime logical channel should remain open")
+        .expect("command should be valid");
+    assert_eq!(
+        serde_json::to_value(delivered).unwrap()["method"],
+        "command"
+    );
+
+    handle.stop().expect("server should stop");
+    handle.stopped().await;
+}
+
+struct Commands;
+
+impl CommandHandler for Commands {
+    async fn handle(
+        &self,
+        command: Command,
+    ) -> Result<CommandResult, agent_client_protocol::Error> {
+        Ok(CommandResult::completed_with(json!({
+            "commandId": command.command_id,
+        })))
+    }
+}
+
+struct Events(tokio::sync::mpsc::UnboundedSender<SystemEvent>);
+
+impl SystemEventHandler for Events {
+    async fn handle(&self, event: SystemEvent) -> Result<(), agent_client_protocol::Error> {
+        self.0
+            .send(event)
+            .expect("event receiver should remain open");
+        Ok(())
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn role_connections_run_over_a_runtime_initiated_websocket() {
+    let transport = ServerTransport::new();
+    let server = Server::builder()
+        .build("127.0.0.1:0")
+        .await
+        .expect("server should bind");
+    let address = server.local_addr().unwrap();
+    let handle = server.start(transport.rpc_module().unwrap());
+    let client = Arc::new(
+        WsClientBuilder::default()
+            .build(format!("ws://{address}"))
+            .await
+            .expect("runtime should connect"),
+    );
+    let runtime_channel = connect_runtime(client, "connection-1").await.unwrap();
+    let server_channel = transport.accept().await.unwrap().into_channel();
+    let (event_sender, mut event_receiver) = tokio::sync::mpsc::unbounded_channel();
+    let server_connection = ServerConnection::connect(server_channel, Events(event_sender));
+    let runtime_connection = RuntimeConnection::connect(runtime_channel, Commands);
+
+    runtime_connection
+        .system_event(SystemEvent::new(
+            "event-1",
+            1,
+            SystemEventName::Unknown("runtime/ready".to_owned()),
+            "2026-07-17T00:00:00Z",
+        ))
+        .unwrap();
+    let received = timeout(Duration::from_secs(1), event_receiver.recv())
+        .await
+        .expect("event should not hang")
+        .expect("event channel should remain open");
+    assert_eq!(received.event_id, "event-1");
+
+    let result = timeout(
+        Duration::from_secs(1),
+        server_connection.command(Command::new(
+            "command-1",
+            CommandName::Unknown("runtime/configure".to_owned()),
+        )),
+    )
+    .await
+    .expect("command should not hang")
+    .expect("command should succeed");
+    assert_eq!(
+        result,
+        CommandResult::completed_with(json!({ "commandId": "command-1" }))
+    );
+
+    handle.stop().unwrap();
+    handle.stopped().await;
+}

--- a/crates/agent_runtime_protocol/src/transport/mod.rs
+++ b/crates/agent_runtime_protocol/src/transport/mod.rs
@@ -1,0 +1,4 @@
+//! Physical transport bindings.
+
+/// jsonrpsee WebSocket carrier for logical protocol messages.
+pub mod jsonrpsee;

--- a/services/document_text_extractor/src/model/mod.rs
+++ b/services/document_text_extractor/src/model/mod.rs
@@ -6,6 +6,6 @@ pub mod key;
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum IncomingEvent {
-    EventBridgeEvent(EventBridgeEvent),
+    EventBridgeEvent(Box<EventBridgeEvent>),
     SqsEvent(SqsEvent),
 }


### PR DESCRIPTION
Removes the DEV_MODE_ENV gate so Slack shows in the MCP connectors list in production, using the existing pre-registered (non-DCR) OAuth backend and Slack icon.