### PR TITLE
fix(mcp): send progress heartbeats during long tool calls

### DIFF
--- a/services/mcp_service/src/tool_service.rs
+++ b/services/mcp_service/src/tool_service.rs
@@ -3,10 +3,39 @@ use macro_user_id::user_id::MacroUserIdStr;
 use rmcp::{
     handler::server::ServerHandler,
     model::{
-        Content, ListToolsResult, PaginatedRequestParams, ServerCapabilities, ServerInfo, Tool,
+        Content, ListToolsResult, PaginatedRequestParams, ProgressNotificationParam,
+        RequestParamsMeta, ServerCapabilities, ServerInfo, Tool,
     },
 };
+use std::future::Future;
 use std::sync::Arc;
+use tokio::time::Duration;
+
+/// How often to notify the MCP client of progress while a tool call is in
+/// flight, when the client asked for progress updates (via a `progressToken`
+/// on the request). `EditDocument` in particular can chain several LLM calls
+/// and take multiple minutes; without periodic progress notifications, MCP
+/// clients apply their own request timeout and give up on an otherwise
+/// still-running, eventually-successful call.
+const PROGRESS_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(10);
+
+/// Runs `future` to completion, calling `on_tick` every
+/// [`PROGRESS_HEARTBEAT_INTERVAL`] while it is still pending.
+async fn with_heartbeat<F, Fut>(mut on_tick: impl FnMut() -> Fut, future: F) -> F::Output
+where
+    F: Future,
+    Fut: Future<Output = ()>,
+{
+    tokio::pin!(future);
+    let mut interval = tokio::time::interval(PROGRESS_HEARTBEAT_INTERVAL);
+    interval.tick().await; // first tick fires immediately; skip it
+    loop {
+        tokio::select! {
+            output = &mut future => return output,
+            _ = interval.tick() => on_tick().await,
+        }
+    }
+}
 
 /// MCP server handler that extracts authenticated user identity from HTTP
 /// request parts injected by rmcp's `StreamableHttpService`.
@@ -114,29 +143,54 @@ where
         let user_id = Self::authenticated_user_id(&context.extensions)?;
 
         let request_context = RequestContext::new(user_id);
+        let progress_token = request.progress_token();
 
         let arguments = request
             .arguments
             .map(serde_json::Value::Object)
             .ok_or(rmcp::ErrorData::invalid_params("No params provided", None))?;
 
-        let result = self
-            .toolset
-            .try_tool_call(
-                self.context.clone(),
-                request_context,
-                &request.name,
-                &arguments,
-            )
-            .await
-            .map_err(|error| match error {
-                ai_toolset::ToolSetError::Deserialization(error) => {
-                    rmcp::ErrorData::parse_error(error.to_string(), None)
-                }
-                ai_toolset::ToolSetError::NotFound(message) => {
-                    rmcp::ErrorData::resource_not_found(message, None)
-                }
-            })?;
+        let tool_call = self.toolset.try_tool_call(
+            self.context.clone(),
+            request_context,
+            &request.name,
+            &arguments,
+        );
+
+        let result = match progress_token {
+            Some(progress_token) => {
+                let peer = context.peer.clone();
+                let mut progress = 0.0;
+                with_heartbeat(
+                    || {
+                        progress += 1.0;
+                        let peer = peer.clone();
+                        let notification =
+                            ProgressNotificationParam::new(progress_token.clone(), progress);
+                        async move {
+                            if let Err(error) = peer.notify_progress(notification).await {
+                                tracing::warn!(
+                                    error = ?error,
+                                    "failed to send MCP progress notification"
+                                );
+                            }
+                        }
+                    },
+                    tool_call,
+                )
+                .await
+            }
+            None => tool_call.await,
+        };
+
+        let result = result.map_err(|error| match error {
+            ai_toolset::ToolSetError::Deserialization(error) => {
+                rmcp::ErrorData::parse_error(error.to_string(), None)
+            }
+            ai_toolset::ToolSetError::NotFound(message) => {
+                rmcp::ErrorData::resource_not_found(message, None)
+            }
+        })?;
 
         match result {
             Ok(value) => Ok(rmcp::model::CallToolResult::structured(value)),

--- a/services/mcp_service/src/tool_service/test.rs
+++ b/services/mcp_service/src/tool_service/test.rs
@@ -1,6 +1,7 @@
 use super::*;
 use ai_toolset::AsyncToolCollection;
 use rmcp::{handler::server::ServerHandler, model::ErrorCode};
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 fn empty_service() -> AuthenticatedToolService<()> {
     AuthenticatedToolService::new(
@@ -83,6 +84,41 @@ async fn server_instructions_link_items_as_urls_not_mention_tags() {
 #[tokio::test]
 async fn empty_toolset_lists_no_tools() {
     assert!(empty_service().tool_definitions().is_empty());
+}
+
+#[tokio::test(start_paused = true)]
+async fn with_heartbeat_ticks_periodically_until_the_future_resolves() {
+    let ticks = Arc::new(AtomicUsize::new(0));
+    let ticks_for_callback = ticks.clone();
+
+    let output = with_heartbeat(
+        move || {
+            ticks_for_callback.fetch_add(1, Ordering::SeqCst);
+            async {}
+        },
+        tokio::time::sleep(PROGRESS_HEARTBEAT_INTERVAL * 3 + Duration::from_secs(5)),
+    )
+    .await;
+
+    assert_eq!(output, ());
+    assert_eq!(ticks.load(Ordering::SeqCst), 3);
+}
+
+#[tokio::test(start_paused = true)]
+async fn with_heartbeat_never_ticks_for_a_future_that_resolves_before_the_first_interval() {
+    let ticks = Arc::new(AtomicUsize::new(0));
+    let ticks_for_callback = ticks.clone();
+
+    with_heartbeat(
+        move || {
+            ticks_for_callback.fetch_add(1, Ordering::SeqCst);
+            async {}
+        },
+        tokio::time::sleep(PROGRESS_HEARTBEAT_INTERVAL / 2),
+    )
+    .await;
+
+    assert_eq!(ticks.load(Ordering::SeqCst), 0);
 }
 
 #[test]


### PR DESCRIPTION
Send periodic MCP progress notifications while a tool call (e.g. EditDocument) is in flight so long-running calls don't trip the calling client's own request timeout; addresses task 2509.