### PR TITLE
feat(activity): attribute EditDocument collab edits to the AI bot

### DIFF
--- a/crates/documents/src/domain/activity.rs
+++ b/crates/documents/src/domain/activity.rs
@@ -82,9 +82,21 @@ impl ActivitySource for DocumentTopicEvent {
             }
             // Extraction-pipeline noise, not user activity.
             DocumentTopicEvent::ContentUploaded(_) => Ingest::Ignore,
-            // Carries no actor today; becomes an Edited activity once collab
-            // edits are attributed.
-            DocumentTopicEvent::SyncContentUpdated(_) => Ingest::Ignore,
+            DocumentTopicEvent::SyncContentUpdated(metadata) => match metadata.actor.clone() {
+                Some(actor) => {
+                    let attribution = match metadata.on_behalf_of.clone() {
+                        Some(subject) => Attribution::delegated(actor, subject),
+                        None => Attribution::direct(actor),
+                    };
+                    single(
+                        attribution,
+                        CommonAction::Edited,
+                        &metadata.document_id,
+                        event_time(event_id),
+                    )
+                }
+                None => Ingest::Ignore,
+            },
             // Session lifecycle (first join / last leave), no actor.
             DocumentTopicEvent::Interaction(_) => Ingest::Ignore,
         }

--- a/crates/documents/src/domain/activity/test.rs
+++ b/crates/documents/src/domain/activity/test.rs
@@ -191,6 +191,8 @@ fn pipeline_and_session_events_are_ignored() {
             document_id: DOCUMENT_ID.to_string(),
             file_type: FileType::Md,
             document_version_id: None,
+            actor: None,
+            on_behalf_of: None,
         },
     ));
     assert_eq!(sync.event.ingest(sync.event_id), Ingest::Ignore);
@@ -205,6 +207,26 @@ fn pipeline_and_session_events_are_ignored() {
         interaction.event.ingest(interaction.event_id),
         Ingest::Ignore
     );
+}
+
+#[test]
+fn attributed_sync_content_is_an_edited_activity() {
+    let event = envelope(DocumentTopicEvent::SyncContentUpdated(
+        DocumentSyncContentUpdatedMetadata {
+            document_id: DOCUMENT_ID.to_string(),
+            file_type: FileType::Md,
+            document_version_id: None,
+            actor: Some(Actor::new_from_bot(bot_id::MACRO_AI_BOT_ID)),
+            on_behalf_of: Some(user("macro|owner@example.com")),
+        },
+    ));
+    let activity = single_activity(event.event.ingest(event.event_id));
+    assert_eq!(activity.action, Action::Edited);
+    assert_eq!(
+        activity.actor.as_ref(),
+        bot_id::MACRO_AI_BOT_ID.into_storage_id().as_ref()
+    );
+    assert_eq!(activity.subject_id, "macro|owner@example.com");
 }
 
 #[test]

--- a/crates/documents/src/domain/events.rs
+++ b/crates/documents/src/domain/events.rs
@@ -110,6 +110,15 @@ pub struct DocumentSyncContentUpdatedMetadata {
     pub file_type: FileType,
     /// Version marker for the sync snapshot, when the caller supplies one.
     pub document_version_id: Option<String>,
+    /// Who mechanically changed the content. Absent on events published
+    /// before attribution, and on human-only collab sessions.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "schema", schema(value_type = Option<String>))]
+    pub actor: Option<Actor<'static>>,
+    /// The user whose feed this edit belongs on, when different from
+    /// [`Self::actor`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub on_behalf_of: Option<MacroUserIdStr<'static>>,
 }
 
 /// Metadata for [`DocumentTopicEvent::Purged`].

--- a/crates/documents/src/domain/events.rs
+++ b/crates/documents/src/domain/events.rs
@@ -121,6 +121,26 @@ pub struct DocumentSyncContentUpdatedMetadata {
     pub on_behalf_of: Option<MacroUserIdStr<'static>>,
 }
 
