### PR TITLE
fix(push): respect explicit opt-out during device re-registration sync

### DIFF
--- a/apps/web/src/lib/tauri/PushNotification.tsx
+++ b/apps/web/src/lib/tauri/PushNotification.tsx
@@ -50,6 +50,14 @@ function usePushNotifications(
     createSignal<'granted' | 'denied' | undefined>(undefined)
   );
 
+  // Tracks an explicit in-app opt-out, as opposed to a logout or a fresh
+  // login/account-switch. Only this flag should suppress the automatic
+  // re-registration in syncDeviceRegistration; registrationResult/permission
+  // are cleared on logout too and can't be used to detect opt-out.
+  const [pushDisabledByUser, setPushDisabledByUser] = makePersisted(
+    createSignal(false)
+  );
+
   async function registerDeviceWithNotificationService(
     token: string
   ): Promise<'granted' | 'denied'> {
@@ -67,6 +75,7 @@ function usePushNotifications(
       return 'denied';
     }
     setPermission('granted');
+    setPushDisabledByUser(false);
     return 'granted';
   }
 
@@ -103,6 +112,7 @@ function usePushNotifications(
     }
     setRegistrationResult(undefined);
     setPermission(undefined);
+    setPushDisabledByUser(true);
   }
 
   // (Re-)register this device under whoever is currently logged in. The
@@ -110,6 +120,7 @@ function usePushNotifications(
   // not just when the APNs token rotates — or the previous account keeps
   // receiving this device's pushes.
   async function syncDeviceRegistration() {
+    if (pushDisabledByUser()) return;
     const sysPerm = await checkPermissions();
     if (sysPerm.status !== 'granted') return;
     const freshResult = await registerForRemoteNotifications();
@@ -138,6 +149,9 @@ function usePushNotifications(
       removeAllActive().catch(console.error),
       unregisterPushNotifications(),
     ]);
+    // unregisterPushNotifications() sets pushDisabledByUser, but that's an
+    // opt-out for this account, not the next one that logs in on this device.
+    setPushDisabledByUser(false);
   }
 
   const removeLifecycle = registerPushRegistrationLifecycle({


### PR DESCRIPTION
## Bug

Reported in the `hutch@macro.com` bug-reports channel: push notifications were re-enabling themselves after being explicitly turned off in-app, starting ~2026-08-04. The opt-out had previously stuck across restarts.

## Root cause

`syncDeviceRegistration()` in `apps/web/src/lib/tauri/PushNotification.tsx` re-registers the device's push token on every app launch/login. This is intentional — it keeps the backend's token-to-user mapping correct when a different account logs in on the same device (see the comment above the function, added in #5348 to fix cross-account push leakage).

That change (#5348, merged 2026-07-31) removed the old guard that skipped re-registration when there was no stored token, but never replaced it with any check for "the user explicitly disabled push." It only checks OS-level notification permission (`checkPermissions()`), which stays `granted` when a user disables push via the in-app toggle (`unregisterPushNotifications()`) rather than through OS Settings. As a result, the next app launch/login silently re-registers the device and resumes delivery, undoing the user's opt-out.

`registrationResult`/`permission` can't be reused as an "opted out" signal because they're also cleared on logout (needed for the account-switch fix), so a plain re-check of those would either reintroduce the original account-switch bug or fail to distinguish "logged out" from "opted out."

## Fix

Add a dedicated persisted `pushDisabledByUser` flag:
- Set to `true` in `unregisterPushNotifications()` (in-app explicit opt-out).
- Checked at the top of `syncDeviceRegistration()`, short-circuiting the automatic re-registration while the user has opted out.
- Reset to `false` on successful re-registration (explicit re-enable) and on logout, so the next account on the same device isn't affected by a previous user's opt-out.

## Testing

- `bunx --bun biome check` passes clean on the changed file.
- Full workspace `tsc`/test run wasn't available in this environment (monorepo `node_modules` isn't installed here), so please double check CI on this PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y5J8bZbERDv8YFPC5EsRva)_