### PR TITLE
fix(auth): stop the jwt/refresh storm for anonymous visitors

### DIFF
--- a/apps/web/src/lib/core/util/fetchWithToken.spec.ts
+++ b/apps/web/src/lib/core/util/fetchWithToken.spec.ts
@@ -4,7 +4,11 @@
 
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
-import { fetchWithToken, unsetTokenPromise } from './fetchWithToken';
+import {
+  fetchToken,
+  fetchWithToken,
+  unsetTokenPromise,
+} from './fetchWithToken';
 
 const RESOURCE_URL = 'https://localhost/resource';
 
@@ -16,6 +20,16 @@ function jsonResponse(status: number, body: unknown = {}): Response {
     headers: new Headers({ 'Content-Type': 'application/json' }),
   } as Response;
 }
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+const tick = () => new Promise((r) => setTimeout(r, 0));
 
 const isRefresh = (input: RequestInfo | URL) =>
   String(input).includes('/jwt/refresh');
@@ -112,5 +126,44 @@ describe('fetchWithToken refresh latch', () => {
 
     await fetchWithToken<{ data: string }>(RESOURCE_URL);
     expect(refreshCalls()).toBe(2);
+  });
+
+  test('a reset while a refresh is pending neither latches nor clears newer state', async () => {
+    const pending = [deferred<Response>(), deferred<Response>()];
+    let idx = 0;
+    mockFetch.mockImplementation((input) => {
+      if (isRefresh(input)) {
+        const d = pending[idx++];
+        return d ? d.promise : Promise.resolve(jsonResponse(200));
+      }
+      return Promise.resolve(jsonResponse(401));
+    });
+
+    // R1 starts and stays in-flight.
+    const p1 = fetchToken();
+    // A login-style reset happens while R1 is pending.
+    unsetTokenPromise();
+    // R2 starts under the new generation and also stays in-flight.
+    const p2 = fetchToken();
+    await tick();
+    expect(refreshCalls()).toBe(2);
+
+    // R1 fails under the stale generation.
+    pending[0].resolve(jsonResponse(400));
+    expect((await p1).isErr()).toBe(true);
+
+    // R1's finally must not have cleared R2's tokenPromise: a call now dedupes
+    // onto R2 instead of starting a third refresh.
+    const p2b = fetchToken();
+    await tick();
+    expect(refreshCalls()).toBe(2);
+
+    pending[1].resolve(jsonResponse(200));
+    expect((await p2).isOk()).toBe(true);
+    expect((await p2b).isOk()).toBe(true);
+
+    // R1's stale failure must not have latched: a fresh 401 still refreshes.
+    expect((await fetchToken()).isOk()).toBe(true);
+    expect(refreshCalls()).toBe(3);
   });
 });

