### PR TITLE
feat(calendar): gate the desktop/web enable-calendar prompt behind a flag

### DIFF
--- a/apps/web/src/features/auth/CalendarPermissionPrompt.tsx
+++ b/apps/web/src/features/auth/CalendarPermissionPrompt.tsx
@@ -16,9 +16,9 @@ import { useEmailLinksQuery } from '@queries/email/link';
  * Inboxes that also need a full reconnect are skipped: the reconnect prompt
  * covers them, and reconnecting records the calendar grant anyway.
  *
- * Suppressed on phones unless `enable-calendar-prompt-mobile` says otherwise —
- * the mobile toast layout can't present it without stranding the user. See
- * `useCalendarPromptAllowed`.
+ * Gated per form factor: `enable-calendar-prompt-web` on desktop/web and
+ * `enable-calendar-prompt-mobile` on phones, where the toast layout can't
+ * present it without stranding the user. See `useCalendarPromptAllowed`.
  */
 export function CalendarPermissionPrompt() {
   const calendarUiEnabled = useCalendarUiFlag();

--- a/apps/web/src/features/calendar/use-calendar-ui-flag.test.ts
+++ b/apps/web/src/features/calendar/use-calendar-ui-flag.test.ts
@@ -21,24 +21,38 @@ vi.mock('@core/constant/featureFlags', () => ({
   ENABLE_CALENDAR_UI_OVERRIDE: undefined,
   ENABLE_CALENDAR_PROMPT_MOBILE_FLAG: 'enable-calendar-prompt-mobile',
   ENABLE_CALENDAR_PROMPT_MOBILE_OVERRIDE: undefined,
+  ENABLE_CALENDAR_PROMPT_WEB_FLAG: 'enable-calendar-prompt-web',
+  ENABLE_CALENDAR_PROMPT_WEB_OVERRIDE: undefined,
 }));
 
 import { useCalendarPromptAllowed } from './use-calendar-ui-flag';
 
 describe('useCalendarPromptAllowed', () => {
-  function allowed(state: { mobile: boolean; mobileFlag?: boolean }): boolean {
+  function allowed(state: {
+    mobile: boolean;
+    mobileFlag?: boolean;
+    webFlag?: boolean;
+  }): boolean {
     mocks.mobile = state.mobile;
-    mocks.flags = { 'enable-calendar-prompt-mobile': !!state.mobileFlag };
+    mocks.flags = {
+      'enable-calendar-prompt-mobile': !!state.mobileFlag,
+      'enable-calendar-prompt-web': !!state.webFlag,
+    };
     return useCalendarPromptAllowed()();
   }
 
-  it('allows the prompt on desktop regardless of the mobile flag', () => {
-    expect(allowed({ mobile: false })).toBe(true);
-    expect(allowed({ mobile: false, mobileFlag: true })).toBe(true);
+  it('suppresses the prompt on desktop while the web flag is off', () => {
+    expect(allowed({ mobile: false })).toBe(false);
+    expect(allowed({ mobile: false, mobileFlag: true })).toBe(false);
+  });
+
+  it('allows the prompt on desktop once the web flag is turned on', () => {
+    expect(allowed({ mobile: false, webFlag: true })).toBe(true);
   });
 
   it('suppresses the prompt on mobile while the flag is off', () => {
     expect(allowed({ mobile: true })).toBe(false);
+    expect(allowed({ mobile: true, webFlag: true })).toBe(false);
   });
 
   it('allows the prompt on mobile once the flag is turned on', () => {

--- a/apps/web/src/features/calendar/use-calendar-ui-flag.ts
+++ b/apps/web/src/features/calendar/use-calendar-ui-flag.ts
@@ -2,6 +2,8 @@ import { useFeatureFlag } from '@app/lib/analytics/posthog';
 import {
   ENABLE_CALENDAR_PROMPT_MOBILE_FLAG,
   ENABLE_CALENDAR_PROMPT_MOBILE_OVERRIDE,
+  ENABLE_CALENDAR_PROMPT_WEB_FLAG,
+  ENABLE_CALENDAR_PROMPT_WEB_OVERRIDE,
   ENABLE_CALENDAR_UI_FLAG,
   ENABLE_CALENDAR_UI_OVERRIDE,
 } from '@core/constant/featureFlags';
@@ -16,13 +18,19 @@ export function useCalendarUiFlag(): Accessor<boolean> {
 }
 
 /**
- * Whether the "Enable calendar" prompt may surface on this device. Always true
- * on desktop; on a phone it defers to `enable-calendar-prompt-mobile`, which is
- * off until the mobile toast layout can present the prompt properly.
+ * Whether the "Enable calendar" prompt may surface on this device. Each form
+ * factor has its own kill switch: a phone defers to
+ * `enable-calendar-prompt-mobile`, which is off until the mobile toast layout
+ * can present the prompt properly, and everything else defers to
+ * `enable-calendar-prompt-web`. Both are gated by `enable-calendar-ui` at the
+ * call site.
  */
 export function useCalendarPromptAllowed(): Accessor<boolean> {
   const mobileFlag = useFeatureFlag(ENABLE_CALENDAR_PROMPT_MOBILE_FLAG, {
     enabledOverride: ENABLE_CALENDAR_PROMPT_MOBILE_OVERRIDE,
   });
-  return () => !isMobile() || mobileFlag().enabled;
+  const webFlag = useFeatureFlag(ENABLE_CALENDAR_PROMPT_WEB_FLAG, {
+    enabledOverride: ENABLE_CALENDAR_PROMPT_WEB_OVERRIDE,
+  });
+  return () => (isMobile() ? mobileFlag() : webFlag()).enabled;
 }

--- a/apps/web/src/lib/core/constant/featureFlags.ts
+++ b/apps/web/src/lib/core/constant/featureFlags.ts
@@ -576,3 +576,13 @@ export const ENABLE_CALENDAR_PROMPT_MOBILE_FLAG =
 export const ENABLE_CALENDAR_PROMPT_MOBILE_OVERRIDE = getFeatureFlagOverride(
   'ENABLE_CALENDAR_PROMPT_MOBILE'
 );
+
+// The "Enable calendar" prompt on desktop/web, the counterpart to
+// `enable-calendar-prompt-mobile`. Off by default everywhere, including dev,
+// until the PostHog rollout is raised; Settings › Email keeps a per-inbox
+// "Enable calendar" button, so nothing becomes unreachable while this is off.
+// Override locally with VITE_ENABLE_CALENDAR_PROMPT_WEB=true.
+export const ENABLE_CALENDAR_PROMPT_WEB_FLAG = 'enable-calendar-prompt-web';
+export const ENABLE_CALENDAR_PROMPT_WEB_OVERRIDE = getFeatureFlagOverride(
+  'ENABLE_CALENDAR_PROMPT_WEB'
+);


### PR DESCRIPTION
Puts the desktop/web "Enable calendar" prompt behind `enable-calendar-prompt-web`, the counterpart to the existing `enable-calendar-prompt-mobile`, so each form factor has its own kill switch (`enable-calendar-ui` still gates both at the call site).

Heads up: the flag is at 0% rollout in PostHog and has no dev-mode default, so merging this turns the prompt off for everyone until someone raises the rollout — that's the intended kill-switch shape, but it is a behavior change from today's unconditional-on-desktop. Locally, `VITE_ENABLE_CALENDAR_PROMPT_WEB=true` re-enables it; verified in the browser that the prompt is suppressed with the flag off and renders with the override on.
