### PR TITLE
fix(local): unbreak the SDK webhook tunnel and stop stubbing out Daytona secrets

### DIFF
--- a/tooling/xtask/crates/xtask_local/src/local/local_env.rs
+++ b/tooling/xtask/crates/xtask_local/src/local/local_env.rs
@@ -250,11 +250,14 @@ impl MailEnv {
 }
 
 /// The agent harness: which bot it answers for, and the Daytona sandbox
-/// credentials.
+/// snapshot it launches from.
 ///
 /// The bot id and snapshot name are deterministic (the bot is seeded by
-/// migration). The two secrets are seeded empty so the process-env overlay can
-/// replace them; the harness refuses to start unless both are supplied.
+/// migration), so they belong here: local plumbing, layered above Doppler.
+/// Their two companion secrets — `DAYTONA_API_KEY` and `GITHUB_TOKEN` — are
+/// NOT written here. Those are real integration values, so they are seeded in
+/// [`BootStubEnv`] below Doppler instead, where a developer's Doppler config
+/// wins over the stub. The harness refuses to start unless both are supplied.
 struct AgentHarnessEnv {
     bot_id: &'static str,
     snapshot: &'static str,
@@ -272,8 +275,6 @@ impl AgentHarnessEnv {
     fn write(&self, env: &mut BTreeMap<String, String>) {
         env.insert("HARNESS_BOT_ID".into(), self.bot_id.into());
         env.insert("DAYTONA_SNAPSHOT".into(), self.snapshot.into());
-        env.insert("DAYTONA_API_KEY".into(), String::new());
-        env.insert("GITHUB_TOKEN".into(), String::new());
     }
 }
 
@@ -404,6 +405,14 @@ struct BootStubEnv;
 
 impl BootStubEnv {
     fn write(&self, env: &mut BTreeMap<String, String>) {
+        // agent_harness_service's managed sandboxes. Seeded (not omitted) so
+        // the process-env overlay — which only replaces keys already present —
+        // can still override them from the shell; seeded HERE rather than in
+        // `AgentHarnessEnv` so Doppler's real values win, which is the whole
+        // point of this layer. Trigger processing and external sessions run
+        // fine without either.
+        env.insert("DAYTONA_API_KEY".into(), String::new());
+        env.insert("GITHUB_TOKEN".into(), String::new());
         // connection_gateway config reads `REDIS_HOST` (a Redis URL, not a
         // hostname — see `redis::Client::open`).
         env.insert("REDIS_HOST".into(), "redis://redis:6379".into());

--- a/tooling/xtask/crates/xtask_local/src/local/local_env/test.rs
+++ b/tooling/xtask/crates/xtask_local/src/local/local_env/test.rs
@@ -256,3 +256,37 @@ fn fusionauth_public_url_uses_the_instance_host_port() {
         Some(named_public_url.as_str())
     );
 }
+
+/// Real integration secrets must be seeded in the boot stubs (BELOW Doppler),
+/// never in `to_env` (ABOVE it). These two were originally written by
+/// `AgentHarnessEnv` as empty strings in `to_env`, which blanked the real
+/// values a developer's Doppler config supplies — the harness then ran without
+/// managed sandboxes on every stack that did not also export them by hand.
+///
+/// Seeded (not omitted) so the process-env overlay, which only replaces keys
+/// already present, can still override them from the shell.
+#[test]
+fn harness_secrets_are_stubs_that_doppler_can_override() {
+    let instance = Instance::derive(None, None).expect("default instance derives");
+    let local = LocalEnv::for_instance(Mode::Local, &instance, true);
+    let authoritative = local.to_env();
+    let stubs = local.boot_stub_env();
+    for key in ["DAYTONA_API_KEY", "GITHUB_TOKEN"] {
+        assert_eq!(
+            stubs.get(key).map(String::as_str),
+            Some(""),
+            "{key} must be seeded empty in the boot stubs so Doppler wins and \
+             the process-env overlay can still replace it"
+        );
+        assert!(
+            !authoritative.contains_key(key),
+            "{key} in to_env would overwrite Doppler's real value with a stub"
+        );
+    }
+    // The snapshot name is deterministic local plumbing, so it stays
+    // authoritative — the contrast the two layers are for.
+    assert_eq!(
+        authoritative.get("DAYTONA_SNAPSHOT").map(String::as_str),
+        Some("macro-agent-harness")
+    );
+}

--- a/tooling/xtask/crates/xtask_local/src/local/mod.rs
+++ b/tooling/xtask/crates/xtask_local/src/local/mod.rs
@@ -264,9 +264,11 @@ pub fn run_stack(mode: Mode, args: &cli::RunArgs) -> Result<()> {
     // DynamoDB/OpenSearch connection refused).
     bring_up_infra(&stage, mode, &instance, &env, InfraInit::Full)?;
     bring_up_app(&stage, mode, &instance, &env)?;
+    // Best-effort: a tunnel that won't come up costs webhook delivery to host
+    // receivers, nothing else, so it warns instead of failing the whole run.
     let _sdk_webhook_tunnel = (mode == Mode::Local && !stage.is_dry_run())
-        .then(|| sdk_webhook::start(&instance))
-        .transpose()?;
+        .then(|| sdk_webhook::start_or_warn(&stage, &instance))
+        .flatten();
 
     // No restart-to-reload step: the teardown means `up` always creates fresh
     // containers, which start on the just-built binaries bind-mounted at

--- a/tooling/xtask/crates/xtask_local/src/local/sdk_webhook.rs
+++ b/tooling/xtask/crates/xtask_local/src/local/sdk_webhook.rs
@@ -1,15 +1,33 @@
 //! Instance-local relay for SDK webhook receivers running on the host.
 
+use std::io::Read;
 use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result, bail};
 
 use super::instance::{Instance, Port};
+use super::stage::Stage;
 
 const RELAY_PORT: u16 = 8787;
 const USER: &str = "sdk-webhook";
+
+/// How long a single spawned `ssh` must stay alive before we call the tunnel
+/// up. Long enough for a refused/reset connect to have surfaced, short enough
+/// that it costs nothing on the happy path.
+const SETTLE: Duration = Duration::from_millis(300);
+
+/// How long to keep retrying the connect. `bring_up_app` runs `docker compose
+/// up -d` without `--wait`, and the relay has no healthcheck, so compose
+/// returns once the container is *created* — before its `ssh-keygen -A &&
+/// sshd` is listening. On Docker Desktop the published port answers and then
+/// resets during that window, so ssh dies instantly (255) rather than blocking
+/// on connect, and a single attempt loses the race on most Macs.
+const READY_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// Pause between connect attempts.
+const RETRY_DELAY: Duration = Duration::from_millis(250);
 
 pub fn relay_url() -> &'static str {
     "http://sdk-webhook-relay:8787/macro-events"
@@ -57,14 +75,67 @@ pub fn ensure_keys(instance: &Instance) -> Result<()> {
     Ok(())
 }
 
-/// Start the host-side reverse tunnel after the relay container is running.
+/// Start the host-side reverse tunnel, retrying until the relay container's
+/// `sshd` accepts the connection (see [`READY_TIMEOUT`]).
 pub fn start(instance: &Instance) -> Result<Child> {
     ensure_keys(instance)?;
     stop(instance);
+    let deadline = Instant::now() + READY_TIMEOUT;
+    let mut last_err;
+    loop {
+        match try_start(instance) {
+            Ok(child) => {
+                std::fs::write(pid_path(instance), child.id().to_string())?;
+                return Ok(child);
+            }
+            Err(e) => last_err = e,
+        }
+        if Instant::now() >= deadline {
+            break;
+        }
+        std::thread::sleep(RETRY_DELAY);
+    }
+    bail!(
+        "SDK webhook SSH reverse tunnel did not come up within {}s: {last_err}",
+        READY_TIMEOUT.as_secs()
+    );
+}
+
+/// Start the tunnel, downgrading failure to a warning. Webhook delivery to
+/// host receivers is a development convenience — losing it must not take the
+/// whole stack down with it.
+pub fn start_or_warn(stage: &Stage, instance: &Instance) -> Option<Child> {
+    match start(instance) {
+        Ok(child) => Some(child),
+        Err(e) => {
+            stage.note(&format!(
+                "! SDK webhook tunnel unavailable — webhooks posted to {} will not reach \
+                 host receivers on port {}. Everything else is up. ({e:#})",
+                relay_url(),
+                host_receiver_port(instance)
+            ));
+            None
+        }
+    }
+}
+
+/// One connect attempt. `Err` carries ssh's own diagnosis so a persistent
+/// failure (bad key, port taken in the relay) is legible instead of a bare
+/// exit status.
+fn try_start(instance: &Instance) -> std::result::Result<Child, String> {
     let mut child = Command::new("ssh")
         .args([
             "-N",
             "-T",
+            // Ignore the developer's ~/.ssh/config (and, per `-F`, the
+            // system-wide one): everything this connection needs is specified
+            // below, and inheriting personal config only imports failure. The
+            // common one on macOS is the Apple keychain stanza — `UseKeychain`
+            // is an Apple-only extension that the nix dev shell's upstream
+            // OpenSSH rejects outright ("bad configuration options"), so ssh
+            // exits 255 before it ever dials the relay.
+            "-F",
+            "/dev/null",
             "-o",
             "ExitOnForwardFailure=yes",
             "-o",
@@ -91,16 +162,38 @@ pub fn start(instance: &Instance) -> Result<Child> {
         ])
         .arg(format!("{USER}@127.0.0.1"))
         .stdout(Stdio::null())
-        .stderr(Stdio::null())
+        .stderr(Stdio::piped())
         .spawn()
-        .context("starting the SDK webhook SSH reverse tunnel")?;
+        .map_err(|e| format!("spawning ssh: {e}"))?;
 
-    std::thread::sleep(Duration::from_millis(300));
-    if let Some(status) = child.try_wait()? {
-        bail!("SDK webhook SSH reverse tunnel exited with {status}");
+    std::thread::sleep(SETTLE);
+    match child.try_wait() {
+        Ok(Some(status)) => {
+            let mut stderr = String::new();
+            if let Some(mut pipe) = child.stderr.take() {
+                let _ = pipe.read_to_string(&mut stderr);
+            }
+            // ssh prints the definitive reason last ("Connection closed by
+            // 127.0.0.1 port N"), preceded by lower-level noise.
+            let reason = stderr
+                .lines()
+                .map(str::trim)
+                .rfind(|l| !l.is_empty())
+                .unwrap_or("no stderr output");
+            Err(format!("ssh exited with {status}: {reason}"))
+        }
+        // Still alive: the tunnel is up. Drain stderr in the background so a
+        // chatty ssh can never fill the pipe buffer and wedge the tunnel.
+        Ok(None) => {
+            if let Some(mut pipe) = child.stderr.take() {
+                std::thread::spawn(move || {
+                    let _ = std::io::copy(&mut pipe, &mut std::io::sink());
+                });
+            }
+            Ok(child)
+        }
+        Err(e) => Err(format!("waiting on ssh: {e}")),
     }
-    std::fs::write(pid_path(instance), child.id().to_string())?;
-    Ok(child)
 }
 
 /// Stop a previously started host-side tunnel, if present.

--- a/tooling/xtask/crates/xtask_local/src/local/stack.rs
+++ b/tooling/xtask/crates/xtask_local/src/local/stack.rs
@@ -274,9 +274,11 @@ pub fn up(mode: Mode, args: &UpArgs) -> Result<Instance> {
         return Ok(instance);
     }
     super::bring_up_app(&stage, mode, &instance, &env)?;
+    // Best-effort: a tunnel that won't come up costs webhook delivery to host
+    // receivers, nothing else, so it warns instead of failing the whole run.
     let _sdk_webhook_tunnel = (mode == Mode::Local && !stage.is_dry_run())
-        .then(|| sdk_webhook::start(&instance))
-        .transpose()?;
+        .then(|| sdk_webhook::start_or_warn(&stage, &instance))
+        .flatten();
 
     // Headless "ready" means the backend answers through the proxy — the caller
     // (a CI step, an agent) acts on the URL the moment we return.


### PR DESCRIPTION
Fixes two local-stack bugs that broke `just run local` on macOS: the SDK webhook tunnel now ignores the developer's `~/.ssh/config` (whose Apple-only `UseKeychain` option the nix shell's OpenSSH rejects, exiting 255 and failing the whole run), retries while the relay container starts, and warns instead of aborting; and `DAYTONA_API_KEY`/`GITHUB_TOKEN` move below Doppler in the env layering so their empty stubs stop clobbering the real values.