### PR TITLE
fix(email): scope sender Signal/Noise/Block to the thread's inbox

### DIFF
--- a/apps/web/src/features/block-email/component/EmailContext.tsx
+++ b/apps/web/src/features/block-email/component/EmailContext.tsx
@@ -763,14 +763,20 @@ export function EmailProvider(props: FlowProps<{ threadID: string }>) {
   const markSenderSignal = () => {
     const senderEmail = getSenderEmail();
     if (!senderEmail) return false;
-    markSenderSignalWithToast(senderEmail);
+    markSenderSignalWithToast(
+      senderEmail,
+      toHeaderLinkId(threadQuery.data?.link_id)
+    );
     return true;
   };
 
   const markSenderNoise = () => {
     const senderEmail = getSenderEmail();
     if (!senderEmail) return false;
-    markSenderNoiseWithToast(senderEmail);
+    markSenderNoiseWithToast(
+      senderEmail,
+      toHeaderLinkId(threadQuery.data?.link_id)
+    );
     return true;
   };
 

--- a/apps/web/src/features/next-soup/actions/make-block-sender-action.ts
+++ b/apps/web/src/features/next-soup/actions/make-block-sender-action.ts
@@ -1,8 +1,11 @@
 import type { EntityData } from '@entity';
+import { useNonPrimaryEmailLinkIdHeader } from '@queries/email/link';
 import { blockSenderWithToast } from '@queries/email/thread';
 import type { SoupState } from '../create-soup-state';
 
 export const makeBlockSenderAction = () => {
+  const toHeaderLinkId = useNonPrimaryEmailLinkIdHeader();
+
   const canExecute = (entity: EntityData): boolean => {
     return entity.type === 'email' && !!entity.senderEmail;
   };
@@ -10,7 +13,12 @@ export const makeBlockSenderAction = () => {
   const execute = async (entities: EntityData[]) => {
     for (const entity of entities) {
       if (entity.type !== 'email' || !entity.senderEmail) continue;
-      await blockSenderWithToast(entity.senderEmail);
+      // The block creates a Gmail filter on one linked account, so it has to
+      // target the inbox the thread arrived in.
+      await blockSenderWithToast(
+        entity.senderEmail,
+        toHeaderLinkId(entity.linkId)
+      );
     }
   };
 

--- a/apps/web/src/features/next-soup/actions/make-sender-filter-action.test.ts
+++ b/apps/web/src/features/next-soup/actions/make-sender-filter-action.test.ts
@@ -1,0 +1,109 @@
+import type { EntityData } from '@entity';
+import { createRoot } from 'solid-js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  blockSenderWithToast: vi.fn(async () => {}),
+  filterAction: vi.fn(async () => {}),
+  primaryLinkId: 'link-primary',
+}));
+
+vi.mock('@queries/email/link', () => ({
+  // Mirrors the real hook: the primary inbox's link id maps to `undefined`
+  // (the backend defaults to primary when the header is absent).
+  useNonPrimaryEmailLinkIdHeader: () => (linkId: string | undefined | null) =>
+    !linkId || linkId === mocks.primaryLinkId ? undefined : linkId,
+}));
+
+vi.mock('@queries/email/thread', () => ({
+  blockSenderWithToast: mocks.blockSenderWithToast,
+}));
+
+import { makeBlockSenderAction } from './make-block-sender-action';
+import { makeSenderFilterAction } from './make-sender-filter-action';
+
+const emailEntity = (over: Partial<EntityData> = {}) =>
+  ({
+    type: 'email',
+    id: 'thread-1',
+    senderEmail: 'sender@example.com',
+    ...over,
+  }) as EntityData;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('makeSenderFilterAction', () => {
+  it('sends the thread inbox link id for a non-primary inbox', async () => {
+    await createRoot(async (dispose) => {
+      const action = makeSenderFilterAction(mocks.filterAction);
+      await action.execute([emailEntity({ linkId: 'link-secondary' })]);
+      dispose();
+    });
+
+    expect(mocks.filterAction).toHaveBeenCalledWith(
+      'sender@example.com',
+      'link-secondary'
+    );
+  });
+
+  it('omits the link id for the primary inbox', async () => {
+    await createRoot(async (dispose) => {
+      const action = makeSenderFilterAction(mocks.filterAction);
+      await action.execute([emailEntity({ linkId: mocks.primaryLinkId })]);
+      dispose();
+    });
+
+    expect(mocks.filterAction).toHaveBeenCalledWith(
+      'sender@example.com',
+      undefined
+    );
+  });
+
+  it('keys the dedupe on the inbox so one sender in two inboxes is two filters', async () => {
+    await createRoot(async (dispose) => {
+      const action = makeSenderFilterAction(mocks.filterAction);
+      await action.execute([
+        emailEntity({ id: 'a', linkId: 'link-a' }),
+        emailEntity({ id: 'b', linkId: 'link-b' }),
+        emailEntity({ id: 'c', linkId: 'link-a' }),
+      ]);
+      dispose();
+    });
+
+    expect(mocks.filterAction).toHaveBeenCalledTimes(2);
+    expect(mocks.filterAction).toHaveBeenCalledWith(
+      'sender@example.com',
+      'link-a'
+    );
+    expect(mocks.filterAction).toHaveBeenCalledWith(
+      'sender@example.com',
+      'link-b'
+    );
+  });
+});
+
+describe('makeBlockSenderAction', () => {
+  it('blocks on the inbox the thread belongs to', async () => {
+    await createRoot(async (dispose) => {
+      const action = makeBlockSenderAction();
+      await action.execute([
+        emailEntity({ id: 'a', linkId: 'link-secondary' }),
+        emailEntity({ id: 'b', linkId: mocks.primaryLinkId }),
+      ]);
+      dispose();
+    });
+
+    expect(mocks.blockSenderWithToast).toHaveBeenNthCalledWith(
+      1,
+      'sender@example.com',
+      'link-secondary'
+    );
+    expect(mocks.blockSenderWithToast).toHaveBeenNthCalledWith(
+      2,
+      'sender@example.com',
+      undefined
+    );
+  });
+});

