### PR TITLE
fix(soup): use google source kind in calendar grouping test

### DIFF
--- a/crates/soup/src/outbound/pg_soup_repo/grouping/test.rs
+++ b/crates/soup/src/outbound/pg_soup_repo/grouping/test.rs
@@ -338,7 +338,7 @@ async fn tagged_calendar_event_participates_in_grouped_property_soup(
         )
         VALUES (
             $1, $2, $3, 'grouped@example.com', 'Grouped calendar event',
-            '2026-07-24T14:00:00Z', '2026-07-24T15:00:00Z', 'email_ics',
+            '2026-07-24T14:00:00Z', '2026-07-24T15:00:00Z', 'google',
             '2026-07-24T12:00:00Z'
         )
         "#,


### PR DESCRIPTION
Follow-up to #5506 — **main is still red**.

#5483 restricted `calendar_events.canonical_source_kind` to `'google'`. Two
soup tests still inserted `'email_ics'`; nextest cancels the run on the first
failure, so #5506 only surfaced the first one. This is the second:

```
FAIL soup::outbound::pg_soup_repo::grouping::test::tagged_calendar_event_participates_in_grouped_property_soup
```

`grep` confirms this is the **last** `email_ics` reference outside migrations
and `.sqlx`, so this should fully unblock main.

Same reasoning as #5506: the source kind is incidental to what the test covers
(a tagged calendar event participating in grouped property soup), `'google'` is
the only permitted value, and no `.sqlx` regeneration is needed — the offline
`check` job runs `cargo clippy --workspace --all-features` without
`--all-targets`/`--tests`, so test-only queries never compile offline.

cc @gbirman