### PR TITLE
fix(ci): restore desktop Nix builds

### DIFF
--- a/.github/workflows/check_node_modules_nix.yml
+++ b/.github/workflows/check_node_modules_nix.yml
@@ -39,7 +39,12 @@ jobs:
     - name: Setup Nix
       uses: './.github/actions/setup-nix'
     - name: verify js node_modules derivation is up to date
-      run: nix build .#js-node-modules --no-link
+      run: |
+        # The first build ensures the output exists. The rebuild then forces Nix
+        # to validate it instead of accepting a cached fixed-output derivation
+        # whose hash predates a bun.lock or package manifest change.
+        nix build .#js-node-modules --no-link
+        nix build .#js-node-modules --no-link --rebuild
     - name: Teardown Nix
       if: always()
       uses: './.github/actions/teardown-nix'
@@ -78,4 +83,9 @@ jobs:
         nix --version
       shell: bash
     - name: verify js node_modules derivation is up to date
-      run: nix build .#js-node-modules --no-link
+      run: |
+        # The first build ensures the output exists. The rebuild then forces Nix
+        # to validate it instead of accepting a cached fixed-output derivation
+        # whose hash predates a bun.lock or package manifest change.
+        nix build .#js-node-modules --no-link
+        nix build .#js-node-modules --no-link --rebuild

--- a/justfile
+++ b/justfile
@@ -72,6 +72,7 @@ update-node-modules-hash:
 # Verify the fixed-output js node_modules derivation matches bun.lock.
 check-node-modules-nix:
   nix build .#js-node-modules --no-link
+  nix build .#js-node-modules --no-link --rebuild
 
 # Patches .env with local FusionAuth values if the Pulumi stack exists.
 # Requires FusionAuth to be running — starts it temporarily if needed.

--- a/nix/tauri-desktop.nix
+++ b/nix/tauri-desktop.nix
@@ -67,7 +67,8 @@
         cargoVendorDir = rootCargoVendorDir;
         nativeBuildInputs = [
           pkgs.binaryen
-          pkgs.wasm-bindgen-cli
+          # wasm-pack requires the CLI version to exactly match Cargo.lock.
+          pkgs.wasm-bindgen-cli_0_2_126
           pkgs.wasm-pack
         ];
         doCheck = false;

--- a/tooling/scripts/update-node-modules-hash.sh
+++ b/tooling/scripts/update-node-modules-hash.sh
@@ -65,6 +65,12 @@ trap 'rm -f "$log"' EXIT
 set +e
 nix build .#js-node-modules --no-link 2>&1 | tee "$log"
 status=${PIPESTATUS[0]}
+if [ "$status" -eq 0 ]; then
+  # Fixed-output paths only depend on the declared hash and name. Force a
+  # rebuild so a cached output cannot hide changes to bun.lock or manifests.
+  nix build .#js-node-modules --no-link --rebuild 2>&1 | tee -a "$log"
+  status=${PIPESTATUS[0]}
+fi
 set -e
 
 if [ "$status" -eq 0 ]; then

--- a/tooling/xtask/crates/xtask_workflows/src/workflows/check_node_modules_nix.rs
+++ b/tooling/xtask/crates/xtask_workflows/src/workflows/check_node_modules_nix.rs
@@ -86,6 +86,11 @@ fn install_nix_macos() -> Step<gh_workflow::Run> {
 }
 
 fn verify_node_modules_nix() -> Step<gh_workflow::Run> {
-    Step::new("verify js node_modules derivation is up to date")
-        .run("nix build .#js-node-modules --no-link")
+    Step::new("verify js node_modules derivation is up to date").run(indoc::indoc! {r#"
+        # The first build ensures the output exists. The rebuild then forces Nix
+        # to validate it instead of accepting a cached fixed-output derivation
+        # whose hash predates a bun.lock or package manifest change.
+        nix build .#js-node-modules --no-link
+        nix build .#js-node-modules --no-link --rebuild
+    "#})
 }


### PR DESCRIPTION
Fixes an issue where the nix hash could drift though unpinned wasm bindgen, fixing desktop builds in CI