### PR TITLE
feat(theme): resolve system color scheme at first paint

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -8,6 +8,57 @@
     />
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="theme-color" content="#FFFFFF" />
+    <script id="first-paint-appearance">
+      (function () {
+        var FALLBACK = {
+          light: "oklch(0.964 0 59deg)",
+          dark: "oklch(0.14 0 59deg)",
+        };
+        function read(key) {
+          try {
+            var raw = localStorage.getItem(key);
+            if (raw === null) return null;
+            try {
+              return JSON.parse(raw);
+            } catch {
+              return raw;
+            }
+          } catch {
+            return null;
+          }
+        }
+
+        var storedMode = read("macro-theme-mode");
+        var mode =
+          storedMode === "light" ||
+          storedMode === "dark" ||
+          storedMode === "system"
+            ? storedMode
+            : "system";
+        var scheme =
+          mode === "light" || mode === "dark"
+            ? mode
+            : window.matchMedia("(prefers-color-scheme: dark)").matches
+              ? "dark"
+              : "light";
+        var cached = read("html-color-theme");
+        var cachedSurface =
+          cached &&
+          typeof cached === "object" &&
+          !Array.isArray(cached) &&
+          typeof cached[scheme] === "string" &&
+          cached[scheme].trim()
+            ? cached[scheme]
+            : null;
+        var surface = cachedSurface || FALLBACK[scheme];
+
+        document.documentElement.style.colorScheme = scheme;
+        document.documentElement.style.backgroundColor = surface;
+        if (document.body) document.body.style.backgroundColor = surface;
+        var meta = document.querySelector('meta[name="theme-color"]');
+        if (meta) meta.setAttribute("content", surface);
+      })();
+    </script>
     <meta name="description" content="Macro AI Workspace" />
     <meta name="macro-bundle-build" content="__MACRO_BUNDLE_BUILD__" />
     <link
@@ -38,18 +89,6 @@
     <script type="module" src="/src/index.tsx"></script>
     <script>
       window.__START_TIME__ = performance.now();
-    </script>
-    <!-- Sets blank page to theme surface color to prevent background color flash -->
-    <script>
-      try {
-        let htmlColorString = localStorage.getItem("html-color-theme");
-        if (htmlColorString) {
-          let htmlColor = JSON.parse(htmlColorString);
-          document.body.style.backgroundColor = htmlColor.color;
-        }
-      } catch (err) {
-        console.error("Failed parse macro-selected-theme: ", err);
-      }
     </script>
   </body>
 </html>

