### PR TITLE
fix(calendar): re-aim the calendar when a mention repeats its target

### DIFF
--- a/apps/web/src/features/block-calendar/CalendarBlockAdapter.tsx
+++ b/apps/web/src/features/block-calendar/CalendarBlockAdapter.tsx
@@ -9,105 +9,14 @@ import { LoadingBlock } from '@core/component/LoadingBlock';
 import { useUserId } from '@core/context/user';
 import { createMethodRegistration } from '@core/orchestrator';
 import { blockHandleSignal } from '@core/signal/load';
-import { fetchCalendarMentionPreview } from '@queries/calendar/mention-preview';
 import { useCalendarOccurrencesQuery } from '@queries/calendar/occurrences';
 import { useSearchParams } from '@solidjs/router';
-import { createMemo, createSignal, onMount, Show } from 'solid-js';
+import { createMemo, onMount, Show } from 'solid-js';
 import { CalendarFocusContextProvider } from './calendar-focus-target';
-import {
-  type CalendarBlockEventTime,
-  createCalendarBlockRange,
-  isCalendarBlockRange,
-} from './calendar-range';
 import { resolveCalendarBlockTarget } from './calendar-target';
+import { createCalendarTargetAim } from './calendar-target-request';
 import { Workspace } from './components/Workspace';
-import type { CalendarBlockProps, CalendarBlockTargetRequest } from './types';
-
-function targetRequestFromParams(
-  params: CalendarBlockProps,
-  requestId: number
-): CalendarBlockTargetRequest | undefined {
-  if (
-    typeof params.eventId !== 'string' ||
-    params.eventId.length === 0 ||
-    !isCalendarBlockRange(params.range)
-  ) {
-    return undefined;
-  }
-
-  return {
-    eventId: params.eventId,
-    range: params.range,
-    occurrenceKey:
-      typeof params.occurrenceKey === 'string'
-        ? params.occurrenceKey
-        : undefined,
-    requestId,
-    requestedAt: Date.now(),
-  };
-}
-
-function isSameTargetRequest(
-  current: CalendarBlockTargetRequest | undefined,
-  next: CalendarBlockTargetRequest | undefined
-): boolean {
-  if (!current || !next) return current === next;
-  if (current.eventId !== next.eventId) return false;
-  if (current.occurrenceKey !== undefined || next.occurrenceKey !== undefined) {
-    return current.occurrenceKey === next.occurrenceKey;
-  }
-  return (
-    current.range.start === next.range.start &&
-    current.range.end === next.range.end &&
-    current.range.startDate === next.range.startDate &&
-    current.range.endDate === next.range.endDate
-  );
-}
-
-/**
- * A target with an event id but no usable range — a copied `/app/calendar`
- * link or a mention without preview data — resolves through the calendar
- * mention preview API, which also maps another user's projection of the
- * meeting to the viewer's own copy.
- */
-async function resolveTargetRequestFromPreview(
-  params: CalendarBlockProps,
-  requestId: number
-): Promise<CalendarBlockTargetRequest | undefined> {
-  if (typeof params.eventId !== 'string' || params.eventId.length === 0) {
-    return undefined;
-  }
-  const occurrenceKey =
-    typeof params.occurrenceKey === 'string' ? params.occurrenceKey : undefined;
-  const event = await fetchCalendarMentionPreview(
-    params.eventId,
-    occurrenceKey
-  ).catch(() => null);
-  if (!event) return undefined;
-
-  const time: CalendarBlockEventTime =
-    event.time.kind === 'timed'
-      ? {
-          kind: 'timed',
-          startsAt: event.time.startsAt,
-          endsAt: event.time.endsAt,
-        }
-      : {
-          kind: 'allDay',
-          startDate: event.time.startDate,
-          endDate: event.time.endDate,
-        };
-  const range = createCalendarBlockRange(time);
-  if (!range) return undefined;
-
-  return {
-    eventId: event.viewerEventId,
-    range,
-    occurrenceKey: event.occurrenceKey ?? occurrenceKey,
-    requestId,
-    requestedAt: Date.now(),
-  };
-}
+import type { CalendarBlockProps } from './types';
 
 function CalendarBlockDisabledRedirect() {
   const panel = useSplitPanelOrThrow();
@@ -149,52 +58,12 @@ function CalendarBlockAdapter(props: CalendarBlockProps) {
         : queryAim.occurrenceKey,
     range: props.range,
   };
-  let nextRequestId = 1;
-  let latestRequestId = 0;
-  const [targetRequest, setTargetRequest] = createSignal<
-    CalendarBlockTargetRequest | undefined
-  >(targetRequestFromParams(initialAim, nextRequestId++));
-
-  // Preview resolution is async, so a stale answer must never clobber a
-  // target the user has since re-aimed or cleared.
-  const applyResolvedTarget = (request: CalendarBlockTargetRequest) => {
-    if (
-      request.requestId < latestRequestId ||
-      isSameTargetRequest(targetRequest(), request)
-    ) {
-      return;
-    }
-    setTargetRequest(request);
-  };
-
-  const aimAtParams = (params: CalendarBlockProps) => {
-    const requestId = nextRequestId++;
-    latestRequestId = requestId;
-    const direct = targetRequestFromParams(params, requestId);
-    if (direct) {
-      applyResolvedTarget(direct);
-      return;
-    }
-    if (typeof params.eventId === 'string' && params.eventId.length > 0) {
-      resolveTargetRequestFromPreview(params, requestId).then((resolved) => {
-        if (resolved) applyResolvedTarget(resolved);
-      });
-      return;
-    }
-    if (targetRequest() !== undefined) setTargetRequest(undefined);
-  };
-
-  if (
-    !targetRequest() &&
-    typeof initialAim.eventId === 'string' &&
-    initialAim.eventId
-  ) {
-    aimAtParams(initialAim);
-  }
+  const aim = createCalendarTargetAim({ initial: initialAim });
+  const targetRequest = aim.target;
 
   createMethodRegistration(blockHandle, {
     goToLocationFromParams: async (params: Record<string, unknown>) => {
-      aimAtParams(params as CalendarBlockProps);
+      aim.aimAt(params as CalendarBlockProps);
     },
   });
 

--- a/apps/web/src/features/block-calendar/CalendarBlockAdapter.tsx
+++ b/apps/web/src/features/block-calendar/CalendarBlockAdapter.tsx
@@ -78,9 +78,20 @@ function CalendarBlockAdapter(props: CalendarBlockProps) {
       };
     }
   );
