### PR TITLE
feat: add invite-teammates action to the channel composer

### DIFF
--- a/apps/web/src/features/channel/Channel/Channel.tsx
+++ b/apps/web/src/features/channel/Channel/Channel.tsx
@@ -17,6 +17,7 @@ import {
   SearchHighlightTermsProvider,
 } from '@channel/Message';
 import { MaybeMessageActionDrawerManager } from '@channel/Mobile/MessageActionDrawerManager';
+import { InviteTeammatesAction } from '@channel/Participants/InviteTeammatesAction';
 import { useChannelBotMentionUsers } from '@channel/use-channel-bot-mention-users';
 import { useChannelParticipants } from '@channel/use-channel-participants';
 import { FloatRegionOrInline } from '@components/app/mobile/float-regions/FloatRegion';
@@ -927,6 +928,11 @@ export function Channel(props: ChannelProps) {
                           taskPersistence={makeTaskPersistence({
                             channelId: props.channelId,
                           })}
+                          inviteAction={
+                            <InviteTeammatesAction
+                              channelId={props.channelId}
+                            />
+                          }
                           onStartTyping={() =>
                             typingMutation.mutate({
                               channelId: props.channelId,

--- a/apps/web/src/features/channel/Input/TaskModeChannelInput.tsx
+++ b/apps/web/src/features/channel/Input/TaskModeChannelInput.tsx
@@ -2,7 +2,7 @@ import { isMobile } from '@core/mobile/isMobile';
 import { isPlatform } from '@core/util/platform';
 import { makePersisted } from '@solid-primitives/storage';
 import { cn } from '@ui';
-import { createSignal, onCleanup, Show, splitProps } from 'solid-js';
+import { createSignal, type JSX, onCleanup, Show, splitProps } from 'solid-js';
 import { ChannelInput, type ChannelInputProps } from './ChannelInput';
 import { Input } from './Input';
 import { TaskComposer, type TaskComposerSendPayload } from './TaskComposer';
@@ -19,11 +19,18 @@ export type TaskModeChannelInputProps = Omit<
   onSendTask: (task: TaskComposerSendPayload) => void;
   /** Persistence keys for the task draft and selected input mode. */
   taskPersistence?: InputTaskPersistence;
+  /**
+   * Optional affordance rendered to the right of the task mode switch in
+   * message mode (e.g. the channel's invite-teammates action). Shares the
+   * switch's visibility so it never appears without its anchor.
+   */
+  inviteAction?: JSX.Element;
 };
 
 function MessageModeActions(props: {
   canUseTaskMode: boolean;
   onEnterTaskMode: () => void;
+  inviteAction?: JSX.Element;
 }) {
   return (
     <Show
@@ -38,6 +45,7 @@ function MessageModeActions(props: {
                 checked={false}
                 onChange={props.onEnterTaskMode}
               />
+              {props.inviteAction}
             </Show>
           </Input.Actions.Left>
           <Input.Actions.Right>
@@ -67,6 +75,7 @@ function MessageModeActions(props: {
 export function TaskModeChannelInput(props: TaskModeChannelInputProps) {
   const [local, inputProps] = splitProps(props, [
     'autofocus',
+    'inviteAction',
     'onReady',
     'onSendTask',
     'taskPersistence',
@@ -184,6 +193,7 @@ export function TaskModeChannelInput(props: TaskModeChannelInputProps) {
       <MessageModeActions
         canUseTaskMode={canUseTaskMode()}
         onEnterTaskMode={() => setTaskMode(true)}
+        inviteAction={local.inviteAction}
       />
     </ChannelInput>
   );

--- a/apps/web/src/features/channel/Input/tests/task-mode.test.tsx
+++ b/apps/web/src/features/channel/Input/tests/task-mode.test.tsx
@@ -290,6 +290,21 @@ describe('Channel input task mode', () => {
     expect(screen.getByTestId('task-composer')).toBeTruthy();
   });
 
+  it('renders the invite action immediately after the task mode switch', () => {
+    render(() => (
+      <TaskModeChannelInput
+        input={baseInput}
+        onSendTask={() => {}}
+        inviteAction={<button type="button" data-testid="invite-action" />}
+      />
+    ));
+
+    // The pill (Kobalte switch root) is the label's parent; the invite action
+    // slot must be its immediate sibling so it sits to the toggle's right.
+    const pill = screen.getByText('Task').parentElement as HTMLElement;
+    expect(pill.nextElementSibling).toBe(screen.getByTestId('invite-action'));
+  });
+
   it('enters task mode from clicks on the switch pill itself, not just the control', async () => {
     const user = userEvent.setup();
     render(() => (

--- a/apps/web/src/features/channel/Participants/InviteTeammatesAction.test.tsx
+++ b/apps/web/src/features/channel/Participants/InviteTeammatesAction.test.tsx
@@ -1,0 +1,201 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { ChannelType } from '@service-storage/generated/schemas/channelType';
+import { fireEvent, render, screen } from '@solidjs/testing-library';
+import type { JSX } from 'solid-js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type AddParticipantsVars = { channelId: string; participants: string[] };
+type AddParticipantsCallbacks = {
+  onSuccess?: (response: unknown, vars: AddParticipantsVars) => void;
+};
+
+const mocks = vi.hoisted(() => ({
+  channelType: 'private' as string | undefined,
+  participants: [] as { user_id: string }[],
+  team: undefined as
+    | { team: { id: string }; members: { user_id: string }[] }
+    | undefined,
+  mutate: vi.fn(),
+  mutationCallbacks: undefined as AddParticipantsCallbacks | undefined,
+  toastSuccess: vi.fn(),
+}));
+
+vi.mock('@core/context/channels', () => ({
+  useChannelType: () => () => mocks.channelType,
+}));
+
+vi.mock('@queries/channel/channel-participants', () => ({
+  useChannelParticipantsQuery: () => ({
+    get data() {
+      return mocks.participants;
+    },
+  }),
+}));
+
+vi.mock('@queries/team/teams', () => ({
+  useCurrentTeamQuery: () => ({
+    get data() {
+      return mocks.team;
+    },
+  }),
+}));
+
+vi.mock('@queries/channel/participants', () => ({
+  useAddParticipantsMutation: (callbacks?: AddParticipantsCallbacks) => {
+    mocks.mutationCallbacks = callbacks;
+    return { mutate: mocks.mutate };
+  },
+}));
+
+vi.mock('@core/component/Toast/Toast', () => ({
+  toast: { success: mocks.toastSuccess, failure: vi.fn() },
+}));
+
+// The user barrel drags service clients into the module graph; the component
+// only needs the two pure id helpers.
+vi.mock('@core/user', () => ({
+  idToDisplayName: (id: string) => id.replace('macro|', '').split('@')[0],
+  idToEmail: (id: string) => id.replace('macro|', ''),
+}));
+
+vi.mock('@core/component/UserIcon', () => ({
+  UserIcon: (props: { id?: string }) => (
+    <span data-testid="user-icon" data-user-id={props.id} />
+  ),
+}));
+
+vi.mock('@phosphor/user-plus.svg', () => ({
+  default: () => <span data-testid="user-plus-icon" />,
+}));
+
+// Render the Kobalte popover as a transparent passthrough so the content is
+// always in the DOM — these tests exercise the invite logic, not the popover
+// primitive.
+vi.mock('@kobalte/core/popover', () => {
+  const Popover: any = (p: { children?: JSX.Element }) => (
+    <div>{p.children}</div>
+  );
+  Popover.Trigger = (p: any) => (
+    <button
+      type="button"
+      aria-label={p['aria-label']}
+      data-input-action={p['data-input-action']}
+    >
+      {p.children}
+    </button>
+  );
+  Popover.Portal = (p: { children?: JSX.Element }) => <div>{p.children}</div>;
+  Popover.Content = (p: { children?: JSX.Element }) => <div>{p.children}</div>;
+  return { Popover };
+});
+
+vi.mock('@ui', () => ({
+  Button: (p: any) => p.children,
+  Layer: (p: { children?: JSX.Element }) => <>{p.children}</>,
+}));
+
+import { InviteTeammatesAction } from './InviteTeammatesAction';
+
+const member = (email: string) => ({ user_id: `macro|${email}` });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.channelType = ChannelType.private;
+  mocks.participants = [member('owner@team.com')];
+  mocks.team = {
+    team: { id: 'team-1' },
+    members: [
+      member('owner@team.com'),
+      member('zoe@team.com'),
+      member('amir@team.com'),
+    ],
+  };
+});
+
+function renderAction() {
+  return render(() => <InviteTeammatesAction channelId="channel-1" />);
+}
+
+describe('InviteTeammatesAction', () => {
+  it('lists teammates who are not participants, alphabetically', () => {
+    const { container } = renderAction();
+
+    const rows = Array.from(
+      container.querySelectorAll('[data-invite-teammate]')
+    );
+    expect(rows.map((row) => row.getAttribute('data-invite-teammate'))).toEqual(
+      ['macro|amir@team.com', 'macro|zoe@team.com']
+    );
+  });
+
+  it('invites the clicked teammate to the channel', () => {
+    const { container } = renderAction();
+
+    const row = container.querySelector(
+      '[data-invite-teammate="macro|zoe@team.com"]'
+    ) as HTMLElement;
+    fireEvent.click(row);
+
+    expect(mocks.mutate).toHaveBeenCalledWith({
+      channelId: 'channel-1',
+      participants: ['macro|zoe@team.com'],
+    });
+  });
+
+  it('filters by search and invites the first match on Enter', () => {
+    renderAction();
+
+    const search = screen.getByRole('searchbox', { name: 'Search teammates' });
+    fireEvent.input(search, { target: { value: 'zoe' } });
+    expect(
+      screen
+        .getByRole('dialog', { name: 'Invite teammates' })
+        .querySelectorAll('[data-invite-teammate]')
+    ).toHaveLength(1);
+
+    fireEvent.keyDown(search, { key: 'Enter' });
+    expect(mocks.mutate).toHaveBeenCalledWith({
+      channelId: 'channel-1',
+      participants: ['macro|zoe@team.com'],
+    });
+  });
+
+  it('toasts with the display name after a successful invite', () => {
+    renderAction();
+
+    mocks.mutationCallbacks?.onSuccess?.(undefined, {
+      channelId: 'channel-1',
+      participants: ['macro|zoe@team.com'],
+    });
+
+    expect(mocks.toastSuccess).toHaveBeenCalledOnce();
+    expect(mocks.toastSuccess.mock.calls[0]?.[0]).toContain('Invite sent to');
+  });
+
+  it('explains when everyone on the team is already in the channel', () => {
+    mocks.participants = mocks.team?.members ?? [];
+    renderAction();
+
+    expect(
+      screen.getByText('Everyone on your team is already in this channel.')
+    ).toBeTruthy();
+  });
+
+  it.each([ChannelType.direct_message, ChannelType.public])(
+    'renders nothing for %s channels',
+    (channelType) => {
+      mocks.channelType = channelType;
+      const { container } = renderAction();
+      expect(container.innerHTML).toBe('');
+    }
+  );
+
+  it('renders nothing when the viewer has no team', () => {
+    mocks.team = undefined;
+    const { container } = renderAction();
+    expect(container.innerHTML).toBe('');
+  });
+});

--- a/apps/web/src/features/channel/Participants/InviteTeammatesAction.tsx
+++ b/apps/web/src/features/channel/Participants/InviteTeammatesAction.tsx
@@ -1,0 +1,198 @@
+import { toast } from '@core/component/Toast/Toast';
+import { UserIcon } from '@core/component/UserIcon';
+import { useChannelType } from '@core/context/channels';
+import { idToDisplayName, idToEmail } from '@core/user';
+import { Popover } from '@kobalte/core/popover';
+import UserPlusIcon from '@phosphor/user-plus.svg';
+import { useChannelParticipantsQuery } from '@queries/channel/channel-participants';
+import { useAddParticipantsMutation } from '@queries/channel/participants';
+import { useCurrentTeamQuery } from '@queries/team/teams';
+import { ChannelType } from '@service-storage/generated/schemas/channelType';
+import { Button, Layer } from '@ui';
+import { createMemo, createSignal, For, Match, Show, Switch } from 'solid-js';
+
+type InviteCandidate = {
+  id: string;
+  name: string;
+  email: string;
+};
+
+/**
+ * A composer-footer pill that invites teammates into the channel without
+ * leaving the conversation. Opens a searchable list of team members who
+ * aren't participants yet; picking one adds them to the channel, which
+ * sends them the standard channel invite notification.
+ *
+ * Renders nothing for channel types that don't support adding participants
+ * (DMs, public channels) or when the viewer doesn't belong to a team,
+ * mirroring the participants tab's add rules.
+ */
+export function InviteTeammatesAction(props: { channelId: string }) {
+  const channelType = useChannelType(props.channelId);
+  const participantsQuery = useChannelParticipantsQuery(() => props.channelId);
+  const currentTeamQuery = useCurrentTeamQuery();
+  const addParticipantsMutation = useAddParticipantsMutation({
+    onSuccess(_response, vars) {
+      const invited = vars.participants[0];
+      if (invited) {
+        toast.success(`Invite sent to ${idToDisplayName(invited)}`);
+      }
+    },
+  });
+
+  const [open, setOpen] = createSignal(false);
+  const [query, setQuery] = createSignal('');
+
+  // The component outlives the popover content, so reset the search when it
+  // closes or reopening shows a stale filter.
+  const onOpenChange = (isOpen: boolean) => {
+    setOpen(isOpen);
+    if (!isOpen) setQuery('');
+  };
+
+  // Mirrors ChannelParticipantsTab's canAddParticipants: the backend rejects
+  // participant changes on DMs, and public channels are join-only.
+  const canInvite = () =>
+    channelType() === ChannelType.private || channelType() === ChannelType.team;
+
+  const loaded = () => !!currentTeamQuery.data && !!participantsQuery.data;
+
+  const candidates = createMemo<InviteCandidate[]>(() => {
+    const members = currentTeamQuery.data?.members ?? [];
+    const participantIds = new Set(
+      (participantsQuery.data ?? []).map((participant) => participant.user_id)
+    );
+    return members
+      .filter((member) => !participantIds.has(member.user_id))
+      .map((member) => ({
+        id: member.user_id,
+        name: idToDisplayName(member.user_id),
+        email: idToEmail(member.user_id),
+      }))
+      .sort((a, b) => a.name.localeCompare(b.name));
+  });
+
+  const visibleCandidates = createMemo<InviteCandidate[]>(() => {
+    const term = query().trim().toLowerCase();
+    if (!term) return candidates();
+    return candidates().filter(
+      (candidate) =>
+        candidate.name.toLowerCase().includes(term) ||
+        candidate.email.toLowerCase().includes(term)
+    );
+  });
+
+  const invite = (candidate: InviteCandidate) => {
+    addParticipantsMutation.mutate({
+      channelId: props.channelId,
+      participants: [candidate.id],
+    });
+  };
+
+  return (
+    <Show when={canInvite() && currentTeamQuery.data}>
+      <Popover
+        placement="top"
+        gutter={8}
+        overflowPadding={8}
+        slide
+        open={open()}
+        onOpenChange={onOpenChange}
+      >
+        <Popover.Trigger
+          as={Button}
+          type="button"
+          variant="ghost"
+          size="sm"
+          title="Invite teammates"
+          aria-label="Invite teammates"
+          tooltip="Invite teammates"
+          tooltipPlacement="top"
+          class="h-7 gap-1.5 rounded-full border border-edge-muted bg-surface px-2.5 text-xs font-normal text-ink-muted"
+          data-input-action="invite-teammates"
+        >
+          <UserPlusIcon />
+          Invite
+        </Popover.Trigger>
+        <Popover.Portal>
+          <Layer depth={3}>
+            <Popover.Content class="z-modal">
+              <div
+                class="flex w-72 flex-col gap-2 rounded-md border border-edge bg-surface p-2 shadow-lg"
+                role="dialog"
+                aria-label="Invite teammates"
+              >
+                <div class="flex w-full flex-row items-center gap-1 rounded-md border border-edge-muted px-2 py-1 text-xs text-ink">
+                  <input
+                    class="w-full bg-transparent outline-none placeholder:text-ink-muted"
+                    value={query()}
+                    onInput={(event) => setQuery(event.currentTarget.value)}
+                    onKeyDown={(event) => {
+                      if (event.key !== 'Enter') return;
+                      const first = visibleCandidates()[0];
+                      if (!first) return;
+                      event.preventDefault();
+                      invite(first);
+                      setQuery('');
+                    }}
+                    placeholder="Search teammates"
+                    role="searchbox"
+                    aria-label="Search teammates"
+                  />
+                </div>
+                <div class="max-h-64 overflow-y-auto overflow-x-hidden">
+                  <Switch>
+                    <Match when={visibleCandidates().length > 0}>
+                      <div class="flex flex-col">
+                        <For each={visibleCandidates()}>
+                          {(candidate) => (
+                            <button
+                              type="button"
+                              class="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left hover:bg-hover"
+                              onClick={() => invite(candidate)}
+                              data-invite-teammate={candidate.id}
+                            >
+                              <UserIcon
+                                id={candidate.id}
+                                size="md"
+                                suppressClick
+                                showTooltip={false}
+                              />
+                              <span class="flex min-w-0 flex-col">
+                                <span class="truncate text-sm text-ink">
+                                  {candidate.name}
+                                </span>
+                                <span class="truncate text-xs text-ink-muted">
+                                  {candidate.email}
+                                </span>
+                              </span>
+                            </button>
+                          )}
+                        </For>
+                      </div>
+                    </Match>
+                    <Match when={loaded() && candidates().length === 0}>
+                      <div class="px-2 py-1.5 text-xs text-ink-muted">
+                        Everyone on your team is already in this channel.
+                      </div>
+                    </Match>
+                    <Match when={loaded()}>
+                      <div class="px-2 py-1.5 text-xs text-ink-muted">
+                        No teammates match your search.
+                      </div>
+                    </Match>
+                    <Match when>
+                      <div class="px-2 py-1.5 text-xs text-ink-muted">
+                        Loading teammates…
+                      </div>
+                    </Match>
+                  </Switch>
+                </div>
+              </div>
+            </Popover.Content>
+          </Layer>
+        </Popover.Portal>
+      </Popover>
+    </Show>
+  );
+}


### PR DESCRIPTION
## Summary

Adds an **Invite** pill to the right of the task toggle in the channel input footer, so teammates can be invited into a channel without leaving the conversation.

- Opens a searchable popover of team members who aren't participants yet
- Clicking a person (or pressing Enter for the first match) adds them to the channel, which sends the standard channel invite notification and shows an "Invite sent to …" toast
- The popover stays open and the invited person drops out of the list (optimistic update), so several people can be invited in one pass

## Scope

- Renders only for **private and team channels** — the backend rejects participant changes on DMs, and public channels are join-only — mirroring the participants tab's add rules
- Requires the viewer to belong to a team ("people on the team" is the candidate pool)
- Shares the task toggle's visibility (desktop web; not iOS/mobile)

## Implementation

- New `InviteTeammatesAction` composed component in `features/channel/Participants/` — owns the team/participants queries and reuses `useAddParticipantsMutation`'s optimistic updates and error toasts
- New `inviteAction` slot on `TaskModeChannelInput`, rendered immediately after `TaskModeSwitch` so it never appears without its anchor
- Wired up in `Channel.tsx`

## Testing

- 8 new tests for `InviteTeammatesAction` (candidate list/sorting, invite mutation, search + Enter-to-invite, everyone-already-in state, DM/public/no-team render nothing)
- New slot-placement test in `task-mode.test.tsx` (invite action is the switch pill's immediate sibling)
- `tsc` type-check clean; biome clean on touched files; all 57 tests in the channel Input/Participants suites pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A1JPTEEE9AFDKv49mDbMiy

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1JPTEEE9AFDKv49mDbMiy)_