### PR TITLE
chore(opensearch): bump storage size

### DIFF
--- a/infra/stacks/opensearch/index.ts
+++ b/infra/stacks/opensearch/index.ts
@@ -128,11 +128,11 @@ const opensearchDomain = new aws.opensearch.Domain(
     // per instance storage
     ebsOptions: {
       ebsEnabled: true,
-      volumeSize: stack === 'prod' ? 400 : 50,
+      volumeSize: stack === 'prod' ? 1400 : 50,
       volumeType: 'gp3',
       // Pin prod gp3 IOPS/throughput to the live values so a size change
       // doesn't reset throughput to the gp3 default (125 MB/s).
-      ...(stack === 'prod' ? { iops: 3000, throughput: 250 } : {}),
+      ...(stack === 'prod' ? { iops: 4200, throughput: 350 } : {}),
     },
     nodeToNodeEncryption: {
       enabled: true,


### PR DESCRIPTION
bumps node size, iops and throughput