### PR TITLE
fix(calendar): include the organizer as an accepted guest

### DIFF
--- a/crates/calendar_events/src/domain/models.rs
+++ b/crates/calendar_events/src/domain/models.rs
@@ -805,6 +805,8 @@ pub struct CalendarAttendeeInput {
     pub email: String,
     /// Whether attendance is optional.
     pub is_optional: bool,
+    /// RSVP to write for this attendee. `None` leaves the provider default.
+    pub response_status: Option<AttendeeResponseStatus>,
 }
 
 /// User-supplied fields for a new provider event.

--- a/crates/calendar_events/src/domain/mutations.rs
+++ b/crates/calendar_events/src/domain/mutations.rs
@@ -11,10 +11,10 @@ use uuid::Uuid;
 
 use super::{
     models::{
-        AttendeeResponseStatus, CalendarEvent, CalendarEventDraft, CalendarEventMutationTarget,
-        CalendarEventPatch, CalendarEventUpsert, DisconnectedGoogleCalendar, EventReminders,
-        EventTime, OccurrenceRange, REMINDER_METHOD_EMAIL, REMINDER_METHOD_POPUP,
-        REMINDER_MINUTES_MAX, REMINDER_OVERRIDES_MAX,
+        AttendeeResponseStatus, CalendarAttendeeInput, CalendarEvent, CalendarEventDraft,
+        CalendarEventMutationTarget, CalendarEventPatch, CalendarEventUpsert,
+        DisconnectedGoogleCalendar, EventReminders, EventTime, OccurrenceRange,
+        REMINDER_METHOD_EMAIL, REMINDER_METHOD_POPUP, REMINDER_MINUTES_MAX, REMINDER_OVERRIDES_MAX,
     },
     ports::{
         CalendarAccessTokenProvider, CalendarDeletionScope, CalendarEventChange,
@@ -161,7 +161,7 @@ where
         requester_id: &str,
         email_link_id: Option<Uuid>,
         calendar_id: Option<Uuid>,
-        draft: CalendarEventDraft,
+        mut draft: CalendarEventDraft,
     ) -> Result<CalendarEvent, CalendarMutationError> {
         validate_time(&draft.time)?;
         validate_attendee_emails(draft.attendees.iter().map(|attendee| &attendee.email))?;
@@ -177,6 +177,7 @@ where
         if target.is_read_only {
             return Err(CalendarMutationError::ReadOnly);
         }
+        ensure_organizer_attendee(&mut draft.attendees, &target.token_identity.email_address);
         let access_token = self.fetch_token(&target.token_identity).await?;
         let upsert = self
             .provider
@@ -540,6 +541,24 @@ fn validate_reminders(reminders: &EventReminders) -> Result<(), CalendarMutation
         }
     }
     Ok(())
+}
+
+fn ensure_organizer_attendee(attendees: &mut Vec<CalendarAttendeeInput>, organizer_email: &str) {
+    if let Some(existing) = attendees
+        .iter_mut()
+        .find(|attendee| attendee.email.eq_ignore_ascii_case(organizer_email))
+    {
+        existing.response_status = Some(AttendeeResponseStatus::Accepted);
+        return;
+    }
+    attendees.insert(
+        0,
+        CalendarAttendeeInput {
+            email: organizer_email.to_string(),
+            is_optional: false,
+            response_status: Some(AttendeeResponseStatus::Accepted),
+        },
+    );
 }
 
 fn validate_attendee_emails<'a>(

