### PR TITLE
fix(calendar): patch only the connected attendee's RSVP

### DIFF
--- a/crates/calendar_events/src/outbound/google.rs
+++ b/crates/calendar_events/src/outbound/google.rs
@@ -1127,7 +1127,15 @@ impl<G: GoogleRequestGate> GoogleCalendarClient<G> {
     }
 
     /// Rewrite just the connected account's `responseStatus` on one provider
-    /// event, preserving every other attendee exactly as Google has them.
+    /// event, leaving every other attendee untouched.
+    ///
+    /// The patch sends `attendeesOmitted: true` with only the connected
+    /// attendee's entry — Google's documented mechanism for updating one
+    /// participant's response — so a concurrent attendee change between our
+    /// read and this write cannot be overwritten by a full-array replace.
+    /// The read stays: it distinguishes a vanished event from a requester
+    /// who simply is not on the guest list, which the patch alone would
+    /// answer by quietly adding them.
     async fn patch_self_response(
         &self,
         access_token: &str,
@@ -1136,8 +1144,6 @@ impl<G: GoogleRequestGate> GoogleCalendarClient<G> {
         self_email: &str,
         response: AttendeeResponseStatus,
     ) -> Result<RsvpPatch, GoogleProviderError> {
-        // Patching `attendees` replaces the whole array, so start from the
-        // provider's current list rather than a possibly stale projection.
         let Some(current) = self
             .event(
                 access_token,
@@ -1149,23 +1155,22 @@ impl<G: GoogleRequestGate> GoogleCalendarClient<G> {
         else {
             return Ok(RsvpPatch::Gone);
         };
-        let mut attendees: Vec<GoogleAttendee> = current.attendees.clone().unwrap_or_default();
-        let self_position = attendees
+        let attendees: Vec<GoogleAttendee> = current.attendees.clone().unwrap_or_default();
+        let self_attendee = attendees
             .iter()
-            .position(|attendee| attendee.is_self)
+            .find(|attendee| attendee.is_self)
             .or_else(|| {
-                attendees.iter().position(|attendee| {
+                attendees.iter().find(|attendee| {
                     attendee
                         .email
                         .as_deref()
                         .is_some_and(|email| email.eq_ignore_ascii_case(self_email))
                 })
             });
-        let Some(position) = self_position else {
+        let Some(self_attendee) = self_attendee else {
             return Ok(RsvpPatch::NotAttendee);
         };
-        attendees[position].response_status = Some(google_response_status(response).to_string());
-        let body = serde_json::json!({ "attendees": attendees });
+        let body = rsvp_patch_body(self_attendee, response);
         match self
             .patch_event_raw(access_token, target, provider_event_id, body)
             .await?
@@ -1267,6 +1272,20 @@ fn google_response_status(status: AttendeeResponseStatus) -> &'static str {
         AttendeeResponseStatus::Declined => "declined",
         AttendeeResponseStatus::Tentative => "tentative",
     }
+}
+
+/// Body updating only the connected attendee's response: `attendeesOmitted`
+/// tells Google the array is partial, so other attendees survive untouched.
+fn rsvp_patch_body(
+    self_attendee: &GoogleAttendee,
+    response: AttendeeResponseStatus,
+) -> serde_json::Value {
+    let mut entry = self_attendee.clone();
+    entry.response_status = Some(google_response_status(response).to_string());
+    serde_json::json!({
+        "attendeesOmitted": true,
+        "attendees": [entry],
+    })
 }
 
 /// Serialize an event time as Google `start`/`end` objects. The unused shape

--- a/crates/calendar_events/src/outbound/google/test.rs
+++ b/crates/calendar_events/src/outbound/google/test.rs
@@ -535,3 +535,26 @@ fn exception_attendees_are_carried_onto_the_override() {
     // Every attendee survives, not just the one whose response changed.
     assert_eq!(override_attendees.len(), 2);
 }
+
+/// The RSVP patch must not replace the full attendee array: a concurrent
+/// attendee change between our read and the patch would be silently undone.
+/// `attendeesOmitted` marks the array partial so Google merges by email.
+#[test]
+fn rsvp_patch_updates_only_the_connected_attendee() {
+    let self_attendee: GoogleAttendee = serde_json::from_value(serde_json::json!({
+        "email": "self@example.com",
+        "self": true,
+        "responseStatus": "needsAction",
+        "comment": "unrelated state that must survive"
+    }))
+    .unwrap();
+
+    let body = rsvp_patch_body(&self_attendee, AttendeeResponseStatus::Declined);
+
+    assert_eq!(body["attendeesOmitted"], serde_json::json!(true));
+    let attendees = body["attendees"].as_array().unwrap();
+    assert_eq!(attendees.len(), 1);
+    assert_eq!(attendees[0]["email"], "self@example.com");
+    assert_eq!(attendees[0]["responseStatus"], "declined");
+    assert_eq!(attendees[0]["comment"], "unrelated state that must survive");
+}


### PR DESCRIPTION
The RSVP patch sent Google the complete attendee array, so a concurrent attendee change between our read and the write could be silently reverted. It now sends attendeesOmitted: true with only the connected attendee's entry — Google's documented mechanism for updating one participant's response — and keeps the preceding read, which distinguishes a vanished event from a requester who is not on the guest list (a bare patch would answer that by quietly adding them).

Addresses https://github.com/macro-inc/macro/pull/5533#discussion_r3752464918.