--- a/apps/web/src/lib/core/util/fetchWithToken.spec.ts
+++ b/apps/web/src/lib/core/util/fetchWithToken.spec.ts
@@ -1,0 +1,116 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { fetchWithToken, unsetTokenPromise } from './fetchWithToken';
+
+const RESOURCE_URL = 'https://localhost/resource';
+
+function jsonResponse(status: number, body: unknown = {}): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+    headers: new Headers({ 'Content-Type': 'application/json' }),
+  } as Response;
+}
+
+const isRefresh = (input: RequestInfo | URL) =>
+  String(input).includes('/jwt/refresh');
+
+describe('fetchWithToken refresh latch', () => {
+  const originalFetch = global.fetch;
+  const mockFetch = vi.fn<typeof fetch>();
+
+  beforeEach(() => {
+    unsetTokenPromise();
+    global.fetch = mockFetch as typeof fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    mockFetch.mockReset();
+  });
+
+  const refreshCalls = () =>
+    mockFetch.mock.calls.filter(([input]) => isRefresh(input)).length;
+
+  test('fires at most one doomed refresh across sequential 401s', async () => {
+    mockFetch.mockImplementation((input) =>
+      Promise.resolve(isRefresh(input) ? jsonResponse(400) : jsonResponse(401))
+    );
+
+    for (let i = 0; i < 3; i++) {
+      const result = await fetchWithToken<{ data: string }>(RESOURCE_URL);
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.some((e) => e.code === 'UNAUTHORIZED')).toBe(true);
+      }
+    }
+
+    expect(refreshCalls()).toBe(1);
+  });
+
+  test('authenticated expired-token request still refreshes and retries', async () => {
+    let refreshed = false;
+    mockFetch.mockImplementation((input) => {
+      if (isRefresh(input)) {
+        refreshed = true;
+        return Promise.resolve(jsonResponse(200));
+      }
+      return Promise.resolve(
+        refreshed ? jsonResponse(200, { data: 'ok' }) : jsonResponse(401)
+      );
+    });
+
+    const result = await fetchWithToken<{ data: string }>(RESOURCE_URL);
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) expect(result.value).toEqual({ data: 'ok' });
+    expect(refreshCalls()).toBe(1);
+  });
+
+  test('a successful refresh does not latch subsequent 401s', async () => {
+    let refreshCount = 0;
+    mockFetch.mockImplementation((input) => {
+      if (isRefresh(input)) {
+        refreshCount++;
+        return Promise.resolve(jsonResponse(200));
+      }
+      // Each resource call 401s, forcing a fresh refresh every time.
+      return Promise.resolve(jsonResponse(401));
+    });
+
+    await fetchWithToken<{ data: string }>(RESOURCE_URL);
+    await fetchWithToken<{ data: string }>(RESOURCE_URL);
+
+    expect(refreshCount).toBe(2);
+  });
+
+  test('a transient refresh failure (500) does not latch', async () => {
+    mockFetch.mockImplementation((input) =>
+      Promise.resolve(isRefresh(input) ? jsonResponse(500) : jsonResponse(401))
+    );
+
+    await fetchWithToken<{ data: string }>(RESOURCE_URL);
+    await fetchWithToken<{ data: string }>(RESOURCE_URL);
+
+    expect(refreshCalls()).toBe(2);
+  });
+
+  test('unsetTokenPromise clears the latch so refresh is attempted again', async () => {
+    mockFetch.mockImplementation((input) =>
+      Promise.resolve(isRefresh(input) ? jsonResponse(400) : jsonResponse(401))
+    );
+
+    await fetchWithToken<{ data: string }>(RESOURCE_URL);
+    expect(refreshCalls()).toBe(1);
+
+    unsetTokenPromise();
+
+    await fetchWithToken<{ data: string }>(RESOURCE_URL);
+    expect(refreshCalls()).toBe(2);
+  });
+});

--- a/apps/web/src/lib/core/util/fetchWithToken.ts
+++ b/apps/web/src/lib/core/util/fetchWithToken.ts
@@ -60,11 +60,17 @@ let tokenPromise: Promise<TokenResult> | null = null;
 // unsetTokenPromise, which the login flows call on a session change.
 let refreshUnavailable: TokenResult | null = null;
 