--- a/crates/calendar_events/src/domain/mutations.rs
+++ b/crates/calendar_events/src/domain/mutations.rs
@@ -544,11 +544,19 @@ fn validate_reminders(reminders: &EventReminders) -> Result<(), CalendarMutation
 }
 
 fn ensure_organizer_attendee(attendees: &mut Vec<CalendarAttendeeInput>, organizer_email: &str) {
-    if let Some(existing) = attendees
-        .iter_mut()
-        .find(|attendee| attendee.email.eq_ignore_ascii_case(organizer_email))
-    {
-        existing.response_status = Some(AttendeeResponseStatus::Accepted);
+    let mut kept = false;
+    attendees.retain_mut(|attendee| {
+        if !attendee.email.eq_ignore_ascii_case(organizer_email) {
+            return true;
+        }
+        if kept {
+            return false;
+        }
+        attendee.response_status = Some(AttendeeResponseStatus::Accepted);
+        kept = true;
+        true
+    });
+    if kept {
         return;
     }
     attendees.insert(

--- a/crates/calendar_events/src/domain/mutations/test.rs
+++ b/crates/calendar_events/src/domain/mutations/test.rs
@@ -931,6 +931,53 @@ async fn create_does_not_duplicate_an_organizer_already_on_the_guest_list() {
 }
 
 #[tokio::test]
+async fn create_collapses_duplicate_organizer_rows() {
+    let provider = FakeProvider::new(FakeProviderBehavior::Echo);
+    let drafts = provider.created_drafts.clone();
+    let mut listed = draft();
+    listed.attendees.push(CalendarAttendeeInput {
+        email: "Self@example.com".to_string(),
+        is_optional: true,
+        response_status: None,
+    });
+    listed.attendees.push(CalendarAttendeeInput {
+        email: "self@EXAMPLE.com".to_string(),
+        is_optional: false,
+        response_status: Some(AttendeeResponseStatus::NeedsAction),
+    });
+    service(
+        FakeRepo {
+            creation_target: Some(creation_target(false)),
+            persisted_event_id: Some(Uuid::now_v7()),
+            ..FakeRepo::default()
+        },
+        provider,
+        FakeTokens::ok(),
+    )
+    .create_event("macro|user", None, None, listed)
+    .await
+    .unwrap();
+
+    let sent = drafts.lock().unwrap();
+    let organizers: Vec<_> = sent[0]
+        .attendees
+        .iter()
+        .filter(|attendee| attendee.email.eq_ignore_ascii_case("self@example.com"))
+        .collect();
+    assert_eq!(organizers.len(), 1);
+    assert_eq!(
+        organizers[0].response_status,
+        Some(AttendeeResponseStatus::Accepted)
+    );
+    assert!(
+        sent[0]
+            .attendees
+            .iter()
+            .any(|attendee| attendee.email == "guest@example.com")
+    );
+}
+
+#[tokio::test]
 async fn create_rejects_invalid_input_before_reaching_the_provider() {
     let provider = FakeProvider::new(FakeProviderBehavior::Echo);
     let calls = provider.calls.clone();

--- a/crates/calendar_events/src/domain/mutations/test.rs
+++ b/crates/calendar_events/src/domain/mutations/test.rs
@@ -105,6 +105,7 @@ fn draft() -> CalendarEventDraft {
         attendees: vec![CalendarAttendeeInput {
             email: "guest@example.com".to_string(),
             is_optional: false,
+            response_status: None,
         }],
         recurrence_lines: Vec::new(),
         visibility: None,
@@ -319,6 +320,7 @@ enum FakeProviderBehavior {
 struct FakeProvider {
     behavior: FakeProviderBehavior,
     calls: Arc<Mutex<Vec<String>>>,
+    created_drafts: Arc<Mutex<Vec<CalendarEventDraft>>>,
 }
 
 impl FakeProvider {
@@ -326,6 +328,7 @@ impl FakeProvider {
         Self {
             behavior,
             calls: Arc::new(Mutex::new(Vec::new())),
+            created_drafts: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
@@ -344,9 +347,10 @@ impl GoogleCalendarMutationProvider for FakeProvider {
         &self,
         _access_token: &str,
         target: &GoogleCalendarTarget,
-        _draft: &CalendarEventDraft,
+        draft: &CalendarEventDraft,
     ) -> Result<CalendarEventUpsert, GoogleProviderError> {
         self.calls.lock().unwrap().push("create".to_string());
+        self.created_drafts.lock().unwrap().push(draft.clone());
         if let Some(error) = self.fail() {
             return Err(error);
         }
@@ -849,6 +853,80 @@ async fn a_rejected_mutation_publishes_nothing() {
     assert!(
         broker.published().is_empty(),
         "nothing persisted, so nothing to announce"
+    );
+}
+
+#[tokio::test]
+async fn create_includes_the_calendar_inbox_as_an_accepted_guest() {
+    let provider = FakeProvider::new(FakeProviderBehavior::Echo);
+    let drafts = provider.created_drafts.clone();
+    service(
+        FakeRepo {
+            creation_target: Some(creation_target(false)),
+            persisted_event_id: Some(Uuid::now_v7()),
+            ..FakeRepo::default()
+        },
+        provider,
+        FakeTokens::ok(),
+    )
+    .create_event("macro|user", None, None, draft())
+    .await
+    .unwrap();
+
+    let sent = drafts.lock().unwrap();
+    assert_eq!(sent.len(), 1);
+    let organizer = sent[0]
+        .attendees
+        .iter()
+        .find(|attendee| attendee.email.eq_ignore_ascii_case("self@example.com"))
+        .expect("the creation-target inbox must be on the guest list");
+    assert_eq!(
+        organizer.response_status,
+        Some(AttendeeResponseStatus::Accepted)
+    );
+    assert!(!organizer.is_optional);
+    assert!(
+        sent[0]
+            .attendees
+            .iter()
+            .any(|attendee| attendee.email == "guest@example.com"),
+        "invited guests must still be sent"
+    );
+}
+
+#[tokio::test]
+async fn create_does_not_duplicate_an_organizer_already_on_the_guest_list() {
+    let provider = FakeProvider::new(FakeProviderBehavior::Echo);
+    let drafts = provider.created_drafts.clone();
+    let mut already_listed = draft();
+    already_listed.attendees.push(CalendarAttendeeInput {
+        email: "Self@example.com".to_string(),
+        is_optional: true,
+        response_status: None,
+    });
+    service(
+        FakeRepo {
+            creation_target: Some(creation_target(false)),
+            persisted_event_id: Some(Uuid::now_v7()),
+            ..FakeRepo::default()
+        },
+        provider,
+        FakeTokens::ok(),
+    )
+    .create_event("macro|user", None, None, already_listed)
+    .await
+    .unwrap();
+
+    let sent = drafts.lock().unwrap();
+    let organizers: Vec<_> = sent[0]
+        .attendees
+        .iter()
+        .filter(|attendee| attendee.email.eq_ignore_ascii_case("self@example.com"))
+        .collect();
+    assert_eq!(organizers.len(), 1);
+    assert_eq!(
+        organizers[0].response_status,
+        Some(AttendeeResponseStatus::Accepted)
     );
 }
 

--- a/crates/calendar_events/src/inbound/mutation_router.rs
+++ b/crates/calendar_events/src/inbound/mutation_router.rs
@@ -105,6 +105,7 @@ impl From<CalendarAttendeeInputBody> for CalendarAttendeeInput {
         Self {
             email: body.email,
             is_optional: body.is_optional,
+            response_status: None,
         }
     }
 }

--- a/crates/calendar_events/src/inbound/toolset.rs
+++ b/crates/calendar_events/src/inbound/toolset.rs
@@ -185,6 +185,7 @@ impl From<AttendeeInput> for CalendarAttendeeInput {
         Self {
             email: input.email,
             is_optional: input.is_optional,
+            response_status: None,
         }
     }
 }

--- a/crates/calendar_events/src/outbound/email_service_mutations/test.rs
+++ b/crates/calendar_events/src/outbound/email_service_mutations/test.rs
@@ -26,6 +26,7 @@ fn sample_draft() -> CalendarEventDraft {
         attendees: vec![CalendarAttendeeInput {
             email: "guest@example.com".to_string(),
             is_optional: true,
+            response_status: None,
         }],
         recurrence_lines: vec!["RRULE:FREQ=WEEKLY".to_string()],
         visibility: None,
@@ -64,6 +65,7 @@ fn update_body_matches_the_router_request() {
         attendees: Some(vec![CalendarAttendeeInput {
             email: "guest@example.com".to_string(),
             is_optional: false,
+            response_status: None,
         }]),
         conference: Some(crate::domain::models::ConferenceChange::Removed),
         ..Default::default()

--- a/crates/calendar_events/src/outbound/google.rs
+++ b/crates/calendar_events/src/outbound/google.rs
@@ -1471,10 +1471,15 @@ fn google_attendees_body(attendees: &[CalendarAttendeeInput]) -> serde_json::Val
     attendees
         .iter()
         .map(|attendee| {
-            serde_json::json!({
+            let mut entry = serde_json::json!({
                 "email": attendee.email,
                 "optional": attendee.is_optional,
-            })
+            });
+            if let Some(status) = attendee.response_status {
+                entry["responseStatus"] =
+                    serde_json::Value::String(google_response_status(status).to_string());
+            }
+            entry
         })
         .collect()
 }

--- a/crates/calendar_events/src/outbound/google/test.rs
+++ b/crates/calendar_events/src/outbound/google/test.rs
@@ -560,6 +560,32 @@ fn rsvp_patch_updates_only_the_connected_attendee() {
 }
 
 #[test]
+fn google_attendees_write_an_explicit_response_status() {
+    let body = google_attendees_body(&[
+        CalendarAttendeeInput {
+            email: "self@example.com".to_string(),
+            is_optional: false,
+            response_status: Some(AttendeeResponseStatus::Accepted),
+        },
+        CalendarAttendeeInput {
+            email: "guest@example.com".to_string(),
+            is_optional: true,
+            response_status: None,
+        },
+    ]);
+
+    assert_eq!(body[0]["email"], "self@example.com");
+    assert_eq!(body[0]["responseStatus"], "accepted");
+    assert_eq!(body[0]["optional"], false);
+    assert_eq!(body[1]["email"], "guest@example.com");
+    assert_eq!(body[1]["optional"], true);
+    assert!(
+        body[1].get("responseStatus").is_none(),
+        "a guest without a status must keep Google's default"
+    );
+}
+
+#[test]
 fn reminders_round_trip_between_google_and_the_domain() {
     let master: GoogleEvent = serde_json::from_value(serde_json::json!({
         "id": "provider-event",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why


The HTTP body and the AI tool both send only the chips the user picked. `create_event` forwarded that list as-is. Guests therefore never saw the creator.

## Scope

`create_event` now calls `ensure_organizer_attendee` after it resolves the creation-target inbox.

- If that inbox is not already on `draft.attendees`, it is inserted first and marked `accepted`.
- If it is already present, the existing row is marked `accepted`. Match is case-insensitive.
- `CalendarAttendeeInput` gained `response_status`. HTTP and tool adapters leave it `None`.
- `google_attendees_body` writes `responseStatus` only when that field is set.

Out of scope: RSVP identity, guest-picker Tab, and synthesizing an organizer on persist.

## Tradeoffs

Domain injection beats adding the creator only in the composer chips. HTTP create and the AI tool both go through `create_event`. A persist-time synthesis was rejected because Google already echoes attendees after a correct write.

## Blast Radius

Every new event created through Macro, including the AI tool. Existing events are unchanged until edited. Guest rows without `response_status` still omit the field, so Google keeps `needsAction`.

## Verification

Red, then green, against the live crate tests.

- `cargo test -p calendar_events --lib create_includes_the_calendar_inbox` failed with `the creation-target inbox must be on the guest list`.
- The same test now passes.
- `create_does_not_duplicate_an_organizer` passes. A listed organizer is not inserted twice and is marked accepted.
- `cargo test -p calendar_events --features google --lib google_attendees_write_an_explicit` passes.
- `cargo test -p calendar_events --lib` is 54 passed, 0 failed.

I did not drive Google Calendar with two accounts. The unit path is the create draft sent to the provider.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2891aa86-4fe5-45bb-a92f-6e5a08588b74?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2891aa86-4fe5-45bb-a92f-6e5a08588b74&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

