### PR TITLE
feat(rules): ban Tailwind class-string constants in TSX (FE-30)

### DIFF
--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -236,3 +236,8 @@ TypeScript · `[ui]` UI / UX conventions
   If none exists below the app root, or the nearest one is far outside the component's
   own UI scope (e.g. the route-level boundary in `apps/web/src/routes/Root.tsx`, whose
   fallback blanks unrelated UI), flag it and ask which boundary is intended.
+- **FE-30** `[ui]` Never hoist Tailwind class strings into named constants
+  (`const DAY_CELL_CLASS = '...'`) — shared markup+styling is a component; a class
+  string can't carry structure, props, or behavior. Extract a component, or inline the
+  literal at its single use; styling variants are component props, not exported
+  strings. (enforced: ast-grep `tsx-no-class-string-consts`, warning)

--- a/rules/ast-grep/tsx-no-class-string-consts.yml
+++ b/rules/ast-grep/tsx-no-class-string-consts.yml
@@ -1,0 +1,29 @@
+id: tsx-no-class-string-consts
+language: tsx
+severity: warning
+message: Don't hoist Tailwind class strings into named constants — shared markup+styling is a component, not a string.
+note: |-
+  Rule FE-30 in docs/STYLE_GUIDE.md. A named class-string constant
+  (`const DAY_CELL_CLASS = 'aspect-square w-full shrink-0'`) is a
+  component's render detail leaking into module scope: it can't carry
+  structure, props, or behavior, and every consumer re-implements the
+  element around it. Extract a component (or keep the literal inline at
+  its single use). For genuine styling variants, use the component's
+  props, not exported strings. When a class string must feed an imperative
+  DOM/editor API and no component boundary exists, inline it at the call
+  site. ~46 legacy uses exist — don't add new ones.
+files:
+  - apps/web/**
+  - packages/**
+rule:
+  kind: variable_declarator
+  all:
+    - has:
+        field: name
+        kind: identifier
+        regex: (?i)class(es|_?names?)?$
+    - has:
+        field: value
+        any:
+          - kind: string
+          - kind: template_string


### PR DESCRIPTION
New ast-grep rule `tsx-no-class-string-consts` + style-guide entry **FE-30**, targeting the pattern where a model (or human) hoists a class string instead of extracting a component:

```ts
const DAY_CELL_CLASS = 'aspect-square w-full shrink-0';
```

**Why it's banned:** a named class-string constant is a component's render detail leaking into module scope. It can't carry structure, props, or behavior — every consumer re-implements the element around it, and the constant becomes a second, weaker component API. The fix is a component (or inlining the literal at its single use); genuine styling variants are component props, not exported strings.

**Detection:** `variable_declarator` whose identifier ends in `Class`/`Classes`/`ClassName(s)` (case-insensitive, so `DAY_CELL_CLASS` and `dayCellClass` both match) with a string or template-string value. Call-expression values (e.g. `cva(...)`) deliberately don't match. Scoped to `apps/web/**` + `packages/**`.

**Severity:** warning per the sgconfig convention — **~46 legacy uses across ~30 files** (worst: PillTabs ×4, ItemPreview ×3, SplitDrawer ×3) to burn down before flipping to error. Spot-checked hits are true positives; the note carves out the one legitimate shape (class strings fed to imperative DOM/editor APIs where no component boundary exists — inline those at the call site).