### PR TITLE
fix(search): stop stale channel thread rows flashing in the search feed

### DIFF
--- a/apps/web/src/features/next-soup/filters/predicates.test.ts
+++ b/apps/web/src/features/next-soup/filters/predicates.test.ts
@@ -1,0 +1,77 @@
+import type { EntityData } from '@entity';
+import { describe, expect, it, vi } from 'vitest';
+
+// predicates.ts transitively imports the websocket client modules, which open
+// real sockets at module scope and reject under jsdom.
+vi.mock('@service-storage/websocket', () => ({
+  storageWS: { reconnectIfDisconnected: vi.fn() },
+  createWebSocketJob: vi.fn(),
+}));
+vi.mock('@service-connection/websocket', () => ({
+  ws: { addEventListener: vi.fn(), send: vi.fn() },
+  state: () => 'closed',
+  createConnectionBlockWebsocketEffect: vi.fn(),
+  createConnectionWebsocketEffect: vi.fn(),
+}));
+
+import { searchSupportedFilter } from './predicates';
+
+const entity = (
+  type: string,
+  extra: Record<string, unknown> = {}
+): EntityData => ({ type, id: `${type}-1`, ...extra }) as unknown as EntityData;
+
+describe('searchSupportedFilter', () => {
+  // The search preset NIL-excludes channel threads server-side, so a thread row
+  // reaching the feed is always stale cache — another view's rows held as
+  // placeholder data, or a websocket insert. They render as an unnamed row with
+  // the fallback icon until the real results land.
+  it('rejects channel threads', () => {
+    expect(
+      searchSupportedFilter(
+        entity('channel_thread', {
+          channelId: 'channel-1',
+          threadId: 'root-msg',
+        })
+      )
+    ).toBe(false);
+  });
+
+  it('rejects foreign entities and CRM rows', () => {
+    expect(searchSupportedFilter(entity('foreign'))).toBe(false);
+    expect(searchSupportedFilter(entity('crm_company'))).toBe(false);
+    expect(searchSupportedFilter(entity('crm_contact'))).toBe(false);
+  });
+
+  // Searching a message that lives in a thread does return a hit, but the
+  // search service maps it to `channel_message` carrying a `threadId` — never
+  // to `channel_thread`, which is a whole-thread soup row (root message,
+  // reply count, preview) with no equivalent in the search response.
+  it('keeps the channel rows search does return, thread replies included', () => {
+    expect(searchSupportedFilter(entity('channel'))).toBe(true);
+    expect(
+      searchSupportedFilter(
+        entity('channel_message', {
+          channelId: 'channel-1',
+          messageId: 'msg-1',
+        })
+      )
+    ).toBe(true);
+    expect(
+      searchSupportedFilter(
+        entity('channel_message', {
+          channelId: 'channel-1',
+          messageId: 'reply-1',
+          threadId: 'root-msg',
+          target: { messageId: 'reply-1', threadId: 'root-msg' },
+        })
+      )
+    ).toBe(true);
+  });
+
+  it('keeps every other searchable entity type', () => {
+    for (const type of ['document', 'email', 'chat', 'project', 'call']) {
+      expect(searchSupportedFilter(entity(type))).toBe(true);
+    }
+  });
+});

--- a/apps/web/src/features/next-soup/filters/predicates.ts
+++ b/apps/web/src/features/next-soup/filters/predicates.ts
@@ -143,15 +143,19 @@ export function crmCompanyFilter(entity: EntityData): boolean {
 
 /**
  * Entity types the search view supports. Mirrors the search preset's
- * server-side exclusions (foreign entities + CRM) so entities that enter
- * the soup cache outside the query — e.g. websocket-driven optimistic
- * inserts — don't surface in the search feed.
+ * server-side exclusions (foreign entities, CRM, channel threads) so entities
+ * that enter the soup cache outside the query — websocket-driven optimistic
+ * inserts, or another view's rows held as placeholder data while this view's
+ * query loads — don't surface in the search feed. Channel threads are only
+ * renderable in the inbox, which requests them explicitly; everywhere else the
+ * AST NIL-excludes them, so a thread row here is always stale cache.
  */
 export function searchSupportedFilter(entity: EntityData): boolean {
   return (
     entity.type !== 'foreign' &&
     entity.type !== 'crm_company' &&
-    entity.type !== 'crm_contact'
+    entity.type !== 'crm_contact' &&
+    entity.type !== 'channel_thread'
   );
 }
 

--- a/apps/web/src/features/next-soup/sidebar/soup-filter-presets.test.ts
+++ b/apps/web/src/features/next-soup/sidebar/soup-filter-presets.test.ts
@@ -6,6 +6,7 @@ vi.mock('@core/constant/featureFlags', () => ({
   ENABLE_SUPPORTED_SOUP_FOREIGN_ENTITIES_OVERRIDE: false,
 }));
 
+import { NIL_UUID } from '@app/features/next-soup/filters/filter-store';
 import { getViewPreset, VIEW_TAB_PRESETS } from './soup-filter-presets';
 
 const mailTabs = Object.keys(VIEW_TAB_PRESETS.mail.tabs);
@@ -15,5 +16,18 @@ describe('mail view presets', () => {
     for (const tab of mailTabs) {
       expect(getViewPreset('mail', tab)?.groupBy).toBe('date');
     }
+  });
+});
+
+describe('search view preset', () => {
+  // Channel threads render as an unnamed fallback row, so search excludes them
+  // server-side. `search-supported` is the client-side mirror that keeps rows
+  // arriving outside the query (websocket inserts, another view's placeholder
+  // rows) out of the feed — dropping either half brings the bad rows back.
+  it('excludes channel threads server-side and mirrors it client-side', () => {
+    const preset = getViewPreset('search');
+
+    expect(preset?.filters?.include?.channelThreadId).toEqual([NIL_UUID]);
+    expect(preset?.clientFilters?.and).toContain('search-supported');
   });
 });


### PR DESCRIPTION
The search preset NIL-excludes channel threads server-side and documents `search-supported` as the client-side mirror, but that predicate only rejected foreign entities and CRM rows, so thread rows entering the soup cache outside the query — mainly the previous view's rows held as placeholder data while the search query loads — rendered unnamed with the fallback icon until the real results landed. Search-service message hits are unaffected: a reply in a thread comes back as a `channel_message` carrying `threadId`, never as the `channel_thread` soup row this drops.
