### PR TITLE
feat: add purple todo app

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14907,6 +14907,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "todo_app"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "http-body-util",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tower 0.5.3",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
+ "workspace-hack",
+]
+
+[[package]]
 name = "tokio"
 version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,7 @@ members = [
   "tooling/native_app_server",
   "tooling/notification_sandbox",
   "tooling/seed_cli",
+  "tooling/todo_app",
   "tooling/xtask",
   "tooling/xtask/crates/*",
 ]

--- a/tooling/todo_app/Cargo.toml
+++ b/tooling/todo_app/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+edition = "2024"
+name = "todo_app"
+publish = false
+version = "0.1.0"
+
+[dependencies]
+axum = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true, features = ["macros", "net", "rt-multi-thread"] }
+tower = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+uuid = { workspace = true }
+workspace-hack = { version = "0.1", path = "../../crates/workspace-hack" }
+
+[dev-dependencies]
+http-body-util = { workspace = true }
+tower = { workspace = true, features = ["util"] }

--- a/tooling/todo_app/src/handlers.rs
+++ b/tooling/todo_app/src/handlers.rs
@@ -1,0 +1,43 @@
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    response::{Html, IntoResponse},
+    Json,
+};
+use uuid::Uuid;
+
+use crate::store::{MemoryTodoStore, NewTodo, Todo};
+
+pub async fn ui() -> Html<&'static str> {
+    Html(include_str!("../static/index.html"))
+}
+
+pub async fn list_todos(State(store): State<MemoryTodoStore>) -> Json<Vec<Todo>> {
+    Json(store.list())
+}
+
+pub async fn create_todo(
+    State(store): State<MemoryTodoStore>,
+    Json(new): Json<NewTodo>,
+) -> impl IntoResponse {
+    let todo = store.insert(Todo::new(new.text));
+    (StatusCode::CREATED, Json(todo))
+}
+
+pub async fn toggle_todo(
+    State(store): State<MemoryTodoStore>,
+    Path(id): Path<Uuid>,
+) -> Result<Json<Todo>, StatusCode> {
+    store.toggle(id).map(Json).ok_or(StatusCode::NOT_FOUND)
+}
+
+pub async fn delete_todo(
+    State(store): State<MemoryTodoStore>,
+    Path(id): Path<Uuid>,
+) -> Result<StatusCode, StatusCode> {
+    if store.delete(id) {
+        Ok(StatusCode::NO_CONTENT)
+    } else {
+        Err(StatusCode::NOT_FOUND)
+    }
+}

--- a/tooling/todo_app/src/main.rs
+++ b/tooling/todo_app/src/main.rs
@@ -1,0 +1,47 @@
+mod handlers;
+mod store;
+
+#[cfg(test)]
+mod test;
+
+use std::net::{Ipv4Addr, SocketAddr};
+
+use axum::{
+    routing::{get, patch},
+    Router,
+};
+
+use crate::store::MemoryTodoStore;
+
+const PORT: u16 = 3000;
+
+pub fn router(store: MemoryTodoStore) -> Router {
+    Router::new()
+        .route("/", get(handlers::ui))
+        .route(
+            "/api/todos",
+            get(handlers::list_todos).post(handlers::create_todo),
+        )
+        .route(
+            "/api/todos/{id}",
+            patch(handlers::toggle_todo).delete(handlers::delete_todo),
+        )
+        .with_state(store)
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
+
+    let addr = SocketAddr::from((Ipv4Addr::UNSPECIFIED, PORT));
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    tracing::info!(%addr, "purple todo app listening");
+
+    axum::serve(listener, router(MemoryTodoStore::default())).await?;
+    Ok(())
+}

