### PR TITLE
fix(ai): remove sonnet 4.6, bump openai models to gpt-5.6

### DIFF
--- a/apps/web/src/lib/core/component/AI/component/input/ModelSelector.test.tsx
+++ b/apps/web/src/lib/core/component/AI/component/input/ModelSelector.test.tsx
@@ -107,8 +107,8 @@ describe('ModelSelector: selection routing', () => {
       />
     ));
 
-    fireEvent.click(itemFor(container, Model.gpt55));
-    expect(onSelect).toHaveBeenCalledWith(Model.gpt55);
+    fireEvent.click(itemFor(container, Model.gpt56));
+    expect(onSelect).toHaveBeenCalledWith(Model.gpt56);
     expect(onLocked).not.toHaveBeenCalled();
   });
 
@@ -158,9 +158,9 @@ describe('ModelSelector: what is shown is what is sent', () => {
 
     // Select a different model -> both the trigger and the would-send value move
     // together to exactly that model.
-    fireEvent.click(itemFor(container, Model.sonnet46));
-    expect(getByTestId('would-send').textContent).toBe(Model.sonnet46);
-    expect(trigger.textContent).toContain(MODEL_PRETTYNAME[Model.sonnet46]);
+    fireEvent.click(itemFor(container, Model.sonnet5));
+    expect(getByTestId('would-send').textContent).toBe(Model.sonnet5);
+    expect(trigger.textContent).toContain(MODEL_PRETTYNAME[Model.sonnet5]);
   });
 
   it('a free user cannot select an inaccessible model into the would-send value', () => {

--- a/apps/web/src/lib/core/component/AI/constant/model.test.ts
+++ b/apps/web/src/lib/core/component/AI/constant/model.test.ts
@@ -28,7 +28,7 @@ describe('modelsForPlan / defaultModelForPlan', () => {
     expect(defaultModelForPlan(false)).toBe(FREE_DEFAULT_MODEL);
     // The premium models are *not* in a free user's selectable set.
     expect(free).not.toContain(Model.opus5);
-    expect(free).not.toContain(Model.gpt55);
+    expect(free).not.toContain(Model.gpt56);
   });
 });
 
