### PR TITLE
fix(xtask_local): isolate sdk webhook ssh from user config

### DIFF
--- a/tooling/xtask/crates/xtask_local/src/local/sdk_webhook.rs
+++ b/tooling/xtask/crates/xtask_local/src/local/sdk_webhook.rs
@@ -1,5 +1,6 @@
 //! Instance-local relay for SDK webhook receivers running on the host.
 
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::time::Duration;
@@ -18,6 +19,12 @@ fn ssh_client_flags(private_key: &Path, ssh_port: u16, host_receiver_port: u16) 
     vec![
         "-N".into(),
         "-T".into(),
+        "-F".into(),
+        "/dev/null".into(),
+        "-o".into(),
+        "BatchMode=yes".into(),
+        "-o".into(),
+        "IdentitiesOnly=yes".into(),
         "-o".into(),
         "ExitOnForwardFailure=yes".into(),
         "-o".into(),
@@ -97,13 +104,21 @@ pub fn start(instance: &Instance) -> Result<Child> {
             host_receiver_port(instance),
         ))
         .stdout(Stdio::null())
-        .stderr(Stdio::null())
+        .stderr(Stdio::piped())
         .spawn()
         .context("starting the SDK webhook SSH reverse tunnel")?;
 
     std::thread::sleep(Duration::from_millis(300));
     if let Some(status) = child.try_wait()? {
-        bail!("SDK webhook SSH reverse tunnel exited with {status}");
+        let mut err = String::new();
+        if let Some(mut stderr) = child.stderr.take() {
+            let _ = stderr.read_to_string(&mut err);
+        }
+        let err = err.trim();
+        if err.is_empty() {
+            bail!("SDK webhook SSH reverse tunnel exited with {status}");
+        }
+        bail!("SDK webhook SSH reverse tunnel exited with {status}: {err}");
     }
     std::fs::write(pid_path(instance), child.id().to_string())?;
     Ok(child)

--- a/tooling/xtask/crates/xtask_local/src/local/sdk_webhook.rs
+++ b/tooling/xtask/crates/xtask_local/src/local/sdk_webhook.rs
@@ -1,6 +1,6 @@
 //! Instance-local relay for SDK webhook receivers running on the host.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::time::Duration;
 
@@ -8,8 +8,37 @@ use anyhow::{Context, Result, bail};
 
 use super::instance::{Instance, Port};
 
+#[cfg(test)]
+mod test;
+
 const RELAY_PORT: u16 = 8787;
 const USER: &str = "sdk-webhook";
+
+fn ssh_client_flags(private_key: &Path, ssh_port: u16, host_receiver_port: u16) -> Vec<String> {
+    vec![
+        "-N".into(),
+        "-T".into(),
+        "-o".into(),
+        "ExitOnForwardFailure=yes".into(),
+        "-o".into(),
+        "StrictHostKeyChecking=no".into(),
+        "-o".into(),
+        "UserKnownHostsFile=/dev/null".into(),
+        "-o".into(),
+        "ConnectTimeout=2".into(),
+        "-o".into(),
+        "ServerAliveInterval=15".into(),
+        "-o".into(),
+        "ServerAliveCountMax=3".into(),
+        "-i".into(),
+        private_key.display().to_string(),
+        "-p".into(),
+        ssh_port.to_string(),
+        "-R".into(),
+        format!("0.0.0.0:{RELAY_PORT}:127.0.0.1:{host_receiver_port}"),
+        format!("{USER}@127.0.0.1"),
+    ]
+}
 
 pub fn relay_url() -> &'static str {
     "http://sdk-webhook-relay:8787/macro-events"
