### PR TITLE
feat(activity): attribute system and agent document creates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -475,6 +475,7 @@ dependencies = [
 name = "ai_tools"
 version = "0.1.0"
 dependencies = [
+ "activity",
  "agent",
  "ai_toolset",
  "ai_usage",
@@ -485,6 +486,7 @@ dependencies = [
  "aws-sdk-secretsmanager",
  "aws-sdk-sqs",
  "axum",
+ "bot_id",
  "calendar_events",
  "call",
  "channels",
@@ -4862,6 +4864,7 @@ dependencies = [
  "axum",
  "axum-extra",
  "base64 0.22.1",
+ "bot_id",
  "bots",
  "bytes",
  "bzip2",
@@ -5078,6 +5081,7 @@ dependencies = [
  "axum",
  "axum-extra",
  "base64 0.22.1",
+ "bot_id",
  "chrono",
  "clap",
  "cloudfront_sign",

--- a/apps/web/src/lib/service-clients/service-storage/openapi.json
+++ b/apps/web/src/lib/service-clients/service-storage/openapi.json
@@ -16474,6 +16474,10 @@
         "description": "Metadata for [`DocumentTopicEvent::Created`].",
         "required": ["document_id", "owner", "document_name"],
         "properties": {
+          "actor": {
+            "type": ["string", "null"],
+            "description": "Who mechanically created the document. Absent on events published\nbefore attribution: ingest then treats [`Self::owner`] as the actor."
+          },
           "created_at": {
             "type": ["string", "null"],
             "format": "date-time",
@@ -16495,6 +16499,17 @@
               {
                 "$ref": "#/components/schemas/FileType",
                 "description": "File type of the document, when known."
+              }
+            ]
+          },
+          "on_behalf_of": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/MacroUserIdStr",
+                "description": "The user whose feed this creation belongs on, when different from\n[`Self::actor`]. Absent means the actor is also the subject."
               }
             ]
           },

--- a/crates/activity/src/domain/models.rs
+++ b/crates/activity/src/domain/models.rs
@@ -31,6 +31,53 @@ use uuid::Uuid;
 /// prefix-parseable string. An agent is a bot acting with `on_behalf_of`
 /// set — agent-ness is relational, not an identity kind.
 pub use channel_sender::ChannelSender as Actor;
+
+/// Who performed an action, and whose feed it belongs on.
+///
+/// Stored as `actor_id` plus `subject_id` (`on_behalf_of ?? actor`).
+#[derive(Debug, Clone, PartialEq)]
+pub enum Attribution {
+    /// The principal acted for themselves. Subject equals actor.
+    Direct {
+        /// Who mechanically acted.
+        actor: Actor<'static>,
+    },
+    /// A bot or the platform acted for a user. Subject is that user.
+    Delegated {
+        /// Who mechanically acted.
+        actor: Actor<'static>,
+        /// Whose activity feed this belongs on.
+        subject: MacroUserIdStr<'static>,
+    },
+}
+
+impl Attribution {
+    /// The principal acted for themselves.
+    pub fn direct(actor: Actor<'static>) -> Self {
+        Self::Direct { actor }
+    }
+
+    /// A bot or the platform acted for `subject`.
+    pub fn delegated(actor: Actor<'static>, subject: MacroUserIdStr<'static>) -> Self {
+        Self::Delegated { actor, subject }
+    }
+
+    /// Who mechanically acted.
+    pub fn actor(&self) -> Actor<'static> {
+        match self {
+            Self::Direct { actor } | Self::Delegated { actor, .. } => actor.clone(),
+        }
+    }
+
+    /// The initiating user when this action is delegated; `None` when direct.
+    pub fn on_behalf_of(&self) -> Option<MacroUserIdStr<'static>> {
+        match self {
+            Self::Direct { .. } => None,
+            Self::Delegated { subject, .. } => Some(subject.clone()),
+        }
+    }
+}
+
 /// The entity-kind vocabulary activities are recorded against (re-exported
 /// for domain mappings).
 pub use model_entity::EntityType;
