### PR TITLE
fix(ui): fill in missing Hotkey theme token styles

### DIFF
--- a/apps/web/src/components/ui/components/Hotkey.tsx
+++ b/apps/web/src/components/ui/components/Hotkey.tsx
@@ -64,28 +64,28 @@ const hotkeyStyles: Record<Theme, { label: string; hotkey: string }> = {
     label: 'bg-ink border border-ink text-surface',
   },
   accentOpaque: {
-    label: '',
-    hotkey: '',
+    hotkey: 'bg-accent/10 border border-accent text-accent',
+    label: 'bg-accent border border-accent text-surface',
   },
   contrast: {
-    label: '',
-    hotkey: '',
+    hotkey: 'bg-ink border border-ink text-surface',
+    label: 'bg-surface border border-ink text-ink',
   },
   selected: {
-    label: '',
-    hotkey: '',
+    hotkey: 'bg-accent-bg border border-accent/40 text-accent',
+    label: 'bg-accent border border-accent text-surface',
   },
   clear: {
-    label: '',
-    hotkey: '',
+    hotkey: 'bg-transparent border border-transparent text-ink-muted',
+    label: 'bg-transparent border border-transparent text-ink',
   },
   green: {
-    label: '',
-    hotkey: '',
+    hotkey: 'bg-success-bg border border-success/30 text-success',
+    label: 'bg-success border border-success text-surface',
   },
   red: {
-    label: '',
-    hotkey: '',
+    hotkey: 'bg-failure/10 border border-failure/30 text-failure',
+    label: 'bg-failure border border-failure text-surface',
   },
 };
 


### PR DESCRIPTION
## What changed
Fixed `Hotkey.tsx` theme definitions for `accentOpaque`, `contrast`, `selected`, `clear`, `green`, and `red`. Previously, these 6 theme options had empty string values (`label: ''`, `hotkey: ''`), which caused shortcut badges using those themes to render without any visual styling or background tokens.

Filled them in with the appropriate semantic design system classes matching the workspace theme definitions.

## Tested
- Verified type checking (`bun run check`) passes cleanly.
- Verified linting (`bun run lint`) passes cleanly.
