### PR TITLE
feat(paywall): track paywall impressions with their trigger reason

### DIFF
--- a/apps/web/src/lib/analytics/app-events.ts
+++ b/apps/web/src/lib/analytics/app-events.ts
@@ -86,6 +86,13 @@ export type AppEvents = {
     connectors_connected: string[];
   };
 
+  /**
+   * The in-app paywall dialog was shown. `reason` is the PaywallKey that
+   * triggered it (PROJECT_LIMIT, CHAT_LIMIT, ...) or 'unspecified' when
+   * opened without one. Pairs with subscription_start (which carries the
+   * same key as `errorKey`) to measure per-trigger upgrade conversion.
+   */
+  paywall_viewed: { reason: string };
   subscription_start: Record<string, unknown>;
   subscription_cancel: Record<string, unknown>;
   subscription_success: Record<string, unknown>;

--- a/apps/web/src/lib/core/constant/PaywallState.tsx
+++ b/apps/web/src/lib/core/constant/PaywallState.tsx
@@ -1,3 +1,4 @@
+import { analytics } from '@app/lib/analytics';
 import { createSignal } from 'solid-js';
 
 const DAILY_LIMIT = 5;
@@ -93,6 +94,9 @@ const [paywallKey, setPaywallKey] = createSignal<PaywallKey | null>(null);
 
 export const usePaywallState = () => {
   const showPaywall = (errorKey?: PaywallKey | null) => {
+    // Every paywall trigger funnels through here, so this is the one spot
+    // that can attribute impressions to the limit that raised them.
+    analytics.track('paywall_viewed', { reason: errorKey ?? 'unspecified' });
     if (errorKey) {
       setPaywallKey(errorKey);
     }


### PR DESCRIPTION
## What

Adds a typed `paywall_viewed` event fired from `showPaywall()`, carrying the `PaywallKey` that triggered the dialog (`PROJECT_LIMIT`, `CHAT_LIMIT`, `MULTI_INBOX`, …) or `'unspecified'`.

## Why

The paywall fires `subscription_start` when a user clicks upgrade, but nothing when the dialog is shown — so there was no way to compute view→upgrade conversion per trigger, or to see which limits users hit most and bounce from. `showPaywall()` is the single chokepoint all call sites funnel through, so one line covers every trigger, current and future.

## Notes

- `subscription_start` already carries the same key as `errorKey`, so the two events pair cleanly per trigger.
- The onboarding plan step renders its checkout UI without going through `showPaywall()`, so it doesn't double-count here (it has its own `onboarding_v4_*` events).
- Verified with `bun run check` (tsc + biome).

---
_Generated by [Claude Code](https://claude.ai/code/session_01ScmWwmYyWzeTwDLtnSXAvd)_