### PR TITLE
feat(inbox): mark done by hovering a row's leading icon

### DIFF
--- a/apps/web/src/features/entity/composed/list-entity/shared.tsx
+++ b/apps/web/src/features/entity/composed/list-entity/shared.tsx
@@ -39,6 +39,10 @@ export interface BaseListEntityProps<E extends EntityData = EntityData> {
     location?: SearchLocation
   ) => void;
   entityRowConfig?: EntityRowConfig;
+  /** Whether the row's mark-done affordance (e.g. hover-to-check the leading icon) should be shown for this entity. */
+  canMarkDone?: (entity: WithNotification<E>) => boolean;
+  /** Marks the row done, e.g. when the leading icon's hover checkmark is clicked. */
+  onMarkDone?: (entity: WithNotification<E>) => void;
 }
 
 const WIDE_BREAKPOINT = 512; // @lg container query = 32rem

--- a/apps/web/src/features/next-soup/soup-view/soup-view.tsx
+++ b/apps/web/src/features/next-soup/soup-view/soup-view.tsx
@@ -1608,6 +1608,27 @@ const SoupViewListContent = (props: SoupViewListProps) => {
                                               <CheckIcon class="size-8 text-panel" />
                                             ),
                                           }}
+                                          canMarkDone={(entity) => {
+                                            const tab = activeTab();
+                                            if (
+                                              !isListViewID(contentId) ||
+                                              (tab &&
+                                                !canExecuteMarkDoneOnView(
+                                                  contentId,
+                                                  tab
+                                                ))
+                                            )
+                                              return false;
+                                            return markDoneAction.canExecute(
+                                              entity
+                                            );
+                                          }}
+                                          onMarkDone={(entity) => {
+                                            markDoneAction.executeWithSoup(
+                                              [entity],
+                                              soup
+                                            );
+                                          }}
                                         />
                                       </SoupEntityContextMenu>
                                     </Match>

