### PR TITLE
fix(email): enhance forward subject detection for HTML and plaintext

### DIFF
--- a/crates/email_utils/src/body_replyless/constants.rs
+++ b/crates/email_utils/src/body_replyless/constants.rs
@@ -22,6 +22,12 @@ lazy_static! {
         r#"(?i)(^\s*--+original message--+)|(^\s*from:)|(^\s*on .*wrote:)"#
     ).unwrap();
 
+    // Regex for common forward-subject prefixes ("Fwd:", "FW:", "fwd:", ...), allowing
+    // leading whitespace but requiring the colon so "fwiw:" etc. don't match.
+    pub static ref FORWARD_SUBJECT_RE: Regex = Regex::new(
+        r#"(?i)^\s*fwd?:"#
+    ).unwrap();
+
     // Regex for common signature lines.
     // (?im) -> i: case-insensitive, m: multiline mode (^ and $ match line start/end)
     pub static ref SIGNATURE_RE: Regex = Regex::new(
@@ -73,4 +79,10 @@ lazy_static! {
     pub static ref ANY_ELEMENT_SELECTOR: Selector = Selector::parse("*").unwrap();
     pub static ref BODY_SELECTOR: Selector = Selector::parse("body").unwrap();
     pub static ref BLOCK_LEVEL_ELEMENTS_SELECTOR: Selector = Selector::parse("p, div, li, h1, h2, h3, h4, h5, h6").unwrap();
+}
+
+/// Returns true if the subject uses a common forward prefix (`Fwd:`, `FW:`, ...),
+/// matched case-insensitively and independent of leading whitespace.
+pub fn is_forward_subject(subject: Option<&str>) -> bool {
+    subject.is_some_and(|s| FORWARD_SUBJECT_RE.is_match(s))
 }

--- a/crates/email_utils/src/body_replyless/html_parser.rs
+++ b/crates/email_utils/src/body_replyless/html_parser.rs
@@ -7,7 +7,7 @@ use std::{collections::HashSet, ops::Deref};
 pub fn extract_reply_html(subject: Option<&str>, html_content: &str) -> String {
     let document = Html::parse_document(html_content);
 
-    if subject.is_some() && subject.unwrap().starts_with("Fwd:") {
+    if is_forward_subject(subject) {
         // If it's a forward, the entire original HTML is the desired content.
         return html_content.to_string();
     }

--- a/crates/email_utils/src/body_replyless/plaintext_parser.rs
+++ b/crates/email_utils/src/body_replyless/plaintext_parser.rs
@@ -1,8 +1,8 @@
-use super::constants::PLAINTEXT_SPLITTER_RE;
+use super::constants::{PLAINTEXT_SPLITTER_RE, is_forward_subject};
 
 /// Extracts the latest reply from a plaintext email string.
 pub fn extract_reply_plaintext(subject: Option<&str>, text_content: &str) -> String {
-    if subject.is_some() && subject.unwrap().starts_with("Fwd:") {
+    if is_forward_subject(subject) {
         return text_content.to_string();
     }
 

--- a/crates/email_utils/src/body_replyless/test.rs
+++ b/crates/email_utils/src/body_replyless/test.rs
@@ -1,4 +1,6 @@
 use super::compute_body_replyless;
+use super::html_parser::extract_reply_html;
+use super::plaintext_parser::extract_reply_plaintext;
 
 #[test]
 fn test_extract_message_reply_outlook_test_1() {
@@ -57,6 +59,68 @@ fn test_extract_message_reply_test_5() {
     let expected_reply = include_str!("testdata/test-5/body_replyless.html");
 
     test_email_extraction(full_email, expected_reply, "test-5");
+}
+
+#[test]
+fn test_forward_subject_recognized_case_insensitively_html() {
+    let html = "<html><body><p>Forwarded content</p><blockquote>quoted</blockquote></body></html>";
+
+    for subject in [
+        "Fwd: hi",
+        "FW: hi",
+        "fw: hi",
+        "fwd: hi",
+        "  Fwd: hi",
+        "  fw:hi",
+    ] {
+        assert_eq!(
+            extract_reply_html(Some(subject), html),
+            html,
+            "subject '{subject}' should be recognized as a forward"
+        );
+    }
+}
+
+#[test]
+fn test_non_forward_subject_prefix_not_treated_as_forward_html() {
+    let html = "<html><body><p>Reply content</p><blockquote>quoted</blockquote></body></html>";
+
+    let result = extract_reply_html(Some("fwiw: hi"), html);
+    assert!(
+        !result.contains("quoted"),
+        "'fwiw:' should not be treated as a forward prefix"
+    );
+}
+
+#[test]
+fn test_forward_subject_recognized_case_insensitively_plaintext() {
+    let text = "Forwarded content\n\nOn Mon, Jan 1, 2024 at 10:00 AM wrote:\nquoted";
+
+    for subject in [
+        "Fwd: hi",
+        "FW: hi",
+        "fw: hi",
+        "fwd: hi",
+        "  Fwd: hi",
+        "  fw:hi",
+    ] {
+        assert_eq!(
+            extract_reply_plaintext(Some(subject), text),
+            text,
+            "subject '{subject}' should be recognized as a forward"
+        );
+    }
+}
+
+#[test]
+fn test_non_forward_subject_prefix_not_treated_as_forward_plaintext() {
+    let text = "Reply content\n\nOn Mon, Jan 1, 2024 at 10:00 AM wrote:\nquoted";
+
+    let result = extract_reply_plaintext(Some("fwiw: hi"), text);
+    assert!(
+        !result.contains("quoted"),
+        "'fwiw:' should not be treated as a forward prefix"
+    );
 }
 
 fn test_email_extraction(full_email: &str, expected_reply: &str, test_name: &str) {


### PR DESCRIPTION
closes #5704 

## Summary

- Fixes forward-subject detection in `body_replyless` so it recognizes common `FW:`/`Fwd:` variants instead of only the exact-case string `Fwd:`.

## Problem

Both `crates/email_utils/src/body_replyless/html_parser.rs` and `plaintext_parser.rs` bypassed quoted-content removal only when the subject started with the exact case-sensitive string `Fwd:`. Providers/clients also emit `FW:`, `fw:`, `fwd:`, and subjects with leading whitespace, which were not recognized. When missed, the normal reply splitter stripped the forwarded content out of the parsed and search representations.

## Fix

- Added a shared `is_forward_subject` predicate in `constants.rs`, backed by a case-insensitive regex (`^\s*fwd?:`) that:
  - Matches `Fwd:`, `FW:`, `fw:`, `fwd:` regardless of case.
  - Tolerates leading whitespace.
  - Does **not** match words that merely start with `fw`/`fwd` (e.g. `fwiw:`), since the regex requires the colon immediately after `fw`/`fwd`.
- Both `extract_reply_html` and `extract_reply_plaintext` now call this shared predicate instead of duplicating the exact-case check.

## Tests

Added regression tests in `body_replyless/test.rs` covering both parsers:
- `test_forward_subject_recognized_case_insensitively_html` / `_plaintext` — asserts `Fwd:`, `FW:`, `fw:`, `fwd:`, and whitespace-prefixed variants are all treated as forwards (full content returned unmodified).
- `test_non_forward_subject_prefix_not_treated_as_forward_html` / `_plaintext` — asserts `fwiw:` is *not* treated as a forward prefix (quoted content still gets stripped).

All 11 tests in `email_utils::body_replyless` pass; `cargo fmt` / `cargo clippy -p email_utils` clean.