### PR TITLE
fix(editor): don't autolink inline code mid-typing (MACRO-2663)

### DIFF
--- a/apps/web/src/lib/core/component/LexicalMarkdown/plugins/links/linksPlugin.test.ts
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/plugins/links/linksPlugin.test.ts
@@ -1,9 +1,14 @@
 import { $isAutoLinkNode } from '@lexical/link';
+import { INLINE_CODE, registerMarkdownShortcuts } from '@lexical/markdown';
 import { SupportedNodeTypes } from '@macro-inc/lexical-core/node-list';
 import {
   $createParagraphNode,
   $createTextNode,
   $getRoot,
+  $getSelection,
+  $isElementNode,
+  $isRangeSelection,
+  $isTextNode,
   createEditor,
   type LexicalEditor,
 } from 'lexical';
@@ -25,6 +30,10 @@ function createTestEditor(): LexicalEditor {
   document.body.appendChild(root);
   editor.setRootElement(root);
   linksPlugin({ autoLinkMatchMode: 'common-tlds' })(editor);
+  // Also register the real inline-code markdown shortcut (as production does
+  // via markdownShortcutsPlugin) so tests exercise the actual interaction
+  // between autolinking and the backtick shortcut, not just linksPlugin alone.
+  registerMarkdownShortcuts(editor, [INLINE_CODE]);
 
   return editor;
 }
