### PR TITLE
feat(nav): nav rails, a top bar, and digit jumps

### DIFF
--- a/apps/web/src/components/app/Layout.tsx
+++ b/apps/web/src/components/app/Layout.tsx
@@ -41,6 +41,8 @@ import {
   type SidebarState,
 } from '@components/app/app-sidebar/sidebar';
 import { SkinnySidebarRail } from '@components/app/app-sidebar/skinny-rail';
+import { SplitNavRail } from '@components/app/app-sidebar/split-rail';
+import { AppTopbar } from '@components/app/app-topbar';
 import { registerMailtoComposerHandler } from '@components/app/mailtoComposerHandler';
 import {
   isSidebarVisible,
@@ -490,6 +492,9 @@ function LayoutInner(props: RouteSectionProps) {
       <Show when={paywallOpen()}>
         <Paywall />
       </Show>
+      <Show when={isSidebarVisible()}>
+        <AppTopbar />
+      </Show>
       <div class="max-h-full grow flex">
         {/* The provider spans the sidebar too so its favorites can register
             sortables with the same drag-drop context as the entity drags. */}
@@ -509,8 +514,8 @@ function LayoutInner(props: RouteSectionProps) {
               }}
             />
           </Show>
-          {/* The collapsed sidebar is a visible 30px rail, not an empty edge:
-              its logo is the peek/expand trigger the old invisible hover strip
+          {/* The collapsed sidebar is a visible rail, not an empty edge: its
+              logo is the peek/expand trigger the old invisible hover strip
               used to be, so hovering an icon can't yank the overlay open over
               the icon being aimed at. */}
           <Show when={sidebarCollapsed()}>
@@ -526,6 +531,12 @@ function LayoutInner(props: RouteSectionProps) {
           <div class="flex-1 w-full min-h-0 font-sans text-ink caret-accent">
             {props.children}
           </div>
+
+          {/* Same destinations as the left rail, docked beside what you are
+              already looking at instead of taking it over. */}
+          <Show when={isSidebarVisible()}>
+            <SplitNavRail />
+          </Show>
         </ItemDndProvider>
       </div>
       <CollapsedSidebarIncomingCallWidget

--- a/apps/web/src/components/app/Layout.tsx
+++ b/apps/web/src/components/app/Layout.tsx
@@ -40,6 +40,7 @@ import {
   GoToHotkeys,
   type SidebarState,
 } from '@components/app/app-sidebar/sidebar';
+import { SkinnySidebarRail } from '@components/app/app-sidebar/skinny-rail';
 import { registerMailtoComposerHandler } from '@components/app/mailtoComposerHandler';
 import {
   isSidebarVisible,
@@ -101,8 +102,11 @@ const AUTH_URLS = [
   `${ROUTER_BASE_CONCAT}team-invite`,
 ];
 
+// Desktop starts on the skinny rail: it is the nav users meet first, and one
+// click on its logo pins the wide sidebar open for good. Anyone who already has
+// a stored preference keeps it.
 const [sidebarState, setSidebarState] = makePersisted(
-  createSignal<SidebarState>(!isTouchDevice() ? 'expanded' : 'hidden'),
+  createSignal<SidebarState>(!isTouchDevice() ? 'slim' : 'hidden'),
   {
     name: 'sidebar-state',
   }
@@ -505,16 +509,16 @@ function LayoutInner(props: RouteSectionProps) {
               }}
             />
           </Show>
+          {/* The collapsed sidebar is a visible 30px rail, not an empty edge:
+              its logo is the peek/expand trigger the old invisible hover strip
+              used to be, so hovering an icon can't yank the overlay open over
+              the icon being aimed at. */}
           <Show when={sidebarCollapsed()}>
-            <div
-              class="fixed left-0 inset-y-0 z-modal-content w-[8px]"
-              onPointerEnter={() => {
-                setSidebarOverlayTriggerHovered(true);
-                setSidebarOverlayOpenGuarded(true);
-              }}
-              onPointerLeave={() => {
-                setSidebarOverlayTriggerHovered(false);
-                setSidebarOverlayOpenGuarded(false);
+            <SkinnySidebarRail
+              onExpand={() => setSidebarState('expanded')}
+              onPeekChange={(open) => {
+                setSidebarOverlayTriggerHovered(open);
+                setSidebarOverlayOpenGuarded(open);
               }}
             />
           </Show>

--- a/apps/web/src/components/app/app-sidebar/links.ts
+++ b/apps/web/src/components/app/app-sidebar/links.ts
@@ -1,0 +1,265 @@
+import { LIST_VIEW_PATHS, type ListView } from '@app/constants/list-views';
+import { useActivityFeedFlag } from '@app/features/activity/use-activity-feed-flag';
+import { useCalendarUiFlag } from '@app/features/calendar/hooks/use-calendar-ui-flag';
+import { useGettingStartedEnabled } from '@app/features/getting-started/account-gate';
+import { buildDocumentTypeQuery } from '@app/features/next-soup/filters/configs/document-type-query';
+import { useRecentViewFlag } from '@app/features/next-soup/use-recent-view-flag';
+import { ENABLE_CALLS, ENABLE_CRM } from '@core/constant/featureFlags';
+import { type HotkeyToken, TOKENS } from '@core/hotkey/tokens';
+import type { ValidHotkey } from '@core/hotkey/types';
+import { AnimatedActivityIcon } from '@icon/wide-activity';
+import WideCalendarIcon from '@icon/wide-calendar.svg';
+import { AnimatedCallIcon } from '@icon/wide-call';
+import { AnimatedChannelIcon } from '@icon/wide-channel';
+import { AnimatedCompanyIcon } from '@icon/wide-company';
+import { AnimatedEmailIcon } from '@icon/wide-email';
+import { AnimatedFileMdIcon } from '@icon/wide-fileMd';
+import { AnimatedHomeIcon } from '@icon/wide-home';
+import { AnimatedInboxIcon } from '@icon/wide-inbox';
+import { AnimatedSearchIcon } from '@icon/wide-search';
+import { AnimatedStarIcon } from '@icon/wide-star';
+import { AnimatedTaskIcon } from '@icon/wide-task';
+import CompassIcon from '@phosphor/compass.svg';
+import { type Component, createMemo, type JSX } from 'solid-js';
+
+/**
+ * A sidebar destination: the shared model behind the expanded sidebar rows,
+ * the skinny rail's icons, and the `g`-leader "go to" hotkeys.
+ */
+export interface SidebarItem {
+  id: ListView | (string & {});
+  label: string;
+  href: string;
+  params?: Record<string, unknown>;
+  icon?: Component<
+    JSX.SvgSVGAttributes<SVGSVGElement> & { triggerAnimation?: boolean }
+  >;
+  hotkey: ValidHotkey;
+  hotkeyToken: HotkeyToken;
+  standaloneHotkey?: boolean;
+  hiddenFromSidebar?: boolean;
+}
+
+const markdownDocumentsQuery = buildDocumentTypeQuery(['doc-markdown']);
+
+const SIDEBAR_LINKS = [
+  {
+    id: 'inbox',
+    label: 'Inbox',
+    href: LIST_VIEW_PATHS.inbox,
+    icon: AnimatedInboxIcon,
+    hotkey: 'i',
+    hotkeyToken: TOKENS.sidebar.goTo.inbox,
+  },
+  {
+    id: 'search',
+    label: 'Search',
+    href: LIST_VIEW_PATHS.search,
+    icon: AnimatedSearchIcon,
+    hotkey: '/',
+    hotkeyToken: TOKENS.sidebar.goTo.search,
+    standaloneHotkey: true,
+    hiddenFromSidebar: true,
+  },
+  {
+    id: 'agents',
+    label: 'Agents',
+    href: LIST_VIEW_PATHS.agents,
+    icon: AnimatedStarIcon,
+    hotkey: 'a',
+    hotkeyToken: TOKENS.sidebar.goTo.agents,
+  },
+  {
+    id: 'mail',
+    label: 'Email',
+    href: LIST_VIEW_PATHS.mail,
+    icon: AnimatedEmailIcon,
+    hotkey: 'e',
+    hotkeyToken: TOKENS.sidebar.goTo.mail,
+  },
+  {
+    id: 'documents',
+    label: 'Files',
+    href: LIST_VIEW_PATHS.documents,
+    icon: AnimatedFileMdIcon,
+    hotkey: 'f',
+    hotkeyToken: TOKENS.sidebar.goTo.documents,
+  },
+  {
+    id: 'documents',
+    label: 'Documents',
+    href: LIST_VIEW_PATHS.documents,
+    params: {
+      initialFilters: markdownDocumentsQuery ?? {},
+      initialClientFilters: {
+        and: ['document-or-file'],
+        or: ['doc-markdown'],
+      },
+    },
+    icon: AnimatedFileMdIcon,
+    hotkey: 'd',
+    hotkeyToken: TOKENS.sidebar.goTo.markdownDocuments,
+    hiddenFromSidebar: true,
+  },
+  {
+    id: 'tasks',
+    label: 'Tasks',
+    href: LIST_VIEW_PATHS.tasks,
+    icon: AnimatedTaskIcon,
+    hotkey: 't',
+    hotkeyToken: TOKENS.sidebar.goTo.tasks,
+  },
+  {
+    id: 'calendar',
+    label: 'Calendar',
+    href: '/calendar',
+    icon: WideCalendarIcon,
+    hotkey: 'r',
+    hotkeyToken: TOKENS.sidebar.goTo.calendar,
+  },
+  {
+    id: 'channels',
+    label: 'Channels',
+    href: LIST_VIEW_PATHS.channels,
+    icon: AnimatedChannelIcon,
+    hotkey: 'c',
+    hotkeyToken: TOKENS.sidebar.goTo.channels,
+  },
+] satisfies SidebarItem[];
+
+const CALLS_LINK: SidebarItem = {
+  id: 'calls',
+  label: 'Calls',
+  href: LIST_VIEW_PATHS.calls,
+  icon: AnimatedCallIcon,
+  hotkey: 'l',
+  hotkeyToken: TOKENS.sidebar.goTo.calls,
+};
+
+const COMPANIES_LINK: SidebarItem = {
+  id: 'companies',
+  label: 'Customers',
+  href: LIST_VIEW_PATHS.companies,
+  icon: AnimatedCompanyIcon,
+  hotkey: 'o',
+  hotkeyToken: TOKENS.sidebar.goTo.companies,
+};
+
+const DASHBOARD_LINK: SidebarItem = {
+  id: 'home',
+  label: 'Home',
+  href: '/home',
+  icon: AnimatedHomeIcon,
+  hotkey: 'h',
+  hotkeyToken: TOKENS.sidebar.goTo.home,
+};
+
+const GETTING_STARTED_LINK: SidebarItem = {
+  id: 'getting-started',
+  label: 'Getting Started',
+  href: '/getting-started',
+  icon: CompassIcon,
+  hotkey: 's',
+  hotkeyToken: TOKENS.sidebar.goTo.gettingStarted,
+};
+
+const ACTIVITY_LINK: SidebarItem = {
+  id: 'activity',
+  label: 'Activity',
+  href: '/activity',
+  icon: AnimatedActivityIcon,
+  hotkey: 'y',
+  hotkeyToken: TOKENS.sidebar.goTo.activity,
+};
+
+const RECENT_LINK: SidebarItem = {
+  id: 'recent',
+  label: 'Recent',
+  href: LIST_VIEW_PATHS.recent,
+  icon: AnimatedActivityIcon,
+  // `r` is Calendar and `e`/`c`/`t` are taken; `n` is the only letter of
+  // "recent" that is not already a sidebar destination.
+  hotkey: 'n',
+  hotkeyToken: TOKENS.sidebar.goTo.recent,
+};
+
+/**
+ * Assemble the ordered sidebar link list: the static links plus Home, Getting
+ * started, and the flag-gated Activity, Calendar, Calls, and CRM entries in
+ * their correct positions.
+ * Call from a reactive context — it reads `ENABLE_CALLS()` / `ENABLE_CRM()`;
+ * {@link useSidebarLinks} is the wrapper every consumer should use.
+ * `showGettingStarted` is the account-age gate (`useGettingStartedEnabled`),
+ * passed in because this runs outside a component; when false the link is
+ * fully absent — row, `g s` hotkey, and command menu entry.
+ * Rendered sections additionally drop `hiddenFromSidebar` entries, which have
+ * hotkeys but no sidebar row.
+ */
+const buildSidebarLinks = (
+  showGettingStarted: boolean,
+  showCalendar: boolean,
+  showActivity: boolean,
+  showRecent: boolean
+): SidebarItem[] => {
+  let links: SidebarItem[] = [
+    DASHBOARD_LINK,
+    ...(showGettingStarted ? [GETTING_STARTED_LINK] : []),
+    ...SIDEBAR_LINKS.filter((link) => showCalendar || link.id !== 'calendar'),
+  ];
+
+  if (showRecent) {
+    // Directly below Inbox; Activity anchors after it.
+    const idx = links.findIndex((link) => link.id === 'inbox');
+    links = [...links.slice(0, idx + 1), RECENT_LINK, ...links.slice(idx + 1)];
+  }
+
+  if (showActivity) {
+    const anchorId = showRecent ? 'recent' : 'inbox';
+    const idx = links.findIndex((link) => link.id === anchorId);
+    links = [
+      ...links.slice(0, idx + 1),
+      ACTIVITY_LINK,
+      ...links.slice(idx + 1),
+    ];
+  }
+
+  if (ENABLE_CALLS()) {
+    const idx = links.findIndex((l) => l.id === 'channels');
+    links = [...links.slice(0, idx + 1), CALLS_LINK, ...links.slice(idx + 1)];
+  }
+
+  if (ENABLE_CRM()) {
+    // Customers sits just after Channels (and Calls when present).
+    const anchorId = ENABLE_CALLS() ? 'calls' : 'channels';
+    const idx = links.findIndex((l) => l.id === anchorId);
+    links = [
+      ...links.slice(0, idx + 1),
+      COMPANIES_LINK,
+      ...links.slice(idx + 1),
+    ];
+  }
+
+  return links;
+};
+
+/**
+ * The reactive link list: {@link buildSidebarLinks} with its feature-flag gates
+ * read for you. Call from a component — the expanded sidebar's rows, the skinny
+ * rail's icons, and the always-mounted `GoToHotkeys` registrar all share it, so
+ * their link sets can't drift.
+ */
+export const useSidebarLinks = () => {
+  const gettingStartedEnabled = useGettingStartedEnabled();
+  const calendarUiEnabled = useCalendarUiFlag();
+  const activityFeedEnabled = useActivityFeedFlag();
+  const recentViewEnabled = useRecentViewFlag();
+
+  return createMemo((): SidebarItem[] =>
+    buildSidebarLinks(
+      gettingStartedEnabled(),
+      calendarUiEnabled(),
+      activityFeedEnabled(),
+      recentViewEnabled()
+    )
+  );
+};

--- a/apps/web/src/components/app/app-sidebar/navigation.ts
+++ b/apps/web/src/components/app/app-sidebar/navigation.ts
@@ -1,0 +1,97 @@
+import { getDocumentsFilterSplit } from '@app/features/next-soup/soup-view/documents-filter-controllers';
+import { globalSplitManager } from '@app/signal/splitLayout';
+import { CALENDAR_BLOCK_ID } from '@block-calendar/types';
+import type { useSplitLayout } from '@components/app/split-layout/layout';
+import type {
+  ReferredFrom,
+  SplitContent,
+  SplitHandle,
+} from '@components/app/split-layout/layoutManager';
+import type { SidebarItem } from './links';
+
+type OpenWithSplitFn = ReturnType<typeof useSplitLayout>['openWithSplit'];
+
+const isMarkdownDocumentsParams = (
+  params: SidebarItem['params'] | undefined
+): boolean => {
+  const initialClientFilters = params?.initialClientFilters as
+    | { or?: readonly unknown[] }
+    | undefined;
+
+  return initialClientFilters?.or?.includes('doc-markdown') ?? false;
+};
+
+export function sidebarContent(
+  viewId: SidebarItem['id'],
+  params?: SidebarItem['params']
+): SplitContent {
+  return viewId === 'calendar'
+    ? { type: 'calendar', id: CALENDAR_BLOCK_ID }
+    : { type: 'component', id: viewId, params };
+}
+
+/**
+ * Navigate to a sidebar view by pushing a fresh entry into the active split.
+ * Holding shift opens it in a new split. Use in-app back/forward to return to
+ * prior entries.
+ */
+export function navigateToSidebarView(args: {
+  viewId: SidebarItem['id'];
+  params?: SidebarItem['params'];
+  shiftKey: boolean;
+  activeSplit: SplitHandle | undefined;
+  openWithSplit: OpenWithSplitFn;
+  referredFrom?: ReferredFrom;
+}): SplitHandle | undefined {
+  const { viewId, params, shiftKey, activeSplit, openWithSplit, referredFrom } =
+    args;
+
+  const activeContent = activeSplit?.content();
+  if (
+    !shiftKey &&
+    isMarkdownDocumentsParams(params) &&
+    activeContent?.type === 'component' &&
+    activeContent.id === 'documents'
+  ) {
+    const controller = activeSplit
+      ? getDocumentsFilterSplit(activeSplit.id)
+      : undefined;
+    if (controller) {
+      controller.toggleMarkdownFilter();
+      return activeSplit;
+    }
+  }
+
+  return openWithSplit(sidebarContent(viewId, params), {
+    preferNewSplit: shiftKey,
+    mergeHistory: false,
+    allowDuplicate: viewId !== 'calendar',
+    referredFrom,
+  });
+}
+
+/**
+ * Whether a sidebar destination is what the active split currently shows.
+ * Shared by the expanded sidebar rows and the skinny rail so one click can't
+ * highlight in one and not the other. Pass the live `useLocation().pathname`:
+ * it is the fallback for the window between mount and the split layout
+ * registering its manager.
+ */
+export function isSidebarViewActive(
+  viewId: SidebarItem['id'],
+  params: SidebarItem['params'] | undefined,
+  pathname: string
+): boolean {
+  // Always read the manager signal live: it is undefined until the split
+  // layout mounts, which happens after the sidebar.
+  const activeContent = globalSplitManager()?.activeSplit()?.content();
+  if (!activeContent) {
+    return pathname.split('/').filter(Boolean).includes(viewId);
+  }
+
+  const expectedContent = sidebarContent(viewId, params);
+  return (
+    activeContent.type === expectedContent.type &&
+    activeContent.id === expectedContent.id
+  );
+}

--- a/apps/web/src/components/app/app-sidebar/rail-groups.test.ts
+++ b/apps/web/src/components/app/app-sidebar/rail-groups.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest';
 import type { SidebarItem } from './links';
 import {
   formatRailUnreadCount,
+  railDigitBindings,
   railGroups,
   unreadCountsByLinkId,
 } from './rail-groups';
@@ -156,5 +157,51 @@ describe('formatRailUnreadCount', () => {
     expect(formatRailUnreadCount(9)).toBe('9');
     expect(formatRailUnreadCount(99)).toBe('99');
     expect(formatRailUnreadCount(100)).toBe('99+');
+  });
+});
+
+describe('railDigitBindings', () => {
+  const bindingsFor = (ids: string[]) =>
+    railDigitBindings(railGroups(ids.map((id) => link(id)))).map(
+      (binding) => [binding.key, binding.link.id] as const
+    );
+
+  it('starts at 0 and increments down the rail', () => {
+    expect(bindingsFor(['home', 'inbox', 'mail', 'calendar'])).toEqual([
+      ['0', 'home'],
+      ['1', 'inbox'],
+      ['2', 'mail'],
+      ['3', 'calendar'],
+    ]);
+  });
+
+  it('follows the rail order, not the order links arrive in', () => {
+    expect(bindingsFor(['mail', 'home', 'channels', 'inbox'])).toEqual([
+      ['0', 'home'],
+      ['1', 'inbox'],
+      ['2', 'mail'],
+      ['3', 'channels'],
+    ]);
+  });
+
+  it('runs out of keys after the tenth destination', () => {
+    const ids = [
+      'home',
+      'getting-started',
+      'inbox',
+      'recent',
+      'activity',
+      'mail',
+      'calendar',
+      'channels',
+      'calls',
+      'documents',
+      'tasks',
+      'companies',
+    ];
+
+    const bindings = bindingsFor(ids);
+    expect(bindings).toHaveLength(10);
+    expect(bindings.at(-1)).toEqual(['9', 'documents']);
   });
 });

--- a/apps/web/src/components/app/app-sidebar/rail-groups.test.ts
+++ b/apps/web/src/components/app/app-sidebar/rail-groups.test.ts
@@ -1,0 +1,160 @@
+import { TOKENS } from '@core/hotkey/tokens';
+import type { UnifiedNotification } from '@notifications/types';
+import { describe, expect, it } from 'vitest';
+import type { SidebarItem } from './links';
+import {
+  formatRailUnreadCount,
+  railGroups,
+  unreadCountsByLinkId,
+} from './rail-groups';
+
+function link(id: string, overrides: Partial<SidebarItem> = {}): SidebarItem {
+  return {
+    id,
+    label: id,
+    href: `/${id}`,
+    hotkey: 'i',
+    hotkeyToken: TOKENS.sidebar.goTo.inbox,
+    ...overrides,
+  };
+}
+
+function notification(
+  entityType: UnifiedNotification['entity_type'],
+  overrides: Partial<UnifiedNotification> = {}
+): UnifiedNotification {
+  return {
+    id: `${entityType}-${Math.random()}`,
+    entity_id: 'entity-1',
+    entity_type: entityType,
+    created_at: '2026-08-17T00:00:00.000Z',
+    done: false,
+    notification_event_type: 'test',
+    notification_metadata: {
+      tag: 'channel_message_send',
+    } as UnifiedNotification['notification_metadata'],
+    sent: true,
+    updated_at: '2026-08-17T00:00:00.000Z',
+    viewed_at: null,
+    ...overrides,
+  };
+}
+
+describe('railGroups', () => {
+  it('clusters links in the rail order, not the sidebar order', () => {
+    const groups = railGroups([
+      link('channels'),
+      link('mail'),
+      link('inbox'),
+      link('calendar'),
+    ]);
+
+    expect(
+      groups.map((group) => [group.id, group.items.map((item) => item.id)])
+    ).toEqual([
+      ['overview', ['inbox']],
+      ['comms', ['mail', 'calendar']],
+      ['rooms', ['channels']],
+    ]);
+  });
+
+  it('drops links hidden from the sidebar', () => {
+    const groups = railGroups([
+      link('inbox'),
+      link('search', { hiddenFromSidebar: true }),
+    ]);
+
+    expect(groups).toEqual([
+      { id: 'overview', items: [expect.objectContaining({ id: 'inbox' })] },
+    ]);
+  });
+
+  it('keeps a link no cluster claims, in a trailing cluster', () => {
+    const groups = railGroups([link('mail'), link('brand-new-view')]);
+
+    expect(
+      groups.map((group) => [group.id, group.items.map((item) => item.id)])
+    ).toEqual([
+      ['comms', ['mail']],
+      ['other', ['brand-new-view']],
+    ]);
+  });
+
+  it('claims a duplicated link id once', () => {
+    // `documents` ships twice — the Files row plus a Documents variant that is
+    // hidden from the sidebar but keeps its own hotkey.
+    const groups = railGroups([
+      link('documents'),
+      link('documents', { label: 'Documents' }),
+    ]);
+
+    expect(groups).toEqual([
+      {
+        id: 'work',
+        items: [
+          expect.objectContaining({ id: 'documents', label: 'documents' }),
+        ],
+      },
+    ]);
+  });
+});
+
+describe('unreadCountsByLinkId', () => {
+  it('counts unread notifications per destination', () => {
+    const counts = unreadCountsByLinkId([
+      notification('email_thread'),
+      notification('email_thread'),
+      notification('calendar_event'),
+    ]);
+
+    expect(counts.get('mail')).toBe(2);
+    expect(counts.get('calendar')).toBe(1);
+  });
+
+  it('aggregates every unread notification under the inbox', () => {
+    const counts = unreadCountsByLinkId([
+      notification('email_thread'),
+      notification('channel'),
+      // No rail destination of its own — still an unread inbox item.
+      notification('team'),
+    ]);
+
+    expect(counts.get('inbox')).toBe(3);
+    expect(counts.get('team')).toBeUndefined();
+  });
+
+  it('counts documents and static files together, as Files does', () => {
+    const counts = unreadCountsByLinkId([
+      notification('document'),
+      notification('static_file'),
+    ]);
+
+    expect(counts.get('documents')).toBe(2);
+  });
+
+  it('ignores seen, done, and non-message channel notifications', () => {
+    const counts = unreadCountsByLinkId([
+      notification('email_thread', { viewed_at: '2026-08-18T00:00:00.000Z' }),
+      notification('email_thread', { done: true }),
+      notification('channel', {
+        notification_metadata: {
+          tag: 'channel_invite',
+        } as UnifiedNotification['notification_metadata'],
+      }),
+    ]);
+
+    expect(counts.size).toBe(0);
+  });
+
+  it('leaves an id with no unread notifications absent', () => {
+    expect(unreadCountsByLinkId([]).get('mail')).toBeUndefined();
+  });
+});
+
+describe('formatRailUnreadCount', () => {
+  it('caps the badge so it fits the rail', () => {
+    expect(formatRailUnreadCount(9)).toBe('9');
+    expect(formatRailUnreadCount(99)).toBe('99');
+    expect(formatRailUnreadCount(100)).toBe('99+');
+  });
+});

--- a/apps/web/src/components/app/app-sidebar/rail-groups.ts
+++ b/apps/web/src/components/app/app-sidebar/rail-groups.ts
@@ -1,3 +1,5 @@
+import { type HotkeyToken, TOKENS } from '@core/hotkey/tokens';
+import type { ValidHotkey } from '@core/hotkey/types';
 import type { EntityType } from '@core/types';
 import { notificationIsRead } from '@notifications/notification-helpers';
 import type { UnifiedNotification } from '@notifications/types';
@@ -133,4 +135,41 @@ export function unreadCountsByLinkId(
 /** Badge text: the count, capped so it stays inside the 30px rail. */
 export function formatRailUnreadCount(count: number): string {
   return count > 99 ? '99+' : String(count);
+}
+
+/**
+ * The single-key jumps to rail destinations: `0` is the first destination,
+ * incrementing through the rail's own order, and destinations past `9` get
+ * none. Feature-gated destinations shift the ones after them, so the keys
+ * always match what the rail actually shows.
+ */
+const RAIL_DIGITS = [
+  { key: '0', token: TOKENS.sidebar.goToIndex['0'] },
+  { key: '1', token: TOKENS.sidebar.goToIndex['1'] },
+  { key: '2', token: TOKENS.sidebar.goToIndex['2'] },
+  { key: '3', token: TOKENS.sidebar.goToIndex['3'] },
+  { key: '4', token: TOKENS.sidebar.goToIndex['4'] },
+  { key: '5', token: TOKENS.sidebar.goToIndex['5'] },
+  { key: '6', token: TOKENS.sidebar.goToIndex['6'] },
+  { key: '7', token: TOKENS.sidebar.goToIndex['7'] },
+  { key: '8', token: TOKENS.sidebar.goToIndex['8'] },
+  { key: '9', token: TOKENS.sidebar.goToIndex['9'] },
+] as const satisfies readonly { key: ValidHotkey; token: HotkeyToken }[];
+
+/** A rail destination paired with the digit that jumps to it. */
+export interface RailDigitBinding {
+  link: SidebarItem;
+  key: ValidHotkey;
+  token: HotkeyToken;
+}
+
+/** Pair the rail's destinations with their digit keys, in rail order. */
+export function railDigitBindings(
+  groups: readonly RailGroup[]
+): RailDigitBinding[] {
+  const destinations = groups.flatMap((group) => group.items);
+  return RAIL_DIGITS.flatMap(({ key, token }, index) => {
+    const link = destinations[index];
+    return link ? [{ link, key, token }] : [];
+  });
 }

--- a/apps/web/src/components/app/app-sidebar/rail-groups.ts
+++ b/apps/web/src/components/app/app-sidebar/rail-groups.ts
@@ -1,0 +1,136 @@
+import type { EntityType } from '@core/types';
+import { notificationIsRead } from '@notifications/notification-helpers';
+import type { UnifiedNotification } from '@notifications/types';
+import type { SidebarItem } from './links';
+
+/**
+ * The skinny rail's clusters, in render order. Each cluster is one rounded
+ * block of icons, so related destinations read as one thing at 30px wide —
+ * Email and Calendar together, the two live-conversation views together, and
+ * so on. Link ids the definitions don't mention still render, in a trailing
+ * cluster of their own (see {@link railGroups}), so adding a sidebar link can
+ * never silently drop it from the rail.
+ */
+const RAIL_GROUP_DEFINITIONS = [
+  {
+    id: 'overview',
+    linkIds: ['home', 'getting-started', 'inbox', 'recent', 'activity'],
+  },
+  { id: 'comms', linkIds: ['mail', 'calendar'] },
+  { id: 'rooms', linkIds: ['channels', 'calls'] },
+  { id: 'work', linkIds: ['documents', 'tasks'] },
+  { id: 'records', linkIds: ['companies', 'agents'] },
+] as const satisfies readonly {
+  id: string;
+  linkIds: readonly string[];
+}[];
+
+/** One rendered cluster: its id plus the links it resolved to. */
+export interface RailGroup {
+  id: string;
+  items: SidebarItem[];
+}
+
+/** The cluster id everything unclaimed by {@link RAIL_GROUP_DEFINITIONS} lands in. */
+const OTHER_GROUP_ID = 'other';
+
+/**
+ * Resolve {@link RAIL_GROUP_DEFINITIONS} against the live link list: keeps the
+ * defined order, drops links the feature flags gated out (and rows hidden from
+ * the sidebar), drops empty clusters, and sweeps anything left over into a
+ * trailing cluster.
+ */
+export function railGroups(links: readonly SidebarItem[]): RailGroup[] {
+  // Keyed by id, first row wins: a destination can ship more than once (Files
+  // and the sidebar-hidden Documents variant are both `documents`), and the
+  // rail has room for exactly one icon per destination.
+  const railable = new Map<string, SidebarItem>();
+  for (const link of links) {
+    if (link.hiddenFromSidebar) continue;
+    if (!railable.has(link.id)) railable.set(link.id, link);
+  }
+
+  const claimedIds = new Set<string>();
+  const groups: RailGroup[] = [];
+  for (const definition of RAIL_GROUP_DEFINITIONS) {
+    const items: SidebarItem[] = [];
+    for (const linkId of definition.linkIds) {
+      const link = railable.get(linkId);
+      if (!link) continue;
+      claimedIds.add(linkId);
+      items.push(link);
+    }
+    if (items.length > 0) groups.push({ id: definition.id, items });
+  }
+
+  const leftovers = [...railable.values()].filter(
+    (link) => !claimedIds.has(link.id)
+  );
+  if (leftovers.length > 0) {
+    groups.push({ id: OTHER_GROUP_ID, items: leftovers });
+  }
+
+  return groups;
+}
+
+/**
+ * Which notification entity types each link's unread badge counts. Tasks are
+ * documents server-side, so a task notification counts toward Files — there is
+ * no task-only entity type to split them by.
+ */
+const UNREAD_ENTITY_TYPES_BY_LINK_ID: Record<string, readonly EntityType[]> = {
+  mail: ['email_thread'],
+  calendar: ['calendar_event'],
+  channels: ['channel'],
+  calls: ['call'],
+  documents: ['document', 'static_file'],
+  companies: ['crm_company', 'crm_contact'],
+  agents: ['agent_session'],
+};
+
+/** Links whose badge counts every unread notification, whatever its entity. */
+const AGGREGATE_UNREAD_LINK_IDS: readonly string[] = ['inbox'];
+
+const LINK_IDS_BY_UNREAD_ENTITY_TYPE = ((): Map<string, string[]> => {
+  const byEntityType = new Map<string, string[]>();
+  for (const [linkId, entityTypes] of Object.entries(
+    UNREAD_ENTITY_TYPES_BY_LINK_ID
+  )) {
+    for (const entityType of entityTypes) {
+      const linkIds = byEntityType.get(entityType);
+      if (linkIds) linkIds.push(linkId);
+      else byEntityType.set(entityType, [linkId]);
+    }
+  }
+  return byEntityType;
+})();
+
+/**
+ * Unread notification counts per sidebar link id, in one pass. Ids with no
+ * unread notifications are absent rather than zero, so a badge renders only
+ * when {@link Map.get} finds something.
+ */
+export function unreadCountsByLinkId(
+  notifications: readonly UnifiedNotification[]
+): Map<string, number> {
+  const counts = new Map<string, number>();
+  const increment = (linkId: string) =>
+    counts.set(linkId, (counts.get(linkId) ?? 0) + 1);
+
+  for (const notification of notifications) {
+    if (notificationIsRead(notification)) continue;
+    for (const linkId of AGGREGATE_UNREAD_LINK_IDS) increment(linkId);
+    const linkIds = LINK_IDS_BY_UNREAD_ENTITY_TYPE.get(
+      notification.entity_type
+    );
+    if (!linkIds) continue;
+    for (const linkId of linkIds) increment(linkId);
+  }
+
+  return counts;
+}
+
+/** Badge text: the count, capped so it stays inside the 30px rail. */
+export function formatRailUnreadCount(count: number): string {
+  return count > 99 ? '99+' : String(count);
+}

--- a/apps/web/src/components/app/app-sidebar/rail-parts.tsx
+++ b/apps/web/src/components/app/app-sidebar/rail-parts.tsx
@@ -1,0 +1,131 @@
+import { useGlobalNotificationSource } from '@components/app/GlobalAppState';
+import type { HotkeyToken } from '@core/hotkey/tokens';
+import { Button, cn } from '@ui';
+import { createMemo, For, type JSX, Show, Suspense } from 'solid-js';
+import { Dynamic } from 'solid-js/web';
+import type { SidebarItem } from './links';
+import {
+  formatRailUnreadCount,
+  type RailGroup,
+  unreadCountsByLinkId,
+} from './rail-groups';
+
+/**
+ * Unread counts per destination, shared by both rails. Read it lazily (inside
+ * a `Suspense` boundary): the notification query behind it can suspend.
+ */
+export const useRailUnreadCounts = () => {
+  const notificationSource = useGlobalNotificationSource();
+  return createMemo(() =>
+    unreadCountsByLinkId(notificationSource.notifications())
+  );
+};
+
+/**
+ * A destination's unread count, badged on its icon. Rendered inside its own
+ * `Suspense` by {@link RailDestination}: the notification query behind the
+ * count can suspend, and that must not blank the icon it sits on.
+ */
+const RailUnreadBadge = (props: { count: () => number | undefined }) => (
+  <Show when={props.count()}>
+    {(count) => (
+      <span
+        role="status"
+        aria-label={`${count()} unread`}
+        class="absolute -top-1 -right-1.5 flex h-3 min-w-3 items-center justify-center rounded-full bg-accent px-0.5 text-[8px] leading-none font-medium text-surface ring-1 ring-surface"
+      >
+        {formatRailUnreadCount(count())}
+      </span>
+    )}
+  </Show>
+);
+
+type RailDestinationProps = {
+  link: SidebarItem;
+  /** Show the label under the icon (the wide left rail) or rely on the tooltip. */
+  showLabel?: boolean;
+  unreadCount: () => number | undefined;
+  active: () => boolean;
+  /** Shortcut shown in the tooltip. */
+  hotkey?: HotkeyToken | HotkeyToken[];
+  /** What the tooltip says this click does, e.g. "Go to Email". */
+  action: string;
+  onOpen: (event: MouseEvent) => void;
+};
+
+/** One destination in a nav rail: icon, unread badge, and optional label. */
+export const RailDestination = (props: RailDestinationProps) => (
+  <Button
+    aria-label={`${props.action} ${props.link.label}`}
+    data-rail-link={props.link.id}
+    data-active={props.active() ? '' : undefined}
+    class={cn(
+      'h-auto flex-col gap-1 rounded-lg p-1',
+      // Wide enough for a one-word label ("Calendar") before truncation.
+      props.showLabel ? 'w-14' : 'w-8',
+      props.active() && 'bg-ink/10 text-ink'
+    )}
+    label={`${props.action} ${props.link.label}`}
+    hotkey={props.hotkey}
+    tooltipPlacement={props.showLabel ? 'right' : 'left'}
+    noTouchResize
+    onMouseDown={(event: MouseEvent) => {
+      if (event.button !== 0) return;
+      event.preventDefault();
+      props.onOpen(event);
+    }}
+  >
+    <span class="relative flex size-4 shrink-0 items-center justify-center [&_svg]:size-4">
+      <Show when={props.link.icon}>
+        {(icon) => <Dynamic component={icon()} />}
+      </Show>
+      <Suspense>
+        <RailUnreadBadge count={props.unreadCount} />
+      </Suspense>
+    </span>
+    <Show when={props.showLabel}>
+      <span class="w-full truncate text-center text-[10px] leading-none font-medium">
+        {props.link.label}
+      </span>
+    </Show>
+  </Button>
+);
+
+type RailDestinationsProps = {
+  groups: RailGroup[];
+  /** Rendered for each destination — the rails differ only in what a click does. */
+  destination: (link: SidebarItem) => JSX.Element;
+};
+
+/**
+ * The rail's scrolling body: each cluster of destinations, separated by a
+ * hairline so related views read as one block.
+ */
+export const RailDestinations = (props: RailDestinationsProps) => (
+  <div class="flex min-h-0 flex-1 flex-col items-center gap-1 overflow-y-auto">
+    <For each={props.groups}>
+      {(group, index) => (
+        <>
+          <Show when={index() > 0}>
+            <span
+              aria-hidden="true"
+              class="my-0.5 h-px w-5 shrink-0 bg-edge-muted"
+            />
+          </Show>
+          <ul
+            data-rail-group={group.id}
+            class="flex shrink-0 flex-col items-center gap-0.5"
+          >
+            <For each={group.items}>
+              {(link) => (
+                <li class="flex items-center justify-center">
+                  {props.destination(link)}
+                </li>
+              )}
+            </For>
+          </ul>
+        </>
+      )}
+    </For>
+  </div>
+);

--- a/apps/web/src/components/app/app-sidebar/sidebar.tsx
+++ b/apps/web/src/components/app/app-sidebar/sidebar.tsx
@@ -1,23 +1,16 @@
 import { GO_TO_COMMAND_SCOPE, GO_TO_LEADER_KEY } from '@app/constants/hotkeys';
-import { LIST_VIEW_PATHS, type ListView } from '@app/constants/list-views';
-import { useActivityFeedFlag } from '@app/features/activity/use-activity-feed-flag';
 import { SidebarActiveCallWidget } from '@app/features/block-call/sidebar/active-call-widget';
-import { useCalendarUiFlag } from '@app/features/calendar/hooks/use-calendar-ui-flag';
 import { ChannelsRecentWidget } from '@app/features/channel/sidebar/channels-recent-widget';
 import { CommandState } from '@app/features/command';
 import { SidebarCreateMenu } from '@app/features/command/sidebar/sidebar-create-menu';
 import { FavoritesSection } from '@app/features/favorites/sidebar/favorites-section';
-import { useGettingStartedEnabled } from '@app/features/getting-started/account-gate';
 import { createGettingStartedSidebarVisibility } from '@app/features/getting-started/sidebar-visibility';
-import { buildDocumentTypeQuery } from '@app/features/next-soup/filters/configs/document-type-query';
-import { getDocumentsFilterSplit } from '@app/features/next-soup/soup-view/documents-filter-controllers';
 import {
   getInboxFilterSplit,
   INBOX_FILTER_ENTRY_KEY,
   requestInboxFilter,
 } from '@app/features/next-soup/soup-view/inbox-filter-controllers';
 import { requestSearchFocus } from '@app/features/next-soup/soup-view/search-controllers';
-import { useRecentViewFlag } from '@app/features/next-soup/use-recent-view-flag';
 import {
   InviteModal,
   setInviteModalOpen,
@@ -26,7 +19,6 @@ import { useAnalytics } from '@app/lib/analytics/analytics-context';
 import { useFeatureFlag } from '@app/lib/analytics/posthog';
 import { useHotkeyInterceptor } from '@app/signal/hotkeyRoot';
 import { globalSplitManager } from '@app/signal/splitLayout';
-import { CALENDAR_BLOCK_ID } from '@block-calendar/types';
 import { useCallContextOptional } from '@channel/Call/CallContext';
 import { InCallPanel } from '@channel/Call/InCallPanel';
 import {
@@ -39,7 +31,6 @@ import {
 } from '@components/app/app-sidebar/sidebar-promo';
 import { useSplitLayout } from '@components/app/split-layout/layout';
 import type {
-  ReferredFrom,
   SplitContent,
   SplitHandle,
 } from '@components/app/split-layout/layoutManager';
@@ -49,11 +40,7 @@ import { ContextMenuContent, MenuItem } from '@core/component/ContextMenu';
 import { inboxIconProps } from '@core/component/inboxIcon';
 import { toast } from '@core/component/Toast/Toast';
 import { UserIcon } from '@core/component/UserIcon';
-import {
-  ENABLE_CALLS,
-  ENABLE_CRM,
-  ENABLE_NEW_PRICING_OVERRIDE,
-} from '@core/constant/featureFlags';
+import { ENABLE_NEW_PRICING_OVERRIDE } from '@core/constant/featureFlags';
 import {
   type SettingsTab,
   useSettingsState,
@@ -65,27 +52,14 @@ import {
 import { useEmail, useUserId } from '@core/context/user';
 import { registerHotkey } from '@core/hotkey/hotkeys';
 import { clearPressedKeys } from '@core/hotkey/state';
-import { type HotkeyToken, TOKENS } from '@core/hotkey/tokens';
+import { TOKENS } from '@core/hotkey/tokens';
 import type { ValidHotkey } from '@core/hotkey/types';
 import { activateClosestDOMScope } from '@core/hotkey/utils';
 import { getDisplayName, tryMacroId } from '@core/user';
 import LogoIcon from '@icon/macro-logo.svg';
-import { AnimatedActivityIcon } from '@icon/wide-activity';
-import WideCalendarIcon from '@icon/wide-calendar.svg';
-import { AnimatedCallIcon } from '@icon/wide-call';
-import { AnimatedChannelIcon } from '@icon/wide-channel';
-import { AnimatedCompanyIcon } from '@icon/wide-company';
-import { AnimatedEmailIcon } from '@icon/wide-email';
-import { AnimatedFileMdIcon } from '@icon/wide-fileMd';
-import { AnimatedHomeIcon } from '@icon/wide-home';
-import { AnimatedInboxIcon } from '@icon/wide-inbox';
-import { AnimatedSearchIcon } from '@icon/wide-search';
-import { AnimatedStarIcon } from '@icon/wide-star';
-import { AnimatedTaskIcon } from '@icon/wide-task';
 import { ContextMenu } from '@kobalte/core/context-menu';
 import CaretRightIcon from '@phosphor/caret-right.svg';
 import CaretUpIcon from '@phosphor/caret-up.svg';
-import CompassIcon from '@phosphor/compass.svg';
 import DotsThreeIcon from '@phosphor/dots-three.svg';
 import GearIcon from '@phosphor/gear.svg';
 import MagnifyingGlassIcon from '@phosphor/magnifying-glass.svg';
@@ -120,20 +94,12 @@ import {
 } from 'solid-js';
 import { Dynamic } from 'solid-js/web';
 import { CalendarSidebarPreview } from './calendar-sidebar-preview';
-
-interface SidebarItem {
-  id: ListView | (string & {});
-  label: string;
-  href: string;
-  params?: Record<string, unknown>;
-  icon?: Component<
-    JSX.SvgSVGAttributes<SVGSVGElement> & { triggerAnimation?: boolean }
-  >;
-  hotkey: ValidHotkey;
-  hotkeyToken: HotkeyToken;
-  standaloneHotkey?: boolean;
-  hiddenFromSidebar?: boolean;
-}
+import { type SidebarItem, useSidebarLinks } from './links';
+import {
+  isSidebarViewActive,
+  navigateToSidebarView,
+  sidebarContent,
+} from './navigation';
 
 type SidebarSectionLinkId =
   | 'mail'
@@ -179,93 +145,6 @@ const DEFAULT_TRY_VISIBILITY: TryItemVisibility = {
   mobile: true,
 };
 
-const markdownDocumentsQuery = buildDocumentTypeQuery(['doc-markdown']);
-
-const SIDEBAR_LINKS = [
-  {
-    id: 'inbox',
-    label: 'Inbox',
-    href: LIST_VIEW_PATHS.inbox,
-    icon: AnimatedInboxIcon,
-    hotkey: 'i',
-    hotkeyToken: TOKENS.sidebar.goTo.inbox,
-  },
-  {
-    id: 'search',
-    label: 'Search',
-    href: LIST_VIEW_PATHS.search,
-    icon: AnimatedSearchIcon,
-    hotkey: '/',
-    hotkeyToken: TOKENS.sidebar.goTo.search,
-    standaloneHotkey: true,
-    hiddenFromSidebar: true,
-  },
-  {
-    id: 'agents',
-    label: 'Agents',
-    href: LIST_VIEW_PATHS.agents,
-    icon: AnimatedStarIcon,
-    hotkey: 'a',
-    hotkeyToken: TOKENS.sidebar.goTo.agents,
-  },
-  {
-    id: 'mail',
-    label: 'Email',
-    href: LIST_VIEW_PATHS.mail,
-    icon: AnimatedEmailIcon,
-    hotkey: 'e',
-    hotkeyToken: TOKENS.sidebar.goTo.mail,
-  },
-  {
-    id: 'documents',
-    label: 'Files',
-    href: LIST_VIEW_PATHS.documents,
-    icon: AnimatedFileMdIcon,
-    hotkey: 'f',
-    hotkeyToken: TOKENS.sidebar.goTo.documents,
-  },
-  {
-    id: 'documents',
-    label: 'Documents',
-    href: LIST_VIEW_PATHS.documents,
-    params: {
-      initialFilters: markdownDocumentsQuery ?? {},
-      initialClientFilters: {
-        and: ['document-or-file'],
-        or: ['doc-markdown'],
-      },
-    },
-    icon: AnimatedFileMdIcon,
-    hotkey: 'd',
-    hotkeyToken: TOKENS.sidebar.goTo.markdownDocuments,
-    hiddenFromSidebar: true,
-  },
-  {
-    id: 'tasks',
-    label: 'Tasks',
-    href: LIST_VIEW_PATHS.tasks,
-    icon: AnimatedTaskIcon,
-    hotkey: 't',
-    hotkeyToken: TOKENS.sidebar.goTo.tasks,
-  },
-  {
-    id: 'calendar',
-    label: 'Calendar',
-    href: '/calendar',
-    icon: WideCalendarIcon,
-    hotkey: 'r',
-    hotkeyToken: TOKENS.sidebar.goTo.calendar,
-  },
-  {
-    id: 'channels',
-    label: 'Channels',
-    href: LIST_VIEW_PATHS.channels,
-    icon: AnimatedChannelIcon,
-    hotkey: 'c',
-    hotkeyToken: TOKENS.sidebar.goTo.channels,
-  },
-] satisfies SidebarItem[];
-
 export type SidebarState = 'hidden' | 'expanded' | 'slim';
 
 /** Root sidebar `max-width` transition (see `SIDEBAR_MAX_WIDTH_TRANSITION_STYLE`). */
@@ -288,67 +167,6 @@ type SidebarHotkeyDeps = {
   isSlim: () => boolean;
   onOpenChange: (open: boolean) => void;
 };
-
-type OpenWithSplitFn = ReturnType<typeof useSplitLayout>['openWithSplit'];
-
-const isMarkdownDocumentsParams = (
-  params: SidebarItem['params'] | undefined
-): boolean => {
-  const initialClientFilters = params?.initialClientFilters as
-    | { or?: readonly unknown[] }
-    | undefined;
-
-  return initialClientFilters?.or?.includes('doc-markdown') ?? false;
-};
-
-function sidebarContent(
-  viewId: SidebarItem['id'],
-  params?: SidebarItem['params']
-): SplitContent {
-  return viewId === 'calendar'
-    ? { type: 'calendar', id: CALENDAR_BLOCK_ID }
-    : { type: 'component', id: viewId, params };
-}
-
-/**
- * Navigate to a sidebar view by pushing a fresh entry into the active split.
- * Holding shift opens it in a new split. Use in-app back/forward to return to
- * prior entries.
- */
-function navigateToSidebarView(args: {
-  viewId: SidebarItem['id'];
-  params?: SidebarItem['params'];
-  shiftKey: boolean;
-  activeSplit: SplitHandle | undefined;
-  openWithSplit: OpenWithSplitFn;
-  referredFrom?: ReferredFrom;
-}): SplitHandle | undefined {
-  const { viewId, params, shiftKey, activeSplit, openWithSplit, referredFrom } =
-    args;
-
-  const activeContent = activeSplit?.content();
-  if (
-    !shiftKey &&
-    isMarkdownDocumentsParams(params) &&
-    activeContent?.type === 'component' &&
-    activeContent.id === 'documents'
-  ) {
-    const controller = activeSplit
-      ? getDocumentsFilterSplit(activeSplit.id)
-      : undefined;
-    if (controller) {
-      controller.toggleMarkdownFilter();
-      return activeSplit;
-    }
-  }
-
-  return openWithSplit(sidebarContent(viewId, params), {
-    preferNewSplit: shiftKey,
-    mergeHistory: false,
-    allowDuplicate: viewId !== 'calendar',
-    referredFrom,
-  });
-}
 
 const registerSidebarHotkeys = ({
   isSlim,
@@ -410,18 +228,7 @@ export const GoToHotkeys = () => {
     },
   });
 
-  const gettingStartedEnabled = useGettingStartedEnabled();
-  const calendarUiEnabled = useCalendarUiFlag();
-  const activityFeedEnabled = useActivityFeedFlag();
-  const recentViewEnabled = useRecentViewFlag();
-  const links = createMemo((): SidebarItem[] =>
-    buildSidebarLinks(
-      gettingStartedEnabled(),
-      calendarUiEnabled(),
-      activityFeedEnabled(),
-      recentViewEnabled()
-    )
-  );
+  const links = useSidebarLinks();
 
   const debounceResetHotkeysState = debounce(resetGoToHotkeysState, 2000);
   const debounceSetHotkeyVisible = debounce(
@@ -990,122 +797,6 @@ const SidebarSettingsWidget = (props: SidebarSettingsWidgetProps) => {
   );
 };
 
-const CALLS_LINK: SidebarItem = {
-  id: 'calls',
-  label: 'Calls',
-  href: LIST_VIEW_PATHS.calls,
-  icon: AnimatedCallIcon,
-  hotkey: 'l',
-  hotkeyToken: TOKENS.sidebar.goTo.calls,
-};
-
-const COMPANIES_LINK: SidebarItem = {
-  id: 'companies',
-  label: 'Customers',
-  href: LIST_VIEW_PATHS.companies,
-  icon: AnimatedCompanyIcon,
-  hotkey: 'o',
-  hotkeyToken: TOKENS.sidebar.goTo.companies,
-};
-
-const DASHBOARD_LINK: SidebarItem = {
-  id: 'home',
-  label: 'Home',
-  href: '/home',
-  icon: AnimatedHomeIcon,
-  hotkey: 'h',
-  hotkeyToken: TOKENS.sidebar.goTo.home,
-};
-
-const GETTING_STARTED_LINK: SidebarItem = {
-  id: 'getting-started',
-  label: 'Getting Started',
-  href: '/getting-started',
-  icon: CompassIcon,
-  hotkey: 's',
-  hotkeyToken: TOKENS.sidebar.goTo.gettingStarted,
-};
-
-const ACTIVITY_LINK: SidebarItem = {
-  id: 'activity',
-  label: 'Activity',
-  href: '/activity',
-  icon: AnimatedActivityIcon,
-  hotkey: 'y',
-  hotkeyToken: TOKENS.sidebar.goTo.activity,
-};
-
-const RECENT_LINK: SidebarItem = {
-  id: 'recent',
-  label: 'Recent',
-  href: LIST_VIEW_PATHS.recent,
-  icon: AnimatedActivityIcon,
-  // `r` is Calendar and `e`/`c`/`t` are taken; `n` is the only letter of
-  // "recent" that is not already a sidebar destination.
-  hotkey: 'n',
-  hotkeyToken: TOKENS.sidebar.goTo.recent,
-};
-
-/**
- * Assemble the ordered sidebar link list: the static links plus Home, Getting
- * started, and the flag-gated Activity, Calendar, Calls, and CRM entries in
- * their correct positions.
- * Shared by the rendered sidebar (`AppSidebar.visibleLinks`) and the
- * always-mounted `GoToHotkeys` registrar so their link sets can't drift. Call
- * from a reactive context — it reads `ENABLE_CALLS()` / `ENABLE_CRM()`.
- * `showGettingStarted` is the account-age gate (`useGettingStartedEnabled`),
- * passed in because this runs outside a component; when false the link is
- * fully absent — row, `g s` hotkey, and command menu entry.
- * Rendered sections additionally drop `hiddenFromSidebar` entries, which have
- * hotkeys but no sidebar row.
- */
-const buildSidebarLinks = (
-  showGettingStarted: boolean,
-  showCalendar: boolean,
-  showActivity: boolean,
-  showRecent: boolean
-): SidebarItem[] => {
-  let links: SidebarItem[] = [
-    DASHBOARD_LINK,
-    ...(showGettingStarted ? [GETTING_STARTED_LINK] : []),
-    ...SIDEBAR_LINKS.filter((link) => showCalendar || link.id !== 'calendar'),
-  ];
-
-  if (showRecent) {
-    // Directly below Inbox; Activity anchors after it.
-    const idx = links.findIndex((link) => link.id === 'inbox');
-    links = [...links.slice(0, idx + 1), RECENT_LINK, ...links.slice(idx + 1)];
-  }
-
-  if (showActivity) {
-    const anchorId = showRecent ? 'recent' : 'inbox';
-    const idx = links.findIndex((link) => link.id === anchorId);
-    links = [
-      ...links.slice(0, idx + 1),
-      ACTIVITY_LINK,
-      ...links.slice(idx + 1),
-    ];
-  }
-
-  if (ENABLE_CALLS()) {
-    const idx = links.findIndex((l) => l.id === 'channels');
-    links = [...links.slice(0, idx + 1), CALLS_LINK, ...links.slice(idx + 1)];
-  }
-
-  if (ENABLE_CRM()) {
-    // Customers sits just after Channels (and Calls when present).
-    const anchorId = ENABLE_CALLS() ? 'calls' : 'channels';
-    const idx = links.findIndex((l) => l.id === anchorId);
-    links = [
-      ...links.slice(0, idx + 1),
-      COMPANIES_LINK,
-      ...links.slice(idx + 1),
-    ];
-  }
-
-  return links;
-};
-
 const TeamInviteSidebarPromo = (props: { invite: TeamInviteDetails }) => {
   const inviterName = () => getDisplayName(tryMacroId(props.invite.invited_by));
   const joinTeamMutation = useJoinTeamMutation();
@@ -1161,18 +852,7 @@ export const AppSidebar = (props: AppSidebarProps) => {
     enabledOverride: ENABLE_NEW_PRICING_OVERRIDE,
   });
 
-  const gettingStartedEnabled = useGettingStartedEnabled();
-  const calendarUiEnabled = useCalendarUiFlag();
-  const activityFeedEnabled = useActivityFeedFlag();
-  const recentViewEnabled = useRecentViewFlag();
-  const allLinks = createMemo((): SidebarItem[] =>
-    buildSidebarLinks(
-      gettingStartedEnabled(),
-      calendarUiEnabled(),
-      activityFeedEnabled(),
-      recentViewEnabled()
-    )
-  );
+  const allLinks = useSidebarLinks();
 
   // Hides only the rendered row: the g+s hotkey and command menu entry keep
   // working (like `hiddenFromSidebar` links), so the page stays reachable.
@@ -1790,25 +1470,8 @@ const SidebarLinkRow = (props: SidebarLinkProps) => {
 
   const location = useLocation();
   const content = () => sidebarContent(props.id, props.params);
-
-  // Always read the manager signal live: it is undefined until the split
-  // layout mounts, which happens after the sidebar.
-  const isActive = () => {
-    const activeContent = globalSplitManager()?.activeSplit()?.content();
-
-    // In case we can't match on the active split, use the url path to determine
-    // if this link is active
-    if (!activeContent) {
-      const paths = location.pathname.split('/').filter(Boolean);
-      return paths.includes(props.id);
-    }
-
-    const expectedContent = content();
-    return (
-      activeContent.type === expectedContent.type &&
-      activeContent.id === expectedContent.id
-    );
-  };
+  const isActive = () =>
+    isSidebarViewActive(props.id, props.params, location.pathname);
 
   return (
     <NavRow

--- a/apps/web/src/components/app/app-sidebar/sidebar.tsx
+++ b/apps/web/src/components/app/app-sidebar/sidebar.tsx
@@ -100,6 +100,7 @@ import {
   navigateToSidebarView,
   sidebarContent,
 } from './navigation';
+import { railDigitBindings, railGroups } from './rail-groups';
 
 type SidebarSectionLinkId =
   | 'mail'
@@ -299,49 +300,66 @@ export const GoToHotkeys = () => {
   // This must be reactive because prod feature flags can add links after the
   // initial render (e.g. Home), and Hotkey UI resolves tokens from the registry.
   createEffect(() => {
-    const disposers = links().map((link) => {
-      const openSidebarView = (e?: KeyboardEvent) => {
-        e?.preventDefault();
-        if (goToHotkeyVisible()) {
-          resetGoToHotkeysState();
-          debounceResetHotkeysState.clear();
-        }
+    const openSidebarView = (link: SidebarItem) => (e?: KeyboardEvent) => {
+      e?.preventDefault();
+      if (goToHotkeyVisible()) {
+        resetGoToHotkeysState();
+        debounceResetHotkeysState.clear();
+      }
 
-        if (link.id === 'search' && !e?.shiftKey) {
-          const activeSplit = globalSplitManager()?.activeSplit();
-          const content = activeSplit?.content();
-          if (
-            activeSplit &&
-            content?.type === 'component' &&
-            content.id === 'search'
-          ) {
-            requestSearchFocus(activeSplit.id);
-            return true;
-          }
+      if (link.id === 'search' && !e?.shiftKey) {
+        const activeSplit = globalSplitManager()?.activeSplit();
+        const content = activeSplit?.content();
+        if (
+          activeSplit &&
+          content?.type === 'component' &&
+          content.id === 'search'
+        ) {
+          requestSearchFocus(activeSplit.id);
+          return true;
         }
+      }
 
-        const handle = navigateToSidebarView({
-          viewId: link.id,
-          params: link.params,
-          shiftKey: !!e?.shiftKey,
-          activeSplit: globalSplitManager()?.activeSplit(),
-          openWithSplit,
-        });
-        if (link.id === 'search' && handle) {
-          requestSearchFocus(handle.id);
-        }
-        return true;
-      };
-
-      return registerHotkey({
-        hotkey: link.hotkey,
-        scopeId: link.standaloneHotkey ? 'global' : GO_TO_COMMAND_SCOPE,
-        hotkeyToken: link.hotkeyToken,
-        description: `Go to ${link.label}`,
-        keyDownHandler: openSidebarView,
-        icon: link.icon,
+      const handle = navigateToSidebarView({
+        viewId: link.id,
+        params: link.params,
+        shiftKey: !!e?.shiftKey,
+        activeSplit: globalSplitManager()?.activeSplit(),
+        openWithSplit,
       });
-    });
+      if (link.id === 'search' && handle) {
+        requestSearchFocus(handle.id);
+      }
+      return true;
+    };
+
+    const disposers = [
+      ...links().map((link) =>
+        registerHotkey({
+          hotkey: link.hotkey,
+          scopeId: link.standaloneHotkey ? 'global' : GO_TO_COMMAND_SCOPE,
+          hotkeyToken: link.hotkeyToken,
+          description: `Go to ${link.label}`,
+          keyDownHandler: openSidebarView(link),
+          icon: link.icon,
+        })
+      ),
+      // Single-key jumps down the nav rail: `0` is its first destination,
+      // incrementing from there. Hidden from the command menu — every one of
+      // these duplicates a `g`-leader command that is already listed — but the
+      // rail's tooltips surface the digit.
+      ...railDigitBindings(railGroups(links())).map((binding) =>
+        registerHotkey({
+          hotkey: binding.key,
+          scopeId: 'global',
+          hotkeyToken: binding.token,
+          description: `Go to ${binding.link.label}`,
+          keyDownHandler: openSidebarView(binding.link),
+          icon: binding.link.icon,
+          hide: true,
+        })
+      ),
+    ];
 
     onCleanup(() => {
       for (const disposer of disposers) {

--- a/apps/web/src/components/app/app-sidebar/skinny-rail.test.tsx
+++ b/apps/web/src/components/app/app-sidebar/skinny-rail.test.tsx
@@ -1,0 +1,217 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { TOKENS } from '@core/hotkey/tokens';
+import type { UnifiedNotification } from '@notifications/types';
+import { fireEvent, render } from '@solidjs/testing-library';
+import type { JSX } from 'solid-js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SidebarItem } from './links';
+import { SkinnySidebarRail } from './skinny-rail';
+
+const mocks = vi.hoisted(() => ({
+  links: [] as SidebarItem[],
+  notifications: [] as UnifiedNotification[],
+  openWithSplit: vi.fn(),
+  pathname: '/',
+  track: vi.fn(),
+}));
+
+vi.mock('@app/lib/analytics/analytics-context', () => ({
+  useAnalytics: () => ({ track: mocks.track }),
+}));
+
+vi.mock('@app/signal/splitLayout', () => ({
+  // Nothing has claimed a split yet, so the active view comes from the path.
+  globalSplitManager: () => undefined,
+}));
+
+vi.mock('@components/app/GlobalAppState', () => ({
+  useGlobalNotificationSource: () => ({
+    notifications: () => mocks.notifications,
+  }),
+}));
+
+vi.mock('@components/app/split-layout/layout', () => ({
+  useSplitLayout: () => ({ openWithSplit: mocks.openWithSplit }),
+}));
+
+vi.mock('@core/constant/SettingsState', () => ({
+  useSettingsState: () => ({
+    openSettings: vi.fn(),
+    selectTab: vi.fn(),
+    settingsOpen: () => false,
+  }),
+}));
+
+vi.mock('@core/constant/settingsTabsConfig', () => ({
+  useSettingsTabAvailable: () => () => true,
+}));
+
+vi.mock('@solidjs/router', () => ({
+  useLocation: () => ({
+    get pathname() {
+      return mocks.pathname;
+    },
+  }),
+}));
+
+vi.mock('./links', () => ({
+  useSidebarLinks: () => () => mocks.links,
+}));
+
+vi.mock('@ui', () => {
+  type MockButtonProps = {
+    children?: JSX.Element;
+    label?: string;
+    onClick?: () => void;
+    onMouseDown?: (event: MouseEvent) => void;
+    onPointerEnter?: () => void;
+    onPointerLeave?: () => void;
+    'data-active'?: string;
+    'data-rail-link'?: string;
+  };
+
+  const Button = (props: MockButtonProps) => (
+    <button
+      type="button"
+      aria-label={props.label}
+      data-active={props['data-active']}
+      data-rail-link={props['data-rail-link']}
+      onClick={() => props.onClick?.()}
+      onMouseDown={(event) => props.onMouseDown?.(event)}
+      onPointerEnter={() => props.onPointerEnter?.()}
+      onPointerLeave={() => props.onPointerLeave?.()}
+    >
+      {props.children}
+    </button>
+  );
+
+  return { Button, cn: (...args: unknown[]) => args.filter(Boolean).join(' ') };
+});
+
+function link(id: string, label: string): SidebarItem {
+  return {
+    id,
+    label,
+    href: `/${id}`,
+    hotkey: 'i',
+    hotkeyToken: TOKENS.sidebar.goTo.inbox,
+  };
+}
+
+function unreadEmail(id: string): UnifiedNotification {
+  return {
+    id,
+    entity_id: `thread-${id}`,
+    entity_type: 'email_thread',
+    created_at: '2026-08-17T00:00:00.000Z',
+    done: false,
+    notification_event_type: 'test',
+    notification_metadata: {} as UnifiedNotification['notification_metadata'],
+    sent: true,
+    updated_at: '2026-08-17T00:00:00.000Z',
+    viewed_at: null,
+  };
+}
+
+function renderRail() {
+  const onExpand = vi.fn();
+  const onPeekChange = vi.fn();
+  const rendered = render(() => (
+    <SkinnySidebarRail onExpand={onExpand} onPeekChange={onPeekChange} />
+  ));
+  return { ...rendered, onExpand, onPeekChange };
+}
+
+describe('SkinnySidebarRail', () => {
+  beforeEach(() => {
+    mocks.links = [];
+    mocks.notifications = [];
+    mocks.pathname = '/';
+    mocks.openWithSplit.mockClear();
+  });
+
+  it('renders one icon per destination, clustered', () => {
+    mocks.links = [
+      link('inbox', 'Inbox'),
+      link('mail', 'Email'),
+      link('calendar', 'Calendar'),
+      link('channels', 'Channels'),
+    ];
+
+    const { container } = renderRail();
+
+    const groups = [...container.querySelectorAll('[data-rail-group]')].map(
+      (group) => [
+        group.getAttribute('data-rail-group'),
+        [...group.querySelectorAll('[data-rail-link]')].map((item) =>
+          item.getAttribute('data-rail-link')
+        ),
+      ]
+    );
+
+    expect(groups).toEqual([
+      ['overview', ['inbox']],
+      ['comms', ['mail', 'calendar']],
+      ['rooms', ['channels']],
+    ]);
+  });
+
+  it('badges a destination with its unread count', () => {
+    mocks.links = [link('mail', 'Email'), link('calendar', 'Calendar')];
+    mocks.notifications = [unreadEmail('a'), unreadEmail('b')];
+
+    const { container } = renderRail();
+
+    const mail = container.querySelector('[data-rail-link="mail"]');
+    const calendar = container.querySelector('[data-rail-link="calendar"]');
+    expect(mail?.textContent).toBe('2');
+    expect(calendar?.textContent).toBe('');
+  });
+
+  it('marks the destination the current path is showing', () => {
+    mocks.links = [link('mail', 'Email'), link('calendar', 'Calendar')];
+    mocks.pathname = '/app/mail';
+
+    const { container } = renderRail();
+
+    const hasActiveAttribute = (linkId: string) =>
+      container
+        .querySelector(`[data-rail-link="${linkId}"]`)
+        ?.hasAttribute('data-active');
+
+    expect(hasActiveAttribute('mail')).toBe(true);
+    expect(hasActiveAttribute('calendar')).toBe(false);
+  });
+
+  it('opens a destination on click', () => {
+    mocks.links = [link('mail', 'Email')];
+
+    const { container } = renderRail();
+    const mail = container.querySelector('[data-rail-link="mail"]');
+    if (!mail) throw new Error('missing mail rail link');
+    fireEvent.mouseDown(mail);
+
+    expect(mocks.openWithSplit).toHaveBeenCalledWith(
+      { type: 'component', id: 'mail', params: undefined },
+      expect.objectContaining({ referredFrom: 'sidebar' })
+    );
+  });
+
+  it('expands the full sidebar from the logo, and peeks it on hover', () => {
+    mocks.links = [link('mail', 'Email')];
+
+    const { getByLabelText, onExpand, onPeekChange } = renderRail();
+    const logo = getByLabelText('Expand sidebar');
+
+    fireEvent.pointerEnter(logo);
+    expect(onPeekChange).toHaveBeenCalledWith(true);
+    fireEvent.pointerLeave(logo);
+    expect(onPeekChange).toHaveBeenCalledWith(false);
+
+    fireEvent.click(logo);
+    expect(onExpand).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/app/app-sidebar/skinny-rail.test.tsx
+++ b/apps/web/src/components/app/app-sidebar/skinny-rail.test.tsx
@@ -159,16 +159,30 @@ describe('SkinnySidebarRail', () => {
     ]);
   });
 
+  it('labels every destination, Slack-style', () => {
+    mocks.links = [link('mail', 'Email'), link('calendar', 'Calendar')];
+
+    const { container } = renderRail();
+
+    expect(
+      [...container.querySelectorAll('[data-rail-link]')].map(
+        (item) => item.textContent
+      )
+    ).toEqual(['Email', 'Calendar']);
+  });
+
   it('badges a destination with its unread count', () => {
     mocks.links = [link('mail', 'Email'), link('calendar', 'Calendar')];
     mocks.notifications = [unreadEmail('a'), unreadEmail('b')];
 
     const { container } = renderRail();
 
-    const mail = container.querySelector('[data-rail-link="mail"]');
-    const calendar = container.querySelector('[data-rail-link="calendar"]');
-    expect(mail?.textContent).toBe('2');
-    expect(calendar?.textContent).toBe('');
+    const badgeOf = (linkId: string) =>
+      container.querySelector(`[data-rail-link="${linkId}"] [role="status"]`)
+        ?.textContent;
+
+    expect(badgeOf('mail')).toBe('2');
+    expect(badgeOf('calendar')).toBeUndefined();
   });
 
   it('marks the destination the current path is showing', () => {

--- a/apps/web/src/components/app/app-sidebar/skinny-rail.tsx
+++ b/apps/web/src/components/app/app-sidebar/skinny-rail.tsx
@@ -1,26 +1,25 @@
 import { useAnalytics } from '@app/lib/analytics/analytics-context';
 import { globalSplitManager } from '@app/signal/splitLayout';
-import { useGlobalNotificationSource } from '@components/app/GlobalAppState';
 import { useSplitLayout } from '@components/app/split-layout/layout';
 import {
   type SettingsTab,
   useSettingsState,
 } from '@core/constant/SettingsState';
 import { useSettingsTabAvailable } from '@core/constant/settingsTabsConfig';
-import { TOKENS } from '@core/hotkey/tokens';
+import { type HotkeyToken, TOKENS } from '@core/hotkey/tokens';
 import LogoIcon from '@icon/macro-logo.svg';
 import GearIcon from '@phosphor/gear.svg';
 import { useLocation } from '@solidjs/router';
-import { Button, cn } from '@ui';
-import { createMemo, For, Show, Suspense } from 'solid-js';
-import { Dynamic } from 'solid-js/web';
+import { Button } from '@ui';
+import { createMemo } from 'solid-js';
 import { type SidebarItem, useSidebarLinks } from './links';
 import { isSidebarViewActive, navigateToSidebarView } from './navigation';
+import { railDigitBindings, railGroups } from './rail-groups';
 import {
-  formatRailUnreadCount,
-  railGroups,
-  unreadCountsByLinkId,
-} from './rail-groups';
+  RailDestination,
+  RailDestinations,
+  useRailUnreadCounts,
+} from './rail-parts';
 
 type SkinnySidebarRailProps = {
   /** Pin the full sidebar open — the rail's logo click. */
@@ -30,33 +29,50 @@ type SkinnySidebarRailProps = {
 };
 
 /**
- * The collapsed sidebar's visible surface: a 30px rail of destination icons,
- * clustered so related views (Email + Calendar, Channels + Calls, …) read as
- * one block, each carrying its unread count. Desktop only — `Layout` renders it
- * in place of the wide sidebar while the sidebar state is `slim`, and touch
- * devices get the mobile dock instead.
+ * The collapsed sidebar's visible surface: a narrow rail of destination icons
+ * with their labels underneath, clustered so related views (Email + Calendar,
+ * Channels + Calls, …) read as one block, each carrying its unread count.
+ * Desktop only — `Layout` renders it in place of the wide sidebar while the
+ * sidebar state is `slim`, and touch devices get the mobile dock instead.
  *
- * Labels live in the tooltips (with their `g`-leader shortcut), which is the
- * only place they fit at this width.
+ * Clicking a destination opens it in the active split, like the wide sidebar's
+ * rows; the right-hand `SplitNavRail` is the same set of destinations opening
+ * into a narrow side split instead.
  */
 export const SkinnySidebarRail = (props: SkinnySidebarRailProps) => {
   const links = useSidebarLinks();
-  const notificationSource = useGlobalNotificationSource();
+  const unreadCounts = useRailUnreadCounts();
+  const analytics = useAnalytics();
+  const layout = useSplitLayout();
+  const location = useLocation();
 
   const groups = createMemo(() => railGroups(links()));
-  const unreadCounts = createMemo(() =>
-    unreadCountsByLinkId(notificationSource.notifications())
-  );
+  // Which single-key jump, if any, lands on each destination.
+  const digitTokens = createMemo(() => {
+    const tokens = new Map<string, HotkeyToken>();
+    for (const binding of railDigitBindings(groups())) {
+      tokens.set(binding.link.id, binding.token);
+    }
+    return tokens;
+  });
+
+  const goToHotkey = (link: SidebarItem): HotkeyToken | HotkeyToken[] => {
+    const digit = digitTokens().get(link.id);
+    if (digit) return digit;
+    return link.standaloneHotkey
+      ? link.hotkeyToken
+      : [TOKENS.sidebar.goToLeader, link.hotkeyToken];
+  };
 
   return (
     <nav
       aria-label="Navigation rail"
       data-ui="skinny-sidebar-rail"
-      class="flex h-full w-[30px] shrink-0 flex-col items-center gap-2 overflow-hidden border-r border-edge-muted bg-surface py-2"
+      class="flex h-full w-16 shrink-0 flex-col items-center gap-1 overflow-hidden border-r border-edge-muted bg-surface py-2"
     >
       <Button
         aria-label="Expand sidebar"
-        class="size-6 shrink-0 rounded-md p-0 text-accent [&_svg]:size-4"
+        class="size-8 shrink-0 rounded-lg p-0 text-accent [&_svg]:size-4"
         label="Expand sidebar"
         hotkey={TOKENS.global.toggleSidebar}
         tooltipPlacement="right"
@@ -68,101 +84,41 @@ export const SkinnySidebarRail = (props: SkinnySidebarRailProps) => {
         <LogoIcon />
       </Button>
 
-      <div class="flex min-h-0 flex-1 flex-col items-center gap-2 overflow-y-auto">
-        <For each={groups()}>
-          {(group) => (
-            <ul
-              data-rail-group={group.id}
-              class="flex shrink-0 flex-col items-center gap-0.5 rounded-lg bg-ink/3 p-0.5"
-            >
-              <For each={group.items}>
-                {(link) => (
-                  <li class="flex items-center justify-center">
-                    <RailLink
-                      link={link}
-                      unreadCount={() => unreadCounts().get(link.id)}
-                    />
-                  </li>
-                )}
-              </For>
-            </ul>
-          )}
-        </For>
-      </div>
+      <RailDestinations
+        groups={groups()}
+        destination={(link) => (
+          <RailDestination
+            link={link}
+            showLabel
+            action="Go to"
+            hotkey={goToHotkey(link)}
+            unreadCount={() => unreadCounts().get(link.id)}
+            active={() =>
+              isSidebarViewActive(link.id, link.params, location.pathname)
+            }
+            onOpen={(event) => {
+              analytics.track('sidebar_click', {
+                view: link.id,
+                surface: 'rail',
+              });
+              navigateToSidebarView({
+                viewId: link.id,
+                params: link.params,
+                shiftKey: event.shiftKey,
+                activeSplit: globalSplitManager()?.activeSplit(),
+                openWithSplit: layout.openWithSplit,
+                referredFrom: 'sidebar',
+              });
+              globalSplitManager()?.returnFocus();
+            }}
+          />
+        )}
+      />
 
       <RailSettingsButton />
     </nav>
   );
 };
-
-const RailLink = (props: {
-  link: SidebarItem;
-  /** Read lazily: the notification query behind it can suspend. */
-  unreadCount: () => number | undefined;
-}) => {
-  const analytics = useAnalytics();
-  const layout = useSplitLayout();
-  const location = useLocation();
-
-  const link = () => props.link;
-  const isActive = () =>
-    isSidebarViewActive(link().id, link().params, location.pathname);
-
-  return (
-    <Button
-      aria-label={`Go to ${link().label}`}
-      data-rail-link={link().id}
-      data-active={isActive() ? '' : undefined}
-      class={cn(
-        'relative size-6 rounded-md p-0 [&_svg]:size-3.5',
-        isActive() && 'bg-ink/10 text-ink'
-      )}
-      label={`Go to ${link().label}`}
-      hotkey={
-        link().standaloneHotkey
-          ? link().hotkeyToken
-          : [TOKENS.sidebar.goToLeader, link().hotkeyToken]
-      }
-      tooltipPlacement="right"
-      noTouchResize
-      onMouseDown={(e: MouseEvent) => {
-        if (e.button !== 0) return;
-        e.preventDefault();
-        analytics.track('sidebar_click', { view: link().id, surface: 'rail' });
-        navigateToSidebarView({
-          viewId: link().id,
-          params: link().params,
-          shiftKey: e.shiftKey,
-          activeSplit: globalSplitManager()?.activeSplit(),
-          openWithSplit: layout.openWithSplit,
-          referredFrom: 'sidebar',
-        });
-        globalSplitManager()?.returnFocus();
-      }}
-    >
-      <Show when={link().icon}>{(icon) => <Dynamic component={icon()} />}</Show>
-      {/* Own boundary: an unread count that suspends must not blank the icon
-          it sits on, let alone the rest of the rail. */}
-      <Suspense>
-        <RailUnreadBadge count={props.unreadCount} />
-      </Suspense>
-    </Button>
-  );
-};
-
-const RailUnreadBadge = (props: { count: () => number | undefined }) => (
-  <Show when={props.count()}>
-    {(count) => (
-      <span
-        role="status"
-        aria-label={`${count()} unread`}
-        class="absolute -top-0.5 -right-0.5 flex h-3 min-w-3 items-center justify-center rounded-full bg-accent px-0.5 text-[8px] leading-none font-medium text-surface ring-1 ring-surface"
-      >
-        {formatRailUnreadCount(count())}
-      </span>
-    )}
-  </Show>
-);
 
 const RailSettingsButton = () => {
   const { openSettings, selectTab, settingsOpen } = useSettingsState();
@@ -180,7 +136,7 @@ const RailSettingsButton = () => {
   return (
     <Button
       aria-label="Settings"
-      class="size-6 shrink-0 rounded-md p-0 [&_svg]:size-3.5"
+      class="size-8 shrink-0 rounded-lg p-0 [&_svg]:size-4"
       label="Settings"
       hotkey={TOKENS.global.toggleSettings}
       tooltipPlacement="right"

--- a/apps/web/src/components/app/app-sidebar/skinny-rail.tsx
+++ b/apps/web/src/components/app/app-sidebar/skinny-rail.tsx
@@ -1,0 +1,193 @@
+import { useAnalytics } from '@app/lib/analytics/analytics-context';
+import { globalSplitManager } from '@app/signal/splitLayout';
+import { useGlobalNotificationSource } from '@components/app/GlobalAppState';
+import { useSplitLayout } from '@components/app/split-layout/layout';
+import {
+  type SettingsTab,
+  useSettingsState,
+} from '@core/constant/SettingsState';
+import { useSettingsTabAvailable } from '@core/constant/settingsTabsConfig';
+import { TOKENS } from '@core/hotkey/tokens';
+import LogoIcon from '@icon/macro-logo.svg';
+import GearIcon from '@phosphor/gear.svg';
+import { useLocation } from '@solidjs/router';
+import { Button, cn } from '@ui';
+import { createMemo, For, Show, Suspense } from 'solid-js';
+import { Dynamic } from 'solid-js/web';
+import { type SidebarItem, useSidebarLinks } from './links';
+import { isSidebarViewActive, navigateToSidebarView } from './navigation';
+import {
+  formatRailUnreadCount,
+  railGroups,
+  unreadCountsByLinkId,
+} from './rail-groups';
+
+type SkinnySidebarRailProps = {
+  /** Pin the full sidebar open — the rail's logo click. */
+  onExpand: () => void;
+  /** Peek the full sidebar as a hover overlay while the logo is hovered. */
+  onPeekChange: (open: boolean) => void;
+};
+
+/**
+ * The collapsed sidebar's visible surface: a 30px rail of destination icons,
+ * clustered so related views (Email + Calendar, Channels + Calls, …) read as
+ * one block, each carrying its unread count. Desktop only — `Layout` renders it
+ * in place of the wide sidebar while the sidebar state is `slim`, and touch
+ * devices get the mobile dock instead.
+ *
+ * Labels live in the tooltips (with their `g`-leader shortcut), which is the
+ * only place they fit at this width.
+ */
+export const SkinnySidebarRail = (props: SkinnySidebarRailProps) => {
+  const links = useSidebarLinks();
+  const notificationSource = useGlobalNotificationSource();
+
+  const groups = createMemo(() => railGroups(links()));
+  const unreadCounts = createMemo(() =>
+    unreadCountsByLinkId(notificationSource.notifications())
+  );
+
+  return (
+    <nav
+      aria-label="Navigation rail"
+      data-ui="skinny-sidebar-rail"
+      class="flex h-full w-[30px] shrink-0 flex-col items-center gap-2 overflow-hidden border-r border-edge-muted bg-surface py-2"
+    >
+      <Button
+        aria-label="Expand sidebar"
+        class="size-6 shrink-0 rounded-md p-0 text-accent [&_svg]:size-4"
+        label="Expand sidebar"
+        hotkey={TOKENS.global.toggleSidebar}
+        tooltipPlacement="right"
+        noTouchResize
+        onClick={() => props.onExpand()}
+        onPointerEnter={() => props.onPeekChange(true)}
+        onPointerLeave={() => props.onPeekChange(false)}
+      >
+        <LogoIcon />
+      </Button>
+
+      <div class="flex min-h-0 flex-1 flex-col items-center gap-2 overflow-y-auto">
+        <For each={groups()}>
+          {(group) => (
+            <ul
+              data-rail-group={group.id}
+              class="flex shrink-0 flex-col items-center gap-0.5 rounded-lg bg-ink/3 p-0.5"
+            >
+              <For each={group.items}>
+                {(link) => (
+                  <li class="flex items-center justify-center">
+                    <RailLink
+                      link={link}
+                      unreadCount={() => unreadCounts().get(link.id)}
+                    />
+                  </li>
+                )}
+              </For>
+            </ul>
+          )}
+        </For>
+      </div>
+
+      <RailSettingsButton />
+    </nav>
+  );
+};
+
+const RailLink = (props: {
+  link: SidebarItem;
+  /** Read lazily: the notification query behind it can suspend. */
+  unreadCount: () => number | undefined;
+}) => {
+  const analytics = useAnalytics();
+  const layout = useSplitLayout();
+  const location = useLocation();
+
+  const link = () => props.link;
+  const isActive = () =>
+    isSidebarViewActive(link().id, link().params, location.pathname);
+
+  return (
+    <Button
+      aria-label={`Go to ${link().label}`}
+      data-rail-link={link().id}
+      data-active={isActive() ? '' : undefined}
+      class={cn(
+        'relative size-6 rounded-md p-0 [&_svg]:size-3.5',
+        isActive() && 'bg-ink/10 text-ink'
+      )}
+      label={`Go to ${link().label}`}
+      hotkey={
+        link().standaloneHotkey
+          ? link().hotkeyToken
+          : [TOKENS.sidebar.goToLeader, link().hotkeyToken]
+      }
+      tooltipPlacement="right"
+      noTouchResize
+      onMouseDown={(e: MouseEvent) => {
+        if (e.button !== 0) return;
+        e.preventDefault();
+        analytics.track('sidebar_click', { view: link().id, surface: 'rail' });
+        navigateToSidebarView({
+          viewId: link().id,
+          params: link().params,
+          shiftKey: e.shiftKey,
+          activeSplit: globalSplitManager()?.activeSplit(),
+          openWithSplit: layout.openWithSplit,
+          referredFrom: 'sidebar',
+        });
+        globalSplitManager()?.returnFocus();
+      }}
+    >
+      <Show when={link().icon}>{(icon) => <Dynamic component={icon()} />}</Show>
+      {/* Own boundary: an unread count that suspends must not blank the icon
+          it sits on, let alone the rest of the rail. */}
+      <Suspense>
+        <RailUnreadBadge count={props.unreadCount} />
+      </Suspense>
+    </Button>
+  );
+};
+
+const RailUnreadBadge = (props: { count: () => number | undefined }) => (
+  <Show when={props.count()}>
+    {(count) => (
+      <span
+        role="status"
+        aria-label={`${count()} unread`}
+        class="absolute -top-0.5 -right-0.5 flex h-3 min-w-3 items-center justify-center rounded-full bg-accent px-0.5 text-[8px] leading-none font-medium text-surface ring-1 ring-surface"
+      >
+        {formatRailUnreadCount(count())}
+      </span>
+    )}
+  </Show>
+);
+
+const RailSettingsButton = () => {
+  const { openSettings, selectTab, settingsOpen } = useSettingsState();
+  const isTabAvailable = useSettingsTabAvailable();
+
+  const openSettingsTab = (tab: SettingsTab) => {
+    if (!isTabAvailable(tab)) return;
+    if (settingsOpen()) {
+      selectTab(tab);
+      return;
+    }
+    openSettings(tab);
+  };
+
+  return (
+    <Button
+      aria-label="Settings"
+      class="size-6 shrink-0 rounded-md p-0 [&_svg]:size-3.5"
+      label="Settings"
+      hotkey={TOKENS.global.toggleSettings}
+      tooltipPlacement="right"
+      noTouchResize
+      onClick={() => openSettingsTab('Account')}
+    >
+      <GearIcon />
+    </Button>
+  );
+};

--- a/apps/web/src/components/app/app-sidebar/split-rail.test.tsx
+++ b/apps/web/src/components/app/app-sidebar/split-rail.test.tsx
@@ -1,0 +1,168 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { TOKENS } from '@core/hotkey/tokens';
+import { fireEvent, render } from '@solidjs/testing-library';
+import type { JSX } from 'solid-js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SidebarItem } from './links';
+import { SplitNavRail } from './split-rail';
+
+const mocks = vi.hoisted(() => ({
+  links: [] as SidebarItem[],
+  /** Split ids the layout is currently laying out as side panels. */
+  sideSplitIds: new Set<string>(),
+  /** Content already open, by `type:id`, with the split id showing it. */
+  openSplits: new Map<string, string>(),
+  canFit: true,
+  close: vi.fn(),
+  createNewSplit: vi.fn(),
+  markSideSplit: vi.fn(),
+}));
+
+vi.mock('@app/lib/analytics/analytics-context', () => ({
+  useAnalytics: () => ({ track: vi.fn() }),
+}));
+
+vi.mock('@app/signal/splitLayout', () => ({
+  globalSplitManager: () => ({
+    getSplitByContent: (type: string, id: string) => {
+      const splitId = mocks.openSplits.get(`${type}:${id}`);
+      return splitId === undefined
+        ? undefined
+        : { id: splitId, close: mocks.close };
+    },
+    resizeContext: () => ({ canFit: () => mocks.canFit }),
+    createNewSplit: mocks.createNewSplit,
+  }),
+}));
+
+vi.mock('@components/app/split-layout/side-split-sizing', () => ({
+  SIDE_SPLIT_MIN_WIDTH: 250,
+  isSideSplit: (id: string) => mocks.sideSplitIds.has(id),
+  markSideSplit: mocks.markSideSplit,
+}));
+
+vi.mock('./links', () => ({
+  useSidebarLinks: () => () => mocks.links,
+}));
+
+vi.mock('./rail-parts', async (importOriginal) => {
+  const original = await importOriginal<typeof import('./rail-parts')>();
+  return { ...original, useRailUnreadCounts: () => () => new Map() };
+});
+
+vi.mock('@ui', () => {
+  type MockButtonProps = {
+    children?: JSX.Element;
+    label?: string;
+    onMouseDown?: (event: MouseEvent) => void;
+    'data-active'?: string;
+    'data-rail-link'?: string;
+  };
+
+  const Button = (props: MockButtonProps) => (
+    <button
+      type="button"
+      aria-label={props.label}
+      data-active={props['data-active']}
+      data-rail-link={props['data-rail-link']}
+      onMouseDown={(event) => props.onMouseDown?.(event)}
+    >
+      {props.children}
+    </button>
+  );
+
+  return { Button, cn: (...args: unknown[]) => args.filter(Boolean).join(' ') };
+});
+
+function link(id: string, label: string): SidebarItem {
+  return {
+    id,
+    label,
+    href: `/${id}`,
+    hotkey: 'i',
+    hotkeyToken: TOKENS.sidebar.goTo.inbox,
+  };
+}
+
+function clickDestination(container: HTMLElement, linkId: string) {
+  const target = container.querySelector(`[data-rail-link="${linkId}"]`);
+  if (!target) throw new Error(`missing rail link ${linkId}`);
+  fireEvent.mouseDown(target);
+}
+
+describe('SplitNavRail', () => {
+  beforeEach(() => {
+    mocks.links = [link('mail', 'Email'), link('calendar', 'Calendar')];
+    mocks.sideSplitIds = new Set();
+    mocks.openSplits = new Map();
+    mocks.canFit = true;
+    mocks.close.mockClear();
+    mocks.createNewSplit.mockClear().mockReturnValue({ id: 'split-new' });
+    mocks.markSideSplit.mockClear();
+  });
+
+  it('docks a destination as a side split', () => {
+    const { container } = render(() => <SplitNavRail />);
+    clickDestination(container, 'mail');
+
+    expect(mocks.createNewSplit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: { type: 'component', id: 'mail', params: undefined },
+        activate: true,
+        referredFrom: 'sidebar',
+      })
+    );
+    expect(mocks.markSideSplit).toHaveBeenCalledWith('split-new');
+  });
+
+  it('undocks a destination that is already docked', () => {
+    mocks.openSplits.set('component:mail', 'split-mail');
+    mocks.sideSplitIds.add('split-mail');
+
+    const { container } = render(() => <SplitNavRail />);
+    clickDestination(container, 'mail');
+
+    expect(mocks.close).toHaveBeenCalled();
+    expect(mocks.createNewSplit).not.toHaveBeenCalled();
+  });
+
+  it('marks a docked destination active', () => {
+    mocks.openSplits.set('component:mail', 'split-mail');
+    mocks.sideSplitIds.add('split-mail');
+
+    const { container } = render(() => <SplitNavRail />);
+
+    const isActive = (linkId: string) =>
+      container
+        .querySelector(`[data-rail-link="${linkId}"]`)
+        ?.hasAttribute('data-active');
+
+    expect(isActive('mail')).toBe(true);
+    expect(isActive('calendar')).toBe(false);
+  });
+
+  it('leaves a full-size split of the same view alone', () => {
+    // Open, but not as a side panel — docking must not close someone's
+    // full-size view, and the rail must not read as already docked.
+    mocks.openSplits.set('component:mail', 'split-mail');
+
+    const { container } = render(() => <SplitNavRail />);
+    clickDestination(container, 'mail');
+
+    expect(mocks.close).not.toHaveBeenCalled();
+    expect(mocks.createNewSplit).toHaveBeenCalled();
+  });
+
+  it('does nothing when the layout has no room for a side split', () => {
+    mocks.canFit = false;
+
+    const { container } = render(() => <SplitNavRail />);
+    clickDestination(container, 'mail');
+
+    expect(mocks.createNewSplit).not.toHaveBeenCalled();
+    expect(mocks.markSideSplit).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/app/app-sidebar/split-rail.tsx
+++ b/apps/web/src/components/app/app-sidebar/split-rail.tsx
@@ -1,0 +1,115 @@
+import { useAnalytics } from '@app/lib/analytics/analytics-context';
+import { globalSplitManager } from '@app/signal/splitLayout';
+import type { SplitManager } from '@components/app/split-layout/layoutManager';
+import {
+  isSideSplit,
+  markSideSplit,
+  SIDE_SPLIT_MIN_WIDTH,
+} from '@components/app/split-layout/side-split-sizing';
+import { TOKENS } from '@core/hotkey/tokens';
+import { createMemo } from 'solid-js';
+import { type SidebarItem, useSidebarLinks } from './links';
+import { sidebarContent } from './navigation';
+import { railGroups } from './rail-groups';
+import {
+  RailDestination,
+  RailDestinations,
+  useRailUnreadCounts,
+} from './rail-parts';
+
+/**
+ * The right-hand companion to {@link SkinnySidebarRail}: the same destinations,
+ * but a click docks one beside what you are already looking at instead of
+ * taking it over — a narrow side split (a fifth of the viewport, never under
+ * {@link SIDE_SPLIT_MIN_WIDTH}px), the way Google's suite rail works.
+ *
+ * A destination already docked toggles closed, so the rail reads as a set of
+ * panels you switch on and off. Desktop only, rendered by `Layout` alongside
+ * the left rail.
+ */
+export const SplitNavRail = () => {
+  const links = useSidebarLinks();
+  const unreadCounts = useRailUnreadCounts();
+  const analytics = useAnalytics();
+
+  const groups = createMemo(() => railGroups(links()));
+
+  return (
+    <nav
+      aria-label="Side panel rail"
+      data-ui="split-nav-rail"
+      class="flex h-full w-11 shrink-0 flex-col items-center gap-1 overflow-hidden border-l border-edge-muted bg-surface py-2"
+    >
+      <RailDestinations
+        groups={groups()}
+        destination={(link) => (
+          <RailDestination
+            link={link}
+            action="Open"
+            hotkey={
+              link.standaloneHotkey
+                ? link.hotkeyToken
+                : [TOKENS.sidebar.goToLeader, link.hotkeyToken]
+            }
+            unreadCount={() => unreadCounts().get(link.id)}
+            active={() => isDockedSideSplit(globalSplitManager(), link)}
+            onOpen={() => {
+              analytics.track('sidebar_click', {
+                view: link.id,
+                surface: 'split-rail',
+              });
+              toggleSideSplit(globalSplitManager(), link);
+            }}
+          />
+        )}
+      />
+    </nav>
+  );
+};
+
+/** The live side split showing this destination, if it is docked right now. */
+function dockedSideSplit(manager: SplitManager | undefined, link: SidebarItem) {
+  if (!manager) return undefined;
+  const content = sidebarContent(link.id, link.params);
+  const split = manager.getSplitByContent(content.type, content.id);
+  if (!split || !isSideSplit(split.id)) return undefined;
+  return split;
+}
+
+function isDockedSideSplit(
+  manager: SplitManager | undefined,
+  link: SidebarItem
+): boolean {
+  return dockedSideSplit(manager, link) !== undefined;
+}
+
+/**
+ * Dock a destination beside the current view, or undock it when it is already
+ * there. Does nothing when the zone has no room left for a side split — the
+ * gutters are the way out of that, not a surprise replacement of someone's
+ * open view.
+ */
+function toggleSideSplit(
+  manager: SplitManager | undefined,
+  link: SidebarItem
+): void {
+  if (!manager) return;
+
+  const docked = dockedSideSplit(manager, link);
+  if (docked) {
+    docked.close();
+    return;
+  }
+
+  const canFitSideSplit =
+    manager.resizeContext()?.canFit({ minSize: SIDE_SPLIT_MIN_WIDTH }) ?? true;
+  if (!canFitSideSplit) return;
+
+  const split = manager.createNewSplit({
+    content: sidebarContent(link.id, link.params),
+    activate: true,
+    allowDuplicate: true,
+    referredFrom: 'sidebar',
+  });
+  markSideSplit(split.id);
+}

--- a/apps/web/src/components/app/app-topbar.test.tsx
+++ b/apps/web/src/components/app/app-topbar.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { fireEvent, render } from '@solidjs/testing-library';
+import type { JSX } from 'solid-js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AppTopbar } from './app-topbar';
+
+const mocks = vi.hoisted(() => ({
+  activeSplit: undefined as
+    | {
+        canGoBack: () => boolean;
+        canGoForward: () => boolean;
+        goBack: () => void;
+        goForward: () => void;
+      }
+    | undefined,
+  goBack: vi.fn(),
+  goForward: vi.fn(),
+  openCommandMenu: vi.fn(),
+}));
+
+vi.mock('@app/features/command', () => ({
+  CommandState: { open: mocks.openCommandMenu },
+}));
+
+vi.mock('@app/signal/splitLayout', () => ({
+  globalSplitManager: () => ({ activeSplit: () => mocks.activeSplit }),
+}));
+
+vi.mock('@ui', () => {
+  type MockButtonProps = {
+    children?: JSX.Element;
+    disabled?: boolean;
+    label?: string;
+    'aria-label'?: string;
+    onClick?: () => void;
+  };
+
+  const Button = (props: MockButtonProps) => (
+    <button
+      type="button"
+      aria-label={props['aria-label'] ?? props.label}
+      disabled={props.disabled}
+      onClick={() => props.onClick?.()}
+    >
+      {props.children}
+    </button>
+  );
+
+  return { Button, Hotkey: () => <span>⌘K</span> };
+});
+
+function splitWithHistory(back: boolean, forward: boolean) {
+  return {
+    canGoBack: () => back,
+    canGoForward: () => forward,
+    goBack: mocks.goBack,
+    goForward: mocks.goForward,
+  };
+}
+
+describe('AppTopbar', () => {
+  beforeEach(() => {
+    mocks.activeSplit = splitWithHistory(true, true);
+    mocks.goBack.mockClear();
+    mocks.goForward.mockClear();
+    mocks.openCommandMenu.mockClear();
+  });
+
+  it('navigates the active split’s history', () => {
+    const { getByLabelText } = render(() => <AppTopbar />);
+
+    fireEvent.click(getByLabelText('Back'));
+    expect(mocks.goBack).toHaveBeenCalled();
+
+    fireEvent.click(getByLabelText('Forward'));
+    expect(mocks.goForward).toHaveBeenCalled();
+  });
+
+  it('disables a direction the active split cannot go', () => {
+    mocks.activeSplit = splitWithHistory(true, false);
+
+    const { getByLabelText } = render(() => <AppTopbar />);
+
+    expect((getByLabelText('Back') as HTMLButtonElement).disabled).toBe(false);
+    expect((getByLabelText('Forward') as HTMLButtonElement).disabled).toBe(
+      true
+    );
+  });
+
+  it('disables both directions with no active split', () => {
+    mocks.activeSplit = undefined;
+
+    const { getByLabelText } = render(() => <AppTopbar />);
+
+    expect((getByLabelText('Back') as HTMLButtonElement).disabled).toBe(true);
+    expect((getByLabelText('Forward') as HTMLButtonElement).disabled).toBe(
+      true
+    );
+  });
+
+  it('opens the command menu from the search field', () => {
+    const { getByLabelText } = render(() => <AppTopbar />);
+
+    fireEvent.click(getByLabelText('Search Macro'));
+    expect(mocks.openCommandMenu).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/app/app-topbar.tsx
+++ b/apps/web/src/components/app/app-topbar.tsx
@@ -1,0 +1,72 @@
+import { CommandState } from '@app/features/command';
+import { globalSplitManager } from '@app/signal/splitLayout';
+import { TOKENS } from '@core/hotkey/tokens';
+import ArrowLeftIcon from '@phosphor/arrow-left.svg';
+import ArrowRightIcon from '@phosphor/arrow-right.svg';
+import MagnifyingGlassIcon from '@phosphor/magnifying-glass.svg';
+import { Button, Hotkey } from '@ui';
+
+/**
+ * The window-level top bar: history navigation for whatever split is active,
+ * and one always-visible search field that opens the command menu — the same
+ * shape as Slack's. Desktop only; `Layout` renders it above the nav rails and
+ * the splits, and touch devices keep their own per-view chrome.
+ *
+ * Back/forward act on the active split, which is what the per-split header's
+ * own carets do — this is the same navigation reachable without hunting for
+ * the right split's header.
+ */
+export const AppTopbar = () => {
+  const activeSplit = () => globalSplitManager()?.activeSplit();
+
+  return (
+    <header
+      data-ui="app-topbar"
+      class="shrink-0 border-b border-edge-muted bg-surface pt-(--safe-top)"
+    >
+      <div class="flex h-9 items-center gap-2 px-2">
+        <div class="flex flex-1 items-center gap-0.5">
+          <Button
+            aria-label="Back"
+            class="size-7 rounded-md p-0 [&_svg]:size-4"
+            label="Back"
+            tooltipPlacement="bottom"
+            disabled={!activeSplit()?.canGoBack()}
+            onClick={() => activeSplit()?.goBack()}
+          >
+            <ArrowLeftIcon />
+          </Button>
+          <Button
+            aria-label="Forward"
+            class="size-7 rounded-md p-0 [&_svg]:size-4"
+            label="Forward"
+            tooltipPlacement="bottom"
+            disabled={!activeSplit()?.canGoForward()}
+            onClick={() => activeSplit()?.goForward()}
+          >
+            <ArrowRightIcon />
+          </Button>
+        </div>
+
+        {/* A field, not a tooltip'd icon: the shortcut is rendered inside it. */}
+        <Button
+          aria-label="Search Macro"
+          variant="base"
+          class="h-7 w-full max-w-xl justify-start gap-2 rounded-lg px-2 text-xs font-normal text-ink-muted [&_svg]:size-4"
+          onClick={() => CommandState.open()}
+        >
+          <MagnifyingGlassIcon class="shrink-0" />
+          <span class="truncate">Search Macro</span>
+          <Hotkey
+            token={TOKENS.global.commandMenu}
+            theme="subtle"
+            class="ml-auto"
+          />
+        </Button>
+
+        {/* Balances the history controls so the search field stays centered. */}
+        <div class="flex-1" aria-hidden="true" />
+      </div>
+    </header>
+  );
+};

--- a/apps/web/src/components/app/split-layout/SplitLayout.tsx
+++ b/apps/web/src/components/app/split-layout/SplitLayout.tsx
@@ -38,6 +38,12 @@ import {
   loadRestorablePreviewLayout,
   PREVIEW_QUERY_PARAM,
 } from './previewPersistence';
+import {
+  isSideSplit,
+  releaseSideSplit,
+  SIDE_SPLIT_MIN_WIDTH,
+  sideSplitPreferredWidth,
+} from './side-split-sizing';
 import { splitMinWidthForContent } from './splitContentSizing';
 import { createSplitFocusTracker } from './splitFocusTracker';
 
@@ -130,47 +136,64 @@ export function SplitLayoutContainer(props: SplitLayoutContainerProps) {
               captureResizeCtx={splitManager.setResizeContext}
             >
               <For each={ids()}>
-                {(id, index) => (
-                  <Show when={splitManager.getSplit(id)}>
-                    {(handle) => (
-                      <Suspense>
-                        <Resize.Panel
-                          id={id}
-                          minSize={splitMinWidthForContent(handle().content(), {
-                            isPreviewController: handle().isControllerSplit(),
-                          })}
-                          // A Preview Pair is one layout unit: its two splits
-                          // share the space a single split would get. Both
-                          // members key their group by the Controller's id.
-                          shareGroup={
-                            splitManager.viewerOf(id) !== undefined
-                              ? id
-                              : splitManager.controllerOf(id)
-                          }
-                          // Automatic redistribution targets an engaged
-                          // Controller at its configured preferred width.
-                          // This is not a hard max: the gutter can still be
-                          // dragged past it.
-                          redistributionPreferredSize={splitManager.previewControllerWidth(
-                            id,
-                            viewportSize.width
-                          )}
-                          index={index()}
-                        >
-                          <SplitPanel
-                            split={splits()[index()]!}
-                            handle={handle()}
-                            active={activeSplitSelector(id)}
-                            setPanelRef={(panelRef) =>
-                              panelRefs.set(id, panelRef)
+                {(id, index) => {
+                  // A side split's narrow sizing is keyed by split id, so it
+                  // has to be released when the split leaves the layout.
+                  onCleanup(() => releaseSideSplit(id));
+
+                  return (
+                    <Show when={splitManager.getSplit(id)}>
+                      {(handle) => (
+                        <Suspense>
+                          <Resize.Panel
+                            id={id}
+                            minSize={
+                              isSideSplit(id)
+                                ? SIDE_SPLIT_MIN_WIDTH
+                                : splitMinWidthForContent(handle().content(), {
+                                    isPreviewController:
+                                      handle().isControllerSplit(),
+                                  })
+                            }
+                            // A Preview Pair is one layout unit: its two splits
+                            // share the space a single split would get. Both
+                            // members key their group by the Controller's id.
+                            shareGroup={
+                              splitManager.viewerOf(id) !== undefined
+                                ? id
+                                : splitManager.controllerOf(id)
+                            }
+                            // Automatic redistribution targets an engaged
+                            // Controller at its configured preferred width.
+                            // This is not a hard max: the gutter can still be
+                            // dragged past it.
+                            redistributionPreferredSize={
+                              isSideSplit(id)
+                                ? sideSplitPreferredWidth(
+                                    viewportSize.width ?? 0
+                                  )
+                                : splitManager.previewControllerWidth(
+                                    id,
+                                    viewportSize.width
+                                  )
                             }
                             index={index()}
-                          />
-                        </Resize.Panel>
-                      </Suspense>
-                    )}
-                  </Show>
-                )}
+                          >
+                            <SplitPanel
+                              split={splits()[index()]!}
+                              handle={handle()}
+                              active={activeSplitSelector(id)}
+                              setPanelRef={(panelRef) =>
+                                panelRefs.set(id, panelRef)
+                              }
+                              index={index()}
+                            />
+                          </Resize.Panel>
+                        </Suspense>
+                      )}
+                    </Show>
+                  );
+                }}
               </For>
             </Resize.Zone>
           }

--- a/apps/web/src/components/app/split-layout/SplitLayout.tsx
+++ b/apps/web/src/components/app/split-layout/SplitLayout.tsx
@@ -1,15 +1,10 @@
 import { useGlobalBlockOrchestrator } from '@components/app/GlobalAppState';
-import {
-  isSidebarVisible,
-  useSidebarCollapse,
-} from '@components/app/sidebarVisibility';
 import { Resize } from '@core/component/Resize';
 import { isNativeMobilePlatform } from '@core/mobile/isNativeMobilePlatform';
 import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import { tabTitleSignal } from '@core/signal/tabTitle';
 import { useWindowSize } from '@solid-primitives/resize-observer';
 import { useLocation, useNavigate } from '@solidjs/router';
-import { cn } from '@ui';
 import {
   createEffect,
   createMemo,
@@ -47,6 +42,9 @@ import {
 import { splitMinWidthForContent } from './splitContentSizing';
 import { createSplitFocusTracker } from './splitFocusTracker';
 
+/** The hairline between two splits, and the whole of the gap between them. */
+const SPLIT_SEAM_WIDTH = 1;
+
 type SplitLayoutContainerProps = {
   pairs: string[];
   setManager: Setter<SplitManager | undefined>;
@@ -70,7 +68,6 @@ export function SplitLayoutContainer(props: SplitLayoutContainerProps) {
   );
   restorePreviewPairs(splitManager, initialLayout.previewPairs);
   const [, setTabTitle] = tabTitleSignal;
-  const sidebar = useSidebarCollapse();
 
   // Create the mobile swipe layout once on mobile devices.
   const mobileSwipeLayout: MobileSwipeLayout | undefined =
@@ -121,18 +118,17 @@ export function SplitLayoutContainer(props: SplitLayoutContainerProps) {
 
   return (
     <SplitLayoutContext.Provider value={{ manager: splitManager }}>
-      <div
-        class={cn('size-full p-2 touch:p-0', {
-          'pl-0': isSidebarVisible() && !sidebar.isCollapsed(),
-        })}
-      >
+      {/* No inset: the splits fill the frame and a hairline gutter is the only
+          thing between them. */}
+      <div class="size-full">
         <Show
           when={isNativeMobilePlatform() && mobileSwipeLayout}
           fallback={
             // Desktop: side-by-side resizable splits.
             <Resize.Zone
               direction="horizontal"
-              gutter={8}
+              gutter={SPLIT_SEAM_WIDTH}
+              seam
               captureResizeCtx={splitManager.setResizeContext}
             >
               <For each={ids()}>

--- a/apps/web/src/components/app/split-layout/components/SplitPanel.tsx
+++ b/apps/web/src/components/app/split-layout/components/SplitPanel.tsx
@@ -162,12 +162,6 @@ export function SplitPanel(props: SplitPanelProps) {
   // floating filter-pill strip (see MobileSoupViewTabs).
   const shouldHideSplitHeader = createMemo(() => isSoloSettings());
 
-  const splitFocusStyling = () =>
-    !isTouchDevice() &&
-    props.active &&
-    multipleSplits() &&
-    !props.handle.isSpotLight();
-
   const splitUnfocusedStyling = () =>
     !isTouchDevice() && !props.active && multipleSplits();
 
@@ -187,37 +181,6 @@ export function SplitPanel(props: SplitPanelProps) {
     );
   });
 
-  /**
-   * This split is a preview controller with its viewer tucked flush against
-   * its right edge: paint above the viewer so the controller's card and
-   * shadow read as being in front.
-   */
-  const hasTuckedViewer = createMemo(() => {
-    return (
-      !isTouchDevice() &&
-      !props.handle.isSpotLight() &&
-      props.handle.isControllerSplit()
-    );
-  });
-
-  /**
-   * When either member of a tucked Preview Pair is active, the active member
-   * stays solid and its partner is dashed. Both retain the standard edge color.
-   */
-  const previewPairFocusStyling = createMemo(() => {
-    const manager = globalSplitManager();
-    if (!manager || isTouchDevice() || props.handle.isSpotLight()) return false;
-
-    const peerId = props.handle.isControllerSplit()
-      ? manager.viewerOf(props.split.id)
-      : props.handle.isViewerSplit()
-        ? manager.controllerOf(props.split.id)
-        : undefined;
-    if (!peerId || manager.getSplit(peerId)?.isSpotLight()) return false;
-
-    const activeId = manager.activeSplitId();
-    return activeId === props.split.id || activeId === peerId;
-  });
   return (
     <SoupContextProvider soup={nextSoup}>
       <SplitPanelContext.Provider
@@ -294,25 +257,14 @@ export function SplitPanel(props: SplitPanelProps) {
             data-modal={props.handle.isSpotLight()}
             tabindex={-1}
           >
+            {/* Flat, edge-to-edge: no card frame, no shadow, no corners. The
+                zone's hairline gutter is the only thing between two splits, and
+                an unfocused split reads by its dimmer panel fill. */}
             <Panel
+              hideBorder
               class={cn(
-                'rounded-xl touch:rounded-none touch:after:hidden touch:border-0! bg-panel',
-                splitUnfocusedStyling() && 'split-panel-inactive',
-                {
-                  'shadow-sm shadow-drop-shadow/50': splitUnfocusedStyling(),
-                  'shadow-2xl shadow-drop-shadow': splitFocusStyling(),
-                  'border-solid!': previewPairFocusStyling() && props.active,
-                  'border-dashed!': previewPairFocusStyling() && !props.active,
-                  // Drawer look: both members square their seam corners. The
-                  // seam border always belongs to the Controller — the
-                  // Viewer's seam edge stays borderless so the line never
-                  // doubles, and keeping it on one fixed member regardless
-                  // of focus means switching focus can't shift layout by the
-                  // border width (the ! beats Surface's inline border
-                  // shorthand).
-                  'rounded-l-none border-l-0!': tuckedBehindController(),
-                  'rounded-r-none': hasTuckedViewer(),
-                }
+                'rounded-none bg-panel',
+                splitUnfocusedStyling() && 'split-panel-inactive'
               )}
               depth={isTouchDevice() ? 0 : 1}
             >

--- a/apps/web/src/components/app/split-layout/side-split-sizing.ts
+++ b/apps/web/src/components/app/split-layout/side-split-sizing.ts
@@ -1,0 +1,60 @@
+import { createRoot, createSignal } from 'solid-js';
+import type { SplitId } from './layoutManager';
+
+/**
+ * Hard minimum width for a side split, whatever its content would otherwise
+ * ask for (`DEFAULT_SPLIT_MIN_WIDTH` and friends).
+ */
+export const SIDE_SPLIT_MIN_WIDTH = 250;
+
+/** Share of the viewport a side split targets on automatic layout. */
+const SIDE_SPLIT_VIEWPORT_FRACTION = 0.2;
+
+/**
+ * Splits opened as a side panel (from the right-hand nav rail): they lay out
+ * narrow instead of taking an even share of the zone.
+ *
+ * Keyed by split id rather than by content because the same view can be open
+ * both full-size and as a side panel. `SplitLayout` releases the mark when the
+ * split leaves the layout.
+ */
+const [sideSplitIds, setSideSplitIds] = createRoot(() =>
+  createSignal<ReadonlySet<SplitId>>(new Set())
+);
+
+/** Lay this split out as a narrow side panel. */
+export function markSideSplit(id: SplitId): void {
+  setSideSplitIds((previous) => {
+    if (previous.has(id)) return previous;
+    const next = new Set(previous);
+    next.add(id);
+    return next;
+  });
+}
+
+/** Drop a side split's narrow sizing — called as the split leaves the layout. */
+export function releaseSideSplit(id: SplitId): void {
+  setSideSplitIds((previous) => {
+    if (!previous.has(id)) return previous;
+    const next = new Set(previous);
+    next.delete(id);
+    return next;
+  });
+}
+
+/** Whether this split lays out as a narrow side panel. Reactive. */
+export function isSideSplit(id: SplitId): boolean {
+  return sideSplitIds().has(id);
+}
+
+/**
+ * The width a side split targets on automatic layout: a fifth of the viewport,
+ * never below {@link SIDE_SPLIT_MIN_WIDTH}. Not a hard cap — dragging the
+ * gutter still wins until the next automatic solve.
+ */
+export function sideSplitPreferredWidth(viewportWidth: number): number {
+  return Math.max(
+    SIDE_SPLIT_MIN_WIDTH,
+    viewportWidth * SIDE_SPLIT_VIEWPORT_FRACTION
+  );
+}

--- a/apps/web/src/features/next-soup/soup-view/use-soup-view-hotkeys.ts
+++ b/apps/web/src/features/next-soup/soup-view/use-soup-view-hotkeys.ts
@@ -354,30 +354,9 @@ export const useSoupViewHotkeys = (options: UseSoupViewHotkeysOptions) => {
     return visibleViewTabs(view).map((t) => t.value);
   };
 
-  const switchToTabIndex = (index: number) => {
-    const view = currentView();
-    if (!view) return false;
-    const tabKeys = getTabKeys();
-    if (index < 0 || index >= tabKeys.length) return false;
-    applyTabPreset(view, tabKeys[index]!);
-    return true;
-  };
-
-  // 1-9 number keys to jump to specific tabs
-  const tabNumberKeys = ['1', '2', '3', '4', '5', '6', '7', '8', '9'] as const;
-  for (let i = 0; i < tabNumberKeys.length; i++) {
-    const index = i;
-    const key = tabNumberKeys[i]!;
-    registerHotkey({
-      hotkey: key,
-      scopeId,
-      hotkeyToken: TOKENS.soup.tabs[key],
-      description: `Switch to tab ${key}`,
-      condition: () => getTabKeys().length > index,
-      keyDownHandler: () => switchToTabIndex(index),
-      hide: true,
-    }).withGroup(group);
-  }
+  // The 1-9 keys are the global nav-rail jumps (see `GoToHotkeys`), which a
+  // per-view binding here would shadow inside every tabbed list — so tabs are
+  // reached with tab / shift+tab below, and by clicking.
 
   // fall back to the view's default tab if the soup view active tab accessor
   // returns undefined

--- a/apps/web/src/lib/core/component/Resize/Resize.tsx
+++ b/apps/web/src/lib/core/component/Resize/Resize.tsx
@@ -22,6 +22,9 @@ import type {
 
 export const ResizeZoneContext = createContext<ResizeZoneCtx>();
 
+/** How far a seam gutter's drag target spills past the hairline, each side. */
+const SEAM_GRAB_PX = 4;
+
 /**
  * Props for the Resize Zone component.
  *
@@ -31,6 +34,8 @@ export const ResizeZoneContext = createContext<ResizeZoneCtx>();
  * @property class - Optional class name for the Zone.
  * @property id - Optional id for the Zone.
  * @property resizable - Optional boolean indicating whether the zone is resizable. Defaults to true.
+ * @property seam - Paint a hairline between panels and widen the drag target
+ *   past it, for zones whose gutter is only as wide as the line itself.
  */
 type ZoneProps = {
   direction: 'horizontal' | 'vertical';
@@ -40,6 +45,7 @@ type ZoneProps = {
   id?: string;
   captureResizeCtx?: (ctx: ResizeZoneCtx) => void;
   resizable?: boolean;
+  seam?: boolean;
 };
 
 /**
@@ -181,6 +187,7 @@ function Zone(props: ParentProps<ZoneProps>) {
                     index={actualIndex}
                     nudge={solver.moveHandle}
                     root={root}
+                    seam={props.seam}
                   />
                 </Show>
               );
@@ -408,6 +415,8 @@ type GutterProps = {
   index: number;
   nudge: (index: number, amt: number) => void;
   root: () => HTMLDivElement | undefined;
+  /** Paint the resting hairline and widen the drag target past it. */
+  seam?: boolean;
 };
 
 function Gutter(props: GutterProps) {
@@ -520,6 +529,41 @@ function Gutter(props: GutterProps) {
       onPointerDown={onPointerDown}
       onKeyDown={onKeyDown}
     >
+      <Show when={props.seam}>
+        {/* A seam-width gutter is too thin to grab, so the target spills past
+            it on both sides. Pointer events here bubble to the gutter. */}
+        <div
+          class="absolute"
+          style={
+            ctx.direction() === 'horizontal'
+              ? {
+                  top: 0,
+                  bottom: 0,
+                  left: `-${SEAM_GRAB_PX}px`,
+                  right: `-${SEAM_GRAB_PX}px`,
+                }
+              : {
+                  left: 0,
+                  right: 0,
+                  top: `-${SEAM_GRAB_PX}px`,
+                  bottom: `-${SEAM_GRAB_PX}px`,
+                }
+          }
+        />
+        <div
+          class="bg-edge-muted absolute"
+          style={{
+            left: ctx.direction() === 'horizontal' ? '50%' : '0',
+            top: ctx.direction() === 'vertical' ? '50%' : '0',
+            width: ctx.direction() === 'horizontal' ? '1px' : '100%',
+            height: ctx.direction() === 'vertical' ? '1px' : '100%',
+            transform:
+              ctx.direction() === 'horizontal'
+                ? 'translateX(-50%)'
+                : 'translateY(-50%)',
+          }}
+        />
+      </Show>
       <div
         class={cn(
           'bg-accent absolute opacity-0 group-focus:opacity-100 rounded-[1px]',

--- a/apps/web/src/lib/core/hotkey/tokens.ts
+++ b/apps/web/src/lib/core/hotkey/tokens.ts
@@ -6,16 +6,6 @@ export const TOKENS = {
     sort: 'soup.sort',
     filter: 'soup.filter',
     tabs: {
-      '0': 'soup.tabs.0',
-      '1': 'soup.tabs.1',
-      '2': 'soup.tabs.2',
-      '3': 'soup.tabs.3',
-      '4': 'soup.tabs.4',
-      '5': 'soup.tabs.5',
-      '6': 'soup.tabs.6',
-      '7': 'soup.tabs.7',
-      '8': 'soup.tabs.8',
-      '9': 'soup.tabs.9',
       next: 'soup.tabs.next',
       prev: 'soup.tabs.prev',
     },
@@ -109,6 +99,19 @@ export const TOKENS = {
   // sidebar navigation
   sidebar: {
     goToLeader: 'sidebar.goToLeader',
+    /** Single-key jumps to the nav rail's destinations, in rail order. */
+    goToIndex: {
+      '0': 'sidebar.goToIndex.0',
+      '1': 'sidebar.goToIndex.1',
+      '2': 'sidebar.goToIndex.2',
+      '3': 'sidebar.goToIndex.3',
+      '4': 'sidebar.goToIndex.4',
+      '5': 'sidebar.goToIndex.5',
+      '6': 'sidebar.goToIndex.6',
+      '7': 'sidebar.goToIndex.7',
+      '8': 'sidebar.goToIndex.8',
+      '9': 'sidebar.goToIndex.9',
+    },
     goTo: {
       home: 'sidebar.goTo.home',
       gettingStarted: 'sidebar.goTo.gettingStarted',

--- a/apps/web/tests/e2e/helpers/local-app.ts
+++ b/apps/web/tests/e2e/helpers/local-app.ts
@@ -7,6 +7,17 @@ import {
 
 export const LOCAL_E2E = process.env.LOCAL_E2E === 'true';
 
+/**
+ * Pin the wide sidebar open before the app loads. Desktop sessions start on the
+ * skinny nav rail, where the wide sidebar's rows are not rendered — a test that
+ * drives those rows has to ask for them. Call before {@link gotoApp}.
+ */
+export async function useExpandedSidebar(page: Page) {
+  await page.addInitScript(() => {
+    window.localStorage.setItem('sidebar-state', '"expanded"');
+  });
+}
+
 export async function gotoApp(page: Page, path: `/${string}`) {
   await page.goto(`/app${path}`);
   await expect(page).not.toHaveURL(/\/app\/(welcome|signup|login)/);

--- a/apps/web/tests/e2e/local-search-state.spec.ts
+++ b/apps/web/tests/e2e/local-search-state.spec.ts
@@ -6,7 +6,7 @@ import {
   splitContainerSelector,
 } from '../../src/lib/core/dom-selectors';
 import { localE2ESeed } from './fixtures/local-e2e-seed';
-import { gotoApp, LOCAL_E2E } from './helpers/local-app';
+import { gotoApp, LOCAL_E2E, useExpandedSidebar } from './helpers/local-app';
 
 const SEARCH_BAR = '[data-soup-search]';
 const SEEDED_DOCUMENT = localE2ESeed.smoke.projectRoadmap;
@@ -37,6 +37,7 @@ test.describe('local search bar state', () => {
   test('restores the query after switching sidebar views and going back', async ({
     page,
   }) => {
+    await useExpandedSidebar(page);
     await gotoApp(page, '/component/search');
     await search(page, SEEDED_DOCUMENT.document_name);
 

--- a/apps/web/tests/e2e/local-sidebar.spec.ts
+++ b/apps/web/tests/e2e/local-sidebar.spec.ts
@@ -6,6 +6,7 @@ import {
   expectEntityInCurrentList,
   gotoApp,
   LOCAL_E2E,
+  useExpandedSidebar,
 } from './helpers/local-app';
 
 const SIDEBAR_LIST_VIEWS = [
@@ -42,6 +43,7 @@ test.describe('local sidebar views', () => {
 
   for (const view of SIDEBAR_LIST_VIEWS) {
     test(`opens ${view.label} from the sidebar`, async ({ page }) => {
+      await useExpandedSidebar(page);
       await gotoApp(
         page,
         view.id === 'documents' ? '/component/inbox' : '/component/documents'
@@ -77,6 +79,39 @@ test.describe('local sidebar views', () => {
       }
     });
   }
+});
+
+test.describe('local nav rail', () => {
+  test.describe.configure({ timeout: 60_000 });
+
+  // No `useExpandedSidebar`: the rail is what a fresh desktop session gets.
+  test('opens a view from the rail', async ({ page }) => {
+    await gotoApp(page, '/component/documents');
+
+    const link = railLink(page, 'mail');
+    await expect(link).toBeVisible({ timeout: 30_000 });
+    await link.click();
+
+    await expect(page).toHaveURL(/\/app\/component\/mail$/);
+    await expect(railLink(page, 'mail')).toHaveAttribute('data-active', '', {
+      timeout: 10_000,
+    });
+    await expectLoadedListView(page, 'mail');
+  });
+
+  test('docks a view beside the current one from the right-hand rail', async ({
+    page,
+  }) => {
+    await gotoApp(page, '/component/documents');
+
+    const link = splitRailLink(page, 'mail');
+    await expect(link).toBeVisible({ timeout: 30_000 });
+    await link.click();
+
+    // Docked alongside, not in place of: both views stay mounted.
+    await expectLoadedListView(page, 'mail');
+    await expectLoadedListView(page, 'documents');
+  });
 });
 
 async function openSidebarView(page: Page, id: string) {
@@ -117,4 +152,16 @@ async function expectListViewChrome(page: Page, tabs: readonly string[]) {
 
 function sidebarLink(page: Page, id: string): Locator {
   return page.locator(`nav [data-sidebar-link="${id}"]`).first();
+}
+
+function railLink(page: Page, id: string): Locator {
+  return page
+    .locator(`[data-ui="skinny-sidebar-rail"] [data-rail-link="${id}"]`)
+    .first();
+}
+
+function splitRailLink(page: Page, id: string): Locator {
+  return page
+    .locator(`[data-ui="split-nav-rail"] [data-rail-link="${id}"]`)
+    .first();
 }


### PR DESCRIPTION
Users are telling us the sidebar is confusing, so the app's navigation becomes two always-visible rails plus a window-level top bar, and the splits behind them go flat.

Before, collapsing the sidebar left nothing but an invisible 8px hover strip at the window edge — the only always-visible nav was the wide 220px sidebar.

## Left rail (the collapsed sidebar)

- **64px, Slack-width**: icon plus its label underneath, clusters separated by a hairline.
- **Grouped destinations** so related views read as one block:
  - overviews: Home, Getting Started, Inbox, Recent, Activity
  - **Email + Calendar**
  - Channels + Calls
  - Files + Tasks
  - Customers + Agents
  - A destination no group claims still renders, in a trailing group, so adding a sidebar link can't silently drop it from the rail.
- **Unread badges** per destination, from the notification source by entity type (`email_thread` → Email, `calendar_event` → Calendar, `channel` → Channels, …); Inbox aggregates every unread. Capped at `99+`. Each badge sits in its own `Suspense` boundary — a suspending count must not blank the icon it sits on.
- **Hover-to-peek lives on the logo**, not the whole edge: on the full rail it would yank the overlay open over the icon you were aiming at. Click the logo to pin the wide sidebar; `cmd+.` and the split-header toggle are unchanged.
- Tooltips carry the label and the shortcut; icon-only buttons carry explicit `aria-label`s.

## Top bar

Back/forward for the active split, and a persistent search field that opens the command menu (⌘K) — the same shape as Slack's. Desktop only, spanning above the rails and the splits.

## Digit jumps (`0`–`9`)

`0` opens the rail's first destination and the keys increment from there, following the rail's own order so feature-gated destinations can't desync the mapping. Registered globally, skipped while an input or editor has focus, hidden from the command menu (each duplicates a listed `g`-leader command) and surfaced in the rail tooltips instead.

**Conflict this resolves, worth a look:** `1`-`9` were already bound inside every tabbed list view (mail's Important/Calendar/Other, inbox, …) to switch tabs. Those bindings were hidden from the command menu, and they sat in a child hotkey scope, so they'd have shadowed the new global jumps exactly where people spend their time — the two can't coexist. I removed them; `tab` / `shift+tab` (already the discoverable bindings) and clicking still switch tabs. Say the word if you'd rather keep tab digits and move nav to `opt+digit`.

## Right-hand split rail

The same destinations, but a click **docks** one beside what you're already looking at instead of taking it over — a side split at a fifth of the viewport, never under 250px, the way Google's suite rail works. Clicking a destination that's already docked undocks it; a full-size split of the same view is left alone. When the zone has no room for another panel the click is a no-op rather than a surprise replacement.

Side splits are marked by split id (`side-split-sizing.ts`) and honored by `SplitLayout` through the resize solver's existing per-panel minimum and redistribution preference, so the layout engine itself is untouched. Two consequences worth reviewing: a docked split settles from an even share to its narrow width on the frame after it opens, and at ~1280px viewports 20% lands near 256px — under the 300px floor `splitContentSizing.ts` documents for list views ("as low as we can go without rethinking the layout"). Raising the floor to 300 is a one-line change if the cramped list bothers you more than the width does.

## Flat splits

The splits were floating cards: an 8px inset around the zone, an 8px gutter between panels, each panel rounded, bordered and drop-shadowed. Now they fill the frame edge to edge with a **single hairline** between them, and no line at all when there's only one split.

- `Resize.Zone` takes an opt-in `seam` flag: the gutter paints a resting 1px line and its drag target spills 4px past the line on each side, so a gutter only as wide as the seam is still grabbable. The side panel and the internal demo keep their own gutters untouched.
- `SplitPanel` loses its corners, border and shadows. An unfocused split still reads by its dimmer panel fill (`split-panel-inactive`) — which is now the only focus cue, since the preview pair's solid/dashed border cue went with the borders. Worth a look in the live app: if two splits need a stronger "which one has focus" signal, that's the place to add it.

## Product call worth a look

Desktop sessions now **start** on the rail (`sidebarState` default `expanded` → `slim`). Anyone with a stored preference keeps it, and one click on the logo pins the wide sidebar back. One-line revert in `Layout.tsx` if you'd rather ship it opt-in.

## Refactor riding along

`sidebar.tsx` was 2.2k lines and held the link catalog plus the navigate/active-view helpers as module-private code, with **two copies** of the same flag-gated link memo. Extracted so every nav surface shares one source of destinations:

- `links.ts` — `SidebarItem`, the link catalog, `useSidebarLinks()`.
- `navigation.ts` — `sidebarContent`, `navigateToSidebarView`, `isSidebarViewActive`.
- `rail-groups.ts` — grouping, unread mapping, digit bindings (pure, unit-tested).
- `rail-parts.tsx` — the destination button both rails render.

## Testing

- `rail-groups.test.ts` — grouping order, hidden/gated links, duplicate ids (`documents` ships twice), the leftover sweep, unread mapping (per-type, inbox aggregate, `document` + `static_file` together, seen/done/non-message-channel ignored), and digit assignment including running out of keys past the tenth destination.
- `skinny-rail.test.tsx` — clusters, labels, badges, active marking, click-to-open, logo peek/pin.
- `split-rail.test.tsx` — docks as a side split, undocks when docked, marks docked destinations active, leaves a full-size split of the same view alone, no-ops when the zone is full.
- `app-topbar.test.tsx` — history navigation, disabled directions, opening the command menu.
- `bunx vitest run` (whole repo): 3249 passed. Three failing files are environmental and unrelated: `next-soup/utils.test.ts` and the `scripts`/`websocket` suites fail on `pdfjs-dist` (a private GitHub tarball this sandbox's egress policy blocks) and on network/timing.
- `tsc --noEmit`: no new errors. `biome check` and `ast-grep scan` clean on the touched paths.
- e2e: the two specs that drive the wide sidebar's rows now ask for it via a new `useExpandedSidebar` helper (the rail is the default surface now), and the rail and split rail got their own specs. These need `LOCAL_E2E` and seeded data, so they were not run here.

The flat-split change is presentational and can't be asserted in jsdom (panels never register a size there), so it needs eyes rather than a test. Nothing here was verified in a running app — the local stack needs those blocked private deps — so the visual pass (rail metrics, label truncation, badge placement, top-bar centering, seam contrast in light and dark, the docked-split settle) is worth a preview build.