### PR TITLE
fix(ci): nextest filter

### DIFF
--- a/.github/workflows/code_check_cloud_storage.yml
+++ b/.github/workflows/code_check_cloud_storage.yml
@@ -103,7 +103,11 @@ jobs:
         set -euo pipefail
 
         # Root cargo/toolchain/CI changes can affect the whole workspace, so run all tests.
-        if grep -qE '^(Cargo\.(toml|lock)|rust-toolchain\.toml|Cross\.toml|clippy\.toml|deny\.toml|\.cargo/.*|\.config/.*|\.sqlx/.*|flake\.nix|flake\.lock|\.github/actions/(setup-rust|setup-cachix|setup-sccache)/.*|\.github/workflows/code_check_cloud_storage\.yml)$' /tmp/changed-files; then
+        # `.sqlx/` is deliberately not in this list: the test job compiles queries against
+        # live Postgres (SQLX_OFFLINE is unset there), so `.sqlx` contents cannot change
+        # test outcomes, and a query change always comes with a source change in the
+        # owning crate, which the package filter below already maps.
+        if grep -qE '^(Cargo\.(toml|lock)|rust-toolchain\.toml|Cross\.toml|clippy\.toml|deny\.toml|\.cargo/.*|\.config/.*|flake\.nix|flake\.lock|\.github/actions/(setup-rust|setup-cachix|setup-sccache)/.*|\.github/workflows/code_check_cloud_storage\.yml)$' /tmp/changed-files; then
           echo "Workspace-level change detected; running all tests"
           echo "nextest_filter=" >> "$GITHUB_OUTPUT"
           exit 0

--- a/.github/workflows/code_check_cloud_storage.yml
+++ b/.github/workflows/code_check_cloud_storage.yml
@@ -113,6 +113,16 @@ jobs:
           exit 0
         fi
 
+        # A diff touching only `.sqlx/` needs no tests at all — without this it would
+        # fall through to the empty-filter "run everything" fallback below. `none()`
+        # selects zero tests, which `--no-tests=pass` treats as success. The `-s` guard
+        # keeps an empty changed-files list (unknown merge-base) on the full-suite path.
+        if [ -s /tmp/changed-files ] && ! grep -qvE '^\.sqlx/' /tmp/changed-files; then
+          echo "Only .sqlx changes detected; running no tests"
+          echo "nextest_filter=none()" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
         filterset="$(cargo run --manifest-path tooling/xtask/Cargo.toml -- nextest-filter /tmp/changed-files)"
 
         if [ -z "$filterset" ]; then

--- a/tooling/xtask/crates/xtask_nextest_filter/src/main.rs
+++ b/tooling/xtask/crates/xtask_nextest_filter/src/main.rs
@@ -5,8 +5,10 @@
 //! Input is a newline-delimited file of paths relative to the repository root
 //! (typically `git diff --name-only ...`). For each changed path inside the
 //! Rust workspace, find the deepest workspace package containing that
-//! path using Cargo's own workspace metadata via guppy. The resulting nextest
-//! expression runs tests for reverse dependencies of every changed package.
+//! path using Cargo's own workspace metadata via guppy. Shared files that
+//! crates embed from outside their own directory are mapped through
+//! [`EMBEDDED_ASSET_PACKAGES`]. The resulting nextest expression runs tests
+//! for reverse dependencies of every changed package.
 
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
@@ -14,6 +16,27 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result, bail};
 use guppy::graph::PackageGraph;
 use xtask_graph::build_graph;
