### PR TITLE
feat!(infra): tune macro-db parameter group, update macro-db instance size

### DIFF
--- a/infra/stacks/macrodb/Pulumi.prod.yaml
+++ b/infra/stacks/macrodb/Pulumi.prod.yaml
@@ -4,7 +4,7 @@ config:
   macrodb:parameter_group_family_legacy: postgres14
   macrodb:parameter_group_family: postgres16
   macrodb:engine_version: 14.17
-  macrodb:instance_size: db.t4g.xlarge
+  macrodb:instance_size: db.m9g.2xlarge
   macrodb:storage_type: gp3
   macrodb:storage_iops: 12000
   macrodb:storage_throughput: 500
@@ -19,4 +19,4 @@ config:
   macrodb:monitoring_interval: 60
   macrodb:rds_monitoring_role_arn: arn:aws:iam::569036502058:role/rds-monitoring-role
   macrodb:backup_retention_days: 6
-  macrodb:read_replica_instance_size: db.t4g.xlarge
+  macrodb:read_replica_instance_size: db.m9g.xlarge

--- a/infra/stacks/macrodb/Pulumi.prod.yaml
+++ b/infra/stacks/macrodb/Pulumi.prod.yaml
@@ -3,7 +3,7 @@ config:
   macrodb:db_password_secret_key: macrodb-password-prod
   macrodb:parameter_group_family_legacy: postgres14
   macrodb:parameter_group_family: postgres16
-  macrodb:engine_version: 14.17
+  macrodb:engine_version: 14.22
   macrodb:instance_size: db.m9g.2xlarge
   macrodb:storage_type: gp3
   macrodb:storage_iops: 12000