+impl DocumentSyncContentUpdatedMetadata {
+    /// Build metadata from extract-sync strings. Invalid actor or subject
+    /// ids are dropped so a bad payload still extracts the document.
+    pub fn from_extract(
+        document_id: String,
+        file_type: FileType,
+        document_version_id: Option<String>,
+        actor: Option<String>,
+        on_behalf_of: Option<String>,
+    ) -> Self {
+        Self {
+            document_id,
+            file_type,
+            document_version_id,
+            actor: actor.and_then(|id| Actor::try_from(id).ok()),
+            on_behalf_of: on_behalf_of.and_then(|id| MacroUserIdStr::try_from(id).ok()),
+        }
+    }
+}
+
 /// Metadata for [`DocumentTopicEvent::Purged`].
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(utoipa::ToSchema))]

--- a/crates/documents/src/domain/events/test.rs
+++ b/crates/documents/src/domain/events/test.rs
@@ -249,3 +249,16 @@ fn existing_v1_document_events_still_decode() {
         })
     );
 }
+
+#[test]
+fn sync_extract_drops_invalid_attribution_strings() {
+    let metadata = DocumentSyncContentUpdatedMetadata::from_extract(
+        DOCUMENT_ID.to_string(),
+        FileType::Md,
+        None,
+        Some("not-an-actor".to_string()),
+        Some("also-not-a-user".to_string()),
+    );
+    assert_eq!(metadata.actor, None);
+    assert_eq!(metadata.on_behalf_of, None);
+}

--- a/crates/documents/src/domain/events/test.rs
+++ b/crates/documents/src/domain/events/test.rs
@@ -63,6 +63,8 @@ fn sync_content_updated_serializes_to_the_exact_envelope() {
             document_id: DOCUMENT_ID.to_string(),
             file_type: FileType::Md,
             document_version_id: None,
+            actor: None,
+            on_behalf_of: None,
         }),
     );
 
@@ -116,6 +118,8 @@ fn optional_document_versions_support_present_and_absent_values() {
             document_id: DOCUMENT_ID.to_string(),
             file_type: FileType::Md,
             document_version_id: Some("snapshot-7".to_string()),
+            actor: None,
+            on_behalf_of: None,
         }),
     ];
 
@@ -162,6 +166,8 @@ fn search_event_constructors_use_the_document_key_and_schema_v1() {
         document_id: DOCUMENT_ID.to_string(),
         file_type: FileType::Md,
         document_version_id: None,
+        actor: None,
+        on_behalf_of: None,
     };
     let sync_content_updated =
         DocumentMacroEvent::sync_content_updated(DOCUMENT_ID, sync_metadata.clone());

--- a/crates/documents/src/domain/permission_token.rs
+++ b/crates/documents/src/domain/permission_token.rs
@@ -53,6 +53,7 @@ pub fn encode_permission_token(
 }
 
 /// Read claims from a token minted by [`encode_permission_token`].
