### PR TITLE
fix(cloud): call nix via NIX_BIN after develop replaces PATH

### DIFF
--- a/.cursor/cloud-lib.sh
+++ b/.cursor/cloud-lib.sh
@@ -240,6 +240,6 @@ ensure_persistent_caches() {
 build_local_stack_binaries() {
   (
     \cd "${WORKSPACE_ROOT}"
-    nix build "${WORKSPACE_ROOT}#local-stack-binaries" --out-link "${LOCAL_STACK_BINS}"
+    "${NIX_BIN}" build "${WORKSPACE_ROOT}#local-stack-binaries" --out-link "${LOCAL_STACK_BINS}"
   )
 }


### PR DESCRIPTION
## Summary
- `install.sh` re-enters the flake with `nix develop --command`, which replaces `PATH` with the shell packages. The host `nix` CLI is not one of them.
- `build_local_stack_binaries` was the only caller that used a bare `nix`, so the first post-merge bake died at `cloud-lib.sh:243` after cargo/bun caches were already warm.
- Use the same `NIX_BIN` (`/nix/var/nix/profiles/default/bin/nix`) every other helper already uses.

## Test plan
- [x] Confirmed this is the only bare `nix` invocation in `.cursor/`
- [ ] Retrigger the Cursor environment Build on `main` after merge; install log should show `nix build .#local-stack-binaries` substituting from S3 instead of `command not found`