### PR TITLE
fix(email): avoid undefined in subjectless replies and forwards

### DIFF
--- a/apps/web/src/features/block-email/util/subjectText.test.ts
+++ b/apps/web/src/features/block-email/util/subjectText.test.ts
@@ -63,6 +63,7 @@ describe('getSubjectText', () => {
     expect(getSubjectText(messageWithSubject(undefined), 'reply-all')).toBe(
       'Re:'
     );
+    expect(getSubjectText(messageWithSubject(null), 'reply-all')).toBe('Re:');
   });
 
   it('uses a bare Fwd: prefix for a subjectless message on forward', () => {

--- a/apps/web/src/features/block-email/util/subjectText.test.ts
+++ b/apps/web/src/features/block-email/util/subjectText.test.ts
@@ -36,7 +36,7 @@ describe('displaySubject', () => {
 });
 
 describe('getSubjectText', () => {
-  const messageWithSubject = (subject: string): ApiMessage =>
+  const messageWithSubject = (subject: string | null | undefined): ApiMessage =>
     ({ subject }) as ApiMessage;
 
   it('preserves an existing reply prefix regardless of case', () => {
@@ -52,5 +52,23 @@ describe('getSubjectText', () => {
     expect(
       getSubjectText(messageWithSubject('Project Re: timeline'), 'reply')
     ).toBe('Re: Project Re: timeline');
+  });
+
+  it('uses a bare Re: prefix for a subjectless message on reply', () => {
+    expect(getSubjectText(messageWithSubject(undefined), 'reply')).toBe('Re:');
+    expect(getSubjectText(messageWithSubject(null), 'reply')).toBe('Re:');
+  });
+
+  it('uses a bare Re: prefix for a subjectless message on reply-all', () => {
+    expect(getSubjectText(messageWithSubject(undefined), 'reply-all')).toBe(
+      'Re:'
+    );
+  });
+
+  it('uses a bare Fwd: prefix for a subjectless message on forward', () => {
+    expect(getSubjectText(messageWithSubject(undefined), 'forward')).toBe(
+      'Fwd:'
+    );
+    expect(getSubjectText(messageWithSubject(null), 'forward')).toBe('Fwd:');
   });
 });

--- a/apps/web/src/features/block-email/util/subjectText.ts
+++ b/apps/web/src/features/block-email/util/subjectText.ts
@@ -18,14 +18,13 @@ export const getSubjectText = (
 ) => {
   if (!replyingTo) return '';
   if (replyType === 'reply-all' || replyType === 'reply') {
-    const subject = replyingTo.subject;
+    const subject = replyingTo.subject ?? '';
     if (subject && /^re:/i.test(subject)) {
       return subject;
-    } else {
-      return `Re: ${subject}`;
     }
+    return subject ? `Re: ${subject}` : 'Re:';
   } else if (replyType === 'forward') {
-    return `Fwd: ${replyingTo.subject}`;
+    return replyingTo.subject ? `Fwd: ${replyingTo.subject}` : 'Fwd:';
   } else {
     return replyingTo.subject ?? '';
   }


### PR DESCRIPTION
Replying to or forwarding an email without a subject produced the literal subjects `Re: undefined` and `Fwd: undefined` — `ApiMessage.subject` is optional and was interpolated directly into the template.

The missing subject is now normalized to an empty value and a bare `Re:` / `Fwd:` prefix is used for the subjectless case, matching the expected result in #5703. Existing subjects and case-insensitive `Re:` prefixes keep their current behavior.

Added regression tests for reply, reply-all, and forward with `null` / `undefined` subjects; they fail with `Fwd: undefined` / `Re: undefined` on the previous code.
