### PR TITLE
feat(activity): add actor-index feed for first-party bots

### DIFF
--- a/.sqlx/query-2b300a81580168701bdabf03dd728f17ecd6e7946b663365ecbdef58de170a3c.json
+++ b/.sqlx/query-2b300a81580168701bdabf03dd728f17ecd6e7946b663365ecbdef58de170a3c.json
@@ -1,0 +1,65 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                    SELECT id, actor_id, action, action_payload,\n                           subject_id, entity_type, entity_id, occurred_at\n                    FROM activity_events\n                    WHERE actor_id = $1\n                    ORDER BY occurred_at DESC, id DESC\n                    LIMIT $2\n                    ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "actor_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "action",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "action_payload",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "subject_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "entity_type",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "entity_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "occurred_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "2b300a81580168701bdabf03dd728f17ecd6e7946b663365ecbdef58de170a3c"
+}

--- a/.sqlx/query-5fb3874e54a8e53a142448faecff35fd8afcdb9b34d391d9913c18efa33a76fa.json
+++ b/.sqlx/query-5fb3874e54a8e53a142448faecff35fd8afcdb9b34d391d9913c18efa33a76fa.json
@@ -1,0 +1,67 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                    SELECT id, actor_id, action, action_payload,\n                           subject_id, entity_type, entity_id, occurred_at\n                    FROM activity_events\n                    WHERE actor_id = $1 AND (occurred_at, id) < ($2, $3)\n                    ORDER BY occurred_at DESC, id DESC\n                    LIMIT $4\n                    ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "actor_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "action",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "action_payload",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "subject_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "entity_type",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "entity_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "occurred_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Timestamptz",
+        "Uuid",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "5fb3874e54a8e53a142448faecff35fd8afcdb9b34d391d9913c18efa33a76fa"
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6758,6 +6758,7 @@ version = "0.1.0"
 dependencies = [
  "activity",
  "async-graphql",
+ "bot_id",
  "chrono",
  "futures",
  "graphql_common",

--- a/crates/activity/src/domain/ports.rs
+++ b/crates/activity/src/domain/ports.rs
@@ -66,6 +66,17 @@ pub trait ActivityReads {
         limit: NonZeroU32,
     ) -> impl Future<Output = Result<ActivityFeedPage, Self::Err>> + Send;
 
+    /// One page of a mechanical actor's activity, newest first. Same
+    /// keyset and limit rules as [`Self::subject_feed`]. Use this for a
+    /// bot's own actions, which never appear as `subject_id` when they
+    /// were delegated to a user.
+    fn actor_feed(
+        &self,
+        actor_id: &str,
+        cursor: Option<(DateTime<Utc>, Uuid)>,
+        limit: NonZeroU32,
+    ) -> impl Future<Output = Result<ActivityFeedPage, Self::Err>> + Send;
+
     /// The newest `per_entity_limit` activities for each requested entity,
     /// in one round trip. Entities with no activity are absent from the map.
     fn entity_activity(

--- a/crates/activity/src/outbound/pg_activity_repo.rs
+++ b/crates/activity/src/outbound/pg_activity_repo.rs
@@ -121,6 +121,18 @@ struct StoredRow {
 }
 
 impl StoredRow {
+    fn into_page(mut rows: Vec<Self>, limit: u32) -> ActivityFeedPage {
+        let has_more = rows.len() > limit as usize;
+        rows.truncate(limit as usize);
+        let next = has_more
+            .then(|| rows.last().map(|row| (row.occurred_at, row.id)))
+            .flatten();
+        ActivityFeedPage {
+            records: rows.into_iter().filter_map(Self::decode).collect(),
+            next,
+        }
+    }
+
     /// Decodes the raw row, forward-tolerantly for the action and
     /// skip-with-warn for corruption the model can't represent: one bad row
     /// must not fail a whole page.
@@ -184,7 +196,7 @@ impl ActivityReads for PgActivityRepo {
         let fetch = i64::from(limit) + 1;
         // Two static queries instead of one `$x IS NULL OR …` merge, which
         // would defeat the (subject_id, occurred_at DESC, id DESC) index.
-        let mut rows = match cursor {
+        let rows = match cursor {
             None => {
                 sqlx::query_as!(
                     StoredRow,
@@ -223,15 +235,57 @@ impl ActivityReads for PgActivityRepo {
             }
         };
 
-        let has_more = rows.len() > limit as usize;
-        rows.truncate(limit as usize);
-        let next = has_more
-            .then(|| rows.last().map(|row| (row.occurred_at, row.id)))
-            .flatten();
-        Ok(ActivityFeedPage {
-            records: rows.into_iter().filter_map(StoredRow::decode).collect(),
-            next,
-        })
+        Ok(StoredRow::into_page(rows, limit))
+    }
+
+    async fn actor_feed(
+        &self,
+        actor_id: &str,
+        cursor: Option<(DateTime<Utc>, Uuid)>,
+        limit: NonZeroU32,
+    ) -> Result<ActivityFeedPage, Self::Err> {
+        let limit = limit.get();
+        let fetch = i64::from(limit) + 1;
+        let rows = match cursor {
+            None => {
+                sqlx::query_as!(
+                    StoredRow,
+                    r#"
+                    SELECT id, actor_id, action, action_payload,
+                           subject_id, entity_type, entity_id, occurred_at
+                    FROM activity_events
+                    WHERE actor_id = $1
+                    ORDER BY occurred_at DESC, id DESC
+                    LIMIT $2
+                    "#,
+                    actor_id,
+                    fetch,
+                )
+                .fetch_all(&self.pool)
+                .await?
+            }
+            Some((cursor_at, cursor_id)) => {
+                sqlx::query_as!(
+                    StoredRow,
+                    r#"
+                    SELECT id, actor_id, action, action_payload,
+                           subject_id, entity_type, entity_id, occurred_at
+                    FROM activity_events
+                    WHERE actor_id = $1 AND (occurred_at, id) < ($2, $3)
+                    ORDER BY occurred_at DESC, id DESC
+                    LIMIT $4
+                    "#,
+                    actor_id,
+                    cursor_at,
+                    cursor_id,
+                    fetch,
+                )
+                .fetch_all(&self.pool)
+                .await?
+            }
+        };
+
+        Ok(StoredRow::into_page(rows, limit))
     }
 
     async fn entity_activity(

--- a/crates/activity/src/outbound/pg_activity_repo/test.rs
+++ b/crates/activity/src/outbound/pg_activity_repo/test.rs
@@ -4,7 +4,7 @@ use macro_user_id::user_id::MacroUserIdStr;
 use uuid::Uuid;
 
 use super::*;
-use crate::domain::models::{Action, Actor, CommonAction};
+use crate::domain::models::{Action, Activity, Actor, Attribution, CommonAction};
 
 fn user(id: &str) -> MacroUserIdStr<'static> {
     MacroUserIdStr::try_from(id.to_string()).expect("valid user id")
@@ -372,4 +372,40 @@ async fn a_corrupt_row_shrinks_the_page_but_never_ends_pagination(pool: PgPool) 
     assert_eq!(second.records.len(), 1);
     assert_eq!(second.records[0].entity_id, "doc-old");
     assert_eq!(second.next, None);
+}
+
+fn system_bot() -> Actor<'static> {
+    Actor::try_from("bot|00000000-0000-0000-0000-000000005759".to_string()).expect("system bot")
+}
+
+#[sqlx::test(migrator = "MACRO_DB_MIGRATIONS")]
+async fn actor_feed_lists_delegated_actions_the_bot_subject_feed_does_not(pool: PgPool) {
+    let repo = PgActivityRepo::new(pool.clone());
+    let owner = user("macro|owner@example.com");
+    let delegated = Activity::attributed(
+        Uuid::from_u128(60),
+        0,
+        Attribution::delegated(system_bot(), owner.clone()),
+        model_entity::EntityType::Document,
+        "doc-system",
+        CommonAction::Created,
+        Utc::now(),
+    );
+    repo.insert_activities(&[delegated, seed(61, CommonAction::Edited, "doc-user")])
+        .await
+        .unwrap();
+
+    let actor_page = repo
+        .actor_feed(system_bot().as_ref(), None, nz(10))
+        .await
+        .unwrap();
+    assert_eq!(actor_page.records.len(), 1);
+    assert_eq!(actor_page.records[0].entity_id, "doc-system");
+    assert_eq!(actor_page.records[0].subject_id, owner.as_ref());
+
+    let bot_as_subject = repo
+        .subject_feed(system_bot().as_ref(), None, nz(10))
+        .await
+        .unwrap();
+    assert!(bot_as_subject.records.is_empty());
 }

--- a/crates/bot_id/src/lib.rs
+++ b/crates/bot_id/src/lib.rs
@@ -112,6 +112,14 @@ impl BotId {
             .map_err(|_| BotIdParseError::invalid(value))
     }
 
+    /// First-party Macro platform bots (AI, system, coder).
+    pub const fn is_first_party(self) -> bool {
+        matches!(
+            self,
+            MACRO_AI_BOT_ID | MACRO_SYSTEM_BOT_ID | MACRO_CODER_BOT_ID
+        )
+    }
+
     /// Canonical storage representation as a parsed [`BotIdStr`].
     pub fn into_storage_id(self) -> BotIdStr<'static> {
         let storage_id = format!("{BOT_STORAGE_PREFIX}|{}", self.0);

--- a/crates/bot_id/src/test.rs
+++ b/crates/bot_id/src/test.rs
@@ -44,6 +44,10 @@ fn system_bot_id_is_stable_and_distinct_from_ai_personas() {
     );
     assert_ne!(MACRO_SYSTEM_BOT_ID, MACRO_AI_BOT_ID);
     assert_ne!(MACRO_SYSTEM_BOT_ID, MACRO_CODER_BOT_ID);
+    assert!(MACRO_SYSTEM_BOT_ID.is_first_party());
+    assert!(MACRO_AI_BOT_ID.is_first_party());
+    assert!(MACRO_CODER_BOT_ID.is_first_party());
+    assert!(!BotId::TEST_A.is_first_party());
 }
 
 #[test]

--- a/crates/complete_graph/src/schema.rs
+++ b/crates/complete_graph/src/schema.rs
@@ -13,7 +13,7 @@ use entity_access::domain::ports::{EntityAccessService, NoOpEntityAccessService}
 use entity_mutation::{EntityMutationService, UnavailableEntityMutationService};
 use graphql_activity::{
     ActivityFeedInput, ActivityReader, GraphqlActivityPage, NoOpActivityReader,
-    resolve_activity_feed,
+    resolve_activity_feed, resolve_actor_activity,
 };
 use graphql_channel::{
     ChannelActivityAuthorizer, ChannelActivityMutationService, ChannelMutationRoot,
@@ -534,6 +534,21 @@ where
         input: ActivityFeedInput,
     ) -> async_graphql::Result<GraphqlActivityPage> {
         resolve_activity_feed::<AcR>(ctx, &self.user_id, input).await
+    }
+
+    /// A page of activity performed by `actor_id`, newest first.
+    ///
+    /// `actor_id` must be the viewer or a first-party Macro bot
+    /// (`bot|<uuid>`). Use this for a bot's mechanical actions, which
+    /// do not appear on that bot's subject feed when they were
+    /// delegated to a user.
+    async fn actor_activity(
+        &self,
+        ctx: &Context<'_>,
+        actor_id: String,
+        input: ActivityFeedInput,
+    ) -> async_graphql::Result<GraphqlActivityPage> {
+        resolve_actor_activity::<AcR>(ctx, &self.user_id, actor_id, input).await
     }
 
     /// Authenticated user email catalog fields supplied by `graphql_email`.

--- a/crates/complete_graph/src/schema/test.rs
+++ b/crates/complete_graph/src/schema/test.rs
@@ -560,6 +560,34 @@ impl graphql_activity::ActivityFeedReader for RecordingActivityReader {
             next,
         })
     }
+
+    async fn actor_feed(
+        &self,
+        actor_id: &str,
+        cursor: Option<(chrono::DateTime<chrono::Utc>, Uuid)>,
+        limit: std::num::NonZeroU32,
+    ) -> Result<activity::ActivityFeedPage, graphql_activity::ActivityReadFailed> {
+        let limit = limit.get();
+        let records = self.records.lock().expect("activity records lock").clone();
+        let mut page: Vec<activity::ActivityRecord> = records
+            .into_iter()
+            .filter(|record| record.actor.as_ref() == actor_id)
+            .filter(|record| {
+                cursor.is_none_or(|(occurred_at, id)| {
+                    (record.occurred_at, record.id) < (occurred_at, id)
+                })
+            })
+            .collect();
+        let has_more = page.len() > limit as usize;
+        page.truncate(limit as usize);
+        let next = has_more
+            .then(|| page.last().map(|record| (record.occurred_at, record.id)))
+            .flatten();
+        Ok(activity::ActivityFeedPage {
+            records: page,
+            next,
+        })
+    }
 }
 
 fn parsed_message(thread_id: Uuid) -> ParsedMessage {
@@ -1627,6 +1655,49 @@ async fn activity_feed_pages_by_cursor_and_carries_unknown_actions() {
     let (cursor_at, cursor_id) = feed_calls[1].1.expect("second page carries the cursor");
     assert_eq!(cursor_at, chrono::DateTime::from_timestamp(200, 0).unwrap());
     assert_eq!(cursor_id, Uuid::from_u128(2));
+}
+
+#[tokio::test]
+async fn actor_activity_returns_bot_actions_and_rejects_other_users() {
+    let harness = harness();
+    let doc = Uuid::from_u128(72).to_string();
+    let mut record = activity_record(
+        8,
+        ModelEntityType::Document,
+        &doc,
+        activity::RecordedAction::Known(activity::Action::Created),
+        400,
+    );
+    record.actor =
+        activity::Actor::try_from("bot|00000000-0000-0000-0000-000000005759".to_string()).unwrap();
+    harness.activity_reader.set_records(vec![record]);
+
+    let ok = harness
+        .execute(
+            r#"{ user { actorActivity(actorId: "bot|00000000-0000-0000-0000-000000005759", input: {limit: 10}) { items { entityId actorId subjectId } nextCursor } } }"#,
+        )
+        .await;
+    assert!(ok.errors.is_empty(), "{:?}", ok.errors);
+    let items = &ok.data.into_json().unwrap()["user"]["actorActivity"]["items"];
+    assert_eq!(items.as_array().map(Vec::len), Some(1));
+    assert_eq!(items[0]["entityId"], doc);
+    assert_eq!(
+        items[0]["actorId"],
+        "bot|00000000-0000-0000-0000-000000005759"
+    );
+    assert_eq!(items[0]["subjectId"], VALID_USER_ID);
+
+    let denied = harness
+        .execute(
+            r#"{ user { actorActivity(actorId: "macro|other@example.com", input: {limit: 10}) { items { entityId } } } }"#,
+        )
+        .await;
+    assert!(!denied.errors.is_empty());
+    assert!(
+        denied.errors[0]
+            .message
+            .contains("actor activity is only available")
+    );
 }
 
 #[tokio::test]

--- a/crates/graphql_activity/Cargo.toml
+++ b/crates/graphql_activity/Cargo.toml
@@ -7,6 +7,7 @@ version = "0.1.0"
 [dependencies]
 activity = { path = "../activity", default-features = false }
 async-graphql = { workspace = true, features = ["dataloader"] }
+bot_id = { path = "../bot_id" }
 chrono = { workspace = true }
 futures = { workspace = true }
 graphql_common = { path = "../graphql_common" }

--- a/crates/graphql_activity/src/feed.rs
+++ b/crates/graphql_activity/src/feed.rs
@@ -1,6 +1,7 @@
 use std::num::NonZeroU32;
 
 use async_graphql::{Context, InputObject, SimpleObject};
+use bot_id::BotIdStr;
 use chrono::{DateTime, Utc};
 use macro_user_id::user_id::MacroUserIdStr;
 use models_pagination::{Base64Str, CursorVal, CursorWithVal, Sortable};
@@ -97,6 +98,51 @@ where
 
     let page = reader
         .subject_feed(user_id.as_ref(), cursor, limit)
+        .await
+        .map_err(|_| async_graphql::Error::new("activity feed is unavailable"))?;
+
+    Ok(GraphqlActivityPage {
+        items: page.records.into_iter().map(Into::into).collect(),
+        next_cursor: page
+            .next
+            .map(|(occurred_at, id)| encode_cursor(occurred_at, id, limit.get())),
+    })
+}
+
+/// Whether the viewer may read `actor_id`'s mechanical activity.
+///
+/// Allowed for the viewer's own principal, or a first-party Macro bot.
+pub fn actor_feed_is_visible(viewer: &MacroUserIdStr<'_>, actor_id: &str) -> bool {
+    if actor_id == viewer.as_ref() {
+        return true;
+    }
+    BotIdStr::parse_from_str(actor_id).is_ok_and(|bot| bot.bot_id().is_first_party())
+}
+
+/// Resolve one page of a mechanical actor's activity.
+///
+/// Rejects actor ids the viewer is not allowed to inspect.
+pub async fn resolve_actor_activity<R>(
+    ctx: &Context<'_>,
+    viewer: &MacroUserIdStr<'static>,
+    actor_id: String,
+    input: ActivityFeedInput,
+) -> async_graphql::Result<GraphqlActivityPage>
+where
+    R: ActivityFeedReader,
+{
+    if !actor_feed_is_visible(viewer, &actor_id) {
+        return Err(async_graphql::Error::new(
+            "actor activity is only available for the viewer or a Macro system bot",
+        ));
+    }
+
+    let reader = ctx.data::<R>()?;
+    let limit = parse_feed_limit(input.limit)?;
+    let cursor = input.cursor.map(decode_cursor).transpose()?;
+
+    let page = reader
+        .actor_feed(&actor_id, cursor, limit)
         .await
         .map_err(|_| async_graphql::Error::new("activity feed is unavailable"))?;
 

--- a/crates/graphql_activity/src/feed/test.rs
+++ b/crates/graphql_activity/src/feed/test.rs
@@ -19,6 +19,21 @@ fn garbage_cursors_are_rejected() {
 }
 
 #[test]
+fn actor_feed_is_visible_for_the_viewer_and_first_party_bots() {
+    let viewer = MacroUserIdStr::try_from("macro|teo@example.com".to_string()).unwrap();
+    assert!(actor_feed_is_visible(&viewer, "macro|teo@example.com"));
+    assert!(actor_feed_is_visible(
+        &viewer,
+        "bot|00000000-0000-0000-0000-000000005759"
+    ));
+    assert!(!actor_feed_is_visible(&viewer, "macro|other@example.com"));
+    assert!(!actor_feed_is_visible(
+        &viewer,
+        "bot|00000000-0000-0000-0000-0000000000b07a"
+    ));
+}
+
+#[test]
 fn feed_limits_are_defaulted_and_clamped() {
     assert_eq!(parse_feed_limit(None).unwrap().get(), 25);
     assert_eq!(parse_feed_limit(Some(100)).unwrap().get(), 100);

--- a/crates/graphql_activity/src/lib.rs
+++ b/crates/graphql_activity/src/lib.rs
@@ -6,6 +6,8 @@
 //!
 //! - the authenticated user's own feed ([`resolve_activity_feed`]), a
 //!   keyset-paginated field on `GraphqlUser`;
+//! - a mechanical-actor feed ([`resolve_actor_activity`]) for the viewer
+//!   or a first-party Macro bot;
 //! - a lazily-loaded `activity` edge on every Soup entity, batched across
 //!   entities through [`EntityActivityLoader`] so it costs nothing when not
 //!   selected and one query when it is.
@@ -23,7 +25,7 @@ mod objects;
 
 pub use feed::{
     ActivityFeedInput, DEFAULT_ACTIVITY_FEED_LIMIT, GraphqlActivityPage, MAX_ACTIVITY_FEED_LIMIT,
-    resolve_activity_feed,
+    actor_feed_is_visible, resolve_activity_feed, resolve_actor_activity,
 };
 pub use loaders::{
     ActivityEdgeKey, ActivityEdgeLoad, ActivityFeedReader, ActivityPortReader, ActivityReadFailed,

--- a/crates/graphql_activity/src/loaders.rs
+++ b/crates/graphql_activity/src/loaders.rs
@@ -75,6 +75,15 @@ pub trait ActivityFeedReader: Send + Sync + 'static {
         cursor: Option<(DateTime<Utc>, Uuid)>,
         limit: NonZeroU32,
     ) -> impl Future<Output = Result<ActivityFeedPage, ActivityReadFailed>> + Send + 'a;
+
+    /// One page of a mechanical actor's activity. Same keyset rules as
+    /// [`Self::subject_feed`].
+    fn actor_feed<'a>(
+        &'a self,
+        actor_id: &'a str,
+        cursor: Option<(DateTime<Utc>, Uuid)>,
+        limit: NonZeroU32,
+    ) -> impl Future<Output = Result<ActivityFeedPage, ActivityReadFailed>> + Send + 'a;
 }
 
 /// Combined reader capability required by the complete activity surface —
@@ -102,6 +111,18 @@ impl ActivityFeedReader for NoOpActivityReader {
     async fn subject_feed(
         &self,
         _subject_id: &str,
+        _cursor: Option<(DateTime<Utc>, Uuid)>,
+        _limit: NonZeroU32,
+    ) -> Result<ActivityFeedPage, ActivityReadFailed> {
+        Ok(ActivityFeedPage {
+            records: Vec::new(),
+            next: None,
+        })
+    }
+
+    async fn actor_feed(
+        &self,
+        _actor_id: &str,
         _cursor: Option<(DateTime<Utc>, Uuid)>,
         _limit: NonZeroU32,
     ) -> Result<ActivityFeedPage, ActivityReadFailed> {
@@ -198,6 +219,21 @@ where
             .await
             .map_err(|error| {
                 tracing::error!(?error, "activity feed load failed");
+                ActivityReadFailed
+            })
+    }
+
+    async fn actor_feed(
+        &self,
+        actor_id: &str,
+        cursor: Option<(DateTime<Utc>, Uuid)>,
+        limit: NonZeroU32,
+    ) -> Result<ActivityFeedPage, ActivityReadFailed> {
+        self.reads
+            .actor_feed(actor_id, cursor, limit)
+            .await
+            .map_err(|error| {
+                tracing::error!(?error, "actor activity feed load failed");
                 ActivityReadFailed
             })
     }

--- a/crates/macro_db_client/migrations/20260821183352_add_activity_events_actor_index.down.sql
+++ b/crates/macro_db_client/migrations/20260821183352_add_activity_events_actor_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_activity_events_actor;

--- a/crates/macro_db_client/migrations/20260821183352_add_activity_events_actor_index.up.sql
+++ b/crates/macro_db_client/migrations/20260821183352_add_activity_events_actor_index.up.sql
@@ -1,0 +1,2 @@
+CREATE INDEX idx_activity_events_actor
+    ON activity_events (actor_id, occurred_at DESC, id DESC);

--- a/static_assets/schema.graphql
+++ b/static_assets/schema.graphql
@@ -5172,6 +5172,15 @@ type GraphqlUser {
 	"""
 	activity(input: ActivityFeedInput!): GraphqlActivityPage!
 	"""
+	A page of activity performed by `actor_id`, newest first.
+	
+	`actor_id` must be the viewer or a first-party Macro bot
+	(`bot|<uuid>`). Use this for a bot's mechanical actions, which
+	do not appear on that bot's subject feed when they were
+	delegated to a user.
+	"""
+	actorActivity(actorId: String!, input: ActivityFeedInput!): GraphqlActivityPage!
+	"""
 	Labels across every owned or delegated inbox accessible to the authenticated user.
 	"""
 	emailLabels: [GraphqlSoupEmailLabel!]!


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Delegated bot actions live on the user's subject feed. There is no query for "this bot's activity".

## Scope

- Migration `idx_activity_events_actor` on `(actor_id, occurred_at DESC, id DESC)`.
- `ActivityReads::actor_feed` and matching `PgActivityRepo` keyset pages.
- `GraphqlUser.actorActivity(actorId, input)` on the same page type as `activity`.
- Visibility is the viewer's principal or a first-party Macro bot (`BotId::is_first_party`).
- Regenerated `static_assets/schema.graphql`.

## Tradeoffs

Visibility stays narrow. Arbitrary bots and other users cannot be queried as actors.

## Blast Radius

Read path only. New optional GraphQL field. New index on `activity_events`. Existing subject feeds are unchanged.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a1381642-d8e6-4e7a-8c8e-a86c6a163b66?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a1381642-d8e6-4e7a-8c8e-a86c6a163b66&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

