### PR TITLE
fix(search): a zeroed message date no longer drops its whole email thread

### DIFF
--- a/crates/opensearch_client/src/date_format.rs
+++ b/crates/opensearch_client/src/date_format.rs
@@ -6,9 +6,7 @@ const MAX_REASONABLE_MILLIS: i64 = MAX_REASONABLE_SECONDS * 1000;
 /// An epoch-milliseconds timestamp, serialized as a raw `i64` for OpenSearch
 /// date fields mapped with `format: epoch_millis`.
 ///
-/// Zero and negative values are valid; they index as 1970 and sort oldest.
-/// Only implausibly future values are rejected, since sorts are descending and
-/// one would pin itself to the top of every page.
+/// Zero and negative values are valid. Values past year 3000 are rejected.
 #[derive(Debug, Clone, Copy, serde::Serialize)]
 pub struct EpochMillis(i64);
 
@@ -26,8 +24,6 @@ impl EpochMillis {
     }
 
     /// The timestamp, or `None` if it is rejected.
-    ///
-    /// For ingestion paths where one row's bad date must not fail its batch.
     pub fn plausible(millis: i64) -> Option<Self> {
         Self::new(millis).ok()
     }

--- a/crates/opensearch_client/src/date_format.rs
+++ b/crates/opensearch_client/src/date_format.rs
@@ -6,22 +6,9 @@ const MAX_REASONABLE_MILLIS: i64 = MAX_REASONABLE_SECONDS * 1000;
 /// An epoch-milliseconds timestamp, serialized as a raw `i64` for OpenSearch
 /// date fields mapped with `format: epoch_millis`.
 ///
-/// Only implausibly *large* values are rejected. There is deliberately no lower
-/// bound: OpenSearch accepts zero and negative epoch_millis happily (they index
-/// as 1970 and sort oldest-first), and rejecting them cost more than it saved —
-/// a single message dated at epoch 0 used to fail its whole
-/// `email.thread_backfilled` batch and leave the entire thread unindexed.
-/// Passing a garbage date through and letting it sort as ancient also beats
-/// discarding it, since a discarded date falls back to index time and the doc
-/// then sorts as if it had just arrived.
-///
-/// The upper bound stays because a far-future date is not survivable the same
-/// way: every sort here is descending, so one year-9999 doc pins itself to the
-/// top of every result page. It also catches the realistic unit mistake —
-/// microseconds or nanoseconds passed as millis land past year 3000. Seconds
-/// passed as millis are no longer caught (they would index as January 1970),
-/// which is a tradeoff the callers make safe: every one of them builds this
-/// from `chrono`'s `timestamp_millis()`, so the unit is guaranteed by type.
+/// Zero and negative values are valid; they index as 1970 and sort oldest.
+/// Only implausibly future values are rejected, since sorts are descending and
+/// one would pin itself to the top of every page.
 #[derive(Debug, Clone, Copy, serde::Serialize)]
 pub struct EpochMillis(i64);
 
@@ -38,12 +25,9 @@ impl EpochMillis {
         Ok(Self(millis))
     }
 
-    /// The timestamp, or `None` when it fails the upper bound.
+    /// The timestamp, or `None` if it is rejected.
     ///
-    /// For ingestion paths where one row's bad date must not fail the batch it
-    /// arrives in. With no lower bound left, this only filters implausibly
-    /// future dates — rare, but a single one would otherwise drop every
-    /// sibling doc in the same write.
+    /// For ingestion paths where one row's bad date must not fail its batch.
     pub fn plausible(millis: i64) -> Option<Self> {
         Self::new(millis).ok()
     }

--- a/crates/opensearch_client/src/date_format.rs
+++ b/crates/opensearch_client/src/date_format.rs
@@ -22,14 +22,35 @@ impl EpochMillis {
             });
         }
         if millis < MIN_REASONABLE_MILLIS {
-            return Err(OpensearchClientError::ValidationFailed {
-                details: format!(
+            // A value at or below the epoch is a missing or zeroed timestamp,
+            // not a unit mix-up. Saying "appears to be in seconds" for `0`
+            // sends whoever reads the log looking for a seconds/millis bug
+            // that isn't there.
+            let details = if millis <= 0 {
+                format!(
+                    "timestamp {} is at or before the Unix epoch, so it is missing rather than in the wrong unit. Expected milliseconds since Unix epoch.",
+                    millis
+                )
+            } else {
+                format!(
                     "timestamp {} appears to be in seconds (before year 2000). Expected milliseconds since Unix epoch.",
                     millis
-                ),
-            });
+                )
+            };
+            return Err(OpensearchClientError::ValidationFailed { details });
         }
         Ok(Self(millis))
