### PR TITLE
chore(email): drop no-team CRM population debug log

### DIFF
--- a/services/email_service/src/pubsub/backfill/populate_crm_contact.rs
+++ b/services/email_service/src/pubsub/backfill/populate_crm_contact.rs
@@ -41,7 +41,6 @@ pub async fn populate_crm_contact(
         })?;
 
     let Some(team_id) = team_id else {
-        tracing::debug!("User has no team; skipping CRM population");
         return Ok(());
     };
 


### PR DESCRIPTION
Removes the `"User has no team; skipping CRM population"` debug log from `populate_crm_contact`.

This fires once per fanned-out `(link, contact_email)` pair for every user without a team, which is high-volume noise for a case that is an expected no-op. The early return is unchanged.