### PR TITLE
fix(import): reuse system properties during document import

### DIFF
--- a/crates/import/src/outbound/document_properties.rs
+++ b/crates/import/src/outbound/document_properties.rs
@@ -420,40 +420,99 @@ async fn find_or_create_definition<P: ImportedPropertyDefinitions>(
     definitions: &mut Vec<PropertyDefinition>,
     system_definitions: &[PropertyDefinition],
 ) -> Option<PropertyDefinition> {
+    match resolve_existing_definition(&property.name, descriptor, definitions, system_definitions) {
+        ExistingDefinitionResolution::Reuse(definition) => Some(definition),
+        ExistingDefinitionResolution::Create => {
+            create_or_recover_definition(
+                properties,
+                user,
+                document_id,
+                &property.name,
+                descriptor,
+                definitions,
+            )
+            .await
+        }
+        ExistingDefinitionResolution::Conflict(conflict) => {
+            log_definition_conflict(document_id, &property.name, conflict);
+            None
+        }
+    }
+}
+
+#[derive(Debug)]
+enum DefinitionConflict {
+    IncompatibleExisting { is_system: bool },
+    ReservedSystem { definition_id: Uuid },
+}
+
+#[derive(Debug)]
+enum ExistingDefinitionResolution {
+    Reuse(PropertyDefinition),
+    Create,
+    Conflict(DefinitionConflict),
+}
+
+fn resolve_existing_definition(
+    property_name: &str,
+    descriptor: &ImportedPropertyDescriptor,
+    definitions: &[PropertyDefinition],
+    system_definitions: &[PropertyDefinition],
+) -> ExistingDefinitionResolution {
     if let Some(definition) = definitions
         .iter()
         .find(|definition| {
-            definition.display_name.eq_ignore_ascii_case(&property.name)
+            definition.display_name.eq_ignore_ascii_case(property_name)
                 && descriptor.matches(definition)
         })
         .cloned()
     {
-        return Some(definition);
+        return ExistingDefinitionResolution::Reuse(definition);
     }
 
-    if let Some(definition) = find_definition_by_name(definitions, &property.name) {
-        tracing::warn!(
+    if let Some(definition) = find_definition_by_name(definitions, property_name) {
+        return ExistingDefinitionResolution::Conflict(DefinitionConflict::IncompatibleExisting {
+            is_system: definition.is_system,
+        });
+    }
+
+    if let Some(definition) = find_definition_by_name(system_definitions, property_name) {
+        return ExistingDefinitionResolution::Conflict(DefinitionConflict::ReservedSystem {
+            definition_id: definition.id,
+        });
+    }
+
+    ExistingDefinitionResolution::Create
+}
+
+fn log_definition_conflict(document_id: &str, property_name: &str, conflict: DefinitionConflict) {
+    match conflict {
+        DefinitionConflict::IncompatibleExisting { is_system } => tracing::warn!(
             document_id,
-            property = %property.name,
-            is_system = definition.is_system,
+            property = %property_name,
+            is_system,
             "skipping imported property whose existing Macro definition has a different type"
-        );
-        return None;
-    }
-
-    if let Some(definition) = find_definition_by_name(system_definitions, &property.name) {
-        tracing::warn!(
+        ),
+        DefinitionConflict::ReservedSystem { definition_id } => tracing::warn!(
             document_id,
-            property = %property.name,
-            property_definition_id = %definition.id,
+            property = %property_name,
+            property_definition_id = %definition_id,
             "skipping imported property whose name is reserved by an inapplicable system property"
-        );
-        return None;
+        ),
     }
+}
 
+async fn create_or_recover_definition<P: ImportedPropertyDefinitions>(
+    properties: &P,
+    user: &MacroUserIdStr<'static>,
+    document_id: &str,
+    property_name: &str,
+    descriptor: &ImportedPropertyDescriptor,
+    definitions: &mut Vec<PropertyDefinition>,
+) -> Option<PropertyDefinition> {
     let request = CreatePropertyDefinitionRequest {
         scope: CreatePropertyScope::User,
-        display_name: property.name.clone(),
+        display_name: property_name.to_string(),
         data_type: descriptor.definition_type.clone(),
     };
     let definition = match properties.create_imported_definition(user, &request).await {
@@ -466,14 +525,14 @@ async fn find_or_create_definition<P: ImportedPropertyDefinitions>(
                 .ok()
                 .and_then(|definitions| {
                     definitions.into_iter().find(|definition| {
-                        definition.display_name.eq_ignore_ascii_case(&property.name)
+                        definition.display_name.eq_ignore_ascii_case(property_name)
                             && descriptor.matches(definition)
                     })
                 });
             let Some(definition) = recovered else {
                 tracing::warn!(
                     document_id,
-                    property = %property.name,
+                    property = %property_name,
                     error = ?error,
                     "failed to create imported document property"
                 );

--- a/crates/import/src/outbound/document_properties.rs
+++ b/crates/import/src/outbound/document_properties.rs
@@ -92,7 +92,7 @@ impl<P: PropertiesService> DocumentPropertiesApplicator<P> {
                 .find_or_create_string_option(
                     user,
                     document_id,
-                    definition.id,
+                    &definition,
                     &mut options,
                     label,
                     Some(imported_tag_color(index)),
@@ -130,12 +130,23 @@ impl<P: PropertiesService> DocumentPropertiesApplicator<P> {
 
         let mut definitions = match self
             .properties
-            .list_property_definitions(None, Some(user), false, Some(EntityType::Document))
+            .list_property_definitions(None, Some(user), true, Some(EntityType::Document))
             .await
         {
             Ok(definitions) => definitions,
             Err(error) => {
                 tracing::warn!(document_id, error = ?error, "failed to list imported document properties");
+                return;
+            }
+        };
+        let system_definitions = match self
+            .properties
+            .list_property_definitions(None, None, true, None)
+            .await
+        {
+            Ok(definitions) => definitions,
+            Err(error) => {
+                tracing::warn!(document_id, error = ?error, "failed to list system properties for import");
                 return;
             }
         };
@@ -149,6 +160,7 @@ impl<P: PropertiesService> DocumentPropertiesApplicator<P> {
                     property,
                     &descriptor,
                     &mut definitions,
+                    &system_definitions,
                 )
                 .await;
             let Some(definition) = definition else {
@@ -190,19 +202,27 @@ impl<P: PropertiesService> DocumentPropertiesApplicator<P> {
         property: &ImportedDocumentProperty,
         descriptor: &ImportedPropertyDescriptor,
         definitions: &mut Vec<PropertyDefinition>,
+        system_definitions: &[PropertyDefinition],
     ) -> Option<PropertyDefinition> {
-        if let Some(definition) = definitions
-            .iter()
-            .find(|definition| definition.display_name.eq_ignore_ascii_case(&property.name))
-            .cloned()
-        {
+        if let Some(definition) = find_definition_by_name(definitions, &property.name).cloned() {
             if descriptor.matches(&definition) {
                 return Some(definition);
             }
             tracing::warn!(
                 document_id,
                 property = %property.name,
+                is_system = definition.is_system,
                 "skipping imported property whose existing Macro definition has a different type"
+            );
+            return None;
+        }
+
+        if let Some(definition) = find_definition_by_name(system_definitions, &property.name) {
+            tracing::warn!(
+                document_id,
+                property = %property.name,
+                property_definition_id = %definition.id,
+                "skipping imported property whose name is reserved by an inapplicable system property"
             );
             return None;
         }
@@ -222,14 +242,13 @@ impl<P: PropertiesService> DocumentPropertiesApplicator<P> {
                 // Concurrent imports may race to create the same definition.
                 let recovered = self
                     .properties
-                    .list_property_definitions(None, Some(user), false, Some(EntityType::Document))
+                    .list_property_definitions(None, Some(user), true, Some(EntityType::Document))
                     .await
                     .ok()
                     .and_then(|definitions| {
-                        definitions.into_iter().find(|definition| {
-                            definition.display_name.eq_ignore_ascii_case(&property.name)
-                                && descriptor.matches(definition)
-                        })
+                        find_definition_by_name(&definitions, &property.name)
+                            .filter(|definition| descriptor.matches(definition))
+                            .cloned()
                     });
                 let Some(definition) = recovered else {
                     tracing::warn!(
@@ -330,7 +349,7 @@ impl<P: PropertiesService> DocumentPropertiesApplicator<P> {
                 .find_or_create_string_option(
                     user,
                     document_id,
-                    definition.id,
+                    definition,
                     &mut options,
                     value,
                     None,
@@ -357,13 +376,24 @@ impl<P: PropertiesService> DocumentPropertiesApplicator<P> {
         &self,
         user: &MacroUserIdStr<'static>,
         document_id: &str,
-        definition_id: Uuid,
+        definition: &PropertyDefinition,
         options: &mut Vec<PropertyOption>,
         label: &str,
         color: Option<&str>,
     ) -> Option<Uuid> {
         if let Some(option) = find_string_option(options, label) {
             return Some(option.id);
+        }
+
+        if definition.is_system {
+            tracing::warn!(
+                document_id,
+                property_definition_id = %definition.id,
+                property = %definition.display_name,
+                label,
+                "skipping imported value absent from system property options"
+            );
+            return None;
         }
 
         let request = AddPropertyOptionRequest::SelectString {
@@ -375,7 +405,7 @@ impl<P: PropertiesService> DocumentPropertiesApplicator<P> {
         };
         match self
             .properties
-            .add_property_option(user, None, definition_id, &request)
+            .add_property_option(user, None, definition.id, &request)
             .await
         {
             Ok(option) => {
@@ -387,7 +417,7 @@ impl<P: PropertiesService> DocumentPropertiesApplicator<P> {
                 // A concurrent import may have created the option first.
                 let recovered = self
                     .properties
-                    .get_property_options(definition_id, user, None)
+                    .get_property_options(definition.id, user, None)
                     .await
                     .ok()
                     .and_then(|fresh| find_string_option(&fresh, label).cloned());
@@ -457,6 +487,15 @@ fn find_string_option<'a>(
             PropertyOptionValue::String(value) if value.eq_ignore_ascii_case(label)
         )
     })
+}
+
+fn find_definition_by_name<'a>(
+    definitions: &'a [PropertyDefinition],
+    name: &str,
+) -> Option<&'a PropertyDefinition> {
+    definitions
+        .iter()
+        .find(|definition| definition.display_name.eq_ignore_ascii_case(name))
 }
 
 fn imported_tag_color(index: usize) -> &'static str {

--- a/crates/import/src/outbound/document_properties.rs
+++ b/crates/import/src/outbound/document_properties.rs
@@ -153,16 +153,16 @@ impl<P: PropertiesService> DocumentPropertiesApplicator<P> {
 
         for property in imported {
             let descriptor = ImportedPropertyDescriptor::of(&property.value);
-            let definition = self
-                .find_or_create_definition(
-                    user,
-                    document_id,
-                    property,
-                    &descriptor,
-                    &mut definitions,
-                    &system_definitions,
-                )
-                .await;
+            let definition = find_or_create_definition(
+                self.properties.as_ref(),
+                user,
+                document_id,
+                property,
+                &descriptor,
+                &mut definitions,
+                &system_definitions,
+            )
+            .await;
             let Some(definition) = definition else {
                 continue;
             };
@@ -193,77 +193,6 @@ impl<P: PropertiesService> DocumentPropertiesApplicator<P> {
                 );
             }
         }
-    }
-
-    async fn find_or_create_definition(
-        &self,
-        user: &MacroUserIdStr<'static>,
-        document_id: &str,
-        property: &ImportedDocumentProperty,
-        descriptor: &ImportedPropertyDescriptor,
-        definitions: &mut Vec<PropertyDefinition>,
-        system_definitions: &[PropertyDefinition],
-    ) -> Option<PropertyDefinition> {
-        if let Some(definition) = find_definition_by_name(definitions, &property.name).cloned() {
-            if descriptor.matches(&definition) {
-                return Some(definition);
-            }
-            tracing::warn!(
-                document_id,
-                property = %property.name,
-                is_system = definition.is_system,
-                "skipping imported property whose existing Macro definition has a different type"
-            );
-            return None;
-        }
-
-        if let Some(definition) = find_definition_by_name(system_definitions, &property.name) {
-            tracing::warn!(
-                document_id,
-                property = %property.name,
-                property_definition_id = %definition.id,
-                "skipping imported property whose name is reserved by an inapplicable system property"
-            );
-            return None;
-        }
-
-        let request = CreatePropertyDefinitionRequest {
-            scope: CreatePropertyScope::User,
-            display_name: property.name.clone(),
-            data_type: descriptor.definition_type.clone(),
-        };
-        let definition = match self
-            .properties
-            .create_property_definition(user, None, &request)
-            .await
-        {
-            Ok(definition) => definition,
-            Err(error) => {
-                // Concurrent imports may race to create the same definition.
-                let recovered = self
-                    .properties
-                    .list_property_definitions(None, Some(user), true, Some(EntityType::Document))
-                    .await
-                    .ok()
-                    .and_then(|definitions| {
-                        find_definition_by_name(&definitions, &property.name)
-                            .filter(|definition| descriptor.matches(definition))
-                            .cloned()
-                    });
-                let Some(definition) = recovered else {
-                    tracing::warn!(
-                        document_id,
-                        property = %property.name,
-                        error = ?error,
-                        "failed to create imported document property"
-                    );
-                    return None;
-                };
-                definition
-            }
-        };
-        definitions.push(definition.clone());
-        Some(definition)
     }
 
     async fn property_value(
@@ -437,6 +366,124 @@ impl<P: PropertiesService> DocumentPropertiesApplicator<P> {
             }
         }
     }
+}
+
+#[async_trait::async_trait]
+trait ImportedPropertyDefinitions: Send + Sync {
+    type Error: std::fmt::Debug + Send;
+
+    async fn create_imported_definition(
+        &self,
+        user: &MacroUserIdStr<'_>,
+        request: &CreatePropertyDefinitionRequest,
+    ) -> Result<PropertyDefinition, Self::Error>;
+
+    async fn list_imported_definitions(
+        &self,
+        user: &MacroUserIdStr<'_>,
+    ) -> Result<Vec<PropertyDefinition>, Self::Error>;
+}
+
+#[async_trait::async_trait]
+impl<P: PropertiesService> ImportedPropertyDefinitions for P {
+    type Error = properties::PropertiesErr;
+
+    async fn create_imported_definition(
+        &self,
+        user: &MacroUserIdStr<'_>,
+        request: &CreatePropertyDefinitionRequest,
+    ) -> Result<PropertyDefinition, Self::Error> {
+        PropertiesService::create_property_definition(self, user, None, request).await
+    }
+
+    async fn list_imported_definitions(
+        &self,
+        user: &MacroUserIdStr<'_>,
+    ) -> Result<Vec<PropertyDefinition>, Self::Error> {
+        PropertiesService::list_property_definitions(
+            self,
+            None,
+            Some(user),
+            true,
+            Some(EntityType::Document),
+        )
+        .await
+    }
+}
+
+async fn find_or_create_definition<P: ImportedPropertyDefinitions>(
+    properties: &P,
+    user: &MacroUserIdStr<'static>,
+    document_id: &str,
+    property: &ImportedDocumentProperty,
+    descriptor: &ImportedPropertyDescriptor,
+    definitions: &mut Vec<PropertyDefinition>,
+    system_definitions: &[PropertyDefinition],
+) -> Option<PropertyDefinition> {
+    if let Some(definition) = definitions
+        .iter()
+        .find(|definition| {
+            definition.display_name.eq_ignore_ascii_case(&property.name)
+                && descriptor.matches(definition)
+        })
+        .cloned()
+    {
+        return Some(definition);
+    }
+
+    if let Some(definition) = find_definition_by_name(definitions, &property.name) {
+        tracing::warn!(
+            document_id,
+            property = %property.name,
+            is_system = definition.is_system,
+            "skipping imported property whose existing Macro definition has a different type"
+        );
+        return None;
+    }
+
+    if let Some(definition) = find_definition_by_name(system_definitions, &property.name) {
+        tracing::warn!(
+            document_id,
+            property = %property.name,
+            property_definition_id = %definition.id,
+            "skipping imported property whose name is reserved by an inapplicable system property"
+        );
+        return None;
+    }
+
+    let request = CreatePropertyDefinitionRequest {
+        scope: CreatePropertyScope::User,
+        display_name: property.name.clone(),
+        data_type: descriptor.definition_type.clone(),
+    };
+    let definition = match properties.create_imported_definition(user, &request).await {
+        Ok(definition) => definition,
+        Err(error) => {
+            // Concurrent imports may race to create the same definition.
+            let recovered = properties
+                .list_imported_definitions(user)
+                .await
+                .ok()
+                .and_then(|definitions| {
+                    definitions.into_iter().find(|definition| {
+                        definition.display_name.eq_ignore_ascii_case(&property.name)
+                            && descriptor.matches(definition)
+                    })
+                });
+            let Some(definition) = recovered else {
+                tracing::warn!(
+                    document_id,
+                    property = %property.name,
+                    error = ?error,
+                    "failed to create imported document property"
+                );
+                return None;
+            };
+            definition
+        }
+    };
+    definitions.push(definition.clone());
+    Some(definition)
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/import/src/outbound/document_properties/test.rs
+++ b/crates/import/src/outbound/document_properties/test.rs
@@ -33,28 +33,99 @@ fn descriptor_uses_declared_source_cardinality() {
     );
 }
 
-#[test]
-fn system_definition_is_reused_when_name_and_type_match() {
-    let definition = system_definition();
-    let definitions = vec![definition];
-    let descriptor = ImportedPropertyDescriptor::of(&ImportedDocumentPropertyValue::Select {
-        values: vec!["In Progress".to_string()],
-        multi: false,
-    });
+#[tokio::test]
+async fn resolver_prefers_compatible_system_definition_after_incompatible_custom_definition() {
+    let mut incompatible_custom = system_definition();
+    incompatible_custom.id = Uuid::from_u128(1);
+    incompatible_custom.owner = PropertyOwner::User {
+        user_id: user().to_string(),
+    };
+    incompatible_custom.data_type = DataType::String;
+    incompatible_custom.is_system = false;
 
-    let matched = find_definition_by_name(&definitions, "status").unwrap();
-    assert!(matched.is_system);
-    assert!(descriptor.matches(matched));
+    let compatible_system = system_definition();
+    let mut definitions = vec![incompatible_custom, compatible_system.clone()];
+    let property = select_property();
+    let descriptor = ImportedPropertyDescriptor::of(&property.value);
+
+    let resolved = find_or_create_definition(
+        &TestPropertiesService,
+        &user(),
+        "document-id",
+        &property,
+        &descriptor,
+        &mut definitions,
+        std::slice::from_ref(&compatible_system),
+    )
+    .await
+    .expect("compatible system definition should be reused");
+
+    assert_eq!(resolved.id, compatible_system.id);
+    assert!(resolved.is_system);
+    assert_eq!(definitions.len(), 2);
 }
 
-#[test]
-fn system_definition_with_incompatible_type_is_not_reusable() {
-    let definition = system_definition();
-    let descriptor = ImportedPropertyDescriptor::of(&ImportedDocumentPropertyValue::String {
-        value: "In Progress".to_string(),
-    });
+#[tokio::test]
+async fn resolver_rejects_incompatible_reserved_system_definition_without_creating() {
+    let system_definition = system_definition();
+    let property = ImportedDocumentProperty {
+        name: "status".to_string(),
+        value: ImportedDocumentPropertyValue::String {
+            value: "In Progress".to_string(),
+        },
+    };
+    let descriptor = ImportedPropertyDescriptor::of(&property.value);
+    let mut definitions = Vec::new();
 
-    assert!(!descriptor.matches(&definition));
+    let resolved = find_or_create_definition(
+        &TestPropertiesService,
+        &user(),
+        "document-id",
+        &property,
+        &descriptor,
+        &mut definitions,
+        std::slice::from_ref(&system_definition),
+    )
+    .await;
+
+    assert!(resolved.is_none());
+    assert!(definitions.is_empty());
+}
+
+struct TestPropertiesService;
+
+#[async_trait::async_trait]
+impl ImportedPropertyDefinitions for TestPropertiesService {
+    type Error = std::convert::Infallible;
+
+    async fn create_imported_definition(
+        &self,
+        _user: &MacroUserIdStr<'_>,
+        _request: &CreatePropertyDefinitionRequest,
+    ) -> Result<PropertyDefinition, Self::Error> {
+        panic!("resolver should not create a property definition")
+    }
+
+    async fn list_imported_definitions(
+        &self,
+        _user: &MacroUserIdStr<'_>,
+    ) -> Result<Vec<PropertyDefinition>, Self::Error> {
+        panic!("resolver should not reload property definitions")
+    }
+}
+
+fn user() -> MacroUserIdStr<'static> {
+    MacroUserIdStr::parse_from_str("macro|import-test@example.com").expect("valid user id")
+}
+
+fn select_property() -> ImportedDocumentProperty {
+    ImportedDocumentProperty {
+        name: "status".to_string(),
+        value: ImportedDocumentPropertyValue::Select {
+            values: vec!["In Progress".to_string()],
+            multi: false,
+        },
+    }
 }
 
 fn system_definition() -> PropertyDefinition {

--- a/crates/import/src/outbound/document_properties/test.rs
+++ b/crates/import/src/outbound/document_properties/test.rs
@@ -33,40 +33,37 @@ fn descriptor_uses_declared_source_cardinality() {
     );
 }
 
-#[tokio::test]
-async fn resolver_prefers_compatible_system_definition_after_incompatible_custom_definition() {
+#[test]
+fn resolver_prefers_compatible_system_definition_after_incompatible_custom_definition() {
     let mut incompatible_custom = system_definition();
     incompatible_custom.id = Uuid::from_u128(1);
     incompatible_custom.owner = PropertyOwner::User {
-        user_id: user().to_string(),
+        user_id: "macro|import-test@example.com".to_string(),
     };
     incompatible_custom.data_type = DataType::String;
     incompatible_custom.is_system = false;
 
     let compatible_system = system_definition();
-    let mut definitions = vec![incompatible_custom, compatible_system.clone()];
+    let definitions = vec![incompatible_custom, compatible_system.clone()];
     let property = select_property();
     let descriptor = ImportedPropertyDescriptor::of(&property.value);
 
-    let resolved = find_or_create_definition(
-        &TestPropertiesService,
-        &user(),
-        "document-id",
-        &property,
+    let resolution = resolve_existing_definition(
+        &property.name,
         &descriptor,
-        &mut definitions,
+        &definitions,
         std::slice::from_ref(&compatible_system),
-    )
-    .await
-    .expect("compatible system definition should be reused");
+    );
+    let ExistingDefinitionResolution::Reuse(resolved) = resolution else {
+        panic!("compatible system definition should be reused");
+    };
 
     assert_eq!(resolved.id, compatible_system.id);
     assert!(resolved.is_system);
-    assert_eq!(definitions.len(), 2);
 }
 
-#[tokio::test]
-async fn resolver_rejects_incompatible_reserved_system_definition_without_creating() {
+#[test]
+fn resolver_rejects_incompatible_reserved_system_definition() {
     let system_definition = system_definition();
     let property = ImportedDocumentProperty {
         name: "status".to_string(),
@@ -75,47 +72,36 @@ async fn resolver_rejects_incompatible_reserved_system_definition_without_creati
         },
     };
     let descriptor = ImportedPropertyDescriptor::of(&property.value);
-    let mut definitions = Vec::new();
 
-    let resolved = find_or_create_definition(
-        &TestPropertiesService,
-        &user(),
-        "document-id",
-        &property,
+    let resolution = resolve_existing_definition(
+        &property.name,
         &descriptor,
-        &mut definitions,
+        &[],
         std::slice::from_ref(&system_definition),
-    )
-    .await;
+    );
 
-    assert!(resolved.is_none());
-    assert!(definitions.is_empty());
+    assert!(matches!(
+        resolution,
+        ExistingDefinitionResolution::Conflict(DefinitionConflict::ReservedSystem {
+            definition_id
+        })
+            if definition_id == system_definition.id
+    ));
 }
 
-struct TestPropertiesService;
+#[test]
+fn resolver_allows_creation_for_unreserved_name() {
+    let property = ImportedDocumentProperty {
+        name: "Priority".to_string(),
+        value: ImportedDocumentPropertyValue::String {
+            value: "High".to_string(),
+        },
+    };
+    let descriptor = ImportedPropertyDescriptor::of(&property.value);
 
-#[async_trait::async_trait]
-impl ImportedPropertyDefinitions for TestPropertiesService {
-    type Error = std::convert::Infallible;
+    let resolution = resolve_existing_definition(&property.name, &descriptor, &[], &[]);
 
-    async fn create_imported_definition(
-        &self,
-        _user: &MacroUserIdStr<'_>,
-        _request: &CreatePropertyDefinitionRequest,
-    ) -> Result<PropertyDefinition, Self::Error> {
-        panic!("resolver should not create a property definition")
-    }
-
-    async fn list_imported_definitions(
-        &self,
-        _user: &MacroUserIdStr<'_>,
-    ) -> Result<Vec<PropertyDefinition>, Self::Error> {
-        panic!("resolver should not reload property definitions")
-    }
-}
-
-fn user() -> MacroUserIdStr<'static> {
-    MacroUserIdStr::parse_from_str("macro|import-test@example.com").expect("valid user id")
+    assert!(matches!(resolution, ExistingDefinitionResolution::Create));
 }
 
 fn select_property() -> ImportedDocumentProperty {

--- a/crates/import/src/outbound/document_properties/test.rs
+++ b/crates/import/src/outbound/document_properties/test.rs
@@ -1,4 +1,6 @@
 use super::*;
+use chrono::Utc;
+use models_properties::PropertyOwner;
 
 #[test]
 fn descriptor_uses_declared_source_cardinality() {
@@ -29,4 +31,43 @@ fn descriptor_uses_declared_source_cardinality() {
         single_link.definition_type,
         PropertyDataType::Link { multi: false }
     );
+}
+
+#[test]
+fn system_definition_is_reused_when_name_and_type_match() {
+    let definition = system_definition();
+    let definitions = vec![definition];
+    let descriptor = ImportedPropertyDescriptor::of(&ImportedDocumentPropertyValue::Select {
+        values: vec!["In Progress".to_string()],
+        multi: false,
+    });
+
+    let matched = find_definition_by_name(&definitions, "status").unwrap();
+    assert!(matched.is_system);
+    assert!(descriptor.matches(matched));
+}
+
+#[test]
+fn system_definition_with_incompatible_type_is_not_reusable() {
+    let definition = system_definition();
+    let descriptor = ImportedPropertyDescriptor::of(&ImportedDocumentPropertyValue::String {
+        value: "In Progress".to_string(),
+    });
+
+    assert!(!descriptor.matches(&definition));
+}
+
+fn system_definition() -> PropertyDefinition {
+    PropertyDefinition {
+        id: Uuid::from_u128(2),
+        owner: PropertyOwner::System,
+        display_name: "Status".to_string(),
+        data_type: DataType::SelectString,
+        is_multi_select: false,
+        specific_entity_type: None,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+        is_system: true,
+        is_metadata: false,
+    }
 }


### PR DESCRIPTION
- Prefer compatible same-name definitions, including system definitions, before rejecting incompatible collisions.
- Skip inapplicable reserved system-property names instead of creating invalid custom definitions.
- Add resolver-level regression coverage and reuse existing system select options without mutating global definitions.