### PR TITLE
fix(agent_harness): embed ensure_ready.sh in nix deploy sources

### DIFF
--- a/crates/agent_harness/src/outbound/provision.rs
+++ b/crates/agent_harness/src/outbound/provision.rs
@@ -15,7 +15,8 @@ pub const SIDECAR_LOG: &str = "/tmp/acp-sidecar.log";
 pub const SIDECAR_PORT: u16 = 8700;
 
 /// Readiness recipe baked alongside the harness container.
-const ENSURE_READY_SCRIPT: &str = include_str!("../../container/ensure_ready.sh");
+const ENSURE_READY_SCRIPT: &str =
+    include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/container/ensure_ready.sh"));
 
 /// Wrap the readiness recipe as one command for provider exec APIs.
 #[must_use]

--- a/nix/cloud-storage.nix
+++ b/nix/cloud-storage.nix
@@ -53,7 +53,9 @@
       # Include Cargo sources plus the .sqlx offline query cache.
       sqlxFilter = path: _type: builtins.match ".*\\.sqlx/.*\\.json$" path != null;
       pdfiumFilter = path: _type: builtins.match ".*pdfium-lib/.*\\.(so|dylib)$" path != null;
-      assetFilter = path: _type: builtins.match ".*\\.(md|html|txt|json|canvas|sql)$" path != null;
+      # `.sh` is required so `include_str!` of
+      # `crates/agent_harness/container/ensure_ready.sh` survives the prune.
+      assetFilter = path: _type: builtins.match ".*\\.(md|html|txt|json|canvas|sql|sh)$" path != null;
       binFilter = path: _type: builtins.match ".*\\.bin$" path != null;
       srcFilter =
         path: type:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The `cloud-storage-agent-harness-service-binaries` derivation failed compiling `agent_harness` because Crane's source filter dropped `.sh` files. `provision.rs` embeds `crates/agent_harness/container/ensure_ready.sh` via `include_str!`, so the file was missing from the pruned deploy tree.

## Changes
- Include `.sh` in the Nix `assetFilter` so the readiness script survives source pruning
- Resolve the script from `CARGO_MANIFEST_DIR` instead of a path relative to `provision.rs`

## Test plan
- Not run (requested no validation)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0928dcec-cbb3-4347-b2a4-32e58eab7841?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0928dcec-cbb3-4347-b2a4-32e58eab7841&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

