### PR TITLE
feat(reminders): create a reminder about nothing

### DIFF
--- a/apps/web/src/components/app/GlobalHotkeys.tsx
+++ b/apps/web/src/components/app/GlobalHotkeys.tsx
@@ -198,12 +198,15 @@ export default function GlobalShortcuts() {
       description: item.description,
       condition: () =>
         (item.condition?.() ?? true) &&
+        (item.enabled?.() ?? true) &&
         (item.blockName !== 'snippet' || snippetsFlag().enabled),
       keyDownHandler: item.keyDownHandler,
       icon: Plus,
       tags: item.tags,
       keywords: item.keywords,
-      hide: () => item.blockName === 'snippet' && !snippetsFlag().enabled,
+      hide: () =>
+        !(item.enabled?.() ?? true) ||
+        (item.blockName === 'snippet' && !snippetsFlag().enabled),
       runWithInputFocused: true,
     });
   });

--- a/apps/web/src/features/command/Launcher.tsx
+++ b/apps/web/src/features/command/Launcher.tsx
@@ -1,3 +1,4 @@
+import { openStandaloneReminderComposer } from '@app/features/reminders/reminder-composer';
 import { useFeatureFlag } from '@app/lib/analytics/posthog';
 import { setAutomationComposerOpen } from '@block-automation/component';
 import { EMAIL_COMPOSE_TO_INPUT_ID } from '@block-email/constants';
@@ -13,6 +14,9 @@ import { CHAT_INPUT_TEXT_AREA_ID } from '@core/component/AI/component/input/Chat
 import { getIconConfig } from '@core/component/EntityIcon';
 import {
   ENABLE_ANIMATED_ICONS,
+  ENABLE_REMINDERS,
+  ENABLE_REMINDERS_FLAG,
+  ENABLE_REMINDERS_OVERRIDE,
   ENABLE_SNIPPETS_FLAG,
   ENABLE_SNIPPETS_OVERRIDE,
 } from '@core/constant/featureFlags';
@@ -59,6 +63,7 @@ import WideTask from '@icon/wide-task.svg';
 import { Dialog } from '@kobalte/core/dialog';
 import { getMarkdownGoldenBytes } from '@macro-inc/lexical-core/markdown-golden';
 import type { Span } from '@macro-inc/observability';
+import BellSimpleIcon from '@phosphor/bell-simple.svg';
 import MagnifyingGlassIcon from '@phosphor/magnifying-glass.svg';
 import PlusIcon from '@phosphor/plus.svg';
 import { createProject } from '@queries/storage/projects';
@@ -85,7 +90,7 @@ import {
 } from 'solid-js';
 import { createStore } from 'solid-js/store';
 import { Dynamic } from 'solid-js/web';
-import type { CreatableBlock } from './types';
+import type { CreatableBlock, CreatableName } from './types';
 
 const LAUNCHER_FRECENCY_STORE = 'launcher-frecency-v1';
 const LAUNCHER_SEARCH_MODE_STORE = 'launcher-search-mode-v1';
@@ -253,7 +258,7 @@ const createComponent = async (spec: {
 };
 
 export function runCreateAction(
-  blockName: BlockName | BlockAlias,
+  blockName: CreatableName,
   options: { shouldInsert?: boolean; source?: string } = {}
 ) {
   const shouldInsert = options.shouldInsert ?? false;
@@ -398,10 +403,17 @@ export function runCreateAction(
         asPopover: true,
       });
       return;
+    // A reminder has no block to open: the composer asks what and when, and the
+    // reminder lives in the Reminders lists from there.
+    case 'reminder':
+      if (!ENABLE_REMINDERS()) return;
+      setCreateMenuOpen(false, false);
+      openStandaloneReminderComposer();
+      return;
   }
 }
 
