### PR TITLE
Add hover explainer panel to create menu

### DIFF
--- a/apps/web/src/features/command/sidebar/create-menu-explainer.tsx
+++ b/apps/web/src/features/command/sidebar/create-menu-explainer.tsx
@@ -1,0 +1,126 @@
+import type { CreatableBlock } from '@app/features/command/types';
+import { getIconConfig } from '@core/component/EntityIcon';
+import {
+  autoUpdate,
+  computePosition,
+  flip,
+  offset,
+  shift,
+} from '@floating-ui/dom';
+import { cn, Hotkey, Surface } from '@ui';
+import {
+  createEffect,
+  createMemo,
+  createSignal,
+  onCleanup,
+  Show,
+} from 'solid-js';
+import { Dynamic, Portal } from 'solid-js/web';
+import { CREATE_MENU_EXPLAINERS } from './create-menu-explainers';
+
+/** Gap between the hovered row and the explainer panel. */
+const ANCHOR_GAP_PX = 14;
+/** Keeps the panel clear of the viewport edges when it has to shift or flip. */
+const VIEWPORT_PADDING_PX = 12;
+
+/**
+ * The secondary panel that opens beside the create menu, explaining whichever
+ * item is currently hovered or keyboard-focused.
+ *
+ * It is not a Kobalte submenu: sub-triggers can't also be selectable items, and
+ * every row here has to stay clickable. Instead it's a portaled, pointer-inert
+ * panel anchored to the active row — so it can't intercept clicks or trip the
+ * menu's outside-interaction dismissal, and it follows keyboard navigation as
+ * well as the pointer.
+ */
+export function CreateMenuExplainer(props: {
+  /** The row the panel points at — undefined when nothing is active. */
+  anchor: HTMLElement | undefined;
+  /** The block that row creates. */
+  block: CreatableBlock | undefined;
+}) {
+  const [panel, setPanel] = createSignal<HTMLElement>();
+  // Floating UI resolves asynchronously, so hold the panel transparent until it
+  // has a real position — otherwise it flashes in the viewport's top-left.
+  // Tracked as the element that was placed, not a boolean, so a freshly
+  // mounted panel doesn't inherit the previous one's "already placed" state.
+  const [placedPanel, setPlacedPanel] = createSignal<HTMLElement>();
+  const placed = () => panel() !== undefined && placedPanel() === panel();
+
+  const explainer = createMemo(() => {
+    const token = props.block?.hotkeyToken;
+    return token ? CREATE_MENU_EXPLAINERS[token] : undefined;
+  });
+
+  createEffect(() => {
+    const anchor = props.anchor;
+    const el = panel();
+    if (!anchor || !el) return;
+
+    onCleanup(
+      autoUpdate(anchor, el, () => {
+        void computePosition(anchor, el, {
+          strategy: 'fixed',
+          placement: 'right-start',
+          middleware: [
+            offset(ANCHOR_GAP_PX),
+            flip({ fallbackPlacements: ['left-start'] }),
+            shift({ padding: VIEWPORT_PADDING_PX }),
+          ],
+        }).then(({ x, y }) => {
+          el.style.translate = `${x}px ${y}px`;
+          setPlacedPanel(el);
+        });
+      })
+    );
+  });
+
+  return (
+    <Show when={explainer()}>
+      {(content) => (
+        <Portal>
+          <div
+            ref={setPanel}
+            aria-hidden="true"
+            class="fixed top-0 left-0 z-action-menu w-72 max-w-[calc(100vw-24px)] pointer-events-none transition-opacity duration-100"
+            style={{ opacity: placed() ? 1 : 0 }}
+          >
+            <Surface
+              depth={3}
+              class="flex flex-col gap-2 rounded-xl bg-menu p-3 shadow-menu"
+            >
+              <div class="flex items-center gap-2">
+                <Show when={props.block}>
+                  {(block) => (
+                    <div
+                      class={cn(
+                        'size-4 shrink-0 flex items-center [&_svg]:size-4',
+                        getIconConfig(block().blockName).foreground
+                      )}
+                    >
+                      <Dynamic component={block().icon} />
+                    </div>
+                  )}
+                </Show>
+                <span class="text-[13px] font-medium text-ink">
+                  {content().title}
+                </span>
+              </div>
+              <p class="text-xs leading-relaxed text-ink-muted">
+                {content().body}
+              </p>
+              <Show when={props.block?.altHotkeyToken}>
+                {(token) => (
+                  <div class="flex items-center gap-1.5 text-xxs text-ink-extra-muted">
+                    <Hotkey token={token()} theme="subtle" class="flex gap-1" />
+                    <span>Open in a new split</span>
+                  </div>
+                )}
+              </Show>
+            </Surface>
+          </div>
+        </Portal>
+      )}
+    </Show>
+  );
+}

