### PR TITLE
feat(tags): add tag filters to the email view and other taggable views

### DIFF
--- a/apps/web/src/features/entity/composed/list-entity/wide-layout.tsx
+++ b/apps/web/src/features/entity/composed/list-entity/wide-layout.tsx
@@ -189,12 +189,11 @@ export function WideLayout(props: LayoutProps) {
         </Show>
         <Show when={isEmailEntity(props.entity) && props.entity}>
           {(entity) => (
-            // No filter-by-tag affordance. The soup email path does not apply
-            // tag filters, so filtering would leave email rows unfiltered.
-            <EntityRowTags
+            <RowTags
               entityId={entity().id}
               entityType={EntityType.THREAD}
               properties={entity().properties}
+              onFilterByTag={soupView?.filterByTag}
             />
           )}
         </Show>

--- a/apps/web/src/features/next-soup/soup-view/filters-bar/unified-filter-dropdown.tsx
+++ b/apps/web/src/features/next-soup/soup-view/filters-bar/unified-filter-dropdown.tsx
@@ -817,10 +817,11 @@ export const UnifiedFilterDropdown = (
   const isTasksView = () => currentView() === 'tasks';
   const isCompaniesView = () => currentView() === 'companies';
   const isDocumentsView = () => currentView() === 'documents';
+  const isMailView = () => currentView() === 'mail';
 
   const tagFilter = useTagFilter();
   const showTagsFilter = () =>
-    tagFilter.hasTags() && (isTasksView() || isDocumentsView());
+    tagFilter.hasTags() && (isTasksView() || isDocumentsView() || isMailView());
 
   registerHotkey({
     hotkey: 'f',

--- a/apps/web/src/features/next-soup/soup-view/filters-bar/unified-filter-dropdown.tsx
+++ b/apps/web/src/features/next-soup/soup-view/filters-bar/unified-filter-dropdown.tsx
@@ -1,5 +1,5 @@
 import type { ListView } from '@app/constants/list-views';
-import { isListViewID } from '@app/constants/list-views';
+import { isListViewID, TAGGABLE_LIST_VIEWS } from '@app/constants/list-views';
 import {
   type FilterContext,
   NO_ASSIGNEE,
@@ -816,12 +816,12 @@ export const UnifiedFilterDropdown = (
 
   const isTasksView = () => currentView() === 'tasks';
   const isCompaniesView = () => currentView() === 'companies';
-  const isDocumentsView = () => currentView() === 'documents';
-  const isMailView = () => currentView() === 'mail';
 
   const tagFilter = useTagFilter();
-  const showTagsFilter = () =>
-    tagFilter.hasTags() && (isTasksView() || isDocumentsView() || isMailView());
+  const showTagsFilter = () => {
+    const view = currentView();
+    return tagFilter.hasTags() && !!view && TAGGABLE_LIST_VIEWS.has(view);
+  };
 
   registerHotkey({
     hotkey: 'f',

--- a/apps/web/src/features/next-soup/soup-view/filters-bar/use-filter-refinements.tsx
+++ b/apps/web/src/features/next-soup/soup-view/filters-bar/use-filter-refinements.tsx
@@ -1,5 +1,5 @@
 import type { ListView } from '@app/constants/list-views';
-import { isListViewID } from '@app/constants/list-views';
+import { isListViewID, TAGGABLE_LIST_VIEWS } from '@app/constants/list-views';
 import {
   type FilterContext,
   type FilterID,
@@ -683,9 +683,9 @@ export function useFilterRefinements() {
       );
     };
 
-    // Tags chip (consolidated, searchable) for the documents/tasks/mail views.
+    // Tags chip (consolidated, searchable) for every taggable list view.
     const pushTagsConsolidatedChip = () => {
-      if (view !== 'tasks' && view !== 'documents' && view !== 'mail') return;
+      if (!view || !TAGGABLE_LIST_VIEWS.has(view)) return;
       if (!tagFilter.hasTags()) return;
 
       const key = 'tags';

--- a/apps/web/src/features/next-soup/soup-view/filters-bar/use-filter-refinements.tsx
+++ b/apps/web/src/features/next-soup/soup-view/filters-bar/use-filter-refinements.tsx
@@ -683,9 +683,9 @@ export function useFilterRefinements() {
       );
     };
 
-    // Tags chip (consolidated, searchable) for the documents/tasks views.
+    // Tags chip (consolidated, searchable) for the documents/tasks/mail views.
     const pushTagsConsolidatedChip = () => {
-      if (view !== 'tasks' && view !== 'documents') return;
+      if (view !== 'tasks' && view !== 'documents' && view !== 'mail') return;
       if (!tagFilter.hasTags()) return;
 
       const key = 'tags';

--- a/apps/web/src/lib/constants/list-views.ts
+++ b/apps/web/src/lib/constants/list-views.ts
@@ -114,10 +114,10 @@ export const soupItemMatchesTagFilter = (
 
 /**
  * `soupItemMatchesTagFilter` for mapped entities. Rendered rows are checked
- * against the active tag filter because the server only tag-filters the
- * document/chat/project soup unions and the document search leg. Entity types
- * without loaded properties (channels, calls, search-service email results)
- * never match, so they are excluded rather than leaking through unfiltered.
+ * against the active tag filter as a client-side backstop, since the server
+ * does not tag-filter every soup union. Rows carrying loaded properties are
+ * matched on those (emails included); rows without loaded properties never
+ * match, so they are excluded rather than leaking through unfiltered.
  */
 export const entityMatchesTagFilter = (
   entity: EntityData,

--- a/apps/web/src/lib/constants/list-views.ts
+++ b/apps/web/src/lib/constants/list-views.ts
@@ -53,6 +53,20 @@ export const isListViewID = (id: string | null | undefined): id is ListView => {
   return LIST_VIEWS.includes(id as 'inbox');
 };
 
+/**
+ * List views whose entities are taggable, so their filter bar surfaces the tag
+ * filter. Mirrors TAGGABLE_ENTITY_TYPES (document/task/thread/project/chat/
+ * call). Channels, companies, and the mixed inbox are omitted.
+ */
+export const TAGGABLE_LIST_VIEWS: ReadonlySet<ListView> = new Set<ListView>([
+  'documents',
+  'tasks',
+  'mail',
+  'folders',
+  'agents',
+  'calls',
+]);
+
 export const soupItemMatchesListView = (
   item: SoupApiItem,
   view: ListView | undefined


### PR DESCRIPTION
Surface the shared tag filter (dropdown, active chips, and the per-row "Filter by tag" affordance) in the email view, then generalize the gate so every taggable list view shows it — email, calls, chats/agents, and folders, alongside docs/tasks — keyed off a single TAGGABLE_LIST_VIEWS set. Channels and companies stay excluded. The soup and search legs already tag-filter these entities server-side, so this is UI wiring only, with no new flag gating.
