### PR TITLE
fix(cursor-cloud): bake aux

### DIFF
--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -65,7 +65,7 @@ echo "cursor-cloud install: bun cache ready"
 build_local_stack_binaries
 echo "cursor-cloud install: local stack binaries ready"
 
-just stack up --infra-only --no-doppler --build-aux-services --json
+just stack up --infra-only --no-doppler --build-aux-services --binaries-dir "${LOCAL_STACK_BINS}/bin" --json
 cleanup_stack
 trap - EXIT
 


### PR DESCRIPTION
## Summary
- The Cloud environment bake (`install.sh`) builds `.#local-stack-binaries` from the S3 Nix cache, but then ran `just stack up --infra-only` without `--binaries-dir`, so xtask zigbuilt every service binary a second time (~11 min per bake, seen in build `bld-20260821-591df3ee`).
- Pass `--binaries-dir "${LOCAL_STACK_BINS}/bin"` to the bake's `stack up`, matching what `stack.sh` already does, so the bake reuses the Nix binaries it just realized.
- `--build-aux-services` stays: baking the aux images into the snapshot is what keeps first `stack.sh` fast in a session. The compose-build failure in the last bake had no visible root cause in the truncated log; with ~11 min of duplicate compilation and its disk churn gone, retriggering the bake is the next step.

## Test plan
- [ ] Retrigger the Cursor Cloud environment build and confirm the bake skips "Building service binaries" in favor of the prebuilt Nix directory
- [ ] Confirm the aux `docker compose build` completes