### PR TITLE
refactor(email): remove Details panel from thread side panel

### DIFF
--- a/apps/web/src/features/block-email/component/sidepanel/EmailSidePanelSections.tsx
+++ b/apps/web/src/features/block-email/component/sidepanel/EmailSidePanelSections.tsx
@@ -4,7 +4,6 @@ import {
 } from '@app/features/property/side-panel/properties';
 import { SidePanel } from '@components/app/side-panel';
 import { References } from '@core/component/References';
-import type { Property } from '@property/types';
 import { useAttachmentReferencesQuery } from '@queries/storage/attachment-references';
 import type { ItemType } from '@service-storage/client';
 import { Show, Suspense } from 'solid-js';
@@ -21,21 +20,6 @@ export function EmailSidePanelSections(props: EmailSidePanelSectionsProps) {
 
   return (
     <>
-      <SidePanel.Section id="details" title="Details" defaultOpen order={10}>
-        <Suspense fallback={<SidePanel.Loading />}>
-          <EntityPropertiesSection
-            entityId={props.threadId}
-            entityType="THREAD"
-            canEdit={canEdit()}
-            documentName={props.title}
-            includeMetadata
-            propertyFilter={(property) => property.isMetadata === true}
-            getEmptyLabel={getEmailMetadataEmptyLabel}
-            showAddProperty={false}
-            showTags={false}
-          />
-        </Suspense>
-      </SidePanel.Section>
       <EntityTagsSection
         entityId={props.threadId}
         entityType="THREAD"
@@ -95,21 +79,4 @@ function ReferencesSectionConditional(props: { threadId: string }) {
       </SidePanel.Section>
     </Show>
   );
-}
-
-function getEmailMetadataEmptyLabel(property: Property) {
-  if (!property.isMetadata) return undefined;
-
-  switch (property.displayName) {
-    case 'Last Sent':
-      return 'No sent messages';
-    case 'Last Received':
-      return 'No received messages';
-    case 'Thread Started':
-      return 'No messages';
-    case 'Subject':
-      return 'No subject';
-    default:
-      return undefined;
-  }
 }


### PR DESCRIPTION
## Summary

Removes the **Details** panel from the email thread view's side panel. This section displayed thread-level metadata — Last Sent, Last Received, Thread Started, and Subject — as read-only metadata properties.

## Changes

- Delete the `id="details"` `SidePanel.Section` from `EmailSidePanelSections`, which rendered an `EntityPropertiesSection` filtered to metadata-only properties.
- Remove the now-unused `getEmailMetadataEmptyLabel` helper that supplied empty-state copy for those metadata fields.
- Drop the now-unused `Property` type import.

The remaining side-panel sections (Tags, Properties, References) and the Actions section are untouched.
