### PR TITLE
fix: open MCP connection auth in the system browser on native apps

### DIFF
--- a/apps/web/src/features/settings/Integrations.tsx
+++ b/apps/web/src/features/settings/Integrations.tsx
@@ -5,6 +5,7 @@ import {
   type SvgIcon,
 } from '@core/component/AI/constant/mcpServers';
 import { toast } from '@core/component/Toast/Toast';
+import { openExternalUrl } from '@core/util/url';
 import CheckIcon from '@phosphor-icons/core/regular/check.svg?component-solid';
 import PlugIcon from '@phosphor-icons/core/regular/plug.svg?component-solid';
 import PlusIcon from '@phosphor-icons/core/regular/plus.svg?component-solid';
@@ -53,7 +54,7 @@ function AddServerForm(props: {
       { server_name: serverName, server_url: serverUrl },
       {
         onSuccess: (result: StartAuthResponse) => {
-          window.open(result.authorization_url, '_blank');
+          openExternalUrl(result.authorization_url);
         },
         onError: () => {
           toast.failure('Server added but failed to start authorization');
@@ -238,7 +239,7 @@ function ServerRow(props: { server: ServerResponse }) {
       },
       {
         onSuccess: (result: StartAuthResponse) => {
-          window.open(result.authorization_url, '_blank');
+          openExternalUrl(result.authorization_url);
           writeAuthAttempted(props.server.url, true);
           setAttempted(true);
         },
@@ -371,7 +372,7 @@ function FeaturedServerRow(props: { server: FeaturedMcpServer }) {
         server_name: props.server.server_name,
         server_url: props.server.url,
       });
-      window.open(result.authorization_url, '_blank');
+      openExternalUrl(result.authorization_url);
     } catch {
       toast.failure('Server added but failed to start authorization');
     }

--- a/apps/web/src/features/setup/useConnectorConnect.ts
+++ b/apps/web/src/features/setup/useConnectorConnect.ts
@@ -1,5 +1,7 @@
 import type { FeaturedMcpServer } from '@core/component/AI/constant/mcpServers';
 import { toast } from '@core/component/Toast/Toast';
+import { isTauri } from '@core/util/platform';
+import { openExternalUrl } from '@core/util/url';
 import {
   useAddMcpServerMutation,
   useStartMcpAuthMutation,
@@ -16,6 +18,11 @@ import { type Accessor, createSignal } from 'solid-js';
  * keeps the provider page from reaching back into the app (reverse
  * tabnabbing).
  *
+ * Inside the Tauri shell there are no popup blockers and `_blank` opens
+ * never reach the native navigation hook (on iOS they're silently dropped),
+ * so the popup dance is skipped and the URL is handed to the system browser
+ * via `openExternalUrl` once it's known.
+ *
  * Completion is observed, not returned: the server reconciles the moment
  * OAuth completes, and the caller's polled servers query flips the state.
  */
@@ -31,7 +38,7 @@ export function createConnectorConnect(options: {
   const connect = async () => {
     if (options.authenticated() || busy()) return;
     setBusy(true);
-    const popup = window.open('about:blank', '_blank');
+    const popup = isTauri() ? null : window.open('about:blank', '_blank');
     if (popup) popup.opener = null;
     try {
       if (!options.connected()) {
@@ -47,9 +54,11 @@ export function createConnectorConnect(options: {
       if (popup) {
         popup.location.href = result.authorization_url;
       } else {
-        // Popup was blocked outright — fall back to a plain open (may
-        // still be blocked, but nothing else to try).
-        window.open(result.authorization_url, '_blank', 'noopener,noreferrer');
+        // Native shell, or the popup was blocked outright — openExternalUrl
+        // routes through the system browser on Tauri and is a plain
+        // noopener open on web (may still be blocked, but nothing else to
+        // try).
+        openExternalUrl(result.authorization_url);
       }
     } catch {
       popup?.close();


### PR DESCRIPTION
## Summary

On iOS, tapping **Connect** on an MCP integration in Settings → Connections did nothing: the OAuth authorization URL was opened with a raw `window.open(url, '_blank')`, which the Tauri webview silently drops (it can't spawn separate windows on iOS), so the auth page never appeared.

- `apps/web/src/features/settings/Integrations.tsx`: all three auth call sites (Add-server dialog, Connect/Try Again on a server row, featured-server Connect) now go through `openExternalUrl` — the app's single entry point for external URLs. Inside the Tauri shell it hands the URL to the native navigation plugin, which opens the system browser (Safari on iOS); on web the existing new-tab behavior is unchanged. When the user returns to the app, the servers query already refetches on focus, so the row flips to Connected.
- `apps/web/src/features/setup/useConnectorConnect.ts`: the onboarding connector flow had the same dead `_blank` path — inside Tauri it now skips the `about:blank` popup dance (only needed for web popup blockers) and opens the auth URL via `openExternalUrl`.

The tauri auth plugin (`ASWebAuthenticationSession`) was considered but not used: the MCP OAuth callback terminates on the backend with a plain "you can close this tab" page and no `macro://` redirect, so the in-app session could never auto-complete without backend/SDK changes.

Session: https://claude.ai/code/8b68d69a-4ff8-5aba-9172-c9443d0a0709

---
_Generated by [Claude Code](https://claude.ai/code/session_013eb3tZD2Tkx6VPJCRmRu14)_