### PR TITLE
feat(reminders): edit an existing reminder's description and time

### DIFF
--- a/apps/web/src/components/app/Layout.tsx
+++ b/apps/web/src/components/app/Layout.tsx
@@ -25,7 +25,7 @@ import {
 import { MacroMcpSetupModal } from '@app/features/integrations/mcp-setup/MacroMcpSetupModal';
 import { Paywall } from '@app/features/paywall/Paywall';
 import { PropertyEditorModal } from '@app/features/property/editor/PropertyEditorModal';
-import { CreateReminderModal } from '@app/features/reminders/CreateReminderModal';
+import { ReminderComposerModal } from '@app/features/reminders/ReminderComposerModal';
 import { useOnboardingV4Flag } from '@app/features/setup/flow/useOnboardingV4Flag';
 import { GlobalShareModal } from '@app/features/sharing/global-share-modal/GlobalShareModal';
 import { IosShareSheet } from '@app/features/sharing/ios-share-sheet/IosShareSheet';
@@ -463,7 +463,7 @@ function LayoutInner(props: RouteSectionProps) {
             key={ENABLE_REMINDERS_FLAG}
             enabledOverride={ENABLE_REMINDERS_OVERRIDE}
           >
-            <CreateReminderModal />
+            <ReminderComposerModal />
           </ShowFeatureFlag>
           <Show when={isAddInboxDialogOpen()}>
             <AddInboxDialog />

--- a/apps/web/src/features/next-soup/actions/index.ts
+++ b/apps/web/src/features/next-soup/actions/index.ts
@@ -5,6 +5,7 @@ export { makeCopyEntityIdAction } from './make-copy-entity-id-action';
 export { makeCopyLinkAction } from './make-copy-link-action';
 export { makeCreateReminderAction } from './make-create-reminder-action';
 export { makeDeleteAction } from './make-delete-action';
+export { makeEditReminderAction } from './make-edit-reminder-action';
 export { makeFavoriteAction } from './make-favorite-action';
 export { makeHideCompanyAction } from './make-hide-company-action';
 export { makeMarkDoneAction } from './make-mark-done-action';

--- a/apps/web/src/features/next-soup/actions/make-edit-reminder-action.test.ts
+++ b/apps/web/src/features/next-soup/actions/make-edit-reminder-action.test.ts
@@ -1,0 +1,148 @@
+import type { EntityData, ReminderEntity } from '@entity';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  openReminderEditor: vi.fn(),
+  remindersEnabled: true,
+}));
+
+vi.mock('@app/features/reminders/reminder-composer', () => ({
+  openReminderEditor: mocks.openReminderEditor,
+}));
+
+// Spread the original so the other flags in this module keep working; only the
+// reminders gate is driven by the tests. Under vitest MODE is not
+// 'development', so the real ENABLE_REMINDERS would resolve to false.
+vi.mock('@core/constant/featureFlags', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@core/constant/featureFlags')>()),
+  ENABLE_REMINDERS: () => mocks.remindersEnabled,
+}));
+
+import { makeEditReminderAction } from './make-edit-reminder-action';
+
+const NEXT_RUN = '2026-08-09T09:00:00.000Z';
+
+const reminder = (overrides: Partial<ReminderEntity> = {}) =>
+  ({
+    type: 'reminder',
+    id: 'rem-1',
+    name: 'Chase the contract',
+    description: 'Chase the contract',
+    ownerId: '',
+    scheduleType: 'once',
+    nextRunAt: NEXT_RUN,
+    enabled: true,
+    ...overrides,
+  }) as ReminderEntity;
+
+const entity = (type: EntityData['type'], id = 'e1') =>
+  ({ type, id, name: 'Thing' }) as EntityData;
+
+describe('makeEditReminderAction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.remindersEnabled = true;
+  });
+
+  it('can run for a one-shot reminder', () => {
+    expect(makeEditReminderAction().canExecute(reminder())).toBe(true);
+  });
+
+  it('cannot run for anything that is not a reminder', () => {
+    const { canExecute } = makeEditReminderAction();
+
+    expect(canExecute(entity('document'))).toBe(false);
+    expect(canExecute(entity('email'))).toBe(false);
+  });
+
+  // The composer only speaks one-shot schedules, so editing a recurring
+  // reminder through it would quietly turn a cron into a single firing.
+  it('cannot run for a recurring reminder', () => {
+    const recurring = reminder({
+      scheduleType: 'recurring',
+      cron: '0 0 9 * * *',
+      timezone: 'UTC',
+    });
+
+    expect(makeEditReminderAction().canExecute(recurring)).toBe(false);
+  });
+
+  it('opens the editor with the reminder as the row knows it', () => {
+    makeEditReminderAction().execute([reminder()]);
+
+    expect(mocks.openReminderEditor).toHaveBeenCalledWith({
+      id: 'rem-1',
+      description: 'Chase the contract',
+      remindAt: new Date(NEXT_RUN),
+      completed: false,
+    });
+  });
+
+  // A reschedule has to clear the done flag, so the editor needs to know the
+  // reminder was completed — see reminderEditPatch.
+  it('reports a completed reminder as completed', () => {
+    makeEditReminderAction().execute([
+      reminder({ completedAt: '2026-08-08T10:00:00.000Z' }),
+    ]);
+
+    expect(mocks.openReminderEditor).toHaveBeenCalledWith(
+      expect.objectContaining({ completed: true })
+    );
+  });
+
+  it('does nothing for an empty selection', () => {
+    makeEditReminderAction().execute([]);
+
+    expect(mocks.openReminderEditor).not.toHaveBeenCalled();
+  });
+
+  // The editor asks about one reminder's time, so a multi-select is not a
+  // batch — the menu only offers it for a single row.
+  it('uses only the first entity of a multi-selection', () => {
+    const first = reminder();
+
+    makeEditReminderAction().execute([first, reminder({ id: 'rem-2' })]);
+
+    expect(mocks.openReminderEditor).toHaveBeenCalledOnce();
+    expect(mocks.openReminderEditor).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'rem-1' })
+    );
+  });
+
+  it('does not open the editor for a non-reminder', () => {
+    makeEditReminderAction().execute([entity('document')]);
+
+    expect(mocks.openReminderEditor).not.toHaveBeenCalled();
+  });
+
+  it('cannot run when the reminders flag is off', () => {
+    mocks.remindersEnabled = false;
+
+    expect(makeEditReminderAction().canExecute(reminder())).toBe(false);
+  });
+
+  // execute re-checks the gate, so a command-menu entry left over from before
+  // the flag closed cannot still open the editor.
+  it('does not open the editor when the reminders flag is off', () => {
+    mocks.remindersEnabled = false;
+
+    makeEditReminderAction().execute([reminder()]);
+
+    expect(mocks.openReminderEditor).not.toHaveBeenCalled();
+  });
+
+  // The soup context menu and soup command menu both drive actions through
+  // executeWithSoup, so the action is unreachable from a list without it.
+  it('opens the editor when driven from a soup list', async () => {
+    await makeEditReminderAction().executeWithSoup(
+      [reminder()],
+      {} as Parameters<
+        ReturnType<typeof makeEditReminderAction>['executeWithSoup']
+      >[1]
+    );
+
+    expect(mocks.openReminderEditor).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'rem-1' })
+    );
+  });
+});

--- a/apps/web/src/features/next-soup/actions/make-edit-reminder-action.test.ts
+++ b/apps/web/src/features/next-soup/actions/make-edit-reminder-action.test.ts
@@ -4,10 +4,18 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mocks = vi.hoisted(() => ({
   openReminderEditor: vi.fn(),
   remindersEnabled: true,
+  cachedPreview: undefined as { rawName: string; access: string } | undefined,
 }));
 
 vi.mock('@app/features/reminders/reminder-composer', () => ({
   openReminderEditor: mocks.openReminderEditor,
+}));
+
+// The reference name comes from the preview cache the row already populated.
+vi.mock('@queries/preview', () => ({
+  getCachedItemPreview: () => mocks.cachedPreview,
+  isAccessiblePreviewItem: (item: { access?: string } | undefined) =>
+    item?.access === 'access',
 }));
 
 // Spread the original so the other flags in this module keep working; only the
