### PR TITLE
feat(tasks): ungroup Created tab, sort by date created

### DIFF
--- a/apps/web/src/features/next-soup/sidebar/soup-filter-presets.test.ts
+++ b/apps/web/src/features/next-soup/sidebar/soup-filter-presets.test.ts
@@ -17,3 +17,13 @@ describe('mail view presets', () => {
     }
   });
 });
+
+describe('tasks view presets', () => {
+  const ctx = { userId: 'user-1', isTeamAdmin: false };
+
+  it('shows the Created tab as a flat list sorted by date created', () => {
+    const preset = getViewPreset('tasks', 'created-by-me', ctx);
+    expect(preset?.groupBy).toBeUndefined();
+    expect(preset?.sort).toEqual(['created_at']);
+  });
+});

--- a/apps/web/src/features/next-soup/sidebar/soup-filter-presets.ts
+++ b/apps/web/src/features/next-soup/sidebar/soup-filter-presets.ts
@@ -24,6 +24,13 @@ type SoupFiltersPreset = {
    * `entity_type`, `project`, or `property:<definition-id>`).
    */
   groupBy?: string;
+  /**
+   * Initial sort to apply when this tab is selected (ordered by priority).
+   * Uses the same ids as `soup.sort.setAll` (e.g. `created_at`,
+   * `updated_at`). Only set when the tab wants a sort other than the view's
+   * persisted/default sort.
+   */
+  sort?: string[];
 };
 
 // Tab preset configuration types
@@ -366,7 +373,9 @@ export const VIEW_TAB_PRESETS: Record<ListView, ViewTabConfig> = {
             and: ['task', 'owned-entity'],
             or: [...OPEN_TASK_STATUS_FILTER_IDS],
           },
-          groupBy: `property:${SYSTEM_PROPERTY_IDS.STATUS}`,
+          // Created tasks are shown as a flat list sorted by date created
+          // rather than grouped by status.
+          sort: ['created_at'],
         };
       },
       all: () => ({

--- a/apps/web/src/features/next-soup/soup-view/soup-view-tabs.tsx
+++ b/apps/web/src/features/next-soup/soup-view/soup-view-tabs.tsx
@@ -209,6 +209,13 @@ export const useApplyPreset = () => {
         soup.predicates.set(nextClientFilters);
       }
       soup.grouping.setActiveGroupId(preset.groupBy);
+      // Only override the active sort when the tab preset asks for a specific
+      // one; otherwise the view keeps its persisted/default sort.
+      if (preset.sort) {
+        soup.sort.setAll(
+          preset.sort as Parameters<typeof soup.sort.setAll>[0]
+        );
+      }
     });
 
     // The new tab replaces the dataset wholesale, and row focus only follows

--- a/apps/web/src/features/next-soup/soup-view/soup-view-tabs.tsx
+++ b/apps/web/src/features/next-soup/soup-view/soup-view-tabs.tsx
@@ -212,9 +212,7 @@ export const useApplyPreset = () => {
       // Only override the active sort when the tab preset asks for a specific
       // one; otherwise the view keeps its persisted/default sort.
       if (preset.sort) {
-        soup.sort.setAll(
-          preset.sort as Parameters<typeof soup.sort.setAll>[0]
-        );
+        soup.sort.setAll(preset.sort as Parameters<typeof soup.sort.setAll>[0]);
       }
     });
 


### PR DESCRIPTION
## What & why

The **Tasks → Created** tab defaulted to being **grouped by Status**. It should instead be a flat list **sorted by date created**.

## How

- Added an optional per-tab `sort?: string[]` to `SoupFiltersPreset` (mirrors the existing `groupBy` field; uses the same ids as `soup.sort.setAll`).
- `created-by-me` tab preset: removed `groupBy: property:STATUS` and set `sort: ['created_at']`.
- `applyTabPreset` now applies `preset.sort` when a tab specifies one, guarded so tabs without a sort preset keep the view's persisted/default sort (no change for other tabs).
- Added a unit test asserting the Created tab has no `groupBy` and sorts by `created_at`.

Result: selecting the Created tab yields an ungrouped list sorted by date created (newest first).

---
_Generated by [Claude Code](https://claude.ai/code/session_016yNobmugQchtxfiXR2CkB4)_