### PR TITLE
fix(ci): publish local-stack-binaries on every main push

### DIFF
--- a/.github/workflows/push_local_stack_binaries.yml
+++ b/.github/workflows/push_local_stack_binaries.yml
@@ -5,19 +5,6 @@ name: Push local stack binaries
   push:
     branches:
     - main
-    paths:
-    - Cargo.toml
-    - Cargo.lock
-    - rust-toolchain.toml
-    - crates/**
-    - services/**
-    - nix/**
-    - nix-support/**
-    - flake.nix
-    - flake.lock
-    - '.github/actions/setup-nix/**'
-    - '.github/actions/teardown-nix/**'
-    - '.github/workflows/push_local_stack_binaries.yml'
   workflow_dispatch: {}
 permissions:
   contents: read

--- a/tooling/xtask/crates/xtask_workflows/src/workflows/push_local_stack_binaries.rs
+++ b/tooling/xtask/crates/xtask_workflows/src/workflows/push_local_stack_binaries.rs
@@ -15,15 +15,6 @@ use crate::workflows::{runners, steps};
 
 /// Build the workflow.
 pub fn push_local_stack_binaries() -> Workflow {
-    // Every push to main, no paths filter. The stack derivation hashes
-    // depend on every file the Nix src filters keep — Rust anywhere
-    // (including tooling/), root *.md via rootDepsSrc, .sh/.sql/.json
-    // assets — which a paths list cannot faithfully enumerate. On
-    // 2026-08-23 a tooling+docs merge changed every service hash without
-    // matching the old filter; nothing published, and the environment
-    // bake plus every Cloud agent compiled the same binaries from source
-    // independently. When hashes are unchanged the run substitutes and
-    // finishes in under a minute, so always running is near-free.
     let push = Push::default().add_branch("main");
 
     Workflow::new("Push local stack binaries")

--- a/tooling/xtask/crates/xtask_workflows/src/workflows/push_local_stack_binaries.rs
+++ b/tooling/xtask/crates/xtask_workflows/src/workflows/push_local_stack_binaries.rs
@@ -15,23 +15,16 @@ use crate::workflows::{runners, steps};
 
 /// Build the workflow.
 pub fn push_local_stack_binaries() -> Workflow {
-    let mut push = Push::default().add_branch("main");
-    for path in [
-        xtask_paths::repo_glob!("Cargo.toml"),
-        xtask_paths::repo_glob!("Cargo.lock"),
-        xtask_paths::repo_glob!("rust-toolchain.toml"),
-        xtask_paths::repo_glob!("crates/**"),
-        xtask_paths::repo_glob!("services/**"),
-        xtask_paths::repo_glob!("nix/**"),
-        xtask_paths::repo_glob!("nix-support/**"),
-        xtask_paths::repo_glob!("flake.nix"),
-        xtask_paths::repo_glob!("flake.lock"),
-        xtask_paths::repo_glob!(".github/actions/setup-nix/**"),
-        xtask_paths::repo_glob!(".github/actions/teardown-nix/**"),
-        xtask_paths::repo_glob!(".github/workflows/push_local_stack_binaries.yml"),
-    ] {
-        push = push.add_path(path);
-    }
+    // Every push to main, no paths filter. The stack derivation hashes
+    // depend on every file the Nix src filters keep — Rust anywhere
+    // (including tooling/), root *.md via rootDepsSrc, .sh/.sql/.json
+    // assets — which a paths list cannot faithfully enumerate. On
+    // 2026-08-23 a tooling+docs merge changed every service hash without
+    // matching the old filter; nothing published, and the environment
+    // bake plus every Cloud agent compiled the same binaries from source
+    // independently. When hashes are unchanged the run substitutes and
+    // finishes in under a minute, so always running is near-free.
+    let push = Push::default().add_branch("main");
 
     Workflow::new("Push local stack binaries")
         .permissions(Permissions {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`push_local_stack_binaries.yml` gated on a `paths` filter (`Cargo.*`, `crates/**`, `services/**`, `nix/**`, `flake.*`). The stack derivation hashes depend on more than that: Rust anywhere in the workspace including `tooling/` (via `filterCargoSources` → `mkDummySrc`), root `*.md` (via `rootDepsSrc`, copied into every pruned service source), and `.sh`/`.sql`/`.json` assets. A paths list cannot faithfully enumerate the Nix src filters.

On 2026-08-23 the evening merges (#5863 + #5853 — `tooling/**` xtask Rust, root `CLAUDE.md`/`README.md`, `.cursor/*.sh`) changed **every** stack binary hash without matching the filter. Nothing published to `s3://macro-nix-cache`, so:

- the 22:30 UTC environment bake compiled all 16 binaries from source (~1h, then failed on an unrelated `macro-agent-harness` docker-build nix-store race),
- the 23:41 UTC bake is compiling the identical derivations again,
- both running Cloud agents that merged main compiled them again on their own VMs (~1h49m observed).

Four full from-source compiles of the same derivation set in one evening. Verified against build logs `bld-20260823-464098b7` / `bld-20260823-f7cbb08f` (S3 substitution itself worked — 1,871 and 1,215 `copying path` lines; only the top-level hashes were absent) and the workflow run history (last publish: `40c815713` at 03:57 UTC; no runs for the evening merges).

## Fix

Run on every push to `main`, no paths filter. When hashes are unchanged the `nix build` fully substitutes and the run completes in under a minute (the run for `91a7c07f` took 46 seconds), so the always-run cost is near-free — and it can never drift out of sync with the src filters again.

## Test plan

- [x] `cargo x workflows` regenerated cleanly; only `push_local_stack_binaries.yml` changed (paths filter removed, nothing else)
- [x] `cargo test -p xtask_workflows` — 10 passed (includes the embedded-path-filter validation)
- [x] `cargo fmt`

After merge, this push itself triggers the workflow and backfills the current main hashes. Until then, `workflow_dispatch` on main can backfill manually.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-465178fd-253b-4885-b3a1-91518a3aebad?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-465178fd-253b-4885-b3a1-91518a3aebad&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

