### PR TITLE
feat(mcp_service): advertise the Macro web app favicon as the MCP server icon

### DIFF
--- a/services/mcp_service/src/tool_service.rs
+++ b/services/mcp_service/src/tool_service.rs
@@ -3,8 +3,8 @@ use macro_user_id::user_id::MacroUserIdStr;
 use rmcp::{
     handler::server::ServerHandler,
     model::{
-        Content, ListToolsResult, PaginatedRequestParams, ServerCapabilities, ServerInfo, Tool,
-        ToolAnnotations,
+        Content, Icon, ListToolsResult, PaginatedRequestParams, ServerCapabilities, ServerInfo,
+        Tool, ToolAnnotations,
     },
 };
 use std::sync::Arc;
@@ -88,6 +88,7 @@ where
 {
     fn get_info(&self) -> ServerInfo {
         let mut info = ServerInfo::new(ServerCapabilities::builder().enable_tools().build());
+        let base_url = self.item_base_url.trim_end_matches('/');
         info.server_info = rmcp::model::Implementation::new(
             "macro-tools",
             env!("CARGO_PKG_VERSION"),
@@ -95,8 +96,14 @@ where
         .with_title("Macro")
         .with_description(
             "Search, read, and create content across documents, emails, and messages in Macro.",
-        );
-        let base_url = self.item_base_url.trim_end_matches('/');
+        )
+        // The same icon the web app's <link rel="icon"> points at, so the
+        // server shows up in MCP clients with the Macro favicon.
+        .with_icons(vec![
+            Icon::new(format!("{base_url}/app/macro-favicon.svg"))
+                .with_mime_type("image/svg+xml")
+                .with_sizes(vec!["any".to_owned()]),
+        ]);
         info.instructions = Some(format!(
             "This server provides tools for interacting with a user's Macro workspace. \
              Use ContentSearch and NameSearch to find entities. \

--- a/services/mcp_service/src/tool_service/test.rs
+++ b/services/mcp_service/src/tool_service/test.rs
@@ -27,6 +27,24 @@ async fn server_info_advertises_macro_tools() {
 }
 
 #[tokio::test]
+async fn server_info_advertises_the_web_app_favicon() {
+    let info = empty_service().get_info();
+
+    let icons = info
+        .server_info
+        .icons
+        .expect("server should advertise an icon");
+    let [icon] = icons.as_slice() else {
+        panic!("server should advertise exactly one icon");
+    };
+
+    // The same file the web app's <link rel="icon"> points at.
+    assert_eq!(icon.src, "https://macro.com/app/macro-favicon.svg");
+    assert_eq!(icon.mime_type.as_deref(), Some("image/svg+xml"));
+    assert_eq!(icon.sizes.as_deref(), Some(["any".to_owned()].as_slice()));
+}
+
+#[tokio::test]
 async fn server_instructions_describe_available_workflows() {
     let instructions = empty_service()
         .get_info()


### PR DESCRIPTION
Sets serverInfo.icons on the MCP server's initialize response to the web app's favicon (`{APP_BASE_URL}/app/macro-favicon.svg`) so MCP clients display the Macro logo instead of a default icon.