### PR TITLE
fix(dynamic-ui): wrap long stat labels instead of clipping

### DIFF
--- a/apps/web/src/features/dynamic-ui/core/Layout.tsx
+++ b/apps/web/src/features/dynamic-ui/core/Layout.tsx
@@ -77,7 +77,15 @@ export function Row(props: {
     <div
       class={cn(
         'flex flex-row',
-        '[&>*]:min-w-0 [&>*]:flex-1',
+        // Non-wrapping rows must always fit their children on one line, so
+        // items are given a zero basis (flex-1) and no min-width floor and
+        // simply shrink evenly to fit. A wrapping row needs the opposite:
+        // items need a real min-width floor so the browser's line-breaking
+        // algorithm can tell when they no longer fit and start a new line,
+        // instead of shrinking indefinitely to stay on one line forever.
+        local.wrap
+          ? '[&>*]:min-w-40 [&>*]:flex-1 [&>*]:basis-40'
+          : '[&>*]:min-w-0 [&>*]:flex-1',
         gapClass(local.gap),
         alignClass(local.align),
         justifyClass(local.justify),

--- a/apps/web/src/features/dynamic-ui/widgets/Stat.tsx
+++ b/apps/web/src/features/dynamic-ui/widgets/Stat.tsx
@@ -16,7 +16,7 @@ const DELTA_GLYPH: Record<'up' | 'down' | 'neutral', string> = {
 export function Stat(props: StatProps) {
   return (
     <div class="w-full gap-1 rounded-lg border border-edge-muted bg-surface p-3">
-      <span class="text-ink-extra-muted text-xxs font-medium uppercase tracking-wide">
+      <span class="text-ink-extra-muted text-xxs font-medium uppercase tracking-wide break-words">
         {props.label}
       </span>
       <div class="flex items-baseline gap-1">


### PR DESCRIPTION
Adds `break-words` to the Stat widget's label so single-word uppercase labels wrap instead of getting clipped when squeezed by the Row layout's min-w-0/flex-1 children (macro-2583).