### PR TITLE
Seanaye/perf/urql solid

### DIFF
--- a/apps/web/src/lib/core/constant/featureFlags.ts
+++ b/apps/web/src/lib/core/constant/featureFlags.ts
@@ -494,7 +494,7 @@ const parseBooleanOverride = (value: unknown): boolean | undefined =>
 /** Controls the cache-warming GraphQL soup backfill. */
 export const ENABLE_GRAPHQL_BACKFILL = resolveFeatureFlag(
   'ENABLE_GRAPHQL_BACKFILL',
-  false
+  true
 );
 
 /** Independent emergency stop. Any true env/PostHog source wins. */

--- a/apps/web/src/lib/queries/soup/graphql/items.test.ts
+++ b/apps/web/src/lib/queries/soup/graphql/items.test.ts
@@ -13,7 +13,16 @@ const getGraphqlSoupClientMock = vi.hoisted(() => vi.fn());
 const getGraphqlSoupCacheHostMock = vi.hoisted(() => vi.fn());
 const entityFilterMock = vi.hoisted(() => vi.fn());
 const readRecordsByKeysMock = vi.hoisted(() => vi.fn());
-const mapGraphqlSoupPageMock = vi.hoisted(() => vi.fn((data) => data));
+const mapGraphqlSoupPageMock = vi.hoisted(() =>
+  vi.fn(
+    (data: {
+      user: { soup: { items: unknown[]; nextCursor: string | null } };
+    }) => ({
+      items: data.user.soup.items,
+      next_cursor: data.user.soup.nextCursor,
+    })
+  )
+);
 const mapSoupPageToEntityListMock = vi.hoisted(() =>
   vi.fn((page) => page.items)
 );
@@ -52,6 +61,22 @@ import { createGraphqlSoupAstItemsQuery } from './items';
 type FakeExecution = {
   next(data: unknown): void;
 };
