### PR TITLE
fix(mobile): broken drawers

### DIFF
--- a/apps/web/src/components/app/split-layout/components/SplitFileMenu.tsx
+++ b/apps/web/src/components/app/split-layout/components/SplitFileMenu.tsx
@@ -278,7 +278,7 @@ function MobileRender(
           <MobileDrawer.Handle />
           {/* Scrolls when the sections outgrow the drawer's max height; the
               handle stays pinned so drag-to-dismiss remains reachable. */}
-          <div class="flex flex-col min-h-0 flex-1 overflow-y-auto">
+          <div class="flex flex-col min-h-0 flex-auto overflow-y-auto">
             <Show when={props.views}>
               {(views) => (
                 <>

--- a/apps/web/src/features/block-calendar/components/SelectedEventDetails.tsx
+++ b/apps/web/src/features/block-calendar/components/SelectedEventDetails.tsx
@@ -193,7 +193,7 @@ function EventDetailsDrawer(props: EventDetailsOverlayProps) {
               </Show>
             </div>
           </div>
-          <div class="flex min-h-0 flex-1 flex-col overflow-y-auto">
+          <div class="flex min-h-0 flex-auto flex-col overflow-y-auto">
             <div class="px-3">
               <EventDetails
                 event={props.event}

--- a/apps/web/src/features/next-soup/soup-view/SoupEntityActionDrawer.tsx
+++ b/apps/web/src/features/next-soup/soup-view/SoupEntityActionDrawer.tsx
@@ -65,7 +65,7 @@ export function SoupEntityActionDrawer() {
 
           {/* Action groups. Scrolls when the groups outgrow the drawer's max
               height; the handle and entity preview stay pinned. */}
-          <div class="flex flex-col min-h-0 flex-1 overflow-y-auto">
+          <div class="flex flex-col min-h-0 flex-auto overflow-y-auto">
             <For each={groups()}>
               {(group, groupIndex) => (
                 <>


### PR DESCRIPTION
In #5751 we made the mobile drawers scrollable, with their sizing set by `flex-1`. This caused them to collapse to their minimum height. They instead needed `flex-auto`. This is a quick fix, we will be making this less fragile in a separate PR. 