### PR TITLE
fix(document-upload): skip sync snapshots in upload consumers

### DIFF
--- a/crates/s3_key/src/document_key.rs
+++ b/crates/s3_key/src/document_key.rs
@@ -22,6 +22,7 @@ pub const DOCX_EXTENSION: &str = "docx";
 /// - `Versioned`: `{user_id}/{document_id}/{version_id}` — a specific document version
 /// - `ConvertedPdf`: `{user_id}/{document_id}/converted.pdf` — a DOCX converted to PDF
 /// - `TempDocx`: `temp_files/{document_id}.docx` — a temporary DOCX export
+/// - `SyncServiceSnapshot`: `sync_service_snapshot/{document_id}` — a cached CRDT snapshot
 /// - `BomPart`: `{sha}` — a content-addressable BOM part from DOCX uploads
 #[derive(Eq, PartialEq, Debug, Clone)]
 pub enum DocumentKey {
@@ -43,6 +44,11 @@ pub enum DocumentKey {
     },
     /// A temporary DOCX export: `temp_files/{document_id}.docx`
     TempDocx {
+        /// The document ID.
+        document_id: String,
+    },
+    /// A sync-service CRDT snapshot cache object: `sync_service_snapshot/{document_id}`.
+    SyncServiceSnapshot {
         /// The document ID.
         document_id: String,
     },
@@ -75,6 +81,9 @@ impl DocumentKey {
                     document_id: document_id.to_string(),
                 })
             }
+            2 if split[0] == SYNC_SERVICE_SNAPSHOT_PREFIX => Ok(Self::SyncServiceSnapshot {
+                document_id: split[1].to_string(),
+            }),
             3 => {
                 let user_id = urlencoding::decode(split[0]).context("UTF-8")?.into_owned();
                 let document_id = split[1].to_string();
@@ -112,7 +121,8 @@ impl DocumentKey {
         match self {
             Self::Versioned { document_id, .. }
             | Self::ConvertedPdf { document_id, .. }
-            | Self::TempDocx { document_id } => Some(document_id),
+            | Self::TempDocx { document_id }
+            | Self::SyncServiceSnapshot { document_id } => Some(document_id),
             Self::BomPart { .. } => None,
         }
     }
@@ -125,6 +135,11 @@ impl DocumentKey {
     /// Returns `true` if this is a temporary DOCX export key.
     pub fn is_temp(&self) -> bool {
         matches!(self, Self::TempDocx { .. })
+    }
+
+    /// Returns `true` if this is a sync-service snapshot cache key.
+    pub fn is_sync_service_snapshot(&self) -> bool {
+        matches!(self, Self::SyncServiceSnapshot { .. })
     }
 
     /// Returns `true` if this is a BOM part key.
@@ -146,7 +161,7 @@ impl DocumentKey {
         match self {
             Self::Versioned { version_id, .. } => Some(version_id.to_string()),
             Self::ConvertedPdf { .. } => Some(CONVERTED_DOCUMENT_FILE_NAME.to_string()),
-            Self::TempDocx { .. } | Self::BomPart { .. } => None,
+            Self::TempDocx { .. } | Self::SyncServiceSnapshot { .. } | Self::BomPart { .. } => None,
         }
     }
 
@@ -163,6 +178,9 @@ impl DocumentKey {
                 document_id,
             } => build_docx_to_pdf_converted_document_key(user_id, document_id),
             Self::TempDocx { document_id } => build_temp_docx_key(document_id),
+            Self::SyncServiceSnapshot { document_id } => {
+                format!("{SYNC_SERVICE_SNAPSHOT_PREFIX}/{document_id}")
+            }
             Self::BomPart { sha } => sha.clone(),
         }
     }

--- a/crates/s3_key/src/document_key/test.rs
+++ b/crates/s3_key/src/document_key/test.rs
@@ -44,6 +44,24 @@ fn test_temp_docx_key_from_s3_key() {
 }
 
 #[test]
+fn test_sync_service_snapshot_key_from_s3_key() {
+    let key = DocumentKey::from_s3_key("sync_service_snapshot/doc456").unwrap();
+    assert_eq!(
+        key,
+        DocumentKey::SyncServiceSnapshot {
+            document_id: "doc456".to_string(),
+        }
+    );
+    assert_eq!(key.to_key(), "sync_service_snapshot/doc456");
+    assert_eq!(key.document_id(), Some("doc456"));
+    assert_eq!(key.version_id_string(), None);
+    assert!(key.is_sync_service_snapshot());
+    assert!(!key.is_temp());
+    assert!(!key.is_bom_part());
+    assert!(!key.is_converted_pdf());
+}
+
+#[test]
 fn test_url_encoded_user_id() {
     let key = DocumentKey::from_s3_key("user%20123/doc456/789").unwrap();
     assert_eq!(
@@ -104,6 +122,9 @@ fn test_document_id_accessor() {
 
     let temp = DocumentKey::from_s3_key("temp_files/doc3.docx").unwrap();
     assert_eq!(temp.document_id(), Some("doc3"));
+
+    let snapshot = DocumentKey::from_s3_key("sync_service_snapshot/doc4").unwrap();
+    assert_eq!(snapshot.document_id(), Some("doc4"));
 }
 
 #[test]
@@ -116,6 +137,9 @@ fn test_version_id_string() {
 
     let temp = DocumentKey::from_s3_key("temp_files/doc.docx").unwrap();
     assert_eq!(temp.version_id_string(), None);
+
+    let snapshot = DocumentKey::from_s3_key("sync_service_snapshot/doc").unwrap();
+    assert_eq!(snapshot.version_id_string(), None);
 }
 
 #[test]

--- a/services/document_text_extractor/src/handler/extract_text_citations.rs
+++ b/services/document_text_extractor/src/handler/extract_text_citations.rs
@@ -155,8 +155,8 @@ pub async fn extract_text_from_document(
         Error::from("invalid key format")
     })?;
 
-    if document_key.is_bom_part() {
-        tracing::trace!("skipping bom part key");
+    if document_key.is_bom_part() || document_key.is_sync_service_snapshot() {
+        tracing::trace!(?document_key, "skipping non-document key");
         return Ok(None);
     }
 

--- a/services/search_upload_handler/src/handler.rs
+++ b/services/search_upload_handler/src/handler.rs
@@ -32,7 +32,10 @@ pub async fn handler(
         }
     };
 
-    if document_key.is_temp() || document_key.is_bom_part() {
+    if document_key.is_temp()
+        || document_key.is_bom_part()
+        || document_key.is_sync_service_snapshot()
+    {
         tracing::trace!("skipping non-document key");
         return Ok(());
     }


### PR DESCRIPTION
- Recognize `sync_service_snapshot/{document_id}` as a valid S3 key variant.
- Skip snapshot objects in text extraction, search upload relaying, and upload finalization.
- Add parser and accessor coverage for snapshot keys.