### PR TITLE
fix(next-soup): gate folder block optimistic inserts by project membership

### DIFF
--- a/apps/web/src/features/block-project/component/Block.tsx
+++ b/apps/web/src/features/block-project/component/Block.tsx
@@ -4,6 +4,7 @@ import {
   type SoupState,
 } from '@app/features/next-soup/create-soup-state';
 import { defineQueryFilters } from '@app/features/next-soup/filters/filter-store';
+import { soupItemMatchesProjectMembership } from '@app/features/next-soup/filters/query-filters';
 import { SoupContextProvider } from '@app/features/next-soup/soup-context';
 import { SoupViewList } from '@app/features/next-soup/soup-view/soup-view';
 import { SoupViewContextProvider } from '@app/features/next-soup/soup-view/soup-view-context';
@@ -206,6 +207,11 @@ const ProjectEntityList = (props: {
       <SoupViewContextProvider
         soup={props.soup}
         initialEnabled
+        itemMembershipFilter={
+          getIsSpecialProject(props.projectId)
+            ? undefined
+            : (item) => soupItemMatchesProjectMembership(item, props.projectId)
+        }
         initialQuery={defineQueryFilters({
           include: {
             // Filter documents by project

--- a/apps/web/src/features/next-soup/filters/query-filters.test.ts
+++ b/apps/web/src/features/next-soup/filters/query-filters.test.ts
@@ -1,7 +1,10 @@
 import type { SoupApiItem } from '@service-storage/generated/schemas';
 import { describe, expect, it } from 'vitest';
 import type { Query } from './filter-store/types';
-import { soupItemMatchesQuery } from './query-filters';
+import {
+  soupItemMatchesProjectMembership,
+  soupItemMatchesQuery,
+} from './query-filters';
 
 const documentItem = (id: string, overrides: object = {}): SoupApiItem =>
   ({ tag: 'document', data: { id, ...overrides } }) as unknown as SoupApiItem;
@@ -20,8 +23,11 @@ const taskItem = (id: string): SoupApiItem =>
 const emailItem = (id: string): SoupApiItem =>
   ({ tag: 'emailThread', data: { id } }) as unknown as SoupApiItem;
 
-const chatItem = (id: string): SoupApiItem =>
-  ({ tag: 'chat', data: { id } }) as unknown as SoupApiItem;
+const chatItem = (id: string, overrides: object = {}): SoupApiItem =>
+  ({ tag: 'chat', data: { id, ...overrides } }) as unknown as SoupApiItem;
+
+const projectItem = (id: string, overrides: object = {}): SoupApiItem =>
+  ({ tag: 'project', data: { id, ...overrides } }) as unknown as SoupApiItem;
 
 describe('soupItemMatchesQuery', () => {
   it('rejects entity types the query never references (nil-fill gating)', () => {
@@ -128,5 +134,78 @@ describe('soupItemMatchesQuery', () => {
     expect(
       soupItemMatchesQuery(taggedTaskItem('doc-one', ['opt-1']), query)
     ).toBe(false);
+  });
+});
+
+describe('soupItemMatchesProjectMembership', () => {
+  const PROJECT = 'proj-1';
+
+  it('gates documents by their projectId', () => {
+    expect(
+      soupItemMatchesProjectMembership(
+        documentItem('doc-in', { projectId: PROJECT }),
+        PROJECT
+      )
+    ).toBe(true);
+    // A task created/opened outside the folder must not leak in.
+    expect(
+      soupItemMatchesProjectMembership(
+        documentItem('doc-other', { projectId: 'proj-2' }),
+        PROJECT
+      )
+    ).toBe(false);
+    // Root-level documents carry no project.
+    expect(
+      soupItemMatchesProjectMembership(
+        documentItem('doc-root', { projectId: null }),
+        PROJECT
+      )
+    ).toBe(false);
+    expect(
+      soupItemMatchesProjectMembership(documentItem('doc-none'), PROJECT)
+    ).toBe(false);
+  });
+
+  it('gates chats by their projectId', () => {
+    expect(
+      soupItemMatchesProjectMembership(
+        chatItem('chat-in', { projectId: PROJECT }),
+        PROJECT
+      )
+    ).toBe(true);
+    expect(
+      soupItemMatchesProjectMembership(
+        chatItem('chat-other', { projectId: 'proj-2' }),
+        PROJECT
+      )
+    ).toBe(false);
+  });
+
+  it('gates child projects by their parentId', () => {
+    expect(
+      soupItemMatchesProjectMembership(
+        projectItem('sub-in', { parentId: PROJECT }),
+        PROJECT
+      )
+    ).toBe(true);
+    expect(
+      soupItemMatchesProjectMembership(
+        projectItem('sub-other', { parentId: 'proj-2' }),
+        PROJECT
+      )
+    ).toBe(false);
+    // The folder itself is not one of its own children.
+    expect(
+      soupItemMatchesProjectMembership(
+        projectItem(PROJECT, { parentId: null }),
+        PROJECT
+      )
+    ).toBe(false);
+  });
+
+  it('stays permissive for types with no project on the item', () => {
+    expect(
+      soupItemMatchesProjectMembership(emailItem('thread-1'), PROJECT)
+    ).toBe(true);
   });
 });

--- a/apps/web/src/features/next-soup/filters/query-filters.ts
+++ b/apps/web/src/features/next-soup/filters/query-filters.ts
@@ -233,3 +233,26 @@ export function soupItemMatchesQuery(item: SoupApiItem, query: Query): boolean {
     )
   );
 }
+
+/**
+ * Whether a soup item belongs to a given project, mirroring the parent/project
+ * scoping the folder-contents soup query sends to the server: `projectId` on
+ * documents and chats, `parentId` on child projects. Used to gate optimistic
+ * and websocket cache inserts into a folder view so an entity created or opened
+ * outside the folder never flashes into its contents before the server refetch
+ * corrects it.
+ *
+ * Types whose soup item carries no project (emails, channels, calls, …) stay
+ * permissive — membership can't be decided from the item, and an insert that
+ * does belong should still appear optimistically.
+ */
+export function soupItemMatchesProjectMembership(
+  item: SoupApiItem,
+  projectId: string
+): boolean {
+  return match(item)
+    .with({ tag: 'document' }, ({ data }) => data.projectId === projectId)
+    .with({ tag: 'chat' }, ({ data }) => data.projectId === projectId)
+    .with({ tag: 'project' }, ({ data }) => data.parentId === projectId)
+    .otherwise(() => true);
+}

--- a/apps/web/src/features/next-soup/soup-view/soup-view-context.tsx
+++ b/apps/web/src/features/next-soup/soup-view/soup-view-context.tsx
@@ -121,6 +121,15 @@ type SoupViewInitializeOptions = {
   initialSearchText?: string;
   disableLocalSearch?: boolean;
   additionalEntities?: Accessor<EntityData[]>;
+  /**
+   * Extra gate applied to optimistic/websocket cache inserts on top of the
+   * active filters. The soup view's `itemFilter` reflects the active filters
+   * (tab/search/tag), not the base query's scope, so a scoped view (e.g. a
+   * folder's contents) passes this to reject inserts that fall outside its
+   * scope — otherwise an entity created or opened elsewhere flashes into the
+   * list until the server refetch corrects it.
+   */
+  itemMembershipFilter?: (item: SoupApiItem) => boolean;
 };
 
 export type ReadFilter = 'all' | 'unread' | 'read';
@@ -221,6 +230,7 @@ export const SoupViewContextProvider: FlowComponent<
     initialSearchText: props.initialSearchText,
     disableLocalSearch: props.disableLocalSearch,
     additionalEntities: props.additionalEntities,
+    itemMembershipFilter: props.itemMembershipFilter,
   });
 
   const queryClient = useQueryClient();
@@ -614,6 +624,9 @@ export const SoupViewContextProvider: FlowComponent<
     ) {
       return false;
     }
+
+    const membershipFilter = config().itemMembershipFilter;
+    if (membershipFilter && !membershipFilter(item)) return false;
 
     return soup.predicates.test(
       mapApiSoupItemToEntity(item) as SoupEntity,

--- a/apps/web/src/lib/queries/soup/normalized-cache/operations.test.ts
+++ b/apps/web/src/lib/queries/soup/normalized-cache/operations.test.ts
@@ -537,7 +537,10 @@ describe('optimisticUpdateSoupItemUpdatedAt', () => {
 // -- Normalized grouped cache tests --
 
 import type { Query } from '@app/features/next-soup/filters/filter-store/types';
-import { soupItemMatchesQuery } from '@app/features/next-soup/filters/query-filters';
+import {
+  soupItemMatchesProjectMembership,
+  soupItemMatchesQuery,
+} from '@app/features/next-soup/filters/query-filters';
 import type { GroupByField, GroupMeta } from '../grouped/types';
 import { NOT_SET_GROUP_KEY } from '../grouped/types';
 import type { SoupAstItemsFlatPage, SoupAstItemsGroupedPage } from '../items';
@@ -958,5 +961,64 @@ describe('insertSoupEntity — dynamic-ui list query gate', () => {
         key
       )!.pages[0];
     expect(page.items.map(getSoupItemId)).toEqual(['e-2', 'e-1']);
+  });
+});
+
+/**
+ * End-to-end gate for the folder (project) block (macro-2290): the block drives
+ * a project-scoped soup view and attaches `soupItemMatchesProjectMembership` as
+ * its `itemFilter`. Without it, creating or opening an entity outside the folder
+ * (which refetches the item and prepends it into every matching list cache)
+ * flashed into the folder's contents until the server refetch corrected it.
+ */
+describe('insertSoupEntity — folder membership gate', () => {
+  const FOLDER = 'proj-1';
+
+  function folderDocItem(id: string, projectId: string | null): SoupApiItem {
+    return {
+      tag: 'document',
+      data: { id, title: `doc ${id}`, projectId },
+      frecency_score: 1,
+    } as unknown as SoupApiItem;
+  }
+
+  function seedFolderScopedQuery(items: SoupApiItem[], suffix = 'folder-seed') {
+    const key = [...soupKeys.astItems._def, {}, {}, undefined, suffix];
+    const data: InfiniteData<SoupAstItemsFlatPage, unknown> = {
+      pages: [{ kind: 'flat', items, nextCursor: null }],
+      pageParams: [null],
+    };
+    testQueryClient.setQueryDefaults(key, {
+      meta: {
+        itemFilter: (item: SoupApiItem) =>
+          soupItemMatchesProjectMembership(item, FOLDER),
+      },
+    });
+    testQueryClient.setQueryData(key, data);
+    return key;
+  }
+
+  it('rejects a task created outside the folder', () => {
+    const key = seedFolderScopedQuery([folderDocItem('d-in', FOLDER)]);
+
+    insertSoupEntity(folderDocItem('d-root', null));
+
+    const page =
+      testQueryClient.getQueryData<InfiniteData<SoupAstItemsFlatPage, unknown>>(
+        key
+      )!.pages[0];
+    expect(page.items.map(getSoupItemId)).toEqual(['d-in']);
+  });
+
+  it('still inserts an entity that belongs to the folder', () => {
+    const key = seedFolderScopedQuery([folderDocItem('d-in', FOLDER)]);
+
+    insertSoupEntity(folderDocItem('d-new', FOLDER));
+
+    const page =
+      testQueryClient.getQueryData<InfiniteData<SoupAstItemsFlatPage, unknown>>(
+        key
+      )!.pages[0];
+    expect(page.items.map(getSoupItemId)).toEqual(['d-new', 'd-in']);
   });
 });


### PR DESCRIPTION
Creating or opening a task outside an open folder made it flash into that folder's contents until the server refetch corrected it, because the folder's soup view gated cache inserts only by active filters, not project membership. Adds a project-membership itemFilter (projectId for docs/chats, parentId for child folders) applied to regular folders.
