### PR TITLE
feat(search): instrument search queries at the data layer

### DIFF
--- a/apps/web/src/lib/analytics/app-events.ts
+++ b/apps/web/src/lib/analytics/app-events.ts
@@ -112,6 +112,21 @@ export type AppEvents = {
     destination?: 'dss' | 'static';
   };
 
+  // --- Search ----------------------------------------------------------------
+  /**
+   * A search-service request completed (first page only, so pagination
+   * doesn't re-fire it). Fired at the query layer so every search surface is
+   * covered without per-surface instrumentation. `scope` distinguishes
+   * unified search from the in-channel find bar; `resultCount` of 0 is the
+   * zero-results signal.
+   */
+  search_performed: {
+    scope: 'unified' | 'channel';
+    queryLength: number;
+    resultCount: number;
+    hasMore: boolean;
+  };
+
   command_menu_open: { from: string };
   command_menu_use: { itemType: string };
   create_menu_open: { from: string };

--- a/apps/web/src/lib/queries/soup/search.ts
+++ b/apps/web/src/lib/queries/soup/search.ts
@@ -1,3 +1,4 @@
+import { analytics } from '@app/lib/analytics';
 import { ENABLE_SEARCH_SERVICE } from '@core/constant/featureFlags';
 import { useChannelsContext } from '@core/context/channels';
 import { throwOnErr } from '@core/util/result';
@@ -62,7 +63,7 @@ export const useSearchSoupQuery = (
     queryKey: soupKeys.search({ params: args().params, body: request() })
       .queryKey,
     queryFn: async (ctx) => {
-      return throwOnErr(
+      const page = await throwOnErr(
         async () =>
           await searchClient.search(
             {
@@ -72,6 +73,20 @@ export const useSearchSoupQuery = (
             { signal: ctx.signal }
           )
       );
+      // First page only: one event per executed (debounced) search, never
+      // for pagination. Cache hits don't reach the queryFn, so re-running
+      // an identical query doesn't re-fire either. Entity pickers and the
+      // mentions menu search on 'name' — only 'name_content' is a
+      // user-facing search.
+      if (!ctx.pageParam.cursor && request().search_on === 'name_content') {
+        analytics.track('search_performed', {
+          scope: 'unified',
+          queryLength: request().query.length,
+          resultCount: page.results.length,
+          hasMore: !!page.next_cursor,
+        });
+      }
+      return page;
     },
     initialPageParam: {
       cursor: null as string | null,
@@ -142,7 +157,7 @@ export const useSearchChannelQuery = (
   return useInfiniteQuery(() => ({
     queryKey: ['search-channel', args().params, request()] as const,
     queryFn: async (ctx) => {
-      return throwOnErr(
+      const page = await throwOnErr(
         async () =>
           await searchClient.searchChannel(
             {
@@ -152,6 +167,15 @@ export const useSearchChannelQuery = (
             { signal: ctx.signal }
           )
       );
+      if (!ctx.pageParam.cursor) {
+        analytics.track('search_performed', {
+          scope: 'channel',
+          queryLength: request().query?.length ?? 0,
+          resultCount: page.results.length,
+          hasMore: !!page.next_cursor,
+        });
+      }
+      return page;
     },
     initialPageParam: {
       cursor: null as string | null,


### PR DESCRIPTION
## What

Adds a typed `search_performed` event fired from the search query layer (`useSearchSoupQuery` / `useSearchChannelQuery`), carrying `scope` (`unified` vs `channel` find bar), `queryLength`, `resultCount`, and `hasMore`.

## Why

Search is a first-class surface but had zero instrumentation — we could see the view being opened but not whether anyone actually searched, what came back, or how often a query returned nothing. Instrumenting at the query layer follows the same chokepoint pattern as the entity lifecycle events (`create.ts`, `BlockLoader`): every current and future search surface is covered without per-surface wiring.

## Notes

- Fires on the **first page only**, so pagination never re-fires it; TanStack cache hits don't reach the `queryFn`, so identical repeated queries don't double-count.
- Entity pickers and the mentions menu use `search_on: 'name'` — the event is gated to `'name_content'`, so those lookups are excluded.
- `resultCount: 0` doubles as the zero-results signal.
- Verified with `bun run check` and the `queries` vitest project (186 tests passing).

---
_Generated by [Claude Code](https://claude.ai/code/session_01ScmWwmYyWzeTwDLtnSXAvd)_