### PR TITLE
fix(dynamic-ui): render emails correctly in AI list widgets

### DIFF
--- a/apps/web/src/features/dynamic-ui/widgets/List.tsx
+++ b/apps/web/src/features/dynamic-ui/widgets/List.tsx
@@ -5,6 +5,7 @@ import {
   queryStateFrom,
 } from '@app/features/next-soup/filters/filter-store';
 import type { FieldFilters } from '@app/features/next-soup/filters/filter-store/types';
+import { openEntityInSplitFromUnifiedList } from '@app/features/next-soup/utils';
 import { ListEntityMetadataQueryProvider } from '@entity';
 import { CollapsibleList } from '@entity/components/CollapsibleList';
 import { ListEntity, ListLayoutProvider } from '@entity/composed/ListEntity';
@@ -50,12 +51,22 @@ type IdFieldName = {
     : never;
 }[keyof FieldFilters];
 
-/** Map a schema `EntityRef.type` onto the soup `FieldFilters` id field. */
+/**
+ * Map a schema `EntityRef.type` onto the soup `FieldFilters` id field.
+ *
+ * Both `email` and `email_thread` are mapped here: `EntityData`/`ListEntities`
+ * tag emails as `'email'` everywhere else in the app (see
+ * `@entity/types/entity`'s `EmailEntity`), so that's what the AI actually
+ * echoes back from prior tool results into a `list` widget's refs, but
+ * `email_thread` is also a legal `EntityType` value (see `@core/types`) —
+ * keep both so neither spelling gets silently dropped.
+ */
 const ID_FIELD_BY_TYPE: Partial<Record<EntityRef['type'], IdFieldName>> = {
   document: 'documentId',
   chat: 'chatId',
   channel: 'channelId',
   project: 'folderId',
+  email: 'threadId',
   email_thread: 'threadId',
   call: 'callId',
   foreign_entity: 'foreignEntityRecordId',
@@ -98,12 +109,19 @@ const GROUP_BY_BY_NAME: Record<
  * so it must sit in a flush container, NOT a bordered/`divide-y` card, or the
  * pill ends up boxed in by per-row dividers. `hideCheckbox` drops the
  * multi-select checkbox (read-only embed), leaving just the icon / unread dot.
+ *
+ * Clicking opens the entity in a split, exactly like the real unified list
+ * (`soup-view.tsx`) and the other standalone `ListEntity` embeds (e.g.
+ * `ContactEmailsSection`) — via `openEntityInSplitFromUnifiedList`, which
+ * dispatches per `entity.type` and works for every type here already,
+ * `email` included.
  */
 function Row(props: { entity: EntityData }) {
   return (
     <ListEntity
       entity={props.entity as WithNotification<EntityData>}
       hideCheckbox
+      onClick={() => openEntityInSplitFromUnifiedList(props.entity, {})}
     />
   );
 }


### PR DESCRIPTION
Fixes the dynamic-UI `list` widget to map the `email` entity type to its soup id filter (previously only `email_thread` was mapped, so AI-rendered email list items were silently dropped) and wires up click-to-open on list rows for all entity types, including email (task 2542).