### PR TITLE
fix(run-local): frontend startup fails silently on cold node_modules/wasm cache

### DIFF
--- a/tooling/xtask/crates/xtask_local/src/local/frontend.rs
+++ b/tooling/xtask/crates/xtask_local/src/local/frontend.rs
@@ -235,6 +235,15 @@ pub fn start(
              previous run. Free it (`lsof -ti tcp:{port} | xargs kill`) and retry."
         );
     }
+    // Without node_modules, `bun run dev` never binds the port and never exits
+    // within the poll window below — it just times out with an opaque "did not
+    // become ready", giving no hint that a dependency install is missing.
+    if !app_dir().join("node_modules").exists() {
+        anyhow::bail!(
+            "{}/node_modules is missing — run `bun install` from the repo root first.",
+            app_dir().display()
+        );
+    }
     let mut cmd = Command::new("bun");
     cmd.current_dir(app_dir())
         .args(["run", "--bun", "dev"])

--- a/tooling/xtask/crates/xtask_local/src/local/frontend.rs
+++ b/tooling/xtask/crates/xtask_local/src/local/frontend.rs
@@ -198,6 +198,25 @@ fn tail_str(s: &str, n: usize) -> String {
     lines[start..].join("\n")
 }
 
+/// Build the frontend's WASM packages (`cache-wasm`, `agent-fold`) as an
+/// explicit, unbounded step before the port-readiness poll below starts.
+///
+/// `bun run dev` builds these itself via a `predev`-style chain
+/// (`ensure-cache-wasm && ensure-agent-fold-wasm && vite`), but on a cache
+/// miss that means compiling wasm-bindgen's own toolchain from scratch —
+/// several minutes, far past the fixed 36s poll in `start()`. Running the
+/// same `just` recipes here first keeps that one-time cost off that timeout;
+/// they no-op on a warm cache, so this stays cheap on every later run.
+fn ensure_wasm_packages(stage: &Stage) -> Result<()> {
+    let mut cmd = Command::new("just");
+    cmd.current_dir(app_dir()).arg("ensure-cache-wasm");
+    stage.run("Preparing cache-wasm package", &mut cmd)?;
+
+    let mut cmd = Command::new("just");
+    cmd.current_dir(app_dir()).arg("ensure-agent-fold-wasm");
+    stage.run("Preparing agent-fold wasm package", &mut cmd)
+}
+
 /// Start the frontend dev server and wait until *our* child is serving. Output
 /// is captured (suppressed — the vite banner would duplicate the summary's URL)
 /// but retained so an unexpected exit can be diagnosed. Returns `None` in
@@ -246,6 +265,7 @@ pub fn start(
             repo_root().display()
         );
     }
+    ensure_wasm_packages(stage)?;
     let mut cmd = Command::new("bun");
     cmd.current_dir(app_dir())
         .args(["run", "--bun", "dev"])

--- a/tooling/xtask/crates/xtask_local/src/local/frontend.rs
+++ b/tooling/xtask/crates/xtask_local/src/local/frontend.rs
@@ -237,11 +237,13 @@ pub fn start(
     }
     // Without node_modules, `bun run dev` never binds the port and never exits
     // within the poll window below — it just times out with an opaque "did not
-    // become ready", giving no hint that a dependency install is missing.
-    if !app_dir().join("node_modules").exists() {
+    // become ready", giving no hint that a dependency install is missing. This
+    // is a Bun workspace: `bun install` hoists deps into the repo-root
+    // node_modules, not a per-package one under apps/web.
+    if !repo_root().join("node_modules").exists() {
         anyhow::bail!(
             "{}/node_modules is missing — run `bun install` from the repo root first.",
-            app_dir().display()
+            repo_root().display()
         );
     }
     let mut cmd = Command::new("bun");


### PR DESCRIPTION
issue #5788 

## What

Two fixes to `run_local`'s frontend startup so a fresh clone doesn't hit an opaque "frontend dev server did not become ready":

1. Bail with a clear error if the repo-root `node_modules` is missing, instead of letting the port-poll silently time out.
2. Pre-build the frontend's WASM packages (`cache-wasm`, `agent-fold`) as their own explicit, unbounded step before the port-readiness poll starts, instead of letting `bun run dev`'s own predev chain build them on a cold cache — which can take several minutes (compiling wasm-bindgen's own toolchain) and always loses the race against the fixed 36s timeout.

## Why

Both are the same root problem: `bun run dev` does slow, silent prep work before Vite ever binds a port, and the 36s poll has no visibility into that. Every fresh contributor hits this — first the missing install, then the cold WASM build — on their very first `run_local`.

## Test plan

- [x] `cargo check -p xtask_local`
- [x] Reproduced the original opaque timeout on a fresh clone (no `bun install`, no WASM cache)
- [x] Confirmed the `node_modules` error fires immediately and points to `bun install`
- [x] After `bun install`, confirmed the WASM step runs to completion as its own visible stage instead of racing the port-poll timeout
- [x] Ran `just run_local --no-doppler` end-to-end on a fresh clone — frontend starts normally
