### PR TITLE
feat(reminders): reminder creation UI

### DIFF
--- a/apps/web/src/components/app/Layout.tsx
+++ b/apps/web/src/components/app/Layout.tsx
@@ -25,9 +25,11 @@ import {
 import { MacroMcpSetupModal } from '@app/features/integrations/mcp-setup/MacroMcpSetupModal';
 import { Paywall } from '@app/features/paywall/Paywall';
 import { PropertyEditorModal } from '@app/features/property/editor/PropertyEditorModal';
+import { CreateReminderModal } from '@app/features/reminders/CreateReminderModal';
 import { useOnboardingV4Flag } from '@app/features/setup/flow/useOnboardingV4Flag';
 import { GlobalShareModal } from '@app/features/sharing/global-share-modal/GlobalShareModal';
 import { IosShareSheet } from '@app/features/sharing/ios-share-sheet/IosShareSheet';
+import { ShowFeatureFlag } from '@app/lib/analytics/posthog';
 import { mountGlobalFocusListener } from '@app/signal/focus';
 import { AutomationComposer } from '@block-automation/component';
 import { useCallContextOptional } from '@channel/Call/CallContext';
@@ -45,6 +47,10 @@ import {
   SidebarVisibilityContext,
 } from '@components/app/sidebarVisibility';
 import { useIsAuthenticated } from '@core/auth';
+import {
+  ENABLE_REMINDERS_FLAG,
+  ENABLE_REMINDERS_OVERRIDE,
+} from '@core/constant/featureFlags';
 import { usePaywallState } from '@core/constant/PaywallState';
 import { isSoloSettings } from '@core/constant/SettingsState';
 import { attachGlobalDOMScope } from '@core/hotkey/hotkeys';
@@ -450,6 +456,15 @@ function LayoutInner(props: RouteSectionProps) {
           <CreateChannelModal />
           <CreateCompanyModal />
           <CreateContactModal />
+          {/* Reactive, unlike the imperative ENABLE_REMINDERS() gate on the
+              action: this decides whether the composer is mounted at all, so it
+              has to pick up a late PostHog answer. */}
+          <ShowFeatureFlag
+            key={ENABLE_REMINDERS_FLAG}
+            enabledOverride={ENABLE_REMINDERS_OVERRIDE}
+          >
+            <CreateReminderModal />
+          </ShowFeatureFlag>
           <Show when={isAddInboxDialogOpen()}>
             <AddInboxDialog />
           </Show>

--- a/apps/web/src/components/app/split-layout/components/SplitFileMenu.tsx
+++ b/apps/web/src/components/app/split-layout/components/SplitFileMenu.tsx
@@ -1,10 +1,18 @@
 import { openBulkEditModal } from '@app/features/entity/bulk-edit/BulkEditEntityModal';
-import { makeFavoriteAction } from '@app/features/next-soup/actions';
+import {
+  makeCreateReminderAction,
+  makeFavoriteAction,
+} from '@app/features/next-soup/actions';
+import { useFeatureFlag } from '@app/lib/analytics/posthog';
 import { MobileDrawer } from '@components/app/mobile/MobileDrawer';
 import type { BlockTool } from '@components/app/ResponsiveBlockToolbar';
 import { useBlockAliasedName, useBlockName } from '@core/block';
 import { useItemOperations } from '@core/component/FileList/useItemOperations';
 import { toast } from '@core/component/Toast/Toast';
+import {
+  ENABLE_REMINDERS_FLAG,
+  ENABLE_REMINDERS_OVERRIDE,
+} from '@core/constant/featureFlags';
 import { useQuickAccess } from '@core/context/quickAccess';
 import { triggerFocusInput } from '@core/directive/focusInput';
 import { isTouchDevice } from '@core/mobile/isTouchDevice';
@@ -12,6 +20,7 @@ import { useIsDocumentOwner } from '@core/signal/permissions';
 import { buildEntityData, type EntityData } from '@entity';
 import DotsThree from '@icon/dots-three-large.svg';
 import ArrowRight from '@phosphor/arrow-right.svg';
+import BellSimple from '@phosphor/bell-simple.svg';
 import CaretDown from '@phosphor/caret-down.svg';
 import CaretRight from '@phosphor/caret-right.svg';
 import Copy from '@phosphor/copy.svg';
@@ -252,6 +261,7 @@ export function SplitFileMenu(props: {
   const itemOperations = useItemOperations();
   const quickAccess = useQuickAccess();
   const favoriteAction = makeFavoriteAction();
+  const createReminderAction = makeCreateReminderAction();
 
   const { replaceOrInsertSplit, resetSplit } = useSplitLayout();
 
@@ -280,6 +290,32 @@ export function SplitFileMenu(props: {
     };
   };
 
+  // Read reactively as well as through the action's imperative gate: `ops` below
+  // is a memo, so without a reactive dependency the item would stay missing for
+  // the life of this menu if PostHog answered after it was first computed. The
+  // other reminder surfaces re-evaluate per interaction and don't need this.
+  const remindersFlag = useFeatureFlag(ENABLE_REMINDERS_FLAG, {
+    enabledOverride: ENABLE_REMINDERS_OVERRIDE,
+  });
+
+  // Injected here rather than per-block so every block rendering this menu gets
+  // it, the way Favorite does. Entity types the reminders API cannot mint an
+  // access receipt for (channel messages/threads) return undefined and are
+  // filtered out.
+  const reminderOp = (): SplitFileMenuAction | undefined => {
+    if (!remindersFlag().enabled) return undefined;
+    const entity = menuEntity();
+    if (!entity || !createReminderAction.canExecute(entity)) return undefined;
+    return {
+      label: 'Remind me about this',
+      icon: BellSimple,
+      action: () => {
+        setOpen(false);
+        createReminderAction.execute([entity]);
+      },
+    };
+  };
+
   createEffect(() => {
     const openMenu = () => setOpen(true);
     ctx.setTitleFileMenuTrigger(() => openMenu);
@@ -288,6 +324,7 @@ export function SplitFileMenu(props: {
 
   const ops = createMemo<SplitFileMenuAction[]>(() => {
     const favorite = favoriteOp();
+    const reminder = reminderOp();
     const mapped = props.ops
       .map((op) => {
         if (isDefaultFileOperation(op)) {
@@ -387,7 +424,7 @@ export function SplitFileMenu(props: {
         }
       })
       .filter((op) => !!op);
-    return favorite ? [favorite, ...mapped] : mapped;
+    return [favorite, reminder, ...mapped].filter((op) => !!op);
   });
 
   const filteredTools = createMemo(() =>

--- a/apps/web/src/features/block-channel/component/NewChannelBlockAdapter.tsx
+++ b/apps/web/src/features/block-channel/component/NewChannelBlockAdapter.tsx
@@ -44,7 +44,9 @@ import { useBlockId } from '@core/block';
 import { EntityPermissionsGate } from '@core/component/EntityPermissionsGate';
 import { ENABLE_CALLS } from '@core/constant/featureFlags';
 import { useChannelName, useChannelType } from '@core/context/channels';
+import { useHotkeyDOMScope } from '@core/hotkey/hotkeys';
 import { awaitCondition, createMethodRegistration } from '@core/orchestrator';
+import { blockHotkeyScopeSignal } from '@core/signal/blockElement';
 import { blockHandleSignal } from '@core/signal/load';
 import { useActiveCallQuery } from '@queries/call/call';
 import {
@@ -185,6 +187,12 @@ function NewTop(props: { channelId: string }) {
 }
 
 export function NewChannelBlockAdapter(props: BlockChannelProps) {
+  // Every other block gets its hotkey scope from `BlockContainer`, which the
+  // channel block does not render — so `blockHotkeyScopeSignal` stayed empty
+  // here and `useBlockEntityCommands` registered nothing at all. Own the scope
+  // directly instead of adopting BlockContainer and its entity tracking.
+  const [attachHotkeys, hotkeyScope] = useHotkeyDOMScope('channel');
+  blockHotkeyScopeSignal.set(hotkeyScope);
   useBlockEntityCommands();
 
   const splitPanel = useSplitPanelOrThrow();
@@ -428,6 +436,7 @@ export function NewChannelBlockAdapter(props: BlockChannelProps) {
           onHandled={() => setPendingJoinCall(false)}
         />
         <div
+          ref={attachHotkeys}
           class={cn(
             'h-full flex flex-col px-2 mobile:px-0',
             // The channel block is full-frame on mobile (messages scroll

--- a/apps/web/src/features/block-email/component/Block.tsx
+++ b/apps/web/src/features/block-email/component/Block.tsx
@@ -2,15 +2,34 @@ import { useBlockEntityCommands } from '@app/features/next-soup/actions';
 import { useGlobalNotificationSource } from '@components/app/GlobalAppState';
 import { useSplitPanel } from '@components/app/split-layout/layoutUtils';
 import { DocumentBlockContainer } from '@core/component/DocumentBlockContainer';
+import { buildEntityData } from '@entity';
 import { EmailDebouncedReadMarker } from '@notifications';
 import { useThreadQuery } from '@queries/email/thread';
 import { createMemo, Show, Suspense } from 'solid-js';
 import { blockDataSignal } from '../signal/emailBlockData';
+import { displaySubject } from '../util/subjectText';
 import { EmailView } from './Email';
 
 export default function BlockEmail() {
-  useBlockEntityCommands();
   const blockData = blockDataSignal.get;
+
+  // Email threads are absent from quick access, so the entity the block-level
+  // commands act on has to come from here. Built off the block's loaded data
+  // rather than `threadQuery` because command-menu conditions read it outside a
+  // Suspense boundary.
+  const commandEntity = createMemo(() => {
+    const thread = blockData()?.thread;
+    if (!thread) return undefined;
+    return buildEntityData({
+      id: thread.db_id,
+      name: displaySubject(thread.messages[0]?.subject),
+      blockName: 'email',
+      isRead: thread.is_read,
+      done: !thread.inbox_visible,
+    });
+  });
+
+  useBlockEntityCommands(commandEntity);
   const notificationSource = useGlobalNotificationSource();
   // A Preview Pair Viewer shows the thread passively — wait longer before
   // marking it seen so scanning/previewing doesn't clear unread state.
@@ -25,9 +44,7 @@ export default function BlockEmail() {
   const title = () => {
     const data = threadQuery.data;
     if (!data || !data.thread || data.thread.messages.length === 0) return '';
-    if (data.thread.messages[0].subject?.length === 0) return '[No subject]';
-    // remove "re:" prefix(es)
-    return data.thread.messages[0].subject!.replace(/^(re:\s*)+/i, '');
+    return displaySubject(data.thread.messages[0].subject);
   };
 
   return (

--- a/apps/web/src/features/block-email/util/subjectText.test.ts
+++ b/apps/web/src/features/block-email/util/subjectText.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import { displaySubject } from './subjectText';
+
+describe('displaySubject', () => {
+  it('returns the subject as-is when there is nothing to strip', () => {
+    expect(displaySubject('Q3 contract')).toBe('Q3 contract');
+  });
+
+  it('strips a reply prefix, whatever its case', () => {
+    expect(displaySubject('Re: Q3 contract')).toBe('Q3 contract');
+    expect(displaySubject('re: Q3 contract')).toBe('Q3 contract');
+    expect(displaySubject('RE: Q3 contract')).toBe('Q3 contract');
+  });
+
+  it('strips the whole run of prefixes a long thread accumulates', () => {
+    expect(displaySubject('Re: RE: re: Q3 contract')).toBe('Q3 contract');
+  });
+
+  it('leaves a subject that merely starts with "re" alone', () => {
+    expect(displaySubject('Renewal terms')).toBe('Renewal terms');
+  });
+
+  // Previously this path did `subject!.replace(...)` on a missing subject, which
+  // threw rather than falling back.
+  it('names a missing or blank subject', () => {
+    expect(displaySubject(undefined)).toBe('[No subject]');
+    expect(displaySubject(null)).toBe('[No subject]');
+    expect(displaySubject('')).toBe('[No subject]');
+    expect(displaySubject('   ')).toBe('[No subject]');
+  });
+
+  it('names a subject that is nothing but reply prefixes', () => {
+    expect(displaySubject('Re: ')).toBe('[No subject]');
+  });
+});

--- a/apps/web/src/features/block-email/util/subjectText.ts
+++ b/apps/web/src/features/block-email/util/subjectText.ts
@@ -1,6 +1,17 @@
 import type { ApiMessage } from '@service-email/generated/schemas';
 import type { ReplyType } from './replyType';
 
+/**
+ * A thread subject as it should be shown: accumulated "re:" prefixes stripped,
+ * and a name for the blank case so callers never have to render an empty string.
+ */
+export const displaySubject = (subject: string | null | undefined): string => {
+  // Strip before testing for blank: a subject of just "Re:" is empty once the
+  // prefix is gone, and callers rely on this never returning an empty string.
+  const stripped = subject?.replace(/^(\s*re:\s*)+/i, '').trim();
+  return stripped || '[No subject]';
+};
+
 export const getSubjectText = (
   replyingTo: ApiMessage | undefined,
   replyType: ReplyType | undefined

--- a/apps/web/src/features/next-soup/actions/index.ts
+++ b/apps/web/src/features/next-soup/actions/index.ts
@@ -3,6 +3,7 @@ export { makeCopyAction } from './make-copy-action';
 export { makeCopyBranchNameAction } from './make-copy-branch-name-action';
 export { makeCopyEntityIdAction } from './make-copy-entity-id-action';
 export { makeCopyLinkAction } from './make-copy-link-action';
+export { makeCreateReminderAction } from './make-create-reminder-action';
 export { makeDeleteAction } from './make-delete-action';
 export { makeFavoriteAction } from './make-favorite-action';
 export { makeHideCompanyAction } from './make-hide-company-action';

--- a/apps/web/src/features/next-soup/actions/make-create-reminder-action.test.ts
+++ b/apps/web/src/features/next-soup/actions/make-create-reminder-action.test.ts
@@ -1,0 +1,115 @@
+import type { EntityData } from '@entity';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  openReminderComposer: vi.fn(),
+  remindersEnabled: true,
+}));
+
+vi.mock('@app/features/reminders/reminder-composer', () => ({
+  openReminderComposer: mocks.openReminderComposer,
+}));
+
+// Spread the original so the other flags in this module keep working; only the
+// reminders gate is driven by the tests. Under vitest MODE is not
+// 'development', so the real ENABLE_REMINDERS would resolve to false.
+vi.mock('@core/constant/featureFlags', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@core/constant/featureFlags')>()),
+  ENABLE_REMINDERS: () => mocks.remindersEnabled,
+}));
+
+import { makeCreateReminderAction } from './make-create-reminder-action';
+
+const entity = (type: EntityData['type'], id = 'e1') =>
+  ({ type, id, name: 'Thing' }) as EntityData;
+
+describe('makeCreateReminderAction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.remindersEnabled = true;
+  });
+
+  it('can run for entity types the reminders API accepts', () => {
+    const { canExecute } = makeCreateReminderAction();
+
+    expect(canExecute(entity('document'))).toBe(true);
+    expect(canExecute(entity('email'))).toBe(true);
+    expect(canExecute(entity('crm_company'))).toBe(true);
+  });
+
+  // Channel messages/threads have composite `channelId:messageId` ids that the
+  // entity-access layer cannot resolve an access level for.
+  it('cannot run for entity types with no reminder mapping', () => {
+    const { canExecute } = makeCreateReminderAction();
+
+    expect(canExecute(entity('channel_message'))).toBe(false);
+    expect(canExecute(entity('channel_thread'))).toBe(false);
+    expect(canExecute(entity('automation'))).toBe(false);
+  });
+
+  it('opens the composer for the entity', () => {
+    const target = entity('document', 'doc-1');
+
+    makeCreateReminderAction().execute([target]);
+
+    expect(mocks.openReminderComposer).toHaveBeenCalledWith(target);
+  });
+
+  it('does nothing for an empty selection', () => {
+    makeCreateReminderAction().execute([]);
+
+    expect(mocks.openReminderComposer).not.toHaveBeenCalled();
+  });
+
+  // A reminder points at one thing, so a multi-select uses the first entity
+  // rather than opening a composer per item.
+  it('uses only the first entity of a multi-selection', () => {
+    const first = entity('document', 'doc-1');
+
+    makeCreateReminderAction().execute([first, entity('document', 'doc-2')]);
+
+    expect(mocks.openReminderComposer).toHaveBeenCalledOnce();
+    expect(mocks.openReminderComposer).toHaveBeenCalledWith(first);
+  });
+
+  it('does not open the composer for an unsupported entity', () => {
+    makeCreateReminderAction().execute([entity('channel_message')]);
+
+    expect(mocks.openReminderComposer).not.toHaveBeenCalled();
+  });
+
+  // Every surface gates on canExecute, so a closed flag removes the hotkey, both
+  // soup menus and the block menu at once.
+  it('cannot run when the reminders flag is off', () => {
+    mocks.remindersEnabled = false;
+
+    expect(makeCreateReminderAction().canExecute(entity('document'))).toBe(
+      false
+    );
+  });
+
+  // execute re-checks the gate, so a command-menu entry left over from before
+  // the flag closed cannot still open the composer.
+  it('does not open the composer when the reminders flag is off', () => {
+    mocks.remindersEnabled = false;
+
+    makeCreateReminderAction().execute([entity('document', 'doc-1')]);
+
+    expect(mocks.openReminderComposer).not.toHaveBeenCalled();
+  });
+
+  // The soup context menu and soup command menu both drive actions through
+  // executeWithSoup, so the action is unreachable from a list without it.
+  it('opens the composer when driven from a soup list', async () => {
+    const target = entity('channel', 'channel-1');
+
+    await makeCreateReminderAction().executeWithSoup(
+      [target],
+      {} as Parameters<
+        ReturnType<typeof makeCreateReminderAction>['executeWithSoup']
+      >[1]
+    );
+
+    expect(mocks.openReminderComposer).toHaveBeenCalledWith(target);
+  });
+});

--- a/apps/web/src/features/next-soup/actions/make-create-reminder-action.ts
+++ b/apps/web/src/features/next-soup/actions/make-create-reminder-action.ts
@@ -1,0 +1,36 @@
+import { openReminderComposer } from '@app/features/reminders/reminder-composer';
+import { ENABLE_REMINDERS } from '@core/constant/featureFlags';
+import type { EntityData } from '@entity';
+import { reminderEntityType } from '@queries/reminders/reminders';
+import type { SoupState } from '../create-soup-state';
+
+/**
+ * Set a reminder about an entity.
+ *
+ * `execute` opens the composer rather than writing anything: the description
+ * and the date both come from the user, so there is nothing to do until that
+ * modal resolves. Single-entity only — a reminder points at one thing.
+ *
+ * `canExecute` carries the `ENABLE_REMINDERS` gate, which is what every surface
+ * (hotkeys, both soup menus, the block ⋯ menu) checks before offering the
+ * action — so the flag reaches all of them from here. `execute` re-checks it,
+ * since a stale command-menu entry could otherwise still fire.
+ */
+export const makeCreateReminderAction = () => {
+  const canExecute = (entity: EntityData): boolean =>
+    ENABLE_REMINDERS() && reminderEntityType(entity.type) !== undefined;
+
+  const execute = (entities: EntityData[]) => {
+    const [entity] = entities;
+    if (!entity || !canExecute(entity)) return;
+    openReminderComposer(entity);
+  };
+
+  const executeWithSoup = async (entities: EntityData[], _soup: SoupState) => {
+    // Opening the composer doesn't change the list, so selection and focus are
+    // left where they are.
+    execute(entities);
+  };
+
+  return { canExecute, execute, executeWithSoup };
+};

--- a/apps/web/src/features/next-soup/actions/use-block-entity-commands.ts
+++ b/apps/web/src/features/next-soup/actions/use-block-entity-commands.ts
@@ -14,7 +14,7 @@ import { HotkeyTags } from '@core/hotkey/constants';
 import { createHotkeyGroup, registerHotkey } from '@core/hotkey/hotkeys';
 import { TOKENS } from '@core/hotkey/tokens';
 import { blockHotkeyScopeSignal } from '@core/signal/blockElement';
-import { type EntityData, isTaskEntity } from '@entity';
+import { type EntityData, isDocumentEntity, isTaskEntity } from '@entity';
 import { SYSTEM_PROPERTY_IDS } from '@property/constants';
 import type { Property, PropertyDefinitionDomain } from '@property/types';
 import { macroEntityToPropertyEntityType } from '@property/utils';
@@ -24,6 +24,7 @@ import {
   makeCopyBranchNameAction,
   makeCopyEntityIdAction,
   makeCopyLinkAction,
+  makeCreateReminderAction,
   makeDeleteAction,
   makeFavoriteAction,
   makeMarkDoneAction,
@@ -36,8 +37,18 @@ import {
  * This should be called and mounted
  * Note: several of these do not register with an actual hot key so that they
  * can be found by the command menu.
+ *
+ * `resolveEntity` lets a block supply its own entity for blocks quick access
+ * cannot resolve. Quick access is built from history, channels, users, companies
+ * and snippets — email threads appear in none of them, so without an override
+ * `getEntity` returns undefined there and every command below silently drops
+ * out of the command menu. Blocks that pass one must use a non-suspending
+ * source: `condition()` runs inside command-menu evaluation, where a pending
+ * query must not suspend.
  */
-export const useBlockEntityCommands = () => {
+export const useBlockEntityCommands = (
+  resolveEntity?: () => EntityData | undefined
+) => {
   const blockId = useBlockId();
   const quickAccess = useQuickAccess();
   const userId = useUserId();
@@ -58,6 +69,7 @@ export const useBlockEntityCommands = () => {
   const copyBranchNameAction = makeCopyBranchNameAction();
   const copyEntityIdAction = makeCopyEntityIdAction();
   const favoriteAction = makeFavoriteAction();
+  const createReminderAction = makeCreateReminderAction();
 
   const allProperties = useAllProperties();
 
@@ -69,6 +81,8 @@ export const useBlockEntityCommands = () => {
   const assignees = () => propertyById(SYSTEM_PROPERTY_IDS.ASSIGNEES);
 
   const getEntity = (): EntityData | undefined => {
+    const provided = resolveEntity?.();
+    if (provided) return provided;
     const item = quickAccess.getById(blockId);
     if (item?.kind === 'entity') return item.data;
     return undefined;
@@ -102,6 +116,27 @@ export const useBlockEntityCommands = () => {
   const canUseMarkDoneHotkey = () => {
     const referredFrom = splitPanel?.handle.referredFrom();
     return referredFrom === 'inbox' || referredFrom === 'mail';
+  };
+
+  // The canvas block binds 'h' to its hand tool in this same scope
+  // (CanvasController). Canvas keeps the key; the reminder falls back to its
+  // command-menu-only registration there so no shortcut is advertised that the
+  // hand tool would swallow.
+  const canUseReminderHotkey = () => {
+    const entity = getEntity();
+    return !(
+      entity &&
+      isDocumentEntity(entity) &&
+      entity.fileType === 'canvas'
+    );
+  };
+
+  const runCreateReminder = () => {
+    const entity = getEntity();
+    if (!entity) return false;
+    if (!createReminderAction.canExecute(entity)) return false;
+    createReminderAction.execute([entity]);
+    return true;
   };
 
   const runMarkDone = () => {
@@ -329,6 +364,40 @@ export const useBlockEntityCommands = () => {
       keyDownHandler: () => {
         copyEntityIdAction.executeById(blockId);
         return true;
+      },
+      displayPriority: 10,
+      tags: [HotkeyTags.SelectionModification],
+    }).withGroup(group);
+
+    // Set a reminder - 'h'. 'add' rather than the default 'override', so this
+    // and the canvas hand tool coexist in the scope instead of whichever
+    // registered last evicting the other.
+    registerHotkey({
+      hotkey: ['h'],
+      hotkeyToken: TOKENS.entity.action.createReminder,
+      scopeId,
+      description: 'Remind me about this',
+      keyDownHandler: runCreateReminder,
+      condition: () => {
+        if (!canUseReminderHotkey()) return false;
+        const entity = getEntity();
+        return entity !== undefined && createReminderAction.canExecute(entity);
+      },
+      registrationType: 'add',
+      displayPriority: 10,
+      tags: [HotkeyTags.SelectionModification],
+    }).withGroup(group);
+
+    // Set a reminder without a keybinding on canvas, so it stays reachable
+    // from the command menu
+    registerHotkey({
+      scopeId,
+      description: 'Remind me about this',
+      keyDownHandler: runCreateReminder,
+      condition: () => {
+        if (canUseReminderHotkey()) return false;
+        const entity = getEntity();
+        return entity !== undefined && createReminderAction.canExecute(entity);
       },
       displayPriority: 10,
       tags: [HotkeyTags.SelectionModification],

--- a/apps/web/src/features/next-soup/actions/use-entity-action-hotkeys.ts
+++ b/apps/web/src/features/next-soup/actions/use-entity-action-hotkeys.ts
@@ -24,6 +24,7 @@ import {
   makeCopyBranchNameAction,
   makeCopyEntityIdAction,
   makeCopyLinkAction,
+  makeCreateReminderAction,
   makeDeleteAction,
   makeFavoriteAction,
   makeMarkDoneAction,
@@ -86,6 +87,7 @@ export const useEntityActionHotkeys = (
   const copyBranchNameAction = makeCopyBranchNameAction();
 
   const copyEntityIdAction = makeCopyEntityIdAction();
+  const createReminderAction = makeCreateReminderAction();
 
   const shareAction = makeShareAction();
 
@@ -474,6 +476,34 @@ export const useEntityActionHotkeys = (
         entities.length === 1 && copyEntityIdAction.canExecute(entities[0])
       );
     },
+    displayPriority: 10,
+    tags: [HotkeyTags.SelectionModification],
+  }).withGroup(group);
+
+  // Set a reminder - 'h'. This shares the scope with the list's 'h' ("Collapse
+  // item", handlerPriority 4), so 'add' keeps both registered instead of one
+  // evicting the other. Collapse sorts first and returns false when there is
+  // nothing to collapse, which falls through to here.
+  registerHotkey({
+    hotkey: ['h'],
+    hotkeyToken: TOKENS.entity.action.createReminder,
+    scopeId,
+    description: 'Remind me about this',
+    keyDownHandler: () => {
+      const entities = getEntitiesForAction();
+      if (entities.length !== 1) return false;
+      if (!createReminderAction.canExecute(entities[0])) return false;
+      createReminderAction.executeWithSoup(entities, soup);
+      return true;
+    },
+    condition: () => {
+      if (condition && !condition()) return false;
+      const entities = getEntitiesForAction();
+      return (
+        entities.length === 1 && createReminderAction.canExecute(entities[0])
+      );
+    },
+    registrationType: 'add',
     displayPriority: 10,
     tags: [HotkeyTags.SelectionModification],
   }).withGroup(group);

--- a/apps/web/src/features/next-soup/soup-view/create-soup-entity-actions.ts
+++ b/apps/web/src/features/next-soup/soup-view/create-soup-entity-actions.ts
@@ -17,6 +17,7 @@ import {
   makeCopyBranchNameAction,
   makeCopyEntityIdAction,
   makeCopyLinkAction,
+  makeCreateReminderAction,
   makeDeleteAction,
   makeFavoriteAction,
   makeHideCompanyAction,
@@ -120,6 +121,7 @@ export function createSoupEntityActions(): {
   const copyLinkAction = makeCopyLinkAction();
   const copyBranchNameAction = makeCopyBranchNameAction();
   const copyEntityIdAction = makeCopyEntityIdAction();
+  const createReminderAction = makeCreateReminderAction();
   const shareAction = makeShareAction();
   const blockSenderAction = makeBlockSenderAction();
   const markSenderSignalAction = makeMarkSenderSignalAction();
@@ -284,6 +286,16 @@ export function createSoupEntityActions(): {
         label: allFavorited ? 'Unfavorite' : 'Favorite',
         hotkeyToken: TOKENS.entity.action.favorite,
         onClick: handle(favoriteAction.executeWithSoup),
+      });
+    }
+
+    // Single-entity only: a reminder points at one thing.
+    if (entities.length === 1 && createReminderAction.canExecute(entities[0])) {
+      middleItems.push({
+        id: 'create-reminder',
+        label: 'Remind me about this',
+        hotkeyToken: TOKENS.entity.action.createReminder,
+        onClick: handle(createReminderAction.executeWithSoup),
       });
     }
 

--- a/apps/web/src/features/reminders/CreateReminderModal.tsx
+++ b/apps/web/src/features/reminders/CreateReminderModal.tsx
@@ -1,0 +1,268 @@
+import { toast } from '@core/component/Toast/Toast';
+import { registerHotkey, useHotkeyDOMScope } from '@core/hotkey/hotkeys';
+import { useDateSearch } from '@core/util/dateSearch/useDateSearch';
+import { useListKeyBindings } from '@core/util/useListKeyBindings';
+import { type EntityData, InlineEntity } from '@entity';
+import BellIcon from '@phosphor/bell-simple.svg';
+import {
+  reminderEntityType,
+  useCreateReminderMutation,
+} from '@queries/reminders/reminders';
+import { mergeRefs } from '@solid-primitives/refs';
+import {
+  CommandMenuEmptyState,
+  CommandMenuListItem,
+  CommandMenuSearchInput,
+  CommandMenuShell,
+  Dialog,
+} from '@ui';
+import {
+  createEffect,
+  createMemo,
+  createSelector,
+  createSignal,
+  For,
+  on,
+  onCleanup,
+  Show,
+} from 'solid-js';
+import {
+  closeReminderComposer,
+  reminderComposerOpen,
+  reminderComposerState,
+} from './reminder-composer';
+import {
+  futureDateOptions,
+  onceSchedule,
+  REMINDER_DEFAULT_TIME,
+  reminderDefaultOptions,
+  reminderDescriptionFor,
+} from './reminder-schedule';
+
+/**
+ * Asks one question — when — for a reminder about the entity the command was
+ * invoked on.
+ *
+ * This is deliberately the date editor reached by `shift+cmd+o`: the same shell,
+ * entity chip, search input and `useDateSearch` list. The entity is already
+ * known, so there is nothing to pick but the date.
+ */
+export function CreateReminderModal() {
+  const [dialogRef, setDialogRef] = createSignal<HTMLElement | undefined>();
+  const [attach, hotkeyScope] = useHotkeyDOMScope('reminder-composer');
+  const [query, setQuery] = createSignal('');
+  const [selectedIndex, setSelectedIndex] = createSignal(0);
+
+  const createReminder = useCreateReminderMutation();
+  const keybindings = useListKeyBindings(() => dialogRef());
+
+  const entity = () => reminderComposerState.entity;
+
+  const { dispose: disposeHotkey } = registerHotkey({
+    hotkey: ['escape'],
+    description: 'Close reminder composer',
+    keyDownHandler: () => {
+      closeReminderComposer();
+      return true;
+    },
+    scopeId: hotkeyScope,
+  });
+  onCleanup(disposeHotkey);
+
+  createEffect(
+    on(reminderComposerOpen, () => {
+      setQuery('');
+      setSelectedIndex(0);
+    })
+  );
+
+  const submit = async (date: Date, target: EntityData) => {
+    const description = reminderDescriptionFor(target);
+    const entityType = reminderEntityType(target.type);
+    closeReminderComposer();
+
+    try {
+      await createReminder.mutateAsync({
+        description,
+        schedule: onceSchedule(date),
+        // Both or neither: the API rejects one without the other.
+        ...(entityType ? { entityId: target.id, entityType } : undefined),
+      });
+      toast.success(`Reminder set for ${formatWhen(date)}`);
+    } catch {
+      toast.failure('Failed to create reminder');
+    }
+  };
+
+  return (
+    <Dialog
+      open={reminderComposerOpen()}
+      onOpenChange={(open) => {
+        if (!open) closeReminderComposer();
+      }}
+      contentRef={mergeRefs(attach, setDialogRef)}
+    >
+      <CommandMenuShell depth={2} class="rounded-xl max-h-108 text-sm">
+        <CommandMenuShell.Header>
+          <span class="pl-2 text-ink-extra-muted/55 pointer-events-none">
+            <BellIcon class="size-3" />
+          </span>
+          <CommandMenuSearchInput
+            class="text-base"
+            placeholder="Remind me when?"
+            value={query()}
+            onInput={(e) => setQuery(e.currentTarget.value)}
+            autofocus
+          />
+        </CommandMenuShell.Header>
+        <Show when={entity()}>
+          {(target) => (
+            <>
+              <CommandMenuShell.Toolbar class="p-3 py-2 border-b-0">
+                <div class="bg-active border border-edge-muted px-2 py-1 truncate text-xs rounded max-w-[50%]">
+                  <InlineEntity entity={target()} />
+                </div>
+              </CommandMenuShell.Toolbar>
+              <CommandMenuShell.Body>
+                <WhenList
+                  query={query}
+                  selectedIndex={selectedIndex}
+                  setSelectedIndex={setSelectedIndex}
+                  onSubmit={(date) => void submit(date, target())}
+                  setKeybindings={keybindings}
+                />
+              </CommandMenuShell.Body>
+            </>
+          )}
+        </Show>
+      </CommandMenuShell>
+    </Dialog>
+  );
+}
+
+function WhenList(props: {
+  query: () => string;
+  selectedIndex: () => number;
+  setSelectedIndex: (next: number | ((prev: number) => number)) => void;
+  onSubmit: (date: Date) => void;
+  setKeybindings: (actions: {
+    next: VoidFunction;
+    previous: VoidFunction;
+    select: () => void;
+  }) => void;
+}) {
+  const rawOptions = useDateSearch({
+    query: props.query,
+    defaultTime: REMINDER_DEFAULT_TIME,
+    showTimeInResults: true,
+  });
+
+  const dateOptions = createMemo(() => {
+    const now = new Date();
+    // The resting list is reminder-specific; typing hands off to the shared
+    // date search. Either way a reminder must fire in the future.
+    if (!props.query().trim()) return reminderDefaultOptions(now);
+    return futureDateOptions(rawOptions(), now);
+  });
+
+  createEffect(
+    on(dateOptions, (options) => {
+      if (options.length === 0) {
+        props.setSelectedIndex(0);
+      } else {
+        props.setSelectedIndex(
+          Math.min(props.selectedIndex(), options.length - 1)
+        );
+      }
+    })
+  );
+
+  props.setKeybindings({
+    next: () => {
+      const len = dateOptions().length;
+      if (len === 0) return;
+      props.setSelectedIndex((prev) => (prev + 1) % len);
+    },
+    previous: () => {
+      const len = dateOptions().length;
+      if (len === 0) return;
+      props.setSelectedIndex((prev) => (prev - 1 + len) % len);
+    },
+    select: () => {
+      const selected = dateOptions()[props.selectedIndex()];
+      if (selected) props.onSubmit(selected.date);
+    },
+  });
+
+  createEffect(() => {
+    const index = props.selectedIndex();
+    document
+      .getElementById(`reminder-date-option-${index}`)
+      ?.scrollIntoView({ block: 'nearest' });
+  });
+
+  const isSelected = createSelector(props.selectedIndex);
+
+  return (
+    <>
+      <div class="p-2 max-h-54 overflow-y-auto overflow-x-hidden scrollbar-hidden">
+        <Show
+          when={dateOptions().length > 0}
+          fallback={
+            <Show
+              when={props.query().trim()}
+              fallback={
+                <CommandMenuEmptyState>
+                  Enter a date, time or duration
+                </CommandMenuEmptyState>
+              }
+            >
+              <CommandMenuEmptyState>
+                No future dates match "{props.query()}"
+              </CommandMenuEmptyState>
+            </Show>
+          }
+        >
+          <For each={dateOptions()}>
+            {(option, index) => (
+              <CommandMenuListItem
+                id={`reminder-date-option-${index()}`}
+                selected={isSelected(index())}
+                onClick={() => props.onSubmit(option.date)}
+                onMouseMove={() => props.setSelectedIndex(index())}
+                class="scroll-m-2"
+              >
+                <div class="flex-1 text-left">
+                  <p class="text-sm font-medium">{option.displayText}</p>
+                </div>
+                <span class="text-xs text-ink-muted">
+                  {option.secondaryText}
+                </span>
+              </CommandMenuListItem>
+            )}
+          </For>
+        </Show>
+      </div>
+
+      <div class="p-4 border-t border-edge-muted">
+        <div class="text-xs text-ink-muted">
+          <span>Use queries like </span>
+          <code class="bg-active px-1">3d</code>,{' '}
+          <code class="bg-active px-1">1w</code>,{' '}
+          <code class="bg-active px-1">feb 17</code>,{' '}
+          <code class="bg-active px-1">tomorrow</code>, or{' '}
+          <code class="bg-active px-1">tomorrow 3pm</code>
+        </div>
+      </div>
+    </>
+  );
+}
+
+function formatWhen(date: Date): string {
+  return date.toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}

--- a/apps/web/src/features/reminders/CreateReminderModal.tsx
+++ b/apps/web/src/features/reminders/CreateReminderModal.tsx
@@ -77,6 +77,14 @@ export function CreateReminderModal() {
   );
 
   const submit = async (date: Date, target: EntityData) => {
+    // The options are filtered against the time the list was built, so one can
+    // slip into the past while the composer sits open. Re-check rather than
+    // let the API reject it with an opaque failure.
+    if (date.getTime() <= Date.now()) {
+      toast.failure('That time has already passed — pick another');
+      return;
+    }
+
     const description = reminderDescriptionFor(target);
     const entityType = reminderEntityType(target.type);
     closeReminderComposer();

--- a/apps/web/src/features/reminders/reminder-composer.test.ts
+++ b/apps/web/src/features/reminders/reminder-composer.test.ts
@@ -1,0 +1,51 @@
+import type { EntityData } from '@entity';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  closeReminderComposer,
+  openReminderComposer,
+  reminderComposerOpen,
+  reminderComposerState,
+} from './reminder-composer';
+
+const doc = (id: string, name: string) =>
+  ({ type: 'document', id, name }) as EntityData;
+
+describe('reminder composer state', () => {
+  beforeEach(() => {
+    closeReminderComposer();
+  });
+
+  it('opens with the entity the command was invoked on', () => {
+    openReminderComposer(doc('doc-1', 'Q3 Contract'));
+
+    expect(reminderComposerOpen()).toBe(true);
+    expect(reminderComposerState.entity?.id).toBe('doc-1');
+  });
+
+  it('clears the entity on close', () => {
+    openReminderComposer(doc('doc-1', 'Q3 Contract'));
+    closeReminderComposer();
+
+    expect(reminderComposerOpen()).toBe(false);
+    expect(reminderComposerState.entity).toBeUndefined();
+  });
+
+  // Reopening must fully replace the target, or a reminder could be attached to
+  // the previously opened entity.
+  it('replaces the entity when reopened for another one', () => {
+    openReminderComposer(doc('doc-1', 'Q3 Contract'));
+    closeReminderComposer();
+    openReminderComposer(doc('doc-2', 'Roadmap'));
+
+    expect(reminderComposerState.entity?.id).toBe('doc-2');
+    expect(reminderComposerState.entity?.name).toBe('Roadmap');
+  });
+
+  it('replaces the entity even without an intervening close', () => {
+    openReminderComposer(doc('doc-1', 'Q3 Contract'));
+    openReminderComposer(doc('doc-2', 'Roadmap'));
+
+    expect(reminderComposerState.entity?.id).toBe('doc-2');
+  });
+});

--- a/apps/web/src/features/reminders/reminder-composer.ts
+++ b/apps/web/src/features/reminders/reminder-composer.ts
@@ -1,0 +1,41 @@
+import { createControlledOpenSignal } from '@core/util/createControlledOpenSignal';
+import type { EntityData } from '@entity';
+import { batch } from 'solid-js';
+import { createStore, reconcile } from 'solid-js/store';
+
+export const [reminderComposerOpen, setReminderComposerOpen] =
+  createControlledOpenSignal(false, { id: 'reminder-create' });
+
+interface ReminderComposerState {
+  /** The entity the reminder is about. */
+  entity?: EntityData;
+}
+
+const [state, setState] = createStore<ReminderComposerState>({
+  entity: undefined,
+});
+
+/**
+ * Open the composer for an entity.
+ *
+ * There is only one thing left to ask: when. The entity is whatever the command
+ * was invoked on and the description is derived from it, so the composer opens
+ * straight onto the date list.
+ */
+export function openReminderComposer(entity: EntityData) {
+  // Batched so the modal's open-keyed effect sees this entity rather than the
+  // previous one.
+  batch(() => {
+    setState(reconcile({ entity }));
+    setReminderComposerOpen(true);
+  });
+}
+
+export function closeReminderComposer() {
+  batch(() => {
+    setReminderComposerOpen(false);
+    setState(reconcile({ entity: undefined }));
+  });
+}
+
+export const reminderComposerState = state;

--- a/apps/web/src/features/reminders/reminder-schedule.test.ts
+++ b/apps/web/src/features/reminders/reminder-schedule.test.ts
@@ -1,0 +1,210 @@
+import type { DateOption } from '@core/util/dateSearch/useDateSearch';
+import type { EntityData } from '@entity';
+import { describe, expect, it } from 'vitest';
+
+import {
+  futureDateOptions,
+  onceSchedule,
+  REMINDER_DEFAULT_TIME,
+  REMINDER_DESCRIPTION_MAX_LENGTH,
+  reminderDefaultOptions,
+  reminderDescriptionFor,
+} from './reminder-schedule';
+
+const option = (id: string, date: Date): DateOption => ({
+  id,
+  displayText: id,
+  date,
+  type: 'preset',
+});
+
+describe('futureDateOptions', () => {
+  const now = new Date('2026-07-29T12:00:00.000Z');
+
+  it('keeps options after now and drops ones already past', () => {
+    const kept = option('later', new Date('2026-07-30T09:00:00.000Z'));
+    const dropped = option('earlier', new Date('2026-07-28T09:00:00.000Z'));
+
+    expect(futureDateOptions([dropped, kept], now)).toEqual([kept]);
+  });
+
+  // The API rejects a remindAt that is not strictly in the future, so an option
+  // landing exactly on "now" has to go too.
+  it('drops an option exactly at now', () => {
+    expect(futureDateOptions([option('now', new Date(now))], now)).toEqual([]);
+  });
+
+  it('preserves the order of the options it keeps', () => {
+    const first = option('first', new Date('2026-07-30T09:00:00.000Z'));
+    const second = option('second', new Date('2026-07-31T09:00:00.000Z'));
+    const past = option('past', new Date('2026-07-01T09:00:00.000Z'));
+
+    expect(futureDateOptions([first, past, second], now)).toEqual([
+      first,
+      second,
+    ]);
+  });
+});
+
+describe('onceSchedule', () => {
+  it('builds a one-shot schedule at the given instant', () => {
+    const date = new Date('2026-07-30T13:00:00.000Z');
+
+    expect(onceSchedule(date)).toEqual({
+      type: 'once',
+      remindAt: '2026-07-30T13:00:00.000Z',
+    });
+  });
+});
+
+describe('reminderDefaultOptions', () => {
+  // A Wednesday afternoon, so every entry is still ahead of "now".
+  const wednesdayAfternoon = new Date(2026, 6, 29, 16, 37, 52, 400);
+
+  it('offers the five reminder defaults in order', () => {
+    expect(
+      reminderDefaultOptions(wednesdayAfternoon).map((o) => o.displayText)
+    ).toEqual([
+      'In 1 hour',
+      'In 2 hours',
+      'Tomorrow',
+      'End of week',
+      'In 1 week',
+    ]);
+  });
+
+  it('offsets the hour entries from now, keeping the time of day', () => {
+    const [oneHour, twoHours] = reminderDefaultOptions(wednesdayAfternoon);
+
+    expect(oneHour.date.getHours()).toBe(17);
+    expect(oneHour.date.getMinutes()).toBe(37);
+    expect(twoHours.date.getHours()).toBe(18);
+    expect(twoHours.date.getMinutes()).toBe(37);
+  });
+
+  // Seconds dropped so the stored instant is a whole minute.
+  it('rounds the hour entries down to the minute', () => {
+    const hourEntries = reminderDefaultOptions(wednesdayAfternoon).slice(0, 2);
+
+    for (const option of hourEntries) {
+      expect(option.date.getSeconds()).toBe(0);
+      expect(option.date.getMilliseconds()).toBe(0);
+    }
+  });
+
+  it('puts the day-scale entries at the default time', () => {
+    for (const option of reminderDefaultOptions(wednesdayAfternoon).slice(2)) {
+      expect(option.date.getHours()).toBe(REMINDER_DEFAULT_TIME.hours);
+      expect(option.date.getMinutes()).toBe(REMINDER_DEFAULT_TIME.minutes);
+    }
+  });
+
+  it('dates the day-scale entries a day, a week end and a week out', () => {
+    const [, , tomorrow, endOfWeek, oneWeek] =
+      reminderDefaultOptions(wednesdayAfternoon);
+
+    expect(tomorrow.date.getDate()).toBe(30);
+    // Week starts Monday, so the end of this week is Sunday the 2nd.
+    expect(endOfWeek.date.getMonth()).toBe(7);
+    expect(endOfWeek.date.getDate()).toBe(2);
+    expect(oneWeek.date.getDate()).toBe(5);
+  });
+
+  // On a Saturday the week ends tomorrow, so both land on Sunday morning.
+  it('drops a preset that duplicates an earlier one', () => {
+    const saturday = new Date(2026, 7, 1, 13, 0, 0);
+    const options = reminderDefaultOptions(saturday);
+    const labels = options.map((o) => o.displayText);
+
+    expect(labels).toContain('Tomorrow');
+    expect(labels).not.toContain('End of week');
+    expect(new Set(options.map((o) => o.date.getTime())).size).toBe(
+      options.length
+    );
+  });
+
+  // Late on a Sunday, "End of week" has already gone by — offering it would
+  // just produce a 400 from the API.
+  it('drops entries that have already passed', () => {
+    const sundayEvening = new Date(2026, 7, 2, 20, 0, 0);
+    const labels = reminderDefaultOptions(sundayEvening).map(
+      (o) => o.displayText
+    );
+
+    expect(labels).not.toContain('End of week');
+    expect(labels).toContain('In 1 hour');
+    expect(labels).toContain('Tomorrow');
+  });
+
+  it('describes each entry with a concrete date and time', () => {
+    const [oneHour] = reminderDefaultOptions(wednesdayAfternoon);
+
+    // Matched rather than compared: the time is rendered with the runtime
+    // locale's hour cycle, so an exact string pins the test to en-US.
+    expect(oneHour.secondaryText).toMatch(/^Today, \d{1,2}:\d{2}/);
+  });
+});
+
+describe('reminderDescriptionFor', () => {
+  const named = (type: EntityData['type'], name: string) =>
+    ({ type, id: 'e1', name }) as EntityData;
+
+  it('uses the entity name', () => {
+    expect(reminderDescriptionFor(named('document', 'Q3 Contract'))).toBe(
+      'Q3 Contract'
+    );
+  });
+
+  it('trims the entity name', () => {
+    expect(reminderDescriptionFor(named('document', '  Q3 Contract  '))).toBe(
+      'Q3 Contract'
+    );
+  });
+
+  // The API rejects an empty description, and plenty of entities have no name:
+  // a subject-less thread, a freshly created doc.
+  it('names an unnamed entity the way lists label it', () => {
+    expect(reminderDescriptionFor(named('email', ''))).toBe('(No Subject)');
+    expect(reminderDescriptionFor(named('document', '   '))).toBe('Untitled');
+    expect(reminderDescriptionFor(named('crm_company', ''))).toBe(
+      'Unknown Company'
+    );
+    expect(reminderDescriptionFor(named('crm_contact', ''))).toBe(
+      'Unknown Contact'
+    );
+  });
+
+  // Truncated rather than rejected: the description is derived from the entity,
+  // so there is no input the user could shorten to get past a validation error.
+  it('truncates an over-long name instead of failing', () => {
+    const long = 'x'.repeat(REMINDER_DESCRIPTION_MAX_LENGTH + 50);
+
+    expect(reminderDescriptionFor(named('document', long))).toHaveLength(
+      REMINDER_DESCRIPTION_MAX_LENGTH
+    );
+  });
+
+  it('leaves a name exactly at the limit alone', () => {
+    const atLimit = 'x'.repeat(REMINDER_DESCRIPTION_MAX_LENGTH);
+
+    expect(reminderDescriptionFor(named('document', atLimit))).toBe(atLimit);
+  });
+
+  // The service counts characters, not bytes, and truncating mid-surrogate
+  // would corrupt the emoji rather than drop it.
+  it('truncates by character, not by code unit', () => {
+    const emoji = '🔔'.repeat(REMINDER_DESCRIPTION_MAX_LENGTH + 10);
+    const result = reminderDescriptionFor(named('document', emoji));
+
+    expect([...result]).toHaveLength(REMINDER_DESCRIPTION_MAX_LENGTH);
+    expect(result.endsWith('🔔')).toBe(true);
+  });
+});
+
+describe('REMINDER_DEFAULT_TIME', () => {
+  // Bare dates come from presets that land on endOfDay; a reminder at 11:59 PM
+  // is easy to miss, so this is deliberately a morning.
+  it('is 9am', () => {
+    expect(REMINDER_DEFAULT_TIME).toEqual({ hours: 9, minutes: 0 });
+  });
+});

--- a/apps/web/src/features/reminders/reminder-schedule.ts
+++ b/apps/web/src/features/reminders/reminder-schedule.ts
@@ -1,0 +1,145 @@
+import {
+  type DateOption,
+  formatDateWithContext,
+} from '@core/util/dateSearch/useDateSearch';
+import type { EntityData } from '@entity';
+import type { ReminderSchedule } from '@service-storage/generated/schemas/reminderSchedule';
+import { addDays, addHours, addWeeks, endOfWeek } from 'date-fns';
+
+/**
+ * The time of day a bare date resolves to.
+ *
+ * The date presets shared with the due-date editor land on `endOfDay`, which
+ * would put every reminder at 11:59 PM. A reminder is meant to be acted on, so
+ * bare dates get a morning instead; typing a time ("tomorrow 3pm") overrides it.
+ */
+export const REMINDER_DEFAULT_TIME = { hours: 9, minutes: 0 } as const;
+
+/** Longest description the API accepts, mirroring the service's own limit. */
+export const REMINDER_DESCRIPTION_MAX_LENGTH = 2000;
+
+/**
+ * Drop options that have already passed.
+ *
+ * The API rejects a `remindAt` in the past, and the date search happily returns
+ * past dates for a typed query ("yesterday", or a month already gone by). The
+ * no-query preset list filters itself; this covers everything else.
+ */
+export function futureDateOptions(
+  options: readonly DateOption[],
+  now: Date
+): DateOption[] {
+  return options.filter((option) => option.date.getTime() > now.getTime());
+}
+
+/** A one-shot schedule firing at `date`. */
+export function onceSchedule(date: Date): ReminderSchedule {
+  return { type: 'once', remindAt: date.toISOString() };
+}
+
+/** The same instant, at `REMINDER_DEFAULT_TIME`. */
+function atDefaultTime(date: Date): Date {
+  const result = new Date(date);
+  result.setHours(
+    REMINDER_DEFAULT_TIME.hours,
+    REMINDER_DEFAULT_TIME.minutes,
+    0,
+    0
+  );
+  return result;
+}
+
+/** The same instant, with seconds dropped. */
+function toWholeMinute(date: Date): Date {
+  const result = new Date(date);
+  result.setSeconds(0, 0);
+  return result;
+}
+
+/**
+ * What the reminder picker offers before anything is typed.
+ *
+ * Deliberately not the shared `searchPresets` list, which is built for due dates
+ * — it leads with "Today"/"Yesterday" and every entry lands on `endOfDay`.
+ * Typing still goes through `useDateSearch`, so the shared presets remain
+ * reachable by name; this only replaces the resting list.
+ *
+ * The hour offsets keep their computed clock time (an "in 1 hour" reminder at
+ * 9am would be useless); the day-scale ones get the morning default.
+ */
+export function reminderDefaultOptions(now: Date): DateOption[] {
+  const entries: Array<{ id: string; label: string; date: Date }> = [
+    {
+      id: 'in-1-hour',
+      label: 'In 1 hour',
+      date: toWholeMinute(addHours(now, 1)),
+    },
+    {
+      id: 'in-2-hours',
+      label: 'In 2 hours',
+      date: toWholeMinute(addHours(now, 2)),
+    },
+    { id: 'tomorrow', label: 'Tomorrow', date: atDefaultTime(addDays(now, 1)) },
+    {
+      id: 'end-of-week',
+      label: 'End of week',
+      date: atDefaultTime(endOfWeek(now, { weekStartsOn: 1 })),
+    },
+    {
+      id: 'in-1-week',
+      label: 'In 1 week',
+      date: atDefaultTime(addWeeks(now, 1)),
+    },
+  ];
+
+  // On a Saturday `endOfWeek` (Sunday) is the same instant as "Tomorrow" at the
+  // morning default, which would offer the same time under two labels.
+  const seen = new Set<number>();
+  const unique = entries.filter(({ date }) => {
+    const time = date.getTime();
+    if (seen.has(time)) return false;
+    seen.add(time);
+    return true;
+  });
+
+  return futureDateOptions(
+    unique.map(({ id, label, date }) => ({
+      id,
+      displayText: label,
+      secondaryText: formatDateWithContext(date, now, true),
+      date,
+      type: 'preset' as const,
+    })),
+    now
+  );
+}
+
+/** What an entity with no usable name is called, matching how lists render it. */
+function untitledName(type: EntityData['type']): string {
+  switch (type) {
+    case 'email':
+      return '(No Subject)';
+    case 'crm_company':
+      return 'Unknown Company';
+    case 'crm_contact':
+      return 'Unknown Contact';
+    default:
+      return 'Untitled';
+  }
+}
+
+/**
+ * The description for a reminder about `entity`.
+ *
+ * Derived rather than typed, so this must always produce something the API will
+ * accept: an unnamed entity falls back to how lists label it, and an over-long
+ * name is truncated instead of rejected — there is no input for the user to fix.
+ * Counts characters, not bytes, because the service's limit does.
+ */
+export function reminderDescriptionFor(entity: EntityData): string {
+  const name = entity.name?.trim();
+  const characters = [...(name || untitledName(entity.type))];
+  return characters.length > REMINDER_DESCRIPTION_MAX_LENGTH
+    ? characters.slice(0, REMINDER_DESCRIPTION_MAX_LENGTH).join('')
+    : characters.join('');
+}

--- a/apps/web/src/lib/core/hotkey/tokens.ts
+++ b/apps/web/src/lib/core/hotkey/tokens.ts
@@ -59,6 +59,7 @@ export const TOKENS = {
       copyBranchName: 'entity.action.copyBranchName',
       copyEntityId: 'entity.action.copyEntityId',
       favorite: 'entity.action.favorite',
+      createReminder: 'entity.action.createReminder',
       properties: 'entity.action.properties',
       tags: 'entity.action.tags',
       priority: 'entity.action.priority',


### PR DESCRIPTION
Second of three PRs re-slicing the reminders work. Stacked on #5462, which lands the schema, the reminders API, and the SQS fan-out dispatch.

Supersedes #5320 and #5402.

## What's here

The surfaces for creating a reminder:

- `CreateReminderModal` and the composer/schedule parsing behind it.
- The soup/entity action and its hotkey.
- The entry points that reach them — app layout, split file menu, and the email and channel blocks.

Everything is behind `ENABLE_REMINDERS`, which #5462 introduces along with the API these call.

## What's not here

The Soup integration and the Reminders sidebar view — those follow in the next PR.