### PR TITLE
feat(bots): create team-owned bots from settings

### DIFF
--- a/apps/web/src/features/channel/Bots/BotCreatePage.tsx
+++ b/apps/web/src/features/channel/Bots/BotCreatePage.tsx
@@ -13,7 +13,7 @@ import {
 } from '@queries/channel/channel-bots';
 import { useCurrentTeamQuery, useIsTeamAdmin } from '@queries/team/teams';
 import type { Bot } from '@service-storage/generated/schemas/bot';
-import { Button, SegmentedControl } from '@ui';
+import { Button, ToggleSwitch } from '@ui';
 import { createMemo, createSignal, Show } from 'solid-js';
 import { createStore } from 'solid-js/store';
 import { BotCreationResult } from './BotCreationResult';
@@ -30,7 +30,6 @@ import { ChannelMultiSelect } from './ChannelMultiSelect';
 import { createBotAvatarUpload } from './createBotAvatarUpload';
 
 type Stage = 'form' | 'creating' | 'ready';
-type BotOwnerScope = 'personal' | 'team';
 
 export function BotCreate(props: { channelId?: string; onBack: () => void }) {
   const channelsContext = useChannelsContext();
@@ -41,7 +40,7 @@ export function BotCreate(props: { channelId?: string; onBack: () => void }) {
   const createScopedBotMutation = useCreateChannelScopedBotMutation();
   const addBotToChannelsMutation = useAddBotToChannelsMutation();
   const [stage, setStage] = createSignal<Stage>('form');
-  const [ownerScope, setOwnerScope] = createSignal<BotOwnerScope>('personal');
+  const [teamOwned, setTeamOwned] = createSignal(false);
   const [handleEdited, setHandleEdited] = createSignal(false);
   const [errors, setErrors] = createSignal<BotFormErrors>({});
   const [createdBot, setCreatedBot] = createSignal<Bot>();
@@ -63,14 +62,6 @@ export function BotCreate(props: { channelId?: string; onBack: () => void }) {
   const canCreateTeamBot = createMemo(
     () => currentTeam() !== undefined && isTeamAdmin()
   );
-  const ownerOptions = createMemo(() => [
-    { value: 'personal' as const, label: 'Personal' },
-    {
-      value: 'team' as const,
-      label: currentTeam()?.name?.trim() || 'Team',
-      disabled: !canCreateTeamBot(),
-    },
-  ]);
   const resultChannels = createMemo(() => {
     const selected = new Set(createdChannelIds());
     return channelOptions().filter((channel) => selected.has(channel.id));
@@ -89,8 +80,8 @@ export function BotCreate(props: { channelId?: string; onBack: () => void }) {
   };
 
   const submit = () => {
-    const teamId = ownerScope() === 'team' ? currentTeam()?.id : undefined;
-    if (ownerScope() === 'team' && (!teamId || !canCreateTeamBot())) {
+    const teamId = teamOwned() ? currentTeam()?.id : undefined;
+    if (teamOwned() && (!teamId || !canCreateTeamBot())) {
       toast.failure('Only team admins and owners can create team bots');
       return;
     }
@@ -248,25 +239,26 @@ export function BotCreate(props: { channelId?: string; onBack: () => void }) {
 
             <BotFormSection
               title="Ownership"
-              description="Choose whether this bot belongs to you or your team."
+              description="Bots are personal by default."
             >
-              <SegmentedControl
-                class="w-full"
-                value={ownerScope()}
-                options={ownerOptions()}
-                onChange={setOwnerScope}
-                aria-label="Bot owner"
-              />
-              <p class="mt-2 text-xs text-ink-muted">
-                <Show
-                  when={ownerScope() === 'team'}
-                  fallback="Personal bots are managed by you and use user scope."
-                >
-                  Team bots are shared with your team and can use team scope.
-                </Show>
-              </p>
+              <div class="flex items-center justify-between gap-4">
+                <div class="min-w-0">
+                  <div class="text-sm font-medium text-ink">Team bot</div>
+                  <p class="mt-0.5 text-xs text-ink-muted">
+                    Share this bot with your team and let it use team scope.
+                  </p>
+                </div>
+                <ToggleSwitch
+                  size="md"
+                  checked={teamOwned()}
+                  disabled={currentTeamQuery.isLoading || !canCreateTeamBot()}
+                  onChange={setTeamOwned}
+                  label={<span>Create as a team bot</span>}
+                  labelClass="sr-only"
+                />
+              </div>
               <Show when={!currentTeamQuery.isLoading && !canCreateTeamBot()}>
-                <p class="mt-1 text-xs text-ink-extra-muted">
+                <p class="mt-3 border-t border-edge-muted pt-3 text-xs text-ink-extra-muted">
                   {currentTeam()
                     ? 'Only team admins and owners can create team bots.'
                     : 'Join or create a team to create a team bot.'}

--- a/apps/web/src/features/channel/Bots/BotCreatePage.tsx
+++ b/apps/web/src/features/channel/Bots/BotCreatePage.tsx
@@ -11,8 +11,9 @@ import {
   useAddBotToChannelsMutation,
   useCreateChannelScopedBotMutation,
 } from '@queries/channel/channel-bots';
+import { useCurrentTeamQuery, useIsTeamAdmin } from '@queries/team/teams';
 import type { Bot } from '@service-storage/generated/schemas/bot';
-import { Button } from '@ui';
+import { Button, SegmentedControl } from '@ui';
 import { createMemo, createSignal, Show } from 'solid-js';
 import { createStore } from 'solid-js/store';
 import { BotCreationResult } from './BotCreationResult';
@@ -29,14 +30,18 @@ import { ChannelMultiSelect } from './ChannelMultiSelect';
 import { createBotAvatarUpload } from './createBotAvatarUpload';
 
 type Stage = 'form' | 'creating' | 'ready';
+type BotOwnerScope = 'personal' | 'team';
 
 export function BotCreate(props: { channelId?: string; onBack: () => void }) {
   const channelsContext = useChannelsContext();
+  const currentTeamQuery = useCurrentTeamQuery();
+  const isTeamAdmin = useIsTeamAdmin();
   const createBotMutation = useCreateBotMutation();
   const createTokenMutation = useCreateBotTokenMutation();
   const createScopedBotMutation = useCreateChannelScopedBotMutation();
   const addBotToChannelsMutation = useAddBotToChannelsMutation();
   const [stage, setStage] = createSignal<Stage>('form');
+  const [ownerScope, setOwnerScope] = createSignal<BotOwnerScope>('personal');
   const [handleEdited, setHandleEdited] = createSignal(false);
   const [errors, setErrors] = createSignal<BotFormErrors>({});
   const [createdBot, setCreatedBot] = createSignal<Bot>();
@@ -54,6 +59,18 @@ export function BotCreate(props: { channelId?: string; onBack: () => void }) {
   const channelOptions = createMemo(() =>
     botAssignableChannelOptions(channelsContext.channels())
   );
+  const currentTeam = createMemo(() => currentTeamQuery.data?.team);
+  const canCreateTeamBot = createMemo(
+    () => currentTeam() !== undefined && isTeamAdmin()
+  );
+  const ownerOptions = createMemo(() => [
+    { value: 'personal' as const, label: 'Personal' },
+    {
+      value: 'team' as const,
+      label: currentTeam()?.name?.trim() || 'Team',
+      disabled: !canCreateTeamBot(),
+    },
+  ]);
   const resultChannels = createMemo(() => {
     const selected = new Set(createdChannelIds());
     return channelOptions().filter((channel) => selected.has(channel.id));
@@ -72,6 +89,12 @@ export function BotCreate(props: { channelId?: string; onBack: () => void }) {
   };
 
   const submit = () => {
+    const teamId = ownerScope() === 'team' ? currentTeam()?.id : undefined;
+    if (ownerScope() === 'team' && (!teamId || !canCreateTeamBot())) {
+      toast.failure('Only team admins and owners can create team bots');
+      return;
+    }
+
     const parsed = validateBotForm({
       ...form,
       handle: form.handle || slugBotHandle(form.name),
@@ -92,6 +115,7 @@ export function BotCreate(props: { channelId?: string; onBack: () => void }) {
       createScopedBotMutation.mutate(
         {
           channelId: firstChannelId,
+          team_id: teamId,
           name: values.name,
           handle: values.handle,
           description: values.description || undefined,
@@ -125,6 +149,7 @@ export function BotCreate(props: { channelId?: string; onBack: () => void }) {
 
     createBotMutation.mutate(
       {
+        teamId,
         name: values.name,
         handle: values.handle,
         description: values.description || undefined,
@@ -219,6 +244,34 @@ export function BotCreate(props: { channelId?: string; onBack: () => void }) {
                 }}
                 onDescriptionChange={(value) => setForm('description', value)}
               />
+            </BotFormSection>
+
+            <BotFormSection
+              title="Ownership"
+              description="Choose whether this bot belongs to you or your team."
+            >
+              <SegmentedControl
+                class="w-full"
+                value={ownerScope()}
+                options={ownerOptions()}
+                onChange={setOwnerScope}
+                aria-label="Bot owner"
+              />
+              <p class="mt-2 text-xs text-ink-muted">
+                <Show
+                  when={ownerScope() === 'team'}
+                  fallback="Personal bots are managed by you and use user scope."
+                >
+                  Team bots are shared with your team and can use team scope.
+                </Show>
+              </p>
+              <Show when={!currentTeamQuery.isLoading && !canCreateTeamBot()}>
+                <p class="mt-1 text-xs text-ink-extra-muted">
+                  {currentTeam()
+                    ? 'Only team admins and owners can create team bots.'
+                    : 'Join or create a team to create a team bot.'}
+                </p>
+              </Show>
             </BotFormSection>
 
             <BotFormSection

--- a/apps/web/src/features/settings/BotSettingsList.tsx
+++ b/apps/web/src/features/settings/BotSettingsList.tsx
@@ -12,6 +12,8 @@ import { SettingsCard, SettingsPage, SettingsSection } from './primitives';
 function BotSettingsRow(props: { bot: Bot; onOpen: (botId: string) => void }) {
   const channelsQuery = useBotChannelsQuery(() => props.bot.id);
   const channels = () => channelsQuery.data ?? [];
+  const ownerLabel = () =>
+    props.bot.owner?.type === 'team' ? 'Team' : 'Personal';
 
   const channelSummary = () => {
     if (channelsQuery.isLoading) return 'Loading channels…';
@@ -30,12 +32,15 @@ function BotSettingsRow(props: { bot: Bot; onOpen: (botId: string) => void }) {
     >
       <BotAvatar bot={props.bot} size="lg" />
       <div class="min-w-0 flex-1">
-        <div class="flex min-w-0 items-baseline gap-2">
+        <div class="flex min-w-0 items-center gap-2">
           <span class="truncate text-sm font-medium text-ink">
             {props.bot.name}
           </span>
           <span class="truncate text-xs text-ink-extra-muted">
             @{props.bot.handle}
+          </span>
+          <span class="shrink-0 rounded-full border border-edge-muted px-2 py-0.5 font-mono text-xxs font-medium uppercase text-ink-extra-muted">
+            {ownerLabel()}
           </span>
         </div>
         <div class="mt-0.5 truncate text-xs text-ink-muted">


### PR DESCRIPTION
- Use the existing settings toggle to create team-owned bots.
- Restrict team ownership to team admins and owners and submit the selected team ID through both creation paths.
- Label each bot as Personal or Team in the settings list.