@@ -62,34 +91,11 @@ pub fn start(instance: &Instance) -> Result<Child> {
     ensure_keys(instance)?;
     stop(instance);
     let mut child = Command::new("ssh")
-        .args([
-            "-N",
-            "-T",
-            "-o",
-            "ExitOnForwardFailure=yes",
-            "-o",
-            "StrictHostKeyChecking=no",
-            "-o",
-            "UserKnownHostsFile=/dev/null",
-            "-o",
-            "ConnectTimeout=2",
-            "-o",
-            "ServerAliveInterval=15",
-            "-o",
-            "ServerAliveCountMax=3",
-            "-i",
-        ])
-        .arg(private_key(instance))
-        .args(["-p"])
-        .arg(ssh_port(instance).to_string())
-        .args([
-            "-R",
-            &format!(
-                "0.0.0.0:{RELAY_PORT}:127.0.0.1:{}",
-                host_receiver_port(instance)
-            ),
-        ])
-        .arg(format!("{USER}@127.0.0.1"))
+        .args(ssh_client_flags(
+            &private_key(instance),
+            ssh_port(instance),
+            host_receiver_port(instance),
+        ))
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()

--- a/tooling/xtask/crates/xtask_local/src/local/sdk_webhook/test.rs
+++ b/tooling/xtask/crates/xtask_local/src/local/sdk_webhook/test.rs
@@ -1,0 +1,63 @@
+use super::*;
+use std::process::Command;
+
+use crate::local::instance::Instance;
+
+#[test]
+fn isolated_ssh_ignores_apple_usekeychain() {
+    let config = std::env::temp_dir().join(format!(
+        "sdk-webhook-usekeychain-{}-{}.conf",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos()
+    ));
+    std::fs::write(&config, "Host *\n  UseKeychain yes\n").expect("write UseKeychain config");
+
+    let rejected = Command::new("ssh")
+        .args(["-F"])
+        .arg(&config)
+        .args(["-o", "BatchMode=yes", "-o", "ConnectTimeout=1", "-p", "1"])
+        .arg("sdk-webhook@127.0.0.1")
+        .output()
+        .expect("spawn ssh");
+    let rejected_err = String::from_utf8_lossy(&rejected.stderr);
+    let _ = std::fs::remove_file(&config);
+
+    assert!(
+        rejected_err.to_ascii_lowercase().contains("usekeychain"),
+        "expected Nix/OpenSSH to reject UseKeychain: {rejected_err}"
+    );
+
+    let flags = ssh_client_flags(std::path::Path::new("/tmp/missing-relay-key"), 1, 1);
+    assert!(
+        flags.windows(2).any(|pair| pair == ["-F", "/dev/null"]),
+        "relay ssh must ignore ~/.ssh/config, flags={flags:?}"
+    );
+    assert!(
+        flags.windows(2).any(|pair| pair == ["-o", "BatchMode=yes"]),
+        "relay ssh must not prompt, flags={flags:?}"
+    );
+    assert!(
+        flags
+            .windows(2)
+            .any(|pair| pair == ["-o", "IdentitiesOnly=yes"]),
+        "relay ssh must use only the generated key, flags={flags:?}"
+    );
+}
+
+#[test]
+fn start_surfaces_ssh_stderr() {
+    let instance = Instance::derive(
+        Some(&format!("sdk-wh-{}", std::process::id())),
+        Some(31_000),
+    )
+    .unwrap();
+    let err = start(&instance).unwrap_err().to_string();
+    let _ = std::fs::remove_dir_all(instance.artifact_dir());
+    assert!(
+        err.contains("Connection refused") || err.to_ascii_lowercase().contains("ssh:"),
+        "expected the real ssh error, got {err}"
+    );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

`just run_local` dies on the SDK webhook relay when the host SSH client is Nix OpenSSH and `~/.ssh/config` contains Apple `UseKeychain`. That option is valid on macOS `/usr/bin/ssh` and fatal everywhere else. The launcher discarded SSH stderr, so the only signal was exit 255.

You do not need to change your personal SSH config. The localhost relay must ignore it.

## Scope

`sdk_webhook::start` now launches `ssh` with:

- `-F /dev/null` so the tunnel does not read `~/.ssh/config`
- `-o BatchMode=yes`
- `-o IdentitiesOnly=yes`

Startup failures include the real SSH stderr.

`ssh_client_flags` is the single arg list for `start` and the regression in `sdk_webhook/test.rs`.

Out of scope: retries for a relay readiness race. I could not reproduce that race. If the relay is down, the error is now `Connection refused` instead of a bare 255.

## Tradeoffs

`-F /dev/null` also ignores `/etc/ssh/ssh_config`. That is what we want for a generated-key localhost tunnel. I did not add retries. A retry without a reproduced race is a guess.

## Blast Radius

Local stack only (`Mode::Local`). The tunnel still uses the generated ed25519 key and the same reverse-forward to port 8787. Dev mode does not start this tunnel.

## Verification

- Reproduced Nix OpenSSH 10.4 rejecting `UseKeychain` with exit 255, then the same client with `-F /dev/null` getting past config parse.
- Reproduced Ubuntu OpenSSH 9.6 reading passwd-home `~/.ssh/config` and dying on `UseKeychain`. Isolation flags skip that file.
- Red then green: `isolated_ssh_ignores_apple_usekeychain` and `start_surfaces_ssh_stderr`.
- `cargo test -p xtask_local`: 64 passed.
- `cargo clippy -p xtask_local -- -D warnings`: clean.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-318e391f-6d60-42f1-b2b3-46bf6764cdd0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-318e391f-6d60-42f1-b2b3-46bf6764cdd0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

