### PR TITLE
fix desktop app login

### DIFF
--- a/services/authentication_service/src/api/login/sso.rs
+++ b/services/authentication_service/src/api/login/sso.rs
@@ -38,7 +38,7 @@ pub(crate) struct LoginQueryParams {
 fn is_allowed_original_url(url: &Url) -> bool {
     match url.scheme() {
         // The iOS app uses macro://login as its authentication callback.
-        "macro" => url.host_str() == Some("login"),
+        "macro" => matches!(url.host_str(), Some("login" | "welcome")),
         "tauri" => url.host_str() == Some("localhost"),
         "http" => matches!(url.host_str(), Some("localhost" | "tauri.localhost")),
         "https" => matches!(


### PR DESCRIPTION
The frontend now uses /welcome as the original_url which is not allowed by the existing login handler. This fixes the gap