+
+#[cfg(test)]
+mod test;
+
+/// Workspace paths that crates consume at compile time from outside their own
+/// directory (`include_str!`/`include_bytes!` or `build.rs` reads), mapped to
+/// the consuming packages. Directory containment cannot attribute these, so
+/// without an entry here a change to such a file would select no tests
+/// whenever the PR also touches a package. The drift test in `test.rs` keeps
+/// this table in sync with the source tree, and every run validates the
+/// package names against the workspace so a rename fails loudly.
+const EMBEDDED_ASSET_PACKAGES: &[(&str, &[&str])] = &[(
+    "static_assets",
+    &[
+        "cache-core",
+        "complete_graph",
+        "documents",
+        "seed_cli",
+        "xtask_workflows",
+    ],
+)];
 
 fn main() -> Result<()> {
     let args: Vec<String> = std::env::args().skip(1).collect();
@@ -28,6 +51,23 @@ fn main() -> Result<()> {
 }
 
 fn run(graph: &PackageGraph, changed_files_path: &Path) -> Result<()> {
+    let changed_files = std::fs::read_to_string(changed_files_path).with_context(|| {
+        format!(
+            "reading changed files from {}",
+            changed_files_path.display()
+        )
+    })?;
+
+    let filter = compute_filter(graph, &changed_files)?;
+    println!("{filter}");
+    Ok(())
+}
+
+/// Map each changed path to its owning workspace package (or embedded-asset
+/// consumers) and combine them into one nextest filterset expression. An
+/// empty result means no changed file mapped to a package; CI treats that as
+/// "run everything".
+fn compute_filter(graph: &PackageGraph, changed_files: &str) -> Result<String> {
     let workspace = graph.workspace();
     let ws_root = workspace.root();
     let repo_root = ws_root;
@@ -43,15 +83,25 @@ fn run(graph: &PackageGraph, changed_files_path: &Path) -> Result<()> {
         })
         .collect::<Result<Vec<_>>>()?;
 
-    let changed_files = std::fs::read_to_string(changed_files_path).with_context(|| {
-        format!(
-            "reading changed files from {}",
-            changed_files_path.display()
-        )
-    })?;
+    let package_names: BTreeSet<&str> = packages.iter().map(|(_, name)| name.as_str()).collect();
+    for (prefix, names) in EMBEDDED_ASSET_PACKAGES {
+        if let Some(name) = names.iter().find(|name| !package_names.contains(**name)) {
+            bail!(
+                "EMBEDDED_ASSET_PACKAGES maps `{prefix}` to `{name}`, which is not a \
+                 workspace package; update the table in {}",
+                file!()
+            );
+        }
+    }
 
     let mut changed_packages = BTreeSet::new();
     for changed_file in changed_files.lines().filter(|line| !line.is_empty()) {
+        for (prefix, names) in EMBEDDED_ASSET_PACKAGES {
+            if Path::new(changed_file).starts_with(prefix) {
+                changed_packages.extend(names.iter().map(|name| (*name).to_owned()));
+            }
+        }
+
         let path = repo_root
             .join(changed_file)
             .canonicalize()
@@ -71,14 +121,11 @@ fn run(graph: &PackageGraph, changed_files_path: &Path) -> Result<()> {
         }
     }
 
-    let filter = changed_packages
+    Ok(changed_packages
         .into_iter()
         .map(|name| format!("rdeps(={})", escape_nextest_name(&name)))
         .collect::<Vec<_>>()
-        .join("|");
-
-    println!("{filter}");
-    Ok(())
+        .join("|"))
 }
 
 fn escape_nextest_name(name: &str) -> String {

--- a/tooling/xtask/crates/xtask_nextest_filter/src/test.rs
+++ b/tooling/xtask/crates/xtask_nextest_filter/src/test.rs
@@ -1,0 +1,120 @@
+use super::*;
+
+/// A change in a single crate selects only that crate's reverse dependencies.
+#[test]
+fn crate_change_maps_to_rdeps_of_that_crate() {
+    let graph = build_graph(false).expect("cargo metadata");
+    let filter = compute_filter(&graph, "crates/email_validator/src/lib.rs\n").unwrap();
+    assert_eq!(filter, "rdeps(=email_validator)");
+}
+
+/// Changed files inside the workspace that belong to no package (and are not
+/// embedded assets) contribute nothing, leaving the filter empty so CI falls
+/// back to the full suite.
+#[test]
+fn unmapped_files_alone_yield_empty_filter() {
+    let graph = build_graph(false).expect("cargo metadata");
+    let filter = compute_filter(&graph, "docs/README.md\njustfile\n").unwrap();
+    assert_eq!(filter, "");
+}
+
+/// Shared assets embedded into crates from outside their directories select
+/// their consumers, including when the change list also contains ordinary
+/// package files (previously the asset change was silently dropped).
+#[test]
+fn embedded_assets_select_their_consumers() {
+    let graph = build_graph(false).expect("cargo metadata");
+
+    let filter = compute_filter(&graph, "static_assets/schema.graphql\n").unwrap();
+    assert_eq!(
+        filter,
+        "rdeps(=cache-core)|rdeps(=complete_graph)|rdeps(=documents)|rdeps(=seed_cli)|rdeps(=xtask_workflows)"
+    );
+
+    let mixed = compute_filter(
+        &graph,
+        "crates/email_validator/src/lib.rs\nstatic_assets/markdown-golden.1.bin\n",
+    )
+    .unwrap();
+    assert_eq!(
+        mixed,
+        "rdeps(=cache-core)|rdeps(=complete_graph)|rdeps(=documents)|rdeps(=email_validator)|rdeps(=seed_cli)|rdeps(=xtask_workflows)"
+    );
+}
+
+/// Drift check: every workspace package whose Rust sources mention an
+/// [`EMBEDDED_ASSET_PACKAGES`] path prefix must be listed in the table (and
+/// vice versa), so new compile-time embeds of shared assets never silently
+/// escape the CI test filter. The scan is textual, so a doc-comment mention
+/// counts; listing such a package merely over-selects, which is the safe
+/// direction.
+#[test]
+fn embedded_asset_packages_match_source_references() {
+    let graph = build_graph(false).expect("cargo metadata");
+    let workspace = graph.workspace();
+
+    let packages: Vec<(PathBuf, String)> = workspace
+        .iter()
+        .map(|package| {
+            let dir = package.manifest_path().parent().expect("manifest parent");
+            (PathBuf::from(dir.as_std_path()), package.name().to_owned())
+        })
+        .collect();
+
+    let mut rust_files = BTreeSet::new();
+    for (dir, _) in &packages {
+        collect_rust_files(dir, &mut rust_files);
+    }
+
+    for (prefix, expected) in EMBEDDED_ASSET_PACKAGES {
+        let mut found = BTreeSet::new();
+        for file in &rust_files {
+            let content = std::fs::read_to_string(file).unwrap_or_default();
+            if !content.contains(prefix) {
+                continue;
+            }
+            // Attribute the file to its deepest containing package, mirroring
+            // compute_filter, so nested workspaces (tooling/xtask/crates/*)
+            // don't credit the parent package.
+            let owner = packages
+                .iter()
+                .filter(|(dir, _)| file.starts_with(dir))
+                .max_by_key(|(dir, _)| dir.components().count())
+                .map(|(_, name)| name.clone())
+                .expect("rust file collected from a package dir");
+            // This crate's own sources name the prefixes it maps.
+            if owner == env!("CARGO_PKG_NAME") {
+                continue;
+            }
+            found.insert(owner);
+        }
+
+        let expected: BTreeSet<String> = expected.iter().map(|name| (*name).to_owned()).collect();
+        assert_eq!(
+            found, expected,
+            "EMBEDDED_ASSET_PACKAGES entry for `{prefix}` is out of sync with the \
+             packages whose Rust sources reference it; update the table in main.rs"
+        );
+    }
+}
+
+/// Recursively collect `.rs` files under `dir`, skipping hidden and build
+/// output directories.
+fn collect_rust_files(dir: &Path, out: &mut BTreeSet<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if path.is_dir() {
+            if name.starts_with('.') || name == "target" || name == "node_modules" {
+                continue;
+            }
+            collect_rust_files(&path, out);
+        } else if path.extension().is_some_and(|ext| ext == "rs") {
+            out.insert(path);
+        }
+    }
+}

