### PR TITLE
fix(channels): broadcast message edits to channel participants

### DIFF
--- a/crates/channels/src/domain/models.rs
+++ b/crates/channels/src/domain/models.rs
@@ -904,7 +904,7 @@ pub enum PatchMessageNotificationPolicy {
     /// Apply the normal edit behavior: realtime/search only, no notifications.
     #[default]
     Default,
-    /// Broadcast and notify as though the patched message content had just been posted.
+    /// Notify as though the patched message content had just been posted.
     NotifyAsPostedMessage,
 }
 

--- a/crates/channels/src/domain/service.rs
+++ b/crates/channels/src/domain/service.rs
@@ -777,7 +777,14 @@ where
                 }
             }
 
-            let (recipients, posted_notification) =
+            let channel_participants = self
+                .repo
+                .get_participants(channel_id)
+                .await
+                .map_err(|e| ChannelMutationErr::Repo(e.into()))?;
+            let recipients = participant_ids(&channel_participants);
+
+            let posted_notification =
                 if notification_policy == PatchMessageNotificationPolicy::NotifyAsPostedMessage {
                     let metadata = if let Some(user_actor) = actor.as_user() {
                         self.repo
@@ -795,16 +802,6 @@ where
                             channel_name: info.name.unwrap_or_default(),
                         }
                     };
-                    let notification_participants = self
-                        .repo
-                        .get_participants(channel_id)
-                        .await
-                        .map_err(|e| ChannelMutationErr::Repo(e.into()))?;
-                    // This patch replaces a message that was originally posted
-                    // to every channel participant (for example, Macro AI's
-                    // "thinking" placeholder). Keep the realtime audience the
-                    // same so observers do not retain the stale placeholder.
-                    let recipients = participant_ids(&notification_participants);
                     let has_attachments = !self
                         .repo
                         .get_message_attachments(message_id)
@@ -812,31 +809,14 @@ where
                         .map_err(|e| ChannelMutationErr::Repo(e.into()))?
                         .is_empty();
 
-                    (
-                        recipients,
-                        Some(crate::domain::events::MessageChangedNotificationContext {
-                            metadata,
-                            participants: notification_participants,
-                            mentions: replacement_mentions.clone().unwrap_or_default(),
-                            has_attachments,
-                        }),
-                    )
+                    Some(crate::domain::events::MessageChangedNotificationContext {
+                        metadata,
+                        participants: channel_participants,
+                        mentions: replacement_mentions.clone().unwrap_or_default(),
+                        has_attachments,
+                    })
                 } else {
-                    let recipients = if let Some(thread_id) = message.thread_id {
-                        self.repo
-                            .get_thread_participants(thread_id)
-                            .await
-                            .map_err(|e| ChannelMutationErr::Repo(e.into()))?
-                    } else {
-                        participant_ids(
-                            &self
-                                .repo
-                                .get_participants(channel_id)
-                                .await
-                                .map_err(|e| ChannelMutationErr::Repo(e.into()))?,
-                        )
-                    };
-                    (recipients, None)
+                    None
                 };
 
             self.events.dispatch(ChannelEvent::MessageChanged {

--- a/crates/channels/src/domain/service/test.rs
+++ b/crates/channels/src/domain/service/test.rs
@@ -1303,7 +1303,7 @@ async fn bot_patch_message_derives_replacement_mentions_from_content() {
 }
 
 #[tokio::test]
-async fn patch_message_content_emits_message_changed_event_to_thread_participants() {
+async fn patch_message_content_emits_message_changed_event_to_channel_participants() {
     let channel_id = Uuid::new_v4();
     let thread_id = Uuid::new_v4();
     let repo = FakeMutationRepo::new(channel_id, "macro|sender@test.com");
@@ -1349,8 +1349,13 @@ async fn patch_message_content_emits_message_changed_event_to_thread_participant
     assert_eq!(message.id, message_id);
     assert_eq!(message.content, "edited");
     assert_eq!(nonce.as_deref(), Some("edit-nonce"));
-    assert_eq!(recipients.len(), 1);
-    assert_eq!(recipients[0].as_ref(), "macro|thread@test.com");
+    assert_eq!(
+        recipients
+            .iter()
+            .map(|recipient| recipient.as_ref())
+            .collect::<Vec<_>>(),
+        vec!["macro|sender@test.com", "macro|recipient@test.com"]
+    );
     assert_eq!(
         repo.state.lock().unwrap().touched_channel_ids,
         vec![channel_id]
@@ -1503,7 +1508,7 @@ async fn patch_message_propagates_channel_touch_errors() {
 }
 
 #[tokio::test]
-async fn patch_message_notify_as_posted_broadcasts_to_channel_and_adds_notification_context() {
+async fn patch_message_notify_as_posted_adds_notification_context_for_channel_participants() {
     let channel_id = Uuid::new_v4();
     let thread_id = Uuid::new_v4();
     let bot_id = BotId::new_from_uuid(Uuid::new_v4());
@@ -1524,8 +1529,6 @@ async fn patch_message_notify_as_posted_broadcasts_to_channel_and_adds_notificat
                 left_at: None,
             })
             .collect();
-        state.thread_participants =
-            vec![MacroUserIdStr::try_from("macro|requester@test.com".to_string()).unwrap()];
     }
     let message_id = repo.state.lock().unwrap().message.id;
     let events = FakeEvents::default();


### PR DESCRIPTION
## Summary

- broadcast message-content edits to every active channel participant
- keep thread participation scoped to notification targeting rather than realtime cache consistency
- update domain tests to cover passive channel members receiving threaded edits

## Root cause

Threaded message patches used the recorded thread participant list for realtime recipients. Channel members who were viewing a thread but had not posted or been mentioned could retain stale message content until refreshing.

## Impact

Top-level and threaded message edits now use the same active channel audience for realtime updates. Notification behavior, persistence, and authorization are unchanged.

## Validation

- `cargo test -p channels --features ports` (118 passed)
- `cargo test -p channel_bots handle_patches_thinking_message_with_reply`
- `cargo clippy -p channels --features ports --tests -- -A clippy::unnecessary-to-owned -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
