### PR TITLE
feat(calendar): calendar elevated-permissions upgrade flow

### DIFF
--- a/.sqlx/query-14a4283e305f1b0edf4005a06973106e61acc84ec8662b7930a126aea5c514de.json
+++ b/.sqlx/query-14a4283e305f1b0edf4005a06973106e61acc84ec8662b7930a126aea5c514de.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        SELECT l.id as \"id!\", l.macro_id as \"macro_id!\",\n               l.fusionauth_user_id as \"fusionauth_user_id!\",\n               l.email_address as \"email_address!\",\n               l.provider as \"provider!: _\",\n               l.is_sync_active as \"is_sync_active!\",\n               l.is_primary as \"is_primary!\",\n               l.needs_reauth as \"needs_reauth!\",\n               l.last_sync_error_at,\n               l.created_at as \"created_at!\",\n               l.updated_at as \"updated_at!\",\n               s.signature_on_replies_forwards as \"signature_on_replies_forwards?\",\n               s.signature,\n               bj.status as \"latest_backfill_status?: _\",\n               c.sfs_photo_url as \"photo_url?\"\n        FROM (\n            SELECT el.id, el.macro_id, el.fusionauth_user_id, el.email_address,\n                   el.provider, el.is_sync_active, el.is_primary, el.needs_reauth,\n                   el.last_sync_error_at, el.created_at, el.updated_at\n            FROM email_links el\n            WHERE el.macro_id = $1\n            UNION\n            SELECT el.id, el.macro_id, el.fusionauth_user_id, el.email_address,\n                   el.provider, el.is_sync_active, el.is_primary, el.needs_reauth,\n                   el.last_sync_error_at, el.created_at, el.updated_at\n            FROM email_links el\n            JOIN macro_user_links mul ON el.id = mul.link_id\n            WHERE mul.primary_macro_id = $1\n        ) l\n        LEFT JOIN email_settings s ON s.link_id = l.id\n        LEFT JOIN LATERAL (\n            SELECT status FROM email_backfill_jobs\n            WHERE link_id = l.id\n            ORDER BY created_at DESC\n            LIMIT 1\n        ) bj ON true\n        LEFT JOIN email_contacts c\n            ON c.link_id = l.id AND LOWER(c.email_address) = LOWER(l.email_address)\n        ORDER BY l.created_at DESC\n        ",
+  "query": "\n        SELECT l.id as \"id!\", l.macro_id as \"macro_id!\",\n               l.fusionauth_user_id as \"fusionauth_user_id!\",\n               l.email_address as \"email_address!\",\n               l.provider as \"provider!: _\",\n               l.is_sync_active as \"is_sync_active!\",\n               l.is_primary as \"is_primary!\",\n               l.needs_reauth as \"needs_reauth!\",\n               l.last_sync_error_at,\n               l.created_at as \"created_at!\",\n               l.updated_at as \"updated_at!\",\n               s.signature_on_replies_forwards as \"signature_on_replies_forwards?\",\n               s.signature,\n               bj.status as \"latest_backfill_status?: _\",\n               c.sfs_photo_url as \"photo_url?\",\n               l.google_granted_scopes as \"google_granted_scopes!\"\n        FROM (\n            SELECT el.id, el.macro_id, el.fusionauth_user_id, el.email_address,\n                   el.provider, el.is_sync_active, el.is_primary, el.needs_reauth,\n                   el.last_sync_error_at, el.created_at, el.updated_at,\n                   el.google_granted_scopes\n            FROM email_links el\n            WHERE el.macro_id = $1\n            UNION\n            SELECT el.id, el.macro_id, el.fusionauth_user_id, el.email_address,\n                   el.provider, el.is_sync_active, el.is_primary, el.needs_reauth,\n                   el.last_sync_error_at, el.created_at, el.updated_at,\n                   el.google_granted_scopes\n            FROM email_links el\n            JOIN macro_user_links mul ON el.id = mul.link_id\n            WHERE mul.primary_macro_id = $1\n        ) l\n        LEFT JOIN email_settings s ON s.link_id = l.id\n        LEFT JOIN LATERAL (\n            SELECT status FROM email_backfill_jobs\n            WHERE link_id = l.id\n            ORDER BY created_at DESC\n            LIMIT 1\n        ) bj ON true\n        LEFT JOIN email_contacts c\n            ON c.link_id = l.id AND LOWER(c.email_address) = LOWER(l.email_address)\n        ORDER BY l.created_at DESC\n        ",
   "describe": {
     "columns": [
       {
@@ -99,6 +99,11 @@
         "ordinal": 14,
         "name": "photo_url?",
         "type_info": "Text"
+      },
+      {
+        "ordinal": 15,
+        "name": "google_granted_scopes!",
+        "type_info": "TextArray"
       }
     ],
     "parameters": {
@@ -121,8 +126,9 @@
       false,
       true,
       false,
-      true
+      true,
+      null
     ]
   },
