### PR TITLE
feat(block-agent): harness-reported model selector in the composer

### DIFF
--- a/apps/web/src/features/block-agent/component/AgentComposer.tsx
+++ b/apps/web/src/features/block-agent/component/AgentComposer.tsx
@@ -6,10 +6,10 @@
  */
 
 import { useAgentSession } from '../context/AgentSessionContext';
-import { AgentInput, QueuedPromptList } from '../ui';
+import { AgentInput, AgentModelSelector, QueuedPromptList } from '../ui';
 
 export function AgentComposer() {
-  const { composer, loadFailed } = useAgentSession();
+  const { composer, loadFailed, metadata } = useAgentSession();
 
   return (
     <>
@@ -26,6 +26,14 @@ export function AgentComposer() {
         disabled={loadFailed()}
         onSend={composer.send}
         onStop={composer.stop}
+        modelControl={
+          <AgentModelSelector
+            model={metadata()?.model ?? null}
+            options={metadata()?.supportedModels ?? []}
+            disabled={loadFailed()}
+            onSelect={composer.setModel}
+          />
+        }
       />
     </>
   );

--- a/apps/web/src/features/block-agent/context/create-composer-controller.ts
+++ b/apps/web/src/features/block-agent/context/create-composer-controller.ts
@@ -40,6 +40,8 @@ export type ComposerController = {
   /** Drop a queued prompt. Dropping the failed head clears the failure. */
   remove: (promptId: string) => void;
   stop: () => void;
+  /** Ask the agent to run on a different model from here on. */
+  setModel: (model: string) => void;
 };
 
 /**
@@ -80,6 +82,17 @@ export function createComposerController(options: {
       setState('queue', (queue) => queue.filter((p) => p.id !== prompt.id));
       setState('post', { type: 'awaiting_turn', promptId: prompt.id });
     });
+  };
+
+  const postSetModel = async (model: string) => {
+    const result = await agentHarnessServiceClient
+      .control(options.sessionId(), { type: 'setModel', model })
+      .catch(() => undefined);
+    if (result === undefined || result.isErr()) {
+      toast.failure('The model could not be changed');
+    }
+    // Success is observed through the fold: the runtime acks the config
+    // change and the session metadata's `model` moves.
   };
 
   const postStop = async () => {
@@ -165,6 +178,9 @@ export function createComposerController(options: {
     stop: () => {
       if (!isBusy(state.post, options.working())) return;
       void postStop();
+    },
+    setModel: (model) => {
+      void postSetModel(model);
     },
   };
 }

--- a/apps/web/src/features/block-agent/ui/AgentInput.tsx
+++ b/apps/web/src/features/block-agent/ui/AgentInput.tsx
@@ -2,14 +2,15 @@
  * The agent block's composer: the chat input's look and its markdown editing
  * surface (`MarkdownShell` over a lean `EditorConfigBuilder`), without the
  * rest of `ChatInput`'s machinery — no mentions, attachments, upload queue,
- * model plumbing, or contexts. Visual chrome mirrors
+ * or contexts; model plumbing arrives through the `modelControl` slot. Visual
+ * chrome mirrors
  * `@core/component/AI/component/input/ChatInput.tsx`.
  */
 
 import { buildConfig } from '@core/component/LexicalMarkdown/builder/MarkdownConfigBuilder';
 import { MarkdownShell } from '@core/component/LexicalMarkdown/builder/MarkdownShell';
 import { Button, SendButton, Surface } from '@ui';
-import { createSignal, Show } from 'solid-js';
+import { createSignal, type JSX, Show } from 'solid-js';
 
 export interface AgentInputProps {
   placeholder?: string;
@@ -20,6 +21,8 @@ export interface AgentInputProps {
   /** Receives the composed markdown. */
   onSend: (markdown: string) => void;
   onStop?: () => void;
+  /** Rendered in a bar under the text, e.g. the session's model selector. */
+  modelControl?: JSX.Element;
 }
 
 /** Past this height the controls drop below the text instead of overlaying it. */
@@ -104,6 +107,9 @@ export function AgentInput(props: AgentInputProps) {
           </Show>
         </div>
       </div>
+      <Show when={props.modelControl}>
+        <div class="flex items-center px-2 pb-1.5">{props.modelControl}</div>
+      </Show>
     </Surface>
   );
 }

--- a/apps/web/src/features/block-agent/ui/AgentModelSelector.tsx
+++ b/apps/web/src/features/block-agent/ui/AgentModelSelector.tsx
@@ -1,0 +1,66 @@
+/**
+ * The session's model, as a pill that opens the harness's own model list.
+ *
+ * Everything here is harness-reported: the options come from the runtime's
+ * ACP `configOptions` and the current model is the fold's rejection-safe
+ * projection of them, so this component never needs a model registry of its
+ * own. Renders nothing until the harness has advertised its models.
+ */
+
+import CaretDown from '@phosphor-icons/core/regular/caret-down.svg?component-solid';
+import type { ModelOption } from '@service-agent-fold/generated/types';
+import { cn, Dropdown } from '@ui';
+import { For, Show } from 'solid-js';
+
+export interface AgentModelSelectorProps {
+  /** Current model id, when the fold has learned it. */
+  model: string | null;
+  /** The models the harness offers, in the order it listed them. */
+  options: ModelOption[];
+  disabled?: boolean;
+  /** Receives the id of the model to switch to. */
+  onSelect: (model: string) => void;
+}
+
+export function AgentModelSelector(props: AgentModelSelectorProps) {
+  const label = () =>
+    props.options.find((option) => option.id === props.model)?.name ??
+    props.model ??
+    'Model';
+
+  return (
+    <Show when={props.options.length > 0}>
+      <Dropdown placement="top-start">
+        <Dropdown.Trigger
+          variant="ghost"
+          size="sm"
+          class="gap-1.5 rounded-lg text-xs text-ink-muted"
+          disabled={props.disabled}
+        >
+          {label()}
+          <CaretDown />
+        </Dropdown.Trigger>
+        <Dropdown.Content>
+          <Dropdown.Group>
+            <For each={props.options}>
+              {(option) => (
+                <Dropdown.Item
+                  class={cn(
+                    'gap-2',
+                    option.id === props.model && 'text-ink font-medium'
+                  )}
+                  title={option.description ?? undefined}
+                  onSelect={() => {
+                    if (option.id !== props.model) props.onSelect(option.id);
+                  }}
+                >
+                  <span class="flex-1 truncate text-xs">{option.name}</span>
+                </Dropdown.Item>
+              )}
+            </For>
+          </Dropdown.Group>
+        </Dropdown.Content>
+      </Dropdown>
+    </Show>
+  );
+}

--- a/apps/web/src/features/block-agent/ui/index.ts
+++ b/apps/web/src/features/block-agent/ui/index.ts
@@ -7,6 +7,7 @@
  */
 
 export { AgentInput, type AgentInputProps } from './AgentInput';
+export { AgentModelSelector } from './AgentModelSelector';
 export { AnimatedNumber } from './AnimatedNumber';
 export { type CountItem, CountSummary } from './CountSummary';
 export { DiffChanges, type DiffChangesProps } from './DiffChanges';


### PR DESCRIPTION
Renders the harness's own ACP-advertised model list (already projected into the fold's SessionMetadata) as a selector in the agent composer and switches models via the existing setModel control action.