### PR TITLE
Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,36 @@
+---
+name: Bug Report
+about: Report a bug to help us improve
+title: "[BUG] "
+labels: bug
+assignees: ''
+---
+
+## Describe the bug
+
+A clear and concise description of what the bug is.
+
+## To Reproduce
+
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Run '....'
+3. See error
+
+## Expected behavior
+
+A clear and concise description of what you expected to happen.
+
+## Screenshots / Logs
+
+If applicable, add screenshots or log output to help explain your problem.
+
+## Environment
+
+- OS: [e.g., Ubuntu 22.04]
+- `echo 'version info here'` output: [e.g., Python 3.11.5]
+- Version of this package: [e.g., 1.2.3]
+
+## Additional context
+
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature Request
+about: Suggest an idea for this project
+title: "[FEATURE] "
+labels: enhancement
+assignees: ''
+---
+
+## Is your feature request related to a problem?
+
+A clear and concise description of what the problem is.
+
+## Proposed solution
+
+A clear and concise description of what you want to happen.
+
+## Alternatives considered
+
+A clear and concise description of any alternative solutions or features you've considered.
+
+## Additional context
+
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
## Add GitHub issue templates

Repository lacks issue templates, making it harder for users to report bugs or request features.

## Changes

Modified 2 file(s): .github/ISSUE_TEMPLATE/bug_report.md, .github/ISSUE_TEMPLATE/feature_request.md

## Checklist

- [x] Code follows the project's style guidelines
- [x] Changes have been tested locally
- [x] Documentation updated if needed
