### PR TITLE
fix(ai): stop reallocating the whole stream buffer on every emitted character

### DIFF
--- a/apps/web/src/lib/core/component/AI/util/stream/bufferedStream.test.ts
+++ b/apps/web/src/lib/core/component/AI/util/stream/bufferedStream.test.ts
@@ -214,3 +214,27 @@ describe('bufferedStream Macro XML buffering', () => {
     expect(text()).toBe('ABC');
   });
 });
+
+describe('bufferedStream output buffering', () => {
+  it('appends to the output in place instead of copying it on every emitted character', () => {
+    /* Each character tick used to call controller.setData((p) => [...p, part]),
+       copying the whole (ever-growing) output array on every single character —
+       O(n) per unit emitted, O(n^2) over a long message. This is the slow-stream
+       bug: a long response gets progressively slower to render as it grows,
+       and visibly so near the end. A correct implementation mutates one shared
+       buffer and reuses its reference, so the array captured earlier is the
+       same object seen later, just longer. */
+    const { source, out } = setup();
+    source.setData([textPart('abcdef')]);
+    vi.advanceTimersByTime(TICK_MS * 2);
+    const afterTwoRef = out.data();
+    const afterTwoLength = afterTwoRef.length;
+    expect(afterTwoLength).toBeGreaterThan(0);
+    expect(afterTwoLength).toBeLessThan(6);
+
+    vi.advanceTimersByTime(TICK_MS * 3);
+    const afterFiveRef = out.data();
+    expect(afterFiveRef.length).toBeGreaterThan(afterTwoLength);
+    expect(afterFiveRef).toBe(afterTwoRef);
+  });
+});

--- a/apps/web/src/lib/core/component/AI/util/stream/bufferedStream.ts
+++ b/apps/web/src/lib/core/component/AI/util/stream/bufferedStream.ts
@@ -2,11 +2,7 @@ import type {
   AssistantMessagePart,
   ChatStream,
 } from '@service-cognition/generated/schemas';
-import {
-  type ChatMessageStream,
-  type ChatStreamController,
-  createStreamController,
-} from '@service-connection/stream';
+import type { ChatMessageStream } from '@service-connection/stream';
 import { createEffect, createSignal, on } from 'solid-js';
 import { match, P } from 'ts-pattern';
 import { createMentionBufferPlugin } from './mentionPlugin';
@@ -52,7 +48,6 @@ interface ConsumerHandle {
 
 type BufferedStream = {
   source: ChatMessageStream;
-  controller: ChatStreamController;
   dispatch: (event: BufferEvent) => void;
   /* emit units to the output, routed through the plugin chain */
   emit: (parts: ChatStream[]) => void;
@@ -451,9 +446,19 @@ export function bufferedStream(
   source: ChatMessageStream,
   plugins: StreamPlugin[] = [createMentionBufferPlugin()]
 ): BufferedChatMessageStream {
-  const controller = createStreamController<'chat'>(source.id);
+  /*
+   `equals: false` so pushing the same (mutated) array reference still
+   notifies subscribers. Emitting one unit per character means push() runs
+   once per character of the whole message; rebuilding the array each time
+   (the previous `setData((p) => [...p, ...parts])`) copied everything
+   emitted so far on every call — O(n) per unit, O(n^2) over a message,
+   and the reason long streams got progressively slower to render.
+  */
+  const [data, setData] = createSignal<ChatStream[]>([], { equals: false });
+  const [isDone, setIsDone] = createSignal(false);
   const [isHolding, setIsHolding] = createSignal(false);
 
+  const buffer: ChatStream[] = [];
   let holdFlushTimeout: ReturnType<typeof setTimeout> | undefined;
 
   function updateHolding() {
@@ -462,7 +467,8 @@ export function bufferedStream(
 
   function push(parts: ChatStream[]) {
     if (parts.length === 0) return;
-    controller.setData((p) => [...p, ...parts]);
+    buffer.push(...parts);
+    setData(buffer);
   }
 
   function forceFlushHeld() {
@@ -492,7 +498,7 @@ export function bufferedStream(
     if (holdFlushTimeout) clearTimeout(holdFlushTimeout);
     push(flushPlugins(plugins));
     updateHolding();
-    controller.setDone();
+    setIsDone(true);
   }
 
   let state: BufferState;
@@ -500,7 +506,7 @@ export function bufferedStream(
     state = transition(state, event);
   });
 
-  const stream: BufferedStream = { source, controller, dispatch, emit, finish };
+  const stream: BufferedStream = { source, dispatch, emit, finish };
   state = { type: 'waiting', stream };
 
   /* Solid only bridges the reactive inputs into the queue */
@@ -521,7 +527,9 @@ export function bufferedStream(
   );
 
   return {
-    ...controller.stream,
+    id: source.id,
+    data,
+    isDone,
     isHolding,
   };
 }


### PR DESCRIPTION
Fixes bufferedStream's O(n^2) output buffering (an O(n) array copy on every emitted character) that made long AI responses render progressively slower, most noticeably near the end of a long chat (macro-2039).