### PR TITLE
feat(cursor-cloud): use Doppler local/lcl_preview when DOPPLER_TOKEN is set

### DIFF
--- a/.cursor/cloud-lib.sh
+++ b/.cursor/cloud-lib.sh
@@ -232,20 +232,14 @@ ensure_dockerd() {
   return 1
 }
 
-# A config-scoped Doppler service token (local / lcl_preview) is enough —
-# no `doppler login`. Token-scoped downloads omit --project/--config.
-# Accept DOPPLER_PREVIEW_TOKEN as an alias (same name as the Fly/CI secret).
-ensure_doppler_token() {
+# Populate `doppler_args` for `just stack up`. The doppler CLI is already on
+# PATH from `nix develop` — this only chooses whether to pass `--no-doppler`.
+# A config-scoped service token (local / lcl_preview) is enough; no login.
+# DOPPLER_PREVIEW_TOKEN is the Fly/CI name for the same token.
+stack_doppler_args() {
   if [ -z "${DOPPLER_TOKEN:-}" ] && [ -n "${DOPPLER_PREVIEW_TOKEN:-}" ]; then
     export DOPPLER_TOKEN="${DOPPLER_PREVIEW_TOKEN}"
   fi
-}
-
-# Populate `doppler_args` for `just stack up`.
-# With a token: empty (xtask pulls the token-scoped config).
-# Without: --no-doppler (code-owned stubs).
-stack_doppler_args() {
-  ensure_doppler_token
   doppler_args=()
   if [ -n "${DOPPLER_TOKEN:-}" ]; then
     echo "cursor-cloud: DOPPLER_TOKEN present — pulling local/lcl_preview secrets"

--- a/.cursor/cloud-lib.sh
+++ b/.cursor/cloud-lib.sh
@@ -232,6 +232,29 @@ ensure_dockerd() {
   return 1
 }
 
+# A config-scoped Doppler service token (local / lcl_preview) is enough —
+# no `doppler login`. Token-scoped downloads omit --project/--config.
+# Accept DOPPLER_PREVIEW_TOKEN as an alias (same name as the Fly/CI secret).
+ensure_doppler_token() {
+  if [ -z "${DOPPLER_TOKEN:-}" ] && [ -n "${DOPPLER_PREVIEW_TOKEN:-}" ]; then
+    export DOPPLER_TOKEN="${DOPPLER_PREVIEW_TOKEN}"
+  fi
+}
+
+# Populate `doppler_args` for `just stack up`.
+# With a token: empty (xtask pulls the token-scoped config).
+# Without: --no-doppler (code-owned stubs).
+stack_doppler_args() {
+  ensure_doppler_token
+  doppler_args=()
+  if [ -n "${DOPPLER_TOKEN:-}" ]; then
+    echo "cursor-cloud: DOPPLER_TOKEN present — pulling local/lcl_preview secrets"
+  else
+    echo "cursor-cloud: no DOPPLER_TOKEN — using --no-doppler stubs"
+    doppler_args+=(--no-doppler)
+  fi
+}
+
 in_pinned_nix_shell() {
   [ "${MACRO_CLOUD_PINNED_NIX:-}" = "1" ]
 }

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -65,6 +65,8 @@ echo "cursor-cloud install: bun cache ready"
 build_local_stack_binaries
 echo "cursor-cloud install: local stack binaries ready"
 
+# Bake the init snapshot on stubs. Runtime stack.sh pulls Doppler when
+# DOPPLER_TOKEN is present; secrets must not land in the durable snapshot.
 just stack up --infra-only --no-doppler --build-aux-services --binaries-dir "${LOCAL_STACK_BINS}/bin" --json
 cleanup_stack
 trap - EXIT

--- a/.cursor/stack.sh
+++ b/.cursor/stack.sh
@@ -18,7 +18,8 @@ fi
 
 \cd "${WORKSPACE_ROOT}"
 build_local_stack_binaries
-just stack up --no-doppler --build-aux-services --binaries-dir "${LOCAL_STACK_BINS}/bin"
+stack_doppler_args
+just stack up "${doppler_args[@]}" --build-aux-services --binaries-dir "${LOCAL_STACK_BINS}/bin"
 ensure_docker_bridge_forwarding
 
 echo "cursor-cloud stack: app ready"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -325,10 +325,12 @@ Service binaries come from the private S3 Nix cache. A sibling workflow on push 
 
 Set `NIX_CACHE_AWS_ACCESS_KEY_ID` and `NIX_CACHE_AWS_SECRET_ACCESS_KEY` as Cursor environment secrets. The IAM credentials need read-only access to the cache bucket.
 
+Set `DOPPLER_TOKEN` as a Cursor environment **runtime** secret: a Doppler service token scoped to the `local` project's `lcl_preview` config (the same token CI stores as `DOPPLER_PREVIEW_TOKEN` also works). Do not paste the token into chat. When the token is present, `bash .cursor/stack.sh` pulls those secrets instead of passing `--no-doppler`. Install/bake stays on stubs so the snapshot does not embed secrets. Existing running agents do not pick up newly added secrets — start a new agent after adding the token.
+
 Nothing runs after boot. Before DB-backed `cargo test -p <crate>`, run `bash .cursor/infra.sh` once — it brings up Docker, Postgres, and Redis in seconds because install baked the images and volumes. Pure-logic crate tests need nothing. Run `bash .cursor/stack.sh` for a product-ready environment.
 
 After backend edits, run `bash .cursor/rebuild.sh`. Do not use `just stack update` with the read-only Nix binary directory.
 
-No seeding or OTP is needed to log in: passwordless login auto-creates a user for any email, and the stack's auth service is built with `return_passwordless_code`, so the login API returns the code in its response (codes are also visible at the proxy's `/mailpit/` UI). `just seed-scenario apply --file seed/scenarios/team-perms.json` is optional, for multi-user team/permission fixtures. The `agent_harness_service` restart loop is expected without AI provider keys.
+No seeding or OTP is needed to log in: passwordless login auto-creates a user for any email, and the stack's auth service is built with `return_passwordless_code`, so the login API returns the code in its response (codes are also visible at the proxy's `/mailpit/` UI). `just seed-scenario apply --file seed/scenarios/team-perms.json` is optional, for multi-user team/permission fixtures. The `agent_harness_service` restart loop is expected when AI provider keys are missing; with `DOPPLER_TOKEN` those keys come from `local`/`lcl_preview`.
 
 Leave `SQLX_OFFLINE` unset for `cargo test`. If SQLx reports missing cached query data, run `just prepare_db` instead of enabling offline mode. Run crate tests from the repository root with `cargo test -p <crate>`.


### PR DESCRIPTION
## Summary

Cursor Cloud stack bring-up no longer always passes `--no-doppler`. When a config-scoped Doppler service token is present, `bash .cursor/stack.sh` pulls `local` / `lcl_preview` secrets the same way Fly previews do.

The `doppler` CLI is already in the pinned nix shell. This change does not install Doppler — it only decides whether to pass `--no-doppler`.

## What changed

- `.cursor/stack.sh` calls `just stack up` without `--no-doppler` when `DOPPLER_TOKEN` (or the CI alias `DOPPLER_PREVIEW_TOKEN`) is set.
- Install/bake stays on stubs so the durable snapshot does not embed secrets.
- Agent instructions document the runtime secret and that existing agents do not pick up newly added secrets.

- Did not pull live Doppler secrets in this session (no token present).

<div><a href="https://cursor.com/agents/bc-cc1e435f-30db-4428-9212-0158dd94c736?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cc1e435f-30db-4428-9212-0158dd94c736&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

