### PR TITLE
fix(sync-service): strip comment highlight marks when duplicating a doc (MACRO-2624)

### DIFF
--- a/services/sync-service/src/cf_worker.rs
+++ b/services/sync-service/src/cf_worker.rs
@@ -4,6 +4,7 @@ use wasm_bindgen::JsValue;
 use worker::{Env, Error, Headers, Method, Request, RequestInit, Response, Result, Stub};
 
 use crate::{
+    comment_marks,
     constants::header_names::{AUTHORIZATION, MACRO_INTERNAL_AUTH_KEY_HEADER_KEY},
     durable_object::{CopyDocumentRequest, GetSnapshotRequest, response, status_codes},
     error::ResultExt,
@@ -99,8 +100,16 @@ pub async fn copy_handler(env: Env, mut req: Request, document_id: &str) -> Resu
             return Ok(response(ss_res.status_code()));
         }
 
+        // Comment threads are never copied when a document is duplicated (see
+        // `crates/documents`), so any inline comment/mark wrapper left in the
+        // copied snapshot would render as a highlight with no comment behind
+        // it. Strip those wrappers here, before the new document is ever
+        // initialized with this content.
+        let source_snapshot = ss_res.bytes().await?;
+        let stripped_snapshot = comment_marks::strip_orphaned_marks(&source_snapshot)?;
+
         let snapshot_body = InitializeFromSnapshotRequest {
-            snapshot: bebop::SliceWrapper::Raw(&ss_res.bytes().await?),
+            snapshot: bebop::SliceWrapper::Raw(&stripped_snapshot),
         };
         let mut buf = Vec::with_capacity(snapshot_body.serialized_size());
         _ = snapshot_body