@@ -42,6 +50,7 @@ describe('makeEditReminderAction', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.remindersEnabled = true;
+    mocks.cachedPreview = undefined;
   });
 
   it('can run for a one-shot reminder', () => {
@@ -87,6 +96,67 @@ describe('makeEditReminderAction', () => {
 
     expect(mocks.openReminderEditor).toHaveBeenCalledWith(
       expect.objectContaining({ completed: true })
+    );
+  });
+
+  // Blanking the description in the editor means "name it after what it is
+  // about", exactly as it does when creating — so the name has to travel with
+  // the draft.
+  it('carries the reference name as the blank-description fallback', () => {
+    mocks.cachedPreview = { rawName: 'Q3 Contract', access: 'access' };
+
+    makeEditReminderAction().execute([
+      reminder({ referencedEntity: { id: 'doc-1', type: 'document' } }),
+    ]);
+
+    expect(mocks.openReminderEditor).toHaveBeenCalledWith(
+      expect.objectContaining({ fallbackDescription: 'Q3 Contract' })
+    );
+  });
+
+  it('falls back to how lists label an unnamed reference', () => {
+    mocks.cachedPreview = { rawName: '', access: 'access' };
+
+    makeEditReminderAction().execute([
+      reminder({ referencedEntity: { id: 'thread-1', type: 'email' } }),
+    ]);
+
+    expect(mocks.openReminderEditor).toHaveBeenCalledWith(
+      expect.objectContaining({ fallbackDescription: '(No Subject)' })
+    );
+  });
+
+  // Without a fallback the editor keeps the existing description, rather than
+  // renaming the reminder to a placeholder because a lookup missed.
+  it('carries no fallback for a standalone reminder', () => {
+    makeEditReminderAction().execute([reminder()]);
+
+    expect(mocks.openReminderEditor).toHaveBeenCalledWith(
+      expect.objectContaining({ fallbackDescription: undefined })
+    );
+  });
+
+  it('carries no fallback when the reference is not cached', () => {
+    mocks.cachedPreview = undefined;
+
+    makeEditReminderAction().execute([
+      reminder({ referencedEntity: { id: 'doc-1', type: 'document' } }),
+    ]);
+
+    expect(mocks.openReminderEditor).toHaveBeenCalledWith(
+      expect.objectContaining({ fallbackDescription: undefined })
+    );
+  });
+
+  it('carries no fallback when the reference is inaccessible', () => {
+    mocks.cachedPreview = { rawName: 'Secret', access: 'no_access' };
+
+    makeEditReminderAction().execute([
+      reminder({ referencedEntity: { id: 'doc-1', type: 'document' } }),
+    ]);
+
+    expect(mocks.openReminderEditor).toHaveBeenCalledWith(
+      expect.objectContaining({ fallbackDescription: undefined })
     );
   });
 

--- a/apps/web/src/features/next-soup/actions/make-edit-reminder-action.ts
+++ b/apps/web/src/features/next-soup/actions/make-edit-reminder-action.ts
@@ -1,7 +1,31 @@
 import { openReminderEditor } from '@app/features/reminders/reminder-composer';
+import { reminderDescriptionForReference } from '@app/features/reminders/reminder-schedule';
 import { ENABLE_REMINDERS } from '@core/constant/featureFlags';
-import type { EntityData } from '@entity';
+import type { EntityData, ReminderEntity } from '@entity';
+import {
+  getCachedItemPreview,
+  isAccessiblePreviewItem,
+} from '@queries/preview';
 import type { SoupState } from '../create-soup-state';
+
+/**
+ * The description this reminder would get if it were being created now, for a
+ * blank description to fall back to.
+ *
+ * Read from the preview cache rather than fetched: the row the editor was
+ * opened from has already rendered this name, so it is cached. A miss returns
+ * undefined and the editor keeps the existing description instead — better than
+ * blocking on a request to answer a question the user may not even ask.
+ */
+function fallbackDescriptionFor(entity: ReminderEntity): string | undefined {
+  const reference = entity.referencedEntity;
+  if (!reference) return undefined;
+
+  const cached = getCachedItemPreview(reference.id);
+  if (!cached || !isAccessiblePreviewItem(cached)) return undefined;
+
+  return reminderDescriptionForReference(cached.rawName, reference.type);
+}
 
 /**
  * Edit an existing reminder — its description, its time, or both.
@@ -32,6 +56,7 @@ export const makeEditReminderAction = () => {
       description: entity.description,
       remindAt: new Date(entity.nextRunAt),
       completed: entity.completedAt != null,
+      fallbackDescription: fallbackDescriptionFor(entity),
     });
   };
 

--- a/apps/web/src/features/next-soup/actions/make-edit-reminder-action.ts
+++ b/apps/web/src/features/next-soup/actions/make-edit-reminder-action.ts
@@ -1,0 +1,45 @@
+import { openReminderEditor } from '@app/features/reminders/reminder-composer';
+import { ENABLE_REMINDERS } from '@core/constant/featureFlags';
+import type { EntityData } from '@entity';
+import type { SoupState } from '../create-soup-state';
+
+/**
+ * Edit an existing reminder — its description, its time, or both.
+ *
+ * `execute` opens the composer prefilled rather than writing anything: both
+ * answers come from the user, so there is nothing to do until that modal
+ * resolves. Single-entity only, like creating one.
+ *
+ * Recurring reminders are excluded. The composer only speaks one-shot
+ * schedules, so editing one through it would quietly turn a cron into a single
+ * firing. Nothing in the product creates a recurring reminder today, so this
+ * excludes nothing a user can actually reach.
+ */
+export const makeEditReminderAction = () => {
+  const canExecute = (entity: EntityData): boolean =>
+    ENABLE_REMINDERS() &&
+    entity.type === 'reminder' &&
+    entity.scheduleType === 'once';
+
+  const execute = (entities: EntityData[]) => {
+    const [entity] = entities;
+    // Re-checked rather than assumed: a stale command-menu entry could
+    // otherwise still fire against a row that has since changed.
+    if (!entity || entity.type !== 'reminder' || !canExecute(entity)) return;
+
+    openReminderEditor({
+      id: entity.id,
+      description: entity.description,
+      remindAt: new Date(entity.nextRunAt),
+      completed: entity.completedAt != null,
+    });
+  };
+
+  const executeWithSoup = async (entities: EntityData[], _soup: SoupState) => {
+    // Opening the composer doesn't change the list, so selection and focus are
+    // left where they are.
+    execute(entities);
+  };
+
+  return { canExecute, execute, executeWithSoup };
+};

--- a/apps/web/src/features/next-soup/actions/use-entity-action-hotkeys.ts
+++ b/apps/web/src/features/next-soup/actions/use-entity-action-hotkeys.ts
@@ -307,9 +307,12 @@ export const useEntityActionHotkeys = (
   /**
    * Whether 'r' should open the reminder editor rather than rename.
    *
-   * A reminder is never renamable — its name is its description, owned by the
-   * reminders API — so the two are mutually exclusive and can share the key
-   * instead of leaving 'r' dead on a reminder row.
+   * The two are mutually exclusive rather than merely unlikely to overlap:
+   * `renameAction.canExecute` ends at `entity.ownerId === userId()`, and a
+   * reminder row's `ownerId` is always `''` while `userId()` is a macro id or
+   * undefined — so rename never claims a reminder, and sharing the key beats
+   * leaving 'r' dead on one. Its name is its description, which only the
+   * reminders API can change.
    */
   const editsReminder = (): boolean => {
     const entities = getEntitiesForAction();

--- a/apps/web/src/features/next-soup/actions/use-entity-action-hotkeys.ts
+++ b/apps/web/src/features/next-soup/actions/use-entity-action-hotkeys.ts
@@ -26,6 +26,7 @@ import {
   makeCopyLinkAction,
   makeCreateReminderAction,
   makeDeleteAction,
+  makeEditReminderAction,
   makeFavoriteAction,
   makeMarkDoneAction,
   makeMarkNotDoneAction,
@@ -88,6 +89,7 @@ export const useEntityActionHotkeys = (
 
   const copyEntityIdAction = makeCopyEntityIdAction();
   const createReminderAction = makeCreateReminderAction();
+  const editReminderAction = makeEditReminderAction();
 
   const shareAction = makeShareAction();
 
@@ -302,18 +304,37 @@ export const useEntityActionHotkeys = (
     tags: [HotkeyTags.SelectionModification],
   }).withGroup(group);
 
-  // Rename - 'r'
+  /**
+   * Whether 'r' should open the reminder editor rather than rename.
+   *
+   * A reminder is never renamable — its name is its description, owned by the
+   * reminders API — so the two are mutually exclusive and can share the key
+   * instead of leaving 'r' dead on a reminder row.
+   */
+  const editsReminder = (): boolean => {
+    const entities = getEntitiesForAction();
+    return entities.length === 1 && editReminderAction.canExecute(entities[0]);
+  };
+
+  // Rename - 'r'. Edits the reminder instead when the row is one.
   registerHotkey({
     hotkey: ['r'],
     hotkeyToken: TOKENS.entity.action.rename,
     scopeId,
     description: () => {
+      if (editsReminder()) return 'Edit reminder';
       const count = getEntitiesForAction().length;
       return count > 1 ? 'Rename items' : 'Rename item';
     },
     keyDownHandler: () => {
       const entities = getEntitiesForAction();
       if (entities.length === 0) return false;
+
+      if (editsReminder()) {
+        editReminderAction.executeWithSoup(entities, soup);
+        return true;
+      }
+
       if (!entities.every(renameAction.canExecute)) return false;
 
       renameAction.executeWithSoup(entities, soup);
@@ -321,6 +342,7 @@ export const useEntityActionHotkeys = (
     },
     condition: () => {
       if (condition && !condition()) return false;
+      if (editsReminder()) return true;
       const entities = getEntitiesForAction();
       return entities.length > 0 && entities.every(renameAction.canExecute);
     },

--- a/apps/web/src/features/next-soup/soup-view/create-soup-entity-actions.ts
+++ b/apps/web/src/features/next-soup/soup-view/create-soup-entity-actions.ts
@@ -19,6 +19,7 @@ import {
   makeCopyLinkAction,
   makeCreateReminderAction,
   makeDeleteAction,
+  makeEditReminderAction,
   makeFavoriteAction,
   makeHideCompanyAction,
   makeMarkDoneAction,
@@ -126,6 +127,7 @@ export function createSoupEntityActions(): {
   const copyBranchNameAction = makeCopyBranchNameAction();
   const copyEntityIdAction = makeCopyEntityIdAction();
   const createReminderAction = makeCreateReminderAction();
+  const editReminderAction = makeEditReminderAction();
   const shareAction = makeShareAction();
   const blockSenderAction = makeBlockSenderAction();
   const markSenderSignalAction = makeMarkSenderSignalAction();
@@ -288,6 +290,18 @@ export function createSoupEntityActions(): {
         label: 'Rename',
         hotkeyToken: TOKENS.entity.action.rename,
         onClick: handle(renameAction.executeWithSoup),
+      });
+    }
+
+    // A reminder never offers Rename — its name is its description, which the
+    // reminders API owns — so this takes that slot, and the same 'r' key.
+    // Single-entity only: the editor asks about one reminder's time.
+    if (entities.length === 1 && editReminderAction.canExecute(entities[0])) {
+      middleItems.push({
+        id: 'edit-reminder',
+        label: 'Edit reminder',
+        hotkeyToken: TOKENS.entity.action.rename,
+        onClick: handle(editReminderAction.executeWithSoup),
       });
     }
 

--- a/apps/web/src/features/next-soup/soup-view/create-soup-entity-actions.ts
+++ b/apps/web/src/features/next-soup/soup-view/create-soup-entity-actions.ts
@@ -293,8 +293,12 @@ export function createSoupEntityActions(): {
       });
     }
 
-    // A reminder never offers Rename — its name is its description, which the
-    // reminders API owns — so this takes that slot, and the same 'r' key.
+    // Takes Rename's slot, and its 'r' key. The two cannot both appear:
+    // `renameAction.canExecute` ends at `entity.ownerId === userId()`, and a
+    // reminder row's `ownerId` is always `''` (both soup mappers set it — a
+    // reminder is private to its owner, so the row carries no owner id) while
+    // `userId()` is a macro id or undefined. Renaming one would fail anyway;
+    // its name is its description, which only the reminders API can change.
     // Single-entity only: the editor asks about one reminder's time.
     if (entities.length === 1 && editReminderAction.canExecute(entities[0])) {
       middleItems.push({

--- a/apps/web/src/features/reminders/ReminderComposerModal.tsx
+++ b/apps/web/src/features/reminders/ReminderComposerModal.tsx
@@ -10,6 +10,7 @@ import BellIcon from '@phosphor/bell-simple.svg';
 import {
   reminderTarget,
   useCreateReminderMutation,
+  useUpdateReminderMutation,
 } from '@queries/reminders/reminders';
 import { mergeRefs } from '@solid-primitives/refs';
 import {
@@ -37,6 +38,7 @@ import {
 } from 'solid-js';
 import {
   closeReminderComposer,
+  type ReminderDraft,
   reminderComposerOpen,
   reminderComposerState,
 } from './reminder-composer';
@@ -47,6 +49,8 @@ import {
   REMINDER_DEFAULT_TIME,
   REMINDER_DESCRIPTION_MAX_LENGTH,
   reminderDefaultOptions,
+  reminderEditOptions,
+  reminderEditPatch,
   resolveReminderDescription,
 } from './reminder-schedule';
 
@@ -54,15 +58,20 @@ import {
 type Step = 'description' | 'when';
 
 /**
- * Asks two questions — what and when — for a reminder about the entity the
- * command was invoked on.
+ * Asks two questions — what and when — for a reminder, either a new one about
+ * an entity or an existing one being edited.
  *
  * The date step is deliberately the date editor reached by `shift+cmd+o`: the
  * same shell, entity chip, search input and `useDateSearch` list. The
- * description step in front of it is optional, and Enter on an empty field
- * falls straight through to the date list.
+ * description step in front of it is optional when creating, and Enter on an
+ * empty field falls straight through to the date list.
+ *
+ * Editing runs the same two steps prefilled. The difference is that both
+ * answers already have values, so neither step can be skipped into a blank: the
+ * description must stay non-empty, and the date list leads with keeping the
+ * time it already has.
  */
-export function CreateReminderModal() {
+export function ReminderComposerModal() {
   const [dialogRef, setDialogRef] = createSignal<HTMLElement | undefined>();
   const [attach, hotkeyScope] = useHotkeyDOMScope('reminder-composer');
   const [step, setStep] = createSignal<Step>('description');
@@ -71,9 +80,11 @@ export function CreateReminderModal() {
   const [selectedIndex, setSelectedIndex] = createSignal(0);
 
   const createReminder = useCreateReminderMutation();
+  const updateReminder = useUpdateReminderMutation();
   const keybindings = useListKeyBindings(() => dialogRef());
 
   const entity = () => reminderComposerState.entity;
+  const editing = () => reminderComposerState.editing;
 
   /**
    * Escape steps back to the description before it closes the composer,
@@ -107,30 +118,39 @@ export function CreateReminderModal() {
   createEffect(
     on(reminderComposerOpen, () => {
       setStep('description');
-      setDescription('');
+      // Prefilled when editing, so the field starts from what the reminder
+      // already says rather than asking for it again.
+      setDescription(reminderComposerState.editing?.description ?? '');
       setQuery('');
       setSelectedIndex(0);
     })
   );
+
+  /**
+   * Leave the description step, if the current answer is allowed to.
+   *
+   * Creating treats a blank field as "skip" and derives a name from the entity.
+   * Editing cannot: the field was prefilled, so a blank one is a deletion, and
+   * the API rejects an empty description.
+   */
+  const advanceFromDescription = () => {
+    if (editing() && !description().trim()) {
+      toast.failure('A reminder needs a description');
+      return;
+    }
+    setStep('when');
+  };
 
   // The dialog's Enter binding is a single shared slot, so whichever step is on
   // screen has to claim it or the other step's stale handler stays live.
   createEffect(
     on(step, (current) => {
       if (current !== 'description') return;
-      keybindings(descriptionStepKeybindings(() => setStep('when')));
+      keybindings(descriptionStepKeybindings(advanceFromDescription));
     })
   );
 
-  const submit = async (date: Date, target: EntityData) => {
-    // The options are filtered against the time the list was built, so one can
-    // slip into the past while the composer sits open. Re-check rather than
-    // let the API reject it with an opaque failure.
-    if (date.getTime() <= Date.now()) {
-      toast.failure('That time has already passed — pick another');
-      return;
-    }
-
+  const submitCreate = async (date: Date, target: EntityData) => {
     const resolved = resolveReminderDescription(description(), target);
     const attachTo = reminderTarget(target);
     closeReminderComposer();
@@ -147,6 +167,63 @@ export function CreateReminderModal() {
       toast.failure('Failed to create reminder');
     }
   };
+
+  const submitEdit = async (date: Date, draft: ReminderDraft) => {
+    const patch = reminderEditPatch(draft, {
+      description: description(),
+      remindAt: date,
+    });
+    closeReminderComposer();
+
+    // Neither answer moved. There is nothing to send — and an empty patch is
+    // rejected as having no fields to update.
+    if (!patch) return;
+
+    try {
+      await updateReminder.mutateAsync({ id: draft.id, patch });
+      toast.success(
+        patch.schedule
+          ? `Reminder set for ${formatReminderWhen(date)}`
+          : 'Reminder updated'
+      );
+    } catch {
+      toast.failure('Failed to update reminder');
+    }
+  };
+
+  const submit = async (date: Date) => {
+    const draft = editing();
+
+    // The options are filtered against the time the list was built, so one can
+    // slip into the past while the composer sits open. Re-check rather than
+    // let the API reject it with an opaque failure. Keeping an existing time is
+    // exempt: it sends no schedule, so an overdue reminder stays renamable.
+    const keepsCurrentTime = date.getTime() === draft?.remindAt.getTime();
+    if (!keepsCurrentTime && date.getTime() <= Date.now()) {
+      toast.failure('That time has already passed — pick another');
+      return;
+    }
+
+    if (draft) return await submitEdit(date, draft);
+
+    const target = entity();
+    if (target) return await submitCreate(date, target);
+  };
+
+  /**
+   * Whether there is a reminder to compose at all.
+   *
+   * Both targets are cleared on close, so this unmounts the body while the
+   * dialog animates shut — otherwise the reset back to the description step
+   * would be visible as the date list flicking back to a Continue button.
+   */
+  const hasTarget = () => entity() !== undefined || editing() !== undefined;
+
+  // The chip row carries the entity a new reminder is about, and — on the date
+  // step — the description typed so far as a way back to it. Editing has no
+  // entity, so the row is only there once something has been typed.
+  const showsToolbar = () =>
+    entity() !== undefined || (step() === 'when' && !!description().trim());
 
   return (
     <Dialog
@@ -169,7 +246,11 @@ export function CreateReminderModal() {
           <Switch>
             <Match when={step() === 'description'}>
               <StepInput
-                placeholder="What's the reminder? (optional)"
+                placeholder={
+                  editing()
+                    ? 'Reminder description'
+                    : "What's the reminder? (optional)"
+                }
                 value={description()}
                 onInput={setDescription}
                 // Counts UTF-16 code units where the service counts characters,
@@ -187,46 +268,49 @@ export function CreateReminderModal() {
             </Match>
           </Switch>
         </CommandMenuShell.Header>
-        <Show when={entity()}>
-          {(target) => (
-            <>
-              <CommandMenuShell.Toolbar class="p-3 py-2 border-b-0 gap-2">
-                <div class="bg-active border border-edge-muted px-2 py-1 truncate text-xs rounded max-w-[50%]">
-                  <InlineEntity entity={target()} />
-                </div>
-                {/* Sized to the space the entity chip leaves rather than to a
-                    share of its own, so the pair can never overflow. */}
-                <Show when={step() === 'when' && description().trim()}>
-                  {(typed) => (
-                    <button
-                      type="button"
-                      class="bg-active border border-edge-muted px-2 py-1 truncate text-xs rounded min-w-0 flex-1 text-left text-ink-muted hover:text-ink"
-                      title="Edit the description"
-                      onClick={() => setStep('description')}
-                    >
-                      {typed()}
-                    </button>
-                  )}
-                </Show>
-              </CommandMenuShell.Toolbar>
-              <Switch>
-                <Match when={step() === 'description'}>
-                  <DescriptionStep onContinue={() => setStep('when')} />
-                </Match>
-                <Match when={step() === 'when'}>
-                  <CommandMenuShell.Body>
-                    <WhenList
-                      query={query}
-                      selectedIndex={selectedIndex}
-                      setSelectedIndex={setSelectedIndex}
-                      onSubmit={(date) => void submit(date, target())}
-                      setKeybindings={keybindings}
-                    />
-                  </CommandMenuShell.Body>
-                </Match>
-              </Switch>
-            </>
-          )}
+        <Show when={hasTarget()}>
+          <Show when={showsToolbar()}>
+            <CommandMenuShell.Toolbar class="p-3 py-2 border-b-0 gap-2">
+              <Show when={entity()}>
+                {(target) => (
+                  <div class="bg-active border border-edge-muted px-2 py-1 truncate text-xs rounded max-w-[50%]">
+                    <InlineEntity entity={target()} />
+                  </div>
+                )}
+              </Show>
+              {/* Sized to the space the entity chip leaves rather than to a
+                  share of its own, so the pair can never overflow. */}
+              <Show when={step() === 'when' && description().trim()}>
+                {(typed) => (
+                  <button
+                    type="button"
+                    class="bg-active border border-edge-muted px-2 py-1 truncate text-xs rounded min-w-0 flex-1 text-left text-ink-muted hover:text-ink"
+                    title="Edit the description"
+                    onClick={() => setStep('description')}
+                  >
+                    {typed()}
+                  </button>
+                )}
+              </Show>
+            </CommandMenuShell.Toolbar>
+          </Show>
+          <Switch>
+            <Match when={step() === 'description'}>
+              <DescriptionStep onContinue={advanceFromDescription} />
+            </Match>
+            <Match when={step() === 'when'}>
+              <CommandMenuShell.Body>
+                <WhenList
+                  query={query}
+                  current={() => editing()?.remindAt}
+                  selectedIndex={selectedIndex}
+                  setSelectedIndex={setSelectedIndex}
+                  onSubmit={(date) => void submit(date)}
+                  setKeybindings={keybindings}
+                />
+              </CommandMenuShell.Body>
+            </Match>
+          </Switch>
         </Show>
       </CommandMenuShell>
     </Dialog>
@@ -237,7 +321,8 @@ export function CreateReminderModal() {
  * What the description step does with the dialog's shared list bindings.
  *
  * There is no list to move through, so the arrows are inert and Enter is the
- * skip-through: it advances whether or not anything was typed.
+ * skip-through: it advances whether or not anything was typed, subject to the
+ * step's own check.
  */
 function descriptionStepKeybindings(advance: VoidFunction): ListNavActions {
   return { next: () => {}, previous: () => {}, select: advance };
@@ -307,6 +392,8 @@ function DescriptionStep(props: { onContinue: VoidFunction }) {
 
 function WhenList(props: {
   query: () => string;
+  /** The firing an edited reminder already has, offered as "Keep current time". */
+  current: () => Date | undefined;
   selectedIndex: () => number;
   setSelectedIndex: (next: number | ((prev: number) => number)) => void;
   onSubmit: (date: Date) => void;
@@ -326,7 +413,12 @@ function WhenList(props: {
     const now = new Date();
     // The resting list is reminder-specific; typing hands off to the shared
     // date search. Either way a reminder must fire in the future.
-    if (!props.query().trim()) return reminderDefaultOptions(now);
+    if (!props.query().trim()) {
+      const current = props.current();
+      return current
+        ? reminderEditOptions(current, now)
+        : reminderDefaultOptions(now);
+    }
     return futureDateOptions(rawOptions(), now);
   });
 

--- a/apps/web/src/features/reminders/ReminderComposerModal.tsx
+++ b/apps/web/src/features/reminders/ReminderComposerModal.tsx
@@ -8,10 +8,15 @@ import {
 import { type EntityData, InlineEntity } from '@entity';
 import BellIcon from '@phosphor/bell-simple.svg';
 import {
+  reminderSoupPatch,
   reminderTarget,
   useCreateReminderMutation,
   useUpdateReminderMutation,
 } from '@queries/reminders/reminders';
+import {
+  getSoupEntityById,
+  optimisticUpdateSoupEntity,
+} from '@queries/soup/cache';
 import { mergeRefs } from '@solid-primitives/refs';
 import {
   Button,
@@ -81,7 +86,21 @@ export function ReminderComposerModal() {
   const [selectedIndex, setSelectedIndex] = createSignal(0);
 
   const createReminder = useCreateReminderMutation();
-  const updateReminder = useUpdateReminderMutation();
+  // Soup rows come from the normalized soup cache, not the reminders queries,
+  // so the mutation's own invalidation leaves an edited row reading its old
+  // description and firing time until a reload. Applying the response is not an
+  // optimistic guess — `nextRunAt` is derived server-side from the schedule,
+  // and this is the value it derived, which is why it lands on success rather
+  // than in `onMutate`.
+  const updateReminder = useUpdateReminderMutation({
+    onSuccess: (reminder) =>
+      optimisticUpdateSoupEntity(
+        reminderSoupPatch(
+          reminder,
+          getSoupEntityById(reminder.id)?.frecency_score
+        )
+      ),
+  });
   const keybindings = useListKeyBindings(() => dialogRef());
 
   const entity = () => reminderComposerState.entity;

--- a/apps/web/src/features/reminders/ReminderComposerModal.tsx
+++ b/apps/web/src/features/reminders/ReminderComposerModal.tsx
@@ -51,6 +51,7 @@ import {
   reminderDefaultOptions,
   reminderEditOptions,
   reminderEditPatch,
+  resolveEditedDescription,
   resolveReminderDescription,
 } from './reminder-schedule';
 
@@ -66,9 +67,9 @@ type Step = 'description' | 'when';
  * description step in front of it is optional when creating, and Enter on an
  * empty field falls straight through to the date list.
  *
- * Editing runs the same two steps prefilled. The difference is that both
- * answers already have values, so neither step can be skipped into a blank: the
- * description must stay non-empty, and the date list leads with keeping the
+ * Editing runs the same two steps, prefilled from the reminder. Both keep the
+ * create flow's meaning of a blank answer: clearing the description names the
+ * reminder after whatever it is about, and the date list leads with keeping the
  * time it already has.
  */
 export function ReminderComposerModal() {
@@ -126,20 +127,7 @@ export function ReminderComposerModal() {
     })
   );
 
-  /**
-   * Leave the description step, if the current answer is allowed to.
-   *
-   * Creating treats a blank field as "skip" and derives a name from the entity.
-   * Editing cannot: the field was prefilled, so a blank one is a deletion, and
-   * the API rejects an empty description.
-   */
-  const advanceFromDescription = () => {
-    if (editing() && !description().trim()) {
-      toast.failure('A reminder needs a description');
-      return;
-    }
-    setStep('when');
-  };
+  const advanceFromDescription = () => setStep('when');
 
   // The dialog's Enter binding is a single shared slot, so whichever step is on
   // screen has to claim it or the other step's stale handler stays live.
@@ -170,7 +158,13 @@ export function ReminderComposerModal() {
 
   const submitEdit = async (date: Date, draft: ReminderDraft) => {
     const patch = reminderEditPatch(draft, {
-      description: description(),
+      // Blank means the same here as it does when creating: name it after
+      // whatever it is about.
+      description: resolveEditedDescription(
+        description(),
+        draft.description,
+        draft.fallbackDescription
+      ),
       remindAt: date,
     });
     closeReminderComposer();
@@ -366,8 +360,10 @@ function StepInput(props: {
 /**
  * The optional first step: name the reminder, or press Enter past it.
  *
- * The entity name a blank field falls back to is never pre-filled, so skipping
- * stays a single keystroke instead of a select-all and delete.
+ * When creating, the entity name a blank field falls back to is never
+ * pre-filled, so skipping stays a single keystroke instead of a select-all and
+ * delete. When editing it necessarily is pre-filled — clearing it back out asks
+ * for that same fallback.
  */
 function DescriptionStep(props: { onContinue: VoidFunction }) {
   return (

--- a/apps/web/src/features/reminders/reminder-composer.test.ts
+++ b/apps/web/src/features/reminders/reminder-composer.test.ts
@@ -4,12 +4,20 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import {
   closeReminderComposer,
   openReminderComposer,
+  openReminderEditor,
   reminderComposerOpen,
   reminderComposerState,
 } from './reminder-composer';
 
 const doc = (id: string, name: string) =>
   ({ type: 'document', id, name }) as EntityData;
+
+const draft = (id: string, description: string) => ({
+  id,
+  description,
+  remindAt: new Date('2026-08-09T09:00:00.000Z'),
+  completed: false,
+});
 
 describe('reminder composer state', () => {
   beforeEach(() => {
@@ -47,5 +55,56 @@ describe('reminder composer state', () => {
     openReminderComposer(doc('doc-2', 'Roadmap'));
 
     expect(reminderComposerState.entity?.id).toBe('doc-2');
+  });
+});
+
+describe('reminder composer edit mode', () => {
+  beforeEach(() => {
+    closeReminderComposer();
+  });
+
+  it('opens with the reminder being edited', () => {
+    openReminderEditor(draft('rem-1', 'Chase the contract'));
+
+    expect(reminderComposerOpen()).toBe(true);
+    expect(reminderComposerState.editing?.id).toBe('rem-1');
+    expect(reminderComposerState.editing?.description).toBe(
+      'Chase the contract'
+    );
+  });
+
+  it('clears the reminder on close', () => {
+    openReminderEditor(draft('rem-1', 'Chase the contract'));
+    closeReminderComposer();
+
+    expect(reminderComposerOpen()).toBe(false);
+    expect(reminderComposerState.editing).toBeUndefined();
+  });
+
+  // The two modes are exclusive: the modal shows an entity chip for one and
+  // prefills from the reminder for the other, so a leftover from the previous
+  // open would put it in both at once.
+  it('drops a create target when opened to edit', () => {
+    openReminderComposer(doc('doc-1', 'Q3 Contract'));
+    openReminderEditor(draft('rem-1', 'Chase the contract'));
+
+    expect(reminderComposerState.entity).toBeUndefined();
+    expect(reminderComposerState.editing?.id).toBe('rem-1');
+  });
+
+  it('drops an edit target when opened to create', () => {
+    openReminderEditor(draft('rem-1', 'Chase the contract'));
+    openReminderComposer(doc('doc-1', 'Q3 Contract'));
+
+    expect(reminderComposerState.editing).toBeUndefined();
+    expect(reminderComposerState.entity?.id).toBe('doc-1');
+  });
+
+  it('replaces the reminder when reopened for another one', () => {
+    openReminderEditor(draft('rem-1', 'Chase the contract'));
+    openReminderEditor(draft('rem-2', 'Send the invoice'));
+
+    expect(reminderComposerState.editing?.id).toBe('rem-2');
+    expect(reminderComposerState.editing?.description).toBe('Send the invoice');
   });
 });

--- a/apps/web/src/features/reminders/reminder-composer.ts
+++ b/apps/web/src/features/reminders/reminder-composer.ts
@@ -22,6 +22,14 @@ export interface ReminderDraft {
   remindAt: Date;
   /** Whether the owner has marked it done, which a reschedule has to undo. */
   completed: boolean;
+  /**
+   * What a blank description falls back to — the name of the entity this
+   * reminder is about, as creating one would have derived it.
+   *
+   * Absent for a standalone reminder, and for a reference whose name is not
+   * cached; blanking the field then leaves the description alone.
+   */
+  fallbackDescription?: string;
 }
 
 interface ReminderComposerState {

--- a/apps/web/src/features/reminders/reminder-composer.ts
+++ b/apps/web/src/features/reminders/reminder-composer.ts
@@ -6,17 +6,38 @@ import { createStore, reconcile } from 'solid-js/store';
 export const [reminderComposerOpen, setReminderComposerOpen] =
   createControlledOpenSignal(false, { id: 'reminder-create' });
 
+/**
+ * The reminder being edited, as its row already knows it.
+ *
+ * Taken from the list rather than re-fetched: a soup row carries the
+ * description and `nextRunAt` already, so opening the editor costs no request
+ * and cannot show a spinner over a value the user is looking at.
+ */
+export interface ReminderDraft {
+  /** The reminder's id, which the patch is addressed to. */
+  id: string;
+  /** Its current description, prefilled into the first step. */
+  description: string;
+  /** Its current firing, offered as "Keep current time". */
+  remindAt: Date;
+  /** Whether the owner has marked it done, which a reschedule has to undo. */
+  completed: boolean;
+}
+
 interface ReminderComposerState {
-  /** The entity the reminder is about. */
+  /** The entity a new reminder is about. Absent when editing. */
   entity?: EntityData;
+  /** The reminder being edited. Absent when creating. */
+  editing?: ReminderDraft;
 }
 
 const [state, setState] = createStore<ReminderComposerState>({
   entity: undefined,
+  editing: undefined,
 });
 
 /**
- * Open the composer for an entity.
+ * Open the composer to create a reminder about an entity.
  *
  * There is only one thing left to ask: when. The entity is whatever the command
  * was invoked on and the description is derived from it, so the composer opens
@@ -26,7 +47,21 @@ export function openReminderComposer(entity: EntityData) {
   // Batched so the modal's open-keyed effect sees this entity rather than the
   // previous one.
   batch(() => {
-    setState(reconcile({ entity }));
+    setState(reconcile({ entity, editing: undefined }));
+    setReminderComposerOpen(true);
+  });
+}
+
+/**
+ * Open the composer to edit an existing reminder.
+ *
+ * The same two steps as creating one, prefilled: the description step starts
+ * from what the reminder says, and the date step leads with keeping its current
+ * time so a rename does not force a new date to be picked.
+ */
+export function openReminderEditor(reminder: ReminderDraft) {
+  batch(() => {
+    setState(reconcile({ entity: undefined, editing: reminder }));
     setReminderComposerOpen(true);
   });
 }
@@ -34,7 +69,7 @@ export function openReminderComposer(entity: EntityData) {
 export function closeReminderComposer() {
   batch(() => {
     setReminderComposerOpen(false);
-    setState(reconcile({ entity: undefined }));
+    setState(reconcile({ entity: undefined, editing: undefined }));
   });
 }
 

--- a/apps/web/src/features/reminders/reminder-schedule.test.ts
+++ b/apps/web/src/features/reminders/reminder-schedule.test.ts
@@ -10,6 +10,8 @@ import {
   REMINDER_DESCRIPTION_MAX_LENGTH,
   reminderDefaultOptions,
   reminderDescriptionFor,
+  reminderEditOptions,
+  reminderEditPatch,
   resolveReminderDescription,
 } from './reminder-schedule';
 
@@ -341,5 +343,156 @@ describe('formatReminderWhen', () => {
     expect(formatReminderWhen(date, now)).toBe(
       date.toLocaleString(undefined, timeOnly)
     );
+  });
+});
+
+describe('reminderEditOptions', () => {
+  // A Wednesday afternoon, so every default entry is still ahead of "now".
+  const wednesdayAfternoon = new Date(2026, 6, 29, 16, 37, 52, 400);
+  const current = new Date(2026, 7, 3, 9, 0, 0, 0);
+
+  it('leads with keeping the current time, then the defaults', () => {
+    expect(
+      reminderEditOptions(current, wednesdayAfternoon).map((o) => o.displayText)
+    ).toEqual([
+      'Keep current time',
+      'In 1 hour',
+      'In 2 hours',
+      'Tomorrow',
+      'End of week',
+      'In 1 week',
+    ]);
+  });
+
+  it('keeps the exact instant the reminder already has', () => {
+    const [keep] = reminderEditOptions(current, wednesdayAfternoon);
+
+    expect(keep.date.getTime()).toBe(current.getTime());
+  });
+
+  // Both would submit the same instant, so offering them separately would read
+  // as two different choices with one outcome.
+  it('drops a default that lands on the current time', () => {
+    const tomorrowMorning = new Date(2026, 6, 30, 9, 0, 0, 0);
+    const options = reminderEditOptions(tomorrowMorning, wednesdayAfternoon);
+
+    expect(options.map((o) => o.displayText)).not.toContain('Tomorrow');
+    expect(options[0].displayText).toBe('Keep current time');
+  });
+
+  // An overdue reminder still has to be renamable, and keeping its time sends
+  // no schedule at all — so the future filter must not remove the keep option.
+  it('offers keeping a time that has already passed', () => {
+    const overdue = new Date(2026, 6, 20, 9, 0, 0, 0);
+    const [keep] = reminderEditOptions(overdue, wednesdayAfternoon);
+
+    expect(keep.displayText).toBe('Keep current time');
+    expect(keep.date.getTime()).toBe(overdue.getTime());
+  });
+});
+
+describe('reminderEditPatch', () => {
+  const remindAt = new Date('2026-08-09T09:00:00.000Z');
+  const original = {
+    description: 'Chase the contract',
+    remindAt,
+    completed: false,
+  };
+
+  // An empty patch is rejected by the API as having no fields to update, so
+  // "nothing changed" has to be distinguishable from "patch these fields".
+  it('returns undefined when neither answer moved', () => {
+    expect(
+      reminderEditPatch(original, {
+        description: 'Chase the contract',
+        remindAt: new Date(remindAt),
+      })
+    ).toBeUndefined();
+  });
+
+  it('sends only the description when the time is kept', () => {
+    expect(
+      reminderEditPatch(original, {
+        description: 'Chase the signed contract',
+        remindAt: new Date(remindAt),
+      })
+    ).toEqual({ description: 'Chase the signed contract' });
+  });
+
+  it('sends only the schedule when the description is kept', () => {
+    const next = new Date('2026-08-10T09:00:00.000Z');
+
+    expect(
+      reminderEditPatch(original, {
+        description: 'Chase the contract',
+        remindAt: next,
+      })
+    ).toEqual({ schedule: { type: 'once', remindAt: next.toISOString() } });
+  });
+
+  it('sends both when both moved', () => {
+    const next = new Date('2026-08-10T09:00:00.000Z');
+
+    expect(
+      reminderEditPatch(original, { description: 'Follow up', remindAt: next })
+    ).toEqual({
+      description: 'Follow up',
+      schedule: { type: 'once', remindAt: next.toISOString() },
+    });
+  });
+
+  it('trims the description before comparing it', () => {
+    expect(
+      reminderEditPatch(original, {
+        description: '  Chase the contract  ',
+        remindAt: new Date(remindAt),
+      })
+    ).toBeUndefined();
+  });
+
+  // The editor blocks a blank description at the step before this, but a blank
+  // must never be sent — the API rejects it, and it is a deletion, not an edit.
+  it('ignores a blank description', () => {
+    expect(
+      reminderEditPatch(original, {
+        description: '   ',
+        remindAt: new Date(remindAt),
+      })
+    ).toBeUndefined();
+  });
+
+  it('caps an over-long description at the API limit', () => {
+    const patch = reminderEditPatch(original, {
+      description: 'a'.repeat(REMINDER_DESCRIPTION_MAX_LENGTH + 50),
+      remindAt: new Date(remindAt),
+    });
+
+    expect(patch?.description).toHaveLength(REMINDER_DESCRIPTION_MAX_LENGTH);
+  });
+
+  // The dispatcher skips completed reminders, so a new time on one that was
+  // marked done would silently never arrive unless the flag comes off with it.
+  it('clears the done flag when a completed reminder is rescheduled', () => {
+    const next = new Date('2026-08-10T09:00:00.000Z');
+
+    expect(
+      reminderEditPatch(
+        { ...original, completed: true },
+        { description: 'Chase the contract', remindAt: next }
+      )
+    ).toEqual({
+      schedule: { type: 'once', remindAt: next.toISOString() },
+      completed: false,
+    });
+  });
+
+  // Renaming a done reminder is not a request for it to fire again.
+  it('leaves the done flag alone when only the description changes', () => {
+    expect(
+      reminderEditPatch(
+        { ...original, completed: true },
+        { description: 'Follow up', remindAt: new Date(remindAt) }
+      )
+    ).toEqual({ description: 'Follow up' });
   });
 });

--- a/apps/web/src/features/reminders/reminder-schedule.test.ts
+++ b/apps/web/src/features/reminders/reminder-schedule.test.ts
@@ -10,8 +10,10 @@ import {
   REMINDER_DESCRIPTION_MAX_LENGTH,
   reminderDefaultOptions,
   reminderDescriptionFor,
+  reminderDescriptionForReference,
   reminderEditOptions,
   reminderEditPatch,
+  resolveEditedDescription,
   resolveReminderDescription,
 } from './reminder-schedule';
 
@@ -494,5 +496,87 @@ describe('reminderEditPatch', () => {
         { description: 'Follow up', remindAt: new Date(remindAt) }
       )
     ).toEqual({ description: 'Follow up' });
+  });
+});
+
+describe('reminderDescriptionForReference', () => {
+  it('uses the resolved reference name', () => {
+    expect(reminderDescriptionForReference('Q3 Contract', 'document')).toBe(
+      'Q3 Contract'
+    );
+  });
+
+  it('trims the reference name', () => {
+    expect(reminderDescriptionForReference('  Q3 Contract  ', 'document')).toBe(
+      'Q3 Contract'
+    );
+  });
+
+  // Same fallbacks as reminderDescriptionFor, so blanking an edit lands on the
+  // name creating the reminder would have chosen.
+  it('names an unnamed reference the way lists label it', () => {
+    expect(reminderDescriptionForReference('', 'email')).toBe('(No Subject)');
+    expect(reminderDescriptionForReference('   ', 'document')).toBe('Untitled');
+    expect(reminderDescriptionForReference(undefined, 'crm_company')).toBe(
+      'Unknown Company'
+    );
+    expect(reminderDescriptionForReference(undefined, 'crm_contact')).toBe(
+      'Unknown Contact'
+    );
+  });
+
+  it('truncates an over-long reference name instead of failing', () => {
+    const long = 'x'.repeat(REMINDER_DESCRIPTION_MAX_LENGTH + 50);
+
+    expect(reminderDescriptionForReference(long, 'document')).toHaveLength(
+      REMINDER_DESCRIPTION_MAX_LENGTH
+    );
+  });
+});
+
+describe('resolveEditedDescription', () => {
+  it('uses what was typed', () => {
+    expect(
+      resolveEditedDescription('Follow up', 'Chase the contract', 'Q3 Contract')
+    ).toBe('Follow up');
+  });
+
+  it('trims what was typed', () => {
+    expect(
+      resolveEditedDescription('  Follow up  ', 'Chase the contract')
+    ).toBe('Follow up');
+  });
+
+  // Blanking the field means the same thing it means when creating: name this
+  // after whatever it is about.
+  it('falls back to the reference name when left blank', () => {
+    expect(
+      resolveEditedDescription('', 'Chase the contract', 'Q3 Contract')
+    ).toBe('Q3 Contract');
+  });
+
+  it('treats a whitespace-only description as blank', () => {
+    expect(
+      resolveEditedDescription('   ', 'Chase the contract', 'Q3 Contract')
+    ).toBe('Q3 Contract');
+  });
+
+  // A standalone reminder has nothing to name itself after, and a reference
+  // whose name did not resolve must not rename it to a placeholder.
+  it('keeps the current description when there is nothing to fall back to', () => {
+    expect(resolveEditedDescription('', 'Chase the contract')).toBe(
+      'Chase the contract'
+    );
+    expect(
+      resolveEditedDescription('  ', 'Chase the contract', undefined)
+    ).toBe('Chase the contract');
+  });
+
+  it('caps an over-long typed description at the API limit', () => {
+    const long = 'y'.repeat(REMINDER_DESCRIPTION_MAX_LENGTH + 50);
+
+    expect(resolveEditedDescription(long, 'Chase the contract')).toHaveLength(
+      REMINDER_DESCRIPTION_MAX_LENGTH
+    );
   });
 });

--- a/apps/web/src/features/reminders/reminder-schedule.ts
+++ b/apps/web/src/features/reminders/reminder-schedule.ts
@@ -4,6 +4,7 @@ import {
 } from '@core/util/dateSearch/useDateSearch';
 import type { EntityData } from '@entity';
 import type { ReminderSchedule } from '@service-storage/generated/schemas/reminderSchedule';
+import type { UpdateReminderRequest } from '@service-storage/generated/schemas/updateReminderRequest';
 import { addDays, addHours, addWeeks, endOfWeek } from 'date-fns';
 
 /**
@@ -112,6 +113,61 @@ export function reminderDefaultOptions(now: Date): DateOption[] {
     })),
     now
   );
+}
+
+/**
+ * What the picker offers when editing a reminder that already has a time.
+ *
+ * "Keep current time" leads, so a rename costs one Enter rather than forcing a
+ * date to be re-picked. It is the only option exempt from the future filter: an
+ * overdue reminder still has to be renamable, and keeping its time sends no
+ * schedule at all — see {@link reminderEditPatch}.
+ *
+ * Presets landing on the current time are dropped, or the same instant would be
+ * offered twice under two labels.
+ */
+export function reminderEditOptions(current: Date, now: Date): DateOption[] {
+  const keep: DateOption = {
+    id: 'keep',
+    displayText: 'Keep current time',
+    secondaryText: formatDateWithContext(current, now, true),
+    date: current,
+    type: 'preset',
+  };
+  const rest = reminderDefaultOptions(now).filter(
+    (option) => option.date.getTime() !== current.getTime()
+  );
+  return [keep, ...rest];
+}
+
+/**
+ * The patch that turns `original` into `next`, or undefined when they match.
+ *
+ * Only changed fields are sent: the API rejects a patch with no fields, and an
+ * unchanged schedule must be omitted rather than re-sent, since re-sending the
+ * time of a reminder that has already fired would be rejected as being in the
+ * past. Omitting it is also what lets an overdue reminder be renamed at all.
+ */
+export function reminderEditPatch(
+  original: { description: string; remindAt: Date; completed: boolean },
+  next: { description: string; remindAt: Date }
+): UpdateReminderRequest | undefined {
+  const patch: UpdateReminderRequest = {};
+
+  const description = clampDescription(next.description);
+  if (description && description !== original.description) {
+    patch.description = description;
+  }
+  if (next.remindAt.getTime() !== original.remindAt.getTime()) {
+    patch.schedule = onceSchedule(next.remindAt);
+    // Giving a reminder that was marked done a new time is a request for it to
+    // fire again, and the dispatcher skips completed reminders — so without
+    // clearing the flag the time the user just picked would silently never
+    // arrive. A description-only edit leaves it alone.
+    if (original.completed) patch.completed = false;
+  }
+
+  return Object.keys(patch).length > 0 ? patch : undefined;
 }
 
 /** What an entity with no usable name is called, matching how lists render it. */

--- a/apps/web/src/features/reminders/reminder-schedule.ts
+++ b/apps/web/src/features/reminders/reminder-schedule.ts
@@ -229,6 +229,39 @@ export function resolveReminderDescription(
   return clampDescription(input) || reminderDescriptionFor(entity);
 }
 
+/**
+ * The same entity-derived description, from a resolved name rather than a whole
+ * entity.
+ *
+ * An edited reminder only knows its reference as a type and an id — the name
+ * lives in the preview cache — so it cannot go through
+ * {@link reminderDescriptionFor}. The fallbacks are the same, so blanking the
+ * field lands on the name creating it would have chosen.
+ */
+export function reminderDescriptionForReference(
+  name: string | undefined,
+  type: EntityData['type']
+): string {
+  return clampDescription(name?.trim() || untitledName(type));
+}
+
+/**
+ * What to store when an edited reminder's description is left blank.
+ *
+ * Blanking the field means the same thing it means when creating: name this
+ * after whatever it is about. `fallback` is that name, already derived — absent
+ * for a standalone reminder, or one whose reference could not be resolved. With
+ * nothing to derive from, the reminder keeps what it says: renaming it to
+ * "Untitled" because a lookup missed would be worse than leaving it alone.
+ */
+export function resolveEditedDescription(
+  input: string,
+  current: string,
+  fallback?: string
+): string {
+  return clampDescription(input) || fallback || current;
+}
+
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 
 /** Confirmation text for a reminder that was just set.

--- a/apps/web/src/lib/queries/reminders/reminders.test.ts
+++ b/apps/web/src/lib/queries/reminders/reminders.test.ts
@@ -1,6 +1,11 @@
 import type { EntityData } from '@entity';
+import type { Reminder } from '@service-storage/generated/schemas/reminder';
 import { describe, expect, it } from 'vitest';
-import { reminderEntityType, reminderTarget } from './reminders';
+import {
+  reminderEntityType,
+  reminderSoupPatch,
+  reminderTarget,
+} from './reminders';
 
 const entity = (type: EntityData['type'], id = 'e1') =>
   ({ type, id, name: 'Thing' }) as EntityData;
@@ -53,5 +58,62 @@ describe('reminderTarget', () => {
   it('is undefined for types with no reminder target', () => {
     expect(reminderTarget(entity('channel_message'))).toBeUndefined();
     expect(reminderTarget(entity('automation'))).toBeUndefined();
+  });
+});
+
+describe('reminderSoupPatch', () => {
+  const reminder = (overrides: Partial<Reminder> = {}) =>
+    ({
+      id: 'rem-1',
+      description: 'Chase the contract',
+      schedule: { type: 'once', remindAt: '2026-08-20T09:00:00.000Z' },
+      nextRunAt: '2026-08-20T09:00:00.000Z',
+      enabled: true,
+      createdAt: '2026-08-01T09:00:00.000Z',
+      updatedAt: '2026-08-11T09:00:00.000Z',
+      ...overrides,
+    }) as Reminder;
+
+  // Soup rows come from the normalized soup cache, not the reminders queries,
+  // so without this an edited row keeps its old text until a reload.
+  it('projects the edited fields onto the soup row', () => {
+    const patch = reminderSoupPatch(reminder({ description: 'Follow up' }), 0);
+
+    expect(patch.tag).toBe('reminder');
+    expect(patch.data).toMatchObject({
+      id: 'rem-1',
+      description: 'Follow up',
+      nextRunAt: '2026-08-20T09:00:00.000Z',
+      schedule: { type: 'once', remindAt: '2026-08-20T09:00:00.000Z' },
+    });
+  });
+
+  // The cache merges field by field, so an omitted key would leave a stale
+  // completedAt behind and keep a rescheduled reminder filed under Done.
+  it('writes an absent completion as an explicit null', () => {
+    expect(reminderSoupPatch(reminder(), 0).data).toHaveProperty(
+      'completedAt',
+      null
+    );
+  });
+
+  it('keeps a completion that is still set', () => {
+    const patch = reminderSoupPatch(
+      reminder({ completedAt: '2026-08-10T09:00:00.000Z' }),
+      0
+    );
+
+    expect(patch.data).toHaveProperty(
+      'completedAt',
+      '2026-08-10T09:00:00.000Z'
+    );
+  });
+
+  it("preserves the row's existing frecency score", () => {
+    expect(reminderSoupPatch(reminder(), 42).frecency_score).toBe(42);
+  });
+
+  it('defaults the frecency score for a row not in the cache', () => {
+    expect(reminderSoupPatch(reminder(), undefined).frecency_score).toBe(0);
   });
 });

--- a/apps/web/src/lib/queries/reminders/reminders.ts
+++ b/apps/web/src/lib/queries/reminders/reminders.ts
@@ -212,7 +212,49 @@ type UpdateReminderCallbacks = MutationCallbacks<
   UpdateReminderArgs
 >;
 
-/** Modify a reminder's description, schedule, or enabled flag. */
+/**
+ * The Soup-cache patch that brings a row in line with `reminder`.
+ *
+ * Only the shape lives here — applying it does not. Soup's cache module reaches
+ * back into `queryClient`, so importing it from `lib/queries` closes an
+ * initialization cycle; every soup write in the app is made from `features/`
+ * for that reason. See `ReminderComposerModal`, which performs this one.
+ *
+ * `existingFrecencyScore` is the row's current score, or undefined when it is
+ * not in the cache.
+ */
+export function reminderSoupPatch(
+  reminder: Reminder,
+  existingFrecencyScore: number | undefined
+) {
+  return {
+    tag: 'reminder' as const,
+    data: {
+      id: reminder.id,
+      description: reminder.description,
+      schedule: reminder.schedule,
+      // Drives both the row's "next run" and which tab it belongs to: Active
+      // and Scheduled split on whether this has passed.
+      nextRunAt: reminder.nextRunAt,
+      enabled: reminder.enabled,
+      // Explicitly null rather than omitted. The cache merges field by field,
+      // so leaving the key out would keep a stale `completedAt` — and a
+      // rescheduled reminder that cleared it would stay filed under Done.
+      completedAt: reminder.completedAt ?? null,
+      updatedAt: reminder.updatedAt,
+    },
+    frecency_score: existingFrecencyScore ?? 0,
+  };
+}
+
+/**
+ * Modify a reminder's description, schedule, or enabled flag.
+ *
+ * Invalidating these queries is not enough to refresh a Soup row — Soup serves
+ * rows from its own normalized cache. Callers that render into Soup should pass
+ * an `onSuccess` that applies {@link reminderSoupPatch}, or the edit will not
+ * show until a reload.
+ */
 export function useUpdateReminderMutation(callbacks?: UpdateReminderCallbacks) {
   return useMutation(() => ({
     mutationFn: async ({ id, patch }: UpdateReminderArgs) =>


### PR DESCRIPTION
A reminder was write-once from the UI. The `PATCH /reminders/{id}` endpoint has been there since the reminders API landed, but nothing reached it — a reminder's name is its description, which the entity-mutation rename path explicitly refuses, and no surface offered its schedule. A typo or a bad time meant deleting and re-creating.

## What this adds

The composer gains an edit mode over the same two steps it already asks, prefilled from the row:

- **Description** — starts from what the reminder says. Unlike creating, it cannot be left blank: the field was populated, so an empty one is a deletion rather than the create flow's "skip and derive from the entity".
- **When** — the same date list, led by **Keep current time**. A rename is one Enter; changing the time is picking any other option, or typing (`3d`, `tomorrow 3pm`) as before.

Reachable from a reminder row in Soup, on the entity actions menu (**Edit reminder**) and on `r`.

## Notes on the details

**`r` is shared with Rename.** The two are mutually exclusive — a reminder row never offers Rename, since its `ownerId` is empty and `getEntityRenameData` refuses reminders outright — so sharing the key puts the edit where the muscle memory is instead of leaving `r` dead on a reminder.

**Only changed fields are sent.** An unchanged schedule is omitted rather than re-sent: re-sending the time of a reminder that has already fired would be rejected for being in the past, so omitting it is what keeps an overdue reminder renamable. "Keep current time" is likewise the one option exempt from the future filter. An unchanged everything sends no request — the API rejects a patch with no fields.

**Rescheduling a done reminder clears the flag.** `due_firings` skips completed reminders, so giving one a new time without also sending `completed: false` would look like it worked and then silently never arrive. A description-only edit leaves the flag alone — renaming something you finished is not a request for it to happen again.

**Recurring reminders are excluded.** The composer only speaks one-shot schedules, so editing one through it would quietly collapse a cron into a single firing. Nothing in the product creates a recurring reminder today, so this excludes nothing a user can reach.

`CreateReminderModal` is renamed to `ReminderComposerModal` now that it does both.