### PR TITLE
fix(core): stop ParamsProvider triggering reactivity on all url params changes

### DIFF
--- a/apps/web/src/lib/core/component/ParamsProvider.test.tsx
+++ b/apps/web/src/lib/core/component/ParamsProvider.test.tsx
@@ -1,0 +1,220 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { render } from '@solidjs/testing-library';
+import { type Accessor, createEffect, on } from 'solid-js';
+import { createStore, type SetStoreFunction } from 'solid-js/store';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ParamsProvider, useUrlParams } from './ParamsProvider';
+
+type MockSearchParams = Record<string, string | string[] | undefined>;
+
+const mocks = vi.hoisted(() => ({
+  registeredMethods: {} as Record<
+    string,
+    (params: Record<string, string>) => void
+  >,
+  searchParams: undefined as MockSearchParams | undefined,
+  setSearchParams: undefined as SetStoreFunction<MockSearchParams> | undefined,
+}));
+
+vi.mock('@solidjs/router', () => ({
+  useSearchParams: () => [mocks.searchParams, mocks.setSearchParams],
+}));
+
+vi.mock('@core/orchestrator', () => ({
+  createMethodRegistration: (
+    _blockHandle: Accessor<unknown>,
+    methods: Record<string, (params: Record<string, string>) => void>
+  ) => {
+    mocks.registeredMethods = methods;
+  },
+}));
+
+vi.mock('@core/signal/load', () => ({
+  blockHandleSignal: {
+    get: () => ({}),
+  },
+}));
+
+const URL_PARAMS = {
+  nodeId: 'node_id',
+  location: 'location',
+  commentId: 'comment_id',
+} as const;
+
+type Counts = Record<keyof typeof URL_PARAMS, number>;
+type Values = Record<keyof typeof URL_PARAMS, string | undefined>;
+
+function createCounts(): Counts {
+  return {
+    nodeId: 0,
+    location: 0,
+    commentId: 0,
+  };
+}
+
+function resetCounts(counts: Counts) {
+  counts.nodeId = 0;
+  counts.location = 0;
+  counts.commentId = 0;
+}
+
+function Consumer(props: { counts: Counts; values: Values }) {
+  const params = useUrlParams(URL_PARAMS);
+
+  createEffect(
+    on(params.nodeId, (value) => {
+      props.counts.nodeId++;
+      props.values.nodeId = value;
+    })
+  );
+  createEffect(
+    on(params.location, (value) => {
+      props.counts.location++;
+      props.values.location = value;
+    })
+  );
+  createEffect(
+    on(params.commentId, (value) => {
+      props.counts.commentId++;
+      props.values.commentId = value;
+    })
+  );
+
+  return null;
+}
+
+async function settle() {
+  await Promise.resolve();
+}
+
+function renderHarness(initialSearchParams: MockSearchParams = {}) {
+  const counts = createCounts();
+  const values: Values = {
+    nodeId: undefined,
+    location: undefined,
+    commentId: undefined,
+  };
+  const [searchParams, setSearchParams] =
+    createStore<MockSearchParams>(initialSearchParams);
+  mocks.searchParams = searchParams;
+  mocks.setSearchParams = setSearchParams;
+
+  const rendered = render(() => (
+    <ParamsProvider>
+      <Consumer counts={counts} values={values} />
+    </ParamsProvider>
+  ));
+
+  return {
+    ...rendered,
+    counts,
+    values,
+    setSearchParams,
+  };
+}
+
+beforeEach(() => {
+  mocks.registeredMethods = {};
+  mocks.searchParams = undefined;
+  mocks.setSearchParams = undefined;
+});
+
+describe('ParamsProvider', () => {
+  it('does not notify consumers when unrelated URL params change', async () => {
+    const { counts, values, setSearchParams } = renderHarness({
+      node_id: 'node-1',
+      location: 'loc-1',
+      comment_id: 'comment-1',
+    });
+    await settle();
+    resetCounts(counts);
+
+    setSearchParams('unrelated', 'value');
+    await settle();
+
+    expect(counts).toEqual({
+      nodeId: 0,
+      location: 0,
+      commentId: 0,
+    });
+    expect(values).toEqual({
+      nodeId: 'node-1',
+      location: 'loc-1',
+      commentId: 'comment-1',
+    });
+  });
+
+  it('notifies only the URL param consumer whose value changed', async () => {
+    const { counts, values, setSearchParams } = renderHarness({
+      node_id: 'node-1',
+      location: 'loc-1',
+      comment_id: 'comment-1',
+    });
+    await settle();
+    resetCounts(counts);
+
+    setSearchParams('node_id', 'node-2');
+    await settle();
+
+    expect(counts).toEqual({
+      nodeId: 1,
+      location: 0,
+      commentId: 0,
+    });
+    expect(values).toEqual({
+      nodeId: 'node-2',
+      location: 'loc-1',
+      commentId: 'comment-1',
+    });
+  });
+
+  it('notifies an imperatively navigated param even when its value is unchanged', async () => {
+    const { counts, values } = renderHarness({
+      node_id: 'node-1',
+      comment_id: 'comment-1',
+    });
+    await settle();
+    resetCounts(counts);
+
+    mocks.registeredMethods.goToLocationFromParams({
+      comment_id: 'comment-1',
+    });
+    await settle();
+
+    expect(counts).toEqual({
+      nodeId: 0,
+      location: 0,
+      commentId: 1,
+    });
+    expect(values.commentId).toBe('comment-1');
+  });
+
+  it('does not notify watched params when imperative navigation uses unrelated params', async () => {
+    const { counts, values } = renderHarness({
+      node_id: 'node-1',
+      location: 'loc-1',
+      comment_id: 'comment-1',
+    });
+    await settle();
+    resetCounts(counts);
+
+    mocks.registeredMethods.goToLocationFromParams({
+      unrelated: 'value',
+    });
+    await settle();
+
+    expect(counts).toEqual({
+      nodeId: 0,
+      location: 0,
+      commentId: 0,
+    });
+    expect(values).toEqual({
+      nodeId: 'node-1',
+      location: 'loc-1',
+      commentId: 'comment-1',
+    });
+  });
+});

