### PR TITLE
fix(entity_access): inherit thread access for email-attachment documents

### DIFF
--- a/.sqlx/query-99da2764a75ac041d4798999f5db185d220d681b0661377ec12f83eca226d546.json
+++ b/.sqlx/query-99da2764a75ac041d4798999f5db185d220d681b0661377ec12f83eca226d546.json
@@ -1,0 +1,24 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT access_level FROM (\n            -- Source 1: entity_access source_id match\n            SELECT\n                access_level::text FROM entity_access\n            WHERE entity_id = $1\n            AND entity_type = 'document'\n            AND source_id = ANY($2)\n\n            UNION ALL\n            -- Source 2: items share permission\n            SELECT\n                \"publicAccessLevel\"::text AS access_level\n            FROM \"SharePermission\"\n            WHERE \"isPublic\" = true\n            AND \"publicAccessLevel\" IS NOT NULL\n            AND id IN (\n                SELECT \"sharePermissionId\" FROM \"DocumentPermission\" WHERE \"documentId\" = $3\n            )\n\n            UNION ALL\n            -- Source 3: the document is an email attachment — access to the source\n            -- thread grants the same access level on the attachment document.\n            SELECT\n                tea.access_level::text\n            FROM document_email de\n            JOIN email_attachments ea ON ea.id = de.email_attachment_id\n            JOIN email_messages m ON m.id = ea.message_id\n            JOIN entity_access tea ON tea.entity_id = m.thread_id\n                AND tea.entity_type = 'email_thread'\n                AND tea.source_id = ANY($2)\n            WHERE de.document_id = $3\n        ) AS combined_access\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "access_level",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "TextArray",
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "99da2764a75ac041d4798999f5db185d220d681b0661377ec12f83eca226d546"
+}

--- a/crates/entity_access/src/outbound/pg_access_repo/queries/document_access.rs
+++ b/crates/entity_access/src/outbound/pg_access_repo/queries/document_access.rs
@@ -1,5 +1,8 @@
 //! Query for document access level.
 
+#[cfg(test)]
+mod test;
+
 use crate::{domain::models::AccessLevel, outbound::pg_access_repo::queries::SourceIds};
 use sqlx::PgPool;
 use std::str::FromStr;
@@ -53,6 +56,19 @@ pub async fn get_document_access(
             AND id IN (
                 SELECT "sharePermissionId" FROM "DocumentPermission" WHERE "documentId" = $3
             )
+
+            UNION ALL
+            -- Source 3: the document is an email attachment — access to the source
+            -- thread grants the same access level on the attachment document.
+            SELECT
+                tea.access_level::text
+            FROM document_email de
+            JOIN email_attachments ea ON ea.id = de.email_attachment_id
+            JOIN email_messages m ON m.id = ea.message_id
+            JOIN entity_access tea ON tea.entity_id = m.thread_id
+                AND tea.entity_type = 'email_thread'
+                AND tea.source_id = ANY($2)
+            WHERE de.document_id = $3
         ) AS combined_access
         "#,
         document_id,

