### PR TITLE
fix(convert): notify DOCX uploads with mixed-case extensions

### DIFF
--- a/services/convert_service/src/process/convert.rs
+++ b/services/convert_service/src/process/convert.rs
@@ -16,6 +16,10 @@ use crate::{
 
 static MAX_WAIT_TIME_SECONDS: u64 = 30;
 
+fn is_docx_key(key: &str) -> bool {
+    key.to_ascii_lowercase().ends_with(".docx")
+}
+
 /// Processes a message from the convert queue
 /// Returns the job id and the convert queue message
 #[tracing::instrument(skip(worker, s3_client, lambda_client, message), fields(message_id = message.message_id))]
@@ -69,7 +73,7 @@ pub async fn process_message(
 
     match result {
         Ok(_) => {
-            if req.from_key.ends_with(".docx") {
+            if is_docx_key(&req.from_key) {
                 tracing::trace!("sending success message to lambda");
                 lambda_client
                     .invoke_event(
@@ -97,7 +101,7 @@ pub async fn process_message(
             }
         }
         Err(e) => {
-            if req.from_key.ends_with(".docx") {
+            if is_docx_key(&req.from_key) {
                 tracing::trace!("sending failure message to lambda");
                 lambda_client
                     .invoke_event(
@@ -124,6 +128,23 @@ pub async fn process_message(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use super::is_docx_key;
+
+    #[test]
+    fn docx_detection_accepts_mixed_case_extensions() {
+        assert!(is_docx_key("uploads/report.DOCX"));
+        assert!(is_docx_key("uploads/report.DoCx"));
+    }
+
+    #[test]
+    fn docx_detection_requires_the_final_extension() {
+        assert!(!is_docx_key("uploads/report.docx.tmp"));
+        assert!(!is_docx_key("uploads/docx"));
+    }
 }
 
 pub async fn convert(

--- a/services/convert_service/src/process/convert.rs
+++ b/services/convert_service/src/process/convert.rs
@@ -16,7 +16,7 @@ use crate::{
 
 static MAX_WAIT_TIME_SECONDS: u64 = 30;
 
-fn is_docx_key(key: &str) -> bool {
+pub(super) fn is_docx_key(key: &str) -> bool {
     key.to_ascii_lowercase().ends_with(".docx")
 }
 
@@ -128,23 +128,6 @@ pub async fn process_message(
     }
 
     Ok(())
-}
-
-#[cfg(test)]
-mod test {
-    use super::is_docx_key;
-
-    #[test]
-    fn docx_detection_accepts_mixed_case_extensions() {
-        assert!(is_docx_key("uploads/report.DOCX"));
-        assert!(is_docx_key("uploads/report.DoCx"));
-    }
-
-    #[test]
-    fn docx_detection_requires_the_final_extension() {
-        assert!(!is_docx_key("uploads/report.docx.tmp"));
-        assert!(!is_docx_key("uploads/docx"));
-    }
 }
 
 pub async fn convert(

--- a/services/convert_service/src/process/mod.rs
+++ b/services/convert_service/src/process/mod.rs
@@ -1,2 +1,5 @@
 mod convert;
 pub mod runner;
+
+#[cfg(test)]
+mod test;

--- a/services/convert_service/src/process/test.rs
+++ b/services/convert_service/src/process/test.rs
@@ -1,0 +1,13 @@
+use super::convert::is_docx_key;
+
+#[test]
+fn docx_detection_accepts_mixed_case_extensions() {
+    assert!(is_docx_key("uploads/report.DOCX"));
+    assert!(is_docx_key("uploads/report.DoCx"));
+}
+
+#[test]
+fn docx_detection_requires_the_final_extension() {
+    assert!(!is_docx_key("uploads/report.docx.tmp"));
+    assert!(!is_docx_key("uploads/docx"));
+}


### PR DESCRIPTION
## Problem

`process_message` only recognized keys ending in lowercase `.docx` when deciding whether to send the completion or failure callback. The conversion parser accepts extensions case-insensitively, so `.DOCX` uploads could convert successfully while the client received no status update.

## Fix

Use the same case-insensitive extension behavior for callback routing and add focused tests for mixed-case and trailing-extension cases.

## Verification

- `cargo test -p convert_service docx_detection --offline`
- `cargo fmt --all -- --check`

No existing open issue or pull request covers this callback mismatch.