### PR TITLE
fix(nix): pin agent-client-protocol rust-sdk output hash

### DIFF
--- a/nix-support/root-cargo-output-hashes.nix
+++ b/nix-support/root-cargo-output-hashes.nix
@@ -7,4 +7,6 @@
     "sha256-EcmlwqAVXGtbuvozzCOrygoSVipU99mBZK/MrQAIoYg=";
   "git+https://github.com/macro-inc/rs-libreoffice-bindings?rev=056a40ddfac1d9650be30b9f0b4b934e9266c7dc#056a40ddfac1d9650be30b9f0b4b934e9266c7dc" =
     "sha256-lx/AuxPpCarxdDzogkGudCbE4B2OEt5un4s4gIFt1ek=";
+  "git+https://github.com/agentclientprotocol/rust-sdk?rev=8769d16d10e0c9fa7e662ee18424a4313b06ea88#8769d16d10e0c9fa7e662ee18424a4313b06ea88" =
+    "sha256-QI/EyiWoZtIDdbMcMXVcFji/LK0Za4k4aP/4Ho1cx1g=";
 }


### PR DESCRIPTION
## Summary
- `agent-client-protocol` is a Cargo git dep (`8769d16`) but was missing from `nix-support/root-cargo-output-hashes.nix`.
- Evaluating `.#local-stack-binaries` therefore cloned via host `git-remote-https`. On Cursor Cloud that binary is poisoned by the flake's `LD_LIBRARY_PATH` (Nix glibc 2.42 vs Ubuntu libc), so install failed before S3 substitution could run.
- Pin the fetch hash so eval does not need git. Verified `nix eval .#packages.x86_64-linux.local-stack-binaries.drvPath` succeeds.

## Test plan
- [x] `nix-prefetch-git` of rev `8769d16` → `sha256-QI/EyiWoZtIDdbMcMXVcFji/LK0Za4k4aP/4Ho1cx1g=`
- [x] `nix eval` of `local-stack-binaries` on this tree no longer warns about a missing output hash
- [ ] After merge, retrigger the Cursor environment Build; install should get past `local-stack-binaries` and copy from `s3://macro-nix-cache`