### PR TITLE
fix(web): preserve soup rows with a Solid store

### DIFF
--- a/apps/web/src/features/next-soup/create-soup-state.test.ts
+++ b/apps/web/src/features/next-soup/create-soup-state.test.ts
@@ -1,4 +1,5 @@
-import { createRoot } from 'solid-js';
+import { createComputed, createRoot } from 'solid-js';
+import { unwrap } from 'solid-js/store';
 import { describe, expect, it, vi } from 'vitest';
 
 // Mock external dependencies
@@ -25,7 +26,11 @@ vi.mock('@core/component/EntityIcon', () => ({
 }));
 
 import type { EntityData } from '@entity';
-import { createSoupState } from './create-soup-state';
+import {
+  createSoupState,
+  type GroupMeta,
+  type SoupState,
+} from './create-soup-state';
 
 const createTestEntity = (id: string, name?: string): EntityData => ({
   id,
@@ -34,6 +39,36 @@ const createTestEntity = (id: string, name?: string): EntityData => ({
   ownerId: 'test-owner',
   updatedAt: new Date(),
 });
+
+const createTestGroup = (key: string, count: number): GroupMeta => ({
+  key,
+  label: key,
+  value: key,
+  count,
+  isExpanded: () => true,
+  toggle: () => {},
+});
+
+const buildTestRow = (
+  state: SoupState,
+  original: EntityData,
+  index: number,
+  group?: GroupMeta,
+  kind: 'entity' | 'header' | 'load-more' = 'entity'
+) =>
+  state.buildRow({
+    id:
+      kind === 'header'
+        ? `header:${group?.key}`
+        : kind === 'load-more'
+          ? `loadmore:${group?.key}`
+          : original.id,
+    index,
+    original,
+    group,
+    isGrouped: kind === 'header',
+    isLoadMore: kind === 'load-more',
+  });
 
 describe('createSoupState', () => {
   describe('initial state', () => {
@@ -83,6 +118,115 @@ describe('createSoupState', () => {
         dispose();
       });
     });
+
+    it('preserves a row proxy while updating its entity reactively', () => {
+      createRoot((dispose) => {
+        const state = createSoupState();
+        const before = createTestEntity('1', 'Before');
+        const second = createTestEntity('2', 'Second');
+        state.setRows([
+          state.buildRow({ id: before.id, index: 0, original: before }),
+          state.buildRow({ id: second.id, index: 1, original: second }),
+        ]);
+
+        const storedRow = state.rows()[0];
+        const secondStoredRow = state.rows()[1];
+        state.focus.set('1');
+        const observedNames: string[] = [];
+        let rowUpdates = 0;
+        createComputed(() => {
+          observedNames.push(storedRow.original.name);
+        });
+        createComputed(() => {
+          state.rows();
+          rowUpdates += 1;
+        });
+
+        const after = createTestEntity('1', 'After');
+        state.setRows([
+          state.buildRow({
+            id: second.id,
+            index: 0,
+            original: createTestEntity('2', 'Second'),
+          }),
+          state.buildRow({ id: after.id, index: 1, original: after }),
+        ]);
+
+        expect(state.rows()[0]).toBe(secondStoredRow);
+        expect(state.rows()[1]).toBe(storedRow);
+        expect(storedRow.index).toBe(1);
+        expect(storedRow.isFocused()).toBe(true);
+        expect(state.focus.index()).toBe(1);
+        expect(storedRow.original.name).toBe('After');
+        expect(observedNames).toEqual(['Before', 'After']);
+        expect(rowUpdates).toBe(2);
+
+        dispose();
+      });
+    });
+
+    it('uses composite identities for task moves and structural rows', () => {
+      createRoot((dispose) => {
+        const state = createSoupState();
+        const groupA = createTestGroup('a', 2);
+        const groupB = createTestGroup('b', 1);
+        const staysInA = createTestEntity('stays-a');
+        const moved = createTestEntity('moved');
+        const staysInB = createTestEntity('stays-b');
+
+        state.setRows([
+          buildTestRow(state, staysInA, 0, groupA, 'header'),
+          buildTestRow(state, staysInA, 1, groupA),
+          buildTestRow(state, moved, 2, groupA),
+          buildTestRow(state, staysInB, 3, groupB, 'header'),
+          buildTestRow(state, staysInB, 4, groupB),
+          buildTestRow(state, staysInB, 5, groupB, 'load-more'),
+        ]);
+
+        const [headerA, , movedInA, headerB, staysInBRow, loadMoreB] =
+          state.rows();
+        const staysInARow = state.rows()[1];
+        const nextGroupA = createTestGroup('a', 1);
+        const nextGroupB = createTestGroup('b', 2);
+        const movedAfterUpdate = createTestEntity('moved');
+
+        state.setRows([
+          buildTestRow(
+            state,
+            createTestEntity('stays-a'),
+            0,
+            nextGroupA,
+            'header'
+          ),
+          buildTestRow(state, createTestEntity('stays-a'), 1, nextGroupA),
+          buildTestRow(state, movedAfterUpdate, 2, nextGroupB, 'header'),
+          buildTestRow(state, movedAfterUpdate, 3, nextGroupB),
+          buildTestRow(state, createTestEntity('stays-b'), 4, nextGroupB),
+          buildTestRow(
+            state,
+            createTestEntity('stays-b'),
+            5,
+            nextGroupB,
+            'load-more'
+          ),
+        ]);
+
+        expect(state.rows()[0]).toBe(headerA);
+        expect(state.rows()[0].group?.count).toBe(1);
+        expect(state.rows()[1]).toBe(staysInARow);
+        expect(state.rows()[1].index).toBe(1);
+        expect(state.rows()[2]).not.toBe(headerB);
+        expect(state.rows()[2].original.id).toBe('moved');
+        expect(state.rows()[2].group?.count).toBe(2);
+        expect(state.rows()[3]).not.toBe(movedInA);
+        expect(state.rows()[4]).toBe(staysInBRow);
+        expect(state.rows()[4].original.id).toBe('stays-b');
+        expect(state.rows()[5]).toBe(loadMoreB);
+        expect(state.rows()[5].group?.count).toBe(2);
+
+        dispose();
+      });
+    });
   });
 
   describe('items', () => {
@@ -97,8 +241,8 @@ describe('createSoupState', () => {
           )
         );
 
-        expect(state.items.get('1')?.original).toBe(entity1);
-        expect(state.items.get('2')?.original).toBe(entity2);
+        expect(unwrap(state.items.get('1')?.original)).toBe(entity1);
+        expect(unwrap(state.items.get('2')?.original)).toBe(entity2);
         expect(state.items.get('nonexistent')).toBeUndefined();
 
         dispose();
@@ -113,8 +257,8 @@ describe('createSoupState', () => {
           initialData: [entity1, entity2],
         });
 
-        expect(state.items.at(0)?.original).toBe(entity1);
-        expect(state.items.at(1)?.original).toBe(entity2);
+        expect(unwrap(state.items.at(0)?.original)).toBe(entity1);
+        expect(unwrap(state.items.at(1)?.original)).toBe(entity2);
         expect(state.items.at(99)).toBeUndefined();
 
         dispose();
@@ -159,7 +303,7 @@ describe('createSoupState', () => {
         state.focus.set('1');
 
         expect(state.focus.id()).toBe('1');
-        expect(state.focus.item()).toBe(entity);
+        expect(unwrap(state.focus.item())).toBe(entity);
         expect(state.focus.index()).toBe(0);
 
         dispose();
@@ -194,11 +338,11 @@ describe('createSoupState', () => {
         const state = createSoupState({ initialData: entities });
 
         const result1 = state.navigate.down();
-        expect(result1?.row.original).toBe(entities[0]);
+        expect(unwrap(result1?.row.original)).toBe(entities[0]);
         expect(result1?.index).toBe(0);
 
         const result2 = state.navigate.down();
-        expect(result2?.row.original).toBe(entities[1]);
+        expect(unwrap(result2?.row.original)).toBe(entities[1]);
         expect(result2?.index).toBe(1);
 
         dispose();
@@ -216,11 +360,11 @@ describe('createSoupState', () => {
 
         // When no focus, up goes to last
         const result1 = state.navigate.up();
-        expect(result1?.row.original).toBe(entities[2]);
+        expect(unwrap(result1?.row.original)).toBe(entities[2]);
         expect(result1?.index).toBe(2);
 
         const result2 = state.navigate.up();
-        expect(result2?.row.original).toBe(entities[1]);
+        expect(unwrap(result2?.row.original)).toBe(entities[1]);
         expect(result2?.index).toBe(1);
 
         dispose();
@@ -241,7 +385,7 @@ describe('createSoupState', () => {
           skip: (row) => row.id === '2',
         });
 
-        expect(result?.row.original).toBe(entities[2]);
+        expect(unwrap(result?.row.original)).toBe(entities[2]);
         expect(state.focus.id()).toBe('3');
 
         dispose();
@@ -256,7 +400,7 @@ describe('createSoupState', () => {
         state.focus.set('2');
         const result = state.navigate.toFirst();
 
-        expect(result?.row.original).toBe(entities[0]);
+        expect(unwrap(result?.row.original)).toBe(entities[0]);
         expect(state.focus.id()).toBe('1');
 
         dispose();
@@ -271,7 +415,7 @@ describe('createSoupState', () => {
         state.focus.set('1');
         const result = state.navigate.toLast();
 
-        expect(result?.row.original).toBe(entities[1]);
+        expect(unwrap(result?.row.original)).toBe(entities[1]);
         expect(state.focus.id()).toBe('2');
 
         dispose();
@@ -289,7 +433,7 @@ describe('createSoupState', () => {
 
         const result = state.navigate.toIndex(1);
 
-        expect(result?.row.original).toBe(entities[1]);
+        expect(unwrap(result?.row.original)).toBe(entities[1]);
         expect(state.focus.id()).toBe('2');
 
         dispose();
@@ -303,7 +447,7 @@ describe('createSoupState', () => {
 
         const result = state.navigate.toId('2');
 
-        expect(result?.row.original).toBe(entities[1]);
+        expect(unwrap(result?.row.original)).toBe(entities[1]);
         expect(state.focus.id()).toBe('2');
 
         dispose();
@@ -381,7 +525,7 @@ describe('createSoupState', () => {
         expect(state.focus.id()).toBe('2');
 
         const peeked = state.navigate.peekOffset(1);
-        expect(peeked?.row.original).toBe(entities[2]);
+        expect(unwrap(peeked?.row.original)).toBe(entities[2]);
 
         // Focus should remain unchanged
         expect(state.focus.id()).toBe('2');

--- a/apps/web/src/features/next-soup/create-soup-state.test.ts
+++ b/apps/web/src/features/next-soup/create-soup-state.test.ts
@@ -227,6 +227,35 @@ describe('createSoupState', () => {
         dispose();
       });
     });
+
+    it('preserves focus on the same duplicate row after reconciliation', () => {
+      createRoot((dispose) => {
+        const state = createSoupState();
+        const entity = createTestEntity('duplicate');
+        const groups = [
+          createTestGroup('first', 1),
+          createTestGroup('second', 1),
+        ];
+        const buildRows = () =>
+          groups.map((group, index) =>
+            state.buildRow({
+              id: entity.id,
+              index,
+              original: entity,
+              group,
+            })
+          );
+
+        state.setRows(buildRows());
+        state.focus.setIndex(1);
+        state.setRows(buildRows());
+
+        expect(state.focus.index()).toBe(1);
+        expect(state.focus.row()?.group?.key).toBe('second');
+
+        dispose();
+      });
+    });
   });
 
   describe('items', () => {

--- a/apps/web/src/features/next-soup/create-soup-state.ts
+++ b/apps/web/src/features/next-soup/create-soup-state.ts
@@ -12,7 +12,8 @@ import { SORT_CONFIGS } from '@app/features/next-soup/soup-view/sort-options';
 import { isModality } from '@core/mobile/inputModality';
 import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import type { EntityData, WithNotification, WithSearch } from '@entity';
-import { createMemo, createSignal, type JSX } from 'solid-js';
+import { batch, createMemo, createSignal, type JSX } from 'solid-js';
+import { createStore, reconcile } from 'solid-js/store';
 
 /**
  * Active "focus" predicates that exclude done entities. When one of these is
@@ -43,6 +44,8 @@ export type GroupMeta = {
 };
 
 export type SoupRow = {
+  /** Stable identity used to preserve this row's store proxy across updates. */
+  identityKey: string;
   id: string;
   index: number;
   original: SoupEntity;
@@ -141,7 +144,24 @@ export const createSoupState = <TId extends string = FilterID>(
       isGrouped = false,
       isLoadMore = false,
     } = options;
+    const kind = isGrouped
+      ? 'group-header'
+      : isLoadMore
+        ? 'load-more'
+        : 'entity';
+    // Group membership distinguishes duplicate entities and makes a moved task
+    // a new row. Structural rows also include their representative entity so
+    // Solid never merges a new header/load-more entity into an aliased proxy.
+    const identityKey = JSON.stringify([
+      kind,
+      group?.key ?? null,
+      original.type,
+      original.id,
+      id,
+    ]);
+
     return {
+      identityKey,
       id,
       index,
       original,
@@ -154,17 +174,26 @@ export const createSoupState = <TId extends string = FilterID>(
     };
   };
 
-  const [rows, setRowsInternal] = createSignal<SoupRow[]>(
+  const initialRows =
     initialData?.map((e, i) => buildRow({ id: e.id, index: i, original: e })) ??
-      []
-  );
+    [];
+  const [rowStore, setRowStore] = createStore<SoupRow[]>(initialRows);
+  // The array snapshot changes only for structural updates, while its row
+  // proxies update nested entity/group fields reactively in place.
+  const rows = createMemo(() => [...rowStore]);
 
   const setRows = (newRows: SoupRow[]) => {
-    setRowsInternal(newRows);
-    if (!lastFocusedRowId) return;
-    const nextIndex = newRows.findIndex((r) => r.id === lastFocusedRowId);
-    setFocusedIndex(nextIndex);
-    if (nextIndex < 0) lastFocusedRowId = undefined;
+    batch(() => {
+      setRowStore(reconcile(newRows, { key: 'identityKey', merge: true }));
+
+      if (lastFocusedRowId) {
+        const nextIndex = rowStore.findIndex(
+          (row) => row.id === lastFocusedRowId
+        );
+        setFocusedIndex(nextIndex);
+        if (nextIndex < 0) lastFocusedRowId = undefined;
+      }
+    });
   };
 
   const [collapseEntityCallback, setCollapseEntityCallback] = createSignal<

--- a/apps/web/src/features/next-soup/create-soup-state.ts
+++ b/apps/web/src/features/next-soup/create-soup-state.ts
@@ -104,9 +104,9 @@ export const createSoupState = <TId extends string = FilterID>(
   const sort = createSortState(SORT_CONFIGS, ['updated_at']);
 
   // Tracked by index (not id) so a row id duplicated across groups highlights
-  // only one occurrence. lastFocusedRowId follows that row across setRows.
+  // only one occurrence. The identity key follows that row across setRows.
   const [focusedIndex, setFocusedIndex] = createSignal(-1);
-  let lastFocusedRowId: string | undefined;
+  let lastFocusedRowIdentityKey: string | undefined;
 
   const [activeGroupId, setActiveGroupId] = createSignal<string | undefined>();
 
@@ -186,12 +186,12 @@ export const createSoupState = <TId extends string = FilterID>(
     batch(() => {
       setRowStore(reconcile(newRows, { key: 'identityKey', merge: true }));
 
-      if (lastFocusedRowId) {
+      if (lastFocusedRowIdentityKey) {
         const nextIndex = rowStore.findIndex(
-          (row) => row.id === lastFocusedRowId
+          (row) => row.identityKey === lastFocusedRowIdentityKey
         );
         setFocusedIndex(nextIndex);
-        if (nextIndex < 0) lastFocusedRowId = undefined;
+        if (nextIndex < 0) lastFocusedRowIdentityKey = undefined;
       }
     });
   };
@@ -241,7 +241,7 @@ export const createSoupState = <TId extends string = FilterID>(
 
     if (result) {
       setFocusedIndex(result.index);
-      lastFocusedRowId = result.row.id;
+      lastFocusedRowIdentityKey = result.row.identityKey;
     }
 
     return result;
@@ -340,7 +340,7 @@ export const createSoupState = <TId extends string = FilterID>(
 
   const clearFocus = () => {
     setFocusedIndex(-1);
-    lastFocusedRowId = undefined;
+    lastFocusedRowIdentityKey = undefined;
   };
 
   return {
@@ -374,13 +374,13 @@ export const createSoupState = <TId extends string = FilterID>(
         const idx = indexOf(id);
         if (idx < 0) return;
         setFocusedIndex(idx);
-        lastFocusedRowId = id;
+        lastFocusedRowIdentityKey = rows()[idx].identityKey;
       },
       setIndex: (index: number) => {
         const row = rows()[index];
         if (!row) return;
         setFocusedIndex(index);
-        lastFocusedRowId = row.id;
+        lastFocusedRowIdentityKey = row.identityKey;
       },
     },
 

--- a/apps/web/src/features/next-soup/soup-view/soup-view-context.tsx
+++ b/apps/web/src/features/next-soup/soup-view/soup-view-context.tsx
@@ -1260,7 +1260,7 @@ export const SoupViewContextProvider: FlowComponent<
     return '';
   };
 
-  const rows = createMemo((): SoupRow[] => {
+  const builtRows = createMemo((): SoupRow[] => {
     const field = groupByField();
     const groups = itemsSource.data()?.groups;
 
@@ -1514,7 +1514,7 @@ export const SoupViewContextProvider: FlowComponent<
       },
     },
     items,
-    rows,
+    rows: soup.rows,
     searchText: search.searchText,
     setSearchText: search.setSearchText,
     searchPaused: sourceSearchPaused,
@@ -1552,7 +1552,7 @@ export const SoupViewContextProvider: FlowComponent<
     <SoupViewContext.Provider value={context}>
       {props.children}
       <Suspense>
-        <SyncWithSoup soup={soup} rows={rows()} />
+        <SyncWithSoup soup={soup} rows={builtRows()} />
       </Suspense>
     </SoupViewContext.Provider>
   );


### PR DESCRIPTION
This is an alternative implementation of #5429 which instead uses solid-store to track row equality. The main goal here is to reduce re-renders on unchanged rows due to object equality changing