### PR TITLE
fix: comments staying highlighted after duplicating doc

### DIFF
--- a/apps/web/src/features/block-md/comments/CommentsProvider.tsx
+++ b/apps/web/src/features/block-md/comments/CommentsProvider.tsx
@@ -7,6 +7,7 @@ import { autoRegister } from '@core/component/LexicalMarkdown/plugins';
 import {
   commentPlugin,
   MARK_SELECTED_COMMENT_COMMAND,
+  REMOVE_ORPHANED_COMMENT_MARKS_COMMAND,
 } from '@core/component/LexicalMarkdown/plugins/comments/commentPlugin';
 import { useUserId } from '@core/context/user';
 import type { LoroManager } from '@macro-inc/collaboration/collab/manager';
@@ -140,7 +141,6 @@ export const CommentsProvider: VoidComponent<{
         setMarks(markId, undefined);
         const rootId = existing.thread?.rootId;
         if (!rootId) {
-          console.error('Unable to delete comment: no root id');
           return;
         }
         deleteComment({ commentId: rootId });
@@ -259,8 +259,10 @@ export const CommentsProvider: VoidComponent<{
   // Map server comment threads to mark metadata once marks are initialized
   createEffect(() => {
     if (!commentMarksInitializedSignal()) return;
+    if (commentThreadsData.loading || commentThreadsData.error) return;
 
     const commentThreads = commentThreadsData() ?? [];
+    const validAnchorIds = new Set<string>();
 
     const mappedAnchors = commentThreads.map((commentThread) => {
       const threadMetadata = commentThread.thread.metadata as ThreadMetadata;
@@ -273,6 +275,7 @@ export const CommentsProvider: VoidComponent<{
         console.error('Unable to find anchor id');
         return undefined;
       }
+      validAnchorIds.add(anchorId);
 
       const sortedComments = commentThread.comments.sort(sortComments);
       const rootComment = sortedComments[0];
@@ -301,6 +304,11 @@ export const CommentsProvider: VoidComponent<{
       if (!anchor) continue;
       setMarks(anchor.id, anchor);
     }
+
+    editor.dispatchCommand(
+      REMOVE_ORPHANED_COMMENT_MARKS_COMMAND,
+      validAnchorIds
+    );
   });
 
   // Navigate to comment from URL param once comments are loaded

--- a/apps/web/src/features/block-md/comments/commentsResource.ts
+++ b/apps/web/src/features/block-md/comments/commentsResource.ts
@@ -43,7 +43,10 @@ async function fetchComments() {
   const commentThreads = await storageServiceClient.annotations.getComments({
     documentId,
   });
-  return commentThreads.isOk() ? commentThreads.value.data : [];
+  if (commentThreads.isErr()) {
+    throw new Error('Unable to fetch comments');
+  }
+  return commentThreads.value.data;
 }
 
 function useHandleCreateComment() {

--- a/apps/web/src/lib/core/component/LexicalMarkdown/plugins/comments/commentPlugin.ts
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/plugins/comments/commentPlugin.ts
@@ -61,6 +61,10 @@ export const MARK_SELECTED_COMMENT_COMMAND = createCommand<string[]>(
   'MARK_SELECTED_COMMENT_COMMAND'
 );
 
+export const REMOVE_ORPHANED_COMMENT_MARKS_COMMAND = createCommand<
+  ReadonlySet<string>
+>('REMOVE_ORPHANED_COMMENT_MARKS_COMMAND');
+
 export const SET_COMMENT_THREAD_ID_COMMAND = createCommand<{
   markId: string;
   threadId: number;
@@ -408,6 +412,14 @@ function registerPlugin(editor: LexicalEditor, props: CommentPluginProps) {
       COMMAND_PRIORITY_EDITOR
     ),
     editor.registerCommand(
+      REMOVE_ORPHANED_COMMENT_MARKS_COMMAND,
+      (validMarkIds) => {
+        $removeOrphanedCommentMarks(validMarkIds);
+        return true;
+      },
+      COMMAND_PRIORITY_EDITOR
+    ),
+    editor.registerCommand(
       CLEANUP_COMMENTS_COMMAND,
       (payload) => {
         $disposeExternalDraftComments(payload);
@@ -445,6 +457,24 @@ function $disposeExternalDraftComments(validPeerIds: string[]) {
       if (!validPeerIds.includes(nodePeerId)) {
         $unwrapMarkNode(node);
       }
+    }
+  });
+}
+
+function $removeOrphanedCommentMarks(validMarkIds: ReadonlySet<string>) {
+  $traverseNodes($getRoot(), (node) => {
+    if (!$isCommentNode(node) || node.getIsDraft()) return;
+
+    const invalidIds = node.getIDs().filter((id) => !validMarkIds.has(id));
+    if (invalidIds.length === 0) return;
+
+    if (invalidIds.length === node.getIDs().length) {
+      $unwrapMarkNode(node);
+      return;
+    }
+
+    for (const id of invalidIds) {
+      node.deleteID(id);
     }
   });
 }


### PR DESCRIPTION
My stab at https://github.com/macro-inc/macro/pull/5158
Small change on frontend to remove orphaned highlights. I think it's much cleaner this way (and will generally be more robust)