### PR TITLE
fix: skip group-by labels in soup arrow/j/k navigation

### DIFF
--- a/apps/web/src/components/app/split-layout/components/SplitHeader.tsx
+++ b/apps/web/src/components/app/split-layout/components/SplitHeader.tsx
@@ -255,7 +255,7 @@ function SoupNavigationButtons() {
   });
 
   const navigate = (offset: number) => {
-    const next = soup.navigate.by(offset);
+    const next = soup.navigate.by(offset, { skipGroupHeaders: true });
     if (!next) return;
 
     void openEntityInSplitFromUnifiedList(next.row.original, {

--- a/apps/web/src/features/next-soup/create-soup-state.test.ts
+++ b/apps/web/src/features/next-soup/create-soup-state.test.ts
@@ -421,6 +421,45 @@ describe('createSoupState', () => {
       });
     });
 
+    it('should skip group headers when skipGroupHeaders is enabled', () => {
+      createRoot((dispose) => {
+        const state = createSoupState();
+        const groupA = createTestGroup('a', 2);
+        const groupB = createTestGroup('b', 1);
+        const a1 = createTestEntity('a1');
+        const a2 = createTestEntity('a2');
+        const b1 = createTestEntity('b1');
+
+        state.setRows([
+          buildTestRow(state, a1, 0, groupA, 'header'),
+          buildTestRow(state, a1, 1, groupA),
+          buildTestRow(state, a2, 2, groupA),
+          buildTestRow(state, b1, 3, groupB, 'header'),
+          buildTestRow(state, b1, 4, groupB),
+        ]);
+
+        // With no focus, down lands on the first entity, not the leading header
+        const first = state.navigate.down({ skipGroupHeaders: true });
+        expect(first?.row.id).toBe('a1');
+
+        state.focus.set('a2');
+
+        // Crossing a group boundary steps over its header
+        const crossed = state.navigate.down({ skipGroupHeaders: true });
+        expect(crossed?.row.id).toBe('b1');
+
+        const back = state.navigate.up({ skipGroupHeaders: true });
+        expect(back?.row.id).toBe('a2');
+
+        // Peeking honors the option without moving focus
+        const peeked = state.navigate.peekOffset(1, { skipGroupHeaders: true });
+        expect(peeked?.row.id).toBe('b1');
+        expect(state.focus.id()).toBe('a2');
+
+        dispose();
+      });
+    });
+
     it('should navigate to first', () => {
       createRoot((dispose) => {
         const entities = [createTestEntity('1'), createTestEntity('2')];

--- a/apps/web/src/features/next-soup/soup-view/use-soup-navigation-hotkeys.test.ts
+++ b/apps/web/src/features/next-soup/soup-view/use-soup-navigation-hotkeys.test.ts
@@ -1,0 +1,216 @@
+import { createRoot } from 'solid-js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@app/features/next-soup/filters/configs/', () => ({
+  SOUP_FILTERS: [],
+}));
+
+vi.mock('@app/features/next-soup/soup-view/sort-options', () => ({
+  SORT_CONFIGS: {
+    updated_at: {
+      id: 'updated_at',
+      fn: (a: { updatedAt?: number }, b: { updatedAt?: number }) =>
+        (b.updatedAt ?? 0) - (a.updatedAt ?? 0),
+    },
+  },
+}));
+
+vi.mock('@core/mobile/inputModality', () => ({
+  isModality: vi.fn(() => false),
+}));
+
+vi.mock('@app/features/next-soup/utils', () => ({
+  isDuplicatePreviewEntityOpen: vi.fn(() => false),
+  notifyDuplicateContentOpen: vi.fn(),
+  openEntityInSplitFromUnifiedList: vi.fn(),
+}));
+
+vi.mock('@app/signal/splitLayout', () => ({
+  globalSplitManager: () => undefined,
+}));
+
+vi.mock('@core/hotkey/hotkeys', () => {
+  const registration = {
+    dispose: vi.fn(),
+    hotkey: () => undefined,
+    withGroup: vi.fn(),
+  };
+  return {
+    registerHotkey: vi.fn(() => registration),
+    createHotkeyGroup: vi.fn(() => ({ add: vi.fn(), dispose: vi.fn() })),
+  };
+});
+
+vi.mock('@core/hotkey/tokens', () => ({
+  TOKENS: {
+    entity: {
+      step: { start: 'entity.step.start', end: 'entity.step.end' },
+      select: { start: 'entity.select.start', end: 'entity.select.end' },
+    },
+    unifiedList: {
+      navigation: {
+        parent: 'unifiedList.navigation.parent',
+        child: 'unifiedList.navigation.child',
+      },
+    },
+  },
+}));
+
+import type { SplitHandle } from '@components/app/split-layout/layoutManager';
+import { registerHotkey } from '@core/hotkey/hotkeys';
+import type { ValidHotkey } from '@core/hotkey/types';
+import type { EntityData } from '@entity';
+import {
+  createSoupState,
+  type GroupMeta,
+  type SoupState,
+} from '../create-soup-state';
+import { useSoupNavigationHotkeys } from './use-soup-navigation-hotkeys';
+
+const createTestEntity = (id: string): EntityData => ({
+  id,
+  type: 'document',
+  name: `Entity ${id}`,
+  ownerId: 'test-owner',
+  updatedAt: new Date(),
+});
+
+const createTestGroup = (key: string, count: number): GroupMeta => ({
+  key,
+  label: key,
+  value: key,
+  count,
+  isExpanded: () => true,
+  toggle: () => {},
+});
+
+/** headerA, a1, a2, headerB, b1, b2 */
+const setGroupedRows = (soup: SoupState) => {
+  const groupA = createTestGroup('a', 2);
+  const groupB = createTestGroup('b', 2);
+  const [a1, a2, b1, b2] = ['a1', 'a2', 'b1', 'b2'].map(createTestEntity);
+
+  soup.setRows([
+    soup.buildRow({
+      id: 'header:a',
+      index: 0,
+      original: a1,
+      group: groupA,
+      isGrouped: true,
+    }),
+    soup.buildRow({ id: 'a1', index: 1, original: a1, group: groupA }),
+    soup.buildRow({ id: 'a2', index: 2, original: a2, group: groupA }),
+    soup.buildRow({
+      id: 'header:b',
+      index: 3,
+      original: b1,
+      group: groupB,
+      isGrouped: true,
+    }),
+    soup.buildRow({ id: 'b1', index: 4, original: b1, group: groupB }),
+    soup.buildRow({ id: 'b2', index: 5, original: b2, group: groupB }),
+  ]);
+};
+
+const createSplitHandleStub = () =>
+  ({
+    id: 'split-test',
+    content: () => ({ type: 'component', id: 'tasks' }),
+    referredFrom: () => undefined,
+    isControllerSplit: () => false,
+    viewerId: () => undefined,
+  }) as unknown as SplitHandle;
+
+const handlerFor = (key: ValidHotkey) => {
+  const call = vi
+    .mocked(registerHotkey)
+    .mock.calls.find(([options]) =>
+      Array.isArray(options.hotkey)
+        ? options.hotkey.includes(key)
+        : options.hotkey === key
+    );
+  const handler = call?.[0].keyDownHandler;
+  expect(handler).toBeDefined();
+  return handler!;
+};
+
+const setupHotkeys = () =>
+  createRoot((dispose) => {
+    const soup = createSoupState();
+    setGroupedRows(soup);
+    useSoupNavigationHotkeys({
+      scopeId: 'test-scope',
+      soup,
+      splitHandle: createSplitHandleStub(),
+      virtualizerHandle: () => undefined,
+    });
+    return { soup, dispose };
+  });
+
+describe('useSoupNavigationHotkeys', () => {
+  beforeEach(() => {
+    vi.mocked(registerHotkey).mockClear();
+  });
+
+  it('j and k step through entities without focusing group headers', () => {
+    const { soup, dispose } = setupHotkeys();
+    const down = handlerFor('j');
+    const up = handlerFor('k');
+
+    // First press lands on the first entity, not the leading header
+    down();
+    expect(soup.focus.id()).toBe('a1');
+
+    down();
+    expect(soup.focus.id()).toBe('a2');
+
+    // Crossing the group boundary skips header:b
+    down();
+    expect(soup.focus.id()).toBe('b1');
+
+    up();
+    expect(soup.focus.id()).toBe('a2');
+
+    dispose();
+  });
+
+  it('arrow keys share the header-skipping navigation', () => {
+    const { soup, dispose } = setupHotkeys();
+    soup.focus.set('a2');
+
+    handlerFor('arrowdown')();
+    expect(soup.focus.id()).toBe('b1');
+
+    handlerFor('arrowup')();
+    expect(soup.focus.id()).toBe('a2');
+
+    dispose();
+  });
+
+  it('k from no focus starts at the last entity', () => {
+    const { soup, dispose } = setupHotkeys();
+
+    handlerFor('k')();
+    expect(soup.focus.id()).toBe('b2');
+
+    dispose();
+  });
+
+  it('shift+j selects across a group boundary without touching the header', () => {
+    const { soup, dispose } = setupHotkeys();
+    const selectDown = handlerFor('shift+j');
+    soup.focus.set('a2');
+
+    // First press anchors the selection on the focused entity
+    selectDown();
+    expect(soup.selection.selectedIds()).toEqual(new Set(['a2']));
+    expect(soup.focus.id()).toBe('a2');
+
+    // Second press steps over header:b straight onto b1
+    selectDown();
+    expect(soup.focus.id()).toBe('b1');
+    expect(soup.selection.selectedIds()).toEqual(new Set(['a2', 'b1']));
+
+    dispose();
+  });
+});

--- a/apps/web/src/features/next-soup/soup-view/use-soup-navigation-hotkeys.ts
+++ b/apps/web/src/features/next-soup/soup-view/use-soup-navigation-hotkeys.ts
@@ -87,9 +87,12 @@ export const useSoupNavigationHotkeys = (
     });
   };
 
+  // Group labels are structural rows — stepping with j/k or the arrow keys
+  // moves through entities only and never focuses a header.
   const navigateToOpenableEntity = (offset: -1 | 1) => {
     let skippedDuplicate = false;
     const next = soup.navigate.by(offset, {
+      skipGroupHeaders: true,
       skip: (row) => {
         if (
           !splitHandle.isControllerSplit() ||
@@ -149,7 +152,7 @@ export const useSoupNavigationHotkeys = (
   });
 
   const navigateAndSelectEntity = (offset: number) => {
-    const nextRow = soup.navigate.by(offset);
+    const nextRow = soup.navigate.by(offset, { skipGroupHeaders: true });
     if (!nextRow) return true;
     soup.selection.select(nextRow.row.original);
     scrollTo(nextRow.index);
@@ -158,7 +161,7 @@ export const useSoupNavigationHotkeys = (
 
   const handleNavigationSelection = (offset: number) => {
     const focusedEntity = soup.focus.item();
-    const next = soup.navigate.peekOffset(offset);
+    const next = soup.navigate.peekOffset(offset, { skipGroupHeaders: true });
 
     const selection = soup.selection;
 
@@ -190,7 +193,7 @@ export const useSoupNavigationHotkeys = (
 
     if (selection.isSelected(nextEntity.id)) {
       selection.toggle(focusedEntity);
-      soup.navigate.by(offset);
+      soup.navigate.by(offset, { skipGroupHeaders: true });
       scrollTo(next.index);
       return true;
     }


### PR DESCRIPTION
In group-by soup views, `j`/`k` and the arrow keys stepped onto group header rows, highlighting the label and costing an extra keypress at every group boundary (with the shift+select variants getting stuck on headers entirely).

Fixes this by passing the existing `skipGroupHeaders` navigation option at the keyboard call sites in `use-soup-navigation-hotkeys.ts` (`j`/`k`, arrows, shift+select) and in the preview header's prev/next buttons (`SplitHeader.tsx`), which drive the same list navigation. Group headers stay reachable through direct targeting: `h` from a child row still collapses the group and focuses its header, and `enter`/`l` on a focused header still toggle it.

Adds a `createSoupState` unit test for the `skipGroupHeaders` option and a new `use-soup-navigation-hotkeys` test covering `j`/`k`, arrows, and shift+`j` skipping headers.

Session: https://claude.ai/code/cse_01YYCTGhVJbvS4shPnGXG8K5

---
_Generated by [Claude Code](https://claude.ai/code/session_01YYCTGhVJbvS4shPnGXG8K5)_