### PR TITLE
fix(dynamic-ui): gate optimistic inserts into AI list widgets by query

### DIFF
--- a/apps/web/src/features/dynamic-ui/widgets/List.tsx
+++ b/apps/web/src/features/dynamic-ui/widgets/List.tsx
@@ -5,6 +5,7 @@ import {
   queryStateFrom,
 } from '@app/features/next-soup/filters/filter-store';
 import type { FieldFilters } from '@app/features/next-soup/filters/filter-store/types';
+import { soupItemMatchesQuery } from '@app/features/next-soup/filters/query-filters';
 import { openEntityInSplitFromUnifiedList } from '@app/features/next-soup/utils';
 import { ListEntityMetadataQueryProvider } from '@entity';
 import { CollapsibleList } from '@entity/components/CollapsibleList';
@@ -140,11 +141,23 @@ function Rows(props: {
   // and return nothing — which is the correct "No items." outcome anyway.
   // `groupBy` orders the returned entities by the requested facet (the grouped
   // select flattens groups into `data.entities` in group order).
-  const itemsQuery = useSoupAstItemsQuery(() => ({
-    params: { limit: 200 },
-    body: compileQuery(query()),
-    groupBy: props.groupBy ? GROUP_BY_BY_NAME[props.groupBy] : undefined,
-  }));
+  const itemsQuery = useSoupAstItemsQuery(
+    () => ({
+      params: { limit: 200 },
+      body: compileQuery(query()),
+      groupBy: props.groupBy ? GROUP_BY_BY_NAME[props.groupBy] : undefined,
+    }),
+    () => {
+      // Unlike the soup view, this query has no client `itemFilter`, so the
+      // normalized cache would prepend ANY optimistically/WS-inserted entity
+      // into it (a new task landing in an email-scoped list, etc.). Gate inserts
+      // on the same `Query` that produced the AST so only matching items appear.
+      const source = query();
+      return {
+        meta: { itemFilter: (item) => soupItemMatchesQuery(item, source) },
+      };
+    }
+  );
 
   const entities = createMemo<EntityData[]>(() => {
     const all = itemsQuery.data?.entities ?? [];

--- a/apps/web/src/features/next-soup/filters/query-filters.test.ts
+++ b/apps/web/src/features/next-soup/filters/query-filters.test.ts
@@ -1,0 +1,79 @@
+import type { SoupApiItem } from '@service-storage/generated/schemas';
+import { describe, expect, it } from 'vitest';
+import type { Query } from './filter-store/types';
+import { soupItemMatchesQuery } from './query-filters';
+
+const documentItem = (id: string, overrides: object = {}): SoupApiItem =>
+  ({ tag: 'document', data: { id, ...overrides } }) as unknown as SoupApiItem;
+
+const emailItem = (id: string): SoupApiItem =>
+  ({ tag: 'emailThread', data: { id } }) as unknown as SoupApiItem;
+
+const chatItem = (id: string): SoupApiItem =>
+  ({ tag: 'chat', data: { id } }) as unknown as SoupApiItem;
+
+describe('soupItemMatchesQuery', () => {
+  it('rejects entity types the query never references (nil-fill gating)', () => {
+    // An email-scoped list: only threadId is referenced, everything else is
+    // nil-filled by defineQueryFilters.
+    const query: Query = { include: { threadId: ['thread-1'] } };
+
+    expect(soupItemMatchesQuery(emailItem('thread-1'), query)).toBe(true);
+    // A freshly created task/doc must NOT leak into an email-scoped list.
+    expect(soupItemMatchesQuery(documentItem('doc-1'), query)).toBe(false);
+    expect(soupItemMatchesQuery(chatItem('chat-1'), query)).toBe(false);
+  });
+
+  it('honors explicit id lists (items-mode refs)', () => {
+    const query: Query = { include: { documentId: ['doc-1', 'doc-2'] } };
+
+    expect(soupItemMatchesQuery(documentItem('doc-1'), query)).toBe(true);
+    expect(soupItemMatchesQuery(documentItem('doc-2'), query)).toBe(true);
+    expect(soupItemMatchesQuery(documentItem('doc-3'), query)).toBe(false);
+    expect(soupItemMatchesQuery(emailItem('thread-1'), query)).toBe(false);
+  });
+
+  it('accepts any in-type item when the type is scoped by a non-id field', () => {
+    // Referencing the document target via owner keeps documentId un-nil-filled,
+    // so a new document owned by that user still matches optimistically.
+    const query: Query = { include: { documentOwnerId: ['macro|me@x.com'] } };
+
+    expect(
+      soupItemMatchesQuery(
+        documentItem('doc-new', { ownerId: 'macro|me@x.com' }),
+        query
+      )
+    ).toBe(true);
+    expect(
+      soupItemMatchesQuery(
+        documentItem('doc-other', { ownerId: 'macro|other@x.com' }),
+        query
+      )
+    ).toBe(false);
+    expect(soupItemMatchesQuery(emailItem('thread-1'), query)).toBe(false);
+  });
+
+  it('filters documents by sub type', () => {
+    const query: Query = { include: { subType: ['task'] } };
+
+    expect(
+      soupItemMatchesQuery(
+        documentItem('doc-task', { subType: { type: 'task' } }),
+        query
+      )
+    ).toBe(true);
+    expect(
+      soupItemMatchesQuery(
+        documentItem('doc-note', { subType: { type: 'note' } }),
+        query
+      )
+    ).toBe(false);
+  });
+
+  it('rejects everything for an empty items-mode query', () => {
+    const query: Query = { include: {} };
+
+    expect(soupItemMatchesQuery(documentItem('doc-1'), query)).toBe(false);
+    expect(soupItemMatchesQuery(emailItem('thread-1'), query)).toBe(false);
+  });
+});

--- a/apps/web/src/features/next-soup/filters/query-filters.test.ts
+++ b/apps/web/src/features/next-soup/filters/query-filters.test.ts
@@ -6,6 +6,17 @@ import { soupItemMatchesQuery } from './query-filters';
 const documentItem = (id: string, overrides: object = {}): SoupApiItem =>
   ({ tag: 'document', data: { id, ...overrides } }) as unknown as SoupApiItem;
 
+const taggedTaskItem = (id: string, optionIds: string[]): SoupApiItem =>
+  documentItem(id, {
+    subType: { type: 'task' },
+    properties: optionIds.map((optionId) => ({
+      value: { type: 'SelectOption', value: [optionId] },
+    })),
+  });
+
+const taskItem = (id: string): SoupApiItem =>
+  documentItem(id, { subType: { type: 'task' } });
+
 const emailItem = (id: string): SoupApiItem =>
   ({ tag: 'emailThread', data: { id } }) as unknown as SoupApiItem;
 
@@ -75,5 +86,47 @@ describe('soupItemMatchesQuery', () => {
 
     expect(soupItemMatchesQuery(documentItem('doc-1'), query)).toBe(false);
     expect(soupItemMatchesQuery(emailItem('thread-1'), query)).toBe(false);
+  });
+
+  it('enforces an active tag filter within the scoped type', () => {
+    // A task list scoped to a single tag option: a freshly created untagged
+    // task is in-type but must not leak into a tag-scoped list.
+    const query: Query = {
+      include: {
+        subType: ['task'],
+        tagFilters: [{ propertyId: 'def-1', type: 'select', value: 'opt-1' }],
+      },
+    };
+
+    expect(
+      soupItemMatchesQuery(taggedTaskItem('doc-tagged', ['opt-1']), query)
+    ).toBe(true);
+    expect(soupItemMatchesQuery(taskItem('doc-untagged'), query)).toBe(false);
+    expect(
+      soupItemMatchesQuery(taggedTaskItem('doc-other-tag', ['opt-2']), query)
+    ).toBe(false);
+  });
+
+  it('requires every option under tagFilterMode "all"', () => {
+    const query: Query = {
+      include: {
+        subType: ['task'],
+        tagFilterMode: 'all',
+        tagFilters: [
+          { propertyId: 'def-1', type: 'select', value: 'opt-1' },
+          { propertyId: 'def-2', type: 'select', value: 'opt-2' },
+        ],
+      },
+    };
+
+    expect(
+      soupItemMatchesQuery(
+        taggedTaskItem('doc-both', ['opt-1', 'opt-2']),
+        query
+      )
+    ).toBe(true);
+    expect(
+      soupItemMatchesQuery(taggedTaskItem('doc-one', ['opt-1']), query)
+    ).toBe(false);
   });
 });

--- a/apps/web/src/features/next-soup/filters/query-filters.ts
+++ b/apps/web/src/features/next-soup/filters/query-filters.ts
@@ -1,3 +1,4 @@
+import { soupItemMatchesTagFilter } from '@app/constants/list-views';
 import type { SoupBody, SoupItemsQueryFilters } from '@queries/soup/items';
 import type { SoupApiItem } from '@service-storage/generated/schemas';
 import { match } from 'ts-pattern';
@@ -203,16 +204,32 @@ function queryIncludeToRequestBody(query: Query): SoupBody {
  * id filters of every entity type the query never references — so an item whose
  * type is out of scope (e.g. a newly created task inserted into an email-scoped
  * widget) carries a real id against a `[NIL_UUID]` filter and is rejected, the
- * same way the server would never return it.
+ * same way the server would never return it. An active tag filter is enforced
+ * too, reusing {@link soupItemMatchesTagFilter} (the same gate the soup view
+ * applies), so a newly created untagged item never leaks into a tag-scoped list.
  *
- * Refinements the server also applies but this does not — tags/properties, date
- * ranges, seen/done, importance, `documentWhere`, `emailView`, and every
- * `exclude` clause — are treated permissively: a matching item is never
- * rejected for them, so inserts that DO belong still appear optimistically.
+ * Refinements the server also applies but this does not — non-tag
+ * properties, date ranges, seen/done, importance, `documentWhere`, `emailView`,
+ * and every `exclude` clause — are treated permissively: a matching item is
+ * never rejected for them, so inserts that DO belong still appear optimistically.
  */
 export function soupItemMatchesQuery(item: SoupApiItem, query: Query): boolean {
-  return filterSoupItemByRequestBody(
-    item,
-    queryIncludeToRequestBody(defineQueryFilters(query))
+  if (
+    !filterSoupItemByRequestBody(
+      item,
+      queryIncludeToRequestBody(defineQueryFilters(query))
+    )
+  ) {
+    return false;
+  }
+
+  const tagOptionIds = (query.include?.tagFilters ?? []).map((t) => t.value);
+  return (
+    tagOptionIds.length === 0 ||
+    soupItemMatchesTagFilter(
+      item,
+      tagOptionIds,
+      query.include?.tagFilterMode ?? 'any'
+    )
   );
 }

--- a/apps/web/src/features/next-soup/filters/query-filters.ts
+++ b/apps/web/src/features/next-soup/filters/query-filters.ts
@@ -1,7 +1,12 @@
 import type { SoupBody, SoupItemsQueryFilters } from '@queries/soup/items';
 import type { SoupApiItem } from '@service-storage/generated/schemas';
 import { match } from 'ts-pattern';
-import { type CallStatus, callStatusFromAttended } from './filter-store/types';
+import { defineQueryFilters } from './filter-store/compile';
+import {
+  type CallStatus,
+  callStatusFromAttended,
+  type Query,
+} from './filter-store/types';
 
 const NIL_UUID = '00000000-0000-0000-0000-000000000000';
 
@@ -148,4 +153,66 @@ export function filterSoupItemByRequestBody(
         )
     )
     .exhaustive();
+}
+
+/**
+ * Map a filter-store {@link Query}'s `include` clause onto the request-body
+ * filter shape {@link filterSoupItemByRequestBody} understands. Only the id and
+ * scoping fields that matcher reads are mapped; everything else is left off (see
+ * {@link soupItemMatchesQuery}).
+ */
+function queryIncludeToRequestBody(query: Query): SoupBody {
+  const include = query.include ?? {};
+  return {
+    document_filters: {
+      document_ids: include.documentId,
+      owners: include.documentOwnerId,
+      sub_types: include.subType,
+    },
+    chat_filters: { chat_ids: include.chatId },
+    channel_filters: {
+      channel_ids: include.channelId,
+      thread_ids: include.channelMessageThreadId,
+    },
+    channel_thread_filters: {
+      thread_ids: include.channelThreadId,
+      root_sender_ids: include.channelThreadRootSenderId,
+    },
+    project_filters: { project_ids: include.folderId },
+    email_filters: { email_thread_ids: include.threadId },
+    call_filters: {
+      call_ids: include.callId,
+      status: include.callStatus,
+      attended: include.callAttended,
+    },
+    crm_company_filters: { company_ids: include.crmCompanyId },
+    foreign_entity_filters: {
+      ids: include.foreignEntityRecordId,
+      foreign_entity_sources: include.foreignEntitySource,
+    },
+  };
+}
+
+/**
+ * Whether a soup item satisfies a filter-store {@link Query}, mirroring the
+ * include-side entity/id/owner scoping the server AST enforces. Used to gate
+ * optimistic and websocket cache inserts for queries that drive a list from a
+ * raw `Query` (e.g. the dynamic-UI `list` widget) rather than a soup view.
+ *
+ * The query is first run through {@link defineQueryFilters}, which nil-fills the
+ * id filters of every entity type the query never references — so an item whose
+ * type is out of scope (e.g. a newly created task inserted into an email-scoped
+ * widget) carries a real id against a `[NIL_UUID]` filter and is rejected, the
+ * same way the server would never return it.
+ *
+ * Refinements the server also applies but this does not — tags/properties, date
+ * ranges, seen/done, importance, `documentWhere`, `emailView`, and every
+ * `exclude` clause — are treated permissively: a matching item is never
+ * rejected for them, so inserts that DO belong still appear optimistically.
+ */
+export function soupItemMatchesQuery(item: SoupApiItem, query: Query): boolean {
+  return filterSoupItemByRequestBody(
+    item,
+    queryIncludeToRequestBody(defineQueryFilters(query))
+  );
 }

--- a/apps/web/src/lib/queries/soup/normalized-cache/operations.test.ts
+++ b/apps/web/src/lib/queries/soup/normalized-cache/operations.test.ts
@@ -536,9 +536,11 @@ describe('optimisticUpdateSoupItemUpdatedAt', () => {
 
 // -- Normalized grouped cache tests --
 
+import type { Query } from '@app/features/next-soup/filters/filter-store/types';
+import { soupItemMatchesQuery } from '@app/features/next-soup/filters/query-filters';
 import type { GroupByField, GroupMeta } from '../grouped/types';
 import { NOT_SET_GROUP_KEY } from '../grouped/types';
-import type { SoupAstItemsGroupedPage } from '../items';
+import type { SoupAstItemsFlatPage, SoupAstItemsGroupedPage } from '../items';
 
 const STATUS_DEF = 'status-def-id';
 const STATUS_GROUP_BY: GroupByField = {
@@ -898,5 +900,63 @@ describe('optimisticUpdateSoupEntity — parent item filter gate', () => {
     const notSet = page.groups.find((g) => g.key === NOT_SET_GROUP_KEY)!;
     expect(notSet.itemIds).toEqual([]);
     expect(notSet.totalCount).toBe(0);
+  });
+});
+
+/**
+ * End-to-end gate for the dynamic-UI `list` widget (macro-2587): the widget
+ * drives a flat astItems query from a raw `Query` and now attaches
+ * `soupItemMatchesQuery` as its `itemFilter`. Without it, any optimistic insert
+ * (e.g. creating a task) prepended into an email-scoped list's cache.
+ */
+describe('insertSoupEntity — dynamic-ui list query gate', () => {
+  function seedFlatAstQueryWithFilter(
+    items: SoupApiItem[],
+    query: Query,
+    suffix = 'widget-seed'
+  ) {
+    const key = [...soupKeys.astItems._def, {}, {}, undefined, suffix];
+    const data: InfiniteData<SoupAstItemsFlatPage, unknown> = {
+      pages: [{ kind: 'flat', items, nextCursor: null }],
+      pageParams: [null],
+    };
+    testQueryClient.setQueryDefaults(key, {
+      meta: {
+        itemFilter: (item: SoupApiItem) => soupItemMatchesQuery(item, query),
+      },
+    });
+    testQueryClient.setQueryData(key, data);
+    return key;
+  }
+
+  const emailScopedQuery: Query = { include: { threadId: ['e-1'] } };
+
+  it('rejects a newly created task from an email-scoped list', () => {
+    const key = seedFlatAstQueryWithFilter(
+      [mockEmailItem('e-1')],
+      emailScopedQuery
+    );
+
+    insertSoupEntity(mockTaskItem('task-new', 'in_progress'));
+
+    const page =
+      testQueryClient.getQueryData<InfiniteData<SoupAstItemsFlatPage, unknown>>(
+        key
+      )!.pages[0];
+    expect(page.items.map(getSoupItemId)).toEqual(['e-1']);
+  });
+
+  it('still inserts a matching email optimistically', () => {
+    const key = seedFlatAstQueryWithFilter([mockEmailItem('e-1')], {
+      include: { threadId: ['e-1', 'e-2'] },
+    });
+
+    insertSoupEntity(mockEmailItem('e-2'));
+
+    const page =
+      testQueryClient.getQueryData<InfiniteData<SoupAstItemsFlatPage, unknown>>(
+        key
+      )!.pages[0];
+    expect(page.items.map(getSoupItemId)).toEqual(['e-2', 'e-1']);
   });
 });


### PR DESCRIPTION
The dynamic-UI List widget drove its soup query with no client `itemFilter`, so the normalized cache prepended any optimistically/WS-inserted entity into it (e.g. a new task showing up in an email-scoped list). It now attaches an `itemFilter` derived from the same `Query` that produced the AST, reusing `filterSoupItemByRequestBody` and `defineQueryFilters`' nil-fills to reject out-of-scope items while still admitting matching ones optimistically.
