### PR TITLE
fix(calendar): aim deep links at the event in the URL query

### DIFF
--- a/apps/web/src/features/block-calendar/CalendarBlockAdapter.tsx
+++ b/apps/web/src/features/block-calendar/CalendarBlockAdapter.tsx
@@ -109,9 +109,8 @@ function CalendarBlockAdapter(props: CalendarBlockProps) {
   const [searchParams] = useSearchParams();
   const searchParam = (value: string | string[] | undefined) =>
     typeof value === 'string' && value.length > 0 ? value : undefined;
-  // In-app opens pass the target through split content props; a deep link
-  // (`/app/calendar/view?eventId=...`) carries it in the query string, which
-  // never reaches block props.
+  // In-app opens pass the target through split content props, but a deep
+  // link carries it in the query string, which never reaches block props.
   const initialAim: CalendarBlockProps = {
     eventId:
       typeof props.eventId === 'string' && props.eventId.length > 0

--- a/apps/web/src/features/block-calendar/CalendarBlockAdapter.tsx
+++ b/apps/web/src/features/block-calendar/CalendarBlockAdapter.tsx
@@ -117,7 +117,7 @@ function CalendarBlockAdapter(props: CalendarBlockProps) {
         ? props.eventId
         : searchParam(searchParams.eventId),
     occurrenceKey:
-      typeof props.occurrenceKey === 'string'
+      typeof props.occurrenceKey === 'string' && props.occurrenceKey.length > 0
         ? props.occurrenceKey
         : searchParam(searchParams.occurrenceKey),
     range: props.range,

--- a/apps/web/src/features/block-calendar/CalendarBlockAdapter.tsx
+++ b/apps/web/src/features/block-calendar/CalendarBlockAdapter.tsx
@@ -3,6 +3,7 @@ import { useCalendarUiFlag } from '@app/features/calendar/hooks/use-calendar-ui-
 import { isCalendarRangeSupported } from '@app/features/calendar/utils/calendar-supported-range';
 import { useAnalytics } from '@app/lib/analytics/analytics-context';
 import { usePosthog } from '@app/lib/analytics/posthog';
+import { globalSplitManager } from '@app/signal/splitLayout';
 import { useSplitPanelOrThrow } from '@components/app/split-layout/layoutUtils';
 import { LoadingBlock } from '@core/component/LoadingBlock';
 import { useUserId } from '@core/context/user';
@@ -111,15 +112,24 @@ function CalendarBlockAdapter(props: CalendarBlockProps) {
     typeof value === 'string' && value.length > 0 ? value : undefined;
   // In-app opens pass the target through split content props, but a deep
   // link carries it in the query string, which never reaches block props.
+  // Query params are only trusted for a single-split URL, mirroring the
+  // channel block's deep-link guard.
+  const queryAim =
+    globalSplitManager()?.splits().length === 1
+      ? {
+          eventId: searchParam(searchParams.eventId),
+          occurrenceKey: searchParam(searchParams.occurrenceKey),
+        }
+      : {};
   const initialAim: CalendarBlockProps = {
     eventId:
       typeof props.eventId === 'string' && props.eventId.length > 0
         ? props.eventId
-        : searchParam(searchParams.eventId),
+        : queryAim.eventId,
     occurrenceKey:
       typeof props.occurrenceKey === 'string' && props.occurrenceKey.length > 0
         ? props.occurrenceKey
-        : searchParam(searchParams.occurrenceKey),
+        : queryAim.occurrenceKey,
     range: props.range,
   };
   let nextRequestId = 1;

--- a/apps/web/src/features/block-calendar/CalendarBlockAdapter.tsx
+++ b/apps/web/src/features/block-calendar/CalendarBlockAdapter.tsx
@@ -10,6 +10,7 @@ import { createMethodRegistration } from '@core/orchestrator';
 import { blockHandleSignal } from '@core/signal/load';
 import { fetchCalendarMentionPreview } from '@queries/calendar/mention-preview';
 import { useCalendarOccurrencesQuery } from '@queries/calendar/occurrences';
+import { useSearchParams } from '@solidjs/router';
 import { createMemo, createSignal, onMount, Show } from 'solid-js';
 import { CalendarFocusContextProvider } from './calendar-focus-target';
 import {
@@ -105,11 +106,28 @@ function CalendarBlockAdapter(props: CalendarBlockProps) {
   const userId = useUserId();
   const analytics = useAnalytics();
   const blockHandle = blockHandleSignal.get;
+  const [searchParams] = useSearchParams();
+  const searchParam = (value: string | string[] | undefined) =>
+    typeof value === 'string' && value.length > 0 ? value : undefined;
+  // In-app opens pass the target through split content props; a deep link
+  // (`/app/calendar/view?eventId=...`) carries it in the query string, which
+  // never reaches block props.
+  const initialAim: CalendarBlockProps = {
+    eventId:
+      typeof props.eventId === 'string' && props.eventId.length > 0
+        ? props.eventId
+        : searchParam(searchParams.eventId),
+    occurrenceKey:
+      typeof props.occurrenceKey === 'string'
+        ? props.occurrenceKey
+        : searchParam(searchParams.occurrenceKey),
+    range: props.range,
+  };
   let nextRequestId = 1;
   let latestRequestId = 0;
   const [targetRequest, setTargetRequest] = createSignal<
     CalendarBlockTargetRequest | undefined
-  >(targetRequestFromParams(props, nextRequestId++));
+  >(targetRequestFromParams(initialAim, nextRequestId++));
 
   // Preview resolution is async, so a stale answer must never clobber a
   // target the user has since re-aimed or cleared.
@@ -135,8 +153,12 @@ function CalendarBlockAdapter(props: CalendarBlockProps) {
     setTargetRequest(undefined);
   };
 
-  if (!targetRequest() && typeof props.eventId === 'string' && props.eventId) {
-    aimAtParams(props);
+  if (
+    !targetRequest() &&
+    typeof initialAim.eventId === 'string' &&
+    initialAim.eventId
+  ) {
+    aimAtParams(initialAim);
   }
 
   createMethodRegistration(blockHandle, {


### PR DESCRIPTION
Copied `/app/calendar/view?eventId=…` links opened the calendar without selecting the event: in-app opens pass the target through split content props, but URL query params never reach block props, and the calendar adapter never read the query. It now consumes `eventId`/`occurrenceKey` from the URL as its initial aim (the same pattern the channel block uses for its deep-link params), resolving through the mention preview API when the range is absent.
