### PR TITLE
Rename "Add label" to "Add tag" in soup entity actions

### DIFF
--- a/apps/web/src/features/next-soup/soup-view/create-soup-entity-actions.ts
+++ b/apps/web/src/features/next-soup/soup-view/create-soup-entity-actions.ts
@@ -317,8 +317,8 @@ export function createSoupEntityActions(): {
 
     if (entities.length === 1 && openTagPicker) {
       middleItems.push({
-        id: 'add-label',
-        label: 'Add label',
+        id: 'add-tag',
+        label: 'Add tag',
         onClick: openTagPicker,
       });
     }


### PR DESCRIPTION
## Summary
Updated the terminology in the soup entity actions menu to use "tag" instead of "label" for consistency with the application's vocabulary.

## Changes
- Changed menu item ID from `add-label` to `add-tag`
- Updated menu item label text from "Add label" to "Add tag"

## Details
This change affects the context menu that appears when a single entity is selected in the soup view. The menu item that opens the tag picker now uses the correct terminology ("tag") instead of the previous label ("label"), ensuring consistent language throughout the UI.

https://claude.ai/code/session_01J18ZxUWfYqhr4LgofdaDtN