### PR TITLE
fix(email): remove spurious inner scrollbar on email message bodies

### DIFF
--- a/apps/web/src/features/block-email/component/EmailMessageBody.tsx
+++ b/apps/web/src/features/block-email/component/EmailMessageBody.tsx
@@ -287,9 +287,10 @@ export function EmailMessageBody(props: EmailMessageBodyProps) {
         // Use zoom instead of transform: scale() so that backgrounds,
         // borders, and layout all shrink together without clipping.
         messageDiv.style.zoom = `${scale}`;
-      } else {
-        messageDiv.style.overflow = 'auto';
       }
+      // When content fits, leave overflow alone — an overflow:auto wrapper
+      // turns hidden tracking-pixel divs (e.g. max-height:1px) into a
+      // message-height scrollbar.
     };
 
     // Re-run on container resize (e.g. orientation change, split resize)


### PR DESCRIPTION
## Problem

Some emails render with their own vertical scrollbar inside the message body, separate from the thread scroll.

The fit-to-width scaling effect in `EmailMessageBody.tsx` (added in #2146) sets `overflow: auto` on the shadow-DOM message wrapper whenever the content **doesn't** need to be zoomed down — i.e. on every normal-width email. That's usually invisible, but any hidden overflow inside the email turns it into a real scrollbar.

Trigger case: emails sent via Streak end with a tracking-pixel div styled `max-height: 1px` containing a hidden `ᐧ` character. The character's line box overflows the 1px-tall div, and with `overflow: auto` on the wrapper those ~15px of spill-over become scrollable overflow — the whole message grows a near-full-height scrollbar with a few pixels of scroll range.

## Fix

Don't touch `overflow` when the content already fits the container. The wide-email zoom path is unchanged, and `overflow` is still reset before each re-measure (and by `clearScale`).
