### PR TITLE
feat(email): internal endpoint to reindex specific threads

### DIFF
--- a/.sqlx/query-63d5c11fd6674bfd837e13061d49f09f1cea5a9815302913d941a387248c86f0.json
+++ b/.sqlx/query-63d5c11fd6674bfd837e13061d49f09f1cea5a9815302913d941a387248c86f0.json
@@ -1,0 +1,34 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT t.id, t.link_id, l.macro_id\n        FROM email_threads t\n        JOIN email_links l ON t.link_id = l.id\n        WHERE t.id = ANY($1)\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "link_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "macro_id",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "UuidArray"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "63d5c11fd6674bfd837e13061d49f09f1cea5a9815302913d941a387248c86f0"
+}

--- a/crates/email/src/domain/events.rs
+++ b/crates/email/src/domain/events.rs
@@ -91,6 +91,8 @@ pub enum SendCancelReason {
 pub enum ThreadsReindexReason {
     /// Contact display names changed; sender/recipient names in the index are stale.
     ContactsChanged,
+    /// An operator asked for these threads to be reindexed.
+    ManualRepair,
 }
 
 /// Metadata for [`EmailTopicEvent::LinkConnected`].

--- a/crates/email_db_client/src/threads/get.rs
+++ b/crates/email_db_client/src/threads/get.rs
@@ -273,6 +273,33 @@ pub async fn get_macro_id_from_thread_id(
     Ok(macro_id)
 }
 
+/// Resolve the owning link and Macro user for many threads at once.
+///
+/// Threads that do not exist are absent from the result, so callers can diff
+/// against their input to find unknown ids.
+#[tracing::instrument(skip(pool, thread_ids), err)]
+pub async fn get_thread_links_by_ids(
+    pool: &PgPool,
+    thread_ids: &[Uuid],
+) -> anyhow::Result<Vec<(Uuid, Uuid, String)>> {
+    let rows = sqlx::query!(
+        r#"
+        SELECT t.id, t.link_id, l.macro_id
+        FROM email_threads t
+        JOIN email_links l ON t.link_id = l.id
+        WHERE t.id = ANY($1)
+        "#,
+        thread_ids
+    )
+    .fetch_all(pool)
+    .await?;
+
+    Ok(rows
+        .into_iter()
+        .map(|row| (row.id, row.link_id, row.macro_id))
+        .collect())
+}
+
 /// Gets a single thread by ID and link_ID
 #[tracing::instrument(skip(pool), err)]
 pub async fn get_thread_by_id_and_link_id(

--- a/services/email_service/src/api/internal/mod.rs
+++ b/services/email_service/src/api/internal/mod.rs
@@ -10,6 +10,7 @@ mod get_messages_by_thread_id;
 mod get_thread_histories;
 mod get_thread_owner;
 mod gmail;
+mod reindex_threads;
 
 pub fn router() -> Router<ApiContext> {
     Router::new()
@@ -29,4 +30,5 @@ pub fn router() -> Router<ApiContext> {
         .route("/backfill/provider/gmail/{id}", get(gmail::get::handler))
         .route("/delete_user/{id}", delete(delete_user::handler))
         .route("/threads/{id}/owner", get(get_thread_owner::handler))
+        .route("/threads/reindex", post(reindex_threads::handler))
 }

--- a/services/email_service/src/api/internal/reindex_threads.rs
+++ b/services/email_service/src/api/internal/reindex_threads.rs
@@ -1,0 +1,187 @@
+use std::collections::{HashMap, HashSet};
+
+use axum::Json;
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use email::domain::events::{
+    EmailMacroEvent, ThreadsReindexReason, ThreadsReindexRequestedMetadata,
+};
+use macro_authorization::{InternalOnly, MacroAuthorizationExtractor};
+use macro_user_id::cowlike::CowLike;
+use macro_user_id::user_id::MacroUserIdStr;
+use model::response::ErrorResponse;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use email_service::pubsub::util::publish_email_event;
+
+use crate::api::context::{ApiContext, AuthorizationService};
+
+#[cfg(test)]
+mod test;
+
+/// Thread ids per request. Publishing is fire-and-forget, so a caller with more
+/// than this splits the work and sees partial progress between calls.
+const MAX_THREAD_IDS: usize = 5000;
+
+/// Thread ids per published event, matching the contacts-sync producer.
+const REINDEX_BATCH_SIZE: usize = 50;
+
+#[derive(Debug, Deserialize)]
+pub struct ReindexThreadsRequest {
+    pub thread_ids: Vec<Uuid>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ReindexThreadsResponse {
+    /// Threads that resolved to a live link and were published.
+    pub threads_requested: usize,
+    /// Events published, each covering up to 50 threads.
+    pub events_published: usize,
+    /// Requested ids with no matching thread row.
+    pub unknown_thread_ids: Vec<Uuid>,
+}
+
+/// One event's worth of work: a single link, its owner, and up to
+/// [`REINDEX_BATCH_SIZE`] of its threads.
+#[derive(Debug, PartialEq, Eq)]
+pub(super) struct ReindexBatch {
+    pub link_id: Uuid,
+    pub macro_id: String,
+    pub thread_ids: Vec<Uuid>,
+}
+
+/// Turn resolved thread rows into publishable batches, plus the requested ids
+/// that matched no thread.
+///
+/// An event carries one link and owner, so threads group by link before they
+/// chunk. Duplicate requested ids collapse, since publishing a thread twice
+/// only costs a redundant reindex.
+pub(super) fn plan_reindex_batches(
+    requested: &[Uuid],
+    resolved: Vec<(Uuid, Uuid, String)>,
+) -> (Vec<ReindexBatch>, Vec<Uuid>) {
+    let found: HashSet<Uuid> = resolved.iter().map(|(id, _, _)| *id).collect();
+
+    let mut seen_unknown = HashSet::new();
+    let unknown: Vec<Uuid> = requested
+        .iter()
+        .filter(|id| !found.contains(id) && seen_unknown.insert(**id))
+        .copied()
+        .collect();
+
+    let mut by_link: HashMap<(Uuid, String), Vec<Uuid>> = HashMap::new();
+    let mut seen_thread = HashSet::new();
+    for (thread_id, link_id, macro_id) in resolved {
+        if !seen_thread.insert(thread_id) {
+            continue;
+        }
+        by_link
+            .entry((link_id, macro_id))
+            .or_default()
+            .push(thread_id);
+    }
+
+    let mut batches = Vec::new();
+    for ((link_id, macro_id), thread_ids) in by_link {
+        for chunk in thread_ids.chunks(REINDEX_BATCH_SIZE) {
+            batches.push(ReindexBatch {
+                link_id,
+                macro_id: macro_id.clone(),
+                thread_ids: chunk.to_vec(),
+            });
+        }
+    }
+
+    (batches, unknown)
+}
+
+/// Ask search to reindex specific email threads.
+///
+/// Publishes the same events contact-name sync does, so consumers need no new
+/// handling. Intended for repairing threads whose index updates were lost —
+/// nothing else re-emits them once the original event is gone.
+#[tracing::instrument(skip(ctx, request), fields(thread_count = request.thread_ids.len()))]
+pub async fn handler(
+    State(ctx): State<ApiContext>,
+    _: MacroAuthorizationExtractor<AuthorizationService, InternalOnly>,
+    Json(request): Json<ReindexThreadsRequest>,
+) -> Result<Response, Response> {
+    if request.thread_ids.is_empty() {
+        return Err(error_response(
+            StatusCode::BAD_REQUEST,
+            "thread_ids must not be empty",
+        ));
+    }
+    if request.thread_ids.len() > MAX_THREAD_IDS {
+        return Err(error_response(
+            StatusCode::BAD_REQUEST,
+            &format!("thread_ids exceeds the {MAX_THREAD_IDS} per-request limit"),
+        ));
+    }
+
+    let resolved =
+        email_db_client::threads::get::get_thread_links_by_ids(&ctx.db, &request.thread_ids)
+            .await
+            .map_err(|e| {
+                tracing::error!(error=?e, "unable to resolve threads for reindex");
+                error_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "unable to resolve threads",
+                )
+            })?;
+
+    let (batches, unknown_thread_ids) = plan_reindex_batches(&request.thread_ids, resolved);
+
+    let mut threads_requested = 0;
+    let mut events_published = 0;
+    for batch in batches {
+        let owner = match MacroUserIdStr::parse_from_str(&batch.macro_id) {
+            Ok(owner) => owner.into_owned(),
+            Err(e) => {
+                tracing::error!(error=?e, link_id=%batch.link_id, "skipping link with unparseable owner");
+                continue;
+            }
+        };
+
+        threads_requested += batch.thread_ids.len();
+        publish_email_event(
+            ctx.macro_event_broker.as_ref(),
+            &EmailMacroEvent::threads_reindex_requested(ThreadsReindexRequestedMetadata {
+                link_id: batch.link_id,
+                owner,
+                thread_ids: batch.thread_ids,
+                reason: ThreadsReindexReason::ManualRepair,
+            }),
+        );
+        events_published += 1;
+    }
+
+    tracing::info!(
+        threads_requested,
+        events_published,
+        unknown = unknown_thread_ids.len(),
+        "published thread reindex requests"
+    );
+
+    Ok((
+        StatusCode::ACCEPTED,
+        Json(ReindexThreadsResponse {
+            threads_requested,
+            events_published,
+            unknown_thread_ids,
+        }),
+    )
+        .into_response())
+}
+
+fn error_response(status: StatusCode, message: &str) -> Response {
+    (
+        status,
+        Json(ErrorResponse {
+            message: message.into(),
+        }),
+    )
+        .into_response()
+}

--- a/services/email_service/src/api/internal/reindex_threads/test.rs
+++ b/services/email_service/src/api/internal/reindex_threads/test.rs
@@ -1,0 +1,104 @@
+use super::*;
+
+fn uuid(n: u128) -> Uuid {
+    Uuid::from_u128(n)
+}
+
+#[test]
+fn groups_threads_by_link() {
+    let link_a = uuid(100);
+    let link_b = uuid(200);
+    let (batches, unknown) = plan_reindex_batches(
+        &[uuid(1), uuid(2), uuid(3)],
+        vec![
+            (uuid(1), link_a, "macro|a@example.com".into()),
+            (uuid(2), link_b, "macro|b@example.com".into()),
+            (uuid(3), link_a, "macro|a@example.com".into()),
+        ],
+    );
+
+    assert!(unknown.is_empty());
+    assert_eq!(batches.len(), 2);
+    let a = batches
+        .iter()
+        .find(|b| b.link_id == link_a)
+        .expect("link a");
+    let b = batches
+        .iter()
+        .find(|b| b.link_id == link_b)
+        .expect("link b");
+    assert_eq!(a.thread_ids.len(), 2);
+    assert_eq!(b.thread_ids, vec![uuid(2)]);
+}
+
+#[test]
+fn chunks_at_the_batch_size() {
+    let link = uuid(100);
+    let requested: Vec<Uuid> = (0..125).map(uuid).collect();
+    let resolved = requested
+        .iter()
+        .map(|id| (*id, link, "macro|a@example.com".to_string()))
+        .collect();
+
+    let (batches, unknown) = plan_reindex_batches(&requested, resolved);
+
+    assert!(unknown.is_empty());
+    assert_eq!(batches.len(), 3);
+    let mut sizes: Vec<usize> = batches.iter().map(|b| b.thread_ids.len()).collect();
+    sizes.sort_unstable();
+    assert_eq!(sizes, vec![25, 50, 50]);
+    assert_eq!(
+        batches.iter().map(|b| b.thread_ids.len()).sum::<usize>(),
+        125
+    );
+}
+
+#[test]
+fn reports_requested_ids_that_match_no_thread() {
+    let (batches, unknown) = plan_reindex_batches(
+        &[uuid(1), uuid(2), uuid(3)],
+        vec![(uuid(2), uuid(100), "macro|a@example.com".into())],
+    );
+
+    assert_eq!(unknown, vec![uuid(1), uuid(3)]);
+    assert_eq!(batches.len(), 1);
+    assert_eq!(batches[0].thread_ids, vec![uuid(2)]);
+}
+
+#[test]
+fn collapses_duplicate_ids() {
+    let link = uuid(100);
+    let (batches, unknown) = plan_reindex_batches(
+        &[uuid(1), uuid(1), uuid(9), uuid(9)],
+        vec![
+            (uuid(1), link, "macro|a@example.com".into()),
+            (uuid(1), link, "macro|a@example.com".into()),
+        ],
+    );
+
+    assert_eq!(unknown, vec![uuid(9)]);
+    assert_eq!(batches.len(), 1);
+    assert_eq!(batches[0].thread_ids, vec![uuid(1)]);
+}
+
+#[test]
+fn nothing_resolved_yields_no_batches() {
+    let (batches, unknown) = plan_reindex_batches(&[uuid(1)], vec![]);
+
+    assert!(batches.is_empty());
+    assert_eq!(unknown, vec![uuid(1)]);
+}
+
+#[test]
+fn same_link_with_different_owners_stays_separate() {
+    let link = uuid(100);
+    let (batches, _) = plan_reindex_batches(
+        &[uuid(1), uuid(2)],
+        vec![
+            (uuid(1), link, "macro|a@example.com".into()),
+            (uuid(2), link, "macro|b@example.com".into()),
+        ],
+    );
+
+    assert_eq!(batches.len(), 2);
+}

--- a/services/email_service/src/pubsub/mod.rs
+++ b/services/email_service/src/pubsub/mod.rs
@@ -13,7 +13,7 @@ pub mod scheduled;
 #[cfg(feature = "sfs_delete")]
 pub mod sfs_deleter;
 pub mod sfs_uploader;
-pub(crate) mod util;
+pub mod util;
 pub(crate) mod worker_lifecycle;
 /// Log-and-drop publisher for `macro.email` events, re-exported for the
 /// HTTP binary's handlers.


### PR DESCRIPTION
Nothing re-emits a thread's search index update once the original event is gone, so a lost `email.thread_backfilled` leaves that thread unfindable until something else happens to touch it. `ThreadsReindexRequested` already exists and SPS already consumes it, but its only producer is contact-name sync, which can't be aimed at a chosen set of threads.

`POST /internal/threads/reindex` takes thread ids, resolves each one's owning link and Macro user, groups by link (an event carries a single link + owner) and publishes in batches of 50 to match the existing producer. Unknown ids return in the response rather than failing the request, duplicates collapse, and the 5000-id cap keeps a bulk repair visible as progress between calls since publishing is fire-and-forget. `plan_reindex_batches` is pure so the grouping and chunking are tested without an ApiContext.

Immediate use: ~8,415 threads across 383 inboxes are absent from email search because any thread containing a pre-2000-dated message failed to index until [#5437](https://github.com/macro-inc/macro/pull/5437). Sampling 200 of them found 0 present. The alternative repair path, `POST /internal/backfill/emails`, currently dies on read-replica statement cancellation.

`pubsub::util` becomes public because `api` is a bin-only module tree that reaches lib code as `email_service::…`; sibling `pubsub::context` is already public and consumed the same way from `api/calendar_watch.rs`.
