### PR TITLE
fix(agent-harness): add HTTP request observability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,6 +270,7 @@ dependencies = [
  "macro_event_broker",
  "macro_queues",
  "macro_service_urls",
+ "macro_tower_layers",
  "macro_user_id",
  "macro_uuid",
  "notification",
@@ -9565,6 +9566,7 @@ dependencies = [
 name = "macro_tower_layers"
 version = "0.1.0"
 dependencies = [
+ "axum",
  "http 1.4.0",
  "opentelemetry",
  "opentelemetry-http",

--- a/crates/agent_session/src/inbound/axum_router.rs
+++ b/crates/agent_session/src/inbound/axum_router.rs
@@ -252,7 +252,6 @@ impl IntoResponse for AgentSessionApiError {
                 if let AgentSessionError::InvalidName(message) = error {
                     return (StatusCode::BAD_REQUEST, Json(message)).into_response();
                 }
-                tracing::error!(error = ?error, "agent session request failed");
                 (StatusCode::INTERNAL_SERVER_ERROR, "internal server error").into_response()
             }
         }
@@ -471,7 +470,11 @@ pub async fn rename_agent_session_handler<
 /// Perform a control operation on a live agent session.
 #[tracing::instrument(
     skip_all,
-    fields(actor = %caller.acting_entity(), session_id = %session_id),
+    fields(
+        actor = %caller.acting_entity(),
+        session_id = %session_id,
+        agent.action.name = req.action.as_ref(),
+    ),
     err(Debug)
 )]
 pub async fn control_agent_session_handler<

--- a/crates/macro_tower_layers/Cargo.toml
+++ b/crates/macro_tower_layers/Cargo.toml
@@ -5,6 +5,7 @@ publish = false
 version = "0.1.0"
 
 [dependencies]
+axum = { workspace = true }
 http = { workspace = true }
 opentelemetry = { workspace = true, features = ["trace"] }
 opentelemetry-http = { workspace = true }

--- a/crates/macro_tower_layers/src/lib.rs
+++ b/crates/macro_tower_layers/src/lib.rs
@@ -79,7 +79,7 @@ impl MakeRequestId for RequestIdBuilder {
 /// Records response telemetry on the request span.
 ///
 /// Successful requests only emit an event when their latency meets or exceeds the warning
-/// threshold. Failed requests may be logged by [`CustomOnFailure`].
+/// threshold. Failed requests are logged by [`CustomOnFailure`].
 #[derive(Clone)]
 pub struct CustomOnResponse {
     warning_threshold: Duration,
@@ -151,11 +151,9 @@ impl<B> OnResponse<B> for CustomOnResponse {
     }
 }
 
-/// Marks failed request spans and optionally emits a log with route context.
+/// Emits failed-request logs with the request span as the parent so logs include route context.
 #[derive(Clone)]
-pub struct CustomOnFailure {
-    emit_event: bool,
-}
+pub struct CustomOnFailure;
 
 impl<FailureClass> OnFailure<FailureClass> for CustomOnFailure
 where
@@ -170,14 +168,12 @@ where
             tracing::field::display(&failure_classification),
         );
 
-        if self.emit_event {
-            tracing::error!(
-                parent: span,
-                error = %failure_classification,
-                latency_ms,
-                "http request failed"
-            );
-        }
+        tracing::error!(
+            parent: span,
+            error = %failure_classification,
+            latency_ms,
+            "http request failed"
+        );
     }
 }
 
