### PR TITLE
feat: default channel preview

### DIFF
--- a/apps/web/src/components/app/split-layout/SplitLayout.tsx
+++ b/apps/web/src/components/app/split-layout/SplitLayout.tsx
@@ -40,6 +40,7 @@ import {
   loadRestorablePreviewLayout,
   PREVIEW_QUERY_PARAM,
 } from './previewPersistence';
+import { splitMinWidthForContent } from './splitContentSizing';
 import { createSplitFocusTracker } from './splitFocusTracker';
 
 type SplitLayoutContainerProps = {
@@ -134,7 +135,7 @@ export function SplitLayoutContainer(props: SplitLayoutContainerProps) {
                       <Suspense>
                         <Resize.Panel
                           id={id}
-                          minSize={400}
+                          minSize={splitMinWidthForContent(handle().content())}
                           // Automatic redistribution targets an engaged
                           // Controller at its configured preferred width.
                           // This is not a hard max: the gutter can still be

--- a/apps/web/src/components/app/split-layout/components/SplitHeader.tsx
+++ b/apps/web/src/components/app/split-layout/components/SplitHeader.tsx
@@ -470,7 +470,7 @@ export function SplitHeader(props: { ref: Setter<HTMLDivElement | null> }) {
     <SplitHeaderContextMenu>
       <div
         class={cn(
-          'isolate relative w-full h-full overflow-clip text-ink',
+          '@container/split-header isolate relative w-full h-full overflow-clip text-ink',
           // On mobile the header overlays the panel body as a transparent strip
           // of floating islands
           'mobile:absolute mobile:inset-x-0 mobile:top-(--safe-top) mobile:z-mobile-nav-bar mobile:h-11.25 mobile:overflow-visible mobile:pointer-events-none',
@@ -508,8 +508,10 @@ export function SplitHeader(props: { ref: Setter<HTMLDivElement | null> }) {
               <div class="relative flex items-center pl-2 h-full">
                 <SidebarExpandButton />
                 <SplitCloseButton />
-                <SplitBackButton />
-                <SplitForwardButton />
+                <div class='flex items-center @max-[380px]/split-header:hidden'>
+                  <SplitBackButton />
+                  <SplitForwardButton />
+                </div>
               </div>
             }
           >

--- a/apps/web/src/components/app/split-layout/components/SplitHeader.tsx
+++ b/apps/web/src/components/app/split-layout/components/SplitHeader.tsx
@@ -508,7 +508,7 @@ export function SplitHeader(props: { ref: Setter<HTMLDivElement | null> }) {
               <div class="relative flex items-center pl-2 h-full">
                 <SidebarExpandButton />
                 <SplitCloseButton />
-                <div class='flex items-center @max-[380px]/split-header:hidden'>
+                <div class="flex items-center @max-[380px]/split-header:hidden">
                   <SplitBackButton />
                   <SplitForwardButton />
                 </div>

--- a/apps/web/src/components/app/split-layout/layoutManager.ts
+++ b/apps/web/src/components/app/split-layout/layoutManager.ts
@@ -33,6 +33,7 @@ import {
   isPreviewControllerContent,
   previewControllerWidthForContent,
 } from './previewController';
+import { DEFAULT_SPLIT_MIN_WIDTH } from './splitContentSizing';
 
 const ENABLE_DEFAULT_ALWAYS_IN_HISTORY = false;
 
@@ -652,7 +653,7 @@ export function createSplitLayout(
   const isExcluded = (split: SplitState) => exclusionFilter?.(split) ?? false;
 
   const canAppendSplit = createMemo(
-    () => resizeContext()?.canFit({ minSize: 400 }) ?? true
+    () => resizeContext()?.canFit({ minSize: DEFAULT_SPLIT_MIN_WIDTH }) ?? true
   );
 
   const [splitNamesById, setSplitNamesById] = createStore<{
@@ -869,6 +870,7 @@ export function createSplitLayout(
       if (!prev) return;
 
       reattach(split, prev, undefined, 'history-back');
+      resetPreviewMode(id);
     });
   }
 
@@ -886,6 +888,7 @@ export function createSplitLayout(
       if (!next) return;
 
       reattach(split, next, undefined, 'history-forward');
+      resetPreviewMode(id);
     });
   }
 

--- a/apps/web/src/components/app/split-layout/previewController.ts
+++ b/apps/web/src/components/app/split-layout/previewController.ts
@@ -27,8 +27,13 @@ const PREVIEW_CONTROLLER_CONTENT_CONFIG: readonly PreviewControllerContentConfig
     },
     {
       type: 'component',
+      id: LIST_VIEW_ID.channels,
+      redistributionWidth: { preferredPx: 360 },
+    },
+    {
+      type: 'component',
       id: LIST_VIEW_ID.mail,
-      redistributionWidth: { preferredPx: 1050, maxViewportFraction: 0.6 },
+      redistributionWidth: { preferredPx: 800, maxViewportFraction: 0.6 },
     },
     {
       type: 'component',

--- a/apps/web/src/components/app/split-layout/splitContentSizing.ts
+++ b/apps/web/src/components/app/split-layout/splitContentSizing.ts
@@ -1,0 +1,30 @@
+import { isListViewID } from '@app/constants/list-views';
+import type { SplitContent } from './layoutManager';
+
+/** Default hard minimum width for split content without an override. */
+export const DEFAULT_SPLIT_MIN_WIDTH = 400;
+
+type SplitContentSizingConfig = {
+  matches: (content: SplitContent) => boolean;
+  minWidthPx: number;
+};
+
+/**
+ * Declarative hard-size overrides for categories of split content. Earlier
+ * rules take precedence, allowing exact-content exceptions before broad rules.
+ */
+const SPLIT_CONTENT_SIZING_CONFIG: readonly SplitContentSizingConfig[] = [
+  {
+    matches: (content) =>
+      content.type === 'component' && isListViewID(content.id),
+    minWidthPx: 340,
+  },
+];
+
+/** Resolve the hard minimum width for a split from its mounted content. */
+export function splitMinWidthForContent(content: SplitContent): number {
+  const config = SPLIT_CONTENT_SIZING_CONFIG.find((candidate) =>
+    candidate.matches(content)
+  );
+  return config?.minWidthPx ?? DEFAULT_SPLIT_MIN_WIDTH;
+}

--- a/apps/web/src/components/app/split-layout/tests/layoutManager.test.ts
+++ b/apps/web/src/components/app/split-layout/tests/layoutManager.test.ts
@@ -575,6 +575,51 @@ describe('layoutManager', () => {
       });
     });
 
+    it('resets the viewer when the controller navigates backward or forward', () => {
+      createRoot((dispose) => {
+        const { manager, controllerId } = setup();
+        const controller = manager.getSplit(controllerId)!;
+        controller.replace({
+          next: { type: 'component', id: 'channels' },
+        });
+        manager.engagePreviewMode(controllerId);
+        const viewerId = manager.viewerOf(controllerId)!;
+
+        manager.openWithSplit(
+          { type: 'md', id: 'doc-1' },
+          { referredFrom: null, handle: controller }
+        );
+        controller.goBack();
+
+        expect(controller.content()).toMatchObject({
+          type: 'component',
+          id: 'inbox',
+        });
+        expect(manager.getSplit(viewerId)?.content()).toMatchObject({
+          type: 'component',
+          id: 'preview-empty',
+        });
+
+        manager.openWithSplit(
+          { type: 'md', id: 'doc-2' },
+          { referredFrom: null, handle: controller }
+        );
+        controller.goForward();
+
+        expect(controller.content()).toMatchObject({
+          type: 'component',
+          id: 'channels',
+        });
+        expect(manager.getSplit(viewerId)?.content()).toMatchObject({
+          type: 'component',
+          id: 'preview-empty',
+        });
+        expect(manager.viewerOf(controllerId)).toBe(viewerId);
+
+        dispose();
+      });
+    });
+
     it('reset is a no-op without a viewer or when already on the placeholder', () => {
       createRoot((dispose) => {
         const { manager, controllerId } = setup();
@@ -605,7 +650,7 @@ describe('layoutManager', () => {
 
         manager.engagePreviewMode(controllerId);
 
-        expect(manager.previewControllerWidth(controllerId)).toBe(1050);
+        expect(manager.previewControllerWidth(controllerId)).toBe(800);
 
         dispose();
       });

--- a/apps/web/src/components/app/split-layout/tests/previewController.test.ts
+++ b/apps/web/src/components/app/split-layout/tests/previewController.test.ts
@@ -3,6 +3,7 @@ import {
   isPreviewControllerContent,
   previewControllerWidthForContent,
 } from '../previewController';
+import { splitMinWidthForContent } from '../splitContentSizing';
 
 describe('preview controller content', () => {
   it('explicitly recognizes configured content', () => {
@@ -23,8 +24,11 @@ describe('preview controller content', () => {
       previewControllerWidthForContent({ type: 'component', id: 'inbox' })
     ).toBe(440);
     expect(
+      previewControllerWidthForContent({ type: 'component', id: 'channels' })
+    ).toBe(360);
+    expect(
       previewControllerWidthForContent({ type: 'component', id: 'mail' })
-    ).toBe(1050);
+    ).toBe(800);
     expect(
       previewControllerWidthForContent({ type: 'component', id: 'companies' })
     ).toBe(880);
@@ -49,5 +53,18 @@ describe('preview controller content', () => {
         id: 'project-1',
       })
     ).toBe(440);
+  });
+
+  it('uses the list-view minimum width with a 400px default', () => {
+    expect(splitMinWidthForContent({ type: 'component', id: 'channels' })).toBe(
+      340
+    );
+    expect(splitMinWidthForContent({ type: 'component', id: 'inbox' })).toBe(
+      340
+    );
+    expect(splitMinWidthForContent({ type: 'component', id: 'settings' })).toBe(
+      400
+    );
+    expect(splitMinWidthForContent({ type: 'md', id: 'doc-1' })).toBe(400);
   });
 });

--- a/apps/web/src/features/entity/composed/ListEntity.tsx
+++ b/apps/web/src/features/entity/composed/ListEntity.tsx
@@ -45,6 +45,7 @@ import {
   filterValidNotifications,
 } from '../utils/notification';
 import { useIsShared } from '../utils/shared';
+import { NarrowCondensedLayout } from './list-entity/narrow-condensed-layout';
 import { NarrowInboxLayout } from './list-entity/narrow-inbox-layout';
 import { NarrowLayout } from './list-entity/narrow-layout';
 import {
@@ -57,7 +58,10 @@ import {
 } from './list-entity/shared';
 import { WideLayout } from './list-entity/wide-layout';
 
-export { ListLayoutProvider } from './list-entity/shared';
+export {
+  ListLayoutProvider,
+  type NarrowLayoutVariant,
+} from './list-entity/shared';
 
 interface ListEntityProps extends BaseListEntityProps {
   showUnrollNotifications?: boolean;
@@ -153,7 +157,10 @@ export function ListEntity(props: ListEntityProps) {
     splitId: useSplitPanel()?.handle?.id,
   });
 
-  const isWide = useListLayout()?.isWide ?? (() => true);
+  const listLayout = useListLayout();
+  const isWide = listLayout?.isWide ?? (() => true);
+  const usesCondensedNarrowLayout = () =>
+    !isWide() && listLayout?.narrowLayout() === 'condensed';
 
   const mobileStacks = createMemo(() => {
     if (!isMobile()) return [];
@@ -203,7 +210,8 @@ export function ListEntity(props: ListEntityProps) {
       class={cn(
         'soup-list-entity rounded-lg @container/entity w-[calc(100%-0.5rem)] mr-1 relative group/narrow flex flex-col py-0.5',
         {
-          'min-h-10 mx-1': !isMobile(),
+          'min-h-10 mx-1': !isMobile() && !usesCondensedNarrowLayout(),
+          'min-h-9 mx-1': !isMobile() && usesCondensedNarrowLayout(),
           'bg-accent/8': props.checked,
           'bg-accent/16': props.checked && props.highlighted,
           'bg-hover/30':
@@ -244,6 +252,14 @@ export function ListEntity(props: ListEntityProps) {
             config={props.entityRowConfig}
           >
             <NarrowInboxLayout {...layoutProps()} />
+          </MaybeEntityRow>
+        </Match>
+        <Match when={usesCondensedNarrowLayout()}>
+          <MaybeEntityRow
+            entityId={props.entity.id}
+            config={props.entityRowConfig}
+          >
+            <NarrowCondensedLayout {...layoutProps()} />
           </MaybeEntityRow>
         </Match>
         <Match when={true}>

--- a/apps/web/src/features/entity/composed/list-entity/narrow-condensed-layout.tsx
+++ b/apps/web/src/features/entity/composed/list-entity/narrow-condensed-layout.tsx
@@ -1,0 +1,61 @@
+import { cn } from '@ui';
+import { Show } from 'solid-js';
+import { MultiSelectCheckbox } from '../../components/MultiSelectCheckbox';
+import { UnreadIndicator } from '../../components/UnreadIndicator';
+import { Entity } from '../../entity';
+import { isChannelEntity } from '../../types/entity';
+import { ChannelJoinButton } from './channel';
+import type { LayoutProps } from './shared';
+
+/** Condensed row used for maximum density. */
+export function NarrowCondensedLayout(props: LayoutProps) {
+  return (
+    <Entity.Layout
+      class="w-full gap-x-2 items-center px-2 grid text-sm"
+      style={{
+        'grid-template-columns': 'auto 1fr',
+        'grid-template-rows': '36px',
+        'grid-template-areas': '"indicator title"',
+      }}
+    >
+      <Entity.Slot placement="indicator" class="relative self-start pt-2">
+        <Show when={!props.hideCheckbox}>
+          <div
+            class={cn('w-0 opacity-0 overflow-hidden', {
+              'w-6 opacity-100': props.checked,
+            })}
+          >
+            <MultiSelectCheckbox
+              checked={props.checked}
+              onChecked={props.onChecked}
+            />
+          </div>
+        </Show>
+      </Entity.Slot>
+
+      <Entity.Slot
+        placement="title"
+        class="ph-no-capture flex min-w-0 items-center gap-2 truncate font-normal"
+      >
+        <Show when={props.unread}>
+          <UnreadIndicator active />
+        </Show>
+        <div class="size-4 shrink-0">
+          <Entity.Icon entity={props.entity} streamState={props.streamState} />
+        </div>
+        <Entity.Title entity={props.entity} />
+        <Show
+          when={
+            isChannelEntity(props.entity) &&
+            props.entity.isParticipant === false &&
+            props.entity
+          }
+        >
+          {(entity) => (
+            <ChannelJoinButton entity={entity()} class="ml-auto shrink-0" />
+          )}
+        </Show>
+      </Entity.Slot>
+    </Entity.Layout>
+  );
+}

--- a/apps/web/src/features/entity/composed/list-entity/shared.tsx
+++ b/apps/web/src/features/entity/composed/list-entity/shared.tsx
@@ -61,14 +61,18 @@ export interface LayoutProps {
   ) => void;
 }
 
+export type NarrowLayoutVariant = 'standard' | 'condensed';
+
 interface ListLayoutContextValue {
   isWide: Accessor<boolean>;
+  narrowLayout: Accessor<NarrowLayoutVariant>;
 }
 
 const ListLayoutContext = createContext<ListLayoutContextValue>();
 
 export function ListLayoutProvider(props: {
   ref: Accessor<HTMLElement | undefined>;
+  narrowLayout?: NarrowLayoutVariant;
   children: JSX.Element;
 }) {
   const [isWide, setIsWide] = createSignal(true);
@@ -84,7 +88,9 @@ export function ListLayoutProvider(props: {
   });
 
   return (
-    <ListLayoutContext.Provider value={{ isWide }}>
+    <ListLayoutContext.Provider
+      value={{ isWide, narrowLayout: () => props.narrowLayout ?? 'standard' }}
+    >
       {props.children}
     </ListLayoutContext.Provider>
   );

--- a/apps/web/src/features/entity/index.ts
+++ b/apps/web/src/features/entity/index.ts
@@ -7,6 +7,7 @@ export {
   ListEntity,
   ListLayoutProvider,
   MaybeEntityRow,
+  type NarrowLayoutVariant,
 } from './composed/ListEntity';
 export {
   ListEntityMetadataProvider,

--- a/apps/web/src/features/next-soup/soup-view/soup-view.tsx
+++ b/apps/web/src/features/next-soup/soup-view/soup-view.tsx
@@ -92,6 +92,7 @@ import {
   isNonMemberChannelEntity,
   ListEntity,
   ListLayoutProvider,
+  type NarrowLayoutVariant,
   type ProjectEntity,
   type SearchLocation,
 } from '@entity';
@@ -206,7 +207,10 @@ const MobileTabLoadingBar = () => (
 );
 
 const SOUP_LIST_STATE_ENTRY_KEY = 'soup.listState';
-const INBOX_PREVIEW_OPEN_PREFERENCE_KEY = 'macro:pref:soup:inbox:preview-open';
+const DEFAULT_PREVIEW_VIEWS = new Set(['inbox', 'channels']);
+const CONDENSED_NARROW_LIST_VIEWS: ReadonlySet<ListView> = new Set([
+  'channels',
+]);
 type SoupListEntryState = {
   focus: string | undefined;
   virtualCache?: CacheSnapshot;
@@ -294,8 +298,8 @@ export const SoupView = (props: SoupViewProps) => {
     `macro:pref:soup:${contentId}:sort`,
     { default: [] }
   );
-  const [inboxPreviewOpenPreference, setInboxPreviewOpenPreference] =
-    usePreference<boolean>(INBOX_PREVIEW_OPEN_PREFERENCE_KEY, {
+  const [previewOpenPreference, setPreviewOpenPreference] =
+    usePreference<boolean>(`macro:pref:soup:${contentId}:preview-open`, {
       default: true,
     });
 
@@ -394,19 +398,30 @@ export const SoupView = (props: SoupViewProps) => {
     });
   });
 
-  // A fresh Inbox starts in preview mode once its initial result settles, but
-  // only when it has an entity to show. Resolve this once so manually exiting
-  // preview mode is not undone by later Soup updates.
-  let initialInboxPreviewResolved = false;
+  // Fresh preview-default views engage as soon as the layout can form a pair.
+  // useSoupPreviewAvailability owns disengagement and only closes the pair once
+  // the active query has settled with no previewable rows.
+  let initialPreviewResolved = false;
   createEffect(() => {
-    if (initialInboxPreviewResolved || soupView.source.isLoading()) return;
-    initialInboxPreviewResolved = true;
-    if (contentId !== 'inbox' || !inboxPreviewOpenPreference()) return;
-    if (panel.handle.lastNavigationCause() !== 'fresh') return;
-    if (panel.handle.isViewerSplit()) return;
-    if (!hasPreviewItems()) return;
+    if (initialPreviewResolved) return;
+    if (!DEFAULT_PREVIEW_VIEWS.has(contentId) || !previewOpenPreference()) {
+      initialPreviewResolved = true;
+      return;
+    }
+    if (
+      panel.handle.lastNavigationCause() !== 'fresh' ||
+      panel.handle.isViewerSplit()
+    ) {
+      initialPreviewResolved = true;
+      return;
+    }
+
+    // Split redistribution may still be reconciling after a hotkey-driven
+    // replacement. Keep the effect live until engagement actually succeeds.
+    if (!panel.handle.canEngagePreview()) return;
+    soup.focus.clear();
     panel.handle.engagePreview();
-    if (panel.handle.isControllerSplit()) openFocusedEntityInPreview();
+    if (panel.handle.isControllerSplit()) initialPreviewResolved = true;
   });
 
   onMount(() => {
@@ -506,7 +521,10 @@ export const SoupView = (props: SoupViewProps) => {
   });
 
   return (
-    <div class="size-full flex flex-col" data-list-view={activeListView()}>
+    <div
+      class="size-full flex flex-col @container"
+      data-list-view={activeListView()}
+    >
       <div class="flex flex-col w-full">
         <SplitHeaderLeft>
           <div
@@ -522,7 +540,7 @@ export const SoupView = (props: SoupViewProps) => {
                   {(url) => (
                     <Button
                       variant="ghost"
-                      class="p-0.5 rounded-sm text-ink-extra-muted hover:text-ink-muted"
+                      class="p-0.5 rounded-sm text-ink-extra-muted hover:text-ink-muted @max-[380px]/split-header:hidden"
                       label="View documentation"
                       onClick={() => openExternalUrl(url())}
                     >
@@ -642,7 +660,8 @@ export const SoupView = (props: SoupViewProps) => {
         hasPreviewItems={hasPreviewItems()}
         onPreviewEngage={openFocusedEntityInPreview}
         onPreviewOpenChange={(open) => {
-          if (contentId === 'inbox') setInboxPreviewOpenPreference(open);
+          if (DEFAULT_PREVIEW_VIEWS.has(contentId))
+            setPreviewOpenPreference(open);
         }}
       />
       <Show when={applyDefaultCrmView}>
@@ -731,6 +750,13 @@ const SoupViewListContent = (props: SoupViewListProps) => {
     return isListViewID(id) ? id : undefined;
   });
 
+  const narrowLayout = createMemo<NarrowLayoutVariant>(() => {
+    const view = currentView();
+    return view && CONDENSED_NARROW_LIST_VIEWS.has(view)
+      ? 'condensed'
+      : 'standard';
+  });
+
   const focusFirstEntity = () => {
     const allRows = rows();
     const firstEntityIndex = allRows.findIndex(
@@ -761,7 +787,7 @@ const SoupViewListContent = (props: SoupViewListProps) => {
       if (!focusEffectsEnabled() || !moveInitialFocus()) return;
       if (!initialLoad || source.isLoading()) return;
 
-      if (isNewInboxEnabled()) return;
+      if (panel.handle.isControllerSplit()) return;
 
       focusFirstEntity();
       initialLoad = false;
@@ -775,7 +801,7 @@ const SoupViewListContent = (props: SoupViewListProps) => {
       () => {
         if (!focusEffectsEnabled()) return;
 
-        if (isNewInboxEnabled()) return;
+        if (panel.handle.isControllerSplit()) return;
 
         focusFirstEntity();
       },
@@ -1105,7 +1131,8 @@ const SoupViewListContent = (props: SoupViewListProps) => {
 
     const cached = readListEntryState();
     if (cached) {
-      soup.focus.set(cached.focus);
+      if (panel.handle.isControllerSplit()) soup.focus.clear();
+      else soup.focus.set(cached.focus);
       const handle = virtualizerHandle();
       if (!handle) return;
 
@@ -1118,9 +1145,8 @@ const SoupViewListContent = (props: SoupViewListProps) => {
     if (force) return;
 
     restored = true;
-    // The new inbox opens with a Preview Pair Viewer, so don't auto-focus (and
-    // thus open) the first row on initial load.
-    registerFocusEffects(!isNewInboxEnabled());
+    // Preview Controllers start without a focused row or Viewer content.
+    registerFocusEffects(!panel.handle.isControllerSplit());
   };
 
   const registerVirtualizerHandler = (
@@ -1203,7 +1229,10 @@ const SoupViewListContent = (props: SoupViewListProps) => {
                   </div>
                 </Match>
                 <Match when={rows().length}>
-                  <ListLayoutProvider ref={localEntityListRef}>
+                  <ListLayoutProvider
+                    ref={localEntityListRef}
+                    narrowLayout={narrowLayout()}
+                  >
                     <Show when={currentView() === 'tasks' && !isMobile()}>
                       <ResponsiveTaskListHeader class="shrink-0" />
                     </Show>


### PR DESCRIPTION
We turn Preview mode on for Channels by default.

We allow split min width overrides for specific content. We introduce a new Narrow Condensed list layout, used for Channels.

We fix a few bugs re: Preview mode activation.

We create a new condensed layout for the split header, hiding the back and forwards arrows at the smallest widths.