-  "hash": "d1a0fe539e47a9394246dcebcdf0b01463fe872365d6ded02c64a40a498a4295"
+  "hash": "14a4283e305f1b0edf4005a06973106e61acc84ec8662b7930a126aea5c514de"
 }

--- a/apps/web/src/components/app/Layout.tsx
+++ b/apps/web/src/components/app/Layout.tsx
@@ -1,6 +1,7 @@
 import { DEFAULT_ROUTE } from '@app/constants/defaultRoute';
 import { ROUTER_BASE_CONCAT } from '@app/constants/routerBase';
 import Banner from '@app/features/auth/banner/Banner';
+import { CalendarPermissionPrompt } from '@app/features/auth/CalendarPermissionPrompt';
 import { GithubReauthenticationPrompt } from '@app/features/auth/GithubReauthenticationPrompt';
 import { GmailReauthenticationPrompt } from '@app/features/auth/GmailReauthenticationPrompt';
 import { SidebarActiveCallWidget } from '@app/features/block-call/sidebar/active-call-widget';
@@ -429,6 +430,7 @@ function LayoutInner(props: RouteSectionProps) {
           <Show when={!AUTH_URLS.includes(location.pathname)}>
             <GithubReauthenticationPrompt />
             <GmailReauthenticationPrompt />
+            <CalendarPermissionPrompt />
           </Show>
           <GlobalShortcuts />
           <Show when={!isMobile()}>

--- a/apps/web/src/features/auth/CalendarPermissionPrompt.tsx
+++ b/apps/web/src/features/auth/CalendarPermissionPrompt.tsx
@@ -1,0 +1,103 @@
+import { useCalendarUiFlag } from '@app/features/calendar/use-calendar-ui-flag';
+import { toast } from '@core/component/Toast/Toast';
+import { useAddInboxFlow } from '@core/email-link';
+import { useEmailLinksQuery } from '@queries/email/link';
+import { createEffect, onCleanup } from 'solid-js';
+
+/**
+ * Surfaces a per-inbox "Enable calendar" prompt for every linked inbox whose
+ * Google grant predates the calendar scope (or declined it), driven by
+ * `needs_calendar_permission` from the links list. Re-running the connect flow
+ * re-shows Google consent for the linked account and applies the upgraded
+ * grant to the existing link, which kicks off the calendar backfill.
+ *
+ * Inboxes that also need a full reconnect are skipped: the reconnect prompt
+ * covers them, and reconnecting records the calendar grant anyway.
+ */
+export function CalendarPermissionPrompt() {
+  const calendarUiEnabled = useCalendarUiFlag();
+  const linksQuery = useEmailLinksQuery();
+  const startAddInbox = useAddInboxFlow();
+
+  // One persistent toast per inbox, keyed by link id.
+  const toastIds = new Map<string, number>();
+  // Inboxes the user dismissed this session; not re-prompted until they upgrade.
+  const dismissed = new Set<string>();
+
+  const dismissToast = (linkId: string) => {
+    const id = toastIds.get(linkId);
+    if (id !== undefined) {
+      toast.dismiss(id);
+      toastIds.delete(linkId);
+    }
+  };
+
+  createEffect(() => {
+    if (!calendarUiEnabled()) {
+      for (const linkId of [...toastIds.keys()]) dismissToast(linkId);
+      return;
+    }
+
+    const links = linksQuery.data?.links ?? [];
+    const needingCalendar = new Set(
+      links
+        .filter((link) => link.needs_calendar_permission && !link.needs_reauth)
+        .map((link) => link.id)
+    );
+
+    // Clear toasts and dismissals for inboxes that upgraded or were removed,
+    // so a later downgrade can prompt again.
+    for (const linkId of [...toastIds.keys()]) {
+      if (!needingCalendar.has(linkId)) dismissToast(linkId);
+    }
+    for (const linkId of [...dismissed]) {
+      if (!needingCalendar.has(linkId)) dismissed.delete(linkId);
+    }
+
+    for (const link of links) {
+      if (
+        !needingCalendar.has(link.id) ||
+        toastIds.has(link.id) ||
+        dismissed.has(link.id)
+      ) {
+        continue;
+      }
+
+      const linkId = link.id;
+      const id = toast.custom(
+        {
+          title: 'Enable calendar',
+          content(): string {
+            return `Macro can now sync your Google Calendar. Grant calendar access for ${link.email_address} to turn it on.`;
+          },
+          actions: [
+            {
+              label: 'Grant access',
+              onClick: () => {
+                // Suppress re-prompting until the grant upgrades; on native the
+                // page stays mounted while the OAuth flow runs.
+                dismissed.add(linkId);
+                dismissToast(linkId);
+                startAddInbox();
+              },
+            },
+          ],
+        },
+        {
+          persistent: true,
+          onDismiss: () => {
+            toastIds.delete(linkId);
+            dismissed.add(linkId);
+          },
+        }
+      );
+      toastIds.set(linkId, id);
+    }
+  });
+
+  onCleanup(() => {
+    for (const linkId of [...toastIds.keys()]) dismissToast(linkId);
+  });
+
+  return null;
+}

--- a/apps/web/src/features/auth/CalendarPermissionPrompt.tsx
+++ b/apps/web/src/features/auth/CalendarPermissionPrompt.tsx
@@ -1,8 +1,7 @@
 import { useCalendarUiFlag } from '@app/features/calendar/use-calendar-ui-flag';
-import { toast } from '@core/component/Toast/Toast';
+import { useKeyedPersistentToasts } from '@core/component/Toast/useKeyedPersistentToasts';
 import { useAddInboxFlow } from '@core/email-link';
 import { useEmailLinksQuery } from '@queries/email/link';
-import { createEffect, onCleanup } from 'solid-js';
 
 /**
  * Surfaces a per-inbox "Enable calendar" prompt for every linked inbox whose
@@ -19,84 +18,31 @@ export function CalendarPermissionPrompt() {
   const linksQuery = useEmailLinksQuery();
   const startAddInbox = useAddInboxFlow();
 
-  // One persistent toast per inbox, keyed by link id.
-  const toastIds = new Map<string, number>();
-  // Inboxes the user dismissed this session; not re-prompted until they upgrade.
-  const dismissed = new Set<string>();
-
-  const dismissToast = (linkId: string) => {
-    const id = toastIds.get(linkId);
-    if (id !== undefined) {
-      toast.dismiss(id);
-      toastIds.delete(linkId);
-    }
-  };
-
-  createEffect(() => {
-    if (!calendarUiEnabled()) {
-      for (const linkId of [...toastIds.keys()]) dismissToast(linkId);
-      return;
-    }
-
-    const links = linksQuery.data?.links ?? [];
-    const needingCalendar = new Set(
-      links
-        .filter((link) => link.needs_calendar_permission && !link.needs_reauth)
-        .map((link) => link.id)
-    );
-
-    // Clear toasts and dismissals for inboxes that upgraded or were removed,
-    // so a later downgrade can prompt again.
-    for (const linkId of [...toastIds.keys()]) {
-      if (!needingCalendar.has(linkId)) dismissToast(linkId);
-    }
-    for (const linkId of [...dismissed]) {
-      if (!needingCalendar.has(linkId)) dismissed.delete(linkId);
-    }
-
-    for (const link of links) {
-      if (
-        !needingCalendar.has(link.id) ||
-        toastIds.has(link.id) ||
-        dismissed.has(link.id)
-      ) {
-        continue;
-      }
-
-      const linkId = link.id;
-      const id = toast.custom(
+  useKeyedPersistentToasts({
+    items: () =>
+      calendarUiEnabled()
+        ? (linksQuery.data?.links ?? []).filter(
+            (link) => link.needs_calendar_permission && !link.needs_reauth
+          )
+        : [],
+    key: (link) => link.id,
+    toast: (link, dismiss) => ({
+      title: 'Enable calendar',
+      content(): string {
+        return `Macro can now sync your Google Calendar. Grant calendar access for ${link.email_address} to turn it on.`;
+      },
+      actions: [
         {
-          title: 'Enable calendar',
-          content(): string {
-            return `Macro can now sync your Google Calendar. Grant calendar access for ${link.email_address} to turn it on.`;
+          label: 'Grant access',
+          onClick: () => {
+            // Suppress re-prompting until the grant upgrades; on native the
+            // page stays mounted while the OAuth flow runs.
+            dismiss();
+            startAddInbox();
           },
-          actions: [
-            {
-              label: 'Grant access',
-              onClick: () => {
-                // Suppress re-prompting until the grant upgrades; on native the
-                // page stays mounted while the OAuth flow runs.
-                dismissed.add(linkId);
-                dismissToast(linkId);
-                startAddInbox();
-              },
-            },
-          ],
         },
-        {
-          persistent: true,
-          onDismiss: () => {
-            toastIds.delete(linkId);
-            dismissed.add(linkId);
-          },
-        }
-      );
-      toastIds.set(linkId, id);
-    }
-  });
-
-  onCleanup(() => {
-    for (const linkId of [...toastIds.keys()]) dismissToast(linkId);
+      ],
+    }),
   });
 
   return null;

--- a/apps/web/src/features/auth/GmailReauthenticationPrompt.tsx
+++ b/apps/web/src/features/auth/GmailReauthenticationPrompt.tsx
@@ -1,10 +1,9 @@
-import { toast } from '@core/component/Toast/Toast';
+import { useKeyedPersistentToasts } from '@core/component/Toast/useKeyedPersistentToasts';
 import { useAddInboxFlow } from '@core/email-link';
 import {
   useEmailLinksQuery,
   useInboxHealthProbeQuery,
 } from '@queries/email/link';
-import { createEffect, onCleanup } from 'solid-js';
 
 /**
  * Surfaces a per-inbox "Reconnect Gmail" prompt for every linked inbox whose grant
@@ -21,77 +20,27 @@ export function GmailReauthenticationPrompt() {
   // user was away surfaces here instead of only after the daily refresh.
   useInboxHealthProbeQuery();
 
-  // One persistent toast per broken inbox, keyed by link id.
-  const toastIds = new Map<string, number>();
-  // Inboxes the user dismissed this session; not re-prompted until they recover.
-  const dismissed = new Set<string>();
-
-  const dismissToast = (linkId: string) => {
-    const id = toastIds.get(linkId);
-    if (id !== undefined) {
-      toast.dismiss(id);
-      toastIds.delete(linkId);
-    }
-  };
-
-  createEffect(() => {
-    const links = linksQuery.data?.links ?? [];
-    const needingReauth = new Set(
-      links.filter((link) => link.needs_reauth).map((link) => link.id)
-    );
-
-    // Clear toasts and dismissals for inboxes that recovered or were removed, so a
-    // later failure can prompt again.
-    for (const linkId of [...toastIds.keys()]) {
-      if (!needingReauth.has(linkId)) dismissToast(linkId);
-    }
-    for (const linkId of [...dismissed]) {
-      if (!needingReauth.has(linkId)) dismissed.delete(linkId);
-    }
-
-    for (const link of links) {
-      if (
-        !link.needs_reauth ||
-        toastIds.has(link.id) ||
-        dismissed.has(link.id)
-      ) {
-        continue;
-      }
-
-      const linkId = link.id;
-      const id = toast.custom(
+  useKeyedPersistentToasts({
+    items: () =>
+      (linksQuery.data?.links ?? []).filter((link) => link.needs_reauth),
+    key: (link) => link.id,
+    toast: (link, dismiss) => ({
+      title: 'Reconnect Gmail',
+      content(): string {
+        return `Sync stopped for ${link.email_address}. Reconnect to restore email sync.`;
+      },
+      actions: [
         {
-          title: 'Reconnect Gmail',
-          content(): string {
-            return `Sync stopped for ${link.email_address}. Reconnect to restore email sync.`;
+          label: 'Reconnect',
+          onClick: () => {
+            // Suppress re-prompting until the inbox recovers; on native the page
+            // stays mounted while the OAuth flow runs.
+            dismiss();
+            startAddInbox();
           },
-          actions: [
-            {
-              label: 'Reconnect',
-              onClick: () => {
-                // Suppress re-prompting until the inbox recovers; on native the page
-                // stays mounted while the OAuth flow runs.
-                dismissed.add(linkId);
-                dismissToast(linkId);
-                void startAddInbox();
-              },
-            },
-          ],
         },
-        {
-          persistent: true,
-          onDismiss: () => {
-            toastIds.delete(linkId);
-            dismissed.add(linkId);
-          },
-        }
-      );
-      toastIds.set(linkId, id);
-    }
-  });
-
-  onCleanup(() => {
-    for (const linkId of [...toastIds.keys()]) dismissToast(linkId);
+      ],
+    }),
   });
 
   return null;

--- a/apps/web/src/features/calendar/use-calendar-ui-flag.ts
+++ b/apps/web/src/features/calendar/use-calendar-ui-flag.ts
@@ -1,0 +1,13 @@
+import { useFeatureFlag } from '@app/lib/analytics/posthog';
+import {
+  ENABLE_CALENDAR_UI_FLAG,
+  ENABLE_CALENDAR_UI_OVERRIDE,
+} from '@core/constant/featureFlags';
+import type { Accessor } from 'solid-js';
+
+export function useCalendarUiFlag(): Accessor<boolean> {
+  const flag = useFeatureFlag(ENABLE_CALENDAR_UI_FLAG, {
+    enabledOverride: ENABLE_CALENDAR_UI_OVERRIDE,
+  });
+  return () => flag().enabled;
+}

--- a/apps/web/src/features/settings/Email.tsx
+++ b/apps/web/src/features/settings/Email.tsx
@@ -1,3 +1,4 @@
+import { useCalendarUiFlag } from '@app/features/calendar/use-calendar-ui-flag';
 import { openAddInboxDialog } from '@app/features/inbox/AddInboxDialog';
 import { useFeatureFlag } from '@app/lib/analytics/posthog';
 import { toast } from '@core/component/Toast/Toast';
@@ -388,6 +389,7 @@ function InboxRow(props: {
   const emailSignaturesFlag = useFeatureFlag(ENABLE_EMAIL_SIGNATURES_FLAG, {
     enabledOverride: ENABLE_EMAIL_SIGNATURES_OVERRIDE,
   });
+  const calendarUiEnabled = useCalendarUiFlag();
   const showSignature = () => isSignatureExpanded(props.link.id);
   const signatureSectionId = `signature-section-${props.link.id}`;
   return (
@@ -477,6 +479,25 @@ function InboxRow(props: {
               aria-label={`Reconnect ${props.link.email_address}`}
             >
               Reconnect
+            </Button>
+          </Show>
+          {/* Reconnecting re-runs consent with the calendar scope, so a link
+              that already shows Reconnect doesn't need a second button. */}
+          <Show
+            when={
+              calendarUiEnabled() &&
+              props.link.needs_calendar_permission &&
+              props.link.sync_status !== SyncStatus.NEEDS_REAUTH
+            }
+          >
+            <Button
+              variant="active"
+              size="sm"
+              depth={3}
+              onClick={props.onReconnect}
+              aria-label={`Enable calendar for ${props.link.email_address}`}
+            >
+              Enable calendar
             </Button>
           </Show>
           <Show when={ENABLE_INBOX_RESYNC}>