+// Bumped on every reset. A refresh started before a reset carries the older
+// generation, so once the session has moved on (e.g. a login) it can neither
+// re-latch refreshUnavailable nor clear a newer tokenPromise on completion.
+let refreshGeneration = 0;
+
 export async function fetchToken(): Promise<TokenResult> {
   if (refreshUnavailable != null) {
     return refreshUnavailable;
   }
   if (tokenPromise == null) {
+    const generation = refreshGeneration;
     tokenPromise = (async () => {
       try {
         const result = await fetchWithCredentials(
@@ -82,6 +88,7 @@ export async function fetchToken(): Promise<TokenResult> {
         if (result.isErr()) {
           const failure = err(result.error);
           if (
+            generation === refreshGeneration &&
             result.error.some(
               (e) => e.code === 'HTTP_ERROR' || e.code === 'UNAUTHORIZED'
             )
@@ -93,7 +100,9 @@ export async function fetchToken(): Promise<TokenResult> {
 
         return ok(undefined);
       } finally {
-        tokenPromise = null;
+        if (generation === refreshGeneration) {
+          tokenPromise = null;
+        }
       }
     })();
   }
@@ -180,6 +189,7 @@ export async function fetchWithToken<
  * unsetTokenPromise();
  */
 export function unsetTokenPromise() {
+  refreshGeneration++;
   tokenPromise = null;
   refreshUnavailable = null;
 }

--- a/apps/web/src/lib/core/util/fetchWithToken.ts
+++ b/apps/web/src/lib/core/util/fetchWithToken.ts
@@ -49,13 +49,21 @@ function fetchWithCredentials<
   );
 }
 
-let tokenPromise: Promise<
-  Result<void, ResultError<FetchWithTokenErrorCode>[]>
-> | null = null;
+type TokenResult = Result<void, ResultError<FetchWithTokenErrorCode>[]>;
 
-export async function fetchToken(): Promise<
-  Result<void, ResultError<FetchWithTokenErrorCode>[]>
-> {
+let tokenPromise: Promise<TokenResult> | null = null;
+
+// Once /jwt/refresh fails because the session is not authenticated (400/401),
+// cache that failure so subsequent 401s short-circuit instead of each firing
+// another doomed refresh. An anonymous visitor on a public link otherwise
+// triggers one refresh per authenticated app-chrome query. Cleared by
+// unsetTokenPromise, which the login flows call on a session change.
+let refreshUnavailable: TokenResult | null = null;
+
+export async function fetchToken(): Promise<TokenResult> {
+  if (refreshUnavailable != null) {
+    return refreshUnavailable;
+  }
   if (tokenPromise == null) {
     tokenPromise = (async () => {
       try {
@@ -72,7 +80,15 @@ export async function fetchToken(): Promise<
         );
 
         if (result.isErr()) {
-          return err(result.error);
+          const failure = err(result.error);
+          if (
+            result.error.some(
+              (e) => e.code === 'HTTP_ERROR' || e.code === 'UNAUTHORIZED'
+            )
+          ) {
+            refreshUnavailable = failure;
+          }
+          return failure;
         }
 
         return ok(undefined);
@@ -165,4 +181,5 @@ export async function fetchWithToken<
  */
 export function unsetTokenPromise() {
   tokenPromise = null;
+  refreshUnavailable = null;
 }

--- a/apps/web/src/lib/service-clients/service-connection/websocket.ts
+++ b/apps/web/src/lib/service-clients/service-connection/websocket.ts
@@ -1,7 +1,7 @@
 import { createBlockEffect, inBlock } from '@core/block';
 import { ENABLE_BEARER_TOKEN_AUTH } from '@core/constant/featureFlags';
 import { SERVER_HOSTS } from '@core/constant/servers';
-import { fetchToken, unsetTokenPromise } from '@core/util/fetchWithToken';
+import { fetchToken } from '@core/util/fetchWithToken';
 import {
   ArrayQueue,
   createSocketEffect,
@@ -34,8 +34,6 @@ async function resolveWsUrl() {
 
     return `${wsHost}/?macro-api-token=${apiToken}`;
   }
-  // Clear any cached token promise to force a fresh refresh on reconnect
-  unsetTokenPromise();
   await fetchToken();
   return wsHost;
 }


### PR DESCRIPTION
Unauthenticated visitors on a public link fired ~15-20 doomed `POST /jwt/refresh` 400s per page view — every authenticated app-chrome query 401s and each independently re-fired a refresh, and the websocket reconnect loop kept re-triggering it. This caches the first unauthenticated refresh failure so later 401s short-circuit (cleared on login), and stops the websocket reconnect from clobbering that latch. Verified with a cookie-less dev viewer: refresh 400s drop from 5+ to exactly one and the doc still renders.

Heads up for a backend audit: the auth service sends `Set-Cookie` clearing the access token on a failed refresh that carried a cookie, so a doomed refresh must never be able to clear a real session that's racing a fresh login in another tab.