+#[cfg(test)]
 pub(crate) fn decode_permission_token(
     token: &DocumentPermissionToken,
     jwt_secret: &str,

--- a/crates/documents/src/domain/permission_token.rs
+++ b/crates/documents/src/domain/permission_token.rs
@@ -4,9 +4,22 @@
 use crate::domain::models::DocumentError;
 use macro_sync_service_jwt::{DocumentPermissionToken, ISSUER, TOKEN_TTL_SECS};
 use macro_user_id::user_id::MacroUserIdStr;
-use model::document::DocumentPermissionsToken;
 use models_permissions::share_permission::access_level::AccessLevel;
 use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Claims minted for the sync service. `actor` is not on the public
+/// document-permissions token type so the OpenAPI validate API stays unchanged.
+#[derive(serde::Serialize, serde::Deserialize)]
+pub(crate) struct PermissionTokenClaims {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) user_id: Option<MacroUserIdStr<'static>>,
+    document_id: String,
+    access_level: AccessLevel,
+    exp: usize,
+    iss: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) actor: Option<String>,
+}
 
 /// Sign a document permission token for the given user and document.
 pub fn encode_permission_token(
@@ -14,6 +27,7 @@ pub fn encode_permission_token(
     document_id: String,
     access_level: AccessLevel,
     jwt_secret: &str,
+    actor: Option<String>,
 ) -> Result<DocumentPermissionToken, DocumentError> {
     let user_id = user_id
         .map(MacroUserIdStr::try_from)
@@ -26,13 +40,22 @@ pub fn encode_permission_token(
         .as_secs() as usize;
 
     Ok(macro_sync_service_jwt::encode(
-        &DocumentPermissionsToken {
+        &PermissionTokenClaims {
             user_id,
             document_id,
             access_level,
             exp: now + TOKEN_TTL_SECS,
             iss: ISSUER.to_string(),
+            actor,
         },
         jwt_secret,
     )?)
+}
+
+/// Read claims from a token minted by [`encode_permission_token`].
+pub(crate) fn decode_permission_token(
+    token: &DocumentPermissionToken,
+    jwt_secret: &str,
+) -> Result<PermissionTokenClaims, DocumentError> {
+    Ok(macro_sync_service_jwt::decode(token.as_str(), jwt_secret)?)
 }

--- a/crates/documents/src/inbound/axum_router/create_markdown.rs
+++ b/crates/documents/src/inbound/axum_router/create_markdown.rs
@@ -79,6 +79,7 @@ pub async fn create_markdown_handler<
         document_id.clone(),
         AccessLevel::Edit,
         &state.document_permission_jwt_secret,
+        None,
     )
     .map_err(|e| {
         tracing::error!(error=?e, "failed to encode permission token");

--- a/crates/documents/src/inbound/axum_router/create_task.rs
+++ b/crates/documents/src/inbound/axum_router/create_task.rs
@@ -106,6 +106,7 @@ pub async fn create_task_handler<
         document_id.clone(),
         AccessLevel::Edit,
         &state.document_permission_jwt_secret,
+        None,
     )
     .map_err(|e| {
         tracing::error!(error=?e, "failed to encode permission token");

--- a/crates/documents/src/inbound/toolset/edit_document.rs
+++ b/crates/documents/src/inbound/toolset/edit_document.rs
@@ -120,6 +120,7 @@ where
             self.document_id.clone(),
             AccessLevel::Edit,
             &ctx.document_permission_jwt_secret,
+            Some(bot_id::MACRO_AI_BOT_ID.into_storage_id().to_string()),
         )
         .map_err(|e| ToolCallError {
             description: "failed to mint document token".to_string(),

--- a/crates/documents/src/inbound/toolset/edit_document/test.rs
+++ b/crates/documents/src/inbound/toolset/edit_document/test.rs
@@ -9,6 +9,7 @@ use crate::domain::models::{
     DocumentTeamShareResponse, EditDocumentServiceArgs, GithubPullRequestsResponse,
     LocationQueryParams, TaskBranchName,
 };
+use crate::domain::permission_token::decode_permission_token;
 use crate::domain::ports::editing::{EditResult, EditingWorkerService};
 use crate::domain::response::{
     CreateDocumentResponseData, DocumentResponse, GetDocumentResponseData, LocationResponseV3,
@@ -383,19 +384,24 @@ impl EntityAccessService for FakeEntityAccessService {
 #[derive(Clone, Default)]
 struct FakeEditingWorker {
     edit_calls: Arc<Mutex<Vec<String>>>,
+    tokens: Arc<Mutex<Vec<DocumentPermissionToken>>>,
 }
 
 impl EditingWorkerService for FakeEditingWorker {
     async fn edit(
         &self,
         document_id: &str,
-        _document_token: &DocumentPermissionToken,
+        document_token: &DocumentPermissionToken,
         _instructions: &str,
     ) -> anyhow::Result<EditResult> {
         self.edit_calls
             .lock()
             .expect("edit calls lock poisoned")
             .push(document_id.to_string());
+        self.tokens
+            .lock()
+            .expect("edit tokens lock poisoned")
+            .push(document_token.clone());
 
         Ok(EditResult {
             edits_applied: 1,
@@ -496,6 +502,24 @@ async fn allows_markdown_document() {
     assert_eq!(
         *editing.edit_calls.lock().expect("edit calls lock poisoned"),
         vec![TEST_DOCUMENT_ID.to_string()]
+    );
+
+    let token = editing
+        .tokens
+        .lock()
+        .expect("edit tokens lock poisoned")
+        .first()
+        .expect("edit minted a document token")
+        .clone();
+    let claims =
+        decode_permission_token(&token, "unused-jwt-secret").expect("edit token should decode");
+    assert_eq!(
+        claims.user_id.as_ref().map(|user| user.as_ref()),
+        Some(TEST_USER_ID)
+    );
+    assert_eq!(
+        claims.actor.as_deref(),
+        Some(bot_id::MACRO_AI_BOT_ID.into_storage_id().as_ref())
     );
 }
 

--- a/crates/soup_realtime/src/inbound/kafka_consumer/test.rs
+++ b/crates/soup_realtime/src/inbound/kafka_consumer/test.rs
@@ -196,6 +196,8 @@ fn search_only_document_events_do_not_emit_patches() {
             document_id: DOCUMENT_ID.to_string(),
             file_type: "md".parse().expect("valid file type"),
             document_version_id: None,
+            actor: None,
+            on_behalf_of: None,
         }),
         DocumentTopicEvent::Purged(DocumentPurgedMetadata {
             document_id: DOCUMENT_ID.to_string(),

--- a/crates/webhook/src/domain/ingestion/test.rs
+++ b/crates/webhook/src/domain/ingestion/test.rs
@@ -537,6 +537,8 @@ fn search_only_document_event_cases() -> Vec<(&'static str, Event<DocumentTopicE
                     document_id: DOCUMENT_ID.to_string(),
                     file_type: "md".parse().expect("valid file type"),
                     document_version_id: None,
+                    actor: None,
+                    on_behalf_of: None,
                 },
             )),
         ),

--- a/services/document_storage_service/src/api/documents/permissions_token/create_permission_token.rs
+++ b/services/document_storage_service/src/api/documents/permissions_token/create_permission_token.rs
@@ -78,6 +78,7 @@ pub async fn handler(
         document_id,
         access_level,
         state.config.document_permission_jwt.as_ref(),
+        None,
     )
     .map_err(|e| {
         tracing::error!(error=?e, "unable to encode jwt");

--- a/services/search_processing_service/src/api/internal/extract_sync.rs
+++ b/services/search_processing_service/src/api/internal/extract_sync.rs
@@ -1,5 +1,4 @@
 use crate::api::context::{ApiContext, AuthorizationService};
-use activity::Actor;
 use axum::{
     extract::{self, State},
     http::StatusCode,
@@ -8,7 +7,6 @@ use axum::{
 use documents::domain::events::{DocumentMacroEvent, DocumentSyncContentUpdatedMetadata};
 use macro_authorization::{InternalOnly, MacroAuthorizationExtractor};
 use macro_event_broker::MacroEventBroker as _;
-use macro_user_id::user_id::MacroUserIdStr;
 use model::document::FileType;
 
 #[cfg(test)]
@@ -39,15 +37,13 @@ fn documents_to_events(documents: Vec<SyncDocument>) -> Vec<DocumentMacroEvent> 
             let document_id = document.document_id;
             DocumentMacroEvent::sync_content_updated(
                 document_id.clone(),
-                DocumentSyncContentUpdatedMetadata {
+                DocumentSyncContentUpdatedMetadata::from_extract(
                     document_id,
-                    file_type: document.file_type,
-                    document_version_id: document.document_version_id,
-                    actor: document.actor.and_then(|id| Actor::try_from(id).ok()),
-                    on_behalf_of: document
-                        .on_behalf_of
-                        .and_then(|id| MacroUserIdStr::try_from(id).ok()),
-                },
+                    document.file_type,
+                    document.document_version_id,
+                    document.actor,
+                    document.on_behalf_of,
+                ),
             )
         })
         .collect()

--- a/services/search_processing_service/src/api/internal/extract_sync.rs
+++ b/services/search_processing_service/src/api/internal/extract_sync.rs
@@ -1,4 +1,5 @@
 use crate::api::context::{ApiContext, AuthorizationService};
+use activity::Actor;
 use axum::{
     extract::{self, State},
     http::StatusCode,
@@ -7,6 +8,7 @@ use axum::{
 use documents::domain::events::{DocumentMacroEvent, DocumentSyncContentUpdatedMetadata};
 use macro_authorization::{InternalOnly, MacroAuthorizationExtractor};
 use macro_event_broker::MacroEventBroker as _;
+use macro_user_id::user_id::MacroUserIdStr;
 use model::document::FileType;
 
 #[cfg(test)]
@@ -18,6 +20,10 @@ pub struct SyncDocument {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub document_version_id: Option<String>,
     pub file_type: FileType,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub actor: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub on_behalf_of: Option<String>,
 }
 
 #[derive(serde::Deserialize)]
@@ -37,6 +43,10 @@ fn documents_to_events(documents: Vec<SyncDocument>) -> Vec<DocumentMacroEvent> 
                     document_id,
                     file_type: document.file_type,
                     document_version_id: document.document_version_id,
+                    actor: document.actor.and_then(|id| Actor::try_from(id).ok()),
+                    on_behalf_of: document
+                        .on_behalf_of
+                        .and_then(|id| MacroUserIdStr::try_from(id).ok()),
                 },
             )
         })

--- a/services/search_processing_service/src/api/internal/extract_sync/test.rs
+++ b/services/search_processing_service/src/api/internal/extract_sync/test.rs
@@ -11,11 +11,15 @@ fn documents_map_to_events_with_matching_keys_and_exact_metadata() {
             document_id: "document-a".to_string(),
             document_version_id: Some("version-42".to_string()),
             file_type: FileType::Md,
+            actor: None,
+            on_behalf_of: None,
         },
         SyncDocument {
             document_id: "document-b".to_string(),
             document_version_id: None,
             file_type: FileType::Pdf,
+            actor: None,
+            on_behalf_of: None,
         },
     ]);
 
@@ -27,6 +31,8 @@ fn documents_map_to_events_with_matching_keys_and_exact_metadata() {
             document_id: "document-a".to_string(),
             file_type: FileType::Md,
             document_version_id: Some("version-42".to_string()),
+            actor: None,
+            on_behalf_of: None,
         })
     );
     assert_eq!(events[1].key(), "document-b");
@@ -36,6 +42,8 @@ fn documents_map_to_events_with_matching_keys_and_exact_metadata() {
             document_id: "document-b".to_string(),
             file_type: FileType::Pdf,
             document_version_id: None,
+            actor: None,
+            on_behalf_of: None,
         })
     );
 }
@@ -49,10 +57,35 @@ fn documents_map_to_one_event_each_in_input_order() {
                 document_id: document_id.to_string(),
                 document_version_id: None,
                 file_type: FileType::Md,
+                actor: None,
+                on_behalf_of: None,
             })
             .collect(),
     );
 
     let event_keys: Vec<&str> = events.iter().map(|event| event.key()).collect();
     assert_eq!(event_keys, ["document-a", "document-c", "document-b"]);
+}
+
+#[test]
+fn documents_forward_sync_attribution() {
+    let events = documents_to_events(vec![SyncDocument {
+        document_id: "document-a".to_string(),
+        document_version_id: None,
+        file_type: FileType::Md,
+        actor: Some("bot|00000000-0000-0000-0000-00000000a1a1".to_string()),
+        on_behalf_of: Some("macro|owner@example.com".to_string()),
+    }]);
+
+    let DocumentTopicEvent::SyncContentUpdated(metadata) = &events[0].event().event else {
+        panic!("expected sync_content_updated");
+    };
+    assert_eq!(
+        metadata.actor.as_ref().map(|actor| actor.as_ref()),
+        Some("bot|00000000-0000-0000-0000-00000000a1a1")
+    );
+    assert_eq!(
+        metadata.on_behalf_of.as_ref().map(|user| user.as_ref()),
+        Some("macro|owner@example.com")
+    );
 }

