### PR TITLE
fix(agent_session): time out a stalled ACP handshake sooner

### DIFF
--- a/crates/agent_session/src/domain/service.rs
+++ b/crates/agent_session/src/domain/service.rs
@@ -61,6 +61,17 @@ use super::session::{CloseReason, Input};
 const COMMAND_BUFFER: usize = 1028;
 /// Persistence may delay lifecycle teardown, but never indefinitely.
 const SESSION_PERSIST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+/// How long a command may sit queued behind the ACP handshake
+/// (`Booting`/`Initializing`/`Opening`) before the caller gives up on it.
+/// The runtime never completes a queued command on its own until it reaches
+/// `Live` - see [`super::session::session::SessionMachine::on_command`] - so
+/// without this bound a stalled handshake (e.g. the runtime process never
+/// sends `AcpReady`, or never answers `initialize`/`session/new`) hangs the
+/// caller forever.
+#[cfg(not(test))]
+const HANDSHAKE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+#[cfg(test)]
+const HANDSHAKE_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(50);
 
 struct ActiveSession {
     commands: Option<mpsc::Sender<SessionCommand>>,
@@ -395,9 +406,29 @@ impl<R, Folds, Rt, Namer> AgentSessionServiceImpl<R, Folds, Rt, Namer> {
         {
             return Err(AgentSessionError::Disconnected(id));
         }
-        match result.await {
-            Ok(result) => result,
-            Err(_) => Err(AgentSessionError::Disconnected(id)),
+        // Not needed past this point, and holding it would be exactly the bug
+        // `begin_stop` exists to avoid: a live sender clone keeping the
+        // channel open no matter how many others get dropped, so the actor
+        // can only notice by hitting its own much longer internal deadline
+        // instead of promptly.
+        drop(commands);
+        match tokio::time::timeout(HANDSHAKE_TIMEOUT, result).await {
+            Ok(Ok(result)) => result,
+            Ok(Err(_)) => Err(AgentSessionError::Disconnected(id)),
+            Err(_elapsed) => {
+                // The actor is presumably still stuck in the handshake, so it
+                // is stopped directly - the same "drop the sender, the actor
+                // notices and tears itself down" mechanism `close_session`
+                // uses - rather than left to queue behind the same stall
+                // forever.
+                let (stopped, marker) = self.begin_stop(id, false);
+                Self::wait_stopped(stopped).await;
+                self.active.remove_if(&id, |_, active| {
+                    Arc::ptr_eq(&active.marker, &marker) && !active.deleting
+                });
+                tracing::warn!(%id, "agent session command timed out waiting for the ACP handshake");
+                Err(AgentSessionError::Disconnected(id))
+            }
         }
     }
 

--- a/crates/agent_session/src/domain/service/test.rs
+++ b/crates/agent_session/src/domain/service/test.rs
@@ -568,6 +568,42 @@ async fn close_does_not_remove_a_concurrent_delete_guard() {
     });
 }
 
+/// A command sent while the handshake never completes cannot hang its caller
+/// forever - see [`HANDSHAKE_TIMEOUT`]. Without that bound, this test would
+/// simply never finish. The actor it was stuck in cannot linger afterwards
+/// either: its `commands` sender is gone from `active`, the same signal
+/// `close_session` relies on to mean the actor tore itself down.
+#[tokio::test]
+async fn a_command_stuck_behind_a_stalled_handshake_times_out_as_disconnected() {
+    let fx = fixture();
+    fx.service
+        .attach_session(fx.session, RuntimeAttachment::solo(PendingTransport))
+        .await
+        .expect("attach succeeds");
+
+    let result = fx
+        .service
+        .send_action(
+            fx.session,
+            None,
+            AgentAction::prompt("hello"),
+            AgentActionId::mint(),
+        )
+        .await;
+
+    assert!(
+        matches!(result, Err(AgentSessionError::Disconnected(id)) if id == fx.session),
+        "a stalled handshake times out rather than hanging forever, got {result:?}"
+    );
+    assert!(
+        fx.service
+            .active
+            .get(&fx.session)
+            .is_none_or(|active| active.commands.is_none()),
+        "the stuck actor's connector is released, not left running"
+    );
+}
+
 #[tokio::test]
 async fn cancellation_does_not_drop_an_effect_batch_after_machine_mutation() {
     let repo = InMemoryAgentSessionRepo::new();


### PR DESCRIPTION
## Summary
This PR was originally opened against a `deliver_action` with no timeout at all — a stuck ACP handshake (`AcpReady` never arrives, or `initialize`/`session/new` never answered) hung the caller (and the HTTP control endpoint behind it) forever, showing as a permanently stuck "Waking the agent's sandbox…" on the frontend.

**While this PR was open, #5819 merged an independent, more thorough fix for the same root problem**: `SessionActor` now carries its own `handshake_deadline` (60s) and self-terminates a stalled handshake via `CloseReason::HandshakeTimedOut`, completing every queued command with an error. So `deliver_action` is no longer literally unbounded — a caller now waits at most 60s, not forever.

What's left after rebasing onto that:
- The caller still had to sit through the actor's *entire* internal 60s deadline before finding out, with no way to give up sooner.
- The actor kept running (holding its connector/transport) until it hit that same 60s deadline on its own, rather than being told to stop as soon as the caller gave up.

This PR now adds a 30s `HANDSHAKE_TIMEOUT` around `deliver_action`'s wait. On elapse, it actively stops the actor via the same `begin_stop`/`wait_stopped` path `close_session` already uses (rather than reinventing anything), then returns `Disconnected`. Net effect: worst case caller wait is halved, and a stuck actor is torn down the moment its caller gives up instead of lingering for the rest of its own deadline.

## Test plan
- [x] `cargo test -p agent_session` — 105 passed, including `a_command_stuck_behind_a_stalled_handshake_times_out_as_disconnected` (stalled handshake times out well before the actor's own 60s deadline, and its connector is released — verified via `active.commands.is_none()`, the same signal `close_session` relies on)
- [x] `cargo clippy -p agent_session -p agent_harness --all-targets`
- [x] `cargo fmt`