### PR TITLE
fix(calendar): scope the optimistic RSVP patch like the API default

### DIFF
--- a/apps/web/src/lib/queries/calendar/mutations.ts
+++ b/apps/web/src/lib/queries/calendar/mutations.ts
@@ -72,14 +72,23 @@ export interface RsvpCalendarEventArgs {
   occurrenceKey?: string;
 }
 
-/** Whether a cached occurrence is covered by a scoped response. */
+/**
+ * Whether a cached occurrence is covered by a scoped response. An omitted
+ * scope with a recurrenceId is occurrence-scoped, matching the API default.
+ */
 function answeredByRsvp(
   item: CalendarOccurrenceItem,
   args: RsvpCalendarEventArgs
 ): boolean {
   if (item.event.id !== args.eventId) return false;
-  if (args.scope === 'this_event' && args.occurrenceKey !== undefined) {
-    return item.occurrence.occurrenceKey === args.occurrenceKey;
+  if (
+    args.scope === 'this_event' ||
+    (args.scope === undefined && args.recurrenceId !== undefined)
+  ) {
+    return (
+      args.occurrenceKey !== undefined &&
+      item.occurrence.occurrenceKey === args.occurrenceKey
+    );
   }
   return true;
 }

--- a/apps/web/src/lib/queries/calendar/tests/mutations.test.tsx
+++ b/apps/web/src/lib/queries/calendar/tests/mutations.test.tsx
@@ -250,6 +250,19 @@ describe('useRsvpCalendarEventMutation', () => {
     expect(responseAt(keys[0])).toBe('tentative');
     expect(responseAt(keys[1])).toBe('tentative');
     expect(responseAt(keys[2])).toBe('tentative');
+
+    // An omitted scope with a recurrenceId is occurrence-scoped on the
+    // server, so the optimistic patch must not widen it to the series.
+    await rsvp.mutateAsync({
+      eventId: 'event-3',
+      response: 'declined',
+      recurrenceId: keys[2],
+      occurrenceKey: keys[2],
+    });
+
+    expect(responseAt(keys[0])).toBe('tentative');
+    expect(responseAt(keys[1])).toBe('tentative');
+    expect(responseAt(keys[2])).toBe('declined');
   });
 
   it('rolls back every viewport when the request fails', async () => {


### PR DESCRIPTION
The RSVP mutation treated an omitted scope as series-wide in the optimistic cache patch, while the server treats an omitted scope with a recurrenceId as this-event — a caller using the implicit shape would see every cached occurrence flip until refetch. Aligns the cache predicate with the API default and adds a regression test for that request shape.

Addresses https://github.com/macro-inc/macro/pull/5533#discussion_r3752464900.
