### PR TITLE
feat(ui): show full name tooltip on truncated soup names (MACRO-2623)

### DIFF
--- a/apps/web/src/features/entity/extractors/entity-title.tsx
+++ b/apps/web/src/features/entity/extractors/entity-title.tsx
@@ -2,7 +2,15 @@ import { StaticMarkdown } from '@core/component/LexicalMarkdown/component/core/S
 import { unifiedListMarkdownTheme } from '@core/component/LexicalMarkdown/theme';
 import { blockNameToDefaultFile } from '@core/constant/allBlocks';
 import { formatDocumentName } from '@service-storage/util/filename';
-import { type JSX, Show } from 'solid-js';
+import { createElementSize } from '@solid-primitives/resize-observer';
+import { Tooltip } from '@ui';
+import {
+  type Accessor,
+  createEffect,
+  createSignal,
+  type JSX,
+  Show,
+} from 'solid-js';
 import { match } from 'ts-pattern';
 import { type EntityData, isGithubPrEntity } from '../types/entity';
 import { isSearchEntity } from '../types/search';
@@ -47,6 +55,27 @@ function extractSearchHighlight(entity: EntityData): string | undefined {
   return entity.search.nameHighlight ?? undefined;
 }
 
+/**
+ * Tracks whether the rendered element's text is visually clipped
+ * (`scrollWidth` exceeds `clientWidth`), re-checking whenever the element's
+ * own box size changes.
+ */
+function useIsTruncated(ref: Accessor<HTMLElement | undefined>) {
+  const size = createElementSize(ref);
+  const [truncated, setTruncated] = createSignal(false);
+
+  createEffect(() => {
+    // Track size so we re-measure whenever the element (or its container)
+    // resizes.
+    void size.width;
+    void size.height;
+    const el = ref();
+    setTruncated(!!el && el.scrollWidth > el.clientWidth);
+  });
+
+  return truncated;
+}
+
 export function EntityTitle(props: { entity: EntityData }) {
   const titleData = () => {
     const searchHighlight = extractSearchHighlight(props.entity);
@@ -63,16 +92,34 @@ export function EntityTitle(props: { entity: EntityData }) {
     };
   };
 
+  const [titleRef, setTitleRef] = createSignal<HTMLElement>();
+  const isTruncated = useIsTruncated(titleRef);
+  // The tooltip re-uses the rendered element's own text, so it stays correct
+  // for markdown/highlighted titles without re-deriving a plain-text label.
+  const tooltipLabel = () => titleRef()?.textContent?.trim() ?? '';
+
   return (
-    <Show
-      when={titleData().isMarkdown}
-      fallback={<span class="truncate">{titleData().text}</span>}
+    <Tooltip
+      as="span"
+      class="min-w-0 truncate"
+      label={tooltipLabel()}
+      disabled={!isTruncated()}
     >
-      <StaticMarkdown
-        markdown={titleData().text as string}
-        theme={unifiedListMarkdownTheme}
-        singleLine={true}
-      />
-    </Show>
+      <Show
+        when={titleData().isMarkdown}
+        fallback={
+          <span ref={setTitleRef} class="truncate">
+            {titleData().text}
+          </span>
+        }
+      >
+        <StaticMarkdown
+          markdown={titleData().text as string}
+          theme={unifiedListMarkdownTheme}
+          singleLine={true}
+          rootRef={setTitleRef}
+        />
+      </Show>
+    </Tooltip>
   );
 }


### PR DESCRIPTION
## Summary

Long document/task/project ("soup" entity) names get truncated with an ellipsis across list views (sidebar, search results, command palette, kanban, inbox, attachments, etc.), with no way to see the full name without opening the item. This adds a tooltip that reveals the full name on hover, shown only when the name is actually visually clipped.

`EntityTitle` (`apps/web/src/features/entity/extractors/entity-title.tsx`, exposed as `Entity.Title`) is the single shared component all of these surfaces already render through, so the fix was made there instead of at each call site:

- Wraps the rendered title in the existing `@ui` `Tooltip` primitive (Kobalte-based) rather than introducing a new tooltip dependency.
- Adds a small `useIsTruncated` helper that tracks the title element via `@solid-primitives/resize-observer`'s `createElementSize` and compares `scrollWidth > clientWidth`, re-checking whenever the element resizes. The tooltip is disabled unless the title is actually truncated, so it never fires for short names.
- The tooltip's label is read from the rendered element's own `textContent`, so it stays correct for both the plain-text title path and the markdown/search-highlight render path without needing a second plain-text extraction.

Kept intentionally scoped to this one shared component — no changes to individual list-view layouts.

## Testing

- `cd apps/web && bunx --bun biome lint --skip=suspicious/noImportCycles src/features/entity/extractors/entity-title.tsx` — passes
- `bunx --bun biome check src/features/entity/extractors/entity-title.tsx` — passes
- `bun run type-check` (scoped `tsc --noEmit`) — no errors in the touched file or its callers (pre-existing unrelated `pdfjs-dist`/`@inkibra/tauri-plugins` type errors come from those private git dependencies not being installable in this sandbox, unrelated to this change)
- `bunx vitest run src/features/entity` — all 10 existing test files / 201 tests pass (no dedicated test file exists yet for `entity-title.tsx`)

Ref: MACRO-2623


---
_Generated by [Claude Code](https://claude.ai/code/session_01CkyWHDFXmriQLztPy1vaLt)_