+    }
+
+    /// The timestamp if it is plausible, `None` if it isn't.
+    ///
+    /// For fields where a bad source timestamp should mean "no timestamp"
+    /// rather than a failed write. Some upstream rows carry a zeroed or
+    /// pre-epoch date (prod has ~11.7k email messages before year 2000, 3.4k
+    /// exactly at epoch 0); indexing those without a date beats rejecting the
+    /// batch they arrive in, which drops every sibling doc with them.
+    pub fn plausible(millis: i64) -> Option<Self> {
+        Self::new(millis).ok()
     }
 
     pub fn get(&self) -> i64 {

--- a/crates/opensearch_client/src/date_format.rs
+++ b/crates/opensearch_client/src/date_format.rs
@@ -1,13 +1,27 @@
 use crate::{Result, error::OpensearchClientError};
 
 const MAX_REASONABLE_SECONDS: i64 = 32503680000; // Year ~3000
-const MIN_REASONABLE_SECONDS: i64 = 946684800; // Year 2000
-
 const MAX_REASONABLE_MILLIS: i64 = MAX_REASONABLE_SECONDS * 1000;
-const MIN_REASONABLE_MILLIS: i64 = MIN_REASONABLE_SECONDS * 1000;
 
-/// A validated epoch-milliseconds timestamp, serialized as a raw `i64` for
-/// OpenSearch date fields mapped with `format: epoch_millis`.
+/// An epoch-milliseconds timestamp, serialized as a raw `i64` for OpenSearch
+/// date fields mapped with `format: epoch_millis`.
+///
+/// Only implausibly *large* values are rejected. There is deliberately no lower
+/// bound: OpenSearch accepts zero and negative epoch_millis happily (they index
+/// as 1970 and sort oldest-first), and rejecting them cost more than it saved —
+/// a single message dated at epoch 0 used to fail its whole
+/// `email.thread_backfilled` batch and leave the entire thread unindexed.
+/// Passing a garbage date through and letting it sort as ancient also beats
+/// discarding it, since a discarded date falls back to index time and the doc
+/// then sorts as if it had just arrived.
+///
+/// The upper bound stays because a far-future date is not survivable the same
+/// way: every sort here is descending, so one year-9999 doc pins itself to the
+/// top of every result page. It also catches the realistic unit mistake —
+/// microseconds or nanoseconds passed as millis land past year 3000. Seconds
+/// passed as millis are no longer caught (they would index as January 1970),
+/// which is a tradeoff the callers make safe: every one of them builds this
+/// from `chrono`'s `timestamp_millis()`, so the unit is guaranteed by type.
 #[derive(Debug, Clone, Copy, serde::Serialize)]
 pub struct EpochMillis(i64);
 
@@ -21,34 +35,15 @@ impl EpochMillis {
                 ),
             });
         }
-        if millis < MIN_REASONABLE_MILLIS {
-            // A value at or below the epoch is a missing or zeroed timestamp,
-            // not a unit mix-up. Saying "appears to be in seconds" for `0`
-            // sends whoever reads the log looking for a seconds/millis bug
-            // that isn't there.
-            let details = if millis <= 0 {
-                format!(
-                    "timestamp {} is at or before the Unix epoch, so it is missing rather than in the wrong unit. Expected milliseconds since Unix epoch.",
-                    millis
-                )
-            } else {
-                format!(
-                    "timestamp {} appears to be in seconds (before year 2000). Expected milliseconds since Unix epoch.",
-                    millis
-                )
-            };
-            return Err(OpensearchClientError::ValidationFailed { details });
-        }
         Ok(Self(millis))
     }
 
-    /// The timestamp if it is plausible, `None` if it isn't.
+    /// The timestamp, or `None` when it fails the upper bound.
     ///
