### PR TITLE
feat(activity): attribute starter-doc property writes to system

### DIFF
--- a/crates/properties/src/domain/activity.rs
+++ b/crates/properties/src/domain/activity.rs
@@ -52,18 +52,13 @@ fn event_attribution(
 
 fn attributed(
     event_id: uuid::Uuid,
-    actor: &Option<Actor<'static>>,
-    on_behalf_of: &Option<MacroUserIdStr<'static>>,
-    actor_user_id: &Option<MacroUserIdStr<'static>>,
+    attribution: Option<Attribution>,
     property_entity: &PropertyEntityType,
     entity_id: &str,
     action: CommonAction,
     occurred_at: chrono::DateTime<chrono::Utc>,
 ) -> Ingest {
-    let (Some(attribution), Some(entity_type)) = (
-        event_attribution(actor, on_behalf_of, actor_user_id),
-        entity_type(property_entity),
-    ) else {
+    let (Some(attribution), Some(entity_type)) = (attribution, entity_type(property_entity)) else {
         return Ingest::Ignore;
     };
     Ingest::Insert(vec![Activity::attributed(
@@ -86,9 +81,7 @@ impl ActivitySource for PropertyTopicEvent {
         match self {
             PropertyTopicEvent::EntityPropertyUpdated(m) => attributed(
                 event_id,
-                &m.actor,
-                &m.on_behalf_of,
-                &m.actor_user_id,
+                event_attribution(&m.actor, &m.on_behalf_of, &m.actor_user_id),
                 &m.entity_type,
                 &m.entity_id,
                 CommonAction::PropertyChanged(PropertyChange {
@@ -114,9 +107,7 @@ impl ActivitySource for PropertyTopicEvent {
             ),
             PropertyTopicEvent::EntityPropertyDeleted(m) => attributed(
                 event_id,
-                &m.actor,
-                &m.on_behalf_of,
-                &m.actor_user_id,
+                event_attribution(&m.actor, &m.on_behalf_of, &m.actor_user_id),
                 &m.entity_type,
                 &m.entity_id,
                 CommonAction::PropertyChanged(PropertyChange {
@@ -130,9 +121,7 @@ impl ActivitySource for PropertyTopicEvent {
             // mutation of the entity.
             PropertyTopicEvent::EntityPropertiesCleared(m) => attributed(
                 event_id,
-                &m.actor,
-                &m.on_behalf_of,
-                &m.actor_user_id,
+                event_attribution(&m.actor, &m.on_behalf_of, &m.actor_user_id),
                 &m.entity_type,
                 &m.entity_id,
                 CommonAction::Edited,

--- a/crates/properties/src/domain/activity.rs
+++ b/crates/properties/src/domain/activity.rs
@@ -9,7 +9,8 @@
 mod test;
 
 use ::activity::{
-    Activity, ActivitySource, Actor, CommonAction, EntityType, Ingest, PropertyChange, event_time,
+    Activity, ActivitySource, Actor, Attribution, CommonAction, EntityType, Ingest, PropertyChange,
+    event_time,
 };
 use macro_user_id::user_id::MacroUserIdStr;
 use models_properties::EntityType as PropertyEntityType;
@@ -33,22 +34,42 @@ fn entity_type(property_entity: &PropertyEntityType) -> Option<EntityType> {
     }
 }
 
+fn event_attribution(
+    actor: &Option<Actor<'static>>,
+    on_behalf_of: &Option<MacroUserIdStr<'static>>,
+    actor_user_id: &Option<MacroUserIdStr<'static>>,
+) -> Option<Attribution> {
+    if let Some(actor) = actor.clone() {
+        return Some(match on_behalf_of.clone() {
+            Some(subject) => Attribution::delegated(actor, subject),
+            None => Attribution::direct(actor),
+        });
+    }
+    actor_user_id
+        .clone()
+        .map(|user| Attribution::direct(Actor::new_from_user(user)))
+}
+
 fn attributed(
     event_id: uuid::Uuid,
-    actor: &Option<MacroUserIdStr<'static>>,
+    actor: &Option<Actor<'static>>,
+    on_behalf_of: &Option<MacroUserIdStr<'static>>,
+    actor_user_id: &Option<MacroUserIdStr<'static>>,
     property_entity: &PropertyEntityType,
     entity_id: &str,
     action: CommonAction,
     occurred_at: chrono::DateTime<chrono::Utc>,
 ) -> Ingest {
-    let (Some(actor), Some(entity_type)) = (actor, entity_type(property_entity)) else {
+    let (Some(attribution), Some(entity_type)) = (
+        event_attribution(actor, on_behalf_of, actor_user_id),
+        entity_type(property_entity),
+    ) else {
         return Ingest::Ignore;
     };
-    Ingest::Insert(vec![Activity::common(
+    Ingest::Insert(vec![Activity::attributed(
         event_id,
         0,
-        Actor::new_from_user(actor.clone()),
-        None,
+        attribution,
         entity_type,
         entity_id,
         action,
@@ -65,6 +86,8 @@ impl ActivitySource for PropertyTopicEvent {
         match self {
             PropertyTopicEvent::EntityPropertyUpdated(m) => attributed(
                 event_id,
+                &m.actor,
+                &m.on_behalf_of,
                 &m.actor_user_id,
                 &m.entity_type,
                 &m.entity_id,
@@ -91,6 +114,8 @@ impl ActivitySource for PropertyTopicEvent {
             ),
             PropertyTopicEvent::EntityPropertyDeleted(m) => attributed(
                 event_id,
+                &m.actor,
+                &m.on_behalf_of,
                 &m.actor_user_id,
                 &m.entity_type,
                 &m.entity_id,
@@ -105,6 +130,8 @@ impl ActivitySource for PropertyTopicEvent {
             // mutation of the entity.
             PropertyTopicEvent::EntityPropertiesCleared(m) => attributed(
                 event_id,
+                &m.actor,
+                &m.on_behalf_of,
                 &m.actor_user_id,
                 &m.entity_type,
                 &m.entity_id,

--- a/crates/properties/src/domain/activity/test.rs
+++ b/crates/properties/src/domain/activity/test.rs
@@ -1,4 +1,4 @@
-use ::activity::Action;
+use ::activity::{Action, Actor};
 use chrono::Utc;
 use macro_user_id::user_id::MacroUserIdStr;
 use model_entity::EntityType as ActivityEntityType;
@@ -25,6 +25,8 @@ fn update(actor: Option<MacroUserIdStr<'static>>) -> EntityPropertyUpdatedMetada
         entity_type: PropertyEntityType::Task,
         property_definition_id: Uuid::from_u128(3),
         actor_user_id: actor,
+        actor: None,
+        on_behalf_of: None,
         value: None,
         previous_value: None,
         updated_at: Utc::now(),
@@ -80,4 +82,24 @@ fn task_property_update_maps_to_property_changed_on_the_document() {
 fn unattributed_property_update_is_dropped() {
     let event = envelope(PropertyTopicEvent::EntityPropertyUpdated(update(None)));
     assert_eq!(event.event.ingest(event.event_id), Ingest::Ignore);
+}
+
+#[test]
+fn delegated_property_update_keeps_the_user_as_subject() {
+    let mut metadata = update(None);
+    metadata.actor = Some(
+        Actor::try_from("bot|00000000-0000-0000-0000-000000005759".to_string())
+            .expect("system bot"),
+    );
+    metadata.on_behalf_of = Some(user("macro|owner@example.com"));
+    let event = envelope(PropertyTopicEvent::EntityPropertyUpdated(metadata));
+
+    let Ingest::Insert(activities) = event.event.ingest(event.event_id) else {
+        panic!("expected activities");
+    };
+    assert_eq!(
+        activities[0].actor.as_ref(),
+        "bot|00000000-0000-0000-0000-000000005759"
+    );
+    assert_eq!(activities[0].subject_id, "macro|owner@example.com");
 }

--- a/crates/properties/src/domain/events.rs
+++ b/crates/properties/src/domain/events.rs
@@ -6,6 +6,7 @@
 #[cfg(test)]
 mod test;
 
+use activity::Actor;
 use chrono::{DateTime, Utc};
 use macro_event_broker::{Event, MacroEvent, TopicEvent};
 use macro_event_topics::MacroPropertiesTopic;
@@ -112,6 +113,15 @@ pub struct EntityPropertyUpdatedMetadata {
     pub property_definition_id: Uuid,
     /// Authenticated user who changed the value, or `None` for a system operation.
     pub actor_user_id: Option<MacroUserIdStr<'static>>,
+    /// Who mechanically changed the value. Absent on events published
+    /// before attribution: ingest then treats [`Self::actor_user_id`] as
+    /// the actor.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub actor: Option<Actor<'static>>,
+    /// The user whose feed this change belongs on, when different from
+    /// [`Self::actor`]. Absent means the actor is also the subject.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub on_behalf_of: Option<MacroUserIdStr<'static>>,
     /// Full value after the update, or `None` when cleared without deleting the row.
     pub value: Option<PropertyValue>,
     /// Full value before the update: `None` when the property was newly
@@ -136,6 +146,15 @@ pub struct EntityPropertyDeletedMetadata {
     pub property_definition_id: Uuid,
     /// Authenticated user who deleted the value, or `None` for a system operation.
     pub actor_user_id: Option<MacroUserIdStr<'static>>,
+    /// Who mechanically deleted the value. Absent on events published
+    /// before attribution: ingest then treats [`Self::actor_user_id`] as
+    /// the actor.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub actor: Option<Actor<'static>>,
+    /// The user whose feed this deletion belongs on, when different from
+    /// [`Self::actor`]. Absent means the actor is also the subject.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub on_behalf_of: Option<MacroUserIdStr<'static>>,
 }
 
 /// Metadata for [`PropertyTopicEvent::EntityPropertiesCleared`].
@@ -147,6 +166,15 @@ pub struct EntityPropertiesClearedMetadata {
     pub entity_type: EntityType,
     /// Authenticated user who cleared the values, or `None` for a system operation.
     pub actor_user_id: Option<MacroUserIdStr<'static>>,
+    /// Who mechanically cleared the values. Absent on events published
+    /// before attribution: ingest then treats [`Self::actor_user_id`] as
+    /// the actor.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub actor: Option<Actor<'static>>,
+    /// The user whose feed this clear belongs on, when different from
+    /// [`Self::actor`]. Absent means the actor is also the subject.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub on_behalf_of: Option<MacroUserIdStr<'static>>,
 }
 
 /// Property mutation events published to [`MacroPropertiesTopic`].

--- a/crates/properties/src/domain/events/test.rs
+++ b/crates/properties/src/domain/events/test.rs
@@ -160,6 +160,8 @@ fn topic_events(
                 entity_type: EntityType::Document,
                 property_definition_id: uuid(PROPERTY_DEFINITION_ID),
                 actor_user_id: actor_user_id.clone(),
+                actor: None,
+                on_behalf_of: None,
                 value: Some(PropertyValue::SelectOption(vec![uuid(OPTION_ID)])),
                 previous_value: None,
                 updated_at: timestamp(UPDATED_AT),
@@ -188,6 +190,8 @@ fn topic_events(
                 entity_type: EntityType::Document,
                 property_definition_id: uuid(PROPERTY_DEFINITION_ID),
                 actor_user_id: actor_user_id.clone(),
+                actor: None,
+                on_behalf_of: None,
             }),
             json!({
                 "event_type": "entity_property.deleted",
@@ -205,6 +209,8 @@ fn topic_events(
                 entity_id: ENTITY_ID.to_string(),
                 entity_type: EntityType::Document,
                 actor_user_id,
+                actor: None,
+                on_behalf_of: None,
             }),
             json!({
                 "event_type": "entity_properties.cleared",
@@ -297,6 +303,33 @@ fn constructors_use_exact_bare_keys_topic_and_schema_version() {
         assert_eq!(event.topic(), "macro.properties");
         assert_eq!(event.event().schema_version, 1);
     }
+}
+
+#[test]
+fn entity_property_updated_decodes_without_actor_fields() {
+    let json = json!({
+        "event_type": "entity_property.updated",
+        "metadata": {
+            "entity_property_id": ENTITY_PROPERTY_ID,
+            "entity_id": ENTITY_ID,
+            "entity_type": "DOCUMENT",
+            "property_definition_id": PROPERTY_DEFINITION_ID,
+            "actor_user_id": "macro|editor@acme.com",
+            "value": null,
+            "previous_value": null,
+            "updated_at": UPDATED_AT
+        }
+    });
+    let event: PropertyTopicEvent = serde_json::from_value(json).expect("decodable event");
+    let PropertyTopicEvent::EntityPropertyUpdated(metadata) = event else {
+        panic!("expected entity_property.updated");
+    };
+    assert_eq!(metadata.actor, None);
+    assert_eq!(metadata.on_behalf_of, None);
+    assert_eq!(
+        metadata.actor_user_id,
+        Some(user_id("macro|editor@acme.com"))
+    );
 }
 
 #[test]

--- a/crates/properties/src/domain/model.rs
+++ b/crates/properties/src/domain/model.rs
@@ -1,8 +1,9 @@
 //! Domain models for properties.
 
+use activity::{Actor, Attribution};
 use entity_access::domain::models::{
-    EditAccessLevel, EntityAccessAuth, EntityAccessReceipt, EntityType as AccessEntityType,
-    RequiredPermission, ViewAccessLevel,
+    BotReceiptScope, EditAccessLevel, EntityAccessAuth, EntityAccessReceipt,
+    EntityType as AccessEntityType, RequiredPermission, ViewAccessLevel,
 };
 use macro_user_id::user_id::MacroUserIdStr;
 use models_properties::service::entity_property::EntityProperty;
@@ -40,6 +41,11 @@ pub trait PropertyAccessReceiptExt {
     fn entity_type(&self) -> AccessEntityType;
     /// Authenticated user, if the receipt represents one.
     fn authenticated_user(&self) -> Option<&MacroUserIdStr<'static>>;
+    /// Activity attribution implied by this receipt.
+    ///
+    /// A user receipt is Direct. A bot acting as a user is Delegated.
+    /// Team-scoped bots and unauthenticated receipts have no attribution.
+    fn attribution(&self) -> Option<Attribution>;
 }
 
 impl<T: RequiredPermission> PropertyAccessReceiptExt for EntityAccessReceipt<T> {
@@ -57,6 +63,22 @@ impl<T: RequiredPermission> PropertyAccessReceiptExt for EntityAccessReceipt<T> 
             EntityAccessAuth::Bot(_)
             | EntityAccessAuth::Unauthenticated
             | EntityAccessAuth::Internal => None,
+        }
+    }
+
+    fn attribution(&self) -> Option<Attribution> {
+        match self.auth() {
+            EntityAccessAuth::Authenticated(user) => {
+                Some(Attribution::direct(Actor::new_from_user(user.clone())))
+            }
+            EntityAccessAuth::Bot(bot) => match bot.scope() {
+                BotReceiptScope::User { acting_user } => Some(Attribution::delegated(
+                    Actor::new_from_bot(bot.bot_id()),
+                    acting_user.clone(),
+                )),
+                BotReceiptScope::Team { .. } => None,
+            },
+            EntityAccessAuth::Unauthenticated | EntityAccessAuth::Internal => None,
         }
     }
 }

--- a/crates/properties/src/domain/model.rs
+++ b/crates/properties/src/domain/model.rs
@@ -1,9 +1,8 @@
 //! Domain models for properties.
 
-use activity::{Actor, Attribution};
 use entity_access::domain::models::{
-    BotReceiptScope, EditAccessLevel, EntityAccessAuth, EntityAccessReceipt,
-    EntityType as AccessEntityType, RequiredPermission, ViewAccessLevel,
+    EditAccessLevel, EntityAccessAuth, EntityAccessReceipt, EntityType as AccessEntityType,
+    RequiredPermission, ViewAccessLevel,
 };
 use macro_user_id::user_id::MacroUserIdStr;
 use models_properties::service::entity_property::EntityProperty;
@@ -41,11 +40,6 @@ pub trait PropertyAccessReceiptExt {
     fn entity_type(&self) -> AccessEntityType;
     /// Authenticated user, if the receipt represents one.
     fn authenticated_user(&self) -> Option<&MacroUserIdStr<'static>>;
-    /// Activity attribution implied by this receipt.
-    ///
-    /// A user receipt is Direct. A bot acting as a user is Delegated.
-    /// Team-scoped bots and unauthenticated receipts have no attribution.
-    fn attribution(&self) -> Option<Attribution>;
 }
 
 impl<T: RequiredPermission> PropertyAccessReceiptExt for EntityAccessReceipt<T> {
@@ -63,22 +57,6 @@ impl<T: RequiredPermission> PropertyAccessReceiptExt for EntityAccessReceipt<T> 
             EntityAccessAuth::Bot(_)
             | EntityAccessAuth::Unauthenticated
             | EntityAccessAuth::Internal => None,
-        }
-    }
-
-    fn attribution(&self) -> Option<Attribution> {
-        match self.auth() {
-            EntityAccessAuth::Authenticated(user) => {
-                Some(Attribution::direct(Actor::new_from_user(user.clone())))
-            }
-            EntityAccessAuth::Bot(bot) => match bot.scope() {
-                BotReceiptScope::User { acting_user } => Some(Attribution::delegated(
-                    Actor::new_from_bot(bot.bot_id()),
-                    acting_user.clone(),
-                )),
-                BotReceiptScope::Team { .. } => None,
-            },
-            EntityAccessAuth::Unauthenticated | EntityAccessAuth::Internal => None,
         }
     }
 }

--- a/crates/properties/src/domain/service_impl/mod.rs
+++ b/crates/properties/src/domain/service_impl/mod.rs
@@ -5,10 +5,11 @@ mod task_properties;
 
 use std::collections::{HashMap, HashSet};
 
-use activity::{Actor, Attribution};
+use activity::Actor;
 use document_sub_type::DocumentSubType;
 use entity_access::domain::models::{
-    EntityAccessReceipt, EntityType as AccessEntityType, RequiredPermission,
+    BotReceiptScope, EntityAccessAuth, EntityAccessReceipt, EntityType as AccessEntityType,
+    RequiredPermission,
 };
 use macro_event_broker::{MacroEventBroker, NoopMacroEventBroker};
 use macro_user_id::cowlike::CowLike;
@@ -50,18 +51,36 @@ use helpers::{
     extract_option_ids_from_property_value, is_property_applicable_to, retain_caller_visible_tags,
 };
 
-fn published_event_actors(
-    access: &EditReceipt,
-) -> (
-    Option<Actor<'static>>,
-    Option<MacroUserIdStr<'static>>,
-    Option<MacroUserIdStr<'static>>,
-) {
-    match access.attribution() {
-        Some(Attribution::Delegated { actor, subject }) => (Some(actor), Some(subject), None),
-        Some(Attribution::Direct { .. }) | None => {
-            (None, None, access.authenticated_user().cloned())
-        }
+struct PublishedEventActors {
+    actor: Option<Actor<'static>>,
+    on_behalf_of: Option<MacroUserIdStr<'static>>,
+    actor_user_id: Option<MacroUserIdStr<'static>>,
+}
+
+fn published_event_actors(access: &EditReceipt) -> PublishedEventActors {
+    match access.auth() {
+        EntityAccessAuth::Authenticated(user) => PublishedEventActors {
+            actor: None,
+            on_behalf_of: None,
+            actor_user_id: Some(user.clone()),
+        },
+        EntityAccessAuth::Bot(bot) => match bot.scope() {
+            BotReceiptScope::User { acting_user } => PublishedEventActors {
+                actor: Some(Actor::new_from_bot(bot.bot_id())),
+                on_behalf_of: Some(acting_user.clone()),
+                actor_user_id: None,
+            },
+            BotReceiptScope::Team { .. } => PublishedEventActors {
+                actor: None,
+                on_behalf_of: None,
+                actor_user_id: None,
+            },
+        },
+        EntityAccessAuth::Unauthenticated | EntityAccessAuth::Internal => PublishedEventActors {
+            actor: None,
+            on_behalf_of: None,
+            actor_user_id: None,
+        },
     }
 }
 
@@ -197,7 +216,11 @@ where
         previous_value: &Option<PropertyValue>,
         access: &EditReceipt,
     ) -> PropertyMacroEvent {
-        let (actor, on_behalf_of, actor_user_id) = published_event_actors(access);
+        let PublishedEventActors {
+            actor,
+            on_behalf_of,
+            actor_user_id,
+        } = published_event_actors(access);
         PropertyMacroEvent::entity_property_updated(EntityPropertyUpdatedMetadata {
             entity_property_id: property.id,
             entity_id: property.entity_id.clone(),
@@ -1624,7 +1647,11 @@ where
             .await
             .map_err(anyhow::Error::from)?;
 
-        let (actor, on_behalf_of, actor_user_id) = published_event_actors(access);
+        let PublishedEventActors {
+            actor,
+            on_behalf_of,
+            actor_user_id,
+        } = published_event_actors(access);
         self.publish_property_event(PropertyMacroEvent::entity_properties_cleared(
             EntityPropertiesClearedMetadata {
                 entity_id: access.entity_id().to_string(),
@@ -1703,7 +1730,11 @@ where
 
         tracing::info!("successfully removed entity property");
 
-        let (actor, on_behalf_of, actor_user_id) = published_event_actors(access);
+        let PublishedEventActors {
+            actor,
+            on_behalf_of,
+            actor_user_id,
+        } = published_event_actors(access);
         self.publish_property_event(PropertyMacroEvent::entity_property_deleted(
             EntityPropertyDeletedMetadata {
                 entity_property_id,

--- a/crates/properties/src/domain/service_impl/mod.rs
+++ b/crates/properties/src/domain/service_impl/mod.rs
@@ -5,6 +5,7 @@ mod task_properties;
 
 use std::collections::{HashMap, HashSet};
 
+use activity::{Actor, Attribution};
 use document_sub_type::DocumentSubType;
 use entity_access::domain::models::{
     EntityAccessReceipt, EntityType as AccessEntityType, RequiredPermission,
@@ -48,6 +49,21 @@ use super::service::{PropertiesService, TeamReceipt, team_id_from_receipt};
 use helpers::{
     extract_option_ids_from_property_value, is_property_applicable_to, retain_caller_visible_tags,
 };
+
+fn published_event_actors(
+    access: &EditReceipt,
+) -> (
+    Option<Actor<'static>>,
+    Option<MacroUserIdStr<'static>>,
+    Option<MacroUserIdStr<'static>>,
+) {
+    match access.attribution() {
+        Some(Attribution::Delegated { actor, subject }) => (Some(actor), Some(subject), None),
+        Some(Attribution::Direct { .. }) | None => {
+            (None, None, access.authenticated_user().cloned())
+        }
+    }
+}
 
 /// Implementation of [`PropertiesService`] using repository, permission,
 /// notification, and event-publishing ports.
@@ -181,12 +197,15 @@ where
         previous_value: &Option<PropertyValue>,
         access: &EditReceipt,
     ) -> PropertyMacroEvent {
+        let (actor, on_behalf_of, actor_user_id) = published_event_actors(access);
         PropertyMacroEvent::entity_property_updated(EntityPropertyUpdatedMetadata {
             entity_property_id: property.id,
             entity_id: property.entity_id.clone(),
             entity_type: property.entity_type,
             property_definition_id: property.property_definition_id,
-            actor_user_id: access.authenticated_user().cloned(),
+            actor_user_id,
+            actor,
+            on_behalf_of,
             value: value.clone(),
             previous_value: previous_value.clone(),
             updated_at: property.updated_at,
@@ -392,6 +411,8 @@ where
                     entity_type: mutation.property.entity_type,
                     property_definition_id: mutation.property.property_definition_id,
                     actor_user_id: Some(actor.clone().into_owned()),
+                    actor: None,
+                    on_behalf_of: None,
                     value: mutation.value.clone(),
                     previous_value: mutation.previous_value.clone(),
                     updated_at: mutation.property.updated_at,
@@ -1603,11 +1624,14 @@ where
             .await
             .map_err(anyhow::Error::from)?;
 
+        let (actor, on_behalf_of, actor_user_id) = published_event_actors(access);
         self.publish_property_event(PropertyMacroEvent::entity_properties_cleared(
             EntityPropertiesClearedMetadata {
                 entity_id: access.entity_id().to_string(),
                 entity_type: subject.storage_entity_type,
-                actor_user_id: access.authenticated_user().cloned(),
+                actor_user_id,
+                actor,
+                on_behalf_of,
             },
         ));
 
@@ -1679,13 +1703,16 @@ where
 
         tracing::info!("successfully removed entity property");
 
+        let (actor, on_behalf_of, actor_user_id) = published_event_actors(access);
         self.publish_property_event(PropertyMacroEvent::entity_property_deleted(
             EntityPropertyDeletedMetadata {
                 entity_property_id,
                 entity_id: property_info.entity_id,
                 entity_type: property_info.entity_type,
                 property_definition_id: property_info.property_definition_id,
-                actor_user_id: access.authenticated_user().cloned(),
+                actor_user_id,
+                actor,
+                on_behalf_of,
             },
         ));
 

--- a/crates/properties/src/domain/test.rs
+++ b/crates/properties/src/domain/test.rs
@@ -1242,7 +1242,65 @@ async fn entity_property_event_actor_is_only_an_authenticated_user() {
             published.envelope["metadata"]["actor_user_id"],
             serde_json::Value::Null
         );
+        assert!(published.envelope["metadata"]["actor"].is_null());
+        assert!(published.envelope["metadata"]["on_behalf_of"].is_null());
     }
+}
+
+#[tokio::test]
+async fn entity_property_event_delegates_user_scoped_bot_writes() {
+    let bot_id = BotId::new_from_uuid(uuid::uuid!("00000000-0000-0000-0000-000000005759"));
+    let bot_access = EditReceipt::dangerously_assert_bot(
+        bot_id.into_storage_id(),
+        BotReceiptScope::User {
+            acting_user: caller_user_id(),
+        },
+        "doc1",
+        AccessEntityType::Document,
+    );
+    let property_definition_id = Uuid::from_u128(0xE706);
+    let assignment = entity_property_for_event(
+        Uuid::from_u128(0xE707),
+        "doc1",
+        EntityType::Document,
+        property_definition_id,
+        event_timestamp(),
+    );
+    let mut repo = MockPropertiesRepo::new();
+    repo.expect_get_property_definition().return_once(move |_| {
+        Box::pin(async move { Ok(Some(multi_select_definition(property_definition_id, false))) })
+    });
+    repo.expect_upsert_entity_property()
+        .return_once(move |_, _, _, _| {
+            Box::pin(async move {
+                Ok(EntityPropertyMutationSnapshot {
+                    property: assignment,
+                    value: None,
+                    previous_value: None,
+                })
+            })
+        });
+    let event_broker = RecordingEventBroker::default();
+    let service = service_with_event_broker(repo, event_broker.clone());
+
+    service
+        .set_entity_property(&bot_access, property_definition_id, None)
+        .await
+        .unwrap();
+
+    let published = only_published_property_event(&event_broker);
+    assert_eq!(
+        published.envelope["metadata"]["actor_user_id"],
+        serde_json::Value::Null
+    );
+    assert_eq!(
+        published.envelope["metadata"]["actor"],
+        "bot|00000000-0000-0000-0000-000000005759"
+    );
+    assert_eq!(
+        published.envelope["metadata"]["on_behalf_of"],
+        caller_user_id().as_ref()
+    );
 }
 
 #[test]
@@ -1259,6 +1317,7 @@ fn bot_receipt_has_no_authenticated_user_identity() {
     let access = receipt;
 
     assert!(access.authenticated_user().is_none());
+    assert!(access.attribution().is_none());
     assert!(matches!(access.auth(), EntityAccessAuth::Bot(id) if id.bot_id() == bot_id));
 }
 

--- a/crates/properties/src/domain/test.rs
+++ b/crates/properties/src/domain/test.rs
@@ -1317,7 +1317,6 @@ fn bot_receipt_has_no_authenticated_user_identity() {
     let access = receipt;
 
     assert!(access.authenticated_user().is_none());
-    assert!(access.attribution().is_none());
     assert!(matches!(access.auth(), EntityAccessAuth::Bot(id) if id.bot_id() == bot_id));
 }
 

--- a/crates/soup_realtime/src/inbound/kafka_consumer/test.rs
+++ b/crates/soup_realtime/src/inbound/kafka_consumer/test.rs
@@ -295,6 +295,8 @@ fn task_property_updates_map_to_document_updates() {
         entity_type: PropertyEntityType::Task,
         property_definition_id: Uuid::now_v7(),
         actor_user_id: Some(user()),
+        actor: None,
+        on_behalf_of: None,
         value: None,
         previous_value: None,
         updated_at: Utc::now(),
@@ -316,12 +318,16 @@ fn deleting_or_clearing_properties_updates_the_soup_entity() {
         entity_type: PropertyEntityType::Thread,
         property_definition_id: Uuid::now_v7(),
         actor_user_id: Some(user()),
+        actor: None,
+        on_behalf_of: None,
     });
     let company_id = Uuid::now_v7().to_string();
     let cleared = PropertyTopicEvent::EntityPropertiesCleared(EntityPropertiesClearedMetadata {
         entity_id: company_id.clone(),
         entity_type: PropertyEntityType::Company,
         actor_user_id: Some(user()),
+        actor: None,
+        on_behalf_of: None,
     });
 
     let deleted = patches_from_property_event(&deleted);
@@ -348,6 +354,8 @@ fn property_events_for_non_property_soup_items_are_ignored() {
             entity_id: DOCUMENT_ID.to_string(),
             entity_type,
             actor_user_id: Some(user()),
+            actor: None,
+            on_behalf_of: None,
         });
         assert!(patches_from_property_event(&event).is_empty());
     }

--- a/services/document_storage_service/src/api/documents/initialize_starter_docs.rs
+++ b/services/document_storage_service/src/api/documents/initialize_starter_docs.rs
@@ -10,7 +10,7 @@ use documents_hex::domain::{
     models::DocumentError,
 };
 use entity_access::domain::{
-    models::{EditAccessLevel, ViewAccessLevel},
+    models::{BotAccessScope, EditAccessLevel, ViewAccessLevel},
     ports::EntityAccessService,
 };
 use favorites::domain::ports::FavoritesService;
@@ -326,9 +326,12 @@ pub async fn handler(
         // properties service takes its authorization as this typed receipt.
         let receipt = match state
             .entity_access_service
-            .generate_entity_access_receipt::<EditAccessLevel>(
-                &user_context.authorization.user.macro_user_id,
-                organization_id,
+            .generate_bot_entity_access_receipt::<EditAccessLevel>(
+                bot_id::MACRO_SYSTEM_BOT_ID,
+                BotAccessScope::User {
+                    user_id: user_context.authorization.user.macro_user_id.clone(),
+                    user_org_id: organization_id,
+                },
                 &document_id,
                 EntityType::Document,
             )

--- a/services/search_processing_service/src/inbound/kafka_consumer/test.rs
+++ b/services/search_processing_service/src/inbound/kafka_consumer/test.rs
@@ -1200,6 +1200,8 @@ fn property_event_cases() -> Vec<(PropertyTopicEvent, PropertyEventDescription<'
                 entity_type: EntityType::Document,
                 property_definition_id: PROPERTY_DEFINITION_ID,
                 actor_user_id: actor_user_id.clone(),
+                actor: None,
+                on_behalf_of: None,
                 value: None,
                 previous_value: None,
                 updated_at: Utc::now(),
@@ -1219,6 +1221,8 @@ fn property_event_cases() -> Vec<(PropertyTopicEvent, PropertyEventDescription<'
                 entity_type: EntityType::Chat,
                 property_definition_id: PROPERTY_DEFINITION_ID,
                 actor_user_id: actor_user_id.clone(),
+                actor: None,
+                on_behalf_of: None,
             }),
             PropertyEventDescription {
                 action: PropertyIndexAction::Reindex {
@@ -1233,6 +1237,8 @@ fn property_event_cases() -> Vec<(PropertyTopicEvent, PropertyEventDescription<'
                 entity_id: PROPERTY_ENTITY_ID.to_string(),
                 entity_type: EntityType::Thread,
                 actor_user_id,
+                actor: None,
+                on_behalf_of: None,
             }),
             PropertyEventDescription {
                 action: PropertyIndexAction::Reindex {
@@ -1564,6 +1570,8 @@ fn property_envelope_decodes_round_trip_with_entity_key() {
         entity_id: PROPERTY_ENTITY_ID.to_string(),
         entity_type: EntityType::Document,
         actor_user_id: Some(user_id()),
+        actor: None,
+        on_behalf_of: None,
     });
     let message = encoded_message(
         MacroPropertiesTopic::TOPIC_STR,
@@ -1796,6 +1804,8 @@ async fn unsupported_property_schema_message_is_commit_safe() {
         entity_id: PROPERTY_ENTITY_ID.to_string(),
         entity_type: EntityType::Document,
         actor_user_id: Some(user_id()),
+        actor: None,
+        on_behalf_of: None,
     });
     let message = encoded_message(
         MacroPropertiesTopic::TOPIC_STR,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Starter docs already create as Delegated system actions. Priority and tag writes after create still mint a user receipt, so those property events look like the user.

Reopened against `main` after dropping the actor-index feed PR. That feed was not required for attribution. Nothing in this stack calls `actorActivity`.

## Scope

- `EntityPropertyUpdated`, `EntityPropertyDeleted`, and `EntityPropertiesCleared` gain optional `actor` and `on_behalf_of`. Old events keep decoding through `actor_user_id`.
- Publish maps `EntityAccessAuth` onto a named `PublishedEventActors` struct. Receipts stay access proof. They do not grow an `attribution()` helper.
- `initialize_starter_docs` mints `generate_bot_entity_access_receipt(MACRO_SYSTEM_BOT_ID, User { ... })` for decoration writes.

## Tradeoffs

Team-scoped bot property writes still have no attribution and stay ignored. That is the same as today.

## Blast Radius

Property Kafka payload grows two optional fields. Ingest of old events is unchanged. Starter-doc priority and tag activity moves from the user-as-actor path to system-as-actor on the user's feed.

## Verification

`cargo test -p properties --lib -- entity_property_event_delegates_user_scoped_bot_writes bot_receipt_has_no_authenticated_user_identity` passed after the named-actors reshape.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a1381642-d8e6-4e7a-8c8e-a86c6a163b66?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a1381642-d8e6-4e7a-8c8e-a86c6a163b66&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

