### PR TITLE
feat(ci): restore a nix binary cache substituter via private S3

### DIFF
--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -6,12 +6,41 @@ description: >-
   rather than reinstalling the store. Init-agnostic: uses systemd units when
   systemd is active (full VMs), otherwise starts nix-daemon directly as a
   background process (e.g. Namespace runners, where systemd is not active).
+  Optionally configures a private S3 binary cache as a substituter: the daemon
+  performs substitution, so it is started with the AWS credentials in its
+  environment. All four cache inputs must be set for the substituter to be
+  configured; otherwise the action behaves exactly as before.
+
+inputs:
+  nix-cache-url:
+    description: >-
+      S3 store URL of the private nix binary cache
+      (e.g. s3://macro-nix-cache?region=us-east-1). Empty disables.
+    required: false
+    default: ''
+  nix-cache-public-key:
+    description: Public signing key the daemon should trust for that cache.
+    required: false
+    default: ''
+  aws-access-key-id:
+    description: AWS access key id for reading the private cache bucket.
+    required: false
+    default: ''
+  aws-secret-access-key:
+    description: AWS secret access key for reading the private cache bucket.
+    required: false
+    default: ''
 
 runs:
   using: composite
   steps:
     - name: Install or re-initialise Nix
       shell: bash
+      env:
+        NIX_CACHE_URL: ${{ inputs.nix-cache-url }}
+        NIX_CACHE_PUBLIC_KEY: ${{ inputs.nix-cache-public-key }}
+        NIX_CACHE_AWS_ACCESS_KEY_ID: ${{ inputs.aws-access-key-id }}
+        NIX_CACHE_AWS_SECRET_ACCESS_KEY: ${{ inputs.aws-secret-access-key }}
       run: |
         set -euo pipefail
 
@@ -21,6 +50,14 @@ runs:
         have_systemd=false
         if [ -d /run/systemd/system ]; then have_systemd=true; fi
 
+        # The private-bucket substituter needs all four pieces: URL, a key to
+        # verify signatures, and AWS credentials for the daemon to read S3.
+        cache_enabled=false
+        if [[ -n "$NIX_CACHE_URL" && -n "$NIX_CACHE_PUBLIC_KEY" \
+              && -n "$NIX_CACHE_AWS_ACCESS_KEY_ID" && -n "$NIX_CACHE_AWS_SECRET_ACCESS_KEY" ]]; then
+          cache_enabled=true
+        fi
+
         write_conf() {
           sudo mkdir -p /etc/nix
           # The minimal config the Determinate installer would have written.
@@ -28,6 +65,14 @@ runs:
             echo "experimental-features = nix-command flakes"
             echo "trusted-users = root runner"
             echo "build-users-group = nixbld"
+            if $cache_enabled; then
+              echo "extra-substituters = $NIX_CACHE_URL"
+              echo "extra-trusted-public-keys = $NIX_CACHE_PUBLIC_KEY"
+              # A missing narinfo is the common case for freshly built crates;
+              # don't let its negative cache linger across a push from another
+              # job in the same run.
+              echo "narinfo-cache-negative-ttl = 30"
+            fi
           } | sudo tee /etc/nix/nix.conf >/dev/null
         }
 
@@ -51,11 +96,18 @@ runs:
             sudo systemctl enable --now nix-daemon.socket nix-daemon.service 2>/dev/null || true
           fi
           # Without systemd (or if the unit failed to come up), run the daemon
-          # directly: it is just a process listening on the daemon socket.
+          # directly: it is just a process listening on the daemon socket. The
+          # daemon is what talks to substituters, so the S3 credentials must be
+          # in *its* environment, not the client's.
           if ! sudo test -S /nix/var/nix/daemon-socket/socket || ! pgrep -x nix-daemon >/dev/null 2>&1; then
             sudo mkdir -p /nix/var/nix/daemon-socket
             sudo rm -f /nix/var/nix/daemon-socket/socket
