### PR TITLE
fix: keep soup preview open while a tab switch is still fetching

### DIFF
--- a/apps/web/src/components/app/split-layout/components/PopoverSplitRenderer.tsx
+++ b/apps/web/src/components/app/split-layout/components/PopoverSplitRenderer.tsx
@@ -103,6 +103,7 @@ function PopoverSplitModal(props: {
     canEngagePreview: () => false,
     engagePreview: () => {},
     disengagePreview: () => {},
+    resetPreview: () => {},
     viewerId: () => undefined,
   };
 

--- a/apps/web/src/components/app/split-layout/layoutManager.ts
+++ b/apps/web/src/components/app/split-layout/layoutManager.ts
@@ -419,6 +419,16 @@ export type SplitManager = {
   /** Exit preview mode and close the Preview Pair's Viewer. */
   disengagePreviewMode: (controllerId: SplitId) => void;
 
+  /**
+   * Return the Preview Pair's Viewer to its empty placeholder, e.g. when the
+   * Controller's list changes wholesale and the previewed entity no longer
+   * corresponds to a selected row. Replaces the Viewer's current entry (like
+   * Controller-originated selection navigation) rather than stacking a
+   * placeholder entry. No-op without a Viewer or when it already shows the
+   * placeholder.
+   */
+  resetPreviewMode: (controllerId: SplitId) => void;
+
   /** Preserve both splits while unlinking their Preview Pair. */
   unlinkPreviewPair: (controllerId: SplitId) => void;
 
@@ -525,6 +535,8 @@ export type SplitHandle<TMeta extends ComponentMeta = ComponentMeta> = {
   engagePreview: () => void;
   /** Exit preview mode and close this Controller's Viewer. */
   disengagePreview: () => void;
+  /** Return this Controller's Viewer to its placeholder (see SplitManager.resetPreviewMode). */
+  resetPreview: () => void;
   /** This Controller's live Viewer id, if one exists. Reactive. */
   viewerId: () => SplitId | undefined;
 } & UrlCapabilities;
@@ -1144,6 +1156,7 @@ export function createSplitLayout(
       canEngagePreview: () => canEngagePreview(currentSplit.id),
       engagePreview: () => engagePreviewMode(currentSplit.id),
       disengagePreview: () => disengagePreviewMode(currentSplit.id),
+      resetPreview: () => resetPreviewMode(currentSplit.id),
       viewerId: () => viewerOf(currentSplit.id),
     };
   };
@@ -1394,6 +1407,27 @@ export function createSplitLayout(
     const viewerId = viewerOf(controllerId);
     unlinkPreviewPair(controllerId);
     if (viewerId) removeSplit(viewerId);
+  }
+
+  function resetPreviewMode(controllerId: SplitId) {
+    const viewerId = viewerOf(controllerId);
+    if (viewerId === undefined) return;
+    const viewer = getSplit(viewerId);
+    if (!viewer) return;
+    const content = viewer.content();
+    if (
+      content.type === PREVIEW_VIEWER_EMPTY_CONTENT.type &&
+      content.id === PREVIEW_VIEWER_EMPTY_CONTENT.id
+    ) {
+      return;
+    }
+    viewer.replace({
+      next: PREVIEW_VIEWER_EMPTY_CONTENT,
+      referredFrom: null,
+      // Like Controller-originated selection navigation, the reset replaces
+      // the Viewer's current entry instead of stacking a placeholder entry.
+      mergeHistory: true,
+    });
   }
 
   const previewControllerWidth = (
@@ -1926,6 +1960,7 @@ export function createSplitLayout(
     restorePreviewPair,
     canEngagePreview,
     disengagePreviewMode,
+    resetPreviewMode,
     unlinkPreviewPair,
     previewControllerWidth,
     viewerOf,

--- a/apps/web/src/components/app/split-layout/tests/layoutManager.test.ts
+++ b/apps/web/src/components/app/split-layout/tests/layoutManager.test.ts
@@ -544,6 +544,58 @@ describe('layoutManager', () => {
       });
     });
 
+    it('resets the viewer to its placeholder without stacking history', () => {
+      createRoot((dispose) => {
+        const { manager, controllerId } = setup();
+        manager.engagePreviewMode(controllerId);
+        const viewerId = manager.viewerOf(controllerId)!;
+
+        manager.openWithSplit(
+          { type: 'md', id: 'doc-1' },
+          { referredFrom: null, handle: manager.getSplit(controllerId) }
+        );
+        expect(manager.splits()[1].content).toMatchObject({
+          type: 'md',
+          id: 'doc-1',
+        });
+
+        manager.getSplit(controllerId)?.resetPreview();
+
+        expect(manager.viewerOf(controllerId)).toBe(viewerId);
+        expect(manager.splits()).toHaveLength(2);
+        expect(manager.splits()[1].content).toMatchObject({
+          type: 'component',
+          id: 'preview-empty',
+        });
+        // Selection state was merge-replaced both ways, so the stale entity
+        // does not linger as a back entry.
+        expect(manager.getSplit(viewerId)?.canGoBack()).toBe(false);
+
+        dispose();
+      });
+    });
+
+    it('reset is a no-op without a viewer or when already on the placeholder', () => {
+      createRoot((dispose) => {
+        const { manager, controllerId } = setup();
+
+        manager.resetPreviewMode(controllerId);
+        expect(manager.splits()).toHaveLength(1);
+
+        manager.engagePreviewMode(controllerId);
+        const viewerId = manager.viewerOf(controllerId)!;
+        manager.resetPreviewMode(controllerId);
+
+        expect(manager.viewerOf(controllerId)).toBe(viewerId);
+        expect(manager.splits()[1].content).toMatchObject({
+          type: 'component',
+          id: 'preview-empty',
+        });
+
+        dispose();
+      });
+    });
+
     it('uses the configured controller width for Email Soup', () => {
       createRoot((dispose) => {
         const manager = createSplitLayout(createMockOrchestrator(), [

--- a/apps/web/src/features/next-soup/soup-view/soup-view-tabs.tsx
+++ b/apps/web/src/features/next-soup/soup-view/soup-view-tabs.tsx
@@ -108,6 +108,7 @@ export const shouldPreserveFiltersOnTabChange = (view: ListView) =>
 
 export const useApplyPreset = () => {
   const soup = useSoup();
+  const panel = useSplitPanelOrThrow();
   const {
     queryFilters,
     restorePersistedQueryFilters,
@@ -209,6 +210,19 @@ export const useApplyPreset = () => {
       }
       soup.grouping.setActiveGroupId(preset.groupBy);
     });
+
+    // The new tab replaces the dataset wholesale, and row focus only follows
+    // a row that survives into it (see soup.setRows). When it doesn't,
+    // nothing is selected anymore, so the Preview Pair's Viewer returns to
+    // its placeholder instead of lingering on the previous tab's entity.
+    const focusedRow = soup.focus.row();
+    if (
+      !focusedRow ||
+      focusedRow.getIsGrouped() ||
+      focusedRow.getIsLoadMore()
+    ) {
+      panel.handle.resetPreview();
+    }
     return true;
   };
 

--- a/apps/web/src/features/next-soup/soup-view/soup-view.tsx
+++ b/apps/web/src/features/next-soup/soup-view/soup-view.tsx
@@ -336,6 +336,8 @@ export const SoupView = (props: SoupViewProps) => {
   const hasPreviewItems = useSoupPreviewAvailability({
     rows: soupView.rows,
     isLoading: soupView.source.isLoading,
+    isFetching: soupView.source.isFetching,
+    isPlaceholderData: soupView.source.isPlaceholderData,
     splitHandle: panel.handle,
   });
   const openFocusedEntityInPreview = () => {

--- a/apps/web/src/features/next-soup/soup-view/use-soup-preview-availability.test.ts
+++ b/apps/web/src/features/next-soup/soup-view/use-soup-preview-availability.test.ts
@@ -1,5 +1,5 @@
 import type { SplitHandle } from '@components/app/split-layout/layoutManager';
-import { createRoot, createSignal } from 'solid-js';
+import { batch, createRoot, createSignal } from 'solid-js';
 import { describe, expect, it, vi } from 'vitest';
 import type { SoupRow } from '../create-soup-state';
 import {
@@ -17,6 +17,57 @@ const row = (
 
 const flushEffects = () => Promise.resolve();
 
+type HarnessOptions = {
+  rows?: SoupRow[];
+  isLoading?: boolean;
+  isFetching?: boolean;
+  isPlaceholderData?: boolean;
+};
+
+const createHarness = (initial: HarnessOptions = {}) => {
+  const disengagePreview = vi.fn();
+  let dispose!: () => void;
+  let setRows!: (rows: SoupRow[]) => void;
+  let setLoading!: (loading: boolean) => void;
+  let setFetching!: (fetching: boolean) => void;
+  let setPlaceholderData!: (placeholder: boolean) => void;
+
+  createRoot((rootDispose) => {
+    dispose = rootDispose;
+    const [rows, updateRows] = createSignal(initial.rows ?? [row()]);
+    const [isLoading, updateLoading] = createSignal(initial.isLoading ?? false);
+    const [isFetching, updateFetching] = createSignal(
+      initial.isFetching ?? false
+    );
+    const [isPlaceholderData, updatePlaceholderData] = createSignal(
+      initial.isPlaceholderData ?? false
+    );
+    setRows = updateRows;
+    setLoading = updateLoading;
+    setFetching = updateFetching;
+    setPlaceholderData = updatePlaceholderData;
+    useSoupPreviewAvailability({
+      rows,
+      isLoading,
+      isFetching,
+      isPlaceholderData,
+      splitHandle: {
+        isControllerSplit: () => true,
+        disengagePreview,
+      } as unknown as SplitHandle,
+    });
+  });
+
+  return {
+    disengagePreview,
+    dispose,
+    setRows,
+    setLoading,
+    setFetching,
+    setPlaceholderData,
+  };
+};
+
 describe('Soup preview availability', () => {
   it('requires an entity row rather than a group or load-more row', () => {
     expect(
@@ -26,58 +77,89 @@ describe('Soup preview availability', () => {
   });
 
   it('disengages preview when the last entity row disappears', async () => {
-    const disengagePreview = vi.fn();
-    let setRows!: (rows: SoupRow[]) => void;
-    let dispose!: () => void;
-
-    createRoot((rootDispose) => {
-      dispose = rootDispose;
-      const [rows, updateRows] = createSignal([row()]);
-      setRows = updateRows;
-      useSoupPreviewAvailability({
-        rows,
-        isLoading: () => false,
-        splitHandle: {
-          isControllerSplit: () => true,
-          disengagePreview,
-        } as unknown as SplitHandle,
-      });
-    });
+    const harness = createHarness();
 
     await flushEffects();
-    expect(disengagePreview).not.toHaveBeenCalled();
+    expect(harness.disengagePreview).not.toHaveBeenCalled();
 
-    setRows([]);
+    harness.setRows([]);
     await flushEffects();
-    expect(disengagePreview).toHaveBeenCalledOnce();
-    dispose();
+    expect(harness.disengagePreview).toHaveBeenCalledOnce();
+    harness.dispose();
   });
 
   it('keeps preview open while an empty result is still loading', async () => {
-    const disengagePreview = vi.fn();
-    let setLoading!: (loading: boolean) => void;
-    let dispose!: () => void;
+    const harness = createHarness({ rows: [], isLoading: true });
 
-    createRoot((rootDispose) => {
-      dispose = rootDispose;
-      const [isLoading, updateLoading] = createSignal(true);
-      setLoading = updateLoading;
-      useSoupPreviewAvailability({
-        rows: () => [],
-        isLoading,
-        splitHandle: {
-          isControllerSplit: () => true,
-          disengagePreview,
-        } as unknown as SplitHandle,
-      });
+    await flushEffects();
+    expect(harness.disengagePreview).not.toHaveBeenCalled();
+
+    harness.setLoading(false);
+    await flushEffects();
+    expect(harness.disengagePreview).toHaveBeenCalledOnce();
+    harness.dispose();
+  });
+
+  it('keeps preview open across a tab switch whose fetch repopulates the rows', async () => {
+    const harness = createHarness();
+
+    await flushEffects();
+
+    // Tab switch: the kept-previous rows all fail the next tab's client
+    // predicates (e.g. Signal rows never match Noise) while its uncached
+    // query is in flight — `isLoading` stays false the whole time.
+    batch(() => {
+      harness.setRows([]);
+      harness.setFetching(true);
     });
+    await flushEffects();
+    expect(harness.disengagePreview).not.toHaveBeenCalled();
+
+    batch(() => {
+      harness.setRows([row()]);
+      harness.setFetching(false);
+    });
+    await flushEffects();
+    expect(harness.disengagePreview).not.toHaveBeenCalled();
+    harness.dispose();
+  });
+
+  it('keeps preview open while rows are placeholder data from the previous tab', async () => {
+    const harness = createHarness();
 
     await flushEffects();
-    expect(disengagePreview).not.toHaveBeenCalled();
 
-    setLoading(false);
+    batch(() => {
+      harness.setRows([]);
+      harness.setPlaceholderData(true);
+    });
     await flushEffects();
-    expect(disengagePreview).toHaveBeenCalledOnce();
-    dispose();
+    expect(harness.disengagePreview).not.toHaveBeenCalled();
+
+    batch(() => {
+      harness.setRows([row()]);
+      harness.setPlaceholderData(false);
+    });
+    await flushEffects();
+    expect(harness.disengagePreview).not.toHaveBeenCalled();
+    harness.dispose();
+  });
+
+  it('disengages preview once a fetch settles on an empty result', async () => {
+    const harness = createHarness();
+
+    await flushEffects();
+
+    batch(() => {
+      harness.setRows([]);
+      harness.setFetching(true);
+    });
+    await flushEffects();
+    expect(harness.disengagePreview).not.toHaveBeenCalled();
+
+    harness.setFetching(false);
+    await flushEffects();
+    expect(harness.disengagePreview).toHaveBeenCalledOnce();
+    harness.dispose();
   });
 });

--- a/apps/web/src/features/next-soup/soup-view/use-soup-preview-availability.ts
+++ b/apps/web/src/features/next-soup/soup-view/use-soup-preview-availability.ts
@@ -9,18 +9,35 @@ export function hasPreviewableSoupRows(rows: readonly SoupRow[]): boolean {
 /**
  * Tracks whether a Soup view has an entity that can be previewed and closes
  * its Preview Pair once a settled result contains no such entities.
+ *
+ * A result is only settled once nothing is in flight. `isLoading` alone
+ * doesn't cover a tab switch: both soup sources keep the previous tab's rows
+ * on screen while the next tab's (uncached) query loads, and those rows are
+ * immediately re-filtered by the next tab's client predicates. When none of
+ * them match (e.g. Signal rows never match Noise), rows are transiently empty
+ * while `isLoading` is already false — so the fetch state must also hold the
+ * preview open.
  */
 export function useSoupPreviewAvailability(options: {
   rows: Accessor<readonly SoupRow[]>;
   isLoading: Accessor<boolean>;
+  /** True while any fetch for the active filters is in flight. */
+  isFetching: Accessor<boolean>;
+  /** True while rows still belong to the previous query key (tab switch). */
+  isPlaceholderData: Accessor<boolean>;
   splitHandle: SplitHandle;
 }): Accessor<boolean> {
   const hasPreviewItems = createMemo(() =>
     hasPreviewableSoupRows(options.rows())
   );
 
+  const isSettled = () =>
+    !options.isLoading() &&
+    !options.isFetching() &&
+    !options.isPlaceholderData();
+
   createEffect(() => {
-    if (options.isLoading() || hasPreviewItems()) return;
+    if (!isSettled() || hasPreviewItems()) return;
     if (options.splitHandle.isControllerSplit()) {
       options.splitHandle.disengagePreview();
     }


### PR DESCRIPTION
Fixes the inbox soup view closing the preview split when selecting the Noise tab, and resets the preview viewer when a tab switch clears the selection (macro-2633).

**Root cause:** `useSoupPreviewAvailability` disengages the Preview Pair when a settled result has no previewable rows, but it only guarded on `source.isLoading()`. During a tab switch, both soup sources keep the previous tab's rows on screen while the next tab's uncached query loads (TanStack `placeholderData` / `createQuerySignal` retaining data across re-executions), so `isLoading` is already false — while those kept rows are simultaneously re-filtered by the next tab's client predicates. Signal rows never match the `noise` predicate (`!signalFilter`), so rows were transiently empty mid-fetch and the hook closed the preview. Signal and All were unaffected (kept rows pass their predicates), and a cached Noise query repopulates rows within the same update cycle — which is why the bug disappeared once the query was cached.

**Fixes:**
- `useSoupPreviewAvailability` now also takes `isFetching` and `isPlaceholderData` and only disengages once nothing is in flight, so only a genuinely settled empty result closes the preview. Both signals are set in the pure/render phase on both data paths, before user effects run, so the guard is deterministic. Adds regression tests for the tab-switch window (verified they fail against the previous implementation).
- New `SplitManager.resetPreviewMode` / `SplitHandle.resetPreview` returns a Preview Pair's Viewer to its empty placeholder by replacing its current entry (mirroring Controller-originated selection navigation). `applyTabPreset` calls it unless the focused row survives into the new tab (row focus follows surviving row ids in `soup.setRows`), so e.g. Signal → All keeps the previewed entity while Signal → Noise shows the empty preview instead of lingering on the old tab's entity.

Session: https://claude.ai/code/e8019bc0-97b5-5938-b585-a2a195a8b367