### PR TITLE
fix(web): mark soup channel target notifications read

### DIFF
--- a/apps/web/src/features/next-soup/soup-view/soup-view.tsx
+++ b/apps/web/src/features/next-soup/soup-view/soup-view.tsx
@@ -49,6 +49,7 @@ import { TaskListEntity } from '@app/features/next-soup/soup-view/views/tasks/Ta
 import { ResponsiveTaskListHeader } from '@app/features/next-soup/soup-view/views/tasks/TaskListHeader';
 import { TaskGroupHeader } from '@app/features/next-soup/soup-view/views/tasks/task-group-header';
 import {
+  markChannelTargetSeenOnOpen,
   markReminderSeenOnOpen,
   openEntityInNewTab,
   openEntityInSplitFromUnifiedList,
@@ -956,6 +957,7 @@ const SoupViewListContent = (props: SoupViewListProps) => {
       type === 'entity' ? args.entity : args.projectEntity
     ) as EntityData;
 
+    markChannelTargetSeenOnOpen(entity, notificationSource);
     markReminderSeenOnOpen(entity, notificationSource);
 
     // FIXME: this never gets called because we have overrides

--- a/apps/web/src/features/next-soup/soup-view/soup-view.tsx
+++ b/apps/web/src/features/next-soup/soup-view/soup-view.tsx
@@ -957,7 +957,6 @@ const SoupViewListContent = (props: SoupViewListProps) => {
       type === 'entity' ? args.entity : args.projectEntity
     ) as EntityData;
 
-    markChannelTargetSeenOnOpen(entity, notificationSource);
     markReminderSeenOnOpen(entity, notificationSource);
 
     // FIXME: this never gets called because we have overrides
@@ -966,6 +965,7 @@ const SoupViewListContent = (props: SoupViewListProps) => {
       // Join button (or, in preview, the Viewer's Join prompt) is the only
       // affordance.
       if (!isNonMemberChannelEntity(entity)) {
+        markChannelTargetSeenOnOpen(entity, notificationSource);
         openEntityInNewTab({ entity, location });
       }
       return;
@@ -992,6 +992,9 @@ const SoupViewListContent = (props: SoupViewListProps) => {
       // Single click: focus the row AND open it in the Preview Pair's Viewer.
       // The openWithSplit redirect keeps the Viewer unfocused so keyboard
       // navigation stays in this list.
+      if (!isNonMemberChannelEntity(entity)) {
+        markChannelTargetSeenOnOpen(entity, notificationSource);
+      }
       if (args.rowIndex !== undefined) soup.focus.setIndex(args.rowIndex);
       else soup.focus.set(entity.id);
 
@@ -1005,6 +1008,10 @@ const SoupViewListContent = (props: SoupViewListProps) => {
     }
 
     const finishTouchHighlight = persistSoupNavigationTouchHighlight(event);
+
+    if (!isNonMemberChannelEntity(entity)) {
+      markChannelTargetSeenOnOpen(entity, notificationSource);
+    }
 
     try {
       await openEntityInSplitFromUnifiedList(entity, {

--- a/apps/web/src/features/next-soup/utils.test.ts
+++ b/apps/web/src/features/next-soup/utils.test.ts
@@ -79,6 +79,7 @@ import {
   executeMarkEntitiesDone,
   getChannelEntityTarget,
   getRowClickFallbackLocation,
+  markChannelTargetSeenOnOpen,
   openEntityInSplitFromUnifiedList,
   preventDuplicatePreviewEntityOpen,
   resolveMarkEntitiesDoneVariables,
@@ -391,6 +392,31 @@ describe('getChannelEntityTarget', () => {
       messageId: 'notif-msg',
       threadId: undefined,
     });
+  });
+
+  it('marks an attached agent notification read even when the global source does not contain it', () => {
+    const notification = sendNotification('agent-notification', 'agent-msg');
+    notification.notification_metadata = {
+      tag: 'channel_message_send',
+      content: {
+        messageId: 'agent-msg',
+        sender: null,
+        senderDisplayName: 'Macro Agent',
+      },
+    } as UnifiedNotification['notification_metadata'];
+    const bulkMarkAsRead = vi.fn(async () => {});
+    const notificationSource = {
+      notificationsByEntity: () => ({}),
+      bulkMarkAsRead,
+    } as unknown as NotificationSource;
+
+    markChannelTargetSeenOnOpen(
+      channelRow({ notifications: [notification] }),
+      notificationSource
+    );
+
+    expect(bulkMarkAsRead).toHaveBeenCalledOnce();
+    expect(bulkMarkAsRead).toHaveBeenCalledWith([notification]);
   });
 
   it('opens a channel row at latest when it has no notifications', () => {

--- a/apps/web/src/features/next-soup/utils.test.ts
+++ b/apps/web/src/features/next-soup/utils.test.ts
@@ -419,6 +419,34 @@ describe('getChannelEntityTarget', () => {
     expect(bulkMarkAsRead).toHaveBeenCalledWith([notification]);
   });
 
+  it('reports failures to mark an attached channel notification read', async () => {
+    const error = new Error('mark failed');
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    const notification = sendNotification('notification', 'message');
+    const notificationSource = {
+      bulkMarkAsRead: vi.fn(async () => {
+        throw error;
+      }),
+    } as unknown as NotificationSource;
+
+    try {
+      markChannelTargetSeenOnOpen(
+        channelRow({ notifications: [notification] }),
+        notificationSource
+      );
+      await Promise.resolve();
+
+      expect(consoleError).toHaveBeenCalledWith(
+        'Failed to mark message notifications as read',
+        error
+      );
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
   it('opens a channel row at latest when it has no notifications', () => {
     expect(getChannelEntityTarget(channelRow())).toEqual({ kind: 'latest' });
   });

--- a/apps/web/src/features/next-soup/utils.ts
+++ b/apps/web/src/features/next-soup/utils.ts
@@ -757,7 +757,9 @@ export function markChannelTargetSeenOnOpen(
   });
   if (notifications.length === 0) return;
 
-  void notificationSource.bulkMarkAsRead(notifications);
+  void notificationSource.bulkMarkAsRead(notifications).catch((error) => {
+    console.error('Failed to mark message notifications as read', error);
+  });
 }
 
 /**

--- a/apps/web/src/features/next-soup/utils.ts
+++ b/apps/web/src/features/next-soup/utils.ts
@@ -733,6 +733,34 @@ export const openEntityInSplitFromUnifiedList = async (
 };
 
 /**
+ * Mark the attached notification that caused a channel row to target a message.
+ *
+ * The row's Soup edge is authoritative here. The channel block's message marker
+ * discovers notifications through the separately paginated global source, so
+ * an older notification can drive navigation without being present there.
+ */
+export function markChannelTargetSeenOnOpen(
+  entity: EntityData,
+  notificationSource: NotificationSource
+) {
+  const target = getChannelEntityTarget(entity);
+  if (target?.kind !== 'message' || !isWithNotification(entity)) return;
+
+  const notifications = scopeChannelNotificationsForEntity(
+    entity,
+    entity.notifications?.() ?? []
+  ).filter((notification) => {
+    if (notificationIsRead(notification)) return false;
+    return (
+      getChannelNotificationParams(notification).messageId === target.messageId
+    );
+  });
+  if (notifications.length === 0) return;
+
+  void notificationSource.bulkMarkAsRead(notifications);
+}
+
+/**
  * Mark a reminder's notification read when the user opens it.
  *
  * Every other entity type gets this for free from the block it opens into,


### PR DESCRIPTION
Fix another issue with mark notification as read, if it exists outside the global source it would fail to mark the specific notification, leaving orphaned unreads