### PR TITLE
fix(split-layout): keep Preview Pair seam border on the Controller

### DIFF
--- a/apps/web/src/components/app/split-layout/components/SplitPanel.tsx
+++ b/apps/web/src/components/app/split-layout/components/SplitPanel.tsx
@@ -305,14 +305,15 @@ export function SplitPanel(props: SplitPanelProps) {
                   'shadow-2xl shadow-drop-shadow': splitFocusStyling(),
                   'border-solid!': previewPairFocusStyling() && props.active,
                   'border-dashed!': previewPairFocusStyling() && !props.active,
-                  // Drawer look: both members square their seam corners, and
-                  // the seam border belongs to the pair's active member — its
-                  // partner's seam edge goes borderless so the line never
-                  // doubles (the ! beats Surface's inline border shorthand).
-                  'rounded-l-none': tuckedBehindController(),
-                  'border-l-0!': tuckedBehindController() && !props.active,
+                  // Drawer look: both members square their seam corners. The
+                  // seam border always belongs to the Controller — the
+                  // Viewer's seam edge stays borderless so the line never
+                  // doubles, and keeping it on one fixed member regardless
+                  // of focus means switching focus can't shift layout by the
+                  // border width (the ! beats Surface's inline border
+                  // shorthand).
+                  'rounded-l-none border-l-0!': tuckedBehindController(),
                   'rounded-r-none': hasTuckedViewer(),
-                  'border-r-0!': hasTuckedViewer() && !props.active,
                 }
               )}
               depth={isMobile() ? 0 : 1}


### PR DESCRIPTION
Closes MACRO-2629.

Since #5148 the Preview Pair's seam border belonged to whichever member was active, so switching focus between the Controller and the Viewer moved the border from one panel to the other and shifted both panels' content by the border width (1px).

The seam border now always belongs to the Controller: it keeps its right border regardless of focus, and the Viewer's seam edge stays borderless. Focus changes only restyle the seam (solid when the Controller is active, dashed while its partner holds focus, muted when the pair is unfocused) — border widths never change, so layout never shifts.

Session: https://claude.ai/code/c21689f7-526d-5628-a835-d43c69568dcc

---
_Generated by [Claude Code](https://claude.ai/code/session_01HsijE6HD5wEbXNkrNjPCw9)_