### PR TITLE
fix(notifications): say "task" not "document" when a shared entity is a task

### DIFF
--- a/apps/web/src/features/notifications/notification-metadata.ts
+++ b/apps/web/src/features/notifications/notification-metadata.ts
@@ -7,7 +7,17 @@ import type { UnifiedNotification } from './types';
 export function getNotificationAction(n: UnifiedNotification): string {
   return match(n.notification_metadata.tag)
     .with('channel_mention', () => 'mentioned you in')
-    .with('document_mention', () => 'sent a document')
+    .with('document_mention', () => {
+      const meta = n.notification_metadata;
+      if (
+        meta.tag === 'document_mention' &&
+        meta.content.subType?.type === 'task'
+      ) {
+        return 'sent a task';
+      }
+
+      return 'sent a document';
+    })
     .with('mentioned_in_document_comment', () => 'mentioned you in')
     .with('replied_to_document_comment_thread', () => 'replied in')
     .with('commented_on_document', () => 'commented on')

--- a/crates/model_notifications/src/metadata.rs
+++ b/crates/model_notifications/src/metadata.rs
@@ -777,7 +777,11 @@ impl NotificationTitle for DocumentMentionMetadata {
             .map(|sender| sender.0.email_part().email_str().to_string())
             .or_else(|| self.channel.sender_display_name.clone())
             .ok_or_else(|| report!("Expected sender id to exist for {:?}", &self))?;
-        Ok(format!("{sender} sent a document",))
+        let noun = match self.sub_type {
+            Some(NotificationDocumentSubType::Task) => "task",
+            _ => "document",
+        };
+        Ok(format!("{sender} sent a {noun}"))
     }
 
     fn format_body(

--- a/crates/model_notifications/src/metadata/test.rs
+++ b/crates/model_notifications/src/metadata/test.rs
@@ -570,6 +570,44 @@ fn channel_mention_title_falls_back_to_bot_display_name() {
     assert_eq!(title, "Helper Bot mentioned you in #general");
 }
 
+fn document_mention(sub_type: Option<NotificationDocumentSubType>) -> DocumentMentionMetadata {
+    DocumentMentionMetadata {
+        document_name: "Q3 plan".to_string(),
+        owner: uid("macro|owner@macro.com"),
+        file_type: Some("md".to_string()),
+        sub_type,
+        channel: ChannelMentionMetadata {
+            message_id: Uuid::nil().to_string(),
+            message_content: "check this out".to_string(),
+            has_attachments: false,
+            thread_id: None,
+            sender_display_name: None,
+            common: CommonChannelMetadata {
+                channel_type: ChannelType::Public,
+                channel_name: "general".to_string(),
+            },
+            sender_profile_picture_url: None,
+        },
+    }
+}
+
+#[test]
+fn document_mention_title_says_task_for_task_sub_type() {
+    let task = document_mention(Some(NotificationDocumentSubType::Task));
+    let doc = document_mention(None);
+
+    assert_eq!(
+        task.format_title(Some(uid("macro|sender@macro.com")))
+            .unwrap(),
+        "sender@macro.com sent a task"
+    );
+    assert_eq!(
+        doc.format_title(Some(uid("macro|sender@macro.com")))
+            .unwrap(),
+        "sender@macro.com sent a document"
+    );
+}
+
 #[test]
 fn channel_message_send_legacy_json_deserializes_with_required_sender() {
     let legacy: ChannelMessageSendMetadata = serde_json::from_value(serde_json::json!({


### PR DESCRIPTION
## Summary

- Fixes: the push notification (and in-app notification list) title for a shared task reads "`<user>` sent a document" instead of "sent a task".
- Root cause: `DocumentMentionMetadata` already carries `sub_type`/`subType` (`Task` vs `Snippet`) — it's used elsewhere for navigation (routing to the `task` block instead of raw `md`) — but both the server-side `format_title` (used for push notifications) and the frontend's `getNotificationAction` (used for the in-app notification list) hardcoded "sent a document" regardless of `sub_type`.
- Fix: branch on `sub_type`/`subType` in both places, matching the existing pattern used for `github_pr_check_run`'s state-dependent title in the same frontend file.

MACRO-2592

## Why prioritized

Reported by Aidan in bug-reports: "My phone notifications when someone shares a task has the title '\<user\> sent a document...' should probably say 'task'". Small, mechanical, single root cause, no existing task/PR in flight.

## Test plan

- [x] Added a Rust unit test (`document_mention_title_says_task_for_task_sub_type`) covering both the task and non-task cases for `format_title`.
- [x] `cargo test -p model_notifications` — 26 passed, 0 failed.
- [x] `cargo fmt -p model_notifications -- --check` clean.
- [ ] Reviewer: share a task with someone and confirm the phone/desktop notification says "sent a task".

I couldn't type-check/run the frontend (`bun install` fails in this sandbox on the private `tauri-plugins`/`pdf.js` git deps), so the frontend half of this fix is unverified beyond manual inspection — it's a 10-line, same-shape-as-existing-code change, but please give it a look.

---
_Generated by [Claude Code](https://claude.ai/code/session_015VGJqDsCG19in95rxzemZm)_