### PR TITLE
fix(chat): allow anonymous view of publicly-shared chats

### DIFF
--- a/crates/chat/src/domain/service/chat.rs
+++ b/crates/chat/src/domain/service/chat.rs
@@ -7,7 +7,8 @@ use crate::domain::{
 use agent::types::{AssistantMessagePart, ChatMessageContent};
 use ai_toolset::{AsyncToolCollection, RequestContext, tool_object::UserToolResponse};
 use entity_access::domain::models::{
-    EditAccessLevel, EntityAccessReceipt, OwnerAccessLevel, ViewAccessLevel,
+    AccessLevel, EditAccessLevel, EntityAccessAuth, EntityAccessReceipt, EntityPermission,
+    OwnerAccessLevel, ViewAccessLevel,
 };
 use entity_access_management::domain::ports::EntityAccessManagementService;
 use macro_user_id::user_id::MacroUserIdStr;
@@ -92,17 +93,32 @@ where
         &self,
         entity_access_receipt: EntityAccessReceipt<ViewAccessLevel>,
     ) -> Result<GetChatResponse> {
-        let user_id = entity_access_receipt.get_authenticated_user()?;
         let chat_id = &entity_access_receipt.entity().entity_id;
 
-        let (chat, access_level) = tokio::join!(
-            self.repo.get_chat(chat_id),
-            self.repo.get_access_level(user_id.to_owned(), chat_id),
-        );
+        // Anonymous public-link viewers hold an Unauthenticated receipt: there
+        // is no user to look up an access level for, so report the level the
+        // receipt was granted with (the chat's public access level).
+        if let EntityAccessAuth::Authenticated(user_id) = entity_access_receipt.auth() {
+            let (chat, access_level) = tokio::join!(
+                self.repo.get_chat(chat_id),
+                self.repo.get_access_level(user_id.to_owned(), chat_id),
+            );
+
+            return Ok(GetChatResponse {
+                chat: chat?,
+                user_access_level: access_level?,
+            });
+        }
+
+        let chat = self.repo.get_chat(chat_id).await?;
+        let user_access_level = match entity_access_receipt.entity_permission() {
+            EntityPermission::AccessLevel { access_level } => *access_level,
+            _ => AccessLevel::View,
+        };
 
         Ok(GetChatResponse {
-            chat: chat?,
-            user_access_level: access_level?,
+            chat,
+            user_access_level,
         })
     }
 

--- a/crates/chat/src/inbound/http/router.rs
+++ b/crates/chat/src/inbound/http/router.rs
@@ -107,7 +107,29 @@ pub fn chat_create_router<
         .with_state(state)
 }
 
-/// Build the router for all `/{chat_id}` routes.
+/// Build the router for the read-only `GET /{chat_id}` view route.
+///
+/// Separated from [`chat_id_router`] so callers can apply
+/// `ensure_chat_exists` without also requiring a real authenticated user:
+/// the [`ChatAccessLevelExtractor`] already grants `ViewAccessLevel` to
+/// anonymous callers when the chat has public-link view sharing enabled,
+/// so gating this route on authentication would 401 legitimate public-link
+/// viewers before the extractor ever runs.
+pub fn chat_view_router<
+    S: ChatService,
+    Svc: EntityAccessService,
+    Auth: MacroAuthorizationService,
+    P: UserRolesAndPermissionsService,
+    T: Send + Sync + 'static,
+>(
+    state: ChatRouterState<S, Svc, Auth, P>,
+) -> Router<T> {
+    Router::new()
+        .route("/{chat_id}", get(get_chat_handler::<S, Svc, Auth, P>))
+        .with_state(state)
+}
+
+/// Build the router for the remaining, owner/editor-only `/{chat_id}` routes.
 ///
 /// These routes require `ensure_chat_exists` middleware to populate
 /// `ChatBasic` in extensions before the [`ChatAccessLevelExtractor`] runs.
