### PR TITLE
fix(soup): ListEntities prompt is out of date

### DIFF
--- a/apps/web/src/lib/service-clients/service-cognition/generated/tools/types.ts
+++ b/apps/web/src/lib/service-clients/service-cognition/generated/tools/types.ts
@@ -1884,7 +1884,7 @@ export interface ListEntities {
     [k: string]: unknown;
   };
   /**
-   * Advanced full soup AST email filter (ef). Prefer emailPreset="signal" for common requests. Signal emails and important emails are synonymous; they use {"&":[{"l":{"Importance":true}},{"l":{"Shared":"exclude"}}]}.
+   * Advanced full soup AST email filter (ef). Prefer emailPreset="signal" for common requests. Signal emails and important emails are synonymous; they use {"&":[{"l":{"Importance":true}},{"l":{"Shared":"exclude"}}]}. Supports filtering by thread timestamp: {"l":{"ca":{"gte":"<start>"}}} matches created_at, {"l":{"ua":{"gte":"<start>","lt":"<end>"}}} matches updated_at, using ISO timestamps with gt/lt/gte/lte comparators. For "emails from the last 7 days", AND a ua (or ca) gte bound set to 7 days before now, e.g. {"l":{"ua":{"gte":"<7-days-ago-ISO>"}}}.
    */
   ef?: {
     [k: string]: unknown;

--- a/crates/soup/src/inbound/toolset/list_entities.rs
+++ b/crates/soup/src/inbound/toolset/list_entities.rs
@@ -389,7 +389,7 @@ pub struct ListEntities {
 
     /// Email entity AST filter.
     #[schemars(
-        description = "Advanced full soup AST email filter (ef). Prefer emailPreset=\"signal\" for common requests. Signal emails and important emails are synonymous; they use {\"&\":[{\"l\":{\"Importance\":true}},{\"l\":{\"Shared\":\"exclude\"}}]}.",
+        description = "Advanced full soup AST email filter (ef). Prefer emailPreset=\"signal\" for common requests. Signal emails and important emails are synonymous; they use {\"&\":[{\"l\":{\"Importance\":true}},{\"l\":{\"Shared\":\"exclude\"}}]}. Supports filtering by thread timestamp: {\"l\":{\"ca\":{\"gte\":\"<start>\"}}} matches created_at, {\"l\":{\"ua\":{\"gte\":\"<start>\",\"lt\":\"<end>\"}}} matches updated_at, using ISO timestamps with gt/lt/gte/lte comparators. For \"emails from the last 7 days\", AND a ua (or ca) gte bound set to 7 days before now, e.g. {\"l\":{\"ua\":{\"gte\":\"<7-days-ago-ISO>\"}}}.",
         with = "Option<serde_json::Value>"
     )]
     #[serde(default, rename = "ef")]

--- a/crates/soup/src/inbound/toolset/test.rs
+++ b/crates/soup/src/inbound/toolset/test.rs
@@ -185,6 +185,40 @@ fn test_include_types_foreign_entity_without_filter_keeps_foreign_entity_unfilte
 }
 
 #[test]
+fn test_list_entities_schema_documents_email_time_range_filtering() {
+    let validated = generate_validated_input_schema::<ListEntities>().unwrap();
+    let schema_json = serde_json::to_string(&validated.schema).unwrap();
+
+    assert!(
+        schema_json.contains("\\\"ua\\\""),
+        "schema should document the ua (updated_at) email filter key"
+    );
+    assert!(
+        schema_json.contains("last 7 days"),
+        "schema should give a worked example for filtering emails by a recent time window (macro-2543)"
+    );
+}
+
+#[test]
+fn test_email_updated_at_range_filter_deserializes() {
+    let input = serde_json::json!({
+        "includeTypes": ["email"],
+        "ef": {
+            "&": [
+                { "l": { "ua": { "gte": "2026-07-15T00:00:00Z" } } },
+                { "l": { "ua": { "lt": "2026-07-22T00:00:00Z" } } }
+            ]
+        }
+    });
+
+    let list: ListEntities = serde_json::from_value(input).unwrap();
+    let ast = list.entity_filter_ast(None);
+
+    assert_eq!(list.effective_include_types(), Some(vec![ItemType::Email]));
+    assert!(ast.email_filter.tree.is_some());
+}
+
+#[test]
 fn test_build_summary_empty() {
     let summary = build_summary(&[], false, &None);
     assert_eq!(summary, "No items found in workspace.");


### PR DESCRIPTION
ListEntities already supports filtering emails by created_at/updated_at (ca/ua) end-to-end in email_pg_repo, but the tool's ef schema description never documented it, so the AI had no way to know how to filter emails by a recent time window; documents ca/ua usage with a worked "last 7 days" example. Fixes MACRO-2543.