### PR TITLE
fix(ui): render "then" separator between hotkey tokens and shortcuts in Tooltip

### DIFF
--- a/apps/web/src/components/ui/components/Tooltip.tsx
+++ b/apps/web/src/components/ui/components/Tooltip.tsx
@@ -129,7 +129,12 @@ export function Tooltip(props: TooltipProps) {
                       {(token, ndx) => (
                         <>
                           <Hotkey token={token} theme="subtle" />
-                          <Show when={ndx() < tokens().length - 1}>
+                          <Show
+                            when={
+                              ndx() < tokens().length - 1 ||
+                              shortcuts().length > 0
+                            }
+                          >
                             <span class="text-ink-extra-muted">then</span>
                           </Show>
                         </>


### PR DESCRIPTION
Closes #5338

## Summary

In `apps/web/src/components/ui/components/Tooltip.tsx`, when a Tooltip renders both a `hotkey` token list and a custom `shortcut` list, the `"then"` separator was missing between the last hotkey token and the first shortcut.

The separator guard only checked `ndx() < tokens().length - 1`, which is `false` on the last token, so nothing was rendered before the first shortcut item.

## Fix

The `"then"` separator now also renders when there are remaining shortcut items:

```tsx
<Show when={ndx() < tokens().length - 1 || shortcuts().length > 0}>
```

Multi-step sequences like `cmd+k then <shortcut>` now render `"then"` correctly across the hotkey/shortcut boundary.

## Verification

- `bun run check` (type-check + biome) passes in `apps/web`.