### PR TITLE
style(block-md): lighten blank markdown placeholder text

### DIFF
--- a/apps/web/src/features/block-md/component/MarkdownEditor.tsx
+++ b/apps/web/src/features/block-md/component/MarkdownEditor.tsx
@@ -1027,7 +1027,7 @@ export function MarkdownEditor(props: {
           </div>
         </Show>
         <Show when={editorReady() && isBlankMarkdown()}>
-          <div class="pointer-events-none text-ink-placeholder/70 absolute top-0">
+          <div class="pointer-events-none text-ink-placeholder/85 absolute top-0">
             {getBlankMarkdownPlaceholder(canEdit())}
           </div>
         </Show>

--- a/apps/web/src/features/block-md/component/MarkdownEditor.tsx
+++ b/apps/web/src/features/block-md/component/MarkdownEditor.tsx
@@ -1027,7 +1027,7 @@ export function MarkdownEditor(props: {
           </div>
         </Show>
         <Show when={editorReady() && isBlankMarkdown()}>
-          <div class="pointer-events-none text-ink-placeholder/85 absolute top-0">
+          <div class="pointer-events-none text-ink-placeholder/90 absolute top-0">
             {getBlankMarkdownPlaceholder(canEdit())}
           </div>
         </Show>

--- a/apps/web/src/features/block-md/component/MarkdownEditor.tsx
+++ b/apps/web/src/features/block-md/component/MarkdownEditor.tsx
@@ -1027,7 +1027,7 @@ export function MarkdownEditor(props: {
           </div>
         </Show>
         <Show when={editorReady() && isBlankMarkdown()}>
-          <div class="pointer-events-none text-ink-placeholder absolute top-0">
+          <div class="pointer-events-none text-ink-placeholder/70 absolute top-0">
             {getBlankMarkdownPlaceholder(canEdit())}
           </div>
         </Show>


### PR DESCRIPTION
## Summary

Slightly lightens the blank markdown editor placeholder ("Press '/' for commands, '@' to reference files, ';' for snippets...") so it reads as a softer hint.

## Changes

- Apply a `/70` opacity modifier to the placeholder's `text-ink-placeholder` color in `MarkdownEditor.tsx`.
