### PR TITLE
fix(mcp): allow cursor.com as a FusionAuth OAuth origin

### DIFF
--- a/infra/stacks/fusionauth-instance/origins.ts
+++ b/infra/stacks/fusionauth-instance/origins.ts
@@ -25,6 +25,7 @@ export const ALLOWED_ORIGINS = () => {
         'https://claude.ai',
         'https://chatgpt.com',
         'https://chat.openai.com',
+        'https://cursor.com',
       ];
     case 'dev':
       return [
@@ -47,6 +48,7 @@ export const ALLOWED_ORIGINS = () => {
         'https://claude.ai',
         'https://chatgpt.com',
         'https://chat.openai.com',
+        'https://cursor.com',
       ];
     case 'prod':
       return [
@@ -60,6 +62,7 @@ export const ALLOWED_ORIGINS = () => {
         'https://claude.ai',
         'https://chatgpt.com',
         'https://chat.openai.com',
+        'https://cursor.com',
       ];
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Cursor web cannot complete Macro MCP OAuth. FusionAuth reads the browser `Referer` against `authorizedOriginUrls`. That list comes from `ALLOWED_ORIGINS()` and already includes `https://claude.ai` and `https://chatgpt.com`. It does not include `https://cursor.com`.

A live request to `https://auth.macro.com/oauth2/authorize` with `Referer: https://cursor.com/` returns:

```
error=invalid_request
error_reason=invalid_origin
error_description=Invalid origin uri https://cursor.com
```

The same request with `Referer: https://claude.ai/` continues the Google login redirect. That is the exact Cursor web error.

## Scope

Adds `https://cursor.com` to the local, dev, and prod lists in `infra/stacks/fusionauth-instance/origins.ts`. Pulumi maps that array to FusionAuth `oauthConfiguration.authorizedOriginUrls`.

Out of scope:

- `https://www.cursor.com` and `https://cursor.sh`. Those also fail the live check, but the reported client origin is `https://cursor.com`.
- MCP proxy CORS. `mcp_auth_proxy` already mirrors `Origin`, including `https://cursor.com`.
- FusionAuth `authorizedRedirectUrls`. The upstream redirect stays `https://mcp-server.macro.com/oauth/callback`.

## Tradeoffs

None. This is the same allowlist change PR #2865 made for Claude and ChatGPT.

## Blast Radius

The FusionAuth Macro application accepts OAuth authorize requests whose `Referer` is `https://cursor.com`. Existing origins stay as they are. The change is inert until someone applies the `fusionauth-instance` Pulumi stack.

## Verification

- Hit prod `https://auth.macro.com/oauth2/authorize` with `Referer: https://cursor.com/`. FusionAuth redirected to the MCP callback with `Invalid origin uri https://cursor.com`.
- Same URL with `Referer: https://claude.ai/` continued to `/oauth2/redirect`.
- MCP metadata and `/mcp` preflight already return `access-control-allow-origin: https://cursor.com`.
- A parse of `origins.ts` confirms `https://cursor.com` is in the local, dev, and prod arrays.

The live FusionAuth check will stay red until this stack is applied. I did not apply Pulumi.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9f882877-7533-44b9-9249-5c70d1e144bf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9f882877-7533-44b9-9249-5c70d1e144bf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

