### PR TITLE
docs(calendar): drop the forward-scope claim from the RSVP hook doc

### DIFF
--- a/apps/web/src/lib/queries/calendar/mutations.ts
+++ b/apps/web/src/lib/queries/calendar/mutations.ts
@@ -92,9 +92,9 @@ type RsvpCallbacks = MutationCallbacks<
 >;
 
 /**
- * Sets the viewer's RSVP for one occurrence, an occurrence onward, or the
- * whole series. Google records an occurrence-scoped response as an exception
- * instance, so the answer can differ per occurrence.
+ * Sets the viewer's RSVP for one occurrence or the whole series. Google
+ * records an occurrence-scoped response as an exception instance, so the
+ * answer can differ per occurrence.
  */
 export function useRsvpCalendarEventMutation(callbacks?: RsvpCallbacks) {
   return useMutation(() => ({


### PR DESCRIPTION
The RSVP hook doc still described "an occurrence onward", a scope the API deliberately does not support. Doc-only change.

Addresses https://github.com/macro-inc/macro/pull/5533#discussion_r3752464907.
