### PR TITLE
fix notifications for channel thread edges

### DIFF
--- a/crates/notification/src/outbound/repository.rs
+++ b/crates/notification/src/outbound/repository.rs
@@ -44,6 +44,25 @@ type UserNotificationListRow = (
     Option<String>,
 );
 
+#[derive(sqlx::FromRow)]
+struct EntityNotificationListRow {
+    owner_id: String,
+    notification_id: Uuid,
+    event_item_id: String,
+    event_item_type: String,
+    secondary_event_item_id: Option<String>,
+    secondary_event_item_type: Option<String>,
+    sent: bool,
+    done: bool,
+    created_at: DateTime<Utc>,
+    viewed_at: Option<DateTime<Utc>>,
+    updated_at: DateTime<Utc>,
+    deleted_at: Option<DateTime<Utc>>,
+    notification_metadata: serde_json::Value,
+    notification_event_type: String,
+    sender_id: Option<String>,
+}
+
 struct UserNotificationsQueryArgs<'a> {
     user_id: &'a str,
     event_item_ids: Option<&'a [String]>,
@@ -243,6 +262,10 @@ fn push_entities_filter<'a>(builder: &mut QueryBuilder<'a, Postgres>, entity_tok
 
         builder.push("('message:' || COALESCE(n.metadata->>'messageId', n.metadata->>'message_id', '') = ANY(");
         builder.push_bind(entity_tokens);
+        builder.push(")) OR ");
+
+        builder.push("(n.secondary_event_item_type = 'channel_message' AND 'message:' || n.secondary_event_item_id = ANY(");
+        builder.push_bind(entity_tokens);
         builder.push("))");
 
         builder.push(")");
