### PR TITLE
Fix close button visibility for single Preview Pair splits

### DIFF
--- a/apps/web/src/components/app/split-layout/components/SplitHeader.tsx
+++ b/apps/web/src/components/app/split-layout/components/SplitHeader.tsx
@@ -184,8 +184,17 @@ function SplitCloseButton() {
   // Controller leaving its list view), or via the preview toggle.
   const isPreviewViewer = () => context.handle.isViewerSplit();
 
+  // A Preview Pair occupies two split slots but is a single logical split: its
+  // Viewer isn't independently closable. Subtract one slot per pair so that
+  // when the only splits open are a single Preview Pair, the Controller hides
+  // its close button — just like a lone split does.
+  const hasMultipleSplits = createMemo(
+    () =>
+      layout.manager.splits().length - layout.manager.previewPairs().length > 1
+  );
+
   return (
-    <Show when={layout.manager.splits().length > 1 && !isPreviewViewer()}>
+    <Show when={hasMultipleSplits() && !isPreviewViewer()}>
       <Button
         class="p-1 rounded-lg"
         label={label()}


### PR DESCRIPTION
## Summary
Fixed the close button visibility logic in the split layout header to correctly account for Preview Pairs, which occupy two split slots but represent a single logical split.

## Key Changes
- Added `hasMultipleSplits` memo that accounts for Preview Pairs when determining if multiple splits are open
- The calculation subtracts the number of preview pairs from the total split count, since each pair occupies two slots but should be treated as one logical split
- Updated the close button visibility condition to use the new `hasMultipleSplits()` memo instead of directly checking split count

## Implementation Details
The fix ensures that when only a single Preview Pair is open (which occupies two split slots), the Controller's close button is hidden, matching the behavior when a lone split is open. This prevents users from closing the Controller when it's the only logical split available.

The Preview Pair is a special case where the Viewer isn't independently closable, so the slot accounting needed to be adjusted to reflect the actual number of independently-closable splits.

https://claude.ai/code/session_019ZX1DyFbjaU53VkqBnBWEo