### PR TITLE
fix(tags): show long names in the tag picker

### DIFF
--- a/apps/web/src/features/property/tags/TagPicker.tsx
+++ b/apps/web/src/features/property/tags/TagPicker.tsx
@@ -689,7 +689,7 @@ function TagPickerBody(props: {
     <Popover.Portal>
       <Layer depth={3}>
         <Popover.Content
-          class="z-modal w-64 rounded-xl border border-edge-muted bg-surface text-sm shadow-menu menu-open-animation"
+          class="z-modal w-96 max-w-[min(24rem,calc(100vw-1.5rem))] rounded-xl border border-edge-muted bg-surface text-sm shadow-menu menu-open-animation"
           onCloseAutoFocus={(event) => event.preventDefault()}
           onFocusOutside={(event) => {
             if (shouldIgnoreOutsideEvent()) event.preventDefault();
@@ -938,7 +938,7 @@ function TagPickerRow(props: {
       >
         <OptionCheckBox checked={props.checked} multiselect />
         <TagDot color={props.item.option.color ?? undefined} />
-        <span class="min-w-0 truncate">{label()}</span>
+        <span class="min-w-0 flex-1 truncate">{label()}</span>
         <Show when={props.item.scope === 'team'}>
           <span class="max-w-20 shrink-0 truncate rounded-full border border-ink/5 px-1.5 py-0.5 text-[10px] leading-none text-ink-extra-muted">
             {props.teamName}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Long tag names were unreadable in the picker on a task block. A name like `features/team-permissions` showed as `features/te...`, so tags that share a prefix could not be told apart.

The menu was a fixed 16rem. Hover filter and edit actions still reserved space while invisible. The label truncated instead of using leftover space in the row.

## Scope

`TagPicker` in `apps/web/src/features/property/tags/TagPicker.tsx`:

- Widen `Popover.Content` from `w-64` to `w-96`, capped at the viewport.
- Give the row label `flex-1` so leftover space goes to the name.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-207962e6-4510-4447-91c0-7a64dfdf5952?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-207962e6-4510-4447-91c0-7a64dfdf5952&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

