### PR TITLE
fix: consistent unauthed behavior on public-link surfaces

### DIFF
--- a/apps/web/src/features/block-chat/definition.ts
+++ b/apps/web/src/features/block-chat/definition.ts
@@ -5,7 +5,7 @@ import {
   loadResult,
 } from '@core/block';
 import { Model } from '@core/component/AI/constant/model';
-import { cognitionApiServiceClient } from '@service-cognition/client';
+import { fetchAndCacheChat } from '@queries/cognition/chat-data';
 import type { Entity } from '@service-cognition/generated/schemas/entity';
 import type { DocumentMetadata } from '@service-storage/generated/schemas/documentMetadata';
 import { err, ok } from 'neverthrow';
@@ -25,9 +25,7 @@ export const definition = defineBlock({
     if (source.type === 'dss') {
       // Fetch the chat from dcs
       const chatId = source.id;
-      const res = await loadResult(
-        cognitionApiServiceClient.getChat({ chat_id: chatId })
-      );
+      const res = await loadResult(fetchAndCacheChat(chatId));
       if (res.isErr()) return err(res.error);
       const chat = res.value;
 

--- a/apps/web/src/features/block-chat/definition.ts
+++ b/apps/web/src/features/block-chat/definition.ts
@@ -1,9 +1,14 @@
-import { defineBlock, type ExtractLoadType, LoadErrors } from '@core/block';
+import {
+  defineBlock,
+  type ExtractLoadType,
+  LoadErrors,
+  loadResult,
+} from '@core/block';
 import { Model } from '@core/component/AI/constant/model';
 import { cognitionApiServiceClient } from '@service-cognition/client';
 import type { Entity } from '@service-cognition/generated/schemas/entity';
 import type { DocumentMetadata } from '@service-storage/generated/schemas/documentMetadata';
-import { ok } from 'neverthrow';
+import { err, ok } from 'neverthrow';
 import BlockChat from './component/Block';
 
 export const DEFAULT_CHAT_NAME = 'New Chat';
@@ -20,13 +25,10 @@ export const definition = defineBlock({
     if (source.type === 'dss') {
       // Fetch the chat from dcs
       const chatId = source.id;
-      const res = await cognitionApiServiceClient.getChat({ chat_id: chatId });
-      if (
-        res.isErr() &&
-        res.error.some((error) => error.code === 'UNAUTHORIZED')
-      )
-        return LoadErrors.INVALID;
-      if (res.isErr()) return LoadErrors.MISSING;
+      const res = await loadResult(
+        cognitionApiServiceClient.getChat({ chat_id: chatId })
+      );
+      if (res.isErr()) return err(res.error);
       const chat = res.value;
 
       if (intent === 'preload') {

--- a/apps/web/src/features/property/side-panel/properties/EntityPropertiesSection.tsx
+++ b/apps/web/src/features/property/side-panel/properties/EntityPropertiesSection.tsx
@@ -1,4 +1,5 @@
 import { SidePanel } from '@components/app/side-panel/SidePanel';
+import { useIsAuthenticated } from '@core/auth';
 import type { BlockAlias, BlockName } from '@core/block';
 import { PopupPreview } from '@core/component/DocumentPreview';
 import { HoverCard } from '@core/component/HoverCard';
@@ -84,12 +85,13 @@ const TAGGABLE_ENTITY_TYPES: ReadonlySet<EntityType> = new Set<EntityType>([
 
 export function EntityTagsSection(props: EntityTagsSectionProps) {
   const tagsQuery = useTagsQuery();
+  const isAuthenticated = useIsAuthenticated();
 
   return (
     <Show when={TAGGABLE_ENTITY_TYPES.has(props.entityType)}>
       <SidePanel.Section id="tags" title="Tags" defaultOpen order={props.order}>
         <Show
-          when={!tagsQuery.isError}
+          when={isAuthenticated() !== false && !tagsQuery.isError}
           fallback={
             <span class="text-xs text-ink-extra-muted">Tags unavailable</span>
           }

--- a/apps/web/src/lib/queries/channel/channel-messages.ts
+++ b/apps/web/src/lib/queries/channel/channel-messages.ts
@@ -1,4 +1,8 @@
-import { ThrownResultError, throwOnErr } from '@core/util/result';
+import {
+  ThrownResultError,
+  thrownResultErrorHasCode,
+  throwOnErr,
+} from '@core/util/result';
 import {
   type ApiChannelMessage,
   type ApiResolvedChannelMessage,
@@ -126,6 +130,12 @@ export function channelMessagesQueryOptions(
     staleTime: Infinity,
     retry: (failureCount: number, error: Error) => {
       if (loadAroundMessageId && isMissingChannelMessageError(error)) {
+        return false;
+      }
+      if (
+        thrownResultErrorHasCode(error, 'UNAUTHORIZED') ||
+        thrownResultErrorHasCode(error, 'FORBIDDEN')
+      ) {
         return false;
       }
       return failureCount < 1;

--- a/apps/web/src/lib/queries/cognition/chat-data.ts
+++ b/apps/web/src/lib/queries/cognition/chat-data.ts
@@ -1,26 +1,43 @@
+import { catchToResult, throwOnErr } from '@core/util/result';
 import { cognitionApiServiceClient } from '@service-cognition/client';
-import type { ChatResponse } from '@service-cognition/generated/schemas';
 import { useQuery } from '@tanstack/solid-query';
 import type { Accessor } from 'solid-js';
+import { queryClient } from '../client';
 import { chatDataQueryKey } from './keys';
 
 const STALE_TIME = 60 * 1000;
 const GC_TIME = 10 * 60 * 1000;
 
-async function fetchChatData(chatId: string): Promise<ChatResponse> {
-  const result = await cognitionApiServiceClient.getChat({ chat_id: chatId });
-  if (result.isErr()) {
-    throw new Error('Failed to fetch chat');
-  }
-  return result.value.chat;
+function chatQueryOptions(chatId: string) {
+  return {
+    queryKey: chatDataQueryKey(chatId),
+    queryFn: async () =>
+      await throwOnErr(
+        async () => await cognitionApiServiceClient.getChat({ chat_id: chatId })
+      ),
+    staleTime: STALE_TIME,
+    gcTime: GC_TIME,
+  };
+}
+
+/**
+ * Fetch a chat fresh from the service through the query cache, so mounted
+ * chat queries reuse the response instead of refetching.
+ */
+export async function fetchAndCacheChat(chatId: string) {
+  return await catchToResult(
+    async () =>
+      await queryClient.fetchQuery({
+        ...chatQueryOptions(chatId),
+        staleTime: 0,
+      })
+  );
 }
 
 export function useChatDataQuery(chatId: Accessor<string>) {
   return useQuery(() => ({
-    queryKey: chatDataQueryKey(chatId()),
-    queryFn: () => fetchChatData(chatId()),
-    staleTime: STALE_TIME,
-    gcTime: GC_TIME,
+    ...chatQueryOptions(chatId()),
+    select: (data) => data.chat,
     enabled: !!chatId(),
   }));
 }

--- a/apps/web/src/lib/queries/properties/tags.ts
+++ b/apps/web/src/lib/queries/properties/tags.ts
@@ -23,7 +23,7 @@ export function useTagsQuery() {
     queryFn: async () =>
       await throwOnErr(async () => await propertiesServiceClient.listTags()),
     staleTime: 1000 * 60 * 5,
-    enabled: isAuthenticated(),
+    enabled: isAuthenticated() === true,
     placeholderData: EMPTY_TAG_SETS,
   }));
 }


### PR DESCRIPTION
Anonymous viewers of an inaccessible chat now get the standard unauthorized view (with login prompt) instead of "an unexpected error has occurred" — the chat block load maps 401/404/410 through `loadResult` like every other block. Also audited the other public-link surfaces (pdf/code/canvas/image/video render fine anonymously): stops the tags query from firing for anonymous/unsettled sessions so the side panel deterministically shows "Tags unavailable", and makes the channel-messages retry respect the global no-retry-on-401/403 rule. Anonymous *view* of public chats additionally needs #5090 plus a `get_chat` fix (`get_authenticated_user` 403s anonymous receipts) — verified E2E with a locally patched DCS: public chat renders read-only for an anonymous viewer, authed owner unaffected.
