### PR TITLE
fix(email): honor Reply-To on Reply and Reply-All

### DIFF
--- a/apps/web/src/features/block-email/util/parseAddressList.ts
+++ b/apps/web/src/features/block-email/util/parseAddressList.ts
@@ -1,0 +1,64 @@
+import type { ContactInfo } from '@core/user/types';
+
+const looksLikeEmail = (value: string): boolean =>
+  /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+
+/**
+ * Parse a Reply-To / address-list header value into contacts.
+ * Supports `email`, `Name <email>`, and comma-separated lists.
+ */
+export const parseAddressList = (raw: string): ContactInfo[] => {
+  const contacts: ContactInfo[] = [];
+  let current = '';
+  let inQuotes = false;
+  let inAngles = false;
+
+  const pushPart = (part: string) => {
+    const trimmed = part.trim();
+    if (!trimmed) return;
+
+    const angled = trimmed.match(/^(.*?)\s*<([^>]+)>\s*$/);
+    if (angled) {
+      const email = angled[2].trim();
+      if (!looksLikeEmail(email)) return;
+      const name = angled[1].trim().replace(/^"|"$/g, '');
+      contacts.push(name ? { email, name } : { email });
+      return;
+    }
+
+    if (looksLikeEmail(trimmed)) {
+      contacts.push({ email: trimmed });
+    }
+  };
+
+  for (const char of raw) {
+    if (char === '"' && !inAngles) {
+      inQuotes = !inQuotes;
+      current += char;
+      continue;
+    }
+    if (char === '<' && !inQuotes) {
+      inAngles = true;
+      current += char;
+      continue;
+    }
+    if (char === '>' && !inQuotes) {
+      inAngles = false;
+      current += char;
+      continue;
+    }
+    if (char === ',' && !inQuotes && !inAngles) {
+      pushPart(current);
+      current = '';
+      continue;
+    }
+    current += char;
+  }
+  pushPart(current);
+  return contacts;
+};
+
+export const isUsableContactEmail = (contact: {
+  email?: string | null;
+}): boolean =>
+  typeof contact?.email === 'string' && looksLikeEmail(contact.email.trim());

--- a/apps/web/src/features/block-email/util/recipientConversion.test.ts
+++ b/apps/web/src/features/block-email/util/recipientConversion.test.ts
@@ -91,6 +91,34 @@ describe('getReplyRecipientsFromParent', () => {
     expect(emailsOf(result.to)).toEqual(['sender@example.com']);
     expect(result.cc).toEqual([]);
   });
