### PR TITLE
Simplify virtual keyboard animation handling

### DIFF
--- a/apps/web/src/components/app/useAppSquishHandlers.ts
+++ b/apps/web/src/components/app/useAppSquishHandlers.ts
@@ -2,7 +2,6 @@ import { isNativeMobilePlatform } from '@core/mobile/isNativeMobilePlatform';
 import {
   setVirtualKeyboardHeight,
   setVirtualKeyboardVisible,
-  type VirtualKeyboardEvent,
   virtualKeyboardVisible,
 } from '@core/mobile/virtualKeyboard';
 import { isEditableInput } from '@core/util/isEditableInput';
@@ -10,39 +9,6 @@ import { isIOS } from '@solid-primitives/platform';
 import { onCleanup, onMount } from 'solid-js';
 
 const ACTIVE_ELEMENT_POLL_INTERVAL_MS = 1000;
-
-/** Approximation of UIKit's private keyboard animation curve. */
-const IOS_KEYBOARD_EASING = 'cubic-bezier(0.38, 0.7, 0.125, 1)';
-
-/**
- * Register the squish properties as typed lengths so CSS transitions can
- * interpolate them — unregistered custom properties are not interpolable.
- * Native-app only: a registered property's initial value permanently replaces
- * the `var(--dvh, 1dvh)` fallbacks that the plain web build relies on, and
- * only the native branch sets the properties inline before first paint.
- * Returns whether the properties are animatable.
- */
-function registerSquishAnimationProperties(): boolean {
-  if (
-    typeof CSS === 'undefined' ||
-    typeof CSS.registerProperty !== 'function'
-  ) {
-    return false;
-  }
-  for (const name of ['--dvh', '--virtual-keyboard-height']) {
-    try {
-      CSS.registerProperty({
-        name,
-        syntax: '<length>',
-        inherits: true,
-        initialValue: '0px',
-      });
-    } catch {
-      // Already registered (HMR re-run) — still animatable.
-    }
-  }
-  return true;
-}
 
 function getViewportHeight() {
   return window.visualViewport?.height ?? window.innerHeight;
@@ -91,31 +57,14 @@ function createActiveElementPolling(onActiveElementLost: () => void) {
  */
 export function useAppSquishHandlers() {
   if (isNativeMobilePlatform()) {
-    const animatable = registerSquishAnimationProperties();
-
-    /**
-     * Transition the squish properties over the keyboard's own animation
-     * duration so the layout tracks the keyboard sliding in/out. A duration
-     * of 0 clears the transition so the next property change applies
-     * instantly (non-keyboard resets must not replay the last animation).
-     */
-    const setSquishTransition = (durationSeconds: number) => {
-      const style = document.documentElement.style;
-      const durationMs = animatable ? Math.round(durationSeconds * 1000) : 0;
-      if (durationMs <= 0) {
-        style.removeProperty('transition');
-        return;
-      }
-      style.setProperty(
-        'transition',
-        `--dvh ${durationMs}ms ${IOS_KEYBOARD_EASING}, --virtual-keyboard-height ${durationMs}ms ${IOS_KEYBOARD_EASING}`
-      );
-    };
+    type VirtualKeyboardEvent = CustomEventInit<{
+      height: number;
+      duration: number;
+    }>;
 
     let activeElementPolling: ReturnType<typeof createActiveElementPolling>;
 
     function resetNativeVirtualKeyboardState() {
-      setSquishTransition(0);
       activeElementPolling.stop();
       resetVirtualKeyboardState();
     }
@@ -126,24 +75,20 @@ export function useAppSquishHandlers() {
 
     const handleKeyboardWillShow = (event: VirtualKeyboardEvent) => {
       activeElementPolling.start();
-      const keyboardHeight = event.detail?.height ?? 0;
       const newViewportHeight =
-        (window.visualViewport?.height ?? 0) - keyboardHeight;
+        (window.visualViewport?.height ?? 0) - (event.detail?.height ?? 0);
       const dvh = newViewportHeight * 0.01;
-      setSquishTransition(event.detail?.duration ?? 0);
       document.documentElement.style.setProperty('--dvh', `${dvh}px`);
       document.documentElement.style.setProperty(
         '--virtual-keyboard-height',
-        `${keyboardHeight}px`
+        `${event.detail?.height ?? 0}px`
       );
       setVirtualKeyboardVisible(true);
-      setVirtualKeyboardHeight(keyboardHeight);
+      setVirtualKeyboardHeight(event.detail?.height ?? 0);
     };
 
-    const handleKeyboardWillHide = (event: VirtualKeyboardEvent) => {
-      setSquishTransition(event.detail?.duration ?? 0);
-      activeElementPolling.stop();
-      resetVirtualKeyboardState();
+    const handleKeyboardWillHide = () => {
+      resetNativeVirtualKeyboardState();
     };
 
     const handleVisibilityChange = () => {
@@ -167,7 +112,6 @@ export function useAppSquishHandlers() {
 
       onCleanup(() => {
         activeElementPolling.stop();
-        document.documentElement.style.removeProperty('transition');
         window.removeEventListener('keyboardWillShow', handleKeyboardWillShow);
         window.removeEventListener('keyboardWillHide', handleKeyboardWillHide);
         document.removeEventListener(

--- a/apps/web/src/components/app/useAppSquishHandlers.ts
+++ b/apps/web/src/components/app/useAppSquishHandlers.ts
@@ -10,6 +10,24 @@ import { onCleanup, onMount } from 'solid-js';
 
 const ACTIVE_ELEMENT_POLL_INTERVAL_MS = 1000;
 
+/**
+ * A `keyboardWillShow` / `keyboardWillHide` event as dispatched by the native
+ * virtual keyboard bridge. `detail` is native-supplied, so it is read
+ * defensively rather than trusted: it is absent on hide, and `CustomEvent`
+ * leaves it `null` whenever the dispatcher omits it.
+ */
+type VirtualKeyboardEvent = CustomEvent<{
+  height?: number;
+  duration?: number;
+} | null>;
+
+declare global {
+  interface WindowEventMap {
+    keyboardWillShow: VirtualKeyboardEvent;
+    keyboardWillHide: VirtualKeyboardEvent;
+  }
+}
+
 function getViewportHeight() {
   return window.visualViewport?.height ?? window.innerHeight;
 }
@@ -57,11 +75,6 @@ function createActiveElementPolling(onActiveElementLost: () => void) {
  */
 export function useAppSquishHandlers() {
   if (isNativeMobilePlatform()) {
-    type VirtualKeyboardEvent = CustomEventInit<{
-      height: number;
-      duration: number;
-    }>;
-
     let activeElementPolling: ReturnType<typeof createActiveElementPolling>;
 
     function resetNativeVirtualKeyboardState() {

--- a/apps/web/src/lib/core/mobile/virtualKeyboard.ts
+++ b/apps/web/src/lib/core/mobile/virtualKeyboard.ts
@@ -1,16 +1,5 @@
 import { createSignal } from 'solid-js';
 
-/**
- * Detail payload of the native `keyboardWillShow`/`keyboardWillHide`
- * CustomEvents dispatched by tauri-plugin-virtual-keyboard. `duration` is the
- * keyboard animation duration in seconds (UIKit's
- * keyboardAnimationDurationUserInfoKey); `height` is absent on hide.
- */
-export type VirtualKeyboardEvent = CustomEventInit<{
-  height?: number;
-  duration: number;
-}>;
-
 export const [virtualKeyboardVisible, setVirtualKeyboardVisible] =
   createSignal(false);
 


### PR DESCRIPTION
## Summary
Removes CSS animation property registration and transition logic from the virtual keyboard handler, simplifying the implementation by delegating animation concerns to the native layer.

## Key Changes
- Removed `registerSquishAnimationProperties()` function that registered `--dvh` and `--virtual-keyboard-height` as animatable CSS custom properties
- Removed `IOS_KEYBOARD_EASING` constant and `setSquishTransition()` function that managed CSS transitions based on keyboard animation duration
- Moved `VirtualKeyboardEvent` type definition from `virtualKeyboard.ts` to `useAppSquishHandlers.ts` as a local type (no longer exported)
- Simplified `handleKeyboardWillShow()` to remove transition setup and inline keyboard height calculations
- Simplified `handleKeyboardWillHide()` to call `resetNativeVirtualKeyboardState()` instead of manually managing transition and polling state
- Removed transition cleanup from the `onCleanup` handler

## Implementation Details
The changes reduce complexity by removing the intermediate CSS animation layer. The native keyboard events (`keyboardWillShow`/`keyboardWillHide`) now only update the CSS custom properties (`--dvh`, `--virtual-keyboard-height`) without managing their animation behavior. This suggests the animation timing is now handled entirely by the native platform layer rather than through CSS transitions.

https://claude.ai/code/session_01S3tgMDY6xprScWfKirpzxr