--- a/apps/web/src/features/command/sidebar/create-menu-explainers.ts
+++ b/apps/web/src/features/command/sidebar/create-menu-explainers.ts
@@ -1,0 +1,66 @@
+import { type HotkeyToken, TOKENS } from '@core/hotkey/tokens';
+
+/**
+ * Copy for the create menu's hover explainer — the secondary panel that opens
+ * beside whichever item is hovered or keyboard-focused.
+ *
+ * Kept out of `CREATABLE_BLOCKS` (which is shared with the command palette,
+ * the mobile dock, and the global hotkey table, all of which show only the
+ * terse `description`) so the longer product copy lives in one place.
+ */
+export type CreateMenuExplainer = {
+  /** What the item produces, phrased as the outcome. */
+  title: string;
+  /** One or two sentences on what the block is for. */
+  body: string;
+};
+
+/**
+ * Keyed by the block's create hotkey token — the only field on a
+ * `CreatableBlock` that is unique per item (`blockName` is not: Message and
+ * Channel are both `channel`).
+ */
+export const CREATE_MENU_EXPLAINERS: Partial<
+  Record<HotkeyToken, CreateMenuExplainer>
+> = {
+  [TOKENS.create.email]: {
+    title: 'Draft an email',
+    body: 'Compose from any of your linked Gmail accounts, with threads syncing both ways. Signal/Noise filtering keeps the inbox quiet, and an agent can draft or send for you.',
+  },
+  [TOKENS.create.chat]: {
+    title: 'Start an agent chat',
+    body: 'Ask a question against your whole workspace — email, tasks, docs, calls, and channels. Agents can draft, create tasks, post in channels, and run on a schedule, always bounded by your permissions.',
+  },
+  [TOKENS.create.note]: {
+    title: 'Write a document',
+    body: 'Markdown-native, real-time collaborative, and @linked to everything else you work on. Organize docs in folders and add tags to filter them like a database.',
+  },
+  [TOKENS.create.task]: {
+    title: 'Track a piece of work',
+    body: 'Just status, priority, and assignee — no extra labels to maintain. Tasks are @mentionable anywhere as live pills, sync bidirectionally with GitHub pull requests, and are readable by AI clients over MCP.',
+  },
+  [TOKENS.create.snippet]: {
+    title: 'Save reusable text',
+    body: 'A full markdown document you can drop into anything you write — type ";" in any markdown area to insert it. Edit the snippet and every future insertion picks up the change.',
+  },
+  [TOKENS.create.message]: {
+    title: 'Message someone',
+    body: 'Pick people by name or email and send; Macro opens the direct or group conversation for you. Anything you @mention is shared with everyone in the conversation.',
+  },
+  [TOKENS.create.channel]: {
+    title: 'Open a channel',
+    body: 'A hub for a topic, project, or team, with threaded replies to keep discussions separate. Anyone can be added by email — people without a Macro account get their notifications by email.',
+  },
+  [TOKENS.create.canvas]: {
+    title: 'Map something out',
+    body: 'An infinite board for diagrams and mind maps, with shapes, connectors, and freehand drawing. Place live @mentions of real tasks, docs, emails, and calls right on it.',
+  },
+  [TOKENS.create.project]: {
+    title: 'Organize your files',
+    body: 'Group docs, PDFs, images, videos, code files, and canvases in one place. Channel and email attachments land in your workspace automatically, and everything stays searchable.',
+  },
+  [TOKENS.create.code]: {
+    title: 'Add a code file',
+    body: 'A syntax-highlighted file that shares, embeds, and @mentions like any other block. Starts out as Python.',
+  },
+};

