### PR TITLE
fix(call): skip preview cleanup for non-mp4 recordings

### DIFF
--- a/crates/call/src/domain/service.rs
+++ b/crates/call/src/domain/service.rs
@@ -1860,6 +1860,9 @@ fn recording_key_parent_and_file_name(recording_key: &str) -> Option<(&str, &str
 
 fn derive_preview_key_from_recording_key(recording_key: &str) -> Option<String> {
     let (parent, file_name) = recording_key_parent_and_file_name(recording_key)?;
+    if !file_name.ends_with(".mp4") {
+        return None;
+    }
     let recording_stem = file_name.strip_suffix(".mp4").unwrap_or(file_name);
 
     Some(format!("calls/{parent}/{recording_stem}/PREVIEW.jpg"))

--- a/crates/call/src/domain/service/test.rs
+++ b/crates/call/src/domain/service/test.rs
@@ -2224,6 +2224,11 @@ fn derive_preview_key_from_recording_key_returns_none_without_parent() {
 }
 
 #[test]
+fn derive_preview_key_from_recording_key_returns_none_for_non_mp4_recording() {
+    assert!(derive_preview_key_from_recording_key("abc-123/recording.mov").is_none());
+}
+
+#[test]
 fn derive_preview_keys_from_recording_key_includes_new_and_legacy_mp4_paths() {
     assert_eq!(
         derive_preview_keys_from_recording_key("abc-123/recording.mp4"),


### PR DESCRIPTION
## Problem

When a call record has no stored preview key, deletion derives fallback preview paths from the recording key. The helper derived paths for every filename, even though the preview producer only handles `.mp4` recordings. A non-MP4 recording could therefore trigger deletion attempts for paths that cannot exist.

## Fix

Return no derived preview key unless the recording filename ends in `.mp4`, and cover the non-MP4 case with a regression test.

## Verification

- `cargo check -p call --no-default-features --features ports`
- `cargo fmt --all -- --check`

The focused unit target is included, but this checkout cannot compile the full call test binary because existing SQLx tests require unavailable query-cache entries.