### PR TITLE
fix(sidebar): show unread channels even when outside the newest 100

### DIFF
--- a/apps/web/src/features/channel/sidebar/channels-recent-widget.tsx
+++ b/apps/web/src/features/channel/sidebar/channels-recent-widget.tsx
@@ -351,11 +351,51 @@ export const ChannelsRecentWidget = (props: {
     return map;
   });
 
+  // A channel can carry unread notifications while being older than the
+  // newest-RECENT_CHANNELS_LIMIT window the main query returns. Fetch those
+  // stragglers by id so an unread channel always makes the list.
+  const missingUnreadChannelIds = createMemo(() => {
+    const entities = channelsQuery.data?.entities;
+    if (!entities) return [];
+    const listed = new Set(
+      entities.filter(isChannelEntity).map((entity) => entity.id)
+    );
+    // Sorted so the derived query key is stable across notification reorders.
+    return [...unreadByChannel().keys()].filter((id) => !listed.has(id)).sort();
+  });
+
+  const missingUnreadChannelsQuery = useSoupAstItemsQuery(
+    () => ({
+      params: { limit: RECENT_CHANNELS_LIMIT, sort_method: 'updated_at' },
+      body: compileToAst(
+        queryStateFrom(
+          defineQueryFilters({
+            include: {
+              channelId: missingUnreadChannelIds(),
+              channelImportance: true,
+              channelIsParticipant: [true],
+            },
+          })
+        )
+      ),
+    }),
+    () => ({
+      enabled: missingUnreadChannelIds().length > 0,
+      staleTime: RECENT_CHANNELS_STALE_MS,
+    })
+  );
+
   const recentChannels = createMemo<RecentChannel[]>(() => {
     const unread = unreadByChannel();
-    const channels = (channelsQuery.data?.entities ?? [])
-      .filter(isChannelEntity)
-      .map((entity) => ({ entity, unread: unread.get(entity.id) ?? [] }));
+    // Only ids still missing may merge in: placeholder rows from a previous id
+    // set must not duplicate a listed channel or resurrect a since-read one.
+    const missing = new Set(missingUnreadChannelIds());
+    const channels = [
+      ...(channelsQuery.data?.entities ?? []).filter(isChannelEntity),
+      ...(missingUnreadChannelsQuery.data?.entities ?? [])
+        .filter(isChannelEntity)
+        .filter((entity) => missing.has(entity.id)),
+    ].map((entity) => ({ entity, unread: unread.get(entity.id) ?? [] }));
     // Same ordering as the channels soup view…
     channels.sort((a, b) =>
       compareDateDesc(

--- a/apps/web/src/features/channel/sidebar/channels-recent-widget.tsx
+++ b/apps/web/src/features/channel/sidebar/channels-recent-widget.tsx
@@ -366,7 +366,13 @@ export const ChannelsRecentWidget = (props: {
 
   const missingUnreadChannelsQuery = useSoupAstItemsQuery(
     () => ({
-      params: { limit: RECENT_CHANNELS_LIMIT, sort_method: 'updated_at' },
+      // Sized to the id list, not RECENT_CHANNELS_LIMIT: this query must
+      // return every exact-id match, and a fixed limit would silently drop
+      // the oldest ones past it. The server clamps to its own [20, 500].
+      params: {
+        limit: missingUnreadChannelIds().length,
+        sort_method: 'updated_at',
+      },
       body: compileToAst(
         queryStateFrom(
           defineQueryFilters({


### PR DESCRIPTION
## Summary
Ensures that channels with unread notifications always appear in the recent channels sidebar widget, even if they fall outside the main query's newest-RECENT_CHANNELS_LIMIT window.

## Key Changes
- Added `missingUnreadChannelIds` memo that identifies unread channels not included in the main channels query
- Created `missingUnreadChannelsQuery` to fetch those missing unread channels by ID
- Updated `recentChannels` memo to merge both the main query results and the missing unread channels, with deduplication logic to prevent stale placeholder rows from resurrecting since-read channels

## Implementation Details
- The missing channel IDs are sorted to ensure a stable query key across notification reorders
- Deduplication uses a Set to filter out channels that are already in the main query results
- Only channels still in the `missingUnreadChannelIds` set are merged in, preventing placeholder rows from a previous ID set from duplicating listed channels or resurrecting since-read ones
- The secondary query is only enabled when there are actually missing unread channels to fetch

https://claude.ai/code/session_019Dw45QnwaUAqjLwh3oc7vh