### PR TITLE
fix(web): preserve stable soup row identities

### DIFF
--- a/apps/web/src/features/next-soup/create-soup-state.test.ts
+++ b/apps/web/src/features/next-soup/create-soup-state.test.ts
@@ -83,6 +83,34 @@ describe('createSoupState', () => {
         dispose();
       });
     });
+
+    it('uses a reused row current index for focus state', () => {
+      createRoot((dispose) => {
+        const state = createSoupState();
+        const first = state.buildRow({
+          id: '1',
+          index: 0,
+          original: createTestEntity('1'),
+        });
+        const second = state.buildRow({
+          id: '2',
+          index: 1,
+          original: createTestEntity('2'),
+        });
+        state.setRows([first, second]);
+        state.focus.set('2');
+
+        second.index = 0;
+        first.index = 1;
+        state.setRows([second, first]);
+
+        expect(state.focus.index()).toBe(0);
+        expect(second.isFocused()).toBe(true);
+        expect(first.isFocused()).toBe(false);
+
+        dispose();
+      });
+    });
   });
 
   describe('items', () => {

--- a/apps/web/src/features/next-soup/create-soup-state.ts
+++ b/apps/web/src/features/next-soup/create-soup-state.ts
@@ -141,17 +141,18 @@ export const createSoupState = <TId extends string = FilterID>(
       isGrouped = false,
       isLoadMore = false,
     } = options;
-    return {
+    const row: SoupRow = {
       id,
       index,
       original,
       group,
       getIsGrouped: () => isGrouped,
       getIsLoadMore: () => isLoadMore,
-      isFocused: () => focusedIndex() === index,
+      isFocused: () => focusedIndex() === row.index,
       isSelected: () =>
         !isGrouped && !isLoadMore && selection.isSelected(original.id),
     };
+    return row;
   };
 
   const [rows, setRowsInternal] = createSignal<SoupRow[]>(

--- a/apps/web/src/features/next-soup/soup-view/reconcile-soup-rows.test.ts
+++ b/apps/web/src/features/next-soup/soup-view/reconcile-soup-rows.test.ts
@@ -1,0 +1,226 @@
+import type {
+  GroupMeta,
+  SoupEntity,
+  SoupRow,
+} from '@app/features/next-soup/create-soup-state';
+import { describe, expect, it } from 'vitest';
+import { reconcileSoupRows } from './reconcile-soup-rows';
+
+function entity(id: string, status: string): SoupEntity {
+  return {
+    id,
+    type: 'document',
+    name: `Task ${id}`,
+    ownerId: 'owner',
+    fileType: 'md',
+    subType: { type: 'task' },
+    properties: [
+      {
+        id: `property-${id}`,
+        definition: { id: 'status' },
+        value: { type: 'SelectOption', value: [status] },
+      },
+    ],
+    notifications: () => [
+      {
+        id: `notification-${id}`,
+        entityId: id,
+      },
+    ],
+  } as unknown as SoupEntity;
+}
+
+function group(key: string, count: number): GroupMeta {
+  return {
+    key,
+    value: key,
+    label: key,
+    count,
+    isExpanded: () => true,
+    toggle: () => {},
+  };
+}
+
+function row(options: {
+  id: string;
+  index: number;
+  original: SoupEntity;
+  group?: GroupMeta;
+  kind?: 'entity' | 'group-header' | 'load-more';
+}): SoupRow {
+  const kind = options.kind ?? 'entity';
+  return {
+    id: options.id,
+    index: options.index,
+    original: options.original,
+    group: options.group,
+    getIsGrouped: () => kind === 'group-header',
+    getIsLoadMore: () => kind === 'load-more',
+    isFocused: () => false,
+    isSelected: () => false,
+  };
+}
+
+function groupedRows(status = 'todo'): SoupRow[] {
+  const groupMeta = group('todo', 2);
+  const first = entity('first', status);
+  const second = entity('second', 'todo');
+
+  return [
+    row({
+      id: 'header:todo',
+      index: 0,
+      original: first,
+      group: groupMeta,
+      kind: 'group-header',
+    }),
+    row({ id: first.id, index: 1, original: first, group: groupMeta }),
+    row({ id: second.id, index: 2, original: second, group: groupMeta }),
+    row({
+      id: 'loadmore:todo',
+      index: 3,
+      original: second,
+      group: groupMeta,
+      kind: 'load-more',
+    }),
+  ];
+}
+
+describe('reconcileSoupRows', () => {
+  it('reuses unchanged entity and structural row references', () => {
+    const previous = groupedRows();
+    const rebuilt = groupedRows();
+
+    const reconciled = reconcileSoupRows(previous, rebuilt);
+
+    expect(reconciled).toHaveLength(previous.length);
+    for (let index = 0; index < previous.length; index++) {
+      expect(reconciled[index]).toBe(previous[index]);
+      expect(reconciled[index]).not.toBe(rebuilt[index]);
+    }
+  });
+
+  it('replaces only an entity whose rendered data changed', () => {
+    const previous = groupedRows();
+    const rebuilt = groupedRows('in-progress');
+
+    const reconciled = reconcileSoupRows(previous, rebuilt);
+
+    expect(reconciled[0]).not.toBe(previous[0]);
+    expect(reconciled[1]).not.toBe(previous[1]);
+    expect(reconciled[1].original).toMatchObject({
+      properties: [
+        {
+          value: {
+            type: 'SelectOption',
+            value: ['in-progress'],
+          },
+        },
+      ],
+    });
+    expect(reconciled[2]).toBe(previous[2]);
+    expect(reconciled[3]).toBe(previous[3]);
+  });
+
+  it('replaces moved tasks and changed structural rows while reusing unaffected tasks', () => {
+    const previousGroupA = group('a', 2);
+    const previousGroupB = group('b', 1);
+    const moved = entity('moved', 'a');
+    const staysInA = entity('stays-a', 'a');
+    const staysInB = entity('stays-b', 'b');
+    const previous = [
+      row({
+        id: 'header:a',
+        index: 0,
+        original: moved,
+        group: previousGroupA,
+        kind: 'group-header',
+      }),
+      row({ id: moved.id, index: 1, original: moved, group: previousGroupA }),
+      row({
+        id: staysInA.id,
+        index: 2,
+        original: staysInA,
+        group: previousGroupA,
+      }),
+      row({
+        id: 'header:b',
+        index: 3,
+        original: staysInB,
+        group: previousGroupB,
+        kind: 'group-header',
+      }),
+      row({
+        id: staysInB.id,
+        index: 4,
+        original: staysInB,
+        group: previousGroupB,
+      }),
+      row({
+        id: 'loadmore:b',
+        index: 5,
+        original: staysInB,
+        group: previousGroupB,
+        kind: 'load-more',
+      }),
+    ];
+
+    const nextGroupA = group('a', 1);
+    const nextGroupB = group('b', 2);
+    const movedAfterUpdate = entity('moved', 'b');
+    const rebuilt = [
+      row({
+        id: 'header:a',
+        index: 0,
+        original: staysInA,
+        group: nextGroupA,
+        kind: 'group-header',
+      }),
+      row({
+        id: staysInA.id,
+        index: 1,
+        original: entity('stays-a', 'a'),
+        group: nextGroupA,
+      }),
+      row({
+        id: 'header:b',
+        index: 2,
+        original: movedAfterUpdate,
+        group: nextGroupB,
+        kind: 'group-header',
+      }),
+      row({
+        id: movedAfterUpdate.id,
+        index: 3,
+        original: movedAfterUpdate,
+        group: nextGroupB,
+      }),
+      row({
+        id: staysInB.id,
+        index: 4,
+        original: entity('stays-b', 'b'),
+        group: nextGroupB,
+      }),
+      row({
+        id: 'loadmore:b',
+        index: 5,
+        original: entity('stays-b', 'b'),
+        group: nextGroupB,
+        kind: 'load-more',
+      }),
+    ];
+
+    const reconciled = reconcileSoupRows(previous, rebuilt);
+
+    expect(reconciled[0]).toBe(rebuilt[0]);
+    expect(reconciled[0].group?.count).toBe(1);
+    expect(reconciled[1]).toBe(previous[2]);
+    expect(reconciled[1].index).toBe(1);
+    expect(reconciled[2]).toBe(rebuilt[2]);
+    expect(reconciled[2].group?.count).toBe(2);
+    expect(reconciled[3]).toBe(rebuilt[3]);
+    expect(reconciled[3]).not.toBe(previous[1]);
+    expect(reconciled[4]).toBe(previous[4]);
+    expect(reconciled[5]).toBe(rebuilt[5]);
+  });
+});

--- a/apps/web/src/features/next-soup/soup-view/reconcile-soup-rows.ts
+++ b/apps/web/src/features/next-soup/soup-view/reconcile-soup-rows.ts
@@ -1,0 +1,146 @@
+import type {
+  GroupMeta,
+  SoupEntity,
+  SoupRow,
+} from '@app/features/next-soup/create-soup-state';
+import { untrack } from 'solid-js';
+
+type SoupRowKind = 'entity' | 'group-header' | 'load-more';
+
+function rowKind(row: SoupRow): SoupRowKind {
+  if (row.getIsGrouped()) return 'group-header';
+  if (row.getIsLoadMore()) return 'load-more';
+  return 'entity';
+}
+
+/**
+ * Virtua's Solid adapter keys rows by object identity. Include the row variant
+ * and group in the logical identity so headers/load-more rows cannot collide
+ * with entities, and moving an entity between groups creates a new row.
+ */
+function rowIdentity(row: SoupRow): string {
+  const kind = rowKind(row);
+  const groupKey = row.group?.key ?? null;
+
+  if (kind === 'entity') {
+    return JSON.stringify([kind, groupKey, row.original.type, row.id]);
+  }
+
+  return JSON.stringify([kind, groupKey, row.id]);
+}
+
+function valuesEqual(left: unknown, right: unknown): boolean {
+  if (left === right) return true;
+  if (left == null || right == null) return false;
+  if (typeof left !== typeof right) return false;
+
+  if (left instanceof Date || right instanceof Date) {
+    return (
+      left instanceof Date &&
+      right instanceof Date &&
+      left.getTime() === right.getTime()
+    );
+  }
+
+  if (Array.isArray(left) || Array.isArray(right)) {
+    if (!Array.isArray(left) || !Array.isArray(right)) return false;
+    if (left.length !== right.length) return false;
+    return left.every((value, index) => valuesEqual(value, right[index]));
+  }
+
+  if (typeof left !== 'object') return false;
+
+  const leftRecord = left as Record<string, unknown>;
+  const rightRecord = right as Record<string, unknown>;
+  const keys = new Set([
+    ...Object.keys(leftRecord),
+    ...Object.keys(rightRecord),
+  ]);
+
+  for (const key of keys) {
+    if (!valuesEqual(leftRecord[key], rightRecord[key])) return false;
+  }
+
+  return true;
+}
+
+function notificationValues(entity: SoupEntity): unknown {
+  return untrack(() => entity.notifications?.());
+}
+
+function entitiesEqual(left: SoupEntity, right: SoupEntity): boolean {
+  if (left === right) return true;
+
+  const leftRecord = left as Record<string, unknown>;
+  const rightRecord = right as Record<string, unknown>;
+  const keys = new Set([
+    ...Object.keys(leftRecord),
+    ...Object.keys(rightRecord),
+  ]);
+  keys.delete('notifications');
+
+  for (const key of keys) {
+    if (!valuesEqual(leftRecord[key], rightRecord[key])) return false;
+  }
+
+  return valuesEqual(notificationValues(left), notificationValues(right));
+}
+
+function groupsEqual(
+  left: GroupMeta | undefined,
+  right: GroupMeta | undefined
+): boolean {
+  if (left === right) return true;
+  if (!left || !right) return false;
+
+  return (
+    left.key === right.key &&
+    left.label === right.label &&
+    left.count === right.count &&
+    left.renderHeader === right.renderHeader &&
+    valuesEqual(left.value, right.value)
+  );
+}
+
+function rowsEqual(left: SoupRow, right: SoupRow): boolean {
+  if (left.id !== right.id || rowKind(left) !== rowKind(right)) return false;
+  if (!entitiesEqual(left.original, right.original)) return false;
+
+  // Entity rows only consume the group's stable key and expansion callbacks.
+  // Display metadata belongs to structural rows; changing a group count should
+  // replace its header/load-more row without remounting every entity in it.
+  if (rowKind(left) === 'entity') {
+    return left.group?.key === right.group?.key;
+  }
+
+  return groupsEqual(left.group, right.group);
+}
+
+/**
+ * Reuses semantically unchanged SoupRow objects across rebuilt row arrays.
+ * Rows may shift when a task moves, so refresh their mutable index while
+ * retaining the object Virtua uses as its identity key.
+ */
+export function reconcileSoupRows(
+  previousRows: SoupRow[],
+  nextRows: SoupRow[]
+): SoupRow[] {
+  const previousByIdentity = new Map<string, SoupRow[]>();
+
+  for (const row of previousRows) {
+    const identity = rowIdentity(row);
+    const matches = previousByIdentity.get(identity);
+    if (matches) matches.push(row);
+    else previousByIdentity.set(identity, [row]);
+  }
+
+  return nextRows.map((nextRow) => {
+    const matches = previousByIdentity.get(rowIdentity(nextRow));
+    const previousRow = matches?.shift();
+
+    if (!previousRow || !rowsEqual(previousRow, nextRow)) return nextRow;
+
+    previousRow.index = nextRow.index;
+    return previousRow;
+  });
+}

--- a/apps/web/src/features/next-soup/soup-view/soup-view-context.tsx
+++ b/apps/web/src/features/next-soup/soup-view/soup-view-context.tsx
@@ -36,6 +36,7 @@ import {
   INBOX_FILTER_ENTRY_KEY,
   registerInboxFilterSplit,
 } from '@app/features/next-soup/soup-view/inbox-filter-controllers';
+import { reconcileSoupRows } from '@app/features/next-soup/soup-view/reconcile-soup-rows';
 import { useSoupFilterPersistence } from '@app/features/next-soup/use-soup-filter-persistence';
 import {
   deduplicateEntities,
@@ -1260,7 +1261,7 @@ export const SoupViewContextProvider: FlowComponent<
     return '';
   };
 
-  const rows = createMemo((): SoupRow[] => {
+  const builtRows = createMemo((): SoupRow[] => {
     const field = groupByField();
     const groups = itemsSource.data()?.groups;
 
@@ -1460,6 +1461,11 @@ export const SoupViewContextProvider: FlowComponent<
 
     return result;
   });
+
+  const rows = createMemo(
+    (previousRows: SoupRow[]) => reconcileSoupRows(previousRows, builtRows()),
+    []
+  );
 
   const { searchQuery } = search;
 


### PR DESCRIPTION
This PR introduces better soup row identification which prevents excessive remounting of elements inside virtua