### PR TITLE
fix(cloud): apply the bridge-forwarding watcher to the bake stack up

### DIFF
--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -67,7 +67,13 @@ echo "cursor-cloud install: local stack binaries ready"
 
 # Bake the init snapshot on stubs. Runtime stack.sh pulls Doppler when
 # DOPPLER_TOKEN is present; secrets must not land in the durable snapshot.
-just stack up --infra-only --no-doppler --build-aux-services --binaries-dir "${LOCAL_STACK_BINS}/bin" --json
+# The bridge watcher mirrors stack.sh: compose creates the stack networks
+# mid-`up`, and a bridge born after the iptables pass has no FORWARD accept
+# rules — FusionAuth then cannot reach Postgres and wedges in maintenance
+# mode, failing the strict-200 kickstart wait.
+run_with_bridge_forwarding \
+  just stack up --infra-only --no-doppler --build-aux-services --binaries-dir "${LOCAL_STACK_BINS}/bin" --json
+ensure_docker_bridge_forwarding
 cleanup_stack
 trap - EXIT
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Six consecutive recurring environment builds failed on 2026-08-24, all identically: `✗ Waiting for FusionAuth (kickstart) — Failed ~5m57s`, maintenance-mode 302 (`bld-20260824-647f21ce`, `-54d5f4fb`, `-7052de40`, `-eaae6d1a`, `-8ad45732`, `-7f4642a2`).

Root cause is the bug #5863 fixed for the runtime path but not the bake: compose creates the stack networks in the middle of `just stack up`, and a bridge born after the iptables pass has no `DOCKER-FORWARD` accept rules. FusionAuth boots unable to reach Postgres and wedges in maintenance mode. `stack.sh` wraps its bring-up in `run_with_bridge_forwarding` (re-applies rules every 3s); `install.sh` still called `just stack up --infra-only` bare.

Before #5863's strict-200 kickstart wait this failure was silent: bakes "succeeded" while snapshotting a wedged FusionAuth — the source of the "unable to lookup identity providers" symptom agents used to hit at runtime. Now it fails loudly at bake time.

## Fix

Mirror `stack.sh`: wrap the bake's `just stack up` in `run_with_bridge_forwarding`, re-assert rules after.

## Verification — side-by-side environment builds

- **Draft build on this branch** (`bld-20260824-4c6a054b`): `✓ Waiting for FusionAuth (kickstart) — Done 8s` (and `Done 4s` on the post-snapshot restart), `cursor-cloud install: durable stack ready`, `[INSTALL] Exit code: 0`.
- **Concurrent recurring build on main** (`bld-20260824-7f4642a2`, no fix): failed the same kickstart wait at 19:04 UTC — the sixth identical failure today.

After merge, the next default-branch build will produce the first good snapshot since `bld-20260822-1859f33f`; draft builds don't promote.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-465178fd-253b-4885-b3a1-91518a3aebad?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-465178fd-253b-4885-b3a1-91518a3aebad&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

