### PR TITLE
feat: claude recorder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,15 +221,18 @@ dependencies = [
  "agent-client-protocol",
  "agent_runtime_protocol",
  "anyhow",
+ "axum",
  "bots",
  "chrono",
  "macro_db_migrator",
  "macro_user_id",
  "macro_uuid",
+ "serde",
  "serde_json",
  "sqlx",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-tungstenite 0.28.0",
  "workspace-hack",
 ]
 

--- a/crates/agent_session/Cargo.toml
+++ b/crates/agent_session/Cargo.toml
@@ -13,10 +13,13 @@ sqlx = { workspace = true }
 chrono = { workspace = true }
 thiserror = { workspace = true }
 anyhow = { workspace = true }
+serde = { workspace = true }
 serde_json = { workspace = true }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
 [dev-dependencies]
 agent-client-protocol = { workspace = true }
+axum = { workspace = true, features = ["ws"] }
 macro_db_migrator = { path = "../macro_db_migrator" }
-tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["fs", "io-std", "io-util", "macros", "net", "rt-multi-thread", "time"] }
+tokio-tungstenite = { workspace = true }

--- a/crates/agent_session/examples/agent_session_recorder.rs
+++ b/crates/agent_session/examples/agent_session_recorder.rs
@@ -1,0 +1,470 @@
+//! Record a live agent session as [`Message`]-per-line JSONL fixtures.
+//!
+//! An ACP client (e.g. Zed) spawns this example as its agent server and
+//! speaks ACP over stdio. Internally the process is both sides of an
+//! Agent Runtime Protocol connection over a loopback WebSocket:
+//!
+//! - the service side accepts the runtime connection, records every logical
+//!   protocol message crossing the wire, and bridges the connection's ACP
+//!   channel to stdio;
+//! - a Tokio task stands in for a container, connects its runtime to the
+//!   service, announces `acp_ready`, and starts the official Claude Code ACP
+//!   adapter (`@agentclientprotocol/claude-agent-acp`) with `npx`.
+//!
+//! Each ACP session on the connection is recorded to its own file,
+//! `~/.agent_runtime_sessions/<session-id>.jsonl`, one JSON object per line:
+//! a timestamp flattened together with this crate's own [`Message`]
+//! serialization, so each line parses straight back into [`Message`]:
+//!
+//! ```text
+//! {"ts": "2026-08-03T14:22:07.123Z", "direction": "to_server" | "to_runtime", "content": <envelope>}
+//! ```
+//!
+//! One connection multiplexes many sessions (an ACP client like Zed spawns
+//! the agent server once and opens every session over it), so lines are
+//! routed by the session they belong to: `params.sessionId` where present,
+//! and JSON-RPC request ids otherwise — a response is attributed to the
+//! session of the request it answers, and `session/new` only reveals its
+//! session in the response. Connection-level traffic that belongs to no
+//! session (the `acp_ready` event, the `initialize` handshake) is copied
+//! into every session file so each recording stands alone. A connection that
+//! never opens a session records nothing; a session resumed by a later
+//! process appends to its existing file.
+//!
+//! Prerequisites:
+//!
+//! - Node.js and `npx` must be installed;
+//! - Claude Code credentials: either a subscription login (`claude /login`)
+//!   or `ANTHROPIC_API_KEY` in the environment. The API key takes precedence
+//!   over the subscription login when both are present.
+//!
+//! Install the recorder to `~/.cargo/bin` (`--locked` keeps the workspace
+//! lockfile's dependency versions, which the pinned toolchain requires), then
+//! point an ACP client at the installed binary:
+//!
+//! ```text
+//! cargo install --locked --path crates/agent_session --example agent_session_recorder
+//! ```
+//!
+//! Zed `settings.json` (the shell resolves the binary from `$HOME`, so no
+//! hardcoded paths; the `env -u` strips a stray API key from the environment
+//! so the session uses the subscription login):
+//!
+//! ```text
+//! "agent_servers": {
+//!   "Recorded Claude": {
+//!     "type": "custom",
+//!     "command": "/bin/bash",
+//!     "args": [
+//!       "-c",
+//!       "exec env -u ANTHROPIC_API_KEY \"$HOME/.cargo/bin/agent_session_recorder\""
+//!     ]
+//!   }
+//! }
+//! ```
+//!
+//! All diagnostics go to stderr: stdout carries the ACP stream.
+
+use std::collections::HashMap;
+use std::collections::hash_map::Entry;
+use std::error::Error;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use agent_client_protocol::{AcpAgent, Agent, Client, ConnectTo, Stdio};
+use agent_runtime_protocol::domain::channel::Channel;
+use agent_runtime_protocol::domain::connection::{
+    RuntimeConnection, ServerChannel, ServerConnection,
+};
+use agent_runtime_protocol::domain::schema::v0::{SystemEvent, ToRuntimeMessage, ToServerMessage};
+use agent_runtime_protocol::outbound::websocket::{ServerTransport, connect_runtime};
+use agent_session::domain::model::Message;
+use chrono::{SecondsFormat, Utc};
+use serde::Serialize;
+use tokio::io::AsyncWriteExt;
+use tokio::sync::mpsc;
+
+#[cfg(test)]
+#[path = "agent_session_recorder/test.rs"]
+mod test;
+
+type AnyError = Box<dyn Error + Send + Sync>;
+
+const CLAUDE_AGENT_ACP: &str = "@agentclientprotocol/claude-agent-acp@0.64.2";
+
+#[tokio::main]
+async fn main() -> Result<(), AnyError> {
+    let dir = recordings_dir(&std::env::home_dir().ok_or("cannot determine home directory")?);
+    let (sink, lines) = mpsc::unbounded_channel();
+    let writer = tokio::spawn(run_writer(dir.clone(), lines));
+
+    let carrier: Arc<ServerTransport<ToRuntimeMessage, ToServerMessage>> =
+        Arc::new(ServerTransport::new());
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+    let address = listener.local_addr()?;
+    let app = Arc::clone(&carrier).into_router();
+    let websocket_handle = tokio::spawn(async move { axum::serve(listener, app).await });
+    eprintln!("recorder: service listening on ws://{address}");
+
+    let mut container = tokio::spawn(run_container(format!("ws://{address}")));
+    let incoming = accept_runtime(&carrier, &mut container).await?;
+    eprintln!(
+        "recorder: runtime connected, recording sessions under {}",
+        dir.display()
+    );
+
+    let (service, acp) = ServerConnection::connect(record_channel(incoming, sink), ());
+
+    // Bridge the ACP client on stdio to this connection's agent. The client
+    // drives the whole session; this future completes when it closes stdio.
+    let bridge = ConnectTo::<Agent>::connect_to(Stdio::new(), acp);
+    tokio::pin!(bridge);
+    let result: Result<(), AnyError> = tokio::select! {
+        result = &mut bridge => {
+            container.abort();
+            let _ = container.await;
+            result.map_err(Into::into)
+        }
+        container_result = &mut container => Err(container_error(container_result)),
+    };
+
+    // Tear the connection down, then let the writer drain what was recorded.
+    drop(service);
+    websocket_handle.abort();
+    match writer.await {
+        Ok(Ok(())) => eprintln!("recorder: session recordings saved under {}", dir.display()),
+        Ok(Err(error)) => eprintln!("recorder: writing the recordings failed: {error}"),
+        Err(error) => eprintln!("recorder: recording writer panicked: {error}"),
+    }
+    result
+}
+
+/// The directory holding per-session recordings for the user whose home
+/// directory is `home`.
+fn recordings_dir(home: &Path) -> PathBuf {
+    home.join(".agent_runtime_sessions")
+}
+
+/// Where the session identified by `session_id` is recorded under `dir`.
+///
+/// The id is minted by the agent (a UUID in practice); anything outside a
+/// conservative filename alphabet maps to `_` so an exotic id cannot name a
+/// path outside `dir`.
+fn session_recording_path(dir: &Path, session_id: &str) -> PathBuf {
+    let safe: String = session_id
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.') {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    dir.join(format!("{safe}.jsonl"))
+}
+
+/// One recorded line's destination.
+#[derive(Debug, PartialEq)]
+enum Append {
+    /// A connection-level line: appended to every open recording and copied
+    /// to the front of any recording opened later, so each file stands alone.
+    Shared(String),
+    /// A line belonging to one session's recording.
+    Session { session_id: String, line: String },
+}
+
+/// Where the response to an in-flight request belongs.
+enum Pending {
+    /// The request named its session; the response follows it there.
+    Session(String),
+    /// The request named no session (`initialize`, `session/new`, ...); its
+    /// line is held back until the response shows whether it minted one.
+    Unattributed { request_line: String },
+}
+
+/// Routes recorded JSONL lines to per-session recordings.
+///
+/// Most ACP traffic names its session in `params.sessionId`. Responses never
+/// do, so requests register their JSON-RPC id and responses are attributed
+/// by looking that id back up. Ids are scoped by the direction of the
+/// request: the two peers' id spaces are independent, so an id alone is
+/// ambiguous.
+#[derive(Default)]
+struct SessionRouter {
+    /// `"<issuer direction>:<id>"` of each in-flight request, mapped to
+    /// where its response belongs.
+    pending: HashMap<String, Pending>,
+}
+
+impl SessionRouter {
+    /// Decide where `line` (one serialized [`RecordedLine`]) is appended.
+    ///
+    /// A request that names no session yields nothing until its response
+    /// arrives; the pair is then routed together.
+    fn route(&mut self, line: String) -> Vec<Append> {
+        let value: serde_json::Value = match serde_json::from_str(&line) {
+            Ok(value) => value,
+            // Lines come from record_line, so this cannot happen; shared is
+            // the destination that never loses data.
+            Err(_) => return vec![Append::Shared(line)],
+        };
+        let direction = value["direction"].as_str().unwrap_or_default().to_owned();
+        let content = &value["content"];
+        let method = content["method"].as_str();
+        let id = match &content["id"] {
+            serde_json::Value::Null => None,
+            id => Some(id.to_string()),
+        };
+        let session_id = content["params"]["sessionId"].as_str().map(str::to_owned);
+
+        match (method, id) {
+            // A request: remember where its response belongs.
+            (Some(_), Some(id)) => match session_id {
+                Some(session_id) => {
+                    self.pending.insert(
+                        format!("{direction}:{id}"),
+                        Pending::Session(session_id.clone()),
+                    );
+                    vec![Append::Session { session_id, line }]
+                }
+                None => {
+                    self.pending.insert(
+                        format!("{direction}:{id}"),
+                        Pending::Unattributed { request_line: line },
+                    );
+                    vec![]
+                }
+            },
+            // A notification.
+            (Some(_), None) => match session_id {
+                Some(session_id) => vec![Append::Session { session_id, line }],
+                None => vec![Append::Shared(line)],
+            },
+            // A response: attribute it via the request that caused it, which
+            // traveled in the opposite direction.
+            (None, Some(id)) => {
+                let issuer = opposite(&direction);
+                match self.pending.remove(&format!("{issuer}:{id}")) {
+                    Some(Pending::Session(session_id)) => {
+                        vec![Append::Session { session_id, line }]
+                    }
+                    Some(Pending::Unattributed { request_line }) => {
+                        match content["result"]["sessionId"].as_str() {
+                            // The request minted a session (session/new);
+                            // both lines open its recording.
+                            Some(minted) => vec![
+                                Append::Session {
+                                    session_id: minted.to_owned(),
+                                    line: request_line,
+                                },
+                                Append::Session {
+                                    session_id: minted.to_owned(),
+                                    line,
+                                },
+                            ],
+                            None => vec![Append::Shared(request_line), Append::Shared(line)],
+                        }
+                    }
+                    None => vec![Append::Shared(line)],
+                }
+            }
+            // Not JSON-RPC at all, e.g. the acp_ready system event.
+            (None, None) => vec![Append::Shared(line)],
+        }
+    }
+
+    /// Give back request lines still waiting on a response — e.g. when the
+    /// connection closes mid-request — so they are not lost. Sorted by
+    /// pending key for determinism.
+    fn drain(&mut self) -> Vec<Append> {
+        let mut pending: Vec<_> = std::mem::take(&mut self.pending).into_iter().collect();
+        pending.sort_by(|(a, _), (b, _)| a.cmp(b));
+        pending
+            .into_iter()
+            .filter_map(|(_, entry)| match entry {
+                Pending::Session(_) => None,
+                Pending::Unattributed { request_line } => Some(Append::Shared(request_line)),
+            })
+            .collect()
+    }
+}
+
+/// The opposite of a recorded `direction` value.
+fn opposite(direction: &str) -> &'static str {
+    match direction {
+        "to_server" => "to_runtime",
+        _ => "to_server",
+    }
+}
+
+/// Route recorded lines to per-session files until every sink handle drops.
+///
+/// Flushes after every line so a session killed mid-run keeps its data.
+async fn run_writer(
+    dir: PathBuf,
+    mut lines: mpsc::UnboundedReceiver<String>,
+) -> std::io::Result<()> {
+    tokio::fs::create_dir_all(&dir).await?;
+    let mut router = SessionRouter::default();
+    // Connection-level lines recorded so far, copied into each new recording.
+    let mut shared: Vec<String> = Vec::new();
+    let mut recordings: HashMap<String, tokio::fs::File> = HashMap::new();
+
+    while let Some(line) = lines.recv().await {
+        let appends = router.route(line);
+        append_lines(&dir, appends, &mut shared, &mut recordings).await?;
+    }
+    let leftovers = router.drain();
+    append_lines(&dir, leftovers, &mut shared, &mut recordings).await
+}
+
+/// Apply routed appends, opening a session's recording on its first line.
+///
+/// A recording opens in append mode: a session resumed by a later process
+/// continues its existing file. Each newly opened recording starts with a
+/// copy of the connection-level lines seen so far.
+async fn append_lines(
+    dir: &Path,
+    appends: Vec<Append>,
+    shared: &mut Vec<String>,
+    recordings: &mut HashMap<String, tokio::fs::File>,
+) -> std::io::Result<()> {
+    for append in appends {
+        match append {
+            Append::Shared(line) => {
+                for file in recordings.values_mut() {
+                    write_line(file, &line).await?;
+                }
+                shared.push(line);
+            }
+            Append::Session { session_id, line } => {
+                let file = match recordings.entry(session_id) {
+                    Entry::Occupied(entry) => entry.into_mut(),
+                    Entry::Vacant(entry) => {
+                        let path = session_recording_path(dir, entry.key());
+                        let mut file = tokio::fs::OpenOptions::new()
+                            .create(true)
+                            .append(true)
+                            .open(&path)
+                            .await?;
+                        for line in shared.iter() {
+                            write_line(&mut file, line).await?;
+                        }
+                        eprintln!(
+                            "recorder: session {} recording to {}",
+                            entry.key(),
+                            path.display()
+                        );
+                        entry.insert(file)
+                    }
+                };
+                write_line(file, &line).await?;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Append one line to `file` and flush it.
+async fn write_line(file: &mut tokio::fs::File, line: &str) -> std::io::Result<()> {
+    file.write_all(line.as_bytes()).await?;
+    file.write_all(b"\n").await?;
+    file.flush().await
+}
+
+/// Interpose a recording tap on the service side of a logical connection.
+///
+/// Every message crossing the channel is appended to `sink` as one JSONL
+/// line before being forwarded unchanged. Recording is best-effort: a
+/// message that fails to serialize is reported on stderr and forwarded
+/// anyway, and a closed sink never tears down the session.
+fn record_channel(inner: ServerChannel, sink: mpsc::UnboundedSender<String>) -> ServerChannel {
+    let (outer, bridge) = Channel::duplex();
+    let Channel {
+        tx: inner_tx,
+        rx: mut inner_rx,
+    } = inner;
+    let Channel {
+        tx: bridge_tx,
+        rx: mut bridge_rx,
+    }: Channel<ToServerMessage, ToRuntimeMessage> = bridge;
+
+    let to_runtime_sink = sink.clone();
+    tokio::spawn(async move {
+        while let Some(message) = bridge_rx.recv().await {
+            record(&to_runtime_sink, &Message::ToRuntime(message.clone()));
+            if inner_tx.send(message).is_err() {
+                break;
+            }
+        }
+    });
+    tokio::spawn(async move {
+        while let Some(message) = inner_rx.recv().await {
+            record(&sink, &Message::ToServer(message.clone()));
+            if bridge_tx.send(message).is_err() {
+                break;
+            }
+        }
+    });
+
+    outer
+}
+
+/// One recorded JSONL line: a timestamp flattened alongside [`Message`]'s
+/// own `direction`/`content` serialization.
+#[derive(Serialize)]
+struct RecordedLine<'a> {
+    ts: String,
+    #[serde(flatten)]
+    message: &'a Message,
+}
+
+fn record(sink: &mpsc::UnboundedSender<String>, message: &Message) {
+    match record_line(message) {
+        Ok(line) => {
+            let _ = sink.send(line);
+        }
+        Err(error) => eprintln!("recorder: dropping unserializable message: {error}"),
+    }
+}
+
+fn record_line(message: &Message) -> serde_json::Result<String> {
+    serde_json::to_string(&RecordedLine {
+        ts: Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true),
+        message,
+    })
+}
+
+async fn accept_runtime(
+    carrier: &ServerTransport<ToRuntimeMessage, ToServerMessage>,
+    container: &mut tokio::task::JoinHandle<Result<(), AnyError>>,
+) -> Result<ServerChannel, AnyError> {
+    tokio::select! {
+        incoming = carrier.accept() => incoming
+            .ok_or_else(|| "container disconnected before connecting".into()),
+        result = &mut *container => Err(container_error(result)),
+    }
+}
+
+fn container_error(result: Result<Result<(), AnyError>, tokio::task::JoinError>) -> AnyError {
+    match result {
+        Ok(Ok(())) => "container exited unexpectedly".into(),
+        Ok(Err(error)) => error,
+        Err(error) => Box::new(error),
+    }
+}
+
+async fn run_container(websocket_url: String) -> Result<(), AnyError> {
+    let (stream, _response) = tokio_tungstenite::connect_async(websocket_url).await?;
+    let channel = connect_runtime::<ToServerMessage, ToRuntimeMessage, _>(stream);
+    let (runtime, acp) = RuntimeConnection::connect(channel);
+    // Announce readiness over the wire like a real Agent Runtime would, so
+    // the recording contains the acp_ready event that production logs carry.
+    runtime.system_event(SystemEvent::AcpReady)?;
+
+    let claude_code = AcpAgent::from_args(["npx", "-y", CLAUDE_AGENT_ACP])?;
+    ConnectTo::<Client>::connect_to(claude_code, acp)
+        .await
+        .map_err(Into::into)
+}

--- a/crates/agent_session/examples/agent_session_recorder/test.rs
+++ b/crates/agent_session/examples/agent_session_recorder/test.rs
@@ -1,0 +1,330 @@
+use chrono::DateTime;
+use serde_json::{Value, json};
+use tokio::time::{Duration, timeout};
+
+use super::*;
+
+/// A recorded line the way `record_line` would serialize it.
+fn line(direction: &str, content: Value) -> String {
+    json!({
+        "ts": "2026-08-03T14:22:07.123Z",
+        "direction": direction,
+        "content": content,
+    })
+    .to_string()
+}
+
+fn shared(line: &str) -> Append {
+    Append::Shared(line.to_owned())
+}
+
+fn session(session_id: &str, line: &str) -> Append {
+    Append::Session {
+        session_id: session_id.to_owned(),
+        line: line.to_owned(),
+    }
+}
+
+#[test]
+fn session_recording_path_is_sanitized_jsonl_under_dir() {
+    assert_eq!(
+        session_recording_path(Path::new("/tmp/recordings"), "sess-1"),
+        PathBuf::from("/tmp/recordings/sess-1.jsonl"),
+    );
+    // Path separators in an exotic id cannot escape the directory.
+    assert_eq!(
+        session_recording_path(Path::new("/tmp/recordings"), "../evil/id"),
+        PathBuf::from("/tmp/recordings/.._evil_id.jsonl"),
+    );
+}
+
+#[test]
+fn router_attributes_session_new_to_its_minted_session() {
+    let mut router = SessionRouter::default();
+
+    // Connection-level traffic is shared: the readiness event immediately,
+    // the initialize pair once its response shows no session was minted.
+    let ready = line("to_server", json!({"type": "event", "event": "acp_ready"}));
+    assert_eq!(router.route(ready.clone()), vec![shared(&ready)]);
+    let init_request = line(
+        "to_runtime",
+        json!({"type": "acp", "jsonrpc": "2.0", "id": 0, "method": "initialize", "params": {}}),
+    );
+    assert_eq!(router.route(init_request.clone()), vec![]);
+    let init_response = line(
+        "to_server",
+        json!({"type": "acp", "jsonrpc": "2.0", "id": 0, "result": {"protocolVersion": 1}}),
+    );
+    assert_eq!(
+        router.route(init_response.clone()),
+        vec![shared(&init_request), shared(&init_response)],
+    );
+
+    // session/new is buffered until the response mints the session id, then
+    // both lines land in that session.
+    let new_request = line(
+        "to_runtime",
+        json!({"type": "acp", "jsonrpc": "2.0", "id": 1, "method": "session/new", "params": {"cwd": "/"}}),
+    );
+    assert_eq!(router.route(new_request.clone()), vec![]);
+    let new_response = line(
+        "to_server",
+        json!({"type": "acp", "jsonrpc": "2.0", "id": 1, "result": {"sessionId": "sess-1"}}),
+    );
+    assert_eq!(
+        router.route(new_response.clone()),
+        vec![
+            session("sess-1", &new_request),
+            session("sess-1", &new_response),
+        ],
+    );
+
+    // Traffic naming the session follows it directly.
+    let update = line(
+        "to_server",
+        json!({"type": "acp", "jsonrpc": "2.0", "method": "session/update", "params": {"sessionId": "sess-1", "update": {}}}),
+    );
+    assert_eq!(
+        router.route(update.clone()),
+        vec![session("sess-1", &update)]
+    );
+}
+
+#[test]
+fn router_scopes_request_ids_by_direction() {
+    let mut router = SessionRouter::default();
+
+    // Both peers use id 7 concurrently: the client prompts sess-a while the
+    // agent asks sess-b for permission.
+    let prompt = line(
+        "to_runtime",
+        json!({"type": "acp", "jsonrpc": "2.0", "id": 7, "method": "session/prompt", "params": {"sessionId": "sess-a", "prompt": []}}),
+    );
+    assert_eq!(
+        router.route(prompt.clone()),
+        vec![session("sess-a", &prompt)]
+    );
+    let permission = line(
+        "to_server",
+        json!({"type": "acp", "jsonrpc": "2.0", "id": 7, "method": "session/request_permission", "params": {"sessionId": "sess-b"}}),
+    );
+    assert_eq!(
+        router.route(permission.clone()),
+        vec![session("sess-b", &permission)],
+    );
+
+    // Each response routes to the session of the request it answers.
+    let permission_reply = line(
+        "to_runtime",
+        json!({"type": "acp", "jsonrpc": "2.0", "id": 7, "result": {"outcome": {"outcome": "cancelled"}}}),
+    );
+    assert_eq!(
+        router.route(permission_reply.clone()),
+        vec![session("sess-b", &permission_reply)],
+    );
+    let prompt_reply = line(
+        "to_server",
+        json!({"type": "acp", "jsonrpc": "2.0", "id": 7, "result": {"stopReason": "end_turn"}}),
+    );
+    assert_eq!(
+        router.route(prompt_reply.clone()),
+        vec![session("sess-a", &prompt_reply)],
+    );
+}
+
+#[test]
+fn router_falls_back_to_shared_for_unattributable_lines() {
+    let mut router = SessionRouter::default();
+
+    // A notification naming no session, and a response to a request the
+    // router never saw, both stay at connection level.
+    let notification = line(
+        "to_server",
+        json!({"type": "acp", "jsonrpc": "2.0", "method": "connection/ping", "params": {}}),
+    );
+    assert_eq!(
+        router.route(notification.clone()),
+        vec![shared(&notification)],
+    );
+    let orphan_response = line(
+        "to_server",
+        json!({"type": "acp", "jsonrpc": "2.0", "id": 99, "result": {}}),
+    );
+    assert_eq!(
+        router.route(orphan_response.clone()),
+        vec![shared(&orphan_response)],
+    );
+}
+
+#[test]
+fn router_drain_recovers_unanswered_requests() {
+    let mut router = SessionRouter::default();
+
+    let unanswered = line(
+        "to_runtime",
+        json!({"type": "acp", "jsonrpc": "2.0", "id": 3, "method": "session/new", "params": {"cwd": "/"}}),
+    );
+    assert_eq!(router.route(unanswered.clone()), vec![]);
+    assert_eq!(router.drain(), vec![shared(&unanswered)]);
+    assert_eq!(router.drain(), vec![]);
+}
+
+#[tokio::test]
+async fn writer_splits_sessions_into_standalone_files() {
+    let dir = std::env::temp_dir().join(format!(
+        "agent_session_recorder_writer_test_{}",
+        std::process::id()
+    ));
+    let _ = tokio::fs::remove_dir_all(&dir).await;
+
+    let ready = line("to_server", json!({"type": "event", "event": "acp_ready"}));
+    let new_a_request = line(
+        "to_runtime",
+        json!({"type": "acp", "jsonrpc": "2.0", "id": 1, "method": "session/new", "params": {"cwd": "/"}}),
+    );
+    let new_a_response = line(
+        "to_server",
+        json!({"type": "acp", "jsonrpc": "2.0", "id": 1, "result": {"sessionId": "sess-a"}}),
+    );
+    let update_a = line(
+        "to_server",
+        json!({"type": "acp", "jsonrpc": "2.0", "method": "session/update", "params": {"sessionId": "sess-a", "update": {}}}),
+    );
+    let ping = line(
+        "to_server",
+        json!({"type": "acp", "jsonrpc": "2.0", "method": "connection/ping", "params": {}}),
+    );
+    let new_b_request = line(
+        "to_runtime",
+        json!({"type": "acp", "jsonrpc": "2.0", "id": 2, "method": "session/new", "params": {"cwd": "/"}}),
+    );
+    let new_b_response = line(
+        "to_server",
+        json!({"type": "acp", "jsonrpc": "2.0", "id": 2, "result": {"sessionId": "sess-b"}}),
+    );
+    let update_b = line(
+        "to_server",
+        json!({"type": "acp", "jsonrpc": "2.0", "method": "session/update", "params": {"sessionId": "sess-b", "update": {}}}),
+    );
+
+    let (sink, lines) = mpsc::unbounded_channel();
+    let writer = tokio::spawn(run_writer(dir.clone(), lines));
+    for recorded in [
+        &ready,
+        &new_a_request,
+        &new_a_response,
+        &update_a,
+        &ping,
+        &new_b_request,
+        &new_b_response,
+        &update_b,
+    ] {
+        sink.send(recorded.clone())
+            .expect("writer should be listening");
+    }
+    drop(sink);
+    timeout(Duration::from_secs(5), writer)
+        .await
+        .expect("writer should stop once the sink drops")
+        .expect("writer should not panic")
+        .expect("writer should not fail");
+
+    // sess-a was open when the shared ping arrived, so it appears in stream
+    // order; sess-b opened later and gets it as part of its shared prefix.
+    let recording_a = tokio::fs::read_to_string(session_recording_path(&dir, "sess-a"))
+        .await
+        .expect("sess-a recording should exist");
+    assert_eq!(
+        recording_a.lines().collect::<Vec<_>>(),
+        vec![&ready, &new_a_request, &new_a_response, &update_a, &ping],
+    );
+    let recording_b = tokio::fs::read_to_string(session_recording_path(&dir, "sess-b"))
+        .await
+        .expect("sess-b recording should exist");
+    assert_eq!(
+        recording_b.lines().collect::<Vec<_>>(),
+        vec![&ready, &ping, &new_b_request, &new_b_response, &update_b],
+    );
+
+    tokio::fs::remove_dir_all(&dir)
+        .await
+        .expect("test directory should be removable");
+}
+
+#[tokio::test]
+async fn tap_records_and_forwards_both_directions() {
+    let (inner, mut runtime_side) = Channel::duplex();
+    let (sink, mut lines) = mpsc::unbounded_channel();
+    let mut tapped = record_channel(inner, sink);
+
+    // Runtime -> service traffic is forwarded and recorded as to_server.
+    runtime_side
+        .tx
+        .send(ToServerMessage::Event {
+            event: SystemEvent::AcpReady,
+        })
+        .expect("tap should be listening");
+    let forwarded = timeout(Duration::from_secs(1), tapped.rx.recv())
+        .await
+        .expect("runtime message should be forwarded promptly")
+        .expect("tapped channel should stay open");
+    assert!(matches!(
+        forwarded,
+        ToServerMessage::Event {
+            event: SystemEvent::AcpReady
+        }
+    ));
+
+    // Service -> runtime traffic is forwarded and recorded as to_runtime.
+    let prompt: ToRuntimeMessage = serde_json::from_value(json!({
+        "type": "acp",
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "session/prompt",
+        "params": { "sessionId": "sess-1", "prompt": [] },
+    }))
+    .expect("envelope should deserialize");
+    tapped.tx.send(prompt).expect("tap should be listening");
+    let forwarded = timeout(Duration::from_secs(1), runtime_side.rx.recv())
+        .await
+        .expect("service message should be forwarded promptly")
+        .expect("runtime channel should stay open");
+    assert!(matches!(forwarded, ToRuntimeMessage::Acp(_)));
+
+    // Each direction was recorded before it was forwarded, so by the time
+    // the forwards above were observed both lines are already in the sink,
+    // in send order. Each line is Message's own serialization plus `ts`, so
+    // it parses straight back into Message.
+    let event_line = lines.recv().await.expect("event line");
+    let event_value: Value =
+        serde_json::from_str(&event_line).expect("recorded line should be JSON");
+    assert_eq!(event_value["direction"], "to_server");
+    assert_eq!(
+        event_value["content"],
+        json!({"type": "event", "event": "acp_ready"})
+    );
+    DateTime::parse_from_rfc3339(event_value["ts"].as_str().expect("ts should be a string"))
+        .expect("ts should be RFC 3339");
+    let event_message: Message =
+        serde_json::from_str(&event_line).expect("line should parse as Message");
+    assert!(matches!(
+        event_message,
+        Message::ToServer(ToServerMessage::Event {
+            event: SystemEvent::AcpReady
+        })
+    ));
+
+    let prompt_line = lines.recv().await.expect("prompt line");
+    let prompt_value: Value =
+        serde_json::from_str(&prompt_line).expect("recorded line should be JSON");
+    assert_eq!(prompt_value["direction"], "to_runtime");
+    assert_eq!(prompt_value["content"]["type"], "acp");
+    assert_eq!(prompt_value["content"]["method"], "session/prompt");
+    assert_eq!(prompt_value["content"]["params"]["sessionId"], "sess-1");
+    let prompt_message: Message =
+        serde_json::from_str(&prompt_line).expect("line should parse as Message");
+    assert!(matches!(
+        prompt_message,
+        Message::ToRuntime(ToRuntimeMessage::Acp(_))
+    ));
+}

--- a/crates/agent_session/src/domain/model.rs
+++ b/crates/agent_session/src/domain/model.rs
@@ -3,6 +3,7 @@ use bots::domain::models::BotId;
 use chrono::{DateTime, Utc};
 use macro_user_id::user_id::MacroUserIdStr;
 use macro_uuid::Uuid;
+use serde::{Deserialize, Serialize};
 
 pub struct UninitializedSession;
 
@@ -56,7 +57,14 @@ pub struct AgentSession<SessionId> {
     pub modified_at: DateTime<Utc>,
 }
 
-#[derive(Debug, Clone)]
+/// One logical protocol message with its direction.
+///
+/// Serializes as `{"direction": "to_server" | "to_runtime", "content": <envelope>}`,
+/// the same vocabulary the Postgres log storage uses for its `direction` and
+/// `content` columns, so recorded fixtures and stored rows share one wire
+/// format.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "direction", content = "content", rename_all = "snake_case")]
 pub enum Message {
     ToServer(ToServerMessage),
     ToRuntime(ToRuntimeMessage),


### PR DESCRIPTION
Records each ACP session on a runtime connection to its own `~/.agent_runtime_sessions/<session-id>.jsonl` fixture, routing lines by `params.sessionId` and by JSON-RPC request id for responses, so the many sessions an ACP client multiplexes over one recorder process no longer land in a single per-process file.