### PR TITLE
Seanaye/feat/optimistic links

### DIFF
--- a/apps/web/src/lib/graphql-cache/exchange/optimistic.test.ts
+++ b/apps/web/src/lib/graphql-cache/exchange/optimistic.test.ts
@@ -124,6 +124,24 @@ describe('typed optimistic graph updates', () => {
         entity: { __typename: 'GraphqlSoupDocument', id: 'task-1' },
         insertFields: { nextCursor: null },
       });
+      upsertEmbeddedLink(bins, {
+        listItem: { whereField: 'key', equals: 'urgent' },
+        // @ts-expect-error Link fields must be generated normalized-entity lists.
+        linkField: 'key',
+        countField: 'totalCount',
+        entity: { __typename: 'GraphqlSoupDocument', id: 'task-1' },
+        insertFields: { nextCursor: null },
+      });
+      upsertEmbeddedLink(bins, {
+        listItem: { whereField: 'key', equals: 'urgent' },
+        linkField: 'items',
+        countField: 'totalCount',
+        entity: { __typename: 'GraphqlSoupDocument', id: 'task-1' },
+        insertFields: {
+          // @ts-expect-error Managed fields cannot be supplied for insertion.
+          key: 'urgent',
+        },
+      });
     };
 
     expect(typeAssertions).toBeTypeOf('function');

--- a/apps/web/src/lib/graphql-cache/exchange/optimistic.test.ts
+++ b/apps/web/src/lib/graphql-cache/exchange/optimistic.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   prependUnique,
   remove,
+  removeEmbeddedLink,
   select,
   update,
   upsertEmbeddedLink,
@@ -54,18 +55,33 @@ describe('typed optimistic graph updates', () => {
     expect(prepend.operation.kind).toBe('prependUnique');
   });
 
