### PR TITLE
chore: document PR title and body preferences for agents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,12 @@ cargo fmt                   # format
 just clippy                 # extra lints / best practices
 ```
 
+### Pull requests
+
+- Titles use Conventional Commits: `type(scope): short description` (see CONTRIBUTING.md).
+- Bodies: a short summary of what changed and why. No test-plan checklists or generated boilerplate.
+- Link walkthrough videos as markdown links. Do not embed HTML video/img artifact cards.
+
 ### Database Management
 
 ```bash


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds PR conventions to the repo-root agent instructions (`AGENTS.md` → `CLAUDE.md`): Conventional Commit titles, a short summary, and markdown video links instead of HTML embeds.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2367abc8-7765-4f96-bccb-370ba9c63dd2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2367abc8-7765-4f96-bccb-370ba9c63dd2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

