### PR TITLE
fix(split-layout): add border to right of Preview Controller

### DIFF
--- a/apps/web/src/components/app/split-layout/components/SplitPanel.tsx
+++ b/apps/web/src/components/app/split-layout/components/SplitPanel.tsx
@@ -309,9 +309,9 @@ export function SplitPanel(props: SplitPanelProps) {
                   // a square, borderless left edge (the ! beats Surface's
                   // inline border shorthand)...
                   'rounded-l-none border-l-0!': tuckedBehindController(),
-                  // ...and the controller squares and removes its right edge,
-                  // leaving no border between the Preview Pair's panels.
-                  'rounded-r-none border-r-0!': hasTuckedViewer(),
+                  // ...and the controller squares its right edge, keeping its
+                  // border as the single seam line between the pair's panels.
+                  'rounded-r-none': hasTuckedViewer(),
                 }
               )}
               depth={isMobile() ? 0 : 1}

--- a/apps/web/src/components/app/split-layout/components/SplitPanel.tsx
+++ b/apps/web/src/components/app/split-layout/components/SplitPanel.tsx
@@ -305,13 +305,14 @@ export function SplitPanel(props: SplitPanelProps) {
                   'shadow-2xl shadow-drop-shadow': splitFocusStyling(),
                   'border-solid!': previewPairFocusStyling() && props.active,
                   'border-dashed!': previewPairFocusStyling() && !props.active,
-                  // Drawer look: the Viewer meets its Controller with
-                  // a square, borderless left edge (the ! beats Surface's
-                  // inline border shorthand)...
-                  'rounded-l-none border-l-0!': tuckedBehindController(),
-                  // ...and the controller squares its right edge, keeping its
-                  // border as the single seam line between the pair's panels.
+                  // Drawer look: both members square their seam corners, and
+                  // the seam border belongs to the pair's active member — its
+                  // partner's seam edge goes borderless so the line never
+                  // doubles (the ! beats Surface's inline border shorthand).
+                  'rounded-l-none': tuckedBehindController(),
+                  'border-l-0!': tuckedBehindController() && !props.active,
                   'rounded-r-none': hasTuckedViewer(),
+                  'border-r-0!': hasTuckedViewer() && !props.active,
                 }
               )}
               depth={isMobile() ? 0 : 1}


### PR DESCRIPTION
Closes MACRO-2615.

The Preview Pair previously had no divider at the seam between its panels (the controller dropped `border-r`, the viewer dropped `border-l`). The seam border now belongs to whichever member of the pair is active:

- **Controller active** — the controller keeps a solid right border; the viewer's left edge is borderless.
- **Viewer active** — the viewer keeps a solid left border; the controller's right edge is borderless.

The active member's seam edge picks up the pair's existing focus treatment (solid style, active edge color), and the inactive member's seam edge is removed so the line never doubles. When neither member is active (focus is in another split), the seam disappears and the pair keeps its merged drawer look. Seam corners stay squared via `rounded-l-none` / `rounded-r-none`.

Session: https://claude.ai/code/8b27e93e-2d49-5872-ac30-bd4a1259466b