--- a/crates/entity_access/src/outbound/pg_access_repo/queries/document_access/test.rs
+++ b/crates/entity_access/src/outbound/pg_access_repo/queries/document_access/test.rs
@@ -1,0 +1,265 @@
+#[allow(unused_imports)]
+use super::*;
+use crate::domain::models::AccessLevel;
+use macro_db_migrator::MACRO_DB_MIGRATIONS;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+const OWNER: &str = "macro|owner@corp.test";
+const REQUESTER: &str = "macro|requester@corp.test";
+const OTHER: &str = "macro|other@corp.test";
+
+async fn insert_user(pool: &PgPool, user_id: &str, email: &str) {
+    let macro_uuid = Uuid::new_v4();
+    sqlx::query!(
+        r#"INSERT INTO macro_user (id, username, email, stripe_customer_id)
+           VALUES ($1, $2, $3, $4)"#,
+        macro_uuid,
+        user_id,
+        email,
+        user_id,
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+
+    sqlx::query!(
+        r#"INSERT INTO "User" (id, email, macro_user_id) VALUES ($1, $2, $3)"#,
+        user_id,
+        email,
+        macro_uuid,
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+async fn insert_document(pool: &PgPool, document_id: &Uuid, owner: &str) {
+    sqlx::query!(
+        r#"INSERT INTO "Document" (id, name, owner) VALUES ($1, 'Test Doc', $2)"#,
+        document_id.to_string(),
+        owner,
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+/// An empty link + thread owned by `owner_macro_id`. Returns `(link_id, thread_id)`.
+async fn insert_thread(pool: &PgPool, owner_macro_id: &str) -> (Uuid, Uuid) {
+    let link_id = Uuid::new_v4();
+    let thread_id = Uuid::new_v4();
+
+    sqlx::query!(
+        r#"INSERT INTO email_links (id, macro_id, fusionauth_user_id, email_address, provider)
+           VALUES ($1, $2, $2, $3, 'GMAIL')"#,
+        link_id,
+        owner_macro_id,
+        format!("{owner_macro_id}@mail.test"),
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+
+    sqlx::query!(
+        r#"INSERT INTO email_threads (id, link_id) VALUES ($1, $2)"#,
+        thread_id,
+        link_id,
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+
+    (link_id, thread_id)
+}
+
+/// A message + attachment on `thread_id`. Returns the attachment id.
+async fn insert_attachment(pool: &PgPool, thread_id: Uuid, link_id: Uuid) -> Uuid {
+    let message_id = Uuid::new_v4();
+    sqlx::query!(
+        r#"INSERT INTO email_messages (id, thread_id, link_id) VALUES ($1, $2, $3)"#,
+        message_id,
+        thread_id,
+        link_id,
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+
+    let attachment_id = Uuid::new_v4();
+    sqlx::query!(
+        r#"INSERT INTO email_attachments (id, message_id, filename)
+           VALUES ($1, $2, 'resume.pdf')"#,
+        attachment_id,
+        message_id,
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+
+    attachment_id
+}
+
+async fn link_document_to_attachment(pool: &PgPool, document_id: &Uuid, attachment_id: Uuid) {
+    sqlx::query!(
+        r#"INSERT INTO document_email (document_id, email_attachment_id) VALUES ($1, $2)"#,
+        document_id.to_string(),
+        attachment_id,
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+async fn insert_thread_entity_access(
+    pool: &PgPool,
+    thread_id: Uuid,
+    source_id: &str,
+    level: AccessLevel,
+) {
+    let level_str = level.to_string();
+    sqlx::query!(
+        r#"INSERT INTO entity_access (entity_id, entity_type, source_id, source_type, access_level)
+           VALUES ($1, 'email_thread', $2, 'user', $3::text::"AccessLevel")"#,
+        thread_id,
+        source_id,
+        level_str,
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+async fn insert_document_entity_access(
+    pool: &PgPool,
+    document_id: &Uuid,
+    source_id: &str,
+    level: AccessLevel,
+) {
+    let level_str = level.to_string();
+    sqlx::query!(
+        r#"INSERT INTO entity_access (entity_id, entity_type, source_id, source_type, access_level)
+           VALUES ($1, 'document', $2, 'user', $3::text::"AccessLevel")"#,
+        document_id,
+        source_id,
+        level_str,
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+#[sqlx::test(migrator = "MACRO_DB_MIGRATIONS")]
+async fn no_access_without_any_grant(pool: PgPool) -> anyhow::Result<()> {
+    insert_user(&pool, OWNER, "owner@corp.test").await;
+    let document_id = Uuid::new_v4();
+    insert_document(&pool, &document_id, OWNER).await;
+
+    let source_ids = SourceIds(vec![REQUESTER.to_string()]);
+    let access = get_document_access(&pool, &document_id, &source_ids).await?;
+
+    assert_eq!(access, None);
+    Ok(())
+}
+
+#[sqlx::test(migrator = "MACRO_DB_MIGRATIONS")]
+async fn direct_entity_access_still_grants_access(pool: PgPool) -> anyhow::Result<()> {
+    // Regression check: Source 1 (direct entity_access on the document) must
+    // keep working once the email-thread source is added.
+    insert_user(&pool, OWNER, "owner@corp.test").await;
+    let document_id = Uuid::new_v4();
+    insert_document(&pool, &document_id, OWNER).await;
+    insert_document_entity_access(&pool, &document_id, REQUESTER, AccessLevel::Edit).await;
+
+    let source_ids = SourceIds(vec![REQUESTER.to_string()]);
+    let access = get_document_access(&pool, &document_id, &source_ids).await?;
+
+    assert_eq!(access, Some(AccessLevel::Edit));
+    Ok(())
+}
+
+#[sqlx::test(migrator = "MACRO_DB_MIGRATIONS")]
+async fn thread_access_grants_same_level_on_attachment_document(
+    pool: PgPool,
+) -> anyhow::Result<()> {
+    // This is the reported bug: an email attachment uploaded as a Document has
+    // no direct ACL entry for anyone but the uploader, so it must inherit
+    // access from the source thread instead.
+    insert_user(&pool, OWNER, "owner@corp.test").await;
+    let document_id = Uuid::new_v4();
+    insert_document(&pool, &document_id, OWNER).await;
+
+    let (link_id, thread_id) = insert_thread(&pool, OWNER).await;
+    let attachment_id = insert_attachment(&pool, thread_id, link_id).await;
+    link_document_to_attachment(&pool, &document_id, attachment_id).await;
+
+    insert_thread_entity_access(&pool, thread_id, REQUESTER, AccessLevel::View).await;
+
+    let source_ids = SourceIds(vec![REQUESTER.to_string()]);
+    let access = get_document_access(&pool, &document_id, &source_ids).await?;
+
+    assert_eq!(access, Some(AccessLevel::View));
+    Ok(())
+}
+
+#[sqlx::test(migrator = "MACRO_DB_MIGRATIONS")]
+async fn thread_edit_wins_over_direct_view_on_attachment_document(
+    pool: PgPool,
+) -> anyhow::Result<()> {
+    insert_user(&pool, OWNER, "owner@corp.test").await;
+    let document_id = Uuid::new_v4();
+    insert_document(&pool, &document_id, OWNER).await;
+
+    let (link_id, thread_id) = insert_thread(&pool, OWNER).await;
+    let attachment_id = insert_attachment(&pool, thread_id, link_id).await;
+    link_document_to_attachment(&pool, &document_id, attachment_id).await;
+
+    insert_document_entity_access(&pool, &document_id, REQUESTER, AccessLevel::View).await;
+    insert_thread_entity_access(&pool, thread_id, REQUESTER, AccessLevel::Edit).await;
+
+    let source_ids = SourceIds(vec![REQUESTER.to_string()]);
+    let access = get_document_access(&pool, &document_id, &source_ids).await?;
+
+    assert_eq!(access, Some(AccessLevel::Edit));
+    Ok(())
+}
+
+#[sqlx::test(migrator = "MACRO_DB_MIGRATIONS")]
+async fn thread_access_scoped_to_requesters_own_source_ids(pool: PgPool) -> anyhow::Result<()> {
+    // Someone else's thread grant must not leak access to an unrelated caller.
+    insert_user(&pool, OWNER, "owner@corp.test").await;
+    let document_id = Uuid::new_v4();
+    insert_document(&pool, &document_id, OWNER).await;
+
+    let (link_id, thread_id) = insert_thread(&pool, OWNER).await;
+    let attachment_id = insert_attachment(&pool, thread_id, link_id).await;
+    link_document_to_attachment(&pool, &document_id, attachment_id).await;
+
+    insert_thread_entity_access(&pool, thread_id, OTHER, AccessLevel::Edit).await;
+
+    let source_ids = SourceIds(vec![REQUESTER.to_string()]);
+    let access = get_document_access(&pool, &document_id, &source_ids).await?;
+
+    assert_eq!(access, None);
+    Ok(())
+}
+
+#[sqlx::test(migrator = "MACRO_DB_MIGRATIONS")]
+async fn non_attachment_document_unaffected_by_unrelated_thread_access(
+    pool: PgPool,
+) -> anyhow::Result<()> {
+    // A document that isn't linked via document_email must not pick up access
+    // from an otherwise-accessible thread.
+    insert_user(&pool, OWNER, "owner@corp.test").await;
+    let document_id = Uuid::new_v4();
+    insert_document(&pool, &document_id, OWNER).await;
+
+    let (_link_id, thread_id) = insert_thread(&pool, OWNER).await;
+    insert_thread_entity_access(&pool, thread_id, REQUESTER, AccessLevel::Edit).await;
+
+    let source_ids = SourceIds(vec![REQUESTER.to_string()]);
+    let access = get_document_access(&pool, &document_id, &source_ids).await?;
+
+    assert_eq!(access, None);
+    Ok(())
+}


### PR DESCRIPTION
## Bug

Reported in the internal bug-reports channel: clicking to open a shared email attachment ("resume.pdf") threw an error for every recipient except the person who originally opened/uploaded it.

> clicking the resume gives me this error. is that intended?
> ...because we use gmail auth to grab the attachment at request time

## Root cause

Email attachments are uploaded once as a `Document` (linked via the `document_email` table back to the source `email_attachment` → `email_message` → `email_thread`). `get_document_access` (in `crates/entity_access/src/outbound/pg_access_repo/queries/document_access.rs`) only checked two sources for access:

1. Direct `entity_access` rows on the document (`entity_type = 'document'`)
2. Public `SharePermission` / `DocumentPermission`

It never checked whether the caller had access to the **email thread** the document originated from. So sharing a thread (or the channel card) gave recipients thread-level access, but the underlying attachment `Document` had no ACL entry for anyone but the uploader — `get_document_access` returned `None` for everyone else, causing the "open" request to fail with an authorization error.

This mirrors an existing pattern already used for threads inheriting access from their containing project (`get_thread_access`'s "Source 3" in `thread_access.rs`), which was never extended to documents that originated from an email attachment.

## Fix

Adds a third `UNION ALL` source to `get_document_access` that joins `document_email → email_attachments → email_messages → entity_access` (on `entity_type = 'email_thread'`, scoped to the caller's `source_id`s) and grants the document the same access level the caller has on the source thread.

## Tests

Added `crates/entity_access/src/outbound/pg_access_repo/queries/document_access/test.rs` with 6 cases covering:
- No access without any grant (baseline)
- Direct document `entity_access` still works (regression on existing sources)
- Thread access grants the same level on the attachment document (the reported bug)
- A higher thread-level grant wins over a lower direct document grant
- Thread access is scoped to the caller's own source ids (no leakage to unrelated callers)
- A document *not* linked to any email attachment is unaffected by unrelated thread access

All 299 tests in the `entity_access` crate pass, and `cargo clippy -p entity_access` is clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01L7FiCtSXjst53P9HwSSLwN)_