### PR TITLE
Make markdown error messages platform-aware

### DIFF
--- a/apps/web/src/lib/core/component/LexicalMarkdown/constants.ts
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/constants.ts
@@ -1,3 +1,5 @@
+import { isNativeMobilePlatform } from '@core/mobile/isNativeMobilePlatform';
+
 let layer = 0;
 
 export const MarkdownStackingContext = {
@@ -14,18 +16,26 @@ export enum MarkdownEditorErrors {
   STAGING_VERSION_MISMATCH_ERROR = 'STAGING_VERSION_MISMATCH_ERROR',
 }
 
-const MarkdownEditorErrorDescriptions: Record<MarkdownEditorErrors, string> = {
-  [MarkdownEditorErrors.EMPTY_SOURCE]: 'No document content could be found.',
-  [MarkdownEditorErrors.JSON_PARSE_ERROR]:
+const MarkdownEditorErrorDescriptions: Record<
+  MarkdownEditorErrors,
+  () => string
+> = {
+  [MarkdownEditorErrors.EMPTY_SOURCE]: () =>
+    'No document content could be found.',
+  [MarkdownEditorErrors.JSON_PARSE_ERROR]: () =>
     'Parse error. Invalid document JSON.',
-  [MarkdownEditorErrors.VERSION_MISMATCH_ERROR]:
-    'Refresh the page to edit this document. It may have been updated using a newer version of Macro.',
-  [MarkdownEditorErrors.STAGING_VERSION_MISMATCH_ERROR]:
+  // The native mobile app has no way to refresh a page, so tell those users to
+  // relaunch the app instead.
+  [MarkdownEditorErrors.VERSION_MISMATCH_ERROR]: () =>
+    isNativeMobilePlatform()
+      ? 'Close and re-open the app to edit this document. It may have been updated using a newer version of Macro.'
+      : 'Refresh the page to edit this document. It may have been updated using a newer version of Macro.',
+  [MarkdownEditorErrors.STAGING_VERSION_MISMATCH_ERROR]: () =>
     'This doc has been updated on an incompatible version of staging. If you are seeing this message, please open the document on staging to edit.',
 };
 
 export const getErrorDescription = (
   errorType: MarkdownEditorErrors
 ): string => {
-  return MarkdownEditorErrorDescriptions[errorType];
+  return MarkdownEditorErrorDescriptions[errorType]();
 };


### PR DESCRIPTION
## Summary
Updated markdown editor error descriptions to be platform-aware, providing different messaging for native mobile platforms versus web browsers. This improves user experience by giving platform-specific guidance when document version mismatches occur.

## Key Changes
- Imported `isNativeMobilePlatform` utility to detect native mobile app environment
- Converted `MarkdownEditorErrorDescriptions` from static strings to lazy-evaluated functions that return strings
- Updated `VERSION_MISMATCH_ERROR` to provide conditional messaging:
  - Native mobile: instructs users to "Close and re-open the app"
  - Web: instructs users to "Refresh the page"
- Updated `getErrorDescription` to invoke the error description functions

## Implementation Details
- Error descriptions are now functions `() => string` instead of plain strings, allowing runtime platform detection
- The mobile-specific message is determined at call time rather than build time, ensuring accurate detection regardless of where the code is executed
- All error types were converted to functions for consistency, even those without conditional logic
- Added explanatory comment documenting why mobile and web platforms need different messaging

https://claude.ai/code/session_01BSXXxu8fTpDAWygm1Pa2Cf