### PR TITLE
fix(crm): hide Open contact unless the team has CRM enabled

### DIFF
--- a/apps/web/src/lib/core/component/UserTooltip.test.tsx
+++ b/apps/web/src/lib/core/component/UserTooltip.test.tsx
@@ -9,7 +9,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { UserTooltip } from './UserTooltip';
 
 const mocks = vi.hoisted(() => ({
-  crmEnabled: true,
+  crmFlagEnabled: true,
+  teamCrmEnabled: true as boolean | null,
   fetchCrmContactByEmail: vi.fn(),
   openWithSplit: vi.fn(),
   onClose: vi.fn(),
@@ -17,7 +18,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('@app/lib/analytics/posthog', () => ({
   useFeatureFlag: () => () => ({
-    enabled: mocks.crmEnabled,
+    enabled: mocks.crmFlagEnabled,
     payload: undefined,
   }),
 }));
@@ -49,6 +50,15 @@ vi.mock('@queries/crm/contacts', () => ({
   fetchCrmContactByEmail: mocks.fetchCrmContactByEmail,
 }));
 
+vi.mock('@queries/team/teams', () => ({
+  useCurrentTeamQuery: () => ({
+    get data() {
+      if (mocks.teamCrmEnabled === null) return null;
+      return { team: { crm_enabled: mocks.teamCrmEnabled } };
+    },
+  }),
+}));
+
 vi.mock('@ui', () => ({
   cn: (...classes: Array<string | undefined>) =>
     classes.filter(Boolean).join(' '),
@@ -62,7 +72,8 @@ vi.mock('./UserIcon', () => ({
 }));
 
 beforeEach(() => {
-  mocks.crmEnabled = true;
+  mocks.crmFlagEnabled = true;
+  mocks.teamCrmEnabled = true;
   mocks.fetchCrmContactByEmail.mockReset();
   mocks.fetchCrmContactByEmail.mockResolvedValue({ id: 'contact-1' });
   mocks.openWithSplit.mockReset();
@@ -91,8 +102,28 @@ describe('UserTooltip CRM contact action', () => {
     expect(mocks.onClose).toHaveBeenCalledOnce();
   });
 
-  it('hides the contact action when CRM is disabled', () => {
-    mocks.crmEnabled = false;
+  it('hides the contact action when the CRM feature flag is off', () => {
+    mocks.crmFlagEnabled = false;
+
+    render(() => (
+      <UserTooltip displayName="Panat Taranat" email="panat@pync.com" />
+    ));
+
+    expect(screen.queryByRole('button', { name: 'Open contact' })).toBeNull();
+  });
+
+  it('hides the contact action when CRM is disabled for the team', () => {
+    mocks.teamCrmEnabled = false;
+
+    render(() => (
+      <UserTooltip displayName="Panat Taranat" email="panat@pync.com" />
+    ));
+
+    expect(screen.queryByRole('button', { name: 'Open contact' })).toBeNull();
+  });
+
+  it('hides the contact action when the user has no team', () => {
+    mocks.teamCrmEnabled = null;
 
     render(() => (
       <UserTooltip displayName="Panat Taranat" email="panat@pync.com" />

--- a/apps/web/src/lib/core/component/UserTooltip.test.tsx
+++ b/apps/web/src/lib/core/component/UserTooltip.test.tsx
@@ -92,7 +92,9 @@ describe('UserTooltip CRM contact action', () => {
       />
     ));
 
-    await user.click(screen.getByRole('button', { name: 'Open contact' }));
+    await user.click(
+      await screen.findByRole('button', { name: 'Open contact' })
+    );
 
     expect(mocks.fetchCrmContactByEmail).toHaveBeenCalledWith('panat@pync.com');
     expect(mocks.openWithSplit).toHaveBeenCalledWith(

--- a/apps/web/src/lib/core/component/UserTooltip.tsx
+++ b/apps/web/src/lib/core/component/UserTooltip.tsx
@@ -17,7 +17,7 @@ import { fetchCrmContactByEmail } from '@queries/crm/contacts';
 import { useCurrentTeamQuery } from '@queries/team/teams';
 import { debounce } from '@solid-primitives/scheduled';
 import { cn, Surface } from '@ui';
-import { createSignal, type JSX, Show } from 'solid-js';
+import { createSignal, type JSX, Show, Suspense } from 'solid-js';
 import { UserIcon } from './UserIcon';
 
 type UserTooltipProps = {
@@ -31,7 +31,6 @@ type UserTooltipProps = {
 
 export function UserTooltip(props: UserTooltipProps) {
   const [copied, setCopied] = createSignal(false);
-  const [openingContact, setOpeningContact] = createSignal(false);
   const resetCopied = debounce(() => setCopied(false), 800);
 
   function handleCopyEmail(e: MouseEvent) {
@@ -52,9 +51,6 @@ export function UserTooltip(props: UserTooltipProps) {
   const crmFlag = useFeatureFlag(ENABLE_CRM_FLAG, {
     enabledOverride: ENABLE_CRM_OVERRIDE,
   });
-  const currentTeamQuery = useCurrentTeamQuery();
-  const crmEnabled = () =>
-    crmFlag().enabled && currentTeamQuery.data?.team.crm_enabled === true;
   const getOrCreateDmMutation = useGetOrCreateDirectMessageMutation({
     onError: () => toast.failure('Failed to open direct message'),
   });
@@ -75,28 +71,6 @@ export function UserTooltip(props: UserTooltipProps) {
     } catch {
       // The mutation's onError callback handles the toast.
     } finally {
-      props.onClose?.();
-    }
-  };
-
-  const openContact = async (e: MouseEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    const email = props.email;
-    if (!email || openingContact() || !crmEnabled()) return;
-
-    const preferNewSplit = e.shiftKey;
-    setOpeningContact(true);
-    try {
-      const contact = await fetchCrmContactByEmail(email);
-      openWithSplit(
-        { type: 'contact', id: contact.id },
-        { preferNewSplit, reopen: 'latest' }
-      );
-    } catch {
-      toast.failure('Failed to open contact');
-    } finally {
-      setOpeningContact(false);
       props.onClose?.();
     }
   };
@@ -160,11 +134,12 @@ export function UserTooltip(props: UserTooltipProps) {
                 Copy email
               </ActionItem>
             </Show>
-            <Show when={crmEnabled() && props.email}>
-              <ActionItem onClick={openContact} disabled={openingContact()}>
-                <WideContact class="size-3.5" />
-                Open contact
-              </ActionItem>
+            <Show when={crmFlag().enabled ? props.email : undefined}>
+              {(email) => (
+                <Suspense fallback={<div class="h-8" />}>
+                  <OpenContactAction email={email()} onClose={props.onClose} />
+                </Suspense>
+              )}
             </Show>
             <Show when={canTreatAsUser() && props.id !== currentUserId()}>
               <ActionItem onClick={openDM}>
@@ -182,6 +157,47 @@ export function UserTooltip(props: UserTooltipProps) {
         </Show>
       </div>
     </Surface>
+  );
+}
+
+/**
+ * Inner action: lives inside a local `<Suspense>` so reading
+ * `useCurrentTeamQuery().data` suspends only this button, not the tooltip.
+ */
+function OpenContactAction(props: { email: string; onClose?: () => void }) {
+  const [openingContact, setOpeningContact] = createSignal(false);
+  const { openWithSplit } = useSplitLayout();
+  const currentTeamQuery = useCurrentTeamQuery();
+  const crmEnabled = () => currentTeamQuery.data?.team.crm_enabled === true;
+
+  const openContact = async (e: MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (openingContact() || !crmEnabled()) return;
+
+    const preferNewSplit = e.shiftKey;
+    setOpeningContact(true);
+    try {
+      const contact = await fetchCrmContactByEmail(props.email);
+      openWithSplit(
+        { type: 'contact', id: contact.id },
+        { preferNewSplit, reopen: 'latest' }
+      );
+    } catch {
+      toast.failure('Failed to open contact');
+    } finally {
+      setOpeningContact(false);
+      props.onClose?.();
+    }
+  };
+
+  return (
+    <Show when={crmEnabled()}>
+      <ActionItem onClick={openContact} disabled={openingContact()}>
+        <WideContact class="size-3.5" />
+        Open contact
+      </ActionItem>
+    </Show>
   );
 }
 

--- a/apps/web/src/lib/core/component/UserTooltip.tsx
+++ b/apps/web/src/lib/core/component/UserTooltip.tsx
@@ -14,6 +14,7 @@ import WideTask from '@icon/wide-task.svg';
 import IconCheck from '@phosphor/check.svg';
 import { useGetOrCreateDirectMessageMutation } from '@queries/channel/get-or-create-dm';
 import { fetchCrmContactByEmail } from '@queries/crm/contacts';
+import { useCurrentTeamQuery } from '@queries/team/teams';
 import { debounce } from '@solid-primitives/scheduled';
 import { cn, Surface } from '@ui';
 import { createSignal, type JSX, Show } from 'solid-js';
@@ -51,6 +52,9 @@ export function UserTooltip(props: UserTooltipProps) {
   const crmFlag = useFeatureFlag(ENABLE_CRM_FLAG, {
     enabledOverride: ENABLE_CRM_OVERRIDE,
   });
+  const currentTeamQuery = useCurrentTeamQuery();
+  const crmEnabled = () =>
+    crmFlag().enabled && currentTeamQuery.data?.team.crm_enabled === true;
   const getOrCreateDmMutation = useGetOrCreateDirectMessageMutation({
     onError: () => toast.failure('Failed to open direct message'),
   });
@@ -79,7 +83,7 @@ export function UserTooltip(props: UserTooltipProps) {
     e.preventDefault();
     e.stopPropagation();
     const email = props.email;
-    if (!email || openingContact()) return;
+    if (!email || openingContact() || !crmEnabled()) return;
 
     const preferNewSplit = e.shiftKey;
     setOpeningContact(true);
@@ -156,7 +160,7 @@ export function UserTooltip(props: UserTooltipProps) {
                 Copy email
               </ActionItem>
             </Show>
-            <Show when={crmFlag().enabled && props.email}>
+            <Show when={crmEnabled() && props.email}>
               <ActionItem onClick={openContact} disabled={openingContact()}>
                 <WideContact class="size-3.5" />
                 Open contact


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The hover-card **Open contact** action now requires both the `enable-crm` flag and `team.crm_enabled`.

The team query is read inside a local `Suspense` so only that button waits, not the whole tooltip.

[CRM enabled](/opt/cursor/artifacts/open_contact_visible_crm_enabled.mp4)
[CRM disabled](/opt/cursor/artifacts/open_contact_hidden_crm_disabled.mp4)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2367abc8-7765-4f96-bccb-370ba9c63dd2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2367abc8-7765-4f96-bccb-370ba9c63dd2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

