### PR TITLE
fix(calendar): offer turn-off wherever calendar data exists

### DIFF
--- a/.sqlx/query-f5a596b0285397ce7c4c28341482986d8f943f497d79190ed37bd271448864ba.json
+++ b/.sqlx/query-f5a596b0285397ce7c4c28341482986d8f943f497d79190ed37bd271448864ba.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        SELECT l.id as \"id!\", l.macro_id as \"macro_id!\",\n               l.fusionauth_user_id as \"fusionauth_user_id!\",\n               l.email_address as \"email_address!\",\n               l.provider as \"provider!: _\",\n               l.is_sync_active as \"is_sync_active!\",\n               l.is_primary as \"is_primary!\",\n               l.needs_reauth as \"needs_reauth!\",\n               l.last_sync_error_at,\n               l.created_at as \"created_at!\",\n               l.updated_at as \"updated_at!\",\n               s.signature_on_replies_forwards as \"signature_on_replies_forwards?\",\n               s.signature,\n               bj.status as \"latest_backfill_status?: _\",\n               c.sfs_photo_url as \"photo_url?\",\n               COALESCE(g.granted_scopes, '{}') AS \"google_granted_scopes!\",\n               (g.calendar_disabled_at IS NOT NULL) AS \"calendar_disabled!\"\n        FROM (\n            SELECT el.id, el.macro_id, el.fusionauth_user_id, el.email_address,\n                   el.provider, el.is_sync_active, el.is_primary, el.needs_reauth,\n                   el.last_sync_error_at, el.created_at, el.updated_at\n            FROM email_links el\n            WHERE el.macro_id = $1\n            UNION\n            SELECT el.id, el.macro_id, el.fusionauth_user_id, el.email_address,\n                   el.provider, el.is_sync_active, el.is_primary, el.needs_reauth,\n                   el.last_sync_error_at, el.created_at, el.updated_at\n            FROM email_links el\n            JOIN macro_user_links mul ON el.id = mul.link_id\n            WHERE mul.primary_macro_id = $1\n        ) l\n        LEFT JOIN email_link_google_scopes g ON g.link_id = l.id\n        LEFT JOIN email_settings s ON s.link_id = l.id\n        LEFT JOIN LATERAL (\n            SELECT status FROM email_backfill_jobs\n            WHERE link_id = l.id\n            ORDER BY created_at DESC\n            LIMIT 1\n        ) bj ON true\n        LEFT JOIN email_contacts c\n            ON c.link_id = l.id AND LOWER(c.email_address) = LOWER(l.email_address)\n        ORDER BY l.created_at DESC\n        ",
+  "query": "\n        SELECT l.id as \"id!\", l.macro_id as \"macro_id!\",\n               l.fusionauth_user_id as \"fusionauth_user_id!\",\n               l.email_address as \"email_address!\",\n               l.provider as \"provider!: _\",\n               l.is_sync_active as \"is_sync_active!\",\n               l.is_primary as \"is_primary!\",\n               l.needs_reauth as \"needs_reauth!\",\n               l.last_sync_error_at,\n               l.created_at as \"created_at!\",\n               l.updated_at as \"updated_at!\",\n               s.signature_on_replies_forwards as \"signature_on_replies_forwards?\",\n               s.signature,\n               bj.status as \"latest_backfill_status?: _\",\n               c.sfs_photo_url as \"photo_url?\",\n               COALESCE(g.granted_scopes, '{}') AS \"google_granted_scopes!\",\n               (g.calendar_disabled_at IS NOT NULL) AS \"calendar_disabled!\",\n               EXISTS (\n                   SELECT 1 FROM calendar_accounts ca WHERE ca.email_link_id = l.id\n               ) AS \"has_calendar_data!\"\n        FROM (\n            SELECT el.id, el.macro_id, el.fusionauth_user_id, el.email_address,\n                   el.provider, el.is_sync_active, el.is_primary, el.needs_reauth,\n                   el.last_sync_error_at, el.created_at, el.updated_at\n            FROM email_links el\n            WHERE el.macro_id = $1\n            UNION\n            SELECT el.id, el.macro_id, el.fusionauth_user_id, el.email_address,\n                   el.provider, el.is_sync_active, el.is_primary, el.needs_reauth,\n                   el.last_sync_error_at, el.created_at, el.updated_at\n            FROM email_links el\n            JOIN macro_user_links mul ON el.id = mul.link_id\n            WHERE mul.primary_macro_id = $1\n        ) l\n        LEFT JOIN email_link_google_scopes g ON g.link_id = l.id\n        LEFT JOIN email_settings s ON s.link_id = l.id\n        LEFT JOIN LATERAL (\n            SELECT status FROM email_backfill_jobs\n            WHERE link_id = l.id\n            ORDER BY created_at DESC\n            LIMIT 1\n        ) bj ON true\n        LEFT JOIN email_contacts c\n            ON c.link_id = l.id AND LOWER(c.email_address) = LOWER(l.email_address)\n        ORDER BY l.created_at DESC\n        ",
   "describe": {
     "columns": [
       {
@@ -109,6 +109,11 @@
         "ordinal": 16,
         "name": "calendar_disabled!",
         "type_info": "Bool"
+      },
+      {
+        "ordinal": 17,
+        "name": "has_calendar_data!",
+        "type_info": "Bool"
       }
     ],
     "parameters": {
@@ -133,8 +138,9 @@
       false,
       true,
       null,
+      null,
       null
     ]
   },