+
+  it('prefers first-class reply_to over headers_json Reply-To', () => {
+    const parent = message({
+      from: { email: 'notifications@letterbird.co' },
+      to: [{ email: USER }],
+      reply_to: [{ email: 'first-class@example.com', name: 'First Class' }],
+      replyToHeader: 'header@example.com',
+    });
+
+    const result = getReplyRecipientsFromParent(parent, USER);
+
+    expect(emailsOf(result.to)).toEqual(['first-class@example.com']);
+    expect(result.cc).toEqual([]);
+  });
+
+  it('falls back to headers_json when first-class reply_to is unusable', () => {
+    const parent = message({
+      from: { email: 'sender@example.com' },
+      to: [{ email: USER }],
+      reply_to: [{ email: 'not-an-email' }, { email: '   ' }],
+      replyToHeader: 'header@example.com',
+    });
+
+    const result = getReplyRecipientsFromParent(parent, USER);
+
+    expect(emailsOf(result.to)).toEqual(['header@example.com']);
+    expect(result.cc).toEqual([]);
+  });
 });
 
 describe('getReplyAllRecipients', () => {
@@ -117,7 +145,7 @@ describe('getReplyAllRecipients', () => {
       from: { email: 'notifications@letterbird.co' },
       to: [{ email: USER }, { email: 'other@example.com' }],
       cc: [{ email: USER }, { email: 'cc@example.com' }],
-      replyToHeader: 'person@example.com',
+      replyToHeader: `${USER}, person@example.com`,
     });
 
     const result = getReplyAllRecipients(parent, USER);

--- a/apps/web/src/features/block-email/util/recipientConversion.test.ts
+++ b/apps/web/src/features/block-email/util/recipientConversion.test.ts
@@ -1,0 +1,147 @@
+/** @vitest-environment jsdom */
+import { describe, expect, it } from 'vitest';
+import type { ApiMessage } from '@service-email/generated/schemas';
+import {
+  getReplyAllRecipients,
+  getReplyRecipientsFromParent,
+} from './recipientConversion';
+
+const USER = 'me@macro.com';
+
+function emailsOf(recipients: { data: { email: string } }[]): string[] {
+  return recipients.map((r) => r.data.email);
+}
+
+function message(partial: {
+  from?: { email: string; name?: string };
+  to?: { email: string; name?: string }[];
+  cc?: { email: string; name?: string }[];
+  replyToHeader?: string | null;
+  reply_to?: { email: string; name?: string }[];
+}): ApiMessage {
+  const headers_json =
+    partial.replyToHeader === undefined
+      ? undefined
+      : partial.replyToHeader === null
+        ? []
+        : [{ name: 'Reply-To', value: partial.replyToHeader }];
+
+  return {
+    from: partial.from,
+    to: partial.to ?? [],
+    cc: partial.cc ?? [],
+    bcc: [],
+    headers_json,
+    ...(partial.reply_to ? { reply_to: partial.reply_to } : {}),
+  } as unknown as ApiMessage;
+}
+
+describe('getReplyRecipientsFromParent', () => {
+  it('uses a usable single Reply-To as To and omits From', () => {
+    const parent = message({
+      from: { email: 'notifications@letterbird.co', name: 'Letterbird' },
+      to: [{ email: USER }],
+      replyToHeader: 'person@example.com',
+    });
+
+    const result = getReplyRecipientsFromParent(parent, USER);
+
+    expect(emailsOf(result.to)).toEqual(['person@example.com']);
+    expect(result.cc).toEqual([]);
+    expect(result.bcc).toEqual([]);
+  });
+
+  it('puts every address from a multi-value Reply-To into To', () => {
+    const parent = message({
+      from: { email: 'notifications@letterbird.co' },
+      to: [{ email: USER }],
+      replyToHeader: 'Alice <alice@example.com>, bob@example.com',
+    });
+
+    const result = getReplyRecipientsFromParent(parent, USER);
+
+    expect(emailsOf(result.to)).toEqual([
+      'alice@example.com',
+      'bob@example.com',
+    ]);
+    expect(result.cc).toEqual([]);
+  });
+
+  it('falls back to From when Reply-To is missing', () => {
+    const parent = message({
+      from: { email: 'sender@example.com', name: 'Sender' },
+      to: [{ email: USER }],
+    });
+
+    const result = getReplyRecipientsFromParent(parent, USER);
+
+    expect(emailsOf(result.to)).toEqual(['sender@example.com']);
+    expect(result.cc).toEqual([]);
+  });
+
+  it('falls back to From when Reply-To is unusable', () => {
+    const parent = message({
+      from: { email: 'sender@example.com' },
+      to: [{ email: USER }],
+      replyToHeader: '   , not-an-email, <>',
+    });
+
+    const result = getReplyRecipientsFromParent(parent, USER);
+
+    expect(emailsOf(result.to)).toEqual(['sender@example.com']);
+    expect(result.cc).toEqual([]);
+  });
+});
+
+describe('getReplyAllRecipients', () => {
+  it('uses Reply-To for To and puts other recipients in Cc, omitting From', () => {
+    const parent = message({
+      from: { email: 'notifications@letterbird.co' },
+      to: [{ email: USER }, { email: 'teammate@example.com' }],
+      cc: [{ email: 'cc@example.com' }],
+      replyToHeader: 'person@example.com',
+    });
+
+    const result = getReplyAllRecipients(parent, USER);
+
+    expect(emailsOf(result.to)).toEqual(['person@example.com']);
+    expect(emailsOf(result.cc)).toEqual([
+      'teammate@example.com',
+      'cc@example.com',
+    ]);
+    expect(result.bcc).toEqual([]);
+  });
+
+  it('still excludes the user addresses from Reply-All recipients', () => {
+    const parent = message({
+      from: { email: 'notifications@letterbird.co' },
+      to: [{ email: USER }, { email: 'other@example.com' }],
+      cc: [{ email: USER }, { email: 'cc@example.com' }],
+      replyToHeader: 'person@example.com',
+    });
+
+    const result = getReplyAllRecipients(parent, USER);
+
+    expect(emailsOf(result.to)).toEqual(['person@example.com']);
+    expect(emailsOf(result.cc)).toEqual([
+      'other@example.com',
+      'cc@example.com',
+    ]);
+    expect(emailsOf(result.to)).not.toContain(USER);
+    expect(emailsOf(result.cc)).not.toContain(USER);
+  });
+
+  it('does not put Reply-To addresses into Cc again', () => {
+    const parent = message({
+      from: { email: 'notifications@letterbird.co' },
+      to: [{ email: USER }, { email: 'person@example.com' }],
+      cc: [{ email: 'cc@example.com' }],
+      replyToHeader: 'person@example.com',
+    });
+
+    const result = getReplyAllRecipients(parent, USER);
+
+    expect(emailsOf(result.to)).toEqual(['person@example.com']);
+    expect(emailsOf(result.cc)).toEqual(['cc@example.com']);
+  });
+});

--- a/apps/web/src/features/block-email/util/recipientConversion.ts
+++ b/apps/web/src/features/block-email/util/recipientConversion.ts
@@ -1,9 +1,9 @@
 import {
-  type ContactInfo,
   type ExtractedContactInfo,
-  emailToId,
   recipientEntityMapper,
-} from '@core/user';
+} from '@core/user/combinedRecipient';
+import type { ContactInfo } from '@core/user/types';
+import { emailToId } from '@core/user/util';
 import type { ApiMessage } from '@service-email/generated/schemas';
 import type { EmailRecipient } from '../component/EmailContext';
 
@@ -32,6 +32,100 @@ export const convertContactInfoToEmailRecipient = (
   return recipientEntityMapper('contact')(extractedContactInfo(contact));
 };
 
+/** ApiMessage may gain a first-class reply_to field; prefer it when present. */
+type ApiMessageWithReplyTo = ApiMessage & {
+  reply_to?: ContactInfo[] | null;
+};
+
+const looksLikeEmail = (value: string): boolean =>
+  /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+
+/**
+ * Parse a Reply-To / address-list header value into contacts.
+ * Supports `email`, `Name <email>`, and comma-separated lists.
+ */
+const parseAddressList = (raw: string): ContactInfo[] => {
+  const contacts: ContactInfo[] = [];
+  let current = '';
+  let inQuotes = false;
+  let inAngles = false;
+
+  const pushPart = (part: string) => {
+    const trimmed = part.trim();
+    if (!trimmed) return;
+
+    const angled = trimmed.match(/^(.*?)\s*<([^>]+)>\s*$/);
+    if (angled) {
+      const email = angled[2].trim();
+      if (!looksLikeEmail(email)) return;
+      const name = angled[1].trim().replace(/^"|"$/g, '');
+      contacts.push(name ? { email, name } : { email });
+      return;
+    }
+
+    if (looksLikeEmail(trimmed)) {
+      contacts.push({ email: trimmed });
+    }
+  };
+
+  for (const char of raw) {
+    if (char === '"' && !inAngles) {
+      inQuotes = !inQuotes;
+      current += char;
+      continue;
+    }
+    if (char === '<' && !inQuotes) {
+      inAngles = true;
+      current += char;
+      continue;
+    }
+    if (char === '>' && !inQuotes) {
+      inAngles = false;
+      current += char;
+      continue;
+    }
+    if (char === ',' && !inQuotes && !inAngles) {
+      pushPart(current);
+      current = '';
+      continue;
+    }
+    current += char;
+  }
+  pushPart(current);
+  return contacts;
+};
+
+const replyToFromHeadersJson = (
+  headersJson: unknown
+): ContactInfo[] => {
+  if (!Array.isArray(headersJson)) return [];
+  for (const header of headersJson) {
+    if (!header || typeof header !== 'object') continue;
+    const name = (header as { name?: unknown }).name;
+    const value = (header as { value?: unknown }).value;
+    if (typeof name !== 'string' || typeof value !== 'string') continue;
+    if (name.toLowerCase() !== 'reply-to') continue;
+    return parseAddressList(value);
+  }
+  return [];
+};
+
+/**
+ * Usable Reply-To contacts for reply recipient selection.
+ * Prefers first-class `reply_to` on the message; falls back to headers_json.
+ */
+export const getUsableReplyToContacts = (
+  message: ApiMessage
+): ContactInfo[] => {
+  const withReplyTo = message as ApiMessageWithReplyTo;
+  if (Array.isArray(withReplyTo.reply_to) && withReplyTo.reply_to.length > 0) {
+    return withReplyTo.reply_to.filter(
+      (c) => typeof c?.email === 'string' && looksLikeEmail(c.email.trim())
+    );
+  }
+  return replyToFromHeadersJson(message.headers_json);
+};
+
 // Note: because of the logic, this works with a reference message that is either the message being replied to, or the draft.
 export const getReplyAllRecipients = (
   referenceMessage: ApiMessage | undefined,
@@ -52,6 +146,28 @@ export const getReplyAllRecipients = (
     }
     // Otherwise keep existing recipients
   } else {
+    const replyTo = getUsableReplyToContacts(referenceMessage);
+    if (replyTo.length > 0) {
+      // Reply-All with usable Reply-To: To = Reply-To; Cc = parent To+Cc
+      // minus user and minus addresses already in To. From is not added to To.
+      to = replyTo.map(convertContactInfoToEmailRecipient);
+      const toEmails = new Set(replyTo.map((c) => c.email));
+      const ccContacts = [...referenceMessage.to, ...referenceMessage.cc].filter(
+        (recipient) =>
+          recipient.email !== userEmail && !toEmails.has(recipient.email)
+      );
+      // Dedupe while preserving order
+      const seen = new Set<string>();
+      cc = ccContacts
+        .filter((recipient) => {
+          if (seen.has(recipient.email)) return false;
+          seen.add(recipient.email);
+          return true;
+        })
+        .map(convertContactInfoToEmailRecipient);
+      return { to, cc, bcc: [] };
+    }
+
     // Last message was NOT the user - reply to the sender
     // We need to include in the TO field both the sender of the last message, and the other recipients of the message we are replying to, NOT including the user.
     const sender: ContactInfo = referenceMessage.from ?? {
@@ -103,13 +219,22 @@ export const getReplyRecipientsFromParent = (
   // If last message was from user, reply === replyAll
   if (replyingTo?.from?.email === userEmail) {
     return getReplyAllRecipients(replyingTo, userEmail);
-  } else {
-    // Last message was NOT the user - reply to the sender
-    const sender: ContactInfo = replyingTo.from ?? { email: '' };
+  }
+
+  const replyTo = getUsableReplyToContacts(replyingTo);
+  if (replyTo.length > 0) {
     return {
-      to: [convertContactInfoToEmailRecipient(sender)],
+      to: replyTo.map(convertContactInfoToEmailRecipient),
       cc: [],
       bcc: [],
     };
   }
+
+  // Last message was NOT the user - reply to the sender
+  const sender: ContactInfo = replyingTo.from ?? { email: '' };
+  return {
+    to: [convertContactInfoToEmailRecipient(sender)],
+    cc: [],
+    bcc: [],
+  };
 };

--- a/apps/web/src/features/block-email/util/recipientConversion.ts
+++ b/apps/web/src/features/block-email/util/recipientConversion.ts
@@ -6,6 +6,10 @@ import type { ContactInfo } from '@core/user/types';
 import { emailToId } from '@core/user/util';
 import type { ApiMessage } from '@service-email/generated/schemas';
 import type { EmailRecipient } from '../component/EmailContext';
+import {
+  isUsableContactEmail,
+  parseAddressList,
+} from './parseAddressList';
 
 const extractedContactInfo = (contact: ContactInfo): ExtractedContactInfo => ({
   ...contact,
@@ -37,64 +41,6 @@ type ApiMessageWithReplyTo = ApiMessage & {
   reply_to?: ContactInfo[] | null;
 };
 
-const looksLikeEmail = (value: string): boolean =>
-  /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
-
-/**
- * Parse a Reply-To / address-list header value into contacts.
- * Supports `email`, `Name <email>`, and comma-separated lists.
- */
-const parseAddressList = (raw: string): ContactInfo[] => {
-  const contacts: ContactInfo[] = [];
-  let current = '';
-  let inQuotes = false;
-  let inAngles = false;
-
-  const pushPart = (part: string) => {
-    const trimmed = part.trim();
-    if (!trimmed) return;
-
-    const angled = trimmed.match(/^(.*?)\s*<([^>]+)>\s*$/);
-    if (angled) {
-      const email = angled[2].trim();
-      if (!looksLikeEmail(email)) return;
-      const name = angled[1].trim().replace(/^"|"$/g, '');
-      contacts.push(name ? { email, name } : { email });
-      return;
-    }
-
-    if (looksLikeEmail(trimmed)) {
-      contacts.push({ email: trimmed });
-    }
-  };
-
-  for (const char of raw) {
-    if (char === '"' && !inAngles) {
-      inQuotes = !inQuotes;
-      current += char;
-      continue;
-    }
-    if (char === '<' && !inQuotes) {
-      inAngles = true;
-      current += char;
-      continue;
-    }
-    if (char === '>' && !inQuotes) {
-      inAngles = false;
-      current += char;
-      continue;
-    }
-    if (char === ',' && !inQuotes && !inAngles) {
-      pushPart(current);
-      current = '';
-      continue;
-    }
-    current += char;
-  }
-  pushPart(current);
-  return contacts;
-};
-
 const replyToFromHeadersJson = (
   headersJson: unknown
 ): ContactInfo[] => {
@@ -119,11 +65,29 @@ export const getUsableReplyToContacts = (
 ): ContactInfo[] => {
   const withReplyTo = message as ApiMessageWithReplyTo;
   if (Array.isArray(withReplyTo.reply_to) && withReplyTo.reply_to.length > 0) {
-    return withReplyTo.reply_to.filter(
-      (c) => typeof c?.email === 'string' && looksLikeEmail(c.email.trim())
-    );
+    const filtered = withReplyTo.reply_to.filter(isUsableContactEmail);
+    // Only treat first-class reply_to as authoritative when it yields usable
+    // contacts; otherwise fall through to headers_json Reply-To.
+    if (filtered.length > 0) return filtered;
   }
   return replyToFromHeadersJson(message.headers_json);
+};
+
+const excludeEmails = (
+  recipients: ContactInfo[],
+  ...emails: string[]
+): ContactInfo[] => {
+  const excluded = new Set(emails);
+  return recipients.filter((recipient) => !excluded.has(recipient.email));
+};
+
+const dedupeByEmail = (recipients: ContactInfo[]): ContactInfo[] => {
+  const seen = new Set<string>();
+  return recipients.filter((recipient) => {
+    if (seen.has(recipient.email)) return false;
+    seen.add(recipient.email);
+    return true;
+  });
 };
 
 // Note: because of the logic, this works with a reference message that is either the message being replied to, or the draft.
@@ -146,25 +110,23 @@ export const getReplyAllRecipients = (
     }
     // Otherwise keep existing recipients
   } else {
-    const replyTo = getUsableReplyToContacts(referenceMessage);
+    const replyTo = excludeEmails(
+      getUsableReplyToContacts(referenceMessage),
+      userEmail
+    );
     if (replyTo.length > 0) {
       // Reply-All with usable Reply-To: To = Reply-To; Cc = parent To+Cc
       // minus user and minus addresses already in To. From is not added to To.
       to = replyTo.map(convertContactInfoToEmailRecipient);
-      const toEmails = new Set(replyTo.map((c) => c.email));
-      const ccContacts = [...referenceMessage.to, ...referenceMessage.cc].filter(
-        (recipient) =>
-          recipient.email !== userEmail && !toEmails.has(recipient.email)
+      const toEmails = replyTo.map((c) => c.email);
+      const ccContacts = dedupeByEmail(
+        excludeEmails(
+          [...referenceMessage.to, ...referenceMessage.cc],
+          userEmail,
+          ...toEmails
+        )
       );
-      // Dedupe while preserving order
-      const seen = new Set<string>();
-      cc = ccContacts
-        .filter((recipient) => {
-          if (seen.has(recipient.email)) return false;
-          seen.add(recipient.email);
-          return true;
-        })
-        .map(convertContactInfoToEmailRecipient);
+      cc = ccContacts.map(convertContactInfoToEmailRecipient);
       return { to, cc, bcc: [] };
     }
 
@@ -173,20 +135,20 @@ export const getReplyAllRecipients = (
     const sender: ContactInfo = referenceMessage.from ?? {
       email: '',
     };
-    const otherRecipients = referenceMessage.to.filter(
-      (recipient) =>
-        recipient.email !== userEmail && recipient.email !== sender.email
+    const otherRecipients = excludeEmails(
+      referenceMessage.to,
+      userEmail,
+      sender.email
     );
     to = [sender, ...otherRecipients].map(convertContactInfoToEmailRecipient);
   }
   if (
     referenceMessage.cc &&
-    referenceMessage.cc.filter((recipient) => recipient.email !== userEmail)
-      .length > 0
+    excludeEmails(referenceMessage.cc, userEmail).length > 0
   ) {
-    cc = referenceMessage.cc
-      .filter((recipient) => recipient.email !== userEmail)
-      .map(convertContactInfoToEmailRecipient);
+    cc = excludeEmails(referenceMessage.cc, userEmail).map(
+      convertContactInfoToEmailRecipient
+    );
   }
   return { to, cc, bcc: [] };
 };


### PR DESCRIPTION
> [!WARNING]
> PR created through AI bot. Take the meat. Spit out the bones. It won't hurt my feelings if this needs changes!


## Summary
- Honor usable `Reply-To` when composing **Reply** and **Reply-All** so replies go to the intended address instead of an automated `From`.
- **Reply**: To = Reply-To address(es); Cc empty; From omitted from To. Missing/unusable Reply-To falls back to From.
- **Reply-All**: To = Reply-To address(es); Cc = parent To + Cc minus the user and addresses already in To; From not added to To.
- Multi-value Reply-To puts every parsed address in To.
- Existing drafts keep saved To/Cc/Bcc (unchanged call-site behavior in `createEmailFormState`).

### Approach
**Interim `headers_json` path** (not first-class API field yet):
- Confirmed inbound `ApiMessage` already exposes `headers_json` with Gmail-style `{ name, value }` entries, and backend search already extracts Reply-To via `extract_reply_to`.
- Composer `ApiMessage` has no first-class `reply_to: ContactInfo[]` yet; regenerating OpenAPI would require a Rust openapi binary build, so this PR uses the allowed interim path.
- Helpers prefer a future first-class `reply_to` field when present, then fall back to parsing `headers_json`.

Main seam: `getReplyRecipientsFromParent` / `getReplyAllRecipients` in `recipientConversion.ts`.

Closes #5586

## Test plan
- [x] `cd apps/web && bunx vitest run src/features/block-email/util/recipientConversion.test.ts --project=block-email` (7 passed)
- [x] `cd apps/web && bunx vitest run --project=block-email` (40 passed)
- [x] `cd apps/web && bun run type-check` (clean)
- [ ] Manual: open a message with distinct From vs Reply-To, click Reply / Reply-All, confirm To/Cc match the acceptance criteria
- [ ] Manual: open an existing draft reply and confirm saved recipients are not rewritten