### PR TITLE
chore: Dockerfile-based Cursor Cloud Environment Build

### DIFF
--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -53,7 +53,8 @@ RUN mkdir -p /etc/docker \
         '  "storage-driver": "fuse-overlayfs",' \
         '  "features": {' \
         '    "containerd-snapshotter": false' \
-        '  }' \
+        '  },' \
+        '  "dns": ["8.8.8.8", "1.1.1.1"]' \
         '}' > /etc/docker/daemon.json \
     && update-alternatives --set iptables /usr/sbin/iptables-legacy \
     && update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy

--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -1,0 +1,87 @@
+# Cursor Cloud Agent base image for the Macro local stack.
+#
+# OS-level deps only. Do not COPY the repository: Cursor checks out the
+# requested revision separately. The Rust/JS toolchain (just, cargo 1.94.0,
+# bun, sqlx-cli, zig/cargo-zigbuild) comes from `nix develop` (flake.nix).
+#
+# Nested Docker (DinD) requires fuse-overlayfs + iptables-legacy. Docker 29
+# also needs the containerd snapshotter disabled or overlay mounts fail.
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    USER=ubuntu \
+    HOME=/home/ubuntu \
+    PATH="/home/ubuntu/.nix-profile/bin:/nix/var/nix/profiles/default/bin:${PATH}"
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        git \
+        gnupg \
+        iptables \
+        fuse-overlayfs \
+        python3 \
+        sudo \
+        xz-utils \
+    && rm -rf /var/lib/apt/lists/*
+
+# Docker CE 29 (compose plugin + buildx). Pin matches the working Cloud Agent
+# VM; Docker 29 requires features.containerd-snapshotter=false below.
+RUN install -m 0755 -d /etc/apt/keyrings \
+    && curl --retry 3 --retry-delay 5 -fsSL https://download.docker.com/linux/ubuntu/gpg \
+        | gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
+    && chmod a+r /etc/apt/keyrings/docker.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+        $(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
+        > /etc/apt/sources.list.d/docker.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        docker-ce=5:29.7.2-1~ubuntu.24.04~noble \
+        docker-ce-cli=5:29.7.2-1~ubuntu.24.04~noble \
+        containerd.io \
+        docker-buildx-plugin \
+        docker-compose-plugin \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /etc/docker \
+    && printf '%s\n' \
+        '{' \
+        '  "storage-driver": "fuse-overlayfs",' \
+        '  "features": {' \
+        '    "containerd-snapshotter": false' \
+        '  }' \
+        '}' > /etc/docker/daemon.json \
+    && update-alternatives --set iptables /usr/sbin/iptables-legacy \
+    && update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
+
+# Cloud Agents have no systemd (init is tini). ubuntu is UID 1000 on this image.
+RUN id -u ubuntu >/dev/null 2>&1 || useradd -m -s /bin/bash ubuntu \
+    && groupadd -f docker \
+    && usermod -aG docker ubuntu \
+    && usermod -aG sudo ubuntu \
+    && echo "ubuntu ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/ubuntu \
+    && chmod 0440 /etc/sudoers.d/ubuntu
+
+# Determinate Nix, no init. sandbox=false is required inside the build container.
+# ubuntu is a trusted-user so later `nix develop` can talk to nix-daemon.
+RUN curl -fsSL https://install.determinate.systems/nix | sh -s -- install linux \
+        --init none \
+        --no-confirm \
+        --extra-conf "trusted-users = root ubuntu" \
+        --extra-conf "sandbox = false" \
+    && ln -sf /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh /etc/profile.d/nix-daemon.sh
+
+# Nix openssh in the ubuntu profile. `just stack up` shells out to ssh-keygen;
+# the Cloud Agent /exec-daemon/ssh-keygen shim crashes under nix develop's
+# LD_LIBRARY_PATH (glibc 2.42 vs system 2.39).
+USER ubuntu
+WORKDIR /home/ubuntu
+RUN . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh \
+    && sudo /nix/var/nix/profiles/default/bin/nix-daemon >/tmp/nix-daemon-build.log 2>&1 & \
+    for i in $(seq 1 60); do \
+        [ -S /nix/var/nix/daemon-socket/socket ] && break; \
+        sleep 1; \
+    done \
+    && [ -S /nix/var/nix/daemon-socket/socket ] \
+    && nix profile add nixpkgs#openssh

--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -20,7 +20,10 @@ RUN apt-get update \
         git \
         gnupg \
         iptables \
+        iproute2 \
+        kmod \
         fuse-overlayfs \
+        procps \
         python3 \
         sudo \
         xz-utils \

--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -54,7 +54,8 @@ RUN mkdir -p /etc/docker \
         '  "features": {' \
         '    "containerd-snapshotter": false' \
         '  },' \
-        '  "dns": ["8.8.8.8", "1.1.1.1"]' \
+        '  "dns": ["8.8.8.8", "1.1.1.1"],' \
+        '  "mtu": 1400' \
         '}' > /etc/docker/daemon.json \
     && update-alternatives --set iptables /usr/sbin/iptables-legacy \
     && update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,13 @@
+{
+  "name": "macro local stack",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "user": "ubuntu",
+  "install": "bash .cursor/install.sh",
+  "start": "bash .cursor/start.sh",
+  "ports": [
+    { "name": "app", "port": 8090 },
+    { "name": "fusionauth", "port": 9011 }
+  ]
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Build-time, idempotent repository bootstrap for Cursor Cloud Environment Builds.
+#
+# Trade-off: this install is a heavy one-time Build (nix flake, bun install,
+# cargo-zigbuild of all services, runtime image, infra image pulls, a cold
+# `just stack up` that saves the init snapshot) so that later agent boots are
+# fast. Processes started here do not survive the snapshot; `.cursor/start.sh`
+# brings daemons back on each boot.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "${ROOT}"
+
+bash "${ROOT}/.cursor/start.sh"
+
+export PATH="${HOME}/.nix-profile/bin:/nix/var/nix/profiles/default/bin:${PATH}"
+
+# Pre-pull public infra images so `stack up` is not gated on Hub on first boot.
+# Built images (runtime, opensearch, webhook relay) are produced by stack up.
+pull_images=(
+  "pgvector/pgvector:pg18"
+  "redis/redis-stack:latest"
+  "apache/kafka:3.9.1"
+  "postgres:16.0-bookworm"
+  "fusionauth/fusionauth-app:1.62.1"
+  "localstack/localstack:4"
+  "axllent/mailpit:v1.20"
+  "caddy:2-alpine"
+  "nginx:alpine"
+)
+for img in "${pull_images[@]}"; do
+  echo "cursor-cloud install: pulling ${img}"
+  docker pull "${img}"
+done
+
+nix_stack() {
+  nix develop --command bash -c 'export PATH=$HOME/.nix-profile/bin:$PATH; '"$*"
+}
+
+echo "cursor-cloud install: bun install"
+nix_stack 'bun install --frozen-lockfile'
+
+echo "cursor-cloud install: doctor-local"
+nix_stack 'just doctor-local'
+
+# Cold stack up cross-compiles services, builds the runtime image, initializes
+# FusionAuth/Postgres/OpenSearch, and writes infra/local/generated/.snapshots.
+# stack down then drops running containers/volumes; images, cargo/sccache, the
+# nix store, and the init snapshot stay on disk for the Build snapshot.
+echo "cursor-cloud install: just stack up --no-doppler (cache warming)"
+nix_stack 'just stack up --no-doppler'
+
+echo "cursor-cloud install: just stack down"
+nix_stack 'just stack down'
+
+echo "cursor-cloud install: complete"

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -2,10 +2,10 @@
 # Build-time, idempotent repository bootstrap for Cursor Cloud Environment Builds.
 #
 # Trade-off: this install is a heavy one-time Build (nix flake, bun install,
-# cargo-zigbuild of all services, runtime image, infra image pulls, a cold
-# `just stack up` that saves the init snapshot) so that later agent boots are
-# fast. Processes started here do not survive the snapshot; `.cursor/start.sh`
-# brings daemons back on each boot.
+# cargo-zigbuild of all services, runtime image, infra image pulls, aux image
+# builds, a cold `just stack up` that saves the init snapshot) so that later
+# agent boots are fast. Processes started here do not survive the snapshot;
+# `.cursor/start.sh` brings daemons back on each boot.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
@@ -14,9 +14,30 @@ cd "${ROOT}"
 bash "${ROOT}/.cursor/start.sh"
 
 export PATH="${HOME}/.nix-profile/bin:/nix/var/nix/profiles/default/bin:${PATH}"
+# Nested compose bake otherwise fans out apt-get against Fastly and 400s.
+export COMPOSE_PARALLEL_LIMIT=1
+export COMPOSE_BAKE=false
+export DOCKER_BUILDKIT=1
 
-# Pre-pull public infra images so `stack up` is not gated on Hub on first boot.
-# Built images (runtime, opensearch, webhook relay) are produced by stack up.
+retry() {
+  local desc="$1"
+  local attempts="$2"
+  shift 2
+  local n
+  for n in $(seq 1 "${attempts}"); do
+    echo "cursor-cloud install: ${desc} (attempt ${n}/${attempts})"
+    if "$@"; then
+      return 0
+    fi
+    echo "cursor-cloud install: ${desc} attempt ${n} failed" >&2
+    if [ "${n}" -eq "${attempts}" ]; then
+      return 1
+    fi
+    sleep $((n * 8))
+  done
+}
+
+# Pre-pull public images so `stack up` is not gated on Hub on first boot.
 pull_images=(
   "pgvector/pgvector:pg18"
   "redis/redis-stack:latest"
@@ -27,11 +48,38 @@ pull_images=(
   "axllent/mailpit:v1.20"
   "caddy:2-alpine"
   "nginx:alpine"
+  "rust:1.94.0-bookworm"
+  "node:22-bookworm-slim"
+  "node:22-slim"
+  "oven/bun:1"
+  "alpine:3.22"
+  "opensearchproject/opensearch:3.5.0"
 )
 for img in "${pull_images[@]}"; do
-  echo "cursor-cloud install: pulling ${img}"
-  docker pull "${img}"
+  retry "docker pull ${img}" 3 docker pull "${img}"
 done
+
+# Nested BuildKit RUN apt-get over the Docker bridge hits Fastly with HTTP 400
+# (DinD MTU / parallel fetches). Build with --network=host so apt uses the VM
+# stack; compose up then reuses the tagged images instead of rebaking.
+docker_build_host() {
+  local tag="$1"
+  local dockerfile="$2"
+  local context="$3"
+  shift 3
+  retry "docker build ${tag}" 3 \
+    docker build --network=host --progress=plain -t "${tag}" -f "${dockerfile}" "${context}" "$@"
+}
+
+echo "cursor-cloud install: pre-building aux images (host network)"
+docker_build_host macro-analytics_proxy docker/analytics-proxy.Dockerfile .
+docker_build_host macro-ai_editing_worker docker/ai-editing-worker.Dockerfile .
+docker_build_host macro-websocket_service docker/websocket-service.Dockerfile .
+docker_build_host macro-sdk-webhook-relay:dev infra/local/sdk-webhook-relay/Dockerfile infra/local/sdk-webhook-relay
+docker_build_host macro-local-opensearch:dev infra/local/opensearch/Dockerfile infra/local/opensearch
+docker_build_host macro-lexical_service docker/lexical-service.Dockerfile . \
+  --build-arg "GITHUB_PACKAGES_TOKEN=${GITHUB_PACKAGES_TOKEN:-}"
+docker_build_host macro-sync_service docker/sync-service.Dockerfile .
 
 nix_stack() {
   nix develop --command bash -c 'export PATH=$HOME/.nix-profile/bin:$PATH; '"$*"
@@ -47,12 +95,17 @@ nix_stack 'just doctor-local'
 # FusionAuth/Postgres/OpenSearch, and writes infra/local/generated/.snapshots.
 # stack down then drops running containers/volumes; images, cargo/sccache, the
 # nix store, and the init snapshot stay on disk for the Build snapshot.
-echo "cursor-cloud install: just stack up --no-doppler (cache warming)"
-# Nested BuildKit apt-get can flake once on DinD; retry once before failing.
-if ! nix_stack 'just stack up --no-doppler'; then
-  echo "cursor-cloud install: stack up failed, retrying once" >&2
+stack_up_or_reset() {
+  if nix_stack 'export COMPOSE_PARALLEL_LIMIT=1 COMPOSE_BAKE=false DOCKER_BUILDKIT=1; just stack up --no-doppler'; then
+    return 0
+  fi
   nix_stack 'just stack down' || true
-  nix_stack 'just stack up --no-doppler'
+  return 1
+}
+
+if ! retry "just stack up --no-doppler" 3 stack_up_or_reset; then
+  echo "cursor-cloud install: stack up failed after retries" >&2
+  exit 1
 fi
 
 echo "cursor-cloud install: just stack down"

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -48,7 +48,12 @@ nix_stack 'just doctor-local'
 # stack down then drops running containers/volumes; images, cargo/sccache, the
 # nix store, and the init snapshot stay on disk for the Build snapshot.
 echo "cursor-cloud install: just stack up --no-doppler (cache warming)"
-nix_stack 'just stack up --no-doppler'
+# Nested BuildKit apt-get can flake once on DinD; retry once before failing.
+if ! nix_stack 'just stack up --no-doppler'; then
+  echo "cursor-cloud install: stack up failed, retrying once" >&2
+  nix_stack 'just stack down' || true
+  nix_stack 'just stack up --no-doppler'
+fi
 
 echo "cursor-cloud install: just stack down"
 nix_stack 'just stack down'

--- a/.cursor/start.sh
+++ b/.cursor/start.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Per-boot daemons for Cursor Cloud Agents. There is no systemd (init is tini).
+# Idempotent: skip a daemon that is already listening.
+set -euo pipefail
+
+NIX_DAEMON="/nix/var/nix/profiles/default/bin/nix-daemon"
+NIX_SOCKET="/nix/var/nix/daemon-socket/socket"
+DOCKER_SOCK="/var/run/docker.sock"
+
+if [ -f /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]; then
+  # shellcheck disable=SC1091
+  . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+fi
+export PATH="${HOME}/.nix-profile/bin:/nix/var/nix/profiles/default/bin:${PATH}"
+
+wait_for() {
+  local desc="$1"
+  local tries="$2"
+  shift 2
+  local i
+  for i in $(seq 1 "${tries}"); do
+    if "$@" >/dev/null 2>&1; then
+      echo "cursor-cloud start: ${desc} ready"
+      return 0
+    fi
+    sleep 1
+  done
+  echo "cursor-cloud start: timed out waiting for ${desc}" >&2
+  return 1
+}
+
+if [ ! -S "${NIX_SOCKET}" ]; then
+  echo "cursor-cloud start: starting nix-daemon"
+  sudo "${NIX_DAEMON}" >>/tmp/nix-daemon.log 2>&1 &
+fi
+wait_for "nix-daemon" 30 test -S "${NIX_SOCKET}"
+
+if ! docker info >/dev/null 2>&1; then
+  echo "cursor-cloud start: starting dockerd"
+  sudo dockerd >>/tmp/dockerd.log 2>&1 &
+fi
+wait_for "docker socket" 60 test -S "${DOCKER_SOCK}"
+sudo chmod 666 "${DOCKER_SOCK}"
+wait_for "docker daemon" 60 docker info

--- a/.cursor/start.sh
+++ b/.cursor/start.sh
@@ -59,11 +59,15 @@ if ! wait_for "docker daemon" 90 sudo docker info; then
   ps -ef | grep -E '[d]ockerd|[c]ontainerd' >&2 || true
   exit 1
 fi
-# Group membership from the image does not apply until a new login; world-write
-# the socket so the ubuntu user can talk to dockerd without `sudo`.
-if [ -S /var/run/docker.sock ]; then
-  sudo chmod 666 /var/run/docker.sock
-elif [ -S /run/docker.sock ]; then
-  sudo chmod 666 /run/docker.sock
-  sudo ln -sfn /run/docker.sock /var/run/docker.sock
+# Group membership from the image does not apply until a new login. Always
+# chmod as root (do not `test -S` as ubuntu first — a 0600 root socket is
+# invisible to that check in some setups) so the ubuntu user can docker(1)
+# without sudo.
+sudo sh -c 'chmod 666 /var/run/docker.sock /run/docker.sock 2>/dev/null || true'
+ls -la /var/run/docker.sock /run/docker.sock || true
+if ! wait_for "docker as ubuntu" 15 docker info; then
+  echo "cursor-cloud start: ubuntu docker info failed after chmod" >&2
+  ls -la /var/run/docker.sock /run/docker.sock >&2 || true
+  id >&2
+  exit 1
 fi

--- a/.cursor/start.sh
+++ b/.cursor/start.sh
@@ -5,7 +5,6 @@ set -euo pipefail
 
 NIX_DAEMON="/nix/var/nix/profiles/default/bin/nix-daemon"
 NIX_SOCKET="/nix/var/nix/daemon-socket/socket"
-DOCKER_SOCK="/var/run/docker.sock"
 
 if [ -f /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]; then
   # shellcheck disable=SC1091
@@ -35,7 +34,7 @@ if [ ! -S "${NIX_SOCKET}" ]; then
 fi
 wait_for "nix-daemon" 30 test -S "${NIX_SOCKET}"
 
-if ! docker info >/dev/null 2>&1; then
+if ! sudo docker info >/dev/null 2>&1; then
   echo "cursor-cloud start: starting dockerd"
   # fuse-overlayfs needs /dev/fuse in nested containers.
   if [ ! -e /dev/fuse ]; then
@@ -44,19 +43,27 @@ if ! docker info >/dev/null 2>&1; then
   fi
   sudo sysctl -w net.ipv4.ip_forward=1 >/dev/null 2>&1 || true
   : >/tmp/dockerd.log
-  sudo dockerd --host=unix:///var/run/docker.sock --pidfile=/var/run/docker.pid \
-    >>/tmp/dockerd.log 2>&1 &
+  # setsid+nohup: `sudo dockerd &` can get SIGHUP and exit after "daemon started"
+  # while never leaving a stable docker.sock for the waiter.
+  sudo setsid nohup dockerd \
+    --host=unix:///var/run/docker.sock \
+    --pidfile=/run/docker.pid \
+    >>/tmp/dockerd.log 2>&1 < /dev/null &
 fi
-if ! wait_for "docker socket" 90 test -S "${DOCKER_SOCK}"; then
+if ! wait_for "docker daemon" 90 sudo docker info; then
   echo "cursor-cloud start: dockerd.log follows" >&2
-  sudo cat /tmp/dockerd.log >&2 || true
-  ls -la /var/run /run /dev/fuse >&2 || true
-  ps -ef >&2 || true
+  sudo tail -n 80 /tmp/dockerd.log >&2 || true
+  echo "cursor-cloud start: socket listing" >&2
+  ls -la /var/run/docker.sock /run/docker.sock /dev/fuse >&2 || true
+  echo "cursor-cloud start: docker processes" >&2
+  ps -ef | grep -E '[d]ockerd|[c]ontainerd' >&2 || true
   exit 1
 fi
-sudo chmod 666 "${DOCKER_SOCK}"
-if ! wait_for "docker daemon" 60 docker info; then
-  echo "cursor-cloud start: docker info failed; dockerd.log follows" >&2
-  sudo cat /tmp/dockerd.log >&2 || true
-  exit 1
+# Group membership from the image does not apply until a new login; world-write
+# the socket so the ubuntu user can talk to dockerd without `sudo`.
+if [ -S /var/run/docker.sock ]; then
+  sudo chmod 666 /var/run/docker.sock
+elif [ -S /run/docker.sock ]; then
+  sudo chmod 666 /run/docker.sock
+  sudo ln -sfn /run/docker.sock /var/run/docker.sock
 fi

--- a/.cursor/start.sh
+++ b/.cursor/start.sh
@@ -37,8 +37,26 @@ wait_for "nix-daemon" 30 test -S "${NIX_SOCKET}"
 
 if ! docker info >/dev/null 2>&1; then
   echo "cursor-cloud start: starting dockerd"
-  sudo dockerd >>/tmp/dockerd.log 2>&1 &
+  # fuse-overlayfs needs /dev/fuse in nested containers.
+  if [ ! -e /dev/fuse ]; then
+    sudo mknod /dev/fuse c 10 229 || true
+    sudo chmod 666 /dev/fuse || true
+  fi
+  sudo sysctl -w net.ipv4.ip_forward=1 >/dev/null 2>&1 || true
+  : >/tmp/dockerd.log
+  sudo dockerd --host=unix:///var/run/docker.sock --pidfile=/var/run/docker.pid \
+    >>/tmp/dockerd.log 2>&1 &
 fi
-wait_for "docker socket" 60 test -S "${DOCKER_SOCK}"
+if ! wait_for "docker socket" 90 test -S "${DOCKER_SOCK}"; then
+  echo "cursor-cloud start: dockerd.log follows" >&2
+  sudo cat /tmp/dockerd.log >&2 || true
+  ls -la /var/run /run /dev/fuse >&2 || true
+  ps -ef >&2 || true
+  exit 1
+fi
 sudo chmod 666 "${DOCKER_SOCK}"
-wait_for "docker daemon" 60 docker info
+if ! wait_for "docker daemon" 60 docker info; then
+  echo "cursor-cloud start: docker info failed; dockerd.log follows" >&2
+  sudo cat /tmp/dockerd.log >&2 || true
+  exit 1
+fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -343,6 +343,10 @@ durable caveats for running the app here.
   cold on 4 cores). Builds warm that plus the init snapshot in `install`, so
   agent boots should reuse `sccache` and restore the snapshot. `just stack
   status` / `just stack update` / `just stack down` manage it.
+- Nested Docker image builds (`sync_service` and friends) run `apt-get` inside
+  Debian containers. DinD's default bridge MTU plus Fastly's HTTP endpoint for
+  `deb.debian.org` can 400 those fetches. The Environment Dockerfile sets
+  `"mtu": 1400`, and `install.sh` pre-builds those images with `--network=host`.
 - Endpoints (default instance): app at `http://localhost:8090/app/`, proxy at `:8090`,
   Mailpit at `http://localhost:8090/mailpit/`, FusionAuth at `:9011`.
 - Login is passwordless: the one-time code is delivered to Mailpit (not a real inbox).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -317,8 +317,13 @@ don't inject it directly into the error message.
 ## Cursor Cloud specific instructions
 
 This VM runs the intended local dev stack from `docs/RUNNING_LOCALLY.md` via Nix + Docker.
-The startup layer (nix daemon, docker daemon, `bun install`) is handled by the environment
-update script; the notes below are durable, non-obvious caveats for running the app here.
+The machine image is `.cursor/Dockerfile` (Docker 29 DinD + Determinate Nix + Nix openssh).
+`.cursor/environment.json` `install` (`.cursor/install.sh`) is a heavy one-time Environment
+Build: `bun install --frozen-lockfile`, `just doctor-local`, and a cold `just stack up
+--no-doppler` so cargo/sccache, the runtime image, infra images, and the init snapshot
+are on disk for fast later boots. `start` (`.cursor/start.sh`) only starts `nix-daemon`
+and `dockerd` — those processes do not survive the Build snapshot. The notes below are
+durable caveats for running the app here.
 
 - Toolchain lives in the Nix dev shell. Run dev commands from the repo root as
   `nix develop --command bash -c '<cmd>'`. If `nix` is not found, first
@@ -333,9 +338,11 @@ update script; the notes below are durable, non-obvious caveats for running the 
   putting a self-consistent Nix openssh first on PATH. openssh is installed in the Nix
   profile (`nix profile add nixpkgs#openssh`), so launch the stack as:
   `nix develop --command bash -c 'export PATH=$HOME/.nix-profile/bin:$PATH; just stack up --no-doppler'`
-- First `stack up` cross-compiles all service binaries with `cargo-zigbuild`
-  (slow — ~10 min cold on 4 cores); later runs reuse `sccache` and a cached init snapshot,
-  so they are fast. `just stack status` / `just stack update` / `just stack down` manage it.
+- First `stack up` on a machine without the Environment Build caches
+  cross-compiles all service binaries with `cargo-zigbuild` (slow — ~10 min
+  cold on 4 cores). Builds warm that plus the init snapshot in `install`, so
+  agent boots should reuse `sccache` and restore the snapshot. `just stack
+  status` / `just stack update` / `just stack down` manage it.
 - Endpoints (default instance): app at `http://localhost:8090/app/`, proxy at `:8090`,
   Mailpit at `http://localhost:8090/mailpit/`, FusionAuth at `:9011`.
 - Login is passwordless: the one-time code is delivered to Mailpit (not a real inbox).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Codifies the Cursor Cloud Agent machine as a reviewable `.cursor/Dockerfile` + `.cursor/environment.json` Environment Build (replacing the ad-hoc snapshot).

## What this does

- **`.cursor/Dockerfile`**: Ubuntu 24.04, Docker CE 29.7.2 DinD (`fuse-overlayfs`, `containerd-snapshotter: false`, iptables-legacy, DNS 8.8.8.8/1.1.1.1, **MTU 1400**), Determinate Nix (`--init none`), Nix `openssh` in the ubuntu profile.
- **`.cursor/environment.json`**: `install` = `.cursor/install.sh` (heavy one-time cache warming), `start` = `.cursor/start.sh` (nix-daemon + dockerd only).
- **`install.sh`**: start daemons, pull infra + aux base images, **pre-build aux images with `--network=host`** (avoids nested `apt-get` HTTP 400 from Fastly on the Docker bridge), `bun install --frozen-lockfile`, `just doctor-local`, `just stack up --no-doppler` (retry ×3), `just stack down`. Snapshot keeps images, cargo/sccache, nix store, and the init snapshot.
- **`start.sh`**: `setsid` dockerd, wait on `sudo docker info`, `chmod 666` both docker sockets.

`--no-doppler` only. No secrets.

## PATH gotcha (documented in AGENTS.md)

`just stack up` must run as:

```bash
nix develop --command bash -c 'export PATH=$HOME/.nix-profile/bin:$PATH; just stack up --no-doppler'
```

The VM `/exec-daemon/ssh-keygen` shim crashes under Nix `LD_LIBRARY_PATH` (glibc 2.42 vs system 2.39).

## Environment Build status

Iterating with `trigger-environment-build` against this branch (`refs: github.com/macro-inc/macro @ synoet/cursor-cloud-dockerfile-e3a7`).

Latest commit: `1a245a43e` — host-network aux builds + DinD MTU 1400 after nested Debian `apt-get` returned Fastly `400 Bad Request`.

This draft is from a **non-default branch**, so it is testable but **not promotable**. After merge, rebuild from `main`. Enable builds on the environment page; this PR does not flip that setting.

## How to verify on a fresh agent from the succeeding build

1. `nix develop --command just doctor-local` — all checks pass.
2. Bring up the stack with the openssh PATH prepend (above).
3. `just seed-scenario apply --file seed/scenarios/team-perms.json`
4. App at http://localhost:8090/app/ ; Mailpit at http://localhost:8090/mailpit/ ; log in as `alice@seed.macro.local` and send a channel message.
5. `agent_harness_service` restarting without AI keys is expected.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4b6f3150-a7d9-4fe8-a393-8e2df97fe3a7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4b6f3150-a7d9-4fe8-a393-8e2df97fe3a7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

