### PR TITLE
feat(onboarding): send mobile welcome email via auth service on signup

### DIFF
--- a/apps/web/src/features/onboarding/MobileWebSignup.tsx
+++ b/apps/web/src/features/onboarding/MobileWebSignup.tsx
@@ -1,4 +1,6 @@
 import { useAnalytics } from '@app/lib/analytics/analytics-context';
+import { toast } from '@core/component/Toast/Toast';
+import { useSendMobileWelcomeEmail } from '@queries/auth';
 import { createSignal, Match, Switch } from 'solid-js';
 import MobileWebSignupSent from './MobileWebSignupSent';
 import MobileWebWelcome from './MobileWebWelcome';
@@ -7,23 +9,43 @@ import MobileWebWelcome from './MobileWebWelcome';
  * Mobile-web entry flow for unauthenticated visitors on a phone/tablet browser.
  *
  * Signing up on mobile web is a poor experience, so instead of pushing visitors
- * through Google SSO + onboarding we capture their email and tell them we've
- * emailed a link to open on desktop. The two screens are:
+ * through Google SSO + onboarding we capture their email and send them a link
+ * to open on desktop (POST /mobile-welcome-email on the auth service). The two
+ * screens are:
  *   1. {@link MobileWebWelcome} — captures the email.
  *   2. {@link MobileWebSignupSent} — confirms "we emailed you a desktop link".
  *
- * Identifying the email hands it to the analytics providers, which is what the
- * downstream marketing automation keys the desktop-download email off of.
+ * Identifying the email also hands it to the analytics providers so downstream
+ * marketing automation can pick it up.
  */
 export default function MobileWebSignup() {
   const analytics = useAnalytics();
+  const sendWelcomeEmail = useSendMobileWelcomeEmail();
   const [submittedEmail, setSubmittedEmail] = createSignal<string | null>(null);
 
-  const handleSignUp = (email: string) => {
+  const handleSignUp = async (email: string) => {
     const trimmed = email.trim();
     // Don't advance on an empty submit — keep the visitor on the capture step.
-    if (!trimmed) return;
+    if (!trimmed || sendWelcomeEmail.isPending) return;
     analytics.identify(trimmed, { email: trimmed });
+
+    const result = await sendWelcomeEmail.mutateAsync(trimmed);
+    if (result.isErr()) {
+      switch (result.error[0]?.code) {
+        case 'INVALID_EMAIL':
+          toast.failure('Invalid email address.');
+          break;
+        case 'RATE_LIMITED':
+          toast.failure('Too many attempts. Please try again later.');
+          break;
+        default:
+          toast.failure('Something went wrong. Please try again.');
+      }
+      return;
+    }
+
+    // `sent: false` means we already emailed this address — the confirmation
+    // screen is still accurate, so advance either way.
     setSubmittedEmail(trimmed);
   };
 


### PR DESCRIPTION
## Summary

Wires the `/mobile-email-signup` flow (added in #5082) back up to the backend so submitting an email actually sends the desktop-link welcome email, instead of relying solely on analytics-driven marketing automation.

- `MobileWebSignup` now calls the existing `useSendMobileWelcomeEmail` mutation (previously orphaned), which hits `POST /mobile-welcome-email` on `authentication_service` — server-side validation, block list, per-IP rate limiting, and already-sent dedupe all apply.
- Maps the client's typed error codes to toasts: `INVALID_EMAIL` → "Invalid email address.", `RATE_LIMITED` → "Too many attempts. Please try again later.", anything else → a generic retry message. On error the visitor stays on the capture screen.
- Advances to the confirmation screen on success, including the `sent: false` (already emailed) case — the screen is still truthful, and this avoids the old flow's "Email already sent." dead end.
- Guards against double-submits while the request is in flight; keeps `analytics.identify` so marketing automation continues to receive the email.

## Background

The original mobile web signup flow (#2624/#2608, Apr 2026) called this endpoint; the call was dropped in the tutorial-modal rework (#3664) and #5082 reintroduced the screens without it. The backend endpoint and mutation hook were still in place — this reconnects them.
