### PR TITLE
fix(soup): notifications on items not being consumed properly

### DIFF
--- a/apps/web/src/lib/service-clients/service-storage/graphql-soup.ts
+++ b/apps/web/src/lib/service-clients/service-storage/graphql-soup.ts
@@ -306,7 +306,10 @@ function mapGraphqlNotifications(notifications: GraphqlSoupNotification[]) {
   return notifications.map((notification) => ({
     id: notification.id,
     notification_event_type: notification.eventType,
-    notification_metadata: notification.metadata,
+    notification_metadata: {
+      tag: notification.eventType,
+      content: notification.metadata,
+    },
     entity_id: notification.entityId,
     entity_type: mapGraphqlNotificationEntityType(notification.entityType),
     sent: notification.sent,


### PR DESCRIPTION
Graphql items have a different notification metadata shape than the consumers expect so they were not being used correctly