### PR TITLE
feat: show Getting Started in account menu when its sidebar row is hidden

### DIFF
--- a/apps/web/src/components/app/app-sidebar/sidebar.tsx
+++ b/apps/web/src/components/app/app-sidebar/sidebar.tsx
@@ -801,14 +801,35 @@ type SidebarSettingsWidgetProps = {
   isSlim: () => boolean;
   onSelect: (tab: SettingsTab) => void;
   onMenuOpenChange?: (open: boolean) => void;
+  /**
+   * The Getting Started link, surfaced here only while it's hidden from the
+   * sidebar rows (see `AppSidebar`). Keeps the page reachable from the account
+   * menu once the user removes its dedicated row.
+   */
+  gettingStartedLink?: SidebarItem;
 };
 
 const SidebarSettingsWidget = (props: SidebarSettingsWidgetProps) => {
   const userId = useUserId();
   const email = useEmail();
   const logout = useLogout();
+  const layout = useSplitLayout();
 
   const userName = useOwnUserName();
+
+  const openGettingStarted = () => {
+    const link = props.gettingStartedLink;
+    if (!link) return;
+    navigateToSidebarView({
+      viewId: link.id,
+      params: link.params,
+      shiftKey: false,
+      activeSplit: globalSplitManager()?.activeSplit(),
+      openWithSplit: layout.openWithSplit,
+      referredFrom: 'sidebar',
+    });
+    globalSplitManager()?.returnFocus();
+  };
 
   // Prefer the user's real name (first/last); fall back to their email.
   const displayName = createMemo(() => {
@@ -886,6 +907,27 @@ const SidebarSettingsWidget = (props: SidebarSettingsWidgetProps) => {
             </div>
           </div>
           <div class="-mx-1.5 mt-2 mb-1.5 h-px bg-edge-muted" />
+          <Show when={props.gettingStartedLink}>
+            {(link) => (
+              <Dropdown.Item
+                class="flex items-center gap-2 px-2.5 py-2 text-sm cursor-default outline-none text-ink-muted"
+                onSelect={openGettingStarted}
+              >
+                <span class="size-5 flex items-center justify-center">
+                  <Dynamic
+                    component={link().icon}
+                    class="size-4 shrink-0 text-ink-extra-muted"
+                  />
+                </span>
+                <span class="flex-1 text-ink">{link().label}</span>
+                <Hotkey
+                  token={link().hotkeyToken}
+                  theme="subtle"
+                  class="ml-6"
+                />
+              </Dropdown.Item>
+            )}
+          </Show>
           <Dropdown.Item
             class="flex items-center gap-2 px-2.5 py-2 text-sm cursor-default outline-none text-ink-muted"
             onSelect={() => CommandState.open()}
@@ -1223,7 +1265,7 @@ export const AppSidebar = (props: AppSidebarProps) => {
                 // so this stays true.
                 toast.success('Removed from sidebar', {
                   subtext:
-                    'You can always find Getting Started in the command menu.',
+                    'You can always find Getting Started in the account menu or command menu.',
                 });
               },
             }
@@ -1250,6 +1292,12 @@ export const AppSidebar = (props: AppSidebarProps) => {
       )
       .map((id) => findLink(id))
       .filter((link): link is SidebarItem => link !== undefined)
+  );
+
+  // While the Getting Started row is hidden (but still account-gated in via
+  // `findLink`), surface it in the account menu so the page stays reachable.
+  const gettingStartedMenuLink = createMemo(() =>
+    gettingStartedVisibility.hidden() ? findLink('getting-started') : undefined
   );
 
   const sectionItemsFor = (ids: readonly SidebarSectionLinkId[]) =>
@@ -1583,6 +1631,7 @@ export const AppSidebar = (props: AppSidebarProps) => {
           isSlim={isSlim}
           onSelect={openSettingsTab}
           onMenuOpenChange={handleOverlayDropdownOpenChange}
+          gettingStartedLink={gettingStartedMenuLink()}
         />
       </div>
       <InviteModal />

--- a/apps/web/src/components/app/app-sidebar/sidebar.tsx
+++ b/apps/web/src/components/app/app-sidebar/sidebar.tsx
@@ -921,7 +921,8 @@ const SidebarSettingsWidget = (props: SidebarSettingsWidgetProps) => {
                 </span>
                 <span class="flex-1 text-ink">{link().label}</span>
                 <Hotkey
-                  token={link().hotkeyToken}
+                  // Hardcoding this so that we can include the command scope activation
+                  shortcut="g s"
                   theme="subtle"
                   class="ml-6"
                 />


### PR DESCRIPTION
## What & why

When a user removes the **Getting Started** row from the sidebar, the page was only reachable via the command menu / `g s` hotkey. This surfaces it in the bottom user-icon (account) dropdown while the row is hidden, so it stays easy to find.

## How

All changes in `apps/web/src/components/app/app-sidebar/sidebar.tsx`:

- `SidebarSettingsWidget` (the avatar dropdown) accepts an optional `gettingStartedLink`. When present it renders a "Getting Started" item (compass icon + `g s` hotkey hint, matching the existing rows) that opens the page via the same `navigateToSidebarView` split-navigation path the sidebar row uses.
- `AppSidebar` derives that link from `findLink('getting-started')` only while `gettingStartedVisibility.hidden()` is true. Since `findLink` already respects the account-age gate, the item appears only when the feature is enabled *and* the user removed the row.
- Removal toast subtext updated to mention the account menu alongside the command menu.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LexdoSzQ9uFmJG9fL3kAde)_