### PR TITLE
feat(search): add an Ask AI button to the search header

### DIFF
--- a/apps/web/src/features/chat/ChatWithAgentButton.tsx
+++ b/apps/web/src/features/chat/ChatWithAgentButton.tsx
@@ -1,4 +1,5 @@
 import { globalSplitManager } from '@app/signal/splitLayout';
+import type { SplitHandle } from '@components/app/split-layout/layoutManager';
 import { DEFAULT_MODEL } from '@core/component/AI/constant';
 import { setPendingSendData } from '@core/component/AI/signal/pendingSend';
 import type { Attachment } from '@core/component/AI/types';
@@ -60,6 +61,8 @@ async function createAndOpenChat(seed: {
   attachments?: Attachment[];
   /** When set, sent immediately when the chat opens instead of seeding the input */
   message?: string;
+  /** When set, replaces this split's content in place instead of opening a new split. */
+  replaceSplit?: SplitHandle;
 }) {
   const result = await createChat();
   if ('error' in result || !result.chatId) {
@@ -68,7 +71,7 @@ async function createAndOpenChat(seed: {
     return;
   }
 
-  const { message, ...stored } = seed;
+  const { message, replaceSplit, ...stored } = seed;
   if (message) {
     setPendingSendData({
       content: message,
@@ -78,10 +81,14 @@ async function createAndOpenChat(seed: {
   } else {
     storeChatStateImmediate(result.chatId, stored);
   }
-  globalSplitManager()?.openWithSplit(
-    { type: 'chat', id: result.chatId },
-    { activate: true, preferNewSplit: true }
-  );
+  if (replaceSplit) {
+    replaceSplit.replace({ next: { type: 'chat', id: result.chatId } });
+  } else {
+    globalSplitManager()?.openWithSplit(
+      { type: 'chat', id: result.chatId },
+      { activate: true, preferNewSplit: true }
+    );
+  }
 }
 
 export async function openChatWithAgent(entity: ChatWithAgentEntity) {
@@ -94,9 +101,31 @@ export async function openChatWithInput(initialInput: string) {
   await createAndOpenChat({ input: initialInput });
 }
 
+/**
+ * Replace `splitHandle`'s content with a new chat seeded with `initialInput`
+ * (not sent). Used by the search view's "Ask AI" button to hand off in place.
+ */
+export async function openChatWithInputReplacingSplit(
+  initialInput: string,
+  splitHandle: SplitHandle
+) {
+  await createAndOpenChat({ input: initialInput, replaceSplit: splitHandle });
+}
+
 /** Open a new chat and immediately send `message` (the chat picks it up via pending send) */
 export async function openChatWithMessage(message: string) {
   await createAndOpenChat({ message });
+}
+
+/**
+ * Replace `splitHandle`'s content with a new chat and immediately send
+ * `message`. Used by the search view's "Ask AI" button to hand off in place.
+ */
+export async function openChatWithMessageReplacingSplit(
+  message: string,
+  splitHandle: SplitHandle
+) {
+  await createAndOpenChat({ message, replaceSplit: splitHandle });
 }
 
 export function ChatWithAgentButton(props: { entity: ChatWithAgentEntity }) {

--- a/apps/web/src/features/next-soup/soup-view/search-ask-ai-button.tsx
+++ b/apps/web/src/features/next-soup/soup-view/search-ask-ai-button.tsx
@@ -40,10 +40,11 @@ export function SearchAskAiButton() {
       variant="ghost"
       size="sm"
       depth={2}
-      class="shrink-0 gap-1.5 rounded-full border border-edge-muted px-2.5 bg-surface"
+      tooltip="Ask AI"
+      class="shrink-0 h-7 mobile:h-9 gap-1.5 rounded-lg px-2"
       onClick={askAi}
     >
-      <span class="text-xs font-medium">Ask AI</span>
+      <span class="font-medium">Ask AI</span>
       <Hotkey shortcut={askAiHotkey.hotkey()} theme="subtle" />
     </Button>
   );

--- a/apps/web/src/features/next-soup/soup-view/search-ask-ai-button.tsx
+++ b/apps/web/src/features/next-soup/soup-view/search-ask-ai-button.tsx
@@ -2,39 +2,49 @@ import {
   openChatWithInputReplacingSplit,
   openChatWithMessageReplacingSplit,
 } from '@app/features/chat/ChatWithAgentButton';
-import { useSplitPanel } from '@components/app/split-layout/layoutUtils';
-import { AnimatedStarIcon } from '@icon/wide-star';
-import { Button } from '@ui';
-import { createSignal } from 'solid-js';
+import { useSplitPanelOrThrow } from '@components/app/split-layout/layoutUtils';
+import { registerHotkey } from '@core/hotkey/hotkeys';
+import { TOKENS } from '@core/hotkey/tokens';
+import { Button, Hotkey } from '@ui';
+import { onCleanup } from 'solid-js';
 import { useSoupView } from './soup-view-context';
 
 export function SearchAskAiButton() {
   const soupView = useSoupView();
-  const splitPanel = useSplitPanel();
-  const [hovering, setHovering] = createSignal(false);
+  const panel = useSplitPanelOrThrow();
+
+  const askAi = () => {
+    const query = soupView.searchText().trim();
+    if (query) {
+      openChatWithMessageReplacingSplit(query, panel.handle);
+    } else {
+      openChatWithInputReplacingSplit('', panel.handle);
+    }
+  };
+
+  const askAiHotkey = registerHotkey({
+    hotkey: 'tab',
+    hotkeyToken: TOKENS.soup.askAi,
+    scopeId: panel.splitHotkeyScope,
+    description: 'Ask AI',
+    keyDownHandler: () => {
+      askAi();
+      return true;
+    },
+    runWithInputFocused: true,
+  });
+  onCleanup(askAiHotkey.dispose);
 
   return (
     <Button
       variant="ghost"
       size="sm"
       depth={2}
-      tooltip="Ask AI"
       class="shrink-0 gap-1.5 rounded-full border border-edge-muted px-2.5 bg-surface"
-      onMouseEnter={() => setHovering(true)}
-      onMouseLeave={() => setHovering(false)}
-      onClick={() => {
-        const handle = splitPanel?.handle;
-        if (!handle) return;
-        const query = soupView.searchText().trim();
-        if (query) {
-          openChatWithMessageReplacingSplit(query, handle);
-        } else {
-          openChatWithInputReplacingSplit('', handle);
-        }
-      }}
+      onClick={askAi}
     >
-      <AnimatedStarIcon triggerAnimation={hovering()} />
       <span class="text-xs font-medium">Ask AI</span>
+      <Hotkey shortcut={askAiHotkey.hotkey()} theme="subtle" />
     </Button>
   );
 }

--- a/apps/web/src/features/next-soup/soup-view/search-ask-ai-button.tsx
+++ b/apps/web/src/features/next-soup/soup-view/search-ask-ai-button.tsx
@@ -1,0 +1,40 @@
+import {
+  openChatWithInputReplacingSplit,
+  openChatWithMessageReplacingSplit,
+} from '@app/features/chat/ChatWithAgentButton';
+import { useSplitPanel } from '@components/app/split-layout/layoutUtils';
+import { AnimatedStarIcon } from '@icon/wide-star';
+import { Button } from '@ui';
+import { createSignal } from 'solid-js';
+import { useSoupView } from './soup-view-context';
+
+export function SearchAskAiButton() {
+  const soupView = useSoupView();
+  const splitPanel = useSplitPanel();
+  const [hovering, setHovering] = createSignal(false);
+
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      depth={2}
+      tooltip="Ask AI"
+      class="shrink-0 gap-1.5 rounded-full border border-edge-muted px-2.5 bg-surface"
+      onMouseEnter={() => setHovering(true)}
+      onMouseLeave={() => setHovering(false)}
+      onClick={() => {
+        const handle = splitPanel?.handle;
+        if (!handle) return;
+        const query = soupView.searchText().trim();
+        if (query) {
+          openChatWithMessageReplacingSplit(query, handle);
+        } else {
+          openChatWithInputReplacingSplit('', handle);
+        }
+      }}
+    >
+      <AnimatedStarIcon triggerAnimation={hovering()} />
+      <span class="text-xs font-medium">Ask AI</span>
+    </Button>
+  );
+}

--- a/apps/web/src/features/next-soup/soup-view/search-ask-ai-button.tsx
+++ b/apps/web/src/features/next-soup/soup-view/search-ask-ai-button.tsx
@@ -6,19 +6,26 @@ import { useSplitPanelOrThrow } from '@components/app/split-layout/layoutUtils';
 import { registerHotkey } from '@core/hotkey/hotkeys';
 import { TOKENS } from '@core/hotkey/tokens';
 import { Button, Hotkey } from '@ui';
-import { onCleanup } from 'solid-js';
+import { createSignal, onCleanup } from 'solid-js';
 import { useSoupView } from './soup-view-context';
 
 export function SearchAskAiButton() {
   const soupView = useSoupView();
   const panel = useSplitPanelOrThrow();
 
-  const askAi = () => {
-    const query = soupView.searchText().trim();
-    if (query) {
-      openChatWithMessageReplacingSplit(query, panel.handle);
-    } else {
-      openChatWithInputReplacingSplit('', panel.handle);
+  const [isAsking, setIsAsking] = createSignal(false);
+  const askAi = async () => {
+    if (isAsking()) return;
+    setIsAsking(true);
+    try {
+      const query = soupView.searchText().trim();
+      if (query) {
+        await openChatWithMessageReplacingSplit(query, panel.handle);
+      } else {
+        await openChatWithInputReplacingSplit('', panel.handle);
+      }
+    } finally {
+      setIsAsking(false);
     }
   };
 
@@ -42,6 +49,7 @@ export function SearchAskAiButton() {
       depth={2}
       tooltip="Ask AI"
       class="shrink-0 h-7 mobile:h-9 gap-1.5 rounded-lg px-2"
+      disabled={isAsking()}
       onClick={askAi}
     >
       <span class="font-medium">Ask AI</span>

--- a/apps/web/src/features/next-soup/soup-view/soup-view.tsx
+++ b/apps/web/src/features/next-soup/soup-view/soup-view.tsx
@@ -120,6 +120,7 @@ import {
 import { Dynamic } from 'solid-js/web';
 import { Virtualizer, type VirtualizerHandle } from 'virtua/solid';
 import type { CacheSnapshot } from 'virtua/unstable_core';
+import { SearchAskAiButton } from './search-ask-ai-button';
 import { SoupEntitySelectionToolbar } from './soup-entity-selection-toolbar';
 import { useSoupNavigationHotkeys } from './use-soup-navigation-hotkeys';
 import { useSoupPreviewAvailability } from './use-soup-preview-availability';
@@ -610,15 +611,18 @@ export const SoupView = (props: SoupViewProps) => {
             <Show
               when={!isComponentListView('search')}
               fallback={
-                <Layer depth={2}>
-                  <div class="grow ml-2 min-w-0 [contain:inline-size]">
-                    <SoupSearchbar
-                      variant="secondary"
-                      placeholder="Search, @mention contacts"
-                      initialValue={props.initialSearchText}
-                    />
-                  </div>
-                </Layer>
+                <>
+                  <Layer depth={2}>
+                    <div class="grow ml-2 min-w-0 [contain:inline-size]">
+                      <SoupSearchbar
+                        variant="secondary"
+                        placeholder="Search, @mention contacts"
+                        initialValue={props.initialSearchText}
+                      />
+                    </div>
+                  </Layer>
+                  <SearchAskAiButton />
+                </>
               }
             >
               <Show when={!narrowSearchExpanded()}>
@@ -694,7 +698,8 @@ export const SoupView = (props: SoupViewProps) => {
             ENABLE_UNIFIED_LIST_AI_INPUT &&
             !isMobile() &&
             !isNewInboxEnabled() &&
-            !isBoardRendered()
+            !isBoardRendered() &&
+            !isComponentListView('search')
           }
         >
           <SoupChatInput />

--- a/apps/web/src/lib/core/hotkey/tokens.ts
+++ b/apps/web/src/lib/core/hotkey/tokens.ts
@@ -2,6 +2,7 @@ export const TOKENS = {
   // soup
   soup: {
     openSearch: 'soup.openSearch',
+    askAi: 'soup.askAi',
     sort: 'soup.sort',
     filter: 'soup.filter',
     tabs: {


### PR DESCRIPTION
Replaces the persistent Ask AI bar in the search view with an always-enabled Ask AI button beside the search bar. Clicking it opens a new AI chat in place — sending the current query immediately, or opening an empty chat when there's no query.
