### PR TITLE
fix(ios): ipad

### DIFF
--- a/apps/web/src/components/app/Layout.tsx
+++ b/apps/web/src/components/app/Layout.tsx
@@ -56,6 +56,7 @@ import { isSoloSettings } from '@core/constant/SettingsState';
 import { attachGlobalDOMScope } from '@core/hotkey/hotkeys';
 import { isMobile } from '@core/mobile/isMobile';
 import { isNativeMobilePlatform } from '@core/mobile/isNativeMobilePlatform';
+import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import { virtualKeyboardVisible } from '@core/mobile/virtualKeyboard';
 import { updateCookie } from '@core/util/cookies';
 import { useUserInfoQuery } from '@queries/auth/user-info';
@@ -101,7 +102,7 @@ const AUTH_URLS = [
 ];
 
 const [sidebarState, setSidebarState] = makePersisted(
-  createSignal<SidebarState>(!isMobile() ? 'expanded' : 'hidden'),
+  createSignal<SidebarState>(!isTouchDevice() ? 'expanded' : 'hidden'),
   {
     name: 'sidebar-state',
   }
@@ -112,7 +113,7 @@ export function Layout(props: RouteSectionProps) {
   const location = useLocation();
   const sidebarVisible = createMemo(
     () =>
-      !isMobile() &&
+      !isTouchDevice() &&
       isAuthenticated() === true &&
       !AUTH_URLS.includes(location.pathname) &&
       // Settings-as-the-sole-split has its own tab nav — hide app chrome.
@@ -438,7 +439,7 @@ function LayoutInner(props: RouteSectionProps) {
             <CalendarPermissionPrompt />
           </Show>
           <GlobalShortcuts />
-          <Show when={!isMobile()}>
+          <Show when={!isTouchDevice()}>
             <GoToHotkeys />
             <Suspense>
               <FavoritesCommands />
@@ -495,7 +496,7 @@ function LayoutInner(props: RouteSectionProps) {
               onOverlayOpenChange={setSidebarOverlayOpenGuarded}
               onOpenChange={(open) => {
                 if (!open) {
-                  setSidebarState(isMobile() ? 'hidden' : 'slim');
+                  setSidebarState(isTouchDevice() ? 'hidden' : 'slim');
                   return;
                 }
 
@@ -533,7 +534,7 @@ function LayoutInner(props: RouteSectionProps) {
       <CollapsedSidebarCallWidget visible={activeCallWidgetVisible()} />
       <Show
         when={
-          isMobile() &&
+          isTouchDevice() &&
           isAuthenticated() &&
           !AUTH_URLS.includes(location.pathname)
         }
@@ -544,7 +545,7 @@ function LayoutInner(props: RouteSectionProps) {
           <MobileDock />
         </FloatRegion>
       </Show>
-      <Show when={isMobile()}>
+      <Show when={isTouchDevice()}>
         <MobileSearchOuter />
       </Show>
       <SwipeDownDismissKeyboard />

--- a/apps/web/src/components/app/ResponsiveBlockToolbar.tsx
+++ b/apps/web/src/components/app/ResponsiveBlockToolbar.tsx
@@ -1,5 +1,5 @@
 import type { HotkeyToken } from '@core/hotkey/tokens';
-import { isMobile } from '@core/mobile/isMobile';
+import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import type { ItemType } from '@service-storage/client';
 import { Button, cn } from '@ui';
 import { type Component, For, type JSX, Show } from 'solid-js';
@@ -65,7 +65,7 @@ function getToolLabel(tool: BlockTool) {
 export function ResponsivePermissionsBadge() {
   return (
     <Show
-      when={isMobile()}
+      when={isTouchDevice()}
       fallback={
         <SplitHeaderRight>
           <SplitPermissionsBadge />
@@ -123,7 +123,7 @@ export function ResponsiveBlockToolbar(props: BlockToolbarProps) {
 
   return (
     <Show
-      when={isMobile()}
+      when={isTouchDevice()}
       fallback={
         <>
           <SplitHeaderRight>

--- a/apps/web/src/components/app/mobile/PullToRefresh.tsx
+++ b/apps/web/src/components/app/mobile/PullToRefresh.tsx
@@ -1,6 +1,6 @@
 import { toast } from '@core/component/Toast/Toast';
 import { hapticImpact } from '@core/mobile/haptics';
-import { isMobile } from '@core/mobile/isMobile';
+import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import Spinner from '@phosphor-icons/core/bold/spinner-bold.svg';
 import { cn } from '@ui';
 import {
@@ -101,7 +101,7 @@ export function PullToRefresh(props: {
   };
 
   const onTouchStart = (e: TouchEvent) => {
-    if (!isMobile() || phase() !== 'idle') return;
+    if (!isTouchDevice() || phase() !== 'idle') return;
     if (e.touches.length !== 1) return;
 
     const container = props.scrollContainer();
@@ -220,7 +220,7 @@ export function PullToRefresh(props: {
   const isRefreshing = () => phase() === 'refreshing';
 
   return (
-    <Show when={isMobile()}>
+    <Show when={isTouchDevice()}>
       <div
         class="pointer-events-none absolute inset-x-0 flex justify-center"
         style={{

--- a/apps/web/src/components/app/mobile/float-regions/FloatRegion.tsx
+++ b/apps/web/src/components/app/mobile/float-regions/FloatRegion.tsx
@@ -1,5 +1,5 @@
 import { useSplitPanel } from '@components/app/split-layout/layoutUtils';
-import { isMobile } from '@core/mobile/isMobile';
+import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import { onCleanup, type ParentProps, Show } from 'solid-js';
 import { Portal } from 'solid-js/web';
 import { type FloatRegionName, FloatRegions } from './float-region-state';
@@ -32,7 +32,7 @@ export function FloatRegion(props: FloatRegionProps) {
     region: props.region,
     priority: props.priority ?? 0,
     isActive: () =>
-      isMobile() &&
+      isTouchDevice() &&
       (panel?.isPanelActive() ?? true) &&
       (props.active?.() ?? true),
   });
@@ -52,7 +52,7 @@ export function FloatRegion(props: FloatRegionProps) {
  */
 export function FloatRegionOrInline(props: FloatRegionProps) {
   return (
-    <Show when={isMobile()} fallback={props.children}>
+    <Show when={isTouchDevice()} fallback={props.children}>
       <FloatRegion {...props} />
     </Show>
   );

--- a/apps/web/src/components/app/side-panel/SidePanel.tsx
+++ b/apps/web/src/components/app/side-panel/SidePanel.tsx
@@ -1,6 +1,7 @@
 import { Resize, ResizeZoneContext } from '@core/component/Resize/Resize';
 import { TOKENS } from '@core/hotkey/tokens';
 import { isMobile } from '@core/mobile/isMobile';
+import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import SidePanelIcon from '@icon/square-half-filled.svg';
 import { Accordion } from '@kobalte/core/accordion';
 import ArrowLeft from '@phosphor/arrow-left.svg';
@@ -192,7 +193,7 @@ function SidePanelLayoutInner(
           <Scroll>
             {/* Full-frame mobile: the overlay spans the whole panel, so the
                 content must clear the floating header islands + status bar. */}
-            <div class="w-full max-w-2xl mx-auto min-w-0 mobile:pt-(--mobile-content-inset-top)">
+            <div class="w-full max-w-2xl mx-auto min-w-0 touch:pt-(--mobile-content-inset-top)">
               <div class="px-2 pt-2">
                 <Button
                   variant="ghost"
@@ -227,10 +228,10 @@ function SidePanelHeaderToggle() {
       variant="base"
       size="icon-sm"
       class={cn(
-        !isMobile() && 'bg-surface',
-        isMobile() &&
+        !isTouchDevice() && 'bg-surface',
+        isTouchDevice() &&
           'border-transparent! hover:bg-transparent! active:bg-transparent! focus-visible:bg-transparent! active:text-accent',
-        isMobile() && ctx.isOpen() && 'text-accent'
+        isTouchDevice() && ctx.isOpen() && 'text-accent'
       )}
       tooltip={ctx.isOpen() ? 'Hide Side Panel' : 'Show Side Panel'}
       hotkey={TOKENS.block.toggleSidePanel}

--- a/apps/web/src/components/app/split-layout/SplitLayout.tsx
+++ b/apps/web/src/components/app/split-layout/SplitLayout.tsx
@@ -4,8 +4,8 @@ import {
   useSidebarCollapse,
 } from '@components/app/sidebarVisibility';
 import { Resize } from '@core/component/Resize';
-import { isMobile } from '@core/mobile/isMobile';
 import { isNativeMobilePlatform } from '@core/mobile/isNativeMobilePlatform';
+import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import { tabTitleSignal } from '@core/signal/tabTitle';
 import { useWindowSize } from '@solid-primitives/resize-observer';
 import { useLocation, useNavigate } from '@solidjs/router';
@@ -53,7 +53,7 @@ export function SplitLayoutContainer(props: SplitLayoutContainerProps) {
   const previewQuery = () => location.query[PREVIEW_QUERY_PARAM];
   const decodedLayout = createMemo(() =>
     loadRestorablePreviewLayout(props.pairs, previewQuery(), {
-      allowPreviewPairs: !isMobile(),
+      allowPreviewPairs: !isTouchDevice(),
     })
   );
   const initialLayout = decodedLayout();
@@ -116,7 +116,7 @@ export function SplitLayoutContainer(props: SplitLayoutContainerProps) {
   return (
     <SplitLayoutContext.Provider value={{ manager: splitManager }}>
       <div
-        class={cn('size-full p-2 mobile:p-0', {
+        class={cn('size-full p-2 touch:p-0', {
           'pl-0': isSidebarVisible() && !sidebar.isCollapsed(),
         })}
       >

--- a/apps/web/src/components/app/split-layout/components/HeaderIsland.tsx
+++ b/apps/web/src/components/app/split-layout/components/HeaderIsland.tsx
@@ -1,4 +1,4 @@
-import { isMobile } from '@core/mobile/isMobile';
+import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import { cn, Layer } from '@ui';
 import { type ComponentProps, Show, splitProps } from 'solid-js';
 
@@ -19,7 +19,7 @@ export function HeaderIsland(props: ComponentProps<'div'>) {
   const [local, rest] = splitProps(props, ['class', 'children']);
 
   return (
-    <Show when={isMobile()} fallback={local.children}>
+    <Show when={isTouchDevice()} fallback={local.children}>
       <Layer depth={3}>
         <div
           {...rest}

--- a/apps/web/src/components/app/split-layout/components/HeaderTitleMenu.tsx
+++ b/apps/web/src/components/app/split-layout/components/HeaderTitleMenu.tsx
@@ -32,7 +32,7 @@ export function HeaderTitleMenu(
 ) {
   return (
     <Dropdown placement="bottom-start">
-      <Dropdown.Trigger class="ph-no-capture h-8 max-w-full min-w-0 gap-1.5 border-none bg-transparent px-1 text-ink mobile:active:bg-transparent">
+      <Dropdown.Trigger class="ph-no-capture h-8 max-w-full min-w-0 gap-1.5 border-none bg-transparent px-1 text-ink touch:active:bg-transparent">
         {props.children}
         <CaretDownIcon class="size-3 shrink-0 text-ink-muted" />
       </Dropdown.Trigger>

--- a/apps/web/src/components/app/split-layout/components/SplitHeader.tsx
+++ b/apps/web/src/components/app/split-layout/components/SplitHeader.tsx
@@ -13,6 +13,7 @@ import { fileTypeToBlockName } from '@core/constant/allBlocks';
 import { TOKENS } from '@core/hotkey/tokens';
 import { isMobile } from '@core/mobile/isMobile';
 import { isNativeMobilePlatform } from '@core/mobile/isNativeMobilePlatform';
+import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import type { EntityDragEvent } from '@entity';
 import { AnimatedSquareSidebarIcon } from '@icon/square-sidebar';
 import SplitIcon from '@icon/wide-newSplit.svg';
@@ -89,7 +90,7 @@ function SplitBackButton() {
   if (!context) return null;
   return (
     <Button
-      class="p-1 rounded-lg mobile:active:bg-transparent"
+      class="p-1 rounded-lg touch:active:bg-transparent"
       label="Go Back"
       hotkey={TOKENS.split.go.back}
       disabled={!context.handle.canGoBack()}
@@ -241,7 +242,7 @@ function SoupNavigationButtons() {
   const shouldShow = createMemo(() => {
     // The mobile swipe layout doesn't handle mergeHistory navigations, so
     // these controls would silently no-op there.
-    if (isMobile()) return false;
+    if (isTouchDevice()) return false;
 
     const referredFrom = navigationReferredFrom();
     const isNavigableListView =
@@ -491,11 +492,13 @@ export function SplitHeader(props: {
           '@container/split-header isolate relative w-full h-full overflow-clip text-ink',
           // On mobile the header overlays the panel body as a transparent strip
           // of floating islands
-          'mobile:absolute mobile:inset-x-0 mobile:top-(--safe-top) mobile:z-mobile-nav-bar mobile:h-11.25 mobile:overflow-visible mobile:pointer-events-none',
-          isMobile() && isListViewID(panel.handle.content().id) && 'hidden',
+          'touch:absolute touch:inset-x-0 touch:top-(--safe-top) touch:z-mobile-nav-bar touch:h-11.25 touch:overflow-visible touch:pointer-events-none',
+          isTouchDevice() &&
+            isListViewID(panel.handle.content().id) &&
+            'hidden',
           isMobile() &&
             !isNativeMobilePlatform() &&
-            'mobile:top-[calc(var(--safe-top)+6px)]',
+            'touch:top-[calc(var(--safe-top)+6px)]',
           isEntityDraggingOver() && 'bg-active/50'
         )}
         data-split-header
@@ -520,11 +523,11 @@ export function SplitHeader(props: {
           )}
         </Show>
         <div
-          class="absolute inset-0 flex justify-start items-center mobile:px-(--mobile-chrome-gutter) mobile:gap-2"
+          class="absolute inset-0 flex justify-start items-center touch:px-(--mobile-chrome-gutter) touch:gap-2"
           ref={props.collapseController.setRow}
         >
           <Show
-            when={isMobile()}
+            when={isTouchDevice()}
             fallback={
               <div class="relative flex items-center pl-2 h-full">
                 <SidebarExpandButton />
@@ -556,14 +559,14 @@ export function SplitHeader(props: {
           <PriorityCollapseOverflowSensor
             controller={props.collapseController}
             truncateAsLastResort
-            class="relative min-w-0 h-full shrink overflow-hidden mobile:overflow-visible"
-            contentClass="h-full flex items-center gap-0.5 pl-2 mobile:pl-0 mobile:gap-2 mobile:max-w-full"
+            class="relative min-w-0 h-full shrink overflow-hidden touch:overflow-visible"
+            contentClass="h-full flex items-center gap-0.5 pl-2 touch:pl-0 touch:gap-2 touch:max-w-full"
             contentRef={(element) => {
               panel.layoutRefs.headerLeft = element;
             }}
           />
 
-          <div class="h-full grow shrink flex items-center justify-end gap-0.5 px-2 mobile:px-0 mobile:gap-2">
+          <div class="h-full grow shrink flex items-center justify-end gap-0.5 px-2 touch:px-0 touch:gap-2">
             <div
               class="contents"
               ref={(ref) => {

--- a/apps/web/src/components/app/split-layout/components/SplitLabel.tsx
+++ b/apps/web/src/components/app/split-layout/components/SplitLabel.tsx
@@ -10,6 +10,7 @@ import {
   type EntityIconSelector,
   isArchiveType,
 } from '@core/component/EntityIcon';
+import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import { blockMetadataSignal } from '@core/signal/load';
 import {
   useCanComment,
@@ -39,7 +40,6 @@ import {
 } from '../context';
 import { useSplitPanelOrThrow } from '../layoutUtils';
 import { HeaderIsland } from './HeaderIsland';
-import { isTouchDevice } from '@core/mobile/isTouchDevice';
 
 export function StaticSplitLabel(props: {
   label: string;

--- a/apps/web/src/components/app/split-layout/components/SplitLabel.tsx
+++ b/apps/web/src/components/app/split-layout/components/SplitLabel.tsx
@@ -10,7 +10,6 @@ import {
   type EntityIconSelector,
   isArchiveType,
 } from '@core/component/EntityIcon';
-import { isMobile } from '@core/mobile/isMobile';
 import { blockMetadataSignal } from '@core/signal/load';
 import {
   useCanComment,
@@ -40,6 +39,7 @@ import {
 } from '../context';
 import { useSplitPanelOrThrow } from '../layoutUtils';
 import { HeaderIsland } from './HeaderIsland';
+import { isTouchDevice } from '@core/mobile/isTouchDevice';
 
 export function StaticSplitLabel(props: {
   label: string;
@@ -54,7 +54,7 @@ export function StaticSplitLabel(props: {
     panel.handle.setDisplayName(props.label);
   });
   const openTitleFileMenu = (e: MouseEvent) => {
-    if (!isMobile()) return;
+    if (!isTouchDevice()) return;
     const trigger = panel.titleFileMenuTrigger();
     if (!trigger) return;
     e.preventDefault();
@@ -126,7 +126,7 @@ export function SplitLabel(props: {
   };
 
   const openTitleFileMenu = (e: MouseEvent) => {
-    if (!isMobile()) return;
+    if (!isTouchDevice()) return;
     const trigger = panel.titleFileMenuTrigger();
     if (!trigger) return;
     e.preventDefault();
@@ -212,7 +212,7 @@ export function BlockItemSplitLabel(props: {
   });
 
   const openTitleFileMenu = (e: MouseEvent) => {
-    if (!isMobile()) return;
+    if (!isTouchDevice()) return;
     const trigger = panel.titleFileMenuTrigger();
     if (!trigger) return;
     e.preventDefault();

--- a/apps/web/src/components/app/split-layout/components/SplitLabel.tsx
+++ b/apps/web/src/components/app/split-layout/components/SplitLabel.tsx
@@ -90,7 +90,7 @@ export function StaticSplitLabel(props: {
               {props.label}
             </span>
             <Show when={panel.titleFileMenuTrigger()}>
-              <CaretDownIcon class="hidden size-3.5 shrink-0 text-ink-muted mobile:block" />
+              <CaretDownIcon class="hidden size-3.5 shrink-0 text-ink-muted touch:block" />
             </Show>
           </span>
           <div
@@ -140,7 +140,7 @@ export function SplitLabel(props: {
         {truncatedLabel()}
       </span>
       <Show when={panel.titleFileMenuTrigger()}>
-        <CaretDownIcon class="hidden size-4 shrink-0 text-ink-muted mobile:block" />
+        <CaretDownIcon class="hidden size-4 shrink-0 text-ink-muted touch:block" />
       </Show>
     </span>
   );

--- a/apps/web/src/components/app/split-layout/components/SplitPanel.tsx
+++ b/apps/web/src/components/app/split-layout/components/SplitPanel.tsx
@@ -8,7 +8,7 @@ import { isSoloSettings } from '@core/constant/SettingsState';
 import { BlockOpenTrackingDelayContext } from '@core/context/blockOpenTracking';
 import { splitContainerAttribute } from '@core/dom-selectors';
 import { useHotkeyDOMScope } from '@core/hotkey/hotkeys';
-import { isMobile } from '@core/mobile/isMobile';
+import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import { getSafeAreaInset } from '@core/mobile/safeAreaInsets';
 import CloseIcon from '@phosphor/x.svg';
 import { createElementSize } from '@solid-primitives/resize-observer';
@@ -103,7 +103,7 @@ export function SplitPanel(props: SplitPanelProps) {
 
   createEffect(
     on([panelRef], () => {
-      if (isMobile()) return;
+      if (isTouchDevice()) return;
       // Only the active split may claim focus on mount. A Preview Pair's Viewer
       // is created with activate:false while its controller stays active, and
       // must not steal the keyboard from it.
@@ -139,7 +139,7 @@ export function SplitPanel(props: SplitPanelProps) {
   });
 
   createEffect(() => {
-    const safeTop = isMobile() ? getSafeAreaInset('top') : 0;
+    const safeTop = isTouchDevice() ? getSafeAreaInset('top') : 0;
     const offset =
       safeTop + (headerSize.height ?? 0) + (toolbarSize.height ?? 0);
     setContentOffsetTop(offset);
@@ -152,18 +152,18 @@ export function SplitPanel(props: SplitPanelProps) {
 
   const shouldHideSplitHeader = createMemo(
     () =>
-      (isMobile() && isListViewID(props.handle.content().id)) ||
+      (isTouchDevice() && isListViewID(props.handle.content().id)) ||
       isSoloSettings()
   );
 
   const splitFocusStyling = () =>
-    !isMobile() &&
+    !isTouchDevice() &&
     props.active &&
     multipleSplits() &&
     !props.handle.isSpotLight();
 
   const splitUnfocusedStyling = () =>
-    !isMobile() && !props.active && multipleSplits();
+    !isTouchDevice() && !props.active && multipleSplits();
 
   const gutterSize = () =>
     globalSplitManager()?.resizeContext()?.gutterSize() ?? 0;
@@ -175,7 +175,9 @@ export function SplitPanel(props: SplitPanelProps) {
    */
   const tuckedBehindController = createMemo(() => {
     return (
-      !isMobile() && !props.handle.isSpotLight() && props.handle.isViewerSplit()
+      !isTouchDevice() &&
+      !props.handle.isSpotLight() &&
+      props.handle.isViewerSplit()
     );
   });
 
@@ -186,7 +188,7 @@ export function SplitPanel(props: SplitPanelProps) {
    */
   const hasTuckedViewer = createMemo(() => {
     return (
-      !isMobile() &&
+      !isTouchDevice() &&
       !props.handle.isSpotLight() &&
       props.handle.isControllerSplit()
     );
@@ -200,7 +202,7 @@ export function SplitPanel(props: SplitPanelProps) {
    */
   const previewPairFocusStyling = createMemo(() => {
     const manager = globalSplitManager();
-    if (!manager || isMobile() || props.handle.isSpotLight()) return false;
+    if (!manager || isTouchDevice() || props.handle.isSpotLight()) return false;
 
     const peerId = props.handle.isControllerSplit()
       ? manager.viewerOf(props.split.id)
@@ -258,16 +260,16 @@ export function SplitPanel(props: SplitPanelProps) {
               'fixed inset-16 z-modal-overlay isolate opacity-50':
                 props.handle.isSpotLight(),
               'opacity-100': props.active || props.handle.isSpotLight(),
-              // mobile:isolate contains the floating SplitHeader within the panel's own stacking context, so the root-level mobile
+              // touch:isolate contains the floating SplitHeader within the panel's own stacking context, so the root-level mobile/tablet
               // search overlay paints over it.
-              'relative size-full mobile:isolate': !props.handle.isSpotLight(),
+              'relative size-full touch:isolate': !props.handle.isSpotLight(),
             }}
             style={{
               '--split-header-height': `${
                 shouldHideSplitHeader() ? 0 : (headerSize.height ?? 0)
               }px`,
               // The hard spacer for top-anchored content on full-frame
-              // mobile: status bar + floating header strip.
+              // mobile/tablet: status bar + floating header strip.
               '--mobile-content-inset-top':
                 'calc(var(--safe-top, 0px) + var(--split-header-height, 0px))',
               // Slide the preview pane left across the gutter so it sits
@@ -296,7 +298,7 @@ export function SplitPanel(props: SplitPanelProps) {
                   : undefined
               }
               class={cn(
-                'rounded-xl mobile:rounded-none mobile:after:hidden mobile:border-0! bg-panel',
+                'rounded-xl touch:rounded-none touch:after:hidden touch:border-0! bg-panel',
                 {
                   'shadow-sm shadow-drop-shadow/50 bg-panel/80 dark-mode:bg-panel/30':
                     splitUnfocusedStyling(),
@@ -314,15 +316,15 @@ export function SplitPanel(props: SplitPanelProps) {
                   'rounded-r-none': hasTuckedViewer(),
                 }
               )}
-              depth={isMobile() ? 0 : 1}
+              depth={isTouchDevice() ? 0 : 1}
             >
               <Panel.Header
                 class={cn(
                   'relative block min-h-10.25 touch:min-h-11.25 p-0 overflow-visible border-b-0!',
                   'z-split-panel-chrome',
-                  // On mobile the header collapses to a zero-height grid row;
+                  // On mobile/tablet the header collapses to a zero-height grid row;
                   // SplitHeader overlays the body as floating islands.
-                  'mobile:min-h-0 mobile:border-b-0',
+                  'touch:min-h-0 touch:border-b-0',
                   shouldHideSplitHeader() && 'hidden'
                 )}
               >
@@ -336,7 +338,7 @@ export function SplitPanel(props: SplitPanelProps) {
                 class={cn(
                   'items-start overflow-visible',
                   !hasToolbarContent() && 'hidden',
-                  isMobile() && 'hidden',
+                  isTouchDevice() && 'hidden',
                   'border-b-0'
                 )}
               >

--- a/apps/web/src/components/app/split-layout/layout.ts
+++ b/apps/web/src/components/app/split-layout/layout.ts
@@ -1,5 +1,5 @@
 import { globalSplitManager } from '@app/signal/splitLayout';
-import { isMobile } from '@core/mobile/isMobile';
+import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import { useContext } from 'solid-js';
 import { SplitPanelContext } from './context';
 import type {
@@ -16,7 +16,7 @@ export function useSplitLayout() {
     options?: OpenWithSplitOptions
   ) {
     const splitManager = globalSplitManager();
-    const preferNewSplit = isMobile() ? false : options?.preferNewSplit;
+    const preferNewSplit = isTouchDevice() ? false : options?.preferNewSplit;
 
     if (!splitManager) {
       console.error('No split manager found');

--- a/apps/web/src/components/app/split-layout/layoutManager.ts
+++ b/apps/web/src/components/app/split-layout/layoutManager.ts
@@ -8,7 +8,7 @@ import type {
 import type { ResizeZoneCtx } from '@core/component/Resize/types';
 import { isBlockAlias, resolveBlockAlias } from '@core/constant/allBlocks';
 import { settingsTabToSlug } from '@core/constant/settingsTabsConfig';
-import { isMobile } from '@core/mobile/isMobile';
+import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import type {
   BlockInstanceHandle,
   BlockOrchestrator,
@@ -1295,7 +1295,7 @@ export function createSplitLayout(
    * Reactive.
    */
   function canEngagePreview(controllerId: SplitId): boolean {
-    if (isMobile()) return false;
+    if (isTouchDevice()) return false;
     const controller = findSplitById(controllerId);
     if (
       !controller ||
@@ -1314,7 +1314,7 @@ export function createSplitLayout(
     controllerId: SplitId,
     viewerId: SplitId
   ): boolean {
-    if (isMobile()) return false;
+    if (isTouchDevice()) return false;
     const controllerIndex = splitIndexById(controllerId);
     const controller = state.splits[controllerIndex];
     const viewer = state.splits[controllerIndex + 1];
@@ -1386,7 +1386,7 @@ export function createSplitLayout(
 
   function engagePreviewMode(controllerId: SplitId) {
     // Mobile shows one panel at a time; a side-by-side viewer cannot exist.
-    if (isMobile()) return;
+    if (isTouchDevice()) return;
     const controller = findSplitById(controllerId);
     if (!controller || !isPreviewControllerContent(controller.content)) return;
     if (state.previewPairs[controllerId] !== undefined) return;

--- a/apps/web/src/components/ui/components/CollapsedInput.tsx
+++ b/apps/web/src/components/ui/components/CollapsedInput.tsx
@@ -110,8 +110,8 @@ export function CollapsedInput(props: CollapsedInputProps) {
         </Show>
         <Show when={!isMobile() || !props.disabled}>
           <SendButton
-            // Match the expanded input's send button (pill on mobile).
-            class="mobile:rounded-full"
+            // Match the expanded input's send button (pill on touch).
+            class="touch:rounded-full"
             pending={props.pending}
             disabled={props.disabled || props.pending}
             onPointerDown={(event) => {

--- a/apps/web/src/components/ui/components/Layer.tsx
+++ b/apps/web/src/components/ui/components/Layer.tsx
@@ -1,4 +1,4 @@
-import { isMobile } from '@core/mobile/isMobile';
+import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import { DEFAULT_LIGHT_THEME } from '@theme/constants';
 import { currentThemeId, themeDepth } from '@theme/signals/themeSignals';
 import { createMemo, type JSX } from 'solid-js';
@@ -10,7 +10,7 @@ type LayerProps = {
 
 export function Layer(props: LayerProps) {
   const isDefaultMobileLight = createMemo(
-    () => currentThemeId() === DEFAULT_LIGHT_THEME && isMobile()
+    () => currentThemeId() === DEFAULT_LIGHT_THEME && isTouchDevice()
   );
   // HACK: on default mobile light theme, we reverse the sign
   const sign = () => (isDefaultMobileLight() ? -1 : 1);
@@ -20,7 +20,7 @@ export function Layer(props: LayerProps) {
   const BORDER_SCALAR = 0.4;
   // For pure black mobile theme, we need to set a min step to get appropriate contrast
   const nearBlackStepMin = () =>
-    (props.depth ?? 0) > 0 && isMobile() ? 0.19 : 0;
+    (props.depth ?? 0) > 0 && isTouchDevice() ? 0.19 : 0;
 
   return (
     <div

--- a/apps/web/src/features/activity-timeline/timeline-view.tsx
+++ b/apps/web/src/features/activity-timeline/timeline-view.tsx
@@ -128,7 +128,7 @@ export function TimelinePane(props: {
         </Show>
       </div>
       <div class="min-h-0 flex-1 overflow-y-auto">
-        <div class="mx-auto flex w-full max-w-2xl flex-col px-3 pb-10 mobile:pb-(--mobile-content-inset-bottom)">
+        <div class="mx-auto flex w-full max-w-2xl flex-col px-3 pb-10 touch:pb-(--mobile-content-inset-bottom)">
           <Show
             when={!props.feed.isLoading()}
             fallback={

--- a/apps/web/src/features/block-call/component/CallRecording/CallRecordingBody.tsx
+++ b/apps/web/src/features/block-call/component/CallRecording/CallRecordingBody.tsx
@@ -160,7 +160,7 @@ export function CallRecordingBody(props: {
           class="h-full min-h-0 overflow-y-auto scrollbar-hidden"
           ref={setScrollRef}
         >
-          <div class="mx-auto max-w-3xl min-w-0 px-6 pt-12 pb-16 mobile:pt-(--mobile-content-inset-top) mobile:pb-(--mobile-content-inset-bottom)">
+          <div class="mx-auto max-w-3xl min-w-0 px-6 pt-12 pb-16 touch:pt-(--mobile-content-inset-top) touch:pb-(--mobile-content-inset-bottom)">
             <div class="flex flex-col gap-10">
               <header>
                 <Show when={!isMobile()}>

--- a/apps/web/src/features/block-canvas/component/FloatingMenu.tsx
+++ b/apps/web/src/features/block-canvas/component/FloatingMenu.tsx
@@ -480,8 +480,8 @@ export function FloatingMenu() {
     <div
       class={cn(
         'absolute flex flex-row top-4 z-5 cursor-auto',
-        // Full-frame mobile: clear the floating split chrome at the top.
-        'mobile:top-[calc(var(--mobile-content-inset-top,0)+0.5rem)]',
+        // Full-frame mobile/tablet: clear the floating split chrome at the top.
+        'touch:top-[calc(var(--mobile-content-inset-top,0)+0.5rem)]',
         !isMobileWidth() && 'right-4'
       )}
     >

--- a/apps/web/src/features/block-canvas/component/ToolBar.tsx
+++ b/apps/web/src/features/block-canvas/component/ToolBar.tsx
@@ -180,8 +180,8 @@ export function ToolBar() {
 
   return (
     <ScopedPortal scope="block">
-      {/* Full-frame mobile: rest above the floating bottom chrome. */}
-      <div class="absolute left-1/2 bottom-2 mobile:bottom-[calc(var(--mobile-content-inset-bottom,0)+0.5rem)] flex flex-row p-1 bg-surface border border-edge -translate-x-1/2">
+      {/* Full-frame mobile/tablet: rest above the floating bottom chrome. */}
+      <div class="absolute left-1/2 bottom-2 touch:bottom-[calc(var(--mobile-content-inset-bottom,0)+0.5rem)] flex flex-row p-1 bg-surface border border-edge -translate-x-1/2">
         <div
           class={cn(
             'flex flex-row items-center space-x-2',

--- a/apps/web/src/features/block-canvas/component/TopBar.tsx
+++ b/apps/web/src/features/block-canvas/component/TopBar.tsx
@@ -162,7 +162,7 @@ export function TopBar() {
       </SplitHeaderLeft>
       <SplitHeaderRight>
         {/* Hidden on mobile/tablet: no floating-island treatment for live avatars yet. */}
-        <div class="-order-1 mobile:hidden">
+        <div class="-order-1 touch:hidden">
           <BlockLiveIndicators />
         </div>
       </SplitHeaderRight>

--- a/apps/web/src/features/block-canvas/component/TopBar.tsx
+++ b/apps/web/src/features/block-canvas/component/TopBar.tsx
@@ -161,7 +161,7 @@ export function TopBar() {
         <BlockItemSplitLabel />
       </SplitHeaderLeft>
       <SplitHeaderRight>
-        {/* Hidden on mobile: no floating-island treatment for live avatars yet. */}
+        {/* Hidden on mobile/tablet: no floating-island treatment for live avatars yet. */}
         <div class="-order-1 mobile:hidden">
           <BlockLiveIndicators />
         </div>

--- a/apps/web/src/features/block-channel/component/Compose.tsx
+++ b/apps/web/src/features/block-channel/component/Compose.tsx
@@ -21,7 +21,7 @@ import {
 import { SplitToolbarLeft } from '@components/app/split-layout/components/SplitToolbar';
 import { MarkdownShell } from '@core/component/LexicalMarkdown/builder/MarkdownShell';
 import { RecipientSelector } from '@core/component/RecipientSelector';
-import { isMobile } from '@core/mobile/isMobile';
+import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import { useCombinedRecipients } from '@core/signal/useCombinedRecipient';
 import {
   getDisplayName,
@@ -185,7 +185,7 @@ export function ChannelCompose() {
     onMentionRemove: (mention) => mentionsTracker.onMentionRemove(mention),
     onChange: (markdown) => inputState.setValue(markdown),
     onEnter: () => {
-      if (isMobile()) return false;
+      if (isTouchDevice()) return false;
       void inputState.commands.send();
       return true;
     },
@@ -218,14 +218,14 @@ export function ChannelCompose() {
         <div class="h-full items-center flex" p-1></div>
       </SplitToolbarLeft>
       <div class="relative flex flex-col size-full panel">
-        <div class="pt-2 mobile:pt-[calc(var(--mobile-content-inset-top)+.5rem)] size-full grow overflow-y-auto @min-[40rem]:px-4">
+        <div class="pt-2 touch:pt-[calc(var(--mobile-content-inset-top)+.5rem)] size-full grow overflow-y-auto @min-[40rem]:px-4">
           <div class="macro-message-width macro-message-padding mx-auto pb-1 h-full">
             <input
               type="text"
               value={channelName()}
               disabled={selectedRecipients().length < 2}
               placeholder={previewName()}
-              class="text-xl font-medium mb-6 mt-12 mobile:mt-0 bg-transparent border-none outline-none w-full resize-none appearance-none focus:ring-0"
+              class="text-xl font-medium mb-6 mt-12 touch:mt-0 bg-transparent border-none outline-none w-full resize-none appearance-none focus:ring-0"
               style="box-shadow: none;"
               onInput={(e) => {
                 if (selectedRecipients().length >= 2) {
@@ -256,7 +256,7 @@ export function ChannelCompose() {
             region above the dock; desktop renders them inline as before. */}
         <FloatRegionOrInline region="accessory">
           <Show when={error()}>
-            <div class="shrink-0 w-full @min-[40rem]:px-4 mobile:px-(--mobile-chrome-gutter)">
+            <div class="shrink-0 w-full @min-[40rem]:px-4 touch:px-(--mobile-chrome-gutter)">
               <div class="mx-auto w-full macro-message-width macro-message-padding">
                 <div class="text-sm font-mono text-failure-ink">{error()}</div>
               </div>
@@ -264,7 +264,7 @@ export function ChannelCompose() {
           </Show>
           {/* ChannelInputContainer owns the mobile chrome gutter, so drop the
               desktop px-2 there. */}
-          <div class="px-2 mobile:px-0">
+          <div class="px-2 touch:px-0">
             <ChannelInputContainer>
               <Input.Root
                 input={inputState.view()}
@@ -272,7 +272,7 @@ export function ChannelCompose() {
               >
                 <Surface
                   depth={2}
-                  class="rounded-xl mobile:rounded-3xl ring ring-edge"
+                  class="rounded-xl touch:rounded-3xl ring ring-edge"
                   style={{ border: '0' }}
                 >
                   <Input.DropZone
@@ -295,7 +295,7 @@ export function ChannelCompose() {
                       <Input.EditorShell
                         ref={setScrollContainer}
                         onClick={(event) => {
-                          if (!isMobile()) {
+                          if (!isTouchDevice()) {
                             event.stopPropagation();
                             markdownEditor.controls.focus();
                           }

--- a/apps/web/src/features/block-channel/component/NewChannelBlockAdapter.tsx
+++ b/apps/web/src/features/block-channel/component/NewChannelBlockAdapter.tsx
@@ -438,12 +438,12 @@ export function NewChannelBlockAdapter(props: BlockChannelProps) {
         <div
           ref={attachHotkeys}
           class={cn(
-            'h-full flex flex-col px-2 mobile:px-0',
+            'h-full flex flex-col px-2 touch:px-0',
             // The channel block is full-frame on mobile (messages scroll
             // behind the chrome); the other tabs still need to start below
             // the status bar + floating header.
             activeTab() !== 'messages' &&
-              'mobile:pt-(--mobile-content-inset-top)'
+              'touch:pt-(--mobile-content-inset-top)'
           )}
         >
           <Switch>

--- a/apps/web/src/features/block-channel/component/Top.tsx
+++ b/apps/web/src/features/block-channel/component/Top.tsx
@@ -10,7 +10,7 @@ import { TabsInset } from '@core/component/TabsInset';
 import { UserIcon } from '@core/component/UserIcon';
 import { useChannelName } from '@core/context/channels';
 import { useUserId } from '@core/context/user';
-import { isMobile } from '@core/mobile/isMobile';
+import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import PhoneIcon from '@icon/wide-call.svg';
 import ChannelIcon from '@icon/wide-channel.svg';
 import ChatTextIcon from '@phosphor/chat-text.svg';
@@ -91,7 +91,7 @@ export function ChannelTopLeft(props: ChannelTopLeftProps) {
   return (
     <SplitHeaderLeft>
       <Show
-        when={isMobile() && hasTabsMenu()}
+        when={isTouchDevice() && hasTabsMenu()}
         fallback={
           <>
             <HeaderIsland class="shrink">
@@ -108,7 +108,7 @@ export function ChannelTopLeft(props: ChannelTopLeftProps) {
                 />
               </div>
             </HeaderIsland>
-            <Show when={!isMobile() && hasTabsMenu() && props.activeTab}>
+            <Show when={!isTouchDevice() && hasTabsMenu() && props.activeTab}>
               <CollapsibleHeaderItem
                 id="channel-tabs"
                 priority={1}

--- a/apps/web/src/features/block-chat/component/Chat.tsx
+++ b/apps/web/src/features/block-chat/component/Chat.tsx
@@ -350,7 +350,7 @@ function ChatInner(props: {
           class="h-full min-h-0 overflow-auto scrollbar-hidden"
           ref={setScrollRef}
         >
-          <div class="mx-auto w-full max-w-3xl mobile:pt-[calc(var(--mobile-content-inset-top,0)+0.5rem)] mobile:pb-(--mobile-content-inset-bottom)">
+          <div class="mx-auto w-full max-w-3xl touch:pt-[calc(var(--mobile-content-inset-top,0)+0.5rem)] touch:pb-(--mobile-content-inset-bottom)">
             <ChatMessages
               editDisabled={disabled()}
               pendingLocationParams={pendingLocationParamsSignal.get}
@@ -361,7 +361,7 @@ function ChatInner(props: {
       </div>
       <Show when={!disabled()}>
         <FloatRegionOrInline region="accessory">
-          <div class="flex w-full justify-center pb-2 px-2 mobile:pb-0 mobile:px-(--mobile-chrome-gutter) mobile:pointer-events-auto">
+          <div class="flex w-full justify-center pb-2 px-2 touch:pb-0 touch:px-(--mobile-chrome-gutter) touch:pointer-events-auto">
             <div class="w-3xl">
               <ChatInput
                 editor={editor}

--- a/apps/web/src/features/block-code/component/CodeMirror.tsx
+++ b/apps/web/src/features/block-code/component/CodeMirror.tsx
@@ -179,10 +179,10 @@ export function CodeMirror() {
 
   return (
     <div
-      // Full-frame mobile: the floating split chrome overlays the panel, so
+      // Full-frame mobile/tablet: the floating split chrome overlays the panel, so
       // the inset lives on the CodeMirror scroller — code rests below the
       // chrome but under-scrolls it.
-      class="size-full overflow-auto mobile:[&_.cm-scroller]:pt-(--mobile-content-inset-top) mobile:[&_.cm-scroller]:pb-(--mobile-content-inset-bottom)"
+      class="size-full overflow-auto touch:[&_.cm-scroller]:pt-(--mobile-content-inset-top) touch:[&_.cm-scroller]:pb-(--mobile-content-inset-bottom)"
       ref={containerRef}
     />
   );

--- a/apps/web/src/features/block-code/component/HtmlPreview.tsx
+++ b/apps/web/src/features/block-code/component/HtmlPreview.tsx
@@ -8,9 +8,9 @@ export function HtmlPreview() {
   });
 
   return (
-    // Static pads on mobile: the iframe scrolls internally, so its content
+    // Static pads on mobile/tablet: the iframe scrolls internally, so its content
     // can't under-scroll the floating chrome — the viewport sits between it.
-    <div class="size-full bg-surface overflow-auto mobile:pt-(--mobile-content-inset-top) mobile:pb-(--mobile-content-inset-bottom)">
+    <div class="size-full bg-surface overflow-auto touch:pt-(--mobile-content-inset-top) touch:pb-(--mobile-content-inset-bottom)">
       <iframe
         title="HTML preview"
         class="size-full border-0"

--- a/apps/web/src/features/block-email/component/BaseInput.tsx
+++ b/apps/web/src/features/block-email/component/BaseInput.tsx
@@ -32,8 +32,8 @@ import { fileFolderDrop } from '@core/directive/fileFolderDrop';
 import { fileSelector } from '@core/directive/fileSelector';
 import { registerHotkey, useHotkeyDOMScope } from '@core/hotkey/hotkeys';
 import { TOKENS } from '@core/hotkey/tokens';
-import { isMobile } from '@core/mobile/isMobile';
 import { isNativeMobilePlatform } from '@core/mobile/isNativeMobilePlatform';
+import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import { useTouchOutsideToDismissKeyboard } from '@core/mobile/useTouchOutsideToDismissKeyboard';
 import { trackMention } from '@core/signal/mention';
 import { plural } from '@core/util/string';
@@ -1283,7 +1283,7 @@ export function BaseInput(props: {
   // connect before focusing.
   createEffect(() => {
     if (!form().shouldFocusInput()) return;
-    if (isMobile()) {
+    if (isTouchDevice()) {
       form().setShouldFocusInput(false);
       return;
     }
@@ -1443,7 +1443,7 @@ export function BaseInput(props: {
   const isMobileDrawer = () => props.mobileDrawer !== undefined;
   const composePortalScope = () => (isMobileDrawer() ? 'local' : undefined);
   const sendActionHidden = () =>
-    isMobile() &&
+    isTouchDevice() &&
     !hasBodyText() &&
     // Forwards carry the quoted thread as content, so send is available without typing anything.
     effectiveReplyType() !== 'forward';
@@ -2149,7 +2149,7 @@ export function BaseInput(props: {
                   sendTime={form().sendTime() ?? null}
                   onSendTimeChange={handleSendTimeChange}
                   disabled={scheduleSendDisabled()}
-                  disablePortal={isMobile()}
+                  disablePortal={isTouchDevice()}
                 />
               </Show>
               <SendButton

--- a/apps/web/src/features/block-email/component/BottomReplyButtons.tsx
+++ b/apps/web/src/features/block-email/component/BottomReplyButtons.tsx
@@ -2,7 +2,7 @@ import { FloatRegionOrInline } from '@components/app/mobile/float-regions/FloatR
 import { inboxIconProps } from '@core/component/inboxIcon';
 import { UserIcon } from '@core/component/UserIcon';
 import { useEmail } from '@core/context/user';
-import { isMobile } from '@core/mobile/isMobile';
+import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import ArrowBendUpLeft from '@phosphor/arrow-bend-up-left.svg';
 import ArrowBendUpRight from '@phosphor/arrow-bend-up-right.svg';
 import CheckIcon from '@phosphor/check.svg';
@@ -28,12 +28,12 @@ function ReplyActionButton(props: {
       // accessory region, match the chrome's depth so the island surface
       // matches the dock buttons. (The region host's Layer can't help —
       // Button's own Layer would reset it.)
-      depth={isMobile() ? 3 : undefined}
+      depth={isTouchDevice() ? 3 : undefined}
       variant="base"
       aria-label={props.ariaLabel}
       class={cn(
-        // Island pills when floating in the mobile accessory region.
-        'mobile:island mobile:h-8 mobile:rounded-full mobile:border-0'
+        // Island pills when floating in the mobile/tablet accessory region.
+        'touch:island touch:h-8 touch:rounded-full touch:border-0'
       )}
       onClick={props.onClick}
     >
@@ -84,7 +84,7 @@ export function BottomReplyButtons(props: { lastMessage: ApiMessage }) {
 
   return (
     <Show
-      when={isMobile()}
+      when={isTouchDevice()}
       fallback={
         <div class="flex w-full items-center pt-4">
           <button
@@ -104,8 +104,8 @@ export function BottomReplyButtons(props: { lastMessage: ApiMessage }) {
       }
     >
       <FloatRegionOrInline region="accessory">
-        <div class="w-full p-2 pb-2 pt-4 mobile:px-(--mobile-chrome-gutter) mobile:py-0">
-          <div class="flex flex-row items-center gap-2 justify-between mobile:pointer-events-auto">
+        <div class="w-full p-2 pb-2 pt-4 touch:px-(--mobile-chrome-gutter) touch:py-0">
+          <div class="flex flex-row items-center gap-2 justify-between touch:pointer-events-auto">
             <div class="flex flex-row items-center gap-2">
               <ReplyActionButton
                 icon={ArrowBendUpLeft}

--- a/apps/web/src/features/block-email/component/Email.tsx
+++ b/apps/web/src/features/block-email/component/Email.tsx
@@ -683,7 +683,7 @@ function EmailContent(props: EmailViewProps) {
             {(draft) => (
               // The email block is bottom-anchored (no default panel inset),
               // so the compose branch pads around the chrome itself.
-              <div class="size-full mobile:pt-(--mobile-content-inset-top) mobile:pb-(--mobile-content-inset-bottom)">
+              <div class="size-full touch:pt-(--mobile-content-inset-top) touch:pb-(--mobile-content-inset-bottom)">
                 <EmailCompose draftID={draft().db_id!} />
               </div>
             )}
@@ -704,7 +704,7 @@ function EmailContent(props: EmailViewProps) {
                   ),
               }}
             >
-              {/* Edge-to-edge on mobile: the message list carries its own
+              {/* Edge-to-edge on mobile/tablet: the message list carries its own
                   insets in-scroll and under-scrolls the floating chrome. */}
               <div class="size-full select-none overscroll-none overflow-hidden flex flex-col">
                 <TopBar

--- a/apps/web/src/features/block-email/component/Email.tsx
+++ b/apps/web/src/features/block-email/component/Email.tsx
@@ -14,7 +14,6 @@ import { CustomScrollbar } from '@core/component/CustomScrollbar';
 import { useEmail, useUserContext } from '@core/context/user';
 import { TOKENS } from '@core/hotkey/tokens';
 import { registerScopeSignalHotkey } from '@core/hotkey/utils';
-import { isMobile } from '@core/mobile/isMobile';
 import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import {
   blockElementSignal,
@@ -612,7 +611,7 @@ function EmailContent(props: EmailViewProps) {
     const lastMessage = filtered.at(-1);
     if (!lastMessage?.db_id) return;
     if (context.drafts.getDraftForMessage(lastMessage.db_id)) {
-      if (isMobile()) {
+      if (isTouchDevice()) {
         context.mobileReplyComposer.openForMessage(lastMessage.db_id);
       } else {
         context.messages.setBottomReplyOpen(true);
@@ -743,7 +742,7 @@ function EmailContent(props: EmailViewProps) {
                   class="w-full flex-1 flex flex-col items-center overflow-hidden"
                   ref={context.registerMessagesContainer}
                 >
-                  <Show when={!isMobile()}>
+                  <Show when={!isTouchDevice()}>
                     <div class="shrink-0 w-full flex justify-center">
                       <div
                         class="macro-message-width macro-message-padding w-full border-b"
@@ -776,12 +775,12 @@ function EmailContent(props: EmailViewProps) {
                     scrollContainer={context.messagesListRef}
                   />
                 </div>
-                <Show when={isMobile() && mobileBottomReplyMessage()}>
+                <Show when={isTouchDevice() && mobileBottomReplyMessage()}>
                   {(lastMessage) => (
                     <BottomReplyButtons lastMessage={lastMessage()} />
                   )}
                 </Show>
-                <Show when={isMobile()}>
+                <Show when={isTouchDevice()}>
                   <MobileEmailComposeDrawer
                     markdownDomRef={(el) => {
                       markdownDomRef = el;

--- a/apps/web/src/features/block-email/component/MessageContainer.tsx
+++ b/apps/web/src/features/block-email/component/MessageContainer.tsx
@@ -12,7 +12,7 @@ import { toast } from '@core/component/Toast/Toast';
 import { UserIcon, type UserIconProps } from '@core/component/UserIcon';
 import { VideoPreview } from '@core/component/VideoPreview';
 import { fileTypeToBlockName } from '@core/constant/allBlocks';
-import { isMobile } from '@core/mobile/isMobile';
+import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import { Telemetry } from '@macro-inc/observability';
 import { refetchSoupEntity } from '@queries/soup/cache';
 import { emailClient } from '@service-email/client';
@@ -50,7 +50,7 @@ export function MessageContainer(props: MessageContainerProps) {
     context.messages.replyingToMessageId() === props.message.db_id;
 
   const showInlineReplyInput = createMemo(() => {
-    if (isMobile()) return false;
+    if (isTouchDevice()) return false;
     if (!props.isLastMessage) return showReply() || !!draftChild();
     return context.messages.bottomReplyOpen() || !!draftChild();
   });
@@ -59,7 +59,7 @@ export function MessageContainer(props: MessageContainerProps) {
     () =>
       props.isLastMessage &&
       !!props.message.db_id &&
-      !isMobile() &&
+      !isTouchDevice() &&
       context.drafts.initialDraftsSettled()
   );
 
@@ -352,7 +352,7 @@ export function MessageContainer(props: MessageContainerProps) {
             </div>
             <Show when={showInlineReplyArea()}>
               <div class="relative -mx-4 mb-0 border-t border-ink/20 mt-4">
-                <Show when={props.isLastMessage && !isMobile()}>
+                <Show when={props.isLastMessage && !isTouchDevice()}>
                   <FloatingInputLoader
                     isLoading={context.query.isFetching}
                     loadingText="Loading messages"
@@ -371,7 +371,7 @@ export function MessageContainer(props: MessageContainerProps) {
                         unframed
                       />
                     </Match>
-                    <Match when={props.isLastMessage && !isMobile()}>
+                    <Match when={props.isLastMessage && !isTouchDevice()}>
                       <BottomReplyButtons lastMessage={props.message} />
                     </Match>
                   </Switch>

--- a/apps/web/src/features/block-email/component/MessageList.tsx
+++ b/apps/web/src/features/block-email/component/MessageList.tsx
@@ -1,7 +1,7 @@
 import { useEmailContext } from '@block-email/component/EmailContext';
 import { isScrollingToMessage } from '@block-email/signal/scrollState';
 import { StaticMarkdownContext } from '@core/component/LexicalMarkdown/component/core/StaticMarkdown';
-import { isMobile } from '@core/mobile/isMobile';
+import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import { cn } from '@ui';
 import {
   createEffect,
@@ -49,7 +49,7 @@ export function MessageList(props: MessageListProps) {
   // consistent height wins over keeping the whole thread in view.
   createEffect(() => {
     const list = context.messagesListRef();
-    if (!list || isMobile()) return;
+    if (!list || isTouchDevice()) return;
     const observer = new ResizeObserver(() => {
       list.style.setProperty(
         '--thread-bottom-pad',
@@ -139,7 +139,7 @@ export function MessageList(props: MessageListProps) {
             // Gmail/Superhuman). Desktop only: mobile edits drafts in a drawer.
             const hasDraft = createMemo(() => {
               const messageID = message().db_id;
-              if (!messageID || isMobile()) return false;
+              if (!messageID || isTouchDevice()) return false;
               return !!context.drafts.getDraftForMessage(messageID);
             });
 
@@ -174,7 +174,7 @@ export function MessageList(props: MessageListProps) {
           }}
         </Index>
       </StaticMarkdownContext>
-      <Show when={isMobile() && props.title}>
+      <Show when={isTouchDevice() && props.title}>
         <div class="shrink-0 w-full flex justify-center pb-3">
           <div class="macro-message-width macro-message-padding w-full">
             <h1 class="text-xl font-semibold text-ink pt-1 pb-0 tracking-tight text-balance">

--- a/apps/web/src/features/block-email/component/MessageList.tsx
+++ b/apps/web/src/features/block-email/component/MessageList.tsx
@@ -68,9 +68,9 @@ export function MessageList(props: MessageListProps) {
         'pt-1 pb-[calc(1.5rem+var(--thread-bottom-pad,0px))] w-full flex flex-col-reverse items-center overflow-y-scroll overflow-x-hidden scrollbar-hidden text-sm gap-1.5',
         // In-scroll top inset: messages rest below the floating split chrome
         // but under-scroll it.
-        'mobile:pt-[calc(var(--mobile-content-inset-top,0)+0.5rem)]',
+        'touch:pt-[calc(var(--mobile-content-inset-top,0)+0.5rem)]',
         props.underScrollsBottom &&
-          'mobile:pb-[calc(var(--mobile-content-inset-bottom,0)+1.5rem)]'
+          'touch:pb-[calc(var(--mobile-content-inset-bottom,0)+1.5rem)]'
       )}
       ref={context.registerMessagesList}
       onscroll={(e) => {

--- a/apps/web/src/features/block-email/component/compose/Compose.tsx
+++ b/apps/web/src/features/block-email/component/compose/Compose.tsx
@@ -841,7 +841,7 @@ export function EmailCompose(props: EmailComposeProps) {
         </SplitHeaderLeft>
       </Show>
       <div class="relative flex flex-col size-full min-h-0 overflow-hidden text-sm">
-        <div class="macro-message-width sm:macro-message-padding mx-auto w-full min-h-120 max-h-full my-2 sm:my-12 mobile:my-0 px-2 sm:px-4 mobile:px-0 overflow-hidden mobile:overflow-y-auto mobile:scrollbar-hidden mobile:min-h-full">
+        <div class="macro-message-width sm:macro-message-padding mx-auto w-full min-h-120 max-h-full my-2 sm:my-12 touch:my-0 px-2 sm:px-4 touch:px-0 overflow-hidden touch:overflow-y-auto touch:scrollbar-hidden touch:min-h-full">
           <WrapUnlessMobile
             wrapper={(children) => (
               <Surface depth={2} class="rounded-xl border border-ink-muted/8">
@@ -852,7 +852,7 @@ export function EmailCompose(props: EmailComposeProps) {
             <ComposeLayout
               toolbar={<EmailComposeToolbar editor={editor} />}
               notice={hasLinkError() ? <EmailPermissionsBanner /> : undefined}
-              class="size-full p-4 bg-surface max-h-full mobile:max-h-none overflow-hidden flex flex-col min-h-0 mobile:min-h-full"
+              class="size-full p-4 bg-surface max-h-full touch:max-h-none overflow-hidden flex flex-col min-h-0 touch:min-h-full"
             />
           </WrapUnlessMobile>
         </div>

--- a/apps/web/src/features/block-email/component/compose/ComposeBody.tsx
+++ b/apps/web/src/features/block-email/component/compose/ComposeBody.tsx
@@ -138,7 +138,7 @@ export function ComposeBody(props: {
 
   return (
     <>
-      <div class="size-full min-h-0 sm:max-h-full mobile:flex-1 flex flex-col flex-1">
+      <div class="size-full min-h-0 sm:max-h-full touch:flex-1 flex flex-col flex-1">
         <div
           class="grow size-full flex flex-col cursor-text placeholder:text-ink-placeholder placeholder:opacity-50 overflow-hidden relative [&_.text-ink-placeholder]:left-0 [&_.text-ink-placeholder>p]:my-0"
           ref={bodyDiv}

--- a/apps/web/src/features/block-email/component/compose/ComposeLayout.tsx
+++ b/apps/web/src/features/block-email/component/compose/ComposeLayout.tsx
@@ -184,7 +184,7 @@ export function ComposeLayout(props: {
     <div
       ref={registerRef('containerRef')}
       class={cn(
-        'mobile:pt-[calc(var(--mobile-content-inset-top)+.5rem)]',
+        'touch:pt-[calc(var(--mobile-content-inset-top)+.5rem)]',
         props.class
       )}
     >

--- a/apps/web/src/features/block-md/component/Block.tsx
+++ b/apps/web/src/features/block-md/component/Block.tsx
@@ -306,7 +306,7 @@ function BlockMarkdownContent({ optimisticSnapshot }: BlockMarkdownProps) {
                   data-block-content
                 >
                   <Scroll class="relative" scrollRef={setScrollRef}>
-                    <div class="relative portal-scope mobile:pt-(--mobile-content-inset-top) mobile:pb-(--mobile-content-inset-bottom)">
+                    <div class="relative portal-scope touch:pt-(--mobile-content-inset-top) touch:pb-(--mobile-content-inset-bottom)">
                       <Suspense>
                         <Show
                           when={!isInstructionsMd()}

--- a/apps/web/src/features/block-md/component/Notebook.tsx
+++ b/apps/web/src/features/block-md/component/Notebook.tsx
@@ -296,7 +296,7 @@ export function Notebook(props: {
 
   const contentDivClasses = createMemo(() => {
     const mode = layoutMode();
-    const shared = 'grow max-w-3xl pt-12 mobile:pt-6 min-w-0';
+    const shared = 'grow max-w-3xl pt-12 touch:pt-6 min-w-0';
     switch (mode) {
       case CommentLayoutMode.lg:
         return `${shared} mx-auto`;

--- a/apps/web/src/features/block-md/component/TopBar.tsx
+++ b/apps/web/src/features/block-md/component/TopBar.tsx
@@ -228,8 +228,8 @@ export function TopBar(props: { name?: Accessor<string | undefined> } = {}) {
       </SplitHeaderLeft>
 
       <SplitHeaderRight>
-        {/* Hidden on mobile: no floating-island treatment for live avatars yet. */}
-        <div class="-order-1 mobile:hidden">
+        {/* Hidden on mobile/tablet: no floating-island treatment for live avatars yet. */}
+        <div class="-order-1 touch:hidden">
           <BlockLiveIndicators />
         </div>
       </SplitHeaderRight>

--- a/apps/web/src/features/block-pdf/component/TopBar.tsx
+++ b/apps/web/src/features/block-pdf/component/TopBar.tsx
@@ -242,8 +242,8 @@ export function TopBar() {
         <BlockItemSplitLabel />
       </SplitHeaderLeft>
       <SplitHeaderRight>
-        {/* Hidden on mobile: no floating-island treatment for live avatars yet. */}
-        <div class="-order-1 mobile:hidden">
+        {/* Hidden on mobile/tablet: no floating-island treatment for live avatars yet. */}
+        <div class="-order-1 touch:hidden">
           <BlockLiveIndicators />
         </div>
       </SplitHeaderRight>

--- a/apps/web/src/features/channel/Bots/BotCreatePage.tsx
+++ b/apps/web/src/features/channel/Bots/BotCreatePage.tsx
@@ -170,7 +170,7 @@ export function BotCreate(props: { channelId?: string; onBack: () => void }) {
 
   return (
     <div class="size-full overflow-y-auto bg-surface text-ink">
-      <main class="mx-auto w-full max-w-[560px] px-8 pt-14 pb-24 mobile:px-5 mobile:pt-8 mobile:pb-12">
+      <main class="mx-auto w-full max-w-[560px] px-8 pt-14 pb-24 touch:px-5 touch:pt-8 touch:pb-12">
         <Button
           type="button"
           variant="ghost"

--- a/apps/web/src/features/channel/Bots/BotDetailPage.tsx
+++ b/apps/web/src/features/channel/Bots/BotDetailPage.tsx
@@ -169,7 +169,7 @@ export function BotDetail(props: { botId: string; onBack: () => void }) {
   return (
     <>
       <div class="size-full overflow-y-auto bg-surface text-ink">
-        <main class="mx-auto w-full max-w-[560px] px-8 pt-14 pb-24 mobile:px-5 mobile:pt-8 mobile:pb-12">
+        <main class="mx-auto w-full max-w-[560px] px-8 pt-14 pb-24 touch:px-5 touch:pt-8 touch:pb-12">
           <Button
             type="button"
             variant="ghost"

--- a/apps/web/src/features/channel/Call/CallOverlay.tsx
+++ b/apps/web/src/features/channel/Call/CallOverlay.tsx
@@ -281,7 +281,7 @@ export function CallOverlay(props: { onLeave: () => void }) {
   };
 
   return (
-    <div class="flex flex-col h-full mobile:pb-(--mobile-content-inset-bottom)">
+    <div class="flex flex-col h-full touch:pb-(--mobile-content-inset-bottom)">
       {/* Screen share area */}
       <Show when={hasAnyScreenShare()}>
         <div class="flex-1 min-h-0 pt-2">

--- a/apps/web/src/features/channel/Call/ChannelCallButton.tsx
+++ b/apps/web/src/features/channel/Call/ChannelCallButton.tsx
@@ -1,6 +1,6 @@
 import { analytics } from '@app/lib/analytics';
 import { useChannelTab } from '@channel/Channel/ChannelTabContext';
-import { isMobile } from '@core/mobile/isMobile';
+import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import PhoneIcon from '@icon/wide-call.svg';
 import { useActiveCallQuery } from '@queries/call/call';
 import { Button, cn } from '@ui';
@@ -22,7 +22,7 @@ export function ChannelCallButton(props: { channelId: string }) {
   const label = () => (isCallInProgress() ? 'Join' : 'Call');
 
   const variant = () => {
-    if (isMobile()) return 'ghost';
+    if (isTouchDevice()) return 'ghost';
     if (isCallInProgress()) return 'success';
     return 'base';
   };
@@ -59,8 +59,8 @@ export function ChannelCallButton(props: { channelId: string }) {
         size="sm"
         depth={2}
         class={cn(
-          !isCallInProgress() && !isMobile() && 'bg-surface',
-          isMobile() && 'active:bg-transparent'
+          !isCallInProgress() && !isTouchDevice() && 'bg-surface',
+          isTouchDevice() && 'active:bg-transparent'
         )}
       >
         <PhoneIcon />

--- a/apps/web/src/features/channel/Channel/ActiveCallMessage.tsx
+++ b/apps/web/src/features/channel/Channel/ActiveCallMessage.tsx
@@ -37,8 +37,8 @@ export function ActiveCallMessage(props: { channelId: string }) {
 
   return (
     <Show when={shouldShow()}>
-      {/* Full-frame mobile: place above the floating input/dock stack. */}
-      <div class="w-full flex justify-center mobile:pb-(--mobile-content-inset-bottom)">
+      {/* Full-frame mobile/tablet: place above the floating input/dock stack. */}
+      <div class="w-full flex justify-center touch:pb-(--mobile-content-inset-bottom)">
         <div class="macro-message-width w-full relative">
           <div class="w-full pr-2 pl-(--message-padding-x)">
             <div

--- a/apps/web/src/features/channel/Channel/Channel.tsx
+++ b/apps/web/src/features/channel/Channel/Channel.tsx
@@ -33,7 +33,7 @@ import {
   useChannelType,
 } from '@core/context/channels';
 import { useUserId } from '@core/context/user';
-import { isMobile } from '@core/mobile/isMobile';
+import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import type { DateValue } from '@core/util/date';
 import {
   extractUserMentions,
@@ -156,11 +156,11 @@ export function Channel(props: ChannelProps) {
   const userId = useUserId();
   const splitPanel = useSplitPanel();
 
-  // Full-frame mobile: the thread list spans the whole screen and messages
+  // Full-frame mobile/tablet: the thread list spans the whole screen and messages
   // scroll behind the floating header islands (top) and the floating
   // input + dock (bottom). contentOffsetTop already includes the safe area.
   const threadListScrollInsets = () =>
-    isMobile()
+    isTouchDevice()
       ? {
           start: splitPanel?.contentOffsetTop() ?? 0,
           // '4' here is a magic offset so that the ThreadRail correctly hits the the curved edge of the floating input. Not idea, but low impact and it works.
@@ -699,7 +699,7 @@ export function Channel(props: ChannelProps) {
               >
                 <Show when={findBar.isOpen()}>
                   <FindBar
-                    class="absolute top-2 right-3 z-10 w-80 max-w-[calc(100%-1.5rem)] mobile:top-[calc(var(--mobile-content-inset-top,0)+0.5rem)]"
+                    class="absolute top-2 right-3 z-10 w-80 max-w-[calc(100%-1.5rem)] touch:top-[calc(var(--mobile-content-inset-top,0)+0.5rem)]"
                     controller={findBar}
                     direction="desc"
                   />
@@ -823,7 +823,7 @@ export function Channel(props: ChannelProps) {
                       <ScrollToBottomOverlay
                         scrollState={threadListScrollState}
                         onScrollToBottom={handleScrollToBottom}
-                        class="mobile:top-[calc(var(--mobile-content-inset-top,0)+1rem)]"
+                        class="touch:top-[calc(var(--mobile-content-inset-top,0)+1rem)]"
                       />
                     </Show>
                   </div>

--- a/apps/web/src/features/channel/Channel/Channel.tsx
+++ b/apps/web/src/features/channel/Channel/Channel.tsx
@@ -135,7 +135,7 @@ export type ChannelProps = {
   lastViewedAt?: DateValue | null;
   initialMessagesStateSnapshot?: ChannelMessagesStateSnapshot;
   onHandleReady?: (handle: ChannelHandle) => void;
-  /** Whether to auto-focus the channel input on mount. Defaults to `!isMobile()`. */
+  /** Whether to auto-focus the channel input on mount. Defaults to `!isTouchDevice()`. */
   autofocus?: boolean;
 };
 

--- a/apps/web/src/features/channel/Channel/ChannelTopBarLiveIndicators.tsx
+++ b/apps/web/src/features/channel/Channel/ChannelTopBarLiveIndicators.tsx
@@ -35,8 +35,8 @@ export function ChannelTopBarLiveIndicators() {
 
   return (
     <SplitHeaderRight>
-      {/* Hidden on mobile: no floating-island treatment for live avatars yet. */}
-      <div class="-order-1 mobile:hidden">
+      {/* Hidden on mobile/tablet: no floating-island treatment for live avatars yet. */}
+      <div class="-order-1 touch:hidden">
         <BlockLiveIndicators />
       </div>
     </SplitHeaderRight>

--- a/apps/web/src/features/channel/Input/Attachments.tsx
+++ b/apps/web/src/features/channel/Input/Attachments.tsx
@@ -213,8 +213,8 @@ export function Attachments(props: AttachmentsProps) {
       <div
         class={cn(
           'flex flex-row w-full p-2 gap-2 flex-wrap',
-          // On mobile, attachments scroll horizontally
-          'mobile:flex-nowrap mobile:*:shrink-0 mobile:overflow-x-auto mobile:scrollbar-hidden',
+          // On mobile/tablet, attachments scroll horizontally
+          'touch:flex-nowrap touch:*:shrink-0 touch:overflow-x-auto touch:scrollbar-hidden',
           local.class
         )}
         data-input-attachments={local.kind ?? 'all'}

--- a/apps/web/src/features/channel/Input/ChannelInput.tsx
+++ b/apps/web/src/features/channel/Input/ChannelInput.tsx
@@ -13,6 +13,7 @@ import {
 } from '@core/component/LexicalMarkdown/utils/dragInsertUtils';
 import { registerHotkey, useHotkeyDOMScope } from '@core/hotkey/hotkeys';
 import { isMobile } from '@core/mobile/isMobile';
+import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import type { IUser } from '@core/user/types';
 import { uniqueByKey } from '@core/util/compareUtils';
 import { isPlatform } from '@core/util/platform';
@@ -481,7 +482,7 @@ export function ChannelInput(props: ChannelInputProps) {
           data-collapsed-input-file-picker
         />
         <CollapsedInput
-          class="mobile:rounded-full mobile:island"
+          class="touch:rounded-full touch:island"
           draft={inputState.view().value}
           renderDraft={(draft) => (
             <StaticMarkdown
@@ -511,12 +512,12 @@ export function ChannelInput(props: ChannelInputProps) {
           collapsedInput.collapse();
         }}
         class={cn(
-          'rounded-xl mobile:rounded-3xl mobile:island',
+          'rounded-xl touch:rounded-3xl touch:island',
           isCollapsed() && 'hidden',
-          isMobile() && 'bg-chrome'
+          isTouchDevice() && 'bg-chrome'
         )}
-        hideBorder={isMobile()}
-        depth={isMobile() ? 3 : 2}
+        hideBorder={isTouchDevice()}
+        depth={isTouchDevice() ? 3 : 2}
         solid
       >
         {renderSurfaceContent()}

--- a/apps/web/src/features/channel/Input/ChannelInput.tsx
+++ b/apps/web/src/features/channel/Input/ChannelInput.tsx
@@ -12,7 +12,6 @@ import {
   updateDragInsertPreviewFromCoordinates,
 } from '@core/component/LexicalMarkdown/utils/dragInsertUtils';
 import { registerHotkey, useHotkeyDOMScope } from '@core/hotkey/hotkeys';
-import { isMobile } from '@core/mobile/isMobile';
 import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import type { IUser } from '@core/user/types';
 import { uniqueByKey } from '@core/util/compareUtils';
@@ -71,7 +70,7 @@ export type ChannelInputProps = InputCallbacks & {
   bots?: Accessor<IUser[]>;
   onReady?: (handle: InputHandle) => void;
   children?: JSX.Element;
-  /** Whether to auto-focus the input on mount. Defaults to `!isMobile()`. */
+  /** Whether to auto-focus the input on mount. Defaults to `!isTouchDevice()`. */
   autofocus?: boolean;
   /**
    * Render a one-line `CollapsedInput` stand-in until the user clicks it.
@@ -275,7 +274,7 @@ export function ChannelInput(props: ChannelInputProps) {
       typingTracker.keystroke();
     },
     onEnter: () => {
-      if (isMobile()) return false;
+      if (isTouchDevice()) return false;
       typingTracker.stop();
       inputState.commands.send();
       return true;
@@ -424,7 +423,7 @@ export function ChannelInput(props: ChannelInputProps) {
           <Input.EditorShell
             ref={setScrollContainer}
             onClick={(event) => {
-              if (!isMobile()) {
+              if (!isTouchDevice()) {
                 event.stopPropagation();
                 markdownEditor.controls.focus();
               }
@@ -435,7 +434,7 @@ export function ChannelInput(props: ChannelInputProps) {
                 config={markdownEditor}
                 placeholder={props.input.placeholder}
                 initialValue={inputState.view().value}
-                autofocus={!isMobile() && (props.autofocus ?? true)}
+                autofocus={!isTouchDevice() && (props.autofocus ?? true)}
                 class="text-sm"
                 refFn={attach}
                 onConnect={() => {

--- a/apps/web/src/features/channel/Input/ChannelInputContainer.tsx
+++ b/apps/web/src/features/channel/Input/ChannelInputContainer.tsx
@@ -6,7 +6,7 @@ export function ChannelInputContainer(props: {
 }) {
   return (
     <div
-      class="pb-2 mobile:pb-0 w-full flex justify-center **:data-input-editor-shell:max-h-[calc(60*var(--dvh,1dvh))] mobile:**:data-input-editor-shell:max-h-[calc(32*var(--dvh,1dvh))] mobile:px-(--mobile-chrome-gutter) mobile:pointer-events-auto"
+      class="pb-2 touch:pb-0 w-full flex justify-center **:data-input-editor-shell:max-h-[calc(60*var(--dvh,1dvh))] mobile:**:data-input-editor-shell:max-h-[calc(32*var(--dvh,1dvh))] touch:px-(--mobile-chrome-gutter) touch:pointer-events-auto"
       ref={props.ref}
     >
       {props.children}

--- a/apps/web/src/features/channel/Input/SendAction.tsx
+++ b/apps/web/src/features/channel/Input/SendAction.tsx
@@ -34,8 +34,8 @@ export function SendAction(props: SendActionProps) {
       pending={isBlockedByPending()}
       disabled={isDisabled()}
       hidden={isMobile() && isBlockedByEmptyInput()}
-      // Full-frame mobile: pill rounding to match the dock/accessory islands.
-      class={cn('mobile:rounded-full', local.class)}
+      // Full-frame mobile/tablet: pill rounding to match the dock/accessory islands.
+      class={cn('touch:rounded-full', local.class)}
       onPointerDown={(event) => {
         event.preventDefault();
         void commands.send();

--- a/apps/web/src/features/channel/Message/SwipeToReplyRow.tsx
+++ b/apps/web/src/features/channel/Message/SwipeToReplyRow.tsx
@@ -3,7 +3,7 @@ import {
   SwipableRowContext,
 } from '@components/app/mobile/SwipableRow';
 import { triggerFocusInput } from '@core/directive/focusInput';
-import { isMobile } from '@core/mobile/isMobile';
+import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import ReplyIcon from '@phosphor/arrow-bend-up-left.svg';
 import { type ParentProps, Show, useContext } from 'solid-js';
 import type { MessageActions, MessageData } from './types';
@@ -29,10 +29,13 @@ function SwipeReplyBadge(props: { messageId: string }) {
 }
 
 /**
- * On mobile, wraps a channel message so swiping it left reveals a reply
+ * On touch devices, wraps a channel message so swiping it left reveals a reply
  * affordance and opens the reply input for its thread. Renders children
  * as-is when there is no surrounding `EntityRowProvider` (desktop,
  * standalone threads) or the message cannot be replied to.
+ *
+ * Keyed on touch rather than viewport width so tablets get the gesture too —
+ * an iPad is wider than the mobile breakpoint but is still finger-driven.
  */
 export function MaybeSwipeToReplyRow(
   props: ParentProps<{ message: MessageData; actions?: MessageActions }>
@@ -56,7 +59,7 @@ export function MaybeSwipeToReplyRow(
 
   return (
     <Show
-      when={isMobile() && ctx && props.actions?.onReply}
+      when={isTouchDevice() && ctx && props.actions?.onReply}
       fallback={props.children}
     >
       <SwipableRow

--- a/apps/web/src/features/channel/Mobile/MessageActionDrawerManager.tsx
+++ b/apps/web/src/features/channel/Mobile/MessageActionDrawerManager.tsx
@@ -1,4 +1,4 @@
-import { isMobile } from '@core/mobile/isMobile';
+import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import { createSignal, type JSX } from 'solid-js';
 import type { MessageActions, MessageData } from '../Message/types';
 import { ActionDrawer } from './ActionDrawer';
@@ -15,7 +15,7 @@ import {
 export function MaybeMessageActionDrawerManager(props: {
   children: JSX.Element;
 }) {
-  if (!isMobile()) return props.children;
+  if (!isTouchDevice()) return props.children;
 
   const [isOpen, setIsOpen] = createSignal(false);
   const [message, setMessage] = createSignal<MessageData | undefined>();

--- a/apps/web/src/features/channel/unified-input-mode.ts
+++ b/apps/web/src/features/channel/unified-input-mode.ts
@@ -1,5 +1,5 @@
 import { UNIFIED_CHANNEL_INPUT } from '@core/constant/featureFlags';
-import { isMobile } from '@core/mobile/isMobile';
+import { isTouchDevice } from '@core/mobile/isTouchDevice';
 
 /**
  * Whether the channel is in unified-input mode: one floating input handles
@@ -7,9 +7,12 @@ import { isMobile } from '@core/mobile/isMobile';
  * naming the current target. When off, threads render inline inputs instead
  * (thread-reply inputs inside each thread, in-place message editing).
  *
- * Always on for mobile; on desktop behind `DISABLE_INLINE_INPUTS`.
- * Reactive: `isMobile()` is signal-backed, so this flips on viewport resize.
+ * Always on for touch devices (phone and tablet alike — an iPad is wider than
+ * the mobile breakpoint but drives the same one-input-at-a-time UX); on
+ * desktop behind `DISABLE_INLINE_INPUTS`.
+ * Reactive: `isTouchDevice()` is signal-backed, so this flips if the pointer
+ * type changes.
  */
 export function isUnifiedInputMode(): boolean {
-  return isMobile() || UNIFIED_CHANNEL_INPUT;
+  return isTouchDevice() || UNIFIED_CHANNEL_INPUT;
 }

--- a/apps/web/src/features/entity/composed/ListEntity.tsx
+++ b/apps/web/src/features/entity/composed/ListEntity.tsx
@@ -74,7 +74,7 @@ export function MaybeEntityRow(props: {
 }) {
   const ctx = useContext(SwipableRowContext);
   return (
-    <Show when={isMobile() && ctx} fallback={props.children}>
+    <Show when={isTouchDevice() && ctx} fallback={props.children}>
       <SwipableRow
         id={props.entityId}
         swipeLeftColor={props.config?.swipeLeftColor}
@@ -163,7 +163,7 @@ export function ListEntity(props: ListEntityProps) {
     !isWide() && listLayout?.narrowLayout() === 'condensed';
 
   const mobileStacks = createMemo(() => {
-    if (!isMobile()) return [];
+    if (!isTouchDevice()) return [];
     if (!props.showUnrollNotifications) return [];
     const notifs = props.entity.notifications?.();
     if (!notifs?.length) return [];
@@ -230,7 +230,9 @@ export function ListEntity(props: ListEntityProps) {
             <WideLayout {...layoutProps()} />
           </MaybeEntityRow>
         </Match>
-        <Match when={isMobile() && (hasBeenUnrolled() || shouldUnrollStacks())}>
+        <Match
+          when={isTouchDevice() && (hasBeenUnrolled() || shouldUnrollStacks())}
+        >
           <Entity.Notification.MobileStacks
             stacks={mobileStacks()}
             entity={props.entity}
@@ -240,7 +242,7 @@ export function ListEntity(props: ListEntityProps) {
         </Match>
         <Match
           when={
-            isMobile() &&
+            isTouchDevice() &&
             (isChannelEntity(props.entity) ||
               isEmailEntity(props.entity) ||
               props.showUnrollNotifications)
@@ -271,7 +273,7 @@ export function ListEntity(props: ListEntityProps) {
         </Match>
       </Switch>
 
-      <Show when={hasNotifications() && !isMobile()}>
+      <Show when={hasNotifications() && !isTouchDevice()}>
         <div class="px-2 pb-1.5 -mt-1 min-w-0 overflow-hidden">
           <div class={cn('min-w-0 flex-1 ml-2 @lg/entity:ml-6')}>
             <Show when={isWithNotification(props.entity) && !showContentHits()}>

--- a/apps/web/src/features/home/home.tsx
+++ b/apps/web/src/features/home/home.tsx
@@ -126,7 +126,7 @@ function HomeContent() {
       }</style>
 
       <div class="min-h-0 flex-1 overflow-y-auto">
-        <div class="home-content mx-auto flex w-full max-w-3xl flex-col gap-6 px-4 pb-6 pt-10 mobile:pt-[calc(var(--mobile-content-inset-top,0px)+0.5rem)] mobile:pb-(--mobile-content-inset-bottom) md:pt-16">
+        <div class="home-content mx-auto flex w-full max-w-3xl flex-col gap-6 px-4 pb-6 pt-10 touch:pt-[calc(var(--mobile-content-inset-top,0px)+0.5rem)] touch:pb-(--mobile-content-inset-bottom) md:pt-16">
           <header class="flex items-center gap-2.5">
             <AnimatedHeroLogo class="size-6 shrink-0 text-accent" />
             <h1 class="text-xl font-normal tracking-tight text-ink">
@@ -158,7 +158,7 @@ function HomeContent() {
       </div>
 
       <FloatRegionOrInline region="accessory">
-        <div class="mx-auto w-full max-w-3xl shrink-0 px-4 pb-3 pointer-events-auto mobile:px-(--mobile-chrome-gutter) mobile:pb-0">
+        <div class="mx-auto w-full max-w-3xl shrink-0 px-4 pb-3 pointer-events-auto touch:px-(--mobile-chrome-gutter) touch:pb-0">
           <HomeChatInput />
         </div>
       </FloatRegionOrInline>

--- a/apps/web/src/features/next-soup/soup-view/filters-bar/soup-filters-bar.tsx
+++ b/apps/web/src/features/next-soup/soup-view/filters-bar/soup-filters-bar.tsx
@@ -20,7 +20,7 @@ import {
   ENABLE_NEW_INBOX_FLAG,
   ENABLE_NEW_INBOX_OVERRIDE,
 } from '@core/constant/featureFlags';
-import { isMobile } from '@core/mobile/isMobile';
+import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import { createMemo, createSignal, Show } from 'solid-js';
 
 export function SoupFiltersBar(props: {
@@ -78,7 +78,7 @@ export function SoupFiltersBar(props: {
   );
 
   return (
-    <Show when={!isMobile()}>
+    <Show when={!isTouchDevice()}>
       <SplitToolbarLeft>
         <Show
           when={!isSearchView() && !isTagView()}

--- a/apps/web/src/features/next-soup/soup-view/search-ask-ai-button.tsx
+++ b/apps/web/src/features/next-soup/soup-view/search-ask-ai-button.tsx
@@ -48,7 +48,7 @@ export function SearchAskAiButton() {
       size="sm"
       depth={2}
       tooltip="Ask AI"
-      class="shrink-0 h-7 mobile:h-9 gap-1.5 rounded-lg px-2"
+      class="shrink-0 h-7 touch:h-9 gap-1.5 rounded-lg px-2"
       disabled={isAsking()}
       onClick={askAi}
     >

--- a/apps/web/src/features/next-soup/soup-view/soup-view-create-button.tsx
+++ b/apps/web/src/features/next-soup/soup-view/soup-view-create-button.tsx
@@ -115,7 +115,7 @@ function CreateOptionIcon(props: { id: CreateOption['id'] }) {
         <EntityIcon
           targetType={props.id as BlockName}
           size="xs"
-          class="mobile:size-6"
+          class="touch:size-6"
         />
       </Show>
     </Show>

--- a/apps/web/src/features/next-soup/soup-view/soup-view.tsx
+++ b/apps/web/src/features/next-soup/soup-view/soup-view.tsx
@@ -82,6 +82,7 @@ import {
 import { registerHotkey, useHotkeyDOMScope } from '@core/hotkey/hotkeys';
 import { TOKENS } from '@core/hotkey/tokens';
 import { isMobile } from '@core/mobile/isMobile';
+import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import { openExternalUrl } from '@core/util/url';
 import { useIsKeyPressActive } from '@core/util/useIsKeyPressActive';
 import {
@@ -538,7 +539,7 @@ export const SoupView = (props: SoupViewProps) => {
               }
             )}
           >
-            <Show when={!isMobile() && !narrowSearchExpanded()}>
+            <Show when={!isTouchDevice() && !narrowSearchExpanded()}>
               <div class="flex items-center gap-1">
                 <span class="text-sm font-semibold">{props.viewName}</span>
                 <Show when={docsUrl()}>
@@ -558,7 +559,7 @@ export const SoupView = (props: SoupViewProps) => {
             <Show
               when={!narrowSearchExpanded() && !isComponentListView('search')}
             >
-              <Show when={!isMobile()}>
+              <Show when={!isTouchDevice()}>
                 <CollapsibleHeaderItem
                   id="tabs"
                   priority={1}
@@ -577,7 +578,7 @@ export const SoupView = (props: SoupViewProps) => {
             </Show>
             <Show
               when={
-                !isMobile() &&
+                !isTouchDevice() &&
                 !narrowSearchExpanded() &&
                 isComponentListView('mail')
               }
@@ -586,7 +587,7 @@ export const SoupView = (props: SoupViewProps) => {
             </Show>
           </div>
         </SplitHeaderLeft>
-        <Show when={!isMobile()}>
+        <Show when={!isTouchDevice()}>
           <SplitHeaderRight>
             <Show
               when={
@@ -685,7 +686,7 @@ export const SoupView = (props: SoupViewProps) => {
             <SoupViewList />
           </Show>
         </Suspense>
-        <Show when={isMobile()}>
+        <Show when={isTouchDevice()}>
           <FloatRegion region="accessory">
             <MobileSoupViewTabs />
           </FloatRegion>
@@ -697,7 +698,7 @@ export const SoupView = (props: SoupViewProps) => {
         <Show
           when={
             ENABLE_UNIFIED_LIST_AI_INPUT &&
-            !isMobile() &&
+            !isTouchDevice() &&
             !isNewInboxEnabled() &&
             !panel.handle.isControllerSplit() &&
             !isBoardRendered() &&
@@ -1201,10 +1202,10 @@ const SoupViewListContent = (props: SoupViewListProps) => {
       >
         <SoupViewFileDropzone>
           <div class="@container/u-list size-full unified-list-root flex flex-col relative no-select-children">
-            <Show when={isMobile() && source.isPlaceholderData()}>
+            <Show when={isTouchDevice() && source.isPlaceholderData()}>
               <MobileTabLoadingBar />
             </Show>
-            <Show when={isMobile()}>
+            <Show when={isTouchDevice()}>
               <PullToRefresh
                 scrollContainer={() =>
                   showEmptyState() ? emptyStateRef() : listScrollerRef()
@@ -1222,7 +1223,7 @@ const SoupViewListContent = (props: SoupViewListProps) => {
                   {/* Non-list states pad the chrome top themselves — the
                         panel leaves list views unpadded so rows can
                         under-scroll the status bar. */}
-                  <div class="flex-1 min-h-0 flex flex-col mobile:pt-(--mobile-content-inset-top) mobile:pb-(--mobile-content-inset-bottom)">
+                  <div class="flex-1 min-h-0 flex flex-col touch:pt-(--mobile-content-inset-top) touch:pb-(--mobile-content-inset-bottom)">
                     <LoadingBlock />
                   </div>
                 </Match>
@@ -1233,7 +1234,7 @@ const SoupViewListContent = (props: SoupViewListProps) => {
                     !isPullRefreshing()
                   }
                 >
-                  <div class="flex items-center gap-2 p-3 text-xs text-text-muted mobile:mt-(--mobile-content-inset-top) mobile:mb-(--mobile-content-inset-bottom)">
+                  <div class="flex items-center gap-2 p-3 text-xs text-text-muted touch:mt-(--mobile-content-inset-top) touch:mb-(--mobile-content-inset-bottom)">
                     <Spinner class="size-3 animate-spin" />
                     Searching...
                   </div>
@@ -1241,7 +1242,7 @@ const SoupViewListContent = (props: SoupViewListProps) => {
                 <Match when={showEmptyState()}>
                   <div
                     ref={setEmptyStateRef}
-                    class="flex-1 min-h-0 flex flex-col mobile:pt-(--mobile-content-inset-top) mobile:pb-(--mobile-content-inset-bottom)"
+                    class="flex-1 min-h-0 flex flex-col touch:pt-(--mobile-content-inset-top) touch:pb-(--mobile-content-inset-bottom)"
                   >
                     <EmptyState
                       listView={currentView()}
@@ -1257,10 +1258,12 @@ const SoupViewListContent = (props: SoupViewListProps) => {
                     ref={localEntityListRef}
                     narrowLayout={narrowLayout()}
                   >
-                    <Show when={currentView() === 'tasks' && !isMobile()}>
+                    <Show when={currentView() === 'tasks' && !isTouchDevice()}>
                       <ResponsiveTaskListHeader class="shrink-0" />
                     </Show>
-                    <Show when={currentView() === 'companies' && !isMobile()}>
+                    <Show
+                      when={currentView() === 'companies' && !isTouchDevice()}
+                    >
                       <ResponsiveCompanyListHeader class="shrink-0" />
                     </Show>
                     <SwipableRowProvider
@@ -1507,7 +1510,7 @@ const SoupViewListContent = (props: SoupViewListProps) => {
                               <Show when={i() === rows().length - 1}>
                                 {/* Desktop-only: mobile clearance comes
                                       from the in-scroll trailing spacer. */}
-                                <div class="h-15 mobile:hidden" />
+                                <div class="h-15 touch:hidden" />
                               </Show>
                             </>
                           );
@@ -1574,9 +1577,11 @@ const SoupList = (props: SoupListProps) => {
   const [topSpacerRef, setTopSpacerRef] = createSignal<HTMLDivElement>();
   const topSpacerSize = createElementSize(topSpacerRef);
 
-  // Full-frame mobile: rows under-scroll the status bar; this in-scroll
+  // Full-frame touch devices: rows under-scroll the status bar; this in-scroll
   // spacer is their resting inset (safe-top — list views have no header).
-  const topInset = () => (isMobile() ? (topSpacerSize.height ?? 0) : 0);
+  // Keyed on touch, not width: an iPad is a full-frame native app but is wider
+  // than the mobile breakpoint, so a width check would leave it at 0.
+  const topInset = () => (isTouchDevice() ? (topSpacerSize.height ?? 0) : 0);
 
   const handleScroll = (offset: number) => {
     const handle = virtualizerHandle();
@@ -1633,7 +1638,7 @@ const SoupList = (props: SoupListProps) => {
         <div
           ref={setTopSpacerRef}
           aria-hidden
-          class="h-0 block sm:hidden mobile:h-(--mobile-content-inset-top)"
+          class="h-0 block touch:h-(--mobile-content-inset-top)"
         />
         <Virtualizer
           cache={props.cache}
@@ -1650,7 +1655,7 @@ const SoupList = (props: SoupListProps) => {
         >
           {(row, i) => props.children(row, i)}
         </Virtualizer>
-        <Show when={isMobile()}>
+        <Show when={isTouchDevice()}>
           <div aria-hidden class="h-(--mobile-content-inset-bottom)" />
         </Show>
       </div>

--- a/apps/web/src/features/settings/Account.tsx
+++ b/apps/web/src/features/settings/Account.tsx
@@ -15,8 +15,8 @@ import {
 } from '@core/constant/featureFlags';
 import { staticFileIdEndpoint } from '@core/constant/servers';
 import { useEmail, useUserId } from '@core/context/user';
-import { isMobile } from '@core/mobile/isMobile';
 import { isNativeMobilePlatform } from '@core/mobile/isNativeMobilePlatform';
+import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import {
   type ProfilePictureItem,
   useProfilePictureUrl,
@@ -458,7 +458,7 @@ export function Account() {
         </SettingsCard>
       </SettingsSection>
 
-      <Show when={isMobile()}>
+      <Show when={isTouchDevice()}>
         <SettingsSection>
           <SettingsCard>
             <div class="px-6 py-3.5">

--- a/apps/web/src/features/settings/Appearance.tsx
+++ b/apps/web/src/features/settings/Appearance.tsx
@@ -58,7 +58,7 @@ function CopyThemeButton(props: { themeId: string; name: string }) {
       <button
         type="button"
         aria-label={`Copy ${props.name}`}
-        class="rounded p-0.5 hover:text-ink mobile:p-1.5"
+        class="rounded p-0.5 hover:text-ink touch:p-1.5"
         onPointerDown={(e) => e.stopPropagation()}
         onPointerUp={(e) => e.stopPropagation()}
         onClick={(e) => {
@@ -81,7 +81,7 @@ function EditThemeButton(props: { name: string; onEdit: () => void }) {
       <button
         type="button"
         aria-label={`Edit ${props.name}`}
-        class="rounded p-0.5 hover:text-ink mobile:p-1.5"
+        class="rounded p-0.5 hover:text-ink touch:p-1.5"
         onClick={(e) => {
           e.preventDefault();
           e.stopPropagation();

--- a/apps/web/src/features/settings/BotSettingsList.tsx
+++ b/apps/web/src/features/settings/BotSettingsList.tsx
@@ -27,7 +27,7 @@ function BotSettingsRow(props: { bot: Bot; onOpen: (botId: string) => void }) {
   return (
     <button
       type="button"
-      class="flex w-full items-center gap-4 px-6 py-4 text-left outline-none hover:bg-hover focus-visible:bg-hover mobile:items-start mobile:px-4"
+      class="flex w-full items-center gap-4 px-6 py-4 text-left outline-none hover:bg-hover focus-visible:bg-hover mobile:items-start touch:px-4"
       onClick={() => props.onOpen(props.bot.id)}
     >
       <BotAvatar bot={props.bot} size="lg" />

--- a/apps/web/src/features/settings/Settings.tsx
+++ b/apps/web/src/features/settings/Settings.tsx
@@ -19,6 +19,7 @@ import { useSettingsTabs } from '@core/constant/settingsTabsConfig';
 import { registerHotkey, useHotkeyDOMScope } from '@core/hotkey/hotkeys';
 import type { ValidHotkey } from '@core/hotkey/types';
 import { isMobile } from '@core/mobile/isMobile';
+import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import { activeTabId, setActiveTabId } from '@core/signal/settingsTab';
 import ArrowsIn from '@phosphor/arrows-in.svg';
 import ArrowsOut from '@phosphor/arrows-out.svg';
@@ -46,7 +47,6 @@ import { MobileApp } from './MobileApp';
 import { Shortcuts } from './Shortcuts';
 import { Tags } from './Tags';
 import { Team } from './Team';
-import { isTouchDevice } from '@core/mobile/isTouchDevice';
 
 /** Where the settings panel is mounted, which determines its header chrome. */
 export type SettingsVariant = 'split' | 'fullscreen';

--- a/apps/web/src/features/settings/Settings.tsx
+++ b/apps/web/src/features/settings/Settings.tsx
@@ -350,7 +350,7 @@ export function SettingsPanel(props: SettingsPanelProps) {
             around it tightens as the panel narrows, and goes uniform once the
             sidebar collapses. Full-bleed on mobile. */}
         <div
-          class="flex-1 min-w-0 overflow-hidden mobile:p-0"
+          class="flex-1 min-w-0 overflow-hidden touch:p-0"
           classList={{
             'py-2 pr-2 pl-0': !compact() && !narrow(),
             'py-1 pr-1 pl-0': !compact() && narrow(),
@@ -376,7 +376,7 @@ export function SettingsPanel(props: SettingsPanelProps) {
                 </div>
               </Show>
 
-              <div class="relative min-h-0 flex-1 overflow-hidden mobile:pt-(--mobile-content-inset-top) mobile:pb-(--mobile-content-inset-bottom)">
+              <div class="relative min-h-0 flex-1 overflow-hidden touch:pt-(--mobile-content-inset-top) touch:pb-(--mobile-content-inset-bottom)">
                 <Show when={isCurrentTab('Account')}>
                   <Suspense>
                     <Account />

--- a/apps/web/src/features/settings/Settings.tsx
+++ b/apps/web/src/features/settings/Settings.tsx
@@ -46,6 +46,7 @@ import { MobileApp } from './MobileApp';
 import { Shortcuts } from './Shortcuts';
 import { Tags } from './Tags';
 import { Team } from './Team';
+import { isTouchDevice } from '@core/mobile/isTouchDevice';
 
 /** Where the settings panel is mounted, which determines its header chrome. */
 export type SettingsVariant = 'split' | 'fullscreen';
@@ -100,8 +101,8 @@ export function SettingsPanel(props: SettingsPanelProps) {
 
   // Responsive state, driven by the panel's own width (see breakpoints above).
   const [panelWidth, setPanelWidth] = createSignal(Number.POSITIVE_INFINITY);
-  const compact = () => !isMobile() && panelWidth() < COMPACT_WIDTH;
-  const narrow = () => !isMobile() && panelWidth() < NARROW_WIDTH;
+  const compact = () => !isTouchDevice() && panelWidth() < COMPACT_WIDTH;
+  const narrow = () => !isTouchDevice() && panelWidth() < NARROW_WIDTH;
 
   // Set up hotkey scope for settings panel
   const [attachHotkeys, settingsHotkeyScope] = useHotkeyDOMScope('settings');
@@ -300,7 +301,7 @@ export function SettingsPanel(props: SettingsPanelProps) {
 
       <div class="flex grow min-h-1 overflow-hidden">
         {/* Inline sidebar — hidden once the panel gets too narrow. */}
-        <Show when={!isMobile() && !compact()}>
+        <Show when={!isTouchDevice() && !compact()}>
           <SideNav
             class={cn(
               'w-[clamp(208px,20%,248px)] gap-3',
@@ -358,7 +359,7 @@ export function SettingsPanel(props: SettingsPanelProps) {
           }}
         >
           <Layer depth={1}>
-            <div class="relative flex size-full flex-col overflow-hidden rounded-xl border border-ink/[0.06] bg-surface shadow-menu mobile:rounded-none mobile:border-0 mobile:bg-transparent">
+            <div class="relative flex size-full flex-col overflow-hidden rounded-xl border border-ink/[0.06] bg-surface shadow-menu touch:rounded-none touch:border-0 touch:bg-transparent">
               {/* Compact full-screen chrome: no split header to host the tabs,
                   so the sidebar collapses into a top bar here — back / tab
                   dropdown / move-to-split. (Split mode puts the tabs in its

--- a/apps/web/src/features/settings/primitives.tsx
+++ b/apps/web/src/features/settings/primitives.tsx
@@ -31,7 +31,7 @@ export function SettingsPage(props: {
 }) {
   return (
     <div class="h-full overflow-y-auto">
-      <div class="mx-auto w-full max-w-[710px] px-10 pt-14 pb-24 mobile:px-5 mobile:pt-8 mobile:pb-12">
+      <div class="mx-auto w-full max-w-[710px] px-10 pt-14 pb-24 touch:px-5 touch:pt-8 touch:pb-12">
         {/* Headers are inset by the card's inner padding so the title and
             section labels line up with the leftmost content inside the cards,
             while the cards themselves stay full-width. */}

--- a/apps/web/src/features/theme/constants.ts
+++ b/apps/web/src/features/theme/constants.ts
@@ -1,10 +1,10 @@
-import { isMobile } from '@core/mobile/isMobile';
 import type { ThemeV2 } from './types/themeTypes';
+import { isTouchDevice } from '@core/mobile/isTouchDevice';
 
 export const DEFAULT_LIGHT_THEME: DefaultTheme = 'Macro Light';
 export const DEFAULT_DARK_THEME: DefaultTheme = 'Macro Dark';
 
-const MACRO_DARK: Pick<ThemeV2, 'depth' | 'tokens' | 'overrides'> = isMobile()  ? {
+const MACRO_DARK: Pick<ThemeV2, 'depth' | 'tokens' | 'overrides'> = isTouchDevice()  ? {
       depth: 0.35,
       tokens: {
         a0: { l: 0.75, c: 0.20, h:  59 },
@@ -45,7 +45,7 @@ const MACRO_DARK: Pick<ThemeV2, 'depth' | 'tokens' | 'overrides'> = isMobile()  
       },
     };
 
-const MACRO_LIGHT: Pick<ThemeV2, 'depth' | 'tokens' | 'overrides'> = isMobile()
+const MACRO_LIGHT: Pick<ThemeV2, 'depth' | 'tokens' | 'overrides'> = isTouchDevice()
   ? {
       depth: 0.06,
       tokens: {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -321,16 +321,13 @@ body.tauri-ios {
 /* scuffed: might wan to use signals for this */
 @custom-variant touch (&:where(html[data-touch-device="true"] *));
 
-/*@custom-variant mobile {
+@custom-variant mobile {
   &:where(html[data-touch-device="true"] *) {
     @media (max-width: 639px) {
       @slot;
     }
   }
-}*/
-
-@custom-variant mobile (&:where(html[data-touch-device="true"] *));
-
+}
 
 @custom-variant light-mode (&:where(html[data-theme-light="true"] *));
 @custom-variant dark-mode (&:where(html[data-theme-light="false"] *));

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -321,13 +321,16 @@ body.tauri-ios {
 /* scuffed: might wan to use signals for this */
 @custom-variant touch (&:where(html[data-touch-device="true"] *));
 
-@custom-variant mobile {
+/*@custom-variant mobile {
   &:where(html[data-touch-device="true"] *) {
     @media (max-width: 639px) {
       @slot;
     }
   }
-}
+}*/
+
+@custom-variant mobile (&:where(html[data-touch-device="true"] *));
+
 
 @custom-variant light-mode (&:where(html[data-theme-light="true"] *));
 @custom-variant dark-mode (&:where(html[data-theme-light="false"] *));

--- a/apps/web/src/lib/core/component/AI/component/message/ChatMessages.tsx
+++ b/apps/web/src/lib/core/component/AI/component/message/ChatMessages.tsx
@@ -3,7 +3,6 @@ import type { ChatMessageWithAttachments } from '@core/component/AI/types';
 import { asChatMessage } from '@core/component/AI/util/message';
 import { StaticMarkdownContext } from '@core/component/LexicalMarkdown/component/core/StaticMarkdown';
 import { aiChatTheme } from '@core/component/LexicalMarkdown/theme';
-import { isMobile } from '@core/mobile/isMobile';
 import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import { isMobileWidth } from '@core/mobile/mobileWidth';
 import { PulsingStar } from '@entity/components/PulsingStar';
@@ -262,7 +261,7 @@ export function ChatMessages(props: ChatMessagesProps) {
                     // pushes the message above the viewport, and the message
                     // should rest below the floating top chrome, not under
                     // it. (0.5rem matches the scroll content's top gap.)
-                    'min-height': isMobile()
+                    'min-height': isTouchDevice()
                       ? `calc(${parentHeight()}px - var(--mobile-content-inset-top, 0px) - var(--mobile-content-inset-bottom, 0px) - 0.5rem)`
                       : `${parentHeight()}px`,
                   }}

--- a/apps/web/src/lib/core/component/AI/component/message/create-mobile-keyboard-scroll-pin.ts
+++ b/apps/web/src/lib/core/component/AI/component/message/create-mobile-keyboard-scroll-pin.ts
@@ -1,4 +1,4 @@
-import { isMobile } from '@core/mobile/isMobile';
+import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import {
   createElementSize,
   makeResizeObserver,
@@ -10,7 +10,7 @@ import { type Accessor, createEffect, on, onMount } from 'solid-js';
 const NEAR_BOTTOM_THRESHOLD = 100;
 
 /**
- * Full-frame mobile: keep the AI chat pinned to the bottom across virtual
+ * Full-frame mobile/tablet: keep the AI chat pinned to the bottom across virtual
  * keyboard show/hide, when the user was already at the bottom. Two distinct
  * geometry changes move the bottom, so two observers:
  *
@@ -31,7 +31,7 @@ export function createMobileKeyboardScrollPin(opts: {
   wrapperEl: Accessor<HTMLElement | null | undefined>;
   scrollToBottom: (behavior: 'instant' | 'smooth') => void;
 }): void {
-  if (!isMobile()) return;
+  if (!isTouchDevice()) return;
   const { scrollEl, wrapperEl, scrollToBottom } = opts;
 
   // Scroller shrink (keyboard appearing). "Was at bottom" is measured against

--- a/apps/web/src/lib/core/component/Lightbox/LightboxChrome.tsx
+++ b/apps/web/src/lib/core/component/Lightbox/LightboxChrome.tsx
@@ -1,4 +1,4 @@
-import { isMobile } from '@core/mobile/isMobile';
+import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import ChevronLeftIcon from '@phosphor/caret-left.svg';
 import ChevronRightIcon from '@phosphor/caret-right.svg';
 import { cn } from '@ui';
@@ -21,7 +21,7 @@ export function LightboxChrome(props: LightboxChromeProps) {
   return (
     <>
       {/* Nav arrows — desktop only */}
-      <Show when={!isMobile()}>
+      <Show when={!isTouchDevice()}>
         <Show when={!props.navigationHidden}>
           <button
             class={cn(navButtonClass, 'left-4')}

--- a/apps/web/src/lib/core/component/Lightbox/LightboxToolbar.tsx
+++ b/apps/web/src/lib/core/component/Lightbox/LightboxToolbar.tsx
@@ -1,4 +1,4 @@
-import { isMobile } from '@core/mobile/isMobile';
+import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import { cn } from '@ui';
 import type { JSX } from 'solid-js';
 
@@ -12,7 +12,7 @@ export function LightboxToolbar(props: LightboxToolbarProps) {
     <div
       class={cn(
         'absolute top-4 right-4 bg-surface backdrop-blur-sm rounded-lg border border-edge p-1 flex flex-row items-center gap-1 shadow-md transition-opacity duration-300',
-        isMobile() || props.isVisible
+        isTouchDevice() || props.isVisible
           ? 'opacity-100'
           : 'opacity-0 pointer-events-none'
       )}

--- a/apps/web/src/lib/core/component/Lightbox/createZoomModel.ts
+++ b/apps/web/src/lib/core/component/Lightbox/createZoomModel.ts
@@ -1,4 +1,4 @@
-import { isMobile } from '@core/mobile/isMobile';
+import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import { type Accessor, createMemo, createSignal } from 'solid-js';
 import type { ZoompinchHandle } from '../Zoompinch';
 
@@ -31,7 +31,7 @@ export function createZoomModel(
     return {
       w: containerEl.clientWidth,
       // Mirror the img's sm:max-h-[80vh] cap on desktop
-      h: isMobile()
+      h: isTouchDevice()
         ? containerEl.clientHeight
         : Math.min(containerEl.clientHeight, window.innerHeight * 0.8),
     };
@@ -70,7 +70,7 @@ export function createZoomModel(
     const nh = img.naturalHeight;
     if (!avail || !nw || !nh) return undefined;
     const fit = Math.min(avail.w / nw, avail.h / nh, 1);
-    const width = Math.max(nw * fit, isMobile() ? 0 : 200);
+    const width = Math.max(nw * fit, isTouchDevice() ? 0 : 200);
     const scale = width / nw;
     return { w: width, h: nh * scale };
   };

--- a/apps/web/src/lib/core/mobile/IpadUnsupportedDialog.tsx
+++ b/apps/web/src/lib/core/mobile/IpadUnsupportedDialog.tsx
@@ -1,0 +1,55 @@
+import { isPlatform } from '@core/util/platform';
+import { Button, Dialog, Surface } from '@ui';
+import { createResource, createSignal, Show } from 'solid-js';
+import { isIpad } from './isIpad';
+
+const DEBUG_FORCE_OPEN = false;
+
+/**
+ * Soft notice shown to iPad users of the native app.
+ *
+ * The UI is designed for iPhone, and an iPad additionally falls outside
+ * `isMobile()` (which is width-based), so it gets served the desktop layout
+ * inside an iPhone-tuned shell. This sets expectations rather than blocking
+ * anything.
+ *
+ * Dismissal is deliberately not persisted — it shows once per cold launch.
+ */
+export function IpadUnsupportedDialog() {
+  if (!isPlatform('ios') && !DEBUG_FORCE_OPEN) return null;
+
+  const [onIpad] = createResource(isIpad);
+  const [dismissed, setDismissed] = createSignal(false);
+
+  return (
+    <Show when={(DEBUG_FORCE_OPEN || onIpad()) && !dismissed()}>
+      <Dialog
+        open
+        onOpenChange={(open) => {
+          if (!open) setDismissed(true);
+        }}
+        class="w-[90%] max-w-120"
+        position="center"
+      >
+        <Surface depth={2}>
+          <div class="flex flex-col gap-4 px-4 py-5">
+            <div class="flex flex-col gap-2">
+              <Dialog.Title class="text-lg font-semibold text-ink">
+                Optimized for iPhone
+              </Dialog.Title>
+              <Dialog.Description class="text-sm leading-5 text-ink-extra-muted">
+                The Macro iOS app is currently built for iPhone. Some parts of
+                the app may feel off on iPad. Full iPad support coming soon.
+              </Dialog.Description>
+            </div>
+            <div class="flex justify-end">
+              <Dialog.CloseButton as={Button} variant="active" size="sm">
+                Got it
+              </Dialog.CloseButton>
+            </div>
+          </div>
+        </Surface>
+      </Dialog>
+    </Show>
+  );
+}

--- a/apps/web/src/lib/core/mobile/IpadUnsupportedDialog.tsx
+++ b/apps/web/src/lib/core/mobile/IpadUnsupportedDialog.tsx
@@ -1,9 +1,18 @@
 import { isPlatform } from '@core/util/platform';
+import { makePersisted } from '@solid-primitives/storage';
 import { Button, Dialog, Surface } from '@ui';
 import { createResource, createSignal, Show } from 'solid-js';
 import { isIpad } from './isIpad';
 
 const DEBUG_FORCE_OPEN = false;
+
+/**
+ * Survives relaunches, so the notice is shown once per device and never again.
+ * Module scope so the stored value is read once rather than on every mount.
+ */
+const [dismissed, setDismissed] = makePersisted(createSignal(false), {
+  name: 'ipad-unsupported-notice-dismissed',
+});
 
 /**
  * Soft notice shown to iPad users of the native app.
@@ -13,16 +22,17 @@ const DEBUG_FORCE_OPEN = false;
  * inside an iPhone-tuned shell. This sets expectations rather than blocking
  * anything.
  *
- * Dismissal is deliberately not persisted — it shows once per cold launch.
+ * Shown once per device: dismissal is persisted to localStorage, so it never
+ * returns after the user acknowledges it. `DEBUG_FORCE_OPEN` bypasses the
+ * stored flag so the dialog can still be re-tested after dismissing it.
  */
 export function IpadUnsupportedDialog() {
   if (!isPlatform('ios') && !DEBUG_FORCE_OPEN) return null;
 
   const [onIpad] = createResource(isIpad);
-  const [dismissed, setDismissed] = createSignal(false);
 
   return (
-    <Show when={(DEBUG_FORCE_OPEN || onIpad()) && !dismissed()}>
+    <Show when={DEBUG_FORCE_OPEN || (onIpad() && !dismissed())}>
       <Dialog
         open
         onOpenChange={(open) => {

--- a/apps/web/src/lib/core/mobile/isIpad.ts
+++ b/apps/web/src/lib/core/mobile/isIpad.ts
@@ -1,0 +1,25 @@
+import { isPlatform } from '@core/util/platform';
+import { invoke } from '@tauri-apps/api/core';
+
+let cached: Promise<boolean> | undefined;
+
+/**
+ * Whether we're running in the native iOS app on an iPad.
+ *
+ * `getPlatform()` reports `'ios'` for iPhone and iPad alike, so this asks the
+ * native side for `UIDevice.current.userInterfaceIdiom`. iOS apps running on an
+ * Apple Silicon Mac report the iPad idiom too, and are excluded natively.
+ *
+ * The idiom can't change at runtime, so the result is cached.
+ */
+export function isIpad(): Promise<boolean> {
+  if (!isPlatform('ios')) return Promise.resolve(false);
+  cached ??= invoke<boolean>('is_ipad').catch((error) => {
+    // Most likely the native side predates the `is_ipad` command — warn rather
+    // than fail silently, since "not an iPad" is indistinguishable from a
+    // stale binary otherwise.
+    console.warn('is_ipad command unavailable; assuming non-iPad', error);
+    return false;
+  });
+  return cached;
+}

--- a/apps/web/src/lib/core/mobile/useTouchOutsideToDismissKeyboard.ts
+++ b/apps/web/src/lib/core/mobile/useTouchOutsideToDismissKeyboard.ts
@@ -1,6 +1,6 @@
-import { isMobile } from '@core/mobile/isMobile';
 import { virtualKeyboardVisible } from '@core/mobile/virtualKeyboard';
 import { onCleanup, onMount } from 'solid-js';
+import { isTouchDevice } from './isTouchDevice';
 
 /**
  * Dismisses the virtual keyboard when the user touches outside of the given
@@ -14,7 +14,7 @@ import { onCleanup, onMount } from 'solid-js';
 export function useTouchOutsideToDismissKeyboard(
   getContainer: () => HTMLElement | null | undefined
 ) {
-  if (!isMobile()) return;
+  if (!isTouchDevice()) return;
 
   onMount(() => {
     function handleTouchStart(e: TouchEvent) {

--- a/apps/web/src/lib/core/util/openInNewSplit.test.ts
+++ b/apps/web/src/lib/core/util/openInNewSplit.test.ts
@@ -1,14 +1,14 @@
-import { isMobile } from '@core/mobile/isMobile';
+import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { openInNewSplitForMention } from './openInNewSplit';
 
-vi.mock('@core/mobile/isMobile', () => ({
-  isMobile: vi.fn(() => false),
+vi.mock('@core/mobile/isTouchDevice', () => ({
+  isTouchDevice: vi.fn(() => false),
 }));
 
 describe('openInNewSplitForMention', () => {
   afterEach(() => {
-    vi.mocked(isMobile).mockReturnValue(false);
+    vi.mocked(isTouchDevice).mockReturnValue(false);
   });
 
   it('opens in a new split by default for mouse/keyboard interactions', () => {
@@ -23,8 +23,8 @@ describe('openInNewSplitForMention', () => {
     expect(openInNewSplitForMention(undefined, false)).toBe(false);
   });
 
-  it('always opens in the current split on mobile', () => {
-    vi.mocked(isMobile).mockReturnValue(true);
+  it('always opens in the current split on touch devices', () => {
+    vi.mocked(isTouchDevice).mockReturnValue(true);
     expect(openInNewSplitForMention(false, true)).toBe(false);
   });
 });

--- a/apps/web/src/lib/core/util/openInNewSplit.ts
+++ b/apps/web/src/lib/core/util/openInNewSplit.ts
@@ -1,4 +1,4 @@
-import { isMobile } from '@core/mobile/isMobile';
+import { isTouchDevice } from '@core/mobile/isTouchDevice';
 
 /**
  * Macro uses "splits" as its tab-like navigation concept.
@@ -9,13 +9,13 @@ import { isMobile } from '@core/mobile/isMobile';
  *
  * We also want touch opens to remain in the current split to avoid surprising
  * split creation. The call-site `e != null` heuristic can't detect touch on
- * iOS WKWebView (taps fire real mouse events), so guard on `isMobile()` here —
+ * iOS WKWebView (taps fire real mouse events), so guard on `isTouchDevice()` here —
  * mobile has no split concept and navigates in place / via forward navigation.
  */
 export function openInNewSplitForMention(
   altKey: boolean | undefined,
   defaultOpenInNewSplit: boolean
 ): boolean {
-  if (isMobile()) return false;
+  if (isTouchDevice()) return false;
   return altKey ? false : defaultOpenInNewSplit;
 }

--- a/apps/web/src/routes/Root.tsx
+++ b/apps/web/src/routes/Root.tsx
@@ -47,6 +47,7 @@ import {
 import { initAndStartEmailSync } from '@core/email-link';
 import { useHotKeyRoot } from '@core/hotkey/hotkeys';
 import { IosPushNotificationModal } from '@core/mobile/IosPushNotificationModal';
+import { IpadUnsupportedDialog } from '@core/mobile/IpadUnsupportedDialog';
 import { isMobile } from '@core/mobile/isMobile';
 import { isNativeMobilePlatform } from '@core/mobile/isNativeMobilePlatform';
 import { createBlockOrchestrator } from '@core/orchestrator';
@@ -571,6 +572,7 @@ export function Root() {
                 <EmailLinksContextProvider>
                   <BrowserNotificationModal />
                   <IosPushNotificationModal />
+                  <IpadUnsupportedDialog />
                   <GlobalShareInboxConflictDialog />
                   <QuerySyncProviderWithUserId />
                   <UserInfoSideEffects />

--- a/apps/web/tauri/src-tauri/src/device.rs
+++ b/apps/web/tauri/src-tauri/src/device.rs
@@ -1,0 +1,80 @@
+//! Device form-factor detection.
+//!
+//! `-[UIDevice userInterfaceIdiom]` is UIKit and must only be touched on the
+//! main thread, but a sync `#[tauri::command]` is served off the IPC thread.
+//! The idiom never changes at runtime, so it is sampled once at the top of
+//! `run()` — which on iOS is `main()`'s thread, via `ffi::start_app()` in
+//! `gen/apple/Sources/app/main.mm` — and stored as managed state. The command
+//! only reads that snapshot.
+
+/// Managed state: whether the device reports the iPad UI idiom.
+///
+/// Always `false` off iOS.
+pub(crate) struct IsIpad(pub(crate) bool);
+
+/// `UIUserInterfaceIdiomPad`, from `<UIKit/UIDevice.h>`.
+#[cfg(target_os = "ios")]
+const UI_USER_INTERFACE_IDIOM_PAD: objc2::ffi::NSInteger = 1;
+
+/// Reads `[[UIDevice currentDevice] userInterfaceIdiom]`, excluding iOS apps
+/// running on an Apple Silicon Mac (which also report the iPad idiom).
+///
+/// Must be called on the main thread — UIKit requirement.
+///
+/// This depends on `TARGETED_DEVICE_FAMILY` including `2` (see
+/// `gen/apple/project.yml` and `project.pbxproj`). If the app were ever built
+/// iPhone-only, it would run on iPad in compatibility mode and the idiom would
+/// silently become `.phone`, making this return `false` with no compile error.
+#[cfg(target_os = "ios")]
+pub(crate) fn detect_is_ipad() -> bool {
+    use objc2::ffi::NSInteger;
+    use objc2::runtime::{AnyObject, Bool};
+    use objc2::{class, msg_send};
+
+    // SAFETY: `+[UIDevice currentDevice]`, `-[UIDevice userInterfaceIdiom]`,
+    // `+[NSProcessInfo processInfo]` and `-[NSProcessInfo isiOSAppOnMac]` all
+    // take no arguments and return `id`/`NSInteger`/`BOOL` respectively. Both
+    // `currentDevice` and `processInfo` return unowned shared singletons, so
+    // nothing needs releasing. Called on the main thread. Each nil check
+    // precedes the message send that follows it because objc2 panics on
+    // messaging nil in debug builds.
+    unsafe {
+        let device: *mut AnyObject = msg_send![class!(UIDevice), currentDevice];
+        if device.is_null() {
+            tracing::warn!("[UIDevice currentDevice] was nil; assuming non-iPad");
+            return false;
+        }
+
+        let idiom: NSInteger = msg_send![device, userInterfaceIdiom];
+        tracing::debug!(idiom, "UIDevice userInterfaceIdiom");
+        if idiom != UI_USER_INTERFACE_IDIOM_PAD {
+            return false;
+        }
+
+        // An unmodified iOS binary running on an Apple Silicon Mac ("Designed
+        // for iPad") also reports the `.pad` idiom. Those users are not on an
+        // iPad, so exclude them.
+        let process: *mut AnyObject = msg_send![class!(NSProcessInfo), processInfo];
+        if !process.is_null() {
+            let is_ios_app_on_mac: Bool = msg_send![process, isiOSAppOnMac];
+            if is_ios_app_on_mac.as_bool() {
+                tracing::debug!("iPad idiom reported by an iOS app on macOS; treating as non-iPad");
+                return false;
+            }
+        }
+
+        true
+    }
+}
+
+/// Non-iOS builds are never an iPad.
+#[cfg(not(target_os = "ios"))]
+pub(crate) fn detect_is_ipad() -> bool {
+    false
+}
+
+/// Returns `true` when the app is running with the iPad UI idiom.
+#[tauri::command]
+pub(crate) fn is_ipad(state: tauri::State<'_, IsIpad>) -> bool {
+    state.0
+}

--- a/apps/web/tauri/src-tauri/src/lib.rs
+++ b/apps/web/tauri/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+use device::{IsIpad, detect_is_ipad, is_ipad};
 use logger::Logger;
 use macro_bundle_updater_plugin::domain::{
     asset_service::BundleAssetResolver, bundle_routes::BundleRoutes,
@@ -29,6 +30,7 @@ use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use url::Url;
 
+mod device;
 mod share_target;
 mod staged_upload;
 
@@ -136,6 +138,11 @@ pub fn run() {
 
     registry.init();
 
+    // UIKit must be queried on the main thread, and `run()` is called straight
+    // from `main()` (`ffi::start_app()` on iOS), so this is it. The idiom never
+    // changes at runtime, so a one-shot snapshot is enough.
+    let is_ipad_device = detect_is_ipad();
+
     let embedded_bundle_build = embedded_bundle_build();
     let bundle_routes = BundleRoutes::new(embedded_bundle_build);
     let bundle_asset_resolver = BundleAssetResolver::new(bundle_routes.clone(), FileSystem);
@@ -241,6 +248,7 @@ pub fn run() {
         .manage(PendingShareFilesState::default())
         .manage(DeepLinkDelivery::default())
         .manage(graphql_cache_plugin::CacheState::default())
+        .manage(IsIpad(is_ipad_device))
         .invoke_handler(tauri::generate_handler![
             graphql_cache_plugin::commands::graphql_cache_init,
             graphql_cache_plugin::commands::graphql_cache_read,
@@ -264,6 +272,7 @@ pub fn run() {
             macro_bundle_updater_plugin::inbound::plugin::get_bundle_debug_info,
             macro_bundle_updater_plugin::inbound::plugin::get_bundle_update_status,
             macro_bundle_updater_plugin::inbound::plugin::clear_bundle,
+            is_ipad,
             get_pending_share_filenames,
             pop_shared_files,
             clear_shared_files,

--- a/bun.lock
+++ b/bun.lock
@@ -943,7 +943,7 @@
 
     "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
 
-    "@inkibra/tauri-plugins": ["@inkibra/tauri-plugins@github:macro-inc/tauri-plugins#6ddd660", { "dependencies": { "react": "^18.3.1", "react-dom": "^18.3.1" } }, "macro-inc-tauri-plugins-6ddd660"],
+    "@inkibra/tauri-plugins": ["@inkibra/tauri-plugins@github:macro-inc/tauri-plugins#6ddd660", { "dependencies": { "react": "^18.3.1", "react-dom": "^18.3.1" } }, "macro-inc-tauri-plugins-6ddd660", "sha512-7+0ebEOYqedkOY67Clwu65Np3qJ3aJc/H/NjNxmjgA/7HIu0C+DSoKAArG7HTdTVpdcAtHyhrqsJujdEAyJf6Q=="],
 
     "@inquirer/ansi": ["@inquirer/ansi@2.0.7", "", {}, "sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q=="],
 
@@ -2721,7 +2721,7 @@
 
     "pathval": ["pathval@2.0.1", "", {}, "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ=="],
 
-    "pdfjs-dist": ["pdfjs-dist@github:macro-inc/pdf.js#f9b2ce6", { "dependencies": { "dommatrix": "^1.0.3", "web-streams-polyfill": "^3.2.1" }, "peerDependencies": { "worker-loader": "^3.0.8" }, "optionalPeers": ["worker-loader"] }, "macro-inc-pdf.js-f9b2ce6"],
+    "pdfjs-dist": ["pdfjs-dist@github:macro-inc/pdf.js#f9b2ce6", { "dependencies": { "dommatrix": "^1.0.3", "web-streams-polyfill": "^3.2.1" }, "peerDependencies": { "worker-loader": "^3.0.8" }, "optionalPeers": ["worker-loader"] }, "macro-inc-pdf.js-f9b2ce6", "sha512-HDFaPbCxLG2GHpf1smUG97nku5aPGBGaCcIbK05dGdp07TBLUlDcXsM4WcE82mO5W4RBPIBVYobX5N/6M6NFrA=="],
 
     "performance-now": ["performance-now@2.1.0", "", {}, "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="],
 


### PR DESCRIPTION
Adds a warning when users launch our native iOS app on an iPad that the app was built for iPhone and so some things might be off.

Additionally we make changes to mobile-width vs touch-enabled gating so that the app on iPad is essentially just a big version of the iPhone app. This is not ideal but it makes the iPad app significantly more usable in a minimally invasive way.