### PR TITLE
fix(channels): bot-authored messages don't trigger mention notifications in document_cognition_service

### DIFF
--- a/crates/channels/src/domain/service.rs
+++ b/crates/channels/src/domain/service.rs
@@ -14,9 +14,9 @@ use crate::domain::{
         WithChannelId,
     },
     ports::{
-        ChannelAttachmentsPage, ChannelEventDispatcher, ChannelMentionExtractor,
-        ChannelMessagesErr, ChannelMessagesQueryResult, ChannelMutationErr,
-        ChannelReferenceSharePermissions, ChannelRepo, ChannelService,
+        ChannelAttachmentsPage, ChannelContactsDispatcher, ChannelEventDispatcher,
+        ChannelMentionExtractor, ChannelMessagesErr, ChannelMessagesQueryResult,
+        ChannelMutationErr, ChannelReferenceSharePermissions, ChannelRepo, ChannelService,
     },
 };
 use bot_id::BotIdStr;
@@ -67,6 +67,22 @@ impl ChannelReferenceSharePermissions for NoopChannelReferenceSharePermissions {
         _actor: MacroUserIdStr<'static>,
         _channel_id: Uuid,
         _items: Vec<ReferencedShareItem>,
+    ) -> Result<(), Self::Err> {
+        Ok(())
+    }
+}
+
+/// No-op contacts dispatcher used by hosts that don't have a contacts ingress
+/// client wired (e.g. hosts that only need channel notifications/realtime).
+#[derive(Debug, Clone, Copy, Default)]
+pub struct NoopChannelContactsDispatcher;
+
+impl ChannelContactsDispatcher for NoopChannelContactsDispatcher {
+    type Err = anyhow::Error;
+
+    async fn enqueue_contacts(
+        &self,
+        _users: HashSet<MacroUserIdStr<'static>>,
     ) -> Result<(), Self::Err> {
         Ok(())
     }

--- a/crates/channels/src/domain/side_effects/test.rs
+++ b/crates/channels/src/domain/side_effects/test.rs
@@ -894,6 +894,89 @@ async fn document_mentions_notify_participants_except_sender() {
     assert!(!document_recipients.contains(&sender));
 }
 
+#[tokio::test]
+async fn bot_message_with_user_mention_sends_mention_notification() {
+    // Regression test for a bug where AI/agent-posted channel messages that
+    // @-mentioned a user did not notify the mentioned user: some hosts wired
+    // `ChannelServiceImpl` with a no-op `ChannelEventDispatcher`, so
+    // `ChannelEvent::MessagePosted` was never handed to this side-effect
+    // service and `handle_message_posted` (below) never ran. This test
+    // exercises the notification-derivation logic this service owns, using a
+    // bot sender to confirm it dispatches a mention notification exactly like
+    // it does for a human sender (mirrors
+    // `document_mentions_notify_participants_except_sender` above).
+    let channel_id = Uuid::new_v4();
+    let message_id = Uuid::new_v4();
+    let mentioned = user("mentioned@example.com");
+    let other = user("other@example.com");
+    let notifications = FakeNotifications::default();
+    let service = ChannelSideEffectService::new(
+        FakeContext::default(),
+        FakeRealtime::default(),
+        notifications.clone(),
+        FakeSearch::default(),
+        FakeContacts::default(),
+    );
+    let now = Utc::now();
+
+    service
+        .handle(ChannelEvent::MessagePosted {
+            channel_id,
+            metadata: ChannelMetadata {
+                channel_type: ChannelType::Private,
+                channel_name: "Project".to_string(),
+            },
+            participants: vec![
+                ChannelParticipant {
+                    channel_id,
+                    user_id: mentioned.as_ref().to_string(),
+                    role: ParticipantRole::Member,
+                    joined_at: now,
+                    left_at: None,
+                },
+                ChannelParticipant {
+                    channel_id,
+                    user_id: other.as_ref().to_string(),
+                    role: ParticipantRole::Member,
+                    joined_at: now,
+                    left_at: None,
+                },
+            ],
+            message: MutatedMessage {
+                id: message_id,
+                channel_id,
+                thread_id: None,
+                sender_id: Sender::new_from_bot(BotId::new_from_uuid(Uuid::new_v4())),
+                triggered_by: None,
+                content: "hello @mentioned".to_string(),
+                created_at: now,
+                updated_at: now,
+                edited_at: None,
+                deleted_at: None,
+            },
+            mentions: vec![SimpleMention {
+                entity_type: "user".to_string(),
+                entity_id: mentioned.as_ref().to_string(),
+            }],
+            has_attachments: false,
+            attachments: Vec::new(),
+            nonce: None,
+            notification_policy: PostMessageNotificationPolicy::Default,
+        })
+        .await;
+
+    let notification_effects = notifications.effects.lock().unwrap();
+    let mention_recipients = notification_effects
+        .iter()
+        .find_map(|effect| match effect {
+            ChannelNotificationEffect::UserMention { recipient_ids, .. } => Some(recipient_ids),
+            _ => None,
+        })
+        .expect("expected a user mention notification to be enqueued");
+    assert!(mention_recipients.contains(&mentioned));
+    assert!(!mention_recipients.contains(&other));
+}
+
 #[test]
 fn contact_sync_is_derived_from_private_channel_created() {
     let event = ChannelEvent::ChannelCreated {

--- a/services/document_cognition_service/src/main.rs
+++ b/services/document_cognition_service/src/main.rs
@@ -7,7 +7,17 @@ use call::inbound::toolset::CallToolContext;
 use call::outbound::pg_call_repo::PgCallRepo;
 use call::outbound::s3_recording_storage::S3RecordingStorage;
 use channels::{
-    domain::list_service::ChannelListServiceImpl, outbound::pg_channels_repo::PgChannelsRepo,
+    domain::{
+        list_service::ChannelListServiceImpl,
+        service::NoopChannelContactsDispatcher,
+        side_effects::{ChannelSideEffectService, SpawnedChannelEventDispatcher},
+    },
+    outbound::{
+        connection_gateway_realtime::ConnectionGatewayChannelRealtimePublisher,
+        notification_sender::NotificationChannelSender, pg_channels_repo::PgChannelsRepo,
+        pg_side_effect_context::PgChannelSideEffectContext,
+        sqs_search_indexer::SqsChannelSearchIndexer,
+    },
 };
 use config::{Config, Environment};
 use document_storage_service_client::DocumentStorageServiceClient;
@@ -420,8 +430,29 @@ async fn main() -> anyhow::Result<()> {
 
     tracing::info!("initialized chat tool context");
 
-    let channel_tool_context =
-        ai_tools::build_channel_tool_context(db.clone(), lexical_client.clone());
+    // Wire channel message posting to real side effects (notifications,
+    // realtime, search indexing) so AI/agent flows that post channel messages
+    // through this host (e.g. document cognition tools) notify mentioned
+    // users the same way the in-app Macro AI channel bot does. Contact-graph
+    // sync is intentionally a no-op here: this host doesn't have a contacts
+    // ingress client wired.
+    let channel_gateway_client = Arc::new(connection_gateway_client::ConnectionGatewayClient::new(
+        internal_api_key.clone(),
+        ConnectionGatewayUrl::new()?.to_string(),
+    ));
+    let channel_side_effects = ChannelSideEffectService::new(
+        PgChannelSideEffectContext::new(db.clone()),
+        ConnectionGatewayChannelRealtimePublisher::new(channel_gateway_client),
+        NotificationChannelSender::new(notification_ingress_service.clone()),
+        SqsChannelSearchIndexer::new(Arc::new(sqs_client.clone())),
+        NoopChannelContactsDispatcher,
+    )
+    .with_macro_event_broker(macro_event_broker.clone());
+    let channel_tool_context = ai_tools::build_channel_tool_context_with_dispatcher(
+        db.clone(),
+        Arc::new(SpawnedChannelEventDispatcher::new(channel_side_effects)),
+        lexical_client.clone(),
+    );
     let recorder = ai_usage::pg_recorder(db.clone());
 
     // The import pipeline: staged/imported external items, gather jobs over


### PR DESCRIPTION
## Bug

Reported by peter@macro.com in #bug-reports, escalated by hutch@macro.com: when an AI agent/bot posts a channel message that @-mentions a user, the mentioned user never gets a notification. Human-sent messages with mentions notify correctly.

## Root cause

Mention detection and notification-eligibility logic is sender-agnostic and correct (`crates/channels/src/domain/side_effects.rs`, `send_user_mention_notifications`) — not the bug.

`ChannelServiceImpl::post_message` (`crates/channels/src/domain/service.rs`) triggers notifications by dispatching `ChannelEvent::MessagePosted`, but whether that does anything depends on which `ChannelEventDispatcher` was wired in when the service was built. `ai_tools::build_channel_tool_context` defaults to a `NoopChannelEventDispatcher` whose `dispatch()` is a no-op — mentions are still parsed and persisted to `entity_mentions`, but `ChannelSideEffectService::handle_message_posted` never runs, so no notification is enqueued.

`document_storage_service` is the only host that overrides this default (it wires a real `ChannelSideEffectService` via `build_channel_tool_context_with_dispatcher`), which is why the in-app Macro AI channel bot notifies correctly. `document_cognition_service` did not, so AI/agent flows posting channel messages through that host silently dropped mention notifications.

(Two other affected hosts — `mcp_service` and `crates/memory` — are **not** touched by this PR; they need new infra/Doppler config and a product decision respectively, and are tracked separately for manual follow-up.)

## Fix

- `crates/channels/src/domain/service.rs`: add `NoopChannelContactsDispatcher`, mirroring the existing `Noop*` dispatchers, for hosts without a contacts-ingress client wired.
- `services/document_cognition_service/src/main.rs`: build a real `ChannelSideEffectService` from clients this service already constructs (connection gateway, notification ingress, SQS, macro event broker), pair it with `NoopChannelContactsDispatcher`, and switch to `build_channel_tool_context_with_dispatcher(...)`, matching the existing pattern in `document_storage_service/src/main.rs`.
- `crates/channels/src/domain/side_effects/test.rs`: add a regression test, `bot_message_with_user_mention_sends_mention_notification`, mirroring the existing human-sender mention test but with a bot sender.

## Testing

- `cargo check -p document_cognition_service -p channels` (SQLX_OFFLINE=true): clean
- `cargo test -p channels --all-features` against live Postgres: 234 passed, 0 failed (includes the new regression test)
- `cargo test -p document_cognition_service` against live Postgres: 21 passed, 1 pre-existing ignored, 0 failed
- `cargo fmt -p channels -p document_cognition_service -- --check`: clean
- `cargo clippy -p document_cognition_service -p channels --all-features` (with repo's `-Dwarnings -Dclippy::disallowed_methods`): clean

Full-workspace `just clippy` was not run (scoped clippy on just these two crates already took ~8.5 min to compile); happy to run it if wanted.

---
_Generated by [Claude Code](https://claude.ai/code/session_013Y2t6tJ1898pVS7KamMhaU)_