### PR TITLE
fix(mcp): request explicit OAuth scopes for Linear's MCP connector

### DIFF
--- a/crates/mcp_client/src/domain/provider_registry/mod.rs
+++ b/crates/mcp_client/src/domain/provider_registry/mod.rs
@@ -5,6 +5,7 @@ use super::models;
 /// Slack MCP server URL.
 const SLACK_SERVER_URL: &str = "https://mcp.slack.com/mcp";
 const GITHUB_SERVER_URL: &str = "https://api.githubcopilot.com/mcp";
+const LINEAR_SERVER_URL: &str = "https://mcp.linear.app/mcp";
 
 macro_env_var::env_var! {
     /// Environment variables for pre-registered MCP providers.
@@ -82,3 +83,23 @@ impl PreRegisteredProviders {
         }
     }
 }
+
+/// Default OAuth scopes to request for MCP servers that support Dynamic
+/// Client Registration but have no pre-registered credentials.
+///
+/// Requesting no scope isn't the same as requesting "default" access on
+/// every provider: Linear's MCP authorization server records the local
+/// approval with whatever scope was requested (empty, if none was) but then
+/// defaults the actual grant it asks the user for to full write access,
+/// leaving the recorded approval and the granted access out of sync and the
+/// flow failing after the user approves. Requesting explicit scopes keeps
+/// both sides consistent.
+pub fn dcr_default_scopes(server_url: &str) -> Vec<String> {
+    match server_url {
+        LINEAR_SERVER_URL => vec!["read".to_string(), "write".to_string()],
+        _ => vec![],
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/crates/mcp_client/src/domain/provider_registry/test.rs
+++ b/crates/mcp_client/src/domain/provider_registry/test.rs
@@ -1,0 +1,17 @@
+use super::*;
+
+#[test]
+fn linear_gets_explicit_read_write_scopes() {
+    assert_eq!(
+        dcr_default_scopes("https://mcp.linear.app/mcp"),
+        vec!["read".to_string(), "write".to_string()]
+    );
+}
+
+#[test]
+fn unknown_server_gets_no_default_scopes() {
+    assert_eq!(
+        dcr_default_scopes("https://mcp.example.com/mcp"),
+        Vec::<String>::new()
+    );
+}

--- a/crates/mcp_client/src/domain/service/oauth.rs
+++ b/crates/mcp_client/src/domain/service/oauth.rs
@@ -72,13 +72,15 @@ impl<S, R> OAuthService<S, R> {
                 scopes: creds.scopes.clone(),
             })
         } else {
+            let scopes = crate::domain::provider_registry::dcr_default_scopes(server_url);
+            let scope_refs: Vec<&str> = scopes.iter().map(String::as_str).collect();
             let config = auth_manager
-                .register_client(MCP_CLIENT_NAME, &self.redirect_uri, &[])
+                .register_client(MCP_CLIENT_NAME, &self.redirect_uri, &scope_refs)
                 .await?;
             Ok(ResolvedClient {
                 client_id: config.client_id,
                 client_secret: config.client_secret,
-                scopes: vec![],
+                scopes,
             })
         }
     }


### PR DESCRIPTION
Requests explicit `read write` scopes during DCR for Linear's MCP server instead of an empty scope list, avoiding a scope mismatch between what mcp.linear.app records as approved and what it actually grants downstream.

Ticket: https://macro.com/app/task/019f9127-ff4e-7865-ad3a-6ec6651763e9