### PR TITLE
fix(gql): notification map

### DIFF
--- a/apps/web/src/features/channel/sidebar/channels-recent-widget.tsx
+++ b/apps/web/src/features/channel/sidebar/channels-recent-widget.tsx
@@ -368,7 +368,9 @@ export const ChannelsRecentWidget = (props: {
     () => ({
       // Sized to the id list, not RECENT_CHANNELS_LIMIT: this query must
       // return every exact-id match, and a fixed limit would silently drop
-      // the oldest ones past it. The server clamps to its own [20, 500].
+      // the oldest ones past it. (The server's [20, 500] clamp covers only
+      // the merged page; the channel SQL takes this limit verbatim, safe
+      // here because the exact-id filter runs before LIMIT.)
       params: {
         limit: missingUnreadChannelIds().length,
         sort_method: 'updated_at',

--- a/apps/web/src/lib/queries/notification/graphql/user-notifications.ts
+++ b/apps/web/src/lib/queries/notification/graphql/user-notifications.ts
@@ -7,7 +7,6 @@ import type { UnifiedNotification } from '@notifications/types';
 import {
   type NotificationUpdateOperation,
   type SoupInput,
-  type SoupNotificationFieldsFragment,
   SoupNotificationsDocument,
   type SoupNotificationsQuery,
   type SoupNotificationsQueryVariables,
@@ -15,7 +14,10 @@ import {
   type UpdateNotificationsMutation,
   type UpdateNotificationsMutationVariables,
 } from '@service-storage/graphql/generated/graphql';
-import { getGraphqlSoupClient } from '@service-storage/graphql-soup';
+import {
+  getGraphqlSoupClient,
+  mapGraphqlNotification,
+} from '@service-storage/graphql-soup';
 import { executeGraphqlUpdateNotifications } from '@service-storage/graphql-update-notifications';
 import { CombinedError } from '@urql/core';
 import type { Accessor } from 'solid-js';
@@ -27,27 +29,6 @@ function normalizeLimit(limit?: number): number {
   return limit && limit > 0 && limit <= MAX_NOTIFICATION_LIMIT
     ? limit
     : DEFAULT_NOTIFICATION_LIMIT;
-}
-
-/** Maps one GraphQL notification fragment to the shared UI shape. */
-export function mapGraphqlNotification(
-  record: SoupNotificationFieldsFragment
-): UnifiedNotification {
-  return {
-    id: record.id,
-    notification_event_type: record.eventType,
-    notification_metadata:
-      record.metadata as UnifiedNotification['notification_metadata'],
-    entity_id: record.entityId,
-    entity_type:
-      record.entityType.toLowerCase() as UnifiedNotification['entity_type'],
-    sent: record.sent,
-    done: record.done,
-    created_at: record.createdAt,
-    viewed_at: record.viewedAt,
-    updated_at: record.updatedAt,
-    sender_id: record.senderId,
-  };
 }
 
 function soupInput(cursor: string | null, limit: number): SoupInput {

--- a/apps/web/src/lib/service-clients/service-storage/graphql-soup.ts
+++ b/apps/web/src/lib/service-clients/service-storage/graphql-soup.ts
@@ -16,6 +16,7 @@ import {
 import { registerCacheHost } from '@graphql-cache/lifecycle';
 import { getOrCreateCacheScope } from '@graphql-cache/scope';
 import { getMacroApiToken } from '@service-auth/fetch';
+import type { ApiUserNotification } from '@service-notification/generated/schemas/apiUserNotification';
 import {
   type Client,
   createClient,
@@ -41,6 +42,7 @@ import {
   type GroupSoupQueryVariables,
   type SoupInitialInput,
   type SoupInput,
+  type SoupNotificationFieldsFragment,
   type SoupPropertyFieldsFragment,
   type SoupQuery,
   SoupDocument as SoupQueryDocument,
@@ -267,10 +269,6 @@ type GraphqlSoupChannelMessage = NonNullable<
     { __typename: 'GraphqlSoupChannel' }
   >['latestMessage']
 >;
-type GraphqlSoupNotification = Extract<
-  GraphqlSoupEntity,
-  { __typename: 'GraphqlSoupDocument' }
->['notifications'][number];
 
 function mapGraphqlPropertyValue(
   value: GraphqlPropertyValue | null | undefined
@@ -377,30 +375,41 @@ function normalizeChannelType(channelType: string) {
   return channelType.toLowerCase();
 }
 
-function mapGraphqlNotificationEntityType(
-  entityType: GraphqlSoupNotification['entityType']
-) {
-  return entityType.toLowerCase();
+/**
+ * Rebuilds the REST notification shape from the flat GraphQL fields. The
+ * server stores the event tag apart from the metadata JSON and only REST
+ * re-joins them (`UserNotificationRow::into_tagged`); GraphQL ships them
+ * flat, so the adjacently-tagged `notification_metadata` union must be
+ * reassembled here. Consumers pattern-match on `notification_metadata.tag`
+ * and treat an untagged channel notification as read — every GraphQL
+ * notification must go through this mapper.
+ */
+export function mapGraphqlNotification(
+  record: SoupNotificationFieldsFragment
+): Omit<ApiUserNotification, 'owner_id'> {
+  return {
+    id: record.id,
+    notification_event_type: record.eventType,
+    notification_metadata: {
+      tag: record.eventType,
+      content: record.metadata,
+    } as ApiUserNotification['notification_metadata'],
+    entity_id: record.entityId,
+    entity_type:
+      record.entityType.toLowerCase() as ApiUserNotification['entity_type'],
+    sent: record.sent,
+    done: record.done,
+    created_at: record.createdAt,
+    viewed_at: record.viewedAt ?? undefined,
+    updated_at: record.updatedAt,
+    sender_id: record.senderId ?? undefined,
+  };
 }
 
-function mapGraphqlNotifications(notifications: GraphqlSoupNotification[]) {
-  return notifications.map((notification) => ({
-    id: notification.id,
-    notification_event_type: notification.eventType,
-    notification_metadata: {
-      tag: notification.eventType,
-      content: notification.metadata,
-    },
-    entity_id: notification.entityId,
-    entity_type: mapGraphqlNotificationEntityType(notification.entityType),
-    sent: notification.sent,
-    done: notification.done,
-    seen: notification.seen,
-    created_at: notification.createdAt,
-    viewed_at: notification.viewedAt ?? undefined,
-    updated_at: notification.updatedAt,
-    sender_id: notification.senderId ?? undefined,
-  }));
+function mapGraphqlNotifications(
+  notifications: SoupNotificationFieldsFragment[]
+) {
+  return notifications.map(mapGraphqlNotification);
 }
 
 /**


### PR DESCRIPTION
`mapGraphqlNotification()` from `user-notifications.ts` was missing `metadata` `tag` and so the channel widget was seeing all channels as `read`. `graphql-soup.ts` has the correct one and so we use that.