### PR TITLE
Point billing "contact us" link to mailto:support@macro.com

### DIFF
--- a/apps/web/src/features/settings/Billing.tsx
+++ b/apps/web/src/features/settings/Billing.tsx
@@ -4,8 +4,8 @@ import { useHasPaidAccess } from '@core/auth';
 import { PERMISSION_IDS } from '@core/constant/permissions';
 import { usePermissions, useUserId } from '@core/context/user';
 import { plural } from '@core/util/string';
-import ArrowSquareOutIcon from '@phosphor/arrow-square-out.svg';
 import CheckIcon from '@phosphor/check.svg';
+import EnvelopeIcon from '@phosphor/envelope.svg';
 import { useCurrentTeamQuery } from '@queries/team/teams';
 import { stripeServiceClient } from '@service-stripe/client';
 import { Button, Layer } from '@ui';
@@ -96,12 +96,10 @@ export const Billing = () => {
           For questions about billing,{' '}
           <a
             class="text-ink inline-flex items-center hover:text-accent"
-            href="https://cal.com/team/macro/macro-demo-call"
-            target="_blank"
-            rel="noopener"
+            href="mailto:support@macro.com"
           >
             contact us
-            <ArrowSquareOutIcon class="size-4 inline mx-1" />
+            <EnvelopeIcon class="size-4 inline mx-1" />
           </a>
         </>
       }


### PR DESCRIPTION
## Summary

The "contact us" link in the Billing settings page pointed to the cal.com demo-call booking page (`https://cal.com/team/macro/macro-demo-call`). That's a sales/onboarding call flow, not what someone looking for **billing support** wants.

This changes the link to `mailto:support@macro.com` so it opens the user's email client addressed to support directly.

## Changes

- `apps/web/src/features/settings/Billing.tsx`
  - `href` changed from the cal.com booking URL to `mailto:support@macro.com`
  - Removed the now-unneeded `target="_blank"` / `rel="noopener"` (a mailto doesn't open a new tab)
  - Swapped the external-link arrow icon (`ArrowSquareOutIcon`) for an envelope icon (`EnvelopeIcon`), which better signals an email action

## Testing

Visual/link change only. The `EnvelopeIcon` import mirrors existing usage elsewhere in the settings feature (e.g. `Team.tsx`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01W7tNQ2WFRFdB9ZQr3FNEAC)_