### PR TITLE
fix(graphql): include shared email threads in direct loads

### DIFF
--- a/crates/graphql_soup/src/loaders.rs
+++ b/crates/graphql_soup/src/loaders.rs
@@ -16,18 +16,21 @@ use email::domain::{
 };
 use filter_ast::Expr;
 use futures::{future::BoxFuture, future::try_join_all};
-use item_filters::ast::{
-    EmailFilterAst, EntityFilterAst,
-    calendar_event::CalendarEventLiteral,
-    call::CallLiteral,
-    channel::{ChannelLiteral, ChannelThreadLiteral},
-    chat::ChatLiteral,
-    crm_company::CrmCompanyLiteral,
-    document::DocumentLiteral,
-    email::EmailLiteral,
-    foreign_entity::ForeignEntityLiteral,
-    project::ProjectLiteral,
-    reminder::ReminderLiteral,
+use item_filters::{
+    SharedEmailFilter,
+    ast::{
+        EmailFilterAst, EntityFilterAst,
+        calendar_event::CalendarEventLiteral,
+        call::CallLiteral,
+        channel::{ChannelLiteral, ChannelThreadLiteral},
+        chat::ChatLiteral,
+        crm_company::CrmCompanyLiteral,
+        document::DocumentLiteral,
+        email::EmailLiteral,
+        foreign_entity::ForeignEntityLiteral,
+        project::ProjectLiteral,
+        reminder::ReminderLiteral,
+    },
 };
 use macro_user_id::user_id::MacroUserIdStr;
 use model_entity::{Entity, EntityType};
@@ -387,7 +390,12 @@ fn entity_filter_ast(entities: &[Entity<'static>]) -> Result<EntityFilterAst, So
         project_filter: Some(literal_tree(projects, ProjectLiteral::ProjectIdSelf(nil))),
         chat_filter: Some(literal_tree(chats, ChatLiteral::ChatId(nil))),
         email_filter: EmailFilterAst {
-            tree: Some(literal_tree(email_threads, EmailLiteral::ThreadId(nil))),
+            tree: Some(Arc::new(Expr::and(
+                literal_tree(email_threads, EmailLiteral::ThreadId(nil))
+                    .as_ref()
+                    .clone(),
+                Expr::val(EmailLiteral::Shared(SharedEmailFilter::Include)),
+            ))),
             crm_scope: None,
         },
         channel_filter: Some(literal_tree(channels, ChannelLiteral::ChannelId(nil))),

--- a/crates/graphql_soup/src/loaders/test.rs
+++ b/crates/graphql_soup/src/loaders/test.rs
@@ -213,15 +213,37 @@ fn collect_ids<T>(expr: &Expr<T>, literal_id: impl Copy + Fn(&T) -> Option<Uuid>
     }
 }
 
-/// Return whether an email expression explicitly includes shared threads.
-fn includes_shared_threads(expr: &Expr<EmailLiteral>) -> bool {
+/// Collect thread IDs from an expression that contains only positive thread-ID literals.
+fn positive_email_thread_ids(expr: &Expr<EmailLiteral>) -> Option<HashSet<Uuid>> {
     match expr {
         Expr::And(left, right) | Expr::Or(left, right) => {
-            includes_shared_threads(left) || includes_shared_threads(right)
+            let mut ids = positive_email_thread_ids(left)?;
+            ids.extend(positive_email_thread_ids(right)?);
+            Some(ids)
         }
-        Expr::Not(_) => false,
-        Expr::Literal(EmailLiteral::Shared(SharedEmailFilter::Include)) => true,
-        Expr::Literal(_) => false,
+        Expr::Not(_) => None,
+        Expr::Literal(EmailLiteral::ThreadId(id)) => Some(HashSet::from([*id])),
+        Expr::Literal(_) => None,
+    }
+}
+
+/// Return whether positive thread IDs are combined with shared-thread inclusion via `And`.
+fn includes_shared_threads(expr: &Expr<EmailLiteral>, expected_ids: &HashSet<Uuid>) -> bool {
+    let is_shared_include = |expr: &Expr<EmailLiteral>| {
+        matches!(
+            expr,
+            Expr::Literal(EmailLiteral::Shared(SharedEmailFilter::Include))
+        )
+    };
+    let has_expected_ids =
+        |expr: &Expr<EmailLiteral>| positive_email_thread_ids(expr).as_ref() == Some(expected_ids);
+
+    match expr {
+        Expr::And(left, right) => {
+            (has_expected_ids(left) && is_shared_include(right))
+                || (is_shared_include(left) && has_expected_ids(right))
+        }
+        Expr::Or(_, _) | Expr::Not(_) | Expr::Literal(_) => false,
     }
 }
 
@@ -389,14 +411,10 @@ fn email_entity_filter_includes_shared_threads() {
     let ast = entity_filter_ast(&entities).expect("valid AST");
     let email_filter = ast.email_filter.tree.as_deref().expect("email filter");
 
-    assert!(includes_shared_threads(email_filter));
-    assert_eq!(
-        collect_ids(email_filter, |literal| match literal {
-            EmailLiteral::ThreadId(id) => Some(*id),
-            _ => None,
-        }),
-        HashSet::from([thread_id])
-    );
+    assert!(includes_shared_threads(
+        email_filter,
+        &HashSet::from([thread_id])
+    ));
 }
 
 #[test]
@@ -457,16 +475,10 @@ fn encodes_requested_ids_and_disables_unrequested_entity_branches() {
         ),
         HashSet::from([nil])
     );
-    assert_eq!(
-        collect_ids(
-            ast.email_filter.tree.as_deref().expect("email filter"),
-            |literal| match literal {
-                EmailLiteral::ThreadId(id) => Some(*id),
-                _ => None,
-            }
-        ),
-        HashSet::from([nil])
-    );
+    assert!(includes_shared_threads(
+        ast.email_filter.tree.as_deref().expect("email filter"),
+        &HashSet::from([nil])
+    ));
     assert_eq!(
         collect_ids(
             ast.channel_thread_filter

--- a/crates/graphql_soup/src/loaders/test.rs
+++ b/crates/graphql_soup/src/loaders/test.rs
@@ -5,15 +5,18 @@ use std::{
 
 use chrono::{DateTime, Utc};
 use entity_access::domain::models::{EntityAccessReceipt, MemberTeamRole};
-use item_filters::ast::{
-    call::CallLiteral,
-    channel::{ChannelLiteral, ChannelThreadLiteral},
-    chat::ChatLiteral,
-    crm_company::CrmCompanyLiteral,
-    document::DocumentLiteral,
-    email::EmailLiteral,
-    foreign_entity::ForeignEntityLiteral,
-    project::ProjectLiteral,
+use item_filters::{
+    SharedEmailFilter,
+    ast::{
+        call::CallLiteral,
+        channel::{ChannelLiteral, ChannelThreadLiteral},
+        chat::ChatLiteral,
+        crm_company::CrmCompanyLiteral,
+        document::DocumentLiteral,
+        email::EmailLiteral,
+        foreign_entity::ForeignEntityLiteral,
+        project::ProjectLiteral,
+    },
 };
 use models_pagination::{Paginated, PaginatedCursor};
 use models_properties::service::property_definition_with_options::PropertyDefinitionWithOptions;
@@ -210,6 +213,18 @@ fn collect_ids<T>(expr: &Expr<T>, literal_id: impl Copy + Fn(&T) -> Option<Uuid>
     }
 }
 
+/// Return whether an email expression explicitly includes shared threads.
+fn includes_shared_threads(expr: &Expr<EmailLiteral>) -> bool {
+    match expr {
+        Expr::And(left, right) | Expr::Or(left, right) => {
+            includes_shared_threads(left) || includes_shared_threads(right)
+        }
+        Expr::Not(_) => false,
+        Expr::Literal(EmailLiteral::Shared(SharedEmailFilter::Include)) => true,
+        Expr::Literal(_) => false,
+    }
+}
+
 #[tokio::test]
 async fn batches_all_keys_for_one_user_into_one_soup_request() {
     let user_id = user("macro|one@example.com");
@@ -364,6 +379,24 @@ async fn context_loader_returns_none_for_a_missing_item() {
         .expect("missing item is not a loader failure");
 
     assert!(item.is_none());
+}
+
+#[test]
+fn email_entity_filter_includes_shared_threads() {
+    let thread_id = Uuid::from_u128(20);
+    let entities = vec![EntityType::EmailThread.with_entity_string(thread_id.to_string())];
+
+    let ast = entity_filter_ast(&entities).expect("valid AST");
+    let email_filter = ast.email_filter.tree.as_deref().expect("email filter");
+
+    assert!(includes_shared_threads(email_filter));
+    assert_eq!(
+        collect_ids(email_filter, |literal| match literal {
+            EmailLiteral::ThreadId(id) => Some(*id),
+            _ => None,
+        }),
+        HashSet::from([thread_id])
+    );
 }
 
 #[test]


### PR DESCRIPTION
Fixes an issue where graphql requests for shared emails would not resolve because we were implcitly querying for non-shared emails