### PR TITLE
fix(soup): read for notifications throwing error

### DIFF
--- a/apps/web/src/features/next-soup/filters/predicates.ts
+++ b/apps/web/src/features/next-soup/filters/predicates.ts
@@ -21,7 +21,12 @@ function getPredicateNotifications(
 ) {
   const attachedNotifications = (entity as WithNotification<EntityData>)
     .notifications;
-  if (attachedNotifications) return attachedNotifications();
+
+  if (typeof attachedNotifications === 'function') {
+    return attachedNotifications();
+  }
+
+  if (Array.isArray(attachedNotifications)) return attachedNotifications;
 
   return notificationSource.notificationsByEntity()[
     compositeEntity(toNotificationEntity(entity))


### PR DESCRIPTION
Caused by search using quick access entities which have notifications attached to them but are not functions like the soup. Ideally we'll move to the no function approach eventually for soup as well