### PR TITLE
feat(uploads): attribute generic upload errors to their cause

### DIFF
--- a/apps/web/src/lib/analytics/app-events.ts
+++ b/apps/web/src/lib/analytics/app-events.ts
@@ -110,6 +110,11 @@ export type AppEvents = {
   upload_error: {
     type: string;
     destination?: 'dss' | 'static';
+    /**
+     * Compressed underlying cause (error class + message head) so generic
+     * UploadError volume can be broken down without reproducing locally.
+     */
+    reason?: string;
   };
 
   command_menu_open: { from: string };

--- a/apps/web/src/lib/core/util/upload.ts
+++ b/apps/web/src/lib/core/util/upload.ts
@@ -282,6 +282,16 @@ class UnsupportedFileTypeError extends Error {
   }
 }
 
+// Compresses the underlying failure into a short label analytics can break
+// down by (error class + message head), so a spike in generic UploadErrors is
+// attributable to its cause without a local repro. File names never appear in
+// the label — the message head is the error's own text.
+function describeUploadFailure(cause?: Error | string): string {
+  if (!cause) return 'unknown';
+  if (typeof cause === 'string') return cause.slice(0, 120);
+  return `${cause.name}: ${cause.message}`.slice(0, 120);
+}
+
 class UploadError extends Error {
   public readonly originalError?: Error | string;
 
@@ -306,6 +316,7 @@ class UploadError extends Error {
     analytics.track('upload_error', {
       type: this.name,
       destination,
+      reason: describeUploadFailure(originalError),
     });
   }
 


### PR DESCRIPTION
## What

The catch-all `UploadError` (the network/server failure path) reported only `type: 'UploadError'` to analytics, while the actual cause went to the console alone. This adds a `reason` field to the `upload_error` event — the original error compressed into a short label (error class + message head, capped at 120 chars).

## Why

Upload failures are visible in aggregate but not diagnosable: when the generic error spikes, there's currently no way to tell a service outage from a CORS regression from client network flakiness without a local repro. The specific error classes (size limits, unsupported types, HEIC conversion, directory limits) already carry distinct `type`s — the generic path was the only blind spot.

## Notes

- File names never enter the label; it's built from the error's own class name and message.
- `reason` is optional in the typed catalog, so the other `upload_error` call sites are unaffected.
- Verified with `bun run check` (tsc + biome).

---
_Generated by [Claude Code](https://claude.ai/code/session_01ScmWwmYyWzeTwDLtnSXAvd)_