### PR TITLE
fix(quick-access): not able to get item from quick access because of pagination

### DIFF
--- a/apps/web/src/lib/core/context/quickAccess/GraphqlQuickAccessSource.tsx
+++ b/apps/web/src/lib/core/context/quickAccess/GraphqlQuickAccessSource.tsx
@@ -51,7 +51,6 @@ import type {
 } from './types';
 
 const QUICK_ACCESS_LIMIT = 500;
-const DEFAULT_SEARCH_PAGE_SIZE = 50;
 const CACHE_REFRESH_DEBOUNCE_MS = 250;
 const NIL_UUID = '00000000-0000-0000-0000-000000000000';
 
@@ -279,7 +278,6 @@ export function createGraphqlQuickAccessValue(): QuickAccessContextValue {
         buckets,
         searchTerm: activeSearchTerm,
         enabled: listEnabled,
-        pageSize: DEFAULT_SEARCH_PAGE_SIZE,
         selectedItems,
         localItems,
         instructionsId: () => instructionsIdQuery.data ?? undefined,

--- a/apps/web/src/lib/core/context/quickAccess/record-selection-list.test.ts
+++ b/apps/web/src/lib/core/context/quickAccess/record-selection-list.test.ts
@@ -44,7 +44,7 @@ function runInRoot(run: () => Promise<void>): Promise<void> {
 }
 
 describe('createRecordSelectionQuickAccessItems', () => {
-  it('filters, sorts, searches, counts, and paginates locally', async () => {
+  it('filters, sorts, searches, and counts locally', async () => {
     await runInRoot(async () => {
       const [searchTerm, setSearchTerm] = createSignal('');
       const selected = [
@@ -73,7 +73,6 @@ describe('createRecordSelectionQuickAccessItems', () => {
         buckets: [],
         searchTerm,
         enabled: () => true,
-        pageSize: 2,
         selectedItems: () => selected,
         localItems: () => local,
         instructionsId: () => undefined,
@@ -82,9 +81,14 @@ describe('createRecordSelectionQuickAccessItems', () => {
         onItems: () => undefined,
       });
 
-      expect(list.items().map((item) => item.id)).toEqual(['b', 'a']);
+      expect(list.items().map((item) => item.id)).toEqual([
+        'b',
+        'a',
+        'c',
+        'person',
+      ]);
       expect(list.totalCount()).toBe(4);
-      expect(list.hasMore()).toBe(true);
+      expect(list.hasMore()).toBe(false);
       await list.loadMore();
       expect(list.items().map((item) => item.id)).toEqual([
         'b',
@@ -92,7 +96,6 @@ describe('createRecordSelectionQuickAccessItems', () => {
         'c',
         'person',
       ]);
-      expect(list.hasMore()).toBe(false);
 
       setSearchTerm('charlie');
       await Promise.resolve();
@@ -102,13 +105,12 @@ describe('createRecordSelectionQuickAccessItems', () => {
     });
   });
 
-  it('applies bucket filtering before counts and visible slicing', async () => {
+  it('applies bucket filtering before counting items', async () => {
     await runInRoot(async () => {
       const list = createRecordSelectionQuickAccessItems({
         buckets: ['document'],
         searchTerm: () => '',
         enabled: () => true,
-        pageSize: 1,
         selectedItems: () => [
           entity('doc-a', 'document', 'A', 1),
           entity('email-a', 'email', 'Email', 2),
@@ -121,9 +123,9 @@ describe('createRecordSelectionQuickAccessItems', () => {
         onItems: () => undefined,
       });
 
-      expect(list.items().map((item) => item.id)).toEqual(['doc-b']);
+      expect(list.items().map((item) => item.id)).toEqual(['doc-b', 'doc-a']);
       expect(list.totalCount()).toBe(2);
-      expect(list.hasMore()).toBe(true);
+      expect(list.hasMore()).toBe(false);
       await list.loadMore();
       expect(list.items().map((item) => item.id)).toEqual(['doc-b', 'doc-a']);
     });

--- a/apps/web/src/lib/core/context/quickAccess/record-selection-list.ts
+++ b/apps/web/src/lib/core/context/quickAccess/record-selection-list.ts
@@ -1,9 +1,4 @@
-import {
-  type Accessor,
-  createComputed,
-  createMemo,
-  createSignal,
-} from 'solid-js';
+import { type Accessor, createMemo } from 'solid-js';
 import { searchQuickAccessEntities } from './entity-search';
 import type {
   Bucket,
@@ -61,14 +56,6 @@ export function createRecordSelectionQuickAccessItems(options: {
         (bucket !== 'crm_company' || options.crmEnabled())
     )
   );
-  const [visibleLimit, setVisibleLimit] = createSignal(options.pageSize);
-
-  createComputed(() => {
-    options.searchTerm();
-    options.enabled();
-    entityBuckets();
-    setVisibleLimit(options.pageSize);
-  });
 
   const allItems = createMemo<QuickAccessItem[]>(() => {
     if (!options.enabled()) return [];
@@ -115,18 +102,18 @@ export function createRecordSelectionQuickAccessItems(options: {
     return result;
   });
 
-  const items = createMemo(() => allItems().slice(0, visibleLimit()));
-  const hasMore = createMemo(() => visibleLimit() < allItems().length);
+  const items = createMemo(() => allItems());
+
+  // No more items since we show all
+  const hasMore = createMemo(() => false);
 
   return {
     items,
     totalCount: () => allItems().length,
     hasMore,
     isLoadingMore: () => false,
-    loadMore: async () => {
-      setVisibleLimit((limit) =>
-        Math.min(limit + options.pageSize, allItems().length)
-      );
+    loadMore: () => {
+      // Noop since we load all the items anyway, leaving for later
     },
     entityBuckets,
   };

--- a/apps/web/src/lib/core/context/quickAccess/record-selection-list.ts
+++ b/apps/web/src/lib/core/context/quickAccess/record-selection-list.ts
@@ -35,12 +35,11 @@ function addItem(
   }
 }
 
-/** Creates a locally filtered and paginated Quick Access record list. */
+/** Creates a locally filtered Quick Access record list. */
 export function createRecordSelectionQuickAccessItems(options: {
   buckets: Bucket[];
   searchTerm: Accessor<string>;
   enabled: Accessor<boolean>;
-  pageSize: number;
   selectedItems: Accessor<EntityItem[]>;
   localItems: Accessor<QuickAccessItem[]>;
   instructionsId: Accessor<string | undefined>;
@@ -102,19 +101,12 @@ export function createRecordSelectionQuickAccessItems(options: {
     return result;
   });
 
-  const items = createMemo(() => allItems());
-
-  // No more items since we show all
-  const hasMore = createMemo(() => false);
-
   return {
-    items,
+    items: allItems,
     totalCount: () => allItems().length,
-    hasMore,
+    hasMore: () => false,
     isLoadingMore: () => false,
-    loadMore: () => {
-      // Noop since we load all the items anyway, leaving for later
-    },
+    loadMore: async () => undefined,
     entityBuckets,
   };
 }


### PR DESCRIPTION
Since we are already loading all the items from the cache, we don't actually need this fake pagination as it causes issues for places that expect to get data from quick-access but aren't able to like for the property dropdown that was trying to get contacts from quick access