### PR TITLE
fix(command): clear query when escaping nested command scope

### DIFF
--- a/apps/web/src/features/command/CommandMenu.tsx
+++ b/apps/web/src/features/command/CommandMenu.tsx
@@ -150,8 +150,8 @@ export function CommandMenuInner(props: {
   const defaultCommandItems = props.items
     ? undefined
     : useCommandItems(query, CommandState.categoryFilter, {
-        searchActive: CommandState.isOpen,
-      });
+      searchActive: CommandState.isOpen,
+    });
   const filteredItems = props.items ?? defaultCommandItems!.items;
   const pagination = defaultCommandItems?.pagination;
   const listController = createCommandListController({
@@ -446,6 +446,7 @@ export function CommandMenuInner(props: {
       // If in command scope, go back to main menu
       if (CommandState.commandScopeCommands().length > 0) {
         CommandState.clearCommandScopeCommands();
+        CommandState.clearQuery(); // Reset query text when backing out
         CommandState.setSelectedIndex(0);
         setActiveScope(hotkeyScope);
         return true;


### PR DESCRIPTION
## What changed
When pressing `ESC` to back out of a sub-command menu (like a multi-step command in Cmd+K), the search text field now resets and clears automatically.

## Why
Previously, backing out of a sub-command left the old search text stuck in the input box, so you had to manually backspace the old text before searching for another command.

## How it was tested
Verified that pressing `ESC` inside nested command views returns to a clean, empty search box on the main command menu.