-            sudo sh -c "nohup '$daemon_bin' >/tmp/nix-daemon.log 2>&1 &"
+            daemon_env=()
+            if $cache_enabled; then
+              daemon_env+=("AWS_ACCESS_KEY_ID=$NIX_CACHE_AWS_ACCESS_KEY_ID")
+              daemon_env+=("AWS_SECRET_ACCESS_KEY=$NIX_CACHE_AWS_SECRET_ACCESS_KEY")
+            fi
+            sudo env "${daemon_env[@]}" sh -c "nohup '$daemon_bin' >/tmp/nix-daemon.log 2>&1 &"
             for _ in $(seq 1 30); do
               if sudo test -S /nix/var/nix/daemon-socket/socket; then break; fi
               sleep 1
@@ -85,9 +137,17 @@ runs:
             sh -s -- install linux --no-confirm --init "$init_flag" \
             --extra-conf "experimental-features = nix-command flakes" \
             --extra-conf "trusted-users = root runner"
-          # With --init none the installer lays out the multi-user store but
-          # starts no service; bring the daemon up ourselves.
+          # Rewrite the config so the substituter block above applies on fresh
+          # installs too, then bring the daemon up ourselves (with --init none
+          # the installer lays out the multi-user store but starts no service).
+          write_conf
           start_daemon
+        fi
+
+        if $cache_enabled; then
+          echo "S3 nix cache substituter configured: $NIX_CACHE_URL"
+        else
+          echo "S3 nix cache substituter not configured (inputs unset); volume-only caching."
         fi
 
         # Make nix discoverable in subsequent (non-login) steps.

--- a/.github/scripts/build-cloud-storage-lambdas-nix.sh
+++ b/.github/scripts/build-cloud-storage-lambdas-nix.sh
@@ -8,8 +8,12 @@ set -euo pipefail
 #
 # Unlike the cargo-lambda path, this never recompiles unchanged handlers: nix is
 # content-addressed, so an unchanged handler is a pure cache hit from the
-# Namespace Nix volume. Independent handler derivations
+# Namespace Nix volume or the S3 binary cache. Independent handler derivations
 # also build in parallel within the single `nix build` invocation.
+#
+# When NIX_CACHE_URL + NIX_CACHE_SIGNING_KEY are set (deploy pipeline only),
+# the freshly built out-paths are pushed back to the S3 cache, signed on
+# upload — so the next run substitutes them even from a cold /nix volume.
 
 SERVICE="${SERVICE:?SERVICE is required}"
 OUTPUT_DIR="${OUTPUT_DIR:-lambda-artifacts}"
@@ -38,6 +42,17 @@ for lambda in "${LAMBDAS[@]}"; do
   installables+=(".#deploy-lambda-${lambda}")
 done
 mapfile -t outs < <(nix build --no-link --print-build-logs --print-out-paths "${installables[@]}")
+
+if [[ -n "${NIX_CACHE_URL:-}" && -n "${NIX_CACHE_SIGNING_KEY:-}" ]]; then
+  key="${RUNNER_TEMP:-/tmp}/nix-cache-signing-key"
+  printf '%s\n' "$NIX_CACHE_SIGNING_KEY" > "$key"
+  sep='?'; [[ "$NIX_CACHE_URL" == *\?* ]] && sep='&'
+  nix copy --to "${NIX_CACHE_URL}${sep}secret-key=${key}" "${outs[@]}" \
+    || echo "::warning::nix cache push failed (non-fatal)"
+  rm -f "$key"
+else
+  echo "nix cache not configured; skipping push"
+fi
 
 # Assemble target/lambda/<name>/*.zip. Each out path is laid out as
 # <out>/<handler>/{bootstrap.zip,...} (see deployLambdaPackage in flake.nix),

--- a/.github/workflows/deploy_all_services.yml
+++ b/.github/workflows/deploy_all_services.yml
@@ -19,6 +19,8 @@ on:
         required: true
       DD_API_KEY:
         required: true
+      NIX_CACHE_SIGNING_KEY:
+        required: false
   workflow_dispatch:
     inputs:
       environment:
@@ -77,12 +79,38 @@ jobs:
       continue-on-error: true
     - name: Setup Nix
       uses: ./.github/actions/setup-nix
