### PR TITLE
fix(channel_bot): notify all channel members on response

### DIFF
--- a/crates/channels/src/domain/models.rs
+++ b/crates/channels/src/domain/models.rs
@@ -904,7 +904,7 @@ pub enum PatchMessageNotificationPolicy {
     /// Apply the normal edit behavior: realtime/search only, no notifications.
     #[default]
     Default,
-    /// Notify as though the patched message content had just been posted.
+    /// Broadcast and notify as though the patched message content had just been posted.
     NotifyAsPostedMessage,
 }
 

--- a/crates/channels/src/domain/service.rs
+++ b/crates/channels/src/domain/service.rs
@@ -777,22 +777,7 @@ where
                 }
             }
 
-            let participants = if let Some(thread_id) = message.thread_id {
-                self.repo
-                    .get_thread_participants(thread_id)
-                    .await
-                    .map_err(|e| ChannelMutationErr::Repo(e.into()))?
-            } else {
-                participant_ids(
-                    &self
-                        .repo
-                        .get_participants(channel_id)
-                        .await
-                        .map_err(|e| ChannelMutationErr::Repo(e.into()))?,
-                )
-            };
-
-            let posted_notification =
+            let (recipients, posted_notification) =
                 if notification_policy == PatchMessageNotificationPolicy::NotifyAsPostedMessage {
                     let metadata = if let Some(user_actor) = actor.as_user() {
                         self.repo
@@ -815,6 +800,11 @@ where
                         .get_participants(channel_id)
                         .await
                         .map_err(|e| ChannelMutationErr::Repo(e.into()))?;
+                    // This patch replaces a message that was originally posted
+                    // to every channel participant (for example, Macro AI's
+                    // "thinking" placeholder). Keep the realtime audience the
+                    // same so observers do not retain the stale placeholder.
+                    let recipients = participant_ids(&notification_participants);
                     let has_attachments = !self
                         .repo
                         .get_message_attachments(message_id)
@@ -822,21 +812,38 @@ where
                         .map_err(|e| ChannelMutationErr::Repo(e.into()))?
                         .is_empty();
 
-                    Some(crate::domain::events::MessageChangedNotificationContext {
-                        metadata,
-                        participants: notification_participants,
-                        mentions: replacement_mentions.clone().unwrap_or_default(),
-                        has_attachments,
-                    })
+                    (
+                        recipients,
+                        Some(crate::domain::events::MessageChangedNotificationContext {
+                            metadata,
+                            participants: notification_participants,
+                            mentions: replacement_mentions.clone().unwrap_or_default(),
+                            has_attachments,
+                        }),
+                    )
                 } else {
-                    None
+                    let recipients = if let Some(thread_id) = message.thread_id {
+                        self.repo
+                            .get_thread_participants(thread_id)
+                            .await
+                            .map_err(|e| ChannelMutationErr::Repo(e.into()))?
+                    } else {
+                        participant_ids(
+                            &self
+                                .repo
+                                .get_participants(channel_id)
+                                .await
+                                .map_err(|e| ChannelMutationErr::Repo(e.into()))?,
+                        )
+                    };
+                    (recipients, None)
                 };
 
             self.events.dispatch(ChannelEvent::MessageChanged {
                 channel_id,
                 actor: actor.clone(),
                 message: message.clone(),
-                recipients: participants,
+                recipients,
                 nonce,
                 posted_notification,
             });

--- a/crates/channels/src/domain/service/test.rs
+++ b/crates/channels/src/domain/service/test.rs
@@ -1503,7 +1503,7 @@ async fn patch_message_propagates_channel_touch_errors() {
 }
 
 #[tokio::test]
-async fn patch_message_notify_as_posted_adds_notification_context() {
+async fn patch_message_notify_as_posted_broadcasts_to_channel_and_adds_notification_context() {
     let channel_id = Uuid::new_v4();
     let thread_id = Uuid::new_v4();
     let bot_id = BotId::new_from_uuid(Uuid::new_v4());
@@ -1511,6 +1511,22 @@ async fn patch_message_notify_as_posted_adds_notification_context() {
     let repo = FakeMutationRepo::new(channel_id, &bot_sender);
     repo.state.lock().unwrap().message.thread_id = Some(thread_id);
     repo.state.lock().unwrap().message.sender_id = Sender::new_from_bot(bot_id);
+    {
+        let mut state = repo.state.lock().unwrap();
+        let now = Utc::now();
+        state.participants = ["macro|requester@test.com", "macro|observer@test.com"]
+            .into_iter()
+            .map(|user_id| ChannelParticipant {
+                channel_id,
+                user_id: user_id.to_string(),
+                role: ParticipantRole::Member,
+                joined_at: now,
+                left_at: None,
+            })
+            .collect();
+        state.thread_participants =
+            vec![MacroUserIdStr::try_from("macro|requester@test.com".to_string()).unwrap()];
+    }
     let message_id = repo.state.lock().unwrap().message.id;
     let events = FakeEvents::default();
     let svc = mutation_service(
@@ -1540,6 +1556,7 @@ async fn patch_message_notify_as_posted_adds_notification_context() {
     assert_eq!(emitted.len(), 1);
     let ChannelEvent::MessageChanged {
         message,
+        recipients,
         posted_notification,
         ..
     } = &emitted[0]
@@ -1547,6 +1564,13 @@ async fn patch_message_notify_as_posted_adds_notification_context() {
         panic!("expected MessageChanged event, got {:?}", emitted[0]);
     };
     assert_eq!(message.content, "final answer");
+    assert_eq!(
+        recipients
+            .iter()
+            .map(|recipient| recipient.as_ref())
+            .collect::<Vec<_>>(),
+        vec!["macro|requester@test.com", "macro|observer@test.com"]
+    );
     let posted_notification = posted_notification
         .as_ref()
         .expect("expected posted notification context");


### PR DESCRIPTION
- We were only broadcasted the message update to thread participants, not channel participants.
