### PR TITLE
fix(markdown): add fallback error message guard in getErrorDescription

### DIFF
--- a/apps/web/src/lib/core/component/LexicalMarkdown/constants.ts
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/constants.ts
@@ -37,5 +37,8 @@ const MarkdownEditorErrorDescriptions: Record<
 export const getErrorDescription = (
   errorType: MarkdownEditorErrors
 ): string => {
-  return MarkdownEditorErrorDescriptions[errorType]();
+  return (
+    MarkdownEditorErrorDescriptions[errorType]?.() ??
+    'An error occurred while opening the document.'
+  );
 };


### PR DESCRIPTION
When evaluating getErrorDescription in LexicalMarkdown/constants.ts, indexing MarkdownEditorErrorDescriptions with an unmapped errorType returned undefined, throwing an unhandled TypeError upon invocation. Added optional chaining and a fallback error description.