### PR TITLE
Reorganize sidebar layout and add recent activity sections

### DIFF
--- a/apps/web/src/components/app/app-sidebar/sidebar.tsx
+++ b/apps/web/src/components/app/app-sidebar/sidebar.tsx
@@ -15,6 +15,7 @@ import {
   requestInboxFilter,
 } from '@app/features/next-soup/soup-view/inbox-filter-controllers';
 import { requestSearchFocus } from '@app/features/next-soup/soup-view/search-controllers';
+import { RecentActivitySections } from '@app/features/recents/sidebar/recent-activity-sections';
 import {
   InviteModal,
   setInviteModalOpen,
@@ -55,10 +56,7 @@ import {
   type SettingsTab,
   useSettingsState,
 } from '@core/constant/SettingsState';
-import {
-  getSettingsTabItem,
-  useSettingsTabAvailable,
-} from '@core/constant/settingsTabsConfig';
+import { useSettingsTabAvailable } from '@core/constant/settingsTabsConfig';
 import { useEmail, useUserId } from '@core/context/user';
 import { registerHotkey } from '@core/hotkey/hotkeys';
 import { clearPressedKeys } from '@core/hotkey/state';
@@ -86,7 +84,6 @@ import GearIcon from '@phosphor/gear.svg';
 import HomeIcon from '@phosphor/house.svg';
 import MagnifyingGlassIcon from '@phosphor/magnifying-glass.svg';
 import SignOutIcon from '@phosphor/sign-out.svg';
-import UsersThreeIcon from '@phosphor/users-three.svg';
 import XIcon from '@phosphor/x.svg';
 import { isRealNamePart, useOwnUserName } from '@queries/auth/user-name-self';
 import { useEmailLinksQuery } from '@queries/email/link';
@@ -141,15 +138,25 @@ type SidebarSectionLinkId =
 
 type SidebarSectionVisibility = Record<SidebarSectionLinkId, boolean>;
 
-type TryItemId = 'connect' | 'invite' | 'mobile';
+/**
+ * Links pinned at the top of the Workspace section. Not hideable via the
+ * customize menu; the gated ones (getting-started, activity) simply drop out
+ * of the link list when their gates are off.
+ */
+const WORKSPACE_FIXED_LINK_IDS = [
+  'home',
+  'getting-started',
+  'inbox',
+  'activity',
+] as const;
 
-type TryItemVisibility = Record<TryItemId, boolean>;
-
-const COMMUNICATIONS_LINK_IDS = ['mail', 'channels', 'calls'] as const;
 const WORKSPACE_LINK_IDS = [
+  'mail',
+  'channels',
+  'calls',
   'documents',
-  'tasks',
   'agents',
+  'tasks',
   'companies',
 ] as const;
 
@@ -161,12 +168,6 @@ const DEFAULT_SECTION_VISIBILITY: SidebarSectionVisibility = {
   tasks: true,
   agents: true,
   companies: true,
-};
-
-const DEFAULT_TRY_VISIBILITY: TryItemVisibility = {
-  connect: true,
-  invite: true,
-  mobile: true,
 };
 
 const markdownDocumentsQuery = buildDocumentTypeQuery(['doc-markdown']);
@@ -191,20 +192,20 @@ const SIDEBAR_LINKS = [
     hiddenFromSidebar: true,
   },
   {
-    id: 'agents',
-    label: 'Agents',
-    href: LIST_VIEW_PATHS.agents,
-    icon: AnimatedStarIcon,
-    hotkey: 'a',
-    hotkeyToken: TOKENS.sidebar.goTo.agents,
-  },
-  {
     id: 'mail',
     label: 'Email',
     href: LIST_VIEW_PATHS.mail,
     icon: AnimatedEmailIcon,
     hotkey: 'e',
     hotkeyToken: TOKENS.sidebar.goTo.mail,
+  },
+  {
+    id: 'channels',
+    label: 'Channels',
+    href: LIST_VIEW_PATHS.channels,
+    icon: AnimatedChannelIcon,
+    hotkey: 'c',
+    hotkeyToken: TOKENS.sidebar.goTo.channels,
   },
   {
     id: 'documents',
@@ -231,20 +232,20 @@ const SIDEBAR_LINKS = [
     hiddenFromSidebar: true,
   },
   {
+    id: 'agents',
+    label: 'Agents',
+    href: LIST_VIEW_PATHS.agents,
+    icon: AnimatedStarIcon,
+    hotkey: 'a',
+    hotkeyToken: TOKENS.sidebar.goTo.agents,
+  },
+  {
     id: 'tasks',
     label: 'Tasks',
     href: LIST_VIEW_PATHS.tasks,
     icon: AnimatedTaskIcon,
     hotkey: 't',
     hotkeyToken: TOKENS.sidebar.goTo.tasks,
-  },
-  {
-    id: 'channels',
-    label: 'Channels',
-    href: LIST_VIEW_PATHS.channels,
-    icon: AnimatedChannelIcon,
-    hotkey: 'c',
-    hotkeyToken: TOKENS.sidebar.goTo.channels,
   },
 ] satisfies SidebarItem[];
 
@@ -517,54 +518,6 @@ export const GoToHotkeys = () => {
 /** Session-only signal so a hint shows after dismissal until the user acknowledges or the timer expires. */
 const [premiumHintVisible, setPremiumHintVisible] = createSignal(false);
 
-type SidebarShortcutLinkProps = {
-  label: string;
-  icon: Component<{ triggerAnimation?: boolean; class?: string }>;
-  onClick: () => void;
-  isSlim: () => boolean;
-  trailing?: JSX.Element;
-};
-
-const SidebarShortcutLink = (props: SidebarShortcutLinkProps) => {
-  const [isHovering, setIsHovering] = createSignal(false);
-
-  return (
-    <div class="group/shortcut relative w-full">
-      <NavRow
-        draggable={false}
-        class={cn(
-          'h-7 group-hover/shortcut:bg-ink/3 group-hover/shortcut:text-ink',
-          props.trailing && !props.isSlim() && 'pr-8'
-        )}
-        fullWidth
-        tooltipPlacement="right"
-        label={props.isSlim() ? props.label : undefined}
-        onMouseEnter={() => setIsHovering(true)}
-        onMouseLeave={() => setIsHovering(false)}
-        onMouseDown={(e) => {
-          if (e.button !== 0) return;
-          e.preventDefault();
-          props.onClick();
-        }}
-      >
-        <div class="relative size-5 shrink-0 flex items-center justify-center [&_svg]:size-3.5">
-          <Dynamic component={props.icon} triggerAnimation={isHovering()} />
-        </div>
-
-        <div class="flex items-center gap-1 group-data-[slim=true]/sidebar:hidden">
-          <span class="flex-1 min-w-0 whitespace-nowrap">{props.label}</span>
-        </div>
-      </NavRow>
-
-      <Show when={props.trailing && !props.isSlim()}>
-        <div class="absolute right-1 top-1/2 -translate-y-1/2 flex items-center">
-          {props.trailing}
-        </div>
-      </Show>
-    </div>
-  );
-};
-
 const SidebarSectionMenu = (props: {
   label: string;
   options: { id: SidebarSectionLinkId; label: string; checked: boolean }[];
@@ -603,42 +556,6 @@ const SidebarSectionMenu = (props: {
             </Dropdown.CheckboxItem>
           )}
         </For>
-      </Dropdown.Group>
-    </Dropdown.Content>
-  </Dropdown>
-);
-
-const SidebarTryItemMenu = (props: {
-  label: string;
-  onDismiss: () => void;
-  onOpenChange?: (open: boolean) => void;
-}) => (
-  <Dropdown
-    placement="right-start"
-    gutter={8}
-    onOpenChange={props.onOpenChange}
-  >
-    <Dropdown.Trigger
-      variant="ghost"
-      class="shrink-0 opacity-0 group-hover/shortcut:pointer-events-auto group-hover/shortcut:opacity-100 focus-visible:opacity-100 transition-opacity rounded-md size-5 min-h-0 p-0 bg-transparent hover:bg-ink/6 [&_svg]:size-3.5 pointer-events-none"
-      label={`${props.label} options`}
-      onMouseDown={(e: MouseEvent) => {
-        if (e.button !== 0) return;
-        e.preventDefault();
-        e.stopPropagation();
-      }}
-      onClick={(e: MouseEvent) => e.stopPropagation()}
-    >
-      <DotsThreeIcon />
-    </Dropdown.Trigger>
-    <Dropdown.Content class="w-40 shadow-menu">
-      <Dropdown.Group>
-        <Dropdown.Item
-          class="min-h-8 gap-2 px-2.5 text-[13px]"
-          onSelect={props.onDismiss}
-        >
-          <span class="flex-1 truncate text-ink">Dismiss</span>
-        </Dropdown.Item>
       </Dropdown.Group>
     </Dropdown.Content>
   </Dropdown>
@@ -1009,14 +926,8 @@ const buildSidebarLinks = (showGettingStarted: boolean): SidebarItem[] => {
   }
 
   if (ENABLE_CRM()) {
-    // Customers sits just after Channels (and Calls when present).
-    const anchorId = ENABLE_CALLS() ? 'calls' : 'channels';
-    const idx = links.findIndex((l) => l.id === anchorId);
-    links = [
-      ...links.slice(0, idx + 1),
-      COMPANIES_LINK,
-      ...links.slice(idx + 1),
-    ];
+    // Customers closes out the Workspace section, after Tasks.
+    links = [...links, COMPANIES_LINK];
   }
 
   return links;
@@ -1058,10 +969,6 @@ export const AppSidebar = (props: AppSidebarProps) => {
   const [sectionVisibility, setSectionVisibility] = makePersisted(
     createSignal<SidebarSectionVisibility>(DEFAULT_SECTION_VISIBILITY),
     { name: 'sidebar-section-visibility' }
-  );
-  const [tryVisibility, setTryVisibility] = makePersisted(
-    createSignal<TryItemVisibility>(DEFAULT_TRY_VISIBILITY),
-    { name: 'sidebar-try-visibility' }
   );
   const callCtx = useCallContextOptional();
 
@@ -1243,15 +1150,6 @@ export const AppSidebar = (props: AppSidebarProps) => {
     ),
   });
 
-  const topLinks = createMemo(() =>
-    ['home', 'getting-started', 'inbox', 'activity']
-      .filter(
-        (id) => id !== 'getting-started' || !gettingStartedVisibility.hidden()
-      )
-      .map((id) => findLink(id))
-      .filter((link): link is SidebarItem => link !== undefined)
-  );
-
   const sectionItemsFor = (ids: readonly SidebarSectionLinkId[]) =>
     ids
       .filter((id) => sectionVisibility()[id])
@@ -1259,21 +1157,21 @@ export const AppSidebar = (props: AppSidebarProps) => {
       .filter((link): link is SidebarItem => link !== undefined)
       .map(toSectionItem);
 
-  const communicationsItems = createMemo(() =>
-    sectionItemsFor(COMMUNICATIONS_LINK_IDS)
-  );
-  const workspaceItems = createMemo(() => sectionItemsFor(WORKSPACE_LINK_IDS));
+  const workspaceItems = createMemo(() => [
+    ...WORKSPACE_FIXED_LINK_IDS.filter(
+      (id) => id !== 'getting-started' || !gettingStartedVisibility.hidden()
+    )
+      .map((id) => findLink(id))
+      .filter((link): link is SidebarItem => link !== undefined)
+      .map(toSectionItem),
+    ...sectionItemsFor(WORKSPACE_LINK_IDS),
+  ]);
 
   const toggleSectionVisibility = (id: SidebarSectionLinkId) => {
     setSectionVisibility({
       ...sectionVisibility(),
       [id]: !sectionVisibility()[id],
     });
-    scheduleMiddleScrollUpdate();
-  };
-
-  const dismissTryItem = (id: TryItemId) => {
-    setTryVisibility({ ...tryVisibility(), [id]: false });
     scheduleMiddleScrollUpdate();
   };
 
@@ -1287,73 +1185,10 @@ export const AppSidebar = (props: AppSidebarProps) => {
         checked: sectionVisibility()[link.id as SidebarSectionLinkId],
       }));
 
-  const tryItems = createMemo<CollapsibleSidebarSectionItem[]>(() => {
-    const items: CollapsibleSidebarSectionItem[] = [];
-    const addTryItem = (
-      id: TryItemId,
-      label: string,
-      icon: Component<{ triggerAnimation?: boolean; class?: string }>,
-      onClick: () => void
-    ) => {
-      if (!tryVisibility()[id]) return;
-
-      const trailing = (
-        <SidebarTryItemMenu
-          label={label}
-          onDismiss={() => dismissTryItem(id)}
-          onOpenChange={handleWorkspaceContextMenuOpenChange}
-        />
-      );
-
-      items.push({
-        id,
-        visible: () => (
-          <SidebarShortcutLink
-            label={label}
-            isSlim={isSlim}
-            onClick={onClick}
-            icon={icon}
-            trailing={trailing}
-          />
-        ),
-        dropdown: () => (
-          <SidebarShortcutLink
-            label={label}
-            isSlim={isSlim}
-            onClick={onClick}
-            icon={icon}
-            trailing={trailing}
-          />
-        ),
-      });
-    };
-
-    const connected = getSettingsTabItem('Connected');
-    if (connected && isTabAvailable('Connected')) {
-      addTryItem('connect', 'Connect', connected.icon, () =>
-        openSettingsTab('Connected')
-      );
-    }
-
-    addTryItem('invite', 'Invite', UsersThreeIcon, () =>
-      setInviteModalOpen(true)
-    );
-
-    const mobile = getSettingsTabItem('Mobile App');
-    if (mobile && isTabAvailable('Mobile App')) {
-      addTryItem('mobile', 'Mobile', mobile.icon, () =>
-        openSettingsTab('Mobile App')
-      );
-    }
-    return items;
-  });
-
   createEffect(() => {
     middleScrollSize.width;
     middleScrollSize.height;
-    communicationsItems().length;
     workspaceItems().length;
-    tryItems().length;
     props.overlayOpen;
     scheduleMiddleScrollUpdate();
   });
@@ -1426,57 +1261,25 @@ export const AppSidebar = (props: AppSidebarProps) => {
         </div>
       </div>
 
-      <nav class="shrink-0 mt-2">
-        <ul class="size-full flex flex-col gap-0.5">
-          <For each={topLinks()}>
-            {(link) => (
-              <li class="flex flex-col items-center justify-center">
-                {renderSidebarLink(link)}
-              </li>
-            )}
-          </For>
-        </ul>
-      </nav>
-
-      <div class="relative min-h-0 flex-1 my-3">
+      <div class="relative min-h-0 flex-1 mt-2 mb-3">
         <div
           ref={attachMiddleScrollRef}
           onScroll={updateMiddleScrollShadows}
           class="size-full overflow-y-auto flex flex-col gap-3"
         >
-          <Show
-            when={sectionMenuOptionsFor(COMMUNICATIONS_LINK_IDS).length > 0}
-          >
-            <CollapsibleSidebarSection
-              label="Conversations"
-              items={communicationsItems()}
-              headerMenu={() => (
-                <SidebarSectionMenu
-                  label="Conversations"
-                  options={sectionMenuOptionsFor(COMMUNICATIONS_LINK_IDS)}
-                  onToggle={toggleSectionVisibility}
-                  onOpenChange={handleWorkspaceContextMenuOpenChange}
-                />
-              )}
-              onOpenChange={scheduleMiddleScrollUpdate}
-            />
-          </Show>
-
-          <Show when={sectionMenuOptionsFor(WORKSPACE_LINK_IDS).length > 0}>
-            <CollapsibleSidebarSection
-              label="Workspace"
-              items={workspaceItems()}
-              headerMenu={() => (
-                <SidebarSectionMenu
-                  label="Workspace"
-                  options={sectionMenuOptionsFor(WORKSPACE_LINK_IDS)}
-                  onToggle={toggleSectionVisibility}
-                  onOpenChange={handleWorkspaceContextMenuOpenChange}
-                />
-              )}
-              onOpenChange={scheduleMiddleScrollUpdate}
-            />
-          </Show>
+          <CollapsibleSidebarSection
+            label="Workspace"
+            items={workspaceItems()}
+            headerMenu={() => (
+              <SidebarSectionMenu
+                label="Workspace"
+                options={sectionMenuOptionsFor(WORKSPACE_LINK_IDS)}
+                onToggle={toggleSectionVisibility}
+                onOpenChange={handleWorkspaceContextMenuOpenChange}
+              />
+            )}
+            onOpenChange={scheduleMiddleScrollUpdate}
+          />
 
           <Suspense>
             <FavoritesSection
@@ -1491,13 +1294,12 @@ export const AppSidebar = (props: AppSidebarProps) => {
             onDropdownOpenChange={handleOverlayDropdownOpenChange}
           />
 
-          <Show when={tryItems().length > 0}>
-            <CollapsibleSidebarSection
-              label="Try"
-              items={tryItems()}
-              onOpenChange={scheduleMiddleScrollUpdate}
+          <Suspense>
+            <RecentActivitySections
+              sidebarState={sidebarDisplayState()}
+              onContextMenuOpenChange={handleOverlayDropdownOpenChange}
             />
-          </Show>
+          </Suspense>
         </div>
         <div
           class={cn(

--- a/apps/web/src/features/recents/recent-activity.test.ts
+++ b/apps/web/src/features/recents/recent-activity.test.ts
@@ -1,0 +1,98 @@
+import type { EntityData } from '@entity';
+import { describe, expect, it } from 'vitest';
+import { bucketRecentActivity, entityActivityAt } from './recent-activity';
+
+const NOW = new Date('2026-07-29T15:00:00Z');
+
+let nextId = 0;
+function makeDoc(timestamps: {
+  viewedAt?: string;
+  updatedAt?: string;
+  createdAt?: string;
+}): EntityData {
+  nextId += 1;
+  return {
+    type: 'document',
+    id: `doc-${nextId}`,
+    name: `Doc ${nextId}`,
+    ownerId: 'user-1',
+    ...timestamps,
+  };
+}
+
+describe('entityActivityAt', () => {
+  it('returns the latest of viewedAt/updatedAt/createdAt', () => {
+    const entity = makeDoc({
+      createdAt: '2026-07-01T00:00:00Z',
+      updatedAt: '2026-07-29T10:00:00Z',
+      viewedAt: '2026-07-20T00:00:00Z',
+    });
+    expect(entityActivityAt(entity)).toEqual(new Date('2026-07-29T10:00:00Z'));
+  });
+
+  it('falls back to createdAt and tolerates missing timestamps', () => {
+    expect(
+      entityActivityAt(makeDoc({ createdAt: '2026-07-28T00:00:00Z' }))
+    ).toEqual(new Date('2026-07-28T00:00:00Z'));
+    expect(entityActivityAt(makeDoc({}))).toBeUndefined();
+  });
+});
+
+describe('bucketRecentActivity', () => {
+  it('buckets by calendar day relative to now', () => {
+    const today = makeDoc({ viewedAt: '2026-07-29T08:00:00Z' });
+    const yesterday = makeDoc({ updatedAt: '2026-07-28T23:00:00Z' });
+    const thisWeek = makeDoc({ updatedAt: '2026-07-24T12:00:00Z' });
+    const thisMonth = makeDoc({ viewedAt: '2026-07-05T12:00:00Z' });
+    const ancient = makeDoc({ updatedAt: '2026-05-01T12:00:00Z' });
+
+    const buckets = bucketRecentActivity(
+      [ancient, thisMonth, thisWeek, yesterday, today],
+      NOW
+    );
+
+    expect(
+      buckets.map((bucket) => [
+        bucket.label,
+        bucket.entities.map((entity) => entity.id),
+      ])
+    ).toEqual([
+      ['Today', [today.id]],
+      ['Yesterday', [yesterday.id]],
+      ['Previous 7 Days', [thisWeek.id]],
+      ['Previous 30 Days', [thisMonth.id]],
+    ]);
+  });
+
+  it('omits empty buckets and drops undated entities', () => {
+    const today = makeDoc({ viewedAt: '2026-07-29T08:00:00Z' });
+    const undated = makeDoc({});
+
+    const buckets = bucketRecentActivity([undated, today], NOW);
+
+    expect(buckets).toHaveLength(1);
+    expect(buckets[0].key).toBe('today');
+    expect(buckets[0].entities).toEqual([today]);
+  });
+
+  it('orders entities newest-first within a bucket', () => {
+    const older = makeDoc({ viewedAt: '2026-07-29T01:00:00Z' });
+    const newer = makeDoc({ updatedAt: '2026-07-29T14:00:00Z' });
+
+    const buckets = bucketRecentActivity([older, newer], NOW);
+
+    expect(buckets[0].entities.map((entity) => entity.id)).toEqual([
+      newer.id,
+      older.id,
+    ]);
+  });
+
+  it('counts future timestamps as today', () => {
+    const future = makeDoc({ updatedAt: '2026-07-30T02:00:00Z' });
+
+    const buckets = bucketRecentActivity([future], NOW);
+
+    expect(buckets).toHaveLength(1);
+    expect(buckets[0].key).toBe('today');
+  });
+});

--- a/apps/web/src/features/recents/recent-activity.ts
+++ b/apps/web/src/features/recents/recent-activity.ts
@@ -1,0 +1,107 @@
+import { QUERY_FILTERS_BASE } from '@app/features/next-soup/filters/query-filters';
+import type { EntityData } from '@entity';
+import type { SoupItemsQueryArgs } from '@queries/soup/items';
+import { differenceInCalendarDays, toDate } from 'date-fns';
+
+/** How many items the sidebar recents query pulls (single page, no load-more). */
+export const RECENT_ACTIVITY_LIMIT = 50;
+
+/**
+ * Soup query for the sidebar's time-bucketed recents: documents (files +
+ * tasks) and chats (agents), ordered by `viewed_updated` — the later of when
+ * the viewer opened the item and when it was last edited/received. Emails and
+ * channels are deliberately excluded until their activity feeds are ready.
+ */
+export function buildRecentActivityArgs(): SoupItemsQueryArgs {
+  return {
+    params: { sort_method: 'viewed_updated', limit: RECENT_ACTIVITY_LIMIT },
+    body: {
+      ...QUERY_FILTERS_BASE,
+      document_filters: undefined,
+      chat_filters: undefined,
+    },
+  };
+}
+
+export type RecentActivityBucketKey =
+  | 'today'
+  | 'yesterday'
+  | 'previous-7-days'
+  | 'previous-30-days';
+
+export type RecentActivityBucket = {
+  key: RecentActivityBucketKey;
+  label: string;
+  entities: EntityData[];
+};
+
+/** Ordered newest-first; an item lands in the first bucket wide enough. */
+const BUCKET_DEFS: readonly {
+  key: RecentActivityBucketKey;
+  label: string;
+  maxCalendarDaysAgo: number;
+}[] = [
+  { key: 'today', label: 'Today', maxCalendarDaysAgo: 0 },
+  { key: 'yesterday', label: 'Yesterday', maxCalendarDaysAgo: 1 },
+  { key: 'previous-7-days', label: 'Previous 7 Days', maxCalendarDaysAgo: 7 },
+  {
+    key: 'previous-30-days',
+    label: 'Previous 30 Days',
+    maxCalendarDaysAgo: 30,
+  },
+];
+
+/**
+ * When an entity last "happened" for the viewer: opened (`viewedAt`) or
+ * edited/received (`updatedAt`), whichever is later — mirroring the soup's
+ * `viewed_updated` sort. Falls back to `createdAt` (e.g. an agent kicked off
+ * but never revisited) and undefined when the row carries no timestamps.
+ */
+export function entityActivityAt(entity: EntityData): Date | undefined {
+  let latest: Date | undefined;
+  for (const value of [entity.viewedAt, entity.updatedAt, entity.createdAt]) {
+    if (!value) continue;
+    const date = toDate(value);
+    if (Number.isNaN(date.getTime())) continue;
+    if (!latest || date > latest) latest = date;
+  }
+  return latest;
+}
+
+/**
+ * Group entities into Today / Yesterday / Previous 7 Days / Previous 30 Days
+ * by their activity time, newest first within each bucket. Entities older
+ * than 30 calendar days (or without any timestamp) are dropped; empty buckets
+ * are omitted.
+ */
+export function bucketRecentActivity(
+  entities: readonly EntityData[],
+  now: Date
+): RecentActivityBucket[] {
+  const buckets = BUCKET_DEFS.map(
+    (def): RecentActivityBucket => ({
+      key: def.key,
+      label: def.label,
+      entities: [],
+    })
+  );
+
+  const dated = entities
+    .map((entity) => ({ entity, at: entityActivityAt(entity) }))
+    .filter(
+      (item): item is { entity: EntityData; at: Date } => item.at !== undefined
+    )
+    .sort((a, b) => b.at.getTime() - a.at.getTime());
+
+  for (const { entity, at } of dated) {
+    // Clock skew can stamp an item slightly in the future; count it as today.
+    const daysAgo = Math.max(0, differenceInCalendarDays(now, at));
+    const index = BUCKET_DEFS.findIndex(
+      (def) => daysAgo <= def.maxCalendarDaysAgo
+    );
+    if (index === -1) continue;
+    buckets[index].entities.push(entity);
+  }
+
+  return buckets.filter((bucket) => bucket.entities.length > 0);
+}

--- a/apps/web/src/features/recents/sidebar/recent-activity-sections.tsx
+++ b/apps/web/src/features/recents/sidebar/recent-activity-sections.tsx
@@ -1,0 +1,187 @@
+import { openEntityInSplitFromUnifiedList } from '@app/features/next-soup/utils';
+import {
+  bucketRecentActivity,
+  buildRecentActivityArgs,
+} from '@app/features/recents/recent-activity';
+import { useAnalytics } from '@app/lib/analytics/analytics-context';
+import { globalSplitManager } from '@app/signal/splitLayout';
+import {
+  CollapsibleSidebarSection,
+  type CollapsibleSidebarSectionItem,
+} from '@components/app/app-sidebar/collapsible-sidebar-section';
+import type { SidebarState } from '@components/app/app-sidebar/sidebar';
+import { useSplitLayout } from '@components/app/split-layout/layout';
+import type { SplitContent } from '@components/app/split-layout/layoutManager';
+import { ContextMenuContent, MenuItem } from '@core/component/ContextMenu';
+import { fileTypeToBlockName } from '@core/constant/allBlocks';
+import type { EntityData } from '@entity';
+import { EntityRowIcon } from '@entity';
+import { ContextMenu } from '@kobalte/core/context-menu';
+import { useSoupItemsQuery } from '@queries/soup/items';
+import { NavRow } from '@ui';
+import { startOfDay } from 'date-fns';
+import { createMemo, createSignal, For, onCleanup, Show } from 'solid-js';
+
+const RECENT_ACTIVITY_STALE_TIME = 60 * 1000;
+const DAY_TICK_INTERVAL_MS = 60 * 1000;
+
+/**
+ * The split content that opens a recent-activity row. The recents query only
+ * returns documents (files/tasks/snippets) and chats, so the block name is
+ * the document's sub/file type or the entity type itself.
+ */
+const recentEntitySplitContent = (entity: EntityData): SplitContent =>
+  entity.type === 'document'
+    ? {
+        type: fileTypeToBlockName(entity.subType?.type ?? entity.fileType),
+        id: entity.id,
+      }
+    : { type: fileTypeToBlockName(entity.type), id: entity.id };
+
+/**
+ * Time-bucketed recents for the expanded sidebar: Today / Yesterday /
+ * Previous 7 Days / Previous 30 Days sections of what the viewer recently
+ * opened, edited, or received — documents, tasks, and agents. Items can
+ * appear here and in Unread; buckets older than 30 days are dropped. Hidden
+ * entirely in slim mode and while there is nothing to show.
+ */
+export const RecentActivitySections = (props: {
+  sidebarState: SidebarState;
+  onContextMenuOpenChange?: (open: boolean) => void;
+}) => {
+  const query = useSoupItemsQuery(
+    () => buildRecentActivityArgs(),
+    () => ({ staleTime: RECENT_ACTIVITY_STALE_TIME })
+  );
+
+  // Re-bucket when the calendar day flips so rows drift from Today to
+  // Yesterday without a reload.
+  const [dayStart, setDayStart] = createSignal(
+    startOfDay(new Date()).getTime()
+  );
+  const dayTimer = setInterval(() => {
+    const next = startOfDay(new Date()).getTime();
+    if (next !== dayStart()) setDayStart(next);
+  }, DAY_TICK_INTERVAL_MS);
+  onCleanup(() => clearInterval(dayTimer));
+
+  const buckets = createMemo(() => {
+    dayStart();
+    return bucketRecentActivity(query.data ?? [], new Date());
+  });
+
+  const toSectionItems = (
+    entities: readonly EntityData[]
+  ): CollapsibleSidebarSectionItem[] =>
+    entities.map((entity) => ({
+      id: entity.id,
+      visible: () => (
+        <RecentEntityRow
+          entity={entity}
+          onContextMenuOpenChange={props.onContextMenuOpenChange}
+        />
+      ),
+      dropdown: () => (
+        <RecentEntityRow
+          entity={entity}
+          onContextMenuOpenChange={props.onContextMenuOpenChange}
+        />
+      ),
+    }));
+
+  return (
+    <Show when={props.sidebarState === 'expanded' && buckets().length > 0}>
+      <For each={buckets()}>
+        {(bucket) => (
+          <CollapsibleSidebarSection
+            label={bucket.label}
+            items={toSectionItems(bucket.entities)}
+          />
+        )}
+      </For>
+    </Show>
+  );
+};
+
+const RecentEntityRow = (props: {
+  entity: EntityData;
+  onContextMenuOpenChange?: (open: boolean) => void;
+}) => {
+  const analytics = useAnalytics();
+  const layout = useSplitLayout();
+
+  const isActive = () => {
+    const active = globalSplitManager()?.activeSplit()?.content();
+    return (
+      !!active && active.type !== 'component' && active.id === props.entity.id
+    );
+  };
+
+  const open = (newSplit: boolean) => {
+    analytics.track('sidebar_click', {
+      view: 'recent-activity',
+      entityType: props.entity.type,
+    });
+    void openEntityInSplitFromUnifiedList(props.entity, {
+      openInNewSplit: newSplit,
+      referredFrom: 'sidebar',
+    });
+    globalSplitManager()?.returnFocus();
+  };
+
+  const canOpenInNewSplit = () =>
+    globalSplitManager()?.canAppendSplit() ?? false;
+  const canOpenFullscreen = () => layout.getSplitCount() > 1;
+  const openInCurrentSplit = () => open(false);
+  const openInNewSplit = () => {
+    if (canOpenInNewSplit()) open(true);
+  };
+  const openFullscreen = () => {
+    layout.replaceAllSplits(recentEntitySplitContent(props.entity), {
+      referredFrom: 'sidebar',
+    });
+    globalSplitManager()?.returnFocus();
+  };
+
+  return (
+    <ContextMenu onOpenChange={props.onContextMenuOpenChange}>
+      <ContextMenu.Trigger class="w-full h-7">
+        <NavRow
+          draggable={false}
+          data-sidebar-recent={props.entity.id}
+          data-active={isActive() ? '' : undefined}
+          active={isActive()}
+          class="h-7"
+          fullWidth
+          onClick={(e: MouseEvent) => open(e.shiftKey)}
+        >
+          <div class="size-5 shrink-0 flex items-center justify-center">
+            <EntityRowIcon
+              entity={props.entity}
+              class="size-3.5"
+              suppressClick
+              showTooltip={false}
+            />
+          </div>
+          <span class="min-w-0 truncate">
+            {props.entity.name.trim() || 'Untitled'}
+          </span>
+        </NavRow>
+      </ContextMenu.Trigger>
+
+      <ContextMenu.Portal>
+        <ContextMenuContent class="text-xs text-ink-muted">
+          <MenuItem
+            text="Open in new split"
+            onClick={openInNewSplit}
+            disabled={!canOpenInNewSplit()}
+          />
+          <Show when={canOpenFullscreen()}>
+            <MenuItem text="Open fullscreen" onClick={openFullscreen} />
+          </Show>
+          <MenuItem text="Open in current split" onClick={openInCurrentSplit} />
+        </ContextMenuContent>
+      </ContextMenu.Portal>
+    </ContextMenu>
+  );
+};


### PR DESCRIPTION
## Summary

Restructures the app sidebar to consolidate the "Conversations" and "Workspace" sections into a single unified "Workspace" section with fixed top links, and replaces the dismissible "Try" items with a new time-bucketed "Recent Activity" feature that displays recently viewed/edited documents and chats.

## Key Changes

- **Sidebar Section Reorganization**
  - Merged "Conversations" (mail, channels, calls) and "Workspace" sections into a single "Workspace" section
  - Introduced `WORKSPACE_FIXED_LINK_IDS` for pinned top-level links (home, getting-started, inbox, activity) that appear above customizable workspace items
  - Reordered sidebar links: mail, channels, calls now appear before documents, with agents and tasks following

- **Recent Activity Feature**
  - Added new `RecentActivitySections` component that displays time-bucketed recent items (Today, Yesterday, Previous 7 Days, Previous 30 Days)
  - Created `recent-activity.ts` with bucketing logic based on `viewedAt`, `updatedAt`, and `createdAt` timestamps
  - Implemented `RecentEntityRow` component with context menu support for opening items in new splits or fullscreen
  - Only visible in expanded sidebar mode when items are available
  - Includes comprehensive test coverage for bucketing and timestamp logic

- **Removed Try Items Feature**
  - Eliminated `SidebarShortcutLink` and `SidebarTryItemMenu` components
  - Removed dismissible "Connect", "Invite", and "Mobile" items
  - Removed `TryItemVisibility` state management and related signal handling
  - Removed unused imports (`getSettingsTabItem`, `UsersThreeIcon`)

- **Code Cleanup**
  - Simplified imports and removed unused helper functions
  - Consolidated section visibility logic to use a single customizable menu
  - Removed separate `communicationsItems` memo in favor of unified workspace items

## Implementation Details

- Recent activity query uses `viewed_updated` sort method (latest of viewed/updated times) with a 50-item limit
- Bucketing respects calendar day boundaries and handles clock skew by treating future timestamps as today
- Recent activity sections are wrapped in `Suspense` to handle async data loading
- Context menu on recent items provides options to open in new split, fullscreen, or current split (with appropriate disabled states)
- Analytics tracking added for sidebar recent activity clicks

https://claude.ai/code/session_01HwBpDnCCTZXF3XNanzdWzA