### PR TITLE
fix(ui): smooth opacity transition on SendButton visibility toggle

### DIFF
--- a/apps/web/src/components/ui/components/SendButton.tsx
+++ b/apps/web/src/components/ui/components/SendButton.tsx
@@ -32,7 +32,7 @@ export function SendButton(props: SendButtonProps) {
       tooltip={local.tooltip ?? 'Send'}
       class={cn(
         'rounded-[11px] size-7.5 [&_svg]:stroke-[4px]',
-        'transition-transform ease duration-150',
+        'transition-[transform,opacity] ease-out duration-150',
         'data-disabled:opacity-100 data-disabled:text-ink-extra-muted! data-disabled:bg-ink-muted/5',
         'active:not-disabled:scale-95',
         local.hidden && 'opacity-0!',


### PR DESCRIPTION
## What changed
Updated `SendButton.tsx` transition CSS properties to include `opacity` alongside `transform` (`transition-[transform,opacity]`).

## Why
`SendButton` toggles `opacity-0!` via `local.hidden` when the input state changes, but line 35 previously only transitioned scale transforms, causing the button to snap abruptly when hidden/shown.

## How it was tested
Verified that the send button fades smoothly over 150ms when toggled in `ChatInput`.
