### PR TITLE
fix(local): trigger local-stack-binaries cache push on nix-support changes

### DIFF
--- a/.github/workflows/push_local_stack_binaries.yml
+++ b/.github/workflows/push_local_stack_binaries.yml
@@ -12,6 +12,7 @@ name: Push local stack binaries
     - crates/**
     - services/**
     - nix/**
+    - nix-support/**
     - flake.nix
     - flake.lock
     - '.github/actions/setup-nix/**'

--- a/tooling/xtask/crates/xtask_workflows/src/workflows/push_local_stack_binaries.rs
+++ b/tooling/xtask/crates/xtask_workflows/src/workflows/push_local_stack_binaries.rs
@@ -23,6 +23,7 @@ pub fn push_local_stack_binaries() -> Workflow {
         xtask_paths::repo_glob!("crates/**"),
         xtask_paths::repo_glob!("services/**"),
         xtask_paths::repo_glob!("nix/**"),
+        xtask_paths::repo_glob!("nix-support/**"),
         xtask_paths::repo_glob!("flake.nix"),
         xtask_paths::repo_glob!("flake.lock"),
         xtask_paths::repo_glob!(".github/actions/setup-nix/**"),


### PR DESCRIPTION
## Summary
- Pinning a crate output hash in `nix-support/root-cargo-output-hashes.nix` changes the `local-stack-binaries` derivation.
- The `Push local stack binaries` workflow's path filter did not include `nix-support/**`, so the hash pin in #5807 never republished the new closure.
- Cloud install then compiled the five local-only binaries from source (~10 min) instead of substituting them from S3. Adding `nix-support/**` matches `deploy_on_push`.

## Test plan
- [ ] After merge, confirm the workflow runs on `main` (this YAML change itself is already in the existing path filter)
- [ ] Confirm the run pushes `.#local-stack-binaries` to the S3 cache
- [ ] Next Cloud environment bake should substitute the local-only packages instead of building them