### PR TITLE
fix(integrations): proxy pipedream catalog icons through image proxy

### DIFF
--- a/apps/web/src/features/settings/PipedreamIntegrations.tsx
+++ b/apps/web/src/features/settings/PipedreamIntegrations.tsx
@@ -4,6 +4,7 @@ import {
   pipedreamAppAvailableInEnv,
 } from '@core/component/AI/constant/mcpServers';
 import { toast } from '@core/component/Toast/Toast';
+import { proxyImageUrl } from '@core/util/imageProxy';
 import PlugIcon from '@phosphor-icons/core/regular/plug.svg?component-solid';
 import XIcon from '@phosphor-icons/core/regular/x.svg?component-solid';
 import {
@@ -155,6 +156,8 @@ function CatalogRow(props: { entry: PipedreamCatalogEntryResponse }) {
 /**
  * Connector icon: our bundled SVG for the apps we ship icons for, the
  * directory-provided icon otherwise, and a generic plug as the fallback.
+ * Directory icons load through the image proxy — the app's COEP blocks
+ * cross-origin images from hosts that don't send CORP headers.
  */
 function CatalogIcon(props: { entry: PipedreamCatalogEntryResponse }) {
   const BundledIcon = () => PIPEDREAM_ICON_MAP.get(props.entry.app_slug);
@@ -168,7 +171,7 @@ function CatalogIcon(props: { entry: PipedreamCatalogEntryResponse }) {
         >
           {(iconUrl) => (
             <img
-              src={iconUrl()}
+              src={proxyImageUrl(iconUrl())}
               alt=""
               loading="lazy"
               class="size-5 rounded object-contain"

--- a/apps/web/src/lib/core/email/proxy-email-images.ts
+++ b/apps/web/src/lib/core/email/proxy-email-images.ts
@@ -1,4 +1,4 @@
-import { SERVER_HOSTS } from '../constant/servers';
+import { proxyImageUrl } from '../util/imageProxy';
 
 /**
  * Serves images through image proxy service to avoid storing data.
@@ -13,10 +13,10 @@ export function proxyEmailImages(html: string): string {
   for (const img of images) {
     const src = img.getAttribute('src')?.replace(/\s/g, '');
     if (!src) continue;
-    if (!src.startsWith('http://') && !src.startsWith('https://')) continue;
+    const proxied = proxyImageUrl(src);
+    if (proxied === src) continue;
 
-    const proxiedUrl = `${SERVER_HOSTS['image-proxy-service']}/proxy?url=${encodeURIComponent(src)}`;
-    img.setAttribute('src', proxiedUrl);
+    img.setAttribute('src', proxied);
   }
 
   return container.innerHTML;

--- a/apps/web/src/lib/core/util/imageProxy.ts
+++ b/apps/web/src/lib/core/util/imageProxy.ts
@@ -1,0 +1,15 @@
+import { SERVER_HOSTS } from '../constant/servers';
+
+/**
+ * Rewrite an external image URL to load through the image proxy service.
+ *
+ * The app is served with `Cross-Origin-Embedder-Policy: require-corp`, so
+ * cross-origin images are blocked unless the host opts in via CORP/CORS
+ * headers. The proxy fetches the upstream image server-side and responds
+ * with `Cross-Origin-Resource-Policy: cross-origin`, so proxied images
+ * always render. Non-HTTP(S) URLs (e.g. `data:`) are returned unchanged.
+ */
+export function proxyImageUrl(src: string): string {
+  if (!src.startsWith('http://') && !src.startsWith('https://')) return src;
+  return `${SERVER_HOSTS['image-proxy-service']}/proxy?url=${encodeURIComponent(src)}`;
+}


### PR DESCRIPTION
Route Pipedream catalog icon URLs through the image proxy service so they render under the app's COEP (require-corp) policy instead of being blocked as cross-origin resources.