--- a/infra/stacks/macrodb/index.ts
+++ b/infra/stacks/macrodb/index.ts
@@ -53,7 +53,9 @@ const originalParameterGroup = new aws.rds.ParameterGroup(
       // Tune planner costs and prefetch for gp3 SSD.
       { name: 'random_page_cost', value: '1.1' },
       { name: 'effective_io_concurrency', value: '256' },
-      // Reduce sort and hash spills without overcommitting the 16GiB replica.
+      // Reduce sort and hash spills to disk. Shared by all stacks, so sized
+      // for the smallest instance (8GiB dev); bump to 32768 for prod when it
+      // moves to a 32GiB class. Per-operation cap, not a reservation.
       { name: 'work_mem', value: '16384' },
       // Avoid JIT startup cost for one-off dynamic Soup queries.
       { name: 'jit', value: '0' },
@@ -96,7 +98,11 @@ if (stack === 'prod') {
         // Tune planner costs and prefetch for gp3 SSD.
         { name: 'random_page_cost', value: '1.1' },
         { name: 'effective_io_concurrency', value: '256' },
-        // Reduce sort and hash spills without overcommitting the 16GiB replica.
+        // Reduce sort and hash spills to disk. Shared by all stacks, so sized
+        // for the smallest instance (8GiB dev); bump to 32768 for prod when
+        // it moves to a 32GiB class. Per-operation cap, not a reservation.
+        // Note: on PG15+ hash operations may use 2x this value
+        // (hash_mem_multiplier defaults to 2.0) — factor that into any bump.
         { name: 'work_mem', value: '16384' },
         // Avoid JIT startup cost for one-off dynamic Soup queries.
         { name: 'jit', value: '0' },

--- a/infra/stacks/macrodb/index.ts
+++ b/infra/stacks/macrodb/index.ts
@@ -53,9 +53,7 @@ const originalParameterGroup = new aws.rds.ParameterGroup(
       // Tune planner costs and prefetch for gp3 SSD.
       { name: 'random_page_cost', value: '1.1' },
       { name: 'effective_io_concurrency', value: '256' },
-      // Reduce sort and hash spills to disk. Shared by all stacks, so sized
-      // for the smallest instance (8GiB dev); bump to 32768 for prod when it
-      // moves to a 32GiB class. Per-operation cap, not a reservation.
+      // Reduce sort/hash disk spills; 16MB sized for the smallest (8GiB dev) instance.
       { name: 'work_mem', value: '16384' },
       // Avoid JIT startup cost for one-off dynamic Soup queries.
       { name: 'jit', value: '0' },
@@ -98,11 +96,7 @@ if (stack === 'prod') {
         // Tune planner costs and prefetch for gp3 SSD.
         { name: 'random_page_cost', value: '1.1' },
         { name: 'effective_io_concurrency', value: '256' },
-        // Reduce sort and hash spills to disk. Shared by all stacks, so sized
-        // for the smallest instance (8GiB dev); bump to 32768 for prod when
-        // it moves to a 32GiB class. Per-operation cap, not a reservation.
-        // Note: on PG15+ hash operations may use 2x this value
-        // (hash_mem_multiplier defaults to 2.0) — factor that into any bump.
+        // Reduce sort/hash disk spills; 16MB sized for the smallest (8GiB dev) instance.
         { name: 'work_mem', value: '16384' },
         // Avoid JIT startup cost for one-off dynamic Soup queries.
         { name: 'jit', value: '0' },

--- a/infra/stacks/macrodb/index.ts
+++ b/infra/stacks/macrodb/index.ts
@@ -50,6 +50,20 @@ const originalParameterGroup = new aws.rds.ParameterGroup(
       { name: 'auto_explain.log_nested_statements', value: 'on' },
       { name: 'auto_explain.sample_rate', value: '1' },
       { name: 'idle_in_transaction_session_timeout', value: '300000' },
+      // Query-latency tuning (all dynamic parameters — applied without reboot).
+      // random_page_cost/effective_io_concurrency: correct the planner's
+      // spinning-disk cost assumptions for gp3 SSD.
+      { name: 'random_page_cost', value: '1.1' },
+      { name: 'effective_io_concurrency', value: '256' },
+      // 16MB (kB units), sized for the current 16GiB instance; raise to
+      // 32768 when the instance moves to 32GiB.
+      { name: 'work_mem', value: '16384' },
+      // Dynamically generated queries never repeat, so JIT compilation
+      // cost is never amortized.
+      { name: 'jit', value: '0' },
+      // Log any query spilling >=10MB to temp files to observe residual
+      // work_mem overflows.
+      { name: 'log_temp_files', value: '10240' },
     ],
     tags,
   },
@@ -84,6 +98,20 @@ if (stack === 'prod') {
         { name: 'auto_explain.log_nested_statements', value: 'on' },
         { name: 'auto_explain.sample_rate', value: '1' },
         { name: 'idle_in_transaction_session_timeout', value: '300000' },
+        // Query-latency tuning (all dynamic parameters — applied without reboot).
+        // random_page_cost/effective_io_concurrency: correct the planner's
+        // spinning-disk cost assumptions for gp3 SSD.
+        { name: 'random_page_cost', value: '1.1' },
+        { name: 'effective_io_concurrency', value: '256' },
+        // 16MB (kB units), sized for the current 16GiB instance; raise to
+        // 32768 when the instance moves to 32GiB.
+        { name: 'work_mem', value: '16384' },
+        // Dynamically generated queries never repeat, so JIT compilation
+        // cost is never amortized.
+        { name: 'jit', value: '0' },
+        // Log any query spilling >=10MB to temp files to observe residual
+        // work_mem overflows.
+        { name: 'log_temp_files', value: '10240' },
       ],
       tags,
     },

--- a/infra/stacks/macrodb/index.ts
+++ b/infra/stacks/macrodb/index.ts
@@ -50,19 +50,14 @@ const originalParameterGroup = new aws.rds.ParameterGroup(
       { name: 'auto_explain.log_nested_statements', value: 'on' },
       { name: 'auto_explain.sample_rate', value: '1' },
       { name: 'idle_in_transaction_session_timeout', value: '300000' },
-      // Query-latency tuning (all dynamic parameters — applied without reboot).
-      // random_page_cost/effective_io_concurrency: correct the planner's
-      // spinning-disk cost assumptions for gp3 SSD.
+      // Tune planner costs and prefetch for gp3 SSD.
       { name: 'random_page_cost', value: '1.1' },
       { name: 'effective_io_concurrency', value: '256' },
-      // 16MB (kB units), sized for the current 16GiB instance; raise to
-      // 32768 when the instance moves to 32GiB.
+      // Reduce sort and hash spills without overcommitting the 16GiB replica.
       { name: 'work_mem', value: '16384' },
-      // Dynamically generated queries never repeat, so JIT compilation
-      // cost is never amortized.
+      // Avoid JIT startup cost for one-off dynamic Soup queries.
       { name: 'jit', value: '0' },
-      // Log any query spilling >=10MB to temp files to observe residual
-      // work_mem overflows.
+      // Log spills of at least 10MB for follow-up tuning.
       { name: 'log_temp_files', value: '10240' },
     ],
     tags,
@@ -98,19 +93,14 @@ if (stack === 'prod') {
         { name: 'auto_explain.log_nested_statements', value: 'on' },
         { name: 'auto_explain.sample_rate', value: '1' },
         { name: 'idle_in_transaction_session_timeout', value: '300000' },
-        // Query-latency tuning (all dynamic parameters — applied without reboot).
-        // random_page_cost/effective_io_concurrency: correct the planner's
-        // spinning-disk cost assumptions for gp3 SSD.
+        // Tune planner costs and prefetch for gp3 SSD.
         { name: 'random_page_cost', value: '1.1' },
         { name: 'effective_io_concurrency', value: '256' },
-        // 16MB (kB units), sized for the current 16GiB instance; raise to
-        // 32768 when the instance moves to 32GiB.
+        // Reduce sort and hash spills without overcommitting the 16GiB replica.
         { name: 'work_mem', value: '16384' },
-        // Dynamically generated queries never repeat, so JIT compilation
-        // cost is never amortized.
+        // Avoid JIT startup cost for one-off dynamic Soup queries.
         { name: 'jit', value: '0' },
-        // Log any query spilling >=10MB to temp files to observe residual
-        // work_mem overflows.
+        // Log spills of at least 10MB for follow-up tuning.
         { name: 'log_temp_files', value: '10240' },
       ],
       tags,


### PR DESCRIPTION
| Parameter | Default | New | Why |
|---|---|---|---|
| `random_page_cost` | 4 | **1.1** | Default encodes spinning-disk costs; on gp3 SSD it makes the planner favor seq scans over existing indexes for mid-selectivity queries. 1.1 is the standard SSD value. |
| `effective_io_concurrency` | 1 | **256** | Allows concurrent page prefetch during bitmap heap scans instead of one-read-at-a-time. |
| `work_mem` | 4MB | **16MB** | Reduces sort and hash spills while remaining bounded by the 16GiB read replica. |
| `jit` | on | **off** | JIT adds ~100ms+ compile time before a complex query returns anything. Our dynamically generated soup SQL never textually repeats, so compilation is never amortized — pure tax. |
| `log_temp_files` | -1 | **10MB** | Logs remaining spills of at least 10MB for follow-up tuning. |

macro-db-prod's parameter group only tunes checkpoint/WAL/vacuum and observability; every planner-facing knob is at RDS defaults, which assume spinning disks. The soup query family (dynamic filters + top-N pagination) is exactly the shape these defaults hurt: mischosen seq-scan plans, disk-spilled sorts, and per-query JIT compile spikes.