### PR TITLE
fix(auth): raise mobile welcome email rate limit to 100/hour per IP

### DIFF
--- a/services/authentication_service/src/rate_limit_config.rs
+++ b/services/authentication_service/src/rate_limit_config.rs
@@ -30,5 +30,10 @@ pub static RATE_LIMIT_CONFIG: RateLimitConfig = RateLimitConfig {
     merge_email_daily: (5, 86400),
 
     create_user_hourly: (50, 3600),
-    mobile_welcome_email: (5, 3600), // 10 attempts per hour per IP
+    // 100 attempts per hour per IP. Mobile carriers put thousands of phones
+    // behind one CGNAT address, so a low cap here rejects real visitors on the
+    // marketing site's mobile signup form rather than abusers. Abuse stays
+    // bounded because an address can only ever be sent this email once (the
+    // handler claims it in `mobile_welcome_email` before sending).
+    mobile_welcome_email: (100, 3600),
 };


### PR DESCRIPTION
## Summary
Increased the rate limit for the `mobile_welcome_email` endpoint from 5 attempts per hour to 100 attempts per hour per IP address.

## Key Changes
- Updated `mobile_welcome_email` rate limit configuration from `(5, 3600)` to `(100, 3600)`
- Added detailed comment explaining the rationale: mobile carriers often place thousands of phones behind a single CGNAT address, making a low cap problematic for legitimate users on the marketing site's mobile signup form
- Noted that abuse is still bounded because each address can only be sent this email once (the handler claims it in `mobile_welcome_email` before sending)

## Implementation Details
The rate limit increase is safe because:
1. The handler claims/consumes the email address before sending, preventing duplicate sends to the same address
2. The higher limit accommodates legitimate traffic from shared mobile carrier IP addresses (CGNAT)
3. Abuse remains bounded by the one-email-per-address constraint rather than the rate limit itself

https://claude.ai/code/session_01XQTEfMNETZsFeUUeHX1fyy