### PR TITLE
feat kafka parallelism

### DIFF
--- a/crates/kafka_util/src/lib.rs
+++ b/crates/kafka_util/src/lib.rs
@@ -8,6 +8,8 @@
 #[cfg(test)]
 mod test;
 
+pub mod parallel;
+
 use std::collections::{HashMap, HashSet};
 use std::ffi::CString;
 use std::marker::PhantomData;
@@ -177,6 +179,31 @@ impl RebalanceTracker {
             .collect::<Vec<_>>();
         assignments.sort_by(|left, right| left.topic_partition.cmp(&right.topic_partition));
         assignments
+    }
+
+    pub(crate) fn assignment_epoch(&self, topic: &str, partition: i32) -> Option<AssignmentEpoch> {
+        let state = lock_unpoisoned(&self.inner.state);
+        state
+            .assignments
+            .get(&TopicPartition {
+                topic: topic.to_string(),
+                partition,
+            })
+            .copied()
+    }
+
+    pub(crate) fn with_current_assignment<Output>(
+        &self,
+        topic_partition: &TopicPartition,
+        epoch: AssignmentEpoch,
+        operation: impl FnOnce() -> Output,
+    ) -> Option<Output> {
+        let state = lock_unpoisoned(&self.inner.state);
+        state
+            .assignments
+            .get(topic_partition)
+            .is_some_and(|current_epoch| *current_epoch == epoch)
+            .then(operation)
     }
 
     /// Returns whether `epoch` is the current ownership generation.

