### PR TITLE
Add vim-style hotkeys for calendar period navigation

### DIFF
--- a/apps/web/src/features/calendar/hooks/use-calendar-hotkeys.ts
+++ b/apps/web/src/features/calendar/hooks/use-calendar-hotkeys.ts
@@ -56,10 +56,12 @@ export function useCalendarHotkeys(handlers: CalendarHotkeyHandlers) {
     );
   }
 
+  // 'k'/'j' are vim-style aliases for the same paging, so the keys that step
+  // through soup lists also step through calendar periods.
   group.add(
     registerHotkey({
       scopeId: handlers.scopeId,
-      hotkey: 'p',
+      hotkey: ['p', 'k'],
       hotkeyToken: TOKENS.calendar.period.previous,
       description: 'Previous period',
       keyDownHandler: () => {
@@ -72,7 +74,7 @@ export function useCalendarHotkeys(handlers: CalendarHotkeyHandlers) {
   group.add(
     registerHotkey({
       scopeId: handlers.scopeId,
-      hotkey: 'n',
+      hotkey: ['n', 'j'],
       hotkeyToken: TOKENS.calendar.period.next,
       description: 'Next period',
       keyDownHandler: () => {


### PR DESCRIPTION
## Summary
Added vim-style hotkey aliases (`k` and `j`) for calendar period navigation to match the existing soup list navigation keybindings.

## Changes
- Modified `use-calendar-hotkeys.ts` to support multiple hotkeys per action:
  - `p` and `k` now both navigate to the previous calendar period
  - `n` and `j` now both navigate to the next calendar period
- Updated hotkey registration to accept arrays of hotkey strings instead of single strings
- Added explanatory comment documenting the vim-style alias pattern

## Implementation Details
The change maintains backward compatibility with existing `p` and `n` keybindings while introducing vim-style alternatives that align with common navigation patterns used in soup lists and other parts of the application. This provides users familiar with vim keybindings a consistent navigation experience across the calendar interface.

https://claude.ai/code/session_012zENoeuhwfLLhGwFxCLFhG