--- a/apps/web/src/features/next-soup/soup-view/soup-view.tsx
+++ b/apps/web/src/features/next-soup/soup-view/soup-view.tsx
@@ -1609,12 +1609,19 @@ const SoupViewListContent = (props: SoupViewListProps) => {
                                             ),
                                           }}
                                           canMarkDone={(entity) => {
+                                            // Re-read the panel's content id rather than closing
+                                            // over the outer `contentId` const: this row can
+                                            // outlive a content/tab change without remounting
+                                            // (same reasoning as `canSwipeLeft` below), so a
+                                            // stale id would keep gating against the wrong view.
+                                            const freshContentId =
+                                              panel.handle.content().id;
                                             const tab = activeTab();
                                             if (
-                                              !isListViewID(contentId) ||
+                                              !isListViewID(freshContentId) ||
                                               (tab &&
                                                 !canExecuteMarkDoneOnView(
-                                                  contentId,
+                                                  freshContentId,
                                                   tab
                                                 ))
                                             )

--- a/apps/web/src/features/next-soup/soup-view/views/inbox/InboxListEntity.tsx
+++ b/apps/web/src/features/next-soup/soup-view/views/inbox/InboxListEntity.tsx
@@ -49,7 +49,12 @@ export function InboxListEntity(props: BaseListEntityProps) {
           <button
             type="button"
             aria-label="Mark done"
-            class="hidden size-8 place-items-center rounded-full bg-surface text-ink-muted transition-colors hover:text-ink group-hover/mark-done-icon:grid"
+            class={cn(
+              'grid size-8 place-items-center rounded-full bg-surface text-ink-muted opacity-0 pointer-events-none transition-opacity hover:text-ink',
+              'group-hover/mark-done-icon:opacity-100 group-hover/mark-done-icon:pointer-events-auto',
+              'group-focus-within/mark-done-icon:opacity-100 group-focus-within/mark-done-icon:pointer-events-auto',
+              'focus-visible:opacity-100 focus-visible:pointer-events-auto'
+            )}
             onMouseDown={(event) => event.stopPropagation()}
             onClick={(event) => {
               event.stopPropagation();

--- a/apps/web/src/features/next-soup/soup-view/views/inbox/InboxListEntity.tsx
+++ b/apps/web/src/features/next-soup/soup-view/views/inbox/InboxListEntity.tsx
@@ -1,6 +1,7 @@
 import { useChannelsContext } from '@core/context/channels';
 import { MaybeEntityRow, MultiSelectCheckbox, UnreadIndicator } from '@entity';
 import type { BaseListEntityProps } from '@entity/composed/list-entity/shared';
+import CheckIcon from '@phosphor/check.svg';
 import { cn } from '@ui';
 import { createMemo, Show } from 'solid-js';
 import { InboxCardLayout, toInboxCardDisplayItem } from './inbox-card-layouts';
@@ -41,6 +42,24 @@ export function InboxListEntity(props: BaseListEntityProps) {
           onClick={props.onClick}
         />
       </MaybeEntityRow>
+      {/* Hover the leading icon (col-start-1 of the card's grid, just right of
+          the `pl-9` gutter) to reveal a mark-done checkmark in its place. */}
+      <Show when={props.onMarkDone && props.canMarkDone?.(props.entity)}>
+        <div class="group/mark-done-icon absolute left-9 top-2.5 z-10 grid size-8 place-items-center">
+          <button
+            type="button"
+            aria-label="Mark done"
+            class="hidden size-8 place-items-center rounded-full bg-surface text-ink-muted transition-colors hover:text-ink group-hover/mark-done-icon:grid"
+            onMouseDown={(event) => event.stopPropagation()}
+            onClick={(event) => {
+              event.stopPropagation();
+              props.onMarkDone?.(props.entity);
+            }}
+          >
+            <CheckIcon class="size-4" />
+          </button>
+        </div>
+      </Show>
       {/* Select checkbox lives in the gutter reserved by the card's `pl-9`. */}
       <Show when={!props.hideCheckbox}>
         <div class="group/select-control absolute left-1 top-2.5 z-10 grid size-8 place-items-center">


### PR DESCRIPTION
## Summary

- Adds the requested affordance: hovering an inbox row's leading entity/user icon swaps it for a checkmark button that marks the row done — a lower-friction alternative to right-clicking → "Mark Done" or hitting `e` (which requires the row to be focused).
- Implemented by threading two new **optional** props (`onMarkDone` / `canMarkDone`) through `BaseListEntityProps`, wired only at the one call site that renders the new inbox row (`InboxListEntity`, via `soup-view.tsx`'s `Dynamic` render). Other list-entity variants (tasks, companies, the classic list) don't set them and are unaffected.
- Reuses the existing `makeMarkDoneAction` instance already created in `soup-view.tsx` for the mobile swipe-left gesture — no new mutation/logic, and gated identically (`canExecuteMarkDoneOnView` + `markDoneAction.canExecute`), so this can't mark-done in a view where swipe-left couldn't.
- Hover pattern mirrors the existing self-contained gutter checkbox in `InboxListEntity.tsx` (a same-size absolutely-positioned overlay with its own named group, revealed only when hovering that exact icon).

MACRO-2519

## Why prioritized

Requested directly by a teammate ("in inbox, we should have the entity icon become a mark done check mark") in [\[inbox\] on hover entity/user icon should become mark done check mark](https://macro.com/app/task/019f81b4-6921-71ff-b82c-ddccb923eb5f), filed High priority. Related to the broader "it's too hard to mark things done" thread in bug-reports that this task came out of.

## Test plan

- [ ] Reviewer: in the new inbox (feature flag on), hover a row's leading icon — it should swap to a checkmark; clicking it marks the row done (same effect as the context menu action / `e` hotkey) without opening/focusing the row.
- [ ] Confirm the checkmark only appears in views where mark-done is valid (mirrors swipe-left's gating) and never for row types `canExecute` already excludes (e.g. `channel_message`).
- [ ] Confirm other list views (tasks, companies, classic non-inbox list) render unaffected — they don't pass the new props.

I couldn't run the dev server in this sandbox (git-dependency fetches for `tauri-plugins`/`pdf.js` are blocked here), so the hover/click interaction and positioning are unverified against a live Inbox — flagging that explicitly for reviewers.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HwL2qpNQRoQP9iKn5Py4Qc)_