--- a/apps/web/src/components/app/GlobalHotkeys.tsx
+++ b/apps/web/src/components/app/GlobalHotkeys.tsx
@@ -50,8 +50,6 @@ import { useMutationUndoContext } from '@queries/undo';
 import { debounce } from '@solid-primitives/scheduled';
 import { ThemeChips } from '@theme/components/ThemeChips';
 import {
-  darkModeTheme,
-  lightModeTheme,
   setDarkModeTheme,
   setLightModeTheme,
   setThemeMode,
@@ -61,11 +59,12 @@ import {
 } from '@theme/signals/themeSignals';
 import type { ThemeV3 } from '@theme/types/themeTypes';
 import {
+  activeAppearance,
   applySystemTheme,
   applyTheme,
   clearThemePreview,
   previewTheme,
-  resolveActiveThemeId,
+  systemAppearance,
 } from '@theme/utils/themeUtils';
 import { type Component, onCleanup, Show } from 'solid-js';
 import { useSplitLayout } from './split-layout/layout';
@@ -389,18 +388,13 @@ export default function GlobalShortcuts() {
     </div>
   );
 
-  // The per-mode theme the OS scheme currently resolves to — shown as the
-  // "System preference" option's swatch and previewed on highlight.
   const systemResolvedTheme = (): ThemeV3 | undefined =>
-    themes().find(
-      (theme) =>
-        theme.id ===
-        (systemMode() === 'dark' ? darkModeTheme() : lightModeTheme())
-    );
+    themes().find((theme) => theme.id === systemAppearance().themeId);
 
+  // Stay in the current mode. Update only the active scheme's stored id.
+  // Settings pins and leaves system via pinTheme.
   const setVisibleTheme = (themeId: string) => {
-    const resolvedMode = themeMode() === 'system' ? systemMode() : themeMode();
-    if (resolvedMode === 'dark') {
+    if (activeAppearance().scheme === 'dark') {
       setDarkModeTheme(themeId);
     } else {
       setLightModeTheme(themeId);
@@ -438,10 +432,8 @@ export default function GlobalShortcuts() {
       scopeId: setThemeScope.commandScopeId,
       description: `${theme.name}`,
       keyDownHandler: () => {
-        // Change the theme currently being viewed without switching between
-        // static and system-driven theme modes.
         setVisibleTheme(theme.id);
-        applyTheme(resolveActiveThemeId());
+        applyTheme(activeAppearance().themeId);
         analytics.track('theme_changed', { themeId: theme.id });
         return true;
       },

--- a/apps/web/src/features/settings/Appearance.tsx
+++ b/apps/web/src/features/settings/Appearance.tsx
@@ -24,6 +24,7 @@ import {
 } from '@theme/signals/themeSignals';
 import type { ThemeV3 } from '@theme/types/themeTypes';
 import {
+  activeAppearance,
   applyTheme,
   clearThemePreview,
   deleteTheme,
@@ -31,8 +32,8 @@ import {
   getLiveTheme,
   pinTheme,
   previewTheme,
-  resolveActiveThemeId,
   saveTheme,
+  systemAppearance,
   updateTheme,
 } from '@theme/utils/themeUtils';
 import { Dropdown, Layer, ToggleSwitch, Tooltip } from '@ui';
@@ -140,12 +141,8 @@ function createThemeEditorController(onSelect: (id: string) => void) {
     setEditingThemeId(undefined);
   };
 
-  // Abandon any in-progress edits: resync the live tokens with the active theme
-  // (via resolveActiveThemeId) so a draft/preview doesn't linger, then close.
-  // Shared by every edit-abandoning exit — the pill's edit toggle, the editor's
-  // close button, and picking a different theme.
   const discardAndCloseEditor = () => {
-    applyTheme(resolveActiveThemeId());
+    applyTheme(activeAppearance().themeId);
     closeEditor();
   };
 
@@ -482,23 +479,16 @@ function ActiveThemeSelect(props: {
 }) {
   const [open, setOpen] = createSignal(false);
 
-  // The theme the OS scheme currently resolves to (for the System preference
-  // swatch). Falls back to the live tokens so a swatch always renders.
-  const systemTheme = (): ThemeV3 => {
-    const id = systemMode() === 'dark' ? darkModeTheme() : lightModeTheme();
-    return themes().find((theme) => theme.id === id) ?? getLiveTheme();
-  };
-
-  // The active theme shown on the chip: the OS-resolved theme in system mode,
-  // otherwise the pinned theme (via resolveActiveThemeId).
-  const activeTheme = (): ThemeV3 =>
-    themes().find((theme) => theme.id === resolveActiveThemeId()) ??
+  const systemTheme = (): ThemeV3 =>
+    themes().find((theme) => theme.id === systemAppearance().themeId) ??
     getLiveTheme();
 
-  // The checked radio value: the sentinel in system mode, else the active
-  // theme's id.
+  const activeTheme = (): ThemeV3 =>
+    themes().find((theme) => theme.id === activeAppearance().themeId) ??
+    getLiveTheme();
+
   const selectedValue = () =>
-    themeMode() === 'system' ? SYSTEM_VALUE : resolveActiveThemeId();
+    themeMode() === 'system' ? SYSTEM_VALUE : activeAppearance().themeId;
 
   const onChange = (value: string) => {
     if (value === SYSTEM_VALUE) {
@@ -588,22 +578,16 @@ function ActiveThemeSelect(props: {
   );
 }
 
-/**
- * The full "Active theme" row: the picker chip plus copy/edit affordances for
- * the active theme and its own inline theme editor (opened by the edit button),
- * mirroring the per-mode ThemeSelectorRow. Picking a theme pins it — the mode
- * follows the theme's intrinsic light/dark and it becomes that mode's stored
- * theme, so resolveActiveThemeId / systemThemeEffect apply it live.
- */
 function ActiveThemeRow() {
-  // Saving a new theme from the editor pins it as the active theme.
+  // Settings pins and leaves system. The command palette stays in system
+  // via setVisibleTheme.
   const editor = createThemeEditorController((id) => {
     const theme = themes().find((t) => t.id === id);
     if (theme) pinTheme(theme);
   });
 
   const activeName = () =>
-    themes().find((theme) => theme.id === resolveActiveThemeId())?.name ??
+    themes().find((theme) => theme.id === activeAppearance().themeId)?.name ??
     'Unsaved Theme';
 
   return (
@@ -623,12 +607,12 @@ function ActiveThemeRow() {
             }}
           />
           <ThemePillActions
-            themeId={resolveActiveThemeId()}
+            themeId={activeAppearance().themeId}
             name={activeName()}
             onEdit={() =>
               editor.editorOpen()
                 ? editor.discardAndCloseEditor()
-                : editor.editTheme(resolveActiveThemeId())
+                : editor.editTheme(activeAppearance().themeId)
             }
           />
         </div>

--- a/apps/web/src/features/theme/appearance.test.ts
+++ b/apps/web/src/features/theme/appearance.test.ts
@@ -1,0 +1,218 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  APPEARANCE_KEYS,
+  DEFAULT_SURFACE,
+  paintChrome,
+  parseSurfaceCache,
+  parseThemeId,
+  parseThemeMode,
+  readOsScheme,
+  resolveAppearance,
+  type ThemeMode,
+} from './appearance';
+import { DEFAULT_THEME_ID, DEFAULT_THEMES } from './constants';
+import type { ThemeColorMode } from './types/themeTypes';
+
+const THEME_ID = {
+  light: 'Light theme',
+  dark: 'Dark theme',
+} as const;
+
+describe('resolveAppearance', () => {
+  it.each([
+    ['light', 'light', 'light', 'Light theme'],
+    ['light', 'dark', 'light', 'Light theme'],
+    ['dark', 'light', 'dark', 'Dark theme'],
+    ['dark', 'dark', 'dark', 'Dark theme'],
+    ['system', 'light', 'light', 'Light theme'],
+    ['system', 'dark', 'dark', 'Dark theme'],
+  ] satisfies Array<[ThemeMode, ThemeColorMode, ThemeColorMode, string]>)(
+    '%s mode on a %s system resolves to %s',
+    (mode, system, scheme, themeId) => {
+      expect(resolveAppearance({ mode, themeId: THEME_ID }, system)).toEqual({
+        scheme,
+        themeId,
+      });
+    }
+  );
+});
+
+describe('storage parsers', () => {
+  it.each([
+    ['"dark"', 'dark'],
+    ['light', 'light'],
+    ['"system"', 'system'],
+    ['"sepia"', 'system'],
+    ['garbage', 'system'],
+    [null, 'system'],
+  ] satisfies Array<[string | null, ThemeMode]>)(
+    'parses theme mode %s',
+    (raw, expected) => {
+      expect(parseThemeMode(raw)).toBe(expected);
+    }
+  );
+
+  it('accepts quoted and bare theme ids and rejects malformed values', () => {
+    expect(parseThemeId('"Ocean Dark"', 'Macro Dark')).toBe('Ocean Dark');
+    expect(parseThemeId('Ocean Dark', 'Macro Dark')).toBe('Ocean Dark');
+    expect(parseThemeId('""', 'Macro Dark')).toBe('Macro Dark');
+    expect(parseThemeId('{"id":"Ocean Dark"}', 'Macro Dark')).toBe(
+      'Macro Dark'
+    );
+    expect(parseThemeId(null, 'Macro Dark')).toBe('Macro Dark');
+  });
+
+  it('fills missing and invalid surface cache values from defaults', () => {
+    expect(APPEARANCE_KEYS.surface).toBe('html-color-theme');
+    expect(
+      parseSurfaceCache(
+        JSON.stringify({ light: 'light surface', dark: 'dark surface' })
+      )
+    ).toEqual({ light: 'light surface', dark: 'dark surface' });
+    expect(parseSurfaceCache(JSON.stringify({ dark: 'custom dark' }))).toEqual({
+      light: DEFAULT_SURFACE.light,
+      dark: 'custom dark',
+    });
+    expect(parseSurfaceCache('garbage')).toEqual(DEFAULT_SURFACE);
+    expect(parseSurfaceCache('{"color":"legacy surface"}')).toEqual(
+      DEFAULT_SURFACE
+    );
+    expect(parseSurfaceCache('{"light":42,"dark":""}')).toEqual(
+      DEFAULT_SURFACE
+    );
+    expect(parseSurfaceCache(null)).toEqual(DEFAULT_SURFACE);
+  });
+});
+
+it('matches the built-in desktop surface-0 values', () => {
+  const light = DEFAULT_THEMES.find(
+    (theme) => theme.id === DEFAULT_THEME_ID.light
+  );
+  const dark = DEFAULT_THEMES.find(
+    (theme) => theme.id === DEFAULT_THEME_ID.dark
+  );
+
+  expect(light?.colorTokens['surface-0']).toBe(DEFAULT_SURFACE.light);
+  expect(dark?.colorTokens['surface-0']).toBe(DEFAULT_SURFACE.dark);
+});
+
+it('maps matchMedia.matches onto a color scheme', () => {
+  expect(readOsScheme({ matches: true })).toBe('dark');
+  expect(readOsScheme({ matches: false })).toBe('light');
+});
+
+function createChromeDocument(): Document {
+  const doc = document.implementation.createHTMLDocument('Appearance test');
+  doc.head.innerHTML = '<meta name="theme-color" content="#FFFFFF">';
+  return doc;
+}
+
+function chromeState(doc: Document) {
+  return {
+    colorScheme: doc.documentElement.style.colorScheme,
+    htmlBackground: doc.documentElement.style.backgroundColor,
+    bodyBackground: doc.body.style.backgroundColor,
+    themeColor: doc
+      .querySelector('meta[name="theme-color"]')
+      ?.getAttribute('content'),
+  };
+}
+
+it('paints browser chrome idempotently', () => {
+  const doc = createChromeDocument();
+  const chrome = { scheme: 'dark', surface: DEFAULT_SURFACE.dark } as const;
+
+  paintChrome(chrome, doc);
+  const once = chromeState(doc);
+  paintChrome(chrome, doc);
+
+  expect(chromeState(doc)).toEqual(once);
+  expect(once.colorScheme).toBe('dark');
+  expect(once.themeColor).toBe(DEFAULT_SURFACE.dark);
+});
+
+describe('first-paint script', () => {
+  const indexHtml = readFileSync(resolve(process.cwd(), 'index.html'), 'utf8');
+  const scriptMatch = indexHtml.match(
+    /<script id="first-paint-appearance">([\s\S]*?)<\/script>/
+  );
+
+  it.each([
+    {
+      mode: JSON.stringify('system'),
+      surface: JSON.stringify({
+        light: 'oklch(0.9 0 0deg)',
+        dark: 'oklch(0.1 0 0deg)',
+      }),
+      system: 'dark',
+    },
+    {
+      mode: 'light',
+      surface: JSON.stringify({
+        light: 'oklch(0.8 0 0deg)',
+        dark: 'oklch(0.2 0 0deg)',
+      }),
+      system: 'dark',
+    },
+    {
+      mode: '"sepia"',
+      surface: 'garbage',
+      system: 'light',
+    },
+    {
+      mode: undefined,
+      surface: undefined,
+      system: 'dark',
+    },
+  ] satisfies Array<{
+    mode: string | undefined;
+    surface: string | undefined;
+    system: ThemeColorMode;
+  }>)(
+    'agrees with the module for mode $mode on a $system system',
+    ({ mode, surface, system }) => {
+      expect(scriptMatch?.[1]).toBeTruthy();
+      if (!scriptMatch?.[1]) return;
+
+      const storage = new Map<string, string>();
+      if (mode !== undefined) storage.set(APPEARANCE_KEYS.mode, mode);
+      if (surface !== undefined) {
+        storage.set(APPEARANCE_KEYS.surface, surface);
+      }
+
+      const actual = createChromeDocument();
+      Function(
+        'window',
+        'document',
+        'localStorage',
+        scriptMatch[1]
+      )(
+        {
+          matchMedia: () => ({ matches: system === 'dark' }),
+        },
+        actual,
+        {
+          getItem: (key: string) => storage.get(key) ?? null,
+        }
+      );
+
+      const expected = createChromeDocument();
+      const resolved = resolveAppearance(
+        {
+          mode: parseThemeMode(mode),
+          themeId: DEFAULT_THEME_ID,
+        },
+        system
+      );
+      const surfaces = parseSurfaceCache(surface);
+      paintChrome(
+        { scheme: resolved.scheme, surface: surfaces[resolved.scheme] },
+        expected
+      );
+
+      expect(chromeState(actual)).toEqual(chromeState(expected));
+    }
+  );
+});

--- a/apps/web/src/features/theme/appearance.ts
+++ b/apps/web/src/features/theme/appearance.ts
@@ -1,0 +1,103 @@
+import type { ThemeColorMode } from './types/themeTypes';
+
+export type ThemeMode = ThemeColorMode | 'system';
+
+export type AppearancePreference = {
+  mode: ThemeMode;
+  themeId: Readonly<Record<ThemeColorMode, string>>;
+};
+
+export type ResolvedTheme = {
+  scheme: ThemeColorMode;
+  themeId: string;
+};
+
+export type ChromeAppearance = {
+  scheme: ThemeColorMode;
+  surface: string;
+};
+
+export const APPEARANCE_KEYS = {
+  mode: 'macro-theme-mode',
+  themeId: {
+    light: 'macro-light-mode-theme',
+    dark: 'macro-dark-mode-theme',
+  },
+  surface: 'html-color-theme',
+} as const;
+
+export const DEFAULT_SURFACE = {
+  light: 'oklch(0.964 0 59deg)',
+  dark: 'oklch(0.14 0 59deg)',
+} as const satisfies Record<ThemeColorMode, string>;
+
+export function resolveAppearance(
+  preference: AppearancePreference,
+  system: ThemeColorMode
+): ResolvedTheme {
+  const scheme = preference.mode === 'system' ? system : preference.mode;
+  return { scheme, themeId: preference.themeId[scheme] };
+}
+
+function parseStoredValue(raw: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+}
+
+export function parseThemeMode(raw: string | null | undefined): ThemeMode {
+  if (raw == null) return 'system';
+  const value = parseStoredValue(raw);
+  return value === 'light' || value === 'dark' || value === 'system'
+    ? value
+    : 'system';
+}
+
+export function parseThemeId(
+  raw: string | null | undefined,
+  fallback: string
+): string {
+  if (raw == null) return fallback;
+  const value = parseStoredValue(raw);
+  return typeof value === 'string' && value.trim() ? value : fallback;
+}
+
+export function parseSurfaceCache(
+  raw: string | null | undefined
+): Record<ThemeColorMode, string> {
+  if (raw == null) return { ...DEFAULT_SURFACE };
+  const value = parseStoredValue(raw);
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return { ...DEFAULT_SURFACE };
+  }
+
+  const cache = value as Record<string, unknown>;
+  return {
+    light:
+      typeof cache.light === 'string' && cache.light.trim()
+        ? cache.light
+        : DEFAULT_SURFACE.light,
+    dark:
+      typeof cache.dark === 'string' && cache.dark.trim()
+        ? cache.dark
+        : DEFAULT_SURFACE.dark,
+  };
+}
+
+export function readOsScheme(query: { matches: boolean }): ThemeColorMode {
+  return query.matches ? 'dark' : 'light';
+}
+
+export function paintChrome(
+  chrome: ChromeAppearance,
+  doc: Document = document
+): void {
+  doc.documentElement.style.colorScheme = chrome.scheme;
+  doc.documentElement.style.backgroundColor = chrome.surface;
+  if (doc.body) doc.body.style.backgroundColor = chrome.surface;
+  doc
+    .querySelector('meta[name="theme-color"]')
+    ?.setAttribute('content', chrome.surface);
+}

--- a/apps/web/src/features/theme/constants.ts
+++ b/apps/web/src/features/theme/constants.ts
@@ -1,8 +1,13 @@
 import { DEFAULT_THEMES } from './themes';
+import type { ThemeColorMode } from './types/themeTypes';
 
 type DefaultTheme = (typeof DEFAULT_THEMES)[number]['id'];
 
 export const DEFAULT_LIGHT_THEME: DefaultTheme = 'Macro Light';
 export const DEFAULT_DARK_THEME: DefaultTheme = 'Macro Dark';
+export const DEFAULT_THEME_ID = {
+  light: DEFAULT_LIGHT_THEME,
+  dark: DEFAULT_DARK_THEME,
+} as const satisfies Record<ThemeColorMode, string>;
 
 export { DEFAULT_THEMES };

--- a/apps/web/src/features/theme/signals/themeSignals.ts
+++ b/apps/web/src/features/theme/signals/themeSignals.ts
@@ -1,11 +1,17 @@
 import { makePersisted } from '@solid-primitives/storage';
 import { createMemo, createSignal } from 'solid-js';
 import {
-  DEFAULT_DARK_THEME,
-  DEFAULT_LIGHT_THEME,
-  DEFAULT_THEMES,
-} from '../constants';
+  APPEARANCE_KEYS,
+  DEFAULT_SURFACE,
+  parseSurfaceCache,
+  parseThemeId,
+  parseThemeMode,
+  readOsScheme,
+  type ThemeMode,
+} from '../appearance';
+import { DEFAULT_THEME_ID, DEFAULT_THEMES } from '../constants';
 import type {
+  ThemeColorMode,
   ThemeColorTokens,
   ThemeV0,
   ThemeV1,
@@ -19,16 +25,13 @@ import {
 import { isThemeV2, isThemeV3 } from '../utils/themeValidation';
 import { normalizeThemeColorTokens } from '../utils/themeVNext';
 
+export type { ThemeMode } from '../appearance';
+
 export const [isThemeSaved, setIsThemeSaved] = createSignal<boolean>(true);
 
 export const [themeUpdate, setThemeUpdate] = createSignal<undefined>(
   undefined,
   { equals: () => false }
-);
-
-export const [htmlColor, setHtmlColor] = makePersisted(
-  createSignal({ color: '' }),
-  { name: 'html-color-theme' }
 );
 
 export const [userThemes, setUserThemes] = makePersisted(
@@ -62,7 +65,7 @@ setUserThemes(
 );
 
 export const [currentThemeId, setCurrentThemeId] = makePersisted(
-  createSignal<string>(DEFAULT_DARK_THEME),
+  createSignal<string>(DEFAULT_THEME_ID.dark),
   { name: 'macro-selected-theme' }
 );
 
@@ -80,41 +83,40 @@ export const [liveThemeMode, setLiveThemeMode] = createSignal<'light' | 'dark'>(
   'dark'
 );
 
-// Per-mode theme preferences, persisted to localStorage. The active one is
-// applied by systemThemeEffect / resolveActiveThemeId (themeUtils.ts): the light
-// theme when themeMode is 'light' (or 'system' + OS light), the dark theme when
-// 'dark' (or 'system' + OS dark).
 export const [lightModeTheme, setLightModeTheme] = makePersisted(
-  createSignal<string>(DEFAULT_LIGHT_THEME),
-  { name: 'macro-light-mode-theme' }
+  createSignal<string>(DEFAULT_THEME_ID.light),
+  {
+    name: APPEARANCE_KEYS.themeId.light,
+    deserialize: (raw) => parseThemeId(raw, DEFAULT_THEME_ID.light),
+  }
 );
 
 export const [darkModeTheme, setDarkModeTheme] = makePersisted(
-  createSignal<string>(DEFAULT_DARK_THEME),
-  { name: 'macro-dark-mode-theme' }
+  createSignal<string>(DEFAULT_THEME_ID.dark),
+  {
+    name: APPEARANCE_KEYS.themeId.dark,
+    deserialize: (raw) => parseThemeId(raw, DEFAULT_THEME_ID.dark),
+  }
 );
 
-/** The "Active theme" mode: pin a fixed light or dark theme, or follow the OS
- *  ('system'). Drives which per-mode theme (lightModeTheme/darkModeTheme) is
- *  live — see resolveActiveThemeId / systemThemeEffect in themeUtils. */
-export type ThemeMode = 'light' | 'dark' | 'system';
+export const [surfaceCache, setSurfaceCache] = makePersisted(
+  createSignal<Record<ThemeColorMode, string>>({ ...DEFAULT_SURFACE }),
+  {
+    name: APPEARANCE_KEYS.surface,
+    deserialize: parseSurfaceCache,
+  }
+);
 
-/** Fallback for the initial themeMode, migrating the pre-"Active theme" setting
- *  (`macro-theme-should-match-system`) so returning users keep their appearance:
- *  auto-detect on → 'system'; auto-detect off (a pinned theme) → the fixed
- *  light/dark mode matching the previously-selected theme. Only used until the
- *  new `macro-theme-mode` key is written. */
 function initialThemeMode(): ThemeMode {
   if (typeof localStorage === 'undefined') {
     return 'system';
   }
+  // The old boolean key opted out of OS follow only when it was the string
+  // `'false'`. Missing, `'true'`, or any other value still means system.
   const legacy = localStorage.getItem('macro-theme-should-match-system');
-  // New/already-migrated users, and anyone who had auto-detect on: follow the OS.
   if (legacy !== 'false') {
     return 'system';
   }
-  // Auto-detect was off: pin to the mode matching the previously-selected theme
-  // based on the explicit mode stored by V3.
   const pinned = themes().find((theme) => theme.id === currentThemeId());
   if (!pinned) {
     return 'system';
@@ -124,29 +126,38 @@ function initialThemeMode(): ThemeMode {
 
 export const [themeMode, setThemeMode] = makePersisted(
   createSignal<ThemeMode>(initialThemeMode()),
-  { name: 'macro-theme-mode' }
+  {
+    name: APPEARANCE_KEYS.mode,
+    deserialize: parseThemeMode,
+  }
 );
+
+// First-paint cannot rerun initialThemeMode(). Persist the resolved default
+// so the next cold load matches Solid. setThemeMode(same) does not write.
+if (
+  typeof localStorage !== 'undefined' &&
+  localStorage.getItem(APPEARANCE_KEYS.mode) === null
+) {
+  localStorage.setItem(APPEARANCE_KEYS.mode, JSON.stringify(themeMode()));
+}
 
 const supportsMatchMedia =
   typeof window !== 'undefined' && typeof window.matchMedia === 'function';
 
-// Tracks the OS color scheme so the active theme can follow it when themeMode is
-// 'system'.
-export const [systemMode, setSystemMode] = createSignal<'dark' | 'light'>(
-  supportsMatchMedia &&
-    window.matchMedia('(prefers-color-scheme: dark)').matches
-    ? 'dark'
+export const [systemMode, setSystemMode] = createSignal<ThemeColorMode>(
+  supportsMatchMedia
+    ? readOsScheme(window.matchMedia('(prefers-color-scheme: dark)'))
     : 'light'
 );
 
 if (supportsMatchMedia) {
-  const darkModeQuery = window.matchMedia('(prefers-color-scheme: dark)');
-  darkModeQuery.addEventListener('change', (e: MediaQueryListEvent) => {
-    setSystemMode(e.matches ? 'dark' : 'light');
-  });
+  window
+    .matchMedia('(prefers-color-scheme: dark)')
+    .addEventListener('change', (event) => {
+      setSystemMode(readOsScheme(event));
+    });
 }
 
-// Theme-list filters: whether light and/or dark themes are shown in the list.
 export const [showLightThemes, setShowLightThemes] = makePersisted(
   createSignal<boolean>(true),
   { name: 'macro-show-light-themes' }

--- a/apps/web/src/features/theme/utils/themeUtils.ts
+++ b/apps/web/src/features/theme/utils/themeUtils.ts
@@ -1,6 +1,16 @@
 import { toast } from '@core/component/Toast/Toast';
-import { batch, createEffect, on } from 'solid-js';
-import { DEFAULT_DARK_THEME, DEFAULT_LIGHT_THEME } from '../constants';
+import { batch, createEffect, createMemo, on } from 'solid-js';
+import {
+  type AppearancePreference,
+  paintChrome,
+  type ResolvedTheme,
+  resolveAppearance,
+} from '../appearance';
+import {
+  DEFAULT_DARK_THEME,
+  DEFAULT_LIGHT_THEME,
+  DEFAULT_THEME_ID,
+} from '../constants';
 import { themeReactive } from '../signals/themeReactive';
 import {
   currentThemeId,
@@ -9,13 +19,14 @@ import {
   liveThemeMode,
   setCurrentThemeId,
   setDarkModeTheme,
-  setHtmlColor,
   setIsThemeSaved,
   setLightModeTheme,
   setLiveThemeMode,
+  setSurfaceCache,
   setThemeColorTokens,
   setThemeMode,
   setUserThemes,
+  surfaceCache,
   systemMode,
   themeColorTokens,
   themeMode,
@@ -185,6 +196,7 @@ export function setLiveThemeColorTokens(tokens: ThemeColorTokens): void {
   renderedColorTokenKeys = new Set(Object.keys(normalizedTokens));
   setThemeColorTokens(normalizedTokens);
   syncLegacyCompatibilityTokens();
+  paintLiveChrome();
 }
 
 /** Updates one authored token immediately; persistence still happens on save. */
@@ -194,6 +206,7 @@ export function updateLiveThemeColorToken(token: string, value: string): void {
   renderedColorTokenKeys.add(token);
   setThemeColorTokens(next);
   syncLegacyCompatibilityTokens();
+  paintLiveChrome();
   setIsThemeSaved(false);
 }
 
@@ -208,19 +221,18 @@ export function applyTheme(id: string): void {
   let theme = themes().find((t) => t.id === id);
   if (!theme) {
     console.error(`theme not found: ${id}`);
-    theme = themes().find((t) => t.id === DEFAULT_DARK_THEME)!;
+    theme = themes().find((t) => t.id === DEFAULT_THEME_ID[liveThemeMode()])!;
   }
   setCurrentThemeId(theme.id);
-  // Committing a theme supersedes any in-flight preview; drop the snapshot so
-  // clearThemePreview doesn't revert the commit.
+  // Drop the snapshot so a later clearThemePreview cannot restore the
+  // pre-commit tokens over the theme we just applied.
   previewSnapshot = null;
 
   setLiveThemeMode(theme.mode);
   setLiveThemeColorTokens(theme.colorTokens);
   queueMicrotask(() => {
-    /* scuffed af */
     setIsThemeSaved(true);
-    syncHtmlColor();
+    refreshSurfaceCache();
   });
 }
 
@@ -257,32 +269,63 @@ export function clearThemePreview(): void {
   previewSnapshot = null;
 }
 
-/** Resolves the theme id that should be live for the current "Active theme"
- *  mode: the pinned light/dark theme, or — in system mode — whichever matches
- *  the OS color scheme. Read inside a reactive scope, it subscribes to the mode,
- *  the OS scheme (system mode only), and the relevant per-mode theme. */
-export function resolveActiveThemeId(): string {
-  const resolved = themeMode() === 'system' ? systemMode() : themeMode();
-  return resolved === 'dark' ? darkModeTheme() : lightModeTheme();
+function livePreference(): AppearancePreference {
+  return {
+    mode: themeMode(),
+    themeId: {
+      light: lightModeTheme(),
+      dark: darkModeTheme(),
+    },
+  };
 }
 
-/** Keeps the active theme in sync with the "Active theme" mode: applies the
- *  pinned light/dark theme, or follows the OS color scheme in system mode.
- *  Re-applies whenever the mode, the OS scheme, or the *active* mode's theme
- *  changes — but not when the inactive mode's theme changes (that id isn't read
- *  by resolveActiveThemeId, so it isn't tracked). Call once from a reactive root
- *  (see Root.tsx). */
-export function systemThemeEffect(): void {
-  createEffect(
-    on(resolveActiveThemeId, (id) => applyTheme(id), { defer: true })
+export function activeAppearance(): ResolvedTheme {
+  return resolveAppearance(livePreference(), systemMode());
+}
+
+export function systemAppearance(): ResolvedTheme {
+  return resolveAppearance(
+    { ...livePreference(), mode: 'system' },
+    systemMode()
   );
 }
 
-/** Persists the live background color, used for the pre-hydration first paint. */
-function syncHtmlColor(): void {
+export function resolveActiveThemeId(): string {
+  return activeAppearance().themeId;
+}
+
+export function applyResolvedAppearance(): void {
+  applyTheme(activeAppearance().themeId);
+}
+
+export function systemThemeEffect(): void {
+  // Memo the resolved id so a write to the inactive scheme's stored id does
+  // not re-apply. The effect is deferred. First apply is module init plus
+  // Root onMount.
+  const themeId = createMemo(() => activeAppearance().themeId);
+  createEffect(on(themeId, (id) => applyTheme(id), { defer: true }));
+}
+
+function formatOklch(color: { l: number; c: number; h: number }): string {
+  return `oklch(${color.l} ${color.c} ${color.h}deg)`;
+}
+
+function paintLiveChrome(): void {
   const color = resolvedTokenOklch('surface-0');
   if (!color) return;
-  setHtmlColor({ color: `oklch(${color.l} ${color.c} ${color.h}deg)` });
+  paintChrome({
+    scheme: liveThemeMode(),
+    surface: formatOklch(color),
+  });
+}
+
+function refreshSurfaceCache(): void {
+  const color = resolvedTokenOklch('surface-0');
+  if (!color) return;
+  setSurfaceCache({
+    ...surfaceCache(),
+    [liveThemeMode()]: formatOklch(color),
+  });
 }
 
 export function saveTheme(name: string): void {
@@ -350,11 +393,6 @@ export function getLiveTheme(): ThemeV3 {
   };
 }
 
-/** Pins a theme as the "Active theme": makes it the stored theme for its
- *  intrinsic light/dark mode and switches the mode to match, so
- *  resolveActiveThemeId / systemThemeEffect apply it live. Shared by the settings
- *  Active-theme picker and the command-palette "Change theme" action so choosing
- *  a theme in either place is reflected in the other. */
 export function pinTheme(theme: ThemeV3): void {
   if (theme.mode === 'dark') {
     setDarkModeTheme(theme.id);
@@ -365,15 +403,11 @@ export function pinTheme(theme: ThemeV3): void {
   }
 }
 
-/** Follows the OS color scheme (the "System preference" option): switches the
- *  mode to 'system' and applies whichever per-mode theme the OS currently
- *  resolves to. Shared by the settings picker and the command palette. */
 export function applySystemTheme(): void {
   setThemeMode('system');
-  applyTheme(resolveActiveThemeId());
+  applyResolvedAppearance();
 }
 
-/** Checks if the theme contrast is too low, and if so, applies a readable theme. This is to prevent malicious actors sending "Theme Viruses" which make a user's theme unusable. */
 export function ensureMinimalThemeContrast() {
   const surface = resolvedTokenOklch('surface-0');
   const content = resolvedTokenOklch('content-0');

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -499,6 +499,7 @@ body.tauri-ios {
 
 @layer base {
   html {
+    color-scheme: light dark;
     overflow: hidden;
   }
 

--- a/apps/web/src/index.tsx
+++ b/apps/web/src/index.tsx
@@ -10,6 +10,7 @@ import { initializeLexical } from '@core/component/LexicalMarkdown/init';
 import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import { getPlatform, isTauri } from '@core/util/platform';
 import { platformFetch } from '@core/util/platformFetch';
+import { applyResolvedAppearance } from '@theme/utils/themeUtils';
 import { initMonochromeIcons } from '@ui/utils/monochromeIcons';
 import { ErrorBoundary, render } from 'solid-js/web';
 import { FatalError } from './components/app/FatalError';
@@ -33,6 +34,7 @@ if (isTauri()) {
 
 initializeLexical();
 initMonochromeIcons();
+applyResolvedAppearance();
 
 const renderApp = () => {
   const root = document.getElementById('root');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

New users already default to system mode. After mount, `systemThemeEffect` already follows `prefers-color-scheme`. The miss is first paint.

`index.html` replayed the last `html-color-theme.color`, or left the page white. An overnight OS flip flashed the previous scheme. A first visit on a dark OS flashed `#FFFFFF` until JS ran.

The fix is one Solid-free resolve rule that both the inline script and the app share.

## Scope

Adds `apps/web/src/features/theme/appearance.ts`.

`resolveAppearance(preference, system)` is the only scheme rule. Preference is `{ mode, themeId: { light, dark } }`. The result is `{ scheme, themeId }`. Chrome is `{ scheme, surface }`. Preview paints chrome and does not write the first-paint cache.

`html-color-theme` now stores `{ light, dark }`. `parseSurfaceCache` rejects a legacy `{ color }` blob and fills `DEFAULT_SURFACE`. Those defaults match Macro Light `surface-0` and desktop Macro Dark `b0`.

The first-paint script in `apps/web/index.html` reads `macro-theme-mode` and `html-color-theme`, resolves with `matchMedia`, and sets `color-scheme`, the html background, and `theme-color`. `apps/web/src/index.tsx` calls `applyResolvedAppearance()` before `render()`. `themeSignals.ts` seeds `systemMode` from `readOsScheme` and persists `macro-theme-mode` when that key is missing, so a legacy user gets a first-paint value.

Settings still pins via `pinTheme`. The command palette still stays in system via `setVisibleTheme`.

Out of scope. Tauri native theme APIs, a new storage key, persisting `systemMode`, and email `prefers-color-scheme` stripping.

## Tradeoffs

Kept the existing `html-color-theme` key instead of adding `macro-theme-surface`. Used a handwritten script instead of a Vite plugin. The script can drift from the module, so `appearance.test.ts` extracts it from `index.html` and compares it to `resolveAppearance` plus `paintChrome`.

Did not copy a legacy `{ color }` into both slots. That color belongs to one scheme. Using it for both would paint the wrong surface after an OS flip.

`meta[name=theme-color]` now gets an `oklch()` surface. iOS WKWebView support for that is unproven. The html background still holds first paint if the meta is ignored.

## Blast Radius

Web first paint, theme settings, and the command-palette theme list. Native WebView uses the same `matchMedia` path. Users with a pinned light or dark mode keep that pin. Users with no `macro-theme-mode` key get `'system'` persisted on the next load.

`color-scheme: light dark` on `html` is a no-JS floor. `paintChrome` overwrites it once JS runs. First-paint dark uses the desktop Macro Dark surface (`oklch(0.14 …)`), not the touch `b0` of `l: 0`.

## Verification

Ran `nix develop --command bash -lc 'cd apps/web && bunx vitest run --project theme'` from the repo root. 63 tests passed across 4 files, including the 21 cases in `appearance.test.ts` that lock the inline script to the module. `bunx biome check` on the touched files reported no fixes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-35cdf20a-2efc-49ad-a003-53457c376e96?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-35cdf20a-2efc-49ad-a003-53457c376e96&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