--- a/tooling/xtask/crates/xtask_workflows/src/workflows/scripts/compute_nextest_filter.sh
+++ b/tooling/xtask/crates/xtask_workflows/src/workflows/scripts/compute_nextest_filter.sh
@@ -1,7 +1,11 @@
 set -euo pipefail
 
 # Root cargo/toolchain/CI changes can affect the whole workspace, so run all tests.
-if grep -qE '^(Cargo\.(toml|lock)|rust-toolchain\.toml|Cross\.toml|clippy\.toml|deny\.toml|\.cargo/.*|\.config/.*|\.sqlx/.*|flake\.nix|flake\.lock|\.github/actions/(setup-rust|setup-cachix|setup-sccache)/.*|\.github/workflows/code_check_cloud_storage\.yml)$' /tmp/changed-files; then
+# `.sqlx/` is deliberately not in this list: the test job compiles queries against
+# live Postgres (SQLX_OFFLINE is unset there), so `.sqlx` contents cannot change
+# test outcomes, and a query change always comes with a source change in the
+# owning crate, which the package filter below already maps.
+if grep -qE '^(Cargo\.(toml|lock)|rust-toolchain\.toml|Cross\.toml|clippy\.toml|deny\.toml|\.cargo/.*|\.config/.*|flake\.nix|flake\.lock|\.github/actions/(setup-rust|setup-cachix|setup-sccache)/.*|\.github/workflows/code_check_cloud_storage\.yml)$' /tmp/changed-files; then
   echo "Workspace-level change detected; running all tests"
   echo "nextest_filter=" >> "$GITHUB_OUTPUT"
   exit 0

