### PR TITLE
fix(command): show Copy ID on every block

### DIFF
--- a/apps/web/src/features/next-soup/actions/make-copy-entity-id-action.ts
+++ b/apps/web/src/features/next-soup/actions/make-copy-entity-id-action.ts
@@ -7,17 +7,24 @@ export const makeCopyEntityIdAction = () => {
     return true;
   };
 
+  /** Copying an id needs nothing but the id, so callers that only have one
+   *  (e.g. a block, which is keyed by its entity id) can skip resolving the
+   *  entity. */
+  const executeById = async (id: string) => {
+    await navigator.clipboard.writeText(id);
+    toast.success('ID copied to clipboard');
+  };
+
   const execute = async (entities: EntityData[]) => {
     const entity = entities[0];
     if (!entity) return;
 
-    await navigator.clipboard.writeText(entity.id);
-    toast.success('ID copied to clipboard');
+    await executeById(entity.id);
   };
 
   const executeWithSoup = async (entities: EntityData[], _soup: SoupState) => {
     await execute(entities);
   };
 
-  return { canExecute, execute, executeWithSoup };
+  return { canExecute, execute, executeById, executeWithSoup };
 };

--- a/apps/web/src/features/next-soup/actions/use-block-entity-commands.ts
+++ b/apps/web/src/features/next-soup/actions/use-block-entity-commands.ts
@@ -315,21 +315,20 @@ export const useBlockEntityCommands = () => {
       tags: [HotkeyTags.SelectionModification],
     }).withGroup(group);
 
-    // Copy entity id (command menu only, no keybinding)
+    // Copy entity id (command menu only, no keybinding). Deliberately not
+    // gated on getEntity(): a block is keyed by its entity id, and Quick
+    // Access — a recents cache built from history, channels, contacts,
+    // companies and snippets — has no entry for entity types it never indexes
+    // (emails, calls) or for an item created moments ago. Requiring the entity
+    // hid Copy ID on exactly those blocks, and since it has no keybinding the
+    // command menu is the only way to reach it.
     registerHotkey({
       hotkeyToken: TOKENS.entity.action.copyEntityId,
       scopeId,
       description: 'Copy ID',
       keyDownHandler: () => {
-        const entity = getEntity();
-        if (!entity) return false;
-        if (!copyEntityIdAction.canExecute(entity)) return false;
-        copyEntityIdAction.execute([entity]);
+        copyEntityIdAction.executeById(blockId);
         return true;
-      },
-      condition: () => {
-        const entity = getEntity();
-        return entity !== undefined && copyEntityIdAction.canExecute(entity);
       },
       displayPriority: 10,
       tags: [HotkeyTags.SelectionModification],


### PR DESCRIPTION
Copy ID was gated on resolving a full `EntityData` from Quick Access, a recents cache that never indexes emails or calls and misses items created moments ago — so the command silently disappeared, and with no keybinding the command menu is its only entry point. A block is keyed by its entity id, so copy that directly. Verified on an email opened by URL (previously missing, now present and copying the right id) and on a doc (unchanged).
