### PR TITLE
feat(reminders): describe a reminder when creating it

### DIFF
--- a/apps/web/src/features/entity/components/Badges.tsx
+++ b/apps/web/src/features/entity/components/Badges.tsx
@@ -149,6 +149,26 @@ export function CallChannelNameBadge(props: { channelName: string }) {
   );
 }
 
+/**
+ * What a reminder is about, beside its description.
+ *
+ * The same shape as {@link CallChannelNameBadge} — a reminder row is named by
+ * its own text, so this is the only thing saying which entity it points at.
+ * Presentational: the caller resolves the name and supplies the icon, since a
+ * reminder can reference any entity type.
+ */
+export function ReminderReferenceBadge(props: ParentProps<{ name: string }>) {
+  return (
+    <Badge
+      class="ph-no-capture max-w-32 min-w-0 shrink-0 normal-case font-sans text-ink-extra-muted border-edge-muted px-2"
+      title={props.name}
+    >
+      {props.children}
+      <span class="truncate">{props.name}</span>
+    </Badge>
+  );
+}
+
 export function CallDurationBadge(props: { duration: string }) {
   return (
     <Badge class="normal-case text-ink-extra-muted border-edge-muted px-2">

--- a/apps/web/src/features/entity/composed/list-entity/reminder.tsx
+++ b/apps/web/src/features/entity/composed/list-entity/reminder.tsx
@@ -1,0 +1,91 @@
+import {
+  EntityIcon,
+  reminderReferenceIconType,
+} from '@core/component/EntityIcon';
+import { useItemPreviewData } from '@core/component/ItemPreview';
+import { isAccessiblePreviewItem } from '@queries/preview';
+import { Show } from 'solid-js';
+import { ReminderReferenceBadge } from '../../components/Badges';
+import { Entity } from '../../entity';
+import type { ReminderEntity } from '../../types/entity';
+
+type Reference = NonNullable<ReminderEntity['referencedEntity']>;
+
+/**
+ * A reminder row always leads with the bell, so what it is about has to be
+ * said beside its name.
+ *
+ * Which way round depends on whether the description is the user's own. The
+ * composer's description step is optional, and skipping it names the reminder
+ * after the entity — so the title either *is* the reference and takes its icon
+ * inline, or it is the user's own text and the reference trails as a badge,
+ * the way `CallWideContent` trails a call with its channel.
+ */
+export function ReminderWideContent(props: { entity: ReminderEntity }) {
+  return (
+    <Show
+      when={props.entity.referencedEntity}
+      fallback={
+        <span class="truncate">
+          <Entity.Title entity={props.entity} />
+        </span>
+      }
+    >
+      {(reference) => (
+        <ReferencedReminder entity={props.entity} reference={reference()} />
+      )}
+    </Show>
+  );
+}
+
+function ReferencedReminder(props: {
+  entity: ReminderEntity;
+  reference: Reference;
+}) {
+  const { item, name } = useItemPreviewData(() => ({
+    id: props.reference.id,
+    type: props.reference.type,
+  }));
+
+  // `name()` is the "Untitled" placeholder while the reference resolves and
+  // for one the caller cannot see, so neither can be compared nor shown. Until
+  // it lands the row is the bare description — no icon, no badge.
+  const referenceName = () =>
+    isAccessiblePreviewItem(item()) ? name().trim() || undefined : undefined;
+
+  const titleIsReference = () => {
+    const resolved = referenceName();
+    return resolved !== undefined && resolved === props.entity.name?.trim();
+  };
+
+  return (
+    <>
+      {/* Grouped tighter than the row's own gap, so the icon reads as part of
+          the name rather than as a second leading icon after the bell. */}
+      <span class="flex min-w-0 items-center gap-1.5">
+        <Show when={titleIsReference()}>
+          <EntityIcon
+            class="size-4 shrink-0"
+            targetType={reminderReferenceIconType(props.reference)}
+            size="fill"
+          />
+        </Show>
+        <span class="truncate">
+          <Entity.Title entity={props.entity} />
+        </span>
+      </span>
+      <Show when={!titleIsReference() && referenceName()}>
+        {(text) => (
+          <ReminderReferenceBadge name={text()}>
+            <EntityIcon
+              class="size-3 shrink-0"
+              targetType={reminderReferenceIconType(props.reference)}
+              size="fill"
+              theme="monochrome"
+            />
+          </ReminderReferenceBadge>
+        )}
+      </Show>
+    </>
+  );
+}

--- a/apps/web/src/features/entity/composed/list-entity/wide-layout.tsx
+++ b/apps/web/src/features/entity/composed/list-entity/wide-layout.tsx
@@ -25,6 +25,7 @@ import {
   isGithubPrEntity,
   isProjectContainedEntity,
   isProjectEntity,
+  isReminderEntity,
   isTaskEntity,
 } from '../../types/entity';
 import { isSearchEntity } from '../../types/search';
@@ -40,6 +41,7 @@ import {
   GithubPullRequestChecksIndicator,
   GithubPullRequestPills,
 } from './foreign';
+import { ReminderWideContent } from './reminder';
 import type { LayoutProps } from './shared';
 
 function RowTags(props: {
@@ -142,6 +144,9 @@ export function WideLayout(props: LayoutProps) {
           </Match>
           <Match when={isAutomationEntity(props.entity) && props.entity}>
             {(entity) => <AutomationWideContent entity={entity()} />}
+          </Match>
+          <Match when={isReminderEntity(props.entity) && props.entity}>
+            {(entity) => <ReminderWideContent entity={entity()} />}
           </Match>
           <Match when={isGithubPrEntity(props.entity) && props.entity}>
             {(entity) => (

--- a/apps/web/src/features/entity/extractors/entity-icon.tsx
+++ b/apps/web/src/features/entity/extractors/entity-icon.tsx
@@ -4,7 +4,6 @@ import {
   getIconConfig,
 } from '@core/component/EntityIcon';
 import { UserIcon } from '@core/component/UserIcon';
-import { itemToBlockName } from '@core/constant/allBlocks';
 import { useUserId } from '@core/context/user';
 import GitMerge from '@phosphor/git-merge.svg';
 import GitPullRequest from '@phosphor/git-pull-request.svg';
@@ -17,7 +16,6 @@ import type {
   ChannelEntity,
   EntityData,
   GithubPullRequestEntity,
-  NamedSubType,
 } from '../types/entity';
 import {
   isCallEntity,
@@ -131,24 +129,10 @@ export function EntityIcon(props: EntityIconProps) {
         )
         .with({ type: 'foreign' }, () => 'default')
         .with({ type: 'crm_company' }, () => 'crm_company')
-        // A reminder shows the icon of what it references; `fileType` comes
-        // resolved from the server so this stays synchronous. With nothing
-        // referenced there is no such icon, so it falls back to the bell rather
-        // than to `default`, whose wide variant is the unknown-file glyph.
-        .with({ type: 'reminder' }, ({ referencedEntity }) =>
-          referencedEntity
-            ? (itemToBlockName(
-                {
-                  type: referencedEntity.type,
-                  fileType: referencedEntity.fileType,
-                  subType: referencedEntity.subType
-                    ? { type: referencedEntity.subType as NamedSubType }
-                    : undefined,
-                },
-                true
-              ) ?? 'reminder')
-            : 'reminder'
-        )
+        // Always the bell, never the referenced entity's icon: the row is a
+        // reminder first, and what it points at is iconed beside its name
+        // instead — see `reminderReferenceIconType`.
+        .with({ type: 'reminder' }, () => 'reminder')
         .otherwise(() => 'default')
     );
   };

--- a/apps/web/src/features/entity/types/entity.ts
+++ b/apps/web/src/features/entity/types/entity.ts
@@ -459,6 +459,12 @@ export const isCallEntity = (entity: EntityData): entity is CallEntity => {
   return entity.type === 'call';
 };
 
+export const isReminderEntity = (
+  entity: EntityData
+): entity is ReminderEntity => {
+  return entity.type === 'reminder';
+};
+
 export const isAutomationEntity = (
   entity: EntityData
 ): entity is AutomationEntity => {

--- a/apps/web/src/features/reminders/CreateReminderModal.tsx
+++ b/apps/web/src/features/reminders/CreateReminderModal.tsx
@@ -1,7 +1,10 @@
 import { toast } from '@core/component/Toast/Toast';
 import { registerHotkey, useHotkeyDOMScope } from '@core/hotkey/hotkeys';
 import { useDateSearch } from '@core/util/dateSearch/useDateSearch';
-import { useListKeyBindings } from '@core/util/useListKeyBindings';
+import {
+  type ListNavActions,
+  useListKeyBindings,
+} from '@core/util/useListKeyBindings';
 import { type EntityData, InlineEntity } from '@entity';
 import BellIcon from '@phosphor/bell-simple.svg';
 import {
@@ -10,11 +13,14 @@ import {
 } from '@queries/reminders/reminders';
 import { mergeRefs } from '@solid-primitives/refs';
 import {
+  Button,
   CommandMenuEmptyState,
+  CommandMenuHotkeyHint,
   CommandMenuListItem,
   CommandMenuSearchInput,
   CommandMenuShell,
   Dialog,
+  Hotkey,
 } from '@ui';
 import {
   createEffect,
@@ -22,9 +28,12 @@ import {
   createSelector,
   createSignal,
   For,
+  Match,
   on,
   onCleanup,
+  onMount,
   Show,
+  Switch,
 } from 'solid-js';
 import {
   closeReminderComposer,
@@ -35,21 +44,28 @@ import {
   futureDateOptions,
   onceSchedule,
   REMINDER_DEFAULT_TIME,
+  REMINDER_DESCRIPTION_MAX_LENGTH,
   reminderDefaultOptions,
-  reminderDescriptionFor,
+  resolveReminderDescription,
 } from './reminder-schedule';
 
+/** The composer's two questions, asked in this order. */
+type Step = 'description' | 'when';
+
 /**
- * Asks one question — when — for a reminder about the entity the command was
- * invoked on.
+ * Asks two questions — what and when — for a reminder about the entity the
+ * command was invoked on.
  *
- * This is deliberately the date editor reached by `shift+cmd+o`: the same shell,
- * entity chip, search input and `useDateSearch` list. The entity is already
- * known, so there is nothing to pick but the date.
+ * The date step is deliberately the date editor reached by `shift+cmd+o`: the
+ * same shell, entity chip, search input and `useDateSearch` list. The
+ * description step in front of it is optional, and Enter on an empty field
+ * falls straight through to the date list.
  */
 export function CreateReminderModal() {
   const [dialogRef, setDialogRef] = createSignal<HTMLElement | undefined>();
   const [attach, hotkeyScope] = useHotkeyDOMScope('reminder-composer');
+  const [step, setStep] = createSignal<Step>('description');
+  const [description, setDescription] = createSignal('');
   const [query, setQuery] = createSignal('');
   const [selectedIndex, setSelectedIndex] = createSignal(0);
 
@@ -58,11 +74,29 @@ export function CreateReminderModal() {
 
   const entity = () => reminderComposerState.entity;
 
+  /**
+   * Escape steps back to the description before it closes the composer,
+   * matching how the command menu treats a sub-scope.
+   *
+   * @returns whether it stepped back rather than closed.
+   */
+  const handleEscape = (): boolean => {
+    if (step() === 'when') {
+      setStep('description');
+      return true;
+    }
+    closeReminderComposer();
+    return false;
+  };
+
+  // Only reachable with focus outside the header input — the hotkey layer skips
+  // handlers while an editable is focused. Kobalte's document-level escape
+  // handler below covers the usual case; both have to agree.
   const { dispose: disposeHotkey } = registerHotkey({
     hotkey: ['escape'],
-    description: 'Close reminder composer',
+    description: 'Go back, or close the reminder composer',
     keyDownHandler: () => {
-      closeReminderComposer();
+      handleEscape();
       return true;
     },
     scopeId: hotkeyScope,
@@ -71,8 +105,19 @@ export function CreateReminderModal() {
 
   createEffect(
     on(reminderComposerOpen, () => {
+      setStep('description');
+      setDescription('');
       setQuery('');
       setSelectedIndex(0);
+    })
+  );
+
+  // The dialog's Enter binding is a single shared slot, so whichever step is on
+  // screen has to claim it or the other step's stale handler stays live.
+  createEffect(
+    on(step, (current) => {
+      if (current !== 'description') return;
+      keybindings(descriptionStepKeybindings(() => setStep('when')));
     })
   );
 
@@ -85,13 +130,13 @@ export function CreateReminderModal() {
       return;
     }
 
-    const description = reminderDescriptionFor(target);
+    const resolved = resolveReminderDescription(description(), target);
     const attachTo = reminderTarget(target);
     closeReminderComposer();
 
     try {
       await createReminder.mutateAsync({
-        description,
+        description: resolved,
         schedule: onceSchedule(date),
         // Both or neither: the API rejects one without the other.
         ...(attachTo ?? undefined),
@@ -108,6 +153,11 @@ export function CreateReminderModal() {
       onOpenChange={(open) => {
         if (!open) closeReminderComposer();
       }}
+      // Kobalte dismisses the whole dialog on escape unless the default is
+      // prevented, which would skip the step back.
+      onEscapeKeyDown={(event) => {
+        if (handleEscape()) event.preventDefault();
+      }}
       contentRef={mergeRefs(attach, setDialogRef)}
     >
       <CommandMenuShell depth={2} class="rounded-xl max-h-108 text-sm">
@@ -115,36 +165,142 @@ export function CreateReminderModal() {
           <span class="pl-2 text-ink-extra-muted/55 pointer-events-none">
             <BellIcon class="size-3" />
           </span>
-          <CommandMenuSearchInput
-            class="text-base"
-            placeholder="Remind me when?"
-            value={query()}
-            onInput={(e) => setQuery(e.currentTarget.value)}
-            autofocus
-          />
+          <Switch>
+            <Match when={step() === 'description'}>
+              <StepInput
+                placeholder="What's the reminder? (optional)"
+                value={description()}
+                onInput={setDescription}
+                // Counts UTF-16 code units where the service counts characters,
+                // so this only ever stops short of the real limit, never past
+                // it. `resolveReminderDescription` applies the exact cap.
+                maxLength={REMINDER_DESCRIPTION_MAX_LENGTH}
+              />
+            </Match>
+            <Match when={step() === 'when'}>
+              <StepInput
+                placeholder="Remind me when?"
+                value={query()}
+                onInput={setQuery}
+              />
+            </Match>
+          </Switch>
         </CommandMenuShell.Header>
         <Show when={entity()}>
           {(target) => (
             <>
-              <CommandMenuShell.Toolbar class="p-3 py-2 border-b-0">
+              <CommandMenuShell.Toolbar class="p-3 py-2 border-b-0 gap-2">
                 <div class="bg-active border border-edge-muted px-2 py-1 truncate text-xs rounded max-w-[50%]">
                   <InlineEntity entity={target()} />
                 </div>
+                {/* Sized to the space the entity chip leaves rather than to a
+                    share of its own, so the pair can never overflow. */}
+                <Show when={step() === 'when' && description().trim()}>
+                  {(typed) => (
+                    <button
+                      type="button"
+                      class="bg-active border border-edge-muted px-2 py-1 truncate text-xs rounded min-w-0 flex-1 text-left text-ink-muted hover:text-ink"
+                      title="Edit the description"
+                      onClick={() => setStep('description')}
+                    >
+                      {typed()}
+                    </button>
+                  )}
+                </Show>
               </CommandMenuShell.Toolbar>
-              <CommandMenuShell.Body>
-                <WhenList
-                  query={query}
-                  selectedIndex={selectedIndex}
-                  setSelectedIndex={setSelectedIndex}
-                  onSubmit={(date) => void submit(date, target())}
-                  setKeybindings={keybindings}
-                />
-              </CommandMenuShell.Body>
+              <Switch>
+                <Match when={step() === 'description'}>
+                  <DescriptionStep onContinue={() => setStep('when')} />
+                </Match>
+                <Match when={step() === 'when'}>
+                  <CommandMenuShell.Body>
+                    <WhenList
+                      query={query}
+                      selectedIndex={selectedIndex}
+                      setSelectedIndex={setSelectedIndex}
+                      onSubmit={(date) => void submit(date, target())}
+                      setKeybindings={keybindings}
+                    />
+                  </CommandMenuShell.Body>
+                </Match>
+              </Switch>
             </>
           )}
         </Show>
       </CommandMenuShell>
     </Dialog>
+  );
+}
+
+/**
+ * What the description step does with the dialog's shared list bindings.
+ *
+ * There is no list to move through, so the arrows are inert and Enter is the
+ * skip-through: it advances whether or not anything was typed.
+ */
+function descriptionStepKeybindings(advance: VoidFunction): ListNavActions {
+  return { next: () => {}, previous: () => {}, select: advance };
+}
+
+/**
+ * The header input for one step.
+ *
+ * Focused on mount rather than with `autofocus`, which only fires for the step
+ * that happens to be on screen when the dialog opens — moving between steps
+ * remounts the input inside an already-open dialog.
+ */
+function StepInput(props: {
+  placeholder: string;
+  value: string;
+  onInput: (value: string) => void;
+  maxLength?: number;
+}) {
+  let ref: HTMLInputElement | undefined;
+
+  onMount(() => {
+    ref?.focus();
+    // Caret at the end: stepping back to a field that already has text should
+    // continue it, not land in front of it.
+    const end = ref?.value.length ?? 0;
+    ref?.setSelectionRange(end, end);
+  });
+
+  return (
+    <CommandMenuSearchInput
+      ref={ref}
+      class="text-base"
+      placeholder={props.placeholder}
+      value={props.value}
+      maxLength={props.maxLength}
+      onInput={(e) => props.onInput(e.currentTarget.value)}
+    />
+  );
+}
+
+/**
+ * The optional first step: name the reminder, or press Enter past it.
+ *
+ * The entity name a blank field falls back to is never pre-filled, so skipping
+ * stays a single keystroke instead of a select-all and delete.
+ */
+function DescriptionStep(props: { onContinue: VoidFunction }) {
+  return (
+    <CommandMenuShell.Footer class="gap-2 border-t-0 py-3">
+      <CommandMenuHotkeyHint
+        hotkey={<Hotkey shortcut="escape" />}
+        label="Cancel"
+      />
+      <Button
+        variant="active"
+        size="sm"
+        depth={3}
+        class="ml-auto gap-3 rounded-lg border-0"
+        onClick={props.onContinue}
+      >
+        Continue
+        <Hotkey shortcut="enter" theme="current" />
+      </Button>
+    </CommandMenuShell.Footer>
   );
 }
 
@@ -252,7 +408,7 @@ function WhenList(props: {
         </Show>
       </div>
 
-      <div class="p-4 border-t border-edge-muted">
+      <div class="p-4 border-t border-edge-muted flex items-center gap-4">
         <div class="text-xs text-ink-muted">
           <span>Use queries like </span>
           <code class="bg-active px-1">3d</code>,{' '}
@@ -261,6 +417,11 @@ function WhenList(props: {
           <code class="bg-active px-1">tomorrow</code>, or{' '}
           <code class="bg-active px-1">tomorrow 3pm</code>
         </div>
+        <CommandMenuHotkeyHint
+          class="ml-auto shrink-0 text-xs text-ink-extra-muted/80"
+          hotkey={<Hotkey shortcut="escape" />}
+          label="Back"
+        />
       </div>
     </>
   );

--- a/apps/web/src/features/reminders/CreateReminderModal.tsx
+++ b/apps/web/src/features/reminders/CreateReminderModal.tsx
@@ -41,6 +41,7 @@ import {
   reminderComposerState,
 } from './reminder-composer';
 import {
+  formatReminderWhen,
   futureDateOptions,
   onceSchedule,
   REMINDER_DEFAULT_TIME,
@@ -141,7 +142,7 @@ export function CreateReminderModal() {
         // Both or neither: the API rejects one without the other.
         ...(attachTo ?? undefined),
       });
-      toast.success(`Reminder set for ${formatWhen(date)}`);
+      toast.success(`Reminder set for ${formatReminderWhen(date)}`);
     } catch {
       toast.failure('Failed to create reminder');
     }
@@ -425,13 +426,4 @@ function WhenList(props: {
       </div>
     </>
   );
-}
-
-function formatWhen(date: Date): string {
-  return date.toLocaleString(undefined, {
-    month: 'short',
-    day: 'numeric',
-    hour: 'numeric',
-    minute: '2-digit',
-  });
 }

--- a/apps/web/src/features/reminders/reminder-schedule.test.ts
+++ b/apps/web/src/features/reminders/reminder-schedule.test.ts
@@ -3,6 +3,7 @@ import type { EntityData } from '@entity';
 import { describe, expect, it } from 'vitest';
 
 import {
+  formatReminderWhen,
   futureDateOptions,
   onceSchedule,
   REMINDER_DEFAULT_TIME,
@@ -293,5 +294,52 @@ describe('REMINDER_DEFAULT_TIME', () => {
   // is easy to miss, so this is deliberately a morning.
   it('is 9am', () => {
     expect(REMINDER_DEFAULT_TIME).toEqual({ hours: 9, minutes: 0 });
+  });
+});
+
+describe('formatReminderWhen', () => {
+  // Fixed instants rather than the wall clock, and the assertions compare
+  // against `toLocaleString` output rather than a hardcoded string, so the
+  // test states what is included and stays put across locales and timezones.
+  const now = new Date('2026-08-07T10:00:00.000Z').getTime();
+  const timeOnly = { hour: 'numeric', minute: '2-digit' } as const;
+  const withDate = { month: 'short', day: 'numeric', ...timeOnly } as const;
+
+  it('omits the date three hours out', () => {
+    const date = new Date(now + 3 * 60 * 60 * 1000);
+    expect(formatReminderWhen(date, now)).toBe(
+      date.toLocaleString(undefined, timeOnly)
+    );
+  });
+
+  it('omits the date just under a day out', () => {
+    const date = new Date(now + 24 * 60 * 60 * 1000 - 1);
+    expect(formatReminderWhen(date, now)).toBe(
+      date.toLocaleString(undefined, timeOnly)
+    );
+  });
+
+  it('includes the date at exactly a day out', () => {
+    const date = new Date(now + 24 * 60 * 60 * 1000);
+    expect(formatReminderWhen(date, now)).toBe(
+      date.toLocaleString(undefined, withDate)
+    );
+  });
+
+  it('includes the date a week out', () => {
+    const date = new Date(now + 7 * 24 * 60 * 60 * 1000);
+    expect(formatReminderWhen(date, now)).toBe(
+      date.toLocaleString(undefined, withDate)
+    );
+  });
+
+  // The composer rejects past times before this runs, but a date that slipped
+  // past while the dialog sat open should still read as a time, not crash or
+  // sprout a date.
+  it('omits the date for an instant already past', () => {
+    const date = new Date(now - 60 * 1000);
+    expect(formatReminderWhen(date, now)).toBe(
+      date.toLocaleString(undefined, timeOnly)
+    );
   });
 });

--- a/apps/web/src/features/reminders/reminder-schedule.test.ts
+++ b/apps/web/src/features/reminders/reminder-schedule.test.ts
@@ -9,6 +9,7 @@ import {
   REMINDER_DESCRIPTION_MAX_LENGTH,
   reminderDefaultOptions,
   reminderDescriptionFor,
+  resolveReminderDescription,
 } from './reminder-schedule';
 
 const option = (id: string, date: Date): DateOption => ({
@@ -227,6 +228,63 @@ describe('reminderDescriptionFor', () => {
 
     expect([...result]).toHaveLength(REMINDER_DESCRIPTION_MAX_LENGTH);
     expect(result.endsWith('🔔')).toBe(true);
+  });
+});
+
+describe('resolveReminderDescription', () => {
+  const doc = (name: string) =>
+    ({ type: 'document', id: 'e1', name }) as EntityData;
+
+  it('uses what the user typed', () => {
+    expect(
+      resolveReminderDescription(
+        'Chase the countersignature',
+        doc('Q3 Contract')
+      )
+    ).toBe('Chase the countersignature');
+  });
+
+  it('trims what the user typed', () => {
+    expect(resolveReminderDescription('  Chase it  ', doc('Q3 Contract'))).toBe(
+      'Chase it'
+    );
+  });
+
+  // The step is optional and the API rejects an empty description, so skipping
+  // it has to land on the entity-derived name rather than send nothing.
+  it('falls back to the entity name when the field is skipped', () => {
+    expect(resolveReminderDescription('', doc('Q3 Contract'))).toBe(
+      'Q3 Contract'
+    );
+  });
+
+  it('treats whitespace-only input as skipped', () => {
+    expect(resolveReminderDescription('   \n\t ', doc('Q3 Contract'))).toBe(
+      'Q3 Contract'
+    );
+  });
+
+  // Skipping on an unnamed entity still has to produce something valid.
+  it('falls back through to the untitled label', () => {
+    expect(resolveReminderDescription('', doc('  '))).toBe('Untitled');
+  });
+
+  // The input's maxLength counts code units, so an emoji-heavy paste can still
+  // arrive over the service's character limit.
+  it('truncates over-long input by character', () => {
+    const long = '🔔'.repeat(REMINDER_DESCRIPTION_MAX_LENGTH + 10);
+    const result = resolveReminderDescription(long, doc('Q3 Contract'));
+
+    expect([...result]).toHaveLength(REMINDER_DESCRIPTION_MAX_LENGTH);
+    expect(result.endsWith('🔔')).toBe(true);
+  });
+
+  it('leaves input exactly at the limit alone', () => {
+    const atLimit = 'x'.repeat(REMINDER_DESCRIPTION_MAX_LENGTH);
+
+    expect(resolveReminderDescription(atLimit, doc('Q3 Contract'))).toBe(
+      atLimit
+    );
   });
 });
 

--- a/apps/web/src/features/reminders/reminder-schedule.ts
+++ b/apps/web/src/features/reminders/reminder-schedule.ts
@@ -172,3 +172,24 @@ export function resolveReminderDescription(
 ): string {
   return clampDescription(input) || reminderDescriptionFor(entity);
 }
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+/** Confirmation text for a reminder that was just set.
+ *
+ * The date is dropped for anything inside the next day: "set for 1:08 PM" is
+ * what someone who just asked for three hours from now wants to read back, and
+ * "Aug 7, 1:08 PM" only adds a date they already know. Past the day boundary
+ * the date carries the meaning, so it stays.
+ */
+export function formatReminderWhen(
+  date: Date,
+  now: number = Date.now()
+): string {
+  const withinADay = date.getTime() - now < ONE_DAY_MS;
+  return date.toLocaleString(undefined, {
+    ...(withinADay ? {} : { month: 'short', day: 'numeric' }),
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}

--- a/apps/web/src/features/reminders/reminder-schedule.ts
+++ b/apps/web/src/features/reminders/reminder-schedule.ts
@@ -129,12 +129,24 @@ function untitledName(type: EntityData['type']): string {
 }
 
 /**
- * The description for a reminder about `entity`.
+ * `text` trimmed and cut to the service's limit.
  *
- * Derived rather than typed, so this must always produce something the API will
- * accept: an unnamed entity falls back to how lists label it, and an over-long
- * name is truncated instead of rejected — there is no input for the user to fix.
- * Counts characters, not bytes, because the service's limit does.
+ * Counts characters, not code units, because the service's limit does — a
+ * naive `slice` would cut an emoji in half rather than drop it.
+ */
+function clampDescription(text: string): string {
+  const characters = [...text.trim()];
+  return characters.length > REMINDER_DESCRIPTION_MAX_LENGTH
+    ? characters.slice(0, REMINDER_DESCRIPTION_MAX_LENGTH).join('')
+    : characters.join('');
+}
+
+/**
+ * The description for a reminder about `entity`, derived from the entity alone.
+ *
+ * This is the fallback for a reminder the user did not describe, so it must
+ * always produce something the API will accept: an unnamed entity falls back to
+ * how lists label it, and an over-long name is truncated instead of rejected.
  */
 export function reminderDescriptionFor(entity: EntityData): string {
   // A thread row's `name` is the literal placeholder "Channel thread", so the
@@ -144,8 +156,19 @@ export function reminderDescriptionFor(entity: EntityData): string {
   const label =
     entity.type === 'channel_thread' ? entity.content?.trim() : undefined;
   const name = label || entity.name?.trim();
-  const characters = [...(name || untitledName(entity.type))];
-  return characters.length > REMINDER_DESCRIPTION_MAX_LENGTH
-    ? characters.slice(0, REMINDER_DESCRIPTION_MAX_LENGTH).join('')
-    : characters.join('');
+  return clampDescription(name || untitledName(entity.type));
+}
+
+/**
+ * What to store as a reminder's description: what the user typed, or the
+ * entity-derived name when they skipped the field.
+ *
+ * The composer's description step is optional but the API rejects an empty
+ * description, so blank input has to resolve to something rather than through.
+ */
+export function resolveReminderDescription(
+  input: string,
+  entity: EntityData
+): string {
+  return clampDescription(input) || reminderDescriptionFor(entity);
 }

--- a/apps/web/src/lib/core/component/EntityIcon.tsx
+++ b/apps/web/src/lib/core/component/EntityIcon.tsx
@@ -518,29 +518,41 @@ export function getEntityIconType(entity: EntityIconData): EntityWithValidIcon {
     .with({ type: 'document' }, (e) => itemToBlockName(e, true) ?? 'default')
     .with({ type: 'email', isRead: true }, () => 'emailRead')
     .with({ type: 'email' }, () => 'email')
-    // A reminder shows the icon of what it is about. The referenced entity's
-    // fileType/subType are resolved server-side precisely so this stays
-    // synchronous — every icon call site is.
-    //
-    // A standalone reminder is about nothing else, so it falls back to a bell
-    // rather than to `default`, whose wide variant is the unknown-file glyph.
-    .with({ type: 'reminder' }, (e) =>
-      e.referencedEntity
-        ? (itemToBlockName(
-            {
-              type: e.referencedEntity.type,
-              fileType: e.referencedEntity.fileType,
-              subType: e.referencedEntity.subType
-                ? { type: e.referencedEntity.subType as NamedSubType }
-                : undefined,
-            },
-            true
-          ) ?? 'reminder')
-        : 'reminder'
-    )
+    // Always the bell, never the referenced entity's icon: a reminder is a
+    // reminder first, and what it points at is iconed beside its name instead
+    // — see `reminderReferenceIconType`.
+    .with({ type: 'reminder' }, () => 'reminder')
     .otherwise((e) => e.type);
 
   return validateEntity(typeString);
+}
+
+/**
+ * The icon for what a reminder is about, shown beside the reminder's name.
+ *
+ * Synchronous by design: the referenced entity's `fileType`/`subType` are
+ * resolved server-side precisely so this costs no fetch per row. A reference
+ * that maps to no block falls back to the bell rather than to `default`,
+ * whose wide variant is the unknown-file glyph.
+ */
+export function reminderReferenceIconType(
+  reference: NonNullable<ReminderEntity['referencedEntity']>
+): EntityWithValidIcon {
+  const blockName = itemToBlockName(
+    {
+      type: reference.type,
+      fileType: reference.fileType,
+      subType: reference.subType
+        ? { type: reference.subType as NamedSubType }
+        : undefined,
+    },
+    true
+  );
+
+  if (blockName && getIconConfig(blockName)) {
+    return blockName as EntityWithValidIcon;
+  }
+  return 'reminder';
 }
 
 export function getEntityIconConfig(entity: EntityData) {

--- a/apps/web/src/lib/core/component/EntityIcon.tsx
+++ b/apps/web/src/lib/core/component/EntityIcon.tsx
@@ -527,13 +527,19 @@ export function getEntityIconType(entity: EntityIconData): EntityWithValidIcon {
   return validateEntity(typeString);
 }
 
+/** What the block resolvers return when they cannot place something. */
+const UNRESOLVED_ICONS: ReadonlySet<string> = new Set(['default', 'unknown']);
+
 /**
  * The icon for what a reminder is about, shown beside the reminder's name.
  *
  * Synchronous by design: the referenced entity's `fileType`/`subType` are
- * resolved server-side precisely so this costs no fetch per row. A reference
- * that maps to no block falls back to the bell rather than to `default`,
- * whose wide variant is the unknown-file glyph.
+ * resolved server-side precisely so this costs no fetch per row.
+ *
+ * A reference that resolves to nothing gets the bell, not the unknown-file
+ * glyph, which on a reminder row reads as breakage rather than as a reminder.
+ * That needs both sentinels and neither is falsy: `fileTypeToBlockName`
+ * returns the literal `unknown`, and `validateEntity` returns `default`.
  */
 export function reminderReferenceIconType(
   reference: NonNullable<ReminderEntity['referencedEntity']>
@@ -549,10 +555,8 @@ export function reminderReferenceIconType(
     true
   );
 
-  if (blockName && getIconConfig(blockName)) {
-    return blockName as EntityWithValidIcon;
-  }
-  return 'reminder';
+  const iconType = blockName ? validateEntity(blockName) : 'default';
+  return UNRESOLVED_ICONS.has(iconType) ? 'reminder' : iconType;
 }
 
 export function getEntityIconConfig(entity: EntityData) {


### PR DESCRIPTION
Stacked on #5485 (part D). Base is `evan/reminders-d-active-done`.

## Describing a reminder

The composer asked one question — *when*. The description was derived from the entity, so two reminders on the same document were indistinguishable in a list.

There is now an optional description step in front of the date list:

```
┌──────────────────────────────────┐    ┌──────────────────────────────────┐
│ 🔔 What's the reminder? (optional)│    │ 🔔 Remind me when?               │
├──────────────────────────────────┤    ├──────────────────────────────────┤
│ [📄 Q3 Contract]                 │ →  │ [📄 Q3 Contract] [Chase it]      │
├──────────────────────────────────┤    ├──────────────────────────────────┤
│ [ESC] Cancel      [Continue  ↵]  │    │ In 1 hour            Today, 4:37 │
└──────────────────────────────────┘    └──────────────────────────────────┘
```

Enter on an empty field falls straight through, so setting a reminder stays the same two keystrokes it was. A blank field resolves to the entity-derived name at submit — the field is optional but the API rejects an empty description, so `resolveReminderDescription` has to land on something.

**Escape steps back before it closes**, matching how the command menu treats a sub-scope (`HotkeyHint command={escapeHotkey} label="Back"`). That needs Kobalte's `onEscapeKeyDown` with `preventDefault` — its escape listener is document-level and would otherwise dismiss the whole dialog. The registered escape hotkey only fires with focus *outside* the input, and the hotkey layer is capture-phase with `stopPropagation`, so exactly one of the two paths runs, never both.

Focus is set in `onMount` rather than via `autofocus`, which only fires for whichever step is on screen when the dialog opens; moving between steps remounts the input inside an already-open dialog. The caret lands at the end so stepping back continues the text rather than sitting in front of it.

`maxLength` on the field counts UTF-16 code units where the service counts characters, so it can only ever stop short of the real limit — `resolveReminderDescription` applies the exact character-accurate cap.

## Rows say what a reminder is about

A reminder's name may no longer be its entity's name, so the row has to say which entity it points at:

```
🔔  kill it              [📄 Macro how to guide]     ← own description
🔔  📋 Intro to tasks                                ← description was skipped
🔔  Water the plants                                 ← references nothing
```

Which form appears depends on whether the description matches the referenced entity's resolved name. A match means the step was skipped and the title *is* the reference, so it takes the entity's icon inline; otherwise the reference trails as a badge, the way `CallWideContent` trails a call with its channel. Neither shows while the reference is resolving or for one the caller cannot see — `name()` returns the literal string `"Untitled"` in both cases, so this gates on `isAccessiblePreviewItem`.

Only the wide layout, matching calls (`CallWideContent` badges the channel, `CallNarrowBody` doesn't). The Inbox card path is separate and already has its own `ReminderReferenceChip`; the two never render together since `soup-view.tsx` picks `InboxListEntity` *or* `ListEntity`.

No extra network cost: the name comes from `useItemPreviewData`, which goes through `previewDataLoader` (a batching DataLoader) with a 24-hour `staleTime`, so a page of reminders resolves in one batched request.

## The leading icon is now always the bell

It used to borrow the referenced entity's icon, which would have duplicated whichever of the two forms above the row landed on.

That mapping was written **twice** — once in `features/entity/extractors/entity-icon.tsx` and once in `getEntityIconType` in `core/component/EntityIcon.tsx`, with near-identical comments. Changing only the one behind the list row would have left the drag preview (`ItemDragAndDrop`) and the activity timeline still showing the old icon. It is consolidated into a single `reminderReferenceIconType` in core, and both call sites return the bell.

That helper stays synchronous — `fileType`/`subType` arrive resolved from the server precisely so a reference can be iconed without a fetch per row. Only the *choice* between the two row forms needs the async name.

## Notes

- Frontend only. `CreateReminderRequest.description` already accepts arbitrary text and the service already trims, rejects empty, and caps at 2000 characters — no Rust, schema, or migration changes.
- 7 new tests on `resolveReminderDescription` cover typed / trimmed / skipped / whitespace-only / untitled-fallback / emoji-truncation / exactly-at-limit.
