### PR TITLE
fix(integrations): pass allowed_origins on pipedream connect tokens

### DIFF
--- a/crates/pipedream_mcp/src/outbound/api.rs
+++ b/crates/pipedream_mcp/src/outbound/api.rs
@@ -32,6 +32,11 @@ pub struct PipedreamConfig {
     pub project_id: String,
     /// The Pipedream project environment: `development` or `production`.
     pub environment: String,
+    /// Origins allowed to use Connect tokens from the browser (the app
+    /// origins that embed the hosted Connect UI). Pipedream refuses to be
+    /// framed by origins outside this list; localhost is only tolerated by
+    /// default in the `development` project environment.
+    pub allowed_origins: Vec<String>,
     /// Base URL of the Pipedream API. [`DEFAULT_API_URL`] unless overridden.
     pub api_url: String,
     /// URL of Pipedream's remote MCP server. [`DEFAULT_MCP_URL`] unless
@@ -131,10 +136,13 @@ impl PipedreamClient {
 impl PipedreamConnect for PipedreamClient {
     #[tracing::instrument(skip(self), err)]
     async fn create_connect_token(&self, external_user_id: &str) -> anyhow::Result<ConnectToken> {
-        let body = serde_json::json!({
+        let mut body = serde_json::json!({
             "external_user_id": external_user_id,
             "external_id": external_user_id,
         });
+        if !self.config.allowed_origins.is_empty() {
+            body["allowed_origins"] = serde_json::json!(self.config.allowed_origins);
+        }
 
         let response = self
             .authed(self.http.post(self.connect_api("/tokens")))

--- a/services/document_cognition_service/src/config.rs
+++ b/services/document_cognition_service/src/config.rs
@@ -44,6 +44,11 @@ maybe_env_vars!(
     /// URL of Pipedream's remote MCP server. Defaults to
     /// `https://remote.mcp.pipedream.net`.
     pub struct PipedreamMcpUrl;
+    /// Comma-separated browser origins allowed to embed Pipedream's hosted
+    /// Connect UI (sent as the Connect token's `allowed_origins`). Defaults
+    /// by deploy environment: the app origin (`https://macro.com` /
+    /// `https://dev.macro.com`) plus localhost outside production.
+    pub struct PipedreamAllowedOrigins;
 );
 
 /// The configuration parameters for the application.
@@ -95,6 +100,8 @@ pub struct Config {
     pub pipedream_api_url: PipedreamApiUrl,
     /// URL of Pipedream's remote MCP server.
     pub pipedream_mcp_url: PipedreamMcpUrl,
+    /// Browser origins allowed to embed Pipedream's hosted Connect UI.
+    pub pipedream_allowed_origins: PipedreamAllowedOrigins,
     /// The internal api key
     pub internal_api_key: InternalApiKey,
     /// AI editing worker URL
@@ -155,6 +162,7 @@ impl Config {
             pipedream_environment: PipedreamEnvironment::Unset,
             pipedream_api_url: PipedreamApiUrl::Unset,
             pipedream_mcp_url: PipedreamMcpUrl::Unset,
+            pipedream_allowed_origins: PipedreamAllowedOrigins::Unset,
             internal_api_key: InternalApiKey::Comptime(""),
             ai_editing_worker_url: AiEditingWorkerUrl::unwrap_new().to_string(),
             document_permission_jwt: DocumentPermissionJwt::Comptime("DOCUMENT_PERMISSION_JWT"),

--- a/services/document_cognition_service/src/main.rs
+++ b/services/document_cognition_service/src/main.rs
@@ -487,6 +487,21 @@ async fn main() -> anyhow::Result<()> {
                         .value()
                         .unwrap_or(pipedream_mcp::outbound::api::DEFAULT_MCP_URL)
                         .to_owned(),
+                    allowed_origins: match config.pipedream_allowed_origins.value() {
+                        Some(origins) => origins
+                            .split(',')
+                            .map(|origin| origin.trim().to_owned())
+                            .filter(|origin| !origin.is_empty())
+                            .collect(),
+                        None => match config.environment {
+                            Environment::Production => vec!["https://macro.com".to_owned()],
+                            Environment::Develop => vec![
+                                "https://dev.macro.com".to_owned(),
+                                "http://localhost:3000".to_owned(),
+                            ],
+                            Environment::Local => vec!["http://localhost:3000".to_owned()],
+                        },
+                    },
                 },
             )
             .context("failed to build Pipedream client")?,


### PR DESCRIPTION
Mint Pipedream Connect tokens with allowed_origins (env-var override, app-origin defaults per environment) so the hosted Connect UI allows itself to be embedded on dev and prod instead of refusing to connect.