### PR TITLE
fix(editor): dismiss git-blame tooltip on keydown (MACRO-2664)

### DIFF
--- a/apps/web/src/lib/core/component/LexicalMarkdown/plugins/blame-tooltip/blameTooltipPlugin.test.ts
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/plugins/blame-tooltip/blameTooltipPlugin.test.ts
@@ -1,0 +1,65 @@
+import { SupportedNodeTypes } from '@macro-inc/lexical-core/node-list';
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  createEditor,
+  KEY_DOWN_COMMAND,
+  type LexicalEditor,
+} from 'lexical';
+import { describe, expect, test, vi } from 'vitest';
+
+import {
+  type BlameTooltipState,
+  blameTooltipPlugin,
+} from './blameTooltipPlugin';
+
+function createTestEditor(): LexicalEditor {
+  const editor = createEditor({
+    namespace: 'blame-tooltip-plugin-test',
+    nodes: [...SupportedNodeTypes],
+    onError: (error) => {
+      throw error;
+    },
+  });
+
+  const root = document.createElement('div');
+  root.contentEditable = 'true';
+  document.body.appendChild(root);
+  editor.setRootElement(root);
+
+  return editor;
+}
+
+describe('blameTooltipPlugin', () => {
+  test('dismisses the tooltip on keydown so it does not linger while typing', () => {
+    const editor = createTestEditor();
+    const setState = vi.fn<(state: Partial<BlameTooltipState>) => void>();
+
+    editor.update(
+      () => {
+        const paragraph = $createParagraphNode();
+        paragraph.append($createTextNode('hello'));
+        $getRoot().clear().append(paragraph);
+      },
+      { discrete: true }
+    );
+
+    blameTooltipPlugin({ setState })(editor);
+
+    // Simulate the tooltip already being shown from a prior hover.
+    setState.mockClear();
+
+    editor.update(
+      () => {
+        editor.dispatchCommand(
+          KEY_DOWN_COMMAND,
+          new KeyboardEvent('keydown', { key: 'a' })
+        );
+      },
+      { discrete: true }
+    );
+
+    expect(setState).toHaveBeenCalledWith({ hovering: false, nodeId: null });
+  });
+});

--- a/apps/web/src/lib/core/component/LexicalMarkdown/plugins/blame-tooltip/blameTooltipPlugin.test.ts
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/plugins/blame-tooltip/blameTooltipPlugin.test.ts
@@ -3,18 +3,21 @@ import {
   $createParagraphNode,
   $createTextNode,
   $getRoot,
+  COMPOSITION_START_COMMAND,
   createEditor,
   KEY_DOWN_COMMAND,
   type LexicalEditor,
 } from 'lexical';
-import { describe, expect, test, vi } from 'vitest';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 
 import {
   type BlameTooltipState,
   blameTooltipPlugin,
 } from './blameTooltipPlugin';
 
