### PR TITLE
fix(web): use one placeholder token for every text input

### DIFF
--- a/apps/web/src/features/block-automation/component/automationUtils.ts
+++ b/apps/web/src/features/block-automation/component/automationUtils.ts
@@ -11,7 +11,7 @@ import type {
 import type { ScheduleDraft, ScheduleFrequency } from './types';
 
 export const INPUT_CLASS =
-  'w-full border border-edge-muted rounded-sm bg-surface px-2 py-1.5 text-sm text-ink outline-none placeholder:text-ink/30 focus:border-accent/20 cursor-default';
+  'w-full border border-edge-muted rounded-sm bg-surface px-2 py-1.5 text-sm text-ink outline-none placeholder:text-ink-placeholder focus:border-accent/20 cursor-default';
 export const DEFAULT_TIME = '09:00';
 
 export const FREQUENCY_OPTIONS: Array<{

--- a/apps/web/src/features/block-code/component/CodeFileTypeChip.tsx
+++ b/apps/web/src/features/block-code/component/CodeFileTypeChip.tsx
@@ -95,7 +95,7 @@ export function CodeFileTypeChip() {
                   ref={searchRef}
                   type="text"
                   placeholder="Search..."
-                  class="w-full bg-transparent text-xs outline-none placeholder:text-ink-extra-muted"
+                  class="w-full bg-transparent text-xs outline-none placeholder:text-ink-placeholder"
                   value={search()}
                   onInput={(e) => setSearch(e.currentTarget.value)}
                   onKeyDown={(e) => {

--- a/apps/web/src/features/block-pdf/component/PageNumberInput.tsx
+++ b/apps/web/src/features/block-pdf/component/PageNumberInput.tsx
@@ -67,7 +67,7 @@ export function PageNumberInput() {
           <div class="cursor-default">
             <input
               class={cn(
-                'rounded-md border border-edge-muted bg-transparent px-2 text-sm text-ink outline-none placeholder:text-ink-extra-muted focus:border-accent',
+                'rounded-md border border-edge-muted bg-transparent px-2 text-sm text-ink outline-none placeholder:text-ink-placeholder focus:border-accent',
                 'font-medium cursor-default text-center',
                 getWidthClass(currentPageNumber())
               )}

--- a/apps/web/src/features/next-soup/soup-view/filters-bar/mobile-filter-drawer.tsx
+++ b/apps/web/src/features/next-soup/soup-view/filters-bar/mobile-filter-drawer.tsx
@@ -566,7 +566,7 @@ export const MobileFilterDrawer = () => {
                               setAssigneeSearch(e.currentTarget.value)
                             }
                             placeholder="Search assignees..."
-                            class="flex-1 bg-transparent text-sm outline-none placeholder:text-ink-muted"
+                            class="flex-1 bg-transparent text-sm outline-none placeholder:text-ink-placeholder"
                           />
                         </div>
                         <div class="max-h-[calc(50*var(--dvh))] overflow-y-auto scrollbar-hidden">

--- a/apps/web/src/features/next-soup/soup-view/filters-bar/searchable-multi-select.tsx
+++ b/apps/web/src/features/next-soup/soup-view/filters-bar/searchable-multi-select.tsx
@@ -279,7 +279,7 @@ export const SearchableMultiSelect = (props: SearchableMultiSelectProps) => {
             <div class="flex items-center gap-2 px-3 py-2 border-b border-edge-muted">
               <SearchIcon class="size-3.5 text-ink-muted shrink-0" />
               <Combobox.Input
-                class="flex-1 min-w-0 text-sm bg-transparent outline-none caret-accent placeholder:text-ink-faint"
+                class="flex-1 min-w-0 text-sm bg-transparent outline-none caret-accent placeholder:text-ink-placeholder"
                 placeholder={props.placeholder ?? 'Search...'}
               />
             </div>
@@ -404,7 +404,7 @@ export const SearchableMultiSelectInline = (
         <Combobox.Input
           ref={props.inputRef}
           onKeyDown={handleInputKeyDown}
-          class="flex-1 min-w-0 text-sm bg-transparent outline-none caret-accent placeholder:text-ink-faint"
+          class="flex-1 min-w-0 text-sm bg-transparent outline-none caret-accent placeholder:text-ink-placeholder"
           placeholder={props.placeholder ?? 'Search...'}
         />
       </div>

--- a/apps/web/src/features/next-soup/soup-view/views/companies/CompanyViewsMenu.tsx
+++ b/apps/web/src/features/next-soup/soup-view/views/companies/CompanyViewsMenu.tsx
@@ -277,7 +277,7 @@ export function CompanyViewsMenu() {
                 placeholder="View name"
                 class={cn(
                   'w-full rounded-md border border-edge-muted bg-transparent px-2 py-1 text-sm',
-                  'outline-none focus:border-accent placeholder:text-ink-faint'
+                  'outline-none focus:border-accent placeholder:text-ink-placeholder'
                 )}
               />
               <div class="flex items-center justify-between gap-1.5">

--- a/apps/web/src/features/onboarding/MobileWebWelcome.tsx
+++ b/apps/web/src/features/onboarding/MobileWebWelcome.tsx
@@ -57,7 +57,7 @@ export default function MobileWebWelcome(props: MobileWebWelcomeProps) {
             placeholder="name@company.com"
             value={email()}
             onInput={(e) => setEmail(e.currentTarget.value)}
-            class="w-full px-3 py-2.5 text-base border border-edge-muted rounded-lg bg-surface text-ink placeholder:text-ink/30 outline-none focus:border-accent"
+            class="w-full px-3 py-2.5 text-base border border-edge-muted rounded-lg bg-surface text-ink placeholder:text-ink-placeholder outline-none focus:border-accent"
           />
           <button
             type="submit"

--- a/apps/web/src/features/property/tags/TagEditorDialog.tsx
+++ b/apps/web/src/features/property/tags/TagEditorDialog.tsx
@@ -216,7 +216,7 @@ export function TagEditorDialog(props: {
                 onKeyDown={(event) => {
                   if (event.key === 'Enter' && canSubmit()) submit();
                 }}
-                class="h-9 w-full rounded-md border border-edge-muted bg-surface px-3 text-sm text-ink outline-none placeholder:text-ink/30 focus:border-accent"
+                class="h-9 w-full rounded-md border border-edge-muted bg-surface px-3 text-sm text-ink outline-none placeholder:text-ink-placeholder focus:border-accent"
                 placeholder="Tag name"
               />
             </EditorRow>

--- a/apps/web/src/features/settings/Account.tsx
+++ b/apps/web/src/features/settings/Account.tsx
@@ -587,7 +587,7 @@ function NameInput(props: {
     <div class="ph-no-capture group relative flex items-center gap-1.5 rounded-lg h-9 px-3 border text-sm bg-transparent text-ink-muted border-edge-muted hover:text-ink focus-within:text-ink focus-within:border-accent">
       <input
         type="text"
-        class="flex-1 min-w-0 bg-transparent outline-none border-0 p-0 text-sm placeholder:text-ink-extra-muted"
+        class="flex-1 min-w-0 bg-transparent outline-none border-0 p-0 text-sm placeholder:text-ink-placeholder"
         value={inputValue()}
         onInput={(e) => setInputValue(e.currentTarget.value)}
         onFocus={() => {

--- a/apps/web/src/features/settings/Appearance.tsx
+++ b/apps/web/src/features/settings/Appearance.tsx
@@ -410,7 +410,7 @@ function InterfaceThemeSelect(props: {
                 }}
                 placeholder="Filter themes…"
                 spellcheck={false}
-                class="h-8 w-full rounded-md border border-edge-muted bg-transparent px-2.5 text-sm text-ink outline-none placeholder:text-ink-extra-muted focus:border-accent"
+                class="h-8 w-full rounded-md border border-edge-muted bg-transparent px-2.5 text-sm text-ink outline-none placeholder:text-ink-placeholder focus:border-accent"
               />
             </div>
 

--- a/apps/web/src/features/settings/Crm.tsx
+++ b/apps/web/src/features/settings/Crm.tsx
@@ -278,7 +278,7 @@ function CrmEnablementSection() {
           value={disableConfirmation()}
           onInput={(e) => setDisableConfirmation(e.currentTarget.value)}
           placeholder={DISABLE_CRM_PHRASE}
-          class="w-full px-3 py-2 text-sm border border-edge-muted rounded-lg bg-surface text-ink placeholder:text-ink/30 outline-none focus:border-accent"
+          class="settings-input w-full"
         />
       </ConfirmDialog>
     </SettingsSection>

--- a/apps/web/src/features/settings/Team.tsx
+++ b/apps/web/src/features/settings/Team.tsx
@@ -155,12 +155,8 @@ function InviteEntryRow(props: {
           onInput={(e) => props.onEmailChange(e.currentTarget.value)}
           onBlur={() => props.onBlur()}
           placeholder="Enter email address"
-          class={cn(
-            'flex-1 min-w-0 px-3 py-2 text-sm border rounded-lg bg-surface text-ink placeholder:text-ink/30 outline-none',
-            props.error
-              ? 'border-failure focus:border-failure'
-              : 'border-edge-muted focus:border-accent'
-          )}
+          class="settings-input flex-1 min-w-0"
+          aria-invalid={!!props.error}
         />
         <Show when={props.showRemove}>
           <Tooltip label="Remove">
@@ -655,12 +651,8 @@ function CreateTeamDialog(props: { open: boolean; onClose: () => void }) {
               onInput={(e) => handleTeamNameChange(e.currentTarget.value)}
               onBlur={() => validateTeamName()}
               placeholder="My Team"
-              class={cn(
-                'w-full px-3 py-2 text-sm border rounded-lg bg-surface text-ink placeholder:text-ink/30 outline-none',
-                teamNameError()
-                  ? 'border-failure focus:border-failure'
-                  : 'border-edge-muted focus:border-accent'
-              )}
+              class="settings-input w-full"
+              aria-invalid={!!teamNameError()}
             />
             <Show when={teamNameError()}>
               <p class="text-xs text-failure-ink">{teamNameError()}</p>
@@ -1313,7 +1305,7 @@ function TeamManagement(props: {
                 value={memberQuery()}
                 onInput={(e) => setMemberQuery(e.currentTarget.value)}
                 placeholder="Filter members"
-                class="flex-1 min-w-0 bg-transparent text-sm text-ink outline-none placeholder:text-ink-extra-muted"
+                class="flex-1 min-w-0 bg-transparent text-sm text-ink outline-none placeholder:text-ink-placeholder"
               />
               <Show when={memberQuery()}>
                 <button
@@ -1435,7 +1427,7 @@ function TeamManagement(props: {
               value={deleteConfirmation()}
               onInput={(e) => setDeleteConfirmation(e.currentTarget.value)}
               placeholder={deleteConfirmationPhrase()}
-              class="w-full px-3 py-2 text-sm border border-edge-muted rounded-lg bg-surface text-ink placeholder:text-ink/30 outline-none focus:border-accent"
+              class="settings-input w-full"
             />
             <div class="flex justify-end gap-1 pt-2">
               <Button

--- a/apps/web/src/features/team-invitations/invite-modal.tsx
+++ b/apps/web/src/features/team-invitations/invite-modal.tsx
@@ -93,7 +93,7 @@ export const InviteModal = () => {
               value={value()}
               onInput={(e) => setValue(e.currentTarget.value)}
               rows={4}
-              class="w-full px-3 py-2 text-sm/relaxed border border-edge-muted rounded-lg bg-surface text-ink placeholder:text-ink/30 outline-none focus:border-accent resize-none"
+              class="w-full px-3 py-2 text-sm/relaxed border border-edge-muted rounded-lg bg-surface text-ink placeholder:text-ink-placeholder outline-none focus:border-accent resize-none"
             />
           </div>
 

--- a/apps/web/src/features/theme/components/ThemeEditor.tsx
+++ b/apps/web/src/features/theme/components/ThemeEditor.tsx
@@ -48,7 +48,7 @@ export function ThemeEditor(props: {
             spellcheck={false}
             placeholder="Theme name"
             aria-label="Theme name"
-            class="w-40 min-w-0 rounded-md border border-edge-muted bg-transparent px-2 py-1 text-xs text-ink outline-none placeholder:text-ink-extra-muted focus:border-accent"
+            class="w-40 min-w-0 rounded-md border border-edge-muted bg-transparent px-2 py-1 text-xs text-ink outline-none placeholder:text-ink-placeholder focus:border-accent"
           />
           <div class="flex-1" />
           <Button

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -565,8 +565,10 @@ a {
    Apply to an <input>; pair with a width utility (e.g. `w-full`) as needed. */
 @utility settings-input {
   @apply h-9 px-3 rounded-lg border border-edge-muted bg-transparent text-sm text-ink outline-none transition-colors;
+  /* Matches the composer/chat placeholder token so hint text reads the same
+     faintness everywhere, rather than settings sitting more prominent. */
   &::placeholder {
-    @apply text-ink-extra-muted;
+    @apply text-ink-placeholder;
   }
   &:hover {
     @apply border-edge;

--- a/apps/web/src/lib/core/component/FindBar.tsx
+++ b/apps/web/src/lib/core/component/FindBar.tsx
@@ -167,7 +167,7 @@ function FindBarInput(props: { placeholder?: string; autofocus?: boolean }) {
     <input
       ref={inputEl}
       type="text"
-      class="min-w-0 flex-1 bg-transparent border-0 px-1 text-sm text-ink placeholder:text-ink-muted focus:outline-none focus:ring-0"
+      class="min-w-0 flex-1 bg-transparent border-0 px-1 text-sm text-ink placeholder:text-ink-placeholder focus:outline-none focus:ring-0"
       placeholder={props.placeholder ?? 'Find'}
       value={controller.query()}
       onInput={(e) => controller.setQuery(e.currentTarget.value)}


### PR DESCRIPTION
## What

Every placeholder in the web app now resolves to `ink-placeholder` — 44 usages, no holdouts. It was styled four different ways before:

| Was | Where |
|---|---|
| `text-ink-placeholder` (c4) | chat/channel composers, most channel inputs — **the convention this PR standardizes on** |
| `text-ink-extra-muted` (c2) | settings panels, PDF page number, code file-type chip |
| `text-ink-muted` (c1) | find bar, mobile filter drawer |
| `text-ink/30` (fixed alpha) | CRM/team confirm dialogs, tag editor, invite modal, mobile welcome, automation inputs |
| `text-ink-faint` (**undefined**) | next-soup filter bars, company views menu |

The ink ramp already has a purpose-named step for this — `--color-ink-placeholder: var(--c4)`, the faintest — so `settings-input` in `index.css` and 15 call sites now point at it.

## Why

Placeholders read at three different weights depending on which screen you were on, and settings sat two ramp steps more prominent than the composer right next to it. The `text-ink/30` variant was worse than merely inconsistent: a fixed 30% alpha of ink doesn't adapt per theme the way the ramp tokens do.

## Two changes that are more than a color swap

**`text-ink-faint` was a dead class.** That token is never defined, and since `index.css` sets `--color-*: initial` to disable Tailwind's default palette, those three classes emitted no CSS at all — the placeholders were inheriting full body-text color. The next-soup filter bars and company views menu will now go properly faint, so that's a visible change rather than a subtle one. `text-ink-muted` → c4 is also a three-step shift, visible in the find bar and mobile filter drawer.

**Four settings fields adopted the shared utility.** The CRM disable confirm, team invite row, create-team name, and delete-team confirm were hand-rolling `settings-input`'s geometry. They now use the utility, which lets the two with error states drop their bespoke `border-failure focus:border-failure` branches for `aria-invalid` — a state the utility already styles, ordered after `:focus` so the error border wins while focused. This is how the team slug field already worked. Geometry is unchanged (`px-3 py-2 text-sm` and `h-9 px-3` are both 36px), and `bg-surface` → `bg-transparent` renders identically since all four sit inside a dialog panel that supplies the fill.

## Deliberately left alone

The Quill rule at `SignatureEditor.css:99` keeps its hardcoded `#8a8a8a`. That editor's surface is always white regardless of app theme because the signature ships as HTML email and recipients see it on white — a theme token there would vanish in dark mode.

## Reviewer notes

- `bunx tsc --noEmit` and `biome check` are clean for every touched file. Pre-existing repo-wide errors trace to the unbuilt `@macro-inc/observability` package (including cascading implicit-any in `features/block-md`) and are unrelated.
- **Not visually verified** — worth a look at the surfaces where the shift is largest: the next-soup filter bars and company views menu (previously unstyled), the find bar, and the four settings dialogs that changed utility.
- Five **non-placeholder** `text-ink-faint` usages remain unstyled for the same dead-token reason — two call-recording states, two attachment empty states. Out of scope here since they need a per-site judgment between `ink-muted` and `ink-extra-muted`; tracked separately.