--- a/services/search_processing_service/src/inbound/kafka_consumer/test.rs
+++ b/services/search_processing_service/src/inbound/kafka_consumer/test.rs
@@ -910,6 +910,8 @@ fn document_event_cases() -> Vec<(DocumentTopicEvent, DocumentEventDescription)>
                 document_id: DOCUMENT_ID.to_string(),
                 file_type: FileType::Md,
                 document_version_id: None,
+                actor: None,
+                on_behalf_of: None,
             }),
             DocumentEventDescription {
                 action: DocumentIndexAction::ExtractSync {
@@ -1410,6 +1412,8 @@ fn document_extraction_actions_preserve_optional_versions() {
             document_id: DOCUMENT_ID.to_string(),
             file_type: FileType::Md,
             document_version_id: Some("snapshot-7".to_string()),
+            actor: None,
+            on_behalf_of: None,
         });
     assert_eq!(
         describe_document_event(&sync_content_updated).action,
@@ -1629,6 +1633,8 @@ fn exact_macro_documents_envelopes_decode_into_document_events() {
                     document_id: DOCUMENT_ID.to_string(),
                     file_type: FileType::Md,
                     document_version_id: None,
+                    actor: None,
+                    on_behalf_of: None,
                 }),
             ),
         ),

--- a/services/sync-service/src/auth.rs
+++ b/services/sync-service/src/auth.rs
@@ -33,6 +33,8 @@ pub struct AuthToken {
     pub user_id: Option<String>,
     document_id: String,
     pub access_level: AccessLevel,
+    #[serde(default)]
+    pub actor: Option<String>,
 }
 
 impl AuthToken {
@@ -103,6 +105,7 @@ did not match expected value: {}",
                     user_id: None,
                     document_id: "TODO should be option".to_string(),
                     access_level: AccessLevel::Admin,
+                    actor: None,
                 });
             }
 

