### PR TITLE
fix(ci): publish macrod release artifacts without realizing hermes-agent

### DIFF
--- a/.github/actions/setup-nix-dev-shell/action.yml
+++ b/.github/actions/setup-nix-dev-shell/action.yml
@@ -1,15 +1,29 @@
 name: Setup Nix dev shell
-description: Enter the repository Nix dev shell without configuring a cache provider.
+description: Enter a repository Nix dev shell without configuring a cache provider.
+
+inputs:
+  shell:
+    description: Flake `devShells` attribute to enter (e.g. `default`, `agent-daemon`).
+    required: false
+    default: default
 
 runs:
   using: composite
   steps:
     - name: Enter Nix dev shell
       shell: bash
+      env:
+        DEV_SHELL: ${{ inputs.shell }}
       run: |
         set -euo pipefail
+        case "$DEV_SHELL" in
+          ''|*[!A-Za-z0-9_-]*)
+            echo "invalid devShell attribute: ${DEV_SHELL@Q}" >&2
+            exit 1
+            ;;
+        esac
         dev_env="$RUNNER_TEMP/nix-dev-env"
-        nix print-dev-env --accept-flake-config > "$dev_env"
+        nix print-dev-env --accept-flake-config ".#$DEV_SHELL" > "$dev_env"
         echo "BASH_ENV=$dev_env" >> "$GITHUB_ENV"
         source "$dev_env"
         printf '%s\n' "$PATH" | tr ':' '\n' >> "$GITHUB_PATH"

--- a/.github/workflows/build_agent_daemon_on_tag.yml
+++ b/.github/workflows/build_agent_daemon_on_tag.yml
@@ -88,8 +88,15 @@ jobs:
       continue-on-error: true
     - name: Setup Nix
       uses: './.github/actions/setup-nix'
+      with:
+        nix-cache-url: ${{ vars.NIX_CACHE_URL }}
+        nix-cache-public-key: ${{ vars.NIX_CACHE_PUBLIC_KEY }}
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     - name: Setup Nix dev shell
       uses: './.github/actions/setup-nix-dev-shell'
+      with:
+        shell: agent-daemon
     - name: Configure Namespace remote sccache
       if: (github.event_name != 'pull_request' && github.event_name != 'pull_request_target') || github.event.pull_request.head.repo.full_name == github.repository
       run: |-
@@ -265,8 +272,15 @@ jobs:
       continue-on-error: true
     - name: Setup Nix
       uses: './.github/actions/setup-nix'
+      with:
+        nix-cache-url: ${{ vars.NIX_CACHE_URL }}
+        nix-cache-public-key: ${{ vars.NIX_CACHE_PUBLIC_KEY }}
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     - name: Setup Nix dev shell
       uses: './.github/actions/setup-nix-dev-shell'
+      with:
+        shell: agent-daemon
     - name: Configure Namespace remote sccache
       if: (github.event_name != 'pull_request' && github.event_name != 'pull_request_target') || github.event.pull_request.head.repo.full_name == github.repository
       run: |-
@@ -712,6 +726,7 @@ jobs:
     - build-daemon-linux-aarch64
     - build-daemon-macos-aarch64
     - build-daemon-macos-x86-64
+    if: '!cancelled() && needs.resolve-ref.result == ''success'' && (needs.build-daemon-linux-x86-64.result == ''success'' || needs.build-daemon-linux-aarch64.result == ''success'' || needs.build-daemon-macos-aarch64.result == ''success'' || needs.build-daemon-macos-x86-64.result == ''success'')'
     name: Upload Release Artifacts
     runs-on: ubuntu-latest
     permissions:

--- a/nix/cloud-storage.nix
+++ b/nix/cloud-storage.nix
@@ -1073,6 +1073,29 @@
               BINDGEN_EXTRA_CLANG_ARGS = "-I${pkgs.glibc.dev}/include -I${pkgs.gcc.cc}/lib/gcc/${pkgs.stdenv.hostPlatform.config}/${pkgs.gcc.version}/include";
             }
           );
+
+        # Tools for the self-hosted `macrod` musl builds (see
+        # `build_agent_daemon_on_tag`). The default shell also carries
+        # hermes-agent, whose GitHub tarball + npm/python tree has taken
+        # down every Linux daemon job so far — either a 429 fetching the
+        # flake input, or the nix-daemon dying while realizing it. This
+        # shell is only the rust toolchain, zig, and cmake, so
+        # `nix print-dev-env .#agent-daemon` does not force that input.
+        agent-daemon = pkgs.mkShell {
+          packages = [
+            rustToolchain
+            pkgs.cargo-zigbuild
+            pkgs.zig
+            pkgs.cmake
+            # openssl-src's Configure is perl; aws-lc-sys uses cmake.
+            pkgs.perl
+            pkgs.pkg-config
+            pkgs.sccache
+          ];
+          RUSTC_WRAPPER = "${pkgs.sccache}/bin/sccache";
+          CARGO_INCREMENTAL = "0";
+          AWS_LC_SYS_CMAKE_BUILDER = "1";
+        };
       };
     };
 }