@@ -123,8 +145,7 @@ pub fn chat_id_router<
     Router::new()
         .route(
             "/{chat_id}",
-            get(get_chat_handler::<S, Svc, Auth, P>)
-                .delete(delete_chat_handler::<S, Svc, Auth, P>)
+            delete(delete_chat_handler::<S, Svc, Auth, P>)
                 .patch(patch_chat_handler::<S, Svc, Auth, P>),
         )
         .route(

--- a/crates/chat/src/inbound/test.rs
+++ b/crates/chat/src/inbound/test.rs
@@ -19,7 +19,9 @@ use crate::domain::models::{
     ChatErr, ChatResponse, CreateChatArgs, GetChatResponse, PatchChatArgs, Result,
 };
 use crate::domain::ports::ChatService;
-use crate::inbound::http::router::{ChatRouterState, chat_create_router, chat_id_router};
+use crate::inbound::http::router::{
+    ChatRouterState, chat_create_router, chat_id_router, chat_view_router,
+};
 use ai_toolset::tool_object::UserToolResponse;
 use entity_access::domain::models::{
     AccessError, AccessLevel, BotId, EditAccessLevel, EntityAccessReceipt, EntityPermission,
@@ -578,36 +580,42 @@ fn chat_basic_extension() -> Extension<ChatBasic> {
 }
 
 fn mock_id_router() -> Router {
-    chat_id_router(ChatRouterState::new(
+    let state = ChatRouterState::new(
         MockService,
         MockAccessService,
         authorization_state(),
         permissions_service(),
-    ))
-    .layer(chat_basic_extension())
-    .layer(axum::middleware::map_request(attach_bearer))
+    );
+    chat_view_router(state.clone())
+        .merge(chat_id_router(state))
+        .layer(chat_basic_extension())
+        .layer(axum::middleware::map_request(attach_bearer))
 }
 
 fn error_id_router() -> Router {
-    chat_id_router(ChatRouterState::new(
+    let state = ChatRouterState::new(
         ErrorService,
         MockAccessService,
         authorization_state(),
         permissions_service(),
-    ))
-    .layer(chat_basic_extension())
-    .layer(axum::middleware::map_request(attach_bearer))
+    );
+    chat_view_router(state.clone())
+        .merge(chat_id_router(state))
+        .layer(chat_basic_extension())
+        .layer(axum::middleware::map_request(attach_bearer))
 }
 
 fn not_found_id_router() -> Router {
-    chat_id_router(ChatRouterState::new(
+    let state = ChatRouterState::new(
         NotFoundService,
         MockAccessService,
         authorization_state(),
         permissions_service(),
-    ))
-    .layer(chat_basic_extension())
-    .layer(axum::middleware::map_request(attach_bearer))
+    );
+    chat_view_router(state.clone())
+        .merge(chat_id_router(state))
+        .layer(chat_basic_extension())
+        .layer(axum::middleware::map_request(attach_bearer))
 }
 
 fn mock_create_router() -> Router {

--- a/services/document_cognition_service/src/api/chats/mod.rs
+++ b/services/document_cognition_service/src/api/chats/mod.rs
@@ -10,7 +10,9 @@ use axum::{
     routing::{get, post},
 };
 use chat::domain::service::ChatServiceImpl;
-use chat::inbound::http::router::{ChatRouterState, chat_create_router, chat_id_router};
+use chat::inbound::http::router::{
+    ChatRouterState, chat_create_router, chat_id_router, chat_view_router,
+};
 use chat::outbound::postgres::PgChatRepo;
 use entity_access::domain::service::EntityAccessServiceImpl;
 use entity_access::outbound::PgAccessRepository;
@@ -19,11 +21,14 @@ use tower::ServiceBuilder;
 
 /// Requires an authenticated acting user before the request proceeds.
 ///
-/// Chats are created with a public-view share permission by default, so
-/// without this gate the `/{chat_id}` routes would serve any chat to fully
-/// anonymous callers via the extractor's link-share path. It also keeps the
-/// pre-existing ordering where missing/invalid credentials get a 401 before
-/// `ensure_chat_exists` performs its lookup (and 404s).
+/// Applied to the owner/editor-only `/{chat_id}` routes (delete, patch,
+/// tool calls, etc.) so missing/invalid credentials get a 401 before
+/// `ensure_chat_exists` performs its lookup (and 404s), rather than falling
+/// through to the entity-access-level authorization check. It is
+/// deliberately **not** applied to the read-only `GET /{chat_id}` route
+/// (built via `chat_view_router`): chats can have public-view link sharing
+/// enabled, and that route's own `ChatAccessLevelExtractor` already grants
+/// anonymous callers `ViewAccessLevel` access in that case.
 async fn require_authenticated_user(
     _user: MacroAuthorizationExtractor<DcsAuthorizationService>,
     req: Request,
@@ -65,7 +70,11 @@ pub fn router(state: ApiContext) -> Router<ApiContext> {
         // Note: free users are intentionally no longer capped by chat/document count,
         // so no quota-enforcement middleware is applied here.
         .merge(chat_create_router(chat_state.clone()))
-        // All /{chat_id} routes — require an authenticated user, then
+        // Read-only view route — ensure_chat_exists only. No auth gate:
+        // ChatAccessLevelExtractor<ViewAccessLevel, ..> permits anonymous
+        // callers when the chat has public-view link sharing enabled.
+        .merge(chat_view_router(chat_state.clone()).layer(ensure_chat_exists.clone()))
+        // Remaining /{chat_id} routes — require an authenticated user, then
         // ensure_chat_exists for ChatAccessLevelExtractor
         .merge(
             chat_id_router(chat_state).layer(


### PR DESCRIPTION
Removes DCS's blanket auth gate from the read-only GET /{chat_id} route so anonymous public-link viewers can reach the ChatAccessLevelExtractor's own public-share check instead of being 401'd beforehand (macro-2580).