### PR TITLE
feat(web): onboarding hard mode randomizes the skip button

### DIFF
--- a/apps/web/src/features/setup/flow/HardMode.test.tsx
+++ b/apps/web/src/features/setup/flow/HardMode.test.tsx
@@ -1,0 +1,35 @@
+/** @vitest-environment jsdom */
+import { fireEvent, render, screen } from '@solidjs/testing-library';
+import { describe, expect, it } from 'vitest';
+import { OnboardingHardModeProvider } from './HardMode';
+import { SkipButton } from './shared';
+
+describe('onboarding hard mode', () => {
+  it('shows an always-on Hard mode switch', () => {
+    render(() => (
+      <div class="relative h-96 w-96">
+        <OnboardingHardModeProvider>
+          <SkipButton onClick={() => undefined} />
+        </OnboardingHardModeProvider>
+      </div>
+    ));
+
+    expect(screen.getByText('Hard mode')).toBeTruthy();
+    expect(screen.getByRole('switch')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Skip for now' })).toBeTruthy();
+  });
+
+  it('moves skip out of document flow when hard mode is on', () => {
+    render(() => (
+      <div class="relative h-96 w-96">
+        <OnboardingHardModeProvider>
+          <SkipButton onClick={() => undefined} />
+        </OnboardingHardModeProvider>
+      </div>
+    ));
+
+    fireEvent.click(screen.getByRole('switch'));
+    const skip = screen.getByRole('button', { name: 'Skip for now' });
+    expect(skip.parentElement?.className).toContain('absolute');
+  });
+});

--- a/apps/web/src/features/setup/flow/HardMode.tsx
+++ b/apps/web/src/features/setup/flow/HardMode.tsx
@@ -1,0 +1,54 @@
+import { ToggleSwitch } from '@ui';
+import {
+  type Accessor,
+  createContext,
+  createSignal,
+  type JSX,
+  useContext,
+} from 'solid-js';
+
+export type OnboardingHardMode = {
+  hardMode: Accessor<boolean>;
+  setHardMode: (on: boolean) => void;
+  skipLayer: Accessor<HTMLDivElement | undefined>;
+};
+
+const HardModeContext = createContext<OnboardingHardMode>();
+
+export function useOnboardingHardMode(): OnboardingHardMode {
+  return (
+    useContext(HardModeContext) ?? {
+      hardMode: () => false,
+      setHardMode: () => undefined,
+      skipLayer: () => undefined,
+    }
+  );
+}
+
+/** Always-visible Hard mode switch plus a layer skip buttons portal into. */
+export function OnboardingHardModeProvider(props: {
+  children: JSX.Element;
+}): JSX.Element {
+  const [hardMode, setHardMode] = createSignal(false);
+  const [skipLayer, setSkipLayer] = createSignal<HTMLDivElement>();
+
+  return (
+    <HardModeContext.Provider value={{ hardMode, setHardMode, skipLayer }}>
+      {props.children}
+      <div
+        ref={setSkipLayer}
+        class="pointer-events-none absolute inset-0 z-20"
+      />
+      <div class="absolute bottom-6 left-6 z-30">
+        <ToggleSwitch
+          size="md"
+          checked={hardMode()}
+          onChange={setHardMode}
+          class="origin-bottom-left scale-150 gap-3 rounded-full border border-edge bg-surface/90 px-4 py-3 shadow-lg backdrop-blur-sm"
+          label="Hard mode"
+          labelClass="text-base font-semibold tracking-tight text-ink"
+        />
+      </div>
+    </HardModeContext.Provider>
+  );
+}

--- a/apps/web/src/features/setup/flow/OnboardingFlow.tsx
+++ b/apps/web/src/features/setup/flow/OnboardingFlow.tsx
@@ -31,6 +31,7 @@ import { BuildingStep, type ConnectedTools } from './BuildingStep';
 import { ConnectorStep } from './ConnectorStep';
 import { createFlowFinish } from './createFlowFinish';
 import { EmailStep } from './EmailStep';
+import { OnboardingHardModeProvider } from './HardMode';
 import {
   ONBOARDING_CONNECTORS_FEATURE_FLAG,
   type OnboardingConnectorServerName,
@@ -479,8 +480,9 @@ function FlowContent() {
 
   return (
     <div class="relative size-full overflow-hidden bg-surface font-sans text-ink">
-      <style>{
-        /*css*/ `
+      <OnboardingHardModeProvider>
+        <style>{
+          /*css*/ `
         @keyframes obf-card-in {
           from { opacity: 0; transform: translateY(14px) scale(0.985); }
           to   { opacity: 1; transform: translateY(0)    scale(1);     }
@@ -498,130 +500,131 @@ function FlowContent() {
           transition: background-color 5000s ease-in-out 0s;
         }
       `
-      }</style>
+        }</style>
 
-      <NoiseBackground />
+        <NoiseBackground />
 
-      {/* The backdrop layers are viewport-sized absolutes, so scrolling has
+        {/* The backdrop layers are viewport-sized absolutes, so scrolling has
           to happen inside them — a tall step (the summary's pill cloud)
           would otherwise scroll the wash and grain away with the content,
           and the grain's 100vw width would add a horizontal scrollbar. */}
-      <div class="relative z-10 size-full overflow-y-auto overscroll-contain">
-        <div class="flex min-h-full items-center justify-center px-6 py-12">
-          <div
-            class={cn(
-              'w-full obf-card transition-[max-width] duration-300',
-              currentStep().wide ? 'sm:max-w-xl' : 'sm:max-w-lg'
-            )}
-          >
-            <div class="flex flex-col gap-8">
-              <Show when={currentStep().title}>
-                <div class="flex flex-col gap-1.5">
-                  {/* Hero module above the title — desktop only. Nudged left by
+        <div class="relative z-10 size-full overflow-y-auto overscroll-contain">
+          <div class="flex min-h-full items-center justify-center px-6 py-12">
+            <div
+              class={cn(
+                'w-full obf-card transition-[max-width] duration-300',
+                currentStep().wide ? 'sm:max-w-xl' : 'sm:max-w-lg'
+              )}
+            >
+              <div class="flex flex-col gap-8">
+                <Show when={currentStep().title}>
+                  <div class="flex flex-col gap-1.5">
+                    {/* Hero module above the title — desktop only. Nudged left by
                       the module's built-in viewBox padding (reserved for the
                       click-burst trail) so its at-rest artwork left-aligns with
                       the title text. */}
-                  <Show when={currentStep().module}>
-                    {(mod) => (
-                      <StepModule
-                        logo={mod().logo}
-                        state={heroState()}
-                        class="mb-1 hidden size-32 -ml-8 sm:block"
-                      />
-                    )}
-                  </Show>
-                  {/* Landing slot for the loading-graphic → logo handoff. Kept
-                      hidden while the overlay is mid-flight; the overlay lands
-                      exactly here, then this static logo takes over. */}
-                  <Show when={currentStep().key === 'summary'}>
-                    <LogoIcon
-                      id="summary-brand-logo"
-                      class="mb-1 size-16 text-accent"
-                      style={{ opacity: logoShown() ? 1 : 0 }}
-                    />
-                  </Show>
-                  <div
-                    class="flex flex-col gap-1.5 transition-opacity"
-                    style={{
-                      opacity: summaryContentHidden() ? 0 : 1,
-                      'transition-duration': `${contentFadeMs()}ms`,
-                    }}
-                  >
-                    <h1 class="text-2xl font-semibold tracking-tight text-ink">
-                      {currentStep().title}
-                    </h1>
-                    <Show when={currentStep().subtitle}>
-                      <p class="max-w-md text-sm leading-relaxed text-ink-muted">
-                        {currentStep().subtitle}
-                      </p>
-                    </Show>
-                  </div>
-                </div>
-              </Show>
-
-              <div
-                class="flex flex-col gap-8 transition-opacity"
-                style={{
-                  opacity: summaryContentHidden() ? 0 : 1,
-                  'transition-duration': `${contentFadeMs()}ms`,
-                }}
-              >
-                <Stepper
-                  step={stepIndex()}
-                  transition={Stepper.transitions.scale}
-                >
-                  <For each={steps()}>
-                    {(step) => (
-                      <Stepper.Step noTransition={step.noTransition}>
-                        <Suspense fallback={<StepFallback />}>
-                          {step.render(controls)}
-                        </Suspense>
-                      </Stepper.Step>
-                    )}
-                  </For>
-                </Stepper>
-
-                <Show when={!currentStep().noDot}>
-                  <div class="flex gap-1.5">
-                    <Index each={steps().filter((step) => !step.noDot)}>
-                      {(step) => (
-                        <div
-                          class={cn(
-                            'size-1.5 rounded-full transition-colors',
-                            stepIndex() === steps().indexOf(step())
-                              ? 'bg-accent'
-                              : stepIndex() > steps().indexOf(step())
-                                ? 'bg-ink/40'
-                                : 'bg-ink/15'
-                          )}
+                    <Show when={currentStep().module}>
+                      {(mod) => (
+                        <StepModule
+                          logo={mod().logo}
+                          state={heroState()}
+                          class="mb-1 hidden size-32 -ml-8 sm:block"
                         />
                       )}
-                    </Index>
+                    </Show>
+                    {/* Landing slot for the loading-graphic → logo handoff. Kept
+                      hidden while the overlay is mid-flight; the overlay lands
+                      exactly here, then this static logo takes over. */}
+                    <Show when={currentStep().key === 'summary'}>
+                      <LogoIcon
+                        id="summary-brand-logo"
+                        class="mb-1 size-16 text-accent"
+                        style={{ opacity: logoShown() ? 1 : 0 }}
+                      />
+                    </Show>
+                    <div
+                      class="flex flex-col gap-1.5 transition-opacity"
+                      style={{
+                        opacity: summaryContentHidden() ? 0 : 1,
+                        'transition-duration': `${contentFadeMs()}ms`,
+                      }}
+                    >
+                      <h1 class="text-2xl font-semibold tracking-tight text-ink">
+                        {currentStep().title}
+                      </h1>
+                      <Show when={currentStep().subtitle}>
+                        <p class="max-w-md text-sm leading-relaxed text-ink-muted">
+                          {currentStep().subtitle}
+                        </p>
+                      </Show>
+                    </div>
                   </div>
                 </Show>
+
+                <div
+                  class="flex flex-col gap-8 transition-opacity"
+                  style={{
+                    opacity: summaryContentHidden() ? 0 : 1,
+                    'transition-duration': `${contentFadeMs()}ms`,
+                  }}
+                >
+                  <Stepper
+                    step={stepIndex()}
+                    transition={Stepper.transitions.scale}
+                  >
+                    <For each={steps()}>
+                      {(step) => (
+                        <Stepper.Step noTransition={step.noTransition}>
+                          <Suspense fallback={<StepFallback />}>
+                            {step.render(controls)}
+                          </Suspense>
+                        </Stepper.Step>
+                      )}
+                    </For>
+                  </Stepper>
+
+                  <Show when={!currentStep().noDot}>
+                    <div class="flex gap-1.5">
+                      <Index each={steps().filter((step) => !step.noDot)}>
+                        {(step) => (
+                          <div
+                            class={cn(
+                              'size-1.5 rounded-full transition-colors',
+                              stepIndex() === steps().indexOf(step())
+                                ? 'bg-accent'
+                                : stepIndex() > steps().indexOf(step())
+                                  ? 'bg-ink/40'
+                                  : 'bg-ink/15'
+                            )}
+                          />
+                        )}
+                      </Index>
+                    </div>
+                  </Show>
+                </div>
               </div>
             </div>
           </div>
         </div>
-      </div>
 
-      {/* Brand handoff overlay — rendered outside the animated card (a
+        {/* Brand handoff overlay — rendered outside the animated card (a
           transformed ancestor would break its fixed positioning). */}
-      <Show when={handoff()}>
-        {(active) => (
-          <BrandHandoff
-            scene={active().scene}
-            logo={active().logo}
-            snapshot={active().snapshot}
-            targetSelector="#summary-brand-logo"
-            onDone={() => {
-              setLogoShown(true);
-              setContentShown(true);
-              setHandoff(null);
-            }}
-          />
-        )}
-      </Show>
+        <Show when={handoff()}>
+          {(active) => (
+            <BrandHandoff
+              scene={active().scene}
+              logo={active().logo}
+              snapshot={active().snapshot}
+              targetSelector="#summary-brand-logo"
+              onDone={() => {
+                setLogoShown(true);
+                setContentShown(true);
+                setHandoff(null);
+              }}
+            />
+          )}
+        </Show>
+      </OnboardingHardModeProvider>
     </div>
   );
 }

--- a/apps/web/src/features/setup/flow/hardModePosition.test.ts
+++ b/apps/web/src/features/setup/flow/hardModePosition.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
-import { HARD_MODE_SWITCH_ZONE, randomSkipPosition } from './hardModePosition';
+import {
+  HARD_MODE_SWITCH_ZONE,
+  randomSkipJumpDelayMs,
+  randomSkipPosition,
+  SKIP_JUMP_DELAY_MS,
+} from './hardModePosition';
 
 describe('randomSkipPosition', () => {
   it('uses the rng for both axes', () => {
@@ -31,6 +36,21 @@ describe('randomSkipPosition', () => {
         pos.left < HARD_MODE_SWITCH_ZONE.maxLeft &&
         pos.top > HARD_MODE_SWITCH_ZONE.minTop;
       expect(inSwitchZone).toBe(false);
+    }
+  });
+});
+
+describe('randomSkipJumpDelayMs', () => {
+  it('is 200ms at rng 0 and 1500ms at rng 1', () => {
+    expect(randomSkipJumpDelayMs(() => 0)).toBe(SKIP_JUMP_DELAY_MS.min);
+    expect(randomSkipJumpDelayMs(() => 1)).toBe(SKIP_JUMP_DELAY_MS.max);
+  });
+
+  it('stays in 200–1500ms across many draws', () => {
+    for (let n = 0; n < 200; n++) {
+      const ms = randomSkipJumpDelayMs();
+      expect(ms).toBeGreaterThanOrEqual(SKIP_JUMP_DELAY_MS.min);
+      expect(ms).toBeLessThanOrEqual(SKIP_JUMP_DELAY_MS.max);
     }
   });
 });

--- a/apps/web/src/features/setup/flow/hardModePosition.test.ts
+++ b/apps/web/src/features/setup/flow/hardModePosition.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import { HARD_MODE_SWITCH_ZONE, randomSkipPosition } from './hardModePosition';
+
+describe('randomSkipPosition', () => {
+  it('uses the rng for both axes', () => {
+    const values = [0, 0];
+    let i = 0;
+    const pos = randomSkipPosition(() => values[i++] ?? 0);
+    expect(pos).toEqual({ left: 8, top: 8 });
+  });
+
+  it('keeps skip out of the hard-mode switch zone', () => {
+    // First pair lands in the bottom-left reserved zone; the reroll must
+    // push left past the switch.
+    const values = [0, 1, 0];
+    let i = 0;
+    const pos = randomSkipPosition(() => values[i++] ?? 0);
+    expect(pos.left).toBeGreaterThanOrEqual(HARD_MODE_SWITCH_ZONE.maxLeft);
+    expect(pos.top).toBeGreaterThan(HARD_MODE_SWITCH_ZONE.minTop);
+  });
+
+  it('stays inside the padded surface across many draws', () => {
+    for (let n = 0; n < 200; n++) {
+      const pos = randomSkipPosition();
+      expect(pos.left).toBeGreaterThanOrEqual(8);
+      expect(pos.left).toBeLessThanOrEqual(92);
+      expect(pos.top).toBeGreaterThanOrEqual(8);
+      expect(pos.top).toBeLessThanOrEqual(90);
+      const inSwitchZone =
+        pos.left < HARD_MODE_SWITCH_ZONE.maxLeft &&
+        pos.top > HARD_MODE_SWITCH_ZONE.minTop;
+      expect(inSwitchZone).toBe(false);
+    }
+  });
+});

--- a/apps/web/src/features/setup/flow/hardModePosition.ts
+++ b/apps/web/src/features/setup/flow/hardModePosition.ts
@@ -1,0 +1,38 @@
+/** Viewport-percent placement for the skip button in onboarding hard mode. */
+export type SkipPosition = {
+  left: number;
+  top: number;
+};
+
+/**
+ * Bottom-left region reserved for the Hard mode switch, in percent of the
+ * onboarding surface. Skip must not land here or the switch is unclickable.
+ */
+export const HARD_MODE_SWITCH_ZONE = {
+  maxLeft: 32,
+  minTop: 78,
+} as const;
+
+const PAD = 8;
+const MAX_LEFT = 84;
+const MAX_TOP = 82;
+
+/**
+ * Pick a skip-button origin in percent. `rng` is injectable so tests can
+ * pin the result; production passes `Math.random`.
+ */
+export function randomSkipPosition(
+  rng: () => number = Math.random
+): SkipPosition {
+  let left = PAD + rng() * MAX_LEFT;
+  let top = PAD + rng() * MAX_TOP;
+  if (
+    left < HARD_MODE_SWITCH_ZONE.maxLeft &&
+    top > HARD_MODE_SWITCH_ZONE.minTop
+  ) {
+    left =
+      HARD_MODE_SWITCH_ZONE.maxLeft +
+      rng() * (PAD + MAX_LEFT - HARD_MODE_SWITCH_ZONE.maxLeft);
+  }
+  return { left, top };
+}

--- a/apps/web/src/features/setup/flow/hardModePosition.ts
+++ b/apps/web/src/features/setup/flow/hardModePosition.ts
@@ -17,6 +17,9 @@ const PAD = 8;
 const MAX_LEFT = 84;
 const MAX_TOP = 82;
 
+/** Delay before a hard-mode skip jumps, in milliseconds. */
+export const SKIP_JUMP_DELAY_MS = { min: 200, max: 1500 } as const;
+
 /**
  * Pick a skip-button origin in percent. `rng` is injectable so tests can
  * pin the result; production passes `Math.random`.
@@ -35,4 +38,12 @@ export function randomSkipPosition(
       rng() * (PAD + MAX_LEFT - HARD_MODE_SWITCH_ZONE.maxLeft);
   }
   return { left, top };
+}
+
+/** Wait this long after a skip appears (or jumps) before it jumps again. */
+export function randomSkipJumpDelayMs(rng: () => number = Math.random): number {
+  return (
+    SKIP_JUMP_DELAY_MS.min +
+    rng() * (SKIP_JUMP_DELAY_MS.max - SKIP_JUMP_DELAY_MS.min)
+  );
 }

--- a/apps/web/src/features/setup/flow/shared.tsx
+++ b/apps/web/src/features/setup/flow/shared.tsx
@@ -1,7 +1,17 @@
 import ArrowRight from '@phosphor/arrow-right.svg';
 import CheckIcon from '@phosphor/check.svg';
 import { Button, Layer } from '@ui';
-import { For, onCleanup, onMount } from 'solid-js';
+import {
+  createMemo,
+  createSignal,
+  For,
+  onCleanup,
+  onMount,
+  Show,
+} from 'solid-js';
+import { Portal } from 'solid-js/web';
+import { useOnboardingHardMode } from './HardMode';
+import { randomSkipPosition } from './hardModePosition';
 
 /** Where the flow persists its current step, so full-page OAuth round-trips
  * (adding a Gmail inbox, Stripe checkout aborts) resume where they left. */
@@ -116,16 +126,55 @@ export function SkipButton(props: {
   disabled?: boolean;
   onClick: () => void;
 }) {
-  return (
+  const hardMode = useOnboardingHardMode();
+  const [nonce, setNonce] = createSignal(0);
+  const position = createMemo(() => {
+    if (!hardMode.hardMode()) return undefined;
+    nonce();
+    return randomSkipPosition();
+  });
+  const dodge = () => {
+    if (hardMode.hardMode()) setNonce((n) => n + 1);
+  };
+
+  const button = (className: string) => (
     <Button
       variant="ghost"
       size="sm"
-      class="self-center text-ink-muted"
+      class={className}
       disabled={props.disabled}
       onClick={props.onClick}
+      onPointerEnter={dodge}
     >
       {props.label ?? 'Skip for now'}
     </Button>
+  );
+
+  return (
+    <Show
+      when={
+        hardMode.hardMode() && hardMode.skipLayer() ? position() : undefined
+      }
+      fallback={button('self-center text-ink-muted')}
+    >
+      {(pos) => {
+        const layer = hardMode.skipLayer();
+        if (!layer) return button('self-center text-ink-muted');
+        return (
+          <Portal mount={layer}>
+            <div
+              class="pointer-events-auto absolute"
+              style={{
+                left: `${pos().left}%`,
+                top: `${pos().top}%`,
+              }}
+            >
+              {button('text-ink-muted')}
+            </div>
+          </Portal>
+        );
+      }}
+    </Show>
   );
 }
 

--- a/apps/web/src/features/setup/flow/shared.tsx
+++ b/apps/web/src/features/setup/flow/shared.tsx
@@ -11,7 +11,7 @@ import {
 } from 'solid-js';
 import { Portal } from 'solid-js/web';
 import { useOnboardingHardMode } from './HardMode';
-import { randomSkipPosition } from './hardModePosition';
+import { randomSkipJumpDelayMs, randomSkipPosition } from './hardModePosition';
 
 /** Where the flow persists its current step, so full-page OAuth round-trips
  * (adding a Gmail inbox, Stripe checkout aborts) resume where they left. */
@@ -121,6 +121,14 @@ export function FeatureList(props: { features: string[] }) {
   );
 }
 
+function SkipJumpTimer(props: { onJump: () => void }) {
+  onMount(() => {
+    const timer = setTimeout(props.onJump, randomSkipJumpDelayMs());
+    onCleanup(() => clearTimeout(timer));
+  });
+  return null;
+}
+
 export function SkipButton(props: {
   label?: string;
   disabled?: boolean;
@@ -133,9 +141,6 @@ export function SkipButton(props: {
     nonce();
     return randomSkipPosition();
   });
-  const dodge = () => {
-    if (hardMode.hardMode()) setNonce((n) => n + 1);
-  };
 
   const button = (className: string) => (
     <Button
@@ -144,7 +149,6 @@ export function SkipButton(props: {
       class={className}
       disabled={props.disabled}
       onClick={props.onClick}
-      onPointerEnter={dodge}
     >
       {props.label ?? 'Skip for now'}
     </Button>
@@ -162,6 +166,9 @@ export function SkipButton(props: {
         if (!layer) return button('self-center text-ink-muted');
         return (
           <Portal mount={layer}>
+            <For each={[nonce()]}>
+              {() => <SkipJumpTimer onJump={() => setNonce((n) => n + 1)} />}
+            </For>
             <div
               class="pointer-events-auto absolute"
               style={{


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Stacked on the local-onboarding flag work (`cursor/disable-local-onboarding-f49f`). Separate from that change.

Adds an always-visible **Hard mode** switch at the bottom left of the onboarding flow. When it is on, Skip for now / Decide later teleport around the onboarding surface. Each landing stays put for a random **0.2–1.5s**, so a fast click still counts; then it jumps again. The randomizer keeps the button out of the switch's corner so you can still turn hard mode off.

## Test plan

- [x] `randomSkipPosition` stays in-bounds and out of the switch zone
- [x] Jump delay is 200–1500ms
- [ ] Open `/onboarding` with `VITE_ENABLE_ONBOARDING_V4=true`
- [ ] Hard mode switch is visible bottom-left and off by default
- [ ] Flip it on: skip appears, stays clickable briefly, then jumps
- [ ] Flip it off: skip returns to its normal place under the step

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e7f473da-c828-42e3-bf4b-264a1ad2f49f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e7f473da-c828-42e3-bf4b-264a1ad2f49f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

