### PR TITLE
Add phone number recognition to event location field

### DIFF
--- a/apps/web/src/features/calendar/components/EventDetails.tsx
+++ b/apps/web/src/features/calendar/components/EventDetails.tsx
@@ -14,6 +14,7 @@ import CaretDownIcon from '@phosphor/caret-down.svg';
 import CheckIcon from '@phosphor/check.svg';
 import GlobeIcon from '@phosphor/globe.svg';
 import MapPinIcon from '@phosphor/map-pin.svg';
+import PhoneIcon from '@phosphor/phone.svg';
 import QuestionMarkIcon from '@phosphor/question-mark.svg';
 import TextAlignLeftIcon from '@phosphor/text-align-left.svg';
 import PersonIcon from '@phosphor/user.svg';
@@ -35,6 +36,10 @@ import {
 import { Dynamic } from 'solid-js/web';
 import type { CalendarEvent, CalendarTimeFormat } from '../types';
 import { isSameLocalDate, parseLocalDate } from '../utils/calendar-date';
+import {
+  isPhoneOnlyLocation,
+  parseEventLocation,
+} from '../utils/event-location';
 import {
   formatReminderOffset,
   REMINDER_METHOD_POPUP,
@@ -336,6 +341,41 @@ function findOrganizer(event: CalendarEvent): CalendarOrganizer | undefined {
 }
 
 /**
+ * The location row. A phone number written into the location becomes a call
+ * link, so a dial-in number takes one click instead of being retyped into a
+ * phone by hand.
+ */
+function EventLocationItem(props: { location: string }) {
+  const segments = createMemo(() => parseEventLocation(props.location));
+
+  return (
+    <div class="contents">
+      <Dynamic
+        aria-hidden="true"
+        class="mt-0.5 size-5 text-ink-extra-muted sm:size-4"
+        component={isPhoneOnlyLocation(segments()) ? PhoneIcon : MapPinIcon}
+      />
+      <span class="select-text">
+        <For each={segments()}>
+          {(segment) =>
+            segment.kind === 'phone' ? (
+              <a
+                class="text-link hover:text-link-hover hover:underline"
+                href={segment.telUrl}
+              >
+                {segment.text}
+              </a>
+            ) : (
+              segment.text
+            )
+          }
+        </For>
+      </span>
+    </div>
+  );
+}
+
+/**
  * The reminders the event resolves to, one line each: its own overrides when
  * it departed from the calendar defaults, the calendar defaults otherwise.
  * Nothing renders while the calendar (and so its defaults) is unknown.
@@ -509,13 +549,8 @@ export function EventDetails(props: {
         )}
       </Show>
 
-      <Show when={props.event.location}>
-        {(location) => (
-          <div class="contents">
-            <MapPinIcon class="mt-0.5 size-5 text-ink-extra-muted sm:size-4" />
-            <span class="select-text">{location()}</span>
-          </div>
-        )}
+      <Show when={props.event.location?.trim()}>
+        {(location) => <EventLocationItem location={location()} />}
       </Show>
 
       <Show when={props.event.description}>

--- a/apps/web/src/features/calendar/utils/event-location.test.ts
+++ b/apps/web/src/features/calendar/utils/event-location.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from 'vitest';
+import {
+  type EventLocationSegment,
+  isPhoneOnlyLocation,
+  parseEventLocation,
+} from './event-location';
+
+/** The phone numbers a location was split into, with the URLs they dial. */
+function phones(location: string) {
+  return parseEventLocation(location)
+    .filter((segment) => segment.kind === 'phone')
+    .map((segment) => [segment.text, segment.telUrl]);
+}
+
+/** The location rebuilt from its segments, to prove nothing is dropped. */
+function rejoin(segments: EventLocationSegment[]) {
+  return segments.map((segment) => segment.text).join('');
+}
+
+describe('parseEventLocation', () => {
+  it('dials a location that is only a phone number', () => {
+    expect(parseEventLocation('+1 (555) 123-4567')).toEqual([
+      {
+        kind: 'phone',
+        text: '+1 (555) 123-4567',
+        telUrl: 'tel:+15551234567',
+      },
+    ]);
+  });
+
+  it.each([
+    ['(555) 123-4567', 'tel:5551234567'],
+    ['555-123-4567', 'tel:5551234567'],
+    ['555.123.4567', 'tel:5551234567'],
+    ['555 123 4567', 'tel:5551234567'],
+    ['5551234567', 'tel:5551234567'],
+    ['1-555-123-4567', 'tel:15551234567'],
+    ['+44 20 7123 4567', 'tel:+442071234567'],
+    ['+1 555 123 4567', 'tel:+15551234567'],
+    ['+15551234567', 'tel:+15551234567'],
+    // An en dash is what a paste from a formatted document brings along.
+    ['555–123–4567', 'tel:5551234567'],
+  ])('recognizes %s', (location, telUrl) => {
+    expect(phones(location)).toEqual([[location, telUrl]]);
+  });
+
+  it('links the number inside a location that also names a place', () => {
+    const segments = parseEventLocation("Joe's Diner, 555-123-4567");
+
+    expect(segments).toEqual([
+      { kind: 'text', text: "Joe's Diner, " },
+      { kind: 'phone', text: '555-123-4567', telUrl: 'tel:5551234567' },
+    ]);
+    expect(rejoin(segments)).toBe("Joe's Diner, 555-123-4567");
+  });
+
+  it('keeps the text on both sides of the number', () => {
+    const location = 'Dial-in: +1 555-123-4567 (guest line)';
+    const segments = parseEventLocation(location);
+
+    expect(segments).toEqual([
+      { kind: 'text', text: 'Dial-in: ' },
+      { kind: 'phone', text: '+1 555-123-4567', telUrl: 'tel:+15551234567' },
+      { kind: 'text', text: ' (guest line)' },
+    ]);
+    expect(rejoin(segments)).toBe(location);
+  });
+
+  it('links every number when a location lists more than one', () => {
+    expect(phones('Front desk 555-123-4567, mobile +1 555-987-6543')).toEqual([
+      ['555-123-4567', 'tel:5551234567'],
+      ['+1 555-987-6543', 'tel:+15559876543'],
+    ]);
+  });
+
+  it('leaves the closing paren of a sentence out of the number', () => {
+    expect(phones('Back room (call 5551234567)')).toEqual([
+      ['5551234567', 'tel:5551234567'],
+    ]);
+  });
+
+  it('keeps the parens a number is written with', () => {
+    expect(phones('Reception (5551234567)')).toEqual([
+      ['(5551234567)', 'tel:5551234567'],
+    ]);
+  });
+
+  it.each([
+    // Street numbers, suites, floors, and zips are all too short to dial.
+    ['1600 Amphitheatre Parkway, Mountain View, CA 94043'],
+    ['350 5th Ave, New York, NY 10118'],
+    ['Building 12, Room 3456'],
+    ['Suite 200-3000'],
+    // Vanity numbers lose their digits to the letters.
+    ['1-800-FLOWERS'],
+    // A date carries phone-number digit counts once punctuation is stripped.
+    ['2026-08-25 14'],
+    ['8.25.2026 14'],
+    // Too few digits to be a number, too many to be one.
+    ['555-1234'],
+    ['+1 555'],
+    ['1234567890123456'],
+    // An unpunctuated run past a national number reads as an identifier.
+    ['Locker 123456789012'],
+    ['https://meet.example.com/1234567890123'],
+  ])('leaves %s as plain text', (location) => {
+    expect(phones(location)).toEqual([]);
+    expect(parseEventLocation(location)).toEqual([
+      { kind: 'text', text: location },
+    ]);
+  });
+
+  it.each([
+    ['https://zoom.us/j/9876543210'],
+    ['zoom.us/j/9876543210'],
+    ['www.example.com/1234567890'],
+    ['Meeting ID: 987 6543 210'],
+    ['Access code 5551234567'],
+  ])('leaves the digits of %s alone', (location) => {
+    expect(phones(location)).toEqual([]);
+  });
+
+  it('dials the number of a dial-in without offering its PIN', () => {
+    expect(phones('+1 555-123-4567,,9182736450#')).toEqual([
+      ['+1 555-123-4567', 'tel:+15551234567'],
+    ]);
+  });
+
+  it('trims the surrounding whitespace of a location', () => {
+    expect(parseEventLocation('  555-123-4567  ')).toEqual([
+      { kind: 'phone', text: '555-123-4567', telUrl: 'tel:5551234567' },
+    ]);
+  });
+
+  it('returns a location with no number as one text segment', () => {
+    expect(parseEventLocation('Conference Room B')).toEqual([
+      { kind: 'text', text: 'Conference Room B' },
+    ]);
+  });
+});
+
+describe('isPhoneOnlyLocation', () => {
+  it('is true for a location that is only a phone number', () => {
+    expect(isPhoneOnlyLocation(parseEventLocation('+1 555-123-4567'))).toBe(
+      true
+    );
+  });
+
+  it.each([["Joe's Diner, 555-123-4567"], ['Conference Room B'], ['']])(
+    'is false for %s',
+    (location) => {
+      expect(isPhoneOnlyLocation(parseEventLocation(location))).toBe(false);
+    }
+  );
+});

--- a/apps/web/src/features/calendar/utils/event-location.ts
+++ b/apps/web/src/features/calendar/utils/event-location.ts
@@ -1,0 +1,155 @@
+/**
+ * Recognizes phone numbers written into an event's location field — a
+ * restaurant's number, a dial-in line, a "call me at …" — so a reader can
+ * place the call from the event itself instead of retyping the digits.
+ */
+
+/** A run of an event location: literal text, or a dialable phone number. */
+export type EventLocationSegment =
+  | { kind: 'text'; text: string }
+  | { kind: 'phone'; text: string; telUrl: string };
+
+/** Punctuation phone numbers are written with, between their digits. */
+const PHONE_PUNCTUATION = /[ \u00a0().\u2010-\u2015-]/;
+
+/**
+ * Runs of digits and phone punctuation. Deliberately loose: every match is put
+ * through {@link toTelUrl} and {@link isDialable}, which decide what is
+ * actually a number to call.
+ */
+const PHONE_RUN = /\+?\(?\d[\d \u00a0().\u2010-\u2015-]*/g;
+
+/**
+ * A leading date. "2026-08-25 14" carries as many digits as a phone number
+ * once its punctuation is stripped, and is never something to call.
+ */
+const LEADING_DATE =
+  /^\d{1,4}[.\u2010-\u2015-]\d{1,2}[.\u2010-\u2015-]\d{2,4}(?=$|\s)/;
+
+/** Links, whose digits belong to a meeting URL rather than to a number. */
+const LINK = /\S+:\/\/\S+|\bwww\.\S+/g;
+
+/**
+ * A label that turns the digits after it into something other than a number to
+ * call — a meeting ID, an access code — however phone-like their length.
+ */
+const NON_DIALABLE_LABEL = /\b(?:id|code|pin|passcode|password)\W*$/i;
+
+/**
+ * Characters that, flush against a run, mark its digits as something else: a
+ * conference PIN ("…4567,,918273#") or a path or query inside a bare link.
+ */
+const NON_DIALABLE_PREFIXES = new Set([',', ';', '/', '=']);
+
+/** The most digits E.164 allows, country code included. */
+const MAX_E164_DIGITS = 15;
+/** The fewest digits a number carrying an explicit country code can have. */
+const MIN_INTERNATIONAL_DIGITS = 8;
+/** The fewest digits a number without a country code can have. */
+const MIN_NATIONAL_DIGITS = 10;
+/** The most digits an unpunctuated run may have to still read as a number. */
+const MAX_UNPUNCTUATED_DIGITS = 11;
+
+/** Half-open `[start, end)` bounds of a run of a location. */
+type Range = readonly [start: number, end: number];
+
+/**
+ * Drops the trailing punctuation the run regex swept up, which belongs to the
+ * surrounding sentence rather than to the number.
+ */
+function trimTrailingText(candidate: string): string {
+  let value = candidate.replace(/[^\d)]+$/, '');
+  // A closing paren is part of the number only when it closes one inside it:
+  // "(555) 123-4567" keeps its parens, "(dial 5551234567)" does not.
+  while (value.endsWith(')') && !value.includes('(')) {
+    value = value.slice(0, -1).replace(/[^\d)]+$/, '');
+  }
+  return value;
+}
+
+/** The `tel:` URL for a candidate run, or undefined when it isn't a number. */
+function toTelUrl(candidate: string): string | undefined {
+  if (LEADING_DATE.test(candidate)) return undefined;
+
+  const digits = candidate.replace(/\D/g, '');
+  if (digits.length > MAX_E164_DIGITS) return undefined;
+
+  // A country code states the intent outright, so the full E.164 range is fair
+  // game — including the short national numbers some countries still use.
+  if (candidate.startsWith('+')) {
+    return digits.length >= MIN_INTERNATIONAL_DIGITS
+      ? `tel:+${digits}`
+      : undefined;
+  }
+
+  // Without one, length is most of what marks a number as a number, so accept
+  // only what subscriber numbers actually use. That leaves street numbers,
+  // suite numbers, zip codes, and years alone. A run with no punctuation at
+  // all has nothing but its length going for it, so it is held tighter still.
+  const maxDigits = PHONE_PUNCTUATION.test(candidate)
+    ? MAX_E164_DIGITS
+    : MAX_UNPUNCTUATED_DIGITS;
+  return digits.length >= MIN_NATIONAL_DIGITS && digits.length <= maxDigits
+    ? `tel:${digits}`
+    : undefined;
+}
+
+/**
+ * Whether a run is a number to call rather than digits that merely look like
+ * one — a conference PIN, a meeting ID, part of a link. The markers have to
+ * sit flush against the run, so the comma in "Joe's Diner, 555-123-4567"
+ * leaves its number dialable.
+ */
+function isDialable(location: string, run: Range, links: Range[]): boolean {
+  const [start, end] = run;
+  if (links.some(([from, to]) => start < to && end > from)) return false;
+  if (NON_DIALABLE_PREFIXES.has(location[start - 1] ?? '')) return false;
+  if (location[end] === '#') return false;
+  return !NON_DIALABLE_LABEL.test(location.slice(0, start));
+}
+
+/**
+ * Splits an event location into its text and its dialable phone numbers, in
+ * order. A location with no number in it comes back as a single text segment.
+ */
+export function parseEventLocation(location: string): EventLocationSegment[] {
+  const trimmed = location.trim();
+  const links: Range[] = Array.from(
+    trimmed.matchAll(LINK),
+    (match) => [match.index, match.index + match[0].length] as const
+  );
+  const segments: EventLocationSegment[] = [];
+  let index = 0;
+
+  for (const match of trimmed.matchAll(PHONE_RUN)) {
+    const candidate = trimTrailingText(match[0]);
+    if (!candidate) continue;
+
+    const start = match.index;
+    const end = start + candidate.length;
+    if (!isDialable(trimmed, [start, end], links)) continue;
+
+    const telUrl = toTelUrl(candidate);
+    if (!telUrl) continue;
+
+    if (start > index) {
+      segments.push({ kind: 'text', text: trimmed.slice(index, start) });
+    }
+    segments.push({ kind: 'phone', text: candidate, telUrl });
+    index = end;
+  }
+
+  if (index < trimmed.length) {
+    segments.push({ kind: 'text', text: trimmed.slice(index) });
+  }
+
+  return segments;
+}
+
+/**
+ * Whether the location is a phone number and nothing else, so a caller can
+ * lead with a phone icon instead of a map pin.
+ */
+export function isPhoneOnlyLocation(segments: EventLocationSegment[]) {
+  return segments.length === 1 && segments[0]?.kind === 'phone';
+}


### PR DESCRIPTION
## Summary
Adds intelligent phone number detection and linking to the event location field, allowing users to dial phone numbers directly from event details instead of manually retyping them.

## Key Changes
- **New utility module** (`event-location.ts`): Implements phone number parsing and recognition with comprehensive support for various phone number formats (international, national, with/without punctuation)
  - `parseEventLocation()`: Splits location text into dialable phone numbers and plain text segments
  - `isPhoneOnlyLocation()`: Determines if a location is purely a phone number (for icon selection)
  - Handles edge cases like dates, URLs, meeting IDs, and conference PINs to avoid false positives

- **Comprehensive test coverage** (`event-location.test.ts`): 155 lines of tests covering:
  - Various phone number formats (US, international, with different punctuation styles)
  - Mixed locations (e.g., "Joe's Diner, 555-123-4567")
  - Multiple phone numbers in one location
  - False positive prevention (dates, URLs, meeting IDs, access codes)
  - Whitespace trimming and segment reconstruction

- **Updated EventDetails component**: 
  - New `EventLocationItem` component renders location with clickable phone links
  - Dynamically switches icon from map pin to phone when location is phone-only
  - Preserves all text while making phone numbers dialable via `tel:` URLs
  - Maintains text selection capability for copying

## Implementation Details
- Phone number detection uses E.164 validation rules (max 15 digits, min 8 for international, min 10 for national)
- Strips trailing punctuation intelligently (e.g., closing parens from sentences)
- Avoids false positives by checking for non-dialable labels ("Meeting ID:", "Access code") and special characters (commas, semicolons indicating PINs)
- Preserves original formatting in displayed text while generating clean `tel:` URLs
- Handles various dash characters (hyphens, en-dashes, em-dashes) and non-breaking spaces

https://claude.ai/code/session_01LYhwU8gDywt4SF6Xx3Vo9x