### PR TITLE
fix(routing): show a real 404 instead of bouncing unmatched URLs to root

### DIFF
--- a/apps/web/src/lib/analytics/app-events.ts
+++ b/apps/web/src/lib/analytics/app-events.ts
@@ -112,6 +112,13 @@ export type AppEvents = {
     destination?: 'dss' | 'static';
   };
 
+  /**
+   * The SPA wildcard route rendered a 404 screen: the URL stayed unmatched
+   * even after the one-shot reload that rules out bundle version skew.
+   * Volume here means stale or broken links are circulating.
+   */
+  route_not_found: { path: string };
+
   command_menu_open: { from: string };
   command_menu_use: { itemType: string };
   create_menu_open: { from: string };

--- a/apps/web/src/routes/Root.tsx
+++ b/apps/web/src/routes/Root.tsx
@@ -63,6 +63,7 @@ import { licenseChannel } from '@core/util/licenseUpdateBroadcastChannel';
 import { isTauri } from '@core/util/platform';
 import { thrownResultErrorHasCode } from '@core/util/result';
 import { transformShortIdInUrlPathname } from '@core/util/url';
+import EmptyStateNoSearchMatchGraphic from '@design/empty-state-no-search-match.svg';
 import { EntityProvider } from '@entity';
 import { MaybeTauriProvider } from '@macro/tauri';
 import { TauriRouteListener } from '@macro/tauri/TauriProvider';
@@ -97,6 +98,7 @@ import {
   Router,
   type RouterProps,
   useLocation,
+  useNavigate,
   useSearchParams,
 } from '@solidjs/router';
 import {
@@ -105,7 +107,7 @@ import {
   resolveActiveThemeId,
   systemThemeEffect,
 } from '@theme/utils/themeUtils';
-import { Button } from '@ui';
+import { Button, EmptyStatePanel } from '@ui';
 import { detect } from 'detect-browser';
 import {
   createEffect,
@@ -291,10 +293,52 @@ function BasePathComponent() {
   );
 }
 
+/**
+ * Wildcard fallback for URLs no route matches. Two causes are possible: the
+ * running bundle predates the link's route (version skew right after a
+ * deploy), or the link is genuinely wrong or stale. Reload once to rule out
+ * skew — a fresh bundle that knows the route renders it and never lands back
+ * here — then show a real 404 instead of silently bouncing to the app root
+ * and losing the attempted URL.
+ */
 function NotFound() {
   if (isNativeMobilePlatform()) return <Navigate href={DEFAULT_ROUTE} />;
-  window.location.href = window.location.origin;
-  return '';
+
+  const reloadedKey = `not-found-reloaded:${window.location.pathname}`;
+  if (!sessionStorage.getItem(reloadedKey)) {
+    sessionStorage.setItem(reloadedKey, 'true');
+    window.location.reload();
+    return '';
+  }
+  return <RouteNotFoundScreen />;
+}
+
+function RouteNotFoundScreen() {
+  const analytics = useAnalytics();
+  const navigate = useNavigate();
+  const path = window.location.pathname;
+
+  onMount(() => {
+    analytics.track('route_not_found', { path });
+  });
+
+  return (
+    <EmptyStatePanel
+      centered
+      graphic={EmptyStateNoSearchMatchGraphic}
+      title="Page not found"
+      description={
+        <>
+          Nothing lives at <code class="text-ink">{path}</code> — the link may
+          be stale, or its content may have moved.
+        </>
+      }
+      primaryAction={{
+        label: 'Back to Macro',
+        onClick: () => navigate(DEFAULT_ROUTE),
+      }}
+    />
+  );
 }
 
 const { EmailCallback, CALLBACK_PATH, EmailLinkCallback, LINK_CALLBACK_PATH } =


### PR DESCRIPTION
## What

The SPA's wildcard route previously did `window.location.href = window.location.origin` — any unmatched URL (stale share link, typo, link to a route from a newer deploy) silently hard-navigated to the app root, dropping the attempted URL with no explanation.

This PR:

- Keeps **one automatic reload** for the legitimate case the old behavior half-served: bundle version skew right after a deploy. A fresh bundle that knows the route renders it and never returns to the fallback. (Guarded per-path via `sessionStorage`, so it can't loop.)
- If the URL is still unmatched after that, renders a proper **Page not found** screen (built on the existing `EmptyStatePanel` primitive) showing the attempted path, with a primary action back into the app.
- Fires a typed `route_not_found` event with the unmatched path, so the volume of broken/stale links circulating becomes measurable.

## Why

Share links are a growth surface; when one goes stale the recipient currently gets teleported to the root with zero context. A visible 404 with a path and a way forward is friendlier, and the event tells us how often it happens and to which paths.

## Notes

- Native mobile keeps its existing `Navigate` to the default route.
- Verified with `bun run check` (tsc + biome).

---
_Generated by [Claude Code](https://claude.ai/code/session_01ScmWwmYyWzeTwDLtnSXAvd)_