### PR TITLE
fix(email): make email body text selectable in Safari

### DIFF
--- a/apps/web/src/features/block-email/component/EmailMessageBody.tsx
+++ b/apps/web/src/features/block-email/component/EmailMessageBody.tsx
@@ -176,6 +176,11 @@ export function EmailMessageBody(props: EmailMessageBodyProps) {
     // Raw mailto: anchors open the in-app composer instead of the OS mail client
     interceptMailtoLinks(messageDiv);
     messageDiv.style.userSelect = 'text';
+    // Safari resolves only the -webkit- prefixed form of user-select
+    // (unprefixed shipped in Safari 26.4), and WebKit inherits the app-wide
+    // `user-select: none` through the shadow boundary — without the prefix,
+    // email text isn't selectable in Safari.
+    messageDiv.style.setProperty('-webkit-user-select', 'text');
     messageDiv.style.cursor = 'auto';
     shadow.appendChild(messageDiv);
     return hostContainer;


### PR DESCRIPTION
Fixes [MACRO-2872](https://linear.app/macro/issue/MACRO-2872): on Safari, email text can not be selected.

The app globally disables selection (`user-select: none` in `index.css`, autoprefixed at build time to `-webkit-user-select` so it applies in Safari) and re-enables it per-selector — but those document rules can't reach into the shadow DOM that renders sanitized email HTML. The only re-enable there is the runtime `messageDiv.style.userSelect = 'text'`, which is a no-op in Safari: WebKit only resolves the `-webkit-` prefixed form of `user-select` (unprefixed shipped in Safari 26.4), and it implements the property as *inherited*, so the host's `-webkit-user-select: none` cascades through the shadow boundary into the whole email body. Chrome/Firefox support the unprefixed form, which is why only Safari was affected.

Fix: also set `-webkit-user-select: text` on the message div inside the shadow root. Its descendants inherit it in WebKit (and resolve `user-select: auto` to it in spec-compliant browsers), making email text selectable again. The plaintext/`body_macro` paths were already fine — they render in the light DOM under `.markdown-content`, which the global re-enable rules cover.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B2P4H4srAmcADeMVBPtcGU)_