### PR TITLE
fix(agent-harness): fit default Daytona quota

### DIFF
--- a/apps/web/src/features/block-agent/ui/SandboxSizeSelector.tsx
+++ b/apps/web/src/features/block-agent/ui/SandboxSizeSelector.tsx
@@ -11,7 +11,7 @@ const TIERS: {
   detail: string;
 }[] = [
   { id: 'small', label: 'Small', detail: '2 vCPU · 4 GiB · 96 GiB' },
-  { id: 'default', label: 'Default', detail: '8 vCPU · 16 GiB · 96 GiB' },
+  { id: 'default', label: 'Default', detail: '4 vCPU · 8 GiB · 96 GiB' },
   { id: 'large', label: 'Large', detail: '16 vCPU · 32 GiB · 96 GiB' },
 ];
 

--- a/crates/agent_harness/src/domain/sandbox.rs
+++ b/crates/agent_harness/src/domain/sandbox.rs
@@ -48,8 +48,8 @@ pub fn resources(size: SandboxSize) -> SandboxResources {
             disk_gib: 96,
         },
         SandboxSize::Default => SandboxResources {
-            cpu: 8,
-            memory_gib: 16,
+            cpu: 4,
+            memory_gib: 8,
             disk_gib: 96,
         },
         SandboxSize::Large => SandboxResources {

--- a/crates/agent_harness/src/domain/sandbox/test.rs
+++ b/crates/agent_harness/src/domain/sandbox/test.rs
@@ -8,12 +8,12 @@ fn disk_is_96_gib_for_every_tier() {
 }
 
 #[test]
-fn default_is_eight_cpu_sixteen_gib() {
+fn default_fits_the_daytona_snapshot_quota() {
     assert_eq!(
         resources(SandboxSize::Default),
         SandboxResources {
-            cpu: 8,
-            memory_gib: 16,
+            cpu: 4,
+            memory_gib: 8,
             disk_gib: 96,
         }
     );
@@ -56,11 +56,11 @@ fn live_quotas_that_are_not_named_tiers_still_pick_in_place_or_restart() {
     };
     assert_eq!(
         resize_effect_from_resources(snapshot, resources(SandboxSize::Default)),
-        SandboxResizeEffect::InPlace
+        SandboxResizeEffect::NoOp
     );
     assert_eq!(
         resize_effect_from_resources(resources(SandboxSize::Default), snapshot),
-        SandboxResizeEffect::Restart
+        SandboxResizeEffect::NoOp
     );
     assert_eq!(
         resize_effect_from_resources(snapshot, snapshot),

--- a/crates/agent_session/src/domain/sandbox_size.rs
+++ b/crates/agent_session/src/domain/sandbox_size.rs
@@ -15,7 +15,7 @@ mod test;
 pub enum SandboxSize {
     /// 2 vCPU / 4 GiB RAM / 96 GiB disk.
     Small,
-    /// 8 vCPU / 16 GiB RAM / 96 GiB disk.
+    /// 4 vCPU / 8 GiB RAM / 96 GiB disk.
     #[default]
     Default,
     /// 16 vCPU / 32 GiB RAM / 96 GiB disk.


### PR DESCRIPTION
## Summary
- map the default sandbox tier to 4 vCPU / 8 GiB, matching the current Daytona snapshot and account quota
- avoid the unnecessary default-session resize that returned HTTP 400 and persisted sessions as disconnected
- update sandbox resource/effect tests for the supported default

## Root cause
Hosted PR previews are static development-mode web builds and call `agent-harness-dev`, which uses Daytona. Datadog showed default session provisioning requesting 8 CPUs while the account allows at most 4. Cursor/local-stack previews still use local Docker through `DEV_DANGEROUS_LOCAL_CONTAINERS=true`; that runtime is separate from the hosted preview URL.

## Verification
- `cargo fmt --check`
- `cargo test -p agent_harness` (84 passed)
- `git diff --check`