### PR TITLE
fix(split-layout): route same-split popover navigations to the active split

### DIFF
--- a/apps/web/src/components/app/split-layout/layout.ts
+++ b/apps/web/src/components/app/split-layout/layout.ts
@@ -23,14 +23,19 @@ export function useSplitLayout() {
       return;
     }
 
+    // Navigation issued from inside a split panel (links, mentions, references)
+    // carries that panel as its source; callers outside any panel (sidebar,
+    // command menu) stay handle-less, which is what marks "external navigation"
+    // for Preview Pair routing. A popover's SplitPanelContext handle is a stub
+    // whose replace() is a no-op, so treat popover sources as handle-less too
+    // and let same-split navigation fall back to the active split.
+    const requestedHandle = options?.handle ?? splitPanelContext?.handle;
+    const handle = requestedHandle?.isPopover() ? undefined : requestedHandle;
+
     return splitManager.openWithSplit(content, {
       ...options,
       preferNewSplit,
-      // Navigation issued from inside a split panel (links, mentions,
-      // references) carries that panel as its source; callers outside any
-      // panel (sidebar, command menu) stay handle-less, which is what marks
-      // "external navigation" for Preview Pair routing.
-      handle: options?.handle ?? splitPanelContext?.handle,
+      handle,
     });
   }
 


### PR DESCRIPTION
Same-split navigation issued from inside a popover resolved to the popover's stub `SplitPanelContext` handle, whose `replace()` is a no-op, so the task composer's toast "Open" (and mention/link clicks in its description editor) did nothing while "Open in new split" worked. Treat a popover source handle as handle-less in `useSplitLayout().openWithSplit` so it falls back to the active split — matching command-menu/sidebar behavior — while real panels keep their Preview Pair routing.