@@ -380,6 +427,29 @@ pub struct Activity {
 }
 
 impl Activity {
+    /// Builds an activity for a [`CommonAction`] from a resolved
+    /// [`Attribution`].
+    pub fn attributed(
+        source_event_id: Uuid,
+        ordinal: u32,
+        attribution: Attribution,
+        entity_type: EntityType,
+        entity_id: impl Into<String>,
+        action: CommonAction,
+        occurred_at: DateTime<Utc>,
+    ) -> Self {
+        Self::common(
+            source_event_id,
+            ordinal,
+            attribution.actor(),
+            attribution.on_behalf_of(),
+            entity_type,
+            entity_id,
+            action,
+            occurred_at,
+        )
+    }
+
     /// Builds an activity for a [`CommonAction`] — valid on every entity
     /// kind by definition, so any (kind, id) pairing is accepted.
     #[allow(clippy::too_many_arguments)]

--- a/crates/activity/src/domain/models/test.rs
+++ b/crates/activity/src/domain/models/test.rs
@@ -136,6 +136,49 @@ fn activity_ids_are_deterministic_per_event_and_ordinal() {
 }
 
 #[test]
+fn attribution_direct_leaves_subject_on_the_actor() {
+    let actor = Actor::new_from_user(user("macro|teo@example.com"));
+    let attribution = Attribution::direct(actor.clone());
+
+    assert_eq!(attribution.actor(), actor);
+    assert_eq!(attribution.on_behalf_of(), None);
+
+    let activity = Activity::attributed(
+        Uuid::from_u128(4),
+        0,
+        attribution,
+        EntityType::Document,
+        "doc-1",
+        CommonAction::Created,
+        Utc::now(),
+    );
+    assert_eq!(activity.actor, actor);
+    assert_eq!(activity.subject_id, "macro|teo@example.com");
+}
+
+#[test]
+fn attribution_delegated_keeps_actor_and_scopes_the_subject() {
+    let actor = Actor::new_from_user(user("macro|agent@example.com"));
+    let subject = user("macro|teo@example.com");
+    let attribution = Attribution::delegated(actor.clone(), subject.clone());
+
+    assert_eq!(attribution.actor(), actor);
+    assert_eq!(attribution.on_behalf_of(), Some(subject));
+
+    let activity = Activity::attributed(
+        Uuid::from_u128(5),
+        0,
+        attribution,
+        EntityType::Document,
+        "doc-1",
+        CommonAction::Edited,
+        Utc::now(),
+    );
+    assert_eq!(activity.actor, actor);
+    assert_eq!(activity.subject_id, "macro|teo@example.com");
+}
+
+#[test]
 fn subject_is_the_actor_unless_delegated() {
     let direct = Activity::common(
         Uuid::from_u128(1),

--- a/crates/activity/src/lib.rs
+++ b/crates/activity/src/lib.rs
@@ -26,8 +26,8 @@ pub mod inbound;
 pub mod outbound;
 
 pub use domain::models::{
-    Action, ActionDecodeError, Activity, ActivityRecord, ActivitySource, Actor, CallStart,
-    CommonAction, DomainActivity, EntityType, Ingest, ParticipantChange, PropertyChange,
+    Action, ActionDecodeError, Activity, ActivityRecord, ActivitySource, Actor, Attribution,
+    CallStart, CommonAction, DomainActivity, EntityType, Ingest, ParticipantChange, PropertyChange,
     RecordedAction, VIEW_ACTION_TAGS, activity_id, event_time,
 };
 pub use domain::ports::{ActivityFeedPage, ActivityReads, EntityActivityMap};

--- a/crates/ai_tools/Cargo.toml
+++ b/crates/ai_tools/Cargo.toml
@@ -14,7 +14,9 @@ anthropic = { path = "../anthropic", features = ["toolset"] }
 attachment = { path = "../attachment" }
 non_empty = { path = "../non_empty" }
 ai_toolset = { path = "../ai_toolset" }
+activity = { path = "../activity", default-features = false }
 anyhow.workspace = true
+bot_id = { path = "../bot_id" }
 async-trait.workspace = true
 axum = { workspace = true, features = ["macros"] }
 aws-sdk-sqs.workspace = true

--- a/crates/ai_tools/src/tool_context.rs
+++ b/crates/ai_tools/src/tool_context.rs
@@ -896,7 +896,12 @@ impl ToolEntityCreator {
     ) -> anyhow::Result<String> {
         use std::str::FromStr as _;
         let document = documents::domain::create::NewPlainTextDocument::builder(
-            documents::domain::create::NewDocumentMetadata::new(name.to_string()),
+            documents::domain::create::NewDocumentMetadata::builder(name.to_string())
+                .attribution(activity::Attribution::delegated(
+                    activity::Actor::new_from_bot(bot_id::MACRO_AI_BOT_ID),
+                    user.clone(),
+                ))
+                .build(),
         )
         .file_type(model::document::FileType::from_str("md").expect("md is a valid file type"))
         .text(markdown.to_string())

--- a/crates/bot_id/src/lib.rs
+++ b/crates/bot_id/src/lib.rs
@@ -60,6 +60,13 @@ pub const MACRO_AI_HANDLE: &str = "macro";
 /// Display name for the "Macro" system bot.
 pub const MACRO_AI_NAME: &str = "Macro";
 
+/// Stable [`BotId`] for autonomous Macro platform operations.
+pub const MACRO_SYSTEM_BOT_ID: BotId =
+    BotId::new_from_uuid(Uuid::from_u128(0x0000_0000_0000_0000_0000_0000_0000_5759));
+
+/// Display name for the autonomous Macro platform principal.
+pub const MACRO_SYSTEM_NAME: &str = "Macro System";
+
 /// Stable [`BotId`] for the "Macro Coder" system bot, our coding-agent harness.
 ///
 /// Distinct from [`MACRO_AI_BOT_ID`] on purpose: mentioning Macro AI answers in

--- a/crates/bot_id/src/test.rs
+++ b/crates/bot_id/src/test.rs
@@ -37,6 +37,16 @@ fn bot_id_str_from_bot_id_creates_storage_string() {
 }
 
 #[test]
+fn system_bot_id_is_stable_and_distinct_from_ai_personas() {
+    assert_eq!(
+        MACRO_SYSTEM_BOT_ID.into_storage_id().as_ref(),
+        "bot|00000000-0000-0000-0000-000000005759"
+    );
+    assert_ne!(MACRO_SYSTEM_BOT_ID, MACRO_AI_BOT_ID);
+    assert_ne!(MACRO_SYSTEM_BOT_ID, MACRO_CODER_BOT_ID);
+}
+
+#[test]
 fn rejects_non_bot_storage_string() {
     assert!(BotIdStr::parse_from_str("macro|teo@macro.com").is_err());
 }

--- a/crates/documents/Cargo.toml
+++ b/crates/documents/Cargo.toml
@@ -72,6 +72,7 @@ service = ["dep:entity_access_management", "dep:foreign_entity", "ports"]
 
 [dependencies]
 activity = { path = "../activity", default-features = false }
+bot_id = { path = "../bot_id" }
 # Core
 anyhow = { workspace = true }
 chrono = { workspace = true }

--- a/crates/documents/src/domain/activity.rs
+++ b/crates/documents/src/domain/activity.rs
@@ -6,7 +6,9 @@
 #[cfg(test)]
 mod test;
 
-use ::activity::{Activity, ActivitySource, Actor, CommonAction, EntityType, Ingest, event_time};
+use ::activity::{
+    Activity, ActivitySource, Actor, Attribution, CommonAction, EntityType, Ingest, event_time,
+};
 use chrono::{DateTime, Utc};
 use uuid::Uuid;
 
@@ -18,15 +20,14 @@ impl ActivitySource for DocumentTopicEvent {
     /// Exhaustive on purpose: a new event variant fails compilation here
     /// until someone classifies it or explicitly drops it.
     fn ingest(&self, event_id: Uuid) -> Ingest {
-        let single = |actor: Actor<'static>,
+        let single = |attribution: Attribution,
                       action: CommonAction,
                       document_id: &str,
                       occurred_at: DateTime<Utc>| {
-            Ingest::Insert(vec![Activity::common(
+            Ingest::Insert(vec![Activity::attributed(
                 event_id,
                 0,
-                actor,
-                None,
+                attribution,
                 EntityType::Document,
                 document_id,
                 action,
@@ -35,15 +36,25 @@ impl ActivitySource for DocumentTopicEvent {
         };
 
         match self {
-            DocumentTopicEvent::Created(metadata) => single(
-                Actor::new_from_user(metadata.owner.clone()),
-                CommonAction::Created,
-                &metadata.document_id,
-                metadata.created_at.unwrap_or_else(|| event_time(event_id)),
-            ),
+            DocumentTopicEvent::Created(metadata) => {
+                let actor = metadata
+                    .actor
+                    .clone()
+                    .unwrap_or_else(|| Actor::new_from_user(metadata.owner.clone()));
+                let attribution = match metadata.on_behalf_of.clone() {
+                    Some(subject) => Attribution::delegated(actor, subject),
+                    None => Attribution::direct(actor),
+                };
+                single(
+                    attribution,
+                    CommonAction::Created,
+                    &metadata.document_id,
+                    metadata.created_at.unwrap_or_else(|| event_time(event_id)),
+                )
+            }
             DocumentTopicEvent::Updated(metadata) => match &metadata.actor_user_id {
                 Some(actor) => single(
-                    Actor::new_from_user(actor.clone()),
+                    Attribution::direct(Actor::new_from_user(actor.clone())),
                     CommonAction::Edited,
                     &metadata.document_id,
                     event_time(event_id),
@@ -52,7 +63,7 @@ impl ActivitySource for DocumentTopicEvent {
             },
             DocumentTopicEvent::Deleted(metadata) => match &metadata.actor_user_id {
                 Some(actor) => single(
-                    Actor::new_from_user(actor.clone()),
+                    Attribution::direct(Actor::new_from_user(actor.clone())),
                     CommonAction::Deleted,
                     &metadata.document_id,
                     event_time(event_id),
@@ -61,7 +72,7 @@ impl ActivitySource for DocumentTopicEvent {
             },
             // The copy is a new document; its creation is the activity.
             DocumentTopicEvent::Copied(metadata) => single(
-                Actor::new_from_user(metadata.owner.clone()),
+                Attribution::direct(Actor::new_from_user(metadata.owner.clone())),
                 CommonAction::Created,
                 &metadata.document_id,
                 event_time(event_id),

--- a/crates/documents/src/domain/activity/test.rs
+++ b/crates/documents/src/domain/activity/test.rs
@@ -40,6 +40,8 @@ fn created_maps_to_a_created_activity_with_the_metadata_timestamp() {
     let event = envelope(DocumentTopicEvent::Created(DocumentCreatedMetadata {
         document_id: DOCUMENT_ID.to_string(),
         owner: user("macro|creator@example.com"),
+        actor: None,
+        on_behalf_of: None,
         document_name: "spec".to_string(),
         file_type: Some(FileType::Md),
         project_id: None,
@@ -54,6 +56,55 @@ fn created_maps_to_a_created_activity_with_the_metadata_timestamp() {
     assert_eq!(activity.entity_id, DOCUMENT_ID);
     assert_eq!(activity.occurred_at, created_at);
     assert_eq!(activity.id, activity_id(event.event_id, 0));
+    assert_eq!(activity.actor.as_ref(), "macro|creator@example.com");
+}
+
+#[test]
+fn created_with_system_actor_is_not_the_owner_subject() {
+    let event = envelope(DocumentTopicEvent::Created(DocumentCreatedMetadata {
+        document_id: DOCUMENT_ID.to_string(),
+        owner: user("macro|owner@example.com"),
+        actor: Some(Actor::new_from_bot(bot_id::MACRO_SYSTEM_BOT_ID)),
+        on_behalf_of: None,
+        document_name: "invoice".to_string(),
+        file_type: None,
+        project_id: None,
+        sub_type: None,
+        created_at: None,
+    }));
+
+    let activity = single_activity(event.event.ingest(event.event_id));
+    assert_eq!(activity.action, Action::Created);
+    assert_eq!(
+        activity.actor.as_ref(),
+        bot_id::MACRO_SYSTEM_BOT_ID.into_storage_id().as_ref()
+    );
+    assert_eq!(
+        activity.subject_id,
+        bot_id::MACRO_SYSTEM_BOT_ID.into_storage_id().as_ref()
+    );
+}
+
+#[test]
+fn created_on_behalf_of_the_owner_stays_on_their_feed() {
+    let event = envelope(DocumentTopicEvent::Created(DocumentCreatedMetadata {
+        document_id: DOCUMENT_ID.to_string(),
+        owner: user("macro|owner@example.com"),
+        actor: Some(Actor::new_from_bot(bot_id::MACRO_SYSTEM_BOT_ID)),
+        on_behalf_of: Some(user("macro|owner@example.com")),
+        document_name: "welcome".to_string(),
+        file_type: None,
+        project_id: None,
+        sub_type: None,
+        created_at: None,
+    }));
+
+    let activity = single_activity(event.event.ingest(event.event_id));
+    assert_eq!(
+        activity.actor.as_ref(),
+        bot_id::MACRO_SYSTEM_BOT_ID.into_storage_id().as_ref()
+    );
+    assert_eq!(activity.subject_id, "macro|owner@example.com");
 }
 
 #[test]

--- a/crates/documents/src/domain/create/mod.rs
+++ b/crates/documents/src/domain/create/mod.rs
@@ -5,6 +5,7 @@
 //! call sites should choose the lifecycle they need (`create_markdown_text` or
 //! `create_text_file`).
 
+use activity::Attribution;
 use anyhow::Context;
 use base64::Engine;
 use macro_user_id::user_id::MacroUserIdStr;
@@ -30,6 +31,7 @@ pub struct NewDocumentMetadata {
     email_attachment_id: Option<uuid::Uuid>,
     created_at: Option<chrono::DateTime<chrono::Utc>>,
     skip_history: bool,
+    attribution: Option<Attribution>,
 }
 
 impl NewDocumentMetadata {
@@ -48,6 +50,7 @@ impl NewDocumentMetadata {
                 email_attachment_id: None,
                 created_at: None,
                 skip_history: false,
+                attribution: None,
             },
         }
     }
@@ -69,6 +72,7 @@ impl NewDocumentMetadata {
             created_at: self.created_at,
             sub_type: kind.subtype.sub_type(),
             skip_history: self.skip_history,
+            attribution: self.attribution,
         }
     }
 }
@@ -107,6 +111,12 @@ impl NewDocumentMetadataBuilder {
     /// Skip adding this document to user history.
     pub fn skip_history(mut self) -> Self {
         self.metadata.skip_history = true;
+        self
+    }
+
+    /// Attribute the create without changing document ownership.
+    pub fn attribution(mut self, attribution: Attribution) -> Self {
+        self.metadata.attribution = Some(attribution);
         self
     }
 
@@ -730,11 +740,66 @@ fn file_shas(file_content: &[u8]) -> FileShas {
 
 #[cfg(test)]
 mod tests {
-    use super::{MarkdownSubtype, NewDocumentMetadata, NewPlainTextDocument, file_shas};
+    use super::{
+        MarkdownSubtype, NewDocumentMetadata, NewPlainTextDocument, RepoDocumentKind,
+        RepoDocumentSubtype, file_shas,
+    };
+    use activity::{Actor, Attribution};
+    use macro_user_id::user_id::MacroUserIdStr;
     use model::document::FileType;
 
     fn metadata() -> NewDocumentMetadata {
         NewDocumentMetadata::new("test")
+    }
+
+    fn owner() -> MacroUserIdStr<'static> {
+        MacroUserIdStr::try_from("macro|owner@example.com".to_string()).unwrap()
+    }
+
+    fn repo_kind() -> RepoDocumentKind {
+        RepoDocumentKind {
+            file_type: Some(FileType::Md),
+            sha: "sha".to_string(),
+            subtype: RepoDocumentSubtype::Regular,
+            team_id: None,
+        }
+    }
+
+    #[test]
+    fn creation_attribution_defaults_to_none() {
+        let args = metadata().into_repo_args(owner(), repo_kind());
+        assert_eq!(args.attribution, None);
+        assert_eq!(
+            args.resolved_attribution(),
+            Attribution::direct(Actor::new_from_user(owner()))
+        );
+    }
+
+    #[test]
+    fn email_attachment_create_resolves_to_the_system_principal() {
+        let args = NewDocumentMetadata::builder("invoice.pdf")
+            .email_attachment_id(uuid::Uuid::from_u128(1))
+            .build()
+            .into_repo_args(owner(), repo_kind());
+
+        assert_eq!(args.user_id.as_ref(), "macro|owner@example.com");
+        assert_eq!(
+            args.resolved_attribution(),
+            Attribution::direct(Actor::new_from_bot(bot_id::MACRO_SYSTEM_BOT_ID))
+        );
+    }
+
+    #[test]
+    fn creation_attribution_can_be_set_without_changing_owner() {
+        let attribution =
+            Attribution::delegated(Actor::new_from_bot(bot_id::MACRO_SYSTEM_BOT_ID), owner());
+        let args = NewDocumentMetadata::builder("welcome")
+            .attribution(attribution.clone())
+            .build()
+            .into_repo_args(owner(), repo_kind());
+
+        assert_eq!(args.user_id.as_ref(), "macro|owner@example.com");
+        assert_eq!(args.resolved_attribution(), attribution);
     }
 
     #[test]

--- a/crates/documents/src/domain/events.rs
+++ b/crates/documents/src/domain/events.rs
@@ -7,6 +7,7 @@
 #[cfg(test)]
 mod test;
 
+use activity::Actor;
 use chrono::{DateTime, Utc};
 use document_sub_type::DocumentSubType;
 use macro_event_broker::{Event, MacroEvent, TopicEvent};
@@ -25,6 +26,15 @@ pub struct DocumentCreatedMetadata {
     pub document_id: String,
     /// The owner (creator) of the document.
     pub owner: MacroUserIdStr<'static>,
+    /// Who mechanically created the document. Absent on events published
+    /// before attribution: ingest then treats [`Self::owner`] as the actor.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "schema", schema(value_type = Option<String>))]
+    pub actor: Option<Actor<'static>>,
+    /// The user whose feed this creation belongs on, when different from
+    /// [`Self::actor`]. Absent means the actor is also the subject.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub on_behalf_of: Option<MacroUserIdStr<'static>>,
     /// The document name, with any file extension stripped.
     pub document_name: String,
     /// File type of the document, when known.

--- a/crates/documents/src/domain/events/test.rs
+++ b/crates/documents/src/domain/events/test.rs
@@ -185,6 +185,36 @@ fn search_event_constructors_use_the_document_key_and_schema_v1() {
 }
 
 #[test]
+fn created_events_without_attribution_still_decode() {
+    let payload = json!({
+        "event_id": "00000000-0000-0000-0000-000000000005",
+        "schema_version": 1,
+        "event_type": "document.created",
+        "metadata": {
+            "document_id": DOCUMENT_ID,
+            "owner": "macro|owner@example.com",
+            "document_name": "notes",
+            "file_type": null,
+            "project_id": null,
+            "sub_type": null,
+            "created_at": null,
+        },
+    });
+
+    let decoded: Event<DocumentTopicEvent> =
+        serde_json::from_value(payload).expect("pre-attribution created event decodes");
+
+    match decoded.event {
+        DocumentTopicEvent::Created(metadata) => {
+            assert_eq!(metadata.owner.as_ref(), "macro|owner@example.com");
+            assert_eq!(metadata.actor, None);
+            assert_eq!(metadata.on_behalf_of, None);
+        }
+        other => panic!("expected created, got {other:?}"),
+    }
+}
+
+#[test]
 fn existing_v1_document_events_still_decode() {
     let payload = json!({
         "event_id": "00000000-0000-0000-0000-000000000004",

--- a/crates/documents/src/domain/models.rs
+++ b/crates/documents/src/domain/models.rs
@@ -1,5 +1,6 @@
 //! Domain models for the documents crate.
 
+use activity::{Actor, Attribution};
 use chrono::{DateTime, Utc};
 use macro_user_id::user_id::MacroUserIdStr;
 use model::document::response::DocumentResponseMetadata;
@@ -329,6 +330,24 @@ pub struct CreateDocumentRepoArgs {
     pub sub_type: Option<document_sub_type::DocumentSubType>,
     /// Whether to skip adding to user history.
     pub skip_history: bool,
+    /// Explicit activity attribution. Unset uses [`Self::resolved_attribution`].
+    pub attribution: Option<Attribution>,
+}
+
+impl CreateDocumentRepoArgs {
+    /// Resolves who created this document for activity recording.
+    ///
+    /// Ownership (`user_id`) is unchanged. Email auto-imports default to
+    /// the system principal so they do not appear on the owner's feed.
+    pub fn resolved_attribution(&self) -> Attribution {
+        self.attribution.clone().unwrap_or_else(|| {
+            if self.email_attachment_id.is_some() {
+                Attribution::direct(Actor::new_from_bot(bot_id::MACRO_SYSTEM_BOT_ID))
+            } else {
+                Attribution::direct(Actor::new_from_user(self.user_id.clone()))
+            }
+        })
+    }
 }
 
 /// Configuration for CloudFront presigned URL generation.

--- a/crates/documents/src/domain/service.rs
+++ b/crates/documents/src/domain/service.rs
@@ -1051,6 +1051,7 @@ impl<
         let file_type = args.file_type;
         let project_id = args.project_id;
         let sha = args.sha.clone();
+        let attribution = args.resolved_attribution();
 
         // The owner's team default link-share preference decides the initial
         // share permission; without a team the per-file-type default applies.
@@ -1177,6 +1178,8 @@ impl<
             DocumentCreatedMetadata {
                 document_id: document_metadata.document_id.clone(),
                 owner: document_metadata.owner.clone(),
+                actor: Some(attribution.actor()),
+                on_behalf_of: attribution.on_behalf_of(),
                 document_name: document_metadata.document_name.clone(),
                 file_type,
                 project_id: project_id.map(|p| p.to_string()),

--- a/crates/documents/src/domain/service/tests.rs
+++ b/crates/documents/src/domain/service/tests.rs
@@ -1904,6 +1904,7 @@ fn create_document_repo_args(file_type: FileType) -> CreateDocumentRepoArgs {
         created_at: None,
         sub_type: None,
         skip_history: false,
+        attribution: None,
     }
 }
 
@@ -1989,6 +1990,52 @@ async fn create_document_repo_receives_disabled_share_when_team_turned_link_shar
 
     create_document_with_team_default(Some(TeamLinkShareDefault(None)), FileType::Md, None, None)
         .await;
+}
+
+#[tokio::test]
+async fn create_document_publishes_resolved_attribution() {
+    let mut repo = make_mock_repo();
+    repo.expect_get_team_default_link_share()
+        .returning(|_| Box::pin(std::future::ready(Ok(None))));
+    let created_metadata = make_test_metadata();
+    repo.expect_create_document()
+        .returning(move |_, _| Box::pin(std::future::ready(Ok(created_metadata.clone()))));
+    repo.expect_set_document_content()
+        .returning(|_, _| Box::pin(std::future::ready(Ok(()))));
+    repo.expect_get_team_task_metadata()
+        .returning(|_| Box::pin(std::future::ready(Ok(None))));
+
+    let (service, event_broker) = make_test_service_with_event_broker(repo);
+    let mut args = create_document_repo_args(FileType::Txt);
+    args.email_attachment_id = Some(uuid::Uuid::from_u128(7));
+
+    crate::domain::ports::DocumentService::create_document(
+        &service,
+        macro_user_id::user_id::MacroUserIdStr::parse_from_str("macro|user@user.com")
+            .unwrap()
+            .into_owned(),
+        args,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let published = event_broker.published();
+    let published = published.lock().unwrap();
+    assert_eq!(published[0].payload["event_type"], "document.created");
+    assert_eq!(
+        published[0].payload["metadata"]["owner"],
+        "macro|user@user.com"
+    );
+    assert_eq!(
+        published[0].payload["metadata"]["actor"],
+        bot_id::MACRO_SYSTEM_BOT_ID.into_storage_id().as_ref()
+    );
+    assert!(
+        published[0].payload["metadata"]
+            .get("on_behalf_of")
+            .is_none()
+    );
 }
 
 #[tokio::test]

--- a/crates/documents/src/inbound/axum_router/create_document.rs
+++ b/crates/documents/src/inbound/axum_router/create_document.rs
@@ -102,6 +102,7 @@ pub async fn create_document_handler<
             .is_task
             .then_some(document_sub_type::DocumentSubType::Task),
         skip_history: req.skip_history,
+        attribution: None,
     };
 
     let response_data = state

--- a/crates/documents/src/outbound/pg_document_repo.rs
+++ b/crates/documents/src/outbound/pg_document_repo.rs
@@ -430,6 +430,7 @@ impl DocumentRepo for PgDocumentRepo {
             created_at: provided_created_at,
             sub_type: requested_sub_type,
             skip_history,
+            attribution: _,
         } = args;
 
         let now = chrono::Utc::now();

--- a/crates/documents/src/outbound/pg_document_repo/tests.rs
+++ b/crates/documents/src/outbound/pg_document_repo/tests.rs
@@ -46,6 +46,7 @@ fn create_document_args(
         created_at: None,
         sub_type: is_task.then_some(document_sub_type::DocumentSubType::Task),
         skip_history: false,
+        attribution: None,
     }
 }
 

--- a/crates/soup_realtime/src/inbound/kafka_consumer/test.rs
+++ b/crates/soup_realtime/src/inbound/kafka_consumer/test.rs
@@ -121,6 +121,8 @@ fn document_lifecycle_events_map_to_updated_and_deleted_patches() {
     let created = DocumentTopicEvent::Created(DocumentCreatedMetadata {
         document_id: DOCUMENT_ID.to_string(),
         owner: user(),
+        actor: None,
+        on_behalf_of: None,
         document_name: "Created".to_string(),
         file_type: None,
         project_id: None,

--- a/crates/webhook/src/domain/ingestion/test.rs
+++ b/crates/webhook/src/domain/ingestion/test.rs
@@ -447,6 +447,8 @@ fn document_event_cases() -> Vec<EventCase> {
                 DocumentTopicEvent::Created(DocumentCreatedMetadata {
                     document_id: DOCUMENT_ID.to_string(),
                     owner: user_id("macro|owner@example.com"),
+                    actor: None,
+                    on_behalf_of: None,
                     document_name: "notes".to_string(),
                     file_type: None,
                     project_id: None,

--- a/packages/sdk/generated/storage/types.gen.ts
+++ b/packages/sdk/generated/storage/types.gen.ts
@@ -3743,6 +3743,11 @@ export type DocumentCopiedMetadata = {
  */
 export type DocumentCreatedMetadata = {
     /**
+     * Who mechanically created the document. Absent on events published
+     * before attribution: ingest then treats [`Self::owner`] as the actor.
+     */
+    actor?: string | null;
+    /**
      * Creation timestamp reported by the repository.
      */
     created_at?: string | null;
@@ -3755,6 +3760,7 @@ export type DocumentCreatedMetadata = {
      */
     document_name: string;
     file_type?: null | FileType;
+    on_behalf_of?: null | MacroUserIdStr;
     /**
      * The owner (creator) of the document.
      */

--- a/packages/sdk/specs/storage.json
+++ b/packages/sdk/specs/storage.json
@@ -16474,6 +16474,10 @@
         "description": "Metadata for [`DocumentTopicEvent::Created`].",
         "required": ["document_id", "owner", "document_name"],
         "properties": {
+          "actor": {
+            "type": ["string", "null"],
+            "description": "Who mechanically created the document. Absent on events published\nbefore attribution: ingest then treats [`Self::owner`] as the actor."
+          },
           "created_at": {
             "type": ["string", "null"],
             "format": "date-time",
@@ -16495,6 +16499,17 @@
               {
                 "$ref": "#/components/schemas/FileType",
                 "description": "File type of the document, when known."
+              }
+            ]
+          },
+          "on_behalf_of": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/MacroUserIdStr",
+                "description": "The user whose feed this creation belongs on, when different from\n[`Self::actor`]. Absent means the actor is also the subject."
               }
             ]
           },

--- a/services/document_storage_service/Cargo.toml
+++ b/services/document_storage_service/Cargo.toml
@@ -48,6 +48,7 @@ axum = { workspace = true, features = [
 axum-extra = { workspace = true }
 base64 = { workspace = true }
 bots = { path = "../../crates/bots" }
+bot_id = { path = "../../crates/bot_id" }
 bytes = { workspace = true }
 calendar_events = { path = "../../crates/calendar_events", features = ["dispatch-sqs", "inbound", "notify", "postgres"] }
 bzip2 = { workspace = true, default-features = false, features = [

--- a/services/document_storage_service/src/api/documents/initialize_starter_docs.rs
+++ b/services/document_storage_service/src/api/documents/initialize_starter_docs.rs
@@ -1,4 +1,5 @@
 use crate::api::context::{ApiContext, AuthorizationService};
+use activity::{Actor, Attribution};
 use axum::{
     extract::State,
     response::{IntoResponse, Json, Response},
@@ -170,6 +171,10 @@ pub async fn handler(
     tracing::info!("initialize starter docs");
 
     let user_id = &user_context.authorization.user.macro_user_id;
+    let system_for_user = Attribution::delegated(
+        Actor::new_from_bot(bot_id::MACRO_SYSTEM_BOT_ID),
+        user_id.clone(),
+    );
 
     // Resolve every starter document's deterministic id up front so the
     // templates can cross-link before any document has been created.
@@ -202,6 +207,7 @@ pub async fn handler(
                 NewMarkdownTextDocument {
                     metadata: NewDocumentMetadata::builder(task.name)
                         .id(starter_doc_id(user_id, task.name))
+                        .attribution(system_for_user.clone())
                         .build(),
                     markdown: fill(task.template),
                     subtype: MarkdownSubtype::Task {
@@ -232,6 +238,7 @@ pub async fn handler(
             NewMarkdownTextDocument {
                 metadata: NewDocumentMetadata::builder(HOW_TO_GUIDE_NAME)
                     .id(starter_doc_id(user_id, HOW_TO_GUIDE_NAME))
+                    .attribution(system_for_user.clone())
                     .build(),
                 markdown: fill(HOW_TO_GUIDE_TEMPLATE),
                 subtype: MarkdownSubtype::Note,

--- a/services/search_processing_service/src/inbound/kafka_consumer/test.rs
+++ b/services/search_processing_service/src/inbound/kafka_consumer/test.rs
@@ -828,6 +828,8 @@ fn document_event_cases() -> Vec<(DocumentTopicEvent, DocumentEventDescription)>
             DocumentTopicEvent::Created(DocumentCreatedMetadata {
                 document_id: DOCUMENT_ID.to_string(),
                 owner: owner.clone(),
+                actor: None,
+                on_behalf_of: None,
                 document_name: "Document".to_string(),
                 file_type: Some(FileType::Pdf),
                 project_id: Some(PROJECT_ID.to_string()),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Activity is the record of who did what. Document creates still treated the owner as the actor, so email auto-import, onboarding, and AI-created docs all looked like the user did them.

Feeds already key on `subject_id` (`on_behalf_of ?? actor`). That is enough to split the mechanical actor from the user the event belongs to. A new initiator column is not needed.

## Scope

`Attribution` is `Direct { actor }` or `Delegated { actor, subject }`. `Activity::attributed` is the constructor that writes that pairing.

`MACRO_SYSTEM_BOT_ID` is a new platform principal, separate from Macro AI and Macro Coder.

`DocumentCreatedMetadata` now carries optional `actor` and `on_behalf_of`. Older Kafka events still decode. Ingest falls back to `owner` when `actor` is absent.

`CreateDocumentRepoArgs::resolved_attribution` picks the pairing. Ownership (`user_id`) does not change.

- Email auto-import (`email_attachment_id` set) is Direct on the system bot. It does not land on the owner's feed.
- Starter docs are Delegated (system for the user).
- AI / `create_doc` imports are Delegated (Macro AI for the user).
- A normal user create stays Direct on that user.

Collab / `SyncContentUpdated` edits still have no actor and stay ignored. Property writes on starter docs still use the user as actor.

## Tradeoffs

Email import infers system Direct from `email_attachment_id` instead of requiring every call site to pass `Attribution`. Callers that set an attachment id and also want user attribution must pass it explicitly.

## Blast Radius

Create events on `macro.documents` gain two optional fields. Consumers that ignore unknown fields keep working. Activity rows for email import, starter docs, and AI creates change actor and subject, which changes "Your activity" and entity timelines for those creates going forward. Existing rows are untouched.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a1381642-d8e6-4e7a-8c8e-a86c6a163b66?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a1381642-d8e6-4e7a-8c8e-a86c6a163b66&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