+  // A cold `.data` read suspends the nearest <Suspense>, which is the one
+  // wrapping each calendar page: the first aim of a session enables this
+  // query, so reading it unguarded blanks the whole grid for the length of
+  // the fetch and remounts it. There is no target to resolve until the
+  // occurrences land anyway.
   const focusTarget = createMemo(() => {
     const request = targetRequest();
-    if (!request || occurrencesQuery.isPlaceholderData) return undefined;
+    if (
+      !request ||
+      occurrencesQuery.isLoading ||
+      occurrencesQuery.isPlaceholderData
+    ) {
+      return undefined;
+    }
     return resolveCalendarBlockTarget(
       occurrencesQuery.data?.items ?? [],
       request

--- a/apps/web/src/features/block-calendar/calendar-target-request.test.ts
+++ b/apps/web/src/features/block-calendar/calendar-target-request.test.ts
@@ -1,0 +1,129 @@
+import { createRoot } from 'solid-js';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  type CalendarTargetAim,
+  createCalendarTargetAim,
+} from './calendar-target-request';
+import type { CalendarBlockProps, CalendarBlockTargetRequest } from './types';
+
+const RANGE = {
+  start: '2026-08-17T04:00:00.000Z',
+  end: '2026-08-18T04:00:00.000Z',
+  startDate: '2026-08-17',
+  endDate: '2026-08-18',
+};
+
+const NEXT_WEEK_RANGE = {
+  start: '2026-08-24T04:00:00.000Z',
+  end: '2026-08-25T04:00:00.000Z',
+  startDate: '2026-08-24',
+  endDate: '2026-08-25',
+};
+
+const standup: CalendarBlockProps = {
+  eventId: 'event-1',
+  occurrenceKey: '2026-08-17T14:00:00+00:00',
+  range: RANGE,
+};
+
+function withAim<T>(
+  options: Parameters<typeof createCalendarTargetAim>[0],
+  run: (aim: CalendarTargetAim) => T
+): T {
+  return createRoot((dispose) => {
+    const result = run(createCalendarTargetAim(options));
+    dispose();
+    return result;
+  });
+}
+
+describe('createCalendarTargetAim', () => {
+  it('aims at params that already carry a locator range', () => {
+    const target = withAim({ initial: standup }, (aim) => aim.target());
+
+    expect(target?.eventId).toBe('event-1');
+    expect(target?.occurrenceKey).toBe('2026-08-17T14:00:00+00:00');
+    expect(target?.range).toEqual(RANGE);
+  });
+
+  // The calendar is a singleton block, so a second click on the same mention
+  // is the only way back to an event the user has since paged away from.
+  it('mints a fresh request for a repeat aim at the occurrence already targeted', () => {
+    const [first, second] = withAim({ initial: standup }, (aim) => {
+      const before = aim.target();
+      aim.aimAt(standup);
+      return [before, aim.target()];
+    });
+
+    expect(second?.eventId).toBe(first?.eventId);
+    expect(second?.occurrenceKey).toBe(first?.occurrenceKey);
+    expect(second?.requestId).toBeGreaterThan(first?.requestId ?? 0);
+  });
+
+  it('clears the target when aimed at params without an event', () => {
+    const target = withAim({ initial: standup }, (aim) => {
+      aim.aimAt({});
+      return aim.target();
+    });
+
+    expect(target).toBeUndefined();
+  });
+
+  it('resolves params without a range through the preview', async () => {
+    const resolveFromPreview = vi.fn(
+      async (
+        _params: CalendarBlockProps,
+        requestId: number
+      ): Promise<CalendarBlockTargetRequest> => ({
+        eventId: 'viewer-copy',
+        range: RANGE,
+        occurrenceKey: '2026-08-17T14:00:00+00:00',
+        requestId,
+        requestedAt: Date.now(),
+      })
+    );
+
+    const aim = createRoot(() =>
+      createCalendarTargetAim({
+        initial: { eventId: 'someone-elses-copy' },
+        resolveFromPreview,
+      })
+    );
+    await vi.waitFor(() => expect(aim.target()).toBeDefined());
+
+    expect(resolveFromPreview).toHaveBeenCalledTimes(1);
+    expect(aim.target()?.eventId).toBe('viewer-copy');
+  });
+
+  it('drops a preview answer that a newer aim has superseded', async () => {
+    let releaseStalePreview: (() => void) | undefined;
+    const resolveFromPreview = vi.fn(
+      async (
+        _params: CalendarBlockProps,
+        requestId: number
+      ): Promise<CalendarBlockTargetRequest> => {
+        await new Promise<void>((resolve) => {
+          releaseStalePreview = resolve;
+        });
+        return {
+          eventId: 'stale-event',
+          range: RANGE,
+          requestId,
+          requestedAt: Date.now(),
+        };
+      }
+    );
+
+    const aim = createRoot(() =>
+      createCalendarTargetAim({ initial: {}, resolveFromPreview })
+    );
+    aim.aimAt({ eventId: 'slow-event' });
+    await vi.waitFor(() => expect(releaseStalePreview).toBeDefined());
+
+    aim.aimAt({ eventId: 'newer-event', range: NEXT_WEEK_RANGE });
+    releaseStalePreview?.();
+    await vi.waitFor(() => expect(resolveFromPreview).toHaveBeenCalledTimes(1));
+
+    expect(aim.target()?.eventId).toBe('newer-event');
+  });
+});

--- a/apps/web/src/features/block-calendar/calendar-target-request.test.ts
+++ b/apps/web/src/features/block-calendar/calendar-target-request.test.ts
@@ -95,6 +95,23 @@ describe('createCalendarTargetAim', () => {
     expect(aim.target()?.eventId).toBe('viewer-copy');
   });
 
+  // A mention whose event was deleted resolves to nothing. Holding the
+  // previous target would leave the focus effect free to land on an
+  // unrelated event the user never asked for.
+  it('clears the target when the latest preview cannot resolve', async () => {
+    const resolveFromPreview = vi.fn(async () => undefined);
+
+    const aim = createRoot(() =>
+      createCalendarTargetAim({ initial: standup, resolveFromPreview })
+    );
+    expect(aim.target()?.eventId).toBe('event-1');
+
+    aim.aimAt({ eventId: 'deleted-event' });
+    await vi.waitFor(() => expect(aim.target()).toBeUndefined());
+
+    expect(resolveFromPreview).toHaveBeenCalledTimes(1);
+  });
+
   it('drops a preview answer that a newer aim has superseded', async () => {
     let releaseStalePreview: (() => void) | undefined;
     const resolveFromPreview = vi.fn(

--- a/apps/web/src/features/block-calendar/calendar-target-request.ts
+++ b/apps/web/src/features/block-calendar/calendar-target-request.ts
@@ -1,0 +1,143 @@
+import { fetchCalendarMentionPreview } from '@queries/calendar/mention-preview';
+import { type Accessor, createSignal } from 'solid-js';
+import {
+  type CalendarBlockEventTime,
+  createCalendarBlockRange,
+  isCalendarBlockRange,
+} from './calendar-range';
+import type { CalendarBlockProps, CalendarBlockTargetRequest } from './types';
+
+/** Builds a request straight from params that already carry a locator range. */
+export function targetRequestFromParams(
+  params: CalendarBlockProps,
+  requestId: number
+): CalendarBlockTargetRequest | undefined {
+  if (
+    typeof params.eventId !== 'string' ||
+    params.eventId.length === 0 ||
+    !isCalendarBlockRange(params.range)
+  ) {
+    return undefined;
+  }
+
+  return {
+    eventId: params.eventId,
+    range: params.range,
+    occurrenceKey:
+      typeof params.occurrenceKey === 'string'
+        ? params.occurrenceKey
+        : undefined,
+    requestId,
+    requestedAt: Date.now(),
+  };
+}
+
+/**
+ * A target with an event id but no usable range — a copied `/app/calendar`
+ * link or a mention without preview data — resolves through the calendar
+ * mention preview API, which also maps another user's projection of the
+ * meeting to the viewer's own copy.
+ */
+export async function resolveTargetRequestFromPreview(
+  params: CalendarBlockProps,
+  requestId: number
+): Promise<CalendarBlockTargetRequest | undefined> {
+  if (typeof params.eventId !== 'string' || params.eventId.length === 0) {
+    return undefined;
+  }
+  const occurrenceKey =
+    typeof params.occurrenceKey === 'string' ? params.occurrenceKey : undefined;
+  const event = await fetchCalendarMentionPreview(
+    params.eventId,
+    occurrenceKey
+  ).catch(() => null);
+  if (!event) return undefined;
+
+  const time: CalendarBlockEventTime =
+    event.time.kind === 'timed'
+      ? {
+          kind: 'timed',
+          startsAt: event.time.startsAt,
+          endsAt: event.time.endsAt,
+        }
+      : {
+          kind: 'allDay',
+          startDate: event.time.startDate,
+          endDate: event.time.endDate,
+        };
+  const range = createCalendarBlockRange(time);
+  if (!range) return undefined;
+
+  return {
+    eventId: event.viewerEventId,
+    range,
+    occurrenceKey: event.occurrenceKey ?? occurrenceKey,
+    requestId,
+    requestedAt: Date.now(),
+  };
+}
+
+/** The occurrence the block is currently aimed at, and how to re-aim it. */
+export interface CalendarTargetAim {
+  target: Accessor<CalendarBlockTargetRequest | undefined>;
+  aimAt: (params: CalendarBlockProps) => void;
+}
+
+/**
+ * Tracks the aimed occurrence as a monotonically numbered request.
+ *
+ * Every aim mints a new request id, including one that lands on the
+ * occurrence already targeted. Repeat aims are how a second click on the
+ * same mention, soup row or sidebar event pages the calendar back to that
+ * event and reopens its details, so treating them as redundant would leave
+ * the click with no effect at all beyond activating the split.
+ */
+export function createCalendarTargetAim(options: {
+  initial: CalendarBlockProps;
+  resolveFromPreview?: (
+    params: CalendarBlockProps,
+    requestId: number
+  ) => Promise<CalendarBlockTargetRequest | undefined>;
+}): CalendarTargetAim {
+  const resolveFromPreview =
+    options.resolveFromPreview ?? resolveTargetRequestFromPreview;
+  let nextRequestId = 1;
+  let latestRequestId = 0;
+  const [target, setTarget] = createSignal<
+    CalendarBlockTargetRequest | undefined
+  >(targetRequestFromParams(options.initial, nextRequestId++));
+
+  // Preview resolution is async, so a stale answer must never clobber a
+  // target the user has since re-aimed or cleared.
+  const applyResolvedTarget = (request: CalendarBlockTargetRequest) => {
+    if (request.requestId < latestRequestId) return;
+    setTarget(request);
+  };
+
+  const aimAt = (params: CalendarBlockProps) => {
+    const requestId = nextRequestId++;
+    latestRequestId = requestId;
+    const direct = targetRequestFromParams(params, requestId);
+    if (direct) {
+      applyResolvedTarget(direct);
+      return;
+    }
+    if (typeof params.eventId === 'string' && params.eventId.length > 0) {
+      resolveFromPreview(params, requestId).then((resolved) => {
+        if (resolved) applyResolvedTarget(resolved);
+      });
+      return;
+    }
+    if (target() !== undefined) setTarget(undefined);
+  };
+
+  if (
+    !target() &&
+    typeof options.initial.eventId === 'string' &&
+    options.initial.eventId
+  ) {
+    aimAt(options.initial);
+  }
+
+  return { target, aimAt };
+}

--- a/apps/web/src/features/block-calendar/calendar-target-request.ts
+++ b/apps/web/src/features/block-calendar/calendar-target-request.ts
@@ -108,10 +108,16 @@ export function createCalendarTargetAim(options: {
   >(targetRequestFromParams(options.initial, nextRequestId++));
 
   // Preview resolution is async, so a stale answer must never clobber a
-  // target the user has since re-aimed or cleared.
-  const applyResolvedTarget = (request: CalendarBlockTargetRequest) => {
-    if (request.requestId < latestRequestId) return;
-    setTarget(request);
+  // target the user has since re-aimed or cleared. The latest answer always
+  // wins, including when it resolves to nothing: a mention whose event was
+  // deleted must drop the aim rather than leave the previous event pending
+  // for the focus effect to land on.
+  const applyResolvedTarget = (
+    requestId: number,
+    resolved: CalendarBlockTargetRequest | undefined
+  ) => {
+    if (requestId < latestRequestId) return;
+    setTarget(resolved);
   };
 
   const aimAt = (params: CalendarBlockProps) => {
@@ -119,16 +125,16 @@ export function createCalendarTargetAim(options: {
     latestRequestId = requestId;
     const direct = targetRequestFromParams(params, requestId);
     if (direct) {
-      applyResolvedTarget(direct);
+      applyResolvedTarget(requestId, direct);
       return;
     }
     if (typeof params.eventId === 'string' && params.eventId.length > 0) {
       resolveFromPreview(params, requestId).then((resolved) => {
-        if (resolved) applyResolvedTarget(resolved);
+        applyResolvedTarget(requestId, resolved);
       });
       return;
     }
-    if (target() !== undefined) setTarget(undefined);
+    applyResolvedTarget(requestId, undefined);
   };
 
   if (

--- a/apps/web/src/features/block-calendar/components/Page.tsx
+++ b/apps/web/src/features/block-calendar/components/Page.tsx
@@ -21,6 +21,10 @@ import {
   calendarEventTimeFromFullCalendar,
   canEditCalendarEventTime,
 } from '@app/features/calendar/utils/event-interaction';
+import {
+  scrollEventChipIntoView,
+  timeGridScroller,
+} from '@app/features/calendar/utils/time-grid-scroller';
 import { toast } from '@core/component/Toast/Toast';
 import { ScrollIndicators } from '@core/component/VerticalScrollIndicators';
 import { isMobile } from '@core/mobile/isMobile';
@@ -69,9 +73,7 @@ function CalendarScrollIndicators(props: {
 
       let updateFrame: number | undefined;
       const updateScrollElements = () => {
-        const scrollElement = element.querySelector<HTMLElement>(
-          '.fc-timegrid .fc-scroller-harness-liquid > .fc-scroller'
-        );
+        const scrollElement = timeGridScroller(element);
         const fadeContainer = scrollElement?.parentElement;
         setTarget((current) => {
           if (!scrollElement || !fadeContainer) return undefined;
@@ -362,6 +364,7 @@ function CalendarPageHost(props: {
     const chip = props.grid.eventElements.get(targetId);
     if (!event || !chip?.isConnected) return;
     calendarFocus.consume(target.requestId);
+    scrollEventChipIntoView(props.grid.element(), chip);
     calendarView.selectEvent(event, chip);
   });
 

--- a/apps/web/src/features/calendar/components/CalendarPagerContext.tsx
+++ b/apps/web/src/features/calendar/components/CalendarPagerContext.tsx
@@ -13,12 +13,10 @@ import {
 } from 'solid-js';
 import type { CalendarOccurrenceData } from '../hooks/use-calendar-occurrence-data';
 import type { CalendarPeriodView } from '../types';
+import { timeGridScroller } from '../utils/time-grid-scroller';
 
 export const CALENDAR_PAGE_IDS = ['previous', 'current', 'next'] as const;
 export type CalendarPageId = (typeof CALENDAR_PAGE_IDS)[number];
-
-const TIME_GRID_SCROLLER_SELECTOR =
-  '.fc-timegrid .fc-scroller-harness-liquid > .fc-scroller';
 
 interface CalendarPageHandle {
   id: CalendarPageId;
@@ -83,12 +81,8 @@ function createCalendarPagerContext(props: CalendarPagerContextProps) {
   const activeData = createMemo(() => activePage()?.data);
   const activeDateInfo = createMemo(() => activePage()?.dateInfo());
 
-  const scrollElementFor = (handle: CalendarPageHandle | undefined) => {
-    const element = handle?.element();
-    if (!element) return undefined;
-
-    return element.querySelector<HTMLElement>(TIME_GRID_SCROLLER_SELECTOR);
-  };
+  const scrollElementFor = (handle: CalendarPageHandle | undefined) =>
+    timeGridScroller(handle?.element());
 
   const copyActiveScrollPosition = () => {
     const activeScrollElement = scrollElementFor(activePage());

--- a/apps/web/src/features/calendar/utils/time-grid-scroller.ts
+++ b/apps/web/src/features/calendar/utils/time-grid-scroller.ts
@@ -1,0 +1,44 @@
+/** FullCalendar's liquid time-grid scroller — the element that scrolls hours. */
+const TIME_GRID_SCROLLER_SELECTOR =
+  '.fc-timegrid .fc-scroller-harness-liquid > .fc-scroller';
+
+/** The hour scroller inside one rendered calendar page, when it has one. */
+export function timeGridScroller(
+  root: HTMLElement | undefined
+): HTMLElement | undefined {
+  return (
+    root?.querySelector<HTMLElement>(TIME_GRID_SCROLLER_SELECTOR) ?? undefined
+  );
+}
+
+/** Vertical breathing room kept around a chip scrolled into view. */
+const CHIP_VISIBILITY_MARGIN = 24;
+
+/**
+ * Scrolls a rendered occurrence chip into the hour scroller's viewport, so a
+ * navigation request that lands on an event outside the scrolled hours still
+ * shows it. Month views and all-day chips sit outside the scroller and are
+ * left where they are.
+ */
+export function scrollEventChipIntoView(
+  root: HTMLElement | undefined,
+  chip: HTMLElement
+) {
+  const scroller = timeGridScroller(root);
+  if (!scroller || !scroller.contains(chip)) return;
+
+  const chipBox = chip.getBoundingClientRect();
+  const scrollerBox = scroller.getBoundingClientRect();
+  if (
+    chipBox.top >= scrollerBox.top + CHIP_VISIBILITY_MARGIN &&
+    chipBox.bottom <= scrollerBox.bottom - CHIP_VISIBILITY_MARGIN
+  ) {
+    return;
+  }
+
+  const centeringOffset = Math.max(
+    0,
+    (scrollerBox.height - chipBox.height) / 2
+  );
+  scroller.scrollTop += chipBox.top - scrollerBox.top - centeringOffset;
+}


### PR DESCRIPTION
Clicking a calendar mention while the calendar was already aimed at that occurrence dropped the request, so the click only swapped the active split and left the event unselected — the reported flash and the dead click are the same bug, and the first click on a mention always worked which is why it read as intermittent. Every aim now mints a fresh request id (the `requestId < latestRequestId` check already covered the staleness the removed guard was written for), and the focused chip is scrolled into the hour grid so a target outside the scrolled hours is actually visible. The fix sits in the block adapter, so it covers the mention, soup-row and sidebar paths that all retarget the singleton calendar.
