### PR TITLE
fix(email): preserve paragraph spacing in sent emails

### DIFF
--- a/apps/web/src/features/block-email/util/flattenConsecutiveParagraphs.test.ts
+++ b/apps/web/src/features/block-email/util/flattenConsecutiveParagraphs.test.ts
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import { flattenConsecutiveParagraphs } from './flattenConsecutiveParagraphs';
+
+function flatten(html: string) {
+  const body = new DOMParser().parseFromString(html, 'text/html').body;
+  flattenConsecutiveParagraphs(body);
+  return body.innerHTML;
+}
+
+describe('flattenConsecutiveParagraphs', () => {
+  it('joins consecutive paragraphs with a blank line', () => {
+    expect(flatten('<p>one</p><p>two</p>')).toBe('<div>one<br><br>two</div>');
+  });
+
+  it('keeps a lone paragraph as a div without separators', () => {
+    expect(flatten('<p>only</p>')).toBe('<div>only</div>');
+  });
+
+  it('preserves an explicit blank line (empty paragraph) between paragraphs', () => {
+    // Lexical exports an empty paragraph as <p><br></p>
+    expect(flatten('<p>one</p><p><br></p><p>two</p>')).toBe(
+      '<div>one<br><br><br>two</div>'
+    );
+  });
+
+  it('does not add a separator after an empty paragraph', () => {
+    expect(flatten('<p><br></p><p>two</p>')).toBe('<div><br>two</div>');
+  });
+
+  it('flattens non-adjacent runs into separate divs', () => {
+    expect(flatten('<p>one</p><ul><li>x</li></ul><p>two</p>')).toBe(
+      '<div>one</div><ul><li>x</li></ul><div>two</div>'
+    );
+  });
+
+  it('treats media-only paragraphs as non-empty', () => {
+    expect(flatten('<p><img src="a.png"></p><p>two</p>')).toBe(
+      '<div><img src="a.png"><br><br>two</div>'
+    );
+  });
+
+  it('preserves inline markup within paragraphs', () => {
+    expect(flatten('<p><b>one</b></p><p><i>two</i></p>')).toBe(
+      '<div><b>one</b><br><br><i>two</i></div>'
+    );
+  });
+});

--- a/apps/web/src/features/block-email/util/flattenConsecutiveParagraphs.ts
+++ b/apps/web/src/features/block-email/util/flattenConsecutiveParagraphs.ts
@@ -1,0 +1,67 @@
+/**
+ * Flattens runs of consecutive `<p>` siblings into a single `<div>` with
+ * explicit `<br>` separators, matching how Gmail structures composed mail.
+ * Email clients apply their own margins to `<p>`, so relying on them renders
+ * differently per client. The editor shows a paragraph break as a blank line,
+ * so non-empty paragraphs are joined by two `<br>`s; empty paragraphs already
+ * export their own `<br>` and need no extra separator.
+ */
+export function flattenConsecutiveParagraphs(container: Element) {
+  const paragraphs = container.querySelectorAll('p');
+  const groups = [];
+  let currentGroup: Element[] = [];
+
+  for (let i = 0; i < paragraphs.length; i++) {
+    if (i === 0) {
+      currentGroup.push(paragraphs[i]);
+      continue;
+    }
+
+    // Check if this paragraph immediately follows the previous one
+    const prev = paragraphs[i - 1];
+    if (prev.nextElementSibling === paragraphs[i]) {
+      currentGroup.push(paragraphs[i]);
+    } else {
+      // Start a new group
+      groups.push(currentGroup);
+      currentGroup = [paragraphs[i]];
+    }
+  }
+
+  // Don't forget the last group
+  if (currentGroup.length > 0) {
+    groups.push(currentGroup);
+  }
+
+  // Combine each group and replace in the DOM
+  for (let i = 0; i < groups.length; i++) {
+    const group = groups[i];
+    const div = document.createElement('div');
+
+    for (let j = 0; j < group.length; j++) {
+      const p = group[j];
+
+      const isEmpty =
+        !p.textContent?.trim() &&
+        !p.querySelector('img, video, iframe, canvas');
+
+      if (p.childNodes.length) {
+        div.append(...p.childNodes);
+      }
+
+      if (j < group.length - 1 && !isEmpty) {
+        // Paragraph break = one blank line for the recipient
+        div.appendChild(document.createElement('br'));
+        div.appendChild(document.createElement('br'));
+      }
+    }
+
+    // Replace the first paragraph with the combined div
+    group[0]?.parentNode?.replaceChild(div, group[0]);
+
+    // Remove the rest of the paragraphs in this group
+    for (let j = 1; j < group.length; j++) {
+      group[j].remove();
+    }
+  }
+}

