### PR TITLE
Fix mobile layout for channel participants list scrolling

### DIFF
--- a/apps/web/src/features/channel/Participants/ChannelParticipantsTab.tsx
+++ b/apps/web/src/features/channel/Participants/ChannelParticipantsTab.tsx
@@ -138,8 +138,11 @@ export function ChannelParticipantsTab(props: {
     );
   };
 
+  // The mobile bottom chrome (dock + accessory regions) floats over the
+  // layout, so the panel stack has to end above it for the participants list
+  // to scroll clear of it.
   return (
-    <div class="h-full overflow-hidden flex justify-center p-2">
+    <div class="h-full overflow-hidden flex justify-center p-2 touch:pb-[calc(var(--mobile-content-inset-bottom,0px)+0.5rem)]">
       <div class="max-w-200 size-full flex flex-col gap-2">
         <Panel depth={2} class="min-h-0 flex-1 overflow-hidden text-ink">
           <Panel.Header class="justify-between gap-2 px-6">

--- a/apps/web/src/features/channel/Participants/ParticipantsList.tsx
+++ b/apps/web/src/features/channel/Participants/ParticipantsList.tsx
@@ -33,7 +33,7 @@ export function ParticipantsList(props: {
       <div ref={setListWrapperRef} class="relative h-full min-h-0">
         <VList
           data={props.participants()}
-          class="h-full scrollbar-hidden pb-(--safe-bottom)"
+          class="h-full scrollbar-hidden"
           style={{
             height: '100%',
             width: '100%',


### PR DESCRIPTION
## Summary
Adjusts the channel participants tab layout to account for mobile bottom chrome (dock and accessory regions) that floats over the content, ensuring the participants list can scroll clear of these UI elements.

## Key Changes
- **ChannelParticipantsTab.tsx**: Added bottom padding using `touch:pb-[calc(var(--mobile-content-inset-bottom,0px)+0.5rem)]` to the main container, which respects the mobile safe area inset and provides additional spacing on touch devices
- **ParticipantsList.tsx**: Removed the `pb-(--safe-bottom)` class from the VList component, as the padding is now handled at the parent container level to prevent double-spacing and ensure proper scroll behavior

## Implementation Details
The fix uses a CSS custom property `--mobile-content-inset-bottom` (defaulting to 0px) combined with an additional 0.5rem margin to create proper spacing between the scrollable content and the floating mobile chrome. This approach ensures the participants list can scroll fully without being obscured by the dock or accessory regions on mobile devices.

https://claude.ai/code/session_01QzgKvnVWSf9TEVkwUo17Ev