### PR TITLE
Add narrow sidebar variant with rail-style navigation

### DIFF
--- a/apps/web/src/components/app/Layout.tsx
+++ b/apps/web/src/components/app/Layout.tsx
@@ -32,11 +32,11 @@ import { AutomationComposer } from '@block-automation/component';
 import { useCallContextOptional } from '@channel/Call/CallContext';
 import { InCallPanel } from '@channel/Call/InCallPanel';
 import { CreateChannelModal } from '@channel/CreateChannelModal';
-import {
-  AppSidebar,
-  GoToHotkeys,
-  type SidebarState,
-} from '@components/app/app-sidebar/sidebar';
+import { AppSidebar, GoToHotkeys } from '@components/app/app-sidebar/sidebar';
+import type {
+  SidebarState,
+  VisibleSidebarState,
+} from '@components/app/app-sidebar/sidebar-links';
 import { registerMailtoComposerHandler } from '@components/app/mailtoComposerHandler';
 import {
   isSidebarVisible,
@@ -101,6 +101,26 @@ const [sidebarState, setSidebarState] = makePersisted(
   }
 );
 
+/**
+ * The variant to restore when the sidebar is shown again, so a user on the
+ * narrow rail who hides the sidebar doesn't come back to the wide one.
+ */
+const [preferredSidebarState, setPreferredSidebarState] = makePersisted(
+  createSignal<VisibleSidebarState>('expanded'),
+  { name: 'sidebar-preferred-state' }
+);
+
+/** Show the sidebar again in whichever variant the user last chose. */
+const showSidebar = () => setSidebarState(preferredSidebarState());
+
+/** Switch variants (wide <-> narrow), remembering the choice. */
+const selectSidebarState = (state: SidebarState) => {
+  if (state === 'expanded' || state === 'narrow') {
+    setPreferredSidebarState(state);
+  }
+  setSidebarState(state);
+};
+
 export function Layout(props: RouteSectionProps) {
   const isAuthenticated = useIsAuthenticated();
   const location = useLocation();
@@ -118,7 +138,7 @@ export function Layout(props: RouteSectionProps) {
       <SidebarCollapseContext.Provider
         value={{
           isCollapsed: () => sidebarVisible() && sidebarState() === 'slim',
-          expand: () => setSidebarState('expanded'),
+          expand: showSidebar,
         }}
       >
         <LayoutInner {...props} />
@@ -346,12 +366,13 @@ function LayoutInner(props: RouteSectionProps) {
   const sidebarCollapsed = createMemo(
     () => isSidebarVisible() && sidebarState() === 'slim'
   );
+  // Only the wide sidebar has room for the call panel; on the rail (and when
+  // collapsed) the call UI floats over the app instead.
+  const callWidgetFloats = createMemo(
+    () => isSidebarVisible() && sidebarState() !== 'expanded'
+  );
   const activeCallWidgetVisible = createMemo(
-    () =>
-      isSidebarVisible() &&
-      sidebarState() === 'slim' &&
-      !!callCtx?.isInCall() &&
-      !callCtx?.isCallPage()
+    () => callWidgetFloats() && !!callCtx?.isInCall() && !callCtx?.isCallPage()
   );
   let sidebarOverlayCloseTimer: ReturnType<typeof setTimeout> | undefined;
 
@@ -477,13 +498,14 @@ function LayoutInner(props: RouteSectionProps) {
               sidebarState={sidebarState()}
               overlayOpen={sidebarOverlayOpen()}
               onOverlayOpenChange={setSidebarOverlayOpenGuarded}
+              onStateChange={selectSidebarState}
               onOpenChange={(open) => {
                 if (!open) {
                   setSidebarState(isMobile() ? 'hidden' : 'slim');
                   return;
                 }
 
-                setSidebarState('expanded');
+                showSidebar();
               }}
             />
           </Show>
@@ -507,11 +529,7 @@ function LayoutInner(props: RouteSectionProps) {
         </ItemDndProvider>
       </div>
       <CollapsedSidebarIncomingCallWidget
-        visible={
-          isSidebarVisible() &&
-          sidebarState() === 'slim' &&
-          incomingCallWidgetVisible()
-        }
+        visible={callWidgetFloats() && incomingCallWidgetVisible()}
         activeCallWidgetVisible={activeCallWidgetVisible()}
       />
       <CollapsedSidebarCallWidget visible={activeCallWidgetVisible()} />

--- a/apps/web/src/components/app/app-sidebar/narrow-sidebar-styles.ts
+++ b/apps/web/src/components/app/app-sidebar/narrow-sidebar-styles.ts
@@ -1,0 +1,22 @@
+/**
+ * Shared visuals for the narrow sidebar's big buttons: a wide icon tile with a
+ * small label underneath. Kept in their own module so components outside
+ * `app-sidebar` (the create menu) can render a matching rail button without
+ * importing the rail itself.
+ */
+
+/** The button wrapper — stacks the tile over the label and fills the rail. */
+export const RAIL_BUTTON_CLASS =
+  'group/rail flex h-auto w-full flex-col items-center justify-center gap-1 rounded-lg p-0.5 text-ink-extra-muted not-disabled:hover:bg-transparent not-disabled:hover:text-ink';
+
+/** The rounded square behind the icon; the hover/active surface. */
+export const RAIL_TILE_CLASS =
+  'flex h-9 w-11 items-center justify-center rounded-lg transition-colors [&_svg]:size-5 group-hover/rail:bg-ink/6';
+
+/** The active tile: filled and full-contrast, matching the wide sidebar's active row. */
+export const RAIL_TILE_ACTIVE_CLASS =
+  'bg-ink/8 text-ink group-hover/rail:bg-ink/8';
+
+/** The caption under the tile. Truncates rather than wrapping to two lines. */
+export const RAIL_LABEL_CLASS =
+  'w-full truncate text-center text-[10px] font-medium leading-none';

--- a/apps/web/src/components/app/app-sidebar/narrow-sidebar.tsx
+++ b/apps/web/src/components/app/app-sidebar/narrow-sidebar.tsx
@@ -1,0 +1,421 @@
+import { SidebarCreateMenu } from '@app/features/command/sidebar/sidebar-create-menu';
+import { useGettingStartedEnabled } from '@app/features/getting-started/account-gate';
+import { createGettingStartedSidebarVisibility } from '@app/features/getting-started/sidebar-visibility';
+import { requestSearchFocus } from '@app/features/next-soup/soup-view/search-controllers';
+import {
+  InviteModal,
+  setInviteModalOpen,
+} from '@app/features/team-invitations/invite-modal';
+import { useAnalytics } from '@app/lib/analytics/analytics-context';
+import { globalSplitManager } from '@app/signal/splitLayout';
+import {
+  RAIL_BUTTON_CLASS,
+  RAIL_LABEL_CLASS,
+  RAIL_TILE_ACTIVE_CLASS,
+  RAIL_TILE_CLASS,
+} from '@components/app/app-sidebar/narrow-sidebar-styles';
+import { SidebarDropdownLink } from '@components/app/app-sidebar/sidebar-dropdown-link';
+import {
+  buildSidebarLinks,
+  goToHotkeyVisible,
+  navigateToSidebarView,
+  sectionVisibility,
+  type SidebarItem,
+  type SidebarState,
+  type TryItemId,
+  tryVisibility,
+  WORKSPACE_LINK_IDS,
+} from '@components/app/app-sidebar/sidebar-links';
+import { SidebarSettingsWidget } from '@components/app/app-sidebar/sidebar-settings-widget';
+import { useSplitLayout } from '@components/app/split-layout/layout';
+import { ContextMenuContent, MenuItem } from '@core/component/ContextMenu';
+import {
+  type SettingsTab,
+  useSettingsState,
+} from '@core/constant/SettingsState';
+import {
+  getSettingsTabItem,
+  useSettingsTabAvailable,
+} from '@core/constant/settingsTabsConfig';
+import { TOKENS } from '@core/hotkey/tokens';
+import LogoIcon from '@icon/macro-logo.svg';
+import { ContextMenu } from '@kobalte/core/context-menu';
+import DotsThreeIcon from '@phosphor/dots-three.svg';
+import UsersThreeIcon from '@phosphor/users-three.svg';
+import { useLocation } from '@solidjs/router';
+import { Button, cn, Dropdown, Hotkey } from '@ui';
+import { type Component, createMemo, createSignal, For, Show } from 'solid-js';
+import { Dynamic } from 'solid-js/web';
+
+/**
+ * The narrow sidebar: a Slack-style rail of big buttons, one per feature —
+ * a wide icon tile with the feature name underneath. It replaces the wide
+ * sidebar's scrolling list rather than sitting next to it, so everything that
+ * only makes sense at full width (favorites, recent channels, promo cards,
+ * per-inbox rows) is left to the wide variant; workspace links the user hid,
+ * plus the "Try" shortcuts, stay reachable through the rail's More menu.
+ */
+
+type NarrowSidebarProps = {
+  /** Switch variants — the logo tile uses it to go back to the wide list. */
+  onStateChange: (state: SidebarState) => void;
+};
+
+type NarrowSidebarLinkProps = {
+  link: SidebarItem;
+};
+
+/**
+ * One rail button. Mirrors the wide sidebar row's behavior — mousedown
+ * navigates, shift opens a new split, right-click offers the split targets —
+ * with the label under the icon instead of beside it.
+ */
+const NarrowSidebarLink = (props: NarrowSidebarLinkProps) => {
+  const [isHovering, setIsHovering] = createSignal(false);
+  const analytics = useAnalytics();
+  const layout = useSplitLayout();
+  const location = useLocation();
+
+  // Always read the manager signal live: it is undefined until the split
+  // layout mounts, which happens after the sidebar.
+  const isActive = () => {
+    const activeContent = globalSplitManager()?.activeSplit()?.content();
+    if (!activeContent) {
+      const paths = location.pathname.split('/').filter(Boolean);
+      return paths.includes(props.link.id);
+    }
+    return activeContent.id === props.link.id;
+  };
+
+  const content = () =>
+    ({
+      type: 'component',
+      id: props.link.id,
+      params: props.link.params,
+    }) as const;
+
+  const canOpenInNewSplit = () =>
+    globalSplitManager()?.canAppendSplit() ?? true;
+  const canOpenFullscreen = () => layout.getSplitCount() > 1;
+
+  const openInCurrentSplit = () =>
+    layout.openWithSplit(content(), {
+      allowDuplicate: true,
+      mergeHistory: false,
+      referredFrom: 'sidebar',
+    });
+
+  const openInNewSplit = () => {
+    const manager = globalSplitManager();
+    if (!manager || !manager.canAppendSplit()) return;
+
+    analytics.track('split_created', { from: 'sidebar' });
+
+    manager.createNewSplit({
+      content: content(),
+      activate: true,
+      allowDuplicate: true,
+      referredFrom: 'sidebar',
+    });
+  };
+
+  const openFullscreen = () => {
+    const split = layout.replaceAllSplits(content(), {
+      referredFrom: 'sidebar',
+    });
+    if (props.link.id === 'search' && split) requestSearchFocus(split.id);
+    globalSplitManager()?.returnFocus();
+  };
+
+  const navigate = (shiftKey: boolean) => {
+    analytics.track('sidebar_click', { view: props.link.id });
+    let handle = globalSplitManager()?.activeSplit();
+    const currentContent = handle?.content();
+    const isSameContent =
+      currentContent?.type === 'component' &&
+      currentContent.id === props.link.id;
+
+    // Re-focusing the search input is the useful no-op when Search is already
+    // up; every other link simply stays put.
+    if (!isSameContent || shiftKey) {
+      handle = navigateToSidebarView({
+        viewId: props.link.id,
+        params: props.link.params,
+        shiftKey,
+        activeSplit: handle,
+        openWithSplit: layout.openWithSplit,
+        referredFrom: 'sidebar',
+      });
+    }
+
+    if (props.link.id === 'search' && handle) requestSearchFocus(handle.id);
+    globalSplitManager()?.returnFocus();
+  };
+
+  return (
+    <ContextMenu>
+      <ContextMenu.Trigger class="w-full">
+        <Button
+          variant="ghost"
+          fullWidth
+          draggable={false}
+          data-sidebar-link={props.link.id}
+          data-active={isActive() ? '' : undefined}
+          class={RAIL_BUTTON_CLASS}
+          label={`Go to ${props.link.label}`}
+          hotkey={
+            props.link.standaloneHotkey
+              ? props.link.hotkeyToken
+              : [TOKENS.sidebar.goToLeader, props.link.hotkeyToken]
+          }
+          tooltipPlacement="right"
+          onMouseEnter={() => setIsHovering(true)}
+          onMouseLeave={() => setIsHovering(false)}
+          onMouseDown={(e) => {
+            if (e.button !== 0) return;
+            e.preventDefault();
+            navigate(e.shiftKey);
+          }}
+        >
+          <div
+            class={cn(
+              RAIL_TILE_CLASS,
+              isActive() && RAIL_TILE_ACTIVE_CLASS,
+              'relative'
+            )}
+          >
+            <Show when={props.link.icon}>
+              <Dynamic
+                component={props.link.icon}
+                triggerAnimation={isHovering()}
+              />
+            </Show>
+            <Show when={goToHotkeyVisible()}>
+              <div class="absolute -bottom-0.5 -right-0.5 flex size-4 items-center justify-center overflow-hidden rounded-xs border border-accent/30 bg-accent/10 text-xs text-accent">
+                <Hotkey token={props.link.hotkeyToken} />
+              </div>
+            </Show>
+          </div>
+          <span class={RAIL_LABEL_CLASS}>{props.link.label}</span>
+        </Button>
+      </ContextMenu.Trigger>
+
+      <ContextMenu.Portal>
+        <ContextMenuContent class="text-xs text-ink-muted">
+          <MenuItem
+            text="Open in new split"
+            onClick={openInNewSplit}
+            disabled={!canOpenInNewSplit()}
+          />
+          <Show when={canOpenFullscreen()}>
+            <MenuItem text="Open fullscreen" onClick={openFullscreen} />
+          </Show>
+          <MenuItem text="Open in current split" onClick={openInCurrentSplit} />
+        </ContextMenuContent>
+      </ContextMenu.Portal>
+    </ContextMenu>
+  );
+};
+
+type NarrowTryItem = {
+  id: TryItemId;
+  label: string;
+  icon: Component<{ triggerAnimation?: boolean; class?: string }>;
+  onSelect: () => void;
+};
+
+/**
+ * The rail's overflow menu: the workspace links the user hid from the sidebar
+ * plus the "Try" shortcuts, which have no room of their own on the rail.
+ */
+const NarrowMoreMenu = (props: {
+  hiddenLinks: SidebarItem[];
+  tryItems: NarrowTryItem[];
+}) => (
+  <Dropdown placement="right-start" gutter={8}>
+    <Dropdown.Trigger
+      as={Button}
+      variant="ghost"
+      fullWidth
+      class={RAIL_BUTTON_CLASS}
+      label="More"
+      tooltipPlacement="right"
+      onMouseDown={(e: MouseEvent) => {
+        if (e.button !== 0) return;
+        e.preventDefault();
+      }}
+    >
+      <div class={RAIL_TILE_CLASS}>
+        <DotsThreeIcon />
+      </div>
+      <span class={RAIL_LABEL_CLASS}>More</span>
+    </Dropdown.Trigger>
+    <Dropdown.Content class="w-56 shadow-menu">
+      <Show when={props.hiddenLinks.length > 0}>
+        <Dropdown.Group>
+          <Dropdown.GroupLabel>Workspace</Dropdown.GroupLabel>
+          <For each={props.hiddenLinks}>
+            {(link) => <SidebarDropdownLink {...link} />}
+          </For>
+        </Dropdown.Group>
+      </Show>
+      <Show when={props.tryItems.length > 0}>
+        <Dropdown.Group>
+          <Dropdown.GroupLabel>Try</Dropdown.GroupLabel>
+          <For each={props.tryItems}>
+            {(item) => (
+              <Dropdown.Item
+                class="min-h-8 gap-2 px-2.5 text-[13px]"
+                onSelect={item.onSelect}
+              >
+                <div class="shrink-0 [&_svg]:size-3.5">
+                  <Dynamic component={item.icon} />
+                </div>
+                <span class="min-w-0 flex-1 truncate text-ink">
+                  {item.label}
+                </span>
+              </Dropdown.Item>
+            )}
+          </For>
+        </Dropdown.Group>
+      </Show>
+    </Dropdown.Content>
+  </Dropdown>
+);
+
+export const NarrowSidebar = (props: NarrowSidebarProps) => {
+  const { openSettings, selectTab, settingsOpen } = useSettingsState();
+  const isTabAvailable = useSettingsTabAvailable();
+  const gettingStartedEnabled = useGettingStartedEnabled();
+  const gettingStartedVisibility = createGettingStartedSidebarVisibility();
+
+  const allLinks = createMemo((): SidebarItem[] =>
+    buildSidebarLinks(gettingStartedEnabled())
+  );
+
+  const findLink = (id: SidebarItem['id']) =>
+    allLinks().find((link) => link.id === id && !link.hiddenFromSidebar);
+
+  const openSettingsTab = (tab: SettingsTab) => {
+    if (!isTabAvailable(tab)) return;
+    if (settingsOpen()) {
+      selectTab(tab);
+      return;
+    }
+    openSettings(tab);
+  };
+
+  /**
+   * Search leads the rail (it is `hiddenFromSidebar` in the wide list, which
+   * carries it in the header instead), then the top-level views, then the
+   * workspace links the user kept.
+   */
+  const railLinks = createMemo(() => {
+    const search = allLinks().find((link) => link.id === 'search');
+    const top = ['home', 'getting-started', 'inbox', 'activity']
+      .filter(
+        (id) => id !== 'getting-started' || !gettingStartedVisibility.hidden()
+      )
+      .map((id) => findLink(id));
+    const workspace = WORKSPACE_LINK_IDS.filter(
+      (id) => sectionVisibility()[id]
+    ).map((id) => findLink(id));
+
+    return [search, ...top, ...workspace].filter(
+      (link): link is SidebarItem => link !== undefined
+    );
+  });
+
+  const hiddenWorkspaceLinks = createMemo(() =>
+    WORKSPACE_LINK_IDS.filter((id) => !sectionVisibility()[id])
+      .map((id) => findLink(id))
+      .filter((link): link is SidebarItem => link !== undefined)
+  );
+
+  const tryItems = createMemo<NarrowTryItem[]>(() => {
+    const items: NarrowTryItem[] = [];
+    const addTryItem = (
+      id: TryItemId,
+      label: string,
+      icon: NarrowTryItem['icon'],
+      onSelect: () => void
+    ) => {
+      if (!tryVisibility()[id]) return;
+      items.push({ id, label, icon, onSelect });
+    };
+
+    const connected = getSettingsTabItem('Connected');
+    if (connected && isTabAvailable('Connected')) {
+      addTryItem('connect', 'Connect', connected.icon, () =>
+        openSettingsTab('Connected')
+      );
+    }
+
+    addTryItem('invite', 'Invite', UsersThreeIcon, () =>
+      setInviteModalOpen(true)
+    );
+
+    const mobile = getSettingsTabItem('Mobile App');
+    if (mobile && isTabAvailable('Mobile App')) {
+      addTryItem('mobile', 'Mobile', mobile.icon, () =>
+        openSettingsTab('Mobile App')
+      );
+    }
+    return items;
+  });
+
+  const showMore = () =>
+    hiddenWorkspaceLinks().length > 0 || tryItems().length > 0;
+
+  return (
+    <div
+      class="group/sidebar relative flex h-full w-18 shrink-0 flex-col items-center overflow-hidden bg-surface pt-2.5 pb-2 text-[13px]"
+      data-sidebar="narrow"
+    >
+      <Button
+        variant="ghost"
+        class="size-9 shrink-0 rounded-lg p-0 text-accent"
+        label="Expand sidebar"
+        hotkey={TOKENS.global.toggleSidebar}
+        tooltipPlacement="right"
+        onMouseDown={(e) => {
+          if (e.button !== 0) return;
+          e.preventDefault();
+        }}
+        onClick={() => props.onStateChange('expanded')}
+      >
+        <LogoIcon class="size-5" />
+      </Button>
+
+      <nav class="mt-2 min-h-0 w-full flex-1 overflow-y-auto px-1.5 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+        <ul class="flex w-full flex-col items-center gap-0.5">
+          <For each={railLinks()}>
+            {(link) => (
+              <li class="w-full">
+                <NarrowSidebarLink link={link} />
+              </li>
+            )}
+          </For>
+          <Show when={showMore()}>
+            <li class="w-full">
+              <NarrowMoreMenu
+                hiddenLinks={hiddenWorkspaceLinks()}
+                tryItems={tryItems()}
+              />
+            </li>
+          </Show>
+        </ul>
+      </nav>
+
+      <div class="mt-1 flex w-full shrink-0 flex-col items-center gap-1 border-t border-edge-muted px-1.5 pt-2">
+        <SidebarCreateMenu isSlim={() => false} variant="rail" />
+        <SidebarSettingsWidget
+          isSlim={() => false}
+          onSelect={openSettingsTab}
+          variant="rail"
+        />
+      </div>
+      <InviteModal />
+    </div>
+  );
+};

--- a/apps/web/src/components/app/app-sidebar/sidebar-dropdown-link.tsx
+++ b/apps/web/src/components/app/app-sidebar/sidebar-dropdown-link.tsx
@@ -1,0 +1,124 @@
+import { requestSearchFocus } from '@app/features/next-soup/soup-view/search-controllers';
+import { useAnalytics } from '@app/lib/analytics/analytics-context';
+import { globalSplitManager } from '@app/signal/splitLayout';
+import {
+  navigateToSidebarView,
+  type SidebarItem,
+} from '@components/app/app-sidebar/sidebar-links';
+import { useSplitLayout } from '@components/app/split-layout/layout';
+import { ContextMenuContent, MenuItem } from '@core/component/ContextMenu';
+import { ContextMenu } from '@kobalte/core/context-menu';
+import { useLocation } from '@solidjs/router';
+import { cn, Dropdown, Hotkey } from '@ui';
+import { type ComponentProps, createSignal, onCleanup, Show } from 'solid-js';
+import { Dynamic } from 'solid-js/web';
+
+/**
+ * A sidebar link rendered as a dropdown row: used for links that overflow out
+ * of the visible sidebar — the wide sidebar's collapsed sections and the
+ * narrow rail's "More" menu.
+ */
+export const SidebarDropdownLink = (
+  props: SidebarItem & {
+    onContextMenuOpenChange?: (open: boolean) => void;
+  }
+) => {
+  const analytics = useAnalytics();
+  const layout = useSplitLayout();
+  const location = useLocation();
+  const [isHovering, setIsHovering] = createSignal(false);
+  let contextMenuOpen = false;
+
+  const isActive = () => {
+    const activeContent = globalSplitManager()?.activeSplit()?.content();
+    if (!activeContent) {
+      return location.pathname.split('/').filter(Boolean).includes(props.id);
+    }
+    return activeContent.id === props.id;
+  };
+
+  const handleContextMenuOpenChange = (open: boolean) => {
+    contextMenuOpen = open;
+    props.onContextMenuOpenChange?.(open);
+  };
+
+  onCleanup(() => {
+    if (contextMenuOpen) props.onContextMenuOpenChange?.(false);
+  });
+
+  const open = (newSplit = false) => {
+    analytics.track('sidebar_click', { view: props.id });
+    const handle = navigateToSidebarView({
+      viewId: props.id,
+      params: props.params,
+      shiftKey: newSplit,
+      activeSplit: globalSplitManager()?.activeSplit(),
+      openWithSplit: layout.openWithSplit,
+      referredFrom: 'sidebar',
+    });
+    if (props.id === 'search' && handle) requestSearchFocus(handle.id);
+    globalSplitManager()?.returnFocus();
+    return handle;
+  };
+
+  const canOpenInNewSplit = () =>
+    globalSplitManager()?.canAppendSplit() ?? false;
+  const canOpenFullscreen = () => layout.getSplitCount() > 1;
+  const openInNewSplit = () => {
+    if (canOpenInNewSplit()) open(true);
+  };
+  const openInCurrentSplit = () => open(false);
+  const openFullscreen = () => {
+    analytics.track('sidebar_click', { view: props.id });
+    const handle = layout.replaceAllSplits(
+      { type: 'component', id: props.id, params: props.params },
+      { referredFrom: 'sidebar' }
+    );
+    if (props.id === 'search' && handle) requestSearchFocus(handle.id);
+    globalSplitManager()?.returnFocus();
+  };
+
+  const ContextMenuTriggerItem = (
+    triggerProps: ComponentProps<typeof ContextMenu.Trigger>
+  ) => (
+    <ContextMenu onOpenChange={handleContextMenuOpenChange}>
+      <ContextMenu.Trigger {...triggerProps} />
+      <ContextMenu.Portal>
+        <ContextMenuContent class="z-tool-tip! text-xs text-ink-muted">
+          <MenuItem
+            text="Open in new split"
+            onClick={openInNewSplit}
+            disabled={!canOpenInNewSplit()}
+          />
+          <Show when={canOpenFullscreen()}>
+            <MenuItem text="Open fullscreen" onClick={openFullscreen} />
+          </Show>
+          <MenuItem text="Open in current split" onClick={openInCurrentSplit} />
+        </ContextMenuContent>
+      </ContextMenu.Portal>
+    </ContextMenu>
+  );
+
+  return (
+    <Dropdown.Item
+      as={ContextMenuTriggerItem}
+      class={cn(
+        'min-h-8 gap-2 px-2.5 text-[13px]',
+        isActive() &&
+          'bg-ink/6 text-ink hover:bg-ink/6 data-highlighted:bg-ink/6'
+      )}
+      data-active={isActive() ? '' : undefined}
+      onMouseEnter={() => setIsHovering(true)}
+      onMouseLeave={() => setIsHovering(false)}
+      onSelect={openInCurrentSplit}
+    >
+      <Show when={props.icon}>
+        <div class="shrink-0 [&_svg]:size-3.5">
+          <Dynamic component={props.icon} triggerAnimation={isHovering()} />
+        </div>
+      </Show>
+      <span class="min-w-0 flex-1 truncate text-ink">{props.label}</span>
+      <Hotkey token={props.hotkeyToken} theme="subtle" class="ml-6" />
+    </Dropdown.Item>
+  );
+};

--- a/apps/web/src/components/app/app-sidebar/sidebar-links.ts
+++ b/apps/web/src/components/app/app-sidebar/sidebar-links.ts
@@ -1,0 +1,362 @@
+import { LIST_VIEW_PATHS, type ListView } from '@app/constants/list-views';
+import { buildDocumentTypeQuery } from '@app/features/next-soup/filters/configs/document-type-query';
+import { getDocumentsFilterSplit } from '@app/features/next-soup/soup-view/documents-filter-controllers';
+import type { useSplitLayout } from '@components/app/split-layout/layout';
+import type {
+  ReferredFrom,
+  SplitHandle,
+} from '@components/app/split-layout/layoutManager';
+import {
+  ENABLE_ACTIVITY,
+  ENABLE_CALLS,
+  ENABLE_CRM,
+} from '@core/constant/featureFlags';
+import { clearPressedKeys } from '@core/hotkey/state';
+import { type HotkeyToken, TOKENS } from '@core/hotkey/tokens';
+import type { ValidHotkey } from '@core/hotkey/types';
+import { activateClosestDOMScope } from '@core/hotkey/utils';
+import { AnimatedActivityIcon } from '@icon/wide-activity';
+import { AnimatedCallIcon } from '@icon/wide-call';
+import { AnimatedChannelIcon } from '@icon/wide-channel';
+import { AnimatedCompanyIcon } from '@icon/wide-company';
+import { AnimatedEmailIcon } from '@icon/wide-email';
+import { AnimatedFileMdIcon } from '@icon/wide-fileMd';
+import { AnimatedInboxIcon } from '@icon/wide-inbox';
+import { AnimatedSearchIcon } from '@icon/wide-search';
+import { AnimatedStarIcon } from '@icon/wide-star';
+import { AnimatedTaskIcon } from '@icon/wide-task';
+import CompassIcon from '@phosphor/compass.svg';
+import HomeIcon from '@phosphor/house.svg';
+import { makePersisted } from '@solid-primitives/storage';
+import { type Component, createSignal, type JSX } from 'solid-js';
+/**
+ * Link data, navigation helpers, and persisted customization shared by both
+ * sidebar variants (the wide list in `sidebar.tsx` and the Slack-style rail in
+ * `narrow-sidebar.tsx`) plus the always-mounted `GoToHotkeys` registrar, so
+ * their link sets can't drift.
+ */
+
+export interface SidebarItem {
+  id: ListView | (string & {});
+  label: string;
+  href: string;
+  params?: Record<string, unknown>;
+  icon?: Component<
+    JSX.SvgSVGAttributes<SVGSVGElement> | { triggerAnimation?: boolean }
+  >;
+  hotkey: ValidHotkey;
+  hotkeyToken: HotkeyToken;
+  standaloneHotkey?: boolean;
+  hiddenFromSidebar?: boolean;
+}
+
+/**
+ * `expanded` is the wide list, `narrow` the icon-and-label rail, `slim` hides
+ * the sidebar behind a hover overlay, and `hidden` drops it entirely (mobile).
+ */
+export type SidebarState = 'hidden' | 'expanded' | 'narrow' | 'slim';
+
+/** The two states in which the sidebar occupies layout space. */
+export type VisibleSidebarState = Extract<SidebarState, 'expanded' | 'narrow'>;
+
+export type SidebarSectionLinkId =
+  | 'mail'
+  | 'channels'
+  | 'calls'
+  | 'documents'
+  | 'tasks'
+  | 'agents'
+  | 'companies';
+
+type SidebarSectionVisibility = Record<SidebarSectionLinkId, boolean>;
+
+export type TryItemId = 'connect' | 'invite' | 'mobile';
+
+type TryItemVisibility = Record<TryItemId, boolean>;
+
+export const WORKSPACE_LINK_IDS = [
+  'mail',
+  'channels',
+  'calls',
+  'documents',
+  'tasks',
+  'agents',
+  'companies',
+] as const;
+
+const DEFAULT_SECTION_VISIBILITY: SidebarSectionVisibility = {
+  mail: true,
+  channels: true,
+  calls: true,
+  documents: true,
+  tasks: true,
+  agents: true,
+  companies: true,
+};
+
+const DEFAULT_TRY_VISIBILITY: TryItemVisibility = {
+  connect: true,
+  invite: true,
+  mobile: true,
+};
+
+/**
+ * Which workspace links the user kept in the sidebar. Module scope (like
+ * `sidebar-state` in `Layout.tsx`) so the wide list and the narrow rail read
+ * and write the same customization — only one of them is mounted at a time.
+ */
+export const [sectionVisibility, setSectionVisibility] = makePersisted(
+  createSignal<SidebarSectionVisibility>(DEFAULT_SECTION_VISIBILITY),
+  { name: 'sidebar-section-visibility' }
+);
+
+/** Dismissal state for the "Try" shortcuts; shared for the same reason. */
+export const [tryVisibility, setTryVisibility] = makePersisted(
+  createSignal<TryItemVisibility>(DEFAULT_TRY_VISIBILITY),
+  { name: 'sidebar-try-visibility' }
+);
+
+const markdownDocumentsQuery = buildDocumentTypeQuery(['doc-markdown']);
+
+const SIDEBAR_LINKS = [
+  {
+    id: 'inbox',
+    label: 'Inbox',
+    href: LIST_VIEW_PATHS.inbox,
+    icon: AnimatedInboxIcon,
+    hotkey: 'i',
+    hotkeyToken: TOKENS.sidebar.goTo.inbox,
+  },
+  {
+    id: 'search',
+    label: 'Search',
+    href: LIST_VIEW_PATHS.search,
+    icon: AnimatedSearchIcon,
+    hotkey: '/',
+    hotkeyToken: TOKENS.sidebar.goTo.search,
+    standaloneHotkey: true,
+    hiddenFromSidebar: true,
+  },
+  {
+    id: 'agents',
+    label: 'Agents',
+    href: LIST_VIEW_PATHS.agents,
+    icon: AnimatedStarIcon,
+    hotkey: 'a',
+    hotkeyToken: TOKENS.sidebar.goTo.agents,
+  },
+  {
+    id: 'mail',
+    label: 'Email',
+    href: LIST_VIEW_PATHS.mail,
+    icon: AnimatedEmailIcon,
+    hotkey: 'e',
+    hotkeyToken: TOKENS.sidebar.goTo.mail,
+  },
+  {
+    id: 'documents',
+    label: 'Files',
+    href: LIST_VIEW_PATHS.documents,
+    icon: AnimatedFileMdIcon,
+    hotkey: 'f',
+    hotkeyToken: TOKENS.sidebar.goTo.documents,
+  },
+  {
+    id: 'documents',
+    label: 'Documents',
+    href: LIST_VIEW_PATHS.documents,
+    params: {
+      initialFilters: markdownDocumentsQuery ?? {},
+      initialClientFilters: {
+        and: ['document-or-file'],
+        or: ['doc-markdown'],
+      },
+    },
+    icon: AnimatedFileMdIcon,
+    hotkey: 'd',
+    hotkeyToken: TOKENS.sidebar.goTo.markdownDocuments,
+    hiddenFromSidebar: true,
+  },
+  {
+    id: 'tasks',
+    label: 'Tasks',
+    href: LIST_VIEW_PATHS.tasks,
+    icon: AnimatedTaskIcon,
+    hotkey: 't',
+    hotkeyToken: TOKENS.sidebar.goTo.tasks,
+  },
+  {
+    id: 'channels',
+    label: 'Channels',
+    href: LIST_VIEW_PATHS.channels,
+    icon: AnimatedChannelIcon,
+    hotkey: 'c',
+    hotkeyToken: TOKENS.sidebar.goTo.channels,
+  },
+] satisfies SidebarItem[];
+
+const CALLS_LINK: SidebarItem = {
+  id: 'calls',
+  label: 'Calls',
+  href: LIST_VIEW_PATHS.calls,
+  icon: AnimatedCallIcon,
+  hotkey: 'l',
+  hotkeyToken: TOKENS.sidebar.goTo.calls,
+};
+
+const COMPANIES_LINK: SidebarItem = {
+  id: 'companies',
+  label: 'Customers',
+  href: LIST_VIEW_PATHS.companies,
+  icon: AnimatedCompanyIcon,
+  hotkey: 'o',
+  hotkeyToken: TOKENS.sidebar.goTo.companies,
+};
+
+const DASHBOARD_LINK: SidebarItem = {
+  id: 'home',
+  label: 'Home',
+  href: '/home',
+  icon: HomeIcon,
+  hotkey: 'h',
+  hotkeyToken: TOKENS.sidebar.goTo.home,
+};
+
+const GETTING_STARTED_LINK: SidebarItem = {
+  id: 'getting-started',
+  label: 'Getting Started',
+  href: '/getting-started',
+  icon: CompassIcon,
+  hotkey: 's',
+  hotkeyToken: TOKENS.sidebar.goTo.gettingStarted,
+};
+
+const ACTIVITY_LINK: SidebarItem = {
+  id: 'activity',
+  label: 'Activity',
+  href: '/activity',
+  icon: AnimatedActivityIcon,
+  hotkey: 'y',
+  hotkeyToken: TOKENS.sidebar.goTo.activity,
+};
+
+/**
+ * Assemble the ordered sidebar link list: the static links plus Home, Getting
+ * started, and the flag-gated Activity, Calls, and CRM entries in their
+ * correct positions.
+ * Shared by both rendered sidebar variants and the always-mounted
+ * `GoToHotkeys` registrar so their link sets can't drift. Call from a reactive
+ * context — it reads `ENABLE_CALLS()` / `ENABLE_CRM()`.
+ * `showGettingStarted` is the account-age gate (`useGettingStartedEnabled`),
+ * passed in because this runs outside a component; when false the link is
+ * fully absent — row, `g s` hotkey, and command menu entry.
+ * Rendered sections additionally drop `hiddenFromSidebar` entries, which have
+ * hotkeys but no sidebar row.
+ */
+export const buildSidebarLinks = (
+  showGettingStarted: boolean
+): SidebarItem[] => {
+  let links: SidebarItem[] = [
+    DASHBOARD_LINK,
+    ...(showGettingStarted ? [GETTING_STARTED_LINK] : []),
+    ...SIDEBAR_LINKS,
+  ];
+
+  if (ENABLE_ACTIVITY) {
+    const idx = links.findIndex((link) => link.id === 'inbox');
+    links = [
+      ...links.slice(0, idx + 1),
+      ACTIVITY_LINK,
+      ...links.slice(idx + 1),
+    ];
+  }
+
+  if (ENABLE_CALLS()) {
+    const idx = links.findIndex((l) => l.id === 'channels');
+    links = [...links.slice(0, idx + 1), CALLS_LINK, ...links.slice(idx + 1)];
+  }
+
+  if (ENABLE_CRM()) {
+    // Customers sits just after Channels (and Calls when present).
+    const anchorId = ENABLE_CALLS() ? 'calls' : 'channels';
+    const idx = links.findIndex((l) => l.id === anchorId);
+    links = [
+      ...links.slice(0, idx + 1),
+      COMPANIES_LINK,
+      ...links.slice(idx + 1),
+    ];
+  }
+
+  return links;
+};
+
+type OpenWithSplitFn = ReturnType<typeof useSplitLayout>['openWithSplit'];
+
+const isMarkdownDocumentsParams = (
+  params: SidebarItem['params'] | undefined
+): boolean => {
+  const initialClientFilters = params?.initialClientFilters as
+    | { or?: readonly unknown[] }
+    | undefined;
+
+  return initialClientFilters?.or?.includes('doc-markdown') ?? false;
+};
+
+/**
+ * Navigate to a sidebar view by pushing a fresh entry into the active split.
+ * Holding shift opens it in a new split. Use in-app back/forward to return to
+ * prior entries.
+ */
+export function navigateToSidebarView(args: {
+  viewId: SidebarItem['id'];
+  params?: SidebarItem['params'];
+  shiftKey: boolean;
+  activeSplit: SplitHandle | undefined;
+  openWithSplit: OpenWithSplitFn;
+  referredFrom?: ReferredFrom;
+}): SplitHandle | undefined {
+  const { viewId, params, shiftKey, activeSplit, openWithSplit, referredFrom } =
+    args;
+
+  const activeContent = activeSplit?.content();
+  if (
+    !shiftKey &&
+    isMarkdownDocumentsParams(params) &&
+    activeContent?.type === 'component' &&
+    activeContent.id === 'documents'
+  ) {
+    const controller = activeSplit
+      ? getDocumentsFilterSplit(activeSplit.id)
+      : undefined;
+    if (controller) {
+      controller.toggleMarkdownFilter();
+      return activeSplit;
+    }
+  }
+
+  return openWithSplit(
+    { type: 'component', id: viewId, params },
+    {
+      preferNewSplit: shiftKey,
+      mergeHistory: false,
+      allowDuplicate: true,
+      referredFrom,
+    }
+  );
+}
+
+/**
+ * Whether the "g" leader key is currently awaiting a destination key. Lives
+ * at module scope so it can drive the hint overlay on the sidebar's nav
+ * icons even though the registration is owned by `GoToHotkeys`, which stays
+ * mounted regardless of whether the sidebar itself is visible.
+ */
+export const [goToHotkeyVisible, setGoToHotkeyVisible] = createSignal(false);
+
+export const resetGoToHotkeysState = () => {
+  setGoToHotkeyVisible(false);
+  // To prevent the next key from triggering the hotkey handler,
+  // we reset the pressed keys state and exit the command scope
+  clearPressedKeys();
+  activateClosestDOMScope();
+};

--- a/apps/web/src/components/app/app-sidebar/sidebar-settings-widget.tsx
+++ b/apps/web/src/components/app/app-sidebar/sidebar-settings-widget.tsx
@@ -1,0 +1,151 @@
+import { CommandState } from '@app/features/command';
+import { useLogout } from '@core/auth/logout';
+import { UserIcon } from '@core/component/UserIcon';
+import type { SettingsTab } from '@core/constant/SettingsState';
+import { useEmail, useUserId } from '@core/context/user';
+import { TOKENS } from '@core/hotkey/tokens';
+import GearIcon from '@phosphor/gear.svg';
+import SignOutIcon from '@phosphor/sign-out.svg';
+import { isRealNamePart, useOwnUserName } from '@queries/auth/user-name-self';
+import { cn, Dropdown, Hotkey } from '@ui';
+import { createMemo, Show } from 'solid-js';
+
+type SidebarSettingsWidgetProps = {
+  /** Tooltip-only mode: the wide row shows the name inline, the rail doesn't. */
+  isSlim: () => boolean;
+  onSelect: (tab: SettingsTab) => void;
+  onMenuOpenChange?: (open: boolean) => void;
+  /** `row` is the wide sidebar's full-width row; `rail` is the narrow avatar tile. */
+  variant?: 'row' | 'rail';
+};
+
+/** The account row (or rail tile) that opens the settings / log out menu. */
+export const SidebarSettingsWidget = (props: SidebarSettingsWidgetProps) => {
+  const userId = useUserId();
+  const email = useEmail();
+  const logout = useLogout();
+
+  const userName = useOwnUserName();
+  const isRail = () => props.variant === 'rail';
+
+  // Prefer the user's real name (first/last); fall back to their email.
+  const displayName = createMemo(() => {
+    const name = userName();
+    const parts = [name?.first_name, name?.last_name]
+      .map((part) => part?.trim())
+      .filter((part): part is string => isRealNamePart(part));
+    return parts.length > 0 ? parts.join(' ') : (email() ?? 'Macro User');
+  });
+
+  return (
+    <Dropdown
+      placement={isRail() ? 'right-end' : 'top-start'}
+      gutter={6}
+      onOpenChange={props.onMenuOpenChange}
+    >
+      <Dropdown.Trigger
+        variant="ghost"
+        class={cn(
+          'flex items-center rounded-md cursor-default text-ink-extra-muted not-disabled:hover:bg-ink/3 h-9',
+          isRail()
+            ? 'size-9 justify-center p-0'
+            : 'justify-start gap-3 px-1.5 py-1'
+        )}
+        label={displayName()}
+        fullWidth={!isRail()}
+        tooltipDisabled={!isRail() && !props.isSlim()}
+        tooltipPlacement="right"
+        onMouseDown={(e: MouseEvent) => {
+          if (e.button !== 0) return;
+          e.preventDefault();
+        }}
+      >
+        <Show
+          when={userId()}
+          fallback={<div class="size-5 shrink-0 rounded-full bg-ink/10" />}
+        >
+          {(id) => (
+            <div class={isRail() ? 'size-6 shrink-0' : 'size-5 shrink-0'}>
+              <UserIcon
+                id={id()}
+                size="fill"
+                suppressClick
+                showTooltip={false}
+              />
+            </div>
+          )}
+        </Show>
+        <Show when={!isRail()}>
+          <span class="flex-1 min-w-0 text-left whitespace-nowrap text-sm truncate group-data-[slim=true]/sidebar:hidden">
+            {displayName()}
+          </span>
+        </Show>
+      </Dropdown.Trigger>
+      <Dropdown.Content class="min-w-64 shadow-menu">
+        <Dropdown.Group class="p-1.5 gap-0">
+          <div class="flex items-center gap-3 px-1 py-1">
+            <Show
+              when={userId()}
+              fallback={<div class="size-10 shrink-0 rounded-full bg-ink/10" />}
+            >
+              {(id) => (
+                <div class="size-10 shrink-0">
+                  <UserIcon
+                    id={id()}
+                    size="fill"
+                    suppressClick
+                    showTooltip={false}
+                  />
+                </div>
+              )}
+            </Show>
+            <div class="min-w-0">
+              <div class="truncate text-sm font-semibold text-ink">
+                {displayName()}
+              </div>
+              <div class="truncate text-sm text-ink-muted">{email()}</div>
+            </div>
+          </div>
+          <div class="-mx-1.5 mt-2 mb-1.5 h-px bg-edge-muted" />
+          <Dropdown.Item
+            class="flex items-center gap-2 px-2.5 py-2 text-sm cursor-default outline-none text-ink-muted"
+            onSelect={() => CommandState.open()}
+          >
+            <span class="size-5 flex items-center justify-center text-ink-extra-muted">
+              ⌘
+            </span>
+            <span class="flex-1 text-ink">Command menu</span>
+            <Hotkey
+              token={TOKENS.global.commandMenu}
+              theme="subtle"
+              class="ml-6"
+            />
+          </Dropdown.Item>
+          <Dropdown.Item
+            class="flex items-center gap-2 px-2.5 py-2 text-sm cursor-default outline-none text-ink-muted"
+            onSelect={() => props.onSelect('Account')}
+          >
+            <span class="size-5 flex items-center justify-center">
+              <GearIcon class="size-4 shrink-0 text-ink-extra-muted" />
+            </span>
+            <span class="flex-1 text-ink">Settings</span>
+            <Hotkey
+              token={TOKENS.global.toggleSettings}
+              theme="subtle"
+              class="ml-6"
+            />
+          </Dropdown.Item>
+          <Dropdown.Item
+            class="flex items-center gap-2 px-2.5 py-2 text-sm cursor-default outline-none text-failure"
+            onSelect={() => logout()}
+          >
+            <span class="size-5 flex items-center justify-center">
+              <SignOutIcon class="size-4 shrink-0" />
+            </span>
+            <span>Log out</span>
+          </Dropdown.Item>
+        </Dropdown.Group>
+      </Dropdown.Content>
+    </Dropdown>
+  );
+};

--- a/apps/web/src/components/app/app-sidebar/sidebar.tsx
+++ b/apps/web/src/components/app/app-sidebar/sidebar.tsx
@@ -1,14 +1,10 @@
 import { GO_TO_COMMAND_SCOPE, GO_TO_LEADER_KEY } from '@app/constants/hotkeys';
-import { LIST_VIEW_PATHS, type ListView } from '@app/constants/list-views';
 import { SidebarActiveCallWidget } from '@app/features/block-call/sidebar/active-call-widget';
 import { ChannelsRecentWidget } from '@app/features/channel/sidebar/channels-recent-widget';
-import { CommandState } from '@app/features/command';
 import { SidebarCreateMenu } from '@app/features/command/sidebar/sidebar-create-menu';
 import { FavoritesSection } from '@app/features/favorites/sidebar/favorites-section';
 import { useGettingStartedEnabled } from '@app/features/getting-started/account-gate';
 import { createGettingStartedSidebarVisibility } from '@app/features/getting-started/sidebar-visibility';
-import { buildDocumentTypeQuery } from '@app/features/next-soup/filters/configs/document-type-query';
-import { getDocumentsFilterSplit } from '@app/features/next-soup/soup-view/documents-filter-controllers';
 import {
   getInboxFilterSplit,
   INBOX_FILTER_ENTRY_KEY,
@@ -29,28 +25,37 @@ import {
   CollapsibleSidebarSection,
   type CollapsibleSidebarSectionItem,
 } from '@components/app/app-sidebar/collapsible-sidebar-section';
+import { NarrowSidebar } from '@components/app/app-sidebar/narrow-sidebar';
+import { SidebarDropdownLink } from '@components/app/app-sidebar/sidebar-dropdown-link';
+import {
+  buildSidebarLinks,
+  goToHotkeyVisible,
+  navigateToSidebarView,
+  resetGoToHotkeysState,
+  sectionVisibility,
+  setGoToHotkeyVisible,
+  setSectionVisibility,
+  setTryVisibility,
+  type SidebarItem,
+  type SidebarSectionLinkId,
+  type SidebarState,
+  type TryItemId,
+  tryVisibility,
+  WORKSPACE_LINK_IDS,
+} from '@components/app/app-sidebar/sidebar-links';
 import {
   SidebarPromoCard,
   SidebarPromoHint,
 } from '@components/app/app-sidebar/sidebar-promo';
+import { SidebarSettingsWidget } from '@components/app/app-sidebar/sidebar-settings-widget';
 import { useSplitLayout } from '@components/app/split-layout/layout';
-import type {
-  ReferredFrom,
-  SplitContent,
-  SplitHandle,
-} from '@components/app/split-layout/layoutManager';
+import type { SplitContent } from '@components/app/split-layout/layoutManager';
 import { useHasPaidAccess } from '@core/auth';
-import { useLogout } from '@core/auth/logout';
 import { ContextMenuContent, MenuItem } from '@core/component/ContextMenu';
 import { inboxIconProps } from '@core/component/inboxIcon';
 import { toast } from '@core/component/Toast/Toast';
 import { UserIcon } from '@core/component/UserIcon';
-import {
-  ENABLE_ACTIVITY,
-  ENABLE_CALLS,
-  ENABLE_CRM,
-  ENABLE_NEW_PRICING_OVERRIDE,
-} from '@core/constant/featureFlags';
+import { ENABLE_NEW_PRICING_OVERRIDE } from '@core/constant/featureFlags';
 import {
   type SettingsTab,
   useSettingsState,
@@ -59,36 +64,18 @@ import {
   getSettingsTabItem,
   useSettingsTabAvailable,
 } from '@core/constant/settingsTabsConfig';
-import { useEmail, useUserId } from '@core/context/user';
 import { registerHotkey } from '@core/hotkey/hotkeys';
-import { clearPressedKeys } from '@core/hotkey/state';
-import { type HotkeyToken, TOKENS } from '@core/hotkey/tokens';
+import { TOKENS } from '@core/hotkey/tokens';
 import type { ValidHotkey } from '@core/hotkey/types';
-import { activateClosestDOMScope } from '@core/hotkey/utils';
 import { tryMacroId, useDisplayName } from '@core/user';
 import LogoIcon from '@icon/macro-logo.svg';
-import { AnimatedActivityIcon } from '@icon/wide-activity';
-import { AnimatedCallIcon } from '@icon/wide-call';
-import { AnimatedChannelIcon } from '@icon/wide-channel';
-import { AnimatedCompanyIcon } from '@icon/wide-company';
-import { AnimatedEmailIcon } from '@icon/wide-email';
-import { AnimatedFileMdIcon } from '@icon/wide-fileMd';
-import { AnimatedInboxIcon } from '@icon/wide-inbox';
-import { AnimatedSearchIcon } from '@icon/wide-search';
-import { AnimatedStarIcon } from '@icon/wide-star';
-import { AnimatedTaskIcon } from '@icon/wide-task';
+import { AnimatedSquareSidebarIcon } from '@icon/square-sidebar';
 import { ContextMenu } from '@kobalte/core/context-menu';
 import CaretRightIcon from '@phosphor/caret-right.svg';
-import CaretUpIcon from '@phosphor/caret-up.svg';
-import CompassIcon from '@phosphor/compass.svg';
 import DotsThreeIcon from '@phosphor/dots-three.svg';
-import GearIcon from '@phosphor/gear.svg';
-import HomeIcon from '@phosphor/house.svg';
 import MagnifyingGlassIcon from '@phosphor/magnifying-glass.svg';
-import SignOutIcon from '@phosphor/sign-out.svg';
 import UsersThreeIcon from '@phosphor/users-three.svg';
 import XIcon from '@phosphor/x.svg';
-import { isRealNamePart, useOwnUserName } from '@queries/auth/user-name-self';
 import { useEmailLinksQuery } from '@queries/email/link';
 import {
   useJoinTeamMutation,
@@ -104,7 +91,6 @@ import { useLocation } from '@solidjs/router';
 import { Button, cn, Dropdown, Hotkey, NavRow, Tooltip } from '@ui';
 import {
   type Component,
-  type ComponentProps,
   createEffect,
   createMemo,
   createSignal,
@@ -115,142 +101,6 @@ import {
   Suspense,
 } from 'solid-js';
 import { Dynamic } from 'solid-js/web';
-
-interface SidebarItem {
-  id: ListView | (string & {});
-  label: string;
-  href: string;
-  params?: Record<string, unknown>;
-  icon?: Component<
-    JSX.SvgSVGAttributes<SVGSVGElement> | { triggerAnimation?: boolean }
-  >;
-  hotkey: ValidHotkey;
-  hotkeyToken: HotkeyToken;
-  standaloneHotkey?: boolean;
-  hiddenFromSidebar?: boolean;
-}
-
-type SidebarSectionLinkId =
-  | 'mail'
-  | 'channels'
-  | 'calls'
-  | 'documents'
-  | 'tasks'
-  | 'agents'
-  | 'companies';
-
-type SidebarSectionVisibility = Record<SidebarSectionLinkId, boolean>;
-
-type TryItemId = 'connect' | 'invite' | 'mobile';
-
-type TryItemVisibility = Record<TryItemId, boolean>;
-
-const WORKSPACE_LINK_IDS = [
-  'mail',
-  'channels',
-  'calls',
-  'documents',
-  'tasks',
-  'agents',
-  'companies',
-] as const;
-
-const DEFAULT_SECTION_VISIBILITY: SidebarSectionVisibility = {
-  mail: true,
-  channels: true,
-  calls: true,
-  documents: true,
-  tasks: true,
-  agents: true,
-  companies: true,
-};
-
-const DEFAULT_TRY_VISIBILITY: TryItemVisibility = {
-  connect: true,
-  invite: true,
-  mobile: true,
-};
-
-const markdownDocumentsQuery = buildDocumentTypeQuery(['doc-markdown']);
-
-const SIDEBAR_LINKS = [
-  {
-    id: 'inbox',
-    label: 'Inbox',
-    href: LIST_VIEW_PATHS.inbox,
-    icon: AnimatedInboxIcon,
-    hotkey: 'i',
-    hotkeyToken: TOKENS.sidebar.goTo.inbox,
-  },
-  {
-    id: 'search',
-    label: 'Search',
-    href: LIST_VIEW_PATHS.search,
-    icon: AnimatedSearchIcon,
-    hotkey: '/',
-    hotkeyToken: TOKENS.sidebar.goTo.search,
-    standaloneHotkey: true,
-    hiddenFromSidebar: true,
-  },
-  {
-    id: 'agents',
-    label: 'Agents',
-    href: LIST_VIEW_PATHS.agents,
-    icon: AnimatedStarIcon,
-    hotkey: 'a',
-    hotkeyToken: TOKENS.sidebar.goTo.agents,
-  },
-  {
-    id: 'mail',
-    label: 'Email',
-    href: LIST_VIEW_PATHS.mail,
-    icon: AnimatedEmailIcon,
-    hotkey: 'e',
-    hotkeyToken: TOKENS.sidebar.goTo.mail,
-  },
-  {
-    id: 'documents',
-    label: 'Files',
-    href: LIST_VIEW_PATHS.documents,
-    icon: AnimatedFileMdIcon,
-    hotkey: 'f',
-    hotkeyToken: TOKENS.sidebar.goTo.documents,
-  },
-  {
-    id: 'documents',
-    label: 'Documents',
-    href: LIST_VIEW_PATHS.documents,
-    params: {
-      initialFilters: markdownDocumentsQuery ?? {},
-      initialClientFilters: {
-        and: ['document-or-file'],
-        or: ['doc-markdown'],
-      },
-    },
-    icon: AnimatedFileMdIcon,
-    hotkey: 'd',
-    hotkeyToken: TOKENS.sidebar.goTo.markdownDocuments,
-    hiddenFromSidebar: true,
-  },
-  {
-    id: 'tasks',
-    label: 'Tasks',
-    href: LIST_VIEW_PATHS.tasks,
-    icon: AnimatedTaskIcon,
-    hotkey: 't',
-    hotkeyToken: TOKENS.sidebar.goTo.tasks,
-  },
-  {
-    id: 'channels',
-    label: 'Channels',
-    href: LIST_VIEW_PATHS.channels,
-    icon: AnimatedChannelIcon,
-    hotkey: 'c',
-    hotkeyToken: TOKENS.sidebar.goTo.channels,
-  },
-] satisfies SidebarItem[];
-
-export type SidebarState = 'hidden' | 'expanded' | 'slim';
 
 /** Root sidebar `max-width` transition (see `SIDEBAR_MAX_WIDTH_TRANSITION_STYLE`). */
 const SIDEBAR_MAX_WIDTH_TRANSITION_MS = 120;
@@ -264,6 +114,8 @@ const SIDEBAR_MAX_WIDTH_TRANSITION_STYLE = [
 type AppSidebarProps = {
   sidebarState?: SidebarState;
   onOpenChange: (open: boolean) => void;
+  /** Switch to a specific state — used by the wide/narrow variant toggles. */
+  onStateChange: (state: SidebarState) => void;
   overlayOpen?: boolean;
   onOverlayOpenChange?: (open: boolean) => void;
 };
@@ -272,61 +124,6 @@ type SidebarHotkeyDeps = {
   isSlim: () => boolean;
   onOpenChange: (open: boolean) => void;
 };
-
-type OpenWithSplitFn = ReturnType<typeof useSplitLayout>['openWithSplit'];
-
-const isMarkdownDocumentsParams = (
-  params: SidebarItem['params'] | undefined
-): boolean => {
-  const initialClientFilters = params?.initialClientFilters as
-    | { or?: readonly unknown[] }
-    | undefined;
-
-  return initialClientFilters?.or?.includes('doc-markdown') ?? false;
-};
-
-/**
- * Navigate to a sidebar view by pushing a fresh entry into the active split.
- * Holding shift opens it in a new split. Use in-app back/forward to return to
- * prior entries.
- */
-function navigateToSidebarView(args: {
-  viewId: SidebarItem['id'];
-  params?: SidebarItem['params'];
-  shiftKey: boolean;
-  activeSplit: SplitHandle | undefined;
-  openWithSplit: OpenWithSplitFn;
-  referredFrom?: ReferredFrom;
-}): SplitHandle | undefined {
-  const { viewId, params, shiftKey, activeSplit, openWithSplit, referredFrom } =
-    args;
-
-  const activeContent = activeSplit?.content();
-  if (
-    !shiftKey &&
-    isMarkdownDocumentsParams(params) &&
-    activeContent?.type === 'component' &&
-    activeContent.id === 'documents'
-  ) {
-    const controller = activeSplit
-      ? getDocumentsFilterSplit(activeSplit.id)
-      : undefined;
-    if (controller) {
-      controller.toggleMarkdownFilter();
-      return activeSplit;
-    }
-  }
-
-  return openWithSplit(
-    { type: 'component', id: viewId, params },
-    {
-      preferNewSplit: shiftKey,
-      mergeHistory: false,
-      allowDuplicate: true,
-      referredFrom,
-    }
-  );
-}
 
 const registerSidebarHotkeys = ({
   isSlim,
@@ -349,22 +146,6 @@ const registerSidebarHotkeys = ({
       return true;
     },
   });
-};
-
-/**
- * Whether the "g" leader key is currently awaiting a destination key. Lives
- * at module scope so it can drive the hint overlay on `AppSidebar`'s nav
- * icons even though the registration below is owned by `GoToHotkeys`, which
- * stays mounted regardless of whether the sidebar itself is visible.
- */
-const [goToHotkeyVisible, setGoToHotkeyVisible] = createSignal(false);
-
-const resetGoToHotkeysState = () => {
-  setGoToHotkeyVisible(false);
-  // To prevent the next key from triggering the hotkey handler,
-  // we reset the pressed keys state and exit the command scope
-  clearPressedKeys();
-  activateClosestDOMScope();
 };
 
 /**
@@ -646,111 +427,6 @@ const SidebarTryItemMenu = (props: {
   </Dropdown>
 );
 
-const SidebarDropdownLink = (
-  props: SidebarItem & {
-    onContextMenuOpenChange?: (open: boolean) => void;
-  }
-) => {
-  const analytics = useAnalytics();
-  const layout = useSplitLayout();
-  const location = useLocation();
-  const [isHovering, setIsHovering] = createSignal(false);
-  let contextMenuOpen = false;
-
-  const isActive = () => {
-    const activeContent = globalSplitManager()?.activeSplit()?.content();
-    if (!activeContent) {
-      return location.pathname.split('/').filter(Boolean).includes(props.id);
-    }
-    return activeContent.id === props.id;
-  };
-
-  const handleContextMenuOpenChange = (open: boolean) => {
-    contextMenuOpen = open;
-    props.onContextMenuOpenChange?.(open);
-  };
-
-  onCleanup(() => {
-    if (contextMenuOpen) props.onContextMenuOpenChange?.(false);
-  });
-
-  const open = (newSplit = false) => {
-    analytics.track('sidebar_click', { view: props.id });
-    const handle = navigateToSidebarView({
-      viewId: props.id,
-      params: props.params,
-      shiftKey: newSplit,
-      activeSplit: globalSplitManager()?.activeSplit(),
-      openWithSplit: layout.openWithSplit,
-      referredFrom: 'sidebar',
-    });
-    if (props.id === 'search' && handle) requestSearchFocus(handle.id);
-    globalSplitManager()?.returnFocus();
-    return handle;
-  };
-
-  const canOpenInNewSplit = () =>
-    globalSplitManager()?.canAppendSplit() ?? false;
-  const canOpenFullscreen = () => layout.getSplitCount() > 1;
-  const openInNewSplit = () => {
-    if (canOpenInNewSplit()) open(true);
-  };
-  const openInCurrentSplit = () => open(false);
-  const openFullscreen = () => {
-    analytics.track('sidebar_click', { view: props.id });
-    const handle = layout.replaceAllSplits(
-      { type: 'component', id: props.id, params: props.params },
-      { referredFrom: 'sidebar' }
-    );
-    if (props.id === 'search' && handle) requestSearchFocus(handle.id);
-    globalSplitManager()?.returnFocus();
-  };
-
-  const ContextMenuTriggerItem = (
-    triggerProps: ComponentProps<typeof ContextMenu.Trigger>
-  ) => (
-    <ContextMenu onOpenChange={handleContextMenuOpenChange}>
-      <ContextMenu.Trigger {...triggerProps} />
-      <ContextMenu.Portal>
-        <ContextMenuContent class="z-tool-tip! text-xs text-ink-muted">
-          <MenuItem
-            text="Open in new split"
-            onClick={openInNewSplit}
-            disabled={!canOpenInNewSplit()}
-          />
-          <Show when={canOpenFullscreen()}>
-            <MenuItem text="Open fullscreen" onClick={openFullscreen} />
-          </Show>
-          <MenuItem text="Open in current split" onClick={openInCurrentSplit} />
-        </ContextMenuContent>
-      </ContextMenu.Portal>
-    </ContextMenu>
-  );
-
-  return (
-    <Dropdown.Item
-      as={ContextMenuTriggerItem}
-      class={cn(
-        'min-h-8 gap-2 px-2.5 text-[13px]',
-        isActive() &&
-          'bg-ink/6 text-ink hover:bg-ink/6 data-highlighted:bg-ink/6'
-      )}
-      data-active={isActive() ? '' : undefined}
-      onMouseEnter={() => setIsHovering(true)}
-      onMouseLeave={() => setIsHovering(false)}
-      onSelect={openInCurrentSplit}
-    >
-      <Show when={props.icon}>
-        <div class="shrink-0 [&_svg]:size-3.5">
-          <Dynamic component={props.icon} triggerAnimation={isHovering()} />
-        </div>
-      </Show>
-      <span class="min-w-0 flex-1 truncate text-ink">{props.label}</span>
-      <Hotkey token={props.hotkeyToken} theme="subtle" class="ml-6" />
-    </Dropdown.Item>
-  );
-};
-
 const SidebarHeaderSearchButton = (props: { link: SidebarItem }) => {
   const analytics = useAnalytics();
   const layout = useSplitLayout();
@@ -799,231 +475,6 @@ const SidebarHeaderSearchButton = (props: { link: SidebarItem }) => {
   );
 };
 
-type SidebarSettingsWidgetProps = {
-  isSlim: () => boolean;
-  onSelect: (tab: SettingsTab) => void;
-  onMenuOpenChange?: (open: boolean) => void;
-};
-
-const SidebarSettingsWidget = (props: SidebarSettingsWidgetProps) => {
-  const userId = useUserId();
-  const email = useEmail();
-  const logout = useLogout();
-
-  const userName = useOwnUserName();
-
-  // Prefer the user's real name (first/last); fall back to their email.
-  const displayName = createMemo(() => {
-    const name = userName();
-    const parts = [name?.first_name, name?.last_name]
-      .map((part) => part?.trim())
-      .filter((part): part is string => isRealNamePart(part));
-    return parts.length > 0 ? parts.join(' ') : (email() ?? 'Macro User');
-  });
-
-  return (
-    <Dropdown
-      placement="top-start"
-      gutter={6}
-      onOpenChange={props.onMenuOpenChange}
-    >
-      <Dropdown.Trigger
-        variant="ghost"
-        class={cn(
-          'flex items-center rounded-md cursor-default text-ink-extra-muted not-disabled:hover:bg-ink/3 h-9',
-          'justify-start gap-3 px-1.5 py-1'
-        )}
-        label={displayName()}
-        fullWidth
-        tooltipDisabled={!props.isSlim()}
-        tooltipPlacement="right"
-        onMouseDown={(e: MouseEvent) => {
-          if (e.button !== 0) return;
-          e.preventDefault();
-        }}
-      >
-        <Show
-          when={userId()}
-          fallback={<div class="size-5 shrink-0 rounded-full bg-ink/10" />}
-        >
-          {(id) => (
-            <div class="size-5 shrink-0">
-              <UserIcon
-                id={id()}
-                size="fill"
-                suppressClick
-                showTooltip={false}
-              />
-            </div>
-          )}
-        </Show>
-        <span class="flex-1 min-w-0 text-left whitespace-nowrap text-sm truncate group-data-[slim=true]/sidebar:hidden">
-          {displayName()}
-        </span>
-        <CaretUpIcon class="size-3 text-ink-extra-muted shrink-0 group-data-[slim=true]/sidebar:hidden" />
-      </Dropdown.Trigger>
-      <Dropdown.Content class="min-w-64 shadow-menu">
-        <Dropdown.Group class="p-1.5 gap-0">
-          <div class="flex items-center gap-3 px-1 py-1">
-            <Show
-              when={userId()}
-              fallback={<div class="size-10 shrink-0 rounded-full bg-ink/10" />}
-            >
-              {(id) => (
-                <div class="size-10 shrink-0">
-                  <UserIcon
-                    id={id()}
-                    size="fill"
-                    suppressClick
-                    showTooltip={false}
-                  />
-                </div>
-              )}
-            </Show>
-            <div class="min-w-0">
-              <div class="truncate text-sm font-semibold text-ink">
-                {displayName()}
-              </div>
-              <div class="truncate text-sm text-ink-muted">{email()}</div>
-            </div>
-          </div>
-          <div class="-mx-1.5 mt-2 mb-1.5 h-px bg-edge-muted" />
-          <Dropdown.Item
-            class="flex items-center gap-2 px-2.5 py-2 text-sm cursor-default outline-none text-ink-muted"
-            onSelect={() => CommandState.open()}
-          >
-            <span class="size-5 flex items-center justify-center text-ink-extra-muted">
-              ⌘
-            </span>
-            <span class="flex-1 text-ink">Command menu</span>
-            <Hotkey
-              token={TOKENS.global.commandMenu}
-              theme="subtle"
-              class="ml-6"
-            />
-          </Dropdown.Item>
-          <Dropdown.Item
-            class="flex items-center gap-2 px-2.5 py-2 text-sm cursor-default outline-none text-ink-muted"
-            onSelect={() => props.onSelect('Account')}
-          >
-            <span class="size-5 flex items-center justify-center">
-              <GearIcon class="size-4 shrink-0 text-ink-extra-muted" />
-            </span>
-            <span class="flex-1 text-ink">Settings</span>
-            <Hotkey
-              token={TOKENS.global.toggleSettings}
-              theme="subtle"
-              class="ml-6"
-            />
-          </Dropdown.Item>
-          <Dropdown.Item
-            class="flex items-center gap-2 px-2.5 py-2 text-sm cursor-default outline-none text-failure"
-            onSelect={() => logout()}
-          >
-            <span class="size-5 flex items-center justify-center">
-              <SignOutIcon class="size-4 shrink-0" />
-            </span>
-            <span>Log out</span>
-          </Dropdown.Item>
-        </Dropdown.Group>
-      </Dropdown.Content>
-    </Dropdown>
-  );
-};
-
-const CALLS_LINK: SidebarItem = {
-  id: 'calls',
-  label: 'Calls',
-  href: LIST_VIEW_PATHS.calls,
-  icon: AnimatedCallIcon,
-  hotkey: 'l',
-  hotkeyToken: TOKENS.sidebar.goTo.calls,
-};
-
-const COMPANIES_LINK: SidebarItem = {
-  id: 'companies',
-  label: 'Customers',
-  href: LIST_VIEW_PATHS.companies,
-  icon: AnimatedCompanyIcon,
-  hotkey: 'o',
-  hotkeyToken: TOKENS.sidebar.goTo.companies,
-};
-
-const DASHBOARD_LINK: SidebarItem = {
-  id: 'home',
-  label: 'Home',
-  href: '/home',
-  icon: HomeIcon,
-  hotkey: 'h',
-  hotkeyToken: TOKENS.sidebar.goTo.home,
-};
-
-const GETTING_STARTED_LINK: SidebarItem = {
-  id: 'getting-started',
-  label: 'Getting Started',
-  href: '/getting-started',
-  icon: CompassIcon,
-  hotkey: 's',
-  hotkeyToken: TOKENS.sidebar.goTo.gettingStarted,
-};
-
-const ACTIVITY_LINK: SidebarItem = {
-  id: 'activity',
-  label: 'Activity',
-  href: '/activity',
-  icon: AnimatedActivityIcon,
-  hotkey: 'y',
-  hotkeyToken: TOKENS.sidebar.goTo.activity,
-};
-
-/**
- * Assemble the ordered sidebar link list: the static links plus Home, Getting
- * started, and the flag-gated Activity, Calls, and CRM entries in their
- * correct positions.
- * Shared by the rendered sidebar (`AppSidebar.visibleLinks`) and the
- * always-mounted `GoToHotkeys` registrar so their link sets can't drift. Call
- * from a reactive context — it reads `ENABLE_CALLS()` / `ENABLE_CRM()`.
- * `showGettingStarted` is the account-age gate (`useGettingStartedEnabled`),
- * passed in because this runs outside a component; when false the link is
- * fully absent — row, `g s` hotkey, and command menu entry.
- * Rendered sections additionally drop `hiddenFromSidebar` entries, which have
- * hotkeys but no sidebar row.
- */
-const buildSidebarLinks = (showGettingStarted: boolean): SidebarItem[] => {
-  let links: SidebarItem[] = [
-    DASHBOARD_LINK,
-    ...(showGettingStarted ? [GETTING_STARTED_LINK] : []),
-    ...SIDEBAR_LINKS,
-  ];
-
-  if (ENABLE_ACTIVITY) {
-    const idx = links.findIndex((link) => link.id === 'inbox');
-    links = [
-      ...links.slice(0, idx + 1),
-      ACTIVITY_LINK,
-      ...links.slice(idx + 1),
-    ];
-  }
-
-  if (ENABLE_CALLS()) {
-    const idx = links.findIndex((l) => l.id === 'channels');
-    links = [...links.slice(0, idx + 1), CALLS_LINK, ...links.slice(idx + 1)];
-  }
-
-  if (ENABLE_CRM()) {
-    // Customers sits just after Channels (and Calls when present).
-    const anchorId = ENABLE_CALLS() ? 'calls' : 'channels';
-    const idx = links.findIndex((l) => l.id === anchorId);
-    links = [
-      ...links.slice(0, idx + 1),
-      COMPANIES_LINK,
-      ...links.slice(idx + 1),
-    ];
-  }
-
-  return links;
-};
-
 const TeamInviteSidebarPromo = (props: { invite: TeamInviteDetails }) => {
   const [inviterName] = useDisplayName(tryMacroId(props.invite.invited_by));
   const joinTeamMutation = useJoinTeamMutation();
@@ -1051,20 +502,61 @@ const TeamInviteSidebarPromo = (props: { invite: TeamInviteDetails }) => {
   );
 };
 
+/** Header button that swaps the wide sidebar for the narrow rail. */
+const NarrowSidebarToggle = (props: { onClick: () => void }) => {
+  const [hovering, setHovering] = createSignal(false);
+
+  return (
+    <Button
+      size="icon-sm"
+      class="[&_svg]:size-4!"
+      label="Narrow sidebar"
+      onMouseEnter={() => setHovering(true)}
+      onMouseLeave={() => setHovering(false)}
+      onMouseDown={(e) => {
+        if (e.button !== 0) return;
+        e.preventDefault();
+      }}
+      onClick={props.onClick}
+    >
+      <AnimatedSquareSidebarIcon triggerAnimation={hovering()} />
+    </Button>
+  );
+};
+
+/**
+ * The app sidebar. Renders the narrow Slack-style rail or the wide list,
+ * depending on the state the user last picked; `slim` and `hidden` are
+ * handled by the wide variant, which collapses to a hover overlay.
+ */
 export const AppSidebar = (props: AppSidebarProps) => {
+  // Registered here rather than in a variant so cmd+. keeps working on the
+  // rail, which has no collapse affordance of its own.
+  registerSidebarHotkeys({
+    isSlim: () => props.sidebarState === 'slim',
+    onOpenChange: props.onOpenChange,
+  });
+
+  return (
+    <Show
+      when={props.sidebarState === 'narrow'}
+      fallback={<WideSidebar {...props} />}
+    >
+      <NarrowSidebar onStateChange={props.onStateChange} />
+    </Show>
+  );
+};
+
+/**
+ * The wide sidebar: the full-width list of links, favorites, recent channels
+ * and promos. See `NarrowSidebar` for the rail variant.
+ */
+const WideSidebar = (props: AppSidebarProps) => {
   const { openSettings, selectTab, settingsOpen } = useSettingsState();
   const isTabAvailable = useSettingsTabAvailable();
   const currentTeamQuery = useCurrentTeamQuery();
   const userInvitesQuery = useUserInvitesQuery();
   const firstTeamInvite = () => userInvitesQuery.data?.invites.at(0);
-  const [sectionVisibility, setSectionVisibility] = makePersisted(
-    createSignal<SidebarSectionVisibility>(DEFAULT_SECTION_VISIBILITY),
-    { name: 'sidebar-section-visibility' }
-  );
-  const [tryVisibility, setTryVisibility] = makePersisted(
-    createSignal<TryItemVisibility>(DEFAULT_TRY_VISIBILITY),
-    { name: 'sidebar-try-visibility' }
-  );
   const callCtx = useCallContextOptional();
 
   const hasPaidAccess = useHasPaidAccess();
@@ -1365,11 +857,6 @@ export const AppSidebar = (props: AppSidebarProps) => {
     }
   });
 
-  registerSidebarHotkeys({
-    isSlim: isCollapsed,
-    onOpenChange: props.onOpenChange,
-  });
-
   return (
     <div
       class={cn(
@@ -1413,6 +900,7 @@ export const AppSidebar = (props: AppSidebarProps) => {
           </Show>
         </div>
         <div class="flex shrink-0 items-center gap-1">
+          <NarrowSidebarToggle onClick={() => props.onStateChange('narrow')} />
           <Show when={searchLink()}>
             {(link) => <SidebarHeaderSearchButton link={link()} />}
           </Show>

--- a/apps/web/src/features/block-call/sidebar/active-call-widget.tsx
+++ b/apps/web/src/features/block-call/sidebar/active-call-widget.tsx
@@ -1,6 +1,6 @@
 import { joinChannelCall } from '@channel/Call/join-channel-call';
 import { openChannelCallTab } from '@channel/Call/open-channel-call-tab';
-import type { SidebarState } from '@components/app/app-sidebar/sidebar';
+import type { SidebarState } from '@components/app/app-sidebar/sidebar-links';
 import { ContextMenuContent, MenuItem } from '@core/component/ContextMenu';
 import { useChannelsContext } from '@core/context/channels';
 import { useUserId } from '@core/context/user';

--- a/apps/web/src/features/channel/sidebar/channels-recent-widget.tsx
+++ b/apps/web/src/features/channel/sidebar/channels-recent-widget.tsx
@@ -10,7 +10,7 @@ import {
   CollapsibleSidebarSection,
   type CollapsibleSidebarSectionItem,
 } from '@components/app/app-sidebar/collapsible-sidebar-section';
-import type { SidebarState } from '@components/app/app-sidebar/sidebar';
+import type { SidebarState } from '@components/app/app-sidebar/sidebar-links';
 import {
   useGlobalBlockOrchestrator,
   useGlobalNotificationSource,

--- a/apps/web/src/features/command/sidebar/sidebar-create-menu.tsx
+++ b/apps/web/src/features/command/sidebar/sidebar-create-menu.tsx
@@ -8,18 +8,36 @@ import {
   ENABLE_SNIPPETS_FLAG,
   ENABLE_SNIPPETS_OVERRIDE,
 } from '@core/constant/featureFlags';
+import {
+  RAIL_BUTTON_CLASS,
+  RAIL_LABEL_CLASS,
+  RAIL_TILE_ACTIVE_CLASS,
+  RAIL_TILE_CLASS,
+} from '@components/app/app-sidebar/narrow-sidebar-styles';
 import { setActiveScope } from '@core/hotkey/state';
 import { TOKENS } from '@core/hotkey/tokens';
 import { activateClosestDOMScope } from '@core/hotkey/utils';
 import CreateIcon from '@icon/square-pen-create.svg';
 import PlusIcon from '@phosphor/plus.svg';
 import { Button, cn, Dropdown, Hotkey, NavRow } from '@ui';
-import { createMemo, createSignal, For, onCleanup, Show } from 'solid-js';
+import {
+  createMemo,
+  createSignal,
+  For,
+  Match,
+  onCleanup,
+  Show,
+  Switch,
+} from 'solid-js';
 import { Dynamic } from 'solid-js/web';
 
 export const SidebarCreateMenu = (props: {
   isSlim: () => boolean;
-  variant?: 'row' | 'icon';
+  /**
+   * `row` is the wide sidebar's full-width row, `icon` the round button in its
+   * header, and `rail` the narrow sidebar's big icon-over-label button.
+   */
+  variant?: 'row' | 'icon' | 'rail';
   onMenuOpenChange?: (open: boolean) => void;
 }) => {
   const analytics = useAnalytics();
@@ -85,8 +103,7 @@ export const SidebarCreateMenu = (props: {
       placement="right-start"
       gutter={8}
     >
-      <Show
-        when={props.variant === 'icon'}
+      <Switch
         fallback={
           <Dropdown.Trigger
             as={NavRow}
@@ -118,22 +135,44 @@ export const SidebarCreateMenu = (props: {
           </Dropdown.Trigger>
         }
       >
-        <Dropdown.Trigger
-          as={Button}
-          variant="base"
-          size="icon-sm"
-          depth={1}
-          class="size-[26px] rounded-full bg-surface shadow-md shadow-drop-shadow [&_svg]:size-4!"
-          label="Create"
-          hotkey={TOKENS.global.createCommand}
-          onMouseDown={(e: MouseEvent) => {
-            if (e.button !== 0) return;
-            e.preventDefault();
-          }}
-        >
-          <CreateIcon />
-        </Dropdown.Trigger>
-      </Show>
+        <Match when={props.variant === 'icon'}>
+          <Dropdown.Trigger
+            as={Button}
+            variant="base"
+            size="icon-sm"
+            depth={1}
+            class="size-[26px] rounded-full bg-surface shadow-md shadow-drop-shadow [&_svg]:size-4!"
+            label="Create"
+            hotkey={TOKENS.global.createCommand}
+            onMouseDown={(e: MouseEvent) => {
+              if (e.button !== 0) return;
+              e.preventDefault();
+            }}
+          >
+            <CreateIcon />
+          </Dropdown.Trigger>
+        </Match>
+        <Match when={props.variant === 'rail'}>
+          <Dropdown.Trigger
+            as={Button}
+            variant="ghost"
+            fullWidth
+            class={RAIL_BUTTON_CLASS}
+            label="Create"
+            hotkey={TOKENS.global.createCommand}
+            tooltipPlacement="right"
+            onMouseDown={(e: MouseEvent) => {
+              if (e.button !== 0) return;
+              e.preventDefault();
+            }}
+          >
+            <div class={cn(RAIL_TILE_CLASS, open() && RAIL_TILE_ACTIVE_CLASS)}>
+              <CreateIcon />
+            </div>
+            <span class={RAIL_LABEL_CLASS}>Create</span>
+          </Dropdown.Trigger>
+        </Match>
+      </Switch>
       <Dropdown.Content class="min-w-52 shadow-menu">
         <Dropdown.Group>
           <For each={blocks()}>

--- a/apps/web/src/features/favorites/sidebar/favorites-section.tsx
+++ b/apps/web/src/features/favorites/sidebar/favorites-section.tsx
@@ -8,7 +8,7 @@ import {
 } from '@app/util/favorites';
 import { navigateToChannelMessage } from '@block-channel/utils/link';
 import { ReadonlyThread } from '@channel/StandaloneThread';
-import type { SidebarState } from '@components/app/app-sidebar/sidebar';
+import type { SidebarState } from '@components/app/app-sidebar/sidebar-links';
 import {
   useGlobalBlockOrchestrator,
   useGlobalNotificationSource,


### PR DESCRIPTION
## Summary

Introduces a new narrow sidebar variant that displays navigation as a Slack-style icon rail with labels underneath, complementing the existing wide list view. Users can toggle between the two variants, with their preference persisted across sessions.

## Key Changes

- **New narrow sidebar component** (`narrow-sidebar.tsx`): Renders navigation as a vertical rail of large icon buttons with labels, replacing the scrolling list for a more compact layout
- **Extracted shared sidebar logic** (`sidebar-links.ts`): Centralized link definitions, navigation helpers, and visibility state management used by both sidebar variants and the always-mounted hotkey registrar
- **Extracted settings widget** (`sidebar-settings-widget.tsx`): Separated account menu component to support both row (wide sidebar) and rail (narrow sidebar) layouts
- **Extracted dropdown link component** (`sidebar-dropdown-link.tsx`): Reusable link component for overflow menus in both variants
- **New narrow sidebar styles** (`narrow-sidebar-styles.ts`): Shared CSS classes for rail button styling, used by the narrow sidebar and create menu
- **Updated Layout.tsx**: Added state management for sidebar variant preference (`preferredSidebarState`) and `onStateChange` callback to switch between variants
- **Updated create menu** (`sidebar-create-menu.tsx`): Added `rail` variant to render as a large icon-over-label button matching the narrow sidebar's visual style
- **Updated sidebar.tsx**: Removed extracted code, added `onStateChange` prop for variant switching, simplified to focus on wide list rendering
- **Updated type imports**: Moved `SidebarState` type to `sidebar-links.ts` and added `VisibleSidebarState` type to distinguish between variants that occupy layout space

## Implementation Details

- Both sidebar variants share the same link definitions and navigation logic via `buildSidebarLinks()` and `navigateToSidebarView()`, ensuring consistent behavior
- Sidebar state includes four modes: `hidden` (mobile), `expanded` (wide list), `narrow` (icon rail), and `slim` (hover overlay)
- The narrow rail displays top-level views prominently with a "More" menu for hidden workspace links and "Try" shortcuts
- User preferences for sidebar variant and section visibility are persisted separately, allowing seamless switching between variants
- The narrow sidebar's create button and settings widget use the same styling as rail navigation buttons for visual consistency

https://claude.ai/code/session_01CmGKPL3v7uNjmhjG7LEYPQ