### PR TITLE
feat(db): add new index to support email link deletion for calendar events

### DIFF
--- a/crates/macro_db_client/migrations/20260807131214_add_calendar_backfill_jobs_email_links_id_index.sql
+++ b/crates/macro_db_client/migrations/20260807131214_add_calendar_backfill_jobs_email_links_id_index.sql
@@ -1,0 +1,7 @@
+-- no-transaction
+
+-- Supports the ON DELETE CASCADE from email_links: without this, each link
+-- deletion seq-scans calendar_backfill_jobs while holding the email_links
+-- row lock.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_calendar_backfill_jobs_email_link_id
+    ON calendar_backfill_jobs (email_link_id);


### PR DESCRIPTION
Supports the ON DELETE CASCADE from email_links: without this, each link deletion seq scans calendar_backfill_jobs while holding the email_links row lock.