--- a/crates/kafka_util/src/lib.rs
+++ b/crates/kafka_util/src/lib.rs
@@ -701,6 +701,12 @@ impl<T: GroupName> KafkaEventConsumer<T> {
     /// This opt-in constructor installs a [`RebalanceTracker`] and pins
     /// `partition.assignment.strategy=cooperative-sticky`. Existing constructors
     /// retain librdkafka's default eager assignment strategy.
+    ///
+    /// Do not roll an existing group directly from [`Self::from_env`] to this
+    /// constructor: eager-only and cooperative-only members cannot coexist in a group.
+    /// Use a new group name, or perform Kafka's two-phase strategy rollout: first add
+    /// `cooperative-sticky` after the eager strategies on every member, then roll every
+    /// member to `cooperative-sticky` only.
     pub fn from_env_with_max_poll_interval(
         brokers: &str,
         max_poll_interval: Duration,

--- a/crates/kafka_util/src/lib.rs
+++ b/crates/kafka_util/src/lib.rs
@@ -8,16 +8,24 @@
 #[cfg(test)]
 mod test;
 
+use std::collections::{HashMap, HashSet};
+use std::ffi::CString;
 use std::marker::PhantomData;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use either::Either;
 use macro_env::Environment;
-use rdkafka::consumer::{CommitMode, Consumer, ConsumerContext, StreamConsumer};
+use rdkafka::client::ClientContext;
+use rdkafka::consumer::{
+    BaseConsumer, CommitMode, Consumer, ConsumerContext, Rebalance, StreamConsumer,
+};
 use rdkafka::error::{KafkaError, KafkaResult};
 use rdkafka::message::{BorrowedMessage, Message as _};
 use rdkafka::producer::{FutureProducer, FutureRecord};
+use rdkafka::types::RDKafkaErrorCode;
 use rdkafka::{ClientConfig, Offset, TopicPartitionList};
+use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use uuid::Uuid;
 
 pub use msk_iam::{MskIamClientContext, configure_sasl_iam};
@@ -26,6 +34,8 @@ mod msk_iam;
 
 const UNGROUPED_GROUP_PREFIX: &str = "macro-event-broker-independent";
 const MESSAGE_TIMEOUT_MS: &str = "5000";
+const COOPERATIVE_ASSIGNMENT_STRATEGY: &str = "cooperative-sticky";
+const MAX_LIBRDKAFKA_POLL_INTERVAL_MS: u128 = 86_400_000;
 const SEND_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Failure to construct an environment-specific Kafka consumer.
@@ -37,6 +47,12 @@ pub enum KafkaConsumerError {
     /// Failed to create the TLS and MSK-IAM authenticated consumer.
     #[error("failed to create MSK IAM Kafka consumer")]
     MskIam(#[source] KafkaError),
+    /// The max poll interval cannot be represented by librdkafka.
+    #[error(
+        "max poll interval {0:?} must round up to between 1 and \
+         {MAX_LIBRDKAFKA_POLL_INTERVAL_MS} milliseconds"
+    )]
+    InvalidMaxPollInterval(Duration),
 }
 
 /// Failure to construct an environment-specific Kafka producer.
@@ -51,11 +67,256 @@ pub enum KafkaProducerError {
 }
 
 /// Underlying Kafka consumer transport selected from the runtime environment.
-struct ConsumerTransport(Either<StreamConsumer, StreamConsumer<MskIamClientContext>>);
+struct ConsumerTransport(
+    Either<StreamConsumer<PlaintextConsumerContext>, StreamConsumer<MskIamClientContext>>,
+);
 
 /// Underlying Kafka producer transport selected from the runtime environment.
 #[derive(Clone)]
 struct ProducerTransport(Either<FutureProducer, FutureProducer<MskIamClientContext>>);
+
+/// A Kafka topic and partition affected by a rebalance.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct TopicPartition {
+    /// Kafka topic name.
+    pub topic: String,
+    /// Kafka partition number.
+    pub partition: i32,
+}
+
+/// Monotonically increasing ownership generation for one topic-partition.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct AssignmentEpoch(u64);
+
+impl AssignmentEpoch {
+    /// Returns the integer generation value.
+    pub fn value(self) -> u64 {
+        self.0
+    }
+}
+
+/// A topic-partition and its ownership generation.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PartitionAssignment {
+    /// Topic and partition whose ownership changed.
+    pub topic_partition: TopicPartition,
+    /// Generation created by this ownership transition.
+    pub epoch: AssignmentEpoch,
+}
+
+/// A synchronous group-rebalance state change.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RebalanceEvent {
+    /// Partitions assigned after librdkafka applied an incremental assignment.
+    Assigned(Vec<PartitionAssignment>),
+    /// Partitions fenced before librdkafka applies an incremental revocation.
+    Revoked(Vec<PartitionAssignment>),
+    /// Rebalance callback failure reported by librdkafka.
+    Error(String),
+}
+
+#[derive(Default)]
+struct RebalanceState {
+    epochs: HashMap<TopicPartition, AssignmentEpoch>,
+    assignments: HashMap<TopicPartition, AssignmentEpoch>,
+}
+
+struct RebalanceTrackerInner {
+    state: Mutex<RebalanceState>,
+    event_sender: UnboundedSender<RebalanceEvent>,
+    event_receiver: Mutex<Option<UnboundedReceiver<RebalanceEvent>>>,
+}
+
+/// Tracks current partition ownership and publishes nonblocking rebalance events.
+///
+/// Revocations update the synchronous ownership snapshot before their event is
+/// sent. A coordinator can therefore reject stale work immediately, even if it
+/// has not yet received the asynchronous event.
+#[derive(Clone)]
+pub struct RebalanceTracker {
+    inner: Arc<RebalanceTrackerInner>,
+}
+
+impl Default for RebalanceTracker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RebalanceTracker {
+    /// Creates an empty tracker with one asynchronous event receiver.
+    pub fn new() -> Self {
+        let (event_sender, event_receiver) = mpsc::unbounded_channel();
+        Self {
+            inner: Arc::new(RebalanceTrackerInner {
+                state: Mutex::new(RebalanceState::default()),
+                event_sender,
+                event_receiver: Mutex::new(Some(event_receiver)),
+            }),
+        }
+    }
+
+    /// Takes the event receiver.
+    ///
+    /// Only one coordinator may consume a tracker's events. Later calls return
+    /// `None`; synchronous state queries remain available on every clone.
+    pub fn take_events(&self) -> Option<UnboundedReceiver<RebalanceEvent>> {
+        lock_unpoisoned(&self.inner.event_receiver).take()
+    }
+
+    /// Returns a stable snapshot of currently owned topic-partitions.
+    pub fn current_assignments(&self) -> Vec<PartitionAssignment> {
+        let state = lock_unpoisoned(&self.inner.state);
+        let mut assignments = state
+            .assignments
+            .iter()
+            .map(|(topic_partition, epoch)| PartitionAssignment {
+                topic_partition: topic_partition.clone(),
+                epoch: *epoch,
+            })
+            .collect::<Vec<_>>();
+        assignments.sort_by(|left, right| left.topic_partition.cmp(&right.topic_partition));
+        assignments
+    }
+
+    /// Returns whether `epoch` is the current ownership generation.
+    pub fn is_current_assignment(
+        &self,
+        topic: &str,
+        partition: i32,
+        epoch: AssignmentEpoch,
+    ) -> bool {
+        let state = lock_unpoisoned(&self.inner.state);
+        state
+            .assignments
+            .get(&TopicPartition {
+                topic: topic.to_string(),
+                partition,
+            })
+            .is_some_and(|current_epoch| *current_epoch == epoch)
+    }
+
+    fn observe_pre_rebalance(&self, rebalance: &Rebalance<'_>) {
+        match rebalance {
+            Rebalance::Revoke(partitions) => {
+                let revoked = self.transition_partitions(partitions, false);
+                let _ = self
+                    .inner
+                    .event_sender
+                    .send(RebalanceEvent::Revoked(revoked));
+            }
+            Rebalance::Error(error) => {
+                let _ = self
+                    .inner
+                    .event_sender
+                    .send(RebalanceEvent::Error(error.to_string()));
+            }
+            Rebalance::Assign(_) => {}
+        }
+    }
+
+    fn observe_post_rebalance(&self, rebalance: &Rebalance<'_>) {
+        if let Rebalance::Assign(partitions) = rebalance {
+            let assigned = self.transition_partitions(partitions, true);
+            let _ = self
+                .inner
+                .event_sender
+                .send(RebalanceEvent::Assigned(assigned));
+        }
+    }
+
+    fn transition_partitions(
+        &self,
+        partitions: &TopicPartitionList,
+        assigned: bool,
+    ) -> Vec<PartitionAssignment> {
+        let topic_partitions = unique_topic_partitions(partitions);
+        let mut state = lock_unpoisoned(&self.inner.state);
+
+        topic_partitions
+            .into_iter()
+            .map(|topic_partition| {
+                let next_epoch = state.epochs.get(&topic_partition).map_or(1, |epoch| {
+                    epoch
+                        .0
+                        .checked_add(1)
+                        .expect("Kafka assignment epoch exhausted")
+                });
+                let epoch = AssignmentEpoch(next_epoch);
+                state.epochs.insert(topic_partition.clone(), epoch);
+                if assigned {
+                    state.assignments.insert(topic_partition.clone(), epoch);
+                } else {
+                    state.assignments.remove(&topic_partition);
+                }
+
+                PartitionAssignment {
+                    topic_partition,
+                    epoch,
+                }
+            })
+            .collect()
+    }
+}
+
+fn lock_unpoisoned<T>(mutex: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
+    mutex
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+fn unique_topic_partitions(partitions: &TopicPartitionList) -> Vec<TopicPartition> {
+    let mut seen = HashSet::new();
+    partitions
+        .elements()
+        .into_iter()
+        .filter_map(|element| {
+            let topic_partition = TopicPartition {
+                topic: element.topic().to_string(),
+                partition: element.partition(),
+            };
+            seen.insert(topic_partition.clone())
+                .then_some(topic_partition)
+        })
+        .collect()
+}
+
+#[derive(Default)]
+struct PlaintextConsumerContext {
+    rebalance_tracker: Option<RebalanceTracker>,
+}
+
+impl PlaintextConsumerContext {
+    fn with_rebalance_tracker(rebalance_tracker: RebalanceTracker) -> Self {
+        Self {
+            rebalance_tracker: Some(rebalance_tracker),
+        }
+    }
+
+    fn observe_pre_rebalance(&self, rebalance: &Rebalance<'_>) {
+        if let Some(tracker) = &self.rebalance_tracker {
+            tracker.observe_pre_rebalance(rebalance);
+        }
+    }
+
+    fn observe_post_rebalance(&self, rebalance: &Rebalance<'_>) {
+        if let Some(tracker) = &self.rebalance_tracker {
+            tracker.observe_post_rebalance(rebalance);
+        }
+    }
+}
+
+impl ClientContext for PlaintextConsumerContext {}
+
+impl ConsumerContext for PlaintextConsumerContext {
+    fn pre_rebalance(&self, _consumer: &BaseConsumer<Self>, rebalance: &Rebalance<'_>) {
+        self.observe_pre_rebalance(rebalance);
+    }
+
+    fn post_rebalance(&self, _consumer: &BaseConsumer<Self>, rebalance: &Rebalance<'_>) {
+        self.observe_post_rebalance(rebalance);
+    }
+}
 
 /// Type-level name for a durable Kafka consumer group.
 ///
@@ -98,6 +359,7 @@ impl InitialOffset {
 /// requested topics and cannot subscribe or commit.
 pub struct KafkaEventConsumer<T> {
     consumer: ConsumerTransport,
+    rebalance_tracker: Option<RebalanceTracker>,
     marker: PhantomData<T>,
 }
 
@@ -133,6 +395,33 @@ fn grouped_config<T: GroupName>(brokers: &str) -> ClientConfig {
     config
 }
 
+fn grouped_config_with_max_poll_interval<T: GroupName>(
+    brokers: &str,
+    max_poll_interval: Duration,
+) -> Result<ClientConfig, KafkaConsumerError> {
+    let max_poll_interval_ms = librdkafka_millis(max_poll_interval)?;
+    let mut config = grouped_config::<T>(brokers);
+    config
+        .set("max.poll.interval.ms", max_poll_interval_ms.to_string())
+        .set(
+            "partition.assignment.strategy",
+            COOPERATIVE_ASSIGNMENT_STRATEGY,
+        );
+    Ok(config)
+}
+
+fn librdkafka_millis(duration: Duration) -> Result<u128, KafkaConsumerError> {
+    let whole_milliseconds = duration.as_millis();
+    let has_submillisecond_remainder = !duration.subsec_nanos().is_multiple_of(1_000_000);
+    let milliseconds = whole_milliseconds + u128::from(has_submillisecond_remainder);
+
+    if milliseconds == 0 || milliseconds > MAX_LIBRDKAFKA_POLL_INTERVAL_MS {
+        return Err(KafkaConsumerError::InvalidMaxPollInterval(duration));
+    }
+
+    Ok(milliseconds)
+}
+
 fn ungrouped_config(brokers: &str) -> ClientConfig {
     let mut config = consumer_config(brokers);
     let group_id = format!("{UNGROUPED_GROUP_PREFIX}-{}", Uuid::new_v4());
@@ -144,14 +433,30 @@ fn ungrouped_config(brokers: &str) -> ClientConfig {
 
 fn create_consumer_from_env<T>(
     config: ClientConfig,
+    rebalance_tracker: Option<RebalanceTracker>,
 ) -> Result<KafkaEventConsumer<T>, KafkaConsumerError> {
     let consumer = match Environment::new_or_prod() {
-        Environment::Local => Either::Left(config.create().map_err(KafkaConsumerError::Plaintext)?),
+        Environment::Local => {
+            let context = rebalance_tracker
+                .clone()
+                .map_or_else(PlaintextConsumerContext::default, |tracker| {
+                    PlaintextConsumerContext::with_rebalance_tracker(tracker)
+                });
+            Either::Left(
+                config
+                    .create_with_context(context)
+                    .map_err(KafkaConsumerError::Plaintext)?,
+            )
+        }
         Environment::Develop | Environment::Production => {
             let config = configure_sasl_iam(config);
+            let context = rebalance_tracker.clone().map_or_else(
+                MskIamClientContext::from_env,
+                MskIamClientContext::from_env_with_rebalance_tracker,
+            );
             Either::Right(
                 config
-                    .create_with_context(MskIamClientContext::from_env())
+                    .create_with_context(context)
                     .map_err(KafkaConsumerError::MskIam)?,
             )
         }
@@ -159,6 +464,7 @@ fn create_consumer_from_env<T>(
 
     Ok(KafkaEventConsumer {
         consumer: ConsumerTransport(consumer),
+        rebalance_tracker,
         marker: PhantomData,
     })
 }
@@ -236,6 +542,87 @@ where
     Ok(assignment)
 }
 
+fn invalid_offset_error() -> KafkaError {
+    KafkaError::SetPartitionOffset(RDKafkaErrorCode::InvalidArgument)
+}
+
+/// Converts a completed record offset to Kafka's next-offset commit value.
+///
+/// Kafka commits represent the next record to consume, not the record that was
+/// just completed. Negative completed offsets and `i64` overflow are rejected.
+pub fn next_offset(completed_record_offset: i64) -> KafkaResult<i64> {
+    if completed_record_offset < 0 {
+        return Err(invalid_offset_error());
+    }
+
+    completed_record_offset
+        .checked_add(1)
+        .ok_or_else(invalid_offset_error)
+}
+
+fn build_partition_offset_list(
+    topic: &str,
+    partition: i32,
+    next_offset: i64,
+) -> KafkaResult<TopicPartitionList> {
+    CString::new(topic).map_err(KafkaError::Nul)?;
+    if topic.is_empty() {
+        return Err(KafkaError::Subscription(
+            "topic must not be empty".to_string(),
+        ));
+    }
+    if partition < 0 {
+        return Err(KafkaError::Subscription(
+            "partition must not be negative".to_string(),
+        ));
+    }
+
+    let mut offsets = TopicPartitionList::with_capacity(1);
+    offsets.add_partition_offset(topic, partition, Offset::Offset(next_offset))?;
+    Ok(offsets)
+}
+
+fn assignment_partitions(assignment: &TopicPartitionList) -> KafkaResult<TopicPartitionList> {
+    let mut partitions = TopicPartitionList::with_capacity(assignment.count());
+    for element in assignment.elements() {
+        element.error()?;
+        partitions.add_partition(element.topic(), element.partition());
+    }
+    Ok(partitions)
+}
+
+trait AssignmentControl {
+    fn assignment(&self) -> KafkaResult<TopicPartitionList>;
+    fn pause(&self, partitions: &TopicPartitionList) -> KafkaResult<()>;
+    fn resume(&self, partitions: &TopicPartitionList) -> KafkaResult<()>;
+}
+
+impl<C: ConsumerContext> AssignmentControl for StreamConsumer<C> {
+    fn assignment(&self) -> KafkaResult<TopicPartitionList> {
+        Consumer::assignment(self)
+    }
+
+    fn pause(&self, partitions: &TopicPartitionList) -> KafkaResult<()> {
+        Consumer::pause(self, partitions)
+    }
+
+    fn resume(&self, partitions: &TopicPartitionList) -> KafkaResult<()> {
+        Consumer::resume(self, partitions)
+    }
+}
+
+fn pause_consumer_assignment(consumer: &impl AssignmentControl) -> KafkaResult<()> {
+    let assignment = consumer.assignment()?;
+    let partitions = assignment_partitions(&assignment)?;
+    consumer.pause(&partitions)
+}
+
+fn resume_consumer_assignment(consumer: &impl AssignmentControl) -> KafkaResult<()> {
+    let assignment = consumer.assignment()?;
+    let partitions = assignment_partitions(&assignment)?;
+    consumer.resume(&partitions)
+}
+
 impl KafkaEventProducer {
     /// Creates a producer, selecting plaintext or MSK IAM transport from the runtime environment.
     ///
@@ -271,7 +658,7 @@ impl<T> KafkaEventConsumer<T> {
     pub fn pause_message_partition(&self, message: &BorrowedMessage<'_>) -> KafkaResult<()> {
         let mut partitions = TopicPartitionList::new();
         partitions.add_partition(message.topic(), message.partition());
-        either::for_both!(&self.consumer.0, consumer => consumer.pause(&partitions))
+        either::for_both!(&self.consumer.0, consumer => Consumer::pause(consumer, &partitions))
     }
 }
 
@@ -279,7 +666,26 @@ impl<T: GroupName> KafkaEventConsumer<T> {
     /// Creates a named-group consumer, selecting plaintext or MSK IAM transport
     /// from the runtime environment.
     pub fn from_env(brokers: &str) -> Result<Self, KafkaConsumerError> {
-        create_consumer_from_env(grouped_config::<T>(brokers))
+        create_consumer_from_env(grouped_config::<T>(brokers), None)
+    }
+
+    /// Creates a cooperative named-group consumer with a custom max poll interval.
+    ///
+    /// This opt-in constructor installs a [`RebalanceTracker`] and pins
+    /// `partition.assignment.strategy=cooperative-sticky`. Existing constructors
+    /// retain librdkafka's default eager assignment strategy.
+    pub fn from_env_with_max_poll_interval(
+        brokers: &str,
+        max_poll_interval: Duration,
+    ) -> Result<Self, KafkaConsumerError> {
+        let config = grouped_config_with_max_poll_interval::<T>(brokers, max_poll_interval)?;
+        let rebalance_tracker = RebalanceTracker::new();
+        create_consumer_from_env(config, Some(rebalance_tracker))
+    }
+
+    /// Returns the opt-in rebalance tracker installed by the cooperative constructor.
+    pub fn rebalance_tracker(&self) -> Option<RebalanceTracker> {
+        self.rebalance_tracker.clone()
     }
 
     /// Subscribes the consumer to exactly the provided topics.
@@ -295,6 +701,31 @@ impl<T: GroupName> KafkaEventConsumer<T> {
     ) -> KafkaResult<()> {
         either::for_both!(&self.consumer.0, consumer => consumer.commit_message(message, mode))
     }
+
+    /// Commits a caller-provided next offset for one topic-partition.
+    ///
+    /// `next_offset` is the next record Kafka should deliver. Use
+    /// [`next_offset`] when converting a completed record's offset.
+    pub fn commit_partition_offset(
+        &self,
+        topic: &str,
+        partition: i32,
+        next_offset: i64,
+        mode: CommitMode,
+    ) -> KafkaResult<()> {
+        let offsets = build_partition_offset_list(topic, partition, next_offset)?;
+        either::for_both!(&self.consumer.0, consumer => consumer.commit(&offsets, mode))
+    }
+
+    /// Pauses every partition in the consumer's current assignment.
+    pub fn pause_current_assignment(&self) -> KafkaResult<()> {
+        either::for_both!(&self.consumer.0, consumer => pause_consumer_assignment(consumer))
+    }
+
+    /// Resumes every partition in the consumer's current assignment.
+    pub fn resume_current_assignment(&self) -> KafkaResult<()> {
+        either::for_both!(&self.consumer.0, consumer => resume_consumer_assignment(consumer))
+    }
 }
 
 impl KafkaEventConsumer<Ungrouped> {
@@ -303,7 +734,7 @@ impl KafkaEventConsumer<Ungrouped> {
     ///
     /// Call [`Self::assign_topics`] before receiving messages.
     pub fn from_env(brokers: &str) -> Result<Self, KafkaConsumerError> {
-        create_consumer_from_env(ungrouped_config(brokers))
+        create_consumer_from_env(ungrouped_config(brokers), None)
     }
 
     /// Manually assigns every current partition of `topics` at `initial_offset`.

--- a/crates/kafka_util/src/msk_iam.rs
+++ b/crates/kafka_util/src/msk_iam.rs
@@ -4,7 +4,9 @@ use aws_msk_iam_sasl_signer::generate_auth_token;
 use aws_types::region::Region;
 use rdkafka::ClientConfig;
 use rdkafka::client::{ClientContext, OAuthToken};
-use rdkafka::consumer::ConsumerContext;
+use rdkafka::consumer::{BaseConsumer, ConsumerContext, Rebalance};
+
+use crate::RebalanceTracker;
 
 /// Region used to sign MSK IAM auth tokens when `AWS_REGION` is unset.
 /// Matches the fallback in `macro_aws_config`.
@@ -28,18 +30,47 @@ pub fn configure_sasl_iam(mut config: ClientConfig) -> ClientConfig {
 /// Tokens are signed with ambient AWS credentials such as an ECS task role.
 pub struct MskIamClientContext {
     region: Region,
+    rebalance_tracker: Option<RebalanceTracker>,
 }
 
 impl MskIamClientContext {
     /// Builds a context using `AWS_REGION`, falling back to `us-east-1`.
     pub fn from_env() -> Self {
+        Self::from_env_with_optional_rebalance_tracker(None)
+    }
+
+    pub(crate) fn from_env_with_rebalance_tracker(rebalance_tracker: RebalanceTracker) -> Self {
+        Self::from_env_with_optional_rebalance_tracker(Some(rebalance_tracker))
+    }
+
+    fn from_env_with_optional_rebalance_tracker(
+        rebalance_tracker: Option<RebalanceTracker>,
+    ) -> Self {
         let region = AwsRegion::new()
             .and_then(|region| region.value().map(str::to_string))
             .unwrap_or_else(|| DEFAULT_AWS_REGION.to_string());
 
         Self {
             region: Region::new(region),
+            rebalance_tracker,
         }
+    }
+
+    pub(crate) fn observe_pre_rebalance(&self, rebalance: &Rebalance<'_>) {
+        if let Some(tracker) = &self.rebalance_tracker {
+            tracker.observe_pre_rebalance(rebalance);
+        }
+    }
+
+    pub(crate) fn observe_post_rebalance(&self, rebalance: &Rebalance<'_>) {
+        if let Some(tracker) = &self.rebalance_tracker {
+            tracker.observe_post_rebalance(rebalance);
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn has_rebalance_tracker(&self) -> bool {
+        self.rebalance_tracker.is_some()
     }
 }
 
@@ -82,4 +113,12 @@ impl ClientContext for MskIamClientContext {
     }
 }
 
-impl ConsumerContext for MskIamClientContext {}
+impl ConsumerContext for MskIamClientContext {
+    fn pre_rebalance(&self, _consumer: &BaseConsumer<Self>, rebalance: &Rebalance<'_>) {
+        self.observe_pre_rebalance(rebalance);
+    }
+
+    fn post_rebalance(&self, _consumer: &BaseConsumer<Self>, rebalance: &Rebalance<'_>) {
+        self.observe_post_rebalance(rebalance);
+    }
+}

--- a/crates/kafka_util/src/parallel.rs
+++ b/crates/kafka_util/src/parallel.rs
@@ -131,7 +131,9 @@ pub enum ParallelConsumerError<ProcessError> {
     /// A received record offset could not be converted to Kafka's next-offset convention.
     #[error("received a Kafka record with an invalid offset")]
     InvalidOffset(#[source] KafkaError),
-    /// Deliveries continued beyond the bounded pause-race allowance.
+    /// A defensive crash-on-invariant condition: deliveries exceeded the bounded
+    /// pause-race allowance. This is not an expected backpressure event and should
+    /// not be tuned away by increasing `max_outstanding`.
     #[error(
         "Kafka deliveries exceeded the pause-race hard ceiling: outstanding {outstanding}, hard limit {hard_limit}"
     )]
@@ -163,7 +165,11 @@ pub enum ParallelConsumerError<ProcessError> {
 /// record behind it.
 ///
 /// Commits use receipt order independently for each topic-partition and never
-/// assume Kafka offsets are numerically consecutive.
+/// assume Kafka offsets are numerically consecutive. [`CommitMode::Sync`]
+/// performs its broker round trip while the rebalance tracker's state lock is
+/// held, preserving atomic epoch fencing but delaying rebalance callback
+/// handling until the commit returns. Prefer [`CommitMode::Async`], which the
+/// typed parallel consumer adapter uses.
 pub async fn run_parallel_consumer<T, Process, ProcessFuture, ProcessError>(
     consumer: KafkaEventConsumer<T>,
     config: ParallelConsumerConfig,

--- a/crates/kafka_util/src/parallel.rs
+++ b/crates/kafka_util/src/parallel.rs
@@ -1,0 +1,798 @@
+//! Bounded-parallel Kafka delivery with receipt-order commit tracking.
+//!
+//! The coordinator only manages transport and commit correctness. It does not
+//! inspect message keys or payloads, and it deliberately provides no retry,
+//! timeout, per-key ordering, or per-partition processing-order guarantees.
+//! Callers that require ordering beyond safe contiguous commits should not use
+//! this coordinator.
+
+#[cfg(test)]
+mod test;
+
+use std::collections::{HashMap, VecDeque};
+use std::future::Future;
+
+use rdkafka::consumer::CommitMode;
+use rdkafka::error::KafkaError;
+use rdkafka::message::{Message as _, OwnedMessage};
+use tokio::sync::mpsc::UnboundedReceiver;
+use tokio::task::{AbortHandle, JoinSet};
+
+use crate::{
+    AssignmentEpoch, GroupName, KafkaEventConsumer, PartitionAssignment, RebalanceEvent,
+    RebalanceTracker, TopicPartition, next_offset,
+};
+
+/// Invalid bounded-parallel consumer configuration.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, thiserror::Error)]
+pub enum ParallelConsumerConfigError {
+    /// Processing concurrency must be greater than zero.
+    #[error("parallel Kafka processing concurrency must be greater than zero")]
+    ZeroProcessingConcurrency,
+    /// The outstanding-message limit must be greater than zero.
+    #[error("parallel Kafka outstanding-message limit must be greater than zero")]
+    ZeroMaxOutstanding,
+    /// The outstanding-message limit must accommodate every processing slot.
+    #[error(
+        "parallel Kafka outstanding-message limit {max_outstanding} is smaller than processing concurrency {processing_concurrency}"
+    )]
+    MaxOutstandingBelowConcurrency {
+        /// Configured number of processing slots.
+        processing_concurrency: usize,
+        /// Configured outstanding-message limit.
+        max_outstanding: usize,
+    },
+    /// The pause-race hard ceiling cannot be represented as a `usize`.
+    #[error("parallel Kafka outstanding-message hard ceiling overflows usize")]
+    OutstandingHardLimitOverflow,
+}
+
+/// Validated limits for a bounded-parallel Kafka consumer.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ParallelConsumerConfig {
+    processing_concurrency: usize,
+    max_outstanding: usize,
+    outstanding_hard_limit: usize,
+}
+
+impl ParallelConsumerConfig {
+    /// Validates and creates parallel-consumer limits.
+    ///
+    /// `max_outstanding` counts every received record that has not been released
+    /// by a successful contiguous commit, including queued, active, and completed
+    /// records. It must be at least `processing_concurrency`.
+    pub fn new(
+        processing_concurrency: usize,
+        max_outstanding: usize,
+    ) -> Result<Self, ParallelConsumerConfigError> {
+        if processing_concurrency == 0 {
+            return Err(ParallelConsumerConfigError::ZeroProcessingConcurrency);
+        }
+        if max_outstanding == 0 {
+            return Err(ParallelConsumerConfigError::ZeroMaxOutstanding);
+        }
+        if max_outstanding < processing_concurrency {
+            return Err(
+                ParallelConsumerConfigError::MaxOutstandingBelowConcurrency {
+                    processing_concurrency,
+                    max_outstanding,
+                },
+            );
+        }
+        let outstanding_hard_limit = max_outstanding
+            .checked_add(processing_concurrency)
+            .ok_or(ParallelConsumerConfigError::OutstandingHardLimitOverflow)?;
+
+        Ok(Self {
+            processing_concurrency,
+            max_outstanding,
+            outstanding_hard_limit,
+        })
+    }
+
+    /// Returns the maximum number of processing futures run at once.
+    pub fn processing_concurrency(self) -> usize {
+        self.processing_concurrency
+    }
+
+    /// Returns the soft limit for received but not contiguously committed records.
+    pub fn max_outstanding(self) -> usize {
+        self.max_outstanding
+    }
+}
+
+/// Fatal termination from the bounded-parallel coordinator.
+#[derive(Debug, thiserror::Error)]
+pub enum ParallelConsumerError<ProcessError> {
+    /// The consumer was not built by the cooperative max-poll constructor.
+    #[error("parallel Kafka consumption requires a cooperative rebalance tracker")]
+    RebalanceTrackerUnavailable,
+    /// Another coordinator already took this consumer's rebalance stream.
+    #[error("the Kafka rebalance event stream is already in use")]
+    RebalanceEventsAlreadyTaken,
+    /// The rebalance notification stream ended unexpectedly.
+    #[error("the Kafka rebalance event stream ended unexpectedly")]
+    RebalanceEventStreamClosed,
+    /// librdkafka reported a rebalance callback failure.
+    #[error("Kafka rebalance failed: {0}")]
+    Rebalance(String),
+    /// Receiving the next record failed.
+    #[error("failed to receive a Kafka record")]
+    Receive(#[source] KafkaError),
+    /// Pausing the current assignment failed.
+    #[error("failed to pause the Kafka consumer assignment")]
+    Pause(#[source] KafkaError),
+    /// Resuming the current assignment failed.
+    #[error("failed to resume the Kafka consumer assignment")]
+    Resume(#[source] KafkaError),
+    /// Submitting a contiguous next-offset commit failed.
+    #[error("failed to commit a contiguous Kafka offset")]
+    Commit(#[source] KafkaError),
+    /// A received record offset could not be converted to Kafka's next-offset convention.
+    #[error("received a Kafka record with an invalid offset")]
+    InvalidOffset(#[source] KafkaError),
+    /// Deliveries continued beyond the bounded pause-race allowance.
+    #[error(
+        "Kafka deliveries exceeded the pause-race hard ceiling: outstanding {outstanding}, hard limit {hard_limit}"
+    )]
+    OutstandingHardLimitExceeded {
+        /// Outstanding count that would have resulted from accepting the delivery.
+        outstanding: usize,
+        /// Maximum accepted count, including the pause-race allowance.
+        hard_limit: usize,
+    },
+    /// A processing future reported a fatal, non-commit-safe result.
+    #[error("parallel Kafka message processing reported a fatal failure")]
+    Processing(ProcessError),
+    /// A spawned processing future panicked or was unexpectedly cancelled.
+    #[error("parallel Kafka processing task failed: {0}")]
+    ProcessingTask(String),
+    /// Internal capacity or receipt bookkeeping violated a coordinator invariant.
+    #[error("parallel Kafka coordinator invariant failed: {0}")]
+    CoordinatorInvariant(&'static str),
+}
+
+/// Runs a cooperative Kafka consumer with bounded parallel processing.
+///
+/// The consumer must have been created with
+/// [`KafkaEventConsumer::from_env_with_max_poll_interval`]. The `process`
+/// function receives a detached [`OwnedMessage`]. Returning `Ok(())` declares
+/// the record commit-safe, whether it was handled, intentionally ignored, or
+/// dropped by a caller-owned delivery policy. Returning `Err` is fatal and
+/// stops the coordinator without committing that record or any unfinished
+/// record behind it.
+///
+/// Commits use receipt order independently for each topic-partition and never
+/// assume Kafka offsets are numerically consecutive.
+pub async fn run_parallel_consumer<T, Process, ProcessFuture, ProcessError>(
+    consumer: KafkaEventConsumer<T>,
+    config: ParallelConsumerConfig,
+    commit_mode: CommitMode,
+    process: Process,
+) -> Result<(), ParallelConsumerError<ProcessError>>
+where
+    T: GroupName,
+    Process: Fn(OwnedMessage) -> ProcessFuture,
+    ProcessFuture: Future<Output = Result<(), ProcessError>> + Send + 'static,
+    ProcessError: Send + 'static,
+{
+    let tracker = consumer
+        .rebalance_tracker()
+        .ok_or(ParallelConsumerError::RebalanceTrackerUnavailable)?;
+    let rebalance_events = tracker
+        .take_events()
+        .ok_or(ParallelConsumerError::RebalanceEventsAlreadyTaken)?;
+    let transport = KafkaParallelTransport { consumer, tracker };
+
+    run_coordinator(transport, rebalance_events, config, commit_mode, process).await
+}
+
+struct ReceivedMessage<Message> {
+    message: Message,
+    topic_partition: TopicPartition,
+    offset: i64,
+    epoch: Option<AssignmentEpoch>,
+}
+
+enum CommitSubmission {
+    Submitted,
+    Fenced,
+}
+
+trait ParallelTransport {
+    type Message;
+
+    async fn receive(&self) -> Result<ReceivedMessage<Self::Message>, KafkaError>;
+    fn commit(
+        &self,
+        topic_partition: &TopicPartition,
+        epoch: AssignmentEpoch,
+        next_offset: i64,
+        mode: CommitMode,
+    ) -> Result<CommitSubmission, KafkaError>;
+    fn pause_current_assignment(&self) -> Result<(), KafkaError>;
+    fn resume_current_assignment(&self) -> Result<(), KafkaError>;
+    fn current_assignments(&self) -> Vec<PartitionAssignment>;
+    fn is_current_assignment(
+        &self,
+        topic_partition: &TopicPartition,
+        epoch: AssignmentEpoch,
+    ) -> bool;
+}
+
+struct KafkaParallelTransport<T> {
+    consumer: KafkaEventConsumer<T>,
+    tracker: RebalanceTracker,
+}
+
+impl<T: GroupName> ParallelTransport for KafkaParallelTransport<T> {
+    type Message = OwnedMessage;
+
+    async fn receive(&self) -> Result<ReceivedMessage<Self::Message>, KafkaError> {
+        let message = self.consumer.recv().await?;
+        let topic_partition = TopicPartition {
+            topic: message.topic().to_string(),
+            partition: message.partition(),
+        };
+        let offset = message.offset();
+        let epoch = self
+            .tracker
+            .assignment_epoch(&topic_partition.topic, topic_partition.partition);
+
+        Ok(ReceivedMessage {
+            message: message.detach(),
+            topic_partition,
+            offset,
+            epoch,
+        })
+    }
+
+    fn commit(
+        &self,
+        topic_partition: &TopicPartition,
+        epoch: AssignmentEpoch,
+        next_offset: i64,
+        mode: CommitMode,
+    ) -> Result<CommitSubmission, KafkaError> {
+        let submission = self
+            .tracker
+            .with_current_assignment(topic_partition, epoch, || {
+                self.consumer.commit_partition_offset(
+                    &topic_partition.topic,
+                    topic_partition.partition,
+                    next_offset,
+                    mode,
+                )
+            });
+
+        match submission {
+            Some(result) => {
+                result?;
+                Ok(CommitSubmission::Submitted)
+            }
+            None => Ok(CommitSubmission::Fenced),
+        }
+    }
+
+    fn pause_current_assignment(&self) -> Result<(), KafkaError> {
+        self.consumer.pause_current_assignment()
+    }
+
+    fn resume_current_assignment(&self) -> Result<(), KafkaError> {
+        self.consumer.resume_current_assignment()
+    }
+
+    fn current_assignments(&self) -> Vec<PartitionAssignment> {
+        self.tracker.current_assignments()
+    }
+
+    fn is_current_assignment(
+        &self,
+        topic_partition: &TopicPartition,
+        epoch: AssignmentEpoch,
+    ) -> bool {
+        self.tracker
+            .is_current_assignment(&topic_partition.topic, topic_partition.partition, epoch)
+    }
+}
+
+struct PendingWork<Message> {
+    receipt_id: u64,
+    message: Message,
+    topic_partition: TopicPartition,
+    epoch: AssignmentEpoch,
+}
+
+struct TrackedReceipt {
+    receipt_id: u64,
+    offset: i64,
+    completed: bool,
+}
+
+struct PartitionState {
+    epoch: AssignmentEpoch,
+    receipts: VecDeque<TrackedReceipt>,
+}
+
+struct ActiveWork {
+    topic_partition: TopicPartition,
+    epoch: AssignmentEpoch,
+    abort_handle: AbortHandle,
+}
+
+struct ActiveCompletion<ProcessError> {
+    receipt_id: u64,
+    topic_partition: TopicPartition,
+    epoch: AssignmentEpoch,
+    result: Result<(), ProcessError>,
+}
+
+struct CoordinatorState<Message> {
+    partitions: HashMap<TopicPartition, PartitionState>,
+    pending: VecDeque<PendingWork<Message>>,
+    active: HashMap<u64, ActiveWork>,
+    next_receipt_id: u64,
+    paused: bool,
+}
+
+impl<Message> CoordinatorState<Message> {
+    fn new(assignments: Vec<PartitionAssignment>) -> Self {
+        let partitions = assignments
+            .into_iter()
+            .map(|assignment| {
+                (
+                    assignment.topic_partition,
+                    PartitionState {
+                        epoch: assignment.epoch,
+                        receipts: VecDeque::new(),
+                    },
+                )
+            })
+            .collect();
+
+        Self {
+            partitions,
+            pending: VecDeque::new(),
+            active: HashMap::new(),
+            next_receipt_id: 0,
+            paused: false,
+        }
+    }
+
+    fn outstanding(&self) -> usize {
+        self.partitions
+            .values()
+            .map(|partition| partition.receipts.len())
+            .sum()
+    }
+
+    fn register(
+        &mut self,
+        message: Message,
+        topic_partition: TopicPartition,
+        epoch: AssignmentEpoch,
+        offset: i64,
+    ) -> Result<(), &'static str> {
+        let receipt_id = self.next_receipt_id;
+        self.next_receipt_id = self
+            .next_receipt_id
+            .checked_add(1)
+            .ok_or("receipt identifier exhausted")?;
+        self.partitions
+            .get_mut(&topic_partition)
+            .ok_or("current partition state missing during receipt registration")?
+            .receipts
+            .push_back(TrackedReceipt {
+                receipt_id,
+                offset,
+                completed: false,
+            });
+        self.pending.push_back(PendingWork {
+            receipt_id,
+            message,
+            topic_partition,
+            epoch,
+        });
+        Ok(())
+    }
+
+    fn fence_partition(&mut self, topic_partition: &TopicPartition) {
+        self.partitions.remove(topic_partition);
+        self.pending
+            .retain(|work| work.topic_partition != *topic_partition);
+
+        let revoked_receipts = self
+            .active
+            .iter()
+            .filter_map(|(receipt_id, work)| {
+                (work.topic_partition == *topic_partition).then_some(*receipt_id)
+            })
+            .collect::<Vec<_>>();
+        for receipt_id in revoked_receipts {
+            if let Some(work) = self.active.remove(&receipt_id) {
+                work.abort_handle.abort();
+            }
+        }
+    }
+
+    fn apply_assignment(&mut self, assignment: PartitionAssignment) {
+        let topic_partition = assignment.topic_partition;
+        if self
+            .partitions
+            .get(&topic_partition)
+            .is_some_and(|state| state.epoch == assignment.epoch)
+        {
+            return;
+        }
+
+        self.fence_partition(&topic_partition);
+        self.partitions.insert(
+            topic_partition,
+            PartitionState {
+                epoch: assignment.epoch,
+                receipts: VecDeque::new(),
+            },
+        );
+    }
+}
+
+async fn run_coordinator<Transport, Process, ProcessFuture, ProcessError>(
+    transport: Transport,
+    mut rebalance_events: UnboundedReceiver<RebalanceEvent>,
+    config: ParallelConsumerConfig,
+    commit_mode: CommitMode,
+    process: Process,
+) -> Result<(), ParallelConsumerError<ProcessError>>
+where
+    Transport: ParallelTransport,
+    Transport::Message: Send + 'static,
+    Process: Fn(Transport::Message) -> ProcessFuture,
+    ProcessFuture: Future<Output = Result<(), ProcessError>> + Send + 'static,
+    ProcessError: Send + 'static,
+{
+    let mut state = CoordinatorState::new(transport.current_assignments());
+    let mut processing_tasks = JoinSet::new();
+
+    loop {
+        fence_stale_partitions(&transport, &mut state);
+        fill_processing_slots(
+            &mut state,
+            &mut processing_tasks,
+            config.processing_concurrency,
+            &process,
+        );
+        reconcile_backpressure(&transport, &mut state, config)?;
+        assert_state_invariants(&state, config);
+
+        tokio::select! {
+            biased;
+            rebalance = rebalance_events.recv() => {
+                let rebalance = rebalance
+                    .ok_or(ParallelConsumerError::RebalanceEventStreamClosed)?;
+                handle_rebalance(&transport, &mut state, rebalance)?;
+            }
+            completion = processing_tasks.join_next(), if !processing_tasks.is_empty() => {
+                let completion = completion.expect("a non-empty processing task set must yield a task");
+                match completion {
+                    Ok(completion) => {
+                        handle_completion(
+                            &transport,
+                            &mut state,
+                            completion,
+                            commit_mode,
+                        )?;
+                    }
+                    Err(error) if error.is_cancelled() => {}
+                    Err(error) => {
+                        return Err(ParallelConsumerError::ProcessingTask(error.to_string()));
+                    }
+                }
+            }
+            delivery = transport.receive() => {
+                let delivery = delivery.map_err(ParallelConsumerError::Receive)?;
+                handle_delivery(&transport, &mut state, delivery, config)?;
+            }
+        }
+    }
+}
+
+fn fill_processing_slots<Message, Process, ProcessFuture, ProcessError>(
+    state: &mut CoordinatorState<Message>,
+    processing_tasks: &mut JoinSet<ActiveCompletion<ProcessError>>,
+    processing_concurrency: usize,
+    process: &Process,
+) where
+    Message: Send + 'static,
+    Process: Fn(Message) -> ProcessFuture,
+    ProcessFuture: Future<Output = Result<(), ProcessError>> + Send + 'static,
+    ProcessError: Send + 'static,
+{
+    while state.active.len() < processing_concurrency {
+        let Some(work) = state.pending.pop_front() else {
+            break;
+        };
+
+        let receipt_id = work.receipt_id;
+        let topic_partition = work.topic_partition;
+        let epoch = work.epoch;
+        let process_future = process(work.message);
+        let completion_topic_partition = topic_partition.clone();
+        let abort_handle = processing_tasks.spawn(async move {
+            ActiveCompletion {
+                receipt_id,
+                topic_partition: completion_topic_partition,
+                epoch,
+                result: process_future.await,
+            }
+        });
+        state.active.insert(
+            receipt_id,
+            ActiveWork {
+                topic_partition,
+                epoch,
+                abort_handle,
+            },
+        );
+    }
+}
+
+fn fence_stale_partitions<Transport: ParallelTransport>(
+    transport: &Transport,
+    state: &mut CoordinatorState<Transport::Message>,
+) {
+    let stale_partitions = state
+        .partitions
+        .iter()
+        .filter_map(|(topic_partition, partition)| {
+            (!transport.is_current_assignment(topic_partition, partition.epoch))
+                .then_some(topic_partition.clone())
+        })
+        .collect::<Vec<_>>();
+
+    for topic_partition in stale_partitions {
+        state.fence_partition(&topic_partition);
+    }
+}
+
+fn reconcile_backpressure<Transport, ProcessError>(
+    transport: &Transport,
+    state: &mut CoordinatorState<Transport::Message>,
+    config: ParallelConsumerConfig,
+) -> Result<(), ParallelConsumerError<ProcessError>>
+where
+    Transport: ParallelTransport,
+{
+    let outstanding = state.outstanding();
+    if !state.paused && outstanding >= config.max_outstanding {
+        transport
+            .pause_current_assignment()
+            .map_err(ParallelConsumerError::Pause)?;
+        state.paused = true;
+    } else if state.paused && outstanding < config.max_outstanding {
+        transport
+            .resume_current_assignment()
+            .map_err(ParallelConsumerError::Resume)?;
+        state.paused = false;
+    }
+
+    Ok(())
+}
+
+fn handle_rebalance<Transport, ProcessError>(
+    transport: &Transport,
+    state: &mut CoordinatorState<Transport::Message>,
+    event: RebalanceEvent,
+) -> Result<(), ParallelConsumerError<ProcessError>>
+where
+    Transport: ParallelTransport,
+{
+    match event {
+        RebalanceEvent::Assigned(assignments) => {
+            let had_assignments = !assignments.is_empty();
+            for assignment in assignments {
+                state.apply_assignment(assignment);
+            }
+            if state.paused && had_assignments {
+                transport
+                    .pause_current_assignment()
+                    .map_err(ParallelConsumerError::Pause)?;
+            }
+        }
+        RebalanceEvent::Revoked(assignments) => {
+            for assignment in assignments {
+                let should_fence = state
+                    .partitions
+                    .get(&assignment.topic_partition)
+                    .is_some_and(|partition| partition.epoch < assignment.epoch);
+                if should_fence {
+                    state.fence_partition(&assignment.topic_partition);
+                }
+            }
+        }
+        RebalanceEvent::Error(error) => return Err(ParallelConsumerError::Rebalance(error)),
+    }
+
+    Ok(())
+}
+
+fn handle_delivery<Transport, ProcessError>(
+    transport: &Transport,
+    state: &mut CoordinatorState<Transport::Message>,
+    delivery: ReceivedMessage<Transport::Message>,
+    config: ParallelConsumerConfig,
+) -> Result<(), ParallelConsumerError<ProcessError>>
+where
+    Transport: ParallelTransport,
+{
+    next_offset(delivery.offset).map_err(ParallelConsumerError::InvalidOffset)?;
+
+    let Some(epoch) = delivery.epoch else {
+        tracing::warn!(
+            topic = delivery.topic_partition.topic,
+            partition = delivery.topic_partition.partition,
+            offset = delivery.offset,
+            "discarding Kafka delivery without a current assignment"
+        );
+        return Ok(());
+    };
+    if !transport.is_current_assignment(&delivery.topic_partition, epoch) {
+        tracing::warn!(
+            topic = delivery.topic_partition.topic,
+            partition = delivery.topic_partition.partition,
+            offset = delivery.offset,
+            epoch = epoch.value(),
+            "discarding Kafka delivery from a fenced assignment epoch"
+        );
+        return Ok(());
+    }
+
+    let next_outstanding =
+        state
+            .outstanding()
+            .checked_add(1)
+            .ok_or(ParallelConsumerError::CoordinatorInvariant(
+                "outstanding-message count exhausted",
+            ))?;
+    if next_outstanding > config.outstanding_hard_limit {
+        return Err(ParallelConsumerError::OutstandingHardLimitExceeded {
+            outstanding: next_outstanding,
+            hard_limit: config.outstanding_hard_limit,
+        });
+    }
+    if next_outstanding > config.max_outstanding {
+        tracing::warn!(
+            outstanding = next_outstanding,
+            max_outstanding = config.max_outstanding,
+            processing_concurrency = config.processing_concurrency,
+            topic = delivery.topic_partition.topic,
+            partition = delivery.topic_partition.partition,
+            offset = delivery.offset,
+            "accepting Kafka delivery that raced assignment pause"
+        );
+    }
+
+    let replace_partition = state
+        .partitions
+        .get(&delivery.topic_partition)
+        .is_some_and(|partition| partition.epoch != epoch);
+    if replace_partition {
+        state.fence_partition(&delivery.topic_partition);
+    }
+    state
+        .partitions
+        .entry(delivery.topic_partition.clone())
+        .or_insert_with(|| PartitionState {
+            epoch,
+            receipts: VecDeque::new(),
+        });
+    state
+        .register(
+            delivery.message,
+            delivery.topic_partition,
+            epoch,
+            delivery.offset,
+        )
+        .map_err(ParallelConsumerError::CoordinatorInvariant)
+}
+
+fn handle_completion<Transport, ProcessError>(
+    transport: &Transport,
+    state: &mut CoordinatorState<Transport::Message>,
+    completion: ActiveCompletion<ProcessError>,
+    commit_mode: CommitMode,
+) -> Result<(), ParallelConsumerError<ProcessError>>
+where
+    Transport: ParallelTransport,
+{
+    let Some(active) = state.active.remove(&completion.receipt_id) else {
+        return Ok(());
+    };
+    if active.topic_partition != completion.topic_partition || active.epoch != completion.epoch {
+        return Ok(());
+    }
+    if !transport.is_current_assignment(&completion.topic_partition, completion.epoch) {
+        return Ok(());
+    }
+    let Some(partition) = state.partitions.get_mut(&completion.topic_partition) else {
+        return Ok(());
+    };
+    if partition.epoch != completion.epoch {
+        return Ok(());
+    }
+
+    completion
+        .result
+        .map_err(ParallelConsumerError::Processing)?;
+    let Some(receipt) = partition
+        .receipts
+        .iter_mut()
+        .find(|receipt| receipt.receipt_id == completion.receipt_id)
+    else {
+        return Ok(());
+    };
+    receipt.completed = true;
+
+    commit_completed_prefix(transport, state, &completion.topic_partition, commit_mode)
+}
+
+fn commit_completed_prefix<Transport, ProcessError>(
+    transport: &Transport,
+    state: &mut CoordinatorState<Transport::Message>,
+    topic_partition: &TopicPartition,
+    commit_mode: CommitMode,
+) -> Result<(), ParallelConsumerError<ProcessError>>
+where
+    Transport: ParallelTransport,
+{
+    let Some(partition) = state.partitions.get(topic_partition) else {
+        return Ok(());
+    };
+    if !transport.is_current_assignment(topic_partition, partition.epoch) {
+        return Ok(());
+    }
+
+    let completed_count = partition
+        .receipts
+        .iter()
+        .take_while(|receipt| receipt.completed)
+        .count();
+    if completed_count == 0 {
+        return Ok(());
+    }
+    let completed_offset = partition.receipts[completed_count - 1].offset;
+    let commit_offset =
+        next_offset(completed_offset).map_err(ParallelConsumerError::InvalidOffset)?;
+    let submission = transport
+        .commit(topic_partition, partition.epoch, commit_offset, commit_mode)
+        .map_err(ParallelConsumerError::Commit)?;
+    if matches!(submission, CommitSubmission::Fenced) {
+        return Ok(());
+    }
+
+    let partition = state
+        .partitions
+        .get_mut(topic_partition)
+        .expect("partition ownership was checked before synchronous commit");
+    partition.receipts.drain(..completed_count);
+    Ok(())
+}
+
+fn assert_state_invariants<Message>(
+    state: &CoordinatorState<Message>,
+    config: ParallelConsumerConfig,
+) {
+    debug_assert!(state.active.len() <= config.processing_concurrency);
+    debug_assert!(state.outstanding() <= config.outstanding_hard_limit);
+    debug_assert!(state.pending.iter().all(|work| {
+        state
+            .partitions
+            .get(&work.topic_partition)
+            .is_some_and(|partition| partition.epoch == work.epoch)
+    }));
+    debug_assert!(state.active.values().all(|work| {
+        state
+            .partitions
+            .get(&work.topic_partition)
+            .is_some_and(|partition| partition.epoch == work.epoch)
+    }));
+}

--- a/crates/kafka_util/src/parallel/test.rs
+++ b/crates/kafka_util/src/parallel/test.rs
@@ -1,0 +1,974 @@
+use std::collections::{HashMap, HashSet};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use rdkafka::error::KafkaError;
+use tokio::sync::{mpsc, oneshot};
+use tokio::task::JoinHandle;
+
+use super::*;
+
+const TOPIC: &str = "events";
+const POLL_HEARTBEAT: Duration = Duration::from_secs(1);
+
+#[derive(Clone, Copy, Debug)]
+struct TestMessage {
+    id: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct Commit {
+    topic_partition: TopicPartition,
+    next_offset: i64,
+}
+
+#[derive(Default)]
+struct FakeAssignments {
+    generations: HashMap<TopicPartition, AssignmentEpoch>,
+    current: HashMap<TopicPartition, AssignmentEpoch>,
+}
+
+struct FakeInner {
+    assignments: Mutex<FakeAssignments>,
+    delivery_sender: mpsc::UnboundedSender<Result<ReceivedMessage<TestMessage>, KafkaError>>,
+    rebalance_sender: mpsc::UnboundedSender<RebalanceEvent>,
+    commits: Mutex<Vec<Commit>>,
+    pause_calls: AtomicUsize,
+    resume_calls: AtomicUsize,
+    receive_polls: AtomicUsize,
+    fail_pause: AtomicBool,
+    fail_resume: AtomicBool,
+    fail_commit: AtomicBool,
+}
+
+struct FakeTransport {
+    inner: Arc<FakeInner>,
+    delivery_receiver: tokio::sync::Mutex<
+        mpsc::UnboundedReceiver<Result<ReceivedMessage<TestMessage>, KafkaError>>,
+    >,
+}
+
+#[derive(Clone)]
+struct FakeControl {
+    inner: Arc<FakeInner>,
+}
+
+impl FakeTransport {
+    fn new() -> (Self, FakeControl, mpsc::UnboundedReceiver<RebalanceEvent>) {
+        let (delivery_sender, delivery_receiver) = mpsc::unbounded_channel();
+        let (rebalance_sender, rebalance_receiver) = mpsc::unbounded_channel();
+        let inner = Arc::new(FakeInner {
+            assignments: Mutex::new(FakeAssignments::default()),
+            delivery_sender,
+            rebalance_sender,
+            commits: Mutex::new(Vec::new()),
+            pause_calls: AtomicUsize::new(0),
+            resume_calls: AtomicUsize::new(0),
+            receive_polls: AtomicUsize::new(0),
+            fail_pause: AtomicBool::new(false),
+            fail_resume: AtomicBool::new(false),
+            fail_commit: AtomicBool::new(false),
+        });
+
+        (
+            Self {
+                inner: inner.clone(),
+                delivery_receiver: tokio::sync::Mutex::new(delivery_receiver),
+            },
+            FakeControl { inner },
+            rebalance_receiver,
+        )
+    }
+}
+
+impl ParallelTransport for FakeTransport {
+    type Message = TestMessage;
+
+    async fn receive(&self) -> Result<ReceivedMessage<Self::Message>, KafkaError> {
+        let mut deliveries = self.delivery_receiver.lock().await;
+        loop {
+            self.inner.receive_polls.fetch_add(1, Ordering::SeqCst);
+            tokio::select! {
+                delivery = deliveries.recv() => {
+                    return delivery.unwrap_or_else(|| {
+                        Err(KafkaError::Subscription("fake delivery stream closed".to_string()))
+                    });
+                }
+                () = tokio::time::sleep(POLL_HEARTBEAT) => {}
+            }
+        }
+    }
+
+    fn commit(
+        &self,
+        topic_partition: &TopicPartition,
+        epoch: AssignmentEpoch,
+        next_offset: i64,
+        _mode: CommitMode,
+    ) -> Result<CommitSubmission, KafkaError> {
+        let assignments = self.inner.assignments.lock().unwrap();
+        if assignments
+            .current
+            .get(topic_partition)
+            .is_none_or(|current_epoch| *current_epoch != epoch)
+        {
+            return Ok(CommitSubmission::Fenced);
+        }
+        if self.inner.fail_commit.load(Ordering::SeqCst) {
+            return Err(KafkaError::Subscription("fake commit failure".to_string()));
+        }
+        self.inner.commits.lock().unwrap().push(Commit {
+            topic_partition: topic_partition.clone(),
+            next_offset,
+        });
+        Ok(CommitSubmission::Submitted)
+    }
+
+    fn pause_current_assignment(&self) -> Result<(), KafkaError> {
+        self.inner.pause_calls.fetch_add(1, Ordering::SeqCst);
+        if self.inner.fail_pause.load(Ordering::SeqCst) {
+            return Err(KafkaError::PauseResume("fake pause failure".to_string()));
+        }
+        Ok(())
+    }
+
+    fn resume_current_assignment(&self) -> Result<(), KafkaError> {
+        self.inner.resume_calls.fetch_add(1, Ordering::SeqCst);
+        if self.inner.fail_resume.load(Ordering::SeqCst) {
+            return Err(KafkaError::PauseResume("fake resume failure".to_string()));
+        }
+        Ok(())
+    }
+
+    fn current_assignments(&self) -> Vec<PartitionAssignment> {
+        self.inner
+            .assignments
+            .lock()
+            .unwrap()
+            .current
+            .iter()
+            .map(|(topic_partition, epoch)| PartitionAssignment {
+                topic_partition: topic_partition.clone(),
+                epoch: *epoch,
+            })
+            .collect()
+    }
+
+    fn is_current_assignment(
+        &self,
+        topic_partition: &TopicPartition,
+        epoch: AssignmentEpoch,
+    ) -> bool {
+        self.inner
+            .assignments
+            .lock()
+            .unwrap()
+            .current
+            .get(topic_partition)
+            .is_some_and(|current_epoch| *current_epoch == epoch)
+    }
+}
+
+impl FakeControl {
+    fn assign(&self, topic: &str, partition: i32) -> AssignmentEpoch {
+        let topic_partition = topic_partition(topic, partition);
+        let epoch = {
+            let mut assignments = self.inner.assignments.lock().unwrap();
+            let next_epoch = assignments
+                .generations
+                .get(&topic_partition)
+                .map_or(1, |epoch| epoch.value() + 1);
+            let epoch = AssignmentEpoch(next_epoch);
+            assignments
+                .generations
+                .insert(topic_partition.clone(), epoch);
+            assignments.current.insert(topic_partition.clone(), epoch);
+            epoch
+        };
+        self.inner
+            .rebalance_sender
+            .send(RebalanceEvent::Assigned(vec![PartitionAssignment {
+                topic_partition,
+                epoch,
+            }]))
+            .unwrap();
+        epoch
+    }
+
+    fn revoke(&self, topic: &str, partition: i32) -> AssignmentEpoch {
+        let topic_partition = topic_partition(topic, partition);
+        let epoch = {
+            let mut assignments = self.inner.assignments.lock().unwrap();
+            let next_epoch = assignments
+                .generations
+                .get(&topic_partition)
+                .map_or(1, |epoch| epoch.value() + 1);
+            let epoch = AssignmentEpoch(next_epoch);
+            assignments
+                .generations
+                .insert(topic_partition.clone(), epoch);
+            assignments.current.remove(&topic_partition);
+            epoch
+        };
+        self.inner
+            .rebalance_sender
+            .send(RebalanceEvent::Revoked(vec![PartitionAssignment {
+                topic_partition,
+                epoch,
+            }]))
+            .unwrap();
+        epoch
+    }
+
+    fn send(&self, id: u64, topic: &str, partition: i32, offset: i64) {
+        let topic_partition = topic_partition(topic, partition);
+        let epoch = self
+            .inner
+            .assignments
+            .lock()
+            .unwrap()
+            .current
+            .get(&topic_partition)
+            .copied();
+        self.send_with_epoch(id, topic_partition, offset, epoch);
+    }
+
+    fn send_with_epoch(
+        &self,
+        id: u64,
+        topic_partition: TopicPartition,
+        offset: i64,
+        epoch: Option<AssignmentEpoch>,
+    ) {
+        self.inner
+            .delivery_sender
+            .send(Ok(ReceivedMessage {
+                message: TestMessage { id },
+                topic_partition,
+                offset,
+                epoch,
+            }))
+            .unwrap();
+    }
+
+    fn fail_receive(&self) {
+        self.inner
+            .delivery_sender
+            .send(Err(KafkaError::Subscription(
+                "fake receive failure".to_string(),
+            )))
+            .unwrap();
+    }
+
+    fn commits(&self) -> Vec<Commit> {
+        self.inner.commits.lock().unwrap().clone()
+    }
+
+    fn pause_calls(&self) -> usize {
+        self.inner.pause_calls.load(Ordering::SeqCst)
+    }
+
+    fn resume_calls(&self) -> usize {
+        self.inner.resume_calls.load(Ordering::SeqCst)
+    }
+
+    fn receive_polls(&self) -> usize {
+        self.inner.receive_polls.load(Ordering::SeqCst)
+    }
+
+    fn fail_pause(&self) {
+        self.inner.fail_pause.store(true, Ordering::SeqCst);
+    }
+
+    fn fail_resume(&self) {
+        self.inner.fail_resume.store(true, Ordering::SeqCst);
+    }
+
+    fn fail_commit(&self) {
+        self.inner.fail_commit.store(true, Ordering::SeqCst);
+    }
+
+    fn epoch(&self, topic: &str, partition: i32) -> Option<AssignmentEpoch> {
+        self.inner
+            .assignments
+            .lock()
+            .unwrap()
+            .current
+            .get(&topic_partition(topic, partition))
+            .copied()
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+enum TestProcessError {
+    #[error("test requested a fatal processing outcome")]
+    Fatal,
+    #[error("test process control channel closed")]
+    ControlClosed,
+}
+
+struct StartedWork {
+    id: u64,
+    completion: oneshot::Sender<Result<(), TestProcessError>>,
+}
+
+impl StartedWork {
+    fn commit_safe(self) {
+        self.completion.send(Ok(())).unwrap();
+    }
+
+    fn fatal(self) {
+        self.completion.send(Err(TestProcessError::Fatal)).unwrap();
+    }
+}
+
+type TestResult = Result<(), ParallelConsumerError<TestProcessError>>;
+
+#[derive(Default)]
+struct ProcessMetrics {
+    executing: AtomicUsize,
+    maximum_executing: AtomicUsize,
+}
+
+struct ExecutionGuard {
+    metrics: Arc<ProcessMetrics>,
+}
+
+impl ExecutionGuard {
+    fn new(metrics: Arc<ProcessMetrics>) -> Self {
+        let executing = metrics.executing.fetch_add(1, Ordering::SeqCst) + 1;
+        metrics
+            .maximum_executing
+            .fetch_max(executing, Ordering::SeqCst);
+        Self { metrics }
+    }
+}
+
+impl Drop for ExecutionGuard {
+    fn drop(&mut self) {
+        self.metrics.executing.fetch_sub(1, Ordering::SeqCst);
+    }
+}
+
+struct Harness {
+    control: FakeControl,
+    started: mpsc::UnboundedReceiver<StartedWork>,
+    coordinator: JoinHandle<TestResult>,
+    process_metrics: Arc<ProcessMetrics>,
+}
+
+impl Harness {
+    fn start(config: ParallelConsumerConfig, partitions: &[i32]) -> Self {
+        let (transport, control, rebalance_events) = FakeTransport::new();
+        for partition in partitions {
+            control.assign(TOPIC, *partition);
+        }
+        let (started_sender, started) = mpsc::unbounded_channel();
+        let process_metrics = Arc::new(ProcessMetrics::default());
+        let process_metrics_for_work = process_metrics.clone();
+        let process = move |message: TestMessage| {
+            let (completion, completed) = oneshot::channel();
+            let sent = started_sender.send(StartedWork {
+                id: message.id,
+                completion,
+            });
+            let process_metrics = process_metrics_for_work.clone();
+            async move {
+                let _execution = ExecutionGuard::new(process_metrics);
+                if sent.is_err() {
+                    return Err(TestProcessError::ControlClosed);
+                }
+                completed
+                    .await
+                    .unwrap_or(Err(TestProcessError::ControlClosed))
+            }
+        };
+        let coordinator = tokio::spawn(run_coordinator(
+            transport,
+            rebalance_events,
+            config,
+            CommitMode::Async,
+            process,
+        ));
+
+        Self {
+            control,
+            started,
+            coordinator,
+            process_metrics,
+        }
+    }
+
+    async fn next_started(&mut self) -> StartedWork {
+        self.started.recv().await.expect("expected work to start")
+    }
+
+    fn assert_no_work_started(&mut self) {
+        assert!(matches!(
+            self.started.try_recv(),
+            Err(mpsc::error::TryRecvError::Empty)
+        ));
+    }
+
+    fn executing(&self) -> usize {
+        self.process_metrics.executing.load(Ordering::SeqCst)
+    }
+
+    fn maximum_executing(&self) -> usize {
+        self.process_metrics
+            .maximum_executing
+            .load(Ordering::SeqCst)
+    }
+
+    async fn stop(self) -> ParallelConsumerError<TestProcessError> {
+        self.control.fail_receive();
+        self.coordinator
+            .await
+            .expect("coordinator task should not panic")
+            .expect_err("fake receive failure should stop coordinator")
+    }
+}
+
+fn topic_partition(topic: &str, partition: i32) -> TopicPartition {
+    TopicPartition {
+        topic: topic.to_string(),
+        partition,
+    }
+}
+
+async fn settle() {
+    for _ in 0..10 {
+        tokio::task::yield_now().await;
+    }
+}
+
+async fn wait_until(mut condition: impl FnMut() -> bool) {
+    for _ in 0..100 {
+        if condition() {
+            return;
+        }
+        tokio::task::yield_now().await;
+    }
+    panic!("condition did not become true");
+}
+
+#[test]
+fn configuration_rejects_zero_undersized_and_overflowing_limits() {
+    assert_eq!(
+        ParallelConsumerConfig::new(0, 1),
+        Err(ParallelConsumerConfigError::ZeroProcessingConcurrency)
+    );
+    assert_eq!(
+        ParallelConsumerConfig::new(1, 0),
+        Err(ParallelConsumerConfigError::ZeroMaxOutstanding)
+    );
+    assert_eq!(
+        ParallelConsumerConfig::new(3, 2),
+        Err(
+            ParallelConsumerConfigError::MaxOutstandingBelowConcurrency {
+                processing_concurrency: 3,
+                max_outstanding: 2,
+            }
+        )
+    );
+    assert_eq!(
+        ParallelConsumerConfig::new(1, usize::MAX),
+        Err(ParallelConsumerConfigError::OutstandingHardLimitOverflow)
+    );
+
+    let config = ParallelConsumerConfig::new(3, 8).unwrap();
+    assert_eq!(config.processing_concurrency(), 3);
+    assert_eq!(config.max_outstanding(), 8);
+}
+
+#[tokio::test]
+async fn concurrency_is_capped_and_two_completions_refill_two_slots_fifo() {
+    let mut harness = Harness::start(ParallelConsumerConfig::new(3, 6).unwrap(), &[0]);
+    for id in 0..6 {
+        harness.control.send(id, TOPIC, 0, 10 + id as i64 * 10);
+    }
+
+    let first = harness.next_started().await;
+    let second = harness.next_started().await;
+    let third = harness.next_started().await;
+    assert_eq!([first.id, second.id, third.id], [0, 1, 2]);
+    harness.assert_no_work_started();
+    wait_until(|| harness.executing() == 3).await;
+    assert_eq!(harness.maximum_executing(), 3);
+
+    second.commit_safe();
+    third.commit_safe();
+    let fourth = harness.next_started().await;
+    let fifth = harness.next_started().await;
+    assert_eq!([fourth.id, fifth.id], [3, 4]);
+    harness.assert_no_work_started();
+    wait_until(|| harness.executing() == 3).await;
+    assert_eq!(harness.maximum_executing(), 3);
+    assert!(harness.control.commits().is_empty());
+
+    first.commit_safe();
+    wait_until(|| !harness.control.commits().is_empty()).await;
+    assert_eq!(harness.control.commits()[0].next_offset, 31);
+
+    assert!(matches!(
+        harness.stop().await,
+        ParallelConsumerError::Receive(_)
+    ));
+}
+
+#[tokio::test]
+async fn out_of_order_completion_commits_receipt_order_across_offset_gaps() {
+    let mut harness = Harness::start(ParallelConsumerConfig::new(3, 4).unwrap(), &[0]);
+    harness.control.send(0, TOPIC, 0, 4);
+    harness.control.send(1, TOPIC, 0, 9);
+    harness.control.send(2, TOPIC, 0, 15);
+    let first = harness.next_started().await;
+    let second = harness.next_started().await;
+    let third = harness.next_started().await;
+
+    third.commit_safe();
+    second.commit_safe();
+    settle().await;
+    assert!(harness.control.commits().is_empty());
+
+    first.commit_safe();
+    wait_until(|| harness.control.commits().len() == 1).await;
+    assert_eq!(harness.control.commits()[0].next_offset, 16);
+
+    harness.stop().await;
+}
+
+#[tokio::test]
+async fn partitions_commit_independently() {
+    let mut harness = Harness::start(ParallelConsumerConfig::new(2, 4).unwrap(), &[0, 1]);
+    harness.control.send(0, TOPIC, 0, 100);
+    harness.control.send(1, TOPIC, 1, 7);
+    let partition_zero = harness.next_started().await;
+    let partition_one = harness.next_started().await;
+
+    partition_one.commit_safe();
+    wait_until(|| harness.control.commits().len() == 1).await;
+    assert_eq!(
+        harness.control.commits()[0],
+        Commit {
+            topic_partition: topic_partition(TOPIC, 1),
+            next_offset: 8,
+        }
+    );
+
+    partition_zero.commit_safe();
+    wait_until(|| harness.control.commits().len() == 2).await;
+    assert_eq!(harness.control.commits()[1].topic_partition.partition, 0);
+    harness.stop().await;
+}
+
+#[tokio::test]
+async fn commit_safe_drop_unblocks_a_completed_prefix() {
+    let mut harness = Harness::start(ParallelConsumerConfig::new(2, 3).unwrap(), &[0]);
+    harness.control.send(0, TOPIC, 0, 20);
+    harness.control.send(1, TOPIC, 0, 25);
+    let delayed = harness.next_started().await;
+    let policy_drop = harness.next_started().await;
+
+    policy_drop.commit_safe();
+    settle().await;
+    assert!(harness.control.commits().is_empty());
+    delayed.commit_safe();
+    wait_until(|| harness.control.commits().len() == 1).await;
+    assert_eq!(harness.control.commits()[0].next_offset, 26);
+
+    harness.stop().await;
+}
+
+#[tokio::test]
+async fn fatal_processing_stops_without_committing_the_failed_prefix() {
+    let mut harness = Harness::start(ParallelConsumerConfig::new(2, 3).unwrap(), &[0]);
+    harness.control.send(0, TOPIC, 0, 0);
+    harness.control.send(1, TOPIC, 0, 1);
+    let failed = harness.next_started().await;
+    let unfinished = harness.next_started().await;
+
+    failed.fatal();
+    let error = harness.coordinator.await.unwrap().unwrap_err();
+    assert!(matches!(error, ParallelConsumerError::Processing(_)));
+    assert!(unfinished.completion.send(Ok(())).is_err());
+    assert!(harness.control.commits().is_empty());
+}
+
+#[tokio::test]
+async fn commit_submission_failure_is_fatal_and_does_not_cross_unfinished_work() {
+    let mut harness = Harness::start(ParallelConsumerConfig::new(2, 3).unwrap(), &[0]);
+    harness.control.send(0, TOPIC, 0, 40);
+    harness.control.send(1, TOPIC, 0, 41);
+    let first = harness.next_started().await;
+    let unfinished = harness.next_started().await;
+    harness.control.fail_commit();
+
+    first.commit_safe();
+    let error = harness.coordinator.await.unwrap().unwrap_err();
+    assert!(matches!(error, ParallelConsumerError::Commit(_)));
+    assert!(unfinished.completion.send(Ok(())).is_err());
+    assert!(harness.control.commits().is_empty());
+}
+
+#[tokio::test]
+async fn pause_and_resume_failures_terminate_the_coordinator() {
+    let mut pause_failure = Harness::start(ParallelConsumerConfig::new(1, 1).unwrap(), &[0]);
+    pause_failure.control.fail_pause();
+    pause_failure.control.send(0, TOPIC, 0, 0);
+    let _started = pause_failure.next_started().await;
+    let error = pause_failure.coordinator.await.unwrap().unwrap_err();
+    assert!(matches!(error, ParallelConsumerError::Pause(_)));
+    assert!(pause_failure.control.commits().is_empty());
+
+    let mut resume_failure = Harness::start(ParallelConsumerConfig::new(1, 1).unwrap(), &[0]);
+    resume_failure.control.send(0, TOPIC, 0, 0);
+    let started = resume_failure.next_started().await;
+    wait_until(|| resume_failure.control.pause_calls() == 1).await;
+    resume_failure.control.fail_resume();
+    started.commit_safe();
+    let error = resume_failure.coordinator.await.unwrap().unwrap_err();
+    assert!(matches!(error, ParallelConsumerError::Resume(_)));
+    assert_eq!(resume_failure.control.commits()[0].next_offset, 1);
+}
+
+#[tokio::test(start_paused = true)]
+async fn saturated_consumer_keeps_polling_past_the_modeled_max_poll_interval() {
+    let mut harness = Harness::start(ParallelConsumerConfig::new(1, 1).unwrap(), &[0]);
+    harness.control.send(0, TOPIC, 0, 0);
+    let first = harness.next_started().await;
+    wait_until(|| harness.control.pause_calls() == 1).await;
+    let polls_before = harness.control.receive_polls();
+
+    tokio::time::advance(Duration::from_secs(120)).await;
+    settle().await;
+    assert!(harness.control.receive_polls() > polls_before);
+    assert_eq!(harness.control.resume_calls(), 0);
+
+    first.commit_safe();
+    wait_until(|| harness.control.resume_calls() == 1).await;
+    harness.control.send(1, TOPIC, 0, 1);
+    assert_eq!(harness.next_started().await.id, 1);
+    harness.stop().await;
+}
+
+#[tokio::test]
+async fn deliveries_racing_pause_are_accepted_through_the_hard_ceiling() {
+    let mut harness = Harness::start(ParallelConsumerConfig::new(2, 2).unwrap(), &[0]);
+    harness.control.send(0, TOPIC, 0, 0);
+    harness.control.send(1, TOPIC, 0, 1);
+    let first = harness.next_started().await;
+    let second = harness.next_started().await;
+    wait_until(|| harness.control.pause_calls() == 1).await;
+
+    harness.control.send(2, TOPIC, 0, 2);
+    harness.control.send(3, TOPIC, 0, 3);
+    settle().await;
+    assert!(!harness.coordinator.is_finished());
+    harness.assert_no_work_started();
+
+    first.commit_safe();
+    second.commit_safe();
+    let third = harness.next_started().await;
+    let fourth = harness.next_started().await;
+    assert_eq!([third.id, fourth.id], [2, 3]);
+    assert_eq!(harness.control.resume_calls(), 0);
+
+    third.commit_safe();
+    wait_until(|| harness.control.resume_calls() == 1).await;
+    harness.stop().await;
+}
+
+#[tokio::test]
+async fn deliveries_beyond_pause_race_allowance_are_fatal() {
+    let mut harness = Harness::start(ParallelConsumerConfig::new(2, 2).unwrap(), &[0]);
+    for id in 0..5 {
+        harness.control.send(id, TOPIC, 0, id as i64);
+    }
+    let first = harness.next_started().await;
+    let second = harness.next_started().await;
+
+    let error = harness.coordinator.await.unwrap().unwrap_err();
+    assert!(matches!(
+        error,
+        ParallelConsumerError::OutstandingHardLimitExceeded {
+            outstanding: 5,
+            hard_limit: 4,
+        }
+    ));
+    assert!(first.completion.send(Ok(())).is_err());
+    assert!(second.completion.send(Ok(())).is_err());
+    assert!(harness.control.commits().is_empty());
+}
+
+#[tokio::test]
+async fn incremental_revocation_cancels_only_moved_partition_and_releases_its_slot() {
+    let mut harness = Harness::start(ParallelConsumerConfig::new(2, 4).unwrap(), &[0, 1]);
+    let retained_epoch = harness.control.epoch(TOPIC, 1).unwrap();
+    harness.control.send(0, TOPIC, 0, 0);
+    harness.control.send(1, TOPIC, 1, 10);
+    let revoked = harness.next_started().await;
+    let retained = harness.next_started().await;
+
+    harness.control.revoke(TOPIC, 0);
+    harness.control.send(2, TOPIC, 1, 11);
+    let refill = harness.next_started().await;
+    assert_eq!(refill.id, 2);
+    assert_eq!(harness.control.epoch(TOPIC, 1), Some(retained_epoch));
+    settle().await;
+    assert!(revoked.completion.send(Ok(())).is_err());
+
+    retained.commit_safe();
+    refill.commit_safe();
+    wait_until(|| !harness.control.commits().is_empty()).await;
+    assert!(
+        harness
+            .control
+            .commits()
+            .iter()
+            .all(|commit| commit.topic_partition.partition == 1)
+    );
+    harness.stop().await;
+}
+
+#[tokio::test]
+async fn full_revocation_cancels_all_work_and_releases_all_capacity() {
+    let mut harness = Harness::start(ParallelConsumerConfig::new(2, 4).unwrap(), &[0, 1]);
+    harness.control.send(0, TOPIC, 0, 0);
+    harness.control.send(1, TOPIC, 1, 0);
+    let first = harness.next_started().await;
+    let second = harness.next_started().await;
+
+    harness.control.revoke(TOPIC, 0);
+    harness.control.revoke(TOPIC, 1);
+    settle().await;
+    assert!(first.completion.send(Ok(())).is_err());
+    assert!(second.completion.send(Ok(())).is_err());
+    assert!(harness.control.commits().is_empty());
+
+    harness.control.assign(TOPIC, 2);
+    harness.control.assign(TOPIC, 3);
+    harness.control.send(2, TOPIC, 2, 5);
+    harness.control.send(3, TOPIC, 3, 8);
+    assert_eq!(harness.next_started().await.id, 2);
+    assert_eq!(harness.next_started().await.id, 3);
+    harness.stop().await;
+}
+
+#[tokio::test]
+async fn revocation_discards_completed_offsets_waiting_behind_a_gap() {
+    let mut harness = Harness::start(ParallelConsumerConfig::new(2, 3).unwrap(), &[0]);
+    harness.control.send(0, TOPIC, 0, 3);
+    harness.control.send(1, TOPIC, 0, 9);
+    let gap = harness.next_started().await;
+    let completed_later = harness.next_started().await;
+    completed_later.commit_safe();
+    settle().await;
+    assert!(harness.control.commits().is_empty());
+
+    harness.control.revoke(TOPIC, 0);
+    settle().await;
+    assert!(gap.completion.send(Ok(())).is_err());
+    assert!(harness.control.commits().is_empty());
+    harness.stop().await;
+}
+
+#[tokio::test]
+async fn repeated_rebalances_and_same_partition_reassignment_fence_old_epochs() {
+    let mut harness = Harness::start(ParallelConsumerConfig::new(1, 2).unwrap(), &[0]);
+
+    for cycle in 0..3 {
+        harness.control.send(cycle, TOPIC, 0, cycle as i64);
+        let old_work = harness.next_started().await;
+        let old_epoch = harness.control.epoch(TOPIC, 0).unwrap();
+        harness.control.revoke(TOPIC, 0);
+        let new_epoch = harness.control.assign(TOPIC, 0);
+        assert!(new_epoch > old_epoch);
+        settle().await;
+        assert!(old_work.completion.send(Ok(())).is_err());
+    }
+
+    harness.control.send(100, TOPIC, 0, 0);
+    let current_work = harness.next_started().await;
+    current_work.commit_safe();
+    wait_until(|| harness.control.commits().len() == 1).await;
+    assert_eq!(harness.control.commits()[0].next_offset, 1);
+    harness.stop().await;
+}
+
+#[tokio::test]
+async fn stale_completion_ready_during_reassignment_cannot_commit_new_epoch() {
+    let mut harness = Harness::start(ParallelConsumerConfig::new(1, 2).unwrap(), &[0]);
+    harness.control.send(0, TOPIC, 0, 50);
+    let old_work = harness.next_started().await;
+    old_work.commit_safe();
+    harness.control.revoke(TOPIC, 0);
+    harness.control.assign(TOPIC, 0);
+    settle().await;
+    assert!(harness.control.commits().is_empty());
+
+    harness.control.send(1, TOPIC, 0, 50);
+    let new_work = harness.next_started().await;
+    new_work.commit_safe();
+    wait_until(|| harness.control.commits().len() == 1).await;
+    assert_eq!(harness.control.commits()[0].next_offset, 51);
+    harness.stop().await;
+}
+
+#[derive(Clone, Copy)]
+struct TableReceipt {
+    id: u64,
+    partition: i32,
+    offset: i64,
+}
+
+#[tokio::test]
+async fn table_driven_completion_orders_preserve_state_machine_invariants() {
+    let cases: &[(&[TableReceipt], &[u64])] = &[
+        (
+            &[
+                TableReceipt {
+                    id: 0,
+                    partition: 0,
+                    offset: 2,
+                },
+                TableReceipt {
+                    id: 1,
+                    partition: 0,
+                    offset: 8,
+                },
+                TableReceipt {
+                    id: 2,
+                    partition: 0,
+                    offset: 20,
+                },
+            ],
+            &[2, 0, 1],
+        ),
+        (
+            &[
+                TableReceipt {
+                    id: 0,
+                    partition: 0,
+                    offset: 10,
+                },
+                TableReceipt {
+                    id: 1,
+                    partition: 1,
+                    offset: 4,
+                },
+                TableReceipt {
+                    id: 2,
+                    partition: 0,
+                    offset: 14,
+                },
+                TableReceipt {
+                    id: 3,
+                    partition: 1,
+                    offset: 12,
+                },
+            ],
+            &[3, 2, 1, 0],
+        ),
+        (
+            &[
+                TableReceipt {
+                    id: 0,
+                    partition: 0,
+                    offset: 0,
+                },
+                TableReceipt {
+                    id: 1,
+                    partition: 1,
+                    offset: 100,
+                },
+                TableReceipt {
+                    id: 2,
+                    partition: 2,
+                    offset: 7,
+                },
+            ],
+            &[1, 0, 2],
+        ),
+    ];
+
+    for (receipts, completion_order) in cases {
+        let partitions = receipts
+            .iter()
+            .map(|receipt| receipt.partition)
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
+        let mut harness = Harness::start(
+            ParallelConsumerConfig::new(receipts.len(), receipts.len()).unwrap(),
+            &partitions,
+        );
+        for receipt in *receipts {
+            harness
+                .control
+                .send(receipt.id, TOPIC, receipt.partition, receipt.offset);
+        }
+        let mut started = HashMap::new();
+        for _ in 0..receipts.len() {
+            let work = harness.next_started().await;
+            started.insert(work.id, work);
+        }
+
+        let mut completed = HashSet::new();
+        let mut checked_commits = 0;
+        let mut last_commit_by_partition = HashMap::new();
+        for id in *completion_order {
+            started.remove(id).unwrap().commit_safe();
+            completed.insert(*id);
+            settle().await;
+
+            let commits = harness.control.commits();
+            for commit in &commits[checked_commits..] {
+                if let Some(previous) = last_commit_by_partition
+                    .insert(commit.topic_partition.partition, commit.next_offset)
+                {
+                    assert!(commit.next_offset >= previous);
+                }
+                let committed_receipt = receipts
+                    .iter()
+                    .find(|receipt| {
+                        receipt.partition == commit.topic_partition.partition
+                            && receipt.offset + 1 == commit.next_offset
+                    })
+                    .unwrap();
+                for receipt in receipts
+                    .iter()
+                    .take_while(|receipt| receipt.id != committed_receipt.id)
+                {
+                    if receipt.partition == committed_receipt.partition {
+                        assert!(completed.contains(&receipt.id));
+                    }
+                }
+                assert!(completed.contains(&committed_receipt.id));
+            }
+            checked_commits = commits.len();
+        }
+
+        let commits = harness.control.commits();
+        for partition in &partitions {
+            let expected = receipts
+                .iter()
+                .rev()
+                .find(|receipt| receipt.partition == *partition)
+                .unwrap()
+                .offset
+                + 1;
+            assert_eq!(
+                commits
+                    .iter()
+                    .rev()
+                    .find(|commit| commit.topic_partition.partition == *partition)
+                    .unwrap()
+                    .next_offset,
+                expected
+            );
+        }
+        harness.stop().await;
+    }
+}

--- a/crates/kafka_util/src/test.rs
+++ b/crates/kafka_util/src/test.rs
@@ -6,6 +6,28 @@ impl GroupName for TestConsumerGroup {
     const GROUP_NAME: &'static str = "consumer-group";
 }
 
+fn topic_partition_list(partitions: &[(&str, i32)]) -> TopicPartitionList {
+    let mut list = TopicPartitionList::with_capacity(partitions.len());
+    for (topic, partition) in partitions {
+        list.add_partition(topic, *partition);
+    }
+    list
+}
+
+fn find_assignment<'a>(
+    assignments: &'a [PartitionAssignment],
+    topic: &str,
+    partition: i32,
+) -> &'a PartitionAssignment {
+    assignments
+        .iter()
+        .find(|assignment| {
+            assignment.topic_partition.topic == topic
+                && assignment.topic_partition.partition == partition
+        })
+        .expect("expected topic-partition assignment")
+}
+
 #[test]
 fn producer_config_uses_brokers_and_message_timeout() {
     let config = producer_config("broker-a:9092,broker-b:9092");
@@ -29,6 +51,54 @@ fn grouped_config_uses_named_group_manual_commits_and_earliest_offsets() {
     assert_eq!(config.get("group.id"), Some("consumer-group"));
     assert_eq!(config.get("enable.auto.commit"), Some("false"));
     assert_eq!(config.get("auto.offset.reset"), Some("earliest"));
+    assert_eq!(config.get("max.poll.interval.ms"), None);
+    assert_eq!(config.get("partition.assignment.strategy"), None);
+}
+
+#[test]
+fn cooperative_grouped_config_sets_max_poll_interval_without_changing_group_defaults() {
+    let config = grouped_config_with_max_poll_interval::<TestConsumerGroup>(
+        "broker-a:9092,broker-b:9092",
+        Duration::from_secs(420),
+    )
+    .unwrap();
+
+    assert_eq!(config.get("group.id"), Some("consumer-group"));
+    assert_eq!(config.get("enable.auto.commit"), Some("false"));
+    assert_eq!(config.get("auto.offset.reset"), Some("earliest"));
+    assert_eq!(config.get("max.poll.interval.ms"), Some("420000"));
+    assert_eq!(
+        config.get("partition.assignment.strategy"),
+        Some(COOPERATIVE_ASSIGNMENT_STRATEGY)
+    );
+}
+
+#[test]
+fn max_poll_interval_conversion_rounds_up_and_rejects_librdkafka_out_of_range_values() {
+    let rounded = grouped_config_with_max_poll_interval::<TestConsumerGroup>(
+        "broker:9092",
+        Duration::from_nanos(1),
+    )
+    .unwrap();
+    let maximum = grouped_config_with_max_poll_interval::<TestConsumerGroup>(
+        "broker:9092",
+        Duration::from_millis(MAX_LIBRDKAFKA_POLL_INTERVAL_MS as u64),
+    )
+    .unwrap();
+
+    assert_eq!(rounded.get("max.poll.interval.ms"), Some("1"));
+    assert_eq!(maximum.get("max.poll.interval.ms"), Some("86400000"));
+    assert!(matches!(
+        grouped_config_with_max_poll_interval::<TestConsumerGroup>("broker:9092", Duration::ZERO),
+        Err(KafkaConsumerError::InvalidMaxPollInterval(Duration::ZERO))
+    ));
+    assert!(matches!(
+        grouped_config_with_max_poll_interval::<TestConsumerGroup>(
+            "broker:9092",
+            Duration::from_millis((MAX_LIBRDKAFKA_POLL_INTERVAL_MS + 1) as u64)
+        ),
+        Err(KafkaConsumerError::InvalidMaxPollInterval(_))
+    ));
 }
 
 #[test]
@@ -44,10 +114,308 @@ fn ungrouped_config_uses_unique_internal_groups_without_offset_storage() {
     assert_eq!(first.get("enable.auto.commit"), Some("false"));
     assert_eq!(first.get("enable.auto.offset.store"), Some("false"));
     assert_eq!(first.get("auto.offset.reset"), None);
+    assert_eq!(first.get("partition.assignment.strategy"), None);
 }
 
 #[test]
 fn ungrouped_initial_offsets_are_explicit() {
     assert_eq!(InitialOffset::Earliest.as_kafka_offset(), Offset::Beginning);
     assert_eq!(InitialOffset::Latest.as_kafka_offset(), Offset::End);
+}
+
+#[test]
+fn exact_offset_list_uses_kafka_next_offset_convention() {
+    let completed_offset = 41;
+    let commit_offset = next_offset(completed_offset).unwrap();
+    let offsets = build_partition_offset_list("events", 3, commit_offset).unwrap();
+    let element = offsets.elements().pop().unwrap();
+
+    assert_eq!(offsets.count(), 1);
+    assert_eq!(element.topic(), "events");
+    assert_eq!(element.partition(), 3);
+    assert_eq!(element.offset(), Offset::Offset(42));
+}
+
+#[test]
+fn exact_offset_construction_rejects_invalid_values() {
+    assert!(matches!(
+        build_partition_offset_list("events", 3, -1),
+        Err(KafkaError::SetPartitionOffset(
+            RDKafkaErrorCode::InvalidArgument
+        ))
+    ));
+    assert!(matches!(
+        build_partition_offset_list("events", -1, 1),
+        Err(KafkaError::Subscription(_))
+    ));
+    assert!(matches!(
+        build_partition_offset_list("", 0, 1),
+        Err(KafkaError::Subscription(_))
+    ));
+    assert!(matches!(
+        build_partition_offset_list("invalid\0topic", 0, 1),
+        Err(KafkaError::Nul(_))
+    ));
+    assert!(matches!(
+        next_offset(-1),
+        Err(KafkaError::SetPartitionOffset(
+            RDKafkaErrorCode::InvalidArgument
+        ))
+    ));
+}
+
+#[test]
+fn completed_offset_conversion_checks_the_i64_boundary() {
+    assert_eq!(next_offset(i64::MAX - 1).unwrap(), i64::MAX);
+    assert!(build_partition_offset_list("events", 0, i64::MAX).is_ok());
+    assert!(matches!(
+        next_offset(i64::MAX),
+        Err(KafkaError::SetPartitionOffset(
+            RDKafkaErrorCode::InvalidArgument
+        ))
+    ));
+}
+
+#[derive(Clone, Copy)]
+enum AssignmentFailure {
+    None,
+    Assignment,
+    Pause,
+    Resume,
+}
+
+struct FakeAssignmentControl {
+    assignment: TopicPartitionList,
+    failure: AssignmentFailure,
+    paused: Mutex<Option<TopicPartitionList>>,
+    resumed: Mutex<Option<TopicPartitionList>>,
+}
+
+impl FakeAssignmentControl {
+    fn new(assignment: TopicPartitionList, failure: AssignmentFailure) -> Self {
+        Self {
+            assignment,
+            failure,
+            paused: Mutex::new(None),
+            resumed: Mutex::new(None),
+        }
+    }
+}
+
+impl AssignmentControl for FakeAssignmentControl {
+    fn assignment(&self) -> KafkaResult<TopicPartitionList> {
+        if matches!(self.failure, AssignmentFailure::Assignment) {
+            return Err(KafkaError::Subscription("assignment failed".to_string()));
+        }
+        Ok(self.assignment.clone())
+    }
+
+    fn pause(&self, partitions: &TopicPartitionList) -> KafkaResult<()> {
+        if matches!(self.failure, AssignmentFailure::Pause) {
+            return Err(KafkaError::PauseResume("pause failed".to_string()));
+        }
+        *lock_unpoisoned(&self.paused) = Some(partitions.clone());
+        Ok(())
+    }
+
+    fn resume(&self, partitions: &TopicPartitionList) -> KafkaResult<()> {
+        if matches!(self.failure, AssignmentFailure::Resume) {
+            return Err(KafkaError::PauseResume("resume failed".to_string()));
+        }
+        *lock_unpoisoned(&self.resumed) = Some(partitions.clone());
+        Ok(())
+    }
+}
+
+#[test]
+fn pause_and_resume_use_offset_free_copies_of_the_current_assignment() {
+    let mut assignment = TopicPartitionList::new();
+    assignment
+        .add_partition_offset("events", 2, Offset::Offset(17))
+        .unwrap();
+    let consumer = FakeAssignmentControl::new(assignment, AssignmentFailure::None);
+
+    pause_consumer_assignment(&consumer).unwrap();
+    resume_consumer_assignment(&consumer).unwrap();
+
+    let paused = lock_unpoisoned(&consumer.paused);
+    let paused = paused.as_ref().unwrap();
+    let resumed = lock_unpoisoned(&consumer.resumed);
+    let resumed = resumed.as_ref().unwrap();
+    assert_eq!(paused.count(), 1);
+    assert_eq!(paused.elements()[0].offset(), Offset::Invalid);
+    assert_eq!(resumed.count(), 1);
+    assert_eq!(resumed.elements()[0].offset(), Offset::Invalid);
+}
+
+#[test]
+fn pause_and_resume_propagate_assignment_and_operation_failures() {
+    let assignment_failure = FakeAssignmentControl::new(
+        topic_partition_list(&[("events", 0)]),
+        AssignmentFailure::Assignment,
+    );
+    let pause_failure = FakeAssignmentControl::new(
+        topic_partition_list(&[("events", 0)]),
+        AssignmentFailure::Pause,
+    );
+    let resume_failure = FakeAssignmentControl::new(
+        topic_partition_list(&[("events", 0)]),
+        AssignmentFailure::Resume,
+    );
+
+    assert!(matches!(
+        pause_consumer_assignment(&assignment_failure),
+        Err(KafkaError::Subscription(_))
+    ));
+    assert!(matches!(
+        pause_consumer_assignment(&pause_failure),
+        Err(KafkaError::PauseResume(_))
+    ));
+    assert!(matches!(
+        resume_consumer_assignment(&resume_failure),
+        Err(KafkaError::PauseResume(_))
+    ));
+}
+
+#[test]
+fn cooperative_rebalances_track_incremental_assignments_and_revocations() {
+    let tracker = RebalanceTracker::new();
+    let mut events = tracker.take_events().unwrap();
+    let initial = topic_partition_list(&[("events", 0), ("events", 1)]);
+    tracker.observe_post_rebalance(&Rebalance::Assign(&initial));
+    let initial_assignments = tracker.current_assignments();
+    let retained_epoch = find_assignment(&initial_assignments, "events", 1).epoch;
+    let revoked_epoch = find_assignment(&initial_assignments, "events", 0).epoch;
+
+    let incremental_assignment = topic_partition_list(&[("events", 2)]);
+    tracker.observe_post_rebalance(&Rebalance::Assign(&incremental_assignment));
+    let incremental_revocation = topic_partition_list(&[("events", 0)]);
+    tracker.observe_pre_rebalance(&Rebalance::Revoke(&incremental_revocation));
+
+    assert!(matches!(
+        events.try_recv().unwrap(),
+        RebalanceEvent::Assigned(assignments) if assignments.len() == 2
+    ));
+    assert!(matches!(
+        events.try_recv().unwrap(),
+        RebalanceEvent::Assigned(assignments)
+            if assignments.len() == 1
+                && assignments[0].topic_partition.partition == 2
+    ));
+    assert!(matches!(
+        events.try_recv().unwrap(),
+        RebalanceEvent::Revoked(assignments)
+            if assignments.len() == 1
+                && assignments[0].topic_partition.partition == 0
+                && assignments[0].epoch > revoked_epoch
+    ));
+
+    let current = tracker.current_assignments();
+    assert_eq!(current.len(), 2);
+    assert_eq!(find_assignment(&current, "events", 1).epoch, retained_epoch);
+    assert!(find_assignment(&current, "events", 2).epoch.value() > 0);
+    assert!(!tracker.is_current_assignment("events", 0, revoked_epoch));
+}
+
+#[test]
+fn full_assignment_revocation_fences_every_partition() {
+    let tracker = RebalanceTracker::new();
+    let mut events = tracker.take_events().unwrap();
+    let assignment = topic_partition_list(&[("events", 0), ("events", 1)]);
+    tracker.observe_post_rebalance(&Rebalance::Assign(&assignment));
+    let old_assignments = tracker.current_assignments();
+
+    tracker.observe_pre_rebalance(&Rebalance::Revoke(&assignment));
+
+    let _ = events.try_recv().unwrap();
+    let RebalanceEvent::Revoked(revoked) = events.try_recv().unwrap() else {
+        panic!("expected full revocation event");
+    };
+    assert_eq!(revoked.len(), 2);
+    assert!(tracker.current_assignments().is_empty());
+    for assignment in old_assignments {
+        assert!(!tracker.is_current_assignment(
+            &assignment.topic_partition.topic,
+            assignment.topic_partition.partition,
+            assignment.epoch,
+        ));
+    }
+}
+
+#[test]
+fn same_partition_reassignment_receives_a_new_epoch() {
+    let tracker = RebalanceTracker::new();
+    let assignment = topic_partition_list(&[("events", 0)]);
+    tracker.observe_post_rebalance(&Rebalance::Assign(&assignment));
+    let first_epoch = tracker.current_assignments()[0].epoch;
+
+    tracker.observe_pre_rebalance(&Rebalance::Revoke(&assignment));
+    assert!(!tracker.is_current_assignment("events", 0, first_epoch));
+    tracker.observe_post_rebalance(&Rebalance::Assign(&assignment));
+
+    let second_epoch = tracker.current_assignments()[0].epoch;
+    assert!(second_epoch > first_epoch);
+    assert!(tracker.is_current_assignment("events", 0, second_epoch));
+    assert!(!tracker.is_current_assignment("events", 0, first_epoch));
+}
+
+#[test]
+fn plaintext_and_msk_contexts_forward_rebalance_callbacks() {
+    let assignment = topic_partition_list(&[("events", 0)]);
+
+    let plaintext_tracker = RebalanceTracker::new();
+    let mut plaintext_events = plaintext_tracker.take_events().unwrap();
+    let plaintext = PlaintextConsumerContext::with_rebalance_tracker(plaintext_tracker);
+    plaintext.observe_post_rebalance(&Rebalance::Assign(&assignment));
+    plaintext.observe_pre_rebalance(&Rebalance::Revoke(&assignment));
+    assert!(matches!(
+        plaintext_events.try_recv().unwrap(),
+        RebalanceEvent::Assigned(_)
+    ));
+    assert!(matches!(
+        plaintext_events.try_recv().unwrap(),
+        RebalanceEvent::Revoked(_)
+    ));
+
+    let msk_tracker = RebalanceTracker::new();
+    let mut msk_events = msk_tracker.take_events().unwrap();
+    let msk = MskIamClientContext::from_env_with_rebalance_tracker(msk_tracker);
+    msk.observe_post_rebalance(&Rebalance::Assign(&assignment));
+    msk.observe_pre_rebalance(&Rebalance::Revoke(&assignment));
+    assert!(matches!(
+        msk_events.try_recv().unwrap(),
+        RebalanceEvent::Assigned(_)
+    ));
+    assert!(matches!(
+        msk_events.try_recv().unwrap(),
+        RebalanceEvent::Revoked(_)
+    ));
+}
+
+#[tokio::test]
+async fn existing_and_cooperative_constructors_select_rebalance_observation_without_a_broker() {
+    let existing = KafkaEventConsumer::<TestConsumerGroup>::from_env("localhost:1").unwrap();
+    let cooperative = KafkaEventConsumer::<TestConsumerGroup>::from_env_with_max_poll_interval(
+        "localhost:1",
+        Duration::from_secs(60),
+    )
+    .unwrap();
+
+    assert!(existing.rebalance_tracker().is_none());
+    assert!(cooperative.rebalance_tracker().is_some());
+}
+
+#[test]
+fn existing_contexts_without_a_tracker_ignore_rebalances() {
+    let assignment = topic_partition_list(&[("events", 0)]);
+    let plaintext = PlaintextConsumerContext::default();
+    let msk = MskIamClientContext::from_env();
+
+    plaintext.observe_post_rebalance(&Rebalance::Assign(&assignment));
+    plaintext.observe_pre_rebalance(&Rebalance::Revoke(&assignment));
+    msk.observe_post_rebalance(&Rebalance::Assign(&assignment));
+    msk.observe_pre_rebalance(&Rebalance::Revoke(&assignment));
+
+    assert!(plaintext.rebalance_tracker.is_none());
+    assert!(!msk.has_rebalance_tracker());
 }

--- a/crates/macro_event_broker/src/lib.rs
+++ b/crates/macro_event_broker/src/lib.rs
@@ -31,7 +31,12 @@ pub use domain::service::{
 };
 #[cfg(feature = "outbound")]
 pub use outbound::{
-    kafka_event_consumer::KafkaConsumerAdapter, kafka_event_publisher::KafkaEventPublisher,
+    kafka_event_consumer::KafkaConsumerAdapter,
+    kafka_event_publisher::KafkaEventPublisher,
+    parallel_event_consumer::{
+        DROP_LOG_MESSAGE, DeliveryDecision, DeliveryError, DeliveryPolicy, Handler,
+        ParallelEventConsumerError, UniformBoundedRetry, run_parallel_event_consumer,
+    },
     spawner::GlobalSpawner,
 };
 

--- a/crates/macro_event_broker/src/outbound/kafka_event_consumer.rs
+++ b/crates/macro_event_broker/src/outbound/kafka_event_consumer.rs
@@ -103,6 +103,10 @@ impl<T: GroupName, M> KafkaConsumerAdapter<T, M> {
     pub fn rebalance_tracker(&self) -> Option<RebalanceTracker> {
         self.inner.rebalance_tracker()
     }
+
+    pub(crate) fn into_inner(self) -> KafkaEventConsumer<T> {
+        self.inner
+    }
 }
 
 impl<T, M: MacroEventCollection> KafkaConsumerAdapter<T, M> {

--- a/crates/macro_event_broker/src/outbound/kafka_event_consumer.rs
+++ b/crates/macro_event_broker/src/outbound/kafka_event_consumer.rs
@@ -3,7 +3,7 @@
 
 use std::{marker::PhantomData, time::Duration};
 
-use kafka_util::{GroupName, InitialOffset, KafkaEventConsumer, Ungrouped};
+use kafka_util::{GroupName, InitialOffset, KafkaEventConsumer, RebalanceTracker, Ungrouped};
 use rdkafka::{
     consumer::CommitMode,
     message::{BorrowedMessage, Message as _},
@@ -74,6 +74,34 @@ impl<T: GroupName, M> KafkaConsumerAdapter<T, M> {
         mode: CommitMode,
     ) -> Result<(), rootcause::Report> {
         Ok(self.inner.commit_message(message, mode)?)
+    }
+
+    /// Commits a caller-provided next offset for one topic-partition.
+    pub fn commit_partition_offset(
+        &self,
+        topic: &str,
+        partition: i32,
+        next_offset: i64,
+        mode: CommitMode,
+    ) -> Result<(), rootcause::Report> {
+        Ok(self
+            .inner
+            .commit_partition_offset(topic, partition, next_offset, mode)?)
+    }
+
+    /// Pauses every partition in the consumer's current assignment.
+    pub fn pause_current_assignment(&self) -> Result<(), rootcause::Report> {
+        Ok(self.inner.pause_current_assignment()?)
+    }
+
+    /// Resumes every partition in the consumer's current assignment.
+    pub fn resume_current_assignment(&self) -> Result<(), rootcause::Report> {
+        Ok(self.inner.resume_current_assignment()?)
+    }
+
+    /// Returns the cooperative consumer's rebalance tracker, when enabled.
+    pub fn rebalance_tracker(&self) -> Option<RebalanceTracker> {
+        self.inner.rebalance_tracker()
     }
 }
 

--- a/crates/macro_event_broker/src/outbound/kafka_event_consumer/test.rs
+++ b/crates/macro_event_broker/src/outbound/kafka_event_consumer/test.rs
@@ -1,4 +1,4 @@
-use kafka_util::Ungrouped;
+use kafka_util::{GroupName, Ungrouped};
 
 use super::*;
 use crate::{EventBrokerError, MessageParts};
@@ -15,9 +15,27 @@ impl MacroEventCollection for TestEvents {
     }
 }
 
+struct TestConsumerGroup;
+
+impl GroupName for TestConsumerGroup {
+    const GROUP_NAME: &'static str = "test-consumer-group";
+}
+
 fn assert_event_consumer<T: EventConsumer<TestEvents>>() {}
 
 #[test]
 fn kafka_adapter_implements_event_consumer_port() {
     assert_event_consumer::<KafkaConsumerAdapter<Ungrouped, TestEvents>>();
+}
+
+#[test]
+fn grouped_adapter_exposes_parallel_transport_primitives() {
+    let assertion = |adapter: &KafkaConsumerAdapter<TestConsumerGroup, TestEvents>| {
+        let _ = adapter.commit_partition_offset("events", 0, 1, CommitMode::Async);
+        let _ = adapter.pause_current_assignment();
+        let _ = adapter.resume_current_assignment();
+        let _ = adapter.rebalance_tracker();
+    };
+
+    let _ = assertion;
 }

--- a/crates/macro_event_broker/src/outbound/mod.rs
+++ b/crates/macro_event_broker/src/outbound/mod.rs
@@ -4,6 +4,9 @@ pub mod kafka_event_consumer;
 /// Kafka adapter implementing the [`EventPublisher`](crate::domain::ports::EventPublisher) port.
 #[cfg(feature = "outbound")]
 pub mod kafka_event_publisher;
+/// Typed bounded-parallel Kafka event handler and delivery-policy adapter.
+#[cfg(feature = "outbound")]
+pub mod parallel_event_consumer;
 /// Tokio adapters implementing the [`Spawner`](crate::domain::ports::Spawner) port.
 #[cfg(feature = "outbound")]
 pub mod spawner;

--- a/crates/macro_event_broker/src/outbound/parallel_event_consumer.rs
+++ b/crates/macro_event_broker/src/outbound/parallel_event_consumer.rs
@@ -1,0 +1,364 @@
+//! Typed bounded-parallel Kafka event consumption.
+//!
+//! This adapter decodes a declared [`MacroEventCollection`], invokes a typed
+//! [`Handler`], and applies a [`DeliveryPolicy`] before reporting a record as
+//! commit-safe to `kafka_util`'s message-agnostic coordinator. Attempt timeouts
+//! begin only after the coordinator starts the record in a processing slot;
+//! backoff and time spent waiting for a slot are outside those timeouts.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use std::convert::Infallible;
+//! use std::time::Duration;
+//!
+//! use kafka_util::GroupName;
+//! use kafka_util::parallel::ParallelConsumerConfig;
+//! use macro_event_broker::{
+//!     EventBrokerError, Handler, MacroEventCollection, MessageParts, UniformBoundedRetry,
+//!     run_parallel_event_consumer,
+//! };
+//!
+//! struct ConsumerGroup;
+//!
+//! impl GroupName for ConsumerGroup {
+//!     const GROUP_NAME: &'static str = "example-parallel-consumer";
+//! }
+//!
+//! struct Events;
+//!
+//! impl MacroEventCollection for Events {
+//!     fn decode<T: MessageParts>(_message: &T) -> Result<Self, EventBrokerError> {
+//!         Ok(Self)
+//!     }
+//!
+//!     fn topics() -> &'static [&'static str] {
+//!         &["example.events"]
+//!     }
+//! }
+//!
+//! struct EventHandler;
+//!
+//! impl Handler<Events> for EventHandler {
+//!     type Error = Infallible;
+//!
+//!     async fn handle(&self, _event: Events) -> Result<(), Self::Error> {
+//!         Ok(())
+//!     }
+//! }
+//!
+//! # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+//! let parallel = ParallelConsumerConfig::new(16, 64)?;
+//! run_parallel_event_consumer::<ConsumerGroup, Events, _, _>(
+//!     "localhost:9092",
+//!     Duration::from_secs(300),
+//!     parallel,
+//!     EventHandler,
+//!     UniformBoundedRetry::default(),
+//! )
+//! .await?;
+//! # Ok(())
+//! # }
+//! ```
+
+#[cfg(test)]
+mod test;
+
+use std::fmt::Debug;
+use std::sync::Arc;
+use std::time::Duration;
+
+use kafka_util::parallel::{ParallelConsumerConfig, ParallelConsumerError, run_parallel_consumer};
+use kafka_util::{GroupName, KafkaConsumerError, KafkaEventConsumer};
+use rdkafka::consumer::CommitMode;
+use rdkafka::message::{Message as _, OwnedMessage};
+
+use super::kafka_event_consumer::KafkaConsumerAdapter;
+use crate::{EventBrokerError, MacroEventCollection, MessageParts};
+
+const DEFAULT_MAX_ATTEMPTS: usize = 5;
+const DEFAULT_BASE_BACKOFF: Duration = Duration::from_secs(1);
+const DEFAULT_PER_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(300);
+const UNKNOWN_MESSAGE_FIELD: &str = "unknown";
+const MAX_BACKOFF_DOUBLINGS: usize = 128;
+
+/// Stable log message emitted when a delivery policy drops an event.
+///
+/// Consumer runbooks and log queries match this exact text. Changing it is a
+/// breaking operational change, even when the Rust API remains compatible.
+pub const DROP_LOG_MESSAGE: &str = "dropping event after exhausting delivery attempts";
+
+/// Handles one decoded event from a declared [`MacroEventCollection`].
+///
+/// Returning `Ok(())` marks the attempt successful and commit-safe. This
+/// includes both processed events and events the application intentionally
+/// ignores. Returning an error delegates the delivery decision to the
+/// configured [`DeliveryPolicy`].
+pub trait Handler<M: MacroEventCollection>: Send + Sync + 'static {
+    /// Error returned when an event attempt fails.
+    type Error: Debug + Send + Sync + 'static;
+
+    /// Processes one decoded event.
+    fn handle(&self, event: M) -> impl Future<Output = Result<(), Self::Error>> + Send;
+}
+
+/// Failure produced by one event delivery attempt.
+#[derive(Debug, thiserror::Error)]
+pub enum DeliveryError<E: Debug> {
+    /// The broker payload could not be decoded as the declared event collection.
+    #[error("failed to decode the declared event: {0}")]
+    Decode(#[source] EventBrokerError),
+    /// The application handler returned an error.
+    #[error("event handler failed: {0:?}")]
+    Handler(E),
+    /// The attempt exceeded its policy-provided timeout.
+    #[error("event delivery attempt timed out after {timeout:?}")]
+    Timeout {
+        /// Timeout applied to this attempt.
+        timeout: Duration,
+    },
+}
+
+/// Decision made by a [`DeliveryPolicy`] after an attempt fails.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DeliveryDecision {
+    /// Retry after the supplied delay.
+    Retry(Duration),
+    /// Drop the record and allow its offset to commit.
+    Drop,
+    /// Terminate the consumer without committing the failed record.
+    Fatal,
+}
+
+/// Selects timeout, retry, drop, and fatal behavior for failed attempts.
+///
+/// `attempt` passed to [`Self::decide`] is one-based: the initial attempt is
+/// `1`, the first retry is `2`, and so on. Decode, handler, and timeout errors
+/// all pass through this same policy boundary.
+pub trait DeliveryPolicy<E: Debug>: Send + Sync + 'static {
+    /// Returns the timeout applied independently to every attempt.
+    fn per_attempt_timeout(&self) -> Duration;
+
+    /// Decides what to do after the numbered attempt returned `error`.
+    fn decide(&self, attempt: usize, error: &DeliveryError<E>) -> DeliveryDecision;
+}
+
+/// Uniform bounded retry with exponential backoff and commit-safe exhaustion.
+///
+/// The default performs five total attempts, waits 1, 2, 4, then 8 seconds
+/// between them, gives every attempt a fresh 300-second timeout, and drops the
+/// event after the fifth failure. There is no deadline over the full lifecycle.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct UniformBoundedRetry {
+    /// Maximum total attempts, including the initial attempt.
+    ///
+    /// A value of zero still permits the unavoidable initial attempt and drops
+    /// its failure immediately.
+    pub max_attempts: usize,
+    /// Delay before the first retry. Each later retry doubles this delay.
+    pub base_backoff: Duration,
+    /// Timeout applied freshly when each individual attempt begins.
+    pub per_attempt_timeout: Duration,
+}
+
+impl UniformBoundedRetry {
+    fn retry_delay(self, attempt: usize) -> Duration {
+        if self.base_backoff.is_zero() {
+            return Duration::ZERO;
+        }
+
+        let doublings = attempt.saturating_sub(1).min(MAX_BACKOFF_DOUBLINGS);
+        let mut delay = self.base_backoff;
+        for _ in 0..doublings {
+            delay = delay.saturating_mul(2);
+        }
+        delay
+    }
+}
+
+impl Default for UniformBoundedRetry {
+    fn default() -> Self {
+        Self {
+            max_attempts: DEFAULT_MAX_ATTEMPTS,
+            base_backoff: DEFAULT_BASE_BACKOFF,
+            per_attempt_timeout: DEFAULT_PER_ATTEMPT_TIMEOUT,
+        }
+    }
+}
+
+impl<E: Debug> DeliveryPolicy<E> for UniformBoundedRetry {
+    fn per_attempt_timeout(&self) -> Duration {
+        self.per_attempt_timeout
+    }
+
+    fn decide(&self, attempt: usize, _error: &DeliveryError<E>) -> DeliveryDecision {
+        if attempt >= self.max_attempts.max(1) {
+            DeliveryDecision::Drop
+        } else {
+            DeliveryDecision::Retry(self.retry_delay(attempt))
+        }
+    }
+}
+
+/// Failure while constructing, subscribing, or running a typed parallel consumer.
+#[derive(Debug, thiserror::Error)]
+pub enum ParallelEventConsumerError<E: Debug> {
+    /// The environment-aware cooperative Kafka consumer could not be created.
+    #[error("failed to create the parallel Kafka event consumer")]
+    ConsumerCreation(#[source] KafkaConsumerError),
+    /// Kafka rejected the declared event-topic subscription.
+    #[error("failed to subscribe the parallel Kafka event consumer: {0:?}")]
+    Subscription(rootcause::Report),
+    /// The message-agnostic coordinator terminated fatally.
+    #[error("parallel Kafka event consumption terminated")]
+    Consumption(#[source] ParallelConsumerError<DeliveryError<E>>),
+}
+
+/// Creates and runs a typed bounded-parallel Kafka consumer.
+///
+/// This is the composition entry point intended for a service's `main`: it
+/// creates the cooperative max-poll consumer, subscribes through
+/// [`KafkaConsumerAdapter`] to exactly `M::topics()`, and runs the bounded
+/// coordinator. Successful handling and policy drops are commit-safe. A
+/// [`DeliveryDecision::Fatal`] stops the coordinator without committing the
+/// failed record. Offset commits are submitted asynchronously.
+///
+/// `max_poll_interval` configures librdkafka's group-liveness limit; it is not
+/// an event processing deadline. The coordinator continues polling while
+/// records are queued, handled, or waiting in retry backoff.
+pub async fn run_parallel_event_consumer<G, M, H, P>(
+    brokers: &str,
+    max_poll_interval: Duration,
+    parallel_config: ParallelConsumerConfig,
+    handler: H,
+    policy: P,
+) -> Result<(), ParallelEventConsumerError<H::Error>>
+where
+    G: GroupName,
+    M: MacroEventCollection + Send + 'static,
+    H: Handler<M>,
+    P: DeliveryPolicy<H::Error>,
+{
+    let consumer =
+        KafkaEventConsumer::<G>::from_env_with_max_poll_interval(brokers, max_poll_interval)
+            .map_err(ParallelEventConsumerError::ConsumerCreation)?;
+    let consumer = KafkaConsumerAdapter::<G, ()>::new(consumer)
+        .subscribe::<M>()
+        .map_err(ParallelEventConsumerError::Subscription)?
+        .into_inner();
+
+    let handler = Arc::new(handler);
+    let policy = Arc::new(policy);
+    run_parallel_consumer(
+        consumer,
+        parallel_config,
+        CommitMode::Async,
+        move |message| {
+            process_message::<M, H, P>(message, Arc::clone(&handler), Arc::clone(&policy))
+        },
+    )
+    .await
+    .map_err(ParallelEventConsumerError::Consumption)
+}
+
+async fn process_message<M, H, P>(
+    message: OwnedMessage,
+    handler: Arc<H>,
+    policy: Arc<P>,
+) -> Result<(), DeliveryError<H::Error>>
+where
+    M: MacroEventCollection + Send + 'static,
+    H: Handler<M>,
+    P: DeliveryPolicy<H::Error>,
+{
+    let metadata = DeliveryMetadata::from_message(&message);
+    let mut attempt = 1usize;
+
+    loop {
+        let timeout = policy.per_attempt_timeout();
+        let result = tokio::time::timeout(timeout, deliver_once::<M, H>(&message, &handler)).await;
+        let error = match result {
+            Ok(Ok(())) => return Ok(()),
+            Ok(Err(error)) => error,
+            Err(_) => DeliveryError::Timeout { timeout },
+        };
+
+        match policy.decide(attempt, &error) {
+            DeliveryDecision::Retry(delay) => {
+                let Some(next_attempt) = attempt.checked_add(1) else {
+                    return Err(error);
+                };
+                tokio::time::sleep(delay).await;
+                attempt = next_attempt;
+            }
+            DeliveryDecision::Drop => {
+                log_dropped_event(&metadata, attempt, &error);
+                return Ok(());
+            }
+            DeliveryDecision::Fatal => return Err(error),
+        }
+    }
+}
+
+async fn deliver_once<M, H>(
+    message: &OwnedMessage,
+    handler: &H,
+) -> Result<(), DeliveryError<H::Error>>
+where
+    M: MacroEventCollection + Send + 'static,
+    H: Handler<M>,
+{
+    let event = M::decode(message).map_err(DeliveryError::Decode)?;
+    handler.handle(event).await.map_err(DeliveryError::Handler)
+}
+
+fn log_dropped_event<E: Debug>(
+    metadata: &DeliveryMetadata,
+    attempts: usize,
+    error: &DeliveryError<E>,
+) {
+    tracing::error!(
+        attempts,
+        event_type = %metadata.event_type,
+        key = %metadata.key,
+        topic = %metadata.topic,
+        partition = metadata.partition,
+        offset = metadata.offset,
+        error = ?error,
+        "{}",
+        DROP_LOG_MESSAGE,
+    );
+}
+
+struct DeliveryMetadata {
+    event_type: String,
+    key: String,
+    topic: String,
+    partition: i32,
+    offset: i64,
+}
+
+impl DeliveryMetadata {
+    fn from_message(message: &OwnedMessage) -> Self {
+        Self {
+            event_type: extract_event_type(MessageParts::payload(message)),
+            key: MessageParts::key(message)
+                .unwrap_or(UNKNOWN_MESSAGE_FIELD)
+                .to_owned(),
+            topic: MessageParts::topic(message).to_owned(),
+            partition: message.partition(),
+            offset: message.offset(),
+        }
+    }
+}
+
+fn extract_event_type(payload: Option<&[u8]>) -> String {
+    payload
+        .and_then(|payload| serde_json::from_slice::<serde_json::Value>(payload).ok())
+        .and_then(|json| {
+            json.get("event_type")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_owned)
+        })
+        .unwrap_or_else(|| UNKNOWN_MESSAGE_FIELD.to_owned())
+}

--- a/crates/macro_event_broker/src/outbound/parallel_event_consumer.rs
+++ b/crates/macro_event_broker/src/outbound/parallel_event_consumer.rs
@@ -94,6 +94,11 @@ pub const DROP_LOG_MESSAGE: &str = "dropping event after exhausting delivery att
 /// includes both processed events and events the application intentionally
 /// ignores. Returning an error delegates the delivery decision to the
 /// configured [`DeliveryPolicy`].
+///
+/// On partition revocation, in-flight handler futures are aborted and may be
+/// dropped at any await point. Handlers must therefore be idempotent for
+/// at-least-once redelivery and cancellation-safe partway through side effects;
+/// for example, avoid dangling manual two-phase state outside a transaction.
 pub trait Handler<M: MacroEventCollection>: Send + Sync + 'static {
     /// Error returned when an event attempt fails.
     type Error: Debug + Send + Sync + 'static;
@@ -145,9 +150,11 @@ pub trait DeliveryPolicy<E: Debug>: Send + Sync + 'static {
 
 /// Uniform bounded retry with exponential backoff and commit-safe exhaustion.
 ///
-/// The default performs five total attempts, waits 1, 2, 4, then 8 seconds
-/// between them, gives every attempt a fresh 300-second timeout, and drops the
-/// event after the fifth failure. There is no deadline over the full lifecycle.
+/// Decode failures are dropped after the initial attempt because retrying the
+/// same payload cannot succeed. For handler and timeout failures, the default
+/// performs five total attempts, waits 1, 2, 4, then 8 seconds between them,
+/// gives every attempt a fresh 300-second timeout, and drops the event after
+/// the fifth failure. There is no deadline over the full lifecycle.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct UniformBoundedRetry {
     /// Maximum total attempts, including the initial attempt.
@@ -191,8 +198,8 @@ impl<E: Debug> DeliveryPolicy<E> for UniformBoundedRetry {
         self.per_attempt_timeout
     }
 
-    fn decide(&self, attempt: usize, _error: &DeliveryError<E>) -> DeliveryDecision {
-        if attempt >= self.max_attempts.max(1) {
+    fn decide(&self, attempt: usize, error: &DeliveryError<E>) -> DeliveryDecision {
+        if matches!(error, DeliveryError::Decode(_)) || attempt >= self.max_attempts.max(1) {
             DeliveryDecision::Drop
         } else {
             DeliveryDecision::Retry(self.retry_delay(attempt))
@@ -222,6 +229,12 @@ pub enum ParallelEventConsumerError<E: Debug> {
 /// coordinator. Successful handling and policy drops are commit-safe. A
 /// [`DeliveryDecision::Fatal`] stops the coordinator without committing the
 /// failed record. Offset commits are submitted asynchronously.
+///
+/// A retrying record occupies one processing-concurrency slot for its entire
+/// attempt and backoff lifecycle. For a bounded policy, its worst-case slot
+/// occupancy is the per-attempt timeout multiplied by the number of attempts,
+/// plus total backoff. Prolonged records can fill all processing slots and then
+/// `max_outstanding`, so size parallel capacity and delivery policy together.
 ///
 /// `max_poll_interval` configures librdkafka's group-liveness limit; it is not
 /// an event processing deadline. The coordinator continues polling while

--- a/crates/macro_event_broker/src/outbound/parallel_event_consumer/test.rs
+++ b/crates/macro_event_broker/src/outbound/parallel_event_consumer/test.rs
@@ -174,7 +174,7 @@ fn elapsed_starts(starts: &Arc<Mutex<Vec<Instant>>>, initial: Instant) -> Vec<Du
 }
 
 #[test]
-fn uniform_bounded_retry_defaults_and_decisions_are_exact() {
+fn uniform_bounded_retry_defaults_and_handler_error_decisions_are_exact() {
     let policy = UniformBoundedRetry::default();
     assert_eq!(policy.max_attempts, 5);
     assert_eq!(policy.base_backoff, Duration::from_secs(1));
@@ -197,7 +197,7 @@ fn uniform_bounded_retry_defaults_and_decisions_are_exact() {
 }
 
 #[tokio::test(start_paused = true)]
-async fn default_policy_runs_five_attempts_with_doubling_backoff_and_no_extra_attempt() {
+async fn default_policy_retries_handler_errors_with_bounded_doubling_backoff() {
     let initial = Instant::now();
     let (handler, starts) = TimedHandler::new(Duration::ZERO, None);
 
@@ -273,7 +273,30 @@ async fn timeout_does_not_start_before_the_processing_future_is_polled() {
 }
 
 #[tokio::test(start_paused = true)]
-async fn decode_failures_use_the_same_delivery_policy_as_handler_failures() {
+async fn default_policy_drops_decode_failures_on_the_first_attempt() {
+    let subscriber = CaptureSubscriber::default();
+    let events = Arc::clone(&subscriber.events);
+    let malformed_event = message(br#"{"event_type":"example.test"}"#.to_vec());
+
+    let result = {
+        let _guard = tracing::subscriber::set_default(subscriber);
+        process_message::<TestEvents, _, _>(
+            malformed_event,
+            Arc::new(PanicHandler),
+            Arc::new(UniformBoundedRetry::default()),
+        )
+        .await
+    };
+
+    assert!(result.is_ok(), "a decode failure is dropped commit-safe");
+    let events = events.lock().unwrap();
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].fields.get("attempts").unwrap(), "1");
+    assert!(events[0].fields.get("error").unwrap().contains("Decode"));
+}
+
+#[tokio::test(start_paused = true)]
+async fn custom_policy_can_retry_decode_failures() {
     let policy = RecordingPolicy::new(DeliveryDecision::Drop);
     let decisions = Arc::clone(&policy.decisions);
     let malformed_event = message(br#"{"event_type":"example.test"}"#.to_vec());

--- a/crates/macro_event_broker/src/outbound/parallel_event_consumer/test.rs
+++ b/crates/macro_event_broker/src/outbound/parallel_event_consumer/test.rs
@@ -1,0 +1,452 @@
+use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+
+use macro_event_topics::{MacroExampleTopic, Topic};
+use rdkafka::Timestamp;
+use serde::{Deserialize, Serialize};
+use tokio::time::Instant;
+use tracing::field::{Field, Visit};
+use tracing::span::{Attributes, Id, Record};
+use tracing::{Event as TracingEvent, Metadata, Subscriber};
+use uuid::Uuid;
+
+use super::*;
+use crate::{Event, MacroEvent, TopicEvent};
+
+const TOPIC: &str = MacroExampleTopic::TOPIC_STR;
+const KEY: &str = "event-key";
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "event_type", content = "metadata")]
+pub(super) enum TestTopicEvent {
+    #[serde(rename = "example.test")]
+    Test,
+}
+
+impl TopicEvent for TestTopicEvent {
+    type Topic = MacroExampleTopic;
+
+    const SCHEMA_VERSION: u8 = 1;
+}
+
+pub(super) struct TestMacroEvent {
+    key: String,
+    event: Event<TestTopicEvent>,
+}
+
+impl MacroEvent for TestMacroEvent {
+    type EventPayload = TestTopicEvent;
+
+    fn key(&self) -> &str {
+        &self.key
+    }
+
+    fn event(&self) -> &Event<Self::EventPayload> {
+        &self.event
+    }
+
+    fn from_event(key: String, event: Event<Self::EventPayload>) -> Self {
+        Self { key, event }
+    }
+}
+
+crate::declare_topics!(TestEvents: TestMacroEvent);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct TestError;
+
+struct TimedHandler {
+    starts: Arc<Mutex<Vec<Instant>>>,
+    duration: Duration,
+    succeeds_on: Option<usize>,
+}
+
+impl TimedHandler {
+    fn new(duration: Duration, succeeds_on: Option<usize>) -> (Self, Arc<Mutex<Vec<Instant>>>) {
+        let starts = Arc::new(Mutex::new(Vec::new()));
+        (
+            Self {
+                starts: Arc::clone(&starts),
+                duration,
+                succeeds_on,
+            },
+            starts,
+        )
+    }
+}
+
+impl Handler<TestEvents> for TimedHandler {
+    type Error = TestError;
+
+    fn handle(&self, event: TestEvents) -> impl Future<Output = Result<(), Self::Error>> + Send {
+        let TestEvents::TestMacroEvent(_event) = event;
+        let starts = Arc::clone(&self.starts);
+        let duration = self.duration;
+        let succeeds_on = self.succeeds_on;
+
+        async move {
+            let attempt = {
+                let mut starts = starts.lock().unwrap();
+                starts.push(Instant::now());
+                starts.len()
+            };
+            tokio::time::sleep(duration).await;
+            if succeeds_on == Some(attempt) {
+                Ok(())
+            } else {
+                Err(TestError)
+            }
+        }
+    }
+}
+
+struct PanicHandler;
+
+impl Handler<TestEvents> for PanicHandler {
+    type Error = TestError;
+
+    async fn handle(&self, _event: TestEvents) -> Result<(), Self::Error> {
+        panic!("decode failures must not invoke the handler")
+    }
+}
+
+#[derive(Clone)]
+struct RecordingPolicy {
+    decisions: Arc<Mutex<Vec<(usize, &'static str)>>>,
+    final_decision: DeliveryDecision,
+}
+
+impl RecordingPolicy {
+    fn new(final_decision: DeliveryDecision) -> Self {
+        Self {
+            decisions: Arc::new(Mutex::new(Vec::new())),
+            final_decision,
+        }
+    }
+}
+
+impl DeliveryPolicy<TestError> for RecordingPolicy {
+    fn per_attempt_timeout(&self) -> Duration {
+        Duration::from_secs(300)
+    }
+
+    fn decide(&self, attempt: usize, error: &DeliveryError<TestError>) -> DeliveryDecision {
+        let error_kind = match error {
+            DeliveryError::Decode(_) => "decode",
+            DeliveryError::Handler(_) => "handler",
+            DeliveryError::Timeout { .. } => "timeout",
+        };
+        self.decisions.lock().unwrap().push((attempt, error_kind));
+
+        if attempt == 1 && self.final_decision == DeliveryDecision::Drop {
+            DeliveryDecision::Retry(Duration::from_secs(1))
+        } else {
+            self.final_decision
+        }
+    }
+}
+
+fn message(payload: Vec<u8>) -> OwnedMessage {
+    OwnedMessage::new(
+        Some(payload),
+        Some(KEY.as_bytes().to_vec()),
+        TOPIC.to_owned(),
+        Timestamp::NotAvailable,
+        3,
+        42,
+        None,
+    )
+}
+
+fn valid_message() -> OwnedMessage {
+    let event = Event::with_event_id(Uuid::from_u128(1), TestTopicEvent::Test);
+    message(serde_json::to_vec(&event).unwrap())
+}
+
+fn elapsed_starts(starts: &Arc<Mutex<Vec<Instant>>>, initial: Instant) -> Vec<Duration> {
+    starts
+        .lock()
+        .unwrap()
+        .iter()
+        .map(|start| start.duration_since(initial))
+        .collect()
+}
+
+#[test]
+fn uniform_bounded_retry_defaults_and_decisions_are_exact() {
+    let policy = UniformBoundedRetry::default();
+    assert_eq!(policy.max_attempts, 5);
+    assert_eq!(policy.base_backoff, Duration::from_secs(1));
+    assert_eq!(policy.per_attempt_timeout, Duration::from_secs(300));
+
+    let error = DeliveryError::<TestError>::Handler(TestError);
+    let decisions = (1..=5)
+        .map(|attempt| policy.decide(attempt, &error))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        decisions,
+        vec![
+            DeliveryDecision::Retry(Duration::from_secs(1)),
+            DeliveryDecision::Retry(Duration::from_secs(2)),
+            DeliveryDecision::Retry(Duration::from_secs(4)),
+            DeliveryDecision::Retry(Duration::from_secs(8)),
+            DeliveryDecision::Drop,
+        ]
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn default_policy_runs_five_attempts_with_doubling_backoff_and_no_extra_attempt() {
+    let initial = Instant::now();
+    let (handler, starts) = TimedHandler::new(Duration::ZERO, None);
+
+    let result = process_message::<TestEvents, _, _>(
+        valid_message(),
+        Arc::new(handler),
+        Arc::new(UniformBoundedRetry::default()),
+    )
+    .await;
+
+    assert!(result.is_ok(), "exhaustion is commit-safe");
+    assert_eq!(
+        elapsed_starts(&starts, initial),
+        [0, 1, 3, 7, 15].map(Duration::from_secs)
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn four_nearly_timed_out_attempts_do_not_prevent_the_fifth_attempt() {
+    let initial = Instant::now();
+    let (handler, starts) = TimedHandler::new(Duration::from_secs(299), Some(5));
+
+    let result = process_message::<TestEvents, _, _>(
+        valid_message(),
+        Arc::new(handler),
+        Arc::new(UniformBoundedRetry::default()),
+    )
+    .await;
+
+    assert!(result.is_ok());
+    assert_eq!(
+        elapsed_starts(&starts, initial),
+        [0, 300, 601, 904, 1211].map(Duration::from_secs)
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn every_retry_receives_a_fresh_per_attempt_timeout() {
+    let initial = Instant::now();
+    let (handler, starts) = TimedHandler::new(Duration::from_secs(301), None);
+    let policy = UniformBoundedRetry {
+        max_attempts: 2,
+        base_backoff: Duration::from_secs(1),
+        per_attempt_timeout: Duration::from_secs(300),
+    };
+
+    let result =
+        process_message::<TestEvents, _, _>(valid_message(), Arc::new(handler), Arc::new(policy))
+            .await;
+
+    assert!(result.is_ok());
+    assert_eq!(
+        elapsed_starts(&starts, initial),
+        [0, 301].map(Duration::from_secs)
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn timeout_does_not_start_before_the_processing_future_is_polled() {
+    let (handler, starts) = TimedHandler::new(Duration::from_secs(299), Some(1));
+    let future = process_message::<TestEvents, _, _>(
+        valid_message(),
+        Arc::new(handler),
+        Arc::new(UniformBoundedRetry::default()),
+    );
+
+    tokio::time::advance(Duration::from_secs(1_000)).await;
+    let actual_start = Instant::now();
+    let result = future.await;
+
+    assert!(result.is_ok());
+    assert_eq!(starts.lock().unwrap().as_slice(), &[actual_start]);
+}
+
+#[tokio::test(start_paused = true)]
+async fn decode_failures_use_the_same_delivery_policy_as_handler_failures() {
+    let policy = RecordingPolicy::new(DeliveryDecision::Drop);
+    let decisions = Arc::clone(&policy.decisions);
+    let malformed_event = message(br#"{"event_type":"example.test"}"#.to_vec());
+
+    let result = process_message::<TestEvents, _, _>(
+        malformed_event,
+        Arc::new(PanicHandler),
+        Arc::new(policy),
+    )
+    .await;
+
+    assert!(result.is_ok());
+    assert_eq!(
+        decisions.lock().unwrap().as_slice(),
+        &[(1, "decode"), (2, "decode")]
+    );
+}
+
+#[test]
+fn malformed_payload_event_type_is_best_effort_with_unknown_fallback() {
+    assert_eq!(
+        extract_event_type(Some(br#"{"event_type":"example.test"}"#)),
+        "example.test"
+    );
+    assert_eq!(extract_event_type(Some(b"not-json")), "unknown");
+    assert_eq!(extract_event_type(Some(br#"{"event_type":4}"#)), "unknown");
+    assert_eq!(extract_event_type(None), "unknown");
+}
+
+#[tokio::test(start_paused = true)]
+async fn drop_is_commit_safe_and_processing_can_continue() {
+    let (failing_handler, _) = TimedHandler::new(Duration::ZERO, None);
+    let drop_policy = UniformBoundedRetry {
+        max_attempts: 1,
+        ..UniformBoundedRetry::default()
+    };
+    let dropped = process_message::<TestEvents, _, _>(
+        valid_message(),
+        Arc::new(failing_handler),
+        Arc::new(drop_policy),
+    )
+    .await;
+
+    let (successful_handler, starts) = TimedHandler::new(Duration::ZERO, Some(1));
+    let processed = process_message::<TestEvents, _, _>(
+        valid_message(),
+        Arc::new(successful_handler),
+        Arc::new(UniformBoundedRetry::default()),
+    )
+    .await;
+
+    assert!(dropped.is_ok(), "a policy drop must be commit-safe");
+    assert!(processed.is_ok(), "later processing must continue");
+    assert_eq!(starts.lock().unwrap().len(), 1);
+}
+
+#[tokio::test(start_paused = true)]
+async fn fatal_policy_returns_non_commit_safe_failure() {
+    let (handler, starts) = TimedHandler::new(Duration::ZERO, None);
+    let policy = RecordingPolicy::new(DeliveryDecision::Fatal);
+
+    let result =
+        process_message::<TestEvents, _, _>(valid_message(), Arc::new(handler), Arc::new(policy))
+            .await;
+
+    assert!(matches!(result, Err(DeliveryError::Handler(TestError))));
+    assert_eq!(starts.lock().unwrap().len(), 1);
+}
+
+#[test]
+fn declared_collection_supplies_the_exact_subscription_topics() {
+    assert_eq!(TestEvents::topics(), &[MacroExampleTopic::TOPIC_STR]);
+
+    fn assert_entrypoint<G, M, H, P>()
+    where
+        G: GroupName,
+        M: MacroEventCollection + Send + 'static,
+        H: Handler<M>,
+        P: DeliveryPolicy<H::Error>,
+    {
+        let _ = run_parallel_event_consumer::<G, M, H, P>;
+    }
+
+    struct TestGroup;
+    impl GroupName for TestGroup {
+        const GROUP_NAME: &'static str = "parallel-event-consumer-test";
+    }
+
+    assert_entrypoint::<TestGroup, TestEvents, PanicHandler, RecordingPolicy>();
+}
+
+#[derive(Clone, Debug, Default)]
+struct CaptureSubscriber {
+    events: Arc<Mutex<Vec<CapturedEvent>>>,
+    next_span_id: Arc<AtomicU64>,
+}
+
+#[derive(Clone, Debug, Default)]
+struct CapturedEvent {
+    fields: BTreeMap<String, String>,
+}
+
+impl Subscriber for CaptureSubscriber {
+    fn enabled(&self, _metadata: &Metadata<'_>) -> bool {
+        true
+    }
+
+    fn new_span(&self, _span: &Attributes<'_>) -> Id {
+        let id = self.next_span_id.fetch_add(1, Ordering::Relaxed) + 1;
+        Id::from_u64(id)
+    }
+
+    fn record(&self, _span: &Id, _values: &Record<'_>) {}
+
+    fn record_follows_from(&self, _span: &Id, _follows: &Id) {}
+
+    fn event(&self, event: &TracingEvent<'_>) {
+        let mut captured = CapturedEvent::default();
+        event.record(&mut FieldVisitor(&mut captured.fields));
+        self.events.lock().unwrap().push(captured);
+    }
+
+    fn enter(&self, _span: &Id) {}
+
+    fn exit(&self, _span: &Id) {}
+}
+
+struct FieldVisitor<'a>(&'a mut BTreeMap<String, String>);
+
+impl Visit for FieldVisitor<'_> {
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.0.insert(field.name().to_owned(), value.to_string());
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.0.insert(field.name().to_owned(), value.to_string());
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.0.insert(field.name().to_owned(), value.to_owned());
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn Debug) {
+        self.0.insert(field.name().to_owned(), format!("{value:?}"));
+    }
+}
+
+#[test]
+fn drop_log_has_stable_message_and_required_fields_exactly_once() {
+    let subscriber = CaptureSubscriber::default();
+    let events = Arc::clone(&subscriber.events);
+    let metadata = DeliveryMetadata {
+        event_type: "example.test".to_owned(),
+        key: KEY.to_owned(),
+        topic: TOPIC.to_owned(),
+        partition: 3,
+        offset: 42,
+    };
+    let error = DeliveryError::<TestError>::Handler(TestError);
+
+    tracing::subscriber::with_default(subscriber, || {
+        log_dropped_event(&metadata, 1, &error);
+    });
+
+    let events = events.lock().unwrap();
+    assert_eq!(events.len(), 1);
+    let fields = &events[0].fields;
+    assert_eq!(fields.get("message").unwrap(), DROP_LOG_MESSAGE);
+    assert_eq!(fields.get("attempts").unwrap(), "1");
+    assert_eq!(fields.get("event_type").unwrap(), "example.test");
+    assert_eq!(fields.get("key").unwrap(), KEY);
+    assert_eq!(fields.get("topic").unwrap(), TOPIC);
+    assert_eq!(fields.get("partition").unwrap(), "3");
+    assert_eq!(fields.get("offset").unwrap(), "42");
+    assert!(fields.get("error").unwrap().contains("Handler"));
+}


### PR DESCRIPTION
# Bounded-Parallel Kafka Consumer (`kafka_util::parallel` + typed `macro_event_broker` layer)

Every Kafka consumer in the repo today (webhook, soup, examples) is a sequential loop: `recv()` → decode → handle → `commit_message`. That can't serve `search_processing_service`, whose SQS path runs ~100 messages in flight with handlers that legitimately take minutes. This PR adds the parallel consumer as a **reusable library** so SPS — and later the documents/emails domains or any other service — wires it up with configuration and a handler only. It is the implementation of `.pi/plans/20260728-184412Z-implement-generic-bounded-parallel-kafka-consumer.md`; the SPS wiring + Calls cutover land separately via `.pi/plans/20260728-152800Z-read-spec-md-and-create-a-plan-to-implement-the.md` (see `spec.md` for the full SQS→Kafka migration reference).

**No existing consumer changes behavior.** All new capability is opt-in through new constructors and types; webhook/soup/examples keep their sequential loops and librdkafka's default eager assignment strategy.

## Architecture: two layers with a hard boundary

### 1. Message-agnostic coordinator core — `kafka_util::parallel` (new)

Owns delivery mechanics only. It never inspects keys or payloads and contains no retry/timeout logic. Callers hand it a `process(OwnedMessage) -> commit-safe | fatal` future via `run_parallel_consumer`, and it guarantees **offsets never advance past unfinished work**:

- **Two separate capacity limits** (`ParallelConsumerConfig::new(processing_concurrency, max_outstanding)`, validated nonzero and `outstanding ≥ concurrency`): a finished handler frees its execution slot immediately even when its offset is still waiting behind an earlier record, so commit head-of-line blocking never starves the worker pool.
- **FIFO start order, out-of-order completion**: work starts oldest-first (so potential commit blockers start first), but completions land in any order.
- **Receipt-order contiguous commits per partition**: the coordinator tracks receipt order per `(topic, partition)` — never `offset + 1` adjacency, since Kafka offset numbers can contain gaps (compaction, transactions) — and commits only the *next offset* after the highest contiguously completed receipt. Partitions commit independently: one partition's pending record never blocks another's completed prefix.
- **Saturation backpressure**: at `max_outstanding`, the assignment is paused while the `recv()`/poll future stays live, so group liveness never depends on processing duration. librdkafka's pause is asynchronous, so a message already surfaced into the stream can still arrive after pause is requested — that race is tolerated (accepted + `warn!`; the bound is a soft target). Only overshoot beyond `outstanding + concurrency` — impossible from the benign race — is a fatal transport-invariant error.
- **Cooperative-sticky rebalances with epoch fencing**: incremental revocations fence only the moved partitions (retained partitions keep processing uninterrupted); each `(partition, epoch)` is tracked via the new `RebalanceTracker`, so a stale completion from a revoked epoch can never commit into a new ownership generation — including the same-partition revoke-then-reassign case, where the broker alone wouldn't protect us. New assignments start fresh from the broker's last committed offset.
- **Commit-submission failure is fatal**: the coordinator returns an error without committing unfinished work; the supervisor restarts it and Kafka redelivers — idempotent replay is the designed failure mode (at-least-once).

Explicit non-goals (documented on the module): no per-key or per-partition processing-order guarantees, no retries. Consumers needing strict ordering should not use this coordinator.

### 2. Typed handler + delivery-policy layer — `macro_event_broker::outbound::parallel_event_consumer` (new)

Turns the core's raw boundary into what services actually want:

- **`Handler<M: MacroEventCollection>`** — receives decoded events, returns `Ok` (commit-safe; covers processed *and* intentionally-ignored events) or an error for the policy to judge.
- **`DeliveryPolicy`** — decides per attempt outcome: `Retry(delay)`, `Drop` (commit-safe), or `Fatal` (stop without committing). Policies are pluggable so future consumers (e.g. webhook-style bail-on-transient) don't touch the core.
- **`UniformBoundedRetry`** — the provided policy implementing the decided SPS behavior. Defaults: **5 total attempts** (initial + four retries), **1s doubling backoff** (1s → 2s → 4s → 8s), **fresh 300s timeout per attempt** (started only when the attempt begins — never while queued for a slot or during backoff; no deadline over the full lifecycle). Uniform across all failure categories — infrastructure outages are deliberately *not* special-cased (no indefinite-retry class; see "Operational notes"). One refinement: **decode failures drop on the first attempt** — deserialization is deterministic, so retrying it is pointless.
- **Stable drop-log contract** — exhausted events log `error!` with the exported constant `DROP_LOG_MESSAGE = "dropping event after exhausting delivery attempts"` plus `attempts`, `event_type` (best-effort extracted from malformed JSON, `unknown` fallback), `key`, `topic`, `partition`, `offset`, and `error` fields. Runbooks and CloudWatch Logs Insights queries match on this exact text — do not reword it.
- **`run_parallel_event_consumer::<Group, Events, _, _>(brokers, max_poll_interval, parallel_config, handler, policy)`** — the one-call composition entry point for a service's `main`. See the compile-tested doc example on the module.

## `kafka_util` primitive additions (supporting the above)

- `KafkaEventConsumer::<G>::from_env_with_max_poll_interval(brokers, Duration)` — new grouped constructor that sets `max.poll.interval.ms` (rejecting durations unrepresentable in librdkafka millis) and pins `partition.assignment.strategy=cooperative-sticky`, installing the `RebalanceTracker`. Existing constructors are untouched and stay eager. ⚠️ Migrating an *existing* eager group to this constructor requires the two-step strategy roll documented on the constructor (eager-only and cooperative-only members can't coexist in one group); brand-new groups like `search-processing` have no such concern.
- Exact partition-offset commits with a caller-selected `CommitMode`, plus the pure `next_offset()` helper (overflow-checked, preserving Kafka's next-offset convention).
- Assignment-wide pause/resume (previous API could only pause a single message's partition).
- `RebalanceTracker` / `RebalanceEvent` / `AssignmentEpoch` — synchronous, nonblocking fencing implemented via `pre_rebalance`/`post_rebalance` hooks only (never overriding `rebalance()` itself), so rust-rdkafka's default `incremental_assign`/`incremental_unassign` protocol handling stays correct. Wired through both the plaintext and `MskIamClientContext` (MSK IAM OAuth refresh untouched) transports.

## Operational notes

- **At-least-once everywhere**: crashes, rebalances, and commit failures all resolve to replay. Consumers built on this must keep handlers replay-safe (id-keyed, refetch-current-state) — the standing invariant from `spec.md`.
- **Drops are permanent and log-visible only** (decided): no DLQ topics, no lag alarms, no drop alarms. Detection is the `DROP_LOG_MESSAGE` line; recovery is the domain's HTTP backfill (or offset reset after a fixed bug). This trade was made explicitly — during an infra outage, events burn their attempts and are dropped rather than stalling the pipeline; the backfill is the recovery path.
- **Sizing caveat** (documented on `run_parallel_event_consumer`): a retrying record holds its processing slot for its whole attempt+backoff lifecycle (worst case ≈ attempts × per-attempt timeout + backoff), so size concurrency and policy together.
- **First-subscribe replay**: a group with no committed offsets replays a topic's full retention from earliest — accepted by decision (idempotent handlers; doubles as a backfill); never pre-seed offsets.

## Testing

Everything runs as ordinary `cargo test` — **no live broker, no wall-clock sleeps** (deterministic fake transport + paused Tokio time):

- `crates/kafka_util/src/parallel/test.rs` (~970 lines): concurrency caps and the exact two-of-N refill case, out-of-order completion never skipping an earlier receipt, offset gaps handled by receipt order, independent partition commits, drops unblocking the prefix, commit/pause/resume failures exiting without advancing unfinished offsets, saturation liveness past the modeled max-poll interval, pause-race acceptance vs. gross-overshoot fatality, cooperative rebalance scenarios (partial, full, repeated cycles, revoke-then-reassign-same-partition — stale epochs never commit, retained partitions never see epoch bumps from unrelated revocations), and table-driven state-machine invariants (active ≤ concurrency, outstanding ≤ max + pause-race allowance, monotonic commits, no capacity leaks) across randomized-order transitions.
- `crates/macro_event_broker/src/outbound/parallel_event_consumer/test.rs` (~475 lines): exact attempt counts with no extra attempt, fresh per-attempt timeouts (including four near-300s attempts with the fifth still starting), the 1/2/4/8s backoff schedule, decode-failure immediate drop, drop-log message/fields, drop-commits-and-continues, `Fatal` terminating without commit, and subscription to exactly the declared topics.
- `crates/kafka_util/src/test.rs`: constructor config assertions (max-poll, cooperative pin, existing constructors unchanged on defaults), `next_offset` boundary/overflow cases, rebalance tracker assignment/revocation/reassignment epochs.

## Out of scope (lands separately)

- SPS wiring, the Calls handler, and the SQS cutover — companion plan above.
- Any infrastructure change (IAM, compose, alarms) — none ship with the migration by decision.
