### PR TITLE
update topicevent trait

### DIFF
--- a/crates/bots/src/domain/events.rs
+++ b/crates/bots/src/domain/events.rs
@@ -90,9 +90,7 @@ pub enum BotTopicEvent {
 impl TopicEvent for BotTopicEvent {
     type Topic = MacroBotsTopic;
 
-    fn schema_version(&self) -> u8 {
-        1
-    }
+    const SCHEMA_VERSION: u8 = 1;
 }
 
 /// Publishable lifecycle event for [`MacroBotsTopic`], keyed by bot id.

--- a/crates/channels/src/domain/broker_events.rs
+++ b/crates/channels/src/domain/broker_events.rs
@@ -230,9 +230,7 @@ pub enum ChannelTopicEvent {
 impl TopicEvent for ChannelTopicEvent {
     type Topic = MacroChannelsTopic;
 
-    fn schema_version(&self) -> u8 {
-        1
-    }
+    const SCHEMA_VERSION: u8 = 1;
 }
 
 /// Publishable event for [`MacroChannelsTopic`], keyed by channel id.

--- a/crates/channels/src/domain/mention_events.rs
+++ b/crates/channels/src/domain/mention_events.rs
@@ -68,9 +68,7 @@ pub enum MentionTopicEvent {
 impl TopicEvent for MentionTopicEvent {
     type Topic = MacroMentionsTopic;
 
-    fn schema_version(&self) -> u8 {
-        1
-    }
+    const SCHEMA_VERSION: u8 = 1;
 }
 
 /// Publishable event for [`MacroMentionsTopic`], keyed by the mentioned

--- a/crates/documents/src/domain/events.rs
+++ b/crates/documents/src/domain/events.rs
@@ -134,9 +134,7 @@ pub enum DocumentTopicEvent {
 impl TopicEvent for DocumentTopicEvent {
     type Topic = MacroDocumentsTopic;
 
-    fn schema_version(&self) -> u8 {
-        1
-    }
+    const SCHEMA_VERSION: u8 = 1;
 }
 
 /// Publishable event for [`MacroDocumentsTopic`], keyed by document id.

--- a/crates/email/src/domain/events.rs
+++ b/crates/email/src/domain/events.rs
@@ -436,9 +436,7 @@ pub enum EmailTopicEvent {
 impl TopicEvent for EmailTopicEvent {
     type Topic = MacroEmailTopic;
 
-    fn schema_version(&self) -> u8 {
-        1
-    }
+    const SCHEMA_VERSION: u8 = 1;
 }
 
 /// Publishable event for [`MacroEmailTopic`], keyed by link (inbox) id.

--- a/crates/macro_event_broker/examples/example_event.rs
+++ b/crates/macro_event_broker/examples/example_event.rs
@@ -51,9 +51,7 @@ pub enum ExampleTopicEvent {
 impl TopicEvent for ExampleTopicEvent {
     type Topic = MacroExampleTopic;
 
-    fn schema_version(&self) -> u8 {
-        1
-    }
+    const SCHEMA_VERSION: u8 = 1;
 }
 
 /// Publishable event for [`MacroExampleTopic`].

--- a/crates/macro_event_broker/src/domain/models.rs
+++ b/crates/macro_event_broker/src/domain/models.rs
@@ -18,7 +18,7 @@ pub trait TopicEvent: Serialize + DeserializeOwned + Send + Sync {
     type Topic: Topic;
 
     /// Version of this concrete event variant's payload schema.
-    fn schema_version(&self) -> u8;
+    const SCHEMA_VERSION: u8;
 }
 
 /// Serializable event envelope published through the broker.
@@ -50,7 +50,7 @@ impl<E: TopicEvent> Event<E> {
 
     /// Create a new event with an explicit event id.
     pub fn with_event_id(event_id: Uuid, event: E) -> Self {
-        let schema_version = event.schema_version();
+        let schema_version = E::SCHEMA_VERSION;
         Self::with_event_id_and_schema_version(event_id, schema_version, event)
     }
 
@@ -226,7 +226,7 @@ macro_rules! declare_topics {
                             .ok_or($crate::EventBrokerError::MissingMessagePayload)?;
                         let event = <$event as $crate::MacroEvent>::decode(key, payload)?;
                         let envelope = <$event as $crate::MacroEvent>::event(&event);
-                        let expected = $crate::TopicEvent::schema_version(&envelope.event);
+                        let expected = <<$event as $crate::MacroEvent>::EventPayload as $crate::TopicEvent>::SCHEMA_VERSION;
                         let actual = envelope.schema_version;
                         if actual != expected {
                             return Err($crate::EventBrokerError::UnsupportedSchemaVersion {

--- a/crates/macro_event_broker/src/domain/models/test.rs
+++ b/crates/macro_event_broker/src/domain/models/test.rs
@@ -22,9 +22,7 @@ pub enum ExampleTopicEvent {
 impl TopicEvent for ExampleTopicEvent {
     type Topic = MacroExampleTopic;
 
-    fn schema_version(&self) -> u8 {
-        1
-    }
+    const SCHEMA_VERSION: u8 = 1;
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -130,9 +128,7 @@ pub struct DocumentsTopicEvent;
 impl TopicEvent for DocumentsTopicEvent {
     type Topic = MacroDocumentsTopic;
 
-    fn schema_version(&self) -> u8 {
-        1
-    }
+    const SCHEMA_VERSION: u8 = 1;
 }
 
 pub struct DocumentsMacroEvent {

--- a/crates/macro_event_broker/src/domain/service/test.rs
+++ b/crates/macro_event_broker/src/domain/service/test.rs
@@ -101,9 +101,7 @@ pub enum ExampleTopicEvent {
 impl TopicEvent for ExampleTopicEvent {
     type Topic = MacroExampleTopic;
 
-    fn schema_version(&self) -> u8 {
-        1
-    }
+    const SCHEMA_VERSION: u8 = 1;
 }
 
 pub struct ExampleMacroEvent {
@@ -223,9 +221,7 @@ impl Serialize for UnserializableTopicEvent {
 impl TopicEvent for UnserializableTopicEvent {
     type Topic = MacroExampleTopic;
 
-    fn schema_version(&self) -> u8 {
-        1
-    }
+    const SCHEMA_VERSION: u8 = 1;
 }
 
 struct UnserializableMacroEvent {

--- a/crates/projects/src/domain/events.rs
+++ b/crates/projects/src/domain/events.rs
@@ -135,9 +135,7 @@ pub enum ProjectTopicEvent {
 impl TopicEvent for ProjectTopicEvent {
     type Topic = MacroProjectsTopic;
 
-    fn schema_version(&self) -> u8 {
-        1
-    }
+    const SCHEMA_VERSION: u8 = 1;
 }
 
 /// Publishable event for [`MacroProjectsTopic`], keyed by the root project id.

--- a/crates/soup_realtime/src/domain/models.rs
+++ b/crates/soup_realtime/src/domain/models.rs
@@ -34,9 +34,7 @@ pub enum SoupTopicEvent {
 impl TopicEvent for SoupTopicEvent {
     type Topic = MacroSoupRealtimeTopic;
 
-    fn schema_version(&self) -> u8 {
-        1
-    }
+    const SCHEMA_VERSION: u8 = 1;
 }
 
 /// Publishable realtime Soup event keyed by recipient user ID.

--- a/crates/teams/src/domain/events.rs
+++ b/crates/teams/src/domain/events.rs
@@ -204,9 +204,7 @@ pub enum TeamTopicEvent {
 impl TopicEvent for TeamTopicEvent {
     type Topic = MacroTeamsTopic;
 
-    fn schema_version(&self) -> u8 {
-        1
-    }
+    const SCHEMA_VERSION: u8 = 1;
 }
 
 /// Publishable event for [`MacroTeamsTopic`], keyed by the team's bare UUID.

--- a/crates/webhook/src/domain/events.rs
+++ b/crates/webhook/src/domain/events.rs
@@ -116,9 +116,7 @@ pub enum WebhookTopicEvent {
 impl TopicEvent for WebhookTopicEvent {
     type Topic = MacroWebhooksTopic;
 
-    fn schema_version(&self) -> u8 {
-        1
-    }
+    const SCHEMA_VERSION: u8 = 1;
 }
 
 /// Publishable lifecycle event for [`MacroWebhooksTopic`], keyed by webhook id.


### PR DESCRIPTION
changes the event method on topic event into a const because this value should be known statically at compile time, not receiving an &self
