### PR TITLE
chore(fusionauth): bump fusionauth dev instance

### DIFF
--- a/infra/stacks/fusion-auth/Pulumi.dev.yaml
+++ b/infra/stacks/fusion-auth/Pulumi.dev.yaml
@@ -2,3 +2,4 @@ config:
   aws-native:region: us-east-1
   aws:region: us-east-1
   fusion-auth:db-password-secret-key: fusionauth-db-password-dev
+  fusion-auth:image: fusionauth/fusionauth-app:1.68.0

--- a/infra/stacks/fusion-auth/Pulumi.prod.yaml
+++ b/infra/stacks/fusion-auth/Pulumi.prod.yaml
@@ -2,3 +2,4 @@ config:
   aws-native:region: us-east-1
   aws:region: us-east-1
   fusion-auth:db-password-secret-key: fusionauth-db-password-prod
+  fusion-auth:image: fusionauth/fusionauth-app:1.62.1

--- a/infra/stacks/fusion-auth/fusionauth-service.ts
+++ b/infra/stacks/fusion-auth/fusionauth-service.ts
@@ -9,6 +9,7 @@ import { serviceLoadBalancer } from './resources/load_balancer';
 import {
   BASE_DOMAIN,
   CLOUD_TRAIL_SNS_TOPIC_ARN,
+  config,
   stack,
 } from './resources/shared';
 
@@ -142,7 +143,7 @@ export class FusionAuthService extends pulumi.ComponentResource {
           containers: {
             service: {
               name: BASE_NAME,
-              image: 'fusionauth/fusionauth-app:1.62.1',
+              image: config.require('image'),
               cpu: stack === 'prod' ? 2048 : 2048,
               memory: stack === 'prod' ? 4096 : 4096,
               environment: containerEnvVars,

--- a/infra/stacks/fusion-auth/index.ts
+++ b/infra/stacks/fusion-auth/index.ts
@@ -97,11 +97,11 @@ const service = new FusionAuthService('fusionauth-service', {
     },
     {
       name: 'FUSIONAUTH_APP_RUNTIME_MODE',
-      value: stack === 'prod' ? 'production' : 'development', // NOTE: to perform upgrades to prod, temporarily set to `development`, deploy new version, set back to production
+      value: stack === 'prod' ? 'production' : 'development',
     },
     {
       name: 'FUSIONAUTH_APP_SILENT_MODE',
-      value: 'true', // NOTE: This is disabled when FUSIONAUTH_APP_RUNTIME_MODE is production
+      value: 'true',
     },
   ],
 });

--- a/infra/stacks/fusion-auth/index.ts
+++ b/infra/stacks/fusion-auth/index.ts
@@ -97,11 +97,11 @@ const service = new FusionAuthService('fusionauth-service', {
     },
     {
       name: 'FUSIONAUTH_APP_RUNTIME_MODE',
-      value: stack === 'prod' ? 'production' : 'development',
+      value: stack === 'prod' ? 'production' : 'development', // NOTE: to perform upgrades to prod, temporarily set to `development`, deploy new version, set back to production
     },
     {
-      name: 'FUSIONAUTH_APP_SLENT_MODE',
-      value: 'true',
+      name: 'FUSIONAUTH_APP_SILENT_MODE',
+      value: 'true', // NOTE: This is disabled when FUSIONAUTH_APP_RUNTIME_MODE is production
     },
   ],
 });


### PR DESCRIPTION
Bumps fusionauth from `1.62.1` to `1.68.0` in dev. Once deployed and tested, prod will be updated too.