-  it('serializes an embedded bin insertion with an entity link', () => {
+  it('serializes counted embedded link changes', () => {
     const bins = select(GroupSoupMembershipDocument, { input })
       .field('user')
       .field('groupSoup')
       .field('bins');
+    const entity = { __typename: 'GraphqlSoupDocument', id: 'task-1' };
+    const removal = removeEmbeddedLink(bins, {
+      listItem: { whereField: 'key', equals: 'high' },
+      linkField: 'items',
+      countField: 'totalCount',
+      entity,
+    });
     const insertion = upsertEmbeddedLink(bins, {
       listItem: { whereField: 'key', equals: 'urgent' },
       linkField: 'items',
-      entity: { __typename: 'GraphqlSoupDocument', id: 'task-1' },
-      insertFields: { totalCount: 1, nextCursor: null },
+      countField: 'totalCount',
+      entity,
+      insertFields: { nextCursor: null },
     });
 
+    expect(removal.operation).toEqual({
+      kind: 'removeEmbeddedLink',
+      listItem: { whereField: 'key', equals: 'high' },
+      linkField: 'items',
+      countField: 'totalCount',
+      entityKey: 'GraphqlSoupDocument:task-1',
+    });
     expect(insertion.path).toEqual([
       { field: 'user' },
       { field: 'groupSoup' },
@@ -75,8 +91,9 @@ describe('typed optimistic graph updates', () => {
       kind: 'upsertEmbeddedLink',
       listItem: { whereField: 'key', equals: 'urgent' },
       linkField: 'items',
+      countField: 'totalCount',
       entityKey: 'GraphqlSoupDocument:task-1',
-      insertFields: { totalCount: 1, nextCursor: null },
+      insertFields: { nextCursor: null },
     });
   });
 
@@ -99,6 +116,14 @@ describe('typed optimistic graph updates', () => {
         root.field('user'),
         remove({ __typename: 'GraphqlUser', id: 'user-1' })
       );
+      upsertEmbeddedLink(bins, {
+        listItem: { whereField: 'key', equals: 'urgent' },
+        linkField: 'items',
+        // @ts-expect-error Count fields must be generated numeric fields.
+        countField: 'key',
+        entity: { __typename: 'GraphqlSoupDocument', id: 'task-1' },
+        insertFields: { nextCursor: null },
+      });
     };
 
     expect(typeAssertions).toBeTypeOf('function');

--- a/apps/web/src/lib/graphql-cache/exchange/optimistic.test.ts
+++ b/apps/web/src/lib/graphql-cache/exchange/optimistic.test.ts
@@ -1,6 +1,12 @@
 import { GroupSoupMembershipDocument } from '@service-storage/graphql/generated/graphql';
 import { describe, expect, it } from 'vitest';
-import { prependUnique, remove, select, update } from './optimistic';
+import {
+  prependUnique,
+  remove,
+  select,
+  update,
+  upsertEmbeddedLink,
+} from './optimistic';
 
 const input = {
   initial: {
@@ -46,6 +52,32 @@ describe('typed optimistic graph updates', () => {
       entityKey: 'GraphqlSoupDocument:task-1',
     });
     expect(prepend.operation.kind).toBe('prependUnique');
+  });
+
+  it('serializes an embedded bin insertion with an entity link', () => {
+    const bins = select(GroupSoupMembershipDocument, { input })
+      .field('user')
+      .field('groupSoup')
+      .field('bins');
+    const insertion = upsertEmbeddedLink(bins, {
+      listItem: { whereField: 'key', equals: 'urgent' },
+      linkField: 'items',
+      entity: { __typename: 'GraphqlSoupDocument', id: 'task-1' },
+      insertFields: { totalCount: 1, nextCursor: null },
+    });
+
+    expect(insertion.path).toEqual([
+      { field: 'user' },
+      { field: 'groupSoup' },
+      { field: 'bins' },
+    ]);
+    expect(insertion.operation).toEqual({
+      kind: 'upsertEmbeddedLink',
+      listItem: { whereField: 'key', equals: 'urgent' },
+      linkField: 'items',
+      entityKey: 'GraphqlSoupDocument:task-1',
+      insertFields: { totalCount: 1, nextCursor: null },
+    });
   });
 
   it('uses generated operation result and variable types', () => {

--- a/apps/web/src/lib/graphql-cache/exchange/optimistic.ts
+++ b/apps/web/src/lib/graphql-cache/exchange/optimistic.ts
@@ -39,6 +39,9 @@ type JsonScalar = string | number | boolean | null;
 type ScalarKey<T> = {
   [K in StringKey<T>]-?: Present<T[K]> extends JsonScalar ? K : never;
 }[StringKey<T>];
+type ScalarInsertFields<T> = Partial<{
+  [K in ScalarKey<T>]: Exclude<T[K], undefined>;
+}>;
 type SelectionState = {
   readonly document: TypedDocumentNode<unknown, AnyVariables>;
   readonly variables: AnyVariables;
@@ -74,6 +77,13 @@ export type NormalizedEntityIdentity = {
   __typename: string;
   id: string;
 };
+type NormalizedEntityListKey<T> = {
+  [K in StringKey<T>]-?: Present<T[K]> extends readonly (infer TItem)[]
+    ? Present<TItem> extends NormalizedEntityIdentity
+      ? K
+      : never
+    : never;
+}[StringKey<T>];
 
 /** An idempotent change to a normalized-link list. */
 export type LinkDiff =
@@ -234,6 +244,41 @@ export function update<TItem extends object>(
     operation: {
       kind: operation.kind,
       entityKey: normalizedEntityKey(operation.entity),
+    },
+  } as OptimisticUpdate;
+}
+
+/**
+ * Prepends an entity link inside a selected embedded list item, creating the
+ * embedded item from scalar fields when its selector does not exist.
+ */
+export function upsertEmbeddedLink<
+  TItem extends object,
+  TSelectorField extends ScalarKey<TItem>,
+  TLinkField extends NormalizedEntityListKey<TItem>,
+>(
+  selection: ListSelection<TItem>,
+  args: {
+    listItem: {
+      whereField: TSelectorField;
+      equals: Present<TItem[TSelectorField]>;
+    };
+    linkField: TLinkField;
+    entity: NormalizedEntityIdentity;
+    insertFields: ScalarInsertFields<TItem>;
+  }
+): OptimisticUpdate {
+  return {
+    query: stringifyDocument(selection.document),
+    operationName: documentOperationName(selection.document),
+    variablesJson: JSON.stringify(selection.variables ?? {}),
+    path: [...selection.path],
+    operation: {
+      kind: 'upsertEmbeddedLink',
+      listItem: args.listItem,
+      linkField: args.linkField,
+      entityKey: normalizedEntityKey(args.entity),
+      insertFields: args.insertFields,
     },
   } as OptimisticUpdate;
 }

--- a/apps/web/src/lib/graphql-cache/exchange/optimistic.ts
+++ b/apps/web/src/lib/graphql-cache/exchange/optimistic.ts
@@ -42,8 +42,11 @@ type ScalarKey<T> = {
 type NumberKey<T> = {
   [K in StringKey<T>]-?: Present<T[K]> extends number ? K : never;
 }[StringKey<T>];
-type ScalarInsertFields<T> = Partial<{
-  [K in ScalarKey<T>]: Exclude<T[K], undefined>;
+type ScalarInsertFields<T, TExcluded extends StringKey<T>> = Partial<{
+  [K in Exclude<ScalarKey<T>, TExcluded>]: Extract<
+    Exclude<T[K], undefined>,
+    JsonScalar
+  >;
 }>;
 type SelectionState = {
   readonly document: TypedDocumentNode<unknown, AnyVariables>;
@@ -184,6 +187,16 @@ function serializeRevalidation(
   };
 }
 
+function definedScalarFields(
+  fields: Readonly<Record<string, JsonScalar | undefined>>
+): Record<string, JsonScalar> {
+  return Object.fromEntries(
+    Object.entries(fields).filter(
+      (entry): entry is [string, JsonScalar] => entry[1] !== undefined
+    )
+  );
+}
+
 function createSelection<T>(state: SelectionState): Selection<T> {
   const selection = {
     ...state,
@@ -265,14 +278,14 @@ export function removeEmbeddedLink<
   args: {
     listItem: {
       whereField: TSelectorField;
-      equals: Present<TItem[TSelectorField]>;
+      equals: Extract<Present<TItem[TSelectorField]>, JsonScalar>;
     };
     linkField: TLinkField;
     countField: TCountField;
     entity: NormalizedEntityIdentity;
   }
 ): OptimisticUpdate {
-  return {
+  const update: OptimisticLinkPatchWire = {
     query: stringifyDocument(selection.document),
     operationName: documentOperationName(selection.document),
     variablesJson: JSON.stringify(selection.variables ?? {}),
@@ -284,7 +297,8 @@ export function removeEmbeddedLink<
       countField: args.countField,
       entityKey: normalizedEntityKey(args.entity),
     },
-  } as unknown as OptimisticUpdate;
+  };
+  return update as OptimisticUpdate;
 }
 
 /**
@@ -302,15 +316,18 @@ export function upsertEmbeddedLink<
   args: {
     listItem: {
       whereField: TSelectorField;
-      equals: Present<TItem[TSelectorField]>;
+      equals: Extract<Present<TItem[TSelectorField]>, JsonScalar>;
     };
     linkField: TLinkField;
     countField: TCountField;
     entity: NormalizedEntityIdentity;
-    insertFields: ScalarInsertFields<TItem>;
+    insertFields: ScalarInsertFields<
+      TItem,
+      TSelectorField | TCountField | TLinkField
+    >;
   }
 ): OptimisticUpdate {
-  return {
+  const update: OptimisticLinkPatchWire = {
     query: stringifyDocument(selection.document),
     operationName: documentOperationName(selection.document),
     variablesJson: JSON.stringify(selection.variables ?? {}),
@@ -321,9 +338,10 @@ export function upsertEmbeddedLink<
       linkField: args.linkField,
       countField: args.countField,
       entityKey: normalizedEntityKey(args.entity),
-      insertFields: args.insertFields,
+      insertFields: definedScalarFields(args.insertFields),
     },
-  } as unknown as OptimisticUpdate;
+  };
+  return update as OptimisticUpdate;
 }
 
 /**

--- a/apps/web/src/lib/graphql-cache/exchange/optimistic.ts
+++ b/apps/web/src/lib/graphql-cache/exchange/optimistic.ts
@@ -39,6 +39,9 @@ type JsonScalar = string | number | boolean | null;
 type ScalarKey<T> = {
   [K in StringKey<T>]-?: Present<T[K]> extends JsonScalar ? K : never;
 }[StringKey<T>];
+type NumberKey<T> = {
+  [K in StringKey<T>]-?: Present<T[K]> extends number ? K : never;
+}[StringKey<T>];
 type ScalarInsertFields<T> = Partial<{
   [K in ScalarKey<T>]: Exclude<T[K], undefined>;
 }>;
@@ -249,13 +252,14 @@ export function update<TItem extends object>(
 }
 
 /**
- * Prepends an entity link inside a selected embedded list item, creating the
- * embedded item from scalar fields when its selector does not exist.
+ * Removes an entity link from a selected embedded list item and decrements
+ * its count only when the link was present.
  */
-export function upsertEmbeddedLink<
+export function removeEmbeddedLink<
   TItem extends object,
   TSelectorField extends ScalarKey<TItem>,
   TLinkField extends NormalizedEntityListKey<TItem>,
+  TCountField extends NumberKey<TItem>,
 >(
   selection: ListSelection<TItem>,
   args: {
@@ -264,6 +268,44 @@ export function upsertEmbeddedLink<
       equals: Present<TItem[TSelectorField]>;
     };
     linkField: TLinkField;
+    countField: TCountField;
+    entity: NormalizedEntityIdentity;
+  }
+): OptimisticUpdate {
+  return {
+    query: stringifyDocument(selection.document),
+    operationName: documentOperationName(selection.document),
+    variablesJson: JSON.stringify(selection.variables ?? {}),
+    path: [...selection.path],
+    operation: {
+      kind: 'removeEmbeddedLink',
+      listItem: args.listItem,
+      linkField: args.linkField,
+      countField: args.countField,
+      entityKey: normalizedEntityKey(args.entity),
+    },
+  } as unknown as OptimisticUpdate;
+}
+
+/**
+ * Prepends an entity link inside a selected embedded list item, creating the
+ * embedded item from scalar fields when its selector does not exist. Its
+ * count is initialized or incremented only when the link is newly inserted.
+ */
+export function upsertEmbeddedLink<
+  TItem extends object,
+  TSelectorField extends ScalarKey<TItem>,
+  TLinkField extends NormalizedEntityListKey<TItem>,
+  TCountField extends NumberKey<TItem>,
+>(
+  selection: ListSelection<TItem>,
+  args: {
+    listItem: {
+      whereField: TSelectorField;
+      equals: Present<TItem[TSelectorField]>;
+    };
+    linkField: TLinkField;
+    countField: TCountField;
     entity: NormalizedEntityIdentity;
     insertFields: ScalarInsertFields<TItem>;
   }
@@ -277,6 +319,7 @@ export function upsertEmbeddedLink<
       kind: 'upsertEmbeddedLink',
       listItem: args.listItem,
       linkField: args.linkField,
+      countField: args.countField,
       entityKey: normalizedEntityKey(args.entity),
       insertFields: args.insertFields,
     },

--- a/apps/web/src/lib/graphql-cache/exchange/optimistic.ts
+++ b/apps/web/src/lib/graphql-cache/exchange/optimistic.ts
@@ -280,7 +280,7 @@ export function upsertEmbeddedLink<
       entityKey: normalizedEntityKey(args.entity),
       insertFields: args.insertFields,
     },
-  } as OptimisticUpdate;
+  } as unknown as OptimisticUpdate;
 }
 
 /**

--- a/apps/web/src/lib/graphql-cache/index.ts
+++ b/apps/web/src/lib/graphql-cache/index.ts
@@ -25,6 +25,7 @@ export {
   type Selection,
   select,
   update,
+  upsertEmbeddedLink,
 } from './exchange/optimistic';
 export {
   type RecordSelection,

--- a/apps/web/src/lib/graphql-cache/index.ts
+++ b/apps/web/src/lib/graphql-cache/index.ts
@@ -22,6 +22,7 @@ export {
   prependUnique,
   type QueryRevalidation,
   remove,
+  removeEmbeddedLink,
   type Selection,
   select,
   update,

--- a/apps/web/src/lib/graphql-cache/protocol.ts
+++ b/apps/web/src/lib/graphql-cache/protocol.ts
@@ -79,12 +79,23 @@ export type OptimisticLinkPatchWire = {
     | { kind: 'remove'; entityKey: string }
     | { kind: 'prependUnique'; entityKey: string }
     | {
+        kind: 'removeEmbeddedLink';
+        listItem: {
+          whereField: string;
+          equals: string | number | boolean | null;
+        };
+        linkField: string;
+        countField: string;
+        entityKey: string;
+      }
+    | {
         kind: 'upsertEmbeddedLink';
         listItem: {
           whereField: string;
           equals: string | number | boolean | null;
         };
         linkField: string;
+        countField: string;
         entityKey: string;
         /** Scalar fields used only when the embedded item must be created. */
         insertFields: Record<string, string | number | boolean | null>;

--- a/apps/web/src/lib/graphql-cache/protocol.ts
+++ b/apps/web/src/lib/graphql-cache/protocol.ts
@@ -87,10 +87,7 @@ export type OptimisticLinkPatchWire = {
         linkField: string;
         entityKey: string;
         /** Scalar fields used only when the embedded item must be created. */
-        insertFields: Record<
-          string,
-          string | number | boolean | null
-        >;
+        insertFields: Record<string, string | number | boolean | null>;
       };
 };
 

--- a/apps/web/src/lib/graphql-cache/protocol.ts
+++ b/apps/web/src/lib/graphql-cache/protocol.ts
@@ -77,7 +77,21 @@ export type OptimisticLinkPatchWire = {
   path: EmbeddedLinkPathSegment[];
   operation:
     | { kind: 'remove'; entityKey: string }
-    | { kind: 'prependUnique'; entityKey: string };
+    | { kind: 'prependUnique'; entityKey: string }
+    | {
+        kind: 'upsertEmbeddedLink';
+        listItem: {
+          whereField: string;
+          equals: string | number | boolean | null;
+        };
+        linkField: string;
+        entityKey: string;
+        /** Scalar fields used only when the embedded item must be created. */
+        insertFields: Record<
+          string,
+          string | number | boolean | null
+        >;
+      };
 };
 
 export type CachedQueryVariantWire = {

--- a/apps/web/src/lib/queries/soup/grouped/graphql-optimistic.test.ts
+++ b/apps/web/src/lib/queries/soup/grouped/graphql-optimistic.test.ts
@@ -156,24 +156,25 @@ describe('buildOptimisticGroupedPropertyUpdates', () => {
 
     expect(result.updates).toHaveLength(2);
     expect(result.updates.map((patch) => patch.operation)).toEqual([
-      { kind: 'remove', entityKey: 'GraphqlSoupDocument:task-1' },
-      { kind: 'prependUnique', entityKey: 'GraphqlSoupDocument:task-1' },
+      {
+        kind: 'removeEmbeddedLink',
+        listItem: { whereField: 'key', equals: 'in-progress' },
+        linkField: 'items',
+        countField: 'totalCount',
+        entityKey: 'GraphqlSoupDocument:task-1',
+      },
+      {
+        kind: 'upsertEmbeddedLink',
+        listItem: { whereField: 'key', equals: 'completed' },
+        linkField: 'items',
+        countField: 'totalCount',
+        entityKey: 'GraphqlSoupDocument:task-1',
+        insertFields: { nextCursor: null },
+      },
     ]);
     expect(result.updates.map((update) => update.path)).toEqual([
-      [
-        { field: 'user' },
-        { field: 'groupSoup' },
-        { field: 'bins' },
-        { listItem: { whereField: 'key', equals: 'in-progress' } },
-        { field: 'items' },
-      ],
-      [
-        { field: 'user' },
-        { field: 'groupSoup' },
-        { field: 'bins' },
-        { listItem: { whereField: 'key', equals: 'completed' } },
-        { field: 'items' },
-      ],
+      [{ field: 'user' }, { field: 'groupSoup' }, { field: 'bins' }],
+      [{ field: 'user' }, { field: 'groupSoup' }, { field: 'bins' }],
     ]);
     expect(result.revalidations).toHaveLength(1);
     expect(onInspect).toHaveBeenCalledWith(
@@ -238,8 +239,14 @@ describe('buildOptimisticGroupedPropertyUpdates', () => {
     });
 
     expect(result.updates.map((patch) => patch.operation)).toEqual([
-      { kind: 'remove', entityKey: 'GraphqlSoupCall:task-1' },
-      { kind: 'prependUnique', entityKey: 'GraphqlSoupCall:task-1' },
+      expect.objectContaining({
+        kind: 'removeEmbeddedLink',
+        entityKey: 'GraphqlSoupCall:task-1',
+      }),
+      expect.objectContaining({
+        kind: 'upsertEmbeddedLink',
+        entityKey: 'GraphqlSoupCall:task-1',
+      }),
     ]);
   });
 
@@ -254,13 +261,20 @@ describe('buildOptimisticGroupedPropertyUpdates', () => {
 
     expect(result.updates).toHaveLength(2);
     expect(result.updates.map((patch) => patch.operation)).toEqual([
-      { kind: 'remove', entityKey: 'GraphqlSoupDocument:task-1' },
+      {
+        kind: 'removeEmbeddedLink',
+        listItem: { whereField: 'key', equals: 'in-progress' },
+        linkField: 'items',
+        countField: 'totalCount',
+        entityKey: 'GraphqlSoupDocument:task-1',
+      },
       {
         kind: 'upsertEmbeddedLink',
         listItem: { whereField: 'key', equals: 'completed' },
         linkField: 'items',
+        countField: 'totalCount',
         entityKey: 'GraphqlSoupDocument:task-1',
-        insertFields: { totalCount: 1, nextCursor: null },
+        insertFields: { nextCursor: null },
       },
     ]);
     expect(result.updates[1]?.path).toEqual([
@@ -296,8 +310,8 @@ describe('buildOptimisticGroupedPropertyUpdates', () => {
       onRead.mock.calls.map(([request]) => request.variables.input)
     ).toEqual([input, continuation]);
     expect(result.updates.map((patch) => patch.operation.kind)).toEqual([
-      'remove',
-      'prependUnique',
+      'removeEmbeddedLink',
+      'upsertEmbeddedLink',
     ]);
   });
 
@@ -311,8 +325,8 @@ describe('buildOptimisticGroupedPropertyUpdates', () => {
     });
 
     expect(result.updates.map((patch) => patch.operation.kind)).toEqual([
-      'remove',
-      'prependUnique',
+      'removeEmbeddedLink',
+      'upsertEmbeddedLink',
     ]);
   });
 
@@ -326,7 +340,14 @@ describe('buildOptimisticGroupedPropertyUpdates', () => {
     });
 
     expect(result.updates.map((patch) => patch.operation)).toEqual([
-      { kind: 'prependUnique', entityKey: 'GraphqlSoupDocument:task-1' },
+      {
+        kind: 'upsertEmbeddedLink',
+        listItem: { whereField: 'key', equals: 'completed' },
+        linkField: 'items',
+        countField: 'totalCount',
+        entityKey: 'GraphqlSoupDocument:task-1',
+        insertFields: { nextCursor: null },
+      },
     ]);
   });
 

--- a/apps/web/src/lib/queries/soup/grouped/graphql-optimistic.test.ts
+++ b/apps/web/src/lib/queries/soup/grouped/graphql-optimistic.test.ts
@@ -243,7 +243,7 @@ describe('buildOptimisticGroupedPropertyUpdates', () => {
     ]);
   });
 
-  it('does not make a partial move when the destination bin is absent', async () => {
+  it('creates a missing destination bin as part of the move', async () => {
     const result = await buildOptimisticGroupedPropertyUpdates({
       host: host({ destination: false }),
       entityId: 'task-1',
@@ -252,7 +252,22 @@ describe('buildOptimisticGroupedPropertyUpdates', () => {
       newGroupKeys: ['completed'],
     });
 
-    expect(result.updates).toEqual([]);
+    expect(result.updates).toHaveLength(2);
+    expect(result.updates.map((patch) => patch.operation)).toEqual([
+      { kind: 'remove', entityKey: 'GraphqlSoupDocument:task-1' },
+      {
+        kind: 'upsertEmbeddedLink',
+        listItem: { whereField: 'key', equals: 'completed' },
+        linkField: 'items',
+        entityKey: 'GraphqlSoupDocument:task-1',
+        insertFields: { totalCount: 1, nextCursor: null },
+      },
+    ]);
+    expect(result.updates[1]?.path).toEqual([
+      { field: 'user' },
+      { field: 'groupSoup' },
+      { field: 'bins' },
+    ]);
     expect(result.revalidations).toHaveLength(1);
   });
 

--- a/apps/web/src/lib/queries/soup/grouped/graphql-optimistic.ts
+++ b/apps/web/src/lib/queries/soup/grouped/graphql-optimistic.ts
@@ -7,6 +7,7 @@ import {
   remove,
   select,
   update,
+  upsertEmbeddedLink,
 } from '@graphql-cache/exchange/optimistic';
 import type { CacheHost } from '@graphql-cache/host/types';
 import { stringifyDocument } from '@urql/core';
@@ -164,13 +165,11 @@ export async function buildOptimisticGroupedPropertyUpdates(
       continue;
     }
 
-    const destinationPages = pages.filter(
-      (page) =>
-        isInitialInput(page.input) &&
-        added.every((key) => page.bins.some((bin) => bin.key === key))
+    const destinationPages = pages.filter((page) =>
+      isInitialInput(page.input)
     );
-    // Never expose a source-only move when this logical view has nowhere to
-    // show the destination. Revalidation will recover absent/new groups.
+    // Never expose a source-only move when this logical view has no initial
+    // page where the destination can be shown.
     if (added.length > 0 && destinationPages.length === 0) continue;
 
     for (const page of sourcePages) {
@@ -190,15 +189,27 @@ export async function buildOptimisticGroupedPropertyUpdates(
     }
     for (const page of destinationPages) {
       for (const key of added) {
-        const items = select(GroupSoupMembershipDocument, {
+        const bins = select(GroupSoupMembershipDocument, {
           input: page.input,
         })
           .field('user')
           .field('groupSoup')
-          .field('bins')
-          .item('key', key)
-          .field('items');
-        updates.push(update(items, prependUnique(entity)));
+          .field('bins');
+        const destination = page.bins.find((bin) => bin.key === key);
+        if (destination) {
+          updates.push(
+            update(bins.item('key', key).field('items'), prependUnique(entity))
+          );
+        } else {
+          updates.push(
+            upsertEmbeddedLink(bins, {
+              listItem: { whereField: 'key', equals: key },
+              linkField: 'items',
+              entity,
+              insertFields: { totalCount: 1, nextCursor: null },
+            })
+          );
+        }
       }
     }
   }

--- a/apps/web/src/lib/queries/soup/grouped/graphql-optimistic.ts
+++ b/apps/web/src/lib/queries/soup/grouped/graphql-optimistic.ts
@@ -2,11 +2,9 @@ import { documentOperationName } from '@graphql-cache/exchange/generated-selecti
 import { inspectVariants, selectAll } from '@graphql-cache/exchange/inspection';
 import {
   type OptimisticUpdate,
-  prependUnique,
   type QueryRevalidation,
-  remove,
+  removeEmbeddedLink,
   select,
-  update,
   upsertEmbeddedLink,
 } from '@graphql-cache/exchange/optimistic';
 import type { CacheHost } from '@graphql-cache/host/types';
@@ -94,7 +92,8 @@ export function groupPagesByLogicalView(
 /**
  * Discovers every cached property-grouped field and creates constrained link
  * recipes only where the loaded membership proves the move is applicable.
- * Missing bins/pages are left untouched and revalidated after success.
+ * Missing destination bins are created on initial pages; missing pages are
+ * left untouched and revalidated after success.
  */
 export async function buildOptimisticGroupedPropertyUpdates(
   args: BuildArgs
@@ -174,15 +173,20 @@ export async function buildOptimisticGroupedPropertyUpdates(
       for (const key of removed) {
         const source = page.bins.find((bin) => bin.key === key);
         if (!source?.items.some((item) => item.id === args.entityId)) continue;
-        const items = select(GroupSoupMembershipDocument, {
+        const bins = select(GroupSoupMembershipDocument, {
           input: page.input,
         })
           .field('user')
           .field('groupSoup')
-          .field('bins')
-          .item('key', key)
-          .field('items');
-        updates.push(update(items, remove(entity)));
+          .field('bins');
+        updates.push(
+          removeEmbeddedLink(bins, {
+            listItem: { whereField: 'key', equals: key },
+            linkField: 'items',
+            countField: 'totalCount',
+            entity,
+          })
+        );
       }
     }
     for (const page of destinationPages) {
@@ -193,21 +197,15 @@ export async function buildOptimisticGroupedPropertyUpdates(
           .field('user')
           .field('groupSoup')
           .field('bins');
-        const destination = page.bins.find((bin) => bin.key === key);
-        if (destination) {
-          updates.push(
-            update(bins.item('key', key).field('items'), prependUnique(entity))
-          );
-        } else {
-          updates.push(
-            upsertEmbeddedLink(bins, {
-              listItem: { whereField: 'key', equals: key },
-              linkField: 'items',
-              entity,
-              insertFields: { totalCount: 1, nextCursor: null },
-            })
-          );
-        }
+        updates.push(
+          upsertEmbeddedLink(bins, {
+            listItem: { whereField: 'key', equals: key },
+            linkField: 'items',
+            countField: 'totalCount',
+            entity,
+            insertFields: { nextCursor: null },
+          })
+        );
       }
     }
   }

--- a/apps/web/src/lib/queries/soup/grouped/graphql-optimistic.ts
+++ b/apps/web/src/lib/queries/soup/grouped/graphql-optimistic.ts
@@ -165,9 +165,7 @@ export async function buildOptimisticGroupedPropertyUpdates(
       continue;
     }
 
-    const destinationPages = pages.filter((page) =>
-      isInitialInput(page.input)
-    );
+    const destinationPages = pages.filter((page) => isInitialInput(page.input));
     // Never expose a source-only move when this logical view has no initial
     // page where the destination can be shown.
     if (added.length > 0 && destinationPages.length === 0) continue;

--- a/crates/client/cache-core/src/engine.rs
+++ b/crates/client/cache-core/src/engine.rs
@@ -1120,7 +1120,7 @@ impl<S: Storage> Engine<S> {
         keys: &BTreeSet<EntityKey<'static>>,
     ) -> Result<HashMap<EntityKey<'static>, Record>, EngineError<S::Error>> {
         let mut out = HashMap::new();
-        let mut missing: Vec<EntityKey<'static>> = Vec::new();
+        let mut missing = Vec::new();
         for key in keys {
             match self.hot.peek(key) {
                 Some(record) => {
@@ -1166,7 +1166,7 @@ impl<S: Storage> Engine<S> {
             match resolve_owner(&effective, &operation, &inspection.path)? {
                 OwnerResolution::Owner(owner) => break recover_variants(&owner, &prepared)?,
                 OwnerResolution::Absent => return Ok(Vec::new()),
-                OwnerResolution::NeedRecord(key) if !candidates.contains(key.as_ref()) => {
+                OwnerResolution::NeedRecord(key) if !candidates.contains(&key) => {
                     candidates.insert(key.into_owned());
                 }
                 OwnerResolution::NeedRecord(_) => return Ok(Vec::new()),

--- a/crates/client/cache-core/src/link_patch.rs
+++ b/crates/client/cache-core/src/link_patch.rs
@@ -68,8 +68,24 @@ pub enum LinkOperation {
         #[serde(rename = "entityKey")]
         entity_key: EntityKey<'static>,
     },
+    /// Removes a link from a matching embedded list item and decrements its
+    /// count when the link was present.
+    RemoveEmbeddedLink {
+        /// Scalar selector identifying the embedded list item.
+        #[serde(rename = "listItem")]
+        list_item: ListItemByScalar,
+        /// Field on the embedded item containing normalized links.
+        #[serde(rename = "linkField")]
+        link_field: FieldKey,
+        /// Non-negative integer field tracking the complete link count.
+        #[serde(rename = "countField")]
+        count_field: FieldKey,
+        /// Normalized entity key to remove from the link field.
+        #[serde(rename = "entityKey")]
+        entity_key: EntityKey<'static>,
+    },
     /// Prepends a link inside a matching embedded list item, creating that
-    /// embedded item when it is absent.
+    /// embedded item when it is absent, and increments its link count.
     UpsertEmbeddedLink {
         /// Scalar selector identifying the embedded list item.
         #[serde(rename = "listItem")]
@@ -77,6 +93,9 @@ pub enum LinkOperation {
         /// Field on the embedded item containing normalized links.
         #[serde(rename = "linkField")]
         link_field: FieldKey,
+        /// Non-negative integer field tracking the complete link count.
+        #[serde(rename = "countField")]
+        count_field: FieldKey,
         /// Normalized entity key to prepend to the link field.
         #[serde(rename = "entityKey")]
         entity_key: EntityKey<'static>,
@@ -91,6 +110,7 @@ impl LinkOperation {
         match self {
             Self::Remove { entity_key }
             | Self::PrependUnique { entity_key }
+            | Self::RemoveEmbeddedLink { entity_key, .. }
             | Self::UpsertEmbeddedLink { entity_key, .. } => entity_key.borrow(),
         }
     }
@@ -176,6 +196,12 @@ pub enum LinkPatchError {
     /// The final list contains values other than normalized refs or nulls.
     #[error("link patch target list contains non-link values")]
     NonLinkTarget,
+    /// An embedded link count was absent or not a non-negative integer.
+    #[error("embedded link count must be a non-negative integer")]
+    InvalidLinkCount,
+    /// Incrementing an embedded link count exceeded the stored integer range.
+    #[error("embedded link count overflow")]
+    LinkCountOverflow,
     /// Too many scalar fields were supplied for an embedded item insertion.
     #[error("embedded insert field count {actual} exceeds limit {maximum}")]
     TooManyInsertFields { actual: usize, maximum: usize },
@@ -223,33 +249,54 @@ fn validate_recipe(patch: &OptimisticLinkPatch) -> Result<(), LinkPatchError> {
             return Err(LinkPatchError::NonScalarSelector);
         }
     }
-    if let LinkOperation::UpsertEmbeddedLink {
-        list_item,
-        link_field,
-        insert_fields,
-        ..
-    } = &patch.operation
-    {
-        if !is_json_scalar(&list_item.equals) {
-            return Err(LinkPatchError::NonScalarSelector);
+    match &patch.operation {
+        LinkOperation::RemoveEmbeddedLink {
+            list_item,
+            link_field,
+            count_field,
+            ..
+        } => validate_embedded_link_fields(list_item, link_field, count_field)?,
+        LinkOperation::UpsertEmbeddedLink {
+            list_item,
+            link_field,
+            count_field,
+            insert_fields,
+            ..
+        } => {
+            validate_embedded_link_fields(list_item, link_field, count_field)?;
+            if insert_fields.len() > MAX_INSERT_FIELDS {
+                return Err(LinkPatchError::TooManyInsertFields {
+                    actual: insert_fields.len(),
+                    maximum: MAX_INSERT_FIELDS,
+                });
+            }
+            for managed in [&list_item.where_field, link_field, count_field] {
+                if insert_fields.contains_key(managed) {
+                    return Err(LinkPatchError::ConflictingInsertField(managed.clone()));
+                }
+            }
+            if insert_fields.values().any(|value| !is_json_scalar(value)) {
+                return Err(LinkPatchError::NonScalarInsertField);
+            }
         }
-        if insert_fields.len() > MAX_INSERT_FIELDS {
-            return Err(LinkPatchError::TooManyInsertFields {
-                actual: insert_fields.len(),
-                maximum: MAX_INSERT_FIELDS,
-            });
-        }
-        if insert_fields.contains_key(&list_item.where_field) {
-            return Err(LinkPatchError::ConflictingInsertField(
-                list_item.where_field.clone(),
-            ));
-        }
-        if insert_fields.contains_key(link_field) || list_item.where_field == *link_field {
-            return Err(LinkPatchError::ConflictingInsertField(link_field.clone()));
-        }
-        if insert_fields.values().any(|value| !is_json_scalar(value)) {
-            return Err(LinkPatchError::NonScalarInsertField);
-        }
+        LinkOperation::Remove { .. } | LinkOperation::PrependUnique { .. } => {}
+    }
+    Ok(())
+}
+
+fn validate_embedded_link_fields(
+    list_item: &ListItemByScalar,
+    link_field: &FieldKey,
+    count_field: &FieldKey,
+) -> Result<(), LinkPatchError> {
+    if !is_json_scalar(&list_item.equals) {
+        return Err(LinkPatchError::NonScalarSelector);
+    }
+    if list_item.where_field == *link_field {
+        return Err(LinkPatchError::ConflictingInsertField(link_field.clone()));
+    }
+    if list_item.where_field == *count_field || link_field == count_field {
+        return Err(LinkPatchError::ConflictingInsertField(count_field.clone()));
     }
     Ok(())
 }
@@ -356,6 +403,19 @@ fn apply_one(
         LinkOperation::PrependUnique { entity_key } => {
             prepend_unique(normalized_links(target)?, entity_key.borrow());
         }
+        LinkOperation::RemoveEmbeddedLink { entity_key, .. } => {
+            let fields = resolved
+                .embedded_link
+                .as_ref()
+                .ok_or(LinkPatchError::WrongShape)?;
+            remove_embedded_link(
+                target,
+                &fields.list_item,
+                &fields.link_field,
+                &fields.count_field,
+                entity_key.borrow(),
+            )?;
+        }
         LinkOperation::UpsertEmbeddedLink { entity_key, .. } => {
             let fields = resolved
                 .embedded_link
@@ -365,6 +425,7 @@ fn apply_one(
                 target,
                 &fields.list_item,
                 &fields.link_field,
+                &fields.count_field,
                 entity_key.borrow(),
                 &fields.insert_fields,
             )?;
@@ -408,13 +469,81 @@ fn prepend_unique(links: &mut Vec<CacheValue>, entity_key: EntityKey<'_>) {
     links.insert(0, CacheValue::Ref(entity_key.into_owned()));
 }
 
+fn remove_embedded_link(
+    value: &mut CacheValue,
+    list_item: &ListItemByScalar,
+    link_field: &FieldKey,
+    count_field: &FieldKey,
+    entity_key: EntityKey<'_>,
+) -> Result<(), LinkPatchError> {
+    let items = embedded_items(value)?;
+    let index =
+        embedded_item_index(items, list_item)?.ok_or(LinkPatchError::SelectorMatchCount(0))?;
+    let CacheValue::Object(object) = &mut items[index] else {
+        return Err(LinkPatchError::WrongShape);
+    };
+    let links = object
+        .get_mut(link_field)
+        .ok_or(LinkPatchError::WrongShape)?;
+    let links = normalized_links(links)?;
+    let was_present = contains_link(links, &entity_key);
+    links.retain(
+        |value| !matches!(value, CacheValue::Ref(key) if key.as_ref() == entity_key.as_ref()),
+    );
+    if was_present {
+        adjust_link_count(object, count_field, CountAdjustment::Decrement)?;
+    }
+    Ok(())
+}
+
 fn upsert_embedded_link(
     value: &mut CacheValue,
     list_item: &ListItemByScalar,
     link_field: &FieldKey,
+    count_field: &FieldKey,
     entity_key: EntityKey<'_>,
     insert_fields: &HashMap<FieldKey, Json>,
 ) -> Result<(), LinkPatchError> {
+    let items = embedded_items(value)?;
+    match embedded_item_index(items, list_item)? {
+        Some(index) => {
+            let CacheValue::Object(object) = &mut items[index] else {
+                return Err(LinkPatchError::WrongShape);
+            };
+            let links = object
+                .get_mut(link_field)
+                .ok_or(LinkPatchError::WrongShape)?;
+            let links = normalized_links(links)?;
+            let was_present = contains_link(links, &entity_key);
+            prepend_unique(links, entity_key);
+            if !was_present {
+                adjust_link_count(object, count_field, CountAdjustment::Increment)?;
+            }
+        }
+        None => {
+            let mut object = insert_fields
+                .iter()
+                .map(|(field, value)| Ok((field.clone(), cache_scalar(value)?)))
+                .collect::<Result<std::collections::BTreeMap<_, _>, LinkPatchError>>()?;
+            object.insert(
+                list_item.where_field.clone(),
+                cache_scalar(&list_item.equals)?,
+            );
+            object.insert(
+                count_field.clone(),
+                CacheValue::Number(CacheNumber::PosInt(1)),
+            );
+            object.insert(
+                link_field.clone(),
+                CacheValue::List(vec![CacheValue::Ref(entity_key.into_owned())]),
+            );
+            items.insert(0, CacheValue::Object(object));
+        }
+    }
+    Ok(())
+}
+
+fn embedded_items(value: &mut CacheValue) -> Result<&mut Vec<CacheValue>, LinkPatchError> {
     let CacheValue::List(items) = value else {
         return Err(LinkPatchError::WrongShape);
     };
@@ -430,7 +559,13 @@ fn upsert_embedded_link(
     {
         return Err(LinkPatchError::WrongShape);
     }
+    Ok(items)
+}
 
+fn embedded_item_index(
+    items: &[CacheValue],
+    list_item: &ListItemByScalar,
+) -> Result<Option<usize>, LinkPatchError> {
     let matches: Vec<_> = items
         .iter()
         .enumerate()
@@ -444,34 +579,39 @@ fn upsert_embedded_link(
                 .then_some(index)
         })
         .collect();
-
     match matches.as_slice() {
-        [index] => {
-            let CacheValue::Object(object) = &mut items[*index] else {
-                return Err(LinkPatchError::WrongShape);
-            };
-            let links = object
-                .get_mut(link_field)
-                .ok_or(LinkPatchError::WrongShape)?;
-            prepend_unique(normalized_links(links)?, entity_key);
-        }
-        [] => {
-            let mut object = insert_fields
-                .iter()
-                .map(|(field, value)| Ok((field.clone(), cache_scalar(value)?)))
-                .collect::<Result<std::collections::BTreeMap<_, _>, LinkPatchError>>()?;
-            object.insert(
-                list_item.where_field.clone(),
-                cache_scalar(&list_item.equals)?,
-            );
-            object.insert(
-                link_field.clone(),
-                CacheValue::List(vec![CacheValue::Ref(entity_key.into_owned())]),
-            );
-            items.insert(0, CacheValue::Object(object));
-        }
-        _ => return Err(LinkPatchError::SelectorMatchCount(matches.len())),
+        [] => Ok(None),
+        [index] => Ok(Some(*index)),
+        _ => Err(LinkPatchError::SelectorMatchCount(matches.len())),
     }
+}
+
+fn contains_link(links: &[CacheValue], entity_key: &EntityKey<'_>) -> bool {
+    links
+        .iter()
+        .any(|value| matches!(value, CacheValue::Ref(key) if key.as_ref() == entity_key.as_ref()))
+}
+
+#[derive(Clone, Copy)]
+enum CountAdjustment {
+    Increment,
+    Decrement,
+}
+
+fn adjust_link_count(
+    object: &mut std::collections::BTreeMap<FieldKey, CacheValue>,
+    count_field: &FieldKey,
+    adjustment: CountAdjustment,
+) -> Result<(), LinkPatchError> {
+    let Some(CacheValue::Number(CacheNumber::PosInt(count))) = object.get_mut(count_field) else {
+        return Err(LinkPatchError::InvalidLinkCount);
+    };
+    *count = match adjustment {
+        CountAdjustment::Increment => count
+            .checked_add(1)
+            .ok_or(LinkPatchError::LinkCountOverflow)?,
+        CountAdjustment::Decrement => count.saturating_sub(1),
+    };
     Ok(())
 }
 
@@ -497,6 +637,7 @@ struct ResolvedTarget {
 struct ResolvedEmbeddedLink {
     list_item: ListItemByScalar,
     link_field: FieldKey,
+    count_field: FieldKey,
     insert_fields: HashMap<FieldKey, Json>,
 }
 
@@ -715,14 +856,21 @@ fn resolve_embedded_link_fields(
     variables: &serde_json::Map<String, Json>,
     operation: &LinkOperation,
 ) -> Result<Option<ResolvedEmbeddedLink>, LinkPatchError> {
-    let LinkOperation::UpsertEmbeddedLink {
-        list_item,
-        link_field,
-        insert_fields,
-        ..
-    } = operation
-    else {
-        return Ok(None);
+    let (list_item, link_field, count_field, insert_fields) = match operation {
+        LinkOperation::RemoveEmbeddedLink {
+            list_item,
+            link_field,
+            count_field,
+            ..
+        } => (list_item, link_field, count_field, None),
+        LinkOperation::UpsertEmbeddedLink {
+            list_item,
+            link_field,
+            count_field,
+            insert_fields,
+            ..
+        } => (list_item, link_field, count_field, Some(insert_fields)),
+        LinkOperation::Remove { .. } | LinkOperation::PrependUnique { .. } => return Ok(None),
     };
 
     let selector_key = selected_storage_key(
@@ -731,8 +879,13 @@ fn resolve_embedded_link_fields(
     )?;
     let resolved_link_field =
         selected_storage_key(selected_field(selections, concrete, link_field)?, variables)?;
+    let resolved_count_field = selected_storage_key(
+        selected_field(selections, concrete, count_field)?,
+        variables,
+    )?;
     let resolved_insert_fields = insert_fields
-        .iter()
+        .into_iter()
+        .flat_map(|fields| fields.iter())
         .map(|(field, value)| {
             Ok((
                 selected_storage_key(selected_field(selections, concrete, field)?, variables)?,
@@ -741,13 +894,16 @@ fn resolve_embedded_link_fields(
         })
         .collect::<Result<HashMap<_, _>, LinkPatchError>>()?;
 
-    if resolved_insert_fields.contains_key(&selector_key) {
-        return Err(LinkPatchError::ConflictingInsertField(selector_key));
+    for managed in [&selector_key, &resolved_link_field, &resolved_count_field] {
+        if resolved_insert_fields.contains_key(managed) {
+            return Err(LinkPatchError::ConflictingInsertField(managed.clone()));
+        }
     }
-    if resolved_insert_fields.contains_key(&resolved_link_field)
-        || selector_key == resolved_link_field
+    if selector_key == resolved_link_field
+        || selector_key == resolved_count_field
+        || resolved_link_field == resolved_count_field
     {
-        return Err(LinkPatchError::ConflictingInsertField(resolved_link_field));
+        return Err(LinkPatchError::ConflictingInsertField(resolved_count_field));
     }
 
     Ok(Some(ResolvedEmbeddedLink {
@@ -756,6 +912,7 @@ fn resolve_embedded_link_fields(
             equals: list_item.equals.clone(),
         },
         link_field: resolved_link_field,
+        count_field: resolved_count_field,
         insert_fields: resolved_insert_fields,
     }))
 }
@@ -860,9 +1017,14 @@ mod tests {
 
     fn record() -> (EntityKey<'static>, Record) {
         let parent = EntityKey("GraphqlUser:user-1".into());
-        let bin = |key: &str, items: Vec<CacheValue>| {
+        let bin = |key: &str, total_count: u64, items: Vec<CacheValue>| {
             CacheValue::Object(BTreeMap::from([
                 ("key".into(), CacheValue::String(key.into())),
+                (
+                    "totalCount".into(),
+                    CacheValue::Number(CacheNumber::PosInt(total_count)),
+                ),
+                ("nextCursor".into(), CacheValue::Null),
                 ("items".into(), CacheValue::List(items)),
             ]))
         };
@@ -871,12 +1033,13 @@ mod tests {
             CacheValue::List(vec![
                 bin(
                     "in-progress",
+                    1,
                     vec![
                         CacheValue::Ref(EntityKey("GraphqlSoupItem:task-1".into())),
                         CacheValue::Ref(EntityKey("GraphqlSoupItem:task-1".into())),
                     ],
                 ),
-                bin("completed", vec![]),
+                bin("completed", 0, vec![]),
             ]),
         )]));
         let record = Record {
@@ -936,11 +1099,37 @@ mod tests {
                     equals: json!(bin),
                 },
                 link_field: "items".into(),
+                count_field: "totalCount".into(),
                 entity_key: EntityKey("GraphqlSoupItem:task-1".into()),
-                insert_fields: HashMap::from([
-                    ("totalCount".into(), json!(1)),
-                    ("nextCursor".into(), Json::Null),
-                ]),
+                insert_fields: HashMap::from([("nextCursor".into(), Json::Null)]),
+            },
+        }
+    }
+
+    fn remove_bin_patch(bin: &str) -> OptimisticLinkPatch {
+        OptimisticLinkPatch {
+            query: QUERY.into(),
+            operation_name: None,
+            variables_json: "{}".into(),
+            path: vec![
+                LinkPathSegment::Field {
+                    field: "user".into(),
+                },
+                LinkPathSegment::Field {
+                    field: "groupSoup".into(),
+                },
+                LinkPathSegment::Field {
+                    field: "bins".into(),
+                },
+            ],
+            operation: LinkOperation::RemoveEmbeddedLink {
+                list_item: ListItemByScalar {
+                    where_field: "key".into(),
+                    equals: json!(bin),
+                },
+                link_field: "items".into(),
+                count_field: "totalCount".into(),
+                entity_key: EntityKey("GraphqlSoupItem:task-1".into()),
             },
         }
     }
@@ -1004,7 +1193,7 @@ mod tests {
     }
 
     #[test]
-    fn upsert_embedded_link_creates_a_missing_item_and_reuses_it() {
+    fn embedded_link_changes_create_bins_and_adjust_counts_once() {
         let (parent, initial) = record();
         let mut effective = HashMap::from([
             (
@@ -1016,16 +1205,35 @@ mod tests {
             (parent.clone(), initial),
         ]);
         let mut updates = RecordUpdates::new();
-        let patch = upsert_bin_patch("urgent");
-
-        apply_link_patches(&mut effective, &mut updates, &[patch.clone(), patch], false).unwrap();
+        let urgent = upsert_bin_patch("urgent");
         apply_link_patches(
             &mut effective,
             &mut updates,
-            &[upsert_bin_patch("completed")],
+            &[urgent.clone(), urgent.clone()],
             false,
         )
         .unwrap();
+        apply_link_patches(&mut effective, &mut updates, &[urgent], false).unwrap();
+
+        let completed = upsert_bin_patch("completed");
+        apply_link_patches(
+            &mut effective,
+            &mut updates,
+            std::slice::from_ref(&completed),
+            false,
+        )
+        .unwrap();
+        apply_link_patches(&mut effective, &mut updates, &[completed], false).unwrap();
+
+        let source = remove_bin_patch("in-progress");
+        apply_link_patches(
+            &mut effective,
+            &mut updates,
+            std::slice::from_ref(&source),
+            false,
+        )
+        .unwrap();
+        apply_link_patches(&mut effective, &mut updates, &[source], false).unwrap();
 
         let CacheValue::Object(grouped) = &effective[&parent].fields["groupSoup"] else {
             panic!()
@@ -1048,9 +1256,21 @@ mod tests {
                 "GraphqlSoupItem:task-1".into()
             ))])
         );
+        let CacheValue::Object(source) = &bins[1] else {
+            panic!()
+        };
+        assert_eq!(
+            source["totalCount"],
+            CacheValue::Number(CacheNumber::PosInt(0))
+        );
+        assert_eq!(source["items"], CacheValue::List(vec![]));
         let CacheValue::Object(completed) = &bins[2] else {
             panic!()
         };
+        assert_eq!(
+            completed["totalCount"],
+            CacheValue::Number(CacheNumber::PosInt(1))
+        );
         assert_eq!(
             completed["items"],
             CacheValue::List(vec![CacheValue::Ref(EntityKey(

--- a/crates/client/cache-core/src/link_patch.rs
+++ b/crates/client/cache-core/src/link_patch.rs
@@ -205,9 +205,12 @@ pub enum LinkPatchError {
     /// Too many scalar fields were supplied for an embedded item insertion.
     #[error("embedded insert field count {actual} exceeds limit {maximum}")]
     TooManyInsertFields { actual: usize, maximum: usize },
-    /// An embedded item insertion field conflicts with a selector or link field.
+    /// An embedded item insertion field conflicts with a managed field.
     #[error("embedded insert field `{0}` conflicts with a managed field")]
     ConflictingInsertField(String),
+    /// Two managed embedded-item fields resolve to the same storage key.
+    #[error("embedded managed fields `{first}` and `{second}` conflict")]
+    ConflictingManagedField { first: String, second: String },
     /// Embedded item insertion values must be JSON scalars.
     #[error("embedded insert field values must be JSON scalars")]
     NonScalarInsertField,
@@ -293,10 +296,22 @@ fn validate_embedded_link_fields(
         return Err(LinkPatchError::NonScalarSelector);
     }
     if list_item.where_field == *link_field {
-        return Err(LinkPatchError::ConflictingInsertField(link_field.clone()));
+        return Err(LinkPatchError::ConflictingManagedField {
+            first: list_item.where_field.clone(),
+            second: link_field.clone(),
+        });
     }
-    if list_item.where_field == *count_field || link_field == count_field {
-        return Err(LinkPatchError::ConflictingInsertField(count_field.clone()));
+    if list_item.where_field == *count_field {
+        return Err(LinkPatchError::ConflictingManagedField {
+            first: list_item.where_field.clone(),
+            second: count_field.clone(),
+        });
+    }
+    if link_field == count_field {
+        return Err(LinkPatchError::ConflictingManagedField {
+            first: link_field.clone(),
+            second: count_field.clone(),
+        });
     }
     Ok(())
 }
@@ -883,27 +898,40 @@ fn resolve_embedded_link_fields(
         selected_field(selections, concrete, count_field)?,
         variables,
     )?;
-    let resolved_insert_fields = insert_fields
-        .into_iter()
-        .flat_map(|fields| fields.iter())
-        .map(|(field, value)| {
-            Ok((
-                selected_storage_key(selected_field(selections, concrete, field)?, variables)?,
-                value.clone(),
-            ))
-        })
-        .collect::<Result<HashMap<_, _>, LinkPatchError>>()?;
+    let mut resolved_insert_fields = HashMap::new();
+    if let Some(insert_fields) = insert_fields {
+        for (field, value) in insert_fields {
+            let storage_key =
+                selected_storage_key(selected_field(selections, concrete, field)?, variables)?;
+            if resolved_insert_fields.contains_key(&storage_key) {
+                return Err(LinkPatchError::ConflictingInsertField(storage_key));
+            }
+            resolved_insert_fields.insert(storage_key, value.clone());
+        }
+    }
 
     for managed in [&selector_key, &resolved_link_field, &resolved_count_field] {
         if resolved_insert_fields.contains_key(managed) {
             return Err(LinkPatchError::ConflictingInsertField(managed.clone()));
         }
     }
-    if selector_key == resolved_link_field
-        || selector_key == resolved_count_field
-        || resolved_link_field == resolved_count_field
-    {
-        return Err(LinkPatchError::ConflictingInsertField(resolved_count_field));
+    if selector_key == resolved_link_field {
+        return Err(LinkPatchError::ConflictingManagedField {
+            first: selector_key,
+            second: resolved_link_field,
+        });
+    }
+    if selector_key == resolved_count_field {
+        return Err(LinkPatchError::ConflictingManagedField {
+            first: selector_key,
+            second: resolved_count_field,
+        });
+    }
+    if resolved_link_field == resolved_count_field {
+        return Err(LinkPatchError::ConflictingManagedField {
+            first: resolved_link_field,
+            second: resolved_count_field,
+        });
     }
 
     Ok(Some(ResolvedEmbeddedLink {
@@ -1132,6 +1160,82 @@ mod tests {
                 entity_key: EntityKey("GraphqlSoupItem:task-1".into()),
             },
         }
+    }
+
+    #[test]
+    fn rejects_conflicting_embedded_managed_fields() {
+        let mut direct_conflict = upsert_bin_patch("urgent");
+        let LinkOperation::UpsertEmbeddedLink { link_field, .. } = &mut direct_conflict.operation
+        else {
+            panic!()
+        };
+        *link_field = "key".into();
+        assert_eq!(
+            deduplicate_patches(&[direct_conflict]).unwrap_err(),
+            LinkPatchError::ConflictingManagedField {
+                first: "key".into(),
+                second: "key".into(),
+            }
+        );
+
+        let (parent, initial) = record();
+        let effective = HashMap::from([
+            (
+                EntityKey::root(),
+                Record {
+                    fields: BTreeMap::from([("user".into(), CacheValue::Ref(parent.clone()))]),
+                },
+            ),
+            (parent, initial),
+        ]);
+        let mut resolved_conflict = upsert_bin_patch("urgent");
+        resolved_conflict.query = "query { user { groupSoup { bins { selector: key link: key totalCount nextCursor items { id } } } } }".into();
+        let LinkOperation::UpsertEmbeddedLink {
+            list_item,
+            link_field,
+            ..
+        } = &mut resolved_conflict.operation
+        else {
+            panic!()
+        };
+        list_item.where_field = "selector".into();
+        *link_field = "link".into();
+        assert_eq!(
+            resolve_target(&effective, &resolved_conflict).unwrap_err(),
+            LinkPatchError::ConflictingManagedField {
+                first: "key".into(),
+                second: "key".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_insert_fields_resolving_to_the_same_storage_key() {
+        let (parent, initial) = record();
+        let effective = HashMap::from([
+            (
+                EntityKey::root(),
+                Record {
+                    fields: BTreeMap::from([("user".into(), CacheValue::Ref(parent.clone()))]),
+                },
+            ),
+            (parent, initial),
+        ]);
+        let mut duplicate = upsert_bin_patch("urgent");
+        duplicate.query = "query { user { groupSoup { bins { key totalCount firstCursor: nextCursor secondCursor: nextCursor items { id } } } } }".into();
+        let LinkOperation::UpsertEmbeddedLink { insert_fields, .. } = &mut duplicate.operation
+        else {
+            panic!()
+        };
+        *insert_fields = HashMap::from([
+            ("firstCursor".into(), Json::Null),
+            ("secondCursor".into(), Json::Null),
+        ]);
+
+        assert_eq!(
+            resolve_target(&effective, &duplicate).unwrap_err(),
+            LinkPatchError::ConflictingInsertField("nextCursor".into())
+        );
     }
 
     #[test]

--- a/crates/client/cache-core/src/link_patch.rs
+++ b/crates/client/cache-core/src/link_patch.rs
@@ -1019,6 +1019,13 @@ mod tests {
         let patch = upsert_bin_patch("urgent");
 
         apply_link_patches(&mut effective, &mut updates, &[patch.clone(), patch], false).unwrap();
+        apply_link_patches(
+            &mut effective,
+            &mut updates,
+            &[upsert_bin_patch("completed")],
+            false,
+        )
+        .unwrap();
 
         let CacheValue::Object(grouped) = &effective[&parent].fields["groupSoup"] else {
             panic!()
@@ -1037,6 +1044,15 @@ mod tests {
         assert_eq!(urgent["nextCursor"], CacheValue::Null);
         assert_eq!(
             urgent["items"],
+            CacheValue::List(vec![CacheValue::Ref(EntityKey(
+                "GraphqlSoupItem:task-1".into()
+            ))])
+        );
+        let CacheValue::Object(completed) = &bins[2] else {
+            panic!()
+        };
+        assert_eq!(
+            completed["items"],
             CacheValue::List(vec![CacheValue::Ref(EntityKey(
                 "GraphqlSoupItem:task-1".into()
             ))])

--- a/crates/client/cache-core/src/link_patch.rs
+++ b/crates/client/cache-core/src/link_patch.rs
@@ -356,18 +356,19 @@ fn apply_one(
         LinkOperation::PrependUnique { entity_key } => {
             prepend_unique(normalized_links(target)?, entity_key.borrow());
         }
-        LinkOperation::UpsertEmbeddedLink {
-            list_item,
-            link_field,
-            entity_key,
-            insert_fields,
-        } => upsert_embedded_link(
-            target,
-            list_item,
-            link_field,
-            entity_key.borrow(),
-            insert_fields,
-        )?,
+        LinkOperation::UpsertEmbeddedLink { entity_key, .. } => {
+            let fields = resolved
+                .embedded_link
+                .as_ref()
+                .ok_or(LinkPatchError::WrongShape)?;
+            upsert_embedded_link(
+                target,
+                &fields.list_item,
+                &fields.link_field,
+                entity_key.borrow(),
+                &fields.insert_fields,
+            )?;
+        }
     }
 
     record
@@ -489,6 +490,14 @@ struct ResolvedTarget {
     parent_entity_key: EntityKey<'static>,
     field_key: FieldKey,
     path: Vec<LinkPathSegment>,
+    embedded_link: Option<ResolvedEmbeddedLink>,
+}
+
+#[derive(Debug)]
+struct ResolvedEmbeddedLink {
+    list_item: ListItemByScalar,
+    link_field: FieldKey,
+    insert_fields: HashMap<FieldKey, Json>,
 }
 
 /// Returns the next normalized record required to resolve one query-rooted
@@ -521,6 +530,7 @@ fn resolve_target(
         &operation.selection_set,
         &variables,
         &patch.path,
+        &patch.operation,
     )
 }
 
@@ -531,6 +541,7 @@ fn resolve_from_record(
     selections: &[Selection],
     variables: &serde_json::Map<String, Json>,
     path: &[LinkPathSegment],
+    operation: &LinkOperation,
 ) -> Result<ResolvedTarget, LinkPatchError> {
     let Some(LinkPathSegment::Field {
         field: response_key,
@@ -564,6 +575,7 @@ fn resolve_from_record(
             selections: &selected.selection_set,
         },
         &path[1..],
+        operation,
     )
 }
 
@@ -581,12 +593,19 @@ fn resolve_from_value(
     variables: &serde_json::Map<String, Json>,
     cursor: ValueCursor<'_>,
     path: &[LinkPathSegment],
+    operation: &LinkOperation,
 ) -> Result<ResolvedTarget, LinkPatchError> {
     if path.is_empty() {
         return Ok(ResolvedTarget {
             parent_entity_key: cursor.owner,
             field_key: cursor.anchor_field,
             path: cursor.relative_path,
+            embedded_link: resolve_embedded_link_fields(
+                cursor.selections,
+                cursor.type_name,
+                variables,
+                operation,
+            )?,
         });
     }
 
@@ -598,6 +617,7 @@ fn resolve_from_value(
             cursor.selections,
             variables,
             path,
+            operation,
         );
     }
 
@@ -634,6 +654,7 @@ fn resolve_from_value(
                     selections: &selected.selection_set,
                 },
                 &path[1..],
+                operation,
             )
         }
         (LinkPathSegment::ListItem { list_item }, CacheValue::List(items)) => {
@@ -681,10 +702,62 @@ fn resolve_from_value(
                     selections: cursor.selections,
                 },
                 &path[1..],
+                operation,
             )
         }
         _ => Err(LinkPatchError::WrongShape),
     }
+}
+
+fn resolve_embedded_link_fields(
+    selections: &[Selection],
+    concrete: &str,
+    variables: &serde_json::Map<String, Json>,
+    operation: &LinkOperation,
+) -> Result<Option<ResolvedEmbeddedLink>, LinkPatchError> {
+    let LinkOperation::UpsertEmbeddedLink {
+        list_item,
+        link_field,
+        insert_fields,
+        ..
+    } = operation
+    else {
+        return Ok(None);
+    };
+
+    let selector_key = selected_storage_key(
+        selected_field(selections, concrete, &list_item.where_field)?,
+        variables,
+    )?;
+    let resolved_link_field =
+        selected_storage_key(selected_field(selections, concrete, link_field)?, variables)?;
+    let resolved_insert_fields = insert_fields
+        .iter()
+        .map(|(field, value)| {
+            Ok((
+                selected_storage_key(selected_field(selections, concrete, field)?, variables)?,
+                value.clone(),
+            ))
+        })
+        .collect::<Result<HashMap<_, _>, LinkPatchError>>()?;
+
+    if resolved_insert_fields.contains_key(&selector_key) {
+        return Err(LinkPatchError::ConflictingInsertField(selector_key));
+    }
+    if resolved_insert_fields.contains_key(&resolved_link_field)
+        || selector_key == resolved_link_field
+    {
+        return Err(LinkPatchError::ConflictingInsertField(resolved_link_field));
+    }
+
+    Ok(Some(ResolvedEmbeddedLink {
+        list_item: ListItemByScalar {
+            where_field: selector_key,
+            equals: list_item.equals.clone(),
+        },
+        link_field: resolved_link_field,
+        insert_fields: resolved_insert_fields,
+    }))
 }
 
 fn selected_field<'a>(
@@ -782,7 +855,8 @@ mod tests {
     use serde_json::json;
     use std::collections::BTreeMap;
 
-    const QUERY: &str = "query { user { groupSoup { bins { key items { id } } } } }";
+    const QUERY: &str =
+        "query { user { groupSoup { bins { key totalCount nextCursor items { id } } } } }";
 
     fn record() -> (EntityKey<'static>, Record) {
         let parent = EntityKey("GraphqlUser:user-1".into());

--- a/crates/client/cache-core/src/link_patch.rs
+++ b/crates/client/cache-core/src/link_patch.rs
@@ -111,7 +111,7 @@ impl LinkOperation {
             Self::Remove { entity_key }
             | Self::PrependUnique { entity_key }
             | Self::RemoveEmbeddedLink { entity_key, .. }
-            | Self::UpsertEmbeddedLink { entity_key, .. } => entity_key.borrow(),
+            | Self::UpsertEmbeddedLink { entity_key, .. } => entity_key.borrowed(),
         }
     }
 }
@@ -416,7 +416,7 @@ fn apply_one(
             );
         }
         LinkOperation::PrependUnique { entity_key } => {
-            prepend_unique(normalized_links(target)?, entity_key.borrow());
+            prepend_unique(normalized_links(target)?, entity_key.borrowed());
         }
         LinkOperation::RemoveEmbeddedLink { entity_key, .. } => {
             let fields = resolved
@@ -428,7 +428,7 @@ fn apply_one(
                 &fields.list_item,
                 &fields.link_field,
                 &fields.count_field,
-                entity_key.borrow(),
+                entity_key.borrowed(),
             )?;
         }
         LinkOperation::UpsertEmbeddedLink { entity_key, .. } => {
@@ -441,7 +441,7 @@ fn apply_one(
                 &fields.list_item,
                 &fields.link_field,
                 &fields.count_field,
-                entity_key.borrow(),
+                entity_key.borrowed(),
                 &fields.insert_fields,
             )?;
         }

--- a/crates/client/cache-core/src/link_patch.rs
+++ b/crates/client/cache-core/src/link_patch.rs
@@ -22,6 +22,8 @@ pub const MAX_PATCHES: usize = 128;
 pub const MAX_PATH_DEPTH: usize = 16;
 /// Maximum list length traversed by one recipe.
 pub const MAX_TRAVERSED_LIST: usize = 10_000;
+/// Maximum scalar fields used to initialize one embedded list item.
+pub const MAX_INSERT_FIELDS: usize = 16;
 
 /// One constrained step through an embedded cache value.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -51,7 +53,7 @@ pub struct ListItemByScalar {
 }
 
 /// Idempotent operation on the selected normalized-link list.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "camelCase")]
 pub enum LinkOperation {
     /// Removes every occurrence of the entity reference.
@@ -66,12 +68,30 @@ pub enum LinkOperation {
         #[serde(rename = "entityKey")]
         entity_key: EntityKey<'static>,
     },
+    /// Prepends a link inside a matching embedded list item, creating that
+    /// embedded item when it is absent.
+    UpsertEmbeddedLink {
+        /// Scalar selector identifying the embedded list item.
+        #[serde(rename = "listItem")]
+        list_item: ListItemByScalar,
+        /// Field on the embedded item containing normalized links.
+        #[serde(rename = "linkField")]
+        link_field: FieldKey,
+        /// Normalized entity key to prepend to the link field.
+        #[serde(rename = "entityKey")]
+        entity_key: EntityKey<'static>,
+        /// Additional scalar fields used only when creating the embedded item.
+        #[serde(rename = "insertFields")]
+        insert_fields: HashMap<FieldKey, Json>,
+    },
 }
 
 impl LinkOperation {
     fn entity_key(&self) -> EntityKey<'_> {
         match self {
-            Self::Remove { entity_key } | Self::PrependUnique { entity_key } => entity_key.borrow(),
+            Self::Remove { entity_key }
+            | Self::PrependUnique { entity_key }
+            | Self::UpsertEmbeddedLink { entity_key, .. } => entity_key.borrow(),
         }
     }
 }
@@ -156,6 +176,15 @@ pub enum LinkPatchError {
     /// The final list contains values other than normalized refs or nulls.
     #[error("link patch target list contains non-link values")]
     NonLinkTarget,
+    /// Too many scalar fields were supplied for an embedded item insertion.
+    #[error("embedded insert field count {actual} exceeds limit {maximum}")]
+    TooManyInsertFields { actual: usize, maximum: usize },
+    /// An embedded item insertion field conflicts with a selector or link field.
+    #[error("embedded insert field `{0}` conflicts with a managed field")]
+    ConflictingInsertField(String),
+    /// Embedded item insertion values must be JSON scalars.
+    #[error("embedded insert field values must be JSON scalars")]
+    NonScalarInsertField,
 }
 
 /// Removes exact duplicate recipes while retaining the first occurrence and
@@ -192,6 +221,34 @@ fn validate_recipe(patch: &OptimisticLinkPatch) -> Result<(), LinkPatchError> {
             && !is_json_scalar(&list_item.equals)
         {
             return Err(LinkPatchError::NonScalarSelector);
+        }
+    }
+    if let LinkOperation::UpsertEmbeddedLink {
+        list_item,
+        link_field,
+        insert_fields,
+        ..
+    } = &patch.operation
+    {
+        if !is_json_scalar(&list_item.equals) {
+            return Err(LinkPatchError::NonScalarSelector);
+        }
+        if insert_fields.len() > MAX_INSERT_FIELDS {
+            return Err(LinkPatchError::TooManyInsertFields {
+                actual: insert_fields.len(),
+                maximum: MAX_INSERT_FIELDS,
+            });
+        }
+        if insert_fields.contains_key(&list_item.where_field) {
+            return Err(LinkPatchError::ConflictingInsertField(
+                list_item.where_field.clone(),
+            ));
+        }
+        if insert_fields.contains_key(link_field) || list_item.where_field == *link_field {
+            return Err(LinkPatchError::ConflictingInsertField(link_field.clone()));
+        }
+        if insert_fields.values().any(|value| !is_json_scalar(value)) {
+            return Err(LinkPatchError::NonScalarInsertField);
         }
     }
     Ok(())
@@ -289,7 +346,43 @@ fn apply_one(
             field: resolved.field_key.clone(),
         })?;
     let target = traverse(&mut field_value, &resolved.path)?;
-    let CacheValue::List(links) = target else {
+    match &patch.operation {
+        LinkOperation::Remove { entity_key } => {
+            let links = normalized_links(target)?;
+            links.retain(
+                |value| !matches!(value, CacheValue::Ref(key) if key.as_ref() == entity_key.as_ref()),
+            );
+        }
+        LinkOperation::PrependUnique { entity_key } => {
+            prepend_unique(normalized_links(target)?, entity_key.borrow());
+        }
+        LinkOperation::UpsertEmbeddedLink {
+            list_item,
+            link_field,
+            entity_key,
+            insert_fields,
+        } => upsert_embedded_link(
+            target,
+            list_item,
+            link_field,
+            entity_key.borrow(),
+            insert_fields,
+        )?,
+    }
+
+    record
+        .fields
+        .insert(resolved.field_key.clone(), field_value.clone());
+    updates
+        .entry(resolved.parent_entity_key)
+        .or_default()
+        .fields
+        .insert(resolved.field_key, field_value);
+    Ok(())
+}
+
+fn normalized_links(value: &mut CacheValue) -> Result<&mut Vec<CacheValue>, LinkPatchError> {
+    let CacheValue::List(links) = value else {
         return Err(LinkPatchError::WrongShape);
     };
     if links.len() > MAX_TRAVERSED_LIST {
@@ -304,24 +397,91 @@ fn apply_one(
     {
         return Err(LinkPatchError::NonLinkTarget);
     }
+    Ok(links)
+}
 
-    let entity_key = patch.operation.entity_key();
+fn prepend_unique(links: &mut Vec<CacheValue>, entity_key: EntityKey<'_>) {
     links.retain(
-        |value| !matches!(value, CacheValue::Ref(key) if key.0.as_ref() == entity_key.0.as_ref()),
+        |value| !matches!(value, CacheValue::Ref(key) if key.as_ref() == entity_key.as_ref()),
     );
-    if matches!(patch.operation, LinkOperation::PrependUnique { .. }) {
-        links.insert(0, CacheValue::Ref(entity_key.into_owned()));
+    links.insert(0, CacheValue::Ref(entity_key.into_owned()));
+}
+
+fn upsert_embedded_link(
+    value: &mut CacheValue,
+    list_item: &ListItemByScalar,
+    link_field: &FieldKey,
+    entity_key: EntityKey<'_>,
+    insert_fields: &HashMap<FieldKey, Json>,
+) -> Result<(), LinkPatchError> {
+    let CacheValue::List(items) = value else {
+        return Err(LinkPatchError::WrongShape);
+    };
+    if items.len() > MAX_TRAVERSED_LIST {
+        return Err(LinkPatchError::ListTooLarge {
+            actual: items.len(),
+            maximum: MAX_TRAVERSED_LIST,
+        });
+    }
+    if items
+        .iter()
+        .any(|value| !matches!(value, CacheValue::Object(_)))
+    {
+        return Err(LinkPatchError::WrongShape);
     }
 
-    record
-        .fields
-        .insert(resolved.field_key.clone(), field_value.clone());
-    updates
-        .entry(resolved.parent_entity_key)
-        .or_default()
-        .fields
-        .insert(resolved.field_key, field_value);
+    let matches: Vec<_> = items
+        .iter()
+        .enumerate()
+        .filter_map(|(index, value)| {
+            let CacheValue::Object(object) = value else {
+                return None;
+            };
+            object
+                .get(&list_item.where_field)
+                .is_some_and(|value| cache_scalar_equals(value, &list_item.equals))
+                .then_some(index)
+        })
+        .collect();
+
+    match matches.as_slice() {
+        [index] => {
+            let CacheValue::Object(object) = &mut items[*index] else {
+                return Err(LinkPatchError::WrongShape);
+            };
+            let links = object
+                .get_mut(link_field)
+                .ok_or(LinkPatchError::WrongShape)?;
+            prepend_unique(normalized_links(links)?, entity_key);
+        }
+        [] => {
+            let mut object = insert_fields
+                .iter()
+                .map(|(field, value)| Ok((field.clone(), cache_scalar(value)?)))
+                .collect::<Result<std::collections::BTreeMap<_, _>, LinkPatchError>>()?;
+            object.insert(
+                list_item.where_field.clone(),
+                cache_scalar(&list_item.equals)?,
+            );
+            object.insert(
+                link_field.clone(),
+                CacheValue::List(vec![CacheValue::Ref(entity_key.into_owned())]),
+            );
+            items.insert(0, CacheValue::Object(object));
+        }
+        _ => return Err(LinkPatchError::SelectorMatchCount(matches.len())),
+    }
     Ok(())
+}
+
+fn cache_scalar(value: &Json) -> Result<CacheValue, LinkPatchError> {
+    match value {
+        Json::Null => Ok(CacheValue::Null),
+        Json::Bool(value) => Ok(CacheValue::Bool(*value)),
+        Json::Number(value) => Ok(CacheValue::Number(value.into())),
+        Json::String(value) => Ok(CacheValue::String(value.clone())),
+        Json::Array(_) | Json::Object(_) => Err(LinkPatchError::NonScalarInsertField),
+    }
 }
 
 #[derive(Debug)]
@@ -680,6 +840,37 @@ mod tests {
         }
     }
 
+    fn upsert_bin_patch(bin: &str) -> OptimisticLinkPatch {
+        OptimisticLinkPatch {
+            query: QUERY.into(),
+            operation_name: None,
+            variables_json: "{}".into(),
+            path: vec![
+                LinkPathSegment::Field {
+                    field: "user".into(),
+                },
+                LinkPathSegment::Field {
+                    field: "groupSoup".into(),
+                },
+                LinkPathSegment::Field {
+                    field: "bins".into(),
+                },
+            ],
+            operation: LinkOperation::UpsertEmbeddedLink {
+                list_item: ListItemByScalar {
+                    where_field: "key".into(),
+                    equals: json!(bin),
+                },
+                link_field: "items".into(),
+                entity_key: EntityKey("GraphqlSoupItem:task-1".into()),
+                insert_fields: HashMap::from([
+                    ("totalCount".into(), json!(1)),
+                    ("nextCursor".into(), Json::Null),
+                ]),
+            },
+        }
+    }
+
     #[test]
     fn remove_and_prepend_compose_without_touching_unrelated_values() {
         let (parent, initial) = record();
@@ -731,6 +922,47 @@ mod tests {
         };
         assert_eq!(
             destination["items"],
+            CacheValue::List(vec![CacheValue::Ref(EntityKey(
+                "GraphqlSoupItem:task-1".into()
+            ))])
+        );
+        assert_eq!(updates.len(), 1);
+    }
+
+    #[test]
+    fn upsert_embedded_link_creates_a_missing_item_and_reuses_it() {
+        let (parent, initial) = record();
+        let mut effective = HashMap::from([
+            (
+                EntityKey::root(),
+                Record {
+                    fields: BTreeMap::from([("user".into(), CacheValue::Ref(parent.clone()))]),
+                },
+            ),
+            (parent.clone(), initial),
+        ]);
+        let mut updates = RecordUpdates::new();
+        let patch = upsert_bin_patch("urgent");
+
+        apply_link_patches(&mut effective, &mut updates, &[patch.clone(), patch], false).unwrap();
+
+        let CacheValue::Object(grouped) = &effective[&parent].fields["groupSoup"] else {
+            panic!()
+        };
+        let CacheValue::List(bins) = &grouped["bins"] else {
+            panic!()
+        };
+        let CacheValue::Object(urgent) = &bins[0] else {
+            panic!()
+        };
+        assert_eq!(urgent["key"], CacheValue::String("urgent".into()));
+        assert_eq!(
+            urgent["totalCount"],
+            CacheValue::Number(CacheNumber::PosInt(1))
+        );
+        assert_eq!(urgent["nextCursor"], CacheValue::Null);
+        assert_eq!(
+            urgent["items"],
             CacheValue::List(vec![CacheValue::Ref(EntityKey(
                 "GraphqlSoupItem:task-1".into()
             ))])

--- a/crates/client/cache-core/src/query_inspection.rs
+++ b/crates/client/cache-core/src/query_inspection.rs
@@ -203,7 +203,7 @@ fn resolve_record_owner<'records, 'selection>(
     selections: &'selection [Selection],
     path: &[String],
 ) -> Result<OwnerResolution<'records, 'selection>, QueryInspectionError> {
-    let Some(record) = records.get(key.as_ref()) else {
+    let Some(record) = records.get(&key) else {
         return Ok(OwnerResolution::NeedRecord(key));
     };
     let concrete = record.typename().unwrap_or(declared_type);
@@ -238,7 +238,7 @@ fn resolve_fields_owner<'records, 'selection>(
     match value {
         CacheValue::Ref(key) => resolve_record_owner(
             records,
-            key.borrow(),
+            key.borrowed(),
             next_type,
             &field.selection_set,
             &path[1..],

--- a/crates/client/cache-core/src/store.rs
+++ b/crates/client/cache-core/src/store.rs
@@ -23,7 +23,7 @@ pub trait Storage: MaybeSend {
     /// Fetches records; result is aligned with `keys` (`None` = absent).
     fn get_batch(
         &self,
-        keys: &[EntityKey<'static>],
+        keys: &[EntityKey<'_>],
     ) -> impl Future<Output = Result<Vec<Option<Record>>, Self::Error>> + MaybeSend;
 
     /// Upserts records atomically (all-or-nothing per batch).
@@ -129,10 +129,7 @@ impl InMemoryStorage {
 impl Storage for InMemoryStorage {
     type Error = Infallible;
 
-    async fn get_batch(
-        &self,
-        keys: &[EntityKey<'static>],
-    ) -> Result<Vec<Option<Record>>, Self::Error> {
+    async fn get_batch(&self, keys: &[EntityKey<'_>]) -> Result<Vec<Option<Record>>, Self::Error> {
         Ok(keys.iter().map(|k| self.records.get(k).cloned()).collect())
     }
 

--- a/crates/client/cache-core/src/value.rs
+++ b/crates/client/cache-core/src/value.rs
@@ -2,7 +2,7 @@
 //! values.
 
 use serde::{Deserialize, Serialize};
-use std::borrow::{Borrow, Cow};
+use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::fmt;
 
@@ -36,19 +36,13 @@ impl<'a> EntityKey<'a> {
         self.0 == ROOT_QUERY
     }
 
-    pub fn borrow(&self) -> EntityKey<'_> {
+    pub fn borrowed(&self) -> EntityKey<'_> {
         EntityKey(Cow::Borrowed(self.0.as_ref()))
     }
 
     /// Converts this key into an owned key that can be stored independently.
     pub fn into_owned(self) -> EntityKey<'static> {
         EntityKey(Cow::Owned(self.0.into_owned()))
-    }
-}
-
-impl Borrow<str> for EntityKey<'_> {
-    fn borrow(&self) -> &str {
-        self.0.as_ref()
     }
 }
 

--- a/crates/client/cache-core/tests/grouped_optimistic.rs
+++ b/crates/client/cache-core/tests/grouped_optimistic.rs
@@ -122,6 +122,15 @@ fn mutation_response(option: &str) -> Json {
     json!({ "setEntityProperty": property(option) })
 }
 
+fn group_page_without_destination() -> Json {
+    let mut page = group_page();
+    page["user"]["groupSoup"]["bins"]
+        .as_array_mut()
+        .unwrap()
+        .truncate(1);
+    page
+}
+
 fn patch(bin: &str, operation: LinkOperation) -> OptimisticLinkPatch {
     OptimisticLinkPatch {
         query: GROUP_QUERY.into(),
@@ -151,6 +160,37 @@ fn patch(bin: &str, operation: LinkOperation) -> OptimisticLinkPatch {
     }
 }
 
+fn upsert_bin_patch(bin: &str) -> OptimisticLinkPatch {
+    OptimisticLinkPatch {
+        query: GROUP_QUERY.into(),
+        operation_name: Some("GroupSoup".into()),
+        variables_json: serde_json::to_string(&query_variables()).unwrap(),
+        path: vec![
+            LinkPathSegment::Field {
+                field: "user".into(),
+            },
+            LinkPathSegment::Field {
+                field: "groupSoup".into(),
+            },
+            LinkPathSegment::Field {
+                field: "bins".into(),
+            },
+        ],
+        operation: LinkOperation::UpsertEmbeddedLink {
+            list_item: ListItemByScalar {
+                where_field: "key".into(),
+                equals: json!(bin),
+            },
+            link_field: "items".into(),
+            entity_key: EntityKey("GraphqlSoupDocument:task-1".into()),
+            insert_fields: std::collections::HashMap::from([
+                ("totalCount".into(), json!(1)),
+                ("nextCursor".into(), Json::Null),
+            ]),
+        },
+    }
+}
+
 async fn read_group(engine: &mut Engine<InMemoryStorage>) -> Json {
     match engine
         .read_query(None, GROUP_QUERY, Some("GroupSoup"), &query_variables())
@@ -163,6 +203,10 @@ async fn read_group(engine: &mut Engine<InMemoryStorage>) -> Json {
 }
 
 async fn setup() -> Engine<InMemoryStorage> {
+    setup_with_page(group_page()).await
+}
+
+async fn setup_with_page(page: Json) -> Engine<InMemoryStorage> {
     let mut engine = Engine::new(InMemoryStorage::new());
     engine
         .write_query(
@@ -170,7 +214,7 @@ async fn setup() -> Engine<InMemoryStorage> {
             GROUP_QUERY,
             Some("GroupSoup"),
             &query_variables(),
-            &group_page(),
+            &page,
             None,
         )
         .await
@@ -349,6 +393,50 @@ fn success_reapplies_recipe_and_returns_deduplicated_revalidation() {
             committed["user"]["groupSoup"]["bins"][1]["items"][1]["id"],
             json!("task-2")
         );
+    });
+}
+
+#[test]
+fn missing_destination_is_created_with_the_updated_item() {
+    block_on(async {
+        let mut engine = setup_with_page(group_page_without_destination()).await;
+        let patches = [
+            patch(
+                "in-progress",
+                LinkOperation::Remove {
+                    entity_key: EntityKey("GraphqlSoupDocument:task-1".into()),
+                },
+            ),
+            upsert_bin_patch("completed"),
+        ];
+        engine
+            .begin_optimistic_write(
+                None,
+                BeginOptimisticWrite {
+                    query: MUTATION,
+                    operation_name: Some("SetEntityProperty"),
+                    variables: &mutation_variables("completed"),
+                    data: &mutation_response("completed"),
+                    link_patches: &patches,
+                    revalidations: &[],
+                    created_at_ms: 0,
+                },
+            )
+            .await
+            .unwrap();
+
+        let optimistic = read_group(&mut engine).await;
+        let bins = optimistic["user"]["groupSoup"]["bins"].as_array().unwrap();
+        assert_eq!(bins.len(), 2);
+        assert_eq!(bins[0]["key"], json!("completed"));
+        assert_eq!(bins[0]["totalCount"], json!(1));
+        assert_eq!(bins[0]["nextCursor"], Json::Null);
+        assert_eq!(bins[0]["items"][0]["id"], json!("task-1"));
+        assert_eq!(
+            bins[0]["items"][0]["properties"][0]["value"]["optionIds"],
+            json!(["completed"])
+        );
+        assert!(bins[1]["items"].as_array().unwrap().is_empty());
     });
 }
 

--- a/crates/client/cache-core/tests/grouped_optimistic.rs
+++ b/crates/client/cache-core/tests/grouped_optimistic.rs
@@ -39,6 +39,22 @@ query GroupSoup($input: GroupedSoupInput!) {
 }
 "#;
 
+const GROUP_MEMBERSHIP_QUERY: &str = r#"
+query GroupSoupMembership($input: GroupedSoupInput!) {
+  user {
+    id
+    groupSoup(input: $input) {
+      bins {
+        key
+        totalCount
+        nextCursor
+        items { __typename id }
+      }
+    }
+  }
+}
+"#;
+
 const MUTATION: &str = r#"
 mutation SetEntityProperty($input: SetEntityPropertyInput!) {
   setEntityProperty(input: $input) {
@@ -133,8 +149,8 @@ fn group_page_without_destination() -> Json {
 
 fn patch(bin: &str, operation: LinkOperation) -> OptimisticLinkPatch {
     OptimisticLinkPatch {
-        query: GROUP_QUERY.into(),
-        operation_name: Some("GroupSoup".into()),
+        query: GROUP_MEMBERSHIP_QUERY.into(),
+        operation_name: Some("GroupSoupMembership".into()),
         variables_json: serde_json::to_string(&query_variables()).unwrap(),
         path: vec![
             LinkPathSegment::Field {
@@ -162,8 +178,8 @@ fn patch(bin: &str, operation: LinkOperation) -> OptimisticLinkPatch {
 
 fn upsert_bin_patch(bin: &str) -> OptimisticLinkPatch {
     OptimisticLinkPatch {
-        query: GROUP_QUERY.into(),
-        operation_name: Some("GroupSoup".into()),
+        query: GROUP_MEMBERSHIP_QUERY.into(),
+        operation_name: Some("GroupSoupMembership".into()),
         variables_json: serde_json::to_string(&query_variables()).unwrap(),
         path: vec![
             LinkPathSegment::Field {

--- a/crates/client/cache-core/tests/grouped_optimistic.rs
+++ b/crates/client/cache-core/tests/grouped_optimistic.rs
@@ -176,6 +176,34 @@ fn patch(bin: &str, operation: LinkOperation) -> OptimisticLinkPatch {
     }
 }
 
+fn remove_bin_patch(bin: &str) -> OptimisticLinkPatch {
+    OptimisticLinkPatch {
+        query: GROUP_MEMBERSHIP_QUERY.into(),
+        operation_name: Some("GroupSoupMembership".into()),
+        variables_json: serde_json::to_string(&query_variables()).unwrap(),
+        path: vec![
+            LinkPathSegment::Field {
+                field: "user".into(),
+            },
+            LinkPathSegment::Field {
+                field: "groupSoup".into(),
+            },
+            LinkPathSegment::Field {
+                field: "bins".into(),
+            },
+        ],
+        operation: LinkOperation::RemoveEmbeddedLink {
+            list_item: ListItemByScalar {
+                where_field: "key".into(),
+                equals: json!(bin),
+            },
+            link_field: "items".into(),
+            count_field: "totalCount".into(),
+            entity_key: EntityKey("GraphqlSoupDocument:task-1".into()),
+        },
+    }
+}
+
 fn upsert_bin_patch(bin: &str) -> OptimisticLinkPatch {
     OptimisticLinkPatch {
         query: GROUP_MEMBERSHIP_QUERY.into(),
@@ -198,11 +226,9 @@ fn upsert_bin_patch(bin: &str) -> OptimisticLinkPatch {
                 equals: json!(bin),
             },
             link_field: "items".into(),
+            count_field: "totalCount".into(),
             entity_key: EntityKey("GraphqlSoupDocument:task-1".into()),
-            insert_fields: std::collections::HashMap::from([
-                ("totalCount".into(), json!(1)),
-                ("nextCursor".into(), Json::Null),
-            ]),
+            insert_fields: std::collections::HashMap::from([("nextCursor".into(), Json::Null)]),
         },
     }
 }
@@ -260,18 +286,8 @@ fn cache_only_read_observes_move_and_rollback_restores_it() {
     block_on(async {
         let mut engine = setup().await;
         let patches = [
-            patch(
-                "in-progress",
-                LinkOperation::Remove {
-                    entity_key: EntityKey("GraphqlSoupDocument:task-1".into()),
-                },
-            ),
-            patch(
-                "completed",
-                LinkOperation::PrependUnique {
-                    entity_key: EntityKey("GraphqlSoupDocument:task-1".into()),
-                },
-            ),
+            remove_bin_patch("in-progress"),
+            upsert_bin_patch("completed"),
         ];
         let (transaction, _) = engine
             .begin_optimistic_write(
@@ -293,9 +309,9 @@ fn cache_only_read_observes_move_and_rollback_restores_it() {
         let bins = optimistic["user"]["groupSoup"]["bins"].as_array().unwrap();
         assert!(bins[0]["items"].as_array().unwrap().is_empty());
         assert_eq!(bins[1]["items"][0]["id"], json!("task-1"));
-        // Server-owned pagination metadata is deliberately untouched.
-        assert_eq!(bins[0]["totalCount"], json!(1));
-        assert_eq!(bins[1]["totalCount"], json!(0));
+        assert_eq!(bins[0]["totalCount"], json!(0));
+        assert_eq!(bins[1]["totalCount"], json!(1));
+        // Server-owned pagination cursors are deliberately untouched.
         assert_eq!(bins[1]["nextCursor"], json!("destination-cursor"));
 
         // Durable recipes reconstruct the complete property + relation layer
@@ -311,6 +327,14 @@ fn cache_only_read_observes_move_and_rollback_restores_it() {
         assert_eq!(
             hydrated["user"]["groupSoup"]["bins"][1]["items"][0]["id"],
             json!("task-1")
+        );
+        assert_eq!(
+            hydrated["user"]["groupSoup"]["bins"][0]["totalCount"],
+            json!(0)
+        );
+        assert_eq!(
+            hydrated["user"]["groupSoup"]["bins"][1]["totalCount"],
+            json!(1)
         );
 
         let claim = claim(&mut engine, transaction).await;
@@ -329,6 +353,14 @@ fn cache_only_read_observes_move_and_rollback_restores_it() {
                 .unwrap()
                 .is_empty()
         );
+        assert_eq!(
+            restored["user"]["groupSoup"]["bins"][0]["totalCount"],
+            json!(1)
+        );
+        assert_eq!(
+            restored["user"]["groupSoup"]["bins"][1]["totalCount"],
+            json!(0)
+        );
     });
 }
 
@@ -337,18 +369,8 @@ fn success_reapplies_recipe_and_returns_deduplicated_revalidation() {
     block_on(async {
         let mut engine = setup().await;
         let patches = [
-            patch(
-                "in-progress",
-                LinkOperation::Remove {
-                    entity_key: EntityKey("GraphqlSoupDocument:task-1".into()),
-                },
-            ),
-            patch(
-                "completed",
-                LinkOperation::PrependUnique {
-                    entity_key: EntityKey("GraphqlSoupDocument:task-1".into()),
-                },
-            ),
+            remove_bin_patch("in-progress"),
+            upsert_bin_patch("completed"),
         ];
         let (transaction, _) = engine
             .begin_optimistic_write(
@@ -375,6 +397,7 @@ fn success_reapplies_recipe_and_returns_deduplicated_revalidation() {
             "id": "task-2",
             "properties": []
         }]);
+        concurrent["user"]["groupSoup"]["bins"][1]["totalCount"] = json!(1);
         engine
             .write_query(
                 None,
@@ -409,6 +432,14 @@ fn success_reapplies_recipe_and_returns_deduplicated_revalidation() {
             committed["user"]["groupSoup"]["bins"][1]["items"][1]["id"],
             json!("task-2")
         );
+        assert_eq!(
+            committed["user"]["groupSoup"]["bins"][0]["totalCount"],
+            json!(0)
+        );
+        assert_eq!(
+            committed["user"]["groupSoup"]["bins"][1]["totalCount"],
+            json!(2)
+        );
     });
 }
 
@@ -417,15 +448,10 @@ fn missing_destination_is_created_with_the_updated_item() {
     block_on(async {
         let mut engine = setup_with_page(group_page_without_destination()).await;
         let patches = [
-            patch(
-                "in-progress",
-                LinkOperation::Remove {
-                    entity_key: EntityKey("GraphqlSoupDocument:task-1".into()),
-                },
-            ),
+            remove_bin_patch("in-progress"),
             upsert_bin_patch("completed"),
         ];
-        engine
+        let (transaction, _) = engine
             .begin_optimistic_write(
                 None,
                 BeginOptimisticWrite {
@@ -453,6 +479,33 @@ fn missing_destination_is_created_with_the_updated_item() {
             json!(["completed"])
         );
         assert!(bins[1]["items"].as_array().unwrap().is_empty());
+        assert_eq!(bins[1]["totalCount"], json!(0));
+
+        let claim = claim(&mut engine, transaction).await;
+        engine
+            .commit_optimistic_write(
+                transaction,
+                claim,
+                MUTATION,
+                Some("SetEntityProperty"),
+                &mutation_variables("completed"),
+                &mutation_response("completed"),
+            )
+            .await
+            .unwrap();
+        let committed = read_group(&mut engine).await;
+        assert_eq!(
+            committed["user"]["groupSoup"]["bins"][0]["items"][0]["id"],
+            json!("task-1")
+        );
+        assert_eq!(
+            committed["user"]["groupSoup"]["bins"][0]["totalCount"],
+            json!(1)
+        );
+        assert_eq!(
+            committed["user"]["groupSoup"]["bins"][1]["totalCount"],
+            json!(0)
+        );
     });
 }
 

--- a/crates/client/cache-core/tests/optimistic.rs
+++ b/crates/client/cache-core/tests/optimistic.rs
@@ -71,10 +71,7 @@ impl ClaimFailingStorage {
 impl Storage for ClaimFailingStorage {
     type Error = std::io::Error;
 
-    async fn get_batch(
-        &self,
-        keys: &[EntityKey<'static>],
-    ) -> Result<Vec<Option<Record>>, Self::Error> {
+    async fn get_batch(&self, keys: &[EntityKey<'_>]) -> Result<Vec<Option<Record>>, Self::Error> {
         Ok(self.inner.get_batch(keys).await.unwrap())
     }
 

--- a/crates/client/cache-core/tests/query_inspection.rs
+++ b/crates/client/cache-core/tests/query_inspection.rs
@@ -88,10 +88,7 @@ struct OwnerOnlyStorage(InMemoryStorage);
 impl Storage for OwnerOnlyStorage {
     type Error = std::convert::Infallible;
 
-    async fn get_batch(
-        &self,
-        keys: &[EntityKey<'static>],
-    ) -> Result<Vec<Option<Record>>, Self::Error> {
+    async fn get_batch(&self, keys: &[EntityKey<'_>]) -> Result<Vec<Option<Record>>, Self::Error> {
         assert!(
             keys.iter()
                 .all(|key| key.is_root() || key.0 == "GraphqlUser:user-1"),

--- a/crates/client/cache-idb/src/idb_storage.rs
+++ b/crates/client/cache-idb/src/idb_storage.rs
@@ -109,10 +109,10 @@ impl IdbStorage {
         // upgraded (delete/upgrade requests block while connections are
         // open); without this, `destroy` from another tab can hang forever.
         db.on_version_change(|event: web_sys::Event| {
-            if let Some(target) = event.target() {
-                if let Ok(db) = wasm_bindgen::JsCast::dyn_into::<web_sys::IdbDatabase>(target) {
-                    db.close();
-                }
+            if let Some(target) = event.target()
+                && let Ok(db) = wasm_bindgen::JsCast::dyn_into::<web_sys::IdbDatabase>(target)
+            {
+                db.close();
             }
         });
         let mut storage = IdbStorage { db };
@@ -190,10 +190,7 @@ impl IdbStorage {
 impl Storage for IdbStorage {
     type Error = IdbStorageError;
 
-    async fn get_batch(
-        &self,
-        keys: &[EntityKey<'static>],
-    ) -> Result<Vec<Option<Record>>, Self::Error> {
+    async fn get_batch(&self, keys: &[EntityKey<'_>]) -> Result<Vec<Option<Record>>, Self::Error> {
         let tx = self
             .db
             .transaction(&[RECORDS_STORE], TransactionMode::ReadOnly)?;

--- a/crates/client/cache-sqlite/src/lib.rs
+++ b/crates/client/cache-sqlite/src/lib.rs
@@ -224,10 +224,7 @@ fn claim_is_current(
 impl Storage for SqliteStorage {
     type Error = SqliteStorageError;
 
-    async fn get_batch(
-        &self,
-        keys: &[EntityKey<'static>],
-    ) -> Result<Vec<Option<Record>>, Self::Error> {
+    async fn get_batch(&self, keys: &[EntityKey<'_>]) -> Result<Vec<Option<Record>>, Self::Error> {
         let conn = self.conn();
         let mut stmt = conn.prepare_cached("SELECT value FROM records WHERE key = ?1")?;
         let mut out = Vec::with_capacity(keys.len());


### PR DESCRIPTION
This PR adds a new cache core message which allows upserting links (edges) between entities for optimitic update purposes. This allows callers to correct optimitically add new links, changing the relationship between nodes before the server response returns.

Initially this is used in group soup to re-create bins which might no longer exist, then place objects into those bins