### PR TITLE
feat(logs): improve macro_tower_layers http logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8633,6 +8633,7 @@ name = "macro_tower_layers"
 version = "0.1.0"
 dependencies = [
  "http 1.4.0",
+ "pin-project-lite",
  "tokio",
  "tower 0.5.3",
  "tower-http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -181,6 +181,7 @@ opentelemetry-otlp = { version = "0.31.0", default-features = false, features = 
 opentelemetry_sdk = { version = "0.31.0", features = ["rt-tokio"] }
 ordered-float = "5"
 paste = "1"
+pin-project-lite = "0.2.17"
 pdfium-render = { version = "0.8.37", default-features = false, features = [
   "pdfium_7543",
   "thread_safe",

--- a/crates/macro_tower_layers/Cargo.toml
+++ b/crates/macro_tower_layers/Cargo.toml
@@ -6,6 +6,7 @@ version = "0.1.0"
 
 [dependencies]
 http = { workspace = true }
+pin-project-lite = { workspace = true }
 tokio = { workspace = true, features = ["rt", "time"] }
 tower = { workspace = true }
 tower-http = { workspace = true, features = ["request-id", "util"] }

--- a/crates/macro_tower_layers/src/lib.rs
+++ b/crates/macro_tower_layers/src/lib.rs
@@ -236,16 +236,19 @@ type ServiceBuilderAlias = ServiceBuilder<
     Stack<
         PropagateRequestIdLayer,
         Stack<
-            TraceLayer<
-                SharedClassifier<ServerErrorsAsFailures>,
-                MakeHttpRequestSpan,
-                (),
-                CustomOnResponse,
-                tower_http::trace::DefaultOnBodyChunk,
-                tower_http::trace::DefaultOnEos,
-                CustomOnFailure,
+            RequestMetadataLayer,
+            Stack<
+                TraceLayer<
+                    SharedClassifier<ServerErrorsAsFailures>,
+                    MakeHttpRequestSpan,
+                    (),
+                    CustomOnResponse,
+                    tower_http::trace::DefaultOnBodyChunk,
+                    tower_http::trace::DefaultOnEos,
+                    CustomOnFailure,
+                >,
+                Stack<SetRequestIdLayer<RequestIdBuilder>, Identity>,
             >,
-            Stack<RequestMetadataLayer, Stack<SetRequestIdLayer<RequestIdBuilder>, Identity>>,
         >,
     >,
 >;
@@ -293,7 +296,6 @@ impl MacroRequestIdAndTracingLayer {
 
         let svc_builder = ServiceBuilder::new()
             .set_x_request_id(RequestIdBuilder::default())
-            .layer(RequestMetadataLayer)
             .layer(
                 TraceLayer::new_for_http()
                     .make_span_with(MakeHttpRequestSpan)
@@ -301,6 +303,7 @@ impl MacroRequestIdAndTracingLayer {
                     .on_response(CustomOnResponse::new_with_threshold(warning_threshold))
                     .on_failure(CustomOnFailure),
             )
+            .layer(RequestMetadataLayer)
             .propagate_x_request_id();
 
         MacroRequestIdAndTracingLayer { inner: svc_builder }

--- a/crates/macro_tower_layers/src/lib.rs
+++ b/crates/macro_tower_layers/src/lib.rs
@@ -4,17 +4,20 @@
 #[cfg(test)]
 mod test;
 use std::{
+    future::Future,
     sync::{
         Arc,
         atomic::{self, AtomicU64},
     },
+    task::{Context, Poll},
     time::Duration,
 };
 
-use http::{HeaderValue, Request, Response};
+use http::{HeaderValue, Method, Request, Response};
+use pin_project_lite::pin_project;
 use tokio::time::MissedTickBehavior;
 use tower::{
-    ServiceBuilder,
+    Layer, Service, ServiceBuilder,
     layer::util::{Identity, Stack},
 };
 use tower_http::{
@@ -88,6 +91,92 @@ fn latency_millis(latency: Duration) -> u64 {
     latency.as_millis().try_into().unwrap_or(u64::MAX)
 }
 
+#[derive(Clone, Debug)]
+struct RequestMetadata {
+    method: Method,
+    path: Box<str>,
+}
+
+/// Captures request metadata and attaches it to the corresponding response.
+///
+/// This lets response tracing callbacks include request fields directly on their events.
+#[doc(hidden)]
+#[derive(Clone, Copy, Debug, Default)]
+pub struct RequestMetadataLayer;
+
+/// Service created by [`RequestMetadataLayer`].
+#[doc(hidden)]
+#[derive(Clone, Debug)]
+pub struct RequestMetadataService<S> {
+    inner: S,
+}
+
+impl<S> Layer<S> for RequestMetadataLayer {
+    type Service = RequestMetadataService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        RequestMetadataService { inner }
+    }
+}
+
+pin_project! {
+    /// Response future used by [`RequestMetadataService`].
+    #[doc(hidden)]
+    pub struct RequestMetadataFuture<F> {
+        #[pin]
+        inner: F,
+        metadata: Option<RequestMetadata>,
+    }
+}
+
+impl<F, B, E> Future for RequestMetadataFuture<F>
+where
+    F: Future<Output = Result<Response<B>, E>>,
+{
+    type Output = Result<Response<B>, E>;
+
+    fn poll(self: std::pin::Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut this = self.project();
+        match this.inner.as_mut().poll(cx) {
+            Poll::Ready(Ok(mut response)) => {
+                response.extensions_mut().insert(
+                    this.metadata
+                        .take()
+                        .expect("future polled after completion"),
+                );
+                Poll::Ready(Ok(response))
+            }
+            Poll::Ready(Err(error)) => Poll::Ready(Err(error)),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+impl<S, ReqBody, ResBody> Service<Request<ReqBody>> for RequestMetadataService<S>
+where
+    S: Service<Request<ReqBody>, Response = Response<ResBody>>,
+{
+    type Response = Response<ResBody>;
+    type Error = S::Error;
+    type Future = RequestMetadataFuture<S::Future>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, request: Request<ReqBody>) -> Self::Future {
+        let metadata = RequestMetadata {
+            method: request.method().clone(),
+            path: request.uri().path().into(),
+        };
+
+        RequestMetadataFuture {
+            inner: self.inner.call(request),
+            metadata: Some(metadata),
+        }
+    }
+}
+
 impl<B> OnResponse<B> for CustomOnResponse {
     fn on_response(self, response: &Response<B>, latency: Duration, span: &Span) {
         let status = response.status();
@@ -97,10 +186,20 @@ impl<B> OnResponse<B> for CustomOnResponse {
 
         // Server errors are logged once by CustomOnFailure after this callback returns.
         if !status.is_server_error() && latency >= self.warning_threshold {
+            let metadata = response.extensions().get::<RequestMetadata>();
+            let method = metadata
+                .map(|metadata| metadata.method.as_str())
+                .unwrap_or_default();
+            let path = metadata
+                .map(|metadata| metadata.path.as_ref())
+                .unwrap_or_default();
+
             tracing::warn!(
                 parent: span,
                 latency_ms,
                 status = status.as_u16(),
+                "http.request.method" = method,
+                "url.path" = path,
                 "slow http request"
             );
         }
@@ -146,7 +245,7 @@ type ServiceBuilderAlias = ServiceBuilder<
                 tower_http::trace::DefaultOnEos,
                 CustomOnFailure,
             >,
-            Stack<SetRequestIdLayer<RequestIdBuilder>, Identity>,
+            Stack<RequestMetadataLayer, Stack<SetRequestIdLayer<RequestIdBuilder>, Identity>>,
         >,
     >,
 >;
@@ -194,6 +293,7 @@ impl MacroRequestIdAndTracingLayer {
 
         let svc_builder = ServiceBuilder::new()
             .set_x_request_id(RequestIdBuilder::default())
+            .layer(RequestMetadataLayer)
             .layer(
                 TraceLayer::new_for_http()
                     .make_span_with(MakeHttpRequestSpan)

--- a/crates/macro_tower_layers/src/test.rs
+++ b/crates/macro_tower_layers/src/test.rs
@@ -13,6 +13,7 @@ use tracing::{
 #[derive(Default)]
 struct CapturedTracing {
     event_levels: Mutex<Vec<Level>>,
+    event_fields: Mutex<Vec<HashMap<String, String>>>,
     span_level: Mutex<Option<Level>>,
     declared_span_fields: Mutex<HashSet<String>>,
     initial_span_fields: Mutex<HashMap<String, String>>,
@@ -87,6 +88,10 @@ impl tracing::Subscriber for TracingCapture {
             .lock()
             .unwrap()
             .push(*event.metadata().level());
+
+        let mut fields = HashMap::new();
+        event.record(&mut FieldCapture(&mut fields));
+        self.captured.event_fields.lock().unwrap().push(fields);
     }
 
     fn enter(&self, _span: &tracing::span::Id) {}
@@ -150,13 +155,21 @@ fn successful_response_records_telemetry_without_completion_event() {
 }
 
 #[test]
-fn slow_response_emits_one_warning() {
+fn slow_response_warning_includes_request_method_and_path() {
     let (subscriber, captured) = TracingCapture::new();
 
     with_default(subscriber, || {
-        let request = Request::builder().uri("/documents").body(()).unwrap();
+        let request = Request::builder()
+            .method("POST")
+            .uri("/documents?access_token=secret")
+            .body(())
+            .unwrap();
         let span = MakeHttpRequestSpan.make_span(&request);
-        let response = Response::builder().status(200).body(()).unwrap();
+        let mut response = Response::builder().status(200).body(()).unwrap();
+        response.extensions_mut().insert(RequestMetadata {
+            method: request.method().clone(),
+            path: request.uri().path().into(),
+        });
         CustomOnResponse::new_with_threshold(Duration::from_millis(200)).on_response(
             &response,
             Duration::from_millis(200),
@@ -167,6 +180,29 @@ fn slow_response_emits_one_warning() {
     assert_eq!(captured.event_count(Level::WARN), 1);
     assert_eq!(captured.event_count(Level::INFO), 0);
     assert_eq!(captured.event_count(Level::ERROR), 0);
+
+    let events = captured.event_fields.lock().unwrap();
+    assert_eq!(events[0].get("http.request.method").unwrap(), "\"POST\"");
+    assert_eq!(events[0].get("url.path").unwrap(), "\"/documents\"");
+    assert!(events[0].values().all(|value| !value.contains("secret")));
+}
+
+#[tokio::test]
+async fn request_metadata_layer_attaches_method_and_path_to_response() {
+    let request = Request::builder()
+        .method("PATCH")
+        .uri("/documents/123?access_token=secret")
+        .body(())
+        .unwrap();
+    let service = RequestMetadataLayer.layer(tower::service_fn(|_request| async {
+        Ok::<_, std::convert::Infallible>(Response::new(()))
+    }));
+
+    let response = tower::ServiceExt::oneshot(service, request).await.unwrap();
+    let metadata = response.extensions().get::<RequestMetadata>().unwrap();
+
+    assert_eq!(metadata.method, Method::PATCH);
+    assert_eq!(metadata.path.as_ref(), "/documents/123");
 }
 
 #[test]


### PR DESCRIPTION
Updated macro_tower_layers so "slow http request" warnings include:
- http.request.method
- url.path (query string excluded)