### PR TITLE
feat(iac): configurable queue alarms

### DIFF
--- a/infra/packages/resources/src/resources/queue.ts
+++ b/infra/packages/resources/src/resources/queue.ts
@@ -1,9 +1,11 @@
 import * as aws from '@pulumi/aws';
 import * as pulumi from '@pulumi/pulumi';
 import { CLOUD_TRAIL_SNS_TOPIC_ARN, stack } from '../../../shared';
+import type { QueueAlarmOptions } from './queue_alarms';
 import { QueueAlarms } from './queue_alarms';
 
 type Args = {
+  alarm?: QueueAlarmOptions;
   // The maximum receive count of a message before it's sent to DLQ
   maxReceiveCount?: number;
   tags: { [key: string]: string };
@@ -81,7 +83,7 @@ export class Queue extends pulumi.ComponentResource {
 
     new QueueAlarms(
       `${name}-alarm`,
-      { queue: this.queue, tags },
+      { ...args.alarm, queue: this.queue, tags },
       { parent: this }
     );
   }

--- a/infra/packages/resources/src/resources/queue_alarms.ts
+++ b/infra/packages/resources/src/resources/queue_alarms.ts
@@ -2,17 +2,20 @@ import * as aws from '@pulumi/aws';
 import * as pulumi from '@pulumi/pulumi';
 import { CLOUD_TRAIL_SNS_TOPIC_ARN } from '../../../shared';
 
-type Args = {
-  // The queue to create alarms for
-  queue: aws.sqs.Queue;
-  // The tags to apply to the alarms
-  tags: { [key: string]: string };
+export type QueueAlarmOptions = {
   // The evaluation periods for the alarm
   // Defaults to 60s
   approximateAgeOfOldestMessageEvaluationPeriods?: number;
   // The threshold for the alarm
   // Defaults to 120s
   approximateAgeOfOldestMessageThreshold?: number;
+};
+
+type Args = QueueAlarmOptions & {
+  // The queue to create alarms for
+  queue: aws.sqs.Queue;
+  // The tags to apply to the alarms
+  tags: { [key: string]: string };
 };
 
 /**

--- a/infra/stacks/email-service/index.ts
+++ b/infra/stacks/email-service/index.ts
@@ -118,6 +118,9 @@ const inbox_sync_queue = new Queue('email-service-gmail-webhook', {
   tags,
   maxReceiveCount: 3,
   visibilityTimeoutSeconds: 60,
+  alarm: {
+    approximateAgeOfOldestMessageThreshold: 300, // 5 minutes
+  },
 });
 
 export const inboxSyncQueueArn = pulumi.interpolate`${inbox_sync_queue.queue.arn}`;
@@ -127,6 +130,9 @@ const inbox_sync_retry_queue = new Queue('email-service-gmail-webhook-retry', {
   tags,
   maxReceiveCount: 100,
   visibilityTimeoutSeconds: 60,
+  alarm: {
+    approximateAgeOfOldestMessageThreshold: 300, // 5 minutes
+  },
 });
 
 export const inboxSyncRetryQueueArn = pulumi.interpolate`${inbox_sync_retry_queue.queue.arn}`;
@@ -136,6 +142,9 @@ const gmail_ops_queue = new Queue('email-service-gmail-ops', {
   tags,
   maxReceiveCount: 3,
   visibilityTimeoutSeconds: 60,
+  alarm: {
+    approximateAgeOfOldestMessageThreshold: 300, // 5 minutes
+  },
 });
 
 export const gmailOpsQueueArn = pulumi.interpolate`${gmail_ops_queue.queue.arn}`;
@@ -145,6 +154,9 @@ const gmail_ops_retry_queue = new Queue('email-service-gmail-ops-retry', {
   tags,
   maxReceiveCount: 100,
   visibilityTimeoutSeconds: 60,
+  alarm: {
+    approximateAgeOfOldestMessageThreshold: 300, // 5 minutes
+  },
 });
 
 export const gmailOpsRetryQueueArn = pulumi.interpolate`${gmail_ops_retry_queue.queue.arn}`;
@@ -170,6 +182,9 @@ const backfill_queue = new Queue('email-service-backfill', {
   tags,
   maxReceiveCount: 20,
   visibilityTimeoutSeconds: 60,
+  alarm: {
+    approximateAgeOfOldestMessageThreshold: 600, // 10 minutes
+  },
 });
 
 export const backfillQueueArn = pulumi.interpolate`${backfill_queue.queue.arn}`;
@@ -179,6 +194,9 @@ const crm_cleanup_queue = new Queue('email-service-crm-cleanup', {
   tags,
   maxReceiveCount: 5,
   visibilityTimeoutSeconds: 60,
+  alarm: {
+    approximateAgeOfOldestMessageThreshold: 600, // 10 minutes
+  },
 });
 
 export const crmCleanupQueueArn = pulumi.interpolate`${crm_cleanup_queue.queue.arn}`;


### PR DESCRIPTION
- adds in ability to configure queue alarm threshold from the Queue resource
- updates email queues alarm thresholds to be more reasonable based on metric data of our existing usage patterns