-export type { CreatableBlock } from './types';
+export type { CreatableBlock, CreatableName } from './types';
 
 export const CREATABLE_BLOCKS: CreatableBlock[] = [
   {
@@ -490,6 +502,23 @@ export const CREATABLE_BLOCKS: CreatableBlock[] = [
     hotkey: 't' as const,
     keyDownHandler: () => {
       runCreateAction('task');
+      return true;
+    },
+  },
+  {
+    label: 'Reminder',
+    icon: BellSimpleIcon,
+    description: 'Create reminder',
+    launcherHint: 'Nudge yourself later',
+    keywords: ['new', 'make', 'add', 'remind', 'later', 'todo'],
+    blockName: 'reminder',
+    hotkeyToken: TOKENS.create.reminder,
+    // No `altHotkeyToken`: a reminder opens no split, so there is no
+    // shift-variant to bind.
+    hotkey: 'r',
+    enabled: () => ENABLE_REMINDERS(),
+    keyDownHandler: () => {
+      runCreateAction('reminder');
       return true;
     },
   },
@@ -603,11 +632,20 @@ export function useCreateMenuBlocks(
   const snippetsFlag = useFeatureFlag(ENABLE_SNIPPETS_FLAG, {
     enabledOverride: ENABLE_SNIPPETS_OVERRIDE,
   });
-  return createMemo(() =>
-    source().filter(
-      (block) => block.blockName !== 'snippet' || snippetsFlag().enabled
-    )
-  );
+  // Subscribed to rather than left to the block's own `enabled`, which reads
+  // PostHog without tracking it: this memo has no other reason to re-run, so a
+  // flag that resolves after mount would leave the menu as it was until reload.
+  const remindersFlag = useFeatureFlag(ENABLE_REMINDERS_FLAG, {
+    enabledOverride: ENABLE_REMINDERS_OVERRIDE,
+  });
+  return createMemo(() => {
+    remindersFlag();
+    return source().filter(
+      (block) =>
+        (block.blockName !== 'snippet' || snippetsFlag().enabled) &&
+        (block.enabled?.() ?? true)
+    );
+  });
 }
 
 export const [createMenuOpen, setCreateMenuOpen] = createControlledOpenSignal(

--- a/apps/web/src/features/command/Launcher.tsx
+++ b/apps/web/src/features/command/Launcher.tsx
@@ -648,6 +648,25 @@ export function useCreateMenuBlocks(
   });
 }
 
+/**
+ * Whether one creatable is on offer right now, tracked reactively.
+ *
+ * For the surfaces that offer a single creatable by name rather than rendering
+ * the whole list — an empty state's button, a list view's `+`. Answered from
+ * {@link useCreateMenuBlocks} so there is one gate rather than a copy of it per
+ * surface, and so a flag that resolves after mount reaches these too: a gated
+ * entry left to its own `enabled` reads PostHog without tracking it, which
+ * strands the answer the surface first happened to get.
+ *
+ * A name that is not a creatable-block entry at all is not "disabled" — it is
+ * not this gate's business, and callers reaching for a view-only label handle
+ * it themselves.
+ */
+export function useCreatableEnabled(): (name: CreatableName) => boolean {
+  const blocks = useCreateMenuBlocks();
+  return (name) => blocks().some((block) => block.blockName === name);
+}
+
 export const [createMenuOpen, setCreateMenuOpen] = createControlledOpenSignal(
   false,
   { id: 'launcher' }

--- a/apps/web/src/features/command/types.ts
+++ b/apps/web/src/features/command/types.ts
@@ -3,12 +3,31 @@ import type { HotkeyToken } from '@core/hotkey/tokens';
 import type { HotkeyRegistrationOptions } from '@core/hotkey/types';
 import type { Component } from 'solid-js';
 
+/**
+ * What a create-menu entry makes.
+ *
+ * Every block, plus the things the menu can create that have no block of their
+ * own. A reminder is one: it is not a document type, it opens no split, and
+ * `EntityIcon` already knows the name — which is why it is a member here rather
+ * than in `BlockAliasRegistry`, where it would leak into `fileTypeToBlockName`,
+ * split content types and `NonDocumentBlockTypes`.
+ */
+export type CreatableName = BlockName | BlockAlias | 'reminder';
+
 export type CreatableBlock = Omit<HotkeyRegistrationOptions, 'scopeId'> & {
   label: string;
   launcherHint?: string;
-  blockName: BlockName | BlockAlias;
+  blockName: CreatableName;
   altHotkeyToken?: HotkeyToken;
   animatedIcon?: Component<{ triggerAnimation?: boolean }>;
+  /**
+   * Whether the entry is available at all, for one behind a feature flag.
+   *
+   * Read by every surface that renders or binds these — `useCreateMenuBlocks`
+   * for the menus, `GlobalHotkeys` for the keys — so a gated entry cannot be
+   * shown in one and hidden in the other. Absent means always available.
+   */
+  enabled?: () => boolean;
 };
 
 export type CategoryFilter =

--- a/apps/web/src/features/next-soup/soup-view/empty-states.tsx
+++ b/apps/web/src/features/next-soup/soup-view/empty-states.tsx
@@ -1,8 +1,10 @@
 import { DOCS_BASE } from '@app/constants/docs-links';
 import type { ListView } from '@app/constants/list-views';
-import { runCreateAction } from '@app/features/command/Launcher';
+import {
+  type CreatableName,
+  runCreateAction,
+} from '@app/features/command/Launcher';
 import { openNewChannelModal } from '@channel/CreateChannelModal';
-import type { BlockAlias, BlockName } from '@core/block';
 import { useSettingsState } from '@core/constant/SettingsState';
 import { useAddInboxFlow, useEmailLinksStatus } from '@core/email-link';
 import EmptyStateAiGraphic from '@design/empty-state-ai.svg';
@@ -38,7 +40,7 @@ type FallbackContent = {
   plural: string;
   graphic?: Component<{ class?: string }>;
   description?: JSXElement;
-  create?: { label: string; blockName: BlockName | BlockAlias };
+  create?: { label: string; blockName: CreatableName };
   documentationUrl?: string;
 };
 
@@ -59,16 +61,16 @@ const FALLBACK_CONTENT: Partial<Record<ListView, FallbackContent>> = {
     create: { label: 'New channel', blockName: 'channel' },
     documentationUrl: `${DOCS_BASE}/product/channels`,
   },
-  // No `create`: a reminder is always set on something, from that thing's own
-  // menu — there is no standalone "new reminder" to offer here.
   reminders: {
     plural: 'reminders',
     description: (
       <>
         Set a reminder on anything in Macro by selecting it and pressing{' '}
-        <HotkeyCap>h</HotkeyCap>, or with the option in its right-click menu.
+        <HotkeyCap>h</HotkeyCap>, or write one about nothing in particular from
+        the Create menu.
       </>
     ),
+    create: { label: 'New reminder', blockName: 'reminder' },
   },
   calls: {
     plural: 'calls',
@@ -156,10 +158,14 @@ export function EmptyState(props: {
             <>
               Reminders you schedule wait here until they fire into Signal. Set
               one on anything in Macro by selecting it and pressing{' '}
-              <HotkeyCap>h</HotkeyCap>, or with the option in its right-click
-              menu.
+              <HotkeyCap>h</HotkeyCap>, or write one about nothing in
+              particular.
             </>
           }
+          primaryAction={{
+            label: 'New reminder',
+            onClick: () => runCreateAction('reminder'),
+          }}
           documentationUrl={`${DOCS_BASE}/product/inbox`}
         />
       </Match>

--- a/apps/web/src/features/next-soup/soup-view/empty-states.tsx
+++ b/apps/web/src/features/next-soup/soup-view/empty-states.tsx
@@ -3,6 +3,7 @@ import type { ListView } from '@app/constants/list-views';
 import {
   type CreatableName,
   runCreateAction,
+  useCreatableEnabled,
 } from '@app/features/command/Launcher';
 import { openNewChannelModal } from '@channel/CreateChannelModal';
 import { useSettingsState } from '@core/constant/SettingsState';
@@ -97,6 +98,7 @@ export function EmptyState(props: {
   const startAddInbox = useAddInboxFlow();
   const soup = useSoupView();
   const teamQuery = useCurrentTeamQuery();
+  const isCreatableEnabled = useCreatableEnabled();
   const isTeamAdmin = useIsTeamAdmin();
   const { openSettings } = useSettingsState();
 
@@ -162,10 +164,17 @@ export function EmptyState(props: {
               particular.
             </>
           }
-          primaryAction={{
-            label: 'New reminder',
-            onClick: () => runCreateAction('reminder'),
-          }}
+          // Gated like every other reminder affordance. The tab itself is
+          // already hidden when the flag is off, so this is belt and braces
+          // rather than the only thing standing in the way.
+          primaryAction={
+            isCreatableEnabled('reminder')
+              ? {
+                  label: 'New reminder',
+                  onClick: () => runCreateAction('reminder'),
+                }
+              : undefined
+          }
           documentationUrl={`${DOCS_BASE}/product/inbox`}
         />
       </Match>
@@ -393,26 +402,32 @@ export function EmptyState(props: {
             FALLBACK_CONTENT[props.listView]) ?? {
             plural: 'items',
           };
+          // A gated creatable is not offered here either. Nothing else stops
+          // this button: a view can be reachable while the thing it creates is
+          // flagged off, and `runCreateAction` would then decline the click.
+          const createAction = () => {
+            const create = fallback.create;
+            if (!create || !isCreatableEnabled(create.blockName)) {
+              return undefined;
+            }
+            return {
+              label: create.label,
+              icon: PlusIcon,
+              onClick: () => {
+                if (props.listView === 'channels') {
+                  openNewChannelModal();
+                  return;
+                }
+                runCreateAction(create.blockName);
+              },
+            };
+          };
           return (
             <EmptyStatePanel
               graphic={fallback.graphic ?? EmptyStateInboxZeroGraphic}
               title={`No ${fallback.plural} to show`}
               description={fallback.description}
-              primaryAction={
-                fallback.create
-                  ? {
-                      label: fallback.create.label,
-                      icon: PlusIcon,
-                      onClick: () => {
-                        if (props.listView === 'channels') {
-                          openNewChannelModal();
-                          return;
-                        }
-                        runCreateAction(fallback.create!.blockName);
-                      },
-                    }
-                  : undefined
-              }
+              primaryAction={createAction()}
               documentationUrl={fallback.documentationUrl}
             />
           );

--- a/apps/web/src/features/next-soup/soup-view/soup-view-create-button.tsx
+++ b/apps/web/src/features/next-soup/soup-view/soup-view-create-button.tsx
@@ -1,6 +1,7 @@
 import { isListViewID, type ListView } from '@app/constants/list-views';
 import {
   CREATABLE_BLOCKS,
+  type CreatableName,
   runCreateAction,
 } from '@app/features/command/Launcher';
 import { openCreateCompanyModal } from '@app/features/companies/CreateCompanyModal';
@@ -8,7 +9,7 @@ import { useHandleFileUpload } from '@app/util/handleFileUpload';
 import { openNewChannelModal } from '@channel/CreateChannelModal';
 import { CollapsibleHeaderItem } from '@components/app/split-layout/components/CollapsibleItem';
 import { useSplitPanelOrThrow } from '@components/app/split-layout/layoutUtils';
-import type { BlockAlias, BlockName } from '@core/block';
+import type { BlockName } from '@core/block';
 import { EntityIcon } from '@core/component/EntityIcon';
 import {
   handleFolderSelect,
@@ -24,24 +25,18 @@ import { createMemo, For, Show } from 'solid-js';
 import { NewCallButton } from './NewCallButton';
 
 // Which blocks to show as create options per view, in order
-const VIEW_CREATE_BLOCKNAMES: Partial<
-  Record<ListView, (BlockName | BlockAlias)[]>
-> = {
+const VIEW_CREATE_BLOCKNAMES: Partial<Record<ListView, CreatableName[]>> = {
   documents: ['md', 'snippet', 'canvas', 'code', 'project'],
   tasks: ['task'],
   agents: ['chat', 'automation', 'skill'],
   mail: ['email'],
   channels: ['channel'],
   folders: ['project'],
+  reminders: ['reminder'],
 };
 
 type CreateOption = {
-  id:
-    | BlockName
-    | BlockAlias
-    | 'import-file'
-    | 'import-folder'
-    | 'create-company';
+  id: CreatableName | 'import-file' | 'import-folder' | 'create-company';
   label: string;
 };
 
@@ -65,10 +60,9 @@ const CREATE_COMPANY_OPTION: CreateOption = {
  * (and thus aren't in CREATABLE_BLOCKS) but still need a create entry in
  * specific list views.
  */
-const VIEW_ONLY_BLOCK_LABELS: Partial<Record<BlockName | BlockAlias, string>> =
-  {
-    automation: 'Automation',
-  };
+const VIEW_ONLY_BLOCK_LABELS: Partial<Record<CreatableName, string>> = {
+  automation: 'Automation',
+};
 
 const VIEW_CREATE_LABELS: Partial<Record<ListView, string>> = {
   agents: 'Agent',
@@ -77,6 +71,7 @@ const VIEW_CREATE_LABELS: Partial<Record<ListView, string>> = {
   documents: 'New',
   folders: 'Folder',
   mail: 'Email',
+  reminders: 'Reminder',
   tasks: 'Task',
 };
 
@@ -84,7 +79,12 @@ function getViewCreateOptions(view: ListView): CreateOption[] {
   const createNames = VIEW_CREATE_BLOCKNAMES[view] ?? [];
   const options: CreateOption[] = createNames.flatMap((name) => {
     const block = CREATABLE_BLOCKS.find((b) => b.blockName === name);
-    if (block) return [{ id: block.blockName, label: block.label }];
+    if (block) {
+      // A flagged-off entry is not offered here either, the same as in the
+      // create menus — `runCreateAction` would decline it anyway.
+      if (block.enabled?.() === false) return [];
+      return [{ id: block.blockName, label: block.label }];
+    }
     const viewOnlyLabel = VIEW_ONLY_BLOCK_LABELS[name];
     if (viewOnlyLabel) return [{ id: name, label: viewOnlyLabel }];
     return [];

--- a/apps/web/src/features/next-soup/soup-view/soup-view-create-button.tsx
+++ b/apps/web/src/features/next-soup/soup-view/soup-view-create-button.tsx
@@ -3,6 +3,7 @@ import {
   CREATABLE_BLOCKS,
   type CreatableName,
   runCreateAction,
+  useCreatableEnabled,
 } from '@app/features/command/Launcher';
 import { openCreateCompanyModal } from '@app/features/companies/CreateCompanyModal';
 import { useHandleFileUpload } from '@app/util/handleFileUpload';
@@ -75,14 +76,18 @@ const VIEW_CREATE_LABELS: Partial<Record<ListView, string>> = {
   tasks: 'Task',
 };
 
-function getViewCreateOptions(view: ListView): CreateOption[] {
+function getViewCreateOptions(
+  view: ListView,
+  isCreatableEnabled: (name: CreatableName) => boolean
+): CreateOption[] {
   const createNames = VIEW_CREATE_BLOCKNAMES[view] ?? [];
   const options: CreateOption[] = createNames.flatMap((name) => {
     const block = CREATABLE_BLOCKS.find((b) => b.blockName === name);
     if (block) {
       // A flagged-off entry is not offered here either, the same as in the
-      // create menus — `runCreateAction` would decline it anyway.
-      if (block.enabled?.() === false) return [];
+      // create menus — `runCreateAction` would decline it anyway. Asked
+      // reactively, so an option appears once its flag resolves.
+      if (!isCreatableEnabled(block.blockName)) return [];
       return [{ id: block.blockName, label: block.label }];
     }
     const viewOnlyLabel = VIEW_ONLY_BLOCK_LABELS[name];
@@ -125,6 +130,7 @@ function CreateOptionIcon(props: { id: CreateOption['id'] }) {
 export const SoupViewCreateButton = () => {
   const panel = useSplitPanelOrThrow();
   const handleFileUpload = useHandleFileUpload();
+  const isCreatableEnabled = useCreatableEnabled();
 
   const currentView = createMemo(() => {
     const content = panel.handle.content();
@@ -135,7 +141,7 @@ export const SoupViewCreateButton = () => {
   const options = createMemo<CreateOption[]>(() => {
     const view = currentView();
     if (!view) return [];
-    return getViewCreateOptions(view);
+    return getViewCreateOptions(view, isCreatableEnabled);
   });
   const createLabel = createMemo(() => {
     const view = currentView();

--- a/apps/web/src/features/reminders/ReminderComposerModal.tsx
+++ b/apps/web/src/features/reminders/ReminderComposerModal.tsx
@@ -77,6 +77,7 @@ import {
   repeatPartsFromSchedule,
   resolveEditedDescription,
   resolveReminderDescription,
+  resolveStandaloneDescription,
 } from './reminder-schedule';
 
 /** The composer's questions, asked in this order. */
@@ -137,6 +138,17 @@ export function ReminderComposerModal() {
 
   const entity = () => reminderComposerState.entity;
   const editing = () => reminderComposerState.editing;
+  const standalone = () => reminderComposerState.standalone === true;
+
+  /**
+   * The description as it would be stored, for a reminder about nothing.
+   *
+   * `undefined` means the field has nothing usable in it, which is what both
+   * the step's gate and its submit read — one answer, so a description of
+   * spaces cannot pass one and fail the other.
+   */
+  const standaloneDescription = () =>
+    resolveStandaloneDescription(description());
 
   /**
    * Escape steps back to the description before it closes the composer,
@@ -204,7 +216,21 @@ export function ReminderComposerModal() {
     })
   );
 
-  const advanceFromDescription = () => setStep('when');
+  /**
+   * Whether the description step has been answered well enough to leave.
+   *
+   * Only a standalone reminder can fail this. Everywhere else the field is
+   * optional because there is an entity to name the reminder after, so an
+   * empty one is an answer; with nothing to fall back on it is not, and the API
+   * rejects it.
+   */
+  const canAdvanceFromDescription = () =>
+    !standalone() || standaloneDescription() !== undefined;
+
+  const advanceFromDescription = () => {
+    if (!canAdvanceFromDescription()) return;
+    setStep('when');
+  };
 
   // The dialog's Enter binding is a single shared slot, so whichever step is on
   // screen has to claim it or the other step's stale handler stays live. The
@@ -249,6 +275,38 @@ export function ReminderComposerModal() {
     await onCreated?.();
   };
 
+  /**
+   * Create a reminder attached to nothing.
+   *
+   * Sends no entity at all rather than an empty one — the API rejects an
+   * `entityType` without an `entityId` — and the description is whatever was
+   * typed, since there is nothing to derive one from.
+   */
+  const submitStandalone = async (schedule: ReminderSchedule) => {
+    const resolved = standaloneDescription();
+    // Unreachable: the date step cannot be reached without a description. Kept
+    // as the last word on it rather than a `!` on the value above.
+    if (!resolved) {
+      setStep('description');
+      return;
+    }
+
+    // Taken before the close, which clears it. Nothing passes one today, but
+    // taking it is what keeps a handler from leaking into the next open.
+    const onCreated = takeReminderCreatedHandler();
+    closeReminderComposer();
+
+    try {
+      await createReminder.mutateAsync({ description: resolved, schedule });
+      toast.success('Reminder set');
+    } catch {
+      toast.failure('Failed to create reminder');
+      return;
+    }
+
+    await onCreated?.();
+  };
+
   const submitEdit = async (
     schedule: ReminderSchedule,
     draft: ReminderDraft
@@ -284,6 +342,8 @@ export function ReminderComposerModal() {
 
     const target = entity();
     if (target) return await submitCreate(schedule, target);
+
+    if (standalone()) return await submitStandalone(schedule);
   };
 
   const submit = async (date: Date) => {
@@ -327,11 +387,13 @@ export function ReminderComposerModal() {
    * dialog animates shut — otherwise the reset back to the description step
    * would be visible as the date list flicking back to a Continue button.
    */
-  const hasTarget = () => entity() !== undefined || editing() !== undefined;
+  const hasTarget = () =>
+    entity() !== undefined || editing() !== undefined || standalone();
 
   // The chip row carries the entity a new reminder is about, and — on the date
-  // step — the description typed so far as a way back to it. Editing has no
-  // entity, so the row is only there once something has been typed.
+  // step — the description typed so far as a way back to it. Editing and
+  // standalone have no entity, so the row is only there once something has been
+  // typed.
   const showsToolbar = () =>
     entity() !== undefined ||
     (step() !== 'description' && !!description().trim());
@@ -360,7 +422,12 @@ export function ReminderComposerModal() {
                 placeholder={
                   editing()
                     ? 'Reminder description'
-                    : "What's the reminder? (optional)"
+                    : // Not optional for a standalone reminder: there is no
+                      // entity to name it after, so this is all it will ever
+                      // say.
+                      standalone()
+                      ? "What's the reminder?"
+                      : "What's the reminder? (optional)"
                 }
                 value={description()}
                 onInput={setDescription}
@@ -412,7 +479,12 @@ export function ReminderComposerModal() {
           </Show>
           <Switch>
             <Match when={step() === 'description'}>
-              <DescriptionStep onContinue={advanceFromDescription} />
+              <DescriptionStep
+                onContinue={advanceFromDescription}
+                // An affordance, not the check: `advanceFromDescription` holds
+                // the gate for every way through this step.
+                disabled={!canAdvanceFromDescription()}
+              />
             </Match>
             <Match when={step() === 'when'}>
               <CommandMenuShell.Body>
@@ -525,8 +597,14 @@ function StepInput(props: {
  * pre-filled, so skipping stays a single keystroke instead of a select-all and
  * delete. When editing it necessarily is pre-filled — clearing it back out asks
  * for that same fallback.
+ *
+ * Not optional for a standalone reminder, which has no fallback: `disabled`
+ * says so, and the caller's gate is what enforces it.
  */
-function DescriptionStep(props: { onContinue: VoidFunction }) {
+function DescriptionStep(props: {
+  onContinue: VoidFunction;
+  disabled?: boolean;
+}) {
   return (
     <CommandMenuShell.Footer class="gap-2 border-t-0 py-3">
       <CommandMenuHotkeyHint
@@ -538,6 +616,7 @@ function DescriptionStep(props: { onContinue: VoidFunction }) {
         size="sm"
         depth={3}
         class="ml-auto gap-3 rounded-lg border-0"
+        disabled={props.disabled}
         onClick={props.onContinue}
       >
         Continue

--- a/apps/web/src/features/reminders/reminder-composer.test.ts
+++ b/apps/web/src/features/reminders/reminder-composer.test.ts
@@ -5,6 +5,7 @@ import {
   closeReminderComposer,
   openReminderComposer,
   openReminderEditor,
+  openStandaloneReminderComposer,
   reminderComposerOpen,
   reminderComposerState,
   takeReminderCreatedHandler,
@@ -110,6 +111,65 @@ describe('reminder composer edit mode', () => {
 
     expect(reminderComposerState.editing?.id).toBe('rem-2');
     expect(reminderComposerState.editing?.description).toBe('Send the invoice');
+  });
+});
+
+describe('reminder composer standalone mode', () => {
+  beforeEach(() => {
+    closeReminderComposer();
+  });
+
+  // The flag is what the modal reads to know it is composing at all: with no
+  // entity and no draft, a closed composer and a standalone one look alike.
+  it('opens with no target of any kind', () => {
+    openStandaloneReminderComposer();
+
+    expect(reminderComposerOpen()).toBe(true);
+    expect(reminderComposerState.standalone).toBe(true);
+    expect(reminderComposerState.entity).toBeUndefined();
+    expect(reminderComposerState.editing).toBeUndefined();
+  });
+
+  it('clears the flag on close', () => {
+    openStandaloneReminderComposer();
+    closeReminderComposer();
+
+    expect(reminderComposerOpen()).toBe(false);
+    expect(reminderComposerState.standalone).toBeUndefined();
+  });
+
+  // The three modes are exclusive. A leftover flag would make the modal treat
+  // an entity's reminder as being about nothing, and drop the attachment.
+  it('drops a create target when opened standalone', () => {
+    openReminderComposer(doc('doc-1', 'Q3 Contract'));
+    openStandaloneReminderComposer();
+
+    expect(reminderComposerState.entity).toBeUndefined();
+    expect(reminderComposerState.standalone).toBe(true);
+  });
+
+  it('drops an edit target when opened standalone', () => {
+    openReminderEditor(draft('rem-1', 'Chase the contract'));
+    openStandaloneReminderComposer();
+
+    expect(reminderComposerState.editing).toBeUndefined();
+    expect(reminderComposerState.standalone).toBe(true);
+  });
+
+  it('drops the standalone flag when opened for an entity', () => {
+    openStandaloneReminderComposer();
+    openReminderComposer(doc('doc-1', 'Q3 Contract'));
+
+    expect(reminderComposerState.standalone).toBeUndefined();
+    expect(reminderComposerState.entity?.id).toBe('doc-1');
+  });
+
+  it('drops the standalone flag when opened to edit', () => {
+    openStandaloneReminderComposer();
+    openReminderEditor(draft('rem-1', 'Chase the contract'));
+
+    expect(reminderComposerState.standalone).toBeUndefined();
+    expect(reminderComposerState.editing?.id).toBe('rem-1');
   });
 });
 

--- a/apps/web/src/features/reminders/reminder-composer.ts
+++ b/apps/web/src/features/reminders/reminder-composer.ts
@@ -46,6 +46,14 @@ interface ReminderComposerState {
   entity?: EntityData;
   /** The reminder being edited. Absent when creating. */
   editing?: ReminderDraft;
+  /**
+   * A new reminder about nothing at all.
+   *
+   * Its own flag rather than the absence of the other two: "no entity and no
+   * draft" is how a closed composer looks, so without this the modal cannot
+   * tell a standalone reminder from nothing to compose.
+   */
+  standalone?: boolean;
 }
 
 /** What the surface that opened the composer does once the reminder exists. */
@@ -74,6 +82,7 @@ export function takeReminderCreatedHandler():
 const [state, setState] = createStore<ReminderComposerState>({
   entity: undefined,
   editing: undefined,
+  standalone: undefined,
 });
 
 /**
@@ -91,7 +100,25 @@ export function openReminderComposer(
   // Batched so the modal's open-keyed effect sees this entity rather than the
   // previous one.
   batch(() => {
-    setState(reconcile({ entity, editing: undefined }));
+    setState(reconcile({ entity, editing: undefined, standalone: undefined }));
+    setReminderComposerOpen(true);
+  });
+}
+
+/**
+ * Open the composer to create a reminder about nothing.
+ *
+ * There is no entity to name it after, so the description step it opens on is
+ * the one thing it cannot skip — see `resolveStandaloneDescription`.
+ */
+export function openStandaloneReminderComposer(options?: {
+  onCreated?: ReminderCreatedHandler;
+}) {
+  createdHandler = options?.onCreated;
+  batch(() => {
+    setState(
+      reconcile({ entity: undefined, editing: undefined, standalone: true })
+    );
     setReminderComposerOpen(true);
   });
 }
@@ -106,7 +133,13 @@ export function openReminderComposer(
 export function openReminderEditor(reminder: ReminderDraft) {
   createdHandler = undefined;
   batch(() => {
-    setState(reconcile({ entity: undefined, editing: reminder }));
+    setState(
+      reconcile({
+        entity: undefined,
+        editing: reminder,
+        standalone: undefined,
+      })
+    );
     setReminderComposerOpen(true);
   });
 }
@@ -115,7 +148,13 @@ export function closeReminderComposer() {
   createdHandler = undefined;
   batch(() => {
     setReminderComposerOpen(false);
-    setState(reconcile({ entity: undefined, editing: undefined }));
+    setState(
+      reconcile({
+        entity: undefined,
+        editing: undefined,
+        standalone: undefined,
+      })
+    );
   });
 }
 

--- a/apps/web/src/features/reminders/reminder-schedule.test.ts
+++ b/apps/web/src/features/reminders/reminder-schedule.test.ts
@@ -20,6 +20,7 @@ import {
   repeatPartsFromSchedule,
   resolveEditedDescription,
   resolveReminderDescription,
+  resolveStandaloneDescription,
   sameSchedule,
 } from './reminder-schedule';
 
@@ -285,6 +286,35 @@ describe('resolveReminderDescription', () => {
     expect(resolveReminderDescription(atLimit, doc('Q3 Contract'))).toBe(
       atLimit
     );
+  });
+});
+
+describe('resolveStandaloneDescription', () => {
+  it('uses what the user typed', () => {
+    expect(resolveStandaloneDescription('Book a flight')).toBe('Book a flight');
+  });
+
+  it('trims what the user typed', () => {
+    expect(resolveStandaloneDescription('  Book a flight  ')).toBe(
+      'Book a flight'
+    );
+  });
+
+  // There is no entity to name this reminder after, so an empty field has no
+  // answer at all — which is also how the composer knows it cannot advance.
+  it('has no answer for an empty field', () => {
+    expect(resolveStandaloneDescription('')).toBeUndefined();
+  });
+
+  it('treats whitespace-only input as empty', () => {
+    expect(resolveStandaloneDescription('   \n\t ')).toBeUndefined();
+  });
+
+  it('truncates over-long input by character', () => {
+    const long = '🔔'.repeat(REMINDER_DESCRIPTION_MAX_LENGTH + 10);
+    const result = resolveStandaloneDescription(long);
+
+    expect([...(result ?? '')]).toHaveLength(REMINDER_DESCRIPTION_MAX_LENGTH);
   });
 });
 

--- a/apps/web/src/features/reminders/reminder-schedule.ts
+++ b/apps/web/src/features/reminders/reminder-schedule.ts
@@ -390,6 +390,22 @@ export function resolveReminderDescription(
 }
 
 /**
+ * What to store as a standalone reminder's description, or undefined when
+ * there is nothing usable to store.
+ *
+ * A reminder about nothing has no name to fall back on, so unlike every other
+ * description path this one can come back empty — which is also the answer to
+ * "may the composer move off the description step yet?". Both questions go
+ * through here so the step's gate and its submit cannot disagree about a
+ * description made only of spaces.
+ */
+export function resolveStandaloneDescription(
+  input: string
+): string | undefined {
+  return clampDescription(input) || undefined;
+}
+
+/**
  * The same entity-derived description, from a resolved name rather than a whole
  * entity.
  *

--- a/apps/web/src/lib/core/hotkey/tokens.ts
+++ b/apps/web/src/lib/core/hotkey/tokens.ts
@@ -280,6 +280,7 @@ export const TOKENS = {
     snippetNewSplit: 'create.snippetNewSplit',
     automation: 'create.automation',
     skill: 'create.skill',
+    reminder: 'create.reminder',
     close_menu: 'create.close_menu',
   },
 


### PR DESCRIPTION
## Why

Every reminder in Macro is *about* something: the only way to set one is to select an entity and press `h` (or use its right-click menu), and the composer takes an `EntityData` as its target. There was no way to write "book a flight" — a reminder that points at nothing and is just a note to yourself at a time.

The backend has always accepted one. `POST /reminders` treats `entityType`/`entityId` as optional and mints no access receipt without them, the DB constraint is both-or-neither, `SoupReminder.referenced_entity` is `Option`, and the AI tool already advertises standalone reminders ("standalone is for everything else"). This is the frontend catching up — no Rust, no migration, no API codegen.

## What

**A third composer mode.** `openStandaloneReminderComposer()` sits alongside create-about-entity and edit. It needs its own flag rather than being inferred: "no entity and no draft" is exactly what a *closed* composer looks like, so without one the modal cannot tell a standalone reminder from nothing to compose.

**The description step becomes mandatory in that mode.** It is optional everywhere else because the entity supplies a name when you skip it; with nothing to fall back on, an empty description is not an answer and the API rejects it. `resolveStandaloneDescription()` is the single source for both "may we leave this step?" and "what do we store?", so a description made only of spaces cannot pass one gate and fail the other. The Continue button's `disabled` is an affordance on top of that gate, not a second copy of it.

Recurring works unchanged — the repeat step never cared about the target — so "every weekday at 9am, water the plants" comes for free.

**`r` in the Create menu.** This needed a name for something that is not a block, so `CreatableName = BlockName | BlockAlias | 'reminder'` widens the create surfaces instead of adding an entry to `BlockAliasRegistry`, which would leak a reminder into `fileTypeToBlockName`, split content types and `NonDocumentBlockTypes`. `runCreateAction` gained a `'reminder'` case mirroring the existing `automation` one, and the entry reuses the `BellSimple` glyph reminder rows already carry.

**One gate for the feature flag.** New `CreatableBlock.enabled?: () => boolean`, read by both surfaces that act on these entries — the menus through `useCreateMenuBlocks`, and `GlobalHotkeys`, which registers their hotkeys directly and bypasses the hook. Without the second one, `r` would stay live in the create scope with the flag off. `useCreateMenuBlocks` also subscribes to the reactive flag, since its memo has no other reason to re-run and a PostHog answer that arrives after mount would otherwise leave the menu as it was until reload.

**Create affordances where reminders live**: "New reminder" on both reminder empty states, and `+ Reminder` on the `/reminders` view.

## Notes

- **Activating a standalone row still does nothing.** It has no block to open, and that is deliberate: editing goes through `r` on the focused row or its "Edit reminder" menu item, both of which already work on a row with no reference. Clicking still focuses the row and marks its notification seen, as it did before.
- `r` in the create scope does not collide with soup's `r` (rename / edit reminder) or the sidebar's `r` (go to Calendar) — different scopes.
- Not optimistic on create: `nextRunAt` is derived server-side from the schedule, so the existing `refetchSoupEntity(id, 'reminder')` is what brings the new row into Soup, and it is already entity-agnostic.