--- a/services/sync-service/src/durable_object.rs
+++ b/services/sync-service/src/durable_object.rs
@@ -99,6 +99,8 @@ macro_rules! or_unauth {
 pub struct WebSocketMetadata {
     pub user_id: Option<String>,
     pub access_level: AccessLevel,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub actor: Option<String>,
     #[serde(with = "u64_serde_strings")]
     pub peer_ids: BTreeSet<u64>,
 }
@@ -274,7 +276,13 @@ pub fn get_ws_id(state: &State, ws: &WebSocket) -> Result<String> {
 /// - every few seconds
 /// - on creation
 /// - on everyone being disconnected
-async fn report_new_doc_state(document_id: &str, snapshot: &[u8], env: &Env) {
+async fn report_new_doc_state(
+    document_id: &str,
+    snapshot: &[u8],
+    env: &Env,
+    actor: Option<String>,
+    on_behalf_of: Option<String>,
+) {
     if let Err(err) = DssInternalClient::new(env)
         .publish_shallow_snapshot(document_id, snapshot)
         .await
@@ -282,7 +290,7 @@ async fn report_new_doc_state(document_id: &str, snapshot: &[u8], env: &Env) {
         warn!(error=?err, "failed to push snapshot to DSS");
     }
     #[cfg(feature = "search-service")]
-    if let Err(err) = crate::sps::update(document_id, env).await {
+    if let Err(err) = crate::sps::update(document_id, env, actor, on_behalf_of).await {
         warn!(error=?err, "failed to update search index");
     }
 }
@@ -315,6 +323,18 @@ async fn bump_alarm(state: &State) -> Result<()> {
 impl DocumentSyncSession {
     pub fn get_websockets(&self) -> Vec<WebSocket> {
         self.state.get_websockets()
+    }
+
+    fn actor_attribution(&self) -> (Option<String>, Option<String>) {
+        self.ws_meta_map
+            .lock("actor_attribution")
+            .values()
+            .find_map(|meta| {
+                meta.actor
+                    .clone()
+                    .map(|actor| (Some(actor), meta.user_id.clone()))
+            })
+            .unwrap_or((None, None))
     }
 
     pub fn push_blame_events(&self, events: Vec<crate::d1::BlameEvent>) {
@@ -477,8 +497,10 @@ impl DocumentSyncSession {
             }
             let document_id_owned = document_id.to_string();
             let env = self.env.clone();
+            let (actor, on_behalf_of) = self.actor_attribution();
             self.state.wait_until(async move {
-                report_new_doc_state(&document_id_owned, &snapshot, &env).await;
+                report_new_doc_state(&document_id_owned, &snapshot, &env, actor, on_behalf_of)
+                    .await;
             });
         }
 
@@ -666,6 +688,7 @@ impl DocumentSyncSession {
             let ws_meta = WebSocketMetadata {
                 user_id: claims.user_id,
                 access_level: claims.access_level,
+                actor: claims.actor,
                 peer_ids: Default::default(),
             };
 
@@ -1081,11 +1104,13 @@ impl DurableObject for DocumentSyncSession {
 
             let document_id = self.document_id().await.ok();
             let env = self.env.clone();
+            let (actor, on_behalf_of) = self.actor_attribution();
             self.state.wait_until(async move {
                 if let Some(document_id) = document_id
                     && let Ok(snapshot) = doc_state.export_shallow_snapshot()
                 {
-                    report_new_doc_state(&document_id, &snapshot, &env).await;
+                    report_new_doc_state(&document_id, &snapshot, &env, actor, on_behalf_of)
+                        .await;
                     report_interaction(&document_id, &env, InteractionReason::Edited).await;
                 }
             });
@@ -1141,8 +1166,9 @@ impl DurableObject for DocumentSyncSession {
                 && let Ok(snapshot) = state.export_shallow_snapshot()
             {
                 let env = self.env.clone();
+                let (actor, on_behalf_of) = self.actor_attribution();
                 self.state.wait_until(async move {
-                    report_new_doc_state(&document_id, &snapshot, &env).await;
+                    report_new_doc_state(&document_id, &snapshot, &env, actor, on_behalf_of).await;
                     report_interaction(&document_id, &env, InteractionReason::LastLeave).await;
                 });
             }

--- a/services/sync-service/src/sps.rs
+++ b/services/sync-service/src/sps.rs
@@ -3,7 +3,12 @@ use serde_json::json;
 use tracing::{debug, error};
 use worker::{Fetch, Method, Request, RequestInit};
 
-pub async fn update(document_id: &str, env: &worker::Env) -> worker::Result<()> {
+pub async fn update(
+    document_id: &str,
+    env: &worker::Env,
+    actor: Option<String>,
+    on_behalf_of: Option<String>,
+) -> worker::Result<()> {
     let internal_auth_key = env
         .secret("SPS_API_SECRET_KEY")
         .inspect_err(|e| error!(error=%e, "Could not find API SPS key binding"))?
@@ -14,11 +19,18 @@ pub async fn update(document_id: &str, env: &worker::Env) -> worker::Result<()> 
         .to_string();
 
     let url = format!("{url}/internal/extract_sync");
+    let mut document = json!({
+        "document_id": document_id,
+        "file_type": "md",
+    });
+    if let Some(actor) = actor {
+        document["actor"] = json!(actor);
+    }
+    if let Some(on_behalf_of) = on_behalf_of {
+        document["on_behalf_of"] = json!(on_behalf_of);
+    }
     let json_body = json!({
-        "documents": [{
-            "document_id": document_id,
-            "file_type": "md",
-        }]
+        "documents": [document]
     });
 
     let mut request = Request::new_with_init(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Agent `EditDocument` writes go through collab / `SyncContentUpdated`. Those events had no actor, so ingest ignored them. The user never saw the bot edit on their feed or on an actor-index query.

## Scope

- `encode_permission_token` takes an optional `actor` claim. `EditDocument` sets `MACRO_AI_BOT_ID`. Human token mint paths pass `None`. The public document-permissions OpenAPI type is unchanged.
- Sync `AuthToken` and `WebSocketMetadata` carry `actor`. `DocumentSyncSession::actor_attribution` forwards the first connected actor plus that socket's `user_id` as `on_behalf_of`.
- `sps::update` and `extract_sync` pass `actor` / `on_behalf_of` onto `DocumentSyncContentUpdatedMetadata`.
- `DocumentSyncContentUpdatedMetadata::from_extract` parses those strings so SPS does not depend on the activity crate.
- Ingest treats an attributed sync as `Edited` via `Attribution`. A sync without an actor stays `Ignore`. `Interaction` stays `Ignore`.

## Tradeoffs

If a human and the AI editor share one session, the first meta with an actor wins. A human keystroke in that window can look like the bot. `EditDocument` holds the worker session, so that overlap is rare. Human-only sessions stay ignored on purpose so live typing does not spam activity.

## Blast Radius

Human collab traffic is unchanged. Attributed sync events become `Edited` activity scoped to the user (subject) and Macro AI (actor). Downstream Kafka consumers that construct `DocumentSyncContentUpdatedMetadata` now set the new optional fields.

## Verification

- `nix develop --command cargo test -p documents --lib` — 154 passed. Covers JWT actor on `allows_markdown_document`, ingest `Edited` vs `Ignore`, and `from_extract` dropping invalid ids.
- `nix develop --command cargo test -p search_processing_service --bin search_processing_service -- extract_sync` — 3 passed, including `documents_forward_sync_attribution`.
- `nix develop --command cargo test -p soup_realtime --lib kafka_consumer` — 19 passed.
- `nix develop --command cargo test -p webhook --lib ingestion` — 15 passed.
- `SQLX_OFFLINE=true nix develop --command cargo check -p document_storage_service --tests` — finished.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a1381642-d8e6-4e7a-8c8e-a86c6a163b66?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a1381642-d8e6-4e7a-8c8e-a86c6a163b66&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

