### PR TITLE
Add mobile web signup flow for unauthenticated visitors

### DIFF
--- a/apps/web/src/components/app/Layout.tsx
+++ b/apps/web/src/components/app/Layout.tsx
@@ -82,6 +82,7 @@ const AUTH_URLS = [
   `${ROUTER_BASE_CONCAT}email-signup-callback`,
   `${ROUTER_BASE_CONCAT}offline`,
   `${ROUTER_BASE_CONCAT}welcome`,
+  `${ROUTER_BASE_CONCAT}mobile-email-signup`,
   `${ROUTER_BASE_CONCAT}team-invite`,
 ];
 

--- a/apps/web/src/features/onboarding/MobileWebSignup.tsx
+++ b/apps/web/src/features/onboarding/MobileWebSignup.tsx
@@ -1,0 +1,37 @@
+import { useAnalytics } from '@app/lib/analytics/analytics-context';
+import { createSignal, Match, Switch } from 'solid-js';
+import MobileWebSignupSent from './MobileWebSignupSent';
+import MobileWebWelcome from './MobileWebWelcome';
+
+/**
+ * Mobile-web entry flow for unauthenticated visitors on a phone/tablet browser.
+ *
+ * Signing up on mobile web is a poor experience, so instead of pushing visitors
+ * through Google SSO + onboarding we capture their email and tell them we've
+ * emailed a link to open on desktop. The two screens are:
+ *   1. {@link MobileWebWelcome} — captures the email.
+ *   2. {@link MobileWebSignupSent} — confirms "we emailed you a desktop link".
+ *
+ * Identifying the email hands it to the analytics providers, which is what the
+ * downstream marketing automation keys the desktop-download email off of.
+ */
+export default function MobileWebSignup() {
+  const analytics = useAnalytics();
+  const [submittedEmail, setSubmittedEmail] = createSignal<string | null>(null);
+
+  const handleSignUp = (email: string) => {
+    const trimmed = email.trim();
+    // Don't advance on an empty submit — keep the visitor on the capture step.
+    if (!trimmed) return;
+    analytics.identify(trimmed, { email: trimmed });
+    setSubmittedEmail(trimmed);
+  };
+
+  return (
+    <Switch fallback={<MobileWebWelcome onSignUp={handleSignUp} />}>
+      <Match when={submittedEmail() !== null}>
+        <MobileWebSignupSent email={submittedEmail() ?? undefined} />
+      </Match>
+    </Switch>
+  );
+}

--- a/apps/web/src/routes/Root.tsx
+++ b/apps/web/src/routes/Root.tsx
@@ -11,6 +11,7 @@ import { GlobalShareInboxConflictDialog } from '@app/features/inbox/ShareInboxCo
 import { SearchProvider } from '@app/features/next-soup/search-context';
 import { usePendingNotificationNavigationEffect } from '@app/features/notifications/PendingNotificationNavigationEffect';
 import { InteractiveOnboardingModal } from '@app/features/onboarding/InteractiveOnboardingModal';
+import MobileWebSignup from '@app/features/onboarding/MobileWebSignup';
 import { useCheckoutCompletionListener } from '@app/features/paywall/use-checkout-completion-listener';
 import { TeamInviteAcceptance } from '@app/features/team-invitations/TeamInviteAcceptance';
 import {
@@ -407,6 +408,14 @@ const ROUTES: RouteDefinition[] = [
       ) : (
         <Navigate href="/login" />
       ),
+  },
+  {
+    // Mobile-web visitors can't sign up on a phone, so instead of pushing them
+    // through Google SSO + onboarding we capture their email and email them a
+    // link to open on desktop. The marketing site redirects mobile browsers
+    // here.
+    path: '/mobile-email-signup',
+    component: MobileWebSignup,
   },
   {
     path: '/onboarding',


### PR DESCRIPTION
## Summary

Adds a dedicated mobile web signup flow that captures email addresses from unauthenticated visitors on mobile browsers, instead of pushing them through the full Google SSO + onboarding experience which provides a poor UX on mobile.

## Key Changes

- **New `MobileWebSignup` component** (`apps/web/src/features/onboarding/MobileWebSignup.tsx`): 
  - Entry point for mobile web visitors that manages a two-step flow
  - Step 1: `MobileWebWelcome` — captures the visitor's email
  - Step 2: `MobileWebSignupSent` — confirms email was sent with desktop link
  - Identifies the email with analytics providers to trigger downstream marketing automation

- **New route** (`/mobile-email-signup`):
  - Added to `Root.tsx` route definitions
  - Intended to be used as a redirect target from the marketing site for mobile browsers

- **Updated auth URL allowlist** in `Layout.tsx`:
  - Added `/mobile-email-signup` to `AUTH_URLS` to ensure the route is accessible to unauthenticated visitors

## Implementation Details

- Uses Solid.js `createSignal` for state management to track whether email has been submitted
- Validates email input (trims whitespace and prevents empty submissions)
- Calls `analytics.identify()` to pass email to analytics providers, which keys the desktop-download email off of this identifier
- Conditional rendering with `Switch`/`Match` to show appropriate screen based on submission state

https://claude.ai/code/session_0146VvCFZdFwcdYw9j69wisD