### PR TITLE
Improve TaskComposer and Channel input placeholder styling

### DIFF
--- a/apps/web/src/features/channel/Channel/Channel.tsx
+++ b/apps/web/src/features/channel/Channel/Channel.tsx
@@ -346,19 +346,19 @@ export function Channel(props: ChannelProps) {
   const channelType = useChannelType(props.channelId);
   const { popoverSplit, openWithSplit } = useSplitLayout();
 
-  // Placeholder name: a 1:1 DM named "First Last" shortens to the first
-  // name; channels (and group DMs like "A, B") keep their full name.
+  // Placeholder name: channels render as "#name"; a 1:1 DM named "First Last"
+  // shortens to the first name, and group DMs like "A, B" keep their full name.
   const inputPlaceholderName = () => {
     const name = channelName();
     if (!name) return undefined;
-    if (channelType() !== ChannelTypeEnum.DirectMessage) return name;
+    if (channelType() !== ChannelTypeEnum.DirectMessage) return `#${name}`;
     const parts = name.split(' ');
     return parts.length === 2 && !parts[0]?.endsWith(',') ? parts[0] : name;
   };
 
   const inputPlaceholder = () => {
     const name = inputPlaceholderName();
-    return name ? `Type @ to share with ${name}.` : 'Type @ to share.';
+    return name ? `Type @ to share with ${name}` : 'Type @ to share';
   };
 
   const buildChannelMessageMention = (message: {

--- a/apps/web/src/features/channel/Input/TaskComposer.tsx
+++ b/apps/web/src/features/channel/Input/TaskComposer.tsx
@@ -264,9 +264,10 @@ export function TaskComposer(props: {
   );
 
   return (
-    // Compact edges matching the message face (content at px-3/pt-2, footer
-    // mirroring Input.Footer's h-8 p-2 mb-2), with roomier gap-4 spacing
-    // between title, description, and property pills.
+    // Compact edges matching the message face (content at px-3/pt-2), with
+    // roomier gap-4 spacing between title, description, and property pills.
+    // The property pills and footer share the footer's 8px inset so the pills,
+    // the action buttons, and the composer's edges are evenly spaced.
     <div
       class="relative flex flex-col"
       tabIndex={-1}
@@ -315,7 +316,12 @@ export function TaskComposer(props: {
             />
           </Scroll>
         </div>
+      </div>
 
+      {/* Property pills line up with the footer's action row (px-2) rather
+          than the text above it, so the leading pill is flush with the attach
+          button, and pt-4 keeps the gap-4 rhythm of the content above. */}
+      <div class="px-2 pt-4">
         <Suspense fallback={<div class="h-7" />}>
           <PropertiesProvider
             entityType="TASK"
@@ -344,7 +350,10 @@ export function TaskComposer(props: {
         </Suspense>
       </div>
 
-      <div class="shrink-0 flex h-8 w-full flex-row justify-between items-center p-2 mb-2 space-x-2">
+      {/* A plain p-2 box (no fixed height, no extra bottom margin) puts an
+          even 8px between the action row and the composer's bottom-left edges
+          and the property pills above it. */}
+      <div class="shrink-0 flex w-full flex-row justify-between items-center p-2 space-x-2">
         <div class="flex items-center gap-2">
           <input
             ref={(el) => {


### PR DESCRIPTION
## Summary
This PR refines the layout and styling of the TaskComposer component and updates the Channel input placeholder text to be more consistent and user-friendly.

## Key Changes

**TaskComposer Layout Improvements:**
- Restructured the property pills section into its own container with explicit `px-2 pt-4` styling to align with the footer's action row
- Removed fixed height (`h-8`) and bottom margin (`mb-2`) from the footer action row to create even 8px spacing between all edges
- Updated comments to clarify the spacing rationale: property pills now line up with the footer's action buttons (both at `px-2`), creating consistent visual alignment
- The property pills container uses `pt-4` to maintain the `gap-4` rhythm established by the content above

**Channel Input Placeholder Updates:**
- Updated placeholder text to remove trailing periods for consistency
- Modified channel placeholder to display as `#name` format (e.g., "#general") instead of just the name
- Updated the comment to reflect that channels render with the `#` prefix while DMs show the contact name
- Simplified placeholder messages from "Type @ to share with {name}." to "Type @ to share with {name}"

## Implementation Details
The TaskComposer changes improve visual hierarchy by explicitly grouping the property pills with the footer action row, both using `px-2` padding. This creates a cleaner, more predictable layout where the spacing between elements is uniform and intentional. The Channel placeholder changes make the UI more intuitive by visually distinguishing channels (with `#`) from direct messages (showing contact names).

https://claude.ai/code/session_01XarMiqvJc2hawSmTcqfgix