### PR TITLE
fix(cursor): stop Cloud install daemons so the bake can exit

### DIFF
--- a/.cursor/cloud-lib.sh
+++ b/.cursor/cloud-lib.sh
@@ -95,8 +95,8 @@ ensure_nix_daemon() {
       "AWS_SECRET_ACCESS_KEY=${NIX_CACHE_AWS_SECRET_ACCESS_KEY}"
     )
   fi
-  sudo setsid env "${daemon_env[@]}" "${NIX_BIN}" daemon \
-    >>"${LOG_DIR}/nix-daemon.log" 2>&1 </dev/null &
+  sudo setsid --fork env "${daemon_env[@]}" "${NIX_BIN}" daemon \
+    >>"${LOG_DIR}/nix-daemon.log" 2>&1 </dev/null
   local n=0
   while [ "${n}" -lt 30 ]; do
     if "${NIX_BIN}" ping-store >/dev/null 2>&1; then
@@ -167,8 +167,8 @@ ensure_dockerd() {
   # Disk snapshots preserve dead socket entries.
   sudo rm -f "${DOCKER_SOCK}"
   : >"${LOG_DIR}/dockerd.log"
-  sudo setsid env "PATH=${PATH}" "${dockerd_bin}" "${storage_args[@]}" \
-    >>"${LOG_DIR}/dockerd.log" 2>&1 </dev/null &
+  sudo setsid --fork env "PATH=${PATH}" "${dockerd_bin}" "${storage_args[@]}" \
+    >>"${LOG_DIR}/dockerd.log" 2>&1 </dev/null
   local n=0
   while [ "${n}" -lt 60 ]; do
     if [ -S "${DOCKER_SOCK}" ]; then
@@ -242,4 +242,33 @@ build_local_stack_binaries() {
     \cd "${WORKSPACE_ROOT}"
     "${NIX_BIN}" build "${WORKSPACE_ROOT}#local-stack-binaries" --out-link "${LOCAL_STACK_BINS}"
   )
+}
+
+stop_cloud_daemons() {
+  if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
+    local ids
+    ids="$(docker ps -aq 2>/dev/null || true)"
+    if [ -n "${ids}" ]; then
+      # shellcheck disable=SC2086
+      timeout --kill-after=5s 45s docker stop -t 5 ${ids} >/dev/null 2>&1 || true
+    fi
+  fi
+  sudo pkill -x dockerd >/dev/null 2>&1 || true
+  sudo pkill -x containerd >/dev/null 2>&1 || true
+  sudo pkill -x nix-daemon >/dev/null 2>&1 || true
+  sudo pkill -x determinate-nixd >/dev/null 2>&1 || true
+  local n=0
+  while sudo pgrep -x dockerd >/dev/null 2>&1 \
+    || sudo pgrep -x nix-daemon >/dev/null 2>&1 \
+    || sudo pgrep -x determinate-nixd >/dev/null 2>&1; do
+    n=$((n + 1))
+    if [ "${n}" -ge 15 ]; then
+      sudo pkill -9 -x dockerd >/dev/null 2>&1 || true
+      sudo pkill -9 -x containerd >/dev/null 2>&1 || true
+      sudo pkill -9 -x nix-daemon >/dev/null 2>&1 || true
+      sudo pkill -9 -x determinate-nixd >/dev/null 2>&1 || true
+      break
+    fi
+    sleep 1
+  done
 }

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -69,4 +69,8 @@ just stack up --infra-only --no-doppler --build-aux-services --binaries-dir "${L
 cleanup_stack
 trap - EXIT
 
+# Cursor waits for the install process tree to drain. Images, volumes, and
+# the Nix store stay on disk; start.sh / infra.sh bring the daemons back.
+stop_cloud_daemons
+
 echo "cursor-cloud install: durable stack ready"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -317,7 +317,7 @@ don't inject it directly into the error message.
 
 ## Cursor Cloud specific instructions
 
-`.cursor/install.sh` prepares the durable caches, databases, test dependencies, frontend dependencies, service binaries, and stack init snapshot. `.cursor/start.sh` runs at boot and starts nothing beyond the nix daemon, so sessions and subagents are usable immediately. `.cursor/infra.sh` starts Docker, Postgres, and Redis on demand. `.cursor/stack.sh` starts the on-demand product stack. `.cursor/rebuild.sh` rebuilds the stack after backend edits. These scripts are the only supported entry points; each re-enters the pinned nix shell itself, so run them with plain `bash` from any environment.
+`.cursor/install.sh` prepares the durable caches, databases, test dependencies, frontend dependencies, service binaries, and stack init snapshot, then stops dockerd and nix-daemon so the Cloud bake can exit. `.cursor/start.sh` runs at boot and starts nothing beyond the nix daemon, so sessions and subagents are usable immediately. `.cursor/infra.sh` starts Docker, Postgres, and Redis on demand. `.cursor/stack.sh` starts the on-demand product stack. `.cursor/rebuild.sh` rebuilds the stack after backend edits. These scripts are the only supported entry points; each re-enters the pinned nix shell itself, so run them with plain `bash` from any environment.
 
 Nix is the only host dependency. The pinned dev shell supplies the Docker CLI and daemon, Compose, `fuse-overlayfs`, and OpenSSH. `ssh-keygen` must come from this shell.
 


### PR DESCRIPTION
## Summary
- Build `bld-20260821-35d35f14` printed `cursor-cloud install: durable stack ready` at 10:02 (17 minutes in) and then never exited. Cursor waited until the 90-minute install cap.
- The bake itself is fine: S3 substitution, aux images, and the init snapshot all completed. What stayed running is `dockerd`, `nix-daemon`, and the `just run_dbs -d` Postgres/Redis containers. `just stack down` does not stop those databases (different compose file). Cursor treats leftover servers as part of the install process tree.
- Stop containers and daemons after the snapshot bake. Images, volumes, and the Nix store stay on disk; `start.sh` / `infra.sh` bring the processes back.
- Launch `dockerd` and `nix-daemon` with `setsid --fork` so `sudo` does not leave a waiter inherited by `exec nix develop`.

## Test plan
- [ ] Merge and retrigger the Cursor Cloud environment build
- [ ] Confirm logs show `durable stack ready` and then an `[INSTALL] Exit code: 0` well under 90 minutes
- [ ] Confirm a session can still `bash .cursor/infra.sh` and `bash .cursor/stack.sh`