### PR TITLE
Update pricing copy: teams of up to 5 people are free

### DIFF
--- a/apps/docs/account/billing.mdx
+++ b/apps/docs/account/billing.mdx
@@ -12,8 +12,9 @@ Macro has one paid plan, priced per person. The price is the same whether you're
 | AI agent | Fast model only | All models |
 | AI tool calls | Limited | Unlimited |
 | Storage | 5 GB | 1 TB |
+| Team size | Up to 5 people | Paid seat per member |
 
-Teams require a paid seat for every member; there's no free plan for teams. Your current plan is shown in **Settings → Account**, with an **Upgrade** button if you're on the free plan.
+Teams of up to 5 people are free; beyond 5, every member needs a paid seat. Your current plan is shown in **Settings → Account**, with an **Upgrade** button if you're on the free plan.
 
 ## Managing your subscription
 

--- a/apps/docs/account/teams.mdx
+++ b/apps/docs/account/teams.mdx
@@ -13,7 +13,7 @@ Macro works solo, but everything is better with friends. Teams get auto-shared t
 Click **Team** in the bottom left to create a team. You can add the first members right there, or invite more later by email from **Settings → Team**. Invitees see the pending invitation when they sign in. Owners can also copy an invite link for any pending invite and share it directly, instead of relying on email.
 
 <Note>
-  There's no free plan for teams; every member needs a paid seat. See [Billing & plans](/account/billing).
+  Teams of up to 5 people are free. Beyond 5, every member needs a paid seat. See [Billing & plans](/account/billing).
 </Note>
 
 ## Auto-join on domain

--- a/apps/docs/faq.mdx
+++ b/apps/docs/faq.mdx
@@ -69,7 +69,7 @@ description: "How Macro compares to Notion, Superhuman, and Slack, plus licensin
   </Accordion>
 
   <Accordion title='How do teams work in Macro? Do I need a "team"?'>
-    Macro is designed for solo and team use. Of course, everything is better with friends. The pricing for Macro whether you are on a team or personal plan is the same; Teams exist just to help you collaborate better as a group. Keep in mind there is no free plan for teams, however. Teams give:
+    Macro is designed for solo and team use. Of course, everything is better with friends. The pricing for Macro whether you are on a team or personal plan is the same; Teams exist just to help you collaborate better as a group. Teams of up to 5 people are included on the free plan; beyond 5, every member needs a paid seat. Teams give:
 
     1. Auto-shared emails, tasks and calls, without having to explicitly share everything. For example, when you're working as a team you want all emails to be shared in our CRM module, engineering tasks should be visible by everyone, and having all calls transcribed and stored to the Team gives you a nice team-level memory of all of your conversations.
     2. Team-level memory for your agents. Agents remember not just your personal chat history (like with Claude or ChatGPT's memory system), but everything going on across tasks your team is working on, emails, docs, and calls that the team has had recently!

--- a/apps/web/src/features/paywall/plans.ts
+++ b/apps/web/src/features/paywall/plans.ts
@@ -50,4 +50,11 @@ export const PLAN_FEATURES: PlanFeature[] = [
       premium: '1 TB',
     },
   },
+  {
+    label: 'Teams',
+    values: {
+      free: 'Up to 5 people',
+      premium: 'Paid seat per member',
+    },
+  },
 ];

--- a/apps/web/src/features/settings/Billing.tsx
+++ b/apps/web/src/features/settings/Billing.tsx
@@ -13,7 +13,7 @@ import { createMemo, For, Match, Show, Switch } from 'solid-js';
 import { SettingsCard, SettingsPage, SettingsSection } from './primitives';
 
 const BILLING_PLAN_FEATURES: Record<PlanTier, string[]> = {
-  free: ['Access to Haiku', 'MCP access', '5 GB storage'],
+  free: ['Access to Haiku', 'MCP access', '5 GB storage', 'Teams up to 5 people'],
   premium: [
     'All agents',
     'All models',
@@ -21,7 +21,7 @@ const BILLING_PLAN_FEATURES: Record<PlanTier, string[]> = {
     'AI projections',
     'Multiple email inboxes',
     'Calls',
-    'Teams',
+    'Teams beyond 5 people',
     '1 TB storage',
   ],
 };


### PR DESCRIPTION
## Summary

Free teams of up to 5 members shipped in #4994 (July 20), but the docs and in-app plan copy still said teams require a paid seat for every member — the in-app AI assistant has been telling new users "there's no free plan for teams" as recently as Aug 17, and post-launch funnel data shows team creators almost never invite anyone. This updates every copy surface in this repo to match the shipped behavior (`FREE_TEAM_MAX_MEMBERS = 5`, enforced in `crates/teams/src/domain/team_service.rs`).

## Changes

- `apps/docs/account/teams.mdx` — Note now reads "Teams of up to 5 people are free. Beyond 5, every member needs a paid seat." (this page is a source for the in-app assistant's answers)
- `apps/docs/account/billing.mdx` — added a "Team size" row to the plan table; rewrote the no-free-teams sentence
- `apps/docs/faq.mdx` — teams FAQ answer updated
- `apps/web/src/features/paywall/plans.ts` — added a "Teams" row (`Up to 5 people` / `Paid seat per member`) to `PLAN_FEATURES`, which renders in the onboarding plan step and the paywall plan grid
- `apps/web/src/features/settings/Billing.tsx` — free plan now lists "Teams up to 5 people"; premium's "Teams" renamed to "Teams beyond 5 people"

## Testing

- Copy-only changes (strings inside existing typed structures)
- `apps/web` typecheck could not run in the sandbox: `bun install` 403s on the private git deps (`macro-inc/pdf.js`, `tauri-plugins`) through the session proxy — please rely on CI for `bun run type-check`

## Notes

- The pricing comparison on the marketing site still lists team features (auto-shared email/CRM, team memory, channel-based sharing) as paid-only; whether free 5-person teams get those features is a product decision left out of this PR. Companion marketing-site PR: macro-inc/solid-site#claude/free-teams-story.

---
_Generated by [Claude Code](https://claude.ai/code/session_017jsKWszKtdT5fjTydzFXK3)_