### PR TITLE
feat: gate calendar ingestion and consent scope behind env flags

### DIFF
--- a/.sqlx/query-48f7e5541e5bca5aa2d8ff2c955505822fcca9ff7fd46ebf8f969f193827cfdb.json
+++ b/.sqlx/query-48f7e5541e5bca5aa2d8ff2c955505822fcca9ff7fd46ebf8f969f193827cfdb.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        UPDATE calendar_sync_outbox\n        SET published_at = NULL\n        WHERE backfill_job_id = $1\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "48f7e5541e5bca5aa2d8ff2c955505822fcca9ff7fd46ebf8f969f193827cfdb"
+}

--- a/services/authentication_service/src/api/context.rs
+++ b/services/authentication_service/src/api/context.rs
@@ -138,6 +138,8 @@ pub(crate) struct ApiContext {
     pub rate_limit_service: RateLimiter,
     /// The stripe price id
     pub stripe_price_id: String,
+    /// Whether Gmail link consent requests the Google Calendar scope.
+    pub calendar_scope_enabled: bool,
 }
 
 env_var! {

--- a/services/authentication_service/src/api/link/gmail.rs
+++ b/services/authentication_service/src/api/link/gmail.rs
@@ -128,7 +128,11 @@ pub async fn init_gmail_link_handler(
         return Err(InitGmailLinkError::TooManyInProgressLinks);
     }
 
-    let authorization_scopes = format!("{GMAIL_SCOPES} {}", google_calendar_scope_parameter());
+    let authorization_scopes = if ctx.calendar_scope_enabled {
+        format!("{GMAIL_SCOPES} {}", google_calendar_scope_parameter())
+    } else {
+        GMAIL_SCOPES.to_string()
+    };
     let requested_google_scopes: Vec<String> = authorization_scopes
         .split_ascii_whitespace()
         .map(ToOwned::to_owned)

--- a/services/authentication_service/src/config.rs
+++ b/services/authentication_service/src/config.rs
@@ -118,6 +118,11 @@ pub struct Config {
     pub internal_api_key: InternalApiKey,
     /// Comma-separated Kafka bootstrap servers for the macro event broker.
     pub kafka_brokers: KafkaBrokers,
+    /// Whether Gmail link consent requests the Google Calendar scope. Off by
+    /// default so deployed environments don't ask users for a scope the
+    /// calendar feature isn't using yet.
+    #[macro_config_default(false)]
+    pub calendar_scope_enabled: bool,
 }
 
 impl Config {

--- a/services/authentication_service/src/main.rs
+++ b/services/authentication_service/src/main.rs
@@ -408,6 +408,7 @@ async fn main() -> anyhow::Result<()> {
             sqs_client,
             environment: config.environment,
             rate_limit_service: rate_limit,
+            calendar_scope_enabled: config.calendar_scope_enabled,
             jwt_args,
             authorization_state,
             token_context: MacroApiTokenContext {

--- a/services/email_service/src/bin/pubsub_workers/pubsub_workers.rs
+++ b/services/email_service/src/bin/pubsub_workers/pubsub_workers.rs
@@ -106,6 +106,7 @@ async fn main() -> anyhow::Result<()> {
         calendar_events::domain::service::GoogleCalendarSyncScheduler::new(
             calendar_events::outbound::pg::PgCalendarRepository::new(db.clone()),
         ),
+        config.calendar_sync_enabled,
         worker_cancellation_token.clone(),
     ));
     let macro_event_broker = MacroEventBrokerService::new(
@@ -358,6 +359,7 @@ async fn main() -> anyhow::Result<()> {
                 crm_service_inbox_sync,
                 macro_event_broker_inbox_sync,
                 config.notifications_enabled,
+                config.calendar_sync_enabled,
                 false,
                 cancellation_token,
             )
@@ -402,6 +404,7 @@ async fn main() -> anyhow::Result<()> {
                 crm_service_inbox_sync,
                 macro_event_broker_inbox_sync,
                 config.notifications_enabled,
+                config.calendar_sync_enabled,
                 true,
                 cancellation_token,
             )
@@ -500,6 +503,7 @@ async fn main() -> anyhow::Result<()> {
                 crm_service_backfill,
                 macro_event_broker_backfill,
                 config.notifications_enabled,
+                config.calendar_sync_enabled,
                 cancellation_token,
             )
             .await;

--- a/services/email_service/src/calendar_outbox.rs
+++ b/services/email_service/src/calendar_outbox.rs
@@ -42,6 +42,7 @@ pub async fn run<R>(
     db: PgPool,
     sqs: SQS,
     scheduler: GoogleCalendarSyncScheduler<R>,
+    calendar_sync_enabled: bool,
     cancellation_token: tokio_util::sync::CancellationToken,
 ) where
     R: GoogleCalendarSyncRepository,
@@ -50,19 +51,24 @@ pub async fn run<R>(
         if cancellation_token.is_cancelled() {
             return;
         }
-        scheduler
-            .run_once(Utc::now())
-            .await
-            .inspect_err(|error| {
-                tracing::error!(error=?error, "failed to schedule due Google Calendar syncs");
-            })
-            .ok();
-        drain_calendar(&db, &sqs)
-            .await
-            .inspect_err(|error| {
-                tracing::error!(error = ?error, "failed to publish calendar backfill outbox");
-            })
-            .ok();
+        // With calendar sync disabled, outbox rows keep accumulating
+        // unpublished and due syncs never re-arm — enabling the flag later
+        // resumes everything without a migration.
+        if calendar_sync_enabled {
+            scheduler
+                .run_once(Utc::now())
+                .await
+                .inspect_err(|error| {
+                    tracing::error!(error=?error, "failed to schedule due Google Calendar syncs");
+                })
+                .ok();
+            drain_calendar(&db, &sqs)
+                .await
+                .inspect_err(|error| {
+                    tracing::error!(error = ?error, "failed to publish calendar backfill outbox");
+                })
+                .ok();
+        }
         drain_email_init(&db, &sqs)
             .await
             .inspect_err(|error| {
@@ -151,6 +157,24 @@ fn to_email_completion_message(row: &EmailCompletionOutboxRow) -> Option<Backfil
             payload: FinalizeBackfillPayload {},
         }),
     })
+}
+
+/// Return a calendar backfill delivery to the outbox so the drain republishes
+/// it once calendar sync is enabled again. Deliveries received while the
+/// switch is off would otherwise be acked and lost.
+#[tracing::instrument(skip(db), err)]
+pub async fn republish_calendar_job(db: &PgPool, backfill_job_id: Uuid) -> anyhow::Result<()> {
+    sqlx::query!(
+        r#"
+        UPDATE calendar_sync_outbox
+        SET published_at = NULL
+        WHERE backfill_job_id = $1
+        "#,
+        backfill_job_id,
+    )
+    .execute(db)
+    .await?;
+    Ok(())
 }
 
 #[tracing::instrument(skip(db, sqs), err)]

--- a/services/email_service/src/config.rs
+++ b/services/email_service/src/config.rs
@@ -55,6 +55,13 @@ pub struct Config {
     #[macro_config_default(false)]
     pub use_apollo_crm_enrichment: bool,
 
+    /// Master switch for calendar ingestion and sync. When `false` (the
+    /// default) inline ICS extraction is skipped, the calendar outbox stays
+    /// parked, and calendar backfill deliveries requeue their outbox rows.
+    /// Grant bookkeeping still runs so enabling later resumes cleanly.
+    #[macro_config_default(false)]
+    pub calendar_sync_enabled: bool,
+
     /// Apollo.io API key for CRM enrichment. Locally this is the key
     /// itself; in deployed envs it's the name of the Secrets Manager
     /// secret holding it (resolved at startup). Empty disables enrichment.

--- a/services/email_service/src/openapi.rs
+++ b/services/email_service/src/openapi.rs
@@ -4,6 +4,7 @@ mod api;
 mod backfill_completion_service;
 mod backfill_init_service;
 mod calendar_ingest;
+mod calendar_outbox;
 mod config;
 mod convert;
 mod pubsub;

--- a/services/email_service/src/pubsub/backfill/backfill_message.rs
+++ b/services/email_service/src/pubsub/backfill/backfill_message.rs
@@ -97,29 +97,31 @@ pub async fn backfill_message(
             })
         })?;
 
