### PR TITLE
perf(web): derive grouped initial pages from parent query

### DIFF
--- a/apps/web/src/features/next-soup/soup-view/create-graphql-grouped-soup-queries.test.ts
+++ b/apps/web/src/features/next-soup/soup-view/create-graphql-grouped-soup-queries.test.ts
@@ -1,0 +1,370 @@
+import {
+  type Client,
+  CombinedError,
+  type GraphQLRequest,
+  type Operation,
+  type OperationContext,
+  type OperationResult,
+} from '@urql/core';
+import { createMemo, createRoot } from 'solid-js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { makeSubject, onEnd, pipe } from 'wonka';
+
+const getGraphqlSoupClientMock = vi.hoisted(() => vi.fn());
+const mapGraphqlGroupedSoupPageMock = vi.hoisted(() =>
+  vi.fn((data: { page: unknown }) => data.page)
+);
+
+vi.mock('@macro-inc/observability', () => ({
+  Telemetry: { error: vi.fn() },
+}));
+
+vi.mock('@queries/soup/grouped/api', () => ({
+  makeGroupComparator: () => (left: { key: string }, right: { key: string }) =>
+    left.key.localeCompare(right.key),
+  resolveGroupMetaForKey: (_field: unknown, key: string) => ({
+    key,
+    label: key,
+    displayOrder: null,
+  }),
+}));
+
+vi.mock('@queries/storage/instructions-md', () => ({
+  useInstructionsMdIdQuery: vi.fn(() => ({})),
+}));
+
+vi.mock('@queries/soup/transform-utils', () => ({
+  isDisplayableSoupItem: () => true,
+  isInstructionsMdDoc: () => false,
+  mapApiSoupItemToEntity: (item: unknown) => item,
+  mapSoupPageToEntityList: (page: { items: unknown[] }) => page.items,
+}));
+
+vi.mock('@service-storage/graphql-soup', () => ({
+  getGraphqlSoupClient: getGraphqlSoupClientMock,
+  mapGraphqlGroupedSoupPage: mapGraphqlGroupedSoupPageMock,
+}));
+
+import {
+  groupedSoupInputKey,
+  groupedSoupLogicalViewKey,
+} from '@queries/soup/grouped/graphql-operation-registry';
+import type { GroupMeta } from '@queries/soup/grouped/types';
+import { useReactiveGroupedSoupAstItemsQuery } from '@queries/soup/reactive-grouped-items';
+import type { GroupSoupQueryVariables } from '@service-storage/graphql/generated/graphql';
+import { createGraphqlGroupedSoupQueries } from './create-graphql-grouped-soup-queries';
+
+type TestItem = { id: string; name: string };
+type TestPage = {
+  items: Record<string, TestItem>;
+  groups: Array<
+    Pick<GroupMeta, 'key' | 'totalCount' | 'itemIds' | 'nextCursor'>
+  >;
+};
+
+type FakeExecution = {
+  variables: GroupSoupQueryVariables;
+  next(
+    page: TestPage,
+    state?: Partial<Pick<OperationResult, 'hasNext' | 'stale'>>
+  ): void;
+  fail(error: CombinedError): void;
+  readonly unsubscribed: boolean;
+};
+
+function makeFakeClient(): {
+  client: Client;
+  executions: FakeExecution[];
+} {
+  const executions: FakeExecution[] = [];
+  const execute = (
+    request: GraphQLRequest<unknown, GroupSoupQueryVariables>,
+    context: Partial<OperationContext>
+  ) => {
+    const subject =
+      makeSubject<OperationResult<unknown, GroupSoupQueryVariables>>();
+    let unsubscribed = false;
+    const operation = {
+      kind: 'query',
+      context,
+    } as Operation<unknown, GroupSoupQueryVariables>;
+    executions.push({
+      variables: request.variables,
+      next: (page, state) =>
+        subject.next({ operation, data: { page }, ...state } as OperationResult<
+          unknown,
+          GroupSoupQueryVariables
+        >),
+      fail: (error) =>
+        subject.next({ operation, error, stale: false, hasNext: false }),
+      get unsubscribed() {
+        return unsubscribed;
+      },
+    });
+    return pipe(
+      subject.source,
+      onEnd(() => {
+        unsubscribed = true;
+      })
+    );
+  };
+
+  return {
+    executions,
+    client: {
+      executeQuery: execute,
+    } as unknown as Client,
+  };
+}
+
+const item = (id: string): TestItem => ({ id, name: id });
+const group = (
+  key: string,
+  itemIds: string[],
+  nextCursor: string | null
+): TestPage['groups'][number] => ({
+  key,
+  totalCount: itemIds.length,
+  itemIds,
+  nextCursor,
+});
+const page = (groups: TestPage['groups'], items: TestItem[]): TestPage => ({
+  groups,
+  items: Object.fromEntries(items.map((entry) => [entry.id, entry])),
+});
+const entityIds = (query: {
+  data: () => { entities: Array<{ id: string }> } | undefined;
+}) => query.data()?.entities.map((entity) => entity.id);
+
+const disposals: Array<() => void> = [];
+afterEach(() => {
+  for (const dispose of disposals.splice(0)) dispose();
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+function setup() {
+  const fake = makeFakeClient();
+  getGraphqlSoupClientMock.mockReturnValue(fake.client);
+
+  let grouped!: ReturnType<typeof createGraphqlGroupedSoupQueries>;
+  const dispose = createRoot((rootDispose) => {
+    const parent = useReactiveGroupedSoupAstItemsQuery(
+      () => ({
+        params: { limit: 2, sort_method: 'updated_at' },
+        body: {},
+        groupBy: {
+          type: 'property',
+          propertyDefinitionId: 'status-definition',
+        },
+      }),
+      () => ({ enabled: true })
+    );
+    const initialPage = createMemo(() => {
+      const data = parent.data();
+      if (!data?.groups || !data.itemsById) return;
+      return { groups: data.groups, items: data.itemsById };
+    });
+
+    grouped = createGraphqlGroupedSoupQueries({
+      initialPage,
+      groupByField: () => ({
+        type: 'property',
+        propertyDefinitionId: 'status-definition',
+      }),
+      soupParams: () => ({ limit: 2, sort_method: 'updated_at' }),
+      soupBody: () => ({}),
+      enabled: () => true,
+      itemFilter: () => undefined,
+    });
+
+    return rootDispose;
+  });
+  disposals.push(dispose);
+
+  return { fake, grouped };
+}
+
+describe('createGraphqlGroupedSoupQueries', () => {
+  it('uses only the parent initial subscription and reacts to parent group moves', () => {
+    const { fake, grouped } = setup();
+
+    expect(fake.executions).toHaveLength(1);
+    expect(fake.executions[0]?.variables.input).toHaveProperty('initial');
+
+    fake.executions[0]?.next(
+      page(
+        [group('a', ['a-1'], 'a-cursor'), group('b', ['b-1'], 'b-cursor')],
+        [item('a-1'), item('b-1')]
+      )
+    );
+
+    expect(fake.executions).toHaveLength(1);
+    const a = grouped.map().get('a');
+    const b = grouped.map().get('b');
+    expect(a && entityIds(a)).toEqual(['a-1']);
+    expect(b && entityIds(b)).toEqual(['b-1']);
+
+    fake.executions[0]?.next(
+      page(
+        [group('a', [], 'a-cursor'), group('b', ['a-1', 'b-1'], 'b-cursor')],
+        [item('a-1'), item('b-1')]
+      )
+    );
+
+    expect(grouped.map().get('a')).toBe(a);
+    expect(grouped.map().get('b')).toBe(b);
+    expect(a && entityIds(a)).toEqual([]);
+    expect(b && entityIds(b)).toEqual(['a-1', 'b-1']);
+    expect(fake.executions).toHaveLength(1);
+  });
+
+  it('creates only independent continuation subscriptions when groups paginate', async () => {
+    const { fake, grouped } = setup();
+    fake.executions[0]?.next(
+      page(
+        [group('a', ['a-1'], 'a-cursor'), group('b', ['b-1'], 'b-cursor')],
+        [item('a-1'), item('b-1')]
+      )
+    );
+    const initialInput = fake.executions[0]?.variables.input;
+    const a = grouped.map().get('a')!;
+    const b = grouped.map().get('b')!;
+
+    const firstA = a.fetchNextPage();
+    expect(a.isFetchingNextPage()).toBe(true);
+    expect(fake.executions).toHaveLength(2);
+    expect(fake.executions[1]?.variables.input).toEqual({
+      continuation: {
+        groupBy: {
+          field: 'PROPERTY',
+          propertyDefinitionId: 'status-definition',
+        },
+        groupKey: 'a',
+        cursor: 'a-cursor',
+      },
+    });
+    expect(groupedSoupLogicalViewKey(fake.executions[1]?.variables.input)).toBe(
+      groupedSoupInputKey(initialInput)
+    );
+    let firstASettled = false;
+    void firstA.then(() => {
+      firstASettled = true;
+    });
+    fake.executions[1]?.next(
+      page([group('a', ['a-2'], 'a-cursor-2')], [item('a-2')]),
+      { stale: true }
+    );
+    await Promise.resolve();
+    expect(firstASettled).toBe(false);
+    expect(a.isFetchingNextPage()).toBe(true);
+    expect(entityIds(a)).toEqual(['a-1', 'a-2']);
+
+    fake.executions[1]?.next(
+      page([group('a', ['a-2'], 'a-cursor-2')], [item('a-2')])
+    );
+    await firstA;
+    expect(a.isFetchingNextPage()).toBe(false);
+    expect(entityIds(a)).toEqual(['a-1', 'a-2']);
+
+    const firstB = b.fetchNextPage();
+    expect(fake.executions).toHaveLength(3);
+    expect(fake.executions[2]?.variables.input).toHaveProperty(
+      'continuation.groupKey',
+      'b'
+    );
+    expect(fake.executions[2]?.variables.input).toHaveProperty(
+      'continuation.cursor',
+      'b-cursor'
+    );
+    fake.executions[2]?.next(page([group('b', ['b-2'], null)], [item('b-2')]));
+    await firstB;
+
+    const secondA = a.fetchNextPage();
+    expect(fake.executions).toHaveLength(4);
+    expect(fake.executions[3]?.variables.input).toHaveProperty(
+      'continuation.groupKey',
+      'a'
+    );
+    expect(fake.executions[3]?.variables.input).toHaveProperty(
+      'continuation.cursor',
+      'a-cursor-2'
+    );
+    fake.executions[3]?.next(page([group('a', ['a-3'], null)], [item('a-3')]));
+    await secondA;
+
+    expect(entityIds(a)).toEqual(['a-1', 'a-2', 'a-3']);
+    expect(entityIds(b)).toEqual(['b-1', 'b-2']);
+    expect(
+      fake.executions.filter(({ variables }) => 'initial' in variables.input)
+    ).toHaveLength(1);
+
+    grouped.resetToInitialPage();
+    expect(entityIds(a)).toEqual(['a-1']);
+    expect(entityIds(b)).toEqual(['b-1']);
+    expect(fake.executions[0]?.unsubscribed).toBe(false);
+    expect(
+      fake.executions.slice(1).every((execution) => execution.unsubscribed)
+    ).toBe(true);
+  });
+
+  it('retains parent data and allows retry when the first continuation errors', async () => {
+    const { fake, grouped } = setup();
+    fake.executions[0]?.next(
+      page([group('a', ['a-1'], 'a-cursor')], [item('a-1')])
+    );
+    const a = grouped.map().get('a')!;
+
+    const failedFetch = a.fetchNextPage();
+    fake.executions[1]?.fail(
+      new CombinedError({ graphQLErrors: ['continuation failed'] })
+    );
+    await failedFetch;
+
+    expect(entityIds(a)).toEqual(['a-1']);
+    expect(a.hasNextPage()).toBe(true);
+    expect(a.isFetchingNextPage()).toBe(false);
+
+    const retry = a.fetchNextPage();
+    expect(fake.executions).toHaveLength(3);
+    expect(fake.executions[2]?.variables.input).toHaveProperty(
+      'continuation.cursor',
+      'a-cursor'
+    );
+    fake.executions[2]?.next(page([group('a', ['a-2'], null)], [item('a-2')]));
+    await retry;
+
+    expect(entityIds(a)).toEqual(['a-1', 'a-2']);
+    expect(a.hasNextPage()).toBe(false);
+  });
+
+  it('adds and disposes group state with the reactive parent lifecycle', async () => {
+    const { fake, grouped } = setup();
+    fake.executions[0]?.next(
+      page(
+        [group('a', ['a-1'], null), group('b', ['b-1'], 'b-cursor')],
+        [item('a-1'), item('b-1')]
+      )
+    );
+
+    const b = grouped.map().get('b')!;
+    const fetchB = b.fetchNextPage();
+    fake.executions[1]?.next(page([group('b', ['b-2'], null)], [item('b-2')]));
+    await fetchB;
+
+    fake.executions[0]?.next(
+      page(
+        [group('a', ['a-1'], null), group('c', ['c-1'], 'c-cursor')],
+        [item('a-1'), item('c-1')]
+      )
+    );
+
+    expect(grouped.map().has('b')).toBe(false);
+    expect(fake.executions[1]?.unsubscribed).toBe(true);
+    expect(entityIds(grouped.map().get('c')!)).toEqual(['c-1']);
+    expect(fake.executions).toHaveLength(2);
+    expect(fake.executions[0]?.unsubscribed).toBe(false);
+  });
+});

--- a/apps/web/src/features/next-soup/soup-view/create-graphql-grouped-soup-queries.ts
+++ b/apps/web/src/features/next-soup/soup-view/create-graphql-grouped-soup-queries.ts
@@ -102,7 +102,7 @@ function groupPage(
   };
 }
 
-/** Creates live initial and continuation GroupSoup observers for visible bins. */
+/** Derives initial bins from the live parent and observes loaded continuations. */
 export function createGraphqlGroupedSoupQueries(
   args: CreateGraphqlGroupedSoupQueriesArgs
 ): {
@@ -167,49 +167,105 @@ export function createGraphqlGroupedSoupQueries(
       const getConfig = createMemo(
         () => configs().find((config) => config.key === key) ?? initialConfig
       );
+      const [continuationRevision, setContinuationRevision] = createSignal(0);
+      const [isFetchingFirstPage, setIsFetchingFirstPage] = createSignal(false);
 
-      const query = createUrqlInfiniteQuery<
-        GroupSoupQuery,
-        GroupSoupQueryVariables,
-        string | null,
-        GroupQueryData
-      >(() => {
-        const config = getConfig();
-        return {
-          query: GroupSoupDocument,
-          client: getGraphqlSoupClient(),
-          initialPageParam: null,
-          variables: (cursor) => {
-            if (cursor === null) return { input: config.initialInput };
-            const input = makeGraphqlGroupedSoupContinuationInput({
-              groupBy: config.field,
-              groupKey: config.key,
-              cursor,
-            });
-            registerGroupedSoupContinuation(config.initialInput, input);
-            return { input };
-          },
-          getNextPageParam: (lastPage) =>
-            groupPage(lastPage, config.group)?.group.nextCursor,
-          select: ({ pages }) => ({
-            entities: pages.flatMap((page) => {
-              const selected = groupPage(page, config.group);
-              return selected
-                ? mapItems(
-                    selected.items,
-                    selected.group.itemIds,
-                    config.itemFilter
-                  )
-                : [];
-            }),
-          }),
-          enabled: config.enabled,
-          requestPolicy: 'cache-first',
-          keepPreviousData: false,
-        };
-      });
+      const createContinuationQuery = (firstCursor: string) => {
+        let continuationDispose: (() => void) | undefined;
 
-      const initialData = (): GroupQueryData | undefined => {
+        return createRoot((continuationRootDispose) => {
+          continuationDispose = continuationRootDispose;
+          const [activated, setActivated] = createSignal(false);
+          let initialPageDidSettle = false;
+          let settleInitialPage = () => undefined;
+          const initialPageSettled = new Promise<void>((resolve) => {
+            settleInitialPage = () => {
+              if (initialPageDidSettle) return;
+              initialPageDidSettle = true;
+              resolve();
+            };
+          });
+
+          const query = createUrqlInfiniteQuery<
+            GroupSoupQuery,
+            GroupSoupQueryVariables,
+            string,
+            GroupQueryData
+          >(() => {
+            const config = getConfig();
+            return {
+              query: GroupSoupDocument,
+              client: getGraphqlSoupClient(),
+              initialPageParam: firstCursor,
+              variables: (cursor) => {
+                const input = makeGraphqlGroupedSoupContinuationInput({
+                  groupBy: config.field,
+                  groupKey: config.key,
+                  cursor,
+                });
+                registerGroupedSoupContinuation(config.initialInput, input);
+                return { input };
+              },
+              getNextPageParam: (lastPage) =>
+                groupPage(lastPage, config.group)?.group.nextCursor,
+              select: ({ pages }) => ({
+                entities: pages.flatMap((page) => {
+                  const selected = groupPage(page, config.group);
+                  return selected
+                    ? mapItems(
+                        selected.items,
+                        selected.group.itemIds,
+                        config.itemFilter
+                      )
+                    : [];
+                }),
+              }),
+              enabled: activated() && config.enabled,
+              requestPolicy: 'cache-first',
+              keepPreviousData: false,
+            };
+          });
+
+          createComputed(() => {
+            if (!activated()) return;
+            if (
+              !getConfig().enabled ||
+              (query.isFetched && !query.isFetching)
+            ) {
+              settleInitialPage();
+            }
+          });
+          onCleanup(settleInitialPage);
+
+          return {
+            firstCursor,
+            query,
+            activate: () => {
+              setActivated(true);
+              return initialPageSettled;
+            },
+            dispose: () => continuationDispose?.(),
+          };
+        });
+      };
+
+      let continuation: ReturnType<typeof createContinuationQuery> | undefined;
+      let firstPagePromise: Promise<void> | undefined;
+
+      const getContinuation = () => {
+        continuationRevision();
+        return continuation;
+      };
+
+      const disposeContinuation = () => {
+        continuation?.dispose();
+        continuation = undefined;
+        firstPagePromise = undefined;
+        setIsFetchingFirstPage(false);
+        setContinuationRevision((value) => value + 1);
+      };
+
+      const initialData = createMemo<GroupQueryData | undefined>(() => {
         const config = getConfig();
         const initialPage = args.initialPage();
         if (!initialPage) return;
@@ -224,21 +280,79 @@ export function createGraphqlGroupedSoupQueries(
             config.itemFilter
           ),
         };
+      });
+
+      const data = createMemo<GroupQueryData | undefined>(() => {
+        const initial = initialData();
+        if (!initial) return;
+        const continued = getContinuation()?.query.data;
+        if (!continued) return initial;
+        return { entities: [...initial.entities, ...continued.entities] };
+      });
+
+      const trackFirstPage = (action: Promise<unknown>): Promise<void> => {
+        setIsFetchingFirstPage(true);
+        const tracked = action
+          .then(() => undefined)
+          .finally(() => {
+            if (firstPagePromise !== tracked) return;
+            firstPagePromise = undefined;
+            setIsFetchingFirstPage(false);
+          });
+        firstPagePromise = tracked;
+        return tracked;
       };
+
+      const startContinuation = async (cursor: string): Promise<void> => {
+        continuation = createContinuationQuery(cursor);
+        setContinuationRevision((value) => value + 1);
+        await trackFirstPage(continuation.activate());
+      };
+
+      const fetchNextPage = async (): Promise<void> => {
+        const config = getConfig();
+        if (!config.enabled) return;
+        if (firstPagePromise) return firstPagePromise;
+
+        let current = getContinuation();
+        if (!current) {
+          const cursor = config.group.nextCursor;
+          if (cursor === null) return;
+          await startContinuation(cursor);
+          return;
+        }
+
+        if (current.query.data === undefined) {
+          const cursor = getConfig().group.nextCursor;
+          if (cursor === null) return;
+          if (cursor !== current.firstCursor) {
+            disposeContinuation();
+            await startContinuation(cursor);
+            return;
+          }
+          await trackFirstPage(current.query.refetch());
+          return;
+        }
+
+        await current.query.fetchNextPage();
+      };
+
+      onCleanup(disposeContinuation);
 
       return {
         key,
-        data: () => query.data ?? initialData(),
-        hasNextPage: () =>
-          query.data === undefined
-            ? (getConfig().group.nextCursor ?? null) !== null
-            : query.hasNextPage,
-        isFetchingNextPage: () => query.isFetchingNextPage,
-        fetchNextPage: async () => {
-          if (query.data === undefined) await query.refetch();
-          await query.fetchNextPage();
+        data,
+        hasNextPage: () => {
+          const current = getContinuation();
+          return current?.query.data === undefined
+            ? getConfig().group.nextCursor !== null
+            : current.query.hasNextPage;
         },
-        resetToInitialPage: query.resetToInitialPage,
+        isFetchingNextPage: () =>
+          isFetchingFirstPage() ||
+          (getContinuation()?.query.isFetchingNextPage ?? false),
+        fetchNextPage,
+        resetToInitialPage: disposeContinuation,
       };
     });
 


### PR DESCRIPTION
This PR reduces the number of active subscriptions in soup pages such that they are lazily created beyond the first page. This will prevent cache updates from doing extra work, reprocessing all other groups redundantly.

We need the createRoot stuff because the subscribers get created lazily beyond the first one, so we need a way to create and dispose of the continuations