--- a/tooling/todo_app/src/store.rs
+++ b/tooling/todo_app/src/store.rs
@@ -1,0 +1,60 @@
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Todo {
+    pub id: Uuid,
+    pub text: String,
+    pub completed: bool,
+}
+
+impl Todo {
+    pub fn new(text: String) -> Self {
+        Self {
+            id: Uuid::new_v4(),
+            text,
+            completed: false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NewTodo {
+    pub text: String,
+}
+
+pub trait TodoStore: Send + Sync + 'static {
+    fn list(&self) -> Vec<Todo>;
+    fn insert(&self, todo: Todo) -> Todo;
+    fn toggle(&self, id: Uuid) -> Option<Todo>;
+    fn delete(&self, id: Uuid) -> bool;
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct MemoryTodoStore {
+    todos: std::sync::Mutex<Vec<Todo>>,
+}
+
+impl TodoStore for MemoryTodoStore {
+    fn list(&self) -> Vec<Todo> {
+        self.todos.lock().unwrap().clone()
+    }
+
+    fn insert(&self, todo: Todo) -> Todo {
+        self.todos.lock().unwrap().push(todo.clone());
+        todo
+    }
+
+    fn toggle(&self, id: Uuid) -> Option<Todo> {
+        let mut todos = self.todos.lock().unwrap();
+        let todo = todos.iter_mut().find(|todo| todo.id == id)?;
+        todo.completed = !todo.completed;
+        Some(todo.clone())
+    }
+
+    fn delete(&self, id: Uuid) -> bool {
+        let mut todos = self.todos.lock().unwrap();
+        let index = todos.iter().position(|todo| todo.id == id);
+        index.map(|index| todos.remove(index)).is_some()
+    }
+}

--- a/tooling/todo_app/src/test.rs
+++ b/tooling/todo_app/src/test.rs
@@ -1,0 +1,210 @@
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+};
+use http_body_util::BodyExt;
+use serde_json::{json, Value};
+use tower::ServiceExt;
+
+use crate::{
+    router,
+    store::{MemoryTodoStore, NewTodo, Todo, TodoStore},
+};
+
+fn test_app() -> axum::Router {
+    router(MemoryTodoStore::default())
+}
+
+async fn body_json(response: axum::response::Response) -> Value {
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    serde_json::from_slice(&bytes).unwrap()
+}
+
+#[tokio::test]
+async fn list_starts_empty() {
+    let response = test_app()
+        .oneshot(
+            Request::builder()
+                .uri("/api/todos")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(body_json(response).await, json!([]));
+}
+
+#[tokio::test]
+async fn create_and_list_todo() {
+    let app = test_app();
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/todos")
+                .header("content-type", "application/json")
+                .body(Body::from(json!({ "text": "buy milk" }).to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let created = body_json(response).await;
+    assert_eq!(created["text"], "buy milk");
+    assert_eq!(created["completed"], false);
+
+    let id = created["id"].as_str().unwrap();
+    let response = app
+        .oneshot(Request::builder().uri("/api/todos").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let todos = body_json(response).await;
+    assert_eq!(todos.as_array().unwrap().len(), 1);
+    assert_eq!(todos[0]["id"], id);
+}
+
+#[tokio::test]
+async fn toggle_todo_flips_completed() {
+    let store = MemoryTodoStore::default();
+    let todo = store.insert(Todo::new("write tests".into()));
+    let app = router(store);
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("PATCH")
+                .uri(format!("/api/todos/{}", todo.id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let toggled = body_json(response).await;
+    assert_eq!(toggled["id"], todo.id.to_string());
+    assert_eq!(toggled["completed"], true);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("PATCH")
+                .uri(format!("/api/todos/{}", todo.id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let toggled = body_json(response).await;
+    assert_eq!(toggled["completed"], false);
+}
+
+#[tokio::test]
+async fn toggle_missing_todo_returns_not_found() {
+    let response = test_app()
+        .oneshot(
+            Request::builder()
+                .method("PATCH")
+                .uri("/api/todos/00000000-0000-0000-0000-000000000000")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn delete_todo_removes_it() {
+    let store = MemoryTodoStore::default();
+    let todo = store.insert(Todo::new("clean up".into()));
+    let app = router(store);
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(format!("/api/todos/{}", todo.id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+
+    let response = app
+        .oneshot(Request::builder().uri("/api/todos").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(body_json(response).await, json!([]));
+}
+
+#[tokio::test]
+async fn delete_missing_todo_returns_not_found() {
+    let response = test_app()
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri("/api/todos/00000000-0000-0000-0000-000000000000")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn ui_is_served_at_root() {
+    let response = test_app()
+        .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let html = String::from_utf8(bytes.to_vec()).unwrap();
+    assert!(html.contains("My Todo"));
+}
+
+#[test]
+fn new_todo_starts_incomplete() {
+    let todo = Todo::new("purple theme".into());
+    assert_eq!(todo.completed, false);
+    assert!(todo.id != uuid::Uuid::nil());
+}
+
+#[test]
+fn store_toggle_returns_some_for_known_id() {
+    let store = MemoryTodoStore::default();
+    let todo = store.insert(Todo::new("present".into()));
+
+    let toggled = store.toggle(todo.id).unwrap();
+    assert!(toggled.completed);
+
+    assert!(store.toggle(uuid::Uuid::nil()).is_none());
+}
+
+#[test]
+fn new_todo_serde_round_trip() {
+    let new = NewTodo {
+        text: "hello".into(),
+    };
+    let json = serde_json::to_string(&new).unwrap();
+    let back: NewTodo = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.text, "hello");
+}

--- a/tooling/todo_app/static/index.html
+++ b/tooling/todo_app/static/index.html
@@ -1,0 +1,260 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Purple Todo</title>
+    <style>
+      :root {
+        --purple-950: #2e1065;
+        --purple-900: #4c1d95;
+        --purple-700: #6d28d9;
+        --purple-600: #7c3aed;
+        --purple-500: #8b5cf6;
+        --purple-300: #c4b5fd;
+        --purple-100: #ede9fe;
+        --white: #ffffff;
+      }
+
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+
+      body {
+        font-family:
+          -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica,
+          Arial, sans-serif;
+        min-height: 100vh;
+        display: flex;
+        align-items: flex-start;
+        justify-content: center;
+        padding: 48px 16px;
+        background: linear-gradient(135deg, var(--purple-950), var(--purple-700));
+        color: #1f2937;
+      }
+
+      .card {
+        width: 100%;
+        max-width: 480px;
+        background: var(--white);
+        border-radius: 16px;
+        padding: 32px;
+        box-shadow: 0 20px 50px rgba(0, 0, 0, 0.35);
+      }
+
+      h1 {
+        font-size: 28px;
+        color: var(--purple-700);
+        margin-bottom: 24px;
+      }
+
+      .add-row {
+        display: flex;
+        gap: 8px;
+        margin-bottom: 24px;
+      }
+
+      input[type="text"] {
+        flex: 1;
+        padding: 12px 16px;
+        border: 2px solid var(--purple-100);
+        border-radius: 10px;
+        font-size: 16px;
+        outline: none;
+      }
+
+      input[type="text"]:focus {
+        border-color: var(--purple-500);
+      }
+
+      button {
+        padding: 12px 20px;
+        border: none;
+        border-radius: 10px;
+        font-size: 16px;
+        font-weight: 600;
+        cursor: pointer;
+        background: var(--purple-600);
+        color: var(--white);
+        transition: background 0.15s ease;
+      }
+
+      button:hover {
+        background: var(--purple-700);
+      }
+
+      .todo {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        padding: 12px 0;
+        border-bottom: 1px solid var(--purple-100);
+      }
+
+      .todo:last-child {
+        border-bottom: none;
+      }
+
+      .todo input[type="checkbox"] {
+        width: 20px;
+        height: 20px;
+        accent-color: var(--purple-600);
+        cursor: pointer;
+      }
+
+      .todo .text {
+        flex: 1;
+        font-size: 16px;
+      }
+
+      .todo.done .text {
+        text-decoration: line-through;
+        color: #9ca3af;
+      }
+
+      .todo button {
+        padding: 6px 12px;
+        font-size: 14px;
+        background: var(--purple-500);
+      }
+
+      .todo button:hover {
+        background: var(--purple-700);
+      }
+
+      .empty {
+        text-align: center;
+        color: var(--purple-300);
+        padding: 16px 0;
+      }
+
+      .error {
+        background: #fee2e2;
+        color: #b91c1c;
+        border-radius: 8px;
+        padding: 8px 12px;
+        margin-bottom: 16px;
+        display: none;
+      }
+    </style>
+  </head>
+  <body>
+    <main class="card">
+      <h1>My Todo</h1>
+      <div class="error" id="error"></div>
+      <form class="add-row" id="add-form">
+        <input
+          id="new-todo"
+          type="text"
+          placeholder="What needs doing?"
+          autocomplete="off"
+          required
+        />
+        <button type="submit">Add</button>
+      </form>
+      <div id="todo-list"></div>
+    </main>
+    <script>
+      const list = document.getElementById("todo-list");
+      const error = document.getElementById("error");
+      const form = document.getElementById("add-form");
+      const input = document.getElementById("new-todo");
+
+      function showError(message) {
+        error.textContent = message;
+        error.style.display = "block";
+        setTimeout(() => {
+          error.style.display = "none";
+        }, 3000);
+      }
+
+      function todoElement(todo) {
+        const row = document.createElement("div");
+        row.className = "todo" + (todo.completed ? " done" : "");
+
+        const checkbox = document.createElement("input");
+        checkbox.type = "checkbox";
+        checkbox.checked = todo.completed;
+        checkbox.addEventListener("change", () => toggleTodo(todo.id, checkbox));
+
+        const text = document.createElement("span");
+        text.className = "text";
+        text.textContent = todo.text;
+
+        const remove = document.createElement("button");
+        remove.textContent = "Delete";
+        remove.addEventListener("click", () => deleteTodo(todo.id, row));
+
+        row.append(checkbox, text, remove);
+        return row;
+      }
+
+      async function load() {
+        const res = await fetch("/api/todos");
+        if (!res.ok) {
+          showError("Failed to load todos");
+          return;
+        }
+        const todos = await res.json();
+        list.replaceChildren();
+        if (todos.length === 0) {
+          const empty = document.createElement("p");
+          empty.className = "empty";
+          empty.textContent = "No todos yet. Add one above!";
+          list.append(empty);
+          return;
+        }
+        for (const todo of todos) {
+          list.append(todoElement(todo));
+        }
+      }
+
+      async function addTodo(text) {
+        const res = await fetch("/api/todos", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ text }),
+        });
+        if (!res.ok) {
+          showError("Failed to add todo");
+          return;
+        }
+        await load();
+      }
+
+      async function toggleTodo(id, checkbox) {
+        const res = await fetch(`/api/todos/${id}`, { method: "PATCH" });
+        if (!res.ok) {
+          checkbox.checked = !checkbox.checked;
+          showError("Failed to update todo");
+          return;
+        }
+        await load();
+      }
+
+      async function deleteTodo(id, row) {
+        const res = await fetch(`/api/todos/${id}`, { method: "DELETE" });
+        if (!res.ok) {
+          showError("Failed to delete todo");
+          return;
+        }
+        row.remove();
+        await load();
+      }
+
+      form.addEventListener("submit", (event) => {
+        event.preventDefault();
+        const text = input.value.trim();
+        if (!text) {
+          return;
+        }
+        input.value = "";
+        addTodo(text);
+      });
+
+      load();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Adds a small self-contained todo web app (`tooling/todo_app`).

- Purple-themed single-page UI served by an axum server
- In-memory todo store with list/create/toggle/delete endpoints
- Unit tests for the store and API handlers

Runs with `cargo run -p todo_app` and opens at http://localhost:3000.