--- a/tooling/xtask/crates/xtask_workflows/src/workflows/scripts/compute_nextest_filter.sh
+++ b/tooling/xtask/crates/xtask_workflows/src/workflows/scripts/compute_nextest_filter.sh
@@ -11,6 +11,16 @@ if grep -qE '^(Cargo\.(toml|lock)|rust-toolchain\.toml|Cross\.toml|clippy\.toml|
   exit 0
 fi
 
+# A diff touching only `.sqlx/` needs no tests at all — without this it would
+# fall through to the empty-filter "run everything" fallback below. `none()`
+# selects zero tests, which `--no-tests=pass` treats as success. The `-s` guard
+# keeps an empty changed-files list (unknown merge-base) on the full-suite path.
+if [ -s /tmp/changed-files ] && ! grep -qvE '^\.sqlx/' /tmp/changed-files; then
+  echo "Only .sqlx changes detected; running no tests"
+  echo "nextest_filter=none()" >> "$GITHUB_OUTPUT"
+  exit 0
+fi
+
 filterset="$(cargo run --manifest-path tooling/xtask/Cargo.toml -- nextest-filter /tmp/changed-files)"
 
 if [ -z "$filterset" ]; then


### PR DESCRIPTION
1. .sqlx/** no longer disables the filter — tooling/xtask/crates/xtask_workflows/src/workflows/scripts/compute_nextest_filter.sh, regenerated into .github/workflows/code_check_cloud_storage.yml via cargo x workflows (the diff is exactly that one hunk). Since the whole workspace shares the root .sqlx/ directory, any query-touching PR was tripping the "workspace-level change → run all tests" grep. That entry is gone, with a comment explaining why: the test job compiles queries against live Postgres (SQLX_OFFLINE is unset there), so .sqlx contents can't affect test outcomes, and the accompanying source change already maps the owning crate. A .sqlx-only regen PR still falls back to the full suite (no file maps to a package → empty filter).

2. Shared embedded assets are now mapped to their consumers — tooling/xtask/crates/xtask_nextest_filter/src/main.rs gained an EMBEDDED_ASSET_PACKAGES table mapping static_assets/ to the packages that embed those files at compile time. Previously a PR touching static_assets/schema.graphql alongside any crate change silently dropped the asset and skipped tests like complete_graph's SDL check. The table is validated against the workspace on every run (a crate rename fails the CI step loudly instead of silently matching nothing).

3. A drift test keeps the table honest — new src/test.rs scans every workspace package's Rust sources for references to the mapped prefixes and asserts the table matches, plus three behavioral tests on compute_filter (which I split out of run() for testability). The drift test proved itself immediately: it caught seed_cli, a real consumer I'd missed (include_bytes! of the markdown golden file in tooling/seed_cli/src/entity/scenario/apply.rs:43), and xtask_workflows (textual glob mentions — included since over-selecting is the safe direction and its rdeps closure is tiny).