--- a/apps/web/src/features/block-email/util/prepareEmailBody.ts
+++ b/apps/web/src/features/block-email/util/prepareEmailBody.ts
@@ -24,6 +24,7 @@ import {
   type LexicalEditor,
   type LexicalNode,
 } from 'lexical';
+import { flattenConsecutiveParagraphs } from './flattenConsecutiveParagraphs';
 import type { ReplyType } from './replyType';
 
 export function clearEmailBody(editor: LexicalEditor | undefined) {
@@ -433,64 +434,6 @@ function applyMediaScale(container: Element) {
     if (height > 0)
       el.setAttribute('height', Math.round(height * scale).toString());
   });
-}
-
-function flattenConsecutiveParagraphs(container: Element) {
-  const paragraphs = container.querySelectorAll('p');
-  const groups = [];
-  let currentGroup: Element[] = [];
-
-  for (let i = 0; i < paragraphs.length; i++) {
-    if (i === 0) {
-      currentGroup.push(paragraphs[i]);
-      continue;
-    }
-
-    // Check if this paragraph immediately follows the previous one
-    const prev = paragraphs[i - 1];
-    if (prev.nextElementSibling === paragraphs[i]) {
-      currentGroup.push(paragraphs[i]);
-    } else {
-      // Start a new group
-      groups.push(currentGroup);
-      currentGroup = [paragraphs[i]];
-    }
-  }
-
-  // Don't forget the last group
-  if (currentGroup.length > 0) {
-    groups.push(currentGroup);
-  }
-
-  // Combine each group and replace in the DOM
-  for (let i = 0; i < groups.length; i++) {
-    const group = groups[i];
-    const div = document.createElement('div');
-
-    for (let j = 0; j < group.length; j++) {
-      const p = group[j];
-
-      const isEmpty =
-        !p.textContent?.trim() &&
-        !p.querySelector('img, video, iframe, canvas');
-
-      if (p.childNodes.length) {
-        div.append(...p.childNodes);
-      }
-
-      if (j < group.length - 1 && !isEmpty) {
-        div.appendChild(document.createElement('br'));
-      }
-    }
-
-    // Replace the first paragraph with the combined div
-    group[0]?.parentNode?.replaceChild(div, group[0]);
-
-    // Remove the rest of the paragraphs in this group
-    for (let j = 1; j < group.length; j++) {
-      group[j].remove();
-    }
-  }
 }
 
 export function prepareEmailBody(


### PR DESCRIPTION
## Problem

Bug report: paragraphs written in the email composer arrive with all their vertical spacing removed — the recipient (e.g. Gmail) sees every paragraph collapsed onto consecutive lines.

**Why:** the compose editor renders each `<p>` with a visible vertical gap (`my-4` in the markdown editor theme), so a single Enter looks like a paragraph break with a blank-line-sized gap. But before sending, `flattenConsecutiveParagraphs` (added in #1078, when the editor had no paragraph margins) rewrites runs of `<p>`s into a single `<div>` joined by **one** `<br>` each. On the wire that's just a line break, so the paragraph gap the sender sees never reaches the recipient. The theme change in #3645 made the editor spacing and the wire format disagree.

## Fix

Join non-empty consecutive paragraphs with two `<br>`s so a paragraph break renders as a blank line, matching what the sender sees in the editor. Empty paragraphs (explicit blank lines, exported by Lexical as `<p><br></p>`) keep contributing their own `<br>` with no extra separator, so intentional blank lines still stack proportionally.

Also extracts `flattenConsecutiveParagraphs` from `prepareEmailBody.ts` into its own module (logic otherwise unchanged) so it can be unit-tested without pulling in the Lexical dependency graph, and adds tests covering paragraph joins, empty paragraphs, non-adjacent runs, media-only paragraphs, and inline markup.
