### PR TITLE
fix(middleware): connection_drop_prevention_handler loses tracing context and amplifies panics

### DIFF
--- a/crates/macro_middleware/src/lib.rs
+++ b/crates/macro_middleware/src/lib.rs
@@ -1,9 +1,10 @@
 use axum::{
     body::Body,
     extract::Request,
-    http::{Method, Response},
+    http::{Method, Response, StatusCode},
     middleware::Next,
 };
+use tracing::Instrument;
 
 #[cfg(feature = "cloud_storage")]
 pub mod cloud_storage;
@@ -19,7 +20,23 @@ mod error_handler;
 pub async fn connection_drop_prevention_handler(req: Request, next: Next) -> Response<Body> {
     match req.method() {
         &Method::PUT | &Method::POST | &Method::PATCH | &Method::DELETE => {
-            tokio::task::spawn(next.run(req)).await.unwrap()
+            let span = tracing::Span::current();
+            let handle = tokio::task::spawn(next.run(req).instrument(span));
+            
+            match handle.await {
+                Ok(response) => response,
+                Err(err) => {
+                    if err.is_panic() {
+                        tracing::error!("Request handler panicked: {:?}", err);
+                    } else {
+                        tracing::error!("Request handler task was cancelled: {:?}", err);
+                    }
+                    Response::builder()
+                        .status(StatusCode::INTERNAL_SERVER_ERROR)
+                        .body(Body::empty())
+                        .unwrap()
+                }
+            }
         }
         _ => next.run(req).await,
     }

--- a/crates/macro_middleware/src/lib.rs
+++ b/crates/macro_middleware/src/lib.rs
@@ -27,9 +27,9 @@ pub async fn connection_drop_prevention_handler(req: Request, next: Next) -> Res
                 Ok(response) => response,
                 Err(err) => {
                     if err.is_panic() {
-                        tracing::error!("Request handler panicked: {:?}", err);
+                        tracing::error!(error=?err, "request handler panicked");
                     } else {
-                        tracing::error!("Request handler task was cancelled: {:?}", err);
+                        tracing::error!(error=?err, "request handler task was cancelled");
                     }
                     Response::builder()
                         .status(StatusCode::INTERNAL_SERVER_ERROR)


### PR DESCRIPTION
## Summary

While exploring the architecture in `crates/macro_middleware/src/lib.rs`, I noticed an observability bug in the `connection_drop_prevention_handler`. This middleware wraps mutating requests in `tokio::task::spawn` to prevent database operations from being aborted if the client drops the connection.

By moving the request execution into a new tokio task without explicit instrumentation, this inadvertently introduces two problems:

1. **Loss of Tracing/Logging Context:** `tokio::task::spawn` does not inherit the current thread-local `tracing::Span`. Any logs (`tracing::info!`, `error!`, etc.) emitted downstream inside the request handler are completely orphaned. They lose the `request_id`, user context, and path set by outer middleware layers, making production debugging very difficult for POST/PUT requests.
2. **Panic Amplification:** Using `.unwrap()` on the `JoinHandle` means that if the inner handler panics, the `JoinError::Panic` is unwrapped, causing the middleware itself to panic. This bypasses normal Axum panic-handling layers and abruptly kills the connection, rather than returning a clean HTTP 500.

## Proposed Fix

1. Use `.instrument(tracing::Span::current())` from the `tracing` crate to explicitly pass the span into the spawned task.
2. Handle the `JoinError` gracefully, mapping it to a 500 response.

This PR implements these fixes, ensuring that network drops won't cancel the query, while keeping production observability intact and safely converting task panics to standard 500s.