### PR TITLE
feat(mobile-web): offer the iOS app on the signup-sent screen

### DIFF
--- a/apps/web/src/features/onboarding/MobileWebSignupSent.tsx
+++ b/apps/web/src/features/onboarding/MobileWebSignupSent.tsx
@@ -1,9 +1,11 @@
 import { useAnalytics } from '@app/lib/analytics/analytics-context';
 import { MOBILE_WEB_SIGNUP_LEAD_VALUE } from '@app/lib/analytics/leadValues';
 import { PcNoiseGrid } from '@core/component/PcNoiseGrid';
+import { APP_STORE_URL } from '@core/constant/appLinks';
 import { getWebOrigin } from '@core/util/webOrigin';
 import LogoIcon from '@icon/macro-logo.svg';
-import { onMount } from 'solid-js';
+import { isIOS } from '@solid-primitives/platform';
+import { onMount, Show } from 'solid-js';
 
 type Props = {
   /** Email submitted on the prior step — used as the Google conversion `transaction_id` for dedup. */
@@ -58,15 +60,45 @@ export default function MobileWebSignupSent(props: Props) {
           Macro experience.
         </p>
 
-        <button
-          type="button"
-          onClick={() => {
-            window.location.href = getWebOrigin();
-          }}
-          class="w-full px-3 py-2.5 text-lg font-bold rounded-xs bg-accent text-surface border-none mt-16"
+        <Show
+          when={isIOS}
+          fallback={
+            <button
+              type="button"
+              onClick={() => {
+                window.location.href = getWebOrigin();
+              }}
+              class="w-full px-3 py-2.5 text-lg font-bold rounded-xs bg-accent text-surface border-none mt-16"
+            >
+              Back to Home
+            </button>
+          }
         >
-          Back to Home
-        </button>
+          <p class="text-base text-ink/60">
+            Or start right away with the iPhone app.
+          </p>
+          <a
+            href={APP_STORE_URL}
+            rel="noopener noreferrer"
+            onClick={() =>
+              analytics.track('app_store_click', {
+                source: 'mobile_web_signup_sent',
+              })
+            }
+            class="w-full px-3 py-2.5 text-lg font-bold rounded-xs bg-accent text-surface text-center mt-16"
+          >
+            Download the iOS app
+          </a>
+          <button
+            type="button"
+            onClick={() => {
+              window.location.href = getWebOrigin();
+            }}
+            class="w-full px-3 py-2.5 text-lg rounded-xs bg-transparent text-ink/50 ring ring-edge-muted border-none"
+          >
+            Back to Home
+          </button>
+        </Show>
       </div>
     </div>
   );

--- a/apps/web/src/features/settings/MobileApp.tsx
+++ b/apps/web/src/features/settings/MobileApp.tsx
@@ -1,3 +1,4 @@
+import { APP_STORE_URL } from '@core/constant/appLinks';
 import AppStoreQr from '@design/app-store.svg';
 import { SettingsCard, SettingsPage } from './primitives';
 
@@ -14,7 +15,7 @@ export function MobileApp() {
             Download on the
             <br />
             <a
-              href="https://apps.apple.com/us/app/macro-app/id6743133649"
+              href={APP_STORE_URL}
               rel="noopener noreferrer"
               class="text-accent hover:underline"
               target="_blank"

--- a/apps/web/src/lib/analytics/app-events.ts
+++ b/apps/web/src/lib/analytics/app-events.ts
@@ -35,6 +35,8 @@ export type AppEvents = {
   login_from_onboarding: Record<string, unknown>;
   mobile_web_welcome_viewed: Record<string, unknown>;
   mobile_web_signup_sent_viewed: Record<string, unknown>;
+  /** The App Store install link was tapped. `source` is the UI surface. */
+  app_store_click: { source: 'mobile_web_signup_sent' | (string & {}) };
 
   // --- Interactive tutorial (optional; decoupled from acquisition) ---------
   tutorial_started: { isFirstTime: boolean };

--- a/apps/web/src/lib/core/constant/appLinks.ts
+++ b/apps/web/src/lib/core/constant/appLinks.ts
@@ -1,0 +1,3 @@
+/** Public App Store install link for the Macro iOS app. */
+export const APP_STORE_URL =
+  'https://apps.apple.com/us/app/macro-app/id6743133649';


### PR DESCRIPTION
## What

The mobile-web signup flow currently ends with "Macro is better on desktop — we sent a link to your inbox" and a single **Back to Home** button, even though a native iOS app is live on the App Store. This PR:

- On iOS devices, makes **Download the iOS app** the primary action on the signup-sent screen (with "Or start right away with the iPhone app" copy), demoting Back to Home to a secondary button. Non-iOS devices see the existing screen unchanged.
- Tracks the tap with a new typed `app_store_click` event carrying its source surface.
- Extracts the App Store URL into a shared `APP_STORE_URL` constant, reused by the Settings → Mobile App page (previously hardcoded there).

## Why

Phone visitors who complete the email-capture step currently hit a hard dead end. Giving iOS users an immediate install path turns that stop into a continuation, and the event makes the step measurable.

## Notes

- iOS detection uses `isIOS` from `@solid-primitives/platform`, already a dependency used elsewhere in the app.
- Verified with `bun run check` (tsc + biome).

---
_Generated by [Claude Code](https://claude.ai/code/session_01ScmWwmYyWzeTwDLtnSXAvd)_