@@ -238,18 +234,6 @@ impl MacroRequestIdAndTracingLayer {
     /// Also spawns a background [starvation detector](spawn_starvation_detector) that
     /// warns when the tokio runtime is not polling tasks promptly.
     pub fn new(warning_threshold: Duration) -> Self {
-        Self::build(warning_threshold, true)
-    }
-
-    /// Construct request tracing that records failed spans without emitting a failure event.
-    ///
-    /// Use this when handlers already emit detailed error events and another request-level event
-    /// would double-count the same failure in logs.
-    pub fn new_without_failure_events(warning_threshold: Duration) -> Self {
-        Self::build(warning_threshold, false)
-    }
-
-    fn build(warning_threshold: Duration, emit_failure_events: bool) -> Self {
         spawn_starvation_detector(Duration::from_millis(250));
 
         let svc_builder = ServiceBuilder::new()
@@ -259,9 +243,7 @@ impl MacroRequestIdAndTracingLayer {
                     .make_span_with(MakeSpanWithRemoteParent)
                     .on_request(())
                     .on_response(CustomOnResponse::new_with_threshold(warning_threshold))
-                    .on_failure(CustomOnFailure {
-                        emit_event: emit_failure_events,
-                    }),
+                    .on_failure(CustomOnFailure),
             )
             .propagate_x_request_id();
 

--- a/crates/macro_tower_layers/src/lib.rs
+++ b/crates/macro_tower_layers/src/lib.rs
@@ -11,6 +11,7 @@ use std::{
     time::Duration,
 };
 
+use axum::extract::MatchedPath;
 use http::{HeaderValue, Request, Response};
 use opentelemetry::trace::TraceContextExt;
 use tokio::time::MissedTickBehavior;
@@ -78,7 +79,7 @@ impl MakeRequestId for RequestIdBuilder {
 /// Records response telemetry on the request span.
 ///
 /// Successful requests only emit an event when their latency meets or exceeds the warning
-/// threshold. Failed requests are logged by [`CustomOnFailure`].
+/// threshold. Failed requests may be logged by [`CustomOnFailure`].
 #[derive(Clone)]
 pub struct CustomOnResponse {
     warning_threshold: Duration,
@@ -107,19 +108,23 @@ impl<B> MakeSpan<B> for MakeHttpRequestSpan {
             .get("x-request-id")
             .and_then(|value| value.to_str().ok())
             .unwrap_or_default();
-
-        tracing::info_span!(
+        let span = tracing::info_span!(
             target: HTTP_REQUEST_SPAN_TARGET,
             "http.request",
             otel.kind = "server",
             "http.request.method" = %request.method(),
+            "http.route" = tracing::field::Empty,
             "url.path" = request.uri().path(),
             "request.id" = request_id,
             "http.response.status_code" = tracing::field::Empty,
             latency_ms = tracing::field::Empty,
             otel.status_code = tracing::field::Empty,
             otel.status_description = tracing::field::Empty,
-        )
+        );
+        if let Some(route) = request.extensions().get::<MatchedPath>() {
+            span.record("http.route", route.as_str());
+        }
+        span
     }
 }
 
@@ -146,9 +151,11 @@ impl<B> OnResponse<B> for CustomOnResponse {
     }
 }
 
-/// Emits failed-request logs with the request span as the parent so logs include route context.
+/// Marks failed request spans and optionally emits a log with route context.
 #[derive(Clone)]
-pub struct CustomOnFailure;
+pub struct CustomOnFailure {
+    emit_event: bool,
+}
 
 impl<FailureClass> OnFailure<FailureClass> for CustomOnFailure
 where
@@ -163,12 +170,14 @@ where
             tracing::field::display(&failure_classification),
         );
 
-        tracing::error!(
-            parent: span,
-            error = %failure_classification,
-            latency_ms,
-            "http request failed"
-        );
+        if self.emit_event {
+            tracing::error!(
+                parent: span,
+                error = %failure_classification,
+                latency_ms,
+                "http request failed"
+            );
+        }
     }
 }
 