--- a/apps/web/src/lib/core/component/ParamsProvider.tsx
+++ b/apps/web/src/lib/core/component/ParamsProvider.tsx
@@ -3,60 +3,99 @@ import { blockHandleSignal } from '@core/signal/load';
 import { useSearchParams } from '@solidjs/router';
 import {
   type Accessor,
+  batch,
   createContext,
-  createMemo,
-  createSignal,
   type ParentProps,
   useContext,
 } from 'solid-js';
+import { createStore } from 'solid-js/store';
 
 type ParamSchema = Record<string, string>;
 
 type ParamMap = Record<string, string | undefined>;
 
+// Use a version-bumping pattern to trigger successive reactive updates when
+// calling goToLocationFromParams multiple times even with same values.
+type ParamVersions = Record<string, number | undefined>;
+
 type ResolvedParams<T extends ParamSchema> = {
   [K in keyof T]: Accessor<string | undefined>;
 };
 
-const ParamsContext = createContext<Accessor<ParamMap>>(() => ({}));
+/**
+ * Provides stable per-param accessors so unrelated params do not invalidate
+ * consumers.
+ */
+type ParamsContextValue = {
+  getParam: (param: string) => Accessor<string | undefined>;
+};
+
+const ParamsContext = createContext<ParamsContextValue>({
+  getParam: () => () => undefined,
+});
+
+function flattenParamValue(
+  val: string | string[] | undefined
+): string | undefined {
+  return Array.isArray(val) ? val[0] : val;
+}
 
 export function ParamsProvider(props: ParentProps) {
   const [searchParams] = useSearchParams();
-
-  const [blockParams, setBlockParams] = createSignal<ParamMap>({});
+  const [blockParams, setBlockParams] = createStore<ParamMap>({});
+  const [navigationVersions, setNavigationVersions] =
+    createStore<ParamVersions>({});
 
   const blockHandle = blockHandleSignal.get;
 
   createMethodRegistration(blockHandle, {
     goToLocationFromParams: (params: Record<string, string>) => {
-      setBlockParams({ ...params });
+      batch(() => {
+        const paramNames = new Set([
+          ...Object.keys(blockParams),
+          ...Object.keys(params),
+        ]);
+
+        for (const param of paramNames) {
+          setBlockParams(param, params[param]);
+        }
+
+        for (const param of Object.keys(params)) {
+          setNavigationVersions(param, (navigationVersions[param] ?? 0) + 1);
+        }
+      });
     },
   });
 
-  const merged = createMemo<ParamMap>(() => {
-    const flat: ParamMap = {};
+  const context: ParamsContextValue = {
+    getParam: (param) => () => {
+      navigationVersions[param];
 
-    for (const key in searchParams) {
-      const val = searchParams[key];
-      flat[key] = Array.isArray(val) ? val[0] : val;
-    }
+      const blockValue = blockParams[param];
+      if (blockValue !== undefined) return blockValue;
 
-    return { ...flat, ...blockParams() };
-  });
+      return flattenParamValue(searchParams[param]);
+    },
+  };
 
   return (
-    <ParamsContext.Provider value={merged}>
+    <ParamsContext.Provider value={context}>
       {props.children}
     </ParamsContext.Provider>
   );
 }
 
+/**
+ * Returns URL/block params scoped to the requested schema keys. The context
+ * provides additional logic for retriggering signals on successive calls
+ * to `goToLocationFromParams` with the same values.
+ */
 export function useUrlParams<T extends ParamSchema>(
   schema: T
 ): ResolvedParams<T> {
-  const raw = useContext(ParamsContext);
+  const params = useContext(ParamsContext);
 
   return Object.fromEntries(
-    Object.entries(schema).map(([key, param]) => [key, () => raw()[param]])
+    Object.entries(schema).map(([key, param]) => [key, params.getParam(param)])
   ) as ResolvedParams<T>;
 }


### PR DESCRIPTION
Fixes ParamsProvider to expose per-param accessors instead of one shallow-merged object, preventing *ALL* url param changes from retriggering downstream effects.

Also adds a scoped navigation value bumping for goToLocationFromParams, so imperative navigation still reruns consumers for explicitly targeted params even when the value is unchanged.