### PR TITLE
fix(ui): show dialog overlay backdrop by default

### DIFF
--- a/apps/web/src/components/ui/components/Dialog.tsx
+++ b/apps/web/src/components/ui/components/Dialog.tsx
@@ -70,7 +70,7 @@ export function Dialog(props: DialogProps) {
           class={cn(
             'invisible fixed inset-0 z-modal bg-modal-overlay',
             animateOnOpen() && 'dialog-overlay-open-animation',
-            Boolean(props.visibleScrim) && 'visible'
+            (props.visibleScrim ?? true) && 'visible'
           )}
         />
         <div


### PR DESCRIPTION
## What changed
Updated `Dialog.tsx` overlay backdrop visibility condition so `visibleScrim` defaults to `true` when omitted.

## Why
Previously, `Boolean(props.visibleScrim)` evaluated to `false` when `visibleScrim` was omitted, causing the `invisible` base class to keep modal overlay backdrops hidden (`visibility: hidden`).

## How it was tested
Verified that standard `<Dialog open={true}>` instances render the dimmed background overlay as expected.
