### PR TITLE
fix: align mobile create and views menus to the same order

### DIFF
--- a/apps/web/src/components/app/mobile/MobileDock.tsx
+++ b/apps/web/src/components/app/mobile/MobileDock.tsx
@@ -2,6 +2,7 @@ import type { ListView } from '@app/constants/list-views';
 import { useCalendarUiFlag } from '@app/features/calendar/use-calendar-ui-flag';
 import {
   CREATABLE_BLOCKS,
+  type CreatableBlock,
   runCreateAction,
 } from '@app/features/command/Launcher';
 import { SearchState } from '@app/features/command/mobile/mobileSearchState';
@@ -114,22 +115,25 @@ function MoreViewsMenu(props: {
   const { settingsOpen, toggleSettings } = useSettingsState();
   const calendarUiEnabled = useCalendarUiFlag();
 
+  // Rows render top → bottom, ending at the thumb, so bottom → top this reads
+  // Inbox, Email, Channels, Documents, Tasks, Agents, Calls, Folders — keep
+  // that order in sync with the Create menu's matching entries.
   const moreViews = (): Array<{
     id: DockId;
     label: string;
     icon: MobileTouchIconComponent;
   }> => [
-    { id: 'inbox', label: 'Inbox', icon: AnimatedInboxIcon },
+    { id: 'folders', label: 'Folders', icon: AnimatedFolderIcon },
+    { id: 'calls', label: 'Calls', icon: AnimatedCallIcon },
     { id: 'agents', label: 'Agents', icon: AnimatedStarIcon },
-    { id: 'mail', label: 'Email', icon: AnimatedEmailIcon },
-    { id: 'documents', label: 'Documents', icon: AnimatedFileMdIcon },
     { id: 'tasks', label: 'Tasks', icon: AnimatedTaskIcon },
     ...(calendarUiEnabled()
       ? [{ id: 'calendar' as const, label: 'Calendar', icon: WideCalendarIcon }]
       : []),
+    { id: 'documents', label: 'Documents', icon: AnimatedFileMdIcon },
     { id: 'channels', label: 'Channels', icon: AnimatedChannelIcon },
-    { id: 'calls', label: 'Calls', icon: AnimatedCallIcon },
-    { id: 'folders', label: 'Folders', icon: AnimatedFolderIcon },
+    { id: 'mail', label: 'Email', icon: AnimatedEmailIcon },
+    { id: 'inbox', label: 'Inbox', icon: AnimatedInboxIcon },
   ];
 
   return (
@@ -158,6 +162,24 @@ function MoreViewsMenu(props: {
   );
 }
 
+// Rows render top → bottom, ending at the thumb, so bottom → top this reads
+// Email, Message, Doc, Task, Agent, Folder, Code, Canvas, Snippet — keep the
+// entries both menus share in sync with the Views menu order. Each name
+// resolves to its first CREATABLE_BLOCKS match, which drops the
+// desktop-only 'Channel' entry: it shares the 'channel' blockName with
+// 'Message', so on mobile both would run the same create action.
+const CREATE_MENU_BLOCK_ORDER: CreatableBlock['blockName'][] = [
+  'snippet',
+  'canvas',
+  'code',
+  'project',
+  'chat',
+  'task',
+  'md',
+  'channel',
+  'email',
+];
+
 function CreateMenu() {
   const snippetsFlag = useFeatureFlag(ENABLE_SNIPPETS_FLAG, {
     enabledOverride: ENABLE_SNIPPETS_OVERRIDE,
@@ -165,9 +187,12 @@ function CreateMenu() {
   const handleFileUpload = useHandleFileUpload();
 
   const blocks = () =>
-    CREATABLE_BLOCKS.filter(
-      (block) => block.blockName !== 'snippet' || snippetsFlag().enabled
-    ).toReversed();
+    CREATE_MENU_BLOCK_ORDER.filter(
+      (blockName) => blockName !== 'snippet' || snippetsFlag().enabled
+    ).flatMap((blockName) => {
+      const block = CREATABLE_BLOCKS.find((b) => b.blockName === blockName);
+      return block ? [block] : [];
+    });
 
   const uploadItem: MobileTouchMenuItem = {
     id: 'upload-file',


### PR DESCRIPTION
On mobile, the dock's Create menu and Views menu listed entries in unrelated orders, and the Create menu showed both a "Message" and a "Channel" row that ran the identical create action on mobile (both share the `channel` blockName — the new-channel modal behavior of "Channel" is desktop-only).

Reorders both `MobileDock` menus so they read the same way bottom-to-top (thumb-first):
- **Views:** Inbox, Email, Channels, Documents, Tasks, Agents, Calls, Folders — Calendar stays flag-gated next to Tasks, Settings stays pinned at the top
- **Create:** Email, Message, Doc, Task, Agent, Folder, Code, Canvas, Snippet — Upload file stays pinned at the top

The Create menu now resolves an explicit mobile order list against `CREATABLE_BLOCKS`, taking the first match per block name, which drops the duplicate "Channel" row. Desktop create surfaces are unchanged.

Session: https://claude.ai/code/cse_01VM2Uhc23eiR6rQbgSo6Ewt

---
_Generated by [Claude Code](https://claude.ai/code/session_01VM2Uhc23eiR6rQbgSo6Ewt)_