### PR TITLE
fix(macrod): install the TLS provider before dialing the gateway

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3421,6 +3421,7 @@ dependencies = [
  "macro_uuid",
  "reqwest 0.13.4",
  "rootcause",
+ "rustls 0.23.40",
  "serde",
  "serde_json",
  "strum 0.27.2",

--- a/crates/coding_agent_worker/Cargo.toml
+++ b/crates/coding_agent_worker/Cargo.toml
@@ -28,6 +28,9 @@ macro_user_id = { path = "../macro_user_id" }
 macro_uuid = { path = "../macro_uuid" }
 reqwest = { workspace = true }
 rootcause = { workspace = true }
+# The gateway dial is `wss` on every deployment but a local stack, and
+# tokio-tungstenite's rustls feature selects no crypto provider.
+rustls = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 strum = { workspace = true }

--- a/crates/coding_agent_worker/src/main.rs
+++ b/crates/coding_agent_worker/src/main.rs
@@ -45,6 +45,11 @@ async fn main() -> ExitCode {
         )
         .init();
 
+    // Dialing a `wss` gateway needs a process-wide provider, and rustls
+    // installs none by itself. Before any dial, and idempotent: an error only
+    // means somebody already did this.
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
     let args = Args::parse();
     match run(&args.config).await {
         Ok(()) => ExitCode::SUCCESS,


### PR DESCRIPTION
## What

`macrod` panics on its first `wss` dial of the runtime gateway:

```
thread 'tokio-rt-worker' panicked at rustls-0.23.40/src/crypto/mod.rs:249:14:
Could not automatically determine the process-level CryptoProvider from Rustls crate features.
```

`tokio-tungstenite`'s `rustls-tls-webpki-roots` feature selects no crypto provider, and with both `ring` and `aws-lc-rs` in the workspace graph rustls 0.23 refuses to pick one. `agent_harness` already installs `aws_lc_rs` for its outbound clients; the daemon needs the same, since nothing else in its process does it.

The failure mode is unpleasant: the panic lands in the tokio worker serving the webhook delivery, so the POST is answered by a dropped connection. The daemon creates the session, never dials, and the deliverer redelivers straight back into the panic.

It never fires locally — a local stack's gateway is `ws://localhost`, no TLS — so it only shows up the first time a bot is served against a real deployment.

## How this was found

Serving `@buzzbot1` on dev from a laptop (`opencode acp` as the harness). Before the fix, the delivery died in the panic; after it, the same delivery opens the session, dials `wss://agent-harness-dev.macro.com/runtime/ws`, bridges opencode, and the reply streams back — `status = event`, `status_event_name = acp_ready`, and an `end_turn` in `agent_session_log`.

## Test plan

- `cargo test -p coding_agent_worker` (19 passed)
- `just clippy` on the crate, `cargo fmt`
- Manually: `macrod --config macro.dev.toml` against `agent-harness-dev`, a signed `agent_trigger.new` delivery, opencode answers into the dev channel