--- a/apps/web/src/features/next-soup/actions/make-sender-filter-action.test.ts
+++ b/apps/web/src/features/next-soup/actions/make-sender-filter-action.test.ts
@@ -82,6 +82,23 @@ describe('makeSenderFilterAction', () => {
       'link-b'
     );
   });
+
+  it('collapses a missing link id and an explicit primary one into one request', async () => {
+    await createRoot(async (dispose) => {
+      const action = makeSenderFilterAction(mocks.filterAction);
+      await action.execute([
+        emailEntity({ id: 'a', linkId: undefined }),
+        emailEntity({ id: 'b', linkId: mocks.primaryLinkId }),
+      ]);
+      dispose();
+    });
+
+    expect(mocks.filterAction).toHaveBeenCalledTimes(1);
+    expect(mocks.filterAction).toHaveBeenCalledWith(
+      'sender@example.com',
+      undefined
+    );
+  });
 });
 
 describe('makeBlockSenderAction', () => {

--- a/apps/web/src/features/next-soup/actions/make-sender-filter-action.ts
+++ b/apps/web/src/features/next-soup/actions/make-sender-filter-action.ts
@@ -1,9 +1,12 @@
 import type { EntityData } from '@entity';
+import { useNonPrimaryEmailLinkIdHeader } from '@queries/email/link';
 import type { SoupState } from '../create-soup-state';
 
 export const makeSenderFilterAction = (
-  action: (email: string) => Promise<void>
+  action: (email: string, linkId?: string) => Promise<void>
 ) => {
+  const toHeaderLinkId = useNonPrimaryEmailLinkIdHeader();
+
   const canExecute = (entity: EntityData): boolean =>
     entity.type === 'email' && !!entity.senderEmail;
 
@@ -11,10 +14,12 @@ export const makeSenderFilterAction = (
     const seen = new Set<string>();
     for (const entity of entities) {
       if (entity.type !== 'email' || !entity.senderEmail) continue;
-      const key = entity.senderEmail.trim().toLowerCase();
+      // Filters are per-inbox, so the same sender in two inboxes is two
+      // distinct filters — key the dedupe on the inbox too.
+      const key = `${entity.linkId ?? ''}:${entity.senderEmail.trim().toLowerCase()}`;
       if (seen.has(key)) continue;
       seen.add(key);
-      await action(entity.senderEmail);
+      await action(entity.senderEmail, toHeaderLinkId(entity.linkId));
     }
   };
 

--- a/apps/web/src/features/next-soup/actions/make-sender-filter-action.ts
+++ b/apps/web/src/features/next-soup/actions/make-sender-filter-action.ts
@@ -15,11 +15,14 @@ export const makeSenderFilterAction = (
     for (const entity of entities) {
       if (entity.type !== 'email' || !entity.senderEmail) continue;
       // Filters are per-inbox, so the same sender in two inboxes is two
-      // distinct filters — key the dedupe on the inbox too.
-      const key = `${entity.linkId ?? ''}:${entity.senderEmail.trim().toLowerCase()}`;
+      // distinct filters — key the dedupe on the inbox too. Key off the
+      // normalized header value so a missing link id and an explicit primary
+      // one collapse to a single request.
+      const linkId = toHeaderLinkId(entity.linkId);
+      const key = `${linkId ?? ''}:${entity.senderEmail.trim().toLowerCase()}`;
       if (seen.has(key)) continue;
       seen.add(key);
-      await action(entity.senderEmail, toHeaderLinkId(entity.linkId));
+      await action(entity.senderEmail, linkId);
     }
   };
 

--- a/apps/web/src/lib/queries/email/thread.ts
+++ b/apps/web/src/lib/queries/email/thread.ts
@@ -778,14 +778,18 @@ export async function blockSenderWithToast(
 
 async function upsertSenderFilterWithToast(
   senderEmail: string,
-  isImportant: boolean
+  isImportant: boolean,
+  linkId?: string
 ) {
   const label = isImportant ? 'Signal' : 'Noise';
 
-  const result = await emailClient.upsertEmailFilter({
-    email_address: senderEmail,
-    is_important: isImportant,
-  });
+  const result = await emailClient.upsertEmailFilter(
+    {
+      email_address: senderEmail,
+      is_important: isImportant,
+    },
+    linkId
+  );
 
   if (result.isErr()) {
     toast.failure(`Failed to mark sender as ${label}`, {
@@ -804,9 +808,10 @@ async function upsertSenderFilterWithToast(
         label: 'Undo',
         icon: ArrowCounterClockwise,
         onClick: async () => {
-          const undoResult = await emailClient.deleteEmailFilter({
-            id: filterId,
-          });
+          const undoResult = await emailClient.deleteEmailFilter(
+            { id: filterId },
+            linkId
+          );
           if (undoResult.isErr()) {
             toast.failure('Failed to undo', { subtext: senderEmail });
           } else {
@@ -819,8 +824,20 @@ async function upsertSenderFilterWithToast(
   });
 }
 
-export const markSenderSignalWithToast = (senderEmail: string) =>
-  upsertSenderFilterWithToast(senderEmail, true);
+/**
+ * Marks a sender as Signal for one inbox. `linkId` scopes the filter to the
+ * inbox the thread belongs to — omit it only for the primary inbox.
+ */
+export const markSenderSignalWithToast = (
+  senderEmail: string,
+  linkId?: string
+) => upsertSenderFilterWithToast(senderEmail, true, linkId);
 
-export const markSenderNoiseWithToast = (senderEmail: string) =>
-  upsertSenderFilterWithToast(senderEmail, false);
+/**
+ * Marks a sender as Noise for one inbox. See {@link markSenderSignalWithToast}
+ * for how `linkId` is used.
+ */
+export const markSenderNoiseWithToast = (
+  senderEmail: string,
+  linkId?: string
+) => upsertSenderFilterWithToast(senderEmail, false, linkId);

--- a/apps/web/src/lib/service-clients/service-email/client.ts
+++ b/apps/web/src/lib/service-clients/service-email/client.ts
@@ -540,24 +540,29 @@ export const emailClient = {
       headers: emailLinkHeaders(linkId),
     });
   },
-  async listEmailFilters() {
+  // Filters are stored per linked inbox, so every filter call is scoped to
+  // `linkId` via the X-Email-Link-Id header; omit for the primary inbox.
+  async listEmailFilters(linkId?: string) {
     return (
       await emailFetch<ListEmailFiltersResponse>('/email/filters', {
         method: 'GET',
+        headers: emailLinkHeaders(linkId),
       })
     ).map((result) => result);
   },
-  async upsertEmailFilter(args: UpsertEmailFilterRequest) {
+  async upsertEmailFilter(args: UpsertEmailFilterRequest, linkId?: string) {
     return (
       await emailFetch<UpsertEmailFilterResponse>('/email/filters', {
         method: 'PUT',
         body: JSON.stringify(args),
+        headers: emailLinkHeaders(linkId),
       })
     ).map((result) => result);
   },
-  async deleteEmailFilter(args: { id: string }) {
+  async deleteEmailFilter(args: { id: string }, linkId?: string) {
     return emailFetch(`/email/filters/${args.id}`, {
       method: 'DELETE',
+      headers: emailLinkHeaders(linkId),
     });
   },
   async listCalendars() {


### PR DESCRIPTION
## The bug

Confirmed — the suspicion was right, and it's a bit worse than described.

Right-clicking an email row and choosing **Sender → Signal**, **Sender → Noise**, or **Block Sender** fired the request with no `X-Email-Link-Id` header. Both endpoints are per-inbox on the server:

- `PUT/DELETE/GET /email/filters` resolve the link from `EmailLinkExtractor` and store the filter against `link.id` (`crates/email/src/domain/service/mod.rs:450`).
- `POST /email/contacts/block` enqueues a `gmail_ops` message keyed on `link.id` (`services/email_service/src/api/email/contacts/block_sender.rs`).

With the header absent the backend falls back to the user's primary inbox. So for anyone with more than one account connected, marking a sender Noise on a secondary inbox wrote the filter row against the wrong link (no effect on the inbox they were looking at), and Block Sender created the Gmail filter on the wrong Google account entirely.

The thread view had the same gap in two of three places: `blockSender` was already passing `toHeaderLinkId(thread.link_id)`, but `markSenderSignal` / `markSenderNoise` were not.

## The fix

Thread the inbox's link id through to all three actions.

- `emailClient.listEmailFilters` / `upsertEmailFilter` / `deleteEmailFilter` take an optional `linkId` and send it as `X-Email-Link-Id`, matching what `blockSender` / `unblockSender` already did.
- `markSenderSignalWithToast` / `markSenderNoiseWithToast` take a `linkId` and use it for the upsert *and* for the undo delete, so Undo removes the filter from the same inbox it was added to.
- The soup actions resolve it from the email entity's `linkId` (already populated by the soup transform) via `useNonPrimaryEmailLinkIdHeader` — the same hook `makeMarkReadAction` uses.
- `makeSenderFilterAction`'s dedupe key now includes the inbox. Previously it deduped on sender address alone, which would have collapsed a multi-select spanning two inboxes into a single filter; a sender in two inboxes is genuinely two filters.
- `EmailContext`'s `markSenderSignal` / `markSenderNoise` now pass `thread.link_id`.

Primary-inbox behavior is unchanged: `useNonPrimaryEmailLinkIdHeader` maps the primary link id to `undefined`, so the header stays off and the backend's primary default still applies.