-function createTestEditor(): LexicalEditor {
+function createTestEditor(props: {
+  setState: (state: Partial<BlameTooltipState>) => void;
+}): { editor: LexicalEditor; cleanup: () => void } {
   const editor = createEditor({
     namespace: 'blame-tooltip-plugin-test',
     nodes: [...SupportedNodeTypes],
@@ -28,24 +31,39 @@ function createTestEditor(): LexicalEditor {
   document.body.appendChild(root);
   editor.setRootElement(root);
 
-  return editor;
+  editor.update(
+    () => {
+      const paragraph = $createParagraphNode();
+      paragraph.append($createTextNode('hello'));
+      $getRoot().clear().append(paragraph);
+    },
+    { discrete: true }
+  );
+
+  const unregister = blameTooltipPlugin(props)(editor);
+
+  return {
+    editor,
+    cleanup: () => {
+      unregister();
+      editor.setRootElement(null);
+      root.remove();
+    },
+  };
 }
 
 describe('blameTooltipPlugin', () => {
+  let cleanup: (() => void) | undefined;
+
+  afterEach(() => {
+    cleanup?.();
+    cleanup = undefined;
+  });
+
   test('dismisses the tooltip on keydown so it does not linger while typing', () => {
-    const editor = createTestEditor();
     const setState = vi.fn<(state: Partial<BlameTooltipState>) => void>();
-
-    editor.update(
-      () => {
-        const paragraph = $createParagraphNode();
-        paragraph.append($createTextNode('hello'));
-        $getRoot().clear().append(paragraph);
-      },
-      { discrete: true }
-    );
-
-    blameTooltipPlugin({ setState })(editor);
+    const { editor, cleanup: teardown } = createTestEditor({ setState });
+    cleanup = teardown;
 
     // Simulate the tooltip already being shown from a prior hover.
     setState.mockClear();
@@ -55,6 +73,26 @@ describe('blameTooltipPlugin', () => {
         editor.dispatchCommand(
           KEY_DOWN_COMMAND,
           new KeyboardEvent('keydown', { key: 'a' })
+        );
+      },
+      { discrete: true }
+    );
+
+    expect(setState).toHaveBeenCalledWith({ hovering: false, nodeId: null });
+  });
+
+  test('dismisses the tooltip on composition start (IME input skips KEY_DOWN_COMMAND)', () => {
+    const setState = vi.fn<(state: Partial<BlameTooltipState>) => void>();
+    const { editor, cleanup: teardown } = createTestEditor({ setState });
+    cleanup = teardown;
+
+    setState.mockClear();
+
+    editor.update(
+      () => {
+        editor.dispatchCommand(
+          COMPOSITION_START_COMMAND,
+          new CompositionEvent('compositionstart')
         );
       },
       { discrete: true }

--- a/apps/web/src/lib/core/component/LexicalMarkdown/plugins/blame-tooltip/blameTooltipPlugin.ts
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/plugins/blame-tooltip/blameTooltipPlugin.ts
@@ -5,6 +5,7 @@ import {
   $getNearestNodeFromDOMNode,
   $isTextNode,
   COMMAND_PRIORITY_LOW,
+  COMPOSITION_START_COMMAND,
   KEY_DOWN_COMMAND,
   type LexicalEditor,
   type LexicalNode,
@@ -106,6 +107,16 @@ function registerBlameTooltipPlugin(
     // from a prior hover keeps showing over text the user is actively editing.
     editor.registerCommand(
       KEY_DOWN_COMMAND,
+      () => {
+        dismiss();
+        return false;
+      },
+      COMMAND_PRIORITY_LOW
+    ),
+    // Lexical skips KEY_DOWN_COMMAND while composing (IME input), so without
+    // this the tooltip can keep showing through an entire composition.
+    editor.registerCommand(
+      COMPOSITION_START_COMMAND,
       () => {
         dismiss();
         return false;

--- a/apps/web/src/lib/core/component/LexicalMarkdown/plugins/blame-tooltip/blameTooltipPlugin.ts
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/plugins/blame-tooltip/blameTooltipPlugin.ts
@@ -4,6 +4,8 @@ import { $getId } from '@macro-inc/lexical-core';
 import {
   $getNearestNodeFromDOMNode,
   $isTextNode,
+  COMMAND_PRIORITY_LOW,
+  KEY_DOWN_COMMAND,
   type LexicalEditor,
   type LexicalNode,
 } from 'lexical';
@@ -99,7 +101,17 @@ function registerBlameTooltipPlugin(
         prevRoot.removeEventListener('pointerleave', dismiss);
         prevRoot.removeEventListener('pointerdown', dismiss);
       }
-    })
+    }),
+    // Typing doesn't move or leave the pointer, so without this the tooltip
+    // from a prior hover keeps showing over text the user is actively editing.
+    editor.registerCommand(
+      KEY_DOWN_COMMAND,
+      () => {
+        dismiss();
+        return false;
+      },
+      COMMAND_PRIORITY_LOW
+    )
   );
 }
 


### PR DESCRIPTION
## Summary

- Fixes: the git-blame hover overlay in the markdown editor stays visible while the user starts typing over that text, instead of dismissing like it does on `pointerleave`/`pointerdown`.
- Root cause: `blameTooltipPlugin.ts` only wires up `pointermove`/`pointerleave`/`pointerdown` listeners on the editor root; there's no keydown/input handling at all, so a tooltip left showing from a previous hover has nothing telling it to hide once the user starts editing that spot.
- Fix: register a `KEY_DOWN_COMMAND` handler that calls the plugin's existing `dismiss()` callback, the same one already used for `pointerleave`/`pointerdown`.

MACRO-2664

## Why prioritized

Reported in bug-reports by Peter ("git blame should disappear when I start typing"), 👍'd by Wolf who owns the blame feature. Small, single-file, self-contained fix; no existing task/PR in flight.

## Test plan

- Added `blameTooltipPlugin.test.ts`: registers the plugin, dispatches `KEY_DOWN_COMMAND`, and asserts `setState({ hovering: false, nodeId: null })` is called.
- Verified the test fails against the pre-fix code (temporarily reverted the change locally) and passes with the fix.
- `bunx vitest run src/lib/core/component/LexicalMarkdown/plugins/blame-tooltip/blameTooltipPlugin.test.ts` — 1 passed.
- `bunx --bun biome check` on both changed files — clean.

Note: `bun install` fails in this sandbox on the private `tauri-plugins`/`pdf.js` git deps, so I couldn't run the full dev server or project-wide type-check — I temporarily stubbed those two deps out locally to install everything else and run the real test suite, then reverted that before committing (no `package.json`/lockfile changes in this PR). Please give it a real hover-then-type test in dev before merging.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BW8fwTaasgcL1YVvwgx4Sg)_