### PR TITLE
fix(soup): use google source kind in calendar frecency test

### DIFF
--- a/crates/soup/src/outbound/pg_soup_repo/calendar_event/test.rs
+++ b/crates/soup/src/outbound/pg_soup_repo/calendar_event/test.rs
@@ -31,7 +31,7 @@ async fn frecency_fallback_keeps_calendar_events_with_aggregates(
         )
         VALUES (
             $1, $2, $3, 'calendar-frecency@example.com', 'Frecency event',
-            now(), now() + interval '1 hour', 'email_ics', now()
+            now(), now() + interval '1 hour', 'google', now()
         )
         "#,
         event_id,


### PR DESCRIPTION
## What

One-word test fix: `'email_ics'` → `'google'` in
`crates/soup/src/outbound/pg_soup_repo/calendar_event/test.rs`.

## Why

#5483 added `20260806202039_drop_email_ics_calendar_sources.up.sql`, which
tightened the constraint to:

```sql
ADD CONSTRAINT calendar_events_canonical_source_kind_check
    CHECK (canonical_source_kind = 'google');
```

but left this test inserting `'email_ics'`. Because CI builds the PR *merge*
commit, **every PR targeting main now fails**:

```
FAIL soup::outbound::pg_soup_repo::calendar_event::test::frecency_fallback_keeps_calendar_events_with_aggregates
Error: new row for relation "calendar_events" violates check constraint
       "calendar_events_canonical_source_kind_check"
```

That fails `test` → `Cloud Storage Status Check`, a required check, so main is
currently unmergeable for everyone.

## Why this fix is safe

The source kind is incidental to what the test covers (frecency fallback keeps
calendar events that have aggregates). `'google'` is now the only permitted
value, and nothing else in the test depends on the old one:

- `calendar_events.source_link_id` still `REFERENCES email_links(id)` — the
  `email_links` insert is untouched by #5483
- `calendar_events_time_shape` is satisfied (`starts_at`/`ends_at` set, dates null)

No `.sqlx` regeneration needed: the offline `check` job runs
`cargo clippy --workspace --all-features` without `--all-targets`/`--tests`, so
test-only queries never compile offline, and the `test` job compiles against
live Postgres.

cc @gbirman — flagging since this came from #5483.