### PR TITLE
chg(email): label backfill progress counts as threads

### DIFF
--- a/apps/web/src/features/home/home-backfill-progress.tsx
+++ b/apps/web/src/features/home/home-backfill-progress.tsx
@@ -59,8 +59,8 @@ export function HomeBackfillProgress() {
           </div>
           <Show when={active().length > 0}>
             <span class="shrink-0 text-xs tabular-nums text-ink-muted">
-              {totals().completed.toLocaleString()} /{' '}
-              {totals().total.toLocaleString()}
+              {totals().completed.toLocaleString()} of{' '}
+              {totals().total.toLocaleString()} threads
             </span>
           </Show>
         </div>

--- a/apps/web/src/features/settings/Email.tsx
+++ b/apps/web/src/features/settings/Email.tsx
@@ -329,7 +329,8 @@ function BackfillProgressBar(props: { progress: BackfillProgress }) {
       </span>
       <div class="flex items-center gap-6 whitespace-nowrap text-xs text-ink-muted">
         <span>
-          {props.progress.completed}/{props.progress.total}
+          {props.progress.completed.toLocaleString()} of{' '}
+          {props.progress.total.toLocaleString()} threads
         </span>
         <Show when={etaLabel()}>{(label) => <span>{label()}</span>}</Show>
       </div>

--- a/apps/web/src/features/setup/flow/SummaryStep.tsx
+++ b/apps/web/src/features/setup/flow/SummaryStep.tsx
@@ -83,7 +83,7 @@ export function SummaryStep(props: { onContinue: () => void }) {
                   <>
                     processing your inbox —{' '}
                     {progress().completed.toLocaleString()} of{' '}
-                    {progress().total.toLocaleString()} emails
+                    {progress().total.toLocaleString()} threads
                   </>
                 )}
               </Show>


### PR DESCRIPTION
The email backfill progress UI rendered a bare ratio (`550/11703`) with no unit, so it wasn't clear what was being counted. The counters are thread counts — the backend reports `completed_threads` / `total_threads` — so the label now says so.

- **Settings → Accounts** (`Email.tsx`): `550/11703` → `550 of 11,703 threads`. Also adds thousands separators, matching the other backfill readouts.
- **Home import card** (`home-backfill-progress.tsx`): `550 / 11,703` → `550 of 11,703 threads`.
- **Setup summary** (`SummaryStep.tsx`): said "… of 11,703 **emails**", which was wrong for the same counter — now "threads".

Text-only change; no behavior or data-flow changes.
