### PR TITLE
Fix root font sizing on desktop Safari

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -273,8 +273,20 @@
 
 @layer base {
   html {
-    font: -apple-system-body;
     overflow: hidden;
+  }
+
+  /* `-apple-system-body` opts the root font-size into iOS/iPadOS Dynamic Type
+     so rem-based sizing respects the user's accessibility text-size setting.
+     On desktop Safari the same keyword resolves to the macOS system body size
+     (~13px) instead of the browser default 16px, shrinking every rem-based
+     dimension and making the app look zoomed out next to Chrome. Limit it to
+     coarse-pointer (touch) devices — matching the app's own isTouchDevice()
+     definition — so desktop Safari keeps the standard 16px root. */
+  @media (pointer: coarse) {
+    html {
+      font: -apple-system-body;
+    }
   }
 
   body {


### PR DESCRIPTION
## Summary
Moved the `-apple-system-body` font declaration to a touch-device-only media query to prevent desktop Safari from rendering the app at an incorrect zoom level.

## Problem
The `-apple-system-body` keyword resolves differently across platforms:
- On iOS/iPadOS: Opts into Dynamic Type, respecting user accessibility text-size settings
- On desktop Safari: Resolves to macOS system body size (~13px) instead of the browser default 16px, causing all rem-based dimensions to shrink and making the app appear zoomed out compared to Chrome

## Solution
Wrapped the `-apple-system-body` font declaration in a `@media (pointer: coarse)` query to limit it to touch devices only. This:
- Preserves Dynamic Type support on iOS/iPadOS devices
- Allows desktop Safari to use the standard 16px root font size
- Aligns with the app's existing `isTouchDevice()` definition

## Changes
- Removed `font: -apple-system-body;` from the base `html` rule
- Added a new `@media (pointer: coarse)` block that applies the font only on touch devices
- Added detailed comments explaining the rationale for this approach

https://claude.ai/code/session_01Ke8MeqMFxCh7Pr14tKpS8H