-    crate::calendar_ingest::ingest_calendar_parts(
-        &ctx.db,
-        &ctx.gmail_client,
-        &ctx.redis_client,
-        crate::calendar_ingest::CalendarIngestInput {
-            is_backfill: true,
-            access_token,
-            owner_id: link.macro_id.as_ref(),
-            email_link_id: link.id,
-            email_thread_id: persisted_thread_id,
-            email_message_id: message_db_id,
-            provider_message_id: &p.message_provider_id,
-            payload: &calendar_payload,
-        },
-    )
-    .await
-    .inspect_err(|error| {
-        // Calendar extraction is best-effort: a Gmail or database failure
-        // here must not block the message's core side effects, and the
-        // durable email-ICS backfill re-extracts anything missed.
-        tracing::warn!(error = ?error, "failed to extract calendar invitation");
-    })
-    .ok();
+    if ctx.calendar_sync_enabled {
+        crate::calendar_ingest::ingest_calendar_parts(
+            &ctx.db,
+            &ctx.gmail_client,
+            &ctx.redis_client,
+            crate::calendar_ingest::CalendarIngestInput {
+                is_backfill: true,
+                access_token,
+                owner_id: link.macro_id.as_ref(),
+                email_link_id: link.id,
+                email_thread_id: persisted_thread_id,
+                email_message_id: message_db_id,
+                provider_message_id: &p.message_provider_id,
+                payload: &calendar_payload,
+            },
+        )
+        .await
+        .inspect_err(|error| {
+            // Calendar extraction is best-effort: a Gmail or database failure
+            // here must not block the message's core side effects, and the
+            // durable email-ICS backfill re-extracts anything missed.
+            tracing::warn!(error = ?error, "failed to extract calendar invitation");
+        })
+        .ok();
+    }
 
     // Fan out a PopulateCrmContact job per address involved in the
     // message — every non-draft message contributes, in both