-  "hash": "9a1dd88fd623f93c9b0d94a10790bd5f860a2bd671301790e406843c18e29bcc"
+  "hash": "f5a596b0285397ce7c4c28341482986d8f943f497d79190ed37bd271448864ba"
 }

--- a/apps/web/src/features/calendar/TurnOffCalendarDialog.tsx
+++ b/apps/web/src/features/calendar/TurnOffCalendarDialog.tsx
@@ -15,19 +15,22 @@ export interface TurnOffCalendarTarget {
 }
 
 /**
- * The viewer's own inboxes that currently have calendar access, in the order
+ * The viewer's own inboxes whose calendar Macro can still remove, in the order
  * the links list returns them. Delegated inboxes are excluded: the viewer can
  * read the owner's calendar but must not be able to delete the owner's data.
  *
- * An inbox needing reauth still counts — its events are still in Macro, so
- * turning calendar off is still the way to remove them.
+ * An inbox needing reauth still counts, and so does one whose grant no longer
+ * satisfies today's capability check — in both cases its events are still in
+ * Macro, and turning calendar off is the way to remove them.
  */
 export function useCalendarConnectedInboxes() {
   const linksQuery = useEmailLinksQuery();
   const userId = useUserId();
   return createMemo<EmailLink[]>(() =>
     (linksQuery.data?.links ?? []).filter(
-      (link) => link.macro_id === userId() && !link.needs_calendar_permission
+      (link) =>
+        link.macro_id === userId() &&
+        (!link.needs_calendar_permission || link.has_calendar_data)
     )
   );
 }

--- a/apps/web/src/features/settings/Email.tsx
+++ b/apps/web/src/features/settings/Email.tsx
@@ -531,12 +531,16 @@ function InboxRow(props: {
             </Button>
           </Show>
           {/* Only the owner sees this: turning calendar off deletes the
-              inbox's calendar data, which a delegate must not do. */}
+              inbox's calendar data, which a delegate must not do. Offered
+              whenever that data exists, not only while the grant satisfies
+              today's capability check — an inbox synced under an earlier scope
+              set still has events to remove. */}
           <Show
             when={
               calendarUiEnabled() &&
               props.isOwn &&
-              !props.link.needs_calendar_permission
+              (!props.link.needs_calendar_permission ||
+                props.link.has_calendar_data)
             }
           >
             <Tooltip label="Turn off calendar">

--- a/apps/web/src/lib/queries/email/link.test.tsx
+++ b/apps/web/src/lib/queries/email/link.test.tsx
@@ -39,6 +39,7 @@ const link = (id: string): EmailLink =>
     email_address: `${id}@example.com`,
     needs_calendar_permission: false,
     calendar_disabled: false,
+    has_calendar_data: true,
   }) as unknown as EmailLink;
 
 const cachedLinks = () =>
