### PR TITLE
feat(focus): re-work focus behavior and styling

### DIFF
--- a/apps/web/src/components/app/split-layout/components/SplitPanel.tsx
+++ b/apps/web/src/components/app/split-layout/components/SplitPanel.tsx
@@ -284,6 +284,11 @@ export function SplitPanel(props: SplitPanelProps) {
               props.setPanelRef(ref);
               attachHotKeys(ref);
             }}
+            onPointerDown={(event) => {
+              if (!props.active && event.button === 0) {
+                props.handle.activate();
+              }
+            }}
             data-split-id={props.split.id}
             {...splitContainerAttribute}
             data-modal={props.handle.isSpotLight()}

--- a/apps/web/src/components/app/split-layout/splitFocusTracker.ts
+++ b/apps/web/src/components/app/split-layout/splitFocusTracker.ts
@@ -1,5 +1,6 @@
 import { activeElement } from '@app/signal/focus';
 import { splitContainerSelector } from '@core/dom-selectors';
+import { syncActiveScopeToElement } from '@core/hotkey/utils';
 import { type Accessor, createEffect, on, onCleanup } from 'solid-js';
 import {
   SplitEvent,
@@ -56,6 +57,23 @@ export function createSplitFocusTracker(props: {
     return panelRef === element || panelRef.contains(element);
   };
 
+  const rememberFocusedChild = (element: Element | null) => {
+    const parentId = getParentSplitId(element);
+    if (
+      !parentId ||
+      !(element instanceof HTMLElement) ||
+      element.closest('[data-no-focus-restore]')
+    ) {
+      return;
+    }
+    const panelRef = props.panelRefs.get(parentId);
+    // The panel is the fallback when a split has no meaningful child focus.
+    // Never overwrite a remembered list/editor/input with that fallback.
+    if (!panelRef || element === panelRef || !panelRef.contains(element))
+      return;
+    lastFocusedChildBySplitId.set(parentId, element);
+  };
+
   const focusSplitById = (id: SplitId) => {
     const splitPanelRef = props.panelRefs.get(id);
     if (!splitPanelRef) {
@@ -67,17 +85,33 @@ export function createSplitFocusTracker(props: {
     if (
       splitPanelRef.contains(document.activeElement) &&
       splitPanelRef !== document.activeElement
-    )
+    ) {
+      syncActiveScopeToElement(document.activeElement);
       return;
+    }
 
     // look for a child to return focus to.
     const child = lastFocusedChildBySplitId.get(id);
-    if (child && child.isConnected) {
+    if (child && child.isConnected && splitPanelRef.contains(child)) {
       child.focus();
+      syncActiveScopeToElement(document.activeElement);
+      return;
+    }
+
+    // A split shell only carries split-level commands. When it has no saved
+    // child yet, prefer its first focusable hotkey scope so inbox/channel
+    // navigation remains usable immediately after a rapid split switch.
+    const navigationRegion = splitPanelRef.querySelector<HTMLElement>(
+      '[data-hotkey-scope][tabindex]'
+    );
+    if (navigationRegion) {
+      navigationRegion.focus();
+      syncActiveScopeToElement(document.activeElement);
       return;
     }
 
     splitPanelRef.focus();
+    syncActiveScopeToElement(document.activeElement);
   };
 
   const activateFocusedSplit = (element: Element) => {
@@ -144,13 +178,22 @@ export function createSplitFocusTracker(props: {
   let focusTimeout: ReturnType<typeof setTimeout> | undefined;
   let activateTimeout: ReturnType<typeof setTimeout> | undefined;
   let lastProgrammaticActivation = 0;
+  const handleDocumentFocusIn = (event: FocusEvent) => {
+    rememberFocusedChild(event.target as Element | null);
+  };
 
   // Disposal must cancel pending debounced work so it cannot focus stale
   // panels or activate splits on a torn-down manager after unmount.
   onCleanup(() => {
     clearTimeout(focusTimeout);
     clearTimeout(activateTimeout);
+    document.removeEventListener('focusin', handleDocumentFocusIn, true);
   });
+
+  // Capture the restore target synchronously. The reactive `activeElement`
+  // signal intentionally settles after focus events, which is too late when
+  // the user switches splits again immediately.
+  document.addEventListener('focusin', handleDocumentFocusIn, true);
 
   /** Listens for explicit events from layoutManager that might trigger focus changes */
   createEffect(
@@ -181,6 +224,25 @@ export function createSplitFocusTracker(props: {
     })
   );
 
+  // `SplitHandle.activate()` updates the active split for visual state, but
+  // has no DOM side effect. Keep keyboard scope in sync when that activation
+  // selects an already-mounted split (for example, opening an already-open
+  // chat or channel from the inbox).
+  createEffect(
+    on(
+      activeSplitId,
+      (id) => {
+        if (!id) return;
+        if (isElementInPanel(id, document.activeElement)) {
+          syncActiveScopeToElement(document.activeElement);
+          return;
+        }
+        focusSplitById(id);
+      },
+      { defer: true }
+    )
+  );
+
   /** Listens for focus changes on the document */
   createEffect(
     on(activeElement, (element) => {
@@ -189,14 +251,7 @@ export function createSplitFocusTracker(props: {
       }
       if (!element) return;
 
-      const parentId = getParentSplitId(element);
-      if (
-        parentId &&
-        element instanceof HTMLElement &&
-        !element.closest('[data-no-focus-restore]')
-      ) {
-        lastFocusedChildBySplitId.set(parentId, element);
-      }
+      rememberFocusedChild(element);
 
       activateTimeout = setTimeout(() => {
         const timeSinceActivation = Date.now() - lastProgrammaticActivation;

--- a/apps/web/src/components/app/split-layout/tests/splitFocusTracker.test.ts
+++ b/apps/web/src/components/app/split-layout/tests/splitFocusTracker.test.ts
@@ -138,4 +138,118 @@ describe('createSplitFocusTracker', () => {
 
     dispose();
   });
+
+  it('moves DOM focus when an already-mounted split is activated', async () => {
+    let dispose = () => {};
+    let manager: ReturnType<typeof createSplitLayout>;
+    let panelRefs: Map<SplitId, HTMLDivElement>;
+
+    createRoot((rootDispose) => {
+      dispose = rootDispose;
+      manager = createSplitLayout(createMockOrchestrator(), [
+        { type: 'component', id: 'inbox' },
+        { type: 'chat', id: 'chat-1' },
+      ]);
+      panelRefs = new Map(
+        manager.splits().map((split) => [split.id, createPanel()])
+      );
+      createSplitFocusTracker({
+        splitManager: manager,
+        panelRefs,
+        splits: manager.splits,
+      });
+    });
+
+    await Promise.resolve();
+
+    const [inbox, chat] = manager!.splits();
+    manager!.activateSplit(inbox.id);
+    await Promise.resolve();
+    manager!.activateSplit(chat.id);
+    await Promise.resolve();
+
+    expect(document.activeElement).toBe(panelRefs!.get(chat.id));
+    dispose();
+  });
+
+  it('restores a split child during an immediate split switch', async () => {
+    let dispose = () => {};
+    let manager: ReturnType<typeof createSplitLayout>;
+    let panelRefs: Map<SplitId, HTMLDivElement>;
+
+    createRoot((rootDispose) => {
+      dispose = rootDispose;
+      manager = createSplitLayout(createMockOrchestrator(), [
+        { type: 'component', id: 'inbox' },
+        { type: 'channel', id: 'channel-1' },
+      ]);
+      panelRefs = new Map(
+        manager.splits().map((split) => [split.id, createPanel()])
+      );
+      createSplitFocusTracker({
+        splitManager: manager,
+        panelRefs,
+        splits: manager.splits,
+      });
+    });
+
+    await Promise.resolve();
+
+    const [inbox, channel] = manager!.splits();
+    for (const split of [inbox, channel]) {
+      const panel = panelRefs!.get(split.id);
+      panel?.setAttribute('data-split-container', '');
+      panel?.setAttribute('data-split-id', split.id);
+    }
+    const messageList = document.createElement('div');
+    messageList.tabIndex = -1;
+    panelRefs!.get(channel.id)?.append(messageList);
+    messageList.focus();
+
+    manager!.activateSplit(inbox.id);
+    await Promise.resolve();
+    manager!.activateSplit(channel.id);
+    await Promise.resolve();
+
+    expect(document.activeElement).toBe(messageList);
+    dispose();
+  });
+
+  it('focuses a navigable scope instead of stranding focus on the split shell', async () => {
+    let dispose = () => {};
+    let manager: ReturnType<typeof createSplitLayout>;
+    let panelRefs: Map<SplitId, HTMLDivElement>;
+
+    createRoot((rootDispose) => {
+      dispose = rootDispose;
+      manager = createSplitLayout(createMockOrchestrator(), [
+        { type: 'component', id: 'inbox' },
+        { type: 'channel', id: 'channel-1' },
+      ]);
+      panelRefs = new Map(
+        manager.splits().map((split) => [split.id, createPanel()])
+      );
+      createSplitFocusTracker({
+        splitManager: manager,
+        panelRefs,
+        splits: manager.splits,
+      });
+    });
+
+    await Promise.resolve();
+
+    const [inbox, channel] = manager!.splits();
+    const navigationRegion = document.createElement('div');
+    navigationRegion.tabIndex = -1;
+    navigationRegion.setAttribute('data-hotkey-scope', 'channel-messages');
+    panelRefs!.get(channel.id)?.append(navigationRegion);
+
+    manager!.activateSplit(inbox.id);
+    await Promise.resolve();
+    manager!.activateSplit(channel.id);
+    await Promise.resolve();
+
+    expect(document.activeElement).toBe(navigationRegion);
+    dispose();
+  });
 });

--- a/apps/web/src/features/channel/Channel/Channel.tsx
+++ b/apps/web/src/features/channel/Channel/Channel.tsx
@@ -197,6 +197,7 @@ export function Channel(props: ChannelProps) {
     messageKeys: () => [...messageIndex.keys],
     navigation: threadListNavigation,
     didInitialScroll: () => threadListScrollState()?.didInitialScroll ?? false,
+    isSplitActive: () => splitPanel?.isPanelActive() ?? true,
   });
 
   const [channelInputSnapshot, setChannelInputSnapshot] =
@@ -466,6 +467,8 @@ export function Channel(props: ChannelProps) {
   const selection = createMessageSelection({
     keys: () => messageIndex.keys,
   });
+  const [isKeyboardMessageNavigation, setIsKeyboardMessageNavigation] =
+    createSignal(false);
 
   const selectMessage = (messageId: string) => {
     selection.select(messageId);
@@ -556,19 +559,37 @@ export function Channel(props: ChannelProps) {
     navigation.scrollToBottom('end');
   });
 
-  const { messageListScopeId, attachMessageListRef, attachInputRef } =
-    createChannelHotkeys({
-      selection,
-      navigation: threadListNavigation,
-      messageById,
-      getMessageActions,
-      userId,
-      isEditing: () => !!messageEditor.state(),
-      isInputEmpty: () =>
-        (channelInputSnapshot()?.value.trim().length ?? 0) === 0,
-      onOpenFindBar: findBar.open,
-      onGoToBottom: handleScrollToBottom,
-    });
+  const {
+    messageListScopeId,
+    attachMessageListRef,
+    attachInputRef,
+    focusMessageList,
+  } = createChannelHotkeys({
+    selection,
+    navigation: threadListNavigation,
+    messageById,
+    getMessageActions,
+    userId,
+    isEditing: () => !!messageEditor.state(),
+    isInputEmpty: () =>
+      (channelInputSnapshot()?.value.trim().length ?? 0) === 0,
+    onOpenFindBar: findBar.open,
+    onGoToBottom: handleScrollToBottom,
+    onKeyboardNavigate: () => setIsKeyboardMessageNavigation(true),
+  });
+
+  // Re-entering a channel should make its highlighted message keyboard-active
+  // too. A subsequent click on an input or button will naturally take focus
+  // back to that explicit control.
+  createEffect(
+    on(
+      () => splitPanel?.isPanelActive(),
+      (isActive) => {
+        if (isActive && selection.selectedId()) focusMessageList();
+      },
+      { defer: true }
+    )
+  );
 
   createStickyScrollEffect({
     isNearBottom: () => threadListScrollState()?.isNearBottom ?? false,
@@ -694,8 +715,12 @@ export function Channel(props: ChannelProps) {
                 ref={(element) => {
                   attachMessageListRef(element);
                 }}
+                onPointerMove={() => setIsKeyboardMessageNavigation(false)}
                 tabIndex={-1}
                 data-channel-message-list
+                data-keyboard-navigation={
+                  isKeyboardMessageNavigation() ? '' : undefined
+                }
               >
                 <Show when={findBar.isOpen()}>
                   <FindBar
@@ -756,6 +781,8 @@ export function Channel(props: ChannelProps) {
                                   targetNavigation={{
                                     targetThreadId:
                                       targetMessageController.activeTargetMessageId,
+                                    isTargetHighlighted:
+                                      targetMessageController.isNavigationTargetHighlighted,
                                     targetMessageId: () =>
                                       !targetMessageController.pendingTargetReplyId()
                                         ? targetMessageController.pendingScrollTargetId()
@@ -775,9 +802,16 @@ export function Channel(props: ChannelProps) {
                                         threadRow,
                                         targetElement
                                       ) ?? false,
-                                    onTargetMessageScrolled:
-                                      targetMessageController.completePendingScroll,
+                                    onTargetMessageScrolled: (messageId) => {
+                                      selectMessage(messageId);
+                                      focusMessageList();
+                                      targetMessageController.completePendingScroll(
+                                        messageId
+                                      );
+                                    },
                                     onTargetReplyScrolled: (replyId) => {
+                                      selectMessage(item.id);
+                                      focusMessageList();
                                       targetMessageController.completePendingReplyScroll(
                                         item.id,
                                         replyId
@@ -809,7 +843,10 @@ export function Channel(props: ChannelProps) {
                                   }}
                                   isNewMessage={activityTracker.isNewMessage}
                                   selectedMessageId={selection.selectedId}
-                                  onSelectMessage={selectMessage}
+                                  onSelectMessage={(messageId) => {
+                                    selectMessage(messageId);
+                                    focusMessageList();
+                                  }}
                                   onClearSelection={clearSelection}
                                   messageListScopeId={messageListScopeId}
                                 />

--- a/apps/web/src/features/channel/Channel/create-channel-hotkeys.ts
+++ b/apps/web/src/features/channel/Channel/create-channel-hotkeys.ts
@@ -17,6 +17,7 @@ type CreateChannelHotkeysOptions = {
   isEditing: Accessor<boolean>;
   onOpenFindBar: () => void;
   onGoToBottom: () => void;
+  onKeyboardNavigate?: () => void;
 };
 
 export function canReplyToSelectedMessageFromHotkey(input: {
@@ -65,12 +66,47 @@ export function createChannelHotkeys(options: CreateChannelHotkeysOptions) {
     return options.messageById().get(id);
   };
 
+  const getSelectedMessageActionButtons = () => {
+    const id = options.selection.selectedId();
+    if (!id || !messageListEl) return [];
+    const message = Array.from(
+      messageListEl.querySelectorAll<HTMLElement>('[data-message]')
+    ).find((element) => element.dataset.messageId === id);
+    if (!message) return [];
+    return Array.from(
+      message.querySelectorAll<HTMLButtonElement>('button[data-message-action]')
+    ).filter((button) => !button.disabled);
+  };
+
+  const focusSelectedMessageAction = (direction: -1 | 1) => {
+    const buttons = getSelectedMessageActionButtons();
+    if (buttons.length === 0) return false;
+
+    const currentIndex = buttons.indexOf(
+      document.activeElement as HTMLButtonElement
+    );
+    const nextIndex =
+      currentIndex === -1
+        ? direction === 1
+          ? 0
+          : buttons.length - 1
+        : Math.max(0, Math.min(buttons.length - 1, currentIndex + direction));
+    buttons[nextIndex]?.focus();
+    return true;
+  };
+
+  const isSelectedMessageActionFocused = () =>
+    getSelectedMessageActionButtons().some(
+      (button) => button === document.activeElement
+    );
+
   registerHotkey({
     scopeId: messageListScope,
     hotkey: 'arrowup',
     hotkeyToken: TOKENS.channel.focusPreviousMessage,
     description: 'Previous message',
     keyDownHandler: () => {
+      options.onKeyboardNavigate?.();
       const id = options.selection.selectPrevious();
       if (id) {
         options.navigation()?.markUserIntent('up');
@@ -86,6 +122,7 @@ export function createChannelHotkeys(options: CreateChannelHotkeysOptions) {
     hotkeyToken: TOKENS.channel.focusNextMessage,
     description: 'Next message',
     keyDownHandler: () => {
+      options.onKeyboardNavigate?.();
       const id = options.selection.selectNext();
       if (id) {
         options.navigation()?.markUserIntent('down');
@@ -95,6 +132,46 @@ export function createChannelHotkeys(options: CreateChannelHotkeysOptions) {
       }
       return true;
     },
+  });
+
+  registerHotkey({
+    scopeId: messageListScope,
+    hotkey: 'arrowright',
+    description: 'Next message action',
+    handlerPriority: 4,
+    condition: hasSelection,
+    keyDownHandler: () => {
+      options.onKeyboardNavigate?.();
+      return focusSelectedMessageAction(1);
+    },
+    hide: true,
+  });
+
+  registerHotkey({
+    scopeId: messageListScope,
+    hotkey: 'enter',
+    description: 'Run focused message action',
+    handlerPriority: 4,
+    registrationType: 'add',
+    condition: isSelectedMessageActionFocused,
+    keyDownHandler: () => {
+      (document.activeElement as HTMLButtonElement | null)?.click();
+      return true;
+    },
+    hide: true,
+  });
+
+  registerHotkey({
+    scopeId: messageListScope,
+    hotkey: 'arrowleft',
+    description: 'Previous message action',
+    handlerPriority: 4,
+    condition: hasSelection,
+    keyDownHandler: () => {
+      options.onKeyboardNavigate?.();
+      return focusSelectedMessageAction(-1);
+    },
+    hide: true,
   });
 
   registerHotkey({
@@ -114,6 +191,7 @@ export function createChannelHotkeys(options: CreateChannelHotkeysOptions) {
     hotkey: 'enter',
     hotkeyToken: TOKENS.channel.replyToMessage,
     description: 'Reply to message',
+    registrationType: 'add',
     condition: canRunSelectionActionHotkeys,
     keyDownHandler: () => {
       const msg = getSelectedMessage();
@@ -217,6 +295,7 @@ export function createChannelHotkeys(options: CreateChannelHotkeysOptions) {
 
   return {
     messageListScopeId: messageListScope,
+    focusMessageList: () => messageListEl?.focus(),
     attachMessageListRef: (el: HTMLElement) => {
       messageListEl = el;
       attachMessageList(el);

--- a/apps/web/src/features/channel/Channel/create-target-message-controller.ts
+++ b/apps/web/src/features/channel/Channel/create-target-message-controller.ts
@@ -3,7 +3,13 @@ import {
   getChannelMessagesQueryKey,
 } from '@queries/channel/channel-messages';
 import { queryClient } from '@queries/client';
-import { type Accessor, createEffect, on } from 'solid-js';
+import {
+  type Accessor,
+  createEffect,
+  createSignal,
+  on,
+  onCleanup,
+} from 'solid-js';
 import { createStore } from 'solid-js/store';
 import type { ThreadListNavigation } from './ThreadList';
 
@@ -22,6 +28,8 @@ type CreateTargetMessageControllerOptions = {
    * inside ThreadList.
    */
   didInitialScroll: Accessor<boolean>;
+  /** Whether the channel's containing split is the active split. */
+  isSplitActive?: Accessor<boolean>;
 };
 
 export type TargetMessageController = ReturnType<
@@ -36,6 +44,8 @@ type TargetMessageData = {
   pendingTargetReplyId: string | undefined;
 };
 
+const NAVIGATION_TARGET_RELEASE_DELAY_MS = 600;
+
 export function createTargetMessageController(
   options: CreateTargetMessageControllerOptions
 ) {
@@ -49,9 +59,68 @@ export function createTargetMessageController(
 
   const [targetMessageData, setTargetMessageData] =
     createStore<TargetMessageData>(initialTargetMessageData);
+  const [settledNavigationTargetId, setSettledNavigationTargetId] =
+    createSignal<string>();
+  const [isNavigationTargetHighlighted, setIsNavigationTargetHighlighted] =
+    createSignal(options.initialTargetMessageId !== undefined);
 
   const hasMessageLoaded = (messageId: string) =>
     options.messageKeys().includes(messageId);
+
+  /**
+   * Clear the active target (and any pending scroll) if it still points at
+   * `messageId`; no-op if navigation has since moved elsewhere. Leaves
+   * `loadAroundMessageId` untouched so pagination is not disturbed.
+   */
+  const clearActiveTarget = (messageId: string) => {
+    if (targetMessageData['activeTargetMessageId'] !== messageId) return;
+    setSettledNavigationTargetId(undefined);
+    setIsNavigationTargetHighlighted(false);
+    setTargetMessageData({
+      activeTargetMessageId: undefined,
+      activeTargetMessageReplyId: undefined,
+      pendingScrollTargetId: undefined,
+      pendingTargetReplyId: undefined,
+    });
+  };
+
+  // A navigation target remains the active destination after its measured
+  // scroll settles. Only its accent presentation releases once the user is
+  // looking at the active split. Composer-bound targets are separate display
+  // bindings and remain highlighted after this navigation presentation clears.
+  createEffect(
+    on(
+      [
+        settledNavigationTargetId,
+        () => targetMessageData['activeTargetMessageId'],
+        isNavigationTargetHighlighted,
+        () => options.isSplitActive?.() ?? true,
+      ],
+      ([
+        settledTargetId,
+        activeTargetId,
+        isTargetHighlighted,
+        isSplitActive,
+      ]) => {
+        if (
+          !settledTargetId ||
+          settledTargetId !== activeTargetId ||
+          !isTargetHighlighted ||
+          !isSplitActive
+        ) {
+          return;
+        }
+
+        const timer = window.setTimeout(() => {
+          if (targetMessageData['activeTargetMessageId'] !== settledTargetId)
+            return;
+          setIsNavigationTargetHighlighted(false);
+          setSettledNavigationTargetId(undefined);
+        }, NAVIGATION_TARGET_RELEASE_DELAY_MS);
+        onCleanup(() => window.clearTimeout(timer));
+      }
+    )
+  );
 
   const goToMessage = (messageId: string, replyId?: string) => {
     const isSameTarget =
@@ -62,6 +131,8 @@ export function createTargetMessageController(
 
     if (isSameTarget && isSameReplyTarget && isPending) return;
 
+    setSettledNavigationTargetId(undefined);
+    setIsNavigationTargetHighlighted(true);
     setTargetMessageData({
       activeTargetMessageId: messageId,
       activeTargetMessageReplyId: replyId,
@@ -78,12 +149,16 @@ export function createTargetMessageController(
   const completePendingScroll = (messageId: string) => {
     if (targetMessageData['pendingScrollTargetId'] !== messageId) return;
     setTargetMessageData('pendingScrollTargetId', undefined);
+    if (!targetMessageData['pendingTargetReplyId']) {
+      setSettledNavigationTargetId(messageId);
+    }
   };
 
   const completePendingReplyScroll = (messageId: string, replyId: string) => {
     if (targetMessageData['activeTargetMessageId'] !== messageId) return;
     if (targetMessageData['pendingTargetReplyId'] !== replyId) return;
     setTargetMessageData('pendingTargetReplyId', undefined);
+    setSettledNavigationTargetId(messageId);
   };
 
   createEffect(
@@ -129,25 +204,12 @@ export function createTargetMessageController(
   );
 
   const reset = () => {
+    setSettledNavigationTargetId(undefined);
+    setIsNavigationTargetHighlighted(false);
     setTargetMessageData({
       activeTargetMessageId: undefined,
       activeTargetMessageReplyId: undefined,
       loadAroundMessageId: undefined,
-      pendingScrollTargetId: undefined,
-      pendingTargetReplyId: undefined,
-    });
-  };
-
-  /**
-   * Clear the active target (and any pending scroll) if it still points at
-   * `messageId`; no-op if navigation has since moved elsewhere. Leaves
-   * `loadAroundMessageId` untouched so pagination is not disturbed.
-   */
-  const clearActiveTarget = (messageId: string) => {
-    if (targetMessageData['activeTargetMessageId'] !== messageId) return;
-    setTargetMessageData({
-      activeTargetMessageId: undefined,
-      activeTargetMessageReplyId: undefined,
       pendingScrollTargetId: undefined,
       pendingTargetReplyId: undefined,
     });
@@ -160,6 +222,7 @@ export function createTargetMessageController(
     loadAroundMessageId: () => targetMessageData['loadAroundMessageId'],
     pendingScrollTargetId: () => targetMessageData['pendingScrollTargetId'],
     pendingTargetReplyId: () => targetMessageData['pendingTargetReplyId'],
+    isNavigationTargetHighlighted,
 
     goToMessage,
     completePendingScroll,

--- a/apps/web/src/features/channel/Channel/tests/create-channel-hotkeys.test.ts
+++ b/apps/web/src/features/channel/Channel/tests/create-channel-hotkeys.test.ts
@@ -1,0 +1,42 @@
+import { createRoot } from 'solid-js';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createChannelHotkeys } from '../create-channel-hotkeys';
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+describe('createChannelHotkeys', () => {
+  it('focuses the message-list scope on request', () => {
+    const messageList = document.createElement('div');
+    messageList.tabIndex = -1;
+    document.body.append(messageList);
+
+    createRoot((dispose) => {
+      const hotkeys = createChannelHotkeys({
+        selection: {
+          selectedId: () => undefined,
+          select: () => {},
+          clear: () => {},
+          selectFirst: () => undefined,
+          selectPrevious: () => undefined,
+          selectNext: () => undefined,
+        },
+        navigation: () => undefined,
+        messageById: () => new Map(),
+        getMessageActions: () => undefined,
+        userId: () => undefined,
+        isInputEmpty: () => true,
+        isEditing: () => false,
+        onOpenFindBar: () => {},
+        onGoToBottom: () => {},
+      });
+
+      hotkeys.attachMessageListRef(messageList);
+      hotkeys.focusMessageList();
+
+      expect(document.activeElement).toBe(messageList);
+      dispose();
+    });
+  });
+});

--- a/apps/web/src/features/channel/Channel/tests/create-target-message-controller.test.ts
+++ b/apps/web/src/features/channel/Channel/tests/create-target-message-controller.test.ts
@@ -17,6 +17,7 @@ import {
 
 afterEach(() => {
   queryClient.clear();
+  vi.useRealTimers();
 });
 
 function createController(
@@ -28,11 +29,15 @@ function createController(
     scrollToId: (messageId: string) => boolean;
     withNavigation: boolean;
     didInitialScroll: boolean;
+    isSplitActive: boolean;
   }>
 ) {
   const [messageKeys, setMessageKeys] = createSignal(input?.messageKeys ?? []);
   const [didInitialScroll, setDidInitialScroll] = createSignal(
     input?.didInitialScroll ?? false
+  );
+  const [isSplitActive, setIsSplitActive] = createSignal(
+    input?.isSplitActive ?? true
   );
 
   const scrollToId =
@@ -63,12 +68,14 @@ function createController(
           }
         : undefined,
     didInitialScroll,
+    isSplitActive,
   });
 
   return {
     controller,
     setMessageKeys,
     setDidInitialScroll,
+    setIsSplitActive,
   };
 }
 
@@ -152,6 +159,38 @@ describe('createTargetMessageController', () => {
 
     controller!.completePendingScroll('message-1');
     expect(controller!.pendingScrollTargetId()).toBeUndefined();
+    dispose();
+  });
+
+  it('releases a settled navigation target after the active split has shown it briefly', async () => {
+    vi.useFakeTimers();
+    let dispose = () => {};
+    let controller: ReturnType<typeof createTargetMessageController>;
+    let setIsSplitActive: (active: boolean) => boolean;
+
+    createRoot((rootDispose) => {
+      dispose = rootDispose;
+      ({ controller, setIsSplitActive } = createController({
+        initialTargetMessageId: 'message-1',
+        messageKeys: ['message-1'],
+        isSplitActive: false,
+      }));
+    });
+
+    await Promise.resolve();
+
+    controller!.completePendingScroll('message-1');
+    vi.advanceTimersByTime(600);
+    expect(controller!.activeTargetMessageId()).toBe('message-1');
+    expect(controller!.isNavigationTargetHighlighted()).toBe(true);
+
+    setIsSplitActive!(true);
+    vi.advanceTimersByTime(599);
+    expect(controller!.activeTargetMessageId()).toBe('message-1');
+
+    vi.advanceTimersByTime(1);
+    expect(controller!.activeTargetMessageId()).toBe('message-1');
+    expect(controller!.isNavigationTargetHighlighted()).toBe(false);
     dispose();
   });
 

--- a/apps/web/src/features/channel/Message/ActionMenu.tsx
+++ b/apps/web/src/features/channel/Message/ActionMenu.tsx
@@ -52,7 +52,10 @@ function ActionButton(props: {
       tooltip={props.action.label}
       size="icon-sm"
       variant="ghost"
-      class={props.action.class}
+      class={cn(
+        'focus-visible:bg-accent/15 focus-visible:text-accent focus-visible:ring-1 focus-visible:ring-accent',
+        props.action.class
+      )}
     >
       {renderIcon(
         props.action.icon,
@@ -157,6 +160,7 @@ export function ActionMenu(props: ActionMenuProps) {
                     aria-label={`React ${emoji}`}
                     data-message-action="react-quick"
                     data-emoji={emoji}
+                    class="focus-visible:bg-accent/15 focus-visible:text-accent focus-visible:ring-1 focus-visible:ring-accent"
                   >
                     <span class="text-md my-0">{emoji}</span>
                   </Button>
@@ -174,9 +178,12 @@ export function ActionMenu(props: ActionMenuProps) {
                 triggerProps={{
                   title: 'More reactions',
                   'aria-label': 'More reactions',
+                  'data-message-action': 'react-more',
                   tooltip: 'More reactions',
                   variant: 'ghost',
                   size: 'icon-sm',
+                  class:
+                    'focus-visible:bg-accent/15 focus-visible:text-accent focus-visible:ring-1 focus-visible:ring-accent',
                 }}
               />
               <Show when={visibleActions.length > 0}>

--- a/apps/web/src/features/channel/Message/ChannelMessage.tsx
+++ b/apps/web/src/features/channel/Message/ChannelMessage.tsx
@@ -28,6 +28,7 @@ type ChannelMessageProps = {
    */
   targeted?: boolean;
   onClick?: JSX.EventHandlerUnion<HTMLDivElement, MouseEvent>;
+  onPointerMove?: JSX.EventHandlerUnion<HTMLDivElement, PointerEvent>;
 };
 
 function isEditingMessage(
@@ -214,6 +215,7 @@ export function ChannelMessage(props: ChannelMessageProps) {
             isEditingMessage(props.messageEditor, props.message.id))
         }
         onClick={props.onClick}
+        onPointerMove={props.onPointerMove}
         ref={(el) =>
           touchHandler(el, () => ({
             touchClassName: 'channel-message-long-press-highlight',

--- a/apps/web/src/features/channel/Message/EmojiReactionPopover.tsx
+++ b/apps/web/src/features/channel/Message/EmojiReactionPopover.tsx
@@ -10,7 +10,7 @@ type EmojiReactionPopoverProps = {
   onOpenChange: (isOpen: boolean) => void;
   onEmojiSelect: (emoji: string) => void;
   trigger: JSX.Element;
-  triggerProps?: ButtonProps;
+  triggerProps?: ButtonProps & { 'data-message-action'?: string };
   placement?: EmojiReactionPopoverPlacement;
 };
 

--- a/apps/web/src/features/channel/Message/Root.tsx
+++ b/apps/web/src/features/channel/Message/Root.tsx
@@ -1,3 +1,4 @@
+import { useSplitPanel } from '@components/app/split-layout/layoutUtils';
 import { cn } from '@ui';
 import { type JSX, splitProps } from 'solid-js';
 import { MessageActionsProvider, MessageProvider } from './context';
@@ -16,6 +17,8 @@ type RootProps = JSX.HTMLAttributes<HTMLDivElement> & {
 };
 
 export function Root(props: RootProps) {
+  const splitPanel = useSplitPanel();
+  const isSplitActive = () => splitPanel?.isPanelActive() ?? true;
   const [local, rest] = splitProps(props, [
     'children',
     'class',
@@ -30,8 +33,8 @@ export function Root(props: RootProps) {
       class={cn('group/message relative touch:no-select-children', local.class)}
       data-message
       data-message-id={local.message.id}
-      data-selected={local.selected ? '' : undefined}
-      data-targeted={local.targeted ? '' : undefined}
+      data-selected={local.selected && isSplitActive() ? '' : undefined}
+      data-targeted={local.targeted && isSplitActive() ? '' : undefined}
       {...rest}
     >
       <div class="absolute h-full w-1 left-0 top-0 bg-accent opacity-0 message-accent-bar" />

--- a/apps/web/src/features/channel/Thread/ChannelThread.tsx
+++ b/apps/web/src/features/channel/Thread/ChannelThread.tsx
@@ -115,7 +115,8 @@ export function ChannelThread(props: ThreadProps) {
   // Channel navigation landed on this root message (and not on one of its
   // replies).
   const isRootNavTargeted = () =>
-    !!props.targetNavigation?.targetThreadId() &&
+    !!props.targetNavigation?.isTargetHighlighted() &&
+    !!props.targetNavigation.targetThreadId() &&
     props.targetNavigation.targetThreadId() === props.data().id &&
     !props.targetNavigation.activeTargetReplyId();
 
@@ -152,6 +153,20 @@ export function ChannelThread(props: ThreadProps) {
       return;
     }
 
+    props.onSelectMessage?.(props.data().id);
+    replySelection.select(replyId);
+  };
+
+  const focusThreadMessageFromPointer = () => {
+    if (isTouchDevice()) return;
+    if (isSelected() && !isThreadFocused()) return;
+    props.onSelectMessage?.(props.data().id);
+    replySelection.clear();
+  };
+
+  const focusReplyFromPointer = (replyId: string) => {
+    if (isTouchDevice()) return;
+    if (isSelected() && replySelection.selectedId() === replyId) return;
     props.onSelectMessage?.(props.data().id);
     replySelection.select(replyId);
   };
@@ -313,6 +328,7 @@ export function ChannelThread(props: ThreadProps) {
                 messageEditor={props.messageEditor}
                 participants={props.participants}
                 onClick={selectThreadMessage}
+                onPointerMove={focusThreadMessageFromPointer}
                 selected={isSelected() && !isThreadFocused()}
                 targeted={
                   // The unified input's reply is bound to this root, or
@@ -347,11 +363,13 @@ export function ChannelThread(props: ThreadProps) {
                       positionTarget={props.targetNavigation?.positionTarget}
                       selectedReplyId={replySelection.selectedId}
                       targetedReplyId={() =>
-                        props.targetNavigation?.activeTargetReplyId() ??
-                        unifiedReplyBinding()?.boundReplyId
+                        (props.targetNavigation?.isTargetHighlighted()
+                          ? props.targetNavigation.activeTargetReplyId()
+                          : undefined) ?? unifiedReplyBinding()?.boundReplyId
                       }
                       isThreadFocused={isThreadFocused}
                       onSelectReply={selectReply}
+                      onHoverReply={focusReplyFromPointer}
                     />
                   </DebugSuspense>
 

--- a/apps/web/src/features/channel/Thread/ThreadReplyList.tsx
+++ b/apps/web/src/features/channel/Thread/ThreadReplyList.tsx
@@ -38,6 +38,7 @@ export function ThreadReplyList(props: {
   targetedReplyId?: Accessor<string | undefined>;
   isThreadFocused?: Accessor<boolean>;
   onSelectReply?: (replyId: string) => void;
+  onHoverReply?: (replyId: string) => void;
 }) {
   const listMetaByReplyId = createMemo(() =>
     buildThreadReplyListMeta(props.replies, props.isNewMessage)
@@ -90,6 +91,7 @@ export function ThreadReplyList(props: {
                 messageEditor={props.messageEditor}
                 participants={props.participants}
                 onClick={() => props.onSelectReply?.(reply.id)}
+                onPointerMove={() => props.onHoverReply?.(reply.id)}
                 selected={isReplySelected()}
                 targeted={props.targetedReplyId?.() === reply.id}
               />

--- a/apps/web/src/features/channel/Thread/types.ts
+++ b/apps/web/src/features/channel/Thread/types.ts
@@ -39,6 +39,8 @@ export type MessageEditState = {
 /** Reactive contract for positioning and releasing a channel navigation target. */
 export type ThreadTargetNavigation = {
   targetThreadId: Accessor<string | undefined>;
+  /** Whether the active navigation destination should still receive accent styling. */
+  isTargetHighlighted: Accessor<boolean>;
   targetMessageId: Accessor<string | undefined>;
   targetReplyId: Accessor<string | undefined>;
   activeTargetReplyId: Accessor<string | undefined>;

--- a/apps/web/src/features/entity/composed/ListEntity.tsx
+++ b/apps/web/src/features/entity/composed/ListEntity.tsx
@@ -89,6 +89,9 @@ export function MaybeEntityRow(props: {
 }
 
 export function ListEntity(props: ListEntityProps) {
+  const splitPanel = useSplitPanel();
+  const isSplitActive = () => splitPanel?.isPanelActive() ?? true;
+  const isHighlighted = () => props.highlighted && isSplitActive();
   const unread = () => unreadFilterFn(props.entity);
   const isShared = useIsShared(props.entity);
   const bulkWakeupEnabled = useFeatureFlag(BULK_DOCUMENT_WAKEUP_FEATURE_FLAG);
@@ -154,7 +157,7 @@ export function ListEntity(props: ListEntityProps) {
 
   const draggable = createEntityDraggable({
     entity: props.entity,
-    splitId: useSplitPanel()?.handle?.id,
+    splitId: splitPanel?.handle?.id,
   });
 
   const listLayout = useListLayout();
@@ -213,11 +216,13 @@ export function ListEntity(props: ListEntityProps) {
           'min-h-10 mx-1': !isMobile() && !usesCondensedNarrowLayout(),
           'min-h-9 mx-1': !isMobile() && usesCondensedNarrowLayout(),
           'bg-accent/8': props.checked,
-          'bg-accent/16': props.checked && props.highlighted,
-          'bg-hover/30':
-            props.highlighted && !props.checked && !isTouchDevice(),
+          'bg-accent/16': props.checked && isHighlighted(),
+          'bg-hover/30': isHighlighted() && !props.checked && !isTouchDevice(),
           'hover:bg-hover/30':
-            !props.highlighted && !props.checked && !isTouchDevice(),
+            props.hovered !== false &&
+            !isHighlighted() &&
+            !props.checked &&
+            !isTouchDevice(),
         }
       )}
       onMouseMove={props.onMouseMove}

--- a/apps/web/src/features/entity/composed/list-entity/shared.tsx
+++ b/apps/web/src/features/entity/composed/list-entity/shared.tsx
@@ -24,6 +24,7 @@ export interface BaseListEntityProps<E extends EntityData = EntityData> {
   ref?: Ref<HTMLDivElement>;
   checked?: boolean;
   highlighted?: boolean;
+  /** Whether pointer hover affordances are currently allowed for this row. */
   hovered?: boolean;
   hideContentHits?: boolean;
   /** Hide the multi-select checkbox (e.g. read-only embeds outside soup). */

--- a/apps/web/src/features/next-soup/soup-view/soup-view.tsx
+++ b/apps/web/src/features/next-soup/soup-view/soup-view.tsx
@@ -750,6 +750,7 @@ const SoupViewListContent = (props: SoupViewListProps) => {
   );
 
   const { isKeypressActive } = useIsKeyPressActive();
+  const [isKeyboardNavigation, setIsKeyboardNavigation] = createSignal(false);
 
   const [virtualizerHandle, setVirtualizerHandle] =
     createSignal<VirtualizerHandle>();
@@ -850,6 +851,7 @@ const SoupViewListContent = (props: SoupViewListProps) => {
     isFetching: source.isFetching,
     isFetchingNextPage: source.isFetchingNextPage,
     fetchNextPage: source.fetchNextPage,
+    onKeyboardNavigate: () => setIsKeyboardNavigation(true),
   });
 
   // Register entity action hotkeys
@@ -1297,6 +1299,10 @@ const SoupViewListContent = (props: SoupViewListProps) => {
                         rows={rows()}
                       >
                         {(row, i) => {
+                          const highlighted = () =>
+                            isKeyboardNavigation() &&
+                            row.isFocused() &&
+                            panel.isPanelActive();
                           const timestamp = () => {
                             if (row.original.sortTs) return row.original.sortTs;
 
@@ -1342,7 +1348,7 @@ const SoupViewListContent = (props: SoupViewListProps) => {
                                         groupHeaderComponent()
                                       }
                                       group={group()}
-                                      highlighted={row.isFocused()}
+                                      highlighted={highlighted()}
                                     />
                                   )}
                                 </Match>
@@ -1356,7 +1362,6 @@ const SoupViewListContent = (props: SoupViewListProps) => {
                                   }
                                 >
                                   {(group) => {
-                                    const highlighted = () => row.isFocused();
                                     return (
                                       <div
                                         class={cn(
@@ -1418,9 +1423,11 @@ const SoupViewListContent = (props: SoupViewListProps) => {
                                       component={listEntityComponent()}
                                       entity={row.original}
                                       timestamp={timestamp()}
-                                      highlighted={row.isFocused()}
+                                      highlighted={highlighted()}
+                                      hovered={!isKeyboardNavigation()}
                                       onMouseMove={() => {
                                         if (isKeypressActive()) return;
+                                        setIsKeyboardNavigation(false);
                                         if (panel.handle.isControllerSplit())
                                           return;
                                         soup.focus.setIndex(row.index);

--- a/apps/web/src/features/next-soup/soup-view/use-soup-navigation-hotkeys.ts
+++ b/apps/web/src/features/next-soup/soup-view/use-soup-navigation-hotkeys.ts
@@ -30,6 +30,7 @@ type UseSoupNavigationHotkeysOptions = {
   isFetching?: Accessor<boolean>;
   isFetchingNextPage?: Accessor<boolean>;
   fetchNextPage?: () => void;
+  onKeyboardNavigate?: () => void;
 };
 
 export const useSoupNavigationHotkeys = (
@@ -213,6 +214,7 @@ export const useSoupNavigationHotkeys = (
   };
 
   const navigateDown = () => {
+    options.onKeyboardNavigate?.();
     const rowCount = soup.rows().length;
     const next = navigateToOpenableEntity(1);
 
@@ -232,6 +234,7 @@ export const useSoupNavigationHotkeys = (
   };
 
   const navigateUp = () => {
+    options.onKeyboardNavigate?.();
     const next = navigateToOpenableEntity(-1);
 
     if (!next) return true;
@@ -302,6 +305,7 @@ export const useSoupNavigationHotkeys = (
     description: 'Select up',
     hotkeyToken: TOKENS.entity.select.start,
     keyDownHandler: () => {
+      options.onKeyboardNavigate?.();
       return handleNavigationSelection(-1);
     },
     hide: true,
@@ -314,6 +318,7 @@ export const useSoupNavigationHotkeys = (
     description: 'Select down',
     hotkeyToken: TOKENS.entity.select.end,
     keyDownHandler: () => {
+      options.onKeyboardNavigate?.();
       return handleNavigationSelection(1);
     },
     hide: true,

--- a/apps/web/src/features/next-soup/soup-view/views/companies/CompanyListEntity.tsx
+++ b/apps/web/src/features/next-soup/soup-view/views/companies/CompanyListEntity.tsx
@@ -46,6 +46,9 @@ function MaybeEntityRow(props: {
  * mirroring `TaskListEntity`.
  */
 export function CompanyListEntity(props: BaseListEntityProps) {
+  const splitPanel = useSplitPanel();
+  const isSplitActive = () => splitPanel?.isPanelActive() ?? true;
+  const isHighlighted = () => props.highlighted && isSplitActive();
   const unread = () => unreadFilterFn(props.entity);
 
   const layoutProps = (): LayoutProps => ({
@@ -65,7 +68,7 @@ export function CompanyListEntity(props: BaseListEntityProps) {
 
   const draggable = createEntityDraggable({
     entity: props.entity,
-    splitId: useSplitPanel()?.handle?.id,
+    splitId: splitPanel?.handle?.id,
   });
 
   const isWide = useListLayout()?.isWide ?? (() => true);
@@ -86,12 +89,13 @@ export function CompanyListEntity(props: BaseListEntityProps) {
         {
           'min-h-10 mx-1': !isMobile(),
           'bg-accent/8': props.checked,
-          'bg-accent/16':
-            props.checked && props.highlighted && !isTouchDevice(),
-          'bg-active/60':
-            props.highlighted && !props.checked && !isTouchDevice(),
+          'bg-accent/16': props.checked && isHighlighted() && !isTouchDevice(),
+          'bg-active/60': isHighlighted() && !props.checked && !isTouchDevice(),
           'hover:bg-active/30':
-            !props.highlighted && !props.checked && !isTouchDevice(),
+            props.hovered !== false &&
+            !isHighlighted() &&
+            !props.checked &&
+            !isTouchDevice(),
         }
       )}
       onMouseMove={props.onMouseMove}

--- a/apps/web/src/features/next-soup/soup-view/views/inbox/InboxCard.tsx
+++ b/apps/web/src/features/next-soup/soup-view/views/inbox/InboxCard.tsx
@@ -23,6 +23,7 @@ interface RootProps extends SlotProps {
   dimmed?: boolean;
   selected?: boolean;
   highlighted?: boolean;
+  hovered?: boolean;
   onClick?: (event: MouseEvent) => void;
 }
 
@@ -48,7 +49,10 @@ function Root(props: RootProps): JSX.Element {
           'bg-hover/50':
             props.highlighted && !props.selected && !isTouchDevice(),
           'hover:bg-hover/50':
-            !props.highlighted && !props.selected && !isTouchDevice(),
+            props.hovered !== false &&
+            !props.highlighted &&
+            !props.selected &&
+            !isTouchDevice(),
         },
         props.class
       )}

--- a/apps/web/src/features/next-soup/soup-view/views/inbox/InboxListEntity.tsx
+++ b/apps/web/src/features/next-soup/soup-view/views/inbox/InboxListEntity.tsx
@@ -38,6 +38,7 @@ export function InboxListEntity(props: BaseListEntityProps) {
           item={item()}
           selected={props.checked}
           highlighted={props.highlighted}
+          hovered={props.hovered}
           onClick={props.onClick}
         />
       </MaybeEntityRow>

--- a/apps/web/src/features/next-soup/soup-view/views/inbox/inbox-card-layouts.tsx
+++ b/apps/web/src/features/next-soup/soup-view/views/inbox/inbox-card-layouts.tsx
@@ -60,6 +60,7 @@ export interface InboxCardLayoutProps {
   item: InboxCardDisplayItem;
   selected?: boolean;
   highlighted?: boolean;
+  hovered?: boolean;
   onClick?: (event: MouseEvent) => void;
 }
 
@@ -468,6 +469,7 @@ const githubAction = (notification?: Notification): string => {
 function BaseCard(props: {
   selected?: boolean;
   highlighted?: boolean;
+  hovered?: boolean;
   onClick?: (event: MouseEvent) => void;
   unread: boolean;
   leading: JSX.Element;
@@ -483,6 +485,7 @@ function BaseCard(props: {
       dimmed={!props.unread}
       selected={props.selected}
       highlighted={props.highlighted}
+      hovered={props.hovered}
       onClick={props.onClick}
     >
       <div class="col-start-1 row-start-1 row-span-2">{props.leading}</div>
@@ -617,6 +620,7 @@ export function ChannelCardLayout(props: InboxCardLayoutProps) {
       dimmed={!props.item.unread}
       selected={props.selected}
       highlighted={props.highlighted}
+      hovered={props.hovered}
       onClick={props.onClick}
     >
       <div class="col-start-1 row-start-1 row-span-2">
@@ -704,6 +708,7 @@ export function ChannelMessageCardLayout(props: InboxCardLayoutProps) {
       entityId={props.item.entity.id}
       selected={props.selected}
       highlighted={props.highlighted}
+      hovered={props.hovered}
       onClick={props.onClick}
       unread={props.item.unread}
       timestamp={props.item.timestamp}
@@ -827,6 +832,7 @@ export function ChannelThreadCardLayout(props: InboxCardLayoutProps) {
       dimmed={!props.item.unread}
       selected={props.selected}
       highlighted={props.highlighted}
+      hovered={props.hovered}
       onClick={props.onClick}
     >
       <div class="col-start-1 row-start-2">
@@ -968,6 +974,7 @@ export function DocumentCardLayout(props: InboxCardLayoutProps) {
       entityId={props.item.entity.id}
       selected={props.selected}
       highlighted={props.highlighted}
+      hovered={props.hovered}
       onClick={props.onClick}
       unread={props.item.unread}
       timestamp={props.item.timestamp}
@@ -1023,6 +1030,7 @@ export function TaskCardLayout(props: InboxCardLayoutProps) {
       entityId={props.item.entity.id}
       selected={props.selected}
       highlighted={props.highlighted}
+      hovered={props.hovered}
       onClick={props.onClick}
       unread={props.item.unread}
       timestamp={props.item.timestamp}
@@ -1071,6 +1079,7 @@ export function AiCardLayout(props: InboxCardLayoutProps) {
       entityId={props.item.entity.id}
       selected={props.selected}
       highlighted={props.highlighted}
+      hovered={props.hovered}
       onClick={props.onClick}
       unread={props.item.unread}
       timestamp={props.item.timestamp}
@@ -1134,6 +1143,7 @@ export function EmailCardLayout(props: InboxCardLayoutProps) {
       dimmed={!props.item.unread}
       selected={props.selected}
       highlighted={props.highlighted}
+      hovered={props.hovered}
       onClick={props.onClick}
     >
       <div class="col-start-1 row-start-1 row-span-3">
@@ -1245,6 +1255,7 @@ export function GithubCardLayout(props: InboxCardLayoutProps) {
       dimmed={!props.item.unread}
       selected={props.selected}
       highlighted={props.highlighted}
+      hovered={props.hovered}
       onClick={props.onClick}
     >
       <div class="col-start-1 row-start-1 row-span-3">
@@ -1369,6 +1380,7 @@ export function CallCardLayout(props: InboxCardLayoutProps) {
       dimmed={!props.item.unread}
       selected={props.selected}
       highlighted={props.highlighted}
+      hovered={props.hovered}
       onClick={props.onClick}
     >
       <div class="col-start-1 row-start-1 row-span-3">
@@ -1432,6 +1444,7 @@ export function GenericCardLayout(props: InboxCardLayoutProps) {
       entityId={props.item.entity.id}
       selected={props.selected}
       highlighted={props.highlighted}
+      hovered={props.hovered}
       onClick={props.onClick}
       unread={props.item.unread}
       timestamp={props.item.timestamp}

--- a/apps/web/src/features/next-soup/soup-view/views/tasks/TaskListEntity.tsx
+++ b/apps/web/src/features/next-soup/soup-view/views/tasks/TaskListEntity.tsx
@@ -78,6 +78,9 @@ function MaybeEntityRow(props: {
  * vertically across rows in a list.
  */
 export function TaskListEntity(props: TaskListEntityProps) {
+  const splitPanel = useSplitPanel();
+  const isSplitActive = () => splitPanel?.isPanelActive() ?? true;
+  const isHighlighted = () => props.highlighted && isSplitActive();
   const unread = () => unreadFilterFn(props.entity);
   const isShared = useIsShared(props.entity);
   const bulkWakeupEnabled = useFeatureFlag(BULK_DOCUMENT_WAKEUP_FEATURE_FLAG);
@@ -128,7 +131,7 @@ export function TaskListEntity(props: TaskListEntityProps) {
 
   const draggable = createEntityDraggable({
     entity: props.entity,
-    splitId: useSplitPanel()?.handle?.id,
+    splitId: splitPanel?.handle?.id,
   });
 
   const isWide = useListLayout()?.isWide ?? (() => true);
@@ -149,12 +152,13 @@ export function TaskListEntity(props: TaskListEntityProps) {
         {
           'min-h-10 mx-1': !isMobile(),
           'bg-accent/8': props.checked,
-          'bg-accent/16':
-            props.checked && props.highlighted && !isTouchDevice(),
-          'bg-active/60':
-            props.highlighted && !props.checked && !isTouchDevice(),
+          'bg-accent/16': props.checked && isHighlighted() && !isTouchDevice(),
+          'bg-active/60': isHighlighted() && !props.checked && !isTouchDevice(),
           'hover:bg-active/30':
-            !props.highlighted && !props.checked && !isTouchDevice(),
+            props.hovered !== false &&
+            !isHighlighted() &&
+            !props.checked &&
+            !isTouchDevice(),
         }
       )}
       onMouseMove={props.onMouseMove}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -763,17 +763,41 @@ a {
 /* Channel message hover + selection-cursor highlight */
 /* Suppressed on touch devices */
 /* Background-only — borders/rings are reserved for structural UI edges. */
+[data-message] {
+  transition: background-color 450ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
 [data-message][data-selected],
 html:not([data-touch-device="true"]) [data-message]:hover{
   @apply bg-ink/5 rounded-sm;
 }
 
 [data-message][data-targeted] {
-  @apply bg-accent/30 rounded-sm;
+  @apply bg-accent/10 rounded-sm;
 }
 [data-message][data-selected][data-targeted],
 html:not([data-touch-device="true"]) [data-message][data-targeted]:hover{
-  @apply bg-accent/40 rounded-sm;
+  @apply bg-accent/10 rounded-sm;
+}
+
+/* Keyboard selection owns the message affordance until the pointer moves
+   again; otherwise a stationary pointer paints a second, stale hover row. */
+html:not([data-touch-device="true"]) [data-channel-message-list][data-keyboard-navigation] [data-message]:hover:not([data-selected]):not([data-targeted]) {
+  background-color: transparent;
+}
+
+/* A selection cursor is a keyboard affordance. Once the pointer becomes the
+   latest interaction, let its actual hover be the only message highlight. */
+html:not([data-touch-device="true"]) [data-channel-message-list]:not([data-keyboard-navigation]) [data-message][data-selected]:not([data-targeted]) {
+  background-color: transparent;
+}
+
+html:not([data-touch-device="true"]) [data-channel-message-list][data-keyboard-navigation] [data-message][data-selected] [data-message-hover-actions] {
+  display: block;
+}
+
+html:not([data-touch-device="true"]) [data-channel-message-list][data-keyboard-navigation] [data-message]:not([data-selected]) [data-message-hover-actions] {
+  display: none !important;
 }
 
 @keyframes long-press-message-highlight {

--- a/apps/web/src/lib/core/hotkey/utils.test.ts
+++ b/apps/web/src/lib/core/hotkey/utils.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, test } from 'vitest';
+import { activeScope, setActiveScope } from './state';
 import type { HotkeyToken } from './tokens';
 import type { HotkeyCommand } from './types';
-import { removeCommandsFromTokenMap } from './utils';
+import {
+  registerScope,
+  removeCommandsFromTokenMap,
+  removeScope,
+  syncActiveScopeToElement,
+} from './utils';
 
 const makeCommand = (token: HotkeyToken | undefined): HotkeyCommand =>
   ({
@@ -71,5 +77,35 @@ describe('removeCommandsFromTokenMap', () => {
 
     expect(result.get('hotkey:a' as HotkeyToken)).toEqual([cmd3]);
     expect(result.has('hotkey:b' as HotkeyToken)).toBe(false);
+  });
+});
+
+describe('syncActiveScopeToElement', () => {
+  test('uses the closest registered DOM scope', () => {
+    const scopeId = 'test-sync-dom-scope';
+    registerScope({ parentScopeId: 'global', scopeId, type: 'dom' });
+
+    const scope = document.createElement('div');
+    scope.setAttribute('data-hotkey-scope', scopeId);
+    const target = document.createElement('button');
+    scope.append(target);
+    document.body.append(scope);
+
+    syncActiveScopeToElement(target);
+
+    expect(activeScope()).toBe(scopeId);
+
+    setActiveScope('global');
+    removeScope(scopeId);
+    scope.remove();
+  });
+
+  test('falls back to the global scope when no registered scope contains the element', () => {
+    const target = document.createElement('div');
+    target.setAttribute('data-hotkey-scope', 'missing-scope');
+
+    syncActiveScopeToElement(target);
+
+    expect(activeScope()).toBe('global');
   });
 });

--- a/apps/web/src/lib/core/hotkey/utils.ts
+++ b/apps/web/src/lib/core/hotkey/utils.ts
@@ -296,6 +296,21 @@ export function activateClosestDOMScope() {
   setActiveScope(activeScopeId);
 }
 
+/**
+ * Makes the hotkey state match a DOM element that was focused
+ * programmatically.
+ *
+ * Native focus events normally do this through `useHotkeyDOMScope`, but a
+ * rapid sequence of split activations can leave that event-driven state one
+ * step behind the element that actually owns focus.
+ */
+export function syncActiveScopeToElement(element: Element | null) {
+  const scopeElement = element?.closest('[data-hotkey-scope]');
+  const scopeId = scopeElement?.getAttribute('data-hotkey-scope') ?? 'global';
+
+  setActiveScope(hotkeyScopeTree.has(scopeId) ? scopeId : 'global');
+}
+
 export function updateActiveScopeBranch(activeScopeId: string | undefined) {
   const branch = new Set<string>();
 


### PR DESCRIPTION
## Some changes to make focus and navigation more intuitive
The general idea is to have as few items as possible styled as "focused" at a time.
### Style changes
- "target" accent styling is more subtle now, and fades from accent tinted to regular focus over 600ms
- visual focus is active-split-only: inactive channels don’t show selected/targeted message backgrounds, and inactive inbox/list splits don’t show their keyboard-current row. Checkbox selection remains visible.
### Behavior
- arrow/j/k and cursor don't control different hover/focus states, they control the same one
- using arrows and mousing over messages focuses them: no need to click
- enter on focused message opens reply, arrow keys + enter activate actions (emoji reacts + )
- navigating to a message from notification or inbox item focuses that message