### PR TITLE
fix(tags): keep doc render fast for public-link viewers

### DIFF
--- a/apps/web/src/features/block-md/component/MarkdownEditor.tsx
+++ b/apps/web/src/features/block-md/component/MarkdownEditor.tsx
@@ -551,6 +551,7 @@ export function MarkdownEditor(props: {
         menu: tagsMenuOperations,
         peerIdValidator: peerIdValidator(),
         onCreateTag: (tag) => {
+          if (!canEdit()) return;
           void documentTags.applyTag(tag.scope, tag.optionId);
         },
       })

--- a/apps/web/src/features/block-md/component/TitleEditor.tsx
+++ b/apps/web/src/features/block-md/component/TitleEditor.tsx
@@ -219,6 +219,7 @@ export function TitleEditor(props: { autoFocusOnMount?: boolean } = {}) {
         menu: tagMenuOperations,
         insertTags: false,
         onCreateTag: (tag) => {
+          if (!canEdit()) return;
           void documentTags.applyTag(tag.scope, tag.optionId);
         },
       })

--- a/apps/web/src/features/property/side-panel/properties/EntityPropertiesSection.tsx
+++ b/apps/web/src/features/property/side-panel/properties/EntityPropertiesSection.tsx
@@ -91,22 +91,30 @@ export function EntityTagsSection(props: EntityTagsSectionProps) {
   const tagsFlag = useFeatureFlag(ENABLE_TAGS_FE_FLAG, {
     enabledOverride: ENABLE_TAGS_FE_OVERRIDE,
   });
+  const tagsQuery = useTagsQuery();
 
   return (
     <Show
       when={tagsFlag().enabled && TAGGABLE_ENTITY_TYPES.has(props.entityType)}
     >
       <SidePanel.Section id="tags" title="Tags" defaultOpen order={props.order}>
-        <Suspense fallback={<SidePanel.Loading />}>
-          <div class="text-xs">
-            <TagsRow
-              entityId={props.entityId}
-              entityType={props.entityType}
-              canEdit={props.canEdit}
-              triggerVariant="pill"
-            />
-          </div>
-        </Suspense>
+        <Show
+          when={!tagsQuery.isError}
+          fallback={
+            <span class="text-xs text-ink-extra-muted">Tags unavailable</span>
+          }
+        >
+          <Suspense fallback={<SidePanel.Loading />}>
+            <div class="text-xs">
+              <TagsRow
+                entityId={props.entityId}
+                entityType={props.entityType}
+                canEdit={props.canEdit}
+                triggerVariant="pill"
+              />
+            </div>
+          </Suspense>
+        </Show>
       </SidePanel.Section>
     </Show>
   );

--- a/apps/web/src/lib/core/auth/logout.ts
+++ b/apps/web/src/lib/core/auth/logout.ts
@@ -6,6 +6,7 @@ import { clearRegisteredCaches } from '@graphql-cache/lifecycle';
 import { authKeys, type UserInfoData } from '@queries/auth/user-info';
 import { queryClient } from '@queries/client';
 import { emailKeys } from '@queries/email/keys';
+import { propertiesKeys } from '@queries/properties/keys';
 import { clearDocumentQueryCache } from '@queries/storage/document-cache';
 import { authServiceClient } from '@service-auth/client';
 import { createCallback } from '@solid-primitives/rootless';
@@ -34,6 +35,7 @@ export async function clearLocalAuthSession() {
   clearDocumentQueryCache(queryClient);
   queryClient.setQueryData(authKeys.userInfo.queryKey, unauthenticatedUserInfo);
   queryClient.removeQueries({ queryKey: emailKeys.links.queryKey });
+  queryClient.removeQueries({ queryKey: propertiesKeys._def });
 
   // Queued mutations are user intent; never allow them to replay under a
   // subsequent account sharing this anonymous device cache scope.

--- a/apps/web/src/lib/queries/client.ts
+++ b/apps/web/src/lib/queries/client.ts
@@ -1,3 +1,4 @@
+import { thrownResultErrorHasCode } from '@core/util/result';
 import { QueryClient } from '@tanstack/solid-query';
 import { setupQueryPersistence } from './persistence';
 import { createQueryPersistenceScopes } from './persistence-scopes';
@@ -9,7 +10,18 @@ export const queryClient = new QueryClient({
       staleTime: 1000 * 60 * 5, // 5 minutes
       gcTime: 1000 * 60 * 10, // 10 minutes
       refetchOnWindowFocus: false,
-      retry: 1,
+      // Auth failures are terminal within a session — fetchWithToken already
+      // refreshes and retries the token internally, so a query-level retry just
+      // repeats the doomed request.
+      retry: (failureCount, error) => {
+        if (
+          thrownResultErrorHasCode(error, 'UNAUTHORIZED') ||
+          thrownResultErrorHasCode(error, 'FORBIDDEN')
+        ) {
+          return false;
+        }
+        return failureCount < 1;
+      },
     },
   },
 });

--- a/apps/web/src/lib/queries/properties/tags.ts
+++ b/apps/web/src/lib/queries/properties/tags.ts
@@ -1,5 +1,6 @@
+import { useIsAuthenticated } from '@core/auth';
 import { toast } from '@core/component/Toast/Toast';
-import { throwOnErr } from '@core/util/result';
+import { thrownResultErrorHasCode, throwOnErr } from '@core/util/result';
 import { useMutation, useQuery } from '@tanstack/solid-query';
 import { propertiesServiceClient } from '../../service-clients/service-properties/client';
 import type { AddPropertyOptionRequest } from '../../service-clients/service-properties/generated/schemas/addPropertyOptionRequest';
@@ -12,13 +13,18 @@ import { queryClient } from '../client';
 import { type MutationCallbacks, withCallbacks } from '../utils';
 import { propertiesKeys } from './keys';
 
+const EMPTY_TAG_SETS: TagSetResponse[] = [];
+
 /** The caller's tag sets: their personal set, plus their team's set when on a team. */
 export function useTagsQuery() {
+  const isAuthenticated = useIsAuthenticated();
   return useQuery(() => ({
     queryKey: propertiesKeys.tags.queryKey,
     queryFn: async () =>
       await throwOnErr(async () => await propertiesServiceClient.listTags()),
     staleTime: 1000 * 60 * 5,
+    enabled: isAuthenticated(),
+    placeholderData: EMPTY_TAG_SETS,
   }));
 }
 
@@ -68,6 +74,12 @@ export function useEnsureTagSetMutation(
     ...withCallbacks<TagSetResponse, Error, EnsureTagSetParams>(
       {
         onError(error) {
+          if (
+            thrownResultErrorHasCode(error, 'UNAUTHORIZED') ||
+            thrownResultErrorHasCode(error, 'FORBIDDEN')
+          ) {
+            return;
+          }
           console.error('Failed to provision tag set', error);
           toast.failure('Failed to set up tags');
         },


### PR DESCRIPTION
Public-link docs with embedded tag-mention links took ~1 min to render for unauthenticated viewers: each mention fired an `ensureTagSet` 401 and the erroring tags query drove a Suspense remount/refetch loop that starved doc render. Viewers no longer provision/apply tags, `useTagsQuery` is auth-gated with `placeholderData` so it never suspense-loops (degrading to "Tags unavailable"), 401/403 aren't retried, and the tag-setup toast is suppressed on auth failure. Verified in an unauthenticated context: doc paints immediately, no loop, no toast.
