### PR TITLE
fix(calendar): stop Tab from adding a hovered guest

### DIFF
--- a/apps/web/src/features/calendar/components/composer/EventPropertyPills.tsx
+++ b/apps/web/src/features/calendar/components/composer/EventPropertyPills.tsx
@@ -346,17 +346,7 @@ function EditableEventComposerGuestsPill(props: EventComposerGuestsPillProps) {
                     event.preventDefault();
                     event.stopPropagation();
                     setOpen(false);
-                    return;
                   }
-                  if (event.key !== 'Tab' || !open()) return;
-                  event.preventDefault();
-                  event.stopPropagation();
-                  input?.dispatchEvent(
-                    new KeyboardEvent('keydown', {
-                      bubbles: true,
-                      key: 'Enter',
-                    })
-                  );
                 }}
               />
             </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

The guests pill remapped Tab to Enter. Opening the list shows every contact. Hover moves the highlighted row. Tab then committed that contact even when the typed prefix did not match them.

## Scope

`EditableEventComposerGuestsPill` no longer synthesizes an Enter keydown on Tab. Escape still closes the list. The email `RecipientSelector` Tab remap is unchanged.

Out of scope: organizer-as-guest and RSVP identity.

## Tradeoffs

Native Kobalte Tab leaves the list. That is the smaller fix. Changing the filter so `"Jack"` matches `"Jacqueline"` would invent a bug the picker does not have.

## Blast Radius

Only the event composer guests pill. Tab in the email recipient box still commits the highlighted row.

## Verification

No guest-pill test harness exists. I did not add one for a ten-line deletion.

`rg` on `EventPropertyPills.tsx` finds no Tab-to-Enter remap. `RecipientSelector.tsx` still has its Enter dispatch at line 823.

I did not drive the composer in a browser. The product stack is not up, and the change is the missing key remap.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2891aa86-4fe5-45bb-a92f-6e5a08588b74?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2891aa86-4fe5-45bb-a92f-6e5a08588b74&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

