### PR TITLE
Enable AI worker OTEL export

### DIFF
--- a/services/ai-editing-worker/wrangler.toml
+++ b/services/ai-editing-worker/wrangler.toml
@@ -59,6 +59,7 @@ database_id = "16d34e99-3bc6-44e4-a287-1ea65183bd28"
 
 [env.dev.vars]
 ENVIRONMENT = "development"
+OTEL_EXPORTER_OTLP_ENDPOINT = "https://macro-prox-dev.macroverse.workers.dev/i/otlp/v1/traces"
 SYNC_WS_BASE = "wss://sync-service-dev3.macroverse.workers.dev"
 DSS_BASE = "https://cloud-storage-dev.macro.com"
 SEARCH_SERVICE_BASE = "https://cloud-storage-dev.macro.com"
@@ -91,6 +92,7 @@ name = "ai-editing-worker"
 
 [env.prod.vars]
 ENVIRONMENT = "production"
+OTEL_EXPORTER_OTLP_ENDPOINT = "https://macro-prox-prod.macroverse.workers.dev/i/otlp/v1/traces"
 SYNC_WS_BASE = "wss://sync-service-prod2.macroverse.workers.dev"
 DSS_BASE = "https://cloud-storage.macro.com"
 SEARCH_SERVICE_BASE = "https://cloud-storage.macro.com"


### PR DESCRIPTION

- configure the AI editing worker to export development traces through the dev analytics proxy
- configure the production endpoint for deployment after merge