### PR TITLE
feat(split-layout): cmd+esc returns to the most recent list view

### DIFF
--- a/apps/web/src/components/app/split-layout/components/PopoverSplitRenderer.tsx
+++ b/apps/web/src/components/app/split-layout/components/PopoverSplitRenderer.tsx
@@ -66,6 +66,7 @@ function PopoverSplitModal(props: {
     canGoBack: () => false,
     canGoForward: () => false,
     goBack: () => {},
+    goBackTo: () => false,
     goForward: () => {},
     reset: () => {},
     activate: () => {},

--- a/apps/web/src/components/app/split-layout/components/SplitPanel.tsx
+++ b/apps/web/src/components/app/split-layout/components/SplitPanel.tsx
@@ -75,11 +75,19 @@ export function SplitPanel(props: SplitPanelProps) {
   const splitLayoutHelpers = useSplitLayout();
 
   registerSplitHotkeys({
-    goHome: () =>
+    // Leaving a piece of content should return you to the list you reached it
+    // from, so walk this split's history back to the most recent list view.
+    // Only a split that never passed through one falls back to the inbox.
+    goToList: () => {
+      const wentBack = props.handle.goBackTo(
+        (content) => content.type === 'component' && isListViewID(content.id)
+      );
+      if (wentBack) return;
       props.handle.replace({
         next: { type: 'component', id: LIST_VIEW_ID.inbox },
         referredFrom: 'hotkey',
-      }),
+      });
+    },
     isNotUnifiedList: () => {
       const content = props.handle.content();
       return !isListViewID(content.id);

--- a/apps/web/src/components/app/split-layout/history.ts
+++ b/apps/web/src/components/app/split-layout/history.ts
@@ -4,6 +4,13 @@ export type History<T extends object> = {
   readonly items: ReadonlyArray<T>;
   readonly index: Readonly<number>;
   back: () => T | null;
+  /**
+   * Jump to the nearest earlier entry matching `predicate`, skipping the
+   * entries in between. Those entries stay in the stack, so `forward` still
+   * reaches them. Returns null — leaving the index put — when nothing earlier
+   * matches.
+   */
+  backTo: (predicate: (item: T) => boolean) => T | null;
   forward: () => T | null;
   canGoBack: () => boolean;
   canGoForward: () => boolean;
@@ -88,6 +95,17 @@ export function createHistory<T extends object>(): History<T> {
     return items()[index()];
   };
 
+  const backTo = (predicate: (item: T) => boolean) => {
+    const list = items();
+    for (let i = index() - 1; i >= 0; i--) {
+      const item = list[i];
+      if (!predicate(item)) continue;
+      setIndex(i);
+      return item;
+    }
+    return null;
+  };
+
   const forward = () => {
     if (!canGoForward()) return null;
     setIndex(inc);
@@ -138,6 +156,7 @@ export function createHistory<T extends object>(): History<T> {
       return index();
     },
     back,
+    backTo,
     push,
     merge,
     replaceCurrent,

--- a/apps/web/src/components/app/split-layout/layoutManager.ts
+++ b/apps/web/src/components/app/split-layout/layoutManager.ts
@@ -510,8 +510,9 @@ export type SplitHandle<TMeta extends ComponentMeta = ComponentMeta> = {
   goBack: () => void;
   /**
    * Jump back to the nearest earlier history entry matching `predicate`,
-   * skipping the entries in between. Returns false — navigating nowhere — when
-   * no earlier entry matches.
+   * skipping the entries in between. Entries whose content another split
+   * already displays are skipped too, since this split cannot mount them.
+   * Returns false — navigating nowhere — when no earlier entry qualifies.
    */
   goBackTo: (predicate: (content: SplitContent) => boolean) => boolean;
   close: () => void;
@@ -912,12 +913,21 @@ export function createSplitLayout(
     }
 
     const split = state.splits[i];
+    const otherSplits = state.splits.filter((s) => s.id !== split.id);
     const result = { moved: false };
 
     batch(() => {
       captureCurrentEntryState(split);
 
-      const prev = split.history.backTo(predicate);
+      // Entries whose content another split already displays are not
+      // candidates: `reattach` refuses them, which would strand the history
+      // index on an entry the split never mounted. Skipping them here keeps
+      // the index and the mounted content in step, and lets the search carry
+      // on to an entry that can actually be shown.
+      const prev = split.history.backTo(
+        (content) =>
+          predicate(content) && !isDuplicateSplit(otherSplits, content)
+      );
       if (!prev) return;
 
       result.moved = true;

--- a/apps/web/src/components/app/split-layout/layoutManager.ts
+++ b/apps/web/src/components/app/split-layout/layoutManager.ts
@@ -508,6 +508,12 @@ export type SplitHandle<TMeta extends ComponentMeta = ComponentMeta> = {
   isLast: () => boolean;
   activate: () => void;
   goBack: () => void;
+  /**
+   * Jump back to the nearest earlier history entry matching `predicate`,
+   * skipping the entries in between. Returns false — navigating nowhere — when
+   * no earlier entry matches.
+   */
+  goBackTo: (predicate: (content: SplitContent) => boolean) => boolean;
   close: () => void;
   reset: () => void;
   /** Returns the content item one step back in this split's history, without mutating. */
@@ -889,6 +895,39 @@ export function createSplitLayout(
     });
   }
 
+  /**
+   * Jump a split back to the nearest earlier history entry matching
+   * `predicate`, skipping the entries in between (they stay reachable with
+   * `forward`). Returns whether a match was found; the split is left untouched
+   * when none is.
+   */
+  function backTo(
+    id: SplitId,
+    predicate: (content: SplitContent) => boolean
+  ): boolean {
+    const i = splitIndexById(id);
+    if (i < 0) {
+      console.error(`Split with id ${id} not found`);
+      return false;
+    }
+
+    const split = state.splits[i];
+    const result = { moved: false };
+
+    batch(() => {
+      captureCurrentEntryState(split);
+
+      const prev = split.history.backTo(predicate);
+      if (!prev) return;
+
+      result.moved = true;
+      reattach(split, prev, undefined, 'history-back');
+      resetPreviewMode(id);
+    });
+
+    return result.moved;
+  }
+
   function forward(id: SplitId) {
     const i = splitIndexById(id);
     if (i < 0) return console.error(`Split with id ${id} not found`);
@@ -1062,6 +1101,8 @@ export function createSplitLayout(
       canGoForward: () =>
         (findSplitById(currentSplit.id) ?? currentSplit).history.canGoForward(),
       goBack: () => back(currentSplit.id),
+      goBackTo: (predicate: (content: SplitContent) => boolean) =>
+        backTo(currentSplit.id, predicate),
       reset: () => reset(currentSplit.id),
       goForward: () => forward(currentSplit.id),
       replace: ({ next, mergeHistory = false, referredFrom }) =>

--- a/apps/web/src/components/app/split-layout/registerSplitHotkeys.ts
+++ b/apps/web/src/components/app/split-layout/registerSplitHotkeys.ts
@@ -14,7 +14,7 @@ export function registerSplitHotkeys(args: {
   goBack: () => void;
   canGoForward: () => boolean;
   goForward: () => void;
-  goHome: () => void;
+  goToList: () => void;
   splitName: () => string;
   getSplitCount: () => number;
   isNotUnifiedList: () => boolean;
@@ -32,17 +32,17 @@ export function registerSplitHotkeys(args: {
     getSplitCount,
     isNotUnifiedList,
     isViewerSplit: isPreviewSplit,
-    goHome,
+    goToList,
   } = args;
   registerHotkey({
     scopeId: splitHotkeyScope,
     hotkey: ['cmd+escape', 'opt+escape'],
     condition: () =>
       !isPreviewSplit() && (isNotUnifiedList() || getSplitCount() > 1),
-    description: () => (isNotUnifiedList() ? 'Go home' : 'Close split'),
+    description: () => (isNotUnifiedList() ? 'Back to list' : 'Close split'),
     keyDownHandler: () => {
       if (isNotUnifiedList()) {
-        goHome();
+        goToList();
       } else if (getSplitCount() > 1) {
         closeSplit();
       }

--- a/apps/web/src/components/app/split-layout/tests/layoutHistory.test.ts
+++ b/apps/web/src/components/app/split-layout/tests/layoutHistory.test.ts
@@ -91,6 +91,9 @@ describe('createHistory', () => {
       history.push({ value: 'doc' });
       history.push({ value: 'inbox' });
       history.push({ value: 'thread' });
+      history.push({ value: 'inbox' });
+      // Sitting on 'inbox' at index 1, with another 'inbox' ahead at index 3.
+      history.back();
       history.back();
 
       expect(history.backTo((item) => item.value === 'inbox')).toBe(null);

--- a/apps/web/src/components/app/split-layout/tests/layoutHistory.test.ts
+++ b/apps/web/src/components/app/split-layout/tests/layoutHistory.test.ts
@@ -58,6 +58,46 @@ describe('createHistory', () => {
     });
   });
 
+  describe('backTo', () => {
+    it('jumps to the nearest earlier match, keeping the skipped entries forward', () => {
+      const history = createHistory<{ value: string }>();
+
+      history.push({ value: 'inbox' });
+      history.push({ value: 'doc' });
+      history.push({ value: 'tasks' });
+      history.push({ value: 'task' });
+      history.push({ value: 'thread' });
+
+      const result = history.backTo((item) => item.value === 'tasks');
+      expect(result).toEqual({ value: 'tasks' });
+      expect(history.index).toBe(2);
+      expect(history.items).toHaveLength(5);
+      expect(history.forward()).toEqual({ value: 'task' });
+    });
+
+    it('stays put when no earlier entry matches', () => {
+      const history = createHistory<{ value: string }>();
+
+      history.push({ value: 'doc' });
+      history.push({ value: 'thread' });
+
+      expect(history.backTo((item) => item.value === 'inbox')).toBe(null);
+      expect(history.index).toBe(1);
+    });
+
+    it('ignores the current entry and anything ahead of it', () => {
+      const history = createHistory<{ value: string }>();
+
+      history.push({ value: 'doc' });
+      history.push({ value: 'inbox' });
+      history.push({ value: 'thread' });
+      history.back();
+
+      expect(history.backTo((item) => item.value === 'inbox')).toBe(null);
+      expect(history.index).toBe(1);
+    });
+  });
+
   describe('forward', () => {
     it('should navigate forward in history', () => {
       const history = createHistory<{ value: string }>();

--- a/apps/web/src/components/app/split-layout/tests/layoutManager.test.ts
+++ b/apps/web/src/components/app/split-layout/tests/layoutManager.test.ts
@@ -300,6 +300,39 @@ describe('layoutManager', () => {
       });
     });
 
+    it('skips history entries another split already displays', () => {
+      createRoot((dispose) => {
+        const manager = createSplitLayout(createMockOrchestrator(), [
+          { type: 'component', id: 'inbox' },
+          { type: 'md', id: 'doc-1' },
+        ]);
+        const [listSplitState, docSplitState] = manager.splits();
+        const listSplit = manager.getSplit(listSplitState.id)!;
+        const docSplit = manager.getSplit(docSplitState.id)!;
+
+        // The list split walks through doc-1 — which the other split is
+        // already showing — before landing on a channel.
+        listSplit.replace({ next: { type: 'md', id: 'doc-1' } });
+        listSplit.replace({ next: { type: 'channel', id: 'ch-1' } });
+
+        const moved = listSplit.goBackTo(
+          (content) => content.type === 'md' && content.id === 'doc-1'
+        );
+
+        // doc-1 is unmountable here, so nothing moves: the split keeps showing
+        // the channel rather than stranding its history on an entry it never
+        // mounted.
+        expect(moved).toBe(false);
+        expect(listSplit.content()).toMatchObject({
+          type: 'channel',
+          id: 'ch-1',
+        });
+        expect(docSplit.content()).toMatchObject({ type: 'md', id: 'doc-1' });
+
+        dispose();
+      });
+    });
+
     it('leaves the split put when nothing earlier matches', () => {
       createRoot((dispose) => {
         const manager = createSplitLayout(createMockOrchestrator(), [

--- a/apps/web/src/components/app/split-layout/tests/layoutManager.test.ts
+++ b/apps/web/src/components/app/split-layout/tests/layoutManager.test.ts
@@ -271,6 +271,54 @@ describe('layoutManager', () => {
         dispose();
       });
     });
+
+    it('jumps back to the nearest earlier entry matching a predicate', () => {
+      createRoot((dispose) => {
+        const manager = createSplitLayout(createMockOrchestrator(), [
+          { type: 'component', id: 'inbox' },
+        ]);
+        const split = manager.getSplit(manager.splits()[0].id)!;
+
+        split.replace({ next: { type: 'md', id: 'doc-1' } });
+        split.replace({ next: { type: 'component', id: 'tasks' } });
+        split.replace({ next: { type: 'md', id: 'doc-2' } });
+        split.replace({ next: { type: 'channel', id: 'ch-1' } });
+
+        const moved = split.goBackTo(
+          (content) => content.type === 'component' && content.id === 'tasks'
+        );
+
+        expect(moved).toBe(true);
+        expect(split.content()).toMatchObject({
+          type: 'component',
+          id: 'tasks',
+        });
+        // The skipped entries stay ahead, so forward still reaches them.
+        expect(split.canGoForward()).toBe(true);
+
+        dispose();
+      });
+    });
+
+    it('leaves the split put when nothing earlier matches', () => {
+      createRoot((dispose) => {
+        const manager = createSplitLayout(createMockOrchestrator(), [
+          { type: 'component', id: 'inbox' },
+        ]);
+        const split = manager.getSplit(manager.splits()[0].id)!;
+
+        split.replace({ next: { type: 'md', id: 'doc-1' } });
+
+        const moved = split.goBackTo(
+          (content) => content.type === 'component' && content.id === 'tasks'
+        );
+
+        expect(moved).toBe(false);
+        expect(split.content()).toMatchObject({ type: 'md', id: 'doc-1' });
+
+        dispose();
+      });
+    });
   });
 
   describe('navigation params', () => {

--- a/apps/web/src/components/app/split-layout/tests/registerSplitHotkeys.test.ts
+++ b/apps/web/src/components/app/split-layout/tests/registerSplitHotkeys.test.ts
@@ -48,7 +48,7 @@ describe('registerSplitHotkeys', () => {
       goBack: vi.fn(),
       canGoForward: () => false,
       goForward: vi.fn(),
-      goHome: vi.fn(),
+      goToList: vi.fn(),
       splitName: () => 'Test',
       getSplitCount: () => 2,
       isNotUnifiedList: () => true,

--- a/apps/web/src/features/settings/Shortcuts.tsx
+++ b/apps/web/src/features/settings/Shortcuts.tsx
@@ -935,7 +935,7 @@ const shortcutSections: ShortcutSection[] = [
       {
         keys: ['cmd+escape'],
         codes: ['MetaLeft', 'Escape'],
-        description: 'Go home / close split',
+        description: 'Back to list / close split',
       },
       {
         keys: ['shift+escape'],


### PR DESCRIPTION
`cmd+esc` (and `opt+esc`) on a content split always replaced it with the inbox, even when the split was opened from another list.

It now walks the split's own history back to the nearest earlier list view and lands there, so you return to the list you came from — with that entry's captured state (scroll position, etc.) restored. The skipped entries stay ahead in the stack, so `opt+]` still reaches them. A split that never passed through a list still falls back to the inbox.

- `History.backTo(predicate)` — jump to the nearest earlier matching entry without truncating forward history.
- `SplitHandle.goBackTo(predicate)` — the split-level wrapper (captures entry state, reattaches with a `history-back` cause, resets preview mode); returns `false` and navigates nowhere when nothing matches.
- The hotkey callback (`goHome` → `goToList`) tries `goBackTo` first, then falls back to the inbox. Its description and the Shortcuts settings entry now read "Back to list".

https://claude.ai/code/session_018xQ9txsWXQ4xR3CeYFn3Dj