--- a/apps/web/src/lib/core/component/Toast/Toast.tsx
+++ b/apps/web/src/lib/core/component/Toast/Toast.tsx
@@ -136,7 +136,7 @@ interface ToastSuccessOptions extends ToastOptions {
  * Replaces the icon, title, and accent color of the standard layout while
  * still using the shared Surface chrome and progress/dismiss machinery.
  */
-interface CustomToastConfig {
+export interface CustomToastConfig {
   title: string;
   content?: () => JSX.Element;
   icon?: Component<{ class?: string }>;

--- a/apps/web/src/lib/core/component/Toast/useKeyedPersistentToasts.test.ts
+++ b/apps/web/src/lib/core/component/Toast/useKeyedPersistentToasts.test.ts
@@ -1,0 +1,124 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { createRoot, createSignal } from 'solid-js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  toastCustom: vi.fn(),
+  toastDismiss: vi.fn(),
+}));
+
+vi.mock('./Toast', () => ({
+  toast: {
+    custom: mocks.toastCustom,
+    dismiss: mocks.toastDismiss,
+  },
+}));
+
+import { useKeyedPersistentToasts } from './useKeyedPersistentToasts';
+
+type Item = { id: string; label: string };
+
+type ToastOptions = { persistent?: boolean; onDismiss?: () => void };
+
+function lastToastOptions(): ToastOptions {
+  return mocks.toastCustom.mock.calls.at(-1)?.[1] as ToastOptions;
+}
+
+describe('useKeyedPersistentToasts', () => {
+  let nextToastId: number;
+
+  beforeEach(() => {
+    nextToastId = 1;
+    mocks.toastCustom.mockImplementation(() => nextToastId++);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function mount(initial: Item[]) {
+    let setItems!: (items: Item[]) => void;
+    let dispose!: () => void;
+    createRoot((d) => {
+      dispose = d;
+      const [items, set] = createSignal(initial);
+      setItems = set;
+      useKeyedPersistentToasts<Item>({
+        items,
+        key: (item) => item.id,
+        toast: (item, dismiss) => ({
+          title: item.label,
+          actions: [{ label: 'Go', onClick: dismiss }],
+        }),
+      });
+    });
+    return { setItems, dispose };
+  }
+
+  it('shows one persistent toast per item and no duplicates on re-run', () => {
+    const { setItems, dispose } = mount([
+      { id: 'a', label: 'A' },
+      { id: 'b', label: 'B' },
+    ]);
+    expect(mocks.toastCustom).toHaveBeenCalledTimes(2);
+    expect(lastToastOptions().persistent).toBe(true);
+
+    setItems([
+      { id: 'a', label: 'A' },
+      { id: 'b', label: 'B' },
+    ]);
+    expect(mocks.toastCustom).toHaveBeenCalledTimes(2);
+    dispose();
+  });
+
+  it('dismisses the toast when its item leaves the set', () => {
+    const { setItems, dispose } = mount([{ id: 'a', label: 'A' }]);
+    setItems([]);
+    expect(mocks.toastDismiss).toHaveBeenCalledWith(1);
+    dispose();
+  });
+
+  it('does not re-prompt a user-dismissed key until it leaves and returns', () => {
+    const item = { id: 'a', label: 'A' };
+    const { setItems, dispose } = mount([item]);
+    lastToastOptions().onDismiss?.();
+
+    setItems([]);
+    setItems([{ ...item }]);
+    // Left the set and came back: prompts again.
+    expect(mocks.toastCustom).toHaveBeenCalledTimes(2);
+
+    lastToastOptions().onDismiss?.();
+    setItems([{ ...item, label: 'A2' }]);
+    // Still in the set after dismissal: stays suppressed.
+    expect(mocks.toastCustom).toHaveBeenCalledTimes(2);
+    dispose();
+  });
+
+  it('suppresses re-prompting after the action-provided dismiss handle runs', () => {
+    const item = { id: 'a', label: 'A' };
+    const { setItems, dispose } = mount([item]);
+    const config = mocks.toastCustom.mock.calls[0][0] as {
+      actions: { onClick: () => void }[];
+    };
+    config.actions[0].onClick();
+    expect(mocks.toastDismiss).toHaveBeenCalledWith(1);
+
+    setItems([{ ...item }]);
+    expect(mocks.toastCustom).toHaveBeenCalledTimes(1);
+    dispose();
+  });
+
+  it('dismisses all live toasts on owner cleanup', () => {
+    const { dispose } = mount([
+      { id: 'a', label: 'A' },
+      { id: 'b', label: 'B' },
+    ]);
+    dispose();
+    expect(mocks.toastDismiss).toHaveBeenCalledWith(1);
+    expect(mocks.toastDismiss).toHaveBeenCalledWith(2);
+  });
+});

--- a/apps/web/src/lib/core/component/Toast/useKeyedPersistentToasts.ts
+++ b/apps/web/src/lib/core/component/Toast/useKeyedPersistentToasts.ts
@@ -1,0 +1,65 @@
+import { type Accessor, createEffect, onCleanup } from 'solid-js';
+import { type CustomToastConfig, toast } from './Toast';
+
+/**
+ * Keep exactly one persistent toast alive per keyed item in a reactive set.
+ *
+ * When an item leaves the set its toast is dismissed and its session dismissal
+ * is forgotten, so a later reappearance prompts again. A user-dismissed key is
+ * not re-prompted while the item remains in the set. All live toasts are
+ * dismissed on owner cleanup.
+ *
+ * The factory receives a `dismiss` handle for action handlers that should
+ * close the toast and suppress re-prompting for the session (e.g. after
+ * kicking off a flow that will eventually remove the item from the set).
+ */
+export function useKeyedPersistentToasts<T>(options: {
+  items: Accessor<readonly T[]>;
+  key: (item: T) => string;
+  toast: (item: T, dismiss: () => void) => CustomToastConfig;
+}): void {
+  const toastIds = new Map<string, number>();
+  const dismissed = new Set<string>();
+
+  const dismissToast = (key: string) => {
+    const id = toastIds.get(key);
+    if (id !== undefined) {
+      toast.dismiss(id);
+      toastIds.delete(key);
+    }
+  };
+
+  createEffect(() => {
+    const items = options.items();
+    const liveKeys = new Set(items.map(options.key));
+
+    for (const key of [...toastIds.keys()]) {
+      if (!liveKeys.has(key)) dismissToast(key);
+    }
+    for (const key of [...dismissed]) {
+      if (!liveKeys.has(key)) dismissed.delete(key);
+    }
+
+    for (const item of items) {
+      const key = options.key(item);
+      if (toastIds.has(key) || dismissed.has(key)) continue;
+
+      const suppress = () => {
+        dismissed.add(key);
+        dismissToast(key);
+      };
+      const id = toast.custom(options.toast(item, suppress), {
+        persistent: true,
+        onDismiss: () => {
+          toastIds.delete(key);
+          dismissed.add(key);
+        },
+      });
+      toastIds.set(key, id);
+    }
+  });
+
+  onCleanup(() => {
+    for (const key of [...toastIds.keys()]) dismissToast(key);
+  });
+}

--- a/apps/web/src/lib/core/constant/featureFlags.ts
+++ b/apps/web/src/lib/core/constant/featureFlags.ts
@@ -554,3 +554,12 @@ export const ENABLE_ONBOARDING_V4_FLAG = 'enable-onboarding-v4';
 export const ENABLE_ONBOARDING_V4_OVERRIDE =
   getFeatureFlagOverride('ENABLE_ONBOARDING_V4') ??
   (DEV_MODE_ENV ? true : undefined);
+
+// Calendar UI: calendar surfaces and the elevated-permissions upgrade flow
+// that re-runs Google consent for inboxes connected before the calendar
+// scope existed. PostHog-gated with a dev-mode default; override with
+// VITE_ENABLE_CALENDAR_UI.
+export const ENABLE_CALENDAR_UI_FLAG = 'enable-calendar-ui';
+export const ENABLE_CALENDAR_UI_OVERRIDE =
+  getFeatureFlagOverride('ENABLE_CALENDAR_UI') ??
+  (DEV_MODE_ENV ? true : undefined);

--- a/apps/web/src/lib/service-clients/service-email/generated/schemas/link.ts
+++ b/apps/web/src/lib/service-clients/service-email/generated/schemas/link.ts
@@ -17,6 +17,11 @@ export interface Link {
   is_primary: boolean;
   is_sync_active: boolean;
   macro_id: string;
+  /** Whether the link's Google grant is missing the calendar scope. True for
+inboxes connected before the calendar capability existed (and for
+grants where the user declined it); drives the per-inbox calendar
+upgrade prompt. Re-running the connect flow records the new grant. */
+  needs_calendar_permission: boolean;
   /** Whether the link's Google grant needs to be reconnected. Drives the
 per-inbox reconnect prompt independently of the sync-status badge. */
   needs_reauth: boolean;

--- a/apps/web/src/lib/service-clients/service-email/openapi.json
+++ b/apps/web/src/lib/service-clients/service-email/openapi.json
@@ -4253,6 +4253,7 @@
           "is_sync_active",
           "sync_status",
           "needs_reauth",
+          "needs_calendar_permission",
           "settings",
           "is_primary",
           "created_at",
@@ -4281,6 +4282,10 @@
           },
           "macro_id": {
             "type": "string"
+          },
+          "needs_calendar_permission": {
+            "type": "boolean",
+            "description": "Whether the link's Google grant is missing the calendar scope. True for\ninboxes connected before the calendar capability existed (and for\ngrants where the user declined it); drives the per-inbox calendar\nupgrade prompt. Re-running the connect flow records the new grant."
           },
           "needs_reauth": {
             "type": "boolean",

--- a/crates/email_db_client/src/links/get.rs
+++ b/crates/email_db_client/src/links/get.rs
@@ -173,6 +173,9 @@ pub struct InboxDetails {
     pub settings: service::settings::Settings,
     pub latest_backfill_status: Option<service::backfill::BackfillJobStatus>,
     pub photo_url: Option<String>,
+    /// The Google OAuth scopes recorded for the link's grant. Empty for links
+    /// connected before scope tracking existed (`google_grant_version = 0`).
+    pub google_granted_scopes: Vec<String>,
 }
 
 struct DbInboxDetailsRow {
@@ -190,6 +193,7 @@ struct DbInboxDetailsRow {
     signature_on_replies_forwards: Option<bool>,
     signature: Option<String>,
     latest_backfill_status: Option<db::backfill::BackfillJobStatus>,
+    google_granted_scopes: Vec<String>,
     photo_url: Option<String>,
 }
 
@@ -220,17 +224,20 @@ pub async fn fetch_inbox_details_for_macro_id(
                s.signature_on_replies_forwards as "signature_on_replies_forwards?",
                s.signature,
                bj.status as "latest_backfill_status?: _",
-               c.sfs_photo_url as "photo_url?"
+               c.sfs_photo_url as "photo_url?",
+               l.google_granted_scopes as "google_granted_scopes!"
         FROM (
             SELECT el.id, el.macro_id, el.fusionauth_user_id, el.email_address,
                    el.provider, el.is_sync_active, el.is_primary, el.needs_reauth,
-                   el.last_sync_error_at, el.created_at, el.updated_at
+                   el.last_sync_error_at, el.created_at, el.updated_at,
+                   el.google_granted_scopes
             FROM email_links el
             WHERE el.macro_id = $1
             UNION
             SELECT el.id, el.macro_id, el.fusionauth_user_id, el.email_address,
                    el.provider, el.is_sync_active, el.is_primary, el.needs_reauth,
-                   el.last_sync_error_at, el.created_at, el.updated_at
+                   el.last_sync_error_at, el.created_at, el.updated_at,
+                   el.google_granted_scopes
             FROM email_links el
             JOIN macro_user_links mul ON el.id = mul.link_id
             WHERE mul.primary_macro_id = $1
@@ -277,6 +284,7 @@ pub async fn fetch_inbox_details_for_macro_id(
                 settings,
                 latest_backfill_status: row.latest_backfill_status.map(Into::into),
                 photo_url: row.photo_url,
+                google_granted_scopes: row.google_granted_scopes,
             })
         })
         .collect()

--- a/crates/models_email/src/email/api/link.rs
+++ b/crates/models_email/src/email/api/link.rs
@@ -98,6 +98,11 @@ pub struct Link {
     /// Whether the link's Google grant needs to be reconnected. Drives the
     /// per-inbox reconnect prompt independently of the sync-status badge.
     pub needs_reauth: bool,
+    /// Whether the link's Google grant is missing the calendar scope. True for
+    /// inboxes connected before the calendar capability existed (and for
+    /// grants where the user declined it); drives the per-inbox calendar
+    /// upgrade prompt. Re-running the connect flow records the new grant.
+    pub needs_calendar_permission: bool,
     pub settings: Settings,
     pub is_primary: bool,
     pub created_at: DateTime<Utc>,
@@ -110,6 +115,7 @@ impl Link {
         settings: Settings,
         sync_status: SyncStatus,
         photo_url: Option<String>,
+        needs_calendar_permission: bool,
     ) -> Self {
         Link {
             id: source.id,
@@ -121,6 +127,7 @@ impl Link {
             is_sync_active: source.is_sync_active,
             sync_status,
             needs_reauth: source.needs_reauth,
+            needs_calendar_permission,
             settings,
             is_primary: source.is_primary,
             created_at: source.created_at,

--- a/packages/sdk/generated/email/types.gen.ts
+++ b/packages/sdk/generated/email/types.gen.ts
@@ -725,6 +725,13 @@ export type Link = {
     is_sync_active: boolean;
     macro_id: string;
     /**
+     * Whether the link's Google grant is missing the calendar scope. True for
+     * inboxes connected before the calendar capability existed (and for
+     * grants where the user declined it); drives the per-inbox calendar
+     * upgrade prompt. Re-running the connect flow records the new grant.
+     */
+    needs_calendar_permission: boolean;
+    /**
      * Whether the link's Google grant needs to be reconnected. Drives the
      * per-inbox reconnect prompt independently of the sync-status badge.
      */

--- a/packages/sdk/specs/email.json
+++ b/packages/sdk/specs/email.json
@@ -4253,6 +4253,7 @@
           "is_sync_active",
           "sync_status",
           "needs_reauth",
+          "needs_calendar_permission",
           "settings",
           "is_primary",
           "created_at",
@@ -4281,6 +4282,10 @@
           },
           "macro_id": {
             "type": "string"
+          },
+          "needs_calendar_permission": {
+            "type": "boolean",
+            "description": "Whether the link's Google grant is missing the calendar scope. True for\ninboxes connected before the calendar capability existed (and for\ngrants where the user declined it); drives the per-inbox calendar\nupgrade prompt. Re-running the connect flow records the new grant."
           },
           "needs_reauth": {
             "type": "boolean",

--- a/services/email_service/src/api/email/links/list.rs
+++ b/services/email_service/src/api/email/links/list.rs
@@ -67,11 +67,17 @@ pub async fn list_links_handler(
                 inbox.link.needs_reauth,
                 inbox.latest_backfill_status,
             );
+            let needs_calendar_permission =
+                !calendar_events::domain::models::GoogleScopeSet::from_scopes(
+                    inbox.google_granted_scopes,
+                )
+                .has_calendar_capability();
             api::link::Link::new(
                 inbox.link,
                 api::settings::Settings::from(inbox.settings),
                 sync_status,
                 inbox.photo_url,
+                needs_calendar_permission,
             )
         })
         .collect();


### PR DESCRIPTION
**Tradeoffs considered**
- Derive the missing-calendar-scope signal per request from `google_granted_scopes` rather than persisting a flag: the scopes column is already the source of truth and `apply_google_grant` is its only writer, so a computed field can't go stale.
- Reuse the existing add-inbox flow for the upgrade instead of a dedicated re-consent endpoint: `POST /link/gmail` already requests the calendar scope with `prompt=consent` and `/email/init?link_id=` already applies the grant to an existing link, so a new endpoint would duplicate that path (including its paywall/in-flight caps).

**Approach**
- `GET /email/links` gains `needs_calendar_permission`, computed via `GoogleScopeSet::has_calendar_capability()` over the link's recorded scopes.
- A per-inbox persistent toast (`CalendarPermissionPrompt`, same machinery as `GmailReauthenticationPrompt`) and an "Enable calendar" button on the settings inbox row both re-run the connect flow; the OAuth callback → `/email/init?link_id=` path upgrades the existing link's grant and enqueues calendar backfills.
- Everything user-visible is gated on the `enable-calendar-ui` PostHog flag (default-on in dev via the standard override const, PostHog-controlled in prod).

**Architectural changes**
- `fetch_inbox_details_for_macro_id` now selects `google_granted_scopes`; `api::link::Link::new` takes the derived flag. No schema changes.

**Functional behavior changes**
- Inboxes connected before the calendar scope existed (grant version 0) and grants where the user declined calendar now surface an upgrade prompt; links needing a full reconnect are skipped since reconnecting records the calendar grant anyway.

**Purposefully omitted**
- No calendar-sync-failure surfacing (`calendar_accounts.sync_status='reauth_required'` from `CalendarPermissionRequired`) — this PR only covers the known-missing-scope case; failure-driven prompts can layer on the same field later.
- No changes to the iOS native auth path — it already completes via `completeNativeLink(link_id)`.

**Unrelated additions**
- None.
