### PR TITLE
fix(ci): fix non-deterministic test failure in import crate

### DIFF
--- a/crates/import/src/domain/service.rs
+++ b/crates/import/src/domain/service.rs
@@ -1978,6 +1978,11 @@ fn imported_notion_properties(
     }
 
     dedupe_strings(&mut imported.tags);
+    // `raw` iterates in whatever order `serde_json::Map` happens to use, which
+    // depends on the ambient `preserve_order` Cargo feature and can differ
+    // between build invocations. Sort explicitly so property order is
+    // deterministic regardless of that feature.
+    imported.values.sort_by(|a, b| a.name.cmp(&b.name));
     imported
 }
 

--- a/crates/import/src/domain/service/test.rs
+++ b/crates/import/src/domain/service/test.rs
@@ -310,14 +310,14 @@ fn notion_fetch_text_parses_the_fetch_document_shape() {
                 value: ImportedDocumentPropertyValue::Boolean { value: true },
             },
             ImportedDocumentProperty {
-                name: "Score".into(),
-                value: ImportedDocumentPropertyValue::Number { value: 4.5 },
-            },
-            ImportedDocumentProperty {
                 name: "Due".into(),
                 value: ImportedDocumentPropertyValue::Date {
                     value: "2026-08-01".into(),
                 },
+            },
+            ImportedDocumentProperty {
+                name: "Score".into(),
+                value: ImportedDocumentPropertyValue::Number { value: 4.5 },
             },
         ]
     );


### PR DESCRIPTION
Sort imported Notion document properties by name explicitly instead of relying on serde_json::Map's iteration order, which depends on the ambient preserve_order Cargo feature and can differ between build invocations.