@@ -253,15 +276,21 @@ fn notification_ref_matches_row(
     entity_ref: &NotificationEntityRef,
     event_item_id: &str,
     event_item_type: &str,
+    secondary_event_item_id: Option<&str>,
+    secondary_event_item_type: Option<&str>,
     notification_event_type: &str,
     metadata: &serde_json::Value,
 ) -> bool {
     if entity_ref.entity_type == NotificationItemType::Message {
-        return metadata
+        let directly_targets_message = metadata
             .get("messageId")
             .or_else(|| metadata.get("message_id"))
             .and_then(|value| value.as_str())
             .is_some_and(|message_id| message_id == entity_ref.id);
+        let targets_message_as_thread = secondary_event_item_type == Some("channel_message")
+            && secondary_event_item_id == Some(entity_ref.id.as_str());
+
+        return directly_targets_message || targets_message_as_thread;
     }
 
     if entity_ref.id != event_item_id {
@@ -1112,6 +1141,8 @@ impl NotificationDbOps for PgPool {
                 un.notification_id,
                 n.event_item_id,
                 n.event_item_type,
+                n.secondary_event_item_id,
+                n.secondary_event_item_type,
                 un.sent,
                 un.done,
                 un.created_at::timestamptz as created_at,
@@ -1131,16 +1162,18 @@ impl NotificationDbOps for PgPool {
         builder.push(" ORDER BY un.created_at DESC, un.notification_id DESC");
 
         let rows = builder
-            .build_query_as::<UserNotificationListRow>()
+            .build_query_as::<EntityNotificationListRow>()
             .fetch_all(self)
             .await?;
 
         for row in rows {
-            let (
+            let EntityNotificationListRow {
                 owner_id,
                 notification_id,
                 event_item_id,
                 event_item_type,
+                secondary_event_item_id,
+                secondary_event_item_type,
                 sent,
                 done,
                 created_at,
@@ -1150,7 +1183,7 @@ impl NotificationDbOps for PgPool {
                 notification_metadata,
                 notification_event_type,
                 sender_id,
-            ) = row;
+            } = row;
 
             let entity = match EntityType::from_str(&event_item_type) {
                 Ok(entity_type) => entity_type.with_entity_string(event_item_id.clone()),
@@ -1198,6 +1231,8 @@ impl NotificationDbOps for PgPool {
                     entity_ref,
                     &event_item_id,
                     &event_item_type,
+                    secondary_event_item_id.as_deref(),
+                    secondary_event_item_type.as_deref(),
                     &notification_event_type,
                     &notification_metadata,
                 ) {

--- a/crates/notification/src/outbound/repository/test.rs
+++ b/crates/notification/src/outbound/repository/test.rs
@@ -21,6 +21,16 @@ impl Notification for TestNotification {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct TestMessageNotification {
+    message_id: String,
+}
+
+impl Notification for TestMessageNotification {
+    const TYPE_NAME: &'static str = "test_message_notification";
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 struct TestGithubNotification {
     message: String,
 }
@@ -40,6 +50,29 @@ impl Notification for TestGithubCheckRunNotification {
 
 fn test_user(email: &str) -> MacroUserIdStr<'static> {
     MacroUserIdStr::try_from_email(email).unwrap()
+}
+
+async fn create_message_notification(
+    pool: &Pool<Postgres>,
+    recipient: &MacroUserIdStr<'static>,
+    notification_id: Uuid,
+    message_id: &str,
+    thread_id: Option<&str>,
+) {
+    let request = SendNotificationRequestBuilder {
+        notification_entity: EntityType::Channel.with_entity_str("channel-1"),
+        secondary_notification_entity: thread_id
+            .map(|thread_id| EntityType::ChannelMessage.with_entity_str(thread_id)),
+        notification: TaggedContent::new(TestMessageNotification {
+            message_id: message_id.to_owned(),
+        }),
+        sender_id: None,
+        recipient_ids: std::collections::HashSet::from([recipient.clone()]),
+    };
+
+    pool.create_notification(request, notification_id, "test_service", None)
+        .await
+        .unwrap();
 }
 
 #[sqlx::test(
@@ -613,6 +646,67 @@ async fn test_get_user_notifications_filters_type_and_entity(pool: Pool<Postgres
         .await
         .unwrap();
     assert!(wrong_entity_results.is_empty());
+}
+
+#[sqlx::test(migrator = "MACRO_DB_MIGRATIONS")]
+async fn test_get_entity_notifications_batch_matches_channel_thread_secondary_entity(
+    pool: Pool<Postgres>,
+) {
+    let user = test_user("thread-recipient@test.com");
+    let thread_id = Uuid::new_v4().to_string();
+    let other_thread_id = Uuid::new_v4().to_string();
+    let direct_notification_id = Uuid::new_v4();
+    let reply_notification_id = Uuid::new_v4();
+    let other_thread_notification_id = Uuid::new_v4();
+
+    create_message_notification(&pool, &user, direct_notification_id, &thread_id, None).await;
+    create_message_notification(
+        &pool,
+        &user,
+        reply_notification_id,
+        &Uuid::new_v4().to_string(),
+        Some(&thread_id),
+    )
+    .await;
+    create_message_notification(
+        &pool,
+        &user,
+        other_thread_notification_id,
+        &Uuid::new_v4().to_string(),
+        Some(&other_thread_id),
+    )
+    .await;
+
+    let thread_ref = NotificationEntityRef {
+        entity_type: NotificationItemType::Message,
+        id: thread_id,
+    };
+    let other_thread_ref = NotificationEntityRef {
+        entity_type: NotificationItemType::Message,
+        id: other_thread_id,
+    };
+    let result = pool
+        .get_entity_notifications_batch(user, vec![thread_ref.clone(), other_thread_ref.clone()])
+        .await
+        .unwrap();
+
+    let thread_notification_ids = result[&thread_ref]
+        .iter()
+        .map(|notification| notification.notification_id)
+        .collect::<HashSet<_>>();
+    assert_eq!(
+        thread_notification_ids,
+        HashSet::from([direct_notification_id, reply_notification_id])
+    );
+
+    let other_thread_notification_ids = result[&other_thread_ref]
+        .iter()
+        .map(|notification| notification.notification_id)
+        .collect::<HashSet<_>>();
+    assert_eq!(
+        other_thread_notification_ids,
+        HashSet::from([other_thread_notification_id])
+    );
 }
 
 #[sqlx::test(migrator = "MACRO_DB_MIGRATIONS")]


### PR DESCRIPTION
This PR allows fetching notifications by the secondary associated entity which is required to get linked notifications for ChannelThread entity types