### PR TITLE
fix(automations): disable duplicate action for automation entities

### DIFF
--- a/apps/web/src/features/next-soup/actions/make-copy-action.ts
+++ b/apps/web/src/features/next-soup/actions/make-copy-action.ts
@@ -12,7 +12,8 @@ export const makeCopyAction = () => {
       entity.type !== 'email' &&
       entity.type !== 'channel_message' &&
       entity.type !== 'channel_thread' &&
-      entity.type !== 'foreign'
+      entity.type !== 'foreign' &&
+      entity.type !== 'automation'
     );
   };
 


### PR DESCRIPTION
## Summary
- Clicking "Duplicate" on an automation currently throws `Error: Unsupported entity type provided` because the backend has no duplicate/copy support for automations.
- Excludes `'automation'` from the shared `canExecute` gate in `makeCopyAction()`, which is the single source of truth consumed by the soup context-menu "Duplicate" item, the duplicate hotkey, and the command-palette duplicate command.
- This is a stopgap per the bug report — the button is hidden until backend duplicate support for automations exists. No backend changes needed/made.

MACRO-2510

## Why this was prioritized
Reported in `bug-reports` as a reproducible error with an explicit ask to "disable button until fixed" — a small, contained frontend-only fix with no behavior change for any other entity type (documents, chats, tasks, projects duplicate unaffected).

## Test plan
- [ ] Open an automation in the soup/list view, confirm "Duplicate" no longer appears in the right-click/`...` menu
- [ ] Confirm the duplicate hotkey (Cmd/Ctrl+D style) no-ops for a selected automation
- [ ] Confirm "Duplicate" no longer appears in the command palette when an automation is focused/selected
- [ ] Confirm Duplicate still works normally for documents and chats


---
_Generated by [Claude Code](https://claude.ai/code/session_01QLjY9kgUuRf7HCArWpm9Ny)_