### PR TITLE
fix(soup): exclude the calendar arm from grouped queries when its filter is impossible

### DIFF
--- a/crates/soup/src/outbound/pg_soup_repo/expanded/dynamic.rs
+++ b/crates/soup/src/outbound/pg_soup_repo/expanded/dynamic.rs
@@ -8,6 +8,7 @@ use document_sub_type::DocumentSubType;
 use filter_ast::Expr;
 use item_filters::ast::{
     EntityFilterAst,
+    calendar_event::CalendarEventLiteral,
     chat::ChatLiteral,
     date::DateLiteral,
     document::DocumentLiteral,
@@ -1012,6 +1013,18 @@ fn project_filter_is_impossible(ast: Option<&Expr<ProjectLiteral>>) -> bool {
     })
 }
 
+fn calendar_event_filter_is_impossible(ast: Option<&Expr<CalendarEventLiteral>>) -> bool {
+    ast.is_some_and(|expr| {
+        expr.collapse_frames(|frame| match frame {
+            filter_ast::ExprFrame::And(a, b) => a || b,
+            filter_ast::ExprFrame::Or(a, b) => a && b,
+            filter_ast::ExprFrame::Not(_) => false,
+            filter_ast::ExprFrame::Literal(CalendarEventLiteral::Id(id)) => id.is_nil(),
+            filter_ast::ExprFrame::Literal(_) => false,
+        })
+    })
+}
+
 fn push_union_separator(builder: &mut QueryBuilder<'_, Postgres>, needs_separator: &mut bool) {
     if *needs_separator {
         builder.push(" UNION ALL ");
@@ -1817,10 +1830,15 @@ fn build_grouped_query<'a>(
             filter_ast.properties_filter.as_deref(),
             &[PropertyEntityType::Project],
         );
-    let include_calendar_events = properties_filter_can_apply_to(
-        filter_ast.properties_filter.as_deref(),
-        &[PropertyEntityType::CalendarEvent],
-    );
+    // Gated like the other three legs. Beyond skipping a union branch that can
+    // never match, this keeps the NIL-id exclusion every Soup query now sends
+    // from reaching `push_filter` below — see the bind-numbering note there.
+    let include_calendar_events =
+        !calendar_event_filter_is_impossible(filter_ast.calendar_event_filter.as_deref())
+            && properties_filter_can_apply_to(
+                filter_ast.properties_filter.as_deref(),
+                &[PropertyEntityType::CalendarEvent],
+            );
 
     push_accessible_items_cte(
         &mut builder,
@@ -1874,6 +1892,14 @@ fn build_grouped_query<'a>(
     if include_calendar_events {
         push_union_separator(&mut builder, &mut needs_separator);
         builder.push(GROUPED_CALENDAR_EVENT_TOP_CLAUSE);
+        // FIXME: `push_filter` uses `push_bind`, whose placeholders come from
+        // the builder's own counter starting at $1 — but this query numbers its
+        // parameters by hand ($1..$10) and binds them positionally. The first
+        // bind pushed here therefore collides with $1 (the user id), and
+        // Postgres rejects the statement with `operator does not exist: text =
+        // uuid`. Only reachable now with a calendar filter that survives
+        // `calendar_event_filter_is_impossible`; a grouped view that grows a
+        // real calendar filter needs this rendered at $11+ instead.
         if let Some(filter) = filter_ast.calendar_event_filter.as_deref() {
             builder.push(" AND (");
             super::super::calendar_event::push_filter(&mut builder, filter);

--- a/crates/soup/src/outbound/pg_soup_repo/grouping/test.rs
+++ b/crates/soup/src/outbound/pg_soup_repo/grouping/test.rs
@@ -3,7 +3,10 @@ use crate::outbound::pg_soup_repo::expanded::dynamic::{
     GroupedDynamicCursorArgs, expanded_dynamic_cursor_soup_grouped,
 };
 use filter_ast::Expr;
-use item_filters::ast::{EntityFilterAst, chat::ChatLiteral, document::DocumentLiteral};
+use item_filters::ast::{
+    EntityFilterAst, calendar_event::CalendarEventLiteral, chat::ChatLiteral,
+    document::DocumentLiteral,
+};
 use macro_db_migrator::MACRO_DB_MIGRATIONS;
 use macro_user_id::{cowlike::CowLike, user_id::MacroUserIdStr};
 use models_grouping::date_bucket_sql_key;
@@ -487,6 +490,52 @@ async fn grouped_soup_runs_when_document_arm_excluded(pool: Pool<Postgres>) -> a
     assert!(
         items.iter().all(|item| item.key != "document"),
         "documents must be filtered out"
+    );
+
+    Ok(())
+}
+
+/// Every Soup query sends a NIL calendar id to scope calendar events out. The
+/// calendar arm was the one leg with no impossible-filter gate, so it stayed in
+/// the union and pushed its id through `push_bind` — whose $1 collided with the
+/// hand-numbered user id, failing with "operator does not exist: text = uuid".
+#[sqlx::test(
+    fixtures(
+        path = "../../../../../macro_db_client/fixtures",
+        scripts("mixed_items_expanded")
+    ),
+    migrator = "MACRO_DB_MIGRATIONS"
+)]
+async fn grouped_soup_runs_when_calendar_arm_excluded(pool: Pool<Postgres>) -> anyhow::Result<()> {
+    let user_id = MacroUserIdStr::parse_from_str("macro|user-1@test.com").unwrap();
+    let filter = EntityFilterAst {
+        calendar_event_filter: Some(Arc::new(Expr::val(CalendarEventLiteral::Id(
+            uuid::Uuid::nil(),
+        )))),
+        ..EntityFilterAst::mock_empty()
+    };
+
+    let items = expanded_dynamic_cursor_soup_grouped(
+        &pool,
+        GroupedDynamicCursorArgs {
+            user_id: user_id.copied(),
+            limit: 50,
+            cursor: Query::Sort(SimpleSortMethod::ViewedUpdated, filter),
+            exclude_frecency: false,
+            grouping: GroupingConfig {
+                field: GroupByField::EntityType,
+                group_key: None,
+                per_group_limit: None,
+            },
+        },
+    )
+    .await?
+    .collect::<Vec<_>>();
+
+    assert!(!items.is_empty(), "documents and chats should remain");
+    assert!(
+        items.iter().all(|item| item.key != "calendar_event"),
+        "calendar events must be filtered out"
     );
 
     Ok(())


### PR DESCRIPTION
Every grouped Soup view — Tasks and Customers — currently 500s on `POST /items/soup/ast/grouped`.

## Cause

#5505 added a NIL calendar id to `QUERY_FILTERS_BASE` so calendar events stay scoped out, which means **every** Soup query now sends `calf: {l: {id: NIL_UUID}}`.

The grouped builder was the one leg with no impossible-filter gate — `document_filter_is_impossible`, `chat_filter_is_impossible` and `project_filter_is_impossible` all exist, calendar had no counterpart. So the arm stayed in the union and reached `calendar_event::push_filter`.

That filter uses `push_bind`. `dynamic.rs` contains no other `push_bind` call — it writes `$1`..`$10` by hand and binds them positionally (`.bind(user_id)`, `.bind(sort_method)`, …). `QueryBuilder`'s own placeholder counter starts at 1 regardless, so the calendar id emitted `event.id = $1`, colliding with the user id. Postgres saw `$1` used as both uuid and text and rejected the statement:

```
ERROR: operator does not exist: text = uuid at character 144
```

Character 144 is `WHERE cp.user_id = $1`.

Non-grouped views are unaffected: they run calendar events as a separate standalone query whose builder owns all its binds, so nothing collides. That's why Files and Mail kept loading while Tasks broke.

## Change

Adds `calendar_event_filter_is_impossible`, mirroring the three that already exist, and gates `include_calendar_events` on it. The NIL exclusion now drops the arm instead of reaching `push_filter`.

The bind-numbering hazard itself is documented at the call site rather than fixed. Doing it properly means rendering the filter at `$11+` the way `entity_type_bind` already does for `$10`, which is a wider change than this regression warrants — and no grouped view carries a real calendar filter today, so it is unreachable.

## Note

`grouped_soup_runs_when_calendar_arm_excluded` is added alongside the two existing arm-exclusion regression tests, but I could not execute it locally — the local Postgres was down and `macrodb` had not been recreated. `cargo check -p soup --tests`, `cargo fmt --check` and clippy are all clean. Relying on CI to run it.