### PR TITLE
fix(ui): restore missing icon on the call block's Call Again button

### DIFF
--- a/apps/web/src/components/ui/components/Button.tsx
+++ b/apps/web/src/components/ui/components/Button.tsx
@@ -72,7 +72,7 @@ const variantStyles: Record<ButtonVariant, string> = {
 
 const sizeStyles: Record<ButtonSize, string> = {
   xs: '          p-1  [&_:where(svg)]:size-3 gap-1   text-xs',
-  'icon-xs': 'size-5   p-2.75  [&_:where(svg)]:size-4                  ',
+  'icon-xs': 'size-5    p-0.5  [&_:where(svg)]:size-4                  ',
   lg: '          p-2.5  [&_:where(svg)]:size-5 gap-2   text-base',
   md: '          p-2                           gap-1.5 text-sm  ' /* scuffed */,
   sm: 'h-6       px-2   [&_:where(svg)]:size-4 gap-1   text-xs  ',


### PR DESCRIPTION
The Call Again button in the call block's split header rendered as an empty square — its phone icon was invisible. The `icon-xs` Button size (used only by this button) styled it `size-5 p-2.75`: 11px padding per side inside a 20px box leaves a zero-width content area, and since inline SVGs default to `overflow: hidden`, the icon flex child was free to shrink to 0 width.

Changes `icon-xs` padding to `p-0.5`, matching `icon-sm`. The button renders at its intended 20×20 with the phone icon visible, with the same 2px icon squeeze as the other icon sizes (verified in Chromium: svg was 0px wide before, 14×16 after).

---
_Generated by [Claude Code](https://claude.ai/code/session_012dTzwW7p7uZPHfWm6cpAQK)_