### PR TITLE
Seanaye/fix/mark notifications

### DIFF
--- a/apps/web/src/features/notifications/components/MarkMessageNotifications.tsx
+++ b/apps/web/src/features/notifications/components/MarkMessageNotifications.tsx
@@ -27,26 +27,29 @@ export function MarkMessageNotifications(props: {
     isChannelNotification(n) &&
     n.notification_metadata.content.messageId === props.messageId;
 
+  // A message can generate several notifications — notably one
+  // `document_mention` per mentioned document. Mark every notification for
+  // this message in one batch; selecting only the first leaves the rest unread
+  // and makes a channel row keep targeting the same message.
+  //
   // Not a one-shot latch: a stale refetch can land after the optimistic write
-  // and flip the notification back to unviewed while this row stays mounted,
-  // so re-mark whenever the cache regresses, bounded per mount. inFlight is a
+  // and flip notifications back to unviewed while this row stays mounted, so
+  // re-mark whenever the cache regresses, bounded per mount. inFlight is a
   // signal so a regression that lands mid-mark re-runs the effect on settle.
   const [inFlight, setInFlight] = createSignal(false);
   let attempts = 0;
 
   createEffect(() => {
-    const existing = notifications().find(isMessageNotification);
-    if (
-      !existing ||
-      existing.viewed_at ||
-      inFlight() ||
-      attempts >= MAX_MARK_ATTEMPTS
-    ) {
+    const unread = notifications().filter(
+      (notification) =>
+        isMessageNotification(notification) && !notification.viewed_at
+    );
+    if (unread.length === 0 || inFlight() || attempts >= MAX_MARK_ATTEMPTS) {
       return;
     }
     attempts += 1;
     setInFlight(true);
-    notificationSource.markAsRead(existing).finally(() => {
+    notificationSource.bulkMarkAsRead(unread).finally(() => {
       setInFlight(false);
     });
   });

--- a/apps/web/src/features/notifications/components/MarkMessageNotifications.tsx
+++ b/apps/web/src/features/notifications/components/MarkMessageNotifications.tsx
@@ -49,9 +49,14 @@ export function MarkMessageNotifications(props: {
     }
     attempts += 1;
     setInFlight(true);
-    notificationSource.bulkMarkAsRead(unread).finally(() => {
-      setInFlight(false);
-    });
+    void notificationSource
+      .bulkMarkAsRead(unread)
+      .catch((error) => {
+        console.error('Failed to mark message notifications as read', error);
+      })
+      .finally(() => {
+        setInFlight(false);
+      });
   });
 
   return <>{props.children}</>;

--- a/apps/web/src/features/notifications/tests/mark-message-notifications.test.tsx
+++ b/apps/web/src/features/notifications/tests/mark-message-notifications.test.tsx
@@ -12,9 +12,12 @@ vi.mock('@components/app/GlobalAppState', () => ({
   useGlobalNotificationSource: () => mocks.notificationSource,
 }));
 
-function documentMentionNotification(): UnifiedNotification {
+function documentMentionNotification(
+  id: string,
+  messageId = 'message-1'
+): UnifiedNotification {
   return {
-    id: 'notification-1',
+    id,
     entity_id: 'channel-1',
     entity_type: 'channel',
     created_at: '2026-08-17T00:00:00.000Z',
@@ -22,9 +25,7 @@ function documentMentionNotification(): UnifiedNotification {
     notification_event_type: 'document_mention',
     notification_metadata: {
       tag: 'document_mention',
-      content: {
-        messageId: 'message-1',
-      },
+      content: { messageId },
     } as UnifiedNotification['notification_metadata'],
     sent: true,
     updated_at: '2026-08-17T00:00:00.000Z',
@@ -33,21 +34,27 @@ function documentMentionNotification(): UnifiedNotification {
 }
 
 describe('MarkMessageNotifications', () => {
-  const markAsRead = vi.fn<NotificationSource['markAsRead']>();
+  const bulkMarkAsRead = vi.fn<NotificationSource['bulkMarkAsRead']>();
+  const matchingNotifications = [
+    documentMentionNotification('notification-1'),
+    documentMentionNotification('notification-2'),
+  ];
 
   beforeEach(() => {
     vi.clearAllMocks();
-    markAsRead.mockResolvedValue(undefined);
-    const notification = documentMentionNotification();
+    bulkMarkAsRead.mockResolvedValue(undefined);
     mocks.notificationSource = {
       notificationsByEntity: () => ({
-        'channel@channel-1': [notification],
+        'channel@channel-1': [
+          ...matchingNotifications,
+          documentMentionNotification('notification-3', 'other-message'),
+        ],
       }),
-      markAsRead,
+      bulkMarkAsRead,
     } as unknown as NotificationSource;
   });
 
-  it('marks a document mention as read when its channel message mounts', async () => {
+  it('marks every document mention from the mounted channel message as read', async () => {
     render(() => (
       <MarkMessageNotifications messageId="message-1" channelId="channel-1">
         <span>Message</span>
@@ -55,13 +62,8 @@ describe('MarkMessageNotifications', () => {
     ));
 
     await waitFor(() => {
-      expect(markAsRead).toHaveBeenCalledOnce();
-      expect(markAsRead).toHaveBeenCalledWith(
-        expect.objectContaining({
-          id: 'notification-1',
-          notification_event_type: 'document_mention',
-        })
-      );
+      expect(bulkMarkAsRead).toHaveBeenCalledOnce();
+      expect(bulkMarkAsRead).toHaveBeenCalledWith(matchingNotifications);
     });
   });
 });

--- a/apps/web/src/features/notifications/tests/mark-message-notifications.test.tsx
+++ b/apps/web/src/features/notifications/tests/mark-message-notifications.test.tsx
@@ -35,14 +35,19 @@ function documentMentionNotification(
 
 describe('MarkMessageNotifications', () => {
   const bulkMarkAsRead = vi.fn<NotificationSource['bulkMarkAsRead']>();
-  const matchingNotifications = [
-    documentMentionNotification('notification-1'),
-    documentMentionNotification('notification-2'),
-  ];
+  let matchingNotifications: UnifiedNotification[];
 
   beforeEach(() => {
     vi.clearAllMocks();
-    bulkMarkAsRead.mockResolvedValue(undefined);
+    matchingNotifications = [
+      documentMentionNotification('notification-1'),
+      documentMentionNotification('notification-2'),
+    ];
+    bulkMarkAsRead.mockImplementation(async (notifications) => {
+      for (const notification of notifications) {
+        notification.viewed_at = '2026-08-17T00:01:00.000Z';
+      }
+    });
     mocks.notificationSource = {
       notificationsByEntity: () => ({
         'channel@channel-1': [
@@ -62,8 +67,34 @@ describe('MarkMessageNotifications', () => {
     ));
 
     await waitFor(() => {
-      expect(bulkMarkAsRead).toHaveBeenCalledOnce();
-      expect(bulkMarkAsRead).toHaveBeenCalledWith(matchingNotifications);
+      expect(matchingNotifications.every((n) => n.viewed_at)).toBe(true);
     });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(bulkMarkAsRead).toHaveBeenCalledOnce();
+    expect(bulkMarkAsRead).toHaveBeenCalledWith(matchingNotifications);
+  });
+
+  it('handles mark failures while preserving bounded retries', async () => {
+    const error = new Error('mark failed');
+    bulkMarkAsRead.mockRejectedValue(error);
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    try {
+      render(() => (
+        <MarkMessageNotifications messageId="message-1" channelId="channel-1">
+          <span>Message</span>
+        </MarkMessageNotifications>
+      ));
+
+      await waitFor(() => {
+        expect(bulkMarkAsRead).toHaveBeenCalledTimes(3);
+        expect(consoleError).toHaveBeenCalledTimes(3);
+      });
+    } finally {
+      consoleError.mockRestore();
+    }
   });
 });


### PR DESCRIPTION
This PR fixes an issue where there can be multiple notifications associated with a single channel message, so clearing the first notification will never mark all notifications as seen. Instead, when we see a message we clear all notifications for that message