### PR TITLE
fix(editor): keep empty paragraph when inserting a block node into an empty doc

### DIFF
--- a/apps/web/src/lib/core/component/LexicalMarkdown/utils.ts
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/utils.ts
@@ -1069,6 +1069,21 @@ export function $insertNodesAndSplitList(nodes: LexicalNode[]) {
   }
   const matchingParent = $findMatchingParent(node, $isListItemNode);
   if (!matchingParent) {
+    const topLevelElement = node.getTopLevelElement();
+    if (
+      anchor.offset === 0 &&
+      topLevelElement &&
+      topLevelElement.isEmpty() &&
+      topLevelElement === $getRoot().getFirstChild() &&
+      topLevelElement === $getRoot().getLastChild()
+    ) {
+      // Inserting via $insertNodes here would delete this lone empty
+      // block once the new (non-mergeable, e.g. decorator) nodes are
+      // placed after it, leaving no element for the cursor to land in.
+      // Insert before it instead so it survives as a place to type.
+      $getRoot().splice(0, 0, nodes);
+      return;
+    }
     $insertNodes(nodes);
     nodes.at(-1)?.selectEnd();
     return;


### PR DESCRIPTION
Fixes the cursor becoming unplaceable when a decorator/block node (e.g. a pasted image, horizontal rule) is inserted into a doc containing only an empty paragraph, by inserting the new node before that paragraph instead of after it (macro-2499).