### PR TITLE
feat(crm): make the empty companies list actionable

### DIFF
--- a/apps/web/src/features/next-soup/soup-view/empty-states.tsx
+++ b/apps/web/src/features/next-soup/soup-view/empty-states.tsx
@@ -280,11 +280,24 @@ export function EmptyState(props: {
               }
             />
           </Match>
+          <Match when={!emailActive()}>
+            <EmptyStatePanel
+              graphic={EmptyStateCompaniesGraphic}
+              title="No customers yet"
+              description="Customers your team emails will appear here. Connect an inbox so Macro can start building your customer list."
+              primaryAction={{
+                label: 'Connect email',
+                onClick: onConnectEmail,
+              }}
+              documentationUrl={`${DOCS_BASE}/product/crm`}
+            />
+          </Match>
           <Match when={true}>
             <EmptyStatePanel
               graphic={EmptyStateCompaniesGraphic}
               title="No customers yet"
               description="Customers your team emails will appear here."
+              documentationUrl={`${DOCS_BASE}/product/crm`}
             />
           </Match>
         </Switch>


### PR DESCRIPTION
## What

The Companies view's "No customers yet" empty state was a dead end: no action, no docs link — even though customers are derived from team email, so the actual blocker for many users is simply that no inbox is connected.

- When email is **not** connected, the state now offers the same **Connect email** primary action the inbox/mail empty states use (same `useAddInboxFlow` hook), with copy explaining why.
- Both variants now link the CRM documentation, matching the other list views' empty states.

## Why

Every other major list view's empty state carries a primary CTA and docs link; companies was one of the few dead ends left, and its fix doubles as an email-connection prompt — the connect-an-inbox step is the gateway to most of the product.

## Notes

- Follows the exact `EmptyStatePanel` + `Match` pattern already used in `empty-states.tsx` (see the inbox/mail `!emailActive()` branches).
- `/product/crm` docs page exists and is already referenced by `docs-links.ts`.
- Verified with `bun run check` (tsc + biome).

---
_Generated by [Claude Code](https://claude.ai/code/session_01ScmWwmYyWzeTwDLtnSXAvd)_