+
+type SoupPageFixture = {
+  items: unknown[];
+  next_cursor: string | null;
+};
+
+function graphqlSoupPage(page: SoupPageFixture) {
+  return {
+    user: {
+      soup: {
+        items: page.items,
+        nextCursor: page.next_cursor,
+      },
+    },
+  };
+}
 
 function makeFakeClient(): {
   client: Client;
@@ -149,10 +174,14 @@ describe('createGraphqlSoupAstItemsQuery', () => {
             expect(query.data()?.entities[0]?.name).toBe('Local task');
           })
           .then(() => {
-            fake.executions[0]?.next({
-              items: [{ id: 'task-1', type: 'document', name: 'Network task' }],
-              next_cursor: null,
-            });
+            fake.executions[0]?.next(
+              graphqlSoupPage({
+                items: [
+                  { id: 'task-1', type: 'document', name: 'Network task' },
+                ],
+                next_cursor: null,
+              })
+            );
             expect(query.isPlaceholderData()).toBe(false);
             expect(query.data()?.entities[0]?.name).toBe('Network task');
             dispose();
@@ -205,10 +234,14 @@ describe('createGraphqlSoupAstItemsQuery', () => {
             expect(query.isPlaceholderData()).toBe(true);
           })
           .then(async () => {
-            fake.executions[0]?.next({
-              items: [{ id: 'task-1', type: 'document', name: 'Network task' }],
-              next_cursor: null,
-            });
+            fake.executions[0]?.next(
+              graphqlSoupPage({
+                items: [
+                  { id: 'task-1', type: 'document', name: 'Network task' },
+                ],
+                next_cursor: null,
+              })
+            );
             expect(query.data()?.entities[0]?.name).toBe('Optimistic task');
 
             notifyCacheChanged();
@@ -239,20 +272,23 @@ describe('createGraphqlSoupAstItemsQuery', () => {
       );
 
       expect(fake.executions).toHaveLength(1);
-      fake.executions[0]?.next(firstPage);
+      fake.executions[0]?.next(graphqlSoupPage(firstPage));
+      expect(mapGraphqlSoupPageMock).toHaveBeenCalledTimes(1);
 
       const initial = query.data();
       const initialEntity = initial?.entities[0];
       expect(initialEntity).toEqual(firstPage.items[0]);
 
-      fake.executions[0]?.next(structuredClone(firstPage));
+      fake.executions[0]?.next(graphqlSoupPage(structuredClone(firstPage)));
       expect(query.data()).toBe(initial);
       expect(query.data()?.entities[0]).toBe(initialEntity);
 
-      fake.executions[0]?.next({
-        ...firstPage,
-        items: [{ ...firstPage.items[0], name: 'Updated task' }],
-      });
+      fake.executions[0]?.next(
+        graphqlSoupPage({
+          ...firstPage,
+          items: [{ ...firstPage.items[0], name: 'Updated task' }],
+        })
+      );
       expect(query.data()?.entities[0]).toBe(initialEntity);
       expect(query.data()?.entities[0]?.name).toBe('Updated task');
 

--- a/apps/web/src/lib/queries/soup/graphql/items.ts
+++ b/apps/web/src/lib/queries/soup/graphql/items.ts
@@ -180,7 +180,8 @@ export function createGraphqlSoupAstItemsQuery(
         }
         return { input };
       },
-      getNextPageParam: (lastPage) => mapGraphqlSoupPage(lastPage).next_cursor,
+      getNextPageParam: (lastPage) =>
+        lastPage.user.soup.nextCursor ?? undefined,
       enabled: queryOptions.enabled && firstInput !== undefined,
       requestPolicy: 'cache-and-network',
       keepPreviousData: false,

--- a/apps/web/src/lib/urql-solid/create-urql-infinite-query.test.tsx
+++ b/apps/web/src/lib/urql-solid/create-urql-infinite-query.test.tsx
@@ -8,7 +8,7 @@ import {
 } from '@urql/core';
 import { createRoot, createSignal } from 'solid-js';
 import { afterEach, describe, expect, it } from 'vitest';
-import { makeSubject, onEnd, pipe } from 'wonka';
+import { fromValue, makeSubject, onEnd, pipe } from 'wonka';
 import { createUrqlInfiniteQuery } from './create-urql-infinite-query';
 import { InfiniteQueryObserver } from './infinite-query-observer';
 
@@ -104,6 +104,98 @@ describe('createUrqlInfiniteQuery', () => {
     expect(observer.getCurrentResult()).toBe(updated);
     expect(selectCalls).toBe(1);
 
+    const page = { values: ['same'], nextCursor: null };
+    fake.executions[0]?.next(page);
+    const selected = observer.getCurrentResult().data;
+    expect(selectCalls).toBe(2);
+
+    fake.executions[0]?.next(page);
+    expect(observer.getCurrentResult().data).toBe(selected);
+    expect(selectCalls).toBe(2);
+
+    fake.executions[0]?.next({ ...page });
+    expect(selectCalls).toBe(3);
+
+    observer.destroy();
+  });
+
+  it('reselects unchanged pages when the selector changes', () => {
+    const fake = makeFakeClient();
+    const firstSelect = ({ pages }: { pages: Page[] }) =>
+      pages.flatMap((page) => page.values);
+    const observer = new InfiniteQueryObserver<
+      Page,
+      Variables,
+      string | null,
+      string[]
+    >(fake.client, {
+      query: DOCUMENT,
+      initialPageParam: null,
+      variables: (cursor) => ({ cursor }),
+      getNextPageParam: (lastPage) => lastPage.nextCursor,
+      select: firstSelect,
+    });
+
+    fake.executions[0]?.next({ values: ['first'], nextCursor: null });
+    const secondSelect = ({ pages }: { pages: Page[] }) =>
+      pages.flatMap((page) => page.values.map((value) => `${value}-selected`));
+    observer.setOptions(
+      {
+        query: DOCUMENT,
+        initialPageParam: null,
+        variables: (cursor) => ({ cursor }),
+        getNextPageParam: (lastPage) => lastPage.nextCursor,
+        select: secondSelect,
+      },
+      fake.client
+    );
+
+    expect(observer.getCurrentResult().data).toEqual(['first-selected']);
+    observer.destroy();
+  });
+
+  it('coalesces derivation while setting up the initial page', () => {
+    const page = { values: ['cached'], nextCursor: null };
+    let selectCalls = 0;
+    let paginationCalls = 0;
+    const client = {
+      executeQuery: (
+        _request: GraphQLRequest<Page, Variables>,
+        context: Partial<OperationContext>
+      ) => {
+        const operation = {
+          kind: 'query',
+          context,
+        } as Operation<Page, Variables>;
+        return fromValue({ operation, data: page } as OperationResult<
+          Page,
+          Variables
+        >);
+      },
+    } as unknown as Client;
+
+    const observer = new InfiniteQueryObserver<
+      Page,
+      Variables,
+      string | null,
+      string[]
+    >(client, {
+      query: DOCUMENT,
+      initialPageParam: null,
+      variables: (cursor) => ({ cursor }),
+      getNextPageParam: (lastPage) => {
+        paginationCalls += 1;
+        return lastPage.nextCursor;
+      },
+      select: ({ pages }) => {
+        selectCalls += 1;
+        return pages.flatMap((currentPage) => currentPage.values);
+      },
+    });
+
+    expect(observer.getCurrentResult().data).toEqual(['cached']);
+    expect(selectCalls).toBe(1);
+    expect(paginationCalls).toBe(1);
     observer.destroy();
   });
 

--- a/apps/web/src/lib/urql-solid/infinite-query-observer.ts
+++ b/apps/web/src/lib/urql-solid/infinite-query-observer.ts
@@ -59,6 +59,27 @@ type NextPageParamResult<PageParam> = {
   error: CombinedError | null;
 };
 
+type SelectionCache<PageData, PageParam, SelectedData> = {
+  pages: readonly PageData[];
+  pageParams: readonly PageParam[];
+  select: InfiniteOptions<
+    PageData,
+    AnyVariables,
+    PageParam,
+    SelectedData
+  >['select'];
+  previousData: SelectedData | undefined;
+  data: SelectedData | undefined;
+  error: CombinedError | null;
+};
+
+function sameReferences<T>(left: readonly T[], right: readonly T[]): boolean {
+  return (
+    left.length === right.length &&
+    left.every((value, index) => Object.is(value, right[index]))
+  );
+}
+
 function shallowEqualContext(
   left: Partial<OperationContext> | undefined,
   right: Partial<OperationContext> | undefined
@@ -120,6 +141,13 @@ export class InfiniteQueryObserver<
     SelectedData
   >;
   private readonly result = new ObserverResult(() => this.getCurrentResult());
+  // urql page data is immutable; unchanged references therefore represent the
+  // same selector input across fetching/stale-only observer emissions.
+  private selectionCache:
+    | SelectionCache<PageData, PageParam, SelectedData>
+    | undefined;
+  private emissionBatchDepth = 0;
+  private pendingEmission = false;
   private actionController = new AbortController();
   private destroyed = false;
   private fetchNextPromise:
@@ -155,18 +183,9 @@ export class InfiniteQueryObserver<
     SelectedData
   > {
     const infiniteData = this.successfulPages();
-    let data = this.state.previousData;
-    let derivationError: CombinedError | null = null;
-
-    if (infiniteData.pages.length > 0) {
-      try {
-        data = this.options.select
-          ? this.options.select(infiniteData)
-          : (infiniteData as SelectedData);
-      } catch (cause) {
-        derivationError = toCombinedError(cause);
-      }
-    }
+    const selection = this.deriveSelectedData(infiniteData);
+    const data = selection.data;
+    let derivationError = selection.error;
 
     const pageResults = this.pages.map((page) =>
       page.observer.getCurrentResult()
@@ -223,6 +242,45 @@ export class InfiniteQueryObserver<
       fetchNextPage: this.fetchNextPage,
       refetch: this.refetch,
     };
+  }
+
+  private deriveSelectedData(
+    infiniteData: UrqlInfiniteData<PageData, PageParam>
+  ): { data: SelectedData | undefined; error: CombinedError | null } {
+    if (infiniteData.pages.length === 0) {
+      return { data: this.state.previousData, error: null };
+    }
+
+    const select = this.options.select;
+    const cached = this.selectionCache;
+    if (
+      cached !== undefined &&
+      cached.select === select &&
+      Object.is(cached.previousData, this.state.previousData) &&
+      sameReferences(cached.pages, infiniteData.pages) &&
+      sameReferences(cached.pageParams, infiniteData.pageParams)
+    ) {
+      return { data: cached.data, error: cached.error };
+    }
+
+    let data = this.state.previousData;
+    let error: CombinedError | null = null;
+    try {
+      data = select ? select(infiniteData) : (infiniteData as SelectedData);
+    } catch (cause) {
+      error = toCombinedError(cause);
+    }
+
+    this.selectionCache = {
+      pages: infiniteData.pages,
+      pageParams: infiniteData.pageParams,
+      select,
+      previousData: this.state.previousData,
+      data,
+      error,
+    };
+
+    return { data, error };
   }
 
   setReference(
@@ -310,55 +368,59 @@ export class InfiniteQueryObserver<
     options: InfiniteOptions<PageData, Variables, PageParam, SelectedData>,
     client: Client
   ): void {
-    const wasEnabled = this.state.enabled;
-    const previousResult = this.getCurrentResult();
-    this.options = options;
-    this.client = client;
+    this.batchEmissions(() => {
+      const wasEnabled = this.state.enabled;
+      const previousResult = this.getCurrentResult();
+      this.options = options;
+      this.client = client;
 
-    if (options.enabled === false) {
-      this.cancelActions();
-      this.setState({ enabled: false });
+      if (options.enabled === false) {
+        this.cancelActions();
+        this.setState({ enabled: false });
 
-      for (const page of this.pages) {
-        page.observer.setOptions(this.pageOptions(page, false), client);
+        for (const page of this.pages) {
+          page.observer.setOptions(this.pageOptions(page, false), client);
+        }
+        this.emit();
+        return;
+      }
+
+      const initialVariables = options.variables(options.initialPageParam, 0);
+      const request = createRequest<PageData, Variables>(
+        options.query,
+        initialVariables
+      );
+      const queryKey: InfiniteQueryKey<PageParam> = {
+        key: request.key,
+        initialPageParam: options.initialPageParam,
+        requestPolicy: options.requestPolicy,
+        context: options.context,
+      };
+      const queryChanged = !sameQuery(this.queryKey, queryKey);
+
+      if (queryChanged) {
+        this.cancelActions();
+        this.setState({
+          previousData:
+            options.keepPreviousData !== false
+              ? previousResult.data
+              : undefined,
+          paginationError: undefined,
+        });
+        this.queryKey = queryKey;
+        this.destroyPages();
+      }
+
+      this.setState({ enabled: true });
+      if (this.pages.length === 0) {
+        this.appendPage(options.initialPageParam, 0, initialVariables);
+      } else if (!wasEnabled) {
+        for (const page of this.pages) {
+          page.observer.setOptions(this.pageOptions(page, true), client);
+        }
       }
       this.emit();
-      return;
-    }
-
-    const initialVariables = options.variables(options.initialPageParam, 0);
-    const request = createRequest<PageData, Variables>(
-      options.query,
-      initialVariables
-    );
-    const queryKey: InfiniteQueryKey<PageParam> = {
-      key: request.key,
-      initialPageParam: options.initialPageParam,
-      requestPolicy: options.requestPolicy,
-      context: options.context,
-    };
-    const queryChanged = !sameQuery(this.queryKey, queryKey);
-
-    if (queryChanged) {
-      this.cancelActions();
-      this.setState({
-        previousData:
-          options.keepPreviousData !== false ? previousResult.data : undefined,
-        paginationError: undefined,
-      });
-      this.queryKey = queryKey;
-      this.destroyPages();
-    }
-
-    this.setState({ enabled: true });
-    if (this.pages.length === 0) {
-      this.appendPage(options.initialPageParam, 0, initialVariables);
-    } else if (!wasEnabled) {
-      for (const page of this.pages) {
-        page.observer.setOptions(this.pageOptions(page, true), client);
-      }
-    }
-    this.emit();
+    });
   }
 
   private pageOptions(
@@ -668,7 +730,28 @@ export class InfiniteQueryObserver<
     return this.result.getActionResult();
   }
 
+  private batchEmissions(update: () => void): void {
+    this.emissionBatchDepth += 1;
+    try {
+      update();
+    } finally {
+      this.emissionBatchDepth -= 1;
+      if (this.emissionBatchDepth === 0 && this.pendingEmission) {
+        this.pendingEmission = false;
+        this.emitNow();
+      }
+    }
+  }
+
   private emit(): void {
+    if (this.emissionBatchDepth > 0) {
+      this.pendingEmission = true;
+      return;
+    }
+    this.emitNow();
+  }
+
+  private emitNow(): void {
     this.currentResult = this.buildResult();
     this.result.notify();
   }


### PR DESCRIPTION
This PR improves the performance of our urql solid bindings in the context of soup fetching, by reducing extra work done. We also re-enable the backfill by default