### PR TITLE
fix(agent_harness): simplify Daytona snapshot check

### DIFF
--- a/crates/agent_harness/justfile
+++ b/crates/agent_harness/justfile
@@ -51,50 +51,29 @@ ensure-daytona:
     memory={{snapshot_memory}}
     disk={{snapshot_disk}}
     echo "desired snapshot $name at --cpu $cpu --memory $memory --disk $disk"
-    state="$(daytona snapshot list --format json | python3 -c '
-import json, sys
-name, cpu, memory, disk = sys.argv[1:5]
-found = next((item for item in json.load(sys.stdin) if item.get("name") == name), None)
-if found is None:
-    print("missing")
-    raise SystemExit(0)
-current_cpu = int(found.get("cpu") or 0)
-current_memory = int(found.get("mem") or found.get("memory") or 0)
-current_disk = int(found.get("disk") or 0)
-if current_cpu == int(cpu) and current_memory == int(memory) and current_disk == int(disk):
-    print("match")
-    raise SystemExit(0)
-print(f"mismatch cpu={current_cpu} memory={current_memory} disk={current_disk}")
-' "$name" "$cpu" "$memory" "$disk")"
-    case "$state" in
-      match)
-        echo "snapshot $name already exists at --cpu $cpu --memory $memory --disk $disk, skipping build"
-        ;;
-      mismatch*)
-        echo "$state" >&2
-        echo "snapshot $name is not --cpu $cpu --memory $memory --disk $disk" >&2
-        echo "not deleting it: recreate with 'just rebuild-daytona' after Daytona raises per-sandbox limits (support@daytona.io)" >&2
-        exit 1
-        ;;
-      missing)
-        echo "building snapshot $name (slow: the image bakes two nix dev shells)"
-        # `--context .` matters twice over. Without any `--context` the CLI
-        # auto-detects from COPY lines and misses
-        # `COPY sidecar/Cargo.toml sidecar/Cargo.lock ./`; with per-entry contexts
-        # (`--context sidecar`) it uploads that directory's *contents* flattened, so
-        # the `sidecar/` prefix the Dockerfile copies from does not exist. Either
-        # way the build dies in the sidecar stage with "/sidecar/src: not found".
-        # Passing the directory keeps paths intact - it is only ~84KB.
-        ( cd container && daytona snapshot create "$name" \
-            --dockerfile Dockerfile \
-            --context . \
-            --cpu "$cpu" --memory "$memory" --disk "$disk" )
-        ;;
-      *)
-        echo "unexpected snapshot state: $state" >&2
-        exit 1
-        ;;
-    esac
+    snapshot="$(daytona snapshot list --format json | jq -c --arg name "$name" 'first(.[] | select(.name == $name)) // empty')"
+    if [[ -z "$snapshot" ]]; then
+      echo "building snapshot $name (slow: the image bakes two nix dev shells)"
+      # `--context .` keeps paths intact instead of flattening container/.
+      ( cd container && daytona snapshot create "$name" \
+          --dockerfile Dockerfile \
+          --context . \
+          --cpu "$cpu" --memory "$memory" --disk "$disk" )
+      exit
+    fi
+
+    IFS=$'\t' read -r current_cpu current_memory current_disk < <(
+      jq -r '[.cpu // 0, .mem // .memory // 0, .disk // 0] | @tsv' <<<"$snapshot"
+    )
+    if [[ "$current_cpu/$current_memory/$current_disk" == "$cpu/$memory/$disk" ]]; then
+      echo "snapshot $name already exists at the desired size, skipping build"
+      exit
+    fi
+
+    echo "snapshot $name has --cpu $current_cpu --memory $current_memory --disk $current_disk" >&2
+    echo "expected --cpu $cpu --memory $memory --disk $disk" >&2
+    echo "not deleting it: recreate with 'just rebuild-daytona' after Daytona raises per-sandbox limits (support@daytona.io)" >&2
+    exit 1
 
 # Build the Daytona snapshot if missing, then boot an agent in a sandbox
 boot-daytona prompt=default_prompt: ensure-daytona


### PR DESCRIPTION
## Summary
- replace the multiline embedded Python that Just parsed as recipe syntax with a compact jq-based snapshot lookup
- keep missing, matching, and mismatched snapshot handling explicit and non-destructive
- preserve support for both Daytona memory field names

## Verification
- `just --justfile crates/agent_harness/justfile --list`
- exercised missing snapshot creation with a stub Daytona CLI
- exercised matching `mem` snapshot skip with a stub Daytona CLI
- exercised mismatched `memory` snapshot failure with a stub Daytona CLI
- `git diff --check origin/main...HEAD`