### PR TITLE
fix(md): no focus hijacking on remote doc name changes

### DIFF
--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/PullRequestMention.tsx
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/PullRequestMention.tsx
@@ -4,7 +4,10 @@ import { openInNewSplitForMention } from '@core/util/openInNewSplit';
 import { useSplitNavigationHandler } from '@core/util/useSplitNavigationHandler';
 import {
   $isPullRequestMentionNode,
+  HISTORIC_TAG,
   type PullRequestMentionDecoratorProps,
+  SKIP_DOM_SELECTION_TAG,
+  SKIP_SCROLL_INTO_VIEW_TAG,
 } from '@macro-inc/lexical-core';
 import OpenIcon from '@phosphor/arrows-out.svg';
 import ChatCircle from '@phosphor/chat-circle.svg';
@@ -389,7 +392,10 @@ function PullRequestMentionContent(props: PullRequestMentionDecoratorProps) {
           node.setLabel(nextLabel);
         }
       },
-      { tag: 'historic', discrete: true }
+      {
+        tag: [HISTORIC_TAG, SKIP_DOM_SELECTION_TAG, SKIP_SCROLL_INTO_VIEW_TAG],
+        discrete: true,
+      }
     );
   });
 

--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/TagMention.tsx
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/TagMention.tsx
@@ -3,6 +3,9 @@ import { useSplitPanel } from '@components/app/split-layout/layoutUtils';
 import { useIsAuthenticated } from '@core/auth';
 import {
   $isTagMentionNode,
+  HISTORIC_TAG,
+  SKIP_DOM_SELECTION_TAG,
+  SKIP_SCROLL_INTO_VIEW_TAG,
   type TagMentionDecoratorProps,
 } from '@macro-inc/lexical-core';
 import { TagDot } from '@property/tags/TagDot';
@@ -85,7 +88,10 @@ export function TagMention(props: TagMentionDecoratorProps) {
           color: tag.color,
         });
       },
-      { tag: 'historic', discrete: true }
+      {
+        tag: [HISTORIC_TAG, SKIP_DOM_SELECTION_TAG, SKIP_SCROLL_INTO_VIEW_TAG],
+        discrete: true,
+      }
     );
   });
 

--- a/apps/web/src/lib/core/component/LexicalMarkdown/plugins/mentions/mentionsPlugin.ts
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/plugins/mentions/mentionsPlugin.ts
@@ -30,10 +30,13 @@ import {
   DocumentMentionNode,
   type GroupMentionInfo,
   GroupMentionNode,
+  HISTORIC_TAG,
   InlineSearchNode,
   InlineSearchNodesType,
   type PullRequestMentionInfo,
   PullRequestMentionNode,
+  SKIP_DOM_SELECTION_TAG,
+  SKIP_SCROLL_INTO_VIEW_TAG,
   type SnapshotNodeInfo,
   type ThemeMentionInfo,
   type UserMentionInfo,
@@ -663,7 +666,7 @@ function registerMentionsPlugin(
             // they don't get recorded into the undo stack. This was breaking the predictability
             // of undo with document mentions. This hacks around that by using the an undocumented
             // "historic" tag from the LexicalHistoryPlugin.
-            tag: 'historic',
+            tag: [HISTORIC_TAG, SKIP_DOM_SELECTION_TAG, SKIP_SCROLL_INTO_VIEW_TAG],
             discrete: true,
           }
         );

--- a/apps/web/src/lib/core/component/LexicalMarkdown/plugins/mentions/mentionsPlugin.ts
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/plugins/mentions/mentionsPlugin.ts
@@ -26,6 +26,7 @@ import {
   ContactMentionNode,
   type DateMentionInfo,
   DateMentionNode,
+  DocumentCardNode,
   type DocumentMentionInfo,
   DocumentMentionNode,
   type GroupMentionInfo,
@@ -645,10 +646,12 @@ function registerMentionsPlugin(
       (payload) => {
         editor.update(
           () => {
-            const nodesToUpdate: DocumentMentionNode[] = [];
+            const nodesToUpdate: Array<DocumentMentionNode | DocumentCardNode> =
+              [];
             $traverseNodes($getRoot(), (node) => {
               if (
-                node instanceof DocumentMentionNode &&
+                (node instanceof DocumentMentionNode ||
+                  node instanceof DocumentCardNode) &&
                 payload[node.getDocumentId()] &&
                 node.getDocumentName() !== payload[node.getDocumentId()]
               ) {
@@ -666,7 +669,11 @@ function registerMentionsPlugin(
             // they don't get recorded into the undo stack. This was breaking the predictability
             // of undo with document mentions. This hacks around that by using the an undocumented
             // "historic" tag from the LexicalHistoryPlugin.
-            tag: [HISTORIC_TAG, SKIP_DOM_SELECTION_TAG, SKIP_SCROLL_INTO_VIEW_TAG],
+            tag: [
+              HISTORIC_TAG,
+              SKIP_DOM_SELECTION_TAG,
+              SKIP_SCROLL_INTO_VIEW_TAG,
+            ],
             discrete: true,
           }
         );


### PR DESCRIPTION
- **fix(md): no focus hijacking on remote doc name changes**
- **followup**