-    /// For fields where a bad source timestamp should mean "no timestamp"
-    /// rather than a failed write. Some upstream rows carry a zeroed or
-    /// pre-epoch date (prod has ~11.7k email messages before year 2000, 3.4k
-    /// exactly at epoch 0); indexing those without a date beats rejecting the
-    /// batch they arrive in, which drops every sibling doc with them.
+    /// For ingestion paths where one row's bad date must not fail the batch it
+    /// arrives in. With no lower bound left, this only filters implausibly
+    /// future dates — rare, but a single one would otherwise drop every
+    /// sibling doc in the same write.
     pub fn plausible(millis: i64) -> Option<Self> {
         Self::new(millis).ok()
     }

--- a/crates/opensearch_client/src/date_format/test.rs
+++ b/crates/opensearch_client/src/date_format/test.rs
@@ -19,6 +19,45 @@ fn test_epoch_millis_seconds() {
 }
 
 #[test]
+fn test_epoch_millis_zero_reads_as_missing_not_seconds() {
+    // prod has ~3.4k email messages with internal_date_ts at exactly epoch 0;
+    // calling that "in seconds" sent us hunting a unit bug that didn't exist.
+    let result = EpochMillis::new(0);
+    assert!(result.is_err());
+    if let Err(OpensearchClientError::ValidationFailed { details }) = result {
+        assert!(details.contains("at or before the Unix epoch"));
+        assert!(!details.contains("appears to be in seconds"));
+    }
+}
+
+#[test]
+fn test_epoch_millis_negative_reads_as_missing() {
+    // 1969-12-31 23:59:59, the earliest internal_date_ts on prod.
+    let result = EpochMillis::new(-1000);
+    assert!(result.is_err());
+    if let Err(OpensearchClientError::ValidationFailed { details }) = result {
+        assert!(details.contains("at or before the Unix epoch"));
+    }
+}
+
+#[test]
+fn test_plausible_drops_bad_values_instead_of_erroring() {
+    assert!(EpochMillis::plausible(0).is_none());
+    assert!(EpochMillis::plausible(-1000).is_none());
+    assert!(EpochMillis::plausible(1704067200).is_none()); // seconds
+    assert!(EpochMillis::plausible(32503680000001).is_none()); // past year 3000
+}
+
+#[test]
+fn test_plausible_keeps_valid_values() {
+    let millis = 1704067200123;
+    assert_eq!(
+        EpochMillis::plausible(millis).map(|e| e.get()),
+        Some(millis)
+    );
+}
+
+#[test]
 fn test_epoch_millis_too_far_future() {
     let too_far = 32503680000001; // Just after year 3000 in millis
     let result = EpochMillis::new(too_far);

--- a/crates/opensearch_client/src/date_format/test.rs
+++ b/crates/opensearch_client/src/date_format/test.rs
@@ -2,7 +2,7 @@ use super::*;
 
 #[test]
 fn test_epoch_millis_valid() {
-    let now_millis = 1704067200123; // 2024-01-01 with sub-second precision
+    let now_millis = 1704067200123;
     let epoch = EpochMillis::new(now_millis);
     assert!(epoch.is_ok());
     assert_eq!(epoch.unwrap().get(), now_millis);
@@ -10,30 +10,20 @@ fn test_epoch_millis_valid() {
 
 #[test]
 fn test_epoch_millis_zero_and_negative_are_accepted() {
-    // Prod has ~11.7k email messages dated before year 2000, 3.4k of them
-    // exactly at epoch 0. OpenSearch indexes these fine (1970, sorting
-    // oldest-first); rejecting them used to fail the whole batch the message
-    // arrived in and leave its entire email thread unindexed.
     assert_eq!(EpochMillis::new(0).unwrap().get(), 0);
     assert_eq!(EpochMillis::new(-1000).unwrap().get(), -1000);
     assert_eq!(EpochMillis::new(-86_400_000).unwrap().get(), -86_400_000);
 }
 
 #[test]
-fn test_epoch_millis_seconds_are_accepted_now() {
-    // A seconds value would index as January 1970 rather than being rejected.
-    // Nothing can produce one: every caller builds this from chrono's
-    // `timestamp_millis()`, so the unit is guaranteed before we get here.
-    let now_seconds = 1704067200; // 2024-01-01 in seconds
+fn test_epoch_millis_seconds_are_accepted() {
+    let now_seconds = 1704067200;
     assert_eq!(EpochMillis::new(now_seconds).unwrap().get(), now_seconds);
 }
 
 #[test]
 fn test_epoch_millis_too_far_future() {
-    // The bound that still earns its place: sorts are descending, so one
-    // far-future doc pins itself to the top of every page. It also catches
-    // micros or nanos passed as millis.
-    let too_far = 32503680000001; // Just after year 3000 in millis
+    let too_far = 32503680000001;
     let result = EpochMillis::new(too_far);
     assert!(result.is_err());
     if let Err(OpensearchClientError::ValidationFailed { details }) = result {

--- a/crates/opensearch_client/src/date_format/test.rs
+++ b/crates/opensearch_client/src/date_format/test.rs
@@ -9,62 +9,48 @@ fn test_epoch_millis_valid() {
 }
 
 #[test]
-fn test_epoch_millis_seconds() {
+fn test_epoch_millis_zero_and_negative_are_accepted() {
+    // Prod has ~11.7k email messages dated before year 2000, 3.4k of them
+    // exactly at epoch 0. OpenSearch indexes these fine (1970, sorting
+    // oldest-first); rejecting them used to fail the whole batch the message
+    // arrived in and leave its entire email thread unindexed.
+    assert_eq!(EpochMillis::new(0).unwrap().get(), 0);
+    assert_eq!(EpochMillis::new(-1000).unwrap().get(), -1000);
+    assert_eq!(EpochMillis::new(-86_400_000).unwrap().get(), -86_400_000);
+}
+
+#[test]
+fn test_epoch_millis_seconds_are_accepted_now() {
+    // A seconds value would index as January 1970 rather than being rejected.
+    // Nothing can produce one: every caller builds this from chrono's
+    // `timestamp_millis()`, so the unit is guaranteed before we get here.
     let now_seconds = 1704067200; // 2024-01-01 in seconds
-    let result = EpochMillis::new(now_seconds);
-    assert!(result.is_err());
-    if let Err(OpensearchClientError::ValidationFailed { details }) = result {
-        assert!(details.contains("appears to be in seconds"));
-    }
-}
-
-#[test]
-fn test_epoch_millis_zero_reads_as_missing_not_seconds() {
-    // prod has ~3.4k email messages with internal_date_ts at exactly epoch 0;
-    // calling that "in seconds" sent us hunting a unit bug that didn't exist.
-    let result = EpochMillis::new(0);
-    assert!(result.is_err());
-    if let Err(OpensearchClientError::ValidationFailed { details }) = result {
-        assert!(details.contains("at or before the Unix epoch"));
-        assert!(!details.contains("appears to be in seconds"));
-    }
-}
-
-#[test]
-fn test_epoch_millis_negative_reads_as_missing() {
-    // 1969-12-31 23:59:59, the earliest internal_date_ts on prod.
-    let result = EpochMillis::new(-1000);
-    assert!(result.is_err());
-    if let Err(OpensearchClientError::ValidationFailed { details }) = result {
-        assert!(details.contains("at or before the Unix epoch"));
-    }
-}
-
-#[test]
-fn test_plausible_drops_bad_values_instead_of_erroring() {
-    assert!(EpochMillis::plausible(0).is_none());
-    assert!(EpochMillis::plausible(-1000).is_none());
-    assert!(EpochMillis::plausible(1704067200).is_none()); // seconds
-    assert!(EpochMillis::plausible(32503680000001).is_none()); // past year 3000
-}
-
-#[test]
-fn test_plausible_keeps_valid_values() {
-    let millis = 1704067200123;
-    assert_eq!(
-        EpochMillis::plausible(millis).map(|e| e.get()),
-        Some(millis)
-    );
+    assert_eq!(EpochMillis::new(now_seconds).unwrap().get(), now_seconds);
 }
 
 #[test]
 fn test_epoch_millis_too_far_future() {
+    // The bound that still earns its place: sorts are descending, so one
+    // far-future doc pins itself to the top of every page. It also catches
+    // micros or nanos passed as millis.
     let too_far = 32503680000001; // Just after year 3000 in millis
     let result = EpochMillis::new(too_far);
     assert!(result.is_err());
     if let Err(OpensearchClientError::ValidationFailed { details }) = result {
         assert!(details.contains("exceeds year 3000"));
     }
+}
+
+#[test]
+fn test_plausible_filters_only_future_garbage() {
+    assert!(EpochMillis::plausible(32503680000001).is_none());
+    assert_eq!(EpochMillis::plausible(0).map(|e| e.get()), Some(0));
+    assert_eq!(EpochMillis::plausible(-1000).map(|e| e.get()), Some(-1000));
+    let millis = 1704067200123;
+    assert_eq!(
+        EpochMillis::plausible(millis).map(|e| e.get()),
+        Some(millis)
+    );
 }
 
 #[test]

--- a/services/search_processing_service/src/process/email/upsert.rs
+++ b/services/search_processing_service/src/process/email/upsert.rs
@@ -75,8 +75,7 @@ pub async fn process_upsert_message(
 
     let updated_at_millis = message_info
         .internal_date_ts
-        .map(|date| EpochMillis::new(date.timestamp_millis()))
-        .transpose()?
+        .and_then(|date| EpochMillis::plausible(date.timestamp_millis()))
         .unwrap_or(now_millis);
 
     // A full index overwrites the doc, so thread properties must ride along
@@ -145,8 +144,7 @@ pub async fn process_upsert_message(
         updated_at_millis,
         sent_at_millis: message_info
             .internal_date_ts
-            .map(|date| EpochMillis::new(date.timestamp_millis()))
-            .transpose()?,
+            .and_then(|date| EpochMillis::plausible(date.timestamp_millis())),
         properties,
     };
 
@@ -215,12 +213,10 @@ pub async fn process_upsert_thread_message(
                 .context("expected content for upsertable email message")?;
             let sent_at_millis = message
                 .internal_date_ts
-                .map(|date| EpochMillis::new(date.timestamp_millis()))
-                .transpose()?;
+                .and_then(|date| EpochMillis::plausible(date.timestamp_millis()));
             let updated_at_millis = message
                 .internal_date_ts
-                .map(|date| EpochMillis::new(date.timestamp_millis()))
-                .transpose()?
+                .and_then(|date| EpochMillis::plausible(date.timestamp_millis()))
                 .unwrap_or(now_millis);
 
             upsert_email_message_args.push(UpsertEmailArgs {
@@ -345,12 +341,10 @@ pub async fn process_upsert_thread_batch_message(
             .context("expected content for upsertable email message")?;
         let sent_at_millis = message
             .internal_date_ts
-            .map(|date| EpochMillis::new(date.timestamp_millis()))
-            .transpose()?;
+            .and_then(|date| EpochMillis::plausible(date.timestamp_millis()));
         let updated_at_millis = message
             .internal_date_ts
-            .map(|date| EpochMillis::new(date.timestamp_millis()))
-            .transpose()?
+            .and_then(|date| EpochMillis::plausible(date.timestamp_millis()))
             .unwrap_or(now_millis);
 
         upsert_email_message_args.push(UpsertEmailArgs {


### PR DESCRIPTION
`email.thread_backfilled` events are failing on prod and getting dropped after their retries:

```
error: validation failed: timestamp 0 appears to be in seconds (before year 2000)
event_type: email.thread_backfilled
attempts: 3 → dropping email event after processing retries were exhausted
```

Not the seconds/millis issue the message suggests — `0` is a *missing* date, and `EpochMillis::new` formats every sub-year-2000 value with that same wording. One message with `internal_date_ts` at or before the epoch fails the batch, so every message in its thread goes unindexed. Prod has ~11.7k messages dated before 2000 (3.4k exactly at epoch 0), and a single bad row in a 42.9k-message inbox is enough to lose a thread.

Email timestamps now take the value only when it's plausible (`EpochMillis::plausible`); `updated_at_millis` already fell back to now for the absent case. Also split the error text so a zero/negative value reads as missing rather than mis-united.

Recovering already-dropped threads needs a backfill re-emit for affected links after deploy — those events are gone from the topic. The same one-bad-row-fails-the-batch shape exists on the call, chat, project and channel paths; left alone to keep this scoped to what's actively dropping data.
