### PR TITLE
fix(ui): render then separator between hotkey tokens and shortcuts in…

### DIFF
--- a/apps/web/src/components/ui/components/Tooltip.tsx
+++ b/apps/web/src/components/ui/components/Tooltip.tsx
@@ -129,7 +129,12 @@ export function Tooltip(props: TooltipProps) {
                       {(token, ndx) => (
                         <>
                           <Hotkey token={token} theme="subtle" />
-                          <Show when={ndx() < tokens().length - 1}>
+                          <Show
+                            when={
+                              ndx() < tokens().length - 1 ||
+                              shortcuts().length > 0
+                            }
+                          >
                             <span class="text-ink-extra-muted">then</span>
                           </Show>
                         </>


### PR DESCRIPTION
## Summary
Fixes a rendering bug in `apps/web/src/components/ui/components/Tooltip.tsx` where the `"then"` text separator was omitted between the last `hotkey` token and the first custom `shortcut` string when both props are passed to a `Tooltip`.

## What changed
Updated the `<Show>` condition after the token loop to check if remaining items exist in the `shortcuts()` array (`ndx() < tokens().length - 1 || shortcuts().length > 0`).

## Verified
- Verified TypeScript type checking (`bun run check`) passes cleanly.