@@ -41,7 +41,8 @@ describe('parseModel', () => {
 
   it('rejects unknown / empty values so callers can fall back to a default', () => {
     expect(parseModel('anthropic/claude-opus-4-7')).toBeUndefined(); // retired id
-    expect(parseModel('gpt-5.5')).toBeUndefined(); // unprefixed / legacy
+    expect(parseModel('anthropic/claude-sonnet-4-6')).toBeUndefined(); // retired id
+    expect(parseModel('gpt-5.6')).toBeUndefined(); // unprefixed / legacy
     expect(parseModel('not-a-model')).toBeUndefined();
     expect(parseModel('')).toBeUndefined();
     expect(parseModel(null)).toBeUndefined();
@@ -61,7 +62,7 @@ describe('alternateProviderModel', () => {
   it('only ever suggests a model the user has access to (stays within candidates)', () => {
     // Candidates model the user's accessible models. The suggestion must be
     // one of them, never a model outside the accessible set.
-    const candidates: TModel[] = [Model.haiku45, Model.gpt5Mini];
+    const candidates: TModel[] = [Model.haiku45, Model.gpt56Mini];
     const alt = alternateProviderModel(Model.opus5, { candidates });
     expect(candidates).toContain(alt);
     expect(PROVIDER_OF(alt!)).toBe('openai'); // the only different-provider candidate
@@ -71,12 +72,12 @@ describe('alternateProviderModel', () => {
     // User is on OpenAI but the only accessible model is also OpenAI — there is
     // no provider to fall back to.
     expect(
-      alternateProviderModel(Model.gpt55, { candidates: [Model.gpt5Mini] })
+      alternateProviderModel(Model.gpt56, { candidates: [Model.gpt56Mini] })
     ).toBeUndefined();
     // Likewise when every candidate shares the current (Anthropic) provider.
     expect(
       alternateProviderModel(Model.opus5, {
-        candidates: [Model.haiku45, Model.sonnet46],
+        candidates: [Model.haiku45, Model.sonnet5],
       })
     ).toBeUndefined();
   });

--- a/apps/web/src/lib/core/component/AI/constant/model.ts
+++ b/apps/web/src/lib/core/component/AI/constant/model.ts
@@ -12,9 +12,8 @@ export const Model = {
   sonnet5: 'anthropic/claude-sonnet-5',
   opus5: 'anthropic/claude-opus-5',
   haiku45: 'anthropic/claude-haiku-4-5',
-  sonnet46: 'anthropic/claude-sonnet-4-6',
-  gpt55: 'openai/gpt-5.5',
-  gpt5Mini: 'openai/gpt-5-mini',
+  gpt56: 'openai/gpt-5.6',
+  gpt56Mini: 'openai/gpt-5.6-mini',
 } as const;
 
 // `Model` is both a value (the const above) and a type (the union of api ids).
@@ -30,18 +29,16 @@ export const MODEL_PRETTYNAME: ExhaustiveMap = {
   'anthropic/claude-sonnet-5': 'Sonnet 5',
   'anthropic/claude-opus-5': 'Opus 5',
   'anthropic/claude-haiku-4-5': 'Haiku 4.5',
-  'anthropic/claude-sonnet-4-6': 'Sonnet 4.6',
-  'openai/gpt-5.5': 'GPT-5.5',
-  'openai/gpt-5-mini': 'GPT-5 mini',
+  'openai/gpt-5.6': 'GPT-5.6',
+  'openai/gpt-5.6-mini': 'GPT-5.6 mini',
 } as const;
 
 export const MODEL_PROVIDER_ICON: ExhaustiveMap = {
   'anthropic/claude-sonnet-5': AnthropicIcon,
   'anthropic/claude-opus-5': AnthropicIcon,
   'anthropic/claude-haiku-4-5': AnthropicIcon,
-  'anthropic/claude-sonnet-4-6': AnthropicIcon,
-  'openai/gpt-5.5': OpenAiIcon,
-  'openai/gpt-5-mini': OpenAiIcon,
+  'openai/gpt-5.6': OpenAiIcon,
+  'openai/gpt-5.6-mini': OpenAiIcon,
 };
 
 /** Default model for paid users. */
@@ -80,9 +77,8 @@ export const MODEL_PROVIDER: ExhaustiveMap = {
   'anthropic/claude-sonnet-5': 'anthropic',
   'anthropic/claude-opus-5': 'anthropic',
   'anthropic/claude-haiku-4-5': 'anthropic',
-  'anthropic/claude-sonnet-4-6': 'anthropic',
-  'openai/gpt-5.5': 'openai',
-  'openai/gpt-5-mini': 'openai',
+  'openai/gpt-5.6': 'openai',
+  'openai/gpt-5.6-mini': 'openai',
 } as const;
 
 /** Options for {@link alternateProviderModel}. */

--- a/apps/web/src/lib/core/component/AI/util/storage.test.ts
+++ b/apps/web/src/lib/core/component/AI/util/storage.test.ts
@@ -11,19 +11,19 @@ beforeEach(() => {
 
 describe('chat input storage: model defaults', () => {
   it('remembers the last model a user picked for a chat', () => {
-    storeChatStateImmediate('chat-a', { model: Model.gpt55, input: 'draft' });
+    storeChatStateImmediate('chat-a', { model: Model.gpt56, input: 'draft' });
 
     const restored = getChatInputStoredState('chat-a');
-    expect(restored.model).toBe(Model.gpt55);
+    expect(restored.model).toBe(Model.gpt56);
     expect(restored.input).toBe('draft');
   });
 
   it('keeps each chat on its own remembered model', () => {
-    storeChatStateImmediate('chat-a', { model: Model.gpt55 });
-    storeChatStateImmediate('chat-b', { model: Model.sonnet46 });
+    storeChatStateImmediate('chat-a', { model: Model.gpt56 });
+    storeChatStateImmediate('chat-b', { model: Model.sonnet5 });
 
-    expect(getChatInputStoredState('chat-a').model).toBe(Model.gpt55);
-    expect(getChatInputStoredState('chat-b').model).toBe(Model.sonnet46);
+    expect(getChatInputStoredState('chat-a').model).toBe(Model.gpt56);
+    expect(getChatInputStoredState('chat-b').model).toBe(Model.sonnet5);
   });
 
   it('returns no stored model for a chat that has never been used', () => {

--- a/crates/macro_db_client/migrations/20260728161706_seed_gpt_5_6_pricing.sql
+++ b/crates/macro_db_client/migrations/20260728161706_seed_gpt_5_6_pricing.sql
@@ -1,0 +1,10 @@
+-- Seed pricing for GPT-5.6 / GPT-5.6 mini (USD per million tokens), which
+-- replace GPT-5.5 / gpt-5-mini in the chat model selector. Same prices as the
+-- models they replace per the OpenAI pricing page. ON CONFLICT keeps any
+-- price already set at runtime via the set_pricing endpoint. The old
+-- gpt-5.5 / gpt-5-mini rows are left in place so historical ai_usage rows for
+-- those ids still resolve a price.
+INSERT INTO ai_pricing (model, price_per_million_in, price_per_million_out) VALUES
+    ('gpt-5.6', 5.0, 30.0),
+    ('gpt-5.6-mini', 0.75, 4.5)
+ON CONFLICT (model) DO NOTHING;


### PR DESCRIPTION
Removes Sonnet 4.6 from the frontend chat model selector and bumps the OpenAI models to gpt-5.6 / gpt-5.6-mini in the frontend and ai_pricing seed data (macro-2686).