### PR TITLE
feat(invites): instrument referral invite flow and surface send failures

### DIFF
--- a/apps/web/src/components/app/app-sidebar/sidebar.tsx
+++ b/apps/web/src/components/app/app-sidebar/sidebar.tsx
@@ -15,7 +15,7 @@ import {
 import { requestSearchFocus } from '@app/features/next-soup/soup-view/search-controllers';
 import {
   InviteModal,
-  setInviteModalOpen,
+  openInviteModal,
 } from '@app/features/team-invitations/invite-modal';
 import { useAnalytics } from '@app/lib/analytics/analytics-context';
 import { useFeatureFlag } from '@app/lib/analytics/posthog';
@@ -377,7 +377,7 @@ export const GoToHotkeys = () => {
     description: 'Send Invites',
     keyDownHandler: (e) => {
       e?.preventDefault();
-      setInviteModalOpen(true);
+      openInviteModal('hotkey');
       return true;
     },
   });
@@ -1288,7 +1288,7 @@ export const AppSidebar = (props: AppSidebarProps) => {
     }
 
     addTryItem('invite', 'Invite', UsersThreeIcon, () =>
-      setInviteModalOpen(true)
+      openInviteModal('sidebar')
     );
 
     const mobile = getSettingsTabItem('Mobile App');

--- a/apps/web/src/features/team-invitations/invite-modal.tsx
+++ b/apps/web/src/features/team-invitations/invite-modal.tsx
@@ -1,3 +1,5 @@
+import { analytics } from '@app/lib/analytics';
+import { useAnalytics } from '@app/lib/analytics/analytics-context';
 import { toast } from '@core/component/Toast/Toast';
 import { useReferralCode } from '@core/context/user';
 
@@ -18,9 +20,14 @@ function parseEmails(raw: string): string[] {
 
 const [inviteModalOpen, setInviteModalOpen] = createSignal(false);
 
-export { setInviteModalOpen };
+/** Opens the invite modal. `source` is the UI surface, for analytics. */
+export function openInviteModal(source: 'sidebar' | 'hotkey') {
+  analytics.track('invite_modal_opened', { source });
+  setInviteModalOpen(true);
+}
 
 export const InviteModal = () => {
+  const analyticsClient = useAnalytics();
   const [value, setValue] = createSignal('');
   const [copied, setCopied] = createSignal(false);
   const [sending, setSending] = createSignal(false);
@@ -36,6 +43,7 @@ export const InviteModal = () => {
     const url = referralUrl();
     if (!url) return;
     navigator.clipboard.writeText(url);
+    analyticsClient.track('invite_link_copied');
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   };
@@ -44,18 +52,42 @@ export const InviteModal = () => {
     const emails = parseEmails(value());
     if (!emails.length) return;
     setSending(true);
+    const failedEmails: string[] = [];
     for (const email of emails) {
       const result = await authServiceClient.sendReferralInvite(email);
       if (result.isOk()) {
         contactsClient.addContact(`macro|${email.toLowerCase()}`);
+      } else {
+        failedEmails.push(email);
       }
     }
-    setValue('');
     setSending(false);
+
+    const sent = emails.length - failedEmails.length;
+    analyticsClient.track('invite_sent', {
+      sent,
+      failed: failedEmails.length,
+    });
+
+    if (failedEmails.length) {
+      // Keep the modal open with only the failed addresses so a retry
+      // doesn't re-invite the ones that already went through.
+      setValue(failedEmails.join('\n'));
+      toast.failure(
+        sent > 0
+          ? `Sent ${sent} of ${emails.length} invites — the rest failed to send`
+          : failedEmails.length === 1
+            ? 'Failed to send the invite'
+            : 'Failed to send the invites'
+      );
+      return;
+    }
+
+    setValue('');
     toast.success(
-      emails.length === 1
+      sent === 1
         ? 'Invite sent successfully'
-        : `${emails.length} invites sent successfully`
+        : `${sent} invites sent successfully`
     );
     setInviteModalOpen(false);
   };

--- a/apps/web/src/lib/analytics/app-events.ts
+++ b/apps/web/src/lib/analytics/app-events.ts
@@ -90,6 +90,17 @@ export type AppEvents = {
   subscription_cancel: Record<string, unknown>;
   subscription_success: Record<string, unknown>;
 
+  // --- Referrals & invites --------------------------------------------------
+  /** The referral invite modal was opened. `source` is the UI surface. */
+  invite_modal_opened: { source: 'sidebar' | 'hotkey' | (string & {}) };
+  /**
+   * A batch of referral invite emails was submitted. `sent`/`failed` split the
+   * batch by delivery outcome so failed sends stay visible in the funnel.
+   */
+  invite_sent: { sent: number; failed: number };
+  /** The personal referral link was copied from the invite modal. */
+  invite_link_copied: Record<string, unknown>;
+
   sidebar_click: Record<string, unknown>;
   notifications_toggled: Record<string, unknown>;
 


### PR DESCRIPTION
## What

- Adds typed analytics events for the referral invite flow: `invite_modal_opened` (with the UI surface that opened it), `invite_sent` (with sent/failed counts), and `invite_link_copied`.
- Fixes silent failure handling in the invite modal: previously every send reported success even if the request failed. Now failed addresses stay in the textarea for retry, and the toast reflects what actually happened (full success, partial, or total failure).

## Why

The invite flow had no instrumentation at all, and failures were invisible to both users and us. This makes the flow measurable end-to-end and keeps users from believing invites went out when they didn't.

## Notes

- `openInviteModal(source)` replaces the raw `setInviteModalOpen` export so every open carries its source; both sidebar call sites updated.
- Events follow the existing typed catalog in `app-events.ts`; utility-scope tracking uses the `analytics` singleton (same pattern as `create.ts`), component-scope tracking uses `useAnalytics()`.
- Verified with `bun run check` (tsc + biome).

---
_Generated by [Claude Code](https://claude.ai/code/session_01ScmWwmYyWzeTwDLtnSXAvd)_