@@ -229,6 +238,18 @@ impl MacroRequestIdAndTracingLayer {
     /// Also spawns a background [starvation detector](spawn_starvation_detector) that
     /// warns when the tokio runtime is not polling tasks promptly.
     pub fn new(warning_threshold: Duration) -> Self {
+        Self::build(warning_threshold, true)
+    }
+
+    /// Construct request tracing that records failed spans without emitting a failure event.
+    ///
+    /// Use this when handlers already emit detailed error events and another request-level event
+    /// would double-count the same failure in logs.
+    pub fn new_without_failure_events(warning_threshold: Duration) -> Self {
+        Self::build(warning_threshold, false)
+    }
+
+    fn build(warning_threshold: Duration, emit_failure_events: bool) -> Self {
         spawn_starvation_detector(Duration::from_millis(250));
 
         let svc_builder = ServiceBuilder::new()
@@ -238,7 +259,9 @@ impl MacroRequestIdAndTracingLayer {
                     .make_span_with(MakeSpanWithRemoteParent)
                     .on_request(())
                     .on_response(CustomOnResponse::new_with_threshold(warning_threshold))
-                    .on_failure(CustomOnFailure),
+                    .on_failure(CustomOnFailure {
+                        emit_event: emit_failure_events,
+                    }),
             )
             .propagate_x_request_id();
 

--- a/crates/macro_tower_layers/src/test.rs
+++ b/crates/macro_tower_layers/src/test.rs
@@ -1,8 +1,10 @@
 use super::*;
+use axum::{Router, body::Body, routing::get};
 use std::{
     collections::{HashMap, HashSet},
     sync::{Arc, Mutex},
 };
+use tower::ServiceExt;
 use tower_http::trace::{MakeSpan, OnFailure, OnResponse};
 use tracing::{
     Level,
@@ -120,6 +122,7 @@ fn request_span_uses_info_and_safe_structured_fields() {
 
     let declared_fields = captured.declared_span_fields.lock().unwrap();
     assert!(declared_fields.contains("http.request.method"));
+    assert!(declared_fields.contains("http.route"));
     assert!(declared_fields.contains("url.path"));
     assert!(declared_fields.contains("request.id"));
     assert!(declared_fields.contains("http.response.status_code"));
@@ -132,6 +135,34 @@ fn request_span_uses_info_and_safe_structured_fields() {
     assert_eq!(fields.get("url.path").unwrap(), "\"/documents/123\"");
     assert_eq!(fields.get("request.id").unwrap(), "\"request-42\"");
     assert!(fields.values().all(|value| !value.contains("secret")));
+}
+
+#[tokio::test]
+async fn request_span_records_the_matched_route() {
+    let (subscriber, captured) = TracingCapture::new();
+    let _guard = set_default(subscriber);
+    let app = Router::new()
+        .route("/documents/{id}", get(|| async {}))
+        .layer(MacroRequestIdAndTracingLayer::new(Duration::from_millis(200)).into_inner());
+
+    app.oneshot(
+        Request::builder()
+            .uri("/documents/123")
+            .body(Body::empty())
+            .unwrap(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        captured
+            .recorded_span_fields
+            .lock()
+            .unwrap()
+            .get("http.route")
+            .unwrap(),
+        "\"/documents/{id}\""
+    );
 }
 
 #[test]
@@ -187,7 +218,7 @@ fn server_error_emits_only_failure_event() {
 
         CustomOnResponse::new_with_threshold(Duration::from_millis(200))
             .on_response(&response, latency, &span);
-        CustomOnFailure.on_failure("Status code: 500", latency, &span);
+        CustomOnFailure { emit_event: true }.on_failure("Status code: 500", latency, &span);
     });
 
     assert_eq!(captured.event_count(Level::ERROR), 1);
@@ -197,6 +228,27 @@ fn server_error_emits_only_failure_event() {
     let fields = captured.recorded_span_fields.lock().unwrap();
     assert_eq!(fields.get("http.response.status_code").unwrap(), "500");
     assert_eq!(fields.get("latency_ms").unwrap(), "300");
+    assert_eq!(fields.get("otel.status_code").unwrap(), "\"ERROR\"");
+}
+
+#[test]
+fn quiet_server_error_marks_the_span_without_emitting_an_event() {
+    let (subscriber, captured) = TracingCapture::new();
+
+    with_default(subscriber, || {
+        let request = Request::builder().uri("/documents").body(()).unwrap();
+        let span = MakeHttpRequestSpan.make_span(&request);
+        let response = Response::builder().status(500).body(()).unwrap();
+        let latency = Duration::from_millis(300);
+
+        CustomOnResponse::new_with_threshold(Duration::from_millis(200))
+            .on_response(&response, latency, &span);
+        CustomOnFailure { emit_event: false }.on_failure("Status code: 500", latency, &span);
+    });
+
+    assert!(captured.event_levels.lock().unwrap().is_empty());
+    let fields = captured.recorded_span_fields.lock().unwrap();
+    assert_eq!(fields.get("http.response.status_code").unwrap(), "500");
     assert_eq!(fields.get("otel.status_code").unwrap(), "\"ERROR\"");
 }
 

--- a/crates/macro_tower_layers/src/test.rs
+++ b/crates/macro_tower_layers/src/test.rs
@@ -218,7 +218,7 @@ fn server_error_emits_only_failure_event() {
 
         CustomOnResponse::new_with_threshold(Duration::from_millis(200))
             .on_response(&response, latency, &span);
-        CustomOnFailure { emit_event: true }.on_failure("Status code: 500", latency, &span);
+        CustomOnFailure.on_failure("Status code: 500", latency, &span);
     });
 
     assert_eq!(captured.event_count(Level::ERROR), 1);
@@ -228,27 +228,6 @@ fn server_error_emits_only_failure_event() {
     let fields = captured.recorded_span_fields.lock().unwrap();
     assert_eq!(fields.get("http.response.status_code").unwrap(), "500");
     assert_eq!(fields.get("latency_ms").unwrap(), "300");
-    assert_eq!(fields.get("otel.status_code").unwrap(), "\"ERROR\"");
-}
-
-#[test]
-fn quiet_server_error_marks_the_span_without_emitting_an_event() {
-    let (subscriber, captured) = TracingCapture::new();
-
-    with_default(subscriber, || {
-        let request = Request::builder().uri("/documents").body(()).unwrap();
-        let span = MakeHttpRequestSpan.make_span(&request);
-        let response = Response::builder().status(500).body(()).unwrap();
-        let latency = Duration::from_millis(300);
-
-        CustomOnResponse::new_with_threshold(Duration::from_millis(200))
-            .on_response(&response, latency, &span);
-        CustomOnFailure { emit_event: false }.on_failure("Status code: 500", latency, &span);
-    });
-
-    assert!(captured.event_levels.lock().unwrap().is_empty());
-    let fields = captured.recorded_span_fields.lock().unwrap();
-    assert_eq!(fields.get("http.response.status_code").unwrap(), "500");
     assert_eq!(fields.get("otel.status_code").unwrap(), "\"ERROR\"");
 }
 

--- a/services/agent_harness_service/Cargo.toml
+++ b/services/agent_harness_service/Cargo.toml
@@ -31,6 +31,7 @@ macro_event_broker = { path = "../../crates/macro_event_broker", features = ["ou
 macro_queues = { path = "../../crates/macro_queues" }
 lexical_client = { path = "../../crates/lexical_client" }
 macro_service_urls = { path = "../../crates/macro_service_urls" }
+macro_tower_layers = { path = "../../crates/macro_tower_layers" }
 notification = { path = "../../crates/notification" }
 rdkafka = { workspace = true }
 channels = { path = "../../crates/channels", features = ["ports", "outbound"] }

--- a/services/agent_harness_service/src/api.rs
+++ b/services/agent_harness_service/src/api.rs
@@ -44,10 +44,7 @@ where
     Auth: MacroAuthorizationService,
 {
     let app = api_router(read_state, control_state, create_state, gateway_state)
-        .layer(
-            MacroRequestIdAndTracingLayer::new_without_failure_events(Duration::from_millis(200))
-                .into_inner(),
-        )
+        .layer(MacroRequestIdAndTracingLayer::new(Duration::from_millis(200)).into_inner())
         .merge(Router::new().route("/health", get(health)))
         .layer(macro_cors::cors_layer())
         .merge(SwaggerUi::new("/docs").url("/api-doc/openapi.json", swagger::ApiDoc::openapi()));

--- a/services/agent_harness_service/src/api.rs
+++ b/services/agent_harness_service/src/api.rs
@@ -3,6 +3,8 @@
 //! This process owns the complete agent-session HTTP API: durable metadata and
 //! log reads as well as operations against the live in-memory transport.
 
+use std::time::Duration;
+
 use agent_harness::inbound::runtime_gateway::{RuntimeGatewayState, runtime_gateway_router};
 use agent_session::domain::ports::{
     AgentSessionNotificationRecipient, BotDirectory, SessionOpener,
@@ -18,6 +20,7 @@ use axum::Router;
 use axum::routing::get;
 use entity_access::domain::ports::EntityAccessService;
 use macro_authorization::MacroAuthorizationService;
+use macro_tower_layers::MacroRequestIdAndTracingLayer;
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
 
@@ -41,6 +44,11 @@ where
     Auth: MacroAuthorizationService,
 {
     let app = api_router(read_state, control_state, create_state, gateway_state)
+        .layer(
+            MacroRequestIdAndTracingLayer::new_without_failure_events(Duration::from_millis(200))
+                .into_inner(),
+        )
+        .merge(Router::new().route("/health", get(health)))
         .layer(macro_cors::cors_layer())
         .merge(SwaggerUi::new("/docs").url("/api-doc/openapi.json", swagger::ApiDoc::openapi()));
 
@@ -74,7 +82,6 @@ where
         .merge(agent_session_control_router(control_state))
         .merge(agent_session_create_router(create_state));
     Router::new()
-        .route("/health", get(health))
         .nest("/agent-sessions", agent_sessions)
         .merge(agent_sandbox_size_router(read_state))
         .nest("/runtime", runtime_gateway_router(gateway_state))


### PR DESCRIPTION
## Summary
- install the standard HTTP request tracing layer on `agent_harness_service`
- record low-cardinality `http.route` values for Datadog endpoint grouping
- include safe agent action names on control spans
- retain the standard request-level failure event alongside detailed handler/domain errors
- exclude health checks from request tracing

## Incident context
For session `01a03a27-cd26-782b-95d5-8c370d4fdc5a`, Datadog showed that `session/resume` was written successfully after sandbox resume, but the ACP harness never responded. The session timed out after 30 seconds, was torn down as disconnected, and later control retries failed on the closed transport. Existing telemetry exposed the domain failure but did not emit an HTTP server span or indexed response status, so the browser-visible 500s could not be queried directly.

This PR improves observability; it does not claim to fix the underlying ACP process hang after sandbox resume. Sandbox-side process stderr/lifecycle telemetry is still needed to distinguish an OpenCode hang, crash, or invalid restored state.

## Verification
- `cargo test -p macro_tower_layers`
- `cargo test -p agent_session`
- `cargo check -p agent_harness_service`
- `cargo fmt --all -- --check`
- `git diff --check`