### PR TITLE
fix(soup): filter persistence not working because of async flag

### DIFF
--- a/apps/web/src/features/next-soup/soup-view/soup-view-context.tsx
+++ b/apps/web/src/features/next-soup/soup-view/soup-view-context.tsx
@@ -36,6 +36,7 @@ import {
   INBOX_FILTER_ENTRY_KEY,
   registerInboxFilterSplit,
 } from '@app/features/next-soup/soup-view/inbox-filter-controllers';
+import { useSoupFilterPersistence } from '@app/features/next-soup/use-soup-filter-persistence';
 import {
   deduplicateEntities,
   scopeChannelNotificationsForEntity,
@@ -52,8 +53,6 @@ import {
   ENABLE_GRAPHQL_SOUP_OVERRIDE,
   ENABLE_NEW_INBOX_FLAG,
   ENABLE_NEW_INBOX_OVERRIDE,
-  ENABLE_SOUP_FILTER_PERSISTENCE_FLAG,
-  ENABLE_SOUP_FILTER_PERSISTENCE_OVERRIDE,
   ENABLE_SUPPORTED_SOUP_FOREIGN_ENTITIES_FLAG,
   ENABLE_SUPPORTED_SOUP_FOREIGN_ENTITIES_OVERRIDE,
 } from '@core/constant/featureFlags';
@@ -293,11 +292,7 @@ export const SoupViewContextProvider: FlowComponent<
   });
 
   const queryClient = useQueryClient();
-  const soupFilterPersistenceFF = useFeatureFlag(
-    ENABLE_SOUP_FILTER_PERSISTENCE_FLAG,
-    { enabledOverride: ENABLE_SOUP_FILTER_PERSISTENCE_OVERRIDE }
-  );
-  const filterPersistenceEnabled = () => soupFilterPersistenceFF().enabled;
+  const [filterPersistenceEnabled] = useSoupFilterPersistence();
 
   const useGraphqlSoupFF = useFeatureFlag(ENABLE_GRAPHQL_SOUP_FLAG, {
     enabledOverride: ENABLE_GRAPHQL_SOUP_OVERRIDE,
@@ -597,9 +592,9 @@ export const SoupViewContextProvider: FlowComponent<
     )
   );
 
-  // PostHog can resolve after this provider mounts. Hydrate query-backed
-  // state once on the disabled -> enabled transition; entry state remains the
-  // higher-priority source when navigating through split history.
+  // The local preference can be enabled after this provider mounts. Hydrate
+  // query-backed state once on the disabled -> enabled transition; entry state
+  // remains the higher-priority source when navigating through split history.
   let filterPersistenceHydrated = filterPersistenceEnabled();
   createEffect(
     on(filterPersistenceEnabled, (persistenceEnabled) => {

--- a/apps/web/src/features/next-soup/use-soup-filter-persistence.ts
+++ b/apps/web/src/features/next-soup/use-soup-filter-persistence.ts
@@ -1,20 +1,9 @@
-import { makePersisted } from '@solid-primitives/storage';
-import { createSignal, type Signal } from 'solid-js';
+import { usePreference } from '@app/preferences/use-preference';
 
 const SOUP_FILTER_PERSISTENCE_STORAGE_KEY =
   'macro:pref:soup:filter-persistence';
 
-let soupFilterPersistence: Signal<boolean> | undefined;
-
 /** Whether soup filters should persist across reloads on this device. */
-export function useSoupFilterPersistence(): Signal<boolean> {
-  if (!soupFilterPersistence) {
-    const [shouldPersist, setShouldPersist] = makePersisted(
-      createSignal(false),
-      { name: SOUP_FILTER_PERSISTENCE_STORAGE_KEY }
-    );
-    soupFilterPersistence = [shouldPersist, setShouldPersist];
-  }
-
-  return soupFilterPersistence;
+export function useSoupFilterPersistence() {
+  return usePreference(SOUP_FILTER_PERSISTENCE_STORAGE_KEY, { default: false });
 }

--- a/apps/web/src/features/next-soup/use-soup-filter-persistence.ts
+++ b/apps/web/src/features/next-soup/use-soup-filter-persistence.ts
@@ -1,0 +1,20 @@
+import { makePersisted } from '@solid-primitives/storage';
+import { createSignal, type Signal } from 'solid-js';
+
+const SOUP_FILTER_PERSISTENCE_STORAGE_KEY =
+  'macro:pref:soup:filter-persistence';
+
+let soupFilterPersistence: Signal<boolean> | undefined;
+
+/** Whether soup filters should persist across reloads on this device. */
+export function useSoupFilterPersistence(): Signal<boolean> {
+  if (!soupFilterPersistence) {
+    const [shouldPersist, setShouldPersist] = makePersisted(
+      createSignal(false),
+      { name: SOUP_FILTER_PERSISTENCE_STORAGE_KEY }
+    );
+    soupFilterPersistence = [shouldPersist, setShouldPersist];
+  }
+
+  return soupFilterPersistence;
+}

--- a/apps/web/src/features/settings/Admin.tsx
+++ b/apps/web/src/features/settings/Admin.tsx
@@ -1,3 +1,5 @@
+import { useSoupFilterPersistence } from '@app/features/next-soup/use-soup-filter-persistence';
+import { useFeatureFlag } from '@app/lib/analytics/posthog';
 import {
   clearAllDebugSettings,
   DEBUG_SETTINGS,
@@ -6,8 +8,12 @@ import {
   getDebugSetting,
   setDebugSetting,
 } from '@app/lib/debugSettings';
+import {
+  ENABLE_SOUP_FILTER_PERSISTENCE_FLAG,
+  ENABLE_SOUP_FILTER_PERSISTENCE_OVERRIDE,
+} from '@core/constant/featureFlags';
 import { Button, ToggleSwitch } from '@ui';
-import { For } from 'solid-js';
+import { For, Show } from 'solid-js';
 import { SettingsCard, SettingsPage, SettingsRow } from './primitives';
 
 function DebugSettingRow(props: { setting: DebugSettingDef }) {
@@ -29,6 +35,12 @@ function DebugSettingRow(props: { setting: DebugSettingDef }) {
 
 export function Admin() {
   const hasActiveSettings = () => Object.keys(debugSettings()).length > 0;
+  const soupFilterPersistenceFlag = useFeatureFlag(
+    ENABLE_SOUP_FILTER_PERSISTENCE_FLAG,
+    { enabledOverride: ENABLE_SOUP_FILTER_PERSISTENCE_OVERRIDE }
+  );
+  const [shouldPersistSoupFilters, setShouldPersistSoupFilters] =
+    useSoupFilterPersistence();
 
   return (
     <SettingsPage
@@ -46,6 +58,21 @@ export function Admin() {
         </Button>
       }
     >
+      <Show when={soupFilterPersistenceFlag().enabled}>
+        <SettingsCard>
+          <SettingsRow
+            label="Persist list filters"
+            description="Keep soup filters and the last selected tab across reloads on this device."
+          >
+            <ToggleSwitch
+              size="md"
+              checked={shouldPersistSoupFilters()}
+              onChange={setShouldPersistSoupFilters}
+            />
+          </SettingsRow>
+        </SettingsCard>
+      </Show>
+
       <SettingsCard>
         <For each={DEBUG_SETTINGS}>
           {(setting) => <DebugSettingRow setting={setting} />}


### PR DESCRIPTION
- This didn't work because the flag was not resolved by the time the initial states were set
- Adds a toggle to the admin panel in settings to enable this feature instead