@@ -52,6 +61,7 @@ describe('linksPlugin autolink transform', () => {
 
     editor.read(() => {
       const paragraph = $getRoot().getFirstChildOrThrow();
+      if (!$isElementNode(paragraph)) throw new Error('expected element node');
       const children = paragraph.getChildren();
       expect(children).toHaveLength(1);
       expect($isAutoLinkNode(children[0])).toBe(false);
@@ -59,38 +69,51 @@ describe('linksPlugin autolink transform', () => {
     });
   });
 
-  test('does not leave a stray autolink once the rest of the inline code is typed', () => {
+  test('does not leave a stray autolink once the rest of the inline code is typed, and the code shortcut still converts it', () => {
     const editor = createTestEditor();
-    let textKey = '';
 
     editor.update(
       () => {
         const paragraph = $createParagraphNode();
         const textNode = $createTextNode('`channel.me');
-        textKey = textNode.getKey();
         paragraph.append(textNode);
         $getRoot().clear().append(paragraph);
+        textNode.select(
+          textNode.getTextContentSize(),
+          textNode.getTextContentSize()
+        );
       },
       { discrete: true }
     );
 
-    // Continue "typing" the rest of the word and the closing backtick.
-    editor.update(
-      () => {
-        const textNode = $getRoot()
-          .getFirstChildOrThrow()
-          .getChildren()
-          .find((child) => child.getKey() === textKey);
-        textNode?.setTextContent('`channel.messages`');
-      },
-      { discrete: true }
-    );
+    // Continue "typing" the rest of the word and the closing backtick, one
+    // character at a time via the same selection.insertText() path real
+    // typing goes through — the markdown code-format shortcut keys off
+    // incremental single-character selection changes, not just final text.
+    for (const char of 'ssages`') {
+      editor.update(
+        () => {
+          const selection = $getSelection();
+          if ($isRangeSelection(selection)) {
+            selection.insertText(char);
+          }
+        },
+        { discrete: true }
+      );
+    }
 
     editor.read(() => {
       const paragraph = $getRoot().getFirstChildOrThrow();
+      if (!$isElementNode(paragraph)) throw new Error('expected element node');
       const children = paragraph.getChildren();
       expect(children.some((child) => $isAutoLinkNode(child))).toBe(false);
-      expect(paragraph.getTextContent()).toBe('`channel.messages`');
+      // The backtick shortcut should still be able to convert the completed
+      // span into actual inline code, since no stray AutoLinkNode is left
+      // splitting the text into separate nodes.
+      expect(paragraph.getTextContent()).toBe('channel.messages');
+      expect(
+        children.some((child) => $isTextNode(child) && child.hasFormat('code'))
+      ).toBe(true);
     });
   });
 
@@ -108,6 +131,7 @@ describe('linksPlugin autolink transform', () => {
 
     editor.read(() => {
       const paragraph = $getRoot().getFirstChildOrThrow();
+      if (!$isElementNode(paragraph)) throw new Error('expected element node');
       const children = paragraph.getChildren();
       expect(children.some((child) => $isAutoLinkNode(child))).toBe(true);
     });

--- a/apps/web/src/lib/core/component/LexicalMarkdown/plugins/links/linksPlugin.test.ts
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/plugins/links/linksPlugin.test.ts
@@ -1,6 +1,118 @@
-import { describe, expect, it } from 'vitest';
+import { $isAutoLinkNode } from '@lexical/link';
+import { SupportedNodeTypes } from '@macro-inc/lexical-core/node-list';
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  createEditor,
+  type LexicalEditor,
+} from 'lexical';
+import { describe, expect, it, test } from 'vitest';
 
-import { findNextAutoLinkMatch } from './linksPlugin';
+import { findNextAutoLinkMatch, linksPlugin } from './linksPlugin';
+
+function createTestEditor(): LexicalEditor {
+  const editor = createEditor({
+    namespace: 'links-plugin-test',
+    nodes: [...SupportedNodeTypes],
+    onError: (error) => {
+      throw error;
+    },
+  });
+
+  const root = document.createElement('div');
+  root.contentEditable = 'true';
+  document.body.appendChild(root);
+  editor.setRootElement(root);
+  linksPlugin({ autoLinkMatchMode: 'common-tlds' })(editor);
+
+  return editor;
+}
+
+describe('linksPlugin autolink transform', () => {
+  test('does not autolink a partial domain match while a raw backtick is still present', () => {
+    const editor = createTestEditor();
+
+    editor.update(
+      () => {
+        const paragraph = $createParagraphNode();
+        // Simulates the mid-typing moment right after "`channel.me" has been
+        // entered (a valid common-tld match on its own) but before the
+        // closing backtick / rest of the word ("ssages`") has arrived. Prior
+        // to the fix, this got wrapped into an AutoLinkNode immediately; once
+        // the trailing "ssages`" landed, the combined text no longer matched
+        // as a domain, so the link never got dissolved and the markdown
+        // inline-code shortcut could no longer see one contiguous text node
+        // to convert — leaving a stray link for "channel.me" plus plain text.
+        paragraph.append($createTextNode('`channel.me'));
+        $getRoot().clear().append(paragraph);
+      },
+      { discrete: true }
+    );
+
+    editor.read(() => {
+      const paragraph = $getRoot().getFirstChildOrThrow();
+      const children = paragraph.getChildren();
+      expect(children).toHaveLength(1);
+      expect($isAutoLinkNode(children[0])).toBe(false);
+      expect(children[0].getTextContent()).toBe('`channel.me');
+    });
+  });
+
+  test('does not leave a stray autolink once the rest of the inline code is typed', () => {
+    const editor = createTestEditor();
+    let textKey = '';
+
+    editor.update(
+      () => {
+        const paragraph = $createParagraphNode();
+        const textNode = $createTextNode('`channel.me');
+        textKey = textNode.getKey();
+        paragraph.append(textNode);
+        $getRoot().clear().append(paragraph);
+      },
+      { discrete: true }
+    );
+
+    // Continue "typing" the rest of the word and the closing backtick.
+    editor.update(
+      () => {
+        const textNode = $getRoot()
+          .getFirstChildOrThrow()
+          .getChildren()
+          .find((child) => child.getKey() === textKey);
+        textNode?.setTextContent('`channel.messages`');
+      },
+      { discrete: true }
+    );
+
+    editor.read(() => {
+      const paragraph = $getRoot().getFirstChildOrThrow();
+      const children = paragraph.getChildren();
+      expect(children.some((child) => $isAutoLinkNode(child))).toBe(false);
+      expect(paragraph.getTextContent()).toBe('`channel.messages`');
+    });
+  });
+
+  test('still autolinks plain text without backticks', () => {
+    const editor = createTestEditor();
+
+    editor.update(
+      () => {
+        const paragraph = $createParagraphNode();
+        paragraph.append($createTextNode('Visit example.com'));
+        $getRoot().clear().append(paragraph);
+      },
+      { discrete: true }
+    );
+
+    editor.read(() => {
+      const paragraph = $getRoot().getFirstChildOrThrow();
+      const children = paragraph.getChildren();
+      expect(children.some((child) => $isAutoLinkNode(child))).toBe(true);
+    });
+  });
+});
 
 describe('findNextAutoLinkMatch', () => {
   it('requires a protocol in protocol mode', () => {

--- a/apps/web/src/lib/core/component/LexicalMarkdown/plugins/links/linksPlugin.ts
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/plugins/links/linksPlugin.ts
@@ -473,6 +473,20 @@ function registerLinksPlugin(editor: LexicalEditor, props: LinkPluginProps) {
       if (textNode.hasFormat('code')) {
         return;
       }
+      // While the inline-code markdown shortcut (`` `text` ``) is still being
+      // typed, the raw backticks are present but the `code` format hasn't
+      // been applied yet (the guard above doesn't help here), so this
+      // transform still runs on every keystroke. If an in-progress prefix
+      // happens to match a common TLD (e.g. "`channel.me" while typing
+      // "`channel.messages`"), it gets wrapped into an AutoLinkNode there and
+      // then; once the rest of the word lands, the combined text no longer
+      // matches as a domain so the link is never merged/dissolved, and the
+      // markdown shortcut can no longer see one contiguous text node to
+      // convert — leaving a stray "channel.me" link plus plain text sitting
+      // inside otherwise-unformatted backticks.
+      if (textNode.getTextContent().includes('`')) {
+        return;
+      }
 
       // Avoid autolinking when any ancestor is already a link
       const insideAnyLink =


### PR DESCRIPTION
## Summary

- Fixes: typing an inline-code span like `` `channel.messages` `` renders with part of it turned into a hyperlink — a link for `channel.me` followed by plain `ssages` — instead of plain code text.
- Root cause: the autolink `TextNode` transform in `linksPlugin.ts` already skips text with `hasFormat('code')`, but that format is only applied once the markdown backtick shortcut commits. While the user is still typing between the backticks, an in-progress prefix like `` `channel.me `` matches the `common-tlds` linkifier (`me` is a recognized bare TLD) and gets wrapped in an `AutoLinkNode` right then. Once the rest of the word (`ssages`) lands, the combined text no longer matches as a domain, so the existing "merge into previous autolink" logic (`$handleAppendToMatch`) finds no rematch and leaves the link alone — splitting what should be one code span into a stray link plus plain text, which the markdown shortcut can then no longer see as one contiguous node to convert.
- Fix: skip the autolink transform whenever the text still contains a raw backtick, mirroring the existing `hasFormat('code')` guard right above it.

MACRO-2663

## Why prioritized

Reported in bug-reports: pasting/typing `` `channel.messages` `` renders broken (the report message itself demonstrated the bug). Small, single-file, mechanical fix with a clear repro; no existing task/PR in flight.

## Test plan

- Added `linksPlugin.test.ts` cases:
  - reproduces the exact mid-typing moment (`` `channel.me `` before the rest of the word lands) and asserts no `AutoLinkNode` is created
  - simulates typing the rest of the word + closing backtick and asserts no stray autolink is left behind
  - keeps a sanity check that plain (non-code) autolinking still works
- Verified all three new/changed assertions fail on the pre-fix code and pass with the fix (temporarily reverted the guard locally to confirm).
- `bunx vitest run src/lib/core/component/LexicalMarkdown/plugins/links/linksPlugin.test.ts` — 7 passed.
- `bunx --bun biome check` on both changed files — clean.

Note: `bun install` fails in this sandbox on the private `tauri-plugins`/`pdf.js` git deps, so I couldn't run the full dev server or project-wide type-check — I temporarily stubbed those two deps out locally to install everything else and run the real test suite, then reverted that before committing (no `package.json`/lockfile changes in this PR). Please give it a look in a real dev environment before merging.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BW8fwTaasgcL1YVvwgx4Sg)_