### PR TITLE
fix(web): retry user name/avatar fetch after a failed batch request

### DIFF
--- a/apps/web/src/lib/core/signal/profilePicture.ts
+++ b/apps/web/src/lib/core/signal/profilePicture.ts
@@ -53,7 +53,14 @@ async function fetchProfilePictures(
   });
   if (result.isErr()) {
     console.error('Failed to fetch user profile pictures');
-    return [];
+    // Mark as not-loading with an expired timestamp so the next access
+    // retries the fetch instead of getting stuck forever (see
+    // `useProfilePictureUrl`'s `cacheExpired` check).
+    return ids.map((id) => ({
+      _createdAt: new Date(0),
+      id,
+      loading: false,
+    }));
   }
 
   const { pictures } = result.value;

--- a/apps/web/src/lib/core/user/displayName.ts
+++ b/apps/web/src/lib/core/user/displayName.ts
@@ -115,7 +115,14 @@ async function fetchDisplayNames(ids: string[]): Promise<UserNameItem[]> {
   });
   if (result.isErr()) {
     console.error('Failed to fetch user display names');
-    return [];
+    // Mark as not-loading with an expired timestamp so the next access
+    // retries the fetch instead of getting stuck showing the email
+    // fallback forever (see `ensureUserNameItem`'s `cacheExpired` check).
+    return ids.map((id) => ({
+      _createdAt: new Date(0),
+      id,
+      loading: false,
+    }));
   }
 
   const data = result.value;


### PR DESCRIPTION
## Summary

Bug report from the `#0195ceb6…` channel:

> i had the website open all night and when i went back on it this morning everyone was their email instead of their contact name and no profile pics. I refreshed and things went back to normal

(confirmed by a second person: "this happened to me yesterday")

**Root cause:** `apps/web/src/lib/core/user/displayName.ts` and `apps/web/src/lib/core/signal/profilePicture.ts` each keep a module-level cache of resolved user display names / avatar URLs with a 10-minute TTL. When an entry is missing or expired, it's set to `loading: true` and a background fetch is queued. While `loading: true`, the UI falls back to showing the raw email (no name) / no avatar.

The staleness check that re-queues a fetch is:

```ts
const cacheExpired =
  cached &&
  !cached.loading &&   // <-- never true once stuck loading
  Date.now() - cached._createdAt.getTime() > DEFAULT_CACHE_TIME_SECONDS * 1000;
```

If the background batch fetch fails (network blip, auth race, transient 5xx — exactly what happens when a laptop wakes from sleep and the websocket/auth state is still settling), the failure handler just logs and returns `[]`, leaving the entry stuck at `loading: true` forever. Because of the `!cached.loading` guard, a stuck entry can never be considered "expired" again, so it's never retried for the rest of the browser session — matching "shows email/no avatar until a full page reload" (a reload resets the in-memory module state).

## Fix

On a failed batch fetch, mark the affected ids as `loading: false` with an expired (`epoch`) timestamp instead of dropping them. This makes the entries eligible for `cacheExpired` again, so the very next access retries the fetch instead of getting stuck permanently.

## Test plan

- [x] Manual code review of both call sites (`ensureUserNameItem`, `useProfilePictureUrl`) confirms the new fallback entries satisfy `cacheExpired` immediately.
- [ ] Could not run `bun install` / `tsc` / app test suite in this sandbox (private GitHub tarball dependencies return 403 through the network proxy) — please confirm CI typechecks/builds cleanly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SAsQ6ZgYr4Jr9UGZeQcJky)_