### PR TITLE
feat(crm): let team members edit company properties

### DIFF
--- a/apps/web/src/features/companies/Company/CompanyPropertiesSection.tsx
+++ b/apps/web/src/features/companies/Company/CompanyPropertiesSection.tsx
@@ -1,22 +1,22 @@
 import { EntityPropertiesSection } from '@app/features/property/side-panel/properties/EntityPropertiesSection';
 import { useDealStages } from '@companies/crm/deal-stages';
+import { useCrmPermissions } from '@companies/crm/team-crm-config';
 import { buildCompanyDefaultProperties } from '@entity/extractors-property';
 import { SYSTEM_PROPERTY_IDS } from '@property/constants';
-import { useIsTeamAdmin } from '@queries/team/teams';
 
 /**
  * CRM properties for a company (Stage / Owner / Revenue + custom),
  * mirroring the task side panel's properties section. The builtin
  * defaults render as editable placeholders even before the company has
- * any values saved. Editing follows CRM access: team admins/owners can
- * edit, members see read-only values.
+ * any values saved. Editing follows CRM access: any team member can
+ * edit.
  *
  * Stage goes through the team's active deal-stage set: when the team has
  * customized stages, the panel edits the team Stage definition and the
  * fetched system Stage row is hidden.
  */
 export function CompanyPropertiesSection(props: { companyId: string }) {
-  const isTeamAdmin = useIsTeamAdmin();
+  const { canEditCrm } = useCrmPermissions();
   const dealStages = useDealStages();
 
   // Builtin CRM defaults, with the Stage stub swapped for the active
@@ -39,7 +39,7 @@ export function CompanyPropertiesSection(props: { companyId: string }) {
     <EntityPropertiesSection
       entityId={props.companyId}
       entityType="COMPANY"
-      canEdit={isTeamAdmin()}
+      canEdit={canEditCrm()}
       defaultProperties={defaultProperties}
       pinnedPropertyDefinitionOrder={pinnedOrder()}
       hidePropertyDefinitionIds={

--- a/apps/web/src/features/companies/crm/team-crm-config.ts
+++ b/apps/web/src/features/companies/crm/team-crm-config.ts
@@ -197,7 +197,7 @@ export function useCrmPermissions() {
     permissions,
     isLoading,
     /** Can edit CRM data at all (platform rule: any team member). */
-    canEditCrm: createMemo(() => role() !== undefined),
+    canEditCrm: () => role() !== undefined,
     canEditStages: createMemo(() =>
       roleSatisfies(role(), permissions().editStages)
     ),

--- a/apps/web/src/features/companies/crm/team-crm-config.ts
+++ b/apps/web/src/features/companies/crm/team-crm-config.ts
@@ -13,7 +13,7 @@
 
 import { useUserId } from '@core/context/user';
 import { throwOnErr } from '@core/util/result';
-import { useCurrentTeamQuery, useIsTeamAdmin } from '@queries/team/teams';
+import { useCurrentTeamQuery } from '@queries/team/teams';
 import { TeamRole } from '@service-auth/generated/schemas/teamRole';
 import { storageServiceClient } from '@service-storage/client';
 import type { CrmTeamSettingsResponse } from '@service-storage/generated/schemas/crmTeamSettingsResponse';
@@ -170,13 +170,12 @@ function roleSatisfies(
 
 /**
  * Effective CRM capabilities for the current user, combining the team's
- * configured permission thresholds with the platform-level rule that only
- * admins/owners can edit CRM data at all.
+ * configured permission thresholds with the platform-level rule that any
+ * team member can edit CRM data (governance actions stay admin/owner).
  */
 export function useCrmPermissions() {
   const userId = useUserId();
   const teamQuery = useCurrentTeamQuery();
-  const isTeamAdmin = useIsTeamAdmin();
   const { config, isLoading } = useTeamCrmConfig();
 
   const role = createMemo((): TeamRole | undefined => {
@@ -197,8 +196,8 @@ export function useCrmPermissions() {
     role,
     permissions,
     isLoading,
-    /** Can edit CRM data at all (platform rule: admin/owner). */
-    canEditCrm: isTeamAdmin,
+    /** Can edit CRM data at all (platform rule: any team member). */
+    canEditCrm: createMemo(() => role() !== undefined),
     canEditStages: createMemo(() =>
       roleSatisfies(role(), permissions().editStages)
     ),

--- a/apps/web/src/features/next-soup/soup-view/views/companies/company-grid-layout.tsx
+++ b/apps/web/src/features/next-soup/soup-view/views/companies/company-grid-layout.tsx
@@ -1,5 +1,6 @@
 import { useDealStages } from '@companies/crm/deal-stages';
 import { useCrmDisplayOptions } from '@companies/crm/display-options';
+import { useCrmPermissions } from '@companies/crm/team-crm-config';
 import {
   Entity,
   type EntityData,
@@ -20,7 +21,6 @@ import {
 } from '@property/context/PropertiesContext';
 import type { Property, PropertyApiValues } from '@property/types';
 import { useBulkSaveEntityPropertiesMutation } from '@queries/properties/entity';
-import { useIsTeamAdmin } from '@queries/team/teams';
 import { EntityType } from '@service-properties/generated/schemas/entityType';
 import { cn } from '@ui/utils/classname';
 import { createMemo, For, Show, Suspense } from 'solid-js';
@@ -37,7 +37,7 @@ import {
  * Interaction timestamp, mirroring `TaskGridLayout`.
  */
 export function CompanyGridLayout(props: LayoutProps) {
-  const isTeamAdmin = useIsTeamAdmin();
+  const { canEditCrm } = useCrmPermissions();
   const dealStages = useDealStages();
   const displayOptions = useCrmDisplayOptions();
 
@@ -127,7 +127,7 @@ export function CompanyGridLayout(props: LayoutProps) {
   return (
     <PropertiesProvider
       entityType={EntityType.COMPANY}
-      canEdit={isTeamAdmin()}
+      canEdit={canEditCrm()}
       properties={properties}
       onRefresh={() => {}}
       onPropertyAdded={() => {}}

--- a/apps/web/src/lib/service-clients/service-cognition/generated/tools/types.ts
+++ b/apps/web/src/lib/service-clients/service-cognition/generated/tools/types.ts
@@ -3476,7 +3476,7 @@ export interface SendEmail {
  * - Stage (00000001-0000-0000-0000-000000000010): select_string, single. Use option_id. Default options: Lead (00000001-0000-0000-0010-000000000001), Qualified (...0002), Demo (...0003), Trial (...0004), Negotiation (...0005), Customer (...0006), Churned (...0007). Teams can customize their stages, so prefer calling GetCompany or GetEntityProperties first to get the valid stage option ids.
  * - Owner (00000001-0000-0000-0000-000000000011): entity, single. Use entity_ref with entity_type='user' and entity_id='macro|email@domain.com'.
  * - Revenue (00000001-0000-0000-0000-000000000012): number, single. Use number_value (dollars).
- * Any member of the owning team can edit company properties.
+ * Any member of the owning team can edit visible company properties; hidden records remain admin/owner-only.
  *
  * For non-system or custom properties, call GetEntityProperties first to discover property_definition_id values and options.
  */

--- a/apps/web/src/lib/service-clients/service-cognition/generated/tools/types.ts
+++ b/apps/web/src/lib/service-clients/service-cognition/generated/tools/types.ts
@@ -3476,7 +3476,7 @@ export interface SendEmail {
  * - Stage (00000001-0000-0000-0000-000000000010): select_string, single. Use option_id. Default options: Lead (00000001-0000-0000-0010-000000000001), Qualified (...0002), Demo (...0003), Trial (...0004), Negotiation (...0005), Customer (...0006), Churned (...0007). Teams can customize their stages, so prefer calling GetCompany or GetEntityProperties first to get the valid stage option ids.
  * - Owner (00000001-0000-0000-0000-000000000011): entity, single. Use entity_ref with entity_type='user' and entity_id='macro|email@domain.com'.
  * - Revenue (00000001-0000-0000-0000-000000000012): number, single. Use number_value (dollars).
- * Editing company properties requires the caller to be a team admin or owner.
+ * Any member of the owning team can edit company properties.
  *
  * For non-system or custom properties, call GetEntityProperties first to discover property_definition_id values and options.
  */

--- a/apps/web/src/lib/service-clients/service-storage/generated/schemas/crmPermissionRole.ts
+++ b/apps/web/src/lib/service-clients/service-storage/generated/schemas/crmPermissionRole.ts
@@ -6,8 +6,9 @@
  */
 
 /**
- * Minimum team role required for a CRM capability. Members are
-view-only at the platform level, so the configurable range is
+ * Minimum team role required for a CRM governance capability. Members
+can edit visible CRM records (e.g. company properties), but the
+governance capabilities these settings gate stay restricted to
 admin (default) vs owner. Maps to the `team_role` Postgres enum;
 `member` is deliberately not representable.
  */

--- a/apps/web/src/lib/service-clients/service-storage/generated/zod.ts
+++ b/apps/web/src/lib/service-clients/service-storage/generated/zod.ts
@@ -3644,17 +3644,17 @@ export const getCrmTeamSettingsResponse = zod
     delete_records_role: zod
       .enum(['admin', 'owner'])
       .describe(
-        'Minimum team role required for a CRM capability. Members are\nview-only at the platform level, so the configurable range is\nadmin (default) vs owner. Maps to the `team_role` Postgres enum;\n`member` is deliberately not representable.'
+        'Minimum team role required for a CRM governance capability. Members\ncan edit visible CRM records (e.g. company properties), but the\ngovernance capabilities these settings gate stay restricted to\nadmin (default) vs owner. Maps to the `team_role` Postgres enum;\n`member` is deliberately not representable.'
       ),
     edit_stages_role: zod
       .enum(['admin', 'owner'])
       .describe(
-        'Minimum team role required for a CRM capability. Members are\nview-only at the platform level, so the configurable range is\nadmin (default) vs owner. Maps to the `team_role` Postgres enum;\n`member` is deliberately not representable.'
+        'Minimum team role required for a CRM governance capability. Members\ncan edit visible CRM records (e.g. company properties), but the\ngovernance capabilities these settings gate stay restricted to\nadmin (default) vs owner. Maps to the `team_role` Postgres enum;\n`member` is deliberately not representable.'
       ),
     move_closed_deals_role: zod
       .enum(['admin', 'owner'])
       .describe(
-        'Minimum team role required for a CRM capability. Members are\nview-only at the platform level, so the configurable range is\nadmin (default) vs owner. Maps to the `team_role` Postgres enum;\n`member` is deliberately not representable.'
+        'Minimum team role required for a CRM governance capability. Members\ncan edit visible CRM records (e.g. company properties), but the\ngovernance capabilities these settings gate stay restricted to\nadmin (default) vs owner. Maps to the `team_role` Postgres enum;\n`member` is deliberately not representable.'
       ),
     team_views: zod
       .unknown()
@@ -3694,7 +3694,7 @@ export const putCrmTeamSettingsBody = zod
         zod
           .enum(['admin', 'owner'])
           .describe(
-            'Minimum team role required for a CRM capability. Members are\nview-only at the platform level, so the configurable range is\nadmin (default) vs owner. Maps to the `team_role` Postgres enum;\n`member` is deliberately not representable.'
+            'Minimum team role required for a CRM governance capability. Members\ncan edit visible CRM records (e.g. company properties), but the\ngovernance capabilities these settings gate stay restricted to\nadmin (default) vs owner. Maps to the `team_role` Postgres enum;\n`member` is deliberately not representable.'
           ),
       ])
       .optional(),
@@ -3704,7 +3704,7 @@ export const putCrmTeamSettingsBody = zod
         zod
           .enum(['admin', 'owner'])
           .describe(
-            'Minimum team role required for a CRM capability. Members are\nview-only at the platform level, so the configurable range is\nadmin (default) vs owner. Maps to the `team_role` Postgres enum;\n`member` is deliberately not representable.'
+            'Minimum team role required for a CRM governance capability. Members\ncan edit visible CRM records (e.g. company properties), but the\ngovernance capabilities these settings gate stay restricted to\nadmin (default) vs owner. Maps to the `team_role` Postgres enum;\n`member` is deliberately not representable.'
           ),
       ])
       .optional(),
@@ -3714,7 +3714,7 @@ export const putCrmTeamSettingsBody = zod
         zod
           .enum(['admin', 'owner'])
           .describe(
-            'Minimum team role required for a CRM capability. Members are\nview-only at the platform level, so the configurable range is\nadmin (default) vs owner. Maps to the `team_role` Postgres enum;\n`member` is deliberately not representable.'
+            'Minimum team role required for a CRM governance capability. Members\ncan edit visible CRM records (e.g. company properties), but the\ngovernance capabilities these settings gate stay restricted to\nadmin (default) vs owner. Maps to the `team_role` Postgres enum;\n`member` is deliberately not representable.'
           ),
       ])
       .optional(),
@@ -3744,17 +3744,17 @@ export const putCrmTeamSettingsResponse = zod
     delete_records_role: zod
       .enum(['admin', 'owner'])
       .describe(
-        'Minimum team role required for a CRM capability. Members are\nview-only at the platform level, so the configurable range is\nadmin (default) vs owner. Maps to the `team_role` Postgres enum;\n`member` is deliberately not representable.'
+        'Minimum team role required for a CRM governance capability. Members\ncan edit visible CRM records (e.g. company properties), but the\ngovernance capabilities these settings gate stay restricted to\nadmin (default) vs owner. Maps to the `team_role` Postgres enum;\n`member` is deliberately not representable.'
       ),
     edit_stages_role: zod
       .enum(['admin', 'owner'])
       .describe(
-        'Minimum team role required for a CRM capability. Members are\nview-only at the platform level, so the configurable range is\nadmin (default) vs owner. Maps to the `team_role` Postgres enum;\n`member` is deliberately not representable.'
+        'Minimum team role required for a CRM governance capability. Members\ncan edit visible CRM records (e.g. company properties), but the\ngovernance capabilities these settings gate stay restricted to\nadmin (default) vs owner. Maps to the `team_role` Postgres enum;\n`member` is deliberately not representable.'
       ),
     move_closed_deals_role: zod
       .enum(['admin', 'owner'])
       .describe(
-        'Minimum team role required for a CRM capability. Members are\nview-only at the platform level, so the configurable range is\nadmin (default) vs owner. Maps to the `team_role` Postgres enum;\n`member` is deliberately not representable.'
+        'Minimum team role required for a CRM governance capability. Members\ncan edit visible CRM records (e.g. company properties), but the\ngovernance capabilities these settings gate stay restricted to\nadmin (default) vs owner. Maps to the `team_role` Postgres enum;\n`member` is deliberately not representable.'
       ),
     team_views: zod
       .unknown()

--- a/apps/web/src/lib/service-clients/service-storage/openapi.json
+++ b/apps/web/src/lib/service-clients/service-storage/openapi.json
@@ -13576,7 +13576,7 @@
       },
       "CrmPermissionRole": {
         "type": "string",
-        "description": "Minimum team role required for a CRM capability. Members are\nview-only at the platform level, so the configurable range is\nadmin (default) vs owner. Maps to the `team_role` Postgres enum;\n`member` is deliberately not representable.",
+        "description": "Minimum team role required for a CRM governance capability. Members\ncan edit visible CRM records (e.g. company properties), but the\ngovernance capabilities these settings gate stay restricted to\nadmin (default) vs owner. Maps to the `team_role` Postgres enum;\n`member` is deliberately not representable.",
         "enum": ["admin", "owner"]
       },
       "CrmTeamSettingsResponse": {

--- a/crates/bots/src/inbound/axum_router/tests.rs
+++ b/crates/bots/src/inbound/axum_router/tests.rs
@@ -8,6 +8,7 @@ use axum::{
     body::Body,
     http::{Request, StatusCode, header},
 };
+use entity_access::domain::models::TeamRole;
 use entity_access::domain::{
     models::{
         AccessError, AccessLevel, BotId, CallChannelInfo, EntityPermission, EntityType,
@@ -274,7 +275,7 @@ impl EntityAccessService for TestAccessService {
         _user_id: Option<&MacroUserId<Lowercase<'_>>>,
         _entity_id: &str,
         _entity_type: EntityType,
-    ) -> Result<(EntityPermission, uuid::Uuid), AccessError> {
+    ) -> Result<(EntityPermission, uuid::Uuid, TeamRole), AccessError> {
         unimplemented!("bots test mock does not support CRM entity access")
     }
 

--- a/crates/bots/src/inbound/channel_webhook_router/tests.rs
+++ b/crates/bots/src/inbound/channel_webhook_router/tests.rs
@@ -9,6 +9,7 @@ use axum::{
     http::{Request, StatusCode, header},
 };
 use channels::domain::models::PostMessageResponse;
+use entity_access::domain::models::TeamRole;
 use entity_access::domain::{
     models::{
         AccessError, AccessLevel, BotId, CallChannelInfo, EntityPermission, EntityType,
@@ -381,7 +382,7 @@ impl EntityAccessService for TestAccessService {
         _user_id: Option<&MacroUserId<Lowercase<'_>>>,
         _entity_id: &str,
         _entity_type: EntityType,
-    ) -> Result<(EntityPermission, uuid::Uuid), AccessError> {
+    ) -> Result<(EntityPermission, uuid::Uuid, TeamRole), AccessError> {
         unimplemented!("channel webhook router tests do not support CRM entity access")
     }
 

--- a/crates/channels/src/inbound/axum_router/test.rs
+++ b/crates/channels/src/inbound/axum_router/test.rs
@@ -218,7 +218,7 @@ impl EntityAccessService for TestAccessService {
         _user_id: Option<&MacroUserId<Lowercase<'_>>>,
         _entity_id: &str,
         _entity_type: EntityType,
-    ) -> Result<(EntityPermission, uuid::Uuid), AccessError> {
+    ) -> Result<(EntityPermission, uuid::Uuid, TeamRole), AccessError> {
         unimplemented!("channels test mock does not support CRM entity access")
     }
 

--- a/crates/channels/src/inbound/axum_router/test.rs
+++ b/crates/channels/src/inbound/axum_router/test.rs
@@ -15,6 +15,7 @@ use axum::{
     body::Body,
     http::{Request, StatusCode, header},
 };
+use entity_access::domain::models::TeamRole;
 use entity_access::domain::{
     models::{
         AccessError, AccessLevel, BotId, Entity, EntityAccessReceipt, EntityPermission, EntityType,

--- a/crates/chat/src/inbound/test.rs
+++ b/crates/chat/src/inbound/test.rs
@@ -2,6 +2,7 @@ use axum::Extension;
 use axum::Router;
 use axum::body::Body;
 use axum::http::{Request, StatusCode, header};
+use entity_access::domain::models::TeamRole;
 use http_body_util::BodyExt;
 use macro_authorization::{
     InternalIdentityClaims, MacroAuthorizationError, MacroAuthorizationService,
@@ -423,7 +424,7 @@ impl EntityAccessService for MockAccessService {
         _user_id: Option<&MacroUserId<Lowercase<'_>>>,
         _entity_id: &str,
         _entity_type: EntityType,
-    ) -> std::result::Result<(EntityPermission, uuid::Uuid), AccessError> {
+    ) -> std::result::Result<(EntityPermission, uuid::Uuid, TeamRole), AccessError> {
         unimplemented!("chat test mock does not support CRM entity access")
     }
 

--- a/crates/chat/src/inbound/toolset/test.rs
+++ b/crates/chat/src/inbound/toolset/test.rs
@@ -28,7 +28,7 @@ mod self_read_guard {
     use ai_toolset::{AsyncTool, RequestContext, ServiceContext};
     use entity_access::domain::models::{
         AccessError, AccessLevel, BotId, CallChannelInfo, Entity, EntityAccessReceipt,
-        EntityPermission, EntityType, RequiredPermission, UserTeamInfo,
+        EntityPermission, EntityType, RequiredPermission, TeamRole, UserTeamInfo,
     };
     use entity_access::domain::ports::EntityAccessService;
     use macro_user_id::lowercased::Lowercase;
@@ -228,7 +228,7 @@ mod self_read_guard {
             _user_id: Option<&MacroUserId<Lowercase<'_>>>,
             _entity_id: &str,
             _entity_type: EntityType,
-        ) -> std::result::Result<(EntityPermission, Uuid), AccessError> {
+        ) -> std::result::Result<(EntityPermission, Uuid, TeamRole), AccessError> {
             unreachable!("guard should short-circuit before checking access")
         }
 
@@ -489,7 +489,7 @@ mod self_read_guard {
             _user_id: Option<&MacroUserId<Lowercase<'_>>>,
             _entity_id: &str,
             _entity_type: EntityType,
-        ) -> std::result::Result<(EntityPermission, Uuid), AccessError> {
+        ) -> std::result::Result<(EntityPermission, Uuid, TeamRole), AccessError> {
             unimplemented!("stub does not support CRM entity access")
         }
 

--- a/crates/complete_graph/src/schema/test.rs
+++ b/crates/complete_graph/src/schema/test.rs
@@ -388,7 +388,7 @@ impl EntityAccessService for CountingEntityAccessService {
         _user_id: Option<&MacroUserId<Lowercase<'_>>>,
         _entity_id: &str,
         _entity_type: EntityType,
-    ) -> Result<(EntityPermission, Uuid), AccessError> {
+    ) -> Result<(EntityPermission, Uuid, TeamRole), AccessError> {
         Err(AccessError::Internal)
     }
 

--- a/crates/crm/src/domain/auth.rs
+++ b/crates/crm/src/domain/auth.rs
@@ -19,7 +19,7 @@
 //! caller can mint a receipt without passing an access check.
 
 use entity_access::domain::models::{
-    AccessLevel, EntityAccessReceipt, EntityType, RequiredPermission,
+    EntityAccessReceipt, EntityType, RequiredPermission, TeamRole,
 };
 use uuid::Uuid;
 
@@ -30,12 +30,13 @@ mod test;
 
 /// Capability token for a CRM service call addressing a single company.
 ///
-/// `receipt`'s entity is the `CrmCompany`; `team_id` is the owning team,
-/// resolved at mint time.
+/// `receipt`'s entity is the `CrmCompany`; `team_id` is the owning team
+/// and `team_role` the caller's role on it, both resolved at mint time.
 #[derive(Debug)]
 pub struct CrmCompanyReceipt<T: RequiredPermission> {
     receipt: EntityAccessReceipt<T>,
     team_id: Uuid,
+    team_role: TeamRole,
 }
 
 impl<T: RequiredPermission> CrmCompanyReceipt<T> {
@@ -44,8 +45,12 @@ impl<T: RequiredPermission> CrmCompanyReceipt<T> {
     /// when the extractor seam (`axum`) isn't compiled (e.g. crm pulled
     /// in for `ports` only).
     #[cfg_attr(not(feature = "axum"), allow(dead_code))]
-    pub(crate) fn new(receipt: EntityAccessReceipt<T>, team_id: Uuid) -> Self {
-        Self { receipt, team_id }
+    pub(crate) fn new(receipt: EntityAccessReceipt<T>, team_id: Uuid, team_role: TeamRole) -> Self {
+        Self {
+            receipt,
+            team_id,
+            team_role,
+        }
     }
 
     /// The owning team the repository scopes its query by.
@@ -71,22 +76,38 @@ impl<T: RequiredPermission> CrmCompanyReceipt<T> {
             .map_err(|_| CrmError::InvalidRequest("invalid company id".into()))
     }
 
-    /// Whether the caller's role reveals hidden rows (Edit+).
+    /// Whether the caller's team role reveals hidden rows (admin/owner).
     pub(crate) fn include_hidden(&self) -> bool {
-        self.receipt
-            .entity_permission()
-            .allows_access_level(AccessLevel::Edit)
+        self.has_admin_role()
+    }
+
+    /// Whether the caller's actual team role is admin/owner. Used by the
+    /// service to gate governance mutations (hide, email sync) that every
+    /// role can otherwise reach now that members hold Edit.
+    pub(crate) fn has_admin_role(&self) -> bool {
+        self.team_role >= TeamRole::Admin
     }
 
     /// Test-only: mints an `Owner` receipt with no access check.
     #[cfg(test)]
     pub(crate) fn dangerously_internal(company_id: Uuid, team_id: Uuid) -> Self {
+        Self::dangerously_internal_with_role(company_id, team_id, TeamRole::Owner)
+    }
+
+    /// Test-only: like [`Self::dangerously_internal`] with an explicit role.
+    #[cfg(test)]
+    pub(crate) fn dangerously_internal_with_role(
+        company_id: Uuid,
+        team_id: Uuid,
+        team_role: TeamRole,
+    ) -> Self {
         Self {
             receipt: EntityAccessReceipt::dangerously_assert_internal_user(
                 &company_id.to_string(),
                 EntityType::CrmCompany,
             ),
             team_id,
+            team_role,
         }
     }
 }
@@ -94,11 +115,13 @@ impl<T: RequiredPermission> CrmCompanyReceipt<T> {
 /// Capability token for a CRM service call addressing a single contact.
 ///
 /// `receipt`'s entity is the `CrmContact`; `team_id` is the team that
-/// owns the contact's parent company, resolved at mint time.
+/// owns the contact's parent company and `team_role` the caller's role
+/// on it, both resolved at mint time.
 #[derive(Debug)]
 pub struct CrmContactReceipt<T: RequiredPermission> {
     receipt: EntityAccessReceipt<T>,
     team_id: Uuid,
+    team_role: TeamRole,
 }
 
 impl<T: RequiredPermission> CrmContactReceipt<T> {
@@ -106,8 +129,12 @@ impl<T: RequiredPermission> CrmContactReceipt<T> {
     /// extractors can produce one off a verified access check. Unused
     /// when the extractor seam (`axum`) isn't compiled.
     #[cfg_attr(not(feature = "axum"), allow(dead_code))]
-    pub(crate) fn new(receipt: EntityAccessReceipt<T>, team_id: Uuid) -> Self {
-        Self { receipt, team_id }
+    pub(crate) fn new(receipt: EntityAccessReceipt<T>, team_id: Uuid, team_role: TeamRole) -> Self {
+        Self {
+            receipt,
+            team_id,
+            team_role,
+        }
     }
 
     /// The owning team the repository scopes its query by.
@@ -132,23 +159,40 @@ impl<T: RequiredPermission> CrmContactReceipt<T> {
             .map_err(|_| CrmError::InvalidRequest("invalid contact id".into()))
     }
 
-    /// Whether the caller's role reveals hidden rows (Edit+).
+    /// Whether the caller's team role reveals hidden rows (admin/owner).
     pub(crate) fn include_hidden(&self) -> bool {
-        self.receipt
-            .entity_permission()
-            .allows_access_level(AccessLevel::Edit)
+        self.has_admin_role()
+    }
+
+    /// Whether the caller's actual team role is admin/owner. Used by the
+    /// service to gate governance mutations (hide) that every role can
+    /// otherwise reach now that members hold Edit.
+    pub(crate) fn has_admin_role(&self) -> bool {
+        self.team_role >= TeamRole::Admin
     }
 
     /// Test-only: mints an `Owner` receipt with no access check.
     #[cfg(test)]
     #[allow(dead_code)]
     pub(crate) fn dangerously_internal(contact_id: Uuid, team_id: Uuid) -> Self {
+        Self::dangerously_internal_with_role(contact_id, team_id, TeamRole::Owner)
+    }
+
+    /// Test-only: like [`Self::dangerously_internal`] with an explicit role.
+    #[cfg(test)]
+    #[allow(dead_code)]
+    pub(crate) fn dangerously_internal_with_role(
+        contact_id: Uuid,
+        team_id: Uuid,
+        team_role: TeamRole,
+    ) -> Self {
         Self {
             receipt: EntityAccessReceipt::dangerously_assert_internal_user(
                 &contact_id.to_string(),
                 EntityType::CrmContact,
             ),
             team_id,
+            team_role,
         }
     }
 }
@@ -221,11 +265,13 @@ impl<T: RequiredPermission> CrmTeamReceipt<T> {
 
 /// Capability token for a CRM comment service call. The `receipt`'s
 /// entity is the comment's owning CRM company or contact; `team_id` is
-/// the owning team, resolved at mint time.
+/// the owning team and `team_role` the caller's role on it, both
+/// resolved at mint time.
 #[derive(Debug)]
 pub struct CrmCommentReceipt<T: RequiredPermission> {
     receipt: EntityAccessReceipt<T>,
     team_id: Uuid,
+    team_role: TeamRole,
 }
 
 impl<T: RequiredPermission> CrmCommentReceipt<T> {
@@ -234,9 +280,17 @@ impl<T: RequiredPermission> CrmCommentReceipt<T> {
     /// not for a CRM company or contact. Unused when the extractor seam
     /// (`axum`) isn't compiled.
     #[cfg_attr(not(feature = "axum"), allow(dead_code))]
-    pub(crate) fn new(receipt: EntityAccessReceipt<T>, team_id: Uuid) -> Result<Self, CrmError> {
+    pub(crate) fn new(
+        receipt: EntityAccessReceipt<T>,
+        team_id: Uuid,
+        team_role: TeamRole,
+    ) -> Result<Self, CrmError> {
         match receipt.entity().entity_type {
-            EntityType::CrmCompany | EntityType::CrmContact => Ok(Self { receipt, team_id }),
+            EntityType::CrmCompany | EntityType::CrmContact => Ok(Self {
+                receipt,
+                team_id,
+                team_role,
+            }),
             _ => Err(CrmError::InvalidRequest(
                 "receipt is not for a CrmCompany or CrmContact".into(),
             )),
@@ -253,11 +307,10 @@ impl<T: RequiredPermission> CrmCommentReceipt<T> {
         &self.receipt
     }
 
-    /// Whether the caller's role reveals comments on hidden parents (Edit+).
+    /// Whether the caller's team role reveals comments on hidden parents
+    /// (admin/owner).
     pub(crate) fn include_hidden(&self) -> bool {
-        self.receipt
-            .entity_permission()
-            .allows_access_level(AccessLevel::Edit)
+        self.team_role >= TeamRole::Admin
     }
 
     /// The CRM entity (type + id) the comment hangs off, derived from
@@ -296,6 +349,7 @@ impl<T: RequiredPermission> CrmCommentReceipt<T> {
                 et,
             ),
             team_id,
+            team_role: TeamRole::Owner,
         }
     }
 }

--- a/crates/crm/src/domain/auth/test.rs
+++ b/crates/crm/src/domain/auth/test.rs
@@ -1,5 +1,5 @@
 use super::*;
-use entity_access::domain::models::{EntityAccessReceipt, EntityType, ViewAccessLevel};
+use entity_access::domain::models::{EntityAccessReceipt, EntityType, TeamRole, ViewAccessLevel};
 
 fn company_uuid() -> Uuid {
     Uuid::from_u128(0x1111_1111_1111_1111_1111_1111_1111_1111)
@@ -19,6 +19,7 @@ fn company_receipt_exposes_company_id_and_team() {
             EntityType::CrmCompany,
         ),
         team,
+        TeamRole::Owner,
     );
 
     assert_eq!(access.company_id().unwrap(), company);
@@ -35,6 +36,7 @@ fn company_receipt_rejects_wrong_entity_type() {
             EntityType::Team,
         ),
         team_uuid(),
+        TeamRole::Owner,
     );
 
     assert!(matches!(
@@ -52,6 +54,7 @@ fn contact_receipt_exposes_contact_id() {
             EntityType::CrmContact,
         ),
         team_uuid(),
+        TeamRole::Owner,
     );
 
     assert_eq!(access.contact_id().unwrap(), contact);
@@ -95,6 +98,7 @@ fn comment_receipt_derives_entity_and_rejects_non_crm() {
             EntityType::CrmContact,
         ),
         team_uuid(),
+        TeamRole::Owner,
     )
     .unwrap();
 
@@ -111,6 +115,7 @@ fn comment_receipt_derives_entity_and_rejects_non_crm() {
                 EntityType::Team,
             ),
             team_uuid(),
+            TeamRole::Owner,
         )
         .is_err()
     );

--- a/crates/crm/src/domain/model.rs
+++ b/crates/crm/src/domain/model.rs
@@ -246,8 +246,9 @@ pub struct CrmAddressStatus {
     pub email_sync: bool,
 }
 
-/// Minimum team role required for a CRM capability. Members are
-/// view-only at the platform level, so the configurable range is
+/// Minimum team role required for a CRM governance capability. Members
+/// can edit visible CRM records (e.g. company properties), but the
+/// governance capabilities these settings gate stay restricted to
 /// admin (default) vs owner. Maps to the `team_role` Postgres enum;
 /// `member` is deliberately not representable.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]

--- a/crates/crm/src/domain/service.rs
+++ b/crates/crm/src/domain/service.rs
@@ -195,7 +195,8 @@ pub trait CrmService: Clone + Send + Sync + 'static {
 
     /// Toggle `email_sync` for the company addressed by `access`. Purely
     /// a visibility/permission flag — populate continues to write CRM
-    /// rows regardless. See
+    /// rows regardless. Requires an admin/owner role on the receipt;
+    /// returns [`CrmError::AdminRoleRequired`] otherwise. See
     /// [`crate::domain::companies_repo::CompaniesRepository::set_email_sync`].
     fn set_email_sync(
         &self,
@@ -208,7 +209,8 @@ pub trait CrmService: Clone + Send + Sync + 'static {
     /// contact (`hidden = TRUE`), un-hide soft-restores them (`hidden =
     /// FALSE`). Contact rows and `crm_contact_sources` are preserved
     /// across the cycle. Hide additionally forces `email_sync = false`;
-    /// un-hide leaves `email_sync` as-is. See
+    /// un-hide leaves `email_sync` as-is. Requires an admin/owner role on
+    /// the receipt; returns [`CrmError::AdminRoleRequired`] otherwise. See
     /// [`crate::domain::companies_repo::CompaniesRepository::set_company_hidden`].
     fn set_company_hidden(
         &self,
@@ -218,7 +220,8 @@ pub trait CrmService: Clone + Send + Sync + 'static {
 
     /// Toggle the `hidden` flag on the contact addressed by `access`.
     /// Hiding is a display-only opt-out and does not affect
-    /// populate/depopulate.
+    /// populate/depopulate. Requires an admin/owner role on the receipt;
+    /// returns [`CrmError::AdminRoleRequired`] otherwise.
     fn set_contact_hidden(
         &self,
         access: &CrmContactReceipt<EditAccessLevel>,
@@ -694,6 +697,9 @@ where
         access: &CrmCompanyReceipt<EditAccessLevel>,
         email_sync: bool,
     ) -> Result<(), CrmError> {
+        if !access.has_admin_role() {
+            return Err(CrmError::AdminRoleRequired);
+        }
         let team_id = access.team_id();
         let company_id = access.company_id()?;
         self.companies_repository
@@ -707,6 +713,9 @@ where
         access: &CrmCompanyReceipt<EditAccessLevel>,
         hidden: bool,
     ) -> Result<(), CrmError> {
+        if !access.has_admin_role() {
+            return Err(CrmError::AdminRoleRequired);
+        }
         let team_id = access.team_id();
         let company_id = access.company_id()?;
         self.companies_repository
@@ -720,6 +729,9 @@ where
         access: &CrmContactReceipt<EditAccessLevel>,
         hidden: bool,
     ) -> Result<(), CrmError> {
+        if !access.has_admin_role() {
+            return Err(CrmError::AdminRoleRequired);
+        }
         let team_id = access.team_id();
         let contact_id = access.contact_id()?;
         self.companies_repository

--- a/crates/crm/src/domain/service/test.rs
+++ b/crates/crm/src/domain/service/test.rs
@@ -96,7 +96,7 @@ impl CompaniesRepository for StubRepo {
         _company_id: &uuid::Uuid,
         _email_sync: bool,
     ) -> Result<(), CrmError> {
-        unimplemented!()
+        Ok(())
     }
 
     async fn set_company_hidden(
@@ -105,7 +105,7 @@ impl CompaniesRepository for StubRepo {
         _company_id: &uuid::Uuid,
         _hidden: bool,
     ) -> Result<(), CrmError> {
-        unimplemented!()
+        Ok(())
     }
 
     async fn set_contact_hidden(
@@ -114,7 +114,7 @@ impl CompaniesRepository for StubRepo {
         _contact_id: &uuid::Uuid,
         _hidden: bool,
     ) -> Result<(), CrmError> {
-        unimplemented!()
+        Ok(())
     }
 
     async fn crm_scope_precheck(
@@ -445,5 +445,69 @@ async fn create_contact_rejects_malformed_emails() {
             matches!(err, CrmError::InvalidRequest(_)),
             "email {email:?}"
         );
+    }
+}
+
+fn company_edit_receipt_with_role(role: TeamRole) -> CrmCompanyReceipt<EditAccessLevel> {
+    CrmCompanyReceipt::dangerously_internal_with_role(
+        uuid::Uuid::now_v7(),
+        uuid::Uuid::now_v7(),
+        role,
+    )
+}
+
+fn contact_edit_receipt_with_role(role: TeamRole) -> CrmContactReceipt<EditAccessLevel> {
+    CrmContactReceipt::dangerously_internal_with_role(
+        uuid::Uuid::now_v7(),
+        uuid::Uuid::now_v7(),
+        role,
+    )
+}
+
+#[tokio::test]
+async fn set_email_sync_requires_admin_role() {
+    let err = service()
+        .set_email_sync(&company_edit_receipt_with_role(TeamRole::Member), true)
+        .await
+        .unwrap_err();
+    assert!(matches!(err, CrmError::AdminRoleRequired));
+
+    for role in [TeamRole::Admin, TeamRole::Owner] {
+        service()
+            .set_email_sync(&company_edit_receipt_with_role(role), true)
+            .await
+            .unwrap();
+    }
+}
+
+#[tokio::test]
+async fn set_company_hidden_requires_admin_role() {
+    let err = service()
+        .set_company_hidden(&company_edit_receipt_with_role(TeamRole::Member), true)
+        .await
+        .unwrap_err();
+    assert!(matches!(err, CrmError::AdminRoleRequired));
+
+    for role in [TeamRole::Admin, TeamRole::Owner] {
+        service()
+            .set_company_hidden(&company_edit_receipt_with_role(role), true)
+            .await
+            .unwrap();
+    }
+}
+
+#[tokio::test]
+async fn set_contact_hidden_requires_admin_role() {
+    let err = service()
+        .set_contact_hidden(&contact_edit_receipt_with_role(TeamRole::Member), true)
+        .await
+        .unwrap_err();
+    assert!(matches!(err, CrmError::AdminRoleRequired));
+
+    for role in [TeamRole::Admin, TeamRole::Owner] {
+        service()
+            .set_contact_hidden(&contact_edit_receipt_with_role(role), true)
+            .await
+            .unwrap();
     }
 }

--- a/crates/crm/src/inbound/axum_extractors.rs
+++ b/crates/crm/src/inbound/axum_extractors.rs
@@ -46,9 +46,11 @@ use crate::{
 /// router state, supporting direct credentials and internal service callers.
 ///
 /// Access derives from the caller's role on the owning team: team owners
-/// get `Owner`, admins get `Edit`, members get `View`. Hidden companies are
+/// get `Owner`, admins and members get `Edit`. Hidden companies are
 /// invisible to plain members — the extractor returns `Unauthorized` rather
-/// than leak existence.
+/// than leak existence. The caller's team role rides along in the receipt
+/// so the service can gate hidden-row visibility and governance mutations
+/// on admin/owner.
 ///
 /// Reads `company_id` from the path. The access check resolves the company's
 /// owning `team_id` from the same ownership row and bundles it into the
@@ -88,7 +90,7 @@ where
                 .map_err(ExtractorError::from)?;
         let macro_user_id = authorization.authorization.user.macro_user_id.clone();
 
-        let (permission, team_id) = service
+        let (permission, team_id, team_role) = service
             .get_crm_entity_permission_with_team(
                 Some(&macro_user_id),
                 &company_id,
@@ -111,7 +113,7 @@ where
         )?;
 
         Ok(Self {
-            receipt: CrmCompanyReceipt::new(receipt, team_id),
+            receipt: CrmCompanyReceipt::new(receipt, team_id, team_role),
             _marker: PhantomData,
         })
     }
@@ -164,7 +166,7 @@ where
                 .map_err(ExtractorError::from)?;
         let macro_user_id = authorization.authorization.user.macro_user_id.clone();
 
-        let (permission, team_id) = service
+        let (permission, team_id, team_role) = service
             .get_crm_entity_permission_with_team(
                 Some(&macro_user_id),
                 &contact_id,
@@ -187,7 +189,7 @@ where
         )?;
 
         Ok(Self {
-            receipt: CrmContactReceipt::new(receipt, team_id),
+            receipt: CrmContactReceipt::new(receipt, team_id, team_role),
             _marker: PhantomData,
         })
     }
@@ -254,11 +256,11 @@ where
         // can't tell apart "this comment doesn't exist" (404) from "this
         // comment exists but isn't yours" (401) — comment ids would
         // otherwise be a probable existence oracle.
-        let (permission, team_id) = match access_service
+        let (permission, team_id, team_role) = match access_service
             .get_crm_entity_permission_with_team(Some(&macro_user_id), &entity_id_str, entity_type)
             .await
         {
-            Ok(pair) => pair,
+            Ok(triple) => triple,
             Err(AccessError::Unauthorized | AccessError::UnauthorizedWithMessage(_)) => {
                 return Err(ExtractorError::NotFound("CRM comment not found"));
             }
@@ -280,8 +282,8 @@ where
 
         // entity_type is CrmCompany / CrmContact by construction, so this
         // never errors; surface any future mismatch as Internal.
-        let receipt =
-            CrmCommentReceipt::new(receipt, team_id).map_err(|_| ExtractorError::Internal)?;
+        let receipt = CrmCommentReceipt::new(receipt, team_id, team_role)
+            .map_err(|_| ExtractorError::Internal)?;
 
         Ok(Self {
             receipt,

--- a/crates/crm/src/inbound/axum_extractors/test.rs
+++ b/crates/crm/src/inbound/axum_extractors/test.rs
@@ -1,3 +1,4 @@
+use entity_access::domain::models::TeamRole;
 use std::sync::{Arc, Mutex};
 
 use axum::{
@@ -177,7 +178,7 @@ impl EntityAccessService for FakeEntityAccessService {
         user_id: Option<&MacroUserId<Lowercase<'_>>>,
         entity_id: &str,
         entity_type: EntityType,
-    ) -> Result<(EntityPermission, Uuid), AccessError> {
+    ) -> Result<(EntityPermission, Uuid, TeamRole), AccessError> {
         self.calls
             .lock()
             .expect("calls lock poisoned")
@@ -188,7 +189,18 @@ impl EntityAccessService for FakeEntityAccessService {
             });
 
         match self.result {
-            PermissionResult::Allowed(permission) => Ok((permission, uuid(TEAM_ID))),
+            // Pair the permission with the team role that would have
+            // produced it (owner → Owner, edit → Admin, else Member).
+            PermissionResult::Allowed(permission) => {
+                let team_role = if permission.allows_access_level(AccessLevel::Owner) {
+                    TeamRole::Owner
+                } else if permission.allows_access_level(AccessLevel::Edit) {
+                    TeamRole::Admin
+                } else {
+                    TeamRole::Member
+                };
+                Ok((permission, uuid(TEAM_ID), team_role))
+            }
             PermissionResult::Unauthorized => Err(AccessError::Unauthorized),
         }
     }

--- a/crates/crm/src/inbound/axum_router/comments.rs
+++ b/crates/crm/src/inbound/axum_router/comments.rs
@@ -14,7 +14,10 @@ use axum::{
     extract::{Path, State},
 };
 use entity_access::{
-    domain::{models::ViewAccessLevel, ports::EntityAccessService},
+    domain::{
+        models::{TeamRole, ViewAccessLevel},
+        ports::EntityAccessService,
+    },
     inbound::axum_extractors::EntityPermissionExtractor,
 };
 use macro_authorization::MacroAuthorizationService;
@@ -90,8 +93,8 @@ pub async fn list_handler<
     State(state): State<CrmRouterState<C, Eas, Auth>>,
     Path((_entity_type, entity_id)): Path<(CrmCommentEntityType, Uuid)>,
 ) -> Result<Json<Vec<CrmCommentThread>>, CrmError> {
-    let team_id = owning_team_for_entity(&state, &access).await?;
-    let receipt = CrmCommentReceipt::new(access.entity_access_receipt, team_id)?;
+    let (team_id, team_role) = owning_team_for_entity(&state, &access).await?;
+    let receipt = CrmCommentReceipt::new(access.entity_access_receipt, team_id, team_role)?;
 
     let threads = state.service.get_crm_comment_threads(&receipt).await?;
 
@@ -129,7 +132,7 @@ pub async fn create_handler<
     Path((_entity_type, entity_id)): Path<(CrmCommentEntityType, Uuid)>,
     Json(req): Json<CreateCrmCommentRequest>,
 ) -> Result<Json<CrmCommentThread>, CrmError> {
-    let team_id = owning_team_for_entity(&state, &access).await?;
+    let (team_id, team_role) = owning_team_for_entity(&state, &access).await?;
 
     let text = req.text.trim();
     if text.is_empty() {
@@ -138,7 +141,7 @@ pub async fn create_handler<
         ));
     }
 
-    let receipt = CrmCommentReceipt::new(access.entity_access_receipt, team_id)?;
+    let receipt = CrmCommentReceipt::new(access.entity_access_receipt, team_id, team_role)?;
     let owner = receipt
         .receipt()
         .get_authenticated_user()
@@ -237,11 +240,12 @@ pub async fn delete_handler<
     Ok(Json(result))
 }
 
-/// Resolve the owning team of the entity the comment hangs off, derived from
-/// the same ownership lookup that grants access — not the caller's default
-/// team — so the bundled team can't drift from the authorized entity.
-/// `EntityPermissionExtractor` already validated access on that entity, so a
-/// failure here means corrupted state rather than a real authorization miss.
+/// Resolve the owning team of the entity the comment hangs off — and the
+/// caller's role on it — derived from the same ownership lookup that grants
+/// access, not the caller's default team, so the bundled team can't drift
+/// from the authorized entity. `EntityPermissionExtractor` already validated
+/// access on that entity, so a failure here means corrupted state rather
+/// than a real authorization miss.
 async fn owning_team_for_entity<
     C: CrmService,
     Eas: EntityAccessService,
@@ -249,13 +253,13 @@ async fn owning_team_for_entity<
 >(
     state: &CrmRouterState<C, Eas, Auth>,
     access: &EntityPermissionExtractor<Eas, Auth>,
-) -> Result<Uuid, CrmError> {
+) -> Result<(Uuid, TeamRole), CrmError> {
     let user_id = access
         .entity_access_receipt
         .get_authenticated_user()
         .map_err(|e| CrmError::StorageLayerError(e.into()))?;
     let entity = access.entity_access_receipt.entity();
-    let (_permission, team_id) = state
+    let (_permission, team_id, team_role) = state
         .entity_access_service
         .get_crm_entity_permission_with_team(
             Some(&user_id.0),
@@ -264,5 +268,5 @@ async fn owning_team_for_entity<
         )
         .await
         .map_err(|e| CrmError::StorageLayerError(anyhow::Error::msg(e.to_string())))?;
-    Ok(team_id)
+    Ok((team_id, team_role))
 }

--- a/crates/crm/src/inbound/toolset/get_company.rs
+++ b/crates/crm/src/inbound/toolset/get_company.rs
@@ -157,7 +157,7 @@ where
         // Resolve the caller's permission on this company (derived from
         // their role on the owning team). Access failures collapse to
         // "not found" so company ids can't be probed across teams.
-        let (permission, team_id) = match service_context
+        let (permission, team_id, team_role) = match service_context
             .entity_access_service
             .get_crm_entity_permission_with_team(
                 Some(&request_context.user_id),
@@ -166,7 +166,7 @@ where
             )
             .await
         {
-            Ok(pair) => pair,
+            Ok(triple) => triple,
             Err(
                 AccessError::Unauthorized
                 | AccessError::UnauthorizedWithMessage(_)
@@ -196,7 +196,7 @@ where
             description: "failed to verify access to the CRM company".to_string(),
             internal_error: e.into(),
         })?;
-        let receipt = CrmCompanyReceipt::new(receipt, team_id);
+        let receipt = CrmCompanyReceipt::new(receipt, team_id, team_role);
 
         let record = service_context
             .service

--- a/crates/documents/src/inbound/axum_router/tests.rs
+++ b/crates/documents/src/inbound/axum_router/tests.rs
@@ -625,7 +625,7 @@ impl EntityAccessService for FakeEntityAccessService {
         _user_id: Option<&MacroUserId<Lowercase<'_>>>,
         _entity_id: &str,
         _entity_type: EntityType,
-    ) -> Result<(EntityPermission, Uuid), AccessError> {
+    ) -> Result<(EntityPermission, Uuid, TeamRole), AccessError> {
         panic!("unexpected get_crm_entity_permission_with_team call")
     }
 

--- a/crates/entity_access/src/domain/models.rs
+++ b/crates/entity_access/src/domain/models.rs
@@ -26,6 +26,9 @@ pub struct CrmEntityAccess {
     pub access_level: AccessLevel,
     /// The team that owns the entity.
     pub team_id: Uuid,
+    /// The role the user holds on the owning team. Hidden-row visibility
+    /// keys on this (admin/owner) rather than on the access level.
+    pub team_role: TeamRole,
 }
 
 /// The role a user has within a channel.

--- a/crates/entity_access/src/domain/ports.rs
+++ b/crates/entity_access/src/domain/ports.rs
@@ -5,7 +5,8 @@
 use super::models::EntityType;
 use crate::domain::models::{
     AccessError, AccessLevel, BotId, CallChannelInfo, ChannelRoleResult, CrmEntityAccess,
-    EntityAccessReceipt, EntityPermission, RequiredPermission, UserTeamInfo, ViewAccessLevel,
+    EntityAccessReceipt, EntityPermission, RequiredPermission, TeamRole, UserTeamInfo,
+    ViewAccessLevel,
 };
 use macro_user_id::{lowercased::Lowercase, user_id::MacroUserId, user_id::MacroUserIdStr};
 use std::{collections::HashMap, future::Future};
@@ -95,11 +96,11 @@ pub trait AccessRepository: Clone + Send + Sync + 'static {
     /// owning `team_id`.
     ///
     /// Access derives from the user's role on the team that owns the company:
-    /// `Owner` → [`AccessLevel::Owner`], `Admin` → [`AccessLevel::Edit`],
-    /// `Member` → [`AccessLevel::View`]. Hidden companies are invisible to
-    /// plain members (returns `None`) but reachable by admins and owners. The
-    /// returned `team_id` is the company's owning team, resolved from the same
-    /// row that grants access.
+    /// `Owner` → [`AccessLevel::Owner`], `Admin` and `Member` →
+    /// [`AccessLevel::Edit`]. Hidden companies are invisible to plain members
+    /// (returns `None`) but reachable by admins and owners. The returned
+    /// `team_id` is the company's owning team and `team_role` the user's role
+    /// on it, both resolved from the same row that grants access.
     fn get_crm_company_access(
         &self,
         company_id: &str,
@@ -297,12 +298,14 @@ pub trait EntityAccessService: Clone + Send + Sync + 'static {
     ) -> impl Future<Output = Result<EntityPermission, AccessError>> + Send;
 
     /// Resolve a user's permission for a CRM company or contact **together
-    /// with the entity's owning `team_id`** — the team that owns the entity
-    /// and that the user belongs to, resolved from the same ownership lookup
-    /// that grants access. Mint team-scoped CRM receipts off this rather than
-    /// pairing [`Self::get_entity_permission`] with [`Self::get_user_team`],
-    /// so the bundled team can't drift from the authorized entity for a
-    /// multi-team user. Errors `AccessError::Unauthorized` when access fails.
+    /// with the entity's owning `team_id` and the user's role on that team**
+    /// — all resolved from the same ownership lookup that grants access.
+    /// Mint team-scoped CRM receipts off this rather than pairing
+    /// [`Self::get_entity_permission`] with [`Self::get_user_team`], so the
+    /// bundled team can't drift from the authorized entity for a multi-team
+    /// user. The role rides along so CRM receipts can gate hidden-row
+    /// visibility and governance actions on admin/owner without a second
+    /// lookup. Errors `AccessError::Unauthorized` when access fails.
     ///
     /// No default impl on purpose: implementors must derive the team from the
     /// entity's ownership row (not the user's default team), so the invariant
@@ -312,7 +315,7 @@ pub trait EntityAccessService: Clone + Send + Sync + 'static {
         user_id: Option<&MacroUserId<Lowercase<'_>>>,
         entity_id: &str,
         entity_type: EntityType,
-    ) -> impl Future<Output = Result<(EntityPermission, Uuid), AccessError>> + Send;
+    ) -> impl Future<Output = Result<(EntityPermission, Uuid, TeamRole), AccessError>> + Send;
 
     /// Get all user IDs that have access to a given entity.
     ///
@@ -420,7 +423,7 @@ impl EntityAccessService for NoOpEntityAccessService {
         _user_id: Option<&MacroUserId<Lowercase<'_>>>,
         _entity_id: &str,
         _entity_type: EntityType,
-    ) -> Result<(EntityPermission, Uuid), AccessError> {
+    ) -> Result<(EntityPermission, Uuid, TeamRole), AccessError> {
         Err(AccessError::Internal)
     }
 

--- a/crates/entity_access/src/domain/service.rs
+++ b/crates/entity_access/src/domain/service.rs
@@ -6,7 +6,7 @@ use crate::domain::{
     models::{
         AccessError, AccessLevel, BotId, CallChannelInfo, ChannelRoleResult, CrmEntityAccess,
         Entity, EntityAccessAuth, EntityAccessReceipt, EntityPermission, EntityType,
-        RequiredPermission, UserTeamInfo, ViewAccessLevel,
+        RequiredPermission, TeamRole, UserTeamInfo, ViewAccessLevel,
     },
     ports::{AccessRepository, EntityAccessService},
 };
@@ -423,10 +423,10 @@ where
         user_id: Option<&MacroUserId<Lowercase<'_>>>,
         entity_id: &str,
         entity_type: EntityType,
-    ) -> Result<(EntityPermission, Uuid), AccessError> {
-        // Resolve permission and owning team from one ownership lookup, so the
-        // team is the entity's owner (and the user is a member of it) rather
-        // than the user's default team.
+    ) -> Result<(EntityPermission, Uuid, TeamRole), AccessError> {
+        // Resolve permission, owning team, and team role from one ownership
+        // lookup, so the team is the entity's owner (and the user is a member
+        // of it) rather than the user's default team.
         let access = match entity_type {
             EntityType::CrmCompany => self.get_crm_company_access(entity_id, user_id).await?,
             EntityType::CrmContact => self.get_crm_contact_access(entity_id, user_id).await?,
@@ -442,6 +442,7 @@ where
                 access_level: access.access_level,
             },
             access.team_id,
+            access.team_role,
         ))
     }
 

--- a/crates/entity_access/src/domain/service/test.rs
+++ b/crates/entity_access/src/domain/service/test.rs
@@ -270,11 +270,12 @@ impl AccessRepository for MockRepo {
         _company_id: &str,
         _user_id: Option<&MacroUserId<Lowercase<'_>>>,
     ) -> Result<Option<CrmEntityAccess>, AccessError> {
-        // Owning team is irrelevant to these access-level tests; pair with nil.
+        // Owning team / role are irrelevant to these access-level tests.
         Ok(
             (*self.crm_company_access.lock().await).map(|access_level| CrmEntityAccess {
                 access_level,
                 team_id: Uuid::nil(),
+                team_role: TeamRole::Member,
             }),
         )
     }
@@ -284,11 +285,12 @@ impl AccessRepository for MockRepo {
         _contact_id: &str,
         _user_id: Option<&MacroUserId<Lowercase<'_>>>,
     ) -> Result<Option<CrmEntityAccess>, AccessError> {
-        // Owning team is irrelevant to these access-level tests; pair with nil.
+        // Owning team / role are irrelevant to these access-level tests.
         Ok(
             (*self.crm_contact_access.lock().await).map(|access_level| CrmEntityAccess {
                 access_level,
                 team_id: Uuid::nil(),
+                team_role: TeamRole::Member,
             }),
         )
     }

--- a/crates/entity_access/src/inbound/axum_extractors/call/test.rs
+++ b/crates/entity_access/src/inbound/axum_extractors/call/test.rs
@@ -1,3 +1,4 @@
+use crate::domain::models::TeamRole;
 use std::sync::{Arc, Mutex};
 
 use axum::{
@@ -190,7 +191,7 @@ impl EntityAccessService for FakeEntityAccessService {
         _user_id: Option<&MacroUserId<Lowercase<'_>>>,
         _entity_id: &str,
         _entity_type: EntityType,
-    ) -> Result<(EntityPermission, Uuid), AccessError> {
+    ) -> Result<(EntityPermission, Uuid, TeamRole), AccessError> {
         panic!("unexpected get_crm_entity_permission_with_team call")
     }
 

--- a/crates/entity_access/src/inbound/axum_extractors/channel/test.rs
+++ b/crates/entity_access/src/inbound/axum_extractors/channel/test.rs
@@ -1,3 +1,4 @@
+use crate::domain::models::TeamRole;
 use std::sync::{Arc, Mutex};
 
 use axum::{
@@ -136,7 +137,7 @@ impl EntityAccessService for FakeEntityAccessService {
         _user_id: Option<&MacroUserId<Lowercase<'_>>>,
         _entity_id: &str,
         _entity_type: EntityType,
-    ) -> Result<(EntityPermission, Uuid), AccessError> {
+    ) -> Result<(EntityPermission, Uuid, TeamRole), AccessError> {
         panic!("unexpected get_crm_entity_permission_with_team call")
     }
 

--- a/crates/entity_access/src/inbound/axum_extractors/chat/test.rs
+++ b/crates/entity_access/src/inbound/axum_extractors/chat/test.rs
@@ -1,3 +1,4 @@
+use crate::domain::models::TeamRole;
 use std::sync::{Arc, Mutex};
 
 use axum::{
@@ -133,7 +134,7 @@ impl EntityAccessService for FakeEntityAccessService {
         _user_id: Option<&MacroUserId<Lowercase<'_>>>,
         _entity_id: &str,
         _entity_type: EntityType,
-    ) -> Result<(EntityPermission, Uuid), AccessError> {
+    ) -> Result<(EntityPermission, Uuid, TeamRole), AccessError> {
         panic!("unexpected get_crm_entity_permission_with_team call")
     }
 

--- a/crates/entity_access/src/inbound/axum_extractors/document/test.rs
+++ b/crates/entity_access/src/inbound/axum_extractors/document/test.rs
@@ -1,3 +1,4 @@
+use crate::domain::models::TeamRole;
 use std::sync::{Arc, Mutex};
 
 use axum::{
@@ -138,7 +139,7 @@ impl EntityAccessService for FakeEntityAccessService {
         _user_id: Option<&MacroUserId<Lowercase<'_>>>,
         _entity_id: &str,
         _entity_type: EntityType,
-    ) -> Result<(EntityPermission, Uuid), AccessError> {
+    ) -> Result<(EntityPermission, Uuid, TeamRole), AccessError> {
         panic!("unexpected get_crm_entity_permission_with_team call")
     }
 

--- a/crates/entity_access/src/inbound/axum_extractors/entity_permission/test.rs
+++ b/crates/entity_access/src/inbound/axum_extractors/entity_permission/test.rs
@@ -1,3 +1,4 @@
+use crate::domain::models::TeamRole;
 use std::sync::{Arc, Mutex};
 
 use axum::{
@@ -148,7 +149,7 @@ impl EntityAccessService for FakeEntityAccessService {
         _user_id: Option<&MacroUserId<Lowercase<'_>>>,
         _entity_id: &str,
         _entity_type: EntityType,
-    ) -> Result<(EntityPermission, Uuid), AccessError> {
+    ) -> Result<(EntityPermission, Uuid, TeamRole), AccessError> {
         panic!("unexpected get_crm_entity_permission_with_team call")
     }
 

--- a/crates/entity_access/src/inbound/axum_extractors/project/test.rs
+++ b/crates/entity_access/src/inbound/axum_extractors/project/test.rs
@@ -1,3 +1,4 @@
+use crate::domain::models::TeamRole;
 use std::sync::{Arc, Mutex};
 
 use axum::{
@@ -139,7 +140,7 @@ impl EntityAccessService for FakeEntityAccessService {
         _user_id: Option<&MacroUserId<Lowercase<'_>>>,
         _entity_id: &str,
         _entity_type: EntityType,
-    ) -> Result<(EntityPermission, Uuid), AccessError> {
+    ) -> Result<(EntityPermission, Uuid, TeamRole), AccessError> {
         panic!("unexpected get_crm_entity_permission_with_team call")
     }
 

--- a/crates/entity_access/src/inbound/axum_extractors/team/test.rs
+++ b/crates/entity_access/src/inbound/axum_extractors/team/test.rs
@@ -136,7 +136,7 @@ impl EntityAccessService for FakeEntityAccessService {
         _user_id: Option<&MacroUserId<Lowercase<'_>>>,
         _entity_id: &str,
         _entity_type: EntityType,
-    ) -> Result<(EntityPermission, Uuid), AccessError> {
+    ) -> Result<(EntityPermission, Uuid, TeamRole), AccessError> {
         Err(AccessError::Internal)
     }
 

--- a/crates/entity_access/src/inbound/axum_extractors/test_support.rs
+++ b/crates/entity_access/src/inbound/axum_extractors/test_support.rs
@@ -1,3 +1,4 @@
+use crate::domain::models::TeamRole;
 use std::sync::{Arc, Mutex};
 
 use axum::extract::FromRef;
@@ -124,7 +125,7 @@ impl EntityAccessService for FakeEntityAccessService {
         _user_id: Option<&MacroUserId<Lowercase<'_>>>,
         _entity_id: &str,
         _entity_type: EntityType,
-    ) -> Result<(EntityPermission, Uuid), AccessError> {
+    ) -> Result<(EntityPermission, Uuid, TeamRole), AccessError> {
         panic!("unexpected get_crm_entity_permission_with_team call")
     }
 

--- a/crates/entity_access/src/outbound/pg_access_repo/queries/crm_company_access.rs
+++ b/crates/entity_access/src/outbound/pg_access_repo/queries/crm_company_access.rs
@@ -42,18 +42,22 @@ pub async fn get_crm_company_access(
         team_role_to_access_level(r.role, r.hidden).map(|access_level| CrmEntityAccess {
             access_level,
             team_id: r.team_id,
+            team_role: r.role,
         })
     }))
 }
 
 /// Map a team role + hidden flag to an [`AccessLevel`].
 ///
-/// Hidden CRM rows are invisible to plain members; admins and owners keep
-/// their normal access.
+/// Every team role can edit visible CRM rows (members included, so they can
+/// change company properties like Stage / Owner / Revenue). Hidden CRM rows
+/// are invisible to plain members; admins and owners keep their normal
+/// access. Governance actions (hiding rows, email sync) are gated on the
+/// team role by the CRM domain service, not on the access level.
 pub(super) fn team_role_to_access_level(role: TeamRole, hidden: bool) -> Option<AccessLevel> {
     match (role, hidden) {
         (TeamRole::Member, true) => None,
-        (TeamRole::Member, false) => Some(AccessLevel::View),
+        (TeamRole::Member, false) => Some(AccessLevel::Edit),
         (TeamRole::Admin, _) => Some(AccessLevel::Edit),
         (TeamRole::Owner, _) => Some(AccessLevel::Owner),
     }

--- a/crates/entity_access/src/outbound/pg_access_repo/queries/crm_contact_access.rs
+++ b/crates/entity_access/src/outbound/pg_access_repo/queries/crm_contact_access.rs
@@ -45,6 +45,7 @@ pub async fn get_crm_contact_access(
         team_role_to_access_level(r.role, r.hidden).map(|access_level| CrmEntityAccess {
             access_level,
             team_id: r.team_id,
+            team_role: r.role,
         })
     }))
 }

--- a/crates/entity_access/src/outbound/pg_access_repo/test.rs
+++ b/crates/entity_access/src/outbound/pg_access_repo/test.rs
@@ -2,7 +2,7 @@ use super::PgAccessRepository;
 use crate::domain::{
     models::{
         AccessError, AccessLevel, BotId, ChannelRoleResult, CrmEntityAccess, EntityType,
-        ParticipantRole,
+        ParticipantRole, TeamRole,
     },
     ports::AccessRepository,
 };
@@ -225,8 +225,9 @@ async fn crm_company_access_maps_team_role_to_access_level(pool: PgPool) -> anyh
         (
             TEAM_MEMBER,
             Some(CrmEntityAccess {
-                access_level: AccessLevel::View,
+                access_level: AccessLevel::Edit,
                 team_id: team_alpha,
+                team_role: TeamRole::Member,
             }),
         ),
         (
@@ -234,6 +235,7 @@ async fn crm_company_access_maps_team_role_to_access_level(pool: PgPool) -> anyh
             Some(CrmEntityAccess {
                 access_level: AccessLevel::Edit,
                 team_id: team_alpha,
+                team_role: TeamRole::Admin,
             }),
         ),
         (
@@ -241,6 +243,7 @@ async fn crm_company_access_maps_team_role_to_access_level(pool: PgPool) -> anyh
             Some(CrmEntityAccess {
                 access_level: AccessLevel::Owner,
                 team_id: team_alpha,
+                team_role: TeamRole::Owner,
             }),
         ),
     ];
@@ -273,6 +276,7 @@ async fn crm_company_access_hides_from_member_when_hidden(pool: PgPool) -> anyho
         Some(CrmEntityAccess {
             access_level: AccessLevel::Edit,
             team_id: team_alpha,
+            team_role: TeamRole::Admin,
         }),
     );
     assert_eq!(
@@ -281,6 +285,7 @@ async fn crm_company_access_hides_from_member_when_hidden(pool: PgPool) -> anyho
         Some(CrmEntityAccess {
             access_level: AccessLevel::Owner,
             team_id: team_alpha,
+            team_role: TeamRole::Owner,
         }),
     );
     Ok(())
@@ -349,8 +354,9 @@ async fn crm_contact_access_maps_team_role_to_access_level(pool: PgPool) -> anyh
         (
             TEAM_MEMBER,
             Some(CrmEntityAccess {
-                access_level: AccessLevel::View,
+                access_level: AccessLevel::Edit,
                 team_id: team_alpha,
+                team_role: TeamRole::Member,
             }),
         ),
         (
@@ -358,6 +364,7 @@ async fn crm_contact_access_maps_team_role_to_access_level(pool: PgPool) -> anyh
             Some(CrmEntityAccess {
                 access_level: AccessLevel::Edit,
                 team_id: team_alpha,
+                team_role: TeamRole::Admin,
             }),
         ),
         (
@@ -365,6 +372,7 @@ async fn crm_contact_access_maps_team_role_to_access_level(pool: PgPool) -> anyh
             Some(CrmEntityAccess {
                 access_level: AccessLevel::Owner,
                 team_id: team_alpha,
+                team_role: TeamRole::Owner,
             }),
         ),
     ];
@@ -398,6 +406,7 @@ async fn crm_contact_access_hidden_contact_blocks_member(pool: PgPool) -> anyhow
         Some(CrmEntityAccess {
             access_level: AccessLevel::Edit,
             team_id: team_alpha,
+            team_role: TeamRole::Admin,
         }),
     );
     Ok(())

--- a/crates/foreign_entity/src/inbound/axum_router/tests.rs
+++ b/crates/foreign_entity/src/inbound/axum_router/tests.rs
@@ -208,7 +208,7 @@ impl EntityAccessService for NoopEntityAccessService {
         _user_id: Option<&MacroUserId<Lowercase<'_>>>,
         _entity_id: &str,
         _entity_type: EntityType,
-    ) -> Result<(EntityPermission, uuid::Uuid), AccessError> {
+    ) -> Result<(EntityPermission, uuid::Uuid, TeamRole), AccessError> {
         unreachable!("identity-less internal access should bypass real access checks")
     }
 

--- a/crates/foreign_entity/src/inbound/axum_router/tests.rs
+++ b/crates/foreign_entity/src/inbound/axum_router/tests.rs
@@ -1,3 +1,4 @@
+use entity_access::domain::models::TeamRole;
 use std::sync::{Arc, Mutex};
 
 use axum::{

--- a/crates/graphql_email/src/loaders/test.rs
+++ b/crates/graphql_email/src/loaders/test.rs
@@ -1,3 +1,4 @@
+use entity_access::domain::models::TeamRole;
 use std::sync::{
     Arc,
     atomic::{AtomicUsize, Ordering},
@@ -111,7 +112,7 @@ impl EntityAccessService for TestAccessService {
         _user_id: Option<&MacroUserId<Lowercase<'_>>>,
         _entity_id: &str,
         _entity_type: EntityType,
-    ) -> Result<(EntityPermission, Uuid), AccessError> {
+    ) -> Result<(EntityPermission, Uuid, TeamRole), AccessError> {
         Err(AccessError::Internal)
     }
 

--- a/crates/projects/src/inbound/axum_router/tests.rs
+++ b/crates/projects/src/inbound/axum_router/tests.rs
@@ -1,3 +1,4 @@
+use entity_access::domain::models::TeamRole;
 use std::{
     collections::HashMap,
     sync::{Arc, Mutex},
@@ -326,7 +327,7 @@ impl EntityAccessService for FakeEntityAccessService {
         _user_id: Option<&MacroUserId<Lowercase<'_>>>,
         _entity_id: &str,
         _entity_type: EntityType,
-    ) -> Result<(EntityPermission, Uuid), AccessError> {
+    ) -> Result<(EntityPermission, Uuid, TeamRole), AccessError> {
         panic!("unexpected CRM permission lookup")
     }
 

--- a/crates/properties/src/inbound/axum_router/test.rs
+++ b/crates/properties/src/inbound/axum_router/test.rs
@@ -1,3 +1,4 @@
+use entity_access::domain::models::TeamRole;
 use std::sync::{Arc, Mutex};
 
 use axum::{
@@ -165,7 +166,7 @@ impl EntityAccessService for FakeEntityAccessService {
         _user_id: Option<&MacroUserId<Lowercase<'_>>>,
         _entity_id: &str,
         _entity_type: EntityType,
-    ) -> Result<(EntityPermission, Uuid), AccessError> {
+    ) -> Result<(EntityPermission, Uuid, TeamRole), AccessError> {
         panic!("unexpected CRM permission request")
     }
 

--- a/crates/properties/src/inbound/toolset/set_entity_property.rs
+++ b/crates/properties/src/inbound/toolset/set_entity_property.rs
@@ -55,7 +55,7 @@ CRM companies (entity_type='company', entity_id=the company UUID) always have th
 - Stage (00000001-0000-0000-0000-000000000010): select_string, single. Use option_id. Default options: Lead (00000001-0000-0000-0010-000000000001), Qualified (...0002), Demo (...0003), Trial (...0004), Negotiation (...0005), Customer (...0006), Churned (...0007). Teams can customize their stages, so prefer calling GetCompany or GetEntityProperties first to get the valid stage option ids.
 - Owner (00000001-0000-0000-0000-000000000011): entity, single. Use entity_ref with entity_type='user' and entity_id='macro|email@domain.com'.
 - Revenue (00000001-0000-0000-0000-000000000012): number, single. Use number_value (dollars).
-Editing company properties requires the caller to be a team admin or owner.
+Any member of the owning team can edit company properties.
 
 For non-system or custom properties, call GetEntityProperties first to discover property_definition_id values and options."
 )]

--- a/crates/properties/src/inbound/toolset/set_entity_property.rs
+++ b/crates/properties/src/inbound/toolset/set_entity_property.rs
@@ -55,7 +55,7 @@ CRM companies (entity_type='company', entity_id=the company UUID) always have th
 - Stage (00000001-0000-0000-0000-000000000010): select_string, single. Use option_id. Default options: Lead (00000001-0000-0000-0010-000000000001), Qualified (...0002), Demo (...0003), Trial (...0004), Negotiation (...0005), Customer (...0006), Churned (...0007). Teams can customize their stages, so prefer calling GetCompany or GetEntityProperties first to get the valid stage option ids.
 - Owner (00000001-0000-0000-0000-000000000011): entity, single. Use entity_ref with entity_type='user' and entity_id='macro|email@domain.com'.
 - Revenue (00000001-0000-0000-0000-000000000012): number, single. Use number_value (dollars).
-Any member of the owning team can edit company properties.
+Any member of the owning team can edit visible company properties; hidden records remain admin/owner-only.
 
 For non-system or custom properties, call GetEntityProperties first to discover property_definition_id values and options."
 )]

--- a/crates/soup/src/inbound/axum_router/tests.rs
+++ b/crates/soup/src/inbound/axum_router/tests.rs
@@ -449,7 +449,11 @@ impl entity_access::domain::ports::EntityAccessService for MockEntityAccess {
         _entity_id: &str,
         _entity_type: entity_access::domain::models::EntityType,
     ) -> Result<
-        (entity_access::domain::models::EntityPermission, uuid::Uuid),
+        (
+            entity_access::domain::models::EntityPermission,
+            uuid::Uuid,
+            entity_access::domain::models::TeamRole,
+        ),
         entity_access::domain::models::AccessError,
     > {
         unimplemented!()

--- a/crates/teams/src/inbound/axum_router/test.rs
+++ b/crates/teams/src/inbound/axum_router/test.rs
@@ -480,7 +480,7 @@ impl EntityAccessService for FakeEntityAccessService {
         _user_id: Option<&MacroUserId<Lowercase<'_>>>,
         _entity_id: &str,
         _entity_type: EntityType,
-    ) -> Result<(EntityPermission, uuid::Uuid), AccessError> {
+    ) -> Result<(EntityPermission, uuid::Uuid, TeamRole), AccessError> {
         panic!("unexpected get_crm_entity_permission_with_team call")
     }
 

--- a/crates/webhook/src/domain/ingestion/test.rs
+++ b/crates/webhook/src/domain/ingestion/test.rs
@@ -26,7 +26,7 @@ use documents::domain::events::{
 };
 use entity_access::domain::models::{
     AccessLevel, BotId, CallChannelInfo, EntityAccessReceipt, EntityPermission, RequiredPermission,
-    UserTeamInfo,
+    TeamRole, UserTeamInfo,
 };
 use macro_user_id::{lowercased::Lowercase, user_id::MacroUserId};
 use serde_json::Value;
@@ -144,7 +144,7 @@ impl EntityAccessService for MockAccessService {
         _user_id: Option<&MacroUserId<Lowercase<'_>>>,
         _entity_id: &str,
         _entity_type: EntityType,
-    ) -> Result<(EntityPermission, Uuid), AccessError> {
+    ) -> Result<(EntityPermission, Uuid, TeamRole), AccessError> {
         unimplemented!("not used by webhook event ingestion")
     }
 


### PR DESCRIPTION
## Summary

Members previously mapped to **View** access on CRM companies/contacts, so every company property write (Stage, Owner, Revenue, custom) required a team admin or owner. This PR changes the platform rule so **any team member can edit visible CRM records**, while hidden-row visibility and governance actions stay admin/owner.

## Backend

- **`entity_access`**: `team_role_to_access_level` now grants members `Edit` on visible CRM rows (hidden rows still return no access for members). This is the single choke point behind all property-write paths — the properties axum routes, GraphQL mutations, and the `SetEntityProperty` AI tool all mint `EditAccessLevel` receipts through `get_entity_permission`.
- **Role rides along in receipts**: `CrmEntityAccess` and `get_crm_entity_permission_with_team` now carry the caller's `TeamRole`, and the CRM company/contact/comment receipts store it. `include_hidden` keys on the role (admin/owner) instead of `AccessLevel::Edit`, so members holding Edit still never see hidden companies/contacts or comments on hidden parents.
- **Governance stays gated**: `set_company_hidden`, `set_contact_hidden`, and `set_email_sync` now enforce admin/owner explicitly in the domain service (`AdminRoleRequired`), preserving the behavior that was previously implicit in the Edit access requirement. Matches the existing `delete_records_role` governance model, where member is deliberately not representable.
- Service-level tests cover the new allow/deny cases per role.

## Frontend

- `useCrmPermissions().canEditCrm` now means "any team member" instead of admin/owner.
- The company side-panel properties section, the Customers grid property columns, and kanban stage drags are no longer greyed out for members (closed-stage moves still respect `move_closed_deals_role`).
- Sharing / hide / email-sync controls and the hidden tab remain admin-gated, matching the backend.

## Notes for review

- The `EntityAccessService::get_crm_entity_permission_with_team` port signature changed to return the team role; ~20 test mocks across crates were updated mechanically.
- The hexagonal boundary was kept: the role→access mapping lives in the outbound access repo, policy (admin gates, hidden visibility) lives in the CRM domain service/receipts, and inbound extractors only mint receipts.
