### PR TITLE
fix(calendar): request only the Google Calendar scopes Macro uses

### DIFF
--- a/crates/calendar_events/src/domain/models.rs
+++ b/crates/calendar_events/src/domain/models.rs
@@ -6,12 +6,19 @@ use chrono::{DateTime, NaiveDate, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-/// Top-level Google scope granting the complete calendar capability,
-/// mirroring how email requests the single broad `gmail.modify` scope.
-pub const GOOGLE_CALENDAR_SCOPE: &str = "https://www.googleapis.com/auth/calendar";
+/// Read and write events on every calendar the user can access. Covers the
+/// event list, get, instances, insert, patch, and watch calls.
+pub const GOOGLE_CALENDAR_EVENTS_SCOPE: &str = "https://www.googleapis.com/auth/calendar.events";
+
+/// Read the user's calendar subscriptions. Covers the `calendarList` call that
+/// discovers which calendars to sync.
+pub const GOOGLE_CALENDAR_LIST_SCOPE: &str =
+    "https://www.googleapis.com/auth/calendar.calendarlist.readonly";
 
 /// The Google Calendar scopes Macro requests for the calendar capability.
-pub const GOOGLE_CALENDAR_SCOPES: [&str; 1] = [GOOGLE_CALENDAR_SCOPE];
+pub const GOOGLE_CALENDAR_SCOPES: [&str; 2] =
+    [GOOGLE_CALENDAR_EVENTS_SCOPE, GOOGLE_CALENDAR_LIST_SCOPE];
+
 /// Build the space-delimited calendar scope fragment for an OAuth authorization URL.
 pub fn google_calendar_scope_parameter() -> String {
     GOOGLE_CALENDAR_SCOPES.join(" ")

--- a/crates/calendar_events/src/domain/service/test.rs
+++ b/crates/calendar_events/src/domain/service/test.rs
@@ -235,12 +235,24 @@ fn rejects_invalid_occurrence_time() {
 }
 
 #[test]
-fn complete_scope_capability_requires_top_level_scope() {
+fn complete_scope_capability_requires_every_requested_scope() {
     let complete = GoogleScopeSet::parse(&GOOGLE_CALENDAR_SCOPES.join(" "));
     assert!(complete.has_calendar_capability());
 
-    let partial = GoogleScopeSet::parse("https://www.googleapis.com/auth/calendar.events");
-    assert!(!partial.has_calendar_capability());
+    for scope in GOOGLE_CALENDAR_SCOPES {
+        let partial = GoogleScopeSet::parse(scope);
+        assert!(
+            !partial.has_calendar_capability(),
+            "{scope} alone must not read as the complete capability"
+        );
+    }
+}
+
+#[test]
+fn broad_calendar_grant_no_longer_reads_as_the_capability() {
+    let broad = GoogleScopeSet::parse("https://www.googleapis.com/auth/calendar");
+
+    assert!(!broad.has_calendar_capability());
 }
 
 #[derive(Clone)]

--- a/infra/stacks/fusionauth-instance/index.ts
+++ b/infra/stacks/fusionauth-instance/index.ts
@@ -436,7 +436,10 @@ new FusionAuthIdpOpenIdConnect(
 const enableGoogleCalendarIntegration = config.requireBoolean(
   'enable-google-calendar'
 );
-const GOOGLE_CALENDAR_SCOPES = ['https://www.googleapis.com/auth/calendar'];
+const GOOGLE_CALENDAR_SCOPES = [
+  'https://www.googleapis.com/auth/calendar.events',
+  'https://www.googleapis.com/auth/calendar.calendarlist.readonly',
+];
 
 const GOOGLE_GMAIL_OAUTH_SCOPES = [
   'openid',


### PR DESCRIPTION
keeping scopes in line with current capability