--- a/services/email_service/src/pubsub/backfill/process.rs
+++ b/services/email_service/src/pubsub/backfill/process.rs
@@ -17,6 +17,30 @@ use models_email::email::service::pubsub::{DetailedError, FailureReason, Process
 use sqs_worker::cleanup_message;
 use uuid::Uuid;
 
+/// When calendar sync is disabled, return the delivery's outbox row to the
+/// unpublished state and ack the message; the outbox drain republishes it
+/// once the switch flips back on. `None` means calendar sync is enabled and
+/// the delivery should proceed.
+async fn park_calendar_delivery(
+    ctx: &PubSubContext,
+    calendar_job_id: Uuid,
+) -> Option<Result<(), ProcessingError>> {
+    if ctx.calendar_sync_enabled {
+        return None;
+    }
+    tracing::info!(%calendar_job_id, "calendar sync disabled; returning delivery to the outbox");
+    Some(
+        crate::calendar_outbox::republish_calendar_job(&ctx.db, calendar_job_id)
+            .await
+            .map_err(|e| {
+                ProcessingError::Retryable(DetailedError {
+                    reason: FailureReason::DatabaseQueryFailed,
+                    source: e.context("failed to return calendar delivery to the outbox"),
+                })
+            }),
+    )
+}
+
 // Process a single message from the backfill queue
 pub async fn process_message(
     ctx: PubSubContext,
@@ -134,6 +158,9 @@ async fn inner_process_message(
                 .await
         }
         BackfillOperation::CalendarGoogleBackfill(scope) => {
+            if let Some(parked) = park_calendar_delivery(ctx, scope.payload.calendar_job_id).await {
+                return parked;
+            }
             let link = fetch_link(ctx, scope.link_id).await?;
             // Calendar jobs can be created immediately after an incremental
             // Google scope grant. Bypass the Gmail token cache so this job does
@@ -166,6 +193,9 @@ async fn inner_process_message(
             .await
         }
         BackfillOperation::CalendarEmailIcsBackfill(scope) => {
+            if let Some(parked) = park_calendar_delivery(ctx, scope.payload.calendar_job_id).await {
+                return parked;
+            }
             let link = fetch_link(ctx, scope.link_id).await?;
             calendar_email_ics_backfill::calendar_email_ics_backfill(ctx, &link, &scope.payload)
                 .await

--- a/services/email_service/src/pubsub/backfill/worker.rs
+++ b/services/email_service/src/pubsub/backfill/worker.rs
@@ -34,6 +34,7 @@ pub async fn run_worker(
     crm_service: CrmServiceType,
     macro_event_broker: PubSubEventBroker,
     notifications_enabled: bool,
+    calendar_sync_enabled: bool,
 ) {
     run_worker_with_cancellation(
         db,
@@ -51,6 +52,7 @@ pub async fn run_worker(
         crm_service,
         macro_event_broker,
         notifications_enabled,
+        calendar_sync_enabled,
         CancellationToken::new(),
     )
     .await;
@@ -76,6 +78,7 @@ pub async fn run_worker_with_cancellation(
     crm_service: CrmServiceType,
     macro_event_broker: PubSubEventBroker,
     notifications_enabled: bool,
+    calendar_sync_enabled: bool,
     cancellation_token: CancellationToken,
 ) {
     let calendar_backfills =
@@ -96,6 +99,7 @@ pub async fn run_worker_with_cancellation(
         crm_service,
         macro_event_broker,
         notifications_enabled,
+        calendar_sync_enabled,
         retry_worker: false,
         calendar_backfills,
     };

--- a/services/email_service/src/pubsub/context.rs
+++ b/services/email_service/src/pubsub/context.rs
@@ -157,6 +157,7 @@ pub struct PubSubContext {
     pub crm_service: CrmServiceType,
     pub macro_event_broker: PubSubEventBroker,
     pub notifications_enabled: bool,
+    pub calendar_sync_enabled: bool,
     pub retry_worker: bool,
     pub calendar_backfills: CalendarBackfillServices,
 }

--- a/services/email_service/src/pubsub/inbox_sync/operations/upsert_message.rs
+++ b/services/email_service/src/pubsub/inbox_sync/operations/upsert_message.rs
@@ -323,29 +323,31 @@ pub async fn upsert_message(
         publish_email_event(&ctx.macro_event_broker, &event);
     }
 
-    crate::calendar_ingest::ingest_calendar_parts(
-        &ctx.db,
-        &ctx.gmail_client,
-        &ctx.redis_client,
-        crate::calendar_ingest::CalendarIngestInput {
-            is_backfill: false,
-            access_token: &gmail_access_token,
-            owner_id: link.macro_id.as_ref(),
-            email_link_id: link.id,
-            email_thread_id: thread_db_id,
-            email_message_id: message_db_id,
-            provider_message_id: &payload.provider_message_id,
-            payload: &calendar_payload,
-        },
-    )
-    .await
-    .inspect_err(|error| {
-        // Calendar extraction is best-effort: a Gmail or database failure
-        // here must not block the message's core side effects, and the
-        // durable email-ICS backfill re-extracts anything missed.
-        tracing::warn!(error = ?error, "failed to extract calendar invitation");
-    })
-    .ok();
+    if ctx.calendar_sync_enabled {
+        crate::calendar_ingest::ingest_calendar_parts(
+            &ctx.db,
+            &ctx.gmail_client,
+            &ctx.redis_client,
+            crate::calendar_ingest::CalendarIngestInput {
+                is_backfill: false,
+                access_token: &gmail_access_token,
+                owner_id: link.macro_id.as_ref(),
+                email_link_id: link.id,
+                email_thread_id: thread_db_id,
+                email_message_id: message_db_id,
+                provider_message_id: &payload.provider_message_id,
+                payload: &calendar_payload,
+            },
+        )
+        .await
+        .inspect_err(|error| {
+            // Calendar extraction is best-effort: a Gmail or database failure
+            // here must not block the message's core side effects, and the
+            // durable email-ICS backfill re-extracts anything missed.
+            tracing::warn!(error = ?error, "failed to extract calendar invitation");
+        })
+        .ok();
+    }
 
     handle_attachment_upload(
         ctx,

--- a/services/email_service/src/pubsub/inbox_sync/worker.rs
+++ b/services/email_service/src/pubsub/inbox_sync/worker.rs
@@ -34,6 +34,7 @@ pub async fn run_worker(
     crm_service: CrmServiceType,
     macro_event_broker: PubSubEventBroker,
     notifications_enabled: bool,
+    calendar_sync_enabled: bool,
     retry_worker: bool,
 ) {
     run_worker_with_cancellation(
@@ -52,6 +53,7 @@ pub async fn run_worker(
         crm_service,
         macro_event_broker,
         notifications_enabled,
+        calendar_sync_enabled,
         retry_worker,
         CancellationToken::new(),
     )
@@ -78,6 +80,7 @@ pub async fn run_worker_with_cancellation(
     crm_service: CrmServiceType,
     macro_event_broker: PubSubEventBroker,
     notifications_enabled: bool,
+    calendar_sync_enabled: bool,
     retry_worker: bool,
     cancellation_token: CancellationToken,
 ) {
@@ -99,6 +102,7 @@ pub async fn run_worker_with_cancellation(
         crm_service,
         macro_event_broker,
         notifications_enabled,
+        calendar_sync_enabled,
         retry_worker,
         calendar_backfills,
     };

--- a/tooling/xtask/crates/xtask_local/src/local/local_env.rs
+++ b/tooling/xtask/crates/xtask_local/src/local/local_env.rs
@@ -65,6 +65,10 @@ impl LocalEnv {
         env.insert("COMPOSE_PROJECT_NAME".into(), self.project_name.clone());
         env.insert("PORT".into(), "8080".into());
         env.insert("FRONTEND_PORT".into(), self.frontend_port.to_string());
+        // Calendar ingestion/sync ships dark (both flags default off in
+        // deployed envs); local stacks keep it on for development.
+        env.insert("CALENDAR_SYNC_ENABLED".into(), "true".into());
+        env.insert("CALENDAR_SCOPE_ENABLED".into(), "true".into());
         self.infra.write(&mut env);
         self.storage.write(&mut env);
         self.queues.write(&mut env);


### PR DESCRIPTION
**Tradeoffs considered**
- Env-var flags (Doppler-managed, absence = off) over a dynamic flag service: the backend has no server-side flag evaluation, and a static switch avoids a network dependency in the message hot path. The cost is that flipping requires a config change + restart.
- Gate the execution layer, not the bookkeeping: `apply_google_grant` still records scopes and inserts backfill jobs + outbox rows while disabled. They accumulate unpublished, so enabling later resumes everything (including backfills for users who granted in the interim) with no migration.

**Approach**
- `CALENDAR_SYNC_ENABLED` (email_service, default off): skips inline ICS extraction in live sync and email backfill, parks the calendar outbox drain and due-sync scheduler (the email init/completion drains in the same loop keep running), and makes calendar backfill deliveries return their outbox row to the unpublished state before acking — nothing lost, nothing wedged, no DLQ noise.
- `CALENDAR_SCOPE_ENABLED` (authentication_service, default off, separate commit): Gmail link consent only appends the Google Calendar scope when set.
- Local stacks set both flags on via the generated compose env, so local dev is unchanged.

**Architectural changes**
- None beyond threading the two booleans through `Config` → worker/context construction.

**Functional behavior changes**
- Deployed environments stop all calendar ingestion/sync and stop requesting the calendar consent scope until the flags are set. Dev needs both set to `true` in Doppler to keep its current behavior.

**Purposefully omitted**
- No gating of grant recording or tokeninfo discovery (bookkeeping, keeps `needs_calendar_permission` accurate for the upgrade-flow prompt).
- No dynamic/runtime flag infrastructure.

**Unrelated additions**
- None.