@@ -91,10 +92,12 @@ describe('useDisableCalendarMutation', () => {
     expect(cachedLink('inbox-a')).toMatchObject({
       calendar_disabled: true,
       needs_calendar_permission: true,
+      has_calendar_data: false,
     });
     expect(cachedLink('inbox-b')).toMatchObject({
       calendar_disabled: false,
       needs_calendar_permission: false,
+      has_calendar_data: true,
     });
     expect(disableLinkCalendarMock).toHaveBeenCalledWith({
       linkId: 'inbox-a',
@@ -113,6 +116,7 @@ describe('useDisableCalendarMutation', () => {
     expect(cachedLink('inbox-a')).toMatchObject({
       calendar_disabled: false,
       needs_calendar_permission: false,
+      has_calendar_data: true,
     });
     expect(invalidateCalendarViewsMock).not.toHaveBeenCalled();
   });

--- a/apps/web/src/lib/queries/email/link.ts
+++ b/apps/web/src/lib/queries/email/link.ts
@@ -118,9 +118,10 @@ type DisableCalendarCallbacks = MutationCallbacks<
 /**
  * Turns calendar off for one inbox: the backend deletes its calendar data and
  * drops the calendar scopes from its Google grant. The cached link flips to
- * `calendar_disabled` + `needs_calendar_permission` right away, which is what
- * swaps the settings row back to "Enable calendar" and keeps the enable prompt
- * quiet, and the emptied calendar caches are refetched.
+ * `calendar_disabled` + `needs_calendar_permission` right away and drops
+ * `has_calendar_data`, which is what swaps the settings row back to "Enable
+ * calendar", retires the turn-off control, and keeps the enable prompt quiet.
+ * The emptied calendar caches are refetched.
  */
 export function useDisableCalendarMutation(
   callbacks?: DisableCalendarCallbacks
@@ -152,6 +153,7 @@ export function useDisableCalendarMutation(
                         ...link,
                         calendar_disabled: true,
                         needs_calendar_permission: true,
+                        has_calendar_data: false,
                       }
                     : link
                 ),

--- a/apps/web/src/lib/service-clients/service-email/generated/schemas/link.ts
+++ b/apps/web/src/lib/service-clients/service-email/generated/schemas/link.ts
@@ -18,6 +18,12 @@ unprompted calendar nags must stay quiet for the latter. */
   created_at: string;
   email_address: string;
   fusionauth_user_id: string;
+  /** Whether Macro holds calendar data for this inbox. Drives the turn-off
+control on its own, so removing that data never depends on the recorded
+scopes still matching the set Macro requests today — a set that changes
+as the integration narrows, stranding data behind a capability check
+that no longer recognizes an older grant. */
+  has_calendar_data: boolean;
   id: string;
   is_primary: boolean;
   is_sync_active: boolean;

--- a/apps/web/src/lib/service-clients/service-email/openapi.json
+++ b/apps/web/src/lib/service-clients/service-email/openapi.json
@@ -5224,6 +5224,7 @@
           "needs_reauth",
           "needs_calendar_permission",
           "calendar_disabled",
+          "has_calendar_data",
           "settings",
           "is_primary",
           "created_at",
@@ -5243,6 +5244,10 @@
           },
           "fusionauth_user_id": {
             "type": "string"
+          },
+          "has_calendar_data": {
+            "type": "boolean",
+            "description": "Whether Macro holds calendar data for this inbox. Drives the turn-off\ncontrol on its own, so removing that data never depends on the recorded\nscopes still matching the set Macro requests today — a set that changes\nas the integration narrows, stranding data behind a capability check\nthat no longer recognizes an older grant."
           },
           "id": {
             "type": "string",

--- a/crates/email_db_client/src/links/get.rs
+++ b/crates/email_db_client/src/links/get.rs
@@ -180,6 +180,11 @@ pub struct InboxDetails {
     /// Distinguishes a deliberate opt-out from a grant that never carried the
     /// calendar scopes, which read identically from the scopes alone.
     pub calendar_disabled: bool,
+    /// Whether the inbox has a calendar account in Macro, i.e. whether there
+    /// is calendar data to remove. Independent of the recorded scopes, which
+    /// stop satisfying the capability check whenever Macro changes the scope
+    /// set it requests.
+    pub has_calendar_data: bool,
 }
 
 struct DbInboxDetailsRow {
@@ -199,6 +204,7 @@ struct DbInboxDetailsRow {
     latest_backfill_status: Option<db::backfill::BackfillJobStatus>,
     google_granted_scopes: Vec<String>,
     calendar_disabled: bool,
+    has_calendar_data: bool,
     photo_url: Option<String>,
 }
 
@@ -231,7 +237,10 @@ pub async fn fetch_inbox_details_for_macro_id(
                bj.status as "latest_backfill_status?: _",
                c.sfs_photo_url as "photo_url?",
                COALESCE(g.granted_scopes, '{}') AS "google_granted_scopes!",
-               (g.calendar_disabled_at IS NOT NULL) AS "calendar_disabled!"
+               (g.calendar_disabled_at IS NOT NULL) AS "calendar_disabled!",
+               EXISTS (
+                   SELECT 1 FROM calendar_accounts ca WHERE ca.email_link_id = l.id
+               ) AS "has_calendar_data!"
         FROM (
             SELECT el.id, el.macro_id, el.fusionauth_user_id, el.email_address,
                    el.provider, el.is_sync_active, el.is_primary, el.needs_reauth,
@@ -291,6 +300,7 @@ pub async fn fetch_inbox_details_for_macro_id(
                 photo_url: row.photo_url,
                 google_granted_scopes: row.google_granted_scopes,
                 calendar_disabled: row.calendar_disabled,
+                has_calendar_data: row.has_calendar_data,
             })
         })
         .collect()

--- a/crates/email_db_client/src/links/get/test.rs
+++ b/crates/email_db_client/src/links/get/test.rs
@@ -713,3 +713,41 @@ async fn fetch_link_by_macro_id_and_email_address_none_when_no_match(
 
     Ok(())
 }
+
+/// Removing an inbox's calendar data has to stay reachable no matter what the
+/// recorded scopes say, so the flag tracks the account row rather than the
+/// grant: a calendar synced under an older scope set still reads as present.
+#[sqlx::test(migrator = "MACRO_DB_MIGRATIONS")]
+async fn fetch_inbox_details_reports_calendar_data_from_the_account_row(
+    pool: Pool<Postgres>,
+) -> anyhow::Result<()> {
+    insert_user(&pool, CHILD, "sharedbox@corp.test").await;
+    let (link_id, _, _) =
+        insert_inbox_with_thread_and_message(&pool, CHILD, "sharedbox@corp.test").await;
+
+    let details = fetch_inbox_details_for_macro_id(&pool, &macro_id(CHILD)).await?;
+    assert!(!details[0].has_calendar_data);
+
+    sqlx::query!(
+        r#"
+        INSERT INTO calendar_accounts (
+            id, owner_id, email_link_id, provider, provider_account_id
+        )
+        VALUES ($1, $2, $3, 'google', 'sharedbox@corp.test')
+        "#,
+        Uuid::now_v7(),
+        CHILD,
+        link_id,
+    )
+    .execute(&pool)
+    .await?;
+
+    let details = fetch_inbox_details_for_macro_id(&pool, &macro_id(CHILD)).await?;
+    assert!(details[0].has_calendar_data);
+    assert!(
+        details[0].google_granted_scopes.is_empty(),
+        "the flag is about stored data, not about what the grant carries"
+    );
+
+    Ok(())
+}

--- a/crates/models_email/src/email/api/link.rs
+++ b/crates/models_email/src/email/api/link.rs
@@ -108,6 +108,12 @@ pub struct Link {
     /// this is what separates "never granted" from "deliberately off" —
     /// unprompted calendar nags must stay quiet for the latter.
     pub calendar_disabled: bool,
+    /// Whether Macro holds calendar data for this inbox. Drives the turn-off
+    /// control on its own, so removing that data never depends on the recorded
+    /// scopes still matching the set Macro requests today — a set that changes
+    /// as the integration narrows, stranding data behind a capability check
+    /// that no longer recognizes an older grant.
+    pub has_calendar_data: bool,
     pub settings: Settings,
     pub is_primary: bool,
     pub created_at: DateTime<Utc>,
@@ -122,6 +128,7 @@ impl Link {
         photo_url: Option<String>,
         needs_calendar_permission: bool,
         calendar_disabled: bool,
+        has_calendar_data: bool,
     ) -> Self {
         Link {
             id: source.id,
@@ -135,6 +142,7 @@ impl Link {
             needs_reauth: source.needs_reauth,
             needs_calendar_permission,
             calendar_disabled,
+            has_calendar_data,
             settings,
             is_primary: source.is_primary,
             created_at: source.created_at,

--- a/packages/sdk/generated/email/types.gen.ts
+++ b/packages/sdk/generated/email/types.gen.ts
@@ -1053,6 +1053,14 @@ export type Link = {
     created_at: string;
     email_address: string;
     fusionauth_user_id: string;
+    /**
+     * Whether Macro holds calendar data for this inbox. Drives the turn-off
+     * control on its own, so removing that data never depends on the recorded
+     * scopes still matching the set Macro requests today — a set that changes
+     * as the integration narrows, stranding data behind a capability check
+     * that no longer recognizes an older grant.
+     */
+    has_calendar_data: boolean;
     id: string;
     is_primary: boolean;
     is_sync_active: boolean;

--- a/packages/sdk/specs/email.json
+++ b/packages/sdk/specs/email.json
@@ -5224,6 +5224,7 @@
           "needs_reauth",
           "needs_calendar_permission",
           "calendar_disabled",
+          "has_calendar_data",
           "settings",
           "is_primary",
           "created_at",
@@ -5243,6 +5244,10 @@
           },
           "fusionauth_user_id": {
             "type": "string"
+          },
+          "has_calendar_data": {
+            "type": "boolean",
+            "description": "Whether Macro holds calendar data for this inbox. Drives the turn-off\ncontrol on its own, so removing that data never depends on the recorded\nscopes still matching the set Macro requests today — a set that changes\nas the integration narrows, stranding data behind a capability check\nthat no longer recognizes an older grant."
           },
           "id": {
             "type": "string",

--- a/services/email_service/src/api/email/links/list.rs
+++ b/services/email_service/src/api/email/links/list.rs
@@ -79,6 +79,7 @@ pub async fn list_links_handler(
                 inbox.photo_url,
                 needs_calendar_permission,
                 inbox.calendar_disabled,
+                inbox.has_calendar_data,
             )
         })
         .collect();


### PR DESCRIPTION
The turn-off control appeared only while an inbox's recorded scopes satisfied the current capability check, so an inbox that synced under an earlier scope set — as every calendar grant made before the scopes were narrowed did — kept its events in Macro with no way to remove them. Removing calendar data now follows the data: the links list reports whether a calendar account exists for the inbox, and the settings row and the calendar view's menu both offer turn-off on that.