--- a/services/sync-service/src/comment_marks.rs
+++ b/services/sync-service/src/comment_marks.rs
@@ -1,0 +1,125 @@
+//! Stripping of orphaned comment highlight marks when a document is copied.
+//!
+//! Duplicating a document intentionally does not copy its comment threads
+//! (see the `Thread`/`Comment` tables owned by `crates/documents`), but the
+//! raw Loro snapshot for a markdown document still embeds inline mark
+//! wrapper nodes (Lexical `MarkNode`/`CommentNode`) around the highlighted
+//! text. Left untouched, a duplicated document would render a highlight
+//! with no comment behind it. This module walks the copied document's node
+//! tree and unwraps any such mark nodes, keeping their underlying content
+//! but discarding the wrapper.
+//!
+//! A node is treated as a mark wrapper if it has a non-empty `ids` list,
+//! which is how Lexical's `MarkNode`/`CommentNode` serialize into this
+//! document's schema (see `packages/lexical-core/markdown-loro-schema.ts`).
+//! This intentionally strips any mark-style node, not just `comment-mark`
+//! ones, since none of them have a corresponding comment thread after a copy.
+
+use loro::{Container, ExportMode, LoroDoc, LoroMap, LoroMovableList};
+use tracing::instrument;
+
+use crate::error::ResultExt;
+
+/// The name of the top-level container holding the document's node tree.
+const ROOT_CONTAINER: &str = "root";
+/// The node field holding a mark's list of comment/thread ids.
+const IDS_FIELD: &str = "ids";
+/// The node field holding a node's own children.
+const CHILDREN_FIELD: &str = "children";
+
+/// Strips inline comment/mark wrapper nodes from a Loro document snapshot,
+/// returning a re-exported snapshot with the wrappers removed. The
+/// underlying wrapped content (text, nested elements, etc.) is preserved
+/// in place.
+#[instrument(skip_all, err)]
+pub fn strip_orphaned_marks(snapshot: &[u8]) -> worker::Result<Vec<u8>> {
+    let doc = LoroDoc::new();
+    doc.import_with(snapshot, "strip_orphaned_marks")
+        .context("failed to import snapshot for mark stripping")?;
+
+    let root = doc.get_map(ROOT_CONTAINER);
+    strip_marks_from_children(&root);
+
+    doc.export(ExportMode::Snapshot)
+        .context("failed to export snapshot after stripping marks")
+}
+
+/// Recursively removes mark wrapper nodes from `node`'s `children` list
+/// (postorder, so nested/overlapping marks are all flattened), splicing each
+/// wrapper's own children into its parent's children list in its place.
+fn strip_marks_from_children(node: &LoroMap) {
+    let Some(children) = get_children(node) else {
+        return;
+    };
+
+    let mut i = 0;
+    while i < children.len() {
+        let Some(child) = get_map_at(&children, i) else {
+            i += 1;
+            continue;
+        };
+
+        // Postorder: clean any nested/overlapping marks inside this child first.
+        strip_marks_from_children(&child);
+
+        if !has_non_empty_ids(&child) {
+            i += 1;
+            continue;
+        }
+
+        // This child is a mark wrapper: splice its own (already-cleaned)
+        // children into the parent's list in its place.
+        let grandchildren: Vec<LoroMap> = get_children(&child)
+            .map(|list| {
+                (0..list.len())
+                    .filter_map(|j| get_map_at(&list, j))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        if children.delete(i, 1).is_err() {
+            // Best-effort: if we can't remove the wrapper, leave it in place
+            // rather than risk leaving the tree in an inconsistent state.
+            tracing::error!(index = i, "failed to delete mark wrapper node");
+            i += 1;
+            continue;
+        }
+
+        for (offset, grandchild) in grandchildren.iter().enumerate() {
+            if let Err(error) = children.insert_container(i + offset, grandchild.clone()) {
+                tracing::error!(error=?error, "failed to re-insert mark wrapper's child");
+            }
+        }
+        i += grandchildren.len();
+    }
+}
+
+/// Returns `true` if `node`'s `ids` field is a non-empty list, i.e. `node`
+/// is a mark-style wrapper node.
+fn has_non_empty_ids(node: &LoroMap) -> bool {
+    let Some(value) = node.get(IDS_FIELD) else {
+        return false;
+    };
+    matches!(value.into_container(), Ok(Container::List(list)) if !list.is_empty())
+}
+
+/// Returns `node`'s `children` container, if it has one.
+fn get_children(node: &LoroMap) -> Option<LoroMovableList> {
+    let value = node.get(CHILDREN_FIELD)?;
+    match value.into_container() {
+        Ok(Container::MovableList(list)) => Some(list),
+        _ => None,
+    }
+}
+
+/// Returns the map at `idx` in `list`, if the value there is a map container.
+fn get_map_at(list: &LoroMovableList, idx: usize) -> Option<LoroMap> {
+    let value = list.get(idx)?;
+    match value.into_container() {
+        Ok(Container::Map(map)) => Some(map),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/services/sync-service/src/comment_marks/test.rs
+++ b/services/sync-service/src/comment_marks/test.rs
@@ -1,0 +1,190 @@
+use loro::{ExportMode, LoroDoc, LoroList, LoroMap, LoroMovableList, LoroText, ToJson};
+
+use super::*;
+
+fn text_node(id: &str, text: &str) -> LoroMap {
+    let map = LoroMap::new();
+    let meta = map.insert_container("$", LoroMap::new()).unwrap();
+    meta.insert("type", "text").unwrap();
+    meta.insert("id", id).unwrap();
+    let t = map.insert_container("text", LoroText::new()).unwrap();
+    t.insert(0, text).unwrap();
+    map
+}
+
+fn mark_node(id: &str, thread_id: &str, children: Vec<LoroMap>) -> LoroMap {
+    let map = LoroMap::new();
+    let meta = map.insert_container("$", LoroMap::new()).unwrap();
+    meta.insert("type", "comment-mark").unwrap();
+    meta.insert("id", id).unwrap();
+    let ids = map.insert_container("ids", LoroList::new()).unwrap();
+    ids.push(thread_id).unwrap();
+    let kids = map
+        .insert_container("children", LoroMovableList::new())
+        .unwrap();
+    for c in children {
+        kids.push_container(c).unwrap();
+    }
+    map
+}
+
+fn elem_node(type_name: &str, id: &str, children: Vec<LoroMap>) -> LoroMap {
+    let map = LoroMap::new();
+    let meta = map.insert_container("$", LoroMap::new()).unwrap();
+    meta.insert("type", type_name).unwrap();
+    meta.insert("id", id).unwrap();
+    let kids = map
+        .insert_container("children", LoroMovableList::new())
+        .unwrap();
+    for c in children {
+        kids.push_container(c).unwrap();
+    }
+    map
+}
+
+/// Builds a root document with the given top-level children and returns its
+/// exported snapshot bytes.
+fn doc_snapshot(children: Vec<LoroMap>) -> Vec<u8> {
+    let doc = LoroDoc::new();
+    let root = doc.get_map(ROOT_CONTAINER);
+    let meta = root.insert_container("$", LoroMap::new()).unwrap();
+    meta.insert("type", "root").unwrap();
+    let root_children = root
+        .insert_container(CHILDREN_FIELD, LoroMovableList::new())
+        .unwrap();
+    for c in children {
+        root_children.push_container(c).unwrap();
+    }
+    doc.export(ExportMode::Snapshot).unwrap()
+}
+
+fn deep_value_json(snapshot: &[u8]) -> String {
+    let doc = LoroDoc::new();
+    doc.import(snapshot).unwrap();
+    doc.get_deep_value().to_json()
+}
+
+#[test]
+fn strips_a_simple_comment_mark_keeping_its_text() {
+    let snapshot = doc_snapshot(vec![elem_node(
+        "paragraph",
+        "para-1",
+        vec![
+            text_node("t-before", "before "),
+            mark_node(
+                "mark-1",
+                "thread-1",
+                vec![text_node("t-marked", "highlighted")],
+            ),
+            text_node("t-after", " after"),
+        ],
+    )]);
+
+    let stripped = strip_orphaned_marks(&snapshot).expect("stripping should succeed");
+    let json = deep_value_json(&stripped);
+
+    assert!(
+        !json.contains("comment-mark"),
+        "expected no comment-mark node to remain: {json}"
+    );
+    assert!(
+        json.contains("highlighted"),
+        "text content should survive: {json}"
+    );
+    assert!(
+        json.contains("before "),
+        "surrounding text should survive: {json}"
+    );
+    assert!(
+        json.contains(" after"),
+        "surrounding text should survive: {json}"
+    );
+}
+
+#[test]
+fn strips_nested_overlapping_marks() {
+    let inner = mark_node("mark-2", "thread-2", vec![text_node("t-double", "double")]);
+    let outer = mark_node(
+        "mark-1",
+        "thread-1",
+        vec![inner, text_node("t-single", "single")],
+    );
+    let snapshot = doc_snapshot(vec![elem_node(
+        "paragraph",
+        "para-1",
+        vec![
+            text_node("t-before", "before "),
+            outer,
+            text_node("t-after", " after"),
+        ],
+    )]);
+
+    let stripped = strip_orphaned_marks(&snapshot).expect("stripping should succeed");
+    let json = deep_value_json(&stripped);
+
+    assert!(
+        !json.contains("comment-mark"),
+        "no marks should remain: {json}"
+    );
+    assert!(json.contains("double"));
+    assert!(json.contains("single"));
+    assert!(json.contains("before "));
+    assert!(json.contains(" after"));
+}
+
+#[test]
+fn removes_an_empty_mark_with_no_children() {
+    let snapshot = doc_snapshot(vec![
+        text_node("a", "A"),
+        mark_node("mark-empty", "thread-x", vec![]),
+        text_node("b", "B"),
+    ]);
+
+    let stripped = strip_orphaned_marks(&snapshot).expect("stripping should succeed");
+    let json = deep_value_json(&stripped);
+
+    assert!(!json.contains("comment-mark"), "{json}");
+    assert!(json.contains('A'));
+    assert!(json.contains('B'));
+}
+
+#[test]
+fn leaves_a_document_with_no_marks_unchanged() {
+    let snapshot = doc_snapshot(vec![elem_node(
+        "paragraph",
+        "para-1",
+        vec![text_node("t1", "plain text, nothing to see here")],
+    )]);
+
+    let before = deep_value_json(&snapshot);
+    let stripped = strip_orphaned_marks(&snapshot).expect("stripping should succeed");
+    let after = deep_value_json(&stripped);
+
+    assert_eq!(before, after);
+}
+
+#[test]
+fn stripped_snapshot_round_trips_through_export_import() {
+    let snapshot = doc_snapshot(vec![elem_node(
+        "paragraph",
+        "para-1",
+        vec![
+            text_node("t-before", "before "),
+            mark_node(
+                "mark-1",
+                "thread-1",
+                vec![text_node("t-marked", "highlighted")],
+            ),
+        ],
+    )]);
+
+    let stripped = strip_orphaned_marks(&snapshot).expect("stripping should succeed");
+
+    // Re-import the stripped snapshot and export it again; the content
+    // should be stable (no further changes, no corruption).
+    let doc = LoroDoc::new();
+    doc.import(&stripped).unwrap();
+    let re_exported = doc.export(ExportMode::Snapshot).unwrap();
+
+    assert_eq!(deep_value_json(&stripped), deep_value_json(&re_exported));
+}

--- a/services/sync-service/src/lib.rs
+++ b/services/sync-service/src/lib.rs
@@ -1,6 +1,7 @@
 mod ai_peer;
 mod auth;
 mod cf_worker;
+mod comment_marks;
 mod constants;
 mod d1;
 mod dss_internal;


### PR DESCRIPTION
## Bug

Duplicating a markdown document correctly skips copying its comments (the `Thread`/`Comment` rows in `crates/documents`), but the duplicate still showed highlighted text with no comment attached — a visually broken/confusing leftover.

## Root cause

Document duplication for markdown files (`crates/documents/src/domain/service.rs::copy_document`) delegates the actual document body copy to `services/sync-service`'s `/document/{id}/copy` endpoint (`copy_handler` in `services/sync-service/src/cf_worker.rs`). That handler fetches the source document's raw Loro CRDT snapshot and re-initializes the new document with those bytes verbatim — no inspection of the content.

Comment highlights are represented inline in that snapshot as a wrapper node around the highlighted text (Lexical's `MarkNode`/`CommentNode`, serialized with a non-empty `ids` array referencing the comment thread). Because comment threads are (correctly) never copied, but this wrapper node *was* copied byte-for-byte, the duplicate ends up with a highlight span pointing at a thread that doesn't exist for that document — an orphaned highlight with no comment behind it.

## Fix

Added `services/sync-service/src/comment_marks.rs`, which walks the copied document's node tree (using the real `loro` crate against the document's node schema — see `packages/lexical-core/markdown-loro-schema.ts`) and unwraps any node with a non-empty `ids` list, splicing its own children back into its parent in its place. This runs in `copy_handler` on the fetched snapshot, before the new document is ever initialized with that content, so the duplicate never contains a stray highlight. Non-mark content, and documents with no marks at all, are left byte-identical in effect (unaffected).

The detection (`ids` list is non-empty) intentionally isn't limited to the `comment-mark` node type — it catches any mark-style wrapper, since none of them have a corresponding thread after a copy.

## Testing

- `cargo test -p sync_service --lib` — all 19 tests pass, including 5 new tests in `comment_marks::test` covering: a simple mark around text, nested/overlapping marks, an empty mark with no children, a no-marks document being left unchanged, and the stripped snapshot round-tripping cleanly through export/import.
- `cargo clippy -p sync_service --lib --tests` and `cargo fmt -p sync_service --check` — clean.
- `cargo check -p sync_service` for both the native target and `wasm32-unknown-unknown` (the actual deployment target) — both succeed.
- Not run: the existing TypeScript/Miniflare integration tests in `services/sync-service/tests/` (e.g. `copy_endpoint.test.ts`) require building the Rust code to wasm and running under Miniflare, which wasn't exercised in this environment. Those tests use a simplified plain-text document shape (not the markdown node-tree schema), so they should be unaffected, but a real end-to-end check against a live document with an actual comment would be good follow-up validation before/after deploy.
- This fix is scoped to `services/sync-service` only; `crates/documents`/`document_storage_service` (which own the comment-exclusion-from-copy logic already) are untouched.

Refs MACRO-2624.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CkyWHDFXmriQLztPy1vaLt)_