### PR TITLE
chore(ci): temporarily disable agent-harness-service deploys

### DIFF
--- a/.github/services-config.json
+++ b/.github/services-config.json
@@ -1,6 +1,7 @@
 {
   "services": {
     "agent-harness-service": {
+      "deploy_enabled": false,
       "source_paths": [
         "services/agent_harness_service/**",
         "crates/agent_harness/**",


### PR DESCRIPTION
Temporarily drop `agent-harness-service` from the deploy-all matrix so production (and other) deploys can proceed