--- a/apps/web/src/features/command/sidebar/sidebar-create-menu.tsx
+++ b/apps/web/src/features/command/sidebar/sidebar-create-menu.tsx
@@ -11,11 +11,20 @@ import {
 import { setActiveScope } from '@core/hotkey/state';
 import { TOKENS } from '@core/hotkey/tokens';
 import { activateClosestDOMScope } from '@core/hotkey/utils';
+import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import CreateIcon from '@icon/square-pen-create.svg';
 import PlusIcon from '@phosphor/plus.svg';
 import { Button, cn, Dropdown, Hotkey, NavRow } from '@ui';
-import { createMemo, createSignal, For, onCleanup, Show } from 'solid-js';
+import {
+  createEffect,
+  createMemo,
+  createSignal,
+  For,
+  onCleanup,
+  Show,
+} from 'solid-js';
 import { Dynamic } from 'solid-js/web';
+import { CreateMenuExplainer } from './create-menu-explainer';
 
 export const SidebarCreateMenu = (props: {
   isSlim: () => boolean;
@@ -25,6 +34,10 @@ export const SidebarCreateMenu = (props: {
   const analytics = useAnalytics();
   const [open, setOpen] = createSignal(false);
   const [focusedIndex, setFocusedIndex] = createSignal(-1);
+  // The row the explainer panel points at. Tracked alongside `focusedIndex`
+  // rather than derived from it so the panel can anchor to the real element,
+  // whether it became active by pointer or by keyboard.
+  const [focusedRow, setFocusedRow] = createSignal<HTMLElement>();
   const snippetsFlag = useFeatureFlag(ENABLE_SNIPPETS_FLAG, {
     enabledOverride: ENABLE_SNIPPETS_OVERRIDE,
   });
@@ -34,6 +47,26 @@ export const SidebarCreateMenu = (props: {
       (block) => block.blockName !== 'snippet' || snippetsFlag().enabled
     )
   );
+
+  const focusedBlock = createMemo(() => blocks()[focusedIndex()]);
+
+  const focusRow = (index: number, row: HTMLElement | undefined) => {
+    setFocusedIndex(index);
+    setFocusedRow(row);
+  };
+
+  const clearFocusedRow = () => {
+    setFocusedIndex(-1);
+    setFocusedRow(undefined);
+  };
+
+  // Closing also happens outside `handleOpenChange` — the hotkey interceptor and
+  // `onSelect` call `setOpen(false)` directly — so drop the focused row from the
+  // open state itself. Otherwise reopening would briefly anchor the explainer to
+  // the previous row's now-detached element.
+  createEffect(() => {
+    if (!open()) clearFocusedRow();
+  });
 
   const handleOpenChange = (nextOpen: boolean) => {
     if (nextOpen && !open()) {
@@ -135,16 +168,23 @@ export const SidebarCreateMenu = (props: {
         </Dropdown.Trigger>
       </Show>
       <Dropdown.Content class="min-w-52 shadow-menu">
-        <Dropdown.Group>
+        <Dropdown.Group onMouseLeave={clearFocusedRow}>
           <For each={blocks()}>
             {(block, index) => {
               const iconConfig = getIconConfig(block.blockName);
+              // Captured per row so the explainer can anchor to this element
+              // without indexing into a shared array that goes stale when the
+              // list changes (the snippets flag adds/removes an item).
+              let row: HTMLElement | undefined;
 
               return (
                 <Dropdown.Item
+                  ref={(el: HTMLElement) => {
+                    row = el;
+                  }}
                   class="min-h-9 gap-2 px-2.5"
-                  onFocus={() => setFocusedIndex(index())}
-                  onMouseEnter={() => setFocusedIndex(index())}
+                  onFocus={() => focusRow(index(), row)}
+                  onMouseEnter={() => focusRow(index(), row)}
                   onSelect={() => {
                     setOpen(false);
                     block.keyDownHandler();
@@ -172,6 +212,10 @@ export const SidebarCreateMenu = (props: {
             }}
           </For>
         </Dropdown.Group>
+        {/* Hover-driven, so pointer-only — there is nothing to hover on touch. */}
+        <Show when={!isTouchDevice()}>
+          <CreateMenuExplainer anchor={focusedRow()} block={focusedBlock()} />
+        </Show>
       </Dropdown.Content>
     </Dropdown>
   );


### PR DESCRIPTION
## Summary
Adds a secondary informational panel to the create menu that displays when users hover over or keyboard-navigate to menu items. The panel provides detailed descriptions of what each creatable block does, helping users understand the purpose of each option.

## Key Changes
- **New component `CreateMenuExplainer`**: A portaled panel that anchors to the currently focused/hovered menu row and displays detailed copy about that block. Uses Floating UI for intelligent positioning with fallback placement and viewport padding.
- **New explainer content file**: `CREATE_MENU_EXPLAINERS` constant mapping hotkey tokens to title and body copy for each creatable block type (email, chat, note, task, snippet, message, channel, canvas, project, code).
- **Updated `SidebarCreateMenu`**: 
  - Tracks the focused row element alongside the focused index to enable accurate panel anchoring
  - Clears focus state when menu closes to prevent stale element references
  - Passes anchor and block data to the explainer component
  - Hides explainer on touch devices (pointer-only feature)
  - Captures row refs per item to maintain stable element references as the list changes

## Implementation Details
- The explainer is not a Kobalte submenu to avoid conflicts with item selectability and click handling
- Panel uses `pointer-events-none` to prevent interfering with menu interactions
- Opacity transition hides the panel until Floating UI has computed its position, preventing flash artifacts
- Focus tracking distinguishes between pointer and keyboard navigation by storing the actual element reference
- Touch device detection prevents showing the explainer on devices without hover capability

https://claude.ai/code/session_01Dssuns1YheqzqZuhWyBSHk