+      with:
+        nix-cache-url: ${{ vars.NIX_CACHE_URL }}
+        nix-cache-public-key: ${{ vars.NIX_CACHE_PUBLIC_KEY }}
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     - name: Warm shared release deps
       run: |-
         set -euo pipefail
         nix build --print-build-logs ".#deployCargoArtifacts"
         echo "Shared release deps realised into /nix/store; committed on job exit."
       shell: bash
+    - name: Push to nix cache
+      run: |
+        set -uo pipefail
+        if [[ -z "${NIX_CACHE_URL:-}" || -z "${NIX_CACHE_SIGNING_KEY:-}" ]]; then
+          echo "nix cache not configured; skipping push"
+          exit 0
+        fi
+        key="$RUNNER_TEMP/nix-cache-signing-key"
+        printf '%s\n' "$NIX_CACHE_SIGNING_KEY" > "$key"
+        sep='?'; [[ "$NIX_CACHE_URL" == *\?* ]] && sep='&'
+        # shellcheck disable=SC2086 # TARGETS is a list on purpose
+        nix copy --to "${NIX_CACHE_URL}${sep}secret-key=${key}" $TARGETS \
+          || echo "::warning::nix cache push failed (non-fatal)"
+        rm -f "$key"
+      shell: bash
+      env:
+        TARGETS: .#deployCargoArtifacts
+        NIX_CACHE_URL: ${{ vars.NIX_CACHE_URL }}
+        NIX_CACHE_SIGNING_KEY: ${{ secrets.NIX_CACHE_SIGNING_KEY }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     - name: Teardown Nix
       if: always()
       uses: ./.github/actions/teardown-nix
@@ -104,12 +132,38 @@ jobs:
       continue-on-error: true
     - name: Setup Nix
       uses: ./.github/actions/setup-nix
+      with:
+        nix-cache-url: ${{ vars.NIX_CACHE_URL }}
+        nix-cache-public-key: ${{ vars.NIX_CACHE_PUBLIC_KEY }}
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     - name: Warm shared lambda dep closure
       run: |-
         set -euo pipefail
         nix build --print-build-logs ".#lambdaDeployCargoArtifacts" ".#callRecordingPreviewFfmpegLayer"
         echo "Shared lambda deps realised into /nix/store; committed on job exit."
       shell: bash
+    - name: Push to nix cache
+      run: |
+        set -uo pipefail
+        if [[ -z "${NIX_CACHE_URL:-}" || -z "${NIX_CACHE_SIGNING_KEY:-}" ]]; then
+          echo "nix cache not configured; skipping push"
+          exit 0
+        fi
+        key="$RUNNER_TEMP/nix-cache-signing-key"
+        printf '%s\n' "$NIX_CACHE_SIGNING_KEY" > "$key"
+        sep='?'; [[ "$NIX_CACHE_URL" == *\?* ]] && sep='&'
+        # shellcheck disable=SC2086 # TARGETS is a list on purpose
+        nix copy --to "${NIX_CACHE_URL}${sep}secret-key=${key}" $TARGETS \
+          || echo "::warning::nix cache push failed (non-fatal)"
+        rm -f "$key"
+      shell: bash
+      env:
+        TARGETS: .#lambdaDeployCargoArtifacts .#callRecordingPreviewFfmpegLayer
+        NIX_CACHE_URL: ${{ vars.NIX_CACHE_URL }}
+        NIX_CACHE_SIGNING_KEY: ${{ secrets.NIX_CACHE_SIGNING_KEY }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     - name: Teardown Nix
       if: always()
       uses: ./.github/actions/teardown-nix
@@ -137,6 +191,11 @@ jobs:
       continue-on-error: true
     - name: Setup Nix
       uses: ./.github/actions/setup-nix
+      with:
+        nix-cache-url: ${{ vars.NIX_CACHE_URL }}
+        nix-cache-public-key: ${{ vars.NIX_CACHE_PUBLIC_KEY }}
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     - name: Build prebuilt binaries
       run: |
         set -euo pipefail
@@ -154,6 +213,27 @@ jobs:
       shell: bash
       env:
         SERVICE: ${{ matrix.service }}
+    - name: Push to nix cache
+      run: |
+        set -uo pipefail
+        if [[ -z "${NIX_CACHE_URL:-}" || -z "${NIX_CACHE_SIGNING_KEY:-}" ]]; then
+          echo "nix cache not configured; skipping push"
+          exit 0
+        fi
+        key="$RUNNER_TEMP/nix-cache-signing-key"
+        printf '%s\n' "$NIX_CACHE_SIGNING_KEY" > "$key"
+        sep='?'; [[ "$NIX_CACHE_URL" == *\?* ]] && sep='&'
+        # shellcheck disable=SC2086 # TARGETS is a list on purpose
+        nix copy --to "${NIX_CACHE_URL}${sep}secret-key=${key}" $TARGETS \
+          || echo "::warning::nix cache push failed (non-fatal)"
+        rm -f "$key"
+      shell: bash
+      env:
+        TARGETS: .#deploy-service-binaries-${{ matrix.service }}
+        NIX_CACHE_URL: ${{ vars.NIX_CACHE_URL }}
+        NIX_CACHE_SIGNING_KEY: ${{ secrets.NIX_CACHE_SIGNING_KEY }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     - name: Upload handoff artifact
       run: nsc artifact upload prebuilt-binaries.tar.gz "$DEST" --expires_in=24h
       shell: bash
@@ -186,10 +266,19 @@ jobs:
       continue-on-error: true
     - name: Setup Nix
       uses: ./.github/actions/setup-nix
+      with:
+        nix-cache-url: ${{ vars.NIX_CACHE_URL }}
+        nix-cache-public-key: ${{ vars.NIX_CACHE_PUBLIC_KEY }}
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     - name: Build Lambda artifacts
       run: .github/scripts/build-cloud-storage-lambdas-nix.sh
       env:
         SERVICE: ${{ matrix.service }}
+        NIX_CACHE_URL: ${{ vars.NIX_CACHE_URL }}
+        NIX_CACHE_SIGNING_KEY: ${{ secrets.NIX_CACHE_SIGNING_KEY }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     - name: Log handoff receipt
       run: |
         set -euo pipefail

--- a/.github/workflows/deploy_cloud_storage_on_push.yml
+++ b/.github/workflows/deploy_cloud_storage_on_push.yml
@@ -48,3 +48,4 @@ jobs:
       PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
       DD_APP_KEY: ${{ secrets.DD_APP_KEY }}
       DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      NIX_CACHE_SIGNING_KEY: ${{ secrets.NIX_CACHE_SIGNING_KEY }}

--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -22,6 +22,7 @@ jobs:
       PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
       DD_APP_KEY: ${{ secrets.DD_APP_KEY }}
       DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      NIX_CACHE_SIGNING_KEY: ${{ secrets.NIX_CACHE_SIGNING_KEY }}
 
   deploy-sync-service:
     name: Deploy Sync Service

--- a/tooling/xtask/crates/xtask_workflows/src/workflows/deploy_all_services.rs
+++ b/tooling/xtask/crates/xtask_workflows/src/workflows/deploy_all_services.rs
@@ -45,7 +45,7 @@ pub fn deploy_all_services() -> Workflow {
                 "Warm shared binary deps onto sticky disk",
                 "binaries",
                 "Warm shared release deps",
-                "\".#deployCargoArtifacts\"",
+                ".#deployCargoArtifacts",
                 "Shared release deps realised into /nix/store; committed on job exit.",
             ),
         )
@@ -55,7 +55,7 @@ pub fn deploy_all_services() -> Workflow {
                 "Warm shared lambda deps onto sticky disk",
                 "lambdas",
                 "Warm shared lambda dep closure",
-                "\".#lambdaDeployCargoArtifacts\" \".#callRecordingPreviewFfmpegLayer\"",
+                ".#lambdaDeployCargoArtifacts .#callRecordingPreviewFfmpegLayer",
                 "Shared lambda deps realised into /nix/store; committed on job exit.",
             ),
         )
@@ -105,6 +105,8 @@ pub fn patch(root: &mut serde_yaml::Value) -> Result<()> {
                 required: true
               DD_API_KEY:
                 required: true
+              NIX_CACHE_SIGNING_KEY:
+                required: false
         "#})?,
     );
     Ok(())
@@ -142,10 +144,12 @@ fn set_matrix() -> Step<Run> {
         .id("set-matrix")
 }
 
-/// Warm one shared dep closure onto the /nix sticky disk. The two warm jobs
-/// run in parallel and each build matrix depends only on its own warm job, so
-/// a slow lambda-closure warm never blocks binary builds and vice versa. The
-/// /nix cache volume is provided by Namespace's native Nix integration.
+/// Warm one shared dep closure onto the /nix sticky disk, then push it to the
+/// S3 binary cache so every matrix job that drew a cold/stale volume from the
+/// pool can substitute it instead of rebuilding. The two warm jobs run in
+/// parallel and each build matrix depends only on its own warm job, so a slow
+/// lambda-closure warm never blocks binary builds and vice versa. The /nix
+/// cache volume is provided by Namespace's native Nix integration.
 fn warm_job(
     name: &str,
     gate_output: &str,
@@ -153,6 +157,11 @@ fn warm_job(
     targets: &str,
     done_msg: &str,
 ) -> Job {
+    let quoted_targets = targets
+        .split_whitespace()
+        .map(|t| format!("\"{t}\""))
+        .collect::<Vec<_>>()
+        .join(" ");
     Job::default()
         .name(name)
         .needs(vec!["setup".to_string()])
@@ -162,8 +171,9 @@ fn warm_job(
         .runs_on(runners::Runner::Mid.to_string())
         .add_step(steps::checkout_v4())
         .add_step(steps::mount_nix_cache_volume())
-        .add_step(steps::setup_nix())
-        .add_step(steps::nix_build(build_step_name, targets, done_msg))
+        .add_step(steps::setup_nix_with_cache())
+        .add_step(steps::nix_build(build_step_name, &quoted_targets, done_msg))
+        .add_step(steps::push_nix_cache(targets))
         .add_step(steps::teardown_nix())
 }
 
@@ -188,7 +198,7 @@ fn build_job(name: &str, warm_job_id: &str, gate_output: &str) -> Job {
         })
         .add_step(steps::checkout_v4().add_with(("clean", false)))
         .add_step(steps::mount_nix_cache_volume())
-        .add_step(steps::setup_nix())
+        .add_step(steps::setup_nix_with_cache())
 }
 
 fn build_service_binaries() -> Job {
@@ -198,6 +208,11 @@ fn build_service_binaries() -> Job {
         "binaries",
     )
     .add_step(build_prebuilt_binaries())
+    // Pushing the built output is what makes this service a pure substitution
+    // next run when it is unchanged, even on a cold volume.
+    .add_step(steps::push_nix_cache(
+        ".#deploy-service-binaries-${{ matrix.service }}",
+    ))
     .add_step(steps::upload_handoff_artifact(
         "prebuilt-binaries.tar.gz",
         "${{ matrix.service }}",
@@ -246,9 +261,22 @@ fn build_lambda_artifacts() -> Job {
 }
 
 fn build_lambdas() -> Step<Run> {
+    // The cache env lets the script push the handler out-paths it just built
+    // (see the script's push block) — the store-path equivalent of the binary
+    // job's push step, minus a second flake evaluation.
     Step::new("Build Lambda artifacts")
         .run(".github/scripts/build-cloud-storage-lambdas-nix.sh")
         .add_env(Env::new("SERVICE", "${{ matrix.service }}"))
+        .add_env(Env::new("NIX_CACHE_URL", vars::NIX_CACHE_URL))
+        .add_env(Env::new(
+            "NIX_CACHE_SIGNING_KEY",
+            vars::NIX_CACHE_SIGNING_KEY,
+        ))
+        .add_env(Env::new("AWS_ACCESS_KEY_ID", vars::AWS_ACCESS_KEY))
+        .add_env(Env::new(
+            "AWS_SECRET_ACCESS_KEY",
+            vars::AWS_SECRET_ACCESS_KEY,
+        ))
 }
 
 fn log_lambda_receipt() -> Step<Run> {

--- a/tooling/xtask/crates/xtask_workflows/src/workflows/deploy_cloud_storage_on_push.rs
+++ b/tooling/xtask/crates/xtask_workflows/src/workflows/deploy_cloud_storage_on_push.rs
@@ -89,6 +89,7 @@ pub fn patch(root: &mut serde_yaml::Value) -> Result<()> {
             PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
             DD_APP_KEY: ${{ secrets.DD_APP_KEY }}
             DD_API_KEY: ${{ secrets.DD_API_KEY }}
+            NIX_CACHE_SIGNING_KEY: ${{ secrets.NIX_CACHE_SIGNING_KEY }}
         "#})?,
     );
     Ok(())

--- a/tooling/xtask/crates/xtask_workflows/src/workflows/steps.rs
+++ b/tooling/xtask/crates/xtask_workflows/src/workflows/steps.rs
@@ -93,6 +93,55 @@ pub fn setup_nix() -> Step<Use> {
     )
 }
 
+/// [`setup_nix`] with the private S3 binary cache configured as a substituter,
+/// so a /nix cache-volume miss degrades to a download instead of a rebuild.
+/// Only for jobs with access to the AWS secrets (deploy pipeline — never
+/// PR-triggered jobs). No-ops back to plain [`setup_nix`] behavior while the
+/// `NIX_CACHE_*` repo variables are unset.
+pub fn setup_nix_with_cache() -> Step<Use> {
+    setup_nix()
+        .add_with(("nix-cache-url", vars::NIX_CACHE_URL))
+        .add_with(("nix-cache-public-key", vars::NIX_CACHE_PUBLIC_KEY))
+        .add_with(("aws-access-key-id", vars::AWS_ACCESS_KEY))
+        .add_with(("aws-secret-access-key", vars::AWS_SECRET_ACCESS_KEY))
+}
+
+/// Push built store paths to the private S3 binary cache, signing on upload —
+/// the `cachix watch-store` role. `targets` lands in the step's `TARGETS` env
+/// (space-separated flake refs or store paths; GH expressions fine) and is
+/// word-split on purpose. Skips silently while the cache vars/secret are
+/// unset, and never fails the job: the cache is an optimization, and the paths
+/// were already handed off via Namespace artifacts.
+pub fn push_nix_cache(targets: &str) -> Step<Run> {
+    Step::new("Push to nix cache")
+        .run(indoc::indoc! {r#"
+            set -uo pipefail
+            if [[ -z "${NIX_CACHE_URL:-}" || -z "${NIX_CACHE_SIGNING_KEY:-}" ]]; then
+              echo "nix cache not configured; skipping push"
+              exit 0
+            fi
+            key="$RUNNER_TEMP/nix-cache-signing-key"
+            printf '%s\n' "$NIX_CACHE_SIGNING_KEY" > "$key"
+            sep='?'; [[ "$NIX_CACHE_URL" == *\?* ]] && sep='&'
+            # shellcheck disable=SC2086 # TARGETS is a list on purpose
+            nix copy --to "${NIX_CACHE_URL}${sep}secret-key=${key}" $TARGETS \
+              || echo "::warning::nix cache push failed (non-fatal)"
+            rm -f "$key"
+        "#})
+        .shell("bash")
+        .add_env(Env::new("TARGETS", targets))
+        .add_env(Env::new("NIX_CACHE_URL", vars::NIX_CACHE_URL))
+        .add_env(Env::new(
+            "NIX_CACHE_SIGNING_KEY",
+            vars::NIX_CACHE_SIGNING_KEY,
+        ))
+        .add_env(Env::new("AWS_ACCESS_KEY_ID", vars::AWS_ACCESS_KEY))
+        .add_env(Env::new(
+            "AWS_SECRET_ACCESS_KEY",
+            vars::AWS_SECRET_ACCESS_KEY,
+        ))
+}
+
 /// Enter the repo's Nix dev shell (toolchain, mold, just, the sccache binary,
 /// and `RUSTC_WRAPPER=sccache`) without selecting an sccache provider or
 /// configuring an external Nix binary cache. Jobs that compile Rust can follow

--- a/tooling/xtask/crates/xtask_workflows/src/workflows/vars.rs
+++ b/tooling/xtask/crates/xtask_workflows/src/workflows/vars.rs
@@ -21,6 +21,7 @@ secret!(DOPPLER_TOKEN);
 secret!(FLY_API_TOKEN);
 secret!(MACOS_DEVELOPER_ID_CERTIFICATE_BASE64);
 secret!(MACOS_DEVELOPER_ID_CERTIFICATE_PASSWORD);
+secret!(NIX_CACHE_SIGNING_KEY);
 secret!(POSTHOG_API_KEY);
 secret!(PULUMI_ACCESS_TOKEN);
 secret!(SEGMENT_WRITE_KEY);
@@ -29,6 +30,19 @@ secret!(SEGMENT_WRITE_KEY_PRODUCTION);
 /// Cloudflare account id. A repo *variable* (not a secret), matching the
 /// hand-written `deploy-lexical-service.yml`.
 pub const CLOUDFLARE_ACCOUNT_ID: &str = "${{ vars.CLOUDFLARE_ACCOUNT_ID }}";
+
+/// S3 nix binary cache store URL, a repo *variable* — e.g.
+/// `s3://macro-nix-cache?region=us-east-1`. The substituter role Cachix used
+/// to play: any /nix cache-volume miss becomes a signed-narinfo download
+/// instead of a from-source rebuild. Empty/unset disables all nix-cache
+/// wiring (setup skips the substituter config; push steps no-op), so the
+/// workflows are safe to run before the bucket exists.
+pub const NIX_CACHE_URL: &str = "${{ vars.NIX_CACHE_URL }}";
+
+/// Public counterpart of [`NIX_CACHE_SIGNING_KEY`], a repo *variable* — e.g.
+/// `nix-cache.macro.com-1:BASE64...`. Trusted by the nix daemon so substituted
+/// paths verify.
+pub const NIX_CACHE_PUBLIC_KEY: &str = "${{ vars.NIX_CACHE_PUBLIC_KEY }}";
 
 /// Nextest thread count for the test job. Tuned for the previous
 /// `linux-extra-beefy` runner; revisit if `namespace-profile-linux-mid` is


### PR DESCRIPTION
## Why

Removing cachix (#5370) roughly doubled deploy times (median 11 → 18 min, worst 31 min) and pushed cloud-storage code check p90 from 11 → 15 min. Root cause: Namespace `cache: nix` volumes are a *pool* of independent copies — each concurrent job checks out its own volume and writes never merge. The 31-wide deploy build matrix mostly draws cold or stale volumes (and keeps the pool over the 100GB bundle quota, so warm volumes get evicted), rebuilding the shared dep closure from source over and over. Cachix was the safety net that made any volume miss a fast download; individual lambda builds that were 16s went to 9–15 min without it (one was OOM-killed rebuilding `aws-sdk-s3` — see run 30950355851).

## What

Restore the substituter role with a private S3 nix binary cache:

- `setup-nix` action optionally configures `extra-substituters` / `extra-trusted-public-keys` and starts the nix daemon with AWS credentials (the daemon performs substitution)
- warm jobs push the shared dep closures after building (`nix copy`, signed on upload)
- binary matrix jobs push their service outputs; the lambda build script pushes the exact handler out-paths it built — this is what makes an unchanged service a seconds-long substitution next run, even on a cold volume
- only the deploy pipeline gets the substituter and pushes; PR-triggered jobs never see the AWS secrets

Everything is gated on the `NIX_CACHE_URL` / `NIX_CACHE_PUBLIC_KEY` repo variables and `NIX_CACHE_SIGNING_KEY` secret, and pushes are non-fatal — with them unset the pipeline behaves exactly as today.

## Infra (already live)

- `s3://macro-nix-cache` (us-east-1, private, 75-day object expiry, zstd compression via the store URL)
- signing keypair `nix-cache.macro.com-1`; public key trusted in the daemon config, private key in the `NIX_CACHE_SIGNING_KEY` secret
- `cdk-deploy-user` is in `Administrators`, so no IAM changes
- push path smoke-tested from a dev machine (signed narinfo + zstd nar verified in the bucket)

First deploy after merge pays a one-time dep-closure upload (~2–4 min in the warm jobs); after that pushes are incremental no-ops and cold/stale volumes substitute instead of rebuilding. Expected steady state is back to pre-removal numbers: ~1 min jobs for unchanged services, 2–5 min for changed ones, ~11 min deploys.