### PR TITLE
fix(soup): don't bypass inbox done filter on message send

### DIFF
--- a/apps/web/src/lib/queries/channel/message.ts
+++ b/apps/web/src/lib/queries/channel/message.ts
@@ -3,10 +3,7 @@ import type { OptimisticPostMessageAttachment } from '@channel/Input/message-pay
 import { toast } from '@core/component/Toast/Toast';
 import type { DateValue } from '@core/util/date';
 import { throwOnErr } from '@core/util/result';
-import {
-  invalidateSoupEntity,
-  refetchSoupEntity,
-} from '@queries/soup/normalized-cache';
+import { invalidateSoupEntity } from '@queries/soup/normalized-cache';
 import { type MutationCallbacks, withCallbacks } from '@queries/utils';
 import {
   type ApiChannelMessage,
@@ -470,10 +467,12 @@ export function useSendMessageMutation(
           });
 
           // The sender does not receive the notification that normally refreshes
-          // this soup entity. Refresh root messages here so the channel moves to
-          // its updated position in soup lists.
+          // this soup entity. Invalidate (rather than optimistically merging a
+          // fresh fetch) so the channel's position updates via each view's own
+          // query, which re-applies server-side filters like the inbox done
+          // gate — a direct merge would bypass that gate and leak the channel
+          // into done-filtered inbox queries it doesn't belong in.
           if (threadId === undefined) {
-            refetchSoupEntity(variables.channelID, 'channel');
             invalidateSoupEntity(variables.channelID);
           }
 


### PR DESCRIPTION
## Summary

- Fixes: sending a message in a channel that's already sitting in your inbox bumps it back to the top, even if it was already read/done.
- Root cause: `useSendMessageMutation`'s `onSuccess` compensates for the sender never receiving the notification that would normally reposition the channel, by fetching the channel and merging it into the cache via `refetchSoupEntity` → `optimisticUpdateSoupEntity`. That merge writes through *every* query that references the entity via the normalizer, including done-filtered inbox queries — bypassing the done/notification gate those queries are supposed to enforce server-side.
- Fix: drop the direct merge and just invalidate the entity (already happening alongside the merge). Each view's own query re-applies its own server-side filters (including the inbox done gate) on refetch, so non-done-filtered lists (e.g. the plain channel list) still update promptly, while done-filtered ones don't get the leaked/misordered row.

MACRO-2517

## Why prioritized

Filed as [bug: sending a message bumps channel to top of inbox](https://macro.com/app/task/019f8145-35f4-7c64-a1c2-8e23cae340be) with a root-cause diagnosis already attached (pointing at this exact call site and the two fix options); this PR implements the "invalidate instead of merge" option since it's the smaller, more surgical change and doesn't touch the shared normalized-cache merge path used broadly elsewhere.

## Test plan

- [ ] Reviewer: send a message in a channel that's currently read/done and sitting lower in your inbox — it should no longer jump to the top.
- [ ] Confirm the channel's non-inbox soup views (e.g. the regular channel list, if open) still pick up the new last-message preview/position promptly after sending.
- [ ] `cargo`/rust services untouched — this is a frontend-only (`apps/web`) change.

I couldn't run the dev server in this sandbox (git-dependency fetches for `tauri-plugins`/`pdf.js` are blocked here), so this is unverified against a live Inbox — flagging that explicitly for reviewers.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HwL2qpNQRoQP9iKn5Py4Qc)_