--- a/tooling/xtask/crates/xtask_workflows/src/workflows/build_agent_daemon_on_tag.rs
+++ b/tooling/xtask/crates/xtask_workflows/src/workflows/build_agent_daemon_on_tag.rs
@@ -22,6 +22,9 @@ use crate::workflows::{build_appimage_on_tag, runners, steps, vars};
 
 use std::collections::HashMap;
 
+#[cfg(test)]
+mod test;
+
 const RESOLVED_REF: &str = "${{ needs.resolve-ref.outputs.ref }}";
 
 /// One published binary.
@@ -93,8 +96,22 @@ pub fn build_agent_daemon_on_tag() -> Workflow {
     for target in LINUX_TARGETS.iter().chain(MACOS_TARGETS) {
         publish = publish.add_needs(job_id(target));
     }
+    // Default `needs` skips this job if any platform fails, which is how
+    // successful macOS (and once linux-x86_64) tarballs never reached the
+    // GitHub Release. Attach whatever slices built.
+    publish = publish.cond(Expression::new(publish_when_any_build_succeeded()));
 
     workflow.add_job("publish-daemon", publish)
+}
+
+fn publish_when_any_build_succeeded() -> String {
+    let any_build = LINUX_TARGETS
+        .iter()
+        .chain(MACOS_TARGETS)
+        .map(|target| format!("needs.{}.result == 'success'", job_id(target)))
+        .collect::<Vec<_>>()
+        .join(" || ");
+    format!("!cancelled() && needs.resolve-ref.result == 'success' && ({any_build})")
 }
 
 fn job_id(target: &DaemonTarget) -> String {
@@ -144,16 +161,19 @@ fn resolve_ref_step() -> Step<Run> {
         .add_env(("SELECTED_REF", "${{ github.ref }}"))
 }
 
-/// The Nix dev shell is what carries cargo-zigbuild, zig, and cmake, so the
-/// musl builds go through it rather than a bare rustup toolchain.
+/// cargo-zigbuild, zig, and cmake live in Nix. Enter `devShells.agent-daemon`
+/// rather than the default shell: the default realizes hermes-agent, which is
+/// unrelated to this binary and has been the whole reason Linux jobs die
+/// before they compile (GitHub 429 on the flake tarball, or the nix-daemon
+/// crashing while building hermes-agent's npm/python tree).
 fn linux_job(target: &DaemonTarget) -> Job {
     Job::default()
         .name(format!("Build daemon ({})", target.slug))
         .runs_on(runners::Runner::RustCi.to_string())
         .add_step(steps::checkout_ref(RESOLVED_REF))
         .add_step(steps::mount_cache_volume())
-        .add_step(steps::setup_nix())
-        .add_step(steps::setup_dev_shell())
+        .add_step(steps::setup_nix_with_cache())
+        .add_step(steps::setup_dev_shell_named("agent-daemon"))
         // The dev shell points RUSTC_WRAPPER at sccache regardless; this aims
         // it at the shared remote cache so a release build is not a cold
         // compile of the whole dependency graph. It degrades to the local

--- a/tooling/xtask/crates/xtask_workflows/src/workflows/build_agent_daemon_on_tag/test.rs
+++ b/tooling/xtask/crates/xtask_workflows/src/workflows/build_agent_daemon_on_tag/test.rs
@@ -1,0 +1,56 @@
+use super::*;
+
+fn rendered_yaml() -> String {
+    build_agent_daemon_on_tag()
+        .to_string()
+        .expect("daemon workflow should serialize")
+}
+
+#[test]
+fn linux_jobs_enter_the_agent_daemon_shell() {
+    let yaml = rendered_yaml();
+    assert!(
+        yaml.contains("shell: agent-daemon"),
+        "Linux jobs must enter devShells.agent-daemon, got:\n{yaml}"
+    );
+    assert!(
+        yaml.matches("shell: agent-daemon").count() >= 2,
+        "both Linux targets should request the agent-daemon shell"
+    );
+}
+
+#[test]
+fn linux_jobs_wire_the_s3_nix_cache() {
+    let yaml = rendered_yaml();
+    assert!(
+        yaml.contains("nix-cache-url: ${{ vars.NIX_CACHE_URL }}"),
+        "Linux jobs should substitute from the private nix cache"
+    );
+}
+
+#[test]
+fn publish_runs_when_any_platform_succeeds() {
+    let yaml = rendered_yaml();
+    let publish = yaml
+        .split("\n  publish-daemon:\n")
+        .nth(1)
+        .expect("publish-daemon job");
+    let if_line = publish
+        .lines()
+        .find(|line| line.trim_start().starts_with("if:"))
+        .expect("publish-daemon needs an if so a failed platform does not skip the release");
+    assert!(if_line.contains("!cancelled()"));
+    assert!(if_line.contains("needs.resolve-ref.result"));
+    for slug in [
+        "linux-x86-64",
+        "linux-aarch64",
+        "macos-aarch64",
+        "macos-x86-64",
+    ] {
+        let needle = format!("needs.build-daemon-{slug}.result");
+        assert!(
+            if_line.contains(&needle),
+            "publish if missing {needle}: {if_line}"
+        );
+    }
+}

--- a/tooling/xtask/crates/xtask_workflows/src/workflows/steps.rs
+++ b/tooling/xtask/crates/xtask_workflows/src/workflows/steps.rs
@@ -158,12 +158,20 @@ pub fn push_nix_cache(targets: &str) -> Step<Run> {
 /// and `RUSTC_WRAPPER=sccache`) without selecting an sccache provider or
 /// configuring an external Nix binary cache. Jobs that compile Rust can follow
 /// this with [`configure_namespace_sccache`] to use Namespace's official remote
-/// cache. Requires [`setup_nix`] first.
+/// cache. Requires [`setup_nix`] first. The composite action defaults to the
+/// `default` flake shell when no `shell` input is passed.
 pub fn setup_dev_shell() -> Step<Use> {
     uses_local(
         "Setup Nix dev shell",
         xtask_paths::repo_dir!(".github/actions/setup-nix-dev-shell"),
     )
+}
+
+/// [`setup_dev_shell`] for a named `devShells.<name>` flake output. The
+/// `macrod` Linux jobs use `agent-daemon` so they do not realize the default
+/// shell's hermes-agent input.
+pub fn setup_dev_shell_named(name: &str) -> Step<Use> {
+    setup_dev_shell().add_with(("shell", name))
 }
 
 /// Mount the Namespace profile's persisted cache volume: `cache: rust` persists

--- a/tooling/xtask/crates/xtask_workflows/src/workflows/steps/test.rs
+++ b/tooling/xtask/crates/xtask_workflows/src/workflows/steps/test.rs
@@ -48,3 +48,22 @@ fn namespace_sccache_combines_job_specific_and_trust_conditions() {
     );
     assert!(condition.0.contains("steps.filter.outputs.hit == 'true'"));
 }
+
+#[test]
+fn named_dev_shell_passes_the_flake_attribute() {
+    let step = setup_dev_shell_named("agent-daemon");
+    let with = step.value.with.expect("named shell should set with.shell");
+    assert_eq!(
+        with.0.get("shell").and_then(|value| value.as_str()),
+        Some("agent-daemon")
+    );
+}
+
+#[test]
+fn default_dev_shell_does_not_pass_a_shell_input() {
+    let step = setup_dev_shell();
+    assert!(
+        step.value.with.is_none(),
+        "unspecified shell must keep the action default so other workflows stay unchanged"
+    );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Linux jobs in **Build Agent Daemon on Tag** entered the default Nix shell, which realizes `hermes-agent`. That flake input is unrelated to `macrod` and is why no `macrod-*.tar.gz` files have landed on GitHub Releases.

Every run of the workflow has failed before publish:

- [`v2026.8.20.2`](https://github.com/macro-inc/macro/actions/runs/32401332941) — GitHub 429 fetching `NousResearch/hermes-agent`
- [`v2026.8.20.1`](https://github.com/macro-inc/macro/actions/runs/32399727896) / [`v2026.8.20.0`](https://github.com/macro-inc/macro/actions/runs/32394042374) — nix-daemon crash while building hermes-agent’s npm/python tree

macOS jobs already succeed (they use rustup). Publish `needs` all four platforms, so those tarballs never reached the Release page.

## Changes

- Add `devShells.agent-daemon` with only the rust toolchain, cargo-zigbuild, zig, cmake, perl, pkg-config, and sccache.
- Linux jobs enter that shell (`setup-nix-dev-shell` now takes a `shell` input) and wire the private S3 nix cache.
- `publish-daemon` runs if **any** platform succeeded, so a single Linux flake outage cannot hide working macOS binaries.

Verified locally: `nix print-dev-env .#agent-daemon` completes in ~2.5s with no hermes-agent fetch, and the shell has rustc 1.94, cargo-zigbuild, zig, and cmake. `cargo test -p xtask_workflows` and `cargo x workflows --check` pass.

The next `v*` tag will attach `macrod-<tag>-<platform>.tar.gz` to the GitHub Release. This does not backfill `v2026.8.20.*`; re-run the workflow with `workflow_dispatch` on a tag if those releases need the binaries now.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b73c6ca3-989a-4bbc-b69e-0180f8930597?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b73c6ca3-989a-4bbc-b69e-0180f8930597&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

